### PR TITLE
feat(provider): handle Lambda VpcConfig + wait for ENI detach on delete

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2022,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-  "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2022,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,6 +365,7 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 - ✅ Nested cloud assembly traversal (CDK Stage support)
 - ✅ WorkGraph DAG orchestrator for asset publishing and stack deployment (build→publish→deploy pipeline)
 - ✅ Concurrency options: `--asset-publish-concurrency` (default 8), `--image-build-concurrency` (default 4)
+- ✅ Lambda VpcConfig SDK provider support (avoids CC API fallback) + ENI detach wait on delete (avoids downstream Subnet/SG "has dependencies" failures)
 
 ## Dependencies
 

--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -350,10 +350,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
    * so omitting it cannot move a function out of its existing VPC. To
    * detach we must explicitly send empty SubnetIds / SecurityGroupIds.
    */
-  private buildVpcConfigForUpdate(
-    newRaw: unknown,
-    previousRaw: unknown
-  ): VpcConfig | undefined {
+  private buildVpcConfigForUpdate(newRaw: unknown, previousRaw: unknown): VpcConfig | undefined {
     const next = this.buildVpcConfig(newRaw);
     if (next) {
       return next;

--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -15,7 +15,9 @@ import {
   type Architecture,
   type TracingConfig,
   type EphemeralStorage,
+  type VpcConfig,
 } from '@aws-sdk/client-lambda';
+import { EC2Client, DescribeNetworkInterfacesCommand } from '@aws-sdk/client-ec2';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
@@ -36,6 +38,7 @@ import type {
  */
 export class LambdaFunctionProvider implements ResourceProvider {
   private lambdaClient: LambdaClient;
+  private ec2Client: EC2Client;
   private logger = getLogger().child('LambdaFunctionProvider');
   handledProperties = new Map<string, ReadonlySet<string>>([
     [
@@ -56,13 +59,23 @@ export class LambdaFunctionProvider implements ResourceProvider {
         'PackageType',
         'TracingConfig',
         'EphemeralStorage',
+        'VpcConfig',
       ]),
     ],
   ]);
 
+  // ENI detach polling configuration (overridable for tests).
+  // Lambda VPC ENI detach is async and can take 20-40 minutes in the worst case;
+  // we poll up to 10 minutes and then warn-and-continue, since downstream Subnet/SG
+  // deletion has its own retry logic that handles a small remaining window.
+  private readonly eniWaitTimeoutMs: number = 10 * 60 * 1000;
+  private readonly eniWaitInitialDelayMs: number = 10_000;
+  private readonly eniWaitMaxDelayMs: number = 30_000;
+
   constructor() {
     const awsClients = getAwsClients();
     this.lambdaClient = awsClients.lambda;
+    this.ec2Client = awsClients.ec2;
   }
 
   /**
@@ -125,6 +138,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
         PackageType: properties['PackageType'] as 'Zip' | 'Image' | undefined,
         TracingConfig: properties['TracingConfig'] as TracingConfig | undefined,
         EphemeralStorage: properties['EphemeralStorage'] as EphemeralStorage | undefined,
+        VpcConfig: this.buildVpcConfig(properties['VpcConfig']),
         Tags: tags,
       };
 
@@ -176,6 +190,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
         'Layers',
         'TracingConfig',
         'EphemeralStorage',
+        'VpcConfig',
       ];
 
       let hasConfigChanges = false;
@@ -201,6 +216,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
           Layers: properties['Layers'] as string[] | undefined,
           TracingConfig: properties['TracingConfig'] as TracingConfig | undefined,
           EphemeralStorage: properties['EphemeralStorage'] as EphemeralStorage | undefined,
+          VpcConfig: this.buildVpcConfig(properties['VpcConfig']),
         };
 
         await this.lambdaClient.send(new UpdateFunctionConfigurationCommand(configParams));
@@ -253,14 +269,25 @@ export class LambdaFunctionProvider implements ResourceProvider {
 
   /**
    * Delete a Lambda function
+   *
+   * For VPC-enabled Lambda functions, AWS detaches the hyperplane ENIs
+   * asynchronously after DeleteFunction returns. If we let downstream
+   * resource deletion (Subnet / SecurityGroup) proceed immediately, those
+   * deletions fail with "has dependencies" / "has a dependent object".
+   *
+   * To smooth this out, when properties carry a VpcConfig with subnets or
+   * security groups, we poll DescribeNetworkInterfaces for the function's
+   * managed ENIs and only return once they are gone (or the timeout elapses).
    */
   async delete(
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    properties?: Record<string, unknown>
   ): Promise<void> {
     this.logger.debug(`Deleting Lambda function ${logicalId}: ${physicalId}`);
+
+    const hasVpcConfig = this.hasVpcConfig(properties?.['VpcConfig']);
 
     try {
       await this.lambdaClient.send(new DeleteFunctionCommand({ FunctionName: physicalId }));
@@ -279,6 +306,157 @@ export class LambdaFunctionProvider implements ResourceProvider {
         cause
       );
     }
+
+    if (hasVpcConfig) {
+      await this.waitForLambdaEnisDetached(physicalId);
+    }
+  }
+
+  /**
+   * Build Lambda VpcConfig parameter from CDK properties.
+   *
+   * Returns undefined when VpcConfig is unset, so the SDK leaves the function
+   * outside any VPC. Returns an empty config (no subnets, no SGs) when caller
+   * explicitly clears it on update — that detaches the function from its VPC.
+   */
+  private buildVpcConfig(raw: unknown): VpcConfig | undefined {
+    if (raw === undefined || raw === null) {
+      return undefined;
+    }
+    if (typeof raw !== 'object') {
+      return undefined;
+    }
+    const vpc = raw as Record<string, unknown>;
+    const result: VpcConfig = {};
+    if (Array.isArray(vpc['SubnetIds'])) {
+      result.SubnetIds = vpc['SubnetIds'] as string[];
+    }
+    if (Array.isArray(vpc['SecurityGroupIds'])) {
+      result.SecurityGroupIds = vpc['SecurityGroupIds'] as string[];
+    }
+    if (typeof vpc['Ipv6AllowedForDualStack'] === 'boolean') {
+      result.Ipv6AllowedForDualStack = vpc['Ipv6AllowedForDualStack'];
+    }
+    return result;
+  }
+
+  /**
+   * Determine whether the function actually attaches to a VPC, i.e. has at
+   * least one Subnet ID. A bare VpcConfig with empty arrays does not create
+   * any ENIs, so we skip the wait in that case.
+   */
+  private hasVpcConfig(raw: unknown): boolean {
+    if (raw === undefined || raw === null || typeof raw !== 'object') {
+      return false;
+    }
+    const vpc = raw as Record<string, unknown>;
+    const subnets = vpc['SubnetIds'];
+    return Array.isArray(subnets) && subnets.length > 0;
+  }
+
+  /**
+   * Poll DescribeNetworkInterfaces until the Lambda-managed ENIs for the
+   * given function are gone, or the configured timeout elapses.
+   *
+   * Lambda VPC ENIs carry a Description like:
+   *   "AWS Lambda VPC ENI-<functionName>-<uuid>"
+   * We match on a substring to be tolerant of format drift.
+   *
+   * Polling: starts at eniWaitInitialDelayMs (10s), exponential backoff up
+   * to eniWaitMaxDelayMs (30s), bounded by eniWaitTimeoutMs (10min).
+   *
+   * Timeout is treated as a soft warning: detach can legitimately take 20-40
+   * minutes in degraded conditions, and downstream Subnet/SG deletion has
+   * its own retries to handle the residual window.
+   */
+  private async waitForLambdaEnisDetached(functionName: string): Promise<void> {
+    const start = Date.now();
+    let delay = this.eniWaitInitialDelayMs;
+    let attempt = 0;
+
+    this.logger.debug(
+      `Waiting for Lambda VPC ENIs to detach for function ${functionName} (timeout ${this.eniWaitTimeoutMs}ms)`
+    );
+
+    // Build a substring matcher tolerant of the canonical Lambda ENI Description.
+    const descriptionNeedle = `AWS Lambda VPC ENI`;
+
+    // Loop until either ENIs are gone or we exceed the configured timeout.
+    for (;;) {
+      attempt++;
+      let count: number;
+      try {
+        count = await this.countLambdaEnis(functionName, descriptionNeedle);
+      } catch (error) {
+        // Don't abort delete on transient EC2 errors; warn and continue.
+        this.logger.warn(
+          `DescribeNetworkInterfaces failed while waiting for Lambda ENIs of ${functionName}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+        count = -1;
+      }
+
+      if (count === 0) {
+        this.logger.debug(
+          `Lambda ENIs for ${functionName} fully detached after ${attempt} poll(s) / ${
+            Date.now() - start
+          }ms`
+        );
+        return;
+      }
+
+      const elapsed = Date.now() - start;
+      if (elapsed >= this.eniWaitTimeoutMs) {
+        this.logger.warn(
+          `Timeout (${this.eniWaitTimeoutMs}ms) waiting for Lambda VPC ENIs of ${functionName} ` +
+            `to detach (remaining: ${count >= 0 ? count : 'unknown'}). ` +
+            `Continuing — downstream Subnet/SG deletion will retry as needed.`
+        );
+        return;
+      }
+
+      const remaining = this.eniWaitTimeoutMs - elapsed;
+      const sleepMs = Math.min(delay, remaining);
+      await this.sleep(sleepMs);
+      delay = Math.min(delay * 2, this.eniWaitMaxDelayMs);
+    }
+  }
+
+  /**
+   * Count remaining Lambda-managed ENIs for the given function, paginating
+   * through DescribeNetworkInterfaces and filtering on Description substring.
+   *
+   * Server-side filter (`description`) does not support wildcards in EC2's API,
+   * so we filter client-side after narrowing on `requester-id` + `status`.
+   */
+  private async countLambdaEnis(functionName: string, descriptionNeedle: string): Promise<number> {
+    let nextToken: string | undefined;
+    let count = 0;
+    do {
+      const resp = await this.ec2Client.send(
+        new DescribeNetworkInterfacesCommand({
+          Filters: [
+            // Lambda hyperplane ENIs are owned by the Lambda service principal.
+            { Name: 'requester-id', Values: ['*:awslambda_*'] },
+          ],
+          NextToken: nextToken,
+        })
+      );
+
+      for (const ni of resp.NetworkInterfaces ?? []) {
+        const desc = ni.Description ?? '';
+        if (desc.includes(descriptionNeedle) && desc.includes(functionName)) {
+          count++;
+        }
+      }
+      nextToken = resp.NextToken;
+    } while (nextToken);
+    return count;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   /**

--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -216,7 +216,10 @@ export class LambdaFunctionProvider implements ResourceProvider {
           Layers: properties['Layers'] as string[] | undefined,
           TracingConfig: properties['TracingConfig'] as TracingConfig | undefined,
           EphemeralStorage: properties['EphemeralStorage'] as EphemeralStorage | undefined,
-          VpcConfig: this.buildVpcConfig(properties['VpcConfig']),
+          VpcConfig: this.buildVpcConfigForUpdate(
+            properties['VpcConfig'],
+            previousProperties['VpcConfig']
+          ),
         };
 
         await this.lambdaClient.send(new UpdateFunctionConfigurationCommand(configParams));
@@ -341,6 +344,27 @@ export class LambdaFunctionProvider implements ResourceProvider {
   }
 
   /**
+   * Build VpcConfig for an update call, accounting for VPC detach.
+   *
+   * UpdateFunctionConfiguration treats an absent VpcConfig as "no change",
+   * so omitting it cannot move a function out of its existing VPC. To
+   * detach we must explicitly send empty SubnetIds / SecurityGroupIds.
+   */
+  private buildVpcConfigForUpdate(
+    newRaw: unknown,
+    previousRaw: unknown
+  ): VpcConfig | undefined {
+    const next = this.buildVpcConfig(newRaw);
+    if (next) {
+      return next;
+    }
+    if (this.hasVpcConfig(previousRaw)) {
+      return { SubnetIds: [], SecurityGroupIds: [] };
+    }
+    return undefined;
+  }
+
+  /**
    * Determine whether the function actually attaches to a VPC, i.e. has at
    * least one Subnet ID. A bare VpcConfig with empty arrays does not create
    * any ENIs, so we skip the wait in that case.
@@ -378,15 +402,21 @@ export class LambdaFunctionProvider implements ResourceProvider {
       `Waiting for Lambda VPC ENIs to detach for function ${functionName} (timeout ${this.eniWaitTimeoutMs}ms)`
     );
 
-    // Build a substring matcher tolerant of the canonical Lambda ENI Description.
+    // Match the canonical Lambda ENI Description prefix and require the
+    // function name to appear as a hyphen-bounded token. This prevents a
+    // function named "fn" from matching ENIs whose function-name token has
+    // "fn" as a prefix only (e.g. "myfn"). It cannot disambiguate when one
+    // function name is itself a hyphen-prefix of another (e.g. "fn" vs
+    // "fn-foo"), which is a known limitation of the substring approach.
     const descriptionNeedle = `AWS Lambda VPC ENI`;
+    const functionNamePattern = new RegExp(`(^|-)${escapeRegExp(functionName)}(-|$)`);
 
     // Loop until either ENIs are gone or we exceed the configured timeout.
     for (;;) {
       attempt++;
       let count: number;
       try {
-        count = await this.countLambdaEnis(functionName, descriptionNeedle);
+        count = await this.countLambdaEnis(descriptionNeedle, functionNamePattern);
       } catch (error) {
         // Don't abort delete on transient EC2 errors; warn and continue.
         this.logger.warn(
@@ -430,7 +460,10 @@ export class LambdaFunctionProvider implements ResourceProvider {
    * Server-side filter (`description`) does not support wildcards in EC2's API,
    * so we filter client-side after narrowing on `requester-id` + `status`.
    */
-  private async countLambdaEnis(functionName: string, descriptionNeedle: string): Promise<number> {
+  private async countLambdaEnis(
+    descriptionNeedle: string,
+    functionNamePattern: RegExp
+  ): Promise<number> {
     let nextToken: string | undefined;
     let count = 0;
     do {
@@ -446,7 +479,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
 
       for (const ni of resp.NetworkInterfaces ?? []) {
         const desc = ni.Description ?? '';
-        if (desc.includes(descriptionNeedle) && desc.includes(functionName)) {
+        if (desc.includes(descriptionNeedle) && functionNamePattern.test(desc)) {
           count++;
         }
       }
@@ -561,4 +594,8 @@ export class LambdaFunctionProvider implements ResourceProvider {
     }
     return (crc ^ 0xffffffff) >>> 0;
   }
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/tests/unit/provisioning/lambda-function-provider.test.ts
+++ b/tests/unit/provisioning/lambda-function-provider.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  CreateFunctionCommand,
+  UpdateFunctionConfigurationCommand,
+  DeleteFunctionCommand,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-lambda';
+import { DescribeNetworkInterfacesCommand } from '@aws-sdk/client-ec2';
+
+// Mock AWS clients before importing the provider
+const mockLambdaSend = vi.fn();
+const mockEc2Send = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    lambda: { send: mockLambdaSend },
+    ec2: { send: mockEc2Send },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { LambdaFunctionProvider } from '../../../src/provisioning/providers/lambda-function-provider.js';
+
+describe('LambdaFunctionProvider', () => {
+  let provider: LambdaFunctionProvider;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockLambdaSend.mockReset();
+    mockEc2Send.mockReset();
+    provider = new LambdaFunctionProvider();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('handledProperties', () => {
+    it('declares VpcConfig as handled to prevent CC API fallback', () => {
+      const handled = provider.handledProperties.get('AWS::Lambda::Function');
+      expect(handled).toBeDefined();
+      expect(handled?.has('VpcConfig')).toBe(true);
+    });
+  });
+
+  describe('create', () => {
+    it('passes VpcConfig (SubnetIds, SecurityGroupIds, Ipv6AllowedForDualStack) to CreateFunction', async () => {
+      mockLambdaSend.mockResolvedValueOnce({
+        FunctionName: 'fn-vpc',
+        FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:fn-vpc',
+      });
+
+      const result = await provider.create('VpcFn', 'AWS::Lambda::Function', {
+        FunctionName: 'fn-vpc',
+        Role: 'arn:aws:iam::123456789012:role/exec',
+        Handler: 'index.handler',
+        Runtime: 'nodejs20.x',
+        Code: { S3Bucket: 'b', S3Key: 'k' },
+        VpcConfig: {
+          SubnetIds: ['subnet-aaa', 'subnet-bbb'],
+          SecurityGroupIds: ['sg-111'],
+          Ipv6AllowedForDualStack: true,
+        },
+      });
+
+      expect(result.physicalId).toBe('fn-vpc');
+      expect(mockLambdaSend).toHaveBeenCalledTimes(1);
+      const cmd = mockLambdaSend.mock.calls[0][0];
+      expect(cmd).toBeInstanceOf(CreateFunctionCommand);
+      expect(cmd.input.VpcConfig).toEqual({
+        SubnetIds: ['subnet-aaa', 'subnet-bbb'],
+        SecurityGroupIds: ['sg-111'],
+        Ipv6AllowedForDualStack: true,
+      });
+    });
+
+    it('omits VpcConfig from CreateFunction input when not provided', async () => {
+      mockLambdaSend.mockResolvedValueOnce({
+        FunctionName: 'fn-no-vpc',
+        FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:fn-no-vpc',
+      });
+
+      await provider.create('NoVpcFn', 'AWS::Lambda::Function', {
+        FunctionName: 'fn-no-vpc',
+        Role: 'arn:aws:iam::123456789012:role/exec',
+        Handler: 'index.handler',
+        Runtime: 'nodejs20.x',
+        Code: { S3Bucket: 'b', S3Key: 'k' },
+      });
+
+      const cmd = mockLambdaSend.mock.calls[0][0];
+      expect(cmd.input.VpcConfig).toBeUndefined();
+    });
+  });
+
+  describe('update', () => {
+    it('sends VpcConfig change via UpdateFunctionConfiguration', async () => {
+      // 1) UpdateFunctionConfiguration  2) GetFunction (for attributes)
+      mockLambdaSend
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({
+          Configuration: {
+            FunctionName: 'fn-vpc',
+            FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:fn-vpc',
+          },
+        });
+
+      const result = await provider.update(
+        'VpcFn',
+        'fn-vpc',
+        'AWS::Lambda::Function',
+        {
+          Role: 'arn:aws:iam::123456789012:role/exec',
+          VpcConfig: {
+            SubnetIds: ['subnet-new'],
+            SecurityGroupIds: ['sg-new'],
+          },
+        },
+        {
+          Role: 'arn:aws:iam::123456789012:role/exec',
+          VpcConfig: {
+            SubnetIds: ['subnet-old'],
+            SecurityGroupIds: ['sg-old'],
+          },
+        }
+      );
+
+      expect(result.physicalId).toBe('fn-vpc');
+      const cmd = mockLambdaSend.mock.calls[0][0];
+      expect(cmd).toBeInstanceOf(UpdateFunctionConfigurationCommand);
+      expect(cmd.input.VpcConfig).toEqual({
+        SubnetIds: ['subnet-new'],
+        SecurityGroupIds: ['sg-new'],
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('does not poll EC2 when function has no VpcConfig', async () => {
+      mockLambdaSend.mockResolvedValueOnce({});
+
+      await provider.delete('Fn', 'fn-no-vpc', 'AWS::Lambda::Function', {});
+
+      expect(mockLambdaSend).toHaveBeenCalledTimes(1);
+      const cmd = mockLambdaSend.mock.calls[0][0];
+      expect(cmd).toBeInstanceOf(DeleteFunctionCommand);
+      expect(mockEc2Send).not.toHaveBeenCalled();
+    });
+
+    it('does not poll EC2 when VpcConfig has empty SubnetIds', async () => {
+      mockLambdaSend.mockResolvedValueOnce({});
+
+      await provider.delete('Fn', 'fn-empty', 'AWS::Lambda::Function', {
+        VpcConfig: { SubnetIds: [], SecurityGroupIds: [] },
+      });
+
+      expect(mockEc2Send).not.toHaveBeenCalled();
+    });
+
+    it('treats ResourceNotFoundException as already-deleted (no ENI wait)', async () => {
+      mockLambdaSend.mockRejectedValueOnce(
+        new ResourceNotFoundException({
+          message: 'Function not found',
+          $metadata: {},
+        })
+      );
+
+      await provider.delete('Fn', 'fn-gone', 'AWS::Lambda::Function', {
+        VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
+      });
+
+      expect(mockEc2Send).not.toHaveBeenCalled();
+    });
+
+    it('polls DescribeNetworkInterfaces and returns once Lambda ENIs are gone', async () => {
+      mockLambdaSend.mockResolvedValueOnce({}); // DeleteFunction
+
+      // 1st poll: 1 ENI still present.
+      // 2nd poll: 0 ENIs — wait completes.
+      mockEc2Send
+        .mockResolvedValueOnce({
+          NetworkInterfaces: [
+            {
+              NetworkInterfaceId: 'eni-aaa',
+              Description: 'AWS Lambda VPC ENI-fn-vpc-abc123',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ NetworkInterfaces: [] });
+
+      const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
+        VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
+      });
+
+      // Advance past first poll's backoff (10s).
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await promise;
+
+      expect(mockEc2Send).toHaveBeenCalledTimes(2);
+      const cmd = mockEc2Send.mock.calls[0][0];
+      expect(cmd).toBeInstanceOf(DescribeNetworkInterfacesCommand);
+    });
+
+    it('ignores ENIs whose Description does not match the function name', async () => {
+      mockLambdaSend.mockResolvedValueOnce({});
+
+      mockEc2Send.mockResolvedValueOnce({
+        NetworkInterfaces: [
+          {
+            NetworkInterfaceId: 'eni-other',
+            Description: 'AWS Lambda VPC ENI-other-function-xyz',
+          },
+        ],
+      });
+
+      const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
+        VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
+      });
+
+      await promise;
+
+      // Only one poll needed because the matched ENI does not belong to fn-vpc.
+      expect(mockEc2Send).toHaveBeenCalledTimes(1);
+    });
+
+    it('paginates DescribeNetworkInterfaces using NextToken', async () => {
+      mockLambdaSend.mockResolvedValueOnce({});
+
+      // First page returns NextToken with no matching ENIs;
+      // second page returns no matching ENIs and no NextToken — count is 0.
+      mockEc2Send
+        .mockResolvedValueOnce({
+          NetworkInterfaces: [
+            {
+              NetworkInterfaceId: 'eni-x',
+              Description: 'AWS Lambda VPC ENI-other-fn-xxx',
+            },
+          ],
+          NextToken: 'page2',
+        })
+        .mockResolvedValueOnce({
+          NetworkInterfaces: [],
+        });
+
+      await provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
+        VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
+      });
+
+      expect(mockEc2Send).toHaveBeenCalledTimes(2);
+      const secondCmd = mockEc2Send.mock.calls[1][0];
+      expect(secondCmd.input.NextToken).toBe('page2');
+    });
+
+    it('warns and resolves on ENI-wait timeout instead of throwing', async () => {
+      mockLambdaSend.mockResolvedValueOnce({});
+
+      // Always return one matching ENI — the wait should give up after 10min.
+      mockEc2Send.mockResolvedValue({
+        NetworkInterfaces: [
+          {
+            NetworkInterfaceId: 'eni-stuck',
+            Description: 'AWS Lambda VPC ENI-fn-vpc-stuck',
+          },
+        ],
+      });
+
+      const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
+        VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
+      });
+
+      // Advance well past the 10-minute timeout so the loop exits.
+      await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+
+      // Must resolve (not reject) — timeout is a soft warning.
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('continues polling after a transient EC2 failure', async () => {
+      mockLambdaSend.mockResolvedValueOnce({});
+
+      mockEc2Send
+        .mockRejectedValueOnce(new Error('ThrottlingException'))
+        .mockResolvedValueOnce({ NetworkInterfaces: [] });
+
+      const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
+        VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
+      });
+
+      // Advance past the first poll's backoff.
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(mockEc2Send).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/tests/unit/provisioning/lambda-function-provider.test.ts
+++ b/tests/unit/provisioning/lambda-function-provider.test.ts
@@ -151,6 +151,75 @@ describe('LambdaFunctionProvider', () => {
         SecurityGroupIds: ['sg-new'],
       });
     });
+
+    it('detaches the function from a VPC by sending empty arrays when VpcConfig is removed', async () => {
+      // UpdateFunctionConfiguration treats an absent VpcConfig as "no
+      // change", so we must explicitly send empty SubnetIds and
+      // SecurityGroupIds to detach a function from its VPC.
+      mockLambdaSend
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({
+          Configuration: {
+            FunctionName: 'fn-detach',
+            FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:fn-detach',
+          },
+        });
+
+      await provider.update(
+        'VpcFn',
+        'fn-detach',
+        'AWS::Lambda::Function',
+        {
+          Role: 'arn:aws:iam::123456789012:role/exec',
+          // VpcConfig intentionally absent.
+        },
+        {
+          Role: 'arn:aws:iam::123456789012:role/exec',
+          VpcConfig: {
+            SubnetIds: ['subnet-old'],
+            SecurityGroupIds: ['sg-old'],
+          },
+        }
+      );
+
+      const cmd = mockLambdaSend.mock.calls[0][0];
+      expect(cmd).toBeInstanceOf(UpdateFunctionConfigurationCommand);
+      expect(cmd.input.VpcConfig).toEqual({
+        SubnetIds: [],
+        SecurityGroupIds: [],
+      });
+    });
+
+    it('does not send VpcConfig at all when neither previous nor new has VpcConfig', async () => {
+      // Force a config update by changing Timeout, then verify the input
+      // does not include a synthetic empty VpcConfig.
+      mockLambdaSend
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({
+          Configuration: {
+            FunctionName: 'fn-no-vpc',
+            FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:fn-no-vpc',
+          },
+        });
+
+      await provider.update(
+        'NoVpcFn',
+        'fn-no-vpc',
+        'AWS::Lambda::Function',
+        {
+          Role: 'arn:aws:iam::123456789012:role/exec',
+          Timeout: 30,
+        },
+        {
+          Role: 'arn:aws:iam::123456789012:role/exec',
+          Timeout: 10,
+        }
+      );
+
+      const cmd = mockLambdaSend.mock.calls[0][0];
+      expect(cmd).toBeInstanceOf(UpdateFunctionConfigurationCommand);
+      expect(cmd.input.VpcConfig).toBeUndefined();
+    });
   });
 
   describe('delete', () => {
@@ -239,6 +308,29 @@ describe('LambdaFunctionProvider', () => {
       await promise;
 
       // Only one poll needed because the matched ENI does not belong to fn-vpc.
+      expect(mockEc2Send).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects ENIs where the function name appears only as a non-hyphen-bounded prefix', async () => {
+      // For function "fn", an ENI for "myfn" must not be counted: the
+      // function-name token in the Description is hyphen-bounded, so
+      // "myfn" (preceded by "y") is correctly excluded.
+      mockLambdaSend.mockResolvedValueOnce({});
+
+      mockEc2Send.mockResolvedValueOnce({
+        NetworkInterfaces: [
+          {
+            NetworkInterfaceId: 'eni-myfn',
+            Description: 'AWS Lambda VPC ENI-myfn-abc123',
+          },
+        ],
+      });
+
+      await provider.delete('Fn', 'fn', 'AWS::Lambda::Function', {
+        VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
+      });
+
+      // Single poll exits immediately because no ENI matches.
       expect(mockEc2Send).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
## Summary
Two correlated changes for VPC-attached Lambda functions:

- **`VpcConfig` in `handledProperties`** to avoid CC API fallback (`SDK provider does not handle [VpcConfig]`).
- **ENI detach wait on `delete`**: poll `DescribeNetworkInterfaces` (filtered by `requester-id=*:awslambda_*`, function-name token matched as a hyphen-bounded substring) until ENIs are detached or 10-minute soft timeout. Without this, downstream Subnet/SG deletion fails with `has dependencies`/`has a dependent object` while the function's hyperplane ENIs are still attached.
- **VPC detach on `update`**: explicitly send `{SubnetIds: [], SecurityGroupIds: []}` when previous properties had a VpcConfig and the new ones don't. `UpdateFunctionConfiguration` treats an omitted VpcConfig as no-change, so this is required to actually detach.

## Test plan
- [x] 14 unit tests: ENI poll/timeout/pagination/transient-error, VPC detach round-trip, hyphen-bounded matcher rejects `myfn` for function `fn`
- [ ] Integration: `bench-cdk-sample` (after merging W2/W3/W4 too)