### PR TITLE
feat: add --no-wait option to /use-cdkd skill

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -32,6 +32,7 @@ Run all quality checks and create a GitHub PR if everything passes.
 
 7. **Draft PR title and body**:
    - Title: concise, under 70 characters, based on the commits
+   - **Always write the PR title and body in English**
    - Body format:
      ```
      ## Summary

--- a/.claude/skills/use-cdkd/SKILL.md
+++ b/.claude/skills/use-cdkd/SKILL.md
@@ -37,6 +37,9 @@ Build cdkd and output commands that can be pasted into another CDK project's ter
    # Deploy (verbose)
    node /path/to/cdkd/dist/cli.js deploy --verbose
 
+   # Deploy (no wait - don't wait for resource stabilization)
+   node /path/to/cdkd/dist/cli.js deploy --no-wait
+
    # Destroy
    node /path/to/cdkd/dist/cli.js destroy --force
    ```


### PR DESCRIPTION
## Summary
- Add `--no-wait` deploy command to `/use-cdkd` skill output
- Add instruction to always write PR title and body in English to `/create-pr` skill

## Test plan
- [x] Unit tests pass (43 files, 549 tests)
- [x] Typecheck, lint, build all pass
- [x] No leftover AWS resources