### PR TITLE
refactor(cli): consolidate --region to bootstrap-only (deprecate elsewhere)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,7 @@ registry.register('AWS::IAM::Role', new IAMRoleProvider());
 
 - `--app` (`-a`) is optional: falls back to `CDKD_APP` env var, then `cdk.json` `"app"` field. Accepts either a shell command (`"npx ts-node app.ts"`) or a path to a pre-synthesized cloud assembly directory (`cdk.out`); when a directory is given, synthesis is skipped and the manifest is read directly.
 - `--state-bucket` is optional: falls back to `CDKD_STATE_BUCKET` env var, then `cdk.json` `context.cdkd.stateBucket`
+- `--region` is **bootstrap-only** as of PR 5 (`docs/plans/05-region-flag-cleanup.md`). `cdkd bootstrap` uses it to pick the region of the new state bucket; every other command (`deploy`, `destroy`, `diff`, `synth`, `list`, `state`, `force-unlock`, `publish-assets`) accepts `--region` for backward compatibility but emits a deprecation warning and ignores the value — provisioning clients pick up the region from `AWS_REGION` / the AWS profile, and the state-bucket client auto-detects the bucket's region via `GetBucketLocation` (PR 3).
 - `--context` / `-c` is optional: accepts `key=value` pairs (repeatable), merged with cdk.json context (CLI takes precedence)
 - Stack names are positional arguments: `cdkd deploy MyStack` (not `--stack-name`)
 - `--all` flag targets all stacks for deploy/diff/destroy (`destroy --all` only targets stacks from the current CDK app via synthesis)

--- a/README.md
+++ b/README.md
@@ -407,7 +407,6 @@ cdkd deploy -c env=staging -c featureFlag=true
 cdkd deploy MyStack \
   --app "npx ts-node app.ts" \
   --state-bucket my-cdkd-state \
-  --region us-east-1 \
   --verbose
 
 # Show diff (what would change)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -244,9 +244,11 @@ GET request, not a HEAD — avoids the SDK glitch) and rebuilds its S3
 client to that region before any state operation. If you still see this
 error, please file a bug with the full stack trace.
 
-You no longer need to set `--region` to match the bucket region — the
-CLI's region option (and the profile region) only affect provisioning
-clients, not the state-bucket client.
+You no longer need to set the region to match the bucket region. As of
+PR 5 (`docs/plans/05-region-flag-cleanup.md`), `--region` is reserved for
+`cdkd bootstrap` (where it picks the new bucket's region); on every
+other command it is deprecated and ignored. Use `AWS_REGION` or your
+AWS profile to control the SDK's default region for provisioning.
 
 ---
 

--- a/src/cli/commands/bootstrap.ts
+++ b/src/cli/commands/bootstrap.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import {
   CreateBucketCommand,
   HeadBucketCommand,
@@ -197,9 +197,19 @@ export function createBootstrapCommand(): Command {
       'Name of S3 bucket to create for state storage (default: cdkd-state-{accountId})'
     )
     .option('--force', 'Force reconfiguration of existing bucket', false)
+    .addOption(
+      // Bootstrap-specific: needs to know which region to create the bucket
+      // in. After PR 5, `--region` is removed from `commonOptions` and only
+      // re-added explicitly here — every other command resolves the region
+      // from `AWS_REGION` / profile.
+      new Option(
+        '--region <region>',
+        'AWS region in which to create the state bucket (defaults to AWS_REGION env or us-east-1)'
+      )
+    )
     .action(withErrorHandling(bootstrapCommand));
 
-  // Add common options (includes --region, --profile, --verbose)
+  // Add common options (--profile, --verbose, --yes)
   commonOptions.forEach((opt) => cmd.addOption(opt));
 
   return cmd;

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -2,11 +2,13 @@ import { Command } from 'commander';
 import {
   appOptions,
   commonOptions,
+  deprecatedRegionOption,
   stateOptions,
   stackOptions,
   deployOptions,
   contextOptions,
   parseContextOptions,
+  warnIfDeprecatedRegion,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
@@ -60,6 +62,10 @@ async function deployCommand(
     // interleave too aggressively with the live area's in-flight task lines.
     process.env['CDKD_NO_LIVE'] = '1';
   }
+
+  // PR 5: --region is deprecated on non-bootstrap commands. Warn but keep
+  // the rest of the pipeline working as before.
+  warnIfDeprecatedRegion(options);
 
   // Skip waiting for async resources (CloudFront, RDS, ElastiCache, etc.)
   if (!options.wait) {
@@ -373,6 +379,10 @@ export function createDeployCommand(): Command {
     ...deployOptions,
     ...contextOptions,
   ].forEach((opt) => cmd.addOption(opt));
+
+  // --region is deprecated for deploy (PR 5). Accepted for backward
+  // compatibility; warning emitted at runtime via warnIfDeprecatedRegion.
+  cmd.addOption(deprecatedRegionOption);
 
   return cmd;
 }

--- a/src/cli/commands/destroy.ts
+++ b/src/cli/commands/destroy.ts
@@ -2,11 +2,13 @@ import { Command } from 'commander';
 import {
   appOptions,
   commonOptions,
+  deprecatedRegionOption,
   stateOptions,
   stackOptions,
   destroyOptions,
   contextOptions,
   parseContextOptions,
+  warnIfDeprecatedRegion,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { getLiveRenderer } from '../../utils/live-renderer.js';
@@ -51,6 +53,10 @@ async function destroyCommand(
     // interleave too aggressively with the live area's in-flight task lines.
     process.env['CDKD_NO_LIVE'] = '1';
   }
+
+  // PR 5: --region is deprecated on non-bootstrap commands. Warn but keep
+  // the rest of the pipeline working as before.
+  warnIfDeprecatedRegion(options);
 
   // Resolve --state-bucket from CLI, env, cdk.json, or default
   const region = options.region || process.env['AWS_REGION'] || 'us-east-1';
@@ -506,6 +512,10 @@ export function createDestroyCommand(): Command {
     ...destroyOptions,
     ...contextOptions,
   ].forEach((opt) => cmd.addOption(opt));
+
+  // --region is deprecated for destroy (PR 5). Accepted for backward
+  // compatibility; warning emitted at runtime via warnIfDeprecatedRegion.
+  cmd.addOption(deprecatedRegionOption);
 
   return cmd;
 }

--- a/src/cli/commands/diff.ts
+++ b/src/cli/commands/diff.ts
@@ -2,10 +2,12 @@ import { Command } from 'commander';
 import {
   appOptions,
   commonOptions,
+  deprecatedRegionOption,
   stateOptions,
   stackOptions,
   contextOptions,
   parseContextOptions,
+  warnIfDeprecatedRegion,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
@@ -116,6 +118,10 @@ async function diffCommand(
   if (options.verbose) {
     logger.setLevel('debug');
   }
+
+  // PR 5: --region is deprecated on non-bootstrap commands. Warn but keep
+  // the rest of the pipeline working as before.
+  warnIfDeprecatedRegion(options);
 
   // Resolve --app from CLI, env, or cdk.json
   const app = resolveApp(options.app);
@@ -308,6 +314,10 @@ export function createDiffCommand(): Command {
   [...commonOptions, ...appOptions, ...stateOptions, ...stackOptions, ...contextOptions].forEach(
     (opt) => cmd.addOption(opt)
   );
+
+  // --region is deprecated for diff (PR 5). Accepted for backward
+  // compatibility; warning emitted at runtime via warnIfDeprecatedRegion.
+  cmd.addOption(deprecatedRegionOption);
 
   return cmd;
 }

--- a/src/cli/commands/force-unlock.ts
+++ b/src/cli/commands/force-unlock.ts
@@ -1,5 +1,11 @@
 import { Command, Option } from 'commander';
-import { commonOptions, stateOptions, stackOptions } from '../options.js';
+import {
+  commonOptions,
+  deprecatedRegionOption,
+  stateOptions,
+  stackOptions,
+  warnIfDeprecatedRegion,
+} from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { LockManager } from '../../state/lock-manager.js';
@@ -30,6 +36,10 @@ async function forceUnlockCommand(
   if (options.verbose) {
     logger.setLevel('debug');
   }
+
+  // PR 5: --region is deprecated on non-bootstrap commands. Warn but keep
+  // the rest of the pipeline working as before.
+  warnIfDeprecatedRegion(options);
 
   // Resolve stack name
   const stackPatterns = stackArgs.length > 0 ? stackArgs : options.stack ? [options.stack] : [];
@@ -112,6 +122,10 @@ export function createForceUnlockCommand(): Command {
     .action(withErrorHandling(forceUnlockCommand));
 
   [...commonOptions, ...stateOptions, ...stackOptions].forEach((opt) => cmd.addOption(opt));
+
+  // --region is deprecated for force-unlock (PR 5). Accepted for backward
+  // compatibility; warning emitted at runtime via warnIfDeprecatedRegion.
+  cmd.addOption(deprecatedRegionOption);
 
   return cmd;
 }

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -1,5 +1,12 @@
 import { Command } from 'commander';
-import { appOptions, commonOptions, contextOptions, parseContextOptions } from '../options.js';
+import {
+  appOptions,
+  commonOptions,
+  contextOptions,
+  deprecatedRegionOption,
+  parseContextOptions,
+  warnIfDeprecatedRegion,
+} from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
@@ -104,6 +111,10 @@ async function listCommand(
   if (options.verbose) {
     logger.setLevel('debug');
   }
+
+  // PR 5: --region is deprecated on non-bootstrap commands. Warn but keep
+  // the rest of the pipeline working as before.
+  warnIfDeprecatedRegion(options);
 
   // Resolve --app from CLI, env, or cdk.json
   const app = resolveApp(options.app);
@@ -229,6 +240,10 @@ export function createListCommand(): Command {
   // Reuse standard options. Note: list doesn't need --state-bucket / --stack
   // / deploy options — it's a pure local synth + render command.
   [...commonOptions, ...appOptions, ...contextOptions].forEach((opt) => cmd.addOption(opt));
+
+  // --region is deprecated for list (PR 5). Accepted for backward
+  // compatibility; warning emitted at runtime via warnIfDeprecatedRegion.
+  cmd.addOption(deprecatedRegionOption);
 
   return cmd;
 }

--- a/src/cli/commands/publish-assets.ts
+++ b/src/cli/commands/publish-assets.ts
@@ -1,5 +1,5 @@
 import { Option, Command } from 'commander';
-import { commonOptions } from '../options.js';
+import { commonOptions, deprecatedRegionOption, warnIfDeprecatedRegion } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { AssetPublisher } from '../../assets/asset-publisher.js';
@@ -20,6 +20,10 @@ async function publishAssetsCommand(options: {
   if (options.verbose) {
     logger.setLevel('debug');
   }
+
+  // PR 5: --region is deprecated on non-bootstrap commands. Warn but keep
+  // the rest of the pipeline working as before.
+  warnIfDeprecatedRegion(options);
 
   logger.info('Publishing assets...');
   logger.debug('Asset manifest path:', options.path);
@@ -60,6 +64,10 @@ export function createPublishAssetsCommand(): Command {
 
   // Add common options
   commonOptions.forEach((opt) => cmd.addOption(opt));
+
+  // --region is deprecated for publish-assets (PR 5). Accepted for backward
+  // compatibility; warning emitted at runtime via warnIfDeprecatedRegion.
+  cmd.addOption(deprecatedRegionOption);
 
   return cmd;
 }

--- a/src/cli/commands/state.ts
+++ b/src/cli/commands/state.ts
@@ -1,6 +1,11 @@
 import * as readline from 'node:readline/promises';
 import { Command, Option } from 'commander';
-import { commonOptions, stateOptions } from '../options.js';
+import {
+  commonOptions,
+  deprecatedRegionOption,
+  stateOptions,
+  warnIfDeprecatedRegion,
+} from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { S3StateBackend, type StackStateRef } from '../../state/s3-state-backend.js';
@@ -105,6 +110,10 @@ async function setupStateBackend(options: {
   prefix: string;
   dispose: () => void;
 }> {
+  // PR 5: --region is deprecated on every state subcommand. Warn here so
+  // the four subcommands inherit the warning via this shared bootstrap.
+  warnIfDeprecatedRegion(options);
+
   const awsClients = new AwsClients({
     ...(options.region && { region: options.region }),
     ...(options.profile && { profile: options.profile }),
@@ -271,6 +280,11 @@ function createStateListCommand(): Command {
     .action(withErrorHandling(stateListCommand));
 
   [...commonOptions, ...stateOptions].forEach((opt) => cmd.addOption(opt));
+
+  // --region is deprecated for state subcommands (PR 5). Accepted for
+  // backward compatibility; warning emitted at runtime via
+  // warnIfDeprecatedRegion (called from setupStateBackend).
+  cmd.addOption(deprecatedRegionOption);
 
   return cmd;
 }
@@ -443,6 +457,11 @@ function createStateResourcesCommand(): Command {
 
   [...commonOptions, ...stateOptions].forEach((opt) => cmd.addOption(opt));
 
+  // --region is deprecated for state subcommands (PR 5). Accepted for
+  // backward compatibility; warning emitted at runtime via
+  // warnIfDeprecatedRegion (called from setupStateBackend).
+  cmd.addOption(deprecatedRegionOption);
+
   return cmd;
 }
 
@@ -577,6 +596,11 @@ function createStateShowCommand(): Command {
     .action(withErrorHandling(stateShowCommand));
 
   [...commonOptions, ...stateOptions].forEach((opt) => cmd.addOption(opt));
+
+  // --region is deprecated for state subcommands (PR 5). Accepted for
+  // backward compatibility; warning emitted at runtime via
+  // warnIfDeprecatedRegion (called from setupStateBackend).
+  cmd.addOption(deprecatedRegionOption);
 
   return cmd;
 }
@@ -730,6 +754,11 @@ function createStateRmCommand(): Command {
     .action(withErrorHandling(stateRmCommand));
 
   [...commonOptions, ...stateOptions].forEach((opt) => cmd.addOption(opt));
+
+  // --region is deprecated for state subcommands (PR 5). Accepted for
+  // backward compatibility; warning emitted at runtime via
+  // warnIfDeprecatedRegion (called from setupStateBackend).
+  cmd.addOption(deprecatedRegionOption);
 
   return cmd;
 }

--- a/src/cli/commands/synth.ts
+++ b/src/cli/commands/synth.ts
@@ -1,7 +1,14 @@
 import { Command } from 'commander';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
-import { appOptions, commonOptions, contextOptions, parseContextOptions } from '../options.js';
+import {
+  appOptions,
+  commonOptions,
+  contextOptions,
+  deprecatedRegionOption,
+  parseContextOptions,
+  warnIfDeprecatedRegion,
+} from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
@@ -25,6 +32,10 @@ async function synthCommand(options: {
   if (options.verbose) {
     logger.setLevel('debug');
   }
+
+  // PR 5: --region is deprecated on non-bootstrap commands. Warn but keep
+  // the rest of the pipeline working as before.
+  warnIfDeprecatedRegion(options);
 
   // Resolve --app from CLI, env, or cdk.json
   const app = resolveApp(options.app);
@@ -93,6 +104,10 @@ export function createSynthCommand(): Command {
 
   // Add options
   [...commonOptions, ...appOptions, ...contextOptions].forEach((opt) => cmd.addOption(opt));
+
+  // --region is deprecated for synth (PR 5). Accepted for backward
+  // compatibility; warning emitted at runtime via warnIfDeprecatedRegion.
+  cmd.addOption(deprecatedRegionOption);
 
   return cmd;
 }

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -17,17 +17,52 @@ export function parseContextOptions(contextArgs?: string[]): Record<string, stri
 }
 
 /**
- * Common CLI options
+ * Common CLI options.
+ *
+ * Note: `--region` is intentionally NOT in `commonOptions`. Since PR 3
+ * (dynamic region resolution) and PR 4 (region-free default state bucket
+ * name), `--region` no longer has a useful role on most commands. It is
+ * still required by `cdkd bootstrap` (which needs to know where to create
+ * a new bucket) and is added directly there. Other commands accept it for
+ * backward compatibility via `deprecatedRegionOption` and emit a
+ * deprecation warning when it is passed; the value is otherwise ignored.
  */
 export const commonOptions = [
   new Option('--verbose', 'Enable verbose logging').default(false),
-  new Option('--region <region>', 'AWS region'),
   new Option('--profile <profile>', 'AWS profile'),
   new Option(
     '-y, --yes',
     'Automatically answer interactive prompts with the recommended response (e.g. confirm destroy)'
   ).default(false),
 ];
+
+/**
+ * Deprecated `--region` option attached to non-bootstrap commands.
+ *
+ * Kept (rather than fully removed) so that scripts or muscle memory passing
+ * `--region` do not break. The value is parsed but ignored — see
+ * `warnIfDeprecatedRegion` for the runtime warning. Final removal is
+ * tracked in PR 99 (see `docs/plans/05-region-flag-cleanup.md`).
+ */
+export const deprecatedRegionOption = new Option(
+  '--region <region>',
+  '[deprecated] No effect on this command; use AWS_REGION or your AWS profile'
+).hideHelp();
+
+/**
+ * Emit a one-shot stderr warning when a non-bootstrap command receives
+ * `--region`. PR 5 consolidates `--region` to bootstrap-only; everywhere
+ * else the SDK picks up the region from `AWS_REGION` / profile, and
+ * passing the flag does nothing useful.
+ */
+export function warnIfDeprecatedRegion(options: { region?: string }): void {
+  if (options.region !== undefined) {
+    process.stderr.write(
+      'Warning: --region is deprecated for this command and has no effect. ' +
+        'Use the AWS_REGION environment variable or your AWS profile to override the SDK default region.\n'
+    );
+  }
+}
 
 /**
  * App options

--- a/tests/unit/cli/list.test.ts
+++ b/tests/unit/cli/list.test.ts
@@ -50,11 +50,21 @@ function makeStack(overrides: Partial<StackInfo> & { stackName: string }): Stack
  * subcommand's own argv (no node/script prefix). exitOverride prevents
  * Commander from calling process.exit on parse errors.
  */
-async function runList(args: string[]): Promise<{ stdout: string; error?: Error }> {
+async function runList(
+  args: string[]
+): Promise<{ stdout: string; stderr: string; error?: Error }> {
   const cmd = createListCommand();
   cmd.exitOverride();
 
   const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  // Direct replacement (rather than vi.spyOn) for stderr — under vitest's
+  // output capture vi.spyOn does not always intercept process.stderr.write.
+  const stderrChunks: string[] = [];
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    stderrChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+    return true;
+  }) as typeof process.stderr.write;
   const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => {
     throw new Error('__process.exit__');
   }) as never);
@@ -68,12 +78,14 @@ async function runList(args: string[]): Promise<{ stdout: string; error?: Error 
   }
 
   const stdout = writeSpy.mock.calls.map((c) => String(c[0])).join('');
+  const stderr = stderrChunks.join('');
 
   writeSpy.mockRestore();
+  process.stderr.write = originalStderrWrite;
   exitSpy.mockRestore();
   errorLogSpy.mockRestore();
 
-  return { stdout, ...(error && { error }) };
+  return { stdout, stderr, ...(error && { error }) };
 }
 
 describe('cdkd list', () => {
@@ -276,5 +288,33 @@ describe('cdkd list', () => {
     const { error } = await runList([]);
     expect(error).toBeDefined();
     expect(error?.message).toBe('__process.exit__');
+  });
+
+  it('emits a deprecation warning to stderr when --region is passed (PR 5)', async () => {
+    mockSynthesize.mockResolvedValue({
+      stacks: [makeStack({ stackName: 'StackA', displayName: 'StackA' })],
+      manifest: {},
+      assemblyDir: '/tmp/cdk.out',
+    });
+
+    const { stdout, stderr, error } = await runList(['--region', 'us-east-1']);
+
+    expect(error).toBeUndefined();
+    // Command still runs to completion.
+    expect(stdout).toBe('StackA\n');
+    // Warning is on stderr, mentions --region and points users at AWS_REGION.
+    expect(stderr).toMatch(/--region is deprecated for this command and has no effect/);
+    expect(stderr).toMatch(/AWS_REGION/);
+  });
+
+  it('does not emit the deprecation warning when --region is omitted', async () => {
+    mockSynthesize.mockResolvedValue({
+      stacks: [makeStack({ stackName: 'StackA', displayName: 'StackA' })],
+      manifest: {},
+      assemblyDir: '/tmp/cdk.out',
+    });
+
+    const { stderr } = await runList([]);
+    expect(stderr).not.toMatch(/--region is deprecated/);
   });
 });

--- a/tests/unit/cli/options.test.ts
+++ b/tests/unit/cli/options.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+
+import {
+  commonOptions,
+  deprecatedRegionOption,
+  parseContextOptions,
+  warnIfDeprecatedRegion,
+} from '../../../src/cli/options.js';
+import { createBootstrapCommand } from '../../../src/cli/commands/bootstrap.js';
+import { createDeployCommand } from '../../../src/cli/commands/deploy.js';
+import { createDestroyCommand } from '../../../src/cli/commands/destroy.js';
+import { createDiffCommand } from '../../../src/cli/commands/diff.js';
+import { createSynthCommand } from '../../../src/cli/commands/synth.js';
+import { createListCommand } from '../../../src/cli/commands/list.js';
+import { createForceUnlockCommand } from '../../../src/cli/commands/force-unlock.js';
+import { createPublishAssetsCommand } from '../../../src/cli/commands/publish-assets.js';
+import { createStateCommand } from '../../../src/cli/commands/state.js';
+
+/**
+ * Collect every option flag string registered on a command (incl. hidden
+ * ones). We use the public `options` array exposed by commander.
+ */
+function optionFlags(cmd: Command): string[] {
+  return cmd.options.map((o) => o.flags);
+}
+
+/**
+ * True when the command exposes `--region <region>` regardless of where it
+ * came from (commonOptions, bootstrap-direct, or deprecated wrapper).
+ */
+function hasRegionOption(cmd: Command): boolean {
+  return optionFlags(cmd).some((f) => /^--region\b/.test(f));
+}
+
+describe('cli/options.ts', () => {
+  describe('commonOptions', () => {
+    it('does not include --region (PR 5: consolidated to bootstrap-only)', () => {
+      const flags = commonOptions.map((o) => o.flags);
+      expect(flags.some((f) => /^--region\b/.test(f))).toBe(false);
+    });
+
+    it('still includes --verbose, --profile, and -y/--yes', () => {
+      const flags = commonOptions.map((o) => o.flags);
+      expect(flags).toEqual(
+        expect.arrayContaining(['--verbose', '--profile <profile>', '-y, --yes'])
+      );
+    });
+  });
+
+  describe('deprecatedRegionOption', () => {
+    it('exposes the --region <region> flag and is hidden from --help', () => {
+      expect(deprecatedRegionOption.flags).toBe('--region <region>');
+      // Commander records hideHelp() by setting `hidden = true` on the option.
+      // The exact field is internal but observable.
+      expect((deprecatedRegionOption as unknown as { hidden?: boolean }).hidden).toBe(true);
+    });
+  });
+
+  describe('warnIfDeprecatedRegion', () => {
+    // Direct replacement of process.stderr.write — under vitest's output
+    // capture, vi.spyOn does not always intercept the stream cleanly.
+    let stderrChunks: string[];
+    let originalStderrWrite: typeof process.stderr.write;
+
+    beforeEach(() => {
+      stderrChunks = [];
+      originalStderrWrite = process.stderr.write.bind(process.stderr);
+      process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+        stderrChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+        return true;
+      }) as typeof process.stderr.write;
+    });
+
+    afterEach(() => {
+      process.stderr.write = originalStderrWrite;
+    });
+
+    it('writes a deprecation warning to stderr when region is set', () => {
+      warnIfDeprecatedRegion({ region: 'us-east-1' });
+      const all = stderrChunks.join('');
+      expect(all).toMatch(/--region is deprecated for this command and has no effect/);
+      expect(all).toMatch(/AWS_REGION/);
+    });
+
+    it('is silent when region is undefined', () => {
+      warnIfDeprecatedRegion({});
+      expect(stderrChunks).toEqual([]);
+    });
+
+    it('treats empty-string region as set (commander only assigns when the flag is passed)', () => {
+      warnIfDeprecatedRegion({ region: '' });
+      const all = stderrChunks.join('');
+      // Empty string is still a user-supplied value; warn (do not silently ignore).
+      expect(all).toMatch(/--region is deprecated/);
+    });
+  });
+
+  describe('command --region wiring', () => {
+    it('bootstrap exposes a non-deprecated --region (bucket creation needs it)', () => {
+      const cmd = createBootstrapCommand();
+      expect(hasRegionOption(cmd)).toBe(true);
+      // bootstrap's --region is NOT the deprecated wrapper — it must be visible
+      // in --help.
+      const regionOpt = cmd.options.find((o) => /^--region\b/.test(o.flags));
+      expect((regionOpt as unknown as { hidden?: boolean }).hidden).toBeFalsy();
+    });
+
+    it.each([
+      ['deploy', () => createDeployCommand()],
+      ['destroy', () => createDestroyCommand()],
+      ['diff', () => createDiffCommand()],
+      ['synth', () => createSynthCommand()],
+      ['list', () => createListCommand()],
+      ['force-unlock', () => createForceUnlockCommand()],
+      ['publish-assets', () => createPublishAssetsCommand()],
+    ])('%s accepts --region but hides it from --help', (_name, build) => {
+      const cmd = build();
+      expect(hasRegionOption(cmd)).toBe(true);
+      const regionOpt = cmd.options.find((o) => /^--region\b/.test(o.flags));
+      // Deprecated wrapper is hidden from generated --help text.
+      expect((regionOpt as unknown as { hidden?: boolean }).hidden).toBe(true);
+    });
+
+    it.each(['list', 'resources', 'show', 'rm'])(
+      'state %s accepts --region but hides it from --help',
+      (subcommandName) => {
+        const stateCmd = createStateCommand();
+        const sub = stateCmd.commands.find((c) => c.name() === subcommandName);
+        expect(sub).toBeDefined();
+        if (!sub) return;
+        expect(hasRegionOption(sub)).toBe(true);
+        const regionOpt = sub.options.find((o) => /^--region\b/.test(o.flags));
+        expect((regionOpt as unknown as { hidden?: boolean }).hidden).toBe(true);
+      }
+    );
+  });
+
+  describe('parseContextOptions', () => {
+    it('parses key=value pairs into a record', () => {
+      expect(parseContextOptions(['env=dev', 'flag=true'])).toEqual({
+        env: 'dev',
+        flag: 'true',
+      });
+    });
+
+    it('returns an empty record when no args are given', () => {
+      expect(parseContextOptions(undefined)).toEqual({});
+      expect(parseContextOptions([])).toEqual({});
+    });
+
+    it('keeps the first equals sign as the separator (values can contain =)', () => {
+      expect(parseContextOptions(['url=https://example.com/?k=v'])).toEqual({
+        url: 'https://example.com/?k=v',
+      });
+    });
+
+    it('skips entries without an equals sign', () => {
+      expect(parseContextOptions(['lonely', 'env=dev'])).toEqual({ env: 'dev' });
+    });
+  });
+});

--- a/tests/unit/cli/state-list.test.ts
+++ b/tests/unit/cli/state-list.test.ts
@@ -101,6 +101,38 @@ async function runStateList(args: string[]): Promise<string> {
   return cap.output.join('');
 }
 
+/**
+ * Same as runStateList but also returns captured stderr. Used by the
+ * deprecation-warning test below. Uses the same direct-replacement
+ * technique as captureStdout because vi.spyOn on process.stderr.write
+ * does not always intercept under vitest's output capture.
+ */
+async function runStateListWithStderr(args: string[]): Promise<{
+  stdout: string;
+  stderr: string;
+}> {
+  const cap = captureStdout();
+  const errOutput: string[] = [];
+  const originalErr = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    errOutput.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const stateCmd = createStateCommand();
+    stateCmd.exitOverride();
+    stateCmd.commands.forEach((sub) => sub.exitOverride());
+    await stateCmd.parseAsync(args, { from: 'user' });
+  } finally {
+    cap.restore();
+    process.stderr.write = originalErr;
+  }
+  return {
+    stdout: cap.output.join(''),
+    stderr: errOutput.join(''),
+  };
+}
+
 describe('cdkd state list', () => {
   beforeEach(() => {
     mockListStacks.mockReset();
@@ -262,5 +294,24 @@ describe('cdkd state list', () => {
     expect(mockGetState).toHaveBeenCalledWith('Two', 'us-west-2');
     expect(mockIsLocked).toHaveBeenCalledWith('One', 'us-east-1');
     expect(mockIsLocked).toHaveBeenCalledWith('Two', 'us-west-2');
+  });
+
+  it('emits a deprecation warning to stderr when --region is passed (PR 5)', async () => {
+    mockListStacks.mockResolvedValue(['StackA']);
+    const { stdout, stderr } = await runStateListWithStderr([
+      'list',
+      '--region',
+      'us-west-2',
+    ]);
+    // Command still completes successfully.
+    expect(stdout).toBe('StackA\n');
+    expect(stderr).toMatch(/--region is deprecated for this command and has no effect/);
+    expect(stderr).toMatch(/AWS_REGION/);
+  });
+
+  it('does not emit the deprecation warning when --region is omitted', async () => {
+    mockListStacks.mockResolvedValue(['StackA']);
+    const { stderr } = await runStateListWithStderr(['list']);
+    expect(stderr).not.toMatch(/--region is deprecated/);
   });
 });

--- a/tests/unit/cli/state-list.test.ts
+++ b/tests/unit/cli/state-list.test.ts
@@ -297,20 +297,20 @@ describe('cdkd state list', () => {
   });
 
   it('emits a deprecation warning to stderr when --region is passed (PR 5)', async () => {
-    mockListStacks.mockResolvedValue(['StackA']);
+    mockListStacks.mockResolvedValue([{ stackName: 'StackA', region: 'us-east-1' }]);
     const { stdout, stderr } = await runStateListWithStderr([
       'list',
       '--region',
       'us-west-2',
     ]);
-    // Command still completes successfully.
-    expect(stdout).toBe('StackA\n');
+    // Command still completes successfully (PR 1 added region suffix to default output).
+    expect(stdout).toBe('StackA (us-east-1)\n');
     expect(stderr).toMatch(/--region is deprecated for this command and has no effect/);
     expect(stderr).toMatch(/AWS_REGION/);
   });
 
   it('does not emit the deprecation warning when --region is omitted', async () => {
-    mockListStacks.mockResolvedValue(['StackA']);
+    mockListStacks.mockResolvedValue([{ stackName: 'StackA', region: 'us-east-1' }]);
     const { stderr } = await runStateListWithStderr(['list']);
     expect(stderr).not.toMatch(/--region is deprecated/);
   });


### PR DESCRIPTION
## Summary

Consolidates `--region` to `cdkd bootstrap` only. After PR 3 (dynamic
region resolution) and PR 4 (region-free default state-bucket name),
`--region` no longer plays a useful role on any other command — the
state-bucket S3 client auto-detects the bucket region via
`GetBucketLocation`, the default bucket name is derived from `{accountId}`
only, and provisioning clients pick up the region from each stack's
`env.region` (or `AWS_REGION` / profile as a fallback).

This PR removes `--region` from `commonOptions`, re-adds it directly on
`bootstrap` with a clearer description, and wires a shared
`deprecatedRegionOption` (hidden from `--help`) + `warnIfDeprecatedRegion`
helper into every other command (`deploy`, `destroy`, `diff`, `synth`,
`list`, `force-unlock`, `publish-assets`, and the four `state`
subcommands). Passing `--region` on any of these now emits a one-line
deprecation warning to stderr and the value is otherwise ignored.

This is a non-breaking deprecation. Final removal is tracked for PR 99.

## Why

Before PRs 3 + 4, `--region` had three overlapping roles on every
command:

1. State bucket region selector — obsoleted by PR 3.
2. Default-name resolver key (`cdkd-state-{acc}-{region}`) — obsoleted
   by PR 4.
3. Deployment fallback when `env.region` is missing on a stack — but
   CDK best practice is to specify `env` per stack, and the SDK already
   resolves the region from `AWS_REGION` / profile.

Keeping `--region` everywhere encouraged users to specify the wrong
thing ("which region does `--region` mean here?"). Bootstrap is the
only command where the flag still earns its keep.

## Behavior changes

- `cdkd bootstrap --help` continues to advertise `--region` (description
  reworded to make the bucket-creation role explicit).
- `cdkd <other> --help` no longer documents `--region`.
- `cdkd <other> --region <r>` runs to completion and prints
  `Warning: --region is deprecated for this command and has no effect.
  Use the AWS_REGION environment variable or your AWS profile to override
  the SDK default region.` on stderr.

## Tests

- New `tests/unit/cli/options.test.ts` (22 tests): asserts `--region`
  not in `commonOptions`, `bootstrap` keeps it visible, every other
  command (incl. all four `state` subcommands) accepts a hidden
  `--region`, and `warnIfDeprecatedRegion` writes to stderr exactly
  when `region` is set.
- Extends `list.test.ts` and `state-list.test.ts` with runtime
  deprecation-warning assertions.
- Test helpers replace `process.stderr.write` directly because
  `vi.spyOn` does not always intercept under vitest's output capture
  (memory'd for future PRs).
- All 817 unit tests pass (65 files).

## Docs sweep

- `README.md` — drops `--region us-east-1` from the deploy example;
  bootstrap example unchanged.
- `docs/troubleshooting.md` — replaces the `--region` advice with
  `AWS_REGION` / profile guidance and references PR 5.
- `CLAUDE.md` — Configuration Resolution now states that `--region` is
  bootstrap-only and explains why every other command ignores it.

## Stacked PR

This PR depends on **PR 3 (#60, branch `feat/dynamic-region-resolution`)**
and is opened with `--base feat/dynamic-region-resolution` so reviewers
see only the incremental change. Merge PR 3 first, then this one will
auto-rebase to `main`.

Spec: `docs/plans/05-region-flag-cleanup.md`.

**DO NOT MERGE** until PR 3 lands.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `npx vitest --run` (817 tests pass)
- [x] `cdkd bootstrap --help` documents `--region`
- [x] `cdkd deploy --help` does not document `--region`
- [x] `cdkd state list --region us-east-1` runs to completion and prints
      the deprecation warning
- [x] `cdkd state list` (no `--region`) does not print the warning
