### PR TITLE
chore(harness): close the integ-destroy bypass route in the gate hook

### DIFF
--- a/.claude/hooks/integ-destroy-gate.sh
+++ b/.claude/hooks/integ-destroy-gate.sh
@@ -51,18 +51,20 @@ Blocked by integ-destroy-gate: this PR touches deletion logic
 (provider delete(), destroy.ts, dag-builder, IMPLICIT_DELETE_DEPENDENCIES,
 or similar) and the `integ-destroy` marker is stale.
 
-Required:
+Required action — no exceptions:
   /run-integ <test-name>      # e.g. /run-integ bench-cdk-sample
 
-The skill must report:
-  - destroy completed: 0 errors
+The skill is the ONLY legitimate setter of this marker. It will run
+deploy + destroy against real AWS and only call
+`markgate set integ-destroy` if BOTH of the following hold:
+  - destroy completed with 0 errors
   - 0 orphan resources after the post-destroy verification
 
-Only then will it set the `integ-destroy` marker and let the merge
-through. If you genuinely need to bypass (rare — typically only when
-you have a verified-good run from an earlier commit and the diff is
-docs/test-only), reset the marker manually and document why in the PR
-body:
-    mise exec -- markgate set integ-destroy
+Do NOT call `markgate set integ-destroy` directly from a shell to
+bypass this hook. The whole point of the gate is that an unverified
+destroy cannot reach main; setting the marker by hand defeats it. If
+you believe the file in scope is genuinely unrelated to deletion
+behavior, the right fix is to narrow `.markgate.yml` integ-destroy
+scope, not to bypass the marker.
 EOF
 exit 2


### PR DESCRIPTION
## Summary

Follow-up to #46. The hook script's blocked-message documented a "rare cases" escape hatch:

```
mise exec -- markgate set integ-destroy
```

That undermines the whole point of the gate. The marker exists to guarantee that an unverified destroy can't reach main; if the agent or developer is allowed to hand-flip it the moment the hook complains, we're back to the advisory rule we replaced (the one that produced the v0.3.0 → v0.3.5 chain of broken-destroy releases).

## Changes

- **Hook message rewritten**: removes the bypass instructions; states unambiguously that the only legitimate response is to call `/run-integ`, and that scope problems should be fixed by narrowing `.markgate.yml integ-destroy.include` (a reviewable change), not by flipping the marker by hand (an invisible one).
- **Memory feedback added** (`feedback_no_markgate_bypass.md`): instructs me to refuse `markgate set integ-destroy` from a Bash command even when explicitly asked. The right answer to a false-positive scope is a scope-narrowing PR.

## End-to-end flow after this PR

```
scope-touching edit
  → markgate stale (auto)
  → gh pr merge blocked (auto)
  → hook message tells agent to /run-integ
  → agent calls /run-integ
  → skill flips marker iff destroy was clean (auto)
  → merge unblocked (auto)
```

No human judgement step, no hand-flips available. This is the structural enforcement we wanted in #46 but didn't fully close.

## Test plan
- [x] Hook script syntax (`bash -n .claude/hooks/integ-destroy-gate.sh`)
- [x] Memory feedback indexed in `MEMORY.md`
- [x] PR diff is `.claude/**` only — `integ-destroy` scope unaffected, so this PR itself is mergeable without an integ run
