### PR TITLE
chore: skip comment-only matches in integ-destroy-gate + document provider.import

### DIFF
--- a/.claude/hooks/integ-destroy-gate.sh
+++ b/.claude/hooks/integ-destroy-gate.sh
@@ -55,7 +55,22 @@ if [ -n "$diff_base" ]; then
   delete_touch=0
   always_delete='^(src/cli/commands/destroy(-runner)?\.ts|src/deployment/deploy-engine\.ts|src/analyzer/(dag-builder|implicit-delete-deps|lambda-vpc-deps)\.ts)$'
   provider_pattern='^src/provisioning/(providers/.*\.ts|cloud-control-provider\.ts|region-check\.ts)$'
-  delete_symbol_pattern='^[-+].*\b(delete|IMPLICIT_DELETE|hyperplane|DependencyViolation|ENI|detach)\b'
+  # Match a delete-touching symbol on an added/removed line, but NOT inside
+  # a single-line comment. This avoids the false positives PR #73 hit
+  # (e.g. an ECS provider doc-comment containing the words "delete/update"
+  # tripped the gate even though the diff didn't change any delete code).
+  #
+  #   ^[-+]                  added or removed line
+  #   [^-+]                  one non-+/- char so we don't match the diff header `+++`/`---`
+  #   [[:space:]]*           leading indent
+  #   (?!//|\*|#)            negative lookahead — but POSIX grep -E doesn't
+  #                          support lookahead. Workaround: filter comment
+  #                          lines with a second grep -v pass below.
+  delete_symbol_pattern='^[-+][^-+].*\b(delete|IMPLICIT_DELETE|hyperplane|DependencyViolation|ENI|detach)\b'
+  # Lines we consider "comment only" — drop them before the symbol grep.
+  # Matches an added/removed line whose first non-whitespace content is
+  # a JS/TS/SH comment introducer (`//`, `/*`, `*` mid-block, `#`).
+  comment_line_pattern='^[-+][^-+][[:space:]]*(\*|/\*|//|#)'
 
   while IFS= read -r f; do
     [ -z "$f" ] && continue
@@ -64,7 +79,9 @@ if [ -n "$diff_base" ]; then
       break
     fi
     if printf '%s' "$f" | grep -qE "$provider_pattern"; then
-      if git diff "$diff_base"...HEAD -- "$f" | grep -qE "$delete_symbol_pattern"; then
+      if git diff "$diff_base"...HEAD -- "$f" \
+         | grep -vE "$comment_line_pattern" \
+         | grep -qE "$delete_symbol_pattern"; then
         delete_touch=1
         break
       fi

--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -67,6 +67,22 @@ export interface ResourceProvider {
     properties?: Record<string, unknown>,
     context?: DeleteContext
   ): Promise<void>;
+
+  /**
+   * Adopt an existing AWS resource into cdkd state.
+   *
+   * Optional. Providers without an `import` implementation are reported
+   * by `cdkd import` as `unsupported` and skipped (Cloud Control API
+   * fallback handles them via `--resource <id>=<physicalId>` overrides).
+   *
+   * @param input Logical ID, resource type, CDK path, stack name, region,
+   *   template properties, and (optionally) the user-supplied
+   *   `knownPhysicalId` from `--resource` / `--resource-mapping`.
+   * @returns Physical ID + attributes (same shape as `create` returns),
+   *   or `null` when no matching AWS resource was found (caller treats
+   *   `null` as "skipped — not deployed yet", not as a failure).
+   */
+  import?(input: ResourceImportInput): Promise<ResourceImportResult | null>;
 }
 ```
 
@@ -641,6 +657,86 @@ export class XxxResourceProvider implements ResourceProvider {
   }
 }
 ```
+
+### Step 3.5: Implement `import` (Optional but Recommended)
+
+The `import` method lets `cdkd import <stack> --app "..."` adopt
+already-deployed AWS resources of this type into cdkd state — covering
+disaster recovery (state file lost), adoption (moving from another IaC
+tool), and re-syncing after rollback. Skipping `import` is allowed (CC
+API fallback handles overrides), but providers without it can only be
+adopted via `--resource <id>=<physicalId>` and won't participate in
+tag-based auto-lookup.
+
+The method follows a single shape across the 17+ providers that have
+shipped it. Pick the variant that matches your service's tag API:
+
+```typescript
+import {
+  CDK_PATH_TAG,
+  matchesCdkPath,
+  resolveExplicitPhysicalId,
+} from '../import-helpers.js';
+import type {
+  ResourceImportInput,
+  ResourceImportResult,
+} from '../../types/resource.js';
+
+async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {
+  // 1. Explicit override OR Properties.<NameField> from template.
+  //    Pass `null` as the second arg if the resource type has no
+  //    template-supplied name field (e.g. KMS Key, CloudFront Distribution).
+  const explicit = resolveExplicitPhysicalId(input, '<NameField>');
+  if (explicit) {
+    try {
+      await this.client.send(new <Get|Head|Describe>Command({ /* ... */ }));
+      return { physicalId: explicit, attributes: {} };
+    } catch (err) {
+      if (err instanceof <NotFoundError>) return null;
+      throw err;
+    }
+  }
+  if (!input.cdkPath) return null;
+
+  // 2. Walk List* + ListTags* and match aws:cdk:path tag.
+  let token: string | undefined;
+  do {
+    const list = await this.client.send(new ListCommand({ ...(token && { NextToken: token }) }));
+    for (const item of list.Items ?? []) {
+      if (!item.Id) continue;
+      const tags = await this.client.send(new ListTagsCommand({ ResourceId: item.Id }));
+      // Choose ONE based on your service's tag API:
+      //   matchesCdkPath(tags.Tags, input.cdkPath)              ← Tag[] arrays (S3, IAM, EC2, RDS, …)
+      //   tags.Tags?.[CDK_PATH_TAG] === input.cdkPath           ← Record<string,string> maps (Lambda, SQS)
+      //   inline (key/value lowercase, not Key/Value)           ← ECS only — see ecs-provider.ts
+      if (matchesCdkPath(tags.Tags, input.cdkPath)) {
+        return { physicalId: item.Id, attributes: {} };
+      }
+    }
+    token = list.NextToken;
+  } while (token);
+  return null;
+}
+```
+
+Reference implementations to copy from:
+
+- **Tag[] array, name field present**: `s3-bucket-provider.ts`, `iam-role-provider.ts`, `dynamodb-table-provider.ts`
+- **Tag map (`Record<string,string>`)**: `lambda-function-provider.ts`, `sqs-queue-provider.ts`
+- **No name field, ARN required for tag lookup**: `cloudfront-distribution-provider.ts`, `cognito-provider.ts`
+- **Filter-based one-shot lookup (no per-item ListTags)**: `ec2-provider.ts` uses `Filters: [{Name: 'tag:aws:cdk:path', Values: [path]}]` directly on `Describe*`
+- **Lowercase key/value tag shape**: `ecs-provider.ts` (one of the few services that uses `key`/`value`)
+- **Explicit-override only** (auto lookup is impractical): `apigateway-provider.ts` for sub-resources scoped under a parent RestApi
+
+Notes:
+
+- **Return `null`, don't throw**, when nothing matches — `cdkd import` treats `null` as "not deployed yet", not as a failure
+- `attributes: {}` is fine for most types — the deploy-time `Fn::GetAtt`
+  resolver reconstructs missing attributes via `constructAttribute`
+  (see `src/deployment/intrinsic-function-resolver.ts`)
+- Tests for `import` go in the same file as the create/update/delete
+  tests, with three cases: explicit-override path, tag-based lookup
+  hit, tag-based lookup miss (returns `null`)
 
 ### Step 4: Add AWS Client
 


### PR DESCRIPTION
## Summary
Two retrospective items from PRs #73/#74 in one PR:

1. `.claude/hooks/integ-destroy-gate.sh` skips comment-only matches now (PR #73 hit a false positive on a comment containing `delete/update`).
2. `docs/provider-development.md` documents the `provider.import` method — the "Adding a new provider" guide had been silent on it since PR #67.

## Hook fix

Two-stage pipeline: drop comment lines (`grep -v ^[-+][^-+][[:space:]]*(\*|/\*|//|#)`) before checking the delete-symbol pattern. POSIX `grep -E` lacks lookahead, so two passes is the cleanest portable approach. Tightened `^[-+]` to `^[-+][^-+]` to also drop diff headers (`+++`, `---`).

## Docs fix

Added "Step 3.5: Implement `import` (Optional but Recommended)" between Create Provider Class and Add AWS Client. Carries the same template the `/new-provider` skill uses, with an inline reference table grouping the 17 in-tree implementations by tag-API shape (Tag[] array / Tag map / no-name / filter-based / lowercase / override-only). Interface definition extended with the `import?` signature and "return null, don't throw, when not found" rule.

## Test plan
- [x] `bash -n .claude/hooks/integ-destroy-gate.sh` syntax OK
- [x] `.claude/**` and `docs/**` are outside check/integ-destroy gate scope, so this PR doesn't invalidate either marker
- [x] Visual review of the docs section against existing provider implementations — references all check out (s3-bucket, iam-role, lambda-function, sqs-queue, cloudfront-distribution, cognito, ec2, ecs, apigateway)
