### PR TITLE
chore: cross-PR consistency sweep for #76-#80

### DIFF
--- a/tests/integration/state-destroy/README.md
+++ b/tests/integration/state-destroy/README.md
@@ -53,8 +53,8 @@ The flow that exercises the new command:
 The destroy must succeed without complaining about missing `--app`, missing
 `cdk.json`, or missing synth output.
 
-## Comparison to `cdkd state rm`
+## Comparison to `cdkd state orphan`
 
-`cdkd state rm CdkdStateDestroyExample` would leave the S3 bucket alive and
-just forget about it from cdkd's view. This test ensures `state destroy`
+`cdkd state orphan CdkdStateDestroyExample` would leave the S3 bucket alive
+and just forget about it from cdkd's view. This test ensures `state destroy`
 deletes the bucket too.


### PR DESCRIPTION
## Summary

Cross-PR consistency review of the five in-flight PRs (#76 docs/state-migration,
#77 fix/parallel-deploy-ui, #78 feat/cdkd-import-selective,
#79 feat/cdkd-orphan, #80 feat/provider-import-batch-2) that each passed
individual review. This PR captures only the drift findings that can be
patched without conflicting with the in-flight branches; deeper drift is
documented below for the originating PRs' authors to resolve.

## Findings table

| Severity | Where | Fix here / push back | Status |
| --- | --- | --- | --- |
| medium | `tests/integration/state-destroy/README.md` (still says `cdkd state rm` after PR #79) | fix here | fixed |
| high | `CLAUDE.md` line 115 — same long line is rewritten by **PRs #78, #79, #80** in three independent ways. Whoever merges last has to combine all three. | push back to whichever PR merges last (use unified text in "Canonical merged CLAUDE.md text" section below) | reported |
| high | `README.md` lines 429–438 (import help block) and 458–477 (orphan/destroy block) — both rewritten by PRs #78 and #79 respectively, no overlap, but reviewers should confirm both blocks render correctly when both land | push back / verify on merge | reported |
| low | PR #78 title is 79 chars (`feat(import): selective-resource semantics for CDK CLI parity + README guide`) — over 70-char limit | push back to #78 | reported |
| low | PR #79 title is 78 chars (`feat: rename state rm to orphan + add cdkd orphan + 0.x-friendly releaseRules`) — over 70-char limit | push back to #79 | reported |
| info | PR #80 has no `Promise.all` concurrency unit tests for the 6 new `provider.import` paths. Provider instances are stateless, but `import()` is invoked concurrently by deploy. | follow-up suggested for #80 | reported |
| info | `docs/plans/01-…`, `06-…`, `07-state-bucket-display.md` still reference `cdkd state rm` (historical implementation plans of already-shipped features — by convention these aren't rewritten retroactively) | leave as-is (historical) | reported |

## Fix landed in this PR

- `tests/integration/state-destroy/README.md`: `cdkd state rm` →
  `cdkd state orphan` (assumes PR #79 lands).

## Findings to address in the original PR

### PR #78 / #79 / #80 — CLAUDE.md `Top-level vs state` paragraph drift

All three PRs replace the same long line at `CLAUDE.md:115` (the `cdkd import`
description), but each only updates its own concern:

- PR #78 introduces the three-mode taxonomy (`auto` / `selective` / `hybrid`)
  but keeps `state rm` references.
- PR #79 renames `state rm` → `state orphan` and adds `cdkd orphan` to the
  top-level command list, but still describes `cdkd import` with the
  pre-PR-#78 two-mode wording.
- PR #80 extends the provider list to include the 6 new providers, but keeps
  both `state rm` and the two-mode `cdkd import` wording.

The merger has to combine all three. The canonical post-merge line should:

1. Add `orphan` to the top-level commands list and rename `state rm` to
   `state orphan` in the state-subcommand list (PR #79).
2. Use the three-mode taxonomy (`auto` / `selective` / `hybrid`) for the
   `cdkd import` description (PR #78).
3. Extend the provider list with **ApiGateway V2 API, AppSync GraphqlApi,
   CloudTrail, CloudWatch Alarm, CodeBuild Project, ECR Repository** and
   add the ApiGateway V2 / AppSync sub-resource carve-out (PR #80).
4. Replace `state rm <stack>...` in the `state` subcommand description with
   `state orphan <stack>...` (PR #79).
5. Add the new `cdkd orphan` description sentence (PR #79).

This PR rebases cleanly only after all three of #78, #79, #80 merge —
intentionally so, since editing the line here would create a 3-way conflict
on every in-flight PR.

### PR #79 — title length

Current: `feat: rename state rm to orphan + add cdkd orphan + 0.x-friendly releaseRules`
(78 chars). Suggested: `feat: rename state rm to orphan + add cdkd orphan command` (58 chars);
the `releaseRules` change can move to the body.

### PR #78 — title length

Current: `feat(import): selective-resource semantics for CDK CLI parity + README guide`
(79 chars). Suggested: `feat(import): selective-resource semantics (CDK CLI parity)` (60 chars);
"+ README guide" can move to the body.

### PR #80 — concurrency tests for the 6 new provider.import methods

Per the memory rule "every plausibly-concurrent code path needs a Promise.all
unit test", the 6 new `provider.import` methods should each have a Promise.all
test. Provider instances are stateless, so this is defense-in-depth rather
than a bug fix — list as follow-up rather than blocking.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint:fix` clean
- [x] `pnpm build` succeeds
- [x] `npx vitest --run` — 924 tests pass (no test changes)
- [x] `tests/integration/state-destroy/README.md` reads correctly with the
      renamed section header

## Out of scope

- Editing CLAUDE.md / README.md / docs/state-management.md text that overlaps
  with PRs #78 / #79 / #80 — would create 3-way merge conflicts on the
  in-flight branches.
- Adding the missing concurrency tests to PR #80's providers — out of this
  PR's drift-fix scope; pushed back to PR #80.
- Editing historical `docs/plans/*.md` that still mention `state rm` — by
  repo convention, plans of already-shipped features aren't retroactively
  rewritten.
