### PR TITLE
feat(cli): live multi-line progress display for in-flight resources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ pnpm run typecheck
 - **src/types/assembly.ts** - Cloud Assembly types (AssemblyManifest, MissingContext, etc.)
 - **src/provisioning/register-providers.ts** - Shared provider registration (called from deploy.ts and destroy.ts)
 - **src/types/** - Type definitions (config, state, resources, assembly, etc.)
-- **src/utils/** - Logger, error handler, AWS client factory
+- **src/utils/** - Logger, live progress renderer (multi-line in-flight task display), error handler, AWS client factory
 - **build.mjs** - esbuild build script (ESM modules)
 - **vitest.config.ts** - Vitest configuration
 
@@ -338,6 +338,7 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 - ✅ CREATE retry with exponential backoff (IAM propagation delays)
 - ✅ CC API polling with exponential backoff (1s→2s→4s→8s→10s)
 - ✅ Compact output mode (default clean output, `--verbose` for full details)
+- ✅ Live progress renderer (`src/utils/live-renderer.ts`) — multi-line in-flight task area at the bottom of the terminal during `deploy` / `destroy`, showing `Creating <logical-id>...` / `Deleting <logical-id>...` lines that disappear as each resource completes. Self-disables on non-TTY and when `CDKD_NO_LIVE=1` (the CLI sets this in `--verbose` mode so debug logs do not interleave with the live area)
 - ✅ `--state-bucket` auto-resolves from STS account ID: `cdkd-state-{accountId}-{region}`
 - ✅ CC API GetResource returns GetAtt-compatible attribute names (no mapping needed)
 - ✅ Unit tests, integration examples, E2E test script

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -55,6 +55,9 @@ async function deployCommand(
 
   if (options.verbose) {
     logger.setLevel('debug');
+    // Disable the live progress renderer in verbose mode — debug logs would
+    // interleave too aggressively with the live area's in-flight task lines.
+    process.env['CDKD_NO_LIVE'] = '1';
   }
 
   // Skip waiting for async resources (CloudFront, RDS, ElastiCache, etc.)

--- a/src/cli/commands/destroy.ts
+++ b/src/cli/commands/destroy.ts
@@ -9,6 +9,7 @@ import {
   parseContextOptions,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
+import { getLiveRenderer } from '../../utils/live-renderer.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer } from '../../synthesis/synthesizer.js';
 import { S3StateBackend } from '../../state/s3-state-backend.js';
@@ -45,6 +46,9 @@ async function destroyCommand(
 
   if (options.verbose) {
     logger.setLevel('debug');
+    // Disable the live progress renderer in verbose mode — debug logs would
+    // interleave too aggressively with the live area's in-flight task lines.
+    process.env['CDKD_NO_LIVE'] = '1';
   }
 
   // Resolve --state-bucket from CLI, env, cdk.json, or default
@@ -227,6 +231,12 @@ async function destroyCommand(
       logger.info(`\nAcquiring lock for stack ${stackName}...`);
       await lockManager.acquireLock(stackName, 'destroy');
 
+      // Live progress renderer (multi-line in-flight display at bottom of TTY).
+      // Self-disables on non-TTY and when `CDKD_NO_LIVE=1` is set (the CLI
+      // sets this in verbose mode).
+      const renderer = getLiveRenderer();
+      renderer.start();
+
       try {
         // 6. Build dependency graph from current state
         logger.info('Building dependency graph...');
@@ -312,6 +322,7 @@ async function destroyCommand(
               return;
             }
 
+            renderer.addTask(logicalId, `Deleting ${logicalId} (${resource.resourceType})`);
             try {
               const provider = destroyProviderRegistry.getProvider(resource.resourceType);
               // Retry DELETE for transient errors (throttle, dependency race)
@@ -344,9 +355,11 @@ async function destroyCommand(
               }
               if (lastDeleteError) throw lastDeleteError;
 
+              renderer.removeTask(logicalId);
               logger.info(`  ✅ ${logicalId} (${resource.resourceType}) deleted`);
               deletedCount++;
             } catch (error) {
+              renderer.removeTask(logicalId);
               const msg = error instanceof Error ? error.message : String(error);
               // Treat "not found" as already deleted
               if (
@@ -362,6 +375,10 @@ async function destroyCommand(
                 logger.error(`  ✗ Failed to delete ${logicalId}:`, String(error));
                 errorCount++;
               }
+            } finally {
+              // Safety net for any path that didn't explicitly remove the task.
+              // removeTask is idempotent.
+              renderer.removeTask(logicalId);
             }
           });
 
@@ -380,6 +397,10 @@ async function destroyCommand(
           `\n✓ Stack ${stackName} destroyed (${deletedCount} deleted, ${errorCount} errors)`
         );
       } finally {
+        // Stop live renderer before releasing the lock so any pending in-flight
+        // task lines are cleared cleanly.
+        renderer.stop();
+
         // 9. Release lock
         logger.debug('Releasing lock...');
         await lockManager.releaseLock(stackName);

--- a/src/deployment/deploy-engine.ts
+++ b/src/deployment/deploy-engine.ts
@@ -145,9 +145,13 @@ export class DeployEngine {
     // Register SIGINT handler to save partial state on Ctrl+C
     this.interrupted = false;
     const sigintHandler = () => {
-      process.stderr.write(
-        '\nInterrupted — saving partial state after current operations complete...\n'
-      );
+      // Route the interrupt notice through the live renderer so it does not
+      // collide with the in-flight task display.
+      renderer.printAbove(() => {
+        process.stderr.write(
+          '\nInterrupted — saving partial state after current operations complete...\n'
+        );
+      });
       this.interrupted = true;
     };
     process.on('SIGINT', sigintHandler);
@@ -864,12 +868,17 @@ export class DeployEngine {
     const provider = this.providerRegistry.getProvider(resourceType);
 
     const renderer = getLiveRenderer();
+    const needsReplacement =
+      change.changeType === 'UPDATE' &&
+      (change.propertyChanges?.some((pc) => pc.requiresReplacement) ?? false);
     const verb =
       change.changeType === 'CREATE'
         ? 'Creating'
-        : change.changeType === 'UPDATE'
-          ? 'Updating'
-          : 'Deleting';
+        : change.changeType === 'DELETE'
+          ? 'Deleting'
+          : needsReplacement
+            ? 'Replacing'
+            : 'Updating';
     renderer.addTask(logicalId, `${verb} ${logicalId} (${resourceType})`);
 
     try {

--- a/src/deployment/deploy-engine.ts
+++ b/src/deployment/deploy-engine.ts
@@ -1,4 +1,5 @@
 import { getLogger } from '../utils/logger.js';
+import { getLiveRenderer } from '../utils/live-renderer.js';
 import { ProvisioningError } from '../utils/error-handler.js';
 import { setCurrentStackName, applyDefaultNameForFallback } from '../provisioning/resource-name.js';
 import { IntrinsicFunctionResolver } from './intrinsic-function-resolver.js';
@@ -133,6 +134,13 @@ export class DeployEngine {
 
     // Acquire lock with retry (retries up to 3 times with 2s delay for transient lock conflicts)
     await this.lockManager.acquireLockWithRetry(stackName, undefined, 'deploy');
+
+    // Live progress renderer: shows in-flight resources as a multi-line area
+    // at the bottom of the terminal. Self-disables on non-TTY and when
+    // `CDKD_NO_LIVE=1` is set (the CLI sets this in verbose mode so debug
+    // logs do not interleave with the live area).
+    const renderer = getLiveRenderer();
+    renderer.start();
 
     // Register SIGINT handler to save partial state on Ctrl+C
     this.interrupted = false;
@@ -290,6 +298,9 @@ export class DeployEngine {
         durationMs,
       };
     } finally {
+      // Stop live renderer (clears any remaining in-flight task display)
+      renderer.stop();
+
       // Remove SIGINT handler
       process.removeListener('SIGINT', sigintHandler);
 
@@ -852,6 +863,15 @@ export class DeployEngine {
     const resourceType = change.resourceType;
     const provider = this.providerRegistry.getProvider(resourceType);
 
+    const renderer = getLiveRenderer();
+    const verb =
+      change.changeType === 'CREATE'
+        ? 'Creating'
+        : change.changeType === 'UPDATE'
+          ? 'Updating'
+          : 'Deleting';
+    renderer.addTask(logicalId, `${verb} ${logicalId} (${resourceType})`);
+
     try {
       switch (change.changeType) {
         case 'CREATE': {
@@ -898,6 +918,7 @@ export class DeployEngine {
           if (counts) counts.created++;
           if (progress) progress.current++;
           const createPrefix = progress ? `[${progress.current}/${progress.total}] ` : '  ';
+          renderer.removeTask(logicalId);
           this.logger.info(`${createPrefix}✅ ${logicalId} (${resourceType}) created`);
           break;
         }
@@ -997,6 +1018,7 @@ export class DeployEngine {
             if (counts) counts.updated++;
             if (progress) progress.current++;
             const replacePrefix = progress ? `[${progress.current}/${progress.total}] ` : '  ';
+            renderer.removeTask(logicalId);
             this.logger.info(`${replacePrefix}✅ ${logicalId} (${resourceType}) replaced`);
           } else {
             // Normal update (in-place)
@@ -1091,6 +1113,7 @@ export class DeployEngine {
             if (counts) counts.updated++;
             if (progress) progress.current++;
             const updatePrefix = progress ? `[${progress.current}/${progress.total}] ` : '  ';
+            renderer.removeTask(logicalId);
             this.logger.info(`${updatePrefix}✅ ${logicalId} (${resourceType}) updated`);
           }
           break;
@@ -1148,11 +1171,13 @@ export class DeployEngine {
           if (counts) counts.deleted++;
           if (progress) progress.current++;
           const deletePrefix = progress ? `[${progress.current}/${progress.total}] ` : '  ';
+          renderer.removeTask(logicalId);
           this.logger.info(`${deletePrefix}✅ ${logicalId} (${resourceType}) deleted`);
           break;
         }
       }
     } catch (error) {
+      renderer.removeTask(logicalId);
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error(`Failed to ${change.changeType.toLowerCase()} ${logicalId}: ${message}`);
 
@@ -1163,6 +1188,11 @@ export class DeployEngine {
         stateResources[logicalId]?.physicalId,
         error instanceof Error ? error : undefined
       );
+    } finally {
+      // Safety net for early-break paths (UPDATE skip, DeletionPolicy: Retain).
+      // removeTask is idempotent, so calling it again after the explicit calls
+      // above is a no-op.
+      renderer.removeTask(logicalId);
     }
   }
 

--- a/src/utils/live-renderer.ts
+++ b/src/utils/live-renderer.ts
@@ -1,0 +1,133 @@
+/**
+ * Live multi-line progress renderer for the bottom of the terminal.
+ *
+ * Maintains a "live area" listing in-flight tasks (Creating MyBucket...),
+ * redrawn on a spinner timer. Other log output is routed through
+ * {@link LiveRenderer.printAbove} so it appears above the live area without
+ * disturbing the currently-displayed in-flight tasks.
+ *
+ * Design notes:
+ * - Multiple resources can be in flight concurrently (cdkd uses parallel DAG
+ *   dispatch), so a single in-place line overwrite is not enough — each
+ *   in-flight resource is its own line in the live area.
+ * - On non-TTY (CI/log-collection), the renderer stays inactive and
+ *   {@link LiveRenderer.printAbove} falls through to a direct write, so output
+ *   matches the previous append-only behavior.
+ * - In verbose mode (debug level) the caller should not start the renderer:
+ *   debug logs would interleave too aggressively with the live area.
+ */
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const FRAME_INTERVAL_MS = 80;
+const ESC = '\x1b[';
+
+interface Task {
+  label: string;
+  startedAt: number;
+}
+
+export class LiveRenderer {
+  private tasks = new Map<string, Task>();
+  private active = false;
+  private spinnerIndex = 0;
+  private interval: NodeJS.Timeout | null = null;
+  private linesDrawn = 0;
+
+  constructor(private readonly stream: NodeJS.WriteStream = process.stdout) {}
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  /**
+   * Enable the live renderer. No-op if stdout is not a TTY or if
+   * `CDKD_NO_LIVE=1`. Returns true if successfully enabled.
+   */
+  start(): boolean {
+    if (this.active) return true;
+    if (!this.stream.isTTY) return false;
+    if (process.env['CDKD_NO_LIVE'] === '1') return false;
+
+    this.active = true;
+    this.interval = setInterval(() => this.draw(), FRAME_INTERVAL_MS);
+    if (typeof this.interval.unref === 'function') this.interval.unref();
+    return true;
+  }
+
+  stop(): void {
+    if (!this.active) return;
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    this.clear();
+    this.tasks.clear();
+    this.active = false;
+  }
+
+  addTask(id: string, label: string): void {
+    this.tasks.set(id, { label, startedAt: Date.now() });
+    if (this.active) this.draw();
+  }
+
+  removeTask(id: string): void {
+    if (!this.tasks.delete(id)) return;
+    if (this.active) this.draw();
+  }
+
+  /**
+   * Print content above the live area. Clears the live area, runs the writer,
+   * then redraws the live area. When the renderer is inactive, the writer
+   * runs directly so callers can use this unconditionally.
+   */
+  printAbove(write: () => void): void {
+    if (!this.active) {
+      write();
+      return;
+    }
+    this.clear();
+    write();
+    this.draw();
+  }
+
+  private clear(): void {
+    if (this.linesDrawn === 0) return;
+    this.stream.write('\r');
+    for (let i = 0; i < this.linesDrawn; i++) {
+      this.stream.write(`${ESC}1A${ESC}2K`);
+    }
+    this.linesDrawn = 0;
+  }
+
+  private draw(): void {
+    if (!this.active) return;
+    this.clear();
+    if (this.tasks.size === 0) return;
+
+    const frame = SPINNER_FRAMES[this.spinnerIndex % SPINNER_FRAMES.length]!;
+    this.spinnerIndex++;
+
+    const lines: string[] = [];
+    for (const task of this.tasks.values()) {
+      const elapsed = ((Date.now() - task.startedAt) / 1000).toFixed(1);
+      lines.push(`  ${frame} ${task.label} (${elapsed}s)`);
+    }
+    this.stream.write(lines.join('\n') + '\n');
+    this.linesDrawn = lines.length;
+  }
+}
+
+let globalRenderer: LiveRenderer | null = null;
+
+export function getLiveRenderer(): LiveRenderer {
+  if (!globalRenderer) globalRenderer = new LiveRenderer();
+  return globalRenderer;
+}
+
+/**
+ * Reset the singleton (for tests).
+ */
+export function resetLiveRenderer(): void {
+  if (globalRenderer) globalRenderer.stop();
+  globalRenderer = null;
+}

--- a/src/utils/live-renderer.ts
+++ b/src/utils/live-renderer.ts
@@ -32,6 +32,8 @@ export class LiveRenderer {
   private spinnerIndex = 0;
   private interval: NodeJS.Timeout | null = null;
   private linesDrawn = 0;
+  private cursorHidden = false;
+  private exitListener: (() => void) | null = null;
 
   constructor(private readonly stream: NodeJS.WriteStream = process.stdout) {}
 
@@ -49,6 +51,14 @@ export class LiveRenderer {
     if (process.env['CDKD_NO_LIVE'] === '1') return false;
 
     this.active = true;
+    this.hideCursor();
+    // Restore the cursor on abrupt process exit (e.g., uncaught exception
+    // before stop() runs). Removed in stop() to avoid leaking listeners
+    // across renderer instances.
+    if (!this.exitListener) {
+      this.exitListener = () => this.showCursor();
+      process.on('exit', this.exitListener);
+    }
     this.interval = setInterval(() => this.draw(), FRAME_INTERVAL_MS);
     if (typeof this.interval.unref === 'function') this.interval.unref();
     return true;
@@ -61,6 +71,11 @@ export class LiveRenderer {
       this.interval = null;
     }
     this.clear();
+    this.showCursor();
+    if (this.exitListener) {
+      process.removeListener('exit', this.exitListener);
+      this.exitListener = null;
+    }
     this.tasks.clear();
     this.active = false;
   }
@@ -107,13 +122,35 @@ export class LiveRenderer {
     const frame = SPINNER_FRAMES[this.spinnerIndex % SPINNER_FRAMES.length]!;
     this.spinnerIndex++;
 
+    // Truncate to terminal width so a long label does not wrap and confuse
+    // the line-up clear logic. Default to 80 if columns is unavailable.
+    const cols = this.stream.columns ?? 80;
     const lines: string[] = [];
     for (const task of this.tasks.values()) {
       const elapsed = ((Date.now() - task.startedAt) / 1000).toFixed(1);
-      lines.push(`  ${frame} ${task.label} (${elapsed}s)`);
+      const raw = `  ${frame} ${task.label} (${elapsed}s)`;
+      lines.push(this.truncate(raw, cols));
     }
     this.stream.write(lines.join('\n') + '\n');
     this.linesDrawn = lines.length;
+  }
+
+  private truncate(s: string, maxLen: number): string {
+    if (s.length <= maxLen) return s;
+    if (maxLen <= 1) return '…';
+    return s.substring(0, maxLen - 1) + '…';
+  }
+
+  private hideCursor(): void {
+    if (this.cursorHidden) return;
+    this.stream.write(`${ESC}?25l`);
+    this.cursorHidden = true;
+  }
+
+  private showCursor(): void {
+    if (!this.cursorHidden) return;
+    this.stream.write(`${ESC}?25h`);
+    this.cursorHidden = false;
   }
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,5 @@
 import type { Logger, LogLevel } from '../types/config.js';
+import { getLiveRenderer } from './live-renderer.js';
 
 /**
  * ANSI color codes
@@ -81,25 +82,29 @@ export class ConsoleLogger implements Logger {
 
   debug(message: string, ...args: unknown[]): void {
     if (this.shouldLog('debug')) {
-      console.debug(this.formatMessage('debug', message, ...args));
+      const formatted = this.formatMessage('debug', message, ...args);
+      getLiveRenderer().printAbove(() => console.debug(formatted));
     }
   }
 
   info(message: string, ...args: unknown[]): void {
     if (this.shouldLog('info')) {
-      console.info(this.formatMessage('info', message, ...args));
+      const formatted = this.formatMessage('info', message, ...args);
+      getLiveRenderer().printAbove(() => console.info(formatted));
     }
   }
 
   warn(message: string, ...args: unknown[]): void {
     if (this.shouldLog('warn')) {
-      console.warn(this.formatMessage('warn', message, ...args));
+      const formatted = this.formatMessage('warn', message, ...args);
+      getLiveRenderer().printAbove(() => console.warn(formatted));
     }
   }
 
   error(message: string, ...args: unknown[]): void {
     if (this.shouldLog('error')) {
-      console.error(this.formatMessage('error', message, ...args));
+      const formatted = this.formatMessage('error', message, ...args);
+      getLiveRenderer().printAbove(() => console.error(formatted));
     }
   }
 

--- a/tests/unit/utils/live-renderer.test.ts
+++ b/tests/unit/utils/live-renderer.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { LiveRenderer } from '../../../src/utils/live-renderer.js';
+
+class FakeStream {
+  isTTY = true;
+  chunks: string[] = [];
+  write(s: string): boolean {
+    this.chunks.push(s);
+    return true;
+  }
+  output(): string {
+    return this.chunks.join('');
+  }
+  reset(): void {
+    this.chunks = [];
+  }
+}
+
+function makeRenderer(stream: FakeStream): LiveRenderer {
+  return new LiveRenderer(stream as unknown as NodeJS.WriteStream);
+}
+
+describe('LiveRenderer', () => {
+  beforeEach(() => {
+    delete process.env['CDKD_NO_LIVE'];
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('start() returns false on non-TTY', () => {
+    const stream = new FakeStream();
+    stream.isTTY = false;
+    const r = makeRenderer(stream);
+    expect(r.start()).toBe(false);
+    expect(r.isActive()).toBe(false);
+  });
+
+  it('start() returns false when CDKD_NO_LIVE=1', () => {
+    process.env['CDKD_NO_LIVE'] = '1';
+    const r = makeRenderer(new FakeStream());
+    expect(r.start()).toBe(false);
+    expect(r.isActive()).toBe(false);
+  });
+
+  it('start() activates and stop() deactivates', () => {
+    const r = makeRenderer(new FakeStream());
+    expect(r.start()).toBe(true);
+    expect(r.isActive()).toBe(true);
+    r.stop();
+    expect(r.isActive()).toBe(false);
+  });
+
+  it('addTask draws a line for each in-flight task', () => {
+    const stream = new FakeStream();
+    const r = makeRenderer(stream);
+    r.start();
+    stream.reset();
+
+    r.addTask('A', 'Creating A');
+    const out1 = stream.output();
+    expect(out1).toContain('Creating A');
+
+    r.addTask('B', 'Creating B');
+    const out2 = stream.output();
+    expect(out2).toContain('Creating B');
+    // Most recent draw should contain both labels
+    const lastDraw = stream.chunks[stream.chunks.length - 1] ?? '';
+    expect(lastDraw).toContain('Creating A');
+    expect(lastDraw).toContain('Creating B');
+
+    r.stop();
+  });
+
+  it('removeTask redraws without the removed label', () => {
+    const stream = new FakeStream();
+    const r = makeRenderer(stream);
+    r.start();
+
+    r.addTask('A', 'Creating A');
+    r.addTask('B', 'Creating B');
+    stream.reset();
+
+    r.removeTask('A');
+    const lastDraw = stream.chunks[stream.chunks.length - 1] ?? '';
+    expect(lastDraw).not.toContain('Creating A');
+    expect(lastDraw).toContain('Creating B');
+
+    r.stop();
+  });
+
+  it('removeTask is idempotent (second call is a no-op)', () => {
+    const stream = new FakeStream();
+    const r = makeRenderer(stream);
+    r.start();
+
+    r.addTask('A', 'Creating A');
+    r.removeTask('A');
+    stream.reset();
+
+    r.removeTask('A'); // second remove
+    // Nothing should be written since the task was already removed
+    expect(stream.chunks.length).toBe(0);
+
+    r.stop();
+  });
+
+  it('printAbove falls through directly when inactive', () => {
+    const stream = new FakeStream();
+    const r = makeRenderer(stream);
+    let called = false;
+    r.printAbove(() => {
+      called = true;
+    });
+    expect(called).toBe(true);
+    expect(stream.chunks.length).toBe(0); // renderer wrote nothing itself
+  });
+
+  it('printAbove clears live area, runs writer, redraws when active', () => {
+    const stream = new FakeStream();
+    const r = makeRenderer(stream);
+    r.start();
+    r.addTask('A', 'Creating A');
+    stream.reset();
+
+    let writerRanAt = -1;
+    r.printAbove(() => {
+      writerRanAt = stream.chunks.length;
+    });
+
+    // Sequence should be: clear bytes → writer runs → redraw bytes.
+    // We expect at least one ANSI clear sequence before the writer ran,
+    // and at least one redraw after.
+    expect(writerRanAt).toBeGreaterThan(0);
+    const beforeWriter = stream.chunks.slice(0, writerRanAt).join('');
+    const afterWriter = stream.chunks.slice(writerRanAt).join('');
+    expect(beforeWriter).toContain('\x1b['); // clear
+    expect(afterWriter).toContain('Creating A'); // redraw
+
+    r.stop();
+  });
+
+  it('stop() clears the live area', () => {
+    const stream = new FakeStream();
+    const r = makeRenderer(stream);
+    r.start();
+    r.addTask('A', 'Creating A');
+    stream.reset();
+
+    r.stop();
+    // After stop, a clear sequence should be in the output
+    expect(stream.output()).toContain('\x1b[');
+  });
+
+  it('spinner timer redraws periodically while tasks are in flight', () => {
+    const stream = new FakeStream();
+    const r = makeRenderer(stream);
+    r.start();
+    r.addTask('A', 'Creating A');
+    stream.reset();
+
+    vi.advanceTimersByTime(100); // > 80ms frame interval
+    // Should have drawn at least once
+    expect(stream.chunks.length).toBeGreaterThan(0);
+    expect(stream.output()).toContain('Creating A');
+
+    r.stop();
+  });
+
+  it('does not draw when no tasks are in flight', () => {
+    const stream = new FakeStream();
+    const r = makeRenderer(stream);
+    r.start();
+    stream.reset();
+
+    vi.advanceTimersByTime(200);
+    expect(stream.chunks.length).toBe(0);
+
+    r.stop();
+  });
+
+  it('addTask / removeTask are idempotent silent no-ops when CDKD_NO_LIVE=1', () => {
+    process.env['CDKD_NO_LIVE'] = '1';
+    const stream = new FakeStream();
+    const r = makeRenderer(stream);
+    expect(r.start()).toBe(false);
+
+    // Even with start() refused, the API stays usable (so callers don't have
+    // to branch). It just produces no output.
+    r.addTask('A', 'Creating A');
+    r.removeTask('A');
+    r.removeTask('A');
+    expect(stream.chunks.length).toBe(0);
+  });
+});

--- a/tests/unit/utils/live-renderer.test.ts
+++ b/tests/unit/utils/live-renderer.test.ts
@@ -3,6 +3,7 @@ import { LiveRenderer } from '../../../src/utils/live-renderer.js';
 
 class FakeStream {
   isTTY = true;
+  columns: number | undefined = 200;
   chunks: string[] = [];
   write(s: string): boolean {
     this.chunks.push(s);
@@ -177,6 +178,43 @@ describe('LiveRenderer', () => {
 
     vi.advanceTimersByTime(200);
     expect(stream.chunks.length).toBe(0);
+
+    r.stop();
+  });
+
+  it('hides cursor on start and restores it on stop', () => {
+    const stream = new FakeStream();
+    const r = makeRenderer(stream);
+    r.start();
+    // Cursor-hide ANSI (\x1b[?25l) should have been written during start
+    expect(stream.output()).toContain('\x1b[?25l');
+
+    stream.reset();
+    r.stop();
+    // Cursor-show ANSI (\x1b[?25h) should be written during stop
+    expect(stream.output()).toContain('\x1b[?25h');
+  });
+
+  it('truncates labels that exceed terminal width', () => {
+    const stream = new FakeStream();
+    stream.columns = 30;
+    const r = makeRenderer(stream);
+    r.start();
+    stream.reset();
+
+    const longLabel = 'Creating SomeReallyLongResourceLogicalIdThatDefinitelyOverflows';
+    r.addTask('A', longLabel);
+
+    const out = stream.output();
+    // The full long label must not appear (it would have wrapped). The
+    // ellipsis indicates truncation.
+    expect(out).not.toContain(longLabel);
+    expect(out).toContain('…');
+    // Each rendered line must fit within the column budget. The renderer
+    // writes lines separated by '\n', plus a trailing newline; check the
+    // longest non-empty line.
+    const longest = out.split('\n').reduce((m, l) => Math.max(m, l.length), 0);
+    expect(longest).toBeLessThanOrEqual(30);
 
     r.stop();
   });


### PR DESCRIPTION
## Summary
- Adds a multi-line live progress area at the bottom of the terminal during `deploy` / `destroy`, showing each in-flight resource with a spinner (`⠹ Creating MyBucket (AWS::S3::Bucket) (3.2s)`). Each line moves above as a checkmark once the resource finishes, similar to Docker Compose / pnpm install.
- Required because cdkd runs many resources in parallel (`--concurrency`, default 10) — naive single-line overwrite would not work.
- Self-disables on non-TTY (CI logs are unchanged) and when `CDKD_NO_LIVE=1` is set. The deploy/destroy CLIs set that env var under `--verbose` so debug logs do not interleave with the live area.

## How it works
- New `src/utils/live-renderer.ts` owns the live area: maintains an in-flight task map, redraws on an 80 ms spinner timer, and exposes `printAbove(write)` so any other output (log lines from the existing logger) clears the live area, prints, then redraws.
- `src/utils/logger.ts` routes `info` / `warn` / `error` / `debug` through `printAbove`. When the renderer is inactive, `printAbove` falls through to a direct write — equivalent to the previous behavior.
- `src/deployment/deploy-engine.ts` `provisionResource` calls `addTask` at the start of CREATE / UPDATE / DELETE and `removeTask` immediately before the completion log; a `finally` is the safety net for early-break paths (UPDATE skip, DeletionPolicy: Retain) and any exceptions.
- `src/cli/commands/destroy.ts` does the same around its parallel delete loop.

## Notes / known limitations
- Replacement updates show "Updating X" in the live area while the detail logs above say "Replacing X / Creating new / Deleting old". Acceptable for v1; could be polished by detecting replacement upfront.
- The clear logic assumes each task fits on one terminal row. With default `--concurrency 10` and typical labels this holds; very narrow terminals or unusually long labels could wrap and leave artifacts.
- Spinner uses Braille glyphs (consistent with most modern spinner libs); should render fine on any UTF-8 terminal.

## Test plan
- [x] `pnpm run typecheck` / `lint:fix` / `build` / `vitest --run` (all 667 tests pass, 12 new for `LiveRenderer`)
- [x] Documentation updated (CLAUDE.md `src/utils/` line + Recently Implemented entry)
- [ ] Manual TTY check: run a real deploy and confirm the live area renders correctly and clears on completion (suggest `/run-integ basic` or `/run-integ lambda`)
- [ ] CI / non-TTY check: redirect deploy output to a file (`cdkd deploy ... > out.log`) and confirm the file contains only the existing append-only log lines
- [ ] Verbose check: `cdkd deploy --verbose` should produce the same debug output as before (no spinner)
