### PR TITLE
fix(deploy): force Subnet/SG to wait for Lambda::Function on delete

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2022,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-  "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2022,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,8 @@ registry.register('AWS::IAM::Role', new IAMRoleProvider());
 - Builds DAG with graphlib
 - Determines execution order with topological sort
 - **Implicit edge for Custom Resources**: any `AWS::IAM::Policy` / `AWS::IAM::RolePolicy` / `AWS::IAM::ManagedPolicy` attached to a Custom Resource's ServiceToken Lambda execution role automatically gets an edge to the Custom Resource, preventing the handler from being invoked before inline policy attachment returns (avoids mid-deploy AccessDenied race)
+- **Implicit edge for Lambda VpcConfig**: every `AWS::EC2::Subnet` / `AWS::EC2::SecurityGroup` referenced by a Lambda's `Properties.VpcConfig.SubnetIds` / `SecurityGroupIds` gets an explicit edge to the Lambda (`src/analyzer/lambda-vpc-deps.ts`). Defense-in-depth on top of `extractDependencies`; for the reversed deletion traversal this guarantees Lambda is removed before its Subnet/SG so the asynchronous ENI detach has time to complete before EC2 rejects the subnet/SG delete with `DependencyViolation`.
+- **Type-based deletion ordering rules**: `src/analyzer/implicit-delete-deps.ts` centralizes type-pair rules (e.g. VPC after Subnet, Subnet after Lambda) shared by the deploy DELETE phase and the standalone destroy command.
 
 ## Testing Strategy
 
@@ -350,6 +352,7 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 - ✅ CC API null value stripping + JSON string properties (EventPattern)
 - ✅ CC API ClientToken removed (caches failure results, incompatible with retry)
 - ✅ Implicit delete dependencies for VPC/IGW/EventBus/Subnet/RouteTable
+- ✅ Implicit delete dependency: Subnet/SecurityGroup must be deleted AFTER Lambda::Function (avoids Lambda VpcConfig ENI detach race in DependencyViolation)
 - ✅ CloudFront OAI S3CanonicalUserId enrichment
 - ✅ DynamoDB StreamArn enrichment via DescribeTable
 - ✅ API Gateway RootResourceId enrichment via GetRestApi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,6 +234,7 @@ buildDAG(resources: ParsedResource[]): ResourceDAG
 - `Ref` function (`{ "Ref": "LogicalId" }`)
 - `Fn::GetAtt` function (`{ "Fn::GetAtt": ["LogicalId", "Attribute"] }`)
 - **Implicit edges for Custom Resources**: `AWS::IAM::Policy` / `AWS::IAM::RolePolicy` / `AWS::IAM::ManagedPolicy` resources attached to a Custom Resource's ServiceToken Lambda execution role get an automatic edge to the Custom Resource itself, so the handler can't be invoked before the inline policy attachment has returned (avoids AccessDenied during deploy)
+- **Implicit edges for Lambda VpcConfig**: every `AWS::EC2::Subnet` / `AWS::EC2::SecurityGroup` referenced by an `AWS::Lambda::Function` `VpcConfig.SubnetIds` / `SecurityGroupIds` gets an explicit edge to the Lambda. For DELETE-time reverse traversal this guarantees the Lambda is removed before its Subnets/SGs so the asynchronous ENI detach has time to complete before EC2 rejects the subnet/SG delete with `DependencyViolation`. Implemented via `extractLambdaVpcDeleteDeps` in `src/analyzer/lambda-vpc-deps.ts`.
 
 **Determining Parallel Execution Levels**:
 
@@ -659,6 +660,10 @@ getClient<T>(ClientClass: new (...) => T, region: string): T
 │ - Get State             │
 │ - Rebuild DAG from      │
 │   state.dependencies    │
+│ - Apply implicit type-  │
+│   based delete deps     │
+│   (analyzer/implicit-   │
+│    delete-deps.ts)      │
 └────────┬────────────────┘
          │
          ▼

--- a/src/analyzer/dag-builder.ts
+++ b/src/analyzer/dag-builder.ts
@@ -1,6 +1,7 @@
 import graphlib from 'graphlib';
 import type { CloudFormationTemplate, TemplateResource } from '../types/resource.js';
 import { TemplateParser } from './template-parser.js';
+import { extractLambdaVpcDeleteDeps } from './lambda-vpc-deps.js';
 import { getLogger } from '../utils/logger.js';
 import { DependencyError } from '../utils/error-handler.js';
 
@@ -79,6 +80,14 @@ export class DagBuilder {
     // edge the Custom Resource can run before the policy attachment API returns, so
     // the handler hits AccessDenied in the middle of deploy.
     edgeCount += this.addCustomResourcePolicyEdges(graph, template);
+
+    // Defense-in-depth edges for AWS::Lambda::Function VpcConfig: even though
+    // Refs in `Properties.VpcConfig.SubnetIds` / `SecurityGroupIds` are
+    // already picked up by extractDependencies (and so will produce edges in
+    // the loop above), an explicit pass guards against future regressions in
+    // the recursive extractor and makes the Lambda-vs-VPC ordering visible
+    // in the DAG even when those properties are wrapped in unusual shapes.
+    edgeCount += this.addLambdaVpcEdges(graph, template);
 
     // Validate graph is acyclic
     if (!alg.isAcyclic(graph)) {
@@ -304,6 +313,45 @@ export class DagBuilder {
 
     if (added > 0) {
       this.logger.debug(`Added ${added} implicit edges for custom resource policies`);
+    }
+    return added;
+  }
+
+  /**
+   * Add edges from Subnets / SecurityGroups referenced by an
+   * AWS::Lambda::Function VpcConfig to the Lambda itself.
+   *
+   * Same direction as a normal `Ref`-derived edge (Subnet -> Lambda), so for
+   * deploy this just duplicates what extractDependencies already produced.
+   * The point is robustness: if a future template massages the VpcConfig
+   * shape in a way the recursive extractor doesn't anticipate, this pass
+   * still ties the Lambda to its networking resources so that the
+   * deletion-time reverse traversal continues to delete Lambda before
+   * Subnet / SecurityGroup.
+   *
+   * Returns the number of NEW edges added (existing edges are skipped).
+   */
+  private addLambdaVpcEdges(graph: GraphType, template: CloudFormationTemplate): number {
+    const edges = extractLambdaVpcDeleteDeps(template.Resources);
+    if (edges.length === 0) return 0;
+
+    let added = 0;
+    for (const edge of edges) {
+      // edge: { before: lambdaId, after: vpcResourceId }
+      // Edge convention: setEdge(depId, dependentId) means dependentId
+      // depends on depId. The Lambda depends on the Subnet / SG, so
+      // depId = vpcResourceId (after), dependentId = lambdaId (before).
+      const depId = edge.after;
+      const dependentId = edge.before;
+      if (!graph.hasNode(depId) || !graph.hasNode(dependentId)) continue;
+      if (graph.hasEdge(depId, dependentId)) continue;
+      graph.setEdge(depId, dependentId);
+      added++;
+      this.logger.debug(`Added implicit edge (lambda vpc): ${depId} -> ${dependentId}`);
+    }
+
+    if (added > 0) {
+      this.logger.debug(`Added ${added} implicit edges for Lambda VpcConfig`);
     }
     return added;
   }

--- a/src/analyzer/implicit-delete-deps.ts
+++ b/src/analyzer/implicit-delete-deps.ts
@@ -1,0 +1,64 @@
+/**
+ * Type-based implicit deletion dependency rules.
+ *
+ * CloudFormation expresses creation order via Ref / Fn::GetAtt / DependsOn.
+ * For deletion, AWS additionally enforces ordering rules that aren't visible
+ * in those references — for example, an InternetGateway can't be deleted
+ * while it's still attached to a VPC, even though the attachment Ref's the
+ * IGW (not the other way around). This module centralizes those type-based
+ * rules so that both the deploy engine (DELETE phase) and the destroy
+ * command apply the same ordering.
+ *
+ * Each entry maps `KEY` → list of types that must be deleted BEFORE the
+ * KEY type. Reading example:
+ *
+ *   'AWS::EC2::Subnet': ['AWS::Lambda::Function']
+ *
+ * = "every Subnet in this stack must be deleted AFTER every Lambda in
+ *    this stack" — required because Lambda's VpcConfig leaves an ENI in
+ *    the subnet for some time after the function is deleted, and tearing
+ *    the subnet down first triggers a DependencyViolation.
+ */
+export const IMPLICIT_DELETE_DEPENDENCIES: Record<string, readonly string[]> = {
+  // IGW must be deleted AFTER VPCGatewayAttachment
+  'AWS::EC2::InternetGateway': ['AWS::EC2::VPCGatewayAttachment'],
+
+  // EventBus must be deleted AFTER Rules on that bus
+  'AWS::Events::EventBus': ['AWS::Events::Rule'],
+
+  // Athena workgroup must be deleted AFTER its named queries
+  'AWS::Athena::WorkGroup': ['AWS::Athena::NamedQuery'],
+
+  // CloudFront managed-policy-style resources must be deleted AFTER
+  // any Distribution that references them
+  'AWS::CloudFront::ResponseHeadersPolicy': ['AWS::CloudFront::Distribution'],
+  'AWS::CloudFront::CachePolicy': ['AWS::CloudFront::Distribution'],
+  'AWS::CloudFront::OriginAccessControl': ['AWS::CloudFront::Distribution'],
+
+  // VPC must be deleted AFTER all VPC-dependent resources
+  'AWS::EC2::VPC': [
+    'AWS::EC2::Subnet',
+    'AWS::EC2::SecurityGroup',
+    'AWS::EC2::InternetGateway',
+    'AWS::EC2::EgressOnlyInternetGateway',
+    'AWS::EC2::VPCGatewayAttachment',
+    'AWS::EC2::RouteTable',
+  ],
+
+  // Subnet must be deleted AFTER any Lambda that may still hold an ENI
+  // in it. Lambda DELETE returns immediately but the ENI is detached
+  // asynchronously by AWS, so deleting the Subnet first races the detach
+  // and yields "DependencyViolation".
+  'AWS::EC2::Subnet': ['AWS::EC2::SubnetRouteTableAssociation', 'AWS::Lambda::Function'],
+
+  // RouteTable must be deleted AFTER Route and Association
+  'AWS::EC2::RouteTable': ['AWS::EC2::Route', 'AWS::EC2::SubnetRouteTableAssociation'],
+
+  // SecurityGroup must be deleted AFTER any Lambda whose ENI is bound
+  // to it (same ENI-detach race as Subnet above).
+  'AWS::EC2::SecurityGroup': [
+    'AWS::EC2::SecurityGroupIngress',
+    'AWS::EC2::SecurityGroupEgress',
+    'AWS::Lambda::Function',
+  ],
+};

--- a/src/analyzer/lambda-vpc-deps.ts
+++ b/src/analyzer/lambda-vpc-deps.ts
@@ -1,0 +1,118 @@
+/**
+ * Lambda VpcConfig implicit deletion dependencies.
+ *
+ * AWS::Lambda::Function with a VpcConfig holds onto an ENI in the configured
+ * subnets / security groups for some time AFTER the function is deleted.
+ * If we tear down the VPC's Subnets / SecurityGroups before the ENI is fully
+ * detached, the EC2 API rejects the delete with "has dependencies" /
+ * "DependencyViolation".
+ *
+ * The Ref-based dependency expressed by `VpcConfig.SubnetIds: [{ Ref: ... }]`
+ * is normally captured by `TemplateParser.extractDependencies` and recorded
+ * in `state.dependencies`, which already gives the correct teardown order.
+ * This module provides a defense-in-depth, property-based extractor so the
+ * ordering still holds when:
+ *   - state was written by an older cdkd version that did not record the dep
+ *   - extractDependencies misses a wrapping intrinsic for some reason
+ *
+ * The returned edges express: "the Lambda must be deleted BEFORE each
+ * referenced Subnet / SecurityGroup".
+ */
+import type { TemplateResource } from '../types/resource.js';
+
+/** A single dependency edge for the DELETE phase. */
+export interface DeleteDepEdge {
+  /** Logical ID that must be deleted FIRST. */
+  before: string;
+  /** Logical ID that must be deleted AFTER `before`. */
+  after: string;
+}
+
+/**
+ * Minimal shape used by extractLambdaVpcDeleteDeps: a logical-ID-keyed map of
+ * resources where each entry exposes a CloudFormation-style `Type` and
+ * `Properties`. Both `TemplateResource` and the ad-hoc per-stack template
+ * built in destroy.ts conform to this.
+ */
+export type ResourceLike = Pick<TemplateResource, 'Type' | 'Properties'>;
+
+/**
+ * Extract implicit delete edges for AWS::Lambda::Function with a VpcConfig.
+ *
+ * For each Lambda function in the input map, scans
+ * `Properties.VpcConfig.SubnetIds` and `Properties.VpcConfig.SecurityGroupIds`
+ * for `{ Ref: <logicalId> }` / `{ "Fn::GetAtt": [<logicalId>, ...] }`
+ * references. Every referenced ID that exists in the input map produces an
+ * edge `{ before: <lambdaId>, after: <targetId> }`.
+ *
+ * Notes:
+ *  - Properties already resolved to physical IDs (state.properties after
+ *    deploy) yield no edges. That is intentional — in that case the caller
+ *    should rely on `state.dependencies`, which preserves logical IDs.
+ *  - Self-edges and edges pointing to absent IDs are filtered out.
+ *  - Returned edges are de-duplicated.
+ */
+export function extractLambdaVpcDeleteDeps(
+  resources: Record<string, ResourceLike>
+): DeleteDepEdge[] {
+  const edges: DeleteDepEdge[] = [];
+  const seen = new Set<string>();
+
+  for (const [lambdaId, resource] of Object.entries(resources)) {
+    if (resource.Type !== 'AWS::Lambda::Function') continue;
+
+    const vpcConfig = (resource.Properties ?? {})['VpcConfig'];
+    if (!isObject(vpcConfig)) continue;
+
+    const targets = new Set<string>();
+    collectRefIds(vpcConfig['SubnetIds'], targets);
+    collectRefIds(vpcConfig['SecurityGroupIds'], targets);
+
+    for (const targetId of targets) {
+      if (targetId === lambdaId) continue;
+      if (!(targetId in resources)) continue;
+      const key = `${lambdaId}\u0000${targetId}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      edges.push({ before: lambdaId, after: targetId });
+    }
+  }
+
+  return edges;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Walk `value` (typically an array) and collect every logical ID referenced
+ * via `{ Ref: ... }` or `{ "Fn::GetAtt": [<id>, ...] }`. Pseudo parameters
+ * (Refs starting with `AWS::`) are skipped.
+ */
+function collectRefIds(value: unknown, out: Set<string>): void {
+  if (value === null || value === undefined) return;
+
+  if (Array.isArray(value)) {
+    for (const item of value) collectRefIds(item, out);
+    return;
+  }
+
+  if (!isObject(value)) return;
+
+  if (typeof value['Ref'] === 'string') {
+    const ref = value['Ref'];
+    if (!ref.startsWith('AWS::')) out.add(ref);
+    return;
+  }
+
+  if (Array.isArray(value['Fn::GetAtt'])) {
+    const arr = value['Fn::GetAtt'];
+    if (typeof arr[0] === 'string') out.add(arr[0]);
+    return;
+  }
+
+  // Other intrinsics (Fn::Join, Fn::If, ...) cannot be statically resolved
+  // without a full IntrinsicResolver pass; the regular extractDependencies
+  // path handles those at deploy time.
+}

--- a/src/cli/commands/destroy.ts
+++ b/src/cli/commands/destroy.ts
@@ -14,6 +14,7 @@ import { Synthesizer } from '../../synthesis/synthesizer.js';
 import { S3StateBackend } from '../../state/s3-state-backend.js';
 import { LockManager } from '../../state/lock-manager.js';
 import { DagBuilder } from '../../analyzer/dag-builder.js';
+import { IMPLICIT_DELETE_DEPENDENCIES } from '../../analyzer/implicit-delete-deps.js';
 import { ProviderRegistry } from '../../provisioning/provider-registry.js';
 import { registerAllProviders } from '../../provisioning/register-providers.js';
 import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
@@ -250,28 +251,8 @@ async function destroyCommand(
           };
         }
 
-        // Add implicit dependencies for correct deletion order.
-        const implicitDeleteDeps: Record<string, string[]> = {
-          'AWS::EC2::InternetGateway': ['AWS::EC2::VPCGatewayAttachment'],
-          'AWS::Events::EventBus': ['AWS::Events::Rule'],
-          'AWS::Athena::WorkGroup': ['AWS::Athena::NamedQuery'],
-          'AWS::CloudFront::ResponseHeadersPolicy': ['AWS::CloudFront::Distribution'],
-          'AWS::CloudFront::CachePolicy': ['AWS::CloudFront::Distribution'],
-          'AWS::CloudFront::OriginAccessControl': ['AWS::CloudFront::Distribution'],
-          'AWS::EC2::VPC': [
-            'AWS::EC2::Subnet',
-            'AWS::EC2::SecurityGroup',
-            'AWS::EC2::InternetGateway',
-            'AWS::EC2::VPCGatewayAttachment',
-            'AWS::EC2::RouteTable',
-          ],
-          'AWS::EC2::Subnet': ['AWS::EC2::SubnetRouteTableAssociation'],
-          'AWS::EC2::RouteTable': ['AWS::EC2::Route', 'AWS::EC2::SubnetRouteTableAssociation'],
-          'AWS::EC2::SecurityGroup': [
-            'AWS::EC2::SecurityGroupIngress',
-            'AWS::EC2::SecurityGroupEgress',
-          ],
-        };
+        // Type-based implicit deletion ordering rules are shared with the
+        // deploy DELETE phase (src/analyzer/implicit-delete-deps.ts).
 
         // Build type → logicalId index
         const typeToLogicalIds = new Map<string, string[]>();
@@ -282,7 +263,7 @@ async function destroyCommand(
         }
 
         for (const [logicalId, resource] of Object.entries(currentState.resources)) {
-          const mustDeleteAfter = implicitDeleteDeps[resource.resourceType];
+          const mustDeleteAfter = IMPLICIT_DELETE_DEPENDENCIES[resource.resourceType];
           if (!mustDeleteAfter) continue;
 
           for (const depType of mustDeleteAfter) {

--- a/src/deployment/deploy-engine.ts
+++ b/src/deployment/deploy-engine.ts
@@ -12,6 +12,7 @@ import type { DiffCalculator } from '../analyzer/diff-calculator.js';
 import { ProviderRegistry } from '../provisioning/provider-registry.js';
 import { CloudControlProvider } from '../provisioning/cloud-control-provider.js';
 import { TemplateParser } from '../analyzer/template-parser.js';
+import { IMPLICIT_DELETE_DEPENDENCIES } from '../analyzer/implicit-delete-deps.js';
 
 /**
  * Completed operation record for rollback tracking
@@ -1190,36 +1191,9 @@ export class DeployEngine {
     return deps.size > 0 ? [...deps] : undefined;
   }
 
-  /**
-   * Implicit dependency map for correct deletion order.
-   *
-   * Key = resource type that must be deleted AFTER all value types are deleted.
-   * Value = resource types that must be deleted BEFORE the key type.
-   *
-   * Example: InternetGateway depends on VPCGatewayAttachment being deleted first,
-   * because AWS won't let you delete an IGW while it's still attached to a VPC.
-   */
-  private static readonly IMPLICIT_DELETE_DEPENDENCIES: Record<string, string[]> = {
-    // IGW must be deleted AFTER VPCGatewayAttachment
-    'AWS::EC2::InternetGateway': ['AWS::EC2::VPCGatewayAttachment'],
-    // EventBus must be deleted AFTER Rules on that bus
-    'AWS::Events::EventBus': ['AWS::Events::Rule'],
-    // VPC must be deleted AFTER all VPC-dependent resources
-    'AWS::EC2::VPC': [
-      'AWS::EC2::Subnet',
-      'AWS::EC2::SecurityGroup',
-      'AWS::EC2::InternetGateway',
-      'AWS::EC2::EgressOnlyInternetGateway',
-      'AWS::EC2::VPCGatewayAttachment',
-      'AWS::EC2::RouteTable',
-    ],
-    // Subnet must be deleted AFTER RouteTableAssociation
-    'AWS::EC2::Subnet': ['AWS::EC2::SubnetRouteTableAssociation'],
-    // RouteTable must be deleted AFTER Route and Association
-    'AWS::EC2::RouteTable': ['AWS::EC2::Route', 'AWS::EC2::SubnetRouteTableAssociation'],
-    // SecurityGroup must be deleted AFTER SecurityGroupIngress/Egress
-    'AWS::EC2::SecurityGroup': ['AWS::EC2::SecurityGroupIngress', 'AWS::EC2::SecurityGroupEgress'],
-  };
+  // Type-based implicit deletion ordering rules are defined in
+  // src/analyzer/implicit-delete-deps.ts so the deploy DELETE phase and the
+  // standalone destroy command apply the same rules.
 
   /**
    * Build a per-resource map of "must be deleted before me" dependencies for
@@ -1297,7 +1271,7 @@ export class DeployEngine {
       const resource = state.resources[id];
       if (!resource) continue;
 
-      const mustDeleteAfter = DeployEngine.IMPLICIT_DELETE_DEPENDENCIES[resource.resourceType];
+      const mustDeleteAfter = IMPLICIT_DELETE_DEPENDENCIES[resource.resourceType];
       if (!mustDeleteAfter) continue;
 
       for (const depType of mustDeleteAfter) {

--- a/tests/unit/analyzer/dag-builder.test.ts
+++ b/tests/unit/analyzer/dag-builder.test.ts
@@ -774,4 +774,73 @@ describe('DagBuilder', () => {
       expect(deps.filter((d) => d === 'SeederRoleDefaultPolicy')).toHaveLength(1);
     });
   });
+
+  describe('addLambdaVpcEdges', () => {
+    it('adds Subnet -> Lambda and SecurityGroup -> Lambda edges from VpcConfig', () => {
+      const template: CloudFormationTemplate = {
+        Resources: {
+          SubnetA: { Type: 'AWS::EC2::Subnet', Properties: {} },
+          SgA: { Type: 'AWS::EC2::SecurityGroup', Properties: {} },
+          Fn: {
+            Type: 'AWS::Lambda::Function',
+            Properties: {
+              VpcConfig: {
+                SubnetIds: [{ Ref: 'SubnetA' }],
+                SecurityGroupIds: [{ Ref: 'SgA' }],
+              },
+            },
+          },
+        },
+      };
+
+      const graph = dagBuilder.buildGraph(template);
+
+      expect(graph.hasEdge('SubnetA', 'Fn')).toBe(true);
+      expect(graph.hasEdge('SgA', 'Fn')).toBe(true);
+
+      // Lambda must come after Subnet/SG in execution order, which means
+      // for the reversed deletion traversal Lambda is removed BEFORE
+      // Subnet/SG — exactly what we need to wait for ENI detach.
+      const lambdaDeps = dagBuilder.getDirectDependencies(graph, 'Fn');
+      expect(lambdaDeps).toContain('SubnetA');
+      expect(lambdaDeps).toContain('SgA');
+    });
+
+    it('does not duplicate edges already added by Ref extraction', () => {
+      const template: CloudFormationTemplate = {
+        Resources: {
+          SubnetA: { Type: 'AWS::EC2::Subnet', Properties: {} },
+          Fn: {
+            Type: 'AWS::Lambda::Function',
+            Properties: {
+              VpcConfig: { SubnetIds: [{ Ref: 'SubnetA' }] },
+            },
+          },
+        },
+      };
+
+      const graph = dagBuilder.buildGraph(template);
+      // Only one edge from SubnetA to Fn (Ref extraction + implicit pass
+      // converge on the same edge, no double-count).
+      const subnetSuccessors = graph.successors('SubnetA') ?? [];
+      expect(subnetSuccessors.filter((id) => id === 'Fn')).toHaveLength(1);
+    });
+
+    it('is a no-op for Lambda without VpcConfig', () => {
+      const template: CloudFormationTemplate = {
+        Resources: {
+          Role: { Type: 'AWS::IAM::Role', Properties: {} },
+          Fn: {
+            Type: 'AWS::Lambda::Function',
+            Properties: { Role: { 'Fn::GetAtt': ['Role', 'Arn'] } },
+          },
+        },
+      };
+
+      const graph = dagBuilder.buildGraph(template);
+      // Only the Role -> Fn edge from Fn::GetAtt; no VPC-related edges.
+      expect(graph.edgeCount()).toBe(1);
+      expect(graph.hasEdge('Role', 'Fn')).toBe(true);
+    });
+  });
 });

--- a/tests/unit/analyzer/implicit-delete-deps.test.ts
+++ b/tests/unit/analyzer/implicit-delete-deps.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { IMPLICIT_DELETE_DEPENDENCIES } from '../../../src/analyzer/implicit-delete-deps.js';
+
+describe('IMPLICIT_DELETE_DEPENDENCIES', () => {
+  it('Subnet must be deleted after Lambda::Function (ENI detach race)', () => {
+    expect(IMPLICIT_DELETE_DEPENDENCIES['AWS::EC2::Subnet']).toContain(
+      'AWS::Lambda::Function'
+    );
+  });
+
+  it('SecurityGroup must be deleted after Lambda::Function (ENI detach race)', () => {
+    expect(IMPLICIT_DELETE_DEPENDENCIES['AWS::EC2::SecurityGroup']).toContain(
+      'AWS::Lambda::Function'
+    );
+  });
+
+  it('VPC must be deleted after every VPC-attached resource type', () => {
+    const deps = IMPLICIT_DELETE_DEPENDENCIES['AWS::EC2::VPC'] ?? [];
+    expect(deps).toEqual(
+      expect.arrayContaining([
+        'AWS::EC2::Subnet',
+        'AWS::EC2::SecurityGroup',
+        'AWS::EC2::InternetGateway',
+        'AWS::EC2::EgressOnlyInternetGateway',
+        'AWS::EC2::VPCGatewayAttachment',
+        'AWS::EC2::RouteTable',
+      ])
+    );
+  });
+
+  it('IGW must be deleted after VPCGatewayAttachment', () => {
+    expect(IMPLICIT_DELETE_DEPENDENCIES['AWS::EC2::InternetGateway']).toContain(
+      'AWS::EC2::VPCGatewayAttachment'
+    );
+  });
+
+  it('CloudFront OAC must be deleted after Distribution', () => {
+    expect(
+      IMPLICIT_DELETE_DEPENDENCIES['AWS::CloudFront::OriginAccessControl']
+    ).toContain('AWS::CloudFront::Distribution');
+  });
+
+  it('Subnet still requires SubnetRouteTableAssociation to be deleted first', () => {
+    // Pre-existing rule must not regress when adding the Lambda dep.
+    expect(IMPLICIT_DELETE_DEPENDENCIES['AWS::EC2::Subnet']).toContain(
+      'AWS::EC2::SubnetRouteTableAssociation'
+    );
+  });
+
+  it('SecurityGroup still requires Ingress/Egress to be deleted first', () => {
+    const deps = IMPLICIT_DELETE_DEPENDENCIES['AWS::EC2::SecurityGroup'] ?? [];
+    expect(deps).toContain('AWS::EC2::SecurityGroupIngress');
+    expect(deps).toContain('AWS::EC2::SecurityGroupEgress');
+  });
+
+  it('does not introduce a self-cycle for any type', () => {
+    for (const [key, values] of Object.entries(IMPLICIT_DELETE_DEPENDENCIES)) {
+      expect(values).not.toContain(key);
+    }
+  });
+});

--- a/tests/unit/analyzer/lambda-vpc-deps.test.ts
+++ b/tests/unit/analyzer/lambda-vpc-deps.test.ts
@@ -188,7 +188,12 @@ describe('extractLambdaVpcDeleteDeps', () => {
     expect(edges).toHaveLength(2);
   });
 
-  it('ignores non-array SubnetIds / SecurityGroupIds gracefully', () => {
+  it('walks any-shape SubnetIds / SecurityGroupIds (intentional defensive walking)', () => {
+    // CloudFormation specifies VpcConfig.SubnetIds / SecurityGroupIds as List,
+    // so a non-array value is technically invalid input. The extractor still
+    // walks any object value defensively — a single Ref object is collected
+    // when its target exists. Here the target does not exist as a logical ID,
+    // and the scalar string value yields nothing, so we expect zero edges.
     const resources: Record<string, ResourceLike> = {
       Fn: {
         Type: 'AWS::Lambda::Function',
@@ -200,9 +205,75 @@ describe('extractLambdaVpcDeleteDeps', () => {
         },
       },
     };
-    // The extractor walks any object value, so a single Ref object is still
-    // collected — but only if the target exists. Here the target does not
-    // exist as a logical ID, so we expect zero edges.
     expect(extractLambdaVpcDeleteDeps(resources)).toEqual([]);
+  });
+
+  it('walks a single Ref object (non-array) and emits an edge when the target exists', () => {
+    // Sibling of the previous test: when the malformed (non-array) Ref points
+    // at an existing logical ID, the defensive walk DOES collect it. This
+    // pins down the current behavior so future refactors do not silently
+    // change it.
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SubnetIds: { Ref: 'SubnetA' },
+          },
+        },
+      },
+      SubnetA: { Type: 'AWS::EC2::Subnet', Properties: {} },
+    };
+    expect(extractLambdaVpcDeleteDeps(resources)).toEqual([
+      { before: 'Fn', after: 'SubnetA' },
+    ]);
+  });
+
+  it('returns no edges when SubnetIds is an empty array', () => {
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SubnetIds: [],
+          },
+        },
+      },
+    };
+    expect(extractLambdaVpcDeleteDeps(resources)).toEqual([]);
+  });
+
+  it('extracts edges from SecurityGroupIds only when SubnetIds is absent', () => {
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SecurityGroupIds: [{ Ref: 'SgOnly' }],
+          },
+        },
+      },
+      SgOnly: { Type: 'AWS::EC2::SecurityGroup', Properties: {} },
+    };
+    expect(extractLambdaVpcDeleteDeps(resources)).toEqual([
+      { before: 'Fn', after: 'SgOnly' },
+    ]);
+  });
+
+  it('extracts edges from SubnetIds only when SecurityGroupIds is absent', () => {
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SubnetIds: [{ Ref: 'SubnetOnly' }],
+          },
+        },
+      },
+      SubnetOnly: { Type: 'AWS::EC2::Subnet', Properties: {} },
+    };
+    expect(extractLambdaVpcDeleteDeps(resources)).toEqual([
+      { before: 'Fn', after: 'SubnetOnly' },
+    ]);
   });
 });

--- a/tests/unit/analyzer/lambda-vpc-deps.test.ts
+++ b/tests/unit/analyzer/lambda-vpc-deps.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractLambdaVpcDeleteDeps,
+  type ResourceLike,
+} from '../../../src/analyzer/lambda-vpc-deps.js';
+
+describe('extractLambdaVpcDeleteDeps', () => {
+  it('returns no edges when there are no Lambda functions', () => {
+    const resources: Record<string, ResourceLike> = {
+      Bucket: { Type: 'AWS::S3::Bucket', Properties: {} },
+    };
+    expect(extractLambdaVpcDeleteDeps(resources)).toEqual([]);
+  });
+
+  it('returns no edges for Lambda without VpcConfig', () => {
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: { Role: { 'Fn::GetAtt': ['Role', 'Arn'] } },
+      },
+      Role: { Type: 'AWS::IAM::Role', Properties: {} },
+    };
+    expect(extractLambdaVpcDeleteDeps(resources)).toEqual([]);
+  });
+
+  it('extracts edges from VpcConfig.SubnetIds Refs', () => {
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SubnetIds: [{ Ref: 'SubnetA' }, { Ref: 'SubnetB' }],
+          },
+        },
+      },
+      SubnetA: { Type: 'AWS::EC2::Subnet', Properties: {} },
+      SubnetB: { Type: 'AWS::EC2::Subnet', Properties: {} },
+    };
+
+    const edges = extractLambdaVpcDeleteDeps(resources);
+    expect(edges).toEqual([
+      { before: 'Fn', after: 'SubnetA' },
+      { before: 'Fn', after: 'SubnetB' },
+    ]);
+  });
+
+  it('extracts edges from VpcConfig.SecurityGroupIds via Ref and Fn::GetAtt', () => {
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SecurityGroupIds: [
+              { Ref: 'SgA' },
+              { 'Fn::GetAtt': ['SgB', 'GroupId'] },
+            ],
+          },
+        },
+      },
+      SgA: { Type: 'AWS::EC2::SecurityGroup', Properties: {} },
+      SgB: { Type: 'AWS::EC2::SecurityGroup', Properties: {} },
+    };
+
+    const edges = extractLambdaVpcDeleteDeps(resources);
+    expect(edges).toEqual([
+      { before: 'Fn', after: 'SgA' },
+      { before: 'Fn', after: 'SgB' },
+    ]);
+  });
+
+  it('combines SubnetIds and SecurityGroupIds in a single VpcConfig', () => {
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SubnetIds: [{ Ref: 'Subnet1' }],
+            SecurityGroupIds: [{ Ref: 'Sg1' }],
+          },
+        },
+      },
+      Subnet1: { Type: 'AWS::EC2::Subnet', Properties: {} },
+      Sg1: { Type: 'AWS::EC2::SecurityGroup', Properties: {} },
+    };
+
+    const edges = extractLambdaVpcDeleteDeps(resources);
+    const targets = edges.map((e) => e.after).sort();
+    expect(targets).toEqual(['Sg1', 'Subnet1']);
+    expect(edges.every((e) => e.before === 'Fn')).toBe(true);
+  });
+
+  it('skips refs to logical IDs that are not in the resource map', () => {
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SubnetIds: [{ Ref: 'MissingSubnet' }],
+          },
+        },
+      },
+    };
+    expect(extractLambdaVpcDeleteDeps(resources)).toEqual([]);
+  });
+
+  it('skips pseudo parameters (Refs starting with AWS::)', () => {
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SubnetIds: [{ Ref: 'AWS::Region' }],
+          },
+        },
+      },
+    };
+    expect(extractLambdaVpcDeleteDeps(resources)).toEqual([]);
+  });
+
+  it('skips resolved physical IDs (no Ref / Fn::GetAtt wrapper)', () => {
+    // After deploy, VpcConfig.SubnetIds is a flat array of physical subnet
+    // IDs. The extractor should produce zero edges in that case — the
+    // caller is expected to fall back to state.dependencies.
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SubnetIds: ['subnet-0123456789abcdef0'],
+            SecurityGroupIds: ['sg-0123456789abcdef0'],
+          },
+        },
+      },
+      SubnetA: { Type: 'AWS::EC2::Subnet', Properties: {} },
+      SgA: { Type: 'AWS::EC2::SecurityGroup', Properties: {} },
+    };
+    expect(extractLambdaVpcDeleteDeps(resources)).toEqual([]);
+  });
+
+  it('de-duplicates repeated refs to the same target', () => {
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SubnetIds: [{ Ref: 'SubnetA' }, { Ref: 'SubnetA' }],
+            SecurityGroupIds: [{ Ref: 'SubnetA' }],
+          },
+        },
+      },
+      SubnetA: { Type: 'AWS::EC2::Subnet', Properties: {} },
+    };
+    const edges = extractLambdaVpcDeleteDeps(resources);
+    expect(edges).toEqual([{ before: 'Fn', after: 'SubnetA' }]);
+  });
+
+  it('filters self-edges (a Lambda referencing itself, defensive)', () => {
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SubnetIds: [{ Ref: 'Fn' }],
+          },
+        },
+      },
+    };
+    expect(extractLambdaVpcDeleteDeps(resources)).toEqual([]);
+  });
+
+  it('handles multiple Lambdas independently', () => {
+    const resources: Record<string, ResourceLike> = {
+      FnA: {
+        Type: 'AWS::Lambda::Function',
+        Properties: { VpcConfig: { SubnetIds: [{ Ref: 'Subnet1' }] } },
+      },
+      FnB: {
+        Type: 'AWS::Lambda::Function',
+        Properties: { VpcConfig: { SubnetIds: [{ Ref: 'Subnet2' }] } },
+      },
+      Subnet1: { Type: 'AWS::EC2::Subnet', Properties: {} },
+      Subnet2: { Type: 'AWS::EC2::Subnet', Properties: {} },
+    };
+
+    const edges = extractLambdaVpcDeleteDeps(resources);
+    expect(edges).toContainEqual({ before: 'FnA', after: 'Subnet1' });
+    expect(edges).toContainEqual({ before: 'FnB', after: 'Subnet2' });
+    expect(edges).toHaveLength(2);
+  });
+
+  it('ignores non-array SubnetIds / SecurityGroupIds gracefully', () => {
+    const resources: Record<string, ResourceLike> = {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          VpcConfig: {
+            SubnetIds: { Ref: 'NotAList' },
+            SecurityGroupIds: 'sg-bad',
+          },
+        },
+      },
+    };
+    // The extractor walks any object value, so a single Ref object is still
+    // collected — but only if the target exists. Here the target does not
+    // exist as a logical ID, so we expect zero edges.
+    expect(extractLambdaVpcDeleteDeps(resources)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Belt-and-suspenders for destroy ordering of VPC-attached Lambda:

- **Type-based**: extend `IMPLICIT_DELETE_DEPENDENCIES` so Subnet/SG deletes after every Lambda deletes (catches state files predating property walking).
- **Property-based**: extract `VpcConfig.SubnetIds`/`SecurityGroupIds` Refs at DAG-build time and add explicit edges (insurance against future template-parser regressions).
- Refactor: pull `IMPLICIT_DELETE_DEPENDENCIES` out of inline definitions in `destroy.ts` and `deploy-engine.ts` into a shared `src/analyzer/implicit-delete-deps.ts`.
- 23 new unit tests, plus clarified test name vs implementation in `lambda-vpc-deps.test.ts` (intentional defensive walking).

Combined with feat/lambda-vpc-config (Lambda Provider ENI wait), resolves the destroy failure pattern where Subnet/SG deletes raced ahead of Lambda hyperplane ENI detach.

## Test plan
- [x] 23 unit tests
- [ ] Integration: `bench-cdk-sample` (after merging W1/W2/W4 too)
