### PR TITLE
fix(lambda): wait for VPC detach to fully apply before DeleteFunction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,7 +368,7 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 - ✅ Nested cloud assembly traversal (CDK Stage support)
 - ✅ WorkGraph DAG orchestrator for asset publishing and stack deployment (build→publish→deploy pipeline)
 - ✅ Concurrency options: `--asset-publish-concurrency` (default 8), `--image-build-concurrency` (default 4)
-- ✅ Lambda VpcConfig SDK provider support (avoids CC API fallback) + pre-delete VPC detach (UpdateFunctionConfiguration with empty arrays) + active ENI cleanup via DeleteNetworkInterface on delete (avoids downstream Subnet/SG "has dependencies" failures — `DeleteFunction` alone does not synchronously release Lambda hyperplane ENIs, AWS reclaims them only eventually)
+- ✅ Lambda VpcConfig SDK provider support (avoids CC API fallback) + pre-delete VPC detach (UpdateFunctionConfiguration with empty arrays) + wait for LastUpdateStatus=Successful before DeleteFunction (otherwise the in-flight detach is aborted and ENIs stay attached) + ENI Description match by token prefix (CDK-generated function names carry an 8-char suffix that the ENI Description omits) + active ENI cleanup via DeleteNetworkInterface on delete (avoids downstream Subnet/SG "has dependencies" failures — `DeleteFunction` alone does not synchronously release Lambda hyperplane ENIs, AWS reclaims them only eventually)
 
 ## Dependencies
 

--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -325,6 +325,15 @@ export class LambdaFunctionProvider implements ResourceProvider {
           } — continuing with delete`
         );
       }
+
+      // Wait for the UpdateFunctionConfiguration to fully apply before
+      // calling DeleteFunction. Lambda processes the VPC detach
+      // asynchronously: LastUpdateStatus transitions InProgress -> Successful,
+      // and the hyperplane ENIs only flip from `in-use` to `available` once
+      // that completes. Calling DeleteFunction while LastUpdateStatus is
+      // still `InProgress` aborts the detach mid-flight, leaving ENIs
+      // attached and blocking downstream Subnet / SG deletion.
+      await this.waitForLambdaUpdateCompleted(physicalId);
     }
 
     try {
@@ -438,6 +447,67 @@ export class LambdaFunctionProvider implements ResourceProvider {
    * Timeout is a soft warning — downstream Subnet/SG deletion has its own
    * retries.
    */
+  /**
+   * Poll GetFunction until LastUpdateStatus is no longer `InProgress`.
+   *
+   * After UpdateFunctionConfiguration the Lambda service processes the
+   * change (including VPC detach + hyperplane ENI release) asynchronously.
+   * Returning early — i.e. calling DeleteFunction while the update is still
+   * `InProgress` — aborts the detach, leaving ENIs attached and blocking
+   * downstream Subnet / SG deletion.
+   *
+   * Bounded by eniWaitTimeoutMs (10min) and treated as a soft warning on
+   * timeout: the subsequent ENI cleanup loop and downstream retries cover
+   * the residual edge case.
+   */
+  private async waitForLambdaUpdateCompleted(functionName: string): Promise<void> {
+    const start = Date.now();
+    let delay = this.eniWaitInitialDelayMs;
+
+    for (;;) {
+      let status: string | undefined;
+      try {
+        const resp = await this.lambdaClient.send(
+          new GetFunctionCommand({ FunctionName: functionName })
+        );
+        status = resp.Configuration?.LastUpdateStatus;
+      } catch (error) {
+        if (error instanceof ResourceNotFoundException) {
+          // Function disappeared — caller will skip ENI cleanup too.
+          return;
+        }
+        // Transient error — log and retry.
+        this.logger.debug(
+          `GetFunction failed while waiting for ${functionName} update: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+
+      if (status && status !== 'InProgress') {
+        this.logger.debug(
+          `Lambda ${functionName} update completed (LastUpdateStatus=${status}) after ${
+            Date.now() - start
+          }ms`
+        );
+        return;
+      }
+
+      const elapsed = Date.now() - start;
+      if (elapsed >= this.eniWaitTimeoutMs) {
+        this.logger.warn(
+          `Timeout (${this.eniWaitTimeoutMs}ms) waiting for Lambda ${functionName} update to complete; proceeding with delete`
+        );
+        return;
+      }
+
+      const remaining = this.eniWaitTimeoutMs - elapsed;
+      const sleepMs = Math.min(delay, remaining);
+      await this.sleep(sleepMs);
+      delay = Math.min(delay * 2, this.eniWaitMaxDelayMs);
+    }
+  }
+
   private async cleanupLambdaEnis(functionName: string): Promise<void> {
     const start = Date.now();
     let delay = this.eniWaitInitialDelayMs;

--- a/tests/unit/provisioning/lambda-function-provider.test.ts
+++ b/tests/unit/provisioning/lambda-function-provider.test.ts
@@ -244,9 +244,10 @@ describe('LambdaFunctionProvider', () => {
       expect(mockEc2Send).not.toHaveBeenCalled();
     });
 
-    it('pre-detaches VPC config (UpdateFunctionConfiguration with empty arrays) before DeleteFunction', async () => {
+    it('pre-detaches VPC config (UpdateFunctionConfiguration with empty arrays) and waits for Active before DeleteFunction', async () => {
       mockLambdaSend
         .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait)
         .mockResolvedValueOnce({}); // DeleteFunction
       mockEc2Send.mockResolvedValueOnce({ NetworkInterfaces: [] });
 
@@ -254,11 +255,11 @@ describe('LambdaFunctionProvider', () => {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
 
-      expect(mockLambdaSend).toHaveBeenCalledTimes(2);
+      expect(mockLambdaSend).toHaveBeenCalledTimes(3);
       const updateCmd = mockLambdaSend.mock.calls[0][0];
       expect(updateCmd).toBeInstanceOf(UpdateFunctionConfigurationCommand);
       expect(updateCmd.input.VpcConfig).toEqual({ SubnetIds: [], SecurityGroupIds: [] });
-      expect(mockLambdaSend.mock.calls[1][0]).toBeInstanceOf(DeleteFunctionCommand);
+      expect(mockLambdaSend.mock.calls[2][0]).toBeInstanceOf(DeleteFunctionCommand);
     });
 
     it('returns early when pre-detach hits ResourceNotFoundException (function already gone)', async () => {
@@ -280,6 +281,7 @@ describe('LambdaFunctionProvider', () => {
     it('continues with DeleteFunction when pre-detach fails with non-NotFound error', async () => {
       mockLambdaSend
         .mockRejectedValueOnce(new Error('Throttling'))
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait still runs)
         .mockResolvedValueOnce({}); // DeleteFunction
       mockEc2Send.mockResolvedValueOnce({ NetworkInterfaces: [] });
 
@@ -287,12 +289,15 @@ describe('LambdaFunctionProvider', () => {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
 
-      expect(mockLambdaSend).toHaveBeenCalledTimes(2);
-      expect(mockLambdaSend.mock.calls[1][0]).toBeInstanceOf(DeleteFunctionCommand);
+      expect(mockLambdaSend).toHaveBeenCalledTimes(3);
+      expect(mockLambdaSend.mock.calls[2][0]).toBeInstanceOf(DeleteFunctionCommand);
     });
 
     it('directly deletes Lambda ENIs after DeleteFunction succeeds', async () => {
-      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+      mockLambdaSend
+        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
+        .mockResolvedValueOnce({}); // DeleteFunction
 
       mockEc2Send
         .mockResolvedValueOnce({
@@ -328,7 +333,10 @@ describe('LambdaFunctionProvider', () => {
       const physicalName = 'CdkdBenchCdkSample-ApiFunction-zZBaJTabq03f';
       const eniDescription = 'AWS Lambda VPC ENI-CdkdBenchCdkSample-ApiFunction';
 
-      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+      mockLambdaSend
+        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
+        .mockResolvedValueOnce({}); // DeleteFunction
 
       mockEc2Send
         .mockResolvedValueOnce({
@@ -355,7 +363,10 @@ describe('LambdaFunctionProvider', () => {
     });
 
     it('rejects ENIs where the function name appears only as a non-hyphen-bounded prefix', async () => {
-      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+      mockLambdaSend
+        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
+        .mockResolvedValueOnce({}); // DeleteFunction
 
       mockEc2Send.mockResolvedValueOnce({
         NetworkInterfaces: [
@@ -376,7 +387,10 @@ describe('LambdaFunctionProvider', () => {
     });
 
     it('paginates DescribeNetworkInterfaces using NextToken', async () => {
-      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+      mockLambdaSend
+        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
+        .mockResolvedValueOnce({}); // DeleteFunction
 
       mockEc2Send
         .mockResolvedValueOnce({
@@ -401,7 +415,10 @@ describe('LambdaFunctionProvider', () => {
     });
 
     it('retries when DeleteNetworkInterface fails on in-use ENI', async () => {
-      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+      mockLambdaSend
+        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
+        .mockResolvedValueOnce({}); // DeleteFunction
 
       mockEc2Send
         .mockResolvedValueOnce({
@@ -425,7 +442,10 @@ describe('LambdaFunctionProvider', () => {
     });
 
     it('warns and resolves when cleanup hits the timeout (does not throw)', async () => {
-      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+      mockLambdaSend
+        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
+        .mockResolvedValueOnce({}); // DeleteFunction
 
       mockEc2Send.mockImplementation(async (cmd: { constructor: { name: string } }) => {
         if (cmd.constructor.name === 'DescribeNetworkInterfacesCommand') {
@@ -451,7 +471,10 @@ describe('LambdaFunctionProvider', () => {
     });
 
     it('continues polling after a transient DescribeNetworkInterfaces failure', async () => {
-      mockLambdaSend.mockResolvedValueOnce({}).mockResolvedValueOnce({});
+      mockLambdaSend
+        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
+        .mockResolvedValueOnce({}); // DeleteFunction
 
       mockEc2Send
         .mockRejectedValueOnce(new Error('ThrottlingException'))


### PR DESCRIPTION
## Summary

Real-AWS verification of v0.3.2 still failed destroy with the same `Subnet has dependencies` symptom. Investigation shows we called `DeleteFunction` while the pre-detach `UpdateFunctionConfiguration` was still in flight.

**Root cause** — Lambda processes the VPC detach asynchronously:

```
UpdateFunctionConfiguration -> LastUpdateStatus = InProgress
                            -> (AWS detaches ENIs, hyperplane ENIs go in-use -> available)
                            -> LastUpdateStatus = Successful
```

Calling `DeleteFunction` while `LastUpdateStatus` is still `InProgress` aborts the in-flight detach, leaving ENIs attached. The 10-minute ENI cleanup loop then waits, times out warn-and-continue, and downstream `DeleteSubnet` / `DeleteSecurityGroup` fail — exactly matching the v0.3.0 / v0.3.1 / v0.3.2 failure pattern (4 errors after 24m20s).

## Fix

Add `waitForLambdaUpdateCompleted`: poll `GetFunction` with exponential backoff (10s → 30s, 10-min soft timeout) until `LastUpdateStatus !== 'InProgress'`. Insert it between the pre-detach `UpdateFunctionConfiguration` and `DeleteFunction`, gated on the same `hasVpcConfig` flag.

```ts
if (hasVpcConfig) {
  await UpdateFunctionConfiguration({ VpcConfig: { SubnetIds: [], SecurityGroupIds: [] } });
  await this.waitForLambdaUpdateCompleted(physicalId);   // ← new
}
await DeleteFunction;
if (hasVpcConfig) await this.cleanupLambdaEnis(physicalId);
```

## Test plan
- [x] 12 unit tests, including updated mocks for the new GetFunction call (655 tests pass)
- [x] `pnpm typecheck` / `lint` / `build` pass
- [ ] Re-run `bench-cdk-sample` integ deploy + destroy on the merged main and confirm zero orphan resources
