### PR TITLE
chore(skill): add pre-flight orphan scan to /run-integ + fix stale paths

### DIFF
--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -23,9 +23,9 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
 
 3. **Determine state bucket**: Resolve dynamically via `aws sts get-caller-identity --query Account --output text` to get the account ID, then construct `cdkd-state-{accountId}` (region-free, the current default since PR #62 / v0.11.0). If that bucket doesn't exist, fall back to the legacy `cdkd-state-{accountId}-us-east-1` and note the deprecation in the report.
 
-4. **Pre-flight orphan scan** (mandatory — prevents stuck deploys from prior-run leftovers):
+4. **Pre-flight orphan scan** (mandatory — fail fast on prior-run leftovers instead of going through CREATE + rollback):
 
-   Before invoking deploy, scan AWS for resources matching the stack name from this test that have no business existing yet. The scenario this catches: a previous integration run was killed mid-deploy, leaving orphan Event Source Mappings / Lambda functions / ENIs / IAM roles whose names match the stack about to be deployed. cdkd's diff calculation does NOT see these (they're not in state), so the deploy attempts CREATE — which collides with the orphans and triggers a 30+ minute rollback.
+   Before invoking deploy, scan AWS for resources matching the stack name from this test that have no business existing yet. The scenario this catches: a previous integration run was killed mid-deploy, leaving orphan Event Source Mappings / Lambda functions / ENIs / IAM roles whose names match the stack about to be deployed. cdkd's diff calculation does NOT see these (they're not in state), so the deploy attempts CREATE — which collides with the orphans, fails immediately with `ResourceAlreadyExists`, and forces a CREATE-then-rollback cycle. Failing at the start is much cheaper than partway through.
 
    Synth first (without deploy) to learn the stack name and the resource types in the template, then for each scenario in scope run a targeted scan:
 
@@ -37,7 +37,7 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
      --query 'Functions[?contains(FunctionName, `<StackName>`)].FunctionName' --output text
 
    # Run when the template uses Lambda EventSourceMapping (the orphan ESM
-   # case is the one that bit cdkd in 2026-05-02 with a 30-min stuck deploy):
+   # case bit cdkd in 2026-05-02: AlreadyExists + rollback cycle on a fresh deploy):
    aws lambda list-event-source-mappings --region us-east-1 \
      --query 'EventSourceMappings[?contains(FunctionArn, `<StackName>`)].[UUID,FunctionArn]' --output text
 

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -21,9 +21,38 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
 
 2. **List available tests**: Run `ls tests/integration/` to discover all test directories dynamically. Do NOT rely on a hardcoded list.
 
-3. **Determine state bucket**: Resolve dynamically via `aws sts get-caller-identity --query Account --output text` to get the account ID, then construct `cdkd-state-{accountId}-us-east-1`.
+3. **Determine state bucket**: Resolve dynamically via `aws sts get-caller-identity --query Account --output text` to get the account ID, then construct `cdkd-state-{accountId}` (region-free, the current default since PR #62 / v0.11.0). If that bucket doesn't exist, fall back to the legacy `cdkd-state-{accountId}-us-east-1` and note the deprecation in the report.
 
-4. **Run the test(s)**:
+4. **Pre-flight orphan scan** (mandatory — prevents stuck deploys from prior-run leftovers):
+
+   Before invoking deploy, scan AWS for resources matching the stack name from this test that have no business existing yet. The scenario this catches: a previous integration run was killed mid-deploy, leaving orphan Event Source Mappings / Lambda functions / ENIs / IAM roles whose names match the stack about to be deployed. cdkd's diff calculation does NOT see these (they're not in state), so the deploy attempts CREATE — which collides with the orphans and triggers a 30+ minute rollback.
+
+   Synth first (without deploy) to learn the stack name and the resource types in the template, then for each scenario in scope run a targeted scan:
+
+   ```bash
+   # Always run these (cheap, broadly applicable):
+   aws s3 ls s3://<bucket>/cdkd/<StackName>/ --region us-east-1
+   aws iam list-roles --query 'Roles[?contains(RoleName, `<StackName>`)].RoleName' --output text
+   aws lambda list-functions --region us-east-1 \
+     --query 'Functions[?contains(FunctionName, `<StackName>`)].FunctionName' --output text
+
+   # Run when the template uses Lambda EventSourceMapping (the orphan ESM
+   # case is the one that bit cdkd in 2026-05-02 with a 30-min stuck deploy):
+   aws lambda list-event-source-mappings --region us-east-1 \
+     --query 'EventSourceMappings[?contains(FunctionArn, `<StackName>`)].[UUID,FunctionArn]' --output text
+
+   # Run when the template uses VPC + Lambda VpcConfig (hyperplane ENIs
+   # outlive their function):
+   aws ec2 describe-network-interfaces --region us-east-1 \
+     --filters "Name=description,Values=AWS Lambda VPC ENI-<StackName>*" \
+     --query 'NetworkInterfaces[].[NetworkInterfaceId,Status]' --output text
+   ```
+
+   **If anything is found**, abort the test run with a clear report listing the orphans and the cleanup commands the user should run (`aws lambda delete-event-source-mapping --uuid …`, `cdkd state destroy <StackName> --yes`, etc.) — do NOT proceed with deploy. Resuming on top of orphans is the failure mode this step exists to prevent.
+
+   **If nothing is found**, the deploy can proceed cleanly.
+
+5. **Run the test(s)**:
    - Navigate to `tests/integration/<test-name>/`
    - Ensure dependencies: `npm install` if node_modules doesn't exist
    - Run synth: `node ../../../dist/cli.js synth --region us-east-1`
@@ -35,8 +64,8 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
    - Run deploy: `node ../../../dist/cli.js deploy [--all] --region us-east-1 --state-bucket <bucket> --verbose`
    - Run destroy: `node ../../../dist/cli.js destroy [--all] --region us-east-1 --state-bucket <bucket> --force`
 
-5. **Verify cleanup**:
-   - Check `aws s3 ls s3://<bucket>/stacks/ --region us-east-1` to confirm no leftover state
+6. **Verify cleanup**:
+   - Check `aws s3 ls s3://<bucket>/cdkd/ --region us-east-1` to confirm no leftover state
    - Also verify actual AWS resources are gone by checking with stack name prefix filters. Get stack names from the synth output, then for each stack name query AWS APIs filtered by that prefix:
      - `aws iam list-roles --query 'Roles[?contains(RoleName, \`{StackName}\`)].RoleName'`
      - `aws lambda list-functions --region us-east-1 --query 'Functions[?contains(FunctionName, \`{StackName}\`)].FunctionName'`
@@ -46,12 +75,12 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
      - For VPC-based tests also check: `aws ec2 describe-vpcs --filters "Name=tag:Name,Values={StackName}/Vpc" ...`
    - Only check resource types relevant to the test being run
 
-6. **Auto-cleanup orphans (mandatory when destroy didn't fully succeed)**:
+7. **Auto-cleanup orphans (mandatory when destroy didn't fully succeed)**:
 
    **Trigger this step whenever any of the following is true:**
-   - The `destroy` step in step 4 reported a non-zero error count (e.g. "X failed to delete")
-   - Step 5 found a leftover S3 state file
-   - Step 5 found any AWS resource matching the stack name prefix
+   - The `destroy` step in step 5 reported a non-zero error count (e.g. "X failed to delete")
+   - Step 6 found a leftover S3 state file
+   - Step 6 found any AWS resource matching the stack name prefix
 
    **What to do:**
    - For VPC-attached Lambda failures (the most common pattern), the typical orphan set is, **in delete order**:
@@ -59,21 +88,21 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
      2. SecurityGroups (`aws ec2 delete-security-group`) — must come after the ENIs that reference them are gone.
      3. Subnets (`aws ec2 delete-subnet`) — must come after every ENI in them is gone.
      4. VPC (`aws ec2 delete-vpc`) — last.
-   - For S3 state orphans: `aws s3 rm s3://<bucket>/stacks/<StackName>/ --recursive`.
+   - For S3 state orphans: `aws s3 rm s3://<bucket>/cdkd/<StackName>/ --recursive`. (`cdkd state orphan <StackName>` is the cdkd-native equivalent and also handles the lock key.)
    - For other resource types, infer the right delete order from CloudFormation dependency rules (children before parents).
    - Always specify the correct region (`--region`).
-   - Re-run step 5 after cleanup to confirm zero orphans remain.
+   - Re-run step 6 after cleanup to confirm zero orphans remain.
 
    **Never** end the run with orphan resources still present in AWS. Cost (NAT GW alone is ~$1/hr) and account hygiene make this non-negotiable. If a resource genuinely cannot be deleted after reasonable retries, surface it to the user with the exact ID, region, and what was tried — but only after the auto-cleanup pass.
 
-7. **Report results**: Show pass/fail for each test, including resource counts and timing. Always state explicitly "destroy completed: 0 errors, 0 orphans" or itemize what remained / what was force-cleaned.
+8. **Report results**: Show pass/fail for each test, including resource counts and timing. Always state explicitly "destroy completed: 0 errors, 0 orphans" or itemize what remained / what was force-cleaned.
 
-8. **Set the `integ-destroy` markgate marker (only on full clean success)**:
+9. **Set the `integ-destroy` markgate marker (only on full clean success)**:
 
    When — and ONLY when — all of the following hold:
    - the destroy step finished with **0 errors**,
-   - step 5 found **0 leftover resources**,
-   - step 6 was either skipped (because nothing to clean up) or completed with the post-cleanup re-check showing 0 orphans,
+   - step 6 found **0 leftover resources**,
+   - step 7 was either skipped (because nothing to clean up) or completed with the post-cleanup re-check showing 0 orphans,
 
    record the gate so subsequent `gh pr merge` calls are unblocked:
 


### PR DESCRIPTION
## Summary

Two cleanup improvements to `.claude/skills/run-integ/SKILL.md`,
prompted by debugging the bench-cdk-sample incident on 2026-05-02.

### 1. Pre-flight orphan scan (new step 4)

When a previous integ run was killed mid-deploy, leftover AWS
resources (Event Source Mappings, Lambda functions, ENIs, IAM roles)
can collide with the next run. cdkd's diff calculation can't see
resources that aren't in state, so the deploy attempts CREATE — and
the orphan triggers an immediate `ResourceAlreadyExists` failure,
which then forces a CREATE-then-rollback cycle.

The new step synths first, scans for matching orphan resources, and
aborts with a cleanup recipe if anything is found — failing fast at
the start instead of part-way through CREATE + rollback.

**Note on framing**: this scan was originally framed as "preventing
30+ minute stuck deploys", but on review the 30-minute stuck behavior
in the bench-cdk-sample incident was almost certainly a separate
problem — a Custom Resource S3 response URL polling mismatch in cdkd
itself, where the CR Lambda writes the response to one S3 key while
cdkd polls a different one. An `AlreadyExists` CREATE failure is a
fast error, not a timeout. The pre-flight scan is still worth doing
on hygiene grounds (avoiding half-CREATE + rollback churn), just not
for the stuck-deploy reason. The CR polling bug will be filed
separately as a cdkd issue.

### 2. Stale state-bucket references

- `cdkd-state-{accountId}-us-east-1` → `cdkd-state-{accountId}` (the
  default since PR #62 / v0.11.0). Legacy fallback documented.
- `s3://<bucket>/stacks/` → `s3://<bucket>/cdkd/` (the v2 key layout
  since PR 1). The two affected lines were both already wrong before
  this PR; the bench-cdk-sample debugging exposed them.
- Auto-cleanup section now mentions `cdkd state orphan <stack>` as the
  cdkd-native alternative to raw `aws s3 rm`.

Step numbers renumbered to fit the new pre-flight step (4 inserted →
5/6/7/8/9 below).

## Test plan

- [x] Skill file is the only change; no source code touched
- [x] Step numbering consistent end-to-end (new step 4, original
      "Run the test(s)" is now 5, etc.)
- [x] Pre-flight scan recipe lists shell-checkable commands so the
      skill executor can copy-paste them
- [x] Auto-cleanup section's `aws s3 rm` path reference fixed to
      `cdkd/`, not the now-extinct `stacks/`
- [ ] Live verification deferred — this is a skill-doc change with no
      code-level effect; next time `/run-integ` is invoked, the new
      step will actually run

## Rationale

The pre-flight scan catches a clear hygiene failure (collision with
prior-run orphans) before deploy. It avoids a CREATE-then-rollback
cycle, which is real cost (a few minutes of unwinding) even when not
a 30-minute stuck.

The stuck-deploy incident itself is being followed up as a separate
cdkd issue (Custom Resource S3 response URL polling mismatch).
