### PR TITLE
docs(import): move full Importing guide from README to docs/import.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ pnpm run typecheck
 
   **`provider.import` support coverage**: see [docs/import.md](docs/import.md) for the full per-resource-type list (auto-lookup vs override-only vs CC-API fallback vs unsupported). Single source of truth — when adding `import()` support to a provider, update that file. Keep entries one-per-line so parallel PRs don't conflict on rebase.
 
-  **`cdkd import` vs upstream `cdk import` — parity notes** (the README has the full matrix; this is a quick checklist when working on the import code path):
+  **`cdkd import` vs upstream `cdk import` — parity notes** (see [docs/import.md](docs/import.md) for the full matrix; this is a quick checklist when working on the import code path):
 
   - **Mechanism is per-resource SDK calls, not a CloudFormation changeset.** `cdkd import` is therefore **not atomic**. `import.ts` collects per-resource outcomes (`imported` / `skipped-not-found` / `skipped-no-impl` / `skipped-out-of-scope` / `failed`) and only writes state after a final confirmation (`--yes` to skip). A partial import can be backed out with `cdkd state orphan <stack>`.
   - **No interactive prompt for missing IDs.** Upstream's TTY default prompts per resource; cdkd looks IDs up by `aws:cdk:path` tag (in `auto` / `hybrid` modes) or treats them as `out of scope` (in selective mode). The only prompt is the final "write state?" gate.

--- a/README.md
+++ b/README.md
@@ -431,8 +431,8 @@ cdkd destroy --all --force
 cdkd force-unlock MyStack
 
 # Adopt already-deployed AWS resources into cdkd state.
-# See "Importing existing resources" below for the full guide (auto / selective /
-# hybrid modes, --resource overrides, --resource-mapping CDK CLI compatibility).
+# See docs/import.md for the full guide (auto / selective / hybrid modes,
+# --resource overrides, --resource-mapping CDK CLI compatibility).
 cdkd import MyStack --dry-run
 cdkd import MyStack --yes
 
@@ -614,262 +614,25 @@ Built on modern AWS tooling:
 
 ## Importing existing resources
 
-`cdkd import` adopts AWS resources that are already deployed (e.g. via
-`cdk deploy`, manual creation, or another tool) into cdkd state, so the
-next `cdkd deploy` updates them in-place instead of trying to CREATE
-duplicates.
-
-It reads the CDK app to find logical IDs, resource types, and
-dependencies, then matches each logical ID to a real AWS resource in
-one of three modes:
-
-All examples below assume cdkd reads the CDK app command from `cdk.json`
-(the typical case). Pass `--app "<command>"` only if you're running cdkd
-outside the CDK project directory or want to override `cdk.json`.
-
-### Mode 1: auto (default — no flags)
+`cdkd import` adopts AWS resources that are already deployed (via
+`cdk deploy`, manual creation, or another tool) into cdkd state so the
+next `cdkd deploy` updates them in-place instead of CREATEing duplicates.
 
 ```bash
-cdkd import MyStack
-```
+# Adopt a whole stack previously deployed by cdk deploy (tag-based auto-lookup).
+cdkd import MyStack --yes
 
-Imports **every** resource in the synthesized template by tag. cdkd
-looks up each resource using its `aws:cdk:path` tag (which CDK
-automatically writes), so resources deployed by `cdk deploy` are found
-without any manual work. Useful for **adopting a whole stack** that was
-previously deployed by `cdk deploy`. This is cdkd's value-add over
-`cdk import` — CDK CLI does not have a tag-based bulk-import mode.
-
-### Mode 2: selective (CDK CLI parity — when explicit overrides are given)
-
-```bash
-# Import ONLY MyBucket; the other resources in the template are left alone.
+# Adopt only specific resources (CDK CLI parity).
 cdkd import MyStack --resource MyBucket=my-bucket-name
 
-# Several resources at once (--resource is repeatable).
-cdkd import MyStack \
-  --resource MyBucket=my-bucket-name \
-  --resource MyFn=my-function-name
-
-# CDK CLI compat: read overrides from a JSON file.
-cdkd import MyStack --resource-mapping mapping.json
-# mapping.json: { "MyBucket": "my-bucket-name", "MyFn": "my-function-name" }
-
-# CDK CLI compat: inline JSON (handy for non-TTY CI scripts).
-cdkd import MyStack --resource-mapping-inline '{"MyBucket":"my-bucket-name"}'
-
-# Capture cdkd's resolved logicalId→physicalId mapping for re-use.
-# Combine with --auto (or no flags) to record the tag-based lookups.
-cdkd import MyStack --record-resource-mapping ./mapping.json
-# mapping.json after the run: { "MyBucket": "my-bucket-name", ... }
-# Replay non-interactively in CI:
-cdkd import MyStack --resource-mapping ./mapping.json --yes
-```
-
-When at least one `--resource` flag (or a `--resource-mapping` /
-`--resource-mapping-inline` payload) is supplied, **only the listed
-resources are imported**. Every other resource in the template is
-reported as `out of scope` and left out of state — the next `cdkd
-deploy` will treat them as new and CREATE them. This matches the
-semantics of `cdk import --resource-mapping` /
-`--resource-mapping-inline`. cdkd validates that every override key is
-a real logical ID in the template; a typo aborts the run rather than
-silently importing nothing. `--resource-mapping` and
-`--resource-mapping-inline` are mutually exclusive — pick one source.
-
-Use selective mode when you want to **adopt a few specific resources**
-out of a larger stack — for example, you have one S3 bucket that was
-created manually that you want cdkd to manage, while the rest of the
-stack will be deployed fresh.
-
-**Selective mode is non-destructive.** When state already exists for
-the stack, listed resources are **merged** into it: unlisted entries
-already in state are preserved (no `--force` needed). `--force` is
-only required when a listed override would overwrite a resource
-already in state — that's the one case where the merge is destructive.
-This is the right command for "I have a deployed stack and want to
-adopt one more resource into it":
-
-```bash
-# Existing state has Queue + Topic; add Bucket without affecting them.
-cdkd import MyStack --resource MyBucket=my-bucket-name
-# Resulting state: Queue + Topic (preserved) + Bucket (newly imported).
-```
-
-### Mode 3: hybrid (`--auto` with overrides)
-
-```bash
-cdkd import MyStack \
-  --resource MyBucket=my-bucket-name \
-  --auto
-```
-
-Listed resources use the explicit physical ID you supplied; **every
-other resource still goes through tag-based auto-import**. Useful when
-you have one resource whose tag-based lookup is unreliable (e.g. you
-deleted and re-created it without the tag) but you want cdkd to find
-the rest by tag automatically.
-
-### Common flags
-
-| Flag | Purpose |
-| --- | --- |
-| `--dry-run` | Preview what would be imported. State is NOT written. |
-| `--yes` | Skip the confirmation prompt before writing state (and the CloudFormation retirement prompt under `--migrate-from-cloudformation`). |
-| `--force` | Confirm a destructive write to existing state — see below. |
-| `--migrate-from-cloudformation [name]` | After cdkd state is written, retire the source CloudFormation stack: inject `DeletionPolicy: Retain` + `UpdateReplacePolicy: Retain` on every resource via `UpdateStack`, then `DeleteStack`. AWS resources are NOT deleted. See [Migrating from `cdk deploy` (CloudFormation) to cdkd](#migrating-from-cdk-deploy-cloudformation-to-cdkd) below. |
-
-`--force` is only needed when the import would lose data:
-
-- **Auto / whole-stack mode + existing state**: required. The resource
-  map is rebuilt from the template, so any state entry not re-imported
-  is dropped.
-- **Selective mode + listed override already in state**: required.
-  The listed entry is overwritten with the new physical id.
-- **Selective mode without a conflict (pure merge)**: not required.
-  Unlisted state entries are preserved automatically.
-- **No existing state (first-time import)**: not required.
-
-### Migrating from `cdk deploy` (CloudFormation) to cdkd
-
-If a stack was previously deployed via `cdk deploy` (and is therefore
-managed by CloudFormation), `cdkd import --migrate-from-cloudformation` adopts
-the resources into cdkd state AND retires the source CloudFormation
-stack in one go:
-
-```bash
+# Migrate off CloudFormation in one shot — adopt + retire the source CFn stack.
 cdkd import MyStack --migrate-from-cloudformation --yes
 ```
 
-No `--resource <id>=<physical>` flags are needed — cdkd recovers each
-resource's physical id directly from CloudFormation via
-`DescribeStackResources`, so it works for both `cdk deploy`-managed and
-`cdkd deploy`-managed stacks. (cdkd's tag-based auto-lookup can't help
-here: upstream `cdk deploy` doesn't propagate the `aws:cdk:path` template
-metadata as a real AWS tag, and AWS reserves the `aws:` tag prefix so
-neither cdkd nor a CFn `UpdateStack` can add it on the way through.)
-
-The flow:
-
-1. `DescribeStackResources` — ask CloudFormation for every
-   `(LogicalResourceId, PhysicalResourceId)` pair in the source stack.
-   These are merged into the import overrides; user-supplied
-   `--resource <id>=<physical>` flags take precedence over CFn's view.
-2. `cdkd import` runs and adopts every resource into cdkd state via
-   each provider's `import()` method, using the CFn-resolved physical
-   ids as direct lookups.
-3. `cdkd` writes state.
-4. `DescribeStacks` + `GetTemplate` + `UpdateStack` to inject
-   `DeletionPolicy: Retain` and `UpdateReplacePolicy: Retain` on every
-   resource — a metadata-only update.
-5. `DeleteStack` — every resource is now `Retain`, so CloudFormation
-   walks the stack and skips every resource. The stack record disappears;
-   the underlying AWS resources are left intact and are now solely
-   managed by cdkd.
-
-Steps 1–5 all run inside the same lock so a concurrent `cdkd deploy`
-cannot race the in-flight migration.
-
-By default the CloudFormation stack name is taken from the cdkd stack
-name (the typical case — CDK uses the synthesized stack name as the CFn
-stack name). Pass an explicit value when the names differ:
-
-```bash
-cdkd import MyStack --migrate-from-cloudformation LegacyCfnStackName --yes
-```
-
-Limitations:
-
-- **JSON-only.** The Retain-policy injection in step 4 targets the CDK-
-  generated JSON template. Hand-written YAML CFn stacks fail with a
-  clear error; retire them manually.
-- **51,200-byte template limit.** The modified template is submitted
-  inline via `TemplateBody`. Stacks whose modified template exceeds
-  this limit fail in step 4 with a clear error pointing to the manual
-  3-step procedure (S3-backed `TemplateURL` fallback is a planned
-  follow-up). cdkd state has already been written at that point, so
-  re-runs and manual cleanup are both supported.
-- **Not compatible with `--dry-run`.** The post-state-write
-  `UpdateStack` + `DeleteStack` are real side-effects and cannot be
-  faithfully simulated. Use plain `cdkd import --dry-run` to preview
-  per-resource import outcomes.
-- **Partial imports leave unmanaged resources.** If a resource cannot
-  be imported (no provider, AWS not-found, etc.), `DeleteStack` skips
-  it (Retain) and cdkd never wrote it into state — so the resource
-  exists in AWS but unmanaged by both CloudFormation and cdkd. cdkd
-  warns loudly when this happens; either re-import the missing
-  resources first or accept the orphaning intentionally.
-
-### After import
-
-Run `cdkd diff` to see how the imported state lines up with the
-template. If the resource's actual properties differ from the template,
-the next `cdkd deploy` will UPDATE them to match. If you imported only
-some resources (selective mode), the remaining template resources
-appear as `to create` in the diff.
-
-### Provider support
-
-Tag-based auto-lookup is implemented for the most-used resource types
-(S3 Bucket, Lambda Function, IAM Role, SNS Topic, SQS Queue, DynamoDB
-Table, Logs LogGroup, EventBridge EventBus, KMS Key/Alias, Secrets
-Manager Secret, SSM Parameter, EC2 VPC/Subnet/SecurityGroup, RDS,
-ECS Cluster/Service/TaskDefinition, CloudFront Distribution, Cognito
-User Pool — the full list is in [docs/import.md](docs/import.md)).
-For resource types without auto-lookup support (ApiGateway sub-resources,
-niche services, anything in Cloud Control API), use the explicit
-`--resource <id>=<physicalId>` override mode — selective mode handles
-exactly this case. Resource types whose provider does not implement
-import are reported as `unsupported` and skipped.
-
-### `cdkd import` vs upstream `cdk import`
-
-cdkd's `import` command mirrors the surface of upstream
-[`cdk import`](https://docs.aws.amazon.com/cdk/v2/guide/ref-cli-cmd-import.html)
-where it can, but the underlying mechanism is fundamentally different
-and a handful of upstream-only flags are not implemented. Use this
-table to predict behavior when migrating from `cdk import`.
-
-| Topic | `cdk import` (upstream) | `cdkd import` |
-| --- | --- | --- |
-| Mechanism | CloudFormation `CreateChangeSet` with `ResourcesToImport` — atomic, all-or-nothing. | Per-resource SDK calls (e.g. `s3:HeadBucket`, `lambda:GetFunction`, IAM `ListRoleTags`). **Not atomic.** |
-| Failure mode | Failed import rolls the changeset back; the stack is left unchanged. | Per-resource: `imported` / `skipped-not-found` / `skipped-no-impl` / `skipped-out-of-scope` / `failed` rows are summarized. State is written for whatever succeeded — but only after a confirmation prompt (or `--yes`), so a partial run is opt-in. To roll a partial import back, use `cdkd state orphan <stack>` (drops the state record only). |
-| Selective mode (`--resource-mapping <file>`) | Supported. Listed resources are imported; unlisted resources cause the changeset to fail. | Supported. Listed resources are imported; unlisted resources are reported as `out of scope` and left out of state (next `cdkd deploy` will CREATE them). |
-| Selective mode (`--resource <id>=<physical>` repeatable) | Not supported (upstream uses interactive prompts or a mapping file). | Supported as cdkd's CLI-friendly equivalent. |
-| `--resource-mapping-inline '<json>'` | Supported (use in non-TTY environments). | Supported. Same shape as `--resource-mapping <file>` but supplied as a string — useful for non-TTY CI scripts that do not want a separate file. Mutually exclusive with `--resource-mapping`. |
-| `--record-resource-mapping <file>` | Supported (writes the mapping the user typed at the prompt to a file for re-use). | Supported. Writes the resolved `{logicalId: physicalId}` map (covers explicit overrides AND cdkd's tag-based auto-lookup) to the file before the confirmation prompt. The file is produced even if the user says "no" or under `--dry-run`, so the resolved data is never thrown away. |
-| Interactive prompt for missing IDs | Default in TTY — prompts for every resource not covered by a mapping file. | **Not supported.** cdkd is non-interactive: missing logical IDs are looked up by `aws:cdk:path` tag in `auto` / `hybrid` modes, or skipped as `out of scope` in selective mode. The only prompt is the final "write state?" confirmation, which `--yes` skips. |
-| Typo'd logical ID | Aborts with a clear error before any AWS calls. | Aborts with a clear error before any AWS calls — checked against the synthesized template. |
-| Whole-stack tag-based import | **Not supported.** | **cdkd-specific.** With no flags, cdkd looks every resource up by its `aws:cdk:path` tag — the typical case for adopting a stack previously deployed by `cdk deploy`. |
-| Hybrid mode (overrides + tag fallback) | **Not supported.** | **cdkd-specific.** `--auto` together with `--resource` lets listed resources use the explicit physical id while everything else still goes through tag lookup. |
-| Nested stacks (`AWS::CloudFormation::Stack`) | Explicitly unsupported. | Also unsupported in practice — cdkd does not deploy nested CloudFormation stacks at all (no `AWS::CloudFormation::Stack` provider). The `Stack` resource itself would be reported as `unsupported`. CDK Stages (separate top-level stacks) are fine: pass the stack's display path or physical name as the positional argument. |
-| Bootstrap requirement | Bootstrap v12+ (deploy role needs to read the encrypted staging bucket). | cdkd's own state bucket; no CDK bootstrap version requirement. |
-| Resource-type coverage | Whatever [CloudFormation supports for import](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html). | The set of cdkd providers that implement `import()` (see [docs/import.md](docs/import.md) for the current list). For any other CC-API-supported type, use `--resource <id>=<physical>` to drive the Cloud Control API fallback. The two lists overlap heavily but are not identical. |
-| Confirmation prompt before writing state | n/a (CloudFormation operates atomically). | Yes — cdkd asks before writing the state file. Skip with `--yes`. |
-| `--force` | "Continue even if the diff includes updates or deletions" — about diff strictness. | "Confirm a destructive write to existing state" — required for auto/whole-stack rebuild and for overwriting a listed entry already in state; not required for a pure selective merge. **Same flag name, different meaning.** |
-| `--dry-run` | Implied by `--no-execute` (creates the changeset without executing). | Native: shows the import plan and exits without writing state. |
-
-#### Practical implications when migrating from `cdk import`
-
-- If you script around `--resource-mapping <file>`: behavior matches.
-  The file format (`{"LogicalId": "physical-id"}`) is the same.
-- If you script around `--resource-mapping-inline`: behavior matches.
-  The JSON shape is the same as `--resource-mapping <file>`.
-- If you script around `--record-resource-mapping <file>`: behavior
-  matches. cdkd writes the resolved `{logicalId: physicalId}` map to
-  the file before the confirmation prompt — and even if the user says
-  "no" or under `--dry-run` — so you can capture cdkd's tag-based
-  auto-lookup result and replay it via `--resource-mapping` in CI.
-- If your workflow relies on the interactive prompt: rewrite as
-  `--resource-mapping <file>`. cdkd will not prompt.
-- If you rely on atomic rollback: cdkd cannot offer that — its
-  per-resource model writes state only after the full pass completes
-  (and after confirmation), so a partial run is bounded, but if a
-  later resource fails after several earlier ones already returned
-  successfully and you confirm the write, those earlier ones are
-  in cdkd state. Use `cdkd state orphan <stack>` to back out.
-- If you import nested stacks: neither tool supports this. Convert
-  to top-level CDK stacks first.
+See **[docs/import.md](docs/import.md)** for the full guide: three import
+modes (auto / selective / hybrid), `--resource-mapping` CDK CLI
+compatibility, CloudFormation migration flow, provider coverage, and the
+parity matrix vs upstream `cdk import`.
 
 ## State Management
 

--- a/docs/import.md
+++ b/docs/import.md
@@ -1,16 +1,214 @@
-# `cdkd import` Provider Coverage
+# Importing existing resources
 
-This document lists every resource type whose cdkd provider implements
+`cdkd import` adopts AWS resources that are already deployed (e.g. via
+`cdk deploy`, manual creation, or another tool) into cdkd state, so the
+next `cdkd deploy` updates them in-place instead of trying to CREATE
+duplicates.
+
+It reads the CDK app to find logical IDs, resource types, and
+dependencies, then matches each logical ID to a real AWS resource in
+one of three modes.
+
+All examples below assume cdkd reads the CDK app command from `cdk.json`
+(the typical case). Pass `--app "<command>"` only if you're running cdkd
+outside the CDK project directory or want to override `cdk.json`.
+
+## Mode 1: auto (default — no flags)
+
+```bash
+cdkd import MyStack
+```
+
+Imports **every** resource in the synthesized template by tag. cdkd
+looks up each resource using its `aws:cdk:path` tag (which CDK
+automatically writes), so resources deployed by `cdk deploy` are found
+without any manual work. Useful for **adopting a whole stack** that was
+previously deployed by `cdk deploy`. This is cdkd's value-add over
+`cdk import` — CDK CLI does not have a tag-based bulk-import mode.
+
+## Mode 2: selective (CDK CLI parity — when explicit overrides are given)
+
+```bash
+# Import ONLY MyBucket; the other resources in the template are left alone.
+cdkd import MyStack --resource MyBucket=my-bucket-name
+
+# Several resources at once (--resource is repeatable).
+cdkd import MyStack \
+  --resource MyBucket=my-bucket-name \
+  --resource MyFn=my-function-name
+
+# CDK CLI compat: read overrides from a JSON file.
+cdkd import MyStack --resource-mapping mapping.json
+# mapping.json: { "MyBucket": "my-bucket-name", "MyFn": "my-function-name" }
+
+# CDK CLI compat: inline JSON (handy for non-TTY CI scripts).
+cdkd import MyStack --resource-mapping-inline '{"MyBucket":"my-bucket-name"}'
+
+# Capture cdkd's resolved logicalId→physicalId mapping for re-use.
+# Combine with --auto (or no flags) to record the tag-based lookups.
+cdkd import MyStack --record-resource-mapping ./mapping.json
+# mapping.json after the run: { "MyBucket": "my-bucket-name", ... }
+# Replay non-interactively in CI:
+cdkd import MyStack --resource-mapping ./mapping.json --yes
+```
+
+When at least one `--resource` flag (or a `--resource-mapping` /
+`--resource-mapping-inline` payload) is supplied, **only the listed
+resources are imported**. Every other resource in the template is
+reported as `out of scope` and left out of state — the next `cdkd
+deploy` will treat them as new and CREATE them. This matches the
+semantics of `cdk import --resource-mapping` /
+`--resource-mapping-inline`. cdkd validates that every override key is
+a real logical ID in the template; a typo aborts the run rather than
+silently importing nothing. `--resource-mapping` and
+`--resource-mapping-inline` are mutually exclusive — pick one source.
+
+Use selective mode when you want to **adopt a few specific resources**
+out of a larger stack — for example, you have one S3 bucket that was
+created manually that you want cdkd to manage, while the rest of the
+stack will be deployed fresh.
+
+**Selective mode is non-destructive.** When state already exists for
+the stack, listed resources are **merged** into it: unlisted entries
+already in state are preserved (no `--force` needed). `--force` is
+only required when a listed override would overwrite a resource
+already in state — that's the one case where the merge is destructive.
+This is the right command for "I have a deployed stack and want to
+adopt one more resource into it":
+
+```bash
+# Existing state has Queue + Topic; add Bucket without affecting them.
+cdkd import MyStack --resource MyBucket=my-bucket-name
+# Resulting state: Queue + Topic (preserved) + Bucket (newly imported).
+```
+
+## Mode 3: hybrid (`--auto` with overrides)
+
+```bash
+cdkd import MyStack \
+  --resource MyBucket=my-bucket-name \
+  --auto
+```
+
+Listed resources use the explicit physical ID you supplied; **every
+other resource still goes through tag-based auto-import**. Useful when
+you have one resource whose tag-based lookup is unreliable (e.g. you
+deleted and re-created it without the tag) but you want cdkd to find
+the rest by tag automatically.
+
+## Common flags
+
+| Flag | Purpose |
+| --- | --- |
+| `--dry-run` | Preview what would be imported. State is NOT written. |
+| `--yes` | Skip the confirmation prompt before writing state (and the CloudFormation retirement prompt under `--migrate-from-cloudformation`). |
+| `--force` | Confirm a destructive write to existing state — see below. |
+| `--migrate-from-cloudformation [name]` | After cdkd state is written, retire the source CloudFormation stack: inject `DeletionPolicy: Retain` + `UpdateReplacePolicy: Retain` on every resource via `UpdateStack`, then `DeleteStack`. AWS resources are NOT deleted. See [Migrating from `cdk deploy` (CloudFormation) to cdkd](#migrating-from-cdk-deploy-cloudformation-to-cdkd) below. |
+
+`--force` is only needed when the import would lose data:
+
+- **Auto / whole-stack mode + existing state**: required. The resource
+  map is rebuilt from the template, so any state entry not re-imported
+  is dropped.
+- **Selective mode + listed override already in state**: required.
+  The listed entry is overwritten with the new physical id.
+- **Selective mode without a conflict (pure merge)**: not required.
+  Unlisted state entries are preserved automatically.
+- **No existing state (first-time import)**: not required.
+
+## Migrating from `cdk deploy` (CloudFormation) to cdkd
+
+If a stack was previously deployed via `cdk deploy` (and is therefore
+managed by CloudFormation), `cdkd import --migrate-from-cloudformation` adopts
+the resources into cdkd state AND retires the source CloudFormation
+stack in one go:
+
+```bash
+cdkd import MyStack --migrate-from-cloudformation --yes
+```
+
+No `--resource <id>=<physical>` flags are needed — cdkd recovers each
+resource's physical id directly from CloudFormation via
+`DescribeStackResources`, so it works for both `cdk deploy`-managed and
+`cdkd deploy`-managed stacks. (cdkd's tag-based auto-lookup can't help
+here: upstream `cdk deploy` doesn't propagate the `aws:cdk:path` template
+metadata as a real AWS tag, and AWS reserves the `aws:` tag prefix so
+neither cdkd nor a CFn `UpdateStack` can add it on the way through.)
+
+The flow:
+
+1. `DescribeStackResources` — ask CloudFormation for every
+   `(LogicalResourceId, PhysicalResourceId)` pair in the source stack.
+   These are merged into the import overrides; user-supplied
+   `--resource <id>=<physical>` flags take precedence over CFn's view.
+2. `cdkd import` runs and adopts every resource into cdkd state via
+   each provider's `import()` method, using the CFn-resolved physical
+   ids as direct lookups.
+3. `cdkd` writes state.
+4. `DescribeStacks` + `GetTemplate` + `UpdateStack` to inject
+   `DeletionPolicy: Retain` and `UpdateReplacePolicy: Retain` on every
+   resource — a metadata-only update.
+5. `DeleteStack` — every resource is now `Retain`, so CloudFormation
+   walks the stack and skips every resource. The stack record disappears;
+   the underlying AWS resources are left intact and are now solely
+   managed by cdkd.
+
+Steps 1–5 all run inside the same lock so a concurrent `cdkd deploy`
+cannot race the in-flight migration.
+
+By default the CloudFormation stack name is taken from the cdkd stack
+name (the typical case — CDK uses the synthesized stack name as the CFn
+stack name). Pass an explicit value when the names differ:
+
+```bash
+cdkd import MyStack --migrate-from-cloudformation LegacyCfnStackName --yes
+```
+
+Limitations:
+
+- **JSON-only.** The Retain-policy injection in step 4 targets the CDK-
+  generated JSON template. Hand-written YAML CFn stacks fail with a
+  clear error; retire them manually.
+- **51,200-byte template limit.** The modified template is submitted
+  inline via `TemplateBody`. Stacks whose modified template exceeds
+  this limit fail in step 4 with a clear error pointing to the manual
+  3-step procedure (S3-backed `TemplateURL` fallback is a planned
+  follow-up). cdkd state has already been written at that point, so
+  re-runs and manual cleanup are both supported.
+- **Not compatible with `--dry-run`.** The post-state-write
+  `UpdateStack` + `DeleteStack` are real side-effects and cannot be
+  faithfully simulated. Use plain `cdkd import --dry-run` to preview
+  per-resource import outcomes.
+- **Partial imports leave unmanaged resources.** If a resource cannot
+  be imported (no provider, AWS not-found, etc.), `DeleteStack` skips
+  it (Retain) and cdkd never wrote it into state — so the resource
+  exists in AWS but unmanaged by both CloudFormation and cdkd. cdkd
+  warns loudly when this happens; either re-import the missing
+  resources first or accept the orphaning intentionally.
+
+## After import
+
+Run `cdkd diff` to see how the imported state lines up with the
+template. If the resource's actual properties differ from the template,
+the next `cdkd deploy` will UPDATE them to match. If you imported only
+some resources (selective mode), the remaining template resources
+appear as `to create` in the diff.
+
+## Provider coverage
+
+This section lists every resource type whose cdkd provider implements
 `import()`, grouped by how the import is resolved. Use it to decide
-whether your stack can be adopted with a bare `cdkd import MyStack` (all
-resources auto-resolve) or whether you need `--resource <id>=<physical>`
-overrides for some of them.
+whether your stack can be adopted with a bare `cdkd import MyStack`
+(all resources auto-resolve) or whether you need
+`--resource <id>=<physical>` overrides for some of them.
 
-For the surrounding workflow (modes, flags, CloudFormation migration),
-see the [Importing existing resources](../README.md#importing-existing-resources)
-section of the README.
+For resource types without auto-lookup support (ApiGateway
+sub-resources, niche services, anything in Cloud Control API), use the
+explicit `--resource <id>=<physicalId>` override mode — selective mode
+handles exactly this case. Resource types whose provider does not
+implement import are reported as `unsupported` and skipped.
 
-## Auto-lookup (tag-based, no flag needed)
+### Auto-lookup (tag-based, no flag needed)
 
 Resources here are looked up by their `aws:cdk:path` tag — cdkd lists
 the relevant AWS resources, finds the one whose tag matches the
@@ -72,7 +270,7 @@ template's logical id, and adopts it. Works under `auto` (default) and
 - AWS::S3Tables::Table
 - AWS::S3Vectors::VectorBucket
 
-## Override-only — no standalone identity / list API
+### Override-only — no standalone identity / list API
 
 These resource types have no AWS-side identity that cdkd can list and
 match on. Use `--resource <logicalId>=<physicalId>` (or
@@ -82,7 +280,7 @@ provide the physical id explicitly.
 - AWS::IAM::Policy (inline)
 - AWS::IAM::UserToGroupAddition
 
-## Override-only — sub-resources without per-resource taggable identity
+### Override-only — sub-resources without per-resource taggable identity
 
 Sub-resources of a parent (an API Gateway Method belongs to a Resource
 which belongs to a RestApi; a Route53 RecordSet belongs to a HostedZone)
@@ -106,7 +304,7 @@ are not independently taggable, so cdkd cannot find them by
 - AWS::ElasticLoadBalancingV2::Listener
 - AWS::EFS::MountTarget
 
-## Override-only — sub-resources / attachments
+### Override-only — sub-resources / attachments
 
 Attachment-style resources (a SNS Subscription pinning a Topic to an
 endpoint, a Lambda Permission granting a principal access to a function)
@@ -124,7 +322,7 @@ have no taggable identity either. Provide the physical id via
 - AWS::CloudFront::CloudFrontOriginAccessIdentity
 - AWS::BedrockAgentCore::Runtime (has `ListTagsForResource`; could grow auto-lookup later)
 
-## Cloud Control API fallback
+### Cloud Control API fallback
 
 Any other CC-API-supported resource type can be imported via the same
 `--resource <logicalId>=<physicalId>` override. cdkd does not run
@@ -132,7 +330,7 @@ auto-lookup over Cloud Control API by default — it would issue an
 `aws-cloudcontrol:ListResources` call per type, which is too expensive
 for whole-stack adoption.
 
-## Unsupported
+### Unsupported
 
 Resource types whose cdkd provider does not implement `import()` (or
 which have no provider at all) are reported as `unsupported` in the
@@ -142,8 +340,57 @@ nested CloudFormation stacks, so importing one is also unsupported.
 CDK Stages — separate top-level stacks under one app — are fine; pass
 the stack's display path or physical name as the positional argument.
 
-## Adding a new entry
+### Adding a new entry
 
 When adding `import()` support to a provider, add the resource type to
 the appropriate section above. Keep entries one-per-line so parallel
 PRs don't conflict on rebase.
+
+## `cdkd import` vs upstream `cdk import`
+
+cdkd's `import` command mirrors the surface of upstream
+[`cdk import`](https://docs.aws.amazon.com/cdk/v2/guide/ref-cli-cmd-import.html)
+where it can, but the underlying mechanism is fundamentally different
+and a handful of upstream-only flags are not implemented. Use this
+table to predict behavior when migrating from `cdk import`.
+
+| Topic | `cdk import` (upstream) | `cdkd import` |
+| --- | --- | --- |
+| Mechanism | CloudFormation `CreateChangeSet` with `ResourcesToImport` — atomic, all-or-nothing. | Per-resource SDK calls (e.g. `s3:HeadBucket`, `lambda:GetFunction`, IAM `ListRoleTags`). **Not atomic.** |
+| Failure mode | Failed import rolls the changeset back; the stack is left unchanged. | Per-resource: `imported` / `skipped-not-found` / `skipped-no-impl` / `skipped-out-of-scope` / `failed` rows are summarized. State is written for whatever succeeded — but only after a confirmation prompt (or `--yes`), so a partial run is opt-in. To roll a partial import back, use `cdkd state orphan <stack>` (drops the state record only). |
+| Selective mode (`--resource-mapping <file>`) | Supported. Listed resources are imported; unlisted resources cause the changeset to fail. | Supported. Listed resources are imported; unlisted resources are reported as `out of scope` and left out of state (next `cdkd deploy` will CREATE them). |
+| Selective mode (`--resource <id>=<physical>` repeatable) | Not supported (upstream uses interactive prompts or a mapping file). | Supported as cdkd's CLI-friendly equivalent. |
+| `--resource-mapping-inline '<json>'` | Supported (use in non-TTY environments). | Supported. Same shape as `--resource-mapping <file>` but supplied as a string — useful for non-TTY CI scripts that do not want a separate file. Mutually exclusive with `--resource-mapping`. |
+| `--record-resource-mapping <file>` | Supported (writes the mapping the user typed at the prompt to a file for re-use). | Supported. Writes the resolved `{logicalId: physicalId}` map (covers explicit overrides AND cdkd's tag-based auto-lookup) to the file before the confirmation prompt. The file is produced even if the user says "no" or under `--dry-run`, so the resolved data is never thrown away. |
+| Interactive prompt for missing IDs | Default in TTY — prompts for every resource not covered by a mapping file. | **Not supported.** cdkd is non-interactive: missing logical IDs are looked up by `aws:cdk:path` tag in `auto` / `hybrid` modes, or skipped as `out of scope` in selective mode. The only prompt is the final "write state?" confirmation, which `--yes` skips. |
+| Typo'd logical ID | Aborts with a clear error before any AWS calls. | Aborts with a clear error before any AWS calls — checked against the synthesized template. |
+| Whole-stack tag-based import | **Not supported.** | **cdkd-specific.** With no flags, cdkd looks every resource up by its `aws:cdk:path` tag — the typical case for adopting a stack previously deployed by `cdk deploy`. |
+| Hybrid mode (overrides + tag fallback) | **Not supported.** | **cdkd-specific.** `--auto` together with `--resource` lets listed resources use the explicit physical id while everything else still goes through tag lookup. |
+| Nested stacks (`AWS::CloudFormation::Stack`) | Explicitly unsupported. | Also unsupported in practice — cdkd does not deploy nested CloudFormation stacks at all (no `AWS::CloudFormation::Stack` provider). The `Stack` resource itself would be reported as `unsupported`. CDK Stages (separate top-level stacks) are fine: pass the stack's display path or physical name as the positional argument. |
+| Bootstrap requirement | Bootstrap v12+ (deploy role needs to read the encrypted staging bucket). | cdkd's own state bucket; no CDK bootstrap version requirement. |
+| Resource-type coverage | Whatever [CloudFormation supports for import](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html). | The set of cdkd providers that implement `import()` — see [Provider coverage](#provider-coverage) above. For any other CC-API-supported type, use `--resource <id>=<physical>` to drive the Cloud Control API fallback. The two lists overlap heavily but are not identical. |
+| Confirmation prompt before writing state | n/a (CloudFormation operates atomically). | Yes — cdkd asks before writing the state file. Skip with `--yes`. |
+| `--force` | "Continue even if the diff includes updates or deletions" — about diff strictness. | "Confirm a destructive write to existing state" — required for auto/whole-stack rebuild and for overwriting a listed entry already in state; not required for a pure selective merge. **Same flag name, different meaning.** |
+| `--dry-run` | Implied by `--no-execute` (creates the changeset without executing). | Native: shows the import plan and exits without writing state. |
+
+### Practical implications when migrating from `cdk import`
+
+- If you script around `--resource-mapping <file>`: behavior matches.
+  The file format (`{"LogicalId": "physical-id"}`) is the same.
+- If you script around `--resource-mapping-inline`: behavior matches.
+  The JSON shape is the same as `--resource-mapping <file>`.
+- If you script around `--record-resource-mapping <file>`: behavior
+  matches. cdkd writes the resolved `{logicalId: physicalId}` map to
+  the file before the confirmation prompt — and even if the user says
+  "no" or under `--dry-run` — so you can capture cdkd's tag-based
+  auto-lookup result and replay it via `--resource-mapping` in CI.
+- If your workflow relies on the interactive prompt: rewrite as
+  `--resource-mapping <file>`. cdkd will not prompt.
+- If you rely on atomic rollback: cdkd cannot offer that — its
+  per-resource model writes state only after the full pass completes
+  (and after confirmation), so a partial run is bounded, but if a
+  later resource fails after several earlier ones already returned
+  successfully and you confirm the write, those earlier ones are
+  in cdkd state. Use `cdkd state orphan <stack>` to back out.
+- If you import nested stacks: neither tool supports this. Convert
+  to top-level CDK stacks first.


### PR DESCRIPTION
## Summary

Follow-up to #112. README's `## Importing existing resources` section had grown to ~258 lines (full guide for three import modes, common flags, the CloudFormation migration flow, after-import diff, provider coverage, parity matrix vs upstream `cdk import`). At 1,038 lines total, README has been hard to navigate and the import guide dominates the second half. Move the entire section into [docs/import.md](docs/import.md):

- **[README.md](README.md)** — replace the long section with a short pointer block (three most common invocations + link). README drops from 1,038 to 803 lines.
- **[docs/import.md](docs/import.md)** — receives the full guide (modes / flags / migration / parity matrix). Pre-existing provider coverage content stays as the `## Provider coverage` section.
- **[CLAUDE.md](CLAUDE.md)** — update "the README has the full matrix" pointer to "see docs/import.md for the full matrix".

The content of the Importing section is preserved verbatim; only its location and the surrounding pointers change. Internal anchor links (e.g. `--migrate-from-cloudformation` -> `#migrating-from-cdk-deploy-cloudformation-to-cdkd`) move with the content and remain valid as same-file links inside docs/import.md. The "Resource-type coverage" cell in the parity table previously pointed to "[docs/import.md] for the current list" — now an in-doc `#provider-coverage` anchor.

Why a separate PR from #112: that PR moved only the per-resource-type list (a developer-facing reference). This PR moves the actual user-facing import guide. Splitting kept #112 focused and small enough to review at a glance.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes
- [x] `npx vitest --run` -- 104 files, 1246 tests pass
- [x] No code changes -- markdown reorg only
- [x] All cross-references verified: README -> docs/import.md (2 places), CLAUDE.md -> docs/import.md (already pointing there), intra-file anchors inside docs/import.md (`#migrating-...`, `#provider-coverage`)
