### PR TITLE
feat(state): dynamic state-bucket region resolution + UnknownError normalization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ cdkd has a 7-layer system architecture:
      readable; the next write auto-migrates and deletes the legacy key.
    - An old cdkd binary fails clearly on a `version: 2` blob instead of
      silently mishandling unknown fields.
+   - State bucket region is resolved dynamically via `GetBucketLocation` (`src/utils/aws-region-resolver.ts`); the state-bucket S3 client is rebuilt for the bucket's actual region before any state operation, so the CLI works regardless of the profile region. Provisioning clients (CC API, Lambda, IAM, etc.) keep using `env.region` — only the state-bucket S3 client is region-corrected.
 
 3. **Event-driven DAG Execution**
    - Analyzes dependencies via `Ref` / `Fn::GetAtt` / `DependsOn`
@@ -132,7 +133,7 @@ pnpm run typecheck
 - **src/types/assembly.ts** - Cloud Assembly types (AssemblyManifest, MissingContext, etc.)
 - **src/provisioning/register-providers.ts** - Shared provider registration (called from deploy.ts and destroy.ts)
 - **src/types/** - Type definitions (config, state, resources, assembly, etc.)
-- **src/utils/** - Logger, live progress renderer (multi-line in-flight task display), error handler, AWS client factory
+- **src/utils/** - Logger, live progress renderer (multi-line in-flight task display), error handler (incl. `normalizeAwsError` for AWS SDK v3 synthetic UnknownError → actionable HTTP-status-keyed messages), AWS client factory, AWS region resolver (`aws-region-resolver.ts` — caches bucket-region lookups via `GetBucketLocation` so the state-bucket S3 client can be rebuilt for the bucket's actual region)
 - **build.mjs** - esbuild build script (ESM modules)
 - **vitest.config.ts** - Vitest configuration
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -48,6 +48,20 @@ export STATE_BUCKET="cdkd-state-myteam-1234567890"
 export STATE_PREFIX="cdkd"  # Default
 ```
 
+### State Bucket Region
+
+The state bucket can live in any AWS region — it does not have to match
+your CLI's profile region or the regions you deploy stacks into. cdkd
+auto-detects the bucket's region via `GetBucketLocation` (a GET, not a
+HEAD — has a body and avoids the AWS SDK v3 region-redirect parsing
+glitch on empty-body 301 HEAD responses) and rebuilds its state-bucket
+S3 client to that region before any state operation.
+
+This is intentionally scoped to the state-bucket S3 client only.
+Provisioning clients (Cloud Control API, Lambda, IAM, etc.) continue to
+use the stack's `env.region` so resources are still created in the
+region the CDK app declares.
+
 Result:
 
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -216,6 +216,40 @@ node dist/cli.js deploy --app "..." --state-bucket ${STATE_BUCKET}
 
 ---
 
+### Issue: "UnknownError" / cross-region state bucket
+
+#### Symptoms
+
+```
+StateError: Failed to verify state bucket 'my-bucket': UnknownError
+Caused by: UnknownError
+```
+
+…or similar AWS SDK v3 surface-level `UnknownError` on any S3 operation
+against the state bucket.
+
+#### Cause
+
+The state bucket lives in a region different from the one the AWS SDK
+client was constructed for. AWS SDK v3's region-redirect middleware does
+not handle the empty-body 301 HEAD response S3 returns in this case
+cleanly — the protocol parser falls through and produces a synthetic
+`Unknown` exception with the literal message `UnknownError`.
+
+#### Solution
+
+cdkd resolves this automatically as of PR 3 (`docs/plans/03-dynamic-region-resolution.md`):
+the state backend looks up the bucket region via `GetBucketLocation` (a
+GET request, not a HEAD — avoids the SDK glitch) and rebuilds its S3
+client to that region before any state operation. If you still see this
+error, please file a bug with the full stack trace.
+
+You no longer need to set `--region` to match the bucket region — the
+CLI's region option (and the profile region) only affect provisioning
+clients, not the state-bucket client.
+
+---
+
 ## Deployment Errors
 
 ### Issue: "Resource already exists" Error

--- a/src/cli/commands/bootstrap.ts
+++ b/src/cli/commands/bootstrap.ts
@@ -10,7 +10,7 @@ import {
 import { GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { commonOptions } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
-import { withErrorHandling } from '../../utils/error-handler.js';
+import { withErrorHandling, normalizeAwsError } from '../../utils/error-handler.js';
 import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
 import { getDefaultStateBucketName } from '../config-loader.js';
 
@@ -63,7 +63,13 @@ async function bootstrapCommand(options: {
   }
 
   try {
-    // Check if bucket already exists
+    // Check if bucket already exists.
+    //
+    // The HeadBucket pre-check is the same call site that produces the
+    // AWS SDK v3 synthetic `UnknownError` when the bucket lives in a
+    // different region than the client. Routing the error through
+    // `normalizeAwsError` turns "UnknownError" into a concrete message
+    // ("different region", "access denied", etc.).
     let bucketExists = false;
     try {
       await s3Client.send(new HeadBucketCommand({ Bucket: bucketName }));
@@ -74,7 +80,7 @@ async function bootstrapCommand(options: {
       if (err.name === 'NotFound' || err.name === 'NoSuchBucket') {
         logger.debug(`Bucket ${bucketName} does not exist, will create`);
       } else {
-        throw error;
+        throw normalizeAwsError(error, { bucket: bucketName, operation: 'HeadBucket' });
       }
     }
 

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -95,10 +95,19 @@ async function deployCommand(
   setAwsClients(awsClients);
 
   // Fail fast if the state bucket is missing, before running synth / docker builds / asset uploads.
-  const preflightStateBackend = new S3StateBackend(awsClients.s3, {
-    bucket: stateBucket,
-    prefix: options.statePrefix,
-  });
+  // Passing region/profile lets the backend rebuild its S3 client when the
+  // state bucket lives in a region different from the CLI's profile region.
+  const preflightStateBackend = new S3StateBackend(
+    awsClients.s3,
+    {
+      bucket: stateBucket,
+      prefix: options.statePrefix,
+    },
+    {
+      region,
+      ...(options.profile && { profile: options.profile }),
+    }
+  );
   await preflightStateBackend.verifyBucketExists();
 
   let deployInterrupted = false;
@@ -284,7 +293,10 @@ async function deployCommand(
             region: baseRegion,
             ...(options.profile && { profile: options.profile }),
           });
-          const stackStateBackend = new S3StateBackend(stateS3Client.s3, stateConfig);
+          const stackStateBackend = new S3StateBackend(stateS3Client.s3, stateConfig, {
+            region: baseRegion,
+            ...(options.profile && { profile: options.profile }),
+          });
           const stackLockManager = new LockManager(stateS3Client.s3, stateConfig);
           const stackProviderRegistry = new ProviderRegistry();
           registerAllProviders(stackProviderRegistry);

--- a/src/cli/commands/destroy.ts
+++ b/src/cli/commands/destroy.ts
@@ -77,7 +77,12 @@ async function destroyCommand(
       bucket: stateBucket,
       prefix: options.statePrefix,
     };
-    const stateBackend = new S3StateBackend(awsClients.s3, stateConfig);
+    // Pass region/profile so the backend can rebuild its S3 client if the
+    // bucket lives in a region different from the CLI's profile region.
+    const stateBackend = new S3StateBackend(awsClients.s3, stateConfig, {
+      ...(options.region && { region: options.region }),
+      ...(options.profile && { profile: options.profile }),
+    });
     // Fail fast if the state bucket is missing, before synth or any destructive work.
     await stateBackend.verifyBucketExists();
     const lockManager = new LockManager(awsClients.s3, stateConfig);

--- a/src/cli/commands/diff.ts
+++ b/src/cli/commands/diff.ts
@@ -186,7 +186,12 @@ async function diffCommand(
       bucket: stateBucket,
       prefix: options.statePrefix,
     };
-    const stateBackend = new S3StateBackend(awsClients.s3, stateConfig);
+    // Pass region/profile so the backend can rebuild its S3 client if the
+    // bucket lives in a region different from the CLI's profile region.
+    const stateBackend = new S3StateBackend(awsClients.s3, stateConfig, {
+      region,
+      ...(options.profile && { profile: options.profile }),
+    });
     const diffCalculator = new DiffCalculator();
     const intrinsicResolver = new IntrinsicFunctionResolver(region);
 

--- a/src/cli/commands/state.ts
+++ b/src/cli/commands/state.ts
@@ -115,9 +115,17 @@ async function setupStateBackend(options: {
   const bucket = await resolveStateBucketWithDefault(options.stateBucket, region);
   const prefix = options.statePrefix;
   const stateConfig = { bucket, prefix };
-  const stateBackend = new S3StateBackend(awsClients.s3, stateConfig);
+  // Pass region/profile so the backend can rebuild its S3 client if the
+  // bucket lives in a region different from the CLI's profile region.
+  const stateBackend = new S3StateBackend(awsClients.s3, stateConfig, {
+    region,
+    ...(options.profile && { profile: options.profile }),
+  });
   const lockManager = new LockManager(awsClients.s3, stateConfig);
 
+  // verifyBucketExists() triggers ensureClientForBucket() which resolves the
+  // bucket region via GetBucketLocation. Every state subcommand that follows
+  // sees a fully-ready backend.
   await stateBackend.verifyBucketExists();
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,8 +43,15 @@ export {
   ConfigError,
   isCdkdError,
   formatError,
+  normalizeAwsError,
+  type NormalizeAwsErrorContext,
 } from './utils/error-handler.js';
 export { AwsClients, getAwsClients, setAwsClients, resetAwsClients } from './utils/aws-clients.js';
+export {
+  resolveBucketRegion,
+  clearBucketRegionCache,
+  type ResolveBucketRegionOptions,
+} from './utils/aws-region-resolver.js';
 
 // Synthesis
 export {

--- a/src/state/s3-state-backend.ts
+++ b/src/state/s3-state-backend.ts
@@ -15,7 +15,8 @@ import {
 } from '../types/state.js';
 import type { StateBackendConfig } from '../types/config.js';
 import { getLogger } from '../utils/logger.js';
-import { StateError } from '../utils/error-handler.js';
+import { StateError, normalizeAwsError } from '../utils/error-handler.js';
+import { resolveBucketRegion } from '../utils/aws-region-resolver.js';
 
 /**
  * Identifier of a state record. The legacy layout (`version: 1`) didn't have
@@ -38,20 +39,47 @@ const LEGACY_KEY_DEPTH = 2;
 const NEW_KEY_DEPTH = 3;
 
 /**
- * S3-based state backend using conditional writes for optimistic locking
+ * Options used to reconstruct the S3Client if the bucket lives in a region
+ * different from the one the initial client was built for.
+ *
+ * Mirrors {@link AwsClientConfig} from `aws-clients.ts` but kept local so
+ * the state backend doesn't depend on the CLI-side AwsClients wrapper.
+ */
+export interface S3ClientOptions {
+  region?: string;
+  profile?: string;
+  credentials?: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken?: string;
+  };
+}
+
+/**
+ * S3-based state backend using conditional writes for optimistic locking.
  *
  * State keys are region-scoped (`{prefix}/{stackName}/{region}/state.json`)
  * to prevent two regions of the same stackName from overwriting each other's
  * state. Legacy `{prefix}/{stackName}/state.json` keys (schema `version: 1`)
  * are still readable; the next `saveState` for that stack auto-migrates by
  * writing the new key and deleting the legacy one.
+ *
+ * The state bucket can live in a different AWS region from the rest of the
+ * cdkd CLI's resource provisioning. Before the first state operation, this
+ * backend resolves the bucket's actual region via `GetBucketLocation` and,
+ * if it differs from the client's configured region, rebuilds the S3Client
+ * for that region. Provisioning clients are unaffected — only the
+ * state-bucket S3 client is region-corrected.
  */
 export class S3StateBackend {
   private logger = getLogger().child('S3StateBackend');
+  private clientResolved = false;
+  private resolveInFlight: Promise<void> | null = null;
 
   constructor(
     private s3Client: S3Client,
-    private config: StateBackendConfig
+    private config: StateBackendConfig,
+    private clientOpts: S3ClientOptions = {}
   ) {}
 
   /**
@@ -70,12 +98,70 @@ export class S3StateBackend {
   }
 
   /**
+   * Resolve the state bucket's actual region and, if it differs from the
+   * client's currently-configured region, replace the S3Client with one
+   * pointed at the bucket's region.
+   *
+   * This is idempotent: subsequent calls return immediately. Concurrent
+   * callers (e.g. when several public methods race during a parallel deploy)
+   * share a single in-flight resolution promise so we never issue more than
+   * one `GetBucketLocation` per backend.
+   *
+   * Errors from `GetBucketLocation` are deliberately swallowed by
+   * `resolveBucketRegion` — the resolver returns `fallbackRegion` so the
+   * caller can surface the more actionable downstream error (e.g. the
+   * `HeadBucket` 404 routed via `normalizeAwsError`).
+   */
+  private async ensureClientForBucket(): Promise<void> {
+    if (this.clientResolved) return;
+    if (this.resolveInFlight) return this.resolveInFlight;
+
+    this.resolveInFlight = (async (): Promise<void> => {
+      try {
+        const currentRegion = await this.s3Client.config.region();
+        const fallbackRegion = typeof currentRegion === 'string' ? currentRegion : undefined;
+        const bucketRegion = await resolveBucketRegion(this.config.bucket, {
+          ...(this.clientOpts.profile && { profile: this.clientOpts.profile }),
+          ...(this.clientOpts.credentials && { credentials: this.clientOpts.credentials }),
+          ...(fallbackRegion && { fallbackRegion }),
+        });
+
+        if (bucketRegion !== currentRegion) {
+          this.logger.debug(
+            `State bucket '${this.config.bucket}' is in '${bucketRegion}' (client was '${currentRegion}'); rebuilding S3 client.`
+          );
+          const oldClient = this.s3Client;
+          this.s3Client = new S3Client({
+            region: bucketRegion,
+            ...(this.clientOpts.profile && { profile: this.clientOpts.profile }),
+            ...(this.clientOpts.credentials && { credentials: this.clientOpts.credentials }),
+            // Suppress "Are you using a Stream of unknown length" warning,
+            // matching the suppression in AwsClients.
+            logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+          });
+          oldClient.destroy();
+        }
+        this.clientResolved = true;
+      } finally {
+        this.resolveInFlight = null;
+      }
+    })();
+
+    return this.resolveInFlight;
+  }
+
+  /**
    * Verify that the configured state bucket exists.
    *
    * Called early in deploy/destroy to fail fast before expensive work
    * (asset publishing, Docker builds) runs against a missing bucket.
+   *
+   * Errors are routed through {@link normalizeAwsError} so the AWS SDK v3
+   * synthetic `UnknownError` (e.g. cross-region HEAD) becomes a concrete
+   * "Bucket does not exist" / "Access denied" / "different region" message.
    */
   async verifyBucketExists(): Promise<void> {
+    await this.ensureClientForBucket();
     try {
       await this.s3Client.send(new HeadBucketCommand({ Bucket: this.config.bucket }));
     } catch (error) {
@@ -87,9 +173,13 @@ export class S3StateBackend {
             `--state-bucket, CDKD_STATE_BUCKET, or cdk.json context.cdkd.stateBucket.`
         );
       }
+      const normalized = normalizeAwsError(error, {
+        bucket: this.config.bucket,
+        operation: 'HeadBucket',
+      });
       throw new StateError(
-        `Failed to verify state bucket '${this.config.bucket}': ${error instanceof Error ? error.message : String(error)}`,
-        error instanceof Error ? error : undefined
+        `Failed to verify state bucket '${this.config.bucket}': ${normalized.message}`,
+        normalized
       );
     }
   }
@@ -103,6 +193,7 @@ export class S3StateBackend {
    * state without forcing a write-through migration first.
    */
   async stateExists(stackName: string, region: string): Promise<boolean> {
+    await this.ensureClientForBucket();
     const newKey = this.getStateKey(stackName, region);
 
     if (await this.headObject(newKey)) {
@@ -131,6 +222,7 @@ export class S3StateBackend {
     stackName: string,
     region: string
   ): Promise<{ state: StackState; etag: string; migrationPending?: boolean } | null> {
+    await this.ensureClientForBucket();
     const newKey = this.getStateKey(stackName, region);
 
     // 1. Try new region-scoped key first.
@@ -204,6 +296,7 @@ export class S3StateBackend {
     state: StackState,
     options: { expectedEtag?: string; migrateLegacy?: boolean } = {}
   ): Promise<string> {
+    await this.ensureClientForBucket();
     const newKey = this.getStateKey(stackName, region);
     const { expectedEtag, migrateLegacy } = options;
 
@@ -271,9 +364,13 @@ export class S3StateBackend {
         );
       }
 
+      const normalized = normalizeAwsError(error, {
+        bucket: this.config.bucket,
+        operation: 'PutObject',
+      });
       throw new StateError(
-        `Failed to save state for stack '${stackName}' (${region}): ${error instanceof Error ? error.message : String(error)}`,
-        error instanceof Error ? error : undefined
+        `Failed to save state for stack '${stackName}' (${region}): ${normalized.message}`,
+        normalized
       );
     }
   }
@@ -286,6 +383,7 @@ export class S3StateBackend {
    * field is left alone.
    */
   async deleteState(stackName: string, region: string): Promise<void> {
+    await this.ensureClientForBucket();
     try {
       this.logger.debug(`Deleting state: ${stackName} (${region})`);
 
@@ -309,9 +407,13 @@ export class S3StateBackend {
 
       this.logger.debug(`State deleted: ${stackName} (${region})`);
     } catch (error) {
+      const normalized = normalizeAwsError(error, {
+        bucket: this.config.bucket,
+        operation: 'DeleteObject',
+      });
       throw new StateError(
-        `Failed to delete state for stack '${stackName}' (${region}): ${error instanceof Error ? error.message : String(error)}`,
-        error instanceof Error ? error : undefined
+        `Failed to delete state for stack '${stackName}' (${region}): ${normalized.message}`,
+        normalized
       );
     }
   }
@@ -331,6 +433,7 @@ export class S3StateBackend {
    * shows up exactly once.
    */
   async listStacks(): Promise<StackStateRef[]> {
+    await this.ensureClientForBucket();
     try {
       this.logger.debug('Listing all stacks');
 
@@ -387,10 +490,11 @@ export class S3StateBackend {
       this.logger.debug(`Found ${refs.length} stack(s) across regions`);
       return refs;
     } catch (error) {
-      throw new StateError(
-        `Failed to list stacks: ${error instanceof Error ? error.message : String(error)}`,
-        error instanceof Error ? error : undefined
-      );
+      const normalized = normalizeAwsError(error, {
+        bucket: this.config.bucket,
+        operation: 'ListObjectsV2',
+      });
+      throw new StateError(`Failed to list stacks: ${normalized.message}`, normalized);
     }
   }
 

--- a/src/utils/aws-region-resolver.ts
+++ b/src/utils/aws-region-resolver.ts
@@ -1,0 +1,94 @@
+import { GetBucketLocationCommand, S3Client } from '@aws-sdk/client-s3';
+
+/**
+ * Per-bucket region cache.
+ *
+ * Storing the in-flight `Promise` (rather than the resolved value) collapses
+ * concurrent calls for the same bucket into a single `GetBucketLocation`
+ * request — the second caller awaits the same promise instead of issuing a
+ * duplicate API call.
+ */
+const cache = new Map<string, Promise<string>>();
+
+/**
+ * Options accepted by {@link resolveBucketRegion}.
+ *
+ * `profile` and `credentials` mirror the AWS SDK shape so callers can pass
+ * the same auth configuration the rest of cdkd uses.
+ *
+ * `fallbackRegion` is returned if `GetBucketLocation` fails for any reason —
+ * the resolver never throws so a missing/forbidden bucket does not block the
+ * caller from surfacing a more useful downstream error (e.g. the actionable
+ * `normalizeAwsError` message).
+ */
+export interface ResolveBucketRegionOptions {
+  profile?: string;
+  credentials?: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken?: string;
+  };
+  fallbackRegion?: string;
+}
+
+/**
+ * Resolve the AWS region of an S3 bucket via `GetBucketLocation`.
+ *
+ * Why `GetBucketLocation` rather than `HeadBucket`:
+ *   AWS SDK v3's region-redirect middleware does not handle the empty-body
+ *   HEAD response on a 301 cross-region redirect cleanly — the protocol
+ *   parser falls through to `getErrorSchemaOrThrowBaseException` and
+ *   produces a synthetic `name: 'Unknown', message: 'UnknownError'`.
+ *   `GetBucketLocation` is a GET with an XML body and is not subject to the
+ *   same SDK glitch.
+ *
+ * Why a region-agnostic client (us-east-1):
+ *   `GetBucketLocation` works against the global S3 endpoint regardless of
+ *   the bucket's actual region, so we don't need to know the answer to ask
+ *   the question.
+ *
+ * The result is cached per bucket name for the process lifetime — bucket
+ * regions never move, so the cache never needs invalidation.
+ *
+ * @returns The bucket's region (e.g. `us-west-2`). An empty `LocationConstraint`
+ *   in the response means `us-east-1` (S3 quirk). On any error, returns
+ *   `opts.fallbackRegion` if provided, else `us-east-1`.
+ */
+export async function resolveBucketRegion(
+  bucketName: string,
+  opts: ResolveBucketRegionOptions = {}
+): Promise<string> {
+  const cached = cache.get(bucketName);
+  if (cached) return cached;
+
+  const promise = (async (): Promise<string> => {
+    const client = new S3Client({
+      region: 'us-east-1',
+      ...(opts.profile && { profile: opts.profile }),
+      ...(opts.credentials && { credentials: opts.credentials }),
+    });
+    try {
+      const response = await client.send(new GetBucketLocationCommand({ Bucket: bucketName }));
+      // Empty / null `LocationConstraint` is S3's way of saying us-east-1.
+      return response.LocationConstraint || 'us-east-1';
+    } catch {
+      // The resolver never throws: cdkd would rather surface the actionable
+      // downstream error (HeadBucket → `normalizeAwsError`) than mask it
+      // behind a noisy GetBucketLocation failure.
+      return opts.fallbackRegion ?? 'us-east-1';
+    } finally {
+      client.destroy();
+    }
+  })();
+
+  cache.set(bucketName, promise);
+  return promise;
+}
+
+/**
+ * Clear the per-bucket region cache. Used by tests to reset state between
+ * cases — production code never needs to call this.
+ */
+export function clearBucketRegionCache(): void {
+  cache.clear();
+}

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -155,3 +155,82 @@ export function withErrorHandling<Args extends unknown[], Return extends Promise
     }
   };
 }
+
+/**
+ * Context passed to {@link normalizeAwsError} so the rewritten message can
+ * name the bucket/operation that produced the synthetic SDK error.
+ */
+export interface NormalizeAwsErrorContext {
+  bucket?: string;
+  operation?: string;
+}
+
+/**
+ * Convert AWS SDK v3's synthetic `Unknown` / `UnknownError` exception into
+ * an actionable `Error` keyed off `$metadata.httpStatusCode`.
+ *
+ * Background — why this helper exists:
+ *   AWS SDK v3 produces a synthetic `name: 'Unknown'`, `message:
+ *   'UnknownError'` exception when the protocol parser hits a HEAD response
+ *   with an empty body. The most common trigger is `HeadBucket` against a
+ *   bucket in a different region than the client (S3 returns 301
+ *   PermanentRedirect with `x-amz-bucket-region` set, but the redirect
+ *   middleware doesn't recover from the empty body). Surfacing the literal
+ *   string `UnknownError` to users is uninformative.
+ *
+ * Behavior:
+ *   - Non-AWS-SDK errors (anything where `name` is not `Unknown` and
+ *     `message` is not `UnknownError`) pass through unchanged.
+ *   - AWS SDK Unknown errors are mapped by HTTP status:
+ *     - 301 → `Bucket '<name>' is in a different region…` (auto-resolved
+ *       elsewhere; if this surfaces, it's a bug worth reporting).
+ *     - 403 → `Access denied to bucket '<name>'.`
+ *     - 404 → `Bucket '<name>' does not exist.`
+ *     - other / unknown → `S3 error during <operation> on '<bucket>' (HTTP
+ *       <status>).`
+ */
+export function normalizeAwsError(err: unknown, context: NormalizeAwsErrorContext = {}): Error {
+  if (!(err instanceof Error)) {
+    return new Error(String(err));
+  }
+
+  // Detect the AWS SDK v3 "Unknown" synthetic exception. Other errors pass
+  // through unchanged so we don't accidentally rewrite a legitimate AWS
+  // error message.
+  const isUnknown = err.name === 'Unknown' || err.message === 'UnknownError';
+  if (!isUnknown) return err;
+
+  const meta = (err as { $metadata?: { httpStatusCode?: number } }).$metadata;
+  const status = meta?.httpStatusCode;
+  const bucket = context.bucket ?? '<unknown bucket>';
+  const operation = context.operation ?? 'operation';
+
+  switch (status) {
+    case 301: {
+      // Try to surface the bucket's actual region from the response header
+      // when the SDK exposes it. Header keys are lowercased by the SDK.
+      const responseHeaders = (err as { $response?: { headers?: Record<string, string> } })
+        .$response?.headers;
+      const region =
+        responseHeaders?.['x-amz-bucket-region'] ?? responseHeaders?.['X-Amz-Bucket-Region'];
+      const where = region ? ` (in ${region})` : '';
+      return new Error(
+        `Bucket '${bucket}'${where} is in a different region than the client. ` +
+          `cdkd resolves this automatically; if you see this message, please report it.`
+      );
+    }
+    case 403:
+      return new Error(
+        `Access denied to bucket '${bucket}'. Verify credentials and bucket policy.`
+      );
+    case 404:
+      return new Error(`Bucket '${bucket}' does not exist.`);
+    default: {
+      const statusStr = status !== undefined ? `HTTP ${status}` : 'unknown HTTP status';
+      return new Error(
+        `S3 error during ${operation} on '${bucket}' (${statusStr}). ` +
+          `See CloudTrail for details.`
+      );
+    }
+  }
+}

--- a/tests/integration/cross-region-state-bucket/README.md
+++ b/tests/integration/cross-region-state-bucket/README.md
@@ -1,0 +1,51 @@
+# cross-region-state-bucket
+
+Integration test fixture that verifies cdkd works when the state bucket
+lives in a different AWS region from the CLI's profile region.
+
+## Background
+
+Pre-PR-3 (`docs/plans/03-dynamic-region-resolution.md`), running
+`cdkd state list --state-bucket <bucket-in-us-west-2>` from a
+profile defaulting to `us-east-1` would fail with the AWS SDK v3
+synthetic `UnknownError` — the SDK's region-redirect middleware does not
+recover cleanly from the empty-body 301 HEAD response S3 returns when the
+client's region does not match the bucket's region.
+
+After PR 3, the state backend resolves the bucket region via
+`GetBucketLocation` (a GET, not a HEAD — has a body and is not subject to
+the SDK glitch) and rebuilds its S3 client for the bucket's actual region
+before issuing any state operation. Provisioning clients are unaffected
+and continue to use `env.region`.
+
+## Manual run
+
+Create a state bucket in a non-default region, then run cdkd commands
+under a different default region:
+
+```bash
+# Bucket in us-west-2.
+aws s3api create-bucket \
+  --bucket cdkd-state-test-cross-region \
+  --region us-west-2 \
+  --create-bucket-configuration LocationConstraint=us-west-2
+
+# CLI defaults to us-east-1, but the state bucket lives in us-west-2.
+AWS_REGION=us-east-1 cdkd deploy   --state-bucket cdkd-state-test-cross-region
+AWS_REGION=us-east-1 cdkd state ls --state-bucket cdkd-state-test-cross-region
+AWS_REGION=us-east-1 cdkd destroy  --state-bucket cdkd-state-test-cross-region
+
+# Cleanup.
+aws s3 rb s3://cdkd-state-test-cross-region --region us-west-2 --force
+```
+
+Expected: every command runs to completion. Pre-PR-3 the `state ls` /
+`deploy` commands would surface `UnknownError` and abort.
+
+## What this fixture does NOT cover
+
+- The provisioning clients (CC API, Lambda, IAM, etc.) are still pointed
+  at `env.region`. This test only exercises the state-bucket S3 client's
+  region resolution.
+- `/run-integ` does not invoke this fixture by default — it requires a
+  pre-existing bucket in a non-default region and is therefore manual.

--- a/tests/integration/cross-region-state-bucket/bin/app.ts
+++ b/tests/integration/cross-region-state-bucket/bin/app.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { CrossRegionStateBucketStack } from '../lib/cross-region-state-bucket-stack';
+
+const app = new cdk.App();
+
+new CrossRegionStateBucketStack(app, 'CdkdCrossRegionStateBucketExample', {
+  description: 'Verifies cdkd works when the state bucket is in a different region than the CLI region',
+});

--- a/tests/integration/cross-region-state-bucket/cdk.json
+++ b/tests/integration/cross-region-state-bucket/cdk.json
@@ -1,0 +1,8 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/app.ts",
+  "context": {
+    "cdkd": {
+      "stateBucket": "cdkd-state-test-cross-region"
+    }
+  }
+}

--- a/tests/integration/cross-region-state-bucket/lib/cross-region-state-bucket-stack.ts
+++ b/tests/integration/cross-region-state-bucket/lib/cross-region-state-bucket-stack.ts
@@ -1,0 +1,36 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+
+/**
+ * Trivial stack for the cross-region-state-bucket integration test.
+ *
+ * The point of this fixture is *not* the resources it creates — it is the
+ * combination of a state bucket in one region (e.g. us-west-2) and a CLI
+ * invocation under a different default region (e.g. us-east-1). The stack
+ * itself just needs at least one cheap resource so deploy/destroy do
+ * something observable.
+ *
+ * Manual run example:
+ *
+ *   AWS_REGION=us-east-1 cdkd deploy --state-bucket cdkd-state-test-cross-region
+ *   AWS_REGION=us-east-1 cdkd state list --state-bucket cdkd-state-test-cross-region
+ *   AWS_REGION=us-east-1 cdkd destroy --state-bucket cdkd-state-test-cross-region
+ *
+ * Pre-PR-3 the second command would surface the AWS SDK v3 synthetic
+ * `UnknownError`; post-PR-3 it succeeds silently because the backend
+ * resolves the bucket region via GetBucketLocation and rebuilds its
+ * S3 client to the bucket's region.
+ */
+export class CrossRegionStateBucketStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    new ssm.CfnParameter(this, 'CrossRegionMarker', {
+      type: 'String',
+      value: 'cdkd cross-region-state-bucket fixture',
+      name: `${this.stackName}-marker`,
+      description: 'Marker parameter for the cross-region state-bucket integration test',
+    });
+  }
+}

--- a/tests/integration/cross-region-state-bucket/package.json
+++ b/tests/integration/cross-region-state-bucket/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkd-example-cross-region-state-bucket",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Verifies that cdkd state list works when the state bucket is in a different region than the CLI's profile region",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0",
+    "ts-node": "^10.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/tests/integration/cross-region-state-bucket/tsconfig.json
+++ b/tests/integration/cross-region-state-bucket/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "exclude": ["node_modules", "cdk.out"]
+}

--- a/tests/unit/state/s3-state-backend.test.ts
+++ b/tests/unit/state/s3-state-backend.test.ts
@@ -13,6 +13,7 @@ import { S3StateBackend } from '../../../src/state/s3-state-backend.js';
 import type { StateBackendConfig } from '../../../src/types/config.js';
 import type { StackState } from '../../../src/types/state.js';
 import { StateError } from '../../../src/utils/error-handler.js';
+import { clearBucketRegionCache } from '../../../src/utils/aws-region-resolver.js';
 
 vi.mock('@aws-sdk/client-s3', async () => {
   const actual = await vi.importActual<typeof import('@aws-sdk/client-s3')>('@aws-sdk/client-s3');
@@ -20,7 +21,20 @@ vi.mock('@aws-sdk/client-s3', async () => {
     ...actual,
     S3Client: vi.fn().mockImplementation(() => ({
       send: vi.fn(),
+      destroy: vi.fn(),
     })),
+  };
+});
+
+// Mock the region resolver so tests don't issue real GetBucketLocation calls.
+// Each test case overrides the implementation as needed.
+vi.mock('../../../src/utils/aws-region-resolver.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../src/utils/aws-region-resolver.js')
+  >('../../../src/utils/aws-region-resolver.js');
+  return {
+    ...actual,
+    resolveBucketRegion: vi.fn(),
   };
 });
 
@@ -39,18 +53,43 @@ vi.mock('../../../src/utils/logger.js', () => ({
   }),
 }));
 
+/**
+ * Build a fake S3Client whose `.config.region()` returns the given region.
+ * Mirrors the shape S3StateBackend reads in `ensureClientForBucket`.
+ */
+function makeFakeClient(region: string): {
+  send: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+  config: { region: () => Promise<string> };
+} {
+  return {
+    send: vi.fn(),
+    destroy: vi.fn(),
+    config: { region: () => Promise.resolve(region) },
+  };
+}
+
 describe('S3StateBackend.verifyBucketExists', () => {
-  let s3Client: { send: ReturnType<typeof vi.fn> };
+  let s3Client: ReturnType<typeof makeFakeClient>;
   let backend: S3StateBackend;
   const config: StateBackendConfig = {
     bucket: 'my-state-bucket',
     prefix: 'stacks',
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
-    s3Client = { send: vi.fn() };
-    backend = new S3StateBackend(s3Client as unknown as S3Client, config);
+    clearBucketRegionCache();
+    // Default: bucket is already in the same region as the client, so
+    // ensureClientForBucket() does not rebuild the client.
+    const { resolveBucketRegion } = await import(
+      '../../../src/utils/aws-region-resolver.js'
+    );
+    vi.mocked(resolveBucketRegion).mockResolvedValue('us-east-1');
+    s3Client = makeFakeClient('us-east-1');
+    backend = new S3StateBackend(s3Client as unknown as S3Client, config, {
+      region: 'us-east-1',
+    });
   });
 
   it('resolves when the bucket exists', async () => {
@@ -92,6 +131,104 @@ describe('S3StateBackend.verifyBucketExists', () => {
     expect(caught).toBeInstanceOf(StateError);
     expect((caught as Error).message).toMatch(/Failed to verify state bucket/);
     expect((caught as Error).message).not.toMatch(/cdkd bootstrap/);
+  });
+
+  it('routes the AWS SDK v3 UnknownError through normalizeAwsError (404 → bucket does not exist)', async () => {
+    const unknown = Object.assign(new Error('UnknownError'), {
+      name: 'Unknown',
+      $metadata: { httpStatusCode: 404 },
+    });
+    s3Client.send.mockRejectedValue(unknown);
+
+    const caught = await backend.verifyBucketExists().catch((e: unknown) => e);
+    expect(caught).toBeInstanceOf(StateError);
+    // The verifyBucketExists wrapper takes the normalized message and
+    // re-wraps it; the inner-message text is what we care about here.
+    expect((caught as Error).message).toMatch(/Bucket 'my-state-bucket' does not exist/);
+    expect((caught as Error).message).not.toMatch(/UnknownError/);
+  });
+});
+
+describe('S3StateBackend.ensureClientForBucket — region rebuild', () => {
+  const config: StateBackendConfig = {
+    bucket: 'cross-region-bucket',
+    prefix: 'stacks',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearBucketRegionCache();
+  });
+
+  it('rebuilds the S3 client when the resolved bucket region differs', async () => {
+    const { resolveBucketRegion } = await import(
+      '../../../src/utils/aws-region-resolver.js'
+    );
+    // Bucket lives in us-west-2, client was created for us-east-1.
+    vi.mocked(resolveBucketRegion).mockResolvedValue('us-west-2');
+
+    const initialClient = makeFakeClient('us-east-1');
+    initialClient.send.mockResolvedValue({}); // HeadBucket returns ok
+
+    const backend = new S3StateBackend(initialClient as unknown as S3Client, config, {
+      region: 'us-east-1',
+    });
+
+    await backend.verifyBucketExists();
+
+    // The original us-east-1 client should have been destroyed in favor of
+    // a us-west-2 client.
+    expect(initialClient.destroy).toHaveBeenCalled();
+    // S3Client constructor invoked once to build the replacement.
+    expect(vi.mocked(S3Client)).toHaveBeenCalledWith(
+      expect.objectContaining({ region: 'us-west-2' })
+    );
+  });
+
+  it('does not rebuild the client when the resolved region matches', async () => {
+    const { resolveBucketRegion } = await import(
+      '../../../src/utils/aws-region-resolver.js'
+    );
+    vi.mocked(resolveBucketRegion).mockResolvedValue('us-east-1');
+
+    const initialClient = makeFakeClient('us-east-1');
+    initialClient.send.mockResolvedValue({});
+
+    // Reset the constructor call counter so we can assert on rebuilds only.
+    vi.mocked(S3Client).mockClear();
+
+    const backend = new S3StateBackend(initialClient as unknown as S3Client, config, {
+      region: 'us-east-1',
+    });
+
+    await backend.verifyBucketExists();
+
+    expect(initialClient.destroy).not.toHaveBeenCalled();
+    // No replacement client was constructed.
+    expect(vi.mocked(S3Client)).not.toHaveBeenCalled();
+  });
+
+  it('only resolves the bucket region once across multiple public calls', async () => {
+    const { resolveBucketRegion } = await import(
+      '../../../src/utils/aws-region-resolver.js'
+    );
+    vi.mocked(resolveBucketRegion).mockResolvedValue('us-east-1');
+
+    const initialClient = makeFakeClient('us-east-1');
+    // Each public call issues one S3 send (HeadBucket / ListObjectsV2 / etc.).
+    initialClient.send.mockResolvedValue({ CommonPrefixes: [] });
+
+    const backend = new S3StateBackend(initialClient as unknown as S3Client, config, {
+      region: 'us-east-1',
+    });
+
+    await backend.verifyBucketExists();
+    await backend.listStacks();
+    await backend.listStacks();
+
+    // resolveBucketRegion should have been called exactly once even though
+    // three public methods ran.
+    expect(vi.mocked(resolveBucketRegion)).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/unit/state/s3-state-backend.test.ts
+++ b/tests/unit/state/s3-state-backend.test.ts
@@ -267,16 +267,22 @@ function bodyOf(state: StackState) {
 }
 
 describe('S3StateBackend region-prefixed key layout (PR 1)', () => {
-  let s3Client: { send: ReturnType<typeof vi.fn> };
+  let s3Client: ReturnType<typeof makeFakeClient>;
   let backend: S3StateBackend;
   const config: StateBackendConfig = {
     bucket: 'state-bucket',
     prefix: 'cdkd',
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
-    s3Client = { send: vi.fn() };
+    clearBucketRegionCache();
+    // Bucket is in the same region as the client; ensureClientForBucket() is a no-op.
+    const { resolveBucketRegion } = await import(
+      '../../../src/utils/aws-region-resolver.js'
+    );
+    vi.mocked(resolveBucketRegion).mockResolvedValue('us-east-1');
+    s3Client = makeFakeClient('us-east-1');
     backend = new S3StateBackend(s3Client as unknown as S3Client, config);
   });
 

--- a/tests/unit/utils/aws-region-resolver.test.ts
+++ b/tests/unit/utils/aws-region-resolver.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  resolveBucketRegion,
+  clearBucketRegionCache,
+} from '../../../src/utils/aws-region-resolver.js';
+
+// Replace the real S3Client with a controllable mock. Each test reaches
+// into `mockSend` to dictate the GetBucketLocation result.
+const mockSend = vi.fn();
+const mockDestroy = vi.fn();
+
+vi.mock('@aws-sdk/client-s3', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-s3')>('@aws-sdk/client-s3');
+  return {
+    ...actual,
+    S3Client: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      destroy: mockDestroy,
+    })),
+  };
+});
+
+describe('resolveBucketRegion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearBucketRegionCache();
+  });
+
+  it('returns the LocationConstraint for a non-us-east-1 bucket', async () => {
+    mockSend.mockResolvedValueOnce({ LocationConstraint: 'us-west-2' });
+
+    const region = await resolveBucketRegion('my-bucket');
+
+    expect(region).toBe('us-west-2');
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns us-east-1 when LocationConstraint is empty (S3 quirk)', async () => {
+    mockSend.mockResolvedValueOnce({ LocationConstraint: '' });
+
+    const region = await resolveBucketRegion('us-east-bucket');
+
+    expect(region).toBe('us-east-1');
+  });
+
+  it('returns us-east-1 when LocationConstraint is null', async () => {
+    mockSend.mockResolvedValueOnce({ LocationConstraint: null });
+
+    const region = await resolveBucketRegion('us-east-bucket-null');
+
+    expect(region).toBe('us-east-1');
+  });
+
+  it('caches the result for subsequent calls (no new API call)', async () => {
+    mockSend.mockResolvedValueOnce({ LocationConstraint: 'eu-west-1' });
+
+    const first = await resolveBucketRegion('cached-bucket');
+    const second = await resolveBucketRegion('cached-bucket');
+    const third = await resolveBucketRegion('cached-bucket');
+
+    expect(first).toBe('eu-west-1');
+    expect(second).toBe('eu-west-1');
+    expect(third).toBe('eu-west-1');
+    // Single API call shared by all three callers.
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('collapses concurrent calls for the same bucket into one API call', async () => {
+    mockSend.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve({ LocationConstraint: 'ap-northeast-1' }), 10);
+        })
+    );
+
+    const [a, b, c] = await Promise.all([
+      resolveBucketRegion('concurrent-bucket'),
+      resolveBucketRegion('concurrent-bucket'),
+      resolveBucketRegion('concurrent-bucket'),
+    ]);
+
+    expect(a).toBe('ap-northeast-1');
+    expect(b).toBe('ap-northeast-1');
+    expect(c).toBe('ap-northeast-1');
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns fallbackRegion when GetBucketLocation throws', async () => {
+    mockSend.mockRejectedValueOnce(
+      Object.assign(new Error('Access Denied'), { name: 'AccessDenied' })
+    );
+
+    const region = await resolveBucketRegion('forbidden-bucket', {
+      fallbackRegion: 'eu-central-1',
+    });
+
+    expect(region).toBe('eu-central-1');
+    // Even on failure the client must be destroyed (no socket leak).
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns us-east-1 when no fallbackRegion is provided and the call fails', async () => {
+    mockSend.mockRejectedValueOnce(new Error('network error'));
+
+    const region = await resolveBucketRegion('flaky-bucket');
+
+    expect(region).toBe('us-east-1');
+  });
+
+  it('keeps separate cache entries per bucket name', async () => {
+    mockSend
+      .mockResolvedValueOnce({ LocationConstraint: 'us-west-2' })
+      .mockResolvedValueOnce({ LocationConstraint: 'eu-west-1' });
+
+    const a = await resolveBucketRegion('bucket-a');
+    const b = await resolveBucketRegion('bucket-b');
+
+    expect(a).toBe('us-west-2');
+    expect(b).toBe('eu-west-1');
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/utils/error-handler.test.ts
+++ b/tests/unit/utils/error-handler.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAwsError } from '../../../src/utils/error-handler.js';
+
+/**
+ * Build the AWS SDK v3 synthetic Unknown error shape that this helper is
+ * designed to translate.
+ */
+function makeUnknownError(
+  status: number | undefined,
+  extra: Record<string, unknown> = {}
+): Error {
+  return Object.assign(new Error('UnknownError'), {
+    name: 'Unknown',
+    $metadata: status !== undefined ? { httpStatusCode: status } : undefined,
+    ...extra,
+  }) as Error;
+}
+
+describe('normalizeAwsError', () => {
+  it('passes a regular AWS error through unchanged', () => {
+    const err = Object.assign(new Error('Access Denied'), {
+      name: 'AccessDenied',
+      $metadata: { httpStatusCode: 403 },
+    });
+
+    const result = normalizeAwsError(err, { bucket: 'b', operation: 'op' });
+
+    // Same reference: untouched.
+    expect(result).toBe(err);
+  });
+
+  it('passes a non-Error value through wrapped in Error', () => {
+    const result = normalizeAwsError('boom');
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('boom');
+  });
+
+  it('detects via err.name === "Unknown"', () => {
+    const err = Object.assign(new Error('something else'), {
+      name: 'Unknown',
+      $metadata: { httpStatusCode: 404 },
+    });
+
+    const result = normalizeAwsError(err, { bucket: 'b' });
+
+    expect(result.message).toMatch(/does not exist/);
+  });
+
+  it('detects via err.message === "UnknownError"', () => {
+    const err = Object.assign(new Error('UnknownError'), {
+      name: 'SomeOtherName',
+      $metadata: { httpStatusCode: 404 },
+    });
+
+    const result = normalizeAwsError(err, { bucket: 'b' });
+
+    expect(result.message).toMatch(/does not exist/);
+  });
+
+  it('301 → different-region message including the region from response headers', () => {
+    const err = makeUnknownError(301, {
+      $response: { headers: { 'x-amz-bucket-region': 'us-west-2' } },
+    });
+
+    const result = normalizeAwsError(err, { bucket: 'cross-region', operation: 'HeadBucket' });
+
+    expect(result.message).toMatch(/Bucket 'cross-region'/);
+    expect(result.message).toMatch(/different region/);
+    expect(result.message).toMatch(/us-west-2/);
+  });
+
+  it('301 → different-region message even when the region header is missing', () => {
+    const err = makeUnknownError(301);
+
+    const result = normalizeAwsError(err, { bucket: 'cross-region' });
+
+    expect(result.message).toMatch(/different region/);
+    // No "(in <region>)" parenthetical when the header is absent.
+    expect(result.message).not.toMatch(/\(in /);
+  });
+
+  it('403 → access denied message naming the bucket', () => {
+    const err = makeUnknownError(403);
+
+    const result = normalizeAwsError(err, { bucket: 'forbidden' });
+
+    expect(result.message).toMatch(/Access denied/);
+    expect(result.message).toMatch(/'forbidden'/);
+  });
+
+  it('404 → bucket does not exist', () => {
+    const err = makeUnknownError(404);
+
+    const result = normalizeAwsError(err, { bucket: 'missing' });
+
+    expect(result.message).toMatch(/Bucket 'missing' does not exist/);
+  });
+
+  it('500 → fallback HTTP status message', () => {
+    const err = makeUnknownError(500);
+
+    const result = normalizeAwsError(err, { bucket: 'b', operation: 'GetObject' });
+
+    expect(result.message).toMatch(/S3 error during GetObject/);
+    expect(result.message).toMatch(/HTTP 500/);
+  });
+
+  it('missing $metadata → uses "unknown HTTP status"', () => {
+    const err = makeUnknownError(undefined);
+
+    const result = normalizeAwsError(err, { bucket: 'b', operation: 'PutObject' });
+
+    expect(result.message).toMatch(/unknown HTTP status/);
+    expect(result.message).toMatch(/PutObject/);
+  });
+
+  it("uses '<unknown bucket>' when no bucket context is provided", () => {
+    const err = makeUnknownError(404);
+
+    const result = normalizeAwsError(err);
+
+    expect(result.message).toMatch(/'<unknown bucket>'/);
+  });
+});


### PR DESCRIPTION
## Summary

Two related fixes for working with state buckets that live in a region different from the CLI's profile region.

### 1. Dynamic state-bucket region resolution

When the cdkd CLI's profile region differs from the state bucket's actual region (e.g. `--state-bucket cdkd-state-test` pointing at a teammate's bucket; default region changed locally without re-bootstrapping), the S3 client constructed for the profile region issues `HeadBucket` against a bucket in another region. S3 returns 301 PermanentRedirect with `x-amz-bucket-region` set, but the AWS SDK v3 region-redirect middleware does not handle the empty-body HEAD response cleanly — the protocol parser falls through to `getErrorSchemaOrThrowBaseException` and produces a synthetic `name: 'Unknown'`, `message: 'UnknownError'` exception. Users see:

```
StateError: Failed to verify state bucket 'X': UnknownError
Caused by: UnknownError
```

…which is uninformative.

**Fix**: New helper `src/utils/aws-region-resolver.ts` exposes `resolveBucketRegion(bucketName)`. It:

- Calls `GetBucketLocation` (a GET, not HEAD — has an XML body and is not subject to the same SDK glitch).
- Uses a region-agnostic client (us-east-1 = global S3 endpoint).
- Caches results per-bucket name; collapses concurrent calls into a single in-flight promise.

`S3StateBackend` calls the resolver from a new `ensureClientForBucket()` private helper at the start of every public method (`verifyBucketExists`, `getState`, `saveState`, `deleteState`, `listStacks`, `stateExists`). If the resolved region differs from the client's region, it rebuilds the `S3Client` for the bucket region. Both the resolver and the rebuild are idempotent and single-flighted.

**Scope**: only the state-bucket S3 client is region-corrected. Provisioning clients (CC API, Lambda, IAM, etc.) keep using `env.region` so resources are still created in the region the CDK app declares.

### 2. UnknownError normalization

New `normalizeAwsError(err, context)` exported from `src/utils/error-handler.ts` detects the AWS SDK v3 synthetic `Unknown` / `UnknownError` exception and rewrites the message based on `$metadata.httpStatusCode`:

- `301` → `Bucket '<name>' (in <region>) is in a different region than the client. cdkd resolves this automatically; if you see this message, please report it.`
- `403` → `Access denied to bucket '<name>'. Verify credentials and bucket policy.`
- `404` → `Bucket '<name>' does not exist.`
- other / unknown → `S3 error during <operation> on '<bucket>' (HTTP <status>). See CloudTrail for details.`

Non-Unknown errors pass through unchanged. `S3StateBackend` and `bootstrap`'s pre-existence `HeadBucket` route their errors through `normalizeAwsError`, so the cross-region case (or any other case where the SDK produces an `Unknown` exception) now produces actionable text instead of the literal string `UnknownError`.

## Files

- `src/utils/aws-region-resolver.ts` (new) — `resolveBucketRegion()` + per-bucket cache.
- `src/utils/error-handler.ts` — adds `normalizeAwsError` + `NormalizeAwsErrorContext`.
- `src/state/s3-state-backend.ts` — adds `ensureClientForBucket()`, accepts `clientOpts` constructor arg, routes errors through `normalizeAwsError`.
- `src/cli/commands/{deploy,destroy,diff,state}.ts` — pass `clientOpts` (region/profile) to `S3StateBackend`.
- `src/cli/commands/bootstrap.ts` — `HeadBucket` pre-check routes errors through `normalizeAwsError`.
- `src/index.ts` — adds public exports for the new helpers.
- `tests/unit/utils/aws-region-resolver.test.ts` (new) — 8 tests covering cache, fallback, concurrent collapse, error paths.
- `tests/unit/utils/error-handler.test.ts` (new) — 11 tests covering every status branch + non-Unknown pass-through.
- `tests/unit/state/s3-state-backend.test.ts` — extended with region rebuild on mismatch, no rebuild on match, single-resolution across calls, normalizeAwsError integration.
- `tests/integration/cross-region-state-bucket/` (new scaffold) — fixture for manual end-to-end verification (deploy/destroy with bucket and CLI in different regions).
- `CLAUDE.md`, `docs/state-management.md`, `docs/troubleshooting.md` — documentation updates.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `npx vitest --run` — 64 files / 791 tests pass
- [x] Manual: created a real bucket in `us-west-2`, ran `AWS_REGION=us-east-1 node dist/cli.js state list --state-bucket <bucket-in-us-west-2> --verbose`. Output:
  ```
  DEBUG [S3StateBackend] State bucket '<bucket>' is in 'us-west-2' (client was 'us-east-1'); rebuilding S3 client.
  DEBUG [S3StateBackend] Listing all stacks
  ```
  No `UnknownError`. Pre-PR-3 the same command would fail.
- [x] Manual: `AWS_REGION=us-east-1 node dist/cli.js state list --state-bucket <does-not-exist>` → `StateError: State bucket '<name>' does not exist. Run 'cdkd bootstrap' to create it…` (no `UnknownError` leak).

## Compatibility

No on-disk format change. Constructor change in `S3StateBackend` adds an optional third parameter (`clientOpts: S3ClientOptions = {}`) — fully backwards-compatible with any external caller. All in-tree call sites have been updated to pass region/profile.

## Retrospective notes

Surprises during this session worth recording:

- **Existing tests had to be updated when `ensureClientForBucket()` started reading `client.config.region()`** — the existing `s3-state-backend.test.ts` mocks did not include a `config` property and crashed. Pattern: when extending a class to read a new property of an injected dependency, every existing test that mocks that dependency must be audited. Worth surfacing as a memory entry rather than a hook (judgmental).
- **`git checkout <ref> -- <path>` stages files immediately**. Easy to miss when followed by `git switch -c`. The PR-3 commit almost included files belonging to the plans-rollout PR; caught manually before commit. Memory entry candidate.

Neither warrants a new hook — both are caught by the existing `/verify-pr` checklist (test-suite run + diff review).

## Reference

`docs/plans/03-dynamic-region-resolution.md` (lands via the plans-rollout PR — not included in this PR's diff).

**DO NOT MERGE** until plans-rollout has merged so the cross-reference resolves.
