### PR TITLE
feat(providers): close the 3 deferred getAttribute gaps

### DIFF
--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -936,8 +936,6 @@ the small additional call is reasonable to add.
 
 | Resource | Unsupported attribute | Why deferred |
 | --- | --- | --- |
-| `AWS::Lambda::Function` | `SnapStartResponse.ApplyOn`, `SnapStartResponse.OptimizationStatus` | Rare (SnapStart-specific); requires nested-attribute parsing in the resolver. |
-| `AWS::DynamoDB::Table` | `LatestStreamLabel` | `DescribeTable` exposes the latest stream ARN but not the label; needs `DescribeStream`. Rarely referenced. |
 | `AWS::SQS::Queue` | (none) | All three CFn return values are covered. |
 | `AWS::S3::Bucket` | (none) | All five CFn return values are covered. |
 

--- a/src/provisioning/providers/dynamodb-table-provider.ts
+++ b/src/provisioning/providers/dynamodb-table-provider.ts
@@ -328,13 +328,12 @@ export class DynamoDBTableProvider implements ResourceProvider {
   /**
    * Resolve a single `Fn::GetAtt` attribute for an existing DynamoDB table.
    *
-   * CloudFormation's `AWS::DynamoDB::Table` exposes `Arn` and `StreamArn`
+   * CloudFormation's `AWS::DynamoDB::Table` exposes `Arn`, `StreamArn`
    * (a.k.a. `LatestStreamArn` in the SDK; CFn returns the latest enabled
-   * stream's ARN, which is what `DescribeTable` reports). See:
+   * stream's ARN), and `LatestStreamLabel`. All three are sibling fields on
+   * the same `DescribeTable` response, so a single API call covers every
+   * supported attr. See:
    * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#aws-resource-dynamodb-table-return-values
-   *
-   * `LatestStreamLabel` is also documented but rarely used; not implemented
-   * here — see `docs/provider-development.md` for the deferred list.
    *
    * Used by `cdkd orphan` to live-fetch attribute values that need to be
    * substituted into sibling references.
@@ -353,6 +352,8 @@ export class DynamoDBTableProvider implements ResourceProvider {
           return resp.Table?.TableArn;
         case 'StreamArn':
           return resp.Table?.LatestStreamArn;
+        case 'LatestStreamLabel':
+          return resp.Table?.LatestStreamLabel;
         default:
           return undefined;
       }

--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -760,28 +760,42 @@ export class LambdaFunctionProvider implements ResourceProvider {
   /**
    * Resolve a single `Fn::GetAtt` attribute for an existing Lambda function.
    *
-   * CloudFormation's `AWS::Lambda::Function` exposes `Arn` (the only widely
-   * used return value documented at
-   * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#aws-resource-lambda-function-return-values).
+   * CloudFormation's `AWS::Lambda::Function` exposes `Arn`,
+   * `SnapStartResponse.ApplyOn`, and `SnapStartResponse.OptimizationStatus`
+   * as documented at
+   * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#aws-resource-lambda-function-return-values.
    *
-   * `SnapStartResponse.ApplyOn` and `SnapStartResponse.OptimizationStatus` are
-   * not supported here — see `docs/provider-development.md` for the deferred
-   * list. Used by `cdkd orphan` to live-fetch attribute values that need to
-   * be substituted into sibling references.
+   * All three live in the same `GetFunction` response (`Configuration.FunctionArn`
+   * and `Configuration.SnapStart.{ApplyOn,OptimizationStatus}`), so a single API
+   * call covers every supported attr. Used by `cdkd orphan` to live-fetch
+   * attribute values that need to be substituted into sibling references.
    */
   async getAttribute(
     physicalId: string,
     _resourceType: string,
     attributeName: string
   ): Promise<unknown> {
-    if (attributeName !== 'Arn') {
+    if (
+      attributeName !== 'Arn' &&
+      attributeName !== 'SnapStartResponse.ApplyOn' &&
+      attributeName !== 'SnapStartResponse.OptimizationStatus'
+    ) {
       return undefined;
     }
     try {
       const resp = await this.lambdaClient.send(
         new GetFunctionCommand({ FunctionName: physicalId })
       );
-      return resp.Configuration?.FunctionArn;
+      switch (attributeName) {
+        case 'Arn':
+          return resp.Configuration?.FunctionArn;
+        case 'SnapStartResponse.ApplyOn':
+          return resp.Configuration?.SnapStart?.ApplyOn;
+        case 'SnapStartResponse.OptimizationStatus':
+          return resp.Configuration?.SnapStart?.OptimizationStatus;
+        default:
+          return undefined;
+      }
     } catch (err) {
       if (err instanceof ResourceNotFoundException) return undefined;
       throw err;

--- a/tests/unit/provisioning/dynamodb-table-provider-getattribute.test.ts
+++ b/tests/unit/provisioning/dynamodb-table-provider-getattribute.test.ts
@@ -65,6 +65,24 @@ describe('DynamoDBTableProvider.getAttribute', () => {
     expect(result).toBe('arn:aws:dynamodb:us-east-1:123:table/my-table/stream/2026');
   });
 
+  it('returns LatestStreamLabel from DescribeTable.LatestStreamLabel', async () => {
+    mockSend.mockResolvedValueOnce({
+      Table: {
+        TableName: 'my-table',
+        TableArn: 'arn:aws:dynamodb:us-east-1:123:table/my-table',
+        LatestStreamArn: 'arn:aws:dynamodb:us-east-1:123:table/my-table/stream/2026-05-02T00:00:00.000',
+        LatestStreamLabel: '2026-05-02T00:00:00.000',
+      },
+    });
+
+    const result = await provider.getAttribute(
+      'my-table',
+      'AWS::DynamoDB::Table',
+      'LatestStreamLabel'
+    );
+    expect(result).toBe('2026-05-02T00:00:00.000');
+  });
+
   it('returns undefined for unknown attribute', async () => {
     mockSend.mockResolvedValueOnce({
       Table: { TableName: 'my-table', TableArn: 'arn' },

--- a/tests/unit/provisioning/lambda-function-provider.test.ts
+++ b/tests/unit/provisioning/lambda-function-provider.test.ts
@@ -569,5 +569,37 @@ describe('LambdaFunctionProvider', () => {
       const result = await provider.getAttribute('missing-fn', 'AWS::Lambda::Function', 'Arn');
       expect(result).toBeUndefined();
     });
+
+    it('returns SnapStartResponse.ApplyOn from GetFunction.Configuration.SnapStart.ApplyOn', async () => {
+      mockLambdaSend.mockResolvedValueOnce({
+        Configuration: {
+          FunctionArn: 'arn:aws:lambda:us-east-1:123:function:my-fn',
+          SnapStart: { ApplyOn: 'PublishedVersions', OptimizationStatus: 'On' },
+        },
+      });
+
+      const result = await provider.getAttribute(
+        'my-fn',
+        'AWS::Lambda::Function',
+        'SnapStartResponse.ApplyOn'
+      );
+      expect(result).toBe('PublishedVersions');
+    });
+
+    it('returns SnapStartResponse.OptimizationStatus from GetFunction.Configuration.SnapStart.OptimizationStatus', async () => {
+      mockLambdaSend.mockResolvedValueOnce({
+        Configuration: {
+          FunctionArn: 'arn:aws:lambda:us-east-1:123:function:my-fn',
+          SnapStart: { ApplyOn: 'PublishedVersions', OptimizationStatus: 'On' },
+        },
+      });
+
+      const result = await provider.getAttribute(
+        'my-fn',
+        'AWS::Lambda::Function',
+        'SnapStartResponse.OptimizationStatus'
+      );
+      expect(result).toBe('On');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes the 3 deferred `provider.getAttribute()` attrs from PR
#103's audit:

- `AWS::Lambda::Function` `SnapStartResponse.ApplyOn`
- `AWS::Lambda::Function` `SnapStartResponse.OptimizationStatus`
- `AWS::DynamoDB::Table` `LatestStreamLabel`

All three are reachable from existing API responses (`GetFunction`
for Lambda; `DescribeTable` for DynamoDB) — no new API calls. Each
fix is a 1-2 line addition to the existing switch.

## Implementation notes

### Lambda SnapStart fields ([lambda-function-provider.ts:776-803](src/provisioning/providers/lambda-function-provider.ts#L776))

The CFn attribute names are dotted (`SnapStartResponse.ApplyOn`,
`SnapStartResponse.OptimizationStatus`) but the AWS SDK shape is
`Configuration.SnapStart` (typed `SnapStartResponse` — the SDK
type and CFn attribute prefix happen to share the name). The
match is on the dotted CFn name; the read is from
`resp.Configuration?.SnapStart?.ApplyOn` /
`resp.Configuration?.SnapStart?.OptimizationStatus`.

Refactored the existing `if (attributeName !== 'Arn') return;`
early-return into a 3-name allowlist + switch, since we now have
3 attrs.

### DynamoDB LatestStreamLabel ([dynamodb-table-provider.ts:357-358](src/provisioning/providers/dynamodb-table-provider.ts#L357))

Single line addition: `case 'LatestStreamLabel': return
resp.Table?.LatestStreamLabel;`. Uses the same `DescribeTable`
response that already serves `StreamArn`.

### Docs

Removed the 2 deferred-row entries from
`docs/provider-development.md` "Known coverage gaps" table. The
leading explanation and the remaining `(none)` entries for SQS/S3
are preserved.

## Test plan

- [x] `pnpm run typecheck`, `lint`, `build` clean
- [x] `npx vitest --run` — 1183/1183 pass (was 1180 → +3)
- [x] 3 new unit tests, one per attr, mocking the SDK response
- [ ] Live verification deferred — provider tests use mocked
      SDK responses; the attrs would be exercised naturally by
      orphan / GetAtt resolution flows on stacks that use them.

## Closes

The 3 deferred items from PR #103's audit (#98 follow-up).