### PR TITLE
fix(lambda): derive inline ZipFile filename extension from runtime

### DIFF
--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -40,6 +40,22 @@ import type {
 } from '../../types/resource.js';
 
 /**
+ * Pick the inline-code filename for a Lambda runtime.
+ *
+ * CloudFormation's `Code.ZipFile` auto-zips inline code into a file named
+ * `index.<ext>` where the extension matches the runtime (`index.js` for
+ * `nodejs*`, `index.py` for `python*`). The Lambda SDK's `ZipFile` parameter
+ * accepts a binary zip but does no equivalent runtime-aware naming, so we
+ * have to mirror the CFn behavior here. Defaults to `index.js` since `nodejs`
+ * is the only `Code.fromInline`-supported runtime alongside `python` and is
+ * the more common case in CDK apps.
+ */
+export function inlineCodeFileNameForRuntime(runtime: string | undefined): string {
+  if (runtime?.startsWith('python')) return 'index.py';
+  return 'index.js';
+}
+
+/**
  * AWS Lambda Function Provider
  *
  * Implements resource provisioning for AWS::Lambda::Function using the Lambda SDK.
@@ -166,7 +182,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
       const createParams: CreateFunctionCommandInput = {
         FunctionName: functionName,
         Role: role,
-        Code: this.buildCode(code),
+        Code: this.buildCode(code, properties['Runtime'] as string | undefined),
         Handler: properties['Handler'] as string | undefined,
         Runtime: properties['Runtime'] as Runtime | undefined,
         Timeout: properties['Timeout'] as number | undefined,
@@ -295,7 +311,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
       const oldCode = previousProperties['Code'] as Record<string, unknown> | undefined;
 
       if (newCode && JSON.stringify(newCode) !== JSON.stringify(oldCode)) {
-        const builtCode = this.buildCode(newCode);
+        const builtCode = this.buildCode(newCode, properties['Runtime'] as string | undefined);
         const codeParams: UpdateFunctionCodeCommandInput = {
           FunctionName: physicalId,
           S3Bucket: builtCode.S3Bucket,
@@ -750,7 +766,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
   /**
    * Build Lambda Code parameter from CDK properties
    */
-  private buildCode(code: Record<string, unknown>): FunctionCode {
+  private buildCode(code: Record<string, unknown>, runtime: string | undefined): FunctionCode {
     const result: FunctionCode = {};
 
     if (code['S3Bucket']) {
@@ -766,7 +782,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
       // Lambda SDK expects a zip binary, not raw text.
       // CloudFormation's ZipFile property auto-zips inline code, but SDK does not.
       // Create a minimal zip with the code as index.* file.
-      result.ZipFile = this.createZipFromInlineCode(code['ZipFile'] as string);
+      result.ZipFile = this.createZipFromInlineCode(code['ZipFile'] as string, runtime);
     }
     if (code['ImageUri']) {
       result.ImageUri = code['ImageUri'] as string;
@@ -780,15 +796,15 @@ export class LambdaFunctionProvider implements ResourceProvider {
    *
    * CloudFormation's ZipFile property automatically wraps inline code in a zip,
    * but the Lambda SDK expects actual zip binary. This creates a minimal zip
-   * containing the code as index.* (matching the Handler).
+   * containing the code as index.* (extension derived from runtime — nodejs
+   * runtimes use index.js, python runtimes use index.py; see CFn ZipFile docs).
    */
-  private createZipFromInlineCode(code: string): Uint8Array {
+  private createZipFromInlineCode(code: string, runtime: string | undefined): Uint8Array {
     const fileData = Buffer.from(code, 'utf-8');
     const crc32 = this.crc32(fileData);
     const compressedData = zlib.deflateRawSync(fileData);
 
-    // Determine filename from handler or default to index.py
-    const fileName = Buffer.from('index.py');
+    const fileName = Buffer.from(inlineCodeFileNameForRuntime(runtime));
     const now = new Date();
     const modTime =
       ((now.getHours() << 11) | (now.getMinutes() << 5) | (now.getSeconds() >> 1)) & 0xffff;

--- a/tests/unit/provisioning/lambda-function-provider.test.ts
+++ b/tests/unit/provisioning/lambda-function-provider.test.ts
@@ -43,7 +43,11 @@ vi.mock('../../../src/utils/logger.js', () => {
   };
 });
 
-import { LambdaFunctionProvider } from '../../../src/provisioning/providers/lambda-function-provider.js';
+import {
+  LambdaFunctionProvider,
+  inlineCodeFileNameForRuntime,
+} from '../../../src/provisioning/providers/lambda-function-provider.js';
+import * as zlib from 'node:zlib';
 
 describe('LambdaFunctionProvider', () => {
   let provider: LambdaFunctionProvider;
@@ -697,6 +701,148 @@ describe('LambdaFunctionProvider', () => {
         'SnapStartResponse.OptimizationStatus'
       );
       expect(result).toBe('On');
+    });
+  });
+
+  describe('inline Code.ZipFile', () => {
+    // Reads the first entry's filename out of the hand-rolled ZIP that
+    // createZipFromInlineCode emits. Layout: local file header at offset 0,
+    // filename length at byte 26 (uint16 LE), filename at byte 30.
+    function readZipEntryName(buf: Uint8Array): string {
+      const view = Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength);
+      const nameLen = view.readUInt16LE(26);
+      return view.subarray(30, 30 + nameLen).toString('utf-8');
+    }
+
+    function readZipEntryBody(buf: Uint8Array): string {
+      const view = Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength);
+      const compressedSize = view.readUInt32LE(18);
+      const nameLen = view.readUInt16LE(26);
+      const extraLen = view.readUInt16LE(28);
+      const dataStart = 30 + nameLen + extraLen;
+      const compressed = view.subarray(dataStart, dataStart + compressedSize);
+      return zlib.inflateRawSync(compressed).toString('utf-8');
+    }
+
+    describe('inlineCodeFileNameForRuntime helper', () => {
+      it('returns index.py for python runtimes', () => {
+        expect(inlineCodeFileNameForRuntime('python3.12')).toBe('index.py');
+        expect(inlineCodeFileNameForRuntime('python3.9')).toBe('index.py');
+      });
+
+      it('returns index.js for nodejs runtimes', () => {
+        expect(inlineCodeFileNameForRuntime('nodejs20.x')).toBe('index.js');
+        expect(inlineCodeFileNameForRuntime('nodejs22.x')).toBe('index.js');
+      });
+
+      it('defaults to index.js for undefined or unknown runtimes', () => {
+        // Code.fromInline only supports nodejs + python; an unknown runtime
+        // here means a hand-crafted template. Default to nodejs because
+        // it's the most common in CDK apps.
+        expect(inlineCodeFileNameForRuntime(undefined)).toBe('index.js');
+        expect(inlineCodeFileNameForRuntime('ruby3.2')).toBe('index.js');
+      });
+    });
+
+    it('zips inline ZipFile as index.js for nodejs runtime', async () => {
+      // Regression test: previously the file was hardcoded as index.py
+      // regardless of runtime, breaking nodejs Lambdas with
+      // "Runtime.ImportModuleError: Cannot find module 'index'" because
+      // the runtime expects index.js / index.mjs and finds neither.
+      mockLambdaSend.mockResolvedValueOnce({
+        FunctionName: 'fn-inline-node',
+        FunctionArn: 'arn:aws:lambda:us-east-1:123:function:fn-inline-node',
+      });
+
+      const inlineSource = "exports.handler = async () => ({ statusCode: 200 });\n";
+      await provider.create('Fn', 'AWS::Lambda::Function', {
+        FunctionName: 'fn-inline-node',
+        Role: 'arn:aws:iam::123:role/exec',
+        Handler: 'index.handler',
+        Runtime: 'nodejs20.x',
+        Code: { ZipFile: inlineSource },
+      });
+
+      const cmd = mockLambdaSend.mock.calls[0][0];
+      expect(cmd).toBeInstanceOf(CreateFunctionCommand);
+      const zipBuf = cmd.input.Code.ZipFile as Uint8Array;
+      expect(readZipEntryName(zipBuf)).toBe('index.js');
+      expect(readZipEntryBody(zipBuf)).toBe(inlineSource);
+    });
+
+    it('zips inline ZipFile as index.py for python runtime', async () => {
+      mockLambdaSend.mockResolvedValueOnce({
+        FunctionName: 'fn-inline-py',
+        FunctionArn: 'arn:aws:lambda:us-east-1:123:function:fn-inline-py',
+      });
+
+      const inlineSource = "def handler(event, context):\n    return {'statusCode': 200}\n";
+      await provider.create('Fn', 'AWS::Lambda::Function', {
+        FunctionName: 'fn-inline-py',
+        Role: 'arn:aws:iam::123:role/exec',
+        Handler: 'index.handler',
+        Runtime: 'python3.12',
+        Code: { ZipFile: inlineSource },
+      });
+
+      const cmd = mockLambdaSend.mock.calls[0][0];
+      const zipBuf = cmd.input.Code.ZipFile as Uint8Array;
+      expect(readZipEntryName(zipBuf)).toBe('index.py');
+      expect(readZipEntryBody(zipBuf)).toBe(inlineSource);
+    });
+
+    it('zips inline ZipFile as index.js when runtime is omitted (safe default)', async () => {
+      mockLambdaSend.mockResolvedValueOnce({
+        FunctionName: 'fn-no-runtime',
+        FunctionArn: 'arn:aws:lambda:us-east-1:123:function:fn-no-runtime',
+      });
+
+      await provider.create('Fn', 'AWS::Lambda::Function', {
+        FunctionName: 'fn-no-runtime',
+        Role: 'arn:aws:iam::123:role/exec',
+        Handler: 'index.handler',
+        Code: { ZipFile: "exports.handler = async () => ({});\n" },
+      });
+
+      const cmd = mockLambdaSend.mock.calls[0][0];
+      const zipBuf = cmd.input.Code.ZipFile as Uint8Array;
+      expect(readZipEntryName(zipBuf)).toBe('index.js');
+    });
+
+    it('uses python extension on UpdateFunctionCode when runtime is python', async () => {
+      // 1) UpdateFunctionCode (Code changed)
+      // 2) GetFunction (waitUntilFunctionUpdatedV2)
+      // 3) GetFunction (final attribute fetch)
+      mockLambdaSend
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } })
+        .mockResolvedValueOnce({
+          Configuration: {
+            FunctionName: 'fn-py',
+            FunctionArn: 'arn:aws:lambda:us-east-1:123:function:fn-py',
+          },
+        });
+
+      await provider.update(
+        'Fn',
+        'fn-py',
+        'AWS::Lambda::Function',
+        {
+          Role: 'arn:aws:iam::123:role/exec',
+          Runtime: 'python3.12',
+          Code: { ZipFile: "def handler(e, c): return {}\n" },
+        },
+        {
+          Role: 'arn:aws:iam::123:role/exec',
+          Runtime: 'python3.12',
+          Code: { ZipFile: "def handler(e, c): pass\n" },
+        }
+      );
+
+      const updateCmd = mockLambdaSend.mock.calls[0][0];
+      expect(updateCmd).toBeInstanceOf(UpdateFunctionCodeCommand);
+      const zipBuf = updateCmd.input.ZipFile as Uint8Array;
+      expect(readZipEntryName(zipBuf)).toBe('index.py');
     });
   });
 });


### PR DESCRIPTION
## Summary

`Code.ZipFile` (CDK `lambda.Code.fromInline(...)`) was always zipped as `index.py` regardless of runtime, so a nodejs Lambda created via inline code failed at first invoke with:

```
Runtime.ImportModuleError: Cannot find module 'index'
Require stack:
- /var/runtime/index.mjs
```

The Node.js runtime expects `index.js` / `index.mjs`, not `index.py`. Existing integ tests using inline code (`cloudfront-function-url`, `vpc-lambda`) only exercise PYTHON_3_12, which is why this slipped through CI for so long.

Fix: extract `inlineCodeFileNameForRuntime(runtime)` and thread `Runtime` through `buildCode` → `createZipFromInlineCode`. Mirrors what CFn server-side does for `Code.ZipFile`: `python*` → `index.py`, everything else → `index.js`. Default to `index.js` since nodejs is the more common `Code.fromInline` target in CDK apps.

Discovered while validating a separate proposal (CloudFront Distribution / NAT Gateway parallel-deploy PoC) against `bench-cdk-sample`'s nodejs inline Lambda — the bench was measuring deploy time only and never invoking the deployed function, so the runtime error was invisible.

## Test plan

- [x] Unit tests cover the helper, both create / update paths, and the safe-default behavior. Each test extracts the actual ZIP bytes (`zlib.inflateRawSync`) and asserts both filename and body.
- [x] Full suite passes (104 files, 1275 tests).
- [x] Live-tested against real AWS via `bench-cdk-sample` (nodejs inline Lambda + VPC + CloudFront): deployed `CdkdBenchCdkSample` (398.59s, 0 errors), invoked `ApiFunction` directly with `aws lambda invoke` → `StatusCode 200`, body `{"message":"Hello from VPC Lambda"}` (no ImportModuleError). Destroyed cleanly (39 deleted, 0 errors), state + IAM + Lambda + ESM + ENI + VPC + CF orphan scans all empty.

## Retrospective — proposal for follow-up

The bug existed for months in cdkd because `/run-integ` validates *deploy succeeded + destroy succeeded*, not *Lambda actually executes*. `bench-cdk-sample` deploys with NODEJS_20_X inline code, so a single `aws lambda invoke` on the `ApiFunction` after deploy would have caught this. Suggested follow-up (separate PR, NOT in this one):

- Extend `/run-integ` skill: after the deploy step, for any `AWS::Lambda::Function` in the synth output, do a one-shot `aws lambda invoke --payload '{}' /tmp/<fn>.out` and fail if the response includes a `FunctionError`. Cost: ~1 sec per Lambda. Catches Runtime.* errors before destroy.

If you want me to spin that up as a separate PR after this one lands, say so.
