### PR TITLE
chore(skill): add src/state/** to /check-docs deep review trigger

### DIFF
--- a/.claude/skills/check-docs/SKILL.md
+++ b/.claude/skills/check-docs/SKILL.md
@@ -15,6 +15,7 @@ You are checking whether documentation is up to date with recent code changes in
    - `src/index.ts` — public exports
    - `src/cli/options.ts`, `src/cli/commands/**` — CLI surface described in README.md
    - `src/types/**` — public type definitions
+   - `src/state/**` — bucket name, key layout, lock layout, schema version. These are documented verbatim in `docs/state-management.md`, `docs/troubleshooting.md`, README.md ("Outputs" example path), and CLAUDE.md ("S3 storage structure"). A path-layout change in `s3-state-backend.ts` or `lock-manager.ts` invalidates ~30 shell snippets across those files; the auto-migration session of 2026-05-01 (PR #57 → v0.7.0) shipped before this trigger existed and the docs took the full rollout to be re-aligned.
    - **any new file added** anywhere under `src/**` — must be mentioned in CLAUDE.md "Key Files and Directories"
    - `package.json` — dependency additions/removals described in CLAUDE.md "Dependencies"
    - `README.md`, `CLAUDE.md`, `docs/**` — the docs themselves


### PR DESCRIPTION
## Summary
Add `src/state/**` to the `/check-docs` skill's deep-review trigger list. One-line change with an inline comment pointing at the incident that motivated it.

## Why
Retrospective from the region/state refactor (PR #57 → v0.7.0): the on-disk key layout changed from `cdkd/{stackName}/state.json` to `cdkd/{stackName}/{region}/state.json`, but ~30 shell snippets in `docs/state-management.md`, `docs/troubleshooting.md`, `README.md`, and `CLAUDE.md` kept quoting the old paths. `/check-docs` passed on each of the 8 PRs in the rollout because `src/state/**` was not in its deep-review trigger list.

The drift only surfaced when the user asked "ゴミドキュメントももうない？" after the rollout finished — repo-wide grep found 30 occurrences. Fixed in PR #65 ("docs: align state path examples with v2 region-prefixed layout"), but the structural fix is here: don't let this kind of drift slip through `/check-docs` again.

## Scope rationale
The state layer is documented verbatim across operator-facing files: bucket name, key layout, lock layout, schema version all show up in shell snippets that go stale silently. Same shape as `src/cli/options.ts` (CLI flags shown in README) and `src/cli/commands/**` (CLI command behavior). So `src/state/**` warrants the same trigger.

## Test plan
- [x] Diff is one line + an explanation; no functional code changed
- [x] `.claude/skills/check-docs/SKILL.md` is outside every markgate gate scope (`src/`, `tests/`, `docs/`, `README.md`, `CLAUDE.md`, `package.json`), so this PR does not invalidate any gate marker
- [x] Inline incident reference in the trigger list ("auto-migration session of 2026-05-01 (PR #57 → v0.7.0)") gives future readers (humans or agents) the why without searching git history
