### PR TITLE
docs(plans): add multi-PR rollout plan for region/state refactor

### DIFF
--- a/docs/plans/01-state-key-region-prefix.md
+++ b/docs/plans/01-state-key-region-prefix.md
@@ -1,0 +1,229 @@
+# PR 1: State key region prefix (collection model extension)
+
+**Status**: planned
+**Branch**: `feat/state-region-key`
+**Depends on**: none
+**Breaking change**: yes (auto-migrated, gated by `bc-check` markgate)
+**Parallel with**: PR 2, 3, 6, 7
+
+## Goal
+
+Make a stack's region part of the S3 state key so `env.region` changes do not
+overwrite each other. After this PR, the same `stackName` deployed to two
+different regions has two independent state files.
+
+## Background
+
+Current layout:
+
+```
+s3://{bucket}/cdkd/{stackName}/state.json
+```
+
+The region is stored *inside* `state.json` (`region: string`). When a user
+changes `env.region` from `us-west-2` to `us-east-1` and re-runs `cdkd deploy`,
+the state file at the same key is rewritten with `region: "us-east-1"`. The
+original `us-west-2` resources still exist, but cdkd no longer knows about
+them. A subsequent `cdkd destroy` runs against `us-east-1`, hits
+`ResourceNotFoundException` for each resource, and treats those errors as
+idempotent successes — silent failure.
+
+This is the root cause of the bug surfaced in the discussion that produced
+this rollout.
+
+## Scope
+
+### In scope
+
+- New state key layout: `cdkd/{stackName}/{region}/state.json`.
+- Lock key parallel: `cdkd/{stackName}/{region}/lock.json`.
+- `state.json` schema bump: `version: 2` (was `version: 1`).
+- Backwards-compat read path for `version: 1` (`cdkd/{stackName}/state.json`)
+  with a deprecation warning.
+- Auto-migration on next write: read legacy → write new key → delete legacy.
+- `cdkd state list` default output gains a region column / paren suffix:
+  `MyStack (us-west-2)`.
+- `cdkd state show` and `cdkd state resources` accept an optional
+  `--region` filter when a stack name resolves to multiple region keys.
+- `cdkd state rm` deletes all region keys for the stack by default,
+  with `--region` available to scope to one.
+- DAG-builder, deploy-engine, destroy command pass `region` to the state
+  backend so reads/writes hit the right key.
+
+### Out of scope (handled by other PRs)
+
+- Default bucket name change (PR 4).
+- `--region` flag deprecation on most commands (PR 5).
+- Dynamic bucket region resolution (PR 3).
+- DELETE region verification (PR 2).
+
+## Design
+
+### Key resolution
+
+`S3StateBackend` gains a constructor parameter or method to resolve keys
+based on `(stackName, region)`. Reads use the following lookup order:
+
+1. New key: `cdkd/{stackName}/{region}/state.json`
+2. Legacy key: `cdkd/{stackName}/state.json` (only if region matches the
+   `region` field of the legacy state body)
+
+If a legacy key is found and the caller is a write path, the legacy state is
+copied to the new key and the legacy key is deleted in the same write turn.
+
+### Schema version
+
+```typescript
+interface StackState {
+  version: 1 | 2;     // 1 = legacy, 2 = region-prefixed
+  stackName: string;
+  region: string;     // already exists, now load-bearing
+  resources: Record<string, ResourceState>;
+  outputs: Record<string, string>;
+  lastModified: number;
+}
+```
+
+A `version: 2` reader rejects `version: 3+` with a clear error
+(`Unsupported state schema version 3. Upgrade cdkd.`). A `version: 1` reader
+in older cdkd binaries already rejects `version: 2` because the legacy code
+expects either no version or `version: 1` only.
+
+### Multi-region same-name semantics
+
+When `stackName` resolves to multiple region keys (transient state from an
+in-flight `env.region` change), commands behave as follows:
+
+| Command | Behavior |
+|---|---|
+| `cdkd state list` | One row per region key |
+| `cdkd state show <stack>` | If multiple regions, list them and require `--region` |
+| `cdkd state resources <stack>` | Same as `state show` |
+| `cdkd state rm <stack>` | Removes all region keys (with confirmation) |
+| `cdkd state rm <stack> --region X` | Removes only region X |
+| `cdkd deploy <stack>` | Synth-driven; `env.region` selects the key |
+| `cdkd destroy <stack>` | Synth-driven; `env.region` selects the key |
+| `cdkd diff <stack>` | Synth-driven; `env.region` selects the key |
+
+### Lock key
+
+Locks are also region-scoped: `cdkd/{stackName}/{region}/lock.json`. This
+means two regions of the same stack name can be operated on in parallel
+without contention, which is consistent with the rest of cdkd's parallel
+execution model.
+
+## Implementation steps
+
+1. Update `src/types/state.ts` to allow `version: 1 | 2`.
+2. Add helper `getStateKey(stackName, region)` returning the new key, and
+   `getLegacyStateKey(stackName)` for the old one.
+3. Update `S3StateBackend.getState` / `saveState` / `stateExists` to:
+   - Read new key first; if missing, try legacy; mark `migrationPending`
+     when legacy is used.
+   - On save, always write the new key. If `migrationPending`, also delete
+     the legacy key after the new write succeeds.
+4. Update `LockManager` similarly (region-scoped lock key).
+5. Update `S3StateBackend.listStacks` to enumerate both new and legacy
+   layouts and produce `{stackName, region}[]`.
+6. Update each call site to pass `region` (deploy.ts, destroy.ts, diff.ts,
+   state.ts subcommands, force-unlock.ts).
+7. Update `cdkd state list` output to include region: `MyStack (us-west-2)`.
+8. Update `cdkd state show` / `state resources` to require `--region` when
+   ambiguous; emit a clear error listing the candidate regions.
+9. Update `cdkd state rm` to remove all region keys by default; accept
+   `--region` for scoping.
+10. Add unit tests covering each lookup branch, the migration write path,
+    and the multi-region listing.
+11. Add integration tests:
+    - `tests/integration/legacy-state-migration/` — legacy fixture in S3,
+      run cdkd, verify auto-migration.
+    - `tests/integration/multi-region-same-stack/` — deploy same stackName
+      to two regions, verify both states coexist and `state list` shows
+      both rows.
+12. Update docs: `docs/state-management.md`, `CLAUDE.md`, `README.md`.
+13. Add `scripts/verify-bc.sh` (shared with PR 4) — covers the legacy →
+    new migration path.
+14. Refresh `bc-check` markgate marker via the script.
+
+## Tests
+
+### Unit (Vitest)
+
+- `tests/unit/state/s3-state-backend.test.ts` — extend with cases:
+  - getState reads new key when present.
+  - getState falls back to legacy and surfaces `migrationPending: true`.
+  - saveState writes new key and deletes legacy when `migrationPending`.
+  - listStacks merges new and legacy layouts; deduplicates `(stackName,
+    region)` pairs.
+- `tests/unit/state/lock-manager.test.ts` — region-scoped lock keys.
+- `tests/unit/cli/state.test.ts` — output format, `--region` disambiguation.
+
+### Integration (real AWS)
+
+- `tests/integration/legacy-state-migration/` — minimal stack, seed a
+  `version: 1` state file in the bucket, run deploy, verify post-state.
+- `tests/integration/multi-region-same-stack/` — stack with `env.region`
+  changed mid-flight, verify both state files end up coexisting.
+
+## Compatibility verification (Pre-merge checklist)
+
+Run `scripts/verify-bc.sh PR-1` (script lives alongside this PR), or perform
+the following manually:
+
+### A. Legacy → New (auto-migration)
+
+- [ ] `pnpm run build`
+- [ ] Seed a state bucket with a `version: 1` state at
+      `s3://{bucket}/cdkd/MyStack/state.json` (region: us-west-2).
+- [ ] `cdkd state list --state-bucket {bucket}`
+      Expected: `MyStack (us-west-2)` plus a legacy-format warning in
+      `--verbose` output.
+- [ ] `cdkd deploy MyStack --state-bucket {bucket}` (no template change)
+      Expected: writes `cdkd/MyStack/us-west-2/state.json`; deletes legacy
+      `cdkd/MyStack/state.json`.
+- [ ] `aws s3 ls s3://{bucket}/cdkd/MyStack/` — only `us-west-2/` is left.
+
+### B. New format (regular operation)
+
+- [ ] Fresh bucket, `cdkd deploy MyStack`.
+- [ ] `aws s3 ls s3://{bucket}/cdkd/MyStack/` — `us-west-2/state.json` only.
+- [ ] `cdkd state list` → `MyStack (us-west-2)`.
+- [ ] `cdkd destroy MyStack` removes both AWS resources and the state key.
+
+### C. Multi-region same stackName
+
+- [ ] Deploy `MyStack` to `us-west-2`, then change `env.region` to
+      `us-east-1` in code, deploy again.
+- [ ] `aws s3 ls s3://{bucket}/cdkd/MyStack/` — `us-west-2/` and
+      `us-east-1/` both present.
+- [ ] `cdkd state list` → two rows.
+- [ ] `cdkd state rm MyStack` (with confirmation) → both region keys gone.
+
+### D. Cross-version coexistence (silent-failure prevention)
+
+- [ ] An old cdkd binary trying to read a `version: 2` state file produces
+      a clear error and exits non-zero (no silent fallback).
+
+## Documentation updates
+
+- `docs/state-management.md` — bucket structure section: new key layout,
+  legacy migration, schema version, multi-region semantics.
+- `CLAUDE.md` — Important Implementation Details: state key layout includes
+  region; transient multi-region same-name allowed.
+- `README.md` — Caveats: same `stackName` in multiple regions becomes
+  visible after `env.region` changes; use `cdkd state rm --region X` to
+  prune.
+
+## References
+
+- Original silent-failure incident:
+  `s3://cdkd-state-{accountId}-us-east-1/cdkd/MyStage-CdkSampleStack/state.json`
+  (now cleaned up).
+- Related rule in `CLAUDE.md`: "DELETE idempotency (not-found / No policy
+  found treated as success)" — this PR's protection complements PR 2's
+  region check.
+- Legacy `version: 1` schema: `src/types/state.ts:4-12`.
+
+## Follow-ups discovered during implementation
+
+(To be filled in as work progresses.)

--- a/docs/plans/02-delete-region-verification.md
+++ b/docs/plans/02-delete-region-verification.md
@@ -1,0 +1,168 @@
+# PR 2: DELETE region verification
+
+**Status**: planned
+**Branch**: `feat/delete-region-check`
+**Depends on**: none
+**Breaking change**: no
+**Parallel with**: PR 1, 3, 6, 7
+
+## Goal
+
+Stop treating "resource not found in the AWS client's region" as idempotent
+delete success. Before treating a `*NotFound` error as success, verify that
+the region the provider is operating against actually matches the region
+recorded in the stack's state. If it does not, surface the error.
+
+## Background
+
+In the silent-failure incident, the Lambda function actually existed in
+`us-west-2`, but the cdkd client was operating against `us-east-1`. The
+provider received `ResourceNotFoundException` and treated it as idempotent
+"already gone" success, removing the resource from state. The actual Lambda
+remained orphaned in `us-west-2` until manual cleanup.
+
+The current `CLAUDE.md` rule:
+
+> DELETE idempotency (not-found / No policy found treated as success)
+
+is correct in spirit — duplicate-delete must be safe — but it must not
+mask region mismatches.
+
+## Scope
+
+### In scope
+
+- Add a region-mismatch check before any provider's `delete` returns
+  "success" on a `NotFound` error.
+- Log a clear `ProvisioningError` when client region != state region.
+- Apply consistently across:
+  - All SDK providers (`src/provisioning/providers/*.ts`).
+  - The Cloud Control fallback provider (`src/provisioning/cloud-control-provider.ts`).
+
+### Out of scope
+
+- Detecting orphans in *other* regions (this would require a global scan
+  per resource type and is impractical).
+- Changing how successful deletes are reported.
+
+## Design
+
+The provider's `delete` already receives the `physicalId`. To verify the
+region, the provider needs:
+
+- The region of the AWS client it is using (already known).
+- The region that the resource is *expected* to live in.
+
+The expected region comes from the stack state's `region` field. Plumb that
+through the provider call so each provider can compare:
+
+```typescript
+interface ResourceProvider {
+  delete(
+    physicalId: string,
+    logicalId: string,
+    resourceType: string,
+    properties: Record<string, unknown>,
+    context: { expectedRegion?: string },   // NEW
+  ): Promise<void>;
+}
+```
+
+In each provider's `delete` method:
+
+```typescript
+try {
+  await client.send(new DeleteFooCommand({ ... }));
+} catch (err) {
+  if (isNotFound(err)) {
+    if (context.expectedRegion && context.expectedRegion !== client.config.region) {
+      throw new ProvisioningError(
+        `Refusing to treat NotFound as idempotent: client region ` +
+        `${client.config.region} does not match state region ${context.expectedRegion}.`,
+      );
+    }
+    // genuine idempotent success
+    return;
+  }
+  throw err;
+}
+```
+
+`client.config.region` resolution: SDK v3 clients expose `await
+client.config.region()` (a Provider returning a Promise<string>). The
+helper resolves once at provider construction time and caches.
+
+## Implementation steps
+
+1. Extend the `ResourceProvider` interface in
+   `src/provisioning/types.ts` to include the `context` parameter on
+   `delete` (with `expectedRegion` optional for backwards-compat with any
+   external implementations during the transition).
+2. Update `DeployEngine` and the destroy command to pass
+   `expectedRegion: state.region` when invoking provider deletes.
+3. For each SDK provider in `src/provisioning/providers/`:
+   - Wrap the existing `NotFound` handling in a region-mismatch check.
+   - Emit a `ProvisioningError` with a clear message when the check fails.
+4. Update `cloud-control-provider.ts` similarly.
+5. Add a shared helper `assertRegionMatch(clientRegion, expectedRegion)` to
+   avoid copy-paste, in `src/provisioning/region-check.ts`.
+6. Add unit tests using mocked providers with deliberate region mismatch.
+7. Update `docs/provider-development.md` and `CLAUDE.md` to document the
+   new contract.
+
+## Tests
+
+### Unit (Vitest)
+
+- `tests/unit/provisioning/region-check.test.ts` — the helper itself.
+- For each provider's existing test file, add cases:
+  - delete with matching region + NotFound → success (existing behavior
+    preserved).
+  - delete with mismatched region + NotFound → throws
+    `ProvisioningError` containing both regions.
+  - delete with no `expectedRegion` (fallback) → existing idempotent
+    behavior.
+
+### Integration
+
+- Reproduce the silent-failure scenario locally with mocked AWS where
+  possible. A real-AWS reproduction is impractical without two real regions
+  and live resources, but the unit-level coverage is sufficient given the
+  tightness of the check.
+
+## Compatibility verification (Pre-merge checklist)
+
+This PR is **not** a breaking change for users. Internally it is a small
+behavioral change to providers; external provider implementations (none
+exist today) would need to accept the new context parameter. The check
+runs after build and lint as usual.
+
+- [ ] `pnpm run build`
+- [ ] `pnpm test` — all existing provider tests still pass.
+- [ ] `pnpm run typecheck`
+- [ ] `pnpm run lint`
+- [ ] Manually grep for any provider implementation that has not been
+      updated — every `ResourceProvider` in
+      `src/provisioning/providers/` should accept `context`.
+- [ ] Run `tests/integration/basic` deploy + destroy end-to-end to confirm
+      no regression on the happy path.
+
+## Documentation updates
+
+- `docs/provider-development.md` — Provider contract: explain the
+  `context.expectedRegion` parameter and the region-mismatch check.
+- `CLAUDE.md` — Provider Pattern section: amend `delete` signature.
+  Important Implementation Details: clarify "DELETE idempotency" no
+  longer masks region mismatch.
+
+## References
+
+- Silent-failure incident: a Lambda in `us-west-2` returned NotFound
+  against a `us-east-1` client and was wrongly removed from state. See
+  the `cdkd destroy` log included in the rollout discussion.
+- Affected providers: `src/provisioning/providers/lambda-function-provider.ts`
+  and every other SDK provider.
+
+## Follow-ups discovered during implementation
+
+(To be filled in as work progresses.)

--- a/docs/plans/03-dynamic-region-resolution.md
+++ b/docs/plans/03-dynamic-region-resolution.md
@@ -1,0 +1,251 @@
+# PR 3: Dynamic region resolution + UnknownError normalization
+
+**Status**: planned
+**Branch**: `feat/dynamic-region-resolution`
+**Depends on**: none
+**Breaking change**: no
+**Parallel with**: PR 1, 2, 6, 7
+
+## Goal
+
+Two related fixes:
+
+1. **Dynamic state-bucket region resolution** — When the cdkd CLI's profile
+   region differs from the state bucket's actual region, resolve the
+   bucket region via `GetBucketLocation` and use it for the state-bucket
+   S3 client. Other AWS clients (resource provisioning) keep using the
+   stack's `env.region`, unchanged.
+2. **`UnknownError` normalization** — Convert AWS SDK v3 synthetic
+   `Unknown` / `UnknownError` exceptions into messages keyed off
+   `$metadata.httpStatusCode`, so users get actionable text instead of
+   the literal string `UnknownError`.
+
+## Background
+
+### Bucket region mismatch
+
+The current default state bucket name is `cdkd-state-{accountId}-{region}`
+where `{region}` comes from the CLI's profile region. But a user's profile
+region can differ from the bucket's actual region (e.g., they used
+`--state-bucket cdkd-state-test` to point at a teammate's bucket; or
+the default region was changed locally without re-bootstrapping). The S3
+client created with the profile region then issues `HeadBucket` to a
+bucket in another region. S3 returns `301 PermanentRedirect` with
+`x-amz-bucket-region` set, but the AWS SDK v3 region-redirect middleware
+does not handle the empty-body HEAD response cleanly; the protocol parser
+falls through to `getErrorSchemaOrThrowBaseException` which produces a
+synthetic `name: 'Unknown'`, `message: 'UnknownError'` exception.
+
+### UnknownError surface
+
+The same synthetic error appears in other places where a HEAD response
+arrives without a parseable XML body. Today the user sees:
+
+```
+StateError: Failed to verify state bucket 'X': UnknownError
+Caused by: UnknownError
+```
+
+…which is uninformative.
+
+## Scope
+
+### In scope
+
+- New helper `src/utils/aws-region-resolver.ts` exposing
+  `resolveBucketRegion(bucketName, opts): Promise<string>`.
+  - Uses `GetBucketLocation` (GET, not HEAD — has a body, not subject to
+    the same SDK glitch).
+  - Caches per-bucket result.
+- `S3StateBackend` rebuilds its S3Client using the resolved region before
+  any state operation (idempotent).
+- New helper `src/utils/error-handler.ts` ➜ `normalizeAwsError(err,
+  context)`:
+  - Detects `name === 'Unknown'` / `message === 'UnknownError'`.
+  - Maps `$metadata.httpStatusCode` to a typed message:
+    - 301 → `Bucket '<name>' is in a different region than the client.`
+    - 403 → `Access denied to bucket '<name>'. Verify credentials and
+      bucket policy.`
+    - 404 → `Bucket '<name>' does not exist.`
+    - other → `S3 error (HTTP <status>): see CloudTrail for details.`
+- `verifyBucketExists` and other state-bucket operations route their
+  errors through `normalizeAwsError`.
+- bootstrap's pre-existence `HeadBucket` also routes errors through
+  `normalizeAwsError`, so `cdkd bootstrap --state-bucket existing-bucket`
+  produces a useful message instead of `Unknown: UnknownError`.
+
+### Out of scope
+
+- Default bucket name change (PR 4 — depends on this PR).
+- `--region` deprecation (PR 5 — depends on this PR).
+- Stack-region resolution (already handled by `env.region`).
+
+## Design
+
+### `resolveBucketRegion`
+
+```typescript
+// src/utils/aws-region-resolver.ts
+import { GetBucketLocationCommand, S3Client } from '@aws-sdk/client-s3';
+
+const cache = new Map<string, Promise<string>>();
+
+export async function resolveBucketRegion(
+  bucketName: string,
+  opts: { profile?: string; fallbackRegion?: string } = {},
+): Promise<string> {
+  if (cache.has(bucketName)) return cache.get(bucketName)!;
+
+  const promise = (async () => {
+    // Use a region-agnostic client. us-east-1 works as the default global
+    // endpoint for GetBucketLocation.
+    const client = new S3Client({
+      region: 'us-east-1',
+      ...(opts.profile && { profile: opts.profile }),
+    });
+    try {
+      const r = await client.send(new GetBucketLocationCommand({ Bucket: bucketName }));
+      return r.LocationConstraint || 'us-east-1';   // empty/null = us-east-1
+    } finally {
+      client.destroy();
+    }
+  })();
+
+  cache.set(bucketName, promise);
+  return promise;
+}
+```
+
+### `normalizeAwsError`
+
+```typescript
+// src/utils/error-handler.ts (new export)
+export function normalizeAwsError(
+  err: unknown,
+  context: { bucket?: string; operation?: string } = {},
+): Error {
+  if (!(err instanceof Error)) return new Error(String(err));
+
+  const isUnknown = err.name === 'Unknown' || err.message === 'UnknownError';
+  if (!isUnknown) return err;
+
+  const status = (err as any).$metadata?.httpStatusCode;
+  const bucket = context.bucket ?? '<unknown bucket>';
+  switch (status) {
+    case 301: {
+      const region = (err as any).$response?.headers?.['x-amz-bucket-region'];
+      const where = region ? ` (in ${region})` : '';
+      return new Error(
+        `Bucket '${bucket}'${where} is in a different region than the client. ` +
+        `cdkd resolves this automatically; if you see this message, please report it.`,
+      );
+    }
+    case 403:
+      return new Error(`Access denied to bucket '${bucket}'.`);
+    case 404:
+      return new Error(`Bucket '${bucket}' does not exist.`);
+    default:
+      return new Error(`S3 error during ${context.operation ?? 'operation'} on '${bucket}' (HTTP ${status}).`);
+  }
+}
+```
+
+### State backend integration
+
+Before the first state operation, `S3StateBackend` resolves the bucket
+region and rebuilds its client:
+
+```typescript
+async ensureClientForBucket(): Promise<void> {
+  if (this.clientResolved) return;
+  const region = await resolveBucketRegion(this.config.bucket, this.opts);
+  if (region !== this.s3Client.config.region) {
+    this.s3Client.destroy();
+    this.s3Client = new S3Client({ region, ...this.opts });
+  }
+  this.clientResolved = true;
+}
+```
+
+`getState`, `saveState`, `verifyBucketExists`, etc., all call
+`ensureClientForBucket()` first.
+
+This client is *only* used for state operations. The provisioning clients
+(used by providers) are untouched and continue to use the stack's
+`env.region`.
+
+## Implementation steps
+
+1. Add `src/utils/aws-region-resolver.ts` with cache.
+2. Extend `src/utils/error-handler.ts` with `normalizeAwsError` and unit
+   tests.
+3. Modify `src/state/s3-state-backend.ts`:
+   - `ensureClientForBucket()` private helper.
+   - Call from every public method.
+   - Wrap thrown errors via `normalizeAwsError`.
+4. Modify `src/cli/commands/bootstrap.ts` to use `normalizeAwsError`
+   around its `HeadBucket` pre-check.
+5. Update `src/cli/commands/state.ts`'s `setupStateBackend` so the state
+   backend is fully ready (including resolution) before any subcommand
+   runs.
+6. Unit tests:
+   - region resolver: cache, fallback, IAM/network failure.
+   - normalizeAwsError: each status code, non-Unknown errors are passed
+     through.
+   - S3StateBackend: client rebuild on region mismatch.
+7. Integration: a small fixture bucket in a non-default region
+   (`tests/integration/cross-region-state-bucket/`).
+8. Docs: `docs/state-management.md`, `docs/troubleshooting.md`.
+
+## Tests
+
+### Unit
+
+- `tests/unit/utils/aws-region-resolver.test.ts`
+- `tests/unit/utils/error-handler.test.ts`
+- `tests/unit/state/s3-state-backend.test.ts` — extended with mismatched-
+  region scenario.
+
+### Integration
+
+- `tests/integration/cross-region-state-bucket/` — bucket in `us-west-2`,
+  CLI run with `AWS_REGION=us-east-1`. Expected: `cdkd state list` works
+  without manual region setting.
+
+## Compatibility verification (Pre-merge checklist)
+
+This PR does not change on-disk formats. It only fixes runtime behavior.
+
+- [ ] `pnpm run build`
+- [ ] `pnpm test` — full suite, no regressions.
+- [ ] `pnpm run typecheck`
+- [ ] `pnpm run lint`
+- [ ] Manual: with profile `us-east-1`, run `cdkd state list
+      --state-bucket {bucket-in-us-west-2}`. Expected: no
+      `UnknownError`; output succeeds.
+- [ ] Manual: with profile `us-east-1`, run `cdkd bootstrap
+      --state-bucket {bucket-in-us-west-2}` (already exists).
+      Expected: clear "bucket exists in us-west-2" or "access denied"
+      message, no `UnknownError`.
+
+## Documentation updates
+
+- `docs/state-management.md` — note that the state bucket can live in any
+  region; the CLI auto-detects.
+- `docs/troubleshooting.md` — remove or update any guidance that
+  recommended setting `--region` to match the bucket region (replaced by
+  auto-resolution).
+- `CLAUDE.md` — Important Implementation Details: state bucket region is
+  resolved dynamically via `GetBucketLocation`; provisioning clients
+  continue to use `env.region`.
+
+## References
+
+- Original `UnknownError` reproduction in the rollout discussion (with
+  full stack trace from `@aws-sdk/core/.../protocols/index.js:1842:65`).
+- AWS SDK v3 region-redirect middleware: known to misbehave on HEAD
+  responses with empty bodies.
+
+## Follow-ups discovered during implementation
+
+(To be filled in as work progresses.)

--- a/docs/plans/04-state-bucket-naming.md
+++ b/docs/plans/04-state-bucket-naming.md
@@ -1,0 +1,178 @@
+# PR 4: Default state bucket name (region-free)
+
+**Status**: planned
+**Branch**: `feat/state-bucket-naming`
+**Depends on**: PR 3 (dynamic region resolution)
+**Breaking change**: yes (auto-detected, gated by `bc-check` markgate)
+**Parallel with**: PR 5 (after PR 3 lands)
+
+## Goal
+
+Make the default state bucket name independent of the user's profile region.
+After this PR, two teammates with different profile regions look up the
+same bucket and share state seamlessly.
+
+```
+Before: cdkd-state-{accountId}-{region}
+After:  cdkd-state-{accountId}
+```
+
+## Background
+
+Discussion scenario:
+
+- One CDK app, stack with `env.region = us-west-2`.
+- User A: profile region `us-east-1`. `cdkd bootstrap` →
+  `cdkd-state-{acc}-us-east-1`. `cdkd deploy` works.
+- User B: profile region `ap-northeast-1`. `cdkd deploy` looks up
+  `cdkd-state-{acc}-ap-northeast-1` — does not exist — error.
+
+Two teammates on the same project can't share state without out-of-band
+communication. This is the fundamental defect that the region-free name
+fixes: S3 bucket names are globally unique, so a single `cdkd-state-{acc}`
+name resolves to the same bucket no matter who looks it up.
+
+## Scope
+
+### In scope
+
+- Default bucket name change to `cdkd-state-{accountId}` in
+  `src/cli/config-loader.ts`.
+- Backwards-compat lookup: if the new name doesn't exist, try the legacy
+  `cdkd-state-{accountId}-{profileRegion}` name and use that bucket. Log
+  a warning suggesting the user run `cdkd state migrate-bucket` (PR 99).
+- bootstrap creates the new name by default.
+- Bucket region detection (the new name's region is unknown until
+  `GetBucketLocation` runs — this is what PR 3 enables).
+
+### Out of scope
+
+- `--region` deprecation (PR 5).
+- Removing legacy lookup permanently (PR 99).
+- A `cdkd state migrate-bucket` command (deferred to PR 99).
+
+## Design
+
+### `getDefaultStateBucketName`
+
+```typescript
+// src/cli/config-loader.ts
+export function getDefaultStateBucketName(accountId: string): string {
+  return `cdkd-state-${accountId}`;
+}
+
+export function getLegacyStateBucketName(accountId: string, region: string): string {
+  return `cdkd-state-${accountId}-${region}`;
+}
+```
+
+### Lookup chain
+
+In `resolveStateBucketWithDefault` (or whatever the equivalent helper is
+named after this PR):
+
+1. If `--state-bucket` is passed, use it as-is (and let PR 3's dynamic
+   region resolution figure out the region).
+2. If `CDKD_STATE_BUCKET` env var is set, same as #1.
+3. If `cdk.json` has `context.cdkd.stateBucket`, same as #1.
+4. Otherwise:
+   - Get `accountId` from STS.
+   - Try `cdkd-state-{accountId}` first (new name).
+   - If not found (NoSuchBucket / 404 from `HeadBucket`), try
+     `cdkd-state-{accountId}-{profileRegion}` (legacy).
+   - If legacy is found, log a warning:
+     ```
+     Using legacy state bucket name 'cdkd-state-{acc}-us-east-1'.
+     The default has changed to 'cdkd-state-{acc}'. Future cdkd
+     versions will drop legacy support; consider migrating with
+     cdkd state migrate-bucket (coming in a future release).
+     ```
+   - If neither is found, throw a "run cdkd bootstrap" error pointing at
+     the new name.
+
+### bootstrap
+
+```typescript
+// in bootstrap command
+const bucketName = options.stateBucket ?? getDefaultStateBucketName(accountId);
+```
+
+The legacy name is no longer the default for newly bootstrapped buckets.
+If a user explicitly passes the legacy name, that still works.
+
+## Implementation steps
+
+1. Update `getDefaultStateBucketName` signature and call sites
+   (`src/cli/config-loader.ts`, `src/cli/commands/bootstrap.ts`).
+2. Add `getLegacyStateBucketName` helper.
+3. Update `resolveStateBucketWithDefault` (or its equivalent) to do the
+   new → legacy lookup chain, calling `HeadBucket` (via the existing
+   `S3StateBackend.verifyBucketExists`-style code, with the
+   `normalizeAwsError` integration from PR 3) to decide whether to fall
+   back.
+4. Emit the legacy-warning log line via the standard logger.
+5. Update bootstrap to use the new name.
+6. Update unit tests covering lookup precedence.
+7. Add integration test
+   `tests/integration/legacy-bucket-name-fallback/` — pre-existing
+   bucket with the legacy name; verify cdkd uses it and emits the
+   warning.
+8. Update docs: `docs/state-management.md`, `README.md`, `CLAUDE.md`.
+9. Refresh `bc-check` markgate marker via `scripts/verify-bc.sh PR-4`.
+
+## Tests
+
+### Unit
+
+- `tests/unit/cli/config-loader.test.ts` — extend with cases:
+  - new name found → use it.
+  - new not found, legacy found → use legacy with warning.
+  - neither found → throw "run cdkd bootstrap" error.
+  - explicit `--state-bucket` skips the lookup chain.
+  - `CDKD_STATE_BUCKET` env var same.
+  - `cdk.json` context same.
+
+### Integration
+
+- `tests/integration/legacy-bucket-name-fallback/` — fixture creates the
+  legacy bucket via direct AWS calls, runs `cdkd state list`, verifies
+  output and warning log.
+
+## Compatibility verification (Pre-merge checklist)
+
+Run `scripts/verify-bc.sh PR-4` or follow these steps manually:
+
+- [ ] `pnpm run build`
+- [ ] Fresh AWS account / no existing buckets:
+      `cdkd bootstrap` → creates `cdkd-state-{acc}`.
+      `cdkd state list` → reads `cdkd-state-{acc}`.
+- [ ] Pre-existing legacy bucket only
+      (`cdkd-state-{acc}-us-east-1`):
+      `cdkd state list` → uses legacy bucket, emits warning.
+- [ ] Both buckets exist (mid-migration):
+      `cdkd state list` → uses NEW bucket; legacy untouched.
+- [ ] `--state-bucket cdkd-state-{acc}-us-east-1` (explicit legacy):
+      uses that bucket, no warning (user explicitly chose it).
+- [ ] User A (us-east-1) bootstraps; User B (ap-northeast-1) deploys —
+      both target the same `cdkd-state-{acc}` bucket. No more split
+      state.
+
+## Documentation updates
+
+- `docs/state-management.md` — Default bucket name section: describe new
+  name, legacy fallback, migration path.
+- `README.md` — Update the section that mentions
+  `cdkd-state-{accountId}-{region}` (Caveats / Configuration).
+- `CLAUDE.md` — Important Implementation Details: bucket name no longer
+  embeds region; legacy fallback is temporary.
+
+## References
+
+- Discussion scenario "User A (us-east-1) / User B (ap-northeast-1)"
+  surfaced this defect.
+- Default name is currently set in
+  [`src/cli/config-loader.ts:99-100`](../../src/cli/config-loader.ts#L99-L100).
+
+## Follow-ups discovered during implementation
+
+(To be filled in as work progresses.)

--- a/docs/plans/05-region-flag-cleanup.md
+++ b/docs/plans/05-region-flag-cleanup.md
@@ -1,0 +1,135 @@
+# PR 5: `--region` flag cleanup
+
+**Status**: planned
+**Branch**: `feat/region-flag-cleanup`
+**Depends on**: PR 3 (dynamic region resolution)
+**Breaking change**: no (deprecation only)
+**Parallel with**: PR 4 (after PR 3 lands)
+
+## Goal
+
+`--region` (and the parallel `AWS_REGION` reliance) accumulated several
+overlapping responsibilities over time:
+
+1. State bucket region selector.
+2. Default-name resolver key (`cdkd-state-{acc}-{region}`).
+3. Deployment fallback when `env.region` is missing on a stack.
+
+After PR 3 (dynamic region resolution) and PR 4 (region-free default name),
+roles 1 and 2 are obsolete. Role 3 is unhealthy — CDK best practice is to
+specify `env` on every stack — but `--region` still has one legitimate role:
+selecting the region for `cdkd bootstrap` to create a new bucket.
+
+This PR consolidates `--region` to bootstrap-only and deprecates it on every
+other command.
+
+## Background
+
+Currently every cdkd command accepts `--region`. After PRs 3 and 4 it does
+nothing useful on most commands except shadow `AWS_REGION`. Keeping it
+encourages users to specify the wrong thing ("which region does `--region`
+mean here?").
+
+## Scope
+
+### In scope
+
+- Remove `--region` from `commonOptions` so it stops being added by default
+  to every command.
+- Re-add `--region` explicitly to `bootstrap` (creating a new bucket needs
+  to know where).
+- Detect `--region` usage on other commands and emit a deprecation warning
+  ("`--region` has no effect on this command and will be removed; use
+  `AWS_REGION` env or your AWS profile instead").
+- Update `--help` text to no longer advertise `--region` outside bootstrap.
+- Update docs that recommended `--region`.
+
+### Out of scope
+
+- Removing `--region` outright (deprecation period; final removal in PR
+  99).
+- Re-adding `--region` for niche commands later (not anticipated).
+
+## Design
+
+### Deprecation behavior
+
+When `--region` is passed to a non-bootstrap command:
+
+```
+Warning: --region is deprecated for this command and has no effect.
+         Use the AWS_REGION environment variable or your AWS profile
+         to override the SDK's default region.
+```
+
+The flag is *parsed* (so the existing pipeline does not break) but
+otherwise ignored.
+
+### Help-text updates
+
+For each affected command (`deploy`, `destroy`, `diff`, `synth`, `list`,
+`state` subcommands, `force-unlock`, `publish-assets`):
+
+- `--region` is removed from `--help`.
+- Bootstrap's `--region` description is reworded to make its
+  bucket-creation role explicit.
+
+## Implementation steps
+
+1. Remove `region` from `commonOptions` in `src/cli/options.ts`.
+2. Re-add `--region` in `src/cli/commands/bootstrap.ts` directly.
+3. Add a small helper `warnIfDeprecatedRegion(options)` invoked by every
+   non-bootstrap command.
+4. Update each command's options handling so passing `--region` does not
+   crash but does emit the warning.
+5. Update `--help` outputs (verify visually).
+6. Update unit tests to cover the warning path.
+7. Update docs: `README.md`, `docs/state-management.md`,
+   `docs/troubleshooting.md`, any reference in `CLAUDE.md`.
+
+## Tests
+
+### Unit
+
+- `tests/unit/cli/options.test.ts` — verify `--region` is not in
+  `commonOptions` after change; verify `bootstrap` still has it.
+- For each command's test file, add a case asserting deprecation warning
+  when `--region` is passed.
+
+### Integration
+
+- Quick smoke test: `cdkd state list --region us-east-1` runs to
+  completion and prints the deprecation warning.
+
+## Compatibility verification (Pre-merge checklist)
+
+This PR is non-breaking (deprecation only), but worth manually verifying:
+
+- [ ] `pnpm run build`
+- [ ] `pnpm test`
+- [ ] `cdkd deploy --region us-east-1 ...` — works, prints deprecation
+      warning to stderr.
+- [ ] `cdkd state list --region us-west-2` — works, prints warning.
+- [ ] `cdkd bootstrap --region us-east-1` — works, no warning.
+- [ ] `cdkd bootstrap --help` — `--region` is documented.
+- [ ] `cdkd deploy --help` — `--region` is **not** documented.
+
+## Documentation updates
+
+- `README.md` — remove `--region` from the "common options" section (if
+  any); keep it in bootstrap usage example.
+- `docs/state-management.md` — remove `--region` advice.
+- `docs/troubleshooting.md` — replace any `--region` recommendation with
+  `AWS_REGION` env or profile.
+- `CLAUDE.md` — Configuration Resolution: clarify that `--region` is a
+  bootstrap-only option; profile / env handles everything else.
+
+## References
+
+- `src/cli/options.ts` defines `commonOptions`.
+- `src/cli/commands/bootstrap.ts` is the only command that legitimately
+  needs `--region`.
+
+## Follow-ups discovered during implementation
+
+(To be filled in as work progresses.)

--- a/docs/plans/06-state-destroy-command.md
+++ b/docs/plans/06-state-destroy-command.md
@@ -1,0 +1,180 @@
+# PR 6: `cdkd state destroy` command
+
+**Status**: planned
+**Branch**: `feat/state-destroy-command`
+**Depends on**: none
+**Breaking change**: no (new command)
+**Parallel with**: PR 1, 2, 3, 7
+
+## Goal
+
+Add a new `cdkd state destroy <stack>` subcommand that deletes a stack's
+AWS resources and state record **without requiring the CDK app**. This
+makes it possible to clean up a stack from any working directory, given
+only the state bucket (or its default).
+
+## Background
+
+`cdkd destroy` requires running inside the CDK app (it synthesizes the
+app to discover stacks). That's correct when the app exists, but breaks
+the common cleanup flow:
+
+- A teammate destroys a stack from a different machine.
+- A CI cleanup job runs after the source repo is gone.
+- A user wants to drop a forgotten stack referenced only by name.
+
+`cdkd state rm` already exists but only removes the state record. Users
+need a way to also delete the AWS resources tracked in that state — i.e.,
+the equivalent of `cdkd destroy` minus the synth dependency.
+
+The naming `cdkd state destroy` mirrors `cdkd destroy` ("the cross-app
+version") and contrasts with `cdkd state rm` ("forget without deleting").
+
+## Scope
+
+### In scope
+
+- New subcommand `cdkd state destroy <stack> [stack...]` under the existing
+  `state` command group.
+- Reads stack state from the state bucket (no synth).
+- Deletes resources in reverse dependency order, using the same provider
+  registry as `cdkd destroy`.
+- Removes the state record after successful deletion.
+- Confirmation prompt by default; `--yes` / `-y` to skip.
+- `--state-bucket`, `--state-prefix`, `--profile` supported (consistent
+  with other `state` subcommands).
+- `--region` for narrowing to a specific region key when the stack name
+  exists in multiple regions (PR 1 territory).
+- `--all` to destroy every stack in the bucket (with confirmation).
+
+### Out of scope
+
+- Synth-driven destroy (already handled by `cdkd destroy`).
+- Cross-bucket destroy (one bucket per invocation).
+- Concurrent multi-stack destroy across buckets.
+
+## Design
+
+### Command surface
+
+```
+cdkd state destroy <stack> [stack...] [options]
+cdkd state destroy --all [options]
+
+Options:
+  -y, --yes                 Skip confirmation prompt.
+      --region <region>     If the stack name resolves to multiple regions
+                            in state, scope to one. Optional.
+      --state-bucket <b>    Same semantics as cdkd state list.
+      --state-prefix <p>    Same.
+      --profile <p>         Same.
+```
+
+### Internal flow
+
+1. Resolve state bucket (existing helper).
+2. Read state for the named stack(s) from S3.
+3. For each stack:
+   - Acquire lock.
+   - Build a destroy graph from state (dependency-reversed).
+   - For each resource: invoke provider `delete` (with PR 2's
+     `expectedRegion` plumbing).
+   - On full success: delete the state file.
+   - On partial failure: keep the state file with the surviving
+     resources; report errors and exit non-zero.
+
+This reuses the `runDestroyForStack` (or equivalent) function that
+`cdkd destroy` already calls. The difference is just the source of
+"which stacks" — synth-derived list vs. state-derived list.
+
+### Refactor opportunity
+
+Today's `cdkd destroy` does: synth → for-each-stack → destroy. The "for-
+each-stack → destroy" piece can be hoisted into a shared helper consumed
+by both `cdkd destroy` and `cdkd state destroy`. This PR pulls the
+hoist-and-share refactor along with the new command.
+
+```typescript
+// src/cli/commands/destroy-runner.ts (new)
+export async function runDestroyForStack(
+  stackName: string,
+  region: string,
+  state: StackState,
+  ctx: DestroyContext,
+): Promise<DestroyResult> { ... }
+```
+
+`destroy.ts` calls it after synth. `state.ts`'s new `destroy` subcommand
+calls it after reading state.
+
+### Help text
+
+```
+$ cdkd state destroy --help
+
+Destroy a stack's AWS resources and remove its state record without
+requiring the CDK app. Use this from any working directory when you
+have access to the state bucket.
+
+For removing only the state record (keeping AWS resources intact),
+use 'cdkd state rm'.
+
+Examples:
+  cdkd state destroy MyStack
+  cdkd state destroy MyStack OtherStack
+  cdkd state destroy --all -y
+  cdkd state destroy MyStack --state-bucket cdkd-state-test
+```
+
+## Implementation steps
+
+1. Hoist destroy-per-stack logic into a shared helper
+   (`src/cli/commands/destroy-runner.ts` or similar).
+2. Update `cdkd destroy` to call the helper.
+3. Add `state destroy` subcommand in `src/cli/commands/state.ts`.
+4. Wire confirmation, `--yes`, `--all`, `--region` filters.
+5. Unit tests for the shared helper and the new subcommand wiring.
+6. Integration test
+   `tests/integration/state-destroy/`: deploy then call
+   `cdkd state destroy <stack>` from a temp dir without CDK app sources.
+7. Update help text and docs.
+
+## Tests
+
+### Unit
+
+- `tests/unit/cli/state-destroy.test.ts` — covers wiring, confirmation,
+  `--all`, `--region` filter, multi-region disambiguation.
+
+### Integration
+
+- `tests/integration/state-destroy/`:
+  1. Deploy a small stack via `cdkd deploy`.
+  2. Switch to a temp directory with no CDK app.
+  3. `cdkd state destroy MyStack -y` → resources gone, state empty.
+
+## Compatibility verification (Pre-merge checklist)
+
+- [ ] `pnpm run build`
+- [ ] `pnpm test`
+- [ ] `cdkd state destroy MyStack -y` end-to-end on real AWS.
+- [ ] `cdkd state destroy --help` text is clear and references
+      `cdkd state rm`.
+- [ ] `cdkd destroy MyStack -y` (existing command) still works after the
+      refactor — no regression.
+
+## Documentation updates
+
+- `CLAUDE.md` — describe `state destroy` alongside `state rm`; clarify the
+  difference (state-record-only vs resources-and-state).
+- `README.md` — quick-start examples include the new command.
+- `docs/state-management.md` — section on cleanup options.
+
+## References
+
+- Existing `cdkd state rm` lives in `src/cli/commands/state.ts`.
+- Existing destroy flow: `src/cli/commands/destroy.ts`.
+
+## Follow-ups discovered during implementation
+
+(To be filled in as work progresses.)

--- a/docs/plans/07-state-bucket-display.md
+++ b/docs/plans/07-state-bucket-display.md
@@ -1,0 +1,178 @@
+# PR 7: Hide state bucket from default output + `cdkd state info`
+
+**Status**: planned
+**Branch**: `feat/state-bucket-display`
+**Depends on**: none
+**Breaking change**: no (output cosmetic + new subcommand)
+**Parallel with**: PR 1, 2, 3, 6
+
+## Goal
+
+Two related changes to keep account IDs out of routine cdkd output (so
+screenshots and logs don't accidentally leak them) while still letting
+users inspect bucket info on demand:
+
+1. Remove the `State bucket: cdkd-state-{accountId}-{region}` banner from
+   `cdkd deploy`, `cdkd destroy`, and other commands' default output.
+   Move it to `--verbose` debug logging.
+2. Add a new `cdkd state info` subcommand that explicitly prints bucket
+   info when the user wants it.
+
+## Background
+
+Today `cdkd deploy` starts with:
+
+```
+$ cdkd deploy
+State bucket: cdkd-state-123456789012-us-east-1
+Synthesizing CDK app...
+```
+
+The first line includes the AWS account ID. That's fine for a developer
+running locally, but creates accidental disclosure risk:
+
+- Screenshots in bug reports / blog posts / Slack.
+- CI logs that get archived publicly.
+
+Removing it from default output addresses the leak. But "what's my state
+bucket?" is still a reasonable question. `cdkd state info` becomes the
+explicit answer.
+
+## Scope
+
+### In scope
+
+- Suppress the `State bucket: ...` banner from default output across:
+  - `cdkd deploy`
+  - `cdkd destroy`
+  - `cdkd diff`
+  - `cdkd state list`
+  - `cdkd state show`
+  - `cdkd state resources`
+  - `cdkd state rm`
+  - `cdkd state destroy` (PR 6, if landed first)
+  - `cdkd force-unlock`
+- Move the same info to a `logger.debug` line so `--verbose` still shows
+  it.
+- Add `cdkd state info` subcommand:
+  - Displays bucket name, region, source (cli flag / env / cdk.json /
+    default), schema version, stack count.
+  - Accepts `--state-bucket`, `--state-prefix`, `--profile` like other
+    state subcommands.
+  - `--json` for machine-readable output.
+
+### Out of scope
+
+- Restructuring how the bucket is resolved (PR 3 / PR 4 territory).
+- Hiding the account ID *inside* error messages (out of scope; cdkd
+  errors should still be debuggable).
+
+## Design
+
+### Suppressing the banner
+
+Today the banner is emitted by each command's setup code with `logger.info`.
+Change those call sites to `logger.debug`. With the default log level
+(`info`), the banner disappears; `--verbose` (which sets the level to
+`debug`) still shows it.
+
+### `cdkd state info`
+
+```
+$ cdkd state info
+State bucket:    cdkd-state-123456789012
+Region:          us-east-1 (auto-detected via GetBucketLocation)
+Source:          default (account ID from STS)
+Schema version:  2
+Stacks:          5
+
+$ cdkd state info --state-bucket cdkd-state-test
+State bucket:    cdkd-state-test
+Region:          us-east-1 (auto-detected via GetBucketLocation)
+Source:          --state-bucket flag
+Schema version:  2
+Stacks:          1
+
+$ cdkd state info --json
+{
+  "bucket": "cdkd-state-123456789012",
+  "region": "us-east-1",
+  "regionSource": "auto-detected",
+  "bucketSource": "default",
+  "schemaVersion": 2,
+  "stackCount": 5
+}
+```
+
+#### "Source" field semantics
+
+| Source | Meaning |
+|---|---|
+| `--state-bucket flag` | User passed `--state-bucket` on the command line |
+| `CDKD_STATE_BUCKET env` | Env var resolved the bucket |
+| `cdk.json (context.cdkd.stateBucket)` | cdk.json context resolved it |
+| `default` | Fell through to the default name from STS account ID |
+| `default (legacy)` | Fell through to the legacy name (post-PR 4) |
+
+#### Stack count
+
+Counts state files at `cdkd/{stackName}/{region}/state.json` (new layout).
+After PR 1 lands, also includes legacy-layout files.
+
+## Implementation steps
+
+1. Find every `logger.info('State bucket: ...')` / equivalent and change
+   to `logger.debug`. Confirm no tests depended on it being on stdout.
+2. Add `cdkd state info` subcommand in `src/cli/commands/state.ts`.
+3. Implement source-resolution introspection so the `Source` field can
+   distinguish CLI flag vs env vs cdk.json vs default.
+4. Implement schema-version detection (read first state file or fall back
+   to "unknown" on empty bucket).
+5. Add unit tests.
+6. Integration test
+   `tests/integration/state-info-command/` — small fixture with one
+   stack, verify output structure and `--json` shape.
+7. Update help text.
+
+## Tests
+
+### Unit
+
+- `tests/unit/cli/state-info.test.ts`:
+  - default bucket source vs explicit `--state-bucket` source.
+  - empty bucket (`stackCount: 0`, `schemaVersion: "unknown"`).
+  - mixed legacy + new layout (after PR 1, if applicable in test order).
+  - `--json` shape stability.
+
+### Integration
+
+- `tests/integration/state-info-command/` — basic happy path.
+
+## Compatibility verification (Pre-merge checklist)
+
+- [ ] `pnpm run build`
+- [ ] `pnpm test`
+- [ ] `cdkd deploy MyStack` — no `State bucket:` line in stdout.
+- [ ] `cdkd deploy MyStack --verbose` — `State bucket:` appears in debug
+      logs.
+- [ ] `cdkd state info` — clear, complete output.
+- [ ] `cdkd state info --json` — valid JSON.
+- [ ] `cdkd state info --state-bucket some-bucket` — uses that bucket
+      and reports `Source: --state-bucket flag`.
+
+## Documentation updates
+
+- `CLAUDE.md` — note that bucket info is no longer in default output;
+  point users to `cdkd state info`.
+- `README.md` — quick-start: `cdkd state info` for inspection.
+
+## References
+
+- Banner emission lives in each command's setup; grep for
+  `State bucket:`.
+- `cdkd state list` already loads bucket info for its own purposes —
+  reuse that path for `state info`.
+
+## Follow-ups discovered during implementation
+
+(To be filled in as work progresses.)

--- a/docs/plans/99-future-bc-removal.md
+++ b/docs/plans/99-future-bc-removal.md
@@ -1,0 +1,123 @@
+# PR 99 (future): Backwards-compat removal + final migration command
+
+**Status**: planned (not yet — schedule for 1–2 minor releases after PR 1
+and PR 4 land)
+**Branch**: `feat/drop-bc-and-migration-command`
+**Depends on**: PR 1, PR 4 (must have shipped and been in real use for a
+release window)
+**Breaking change**: yes (no auto-migration this time)
+**Parallel with**: none (this is the final step of the rollout)
+
+## Goal
+
+After users have had one or two releases to organically migrate by virtue
+of normal `cdkd deploy` / `destroy` operations:
+
+1. **Drop the legacy read paths**:
+   - Legacy state key (`cdkd/{stackName}/state.json`) — added by PR 1.
+   - Legacy bucket name (`cdkd-state-{accountId}-{region}`) — added by
+     PR 4.
+2. **Ship a one-shot migration command** for users whose state was
+   never touched in the interim and therefore was not auto-migrated:
+   - `cdkd state migrate` — bulk migrates legacy state files to the new
+     key layout in the same bucket.
+   - `cdkd state migrate-bucket` — copies every state file from the
+     legacy-named bucket into the new-named bucket.
+
+## Background
+
+This PR is intentionally deferred. The point of the auto-migration paths
+in PR 1 and PR 4 is precisely to eliminate the need for a manual migration
+command for active users. Only stacks that haven't been touched at all
+in the meantime require manual intervention. By the time PR 99 ships,
+that population should be small.
+
+## Scope
+
+### In scope
+
+- Remove the legacy lookup branches from
+  `src/state/s3-state-backend.ts` (PR 1 territory) and
+  `src/cli/config-loader.ts` (PR 4 territory).
+- Remove related warning log lines.
+- Add `cdkd state migrate` and `cdkd state migrate-bucket` subcommands.
+- Provide a clear pre-removal warning in the previous release ("This is
+  the last release that reads legacy state files; run `cdkd state
+  migrate` before upgrading").
+- Bump the major version (or document as a breaking change in semver-
+  appropriate way).
+
+### Out of scope
+
+- Any new functionality.
+
+## Design
+
+### `cdkd state migrate`
+
+```
+$ cdkd state migrate
+Scanning bucket cdkd-state-123456789012 for legacy state files...
+Found 3 legacy state files:
+  - cdkd/MyStack/state.json (region: us-west-2)
+  - cdkd/OtherStack/state.json (region: us-east-1)
+  - cdkd/Forgotten/state.json (region: us-west-2)
+Migrate to new region-prefixed layout? (y/N) y
+✓ MyStack       us-west-2   migrated
+✓ OtherStack    us-east-1   migrated
+✓ Forgotten     us-west-2   migrated
+3 files migrated, 0 failed.
+```
+
+### `cdkd state migrate-bucket`
+
+```
+$ cdkd state migrate-bucket
+Source: cdkd-state-123456789012-us-east-1 (legacy)
+Destination: cdkd-state-123456789012 (new default)
+Found 5 stacks in source. Copy and remove from source? (y/N) y
+✓ Copied 5 stacks (plus locks).
+✓ Verified destination matches source.
+✓ Source bucket emptied. To delete it: aws s3 rb s3://... --force
+```
+
+The destination is created if missing (with the same versioning /
+encryption / policy as `cdkd bootstrap`).
+
+The source bucket is **emptied** but not deleted (S3 bucket deletion
+involves DNS-level cooldown, the user can decide if they want to take
+that step).
+
+## Implementation steps
+
+(Deferred — to be detailed when this PR is opened. Outline:)
+
+1. Remove legacy read branches from S3StateBackend and config-loader.
+2. Implement `cdkd state migrate` (single-bucket, key-layout migration).
+3. Implement `cdkd state migrate-bucket` (cross-bucket copy).
+4. Add a release-notes entry calling out the pre-upgrade migration step.
+5. Update docs to remove all mentions of legacy fallback.
+6. Track in GitHub issue (created at PR 1 / 4 merge time).
+
+## Tests
+
+(Deferred — to be detailed when this PR is opened.)
+
+## Compatibility verification (Pre-merge checklist)
+
+(Deferred — to be detailed when this PR is opened.)
+
+## Documentation updates
+
+(Deferred.)
+
+## References
+
+- PR 1 introduces the legacy state-key fallback that this PR removes.
+- PR 4 introduces the legacy bucket-name fallback that this PR removes.
+- A GitHub issue tracks this PR; it is referenced from the
+  `// TODO(remove-bc-after-1.x):` comments seeded by PR 1 and PR 4.
+
+## Follow-ups discovered during implementation
+
+(N/A until this PR is opened.)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,124 @@
+# cdkd PR Roadmap — Region & State Refactor
+
+This directory tracks the rollout plan for a multi-PR refactor that reshapes how
+cdkd handles state buckets, stack regions, and a few related UX issues. Each
+file is a self-contained implementation plan for one PR — the order below is
+the recommended merge order, **not** the required implementation order.
+
+## Why this refactor
+
+Three classes of bugs / UX problems surfaced together and share a single
+underlying cause: the current state model assumes "one region = one cdkd
+client", but cdkd's collection model (one S3 bucket per account) plus CDK's
+per-stack `env.region` conflict in subtle ways.
+
+1. **Silent state corruption on `env.region` change** — Changing a stack's
+   `env.region` between deploys overwrites the recorded region in
+   `state.json`, leaving the original region's resources untracked. `destroy`
+   then runs against the wrong region and produces silent failures (e.g.,
+   Lambda `delete-function` returns `ResourceNotFoundException` from the
+   wrong region, which is treated as idempotent success).
+2. **`UnknownError` from S3 HeadBucket** — When the CLI's profile region and
+   the state bucket's region differ, S3 returns a 301 redirect on a HEAD
+   request with an empty body. The AWS SDK v3 protocol parser cannot classify
+   it and surfaces a synthetic `UnknownError`.
+3. **Team sharing breaks across profile regions** — The default state bucket
+   name embeds the profile region (`cdkd-state-{accountId}-{region}`). Two
+   teammates with different profile regions look up different bucket names
+   and end up with split state.
+
+The refactor introduces a region-aware state key layout, dynamic bucket
+region resolution, and a region-free default bucket name. Plus a few quality-
+of-life additions surfaced in the same discussion (`cdkd state destroy`,
+hiding the bucket-name banner from `deploy` output).
+
+## Design summary
+
+| Aspect | Before | After |
+|---|---|---|
+| State bucket count | 1 per account (region-suffixed name) | 1 per account (region-free name) |
+| Default bucket name | `cdkd-state-{accountId}-{region}` | `cdkd-state-{accountId}` |
+| State key | `cdkd/{stackName}/state.json` | `cdkd/{stackName}/{region}/state.json` |
+| Same `stackName` across regions | One key — second region overwrites first | Independent keys per region |
+| `--region` flag | Used by every command (overloaded) | Bootstrap-only |
+| Bucket region detection | None — relies on profile region matching | `GetBucketLocation` at startup |
+| `UnknownError` handling | Bubbles up verbatim | Normalized via HTTP status code |
+
+## PR list
+
+| # | Title | Depends on | Breaking change | Parallel | Plan |
+|---|---|---|---|---|---|
+| 1 | State key region prefix (collection model extension) | none | yes (auto-migrated) | ✅ | [01](./01-state-key-region-prefix.md) |
+| 2 | DELETE region verification | none | no | ✅ | [02](./02-delete-region-verification.md) |
+| 3 | Dynamic region resolution + UnknownError normalization | none | no | ✅ | [03](./03-dynamic-region-resolution.md) |
+| 4 | Default state bucket name (region-free) | PR 3 | yes (auto-migrated) | △ (after PR 3) | [04](./04-state-bucket-naming.md) |
+| 5 | `--region` flag cleanup | PR 3 | no (deprecation) | △ (after PR 3) | [05](./05-region-flag-cleanup.md) |
+| 6 | `cdkd state destroy` command | none | no | ✅ | [06](./06-state-destroy-command.md) |
+| 7 | Hide state bucket from deploy output + `cdkd state info` | none | no | ✅ | [07](./07-state-bucket-display.md) |
+| 99 | Backwards-compat removal + final migration command (future) | 1, 4 | yes | — | [99](./99-future-bc-removal.md) |
+
+## Operating rules for this rollout
+
+- **Branch naming**: `feat/<short-slug>` for each PR (e.g., `feat/state-region-key`).
+- **PR open, no merge**: open all PRs but wait for explicit user approval to
+  merge. The user reviews and decides merge order.
+- **Parallel worktrees**: PRs 1, 2, 3, 6, 7 are independent — each lives in
+  its own `git worktree` so work can proceed concurrently. PRs 4 and 5 wait
+  for PR 3 to merge.
+- **Subagents**: when subagents drive any of these PRs end-to-end, they MUST
+  use Opus 4.7 (`model: "opus"` plus an Opus-tier `subagent_type`). Do not
+  fall back to a smaller model silently.
+- **Markgate gates**: PRs 1 and 4 are flagged as breaking changes and will
+  gate merges on a new `bc-check` markgate marker (see each plan).
+
+## Compatibility strategy
+
+PRs 1 and 4 are user-visible breaking changes. Both are protected by:
+
+1. **Backwards-compat read path** — Old key layouts and old bucket names are
+   still readable. The legacy form is detected on read; a warning is logged.
+2. **Auto-migration on write** — The next write (deploy / destroy / lock
+   acquisition) silently migrates to the new form and removes the legacy
+   artifact.
+3. **Schema version** — `state.json` carries a `version: number` field
+   (already present, set to `1` today). New writes use `version: 2`. Old
+   binaries that try to read `version: 2` fail with a clear error rather
+   than silently mishandling the new format.
+4. **`bc-check` markgate gate** — Each affected PR ships a verification
+   script (`scripts/verify-bc.sh`) that checks the migration paths against
+   fixtures. The marker is required before `gh pr merge` succeeds.
+
+The legacy read path is **temporary**. PR 99 (future, 1–2 releases later)
+removes it and ships a final `cdkd state migrate` command for any users who
+never touched their state in the interim.
+
+## Out of scope (explicitly)
+
+The following items came up in discussion and were deliberately deferred:
+
+- **Region failure isolation** — One state bucket means one region's S3
+  outage stops all cdkd operations across all stack regions. Accepted as a
+  tradeoff of the collection model. Users who need region failure isolation
+  should split state with `--state-bucket` per stack group.
+- **Data residency / cross-partition (GovCloud, China)** — Not a target use
+  case for cdkd. Users with these requirements should use the upstream CDK
+  CLI.
+- **CFn-style `cdk list` for deployed stacks across all regions** — `cdkd
+  state list` already serves this purpose under the collection model and is
+  better than CFn at it.
+
+## Cross-cutting documentation updates
+
+Each PR updates docs in its own scope. These three files will see edits
+across multiple PRs:
+
+- `README.md` — top-level "Behavior vs CDK" / "Caveats" section
+- `CLAUDE.md` — invariants for collection model + region-prefixed keys
+- `docs/state-management.md` — bucket layout, key layout, migration plan
+
+## Tracking & follow-ups
+
+- A GitHub issue tracks PR 99 (backwards-compat removal) so it is not
+  forgotten.
+- Each PR's plan file ends with a "Follow-ups discovered during
+  implementation" section that should be updated as work progresses.


### PR DESCRIPTION
## Summary

Adds `docs/plans/` with the rollout plan for a multi-PR refactor of cdkd's state-management and region-handling.

The discussion that produced this rollout surfaced three classes of issues sharing one underlying cause: cdkd's collection model (one S3 bucket per account) plus CDK's per-stack `env.region` interact in subtle ways:

1. **Silent state corruption on `env.region` change** — Changing a stack's `env.region` overwrote the recorded region in `state.json`, leaving the original region's resources untracked. `destroy` then ran against the wrong region and silently treated `ResourceNotFoundException` as idempotent success.
2. **`UnknownError` from S3 HeadBucket** — Cross-region HEAD with empty body confuses the AWS SDK v3 protocol parser.
3. **Team sharing breaks** — The default state bucket name embeds the profile region, so two teammates with different profile regions look up different buckets and end up with split state.

This PR is **docs only**. It introduces the plan; subsequent PRs implement it.

## Plan files

| # | Title | Depends on | Plan |
|---|---|---|---|
| 1 | State key region prefix (collection model extension) | none | `docs/plans/01-state-key-region-prefix.md` |
| 2 | DELETE region verification | none | `docs/plans/02-delete-region-verification.md` |
| 3 | Dynamic region resolution + UnknownError normalization | none | `docs/plans/03-dynamic-region-resolution.md` |
| 4 | Default state bucket name (region-free) | PR 3 | `docs/plans/04-state-bucket-naming.md` |
| 5 | `--region` flag cleanup | PR 3 | `docs/plans/05-region-flag-cleanup.md` |
| 6 | `cdkd state destroy` command | none | `docs/plans/06-state-destroy-command.md` |
| 7 | Hide state bucket from default output + `cdkd state info` | none | `docs/plans/07-state-bucket-display.md` |
| 99 | Backwards-compat removal + final migration command (future) | 1, 4 | `docs/plans/99-future-bc-removal.md` |

`docs/plans/README.md` carries the design summary, operating rules for the rollout (parallel worktrees, no-merge-without-approval, subagent model = Opus 4.7), and the compatibility strategy for the breaking-change PRs (1 and 4).

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint:fix`
- [x] `pnpm run build`
- [x] `pnpm test` (62 files, 768 tests)
- [x] No source changes; only doc additions under `docs/plans/`
