### PR TITLE
chore: fall back to mise exec for markgate when shims are not on PATH

### DIFF
--- a/.claude/hooks/check-gate.sh
+++ b/.claude/hooks/check-gate.sh
@@ -20,12 +20,19 @@ fi
 
 cd "$REPO" 2>/dev/null || exit 0
 
-if ! command -v markgate >/dev/null 2>&1; then
+# Prefer direct `markgate` (Homebrew/go install/mise-activated shim); fall back
+# to `mise exec --` so users who installed via `mise install` but don't have
+# shims on PATH still work.
+if command -v markgate >/dev/null 2>&1; then
+  markgate=(markgate)
+elif command -v mise >/dev/null 2>&1; then
+  markgate=(mise exec -- markgate)
+else
   echo "Blocked by check-gate: markgate is not installed. Run 'mise install' at the repo root (see CONTRIBUTING.md)." >&2
   exit 2
 fi
 
-if markgate verify check >/dev/null 2>&1; then
+if "${markgate[@]}" verify check >/dev/null 2>&1; then
   exit 0
 fi
 

--- a/.claude/hooks/stop-warn.sh
+++ b/.claude/hooks/stop-warn.sh
@@ -17,7 +17,17 @@ if [ -z "$status" ]; then
   exit 0
 fi
 
-if command -v markgate >/dev/null 2>&1 && markgate verify check >/dev/null 2>&1; then
+# Prefer direct `markgate`; fall back to `mise exec --` for users who
+# installed via `mise install` without shims on PATH.
+if command -v markgate >/dev/null 2>&1; then
+  markgate=(markgate)
+elif command -v mise >/dev/null 2>&1; then
+  markgate=(mise exec -- markgate)
+else
+  markgate=()
+fi
+
+if [ ${#markgate[@]} -gt 0 ] && "${markgate[@]}" verify check >/dev/null 2>&1; then
   msg="WARNING: Uncommitted changes (/check passed, commit allowed)"
 else
   msg="WARNING: Uncommitted changes. Run /check to allow commit (marker invalid)"

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -34,10 +34,10 @@ If any fail, show the error output and STOP — do not write the commit-gate mar
 
 After all four checks pass, record a marker so the PreToolUse `check-gate` hook (see `.claude/hooks/check-gate.sh`) allows the next `git commit`. The marker is managed by [markgate](https://github.com/go-to-k/markgate) and captures the current working tree state; any subsequent edits invalidate it and require re-running `/check`.
 
-Run this from the repo root:
+Run this from the repo root (cdkd pins markgate via mise, so use `mise exec` to avoid PATH issues when shims aren't active):
 
 ```bash
-markgate set check
+mise exec -- markgate set check
 ```
 
 Skip this step if any check failed — a stale or missing marker correctly forces the user (or Claude) to re-run `/check` after fixing the failure.

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -77,10 +77,10 @@ If any fail, list the issues to fix.
 
 ## Final Step
 
-After all checks pass, record the commit-gate marker via [markgate](https://github.com/go-to-k/markgate) so the PreToolUse `check-gate` hook allows the next `git commit` — `/verify-pr` is a superset of `/check`, so its success implies `/check` success:
+After all checks pass, record the commit-gate marker via [markgate](https://github.com/go-to-k/markgate) so the PreToolUse `check-gate` hook allows the next `git commit` — `/verify-pr` is a superset of `/check`, so its success implies `/check` success. cdkd pins markgate via mise, so use `mise exec` to avoid PATH issues when shims aren't active:
 
 ```bash
-markgate set check
+mise exec -- markgate set check
 ```
 
 Then, if there are uncommitted changes (e.g., lint fixes, doc updates made during this run), commit them and push to the remote. This ensures the remote branch is always up to date when reporting "PR is ready to merge."


### PR DESCRIPTION
## Summary

- The `check-gate` and `stop-warn` hooks called `markgate` directly, which fails for users who installed via `mise install` but do not have mise shims activated in their shell (a common case for Claude Code sessions, where `markgate` is not found even though `mise install` completed).
- Switch to a fallback pattern: prefer direct `markgate` (works for Homebrew / `go install` / mise-activated shim) and fall back to `mise exec -- markgate` when the direct command is missing. Preserve the original "not installed" error path when neither is available.
- Update the `/check` and `/verify-pr` skill docs to run `mise exec -- markgate set check` for the same reason — the Claude Code shell environment usually does not have mise shims active.

## Test plan

- [x] Unit tests pass (44 files, 556 tests)
- [x] `bash -n` syntax check on both hook scripts
- [x] Verified `check-gate.sh` correctly blocks `git commit` via the `mise exec --` fallback path (marker state detected correctly)
- [x] `/check` / `/verify-pr` pass with the new commands
