### PR TITLE
fix(lambda): match ENI description by token prefix, not full physicalId regex

### DIFF
--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -447,8 +447,14 @@ export class LambdaFunctionProvider implements ResourceProvider {
       `Cleaning up Lambda VPC ENIs for function ${functionName} (timeout ${this.eniWaitTimeoutMs}ms)`
     );
 
-    const descriptionNeedle = `AWS Lambda VPC ENI`;
-    const functionNamePattern = new RegExp(`(^|-)${escapeRegExp(functionName)}(-|$)`);
+    // Lambda VPC ENI Descriptions follow `AWS Lambda VPC ENI-<name>` where
+    // <name> is typically the *logical* portion of the function name (e.g.
+    // CDK's `<StackName>-<LogicalId>`), NOT necessarily the full physical
+    // function name (which carries an extra auto-generated 8-char suffix
+    // like `-zZBaJTabq03f`). Matching on the full physicalId as a token
+    // therefore misses the ENIs entirely. Instead, parse the suffix out of
+    // each Description and check it against the physicalId as a prefix
+    // match.
 
     for (;;) {
       attempt++;
@@ -456,7 +462,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
       let enis: { id: string; status: string }[] = [];
       let listFailed = false;
       try {
-        enis = await this.listLambdaEnis(descriptionNeedle, functionNamePattern);
+        enis = await this.listLambdaEnis(functionName);
       } catch (error) {
         this.logger.warn(
           `DescribeNetworkInterfaces failed while cleaning up Lambda ENIs of ${functionName}: ${
@@ -521,11 +527,9 @@ export class LambdaFunctionProvider implements ResourceProvider {
    * Server-side filter (`description`) does not support wildcards on this
    * API, so we narrow with `requester-id` + match Description client-side.
    */
-  private async listLambdaEnis(
-    descriptionNeedle: string,
-    functionNamePattern: RegExp
-  ): Promise<{ id: string; status: string }[]> {
+  private async listLambdaEnis(functionName: string): Promise<{ id: string; status: string }[]> {
     const enis: { id: string; status: string }[] = [];
+    const descriptionPrefix = 'AWS Lambda VPC ENI-';
     let nextToken: string | undefined;
     do {
       const resp = await this.ec2Client.send(
@@ -540,11 +544,17 @@ export class LambdaFunctionProvider implements ResourceProvider {
 
       for (const ni of resp.NetworkInterfaces ?? []) {
         const desc = ni.Description ?? '';
-        if (
-          ni.NetworkInterfaceId &&
-          desc.includes(descriptionNeedle) &&
-          functionNamePattern.test(desc)
-        ) {
+        if (!ni.NetworkInterfaceId || !desc.startsWith(descriptionPrefix)) {
+          continue;
+        }
+        // The portion after `AWS Lambda VPC ENI-` is the function-name token
+        // AWS uses on the ENI. It usually omits the CDK auto-generated 8-char
+        // suffix at the end of the physical function name, so match by
+        // checking that physicalId starts with `<token>-` (allowing the
+        // suffix) or equals it exactly. This is hyphen-bounded so a function
+        // named `fn` does NOT match an ENI whose token is `myfn`.
+        const token = desc.slice(descriptionPrefix.length);
+        if (functionName === token || functionName.startsWith(`${token}-`)) {
           enis.push({ id: ni.NetworkInterfaceId, status: ni.Status ?? 'unknown' });
         }
       }
@@ -659,8 +669,4 @@ export class LambdaFunctionProvider implements ResourceProvider {
     }
     return (crc ^ 0xffffffff) >>> 0;
   }
-}
-
-function escapeRegExp(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/tests/unit/provisioning/lambda-function-provider.test.ts
+++ b/tests/unit/provisioning/lambda-function-provider.test.ts
@@ -318,6 +318,42 @@ describe('LambdaFunctionProvider', () => {
       expect(mockEc2Send.mock.calls[0][0]).toBeInstanceOf(DescribeNetworkInterfacesCommand);
     });
 
+    it('matches ENIs whose Description token is a hyphen-prefix of the physical function name (CDK suffix)', async () => {
+      // Real-world AWS pattern: CDK-managed Lambda functions get an
+      // auto-generated 8-char suffix on the physical name
+      // (e.g. CdkdBenchCdkSample-ApiFunction-zZBaJTabq03f), but the AWS
+      // Lambda VPC ENI Description carries only the token *without* that
+      // suffix (AWS Lambda VPC ENI-CdkdBenchCdkSample-ApiFunction).
+      // The matcher must still treat them as belonging to that function.
+      const physicalName = 'CdkdBenchCdkSample-ApiFunction-zZBaJTabq03f';
+      const eniDescription = 'AWS Lambda VPC ENI-CdkdBenchCdkSample-ApiFunction';
+
+      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+      mockEc2Send
+        .mockResolvedValueOnce({
+          NetworkInterfaces: [
+            {
+              NetworkInterfaceId: 'eni-cdk',
+              Description: eniDescription,
+              Status: 'available',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({}) // DeleteNetworkInterface
+        .mockResolvedValueOnce({ NetworkInterfaces: [] });
+
+      const promise = provider.delete('Fn', physicalName, 'AWS::Lambda::Function', {
+        VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      await promise;
+
+      // 1 list + 1 DeleteNetworkInterface + 1 re-list = 3 calls.
+      expect(mockEc2Send).toHaveBeenCalledTimes(3);
+    });
+
     it('rejects ENIs where the function name appears only as a non-hyphen-bounded prefix', async () => {
       mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
 


### PR DESCRIPTION
## Summary

Real-AWS verification of v0.3.1 (#38) on `bench-cdk-sample` failed destroy with the same `Subnet has dependencies` symptom we thought we fixed. Investigation: the ENI cleanup matcher in #38 never found the actual ENIs.

**Root cause** — the matcher built a hyphen-bounded regex from the *full* physical function name (CDK auto-generates an 8-char suffix), but AWS Lambda VPC ENI Descriptions carry only the token *without* that suffix.

```
physicalId : CdkdBenchCdkSample-ApiFunction-zZBaJTabq03f
ENI desc   : AWS Lambda VPC ENI-CdkdBenchCdkSample-ApiFunction
                                                  ^ no suffix
regex      : (^|-)CdkdBenchCdkSample-ApiFunction-zZBaJTabq03f(-|$)
                                                  ^ never matches
```

`listLambdaEnis` returned `[]` → cleanup loop early-returned ("zero ENIs found = success") → DeleteFunction was the only thing run → ENIs left available but undeleted → `DeleteSubnet`/`DeleteSecurityGroup` failed with `has dependencies`.

## Fix

Parse the token after `AWS Lambda VPC ENI-` and match it against the physical id by hyphen-bounded prefix:

```ts
const token = desc.slice('AWS Lambda VPC ENI-'.length);
if (functionName === token || functionName.startsWith(`${token}-`)) {
  // matches
}
```

This handles both cases — exact match (legacy short names) and `<token>-<cdk-suffix>` (modern CDK-generated names) — while still rejecting lookalike tokens (`fn` does NOT match an ENI for `myfn`, since `'fn'.startsWith('myfn-')` is false and `'fn' === 'myfn'` is false).

Also drops the now-unused `escapeRegExp` helper.

## Test plan
- [x] 12 unit tests including a new regression test that simulates the realistic CDK pattern (physicalId with `-zZBaJTabq03f` suffix + Description without it)
- [x] `pnpm typecheck` / `lint` / `build` / `vitest` all pass (655 tests)
- [ ] Re-run `bench-cdk-sample` integ deploy + destroy on the merged main and confirm zero orphan resources
