### PR TITLE
fix(cloudfront): wait for Enabled=false to propagate before delete

### DIFF
--- a/src/provisioning/providers/cloudfront-distribution-provider.ts
+++ b/src/provisioning/providers/cloudfront-distribution-provider.ts
@@ -99,7 +99,7 @@ export class CloudFrontDistributionProvider implements ResourceProvider {
       // Skip with --no-wait or CDKD_NO_WAIT=true
       if (process.env['CDKD_NO_WAIT'] !== 'true') {
         this.logger.debug(`Waiting for Distribution ${distributionId} to reach Deployed status...`);
-        await this.waitForDistributionDeployed(distributionId);
+        await this.waitForDistributionStable(distributionId);
       }
 
       return {
@@ -239,8 +239,14 @@ export class CloudFrontDistributionProvider implements ResourceProvider {
         );
         etag = updateResponse.ETag!;
 
-        // Wait for the distribution to be fully deployed (Disabled state)
-        await this.waitForDistributionDeployed(physicalId);
+        // Wait until the disable is fully propagated. We must check BOTH
+        // Status==='Deployed' AND DistributionConfig.Enabled===false, because
+        // CloudFront's read-after-write is eventually consistent: a GetDistribution
+        // call made shortly after UpdateDistribution can still return the previous
+        // (Enabled=true, Status=Deployed) snapshot, which would otherwise cause us
+        // to exit the wait loop on the very first poll and fire DeleteDistribution
+        // against an enabled distribution (yielding DistributionNotDisabled).
+        await this.waitForDistributionStable(physicalId, false);
 
         // Re-fetch ETag after waiting (state may have changed)
         const refreshResponse = await this.cloudFrontClient.send(
@@ -297,10 +303,19 @@ export class CloudFrontDistributionProvider implements ResourceProvider {
   }
 
   /**
-   * Wait for a distribution to reach "Deployed" status.
+   * Wait for a distribution to reach a stable state.
+   *
+   * "Stable" means Status === 'Deployed'. When `expectedEnabled` is provided,
+   * we additionally require DistributionConfig.Enabled === expectedEnabled —
+   * this guards against CloudFront's eventually-consistent reads that can
+   * briefly return the pre-update snapshot after UpdateDistribution returns.
+   *
    * Uses exponential backoff polling.
    */
-  private async waitForDistributionDeployed(distributionId: string): Promise<void> {
+  private async waitForDistributionStable(
+    distributionId: string,
+    expectedEnabled?: boolean
+  ): Promise<void> {
     const maxAttempts = 60;
     let delay = 5000; // start at 5s
     const maxDelay = 30000;
@@ -324,14 +339,21 @@ export class CloudFrontDistributionProvider implements ResourceProvider {
           new GetDistributionCommand({ Id: distributionId })
         );
         const status = response.Distribution?.Status;
+        const enabled = response.Distribution?.DistributionConfig?.Enabled;
 
-        if (status === 'Deployed') {
-          this.logger.debug(`Distribution ${distributionId} is now Deployed`);
+        const enabledMatches = expectedEnabled === undefined || enabled === expectedEnabled;
+
+        if (status === 'Deployed' && enabledMatches) {
+          this.logger.debug(
+            `Distribution ${distributionId} is stable (Status=Deployed, Enabled=${enabled})`
+          );
           return;
         }
 
         this.logger.debug(
-          `Distribution ${distributionId} status: ${status} (attempt ${attempt}/${maxAttempts})`
+          `Distribution ${distributionId} status: ${status}, enabled: ${enabled}` +
+            (expectedEnabled === undefined ? '' : ` (waiting for Enabled=${expectedEnabled})`) +
+            ` (attempt ${attempt}/${maxAttempts})`
         );
 
         // Interruptible sleep: check SIGINT every second
@@ -343,7 +365,7 @@ export class CloudFrontDistributionProvider implements ResourceProvider {
       }
 
       this.logger.debug(
-        `Distribution ${distributionId} did not reach Deployed status within timeout, proceeding with deletion attempt`
+        `Distribution ${distributionId} did not reach stable state within timeout, proceeding with next step`
       );
     } finally {
       process.removeListener('SIGINT', sigintHandler);

--- a/tests/unit/provisioning/cloudfront-distribution-provider.test.ts
+++ b/tests/unit/provisioning/cloudfront-distribution-provider.test.ts
@@ -48,9 +48,13 @@ describe('CloudFrontDistributionProvider', () => {
           DomainName: 'd111111abcdef8.cloudfront.net',
         },
       });
-      // GetDistributionCommand (waitForDistributionDeployed)
+      // GetDistributionCommand (waitForDistributionStable)
       mockSend.mockResolvedValueOnce({
-        Distribution: { Id: 'EDFDVBD6EXAMPLE', Status: 'Deployed' },
+        Distribution: {
+          Id: 'EDFDVBD6EXAMPLE',
+          Status: 'Deployed',
+          DistributionConfig: { Enabled: true },
+        },
       });
 
       const result = await provider.create(
@@ -89,9 +93,13 @@ describe('CloudFrontDistributionProvider', () => {
           DomainName: 'd111111abcdef8.cloudfront.net',
         },
       });
-      // GetDistributionCommand (waitForDistributionDeployed)
+      // GetDistributionCommand (waitForDistributionStable)
       mockSend.mockResolvedValueOnce({
-        Distribution: { Id: 'EDFDVBD6EXAMPLE', Status: 'Deployed' },
+        Distribution: {
+          Id: 'EDFDVBD6EXAMPLE',
+          Status: 'Deployed',
+          DistributionConfig: { Enabled: true },
+        },
       });
 
       await provider.create('MyDistribution', 'AWS::CloudFront::Distribution', {
@@ -222,11 +230,12 @@ describe('CloudFrontDistributionProvider', () => {
       mockSend.mockResolvedValueOnce({
         ETag: 'E3NEWETAG',
       });
-      // GetDistributionCommand (wait for deployed - returns Deployed immediately)
+      // GetDistributionCommand (wait for stable: Status=Deployed AND Enabled=false)
       mockSend.mockResolvedValueOnce({
         Distribution: {
           Id: 'EDFDVBD6EXAMPLE',
           Status: 'Deployed',
+          DistributionConfig: { Enabled: false },
         },
       });
       // GetDistributionConfigCommand (re-fetch ETag after waiting)
@@ -265,6 +274,83 @@ describe('CloudFrontDistributionProvider', () => {
       expect(deleteCall.constructor.name).toBe('DeleteDistributionCommand');
       expect(deleteCall.input.Id).toBe('EDFDVBD6EXAMPLE');
       expect(deleteCall.input.IfMatch).toBe('E4FINALETAG');
+    });
+
+    it('should keep waiting when GetDistribution still reports Enabled=true after disable (eventual consistency)', async () => {
+      // Speed up the test: cap the wait loop with a fake timer for the sleeps.
+      // We don't actually need timers here because each polling round only sleeps
+      // when the stable condition is not met; we satisfy it on the second poll.
+      vi.useFakeTimers();
+
+      try {
+        // GetDistributionConfigCommand (initial)
+        mockSend.mockResolvedValueOnce({
+          ETag: 'E2QWRUHAPOMQZL',
+          DistributionConfig: {
+            CallerReference: 'original-caller-ref',
+            Enabled: true,
+          },
+        });
+        // UpdateDistributionCommand (disable)
+        mockSend.mockResolvedValueOnce({
+          ETag: 'E3NEWETAG',
+        });
+        // GetDistributionCommand (1st poll: stale read - still Enabled=true)
+        mockSend.mockResolvedValueOnce({
+          Distribution: {
+            Id: 'EDFDVBD6EXAMPLE',
+            Status: 'Deployed',
+            DistributionConfig: { Enabled: true },
+          },
+        });
+        // GetDistributionCommand (2nd poll: still propagating, InProgress)
+        mockSend.mockResolvedValueOnce({
+          Distribution: {
+            Id: 'EDFDVBD6EXAMPLE',
+            Status: 'InProgress',
+            DistributionConfig: { Enabled: false },
+          },
+        });
+        // GetDistributionCommand (3rd poll: stable Disabled+Deployed)
+        mockSend.mockResolvedValueOnce({
+          Distribution: {
+            Id: 'EDFDVBD6EXAMPLE',
+            Status: 'Deployed',
+            DistributionConfig: { Enabled: false },
+          },
+        });
+        // GetDistributionConfigCommand (re-fetch ETag after waiting)
+        mockSend.mockResolvedValueOnce({
+          ETag: 'E4FINALETAG',
+          DistributionConfig: {
+            CallerReference: 'original-caller-ref',
+            Enabled: false,
+          },
+        });
+        // DeleteDistributionCommand
+        mockSend.mockResolvedValueOnce({});
+
+        const deletePromise = provider.delete(
+          'MyDistribution',
+          'EDFDVBD6EXAMPLE',
+          'AWS::CloudFront::Distribution'
+        );
+
+        // Advance fake timers far enough to flush all the sleep loops
+        // (5s + 7.5s + 11.25s = ~24s of polling backoff).
+        await vi.advanceTimersByTimeAsync(60_000);
+        await deletePromise;
+
+        // The wait loop must NOT exit early on the first stale Deployed read.
+        // We expect: GetConfig + Update + 3xGet + GetConfig + Delete = 7 calls.
+        expect(mockSend).toHaveBeenCalledTimes(7);
+
+        const deleteCall = mockSend.mock.calls[6][0];
+        expect(deleteCall.constructor.name).toBe('DeleteDistributionCommand');
+        expect(deleteCall.input.IfMatch).toBe('E4FINALETAG');
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should handle NoSuchDistribution gracefully', async () => {


### PR DESCRIPTION
## Summary
- Bug: `waitForDistributionDeployed` checked only `Status === 'Deployed'`, so an eventually-consistent stale `Enabled=true` reply caused the loop to exit before the disable propagated. Subsequent `DeleteDistribution` then either failed sporadically or returned in tens of seconds (real disable+delete is several minutes).
- Fix: rename to `waitForDistributionStable` and accept an optional `expectedEnabled`; `delete()` passes `false`, `create()` keeps the old behavior.
- Add regression test that simulates the stale snapshot path.

## Test plan
- [x] Unit: `should keep waiting when GetDistribution still reports Enabled=true after disable`
- [ ] Integration: `bench-cdk-sample` (after merging W1/W2/W3 too)