### PR TITLE
chore: enforce /check before every commit via PreToolUse hook

### DIFF
--- a/.claude/hooks/check-gate.sh
+++ b/.claude/hooks/check-gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# check-gate.sh
+#
+# PreToolUse hook. Blocks `git commit` unless the /check skill has
+# recorded a success marker for the current content state. Emitted
+# inline so Claude reads the failure reason and re-runs /check.
+
+set -u
+
+MARKER="${CDKD_CHECK_MARKER:-/tmp/cdkd-check-marker.json}"
+# Resolve repo root from script location (.claude/hooks/check-gate.sh → repo root).
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Extract the command from the PreToolUse payload.
+cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+
+# Only gate git commit — any other command passes through.
+if ! printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+commit\b'; then
+  exit 0
+fi
+
+cd "$REPO" 2>/dev/null || exit 0
+
+head=$(git rev-parse HEAD 2>/dev/null || echo "none")
+# Staging-agnostic: union of tracked changes + untracked files, hashed by content.
+content=$({
+  git diff HEAD --name-only 2>/dev/null
+  git ls-files --others --exclude-standard 2>/dev/null
+} | sort -u | while IFS= read -r f; do
+  if [ -f "$f" ]; then
+    printf 'FILE:%s\n' "$f"
+    cat "$f"
+  else
+    printf 'DEL:%s\n' "$f"
+  fi
+done | shasum -a 256 | cut -c1-16)
+current=$(printf '{"head":"%s","content":"%s"}' "$head" "$content")
+
+if [ ! -f "$MARKER" ]; then
+  echo "Blocked by check-gate: run /check first, then retry the commit." >&2
+  exit 2
+fi
+
+saved=$(cat "$MARKER" 2>/dev/null || echo "")
+if [ "$current" != "$saved" ]; then
+  echo "Blocked by check-gate: content changed since /check last ran. Re-run /check, then retry the commit." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/stop-warn.sh
+++ b/.claude/hooks/stop-warn.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# stop-warn.sh
+#
+# Stop hook. Emits a systemMessage when there are uncommitted changes,
+# nudging Claude to commit-and-push. When the /check marker is stale
+# (or missing), the message says so — a bare commit would be blocked.
+
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MARKER="${CDKD_CHECK_MARKER:-/tmp/cdkd-check-marker.json}"
+
+cd "$REPO" 2>/dev/null || exit 0
+
+status=$(git status --porcelain 2>/dev/null || echo "")
+if [ -z "$status" ]; then
+  exit 0
+fi
+
+head=$(git rev-parse HEAD 2>/dev/null || echo "none")
+content=$({
+  git diff HEAD --name-only 2>/dev/null
+  git ls-files --others --exclude-standard 2>/dev/null
+} | sort -u | while IFS= read -r f; do
+  if [ -f "$f" ]; then
+    printf 'FILE:%s\n' "$f"
+    cat "$f"
+  else
+    printf 'DEL:%s\n' "$f"
+  fi
+done | shasum -a 256 | cut -c1-16)
+current=$(printf '{"head":"%s","content":"%s"}' "$head" "$content")
+saved=$(cat "$MARKER" 2>/dev/null || echo "")
+
+if [ "$current" = "$saved" ]; then
+  msg="⚠️ 未コミットの変更があります (/check 済・コミット可能)"
+else
+  msg="⚠️ 未コミットの変更があります。/check を走らせるとコミット可能になります (マーカー無効)"
+fi
+
+# Escape the status snippet for inclusion in JSON.
+status_snippet=$(echo "$status" | head -10 | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+printf '{"systemMessage": "%s\\n%s"}' "$msg" "${status_snippet:1:${#status_snippet}-2}"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,14 +1,28 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/check-gate.sh",
+            "if": "Bash(git commit*)",
+            "timeout": 10,
+            "statusMessage": "Checking /check marker..."
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; echo \"$f\" | grep -qE '\\.(ts|tsx)$' && pnpm run typecheck && pnpm run lint:fix && pnpm run build && npx vitest --run; } 2>/dev/null || true",
-            "timeout": 120,
-            "statusMessage": "Running typecheck, lint, build, and tests..."
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; echo \"$f\" | grep -qE '\\.(ts|tsx)$' && pnpm run lint:fix; } 2>/dev/null || true",
+            "timeout": 30,
+            "statusMessage": "Running lint:fix..."
           }
         ]
       }
@@ -18,9 +32,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "status=$(git status --porcelain 2>/dev/null); if [ -n \"$status\" ]; then printf '{\"systemMessage\": \"⚠️ 未コミットの変更があります。コミット・プッシュを忘れていませんか?\\n%s\"}' \"$(echo \"$status\" | head -10)\"; fi",
+            "command": ".claude/hooks/stop-warn.sh",
             "timeout": 10,
-            "statusMessage": "Checking for uncommitted changes..."
+            "statusMessage": "Checking working tree and /check marker..."
           }
         ]
       }

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -28,4 +28,28 @@ Report as a table:
 | tests (N files, M tests) | pass/fail |
 
 If all pass, confirm "All checks passed."
-If any fail, show the error output.
+If any fail, show the error output and STOP — do not write the commit-gate marker.
+
+## Commit-gate marker (on success only)
+
+After all four checks pass, record a marker so the PreToolUse `check-gate` hook (see `.claude/hooks/check-gate.sh`) allows the next `git commit`. The marker records the HEAD SHA + content hash of the current working tree; any subsequent edits invalidate it and require re-running `/check`.
+
+Run this exact command from the repo root:
+
+```bash
+head=$(git rev-parse HEAD)
+content=$({
+  git diff HEAD --name-only
+  git ls-files --others --exclude-standard
+} | sort -u | while IFS= read -r f; do
+  if [ -f "$f" ]; then
+    printf 'FILE:%s\n' "$f"
+    cat "$f"
+  else
+    printf 'DEL:%s\n' "$f"
+  fi
+done | shasum -a 256 | cut -c1-16)
+printf '{"head":"%s","content":"%s"}' "$head" "$content" > /tmp/cdkd-check-marker.json
+```
+
+Skip this step if any check failed — a stale or missing marker correctly forces the user (or Claude) to re-run `/check` after fixing the failure.

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[PR-number]"
 
 # PR Readiness Verification
 
-Run all checks and review code to verify a PR is ready to merge.
+Heavy pre-merge gate. Run this before creating or merging a pull request — NOT before every commit. Per-commit verification is handled by `/check` (enforced by a PreToolUse hook that blocks `git commit` without a fresh marker).
 
 ## Checklist
 
@@ -77,4 +77,24 @@ If any fail, list the issues to fix.
 
 ## Final Step
 
-After all checks pass, if there are uncommitted changes (e.g., lint fixes, doc updates made during this run), commit them and push to the remote. This ensures the remote branch is always up to date when reporting "PR is ready to merge."
+After all checks pass, write the commit-gate marker (so the PreToolUse `check-gate` hook allows the next `git commit` — `/verify-pr` is a superset of `/check`, so its success implies `/check` success):
+
+```bash
+head=$(git rev-parse HEAD)
+content=$({
+  git diff HEAD --name-only
+  git ls-files --others --exclude-standard
+} | sort -u | while IFS= read -r f; do
+  if [ -f "$f" ]; then
+    printf 'FILE:%s\n' "$f"
+    cat "$f"
+  else
+    printf 'DEL:%s\n' "$f"
+  fi
+done | shasum -a 256 | cut -c1-16)
+printf '{"head":"%s","content":"%s"}' "$head" "$content" > /tmp/cdkd-check-marker.json
+```
+
+Then, if there are uncommitted changes (e.g., lint fixes, doc updates made during this run), commit them and push to the remote. This ensures the remote branch is always up to date when reporting "PR is ready to merge."
+
+Skip the marker + commit step if any check failed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,7 +375,8 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 
 - **When adding new functionality or fixing bugs**: Always add corresponding unit tests. Do not wait to be asked.
 - **After modifying source code**: Always run `pnpm run build` before telling the user to test. The user runs cdkd via `node dist/cli.js`, so source changes without a build have no effect.
-- **Before creating a PR or commit**: Run `/verify-pr` to confirm all checks pass (typecheck, lint, build, tests, CI, docs consistency, no leftover AWS resources)
+- **Before every commit**: Run `/check` (typecheck, lint, build, tests). A PreToolUse hook (`.claude/hooks/check-gate.sh`) blocks `git commit` unless `/check` has left a content-matching marker — if you see "Blocked by check-gate", run `/check` and retry. Any edits after `/check` invalidate the marker, so re-run it before committing again.
+- **Before creating or merging a PR**: Run `/verify-pr` (adds CI status, docs consistency, AWS resource cleanup, code review on top of `/check`)
 - **After changing source code that affects behavior or public API**: Run `/check-docs` to verify README.md, CLAUDE.md, and docs/ are consistent with the changes
 - **When running integration tests**: Use `/run-integ` with the appropriate test name (e.g., `/run-integ lambda`)
 - **After running integration tests**: Verify no leftover AWS resources remain (`aws s3 ls s3://cdkd-state-{accountId}-{region}/stacks/` should return empty or error)


### PR DESCRIPTION
## Summary

- `DiffCalculator` was treating any CloudFormation intrinsic as "equal to anything", so a template change like `bucket.bucketName + "-value"` → `bucket.bucketName + "-value2"` (CDK synthesizes this as `Fn::Join: ["", [Ref, "-value"]]`) produced `NO_CHANGE` and never triggered an UPDATE.
- `calculateDiff` is now async and accepts an optional `IntrinsicResolveFn`. When supplied, desired template properties are resolved per-value against current state before comparison, so literals nested inside intrinsics are compared against the already-resolved values stored in state.
- Resolution is best-effort per property: if a single value throws (e.g. `Ref` to a not-yet-created resource during the first deploy), that value falls back to the prior "assume intrinsic equals anything" behavior instead of failing the whole diff.
- Both `deploy` and `diff` commands wire the existing `IntrinsicFunctionResolver` in.

## Test plan

- [x] New unit tests in `tests/unit/analyzer/diff-calculator.test.ts` cover: literal change inside `Fn::Join` is detected; legacy behavior preserved when no resolver; resolver failure falls back safely; plain property changes still detected.
- [x] Existing mocks updated (`mockReturnValue` → `mockResolvedValue`) for the new async signature.
- [x] `pnpm run typecheck`, `pnpm run lint`, `pnpm run build`, full vitest suite (44 files / 556 tests) all pass.
- [x] End-to-end verification with a real `cdk synth` of the reported scenario:
  - Without resolver: `NO_CHANGE` (bug reproduced)
  - With resolver: `UPDATE` with `Value: "bucket-value" → "bucket-value2"` (fix works)
- [ ] Exercise with an actual integration test (e.g. `/run-integ` on a stack that uses template-literal property values) on a follow-up if needed.
