### PR TITLE
chore(eslint): set root: true to stop ancestor lookup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2022,


### PR DESCRIPTION
## Summary
- Add `"root": true` to `.eslintrc.json` so ESLint stops walking parents.
- No-op for normal contributor flows (no ancestor configs exist).
- Prevents `@typescript-eslint plugin cannot be resolved uniquely` errors when the repo is checked out into a nested location (e.g. `.claude/worktrees/agent-*`).

## Test plan
- [x] `pnpm run lint` / `typecheck` / `build` / `test` all pass