### PR TITLE
chore(skill): mandate orphan cleanup in /run-integ; tighten /verify-pr destroy check

### DIFF
--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -43,14 +43,35 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
      - `aws s3api list-buckets --query 'Buckets[?contains(Name, \`{stackName-lowercase}\`)].Name'`
      - `aws ecr describe-repositories --region us-east-1 --query 'repositories[?contains(repositoryName, \`{stackName-lowercase}\`)].repositoryName'`
      - `aws dynamodb list-tables --region us-east-1 --query 'TableNames[?contains(@, \`{StackName}\`)]'`
+     - For VPC-based tests also check: `aws ec2 describe-vpcs --filters "Name=tag:Name,Values={StackName}/Vpc" ...`
    - Only check resource types relevant to the test being run
-   - NEVER delete resources in this step — only report findings. Use `/cleanup` skill to delete if needed.
 
-6. **Report results**: Show pass/fail for each test, including resource counts and timing.
+6. **Auto-cleanup orphans (mandatory when destroy didn't fully succeed)**:
+
+   **Trigger this step whenever any of the following is true:**
+   - The `destroy` step in step 4 reported a non-zero error count (e.g. "X failed to delete")
+   - Step 5 found a leftover S3 state file
+   - Step 5 found any AWS resource matching the stack name prefix
+
+   **What to do:**
+   - For VPC-attached Lambda failures (the most common pattern), the typical orphan set is, **in delete order**:
+     1. Lambda hyperplane ENIs (`aws ec2 describe-network-interfaces --filters "Name=vpc-id,Values=<vpc>"` → `aws ec2 delete-network-interface`). Some may be `in-use` initially — re-poll until they go `available`, then delete.
+     2. SecurityGroups (`aws ec2 delete-security-group`) — must come after the ENIs that reference them are gone.
+     3. Subnets (`aws ec2 delete-subnet`) — must come after every ENI in them is gone.
+     4. VPC (`aws ec2 delete-vpc`) — last.
+   - For S3 state orphans: `aws s3 rm s3://<bucket>/stacks/<StackName>/ --recursive`.
+   - For other resource types, infer the right delete order from CloudFormation dependency rules (children before parents).
+   - Always specify the correct region (`--region`).
+   - Re-run step 5 after cleanup to confirm zero orphans remain.
+
+   **Never** end the run with orphan resources still present in AWS. Cost (NAT GW alone is ~$1/hr) and account hygiene make this non-negotiable. If a resource genuinely cannot be deleted after reasonable retries, surface it to the user with the exact ID, region, and what was tried — but only after the auto-cleanup pass.
+
+7. **Report results**: Show pass/fail for each test, including resource counts and timing. Always state explicitly "destroy completed: 0 errors, 0 orphans" or itemize what remained / what was force-cleaned.
 
 ## Important
 
 - Always use `--region us-east-1` for integration tests
 - Always destroy after deploy to avoid leftover resources
 - If deploy fails, still attempt destroy to clean up partial state
-- Check for leftover state in S3 after destroy
+- **Never report success based on a successful deploy alone** — destroy must complete and orphan check must pass
+- **Never bypass this skill** by calling `cdkd deploy` / `cdkd destroy` directly from a shell — the orphan-cleanup contract above is part of the integration test, not optional

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -38,7 +38,9 @@ Run each check and report pass/fail:
 
 6. **Leftover resources**
    - Resolve account ID via `aws sts get-caller-identity --query Account --output text`
-   - `aws s3 ls s3://cdkd-state-{accountId}-us-east-1/stacks/ --region us-east-1` - no leftover state
+   - `aws s3 ls s3://cdkd-state-{accountId}-us-east-1/stacks/ --region us-east-1` — no leftover state
+   - **For deletion-touching PRs** (any change under `src/provisioning/providers/*` `delete()`, `src/deployment/destroy.ts`, `src/analyzer/dag-builder.ts`, `IMPLICIT_DELETE_DEPENDENCIES`, etc.): also confirm that an end-to-end real-AWS destroy was run via `/run-integ <relevant-test>` and reported zero errors / zero orphans. CI is necessary but not sufficient — it does not exercise real-AWS destroy. If unverified, **fail this check** and run the integ before merging.
+   - For each region this PR may have created resources in (typically `us-east-1`), spot-check the most failure-prone resource types — VPCs (`describe-vpcs --filters "Name=tag:Name,Values=Cdkd*/Vpc"`), Lambda hyperplane ENIs (`describe-network-interfaces --filters "Name=requester-id,Values=*:awslambda_*"`), CloudFront Distributions, NAT Gateways. Any match against a stack name in this PR's diff = orphan, must be cleaned up before merge.
 
 7. **No stale references**
    - Grep for removed imports, old module names, or deprecated references in source files


### PR DESCRIPTION
## Summary

Two skill updates that codify the discipline rules added in #39 (CLAUDE.md). Without these, "use the skill" is a polite request — with these, the skill itself enforces the contract.

### `/run-integ` — new "Auto-cleanup orphans" step

Triggers whenever any of: destroy reported a non-zero error count, an S3 state file was left, or any AWS resource matches the stack name prefix. Encodes the typical Lambda-VPC orphan delete order (ENIs → SG → Subnets → VPC) so the skill itself knows how to recover from a partial destroy.

Also adds two explicit guard rails to the "Important" section:
- **Never** report success based on a successful deploy alone — destroy + orphan check must pass.
- **Never** bypass the skill via direct `cdkd deploy` / `cdkd destroy` shell commands.

### `/verify-pr` — tightened "Leftover resources" step

For any PR touching deletion logic (`delete()`, `dag-builder`, `IMPLICIT_DELETE_DEPENDENCIES`, etc.), require real-AWS destroy evidence (zero errors, zero orphans) before marking the PR mergeable. Spot-check the failure-prone resource types — VPCs, Lambda hyperplane ENIs, CloudFront Distributions, NAT Gateways.

## Background

During the v0.3.0 release I merged 6 PRs after observing only a successful deploy in the background; the destroy was still running and ultimately failed. The actual root cause turned out to be different from my hypothesis (`DeleteFunction` doesn't synchronously release Lambda hyperplane ENIs — fixed in #38). With #39 + this PR, the skill side enforces what the doc side already says.

## Test plan
- [x] `pnpm typecheck` / `lint` / `build` / tests still pass (no code changes)
- [x] Skill markdown renders correctly
