### PR TITLE
feat(intrinsic): add Fn::GetStackOutput for cross-stack/cross-region refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,8 @@ cdkd has a 7-layer system architecture:
    - Implemented in `src/deployment/dag-executor.ts`
 
 4. **Intrinsic Function Resolution**
-   - All CloudFormation intrinsic functions supported: `Ref`, `Fn::GetAtt`, `Fn::Join`, `Fn::Sub`, `Fn::Select`, `Fn::Split`, `Fn::If`, `Fn::Equals`, `Fn::And`, `Fn::Or`, `Fn::Not`, `Fn::ImportValue`, `Fn::FindInMap`, `Fn::Base64`, `Fn::GetAZs`, `Fn::Cidr`
+   - All CloudFormation intrinsic functions supported: `Ref`, `Fn::GetAtt`, `Fn::Join`, `Fn::Sub`, `Fn::Select`, `Fn::Split`, `Fn::If`, `Fn::Equals`, `Fn::And`, `Fn::Or`, `Fn::Not`, `Fn::ImportValue`, `Fn::GetStackOutput`, `Fn::FindInMap`, `Fn::Base64`, `Fn::GetAZs`, `Fn::Cidr`
+   - `Fn::GetStackOutput` reads the producer stack's output directly from cdkd's S3 state (`s3://{bucket}/cdkd/{StackName}/{Region}/state.json`) — no Export needed, and `Region` may differ from the consumer's deploy region (same-account cross-region works out of the box because the state bucket name is account-scoped, not region-scoped). `RoleArn` (cross-account) is rejected with a clear error: cdkd uses S3 state instead of `cloudformation:DescribeStacks`, so cross-account would require assuming the role and reading the producer account's separate state bucket — not yet implemented.
 
 ## Build and Test Commands
 
@@ -467,6 +468,7 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 - ✅ Intrinsic functions: Fn::Select, Fn::Split, Fn::If, Fn::Equals, Fn::And, Fn::Or, Fn::Not, Fn::ImportValue
 - ✅ Conditions evaluation (with logical operators)
 - ✅ Cross-stack references (Fn::ImportValue via S3 state backend)
+- ✅ Cross-stack / cross-region references (Fn::GetStackOutput via S3 state backend) — same-account; cross-account RoleArn rejected with a clear error (not yet implemented)
 - ✅ Cloud Control API JSON Patch for updates (RFC 6902 compliant)
 - ✅ Resource replacement detection (immutable property detection for 10+ AWS resource types)
 - ✅ AWS::NoValue pseudo parameter (for conditional property omission)

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Reproduce with `./tests/benchmark/run-benchmark.sh all`. See [tests/benchmark/RE
 | `Fn::Or` | ✅ Supported | Logical OR (2-10 conditions) |
 | `Fn::Not` | ✅ Supported | Logical NOT |
 | `Fn::ImportValue` | ✅ Supported | Cross-stack references via S3 state |
+| `Fn::GetStackOutput` | ✅ Supported (same-account) | Cross-stack / cross-region output reference via S3 state. Cross-account `RoleArn` is rejected with a clear error (not yet implemented). |
 | `Fn::FindInMap` | ✅ Supported | Mapping lookup |
 | `Fn::GetAZs` | ✅ Supported | Availability Zone list |
 | `Fn::Base64` | ✅ Supported | Base64 encoding |
@@ -283,6 +284,7 @@ Reproduce with `./tests/benchmark/run-benchmark.sh all`. See [tests/benchmark/RE
 | CloudFormation Parameters | ✅ | Default values, type coercion |
 | Conditions | ✅ | With logical operators |
 | Cross-stack references | ✅ | Via `Fn::ImportValue` + S3 state |
+| Cross-region references | ✅ (same-account) | Via `Fn::GetStackOutput` + S3 state. Cross-account `RoleArn` not yet implemented. |
 | JSON Patch updates | ✅ | RFC 6902, minimal patches |
 | Resource replacement detection | ✅ | 10+ resource types |
 | Dynamic References | ✅ | `{{resolve:secretsmanager:...}}`, `{{resolve:ssm:...}}` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -283,6 +283,7 @@ Resolves CloudFormation intrinsic functions
 - `Fn::If`, `Fn::Equals`: Conditional evaluation
 - `Fn::And`, `Fn::Or`, `Fn::Not`: Logical operators for Conditions
 - `Fn::ImportValue`: Cross-stack references
+- `Fn::GetStackOutput`: Cross-stack / cross-region output reference (same-account; cross-account `RoleArn` not yet implemented)
 - `Fn::FindInMap`: Mapping lookup
 - `Fn::GetAZs`: Availability Zone list
 - `Fn::Base64`: Base64 encoding
@@ -807,7 +808,7 @@ Each layer has clear responsibilities
 1. **CloudFormation Macros**: Not supported
 2. **Nested Stacks**: Not supported
 3. **Change Sets**: No concept (always executes immediately)
-4. All intrinsic functions are now supported (15/15)
+4. All intrinsic functions are now supported (16/16, including `Fn::GetStackOutput` for same-account cross-region references; cross-account `RoleArn` not yet implemented)
 5. All pseudo parameters are now supported (7/7)
 
 ### Phase 9 and Beyond Plans

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -510,6 +510,7 @@ CloudFormation intrinsic function not supported by cdkd is being used.
 | `Fn::Or` | ✅ |
 | `Fn::Not` | ✅ |
 | `Fn::ImportValue` | ✅ |
+| `Fn::GetStackOutput` | ✅ (same-account; cross-account `RoleArn` not yet implemented) |
 | `Fn::FindInMap` | ✅ |
 | `Fn::GetAZs` | ✅ |
 | `Fn::Base64` | ✅ |

--- a/src/deployment/intrinsic-function-resolver.ts
+++ b/src/deployment/intrinsic-function-resolver.ts
@@ -53,6 +53,7 @@ export interface ResolverContext {
  * - Fn::Or (logical OR)
  * - Fn::Not (logical NOT)
  * - Fn::ImportValue (cross-stack references)
+ * - Fn::GetStackOutput (cross-stack/cross-region output reference)
  * - Fn::FindInMap (mapping lookups)
  * - Fn::Base64 (base64 encoding)
  * - Fn::GetAZs (availability zone listing)
@@ -359,6 +360,10 @@ export class IntrinsicFunctionResolver {
 
     if ('Fn::ImportValue' in obj) {
       return await this.resolveImportValue(obj['Fn::ImportValue'], context);
+    }
+
+    if ('Fn::GetStackOutput' in obj) {
+      return await this.resolveGetStackOutput(obj['Fn::GetStackOutput'], context);
     }
 
     if ('Fn::FindInMap' in obj) {
@@ -1097,6 +1102,128 @@ export class IntrinsicFunctionResolver {
         `Searched ${allStacks.length} state record(s). ` +
         `Make sure the exporting stack has been deployed and the Output has an Export.Name property.`
     );
+  }
+
+  /**
+   * Resolve Fn::GetStackOutput (cross-stack / cross-region output reference)
+   *
+   * Shape: { "Fn::GetStackOutput": { "StackName": "...", "OutputName": "...",
+   *                                   "Region": "...", "RoleArn": "..." } }
+   *
+   * Unlike Fn::ImportValue, the producer stack is named explicitly and no
+   * Export is required. cdkd reads the producer's `outputs` from the
+   * region-scoped state record at
+   * `s3://{bucket}/cdkd/{StackName}/{Region}/state.json`. When `Region` is
+   * omitted, the consumer's deploy region is used.
+   *
+   * RoleArn (cross-account) is intentionally rejected — cdkd uses S3 state,
+   * not CloudFormation DescribeStacks, so a cross-account reference would
+   * require assuming the role and reading the producer's separate state
+   * bucket. That path is not yet implemented; we surface a clear error
+   * instead of silently downgrading.
+   */
+  private async resolveGetStackOutput(arg: unknown, context: ResolverContext): Promise<unknown> {
+    if (!arg || typeof arg !== 'object' || Array.isArray(arg)) {
+      throw new Error(
+        `Fn::GetStackOutput: argument must be an object with StackName/OutputName/Region/RoleArn, got ${
+          arg === null ? 'null' : Array.isArray(arg) ? 'array' : typeof arg
+        }`
+      );
+    }
+    const args = arg as Record<string, unknown>;
+
+    if (!('StackName' in args)) {
+      throw new Error('Fn::GetStackOutput: StackName is required');
+    }
+    if (!('OutputName' in args)) {
+      throw new Error('Fn::GetStackOutput: OutputName is required');
+    }
+
+    const stackName = await this.resolveValue(args['StackName'], context);
+    if (typeof stackName !== 'string' || stackName === '') {
+      throw new Error(
+        `Fn::GetStackOutput: StackName must resolve to a non-empty string, got ${typeof stackName}`
+      );
+    }
+
+    const outputName = await this.resolveValue(args['OutputName'], context);
+    if (typeof outputName !== 'string' || outputName === '') {
+      throw new Error(
+        `Fn::GetStackOutput: OutputName must resolve to a non-empty string, got ${typeof outputName}`
+      );
+    }
+
+    let region = this.resolverRegion;
+    if ('Region' in args && args['Region'] !== undefined && args['Region'] !== null) {
+      const resolvedRegion = await this.resolveValue(args['Region'], context);
+      if (typeof resolvedRegion !== 'string' || resolvedRegion === '') {
+        throw new Error(
+          `Fn::GetStackOutput: Region must resolve to a non-empty string, got ${typeof resolvedRegion}`
+        );
+      }
+      region = resolvedRegion;
+    }
+
+    let roleArn: string | undefined;
+    if ('RoleArn' in args && args['RoleArn'] !== undefined && args['RoleArn'] !== null) {
+      const resolvedRoleArn = await this.resolveValue(args['RoleArn'], context);
+      if (typeof resolvedRoleArn !== 'string' || resolvedRoleArn === '') {
+        throw new Error(
+          `Fn::GetStackOutput: RoleArn must resolve to a non-empty string, got ${typeof resolvedRoleArn}`
+        );
+      }
+      roleArn = resolvedRoleArn;
+    }
+
+    if (roleArn) {
+      throw new Error(
+        `Fn::GetStackOutput: cross-account references via RoleArn are not yet supported by cdkd ` +
+          `(StackName=${stackName}, Region=${region}, RoleArn=${roleArn}). ` +
+          `cdkd reads outputs from S3 state instead of CloudFormation DescribeStacks, ` +
+          `so cross-account requires assuming the role and reading the producer account's ` +
+          `state bucket — not yet implemented.`
+      );
+    }
+
+    if (!context.stateBackend) {
+      throw new Error('Fn::GetStackOutput: state backend is required for cross-stack references');
+    }
+
+    // Reject obvious self-reference (same stack AND same region).
+    if (context.stackName && context.stackName === stackName && region === this.resolverRegion) {
+      throw new Error(
+        `Fn::GetStackOutput: cannot reference own stack '${stackName}' in the same region '${region}'`
+      );
+    }
+
+    this.logger.debug(
+      `Resolving Fn::GetStackOutput: StackName=${stackName}, Region=${region}, OutputName=${outputName}`
+    );
+
+    const stateData = await context.stateBackend.getState(stackName, region);
+    if (!stateData) {
+      throw new Error(
+        `Fn::GetStackOutput: stack '${stackName}' not found in region '${region}'. ` +
+          `Make sure the producer stack has been deployed via cdkd.`
+      );
+    }
+
+    const outputs = stateData.state.outputs ?? {};
+    if (!(outputName in outputs)) {
+      const available = Object.keys(outputs).join(', ') || '(none)';
+      throw new Error(
+        `Fn::GetStackOutput: output '${outputName}' not found in stack '${stackName}' (${region}). ` +
+          `Available outputs: ${available}`
+      );
+    }
+
+    const value = outputs[outputName];
+    this.logger.info(
+      `Resolved Fn::GetStackOutput: StackName=${stackName}, Region=${region}, OutputName=${outputName} -> ${JSON.stringify(
+        value
+      )}`
+    );
+    return value;
   }
 
   /**

--- a/tests/integration/cross-stack-references/README.md
+++ b/tests/integration/cross-stack-references/README.md
@@ -1,6 +1,9 @@
 # Cross-Stack References Example
 
-This example demonstrates cross-stack references using `Fn::ImportValue` with cdkd.
+This example demonstrates two cross-stack reference mechanisms with cdkd:
+
+- `Fn::ImportValue` — references a `CfnOutput` by `Export.Name`
+- `Fn::GetStackOutput` — references a `CfnOutput` by its **logical id**, no Export required (CloudFormation's newer intrinsic; cdkd resolves it from the producer's S3 state record)
 
 ## Architecture
 
@@ -11,8 +14,8 @@ This example consists of two stacks:
    - Exports the bucket name and ARN using `CfnOutput` with `exportName`
 
 2. **ConsumerStack** - Imports and uses the exported values
-   - Uses `Fn::ImportValue` to import bucket name and ARN
-   - Demonstrates that cross-stack references work correctly
+   - Uses `Fn::ImportValue` to import bucket name and ARN by `Export.Name`
+   - Uses `Fn::GetStackOutput` (injected via `addPropertyOverride` to stay compatible with older `aws-cdk-lib`) to read the same bucket name back by **the producer output's logical id** — no Export needed for this path
 
 ## Setup
 
@@ -67,7 +70,8 @@ node dist/cli.js deploy \
    - Reads exported values from exporter stack's state file
    - Resolves `Fn::ImportValue('SharedBucketName')` to actual bucket name
    - Resolves `Fn::ImportValue('SharedBucketArn')` to actual bucket ARN
-   - Outputs show the imported values
+   - Resolves `Fn::GetStackOutput { StackName: "CdkdExporterStack", OutputName: "BucketNameExport" }` to the same bucket name and stores it in an SSM Parameter (proves Fn::GetStackOutput works for in-resource property values, not just Outputs)
+   - Outputs show both the imported values and the SSM Parameter name
 
 ## Cleanup
 
@@ -91,20 +95,9 @@ node dist/cli.js destroy \
 
 ## How It Works
 
-cdkd implements `Fn::ImportValue` by:
+cdkd implements both intrinsics on top of its S3 state:
 
-1. **Export**: When a stack has `CfnOutput` with `exportName`, cdkd saves the resolved value in the state file under `exports`:
-   ```json
-   {
-     "exports": {
-       "SharedBucketName": "actual-bucket-name-xyz"
-     }
-   }
-   ```
+- `Fn::ImportValue` searches every stack's `outputs` for a key matching the requested `Export.Name`. The export name is stored alongside the output's logical id when `Export.Name` is set on a `CfnOutput`.
+- `Fn::GetStackOutput` reads the producer's state record directly at `s3://<bucket>/cdkd/<StackName>/<Region>/state.json` and returns `outputs[<OutputName>]` — `OutputName` is the **logical id** of the producer's `CfnOutput`. No `Export.Name` required, and `Region` may differ from the consumer's deploy region (same-account cross-region works because cdkd's state bucket is account-scoped, not region-scoped). Cross-account `RoleArn` is currently rejected with a clear error.
 
-2. **Import**: When another stack uses `Fn::ImportValue`, cdkd:
-   - Queries all stacks in the state bucket
-   - Finds the export with matching name
-   - Resolves the imported value during template processing
-
-This allows cross-stack references to work without CloudFormation stacks!
+This allows cross-stack and cross-region references to work without CloudFormation stacks!

--- a/tests/integration/cross-stack-references/lib/consumer-stack.ts
+++ b/tests/integration/cross-stack-references/lib/consumer-stack.ts
@@ -1,23 +1,29 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
 
 /**
  * Consumer stack that imports values from the exporter stack
  *
- * This stack uses Fn::ImportValue to reference values exported
- * by the ExporterStack, demonstrating cross-stack references.
+ * Demonstrates two cross-stack reference mechanisms side-by-side:
+ *  1. Fn::ImportValue via Export.Name (the classic pattern)
+ *  2. Fn::GetStackOutput via OutputName (CFN's newer intrinsic; no Export
+ *     required, supports cross-region in same-account, supports
+ *     cross-account via RoleArn — cdkd implements 1 + 2 except
+ *     RoleArn-based cross-account, which is rejected with a clear error)
+ *
+ * The Fn::GetStackOutput intrinsic is injected via addPropertyOverride
+ * because the `cdk.Fn.getStackOutput` helper only ships in newer
+ * aws-cdk-lib versions; the synthesized template ends up identical.
  */
 export class ConsumerStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    // Import bucket name using Fn::ImportValue
+    // ---- (1) Fn::ImportValue path -------------------------------------------
     const importedBucketName = cdk.Fn.importValue('SharedBucketName');
-
-    // Import bucket ARN using Fn::ImportValue
     const importedBucketArn = cdk.Fn.importValue('SharedBucketArn');
 
-    // Output the imported values to verify they were resolved correctly
     new cdk.CfnOutput(this, 'ImportedBucketName', {
       value: importedBucketName,
       description: 'Bucket name imported via Fn::ImportValue',
@@ -28,12 +34,35 @@ export class ConsumerStack extends cdk.Stack {
       description: 'Bucket ARN imported via Fn::ImportValue',
     });
 
-    // Create a parameter that uses the imported bucket name
-    // This tests that Fn::ImportValue works in resource properties
     new cdk.CfnParameter(this, 'VerifyImport', {
       type: 'String',
       default: importedBucketName,
       description: 'Parameter using imported bucket name to verify resolution',
+    });
+
+    // ---- (2) Fn::GetStackOutput path ----------------------------------------
+    // Read the same output back through Fn::GetStackOutput (by logical id of
+    // the CfnOutput on the producer side, NOT the Export.Name). cdkd resolves
+    // it from the producer stack's S3 state record at deploy time. Region is
+    // omitted -> defaults to the consumer's deploy region (same-account
+    // same-region case here, which is the simplest of the three the new
+    // intrinsic supports: same-region, same-account cross-region, and
+    // cross-account-via-RoleArn).
+    const bucketNameParam = new ssm.CfnParameter(this, 'BucketNameViaGetStackOutput', {
+      type: 'String',
+      value: 'placeholder-replaced-at-deploy-time',
+      description: 'Bucket name resolved via Fn::GetStackOutput',
+    });
+    bucketNameParam.addPropertyOverride('Value', {
+      'Fn::GetStackOutput': {
+        StackName: 'CdkdExporterStack',
+        OutputName: 'BucketNameExport',
+      },
+    });
+
+    new cdk.CfnOutput(this, 'BucketNameViaGetStackOutputName', {
+      value: bucketNameParam.ref,
+      description: 'SSM Parameter name holding the Fn::GetStackOutput-resolved bucket name',
     });
   }
 }

--- a/tests/unit/deployment/intrinsic-functions.test.ts
+++ b/tests/unit/deployment/intrinsic-functions.test.ts
@@ -465,3 +465,364 @@ describe('IntrinsicFunctionResolver - Fn::GetAZs', () => {
     );
   });
 });
+
+describe('IntrinsicFunctionResolver - Fn::GetStackOutput', () => {
+  let resolver: IntrinsicFunctionResolver;
+
+  beforeEach(() => {
+    resolver = new IntrinsicFunctionResolver('us-east-1');
+    resetAccountInfoCache();
+  });
+
+  function makeStateBackend(
+    states: Record<string, Record<string, { outputs: Record<string, unknown> }>>
+  ) {
+    return {
+      getState: vi.fn(async (stackName: string, region: string) => {
+        const byRegion = states[stackName];
+        if (!byRegion) return null;
+        const entry = byRegion[region];
+        if (!entry) return null;
+        return {
+          state: {
+            version: 2 as const,
+            stackName,
+            region,
+            resources: {},
+            outputs: entry.outputs,
+            lastModified: 0,
+          },
+          etag: '"abc"',
+        };
+      }),
+    } as unknown as ResolverContext['stateBackend'];
+  }
+
+  it('resolves a same-account same-region output', async () => {
+    const stateBackend = makeStateBackend({
+      Producer: {
+        'us-east-1': { outputs: { ApiUrl: 'https://example.com' } },
+      },
+    });
+
+    const context: ResolverContext = {
+      template: { Resources: {} },
+      resources: {},
+      stateBackend,
+      stackName: 'Consumer',
+    };
+
+    const result = await resolver.resolve(
+      {
+        'Fn::GetStackOutput': {
+          StackName: 'Producer',
+          OutputName: 'ApiUrl',
+        },
+      },
+      context
+    );
+
+    expect(result).toBe('https://example.com');
+  });
+
+  it('resolves a same-account cross-region output', async () => {
+    const stateBackend = makeStateBackend({
+      Producer: {
+        'us-west-2': { outputs: { Endpoint: 'arn:aws:foo' } },
+      },
+    });
+
+    const context: ResolverContext = {
+      template: { Resources: {} },
+      resources: {},
+      stateBackend,
+      stackName: 'Consumer',
+    };
+
+    const result = await resolver.resolve(
+      {
+        'Fn::GetStackOutput': {
+          StackName: 'Producer',
+          Region: 'us-west-2',
+          OutputName: 'Endpoint',
+        },
+      },
+      context
+    );
+
+    expect(result).toBe('arn:aws:foo');
+    expect(stateBackend!.getState).toHaveBeenCalledWith('Producer', 'us-west-2');
+  });
+
+  it('defaults Region to the consumer deploy region when omitted', async () => {
+    const stateBackend = makeStateBackend({
+      Producer: {
+        'us-east-1': { outputs: { Value: 42 } },
+      },
+    });
+
+    const context: ResolverContext = {
+      template: { Resources: {} },
+      resources: {},
+      stateBackend,
+      stackName: 'Consumer',
+    };
+
+    const result = await resolver.resolve(
+      {
+        'Fn::GetStackOutput': {
+          StackName: 'Producer',
+          OutputName: 'Value',
+        },
+      },
+      context
+    );
+
+    expect(result).toBe(42);
+    expect(stateBackend!.getState).toHaveBeenCalledWith('Producer', 'us-east-1');
+  });
+
+  it('resolves nested intrinsics in StackName / OutputName / Region', async () => {
+    const stateBackend = makeStateBackend({
+      Producer: {
+        'us-west-2': { outputs: { Final: 'ok' } },
+      },
+    });
+
+    const context: ResolverContext = {
+      template: {
+        Resources: {},
+        Parameters: {},
+      },
+      resources: {},
+      parameters: {
+        ProducerStack: 'Producer',
+        ProducerRegion: 'us-west-2',
+        OutputKey: 'Final',
+      },
+      stateBackend,
+      stackName: 'Consumer',
+    };
+
+    const result = await resolver.resolve(
+      {
+        'Fn::GetStackOutput': {
+          StackName: { Ref: 'ProducerStack' },
+          Region: { Ref: 'ProducerRegion' },
+          OutputName: { Ref: 'OutputKey' },
+        },
+      },
+      context
+    );
+
+    expect(result).toBe('ok');
+  });
+
+  it('throws when StackName is missing', async () => {
+    const context: ResolverContext = {
+      template: { Resources: {} },
+      resources: {},
+      stateBackend: makeStateBackend({}),
+      stackName: 'Consumer',
+    };
+
+    await expect(
+      resolver.resolve(
+        { 'Fn::GetStackOutput': { OutputName: 'Foo' } },
+        context
+      )
+    ).rejects.toThrow('Fn::GetStackOutput: StackName is required');
+  });
+
+  it('throws when OutputName is missing', async () => {
+    const context: ResolverContext = {
+      template: { Resources: {} },
+      resources: {},
+      stateBackend: makeStateBackend({}),
+      stackName: 'Consumer',
+    };
+
+    await expect(
+      resolver.resolve(
+        { 'Fn::GetStackOutput': { StackName: 'Producer' } },
+        context
+      )
+    ).rejects.toThrow('Fn::GetStackOutput: OutputName is required');
+  });
+
+  it('throws when state backend is not provided', async () => {
+    const context: ResolverContext = {
+      template: { Resources: {} },
+      resources: {},
+      stackName: 'Consumer',
+    };
+
+    await expect(
+      resolver.resolve(
+        {
+          'Fn::GetStackOutput': {
+            StackName: 'Producer',
+            OutputName: 'Foo',
+          },
+        },
+        context
+      )
+    ).rejects.toThrow(
+      'Fn::GetStackOutput: state backend is required for cross-stack references'
+    );
+  });
+
+  it('throws when producer stack is not in state', async () => {
+    const stateBackend = makeStateBackend({});
+
+    const context: ResolverContext = {
+      template: { Resources: {} },
+      resources: {},
+      stateBackend,
+      stackName: 'Consumer',
+    };
+
+    await expect(
+      resolver.resolve(
+        {
+          'Fn::GetStackOutput': {
+            StackName: 'Producer',
+            Region: 'us-east-1',
+            OutputName: 'Foo',
+          },
+        },
+        context
+      )
+    ).rejects.toThrow(
+      "Fn::GetStackOutput: stack 'Producer' not found in region 'us-east-1'"
+    );
+  });
+
+  it('throws when output is missing from the producer stack', async () => {
+    const stateBackend = makeStateBackend({
+      Producer: {
+        'us-east-1': { outputs: { Other: 'x' } },
+      },
+    });
+
+    const context: ResolverContext = {
+      template: { Resources: {} },
+      resources: {},
+      stateBackend,
+      stackName: 'Consumer',
+    };
+
+    await expect(
+      resolver.resolve(
+        {
+          'Fn::GetStackOutput': {
+            StackName: 'Producer',
+            OutputName: 'Missing',
+          },
+        },
+        context
+      )
+    ).rejects.toThrow(
+      "Fn::GetStackOutput: output 'Missing' not found in stack 'Producer' (us-east-1). Available outputs: Other"
+    );
+  });
+
+  it('rejects RoleArn (cross-account not yet supported)', async () => {
+    const context: ResolverContext = {
+      template: { Resources: {} },
+      resources: {},
+      stateBackend: makeStateBackend({}),
+      stackName: 'Consumer',
+    };
+
+    await expect(
+      resolver.resolve(
+        {
+          'Fn::GetStackOutput': {
+            StackName: 'Producer',
+            Region: 'us-west-2',
+            OutputName: 'Foo',
+            RoleArn: 'arn:aws:iam::222222222222:role/CrossAccount',
+          },
+        },
+        context
+      )
+    ).rejects.toThrow(
+      'Fn::GetStackOutput: cross-account references via RoleArn are not yet supported'
+    );
+  });
+
+  it('rejects self-reference (same stack name AND same region)', async () => {
+    const stateBackend = makeStateBackend({
+      Consumer: {
+        'us-east-1': { outputs: { Foo: 'x' } },
+      },
+    });
+
+    const context: ResolverContext = {
+      template: { Resources: {} },
+      resources: {},
+      stateBackend,
+      stackName: 'Consumer',
+    };
+
+    await expect(
+      resolver.resolve(
+        {
+          'Fn::GetStackOutput': {
+            StackName: 'Consumer',
+            OutputName: 'Foo',
+          },
+        },
+        context
+      )
+    ).rejects.toThrow(
+      "Fn::GetStackOutput: cannot reference own stack 'Consumer' in the same region 'us-east-1'"
+    );
+  });
+
+  it('allows same-stackName cross-region reference', async () => {
+    // Two regions of the same stackName have independent state — referencing
+    // the other region's record is legitimate, not a self-reference.
+    const stateBackend = makeStateBackend({
+      Shared: {
+        'us-west-2': { outputs: { Foo: 'from-west' } },
+      },
+    });
+
+    const context: ResolverContext = {
+      template: { Resources: {} },
+      resources: {},
+      stateBackend,
+      stackName: 'Shared',
+    };
+
+    const result = await resolver.resolve(
+      {
+        'Fn::GetStackOutput': {
+          StackName: 'Shared',
+          Region: 'us-west-2',
+          OutputName: 'Foo',
+        },
+      },
+      context
+    );
+
+    expect(result).toBe('from-west');
+  });
+
+  it('throws on non-object argument shape', async () => {
+    const context: ResolverContext = {
+      template: { Resources: {} },
+      resources: {},
+      stateBackend: makeStateBackend({}),
+      stackName: 'Consumer',
+    };
+
+    await expect(
+      resolver.resolve({ 'Fn::GetStackOutput': 'not-an-object' }, context)
+    ).rejects.toThrow(
+      'Fn::GetStackOutput: argument must be an object with StackName/OutputName/Region/RoleArn'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for the new CloudFormation intrinsic `Fn::GetStackOutput` (introduced alongside [aws-cdk PR #37724](https://github.com/aws/aws-cdk/pull/37724)).

- **Resolver** ([src/deployment/intrinsic-function-resolver.ts](src/deployment/intrinsic-function-resolver.ts)) reads the producer stack's outputs straight out of cdkd's S3 state record at `cdkd/{StackName}/{Region}/state.json`. No `Export` is required, and same-account cross-region works out of the box because the state bucket is account-scoped, not region-scoped.
- **Cross-account `RoleArn`** is rejected with an actionable error: cdkd reads S3 state instead of `cloudformation:DescribeStacks`, so cross-account would require assuming the role and reading the producer account's separate state bucket — explicitly not yet implemented (we surface the limit instead of silently downgrading).
- Handles nested intrinsics in every parameter (`StackName` / `OutputName` / `Region` / `RoleArn`) and rejects self-reference (same stack name AND same region).
- 13 new unit tests cover all branches; 1212 total tests pass.

## Integration test

Extends `tests/integration/cross-stack-references` with an SSM Parameter that resolves its `Value` via `Fn::GetStackOutput`. The intrinsic is injected via `addPropertyOverride` because the `cdk.Fn.getStackOutput` helper only ships in newer `aws-cdk-lib` versions; the synthesized template ends up identical.

## Live-test evidence (us-east-1, real AWS)

- `cdkd deploy CdkdExporterStack` — S3 bucket created
- `cdkd deploy CdkdConsumerStack` — resolved `Fn::GetStackOutput: StackName=CdkdExporterStack, Region=us-east-1, OutputName=BucketNameExport -> "cdkdexporterstack-sharedbucket60d199d6"` and created the SSM Parameter
- `aws ssm get-parameter --name CdkdConsumerStack-BucketNameViaGetStackOutput` returned `cdkdexporterstack-sharedbucket60d199d6` (matches the producer's bucket name)
- `cdkd destroy` of both stacks: 0 errors, 0 orphans (S3 / SSM / state bucket all empty after cleanup)

## Docs

- `CLAUDE.md`, `README.md`, `docs/architecture.md`, `docs/troubleshooting.md` — all intrinsic lists and feature matrices updated, with a note on the cross-account limitation.

## Retrospective

Added `feedback_inject_intrinsic_via_override.md` memory: when integ-testing a CFN intrinsic that the integ's pinned `aws-cdk-lib` doesn't expose yet as a `cdk.Fn.*` helper, inject the raw JSON via `CfnResource.addPropertyOverride` instead of bumping `aws-cdk-lib` or calling private CDK APIs.

## Test plan

- [x] `pnpm run typecheck`, `pnpm run lint`, `pnpm run build`
- [x] `npx vitest --run` — 102 files, 1212 tests pass
- [x] Integration test deploy + destroy verified against real AWS (us-east-1)
- [x] No leftover state / buckets / SSM Parameters after destroy
