### PR TITLE
chore(release): fix releaseRules to recognize feat/fix/breaking commit types

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,7 +5,18 @@
       "@semantic-release/commit-analyzer",
       {
         "preset": "angular",
-        "releaseRules": [{ "breaking": true, "release": "minor" }]
+        "parserOpts": {
+          "headerPattern": "^(\\w*)(?:\\(([^)]+)\\))?(!)?: (.+)$",
+          "headerCorrespondence": ["type", "scope", "breaking", "subject"],
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+        },
+        "releaseRules": [
+          { "breaking": true, "release": "minor" },
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "revert": true, "release": "patch" }
+        ]
       }
     ],
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
## Summary

PR #127 (`feat(deploy)!: --aggressive-vpc-parallel default-on ...`) merged to main but **semantic-release said "no relevant changes"** and skipped the version bump. main is sitting at 98580c2 with no corresponding `chore(release)` commit, no new git tag, and no npm publish. This PR fixes the underlying `.releaserc.json` so the next release CI run picks up the unreleased breaking change as `0.33.0`.

## Root cause

`conventional-changelog-angular@8.3.1`'s `headerPattern`:

```js
/^(\w*)(?:\((.*)\))?: (.*)$/
```

does NOT match the `!` syntax in `feat(deploy)!: subject`. Verified with a direct conventional-commits-parser test: the parser silently fails to extract `type` / `scope` / `subject` when `!` is present, leaving the commit unclassified. Neither the previous custom `{ breaking: true, release: "minor" }` rule nor any default rule fires → "no relevant changes".

Compounding: semantic-release's `@semantic-release/commit-analyzer` treats custom `releaseRules` as a full **replacement** (not additive merge) of the preset's default rules. So the previous single-rule config was the ONLY rule — even a `feat:` commit without `!` would have silently no-op'd if the parser tripped on any quirk (it doesn't, but the config was thinner than it looked).

## Fix

Two changes in `.releaserc.json`:

1. **Override `parserOpts.headerPattern`** to capture `!` and put it into a `breaking` field on the parsed commit. Verified with a direct parser test:

   ```text
   feat(deploy)!: ...   → type=feat scope=deploy breaking=!
   feat: simple         → type=feat
   fix(scope): bug      → type=fix scope=scope
   feat!: x             → type=feat            breaking=!
   chore: x             → type=chore
   ```

2. **Add explicit `feat` / `fix` / `perf` / `revert` rules** so the rule list is self-documenting and matches the angular preset's defaults — except all `breaking` paths cap at `minor` (the project's 0.x policy).

```json
"releaseRules": [
  { "breaking": true, "release": "minor" },
  { "type": "feat", "release": "minor" },
  { "type": "fix", "release": "patch" },
  { "type": "perf", "release": "patch" },
  { "revert": true, "release": "patch" }
]
```

## 0.x "breaking → minor cap" policy preserved

No rule emits `major`. The angular default `{ breaking: true, release: "major" }` is fully replaced by these custom rules. Both:

- `feat!:` (header-`!` form) — captured as `breaking=!` but NOT lifted into `commit.notes`. The `breaking` rule (which fires on `commit.notes.length > 0`) doesn't match. The `type: feat → minor` rule does.
- `feat: subject\n\nBREAKING CHANGE: ...` (footer form) — `notes.length > 0`, `breaking → minor` fires.

Both paths land at `minor`. Major is unreachable.

## Effect on the next release CI

After merge, semantic-release re-analyzes commits since `v0.32.0`:

| Commit | Classified as | Rule | Release |
| --- | --- | --- | --- |
| `chore(release): fix releaseRules ...` (this commit) | type=chore | (no rule) | — |
| `98580c2 feat(deploy)!: --aggressive-vpc-parallel default-on (#127)` | type=feat, breaking=! | `type: feat → minor` | minor |

Aggregate: `minor` → **`0.33.0`**. PR #127's default-on flip ships properly with this release.

## Test plan

- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` — green.
- [x] `npx vitest --run` — 105 files, 1286 tests pass (no code changes).
- [x] **Direct parser test** (config validation): ran a one-off `node` script with `CommitParser` + the new `parserOpts.headerPattern` against five representative subjects (incl. PR #127's exact merge subject). All five extracted the expected `type` / `scope` / `breaking`. Output:

  ```text
  [feat(deploy)!: --aggressive-vpc-parallel default-on (opt out via --no-aggressive-vpc-parallel) (#127)]
    type=feat scope=deploy breaking=! subject=--aggressive-vpc-parallel default-on (op
  [feat: simple]
    type=feat scope=null breaking=null subject=simple
  [fix(scope): bug]
    type=fix scope=scope breaking=null subject=bug
  [feat!: breaking without scope]
    type=feat scope=null breaking=! subject=breaking without scope
  [chore: no release]
    type=chore scope=null breaking=null subject=no release
  ```

- Live-test (real semantic-release dry-run on main with the new config) is the canonical post-merge verification — semantic-release `--dry-run` is gated on the configured branch, so the actual signal will be the next release CI run on main. If `0.33.0` doesn't bump on merge, that's a regression worth investigating immediately.

## Retrospective

The angular preset's parser limitation around `!` is a known issue in the conventional-changelog ecosystem (the `conventionalcommits` preset added `!` support; angular hasn't). For this repo the cheapest fix is `parserOpts.headerPattern` override — a full preset switch would add a dep and change CHANGELOG formatting. Adding `!` support to `parserOpts` is a one-line change and preserves all other angular conventions.

Worth noting in memory so the next "release didn't bump" investigation goes faster: when semantic-release reports "no relevant changes" but you wrote a `feat!:` commit, suspect the `headerPattern` first.
