### PR TITLE
fix(diff): resolve intrinsics against state to detect changes inside Fn::Join

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,10 +247,11 @@ Level 2: Depends on Level 1 (Lambda Function)
 Compares current state (S3) with template and calculates changes
 
 ```typescript
-calculateDiff(
+async calculateDiff(
   currentState: StackState,
-  template: CloudFormationTemplate
-): ResourceDiff[]
+  template: CloudFormationTemplate,
+  resolveFn?: IntrinsicResolveFn
+): Promise<Map<string, ResourceChange>>
 ```
 
 **Diff Types**:
@@ -262,7 +263,7 @@ calculateDiff(
 
 **Comparison Behavior**:
 
-- **Intrinsic function handling**: When comparing state (resolved values) vs template (unresolved intrinsics), intrinsic functions are detected per-value at each level of recursion. If the new value is an intrinsic (e.g., `{ "Fn::Join": [...] }`), it is treated as equal to the old resolved value since the actual resolved result cannot be determined without deployment.
+- **Intrinsic function handling**: State stores resolved values while templates hold unresolved intrinsics. When a `resolveFn` is supplied (always the case from `deploy`/`diff`), desired properties are resolved against current state before comparison, so changes buried inside an intrinsic (e.g. a literal like `-value` → `-value2` inside `Fn::Join`) are detected. If resolution throws for a particular value (e.g. `Ref` to a not-yet-created resource), that value falls back to the legacy "treat intrinsic as equal" behavior so CREATE-time diffs don't fail. When no `resolveFn` is supplied, intrinsics are detected per-value and treated as equal to the old resolved value.
 - **AWS default key filtering**: AWS APIs often return additional properties not present in the template (e.g., `IncludeCookies: false`, `Enabled: true`). During comparison, only keys present in the template (new) side are compared; extra keys in the state (old) side are ignored as AWS-added defaults.
 - **Diff display**: When showing property changes, only the actually changed sub-properties are displayed. Unchanged sibling values and intrinsic-containing values are stripped from the output to reduce noise.
 

--- a/src/analyzer/diff-calculator.ts
+++ b/src/analyzer/diff-calculator.ts
@@ -4,6 +4,13 @@ import { getLogger } from '../utils/logger.js';
 import { ReplacementRulesRegistry } from './replacement-rules.js';
 
 /**
+ * Best-effort resolver for intrinsic functions during diff calculation.
+ * Should return the resolved value on success, or the original value if resolution fails.
+ * Kept as a callback to avoid circular dependency between analyzer and deployment layers.
+ */
+export type IntrinsicResolveFn = (value: unknown) => Promise<unknown>;
+
+/**
  * Diff calculator for comparing desired state (template) with current state
  */
 export class DiffCalculator {
@@ -15,12 +22,18 @@ export class DiffCalculator {
    *
    * @param currentState Current stack state (use existing state or create a new StackState with empty resources for new stacks)
    * @param desiredTemplate Desired CloudFormation template
+   * @param resolveFn Optional intrinsic resolver. When provided, desired properties are
+   *                  resolved against current state before comparison so that changes
+   *                  buried inside intrinsics (e.g. `Fn::Join` literal args) are detected.
+   *                  If resolution throws for a given property value, the unresolved
+   *                  value is used (falling back to the original "assume equal" behavior).
    * @returns Map of logical ID to resource change
    */
-  calculateDiff(
+  async calculateDiff(
     currentState: StackState,
-    desiredTemplate: CloudFormationTemplate
-  ): Map<string, ResourceChange> {
+    desiredTemplate: CloudFormationTemplate,
+    resolveFn?: IntrinsicResolveFn
+  ): Promise<Map<string, ResourceChange>> {
     const changes = new Map<string, ResourceChange>();
 
     const currentResources = currentState.resources;
@@ -79,11 +92,22 @@ export class DiffCalculator {
           `UPDATE (Type change): ${logicalId} (${currentResource.resourceType} -> ${desiredResource.Type})`
         );
       } else {
-        // Resource exists with same type -> check properties
+        // Resource exists with same type -> check properties.
+        //
+        // State stores already-resolved values (e.g. "my-bucket-value"), while the
+        // template holds unresolved intrinsics (e.g. { "Fn::Join": [...] }). When an
+        // intrinsic wraps literal content that changed (e.g. "-value" -> "-value2"),
+        // a naive comparison would short-circuit on the intrinsic node and miss the
+        // change. Resolving desired props against current state first avoids that.
+        const rawDesiredProps = desiredResource.Properties || {};
+        const desiredPropsForCompare = resolveFn
+          ? await this.resolveBestEffort(rawDesiredProps, resolveFn)
+          : rawDesiredProps;
+
         const propertyChanges = this.compareProperties(
           desiredResource.Type,
           currentResource.properties,
-          desiredResource.Properties || {}
+          desiredPropsForCompare
         );
 
         if (propertyChanges.length > 0) {
@@ -93,7 +117,7 @@ export class DiffCalculator {
             changeType: 'UPDATE',
             resourceType: desiredResource.Type,
             currentProperties: currentResource.properties,
-            desiredProperties: desiredResource.Properties || {},
+            desiredProperties: rawDesiredProps,
             propertyChanges,
           });
           this.logger.debug(`UPDATE: ${logicalId} (${propertyChanges.length} property changes)`);
@@ -104,7 +128,7 @@ export class DiffCalculator {
             changeType: 'NO_CHANGE',
             resourceType: desiredResource.Type,
             currentProperties: currentResource.properties,
-            desiredProperties: desiredResource.Properties || {},
+            desiredProperties: rawDesiredProps,
           });
           this.logger.debug(`NO_CHANGE: ${logicalId}`);
         }
@@ -130,6 +154,29 @@ export class DiffCalculator {
     );
 
     return changes;
+  }
+
+  /**
+   * Best-effort resolution of template property intrinsics against current state.
+   *
+   * Iterates top-level properties and resolves each independently: if resolution
+   * throws (e.g. Ref to a resource that isn't in state yet), the original value
+   * is kept so downstream comparison falls back to the "assume intrinsic equals
+   * anything" behavior for that one value instead of failing the whole diff.
+   */
+  private async resolveBestEffort(
+    properties: Record<string, unknown>,
+    resolveFn: IntrinsicResolveFn
+  ): Promise<Record<string, unknown>> {
+    const resolved: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(properties)) {
+      try {
+        resolved[key] = await resolveFn(value);
+      } catch {
+        resolved[key] = value;
+      }
+    }
+    return resolved;
   }
 
   /**

--- a/src/cli/commands/diff.ts
+++ b/src/cli/commands/diff.ts
@@ -12,6 +12,7 @@ import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer } from '../../synthesis/synthesizer.js';
 import { S3StateBackend } from '../../state/s3-state-backend.js';
 import { DiffCalculator } from '../../analyzer/diff-calculator.js';
+import { IntrinsicFunctionResolver } from '../../deployment/intrinsic-function-resolver.js';
 import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
 import { resolveApp, resolveStateBucketWithDefault } from '../config-loader.js';
 
@@ -191,6 +192,7 @@ async function diffCommand(
     };
     const stateBackend = new S3StateBackend(awsClients.s3, stateConfig);
     const diffCalculator = new DiffCalculator();
+    const intrinsicResolver = new IntrinsicFunctionResolver(region);
 
     // 4. Calculate and display diff for each stack
     for (const stackInfo of targetStacks) {
@@ -214,8 +216,17 @@ async function diffCommand(
         };
       }
 
-      // Calculate diff
-      const changes = diffCalculator.calculateDiff(currentState, template);
+      // Calculate diff. A best-effort intrinsic resolver lets us detect changes
+      // buried inside intrinsics (e.g. Fn::Join literal args) against resolved
+      // values in state. Resolution failures fall back to the unresolved value.
+      const diffResolveFn = (value: unknown) =>
+        intrinsicResolver.resolve(value, {
+          template,
+          resources: currentState.resources,
+          stateBackend,
+          stackName: stackInfo.stackName,
+        });
+      const changes = await diffCalculator.calculateDiff(currentState, template, diffResolveFn);
 
       // Display changes
       if (changes.size === 0) {

--- a/src/deployment/deploy-engine.ts
+++ b/src/deployment/deploy-engine.ts
@@ -202,7 +202,23 @@ export class DeployEngine {
       this.logger.debug(`Dependency graph: ${executionLevels.length} execution levels`);
 
       // 5. Calculate diff
-      const changes = this.diffCalculator.calculateDiff(currentState, template);
+      // Pass a best-effort resolver so that changes hidden inside intrinsics (e.g.
+      // `Fn::Join` literal args like "-value" -> "-value2") are detected against
+      // the already-resolved values stored in state.
+      const diffResolverContext = {
+        template,
+        resources: currentState.resources,
+        ...(Object.keys(parameterValues).length > 0 && { parameters: parameterValues }),
+        ...(Object.keys(conditions).length > 0 && { conditions }),
+        stateBackend: this.stateBackend,
+        stackName,
+      };
+      const diffResolveFn = (value: unknown) => this.resolver.resolve(value, diffResolverContext);
+      const changes = await this.diffCalculator.calculateDiff(
+        currentState,
+        template,
+        diffResolveFn
+      );
       const hasChanges = this.diffCalculator.hasChanges(changes);
 
       if (!hasChanges) {

--- a/tests/unit/analyzer/diff-calculator.test.ts
+++ b/tests/unit/analyzer/diff-calculator.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { DiffCalculator } from '../../../src/analyzer/diff-calculator.js';
+import type { CloudFormationTemplate } from '../../../src/types/resource.js';
+import type { StackState } from '../../../src/types/state.js';
+
+const baseState = (): StackState => ({
+  version: 1,
+  stackName: 'TestStack',
+  resources: {},
+  outputs: {},
+  lastModified: 0,
+});
+
+describe('DiffCalculator - intrinsic-aware diff', () => {
+  it('detects literal changes inside Fn::Join when a resolver is provided', async () => {
+    // State stores resolved values (as deploy-engine writes them after intrinsic resolution)
+    const state = baseState();
+    state.resources['Parameter'] = {
+      physicalId: 'TestStack-parameter',
+      resourceType: 'AWS::SSM::Parameter',
+      properties: {
+        Name: 'TestStack-parameter',
+        // Previously deployed value: "${bucket.bucketName}-value" with bucket="my-bucket"
+        Value: 'my-bucket-value',
+      },
+      attributes: {},
+    };
+    state.resources['Bucket'] = {
+      physicalId: 'my-bucket',
+      resourceType: 'AWS::S3::Bucket',
+      properties: { BucketName: 'my-bucket' },
+      attributes: {},
+    };
+
+    // Template uses Fn::Join — the literal changed from "-value" to "-value2"
+    const template: CloudFormationTemplate = {
+      Resources: {
+        Bucket: {
+          Type: 'AWS::S3::Bucket',
+          Properties: { BucketName: 'my-bucket' },
+        },
+        Parameter: {
+          Type: 'AWS::SSM::Parameter',
+          Properties: {
+            Name: 'TestStack-parameter',
+            Value: { 'Fn::Join': ['', [{ Ref: 'Bucket' }, '-value2']] },
+          },
+        },
+      },
+    };
+
+    // Minimal resolver: handles Ref and Fn::Join well enough for this test
+    const resolve = async (value: unknown): Promise<unknown> => {
+      if (value === null || typeof value !== 'object') return value;
+      if (Array.isArray(value)) return Promise.all(value.map((v) => resolve(v)));
+      const obj = value as Record<string, unknown>;
+      if ('Ref' in obj) {
+        const id = obj['Ref'] as string;
+        const res = state.resources[id];
+        if (!res) throw new Error(`Ref ${id} not found`);
+        return res.physicalId;
+      }
+      if ('Fn::Join' in obj) {
+        const [sep, parts] = obj['Fn::Join'] as [string, unknown[]];
+        const resolvedParts = await Promise.all(parts.map((p) => resolve(p)));
+        return resolvedParts.join(sep);
+      }
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(obj)) out[k] = await resolve(v);
+      return out;
+    };
+
+    const calc = new DiffCalculator();
+    const changes = await calc.calculateDiff(state, template, resolve);
+    const paramChange = changes.get('Parameter');
+    expect(paramChange?.changeType).toBe('UPDATE');
+    expect(paramChange?.propertyChanges?.map((p) => p.path)).toContain('Value');
+  });
+
+  it('without resolver, intrinsic wraps mask inner literal changes (legacy behavior)', async () => {
+    const state = baseState();
+    state.resources['Parameter'] = {
+      physicalId: 'TestStack-parameter',
+      resourceType: 'AWS::SSM::Parameter',
+      properties: {
+        Name: 'TestStack-parameter',
+        Value: 'my-bucket-value',
+      },
+      attributes: {},
+    };
+
+    const template: CloudFormationTemplate = {
+      Resources: {
+        Parameter: {
+          Type: 'AWS::SSM::Parameter',
+          Properties: {
+            Name: 'TestStack-parameter',
+            Value: { 'Fn::Join': ['', [{ Ref: 'Bucket' }, '-value2']] },
+          },
+        },
+      },
+    };
+
+    const calc = new DiffCalculator();
+    const changes = await calc.calculateDiff(state, template);
+    // Without resolver, the existing isIntrinsic short-circuit returns "equal"
+    expect(changes.get('Parameter')?.changeType).toBe('NO_CHANGE');
+  });
+
+  it('falls back to unresolved value when resolver throws for a property', async () => {
+    const state = baseState();
+    state.resources['Parameter'] = {
+      physicalId: 'TestStack-parameter',
+      resourceType: 'AWS::SSM::Parameter',
+      properties: {
+        Name: 'TestStack-parameter',
+        Value: 'my-bucket-value',
+      },
+      attributes: {},
+    };
+
+    const template: CloudFormationTemplate = {
+      Resources: {
+        Parameter: {
+          Type: 'AWS::SSM::Parameter',
+          Properties: {
+            Name: 'TestStack-parameter',
+            Value: { 'Fn::GetAtt': ['NotYetCreated', 'Arn'] },
+          },
+        },
+      },
+    };
+
+    const resolve = async (): Promise<unknown> => {
+      throw new Error('not found');
+    };
+
+    const calc = new DiffCalculator();
+    const changes = await calc.calculateDiff(state, template, resolve);
+    // Resolver failure → keep unresolved → intrinsic treated as equal → NO_CHANGE
+    expect(changes.get('Parameter')?.changeType).toBe('NO_CHANGE');
+  });
+
+  it('still detects plain property changes when resolver is provided', async () => {
+    const state = baseState();
+    state.resources['Bucket'] = {
+      physicalId: 'my-bucket',
+      resourceType: 'AWS::S3::Bucket',
+      properties: { BucketName: 'my-bucket', VersioningConfiguration: { Status: 'Suspended' } },
+      attributes: {},
+    };
+
+    const template: CloudFormationTemplate = {
+      Resources: {
+        Bucket: {
+          Type: 'AWS::S3::Bucket',
+          Properties: {
+            BucketName: 'my-bucket',
+            VersioningConfiguration: { Status: 'Enabled' },
+          },
+        },
+      },
+    };
+
+    const resolve = async (v: unknown): Promise<unknown> => v;
+
+    const calc = new DiffCalculator();
+    const changes = await calc.calculateDiff(state, template, resolve);
+    expect(changes.get('Bucket')?.changeType).toBe('UPDATE');
+  });
+});

--- a/tests/unit/deployment/dry-run.test.ts
+++ b/tests/unit/deployment/dry-run.test.ts
@@ -173,7 +173,7 @@ describe('DeployEngine - Dry Run Mode', () => {
         ],
       ]);
 
-      mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+      mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
       const engine = createDryRunEngine();
       const result = await engine.deploy(stackName, template);
@@ -234,7 +234,7 @@ describe('DeployEngine - Dry Run Mode', () => {
         ],
       ]);
 
-      mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+      mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
       const engine = createDryRunEngine();
       const result = await engine.deploy(stackName, template);
@@ -291,7 +291,7 @@ describe('DeployEngine - Dry Run Mode', () => {
         ],
       ]);
 
-      mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+      mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
       const engine = createDryRunEngine();
       const result = await engine.deploy(stackName, template);
@@ -400,7 +400,7 @@ describe('DeployEngine - Dry Run Mode', () => {
         ],
       ]);
 
-      mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+      mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
       const engine = createDryRunEngine();
       const result = await engine.deploy(stackName, template);
@@ -441,7 +441,7 @@ describe('DeployEngine - Dry Run Mode', () => {
         ],
       ]);
 
-      mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+      mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
       const engine = createDryRunEngine();
       await engine.deploy(stackName, template);
@@ -466,7 +466,7 @@ describe('DeployEngine - Dry Run Mode', () => {
         ],
       ]);
 
-      mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+      mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
       const engine = createDryRunEngine();
       await engine.deploy(stackName, template);
@@ -500,7 +500,7 @@ describe('DeployEngine - Dry Run Mode', () => {
         ],
       ]);
 
-      mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+      mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
       // Dry-run mode
       const dryRunEngine = createDryRunEngine();
@@ -528,7 +528,7 @@ describe('DeployEngine - Dry Run Mode', () => {
       mockLockManager.releaseLock.mockResolvedValue(undefined);
       mockDagBuilder.buildGraph.mockReturnValue({});
       mockDagBuilder.getExecutionLevels.mockReturnValue([['MyBucket']]);
-      mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+      mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
       mockDiffCalculator.hasChanges.mockReturnValue(true);
       mockDiffCalculator.filterByType.mockImplementation(
         (ch: Map<string, ResourceChange>, type: string) => {
@@ -584,7 +584,7 @@ describe('DeployEngine - Dry Run Mode', () => {
 
       // No changes detected
       mockDiffCalculator.hasChanges.mockReturnValue(false);
-      mockDiffCalculator.calculateDiff.mockReturnValue(new Map());
+      mockDiffCalculator.calculateDiff.mockResolvedValue(new Map());
 
       const engine = createDryRunEngine();
       const result = await engine.deploy(stackName, template);
@@ -625,7 +625,7 @@ describe('DeployEngine - Dry Run Mode', () => {
         ],
       ]);
 
-      mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+      mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
       const engine = createDryRunEngine();
       const result = await engine.deploy(stackName, template);

--- a/tests/unit/deployment/resource-replacement.test.ts
+++ b/tests/unit/deployment/resource-replacement.test.ts
@@ -167,7 +167,7 @@ describe('DeployEngine - Resource Replacement', () => {
       ],
     ]);
 
-    mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+    mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
     const engine = new DeployEngine(
       mockStateBackend as any,
@@ -239,7 +239,7 @@ describe('DeployEngine - Resource Replacement', () => {
       ],
     ]);
 
-    mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+    mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
     const engine = new DeployEngine(
       mockStateBackend as any,
@@ -281,7 +281,7 @@ describe('DeployEngine - Resource Replacement', () => {
       ],
     ]);
 
-    mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+    mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
     const engine = new DeployEngine(
       mockStateBackend as any,
@@ -335,7 +335,7 @@ describe('DeployEngine - Resource Replacement', () => {
       ],
     ]);
 
-    mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+    mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
     const engine = new DeployEngine(
       mockStateBackend as any,
@@ -377,7 +377,7 @@ describe('DeployEngine - Resource Replacement', () => {
       ],
     ]);
 
-    mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+    mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
 
     const engine = new DeployEngine(
       mockStateBackend as any,

--- a/tests/unit/deployment/safety-net.test.ts
+++ b/tests/unit/deployment/safety-net.test.ts
@@ -199,7 +199,7 @@ describe('DeployEngine - Safety Net (CC API Fallback)', () => {
       ],
     ]);
 
-    mockDiffCalculator.calculateDiff.mockReturnValue(changes);
+    mockDiffCalculator.calculateDiff.mockResolvedValue(changes);
     return template;
   }
 


### PR DESCRIPTION
## Summary

- `DiffCalculator` was treating any CloudFormation intrinsic as "equal to anything", so a template change like `bucket.bucketName + "-value"` → `bucket.bucketName + "-value2"` (CDK synthesizes this as `Fn::Join: ["", [Ref, "-value"]]`) produced `NO_CHANGE` and never triggered an UPDATE.
- `calculateDiff` is now async and accepts an optional `IntrinsicResolveFn`. When supplied, desired template properties are resolved per-value against current state before comparison, so literals nested inside intrinsics are compared against the already-resolved values stored in state.
- Resolution is best-effort per property: if a single value throws (e.g. `Ref` to a not-yet-created resource during the first deploy), that value falls back to the prior "assume intrinsic equals anything" behavior instead of failing the whole diff.
- Both `deploy` and `diff` commands wire the existing `IntrinsicFunctionResolver` in.

## Test plan

- [x] New unit tests in `tests/unit/analyzer/diff-calculator.test.ts` cover: literal change inside `Fn::Join` is detected; legacy behavior preserved when no resolver; resolver failure falls back safely; plain property changes still detected.
- [x] Existing mocks updated (`mockReturnValue` → `mockResolvedValue`) for the new async signature.
- [x] `pnpm run typecheck`, `pnpm run lint`, `pnpm run build`, full vitest suite (44 files / 556 tests) all pass.
- [x] End-to-end verification with a real `cdk synth` of the reported scenario:
  - Without resolver: `NO_CHANGE` (bug reproduced)
  - With resolver: `UPDATE` with `Value: "bucket-value" → "bucket-value2"` (fix works)
- [ ] Exercise with an actual integration test (e.g. `/run-integ` on a stack that uses template-literal property values) on a follow-up if needed.
