### PR TITLE
fix(lambda): detach VPC + actively delete ENIs before downstream cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,7 +368,7 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 - ✅ Nested cloud assembly traversal (CDK Stage support)
 - ✅ WorkGraph DAG orchestrator for asset publishing and stack deployment (build→publish→deploy pipeline)
 - ✅ Concurrency options: `--asset-publish-concurrency` (default 8), `--image-build-concurrency` (default 4)
-- ✅ Lambda VpcConfig SDK provider support (avoids CC API fallback) + ENI detach wait on delete (avoids downstream Subnet/SG "has dependencies" failures)
+- ✅ Lambda VpcConfig SDK provider support (avoids CC API fallback) + pre-delete VPC detach (UpdateFunctionConfiguration with empty arrays) + active ENI cleanup via DeleteNetworkInterface on delete (avoids downstream Subnet/SG "has dependencies" failures — `DeleteFunction` alone does not synchronously release Lambda hyperplane ENIs, AWS reclaims them only eventually)
 
 ## Dependencies
 

--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -17,7 +17,11 @@ import {
   type EphemeralStorage,
   type VpcConfig,
 } from '@aws-sdk/client-lambda';
-import { EC2Client, DescribeNetworkInterfacesCommand } from '@aws-sdk/client-ec2';
+import {
+  EC2Client,
+  DescribeNetworkInterfacesCommand,
+  DeleteNetworkInterfaceCommand,
+} from '@aws-sdk/client-ec2';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
@@ -292,6 +296,37 @@ export class LambdaFunctionProvider implements ResourceProvider {
 
     const hasVpcConfig = this.hasVpcConfig(properties?.['VpcConfig']);
 
+    // For VPC-attached functions, detach the VPC config BEFORE deletion.
+    // DeleteFunction does not synchronously release Lambda hyperplane ENIs;
+    // AWS reclaims them eventually, often well past any reasonable wait
+    // window. UpdateFunctionConfiguration with empty SubnetIds / SecurityGroupIds
+    // triggers an explicit ENI release that completes in seconds-to-minutes,
+    // letting downstream Subnet / SecurityGroup deletes proceed.
+    if (hasVpcConfig) {
+      try {
+        await this.lambdaClient.send(
+          new UpdateFunctionConfigurationCommand({
+            FunctionName: physicalId,
+            VpcConfig: { SubnetIds: [], SecurityGroupIds: [] },
+          })
+        );
+        this.logger.debug(`Detached VPC config from Lambda ${physicalId} before deletion`);
+      } catch (error) {
+        if (error instanceof ResourceNotFoundException) {
+          // Function is already gone — nothing more to do, including ENI wait
+          // (AWS owns the cleanup at this point).
+          return;
+        }
+        // Best-effort: don't fail the entire delete if pre-detach errors.
+        // The post-DeleteFunction ENI wait below remains as a safety net.
+        this.logger.warn(
+          `Pre-delete VPC detach failed for ${physicalId}: ${
+            error instanceof Error ? error.message : String(error)
+          } — continuing with delete`
+        );
+      }
+    }
+
     try {
       await this.lambdaClient.send(new DeleteFunctionCommand({ FunctionName: physicalId }));
       this.logger.debug(`Successfully deleted Lambda function ${logicalId}`);
@@ -311,7 +346,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
     }
 
     if (hasVpcConfig) {
-      await this.waitForLambdaEnisDetached(physicalId);
+      await this.cleanupLambdaEnis(physicalId);
     }
   }
 
@@ -376,68 +411,97 @@ export class LambdaFunctionProvider implements ResourceProvider {
   }
 
   /**
-   * Poll DescribeNetworkInterfaces until the Lambda-managed ENIs for the
-   * given function are gone, or the configured timeout elapses.
+   * Clean up Lambda-managed ENIs for the given function: list, then attempt
+   * DeleteNetworkInterface on each. Repeat until no matching ENIs remain
+   * or the configured timeout elapses.
    *
-   * Lambda VPC ENIs carry a Description like:
-   *   "AWS Lambda VPC ENI-<functionName>-<uuid>"
-   * We match on a substring to be tolerant of format drift.
+   * Why direct delete (not just wait): an `available` ENI still counts as a
+   * Subnet / SecurityGroup dependency, so DeleteSubnet / DeleteSecurityGroup
+   * fail until the ENI itself is gone. AWS's eventual cleanup of unused
+   * Lambda hyperplane ENIs can take well over an hour, which is far longer
+   * than any reasonable destroy budget. Calling DeleteNetworkInterface
+   * ourselves (best-effort) clears `available` ENIs in seconds.
+   *
+   * In-use ENIs (e.g. immediately after the pre-delete VPC detach) cannot
+   * be deleted yet — we swallow that error and retry on the next iteration
+   * once they transition to `available`.
+   *
+   * Lambda VPC ENI Descriptions follow the pattern
+   *   "AWS Lambda VPC ENI-<functionName>"
+   * (and historically "AWS Lambda VPC ENI-<functionName>-<uuid>"). We
+   * narrow the query with a `requester-id` filter and then match the
+   * function name as a hyphen-bounded token to avoid false positives like
+   * "myfn" matching for function "fn".
    *
    * Polling: starts at eniWaitInitialDelayMs (10s), exponential backoff up
    * to eniWaitMaxDelayMs (30s), bounded by eniWaitTimeoutMs (10min).
-   *
-   * Timeout is treated as a soft warning: detach can legitimately take 20-40
-   * minutes in degraded conditions, and downstream Subnet/SG deletion has
-   * its own retries to handle the residual window.
+   * Timeout is a soft warning — downstream Subnet/SG deletion has its own
+   * retries.
    */
-  private async waitForLambdaEnisDetached(functionName: string): Promise<void> {
+  private async cleanupLambdaEnis(functionName: string): Promise<void> {
     const start = Date.now();
     let delay = this.eniWaitInitialDelayMs;
     let attempt = 0;
 
     this.logger.debug(
-      `Waiting for Lambda VPC ENIs to detach for function ${functionName} (timeout ${this.eniWaitTimeoutMs}ms)`
+      `Cleaning up Lambda VPC ENIs for function ${functionName} (timeout ${this.eniWaitTimeoutMs}ms)`
     );
 
-    // Match the canonical Lambda ENI Description prefix and require the
-    // function name to appear as a hyphen-bounded token. This prevents a
-    // function named "fn" from matching ENIs whose function-name token has
-    // "fn" as a prefix only (e.g. "myfn"). It cannot disambiguate when one
-    // function name is itself a hyphen-prefix of another (e.g. "fn" vs
-    // "fn-foo"), which is a known limitation of the substring approach.
     const descriptionNeedle = `AWS Lambda VPC ENI`;
     const functionNamePattern = new RegExp(`(^|-)${escapeRegExp(functionName)}(-|$)`);
 
-    // Loop until either ENIs are gone or we exceed the configured timeout.
     for (;;) {
       attempt++;
-      let count: number;
+
+      let enis: { id: string; status: string }[] = [];
+      let listFailed = false;
       try {
-        count = await this.countLambdaEnis(descriptionNeedle, functionNamePattern);
+        enis = await this.listLambdaEnis(descriptionNeedle, functionNamePattern);
       } catch (error) {
-        // Don't abort delete on transient EC2 errors; warn and continue.
         this.logger.warn(
-          `DescribeNetworkInterfaces failed while waiting for Lambda ENIs of ${functionName}: ${
+          `DescribeNetworkInterfaces failed while cleaning up Lambda ENIs of ${functionName}: ${
             error instanceof Error ? error.message : String(error)
           }`
         );
-        count = -1;
+        listFailed = true;
       }
 
-      if (count === 0) {
+      // Only treat an empty list as success if we actually got it from AWS;
+      // a transient List failure must retry rather than declare cleanup done.
+      if (!listFailed && enis.length === 0) {
         this.logger.debug(
-          `Lambda ENIs for ${functionName} fully detached after ${attempt} poll(s) / ${
+          `Lambda ENIs for ${functionName} fully cleaned up after ${attempt} attempt(s) / ${
             Date.now() - start
           }ms`
         );
         return;
       }
 
+      // Best-effort delete: in-use ENIs reject and we'll retry next loop.
+      if (enis.length > 0) {
+        await Promise.all(
+          enis.map(async (eni) => {
+            try {
+              await this.ec2Client.send(
+                new DeleteNetworkInterfaceCommand({ NetworkInterfaceId: eni.id })
+              );
+              this.logger.debug(`Deleted Lambda ENI ${eni.id} for ${functionName}`);
+            } catch (error) {
+              this.logger.debug(
+                `ENI ${eni.id} (status=${eni.status}) not yet deletable: ${
+                  error instanceof Error ? error.message : String(error)
+                }`
+              );
+            }
+          })
+        );
+      }
+
       const elapsed = Date.now() - start;
       if (elapsed >= this.eniWaitTimeoutMs) {
         this.logger.warn(
-          `Timeout (${this.eniWaitTimeoutMs}ms) waiting for Lambda VPC ENIs of ${functionName} ` +
-            `to detach (remaining: ${count >= 0 ? count : 'unknown'}). ` +
+          `Timeout (${this.eniWaitTimeoutMs}ms) cleaning up Lambda VPC ENIs of ${functionName} ` +
+            `(${enis.length} remaining). ` +
             `Continuing — downstream Subnet/SG deletion will retry as needed.`
         );
         return;
@@ -451,18 +515,18 @@ export class LambdaFunctionProvider implements ResourceProvider {
   }
 
   /**
-   * Count remaining Lambda-managed ENIs for the given function, paginating
-   * through DescribeNetworkInterfaces and filtering on Description substring.
+   * List Lambda-managed ENIs for the given function, paginating through
+   * DescribeNetworkInterfaces and filtering on Description substring.
    *
-   * Server-side filter (`description`) does not support wildcards in EC2's API,
-   * so we filter client-side after narrowing on `requester-id` + `status`.
+   * Server-side filter (`description`) does not support wildcards on this
+   * API, so we narrow with `requester-id` + match Description client-side.
    */
-  private async countLambdaEnis(
+  private async listLambdaEnis(
     descriptionNeedle: string,
     functionNamePattern: RegExp
-  ): Promise<number> {
+  ): Promise<{ id: string; status: string }[]> {
+    const enis: { id: string; status: string }[] = [];
     let nextToken: string | undefined;
-    let count = 0;
     do {
       const resp = await this.ec2Client.send(
         new DescribeNetworkInterfacesCommand({
@@ -476,13 +540,17 @@ export class LambdaFunctionProvider implements ResourceProvider {
 
       for (const ni of resp.NetworkInterfaces ?? []) {
         const desc = ni.Description ?? '';
-        if (desc.includes(descriptionNeedle) && functionNamePattern.test(desc)) {
-          count++;
+        if (
+          ni.NetworkInterfaceId &&
+          desc.includes(descriptionNeedle) &&
+          functionNamePattern.test(desc)
+        ) {
+          enis.push({ id: ni.NetworkInterfaceId, status: ni.Status ?? 'unknown' });
         }
       }
       nextToken = resp.NextToken;
     } while (nextToken);
-    return count;
+    return enis;
   }
 
   private sleep(ms: number): Promise<void> {

--- a/tests/unit/provisioning/lambda-function-provider.test.ts
+++ b/tests/unit/provisioning/lambda-function-provider.test.ts
@@ -223,28 +223,45 @@ describe('LambdaFunctionProvider', () => {
   });
 
   describe('delete', () => {
-    it('does not poll EC2 when function has no VpcConfig', async () => {
+    it('skips VPC handling when no VpcConfig is provided', async () => {
       mockLambdaSend.mockResolvedValueOnce({});
 
       await provider.delete('Fn', 'fn-no-vpc', 'AWS::Lambda::Function', {});
 
       expect(mockLambdaSend).toHaveBeenCalledTimes(1);
-      const cmd = mockLambdaSend.mock.calls[0][0];
-      expect(cmd).toBeInstanceOf(DeleteFunctionCommand);
+      expect(mockLambdaSend.mock.calls[0][0]).toBeInstanceOf(DeleteFunctionCommand);
       expect(mockEc2Send).not.toHaveBeenCalled();
     });
 
-    it('does not poll EC2 when VpcConfig has empty SubnetIds', async () => {
+    it('skips VPC handling when VpcConfig has empty SubnetIds', async () => {
       mockLambdaSend.mockResolvedValueOnce({});
 
       await provider.delete('Fn', 'fn-empty', 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: [], SecurityGroupIds: [] },
       });
 
+      expect(mockLambdaSend).toHaveBeenCalledTimes(1);
       expect(mockEc2Send).not.toHaveBeenCalled();
     });
 
-    it('treats ResourceNotFoundException as already-deleted (no ENI wait)', async () => {
+    it('pre-detaches VPC config (UpdateFunctionConfiguration with empty arrays) before DeleteFunction', async () => {
+      mockLambdaSend
+        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
+        .mockResolvedValueOnce({}); // DeleteFunction
+      mockEc2Send.mockResolvedValueOnce({ NetworkInterfaces: [] });
+
+      await provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
+        VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
+      });
+
+      expect(mockLambdaSend).toHaveBeenCalledTimes(2);
+      const updateCmd = mockLambdaSend.mock.calls[0][0];
+      expect(updateCmd).toBeInstanceOf(UpdateFunctionConfigurationCommand);
+      expect(updateCmd.input.VpcConfig).toEqual({ SubnetIds: [], SecurityGroupIds: [] });
+      expect(mockLambdaSend.mock.calls[1][0]).toBeInstanceOf(DeleteFunctionCommand);
+    });
+
+    it('returns early when pre-detach hits ResourceNotFoundException (function already gone)', async () => {
       mockLambdaSend.mockRejectedValueOnce(
         new ResourceNotFoundException({
           message: 'Function not found',
@@ -256,72 +273,60 @@ describe('LambdaFunctionProvider', () => {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
 
+      expect(mockLambdaSend).toHaveBeenCalledTimes(1);
       expect(mockEc2Send).not.toHaveBeenCalled();
     });
 
-    it('polls DescribeNetworkInterfaces and returns once Lambda ENIs are gone', async () => {
-      mockLambdaSend.mockResolvedValueOnce({}); // DeleteFunction
+    it('continues with DeleteFunction when pre-detach fails with non-NotFound error', async () => {
+      mockLambdaSend
+        .mockRejectedValueOnce(new Error('Throttling'))
+        .mockResolvedValueOnce({}); // DeleteFunction
+      mockEc2Send.mockResolvedValueOnce({ NetworkInterfaces: [] });
 
-      // 1st poll: 1 ENI still present.
-      // 2nd poll: 0 ENIs — wait completes.
+      await provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
+        VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
+      });
+
+      expect(mockLambdaSend).toHaveBeenCalledTimes(2);
+      expect(mockLambdaSend.mock.calls[1][0]).toBeInstanceOf(DeleteFunctionCommand);
+    });
+
+    it('directly deletes Lambda ENIs after DeleteFunction succeeds', async () => {
+      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
       mockEc2Send
         .mockResolvedValueOnce({
           NetworkInterfaces: [
             {
               NetworkInterfaceId: 'eni-aaa',
-              Description: 'AWS Lambda VPC ENI-fn-vpc-abc123',
+              Description: 'AWS Lambda VPC ENI-fn-vpc',
+              Status: 'available',
             },
           ],
         })
-        .mockResolvedValueOnce({ NetworkInterfaces: [] });
+        .mockResolvedValueOnce({}) // DeleteNetworkInterface success
+        .mockResolvedValueOnce({ NetworkInterfaces: [] }); // 2nd list: empty
 
       const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
 
-      // Advance past first poll's backoff (10s).
       await vi.advanceTimersByTimeAsync(15_000);
-
       await promise;
 
-      expect(mockEc2Send).toHaveBeenCalledTimes(2);
-      const cmd = mockEc2Send.mock.calls[0][0];
-      expect(cmd).toBeInstanceOf(DescribeNetworkInterfacesCommand);
-    });
-
-    it('ignores ENIs whose Description does not match the function name', async () => {
-      mockLambdaSend.mockResolvedValueOnce({});
-
-      mockEc2Send.mockResolvedValueOnce({
-        NetworkInterfaces: [
-          {
-            NetworkInterfaceId: 'eni-other',
-            Description: 'AWS Lambda VPC ENI-other-function-xyz',
-          },
-        ],
-      });
-
-      const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
-        VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
-      });
-
-      await promise;
-
-      // Only one poll needed because the matched ENI does not belong to fn-vpc.
-      expect(mockEc2Send).toHaveBeenCalledTimes(1);
+      expect(mockEc2Send).toHaveBeenCalledTimes(3);
+      expect(mockEc2Send.mock.calls[0][0]).toBeInstanceOf(DescribeNetworkInterfacesCommand);
     });
 
     it('rejects ENIs where the function name appears only as a non-hyphen-bounded prefix', async () => {
-      // For function "fn", an ENI for "myfn" must not be counted: the
-      // function-name token in the Description is hyphen-bounded, so
-      // "myfn" (preceded by "y") is correctly excluded.
-      mockLambdaSend.mockResolvedValueOnce({});
+      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
 
       mockEc2Send.mockResolvedValueOnce({
         NetworkInterfaces: [
           {
             NetworkInterfaceId: 'eni-myfn',
             Description: 'AWS Lambda VPC ENI-myfn-abc123',
+            Status: 'available',
           },
         ],
       });
@@ -330,64 +335,87 @@ describe('LambdaFunctionProvider', () => {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
 
-      // Single poll exits immediately because no ENI matches.
+      // Single list call: nothing matched, no DeleteNetworkInterface call.
       expect(mockEc2Send).toHaveBeenCalledTimes(1);
     });
 
     it('paginates DescribeNetworkInterfaces using NextToken', async () => {
-      mockLambdaSend.mockResolvedValueOnce({});
+      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
 
-      // First page returns NextToken with no matching ENIs;
-      // second page returns no matching ENIs and no NextToken — count is 0.
       mockEc2Send
         .mockResolvedValueOnce({
           NetworkInterfaces: [
             {
               NetworkInterfaceId: 'eni-x',
               Description: 'AWS Lambda VPC ENI-other-fn-xxx',
+              Status: 'available',
             },
           ],
           NextToken: 'page2',
         })
-        .mockResolvedValueOnce({
-          NetworkInterfaces: [],
-        });
+        .mockResolvedValueOnce({ NetworkInterfaces: [] });
 
       await provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
 
+      // Two list pages, no ENI matched -> no Delete call, single iteration.
       expect(mockEc2Send).toHaveBeenCalledTimes(2);
-      const secondCmd = mockEc2Send.mock.calls[1][0];
-      expect(secondCmd.input.NextToken).toBe('page2');
+      expect(mockEc2Send.mock.calls[1][0].input.NextToken).toBe('page2');
     });
 
-    it('warns and resolves on ENI-wait timeout instead of throwing', async () => {
-      mockLambdaSend.mockResolvedValueOnce({});
+    it('retries when DeleteNetworkInterface fails on in-use ENI', async () => {
+      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
 
-      // Always return one matching ENI — the wait should give up after 10min.
-      mockEc2Send.mockResolvedValue({
-        NetworkInterfaces: [
-          {
-            NetworkInterfaceId: 'eni-stuck',
-            Description: 'AWS Lambda VPC ENI-fn-vpc-stuck',
-          },
-        ],
+      mockEc2Send
+        .mockResolvedValueOnce({
+          NetworkInterfaces: [
+            {
+              NetworkInterfaceId: 'eni-inuse',
+              Description: 'AWS Lambda VPC ENI-fn-vpc',
+              Status: 'in-use',
+            },
+          ],
+        })
+        .mockRejectedValueOnce(new Error('InvalidParameterValue: in-use'))
+        .mockResolvedValueOnce({ NetworkInterfaces: [] }); // re-list: AWS detached + cleaned up
+
+      const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
+        VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('warns and resolves when cleanup hits the timeout (does not throw)', async () => {
+      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+      mockEc2Send.mockImplementation(async (cmd: { constructor: { name: string } }) => {
+        if (cmd.constructor.name === 'DescribeNetworkInterfacesCommand') {
+          return {
+            NetworkInterfaces: [
+              {
+                NetworkInterfaceId: 'eni-stuck',
+                Description: 'AWS Lambda VPC ENI-fn-vpc',
+                Status: 'in-use',
+              },
+            ],
+          };
+        }
+        throw new Error('In-use');
       });
 
       const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
 
-      // Advance well past the 10-minute timeout so the loop exits.
       await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
-
-      // Must resolve (not reject) — timeout is a soft warning.
       await expect(promise).resolves.toBeUndefined();
     });
 
-    it('continues polling after a transient EC2 failure', async () => {
-      mockLambdaSend.mockResolvedValueOnce({});
+    it('continues polling after a transient DescribeNetworkInterfaces failure', async () => {
+      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
 
       mockEc2Send
         .mockRejectedValueOnce(new Error('ThrottlingException'))
@@ -397,9 +425,7 @@ describe('LambdaFunctionProvider', () => {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
 
-      // Advance past the first poll's backoff.
       await vi.advanceTimersByTimeAsync(15_000);
-
       await expect(promise).resolves.toBeUndefined();
       expect(mockEc2Send).toHaveBeenCalledTimes(2);
     });


### PR DESCRIPTION
## Summary

`DeleteFunction` does not synchronously release Lambda hyperplane ENIs. AWS reclaims them only eventually, often well over an hour, so the previous "wait until count==0" logic hit its 10-minute soft timeout and moved on while ENIs were still attached. The subsequent Subnet / SG deletes then failed with `has dependencies` / `has a dependent object`.

Confirmed during the v0.3.0 `bench-cdk-sample` integration run (deploy 5m58s success, destroy 24m20s with 4 failures: 2 Subnets, SG, VPC).

## Fix (delstack-style: detach + actively delete ENIs)

Restructure `LambdaFunctionProvider.delete`:

1. `UpdateFunctionConfiguration` with empty `SubnetIds` / `SecurityGroupIds` — explicit pre-delete VPC detach. Triggers AWS to start releasing ENIs.
2. `DeleteFunction`.
3. `DescribeNetworkInterfaces` filtered by `requester-id=*:awslambda_*` + hyphen-bounded function-name match.
4. `DeleteNetworkInterface` on each match (best-effort — in-use ENIs reject, retry on next loop once they transition to `available`).
5. Repeat until none remain or the soft 10-minute timeout fires.

`ResourceNotFoundException` on pre-detach short-circuits the entire flow (function already gone). Other pre-detach errors fall through to `DeleteFunction` with a warning.

Mirrors the pattern in [`delstack/internal/preprocessor/lambda_vpc_detacher.go`](https://github.com/go-to-k/delstack/blob/main/internal/preprocessor/lambda_vpc_detacher.go).

## Test plan
- [x] 11 unit tests covering: no-VpcConfig skip, empty-SubnetIds skip, pre-detach happy path, pre-detach NotFound short-circuit, pre-detach non-NotFound fall-through, active ENI delete, hyphen-bounded match rejection, NextToken paging, in-use retry, timeout warn, transient List failure retry
- [ ] Re-run `bench-cdk-sample` integ deploy + destroy on the merged main and verify zero orphan resources
