### PR TITLE
chore(hook): add gh-label-validity-gate to bound parallel-call blast radius

### DIFF
--- a/.claude/hooks/gh-label-validity-gate.sh
+++ b/.claude/hooks/gh-label-validity-gate.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# gh-label-validity-gate.sh
+#
+# PreToolUse hook. Blocks `gh issue create` / `gh issue edit` / `gh pr create`
+# / `gh pr edit` invocations whose `--label` or `--add-label` argument names a
+# label that doesn't exist in the current repo.
+#
+# Why this gate exists: when a parallel-tool-call batch contains one
+# `gh issue create --label NONEXISTENT`, the runtime cancels every sibling
+# call (other issue creates, subagent dispatches, etc.) once the missing-label
+# error fires. Validating labels upfront keeps that blast radius from costing
+# minutes of re-dispatch.
+#
+# See feedback memory `feedback_parallel_call_blast_radius.md` for the rule
+# this hook backs.
+
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+
+# Only gate `gh issue|pr create|edit` invocations that include --label / --add-label.
+# Note: gh's short alias `-l` is intentionally NOT matched. `-l` is also short
+# for `--limit` (gh issue list -l 5), `--locale`, etc. — too ambiguous to filter
+# without parsing each subcommand's flag table. Stick to the long forms; that's
+# what scripts and AI agents use anyway.
+if ! printf '%s' "$cmd" | grep -qE '\bgh[[:space:]]+(issue|pr)[[:space:]]+(create|edit)\b'; then
+  exit 0
+fi
+if ! printf '%s' "$cmd" | grep -qE -- '--(add-)?label\b'; then
+  exit 0
+fi
+
+cd "$REPO" 2>/dev/null || exit 0
+
+# Fetch valid labels. If gh isn't authenticated or the call fails for any
+# reason, skip the check rather than block — the gate is a foot-gun guard,
+# not a hard requirement, and a transient gh failure shouldn't block work.
+valid_labels=$(gh label list --json name -q '.[].name' 2>/dev/null) || exit 0
+[ -z "$valid_labels" ] && exit 0
+
+# Extract every --label / --add-label value from the command string.
+# Handles `--label X`, `--label=X`, `--add-label X`, with the value optionally
+# surrounded by single or double quotes. Splits comma-separated values.
+# The unquoted value is terminated by whitespace or any shell metacharacter
+# (`;`, `&`, `|`, `)`, `>`, `<`, `"`, `'`) so a chained `--label X; other-cmd`
+# captures `X`, not `X;`.
+labels=$(printf '%s' "$cmd" \
+  | grep -oE -- '--(add-)?label[= ]("[^"]+"|'\''[^'\'']+'\''|[^ ;&|()<>"'\'']+)' \
+  | sed -E -e 's/^--(add-)?label[= ]//' -e 's/^["'\'']//' -e 's/["'\'']$//' \
+  | tr ',' '\n' \
+  | sed 's/^ *//;s/ *$//' \
+  | grep -v '^$' || true)
+
+[ -z "$labels" ] && exit 0
+
+missing=""
+while IFS= read -r label; do
+  [ -z "$label" ] && continue
+  if ! printf '%s\n' "$valid_labels" | grep -qFx -- "$label"; then
+    missing="${missing}  - '${label}'"$'\n'
+  fi
+done <<EOF_LABELS
+$labels
+EOF_LABELS
+
+if [ -n "$missing" ]; then
+  cat >&2 <<EOF
+Blocked by gh-label-validity-gate: the following label(s) don't exist in this repo:
+${missing}
+Available labels:
+$(printf '%s\n' "$valid_labels" | sed 's/^/  - /')
+
+To fix: either drop the missing label, use one of the available labels, or
+create the missing label first:
+  gh label create '<label-name>' --description '...' --color '<hex>'
+
+Why this gate exists: a single bad --label aborts every sibling call in a
+parallel tool-call batch (cdkd 2026-05-02 lost a 4-way parallel batch this
+way). Catching the typo upfront keeps the blast radius bounded.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,6 +45,13 @@
             "if": "Bash(gh pr edit*)",
             "timeout": 10,
             "statusMessage": "Checking gh pr edit usage..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/gh-label-validity-gate.sh",
+            "if": "Bash(*--label*) or Bash(*--add-label*)",
+            "timeout": 10,
+            "statusMessage": "Checking gh label validity..."
           }
         ]
       }


### PR DESCRIPTION
## Summary

Adds `.claude/hooks/gh-label-validity-gate.sh` — a PreToolUse hook
that blocks `gh issue create / edit` and `gh pr create / edit` when
`--label` / `--add-label` names a label that doesn't exist in the
current repo.

## Why

When a parallel-tool-call batch contains one `gh issue create
--label NONEXISTENT`, the runtime cancels every sibling call (other
issue creates, subagent dispatches, etc.) once the missing-label
error fires. We lost a 4-way batch this way during the cdkd
2026-05-02 / 2026-05-03 14-PR campaign (`--label chore` — `chore`
wasn't a label in the repo). Validating labels upfront keeps that
blast radius bounded.

The local memory rule
[`feedback_parallel_call_blast_radius.md`](https://github.com/go-to-k/cdkd)
describes the discipline; this hook makes it mechanical.

## Behavior

- Skips entirely if not `gh issue|pr create|edit`, or no
  `--label` / `--add-label` flag
- Skips if `gh label list` fails (transient gh / no auth) — this
  gate is a foot-gun guard, not a hard requirement
- On block: prints the missing label(s), the available labels, and
  the `gh label create` recipe to fix
- The short alias `-l` is intentionally NOT matched: `-l` is also
  short for `--limit` (gh issue list -l 5), `--locale`, etc. —
  ambiguous without per-subcommand parsing. Stick to long forms;
  that's what scripts and AI agents use anyway.

## Implementation

- `.claude/hooks/gh-label-validity-gate.sh` (~70 lines)
- Registered in `.claude/settings.json` PreToolUse list with
  `if: Bash(*--label*) or Bash(*--add-label*)` to keep overhead on
  unrelated commands minimal

## Test plan

Verified with 12 cases (test script at `/tmp/hook-test.sh` —
not committed, fed JSON payloads directly to the hook to bypass
PreToolUse-on-tester-itself). All pass:

| case | expected | actual |
|---|---|---|
| valid label `bug` | pass | ✅ |
| invalid `xxxchore` | block | ✅ |
| mixed `bug,xxxchore` | block | ✅ |
| comma-separated all valid | pass | ✅ |
| comma-separated mixed | block | ✅ |
| non-gh (`docker build --label`) | pass | ✅ |
| no `--label` flag | pass | ✅ |
| `gh issue list --label` (read-only) | pass | ✅ |
| `gh pr edit --add-label nonex` | block | ✅ |
| trailing `; echo done` | pass (regex stops at `;`) | ✅ |
| quoted `"good first issue"` | pass | ✅ |
| `--label=bug` (equals form) | pass | ✅ |

- [x] `bash -n` syntax check passes
- [x] `jq . settings.json` valid JSON
- [ ] Live verification: would require deliberately invoking
      `gh issue create --label nonexistent` and observing the
      block. The unit-equivalent test cases above cover the
      decision logic; the rest of the hook (gh label list call,
      error message formatting) is straightforward.

## What does NOT change

- No source code (`.claude/hooks/**` is outside markgate scope —
  this PR doesn't invalidate any check / docs / verify-pr /
  integ-destroy markers)
- No existing hooks modified
- No README / CLAUDE.md changes (the hook's purpose is documented
  inline in the script header)