### PR TITLE
feat(provider): handle SecurityGroupEgress on AWS::EC2::SecurityGroup

### DIFF
--- a/src/provisioning/providers/ec2-provider.ts
+++ b/src/provisioning/providers/ec2-provider.ts
@@ -118,6 +118,7 @@ export class EC2Provider implements ResourceProvider {
         'CidrIp',
         'Description',
         'SourceSecurityGroupId',
+        'SourceSecurityGroupOwnerId',
       ]),
     ],
     [
@@ -1256,6 +1257,14 @@ export class EC2Provider implements ResourceProvider {
       // Update tags
       await this.applyTags(physicalId, properties, logicalId);
 
+      // Diff and apply ingress rule changes (symmetric with egress below).
+      await this.applySecurityGroupRuleDiff(
+        physicalId,
+        (previousProperties['SecurityGroupIngress'] as Array<Record<string, unknown>>) ?? [],
+        (properties['SecurityGroupIngress'] as Array<Record<string, unknown>>) ?? [],
+        'ingress'
+      );
+
       // Diff and apply egress rule changes
       await this.applySecurityGroupRuleDiff(
         physicalId,
@@ -1737,7 +1746,7 @@ export class EC2Provider implements ResourceProvider {
     ToPort?: number;
     IpRanges?: Array<{ CidrIp: string; Description?: string }>;
     Ipv6Ranges?: Array<{ CidrIpv6: string; Description?: string }>;
-    UserIdGroupPairs?: Array<{ GroupId: string; Description?: string }>;
+    UserIdGroupPairs?: Array<{ GroupId: string; UserId?: string; Description?: string }>;
     PrefixListIds?: Array<{ PrefixListId: string; Description?: string }>;
   } {
     const ipProtocol = (properties['IpProtocol'] as string) ?? '-1';
@@ -1750,7 +1759,7 @@ export class EC2Provider implements ResourceProvider {
       ToPort?: number;
       IpRanges?: Array<{ CidrIp: string; Description?: string }>;
       Ipv6Ranges?: Array<{ CidrIpv6: string; Description?: string }>;
-      UserIdGroupPairs?: Array<{ GroupId: string; Description?: string }>;
+      UserIdGroupPairs?: Array<{ GroupId: string; UserId?: string; Description?: string }>;
       PrefixListIds?: Array<{ PrefixListId: string; Description?: string }>;
     } = { IpProtocol: ipProtocol };
 
@@ -1778,9 +1787,18 @@ export class EC2Provider implements ResourceProvider {
         ? (properties['DestinationSecurityGroupId'] as string | undefined)
         : (properties['SourceSecurityGroupId'] as string | undefined);
     if (peerGroupId) {
-      const groupPair: { GroupId: string; Description?: string } = {
+      const groupPair: { GroupId: string; UserId?: string; Description?: string } = {
         GroupId: peerGroupId,
       };
+      // Cross-account peer reference: CFn supports SourceSecurityGroupOwnerId on
+      // ingress rules to point at a security group in another AWS account. Map
+      // it to the UserIdGroupPairs[].UserId field on the EC2 API. CFn does not
+      // define a Destination*OwnerId counterpart for egress, so this is
+      // ingress-only.
+      if (direction === 'ingress') {
+        const peerOwnerId = properties['SourceSecurityGroupOwnerId'] as string | undefined;
+        if (peerOwnerId) groupPair.UserId = peerOwnerId;
+      }
       if (description) groupPair.Description = description;
       permission.UserIdGroupPairs = [groupPair];
     }
@@ -1824,6 +1842,12 @@ export class EC2Provider implements ResourceProvider {
         direction === 'egress'
           ? (rule['DestinationPrefixListId'] as string | undefined)
           : (rule['SourcePrefixListId'] as string | undefined);
+      // Include the cross-account peer owner id (ingress only) so a same-id
+      // group in a different account is not collapsed into the same rule.
+      const peerOwner =
+        direction === 'ingress'
+          ? (rule['SourceSecurityGroupOwnerId'] as string | undefined)
+          : undefined;
       return JSON.stringify({
         p: rule['IpProtocol'] ?? '-1',
         f: rule['FromPort'] ?? null,
@@ -1831,6 +1855,7 @@ export class EC2Provider implements ResourceProvider {
         c4: rule['CidrIp'] ?? null,
         c6: rule['CidrIpv6'] ?? null,
         peer: peerKey ?? null,
+        peerOwner: peerOwner ?? null,
         pl: prefixKey ?? null,
         d: rule['Description'] ?? null,
       });

--- a/src/provisioning/providers/ec2-provider.ts
+++ b/src/provisioning/providers/ec2-provider.ts
@@ -20,6 +20,8 @@ import {
   DeleteSecurityGroupCommand,
   AuthorizeSecurityGroupIngressCommand,
   RevokeSecurityGroupIngressCommand,
+  AuthorizeSecurityGroupEgressCommand,
+  RevokeSecurityGroupEgressCommand,
   CreateTagsCommand,
   DescribeSubnetsCommand,
   DescribeSecurityGroupsCommand,
@@ -97,7 +99,14 @@ export class EC2Provider implements ResourceProvider {
     ['AWS::EC2::SubnetRouteTableAssociation', new Set(['SubnetId', 'RouteTableId'])],
     [
       'AWS::EC2::SecurityGroup',
-      new Set(['GroupDescription', 'GroupName', 'VpcId', 'SecurityGroupIngress', 'Tags']),
+      new Set([
+        'GroupDescription',
+        'GroupName',
+        'VpcId',
+        'SecurityGroupIngress',
+        'SecurityGroupEgress',
+        'Tags',
+      ]),
     ],
     [
       'AWS::EC2::SecurityGroupIngress',
@@ -221,7 +230,13 @@ export class EC2Provider implements ResourceProvider {
       case 'AWS::EC2::SubnetRouteTableAssociation':
         return this.updateSubnetRouteTableAssociation(logicalId, physicalId);
       case 'AWS::EC2::SecurityGroup':
-        return this.updateSecurityGroup(logicalId, physicalId, resourceType, properties);
+        return this.updateSecurityGroup(
+          logicalId,
+          physicalId,
+          resourceType,
+          properties,
+          previousProperties
+        );
       case 'AWS::EC2::SecurityGroupIngress':
         return this.updateSecurityGroupIngress(
           logicalId,
@@ -1170,6 +1185,43 @@ export class EC2Provider implements ResourceProvider {
         }
       }
 
+      // Egress rules: when explicit SecurityGroupEgress is provided, CFn replaces
+      // the AWS-default "allow all egress" rule (0.0.0.0/0, -1) with the supplied rules.
+      // We replicate this by revoking the default rule first, then authorizing each.
+      const egressRules = properties['SecurityGroupEgress'] as
+        | Array<Record<string, unknown>>
+        | undefined;
+      if (egressRules && Array.isArray(egressRules)) {
+        // Revoke the AWS-default "allow all egress" rule so it does not coexist
+        // with user-specified rules. Tolerate "not found" if the default is absent.
+        try {
+          await this.ec2Client.send(
+            new RevokeSecurityGroupEgressCommand({
+              GroupId: groupId,
+              IpPermissions: [
+                {
+                  IpProtocol: '-1',
+                  IpRanges: [{ CidrIp: '0.0.0.0/0' }],
+                },
+              ],
+            })
+          );
+        } catch (error) {
+          if (!this.isNotFoundError(error)) {
+            throw error;
+          }
+        }
+
+        for (const rule of egressRules) {
+          await this.ec2Client.send(
+            new AuthorizeSecurityGroupEgressCommand({
+              GroupId: groupId,
+              IpPermissions: [this.buildIpPermission(rule, 'egress')],
+            })
+          );
+        }
+      }
+
       this.logger.debug(`Successfully created SecurityGroup ${logicalId}: ${groupId}`);
 
       return {
@@ -1195,13 +1247,22 @@ export class EC2Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties: Record<string, unknown>
+    properties: Record<string, unknown>,
+    previousProperties: Record<string, unknown>
   ): Promise<ResourceUpdateResult> {
     this.logger.debug(`Updating SecurityGroup ${logicalId}: ${physicalId}`);
 
     try {
       // Update tags
       await this.applyTags(physicalId, properties, logicalId);
+
+      // Diff and apply egress rule changes
+      await this.applySecurityGroupRuleDiff(
+        physicalId,
+        (previousProperties['SecurityGroupEgress'] as Array<Record<string, unknown>>) ?? [],
+        (properties['SecurityGroupEgress'] as Array<Record<string, unknown>>) ?? [],
+        'egress'
+      );
 
       this.logger.debug(`Successfully updated SecurityGroup ${logicalId}`);
 
@@ -1661,14 +1722,23 @@ export class EC2Provider implements ResourceProvider {
   // ─── Helpers ──────────────────────────────────────────────────────
 
   /**
-   * Build an IpPermission object from CloudFormation-style properties
+   * Build an IpPermission object from CloudFormation-style properties.
+   *
+   * The EC2 IpPermission shape is identical for ingress and egress; only the
+   * CFn property names that point to the "other" security group differ
+   * (SourceSecurityGroupId vs DestinationSecurityGroupId).
    */
-  private buildIpPermission(properties: Record<string, unknown>): {
+  private buildIpPermission(
+    properties: Record<string, unknown>,
+    direction: 'ingress' | 'egress' = 'ingress'
+  ): {
     IpProtocol: string;
     FromPort?: number;
     ToPort?: number;
     IpRanges?: Array<{ CidrIp: string; Description?: string }>;
+    Ipv6Ranges?: Array<{ CidrIpv6: string; Description?: string }>;
     UserIdGroupPairs?: Array<{ GroupId: string; Description?: string }>;
+    PrefixListIds?: Array<{ PrefixListId: string; Description?: string }>;
   } {
     const ipProtocol = (properties['IpProtocol'] as string) ?? '-1';
     const fromPort = properties['FromPort'] as number | undefined;
@@ -1679,30 +1749,153 @@ export class EC2Provider implements ResourceProvider {
       FromPort?: number;
       ToPort?: number;
       IpRanges?: Array<{ CidrIp: string; Description?: string }>;
+      Ipv6Ranges?: Array<{ CidrIpv6: string; Description?: string }>;
       UserIdGroupPairs?: Array<{ GroupId: string; Description?: string }>;
+      PrefixListIds?: Array<{ PrefixListId: string; Description?: string }>;
     } = { IpProtocol: ipProtocol };
 
     if (fromPort !== undefined) permission.FromPort = fromPort;
     if (toPort !== undefined) permission.ToPort = toPort;
 
     const cidrIp = properties['CidrIp'] as string | undefined;
+    const cidrIpv6 = properties['CidrIpv6'] as string | undefined;
     const description = properties['Description'] as string | undefined;
     if (cidrIp) {
       const ipRange: { CidrIp: string; Description?: string } = { CidrIp: cidrIp };
       if (description) ipRange.Description = description;
       permission.IpRanges = [ipRange];
     }
+    if (cidrIpv6) {
+      const ipv6Range: { CidrIpv6: string; Description?: string } = { CidrIpv6: cidrIpv6 };
+      if (description) ipv6Range.Description = description;
+      permission.Ipv6Ranges = [ipv6Range];
+    }
 
-    const sourceSecurityGroupId = properties['SourceSecurityGroupId'] as string | undefined;
-    if (sourceSecurityGroupId) {
+    // Source SG (ingress) and destination SG (egress) map to the same
+    // UserIdGroupPairs slot on the underlying EC2 IpPermission shape.
+    const peerGroupId =
+      direction === 'egress'
+        ? (properties['DestinationSecurityGroupId'] as string | undefined)
+        : (properties['SourceSecurityGroupId'] as string | undefined);
+    if (peerGroupId) {
       const groupPair: { GroupId: string; Description?: string } = {
-        GroupId: sourceSecurityGroupId,
+        GroupId: peerGroupId,
       };
       if (description) groupPair.Description = description;
       permission.UserIdGroupPairs = [groupPair];
     }
 
+    // Prefix list (egress only in CFn, but harmless to read for both)
+    const prefixListId =
+      direction === 'egress'
+        ? (properties['DestinationPrefixListId'] as string | undefined)
+        : (properties['SourcePrefixListId'] as string | undefined);
+    if (prefixListId) {
+      const prefixEntry: { PrefixListId: string; Description?: string } = {
+        PrefixListId: prefixListId,
+      };
+      if (description) prefixEntry.Description = description;
+      permission.PrefixListIds = [prefixEntry];
+    }
+
     return permission;
+  }
+
+  /**
+   * Compute the diff between two sets of SecurityGroup rule definitions
+   * (ingress or egress) and apply the resulting authorize/revoke calls.
+   *
+   * Rules are identified by a deterministic key derived from their full
+   * shape — protocol, ports, CIDR, peer group, prefix list, description —
+   * so updating any of those fields counts as a replacement (revoke + authorize).
+   */
+  private async applySecurityGroupRuleDiff(
+    groupId: string,
+    previousRules: Array<Record<string, unknown>>,
+    nextRules: Array<Record<string, unknown>>,
+    direction: 'ingress' | 'egress'
+  ): Promise<void> {
+    const ruleKey = (rule: Record<string, unknown>): string => {
+      const peerKey =
+        direction === 'egress'
+          ? (rule['DestinationSecurityGroupId'] as string | undefined)
+          : (rule['SourceSecurityGroupId'] as string | undefined);
+      const prefixKey =
+        direction === 'egress'
+          ? (rule['DestinationPrefixListId'] as string | undefined)
+          : (rule['SourcePrefixListId'] as string | undefined);
+      return JSON.stringify({
+        p: rule['IpProtocol'] ?? '-1',
+        f: rule['FromPort'] ?? null,
+        t: rule['ToPort'] ?? null,
+        c4: rule['CidrIp'] ?? null,
+        c6: rule['CidrIpv6'] ?? null,
+        peer: peerKey ?? null,
+        pl: prefixKey ?? null,
+        d: rule['Description'] ?? null,
+      });
+    };
+
+    const prevByKey = new Map<string, Record<string, unknown>>();
+    for (const rule of previousRules) prevByKey.set(ruleKey(rule), rule);
+    const nextByKey = new Map<string, Record<string, unknown>>();
+    for (const rule of nextRules) nextByKey.set(ruleKey(rule), rule);
+
+    const toRevoke: Array<Record<string, unknown>> = [];
+    for (const [key, rule] of prevByKey) {
+      if (!nextByKey.has(key)) toRevoke.push(rule);
+    }
+    const toAuthorize: Array<Record<string, unknown>> = [];
+    for (const [key, rule] of nextByKey) {
+      if (!prevByKey.has(key)) toAuthorize.push(rule);
+    }
+
+    for (const rule of toRevoke) {
+      try {
+        if (direction === 'egress') {
+          await this.ec2Client.send(
+            new RevokeSecurityGroupEgressCommand({
+              GroupId: groupId,
+              IpPermissions: [this.buildIpPermission(rule, 'egress')],
+            })
+          );
+        } else {
+          await this.ec2Client.send(
+            new RevokeSecurityGroupIngressCommand({
+              GroupId: groupId,
+              IpPermissions: [this.buildIpPermission(rule, 'ingress')],
+            })
+          );
+        }
+      } catch (error) {
+        if (!this.isNotFoundError(error)) throw error;
+      }
+    }
+
+    for (const rule of toAuthorize) {
+      try {
+        if (direction === 'egress') {
+          await this.ec2Client.send(
+            new AuthorizeSecurityGroupEgressCommand({
+              GroupId: groupId,
+              IpPermissions: [this.buildIpPermission(rule, 'egress')],
+            })
+          );
+        } else {
+          await this.ec2Client.send(
+            new AuthorizeSecurityGroupIngressCommand({
+              GroupId: groupId,
+              IpPermissions: [this.buildIpPermission(rule, 'ingress')],
+            })
+          );
+        }
+      } catch (error) {
+        // Tolerate "already exists" to keep the diff idempotent across retries.
+        if (!(error instanceof Error && error.message.includes('already exists'))) {
+          throw error;
+        }
+      }
+    }
   }
 
   // ─── AWS::EC2::NetworkAcl ────────────────────────────────────────

--- a/tests/unit/provisioning/providers/ec2-provider.test.ts
+++ b/tests/unit/provisioning/providers/ec2-provider.test.ts
@@ -193,6 +193,125 @@ describe('EC2Provider - SecurityGroup egress handling', () => {
       );
     });
 
+    it('should map SourceSecurityGroupOwnerId to UserIdGroupPairs[].UserId on ingress (cross-account peer)', async () => {
+      // Cross-account ingress rule: GroupId comes from SourceSecurityGroupId
+      // and UserId from SourceSecurityGroupOwnerId. The default egress is
+      // untouched (no SecurityGroupEgress provided).
+      mockSend
+        .mockResolvedValueOnce({ GroupId: 'sg-xacct' }) // CreateSecurityGroupCommand
+        .mockResolvedValueOnce({}); // AuthorizeSecurityGroupIngressCommand
+
+      await provider.create('XAcctSg', 'AWS::EC2::SecurityGroup', {
+        GroupDescription: 'Cross-account peer',
+        VpcId: 'vpc-abc',
+        SecurityGroupIngress: [
+          {
+            IpProtocol: 'tcp',
+            FromPort: 443,
+            ToPort: 443,
+            SourceSecurityGroupId: 'sg-peer',
+            SourceSecurityGroupOwnerId: '111122223333',
+            Description: 'from peer account',
+          },
+        ],
+      });
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      const authorizeIngressCmds = commands.filter(
+        (c) => c instanceof AuthorizeSecurityGroupIngressCommand
+      );
+      expect(authorizeIngressCmds).toHaveLength(1);
+      expect(authorizeIngressCmds[0].input).toEqual({
+        GroupId: 'sg-xacct',
+        IpPermissions: [
+          {
+            IpProtocol: 'tcp',
+            FromPort: 443,
+            ToPort: 443,
+            UserIdGroupPairs: [
+              {
+                GroupId: 'sg-peer',
+                UserId: '111122223333',
+                Description: 'from peer account',
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('should not set UserId on egress when DestinationSecurityGroupId is provided (no CFn equivalent)', async () => {
+      // CFn does not define a Destination*OwnerId counterpart; even if a
+      // SourceSecurityGroupOwnerId is accidentally present on an egress rule,
+      // it must not leak into UserIdGroupPairs[].UserId.
+      mockSend
+        .mockResolvedValueOnce({ GroupId: 'sg-egress-only' }) // Create
+        .mockResolvedValueOnce({}) // Revoke default egress
+        .mockResolvedValueOnce({}); // Authorize egress
+
+      await provider.create('EgressOnly', 'AWS::EC2::SecurityGroup', {
+        GroupDescription: 'egress-only',
+        SecurityGroupEgress: [
+          {
+            IpProtocol: 'tcp',
+            FromPort: 5432,
+            ToPort: 5432,
+            DestinationSecurityGroupId: 'sg-db',
+            // Stray field - must be ignored on the egress path.
+            SourceSecurityGroupOwnerId: '999988887777',
+          },
+        ],
+      });
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      const authorizeEgressCmds = commands.filter(
+        (c) => c instanceof AuthorizeSecurityGroupEgressCommand
+      );
+      expect(authorizeEgressCmds).toHaveLength(1);
+      expect(authorizeEgressCmds[0].input).toEqual({
+        GroupId: 'sg-egress-only',
+        IpPermissions: [
+          {
+            IpProtocol: 'tcp',
+            FromPort: 5432,
+            ToPort: 5432,
+            UserIdGroupPairs: [{ GroupId: 'sg-db' }],
+          },
+        ],
+      });
+    });
+
+    it('should tolerate "already exists" when authorizing during a diff apply', async () => {
+      // Replays the authorize-on-update path where AWS reports the rule already
+      // exists (e.g. retry after a partial failure). The provider should treat
+      // this as success rather than throwing. Properties include no Tags and
+      // no previous ingress, so the only AWS call we make is the egress
+      // authorize that we want to reject.
+      const alreadyExists = new Error(
+        'the specified rule "peer: 0.0.0.0/0, TCP, from port: 443, to port: 443, ALLOW" already exists'
+      );
+
+      mockSend.mockRejectedValueOnce(alreadyExists);
+
+      await provider.update(
+        'Sg1',
+        'sg-tolerant-diff',
+        'AWS::EC2::SecurityGroup',
+        {
+          GroupDescription: 'd',
+          SecurityGroupEgress: [
+            { IpProtocol: 'tcp', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' },
+          ],
+        },
+        { GroupDescription: 'd' }
+      );
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      expect(commands.filter((c) => c instanceof AuthorizeSecurityGroupEgressCommand)).toHaveLength(
+        1
+      );
+    });
+
     it('should still process SecurityGroupIngress alongside SecurityGroupEgress', async () => {
       mockSend
         .mockResolvedValueOnce({ GroupId: 'sg-mixed' }) // Create
@@ -353,6 +472,143 @@ describe('EC2Provider - SecurityGroup egress handling', () => {
       expect(commands.filter((c) => c instanceof AuthorizeSecurityGroupEgressCommand)).toHaveLength(
         0
       );
+    });
+  });
+
+  describe('updateSecurityGroup ingress rule diff', () => {
+    it('should authorize newly added ingress rules and revoke removed ones', async () => {
+      mockSend.mockResolvedValue({});
+
+      const previous = {
+        GroupDescription: 'desc',
+        SecurityGroupIngress: [
+          { IpProtocol: 'tcp', FromPort: 22, ToPort: 22, CidrIp: '0.0.0.0/0' }, // removed
+          { IpProtocol: 'tcp', FromPort: 80, ToPort: 80, CidrIp: '10.0.0.0/8' }, // unchanged
+        ],
+      };
+      const next = {
+        GroupDescription: 'desc',
+        SecurityGroupIngress: [
+          { IpProtocol: 'tcp', FromPort: 80, ToPort: 80, CidrIp: '10.0.0.0/8' }, // unchanged
+          {
+            IpProtocol: 'tcp',
+            FromPort: 443,
+            ToPort: 443,
+            SourceSecurityGroupId: 'sg-peer',
+            SourceSecurityGroupOwnerId: '111122223333',
+          }, // added (cross-account)
+        ],
+      };
+
+      await provider.update('Sg1', 'sg-deadbeef', 'AWS::EC2::SecurityGroup', next, previous);
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      const revokeIngressCmds = commands.filter(
+        (c) => c instanceof RevokeSecurityGroupIngressCommand
+      );
+      const authorizeIngressCmds = commands.filter(
+        (c) => c instanceof AuthorizeSecurityGroupIngressCommand
+      );
+
+      expect(revokeIngressCmds).toHaveLength(1);
+      expect(revokeIngressCmds[0].input).toEqual({
+        GroupId: 'sg-deadbeef',
+        IpPermissions: [
+          {
+            IpProtocol: 'tcp',
+            FromPort: 22,
+            ToPort: 22,
+            IpRanges: [{ CidrIp: '0.0.0.0/0' }],
+          },
+        ],
+      });
+
+      expect(authorizeIngressCmds).toHaveLength(1);
+      expect(authorizeIngressCmds[0].input).toEqual({
+        GroupId: 'sg-deadbeef',
+        IpPermissions: [
+          {
+            IpProtocol: 'tcp',
+            FromPort: 443,
+            ToPort: 443,
+            UserIdGroupPairs: [{ GroupId: 'sg-peer', UserId: '111122223333' }],
+          },
+        ],
+      });
+    });
+
+    it('should be a no-op (no authorize/revoke) when ingress rules are unchanged', async () => {
+      mockSend.mockResolvedValue({});
+
+      const rules = [
+        { IpProtocol: 'tcp', FromPort: 22, ToPort: 22, CidrIp: '0.0.0.0/0' },
+      ];
+
+      await provider.update(
+        'Sg1',
+        'sg-stable-ingress',
+        'AWS::EC2::SecurityGroup',
+        { GroupDescription: 'd', SecurityGroupIngress: rules },
+        { GroupDescription: 'd', SecurityGroupIngress: rules }
+      );
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      expect(commands.filter((c) => c instanceof RevokeSecurityGroupIngressCommand)).toHaveLength(
+        0
+      );
+      expect(
+        commands.filter((c) => c instanceof AuthorizeSecurityGroupIngressCommand)
+      ).toHaveLength(0);
+    });
+
+    it('should authorize all ingress rules when previous had none', async () => {
+      mockSend.mockResolvedValue({});
+
+      await provider.update(
+        'Sg1',
+        'sg-fresh-ingress',
+        'AWS::EC2::SecurityGroup',
+        {
+          GroupDescription: 'd',
+          SecurityGroupIngress: [
+            { IpProtocol: 'tcp', FromPort: 22, ToPort: 22, CidrIp: '0.0.0.0/0' },
+          ],
+        },
+        { GroupDescription: 'd' }
+      );
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      expect(
+        commands.filter((c) => c instanceof AuthorizeSecurityGroupIngressCommand)
+      ).toHaveLength(1);
+      expect(commands.filter((c) => c instanceof RevokeSecurityGroupIngressCommand)).toHaveLength(
+        0
+      );
+    });
+
+    it('should revoke all ingress rules when next has none', async () => {
+      mockSend.mockResolvedValue({});
+
+      await provider.update(
+        'Sg1',
+        'sg-empty-ingress',
+        'AWS::EC2::SecurityGroup',
+        { GroupDescription: 'd' },
+        {
+          GroupDescription: 'd',
+          SecurityGroupIngress: [
+            { IpProtocol: 'tcp', FromPort: 22, ToPort: 22, CidrIp: '0.0.0.0/0' },
+          ],
+        }
+      );
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      expect(commands.filter((c) => c instanceof RevokeSecurityGroupIngressCommand)).toHaveLength(
+        1
+      );
+      expect(
+        commands.filter((c) => c instanceof AuthorizeSecurityGroupIngressCommand)
+      ).toHaveLength(0);
     });
   });
 

--- a/tests/unit/provisioning/providers/ec2-provider.test.ts
+++ b/tests/unit/provisioning/providers/ec2-provider.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CreateSecurityGroupCommand,
+  AuthorizeSecurityGroupIngressCommand,
+  AuthorizeSecurityGroupEgressCommand,
+  RevokeSecurityGroupEgressCommand,
+  RevokeSecurityGroupIngressCommand,
+  CreateTagsCommand,
+} from '@aws-sdk/client-ec2';
+
+const mockSend = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    ec2: { send: mockSend },
+  }),
+}));
+
+vi.mock('../../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { EC2Provider } from '../../../../src/provisioning/providers/ec2-provider.js';
+
+describe('EC2Provider - SecurityGroup egress handling', () => {
+  let provider: EC2Provider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSend.mockReset();
+    provider = new EC2Provider();
+  });
+
+  describe('handledProperties', () => {
+    it('should declare SecurityGroupEgress as a handled property of AWS::EC2::SecurityGroup', () => {
+      const props = provider.handledProperties.get('AWS::EC2::SecurityGroup');
+      expect(props).toBeDefined();
+      expect(props?.has('SecurityGroupEgress')).toBe(true);
+      // Existing properties should remain handled
+      expect(props?.has('SecurityGroupIngress')).toBe(true);
+      expect(props?.has('GroupDescription')).toBe(true);
+    });
+  });
+
+  describe('createSecurityGroup with SecurityGroupEgress', () => {
+    it('should revoke the AWS-default egress rule and authorize each explicit egress rule', async () => {
+      // CreateSecurityGroup -> CreateTags -> Revoke default egress -> AuthorizeEgress (rule 1) -> AuthorizeEgress (rule 2)
+      mockSend
+        .mockResolvedValueOnce({ GroupId: 'sg-12345678' }) // CreateSecurityGroupCommand
+        .mockResolvedValueOnce({}) // CreateTagsCommand (no tags but applyTags may be a no-op; see assertions)
+        .mockResolvedValueOnce({}) // RevokeSecurityGroupEgressCommand (default rule)
+        .mockResolvedValueOnce({}) // AuthorizeSecurityGroupEgressCommand (rule 1)
+        .mockResolvedValueOnce({}); // AuthorizeSecurityGroupEgressCommand (rule 2)
+
+      const result = await provider.create('LambdaSg', 'AWS::EC2::SecurityGroup', {
+        GroupDescription: 'Lambda SG',
+        VpcId: 'vpc-abc',
+        SecurityGroupEgress: [
+          {
+            IpProtocol: 'tcp',
+            FromPort: 443,
+            ToPort: 443,
+            CidrIp: '0.0.0.0/0',
+            Description: 'HTTPS out',
+          },
+          {
+            IpProtocol: 'tcp',
+            FromPort: 5432,
+            ToPort: 5432,
+            DestinationSecurityGroupId: 'sg-db',
+          },
+        ],
+      });
+
+      expect(result.physicalId).toBe('sg-12345678');
+
+      // Filter by command type so the test is robust against the presence/absence
+      // of the CreateTagsCommand (depends on the applyTags helper's behavior).
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      const createCmds = commands.filter((c) => c instanceof CreateSecurityGroupCommand);
+      const revokeEgressCmds = commands.filter(
+        (c) => c instanceof RevokeSecurityGroupEgressCommand
+      );
+      const authorizeEgressCmds = commands.filter(
+        (c) => c instanceof AuthorizeSecurityGroupEgressCommand
+      );
+      const authorizeIngressCmds = commands.filter(
+        (c) => c instanceof AuthorizeSecurityGroupIngressCommand
+      );
+
+      expect(createCmds).toHaveLength(1);
+      expect(revokeEgressCmds).toHaveLength(1);
+      expect(authorizeEgressCmds).toHaveLength(2);
+      expect(authorizeIngressCmds).toHaveLength(0);
+
+      // Default egress revoke targets 0.0.0.0/0 with -1 protocol
+      expect(revokeEgressCmds[0].input).toEqual({
+        GroupId: 'sg-12345678',
+        IpPermissions: [
+          {
+            IpProtocol: '-1',
+            IpRanges: [{ CidrIp: '0.0.0.0/0' }],
+          },
+        ],
+      });
+
+      // First authorize: HTTPS out via CIDR
+      expect(authorizeEgressCmds[0].input).toEqual({
+        GroupId: 'sg-12345678',
+        IpPermissions: [
+          {
+            IpProtocol: 'tcp',
+            FromPort: 443,
+            ToPort: 443,
+            IpRanges: [{ CidrIp: '0.0.0.0/0', Description: 'HTTPS out' }],
+          },
+        ],
+      });
+
+      // Second authorize: targets DestinationSecurityGroupId via UserIdGroupPairs
+      expect(authorizeEgressCmds[1].input).toEqual({
+        GroupId: 'sg-12345678',
+        IpPermissions: [
+          {
+            IpProtocol: 'tcp',
+            FromPort: 5432,
+            ToPort: 5432,
+            UserIdGroupPairs: [{ GroupId: 'sg-db' }],
+          },
+        ],
+      });
+    });
+
+    it('should not call RevokeSecurityGroupEgress when SecurityGroupEgress is not provided', async () => {
+      mockSend.mockResolvedValueOnce({ GroupId: 'sg-no-egress' });
+
+      await provider.create('SgNoEgress', 'AWS::EC2::SecurityGroup', {
+        GroupDescription: 'No explicit egress',
+        VpcId: 'vpc-abc',
+      });
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      expect(commands.filter((c) => c instanceof RevokeSecurityGroupEgressCommand)).toHaveLength(
+        0
+      );
+      expect(commands.filter((c) => c instanceof AuthorizeSecurityGroupEgressCommand)).toHaveLength(
+        0
+      );
+    });
+
+    it('should tolerate "default rule not found" when revoking the default egress rule', async () => {
+      // Use a message that contains "does not exist" so isNotFoundError() treats
+      // the error as a benign absence of the AWS-default rule.
+      const notFound = new Error('the specified rule does not exist in this security group');
+
+      mockSend
+        .mockResolvedValueOnce({ GroupId: 'sg-tolerant' }) // CreateSecurityGroupCommand
+        .mockRejectedValueOnce(notFound) // RevokeSecurityGroupEgressCommand (default missing)
+        .mockResolvedValueOnce({}); // AuthorizeSecurityGroupEgressCommand
+
+      const result = await provider.create('TolerantSg', 'AWS::EC2::SecurityGroup', {
+        GroupDescription: 'Tolerates missing default rule',
+        SecurityGroupEgress: [
+          {
+            IpProtocol: 'tcp',
+            FromPort: 80,
+            ToPort: 80,
+            CidrIp: '10.0.0.0/8',
+          },
+        ],
+      });
+
+      expect(result.physicalId).toBe('sg-tolerant');
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      expect(commands.filter((c) => c instanceof AuthorizeSecurityGroupEgressCommand)).toHaveLength(
+        1
+      );
+    });
+
+    it('should still process SecurityGroupIngress alongside SecurityGroupEgress', async () => {
+      mockSend
+        .mockResolvedValueOnce({ GroupId: 'sg-mixed' }) // Create
+        .mockResolvedValueOnce({}) // AuthorizeIngress
+        .mockResolvedValueOnce({}) // RevokeEgress (default)
+        .mockResolvedValueOnce({}); // AuthorizeEgress
+
+      await provider.create('MixedSg', 'AWS::EC2::SecurityGroup', {
+        GroupDescription: 'Mixed',
+        SecurityGroupIngress: [
+          { IpProtocol: 'tcp', FromPort: 22, ToPort: 22, CidrIp: '0.0.0.0/0' },
+        ],
+        SecurityGroupEgress: [
+          { IpProtocol: 'tcp', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' },
+        ],
+      });
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      expect(commands.filter((c) => c instanceof AuthorizeSecurityGroupIngressCommand)).toHaveLength(
+        1
+      );
+      expect(commands.filter((c) => c instanceof RevokeSecurityGroupEgressCommand)).toHaveLength(
+        1
+      );
+      expect(commands.filter((c) => c instanceof AuthorizeSecurityGroupEgressCommand)).toHaveLength(
+        1
+      );
+    });
+  });
+
+  describe('updateSecurityGroup egress rule diff', () => {
+    it('should authorize newly added egress rules and revoke removed ones', async () => {
+      // applyTags is invoked first; allow either CreateTags or no call by accepting any successful resolve.
+      // We then expect: revoke removed egress + authorize added egress.
+      mockSend.mockResolvedValue({});
+
+      const previous = {
+        GroupDescription: 'desc',
+        SecurityGroupEgress: [
+          { IpProtocol: 'tcp', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' }, // removed
+          { IpProtocol: 'tcp', FromPort: 80, ToPort: 80, CidrIp: '10.0.0.0/8' }, // unchanged
+        ],
+      };
+      const next = {
+        GroupDescription: 'desc',
+        SecurityGroupEgress: [
+          { IpProtocol: 'tcp', FromPort: 80, ToPort: 80, CidrIp: '10.0.0.0/8' }, // unchanged
+          { IpProtocol: 'tcp', FromPort: 5432, ToPort: 5432, DestinationSecurityGroupId: 'sg-db' }, // added
+        ],
+      };
+
+      await provider.update('Sg1', 'sg-deadbeef', 'AWS::EC2::SecurityGroup', next, previous);
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      const revokeEgressCmds = commands.filter(
+        (c) => c instanceof RevokeSecurityGroupEgressCommand
+      );
+      const authorizeEgressCmds = commands.filter(
+        (c) => c instanceof AuthorizeSecurityGroupEgressCommand
+      );
+
+      expect(revokeEgressCmds).toHaveLength(1);
+      expect(revokeEgressCmds[0].input).toEqual({
+        GroupId: 'sg-deadbeef',
+        IpPermissions: [
+          {
+            IpProtocol: 'tcp',
+            FromPort: 443,
+            ToPort: 443,
+            IpRanges: [{ CidrIp: '0.0.0.0/0' }],
+          },
+        ],
+      });
+
+      expect(authorizeEgressCmds).toHaveLength(1);
+      expect(authorizeEgressCmds[0].input).toEqual({
+        GroupId: 'sg-deadbeef',
+        IpPermissions: [
+          {
+            IpProtocol: 'tcp',
+            FromPort: 5432,
+            ToPort: 5432,
+            UserIdGroupPairs: [{ GroupId: 'sg-db' }],
+          },
+        ],
+      });
+    });
+
+    it('should be a no-op (no authorize/revoke) when egress rules are unchanged', async () => {
+      mockSend.mockResolvedValue({});
+
+      const rules = [
+        { IpProtocol: 'tcp', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' },
+      ];
+
+      await provider.update(
+        'Sg1',
+        'sg-stable',
+        'AWS::EC2::SecurityGroup',
+        { GroupDescription: 'd', SecurityGroupEgress: rules },
+        { GroupDescription: 'd', SecurityGroupEgress: rules }
+      );
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      expect(commands.filter((c) => c instanceof RevokeSecurityGroupEgressCommand)).toHaveLength(
+        0
+      );
+      expect(commands.filter((c) => c instanceof AuthorizeSecurityGroupEgressCommand)).toHaveLength(
+        0
+      );
+    });
+
+    it('should authorize all egress rules when previous had none', async () => {
+      mockSend.mockResolvedValue({});
+
+      await provider.update(
+        'Sg1',
+        'sg-fresh',
+        'AWS::EC2::SecurityGroup',
+        {
+          GroupDescription: 'd',
+          SecurityGroupEgress: [
+            { IpProtocol: 'tcp', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' },
+          ],
+        },
+        { GroupDescription: 'd' }
+      );
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      expect(commands.filter((c) => c instanceof AuthorizeSecurityGroupEgressCommand)).toHaveLength(
+        1
+      );
+      expect(commands.filter((c) => c instanceof RevokeSecurityGroupEgressCommand)).toHaveLength(
+        0
+      );
+    });
+
+    it('should revoke all egress rules when next has none', async () => {
+      mockSend.mockResolvedValue({});
+
+      await provider.update(
+        'Sg1',
+        'sg-empty',
+        'AWS::EC2::SecurityGroup',
+        { GroupDescription: 'd' },
+        {
+          GroupDescription: 'd',
+          SecurityGroupEgress: [
+            { IpProtocol: 'tcp', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' },
+          ],
+        }
+      );
+
+      const commands = mockSend.mock.calls.map((c) => c[0]);
+      expect(commands.filter((c) => c instanceof RevokeSecurityGroupEgressCommand)).toHaveLength(
+        1
+      );
+      expect(commands.filter((c) => c instanceof AuthorizeSecurityGroupEgressCommand)).toHaveLength(
+        0
+      );
+    });
+  });
+
+  describe('CreateTagsCommand passthrough', () => {
+    // Sanity check that imports/awareness of CreateTagsCommand keeps tag handling
+    // intact; actual tag application is exercised across other test cases that
+    // set mockSend.mockResolvedValue({}) for any command.
+    it('should keep CreateTagsCommand reference reachable', () => {
+      expect(CreateTagsCommand).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `SecurityGroupEgress` to the EC2 SDK Provider (eliminates CC API fallback warning `SDK provider does not handle [SecurityGroupEgress]`).
- Authorize/revoke AWS-default `0.0.0.0/0 -1` egress when an explicit rule set is provided (CFn-compatible).
- Symmetric ingress/egress diff via a shared helper; wire ingress diff through `updateSecurityGroup`.
- Cross-account ingress peer support: `SourceSecurityGroupOwnerId` → `UserIdGroupPairs[].UserId`.
- 17 new unit tests.

## Test plan
- [x] Unit: create+update for egress, ingress, cross-account, AWS-default revoke
- [ ] Integration: `bench-cdk-sample` (after merging W1/W3/W4 too)