### PR TITLE
fix(cli): point multi-region errors at --stack-region (not --region)

### DIFF
--- a/src/cli/commands/destroy.ts
+++ b/src/cli/commands/destroy.ts
@@ -225,7 +225,7 @@ async function destroyCommand(
         const regions = refs.map((r) => r.region ?? '(legacy)').join(', ');
         throw new Error(
           `Stack '${stackName}' has state in multiple regions: ${regions}. ` +
-            `Use 'cdkd state orphan ${stackName} --region <region>' to remove cdkd's record for one ` +
+            `Use 'cdkd state orphan ${stackName} --stack-region <region>' to remove cdkd's record for one ` +
             `region, or run destroy from a CDK app whose env.region matches one of them.`
         );
       }

--- a/src/cli/commands/state.ts
+++ b/src/cli/commands/state.ts
@@ -96,7 +96,7 @@ function resolveSingleRegion(
   const regions = matches.map((r) => r.region ?? '(legacy)').join(', ');
   throw new Error(
     `Stack '${stackName}' has state in multiple regions: ${regions}. ` +
-      `Re-run with --region <region> to disambiguate.`
+      `Re-run with --stack-region <region> to disambiguate.`
   );
 }
 
@@ -317,8 +317,8 @@ function createStateListCommand(): Command {
  * - `--json`: emit a JSON array of full resource detail objects.
  *
  * When the same stack name has state in multiple regions, requires
- * `--region <region>` to disambiguate. The error message lists candidate
- * regions so the next attempt is one keystroke away.
+ * `--stack-region <region>` to disambiguate. The error message lists
+ * candidate regions so the next attempt is one keystroke away.
  *
  * Properties are intentionally omitted from all output modes — `state show`
  * is the right command when properties are needed.
@@ -491,7 +491,7 @@ function createStateResourcesCommand(): Command {
  * lighter inspection.
  *
  * When the same stack name has state in multiple regions, requires
- * `--region <region>` to disambiguate.
+ * `--stack-region <region>` to disambiguate.
  *
  * - Default: human-readable multi-line format.
  * - `--json`: a `{state, lock}` object containing the raw `StackState` plus
@@ -917,7 +917,7 @@ async function stateDestroyCommand(
         const regions = refs.map((r) => r.region ?? '(legacy)').join(', ');
         throw new Error(
           `Stack '${stackName}' has state in multiple regions: ${regions}. ` +
-            `Use --region <region> to pick one.`
+            `Use --stack-region <region> to pick one.`
         );
       }
 

--- a/tests/unit/cli/state-resources.test.ts
+++ b/tests/unit/cli/state-resources.test.ts
@@ -163,7 +163,12 @@ describe('cdkd state resources', () => {
     await expect(runStateResources(['resources', 'MyStack'])).rejects.toThrow();
     const message = String(errorSpy.mock.calls[0]?.[0] ?? '');
     expect(message).toMatch(/multiple regions: us-west-2, us-east-1/);
-    expect(message).toMatch(/--region/);
+    // The error must direct users to --stack-region, NOT the deprecated
+    // top-level --region (which is ignored on this command and would emit
+    // its own deprecation warning, causing the very confusion this regex
+    // guards against).
+    expect(message).toMatch(/--stack-region/);
+    expect(message).not.toMatch(/--region\b(?!-)/);
   });
 
   it('disambiguates with --stack-region when a stack has multiple regions', async () => {

--- a/tests/unit/cli/state-show.test.ts
+++ b/tests/unit/cli/state-show.test.ts
@@ -155,6 +155,10 @@ describe('cdkd state show', () => {
     await expect(runStateShow(['show', 'MyStack'])).rejects.toThrow();
     const message = String(errorSpy.mock.calls[0]?.[0] ?? '');
     expect(message).toMatch(/multiple regions/);
+    // Direct users to --stack-region, not the deprecated top-level
+    // --region (which would emit a deprecation warning and be ignored).
+    expect(message).toMatch(/--stack-region/);
+    expect(message).not.toMatch(/--region\b(?!-)/);
   });
 
   it('renders stack header, lock status, outputs, and resources', async () => {


### PR DESCRIPTION
## Summary

Fixes a user-reported bug: when a stack name has state in two regions,
`cdkd state resources` / `state show` / `state destroy` / `cdkd destroy`
all error out asking the user to "Re-run with `--region <region>`" — but
`--region` is deprecated on these commands (PR 5), so passing it emits a
deprecation warning and is ignored, looping back to the same error.

The right flag has always been `--stack-region` — the per-stack scoping
flag wired through `stackRegionOption()`. The error messages just named
the wrong one.

User report:

```
$ cdkd state resources CdkSampleStackVirginia
Error: Stack 'CdkSampleStackVirginia' has state in multiple regions:
  ap-northeast-1, us-east-1. Re-run with --region <region> to disambiguate.

$ cdkd state resources CdkSampleStackVirginia --region us-east-1
Warning: --region is deprecated for this command and has no effect.
Error: Stack 'CdkSampleStackVirginia' has state in multiple regions:
  ap-northeast-1, us-east-1. Re-run with --region <region> to disambiguate.
```

## Fix

- `src/cli/commands/state.ts` — `resolveSingleRegion` (used by
  `state resources` and `state show`) and the `state destroy`
  multi-region path now point at `--stack-region`.
- `src/cli/commands/destroy.ts` — top-level destroy's multi-region
  error message now points at `--stack-region`.
- Two stale doc comments updated.
- Existing tests had asserted `/--region/` which trivially matched
  `--stack-region` too — that's why this slipped through. Tightened
  the assertions to require `--stack-region` AND reject bare
  `--region` (using `\b(?!-)` to avoid false-matching `--stack-region`).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint:fix` clean
- [x] `pnpm build` succeeds
- [x] `npx vitest --run` — 924 tests pass
- [x] Tightened tests in `state-resources.test.ts` and
      `state-show.test.ts` — original flaky `/--region/` assertion
      replaced with `--stack-region` requirement + `--region` ban
- [x] Reproduced the user's failing command path locally; verified
      the new message points at `--stack-region`
- [ ] Live-test deferred: same code path, new string only

## Note on overlap with #79

The `cdkd destroy` error message also mentions `state rm`, which #79
renames to `state orphan`. This PR only touches the `--region` →
`--stack-region` part of that line; the command-name rename happens
in #79's branch. Either merge order works — the lines don't conflict.
