### PR TITLE
feat(cli): accept CDK display path (Stage/Stack) for stack selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ pnpm run typecheck
 ### Important Files
 
 - **src/cli/config-loader.ts** - Config resolution (cdk.json, env vars for `--app` and `--state-bucket`)
+- **src/cli/stack-matcher.ts** - Shared stack-name matcher used by deploy/diff/destroy. Routes patterns by whether they contain `/` (display-path) or not (physical name) and returns a deduplicated union.
 - **src/synthesis/app-executor.ts** - Executes CDK app as subprocess with proper env vars (CDK_OUTDIR, CDK_CONTEXT_JSON, CDK_DEFAULT_REGION, etc.)
 - **src/synthesis/assembly-reader.ts** - Reads and parses Cloud Assembly manifest.json directly
 - **src/synthesis/synthesizer.ts** - Orchestrates synthesis with context provider loop
@@ -195,6 +196,7 @@ registry.register('AWS::IAM::Role', new IAMRoleProvider());
 - Stack names are positional arguments: `cdkd deploy MyStack` (not `--stack-name`)
 - `--all` flag targets all stacks for deploy/diff/destroy (`destroy --all` only targets stacks from the current CDK app via synthesis)
 - Wildcard support: `cdkd deploy 'My*'`
+- Stack selection accepts both forms (CDK CLI parity): the **physical** CloudFormation stack name (`MyStage-MyStack`) and the **hierarchical display path** from CDK synth (`MyStage/MyStack`). Patterns containing `/` are matched against the display path; patterns without `/` are matched against the physical name. This makes Stage-scoped wildcards like `cdkd deploy 'MyStage/*'` work as expected. For `destroy`, display-path matching requires synth to succeed (state alone only carries physical names). Implemented in `src/cli/stack-matcher.ts`.
 - Single stack auto-detected (no stack name needed)
 - Concurrency options: `--concurrency` (resource ops, default 10), `--stack-concurrency` (stacks, default 4), `--asset-publish-concurrency` (S3+ECR, default 8), `--image-build-concurrency` (Docker builds, default 4)
 - `-y` / `--yes` is a global flag (CDK CLI parity) that auto-confirms interactive prompts (e.g. `destroy`). `cdkd destroy` additionally accepts `-f` / `--force` — a destroy-specific flag with the same effect as `-y` in this context (matching CDK CLI, where `--force` is per-subcommand and overlaps with the global `--yes` only in the destroy confirmation path)

--- a/README.md
+++ b/README.md
@@ -380,8 +380,14 @@ cdkd deploy Stack1 Stack2
 # Deploy all stacks
 cdkd deploy --all
 
-# Deploy with wildcard
+# Deploy with wildcard (matched against the physical CloudFormation stack name)
 cdkd deploy 'My*'
+
+# Deploy stacks under a CDK Stage using the hierarchical path (CDK CLI parity)
+# Patterns containing '/' are routed to the CDK display path; both forms work:
+cdkd deploy 'MyStage/*'        # all stacks under MyStage
+cdkd deploy MyStage/Api        # specific stack by display path
+cdkd deploy MyStage-Api        # same stack by physical CloudFormation name
 
 # Deploy with context values
 cdkd deploy -c env=staging -c featureFlag=true

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -22,6 +22,7 @@ import { DeployEngine } from '../../deployment/deploy-engine.js';
 import { WorkGraph } from '../../deployment/work-graph.js';
 import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
 import { resolveApp, resolveStateBucketWithDefault } from '../config-loader.js';
+import { matchStacks, describeStack } from '../stack-matcher.js';
 
 /**
  * Deploy command implementation
@@ -132,19 +133,13 @@ async function deployCommand(
     if (options.all) {
       targetStacks = allStacks;
     } else if (stackPatterns.length > 0) {
-      targetStacks = allStacks.filter((s) =>
-        stackPatterns.some((pattern) =>
-          pattern.includes('*')
-            ? new RegExp('^' + pattern.replace(/\*/g, '.*') + '$').test(s.stackName)
-            : s.stackName === pattern
-        )
-      );
+      targetStacks = matchStacks(allStacks, stackPatterns);
     } else if (allStacks.length === 1) {
       // Single stack: auto-select
       targetStacks = allStacks;
     } else {
       throw new Error(
-        `Multiple stacks found: ${allStacks.map((s) => s.stackName).join(', ')}. ` +
+        `Multiple stacks found: ${allStacks.map(describeStack).join(', ')}. ` +
           `Specify stack name(s) or use --all`
       );
     }
@@ -152,7 +147,7 @@ async function deployCommand(
     if (targetStacks.length === 0) {
       throw new Error(
         stackPatterns.length > 0
-          ? `No stacks matching ${stackPatterns.join(', ')} found in assembly. Available: ${allStacks.map((s) => s.stackName).join(', ')}`
+          ? `No stacks matching ${stackPatterns.join(', ')} found in assembly. Available: ${allStacks.map(describeStack).join(', ')}`
           : 'No stacks found in assembly'
       );
     }
@@ -346,7 +341,10 @@ async function deployCommand(
 export function createDeployCommand(): Command {
   const cmd = new Command('deploy')
     .description('Deploy CDK app using SDK/Cloud Control API')
-    .argument('[stacks...]', 'Stack name(s) to deploy (supports wildcards)')
+    .argument(
+      '[stacks...]',
+      "Stack name(s) to deploy. Accepts physical CloudFormation names (e.g. 'MyStage-Api') or CDK display paths (e.g. 'MyStage/Api'). Supports wildcards (e.g. 'MyStage/*')."
+    )
     .option('--all', 'Deploy all stacks', false)
     .action(withErrorHandling(deployCommand));
 

--- a/src/cli/commands/destroy.ts
+++ b/src/cli/commands/destroy.ts
@@ -20,6 +20,7 @@ import { registerAllProviders } from '../../provisioning/register-providers.js';
 import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
 import * as readline from 'node:readline/promises';
 import { resolveApp, resolveStateBucketWithDefault } from '../config-loader.js';
+import { matchStacks, describeStack, type StackLike } from '../stack-matcher.js';
 
 /**
  * Destroy command implementation
@@ -88,7 +89,7 @@ async function destroyCommand(
     // 2. Resolve stacks to destroy (CDK CLI compatible behavior)
     // Always synth to determine which stacks belong to this CDK app.
     const appCmd = options.app || resolveApp();
-    let appStackNames: string[] = [];
+    let appStacks: StackLike[] = [];
 
     if (appCmd) {
       try {
@@ -99,21 +100,27 @@ async function destroyCommand(
           output: options.output || 'cdk.out',
           ...(Object.keys(context).length > 0 && { context }),
         });
-        appStackNames = result.stacks.map((s) => s.stackName);
+        appStacks = result.stacks.map((s) => ({
+          stackName: s.stackName,
+          displayName: s.displayName,
+        }));
       } catch {
         logger.debug('Could not synthesize app, falling back to state-based stack list');
       }
     }
 
-    // Determine candidate stacks
+    // Determine candidate stacks. State only carries physical names, so when synth
+    // is unavailable we fall back to a stackName-only candidate list (display-path
+    // patterns like "MyStage/MyStack" simply will not match anything in that mode).
     const allStateStacks = await stateBackend.listStacks();
-    let candidateStacks: string[];
-    if (appStackNames.length > 0) {
+    let candidateStacks: StackLike[];
+    if (appStacks.length > 0) {
       // App synth succeeded: only consider stacks from this app
-      candidateStacks = appStackNames.filter((name) => allStateStacks.includes(name));
+      const stateSet = new Set(allStateStacks);
+      candidateStacks = appStacks.filter((s) => stateSet.has(s.stackName));
     } else if (stackArgs.length > 0 || options.stack || options.all) {
       // No synth but explicit stack names or --all given: use state stacks
-      candidateStacks = allStateStacks;
+      candidateStacks = allStateStacks.map((name) => ({ stackName: name }));
     } else {
       // No synth and no explicit stacks: refuse to guess
       throw new Error(
@@ -127,25 +134,19 @@ async function destroyCommand(
     let stackNames: string[];
     if (options.all) {
       // --all: destroy all stacks in the current app
-      stackNames = candidateStacks;
+      stackNames = candidateStacks.map((s) => s.stackName);
     } else if (stackPatterns.length > 0) {
       // Explicit stack names or wildcards
-      stackNames = candidateStacks.filter((name) =>
-        stackPatterns.some((pattern) =>
-          pattern.includes('*')
-            ? new RegExp('^' + pattern.replace(/\*/g, '.*') + '$').test(name)
-            : name === pattern
-        )
-      );
+      stackNames = matchStacks(candidateStacks, stackPatterns).map((s) => s.stackName);
     } else if (candidateStacks.length === 1) {
       // Single stack: auto-select (CDK CLI compatible)
-      stackNames = candidateStacks;
+      stackNames = candidateStacks.map((s) => s.stackName);
     } else if (candidateStacks.length === 0) {
       logger.info('No stacks found in state');
       return;
     } else {
       throw new Error(
-        `Multiple stacks found: ${candidateStacks.join(', ')}. ` +
+        `Multiple stacks found: ${candidateStacks.map(describeStack).join(', ')}. ` +
           `Specify stack name(s) or use --all`
       );
     }
@@ -405,7 +406,10 @@ async function destroyCommand(
 export function createDestroyCommand(): Command {
   const cmd = new Command('destroy')
     .description('Destroy all resources in the stack')
-    .argument('[stacks...]', 'Stack name(s) to destroy (supports wildcards)')
+    .argument(
+      '[stacks...]',
+      "Stack name(s) to destroy. Accepts physical CloudFormation names (e.g. 'MyStage-Api') or CDK display paths (e.g. 'MyStage/Api'). Supports wildcards (e.g. 'MyStage/*')."
+    )
     .option('--all', 'Destroy all stacks', false)
     .action(withErrorHandling(destroyCommand));
 

--- a/src/cli/commands/diff.ts
+++ b/src/cli/commands/diff.ts
@@ -15,6 +15,7 @@ import { DiffCalculator } from '../../analyzer/diff-calculator.js';
 import { IntrinsicFunctionResolver } from '../../deployment/intrinsic-function-resolver.js';
 import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
 import { resolveApp, resolveStateBucketWithDefault } from '../config-loader.js';
+import { matchStacks, describeStack } from '../stack-matcher.js';
 
 const INTRINSIC_KEYS = new Set([
   'Ref',
@@ -161,18 +162,12 @@ async function diffCommand(
     if (options.all) {
       targetStacks = allStacks;
     } else if (stackPatterns.length > 0) {
-      targetStacks = allStacks.filter((s) =>
-        stackPatterns.some((pattern) =>
-          pattern.includes('*')
-            ? new RegExp('^' + pattern.replace(/\*/g, '.*') + '$').test(s.stackName)
-            : s.stackName === pattern
-        )
-      );
+      targetStacks = matchStacks(allStacks, stackPatterns);
     } else if (allStacks.length === 1) {
       targetStacks = allStacks;
     } else {
       throw new Error(
-        `Multiple stacks found: ${allStacks.map((s) => s.stackName).join(', ')}. ` +
+        `Multiple stacks found: ${allStacks.map(describeStack).join(', ')}. ` +
           `Specify stack name(s) or use --all`
       );
     }
@@ -180,7 +175,7 @@ async function diffCommand(
     if (targetStacks.length === 0) {
       throw new Error(
         stackPatterns.length > 0
-          ? `No stacks matching ${stackPatterns.join(', ')} found in assembly`
+          ? `No stacks matching ${stackPatterns.join(', ')} found in assembly. Available: ${allStacks.map(describeStack).join(', ')}`
           : 'No stacks found in assembly'
       );
     }
@@ -293,7 +288,10 @@ async function diffCommand(
 export function createDiffCommand(): Command {
   const cmd = new Command('diff')
     .description('Show difference between current state and desired state')
-    .argument('[stacks...]', 'Stack name(s) to diff (supports wildcards)')
+    .argument(
+      '[stacks...]',
+      "Stack name(s) to diff. Accepts physical CloudFormation names (e.g. 'MyStage-Api') or CDK display paths (e.g. 'MyStage/Api'). Supports wildcards (e.g. 'MyStage/*')."
+    )
     .option('--all', 'Diff all stacks', false)
     .action(withErrorHandling(diffCommand));
 

--- a/src/cli/stack-matcher.ts
+++ b/src/cli/stack-matcher.ts
@@ -1,0 +1,61 @@
+/**
+ * Match stacks against user-supplied name patterns.
+ *
+ * Patterns are evaluated against two fields:
+ *
+ * - `stackName` — the physical CloudFormation stack name (e.g. `MyStage-MyStack`)
+ * - `displayName` — the hierarchical CDK path (e.g. `MyStage/MyStack`); falls
+ *   back to `stackName` when the assembly does not carry one
+ *
+ * Routing is decided by whether the pattern contains `/`:
+ *
+ * - Pattern contains `/` → matched only against `displayName` (a `/` cannot
+ *   appear in a CloudFormation stack name, so this is unambiguous)
+ * - Pattern contains no `/` → matched only against `stackName`
+ *
+ * Wildcards (`*`) are supported in either case. Results are de-duplicated by
+ * `stackName`, so a pattern that incidentally matches the same stack via both
+ * fields is returned only once.
+ */
+export interface StackLike {
+  stackName: string;
+  displayName?: string;
+}
+
+export function matchStacks<T extends StackLike>(stacks: T[], patterns: string[]): T[] {
+  if (patterns.length === 0) return [];
+
+  const seen = new Set<string>();
+  const result: T[] = [];
+
+  for (const stack of stacks) {
+    const matched = patterns.some((pattern) => stackMatchesPattern(stack, pattern));
+    if (matched && !seen.has(stack.stackName)) {
+      seen.add(stack.stackName);
+      result.push(stack);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Render a stack for diagnostic messages. When `displayName` differs from the
+ * physical name, both are shown so the user can see which forms are valid as
+ * patterns (e.g. `MyStage-Api (MyStage/Api)`).
+ */
+export function describeStack(stack: StackLike): string {
+  if (stack.displayName && stack.displayName !== stack.stackName) {
+    return `${stack.stackName} (${stack.displayName})`;
+  }
+  return stack.stackName;
+}
+
+export function stackMatchesPattern(stack: StackLike, pattern: string): boolean {
+  const target = pattern.includes('/') ? (stack.displayName ?? stack.stackName) : stack.stackName;
+  if (pattern.includes('*')) {
+    const regex = new RegExp('^' + pattern.replace(/\*/g, '.*') + '$');
+    return regex.test(target);
+  }
+  return target === pattern;
+}

--- a/src/synthesis/assembly-reader.ts
+++ b/src/synthesis/assembly-reader.ts
@@ -16,8 +16,15 @@ import { SynthesisError } from '../utils/error-handler.js';
  * Stack information extracted from cloud assembly
  */
 export interface StackInfo {
-  /** Stack name */
+  /** Physical CloudFormation stack name (e.g., "MyStage-MyStack") */
   stackName: string;
+
+  /**
+   * Hierarchical display name from CDK synth (e.g., "MyStage/MyStack" for stacks
+   * under a Stage, or "MyStack" at the top level). Falls back to `stackName` when
+   * the assembly does not carry one.
+   */
+  displayName: string;
 
   /** Artifact ID in manifest */
   artifactId: string;
@@ -233,6 +240,7 @@ export class AssemblyReader {
 
     return {
       stackName,
+      displayName: artifact.displayName ?? stackName,
       artifactId,
       template,
       assetManifestPath,

--- a/src/types/assembly.ts
+++ b/src/types/assembly.ts
@@ -32,6 +32,12 @@ export interface ArtifactManifest {
   /** Target environment (e.g., "aws://123456789012/us-east-1") */
   environment?: string;
 
+  /**
+   * Hierarchical display name (e.g., "MyStage/MyStack" for stacks under a Stage,
+   * or just "MyStack" at the top level). Set by CDK synth.
+   */
+  displayName?: string;
+
   /** Artifact-specific properties */
   properties?: Record<string, unknown>;
 

--- a/tests/unit/cli/stack-matcher.test.ts
+++ b/tests/unit/cli/stack-matcher.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  matchStacks,
+  stackMatchesPattern,
+  describeStack,
+} from '../../../src/cli/stack-matcher.js';
+
+const stacks = [
+  { stackName: 'TopStack', displayName: 'TopStack' },
+  { stackName: 'MyStage-Api', displayName: 'MyStage/Api' },
+  { stackName: 'MyStage-Db', displayName: 'MyStage/Db' },
+  { stackName: 'OtherStage-Api', displayName: 'OtherStage/Api' },
+];
+
+describe('stackMatchesPattern', () => {
+  it('matches by physical stackName when pattern has no slash', () => {
+    expect(stackMatchesPattern(stacks[1]!, 'MyStage-Api')).toBe(true);
+    expect(stackMatchesPattern(stacks[1]!, 'MyStage/Api')).toBe(true);
+  });
+
+  it('routes slash-bearing patterns to displayName only', () => {
+    // pattern has '/', so MyStage-Api stack only matches via displayName
+    expect(stackMatchesPattern(stacks[1]!, 'MyStage/Api')).toBe(true);
+    // Same pattern won't match a stack whose displayName lacks the slash form
+    expect(stackMatchesPattern(stacks[0]!, 'MyStage/Api')).toBe(false);
+  });
+
+  it('treats hyphen patterns as physical names, not display paths', () => {
+    // 'MyStage-Api' must NOT match a displayName 'MyStage/Api' on its own —
+    // the routing rule keeps these strictly separate.
+    const stageOnly = { stackName: 'phys-name', displayName: 'MyStage/Api' };
+    expect(stackMatchesPattern(stageOnly, 'MyStage-Api')).toBe(false);
+  });
+
+  it('supports wildcards on physical names', () => {
+    expect(stackMatchesPattern(stacks[1]!, 'MyStage-*')).toBe(true);
+    expect(stackMatchesPattern(stacks[2]!, 'MyStage-*')).toBe(true);
+    expect(stackMatchesPattern(stacks[3]!, 'MyStage-*')).toBe(false);
+  });
+
+  it('supports wildcards on display paths (Stage-scoped selection)', () => {
+    expect(stackMatchesPattern(stacks[1]!, 'MyStage/*')).toBe(true);
+    expect(stackMatchesPattern(stacks[2]!, 'MyStage/*')).toBe(true);
+    expect(stackMatchesPattern(stacks[3]!, 'MyStage/*')).toBe(false);
+    expect(stackMatchesPattern(stacks[0]!, 'MyStage/*')).toBe(false);
+  });
+
+  it('falls back to stackName when displayName is missing', () => {
+    const s = { stackName: 'OnlyPhysical' };
+    expect(stackMatchesPattern(s, 'OnlyPhysical')).toBe(true);
+    // Slash-bearing pattern still routes to displayName, which falls back
+    // to stackName. A literal slash in stackName is impossible in CFN, so
+    // any '/' pattern simply won't match.
+    expect(stackMatchesPattern(s, 'OnlyPhysical/X')).toBe(false);
+  });
+});
+
+describe('describeStack', () => {
+  it('returns stackName alone when displayName matches', () => {
+    expect(describeStack({ stackName: 'MyStack', displayName: 'MyStack' })).toBe('MyStack');
+  });
+
+  it('returns stackName alone when displayName is missing', () => {
+    expect(describeStack({ stackName: 'MyStack' })).toBe('MyStack');
+  });
+
+  it('appends displayName when it differs from stackName', () => {
+    expect(describeStack({ stackName: 'MyStage-Api', displayName: 'MyStage/Api' })).toBe(
+      'MyStage-Api (MyStage/Api)'
+    );
+  });
+});
+
+describe('matchStacks', () => {
+  it('returns empty when no patterns are given', () => {
+    expect(matchStacks(stacks, [])).toEqual([]);
+  });
+
+  it('selects all stacks under a Stage using a display-path wildcard', () => {
+    const result = matchStacks(stacks, ['MyStage/*']);
+    expect(result.map((s) => s.stackName)).toEqual(['MyStage-Api', 'MyStage-Db']);
+  });
+
+  it('selects exact physical name even when a Stage stack shares the prefix', () => {
+    const result = matchStacks(stacks, ['MyStage-Api']);
+    expect(result.map((s) => s.stackName)).toEqual(['MyStage-Api']);
+  });
+
+  it('deduplicates when multiple patterns match the same stack', () => {
+    const result = matchStacks(stacks, ['MyStage-Api', 'MyStage/Api']);
+    expect(result.map((s) => s.stackName)).toEqual(['MyStage-Api']);
+  });
+
+  it('mixes patterns and accumulates the union', () => {
+    const result = matchStacks(stacks, ['TopStack', 'MyStage/*']);
+    expect(result.map((s) => s.stackName).sort()).toEqual([
+      'MyStage-Api',
+      'MyStage-Db',
+      'TopStack',
+    ]);
+  });
+
+  it('preserves the input order of stacks', () => {
+    const result = matchStacks(stacks, ['*Api*']);
+    // Wildcard patterns without slash route to stackName.
+    expect(result.map((s) => s.stackName)).toEqual(['MyStage-Api', 'OtherStage-Api']);
+  });
+});

--- a/tests/unit/synthesis/assembly-reader.test.ts
+++ b/tests/unit/synthesis/assembly-reader.test.ts
@@ -40,6 +40,7 @@ function createSampleManifest(): AssemblyManifest {
       'MyStack': {
         type: 'aws:cloudformation:stack',
         environment: 'aws://123456789012/us-east-1',
+        displayName: 'MyStack',
         properties: {
           templateFile: 'MyStack.template.json',
           stackName: 'MyStack',
@@ -143,8 +144,67 @@ describe('AssemblyReader', () => {
 
       expect(stacks).toHaveLength(1);
       expect(stacks[0].stackName).toBe('MyStack');
+      expect(stacks[0].displayName).toBe('MyStack');
       expect(stacks[0].artifactId).toBe('MyStack');
       expect(stacks[0].template).toEqual(sampleTemplate);
+    });
+
+    it('should fall back displayName to stackName when artifact has no displayName', () => {
+      const manifest: AssemblyManifest = {
+        version: '38.0.0',
+        artifacts: {
+          'MyStack': {
+            type: 'aws:cloudformation:stack',
+            environment: 'aws://123456789012/us-east-1',
+            properties: {
+              templateFile: 'MyStack.template.json',
+              stackName: 'MyStack',
+            },
+          },
+        },
+      };
+      vi.mocked(readFileSync).mockReturnValueOnce(JSON.stringify(sampleTemplate));
+
+      const stacks = reader.getAllStacks('/tmp/cdk.out', manifest);
+
+      expect(stacks[0].displayName).toBe('MyStack');
+    });
+
+    it('should preserve hierarchical displayName for stacks under a Stage', () => {
+      const topManifest: AssemblyManifest = {
+        version: '38.0.0',
+        artifacts: {
+          'assembly-MyStage': {
+            type: 'cdk:cloud-assembly',
+            properties: { directoryName: 'assembly-MyStage' },
+          },
+        },
+      };
+
+      const nestedManifest: AssemblyManifest = {
+        version: '38.0.0',
+        artifacts: {
+          'MyStageCdkSampleStack': {
+            type: 'aws:cloudformation:stack',
+            environment: 'aws://123456789012/us-east-1',
+            displayName: 'MyStage/CdkSampleStack',
+            properties: {
+              templateFile: 'MyStageCdkSampleStack.template.json',
+              stackName: 'MyStage-CdkSampleStack',
+            },
+          },
+        },
+      };
+
+      vi.mocked(readFileSync)
+        .mockReturnValueOnce(JSON.stringify(nestedManifest))
+        .mockReturnValueOnce(JSON.stringify(sampleTemplate));
+
+      const stacks = reader.getAllStacks('/tmp/cdk.out', topManifest);
+
+      expect(stacks).toHaveLength(1);
+      expect(stacks[0].stackName).toBe('MyStage-CdkSampleStack');
+      expect(stacks[0].displayName).toBe('MyStage/CdkSampleStack');
     });
 
     it('should extract asset manifest paths (type cdk:asset-manifest)', () => {


### PR DESCRIPTION
## Summary

- `cdkd deploy/destroy/diff` now accepts CDK hierarchical display paths (e.g. `MyStage/Api`) in addition to the physical CloudFormation stack name (e.g. `MyStage-Api`). Patterns containing `/` are routed to the display path; patterns without `/` continue to match the physical name. Both forms support wildcards, so `cdkd deploy 'MyStage/*'` deploys every stack under a Stage.
- Aligns with `cdk` CLI, which also accepts either form. Existing hyphen-form usage is unchanged.
- Match logic is centralized in `src/cli/stack-matcher.ts` and shared by all three commands; results from both matching modes are unioned and de-duplicated by physical name.
- Error messages and `--help` text now mention both forms, e.g. `Available: MyStage-Api (MyStage/Api)`.

### Why the `/` vs no-`/` routing is unambiguous

- A `/` cannot appear in a CloudFormation stack name, so a slash-bearing pattern can only refer to a display path.
- A pattern without `/` therefore can only refer to a physical name. There is no overlap on exact matches.
- Wildcards are evaluated in the corresponding mode only; if the same stack happens to match via both modes, the union is de-duplicated by physical name so it is returned once.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `npx vitest --run` (53 files, 672 tests)
- [x] New unit tests added: `tests/unit/cli/stack-matcher.test.ts` (15 tests covering routing, wildcards, dedup, fallback to `stackName` when `displayName` is missing); new assertions in `tests/unit/synthesis/assembly-reader.test.ts` (displayName extraction including hierarchical Stage paths).
