### PR TITLE
docs: fix GitHub clone URL in README install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Reproduce with `./tests/benchmark/run-benchmark.sh all`. See [tests/benchmark/RE
 ## Installation
 
 ```bash
-git clone https://github.com/goto-bus-stop/cdkd.git
+git clone https://github.com/go-to-k/cdkd.git
 cd cdkd
 pnpm install
 pnpm run build


### PR DESCRIPTION
## Summary
- Fix clone URL typo in the README install section: `goto-bus-stop/cdkd` → `go-to-k/cdkd` (matches the `repository` field in `package.json`).

The npm install instructions and CI-driven release flow originally bundled into this PR will come in a separate PR.

## Test plan
- [x] `git diff README.md` shows only the one-character owner change