### PR TITLE
docs: explain why stop-warn prefers direct markgate invocation

### DIFF
--- a/.claude/hooks/stop-warn.sh
+++ b/.claude/hooks/stop-warn.sh
@@ -17,8 +17,9 @@ if [ -z "$status" ]; then
   exit 0
 fi
 
-# Prefer direct `markgate`; fall back to `mise exec --` for users who
-# installed via `mise install` without shims on PATH.
+# Prefer direct `markgate` to avoid `mise exec` startup overhead on every
+# Stop hook; fall back to `mise exec --` for users who installed via
+# `mise install` without shims on PATH.
 if command -v markgate >/dev/null 2>&1; then
   markgate=(markgate)
 elif command -v mise >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Add a one-line rationale to `.claude/hooks/stop-warn.sh` explaining that direct `markgate` is preferred to avoid `mise exec` startup overhead on every Stop hook.
- The existing fallback to `mise exec -- markgate` for users without shims on PATH is retained unchanged.

## Test plan
- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build`
- [x] `npx vitest --run` (44 files, 557 tests)
- [x] No behavioral change (comment-only update)