### PR TITLE
feat(cli): add state command (list/resources/show/rm subcommands)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ pnpm run typecheck
 
 ### Core Directories
 
-- **src/cli/** - CLI command implementations (deploy, destroy, diff, synth, bootstrap, force-unlock), config resolution
+- **src/cli/** - CLI command implementations (deploy, destroy, diff, synth, bootstrap, force-unlock, state), config resolution. `state` is a parent command with `state list` (alias `ls`) for inspecting stacks in the configured S3 state bucket; `state show` / `state rm` are planned siblings.
 - **src/synthesis/** - CDK app synthesis (self-implemented: subprocess execution, Cloud Assembly parsing, context providers)
 - **src/analyzer/** - DAG builder, template parser, intrinsic function resolution
 - **src/state/** - S3 state backend, lock manager

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ pnpm run typecheck
 
 ### Core Directories
 
-- **src/cli/** - CLI command implementations (deploy, destroy, diff, synth, bootstrap, force-unlock, state), config resolution. `state` is a parent command with `state list` (alias `ls`) for stacks in the configured S3 state bucket and `state resources <stack>` for the resources recorded in a single stack's state file; `state show` / `state rm` are planned siblings.
+- **src/cli/** - CLI command implementations (deploy, destroy, diff, synth, bootstrap, force-unlock, state), config resolution. `state` is a parent command for inspecting and manipulating cdkd's S3 state bucket: `state list` (alias `ls`) lists deployed stacks; `state resources <stack>` lists the resources of one stack; `state show <stack>` renders the full state record (metadata, outputs, resources incl. properties); `state rm <stack>...` removes cdkd's state record for stacks (does NOT delete AWS resources — `cdkd destroy` is the equivalent for the actual resources).
 - **src/synthesis/** - CDK app synthesis (self-implemented: subprocess execution, Cloud Assembly parsing, context providers)
 - **src/analyzer/** - DAG builder, template parser, intrinsic function resolution
 - **src/state/** - S3 state backend, lock manager

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ pnpm run typecheck
 
 ### Core Directories
 
-- **src/cli/** - CLI command implementations (deploy, destroy, diff, synth, bootstrap, force-unlock, state), config resolution. `state` is a parent command with `state list` (alias `ls`) for inspecting stacks in the configured S3 state bucket; `state show` / `state rm` are planned siblings.
+- **src/cli/** - CLI command implementations (deploy, destroy, diff, synth, bootstrap, force-unlock, state), config resolution. `state` is a parent command with `state list` (alias `ls`) for stacks in the configured S3 state bucket and `state resources <stack>` for the resources recorded in a single stack's state file; `state show` / `state rm` are planned siblings.
 - **src/synthesis/** - CDK app synthesis (self-implemented: subprocess execution, Cloud Assembly parsing, context providers)
 - **src/analyzer/** - DAG builder, template parser, intrinsic function resolution
 - **src/state/** - S3 state backend, lock manager

--- a/README.md
+++ b/README.md
@@ -417,6 +417,11 @@ cdkd destroy --all --force
 
 # Force-unlock a stale lock from interrupted deploy
 cdkd force-unlock MyStack
+
+# List stacks registered in the cdkd state bucket
+cdkd state list
+cdkd state ls --long          # include resource count, last-modified, lock status
+cdkd state list --json        # JSON output (alone, or combined with --long)
 ```
 
 ### Concurrency Options

--- a/README.md
+++ b/README.md
@@ -422,6 +422,11 @@ cdkd force-unlock MyStack
 cdkd state list
 cdkd state ls --long          # include resource count, last-modified, lock status
 cdkd state list --json        # JSON output (alone, or combined with --long)
+
+# List resources of a single stack from state
+cdkd state resources MyStack          # aligned columns: LogicalID, Type, PhysicalID
+cdkd state resources MyStack --long   # per-resource block with dependencies and attributes
+cdkd state resources MyStack --json   # full JSON array
 ```
 
 ### Concurrency Options

--- a/README.md
+++ b/README.md
@@ -427,6 +427,15 @@ cdkd state list --json        # JSON output (alone, or combined with --long)
 cdkd state resources MyStack          # aligned columns: LogicalID, Type, PhysicalID
 cdkd state resources MyStack --long   # per-resource block with dependencies and attributes
 cdkd state resources MyStack --json   # full JSON array
+
+# Show full state record for a stack (metadata, outputs, all resources incl. properties)
+cdkd state show MyStack
+cdkd state show MyStack --json        # raw {state, lock} JSON
+
+# Remove cdkd's state record for a stack (does NOT delete AWS resources)
+cdkd state rm MyStack                 # confirmation prompt (y/N)
+cdkd state rm MyStack --yes           # skip confirmation
+cdkd state rm StackA StackB --force   # also bypass the locked-stack refusal
 ```
 
 ### Concurrency Options

--- a/src/cli/commands/state.ts
+++ b/src/cli/commands/state.ts
@@ -1,0 +1,150 @@
+import { Command } from 'commander';
+import { commonOptions, stateOptions } from '../options.js';
+import { getLogger } from '../../utils/logger.js';
+import { withErrorHandling } from '../../utils/error-handler.js';
+import { S3StateBackend } from '../../state/s3-state-backend.js';
+import { LockManager } from '../../state/lock-manager.js';
+import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
+import { resolveStateBucketWithDefault } from '../config-loader.js';
+
+/**
+ * Detail row for a single stack when --long is requested.
+ */
+interface StackDetail {
+  stackName: string;
+  resourceCount: number;
+  lastModified: string | null;
+  locked: boolean;
+}
+
+/**
+ * `cdkd state list` command implementation
+ *
+ * Lists stacks registered in the configured S3 state bucket.
+ *
+ * - Default: stack names, one per line, sorted alphabetically.
+ * - `--long`/`-l`: include resource count, last-modified time, and lock status.
+ * - `--json`: emit a JSON array (alongside or instead of the long form).
+ */
+async function stateListCommand(options: {
+  long: boolean;
+  json: boolean;
+  stateBucket?: string;
+  statePrefix: string;
+  region?: string;
+  profile?: string;
+  verbose: boolean;
+}): Promise<void> {
+  const logger = getLogger();
+
+  if (options.verbose) {
+    logger.setLevel('debug');
+  }
+
+  // Initialize AWS clients
+  const awsClients = new AwsClients({
+    ...(options.region && { region: options.region }),
+    ...(options.profile && { profile: options.profile }),
+  });
+  setAwsClients(awsClients);
+
+  const region = options.region || process.env['AWS_REGION'] || 'us-east-1';
+  const stateBucket = await resolveStateBucketWithDefault(options.stateBucket, region);
+
+  try {
+    const stateConfig = {
+      bucket: stateBucket,
+      prefix: options.statePrefix,
+    };
+    const stateBackend = new S3StateBackend(awsClients.s3, stateConfig);
+    const lockManager = new LockManager(awsClients.s3, stateConfig);
+
+    const stackNames = (await stateBackend.listStacks()).slice().sort();
+
+    // Default mode: just print sorted stack names, one per line.
+    if (!options.long && !options.json) {
+      for (const name of stackNames) {
+        process.stdout.write(`${name}\n`);
+      }
+      return;
+    }
+
+    // --json without --long: array of names.
+    if (options.json && !options.long) {
+      process.stdout.write(`${JSON.stringify(stackNames, null, 2)}\n`);
+      return;
+    }
+
+    // --long (with or without --json): fetch detail per stack in parallel.
+    const details: StackDetail[] = await Promise.all(
+      stackNames.map(async (stackName): Promise<StackDetail> => {
+        const [stateResult, locked] = await Promise.all([
+          stateBackend.getState(stackName),
+          lockManager.isLocked(stackName),
+        ]);
+        const state = stateResult?.state;
+        return {
+          stackName,
+          resourceCount: state ? Object.keys(state.resources).length : 0,
+          lastModified:
+            state && typeof state.lastModified === 'number'
+              ? new Date(state.lastModified).toISOString()
+              : null,
+          locked,
+        };
+      })
+    );
+
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(details, null, 2)}\n`);
+      return;
+    }
+
+    // Long human-readable format.
+    const lines: string[] = [];
+    for (const detail of details) {
+      lines.push(detail.stackName);
+      lines.push(`  Resources: ${detail.resourceCount}`);
+      lines.push(`  Last Modified: ${detail.lastModified ?? 'unknown'}`);
+      lines.push(`  Lock: ${detail.locked ? 'locked' : 'unlocked'}`);
+      lines.push('');
+    }
+    if (lines.length > 0) {
+      // Drop trailing blank line for tidy output.
+      if (lines[lines.length - 1] === '') {
+        lines.pop();
+      }
+      process.stdout.write(`${lines.join('\n')}\n`);
+    }
+  } finally {
+    awsClients.destroy();
+  }
+}
+
+/**
+ * Create the `state list` subcommand.
+ */
+function createStateListCommand(): Command {
+  const cmd = new Command('list')
+    .alias('ls')
+    .description('List stacks registered in the cdkd state bucket')
+    .option('-l, --long', 'Show resource count, last-modified time, and lock status', false)
+    .option('--json', 'Output as JSON', false)
+    .action(withErrorHandling(stateListCommand));
+
+  [...commonOptions, ...stateOptions].forEach((opt) => cmd.addOption(opt));
+
+  return cmd;
+}
+
+/**
+ * Create the `state` parent command.
+ *
+ * Today only `list` (alias `ls`) is implemented. Future siblings such as
+ * `state show` and `state rm` are planned and will be attached here.
+ */
+export function createStateCommand(): Command {
+  const cmd = new Command('state').description('Manage cdkd state stored in S3');
+  cmd.addCommand(createStateListCommand());
+  return cmd;
+}

--- a/src/cli/commands/state.ts
+++ b/src/cli/commands/state.ts
@@ -18,6 +18,21 @@ interface StackDetail {
 }
 
 /**
+ * Detail row for a single resource emitted by `state resources`.
+ *
+ * Mirrors the public-facing fields of `ResourceState` minus `properties` —
+ * properties are reserved for the planned `state show` subcommand because
+ * they can be very large and noisy for an inventory-style listing.
+ */
+interface ResourceDetail {
+  logicalId: string;
+  resourceType: string;
+  physicalId: string;
+  dependencies: string[];
+  attributes: Record<string, unknown>;
+}
+
+/**
  * `cdkd state list` command implementation
  *
  * Lists stacks registered in the configured S3 state bucket.
@@ -138,13 +153,162 @@ function createStateListCommand(): Command {
 }
 
 /**
+ * `cdkd state resources <stack>` command implementation
+ *
+ * Lists the resources recorded in a single stack's state file.
+ *
+ * - Default: aligned three-column output (LogicalID, Type, PhysicalID)
+ *   sorted alphabetically by logical id.
+ * - `--long`/`-l`: per-resource block including dependencies and attributes.
+ * - `--json`: emit a JSON array of full resource detail objects.
+ *
+ * Properties are intentionally omitted from all output modes — they belong
+ * to the planned `state show` subcommand.
+ */
+async function stateResourcesCommand(
+  stackName: string,
+  options: {
+    long: boolean;
+    json: boolean;
+    stateBucket?: string;
+    statePrefix: string;
+    region?: string;
+    profile?: string;
+    verbose: boolean;
+  }
+): Promise<void> {
+  const logger = getLogger();
+
+  if (options.verbose) {
+    logger.setLevel('debug');
+  }
+
+  const awsClients = new AwsClients({
+    ...(options.region && { region: options.region }),
+    ...(options.profile && { profile: options.profile }),
+  });
+  setAwsClients(awsClients);
+
+  const region = options.region || process.env['AWS_REGION'] || 'us-east-1';
+  const stateBucket = await resolveStateBucketWithDefault(options.stateBucket, region);
+
+  try {
+    const stateConfig = {
+      bucket: stateBucket,
+      prefix: options.statePrefix,
+    };
+    const stateBackend = new S3StateBackend(awsClients.s3, stateConfig);
+
+    const stateResult = await stateBackend.getState(stackName);
+    if (!stateResult) {
+      throw new Error(
+        `No state found for stack '${stackName}' in s3://${stateBucket}/${options.statePrefix}/. ` +
+          `Run 'cdkd state list' to see available stacks.`
+      );
+    }
+
+    const resources = stateResult.state.resources ?? {};
+    const details: ResourceDetail[] = Object.entries(resources)
+      .map(([logicalId, resource]) => ({
+        logicalId,
+        resourceType: resource.resourceType,
+        physicalId: resource.physicalId,
+        dependencies: resource.dependencies ?? [],
+        attributes: resource.attributes ?? {},
+      }))
+      .sort((a, b) => a.logicalId.localeCompare(b.logicalId));
+
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(details, null, 2)}\n`);
+      return;
+    }
+
+    if (details.length === 0) {
+      // Nothing to print; leaving output empty matches `state list` semantics
+      // for an empty bucket.
+      return;
+    }
+
+    if (options.long) {
+      const lines: string[] = [];
+      for (const detail of details) {
+        lines.push(detail.logicalId);
+        lines.push(`  Type: ${detail.resourceType}`);
+        lines.push(`  PhysicalID: ${detail.physicalId}`);
+        lines.push(
+          `  Dependencies: ${detail.dependencies.length > 0 ? detail.dependencies.join(', ') : '(none)'}`
+        );
+        const attrEntries = Object.entries(detail.attributes);
+        if (attrEntries.length === 0) {
+          lines.push('  Attributes: (none)');
+        } else {
+          lines.push('  Attributes:');
+          for (const [k, v] of attrEntries) {
+            lines.push(`    ${k}: ${formatAttributeValue(v)}`);
+          }
+        }
+        lines.push('');
+      }
+      // Drop trailing blank line for tidy output.
+      if (lines[lines.length - 1] === '') {
+        lines.pop();
+      }
+      process.stdout.write(`${lines.join('\n')}\n`);
+      return;
+    }
+
+    // Default: aligned three-column output.
+    const idWidth = Math.max(...details.map((d) => d.logicalId.length));
+    const typeWidth = Math.max(...details.map((d) => d.resourceType.length));
+    for (const detail of details) {
+      process.stdout.write(
+        `${detail.logicalId.padEnd(idWidth)}  ${detail.resourceType.padEnd(typeWidth)}  ${detail.physicalId}\n`
+      );
+    }
+  } finally {
+    awsClients.destroy();
+  }
+}
+
+/**
+ * Render a single attribute value for the `--long` human-readable form.
+ *
+ * Scalar values render as-is; objects/arrays are JSON-encoded inline so a
+ * resource block stays compact even when an attribute is structured.
+ */
+function formatAttributeValue(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+/**
+ * Create the `state resources` subcommand.
+ */
+function createStateResourcesCommand(): Command {
+  const cmd = new Command('resources')
+    .description("List resources recorded in a stack's state")
+    .argument('<stack>', 'Stack name (physical CloudFormation name)')
+    .option('-l, --long', 'Include dependencies and attributes per resource', false)
+    .option('--json', 'Output as JSON', false)
+    .action(withErrorHandling(stateResourcesCommand));
+
+  [...commonOptions, ...stateOptions].forEach((opt) => cmd.addOption(opt));
+
+  return cmd;
+}
+
+/**
  * Create the `state` parent command.
  *
- * Today only `list` (alias `ls`) is implemented. Future siblings such as
- * `state show` and `state rm` are planned and will be attached here.
+ * Today `list` (alias `ls`) and `resources` are implemented. Future siblings
+ * such as `state show` and `state rm` are planned and will be attached here.
  */
 export function createStateCommand(): Command {
   const cmd = new Command('state').description('Manage cdkd state stored in S3');
   cmd.addCommand(createStateListCommand());
+  cmd.addCommand(createStateResourcesCommand());
   return cmd;
 }

--- a/src/cli/commands/state.ts
+++ b/src/cli/commands/state.ts
@@ -1,3 +1,4 @@
+import * as readline from 'node:readline/promises';
 import { Command } from 'commander';
 import { commonOptions, stateOptions } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
@@ -6,6 +7,7 @@ import { S3StateBackend } from '../../state/s3-state-backend.js';
 import { LockManager } from '../../state/lock-manager.js';
 import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
 import { resolveStateBucketWithDefault } from '../config-loader.js';
+import type { LockInfo } from '../../types/state.js';
 
 /**
  * Detail row for a single stack when --long is requested.
@@ -21,8 +23,7 @@ interface StackDetail {
  * Detail row for a single resource emitted by `state resources`.
  *
  * Mirrors the public-facing fields of `ResourceState` minus `properties` —
- * properties are reserved for the planned `state show` subcommand because
- * they can be very large and noisy for an inventory-style listing.
+ * properties are reserved for `state show`, which does include them.
  */
 interface ResourceDetail {
   logicalId: string;
@@ -30,6 +31,53 @@ interface ResourceDetail {
   physicalId: string;
   dependencies: string[];
   attributes: Record<string, unknown>;
+}
+
+/**
+ * Shared bootstrap for every `state` subcommand: build the AWS clients,
+ * resolve the bucket name, verify the bucket exists, and hand back the
+ * S3 state backend / lock manager.
+ *
+ * `verifyBucketExists` runs early so users without a bootstrapped bucket
+ * get a helpful "run cdkd bootstrap" message instead of a generic
+ * NoSuchBucket from a downstream list/get call.
+ *
+ * The returned `dispose` function MUST be called in a `finally` block.
+ */
+async function setupStateBackend(options: {
+  stateBucket?: string;
+  statePrefix: string;
+  region?: string;
+  profile?: string;
+}): Promise<{
+  stateBackend: S3StateBackend;
+  lockManager: LockManager;
+  bucket: string;
+  prefix: string;
+  dispose: () => void;
+}> {
+  const awsClients = new AwsClients({
+    ...(options.region && { region: options.region }),
+    ...(options.profile && { profile: options.profile }),
+  });
+  setAwsClients(awsClients);
+
+  const region = options.region || process.env['AWS_REGION'] || 'us-east-1';
+  const bucket = await resolveStateBucketWithDefault(options.stateBucket, region);
+  const prefix = options.statePrefix;
+  const stateConfig = { bucket, prefix };
+  const stateBackend = new S3StateBackend(awsClients.s3, stateConfig);
+  const lockManager = new LockManager(awsClients.s3, stateConfig);
+
+  await stateBackend.verifyBucketExists();
+
+  return {
+    stateBackend,
+    lockManager,
+    bucket,
+    prefix,
+    dispose: () => awsClients.destroy(),
+  };
 }
 
 /**
@@ -51,30 +99,11 @@ async function stateListCommand(options: {
   verbose: boolean;
 }): Promise<void> {
   const logger = getLogger();
+  if (options.verbose) logger.setLevel('debug');
 
-  if (options.verbose) {
-    logger.setLevel('debug');
-  }
-
-  // Initialize AWS clients
-  const awsClients = new AwsClients({
-    ...(options.region && { region: options.region }),
-    ...(options.profile && { profile: options.profile }),
-  });
-  setAwsClients(awsClients);
-
-  const region = options.region || process.env['AWS_REGION'] || 'us-east-1';
-  const stateBucket = await resolveStateBucketWithDefault(options.stateBucket, region);
-
+  const setup = await setupStateBackend(options);
   try {
-    const stateConfig = {
-      bucket: stateBucket,
-      prefix: options.statePrefix,
-    };
-    const stateBackend = new S3StateBackend(awsClients.s3, stateConfig);
-    const lockManager = new LockManager(awsClients.s3, stateConfig);
-
-    const stackNames = (await stateBackend.listStacks()).slice().sort();
+    const stackNames = (await setup.stateBackend.listStacks()).slice().sort();
 
     // Default mode: just print sorted stack names, one per line.
     if (!options.long && !options.json) {
@@ -94,8 +123,8 @@ async function stateListCommand(options: {
     const details: StackDetail[] = await Promise.all(
       stackNames.map(async (stackName): Promise<StackDetail> => {
         const [stateResult, locked] = await Promise.all([
-          stateBackend.getState(stackName),
-          lockManager.isLocked(stackName),
+          setup.stateBackend.getState(stackName),
+          setup.lockManager.isLocked(stackName),
         ]);
         const state = stateResult?.state;
         return {
@@ -132,7 +161,7 @@ async function stateListCommand(options: {
       process.stdout.write(`${lines.join('\n')}\n`);
     }
   } finally {
-    awsClients.destroy();
+    setup.dispose();
   }
 }
 
@@ -162,8 +191,8 @@ function createStateListCommand(): Command {
  * - `--long`/`-l`: per-resource block including dependencies and attributes.
  * - `--json`: emit a JSON array of full resource detail objects.
  *
- * Properties are intentionally omitted from all output modes — they belong
- * to the planned `state show` subcommand.
+ * Properties are intentionally omitted from all output modes — `state show`
+ * is the right command when properties are needed.
  */
 async function stateResourcesCommand(
   stackName: string,
@@ -178,31 +207,14 @@ async function stateResourcesCommand(
   }
 ): Promise<void> {
   const logger = getLogger();
+  if (options.verbose) logger.setLevel('debug');
 
-  if (options.verbose) {
-    logger.setLevel('debug');
-  }
-
-  const awsClients = new AwsClients({
-    ...(options.region && { region: options.region }),
-    ...(options.profile && { profile: options.profile }),
-  });
-  setAwsClients(awsClients);
-
-  const region = options.region || process.env['AWS_REGION'] || 'us-east-1';
-  const stateBucket = await resolveStateBucketWithDefault(options.stateBucket, region);
-
+  const setup = await setupStateBackend(options);
   try {
-    const stateConfig = {
-      bucket: stateBucket,
-      prefix: options.statePrefix,
-    };
-    const stateBackend = new S3StateBackend(awsClients.s3, stateConfig);
-
-    const stateResult = await stateBackend.getState(stackName);
+    const stateResult = await setup.stateBackend.getState(stackName);
     if (!stateResult) {
       throw new Error(
-        `No state found for stack '${stackName}' in s3://${stateBucket}/${options.statePrefix}/. ` +
+        `No state found for stack '${stackName}' in s3://${setup.bucket}/${setup.prefix}/. ` +
           `Run 'cdkd state list' to see available stacks.`
       );
     }
@@ -266,7 +278,7 @@ async function stateResourcesCommand(
       );
     }
   } finally {
-    awsClients.destroy();
+    setup.dispose();
   }
 }
 
@@ -282,6 +294,31 @@ function formatAttributeValue(value: unknown): string {
     return String(value);
   }
   return JSON.stringify(value);
+}
+
+/**
+ * Render a duration in milliseconds as `1m23s` / `45s`.
+ */
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m${remainingSeconds}s`;
+}
+
+/**
+ * Render lock metadata for the `state show` block.
+ */
+function formatLockSummary(lockInfo: LockInfo | null): string {
+  if (!lockInfo) return 'unlocked';
+  const opStr = lockInfo.operation ? ` (operation: ${lockInfo.operation})` : '';
+  const expiresInMs = lockInfo.expiresAt - Date.now();
+  const expiresStr =
+    expiresInMs > 0
+      ? `expires in ${formatDuration(expiresInMs)}`
+      : `expired ${formatDuration(-expiresInMs)} ago`;
+  return `locked by ${lockInfo.owner}${opStr}, ${expiresStr}`;
 }
 
 /**
@@ -301,14 +338,244 @@ function createStateResourcesCommand(): Command {
 }
 
 /**
+ * `cdkd state show <stack>` command implementation
+ *
+ * Renders the full state record for one stack: stack-level metadata, lock
+ * status, outputs, and every resource (including properties). The deepest /
+ * most verbose `state` subcommand — use `state list` / `state resources` for
+ * lighter inspection.
+ *
+ * - Default: human-readable multi-line format.
+ * - `--json`: a `{state, lock}` object containing the raw `StackState` plus
+ *   the lock record (or null).
+ */
+async function stateShowCommand(
+  stackName: string,
+  options: {
+    json: boolean;
+    stateBucket?: string;
+    statePrefix: string;
+    region?: string;
+    profile?: string;
+    verbose: boolean;
+  }
+): Promise<void> {
+  const logger = getLogger();
+  if (options.verbose) logger.setLevel('debug');
+
+  const setup = await setupStateBackend(options);
+  try {
+    const [stateResult, lockInfo] = await Promise.all([
+      setup.stateBackend.getState(stackName),
+      setup.lockManager.getLockInfo(stackName),
+    ]);
+
+    if (!stateResult) {
+      throw new Error(
+        `No state found for stack '${stackName}' in s3://${setup.bucket}/${setup.prefix}/. ` +
+          `Run 'cdkd state list' to see available stacks.`
+      );
+    }
+
+    if (options.json) {
+      process.stdout.write(
+        `${JSON.stringify({ state: stateResult.state, lock: lockInfo }, null, 2)}\n`
+      );
+      return;
+    }
+
+    const state = stateResult.state;
+    const lines: string[] = [];
+
+    lines.push(`Stack: ${state.stackName}`);
+    if (state.region) lines.push(`  Region: ${state.region}`);
+    lines.push(`  Version: ${state.version}`);
+    lines.push(`  Last Modified: ${new Date(state.lastModified).toISOString()}`);
+    lines.push(`  Lock: ${formatLockSummary(lockInfo)}`);
+
+    const outputEntries = Object.entries(state.outputs ?? {});
+    if (outputEntries.length > 0) {
+      lines.push('');
+      lines.push('Outputs:');
+      for (const [k, v] of outputEntries) {
+        lines.push(`  ${k}: ${formatAttributeValue(v)}`);
+      }
+    }
+
+    const resourceEntries = Object.entries(state.resources ?? {}).sort(([a], [b]) =>
+      a.localeCompare(b)
+    );
+    lines.push('');
+    lines.push(`Resources (${resourceEntries.length}):`);
+    for (const [logicalId, resource] of resourceEntries) {
+      lines.push('');
+      lines.push(logicalId);
+      lines.push(`  Type: ${resource.resourceType}`);
+      lines.push(`  PhysicalID: ${resource.physicalId}`);
+      const deps = resource.dependencies ?? [];
+      lines.push(`  Dependencies: ${deps.length > 0 ? deps.join(', ') : '(none)'}`);
+
+      const attrEntries = Object.entries(resource.attributes ?? {});
+      if (attrEntries.length === 0) {
+        lines.push('  Attributes: (none)');
+      } else {
+        lines.push('  Attributes:');
+        for (const [k, v] of attrEntries) {
+          lines.push(`    ${k}: ${formatAttributeValue(v)}`);
+        }
+      }
+
+      const propEntries = Object.entries(resource.properties ?? {});
+      if (propEntries.length === 0) {
+        lines.push('  Properties: (none)');
+      } else {
+        lines.push('  Properties:');
+        for (const [k, v] of propEntries) {
+          lines.push(`    ${k}: ${formatAttributeValue(v)}`);
+        }
+      }
+    }
+
+    process.stdout.write(`${lines.join('\n')}\n`);
+  } finally {
+    setup.dispose();
+  }
+}
+
+/**
+ * Create the `state show` subcommand.
+ */
+function createStateShowCommand(): Command {
+  const cmd = new Command('show')
+    .description('Show the full cdkd state record for a stack (metadata, outputs, resources)')
+    .argument('<stack>', 'Stack name (physical CloudFormation name)')
+    .option('--json', 'Output the raw state and lock as JSON', false)
+    .action(withErrorHandling(stateShowCommand));
+
+  [...commonOptions, ...stateOptions].forEach((opt) => cmd.addOption(opt));
+
+  return cmd;
+}
+
+/**
+ * `cdkd state rm <stacks...>` command implementation
+ *
+ * Removes the cdkd state record (state.json + any lingering lock.json) for
+ * one or more stacks. **Does not** touch the underlying AWS resources —
+ * `cdkd destroy` is the command that deletes those.
+ *
+ * Behavior:
+ * - Refuses to remove a locked stack unless `--force` is set, since tearing
+ *   the lock out from under an in-flight deploy can corrupt state.
+ * - Confirmation prompt defaults to `(y/N)`, requiring an explicit `y` —
+ *   this is more cautious than `cdkd destroy` because the operation orphans
+ *   AWS resources from cdkd's view rather than reconciling them.
+ * - `--yes` / `--force` skip the prompt.
+ * - Skips cleanly when a stack has no state (idempotent).
+ */
+async function stateRmCommand(
+  stackArgs: string[],
+  options: {
+    force: boolean;
+    yes: boolean;
+    stateBucket?: string;
+    statePrefix: string;
+    region?: string;
+    profile?: string;
+    verbose: boolean;
+  }
+): Promise<void> {
+  const logger = getLogger();
+  if (options.verbose) logger.setLevel('debug');
+
+  if (stackArgs.length === 0) {
+    throw new Error('Stack name is required. Usage: cdkd state rm <stack> [<stack>...]');
+  }
+
+  const setup = await setupStateBackend(options);
+  try {
+    for (const stackName of stackArgs) {
+      const exists = await setup.stateBackend.stateExists(stackName);
+      if (!exists) {
+        logger.info(`No state found for stack: ${stackName}, skipping`);
+        continue;
+      }
+
+      // Refuse to remove a locked stack unless --force is set: an active
+      // deploy could be racing with us and ripping the lock out from under it
+      // would produce arbitrary mid-deploy corruption.
+      if (!options.force) {
+        const locked = await setup.lockManager.isLocked(stackName);
+        if (locked) {
+          throw new Error(
+            `Stack '${stackName}' is locked. Run 'cdkd force-unlock ${stackName}' first, ` +
+              `or pass --force to remove anyway.`
+          );
+        }
+      }
+
+      // Confirmation prompt unless --yes / --force.
+      if (!options.yes && !options.force) {
+        process.stdout.write(
+          `\nWARNING: This removes cdkd's state record for '${stackName}' only. ` +
+            `AWS resources will NOT be deleted.\n` +
+            `Use 'cdkd destroy ${stackName}' if you want to delete the actual resources.\n\n`
+        );
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+        const answer = await rl.question(
+          `Remove state for stack '${stackName}' from s3://${setup.bucket}/${setup.prefix}/? (y/N): `
+        );
+        rl.close();
+        const trimmed = answer.trim().toLowerCase();
+        if (trimmed !== 'y' && trimmed !== 'yes') {
+          logger.info(`Cancelled removal of state for stack: ${stackName}`);
+          continue;
+        }
+      }
+
+      // Remove state.json AND any lingering lock.json. forceReleaseLock is
+      // idempotent (no-op when no lock present).
+      await setup.stateBackend.deleteState(stackName);
+      await setup.lockManager.forceReleaseLock(stackName);
+      logger.info(`✓ Removed state for stack: ${stackName}`);
+    }
+  } finally {
+    setup.dispose();
+  }
+}
+
+/**
+ * Create the `state rm` subcommand.
+ */
+function createStateRmCommand(): Command {
+  const cmd = new Command('rm')
+    .description('Remove cdkd state for one or more stacks (does NOT delete AWS resources)')
+    .argument('<stacks...>', 'Stack name(s) to remove from state')
+    .option('-f, --force', 'Skip confirmation and remove even if the stack is locked', false)
+    .action(withErrorHandling(stateRmCommand));
+
+  [...commonOptions, ...stateOptions].forEach((opt) => cmd.addOption(opt));
+
+  return cmd;
+}
+
+/**
  * Create the `state` parent command.
  *
- * Today `list` (alias `ls`) and `resources` are implemented. Future siblings
- * such as `state show` and `state rm` are planned and will be attached here.
+ * Subcommands:
+ * - `state list` (alias `ls`) — list stacks in the state bucket
+ * - `state resources <stack>` — list resources of one stack
+ * - `state show <stack>` — full state record (metadata, outputs, resources)
+ * - `state rm <stack>...` — remove cdkd's state record (NOT AWS resources)
  */
 export function createStateCommand(): Command {
   const cmd = new Command('state').description('Manage cdkd state stored in S3');
   cmd.addCommand(createStateListCommand());
   cmd.addCommand(createStateResourcesCommand());
+  cmd.addCommand(createStateShowCommand());
+  cmd.addCommand(createStateRmCommand());
   return cmd;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,7 @@ import { createDiffCommand } from './commands/diff.js';
 import { createDestroyCommand } from './commands/destroy.js';
 import { createPublishAssetsCommand } from './commands/publish-assets.js';
 import { createForceUnlockCommand } from './commands/force-unlock.js';
+import { createStateCommand } from './commands/state.js';
 
 const SUBCOMMANDS = new Set([
   'bootstrap',
@@ -19,6 +20,7 @@ const SUBCOMMANDS = new Set([
   'destroy',
   'publish-assets',
   'force-unlock',
+  'state',
 ]);
 
 /**
@@ -58,6 +60,7 @@ async function main(): Promise<void> {
   program.addCommand(createDestroyCommand());
   program.addCommand(createPublishAssetsCommand());
   program.addCommand(createForceUnlockCommand());
+  program.addCommand(createStateCommand());
 
   // Reorder args: move options before subcommand to after it
   // This allows `cdkd -c key=value deploy` like CDK CLI

--- a/src/state/lock-manager.ts
+++ b/src/state/lock-manager.ts
@@ -223,6 +223,19 @@ export class LockManager {
   }
 
   /**
+   * Check whether a lock currently exists for a stack
+   *
+   * Returns true if a lock file is present in S3 (regardless of expiry).
+   * This is intended for read-only inspection (e.g. `cdkd state list --long`),
+   * not for acquisition decisions — use `acquireLock` for that, which has its
+   * own expired-lock cleanup logic.
+   */
+  async isLocked(stackName: string): Promise<boolean> {
+    const lockInfo = await this.getLockInfo(stackName);
+    return lockInfo !== null;
+  }
+
+  /**
    * Release a lock for a stack
    */
   async releaseLock(stackName: string): Promise<void> {

--- a/tests/unit/cli/state-list.test.ts
+++ b/tests/unit/cli/state-list.test.ts
@@ -46,10 +46,12 @@ const mockGetState =
       stackName: string
     ) => Promise<{ state: { resources: Record<string, unknown>; lastModified: number } } | null>
   >();
+const mockVerifyBucketExists = vi.fn<() => Promise<void>>();
 vi.mock('../../../src/state/s3-state-backend.js', () => ({
   S3StateBackend: vi.fn().mockImplementation(() => ({
     listStacks: mockListStacks,
     getState: mockGetState,
+    verifyBucketExists: mockVerifyBucketExists,
   })),
 }));
 
@@ -102,6 +104,8 @@ describe('cdkd state list', () => {
     mockListStacks.mockReset();
     mockGetState.mockReset();
     mockIsLocked.mockReset();
+    mockVerifyBucketExists.mockReset();
+    mockVerifyBucketExists.mockResolvedValue();
   });
 
   afterEach(() => {

--- a/tests/unit/cli/state-list.test.ts
+++ b/tests/unit/cli/state-list.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock logger to suppress output during tests.
+vi.mock('../../../src/utils/logger.js', () => ({
+  getLogger: () => ({
+    setLevel: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  }),
+}));
+
+// Mock state bucket resolver so we don't talk to STS.
+vi.mock('../../../src/cli/config-loader.js', () => ({
+  resolveStateBucketWithDefault: vi.fn(async () => 'test-bucket'),
+}));
+
+// Mock AwsClients factory: just hand back something with an s3 getter and
+// destroy(). The S3StateBackend / LockManager are themselves mocked, so the
+// concrete client value is irrelevant.
+vi.mock('../../../src/utils/aws-clients.ts', () => {
+  return {
+    AwsClients: vi.fn().mockImplementation(() => ({
+      get s3() {
+        return {};
+      },
+      destroy: vi.fn(),
+    })),
+    setAwsClients: vi.fn(),
+    getAwsClients: vi.fn(),
+  };
+});
+
+// Mock S3StateBackend.
+const mockListStacks = vi.fn<() => Promise<string[]>>();
+const mockGetState =
+  vi.fn<
+    (
+      stackName: string
+    ) => Promise<{ state: { resources: Record<string, unknown>; lastModified: number } } | null>
+  >();
+vi.mock('../../../src/state/s3-state-backend.js', () => ({
+  S3StateBackend: vi.fn().mockImplementation(() => ({
+    listStacks: mockListStacks,
+    getState: mockGetState,
+  })),
+}));
+
+// Mock LockManager.
+const mockIsLocked = vi.fn<(stackName: string) => Promise<boolean>>();
+vi.mock('../../../src/state/lock-manager.js', () => ({
+  LockManager: vi.fn().mockImplementation(() => ({
+    isLocked: mockIsLocked,
+  })),
+}));
+
+import { createStateCommand } from '../../../src/cli/commands/state.js';
+
+/**
+ * Helper to capture process.stdout.write output.
+ */
+function captureStdout(): { output: string[]; restore: () => void } {
+  const output: string[] = [];
+  const original = process.stdout.write.bind(process.stdout);
+  // Replace with a recorder that always returns true (the boolean overload of write).
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    output.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+    return true;
+  }) as typeof process.stdout.write;
+  return {
+    output,
+    restore: () => {
+      process.stdout.write = original;
+    },
+  };
+}
+
+async function runStateList(args: string[]): Promise<string> {
+  const cap = captureStdout();
+  try {
+    const stateCmd = createStateCommand();
+    // Disable Commander's exitOverride so action errors bubble up.
+    stateCmd.exitOverride();
+    stateCmd.commands.forEach((sub) => sub.exitOverride());
+    // First arg is the subcommand name, remaining are flags.
+    await stateCmd.parseAsync(args, { from: 'user' });
+  } finally {
+    cap.restore();
+  }
+  return cap.output.join('');
+}
+
+describe('cdkd state list', () => {
+  beforeEach(() => {
+    mockListStacks.mockReset();
+    mockGetState.mockReset();
+    mockIsLocked.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('emits nothing when no stacks are registered (default)', async () => {
+    mockListStacks.mockResolvedValue([]);
+    const out = await runStateList(['list']);
+    expect(out).toBe('');
+  });
+
+  it('prints stack names sorted alphabetically, one per line', async () => {
+    mockListStacks.mockResolvedValue(['Charlie', 'alpha', 'Bravo']);
+    const out = await runStateList(['list']);
+    expect(out).toBe('Bravo\nCharlie\nalpha\n');
+  });
+
+  it('supports the `ls` alias', async () => {
+    mockListStacks.mockResolvedValue(['One', 'Two']);
+    const out = await runStateList(['ls']);
+    expect(out).toBe('One\nTwo\n');
+  });
+
+  it('emits a JSON array of stack names with --json', async () => {
+    mockListStacks.mockResolvedValue(['B', 'a', 'C']);
+    const out = await runStateList(['list', '--json']);
+    expect(JSON.parse(out)).toEqual(['B', 'C', 'a']);
+  });
+
+  it('emits long human-readable details with --long', async () => {
+    mockListStacks.mockResolvedValue(['StackA', 'StackB']);
+    mockGetState.mockImplementation(async (name) => {
+      if (name === 'StackA') {
+        return {
+          state: {
+            resources: { R1: {}, R2: {}, R3: {} },
+            lastModified: Date.UTC(2026, 3, 29, 10, 23, 45),
+          },
+        };
+      }
+      return {
+        state: {
+          resources: {},
+          lastModified: Date.UTC(2026, 3, 25, 8, 0, 0),
+        },
+      };
+    });
+    mockIsLocked.mockImplementation(async (name) => name === 'StackB');
+
+    const out = await runStateList(['list', '--long']);
+
+    expect(out).toContain('StackA');
+    expect(out).toContain('  Resources: 3');
+    expect(out).toContain('  Last Modified: 2026-04-29T10:23:45.000Z');
+    expect(out).toContain('  Lock: unlocked');
+    expect(out).toContain('StackB');
+    expect(out).toContain('  Resources: 0');
+    expect(out).toContain('  Last Modified: 2026-04-25T08:00:00.000Z');
+    expect(out).toContain('  Lock: locked');
+  });
+
+  it('handles missing state by reporting zero resources and unknown last-modified', async () => {
+    mockListStacks.mockResolvedValue(['Orphan']);
+    mockGetState.mockResolvedValue(null);
+    mockIsLocked.mockResolvedValue(false);
+
+    const out = await runStateList(['list', '--long']);
+
+    expect(out).toContain('Orphan');
+    expect(out).toContain('  Resources: 0');
+    expect(out).toContain('  Last Modified: unknown');
+    expect(out).toContain('  Lock: unlocked');
+  });
+
+  it('emits a JSON array of details when --long --json is combined', async () => {
+    mockListStacks.mockResolvedValue(['X']);
+    mockGetState.mockResolvedValue({
+      state: {
+        resources: { R1: {}, R2: {} },
+        lastModified: Date.UTC(2026, 0, 1, 0, 0, 0),
+      },
+    });
+    mockIsLocked.mockResolvedValue(true);
+
+    const out = await runStateList(['list', '--long', '--json']);
+
+    const parsed = JSON.parse(out);
+    expect(parsed).toEqual([
+      {
+        stackName: 'X',
+        resourceCount: 2,
+        lastModified: '2026-01-01T00:00:00.000Z',
+        locked: true,
+      },
+    ]);
+  });
+
+  it('fetches state and lock status for each stack', async () => {
+    mockListStacks.mockResolvedValue(['One', 'Two']);
+    mockGetState.mockResolvedValue({
+      state: { resources: {}, lastModified: 0 },
+    });
+    mockIsLocked.mockResolvedValue(false);
+
+    await runStateList(['list', '--long']);
+
+    expect(mockGetState).toHaveBeenCalledWith('One');
+    expect(mockGetState).toHaveBeenCalledWith('Two');
+    expect(mockIsLocked).toHaveBeenCalledWith('One');
+    expect(mockIsLocked).toHaveBeenCalledWith('Two');
+  });
+});

--- a/tests/unit/cli/state-resources.test.ts
+++ b/tests/unit/cli/state-resources.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ResourceState, StackState } from '../../../src/types/state.js';
+
+const errorSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  getLogger: () => ({
+    setLevel: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: errorSpy,
+    child: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  }),
+}));
+
+vi.mock('../../../src/cli/config-loader.js', () => ({
+  resolveStateBucketWithDefault: vi.fn(async () => 'test-bucket'),
+}));
+
+vi.mock('../../../src/utils/aws-clients.ts', () => {
+  return {
+    AwsClients: vi.fn().mockImplementation(() => ({
+      get s3() {
+        return {};
+      },
+      destroy: vi.fn(),
+    })),
+    setAwsClients: vi.fn(),
+    getAwsClients: vi.fn(),
+  };
+});
+
+const mockGetState = vi.fn<(stackName: string) => Promise<{ state: StackState } | null>>();
+vi.mock('../../../src/state/s3-state-backend.js', () => ({
+  S3StateBackend: vi.fn().mockImplementation(() => ({
+    getState: mockGetState,
+  })),
+}));
+
+// LockManager is imported by state.ts but unused for `state resources`.
+vi.mock('../../../src/state/lock-manager.js', () => ({
+  LockManager: vi.fn().mockImplementation(() => ({
+    isLocked: vi.fn(),
+  })),
+}));
+
+import { createStateCommand } from '../../../src/cli/commands/state.js';
+
+function captureStdout(): { output: string[]; restore: () => void } {
+  const output: string[] = [];
+  const original = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    output.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+    return true;
+  }) as typeof process.stdout.write;
+  return {
+    output,
+    restore: () => {
+      process.stdout.write = original;
+    },
+  };
+}
+
+async function runStateResources(args: string[]): Promise<string> {
+  const cap = captureStdout();
+  try {
+    const stateCmd = createStateCommand();
+    stateCmd.exitOverride();
+    stateCmd.commands.forEach((sub) => sub.exitOverride());
+    await stateCmd.parseAsync(args, { from: 'user' });
+  } finally {
+    cap.restore();
+  }
+  return cap.output.join('');
+}
+
+function makeResource(overrides: Partial<ResourceState> = {}): ResourceState {
+  return {
+    physicalId: overrides.physicalId ?? 'phys-id',
+    resourceType: overrides.resourceType ?? 'AWS::S3::Bucket',
+    properties: overrides.properties ?? {},
+    ...(overrides.attributes && { attributes: overrides.attributes }),
+    ...(overrides.dependencies && { dependencies: overrides.dependencies }),
+  };
+}
+
+function makeState(resources: Record<string, ResourceState>): { state: StackState } {
+  return {
+    state: {
+      version: 1,
+      stackName: 'TestStack',
+      resources,
+      outputs: {},
+      lastModified: 0,
+    },
+  };
+}
+
+describe('cdkd state resources', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockGetState.mockReset();
+    errorSpy.mockReset();
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit-mock');
+    }) as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('reports a clear error message when the stack has no state', async () => {
+    mockGetState.mockResolvedValue(null);
+
+    await expect(runStateResources(['resources', 'Missing'])).rejects.toThrow();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalled();
+    const message = String(errorSpy.mock.calls[0]?.[0] ?? '');
+    expect(message).toMatch(/No state found for stack 'Missing'/);
+  });
+
+  it('emits nothing when the stack has zero resources (default)', async () => {
+    mockGetState.mockResolvedValue(makeState({}));
+    const out = await runStateResources(['resources', 'Empty']);
+    expect(out).toBe('');
+  });
+
+  it('emits an empty JSON array when --json is set on a zero-resource stack', async () => {
+    mockGetState.mockResolvedValue(makeState({}));
+    const out = await runStateResources(['resources', 'Empty', '--json']);
+    expect(JSON.parse(out)).toEqual([]);
+  });
+
+  it('prints aligned columns sorted by logical id by default', async () => {
+    mockGetState.mockResolvedValue(
+      makeState({
+        ZebraBucket: makeResource({
+          resourceType: 'AWS::S3::Bucket',
+          physicalId: 'zebra-bucket',
+        }),
+        Alpha: makeResource({ resourceType: 'AWS::IAM::Role', physicalId: 'alpha-role' }),
+      })
+    );
+
+    const out = await runStateResources(['resources', 'StackA']);
+    const lines = out.trimEnd().split('\n');
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatch(/^Alpha\s+AWS::IAM::Role\s+alpha-role$/);
+    expect(lines[1]).toMatch(/^ZebraBucket\s+AWS::S3::Bucket\s+zebra-bucket$/);
+
+    // Columns must align: the type column starts at the same offset on both lines.
+    const typeOffset0 = lines[0]!.indexOf('AWS::IAM::Role');
+    const typeOffset1 = lines[1]!.indexOf('AWS::S3::Bucket');
+    expect(typeOffset0).toBe(typeOffset1);
+  });
+
+  it('emits a long human-readable block per resource with --long', async () => {
+    mockGetState.mockResolvedValue(
+      makeState({
+        MyFunction: makeResource({
+          resourceType: 'AWS::Lambda::Function',
+          physicalId: 'cdkd-MyFunction-XYZ',
+          attributes: {
+            Arn: 'arn:aws:lambda:us-east-1:123456789012:function:cdkd-MyFunction-XYZ',
+          },
+          dependencies: ['MyLambdaRole'],
+        }),
+      })
+    );
+
+    const out = await runStateResources(['resources', 'StackA', '--long']);
+
+    expect(out).toContain('MyFunction');
+    expect(out).toContain('  Type: AWS::Lambda::Function');
+    expect(out).toContain('  PhysicalID: cdkd-MyFunction-XYZ');
+    expect(out).toContain('  Dependencies: MyLambdaRole');
+    expect(out).toContain('  Attributes:');
+    expect(out).toContain('    Arn: arn:aws:lambda:us-east-1:123456789012:function:cdkd-MyFunction-XYZ');
+  });
+
+  it('reports `(none)` for resources with no dependencies / no attributes under --long', async () => {
+    mockGetState.mockResolvedValue(
+      makeState({
+        Bare: makeResource({ resourceType: 'AWS::S3::Bucket', physicalId: 'bare-bucket' }),
+      })
+    );
+
+    const out = await runStateResources(['resources', 'StackA', '--long']);
+
+    expect(out).toContain('  Dependencies: (none)');
+    expect(out).toContain('  Attributes: (none)');
+  });
+
+  it('renders structured attribute values as inline JSON under --long', async () => {
+    mockGetState.mockResolvedValue(
+      makeState({
+        Table: makeResource({
+          resourceType: 'AWS::DynamoDB::Table',
+          physicalId: 'my-table',
+          attributes: {
+            StreamArn: 'arn:aws:dynamodb:::stream/...',
+            Tags: [{ Key: 'env', Value: 'dev' }],
+          },
+        }),
+      })
+    );
+
+    const out = await runStateResources(['resources', 'StackA', '--long']);
+
+    expect(out).toContain('    StreamArn: arn:aws:dynamodb:::stream/...');
+    expect(out).toContain('    Tags: [{"Key":"env","Value":"dev"}]');
+  });
+
+  it('emits a JSON array of full resource details with --json', async () => {
+    mockGetState.mockResolvedValue(
+      makeState({
+        Beta: makeResource({
+          resourceType: 'AWS::Lambda::Function',
+          physicalId: 'cdkd-Beta',
+          attributes: { Arn: 'arn:beta' },
+          dependencies: ['Alpha'],
+        }),
+        Alpha: makeResource({ resourceType: 'AWS::IAM::Role', physicalId: 'cdkd-Alpha' }),
+      })
+    );
+
+    const out = await runStateResources(['resources', 'StackA', '--json']);
+    const parsed = JSON.parse(out);
+
+    expect(parsed).toEqual([
+      {
+        logicalId: 'Alpha',
+        resourceType: 'AWS::IAM::Role',
+        physicalId: 'cdkd-Alpha',
+        dependencies: [],
+        attributes: {},
+      },
+      {
+        logicalId: 'Beta',
+        resourceType: 'AWS::Lambda::Function',
+        physicalId: 'cdkd-Beta',
+        dependencies: ['Alpha'],
+        attributes: { Arn: 'arn:beta' },
+      },
+    ]);
+  });
+
+  it('does not leak `properties` into any output mode', async () => {
+    mockGetState.mockResolvedValue(
+      makeState({
+        Hidden: makeResource({
+          resourceType: 'AWS::S3::Bucket',
+          physicalId: 'hidden-bucket',
+          properties: { BucketName: 'hidden-bucket', Tags: [{ Key: 'secret', Value: 'shh' }] },
+        }),
+      })
+    );
+
+    const defaultOut = await runStateResources(['resources', 'StackA']);
+    const longOut = await runStateResources(['resources', 'StackA', '--long']);
+    const jsonOut = await runStateResources(['resources', 'StackA', '--json']);
+
+    for (const out of [defaultOut, longOut, jsonOut]) {
+      expect(out).not.toContain('secret');
+      expect(out).not.toContain('shh');
+    }
+  });
+});

--- a/tests/unit/cli/state-resources.test.ts
+++ b/tests/unit/cli/state-resources.test.ts
@@ -37,9 +37,11 @@ vi.mock('../../../src/utils/aws-clients.ts', () => {
 });
 
 const mockGetState = vi.fn<(stackName: string) => Promise<{ state: StackState } | null>>();
+const mockVerifyBucketExists = vi.fn<() => Promise<void>>();
 vi.mock('../../../src/state/s3-state-backend.js', () => ({
   S3StateBackend: vi.fn().mockImplementation(() => ({
     getState: mockGetState,
+    verifyBucketExists: mockVerifyBucketExists,
   })),
 }));
 
@@ -107,6 +109,8 @@ describe('cdkd state resources', () => {
 
   beforeEach(() => {
     mockGetState.mockReset();
+    mockVerifyBucketExists.mockReset();
+    mockVerifyBucketExists.mockResolvedValue();
     errorSpy.mockReset();
     exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
       throw new Error('process.exit-mock');

--- a/tests/unit/cli/state-rm.test.ts
+++ b/tests/unit/cli/state-rm.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const errorSpy = vi.hoisted(() => vi.fn());
+const infoSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  getLogger: () => ({
+    setLevel: vi.fn(),
+    debug: vi.fn(),
+    info: infoSpy,
+    warn: vi.fn(),
+    error: errorSpy,
+    child: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  }),
+}));
+
+vi.mock('../../../src/cli/config-loader.js', () => ({
+  resolveStateBucketWithDefault: vi.fn(async () => 'test-bucket'),
+}));
+
+vi.mock('../../../src/utils/aws-clients.ts', () => {
+  return {
+    AwsClients: vi.fn().mockImplementation(() => ({
+      get s3() {
+        return {};
+      },
+      destroy: vi.fn(),
+    })),
+    setAwsClients: vi.fn(),
+    getAwsClients: vi.fn(),
+  };
+});
+
+const mockStateExists = vi.fn<(stackName: string) => Promise<boolean>>();
+const mockDeleteState = vi.fn<(stackName: string) => Promise<void>>();
+const mockVerifyBucketExists = vi.fn<() => Promise<void>>();
+vi.mock('../../../src/state/s3-state-backend.js', () => ({
+  S3StateBackend: vi.fn().mockImplementation(() => ({
+    stateExists: mockStateExists,
+    deleteState: mockDeleteState,
+    verifyBucketExists: mockVerifyBucketExists,
+  })),
+}));
+
+const mockIsLocked = vi.fn<(stackName: string) => Promise<boolean>>();
+const mockForceReleaseLock = vi.fn<(stackName: string) => Promise<void>>();
+vi.mock('../../../src/state/lock-manager.js', () => ({
+  LockManager: vi.fn().mockImplementation(() => ({
+    isLocked: mockIsLocked,
+    forceReleaseLock: mockForceReleaseLock,
+  })),
+}));
+
+// Mock readline so the confirmation prompt is fully scriptable in tests.
+const readlineQuestion = vi.hoisted(() => vi.fn<(prompt: string) => Promise<string>>());
+const readlineClose = vi.hoisted(() => vi.fn());
+vi.mock('node:readline/promises', () => ({
+  createInterface: vi.fn(() => ({
+    question: readlineQuestion,
+    close: readlineClose,
+  })),
+}));
+
+import { createStateCommand } from '../../../src/cli/commands/state.js';
+
+function captureStdout(): { output: string[]; restore: () => void } {
+  const output: string[] = [];
+  const original = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    output.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+    return true;
+  }) as typeof process.stdout.write;
+  return {
+    output,
+    restore: () => {
+      process.stdout.write = original;
+    },
+  };
+}
+
+async function runStateRm(args: string[]): Promise<string> {
+  const cap = captureStdout();
+  try {
+    const stateCmd = createStateCommand();
+    stateCmd.exitOverride();
+    stateCmd.commands.forEach((sub) => sub.exitOverride());
+    await stateCmd.parseAsync(args, { from: 'user' });
+  } finally {
+    cap.restore();
+  }
+  return cap.output.join('');
+}
+
+describe('cdkd state rm', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockStateExists.mockReset();
+    mockDeleteState.mockReset();
+    mockDeleteState.mockResolvedValue();
+    mockIsLocked.mockReset();
+    mockForceReleaseLock.mockReset();
+    mockForceReleaseLock.mockResolvedValue();
+    mockVerifyBucketExists.mockReset();
+    mockVerifyBucketExists.mockResolvedValue();
+    readlineQuestion.mockReset();
+    readlineClose.mockReset();
+    errorSpy.mockReset();
+    infoSpy.mockReset();
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit-mock');
+    }) as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('skips a stack whose state does not exist (idempotent)', async () => {
+    mockStateExists.mockResolvedValue(false);
+
+    await runStateRm(['rm', 'Missing', '--yes']);
+
+    expect(mockDeleteState).not.toHaveBeenCalled();
+    expect(mockForceReleaseLock).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringMatching(/No state found for stack: Missing/));
+  });
+
+  it('removes state.json AND lock.json when --yes skips the prompt', async () => {
+    mockStateExists.mockResolvedValue(true);
+    mockIsLocked.mockResolvedValue(false);
+
+    await runStateRm(['rm', 'MyStack', '--yes']);
+
+    expect(readlineQuestion).not.toHaveBeenCalled();
+    expect(mockDeleteState).toHaveBeenCalledWith('MyStack');
+    expect(mockForceReleaseLock).toHaveBeenCalledWith('MyStack');
+  });
+
+  it('refuses to remove a locked stack without --force', async () => {
+    mockStateExists.mockResolvedValue(true);
+    mockIsLocked.mockResolvedValue(true);
+
+    await expect(runStateRm(['rm', 'LockedStack', '--yes'])).rejects.toThrow();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const message = String(errorSpy.mock.calls[0]?.[0] ?? '');
+    expect(message).toMatch(/Stack 'LockedStack' is locked/);
+    expect(mockDeleteState).not.toHaveBeenCalled();
+  });
+
+  it('removes a locked stack when --force is set (and skips lock check)', async () => {
+    mockStateExists.mockResolvedValue(true);
+
+    await runStateRm(['rm', 'LockedStack', '--force']);
+
+    // --force bypasses both the lock check and the prompt.
+    expect(mockIsLocked).not.toHaveBeenCalled();
+    expect(readlineQuestion).not.toHaveBeenCalled();
+    expect(mockDeleteState).toHaveBeenCalledWith('LockedStack');
+    expect(mockForceReleaseLock).toHaveBeenCalledWith('LockedStack');
+  });
+
+  it('prompts and deletes when the user answers `y`', async () => {
+    mockStateExists.mockResolvedValue(true);
+    mockIsLocked.mockResolvedValue(false);
+    readlineQuestion.mockResolvedValue('y');
+
+    const out = await runStateRm(['rm', 'MyStack']);
+
+    expect(readlineQuestion).toHaveBeenCalledTimes(1);
+    expect(out).toMatch(/AWS resources will NOT be deleted/);
+    expect(out).toMatch(/Use 'cdkd destroy MyStack'/);
+    expect(mockDeleteState).toHaveBeenCalledWith('MyStack');
+  });
+
+  it('prompts and cancels when the user answers `n` (or empty)', async () => {
+    mockStateExists.mockResolvedValue(true);
+    mockIsLocked.mockResolvedValue(false);
+    readlineQuestion.mockResolvedValue('');
+
+    await runStateRm(['rm', 'MyStack']);
+
+    expect(mockDeleteState).not.toHaveBeenCalled();
+    expect(mockForceReleaseLock).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/Cancelled removal of state for stack: MyStack/)
+    );
+  });
+
+  it('accepts `yes` (full word) as confirmation, case-insensitively', async () => {
+    mockStateExists.mockResolvedValue(true);
+    mockIsLocked.mockResolvedValue(false);
+    readlineQuestion.mockResolvedValue('YES');
+
+    await runStateRm(['rm', 'MyStack']);
+
+    expect(mockDeleteState).toHaveBeenCalledWith('MyStack');
+  });
+
+  it('iterates over multiple stacks, each with its own confirmation', async () => {
+    mockStateExists.mockResolvedValue(true);
+    mockIsLocked.mockResolvedValue(false);
+    readlineQuestion.mockResolvedValueOnce('y').mockResolvedValueOnce('n');
+
+    await runStateRm(['rm', 'A', 'B']);
+
+    expect(readlineQuestion).toHaveBeenCalledTimes(2);
+    expect(mockDeleteState).toHaveBeenCalledWith('A');
+    expect(mockDeleteState).not.toHaveBeenCalledWith('B');
+    expect(mockForceReleaseLock).toHaveBeenCalledWith('A');
+    expect(mockForceReleaseLock).not.toHaveBeenCalledWith('B');
+  });
+});

--- a/tests/unit/cli/state-show.test.ts
+++ b/tests/unit/cli/state-show.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { LockInfo, ResourceState, StackState } from '../../../src/types/state.js';
+
+const errorSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  getLogger: () => ({
+    setLevel: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: errorSpy,
+    child: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  }),
+}));
+
+vi.mock('../../../src/cli/config-loader.js', () => ({
+  resolveStateBucketWithDefault: vi.fn(async () => 'test-bucket'),
+}));
+
+vi.mock('../../../src/utils/aws-clients.ts', () => {
+  return {
+    AwsClients: vi.fn().mockImplementation(() => ({
+      get s3() {
+        return {};
+      },
+      destroy: vi.fn(),
+    })),
+    setAwsClients: vi.fn(),
+    getAwsClients: vi.fn(),
+  };
+});
+
+const mockGetState = vi.fn<(stackName: string) => Promise<{ state: StackState } | null>>();
+const mockVerifyBucketExists = vi.fn<() => Promise<void>>();
+vi.mock('../../../src/state/s3-state-backend.js', () => ({
+  S3StateBackend: vi.fn().mockImplementation(() => ({
+    getState: mockGetState,
+    verifyBucketExists: mockVerifyBucketExists,
+  })),
+}));
+
+const mockGetLockInfo = vi.fn<(stackName: string) => Promise<LockInfo | null>>();
+vi.mock('../../../src/state/lock-manager.js', () => ({
+  LockManager: vi.fn().mockImplementation(() => ({
+    getLockInfo: mockGetLockInfo,
+  })),
+}));
+
+import { createStateCommand } from '../../../src/cli/commands/state.js';
+
+function captureStdout(): { output: string[]; restore: () => void } {
+  const output: string[] = [];
+  const original = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    output.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+    return true;
+  }) as typeof process.stdout.write;
+  return {
+    output,
+    restore: () => {
+      process.stdout.write = original;
+    },
+  };
+}
+
+async function runStateShow(args: string[]): Promise<string> {
+  const cap = captureStdout();
+  try {
+    const stateCmd = createStateCommand();
+    stateCmd.exitOverride();
+    stateCmd.commands.forEach((sub) => sub.exitOverride());
+    await stateCmd.parseAsync(args, { from: 'user' });
+  } finally {
+    cap.restore();
+  }
+  return cap.output.join('');
+}
+
+function makeResource(overrides: Partial<ResourceState> = {}): ResourceState {
+  return {
+    physicalId: overrides.physicalId ?? 'phys-id',
+    resourceType: overrides.resourceType ?? 'AWS::S3::Bucket',
+    properties: overrides.properties ?? {},
+    ...(overrides.attributes && { attributes: overrides.attributes }),
+    ...(overrides.dependencies && { dependencies: overrides.dependencies }),
+  };
+}
+
+function makeState(overrides: Partial<StackState> = {}): { state: StackState } {
+  return {
+    state: {
+      version: overrides.version ?? 1,
+      stackName: overrides.stackName ?? 'TestStack',
+      ...(overrides.region !== undefined && { region: overrides.region }),
+      resources: overrides.resources ?? {},
+      outputs: overrides.outputs ?? {},
+      lastModified: overrides.lastModified ?? Date.UTC(2026, 3, 29, 10, 23, 45),
+    },
+  };
+}
+
+describe('cdkd state show', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockGetState.mockReset();
+    mockGetLockInfo.mockReset();
+    mockVerifyBucketExists.mockReset();
+    mockVerifyBucketExists.mockResolvedValue();
+    errorSpy.mockReset();
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit-mock');
+    }) as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('reports a clear error when the stack has no state', async () => {
+    mockGetState.mockResolvedValue(null);
+    mockGetLockInfo.mockResolvedValue(null);
+
+    await expect(runStateShow(['show', 'Missing'])).rejects.toThrow();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const message = String(errorSpy.mock.calls[0]?.[0] ?? '');
+    expect(message).toMatch(/No state found for stack 'Missing'/);
+  });
+
+  it('renders stack header, lock status, outputs, and resources', async () => {
+    mockGetState.mockResolvedValue(
+      makeState({
+        stackName: 'MyStack',
+        region: 'us-east-1',
+        outputs: { ApiUrl: 'https://api.example.com' },
+        resources: {
+          MyBucket: makeResource({
+            resourceType: 'AWS::S3::Bucket',
+            physicalId: 'my-bucket-abc',
+            properties: { BucketName: 'my-bucket-abc' },
+            attributes: { Arn: 'arn:aws:s3:::my-bucket-abc' },
+          }),
+        },
+      })
+    );
+    mockGetLockInfo.mockResolvedValue(null);
+
+    const out = await runStateShow(['show', 'MyStack']);
+
+    expect(out).toContain('Stack: MyStack');
+    expect(out).toContain('  Region: us-east-1');
+    expect(out).toContain('  Version: 1');
+    expect(out).toContain('  Last Modified: 2026-04-29T10:23:45.000Z');
+    expect(out).toContain('  Lock: unlocked');
+    expect(out).toContain('Outputs:');
+    expect(out).toContain('  ApiUrl: https://api.example.com');
+    expect(out).toContain('Resources (1):');
+    expect(out).toContain('MyBucket');
+    expect(out).toContain('  Type: AWS::S3::Bucket');
+    expect(out).toContain('  PhysicalID: my-bucket-abc');
+    expect(out).toContain('  Properties:');
+    expect(out).toContain('    BucketName: my-bucket-abc');
+    expect(out).toContain('  Attributes:');
+    expect(out).toContain('    Arn: arn:aws:s3:::my-bucket-abc');
+  });
+
+  it('renders a locked stack with owner / operation / expiry detail', async () => {
+    mockGetState.mockResolvedValue(makeState({ stackName: 'MyStack' }));
+    mockGetLockInfo.mockResolvedValue({
+      owner: 'alice@workstation:1234',
+      operation: 'deploy',
+      timestamp: Date.now() - 60_000,
+      expiresAt: Date.now() + 600_000, // 10 minutes from now
+    });
+
+    const out = await runStateShow(['show', 'MyStack']);
+
+    expect(out).toMatch(/Lock: locked by alice@workstation:1234 \(operation: deploy\), expires in /);
+  });
+
+  it('renders an expired lock when expiresAt is in the past', async () => {
+    mockGetState.mockResolvedValue(makeState({ stackName: 'MyStack' }));
+    mockGetLockInfo.mockResolvedValue({
+      owner: 'bob@host:5678',
+      timestamp: Date.now() - 7_200_000,
+      expiresAt: Date.now() - 30_000, // 30 seconds ago
+    });
+
+    const out = await runStateShow(['show', 'MyStack']);
+
+    expect(out).toMatch(/Lock: locked by bob@host:5678, expired \d+s ago/);
+  });
+
+  it('reports `(none)` for resources with no attributes / no properties', async () => {
+    mockGetState.mockResolvedValue(
+      makeState({
+        resources: {
+          Bare: makeResource({ resourceType: 'AWS::SQS::Queue', physicalId: 'q-1' }),
+        },
+      })
+    );
+    mockGetLockInfo.mockResolvedValue(null);
+
+    const out = await runStateShow(['show', 'AnyStack']);
+
+    expect(out).toContain('  Properties: (none)');
+    expect(out).toContain('  Attributes: (none)');
+    expect(out).toContain('  Dependencies: (none)');
+  });
+
+  it('omits the Outputs section when outputs are empty', async () => {
+    mockGetState.mockResolvedValue(makeState({ outputs: {} }));
+    mockGetLockInfo.mockResolvedValue(null);
+
+    const out = await runStateShow(['show', 'AnyStack']);
+
+    expect(out).not.toContain('Outputs:');
+  });
+
+  it('emits a `{state, lock}` JSON object with --json', async () => {
+    const stateRecord = makeState({
+      stackName: 'JsonStack',
+      region: 'us-west-2',
+      outputs: { Endpoint: 'http://x' },
+      resources: {
+        R1: makeResource({ resourceType: 'AWS::IAM::Role', physicalId: 'r-1' }),
+      },
+    });
+    const lockRecord: LockInfo = {
+      owner: 'ci@runner:9999',
+      operation: 'destroy',
+      timestamp: 100,
+      expiresAt: 200,
+    };
+    mockGetState.mockResolvedValue(stateRecord);
+    mockGetLockInfo.mockResolvedValue(lockRecord);
+
+    const out = await runStateShow(['show', 'JsonStack', '--json']);
+    const parsed = JSON.parse(out);
+
+    expect(parsed.state.stackName).toBe('JsonStack');
+    expect(parsed.state.region).toBe('us-west-2');
+    expect(parsed.state.outputs).toEqual({ Endpoint: 'http://x' });
+    expect(parsed.state.resources.R1.physicalId).toBe('r-1');
+    expect(parsed.lock).toEqual(lockRecord);
+  });
+
+  it('emits `lock: null` in JSON when the stack is unlocked', async () => {
+    mockGetState.mockResolvedValue(makeState({ stackName: 'UnlockedStack' }));
+    mockGetLockInfo.mockResolvedValue(null);
+
+    const out = await runStateShow(['show', 'UnlockedStack', '--json']);
+    const parsed = JSON.parse(out);
+
+    expect(parsed.lock).toBeNull();
+  });
+});

--- a/tests/unit/state/lock-manager.test.ts
+++ b/tests/unit/state/lock-manager.test.ts
@@ -219,6 +219,43 @@ describe('LockManager', () => {
     });
   });
 
+  describe('isLocked', () => {
+    it('returns true when a lock file exists', async () => {
+      const lockInfo: LockInfo = {
+        owner: 'user@host:1',
+        timestamp: Date.now(),
+        expiresAt: Date.now() + 30 * 60 * 1000,
+        operation: 'deploy',
+      };
+      s3Client.send.mockResolvedValueOnce({
+        Body: { transformToString: () => Promise.resolve(JSON.stringify(lockInfo)) },
+      });
+
+      await expect(lockManager.isLocked('test-stack')).resolves.toBe(true);
+    });
+
+    it('returns true even when the existing lock is expired', async () => {
+      const expired: LockInfo = {
+        owner: 'old@host:1',
+        timestamp: Date.now() - 60 * 60 * 1000,
+        expiresAt: Date.now() - 30 * 60 * 1000,
+      };
+      s3Client.send.mockResolvedValueOnce({
+        Body: { transformToString: () => Promise.resolve(JSON.stringify(expired)) },
+      });
+
+      // isLocked is a presence check; expiry is irrelevant here.
+      await expect(lockManager.isLocked('test-stack')).resolves.toBe(true);
+    });
+
+    it('returns false when no lock file exists', async () => {
+      const noSuchKeyError = new NoSuchKey({ message: 'NoSuchKey', $metadata: {} });
+      s3Client.send.mockRejectedValueOnce(noSuchKeyError);
+
+      await expect(lockManager.isLocked('test-stack')).resolves.toBe(false);
+    });
+  });
+
   describe('releaseLock', () => {
     it('should delete the lock file', async () => {
       s3Client.send.mockResolvedValueOnce({});


### PR DESCRIPTION
## Summary

Introduces a `cdkd state` parent command — Terraform-style namespaced subcommands for inspecting and manipulating the cdkd state bucket.

### `cdkd state list` (alias `ls`) — list deployed stacks

A CloudFormation-console-style view over the configured state bucket.

- Default: stack names sorted alphabetically, one per line.
- `--long` / `-l`: per-stack block with resource count, last-modified time (ISO), and lock status.
- `--json`: JSON array (of names by default, or detail objects with `--long`).

Adds `LockManager.isLocked()` as a thin presence check (separate from `acquireLock`'s expiry-aware logic).

### `cdkd state resources <stack>` — list resources of a stack

Per-resource inventory backed by the stack's `state.json`.

- Default: aligned three-column output (LogicalID / Type / PhysicalID) sorted by logical id.
- `--long` / `-l`: per-resource block including dependencies and attributes.
- `--json`: JSON array of detail objects.

Properties are intentionally omitted — see `state show` for those.

### `cdkd state show <stack>` — full state record

The deepest inspection: stack metadata + lock summary + outputs + every resource (including properties).

- Default: human-readable multi-line block. Lock detail inline when locked (owner / operation / expiry).
- `--json`: emits `{state, lock}` — the raw `StackState` plus the lock record (or `null`).

### `cdkd state rm <stack>...` — remove cdkd's state record

Removes `state.json` and any lingering `lock.json` for one or more stacks. **Does NOT delete AWS resources** — `cdkd destroy` is the equivalent for actual resource deletion, and the warning in the prompt makes that explicit.

- Defaults to a `(y/N)` confirmation prompt (more cautious than `cdkd destroy`'s `(Y/n)` because this orphans resources from cdkd's view).
- Refuses on a locked stack unless `--force` is set — pulling the lock out from under an in-flight deploy would corrupt state.
- `--yes` / `-y` skips the prompt; `--force` / `-f` also bypasses the locked refusal.
- Idempotent: skips cleanly if state is missing.

### Plus: friendlier bucket-missing error

All four `state` subcommands now call `verifyBucketExists()` up front. Users without a bootstrapped bucket see the actionable `Run 'cdkd bootstrap' to create it...` message instead of a generic `NoSuchBucket`.

## Test plan

- [x] Unit: `state list` empty / multi / `ls` / `--long` / `--json` / `--long --json` / missing-state fallback / per-stack fan-out
- [x] Unit: `state resources` missing-stack / empty / aligned columns / `--long` / `(none)` / structured-attribute JSON / `--json` / properties NOT leaked
- [x] Unit: `state show` missing-stack / header+lock+outputs+resources / locked rendering / expired-lock rendering / `(none)` / outputs-omitted / `--json` shape / `lock: null`
- [x] Unit: `state rm` missing-state idempotent / `--yes` skip prompt / locked refusal / `--force` bypass lock / `y` deletes / empty answer cancels / `YES` (case-insensitive) / multiple stacks per-prompt
- [x] Unit: `LockManager.isLocked` (locked / unlocked / error propagation)
- [x] `pnpm typecheck && pnpm lint && pnpm build && pnpm test` — 722 tests pass, +36 new
- [x] Manual run against real S3 state bucket: `state list` (default / `--long` / `--json`), `state resources <stack>` (3 modes), `state show <stack>` (default / `--json`), `state rm NonExistent --yes` (idempotent skip), bucket-not-exist (helpful message verified)
