### PR TITLE
docs(readme): clarify bootstrap is one-time per AWS account

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,15 @@ alias cdkd="node $(pwd)/dist/cli.js"
 
 ## Quick Start
 
+> **First-time setup**: cdkd requires a one-time `cdkd bootstrap` per AWS
+> account before any other command will work — it creates the S3 state
+> bucket (`cdkd-state-{accountId}`) that cdkd uses to track deployed
+> resources. This is separate from `cdk bootstrap` (which sets up the
+> CDK asset bucket / ECR repo and is also required — see
+> [Prerequisites](#prerequisites)).
+
 ```bash
-# Bootstrap (creates S3 state bucket - only needed once per account/region)
+# Bootstrap (creates S3 state bucket — one-time setup, once per AWS account)
 cdkd bootstrap
 
 # List stacks in the CDK app


### PR DESCRIPTION
## Summary

- Fix the Quick Start comment from `account/region` to `account`. Since v0.7.0 the state bucket has been account-scoped (`cdkd-state-{accountId}`, no region suffix), so "once per account/region" was stale.
- Lift `cdkd bootstrap` out of the inline bash comment into a dedicated "First-time setup" callout. New users tended to miss that cdkd will not work without it, and that it is a separate one-time step from `cdk bootstrap` (which is also required — the callout points at Prerequisites).

Consistent with README L228, Prerequisites L177, and CLAUDE.md's "state bucket is account-scoped, region-free" wording.

## Test plan

- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` / `npx vitest --run` all pass (1325 tests / 109 files)
- [x] Docs-only change (no `src/` edits); no runtime behavior touched
- [x] Verified Markdown rendering on GitHub (callout + Prerequisites anchor link)
