### PR TITLE
chore(skill): /run-integ should pass --all for multi-stack apps

### DIFF
--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -27,8 +27,13 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
    - Navigate to `tests/integration/<test-name>/`
    - Ensure dependencies: `npm install` if node_modules doesn't exist
    - Run synth: `node ../../../dist/cli.js synth --region us-east-1`
-   - Run deploy: `node ../../../dist/cli.js deploy --region us-east-1 --state-bucket <bucket> --verbose`
-   - Run destroy: `node ../../../dist/cli.js destroy --region us-east-1 --state-bucket <bucket> --force`
+   - **Detect multi-stack apps**: read the synth output. If it lists more
+     than one stack (e.g. `multi-stack-deps`, `composite-stack`,
+     `cross-stack-references`), pass `--all` to deploy and destroy.
+     Without `--all`, deploy/destroy will fail with `Multiple stacks
+     found: ... Specify stack name(s) or use --all`.
+   - Run deploy: `node ../../../dist/cli.js deploy [--all] --region us-east-1 --state-bucket <bucket> --verbose`
+   - Run destroy: `node ../../../dist/cli.js destroy [--all] --region us-east-1 --state-bucket <bucket> --force`
 
 5. **Verify cleanup**:
    - Check `aws s3 ls s3://<bucket>/stacks/ --region us-east-1` to confirm no leftover state


### PR DESCRIPTION
## Summary

When running `/run-integ` against a CDK app that contains multiple stacks (e.g., `tests/integration/multi-stack-deps` with `CdkdNetworkStack` / `CdkdDataStack` / `CdkdAppStack`), `cdkd deploy` and `cdkd destroy` fail with:

```
Error: Multiple stacks found: CdkdNetworkStack, CdkdDataStack, CdkdAppStack. Specify stack name(s) or use --all
```

The skill instructed Claude to invoke `cdkd deploy` / `cdkd destroy` without `--all`, so multi-stack tests would always blow up at the first command.

## Why

Discovered while running an integration sweep for #30 — the `multi-stack-deps` test failed not because of any code issue, but because the skill's prescribed command line didn't account for the multi-stack case.

## Changes

- `/run-integ` skill now tells Claude to:
  1. Read the synth output (already part of step 4)
  2. Detect when more than one stack is listed
  3. Pass `--all` to deploy and destroy in that case

## Test plan

- [x] Re-ran `multi-stack-deps` integ test with `--all`: deploy succeeded across all 3 stacks; destroy succeeded across all 3 stacks; no leftover state.
