### PR TITLE
docs(readme): drop Architecture and Testing sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,16 +423,6 @@ LambdaStack
 
 Resources are dispatched as soon as their own dependencies complete (event-driven DAG). ServiceRole and Table run in parallel; DefaultPolicy starts the moment ServiceRole is done — without waiting for Table — and Handler starts the moment DefaultPolicy is done.
 
-## Architecture
-
-Built on modern AWS tooling:
-
-- **Synthesis orchestration** - Executes CDK app as subprocess (synthesis itself is done by aws-cdk-lib), parses Cloud Assembly (manifest.json) directly, context provider loop (missing context → SDK lookup → re-synthesize)
-- **Self-implemented asset publisher** - S3 file upload with ZIP packaging (via `archiver`) and ECR Docker image publishing
-- **AWS SDK v3** - Direct resource provisioning
-- **Cloud Control API** - Fallback resource management for types without SDK Providers
-- **S3 Conditional Writes** - State locking via `If-None-Match`/`If-Match`
-
 ## Importing existing resources
 
 `cdkd import` adopts AWS resources that are already deployed (via
@@ -503,19 +493,6 @@ After deployment, outputs are resolved and saved to the S3 state file:
 - CloudFormation: Outputs accessible via `aws cloudformation describe-stacks`
 - cdkd: Outputs saved in S3 state file (e.g., `s3://bucket/cdkd/MyStack/us-east-1/state.json`)
 - Both resolve intrinsic functions (Ref, Fn::GetAtt, etc.) to actual values
-
-## Testing
-
-- Unit tests covering all layers
-- Integration examples verified with real AWS deployments (see `tests/integration/`)
-- E2E test script for automated deploy/diff/update/destroy cycles
-
-```bash
-pnpm test                # Run unit tests
-pnpm run test:coverage   # With coverage report
-```
-
-See [docs/testing.md](docs/testing.md) for integration and E2E testing instructions.
 
 ## License
 


### PR DESCRIPTION
## Summary

Drop two README sections that don't serve end-users:

- **`## Architecture`** (5 bullets, "Built on modern AWS tooling: Synthesis orchestration / Self-implemented asset publisher / AWS SDK v3 / Cloud Control API / S3 Conditional Writes"): paraphrases the `## Features` list and the `## How it works` diagram. The docs/architecture.md pointer it might have served as already exists at the end of `## How it works`.
- **`## Testing`** (`pnpm test` commands + integration test link): test instructions are contributor concern, not user concern. They belong in [CONTRIBUTING.md](CONTRIBUTING.md) (which exists) and [docs/testing.md](docs/testing.md) (which the section already linked to). README readers are users running cdkd, not contributors developing it.

README drops from 522 to 499 lines.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes
- [x] `npx vitest --run` -- 104 files, 1246 tests pass
- [x] No code changes -- README-only
- [x] Verified no broken anchor references to `#architecture` or `#testing` elsewhere in the repo
