### PR TITLE
chore(hook): split integ-destroy gate into strict + hunk-filtered groups

### DIFF
--- a/.claude/hooks/integ-destroy-gate.sh
+++ b/.claude/hooks/integ-destroy-gate.sh
@@ -37,7 +37,21 @@ cd "$REPO" 2>/dev/null || exit 0
 # symbol is added or removed, skip the gate entirely.
 #
 # Heuristic:
-# - "always-delete" files: any change at all is delete-touching.
+# - "strict-delete" files (dag-builder.ts, implicit-delete-deps.ts,
+#   lambda-vpc-deps.ts): any change at all is delete-touching. These
+#   are small high-stakes analyzer files where a typical addition is an
+#   array entry like `'AWS::Foo': ['AWS::Bar']` whose text does NOT
+#   contain the delete-symbol vocabulary, so the hunk filter would
+#   miss it. Keep strict.
+# - "filtered-delete" files (destroy.ts, destroy-runner.ts,
+#   deploy-engine.ts): considered delete-touching ONLY when the diff
+#   hunks add/remove a delete-related symbol — same filter as provider
+#   files. These are larger files that mix delete logic with UX
+#   strings, command wiring, log messages, etc. Pure UX-string edits
+#   here have no behavioral effect on the destroy path (e.g. PR #84
+#   fixed a `--region` → `--stack-region` error message in destroy.ts);
+#   the old strict rule made such trivial PRs un-mergeable until
+#   /run-integ was re-run, even though no destroy code changed.
 # - provider files: only delete-touching when the diff hunks add/remove
 #   a delete-related symbol (delete*, IMPLICIT_DELETE, ENI/hyperplane,
 #   DependencyViolation).
@@ -53,7 +67,11 @@ fi
 if [ -n "$diff_base" ]; then
   changed_files=$(git diff --name-only "$diff_base"...HEAD 2>/dev/null)
   delete_touch=0
-  always_delete='^(src/cli/commands/destroy(-runner)?\.ts|src/deployment/deploy-engine\.ts|src/analyzer/(dag-builder|implicit-delete-deps|lambda-vpc-deps)\.ts)$'
+  # Strict files — any change triggers (small high-stakes analyzer
+  # files; see header comment for rationale).
+  strict_delete='^src/analyzer/(dag-builder|implicit-delete-deps|lambda-vpc-deps)\.ts$'
+  # Hunk-filtered files — only delete-symbol changes trigger.
+  filtered_delete='^(src/cli/commands/destroy(-runner)?\.ts|src/deployment/deploy-engine\.ts)$'
   provider_pattern='^src/provisioning/(providers/.*\.ts|cloud-control-provider\.ts|region-check\.ts)$'
   # Match a delete-touching symbol on an added/removed line, but NOT inside
   # a single-line comment. This avoids the false positives PR #73 hit
@@ -74,11 +92,17 @@ if [ -n "$diff_base" ]; then
 
   while IFS= read -r f; do
     [ -z "$f" ] && continue
-    if printf '%s' "$f" | grep -qE "$always_delete"; then
+    # Strict-delete files: any change at all is delete-touching.
+    if printf '%s' "$f" | grep -qE "$strict_delete"; then
       delete_touch=1
       break
     fi
-    if printf '%s' "$f" | grep -qE "$provider_pattern"; then
+    # Filtered-delete files (command/orchestration) and provider files
+    # share the same hunk filter: only mark the gate as delete-touching
+    # when the diff lines add or remove a delete-related symbol. A file
+    # in either group with only string / log / typing edits passes
+    # through.
+    if printf '%s' "$f" | grep -qE "$filtered_delete|$provider_pattern"; then
       if git diff "$diff_base"...HEAD -- "$f" \
          | grep -vE "$comment_line_pattern" \
          | grep -qE "$delete_symbol_pattern"; then

--- a/.claude/hooks/integ-destroy-gate.sh
+++ b/.claude/hooks/integ-destroy-gate.sh
@@ -84,7 +84,19 @@ if [ -n "$diff_base" ]; then
   #   (?!//|\*|#)            negative lookahead — but POSIX grep -E doesn't
   #                          support lookahead. Workaround: filter comment
   #                          lines with a second grep -v pass below.
-  delete_symbol_pattern='^[-+][^-+].*\b(delete|IMPLICIT_DELETE|hyperplane|DependencyViolation|ENI|detach)\b'
+  # `rollback` is included so a refactor that changes the order of
+  # `partial state → rollback → final state` in `deploy-engine.ts`
+  # (which would leak orphans on failure) trips the gate even when
+  # the diff doesn't textually mention the literal CRUD verbs.
+  #
+  # Word boundaries (\b) are dropped so camelCase identifiers match:
+  # `performRollback`, `deleteResource`, `detachVpc` should all hit
+  # the gate. Combined with `grep -i` below, this matches `Rollback`,
+  # `rollback`, `ROLLBACK`, etc. The trade-off is occasional false
+  # positives on substrings (e.g. an unrelated word containing `eni`)
+  # — which only cost an integ-test run, vs false negatives that
+  # cost a broken main.
+  delete_symbol_pattern='^[-+][^-+].*(delete|rollback|IMPLICIT_DELETE|hyperplane|DependencyViolation|ENI|detach)'
   # Lines we consider "comment only" — drop them before the symbol grep.
   # Matches an added/removed line whose first non-whitespace content is
   # a JS/TS/SH comment introducer (`//`, `/*`, `*` mid-block, `#`).
@@ -103,9 +115,13 @@ if [ -n "$diff_base" ]; then
     # in either group with only string / log / typing edits passes
     # through.
     if printf '%s' "$f" | grep -qE "$filtered_delete|$provider_pattern"; then
+      # `-i` so identifier names like `performRollback` (camelCase) and
+      # `Delete`/`DELETE` (mixed case in CFN-style constants) match the
+      # lowercase patterns. Word boundaries (\b) keep matches scoped to
+      # whole words / camelCase boundaries; `EnigmaFoo` is safe.
       if git diff "$diff_base"...HEAD -- "$f" \
          | grep -vE "$comment_line_pattern" \
-         | grep -qE "$delete_symbol_pattern"; then
+         | grep -qiE "$delete_symbol_pattern"; then
         delete_touch=1
         break
       fi


### PR DESCRIPTION
## Summary

Refactors the integ-destroy gate hook to stop blocking PRs that only
tweak UX strings in `destroy.ts` / `destroy-runner.ts` /
`deploy-engine.ts`, while keeping the analyzer files (where typical
additions don't textually contain delete-symbol vocabulary) strict.

PR #84 was the trigger: a 1-line UX string change in `destroy.ts`
(switching the multi-region error message from `--region` to
`--stack-region`) was blocked by the gate even though the diff had
zero behavioral effect on the destroy path. Re-running `/run-integ`
for a string-only PR is pure overhead — and the kind of friction
that pushes future contributors to bypass gates rather than respect
them.

### New file classification (in `.claude/hooks/integ-destroy-gate.sh`)

| group | files | rule |
|---|---|---|
| **strict-delete** | `dag-builder.ts`, `implicit-delete-deps.ts`, `lambda-vpc-deps.ts` | any change at all is delete-touching |
| **filtered-delete** *(NEW)* | `destroy.ts`, `destroy-runner.ts`, `deploy-engine.ts` | only diff hunks adding/removing a delete-related symbol trigger |
| **provider** | `src/provisioning/providers/**`, `cloud-control-provider.ts`, `region-check.ts` | (unchanged) only delete-symbol hunks trigger |

The delete-symbol pattern is unchanged
(`delete|IMPLICIT_DELETE|hyperplane|DependencyViolation|ENI|detach`),
matched against added/removed lines with comment lines filtered out.

### Why analyzer files stay strict

`implicit-delete-deps.ts` typical addition:

```diff
+  // EFS MountTarget must be deleted AFTER FileSystem
+  'AWS::EFS::FileSystem': ['AWS::EFS::MountTarget'],
```

The added lines contain `deleted` (past tense, no `\b...\b` match
against `delete`) and the array literal itself, neither of which hit
the symbol pattern. Switching these to filtered would create real
false negatives — wrong delete-order rules slip into main. Keep
strict.

The command/orchestration files are different: they're large, mix
delete logic with UX strings + log messages + flag parsing, and the
delete-touching parts reliably contain `delete` / `destroy` /
`hyperplane` / etc.

### Verified via simulation (6 scenarios)

| scenario | file | expected | result |
|---|---|---|---|
| PR #84-style UX string change | `destroy.ts` | skip | skip |
| real `provider.delete(...)` signature change | `destroy.ts` | trigger | trigger |
| new `IMPLICIT_DELETE_DEPENDENCIES` entry | `implicit-delete-deps.ts` | trigger | trigger |
| new `delete()` method in provider | `providers/foo.ts` | trigger | trigger |
| typing-only change in provider | `providers/foo.ts` | skip | skip |
| out-of-scope file | `list.ts` | skip | skip |

Simulation script kept locally; the regex variables in the hook are
the source of truth.

### What does NOT change

- `.markgate.yml` `integ-destroy.include` scope (still 6 files —
  marker invalidates the same way).
- `/run-integ` skill behavior (still the only legitimate setter,
  still requires 0 errors + 0 orphans).
- The "never merge a PR whose destroy path is unverified" rule in
  CLAUDE.md (same rule, more precise enforcement).

## Test plan

- [x] `bash -n` syntax check passes
- [x] Simulation reproduces PR #84 fix and all 6 expected behaviors
- [ ] End-to-end test deferred — would require staging an actual PR
      through `gh pr merge --auto`. The simulation covers the
      decision logic; the rest of the hook (markgate verify, error
      message) is unchanged.

## Follow-up

Watch the next 1-2 PRs that touch deletion code and confirm the new
heuristic still triggers correctly on real changes. If a real
delete-touching change in a filtered file slips through (false
negative), extend the symbol pattern (e.g. add `destroy`,
`deletion`, etc.).