### PR TITLE
docs: show version-pin example alongside @experimental install

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,8 @@ Reproduce with `./tests/benchmark/run-benchmark.sh all`. See [tests/benchmark/RE
 ### From npm (experimental)
 
 ```bash
-npm i -g @go-to-k/cdkd@experimental
+npm i -g @go-to-k/cdkd@experimental   # latest experimental
+npm i -g @go-to-k/cdkd@0.1.0          # pin to a specific version
 ```
 
 The installed binary is `cdkd` — run it the same way in either install path.


### PR DESCRIPTION
## Summary
Add a version-pinned install example next to the existing `@experimental` one:

```bash
npm i -g @go-to-k/cdkd@experimental   # latest experimental
npm i -g @go-to-k/cdkd@0.1.0          # pin to a specific version
```

## Why
The `@experimental` dist-tag moves every time the Release workflow publishes, so users who want a known-good version need to pin explicitly. A one-line example in the README is clearer than explaining it in prose.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint:fix`
- [x] `pnpm run build`
- [x] `pnpm test`
