### PR TITLE
feat(provisioning): verify region match before idempotent NotFound on delete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,10 +169,17 @@ interface ResourceState {
 interface ResourceProvider {
   create(logicalId: string, resourceType: string, properties: Record<string, unknown>): Promise<ResourceCreateResult>;
   update(physicalId: string, logicalId: string, resourceType: string, oldProperties: Record<string, unknown>, newProperties: Record<string, unknown>): Promise<void>;
-  delete(physicalId: string, logicalId: string, resourceType: string, properties: Record<string, unknown>): Promise<void>;
+  delete(physicalId: string, logicalId: string, resourceType: string, properties: Record<string, unknown>, context?: { expectedRegion?: string }): Promise<void>;
   getAttribute(physicalId: string, logicalId: string, resourceType: string, attributeName: string): Promise<any>;
 }
 ```
+
+The `context.expectedRegion` parameter on `delete` is the region recorded
+in the stack state when the resource was created. Providers MUST verify
+the AWS client's region against `context.expectedRegion` (via the shared
+`assertRegionMatch()` helper in `src/provisioning/region-check.ts`)
+before treating a `*NotFound` error as idempotent delete success — see
+"DELETE idempotency" below and `docs/provider-development.md`.
 
 Register Provider for each resource type in Provider Registry:
 
@@ -362,7 +369,7 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 - ✅ Dynamic References: `{{resolve:secretsmanager:...}}` and `{{resolve:ssm:...}}`
 - ✅ SDK Providers: see SDK Providers section above for full list
 - ✅ ALL pseudo parameters supported (7/7 including AWS::StackName/StackId)
-- ✅ DELETE idempotency (not-found/No policy found treated as success)
+- ✅ DELETE idempotency (not-found/No policy found treated as success **only when client region matches state region** — region-mismatched destroys now surface `ProvisioningError` instead of silently stripping resources from state; helper at `src/provisioning/region-check.ts`)
 - ✅ Destroy ordering: reverse dependency from state + implicit type-based deps
 - ✅ CC API null value stripping + JSON string properties (EventPattern)
 - ✅ CC API ClientToken removed (caches failure results, incompatible with retry)

--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -53,12 +53,19 @@ export interface ResourceProvider {
    * @param physicalId AWS physical ID
    * @param resourceType CloudFormation resource type
    * @param properties Resource properties (optional, for cleanup logic)
+   * @param context Delete-time context (optional). `context.expectedRegion`
+   *   is the region recorded in the stack state when the resource was
+   *   created. Providers MUST verify the AWS client's region against
+   *   `context.expectedRegion` before treating a `*NotFound` error as
+   *   idempotent delete success — see the "DELETE idempotency" section
+   *   below.
    */
   delete(
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void>;
 }
 ```
@@ -739,18 +746,53 @@ try {
 - Handle when `create` is called on existing resource
 - Handle when `delete` is called on non-existent resource
 
+**Region verification on `*NotFound`**: A `*NotFound` error during DELETE
+must NOT be treated as idempotent success without confirming that the AWS
+client's region matches the region the resource was deployed to. A destroy
+run pointing at the wrong region would otherwise receive `NotFound` for
+every resource and silently strip them all from state, leaving the actual
+AWS resources orphaned in the real region (this is the silent-failure
+incident that motivated PR 2 of the region/state refactor).
+
+Providers MUST call `assertRegionMatch()` from
+`src/provisioning/region-check.ts` before returning early on a `*NotFound`
+error:
+
 ```typescript
-// Example during deletion
-try {
-  await this.client.send(new GetXxxCommand({ Id: physicalId }));
-} catch (error) {
-  if (error instanceof ResourceNotFoundException) {
-    this.logger.info('Resource not found, skipping deletion');
-    return;
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
+
+async delete(
+  logicalId: string,
+  physicalId: string,
+  resourceType: string,
+  _properties?: Record<string, unknown>,
+  context?: DeleteContext,
+): Promise<void> {
+  try {
+    await this.client.send(new DeleteXxxCommand({ Id: physicalId }));
+  } catch (error) {
+    if (error instanceof ResourceNotFoundException) {
+      const clientRegion = await this.client.config.region();
+      assertRegionMatch(
+        clientRegion,
+        context?.expectedRegion,
+        resourceType,
+        logicalId,
+        physicalId,
+      );
+      this.logger.info('Resource not found, skipping deletion');
+      return;
+    }
+    throw error;
   }
-  throw error;
 }
 ```
+
+`assertRegionMatch` is a no-op when `context.expectedRegion` is undefined,
+preserving the existing idempotent semantics for callers that have not
+been threaded with state region. When set, a region mismatch throws a
+`ProvisioningError` that surfaces both regions and a hint to rerun with
+the correct `--region`.
 
 ### 3. Returning Attributes
 

--- a/src/cli/commands/destroy.ts
+++ b/src/cli/commands/destroy.ts
@@ -391,7 +391,8 @@ async function destroyCommand(
                     logicalId,
                     resource.physicalId,
                     resource.resourceType,
-                    resource.properties
+                    resource.properties,
+                    { expectedRegion: currentState.region }
                   );
                   lastDeleteError = null;
                   break;

--- a/src/deployment/deploy-engine.ts
+++ b/src/deployment/deploy-engine.ts
@@ -832,7 +832,9 @@ export class DeployEngine {
             `  Rollback: Deleting created resource ${op.logicalId} (${op.resourceType})`
           );
           const provider = this.providerRegistry.getProvider(op.resourceType);
-          await provider.delete(op.logicalId, op.physicalId, op.resourceType, op.properties);
+          await provider.delete(op.logicalId, op.physicalId, op.resourceType, op.properties, {
+            expectedRegion: this.stackRegion,
+          });
 
           // Remove from state
           delete stateResources[op.logicalId];
@@ -1049,7 +1051,8 @@ export class DeployEngine {
                   logicalId,
                   currentResource.physicalId,
                   resourceType,
-                  currentResource.properties
+                  currentResource.properties,
+                  { expectedRegion: this.stackRegion }
                 );
                 this.logger.info(`  ✓ Old resource deleted`);
               } catch (deleteError) {
@@ -1109,7 +1112,8 @@ export class DeployEngine {
                     logicalId,
                     currentResource.physicalId,
                     resourceType,
-                    currentProps
+                    currentProps,
+                    { expectedRegion: this.stackRegion }
                   );
                 } catch (deleteError) {
                   // If old resource doesn't exist (already deleted), proceed with CREATE
@@ -1193,7 +1197,8 @@ export class DeployEngine {
                   logicalId,
                   currentResource.physicalId,
                   resourceType,
-                  currentResource.properties
+                  currentResource.properties,
+                  { expectedRegion: this.stackRegion }
                 ),
               logicalId,
               3, // fewer retries for DELETE

--- a/src/provisioning/cloud-control-provider.ts
+++ b/src/provisioning/cloud-control-provider.ts
@@ -16,6 +16,7 @@ import { getAwsClients } from '../utils/aws-clients.js';
 import { getLogger } from '../utils/logger.js';
 import { ProvisioningError } from '../utils/error-handler.js';
 import { JsonPatchGenerator } from './json-patch-generator.js';
+import { assertRegionMatch, type DeleteContext } from './region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -280,7 +281,8 @@ export class CloudControlProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(
       `Deleting resource ${logicalId} (${resourceType}), physical ID: ${physicalId}`
@@ -313,7 +315,11 @@ export class CloudControlProvider implements ResourceProvider {
 
       this.logger.debug(`Deleted resource ${logicalId}`);
     } catch (error) {
-      // Treat "not found" / "does not exist" as idempotent success for DELETE
+      // Treat "not found" / "does not exist" as idempotent success for DELETE,
+      // but only when the AWS client is operating against the same region the
+      // resource was deployed to. A region mismatch must surface — otherwise a
+      // destroy run with the wrong region would silently strip every resource
+      // from state while leaving the actual AWS resources orphaned.
       const err = error as { name?: string; message?: string };
       if (
         err.name === 'ResourceNotFoundException' ||
@@ -321,6 +327,14 @@ export class CloudControlProvider implements ResourceProvider {
         err.message?.includes('not found') ||
         err.message?.includes('NotFound')
       ) {
+        const clientRegion = await this.cloudControlClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Resource ${logicalId} already deleted (not found), treating as success`);
         return;
       }

--- a/src/provisioning/providers/agentcore-runtime-provider.ts
+++ b/src/provisioning/providers/agentcore-runtime-provider.ts
@@ -49,6 +49,7 @@ function pascalToCamelCaseKeys(value: unknown): unknown {
 }
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -293,7 +294,8 @@ export class AgentCoreRuntimeProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting BedrockAgentCore Runtime ${logicalId}: ${physicalId}`);
 
@@ -307,6 +309,14 @@ export class AgentCoreRuntimeProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted BedrockAgentCore Runtime ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Runtime ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/apigateway-provider.ts
+++ b/src/provisioning/providers/apigateway-provider.ts
@@ -19,6 +19,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -174,21 +175,22 @@ export class ApiGatewayProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::ApiGateway::Account':
         return this.deleteAccount(logicalId, physicalId, resourceType);
       case 'AWS::ApiGateway::Authorizer':
-        return this.deleteAuthorizer(logicalId, physicalId, resourceType, properties);
+        return this.deleteAuthorizer(logicalId, physicalId, resourceType, properties, context);
       case 'AWS::ApiGateway::Resource':
-        return this.deleteResource(logicalId, physicalId, resourceType, properties);
+        return this.deleteResource(logicalId, physicalId, resourceType, properties, context);
       case 'AWS::ApiGateway::Deployment':
-        return this.deleteDeployment(logicalId, physicalId, resourceType, properties);
+        return this.deleteDeployment(logicalId, physicalId, resourceType, properties, context);
       case 'AWS::ApiGateway::Stage':
-        return this.deleteStage(logicalId, physicalId, resourceType, properties);
+        return this.deleteStage(logicalId, physicalId, resourceType, properties, context);
       case 'AWS::ApiGateway::Method':
-        return this.deleteMethod(logicalId, physicalId, resourceType);
+        return this.deleteMethod(logicalId, physicalId, resourceType, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -485,7 +487,8 @@ export class ApiGatewayProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting API Gateway Authorizer ${logicalId}: ${physicalId}`);
 
@@ -511,6 +514,14 @@ export class ApiGatewayProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted API Gateway Authorizer ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.apiGatewayClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`API Gateway Authorizer ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -653,7 +664,8 @@ export class ApiGatewayProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting API Gateway Resource ${logicalId}: ${physicalId}`);
 
@@ -679,6 +691,14 @@ export class ApiGatewayProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted API Gateway Resource ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.apiGatewayClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`API Gateway Resource ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -792,7 +812,8 @@ export class ApiGatewayProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting API Gateway Deployment ${logicalId}: ${physicalId}`);
 
@@ -818,6 +839,14 @@ export class ApiGatewayProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted API Gateway Deployment ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.apiGatewayClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`API Gateway Deployment ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -991,7 +1020,8 @@ export class ApiGatewayProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting API Gateway Stage ${logicalId}: ${physicalId}`);
 
@@ -1017,6 +1047,14 @@ export class ApiGatewayProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted API Gateway Stage ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.apiGatewayClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`API Gateway Stage ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -1162,7 +1200,8 @@ export class ApiGatewayProvider implements ResourceProvider {
   private async deleteMethod(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting API Gateway Method ${logicalId}: ${physicalId}`);
 
@@ -1190,6 +1229,14 @@ export class ApiGatewayProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted API Gateway Method ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.apiGatewayClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`API Gateway Method ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/apigatewayv2-provider.ts
+++ b/src/provisioning/providers/apigatewayv2-provider.ts
@@ -18,6 +18,7 @@ import {
 } from '@aws-sdk/client-apigatewayv2';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -136,19 +137,20 @@ export class ApiGatewayV2Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::ApiGatewayV2::Api':
-        return this.deleteApi(logicalId, physicalId, resourceType);
+        return this.deleteApi(logicalId, physicalId, resourceType, context);
       case 'AWS::ApiGatewayV2::Stage':
-        return this.deleteStage(logicalId, physicalId, resourceType, properties);
+        return this.deleteStage(logicalId, physicalId, resourceType, properties, context);
       case 'AWS::ApiGatewayV2::Integration':
-        return this.deleteIntegration(logicalId, physicalId, resourceType, properties);
+        return this.deleteIntegration(logicalId, physicalId, resourceType, properties, context);
       case 'AWS::ApiGatewayV2::Route':
-        return this.deleteRoute(logicalId, physicalId, resourceType, properties);
+        return this.deleteRoute(logicalId, physicalId, resourceType, properties, context);
       case 'AWS::ApiGatewayV2::Authorizer':
-        return this.deleteAuthorizer(logicalId, physicalId, resourceType, properties);
+        return this.deleteAuthorizer(logicalId, physicalId, resourceType, properties, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -243,7 +245,8 @@ export class ApiGatewayV2Provider implements ResourceProvider {
   private async deleteApi(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting API Gateway V2 Api ${logicalId}: ${physicalId}`);
 
@@ -252,6 +255,14 @@ export class ApiGatewayV2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted API Gateway V2 Api ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`API Gateway V2 Api ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -326,7 +337,8 @@ export class ApiGatewayV2Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting API Gateway V2 Stage ${logicalId}: ${physicalId}`);
 
@@ -345,6 +357,14 @@ export class ApiGatewayV2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted API Gateway V2 Stage ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`API Gateway V2 Stage ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -423,7 +443,8 @@ export class ApiGatewayV2Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting API Gateway V2 Integration ${logicalId}: ${physicalId}`);
 
@@ -444,6 +465,14 @@ export class ApiGatewayV2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted API Gateway V2 Integration ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(
           `API Gateway V2 Integration ${physicalId} does not exist, skipping deletion`
         );
@@ -522,7 +551,8 @@ export class ApiGatewayV2Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting API Gateway V2 Route ${logicalId}: ${physicalId}`);
 
@@ -541,6 +571,14 @@ export class ApiGatewayV2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted API Gateway V2 Route ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`API Gateway V2 Route ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -630,7 +668,8 @@ export class ApiGatewayV2Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting API Gateway V2 Authorizer ${logicalId}: ${physicalId}`);
 
@@ -651,6 +690,14 @@ export class ApiGatewayV2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted API Gateway V2 Authorizer ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(
           `API Gateway V2 Authorizer ${physicalId} does not exist, skipping deletion`
         );

--- a/src/provisioning/providers/appsync-provider.ts
+++ b/src/provisioning/providers/appsync-provider.ts
@@ -18,6 +18,7 @@ import {
 } from '@aws-sdk/client-appsync';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -128,21 +129,22 @@ export class AppSyncProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::AppSync::GraphQLApi':
-        return this.deleteGraphQLApi(logicalId, physicalId, resourceType);
+        return this.deleteGraphQLApi(logicalId, physicalId, resourceType, context);
       case 'AWS::AppSync::GraphQLSchema':
         // Schema is deleted with the API, no-op
         this.logger.debug(`Schema ${logicalId} is deleted with its API, skipping`);
         return;
       case 'AWS::AppSync::DataSource':
-        return this.deleteDataSource(logicalId, physicalId, resourceType);
+        return this.deleteDataSource(logicalId, physicalId, resourceType, context);
       case 'AWS::AppSync::Resolver':
-        return this.deleteResolver(logicalId, physicalId, resourceType);
+        return this.deleteResolver(logicalId, physicalId, resourceType, context);
       case 'AWS::AppSync::ApiKey':
-        return this.deleteApiKey(logicalId, physicalId, resourceType);
+        return this.deleteApiKey(logicalId, physicalId, resourceType, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -241,7 +243,8 @@ export class AppSyncProvider implements ResourceProvider {
   private async deleteGraphQLApi(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting GraphQL API ${logicalId}: ${physicalId}`);
 
@@ -250,6 +253,14 @@ export class AppSyncProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted GraphQL API ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`GraphQL API ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -400,7 +411,8 @@ export class AppSyncProvider implements ResourceProvider {
   private async deleteDataSource(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting DataSource ${logicalId}: ${physicalId}`);
 
@@ -415,6 +427,14 @@ export class AppSyncProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted DataSource ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`DataSource ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -512,7 +532,8 @@ export class AppSyncProvider implements ResourceProvider {
   private async deleteResolver(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Resolver ${logicalId}: ${physicalId}`);
 
@@ -528,6 +549,14 @@ export class AppSyncProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Resolver ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Resolver ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -597,7 +626,8 @@ export class AppSyncProvider implements ResourceProvider {
   private async deleteApiKey(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting ApiKey ${logicalId}: ${physicalId}`);
 
@@ -612,6 +642,14 @@ export class AppSyncProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted ApiKey ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`ApiKey ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/cloudfront-distribution-provider.ts
+++ b/src/provisioning/providers/cloudfront-distribution-provider.ts
@@ -11,6 +11,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -203,7 +204,8 @@ export class CloudFrontDistributionProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting CloudFront Distribution ${logicalId}: ${physicalId}`);
 
@@ -219,6 +221,14 @@ export class CloudFrontDistributionProvider implements ResourceProvider {
         config = getConfigResponse.DistributionConfig!;
       } catch (error) {
         if (error instanceof NoSuchDistribution) {
+          const clientRegion = await this.cloudFrontClient.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(`Distribution ${physicalId} does not exist, skipping deletion`);
           return;
         }
@@ -266,6 +276,14 @@ export class CloudFrontDistributionProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted CloudFront Distribution ${logicalId}`);
     } catch (error) {
       if (error instanceof NoSuchDistribution) {
+        const clientRegion = await this.cloudFrontClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Distribution ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/cloudfront-oai-provider.ts
+++ b/src/provisioning/providers/cloudfront-oai-provider.ts
@@ -8,6 +8,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -116,7 +117,8 @@ export class CloudFrontOAIProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting CloudFront OAI ${logicalId}: ${physicalId}`);
 
@@ -130,6 +132,14 @@ export class CloudFrontOAIProvider implements ResourceProvider {
         etag = getResponse.ETag!;
       } catch (error) {
         if (error instanceof NoSuchCloudFrontOriginAccessIdentity) {
+          const clientRegion = await this.cloudFrontClient.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(`OAI ${physicalId} does not exist, skipping deletion`);
           return;
         }
@@ -147,6 +157,14 @@ export class CloudFrontOAIProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted CloudFront OAI ${logicalId}`);
     } catch (error) {
       if (error instanceof NoSuchCloudFrontOriginAccessIdentity) {
+        const clientRegion = await this.cloudFrontClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`OAI ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/cloudtrail-provider.ts
+++ b/src/provisioning/providers/cloudtrail-provider.ts
@@ -13,6 +13,7 @@ import {
 } from '@aws-sdk/client-cloudtrail';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -269,7 +270,8 @@ export class CloudTrailProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting CloudTrail Trail ${logicalId}: ${physicalId}`);
 
@@ -285,6 +287,14 @@ export class CloudTrailProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted CloudTrail Trail ${logicalId}`);
     } catch (error) {
       if (error instanceof TrailNotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`CloudTrail Trail ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/cloudwatch-alarm-provider.ts
+++ b/src/provisioning/providers/cloudwatch-alarm-provider.ts
@@ -12,6 +12,7 @@ import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
 import { generateResourceName } from '../resource-name.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -151,7 +152,8 @@ export class CloudWatchAlarmProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting CloudWatch alarm ${logicalId}: ${physicalId}`);
 
@@ -165,6 +167,14 @@ export class CloudWatchAlarmProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted CloudWatch alarm ${logicalId}`);
     } catch (error) {
       if (error instanceof Error && error.name === 'ResourceNotFound') {
+        const clientRegion = await this.cloudWatchClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Alarm ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/codebuild-provider.ts
+++ b/src/provisioning/providers/codebuild-provider.ts
@@ -17,6 +17,7 @@ import {
 } from '@aws-sdk/client-codebuild';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -353,7 +354,8 @@ export class CodeBuildProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting CodeBuild Project ${logicalId}: ${physicalId}`);
 
@@ -362,6 +364,14 @@ export class CodeBuildProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted CodeBuild Project ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`CodeBuild Project ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/cognito-provider.ts
+++ b/src/provisioning/providers/cognito-provider.ts
@@ -28,6 +28,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
 import { generateResourceName } from '../resource-name.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -375,7 +376,8 @@ export class CognitoUserPoolProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Cognito User Pool ${logicalId}: ${physicalId}`);
 
@@ -411,6 +413,14 @@ export class CognitoUserPoolProvider implements ResourceProvider {
           }
         } catch (descError) {
           if (descError instanceof ResourceNotFoundException) {
+            const clientRegion = await this.getClient().config.region();
+            assertRegionMatch(
+              clientRegion,
+              context?.expectedRegion,
+              resourceType,
+              logicalId,
+              physicalId
+            );
             this.logger.debug(`Cognito User Pool ${physicalId} does not exist, skipping deletion`);
             return;
           }
@@ -425,6 +435,14 @@ export class CognitoUserPoolProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Cognito User Pool ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Cognito User Pool ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/custom-resource-provider.ts
+++ b/src/provisioning/providers/custom-resource-provider.ts
@@ -10,6 +10,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -330,8 +331,15 @@ export class CustomResourceProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    _context?: DeleteContext
   ): Promise<void> {
+    // Custom resources delegate deletion to a user-provided Lambda handler.
+    // The Lambda invocation itself does not surface a `*NotFound` for the
+    // managed resource, so the region-mismatch check has no signal to act on
+    // here; the underlying Lambda's region is determined by its ARN, which is
+    // already encoded in the ServiceToken regardless of the cdkd client's
+    // region. The context parameter is accepted for interface conformity.
     this.logger.debug(`Deleting custom resource ${logicalId}: ${physicalId} (${resourceType})`);
 
     if (!properties) {

--- a/src/provisioning/providers/dynamodb-table-provider.ts
+++ b/src/provisioning/providers/dynamodb-table-provider.ts
@@ -16,6 +16,7 @@ import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
 import { generateResourceName } from '../resource-name.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -246,7 +247,8 @@ export class DynamoDBTableProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting DynamoDB table ${logicalId}: ${physicalId}`);
 
@@ -255,6 +257,14 @@ export class DynamoDBTableProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted DynamoDB table ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.dynamoDBClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`DynamoDB table ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/ec2-provider.ts
+++ b/src/provisioning/providers/ec2-provider.ts
@@ -47,6 +47,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -268,33 +269,40 @@ export class EC2Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::EC2::VPC':
-        return this.deleteVpc(logicalId, physicalId, resourceType);
+        return this.deleteVpc(logicalId, physicalId, resourceType, context);
       case 'AWS::EC2::Subnet':
-        return this.deleteSubnet(logicalId, physicalId, resourceType);
+        return this.deleteSubnet(logicalId, physicalId, resourceType, context);
       case 'AWS::EC2::InternetGateway':
-        return this.deleteInternetGateway(logicalId, physicalId, resourceType);
+        return this.deleteInternetGateway(logicalId, physicalId, resourceType, context);
       case 'AWS::EC2::VPCGatewayAttachment':
-        return this.deleteVpcGatewayAttachment(logicalId, physicalId, resourceType);
+        return this.deleteVpcGatewayAttachment(logicalId, physicalId, resourceType, context);
       case 'AWS::EC2::RouteTable':
-        return this.deleteRouteTable(logicalId, physicalId, resourceType);
+        return this.deleteRouteTable(logicalId, physicalId, resourceType, context);
       case 'AWS::EC2::Route':
-        return this.deleteRoute(logicalId, physicalId, resourceType);
+        return this.deleteRoute(logicalId, physicalId, resourceType, context);
       case 'AWS::EC2::SubnetRouteTableAssociation':
-        return this.deleteSubnetRouteTableAssociation(logicalId, physicalId, resourceType);
+        return this.deleteSubnetRouteTableAssociation(logicalId, physicalId, resourceType, context);
       case 'AWS::EC2::SecurityGroup':
-        return this.deleteSecurityGroup(logicalId, physicalId, resourceType);
+        return this.deleteSecurityGroup(logicalId, physicalId, resourceType, context);
       case 'AWS::EC2::SecurityGroupIngress':
-        return this.deleteSecurityGroupIngress(logicalId, physicalId, resourceType, properties);
+        return this.deleteSecurityGroupIngress(
+          logicalId,
+          physicalId,
+          resourceType,
+          properties,
+          context
+        );
       case 'AWS::EC2::Instance':
-        return this.deleteInstance(logicalId, physicalId, resourceType);
+        return this.deleteInstance(logicalId, physicalId, resourceType, context);
       case 'AWS::EC2::NetworkAcl':
-        return this.deleteNetworkAcl(logicalId, physicalId, resourceType);
+        return this.deleteNetworkAcl(logicalId, physicalId, resourceType, context);
       case 'AWS::EC2::NetworkAclEntry':
-        return this.deleteNetworkAclEntry(logicalId, physicalId, resourceType);
+        return this.deleteNetworkAclEntry(logicalId, physicalId, resourceType, context);
       case 'AWS::EC2::SubnetNetworkAclAssociation':
         // Association replacement is atomic; no explicit delete needed
         this.logger.debug(`SubnetNetworkAclAssociation ${logicalId} delete is a no-op`);
@@ -483,7 +491,8 @@ export class EC2Provider implements ResourceProvider {
   private async deleteVpc(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting VPC ${logicalId}: ${physicalId}`);
 
@@ -496,6 +505,14 @@ export class EC2Provider implements ResourceProvider {
         return;
       } catch (error) {
         if (this.isNotFoundError(error)) {
+          const clientRegion = await this.ec2Client.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(`VPC ${physicalId} does not exist, skipping deletion`);
           return;
         }
@@ -629,7 +646,8 @@ export class EC2Provider implements ResourceProvider {
   private async deleteSubnet(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Subnet ${logicalId}: ${physicalId}`);
 
@@ -647,6 +665,14 @@ export class EC2Provider implements ResourceProvider {
         return;
       } catch (error) {
         if (this.isNotFoundError(error)) {
+          const clientRegion = await this.ec2Client.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(`Subnet ${physicalId} does not exist, skipping deletion`);
           return;
         }
@@ -791,7 +817,8 @@ export class EC2Provider implements ResourceProvider {
   private async deleteInternetGateway(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting InternetGateway ${logicalId}: ${physicalId}`);
 
@@ -802,6 +829,14 @@ export class EC2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted InternetGateway ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.ec2Client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`InternetGateway ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -874,7 +909,8 @@ export class EC2Provider implements ResourceProvider {
   private async deleteVpcGatewayAttachment(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting VPCGatewayAttachment ${logicalId}: ${physicalId}`);
 
@@ -900,6 +936,14 @@ export class EC2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted VPCGatewayAttachment ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.ec2Client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`VPCGatewayAttachment ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -968,7 +1012,8 @@ export class EC2Provider implements ResourceProvider {
   private async deleteRouteTable(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting RouteTable ${logicalId}: ${physicalId}`);
 
@@ -977,6 +1022,14 @@ export class EC2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted RouteTable ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.ec2Client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`RouteTable ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -1085,7 +1138,8 @@ export class EC2Provider implements ResourceProvider {
   private async deleteRoute(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Route ${logicalId}: ${physicalId}`);
 
@@ -1115,6 +1169,14 @@ export class EC2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Route ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.ec2Client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Route ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -1191,7 +1253,8 @@ export class EC2Provider implements ResourceProvider {
   private async deleteSubnetRouteTableAssociation(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting SubnetRouteTableAssociation ${logicalId}: ${physicalId}`);
 
@@ -1200,6 +1263,14 @@ export class EC2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted SubnetRouteTableAssociation ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.ec2Client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(
           `SubnetRouteTableAssociation ${physicalId} does not exist, skipping deletion`
         );
@@ -1375,7 +1446,8 @@ export class EC2Provider implements ResourceProvider {
   private async deleteSecurityGroup(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting SecurityGroup ${logicalId}: ${physicalId}`);
 
@@ -1388,6 +1460,14 @@ export class EC2Provider implements ResourceProvider {
         return;
       } catch (error) {
         if (this.isNotFoundError(error)) {
+          const clientRegion = await this.ec2Client.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(`SecurityGroup ${physicalId} does not exist, skipping deletion`);
           return;
         }
@@ -1582,7 +1662,8 @@ export class EC2Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting SecurityGroupIngress ${logicalId}: ${physicalId}`);
 
@@ -1618,6 +1699,14 @@ export class EC2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted SecurityGroupIngress ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.ec2Client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`SecurityGroupIngress ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -1776,7 +1865,8 @@ export class EC2Provider implements ResourceProvider {
   private async deleteInstance(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Terminating EC2 Instance ${logicalId}: ${physicalId}`);
 
@@ -1793,6 +1883,14 @@ export class EC2Provider implements ResourceProvider {
       this.logger.debug(`EC2 Instance ${logicalId} terminated: ${physicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.ec2Client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(
           `EC2 Instance ${physicalId} already terminated (not found), treating as success`
         );
@@ -2102,7 +2200,8 @@ export class EC2Provider implements ResourceProvider {
   private async deleteNetworkAcl(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting NetworkAcl ${logicalId}: ${physicalId}`);
 
@@ -2111,6 +2210,14 @@ export class EC2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted NetworkAcl ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.ec2Client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`NetworkAcl ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -2200,7 +2307,8 @@ export class EC2Provider implements ResourceProvider {
   private async deleteNetworkAclEntry(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting NetworkAclEntry ${logicalId}: ${physicalId}`);
 
@@ -2224,6 +2332,14 @@ export class EC2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted NetworkAclEntry ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.ec2Client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`NetworkAclEntry ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/ecr-provider.ts
+++ b/src/provisioning/providers/ecr-provider.ts
@@ -17,6 +17,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
 import { generateResourceName } from '../resource-name.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -300,7 +301,8 @@ export class ECRProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting ECR Repository ${logicalId}: ${physicalId}`);
 
@@ -314,6 +316,14 @@ export class ECRProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted ECR Repository ${logicalId}`);
     } catch (error) {
       if (error instanceof RepositoryNotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`ECR Repository ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/ecs-provider.ts
+++ b/src/provisioning/providers/ecs-provider.ts
@@ -51,6 +51,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
 import { generateResourceName } from '../resource-name.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -205,15 +206,16 @@ export class ECSProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::ECS::Cluster':
-        return this.deleteCluster(logicalId, physicalId, resourceType);
+        return this.deleteCluster(logicalId, physicalId, resourceType, context);
       case 'AWS::ECS::TaskDefinition':
-        return this.deleteTaskDefinition(logicalId, physicalId, resourceType);
+        return this.deleteTaskDefinition(logicalId, physicalId, resourceType, context);
       case 'AWS::ECS::Service':
-        return this.deleteService(logicalId, physicalId, resourceType, properties);
+        return this.deleteService(logicalId, physicalId, resourceType, properties, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -353,7 +355,8 @@ export class ECSProvider implements ResourceProvider {
   private async deleteCluster(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting ECS cluster ${logicalId}: ${physicalId}`);
     const client = this.getClient();
@@ -364,6 +367,14 @@ export class ECSProvider implements ResourceProvider {
     } catch (error) {
       // Handle ClusterNotFoundException for idempotent delete
       if (this.isClusterNotFoundException(error)) {
+        const clientRegion = await client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`ECS cluster ${physicalId} not found, skipping deletion`);
         return;
       }
@@ -495,7 +506,8 @@ export class ECSProvider implements ResourceProvider {
   private async deleteTaskDefinition(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting ECS task definition ${logicalId}: ${physicalId}`);
     const client = this.getClient();
@@ -506,6 +518,14 @@ export class ECSProvider implements ResourceProvider {
     } catch (error) {
       // Handle not found for idempotent delete
       if (this.isNotFoundException(error)) {
+        const clientRegion = await client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`ECS task definition ${physicalId} not found, skipping deletion`);
         return;
       }
@@ -694,7 +714,8 @@ export class ECSProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting ECS service ${logicalId}: ${physicalId}`);
     const client = this.getClient();
@@ -715,6 +736,14 @@ export class ECSProvider implements ResourceProvider {
       } catch (error) {
         // If service not found during scale down, it's already gone
         if (this.isServiceNotFoundException(error)) {
+          const clientRegion = await client.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(
             `ECS service ${physicalId} not found during scale down, skipping deletion`
           );
@@ -734,6 +763,14 @@ export class ECSProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted ECS service ${logicalId}`);
     } catch (error) {
       if (this.isServiceNotFoundException(error)) {
+        const clientRegion = await client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`ECS service ${physicalId} not found, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/efs-provider.ts
+++ b/src/provisioning/providers/efs-provider.ts
@@ -16,6 +16,7 @@ import {
 } from '@aws-sdk/client-efs';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -114,15 +115,16 @@ export class EFSProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::EFS::FileSystem':
-        return this.deleteFileSystem(logicalId, physicalId, resourceType);
+        return this.deleteFileSystem(logicalId, physicalId, resourceType, context);
       case 'AWS::EFS::MountTarget':
-        return this.deleteMountTarget(logicalId, physicalId, resourceType);
+        return this.deleteMountTarget(logicalId, physicalId, resourceType, context);
       case 'AWS::EFS::AccessPoint':
-        return this.deleteAccessPoint(logicalId, physicalId, resourceType);
+        return this.deleteAccessPoint(logicalId, physicalId, resourceType, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -191,7 +193,8 @@ export class EFSProvider implements ResourceProvider {
   private async deleteFileSystem(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting EFS FileSystem ${logicalId}: ${physicalId}`);
 
@@ -204,6 +207,14 @@ export class EFSProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted EFS FileSystem ${logicalId}`);
     } catch (error) {
       if (error instanceof FileSystemNotFound) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`EFS FileSystem ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -355,7 +366,8 @@ export class EFSProvider implements ResourceProvider {
   private async deleteMountTarget(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting EFS MountTarget ${logicalId}: ${physicalId}`);
 
@@ -372,6 +384,14 @@ export class EFSProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted EFS MountTarget ${logicalId}`);
     } catch (error) {
       if (error instanceof MountTargetNotFound) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`EFS MountTarget ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -511,7 +531,8 @@ export class EFSProvider implements ResourceProvider {
   private async deleteAccessPoint(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting EFS AccessPoint ${logicalId}: ${physicalId}`);
 
@@ -524,6 +545,14 @@ export class EFSProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted EFS AccessPoint ${logicalId}`);
     } catch (error) {
       if (error instanceof AccessPointNotFound) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`EFS AccessPoint ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/elasticache-provider.ts
+++ b/src/provisioning/providers/elasticache-provider.ts
@@ -15,6 +15,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
 import { generateResourceName } from '../resource-name.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -127,13 +128,14 @@ export class ElastiCacheProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::ElastiCache::SubnetGroup':
-        return this.deleteSubnetGroup(logicalId, physicalId, resourceType);
+        return this.deleteSubnetGroup(logicalId, physicalId, resourceType, context);
       case 'AWS::ElastiCache::CacheCluster':
-        return this.deleteCacheCluster(logicalId, physicalId, resourceType);
+        return this.deleteCacheCluster(logicalId, physicalId, resourceType, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -233,7 +235,8 @@ export class ElastiCacheProvider implements ResourceProvider {
   private async deleteSubnetGroup(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting CacheSubnetGroup ${logicalId}: ${physicalId}`);
 
@@ -246,6 +249,14 @@ export class ElastiCacheProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted CacheSubnetGroup ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error, 'CacheSubnetGroupNotFoundFault')) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`CacheSubnetGroup ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -437,7 +448,8 @@ export class ElastiCacheProvider implements ResourceProvider {
   private async deleteCacheCluster(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting CacheCluster ${logicalId}: ${physicalId}`);
 
@@ -454,6 +466,14 @@ export class ElastiCacheProvider implements ResourceProvider {
       await this.waitForClusterDeleted(physicalId);
     } catch (error) {
       if (this.isNotFoundError(error, 'CacheClusterNotFoundFault')) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`CacheCluster ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/elbv2-provider.ts
+++ b/src/provisioning/providers/elbv2-provider.ts
@@ -22,6 +22,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
 import { generateResourceName } from '../resource-name.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -154,15 +155,16 @@ export class ELBv2Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::ElasticLoadBalancingV2::LoadBalancer':
-        return this.deleteLoadBalancer(logicalId, physicalId, resourceType);
+        return this.deleteLoadBalancer(logicalId, physicalId, resourceType, context);
       case 'AWS::ElasticLoadBalancingV2::TargetGroup':
-        return this.deleteTargetGroup(logicalId, physicalId, resourceType);
+        return this.deleteTargetGroup(logicalId, physicalId, resourceType, context);
       case 'AWS::ElasticLoadBalancingV2::Listener':
-        return this.deleteListener(logicalId, physicalId, resourceType);
+        return this.deleteListener(logicalId, physicalId, resourceType, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -297,7 +299,8 @@ export class ELBv2Provider implements ResourceProvider {
   private async deleteLoadBalancer(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting LoadBalancer ${logicalId}: ${physicalId}`);
 
@@ -306,6 +309,14 @@ export class ELBv2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted LoadBalancer ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`LoadBalancer ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -473,7 +484,8 @@ export class ELBv2Provider implements ResourceProvider {
   private async deleteTargetGroup(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting TargetGroup ${logicalId}: ${physicalId}`);
 
@@ -482,6 +494,14 @@ export class ELBv2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted TargetGroup ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`TargetGroup ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -602,7 +622,8 @@ export class ELBv2Provider implements ResourceProvider {
   private async deleteListener(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Listener ${logicalId}: ${physicalId}`);
 
@@ -611,6 +632,14 @@ export class ELBv2Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Listener ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Listener ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/eventbridge-bus-provider.ts
+++ b/src/provisioning/providers/eventbridge-bus-provider.ts
@@ -16,6 +16,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -194,7 +195,13 @@ export class EventBridgeBusProvider implements ResourceProvider {
     return { physicalId, wasReplaced: false, attributes: {} };
   }
 
-  async delete(logicalId: string, physicalId: string, resourceType: string): Promise<void> {
+  async delete(
+    logicalId: string,
+    physicalId: string,
+    resourceType: string,
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
+  ): Promise<void> {
     this.logger.debug(`Deleting EventBus ${logicalId}: ${physicalId}`);
 
     try {
@@ -206,11 +213,27 @@ export class EventBridgeBusProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted EventBus ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.eventBridgeClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`EventBus ${physicalId} does not exist, skipping`);
         return;
       }
       const msg = error instanceof Error ? error.message : String(error);
       if (msg.includes('does not exist')) {
+        const clientRegion = await this.eventBridgeClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`EventBus ${physicalId} does not exist, skipping`);
         return;
       }

--- a/src/provisioning/providers/eventbridge-rule-provider.ts
+++ b/src/provisioning/providers/eventbridge-rule-provider.ts
@@ -14,6 +14,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -296,7 +297,8 @@ export class EventBridgeRuleProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting EventBridge rule ${logicalId}: ${physicalId}`);
 
@@ -315,6 +317,14 @@ export class EventBridgeRuleProvider implements ResourceProvider {
           .filter((id): id is string => id !== undefined);
       } catch (error) {
         if (error instanceof ResourceNotFoundException) {
+          const clientRegion = await this.eventBridgeClient.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(`Rule ${ruleName} does not exist, skipping deletion`);
           return;
         }
@@ -338,6 +348,14 @@ export class EventBridgeRuleProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted EventBridge rule ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.eventBridgeClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Rule ${ruleName} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/firehose-provider.ts
+++ b/src/provisioning/providers/firehose-provider.ts
@@ -17,6 +17,7 @@ import {
 } from '@aws-sdk/client-firehose';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -394,7 +395,8 @@ export class FirehoseProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Firehose delivery stream ${logicalId}: ${physicalId}`);
 
@@ -407,6 +409,14 @@ export class FirehoseProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Firehose delivery stream ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(
           `Firehose delivery stream ${physicalId} does not exist, skipping deletion`
         );

--- a/src/provisioning/providers/glue-provider.ts
+++ b/src/provisioning/providers/glue-provider.ts
@@ -14,6 +14,7 @@ import {
 } from '@aws-sdk/client-glue';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -98,13 +99,14 @@ export class GlueProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::Glue::Database':
-        return this.deleteDatabase(logicalId, physicalId, resourceType);
+        return this.deleteDatabase(logicalId, physicalId, resourceType, properties, context);
       case 'AWS::Glue::Table':
-        return this.deleteTable(logicalId, physicalId, resourceType);
+        return this.deleteTable(logicalId, physicalId, resourceType, properties, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -179,7 +181,8 @@ export class GlueProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Glue Database ${logicalId}: ${physicalId}`);
 
@@ -194,6 +197,14 @@ export class GlueProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Glue Database ${logicalId}`);
     } catch (error) {
       if (error instanceof EntityNotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Glue Database ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -334,7 +345,9 @@ export class GlueProvider implements ResourceProvider {
   private async deleteTable(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Glue Table ${logicalId}: ${physicalId}`);
 
@@ -354,6 +367,14 @@ export class GlueProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Glue Table ${logicalId}`);
     } catch (error) {
       if (error instanceof EntityNotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Glue Table ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/iam-instance-profile-provider.ts
+++ b/src/provisioning/providers/iam-instance-profile-provider.ts
@@ -10,6 +10,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -186,7 +187,8 @@ export class IAMInstanceProfileProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting IAM instance profile ${logicalId}: ${physicalId}`);
 
@@ -203,6 +205,14 @@ export class IAMInstanceProfileProvider implements ResourceProvider {
           ) || [];
       } catch (error) {
         if (error instanceof NoSuchEntityException) {
+          const clientRegion = await this.iamClient.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(`Instance profile ${physicalId} does not exist, skipping deletion`);
           return;
         }
@@ -234,6 +244,14 @@ export class IAMInstanceProfileProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted IAM instance profile ${logicalId}`);
     } catch (error) {
       if (error instanceof NoSuchEntityException) {
+        const clientRegion = await this.iamClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Instance profile ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/iam-policy-provider.ts
+++ b/src/provisioning/providers/iam-policy-provider.ts
@@ -11,6 +11,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -337,7 +338,8 @@ export class IAMPolicyProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting IAM policy ${logicalId}: ${physicalId}`);
 
@@ -348,6 +350,24 @@ export class IAMPolicyProvider implements ResourceProvider {
       this.logger.warn(`Invalid physical ID format: ${physicalId}, skipping deletion`);
       return;
     }
+
+    // Each per-target loop swallows NoSuchEntityException as idempotent
+    // delete success. A region mismatch would otherwise let *every* such
+    // exception slip through silently and orphan the underlying inline
+    // policy attachments. Assert region once up front: IAM is global, but
+    // the client region is still meaningful when the destroy run is
+    // pointing at a different account/region than where the stack was
+    // deployed.
+    const onNotFound = async (target: string): Promise<void> => {
+      const clientRegion = await this.iamClient.config.region();
+      assertRegionMatch(
+        clientRegion,
+        context?.expectedRegion,
+        resourceType,
+        logicalId,
+        `${physicalId} (${target})`
+      );
+    };
 
     try {
       // Get target lists from properties (state stores these)
@@ -368,7 +388,9 @@ export class IAMPolicyProvider implements ResourceProvider {
             );
             this.logger.debug(`Deleted inline policy ${policyName} from role ${firstRole}`);
           } catch (error) {
-            if (!(error instanceof NoSuchEntityException)) {
+            if (error instanceof NoSuchEntityException) {
+              await onNotFound(`role ${firstRole}`);
+            } else {
               throw error;
             }
           }
@@ -387,7 +409,9 @@ export class IAMPolicyProvider implements ResourceProvider {
             );
             this.logger.debug(`Deleted inline policy ${policyName} from role ${roleName}`);
           } catch (error) {
-            if (!(error instanceof NoSuchEntityException)) {
+            if (error instanceof NoSuchEntityException) {
+              await onNotFound(`role ${roleName}`);
+            } else {
               throw error;
             }
           }
@@ -406,7 +430,9 @@ export class IAMPolicyProvider implements ResourceProvider {
             );
             this.logger.debug(`Deleted inline policy ${policyName} from group ${groupName}`);
           } catch (error) {
-            if (!(error instanceof NoSuchEntityException)) {
+            if (error instanceof NoSuchEntityException) {
+              await onNotFound(`group ${groupName}`);
+            } else {
               throw error;
             }
           }
@@ -425,7 +451,9 @@ export class IAMPolicyProvider implements ResourceProvider {
             );
             this.logger.debug(`Deleted inline policy ${policyName} from user ${userName}`);
           } catch (error) {
-            if (!(error instanceof NoSuchEntityException)) {
+            if (error instanceof NoSuchEntityException) {
+              await onNotFound(`user ${userName}`);
+            } else {
               throw error;
             }
           }

--- a/src/provisioning/providers/iam-role-provider.ts
+++ b/src/provisioning/providers/iam-role-provider.ts
@@ -22,6 +22,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -378,7 +379,8 @@ export class IAMRoleProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting IAM role ${logicalId}: ${physicalId}`);
 
@@ -388,6 +390,14 @@ export class IAMRoleProvider implements ResourceProvider {
         await this.iamClient.send(new GetRoleCommand({ RoleName: physicalId }));
       } catch (error) {
         if (error instanceof NoSuchEntityException) {
+          const clientRegion = await this.iamClient.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(`Role ${physicalId} does not exist, skipping deletion`);
           return;
         }

--- a/src/provisioning/providers/iam-user-group-provider.ts
+++ b/src/provisioning/providers/iam-user-group-provider.ts
@@ -34,6 +34,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -141,15 +142,22 @@ export class IAMUserGroupProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::IAM::User':
-        return this.deleteUser(logicalId, physicalId, resourceType);
+        return this.deleteUser(logicalId, physicalId, resourceType, context);
       case 'AWS::IAM::Group':
-        return this.deleteGroup(logicalId, physicalId, resourceType);
+        return this.deleteGroup(logicalId, physicalId, resourceType, context);
       case 'AWS::IAM::UserToGroupAddition':
-        return this.deleteUserToGroupAddition(logicalId, physicalId, resourceType, properties);
+        return this.deleteUserToGroupAddition(
+          logicalId,
+          physicalId,
+          resourceType,
+          properties,
+          context
+        );
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -420,7 +428,8 @@ export class IAMUserGroupProvider implements ResourceProvider {
   private async deleteUser(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting IAM user ${logicalId}: ${physicalId}`);
 
@@ -430,6 +439,14 @@ export class IAMUserGroupProvider implements ResourceProvider {
         await this.iamClient.send(new GetUserCommand({ UserName: physicalId }));
       } catch (error) {
         if (error instanceof NoSuchEntityException) {
+          const clientRegion = await this.iamClient.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(`User ${physicalId} does not exist, skipping deletion`);
           return;
         }
@@ -866,7 +883,8 @@ export class IAMUserGroupProvider implements ResourceProvider {
   private async deleteGroup(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting IAM group ${logicalId}: ${physicalId}`);
 
@@ -886,6 +904,14 @@ export class IAMUserGroupProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted IAM group ${logicalId}`);
     } catch (error) {
       if (error instanceof NoSuchEntityException) {
+        const clientRegion = await this.iamClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Group ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -1213,8 +1239,14 @@ export class IAMUserGroupProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    _context?: DeleteContext
   ): Promise<void> {
+    // UserToGroupAddition is metadata-only (RemoveUserFromGroup); the
+    // "skipping" returns below trigger when input properties are missing,
+    // not when AWS reports the user/group missing, so the region check
+    // does not apply here. The context is accepted for interface
+    // consistency.
     this.logger.debug(`Deleting IAM UserToGroupAddition ${logicalId}`);
 
     if (!properties) {

--- a/src/provisioning/providers/kinesis-provider.ts
+++ b/src/provisioning/providers/kinesis-provider.ts
@@ -14,6 +14,7 @@ import {
 } from '@aws-sdk/client-kinesis';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -313,7 +314,8 @@ export class KinesisStreamProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Kinesis stream ${logicalId}: ${physicalId}`);
 
@@ -327,6 +329,14 @@ export class KinesisStreamProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Kinesis stream ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Kinesis stream ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/kms-provider.ts
+++ b/src/provisioning/providers/kms-provider.ts
@@ -20,6 +20,7 @@ import {
 } from '@aws-sdk/client-kms';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -116,13 +117,14 @@ export class KMSProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::KMS::Key':
-        return this.deleteKey(logicalId, physicalId, resourceType, _properties);
+        return this.deleteKey(logicalId, physicalId, resourceType, _properties, context);
       case 'AWS::KMS::Alias':
-        return this.deleteAlias(logicalId, physicalId, resourceType);
+        return this.deleteAlias(logicalId, physicalId, resourceType, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -343,7 +345,8 @@ export class KMSProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Scheduling deletion for KMS Key ${logicalId}: ${physicalId}`);
 
@@ -359,6 +362,14 @@ export class KMSProvider implements ResourceProvider {
       this.logger.debug(`Successfully scheduled deletion for KMS Key ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`KMS Key ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -470,7 +481,8 @@ export class KMSProvider implements ResourceProvider {
   private async deleteAlias(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting KMS Alias ${logicalId}: ${physicalId}`);
 
@@ -483,6 +495,14 @@ export class KMSProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted KMS Alias ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`KMS Alias ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/lambda-eventsource-provider.ts
+++ b/src/provisioning/providers/lambda-eventsource-provider.ts
@@ -10,6 +10,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -249,7 +250,8 @@ export class LambdaEventSourceMappingProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting event source mapping ${logicalId}: ${physicalId}`);
 
@@ -259,6 +261,14 @@ export class LambdaEventSourceMappingProvider implements ResourceProvider {
         await this.lambdaClient.send(new GetEventSourceMappingCommand({ UUID: physicalId }));
       } catch (error) {
         if (error instanceof ResourceNotFoundException) {
+          const clientRegion = await this.lambdaClient.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(`Event source mapping ${physicalId} does not exist, skipping deletion`);
           return;
         }
@@ -269,6 +279,14 @@ export class LambdaEventSourceMappingProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted event source mapping ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.lambdaClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Event source mapping ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -26,6 +26,7 @@ import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
 import { generateResourceName } from '../resource-name.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -306,7 +307,8 @@ export class LambdaFunctionProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Lambda function ${logicalId}: ${physicalId}`);
 
@@ -329,6 +331,14 @@ export class LambdaFunctionProvider implements ResourceProvider {
         this.logger.debug(`Detached VPC config from Lambda ${physicalId} before deletion`);
       } catch (error) {
         if (error instanceof ResourceNotFoundException) {
+          const clientRegion = await this.lambdaClient.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           // Function is already gone — nothing more to do, including ENI wait
           // (AWS owns the cleanup at this point).
           return;
@@ -357,6 +367,14 @@ export class LambdaFunctionProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Lambda function ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.lambdaClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Lambda function ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/lambda-layer-provider.ts
+++ b/src/provisioning/providers/lambda-layer-provider.ts
@@ -10,6 +10,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -146,7 +147,8 @@ export class LambdaLayerVersionProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Lambda layer version ${logicalId}: ${physicalId}`);
 
@@ -175,6 +177,14 @@ export class LambdaLayerVersionProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Lambda layer version ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.lambdaClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Lambda layer version ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/lambda-permission-provider.ts
+++ b/src/provisioning/providers/lambda-permission-provider.ts
@@ -8,6 +8,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -199,7 +200,8 @@ export class LambdaPermissionProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Lambda permission ${logicalId}: ${physicalId}`);
 
@@ -228,6 +230,14 @@ export class LambdaPermissionProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Lambda permission ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.lambdaClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Lambda permission ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/lambda-url-provider.ts
+++ b/src/provisioning/providers/lambda-url-provider.ts
@@ -10,6 +10,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -144,7 +145,8 @@ export class LambdaUrlProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Lambda URL ${logicalId}: ${physicalId}`);
 
@@ -155,6 +157,14 @@ export class LambdaUrlProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Lambda URL ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.lambdaClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Lambda URL ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/logs-loggroup-provider.ts
+++ b/src/provisioning/providers/logs-loggroup-provider.ts
@@ -15,6 +15,7 @@ import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -258,7 +259,8 @@ export class LogsLogGroupProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting log group ${logicalId}: ${physicalId}`);
 
@@ -267,6 +269,14 @@ export class LogsLogGroupProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted log group ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.logsClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Log group ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/rds-provider.ts
+++ b/src/provisioning/providers/rds-provider.ts
@@ -14,6 +14,7 @@ import {
 } from '@aws-sdk/client-rds';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -135,15 +136,16 @@ export class RDSProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::RDS::DBSubnetGroup':
-        return this.deleteDBSubnetGroup(logicalId, physicalId, resourceType);
+        return this.deleteDBSubnetGroup(logicalId, physicalId, resourceType, context);
       case 'AWS::RDS::DBCluster':
-        return this.deleteDBCluster(logicalId, physicalId, resourceType);
+        return this.deleteDBCluster(logicalId, physicalId, resourceType, context);
       case 'AWS::RDS::DBInstance':
-        return this.deleteDBInstance(logicalId, physicalId, resourceType);
+        return this.deleteDBInstance(logicalId, physicalId, resourceType, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -241,7 +243,8 @@ export class RDSProvider implements ResourceProvider {
   private async deleteDBSubnetGroup(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting DBSubnetGroup ${logicalId}: ${physicalId}`);
 
@@ -254,6 +257,14 @@ export class RDSProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted DBSubnetGroup ${logicalId}`);
     } catch (error) {
       if (this.isNotFoundError(error, 'DBSubnetGroupNotFoundFault')) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`DBSubnetGroup ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -420,7 +431,8 @@ export class RDSProvider implements ResourceProvider {
   private async deleteDBCluster(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting DBCluster ${logicalId}: ${physicalId}`);
 
@@ -455,6 +467,14 @@ export class RDSProvider implements ResourceProvider {
       await this.waitForClusterDeleted(physicalId);
     } catch (error) {
       if (this.isNotFoundError(error, 'DBClusterNotFoundFault')) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`DBCluster ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -580,7 +600,8 @@ export class RDSProvider implements ResourceProvider {
   private async deleteDBInstance(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting DBInstance ${logicalId}: ${physicalId}`);
 
@@ -615,6 +636,14 @@ export class RDSProvider implements ResourceProvider {
       await this.waitForInstanceDeleted(physicalId);
     } catch (error) {
       if (this.isNotFoundError(error, 'DBInstanceNotFoundFault')) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`DBInstance ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/route53-provider.ts
+++ b/src/provisioning/providers/route53-provider.ts
@@ -18,6 +18,7 @@ import {
 } from '@aws-sdk/client-route-53';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -123,13 +124,14 @@ export class Route53Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::Route53::HostedZone':
-        return this.deleteHostedZone(logicalId, physicalId, resourceType);
+        return this.deleteHostedZone(logicalId, physicalId, resourceType, context);
       case 'AWS::Route53::RecordSet':
-        return this.deleteRecordSet(logicalId, physicalId, resourceType, properties);
+        return this.deleteRecordSet(logicalId, physicalId, resourceType, properties, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -326,7 +328,8 @@ export class Route53Provider implements ResourceProvider {
   private async deleteHostedZone(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Route 53 hosted zone ${logicalId}: ${physicalId}`);
 
@@ -338,6 +341,14 @@ export class Route53Provider implements ResourceProvider {
       this.logger.debug(`Successfully deleted hosted zone ${logicalId}`);
     } catch (error) {
       if (error instanceof Error && error.name === 'NoSuchHostedZone') {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Hosted zone ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -484,7 +495,8 @@ export class Route53Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Route 53 record set ${logicalId}: ${physicalId}`);
 
@@ -535,6 +547,14 @@ export class Route53Provider implements ResourceProvider {
         error instanceof Error &&
         (error.name === 'InvalidChangeBatch' || error.message.includes('it was not found'))
       ) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Record set ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/s3-bucket-policy-provider.ts
+++ b/src/provisioning/providers/s3-bucket-policy-provider.ts
@@ -7,6 +7,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -163,7 +164,8 @@ export class S3BucketPolicyProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting S3 bucket policy ${logicalId}: ${physicalId}`);
 
@@ -177,6 +179,14 @@ export class S3BucketPolicyProvider implements ResourceProvider {
         this.logger.debug(`Successfully deleted S3 bucket policy ${logicalId}`);
       } catch (error) {
         if (error instanceof NoSuchBucket) {
+          const clientRegion = await this.s3Client.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(`Bucket ${physicalId} does not exist, skipping policy deletion`);
           return;
         }
@@ -185,6 +195,14 @@ export class S3BucketPolicyProvider implements ResourceProvider {
           error instanceof Error &&
           (error.name === 'NoSuchBucketPolicy' || error.message.includes('does not have'))
         ) {
+          const clientRegion = await this.s3Client.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
           this.logger.debug(`Bucket policy for ${physicalId} does not exist, skipping`);
           return;
         }

--- a/src/provisioning/providers/s3-bucket-provider.ts
+++ b/src/provisioning/providers/s3-bucket-provider.ts
@@ -30,6 +30,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -1118,7 +1119,8 @@ export class S3BucketProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting S3 bucket ${logicalId}: ${physicalId}`);
 
@@ -1126,6 +1128,14 @@ export class S3BucketProvider implements ResourceProvider {
       await this.deleteBucketWithEmptyRetry(logicalId, physicalId);
     } catch (error) {
       if (error instanceof NoSuchBucket) {
+        const clientRegion = await this.s3Client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Bucket ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/s3-directory-bucket-provider.ts
+++ b/src/provisioning/providers/s3-directory-bucket-provider.ts
@@ -10,6 +10,7 @@ import { EC2Client, DescribeAvailabilityZonesCommand } from '@aws-sdk/client-ec2
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -196,7 +197,8 @@ export class S3DirectoryBucketProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting S3 Express Directory Bucket ${logicalId}: ${physicalId}`);
 
@@ -217,6 +219,14 @@ export class S3DirectoryBucketProvider implements ResourceProvider {
         error instanceof Error &&
         (error.name === 'NoSuchBucket' || error.name === 'BucketNotFound')
       ) {
+        const clientRegion = await this.s3Client.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Bucket ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/s3-tables-provider.ts
+++ b/src/provisioning/providers/s3-tables-provider.ts
@@ -12,6 +12,7 @@ import {
 } from '@aws-sdk/client-s3tables';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -86,15 +87,16 @@ export class S3TablesProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::S3Tables::TableBucket':
-        return this.deleteTableBucket(logicalId, physicalId, resourceType);
+        return this.deleteTableBucket(logicalId, physicalId, resourceType, context);
       case 'AWS::S3Tables::Namespace':
-        return this.deleteNamespace(logicalId, physicalId, resourceType);
+        return this.deleteNamespace(logicalId, physicalId, resourceType, context);
       case 'AWS::S3Tables::Table':
-        return this.deleteTable(logicalId, physicalId, resourceType);
+        return this.deleteTable(logicalId, physicalId, resourceType, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -155,7 +157,8 @@ export class S3TablesProvider implements ResourceProvider {
   private async deleteTableBucket(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting S3 Table Bucket ${logicalId}: ${physicalId}`);
 
@@ -171,6 +174,14 @@ export class S3TablesProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted S3 Table Bucket ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`S3 Table Bucket ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -320,7 +331,8 @@ export class S3TablesProvider implements ResourceProvider {
   private async deleteNamespace(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting S3 Tables Namespace ${logicalId}: ${physicalId}`);
 
@@ -344,6 +356,14 @@ export class S3TablesProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted S3 Tables Namespace ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`S3 Tables Namespace ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -436,7 +456,8 @@ export class S3TablesProvider implements ResourceProvider {
   private async deleteTable(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting S3 Tables Table ${logicalId}: ${physicalId}`);
 
@@ -465,6 +486,14 @@ export class S3TablesProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted S3 Tables Table ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`S3 Tables Table ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/s3-vectors-provider.ts
+++ b/src/provisioning/providers/s3-vectors-provider.ts
@@ -8,6 +8,7 @@ import {
 } from '@aws-sdk/client-s3vectors';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -83,11 +84,12 @@ export class S3VectorsProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::S3Vectors::VectorBucket':
-        return this.deleteVectorBucket(logicalId, physicalId, resourceType);
+        return this.deleteVectorBucket(logicalId, physicalId, resourceType, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -158,7 +160,8 @@ export class S3VectorsProvider implements ResourceProvider {
   private async deleteVectorBucket(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting S3 VectorBucket ${logicalId}: ${physicalId}`);
 
@@ -176,6 +179,14 @@ export class S3VectorsProvider implements ResourceProvider {
     } catch (error) {
       // Idempotency: treat not-found as success
       if (this.isNotFoundError(error)) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`S3 VectorBucket ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/secretsmanager-secret-provider.ts
+++ b/src/provisioning/providers/secretsmanager-secret-provider.ts
@@ -13,6 +13,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -253,7 +254,8 @@ export class SecretsManagerSecretProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting secret ${logicalId}: ${physicalId}`);
 
@@ -267,6 +269,14 @@ export class SecretsManagerSecretProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted secret ${logicalId}`);
     } catch (error) {
       if (error instanceof ResourceNotFoundException) {
+        const clientRegion = await this.smClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Secret ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/servicediscovery-provider.ts
+++ b/src/provisioning/providers/servicediscovery-provider.ts
@@ -16,6 +16,7 @@ import {
 import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -119,13 +120,14 @@ export class ServiceDiscoveryProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     switch (resourceType) {
       case 'AWS::ServiceDiscovery::PrivateDnsNamespace':
-        return this.deleteNamespace(logicalId, physicalId, resourceType);
+        return this.deleteNamespace(logicalId, physicalId, resourceType, context);
       case 'AWS::ServiceDiscovery::Service':
-        return this.deleteService(logicalId, physicalId, resourceType);
+        return this.deleteService(logicalId, physicalId, resourceType, context);
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -224,7 +226,8 @@ export class ServiceDiscoveryProvider implements ResourceProvider {
   private async deleteNamespace(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting private DNS namespace ${logicalId}: ${physicalId}`);
     const client = this.getClient();
@@ -240,6 +243,14 @@ export class ServiceDiscoveryProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted private DNS namespace ${logicalId}`);
     } catch (error) {
       if (error instanceof NamespaceNotFound) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Namespace ${physicalId} does not exist, skipping deletion`);
         return;
       }
@@ -342,7 +353,8 @@ export class ServiceDiscoveryProvider implements ResourceProvider {
   private async deleteService(
     logicalId: string,
     physicalId: string,
-    resourceType: string
+    resourceType: string,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting service discovery service ${logicalId}: ${physicalId}`);
     const client = this.getClient();
@@ -352,6 +364,14 @@ export class ServiceDiscoveryProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted service discovery service ${logicalId}`);
     } catch (error) {
       if (error instanceof ServiceNotFound) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Service ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/sns-subscription-provider.ts
+++ b/src/provisioning/providers/sns-subscription-provider.ts
@@ -7,6 +7,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -151,7 +152,8 @@ export class SNSSubscriptionProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting SNS subscription ${logicalId}: ${physicalId}`);
 
@@ -165,6 +167,14 @@ export class SNSSubscriptionProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted SNS subscription ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.snsClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Subscription ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/sns-topic-policy-provider.ts
+++ b/src/provisioning/providers/sns-topic-policy-provider.ts
@@ -2,6 +2,7 @@ import { SetTopicAttributesCommand } from '@aws-sdk/client-sns';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -156,7 +157,8 @@ export class SNSTopicPolicyProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting SNS topic policy ${logicalId}: ${physicalId}`);
 
@@ -176,6 +178,14 @@ export class SNSTopicPolicyProvider implements ResourceProvider {
             error.message.includes('does not exist') ||
             error.message.includes('Invalid parameter'))
         ) {
+          const clientRegion = await getAwsClients().sns.config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            topicArn
+          );
           this.logger.debug(`Topic ${topicArn} not found or policy already removed, skipping`);
           continue;
         }

--- a/src/provisioning/providers/sns-topic-provider.ts
+++ b/src/provisioning/providers/sns-topic-provider.ts
@@ -12,6 +12,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -348,7 +349,8 @@ export class SNSTopicProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting SNS topic ${logicalId}: ${physicalId}`);
 
@@ -357,6 +359,14 @@ export class SNSTopicProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted SNS topic ${logicalId}`);
     } catch (error) {
       if (error instanceof NotFoundException) {
+        const clientRegion = await this.snsClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`SNS topic ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/sqs-queue-policy-provider.ts
+++ b/src/provisioning/providers/sqs-queue-policy-provider.ts
@@ -2,6 +2,7 @@ import { SQSClient, SetQueueAttributesCommand } from '@aws-sdk/client-sqs';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -170,7 +171,8 @@ export class SQSQueuePolicyProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting SQS queue policy ${logicalId}: ${physicalId}`);
 
@@ -192,6 +194,14 @@ export class SQSQueuePolicyProvider implements ResourceProvider {
         error instanceof Error &&
         (error.name === 'QueueDoesNotExist' || error.message.includes('does not exist'))
       ) {
+        const clientRegion = await this.sqsClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Queue ${physicalId} does not exist, skipping policy deletion`);
         return;
       }

--- a/src/provisioning/providers/sqs-queue-provider.ts
+++ b/src/provisioning/providers/sqs-queue-provider.ts
@@ -10,6 +10,7 @@ import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -231,7 +232,8 @@ export class SQSQueueProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting SQS queue ${logicalId}: ${physicalId}`);
 
@@ -240,6 +242,14 @@ export class SQSQueueProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted SQS queue ${logicalId}`);
     } catch (error) {
       if (error instanceof QueueDoesNotExist) {
+        const clientRegion = await this.sqsClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`SQS queue ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/ssm-parameter-provider.ts
+++ b/src/provisioning/providers/ssm-parameter-provider.ts
@@ -11,6 +11,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -237,7 +238,8 @@ export class SSMParameterProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting SSM parameter ${logicalId}: ${physicalId}`);
 
@@ -251,6 +253,14 @@ export class SSMParameterProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted SSM parameter ${logicalId}`);
     } catch (error) {
       if (error instanceof ParameterNotFound) {
+        const clientRegion = await this.ssmClient.config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`Parameter ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/providers/stepfunctions-provider.ts
+++ b/src/provisioning/providers/stepfunctions-provider.ts
@@ -14,6 +14,7 @@ import {
 } from '@aws-sdk/client-sfn';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -238,7 +239,8 @@ export class StepFunctionsProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting Step Functions state machine ${logicalId}: ${physicalId}`);
 
@@ -247,6 +249,14 @@ export class StepFunctionsProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted Step Functions state machine ${logicalId}`);
     } catch (error) {
       if (error instanceof StateMachineDoesNotExist) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(
           `Step Functions state machine ${physicalId} does not exist, skipping deletion`
         );

--- a/src/provisioning/providers/wafv2-provider.ts
+++ b/src/provisioning/providers/wafv2-provider.ts
@@ -17,6 +17,7 @@ import {
 } from '@aws-sdk/client-wafv2';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
+import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import type {
   ResourceProvider,
@@ -247,7 +248,8 @@ export class WAFv2WebACLProvider implements ResourceProvider {
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void> {
     this.logger.debug(`Deleting WAFv2 WebACL ${logicalId}: ${physicalId}`);
 
@@ -280,6 +282,14 @@ export class WAFv2WebACLProvider implements ResourceProvider {
       this.logger.debug(`Successfully deleted WAFv2 WebACL ${logicalId}`);
     } catch (error) {
       if (error instanceof WAFNonexistentItemException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
         this.logger.debug(`WAFv2 WebACL ${physicalId} does not exist, skipping deletion`);
         return;
       }

--- a/src/provisioning/region-check.ts
+++ b/src/provisioning/region-check.ts
@@ -1,0 +1,92 @@
+import { ProvisioningError } from '../utils/error-handler.js';
+
+/**
+ * Context passed to provider delete operations.
+ *
+ * `expectedRegion` is the region that the resource is expected to live in,
+ * sourced from the stack state (`StackState.region`). When set, providers
+ * use it to verify that a `NotFound` error from the AWS client is genuinely
+ * "the resource is gone", and not a silent miss caused by the client
+ * pointing at a different region than where the resource actually lives.
+ */
+export interface DeleteContext {
+  /**
+   * Region recorded in the stack state when the resource was created.
+   * Optional: when omitted (or set to undefined), providers preserve their
+   * existing idempotent behavior — i.e., NotFound is treated as success
+   * without verification. The explicit `undefined` is permitted so callers
+   * can spread `state.region` (which is itself `string | undefined`)
+   * directly without first narrowing.
+   */
+  expectedRegion?: string | undefined;
+}
+
+/**
+ * Verify that the AWS client's region matches the region the resource is
+ * expected to live in before treating a `NotFound` error as idempotent
+ * delete success.
+ *
+ * Why: a destroy run with the wrong region would otherwise receive
+ * `*NotFound` for every resource and silently strip them all from state,
+ * leaving the actual AWS resources orphaned in the real region. The
+ * silent-failure incident that motivated this check was a Lambda in
+ * `us-west-2` removed from state by a destroy that ran with a `us-east-1`
+ * client.
+ *
+ * Behavior:
+ * - If `expectedRegion` is unset, this is a no-op (back-compat: existing
+ *   idempotent semantics preserved for callers that have not been
+ *   threaded with state region).
+ * - If `clientRegion` matches `expectedRegion`, returns silently.
+ * - Otherwise throws `ProvisioningError` so the caller surfaces the
+ *   mismatch instead of swallowing the NotFound.
+ *
+ * @param clientRegion Region resolved from the AWS SDK client config
+ *   (typically `await client.config.region()`).
+ * @param expectedRegion Region recorded in stack state, or undefined if
+ *   the caller has no expected region.
+ * @param resourceType CloudFormation resource type, used in the error
+ *   message and on the thrown ProvisioningError.
+ * @param logicalId Logical ID of the resource, used in the error message
+ *   and on the thrown ProvisioningError.
+ * @param physicalId Optional physical ID, used in the error message and
+ *   on the thrown ProvisioningError.
+ */
+export function assertRegionMatch(
+  clientRegion: string | undefined,
+  expectedRegion: string | undefined,
+  resourceType: string,
+  logicalId: string,
+  physicalId?: string
+): void {
+  if (!expectedRegion) {
+    // Back-compat: caller did not supply state region, preserve previous
+    // idempotent behavior.
+    return;
+  }
+
+  if (!clientRegion) {
+    throw new ProvisioningError(
+      `Refusing to treat NotFound as idempotent delete success for ${logicalId} ` +
+        `(${resourceType}): AWS client region is unknown but stack state expects ` +
+        `${expectedRegion}. The resource may exist in ${expectedRegion} and would ` +
+        `be silently removed from state if this NotFound were trusted.`,
+      resourceType,
+      logicalId,
+      physicalId
+    );
+  }
+
+  if (clientRegion !== expectedRegion) {
+    throw new ProvisioningError(
+      `Refusing to treat NotFound as idempotent delete success for ${logicalId} ` +
+        `(${resourceType}): AWS client region ${clientRegion} does not match stack ` +
+        `state region ${expectedRegion}. The resource likely still exists in ` +
+        `${expectedRegion}; rerun the destroy with the correct region (e.g. ` +
+        `--region ${expectedRegion}).`,
+      resourceType,
+      logicalId,
+      physicalId
+    );
+  }
+}

--- a/src/types/resource.ts
+++ b/src/types/resource.ts
@@ -72,6 +72,16 @@ export interface ResourceUpdateResult {
 }
 
 /**
+ * Context passed to a provider's `delete` method.
+ *
+ * Re-exported from `src/provisioning/region-check.ts` so that callers
+ * implementing the provider interface only need to import from
+ * `src/types/resource.ts`.
+ */
+export type { DeleteContext } from '../provisioning/region-check.js';
+import type { DeleteContext } from '../provisioning/region-check.js';
+
+/**
  * Resource provider interface
  */
 export interface ResourceProvider {
@@ -146,12 +156,18 @@ export interface ResourceProvider {
    * @param physicalId Physical resource ID
    * @param resourceType CloudFormation resource type
    * @param properties Resource properties (optional, for providers that need them)
+   * @param context Delete-time context (optional, for back-compat). Contains
+   *   `expectedRegion` from the stack state so providers can refuse to treat
+   *   `NotFound` as idempotent success when the AWS client's region does not
+   *   match the region the resource was deployed to. See
+   *   `src/provisioning/region-check.ts` for the shared verification helper.
    */
   delete(
     logicalId: string,
     physicalId: string,
     resourceType: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    context?: DeleteContext
   ): Promise<void>;
 
   /**

--- a/tests/unit/deployment/resource-replacement.test.ts
+++ b/tests/unit/deployment/resource-replacement.test.ts
@@ -199,7 +199,10 @@ describe('DeployEngine - Resource Replacement', () => {
       // PR-2: DeployEngine threads stack region through provider.delete so
       // providers can refuse to swallow `*NotFound` when the AWS client's
       // region does not match the region the resource was deployed to.
-      expect.objectContaining({ expectedRegion: undefined })
+      // PR-1 (#57) made stackRegion required on DeployEngine, so this test's
+      // engine is constructed with 'us-east-1' (line 181) and that value
+      // flows through.
+      expect.objectContaining({ expectedRegion: 'us-east-1' })
     );
 
     // Verify create was called before delete (CFn order: CREATE new → DELETE old)

--- a/tests/unit/deployment/resource-replacement.test.ts
+++ b/tests/unit/deployment/resource-replacement.test.ts
@@ -195,7 +195,11 @@ describe('DeployEngine - Resource Replacement', () => {
       'MyBucket',
       'old-bucket-physical-id',
       'AWS::S3::Bucket',
-      expect.objectContaining({ BucketName: 'old-bucket-name' })
+      expect.objectContaining({ BucketName: 'old-bucket-name' }),
+      // PR-2: DeployEngine threads stack region through provider.delete so
+      // providers can refuse to swallow `*NotFound` when the AWS client's
+      // region does not match the region the resource was deployed to.
+      expect.objectContaining({ expectedRegion: undefined })
     );
 
     // Verify create was called before delete (CFn order: CREATE new → DELETE old)

--- a/tests/unit/provisioning/agentcore-runtime-provider.test.ts
+++ b/tests/unit/provisioning/agentcore-runtime-provider.test.ts
@@ -6,7 +6,7 @@ const mockSend = vi.fn();
 
 vi.mock('../../../src/utils/aws-clients.js', () => ({
   getAwsClients: () => ({
-    bedrockAgentCoreControl: { send: mockSend },
+    bedrockAgentCoreControl: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
   }),
 }));
 

--- a/tests/unit/provisioning/apigateway-provider.test.ts
+++ b/tests/unit/provisioning/apigateway-provider.test.ts
@@ -6,7 +6,7 @@ const mockSend = vi.fn();
 
 vi.mock('../../../src/utils/aws-clients.js', () => ({
   getAwsClients: () => ({
-    apiGateway: { send: mockSend },
+    apiGateway: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
   }),
 }));
 

--- a/tests/unit/provisioning/cloud-control-provider.test.ts
+++ b/tests/unit/provisioning/cloud-control-provider.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockCloudControlSend = vi.fn();
+const mockCloudControlConfigRegion = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    cloudControl: {
+      send: mockCloudControlSend,
+      // config.region is consulted by region-check.ts before treating
+      // ResourceNotFoundException as idempotent delete success.
+      config: { region: mockCloudControlConfigRegion },
+    },
+    dynamoDB: { send: vi.fn() },
+    apiGateway: { send: vi.fn() },
+    cloudFront: { send: vi.fn() },
+    lambda: { send: vi.fn() },
+  }),
+}));
+
+vi.mock('../../../src/deployment/intrinsic-function-resolver.js', () => ({
+  getAccountInfo: () =>
+    Promise.resolve({ partition: 'aws', region: 'us-east-1', accountId: '123456789012' }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  getLogger: () => {
+    const child = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(() => child),
+    };
+    return {
+      child: () => child,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+  },
+}));
+
+import { CloudControlProvider } from '../../../src/provisioning/cloud-control-provider.js';
+
+describe('CloudControlProvider delete region verification', () => {
+  let provider: CloudControlProvider;
+
+  beforeEach(() => {
+    mockCloudControlSend.mockReset();
+    mockCloudControlConfigRegion.mockReset();
+    mockCloudControlConfigRegion.mockResolvedValue('us-east-1');
+    provider = new CloudControlProvider();
+  });
+
+  it('treats ResourceNotFoundException as success when client region matches expectedRegion', async () => {
+    mockCloudControlSend.mockRejectedValueOnce(
+      Object.assign(new Error('Resource not found'), { name: 'ResourceNotFoundException' })
+    );
+
+    await expect(
+      provider.delete(
+        'MyTopic',
+        'arn:aws:sns:us-east-1:123:t',
+        'AWS::SNS::Topic',
+        {},
+        { expectedRegion: 'us-east-1' }
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws ProvisioningError on ResourceNotFoundException when client region differs from expectedRegion', async () => {
+    mockCloudControlSend.mockRejectedValueOnce(
+      Object.assign(new Error('Resource not found'), { name: 'ResourceNotFoundException' })
+    );
+
+    await expect(
+      provider.delete(
+        'MyTopic',
+        'arn:aws:sns:us-east-1:123:t',
+        'AWS::SNS::Topic',
+        {},
+        { expectedRegion: 'us-west-2' }
+      )
+    ).rejects.toThrow(/us-east-1.*us-west-2|us-west-2.*us-east-1/);
+  });
+
+  it('preserves existing idempotent NotFound behavior when context is omitted', async () => {
+    mockCloudControlSend.mockRejectedValueOnce(
+      Object.assign(new Error('Resource not found'), { name: 'ResourceNotFoundException' })
+    );
+
+    await expect(
+      provider.delete('MyTopic', 'arn:aws:sns:us-east-1:123:t', 'AWS::SNS::Topic', {})
+    ).resolves.toBeUndefined();
+  });
+
+  it('also accepts message-pattern NotFound matches with region check', async () => {
+    // CC API surfaces some not-found cases via message rather than name.
+    mockCloudControlSend.mockRejectedValueOnce(new Error('Topic does not exist'));
+
+    await expect(
+      provider.delete(
+        'MyTopic',
+        'arn:aws:sns:us-east-1:123:t',
+        'AWS::SNS::Topic',
+        {},
+        { expectedRegion: 'eu-west-1' }
+      )
+    ).rejects.toThrow(/eu-west-1/);
+  });
+});

--- a/tests/unit/provisioning/cloudfront-distribution-provider.test.ts
+++ b/tests/unit/provisioning/cloudfront-distribution-provider.test.ts
@@ -6,7 +6,7 @@ const mockSend = vi.fn();
 
 vi.mock('../../../src/utils/aws-clients.js', () => ({
   getAwsClients: () => ({
-    cloudFront: { send: mockSend },
+    cloudFront: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
   }),
 }));
 

--- a/tests/unit/provisioning/cloudfront-oai-provider.test.ts
+++ b/tests/unit/provisioning/cloudfront-oai-provider.test.ts
@@ -6,7 +6,7 @@ const mockSend = vi.fn();
 
 vi.mock('../../../src/utils/aws-clients.js', () => ({
   getAwsClients: () => ({
-    cloudFront: { send: mockSend },
+    cloudFront: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
   }),
 }));
 

--- a/tests/unit/provisioning/ecs-provider.test.ts
+++ b/tests/unit/provisioning/ecs-provider.test.ts
@@ -9,6 +9,7 @@ vi.mock('@aws-sdk/client-ecs', async () => {
     ...actual,
     ECSClient: vi.fn().mockImplementation(() => ({
       send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
     })),
   };
 });

--- a/tests/unit/provisioning/elbv2-provider.test.ts
+++ b/tests/unit/provisioning/elbv2-provider.test.ts
@@ -7,7 +7,7 @@ vi.mock('@aws-sdk/client-elastic-load-balancing-v2', async () => {
   const actual = await vi.importActual('@aws-sdk/client-elastic-load-balancing-v2');
   return {
     ...actual,
-    ElasticLoadBalancingV2Client: vi.fn().mockImplementation(() => ({ send: mockSend })),
+    ElasticLoadBalancingV2Client: vi.fn().mockImplementation(() => ({ send: mockSend, config: { region: () => Promise.resolve('us-east-1') } })),
   };
 });
 

--- a/tests/unit/provisioning/eventbridge-rule-provider.test.ts
+++ b/tests/unit/provisioning/eventbridge-rule-provider.test.ts
@@ -6,7 +6,7 @@ const mockSend = vi.fn();
 
 vi.mock('../../../src/utils/aws-clients.js', () => ({
   getAwsClients: () => ({
-    eventBridge: { send: mockSend },
+    eventBridge: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
   }),
 }));
 

--- a/tests/unit/provisioning/iam-role-provider.test.ts
+++ b/tests/unit/provisioning/iam-role-provider.test.ts
@@ -6,7 +6,7 @@ const mockSend = vi.fn();
 
 vi.mock('../../../src/utils/aws-clients.js', () => ({
   getAwsClients: () => ({
-    iam: { send: mockSend },
+    iam: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
   }),
 }));
 

--- a/tests/unit/provisioning/lambda-function-provider.test.ts
+++ b/tests/unit/provisioning/lambda-function-provider.test.ts
@@ -13,7 +13,12 @@ const mockEc2Send = vi.fn();
 
 vi.mock('../../../src/utils/aws-clients.js', () => ({
   getAwsClients: () => ({
-    lambda: { send: mockLambdaSend },
+    lambda: {
+      send: mockLambdaSend,
+      // config.region is consulted by region-check.ts before treating
+      // ResourceNotFoundException as idempotent delete success.
+      config: { region: () => Promise.resolve('us-east-1') },
+    },
     ec2: { send: mockEc2Send },
   }),
 }));
@@ -484,6 +489,59 @@ describe('LambdaFunctionProvider', () => {
       // Subnet/SG provider will retry from its side, so list-failure is non-fatal.
       await expect(promise).resolves.toBeUndefined();
       expect(mockEc2Send).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('delete region verification', () => {
+    // The PR-2 contract: a `*NotFound` error must not be treated as
+    // idempotent delete success when the AWS client's region differs from
+    // the region recorded in stack state. Otherwise a destroy run with the
+    // wrong region silently strips every resource from state and orphans
+    // the actual AWS resources in the real region (the originating bug).
+
+    it('treats NotFound as success when context.expectedRegion matches client region', async () => {
+      mockLambdaSend.mockRejectedValueOnce(
+        new ResourceNotFoundException({ message: 'Function not found', $metadata: {} })
+      );
+
+      // Mocked client.config.region() returns 'us-east-1' (see mock above).
+      await expect(
+        provider.delete(
+          'Fn',
+          'fn-gone',
+          'AWS::Lambda::Function',
+          {},
+          { expectedRegion: 'us-east-1' }
+        )
+      ).resolves.toBeUndefined();
+      expect(mockLambdaSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws ProvisioningError on NotFound when context.expectedRegion does not match client region', async () => {
+      mockLambdaSend.mockRejectedValueOnce(
+        new ResourceNotFoundException({ message: 'Function not found', $metadata: {} })
+      );
+
+      await expect(
+        provider.delete(
+          'Fn',
+          'fn-gone',
+          'AWS::Lambda::Function',
+          {},
+          { expectedRegion: 'us-west-2' }
+        )
+      ).rejects.toThrow(/us-east-1.*us-west-2|us-west-2.*us-east-1/);
+    });
+
+    it('preserves existing idempotent NotFound behavior when context is omitted', async () => {
+      mockLambdaSend.mockRejectedValueOnce(
+        new ResourceNotFoundException({ message: 'Function not found', $metadata: {} })
+      );
+
+      // No context argument -> back-compat path, NotFound silently succeeds.
+      await expect(
+        provider.delete('Fn', 'fn-gone', 'AWS::Lambda::Function', {})
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/tests/unit/provisioning/providers/cloudtrail-provider.test.ts
+++ b/tests/unit/provisioning/providers/cloudtrail-provider.test.ts
@@ -8,6 +8,7 @@ vi.mock('@aws-sdk/client-cloudtrail', async (importOriginal) => {
     ...actual,
     CloudTrailClient: vi.fn().mockImplementation(() => ({
       send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
     })),
   };
 });

--- a/tests/unit/provisioning/providers/codebuild-provider.test.ts
+++ b/tests/unit/provisioning/providers/codebuild-provider.test.ts
@@ -8,6 +8,7 @@ vi.mock('@aws-sdk/client-codebuild', async (importOriginal) => {
     ...actual,
     CodeBuildClient: vi.fn().mockImplementation(() => ({
       send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
     })),
   };
 });

--- a/tests/unit/provisioning/providers/efs-provider.test.ts
+++ b/tests/unit/provisioning/providers/efs-provider.test.ts
@@ -20,6 +20,7 @@ vi.mock('@aws-sdk/client-efs', async (importOriginal) => {
     ...actual,
     EFSClient: vi.fn().mockImplementation(() => ({
       send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
     })),
   };
 });

--- a/tests/unit/provisioning/providers/firehose-provider.test.ts
+++ b/tests/unit/provisioning/providers/firehose-provider.test.ts
@@ -8,6 +8,7 @@ vi.mock('@aws-sdk/client-firehose', async (importOriginal) => {
     ...actual,
     FirehoseClient: vi.fn().mockImplementation(() => ({
       send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
     })),
   };
 });

--- a/tests/unit/provisioning/providers/kinesis-provider.test.ts
+++ b/tests/unit/provisioning/providers/kinesis-provider.test.ts
@@ -8,6 +8,7 @@ vi.mock('@aws-sdk/client-kinesis', async (importOriginal) => {
     ...actual,
     KinesisClient: vi.fn().mockImplementation(() => ({
       send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
     })),
   };
 });

--- a/tests/unit/provisioning/providers/kms-provider.test.ts
+++ b/tests/unit/provisioning/providers/kms-provider.test.ts
@@ -8,6 +8,7 @@ vi.mock('@aws-sdk/client-kms', async (importOriginal) => {
     ...actual,
     KMSClient: vi.fn().mockImplementation(() => ({
       send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
     })),
   };
 });

--- a/tests/unit/provisioning/providers/s3-tables-provider.test.ts
+++ b/tests/unit/provisioning/providers/s3-tables-provider.test.ts
@@ -8,6 +8,7 @@ vi.mock('@aws-sdk/client-s3tables', async (importOriginal) => {
     ...actual,
     S3TablesClient: vi.fn().mockImplementation(() => ({
       send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
     })),
   };
 });

--- a/tests/unit/provisioning/providers/s3-vectors-provider.test.ts
+++ b/tests/unit/provisioning/providers/s3-vectors-provider.test.ts
@@ -8,6 +8,7 @@ vi.mock('@aws-sdk/client-s3vectors', async (importOriginal) => {
     ...actual,
     S3VectorsClient: vi.fn().mockImplementation(() => ({
       send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
     })),
   };
 });

--- a/tests/unit/provisioning/rds-provider.test.ts
+++ b/tests/unit/provisioning/rds-provider.test.ts
@@ -6,7 +6,7 @@ vi.mock('@aws-sdk/client-rds', async () => {
   const actual = await vi.importActual('@aws-sdk/client-rds');
   return {
     ...actual,
-    RDSClient: vi.fn().mockImplementation(() => ({ send: mockSend })),
+    RDSClient: vi.fn().mockImplementation(() => ({ send: mockSend, config: { region: () => Promise.resolve('us-east-1') } })),
   };
 });
 

--- a/tests/unit/provisioning/region-check.test.ts
+++ b/tests/unit/provisioning/region-check.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { assertRegionMatch } from '../../../src/provisioning/region-check.js';
+import { ProvisioningError } from '../../../src/utils/error-handler.js';
+
+describe('assertRegionMatch', () => {
+  const resourceType = 'AWS::Lambda::Function';
+  const logicalId = 'MyFn';
+  const physicalId = 'fn-123';
+
+  describe('when expectedRegion is undefined', () => {
+    it('returns silently regardless of clientRegion', () => {
+      // Back-compat: callers that have not been threaded with a state region
+      // must continue to see the previous idempotent NotFound behavior.
+      expect(() =>
+        assertRegionMatch('us-east-1', undefined, resourceType, logicalId, physicalId)
+      ).not.toThrow();
+
+      expect(() =>
+        assertRegionMatch(undefined, undefined, resourceType, logicalId, physicalId)
+      ).not.toThrow();
+    });
+  });
+
+  describe('when clientRegion equals expectedRegion', () => {
+    it('returns silently', () => {
+      expect(() =>
+        assertRegionMatch('us-east-1', 'us-east-1', resourceType, logicalId, physicalId)
+      ).not.toThrow();
+    });
+  });
+
+  describe('when clientRegion does not match expectedRegion', () => {
+    it('throws ProvisioningError mentioning both regions', () => {
+      expect(() =>
+        assertRegionMatch('us-east-1', 'us-west-2', resourceType, logicalId, physicalId)
+      ).toThrow(ProvisioningError);
+
+      try {
+        assertRegionMatch('us-east-1', 'us-west-2', resourceType, logicalId, physicalId);
+        // Should be unreachable.
+        expect.fail('expected ProvisioningError to be thrown');
+      } catch (err) {
+        const e = err as ProvisioningError;
+        expect(e).toBeInstanceOf(ProvisioningError);
+        expect(e.message).toContain('us-east-1');
+        expect(e.message).toContain('us-west-2');
+        expect(e.message).toContain(logicalId);
+        expect(e.message).toContain(resourceType);
+        expect(e.resourceType).toBe(resourceType);
+        expect(e.logicalId).toBe(logicalId);
+        expect(e.physicalId).toBe(physicalId);
+      }
+    });
+
+    it('includes a hint to rerun with --region', () => {
+      try {
+        assertRegionMatch('us-east-1', 'eu-west-1', resourceType, logicalId, physicalId);
+        expect.fail('expected ProvisioningError');
+      } catch (err) {
+        expect((err as Error).message).toContain('--region eu-west-1');
+      }
+    });
+  });
+
+  describe('when clientRegion is undefined and expectedRegion is set', () => {
+    it('throws ProvisioningError', () => {
+      // We refuse to silently swallow NotFound when we cannot even determine
+      // what region the client is operating against — the resource may live
+      // in expectedRegion and the destroy run would otherwise strip it from
+      // state without ever calling AWS in the right region.
+      expect(() =>
+        assertRegionMatch(undefined, 'us-west-2', resourceType, logicalId, physicalId)
+      ).toThrow(ProvisioningError);
+    });
+  });
+
+  it('omits physicalId from the error when not provided', () => {
+    try {
+      assertRegionMatch('us-east-1', 'us-west-2', resourceType, logicalId);
+      expect.fail('expected ProvisioningError');
+    } catch (err) {
+      const e = err as ProvisioningError;
+      expect(e.physicalId).toBeUndefined();
+    }
+  });
+});

--- a/tests/unit/provisioning/route53-provider.test.ts
+++ b/tests/unit/provisioning/route53-provider.test.ts
@@ -7,7 +7,7 @@ vi.mock('@aws-sdk/client-route-53', async () => {
   const actual = await vi.importActual('@aws-sdk/client-route-53');
   return {
     ...actual,
-    Route53Client: vi.fn().mockImplementation(() => ({ send: mockSend })),
+    Route53Client: vi.fn().mockImplementation(() => ({ send: mockSend, config: { region: () => Promise.resolve('us-east-1') } })),
   };
 });
 

--- a/tests/unit/provisioning/stepfunctions-provider.test.ts
+++ b/tests/unit/provisioning/stepfunctions-provider.test.ts
@@ -9,6 +9,7 @@ vi.mock('@aws-sdk/client-sfn', async () => {
     ...actual,
     SFNClient: vi.fn().mockImplementation(() => ({
       send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
     })),
   };
 });

--- a/tests/unit/provisioning/wafv2-provider.test.ts
+++ b/tests/unit/provisioning/wafv2-provider.test.ts
@@ -7,7 +7,7 @@ vi.mock('@aws-sdk/client-wafv2', async () => {
   const actual = await vi.importActual('@aws-sdk/client-wafv2');
   return {
     ...actual,
-    WAFV2Client: vi.fn().mockImplementation(() => ({ send: mockSend })),
+    WAFV2Client: vi.fn().mockImplementation(() => ({ send: mockSend, config: { region: () => Promise.resolve('us-east-1') } })),
   };
 });
 


### PR DESCRIPTION
## Summary

PR 2 of the cdkd region/state refactor (see `docs/plans/02-delete-region-verification.md`).

Stop providers from silently treating "resource not found" as idempotent delete success when the AWS client's region differs from the region the resource was deployed to.

### Silent-failure incident

A Lambda function was deployed to `us-west-2`. A subsequent `cdkd destroy` ran with a `us-east-1` client (mis-set `AWS_REGION`). Every provider received `ResourceNotFoundException` against the wrong region and treated it as idempotent "already gone" success, removing the resource from cdkd state. The Lambda continued to run in `us-west-2` until manual cleanup discovered it.

The previous CLAUDE.md rule — *"DELETE idempotency (not-found / No policy found treated as success)"* — was correct in spirit (duplicate-delete must be safe) but masked the region-mismatch case.

## Contract change

`ResourceProvider.delete` now accepts an optional `context: { expectedRegion?: string }` parameter:

```typescript
delete(
  logicalId: string,
  physicalId: string,
  resourceType: string,
  properties?: Record<string, unknown>,
  context?: DeleteContext,
): Promise<void>;
```

`DeployEngine` and the destroy command thread `state.region` through every delete call:

- `src/deployment/deploy-engine.ts` — 4 sites (rollback CREATE, replace-after-CREATE, fallback DELETE→CREATE, normal DELETE)
- `src/cli/commands/destroy.ts` — 1 site (parallel per-level destroy)

When `context.expectedRegion` is undefined the helper is a no-op, preserving the existing idempotent behavior for any caller path that has not been threaded with state region.

## Shared helper

`src/provisioning/region-check.ts` adds `assertRegionMatch(clientRegion, expectedRegion, resourceType, logicalId, physicalId)`:

- `expectedRegion` undefined → no-op (back-compat).
- `clientRegion === expectedRegion` → silent return.
- mismatch → throws `ProvisioningError` with both regions and a hint to rerun with `--region <expectedRegion>`.

Each provider's delete calls this helper before short-circuiting on `*NotFound`.

## Providers updated

All 51 SDK providers under `src/provisioning/providers/` plus the Cloud Control fallback at `src/provisioning/cloud-control-provider.ts`. Multi-resource providers (apigateway, apigatewayv2, appsync, ec2, ecs, efs, elasticache, elbv2, glue, iam-user-group, kms, rds, route53, s3-tables, s3-vectors, servicediscovery) thread `context` through every sub-delete dispatch. The custom-resource-provider accepts `context` for interface conformity but does not consult it (the underlying Lambda invocation does not surface a managed-resource `*NotFound`).

## Test coverage

- `tests/unit/provisioning/region-check.test.ts` (new, 6 tests) — helper directly: matching, mismatched, undefined-region, undefined-client, physicalId formatting, error-message hint.
- `tests/unit/provisioning/cloud-control-provider.test.ts` (new, 4 tests) — Cloud Control delete: matching/mismatched region + NotFound by name, mismatched region + NotFound by message, no context = back-compat.
- `tests/unit/provisioning/lambda-function-provider.test.ts` (extended, +3 tests) — same matrix for an SDK provider.
- Existing provider tests had their AWS client mocks extended with `config.region` so the new region resolution path returns a value.
- `tests/unit/deployment/resource-replacement.test.ts` updated to assert on the new `context` argument.

Full suite: 64 files, 781 tests passing. Typecheck + lint + build all clean.

## Documentation

- `docs/provider-development.md` — Provider interface definition and Idempotency section now document the `context.expectedRegion` parameter and the region-mismatch check, with a worked example.
- `CLAUDE.md` — Provider Pattern signature and "DELETE idempotency" line clarify the new contract.

## Test plan

- [x] Unit tests pass (`npx vitest --run` — 781 / 781).
- [x] Typecheck (`pnpm run typecheck`) clean.
- [x] Lint (`pnpm run lint`) clean.
- [x] Build (`pnpm run build`) succeeds.
- [x] Working tree clean; branch `feat/delete-region-check` ahead of `main` by 1 commit.
- [ ] Real-AWS reproduction of the silent-failure scenario (intentionally **skipped** — the plan calls this out as impractical without two real regions and live resources; the unit-level coverage exercises the exact code path).
- [ ] Integration test (`/run-integ`) before merge to satisfy the `integ-destroy` markgate gate, since this PR touches deletion logic.

## References

- `docs/plans/02-delete-region-verification.md`
- Originating incident: documented in the rollout discussion.
