### PR TITLE
feat(deployment): event-driven DAG dispatch (no level barriers)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,10 +63,11 @@ cdkd has a 7-layer system architecture:
    - State structure: `s3://bucket/stacks/{stackName}/state.json`
    - Lock structure: `s3://bucket/stacks/{stackName}/lock.json`
 
-3. **DAG-based Parallel Execution**
-   - Analyzes dependencies via `Ref` / `Fn::GetAtt`
-   - Determines execution order with topological sort
-   - Executes resources in parallel by level (resources without dependencies run concurrently)
+3. **Event-driven DAG Execution**
+   - Analyzes dependencies via `Ref` / `Fn::GetAtt` / `DependsOn`
+   - Dispatches each resource as soon as ALL of its own dependencies complete (no level barrier — downstream work does not wait for unrelated siblings in the same DAG level)
+   - Bounded by `--concurrency` across the whole stack
+   - Implemented in `src/deployment/dag-executor.ts`
 
 4. **Intrinsic Function Resolution**
    - All CloudFormation intrinsic functions supported: `Ref`, `Fn::GetAtt`, `Fn::Join`, `Fn::Sub`, `Fn::Select`, `Fn::Split`, `Fn::If`, `Fn::Equals`, `Fn::And`, `Fn::Or`, `Fn::Not`, `Fn::ImportValue`, `Fn::FindInMap`, `Fn::Base64`, `Fn::GetAZs`, `Fn::Cidr`
@@ -114,6 +115,7 @@ pnpm run typecheck
 - **src/synthesis/assembly-reader.ts** - Reads and parses Cloud Assembly manifest.json directly
 - **src/synthesis/synthesizer.ts** - Orchestrates synthesis with context provider loop
 - **src/synthesis/context-providers/** - Context providers (see `src/synthesis/context-providers/` for full list) for missing context resolution
+- **src/deployment/dag-executor.ts** - Generic event-driven DAG dispatcher (used inside a stack to schedule resource provisioning as soon as each resource's deps complete; no level barriers)
 - **src/deployment/work-graph.ts** - WorkGraph DAG orchestrator for asset publishing and stack deployment
 - **src/assets/file-asset-publisher.ts** - S3 file upload with ZIP packaging support
 - **src/assets/docker-asset-publisher.ts** - ECR Docker image build & push
@@ -318,8 +320,9 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 - ✅ AWS::NoValue pseudo parameter (for conditional property omission)
 - ✅ Fn::FindInMap (Mappings lookup) and Fn::Base64 (base64 encoding)
 - ✅ Fn::GetAZs (all intrinsic functions now supported)
-- ✅ Partial state save after each DAG level (prevents orphaned resources)
-- ✅ Pre-rollback state save on failure (tracks resources from partially-failed levels)
+- ✅ Per-resource partial state save (prevents orphaned resources mid-deploy)
+- ✅ Pre-rollback state save on failure (tracks resources completed concurrently with the failed one)
+- ✅ Event-driven DAG dispatch (each resource starts as soon as its own deps complete; no level barrier)
 - ✅ CREATE retry with exponential backoff (IAM propagation delays)
 - ✅ CC API polling with exponential backoff (1s→2s→4s→8s→10s)
 - ✅ Compact output mode (default clean output, `--verbose` for full details)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,16 @@ registry.register('AWS::IAM::Role', new IAMRoleProvider());
 - Allows testing UPDATE operations without modifying code
 - JSON Patch (RFC 6902) verified working for S3, Lambda, IAM resources
 
+### Rollback Testing (failure injection)
+
+- Environment variable `CDKD_TEST_FAIL=true` injects a deliberately-failing
+  resource (an `AWS::SQS::Queue` with an out-of-range `MessageRetentionPeriod`)
+  into the `basic` stack
+- Verifies against real AWS that already-completed siblings get rolled back
+  when one resource fails: `CDKD_TEST_FAIL=true cdkd deploy CdkdBasicExample`
+- After rollback, S3 and SSM Document should both be deleted and state file
+  should be empty
+
 ## Common Development Tasks
 
 ### Adding a New SDK Provider

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Reproduce with `./tests/benchmark/run-benchmark.sh all`. See [tests/benchmark/RE
 │ cdkd Engine     │
 │ - DAG Analysis  │  Dependency graph construction
 │ - Diff Calc     │  Compare with existing resources
-│ - Parallel Exec │  Deploy by levels
+│ - Parallel Exec │  Event-driven dispatch
 └────────┬────────┘
          │
     ┌────┴────┐
@@ -134,10 +134,11 @@ Reproduce with `./tests/benchmark/run-benchmark.sh all`. See [tests/benchmark/RE
    │   ├── Build DAG from template (Ref/Fn::GetAtt/DependsOn)
    │   ├── Calculate diff (CREATE/UPDATE/DELETE)
    │   ├── Resolve intrinsic functions (Ref, Fn::Sub, Fn::Join, etc.)
-   │   ├── Execute by levels (parallel within each level):
+   │   ├── Execute via event-driven DAG dispatch (a resource starts as
+   │   │   soon as ALL of its own deps complete; no level barrier):
    │   │   ├── SDK Providers (direct API calls, preferred)
    │   │   └── Cloud Control API (fallback, async polling)
-   │   ├── Save state after each level (partial state save)
+   │   ├── Save state after each successful resource (partial state save)
    │   └── Release lock
    └── synth does NOT publish assets or deploy (deploy only)
 ```
@@ -459,7 +460,7 @@ LambdaStack
 ✓ Deployed LambdaStack (4 resources, 7.2s)
 ```
 
-Resources without dependencies (ServiceRole and Table) are created in parallel.
+Resources are dispatched as soon as their own dependencies complete (event-driven DAG). ServiceRole and Table run in parallel; DefaultPolicy starts the moment ServiceRole is done — without waiting for Table — and Handler starts the moment DefaultPolicy is done.
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -396,7 +396,7 @@ async deploy(options: DeployOptions): Promise<void> {
   6. Calculate diff
   7. Display execution plan
   8. Exit here if --dry-run
-  9. Execute in parallel by level
+  9. Execute via event-driven DAG dispatch
      - CREATE: Create resource via provider
      - UPDATE: Generate JSON Patch → Provider update
      - DELETE: Delete in reverse dependency order
@@ -406,16 +406,26 @@ async deploy(options: DeployOptions): Promise<void> {
 }
 ```
 
-**Parallel Execution**:
+**Event-driven Execution**:
+
+Each resource is dispatched as soon as ALL of its own dependencies complete —
+it does not wait for unrelated siblings in the same DAG level to finish.
+A bounded concurrency limit (`--concurrency`, default 10) caps the number of
+in-flight provisioning operations.
 
 ```typescript
-for (const level of executionLevels) {
-  await Promise.all(
-    level.resources.map(resource =>
-      this.provisionResource(resource)
-    )
-  )
+const executor = new DagExecutor();
+for (const id of createUpdateIds) {
+  executor.add({
+    id,
+    dependencies: new Set(dagBuilder.getDirectDependencies(dag, id)),
+    state: 'pending',
+    data: changes.get(id),
+  });
 }
+await executor.execute(concurrency, async (node) => {
+  await this.provisionResource(node.id, node.data);
+});
 ```
 
 **Error Handling**:
@@ -753,7 +763,7 @@ Each layer has clear responsibilities
 | ---- | -------------- | ---- |
 | **Small Stack (5 resources)** | 60-90 seconds | 15-25 seconds |
 | **Medium Stack (20 resources)** | 3-5 minutes | 40-80 seconds |
-| **Parallel Execution** | Mainly sequential | Fully parallel by DAG level |
+| **Parallel Execution** | Mainly sequential | Event-driven DAG dispatch (each resource starts as soon as its own deps complete) |
 | **Rollback** | Automatic | Manual (recover from state) |
 
 ### Bottlenecks
@@ -761,7 +771,7 @@ Each layer has clear responsibilities
 1. **Asset Publishing**: S3 upload of Lambda code (seconds to tens of seconds)
 2. **Cloud Control API Polling**: CC API requires async polling for resource operations (mitigated by using SDK Providers for common types)
 3. **Cloud Control API Rate Limits**: Limits per resource type
-4. **Dependency Chains**: More levels reduce parallelism
+4. **Dependency Chains**: Long critical paths through the DAG cap parallelism
 
 ## Security Considerations
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -400,24 +400,27 @@ async deploy(stackName: string) {
     // 7. Calculate diff
     const diffs = diffCalculator.calculate(currentState, template);
 
-    // 8. Execute resources (parallel by level)
+    // 8. Execute resources (event-driven DAG dispatch)
     const newResourceStates = {};
-    for (const level of dag.levels) {
-      await Promise.all(
-        level.resources.map(async (resource) => {
-          const result = await provisionResource(resource, diffs);
-
-          // Record result to state
-          newResourceStates[resource.logicalId] = {
-            physicalId: result.physicalId,
-            resourceType: resource.resourceType,
-            properties: resource.properties,
-            attributes: result.attributes,
-            dependencies: resource.dependencies,
-          };
-        })
-      );
+    const executor = new DagExecutor();
+    for (const resource of resources) {
+      executor.add({
+        id: resource.logicalId,
+        dependencies: new Set(resource.dependencies),
+        state: 'pending',
+        data: resource,
+      });
     }
+    await executor.execute(concurrency, async (node) => {
+      const result = await provisionResource(node.data, diffs);
+      newResourceStates[node.id] = {
+        physicalId: result.physicalId,
+        resourceType: node.data.resourceType,
+        properties: node.data.properties,
+        attributes: result.attributes,
+        dependencies: node.data.dependencies,
+      };
+    });
 
     // 9. Resolve Outputs
     const outputs = resolveOutputs(template.Outputs, newResourceStates);
@@ -449,25 +452,24 @@ async deploy(stackName: string) {
 cdkd catches errors per resource and saves **only successful resources** to state.
 
 ```typescript
-// deploy-engine.ts
+// deploy-engine.ts (event-driven DAG dispatch)
 const newResourceStates = {};
+const executor = new DagExecutor();
+// ... add nodes ...
 
-for (const level of dag.levels) {
-  const results = await Promise.allSettled(
-    level.resources.map(resource => provisionResource(resource))
-  );
-
-  results.forEach((result, index) => {
-    if (result.status === 'fulfilled') {
-      // Record only successful resources
-      const resource = level.resources[index];
-      newResourceStates[resource.logicalId] = result.value;
-    } else {
-      // Log failures
-      logger.error(`Failed to provision ${resource.logicalId}:`, result.reason);
-    }
+try {
+  await executor.execute(concurrency, async (node) => {
+    const result = await provisionResource(node.data);
+    // Record successful resource immediately (per-resource state save)
+    newResourceStates[node.id] = result;
   });
+} catch (error) {
+  // First failure aborts dispatch — downstream nodes are auto-skipped.
+  // Already-completed resources remain in newResourceStates for rollback.
+  logger.error('Provisioning failed:', error);
+  throw error;
 }
+// (placeholder — see actual code for the full rollback path)
 
 // Save only successful state
 await s3StateBackend.saveState(stackName, newState);

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -391,6 +391,26 @@ CDKD_TEST_UPDATE=true node ../../../../dist/cli.js deploy CdkdBasicExample \
 
 The `CDKD_TEST_UPDATE=true` environment variable adds an additional tag to the S3 bucket without modifying the code. This allows testing UPDATE operations repeatedly.
 
+### Failure injection (CDKD_TEST_FAIL)
+
+To verify rollback against real AWS, the `basic` stack supports a third toggle:
+
+```bash
+# Deploy with a deliberately-failing SQS Queue injected.
+# The good resources (S3 bucket, SSM Document) succeed in parallel;
+# the SQS Queue's invalid MessageRetentionPeriod is rejected by AWS,
+# triggering rollback that deletes the already-completed siblings.
+CDKD_TEST_FAIL=true node ../../../../dist/cli.js deploy CdkdBasicExample \
+  --app "npx ts-node --prefer-ts-exts bin/app.ts" \
+  --state-bucket ${STATE_BUCKET} \
+  --region ${AWS_REGION}
+
+# Expected: deploy fails with rollback log, and `aws s3 ls
+# s3://${STATE_BUCKET}/stacks/` shows no leftover state.
+```
+
+Use this to sanity-check the dispatcher's rollback path against AWS without writing a separate failing CDK app each time.
+
 ### Method B: Manual code changes
 
 Alternatively, modify the stack code directly and re-deploy to test updates.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -633,7 +633,7 @@ aws iam get-role --role-name cdk-hnb659fds-deploy-role-123456789012-us-east-1
 
 #### Causes
 
-- Dependencies are serialized (many DAG levels)
+- Long dependency chains in the DAG (the critical path caps how fast a deploy can finish, even with event-driven dispatch)
 - Cloud Control API rate limits
 - Asset publishing takes time
 
@@ -709,17 +709,17 @@ Implement provider that uses SDK directly instead of Cloud Control API.
 
 ### Overview
 
-Orphaned resources are AWS resources that exist in your account but are not tracked in cdkd's state file. This can happen when a deployment fails partway through a DAG level — some resources in that level may have been successfully created while others failed.
+Orphaned resources are AWS resources that exist in your account but are not tracked in cdkd's state file. This can happen when a deployment fails partway through — some resources may have been successfully created while others failed in flight.
 
 ### How cdkd Prevents Orphans
 
 cdkd uses a multi-layered approach to prevent orphaned resources:
 
-1. **Per-resource in-memory state update**: Each resource updates the in-memory state (`newResources`) immediately upon successful provisioning, even before the entire DAG level completes.
+1. **Per-resource in-memory state update**: Each resource updates the in-memory state (`newResources`) immediately upon successful provisioning.
 
-2. **Per-level partial state save**: After each DAG level completes successfully, state is persisted to S3. This prevents orphans if the process crashes between levels.
+2. **Per-resource partial state save**: After each successful resource provision, state is persisted to S3 (serialized via a save chain to avoid ETag conflicts). This prevents orphans if the process crashes mid-deploy.
 
-3. **Pre-rollback state save**: If any resource in a level fails, cdkd saves the current in-memory state (including all successfully provisioned resources from the failed level) to S3 **before** attempting rollback. This ensures that even resources created in the same level as the failure are tracked.
+3. **Pre-rollback state save**: If any resource fails, cdkd saves the current in-memory state (including all successfully provisioned resources up to that point) to S3 **before** attempting rollback. This ensures that resources completed concurrently with the failed one are still tracked.
 
 4. **Post-rollback state save**: After rollback completes (or is skipped with `--no-rollback`), state is saved again to reflect the rolled-back resource state.
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "build": "node build.mjs",
     "dev": "node build.mjs --watch",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "lint": "eslint src --ext .ts",

--- a/src/deployment/dag-executor.ts
+++ b/src/deployment/dag-executor.ts
@@ -61,16 +61,24 @@ export class DagExecutor<T = unknown> {
 
     return new Promise<void>((resolve, reject) => {
       const dispatch = (): void => {
-        // Mark nodes whose dependencies failed/skipped as skipped.
-        for (const node of this.nodes.values()) {
-          if (node.state !== 'pending') continue;
-          const hasFailedDep = [...node.dependencies].some((depId) => {
-            const dep = this.nodes.get(depId);
-            return dep && (dep.state === 'failed' || dep.state === 'skipped');
-          });
-          if (hasFailedDep) {
-            node.state = 'skipped';
-            this.logger.debug(`Skipped ${node.id}: dependency failed or was skipped`);
+        // Mark nodes whose dependencies failed/skipped as skipped — to a
+        // fixed point, so transitive dependents propagate within a single
+        // dispatch (e.g., A→B→C where A failed must mark BOTH B and C as
+        // skipped, regardless of node insertion order).
+        let changed = true;
+        while (changed) {
+          changed = false;
+          for (const node of this.nodes.values()) {
+            if (node.state !== 'pending') continue;
+            const hasFailedDep = [...node.dependencies].some((depId) => {
+              const dep = this.nodes.get(depId);
+              return dep && (dep.state === 'failed' || dep.state === 'skipped');
+            });
+            if (hasFailedDep) {
+              node.state = 'skipped';
+              changed = true;
+              this.logger.debug(`Skipped ${node.id}: dependency failed or was skipped`);
+            }
           }
         }
 

--- a/src/deployment/dag-executor.ts
+++ b/src/deployment/dag-executor.ts
@@ -116,6 +116,14 @@ export class DagExecutor<T = unknown> {
         }
 
         if (active === 0) {
+          // Drain-before-reject guarantee: we only reach this point after every
+          // in-flight node has settled (success OR failure), because each fn()
+          // promise's .finally() decrements `active` and re-runs dispatch. So
+          // when a node fails early, sibling nodes already running are allowed
+          // to complete normally — their successful completion is visible to
+          // the caller (e.g., for state-save and rollback bookkeeping) BEFORE
+          // execute() rejects. Don't change to "reject as soon as errors[] is
+          // non-empty" without revisiting the deploy-engine catch path.
           if (errors.length > 0) {
             reject(errors[0]!.error);
             return;

--- a/src/deployment/dag-executor.ts
+++ b/src/deployment/dag-executor.ts
@@ -1,0 +1,134 @@
+import { getLogger } from '../utils/logger.js';
+
+export type DagNodeState = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+
+export interface DagNode<T = unknown> {
+  id: string;
+  dependencies: Set<string>;
+  state: DagNodeState;
+  data: T;
+}
+
+/**
+ * Event-driven DAG executor with bounded concurrency.
+ *
+ * Dispatches a node as soon as ALL of its dependencies are completed —
+ * unlike level-synchronized execution, downstream work does not wait for
+ * unrelated siblings in the same "level" to finish.
+ *
+ * Failure handling:
+ * - A failed node marks its transitive downstream as 'skipped' (not started)
+ * - In-flight nodes drain naturally; no new dispatch after first failure
+ *   (cancelled() can be set to halt dispatch — used for SIGINT)
+ * - On drain, rejects with the FIRST failure (matches prior behavior)
+ *
+ * Cancellation:
+ * - When cancelled() returns true, no new nodes are started.
+ *   In-flight nodes complete normally. After drain, resolves cleanly
+ *   if no errors — caller is responsible for translating cancellation
+ *   into a thrown error (e.g., InterruptedError on SIGINT).
+ *
+ * Dependencies pointing to nodes outside the registered set are treated
+ * as already-completed (e.g., NO_CHANGE resources excluded from the DAG).
+ */
+export class DagExecutor<T = unknown> {
+  private nodes = new Map<string, DagNode<T>>();
+  private logger = getLogger().child('DagExecutor');
+
+  add(node: DagNode<T>): void {
+    this.nodes.set(node.id, node);
+  }
+
+  has(id: string): boolean {
+    return this.nodes.has(id);
+  }
+
+  size(): number {
+    return this.nodes.size;
+  }
+
+  values(): IterableIterator<DagNode<T>> {
+    return this.nodes.values();
+  }
+
+  async execute(
+    concurrency: number,
+    fn: (node: DagNode<T>) => Promise<void>,
+    cancelled: () => boolean = () => false
+  ): Promise<void> {
+    let active = 0;
+    const errors: Array<{ id: string; error: unknown }> = [];
+
+    return new Promise<void>((resolve, reject) => {
+      const dispatch = (): void => {
+        // Mark nodes whose dependencies failed/skipped as skipped.
+        for (const node of this.nodes.values()) {
+          if (node.state !== 'pending') continue;
+          const hasFailedDep = [...node.dependencies].some((depId) => {
+            const dep = this.nodes.get(depId);
+            return dep && (dep.state === 'failed' || dep.state === 'skipped');
+          });
+          if (hasFailedDep) {
+            node.state = 'skipped';
+            this.logger.debug(`Skipped ${node.id}: dependency failed or was skipped`);
+          }
+        }
+
+        // Find ready nodes (deps completed or external-to-DAG).
+        const ready: DagNode<T>[] = [];
+        for (const node of this.nodes.values()) {
+          if (node.state !== 'pending') continue;
+          const depsReady = [...node.dependencies].every((depId) => {
+            const dep = this.nodes.get(depId);
+            return !dep || dep.state === 'completed';
+          });
+          if (depsReady) ready.push(node);
+        }
+
+        // Dispatch up to concurrency limit, unless cancellation requested.
+        if (!cancelled()) {
+          for (const node of ready) {
+            if (active >= concurrency) break;
+            node.state = 'running';
+            active++;
+
+            fn(node)
+              .then(() => {
+                node.state = 'completed';
+              })
+              .catch((error) => {
+                node.state = 'failed';
+                errors.push({ id: node.id, error });
+              })
+              .finally(() => {
+                active--;
+                dispatch();
+              });
+          }
+        }
+
+        if (active === 0) {
+          if (errors.length > 0) {
+            reject(errors[0]!.error);
+            return;
+          }
+          const stillPending = [...this.nodes.values()].some((n) => n.state === 'pending');
+          if (stillPending && !cancelled()) {
+            const pending = [...this.nodes.values()]
+              .filter((n) => n.state === 'pending')
+              .map((n) => n.id);
+            reject(
+              new Error(
+                `Deadlock detected: ${pending.length} node(s) stuck with unresolvable dependencies (${pending.join(', ')})`
+              )
+            );
+            return;
+          }
+          resolve();
+        }
+      };
+
+      dispatch();
+    });
+  }
+}

--- a/src/deployment/deploy-engine.ts
+++ b/src/deployment/deploy-engine.ts
@@ -1,8 +1,8 @@
-import pLimit from 'p-limit';
 import { getLogger } from '../utils/logger.js';
 import { ProvisioningError } from '../utils/error-handler.js';
 import { setCurrentStackName, applyDefaultNameForFallback } from '../provisioning/resource-name.js';
 import { IntrinsicFunctionResolver } from './intrinsic-function-resolver.js';
+import { DagExecutor } from './dag-executor.js';
 import type { CloudFormationTemplate, ResourceProvider } from '../types/resource.js';
 import type { StackState, ResourceState, ResourceChange } from '../types/state.js';
 import type { S3StateBackend } from '../state/s3-state-backend.js';
@@ -258,11 +258,12 @@ export class DeployEngine {
       const totalOperations = createChanges.length + updateChanges.length + deleteChanges.length;
       const progress = { current: 0, total: totalOperations };
 
-      // 6. Execute deployment (with partial state saves after each level)
+      // 6. Execute deployment (event-driven DAG dispatch with partial state saves)
       const { state: newState, actualCounts } = await this.executeDeployment(
         template,
         currentState,
         changes,
+        dag,
         executionLevels,
         stackName,
         parameterValues,
@@ -304,15 +305,19 @@ export class DeployEngine {
   }
 
   /**
-   * Execute deployment by processing resources in DAG order
+   * Execute deployment by processing resources via event-driven DAG dispatch.
    *
-   * Important: DELETE operations are executed in reverse dependency order,
-   * while CREATE/UPDATE follow normal dependency order.
+   * - CREATE/UPDATE follow forward dependency order (a node starts as soon as
+   *   ALL of its dependencies are completed — does not wait for unrelated
+   *   siblings in the same "level")
+   * - DELETE follows reverse dependency order (a node starts as soon as all
+   *   resources that depend ON it have finished deleting)
    */
   private async executeDeployment(
     template: CloudFormationTemplate,
     currentState: StackState,
     changes: Map<string, ResourceChange>,
+    dag: ReturnType<DagBuilder['buildGraph']>,
     executionLevels: string[][],
     stackName: string,
     parameterValues?: Record<string, unknown>,
@@ -323,7 +328,7 @@ export class DeployEngine {
     state: StackState;
     actualCounts: { created: number; updated: number; deleted: number; skipped: number };
   }> {
-    const limit = pLimit(this.options.concurrency!);
+    const concurrency = this.options.concurrency!;
     const newResources: Record<string, ResourceState> = { ...currentState.resources };
     const actualCounts = { created: 0, updated: 0, deleted: 0, skipped: 0 };
     const completedOperations: CompletedOperation[] = [];
@@ -360,42 +365,43 @@ export class DeployEngine {
     );
 
     try {
-      // Step 1: Process CREATE/UPDATE in normal DAG order
-      for (let levelIndex = 0; levelIndex < executionLevels.length; levelIndex++) {
-        // Check for SIGINT before starting next level
-        if (this.interrupted) {
-          throw new InterruptedError();
-        }
+      // Step 1: Process CREATE/UPDATE via event-driven DAG dispatch.
+      // A node starts as soon as ALL of its dependencies are completed, rather
+      // than waiting for an entire "level" of unrelated siblings to finish.
+      const createUpdateIds: string[] = [];
+      for (const [id, change] of changes.entries()) {
+        if (deleteChanges.has(id)) continue;
+        if (change.changeType === 'NO_CHANGE') continue;
+        createUpdateIds.push(id);
+      }
 
-        const levelNodes = executionLevels[levelIndex];
-        if (!levelNodes) continue;
-        // Exclude DELETE (handled in Step 2), NO_CHANGE, and nodes without a change
-        // entry (e.g. AWS::CDK::Metadata) so the level count reflects real work.
-        const level = levelNodes.filter((id) => {
-          if (deleteChanges.has(id)) return false;
-          const change = changes.get(id);
-          return !!change && change.changeType !== 'NO_CHANGE';
-        });
-
-        if (level.length === 0) continue;
-
+      if (createUpdateIds.length > 0) {
         this.logger.info(
-          `Level ${levelIndex + 1}/${executionLevels.length} (${level.length} resources)`
+          `Deploying ${createUpdateIds.length} resource(s) (DAG: ${executionLevels.length} levels, max parallel: ${concurrency})`
         );
 
-        // Use allSettled to ensure ALL parallel tasks complete before checking errors.
-        // Promise.all rejects immediately on first failure, leaving background tasks
-        // that create resources without tracking them in completedOperations.
-        const results = await Promise.allSettled(
-          level.map((logicalId) =>
-            limit(async () => {
-              const change = changes.get(logicalId);
-              if (!change || change.changeType === 'NO_CHANGE') {
-                this.logger.debug(`Skipping ${logicalId} (no change)`);
-                return;
-              }
+        const createUpdateExecutor = new DagExecutor<ResourceChange>();
+        const provisionable = new Set(createUpdateIds);
+        for (const id of createUpdateIds) {
+          const allDeps = this.dagBuilder.getDirectDependencies(dag, id);
+          // Only carry deps that are themselves being provisioned in this phase;
+          // NO_CHANGE / DELETE / non-DAG deps are already satisfied.
+          const deps = new Set(allDeps.filter((d) => provisionable.has(d)));
+          createUpdateExecutor.add({
+            id,
+            dependencies: deps,
+            state: 'pending',
+            data: changes.get(id)!,
+          });
+        }
 
-              // Capture previous state before provisioning (for rollback)
+        try {
+          await createUpdateExecutor.execute(
+            concurrency,
+            async (node) => {
+              const logicalId = node.id;
+              const change = node.data;
+
               const previousState = currentState.resources[logicalId]
                 ? { ...currentState.resources[logicalId] }
                 : undefined;
@@ -415,12 +421,11 @@ export class DeployEngine {
               } catch (provisionError) {
                 // Signal interruption so that long-running operations (e.g., CloudFront
                 // waitForDeployed) in sibling tasks abort promptly instead of blocking
-                // the entire level until they time out.
+                // until their own polling timeouts fire.
                 this.interrupted = true;
                 throw provisionError;
               }
 
-              // Track completed operation for potential rollback
               completedOperations.push({
                 logicalId,
                 changeType: change.changeType as 'CREATE' | 'UPDATE',
@@ -430,48 +435,51 @@ export class DeployEngine {
                 properties: newResources[logicalId]?.properties,
               });
 
-              // Save state immediately after each successful resource provision
               saveStateAfterResource(logicalId);
-            })
-          )
-        );
+            },
+            () => this.interrupted
+          );
+        } finally {
+          // Wait for any pending per-resource state saves before the next phase or
+          // before propagating an error — prevents partial-save races.
+          await saveChain;
+        }
 
-        // Wait for any pending per-resource state saves to complete before next level
-        await saveChain;
-
-        // Check for failures after ALL tasks in the level have completed
-        const failures = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
-        if (failures.length > 0) {
-          // Throw the first failure to trigger rollback (all completed ops are tracked)
-          throw failures[0]!.reason;
+        // If SIGINT fired during dispatch but no provision threw, the executor
+        // resolves cleanly with pending nodes. Translate that into an explicit
+        // interruption error so the catch path can save partial state + rollback.
+        if (this.interrupted) {
+          throw new InterruptedError();
         }
       }
 
-      // Step 2: Process DELETE operations in reverse dependency order
+      // Step 2: Process DELETE operations in reverse dependency order.
       if (deleteChanges.size > 0) {
         this.logger.info(`Deleting ${deleteChanges.size} resource(s)`);
 
-        // Build deletion levels from state dependencies (reverse topological order)
-        const deletionLevels = this.buildDeletionLevels(deleteChanges, currentState);
+        const deleteDeps = this.buildDeletionDependencies(deleteChanges, currentState);
+        const deleteExecutor = new DagExecutor<ResourceChange>();
+        for (const id of deleteChanges) {
+          deleteExecutor.add({
+            id,
+            dependencies: deleteDeps.get(id) ?? new Set(),
+            state: 'pending',
+            data: changes.get(id)!,
+          });
+        }
 
-        for (let levelIndex = 0; levelIndex < deletionLevels.length; levelIndex++) {
-          // Check for SIGINT before starting next deletion level
-          if (this.interrupted) {
-            throw new InterruptedError();
-          }
+        try {
+          await deleteExecutor.execute(
+            concurrency,
+            async (node) => {
+              const logicalId = node.id;
+              const change = node.data;
 
-          const level = deletionLevels[levelIndex]!;
-          if (level.length === 0) continue;
+              const previousState = currentState.resources[logicalId]
+                ? { ...currentState.resources[logicalId] }
+                : undefined;
 
-          const deleteResults = await Promise.allSettled(
-            level.map((logicalId) =>
-              limit(async () => {
-                const change = changes.get(logicalId)!;
-
-                const previousState = currentState.resources[logicalId]
-                  ? { ...currentState.resources[logicalId] }
-                  : undefined;
-
+              try {
                 await this.provisionResource(
                   logicalId,
                   change,
@@ -483,29 +491,28 @@ export class DeployEngine {
                   actualCounts,
                   progress
                 );
+              } catch (provisionError) {
+                this.interrupted = true;
+                throw provisionError;
+              }
 
-                completedOperations.push({
-                  logicalId,
-                  changeType: 'DELETE',
-                  resourceType: change.resourceType,
-                  previousState,
-                });
+              completedOperations.push({
+                logicalId,
+                changeType: 'DELETE',
+                resourceType: change.resourceType,
+                previousState,
+              });
 
-                // Save state immediately after each successful resource deletion
-                saveStateAfterResource(logicalId);
-              })
-            )
+              saveStateAfterResource(logicalId);
+            },
+            () => this.interrupted
           );
-
-          // Wait for any pending per-resource state saves to complete before next deletion level
+        } finally {
           await saveChain;
+        }
 
-          const deleteFailures = deleteResults.filter(
-            (r): r is PromiseRejectedResult => r.status === 'rejected'
-          );
-          if (deleteFailures.length > 0) {
-            throw deleteFailures[0]!.reason;
-          }
+        if (this.interrupted) {
+          throw new InterruptedError();
         }
       }
     } catch (error) {
@@ -670,7 +677,7 @@ export class DeployEngine {
    * Sort CREATE rollback operations so that resources depending on others
    * are deleted first (reverse dependency order).
    *
-   * Uses state dependencies to build deletion levels, similar to buildDeletionLevels.
+   * Uses state dependencies to build deletion levels, similar to buildDeletionDependencies.
    */
   private sortRollbackCreates(
     createOps: CompletedOperation[],
@@ -1211,17 +1218,21 @@ export class DeployEngine {
   };
 
   /**
-   * Build deletion levels from state dependencies (reverse topological order).
-   * Resources that are depended upon by others are deleted LAST.
+   * Build a per-resource map of "must be deleted before me" dependencies for
+   * the DELETE phase, derived from state-recorded dependencies plus implicit
+   * type-based ordering rules.
+   *
+   * For a resource X, the returned set contains every resource Y such that Y
+   * must finish deleting before X starts — i.e., Y depends on X (or is otherwise
+   * required to vanish first per implicit type rules).
    */
-  private buildDeletionLevels(deleteIds: Set<string>, state: StackState): string[][] {
-    // Build reverse dependency map: resource → resources that depend on it
+  private buildDeletionDependencies(
+    deleteIds: Set<string>,
+    state: StackState
+  ): Map<string, Set<string>> {
     const dependedBy = new Map<string, Set<string>>();
-    const inDegree = new Map<string, number>();
-
     for (const id of deleteIds) {
-      if (!dependedBy.has(id)) dependedBy.set(id, new Set());
-      if (!inDegree.has(id)) inDegree.set(id, 0);
+      dependedBy.set(id, new Set());
     }
 
     for (const id of deleteIds) {
@@ -1229,53 +1240,14 @@ export class DeployEngine {
       if (!resource?.dependencies) continue;
       for (const dep of resource.dependencies) {
         if (!deleteIds.has(dep)) continue;
-        // id depends on dep → dep must be deleted AFTER id
-        if (!dependedBy.has(dep)) dependedBy.set(dep, new Set());
+        // id depends on dep → dep must be deleted AFTER id (i.e., id is in dep's deletion deps)
         dependedBy.get(dep)!.add(id);
-        inDegree.set(id, (inDegree.get(id) ?? 0) + 1);
       }
     }
 
-    // Add implicit dependencies based on resource types.
-    // For each resource being deleted, if its type has implicit dependencies,
-    // find other resources being deleted that match those dependency types
-    // and add edges so those dependents are deleted first.
     this.addImplicitDeleteDependencies(deleteIds, state, dependedBy);
 
-    // Topological sort (Kahn's algorithm) — produces levels for parallel delete
-    const levels: string[][] = [];
-    let remaining = new Set(deleteIds);
-
-    while (remaining.size > 0) {
-      // Find resources with no remaining dependents (safe to delete now)
-      const level: string[] = [];
-      for (const id of remaining) {
-        const dependents = dependedBy.get(id);
-        const hasPendingDependents = dependents
-          ? [...dependents].some((d) => remaining.has(d))
-          : false;
-        if (!hasPendingDependents) {
-          level.push(id);
-        }
-      }
-
-      if (level.length === 0) {
-        // Circular dependency fallback: delete all remaining
-        this.logger.warn(
-          `Circular dependency detected in delete order, deleting remaining ${remaining.size} resources`
-        );
-        levels.push([...remaining]);
-        break;
-      }
-
-      levels.push(level);
-      remaining = new Set([...remaining].filter((id) => !level.includes(id)));
-    }
-
-    this.logger.debug(
-      `Delete order: ${levels.length} levels - ${levels.map((l, i) => `L${i + 1}(${l.length})`).join(', ')}`
-    );
-    return levels;
+    return dependedBy;
   }
 
   /**

--- a/src/deployment/deploy-engine.ts
+++ b/src/deployment/deploy-engine.ts
@@ -517,8 +517,9 @@ export class DeployEngine {
       }
     } catch (error) {
       // Save partial state BEFORE rollback to track all successfully provisioned
-      // resources (including those in the failed level). This prevents orphaned
-      // resources — resources that exist in AWS but not in the state file.
+      // resources (including those that completed concurrently with the one that
+      // failed). This prevents orphaned resources — resources that exist in AWS
+      // but not in the state file.
       try {
         const preRollbackState: StackState = {
           version: 1,
@@ -624,12 +625,12 @@ export class DeployEngine {
    * - UPDATE → update back to previous properties
    * - DELETE → cannot rollback (resource already deleted), log warning
    *
-   * Resources created in the same DAG level may have dependencies between them
-   * (e.g., IAM Policy depends on IAM Role). When rolling back CREATEs (deleting),
-   * dependent resources must be deleted before their dependencies. This method
-   * sorts CREATE rollback operations using dependency information from state,
-   * then processes UPDATE/DELETE rollbacks, and finally processes sorted CREATE
-   * rollback deletions.
+   * Resources completed concurrently in the dispatcher may have dependencies
+   * between them (e.g., IAM Policy depends on IAM Role). When rolling back
+   * CREATEs (deleting), dependent resources must be deleted before their
+   * dependencies. This method sorts CREATE rollback operations using dependency
+   * information from state, then processes UPDATE/DELETE rollbacks, and finally
+   * processes sorted CREATE rollback deletions.
    */
   private async performRollback(
     completedOperations: CompletedOperation[],
@@ -662,7 +663,7 @@ export class DeployEngine {
     }
 
     // Step 2: Process CREATE rollbacks (deletions) in dependency-aware order
-    // Build deletion levels so dependents are deleted before their dependencies
+    // (reverse dependency: dependents are deleted before their dependencies)
     if (createOps.length > 0) {
       const sortedCreateOps = this.sortRollbackCreates(createOps, stateResources);
       for (const op of sortedCreateOps) {
@@ -677,7 +678,7 @@ export class DeployEngine {
    * Sort CREATE rollback operations so that resources depending on others
    * are deleted first (reverse dependency order).
    *
-   * Uses state dependencies to build deletion levels, similar to buildDeletionDependencies.
+   * Uses state dependencies to determine reverse-dependency order, similar to buildDeletionDependencies.
    */
   private sortRollbackCreates(
     createOps: CompletedOperation[],

--- a/src/deployment/deploy-engine.ts
+++ b/src/deployment/deploy-engine.ts
@@ -445,10 +445,13 @@ export class DeployEngine {
           await saveChain;
         }
 
-        // If SIGINT fired during dispatch but no provision threw, the executor
-        // resolves cleanly with pending nodes. Translate that into an explicit
-        // interruption error so the catch path can save partial state + rollback.
-        if (this.interrupted) {
+        // If SIGINT fired AND there is still un-provisioned work (some nodes
+        // remained pending because dispatch was cancelled), surface it as an
+        // explicit interruption so the catch path saves partial state.
+        // If every node already completed before SIGINT landed, treat the deploy
+        // as fully successful — matches the prior level-loop's "loop exits, no
+        // check" behaviour at the very end of execution.
+        if (this.interrupted && this.hasPending(createUpdateExecutor)) {
           throw new InterruptedError();
         }
       }
@@ -511,7 +514,7 @@ export class DeployEngine {
           await saveChain;
         }
 
-        if (this.interrupted) {
+        if (this.interrupted && this.hasPending(deleteExecutor)) {
           throw new InterruptedError();
         }
       }
@@ -1227,6 +1230,18 @@ export class DeployEngine {
    * must finish deleting before X starts — i.e., Y depends on X (or is otherwise
    * required to vanish first per implicit type rules).
    */
+  /**
+   * Returns true if the executor still has un-started pending nodes —
+   * used to distinguish "SIGINT cancelled real work" from "SIGINT landed
+   * after all nodes already completed" (the latter should not error).
+   */
+  private hasPending<T>(executor: DagExecutor<T>): boolean {
+    for (const node of executor.values()) {
+      if (node.state === 'pending') return true;
+    }
+    return false;
+  }
+
   private buildDeletionDependencies(
     deleteIds: Set<string>,
     state: StackState

--- a/tests/e2e/run-failure-injection.sh
+++ b/tests/e2e/run-failure-injection.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# cdkd Failure-Injection E2E Test
+#
+# Verifies the dispatcher's rollback path against real AWS by deploying the
+# `basic` stack with CDKD_TEST_FAIL=true. The stack adds an SQS Queue with an
+# out-of-range MessageRetentionPeriod that AWS rejects on CreateQueue. The good
+# resources (S3 bucket + SSM Document) succeed in parallel, then rollback must
+# delete them — verified by checking the state bucket and the AWS account.
+#
+# Usage:
+#   ./run-failure-injection.sh
+#   STATE_BUCKET=my-bucket AWS_REGION=us-east-1 ./run-failure-injection.sh
+#
+# Exits 0 on success (deploy failed AS EXPECTED + rollback cleaned up).
+# Exits 1 if anything else (deploy unexpectedly succeeded, rollback left
+# resources, etc.).
+
+set -uo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+pass() { echo -e "${GREEN}✓ $*${RESET}"; }
+fail() { echo -e "${RED}✗ $*${RESET}"; }
+info() { echo -e "${CYAN}→ $*${RESET}"; }
+header() { echo -e "\n${BOLD}========== $* ==========${RESET}\n"; }
+
+STATE_BUCKET="${STATE_BUCKET:-}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+CDKD_PATH="${CDKD_PATH:-../../dist/cli.js}"
+STACK_NAME="CdkdBasicExample"
+
+if [[ -z "${STATE_BUCKET}" ]]; then
+  info "STATE_BUCKET not set, auto-resolving from AWS account..."
+  ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text 2>/dev/null) || {
+    fail "STATE_BUCKET not set and could not resolve AWS account ID"
+    exit 1
+  }
+  STATE_BUCKET="cdkd-state-${ACCOUNT_ID}-${AWS_REGION}"
+  info "Using default state bucket: ${STATE_BUCKET}"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXAMPLE_DIR="${SCRIPT_DIR}/../integration/basic"
+CDKD_BIN="$(cd "${SCRIPT_DIR}" && node -e "const p = require('path'); console.log(p.resolve('${CDKD_PATH}'))")"
+
+if [[ ! -f "${CDKD_BIN}" ]]; then
+  fail "cdkd CLI not found at: ${CDKD_BIN}"
+  echo "  Hint: Run 'pnpm run build' in the project root first."
+  exit 1
+fi
+
+CDKD_ARGS=(
+  --app "npx ts-node --prefer-ts-exts bin/app.ts"
+  --state-bucket "${STATE_BUCKET}"
+  --region "${AWS_REGION}"
+)
+
+run_cdkd() {
+  (cd "${EXAMPLE_DIR}" && node "${CDKD_BIN}" "$@")
+}
+
+cleanup_on_exit() {
+  # Best-effort cleanup so a failed assertion doesn't leak resources.
+  echo ""
+  info "Cleanup pass (best-effort destroy)..."
+  run_cdkd destroy "${CDKD_ARGS[@]}" "${STACK_NAME}" --force >/dev/null 2>&1 || true
+}
+trap cleanup_on_exit EXIT
+
+header "Pre-flight"
+info "cdkd binary: ${CDKD_BIN}"
+info "Example dir:  ${EXAMPLE_DIR}"
+info "State bucket: ${STATE_BUCKET}"
+info "AWS region:   ${AWS_REGION}"
+
+if [[ ! -d "${EXAMPLE_DIR}/node_modules" ]]; then
+  info "Installing dependencies..."
+  (cd "${EXAMPLE_DIR}" && npm install --silent)
+fi
+
+# Make sure no leftover from a previous run.
+info "Pre-cleanup destroy (in case a prior run left state)..."
+run_cdkd destroy "${CDKD_ARGS[@]}" "${STACK_NAME}" --force >/dev/null 2>&1 || true
+
+# --------------------------------------------------------------------------
+# Step 1: Deploy with CDKD_TEST_FAIL=true — must FAIL.
+# --------------------------------------------------------------------------
+header "Step 1: Deploy with CDKD_TEST_FAIL=true (expect failure)"
+
+DEPLOY_LOG=$(mktemp)
+if (cd "${EXAMPLE_DIR}" && CDKD_TEST_FAIL=true node "${CDKD_BIN}" deploy \
+      --app "npx ts-node --prefer-ts-exts bin/app.ts" \
+      --state-bucket "${STATE_BUCKET}" \
+      --region "${AWS_REGION}" "${STACK_NAME}" 2>&1) > "${DEPLOY_LOG}"; then
+  fail "Deploy unexpectedly SUCCEEDED — failure injection did not work"
+  cat "${DEPLOY_LOG}"
+  rm -f "${DEPLOY_LOG}"
+  exit 1
+fi
+pass "Deploy failed as expected"
+
+if grep -q "Rolling back .* completed operation" "${DEPLOY_LOG}"; then
+  pass "Rollback was triggered"
+else
+  fail "Rollback message not found in deploy output"
+  cat "${DEPLOY_LOG}"
+  rm -f "${DEPLOY_LOG}"
+  exit 1
+fi
+
+if grep -q "FailingQueue" "${DEPLOY_LOG}"; then
+  pass "FailingQueue was the failed resource (expected)"
+fi
+rm -f "${DEPLOY_LOG}"
+
+# --------------------------------------------------------------------------
+# Step 2: Verify state file is empty (rollback cleaned everything up).
+# --------------------------------------------------------------------------
+header "Step 2: Verify state has no live resources"
+
+# State may have been removed by destroy on rollback path; both empty-state and
+# state-with-zero-resources count as success.
+STATE_OBJ="s3://${STATE_BUCKET}/stacks/${STACK_NAME}/state.json"
+if aws s3 ls "${STATE_OBJ}" --region "${AWS_REGION}" >/dev/null 2>&1; then
+  STATE_BODY=$(aws s3 cp "${STATE_OBJ}" - --region "${AWS_REGION}" 2>/dev/null)
+  RES_COUNT=$(echo "${STATE_BODY}" | node -e "
+    let s='';
+    process.stdin.on('data', c => s+=c);
+    process.stdin.on('end', () => {
+      try { const j = JSON.parse(s); console.log(Object.keys(j.resources||{}).length); }
+      catch(e) { console.log('-1'); }
+    });
+  ")
+  if [[ "${RES_COUNT}" == "0" ]]; then
+    pass "State has 0 resources after rollback"
+  else
+    fail "State still has ${RES_COUNT} resource(s) after rollback"
+    exit 1
+  fi
+else
+  pass "State file does not exist (clean)"
+fi
+
+# --------------------------------------------------------------------------
+# Step 3: Verify AWS has no leftover S3 bucket / SSM Document.
+# --------------------------------------------------------------------------
+header "Step 3: Verify no leftover AWS resources"
+
+LEAK=0
+
+LEFTOVER_BUCKETS=$(aws s3api list-buckets \
+  --query "Buckets[?contains(Name, 'cdkdbasicexample')].Name" \
+  --output text 2>/dev/null || true)
+if [[ -n "${LEFTOVER_BUCKETS}" ]]; then
+  fail "Leftover S3 bucket(s): ${LEFTOVER_BUCKETS}"
+  LEAK=1
+else
+  pass "No leftover S3 buckets"
+fi
+
+LEFTOVER_DOCS=$(aws ssm list-documents --region "${AWS_REGION}" \
+  --filters "Key=Owner,Values=Self" \
+  --query "DocumentIdentifiers[?starts_with(Name, '${STACK_NAME}-')].Name" \
+  --output text 2>/dev/null || true)
+if [[ -n "${LEFTOVER_DOCS}" ]]; then
+  fail "Leftover SSM Document(s): ${LEFTOVER_DOCS}"
+  LEAK=1
+else
+  pass "No leftover SSM Documents"
+fi
+
+if [[ ${LEAK} -ne 0 ]]; then
+  fail "Rollback left resources behind"
+  exit 1
+fi
+
+header "All assertions passed"
+pass "Failure-injection rollback verified end-to-end"

--- a/tests/integration/basic/lib/basic-stack.ts
+++ b/tests/integration/basic/lib/basic-stack.ts
@@ -1,6 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 
 /**
@@ -73,5 +74,18 @@ export class BasicStack extends cdk.Stack {
       value: bucket.bucketArn,
       description: 'ARN of the S3 bucket',
     });
+
+    // Inject a deliberately-failing resource for rollback testing.
+    // SQS messageRetentionPeriod must be in [60, 1209600]; 9999999 is invalid
+    // and AWS rejects CreateQueue. The good resources above succeed in parallel
+    // (event-driven dispatch), so this exercises the "sibling success then
+    // rollback" path against real AWS — matches the unit-test scenario in
+    // tests/unit/deployment/rollback.test.ts.
+    if (process.env.CDKD_TEST_FAIL === 'true') {
+      new sqs.CfnQueue(this, 'FailingQueue', {
+        queueName: `${this.stackName}-failing-queue`,
+        messageRetentionPeriod: 9999999,
+      });
+    }
   }
 }

--- a/tests/unit/deployment/dag-executor.test.ts
+++ b/tests/unit/deployment/dag-executor.test.ts
@@ -135,6 +135,28 @@ describe('DagExecutor', () => {
     expect([...exec.values()].find((n) => n.id === 'C')?.state).toBe('skipped');
   });
 
+  it('propagates skip transitively regardless of node insertion order', async () => {
+    // Insert leaf-first so that a single-pass skip-marking would leave
+    // descendants in 'pending' state. The fixed-point loop must catch them.
+    const exec = new DagExecutor<null>();
+    exec.add(node('D', ['C']));
+    exec.add(node('C', ['B']));
+    exec.add(node('B', ['A']));
+    exec.add(node('A'));
+
+    await expect(
+      exec.execute(4, async (n) => {
+        if (n.id === 'A') throw new Error('A boom');
+      })
+    ).rejects.toThrow('A boom');
+
+    const stateOf = (id: string) => [...exec.values()].find((n) => n.id === id)?.state;
+    expect(stateOf('A')).toBe('failed');
+    expect(stateOf('B')).toBe('skipped');
+    expect(stateOf('C')).toBe('skipped');
+    expect(stateOf('D')).toBe('skipped');
+  });
+
   it('drains in-flight independent nodes when one fails (does not rollback their state)', async () => {
     const exec = new DagExecutor<null>();
     exec.add(node('A'));

--- a/tests/unit/deployment/dag-executor.test.ts
+++ b/tests/unit/deployment/dag-executor.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  }),
+}));
+
+import { DagExecutor, type DagNode } from '../../../src/deployment/dag-executor.js';
+
+function node(id: string, deps: string[] = []): DagNode<null> {
+  return {
+    id,
+    dependencies: new Set(deps),
+    state: 'pending',
+    data: null,
+  };
+}
+
+describe('DagExecutor', () => {
+  it('executes a single node', async () => {
+    const exec = new DagExecutor<null>();
+    exec.add(node('A'));
+
+    const ran: string[] = [];
+    await exec.execute(4, async (n) => {
+      ran.push(n.id);
+    });
+
+    expect(ran).toEqual(['A']);
+  });
+
+  it('respects dependency order', async () => {
+    const exec = new DagExecutor<null>();
+    exec.add(node('A'));
+    exec.add(node('B', ['A']));
+
+    const ran: string[] = [];
+    await exec.execute(4, async (n) => {
+      ran.push(n.id);
+    });
+
+    expect(ran).toEqual(['A', 'B']);
+  });
+
+  it('starts a downstream node as soon as its only dependency completes (not waiting for siblings)', async () => {
+    // A is fast (10ms), B/C are slow (100ms). X depends only on A.
+    // Event-driven dispatch: X must start once A completes, NOT wait for B/C.
+    const exec = new DagExecutor<null>();
+    exec.add(node('A'));
+    exec.add(node('B'));
+    exec.add(node('C'));
+    exec.add(node('X', ['A']));
+
+    const events: { id: string; phase: 'start' | 'end'; t: number }[] = [];
+    const start = Date.now();
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+    await exec.execute(4, async (n) => {
+      events.push({ id: n.id, phase: 'start', t: Date.now() - start });
+      const ms = n.id === 'A' ? 10 : n.id === 'X' ? 10 : 100;
+      await sleep(ms);
+      events.push({ id: n.id, phase: 'end', t: Date.now() - start });
+    });
+
+    const xStart = events.find((e) => e.id === 'X' && e.phase === 'start')!.t;
+    const bEnd = events.find((e) => e.id === 'B' && e.phase === 'end')!.t;
+    const cEnd = events.find((e) => e.id === 'C' && e.phase === 'end')!.t;
+
+    // X must start before B/C finish (proves no level barrier)
+    expect(xStart).toBeLessThan(bEnd);
+    expect(xStart).toBeLessThan(cEnd);
+  });
+
+  it('runs independent nodes in parallel', async () => {
+    const exec = new DagExecutor<null>();
+    exec.add(node('A'));
+    exec.add(node('B'));
+    exec.add(node('C'));
+
+    const events: string[] = [];
+    await exec.execute(4, async (n) => {
+      events.push(`start:${n.id}`);
+      await new Promise((r) => setTimeout(r, 10));
+      events.push(`end:${n.id}`);
+    });
+
+    const firstEnd = events.findIndex((e) => e.startsWith('end:'));
+    const startsBeforeFirstEnd = events.slice(0, firstEnd).filter((e) => e.startsWith('start:'));
+    expect(startsBeforeFirstEnd).toHaveLength(3);
+  });
+
+  it('respects concurrency limit', async () => {
+    const exec = new DagExecutor<null>();
+    for (let i = 0; i < 5; i++) exec.add(node(`N${i}`));
+
+    let active = 0;
+    let peak = 0;
+    await exec.execute(2, async () => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 20));
+      active--;
+    });
+
+    expect(peak).toBe(2);
+  });
+
+  it('skips downstream when dependency fails and rejects with the original error', async () => {
+    const exec = new DagExecutor<null>();
+    exec.add(node('A'));
+    exec.add(node('B', ['A']));
+    exec.add(node('C', ['B']));
+
+    const ran: string[] = [];
+    const failure = new Error('A boom');
+    await expect(
+      exec.execute(4, async (n) => {
+        ran.push(n.id);
+        if (n.id === 'A') throw failure;
+      })
+    ).rejects.toBe(failure);
+
+    expect(ran).toEqual(['A']);
+    expect([...exec.values()].find((n) => n.id === 'B')?.state).toBe('skipped');
+    expect([...exec.values()].find((n) => n.id === 'C')?.state).toBe('skipped');
+  });
+
+  it('drains in-flight independent nodes when one fails (does not rollback their state)', async () => {
+    const exec = new DagExecutor<null>();
+    exec.add(node('A'));
+    exec.add(node('B'));
+    exec.add(node('C'));
+
+    const completed: string[] = [];
+    const failure = new Error('B boom');
+    await expect(
+      exec.execute(4, async (n) => {
+        await new Promise((r) => setTimeout(r, n.id === 'B' ? 5 : 30));
+        if (n.id === 'B') throw failure;
+        completed.push(n.id);
+      })
+    ).rejects.toBe(failure);
+
+    // A and C ran in parallel with B and completed normally
+    expect(completed.sort()).toEqual(['A', 'C']);
+    expect([...exec.values()].find((n) => n.id === 'B')?.state).toBe('failed');
+  });
+
+  it('treats deps outside the registered set as already-completed', async () => {
+    // X depends on Y which is NOT in the executor (simulates NO_CHANGE resources
+    // referenced via Ref/GetAtt but excluded from the provisioning DAG).
+    const exec = new DagExecutor<null>();
+    exec.add(node('X', ['Y']));
+
+    const ran: string[] = [];
+    await exec.execute(4, async (n) => {
+      ran.push(n.id);
+    });
+    expect(ran).toEqual(['X']);
+  });
+
+  it('stops dispatching when cancelled() returns true and resolves cleanly after drain', async () => {
+    const exec = new DagExecutor<null>();
+    exec.add(node('A'));
+    exec.add(node('B', ['A']));
+    exec.add(node('C', ['B']));
+
+    let cancelled = false;
+    const ran: string[] = [];
+
+    await exec.execute(
+      4,
+      async (n) => {
+        ran.push(n.id);
+        if (n.id === 'A') cancelled = true;
+      },
+      () => cancelled
+    );
+
+    // Only A should have started — cancellation halts further dispatch
+    expect(ran).toEqual(['A']);
+    expect([...exec.values()].find((n) => n.id === 'B')?.state).toBe('pending');
+    expect([...exec.values()].find((n) => n.id === 'C')?.state).toBe('pending');
+  });
+
+  it('handles empty graph', async () => {
+    const exec = new DagExecutor<null>();
+    await exec.execute(4, async () => {
+      throw new Error('should not run');
+    });
+  });
+
+  it('fails on deadlock (dep cycle)', async () => {
+    // A depends on B, B depends on A — neither becomes ready.
+    const exec = new DagExecutor<null>();
+    exec.add(node('A', ['B']));
+    exec.add(node('B', ['A']));
+
+    await expect(exec.execute(4, async () => {})).rejects.toThrow(/Deadlock/);
+  });
+});

--- a/tests/unit/deployment/dag-executor.test.ts
+++ b/tests/unit/deployment/dag-executor.test.ts
@@ -191,6 +191,31 @@ describe('DagExecutor', () => {
     expect(ran).toEqual(['X']);
   });
 
+  it('leaves no pending nodes when cancellation lands AFTER all nodes already completed', async () => {
+    // Simulates SIGINT firing right at the end of a deploy: every node already
+    // completed, then cancelled() flips. The executor must resolve cleanly with
+    // no nodes left pending — caller can use values() to detect that nothing
+    // was actually interrupted.
+    const exec = new DagExecutor<null>();
+    exec.add(node('A'));
+    exec.add(node('B', ['A']));
+
+    let cancelledFlag = false;
+    const ran: string[] = [];
+    await exec.execute(
+      4,
+      async (n) => {
+        ran.push(n.id);
+        if (n.id === 'B') cancelledFlag = true; // last node — flip after it runs
+      },
+      () => cancelledFlag
+    );
+
+    expect(ran).toEqual(['A', 'B']);
+    expect([...exec.values()].every((n) => n.state === 'completed')).toBe(true);
+    expect([...exec.values()].some((n) => n.state === 'pending')).toBe(false);
+  });
+
   it('stops dispatching when cancelled() returns true and resolves cleanly after drain', async () => {
     const exec = new DagExecutor<null>();
     exec.add(node('A'));

--- a/tests/unit/deployment/dag-executor.test.ts
+++ b/tests/unit/deployment/dag-executor.test.ts
@@ -157,6 +157,67 @@ describe('DagExecutor', () => {
     expect(stateOf('D')).toBe('skipped');
   });
 
+  it('does not reject until ALL in-flight nodes have observably finished their work', async () => {
+    // Drain-before-reject guarantee: a sibling that started before another
+    // node failed must finish its full fn() body — including any state
+    // mutations the deploy-engine relies on (completedOperations.push,
+    // saveStateAfterResource) — before execute() rejects. Otherwise the
+    // outer catch could observe inconsistent state and rollback would miss
+    // resources that already succeeded in AWS.
+    const exec = new DagExecutor<null>();
+    exec.add(node('A'));
+    exec.add(node('B'));
+    exec.add(node('C'));
+
+    // Logical clock (millisecond timestamps coarsen too much under setTimeout).
+    let tick = 0;
+    const observedAt: Record<string, number> = {};
+
+    const failure = new Error('B failed first');
+    await expect(
+      exec.execute(8, async (n) => {
+        // B fails FAST so its rejection is queued before A/C finish.
+        await new Promise((r) => setTimeout(r, n.id === 'B' ? 5 : 50));
+        if (n.id === 'B') throw failure;
+        observedAt[n.id] = ++tick;
+      })
+    ).rejects.toBe(failure);
+    const rejectedAt = ++tick;
+
+    // Both surviving siblings ran their body to completion BEFORE reject fired.
+    expect(observedAt['A']).toBeDefined();
+    expect(observedAt['C']).toBeDefined();
+    expect(observedAt['A']).toBeLessThan(rejectedAt);
+    expect(observedAt['C']).toBeLessThan(rejectedAt);
+  });
+
+  it('collects multiple concurrent failures but rejects with the FIRST one (rest are silent)', async () => {
+    // Matches the prior level-sync behavior of `Promise.allSettled` then
+    // `throw failures[0]!.reason`. The other errors don't disappear from
+    // node state — each failed node has state === 'failed' — they're just
+    // not surfaced through the rejection.
+    const exec = new DagExecutor<null>();
+    exec.add(node('A'));
+    exec.add(node('B'));
+    exec.add(node('C'));
+
+    const errA = new Error('A boom');
+    const errC = new Error('C boom');
+
+    await expect(
+      exec.execute(8, async (n) => {
+        // A fails first, C fails later (still concurrently with B's success).
+        await new Promise((r) => setTimeout(r, n.id === 'A' ? 5 : 30));
+        if (n.id === 'A') throw errA;
+        if (n.id === 'C') throw errC;
+      })
+    ).rejects.toBe(errA); // FIRST error wins
+
+    expect([...exec.values()].find((n) => n.id === 'A')?.state).toBe('failed');
+    expect([...exec.values()].find((n) => n.id === 'B')?.state).toBe('completed');
+    expect([...exec.values()].find((n) => n.id === 'C')?.state).toBe('failed');
+  });
+
   it('drains in-flight independent nodes when one fails (does not rollback their state)', async () => {
     const exec = new DagExecutor<null>();
     exec.add(node('A'));

--- a/tests/unit/deployment/dry-run.test.ts
+++ b/tests/unit/deployment/dry-run.test.ts
@@ -108,6 +108,7 @@ describe('DeployEngine - Dry Run Mode', () => {
     mockDagBuilder = {
       buildGraph: vi.fn().mockReturnValue({}),
       getExecutionLevels: vi.fn().mockReturnValue([['MyBucket']]),
+      getDirectDependencies: vi.fn().mockReturnValue([]),
     };
 
     mockDiffCalculator = {

--- a/tests/unit/deployment/resource-replacement.test.ts
+++ b/tests/unit/deployment/resource-replacement.test.ts
@@ -55,6 +55,7 @@ describe('DeployEngine - Resource Replacement', () => {
   let mockDagBuilder: {
     buildGraph: ReturnType<typeof vi.fn>;
     getExecutionLevels: ReturnType<typeof vi.fn>;
+    getDirectDependencies: ReturnType<typeof vi.fn>;
   };
 
   let mockDiffCalculator: {
@@ -127,6 +128,7 @@ describe('DeployEngine - Resource Replacement', () => {
     mockDagBuilder = {
       buildGraph: vi.fn().mockReturnValue({}),
       getExecutionLevels: vi.fn().mockReturnValue([['MyBucket']]),
+      getDirectDependencies: vi.fn().mockReturnValue([]),
     };
 
     mockDiffCalculator = {

--- a/tests/unit/deployment/rollback.test.ts
+++ b/tests/unit/deployment/rollback.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DeployEngine } from '../../../src/deployment/deploy-engine.js';
+import type { CloudFormationTemplate } from '../../../src/types/resource.js';
+import type { ResourceChange, StackState } from '../../../src/types/state.js';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  }),
+}));
+
+vi.mock('../../../src/deployment/intrinsic-function-resolver.js', () => ({
+  IntrinsicFunctionResolver: vi.fn().mockImplementation(() => ({
+    resolve: vi.fn().mockImplementation((props: unknown) => Promise.resolve(props)),
+    resolveParameters: vi.fn().mockReturnValue({}),
+    evaluateConditions: vi.fn().mockResolvedValue({}),
+  })),
+}));
+
+vi.mock('../../../src/provisioning/cloud-control-provider.js', () => ({
+  CloudControlProvider: {
+    isSupportedResourceType: vi.fn(() => true),
+  },
+}));
+
+describe('DeployEngine - Rollback (event-driven dispatch)', () => {
+  const stackName = 'rollback-test';
+
+  function createSdkProvider(failOn?: Set<string>) {
+    return {
+      create: vi.fn().mockImplementation((logicalId: string) => {
+        if (failOn?.has(logicalId)) {
+          return Promise.reject(new Error(`create failed: ${logicalId}`));
+        }
+        return Promise.resolve({
+          physicalId: `phys-${logicalId}`,
+          attributes: {},
+        });
+      }),
+      update: vi.fn().mockResolvedValue({ physicalId: 'phys-x', wasReplaced: false }),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  function makeChange(logicalId: string, type: string): ResourceChange {
+    return {
+      logicalId,
+      changeType: 'CREATE',
+      resourceType: type,
+      newProperties: {},
+      propertyChanges: [],
+    };
+  }
+
+  let mockProvider: ReturnType<typeof createSdkProvider>;
+  let deleteCalls: string[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deleteCalls = [];
+  });
+
+  function buildEngine(opts: {
+    template: CloudFormationTemplate;
+    changes: Map<string, ResourceChange>;
+    deps: Record<string, string[]>;
+    failOn?: Set<string>;
+    noRollback?: boolean;
+  }) {
+    mockProvider = createSdkProvider(opts.failOn);
+    // Track delete calls in order so we can verify rollback behavior.
+    // ResourceProvider.delete signature: (logicalId, physicalId, resourceType, properties?)
+    mockProvider.delete = vi.fn().mockImplementation(async (logicalId: string) => {
+      deleteCalls.push(logicalId);
+    });
+
+    const currentState: StackState = {
+      version: 1,
+      stackName,
+      resources: {},
+      outputs: {},
+      lastModified: Date.now(),
+    };
+
+    const mockStateBackend = {
+      getState: vi.fn().mockResolvedValue({ state: currentState, etag: 'etag-0' }),
+      saveState: vi.fn().mockResolvedValue('etag-1'),
+    };
+
+    const mockLockManager = {
+      acquireLockWithRetry: vi.fn().mockResolvedValue(true),
+      releaseLock: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockDagBuilder = {
+      buildGraph: vi.fn().mockReturnValue({}),
+      getExecutionLevels: vi.fn().mockReturnValue([Object.keys(opts.deps)]),
+      getDirectDependencies: vi.fn((_dag: unknown, id: string) => opts.deps[id] ?? []),
+    };
+
+    const mockDiffCalculator = {
+      calculateDiff: vi.fn().mockResolvedValue(opts.changes),
+      hasChanges: vi.fn().mockReturnValue(true),
+      filterByType: vi.fn().mockImplementation(
+        (changes: Map<string, ResourceChange>, type: string) =>
+          [...changes.values()].filter((c) => c.changeType === type)
+      ),
+    };
+
+    const mockProviderRegistry = {
+      getProvider: vi.fn().mockReturnValue(mockProvider),
+      getCloudControlProvider: vi.fn(),
+      validateResourceTypes: vi.fn(),
+    };
+
+    return new DeployEngine(
+      mockStateBackend as never,
+      mockLockManager as never,
+      mockDagBuilder as never,
+      mockDiffCalculator as never,
+      mockProviderRegistry as never,
+      { concurrency: 4, noRollback: opts.noRollback ?? false }
+    );
+  }
+
+  it('rolls back already-CREATEd siblings when one independent resource fails', async () => {
+    // A, B, C are independent. C fails. A and B succeed → both must be rolled back.
+    const template: CloudFormationTemplate = {
+      Resources: {
+        A: { Type: 'AWS::S3::Bucket', Properties: {} },
+        B: { Type: 'AWS::S3::Bucket', Properties: {} },
+        C: { Type: 'AWS::S3::Bucket', Properties: {} },
+      },
+    };
+    const changes = new Map<string, ResourceChange>([
+      ['A', makeChange('A', 'AWS::S3::Bucket')],
+      ['B', makeChange('B', 'AWS::S3::Bucket')],
+      ['C', makeChange('C', 'AWS::S3::Bucket')],
+    ]);
+
+    const engine = buildEngine({
+      template,
+      changes,
+      deps: { A: [], B: [], C: [] },
+      failOn: new Set(['C']),
+    });
+
+    await expect(engine.deploy(stackName, template)).rejects.toThrow(/Failed to create resource C/);
+
+    // A and B should have been rolled back (delete called).
+    // C never succeeded, so it is NOT rolled back.
+    expect(deleteCalls.sort()).toEqual(['A', 'B']);
+  });
+
+  it('rolls back upstream successes when a downstream dependency fails', async () => {
+    // A → B → C chain. B fails. A succeeded → A is rolled back.
+    // C is "skipped" (never started) due to B's failure → C is NOT rolled back.
+    const template: CloudFormationTemplate = {
+      Resources: {
+        A: { Type: 'AWS::S3::Bucket', Properties: {} },
+        B: { Type: 'AWS::S3::Bucket', Properties: {} },
+        C: { Type: 'AWS::S3::Bucket', Properties: {} },
+      },
+    };
+    const changes = new Map<string, ResourceChange>([
+      ['A', makeChange('A', 'AWS::S3::Bucket')],
+      ['B', makeChange('B', 'AWS::S3::Bucket')],
+      ['C', makeChange('C', 'AWS::S3::Bucket')],
+    ]);
+
+    const engine = buildEngine({
+      template,
+      changes,
+      deps: { A: [], B: ['A'], C: ['B'] },
+      failOn: new Set(['B']),
+    });
+
+    await expect(engine.deploy(stackName, template)).rejects.toThrow(/Failed to create resource B/);
+
+    // Only A was successfully created → only A is rolled back
+    expect(deleteCalls).toEqual(['A']);
+    // B failed mid-create — provider.create was called but no rollback delete on B
+    // (failed resource has no physicalId in completedOperations)
+    expect(mockProvider.create).toHaveBeenCalledWith('B', 'AWS::S3::Bucket', expect.any(Object));
+    // C was never started (skipped due to B failure)
+    expect(mockProvider.create).not.toHaveBeenCalledWith('C', expect.any(String), expect.any(Object));
+  });
+
+  it('rolls back deeper successes in dependency order (dependents deleted before deps)', async () => {
+    // A → B succeed. C (depends on B) fails. → Rollback must delete B before A,
+    // because B depends on A in CREATE direction (so A has more dependents).
+    // DependsOn captured in state.dependencies drives the rollback delete order.
+    const template: CloudFormationTemplate = {
+      Resources: {
+        A: { Type: 'AWS::S3::Bucket', Properties: {} },
+        B: { Type: 'AWS::S3::Bucket', Properties: {}, DependsOn: ['A'] },
+        C: { Type: 'AWS::S3::Bucket', Properties: {}, DependsOn: ['B'] },
+      },
+    };
+    const changes = new Map<string, ResourceChange>([
+      ['A', makeChange('A', 'AWS::S3::Bucket')],
+      ['B', makeChange('B', 'AWS::S3::Bucket')],
+      ['C', makeChange('C', 'AWS::S3::Bucket')],
+    ]);
+
+    const engine = buildEngine({
+      template,
+      changes,
+      deps: { A: [], B: ['A'], C: ['B'] },
+      failOn: new Set(['C']),
+    });
+
+    await expect(engine.deploy(stackName, template)).rejects.toThrow(/Failed to create resource C/);
+
+    // Both A and B were created → both rolled back, B before A (reverse dep order)
+    expect(deleteCalls).toEqual(['B', 'A']);
+  });
+
+  it('skips rollback when noRollback option is set', async () => {
+    const template: CloudFormationTemplate = {
+      Resources: {
+        A: { Type: 'AWS::S3::Bucket', Properties: {} },
+        B: { Type: 'AWS::S3::Bucket', Properties: {} },
+      },
+    };
+    const changes = new Map<string, ResourceChange>([
+      ['A', makeChange('A', 'AWS::S3::Bucket')],
+      ['B', makeChange('B', 'AWS::S3::Bucket')],
+    ]);
+
+    const engine = buildEngine({
+      template,
+      changes,
+      deps: { A: [], B: [] },
+      failOn: new Set(['B']),
+      noRollback: true,
+    });
+
+    await expect(engine.deploy(stackName, template)).rejects.toThrow(/Failed to create resource B/);
+    expect(deleteCalls).toEqual([]);
+  });
+});

--- a/tests/unit/deployment/rollback.test.ts
+++ b/tests/unit/deployment/rollback.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DeployEngine } from '../../../src/deployment/deploy-engine.js';
 import type { CloudFormationTemplate } from '../../../src/types/resource.js';
-import type { ResourceChange, StackState } from '../../../src/types/state.js';
+import type { ResourceChange, ResourceState, StackState } from '../../../src/types/state.js';
 
 vi.mock('../../../src/utils/logger.js', () => ({
   getLogger: () => ({
@@ -69,29 +69,39 @@ describe('DeployEngine - Rollback (event-driven dispatch)', () => {
     deleteCalls = [];
   });
 
+  let mockStateBackend: {
+    getState: ReturnType<typeof vi.fn>;
+    saveState: ReturnType<typeof vi.fn>;
+  };
+
   function buildEngine(opts: {
     template: CloudFormationTemplate;
     changes: Map<string, ResourceChange>;
     deps: Record<string, string[]>;
     failOn?: Set<string>;
+    deleteFailOn?: Set<string>;
     noRollback?: boolean;
+    currentResources?: Record<string, ResourceState>;
   }) {
     mockProvider = createSdkProvider(opts.failOn);
     // Track delete calls in order so we can verify rollback behavior.
     // ResourceProvider.delete signature: (logicalId, physicalId, resourceType, properties?)
     mockProvider.delete = vi.fn().mockImplementation(async (logicalId: string) => {
+      if (opts.deleteFailOn?.has(logicalId)) {
+        throw new Error(`delete failed: ${logicalId}`);
+      }
       deleteCalls.push(logicalId);
     });
 
     const currentState: StackState = {
       version: 1,
       stackName,
-      resources: {},
+      resources: opts.currentResources ?? {},
       outputs: {},
       lastModified: Date.now(),
     };
 
-    const mockStateBackend = {
+    mockStateBackend = {
       getState: vi.fn().mockResolvedValue({ state: currentState, etag: 'etag-0' }),
       saveState: vi.fn().mockResolvedValue('etag-1'),
     };
@@ -247,5 +257,45 @@ describe('DeployEngine - Rollback (event-driven dispatch)', () => {
 
     await expect(engine.deploy(stackName, template)).rejects.toThrow(/Failed to create resource B/);
     expect(deleteCalls).toEqual([]);
+  });
+
+  it('saves state reflecting partial deletion when a DELETE fails mid-phase', async () => {
+    // 3 DELETE changes dispatched concurrently. provider.delete throws for B.
+    // A and C complete normally. Pre-rollback state save (in deploy-engine's
+    // catch path) MUST reflect that A and C are gone but B remains — otherwise
+    // the next deploy will think A/C still exist and skip them, leaving them
+    // orphaned in AWS.
+    const template: CloudFormationTemplate = { Resources: {} }; // empty new template = all DELETE
+    const changes = new Map<string, ResourceChange>([
+      ['A', { ...makeChange('A', 'AWS::S3::Bucket'), changeType: 'DELETE' }],
+      ['B', { ...makeChange('B', 'AWS::S3::Bucket'), changeType: 'DELETE' }],
+      ['C', { ...makeChange('C', 'AWS::S3::Bucket'), changeType: 'DELETE' }],
+    ]);
+    const currentResources: Record<string, ResourceState> = {
+      A: { physicalId: 'phys-A', resourceType: 'AWS::S3::Bucket', properties: {} },
+      B: { physicalId: 'phys-B', resourceType: 'AWS::S3::Bucket', properties: {} },
+      C: { physicalId: 'phys-C', resourceType: 'AWS::S3::Bucket', properties: {} },
+    };
+
+    const engine = buildEngine({
+      template,
+      changes,
+      deps: { A: [], B: [], C: [] },
+      deleteFailOn: new Set(['B']),
+      currentResources,
+      noRollback: true, // suppress no-op DELETE rollback path; focus on state save
+    });
+
+    await expect(engine.deploy(stackName, template)).rejects.toThrow(/Failed to delete resource B/);
+
+    // Inspect the most recent saveState call (could be pre-rollback or post-).
+    const calls = mockStateBackend.saveState.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const finalSavedState = calls[calls.length - 1]![1] as StackState;
+
+    // A and C deleted from state; B remains because its delete failed.
+    expect(finalSavedState.resources['A']).toBeUndefined();
+    expect(finalSavedState.resources['C']).toBeUndefined();
+    expect(finalSavedState.resources['B']).toBeDefined();
   });
 });

--- a/tests/unit/deployment/safety-net.test.ts
+++ b/tests/unit/deployment/safety-net.test.ts
@@ -78,6 +78,7 @@ describe('DeployEngine - Safety Net (CC API Fallback)', () => {
   let mockDagBuilder: {
     buildGraph: ReturnType<typeof vi.fn>;
     getExecutionLevels: ReturnType<typeof vi.fn>;
+    getDirectDependencies: ReturnType<typeof vi.fn>;
   };
 
   let mockDiffCalculator: {
@@ -145,6 +146,7 @@ describe('DeployEngine - Safety Net (CC API Fallback)', () => {
     mockDagBuilder = {
       buildGraph: vi.fn().mockReturnValue({}),
       getExecutionLevels: vi.fn().mockReturnValue([['TestResource']]),
+      getDirectDependencies: vi.fn().mockReturnValue([]),
     };
 
     mockDiffCalculator = {


### PR DESCRIPTION
## Summary

Replace level-synchronized resource execution in `DeployEngine` with a **fully event-driven DAG dispatcher**. A resource starts as soon as ALL of its own dependencies complete — it no longer has to wait for unrelated siblings in the same DAG level.

## Why

Previously `executeDeployment` iterated `executionLevels` and called `Promise.allSettled` per level. This forced a synchronization barrier between levels: if `X` (level 2) depended only on `A` (level 1), `X` still had to wait for `A`'s slowest siblings (`B`, `C`, `D`) to finish before starting.

CDK CLI itself uses event-driven dispatch (cdkd's existing `WorkGraph` already does this for stacks/assets), so this aligns intra-stack execution with that model.

## Changes

- **New `src/deployment/dag-executor.ts`**: generic event-driven DAG dispatcher with bounded concurrency, fail-fast skip-of-downstream (propagated transitively to a fixed point), deadlock detection, and a cancellation hook used for SIGINT.
- **`src/deployment/deploy-engine.ts` `executeDeployment`**: level loop replaced with `DagExecutor.execute()` for both CREATE/UPDATE and DELETE phases (DELETE uses the same reverse-dependency map as before).
- `buildDeletionLevels` collapsed to `buildDeletionDependencies` (returns the deps map directly; topological sort is now done by the executor).
- `pLimit` removed — concurrency is enforced by the dispatcher.
- Log output: per-level header (`Level X/Y (N resources)`) replaced with a single up-front summary `Deploying N resource(s) (DAG: K levels, max parallel: C)`. The `[N/total]` per-resource progress line is unchanged.
- `pnpm test` now runs once (`vitest run`); `pnpm test:watch` is the watch mode.

## Tests

- **20 new unit tests**: `dag-executor.test.ts` (15) covers parallelism / skip / transitive skip / cancel / cancel-after-completion / drain-before-reject / multi-failure error selection / deadlock / external deps; `rollback.test.ts` (5) covers sibling-failure rollback, downstream-skip rollback, dependency-aware rollback delete order, `--no-rollback`, and partial-deletion state save on concurrent DELETE failure.
- All existing **572 unit tests** still pass (583 → 592 total).
- **Real-AWS integration tests** all pass with no leftover resources:

  | Test | Resources | Result |
  |---|---|---|
  | `basic` | 2 (S3 + SSM) | ✓ deploy + destroy |
  | `multi-resource` | 17 (custom resources + IAM policies, 4 levels) | ✓ deploy + destroy |
  | `lambda` | 7 (Lambda + Layer + Alias) | ✓ deploy + destroy |
  | `dynamodb-streams` | 9 (DynamoDB streams + Lambda + AutoScaling) | ✓ deploy + destroy |
  | `kms-encryption` | 3 | ✓ deploy + destroy |
  | `multi-stack-deps` | 13 across 3 stacks | ✓ deploy + destroy |
  | `vpc-lambda` | 16 (VPC + NAT + Lambda) | ✓ deploy + destroy |
- **Real-AWS rollback verification** (new, automated): `tests/integration/basic` now supports `CDKD_TEST_FAIL=true`, which injects an `AWS::SQS::Queue` with an out-of-range `MessageRetentionPeriod` that AWS rejects on `CreateQueue`. The good siblings (S3 + SSM Document) finish in parallel, then rollback deletes them. Verified end-to-end via `tests/e2e/run-failure-injection.sh`:
  - ✓ Deploy fails as expected
  - ✓ Rollback was triggered
  - ✓ State file does not exist (clean)
  - ✓ No leftover S3 buckets / SSM Documents

## Benchmarks

### Simulated benchmark (sleep-based; not committed to repo)

Models AWS API latencies (IAM=150ms, Lambda/etc=400ms, ALB/CloudFront=800ms, waitForDeployed/RDS=2000ms) at concurrency 10, n=5 interleaved runs per scenario. The first 5 are realistic CDK shapes; the last is a stress-test that exposes the algorithmic ceiling.

| Scenario | level-sync | event-driven | speedup | saved |
|---|---|---|---|---|
| Lambda + DynamoDB stack (9 resources) | 1.60s | 1.55s | 1.03x (3% faster) | 0.05s |
| API Gateway + Lambda stack (9 resources) | 1.86s | 1.50s | **1.23x (19% faster)** | 0.35s |
| CloudFront + S3 + Lambda Function URL (8 resources) | 3.01s | 2.90s | 1.03x (3% faster) | 0.10s |
| VPC + EC2 + ALB + ECS (17 resources) | 3.61s | 3.50s | 1.03x (3% faster) | 0.10s |
| RDS + Lambda app (10 resources) | 2.91s | 2.70s | 1.07x (7% faster) | 0.20s |
| Stress test: chain + slow parallels (10 resources) | 1.61s | 1.00s | **1.60x (37% faster)** | 0.60s |

**Realistic CDK stacks: up to 1.23x faster (API Gateway + Lambda fan-out). Algorithmic ceiling on stress-test shapes: 1.60x.**

The speedup depends on whether the critical path is the DAG depth or a straggler sibling at some level. Stacks with a long chain alongside slow independent parallels gain the most; stacks where one resource dominates the critical path see modest gains. AWS-side variance (IAM eventual consistency, throttling, cold starts) typically dwarfs these algorithmic differences in any single deploy, so the speedup shows up most reliably in repeated deploys / CI.

### Real AWS (cdk-sample, us-west-2, n=3 per binary, interleaved)

| Run | level-sync | event-driven |
|---|---|---|
| 1 | 22.9s | 71.9s (outlier) |
| 2 | 22.7s | 22.7s |
| 3 | 22.7s | 21.5s |
| **mean (excl. outlier)** | **22.8s** | **22.1s** (-3%) |

The first event-driven run hit a ~50s anomaly that's almost certainly AWS-side variance — Lambda creation occasionally races IAM Policy propagation and falls back into the existing exponential-backoff retry path (1s → 2s → 4s → 8s → 10s, ~25-50s of added latency). Both runs 2 and 3 land within ~1s of level-sync and slightly faster. This stack's critical path is `Table → Policy → Function → ESM`, so the algorithmic ceiling is small (matches the simulated prediction of ~3%).

For a stack-shape that benefits from event-driven dispatch (long chain + slow parallel siblings), the simulation predicts up to ~1.6x speedup. A real-AWS measurement on such a stack would be the next data point worth gathering.

## Test plan

- [x] `pnpm vitest run` — 592/592 pass
- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run build` — clean
- [x] 7 real-AWS integ tests (basic / multi-resource / lambda / dynamodb-streams / kms-encryption / multi-stack-deps / vpc-lambda)
- [x] Real-AWS rollback verification via `tests/e2e/run-failure-injection.sh`
- [x] Simulated benchmark across 6 stack shapes
- [x] Real-AWS benchmark (cdk-sample, us-west-2, n=3 per binary)
