### PR TITLE
fix(cli): report real version via build-time package.json injection

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import * as esbuild from 'esbuild';
+import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
@@ -8,6 +9,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const watchMode = process.argv.includes('--watch');
+
+const pkg = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf-8'));
 
 const commonOptions = {
   bundle: true,
@@ -24,6 +27,9 @@ const commonOptions = {
     'graphlib',
     'p-limit',
   ],
+  define: {
+    __CDKD_VERSION__: JSON.stringify(pkg.version),
+  },
   logLevel: 'info',
 };
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,8 @@
 import { Command } from 'commander';
+
+// Injected at build time by esbuild `define` from package.json
+declare const __CDKD_VERSION__: string;
+
 import { createBootstrapCommand } from './commands/bootstrap.js';
 import { createSynthCommand } from './commands/synth.js';
 import { createDeployCommand } from './commands/deploy.js';
@@ -44,7 +48,7 @@ async function main(): Promise<void> {
   program
     .name('cdkd')
     .description('CDK Direct - Deploy AWS CDK apps directly via SDK/Cloud Control API')
-    .version('0.1.0');
+    .version(__CDKD_VERSION__);
 
   // Add commands
   program.addCommand(createBootstrapCommand());

--- a/tests/unit/cli/version.test.ts
+++ b/tests/unit/cli/version.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..', '..');
+const cliPath = join(repoRoot, 'dist', 'cli.js');
+const pkgPath = join(repoRoot, 'package.json');
+
+describe('cdkd --version', () => {
+  it.skipIf(!existsSync(cliPath))(
+    'reports the version baked in from package.json',
+    () => {
+      const { version } = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+      const output = execFileSync('node', [cliPath, '--version'], {
+        encoding: 'utf-8',
+      }).trim();
+      expect(output).toBe(version);
+    },
+  );
+});


### PR DESCRIPTION
## Summary
`cdkd --version` was hard-coded to `0.1.0` in [src/cli/index.ts](src/cli/index.ts), so it kept reporting `0.1.0` no matter which version of `@go-to-k/cdkd` the user actually installed.

## Fix
Inject the version from `package.json` at build time via esbuild's `define`:

- `build.mjs` reads `package.json` and adds `define: { __CDKD_VERSION__: JSON.stringify(pkg.version) }`.
- `src/cli/index.ts` declares `__CDKD_VERSION__` and passes it to `program.version(...)`.

semantic-release's publish flow already lines up: it rewrites `package.json` to the next version before calling `npm publish`, which triggers `prepublishOnly: pnpm run build`, which bakes the new version into `dist/cli.js`.

## Test
New unit test `tests/unit/cli/version.test.ts` spawns `node dist/cli.js --version` and asserts the output equals `package.json`'s version. Skipped automatically when `dist/cli.js` is absent, so a plain `pnpm test` without a prior `pnpm run build` still passes (CI runs build before test).

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint:fix`
- [x] `pnpm run build`
- [x] `pnpm test` (45 files, 558 tests)
- [x] `node dist/cli.js --version` outputs `0.0.0-development` (current package.json)
- [ ] After merge: Release workflow publishes `@go-to-k/cdkd@0.0.2` to the `experimental` dist-tag (patch bump from `v0.0.1` seed tag)
