### PR TITLE
feat(cli): add list/ls command (CDK CLI parity)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ pnpm run typecheck
 
 ### Core Directories
 
-- **src/cli/** - CLI command implementations (deploy, destroy, diff, synth, bootstrap, force-unlock), config resolution
+- **src/cli/** - CLI command implementations (deploy, destroy, diff, synth, list/ls, bootstrap, force-unlock), config resolution
 - **src/synthesis/** - CDK app synthesis (self-implemented: subprocess execution, Cloud Assembly parsing, context providers)
 - **src/analyzer/** - DAG builder, template parser, intrinsic function resolution
 - **src/state/** - S3 state backend, lock manager
@@ -111,7 +111,7 @@ pnpm run typecheck
 ### Important Files
 
 - **src/cli/config-loader.ts** - Config resolution (cdk.json, env vars for `--app` and `--state-bucket`)
-- **src/cli/stack-matcher.ts** - Shared stack-name matcher used by deploy/diff/destroy. Routes patterns by whether they contain `/` (display-path) or not (physical name) and returns a deduplicated union.
+- **src/cli/stack-matcher.ts** - Shared stack-name matcher used by deploy/diff/destroy/list. Routes patterns by whether they contain `/` (display-path) or not (physical name) and returns a deduplicated union.
 - **src/synthesis/app-executor.ts** - Executes CDK app as subprocess with proper env vars (CDK_OUTDIR, CDK_CONTEXT_JSON, CDK_DEFAULT_REGION, etc.)
 - **src/synthesis/assembly-reader.ts** - Reads and parses Cloud Assembly manifest.json directly
 - **src/synthesis/synthesizer.ts** - Orchestrates synthesis with context provider loop
@@ -198,6 +198,7 @@ registry.register('AWS::IAM::Role', new IAMRoleProvider());
 - Wildcard support: `cdkd deploy 'My*'`
 - Stack selection accepts both forms (CDK CLI parity): the **physical** CloudFormation stack name (`MyStage-MyStack`) and the **hierarchical display path** from CDK synth (`MyStage/MyStack`). Patterns containing `/` are matched against the display path; patterns without `/` are matched against the physical name. This makes Stage-scoped wildcards like `cdkd deploy 'MyStage/*'` work as expected. For `destroy`, display-path matching requires synth to succeed (state alone only carries physical names). Implemented in `src/cli/stack-matcher.ts`.
 - Single stack auto-detected (no stack name needed)
+- `cdkd list` (alias `ls`) — CDK CLI parity. Default output: each stack's CDK display path on its own line, ordered by dependency. `--long` / `-l` emits structured `{id, name, environment, [dependencies]}` records (YAML, or JSON with `--json`); `--show-dependencies` / `-d` emits `{id, dependencies}` pairs. Positional patterns filter by physical name or display path with the same routing rules as deploy/diff/destroy. No state bucket / AWS credentials needed beyond what synthesis itself requires.
 - Concurrency options: `--concurrency` (resource ops, default 10), `--stack-concurrency` (stacks, default 4), `--asset-publish-concurrency` (S3+ECR, default 8), `--image-build-concurrency` (Docker builds, default 4)
 - `-y` / `--yes` is a global flag (CDK CLI parity) that auto-confirms interactive prompts (e.g. `destroy`). `cdkd destroy` additionally accepts `-f` / `--force` — a destroy-specific flag with the same effect as `-y` in this context (matching CDK CLI, where `--force` is per-subcommand and overlaps with the global `--yes` only in the destroy confirmation path)
 - Implemented in `src/cli/config-loader.ts`
@@ -323,6 +324,7 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 - ✅ CLI: `--app` and `--state-bucket` optional (fallback to env vars / cdk.json)
 - ✅ CLI: Positional stack names, `--all` flag, wildcard support, single stack auto-detection
 - ✅ CLI: `cdkd destroy` accepts `--app` option; confirmation accepts y/yes
+- ✅ CLI: `cdkd list` / `cdkd ls` (CDK CLI parity) — default per-line display path; `--long`, `--show-dependencies`, `--json` for structured output; reuses shared stack-matcher for pattern filtering
 - ✅ Resource replacement: immutable property changes trigger DELETE then CREATE
 - ✅ Custom Resource ResponseURL: S3 pre-signed URL for cfn-response handlers
 - ✅ CloudFormation Parameters support (with default values and type coercion)

--- a/README.md
+++ b/README.md
@@ -342,6 +342,9 @@ alias cdkd="node $(pwd)/dist/cli.js"
 # Bootstrap (creates S3 state bucket - only needed once per account/region)
 cdkd bootstrap
 
+# List stacks in the CDK app
+cdkd list
+
 # Deploy your CDK app
 cdkd deploy
 
@@ -366,6 +369,14 @@ cdkd bootstrap \
 
 # Synthesize only
 cdkd synth --app "npx ts-node app.ts"
+
+# List all stacks in the CDK app (alias: ls)
+cdkd list
+cdkd ls
+cdkd list --long              # YAML records with id/name/environment
+cdkd list --long --json       # same, but JSON
+cdkd list --show-dependencies # id + dependency list per stack
+cdkd list 'MyStage/*'         # filter by display path (CDK CLI parity)
 
 # Deploy from a pre-synthesized cloud assembly directory
 cdkd deploy --app cdk.out

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -642,21 +642,20 @@ aws s3api get-object \
 # }
 ```
 
-#### List Stacks
+#### List Stacks Stored in S3
 
 ```bash
-# Display all stacks
+# Display all stacks present in the state bucket
 aws s3 ls s3://cdkd-state-bucket/stacks/ --recursive \
   | grep state.json \
   | awk '{print $4}' \
   | sed 's|stacks/||; s|/state.json||'
 ```
 
-Or cdkd command (planned for future implementation):
-
-```bash
-cdkd list --state-bucket cdkd-state-bucket
-```
+Note: `cdkd list` (alias `ls`) lists stacks from the local CDK app via
+synthesis (CDK CLI parity — see README), not from the S3 state bucket.
+Listing deployed stacks from the state bucket is currently only supported
+via the AWS CLI snippet above.
 
 ## State Migration and Version Management
 

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -1,0 +1,218 @@
+import { Command } from 'commander';
+import { appOptions, commonOptions, contextOptions, parseContextOptions } from '../options.js';
+import { getLogger } from '../../utils/logger.js';
+import { withErrorHandling } from '../../utils/error-handler.js';
+import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
+import type { StackInfo } from '../../synthesis/assembly-reader.js';
+import { resolveApp } from '../config-loader.js';
+import { matchStacks, describeStack } from '../stack-matcher.js';
+import { toYaml } from '../../utils/yaml.js';
+
+/**
+ * Long-form stack record matching CDK CLI's `cdk list --long` shape.
+ *
+ * See aws-cdk-cli/packages/aws-cdk/lib/cli/cdk-toolkit.ts (`list` method).
+ */
+interface LongStackRecord {
+  id: string;
+  name: string;
+  environment: {
+    account: string;
+    region: string;
+  };
+  dependencies?: string[];
+}
+
+/**
+ * Compact dependency record used when only `--show-dependencies` is set
+ * (without `--long`).
+ */
+interface DependencyRecord {
+  id: string;
+  dependencies: string[];
+}
+
+/**
+ * Sort stacks in dependency (topological) order so a stack always appears
+ * AFTER the stacks it depends on. Falls back to discovery order on cycles
+ * (which the synthesizer would have rejected anyway).
+ */
+function sortByDependency(stacks: StackInfo[]): StackInfo[] {
+  const byName = new Map(stacks.map((s) => [s.stackName, s]));
+  const visited = new Set<string>();
+  const result: StackInfo[] = [];
+
+  const visit = (stack: StackInfo, ancestors: Set<string>): void => {
+    if (visited.has(stack.stackName)) return;
+    if (ancestors.has(stack.stackName)) return; // cycle guard
+    ancestors.add(stack.stackName);
+    for (const depName of stack.dependencyNames) {
+      const dep = byName.get(depName);
+      if (dep) visit(dep, ancestors);
+    }
+    ancestors.delete(stack.stackName);
+    if (!visited.has(stack.stackName)) {
+      visited.add(stack.stackName);
+      result.push(stack);
+    }
+  };
+
+  for (const stack of stacks) {
+    visit(stack, new Set());
+  }
+
+  return result;
+}
+
+/**
+ * Convert a StackInfo to its `--long` JSON representation.
+ */
+function toLongRecord(stack: StackInfo, includeDeps: boolean): LongStackRecord {
+  const record: LongStackRecord = {
+    id: stack.displayName,
+    name: stack.stackName,
+    environment: {
+      account: stack.account ?? 'unknown-account',
+      region: stack.region ?? 'unknown-region',
+    },
+  };
+  if (includeDeps) {
+    record.dependencies = [...stack.dependencyNames];
+  }
+  return record;
+}
+
+/**
+ * List command implementation
+ */
+async function listCommand(
+  patterns: string[],
+  options: {
+    app?: string;
+    output: string;
+    verbose: boolean;
+    region?: string;
+    profile?: string;
+    context?: string[];
+    long: boolean;
+    showDependencies: boolean;
+    json: boolean;
+  }
+): Promise<void> {
+  const logger = getLogger();
+
+  if (options.verbose) {
+    logger.setLevel('debug');
+  }
+
+  // Resolve --app from CLI, env, or cdk.json
+  const app = resolveApp(options.app);
+  if (!app) {
+    throw new Error(
+      'No app command specified. Use --app, set CDKD_APP env var, or add "app" to cdk.json'
+    );
+  }
+
+  logger.debug('Listing stacks...');
+  logger.debug('App command:', app);
+
+  // Synthesize CDK app
+  const synthesizer = new Synthesizer();
+  const context = parseContextOptions(options.context);
+  const synthOptions: SynthesisOptions = {
+    app,
+    output: options.output,
+    ...(options.region && { region: options.region }),
+    ...(options.profile && { profile: options.profile }),
+    ...(Object.keys(context).length > 0 && { context }),
+  };
+
+  const result = await synthesizer.synthesize(synthOptions);
+  const allStacks = result.stacks;
+
+  if (allStacks.length === 0) {
+    throw new Error('No stacks found in assembly');
+  }
+
+  // Filter by patterns if provided. Patterns match against displayName (when
+  // they contain '/') or stackName (otherwise) — same routing rules as
+  // deploy / diff / destroy (see src/cli/stack-matcher.ts).
+  const selected = patterns.length > 0 ? matchStacks(allStacks, patterns) : allStacks;
+
+  if (selected.length === 0) {
+    throw new Error(
+      `No stacks matching ${patterns.join(', ')} found in assembly. ` +
+        `Available: ${allStacks.map(describeStack).join(', ')}`
+    );
+  }
+
+  // Sort by dependency order so output is deterministic and a stack never
+  // precedes a stack it depends on.
+  const sorted = sortByDependency(selected);
+
+  // Output mode selection (mirrors CDK CLI):
+  // - --long → full record per stack (id, name, environment, [dependencies])
+  // - --show-dependencies (without --long) → {id, dependencies} per stack
+  // - default → bare displayName, one per line
+  // - --json switches the structured outputs to JSON instead of YAML.
+  if (options.long) {
+    const records = sorted.map((s) => toLongRecord(s, options.showDependencies));
+    emitStructured(records, options.json);
+    return;
+  }
+
+  if (options.showDependencies) {
+    const records: DependencyRecord[] = sorted.map((s) => ({
+      id: s.displayName,
+      dependencies: [...s.dependencyNames],
+    }));
+    emitStructured(records, options.json);
+    return;
+  }
+
+  for (const stack of sorted) {
+    process.stdout.write(`${stack.displayName}\n`);
+  }
+}
+
+/**
+ * Emit a structured payload as either YAML (default, CDK CLI parity) or
+ * JSON. Routed via stdout so `cdkd list` output is pipeable.
+ */
+function emitStructured(payload: unknown, asJson: boolean): void {
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+  // toYaml emits a leading newline for non-empty arrays/objects; trim so
+  // the output starts at column 0 like CDK CLI does.
+  const yaml = toYaml(payload).replace(/^\n/, '');
+  process.stdout.write(yaml);
+}
+
+/**
+ * Create list command
+ *
+ * Mirrors `cdk list` / `cdk ls` from the AWS CDK CLI. Default output is one
+ * stack id (display path) per line; `--long` / `--show-dependencies` switch
+ * to a structured YAML payload (or JSON with `--json`).
+ */
+export function createListCommand(): Command {
+  const cmd = new Command('list')
+    .alias('ls')
+    .description('List all stacks in the CDK app')
+    .argument(
+      '[stacks...]',
+      "Stack name pattern(s). Accepts physical CloudFormation names (e.g. 'MyStage-Api') or CDK display paths (e.g. 'MyStage/Api'). Supports wildcards (e.g. 'MyStage/*')."
+    )
+    .option('-l, --long', 'Display environment information for each stack', false)
+    .option('-d, --show-dependencies', 'Display stack dependency information for each stack', false)
+    .option('--json', 'Output as JSON instead of YAML for --long / --show-dependencies', false)
+    .action(withErrorHandling(listCommand));
+
+  // Reuse standard options. Note: list doesn't need --state-bucket / --stack
+  // / deploy options — it's a pure local synth + render command.
+  [...commonOptions, ...appOptions, ...contextOptions].forEach((opt) => cmd.addOption(opt));
+
+  return cmd;
+}

--- a/src/cli/commands/synth.ts
+++ b/src/cli/commands/synth.ts
@@ -7,6 +7,7 @@ import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { AssemblyReader } from '../../synthesis/assembly-reader.js';
 import { resolveApp } from '../config-loader.js';
+import { toYaml } from '../../utils/yaml.js';
 
 /**
  * Synth command implementation
@@ -80,61 +81,6 @@ async function synthCommand(options: {
   }
 
   logger.info(`\nOutput: ${assemblyDir}`);
-}
-
-/**
- * Simple JSON to YAML converter (CDK CLI compatible output)
- */
-function toYaml(obj: unknown, indent = 0): string {
-  const prefix = '  '.repeat(indent);
-
-  if (obj === null || obj === undefined) return 'null\n';
-  if (typeof obj === 'boolean') return `${obj}\n`;
-  if (typeof obj === 'number') return `"${obj}"\n`;
-  if (typeof obj === 'string') {
-    // Strings that need quoting
-    if (obj.includes('\n')) {
-      // Multi-line: use single quotes with escaped content
-      return `'${obj.replace(/'/g, "''")}'\n`;
-    }
-    if (obj.startsWith('{') || obj.startsWith('[') || obj.startsWith('"')) {
-      // JSON-like strings: use single quotes (like CDK CLI)
-      return `'${obj.replace(/'/g, "''")}'\n`;
-    }
-    if (obj.includes('#') || obj === '' || obj === 'true' || obj === 'false' || obj === 'null') {
-      return `"${obj}"\n`;
-    }
-    // Plain string (no quoting needed for colons in values like AWS::S3::Bucket)
-    return `${obj}\n`;
-  }
-
-  if (Array.isArray(obj)) {
-    if (obj.length === 0) return '[]\n';
-    let result = '\n';
-    for (const item of obj) {
-      const value = toYaml(item, indent + 1).trimStart();
-      result += `${prefix}- ${value}`;
-    }
-    return result;
-  }
-
-  if (typeof obj === 'object') {
-    const entries = Object.entries(obj as Record<string, unknown>);
-    if (entries.length === 0) return '{}\n';
-    let result = '\n';
-    for (const [key, value] of entries) {
-      // Keys with special chars need quoting, but AWS:: style keys don't
-      const safeKey = key.includes(' ') ? `"${key}"` : key;
-      if (typeof value === 'object' && value !== null) {
-        result += `${prefix}${safeKey}:${toYaml(value, indent + 1)}`;
-      } else {
-        result += `${prefix}${safeKey}: ${toYaml(value, indent + 1).trimStart()}`;
-      }
-    }
-    return result;
-  }
-
-  return `${String(obj)}\n`;
 }
 
 /**

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ declare const __CDKD_VERSION__: string;
 
 import { createBootstrapCommand } from './commands/bootstrap.js';
 import { createSynthCommand } from './commands/synth.js';
+import { createListCommand } from './commands/list.js';
 import { createDeployCommand } from './commands/deploy.js';
 import { createDiffCommand } from './commands/diff.js';
 import { createDestroyCommand } from './commands/destroy.js';
@@ -14,6 +15,8 @@ import { createForceUnlockCommand } from './commands/force-unlock.js';
 const SUBCOMMANDS = new Set([
   'bootstrap',
   'synth',
+  'list',
+  'ls',
   'deploy',
   'diff',
   'destroy',
@@ -53,6 +56,7 @@ async function main(): Promise<void> {
   // Add commands
   program.addCommand(createBootstrapCommand());
   program.addCommand(createSynthCommand());
+  program.addCommand(createListCommand());
   program.addCommand(createDeployCommand());
   program.addCommand(createDiffCommand());
   program.addCommand(createDestroyCommand());

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -1,0 +1,59 @@
+/**
+ * Simple JSON to YAML converter (CDK CLI compatible output)
+ *
+ * Used by `synth` (CloudFormation template) and `list` (long output) for
+ * human-friendly YAML rendering. Matches the quoting style of CDK CLI:
+ * single-quote JSON-like / multi-line strings, double-quote strings whose
+ * literal content collides with YAML scalar keywords.
+ */
+export function toYaml(obj: unknown, indent = 0): string {
+  const prefix = '  '.repeat(indent);
+
+  if (obj === null || obj === undefined) return 'null\n';
+  if (typeof obj === 'boolean') return `${obj}\n`;
+  if (typeof obj === 'number') return `"${obj}"\n`;
+  if (typeof obj === 'string') {
+    // Strings that need quoting
+    if (obj.includes('\n')) {
+      // Multi-line: use single quotes with escaped content
+      return `'${obj.replace(/'/g, "''")}'\n`;
+    }
+    if (obj.startsWith('{') || obj.startsWith('[') || obj.startsWith('"')) {
+      // JSON-like strings: use single quotes (like CDK CLI)
+      return `'${obj.replace(/'/g, "''")}'\n`;
+    }
+    if (obj.includes('#') || obj === '' || obj === 'true' || obj === 'false' || obj === 'null') {
+      return `"${obj}"\n`;
+    }
+    // Plain string (no quoting needed for colons in values like AWS::S3::Bucket)
+    return `${obj}\n`;
+  }
+
+  if (Array.isArray(obj)) {
+    if (obj.length === 0) return '[]\n';
+    let result = '\n';
+    for (const item of obj) {
+      const value = toYaml(item, indent + 1).trimStart();
+      result += `${prefix}- ${value}`;
+    }
+    return result;
+  }
+
+  if (typeof obj === 'object') {
+    const entries = Object.entries(obj as Record<string, unknown>);
+    if (entries.length === 0) return '{}\n';
+    let result = '\n';
+    for (const [key, value] of entries) {
+      // Keys with special chars need quoting, but AWS:: style keys don't
+      const safeKey = key.includes(' ') ? `"${key}"` : key;
+      if (typeof value === 'object' && value !== null) {
+        result += `${prefix}${safeKey}:${toYaml(value, indent + 1)}`;
+      } else {
+        result += `${prefix}${safeKey}: ${toYaml(value, indent + 1).trimStart()}`;
+      }
+    }
+    return result;
+  }
+
+  return `${String(obj)}\n`;
+}

--- a/tests/unit/cli/list.test.ts
+++ b/tests/unit/cli/list.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+
+// Mock Synthesizer — list.ts only uses Synthesizer.synthesize().
+const mockSynthesize = vi.fn();
+vi.mock('../../../src/synthesis/synthesizer.js', () => ({
+  Synthesizer: vi.fn().mockImplementation(() => ({
+    synthesize: mockSynthesize,
+  })),
+}));
+
+// Mock config-loader so we don't read real cdk.json.
+const mockResolveApp = vi.fn();
+vi.mock('../../../src/cli/config-loader.js', () => ({
+  resolveApp: (cliApp?: string) => mockResolveApp(cliApp),
+}));
+
+// Mock logger so noise doesn't pollute test output.
+vi.mock('../../../src/utils/logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    setLevel: vi.fn(),
+  }),
+}));
+
+import { createListCommand } from '../../../src/cli/commands/list.js';
+
+/**
+ * Helper to build a StackInfo with sane defaults.
+ */
+function makeStack(overrides: Partial<StackInfo> & { stackName: string }): StackInfo {
+  return {
+    artifactId: overrides.stackName,
+    displayName: overrides.displayName ?? overrides.stackName,
+    template: { Resources: {} },
+    dependencyNames: [],
+    region: 'us-east-1',
+    account: '111111111111',
+    ...overrides,
+  };
+}
+
+/**
+ * Run the list command via Commander and capture stdout.
+ *
+ * Use parseAsync with `from: 'user'` so the array is treated as the
+ * subcommand's own argv (no node/script prefix). exitOverride prevents
+ * Commander from calling process.exit on parse errors.
+ */
+async function runList(args: string[]): Promise<{ stdout: string; error?: Error }> {
+  const cmd = createListCommand();
+  cmd.exitOverride();
+
+  const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
+    throw new Error('__process.exit__');
+  }) as never);
+  const errorLogSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  let error: Error | undefined;
+  try {
+    await cmd.parseAsync(args, { from: 'user' });
+  } catch (e) {
+    error = e as Error;
+  }
+
+  const stdout = writeSpy.mock.calls.map((c) => String(c[0])).join('');
+
+  writeSpy.mockRestore();
+  exitSpy.mockRestore();
+  errorLogSpy.mockRestore();
+
+  return { stdout, ...(error && { error }) };
+}
+
+describe('cdkd list', () => {
+  beforeEach(() => {
+    mockSynthesize.mockReset();
+    mockResolveApp.mockReset();
+    mockResolveApp.mockReturnValue('npx ts-node app.ts');
+  });
+
+  it('prints displayName per line by default', async () => {
+    mockSynthesize.mockResolvedValue({
+      stacks: [
+        makeStack({ stackName: 'StackA', displayName: 'StackA' }),
+        makeStack({ stackName: 'MyStage-Api', displayName: 'MyStage/Api' }),
+      ],
+      manifest: {},
+      assemblyDir: '/tmp/cdk.out',
+    });
+
+    const { stdout, error } = await runList([]);
+
+    expect(error).toBeUndefined();
+    expect(stdout).toBe('StackA\nMyStage/Api\n');
+  });
+
+  it('orders stacks by dependency (deps first)', async () => {
+    // StackA depends on StackB, so StackB must come first.
+    mockSynthesize.mockResolvedValue({
+      stacks: [
+        makeStack({ stackName: 'StackA', dependencyNames: ['StackB'] }),
+        makeStack({ stackName: 'StackB' }),
+      ],
+      manifest: {},
+      assemblyDir: '/tmp/cdk.out',
+    });
+
+    const { stdout } = await runList([]);
+    expect(stdout).toBe('StackB\nStackA\n');
+  });
+
+  it('emits YAML records with --long', async () => {
+    mockSynthesize.mockResolvedValue({
+      stacks: [
+        makeStack({
+          stackName: 'MyStage-Api',
+          displayName: 'MyStage/Api',
+          account: '123456789012',
+          region: 'us-west-2',
+        }),
+      ],
+      manifest: {},
+      assemblyDir: '/tmp/cdk.out',
+    });
+
+    const { stdout } = await runList(['--long']);
+
+    expect(stdout).toContain('id: MyStage/Api');
+    expect(stdout).toContain('name: MyStage-Api');
+    expect(stdout).toContain('account: 123456789012');
+    expect(stdout).toContain('region: us-west-2');
+    // No dependencies key without --show-dependencies
+    expect(stdout).not.toContain('dependencies:');
+  });
+
+  it('emits JSON records with --long --json', async () => {
+    mockSynthesize.mockResolvedValue({
+      stacks: [
+        makeStack({
+          stackName: 'StackA',
+          displayName: 'StackA',
+          account: '111111111111',
+          region: 'us-east-1',
+          dependencyNames: ['StackB'],
+        }),
+        makeStack({
+          stackName: 'StackB',
+          displayName: 'StackB',
+          account: '111111111111',
+          region: 'us-east-1',
+        }),
+      ],
+      manifest: {},
+      assemblyDir: '/tmp/cdk.out',
+    });
+
+    const { stdout } = await runList(['--long', '--show-dependencies', '--json']);
+
+    const parsed = JSON.parse(stdout) as Array<{
+      id: string;
+      name: string;
+      environment: { account: string; region: string };
+      dependencies: string[];
+    }>;
+    expect(parsed).toEqual([
+      {
+        id: 'StackB',
+        name: 'StackB',
+        environment: { account: '111111111111', region: 'us-east-1' },
+        dependencies: [],
+      },
+      {
+        id: 'StackA',
+        name: 'StackA',
+        environment: { account: '111111111111', region: 'us-east-1' },
+        dependencies: ['StackB'],
+      },
+    ]);
+  });
+
+  it('emits dependency-only records with --show-dependencies (no --long)', async () => {
+    mockSynthesize.mockResolvedValue({
+      stacks: [
+        makeStack({ stackName: 'StackA', dependencyNames: ['StackB'] }),
+        makeStack({ stackName: 'StackB' }),
+      ],
+      manifest: {},
+      assemblyDir: '/tmp/cdk.out',
+    });
+
+    const { stdout } = await runList(['--show-dependencies', '--json']);
+
+    const parsed = JSON.parse(stdout) as Array<{ id: string; dependencies: string[] }>;
+    expect(parsed).toEqual([
+      { id: 'StackB', dependencies: [] },
+      { id: 'StackA', dependencies: ['StackB'] },
+    ]);
+  });
+
+  it('filters stacks by physical-name pattern', async () => {
+    mockSynthesize.mockResolvedValue({
+      stacks: [
+        makeStack({ stackName: 'MyStage-Api', displayName: 'MyStage/Api' }),
+        makeStack({ stackName: 'MyStage-Db', displayName: 'MyStage/Db' }),
+        makeStack({ stackName: 'OtherStage-Api', displayName: 'OtherStage/Api' }),
+      ],
+      manifest: {},
+      assemblyDir: '/tmp/cdk.out',
+    });
+
+    const { stdout } = await runList(['MyStage-*']);
+    expect(stdout).toBe('MyStage/Api\nMyStage/Db\n');
+  });
+
+  it('filters stacks by display-path wildcard', async () => {
+    mockSynthesize.mockResolvedValue({
+      stacks: [
+        makeStack({ stackName: 'MyStage-Api', displayName: 'MyStage/Api' }),
+        makeStack({ stackName: 'OtherStage-Api', displayName: 'OtherStage/Api' }),
+      ],
+      manifest: {},
+      assemblyDir: '/tmp/cdk.out',
+    });
+
+    const { stdout } = await runList(['MyStage/*']);
+    expect(stdout).toBe('MyStage/Api\n');
+  });
+
+  it('errors when no stacks match the pattern', async () => {
+    mockSynthesize.mockResolvedValue({
+      stacks: [makeStack({ stackName: 'StackA', displayName: 'StackA' })],
+      manifest: {},
+      assemblyDir: '/tmp/cdk.out',
+    });
+
+    const { error } = await runList(['DoesNotExist']);
+    // withErrorHandling calls process.exit(1); our spy throws so the
+    // command's exception bubbles back as the sentinel error.
+    expect(error).toBeDefined();
+    expect(error?.message).toBe('__process.exit__');
+  });
+
+  it('errors when --app cannot be resolved', async () => {
+    mockResolveApp.mockReturnValue(undefined);
+
+    const { error } = await runList([]);
+    expect(error).toBeDefined();
+    expect(error?.message).toBe('__process.exit__');
+  });
+});

--- a/tests/unit/utils/yaml.test.ts
+++ b/tests/unit/utils/yaml.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { toYaml } from '../../../src/utils/yaml.js';
+
+/**
+ * yaml.ts is shared by `cdkd synth` (CloudFormation template render) and
+ * `cdkd list --long` (stack metadata render). These tests pin the quoting
+ * rules so neither command regresses if the helper is later tweaked.
+ */
+describe('toYaml', () => {
+  it('renders primitives with CDK CLI-style quoting', () => {
+    expect(toYaml(null)).toBe('null\n');
+    expect(toYaml(undefined)).toBe('null\n');
+    expect(toYaml(true)).toBe('true\n');
+    expect(toYaml(false)).toBe('false\n');
+    expect(toYaml(42)).toBe('"42"\n');
+  });
+
+  it('does not quote plain strings (including AWS:: type names)', () => {
+    expect(toYaml('hello')).toBe('hello\n');
+    expect(toYaml('AWS::S3::Bucket')).toBe('AWS::S3::Bucket\n');
+  });
+
+  it('double-quotes scalar-collision strings', () => {
+    expect(toYaml('')).toBe('""\n');
+    expect(toYaml('true')).toBe('"true"\n');
+    expect(toYaml('false')).toBe('"false"\n');
+    expect(toYaml('null')).toBe('"null"\n');
+    expect(toYaml('with#hash')).toBe('"with#hash"\n');
+  });
+
+  it('single-quotes JSON-like strings (matches CDK CLI behavior)', () => {
+    expect(toYaml('{"a": 1}')).toBe(`'{"a": 1}'\n`);
+    expect(toYaml('[1,2]')).toBe(`'[1,2]'\n`);
+  });
+
+  it('renders empty containers inline', () => {
+    expect(toYaml([])).toBe('[]\n');
+    expect(toYaml({})).toBe('{}\n');
+  });
+
+  it('renders nested objects with correct indentation', () => {
+    const result = toYaml({ Resources: { Bucket: { Type: 'AWS::S3::Bucket' } } });
+    expect(result).toBe('\nResources:\n  Bucket:\n    Type: AWS::S3::Bucket\n');
+  });
+
+  it('renders arrays of records', () => {
+    const result = toYaml([
+      { id: 'StackA', name: 'StackA' },
+      { id: 'StackB', name: 'StackB' },
+    ]);
+    expect(result).toBe('\n- id: StackA\n  name: StackA\n- id: StackB\n  name: StackB\n');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `cdkd list` (alias `ls`) — CDK CLI parity for listing stacks in the current CDK app.

- Default: prints each stack's CDK display path on its own line, in dependency order.
- `--long` / `-l`: emits `{id, name, environment, [dependencies]}` per stack as YAML (or JSON with `--json`).
- `--show-dependencies` / `-d`: emits `{id, dependencies}` per stack.
- `--json`: switches structured outputs to JSON.
- Positional patterns filter by physical name or display path with the same routing rules as `deploy` / `diff` / `destroy`.

Pure synthesis-side command — does not touch the state bucket or AWS APIs beyond what synthesis itself requires.

Shared `toYaml` helper extracted from `synth.ts` into `src/utils/yaml.ts` so both commands share one serializer.

## Test plan

- [x] Unit tests covering default / `--long` / `--json` / `--show-dependencies` / pattern filtering / topological order
- [x] Unit tests for the extracted `toYaml` (covers all branches of the existing helper)
- [x] `pnpm typecheck && pnpm lint && pnpm build && pnpm test` (702 tests pass; +16 new)
- [ ] Manually run `cdkd list` against a multi-stack CDK app to spot-check default / `--long` / pattern outputs (optional, low risk)
