### PR TITLE
docs(readme): add cdkd vs cdkd-state preface to Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,18 @@ That's it. cdkd reads `--app` from `cdk.json` and auto-resolves the state bucket
 
 ## Usage
 
+cdkd has two command families:
+
+- **Top-level commands** (`cdkd deploy` / `destroy` / `diff` / `synth` /
+  `list` / `import` / `orphan`) require a CDK app — they synthesize
+  a template to learn what they're operating on.
+- **`cdkd state ...` subcommands** (`state info` / `list` / `resources`
+  / `show` / `orphan` / `destroy` / `migrate` / `refresh-observed`)
+  operate on the S3 state bucket only and do NOT need the CDK app —
+  use them to inspect / clean up state when the source is gone or
+  you don't want to synth. `cdkd state destroy` is the CDK-app-free
+  counterpart of `cdkd destroy`.
+
 Options like `--app`, `--state-bucket`, and `--context` can be omitted if configured via `cdk.json` or environment variables (`CDKD_APP`, `CDKD_STATE_BUCKET`).
 
 ```bash


### PR DESCRIPTION
## Summary

The synth-driven (`cdkd deploy` / `destroy` / etc.) vs state-driven
(`cdkd state ...`) split was mentioned in scattered comments — drift
section, individual command annotations, the Orphan-vs-destroy
section — but the README had no upfront overview explaining the rule:
**which commands need a CDK app, which don't, and why**.

That gap means the rest of the README's "synth-driven" / "state-driven"
references work without an antecedent. CLAUDE.md already had a clean
explainer (`Top-level vs `state` subcommand split` in "Core Directories");
the README now matches.

## Change

Adds a 2-bullet preface at the top of `## Usage`:

```markdown
cdkd has two command families:

- **Top-level commands** (cdkd deploy / destroy / diff / synth /
  list / import / orphan) require a CDK app — they synthesize a
  template to learn what they're operating on.
- **cdkd state ... subcommands** (state info / list / resources / show
  / orphan / destroy / migrate / refresh-observed) operate on the S3
  state bucket only and do NOT need the CDK app — use them to inspect
  / clean up state when the source is gone or you don't want to synth.
  cdkd state destroy is the CDK-app-free counterpart of cdkd destroy.
```

12 lines added.

## Test plan

- [x] Docs-only change; no source touched
- [x] `pnpm run typecheck` / `lint` / `build` clean (sanity)
- [x] No new markdownlint warnings (the warnings reported in IDE are
      all pre-existing on unrelated tables / blockquotes; my added
      lines are bullets, not tables)
