### PR TITLE
fix(cli): verify state bucket exists before synth and asset publishing

### DIFF
--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -89,6 +89,13 @@ async function deployCommand(
   });
   setAwsClients(awsClients);
 
+  // Fail fast if the state bucket is missing, before running synth / docker builds / asset uploads.
+  const preflightStateBackend = new S3StateBackend(awsClients.s3, {
+    bucket: stateBucket,
+    prefix: options.statePrefix,
+  });
+  await preflightStateBackend.verifyBucketExists();
+
   let deployInterrupted = false;
   const topLevelSigintHandler = () => {
     if (deployInterrupted) {

--- a/src/cli/commands/destroy.ts
+++ b/src/cli/commands/destroy.ts
@@ -71,6 +71,8 @@ async function destroyCommand(
       prefix: options.statePrefix,
     };
     const stateBackend = new S3StateBackend(awsClients.s3, stateConfig);
+    // Fail fast if the state bucket is missing, before synth or any destructive work.
+    await stateBackend.verifyBucketExists();
     const lockManager = new LockManager(awsClients.s3, stateConfig);
     const dagBuilder = new DagBuilder();
     const providerRegistry = new ProviderRegistry();

--- a/src/state/s3-state-backend.ts
+++ b/src/state/s3-state-backend.ts
@@ -3,6 +3,7 @@ import {
   GetObjectCommand,
   PutObjectCommand,
   DeleteObjectCommand,
+  HeadBucketCommand,
   HeadObjectCommand,
   ListObjectsV2Command,
   NoSuchKey,
@@ -28,6 +29,31 @@ export class S3StateBackend {
    */
   private getStateKey(stackName: string): string {
     return `${this.config.prefix}/${stackName}/state.json`;
+  }
+
+  /**
+   * Verify that the configured state bucket exists.
+   *
+   * Called early in deploy/destroy to fail fast before expensive work
+   * (asset publishing, Docker builds) runs against a missing bucket.
+   */
+  async verifyBucketExists(): Promise<void> {
+    try {
+      await this.s3Client.send(new HeadBucketCommand({ Bucket: this.config.bucket }));
+    } catch (error) {
+      const name = (error as { name?: string }).name;
+      if (name === 'NotFound' || name === 'NoSuchBucket') {
+        throw new StateError(
+          `State bucket '${this.config.bucket}' does not exist. ` +
+            `Run 'cdkd bootstrap' to create it, or specify an existing bucket via ` +
+            `--state-bucket, CDKD_STATE_BUCKET, or cdk.json context.cdkd.stateBucket.`
+        );
+      }
+      throw new StateError(
+        `Failed to verify state bucket '${this.config.bucket}': ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error : undefined
+      );
+    }
   }
 
   /**

--- a/tests/unit/state/s3-state-backend.test.ts
+++ b/tests/unit/state/s3-state-backend.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { S3Client, HeadBucketCommand } from '@aws-sdk/client-s3';
+import { S3StateBackend } from '../../../src/state/s3-state-backend.js';
+import type { StateBackendConfig } from '../../../src/types/config.js';
+import { StateError } from '../../../src/utils/error-handler.js';
+
+vi.mock('@aws-sdk/client-s3', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-s3')>('@aws-sdk/client-s3');
+  return {
+    ...actual,
+    S3Client: vi.fn().mockImplementation(() => ({
+      send: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  getLogger: () => ({
+    child: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+describe('S3StateBackend.verifyBucketExists', () => {
+  let s3Client: { send: ReturnType<typeof vi.fn> };
+  let backend: S3StateBackend;
+  const config: StateBackendConfig = {
+    bucket: 'my-state-bucket',
+    prefix: 'stacks',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    s3Client = { send: vi.fn() };
+    backend = new S3StateBackend(s3Client as unknown as S3Client, config);
+  });
+
+  it('resolves when the bucket exists', async () => {
+    s3Client.send.mockResolvedValueOnce({});
+
+    await expect(backend.verifyBucketExists()).resolves.toBeUndefined();
+
+    const call = s3Client.send.mock.calls[0][0];
+    expect(call).toBeInstanceOf(HeadBucketCommand);
+    expect(call.input).toEqual({ Bucket: 'my-state-bucket' });
+  });
+
+  it('throws a StateError with bootstrap hint when the bucket is missing (NotFound)', async () => {
+    const err = Object.assign(new Error('Not Found'), { name: 'NotFound' });
+    s3Client.send.mockRejectedValue(err);
+
+    const caught = await backend.verifyBucketExists().catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(StateError);
+    expect((caught as Error).message).toMatch(/does not exist/);
+    expect((caught as Error).message).toMatch(/cdkd bootstrap/);
+  });
+
+  it('throws a StateError with bootstrap hint when the bucket is missing (NoSuchBucket)', async () => {
+    const err = Object.assign(new Error('The specified bucket does not exist'), {
+      name: 'NoSuchBucket',
+    });
+    s3Client.send.mockRejectedValue(err);
+
+    const caught = await backend.verifyBucketExists().catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(StateError);
+    expect((caught as Error).message).toMatch(/cdkd bootstrap/);
+  });
+
+  it('wraps other errors as StateError without the bootstrap hint', async () => {
+    const err = Object.assign(new Error('Access Denied'), { name: 'AccessDenied' });
+    s3Client.send.mockRejectedValue(err);
+
+    const caught = await backend.verifyBucketExists().catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(StateError);
+    expect((caught as Error).message).toMatch(/Failed to verify state bucket/);
+    expect((caught as Error).message).not.toMatch(/cdkd bootstrap/);
+  });
+});


### PR DESCRIPTION
## Summary

- Previously, `cdkd deploy` / `cdkd destroy` only discovered a missing state bucket when acquiring the per-stack lock, which runs **after** asset publishing and Docker image builds. Users could sit through a long Docker build only to fail with `The specified bucket does not exist`.
- Added `S3StateBackend.verifyBucketExists()` using `HeadBucket`; the error message points users at `cdkd bootstrap`.
- Call it up front in both `deploy` (before synth / asset work) and `destroy` (before synth / destructive work) so failure is immediate.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint:fix`
- [x] `pnpm run build`
- [x] `npx vitest --run` (562 tests pass, including 4 new tests for `verifyBucketExists`)
- [ ] Manual: run `cdkd deploy` with a non-existent state bucket — should fail immediately with the bootstrap hint, no Docker build triggered