### PR TITLE
chore: refine integ-destroy-gate + extend /new-provider skill with import template

### DIFF
--- a/.claude/hooks/integ-destroy-gate.sh
+++ b/.claude/hooks/integ-destroy-gate.sh
@@ -28,6 +28,57 @@ fi
 
 cd "$REPO" 2>/dev/null || exit 0
 
+# Decide whether the diff actually touches deletion logic. The markgate
+# scope (.markgate.yml) is file-level, so it can't tell apart a real
+# delete-method change from an unrelated edit in the same file (e.g.
+# adding `provider.import` to every provider in PR #67 invalidated the
+# marker even though no provider's `delete` was modified). Use git diff
+# vs origin/main to look at the actual hunks: if no delete-touching
+# symbol is added or removed, skip the gate entirely.
+#
+# Heuristic:
+# - "always-delete" files: any change at all is delete-touching.
+# - provider files: only delete-touching when the diff hunks add/remove
+#   a delete-related symbol (delete*, IMPLICIT_DELETE, ENI/hyperplane,
+#   DependencyViolation).
+# - everything else: not delete-touching.
+#
+# When in doubt, fall through to verifying the marker — false positives
+# cost an integ-test run; false negatives cost a broken main.
+diff_base=""
+if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+  diff_base="origin/main"
+fi
+
+if [ -n "$diff_base" ]; then
+  changed_files=$(git diff --name-only "$diff_base"...HEAD 2>/dev/null)
+  delete_touch=0
+  always_delete='^(src/cli/commands/destroy(-runner)?\.ts|src/deployment/deploy-engine\.ts|src/analyzer/(dag-builder|implicit-delete-deps|lambda-vpc-deps)\.ts)$'
+  provider_pattern='^src/provisioning/(providers/.*\.ts|cloud-control-provider\.ts|region-check\.ts)$'
+  delete_symbol_pattern='^[-+].*\b(delete|IMPLICIT_DELETE|hyperplane|DependencyViolation|ENI|detach)\b'
+
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    if printf '%s' "$f" | grep -qE "$always_delete"; then
+      delete_touch=1
+      break
+    fi
+    if printf '%s' "$f" | grep -qE "$provider_pattern"; then
+      if git diff "$diff_base"...HEAD -- "$f" | grep -qE "$delete_symbol_pattern"; then
+        delete_touch=1
+        break
+      fi
+    fi
+  done <<EOF_FILES
+$changed_files
+EOF_FILES
+
+  if [ "$delete_touch" -eq 0 ]; then
+    # No delete-touching changes → gate is irrelevant. Skip.
+    exit 0
+  fi
+fi
+
 # Prefer direct `markgate`; fall back to `mise exec --` for users who
 # installed via `mise install` but don't have shims on PATH.
 if command -v markgate >/dev/null 2>&1; then

--- a/.claude/skills/new-provider/SKILL.md
+++ b/.claude/skills/new-provider/SKILL.md
@@ -29,13 +29,72 @@ The user provides an AWS resource type like `AWS::SES::EmailIdentity`.
    - UPDATE: Which API updates this resource?
    - DELETE: Which API deletes this resource?
    - getAttribute: Which attributes might be needed for `Fn::GetAtt`?
+   - **import**: Which API verifies a resource exists by physical id (`Get*` / `Describe*` / `Head*`), and which `List*` + `ListTags*` (or equivalent) lookup-by-tag pair lets you find a resource by its `aws:cdk:path` tag? See "Import method" under step 5 — most providers follow the same shape.
 
 5. **Create the provider file** at `src/provisioning/providers/{service}-{resource}-provider.ts`:
    - Import the AWS SDK client and commands
-   - Implement `ResourceProvider` interface (create, update, delete, getAttribute)
+   - Implement `ResourceProvider` interface (create, update, delete, getAttribute, **import**)
    - Use `getAwsClient` from `../../utils/aws-client-factory.js` for client creation
    - Follow ESM import conventions (`.js` extension)
    - Return proper `physicalId` and `attributes` from create
+
+   **Import method** — copy this shape from a similar provider (e.g.
+   `s3-bucket-provider.ts` for tag-array services, `lambda-function-provider.ts`
+   for tag-map services, `kms-provider.ts` for services with no
+   template name property):
+
+   ```ts
+   import { matchesCdkPath, resolveExplicitPhysicalId, CDK_PATH_TAG } from '../import-helpers.js';
+   import type { ResourceImportInput, ResourceImportResult } from '../../types/resource.js';
+
+   async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {
+     // 1. Explicit override OR Properties.<NameField> from template.
+     const explicit = resolveExplicitPhysicalId(input, '<NameField>');  // e.g. 'BucketName' / 'FunctionName' / 'RoleName'
+     if (explicit) {
+       try {
+         await this.client.send(new <Get|Head|Describe>Command({ ... explicit ... }));
+         return { physicalId: explicit, attributes: {} };
+       } catch (err) {
+         if (err instanceof <NotFoundError>) return null;
+         throw err;
+       }
+     }
+     if (!input.cdkPath) return null;
+
+     // 2. List + tag-based lookup. Walk the service's List* paginator,
+     //    fetch tags per resource, match aws:cdk:path.
+     let token: string | undefined;
+     do {
+       const list = await this.client.send(new ListCommand({ ...(token && { NextToken: token }) }));
+       for (const item of list.Items ?? []) {
+         if (!item.Id) continue;
+         const tags = await this.client.send(new ListTagsCommand({ ResourceId: item.Id }));
+         if (matchesCdkPath(tags.Tags, input.cdkPath)) {
+           return { physicalId: item.Id, attributes: {} };
+         }
+       }
+       token = list.NextToken;
+     } while (token);
+     return null;
+   }
+   ```
+
+   Notes:
+   - Return `null` (not throw) when the resource is not found — caller
+     treats this as "skipped" rather than failure.
+   - `attributes: {}` is fine; `Fn::GetAtt` reconstructs missing
+     attributes at deploy time via `constructAttribute` (see
+     `src/deployment/intrinsic-function-resolver.ts`).
+   - For services whose `ListTags` returns a `Record<string,string>`
+     map instead of a `Tag[]` array (Lambda, SQS), read the value at
+     key `CDK_PATH_TAG` directly instead of going through
+     `matchesCdkPath`.
+   - For services with NO template-supplied name field (KMS Key,
+     CloudFront Distribution), skip step 1's name fallback — only
+     the explicit-override path and tag lookup apply.
+   - Some services don't support tagging or `ListTags` requires extra
+     IAM. If tag lookup is impractical, document that limitation in
+     the method's doc comment and rely on `--resource` overrides.
 
 6. **Register the provider** in `src/provisioning/register-providers.ts`:
    - Add import for the new provider
@@ -47,6 +106,9 @@ The user provides an AWS resource type like `AWS::SES::EmailIdentity`.
    - Test update (verify API call)
    - Test delete (verify API call)
    - Test delete idempotency (not-found treated as success)
+   - Test import explicit-override path (knownPhysicalId verified, attrs returned)
+   - Test import tag-based lookup (List + ListTags + cdkPath match)
+   - Test import not-found (returns `null`, does not throw)
 
 8. **Check if `@aws-sdk/client-{service}` is already in package.json**. If not, tell the user to run `pnpm add @aws-sdk/client-{service}`.
 


### PR DESCRIPTION
## Summary
Two retrospective improvements from the region/state refactor session, paired in one PR because they share a theme — make the integ-test contract enforce where it matters and skip where it doesn't:

1. **`.claude/hooks/integ-destroy-gate.sh`**: hunk-level delete-touch detection. PRs that touch `src/provisioning/providers/**` only because they add unrelated methods (e.g. `provider.import` in PR #67) no longer trigger a gate that forces a 5-minute real-AWS deploy/destroy run.
2. **`.claude/skills/new-provider/SKILL.md`**: scaffold template now includes the `provider.import` shape so the remaining 39 SDK providers don't have to reinvent it.

## Why hook refinement?

PR #67 added `provider.import` to 12 SDK provider files (`s3-bucket-provider.ts`, `lambda-function-provider.ts`, ...). The markgate scope in `.markgate.yml` is **file-level**, so any change under `src/provisioning/providers/**` invalidates the `integ-destroy` marker. The import addition has zero interaction with the destroy code path, but the gate forced a real-AWS `/run-integ basic` run before merge anyway.

The hook now uses `git diff` vs `origin/main` to look at the actual hunks. Heuristic:

| File pattern | Trigger condition |
|--------------|-------------------|
| `destroy.ts`, `destroy-runner.ts`, `deploy-engine.ts`, `dag-builder.ts`, `implicit-delete-deps.ts`, `lambda-vpc-deps.ts` | any change |
| `src/provisioning/providers/**`, `cloud-control-provider.ts`, `region-check.ts` | diff hunks add/remove `delete` / `IMPLICIT_DELETE` / `ENI` / `hyperplane` / `DependencyViolation` / `detach` |
| else | none — gate is irrelevant |

Shallow clones with no `origin/main` ref fall through to the existing marker verify (no shortcut). False-positive cost is an integ run; false-negative cost is a broken main, so the rule errs toward verification when in doubt.

## Why skill template?

The 12-provider implementation in PR #67 found the import method has roughly three shapes (Tag-array services, Tag-map services, no-name-property services) but follows a single pattern across all of them. Putting that pattern in `/new-provider`'s SKILL.md as a copy-paste template — with notes on which variant to pick — saves every future contributor from re-reading 12 files to figure out the shape.

The template is intentionally not code generation. The variation between providers is in the per-service `ListTags*` command name and NotFound exception class; a generator would either guess wrong or carry too many template parameters.

## Test plan
- [x] `bash -n .claude/hooks/integ-destroy-gate.sh` passes (syntax check)
- [x] `.claude/**` is outside every markgate gate scope (`src/`, `tests/`, `docs/`, `README.md`, `CLAUDE.md`, `package.json`), so this PR doesn't invalidate any gate marker
- [x] Visual review of the hook against the documented heuristic table — every "always-delete" path covered, provider patterns matched, fallback path preserved
- [x] Visual review of the skill markdown — Step 4/5/7 now reference the import method consistently
