### PR TITLE
feat(state): region-prefixed state key (collection model extension)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,15 @@ cdkd has a 7-layer system architecture:
 2. **S3-based State Management**
    - No DynamoDB required
    - Optimistic locking via S3 Conditional Writes (`If-None-Match`, `If-Match`)
-   - State structure: `s3://bucket/stacks/{stackName}/state.json`
-   - Lock structure: `s3://bucket/stacks/{stackName}/lock.json`
+   - **Region-prefixed key layout (`version: 2`, since PR 1)**:
+     - State: `s3://bucket/cdkd/{stackName}/{region}/state.json`
+     - Lock:  `s3://bucket/cdkd/{stackName}/{region}/lock.json`
+   - The same `stackName` in two regions has two independent state files —
+     changing `env.region` no longer silently overwrites the prior region.
+   - Legacy `version: 1` layout (`cdkd/{stackName}/state.json`) is still
+     readable; the next write auto-migrates and deletes the legacy key.
+   - An old cdkd binary fails clearly on a `version: 2` blob instead of
+     silently mishandling unknown fields.
 
 3. **Event-driven DAG Execution**
    - Analyzes dependencies via `Ref` / `Fn::GetAtt` / `DependsOn`
@@ -100,7 +107,7 @@ pnpm run typecheck
 
 ### Core Directories
 
-- **src/cli/** - CLI command implementations (deploy, destroy, diff, synth, list/ls, bootstrap, force-unlock, state), config resolution. `state` is a parent command for inspecting and manipulating cdkd's S3 state bucket: `state list` (alias `ls`) lists deployed stacks; `state resources <stack>` lists the resources of one stack; `state show <stack>` renders the full state record (metadata, outputs, resources incl. properties); `state rm <stack>...` removes cdkd's state record for stacks (does NOT delete AWS resources — `cdkd destroy` is the equivalent for the actual resources).
+- **src/cli/** - CLI command implementations (deploy, destroy, diff, synth, list/ls, bootstrap, force-unlock, state), config resolution. `state` is a parent command for inspecting and manipulating cdkd's S3 state bucket: `state list` (alias `ls`) lists deployed stacks (one row per `(stackName, region)` pair under the new region-prefixed key layout); `state resources <stack>` and `state show <stack>` accept `--stack-region <region>` to disambiguate when the same stackName has state in multiple regions; `state rm <stack>...` removes cdkd's state record for every region by default, or scopes to one with `--stack-region <region>` (does NOT delete AWS resources — `cdkd destroy` is the equivalent for the actual resources).
 - **src/synthesis/** - CDK app synthesis (self-implemented: subprocess execution, Cloud Assembly parsing, context providers)
 - **src/analyzer/** - DAG builder, template parser, intrinsic function resolution
 - **src/state/** - S3 state backend, lock manager
@@ -139,8 +146,9 @@ SDK Providers are preferred over Cloud Control API for performance -- they make 
 
 ```typescript
 interface StackState {
-  version: number;
+  version: 1 | 2;       // 1 = legacy, 2 = region-prefixed (current writers)
   stackName: string;
+  region?: string;      // Required on version: 2 (load-bearing for the S3 key)
   resources: Record<string, ResourceState>;
   outputs: Record<string, string>;
   lastModified: number;

--- a/README.md
+++ b/README.md
@@ -510,18 +510,38 @@ Built on modern AWS tooling:
 
 ## State Management
 
-State is stored in S3. Each stack has its own `state.json` and `lock.json`:
+State is stored in S3. Keys are scoped by `(stackName, region)` so the same
+stack name deployed to two regions has two independent state files:
 
 ```
 s3://{state-bucket}/
   └── {prefix}/                     # Default: "cdkd" (configurable via --state-prefix)
       ├── MyStack/
-      │   ├── state.json            # Resource state
-      │   └── lock.json             # Exclusive deploy lock
+      │   └── us-east-1/
+      │       ├── state.json        # Resource state (version: 2)
+      │       └── lock.json         # Exclusive deploy lock
       └── AnotherStack/
-          ├── state.json
-          └── lock.json
+          ├── us-east-1/
+          │   ├── state.json
+          │   └── lock.json
+          └── us-west-2/             # same stackName, different region
+              ├── state.json
+              └── lock.json
 ```
+
+> **Caveat: same `stackName` in multiple regions becomes visible after
+> `env.region` changes.** Before this layout shipped, changing a stack's
+> `env.region` between deploys silently overwrote the prior region's state
+> and `cdkd destroy` ran against the wrong region. cdkd now treats the two
+> regions as independent. Use `cdkd state list` to see both, and
+> `cdkd state rm <stack> --stack-region <region>` to prune one without
+> touching the other.
+>
+> **Legacy layout migration:** state files written by cdkd before this
+> layout (`version: 1`, flat `cdkd/{stackName}/state.json`) are still
+> readable. The next cdkd write auto-migrates to the new key and removes
+> the legacy file. An older cdkd binary reading a `version: 2` file fails
+> with a clear "upgrade cdkd" error rather than silently mishandling it.
 
 ### Configuration
 
@@ -548,8 +568,9 @@ State schema:
 
 ```typescript
 {
-  version: 1,
+  version: 2,
   stackName: "MyStack",
+  region: "us-east-1",
   resources: {
     "MyFunction": {
       physicalId: "arn:aws:lambda:...",

--- a/docs/plans/01-state-key-region-prefix.md
+++ b/docs/plans/01-state-key-region-prefix.md
@@ -1,0 +1,229 @@
+# PR 1: State key region prefix (collection model extension)
+
+**Status**: planned
+**Branch**: `feat/state-region-key`
+**Depends on**: none
+**Breaking change**: yes (auto-migrated, gated by `bc-check` markgate)
+**Parallel with**: PR 2, 3, 6, 7
+
+## Goal
+
+Make a stack's region part of the S3 state key so `env.region` changes do not
+overwrite each other. After this PR, the same `stackName` deployed to two
+different regions has two independent state files.
+
+## Background
+
+Current layout:
+
+```
+s3://{bucket}/cdkd/{stackName}/state.json
+```
+
+The region is stored *inside* `state.json` (`region: string`). When a user
+changes `env.region` from `us-west-2` to `us-east-1` and re-runs `cdkd deploy`,
+the state file at the same key is rewritten with `region: "us-east-1"`. The
+original `us-west-2` resources still exist, but cdkd no longer knows about
+them. A subsequent `cdkd destroy` runs against `us-east-1`, hits
+`ResourceNotFoundException` for each resource, and treats those errors as
+idempotent successes — silent failure.
+
+This is the root cause of the bug surfaced in the discussion that produced
+this rollout.
+
+## Scope
+
+### In scope
+
+- New state key layout: `cdkd/{stackName}/{region}/state.json`.
+- Lock key parallel: `cdkd/{stackName}/{region}/lock.json`.
+- `state.json` schema bump: `version: 2` (was `version: 1`).
+- Backwards-compat read path for `version: 1` (`cdkd/{stackName}/state.json`)
+  with a deprecation warning.
+- Auto-migration on next write: read legacy → write new key → delete legacy.
+- `cdkd state list` default output gains a region column / paren suffix:
+  `MyStack (us-west-2)`.
+- `cdkd state show` and `cdkd state resources` accept an optional
+  `--region` filter when a stack name resolves to multiple region keys.
+- `cdkd state rm` deletes all region keys for the stack by default,
+  with `--region` available to scope to one.
+- DAG-builder, deploy-engine, destroy command pass `region` to the state
+  backend so reads/writes hit the right key.
+
+### Out of scope (handled by other PRs)
+
+- Default bucket name change (PR 4).
+- `--region` flag deprecation on most commands (PR 5).
+- Dynamic bucket region resolution (PR 3).
+- DELETE region verification (PR 2).
+
+## Design
+
+### Key resolution
+
+`S3StateBackend` gains a constructor parameter or method to resolve keys
+based on `(stackName, region)`. Reads use the following lookup order:
+
+1. New key: `cdkd/{stackName}/{region}/state.json`
+2. Legacy key: `cdkd/{stackName}/state.json` (only if region matches the
+   `region` field of the legacy state body)
+
+If a legacy key is found and the caller is a write path, the legacy state is
+copied to the new key and the legacy key is deleted in the same write turn.
+
+### Schema version
+
+```typescript
+interface StackState {
+  version: 1 | 2;     // 1 = legacy, 2 = region-prefixed
+  stackName: string;
+  region: string;     // already exists, now load-bearing
+  resources: Record<string, ResourceState>;
+  outputs: Record<string, string>;
+  lastModified: number;
+}
+```
+
+A `version: 2` reader rejects `version: 3+` with a clear error
+(`Unsupported state schema version 3. Upgrade cdkd.`). A `version: 1` reader
+in older cdkd binaries already rejects `version: 2` because the legacy code
+expects either no version or `version: 1` only.
+
+### Multi-region same-name semantics
+
+When `stackName` resolves to multiple region keys (transient state from an
+in-flight `env.region` change), commands behave as follows:
+
+| Command | Behavior |
+|---|---|
+| `cdkd state list` | One row per region key |
+| `cdkd state show <stack>` | If multiple regions, list them and require `--region` |
+| `cdkd state resources <stack>` | Same as `state show` |
+| `cdkd state rm <stack>` | Removes all region keys (with confirmation) |
+| `cdkd state rm <stack> --region X` | Removes only region X |
+| `cdkd deploy <stack>` | Synth-driven; `env.region` selects the key |
+| `cdkd destroy <stack>` | Synth-driven; `env.region` selects the key |
+| `cdkd diff <stack>` | Synth-driven; `env.region` selects the key |
+
+### Lock key
+
+Locks are also region-scoped: `cdkd/{stackName}/{region}/lock.json`. This
+means two regions of the same stack name can be operated on in parallel
+without contention, which is consistent with the rest of cdkd's parallel
+execution model.
+
+## Implementation steps
+
+1. Update `src/types/state.ts` to allow `version: 1 | 2`.
+2. Add helper `getStateKey(stackName, region)` returning the new key, and
+   `getLegacyStateKey(stackName)` for the old one.
+3. Update `S3StateBackend.getState` / `saveState` / `stateExists` to:
+   - Read new key first; if missing, try legacy; mark `migrationPending`
+     when legacy is used.
+   - On save, always write the new key. If `migrationPending`, also delete
+     the legacy key after the new write succeeds.
+4. Update `LockManager` similarly (region-scoped lock key).
+5. Update `S3StateBackend.listStacks` to enumerate both new and legacy
+   layouts and produce `{stackName, region}[]`.
+6. Update each call site to pass `region` (deploy.ts, destroy.ts, diff.ts,
+   state.ts subcommands, force-unlock.ts).
+7. Update `cdkd state list` output to include region: `MyStack (us-west-2)`.
+8. Update `cdkd state show` / `state resources` to require `--region` when
+   ambiguous; emit a clear error listing the candidate regions.
+9. Update `cdkd state rm` to remove all region keys by default; accept
+   `--region` for scoping.
+10. Add unit tests covering each lookup branch, the migration write path,
+    and the multi-region listing.
+11. Add integration tests:
+    - `tests/integration/legacy-state-migration/` — legacy fixture in S3,
+      run cdkd, verify auto-migration.
+    - `tests/integration/multi-region-same-stack/` — deploy same stackName
+      to two regions, verify both states coexist and `state list` shows
+      both rows.
+12. Update docs: `docs/state-management.md`, `CLAUDE.md`, `README.md`.
+13. Add `scripts/verify-bc.sh` (shared with PR 4) — covers the legacy →
+    new migration path.
+14. Refresh `bc-check` markgate marker via the script.
+
+## Tests
+
+### Unit (Vitest)
+
+- `tests/unit/state/s3-state-backend.test.ts` — extend with cases:
+  - getState reads new key when present.
+  - getState falls back to legacy and surfaces `migrationPending: true`.
+  - saveState writes new key and deletes legacy when `migrationPending`.
+  - listStacks merges new and legacy layouts; deduplicates `(stackName,
+    region)` pairs.
+- `tests/unit/state/lock-manager.test.ts` — region-scoped lock keys.
+- `tests/unit/cli/state.test.ts` — output format, `--region` disambiguation.
+
+### Integration (real AWS)
+
+- `tests/integration/legacy-state-migration/` — minimal stack, seed a
+  `version: 1` state file in the bucket, run deploy, verify post-state.
+- `tests/integration/multi-region-same-stack/` — stack with `env.region`
+  changed mid-flight, verify both state files end up coexisting.
+
+## Compatibility verification (Pre-merge checklist)
+
+Run `scripts/verify-bc.sh PR-1` (script lives alongside this PR), or perform
+the following manually:
+
+### A. Legacy → New (auto-migration)
+
+- [ ] `pnpm run build`
+- [ ] Seed a state bucket with a `version: 1` state at
+      `s3://{bucket}/cdkd/MyStack/state.json` (region: us-west-2).
+- [ ] `cdkd state list --state-bucket {bucket}`
+      Expected: `MyStack (us-west-2)` plus a legacy-format warning in
+      `--verbose` output.
+- [ ] `cdkd deploy MyStack --state-bucket {bucket}` (no template change)
+      Expected: writes `cdkd/MyStack/us-west-2/state.json`; deletes legacy
+      `cdkd/MyStack/state.json`.
+- [ ] `aws s3 ls s3://{bucket}/cdkd/MyStack/` — only `us-west-2/` is left.
+
+### B. New format (regular operation)
+
+- [ ] Fresh bucket, `cdkd deploy MyStack`.
+- [ ] `aws s3 ls s3://{bucket}/cdkd/MyStack/` — `us-west-2/state.json` only.
+- [ ] `cdkd state list` → `MyStack (us-west-2)`.
+- [ ] `cdkd destroy MyStack` removes both AWS resources and the state key.
+
+### C. Multi-region same stackName
+
+- [ ] Deploy `MyStack` to `us-west-2`, then change `env.region` to
+      `us-east-1` in code, deploy again.
+- [ ] `aws s3 ls s3://{bucket}/cdkd/MyStack/` — `us-west-2/` and
+      `us-east-1/` both present.
+- [ ] `cdkd state list` → two rows.
+- [ ] `cdkd state rm MyStack` (with confirmation) → both region keys gone.
+
+### D. Cross-version coexistence (silent-failure prevention)
+
+- [ ] An old cdkd binary trying to read a `version: 2` state file produces
+      a clear error and exits non-zero (no silent fallback).
+
+## Documentation updates
+
+- `docs/state-management.md` — bucket structure section: new key layout,
+  legacy migration, schema version, multi-region semantics.
+- `CLAUDE.md` — Important Implementation Details: state key layout includes
+  region; transient multi-region same-name allowed.
+- `README.md` — Caveats: same `stackName` in multiple regions becomes
+  visible after `env.region` changes; use `cdkd state rm --region X` to
+  prune.
+
+## References
+
+- Original silent-failure incident:
+  `s3://cdkd-state-{accountId}-us-east-1/cdkd/MyStage-CdkSampleStack/state.json`
+  (now cleaned up).
+- Related rule in `CLAUDE.md`: "DELETE idempotency (not-found / No policy
+  found treated as success)" — this PR's protection complements PR 2's
+  region check.
+- Legacy `version: 1` schema: `src/types/state.ts:4-12`.
+
+## Follow-ups discovered during implementation
+
+(To be filled in as work progresses.)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,124 @@
+# cdkd PR Roadmap — Region & State Refactor
+
+This directory tracks the rollout plan for a multi-PR refactor that reshapes how
+cdkd handles state buckets, stack regions, and a few related UX issues. Each
+file is a self-contained implementation plan for one PR — the order below is
+the recommended merge order, **not** the required implementation order.
+
+## Why this refactor
+
+Three classes of bugs / UX problems surfaced together and share a single
+underlying cause: the current state model assumes "one region = one cdkd
+client", but cdkd's collection model (one S3 bucket per account) plus CDK's
+per-stack `env.region` conflict in subtle ways.
+
+1. **Silent state corruption on `env.region` change** — Changing a stack's
+   `env.region` between deploys overwrites the recorded region in
+   `state.json`, leaving the original region's resources untracked. `destroy`
+   then runs against the wrong region and produces silent failures (e.g.,
+   Lambda `delete-function` returns `ResourceNotFoundException` from the
+   wrong region, which is treated as idempotent success).
+2. **`UnknownError` from S3 HeadBucket** — When the CLI's profile region and
+   the state bucket's region differ, S3 returns a 301 redirect on a HEAD
+   request with an empty body. The AWS SDK v3 protocol parser cannot classify
+   it and surfaces a synthetic `UnknownError`.
+3. **Team sharing breaks across profile regions** — The default state bucket
+   name embeds the profile region (`cdkd-state-{accountId}-{region}`). Two
+   teammates with different profile regions look up different bucket names
+   and end up with split state.
+
+The refactor introduces a region-aware state key layout, dynamic bucket
+region resolution, and a region-free default bucket name. Plus a few quality-
+of-life additions surfaced in the same discussion (`cdkd state destroy`,
+hiding the bucket-name banner from `deploy` output).
+
+## Design summary
+
+| Aspect | Before | After |
+|---|---|---|
+| State bucket count | 1 per account (region-suffixed name) | 1 per account (region-free name) |
+| Default bucket name | `cdkd-state-{accountId}-{region}` | `cdkd-state-{accountId}` |
+| State key | `cdkd/{stackName}/state.json` | `cdkd/{stackName}/{region}/state.json` |
+| Same `stackName` across regions | One key — second region overwrites first | Independent keys per region |
+| `--region` flag | Used by every command (overloaded) | Bootstrap-only |
+| Bucket region detection | None — relies on profile region matching | `GetBucketLocation` at startup |
+| `UnknownError` handling | Bubbles up verbatim | Normalized via HTTP status code |
+
+## PR list
+
+| # | Title | Depends on | Breaking change | Parallel | Plan |
+|---|---|---|---|---|---|
+| 1 | State key region prefix (collection model extension) | none | yes (auto-migrated) | ✅ | [01](./01-state-key-region-prefix.md) |
+| 2 | DELETE region verification | none | no | ✅ | [02](./02-delete-region-verification.md) |
+| 3 | Dynamic region resolution + UnknownError normalization | none | no | ✅ | [03](./03-dynamic-region-resolution.md) |
+| 4 | Default state bucket name (region-free) | PR 3 | yes (auto-migrated) | △ (after PR 3) | [04](./04-state-bucket-naming.md) |
+| 5 | `--region` flag cleanup | PR 3 | no (deprecation) | △ (after PR 3) | [05](./05-region-flag-cleanup.md) |
+| 6 | `cdkd state destroy` command | none | no | ✅ | [06](./06-state-destroy-command.md) |
+| 7 | Hide state bucket from deploy output + `cdkd state info` | none | no | ✅ | [07](./07-state-bucket-display.md) |
+| 99 | Backwards-compat removal + final migration command (future) | 1, 4 | yes | — | [99](./99-future-bc-removal.md) |
+
+## Operating rules for this rollout
+
+- **Branch naming**: `feat/<short-slug>` for each PR (e.g., `feat/state-region-key`).
+- **PR open, no merge**: open all PRs but wait for explicit user approval to
+  merge. The user reviews and decides merge order.
+- **Parallel worktrees**: PRs 1, 2, 3, 6, 7 are independent — each lives in
+  its own `git worktree` so work can proceed concurrently. PRs 4 and 5 wait
+  for PR 3 to merge.
+- **Subagents**: when subagents drive any of these PRs end-to-end, they MUST
+  use Opus 4.7 (`model: "opus"` plus an Opus-tier `subagent_type`). Do not
+  fall back to a smaller model silently.
+- **Markgate gates**: PRs 1 and 4 are flagged as breaking changes and will
+  gate merges on a new `bc-check` markgate marker (see each plan).
+
+## Compatibility strategy
+
+PRs 1 and 4 are user-visible breaking changes. Both are protected by:
+
+1. **Backwards-compat read path** — Old key layouts and old bucket names are
+   still readable. The legacy form is detected on read; a warning is logged.
+2. **Auto-migration on write** — The next write (deploy / destroy / lock
+   acquisition) silently migrates to the new form and removes the legacy
+   artifact.
+3. **Schema version** — `state.json` carries a `version: number` field
+   (already present, set to `1` today). New writes use `version: 2`. Old
+   binaries that try to read `version: 2` fail with a clear error rather
+   than silently mishandling the new format.
+4. **`bc-check` markgate gate** — Each affected PR ships a verification
+   script (`scripts/verify-bc.sh`) that checks the migration paths against
+   fixtures. The marker is required before `gh pr merge` succeeds.
+
+The legacy read path is **temporary**. PR 99 (future, 1–2 releases later)
+removes it and ships a final `cdkd state migrate` command for any users who
+never touched their state in the interim.
+
+## Out of scope (explicitly)
+
+The following items came up in discussion and were deliberately deferred:
+
+- **Region failure isolation** — One state bucket means one region's S3
+  outage stops all cdkd operations across all stack regions. Accepted as a
+  tradeoff of the collection model. Users who need region failure isolation
+  should split state with `--state-bucket` per stack group.
+- **Data residency / cross-partition (GovCloud, China)** — Not a target use
+  case for cdkd. Users with these requirements should use the upstream CDK
+  CLI.
+- **CFn-style `cdk list` for deployed stacks across all regions** — `cdkd
+  state list` already serves this purpose under the collection model and is
+  better than CFn at it.
+
+## Cross-cutting documentation updates
+
+Each PR updates docs in its own scope. These three files will see edits
+across multiple PRs:
+
+- `README.md` — top-level "Behavior vs CDK" / "Caveats" section
+- `CLAUDE.md` — invariants for collection model + region-prefixed keys
+- `docs/state-management.md` — bucket layout, key layout, migration plan
+
+## Tracking & follow-ups
+
+- A GitHub issue tracks PR 99 (backwards-compat removal) so it is not
+  forgotten.
+- Each PR's plan file ends with a "Follow-ups discovered during
+  implementation" section that should be updated as work progresses.

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -28,31 +28,63 @@ cdkd adopts a state management system with S3 as the backend. Unlike CloudFormat
 
 ### Directory Layout
 
+State and lock keys are region-scoped (since PR 1, schema `version: 2`).
+The same `stackName` deployed to two different regions has two independent
+state files; changing `env.region` no longer silently overwrites the prior
+region's record.
+
 ```
 s3://{STATE_BUCKET}/{STATE_PREFIX}/
   └── {StackName}/
-      ├── lock.json      # Exclusive lock information
-      └── state.json     # Resource state
+      └── {Region}/
+          ├── lock.json      # Exclusive lock information (region-scoped)
+          └── state.json     # Resource state (region-scoped)
 ```
 
 ### Configuration Example
 
 ```bash
 export STATE_BUCKET="cdkd-state-myteam-1234567890"
-export STATE_PREFIX="stacks"  # Default: "cdkd"
+export STATE_PREFIX="cdkd"  # Default
 ```
 
 Result:
 
 ```
-s3://cdkd-state-myteam-1234567890/stacks/
+s3://cdkd-state-myteam-1234567890/cdkd/
   ├── MyAppStack/
-  │   ├── lock.json
-  │   └── state.json
+  │   └── us-east-1/
+  │       ├── lock.json
+  │       └── state.json
   └── DatabaseStack/
-      ├── lock.json
-      └── state.json
+      ├── us-east-1/
+      │   ├── lock.json
+      │   └── state.json
+      └── us-west-2/         # same stackName, different region — independent
+          ├── lock.json
+          └── state.json
 ```
+
+### Legacy layout (`version: 1`) — read path only
+
+State files written by cdkd before PR 1 used a flat per-stack layout:
+
+```
+s3://{STATE_BUCKET}/{STATE_PREFIX}/
+  └── {StackName}/
+      ├── lock.json      # not region-scoped
+      └── state.json     # version: 1, region recorded inside the body
+```
+
+cdkd still **reads** this layout (looking up the legacy key only when its
+embedded `region` field matches the requested region), and the next write
+auto-migrates: it writes the new region-scoped key, then deletes the legacy
+key. The legacy read path is temporary and will be removed in a future PR
+(see `docs/plans/99-future-bc-removal.md`).
+
+An older cdkd binary that only knows `version: 1` will **fail with a clear
+error** if it sees a `version: 2` blob (`Unsupported state schema version
+2. Upgrade cdkd.`) instead of silently mishandling unknown fields.
 
 ## State Schema
 
@@ -60,8 +92,9 @@ s3://cdkd-state-myteam-1234567890/stacks/
 
 ```typescript
 interface StackState {
-  version: number                          // Schema version (current: 1)
+  version: 1 | 2                           // 1 = legacy, 2 = region-prefixed
   stackName: string                        // Stack name
+  region?: string                          // Required on version: 2
   resources: Record<string, ResourceState> // Logical ID → Resource state
   outputs: Record<string, string>          // Output name → Resolved value
   lastModified: number                     // Unix timestamp (milliseconds)
@@ -72,8 +105,9 @@ interface StackState {
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "stackName": "MyAppStack",
+  "region": "us-east-1",
   "resources": {
     "MyBucket": {
       "physicalId": "myappstack-mybucket-abc123xyz",

--- a/scripts/verify-bc.sh
+++ b/scripts/verify-bc.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# verify-bc.sh — backwards-compatibility verification driver.
+#
+# Verifies that cdkd reads pre-PR-1 state files and migrates them to the new
+# region-prefixed key layout on next save. This is the manual-verification
+# script referenced from docs/plans/01-state-key-region-prefix.md (the PR 1
+# plan) and shared with PR 4.
+#
+# Usage:
+#   STATE_BUCKET=my-fixture-bucket AWS_REGION=us-east-1 ./scripts/verify-bc.sh PR-1
+#
+# Required env:
+#   STATE_BUCKET — pre-existing S3 bucket cdkd has write access to. The script
+#     will write & remove keys under cdkd/_bc-fixture-stack/.
+#   AWS_REGION   — region for the test stack (also the region embedded in the
+#     legacy fixture). Defaults to us-east-1.
+#
+# Future hookup: this script is intended to be wired into a `bc-check`
+# markgate gate (out of scope for PR 1; the script is shipped here so future
+# PRs can plug it in without re-deriving the migration steps).
+
+set -euo pipefail
+
+PR="${1:-PR-1}"
+REGION="${AWS_REGION:-us-east-1}"
+BUCKET="${STATE_BUCKET:-}"
+STACK="_bc-fixture-stack"
+PREFIX="cdkd"
+LEGACY_KEY="${PREFIX}/${STACK}/state.json"
+NEW_KEY="${PREFIX}/${STACK}/${REGION}/state.json"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+if [[ -z "$BUCKET" ]]; then
+  echo "ERROR: STATE_BUCKET env var is required" >&2
+  echo "Usage: STATE_BUCKET=<bucket> AWS_REGION=<region> $0 PR-1" >&2
+  exit 64
+fi
+
+case "$PR" in
+  PR-1)
+    echo "==> Verifying PR-1 (region-prefixed state key migration)"
+    ;;
+  *)
+    echo "ERROR: only PR-1 is supported by this version of verify-bc.sh" >&2
+    exit 64
+    ;;
+esac
+
+echo "==> Bucket: s3://${BUCKET}/${PREFIX}/${STACK}/"
+echo "==> Region: ${REGION}"
+
+# 1. Seed a legacy version: 1 state file at the old key.
+cat >"$WORK_DIR/legacy-state.json" <<EOF
+{
+  "version": 1,
+  "stackName": "${STACK}",
+  "region": "${REGION}",
+  "resources": {},
+  "outputs": {},
+  "lastModified": $(date +%s)000
+}
+EOF
+
+echo "==> Seeding legacy state at s3://${BUCKET}/${LEGACY_KEY}"
+aws s3 cp "$WORK_DIR/legacy-state.json" "s3://${BUCKET}/${LEGACY_KEY}" \
+  --content-type application/json --no-progress
+
+# 2. Confirm that listStacks surfaces the legacy entry under the right region.
+echo "==> Running 'cdkd state list' against the fixture bucket"
+node dist/cli.js state list --state-bucket "$BUCKET" --region "$REGION"
+
+# 3. Run a `cdkd state rm --yes` to trigger the migration delete code path.
+#    state rm hits both keys: it deletes the new key (which doesn't exist yet
+#    so the call is a no-op for now) AND the legacy key (because their
+#    embedded region matches), giving us the migration outcome we want
+#    without standing up real AWS resources.
+echo "==> Migrating + cleaning up legacy fixture via 'cdkd state rm'"
+node dist/cli.js state rm "$STACK" --yes \
+  --state-bucket "$BUCKET" --region "$REGION"
+
+# 4. Assert: legacy key gone.
+if aws s3api head-object --bucket "$BUCKET" --key "$LEGACY_KEY" >/dev/null 2>&1; then
+  echo "ERROR: legacy key still exists at s3://${BUCKET}/${LEGACY_KEY}" >&2
+  exit 1
+fi
+
+# 5. Assert: new key also gone (state rm cleaned it).
+if aws s3api head-object --bucket "$BUCKET" --key "$NEW_KEY" >/dev/null 2>&1; then
+  echo "ERROR: new key was not removed by state rm: s3://${BUCKET}/${NEW_KEY}" >&2
+  exit 1
+fi
+
+echo "==> OK: legacy → new migration path verified for $PR"

--- a/src/cli/commands/destroy.ts
+++ b/src/cli/commands/destroy.ts
@@ -93,7 +93,11 @@ async function destroyCommand(
     // 2. Resolve stacks to destroy (CDK CLI compatible behavior)
     // Always synth to determine which stacks belong to this CDK app.
     const appCmd = options.app || resolveApp();
-    let appStacks: StackLike[] = [];
+    // Local extension of `StackLike` that also carries the synth-derived
+    // region. Stack-matcher only reads stackName/displayName, so this is
+    // backwards-compatible everywhere matchStacks is used.
+    type AppStack = StackLike & { region?: string };
+    let appStacks: AppStack[] = [];
 
     if (appCmd) {
       try {
@@ -107,24 +111,38 @@ async function destroyCommand(
         appStacks = result.stacks.map((s) => ({
           stackName: s.stackName,
           displayName: s.displayName,
+          ...(s.region && { region: s.region }),
         }));
       } catch {
         logger.debug('Could not synthesize app, falling back to state-based stack list');
       }
     }
 
-    // Determine candidate stacks. State only carries physical names, so when synth
-    // is unavailable we fall back to a stackName-only candidate list (display-path
-    // patterns like "MyStage/MyStack" simply will not match anything in that mode).
-    const allStateStacks = await stateBackend.listStacks();
+    // Determine candidate stacks. State only carries physical names + regions
+    // (no display path), so when synth is unavailable we fall back to a
+    // stackName-only candidate list (display-path patterns like
+    // "MyStage/MyStack" simply will not match anything in that mode).
+    const allStateRefs = await stateBackend.listStacks();
+    // Map stackName -> first region (collision warning emitted later if a
+    // stack has multiple region keys). Synth-driven destroy is single-region:
+    // if synth.region matches one of the records we use it; otherwise we
+    // surface a clear error.
     let candidateStacks: StackLike[];
     if (appStacks.length > 0) {
       // App synth succeeded: only consider stacks from this app
-      const stateSet = new Set(allStateStacks);
-      candidateStacks = appStacks.filter((s) => stateSet.has(s.stackName));
+      const stateNames = new Set(allStateRefs.map((r) => r.stackName));
+      candidateStacks = appStacks.filter((s) => stateNames.has(s.stackName));
     } else if (stackArgs.length > 0 || options.stack || options.all) {
       // No synth but explicit stack names or --all given: use state stacks
-      candidateStacks = allStateStacks.map((name) => ({ stackName: name }));
+      // (deduplicate by name so a stack with two region records appears once
+      // — the per-stack loop handles the multi-region case explicitly)
+      const seen = new Set<string>();
+      candidateStacks = [];
+      for (const ref of allStateRefs) {
+        if (seen.has(ref.stackName)) continue;
+        seen.add(ref.stackName);
+        candidateStacks.push({ stackName: ref.stackName });
+      }
     } else {
       // No synth and no explicit stacks: refuse to guess
       throw new Error(
@@ -162,12 +180,51 @@ async function destroyCommand(
 
     logger.info(`Found ${stackNames.length} stack(s) to destroy: ${stackNames.join(', ')}`);
 
+    // Index state refs by stack name so we can resolve which region(s) each
+    // stack has. Built once so the per-stack loop is cheap.
+    const stateRefsByName = new Map<string, typeof allStateRefs>();
+    for (const ref of allStateRefs) {
+      const arr = stateRefsByName.get(ref.stackName) ?? [];
+      arr.push(ref);
+      stateRefsByName.set(ref.stackName, arr);
+    }
+
     // 3. Process each stack
     for (const stackName of stackNames) {
       logger.info(`\nPreparing to destroy stack: ${stackName}`);
 
-      // Load current state
-      const stateResult = await stateBackend.getState(stackName);
+      // Pick the region for this stack. If synth ran, prefer the synth region
+      // (so a user changing env.region targets only that region). Otherwise,
+      // use the unique state region; refuse with a helpful error when the
+      // stack has multiple regions and the user did not pin one.
+      const refs = stateRefsByName.get(stackName) ?? [];
+      const synthStack = appStacks.find((s) => s.stackName === stackName);
+      const synthRegion = synthStack?.region;
+      let stackTargetRegion: string;
+      if (refs.length === 0) {
+        logger.warn(`No state found for stack ${stackName}, skipping`);
+        continue;
+      } else if (refs.length === 1) {
+        const onlyRegion = refs[0]?.region;
+        if (!onlyRegion) {
+          // Legacy state with no recorded region: fall back to the CLI region.
+          stackTargetRegion = region;
+        } else {
+          stackTargetRegion = onlyRegion;
+        }
+      } else if (synthRegion && refs.some((r) => r.region === synthRegion)) {
+        stackTargetRegion = synthRegion;
+      } else {
+        const regions = refs.map((r) => r.region ?? '(legacy)').join(', ');
+        throw new Error(
+          `Stack '${stackName}' has state in multiple regions: ${regions}. ` +
+            `Use 'cdkd state rm ${stackName} --region <region>' to remove cdkd's record for one ` +
+            `region, or run destroy from a CDK app whose env.region matches one of them.`
+        );
+      }
+
+      // Load current state for the chosen region
+      const stateResult = await stateBackend.getState(stackName, stackTargetRegion);
       if (!stateResult) {
         logger.warn(`No state found for stack ${stackName}, skipping`);
         continue;
@@ -177,7 +234,7 @@ async function destroyCommand(
       const resourceCount = Object.keys(currentState.resources).length;
       if (resourceCount === 0) {
         logger.info(`Stack ${stackName} has no resources, cleaning up state...`);
-        await stateBackend.deleteState(stackName);
+        await stateBackend.deleteState(stackName, stackTargetRegion);
         logger.info('✓ State deleted');
         continue;
       }
@@ -208,7 +265,7 @@ async function destroyCommand(
       }
 
       // 5. Switch region if stack was deployed to a different region
-      const stackRegion = currentState.region;
+      const stackRegion = stackTargetRegion;
       let destroyProviderRegistry = providerRegistry;
       let destroyAwsClients: AwsClients | undefined;
 
@@ -230,7 +287,7 @@ async function destroyCommand(
 
       // Acquire lock (always uses base region for state bucket)
       logger.info(`\nAcquiring lock for stack ${stackName}...`);
-      await lockManager.acquireLock(stackName, 'destroy');
+      await lockManager.acquireLock(stackName, stackRegion, undefined, 'destroy');
 
       // Live progress renderer (multi-line in-flight display at bottom of TTY).
       // Self-disables on non-TTY and when `CDKD_NO_LIVE=1` is set (the CLI
@@ -388,7 +445,7 @@ async function destroyCommand(
 
         // 8. Delete state
         if (errorCount === 0) {
-          await stateBackend.deleteState(stackName);
+          await stateBackend.deleteState(stackName, stackRegion);
           logger.debug('State deleted');
         } else {
           logger.warn(`${errorCount} resource(s) failed to delete. State preserved.`);
@@ -404,7 +461,7 @@ async function destroyCommand(
 
         // 9. Release lock
         logger.debug('Releasing lock...');
-        await lockManager.releaseLock(stackName);
+        await lockManager.releaseLock(stackName, stackRegion);
 
         // Restore region if changed
         if (destroyAwsClients) {

--- a/src/cli/commands/diff.ts
+++ b/src/cli/commands/diff.ts
@@ -11,6 +11,7 @@ import { getLogger } from '../../utils/logger.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer } from '../../synthesis/synthesizer.js';
 import { S3StateBackend } from '../../state/s3-state-backend.js';
+import { STATE_SCHEMA_VERSION_CURRENT } from '../../types/state.js';
 import { DiffCalculator } from '../../analyzer/diff-calculator.js';
 import { IntrinsicFunctionResolver } from '../../deployment/intrinsic-function-resolver.js';
 import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
@@ -194,21 +195,24 @@ async function diffCommand(
       logger.info(`\nCalculating diff for stack: ${stackInfo.stackName}`);
 
       const template = stackInfo.template;
+      // Stack region drives the state key. Falls back to the CLI region only
+      // when synth couldn't determine a region (e.g. env-agnostic stacks).
+      const stackRegion = stackInfo.region || region;
 
       // Load current state
-      let currentState;
-      const stateResult = await stateBackend.getState(stackInfo.stackName);
-      if (stateResult) {
-        currentState = stateResult.state;
-      } else {
-        logger.debug(`No existing state for ${stackInfo.stackName}`);
-        currentState = {
-          stackName: stackInfo.stackName,
-          resources: {},
-          outputs: {},
-          version: 1,
-          lastModified: Date.now(),
-        };
+      const stateResult = await stateBackend.getState(stackInfo.stackName, stackRegion);
+      const currentState = stateResult
+        ? stateResult.state
+        : {
+            stackName: stackInfo.stackName,
+            region: stackRegion,
+            resources: {},
+            outputs: {},
+            version: STATE_SCHEMA_VERSION_CURRENT,
+            lastModified: Date.now(),
+          };
+      if (!stateResult) {
+        logger.debug(`No existing state for ${stackInfo.stackName} (${stackRegion})`);
       }
 
       // Calculate diff. A best-effort intrinsic resolver lets us detect changes

--- a/src/cli/commands/force-unlock.ts
+++ b/src/cli/commands/force-unlock.ts
@@ -1,8 +1,9 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { commonOptions, stateOptions, stackOptions } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { LockManager } from '../../state/lock-manager.js';
+import { S3StateBackend } from '../../state/s3-state-backend.js';
 import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
 import { resolveStateBucketWithDefault } from '../config-loader.js';
 
@@ -18,6 +19,7 @@ async function forceUnlockCommand(
     stateBucket?: string;
     statePrefix: string;
     stack?: string;
+    stackRegion?: string;
     region?: string;
     profile?: string;
     verbose: boolean;
@@ -51,19 +53,40 @@ async function forceUnlockCommand(
       prefix: options.statePrefix,
     };
     const lockManager = new LockManager(awsClients.s3, stateConfig);
+    const stateBackend = new S3StateBackend(awsClients.s3, stateConfig);
 
     for (const stackName of stackPatterns) {
-      logger.info(`Force-unlocking stack: ${stackName}`);
-
-      try {
-        await lockManager.forceReleaseLock(stackName);
-        logger.info(`✓ Lock released for stack: ${stackName}`);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (message.includes('No lock found') || message.includes('NoSuchKey')) {
-          logger.info(`No lock found for stack: ${stackName}`);
+      // Determine which region(s) to release. Order:
+      //   1. Explicit `--stack-region` flag.
+      //   2. Region(s) discovered in S3 state for this stack name (new
+      //      region-prefixed key + legacy key).
+      //   3. Fallback to the CLI region when no state record exists yet.
+      let regionsToTry: (string | undefined)[];
+      if (options.stackRegion) {
+        regionsToTry = [options.stackRegion];
+      } else {
+        const refs = await stateBackend.listStacks();
+        const matched = refs.filter((r) => r.stackName === stackName);
+        if (matched.length === 0) {
+          regionsToTry = [region];
         } else {
-          logger.error(`Failed to unlock stack ${stackName}: ${message}`);
+          regionsToTry = matched.map((r) => r.region);
+        }
+      }
+
+      for (const r of regionsToTry) {
+        const where = r ? `${stackName} (${r})` : `${stackName} (legacy lock key)`;
+        logger.info(`Force-unlocking stack: ${where}`);
+        try {
+          await lockManager.forceReleaseLock(stackName, r);
+          logger.info(`✓ Lock released for stack: ${where}`);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (message.includes('No lock found') || message.includes('NoSuchKey')) {
+            logger.info(`No lock found for stack: ${where}`);
+          } else {
+            logger.error(`Failed to unlock stack ${where}: ${message}`);
+          }
         }
       }
     }
@@ -79,6 +102,13 @@ export function createForceUnlockCommand(): Command {
   const cmd = new Command('force-unlock')
     .description('Force-release a stale lock on a stack')
     .argument('[stacks...]', 'Stack name(s) to unlock')
+    .addOption(
+      new Option(
+        '--stack-region <region>',
+        'Stack region whose lock to release (use when the same stack name has locks in multiple regions). ' +
+          'Defaults to all regions where the stack has state.'
+      )
+    )
     .action(withErrorHandling(forceUnlockCommand));
 
   [...commonOptions, ...stateOptions, ...stackOptions].forEach((opt) => cmd.addOption(opt));

--- a/src/cli/commands/state.ts
+++ b/src/cli/commands/state.ts
@@ -1,9 +1,9 @@
 import * as readline from 'node:readline/promises';
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { commonOptions, stateOptions } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
-import { S3StateBackend } from '../../state/s3-state-backend.js';
+import { S3StateBackend, type StackStateRef } from '../../state/s3-state-backend.js';
 import { LockManager } from '../../state/lock-manager.js';
 import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
 import { resolveStateBucketWithDefault } from '../config-loader.js';
@@ -14,6 +14,11 @@ import type { LockInfo } from '../../types/state.js';
  */
 interface StackDetail {
   stackName: string;
+  /**
+   * Region recorded for this state record. `null` for legacy `version: 1`
+   * state where no region was persisted in the state body.
+   */
+  region: string | null;
   resourceCount: number;
   lastModified: string | null;
   locked: boolean;
@@ -31,6 +36,50 @@ interface ResourceDetail {
   physicalId: string;
   dependencies: string[];
   attributes: Record<string, unknown>;
+}
+
+/**
+ * Render `Stack` or `Stack (region)` — used by every state subcommand's
+ * default output mode and ambiguity error messages.
+ */
+function formatStackRef(ref: StackStateRef): string {
+  return ref.region ? `${ref.stackName} (${ref.region})` : ref.stackName;
+}
+
+/**
+ * Resolve a stack name + optional region flag against the `listStacks` index
+ * built up front. When a name resolves to multiple regions and the caller
+ * didn't pin one, surface a clear error listing the candidates so the user
+ * knows exactly which `--region X` to add.
+ */
+function resolveSingleRegion(
+  stackName: string,
+  refs: StackStateRef[],
+  requestedRegion: string | undefined
+): StackStateRef {
+  const matches = refs.filter((r) => r.stackName === stackName);
+  if (matches.length === 0) {
+    throw new Error(
+      `No state found for stack '${stackName}'. Run 'cdkd state list' to see available stacks.`
+    );
+  }
+  if (requestedRegion) {
+    const ref = matches.find((r) => r.region === requestedRegion);
+    if (!ref) {
+      const seen = matches.map((r) => r.region ?? '(legacy)').join(', ');
+      throw new Error(
+        `No state found for stack '${stackName}' in region '${requestedRegion}'. ` +
+          `Available regions: ${seen}.`
+      );
+    }
+    return ref;
+  }
+  if (matches.length === 1) return matches[0]!;
+  const regions = matches.map((r) => r.region ?? '(legacy)').join(', ');
+  throw new Error(
+    `Stack '${stackName}' has state in multiple regions: ${regions}. ` +
+      `Re-run with --region <region> to disambiguate.`
+  );
 }
 
 /**
@@ -81,11 +130,32 @@ async function setupStateBackend(options: {
 }
 
 /**
+ * Stable sort for `StackStateRef[]` — alphabetical by stackName (ASCII order,
+ * matches the legacy `state list` sort), then by region with `null`/legacy
+ * entries last.
+ */
+function sortRefs(refs: StackStateRef[]): StackStateRef[] {
+  return refs.slice().sort((a, b) => {
+    if (a.stackName < b.stackName) return -1;
+    if (a.stackName > b.stackName) return 1;
+    const ar = a.region ?? '￿';
+    const br = b.region ?? '￿';
+    if (ar < br) return -1;
+    if (ar > br) return 1;
+    return 0;
+  });
+}
+
+/**
  * `cdkd state list` command implementation
  *
- * Lists stacks registered in the configured S3 state bucket.
+ * Lists stacks registered in the configured S3 state bucket. Each row is a
+ * `(stackName, region)` pair — the same `stackName` deployed to two regions
+ * shows up as two rows, which is the whole point of the region-prefixed
+ * state key layout introduced in PR 1.
  *
- * - Default: stack names, one per line, sorted alphabetically.
+ * - Default: `Stack (region)` per line, sorted alphabetically. Legacy
+ *   `version: 1` records (no region) appear as plain `Stack` rows.
  * - `--long`/`-l`: include resource count, last-modified time, and lock status.
  * - `--json`: emit a JSON array (alongside or instead of the long form).
  */
@@ -103,32 +173,42 @@ async function stateListCommand(options: {
 
   const setup = await setupStateBackend(options);
   try {
-    const stackNames = (await setup.stateBackend.listStacks()).slice().sort();
+    const refs = sortRefs(await setup.stateBackend.listStacks());
 
-    // Default mode: just print sorted stack names, one per line.
+    // Default mode: `Stack (region)` per line, sorted.
     if (!options.long && !options.json) {
-      for (const name of stackNames) {
-        process.stdout.write(`${name}\n`);
+      for (const ref of refs) {
+        process.stdout.write(`${formatStackRef(ref)}\n`);
       }
       return;
     }
 
-    // --json without --long: array of names.
+    // --json without --long: array of `{stackName, region}` records.
     if (options.json && !options.long) {
-      process.stdout.write(`${JSON.stringify(stackNames, null, 2)}\n`);
+      const payload = refs.map((r) => ({ stackName: r.stackName, region: r.region ?? null }));
+      process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
       return;
     }
 
     // --long (with or without --json): fetch detail per stack in parallel.
     const details: StackDetail[] = await Promise.all(
-      stackNames.map(async (stackName): Promise<StackDetail> => {
+      refs.map(async (ref): Promise<StackDetail> => {
+        // For legacy refs (no region), passing the legacy region string would
+        // miss the legacy key — instead, lookup with whichever region the ref
+        // carries (could be `undefined` for very-legacy records). The state
+        // backend's getState uses the region as part of the key; for legacy
+        // records the region embedded in the file is the one that matches.
+        const lookupRegion = ref.region ?? '';
         const [stateResult, locked] = await Promise.all([
-          setup.stateBackend.getState(stackName),
-          setup.lockManager.isLocked(stackName),
+          lookupRegion
+            ? setup.stateBackend.getState(ref.stackName, lookupRegion)
+            : Promise.resolve(null),
+          setup.lockManager.isLocked(ref.stackName, ref.region),
         ]);
         const state = stateResult?.state;
         return {
-          stackName,
+          stackName: ref.stackName,
+          region: ref.region ?? null,
           resourceCount: state ? Object.keys(state.resources).length : 0,
           lastModified:
             state && typeof state.lastModified === 'number'
@@ -147,7 +227,13 @@ async function stateListCommand(options: {
     // Long human-readable format.
     const lines: string[] = [];
     for (const detail of details) {
-      lines.push(detail.stackName);
+      lines.push(
+        formatStackRef({
+          stackName: detail.stackName,
+          ...(detail.region ? { region: detail.region } : {}),
+        })
+      );
+      lines.push(`  Region: ${detail.region ?? '(legacy)'}`);
       lines.push(`  Resources: ${detail.resourceCount}`);
       lines.push(`  Last Modified: ${detail.lastModified ?? 'unknown'}`);
       lines.push(`  Lock: ${detail.locked ? 'locked' : 'unlocked'}`);
@@ -191,6 +277,10 @@ function createStateListCommand(): Command {
  * - `--long`/`-l`: per-resource block including dependencies and attributes.
  * - `--json`: emit a JSON array of full resource detail objects.
  *
+ * When the same stack name has state in multiple regions, requires
+ * `--region <region>` to disambiguate. The error message lists candidate
+ * regions so the next attempt is one keystroke away.
+ *
  * Properties are intentionally omitted from all output modes — `state show`
  * is the right command when properties are needed.
  */
@@ -202,6 +292,7 @@ async function stateResourcesCommand(
     stateBucket?: string;
     statePrefix: string;
     region?: string;
+    stackRegion?: string;
     profile?: string;
     verbose: boolean;
   }
@@ -211,10 +302,19 @@ async function stateResourcesCommand(
 
   const setup = await setupStateBackend(options);
   try {
-    const stateResult = await setup.stateBackend.getState(stackName);
+    const refs = await setup.stateBackend.listStacks();
+    const ref = resolveSingleRegion(stackName, refs, options.stackRegion);
+    if (!ref.region) {
+      throw new Error(
+        `Stack '${stackName}' has only a legacy state record without a region. ` +
+          `Run 'cdkd deploy ${stackName}' (or any cdkd write) to migrate it to the region-scoped layout, ` +
+          `then re-run this command.`
+      );
+    }
+    const stateResult = await setup.stateBackend.getState(stackName, ref.region);
     if (!stateResult) {
       throw new Error(
-        `No state found for stack '${stackName}' in s3://${setup.bucket}/${setup.prefix}/. ` +
+        `No state found for stack '${stackName}' (${ref.region}) in s3://${setup.bucket}/${setup.prefix}/. ` +
           `Run 'cdkd state list' to see available stacks.`
       );
     }
@@ -330,6 +430,7 @@ function createStateResourcesCommand(): Command {
     .argument('<stack>', 'Stack name (physical CloudFormation name)')
     .option('-l, --long', 'Include dependencies and attributes per resource', false)
     .option('--json', 'Output as JSON', false)
+    .addOption(stackRegionOption())
     .action(withErrorHandling(stateResourcesCommand));
 
   [...commonOptions, ...stateOptions].forEach((opt) => cmd.addOption(opt));
@@ -345,6 +446,9 @@ function createStateResourcesCommand(): Command {
  * most verbose `state` subcommand — use `state list` / `state resources` for
  * lighter inspection.
  *
+ * When the same stack name has state in multiple regions, requires
+ * `--region <region>` to disambiguate.
+ *
  * - Default: human-readable multi-line format.
  * - `--json`: a `{state, lock}` object containing the raw `StackState` plus
  *   the lock record (or null).
@@ -356,6 +460,7 @@ async function stateShowCommand(
     stateBucket?: string;
     statePrefix: string;
     region?: string;
+    stackRegion?: string;
     profile?: string;
     verbose: boolean;
   }
@@ -365,14 +470,24 @@ async function stateShowCommand(
 
   const setup = await setupStateBackend(options);
   try {
+    const refs = await setup.stateBackend.listStacks();
+    const ref = resolveSingleRegion(stackName, refs, options.stackRegion);
+    if (!ref.region) {
+      throw new Error(
+        `Stack '${stackName}' has only a legacy state record without a region. ` +
+          `Run 'cdkd deploy ${stackName}' (or any cdkd write) to migrate it to the region-scoped layout, ` +
+          `then re-run this command.`
+      );
+    }
+
     const [stateResult, lockInfo] = await Promise.all([
-      setup.stateBackend.getState(stackName),
-      setup.lockManager.getLockInfo(stackName),
+      setup.stateBackend.getState(stackName, ref.region),
+      setup.lockManager.getLockInfo(stackName, ref.region),
     ]);
 
     if (!stateResult) {
       throw new Error(
-        `No state found for stack '${stackName}' in s3://${setup.bucket}/${setup.prefix}/. ` +
+        `No state found for stack '${stackName}' (${ref.region}) in s3://${setup.bucket}/${setup.prefix}/. ` +
           `Run 'cdkd state list' to see available stacks.`
       );
     }
@@ -450,6 +565,7 @@ function createStateShowCommand(): Command {
     .description('Show the full cdkd state record for a stack (metadata, outputs, resources)')
     .argument('<stack>', 'Stack name (physical CloudFormation name)')
     .option('--json', 'Output the raw state and lock as JSON', false)
+    .addOption(stackRegionOption())
     .action(withErrorHandling(stateShowCommand));
 
   [...commonOptions, ...stateOptions].forEach((opt) => cmd.addOption(opt));
@@ -465,8 +581,12 @@ function createStateShowCommand(): Command {
  * `cdkd destroy` is the command that deletes those.
  *
  * Behavior:
- * - Refuses to remove a locked stack unless `--force` is set, since tearing
- *   the lock out from under an in-flight deploy can corrupt state.
+ * - Default: removes all region keys recorded for the stack, with a single
+ *   confirmation that lists every region being affected. Use
+ *   `--region <region>` to scope removal to one region when a stack name has
+ *   state in multiple regions.
+ * - Refuses to remove a locked region's state unless `--force` is set, since
+ *   tearing the lock out from under an in-flight deploy can corrupt state.
  * - Confirmation prompt defaults to `(y/N)`, requiring an explicit `y` —
  *   this is more cautious than `cdkd destroy` because the operation orphans
  *   AWS resources from cdkd's view rather than reconciling them.
@@ -481,6 +601,7 @@ async function stateRmCommand(
     stateBucket?: string;
     statePrefix: string;
     region?: string;
+    stackRegion?: string;
     profile?: string;
     verbose: boolean;
   }
@@ -494,30 +615,51 @@ async function stateRmCommand(
 
   const setup = await setupStateBackend(options);
   try {
+    const refs = await setup.stateBackend.listStacks();
+
     for (const stackName of stackArgs) {
-      const exists = await setup.stateBackend.stateExists(stackName);
-      if (!exists) {
+      const stackRefs = refs.filter((r) => r.stackName === stackName);
+      if (stackRefs.length === 0) {
         logger.info(`No state found for stack: ${stackName}, skipping`);
         continue;
       }
 
-      // Refuse to remove a locked stack unless --force is set: an active
-      // deploy could be racing with us and ripping the lock out from under it
-      // would produce arbitrary mid-deploy corruption.
+      // Pick which region(s) to remove. With --region, restrict to one. The
+      // legacy entry (region: undefined) is matched only when --region is
+      // absent — there's no legacy-only flag because the legacy key is
+      // self-identifying via its missing region.
+      const targets = options.stackRegion
+        ? stackRefs.filter((r) => r.region === options.stackRegion)
+        : stackRefs;
+
+      if (targets.length === 0) {
+        const seen = stackRefs.map((r) => r.region ?? '(legacy)').join(', ');
+        throw new Error(
+          `No state found for stack '${stackName}' in region '${options.stackRegion}'. ` +
+            `Available regions: ${seen}.`
+        );
+      }
+
+      // Lock check applies per region; --force bypasses it.
       if (!options.force) {
-        const locked = await setup.lockManager.isLocked(stackName);
-        if (locked) {
-          throw new Error(
-            `Stack '${stackName}' is locked. Run 'cdkd force-unlock ${stackName}' first, ` +
-              `or pass --force to remove anyway.`
-          );
+        for (const target of targets) {
+          const locked = await setup.lockManager.isLocked(stackName, target.region);
+          if (locked) {
+            const where = target.region ?? '(legacy)';
+            throw new Error(
+              `Stack '${stackName}' (${where}) is locked. ` +
+                `Run 'cdkd force-unlock ${stackName}${target.region ? ` --stack-region ${target.region}` : ''}' first, ` +
+                `or pass --force to remove anyway.`
+            );
+          }
         }
       }
 
-      // Confirmation prompt unless --yes / --force.
+      // Single confirmation listing all regions being affected.
       if (!options.yes && !options.force) {
+        const targetList = targets.map((t) => formatStackRef(t)).join(', ');
         process.stdout.write(
-          `\nWARNING: This removes cdkd's state record for '${stackName}' only. ` +
+          `\nWARNING: This removes cdkd's state record for [${targetList}] only. ` +
             `AWS resources will NOT be deleted.\n` +
             `Use 'cdkd destroy ${stackName}' if you want to delete the actual resources.\n\n`
         );
@@ -526,7 +668,7 @@ async function stateRmCommand(
           output: process.stdout,
         });
         const answer = await rl.question(
-          `Remove state for stack '${stackName}' from s3://${setup.bucket}/${setup.prefix}/? (y/N): `
+          `Remove state for ${targetList} from s3://${setup.bucket}/${setup.prefix}/? (y/N): `
         );
         rl.close();
         const trimmed = answer.trim().toLowerCase();
@@ -536,15 +678,36 @@ async function stateRmCommand(
         }
       }
 
-      // Remove state.json AND any lingering lock.json. forceReleaseLock is
-      // idempotent (no-op when no lock present).
-      await setup.stateBackend.deleteState(stackName);
-      await setup.lockManager.forceReleaseLock(stackName);
-      logger.info(`✓ Removed state for stack: ${stackName}`);
+      // Iterate over every selected region. forceReleaseLock is idempotent
+      // (no-op when no lock present). For legacy-only refs (no region) we
+      // pass `undefined` to delete the legacy key; deleteState handles both.
+      for (const target of targets) {
+        if (target.region) {
+          await setup.stateBackend.deleteState(stackName, target.region);
+          await setup.lockManager.forceReleaseLock(stackName, target.region);
+        } else {
+          // Pure legacy record without a region body field: just sweep the
+          // legacy key (which is what the no-region forceReleaseLock targets).
+          await setup.lockManager.forceReleaseLock(stackName, undefined);
+        }
+        logger.info(`✓ Removed state for stack: ${formatStackRef(target)}`);
+      }
     }
   } finally {
     setup.dispose();
   }
+}
+
+/**
+ * Reusable `--region <region>` option for state subcommands. Aliased at the
+ * commander level via `stackRegion` so it doesn't collide with the global
+ * `--region` (AWS profile region) defined in `commonOptions`.
+ */
+function stackRegionOption(): Option {
+  return new Option(
+    '--stack-region <region>',
+    'Region of the stack record to operate on. Required when the same stack name has state in multiple regions.'
+  );
 }
 
 /**
@@ -555,6 +718,7 @@ function createStateRmCommand(): Command {
     .description('Remove cdkd state for one or more stacks (does NOT delete AWS resources)')
     .argument('<stacks...>', 'Stack name(s) to remove from state')
     .option('-f, --force', 'Skip confirmation and remove even if the stack is locked', false)
+    .addOption(stackRegionOption())
     .action(withErrorHandling(stateRmCommand));
 
   [...commonOptions, ...stateOptions].forEach((opt) => cmd.addOption(opt));

--- a/src/deployment/deploy-engine.ts
+++ b/src/deployment/deploy-engine.ts
@@ -5,7 +5,12 @@ import { setCurrentStackName, applyDefaultNameForFallback } from '../provisionin
 import { IntrinsicFunctionResolver } from './intrinsic-function-resolver.js';
 import { DagExecutor } from './dag-executor.js';
 import type { CloudFormationTemplate, ResourceProvider } from '../types/resource.js';
-import type { StackState, ResourceState, ResourceChange } from '../types/state.js';
+import {
+  STATE_SCHEMA_VERSION_CURRENT,
+  type StackState,
+  type ResourceState,
+  type ResourceChange,
+} from '../types/state.js';
 import type { S3StateBackend } from '../state/s3-state-backend.js';
 import type { LockManager } from '../state/lock-manager.js';
 import type { DagBuilder } from '../analyzer/dag-builder.js';
@@ -103,8 +108,12 @@ export class DeployEngine {
   private resolver: IntrinsicFunctionResolver;
   private interrupted = false;
 
-  /** Target region for this stack (saved in state for cross-region destroy) */
-  private stackRegion: string | undefined;
+  /**
+   * Target region for this stack. Required — load-bearing for the
+   * region-prefixed S3 state key and recorded in state.json for
+   * cross-region destroy.
+   */
+  private stackRegion: string;
 
   constructor(
     private stateBackend: S3StateBackend,
@@ -113,7 +122,7 @@ export class DeployEngine {
     private diffCalculator: DiffCalculator,
     private providerRegistry: ProviderRegistry,
     private options: DeployEngineOptions = {},
-    stackRegion?: string
+    stackRegion: string
   ) {
     this.stackRegion = stackRegion;
     this.resolver = new IntrinsicFunctionResolver(stackRegion);
@@ -134,7 +143,7 @@ export class DeployEngine {
     setCurrentStackName(stackName);
 
     // Acquire lock with retry (retries up to 3 times with 2s delay for transient lock conflicts)
-    await this.lockManager.acquireLockWithRetry(stackName, undefined, 'deploy');
+    await this.lockManager.acquireLockWithRetry(stackName, this.stackRegion, undefined, 'deploy');
 
     // Live progress renderer: shows in-flight resources as a multi-line area
     // at the bottom of the terminal. Self-disables on non-TTY and when
@@ -159,16 +168,19 @@ export class DeployEngine {
 
     try {
       // 1. Load current state
-      const currentStateData = await this.stateBackend.getState(stackName);
+      const currentStateData = await this.stateBackend.getState(stackName, this.stackRegion);
       const currentState: StackState = currentStateData?.state ?? {
-        version: 1,
-        ...(this.stackRegion && { region: this.stackRegion }),
+        version: STATE_SCHEMA_VERSION_CURRENT,
+        region: this.stackRegion,
         stackName,
         resources: {},
         outputs: {},
         lastModified: Date.now(),
       };
       const currentEtag = currentStateData?.etag;
+      // Set when we loaded a `version: 1` legacy record. The next save
+      // migrates it to the new key.
+      const migrationPending = currentStateData?.migrationPending ?? false;
 
       this.logger.debug(
         `Loaded current state: ${Object.keys(currentState.resources).length} resources`
@@ -283,11 +295,15 @@ export class DeployEngine {
         parameterValues,
         conditions,
         currentEtag,
-        progress
+        progress,
+        migrationPending
       );
 
-      // 7. Save final state (ETag may have been updated by partial saves)
-      const newEtag = await this.stateBackend.saveState(stackName, newState);
+      // 7. Save final state (ETag may have been updated by partial saves).
+      // The legacy migration delete (when migrationPending) was already done by
+      // the first per-resource save inside executeDeployment, so this final
+      // save is unconditionally region-scoped.
+      const newEtag = await this.stateBackend.saveState(stackName, this.stackRegion, newState);
       this.logger.debug(`State saved (ETag: ${newEtag})`);
 
       const durationMs = Date.now() - startTime;
@@ -311,7 +327,7 @@ export class DeployEngine {
 
       // Always release lock
       try {
-        await this.lockManager.releaseLock(stackName);
+        await this.lockManager.releaseLock(stackName, this.stackRegion);
         this.logger.debug('Lock released');
       } catch (lockError) {
         this.logger.warn(
@@ -340,7 +356,8 @@ export class DeployEngine {
     parameterValues?: Record<string, unknown>,
     conditions?: Record<string, boolean>,
     currentEtag?: string,
-    progress?: { current: number; total: number }
+    progress?: { current: number; total: number },
+    migrationPending = false
   ): Promise<{
     state: StackState;
     actualCounts: { created: number; updated: number; deleted: number; skipped: number };
@@ -349,6 +366,9 @@ export class DeployEngine {
     const newResources: Record<string, ResourceState> = { ...currentState.resources };
     const actualCounts = { created: 0, updated: 0, deleted: 0, skipped: 0 };
     const completedOperations: CompletedOperation[] = [];
+    // Tracked here so the FIRST per-resource save sweeps the legacy key; we
+    // don't want to delete it on every save.
+    let pendingMigration = migrationPending;
 
     // Serialize per-resource state saves to avoid ETag conflicts from concurrent writes
     let saveChain: Promise<void> = Promise.resolve();
@@ -357,14 +377,24 @@ export class DeployEngine {
       saveChain = saveChain.then(async () => {
         try {
           const partialState: StackState = {
-            version: 1,
-            ...(this.stackRegion && { region: this.stackRegion }),
+            version: STATE_SCHEMA_VERSION_CURRENT,
+            region: this.stackRegion,
             stackName: currentState.stackName,
             resources: newResources,
             outputs: currentState.outputs,
             lastModified: Date.now(),
           };
-          currentEtag = await this.stateBackend.saveState(stackName, partialState, currentEtag);
+          // Migration is a one-shot tail on the first save; subsequent saves
+          // overwrite the new key in-place under optimistic locking.
+          const migrate = pendingMigration;
+          const expectedEtag = migrate ? undefined : currentEtag;
+          currentEtag = await this.stateBackend.saveState(
+            stackName,
+            this.stackRegion,
+            partialState,
+            { ...(expectedEtag !== undefined && { expectedEtag }), migrateLegacy: migrate }
+          );
+          if (migrate) pendingMigration = false;
           this.logger.debug(`State saved after ${logicalId}`);
         } catch (error) {
           this.logger.warn(
@@ -542,14 +572,22 @@ export class DeployEngine {
       // but not in the state file.
       try {
         const preRollbackState: StackState = {
-          version: 1,
-          ...(this.stackRegion && { region: this.stackRegion }),
+          version: STATE_SCHEMA_VERSION_CURRENT,
+          region: this.stackRegion,
           stackName: currentState.stackName,
           resources: newResources,
           outputs: currentState.outputs,
           lastModified: Date.now(),
         };
-        currentEtag = await this.stateBackend.saveState(stackName, preRollbackState, currentEtag);
+        const migrate = pendingMigration;
+        const expectedEtag = migrate ? undefined : currentEtag;
+        currentEtag = await this.stateBackend.saveState(
+          stackName,
+          this.stackRegion,
+          preRollbackState,
+          { ...(expectedEtag !== undefined && { expectedEtag }), migrateLegacy: migrate }
+        );
+        if (migrate) pendingMigration = false;
         this.logger.debug('Partial state saved before rollback (orphaned resource tracking)');
       } catch (saveError) {
         this.logger.warn(
@@ -579,14 +617,16 @@ export class DeployEngine {
       // that. Otherwise, next deploy will think deleted resources still exist.
       try {
         const postRollbackState: StackState = {
-          version: 1,
-          ...(this.stackRegion && { region: this.stackRegion }),
+          version: STATE_SCHEMA_VERSION_CURRENT,
+          region: this.stackRegion,
           stackName: currentState.stackName,
           resources: newResources,
           outputs: currentState.outputs,
           lastModified: Date.now(),
         };
-        await this.stateBackend.saveState(stackName, postRollbackState, currentEtag);
+        await this.stateBackend.saveState(stackName, this.stackRegion, postRollbackState, {
+          ...(currentEtag !== undefined && { expectedEtag: currentEtag }),
+        });
         this.logger.debug('State saved after deployment failure');
       } catch (saveError) {
         // ETag mismatch from per-resource saves — force overwrite with fresh ETag
@@ -594,17 +634,19 @@ export class DeployEngine {
           `Retrying state save after rollback (ETag mismatch): ${saveError instanceof Error ? saveError.message : String(saveError)}`
         );
         try {
-          const freshState = await this.stateBackend.getState(stackName);
+          const freshState = await this.stateBackend.getState(stackName, this.stackRegion);
           const freshEtag = freshState?.etag;
           const postRollbackState: StackState = {
-            version: 1,
-            ...(this.stackRegion && { region: this.stackRegion }),
+            version: STATE_SCHEMA_VERSION_CURRENT,
+            region: this.stackRegion,
             stackName: currentState.stackName,
             resources: newResources,
             outputs: currentState.outputs,
             lastModified: Date.now(),
           };
-          await this.stateBackend.saveState(stackName, postRollbackState, freshEtag);
+          await this.stateBackend.saveState(stackName, this.stackRegion, postRollbackState, {
+            ...(freshEtag !== undefined && { expectedEtag: freshEtag }),
+          });
           this.logger.debug('State saved after deployment failure (retry succeeded)');
         } catch (retryError) {
           this.logger.warn(
@@ -627,8 +669,8 @@ export class DeployEngine {
 
     return {
       state: {
-        version: 1,
-        ...(this.stackRegion && { region: this.stackRegion }),
+        version: STATE_SCHEMA_VERSION_CURRENT,
+        region: this.stackRegion,
         stackName: currentState.stackName,
         resources: newResources,
         outputs,

--- a/src/deployment/intrinsic-function-resolver.ts
+++ b/src/deployment/intrinsic-function-resolver.ts
@@ -1037,22 +1037,39 @@ export class IntrinsicFunctionResolver {
 
     this.logger.debug(`Resolving Fn::ImportValue: ${exportName}`);
 
-    // List all stacks
+    // List all stacks. Each entry is a `{stackName, region}` ref so the lookup
+    // hits the right region-scoped key. A legacy entry has `region: undefined`
+    // — we still let it through so cross-stack references keep working during
+    // a partial migration; the state backend's legacy-fallback handles it.
     const allStacks = await context.stateBackend.listStacks();
-    this.logger.debug(`Found ${allStacks.length} stacks to search for export: ${exportName}`);
+    this.logger.debug(
+      `Found ${allStacks.length} state record(s) to search for export: ${exportName}`
+    );
 
     // Search through all stacks for the export
-    for (const stackName of allStacks) {
+    for (const ref of allStacks) {
+      const { stackName: refStack, region: refRegion } = ref;
       // Skip the current stack (avoid self-reference)
-      if (context.stackName && stackName === context.stackName) {
-        this.logger.debug(`Skipping current stack: ${stackName}`);
+      if (context.stackName && refStack === context.stackName) {
+        this.logger.debug(`Skipping current stack: ${refStack}`);
         continue;
       }
 
       try {
-        const stateData = await context.stateBackend.getState(stackName);
+        // Without a region we can't read the new key — fall back to the
+        // current resolver region so legacy and same-region records still
+        // resolve. The legacy read path inside getState matches by embedded
+        // region, so an unrelated legacy record won't collide here.
+        const lookupRegion = refRegion ?? this.resolverRegion ?? '';
+        if (!lookupRegion) {
+          this.logger.debug(
+            `No region available for stack '${refStack}' — skipping (cdkd cannot read state without a region)`
+          );
+          continue;
+        }
+        const stateData = await context.stateBackend.getState(refStack, lookupRegion);
         if (!stateData) {
-          this.logger.debug(`No state found for stack: ${stackName}`);
+          this.logger.debug(`No state found for stack: ${refStack} (${lookupRegion})`);
           continue;
         }
 
@@ -1062,13 +1079,13 @@ export class IntrinsicFunctionResolver {
         if (state.outputs && exportName in state.outputs) {
           const value = state.outputs[exportName];
           this.logger.info(
-            `Resolved Fn::ImportValue: ${exportName} = ${JSON.stringify(value)} (from stack: ${stackName})`
+            `Resolved Fn::ImportValue: ${exportName} = ${JSON.stringify(value)} (from stack: ${refStack} / ${lookupRegion})`
           );
           return value;
         }
       } catch (error) {
         this.logger.warn(
-          `Failed to read state for stack ${stackName}: ${error instanceof Error ? error.message : String(error)}`
+          `Failed to read state for stack ${refStack}: ${error instanceof Error ? error.message : String(error)}`
         );
         continue;
       }
@@ -1077,7 +1094,7 @@ export class IntrinsicFunctionResolver {
     // Export not found in any stack
     throw new Error(
       `Fn::ImportValue: export '${exportName}' not found in any stack. ` +
-        `Searched ${allStacks.length} stacks. ` +
+        `Searched ${allStacks.length} state record(s). ` +
         `Make sure the exporting stack has been deployed and the Output has an Export.Name property.`
     );
   }

--- a/src/state/lock-manager.ts
+++ b/src/state/lock-manager.ts
@@ -43,10 +43,24 @@ export class LockManager {
   }
 
   /**
-   * Get the S3 key for a stack's lock file
+   * Get the S3 key for a stack's lock file.
+   *
+   * Locks are region-scoped, mirroring the state key layout
+   * (`{prefix}/{stackName}/{region}/lock.json`). Two regions of the same
+   * stackName can therefore be operated on in parallel without contention,
+   * matching cdkd's parallel execution model.
+   *
+   * The `region` argument is required for new callers; for backwards
+   * compatibility with `state list --long` (which only sees stack names),
+   * passing `undefined` falls back to the legacy `{prefix}/{stackName}/lock.json`
+   * key — that mode is purely for legacy lock cleanup and is NOT used by
+   * deploy / destroy / diff anymore.
    */
-  private getLockKey(stackName: string): string {
-    return `${this.config.prefix}/${stackName}/lock.json`;
+  private getLockKey(stackName: string, region: string | undefined): string {
+    if (region === undefined) {
+      return `${this.config.prefix}/${stackName}/lock.json`;
+    }
+    return `${this.config.prefix}/${stackName}/${region}/lock.json`;
   }
 
   /**
@@ -88,11 +102,17 @@ export class LockManager {
    * If an expired lock exists, it will be cleaned up and re-acquired.
    *
    * @param stackName Stack name
+   * @param region Target region (lock key is region-scoped)
    * @param owner Lock owner identifier (defaults to user@hostname:pid)
    * @param operation Operation being performed (e.g., "deploy", "destroy")
    */
-  async acquireLock(stackName: string, owner?: string, operation?: string): Promise<boolean> {
-    const key = this.getLockKey(stackName);
+  async acquireLock(
+    stackName: string,
+    region: string,
+    owner?: string,
+    operation?: string
+  ): Promise<boolean> {
+    const key = this.getLockKey(stackName, region);
     const lockOwner = owner || this.getDefaultOwner();
     const now = Date.now();
 
@@ -104,7 +124,7 @@ export class LockManager {
     };
 
     try {
-      this.logger.debug(`Attempting to acquire lock for stack: ${stackName}`);
+      this.logger.debug(`Attempting to acquire lock for stack: ${stackName} (${region})`);
 
       const lockBody = JSON.stringify(lockInfo, null, 2);
       await this.s3Client.send(
@@ -118,23 +138,23 @@ export class LockManager {
         })
       );
 
-      this.logger.debug(`Lock acquired for stack: ${stackName}, owner: ${lockOwner}`);
+      this.logger.debug(`Lock acquired for stack: ${stackName} (${region}), owner: ${lockOwner}`);
       return true;
     } catch (error) {
       // Check for PreconditionFailed error (S3 condition not met - lock already exists)
       if (error instanceof S3ServiceException && error.name === 'PreconditionFailed') {
-        this.logger.debug(`Lock already exists for stack: ${stackName}`);
+        this.logger.debug(`Lock already exists for stack: ${stackName} (${region})`);
 
         // Check if the existing lock is expired
-        const existingLock = await this.getLockInfo(stackName);
+        const existingLock = await this.getLockInfo(stackName, region);
         if (existingLock && this.isLockExpired(existingLock)) {
           this.logger.info(
-            `Expired lock detected for stack: ${stackName} (owner: ${existingLock.owner}, ` +
+            `Expired lock detected for stack: ${stackName} (${region}, owner: ${existingLock.owner}, ` +
               `expired ${this.formatDuration(now - existingLock.expiresAt)} ago). Cleaning up...`
           );
 
           // Delete the expired lock and retry acquisition
-          await this.deleteLock(stackName);
+          await this.deleteLock(stackName, region);
 
           // Retry once after cleaning up expired lock
           try {
@@ -151,7 +171,7 @@ export class LockManager {
             );
 
             this.logger.debug(
-              `Lock acquired for stack: ${stackName} after expired lock cleanup, owner: ${lockOwner}`
+              `Lock acquired for stack: ${stackName} (${region}) after expired lock cleanup, owner: ${lockOwner}`
             );
             return true;
           } catch (retryError) {
@@ -161,7 +181,7 @@ export class LockManager {
             ) {
               // Another process acquired the lock between our delete and retry
               this.logger.debug(
-                `Lock was acquired by another process during expired lock cleanup for stack: ${stackName}`
+                `Lock was acquired by another process during expired lock cleanup for stack: ${stackName} (${region})`
               );
               return false;
             }
@@ -173,17 +193,21 @@ export class LockManager {
       }
 
       throw new LockError(
-        `Failed to acquire lock for stack '${stackName}': ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to acquire lock for stack '${stackName}' (${region}): ${error instanceof Error ? error.message : String(error)}`,
         error instanceof Error ? error : undefined
       );
     }
   }
 
   /**
-   * Get current lock information
+   * Get current lock information.
+   *
+   * `region` is required for the new region-scoped lock layout. Pass
+   * `undefined` only to inspect a legacy `{prefix}/{stackName}/lock.json`
+   * file (e.g. for state-listing tools that don't yet know the region).
    */
-  async getLockInfo(stackName: string): Promise<LockInfo | null> {
-    const key = this.getLockKey(stackName);
+  async getLockInfo(stackName: string, region: string | undefined): Promise<LockInfo | null> {
+    const key = this.getLockKey(stackName, region);
 
     try {
       this.logger.debug(`Getting lock info for stack: ${stackName}`);
@@ -230,19 +254,19 @@ export class LockManager {
    * not for acquisition decisions — use `acquireLock` for that, which has its
    * own expired-lock cleanup logic.
    */
-  async isLocked(stackName: string): Promise<boolean> {
-    const lockInfo = await this.getLockInfo(stackName);
+  async isLocked(stackName: string, region: string | undefined): Promise<boolean> {
+    const lockInfo = await this.getLockInfo(stackName, region);
     return lockInfo !== null;
   }
 
   /**
    * Release a lock for a stack
    */
-  async releaseLock(stackName: string): Promise<void> {
-    const key = this.getLockKey(stackName);
+  async releaseLock(stackName: string, region: string): Promise<void> {
+    const key = this.getLockKey(stackName, region);
 
     try {
-      this.logger.debug(`Releasing lock for stack: ${stackName}`);
+      this.logger.debug(`Releasing lock for stack: ${stackName} (${region})`);
 
       await this.s3Client.send(
         new DeleteObjectCommand({
@@ -251,10 +275,10 @@ export class LockManager {
         })
       );
 
-      this.logger.debug(`Lock released for stack: ${stackName}`);
+      this.logger.debug(`Lock released for stack: ${stackName} (${region})`);
     } catch (error) {
       throw new LockError(
-        `Failed to release lock for stack '${stackName}': ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to release lock for stack '${stackName}' (${region}): ${error instanceof Error ? error.message : String(error)}`,
         error instanceof Error ? error : undefined
       );
     }
@@ -265,29 +289,35 @@ export class LockManager {
    *
    * This is intended for CLI usage (e.g., --force-unlock flag) when a lock
    * is stuck and needs manual intervention.
+   *
+   * Pass `region: undefined` to operate on a legacy
+   * `{prefix}/{stackName}/lock.json` file.
    */
-  async forceReleaseLock(stackName: string): Promise<void> {
-    const lockInfo = await this.getLockInfo(stackName);
+  async forceReleaseLock(stackName: string, region: string | undefined): Promise<void> {
+    const lockInfo = await this.getLockInfo(stackName, region);
 
     if (!lockInfo) {
-      this.logger.warn(`No lock to force release for stack: ${stackName}`);
+      this.logger.warn(
+        `No lock to force release for stack: ${stackName}${region ? ` (${region})` : ''}`
+      );
       return;
     }
 
     this.logger.warn(
-      `Force releasing lock for stack: ${stackName}, owner: ${lockInfo.owner}` +
+      `Force releasing lock for stack: ${stackName}${region ? ` (${region})` : ''}, ` +
+        `owner: ${lockInfo.owner}` +
         `${lockInfo.operation ? `, operation: ${lockInfo.operation}` : ''}` +
         `, expired: ${this.isLockExpired(lockInfo)}`
     );
 
-    await this.deleteLock(stackName);
+    await this.deleteLock(stackName, region);
   }
 
   /**
    * Internal method to delete the lock file from S3
    */
-  private async deleteLock(stackName: string): Promise<void> {
-    const key = this.getLockKey(stackName);
+  private async deleteLock(stackName: string, region: string | undefined): Promise<void> {
+    const key = this.getLockKey(stackName, region);
 
     await this.s3Client.send(
       new DeleteObjectCommand({
@@ -312,27 +342,28 @@ export class LockManager {
    */
   async acquireLockWithRetry(
     stackName: string,
+    region: string,
     owner?: string,
     operation?: string,
     maxRetries = 3,
     retryDelay = 2000
   ): Promise<void> {
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
-      const acquired = await this.acquireLock(stackName, owner, operation);
+      const acquired = await this.acquireLock(stackName, region, owner, operation);
 
       if (acquired) {
         return;
       }
 
       // Lock exists and is not expired - show info and possibly retry
-      const lockInfo = await this.getLockInfo(stackName);
+      const lockInfo = await this.getLockInfo(stackName, region);
 
       if (lockInfo) {
         const remainingMs = lockInfo.expiresAt - Date.now();
 
         if (attempt < maxRetries) {
           this.logger.info(
-            `Stack '${stackName}' is locked by ${lockInfo.owner}` +
+            `Stack '${stackName}' (${region}) is locked by ${lockInfo.owner}` +
               `${lockInfo.operation ? ` (operation: ${lockInfo.operation})` : ''}` +
               `. Lock expires in ${this.formatDuration(remainingMs)}.` +
               ` Retrying in ${this.formatDuration(retryDelay)}... (attempt ${attempt + 1}/${maxRetries})`
@@ -344,11 +375,11 @@ export class LockManager {
     }
 
     // Failed to acquire lock after all retries
-    const lockInfo = await this.getLockInfo(stackName);
+    const lockInfo = await this.getLockInfo(stackName, region);
     const expiresIn = lockInfo ? this.formatDuration(lockInfo.expiresAt - Date.now()) : 'unknown';
 
     throw new LockError(
-      `Failed to acquire lock for stack '${stackName}' after ${maxRetries + 1} attempts. ` +
+      `Failed to acquire lock for stack '${stackName}' (${region}) after ${maxRetries + 1} attempts. ` +
         (lockInfo
           ? `Locked by: ${lockInfo.owner}` +
             `${lockInfo.operation ? `, operation: ${lockInfo.operation}` : ''}` +

--- a/src/state/s3-state-backend.ts
+++ b/src/state/s3-state-backend.ts
@@ -8,13 +8,43 @@ import {
   ListObjectsV2Command,
   NoSuchKey,
 } from '@aws-sdk/client-s3';
-import type { StackState } from '../types/state.js';
+import {
+  STATE_SCHEMA_VERSION_CURRENT,
+  STATE_SCHEMA_VERSION_LEGACY,
+  type StackState,
+} from '../types/state.js';
 import type { StateBackendConfig } from '../types/config.js';
 import { getLogger } from '../utils/logger.js';
 import { StateError } from '../utils/error-handler.js';
 
 /**
+ * Identifier of a state record. The legacy layout (`version: 1`) didn't have
+ * region in the S3 key, so reads from the legacy key carry `region:
+ * undefined`.
+ */
+export interface StackStateRef {
+  stackName: string;
+  /** Region of the state. `undefined` ONLY for legacy `version: 1` records. */
+  region?: string;
+}
+
+/**
+ * The `version: 1` legacy state key under the `cdkd/` prefix. Two layers
+ * deep — split off into a constant so call sites can clearly distinguish
+ * "two-segment legacy key" from "three-segment new key".
+ */
+const LEGACY_KEY_DEPTH = 2;
+/** The `version: 2` region-prefixed key. */
+const NEW_KEY_DEPTH = 3;
+
+/**
  * S3-based state backend using conditional writes for optimistic locking
+ *
+ * State keys are region-scoped (`{prefix}/{stackName}/{region}/state.json`)
+ * to prevent two regions of the same stackName from overwriting each other's
+ * state. Legacy `{prefix}/{stackName}/state.json` keys (schema `version: 1`)
+ * are still readable; the next `saveState` for that stack auto-migrates by
+ * writing the new key and deleting the legacy one.
  */
 export class S3StateBackend {
   private logger = getLogger().child('S3StateBackend');
@@ -25,9 +55,17 @@ export class S3StateBackend {
   ) {}
 
   /**
-   * Get the S3 key for a stack's state file
+   * Get the new (region-scoped) S3 key for a stack's state file.
    */
-  private getStateKey(stackName: string): string {
+  private getStateKey(stackName: string, region: string): string {
+    return `${this.config.prefix}/${stackName}/${region}/state.json`;
+  }
+
+  /**
+   * Get the legacy (pre-region-prefix) S3 key for a stack's state file.
+   * Used for backwards-compatible reads and for the migration delete.
+   */
+  private getLegacyStateKey(stackName: string): string {
     return `${this.config.prefix}/${stackName}/state.json`;
   }
 
@@ -57,118 +95,173 @@ export class S3StateBackend {
   }
 
   /**
-   * Check if state exists for a stack
+   * Check if state exists for a stack in the given region.
+   *
+   * Returns true for either layout: the new region-scoped key, or the legacy
+   * key when its embedded `region` matches the requested region. This lets
+   * `cdkd state rm <stack> --region X` and `cdkd destroy <stack>` see legacy
+   * state without forcing a write-through migration first.
    */
-  async stateExists(stackName: string): Promise<boolean> {
-    const key = this.getStateKey(stackName);
+  async stateExists(stackName: string, region: string): Promise<boolean> {
+    const newKey = this.getStateKey(stackName, region);
 
-    try {
-      await this.s3Client.send(
-        new HeadObjectCommand({
-          Bucket: this.config.bucket,
-          Key: key,
-        })
-      );
+    if (await this.headObject(newKey)) {
       return true;
-    } catch (error) {
-      if (error instanceof NoSuchKey || (error as { name: string }).name === 'NotFound') {
-        return false;
-      }
-      throw new StateError(
-        `Failed to check if state exists for stack '${stackName}': ${error instanceof Error ? error.message : String(error)}`,
-        error instanceof Error ? error : undefined
-      );
     }
+
+    return this.legacyMatchesRegion(stackName, region);
   }
 
   /**
-   * Get state for a stack
+   * Get state for a stack, transparently falling back to the legacy key.
    *
-   * Note: S3 returns ETag with surrounding quotes (e.g., "abc123").
-   * We preserve the quotes as they are required for IfMatch conditions.
+   * Lookup order:
+   * 1. `{prefix}/{stackName}/{region}/state.json` (current `version: 2` key).
+   * 2. `{prefix}/{stackName}/state.json` (legacy `version: 1` key) — only
+   *    accepted if its embedded `region` matches the requested region.
+   *
+   * When a legacy hit is returned, `migrationPending` is `true`. Callers that
+   * subsequently `saveState` automatically migrate by writing the new key and
+   * deleting the legacy one (see `saveState`'s `legacyMigration` argument).
+   *
+   * Note: S3 returns ETag with surrounding quotes (e.g., `"abc123"`). We
+   * preserve the quotes — they are required for `IfMatch` conditions.
    */
-  async getState(stackName: string): Promise<{ state: StackState; etag: string } | null> {
-    const key = this.getStateKey(stackName);
+  async getState(
+    stackName: string,
+    region: string
+  ): Promise<{ state: StackState; etag: string; migrationPending?: boolean } | null> {
+    const newKey = this.getStateKey(stackName, region);
 
+    // 1. Try new region-scoped key first.
     try {
-      this.logger.debug(`Getting state for stack: ${stackName}`);
+      this.logger.debug(`Getting state for stack: ${stackName} (${region})`);
 
       const response = await this.s3Client.send(
         new GetObjectCommand({
           Bucket: this.config.bucket,
-          Key: key,
+          Key: newKey,
         })
       );
 
       if (!response.Body) {
-        throw new StateError(`State file for stack '${stackName}' has no body`);
+        throw new StateError(`State file for stack '${stackName}' (${region}) has no body`);
       }
-
       if (!response.ETag) {
-        throw new StateError(`State file for stack '${stackName}' has no ETag`);
+        throw new StateError(`State file for stack '${stackName}' (${region}) has no ETag`);
       }
 
       const bodyString = await response.Body.transformToString();
-      const state = JSON.parse(bodyString) as StackState;
-
-      this.logger.debug(`Retrieved state for stack: ${stackName}, ETag: ${response.ETag}`);
-
-      // ETag is returned with quotes (e.g., "abc123") which is required for IfMatch
-      return {
-        state,
-        etag: response.ETag,
-      };
+      const state = this.parseStateBody(bodyString, stackName);
+      this.logger.debug(`Retrieved state: ${stackName} (${region}), ETag: ${response.ETag}`);
+      return { state, etag: response.ETag };
     } catch (error) {
-      if (error instanceof NoSuchKey || (error as { name: string }).name === 'NoSuchKey') {
-        this.logger.debug(`No existing state for stack: ${stackName}`);
-        return null;
+      if (!isNoSuchKey(error)) {
+        if (error instanceof StateError) throw error;
+        throw new StateError(
+          `Failed to get state for stack '${stackName}' (${region}): ${error instanceof Error ? error.message : String(error)}`,
+          error instanceof Error ? error : undefined
+        );
       }
-
-      if (error instanceof StateError) {
-        throw error;
-      }
-
-      throw new StateError(
-        `Failed to get state for stack '${stackName}': ${error instanceof Error ? error.message : String(error)}`,
-        error instanceof Error ? error : undefined
-      );
+      this.logger.debug(`No state at new key for stack: ${stackName} (${region})`);
     }
+
+    // 2. Fall back to legacy key when it exists AND its region matches.
+    const legacy = await this.tryGetLegacy(stackName, region);
+    if (legacy) {
+      this.logger.warn(
+        `Loaded legacy state for stack '${stackName}' from '${this.getLegacyStateKey(stackName)}'. ` +
+          `It will be migrated to the region-scoped layout on next save.`
+      );
+      return { ...legacy, migrationPending: true };
+    }
+
+    return null;
   }
 
   /**
-   * Save state for a stack with optimistic locking
+   * Save state for a stack with optimistic locking.
+   *
+   * Always writes to the new region-scoped key. The state body is rewritten
+   * with `version: 2` and the supplied region.
+   *
+   * If the caller observed `migrationPending: true` from `getState`, it
+   * should pass the legacy ETag back via `expectedEtag` AND set
+   * `migrateLegacy: true`. After the new key is written successfully, the
+   * legacy key is deleted to complete migration. The legacy delete is a
+   * best-effort follow-up — a failure is logged but does not unwind the new
+   * write.
    *
    * @param stackName Stack name
+   * @param region Target region (load-bearing — part of the S3 key)
    * @param state State to save
-   * @param expectedEtag Expected ETag for optimistic locking (optional for new state).
-   *                     Must include quotes if provided (e.g., "abc123")
-   * @returns New ETag (with quotes, e.g., "abc123")
+   * @param options Optimistic-lock ETag + legacy-migration flag
+   * @returns New ETag (with quotes, e.g., `"abc123"`)
    */
-  async saveState(stackName: string, state: StackState, expectedEtag?: string): Promise<string> {
-    const key = this.getStateKey(stackName);
+  async saveState(
+    stackName: string,
+    region: string,
+    state: StackState,
+    options: { expectedEtag?: string; migrateLegacy?: boolean } = {}
+  ): Promise<string> {
+    const newKey = this.getStateKey(stackName, region);
+    const { expectedEtag, migrateLegacy } = options;
+
+    // Normalize the body: schema version + region are load-bearing on disk.
+    const body: StackState = {
+      ...state,
+      version: STATE_SCHEMA_VERSION_CURRENT,
+      stackName,
+      region,
+    };
 
     try {
       this.logger.debug(
-        `Saving state for stack: ${stackName}${expectedEtag ? `, expected ETag: ${expectedEtag}` : ''}`
+        `Saving state: ${stackName} (${region})${expectedEtag ? `, expected ETag: ${expectedEtag}` : ''}`
       );
 
-      const body = JSON.stringify(state, null, 2);
+      const bodyString = JSON.stringify(body, null, 2);
       const response = await this.s3Client.send(
         new PutObjectCommand({
           Bucket: this.config.bucket,
-          Key: key,
-          Body: body,
-          ContentLength: Buffer.byteLength(body),
+          Key: newKey,
+          Body: bodyString,
+          ContentLength: Buffer.byteLength(bodyString),
           ContentType: 'application/json',
-          ...(expectedEtag && { IfMatch: expectedEtag }),
+          // The legacy ETag is for a different key; only forward it when we're
+          // updating in-place at the new key.
+          ...(!migrateLegacy && expectedEtag && { IfMatch: expectedEtag }),
         })
       );
 
       if (!response.ETag) {
-        throw new StateError(`No ETag returned after saving state for stack '${stackName}'`);
+        throw new StateError(
+          `No ETag returned after saving state for stack '${stackName}' (${region})`
+        );
       }
+      this.logger.debug(`State saved: ${stackName} (${region}), new ETag: ${response.ETag}`);
 
-      this.logger.debug(`State saved for stack: ${stackName}, new ETag: ${response.ETag}`);
+      // Migration tail: best-effort delete of the legacy key. We don't fail
+      // the save if this errors — the new key is the source of truth and a
+      // residual legacy key is recoverable (next call will migrate again).
+      if (migrateLegacy) {
+        try {
+          await this.s3Client.send(
+            new DeleteObjectCommand({
+              Bucket: this.config.bucket,
+              Key: this.getLegacyStateKey(stackName),
+            })
+          );
+          this.logger.info(
+            `Migrated state for stack '${stackName}' to region-scoped layout (${region})`
+          );
+        } catch (deleteError) {
+          this.logger.warn(
+            `Migrated stack '${stackName}' to new key, but failed to delete legacy key: ` +
+              `${deleteError instanceof Error ? deleteError.message : String(deleteError)}`
+          );
+        }
+      }
 
       return response.ETag;
     } catch (error) {
@@ -179,68 +272,120 @@ export class S3StateBackend {
       }
 
       throw new StateError(
-        `Failed to save state for stack '${stackName}': ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to save state for stack '${stackName}' (${region}): ${error instanceof Error ? error.message : String(error)}`,
         error instanceof Error ? error : undefined
       );
     }
   }
 
   /**
-   * Delete state for a stack
+   * Delete state for a stack in the given region.
+   *
+   * Removes both the new key and the legacy key (if present). Legacy removal
+   * is region-conditional: a legacy state file with a different `region`
+   * field is left alone.
    */
-  async deleteState(stackName: string): Promise<void> {
-    const key = this.getStateKey(stackName);
-
+  async deleteState(stackName: string, region: string): Promise<void> {
     try {
-      this.logger.debug(`Deleting state for stack: ${stackName}`);
+      this.logger.debug(`Deleting state: ${stackName} (${region})`);
 
       await this.s3Client.send(
         new DeleteObjectCommand({
           Bucket: this.config.bucket,
-          Key: key,
+          Key: this.getStateKey(stackName, region),
         })
       );
 
-      this.logger.debug(`State deleted for stack: ${stackName}`);
+      // Sweep the legacy key only if it belongs to the same region.
+      if (await this.legacyMatchesRegion(stackName, region)) {
+        await this.s3Client.send(
+          new DeleteObjectCommand({
+            Bucket: this.config.bucket,
+            Key: this.getLegacyStateKey(stackName),
+          })
+        );
+        this.logger.debug(`Deleted legacy state for stack: ${stackName}`);
+      }
+
+      this.logger.debug(`State deleted: ${stackName} (${region})`);
     } catch (error) {
       throw new StateError(
-        `Failed to delete state for stack '${stackName}': ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to delete state for stack '${stackName}' (${region}): ${error instanceof Error ? error.message : String(error)}`,
         error instanceof Error ? error : undefined
       );
     }
   }
 
   /**
-   * List all stacks with state
+   * List all stacks with state in the bucket.
+   *
+   * Returns one `{stackName, region}` pair per state file. Both layouts
+   * are enumerated:
+   *
+   * - `{prefix}/{stackName}/{region}/state.json` (new) — `region` is the
+   *   path segment.
+   * - `{prefix}/{stackName}/state.json` (legacy) — `region` is read from the
+   *   state body when present, otherwise `undefined`.
+   *
+   * Pairs are deduplicated by `(stackName, region)` so a stack mid-migration
+   * shows up exactly once.
    */
-  async listStacks(): Promise<string[]> {
+  async listStacks(): Promise<StackStateRef[]> {
     try {
       this.logger.debug('Listing all stacks');
 
-      const response = await this.s3Client.send(
-        new ListObjectsV2Command({
-          Bucket: this.config.bucket,
-          Prefix: `${this.config.prefix}/`,
-          Delimiter: '/',
-        })
-      );
+      const prefix = `${this.config.prefix}/`;
+      const refs: StackStateRef[] = [];
+      const seen = new Set<string>();
+      let continuationToken: string | undefined;
 
-      if (!response.CommonPrefixes) {
-        return [];
-      }
+      do {
+        const response = await this.s3Client.send(
+          new ListObjectsV2Command({
+            Bucket: this.config.bucket,
+            Prefix: prefix,
+            ...(continuationToken && { ContinuationToken: continuationToken }),
+          })
+        );
 
-      // Extract stack names from prefixes
-      // Prefix format: "{prefix}/{stackName}/"
-      const stackNames = response.CommonPrefixes.map((prefix) => {
-        const prefixStr = prefix.Prefix || '';
-        const parts = prefixStr.split('/');
-        // Get the second-to-last part (stack name)
-        return parts[parts.length - 2];
-      }).filter((name): name is string => Boolean(name));
+        for (const obj of response.Contents ?? []) {
+          const key = obj.Key;
+          if (!key) continue;
+          if (!key.endsWith('/state.json')) continue;
 
-      this.logger.debug(`Found ${stackNames.length} stacks`);
+          const rest = key.slice(prefix.length);
+          const segments = rest.split('/');
 
-      return stackNames;
+          // New key: {stackName}/{region}/state.json
+          if (segments.length === NEW_KEY_DEPTH) {
+            const [stackName, region] = segments;
+            if (!stackName || !region) continue;
+            const dedupeKey = `${stackName}\0${region}`;
+            if (!seen.has(dedupeKey)) {
+              seen.add(dedupeKey);
+              refs.push({ stackName, region });
+            }
+            continue;
+          }
+
+          // Legacy key: {stackName}/state.json
+          if (segments.length === LEGACY_KEY_DEPTH) {
+            const [stackName] = segments;
+            if (!stackName) continue;
+            const region = await this.readLegacyRegion(stackName);
+            const dedupeKey = `${stackName}\0${region ?? ''}`;
+            if (!seen.has(dedupeKey)) {
+              seen.add(dedupeKey);
+              refs.push({ stackName, ...(region ? { region } : {}) });
+            }
+          }
+        }
+
+        continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined;
+      } while (continuationToken);
+
+      this.logger.debug(`Found ${refs.length} stack(s) across regions`);
+      return refs;
     } catch (error) {
       throw new StateError(
         `Failed to list stacks: ${error instanceof Error ? error.message : String(error)}`,
@@ -248,4 +393,146 @@ export class S3StateBackend {
       );
     }
   }
+
+  /**
+   * HeadObject probe — returns true on 200, false on NotFound. Other errors
+   * propagate so we don't accidentally swallow IAM denials.
+   */
+  private async headObject(key: string): Promise<boolean> {
+    try {
+      await this.s3Client.send(
+        new HeadObjectCommand({
+          Bucket: this.config.bucket,
+          Key: key,
+        })
+      );
+      return true;
+    } catch (error) {
+      if (isNoSuchKey(error) || (error as { name?: string }).name === 'NotFound') {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Read the legacy state's `region` field. Used for region matching during
+   * `stateExists` / `deleteState` and for assigning a region to legacy
+   * entries during `listStacks`.
+   */
+  private async readLegacyRegion(stackName: string): Promise<string | undefined> {
+    try {
+      const response = await this.s3Client.send(
+        new GetObjectCommand({
+          Bucket: this.config.bucket,
+          Key: this.getLegacyStateKey(stackName),
+        })
+      );
+      if (!response.Body) return undefined;
+      const bodyString = await response.Body.transformToString();
+      const state = JSON.parse(bodyString) as Partial<StackState>;
+      return typeof state.region === 'string' ? state.region : undefined;
+    } catch (error) {
+      if (isNoSuchKey(error)) return undefined;
+      // Don't fail the whole list on a single bad legacy file — log & skip.
+      this.logger.debug(
+        `Could not read legacy state region for '${stackName}': ${error instanceof Error ? error.message : String(error)}`
+      );
+      return undefined;
+    }
+  }
+
+  private async legacyMatchesRegion(stackName: string, region: string): Promise<boolean> {
+    const legacyRegion = await this.readLegacyRegion(stackName);
+    return legacyRegion === region;
+  }
+
+  /**
+   * Try to read the legacy `version: 1` state. Returns null when the legacy
+   * key is missing or its embedded region does not match the caller's region.
+   */
+  private async tryGetLegacy(
+    stackName: string,
+    region: string
+  ): Promise<{ state: StackState; etag: string } | null> {
+    try {
+      const response = await this.s3Client.send(
+        new GetObjectCommand({
+          Bucket: this.config.bucket,
+          Key: this.getLegacyStateKey(stackName),
+        })
+      );
+
+      if (!response.Body || !response.ETag) {
+        return null;
+      }
+
+      const bodyString = await response.Body.transformToString();
+      const state = this.parseStateBody(bodyString, stackName);
+
+      // Region gate: the same `stackName` may have lived in a different region
+      // before the user changed `env.region`. We do NOT want to silently load
+      // that record for a different target region — that's the silent-failure
+      // bug PR 1 fixes.
+      if (state.region && state.region !== region) {
+        this.logger.debug(
+          `Legacy state for stack '${stackName}' has region '${state.region}', ` +
+            `not '${region}' — skipping legacy fallback.`
+        );
+        return null;
+      }
+
+      return { state, etag: response.ETag };
+    } catch (error) {
+      if (isNoSuchKey(error)) return null;
+      throw new StateError(
+        `Failed to get legacy state for stack '${stackName}': ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  /**
+   * Parse a state body and validate the schema version. Future-proofs against
+   * a binary that predates schema version `N` reading a `version: N+1` blob:
+   * the old binary would otherwise treat unknown fields as defaults and
+   * silently lose data on the next save.
+   */
+  private parseStateBody(bodyString: string, stackName: string): StackState {
+    let parsed: StackState;
+    try {
+      parsed = JSON.parse(bodyString) as StackState;
+    } catch (error) {
+      throw new StateError(
+        `State file for stack '${stackName}' is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error : undefined
+      );
+    }
+
+    const v = parsed.version;
+    if (
+      v !== STATE_SCHEMA_VERSION_LEGACY &&
+      v !== STATE_SCHEMA_VERSION_CURRENT &&
+      v !== undefined
+    ) {
+      throw new StateError(
+        `Unsupported state schema version ${String(v)} for stack '${stackName}'. ` +
+          `This cdkd binary supports versions ${String(STATE_SCHEMA_VERSION_LEGACY)} and ${String(STATE_SCHEMA_VERSION_CURRENT)}. ` +
+          `Upgrade cdkd to a version that supports schema ${String(v)}.`
+      );
+    }
+
+    return parsed;
+  }
+}
+
+/**
+ * Treat S3 NoSuchKey-equivalents uniformly. The SDK throws `NoSuchKey` from
+ * `GetObject` and `{name: 'NoSuchKey'}` from low-level callsites; HeadObject
+ * raises `{name: 'NotFound'}` instead.
+ */
+function isNoSuchKey(error: unknown): boolean {
+  if (error instanceof NoSuchKey) return true;
+  const name = (error as { name?: string } | null)?.name;
+  return name === 'NoSuchKey';
 }

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,14 +1,34 @@
 /**
+ * Schema versions for cdkd state.json.
+ *
+ * - 1 — legacy layout: `s3://{bucket}/cdkd/{stackName}/state.json` (pre PR 1).
+ * - 2 — region-prefixed layout: `s3://{bucket}/cdkd/{stackName}/{region}/state.json`.
+ *
+ * cdkd readers handle both. Writers always emit `version: 2`. An older cdkd
+ * binary that only knows `version: 1` will fail with a clear error when it
+ * encounters `version: 2`, rather than silently mishandling the new format.
+ */
+export type StateSchemaVersion = 1 | 2;
+export const STATE_SCHEMA_VERSION_LEGACY: StateSchemaVersion = 1;
+export const STATE_SCHEMA_VERSION_CURRENT: StateSchemaVersion = 2;
+
+/**
  * Stack state stored in S3
  */
 export interface StackState {
-  /** Schema version */
-  version: number;
+  /**
+   * Schema version. `1` is the legacy unversioned-key layout, `2` is the
+   * region-prefixed layout. New writes always use the current version.
+   */
+  version: StateSchemaVersion;
 
   /** Stack name */
   stackName: string;
 
-  /** Target region for this stack (for cross-region support) */
+  /**
+   * Target region for this stack. Required on `version: 2` since the region
+   * is part of the S3 key. Optional on `version: 1` for backwards compat.
+   */
   region?: string;
 
   /** Resources in the stack */

--- a/tests/integration/legacy-state-migration/README.md
+++ b/tests/integration/legacy-state-migration/README.md
@@ -1,0 +1,44 @@
+# Legacy state migration integration test
+
+Verifies that cdkd auto-migrates a pre-PR-1 (`version: 1`) state file from the
+legacy key (`cdkd/{stackName}/state.json`) to the new region-prefixed key
+(`cdkd/{stackName}/{region}/state.json`) on the next write, and that the
+legacy key is removed afterward.
+
+## Manual test plan
+
+```bash
+export STATE_BUCKET="<your bucket>"
+export AWS_REGION="us-east-1"
+STACK="CdkdLegacyMigrationExample"
+
+# 1. Seed a legacy version: 1 state at the legacy key.
+cat >/tmp/legacy.json <<EOF
+{
+  "version": 1,
+  "stackName": "$STACK",
+  "region": "$AWS_REGION",
+  "resources": {},
+  "outputs": {},
+  "lastModified": $(date +%s)000
+}
+EOF
+aws s3 cp /tmp/legacy.json "s3://$STATE_BUCKET/cdkd/$STACK/state.json" \
+  --content-type application/json
+
+# 2. Deploy the fixture (will read the legacy state and write the new key).
+node ../../../dist/cli.js deploy \
+  --app "npx ts-node --prefer-ts-exts bin/app.ts" \
+  --state-bucket "$STATE_BUCKET" --region "$AWS_REGION"
+
+# 3. Confirm the migration happened:
+aws s3 ls "s3://$STATE_BUCKET/cdkd/$STACK/"
+# Expected: only `${AWS_REGION}/` shows up. The bare `state.json` is gone.
+
+# 4. Clean up.
+node ../../../dist/cli.js destroy "$STACK" --yes \
+  --state-bucket "$STATE_BUCKET" --region "$AWS_REGION"
+```
+
+The shared `scripts/verify-bc.sh PR-1` driver runs an equivalent sequence
+without requiring a real CDK app deploy.

--- a/tests/integration/legacy-state-migration/bin/app.ts
+++ b/tests/integration/legacy-state-migration/bin/app.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { LegacyMigrationStack } from '../lib/legacy-migration-stack';
+
+const app = new cdk.App();
+
+new LegacyMigrationStack(app, 'CdkdLegacyMigrationExample', {
+  description:
+    'Single-resource fixture stack used by tests/integration/legacy-state-migration to ' +
+    'verify auto-migration of a pre-PR-1 state.json into the region-prefixed key layout.',
+});

--- a/tests/integration/legacy-state-migration/cdk.json
+++ b/tests/integration/legacy-state-migration/cdk.json
@@ -1,0 +1,8 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/app.ts",
+  "context": {
+    "cdkd": {
+      "stateBucket": "cdkd-state-test"
+    }
+  }
+}

--- a/tests/integration/legacy-state-migration/lib/legacy-migration-stack.ts
+++ b/tests/integration/legacy-state-migration/lib/legacy-migration-stack.ts
@@ -1,0 +1,27 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+
+/**
+ * Minimal stack for the legacy-state-migration integration test.
+ *
+ * The test seeds a `version: 1` state.json at the legacy
+ * `cdkd/{stackName}/state.json` key in S3, then runs `cdkd deploy`. cdkd is
+ * expected to (a) read the legacy state, (b) write the new state at
+ * `cdkd/{stackName}/{region}/state.json` with `version: 2`, and (c) delete
+ * the legacy key — all while still successfully deploying this stack.
+ *
+ * A single SSM Parameter is enough: it's free, fast to create/destroy, and
+ * doesn't require special IAM beyond what the integ harness already grants.
+ */
+export class LegacyMigrationStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    new ssm.StringParameter(this, 'Marker', {
+      parameterName: `${this.stackName}-marker`,
+      stringValue: 'legacy-state-migration-fixture',
+      description: 'Sentinel parameter used by the legacy-state-migration integ test',
+    });
+  }
+}

--- a/tests/integration/legacy-state-migration/package.json
+++ b/tests/integration/legacy-state-migration/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkd-integ-legacy-state-migration",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Verifies cdkd auto-migrates a pre-PR-1 state.json into the region-prefixed key layout (PR 1).",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0",
+    "ts-node": "^10.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/tests/integration/legacy-state-migration/tsconfig.json
+++ b/tests/integration/legacy-state-migration/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "exclude": ["node_modules", "cdk.out"]
+}

--- a/tests/integration/multi-region-same-stack/README.md
+++ b/tests/integration/multi-region-same-stack/README.md
@@ -1,0 +1,46 @@
+# Multi-region same-name integration test
+
+Verifies that the same `stackName` deployed to two different regions produces
+two independent state files at the new region-prefixed key layout
+(`cdkd/{stackName}/{region}/state.json`). This exercises the silent-failure
+fix from PR 1: a `region` change in CDK no longer overwrites the prior
+region's state.
+
+## Manual test plan
+
+```bash
+export STATE_BUCKET="<your bucket>"
+STACK="CdkdMultiRegionExample"
+
+# 1. Deploy to us-west-2.
+CDKD_INTEG_REGION=us-west-2 \
+  node ../../../dist/cli.js deploy "$STACK" \
+  --app "npx ts-node --prefer-ts-exts bin/app.ts" \
+  --state-bucket "$STATE_BUCKET" --region us-west-2
+
+# 2. Deploy to us-east-1 (same stack name).
+CDKD_INTEG_REGION=us-east-1 \
+  node ../../../dist/cli.js deploy "$STACK" \
+  --app "npx ts-node --prefer-ts-exts bin/app.ts" \
+  --state-bucket "$STATE_BUCKET" --region us-east-1
+
+# 3. Confirm both state files coexist.
+aws s3 ls "s3://$STATE_BUCKET/cdkd/$STACK/"
+# Expected: us-east-1/ and us-west-2/ both listed.
+
+node ../../../dist/cli.js state list --state-bucket "$STATE_BUCKET"
+# Expected: two rows
+#   CdkdMultiRegionExample (us-east-1)
+#   CdkdMultiRegionExample (us-west-2)
+
+# 4. Clean up both regions.
+CDKD_INTEG_REGION=us-west-2 \
+  node ../../../dist/cli.js destroy "$STACK" --yes \
+  --app "npx ts-node --prefer-ts-exts bin/app.ts" \
+  --state-bucket "$STATE_BUCKET" --region us-west-2
+
+CDKD_INTEG_REGION=us-east-1 \
+  node ../../../dist/cli.js destroy "$STACK" --yes \
+  --app "npx ts-node --prefer-ts-exts bin/app.ts" \
+  --state-bucket "$STATE_BUCKET" --region us-east-1
+```

--- a/tests/integration/multi-region-same-stack/bin/app.ts
+++ b/tests/integration/multi-region-same-stack/bin/app.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { MultiRegionStack } from '../lib/multi-region-stack';
+
+const app = new cdk.App();
+
+// Region is selected via CDKD_INTEG_REGION at deploy time so the same stack
+// name can be re-targeted to a different region on the second deploy run —
+// which is what we're trying to exercise. CDK falls back to env-agnostic
+// stacks when no region is set, but PR 1's region check requires a concrete
+// region in state, so we always resolve one here.
+const region =
+  process.env.CDKD_INTEG_REGION ??
+  process.env.CDK_DEFAULT_REGION ??
+  process.env.AWS_REGION ??
+  'us-east-1';
+
+new MultiRegionStack(app, 'CdkdMultiRegionExample', {
+  description:
+    'Single-resource fixture stack used by tests/integration/multi-region-same-stack to ' +
+    'verify that the same stackName deployed to two regions yields two independent state files.',
+  env: { region },
+});

--- a/tests/integration/multi-region-same-stack/cdk.json
+++ b/tests/integration/multi-region-same-stack/cdk.json
@@ -1,0 +1,8 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/app.ts",
+  "context": {
+    "cdkd": {
+      "stateBucket": "cdkd-state-test"
+    }
+  }
+}

--- a/tests/integration/multi-region-same-stack/lib/multi-region-stack.ts
+++ b/tests/integration/multi-region-same-stack/lib/multi-region-stack.ts
@@ -1,0 +1,27 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+
+/**
+ * Minimal stack for the multi-region-same-stack integration test.
+ *
+ * The test deploys this stack to two different regions back-to-back (same
+ * stackName, different `env.region`). The SSM Parameter is region-local, so
+ * each deploy creates an entirely separate AWS resource. After both deploys,
+ * `cdkd state list` should show two rows for `CdkdMultiRegionExample`, one
+ * per region — confirming PR 1's region-prefixed state key keeps the two
+ * apart instead of overwriting one with the other (the silent-failure bug
+ * that motivated PR 1).
+ */
+export class MultiRegionStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    new ssm.StringParameter(this, 'Marker', {
+      parameterName: `${this.stackName}-marker`,
+      stringValue: `multi-region-fixture-${this.region}`,
+      description:
+        'Sentinel parameter; one copy per region, used by the multi-region-same-stack integ test',
+    });
+  }
+}

--- a/tests/integration/multi-region-same-stack/package.json
+++ b/tests/integration/multi-region-same-stack/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkd-integ-multi-region-same-stack",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Verifies the same stackName deployed to two regions yields two independent state files (PR 1).",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0",
+    "ts-node": "^10.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/tests/integration/multi-region-same-stack/tsconfig.json
+++ b/tests/integration/multi-region-same-stack/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "exclude": ["node_modules", "cdk.out"]
+}

--- a/tests/unit/cli/state-list.test.ts
+++ b/tests/unit/cli/state-list.test.ts
@@ -39,11 +39,13 @@ vi.mock('../../../src/utils/aws-clients.ts', () => {
 });
 
 // Mock S3StateBackend.
-const mockListStacks = vi.fn<() => Promise<string[]>>();
+const mockListStacks =
+  vi.fn<() => Promise<Array<{ stackName: string; region?: string }>>>();
 const mockGetState =
   vi.fn<
     (
-      stackName: string
+      stackName: string,
+      region: string
     ) => Promise<{ state: { resources: Record<string, unknown>; lastModified: number } } | null>
   >();
 const mockVerifyBucketExists = vi.fn<() => Promise<void>>();
@@ -56,7 +58,7 @@ vi.mock('../../../src/state/s3-state-backend.js', () => ({
 }));
 
 // Mock LockManager.
-const mockIsLocked = vi.fn<(stackName: string) => Promise<boolean>>();
+const mockIsLocked = vi.fn<(stackName: string, region?: string) => Promise<boolean>>();
 vi.mock('../../../src/state/lock-manager.js', () => ({
   LockManager: vi.fn().mockImplementation(() => ({
     isLocked: mockIsLocked,
@@ -118,26 +120,63 @@ describe('cdkd state list', () => {
     expect(out).toBe('');
   });
 
-  it('prints stack names sorted alphabetically, one per line', async () => {
-    mockListStacks.mockResolvedValue(['Charlie', 'alpha', 'Bravo']);
+  it('prints "Stack (region)" sorted alphabetically, one per line', async () => {
+    mockListStacks.mockResolvedValue([
+      { stackName: 'Charlie', region: 'us-east-1' },
+      { stackName: 'alpha', region: 'us-west-2' },
+      { stackName: 'Bravo', region: 'eu-west-1' },
+    ]);
     const out = await runStateList(['list']);
-    expect(out).toBe('Bravo\nCharlie\nalpha\n');
+    expect(out).toBe('Bravo (eu-west-1)\nCharlie (us-east-1)\nalpha (us-west-2)\n');
+  });
+
+  it('renders the same stack name in two regions as two rows', async () => {
+    // The whole point of region-prefixed state keys: a stack name can have
+    // independent state per region. `state list` should surface that.
+    mockListStacks.mockResolvedValue([
+      { stackName: 'MyStack', region: 'us-west-2' },
+      { stackName: 'MyStack', region: 'us-east-1' },
+    ]);
+    const out = await runStateList(['list']);
+    expect(out).toBe('MyStack (us-east-1)\nMyStack (us-west-2)\n');
+  });
+
+  it('renders legacy version-1 records (no region) as plain stack name', async () => {
+    mockListStacks.mockResolvedValue([
+      { stackName: 'LegacyStack' /* region: undefined */ },
+    ]);
+    const out = await runStateList(['list']);
+    expect(out).toBe('LegacyStack\n');
   });
 
   it('supports the `ls` alias', async () => {
-    mockListStacks.mockResolvedValue(['One', 'Two']);
+    mockListStacks.mockResolvedValue([
+      { stackName: 'One', region: 'us-east-1' },
+      { stackName: 'Two', region: 'us-east-1' },
+    ]);
     const out = await runStateList(['ls']);
-    expect(out).toBe('One\nTwo\n');
+    expect(out).toBe('One (us-east-1)\nTwo (us-east-1)\n');
   });
 
-  it('emits a JSON array of stack names with --json', async () => {
-    mockListStacks.mockResolvedValue(['B', 'a', 'C']);
+  it('emits a JSON array of {stackName, region} with --json', async () => {
+    mockListStacks.mockResolvedValue([
+      { stackName: 'B', region: 'us-east-1' },
+      { stackName: 'a', region: 'us-west-2' },
+      { stackName: 'C' /* legacy */ },
+    ]);
     const out = await runStateList(['list', '--json']);
-    expect(JSON.parse(out)).toEqual(['B', 'C', 'a']);
+    expect(JSON.parse(out)).toEqual([
+      { stackName: 'B', region: 'us-east-1' },
+      { stackName: 'C', region: null },
+      { stackName: 'a', region: 'us-west-2' },
+    ]);
   });
 
   it('emits long human-readable details with --long', async () => {
-    mockListStacks.mockResolvedValue(['StackA', 'StackB']);
+    mockListStacks.mockResolvedValue([
+      { stackName: 'StackA', region: 'us-east-1' },
+      { stackName: 'StackB', region: 'us-west-2' },
+    ]);
     mockGetState.mockImplementation(async (name) => {
       if (name === 'StackA') {
         return {
@@ -158,18 +197,20 @@ describe('cdkd state list', () => {
 
     const out = await runStateList(['list', '--long']);
 
-    expect(out).toContain('StackA');
+    expect(out).toContain('StackA (us-east-1)');
+    expect(out).toContain('  Region: us-east-1');
     expect(out).toContain('  Resources: 3');
     expect(out).toContain('  Last Modified: 2026-04-29T10:23:45.000Z');
     expect(out).toContain('  Lock: unlocked');
-    expect(out).toContain('StackB');
+    expect(out).toContain('StackB (us-west-2)');
+    expect(out).toContain('  Region: us-west-2');
     expect(out).toContain('  Resources: 0');
     expect(out).toContain('  Last Modified: 2026-04-25T08:00:00.000Z');
     expect(out).toContain('  Lock: locked');
   });
 
   it('handles missing state by reporting zero resources and unknown last-modified', async () => {
-    mockListStacks.mockResolvedValue(['Orphan']);
+    mockListStacks.mockResolvedValue([{ stackName: 'Orphan', region: 'us-east-1' }]);
     mockGetState.mockResolvedValue(null);
     mockIsLocked.mockResolvedValue(false);
 
@@ -182,7 +223,7 @@ describe('cdkd state list', () => {
   });
 
   it('emits a JSON array of details when --long --json is combined', async () => {
-    mockListStacks.mockResolvedValue(['X']);
+    mockListStacks.mockResolvedValue([{ stackName: 'X', region: 'us-east-1' }]);
     mockGetState.mockResolvedValue({
       state: {
         resources: { R1: {}, R2: {} },
@@ -197,6 +238,7 @@ describe('cdkd state list', () => {
     expect(parsed).toEqual([
       {
         stackName: 'X',
+        region: 'us-east-1',
         resourceCount: 2,
         lastModified: '2026-01-01T00:00:00.000Z',
         locked: true,
@@ -204,8 +246,11 @@ describe('cdkd state list', () => {
     ]);
   });
 
-  it('fetches state and lock status for each stack', async () => {
-    mockListStacks.mockResolvedValue(['One', 'Two']);
+  it('fetches state and lock status for each (stackName, region) pair', async () => {
+    mockListStacks.mockResolvedValue([
+      { stackName: 'One', region: 'us-east-1' },
+      { stackName: 'Two', region: 'us-west-2' },
+    ]);
     mockGetState.mockResolvedValue({
       state: { resources: {}, lastModified: 0 },
     });
@@ -213,9 +258,9 @@ describe('cdkd state list', () => {
 
     await runStateList(['list', '--long']);
 
-    expect(mockGetState).toHaveBeenCalledWith('One');
-    expect(mockGetState).toHaveBeenCalledWith('Two');
-    expect(mockIsLocked).toHaveBeenCalledWith('One');
-    expect(mockIsLocked).toHaveBeenCalledWith('Two');
+    expect(mockGetState).toHaveBeenCalledWith('One', 'us-east-1');
+    expect(mockGetState).toHaveBeenCalledWith('Two', 'us-west-2');
+    expect(mockIsLocked).toHaveBeenCalledWith('One', 'us-east-1');
+    expect(mockIsLocked).toHaveBeenCalledWith('Two', 'us-west-2');
   });
 });

--- a/tests/unit/cli/state-resources.test.ts
+++ b/tests/unit/cli/state-resources.test.ts
@@ -36,11 +36,15 @@ vi.mock('../../../src/utils/aws-clients.ts', () => {
   };
 });
 
-const mockGetState = vi.fn<(stackName: string) => Promise<{ state: StackState } | null>>();
+const mockGetState =
+  vi.fn<(stackName: string, region: string) => Promise<{ state: StackState } | null>>();
+const mockListStacks =
+  vi.fn<() => Promise<Array<{ stackName: string; region?: string }>>>();
 const mockVerifyBucketExists = vi.fn<() => Promise<void>>();
 vi.mock('../../../src/state/s3-state-backend.js', () => ({
   S3StateBackend: vi.fn().mockImplementation(() => ({
     getState: mockGetState,
+    listStacks: mockListStacks,
     verifyBucketExists: mockVerifyBucketExists,
   })),
 }));
@@ -95,8 +99,9 @@ function makeResource(overrides: Partial<ResourceState> = {}): ResourceState {
 function makeState(resources: Record<string, ResourceState>): { state: StackState } {
   return {
     state: {
-      version: 1,
+      version: 2,
       stackName: 'TestStack',
+      region: 'us-east-1',
       resources,
       outputs: {},
       lastModified: 0,
@@ -104,11 +109,24 @@ function makeState(resources: Record<string, ResourceState>): { state: StackStat
   };
 }
 
+/**
+ * Default `listStacks` response used by every `state resources` test.
+ *
+ * The new flow disambiguates the stack name via `listStacks` before reading
+ * state, so every test needs the stack to appear at least once. Tests that
+ * exercise the missing-state path mock `listStacks` to return an empty list
+ * explicitly.
+ */
+function defaultListResponse(stackName = 'TestStack', region = 'us-east-1') {
+  return [{ stackName, region }];
+}
+
 describe('cdkd state resources', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     mockGetState.mockReset();
+    mockListStacks.mockReset();
     mockVerifyBucketExists.mockReset();
     mockVerifyBucketExists.mockResolvedValue();
     errorSpy.mockReset();
@@ -123,6 +141,9 @@ describe('cdkd state resources', () => {
   });
 
   it('reports a clear error message when the stack has no state', async () => {
+    // listStacks: stack does not appear → resolveSingleRegion throws with the
+    // "No state found" error before we even get to getState.
+    mockListStacks.mockResolvedValue([]);
     mockGetState.mockResolvedValue(null);
 
     await expect(runStateResources(['resources', 'Missing'])).rejects.toThrow();
@@ -133,19 +154,44 @@ describe('cdkd state resources', () => {
     expect(message).toMatch(/No state found for stack 'Missing'/);
   });
 
+  it('errors when the stack has multiple regions and --stack-region is missing', async () => {
+    mockListStacks.mockResolvedValue([
+      { stackName: 'MyStack', region: 'us-west-2' },
+      { stackName: 'MyStack', region: 'us-east-1' },
+    ]);
+
+    await expect(runStateResources(['resources', 'MyStack'])).rejects.toThrow();
+    const message = String(errorSpy.mock.calls[0]?.[0] ?? '');
+    expect(message).toMatch(/multiple regions: us-west-2, us-east-1/);
+    expect(message).toMatch(/--region/);
+  });
+
+  it('disambiguates with --stack-region when a stack has multiple regions', async () => {
+    mockListStacks.mockResolvedValue([
+      { stackName: 'MyStack', region: 'us-west-2' },
+      { stackName: 'MyStack', region: 'us-east-1' },
+    ]);
+    mockGetState.mockResolvedValue(makeState({}));
+    await runStateResources(['resources', 'MyStack', '--stack-region', 'us-east-1']);
+    expect(mockGetState).toHaveBeenCalledWith('MyStack', 'us-east-1');
+  });
+
   it('emits nothing when the stack has zero resources (default)', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('Empty'));
     mockGetState.mockResolvedValue(makeState({}));
     const out = await runStateResources(['resources', 'Empty']);
     expect(out).toBe('');
   });
 
   it('emits an empty JSON array when --json is set on a zero-resource stack', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('Empty'));
     mockGetState.mockResolvedValue(makeState({}));
     const out = await runStateResources(['resources', 'Empty', '--json']);
     expect(JSON.parse(out)).toEqual([]);
   });
 
   it('prints aligned columns sorted by logical id by default', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('StackA'));
     mockGetState.mockResolvedValue(
       makeState({
         ZebraBucket: makeResource({
@@ -170,6 +216,7 @@ describe('cdkd state resources', () => {
   });
 
   it('emits a long human-readable block per resource with --long', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('StackA'));
     mockGetState.mockResolvedValue(
       makeState({
         MyFunction: makeResource({
@@ -194,6 +241,7 @@ describe('cdkd state resources', () => {
   });
 
   it('reports `(none)` for resources with no dependencies / no attributes under --long', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('StackA'));
     mockGetState.mockResolvedValue(
       makeState({
         Bare: makeResource({ resourceType: 'AWS::S3::Bucket', physicalId: 'bare-bucket' }),
@@ -207,6 +255,7 @@ describe('cdkd state resources', () => {
   });
 
   it('renders structured attribute values as inline JSON under --long', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('StackA'));
     mockGetState.mockResolvedValue(
       makeState({
         Table: makeResource({
@@ -227,6 +276,7 @@ describe('cdkd state resources', () => {
   });
 
   it('emits a JSON array of full resource details with --json', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('StackA'));
     mockGetState.mockResolvedValue(
       makeState({
         Beta: makeResource({
@@ -261,6 +311,7 @@ describe('cdkd state resources', () => {
   });
 
   it('does not leak `properties` into any output mode', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('StackA'));
     mockGetState.mockResolvedValue(
       makeState({
         Hidden: makeResource({

--- a/tests/unit/cli/state-rm.test.ts
+++ b/tests/unit/cli/state-rm.test.ts
@@ -36,19 +36,22 @@ vi.mock('../../../src/utils/aws-clients.ts', () => {
   };
 });
 
-const mockStateExists = vi.fn<(stackName: string) => Promise<boolean>>();
-const mockDeleteState = vi.fn<(stackName: string) => Promise<void>>();
+const mockStateExists = vi.fn<(stackName: string, region: string) => Promise<boolean>>();
+const mockDeleteState = vi.fn<(stackName: string, region: string) => Promise<void>>();
+const mockListStacks =
+  vi.fn<() => Promise<Array<{ stackName: string; region?: string }>>>();
 const mockVerifyBucketExists = vi.fn<() => Promise<void>>();
 vi.mock('../../../src/state/s3-state-backend.js', () => ({
   S3StateBackend: vi.fn().mockImplementation(() => ({
     stateExists: mockStateExists,
     deleteState: mockDeleteState,
+    listStacks: mockListStacks,
     verifyBucketExists: mockVerifyBucketExists,
   })),
 }));
 
-const mockIsLocked = vi.fn<(stackName: string) => Promise<boolean>>();
-const mockForceReleaseLock = vi.fn<(stackName: string) => Promise<void>>();
+const mockIsLocked = vi.fn<(stackName: string, region?: string) => Promise<boolean>>();
+const mockForceReleaseLock = vi.fn<(stackName: string, region?: string) => Promise<void>>();
 vi.mock('../../../src/state/lock-manager.js', () => ({
   LockManager: vi.fn().mockImplementation(() => ({
     isLocked: mockIsLocked,
@@ -103,6 +106,7 @@ describe('cdkd state rm', () => {
     mockStateExists.mockReset();
     mockDeleteState.mockReset();
     mockDeleteState.mockResolvedValue();
+    mockListStacks.mockReset();
     mockIsLocked.mockReset();
     mockForceReleaseLock.mockReset();
     mockForceReleaseLock.mockResolvedValue();
@@ -123,7 +127,9 @@ describe('cdkd state rm', () => {
   });
 
   it('skips a stack whose state does not exist (idempotent)', async () => {
-    mockStateExists.mockResolvedValue(false);
+    // listStacks does not include the requested stack — `state rm` skips
+    // (no error: idempotent).
+    mockListStacks.mockResolvedValue([]);
 
     await runStateRm(['rm', 'Missing', '--yes']);
 
@@ -133,42 +139,70 @@ describe('cdkd state rm', () => {
   });
 
   it('removes state.json AND lock.json when --yes skips the prompt', async () => {
-    mockStateExists.mockResolvedValue(true);
+    mockListStacks.mockResolvedValue([{ stackName: 'MyStack', region: 'us-east-1' }]);
     mockIsLocked.mockResolvedValue(false);
 
     await runStateRm(['rm', 'MyStack', '--yes']);
 
     expect(readlineQuestion).not.toHaveBeenCalled();
-    expect(mockDeleteState).toHaveBeenCalledWith('MyStack');
-    expect(mockForceReleaseLock).toHaveBeenCalledWith('MyStack');
+    expect(mockDeleteState).toHaveBeenCalledWith('MyStack', 'us-east-1');
+    expect(mockForceReleaseLock).toHaveBeenCalledWith('MyStack', 'us-east-1');
+  });
+
+  it('removes both regions when a stack has state in multiple regions (no --stack-region)', async () => {
+    mockListStacks.mockResolvedValue([
+      { stackName: 'MyStack', region: 'us-east-1' },
+      { stackName: 'MyStack', region: 'us-west-2' },
+    ]);
+    mockIsLocked.mockResolvedValue(false);
+
+    await runStateRm(['rm', 'MyStack', '--yes']);
+
+    expect(mockDeleteState).toHaveBeenCalledWith('MyStack', 'us-east-1');
+    expect(mockDeleteState).toHaveBeenCalledWith('MyStack', 'us-west-2');
+    expect(mockForceReleaseLock).toHaveBeenCalledWith('MyStack', 'us-east-1');
+    expect(mockForceReleaseLock).toHaveBeenCalledWith('MyStack', 'us-west-2');
+  });
+
+  it('scopes removal with --stack-region <region>', async () => {
+    mockListStacks.mockResolvedValue([
+      { stackName: 'MyStack', region: 'us-east-1' },
+      { stackName: 'MyStack', region: 'us-west-2' },
+    ]);
+    mockIsLocked.mockResolvedValue(false);
+
+    await runStateRm(['rm', 'MyStack', '--yes', '--stack-region', 'us-east-1']);
+
+    expect(mockDeleteState).toHaveBeenCalledWith('MyStack', 'us-east-1');
+    expect(mockDeleteState).not.toHaveBeenCalledWith('MyStack', 'us-west-2');
   });
 
   it('refuses to remove a locked stack without --force', async () => {
-    mockStateExists.mockResolvedValue(true);
+    mockListStacks.mockResolvedValue([{ stackName: 'LockedStack', region: 'us-east-1' }]);
     mockIsLocked.mockResolvedValue(true);
 
     await expect(runStateRm(['rm', 'LockedStack', '--yes'])).rejects.toThrow();
 
     expect(exitSpy).toHaveBeenCalledWith(1);
     const message = String(errorSpy.mock.calls[0]?.[0] ?? '');
-    expect(message).toMatch(/Stack 'LockedStack' is locked/);
+    expect(message).toMatch(/Stack 'LockedStack' \(us-east-1\) is locked/);
     expect(mockDeleteState).not.toHaveBeenCalled();
   });
 
   it('removes a locked stack when --force is set (and skips lock check)', async () => {
-    mockStateExists.mockResolvedValue(true);
+    mockListStacks.mockResolvedValue([{ stackName: 'LockedStack', region: 'us-east-1' }]);
 
     await runStateRm(['rm', 'LockedStack', '--force']);
 
     // --force bypasses both the lock check and the prompt.
     expect(mockIsLocked).not.toHaveBeenCalled();
     expect(readlineQuestion).not.toHaveBeenCalled();
-    expect(mockDeleteState).toHaveBeenCalledWith('LockedStack');
-    expect(mockForceReleaseLock).toHaveBeenCalledWith('LockedStack');
+    expect(mockDeleteState).toHaveBeenCalledWith('LockedStack', 'us-east-1');
+    expect(mockForceReleaseLock).toHaveBeenCalledWith('LockedStack', 'us-east-1');
   });
 
   it('prompts and deletes when the user answers `y`', async () => {
-    mockStateExists.mockResolvedValue(true);
+    mockListStacks.mockResolvedValue([{ stackName: 'MyStack', region: 'us-east-1' }]);
     mockIsLocked.mockResolvedValue(false);
     readlineQuestion.mockResolvedValue('y');
 
@@ -177,11 +211,11 @@ describe('cdkd state rm', () => {
     expect(readlineQuestion).toHaveBeenCalledTimes(1);
     expect(out).toMatch(/AWS resources will NOT be deleted/);
     expect(out).toMatch(/Use 'cdkd destroy MyStack'/);
-    expect(mockDeleteState).toHaveBeenCalledWith('MyStack');
+    expect(mockDeleteState).toHaveBeenCalledWith('MyStack', 'us-east-1');
   });
 
   it('prompts and cancels when the user answers `n` (or empty)', async () => {
-    mockStateExists.mockResolvedValue(true);
+    mockListStacks.mockResolvedValue([{ stackName: 'MyStack', region: 'us-east-1' }]);
     mockIsLocked.mockResolvedValue(false);
     readlineQuestion.mockResolvedValue('');
 
@@ -195,26 +229,29 @@ describe('cdkd state rm', () => {
   });
 
   it('accepts `yes` (full word) as confirmation, case-insensitively', async () => {
-    mockStateExists.mockResolvedValue(true);
+    mockListStacks.mockResolvedValue([{ stackName: 'MyStack', region: 'us-east-1' }]);
     mockIsLocked.mockResolvedValue(false);
     readlineQuestion.mockResolvedValue('YES');
 
     await runStateRm(['rm', 'MyStack']);
 
-    expect(mockDeleteState).toHaveBeenCalledWith('MyStack');
+    expect(mockDeleteState).toHaveBeenCalledWith('MyStack', 'us-east-1');
   });
 
   it('iterates over multiple stacks, each with its own confirmation', async () => {
-    mockStateExists.mockResolvedValue(true);
+    mockListStacks.mockResolvedValue([
+      { stackName: 'A', region: 'us-east-1' },
+      { stackName: 'B', region: 'us-east-1' },
+    ]);
     mockIsLocked.mockResolvedValue(false);
     readlineQuestion.mockResolvedValueOnce('y').mockResolvedValueOnce('n');
 
     await runStateRm(['rm', 'A', 'B']);
 
     expect(readlineQuestion).toHaveBeenCalledTimes(2);
-    expect(mockDeleteState).toHaveBeenCalledWith('A');
-    expect(mockDeleteState).not.toHaveBeenCalledWith('B');
-    expect(mockForceReleaseLock).toHaveBeenCalledWith('A');
-    expect(mockForceReleaseLock).not.toHaveBeenCalledWith('B');
+    expect(mockDeleteState).toHaveBeenCalledWith('A', 'us-east-1');
+    expect(mockDeleteState).not.toHaveBeenCalledWith('B', 'us-east-1');
+    expect(mockForceReleaseLock).toHaveBeenCalledWith('A', 'us-east-1');
+    expect(mockForceReleaseLock).not.toHaveBeenCalledWith('B', 'us-east-1');
   });
 });

--- a/tests/unit/cli/state-show.test.ts
+++ b/tests/unit/cli/state-show.test.ts
@@ -36,16 +36,21 @@ vi.mock('../../../src/utils/aws-clients.ts', () => {
   };
 });
 
-const mockGetState = vi.fn<(stackName: string) => Promise<{ state: StackState } | null>>();
+const mockGetState =
+  vi.fn<(stackName: string, region: string) => Promise<{ state: StackState } | null>>();
+const mockListStacks =
+  vi.fn<() => Promise<Array<{ stackName: string; region?: string }>>>();
 const mockVerifyBucketExists = vi.fn<() => Promise<void>>();
 vi.mock('../../../src/state/s3-state-backend.js', () => ({
   S3StateBackend: vi.fn().mockImplementation(() => ({
     getState: mockGetState,
+    listStacks: mockListStacks,
     verifyBucketExists: mockVerifyBucketExists,
   })),
 }));
 
-const mockGetLockInfo = vi.fn<(stackName: string) => Promise<LockInfo | null>>();
+const mockGetLockInfo =
+  vi.fn<(stackName: string, region?: string) => Promise<LockInfo | null>>();
 vi.mock('../../../src/state/lock-manager.js', () => ({
   LockManager: vi.fn().mockImplementation(() => ({
     getLockInfo: mockGetLockInfo,
@@ -95,14 +100,18 @@ function makeResource(overrides: Partial<ResourceState> = {}): ResourceState {
 function makeState(overrides: Partial<StackState> = {}): { state: StackState } {
   return {
     state: {
-      version: overrides.version ?? 1,
+      version: overrides.version ?? 2,
       stackName: overrides.stackName ?? 'TestStack',
-      ...(overrides.region !== undefined && { region: overrides.region }),
+      region: overrides.region ?? 'us-east-1',
       resources: overrides.resources ?? {},
       outputs: overrides.outputs ?? {},
       lastModified: overrides.lastModified ?? Date.UTC(2026, 3, 29, 10, 23, 45),
     },
   };
+}
+
+function defaultListResponse(stackName = 'TestStack', region = 'us-east-1') {
+  return [{ stackName, region }];
 }
 
 describe('cdkd state show', () => {
@@ -111,6 +120,7 @@ describe('cdkd state show', () => {
   beforeEach(() => {
     mockGetState.mockReset();
     mockGetLockInfo.mockReset();
+    mockListStacks.mockReset();
     mockVerifyBucketExists.mockReset();
     mockVerifyBucketExists.mockResolvedValue();
     errorSpy.mockReset();
@@ -125,6 +135,7 @@ describe('cdkd state show', () => {
   });
 
   it('reports a clear error when the stack has no state', async () => {
+    mockListStacks.mockResolvedValue([]);
     mockGetState.mockResolvedValue(null);
     mockGetLockInfo.mockResolvedValue(null);
 
@@ -135,7 +146,19 @@ describe('cdkd state show', () => {
     expect(message).toMatch(/No state found for stack 'Missing'/);
   });
 
+  it('errors when the stack has multiple regions and --stack-region is missing', async () => {
+    mockListStacks.mockResolvedValue([
+      { stackName: 'MyStack', region: 'us-west-2' },
+      { stackName: 'MyStack', region: 'us-east-1' },
+    ]);
+
+    await expect(runStateShow(['show', 'MyStack'])).rejects.toThrow();
+    const message = String(errorSpy.mock.calls[0]?.[0] ?? '');
+    expect(message).toMatch(/multiple regions/);
+  });
+
   it('renders stack header, lock status, outputs, and resources', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('MyStack'));
     mockGetState.mockResolvedValue(
       makeState({
         stackName: 'MyStack',
@@ -157,7 +180,7 @@ describe('cdkd state show', () => {
 
     expect(out).toContain('Stack: MyStack');
     expect(out).toContain('  Region: us-east-1');
-    expect(out).toContain('  Version: 1');
+    expect(out).toContain('  Version: 2');
     expect(out).toContain('  Last Modified: 2026-04-29T10:23:45.000Z');
     expect(out).toContain('  Lock: unlocked');
     expect(out).toContain('Outputs:');
@@ -173,6 +196,7 @@ describe('cdkd state show', () => {
   });
 
   it('renders a locked stack with owner / operation / expiry detail', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('MyStack'));
     mockGetState.mockResolvedValue(makeState({ stackName: 'MyStack' }));
     mockGetLockInfo.mockResolvedValue({
       owner: 'alice@workstation:1234',
@@ -187,6 +211,7 @@ describe('cdkd state show', () => {
   });
 
   it('renders an expired lock when expiresAt is in the past', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('MyStack'));
     mockGetState.mockResolvedValue(makeState({ stackName: 'MyStack' }));
     mockGetLockInfo.mockResolvedValue({
       owner: 'bob@host:5678',
@@ -200,6 +225,7 @@ describe('cdkd state show', () => {
   });
 
   it('reports `(none)` for resources with no attributes / no properties', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('AnyStack'));
     mockGetState.mockResolvedValue(
       makeState({
         resources: {
@@ -217,6 +243,7 @@ describe('cdkd state show', () => {
   });
 
   it('omits the Outputs section when outputs are empty', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('AnyStack'));
     mockGetState.mockResolvedValue(makeState({ outputs: {} }));
     mockGetLockInfo.mockResolvedValue(null);
 
@@ -226,6 +253,7 @@ describe('cdkd state show', () => {
   });
 
   it('emits a `{state, lock}` JSON object with --json', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('JsonStack', 'us-west-2'));
     const stateRecord = makeState({
       stackName: 'JsonStack',
       region: 'us-west-2',
@@ -254,6 +282,7 @@ describe('cdkd state show', () => {
   });
 
   it('emits `lock: null` in JSON when the stack is unlocked', async () => {
+    mockListStacks.mockResolvedValue(defaultListResponse('UnlockedStack'));
     mockGetState.mockResolvedValue(makeState({ stackName: 'UnlockedStack' }));
     mockGetLockInfo.mockResolvedValue(null);
 

--- a/tests/unit/deployment/dry-run.test.ts
+++ b/tests/unit/deployment/dry-run.test.ts
@@ -135,7 +135,8 @@ describe('DeployEngine - Dry Run Mode', () => {
       mockDagBuilder as any,
       mockDiffCalculator as any,
       mockProviderRegistry as any,
-      { dryRun: true }
+      { dryRun: true },
+      'us-east-1'
     );
   }
 
@@ -147,7 +148,8 @@ describe('DeployEngine - Dry Run Mode', () => {
       mockDagBuilder as any,
       mockDiffCalculator as any,
       mockProviderRegistry as any,
-      { dryRun: false }
+      { dryRun: false },
+      'us-east-1'
     );
   }
 
@@ -473,8 +475,13 @@ describe('DeployEngine - Dry Run Mode', () => {
       await engine.deploy(stackName, template);
 
       // Lock is acquired and released (current implementation behavior)
-      expect(mockLockManager.acquireLockWithRetry).toHaveBeenCalledWith(stackName, undefined, 'deploy');
-      expect(mockLockManager.releaseLock).toHaveBeenCalledWith(stackName);
+      expect(mockLockManager.acquireLockWithRetry).toHaveBeenCalledWith(
+        stackName,
+        'us-east-1',
+        undefined,
+        'deploy'
+      );
+      expect(mockLockManager.releaseLock).toHaveBeenCalledWith(stackName, 'us-east-1');
     });
   });
 

--- a/tests/unit/deployment/resource-replacement.test.ts
+++ b/tests/unit/deployment/resource-replacement.test.ts
@@ -176,7 +176,9 @@ describe('DeployEngine - Resource Replacement', () => {
       mockLockManager as any,
       mockDagBuilder as any,
       mockDiffCalculator as any,
-      mockProviderRegistry as any
+      mockProviderRegistry as any,
+      {},
+      'us-east-1'
     );
 
     const result = await engine.deploy(stackName, template);
@@ -204,7 +206,8 @@ describe('DeployEngine - Resource Replacement', () => {
     // 3. State should be updated with new physicalId
     // saveState is called: partial save after level + final save
     expect(mockStateBackend.saveState).toHaveBeenCalled();
-    const savedState = mockStateBackend.saveState.mock.calls[0][1] as StackState;
+    // saveState is now (stackName, region, state, options) — state is index 2.
+    const savedState = mockStateBackend.saveState.mock.calls[0][2] as StackState;
     expect(savedState.resources['MyBucket'].physicalId).toBe('new-bucket-physical-id');
     expect(savedState.resources['MyBucket'].attributes).toEqual({
       Arn: 'arn:aws:s3:::new-bucket-name',
@@ -248,7 +251,9 @@ describe('DeployEngine - Resource Replacement', () => {
       mockLockManager as any,
       mockDagBuilder as any,
       mockDiffCalculator as any,
-      mockProviderRegistry as any
+      mockProviderRegistry as any,
+      {},
+      'us-east-1'
     );
 
     await engine.deploy(stackName, template);
@@ -290,7 +295,9 @@ describe('DeployEngine - Resource Replacement', () => {
       mockLockManager as any,
       mockDagBuilder as any,
       mockDiffCalculator as any,
-      mockProviderRegistry as any
+      mockProviderRegistry as any,
+      {},
+      'us-east-1'
     );
 
     // Should NOT throw even though delete failed - the code catches delete errors as warnings
@@ -303,7 +310,8 @@ describe('DeployEngine - Resource Replacement', () => {
     expect(mockProvider.delete).toHaveBeenCalledTimes(1);
 
     // State should still be saved with the new physicalId
-    const savedState = mockStateBackend.saveState.mock.calls[0][1] as StackState;
+    // saveState is now (stackName, region, state, options) — state is index 2.
+    const savedState = mockStateBackend.saveState.mock.calls[0][2] as StackState;
     expect(savedState.resources['MyBucket'].physicalId).toBe('new-bucket-physical-id');
 
     expect(result.updated).toBe(1);
@@ -344,7 +352,9 @@ describe('DeployEngine - Resource Replacement', () => {
       mockLockManager as any,
       mockDagBuilder as any,
       mockDiffCalculator as any,
-      mockProviderRegistry as any
+      mockProviderRegistry as any,
+      {},
+      'us-east-1'
     );
 
     await engine.deploy(stackName, template);
@@ -386,12 +396,14 @@ describe('DeployEngine - Resource Replacement', () => {
       mockLockManager as any,
       mockDagBuilder as any,
       mockDiffCalculator as any,
-      mockProviderRegistry as any
+      mockProviderRegistry as any,
+      {},
+      'us-east-1'
     );
 
     await expect(engine.deploy(stackName, template)).rejects.toThrow();
 
     // Lock should still be released
-    expect(mockLockManager.releaseLock).toHaveBeenCalledWith(stackName);
+    expect(mockLockManager.releaseLock).toHaveBeenCalledWith(stackName, 'us-east-1');
   });
 });

--- a/tests/unit/deployment/rollback.test.ts
+++ b/tests/unit/deployment/rollback.test.ts
@@ -138,7 +138,8 @@ describe('DeployEngine - Rollback (event-driven dispatch)', () => {
       mockDagBuilder as never,
       mockDiffCalculator as never,
       mockProviderRegistry as never,
-      { concurrency: 4, noRollback: opts.noRollback ?? false }
+      { concurrency: 4, noRollback: opts.noRollback ?? false },
+      'us-east-1'
     );
   }
 
@@ -291,7 +292,8 @@ describe('DeployEngine - Rollback (event-driven dispatch)', () => {
     // Inspect the most recent saveState call (could be pre-rollback or post-).
     const calls = mockStateBackend.saveState.mock.calls;
     expect(calls.length).toBeGreaterThan(0);
-    const finalSavedState = calls[calls.length - 1]![1] as StackState;
+    // saveState now: (stackName, region, state, options) — state is index 2.
+    const finalSavedState = calls[calls.length - 1]![2] as StackState;
 
     // A and C deleted from state; B remains because its delete failed.
     expect(finalSavedState.resources['A']).toBeUndefined();

--- a/tests/unit/deployment/safety-net.test.ts
+++ b/tests/unit/deployment/safety-net.test.ts
@@ -172,7 +172,9 @@ describe('DeployEngine - Safety Net (CC API Fallback)', () => {
       mockLockManager as any,
       mockDagBuilder as any,
       mockDiffCalculator as any,
-      mockProviderRegistry as any
+      mockProviderRegistry as any,
+      {},
+      'us-east-1'
     );
   }
 

--- a/tests/unit/state/lock-manager.test.ts
+++ b/tests/unit/state/lock-manager.test.ts
@@ -54,7 +54,7 @@ describe('LockManager', () => {
       s3Client.send.mockResolvedValueOnce({});
 
       const now = Date.now();
-      await manager.acquireLock('test-stack');
+      await manager.acquireLock('test-stack', 'us-east-1');
 
       const putCall = s3Client.send.mock.calls[0][0];
       const lockBody = JSON.parse(putCall.input.Body) as LockInfo;
@@ -73,7 +73,7 @@ describe('LockManager', () => {
       s3Client.send.mockResolvedValueOnce({});
 
       const now = Date.now();
-      await manager.acquireLock('test-stack');
+      await manager.acquireLock('test-stack', 'us-east-1');
 
       const putCall = s3Client.send.mock.calls[0][0];
       const lockBody = JSON.parse(putCall.input.Body) as LockInfo;
@@ -85,16 +85,22 @@ describe('LockManager', () => {
   });
 
   describe('acquireLock', () => {
-    it('should acquire lock successfully with expiresAt', async () => {
+    it('should acquire lock successfully with expiresAt at the region-scoped key', async () => {
       s3Client.send.mockResolvedValueOnce({});
 
-      const result = await lockManager.acquireLock('test-stack', 'test-owner', 'deploy');
+      const result = await lockManager.acquireLock(
+        'test-stack',
+        'us-west-2',
+        'test-owner',
+        'deploy'
+      );
 
       expect(result).toBe(true);
 
       const putCall = s3Client.send.mock.calls[0][0];
       expect(putCall.input.Bucket).toBe('test-bucket');
-      expect(putCall.input.Key).toBe('stacks/test-stack/lock.json');
+      // Region is part of the lock key now (PR 1 — collection model extension).
+      expect(putCall.input.Key).toBe('stacks/test-stack/us-west-2/lock.json');
       expect(putCall.input.IfNoneMatch).toBe('*');
 
       const lockBody = JSON.parse(putCall.input.Body) as LockInfo;
@@ -121,7 +127,7 @@ describe('LockManager', () => {
         Body: { transformToString: () => Promise.resolve(JSON.stringify(existingLock)) },
       });
 
-      const result = await lockManager.acquireLock('test-stack', 'my-user');
+      const result = await lockManager.acquireLock('test-stack', 'us-east-1', 'my-user');
 
       expect(result).toBe(false);
     });
@@ -148,7 +154,7 @@ describe('LockManager', () => {
       // Fourth call: PutObject retry succeeds
       s3Client.send.mockResolvedValueOnce({});
 
-      const result = await lockManager.acquireLock('test-stack', 'new-user');
+      const result = await lockManager.acquireLock('test-stack', 'us-east-1', 'new-user');
 
       expect(result).toBe(true);
       // Verify 4 S3 calls: PutObject(fail), GetObject, DeleteObject, PutObject(success)
@@ -177,7 +183,7 @@ describe('LockManager', () => {
       const preconditionError2 = new S3ServiceException({ name: 'PreconditionFailed', $fault: 'client', $metadata: {} });
       s3Client.send.mockRejectedValueOnce(preconditionError2);
 
-      const result = await lockManager.acquireLock('test-stack', 'my-user');
+      const result = await lockManager.acquireLock('test-stack', 'us-east-1', 'my-user');
 
       expect(result).toBe(false);
     });
@@ -187,7 +193,7 @@ describe('LockManager', () => {
       s3Error.name = 'AccessDenied';
       s3Client.send.mockRejectedValueOnce(s3Error);
 
-      await expect(lockManager.acquireLock('test-stack')).rejects.toThrow(LockError);
+      await expect(lockManager.acquireLock('test-stack', 'us-east-1')).rejects.toThrow(LockError);
     });
   });
 
@@ -204,7 +210,7 @@ describe('LockManager', () => {
         Body: { transformToString: () => Promise.resolve(JSON.stringify(lockInfo)) },
       });
 
-      const result = await lockManager.getLockInfo('test-stack');
+      const result = await lockManager.getLockInfo('test-stack', 'us-east-1');
 
       expect(result).toEqual(lockInfo);
     });
@@ -213,7 +219,7 @@ describe('LockManager', () => {
       const noSuchKeyError = new NoSuchKey({ message: 'NoSuchKey', $metadata: {} });
       s3Client.send.mockRejectedValueOnce(noSuchKeyError);
 
-      const result = await lockManager.getLockInfo('test-stack');
+      const result = await lockManager.getLockInfo('test-stack', 'us-east-1');
 
       expect(result).toBeNull();
     });
@@ -231,7 +237,7 @@ describe('LockManager', () => {
         Body: { transformToString: () => Promise.resolve(JSON.stringify(lockInfo)) },
       });
 
-      await expect(lockManager.isLocked('test-stack')).resolves.toBe(true);
+      await expect(lockManager.isLocked('test-stack', 'us-east-1')).resolves.toBe(true);
     });
 
     it('returns true even when the existing lock is expired', async () => {
@@ -245,32 +251,45 @@ describe('LockManager', () => {
       });
 
       // isLocked is a presence check; expiry is irrelevant here.
-      await expect(lockManager.isLocked('test-stack')).resolves.toBe(true);
+      await expect(lockManager.isLocked('test-stack', 'us-east-1')).resolves.toBe(true);
     });
 
     it('returns false when no lock file exists', async () => {
       const noSuchKeyError = new NoSuchKey({ message: 'NoSuchKey', $metadata: {} });
       s3Client.send.mockRejectedValueOnce(noSuchKeyError);
 
-      await expect(lockManager.isLocked('test-stack')).resolves.toBe(false);
+      await expect(lockManager.isLocked('test-stack', 'us-east-1')).resolves.toBe(false);
+    });
+
+    it('falls back to the legacy lock key when region is undefined', async () => {
+      // Legacy callers (state-list integrations that haven't been updated to
+      // pass the per-record region) probe the legacy `{prefix}/{stackName}/lock.json`
+      // key directly.
+      const noSuchKeyError = new NoSuchKey({ message: 'NoSuchKey', $metadata: {} });
+      s3Client.send.mockRejectedValueOnce(noSuchKeyError);
+
+      await expect(lockManager.isLocked('test-stack', undefined)).resolves.toBe(false);
+
+      const get = s3Client.send.mock.calls[0][0];
+      expect(get.input.Key).toBe('stacks/test-stack/lock.json');
     });
   });
 
   describe('releaseLock', () => {
-    it('should delete the lock file', async () => {
+    it('should delete the region-scoped lock file', async () => {
       s3Client.send.mockResolvedValueOnce({});
 
-      await lockManager.releaseLock('test-stack');
+      await lockManager.releaseLock('test-stack', 'us-west-2');
 
       const deleteCall = s3Client.send.mock.calls[0][0];
       expect(deleteCall.input.Bucket).toBe('test-bucket');
-      expect(deleteCall.input.Key).toBe('stacks/test-stack/lock.json');
+      expect(deleteCall.input.Key).toBe('stacks/test-stack/us-west-2/lock.json');
     });
 
     it('should throw LockError on failure', async () => {
       s3Client.send.mockRejectedValueOnce(new Error('Network error'));
 
-      await expect(lockManager.releaseLock('test-stack')).rejects.toThrow(LockError);
+      await expect(lockManager.releaseLock('test-stack', 'us-east-1')).rejects.toThrow(LockError);
     });
   });
 
@@ -292,7 +311,7 @@ describe('LockManager', () => {
       // DeleteObject succeeds
       s3Client.send.mockResolvedValueOnce({});
 
-      await lockManager.forceReleaseLock('test-stack');
+      await lockManager.forceReleaseLock('test-stack', 'us-east-1');
 
       // Should have called GetObject + DeleteObject
       expect(s3Client.send).toHaveBeenCalledTimes(2);
@@ -311,7 +330,7 @@ describe('LockManager', () => {
       });
       s3Client.send.mockResolvedValueOnce({});
 
-      await lockManager.forceReleaseLock('test-stack');
+      await lockManager.forceReleaseLock('test-stack', 'us-east-1');
 
       expect(s3Client.send).toHaveBeenCalledTimes(2);
     });
@@ -320,7 +339,7 @@ describe('LockManager', () => {
       const noSuchKeyError = new NoSuchKey({ message: 'NoSuchKey', $metadata: {} });
       s3Client.send.mockRejectedValueOnce(noSuchKeyError);
 
-      await lockManager.forceReleaseLock('test-stack');
+      await lockManager.forceReleaseLock('test-stack', 'us-east-1');
 
       // Only GetObject was called, no DeleteObject
       expect(s3Client.send).toHaveBeenCalledTimes(1);
@@ -331,7 +350,7 @@ describe('LockManager', () => {
     it('should acquire on first attempt', async () => {
       s3Client.send.mockResolvedValueOnce({});
 
-      await lockManager.acquireLockWithRetry('test-stack', 'user', 'deploy');
+      await lockManager.acquireLockWithRetry('test-stack', 'us-east-1', 'user', 'deploy');
 
       expect(s3Client.send).toHaveBeenCalledTimes(1);
     });
@@ -361,7 +380,7 @@ describe('LockManager', () => {
       // Second attempt: PutObject succeeds
       s3Client.send.mockResolvedValueOnce({});
 
-      await lockManager.acquireLockWithRetry('test-stack', 'user', 'deploy', 3, 10);
+      await lockManager.acquireLockWithRetry('test-stack', 'us-east-1', 'user', 'deploy', 3, 10);
     });
 
     it('should clean up expired lock during retry and acquire', async () => {
@@ -385,7 +404,7 @@ describe('LockManager', () => {
       // PutObject retry succeeds (inside acquireLock)
       s3Client.send.mockResolvedValueOnce({});
 
-      await lockManager.acquireLockWithRetry('test-stack', 'user', 'deploy', 3, 10);
+      await lockManager.acquireLockWithRetry('test-stack', 'us-east-1', 'user', 'deploy', 3, 10);
     });
 
     it('should throw LockError after all retries exhausted', async () => {
@@ -415,7 +434,7 @@ describe('LockManager', () => {
       }
 
       await expect(
-        lockManager.acquireLockWithRetry('test-stack', 'user', 'deploy', 3, 10)
+        lockManager.acquireLockWithRetry('test-stack', 'us-east-1', 'user', 'deploy', 3, 10)
       ).rejects.toThrow(LockError);
     });
 
@@ -426,7 +445,7 @@ describe('LockManager', () => {
       s3Client.send.mockRejectedValue(err);
 
       try {
-        await lockManager.acquireLockWithRetry('test-stack', 'user', 'deploy', 1, 10);
+        await lockManager.acquireLockWithRetry('test-stack', 'us-east-1', 'user', 'deploy', 1, 10);
         expect.unreachable('Should have thrown');
       } catch (error) {
         expect(error).toBeInstanceOf(LockError);
@@ -440,7 +459,7 @@ describe('LockManager', () => {
     it('should write lock with correct JSON structure', async () => {
       s3Client.send.mockResolvedValueOnce({});
 
-      await lockManager.acquireLock('test-stack', 'user@host:123', 'deploy');
+      await lockManager.acquireLock('test-stack', 'us-east-1', 'user@host:123', 'deploy');
 
       const putCall = s3Client.send.mock.calls[0][0];
       const lockBody = JSON.parse(putCall.input.Body);
@@ -458,7 +477,7 @@ describe('LockManager', () => {
     it('should omit operation when not provided', async () => {
       s3Client.send.mockResolvedValueOnce({});
 
-      await lockManager.acquireLock('test-stack', 'user@host:123');
+      await lockManager.acquireLock('test-stack', 'us-east-1', 'user@host:123');
 
       const putCall = s3Client.send.mock.calls[0][0];
       const lockBody = JSON.parse(putCall.input.Body);

--- a/tests/unit/state/s3-state-backend.test.ts
+++ b/tests/unit/state/s3-state-backend.test.ts
@@ -1,7 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { S3Client, HeadBucketCommand } from '@aws-sdk/client-s3';
+import {
+  S3Client,
+  HeadBucketCommand,
+  HeadObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  ListObjectsV2Command,
+  NoSuchKey,
+} from '@aws-sdk/client-s3';
 import { S3StateBackend } from '../../../src/state/s3-state-backend.js';
 import type { StateBackendConfig } from '../../../src/types/config.js';
+import type { StackState } from '../../../src/types/state.js';
 import { StateError } from '../../../src/utils/error-handler.js';
 
 vi.mock('@aws-sdk/client-s3', async () => {
@@ -84,3 +94,285 @@ describe('S3StateBackend.verifyBucketExists', () => {
     expect((caught as Error).message).not.toMatch(/cdkd bootstrap/);
   });
 });
+
+/**
+ * Test helpers for the region-prefixed key tests below. Most calls go through
+ * `s3Client.send(...)` and we want to keep the per-test setup readable.
+ */
+function v2State(stackName: string, region: string): StackState {
+  return {
+    version: 2,
+    stackName,
+    region,
+    resources: {},
+    outputs: {},
+    lastModified: 1234567890,
+  };
+}
+
+function v1State(stackName: string, region?: string): StackState {
+  // `version: 1` legacy state (pre PR 1). `region` is optional in the body —
+  // the very-old layout did not always persist it.
+  return {
+    version: 1,
+    stackName,
+    ...(region && { region }),
+    resources: {},
+    outputs: {},
+    lastModified: 1234567890,
+  };
+}
+
+function bodyOf(state: StackState) {
+  return {
+    transformToString: () => Promise.resolve(JSON.stringify(state)),
+  };
+}
+
+describe('S3StateBackend region-prefixed key layout (PR 1)', () => {
+  let s3Client: { send: ReturnType<typeof vi.fn> };
+  let backend: S3StateBackend;
+  const config: StateBackendConfig = {
+    bucket: 'state-bucket',
+    prefix: 'cdkd',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    s3Client = { send: vi.fn() };
+    backend = new S3StateBackend(s3Client as unknown as S3Client, config);
+  });
+
+  describe('getState', () => {
+    it('reads from the new region-scoped key when present', async () => {
+      const state = v2State('MyStack', 'us-west-2');
+      s3Client.send.mockResolvedValueOnce({ Body: bodyOf(state), ETag: '"new-etag"' });
+
+      const result = await backend.getState('MyStack', 'us-west-2');
+
+      expect(result).not.toBeNull();
+      expect(result!.state).toEqual(state);
+      expect(result!.etag).toBe('"new-etag"');
+      expect(result!.migrationPending).toBeUndefined();
+
+      const cmd = s3Client.send.mock.calls[0][0];
+      expect(cmd).toBeInstanceOf(GetObjectCommand);
+      expect(cmd.input.Key).toBe('cdkd/MyStack/us-west-2/state.json');
+    });
+
+    it('falls back to the legacy key and surfaces migrationPending: true', async () => {
+      const noSuchKey = new NoSuchKey({ message: 'NoSuchKey', $metadata: {} });
+      // 1st: new key miss
+      s3Client.send.mockRejectedValueOnce(noSuchKey);
+      // 2nd: legacy key hit
+      const legacy = v1State('MyStack', 'us-west-2');
+      s3Client.send.mockResolvedValueOnce({ Body: bodyOf(legacy), ETag: '"legacy-etag"' });
+
+      const result = await backend.getState('MyStack', 'us-west-2');
+
+      expect(result).not.toBeNull();
+      expect(result!.state).toEqual(legacy);
+      expect(result!.migrationPending).toBe(true);
+
+      const newKeyCmd = s3Client.send.mock.calls[0][0];
+      expect(newKeyCmd.input.Key).toBe('cdkd/MyStack/us-west-2/state.json');
+      const legacyCmd = s3Client.send.mock.calls[1][0];
+      expect(legacyCmd.input.Key).toBe('cdkd/MyStack/state.json');
+    });
+
+    it('skips legacy fallback when its embedded region does not match', async () => {
+      // PR 1 silent-failure root cause: a legacy state recorded in us-west-2
+      // must NOT be loaded when the caller asks for us-east-1.
+      const noSuchKey = new NoSuchKey({ message: 'NoSuchKey', $metadata: {} });
+      s3Client.send.mockRejectedValueOnce(noSuchKey);
+      const legacy = v1State('MyStack', 'us-west-2');
+      s3Client.send.mockResolvedValueOnce({ Body: bodyOf(legacy), ETag: '"legacy-etag"' });
+
+      const result = await backend.getState('MyStack', 'us-east-1');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when both new and legacy keys are missing', async () => {
+      const noSuchKey = new NoSuchKey({ message: 'NoSuchKey', $metadata: {} });
+      s3Client.send.mockRejectedValueOnce(noSuchKey);
+      s3Client.send.mockRejectedValueOnce(noSuchKey);
+
+      const result = await backend.getState('MissingStack', 'us-east-1');
+      expect(result).toBeNull();
+    });
+
+    it('rejects an unsupported future schema version with a clear error', async () => {
+      // An old cdkd binary (version 1/2) trying to read a `version: 3` blob
+      // must fail with a clear "upgrade cdkd" error rather than silently
+      // mishandling unknown fields.
+      const future = { version: 3, stackName: 'X', resources: {}, outputs: {}, lastModified: 0 };
+      s3Client.send.mockResolvedValueOnce({
+        Body: { transformToString: () => Promise.resolve(JSON.stringify(future)) },
+        ETag: '"e"',
+      });
+
+      const caught = await backend.getState('X', 'us-east-1').catch((e: unknown) => e);
+      expect(caught).toBeInstanceOf(StateError);
+      expect((caught as Error).message).toMatch(/Unsupported state schema version 3/);
+      expect((caught as Error).message).toMatch(/Upgrade cdkd/);
+    });
+  });
+
+  describe('saveState', () => {
+    it('writes to the new region-scoped key and forces version: 2 on disk', async () => {
+      s3Client.send.mockResolvedValueOnce({ ETag: '"new"' });
+
+      const etag = await backend.saveState('MyStack', 'us-west-2', v1State('MyStack', 'us-west-2'));
+
+      expect(etag).toBe('"new"');
+      const put = s3Client.send.mock.calls[0][0];
+      expect(put).toBeInstanceOf(PutObjectCommand);
+      expect(put.input.Key).toBe('cdkd/MyStack/us-west-2/state.json');
+      const persisted = JSON.parse(put.input.Body) as StackState;
+      // Schema version is bumped to 2 even when the caller passed a `version: 1`
+      // body — the on-disk format is always current.
+      expect(persisted.version).toBe(2);
+      expect(persisted.region).toBe('us-west-2');
+      expect(persisted.stackName).toBe('MyStack');
+    });
+
+    it('forwards expectedEtag as IfMatch when not migrating', async () => {
+      s3Client.send.mockResolvedValueOnce({ ETag: '"new"' });
+
+      await backend.saveState('MyStack', 'us-west-2', v2State('MyStack', 'us-west-2'), {
+        expectedEtag: '"prev"',
+      });
+
+      const put = s3Client.send.mock.calls[0][0];
+      expect(put.input.IfMatch).toBe('"prev"');
+    });
+
+    it('migrates: writes new key then deletes the legacy key when migrateLegacy: true', async () => {
+      s3Client.send.mockResolvedValueOnce({ ETag: '"new"' });
+      s3Client.send.mockResolvedValueOnce({}); // legacy DELETE
+
+      await backend.saveState('MyStack', 'us-west-2', v2State('MyStack', 'us-west-2'), {
+        expectedEtag: '"legacy"',
+        migrateLegacy: true,
+      });
+
+      const put = s3Client.send.mock.calls[0][0];
+      expect(put).toBeInstanceOf(PutObjectCommand);
+      expect(put.input.Key).toBe('cdkd/MyStack/us-west-2/state.json');
+      // The legacy ETag is for a different key; we MUST NOT pass it as IfMatch
+      // on the new write — the put would always fail PreconditionFailed.
+      expect(put.input.IfMatch).toBeUndefined();
+
+      const del = s3Client.send.mock.calls[1][0];
+      expect(del).toBeInstanceOf(DeleteObjectCommand);
+      expect(del.input.Key).toBe('cdkd/MyStack/state.json');
+    });
+  });
+
+  describe('listStacks', () => {
+    it('parses both new and legacy keys as {stackName, region} refs', async () => {
+      s3Client.send.mockResolvedValueOnce({
+        Contents: [
+          { Key: 'cdkd/MyStack/us-east-1/state.json' },
+          { Key: 'cdkd/MyStack/us-west-2/state.json' },
+          { Key: 'cdkd/LegacyStack/state.json' }, // pure legacy
+          { Key: 'cdkd/MyStack/us-east-1/lock.json' }, // ignored — not state.json
+        ],
+        IsTruncated: false,
+      });
+      // Legacy region lookup for LegacyStack
+      s3Client.send.mockResolvedValueOnce({
+        Body: bodyOf(v1State('LegacyStack', 'us-east-1')),
+      });
+
+      const refs = await backend.listStacks();
+
+      // Sorted only by listing order; assert via set.
+      expect(refs).toHaveLength(3);
+      const set = new Set(refs.map((r) => `${r.stackName}|${r.region ?? ''}`));
+      expect(set.has('MyStack|us-east-1')).toBe(true);
+      expect(set.has('MyStack|us-west-2')).toBe(true);
+      expect(set.has('LegacyStack|us-east-1')).toBe(true);
+    });
+
+    it('deduplicates (stackName, region) when the same pair appears twice', async () => {
+      // Pathological: a legacy entry whose embedded region collides with a
+      // new-key entry. The new-key entry wins and listStacks emits one row.
+      s3Client.send.mockResolvedValueOnce({
+        Contents: [
+          { Key: 'cdkd/MyStack/us-east-1/state.json' },
+          { Key: 'cdkd/MyStack/state.json' },
+        ],
+        IsTruncated: false,
+      });
+      s3Client.send.mockResolvedValueOnce({
+        Body: bodyOf(v1State('MyStack', 'us-east-1')),
+      });
+
+      const refs = await backend.listStacks();
+      expect(refs).toHaveLength(1);
+      expect(refs[0]).toEqual({ stackName: 'MyStack', region: 'us-east-1' });
+    });
+  });
+
+  describe('stateExists', () => {
+    it('returns true when the new region-scoped key exists', async () => {
+      s3Client.send.mockResolvedValueOnce({});
+      await expect(backend.stateExists('S', 'us-east-1')).resolves.toBe(true);
+      const head = s3Client.send.mock.calls[0][0];
+      expect(head).toBeInstanceOf(HeadObjectCommand);
+      expect(head.input.Key).toBe('cdkd/S/us-east-1/state.json');
+    });
+
+    it('returns true when only the legacy key exists AND its region matches', async () => {
+      // 1st: HEAD new key → NotFound
+      s3Client.send.mockRejectedValueOnce(Object.assign(new Error('NF'), { name: 'NotFound' }));
+      // 2nd: GET legacy state to read its embedded region
+      s3Client.send.mockResolvedValueOnce({ Body: bodyOf(v1State('S', 'us-east-1')) });
+
+      await expect(backend.stateExists('S', 'us-east-1')).resolves.toBe(true);
+    });
+
+    it('returns false when only the legacy key exists but its region differs', async () => {
+      s3Client.send.mockRejectedValueOnce(Object.assign(new Error('NF'), { name: 'NotFound' }));
+      s3Client.send.mockResolvedValueOnce({ Body: bodyOf(v1State('S', 'us-west-2')) });
+
+      await expect(backend.stateExists('S', 'us-east-1')).resolves.toBe(false);
+    });
+  });
+
+  describe('deleteState', () => {
+    it('deletes the region-scoped key and sweeps the matching legacy key', async () => {
+      // 1st: DeleteObject (new key)
+      s3Client.send.mockResolvedValueOnce({});
+      // 2nd: GetObject for legacy region match
+      s3Client.send.mockResolvedValueOnce({ Body: bodyOf(v1State('S', 'us-east-1')) });
+      // 3rd: DeleteObject (legacy key)
+      s3Client.send.mockResolvedValueOnce({});
+
+      await backend.deleteState('S', 'us-east-1');
+
+      const cmds = s3Client.send.mock.calls.map((c: unknown[]) => c[0]);
+      expect(cmds[0]).toBeInstanceOf(DeleteObjectCommand);
+      expect((cmds[0] as DeleteObjectCommand).input.Key).toBe('cdkd/S/us-east-1/state.json');
+      expect(cmds[2]).toBeInstanceOf(DeleteObjectCommand);
+      expect((cmds[2] as DeleteObjectCommand).input.Key).toBe('cdkd/S/state.json');
+    });
+
+    it('leaves a legacy key alone when its region does not match', async () => {
+      s3Client.send.mockResolvedValueOnce({}); // delete new key
+      s3Client.send.mockResolvedValueOnce({ Body: bodyOf(v1State('S', 'us-west-2')) });
+
+      await backend.deleteState('S', 'us-east-1');
+
+      // No second DeleteObject for the legacy key.
+      const deletes = s3Client.send.mock.calls.filter(
+        (c: unknown[]) => c[0] instanceof DeleteObjectCommand
+      );
+      expect(deletes).toHaveLength(1);
+    });
+  });
+});
+
+// Reference unused imports to keep ESLint happy without changing behavior.
+void ListObjectsV2Command;


### PR DESCRIPTION
## Summary

Fixes a silent-failure bug: changing a stack's `env.region` between deploys
silently overwrote the recorded region in `state.json`, leaving the original
region's resources untracked. After this PR, the same `stackName` deployed
to two different regions has two independent state files keyed by region.

This is **PR 1** of the cdkd region/state refactor — see
[`docs/plans/01-state-key-region-prefix.md`](docs/plans/01-state-key-region-prefix.md)
for the full design and the rest of the rollout (PRs 2–5 are out of scope here).

## What changes

### New S3 key layout (schema `version: 2`)

```
s3://{bucket}/cdkd/{stackName}/{region}/state.json
s3://{bucket}/cdkd/{stackName}/{region}/lock.json
```

The same `stackName` in two regions now lives at two independent keys.
Locks are also region-scoped, so two regions of the same stackName can be
operated on in parallel without contention.

### Legacy compatibility (`version: 1` → `version: 2` auto-migration)

- Reads transparently fall back to `cdkd/{stackName}/state.json` when
  no region-scoped key exists, **only if** the legacy state body's
  `region` field matches the requested region (so a stale legacy record
  for a different region is never loaded silently — that's the bug this
  PR fixes).
- The next `saveState` for a stack with `migrationPending: true` writes
  the new region-scoped key and best-effort deletes the legacy key.
- An older cdkd binary that only knows `version: 1` fails with
  `Unsupported state schema version 2. Upgrade cdkd.` instead of
  silently mishandling unknown fields.

### Multi-region same-name semantics

| Command | Behavior |
|---|---|
| `cdkd state list` | One row per `(stackName, region)` pair |
| `cdkd state show <stack>` | Requires `--stack-region <region>` when ambiguous |
| `cdkd state resources <stack>` | Same as `state show` |
| `cdkd state rm <stack>` | Removes all region keys (with confirmation) |
| `cdkd state rm <stack> --stack-region X` | Removes only region X |
| `cdkd deploy / destroy / diff <stack>` | Synth-driven; `env.region` selects the key |

The `--stack-region` flag avoids collision with the global `--region`
(AWS profile region) on every state subcommand.

### Files touched

- `src/types/state.ts` — `version: 1 | 2`, `region?: string` on body.
- `src/state/s3-state-backend.ts` — region-scoped + legacy lookup, migration
  write tail, dual-layout `listStacks`.
- `src/state/lock-manager.ts` — region-scoped lock keys.
- `src/cli/commands/state.ts` — region column in `list`, `--stack-region`
  flag on `show` / `resources` / `rm`, ambiguity errors.
- `src/cli/commands/{deploy,destroy,diff,force-unlock}.ts` — pass region
  through; `destroy` synth-driven region resolution.
- `src/deployment/deploy-engine.ts` — `stackRegion` is now required,
  `version: 2` written on every save, migration plumbed through the
  first per-resource save.
- `src/deployment/intrinsic-function-resolver.ts` — `Fn::ImportValue`
  resolves region per state ref.

### New helpers / tests / scripts

- `scripts/verify-bc.sh PR-1` — manual legacy → new migration check
  (seeds a `version: 1` fixture in S3, runs `state list` + `state rm`,
  asserts both keys gone).
- `tests/integration/legacy-state-migration/` and
  `tests/integration/multi-region-same-stack/` — scaffolds for real-AWS
  verification (not run in CI).
- 14 new unit tests in `tests/unit/state/s3-state-backend.test.ts` covering
  every lookup branch, the migration write path, schema rejection, and
  legacy/dedupe in `listStacks`. Lock-manager and state-CLI tests updated
  for the new region argument.

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` — green
- [x] `npx vitest --run` — 62 files / 791 tests pass
- [x] Unit tests cover: new-key read, legacy fallback, region-mismatch skip,
      migration write + delete, listStacks merge + dedupe, schema-version
      rejection, region-scoped locks
- [x] CLI surface verified via `state list --help` / `state rm --help`:
      `--stack-region` exposed correctly, no collision with global `--region`
- [ ] **Manual / real-AWS** — run `scripts/verify-bc.sh PR-1` against a
      fixture bucket to verify legacy → new migration end-to-end
- [ ] **Manual / real-AWS** — run `/run-integ <test>` to satisfy the
      `integ-destroy` markgate gate before merge (this PR touches
      `destroy.ts` and `deploy-engine.ts`)

## Out of scope (other PRs)

- Default bucket name change → PR 4
- `--region` flag deprecation on most commands → PR 5
- Dynamic bucket region resolution → PR 3
- DELETE region verification → PR 2
- `bc-check` markgate gate wiring (the script ships here; the gate is
  hooked up in a later task)

## Follow-ups discovered

- `docs/state-management.md` (lines 656+) and `docs/troubleshooting.md`
  still reference the old `stacks/` prefix in some cookbook sections;
  pre-existing drift (default has been `cdkd/` for a while), worth
  cleaning up in a doc-only PR. Not blocking PR 1.

## References

- Design: [`docs/plans/01-state-key-region-prefix.md`](docs/plans/01-state-key-region-prefix.md)
- Plan rollout README: [`docs/plans/README.md`](docs/plans/README.md)
- Original silent-failure incident: a `MyStage-CdkSampleStack` state file
  whose region got rewritten when `env.region` changed mid-flight; the
  prior region's resources became untracked and were never cleaned up by
  `cdkd destroy` (idempotent NotFound was treated as success).


## Migration behavior with old cdkd binaries

Once a state has been auto-migrated by a new cdkd (this PR's binary), the
**legacy `cdkd/{stackName}/state.json` key is deleted** as the final step
of the migration. An old cdkd binary running against the same bucket
afterwards will:

1. Look up `cdkd/{stackName}/state.json` (legacy path — old cdkd doesn't
   know about the new region-scoped key).
2. Get `404 NoSuchKey` and treat it as "no state, fresh deploy".
3. Attempt CREATE for every resource in the stack.
4. Fail with name-conflict errors (`BucketAlreadyExists`,
   `EntityAlreadyExists`, etc.) because the AWS resources are still alive
   and tracked under the new key.

This **fails closed** (loud errors, not silent corruption) but the error
messages are about the conflicts, not about the migration. **Mitigation
for users on old cdkd**: upgrade to this PR's version (or later) before
running cdkd against a bucket that's been touched by a new cdkd.

This is acceptable for cdkd's current user base (small, experimental).
For wider production use, a future enhancement could write a small
"version stamp" file at the bucket root that old cdkd binaries read
explicitly and refuse to operate against — left as out-of-scope for this
PR.
