### PR TITLE
feat(cli): add -y/--yes global flag, -a alias, accept assembly dir for --app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ registry.register('AWS::IAM::Role', new IAMRoleProvider());
 - Wildcard support: `cdkd deploy 'My*'`
 - Single stack auto-detected (no stack name needed)
 - Concurrency options: `--concurrency` (resource ops, default 10), `--stack-concurrency` (stacks, default 4), `--asset-publish-concurrency` (S3+ECR, default 8), `--image-build-concurrency` (Docker builds, default 4)
-- `-y` / `--yes` is a global flag (CDK CLI parity) that auto-confirms interactive prompts (e.g. `destroy`); `cdkd destroy` also accepts `--force` as an alias for backwards-compatibility
+- `-y` / `--yes` is a global flag (CDK CLI parity) that auto-confirms interactive prompts (e.g. `destroy`). `cdkd destroy` additionally accepts `-f` / `--force` — a destroy-specific flag with the same effect as `-y` in this context (matching CDK CLI, where `--force` is per-subcommand and overlaps with the global `--yes` only in the destroy confirmation path)
 - Implemented in `src/cli/config-loader.ts`
 
 ### 4. Custom Resources

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ registry.register('AWS::IAM::Role', new IAMRoleProvider());
 
 ### 3. CLI Configuration Resolution
 
-- `--app` is optional: falls back to `CDKD_APP` env var, then `cdk.json` `"app"` field
+- `--app` (`-a`) is optional: falls back to `CDKD_APP` env var, then `cdk.json` `"app"` field. Accepts either a shell command (`"npx ts-node app.ts"`) or a path to a pre-synthesized cloud assembly directory (`cdk.out`); when a directory is given, synthesis is skipped and the manifest is read directly.
 - `--state-bucket` is optional: falls back to `CDKD_STATE_BUCKET` env var, then `cdk.json` `context.cdkd.stateBucket`
 - `--context` / `-c` is optional: accepts `key=value` pairs (repeatable), merged with cdk.json context (CLI takes precedence)
 - Stack names are positional arguments: `cdkd deploy MyStack` (not `--stack-name`)
@@ -195,6 +195,7 @@ registry.register('AWS::IAM::Role', new IAMRoleProvider());
 - Wildcard support: `cdkd deploy 'My*'`
 - Single stack auto-detected (no stack name needed)
 - Concurrency options: `--concurrency` (resource ops, default 10), `--stack-concurrency` (stacks, default 4), `--asset-publish-concurrency` (S3+ECR, default 8), `--image-build-concurrency` (Docker builds, default 4)
+- `-y` / `--yes` is a global flag (CDK CLI parity) that auto-confirms interactive prompts (e.g. `destroy`); `cdkd destroy` also accepts `--force` as an alias for backwards-compatibility
 - Implemented in `src/cli/config-loader.ts`
 
 ### 4. Custom Resources

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Reproduce with `./tests/benchmark/run-benchmark.sh all`. See [tests/benchmark/RE
    └── Initialize AWS clients
 
 2. Synthesis (self-implemented, no CDK CLI dependency)
+   ├── Short-circuit: if --app is an existing directory, treat it as a
+   │   pre-synthesized cloud assembly and skip the steps below
    ├── Load context (merge order, later wins):
    │   ├── CDK defaults (path-metadata, asset-metadata, version-reporting, bundling-stacks)
    │   ├── ~/.cdk.json "context" field (user defaults)
@@ -364,6 +366,9 @@ cdkd bootstrap \
 # Synthesize only
 cdkd synth --app "npx ts-node app.ts"
 
+# Deploy from a pre-synthesized cloud assembly directory
+cdkd deploy --app cdk.out
+
 # Deploy (single stack auto-detected, reads --app from cdk.json)
 cdkd deploy
 
@@ -401,7 +406,7 @@ cdkd deploy -e MyStack
 
 # Destroy resources
 cdkd destroy MyStack
-cdkd destroy --all --force
+cdkd destroy --all -y          # auto-confirm (--force is also accepted)
 
 # Force-unlock a stale lock from interrupted deploy
 cdkd force-unlock MyStack

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ cdkd deploy -e MyStack
 
 # Destroy resources
 cdkd destroy MyStack
-cdkd destroy --all -y          # auto-confirm (--force is also accepted)
+cdkd destroy --all -y          # auto-confirm prompts (or -f/--force)
 
 # Force-unlock a stale lock from interrupted deploy
 cdkd force-unlock MyStack

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ cdkd deploy -e MyStack
 
 # Destroy resources
 cdkd destroy MyStack
-cdkd destroy --all -y          # auto-confirm prompts (or -f/--force)
+cdkd destroy --all --force
 
 # Force-unlock a stale lock from interrupted deploy
 cdkd force-unlock MyStack

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -46,6 +46,7 @@ async function deployCommand(
     rollback: boolean;
     wait: boolean;
     exclusively: boolean;
+    yes: boolean;
     verbose: boolean;
     context?: string[];
   }

--- a/src/cli/commands/destroy.ts
+++ b/src/cli/commands/destroy.ts
@@ -34,6 +34,7 @@ async function destroyCommand(
     all?: boolean;
     region?: string;
     profile?: string;
+    yes: boolean;
     force: boolean;
     verbose: boolean;
     context?: string[];
@@ -181,8 +182,8 @@ async function destroyCommand(
         logger.info(`  - ${logicalId} (${resource.resourceType})`);
       }
 
-      // 4. Confirm (unless --force)
-      if (!options.force) {
+      // 4. Confirm (unless -y/--yes or --force)
+      if (!options.yes && !options.force) {
         const rl = readline.createInterface({
           input: process.stdin,
           output: process.stdout,

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -23,17 +23,23 @@ export const commonOptions = [
   new Option('--verbose', 'Enable verbose logging').default(false),
   new Option('--region <region>', 'AWS region'),
   new Option('--profile <profile>', 'AWS profile'),
+  new Option(
+    '-y, --yes',
+    'Automatically answer interactive prompts with the recommended response (e.g. confirm destroy)'
+  ).default(false),
 ];
 
 /**
  * App options
  *
- * --app is optional: falls back to CDKD_APP env var, then cdk.json "app" field
+ * --app is optional: falls back to CDKD_APP env var, then cdk.json "app" field.
+ * Accepts either a shell command (e.g. "npx ts-node app.ts") or a path to a
+ * pre-synthesized cloud assembly directory (e.g. "cdk.out").
  */
 export const appOptions = [
   new Option(
-    '--app <command>',
-    'CDK app command (e.g., "npx ts-node app.ts"). Falls back to cdk.json or CDKD_APP env'
+    '-a, --app <command>',
+    'CDK app command (e.g., "npx ts-node app.ts") or path to a pre-synthesized cloud assembly directory. Falls back to cdk.json or CDKD_APP env'
   ),
   new Option('--output <path>', 'Output directory for synthesis').default('cdk.out'),
 ];
@@ -100,5 +106,9 @@ export const contextOptions = [
 
 /**
  * Destroy options
+ *
+ * `--force` is kept alongside the global `-y, --yes` for CDK CLI parity.
  */
-export const destroyOptions = [new Option('--force', 'Skip confirmation prompt').default(false)];
+export const destroyOptions = [
+  new Option('--force', 'Skip confirmation prompt (alias of --yes)').default(false),
+];

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -106,9 +106,9 @@ export const contextOptions = [
 
 /**
  * Destroy options
- *
- * `--force` is kept alongside the global `-y, --yes` for CDK CLI parity.
  */
 export const destroyOptions = [
-  new Option('--force', 'Skip confirmation prompt (alias of --yes)').default(false),
+  new Option('-f, --force', 'Do not ask for confirmation before destroying the stacks').default(
+    false
+  ),
 ];

--- a/src/synthesis/synthesizer.ts
+++ b/src/synthesis/synthesizer.ts
@@ -71,16 +71,11 @@ export class Synthesizer {
   async synthesize(options: SynthesisOptions): Promise<SynthesisResult> {
     // CDK CLI compatibility: if --app points at an existing directory, treat it
     // as a pre-synthesized cloud assembly and skip subprocess execution.
+    // See aws-cdk/lib/cxapp/exec.ts: "bypass 'synth' if app points to a cloud assembly".
     const appPath = resolve(options.app);
     if (existsSync(appPath) && statSync(appPath).isDirectory()) {
       this.logger.debug(`Using pre-synthesized cloud assembly at ${appPath}`);
       const manifest = this.assemblyReader.readManifest(appPath);
-      if (manifest.missing && manifest.missing.length > 0) {
-        throw new SynthesisError(
-          `Pre-synthesized assembly at ${appPath} has unresolved context. ` +
-            'Re-synthesize with the CDK CLI before pointing --app at the assembly directory.'
-        );
-      }
       const stacks = this.assemblyReader.getAllStacks(appPath, manifest);
       this.logger.debug(`Loaded ${stacks.length} stack(s) from pre-synthesized assembly`);
       return { manifest, assemblyDir: appPath, stacks };

--- a/src/synthesis/synthesizer.ts
+++ b/src/synthesis/synthesizer.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
 import { AppExecutor } from './app-executor.js';
@@ -69,6 +69,23 @@ export class Synthesizer {
    * 5. Return assembly with stacks
    */
   async synthesize(options: SynthesisOptions): Promise<SynthesisResult> {
+    // CDK CLI compatibility: if --app points at an existing directory, treat it
+    // as a pre-synthesized cloud assembly and skip subprocess execution.
+    const appPath = resolve(options.app);
+    if (existsSync(appPath) && statSync(appPath).isDirectory()) {
+      this.logger.debug(`Using pre-synthesized cloud assembly at ${appPath}`);
+      const manifest = this.assemblyReader.readManifest(appPath);
+      if (manifest.missing && manifest.missing.length > 0) {
+        throw new SynthesisError(
+          `Pre-synthesized assembly at ${appPath} has unresolved context. ` +
+            'Re-synthesize with the CDK CLI before pointing --app at the assembly directory.'
+        );
+      }
+      const stacks = this.assemblyReader.getAllStacks(appPath, manifest);
+      this.logger.debug(`Loaded ${stacks.length} stack(s) from pre-synthesized assembly`);
+      return { manifest, assemblyDir: appPath, stacks };
+    }
+
     const outputDir = resolve(options.output || 'cdk.out');
 
     // Ensure output directory exists

--- a/tests/unit/synthesis/synthesizer.test.ts
+++ b/tests/unit/synthesis/synthesizer.test.ts
@@ -55,8 +55,12 @@ vi.mock('@aws-sdk/client-sts', () => ({
 }));
 
 // Mock node:fs
+const mockExistsSync = vi.fn();
+const mockStatSync = vi.fn();
 vi.mock('node:fs', () => ({
   mkdirSync: vi.fn(),
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  statSync: (...args: unknown[]) => mockStatSync(...args),
 }));
 
 // Mock logger
@@ -91,6 +95,9 @@ describe('Synthesizer', () => {
     mockContextStoreLoad.mockReturnValue({});
     mockLoadCdkJson.mockReturnValue(null);
     mockLoadUserCdkJson.mockReturnValue(null);
+    // Default: --app is treated as a shell command (no existing directory)
+    mockExistsSync.mockReturnValue(false);
+    mockStatSync.mockReturnValue({ isDirectory: () => false });
   });
 
   describe('context merge order', () => {
@@ -194,6 +201,34 @@ describe('Synthesizer', () => {
 
       const passedContext = mockExecute.mock.calls[0]![0].context as Record<string, unknown>;
       expect(passedContext['aws:cdk:enable-path-metadata']).toBe(false);
+    });
+
+    it('should skip subprocess execution when --app points at an existing directory', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockStatSync.mockReturnValue({ isDirectory: () => true });
+      mockReadManifest.mockReturnValue({ version: '38.0.0', artifacts: {} });
+      mockGetAllStacks.mockReturnValue([]);
+
+      const result = await synthesizer.synthesize({ app: 'cdk.out' });
+
+      expect(mockExecute).not.toHaveBeenCalled();
+      expect(mockReadManifest).toHaveBeenCalledTimes(1);
+      expect(result.assemblyDir).toMatch(/cdk\.out$/);
+    });
+
+    it('should reject pre-synthesized assembly with unresolved missing context', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockStatSync.mockReturnValue({ isDirectory: () => true });
+      mockReadManifest.mockReturnValue({
+        version: '38.0.0',
+        artifacts: {},
+        missing: [{ key: 'foo', provider: 'availability-zones', props: {} }],
+      });
+
+      await expect(synthesizer.synthesize({ app: 'cdk.out' })).rejects.toThrow(
+        /unresolved context/i
+      );
+      expect(mockExecute).not.toHaveBeenCalled();
     });
 
     it('should pass cdk.json feature flags to CDK app', async () => {

--- a/tests/unit/synthesis/synthesizer.test.ts
+++ b/tests/unit/synthesis/synthesizer.test.ts
@@ -216,7 +216,7 @@ describe('Synthesizer', () => {
       expect(result.assemblyDir).toMatch(/cdk\.out$/);
     });
 
-    it('should reject pre-synthesized assembly with unresolved missing context', async () => {
+    it('should pass through pre-synthesized assembly even when manifest reports missing context (CDK CLI parity)', async () => {
       mockExistsSync.mockReturnValue(true);
       mockStatSync.mockReturnValue({ isDirectory: () => true });
       mockReadManifest.mockReturnValue({
@@ -224,10 +224,9 @@ describe('Synthesizer', () => {
         artifacts: {},
         missing: [{ key: 'foo', provider: 'availability-zones', props: {} }],
       });
+      mockGetAllStacks.mockReturnValue([]);
 
-      await expect(synthesizer.synthesize({ app: 'cdk.out' })).rejects.toThrow(
-        /unresolved context/i
-      );
+      await expect(synthesizer.synthesize({ app: 'cdk.out' })).resolves.toBeDefined();
       expect(mockExecute).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
- Promote `-y, --yes` to a global option (CDK CLI parity, see [`aws-cdk-cli/.../cli-config.ts:49`](https://github.com/aws/aws-cdk-cli/blob/main/packages/aws-cdk/lib/cli/cli-config.ts#L49)). It auto-confirms interactive prompts (currently only `destroy`) at the IO layer, regardless of the subcommand.
- Add `-a` as the short alias for `--app` on every command that accepts it (synth/deploy/diff/destroy).
- Add `-f` as the short alias for the existing `destroy --force` to match CDK CLI. `--force` and `-y` are **not** aliases of each other — they live on different layers (per-subcommand "force" semantics vs. the global "auto-yes" prompt response). Both happen to short-circuit the destroy confirmation prompt.
- `--app` now accepts a path to a pre-synthesized cloud assembly directory in addition to a shell command. When the value points at an existing directory, `Synthesizer` reads `manifest.json` from it directly and skips subprocess execution — mirroring [`aws-cdk/lib/cxapp/exec.ts:50-58`](https://github.com/aws/aws-cdk-cli/blob/main/packages/aws-cdk/lib/cxapp/exec.ts#L50-L58) ("bypass 'synth' if app points to a cloud assembly"). The assembly is passed through as-is, including manifests with unresolved `missing` context (CDK CLI does not validate that field on this path either).

## Test plan
- [x] Unit tests pass (46 files, 572 tests)
- [x] New unit tests in `tests/unit/synthesis/synthesizer.test.ts` cover the directory short-circuit and the missing-context pass-through
- [x] Manual help output verified across all subcommands: `-y, --yes` shows up under every command (global), `-a, --app` shows up wherever `--app` is accepted, `-f, --force` shows up only on `destroy`
- [x] Manual error-path verified for malformed `--app` values (non-existent path → shell-exec error like CDK CLI, dir without `manifest.json` → SynthesisError ENOENT, dir with bad JSON → SynthesisError parse error)
- [x] README.md and CLAUDE.md updated to describe the new flags, the directory short-circuit, and the `-y` vs `-f` semantic distinction
