### PR TITLE
test(drift): add structural placeholder-emission test convention for readCurrentState

### DIFF
--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -965,7 +965,33 @@ Use these placeholders consistently:
 
 **Wire-layer filtering** — the drift comparator does NOT apply per-type denylists for SDK provider results (those are reserved for the CC-API fallback path). If your provider's SDK response includes AWS-managed fields you don't want to surface, do NOT assign them in the first place.
 
-**Test convention**: each provider's `readCurrentState` test SHOULD have a "AWS returns minimum / empty response" case asserting that every user-controllable top-level key still appears with the expected placeholder. This is the structural defense against the "provider author forgets to emit a key" regression — without it, the bug only surfaces when a user runs drift on a resource configured exactly the way the test missed.
+**Test convention** (mandatory for any provider with `readCurrentState`): every provider test file MUST have an `it('emits placeholders for every user-controllable top-level key on AWS minimum response')` block that:
+
+1. Mocks the SDK to return the resource exists with **all optional fields undefined / empty** (just required fields like Name / ARN).
+2. Calls `readCurrentState(physicalId, logicalId, resourceType)`.
+3. Asserts `Object.keys(result).sort()` matches the **complete expected key list** for that resource type — not a subset.
+4. Spot-checks the placeholder values for the most fragile keys (`?? ''` strings, `?? []` arrays, `?? {}` objects, `?? <semantic-default>` scalars).
+
+Example template:
+
+```typescript
+it('emits placeholders for every user-controllable top-level key on AWS minimum response', async () => {
+  mockSend.mockResolvedValueOnce({
+    /* SDK response: required fields only, all optionals undefined */
+  });
+  const result = await provider.readCurrentState('phys-id', 'L', 'AWS::My::Type');
+  expect(Object.keys(result ?? {}).sort()).toEqual(
+    ['Key1', 'Key2', /* ... complete list ... */ ].sort()
+  );
+  expect(result?.Key1).toBe('');           // string placeholder
+  expect(result?.Key2).toEqual([]);        // array placeholder
+  expect(result?.Key3).toEqual({});        // object placeholder
+});
+```
+
+See [tests/unit/provisioning/lambda-function-provider-readcurrentstate.test.ts](../tests/unit/provisioning/lambda-function-provider-readcurrentstate.test.ts) and [tests/unit/provisioning/cognito-provider-readcurrentstate.test.ts](../tests/unit/provisioning/cognito-provider-readcurrentstate.test.ts) for canonical examples.
+
+This is the **structural defense** against the "provider author forgets to emit a key" regression class. Without it, the bug only surfaces when a user runs drift on a resource configured exactly the way the test missed (and PR review missed). The test makes silent regression mechanically impossible — a refactor that drops a placeholder fails the key-set assertion immediately.
 
 #### `getDriftUnknownPaths()` for unreadable fields
 

--- a/tests/unit/provisioning/apigatewayv2-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/apigatewayv2-provider-readcurrentstate.test.ts
@@ -238,4 +238,33 @@ describe('ApiGatewayV2Provider.readCurrentState', () => {
 
     expect(result?.Tags).toEqual([]);
   });
+
+  // Structural regression test for the always-emit-placeholder convention
+  // (docs/provider-development.md § 3b). Ensures every user-controllable
+  // top-level CFn key is present in the result even when AWS returns
+  // the resource with all optional fields undefined / empty. A future
+  // refactor that drops a placeholder for any of these keys must update
+  // this test consciously — silent regression is structurally prevented.
+  it('emits placeholders for every user-controllable top-level key on AWS minimum response (Api)', async () => {
+    mockSend.mockResolvedValueOnce({
+      ApiId: 'a',
+      ProtocolType: 'HTTP',
+      // Name / Description / CorsConfiguration / Tags deliberately undefined.
+    });
+
+    const result = await provider.readCurrentState(
+      'a',
+      'ApiLogical',
+      'AWS::ApiGatewayV2::Api'
+    );
+
+    expect(Object.keys(result ?? {}).sort()).toEqual(
+      ['CorsConfiguration', 'Description', 'Name', 'ProtocolType', 'Tags'].sort()
+    );
+    expect(result?.Name).toBe('');
+    expect(result?.Description).toBe('');
+    expect(result?.CorsConfiguration).toEqual({});
+    expect(result?.ProtocolType).toBe('HTTP');
+    expect(result?.Tags).toEqual([]);
+  });
 });

--- a/tests/unit/provisioning/appsync-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/appsync-provider-readcurrentstate.test.ts
@@ -127,6 +127,37 @@ describe('AppSyncProvider.readCurrentState', () => {
       );
       expect(result).toBeUndefined();
     });
+
+    // Structural regression test for the always-emit-placeholder convention
+    // (docs/provider-development.md § 3b). Ensures every user-controllable
+    // top-level CFn key is present in the result even when AWS returns
+    // the resource with all optional fields undefined / empty. A future
+    // refactor that drops a placeholder for any of these keys must update
+    // this test consciously — silent regression is structurally prevented.
+    it('emits placeholders for every user-controllable top-level key on AWS minimum response', async () => {
+      mockSend.mockResolvedValueOnce({
+        graphqlApi: {
+          name: 'api',
+          authenticationType: 'API_KEY',
+          // xrayEnabled / logConfig / tags deliberately undefined.
+        },
+      });
+
+      const result = await provider.readCurrentState(
+        'api-1',
+        'L',
+        'AWS::AppSync::GraphQLApi'
+      );
+
+      expect(Object.keys(result ?? {}).sort()).toEqual(
+        ['AuthenticationType', 'LogConfig', 'Name', 'Tags', 'XrayEnabled'].sort()
+      );
+      expect(result?.Name).toBe('api');
+      expect(result?.AuthenticationType).toBe('API_KEY');
+      expect(result?.XrayEnabled).toBe(false);
+      expect(result?.LogConfig).toEqual({});
+      expect(result?.Tags).toEqual([]);
+    });
   });
 
   describe('AWS::AppSync::DataSource', () => {

--- a/tests/unit/provisioning/cloudwatch-alarm-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/cloudwatch-alarm-provider-readcurrentstate.test.ts
@@ -137,4 +137,64 @@ describe('CloudWatchAlarmProvider.readCurrentState', () => {
     const result = await provider.readCurrentState('myalarm', 'L', 'AWS::CloudWatch::Alarm');
     expect(result?.Tags).toEqual([]);
   });
+
+  // Structural regression test for the always-emit-placeholder convention
+  // (docs/provider-development.md § 3b). Ensures every user-controllable
+  // top-level CFn key is present in the result even when AWS returns
+  // the resource with all optional fields undefined / empty. A future
+  // refactor that drops a placeholder for any of these keys must update
+  // this test consciously — silent regression is structurally prevented.
+  //
+  // ComparisonOperator / Threshold / EvaluationPeriods / Period /
+  // DatapointsToAlarm are NOT placeholders — the provider emits them
+  // only when present (alarm-shape-discriminator fields whose absence
+  // already implies "metric-math form"), so they're correctly absent
+  // from the minimum response.
+  it('emits placeholders for every user-controllable top-level key on AWS minimum response', async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        MetricAlarms: [
+          {
+            AlarmName: 'a',
+            AlarmArn: 'arn:aws:cloudwatch:us-east-1:1:alarm:a',
+            // Every other field deliberately undefined.
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ Tags: [] });
+
+    const result = await provider.readCurrentState('a', 'L', 'AWS::CloudWatch::Alarm');
+
+    expect(Object.keys(result ?? {}).sort()).toEqual(
+      [
+        'ActionsEnabled',
+        'AlarmActions',
+        'AlarmDescription',
+        'AlarmName',
+        'Dimensions',
+        'InsufficientDataActions',
+        'MetricName',
+        'Metrics',
+        'Namespace',
+        'OKActions',
+        'Statistic',
+        'Tags',
+        'TreatMissingData',
+        'Unit',
+      ].sort()
+    );
+    expect(result?.ActionsEnabled).toBe(true);
+    expect(result?.AlarmDescription).toBe('');
+    expect(result?.MetricName).toBe('');
+    expect(result?.Namespace).toBe('');
+    expect(result?.Statistic).toBe('');
+    expect(result?.TreatMissingData).toBe('');
+    expect(result?.Unit).toBe('');
+    expect(result?.AlarmActions).toEqual([]);
+    expect(result?.OKActions).toEqual([]);
+    expect(result?.InsufficientDataActions).toEqual([]);
+    expect(result?.Dimensions).toEqual([]);
+    expect(result?.Metrics).toEqual([]);
+    expect(result?.Tags).toEqual([]);
+  });
 });

--- a/tests/unit/provisioning/cognito-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/cognito-provider-readcurrentstate.test.ts
@@ -156,4 +156,80 @@ describe('CognitoUserPoolProvider.readCurrentState', () => {
 
     expect(result?.UserPoolTags).toEqual({});
   });
+
+  // Structural regression test for the always-emit-placeholder convention
+  // (docs/provider-development.md § 3b). Ensures every user-controllable
+  // top-level CFn key is present in the result even when AWS returns
+  // the resource with all optional fields undefined / empty. A future
+  // refactor that drops a placeholder for any of these keys must update
+  // this test consciously — silent regression is structurally prevented.
+  //
+  // Note: `Schema` is intentionally NOT in the expected key set. The
+  // provider only emits Schema when SchemaAttributes is non-empty
+  // (immutable on create — emitting an empty array here would surface
+  // as a phantom diff on every never-customized pool).
+  it('emits placeholders for every user-controllable top-level key on AWS minimum response', async () => {
+    mockSend.mockResolvedValueOnce({
+      UserPool: {
+        Id: 'us-east-1_x',
+        Name: 'p',
+        // Every other field deliberately undefined.
+      },
+    });
+
+    const result = await provider.readCurrentState(
+      'us-east-1_x',
+      'PoolLogical',
+      'AWS::Cognito::UserPool'
+    );
+
+    expect(Object.keys(result ?? {}).sort()).toEqual(
+      [
+        'AccountRecoverySetting',
+        'AdminCreateUserConfig',
+        'AliasAttributes',
+        'AutoVerifiedAttributes',
+        'DeletionProtection',
+        'DeviceConfiguration',
+        'EmailConfiguration',
+        'EmailVerificationMessage',
+        'EmailVerificationSubject',
+        'LambdaConfig',
+        'MfaConfiguration',
+        'Policies',
+        'SmsAuthenticationMessage',
+        'SmsConfiguration',
+        'SmsVerificationMessage',
+        'UserAttributeUpdateSettings',
+        'UserPoolAddOns',
+        'UserPoolName',
+        'UserPoolTags',
+        'UsernameAttributes',
+        'UsernameConfiguration',
+        'VerificationMessageTemplate',
+      ].sort()
+    );
+    expect(result?.UserPoolName).toBe('p');
+    expect(result?.AutoVerifiedAttributes).toEqual([]);
+    expect(result?.UsernameAttributes).toEqual([]);
+    expect(result?.AliasAttributes).toEqual([]);
+    expect(result?.Policies).toEqual({});
+    expect(result?.LambdaConfig).toEqual({});
+    expect(result?.MfaConfiguration).toBe('OFF');
+    expect(result?.AdminCreateUserConfig).toEqual({});
+    expect(result?.AccountRecoverySetting).toEqual({});
+    expect(result?.UserAttributeUpdateSettings).toEqual({});
+    expect(result?.DeletionProtection).toBe('INACTIVE');
+    expect(result?.EmailConfiguration).toEqual({});
+    expect(result?.SmsConfiguration).toEqual({});
+    expect(result?.VerificationMessageTemplate).toEqual({});
+    expect(result?.UsernameConfiguration).toEqual({});
+    expect(result?.DeviceConfiguration).toEqual({});
+    expect(result?.UserPoolAddOns).toEqual({});
+    expect(result?.EmailVerificationMessage).toBe('');
+    expect(result?.EmailVerificationSubject).toBe('');
+    expect(result?.SmsAuthenticationMessage).toBe('');
+    expect(result?.SmsVerificationMessage).toBe('');
+    expect(result?.UserPoolTags).toEqual({});
+  });
 });

--- a/tests/unit/provisioning/iam-role-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/iam-role-provider-readcurrentstate.test.ts
@@ -171,4 +171,42 @@ describe('IAMRoleProvider.readCurrentState', () => {
     const result = await provider.readCurrentState('role', 'Logical', 'AWS::IAM::Role');
     expect(result?.Tags).toEqual([]);
   });
+
+  // Structural regression test for the always-emit-placeholder convention
+  // (docs/provider-development.md § 3b). Ensures every user-controllable
+  // top-level CFn key is present in the result even when AWS returns
+  // the resource with all optional fields undefined / empty. A future
+  // refactor that drops a placeholder for any of these keys must update
+  // this test consciously — silent regression is structurally prevented.
+  it('emits placeholders for every user-controllable top-level key on AWS minimum response', async () => {
+    // GetRole — minimum fields only; Description / MaxSessionDuration /
+    // PermissionsBoundary deliberately undefined.
+    mockSend.mockResolvedValueOnce({
+      Role: {
+        RoleName: 'r',
+        Path: '/',
+        AssumeRolePolicyDocument: '%7B%7D',
+      },
+    });
+    // ListAttachedRolePolicies — none attached.
+    mockSend.mockResolvedValueOnce({ AttachedPolicies: [] });
+    // ListRoleTags — no tags.
+    mockSend.mockResolvedValueOnce({ Tags: [], IsTruncated: false });
+
+    const result = await provider.readCurrentState('r', 'Logical', 'AWS::IAM::Role');
+
+    expect(Object.keys(result ?? {}).sort()).toEqual(
+      [
+        'AssumeRolePolicyDocument',
+        'Description',
+        'ManagedPolicyArns',
+        'Path',
+        'RoleName',
+        'Tags',
+      ].sort()
+    );
+    expect(result?.Description).toBe('');
+    expect(result?.ManagedPolicyArns).toEqual([]);
+    expect(result?.Tags).toEqual([]);
+  });
 });

--- a/tests/unit/provisioning/lambda-function-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/lambda-function-provider-readcurrentstate.test.ts
@@ -163,4 +163,55 @@ describe('LambdaFunctionProvider.readCurrentState', () => {
 
     expect(result?.Tags).toEqual([]);
   });
+
+  // Structural regression test for the always-emit-placeholder convention
+  // (docs/provider-development.md § 3b). Ensures every user-controllable
+  // top-level CFn key is present in the result even when AWS returns
+  // the resource with all optional fields undefined / empty. A future
+  // refactor that drops a placeholder for any of these keys must update
+  // this test consciously — silent regression is structurally prevented.
+  it('emits placeholders for every user-controllable top-level key on AWS minimum response', async () => {
+    mockSend.mockResolvedValueOnce({
+      Configuration: {
+        FunctionName: 'fn',
+        Runtime: 'nodejs20.x',
+        Handler: 'index.handler',
+        Role: 'arn:aws:iam::123456789012:role/exec',
+        Timeout: 3,
+        MemorySize: 128,
+        PackageType: 'Zip',
+        // Description / Environment / Layers / Architectures / TracingConfig
+        // / EphemeralStorage / VpcConfig deliberately omitted.
+      },
+      Tags: undefined,
+    });
+
+    const result = await provider.readCurrentState('fn', 'Logical', 'AWS::Lambda::Function');
+
+    expect(Object.keys(result ?? {}).sort()).toEqual(
+      [
+        'Architectures',
+        'Description',
+        'Environment',
+        'FunctionName',
+        'Handler',
+        'Layers',
+        'MemorySize',
+        'PackageType',
+        'Role',
+        'Runtime',
+        'Tags',
+        'Timeout',
+        'TracingConfig',
+        'VpcConfig',
+      ].sort()
+    );
+    expect(result?.Description).toBe('');
+    expect(result?.Environment).toEqual({ Variables: {} });
+    expect(result?.Layers).toEqual([]);
+    expect(result?.Architectures).toEqual([]);
+    expect(result?.TracingConfig).toEqual({ Mode: 'PassThrough' });
+    expect(result?.VpcConfig).toEqual({ SubnetIds: [], SecurityGroupIds: [] });
+    expect(result?.Tags).toEqual([]);
+  });
 });

--- a/tests/unit/provisioning/s3-bucket-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/s3-bucket-provider-readcurrentstate.test.ts
@@ -158,4 +158,47 @@ describe('S3BucketProvider.readCurrentState', () => {
       },
     });
   });
+
+  // Structural regression test for the always-emit-placeholder convention
+  // (docs/provider-development.md § 3b). Ensures every user-controllable
+  // top-level CFn key is present in the result even when AWS returns
+  // the resource with all optional fields undefined / empty. A future
+  // refactor that drops a placeholder for any of these keys must update
+  // this test consciously — silent regression is structurally prevented.
+  //
+  // Note: the S3 provider's `Tags` key is set inside a try-block that
+  // catches `NoSuchTagSet` without writing the key — so the
+  // minimum-response shape deliberately does NOT include `Tags`. This
+  // mirrors the existing not-configured test above.
+  it('emits placeholders for every user-controllable top-level key on AWS minimum response', async () => {
+    // HeadBucket
+    mockSend.mockResolvedValueOnce({});
+    // GetBucketVersioning — never configured
+    mockSend.mockResolvedValueOnce({});
+    // GetBucketEncryption — feature absent
+    mockSend.mockRejectedValueOnce(notConfigured('ServerSideEncryptionConfigurationNotFoundError'));
+    // GetPublicAccessBlock — feature absent
+    mockSend.mockRejectedValueOnce(notConfigured('NoSuchPublicAccessBlockConfiguration'));
+    // GetBucketTagging — no tag set
+    mockSend.mockRejectedValueOnce(notConfigured('NoSuchTagSet'));
+
+    const result = await provider.readCurrentState('my-bucket', 'Logical', 'AWS::S3::Bucket');
+
+    expect(Object.keys(result ?? {}).sort()).toEqual(
+      [
+        'BucketEncryption',
+        'BucketName',
+        'PublicAccessBlockConfiguration',
+        'VersioningConfiguration',
+      ].sort()
+    );
+    expect(result?.VersioningConfiguration).toEqual({ Status: 'Suspended' });
+    expect(result?.BucketEncryption).toEqual({ ServerSideEncryptionConfiguration: [] });
+    expect(result?.PublicAccessBlockConfiguration).toEqual({
+      BlockPublicAcls: false,
+      BlockPublicPolicy: false,
+      IgnorePublicAcls: false,
+      RestrictPublicBuckets: false,
+    });
+  });
 });

--- a/tests/unit/provisioning/sns-topic-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/sns-topic-provider-readcurrentstate.test.ts
@@ -121,4 +121,40 @@ describe('SNSTopicProvider.readCurrentState', () => {
     const result = await provider.readCurrentState(TOPIC_ARN, 'Logical', 'AWS::SNS::Topic');
     expect(result?.Tags).toEqual([]);
   });
+
+  // Structural regression test for the always-emit-placeholder convention
+  // (docs/provider-development.md § 3b). Ensures every user-controllable
+  // top-level CFn key is present in the result even when AWS returns
+  // the resource with all optional fields undefined / empty. A future
+  // refactor that drops a placeholder for any of these keys must update
+  // this test consciously — silent regression is structurally prevented.
+  it('emits placeholders for every user-controllable top-level key on AWS minimum response', async () => {
+    // GetTopicAttributes — empty Attributes object (no DisplayName, no
+    // KmsMasterKeyId, no TracingConfig, no SignatureVersion, no
+    // FifoThroughputScope, no FifoTopic / ContentBasedDeduplication, no
+    // ArchivePolicy / DataProtectionPolicy).
+    mockSend.mockResolvedValueOnce({ Attributes: {} });
+    // ListTagsForResource — no user tags.
+    mockSend.mockResolvedValueOnce({ Tags: [] });
+
+    const result = await provider.readCurrentState(TOPIC_ARN, 'Logical', 'AWS::SNS::Topic');
+
+    expect(Object.keys(result ?? {}).sort()).toEqual(
+      [
+        'DisplayName',
+        'FifoThroughputScope',
+        'KmsMasterKeyId',
+        'SignatureVersion',
+        'Tags',
+        'TopicName',
+        'TracingConfig',
+      ].sort()
+    );
+    expect(result?.DisplayName).toBe('');
+    expect(result?.KmsMasterKeyId).toBe('');
+    expect(result?.TracingConfig).toBe('');
+    expect(result?.SignatureVersion).toBe('');
+    expect(result?.FifoThroughputScope).toBe('');
+    expect(result?.Tags).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Phase 1 (#152) added the always-emit-placeholder convention to 30+ SDK providers and documented it in [docs/provider-development.md § 3b](docs/provider-development.md). But the convention was reviewer-enforced only — a future refactor that silently dropped a placeholder would NOT fail any test, since each provider's existing tests covered specific scenarios (e.g. "emits empty Tags placeholder") but not the structural property "all user-controllable keys are present on AWS-minimum-response".

This PR closes that gap.

## Changes

### Per-provider structural test (8 providers)

Each touched provider's test file gets one new `it` block:

```typescript
it('emits placeholders for every user-controllable top-level key on AWS minimum response', async () => {
  // Mock: SDK returns resource exists, all optional fields undefined / empty
  mockSend.mockResolvedValueOnce({ ... });
  const result = await provider.readCurrentState(...);

  // Assert COMPLETE key set (not subset)
  expect(Object.keys(result ?? {}).sort()).toEqual([...].sort());

  // Spot-check placeholder values for fragile keys
  expect(result?.SomeKey).toBe('');           // string
  expect(result?.SomeArray).toEqual([]);      // array
  expect(result?.SomeObj).toEqual({});        // object
});
```

8 representative providers covered:

| Provider | Why | Keys verified |
| --- | --- | --- |
| **Lambda Function** | User-reported | 14 keys |
| **IAM Role** | User-reported | 6 keys |
| **SNS Topic** | User-reported | 7 keys |
| **S3 Bucket** | User-reported | 4 keys |
| **Cognito UserPool** | Largest single-resource surface | 22 keys |
| **CloudWatch Alarm** | Phase 2a representative | 14 keys |
| **AppSync GraphQLApi** | Phase 2b multi-resource representative | 5 keys |
| **ApiGatewayV2 Api** | Phase 2b multi-resource representative | 5 keys |

### Docs update

[docs/provider-development.md § 3b](docs/provider-development.md):

- The structural test is now **MANDATORY** (was "SHOULD")
- Template added inline
- Canonical examples linked (lambda-function + cognito)

## How this catches regression

A future refactor that drops a placeholder for any covered key now fails the **key-set assertion** immediately:

```diff
- expected ['Architectures', 'Description', 'Environment', ...]
+ received [ 'Architectures', 'Description', ...]   // Environment dropped
```

vs the pre-PR behavior: silent regression that only surfaced when a user hit drift on a resource configured the way the test missed.

## Future provider author convention

Every new SDK provider with `readCurrentState` MUST add this test block. Reviewer enforces; the docs describe the pattern + provide templates.

This PR covers 8 high-value examples. Adding the structural test to the remaining ~25 providers can be a follow-up — the existing per-key tests across those providers (e.g. "emits empty Tags placeholder when no user tags") already cover individual placeholders piecemeal, so the regression risk is mitigated though not as comprehensively.

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` clean
- [x] `pnpm run build` succeeds
- [x] `npx vitest --run` — **1660 + 8 = 1668 pass**
- [x] No source code touched (test + docs only)

## Phase split (status)

- **Phase 1** ✅ (#152) — 30 high-traffic providers
- **Phase 2a** ✅ (#153) — CloudWatch Alarm + CodeBuild
- **Phase 2b** ✅ (#154) — AppSync + ApiGateway + ApiGatewayV2
- **Phase 2c** ✅ (#155) — Cognito UserPool
- **Structural test** ← this PR — convention enforcement for 8 representative providers
