### PR TITLE
docs: add mise trust to Development Setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,9 @@ This repo pins developer tooling via [mise](https://mise.jdx.dev/). `mise instal
 git clone https://github.com/go-to-k/cdkd.git
 cd cdkd
 
-# Install pinned developer tools (markgate, etc.)
+# Trust the mise config, then install pinned developer tools (markgate, etc.)
+# (mise requires explicit trust on first checkout or whenever .mise.toml changes)
+mise trust
 mise install
 
 # Install dependencies


### PR DESCRIPTION
## Summary

- Add `mise trust` before `mise install` in `CONTRIBUTING.md` so contributors' first `mise install` after clone or pull succeeds.

## Why

mise refuses to use an unknown or changed `.mise.toml` without an explicit trust confirmation, and emits `Config files in ... are not trusted. Trust them with 'mise trust'.` This was observed on the first `git pull` after #13 introduced `.mise.toml`. Other contributors will hit the same on initial checkout. Documenting the one-time trust step avoids the friction.

Reference: https://mise.jdx.dev/cli/trust.html

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint:fix`
- [x] `pnpm run build`
- [x] `npx vitest --run` (44 files, 556 tests)
- [x] Manual: `mise trust && mise install` succeeds on a fresh checkout
- [ ] CI passes on this branch
