### PR TITLE
fix(lambda,ec2): delstack-style ENI cleanup + EC2 side-channel retry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,7 +368,7 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 - ✅ Nested cloud assembly traversal (CDK Stage support)
 - ✅ WorkGraph DAG orchestrator for asset publishing and stack deployment (build→publish→deploy pipeline)
 - ✅ Concurrency options: `--asset-publish-concurrency` (default 8), `--image-build-concurrency` (default 4)
-- ✅ Lambda VpcConfig SDK provider support (avoids CC API fallback) + pre-delete VPC detach (UpdateFunctionConfiguration with empty arrays) + wait for LastUpdateStatus=Successful before DeleteFunction (otherwise the in-flight detach is aborted and ENIs stay attached) + ENI Description match by token prefix (CDK-generated function names carry an 8-char suffix that the ENI Description omits) + active ENI cleanup via DeleteNetworkInterface on delete (avoids downstream Subnet/SG "has dependencies" failures — `DeleteFunction` alone does not synchronously release Lambda hyperplane ENIs, AWS reclaims them only eventually)
+- ✅ Lambda VpcConfig SDK provider support (avoids CC API fallback) + pre-delete VPC detach (UpdateFunctionConfiguration with empty arrays) + wait for LastUpdateStatus=Successful before DeleteFunction (otherwise the in-flight detach is aborted and ENIs stay attached) + ENI Description match by token prefix (CDK-generated function names carry an 8-char suffix that the ENI Description omits) + delstack-style ENI cleanup (initial 10s sleep, then per-ENI parallel delete with 90s retry budget) on delete + side-channel ENI cleanup retry on EC2 Subnet / SecurityGroup delete (last-resort sweep for cases where the Lambda-side cleanup ran out of budget) — `DeleteFunction` alone does not synchronously release Lambda hyperplane ENIs, AWS reclaims them only eventually
 
 ## Dependencies
 

--- a/src/provisioning/providers/ec2-provider.ts
+++ b/src/provisioning/providers/ec2-provider.ts
@@ -37,6 +37,8 @@ import {
   DeleteNetworkAclEntryCommand,
   ReplaceNetworkAclAssociationCommand,
   DescribeNetworkAclsCommand,
+  DescribeNetworkInterfacesCommand,
+  DeleteNetworkInterfaceCommand,
   type Tenancy,
   type _InstanceType,
   type VolumeType,
@@ -631,23 +633,95 @@ export class EC2Provider implements ResourceProvider {
   ): Promise<void> {
     this.logger.debug(`Deleting Subnet ${logicalId}: ${physicalId}`);
 
-    try {
-      await this.ec2Client.send(new DeleteSubnetCommand({ SubnetId: physicalId }));
-      this.logger.debug(`Successfully deleted Subnet ${logicalId}`);
-    } catch (error) {
-      if (this.isNotFoundError(error)) {
-        this.logger.debug(`Subnet ${physicalId} does not exist, skipping deletion`);
+    // Subnet deletes commonly fail with "has dependencies" when Lambda
+    // hyperplane ENIs are still attached. The Lambda provider tries to
+    // clean those up first, but its budget is finite and AWS's ENI release
+    // is asynchronous — by the time we get here, leftover ENIs may still
+    // exist. Retry with a side-channel: best-effort delete remaining
+    // Lambda-managed ENIs in the subnet, sleep, then retry the subnet.
+    const maxAttempts = 10;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await this.ec2Client.send(new DeleteSubnetCommand({ SubnetId: physicalId }));
+        this.logger.debug(`Successfully deleted Subnet ${logicalId}`);
         return;
+      } catch (error) {
+        if (this.isNotFoundError(error)) {
+          this.logger.debug(`Subnet ${physicalId} does not exist, skipping deletion`);
+          return;
+        }
+        const msg = error instanceof Error ? error.message : String(error);
+        const isDependencyError =
+          msg.includes('has dependencies') || msg.includes('DependencyViolation');
+        if (isDependencyError && attempt < maxAttempts) {
+          await this.cleanupSubnetLambdaEnis(physicalId);
+          this.logger.debug(
+            `Subnet ${physicalId} has dependencies (attempt ${attempt}/${maxAttempts}), retrying in ${attempt * 5}s...`
+          );
+          await new Promise((resolve) => setTimeout(resolve, attempt * 5000));
+          continue;
+        }
+        const cause = error instanceof Error ? error : undefined;
+        throw new ProvisioningError(
+          `Failed to delete Subnet ${logicalId}: ${msg}`,
+          resourceType,
+          logicalId,
+          physicalId,
+          cause
+        );
       }
-      const cause = error instanceof Error ? error : undefined;
-      throw new ProvisioningError(
-        `Failed to delete Subnet ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,
-        resourceType,
-        logicalId,
-        physicalId,
-        cause
-      );
     }
+  }
+
+  /**
+   * Best-effort: list Lambda-managed ENIs in the given subnet and try to
+   * delete each one. Used as a side-channel cleanup when DeleteSubnet
+   * fails with "has dependencies" — the Lambda provider's own ENI cleanup
+   * may have run out of budget before AWS finished detaching, so a second
+   * attempt from the subnet side typically succeeds a few seconds later
+   * once the ENIs flip from `in-use` to `available`.
+   */
+  private async cleanupSubnetLambdaEnis(subnetId: string): Promise<void> {
+    let enis: { id: string; status: string }[];
+    try {
+      const resp = await this.ec2Client.send(
+        new DescribeNetworkInterfacesCommand({
+          Filters: [
+            { Name: 'subnet-id', Values: [subnetId] },
+            { Name: 'requester-id', Values: ['*:awslambda_*'] },
+          ],
+        })
+      );
+      enis = (resp.NetworkInterfaces ?? [])
+        .filter((ni) => ni.NetworkInterfaceId)
+        .map((ni) => ({ id: ni.NetworkInterfaceId!, status: ni.Status ?? 'unknown' }));
+    } catch (err) {
+      this.logger.debug(
+        `cleanupSubnetLambdaEnis: DescribeNetworkInterfaces failed for ${subnetId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      return;
+    }
+    if (enis.length === 0) return;
+    await Promise.all(
+      enis.map(async (eni) => {
+        try {
+          await this.ec2Client.send(
+            new DeleteNetworkInterfaceCommand({ NetworkInterfaceId: eni.id })
+          );
+          this.logger.debug(
+            `cleanupSubnetLambdaEnis: deleted Lambda ENI ${eni.id} in subnet ${subnetId}`
+          );
+        } catch (err) {
+          this.logger.debug(
+            `cleanupSubnetLambdaEnis: ENI ${eni.id} (status=${eni.status}) not yet deletable: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      })
+    );
   }
 
   private async getSubnetAttribute(physicalId: string, attributeName: string): Promise<unknown> {
@@ -1316,6 +1390,9 @@ export class EC2Provider implements ResourceProvider {
         }
         const msg = error instanceof Error ? error.message : String(error);
         if (msg.includes('dependent object') && attempt < maxAttempts) {
+          // Same side-channel as deleteSubnet: clean up Lambda-managed
+          // ENIs that still reference this SG, then sleep and retry.
+          await this.cleanupSecurityGroupLambdaEnis(physicalId);
           this.logger.debug(
             `SecurityGroup ${physicalId} has dependent objects (attempt ${attempt}/${maxAttempts}), retrying in ${attempt * 5}s...`
           );
@@ -1332,6 +1409,54 @@ export class EC2Provider implements ResourceProvider {
         );
       }
     }
+  }
+
+  /**
+   * Best-effort: list Lambda-managed ENIs that reference the given security
+   * group and try to delete each one. Mirror of cleanupSubnetLambdaEnis but
+   * filtered by `group-id`.
+   */
+  private async cleanupSecurityGroupLambdaEnis(groupId: string): Promise<void> {
+    let enis: { id: string; status: string }[];
+    try {
+      const resp = await this.ec2Client.send(
+        new DescribeNetworkInterfacesCommand({
+          Filters: [
+            { Name: 'group-id', Values: [groupId] },
+            { Name: 'requester-id', Values: ['*:awslambda_*'] },
+          ],
+        })
+      );
+      enis = (resp.NetworkInterfaces ?? [])
+        .filter((ni) => ni.NetworkInterfaceId)
+        .map((ni) => ({ id: ni.NetworkInterfaceId!, status: ni.Status ?? 'unknown' }));
+    } catch (err) {
+      this.logger.debug(
+        `cleanupSecurityGroupLambdaEnis: DescribeNetworkInterfaces failed for ${groupId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      return;
+    }
+    if (enis.length === 0) return;
+    await Promise.all(
+      enis.map(async (eni) => {
+        try {
+          await this.ec2Client.send(
+            new DeleteNetworkInterfaceCommand({ NetworkInterfaceId: eni.id })
+          );
+          this.logger.debug(
+            `cleanupSecurityGroupLambdaEnis: deleted Lambda ENI ${eni.id} for SG ${groupId}`
+          );
+        } catch (err) {
+          this.logger.debug(
+            `cleanupSecurityGroupLambdaEnis: ENI ${eni.id} (status=${eni.status}) not yet deletable: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      })
+    );
   }
 
   private async getSecurityGroupAttribute(

--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -72,9 +72,22 @@ export class LambdaFunctionProvider implements ResourceProvider {
   // Lambda VPC ENI detach is async and can take 20-40 minutes in the worst case;
   // we poll up to 10 minutes and then warn-and-continue, since downstream Subnet/SG
   // deletion has its own retry logic that handles a small remaining window.
+  // Budget for waiting on UpdateFunctionConfiguration to fully apply
+  // (LastUpdateStatus -> Successful) after pre-delete VPC detach.
   private readonly eniWaitTimeoutMs: number = 10 * 60 * 1000;
   private readonly eniWaitInitialDelayMs: number = 10_000;
   private readonly eniWaitMaxDelayMs: number = 30_000;
+
+  // delstack-style ENI cleanup tunables.
+  // - initial sleep: gives AWS time to publish post-detach ENI state via
+  //   DescribeNetworkInterfaces (right after the update, the API can return
+  //   an empty list even though ENIs still exist).
+  // - per-ENI retry budget: an in-use ENI cannot be deleted until AWS
+  //   finishes the asynchronous detach; budget gives that time to land.
+  // - retry interval: polling cadence inside the per-ENI loop.
+  private readonly eniInitialSleepMs: number = 10_000;
+  private readonly eniDeleteRetryBudgetMs: number = 90_000;
+  private readonly eniDeleteRetryIntervalMs: number = 5_000;
 
   constructor() {
     const awsClients = getAwsClients();
@@ -509,84 +522,61 @@ export class LambdaFunctionProvider implements ResourceProvider {
   }
 
   private async cleanupLambdaEnis(functionName: string): Promise<void> {
+    this.logger.debug(`Cleaning up Lambda VPC ENIs for function ${functionName}`);
+
+    // Mirror delstack's ENI cleanup pattern: an unconditional initial sleep
+    // gives AWS time to register the post-detach ENI state in the API plane
+    // (DescribeNetworkInterfaces can transiently return an empty list right
+    // after UpdateFunctionConfiguration, even though ENIs still exist), then
+    // delete each matched ENI in parallel with a per-ENI retry budget.
+    await this.sleep(this.eniInitialSleepMs);
+
+    let enis: { id: string; status: string }[] = [];
+    try {
+      enis = await this.listLambdaEnis(functionName);
+    } catch (error) {
+      this.logger.warn(
+        `DescribeNetworkInterfaces failed for ${functionName}: ${
+          error instanceof Error ? error.message : String(error)
+        } — downstream Subnet/SG deletion will fall back to its own ENI cleanup`
+      );
+      return;
+    }
+
+    if (enis.length === 0) {
+      this.logger.debug(`No Lambda ENIs found for ${functionName} after initial sleep`);
+      return;
+    }
+
+    // Per-ENI parallel delete with retry. An in-use ENI cannot be deleted
+    // until AWS finishes the asynchronous detach triggered by the prior
+    // UpdateFunctionConfiguration; budget gives that detach time to land.
+    await Promise.all(enis.map((eni) => this.deleteEniWithRetry(eni.id, functionName)));
+  }
+
+  private async deleteEniWithRetry(eniId: string, functionName: string): Promise<void> {
     const start = Date.now();
-    let delay = this.eniWaitInitialDelayMs;
-    let attempt = 0;
-
-    this.logger.debug(
-      `Cleaning up Lambda VPC ENIs for function ${functionName} (timeout ${this.eniWaitTimeoutMs}ms)`
-    );
-
-    // Lambda VPC ENI Descriptions follow `AWS Lambda VPC ENI-<name>` where
-    // <name> is typically the *logical* portion of the function name (e.g.
-    // CDK's `<StackName>-<LogicalId>`), NOT necessarily the full physical
-    // function name (which carries an extra auto-generated 8-char suffix
-    // like `-zZBaJTabq03f`). Matching on the full physicalId as a token
-    // therefore misses the ENIs entirely. Instead, parse the suffix out of
-    // each Description and check it against the physicalId as a prefix
-    // match.
-
     for (;;) {
-      attempt++;
-
-      let enis: { id: string; status: string }[] = [];
-      let listFailed = false;
       try {
-        enis = await this.listLambdaEnis(functionName);
+        await this.ec2Client.send(new DeleteNetworkInterfaceCommand({ NetworkInterfaceId: eniId }));
+        this.logger.debug(`Deleted Lambda ENI ${eniId} for ${functionName}`);
+        return;
       } catch (error) {
-        this.logger.warn(
-          `DescribeNetworkInterfaces failed while cleaning up Lambda ENIs of ${functionName}: ${
-            error instanceof Error ? error.message : String(error)
-          }`
-        );
-        listFailed = true;
+        const msg = error instanceof Error ? error.message : String(error);
+        if (msg.includes('InvalidNetworkInterfaceID.NotFound') || msg.includes('does not exist')) {
+          // Already gone — treat as success.
+          return;
+        }
+        const elapsed = Date.now() - start;
+        if (elapsed >= this.eniDeleteRetryBudgetMs) {
+          this.logger.warn(
+            `Gave up deleting ENI ${eniId} for ${functionName} after ${elapsed}ms: ${msg} — ` +
+              `downstream Subnet/SG deletion will retry`
+          );
+          return;
+        }
+        await this.sleep(this.eniDeleteRetryIntervalMs);
       }
-
-      // Only treat an empty list as success if we actually got it from AWS;
-      // a transient List failure must retry rather than declare cleanup done.
-      if (!listFailed && enis.length === 0) {
-        this.logger.debug(
-          `Lambda ENIs for ${functionName} fully cleaned up after ${attempt} attempt(s) / ${
-            Date.now() - start
-          }ms`
-        );
-        return;
-      }
-
-      // Best-effort delete: in-use ENIs reject and we'll retry next loop.
-      if (enis.length > 0) {
-        await Promise.all(
-          enis.map(async (eni) => {
-            try {
-              await this.ec2Client.send(
-                new DeleteNetworkInterfaceCommand({ NetworkInterfaceId: eni.id })
-              );
-              this.logger.debug(`Deleted Lambda ENI ${eni.id} for ${functionName}`);
-            } catch (error) {
-              this.logger.debug(
-                `ENI ${eni.id} (status=${eni.status}) not yet deletable: ${
-                  error instanceof Error ? error.message : String(error)
-                }`
-              );
-            }
-          })
-        );
-      }
-
-      const elapsed = Date.now() - start;
-      if (elapsed >= this.eniWaitTimeoutMs) {
-        this.logger.warn(
-          `Timeout (${this.eniWaitTimeoutMs}ms) cleaning up Lambda VPC ENIs of ${functionName} ` +
-            `(${enis.length} remaining). ` +
-            `Continuing — downstream Subnet/SG deletion will retry as needed.`
-        );
-        return;
-      }
-
-      const remaining = this.eniWaitTimeoutMs - elapsed;
-      const sleepMs = Math.min(delay, remaining);
-      await this.sleep(sleepMs);
-      delay = Math.min(delay * 2, this.eniWaitMaxDelayMs);
     }
   }
 

--- a/tests/unit/provisioning/lambda-function-provider.test.ts
+++ b/tests/unit/provisioning/lambda-function-provider.test.ts
@@ -251,9 +251,11 @@ describe('LambdaFunctionProvider', () => {
         .mockResolvedValueOnce({}); // DeleteFunction
       mockEc2Send.mockResolvedValueOnce({ NetworkInterfaces: [] });
 
-      await provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
+      const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
+      await vi.advanceTimersByTimeAsync(15_000);
+      await promise;
 
       expect(mockLambdaSend).toHaveBeenCalledTimes(3);
       const updateCmd = mockLambdaSend.mock.calls[0][0];
@@ -285,18 +287,20 @@ describe('LambdaFunctionProvider', () => {
         .mockResolvedValueOnce({}); // DeleteFunction
       mockEc2Send.mockResolvedValueOnce({ NetworkInterfaces: [] });
 
-      await provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
+      const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
+      await vi.advanceTimersByTimeAsync(15_000);
+      await promise;
 
       expect(mockLambdaSend).toHaveBeenCalledTimes(3);
       expect(mockLambdaSend.mock.calls[2][0]).toBeInstanceOf(DeleteFunctionCommand);
     });
 
-    it('directly deletes Lambda ENIs after DeleteFunction succeeds', async () => {
+    it('after DeleteFunction sleeps then lists once and per-ENI deletes in parallel', async () => {
       mockLambdaSend
         .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
-        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait)
         .mockResolvedValueOnce({}); // DeleteFunction
 
       mockEc2Send
@@ -309,34 +313,29 @@ describe('LambdaFunctionProvider', () => {
             },
           ],
         })
-        .mockResolvedValueOnce({}) // DeleteNetworkInterface success
-        .mockResolvedValueOnce({ NetworkInterfaces: [] }); // 2nd list: empty
+        .mockResolvedValueOnce({}); // DeleteNetworkInterface success
 
       const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
 
+      // Advance past the initial 10s sleep so list+delete fire.
       await vi.advanceTimersByTimeAsync(15_000);
       await promise;
 
-      expect(mockEc2Send).toHaveBeenCalledTimes(3);
+      // 1 list + 1 DeleteNetworkInterface (no re-list in delstack pattern).
+      expect(mockEc2Send).toHaveBeenCalledTimes(2);
       expect(mockEc2Send.mock.calls[0][0]).toBeInstanceOf(DescribeNetworkInterfacesCommand);
     });
 
     it('matches ENIs whose Description token is a hyphen-prefix of the physical function name (CDK suffix)', async () => {
-      // Real-world AWS pattern: CDK-managed Lambda functions get an
-      // auto-generated 8-char suffix on the physical name
-      // (e.g. CdkdBenchCdkSample-ApiFunction-zZBaJTabq03f), but the AWS
-      // Lambda VPC ENI Description carries only the token *without* that
-      // suffix (AWS Lambda VPC ENI-CdkdBenchCdkSample-ApiFunction).
-      // The matcher must still treat them as belonging to that function.
       const physicalName = 'CdkdBenchCdkSample-ApiFunction-zZBaJTabq03f';
       const eniDescription = 'AWS Lambda VPC ENI-CdkdBenchCdkSample-ApiFunction';
 
       mockLambdaSend
-        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
-        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
-        .mockResolvedValueOnce({}); // DeleteFunction
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } })
+        .mockResolvedValueOnce({});
 
       mockEc2Send
         .mockResolvedValueOnce({
@@ -348,25 +347,22 @@ describe('LambdaFunctionProvider', () => {
             },
           ],
         })
-        .mockResolvedValueOnce({}) // DeleteNetworkInterface
-        .mockResolvedValueOnce({ NetworkInterfaces: [] });
+        .mockResolvedValueOnce({}); // DeleteNetworkInterface
 
       const promise = provider.delete('Fn', physicalName, 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
-
       await vi.advanceTimersByTimeAsync(15_000);
       await promise;
 
-      // 1 list + 1 DeleteNetworkInterface + 1 re-list = 3 calls.
-      expect(mockEc2Send).toHaveBeenCalledTimes(3);
+      expect(mockEc2Send).toHaveBeenCalledTimes(2);
     });
 
     it('rejects ENIs where the function name appears only as a non-hyphen-bounded prefix', async () => {
       mockLambdaSend
-        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
-        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
-        .mockResolvedValueOnce({}); // DeleteFunction
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } })
+        .mockResolvedValueOnce({});
 
       mockEc2Send.mockResolvedValueOnce({
         NetworkInterfaces: [
@@ -378,19 +374,21 @@ describe('LambdaFunctionProvider', () => {
         ],
       });
 
-      await provider.delete('Fn', 'fn', 'AWS::Lambda::Function', {
+      const promise = provider.delete('Fn', 'fn', 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
+      await vi.advanceTimersByTimeAsync(15_000);
+      await promise;
 
-      // Single list call: nothing matched, no DeleteNetworkInterface call.
+      // Only the list — no DeleteNetworkInterface because the token doesn't match.
       expect(mockEc2Send).toHaveBeenCalledTimes(1);
     });
 
     it('paginates DescribeNetworkInterfaces using NextToken', async () => {
       mockLambdaSend
-        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
-        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
-        .mockResolvedValueOnce({}); // DeleteFunction
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } })
+        .mockResolvedValueOnce({});
 
       mockEc2Send
         .mockResolvedValueOnce({
@@ -405,20 +403,21 @@ describe('LambdaFunctionProvider', () => {
         })
         .mockResolvedValueOnce({ NetworkInterfaces: [] });
 
-      await provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
+      const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
+      await vi.advanceTimersByTimeAsync(15_000);
+      await promise;
 
-      // Two list pages, no ENI matched -> no Delete call, single iteration.
       expect(mockEc2Send).toHaveBeenCalledTimes(2);
       expect(mockEc2Send.mock.calls[1][0].input.NextToken).toBe('page2');
     });
 
-    it('retries when DeleteNetworkInterface fails on in-use ENI', async () => {
+    it('retries DeleteNetworkInterface within the per-ENI budget when AWS reports in-use', async () => {
       mockLambdaSend
-        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
-        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
-        .mockResolvedValueOnce({}); // DeleteFunction
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } })
+        .mockResolvedValueOnce({});
 
       mockEc2Send
         .mockResolvedValueOnce({
@@ -431,21 +430,21 @@ describe('LambdaFunctionProvider', () => {
           ],
         })
         .mockRejectedValueOnce(new Error('InvalidParameterValue: in-use'))
-        .mockResolvedValueOnce({ NetworkInterfaces: [] }); // re-list: AWS detached + cleaned up
+        .mockResolvedValueOnce({}); // 2nd attempt succeeds (AWS detached)
 
       const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
-
-      await vi.advanceTimersByTimeAsync(15_000);
+      // Past initial sleep + the 5s retry interval.
+      await vi.advanceTimersByTimeAsync(20_000);
       await expect(promise).resolves.toBeUndefined();
     });
 
-    it('warns and resolves when cleanup hits the timeout (does not throw)', async () => {
+    it('warns and resolves when DeleteNetworkInterface budget runs out', async () => {
       mockLambdaSend
-        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
-        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
-        .mockResolvedValueOnce({}); // DeleteFunction
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } })
+        .mockResolvedValueOnce({});
 
       mockEc2Send.mockImplementation(async (cmd: { constructor: { name: string } }) => {
         if (cmd.constructor.name === 'DescribeNetworkInterfacesCommand') {
@@ -465,28 +464,26 @@ describe('LambdaFunctionProvider', () => {
       const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
-
-      await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+      // Past initial sleep + the 90s budget for DeleteNetworkInterface retries.
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
       await expect(promise).resolves.toBeUndefined();
     });
 
-    it('continues polling after a transient DescribeNetworkInterfaces failure', async () => {
+    it('returns gracefully when the initial DescribeNetworkInterfaces fails', async () => {
       mockLambdaSend
-        .mockResolvedValueOnce({}) // UpdateFunctionConfiguration (pre-detach)
-        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // GetFunction (wait for Active)
-        .mockResolvedValueOnce({}); // DeleteFunction
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } })
+        .mockResolvedValueOnce({});
 
-      mockEc2Send
-        .mockRejectedValueOnce(new Error('ThrottlingException'))
-        .mockResolvedValueOnce({ NetworkInterfaces: [] });
+      mockEc2Send.mockRejectedValueOnce(new Error('ThrottlingException'));
 
       const promise = provider.delete('Fn', 'fn-vpc', 'AWS::Lambda::Function', {
         VpcConfig: { SubnetIds: ['subnet-aaa'], SecurityGroupIds: ['sg-1'] },
       });
-
       await vi.advanceTimersByTimeAsync(15_000);
+      // Subnet/SG provider will retry from its side, so list-failure is non-fatal.
       await expect(promise).resolves.toBeUndefined();
-      expect(mockEc2Send).toHaveBeenCalledTimes(2);
+      expect(mockEc2Send).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Real-AWS verification of v0.3.3 (#42) **still failed destroy** with the same `Subnet has dependencies` symptom. Root cause: Lambda's post-DeleteFunction ENI cleanup loop ran out of its 10-minute budget while ENIs were still in-use, then warn-and-continued, leaving the ENIs attached and downstream Subnet / SG deletes failing.

This PR mirrors **delstack** exactly (which uses the same approach successfully) and adds a **side-channel sweep on the EC2 side**.

## Changes

### `LambdaFunctionProvider.cleanupLambdaEnis` — delstack pattern

Replaces the previous list/delete loop with the exact pattern in [`delstack/internal/preprocessor/lambda_vpc_detacher.go`](https://github.com/go-to-k/delstack/blob/main/internal/preprocessor/lambda_vpc_detacher.go) + [`pkg/client/ec2.go`](https://github.com/go-to-k/delstack/blob/main/pkg/client/ec2.go):

1. Initial **10s sleep** so `DescribeNetworkInterfaces` sees the post-detach ENI state. The previous loop misread an early empty list as "cleanup done" and short-circuited.
2. List **once** (with pagination).
3. Per-ENI **parallel delete with a 90s budget each** (5s retry interval). `InvalidNetworkInterfaceID.NotFound` is treated as success.

### `EC2Provider.deleteSubnet` / `deleteSecurityGroup` — last-resort sweep

When the call fails with `has dependencies` / `has a dependent object`, run an inline `cleanupSubnetLambdaEnis` / `cleanupSecurityGroupLambdaEnis`:

```ts
DescribeNetworkInterfaces({
  Filters: [
    { Name: 'subnet-id' /* or 'group-id' */, Values: [physicalId] },
    { Name: 'requester-id', Values: ['*:awslambda_*'] },
  ],
})
.then(enis => Promise.all(enis.map(eni => DeleteNetworkInterface(eni.id))))
.then(() => sleep + retry the subnet/SG delete)
```

This is the safety net for cases where AWS's eventually-consistent ENI release lands after Lambda's per-ENI 90s window but during the Subnet/SG retry budget.

## Test plan
- [x] 13 unit tests including budget-exceeded path, prefix-collision rejection, NextToken pagination (655 tests pass)
- [x] `pnpm typecheck` / `lint` / `build` all pass
- [ ] `bench-cdk-sample` integ deploy + destroy on the merged main, confirming zero orphan resources
