### PR TITLE
chore: replace custom check-gate shell with markgate CLI

### DIFF
--- a/.claude/hooks/check-gate.sh
+++ b/.claude/hooks/check-gate.sh
@@ -2,49 +2,32 @@
 # check-gate.sh
 #
 # PreToolUse hook. Blocks `git commit` unless the /check skill has
-# recorded a success marker for the current content state. Emitted
+# recorded a markgate marker for the current content state. Emitted
 # inline so Claude reads the failure reason and re-runs /check.
 
 set -u
 
-MARKER="${CDKD_CHECK_MARKER:-/tmp/cdkd-check-marker.json}"
-# Resolve repo root from script location (.claude/hooks/check-gate.sh → repo root).
+# Resolve repo root from script location (.claude/hooks/check-gate.sh -> repo root).
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # Extract the command from the PreToolUse payload.
 cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 
-# Only gate git commit — any other command passes through.
+# Only gate git commit -- any other command passes through.
 if ! printf '%s' "$cmd" | grep -qE '\bgit[[:space:]]+commit\b'; then
   exit 0
 fi
 
 cd "$REPO" 2>/dev/null || exit 0
 
-head=$(git rev-parse HEAD 2>/dev/null || echo "none")
-# Staging-agnostic: union of tracked changes + untracked files, hashed by content.
-content=$({
-  git diff HEAD --name-only 2>/dev/null
-  git ls-files --others --exclude-standard 2>/dev/null
-} | sort -u | while IFS= read -r f; do
-  if [ -f "$f" ]; then
-    printf 'FILE:%s\n' "$f"
-    cat "$f"
-  else
-    printf 'DEL:%s\n' "$f"
-  fi
-done | shasum -a 256 | cut -c1-16)
-current=$(printf '{"head":"%s","content":"%s"}' "$head" "$content")
-
-if [ ! -f "$MARKER" ]; then
-  echo "Blocked by check-gate: run /check first, then retry the commit." >&2
+if ! command -v markgate >/dev/null 2>&1; then
+  echo "Blocked by check-gate: markgate is not installed. Run 'mise install' at the repo root (see CONTRIBUTING.md)." >&2
   exit 2
 fi
 
-saved=$(cat "$MARKER" 2>/dev/null || echo "")
-if [ "$current" != "$saved" ]; then
-  echo "Blocked by check-gate: content changed since /check last ran. Re-run /check, then retry the commit." >&2
-  exit 2
+if markgate verify check >/dev/null 2>&1; then
+  exit 0
 fi
 
-exit 0
+echo "Blocked by check-gate: run /check first (or re-run if content changed since), then retry the commit." >&2
+exit 2

--- a/.claude/hooks/stop-warn.sh
+++ b/.claude/hooks/stop-warn.sh
@@ -2,13 +2,13 @@
 # stop-warn.sh
 #
 # Stop hook. Emits a systemMessage when there are uncommitted changes,
-# nudging Claude to commit-and-push. When the /check marker is stale
-# (or missing), the message says so — a bare commit would be blocked.
+# nudging Claude to commit-and-push. When the markgate /check marker is
+# stale (or missing), the message says so -- a bare commit would be
+# blocked.
 
 set -u
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-MARKER="${CDKD_CHECK_MARKER:-/tmp/cdkd-check-marker.json}"
 
 cd "$REPO" 2>/dev/null || exit 0
 
@@ -17,22 +17,7 @@ if [ -z "$status" ]; then
   exit 0
 fi
 
-head=$(git rev-parse HEAD 2>/dev/null || echo "none")
-content=$({
-  git diff HEAD --name-only 2>/dev/null
-  git ls-files --others --exclude-standard 2>/dev/null
-} | sort -u | while IFS= read -r f; do
-  if [ -f "$f" ]; then
-    printf 'FILE:%s\n' "$f"
-    cat "$f"
-  else
-    printf 'DEL:%s\n' "$f"
-  fi
-done | shasum -a 256 | cut -c1-16)
-current=$(printf '{"head":"%s","content":"%s"}' "$head" "$content")
-saved=$(cat "$MARKER" 2>/dev/null || echo "")
-
-if [ "$current" = "$saved" ]; then
+if command -v markgate >/dev/null 2>&1 && markgate verify check >/dev/null 2>&1; then
   msg="WARNING: Uncommitted changes (/check passed, commit allowed)"
 else
   msg="WARNING: Uncommitted changes. Run /check to allow commit (marker invalid)"

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -32,24 +32,12 @@ If any fail, show the error output and STOP — do not write the commit-gate mar
 
 ## Commit-gate marker (on success only)
 
-After all four checks pass, record a marker so the PreToolUse `check-gate` hook (see `.claude/hooks/check-gate.sh`) allows the next `git commit`. The marker records the HEAD SHA + content hash of the current working tree; any subsequent edits invalidate it and require re-running `/check`.
+After all four checks pass, record a marker so the PreToolUse `check-gate` hook (see `.claude/hooks/check-gate.sh`) allows the next `git commit`. The marker is managed by [markgate](https://github.com/go-to-k/markgate) and captures the current working tree state; any subsequent edits invalidate it and require re-running `/check`.
 
-Run this exact command from the repo root:
+Run this from the repo root:
 
 ```bash
-head=$(git rev-parse HEAD)
-content=$({
-  git diff HEAD --name-only
-  git ls-files --others --exclude-standard
-} | sort -u | while IFS= read -r f; do
-  if [ -f "$f" ]; then
-    printf 'FILE:%s\n' "$f"
-    cat "$f"
-  else
-    printf 'DEL:%s\n' "$f"
-  fi
-done | shasum -a 256 | cut -c1-16)
-printf '{"head":"%s","content":"%s"}' "$head" "$content" > /tmp/cdkd-check-marker.json
+markgate set check
 ```
 
 Skip this step if any check failed — a stale or missing marker correctly forces the user (or Claude) to re-run `/check` after fixing the failure.

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -77,22 +77,10 @@ If any fail, list the issues to fix.
 
 ## Final Step
 
-After all checks pass, write the commit-gate marker (so the PreToolUse `check-gate` hook allows the next `git commit` — `/verify-pr` is a superset of `/check`, so its success implies `/check` success):
+After all checks pass, record the commit-gate marker via [markgate](https://github.com/go-to-k/markgate) so the PreToolUse `check-gate` hook allows the next `git commit` — `/verify-pr` is a superset of `/check`, so its success implies `/check` success:
 
 ```bash
-head=$(git rev-parse HEAD)
-content=$({
-  git diff HEAD --name-only
-  git ls-files --others --exclude-standard
-} | sort -u | while IFS= read -r f; do
-  if [ -f "$f" ]; then
-    printf 'FILE:%s\n' "$f"
-    cat "$f"
-  else
-    printf 'DEL:%s\n' "$f"
-  fi
-done | shasum -a 256 | cut -c1-16)
-printf '{"head":"%s","content":"%s"}' "$head" "$content" > /tmp/cdkd-check-marker.json
+markgate set check
 ```
 
 Then, if there are uncommitted changes (e.g., lint fixes, doc updates made during this run), commit them and push to the remote. This ensures the remote branch is always up to date when reporting "PR is ready to merge."

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+"ubi:go-to-k/markgate" = "0.1.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,7 +375,7 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 
 - **When adding new functionality or fixing bugs**: Always add corresponding unit tests. Do not wait to be asked.
 - **After modifying source code**: Always run `pnpm run build` before telling the user to test. The user runs cdkd via `node dist/cli.js`, so source changes without a build have no effect.
-- **Before every commit**: Run `/check` (typecheck, lint, build, tests). A PreToolUse hook (`.claude/hooks/check-gate.sh`) blocks `git commit` unless `/check` has left a content-matching marker — if you see "Blocked by check-gate", run `/check` and retry. Any edits after `/check` invalidate the marker, so re-run it before committing again.
+- **Before every commit**: Run `/check` (typecheck, lint, build, tests). A PreToolUse hook (`.claude/hooks/check-gate.sh`) blocks `git commit` unless `/check` has recorded a matching marker via [markgate](https://github.com/go-to-k/markgate) — if you see "Blocked by check-gate", run `/check` and retry. Any edits after `/check` invalidate the marker, so re-run it before committing again. Install markgate via `mise install` at the repo root (see CONTRIBUTING.md).
 - **Before creating or merging a PR**: Run `/verify-pr` (adds CI status, docs consistency, AWS resource cleanup, code review on top of `/check`)
 - **After changing source code that affects behavior or public API**: Run `/check-docs` to verify README.md, CLAUDE.md, and docs/ are consistent with the changes
 - **When running integration tests**: Use `/run-integ` with the appropriate test name (e.g., `/run-integ lambda`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,15 @@ Thank you for your interest in contributing to cdkd!
 
 ## Development Setup
 
+This repo pins developer tooling via [mise](https://mise.jdx.dev/). `mise install` fetches [markgate](https://github.com/go-to-k/markgate), which the commit-gate hook depends on. If you prefer not to use mise, install markgate by any means (Homebrew, `go install`, release binary) and skip that step.
+
 ```bash
 # Clone the repository
 git clone https://github.com/go-to-k/cdkd.git
 cd cdkd
+
+# Install pinned developer tools (markgate, etc.)
+mise install
 
 # Install dependencies
 npm install


### PR DESCRIPTION
## Summary

- Replace the ad-hoc content-hashing shell in `.claude/hooks/check-gate.sh` and `.claude/hooks/stop-warn.sh` with calls to the standalone [markgate](https://github.com/go-to-k/markgate) CLI (v0.1.0).
- Update `/check` and `/verify-pr` skills to record the commit-gate marker via `markgate set check` instead of writing `/tmp/cdkd-check-marker.json` directly.
- Pin markgate via `mise` (`ubi:go-to-k/markgate = 0.1.0`) so contributors can install with `mise install`; document the setup step in `CONTRIBUTING.md` and reference markgate from `CLAUDE.md`.

Closes #12.

## Why

The marker pattern was implemented inline as shell in this repo. Now that it has been extracted into a standalone CLI ([markgate](https://github.com/go-to-k/markgate)), cdkd dogfoods the tool: it validates markgate's real-world integration path and removes duplicated hash logic from the hooks. Behavior of the gate is functionally equivalent to the previous shell.

## Design

- **Key name**: `check` (aligns with the `/check` skill; valid kebab-case per markgate spec)
- **Hash type**: `git-tree` (markgate default; no `.markgate.yml` required)
- **State location**: `$(git rev-parse --git-dir)/markgate/check.json` (markgate default; moves off `/tmp/`)
- **Wrapper scripts**: Kept. The hooks still filter for `git commit`, parse the PreToolUse JSON payload, and format error messages
- **`CDKD_CHECK_MARKER` env var**: Removed (markgate owns the state location)
- **Missing-binary handling**: `check-gate.sh` guards with `command -v markgate` and emits a `mise install` hint; `stop-warn.sh` silently treats missing markgate the same as an invalid marker

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint:fix`
- [x] `pnpm run build`
- [x] `npx vitest --run` (44 files, 556 tests)
- [x] `markgate set check` → `markgate verify check` exits 0
- [x] `markgate clear check` → `markgate verify check` exits 1
- [ ] CI passes on this branch
