### PR TITLE
chore(release): publish to default latest dist-tag instead of experimental

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,5 @@
 {
-  "branches": [
-    { "name": "main", "channel": "experimental" }
-  ],
+  "branches": ["main"],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/README.md
+++ b/README.md
@@ -306,16 +306,16 @@ Reproduce with `./tests/benchmark/run-benchmark.sh all`. See [tests/benchmark/RE
 
 ## Installation
 
-### From npm (experimental)
+### From npm
 
 ```bash
-npm i -g @go-to-k/cdkd@experimental   # latest experimental
-npm i -g @go-to-k/cdkd@0.1.0          # pin to a specific version
+npm i -g @go-to-k/cdkd          # latest release
+npm i -g @go-to-k/cdkd@0.0.2    # pin to a specific version
 ```
 
 The installed binary is `cdkd` — run it the same way in either install path.
 
-> Published under the `experimental` dist-tag while the project is in early development. There is no `latest` tag yet — always pin to `@experimental` (or a specific version) so `npm i -g @go-to-k/cdkd` does not silently resolve to a future stable release with different behavior.
+> cdkd is an experimental / educational project and is not intended for production use — see the warning at the top of this README. Pin to a specific version if you need reproducible installs.
 
 ### From source
 


### PR DESCRIPTION
## Summary
Switch the npm dist-tag for releases from `experimental` back to the default `latest`, and update the README install examples to match.

## Why
The README already has a bold "NOT PRODUCTION READY" warning at the top, and semver 0.x makes the pre-stable status self-evident. Gating installs behind `@experimental` added friction (extra typing, confusing npm package page that shows `latest` = placeholder 0.0.1 instead of the real version) without giving users more information than the README already provides.

## Changes
- `.releaserc.json`: drop `"channel": "experimental"` → main publishes to `latest`.
- README: `npm i -g @go-to-k/cdkd` without a tag is the primary example; version pin still documented for reproducible installs.

## Post-merge manual steps (npm side)
Run these once after the Release workflow publishes the next version (expected: `0.0.3` as a chore bump, though `chore:` normally wouldn't trigger a release — the actual trigger version depends on what lands after this merges):

```bash
# Move latest to the real current release (if 0.0.2 is still the most recent):
npm dist-tag add @go-to-k/cdkd@0.0.2 latest --registry https://registry.npmjs.org/

# Delete the now-unused experimental tag
npm dist-tag rm @go-to-k/cdkd experimental --registry https://registry.npmjs.org/

# Deprecate the original placeholder
npm deprecate "@go-to-k/cdkd@0.0.1" "Placeholder, use latest instead" \
  --registry https://registry.npmjs.org/
```

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint:fix`
- [x] `pnpm run build`
- [x] `pnpm test` (45 files, 558 tests)
- [ ] Merge triggers Release workflow; verify it either no-ops (chore doesn't bump) or publishes cleanly to `latest`
- [ ] Run npm dist-tag / deprecate commands above
