### PR TITLE
fix(release): use channel instead of prerelease for experimental dist-tag

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,6 @@
 {
   "branches": [
-    { "name": "main", "prerelease": "experimental" }
+    { "name": "main", "channel": "experimental" }
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",


### PR DESCRIPTION
## Summary
Switch `.releaserc.json` from `prerelease: "experimental"` to `channel: "experimental"` for the `main` branch.

## Why
The first Release workflow run (triggered by #18 merging) failed with:

```
ERELEASEBRANCHES The release branches are invalid in the `branches` configuration.
Your configuration for the problematic branches is [].
```

Root cause: marking main with `prerelease: "experimental"` classifies it as a prerelease branch. semantic-release then finds zero "release" type branches in the config and aborts validation (it requires at least one release branch).

## Fix
Using `channel` instead keeps main as a release branch — validation passes — but still routes the publish to the `experimental` npm dist-tag (via `npm publish --tag experimental`).

## Behavior change
- Versions are plain semver now (`1.0.0`, `1.0.1`, …) instead of `1.0.0-experimental.N`. Cleaner changelog entries.
- `latest` dist-tag continues to point at the `0.0.1` placeholder — `npm i -g @go-to-k/cdkd@experimental` (as documented in README) still works and remains the intended install path.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint:fix`
- [x] `pnpm run build`
- [x] `pnpm test` (44 files, 557 tests)
- [ ] Merge and confirm Release workflow publishes `@go-to-k/cdkd@1.0.0` (or similar) to the `experimental` dist-tag
