### PR TITLE
test(integ): add orphan-resource integration test for cdkd orphan per-resource

### DIFF
--- a/tests/integration/orphan-resource/README.md
+++ b/tests/integration/orphan-resource/README.md
@@ -1,0 +1,117 @@
+# Orphan Resource Integration Test
+
+Verifies `cdkd orphan <constructPath>` (per-resource orphan, mirrors
+upstream `cdk orphan --unstable=orphan`) end-to-end against real AWS.
+
+PR #100 reworked `cdkd orphan` to operate per-resource: the rewriter
+fetches every `Fn::GetAtt` it has to substitute via
+`provider.getAttribute(...)` and rewrites every sibling `Ref` /
+`Fn::GetAtt` / `Fn::Sub` site to a literal string before removing the
+target from state. Unit tests cover the algorithm
+(`tests/unit/analyzer/orphan-rewriter.test.ts`); this integ test
+exercises the load-bearing real-AWS assertions that unit tests can't:
+
+- Live `provider.getAttribute(...)` calls actually return real AWS values.
+- Sibling resources' `Ref` / `Fn::GetAtt` are rewritten to literal strings
+  (not left as intrinsic objects pointing at the now-missing orphan).
+- The orphaned AWS resource really survives — `cdkd orphan` only
+  removes the cdkd state record.
+- The orphan is reversible via `cdkd import` — re-importing the bucket
+  by physical id puts it back under cdkd's management.
+
+## Resources
+
+Two resources, with one explicit cross-reference:
+
+- **AWS::S3::Bucket** (`MyBucket`) — the orphan target.
+- **AWS::Lambda::Function** (`Handler`) — `BUCKET_NAME` env var is
+  `bucket.bucketName`, which CDK emits as `{Ref: MyBucket}`. This is
+  the reference the orphan rewriter has to substitute.
+
+The Bucket has `RemovalPolicy.RETAIN` so a wrong-order `cdkd destroy`
+(without orphaning first) doesn't accidentally delete it; the integ
+flow below still cleans the bucket up explicitly at the end.
+
+## Test scenario
+
+Run with `/run-integ orphan-resource`. The expected flow:
+
+1. **Deploy**
+
+   ```bash
+   node ../../../dist/cli.js deploy --region us-east-1 --verbose
+   ```
+
+   `cdkd state resources CdkdOrphanResourceExample` should list both
+   `MyBucket` and `Handler`. The Lambda's `BUCKET_NAME` env var in
+   state should still be `{Ref: MyBucket}` (intrinsic form).
+
+2. **Orphan the bucket**
+
+   The construct path matches the CDK `aws:cdk:path` tag in the synthesized
+   template (CDK appends `/Resource` for L1/L2 resource constructs):
+
+   ```bash
+   node ../../../dist/cli.js orphan \
+     'CdkdOrphanResourceExample/MyBucket/Resource' --yes
+   ```
+
+   Expected output (rewrite audit):
+
+   ```text
+   Orphaning 1 resource(s): MyBucketF68F3FF0
+   Applied 1 rewrite(s):
+     [property] Handler<hash>.Properties.Environment.Variables.BUCKET_NAME: {"Ref":"MyBucketF68F3FF0"} → "<physical-bucket-name>"
+   ```
+
+   (The `F68F3FF0`-style suffixes are CDK-generated; the `Handler` logical
+   ID gets a similar suffix.)
+
+3. **Verify**
+
+   - `cdkd state resources CdkdOrphanResourceExample` lists ONLY `Handler`.
+   - The Lambda's `BUCKET_NAME` env var in state is now a literal string
+     (the real bucket name), not `{Ref: MyBucket}`.
+   - `aws s3api head-bucket --bucket <bucket-name>` succeeds — the
+     bucket is still there.
+
+4. **Re-import (optional, proves orphan is reversible)**
+
+   ```bash
+   node ../../../dist/cli.js import CdkdOrphanResourceExample \
+     --resource MyBucket=<physical-bucket-name> --yes
+   ```
+
+   `cdkd state resources` should once again list both resources.
+   (Skip this step if you want to test the destroy-only path.)
+
+5. **Destroy**
+
+   ```bash
+   node ../../../dist/cli.js destroy CdkdOrphanResourceExample --force
+   ```
+
+   - If step 4 was skipped: only `Handler` is in state, so destroy
+     deletes only the function. The bucket is untracked. Clean it up
+     manually:
+
+     ```bash
+     aws s3 rb s3://<physical-bucket-name>
+     ```
+
+   - If step 4 ran: destroy will skip the bucket (RemovalPolicy=RETAIN)
+     and delete the function. Clean up the bucket the same way.
+
+6. **Verify zero orphans** — `cdkd state list` shows no
+   `CdkdOrphanResourceExample` row, and
+   `aws s3api list-buckets --query 'Buckets[?starts_with(Name, \`cdkdorphanresourceexample\`)]'`
+   returns empty.
+
+## Comparison
+
+| Command                                                 | What it does                                                                              |
+|---------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| `cdkd orphan CdkdOrphanResourceExample/MyBucket`        | Per-resource: rewrites siblings, removes one resource from state, AWS resource stays.     |
+| `cdkd state orphan CdkdOrphanResourceExample`           | Whole-stack: removes the entire state record, AWS resources stay (no rewriting needed).   |
+| `cdkd destroy CdkdOrphanResourceExample`                | Whole-stack: deletes AWS resources AND the state record.                                  |
+| `cdkd state destroy CdkdOrphanResourceExample`          | Same as `cdkd destroy`, but no CDK app required.                                          |

--- a/tests/integration/orphan-resource/bin/app.ts
+++ b/tests/integration/orphan-resource/bin/app.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { OrphanResourceStack } from '../lib/orphan-resource-stack';
+
+const app = new cdk.App();
+
+new OrphanResourceStack(app, 'CdkdOrphanResourceExample', {
+  description:
+    'Integration test for `cdkd orphan` per-resource — Lambda env var Refs an S3 bucket; the bucket is the orphan target',
+});

--- a/tests/integration/orphan-resource/cdk.json
+++ b/tests/integration/orphan-resource/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/app.ts"
+}

--- a/tests/integration/orphan-resource/lambda/index.py
+++ b/tests/integration/orphan-resource/lambda/index.py
@@ -1,0 +1,20 @@
+import json
+import os
+
+
+def handler(event, context):
+    """
+    Trivial handler used only as a deploy target for the orphan integ test.
+
+    Reads BUCKET_NAME from the env. After `cdkd orphan` rewrites the
+    sibling reference to a literal string, the deployed function still
+    sees the same value here — proving the rewrite preserved behavior.
+    """
+    bucket_name = os.environ.get('BUCKET_NAME', 'not-set')
+    return {
+        'statusCode': 200,
+        'body': json.dumps({
+            'bucketName': bucket_name,
+            'event': event,
+        }),
+    }

--- a/tests/integration/orphan-resource/lib/orphan-resource-stack.ts
+++ b/tests/integration/orphan-resource/lib/orphan-resource-stack.ts
@@ -1,0 +1,59 @@
+import * as path from 'path';
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+/**
+ * Stack for exercising `cdkd orphan <constructPath>` (per-resource orphan).
+ *
+ * Two resources, with one explicit cross-reference so the orphan
+ * rewriter has something load-bearing to substitute:
+ *
+ *   - `MyBucket` (AWS::S3::Bucket) — the future orphan target.
+ *   - `Handler` (AWS::Lambda::Function) — its `BUCKET_NAME` env var
+ *     is `bucket.bucketName`, which CDK synthesizes to `{Ref: MyBucket}`.
+ *
+ * After `cdkd orphan CdkdOrphanResourceExample/MyBucket`, the state file
+ * for the Function should have `BUCKET_NAME` rewritten to the literal
+ * physical bucket name (a string), and the Bucket should no longer be
+ * tracked in cdkd state — but it must still exist in AWS.
+ *
+ * The Bucket uses `RemovalPolicy.RETAIN` because the destroy path of
+ * this test only removes the Lambda; the test driver deletes the
+ * orphaned bucket out-of-band with `aws s3 rb` to leave zero leftover
+ * resources.
+ */
+export class OrphanResourceStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const bucket = new s3.Bucket(this, 'MyBucket', {
+      // RETAIN: cdkd's destroy will respect this and skip the bucket,
+      // but the orphan flow doesn't even touch destroy — this is just
+      // a safety belt for the cleanup phase if someone runs `cdkd
+      // destroy` *before* orphaning.
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      autoDeleteObjects: false,
+    });
+
+    // Lambda's BUCKET_NAME env var holds `{Ref: MyBucket}` after synth.
+    // After orphaning MyBucket, the rewriter must resolve that Ref via
+    // S3BucketProvider.getAttribute(... 'Ref') and substitute the literal
+    // bucket name string into state.
+    new lambda.Function(this, 'Handler', {
+      runtime: lambda.Runtime.PYTHON_3_12,
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda')),
+      handler: 'index.handler',
+      environment: {
+        BUCKET_NAME: bucket.bucketName,
+      },
+      timeout: cdk.Duration.seconds(10),
+    });
+
+    new cdk.CfnOutput(this, 'BucketName', {
+      value: bucket.bucketName,
+      description: 'Physical name of the S3 bucket (the orphan target)',
+    });
+  }
+}

--- a/tests/integration/orphan-resource/package.json
+++ b/tests/integration/orphan-resource/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkd-integ-orphan-resource",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test for `cdkd orphan` (per-resource orphan via construct path)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0",
+    "ts-node": "^10.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/tests/integration/orphan-resource/tsconfig.json
+++ b/tests/integration/orphan-resource/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "exclude": ["node_modules", "cdk.out"]
+}


### PR DESCRIPTION
## Summary

Adds `tests/integration/orphan-resource/` — the integration test
that PR #100 (cdkd orphan per-resource rework) deferred.

Verifies the load-bearing assertions of the new per-resource orphan
that unit tests can't cover by construction:

- Live `provider.getAttribute()` fetches return real AWS values
- Sibling resources' `Ref` / `Fn::GetAtt` are rewritten to literal
  strings
- The orphaned AWS resource really survives the orphan
- The orphan is re-importable via `cdkd import`

## Stack structure

`CdkdOrphanResourceExample` — 2 user-facing resources (synth shows
4 including CDK-generated IAM Role + Lambda exec):

- `MyBucket` — `AWS::S3::Bucket` with `RemovalPolicy.RETAIN`
  (the orphan target; RETAIN is a safety belt against
  destroy-before-orphan)
- `Handler` — `AWS::Lambda::Function` (Python 3.12) with
  `BUCKET_NAME` env var = `bucket.bucketName`

The Lambda → Bucket dependency is `Ref` in
`Properties.Environment.Variables.BUCKET_NAME` — exactly the
intrinsic the orphan rewriter must substitute.

## Test flow (when invoked via `/run-integ orphan-resource`)

1. Deploy the stack
2. Verify cdkd state has both Bucket and Function
3. Run `cdkd orphan 'CdkdOrphanResourceExample/MyBucket/Resource' --yes`
4. Verify:
   - cdkd state no longer contains the Bucket
   - Function's `BUCKET_NAME` env var is now a literal string
     (the real bucket name), not `{Ref: MyBucket...}`
   - The S3 bucket still exists in AWS
5. (Optional) Re-import the bucket via `cdkd import` to prove
   reversibility
6. `cdkd destroy` — destroys the Function only; bucket is untracked
   (RETAIN already protects it from cdkd state, but the test
   manually `aws s3 rb`s it as a final step to leave zero orphans)

## Note on the orphan path

CDK's L2 constructs append `/Resource` to the construct path, so
the orphan invocation is `cdkd orphan
'CdkdOrphanResourceExample/MyBucket/Resource'` (not
`.../MyBucket`). The README documents this gotcha. `/run-integ`
should use the `/Resource`-suffixed path when this test runs.

## Test plan

- [x] Synth verified locally:
      `node ../../../dist/cli.js synth --region us-east-1` → 1
      stack, 4 resources, 1 output. Template contains
      `"BUCKET_NAME": { "Ref": "MyBucketF68F3FF0" }` — exactly the
      intrinsic the rewriter targets.
- [x] Repo-level `pnpm run typecheck`, `lint`, `build` clean
- [x] `npx vitest --run` — 1180/1180 pass
- [ ] Real-AWS run deferred to `/run-integ orphan-resource` (the
      load-bearing assertion this PR enables — to be exercised
      after merge)

## Files

- `tests/integration/orphan-resource/cdk.json`
- `tests/integration/orphan-resource/package.json`
- `tests/integration/orphan-resource/tsconfig.json`
- `tests/integration/orphan-resource/bin/app.ts`
- `tests/integration/orphan-resource/lib/orphan-resource-stack.ts`
- `tests/integration/orphan-resource/lambda/index.py`
- `tests/integration/orphan-resource/README.md` (explains what the
  test verifies + the `/Resource` suffix gotcha)

## Closes

The integ-test follow-up from PR #100 / issue #92.