### PR TITLE
fix(drift): guard FIFO-only SQS / SNS attributes from always-emit-placeholder

### DIFF
--- a/src/provisioning/providers/sns-topic-provider.ts
+++ b/src/provisioning/providers/sns-topic-provider.ts
@@ -475,20 +475,21 @@ export class SNSTopicProvider implements ResourceProvider {
       if (v !== undefined) result[key] = v === 'true';
     }
 
-    // String attributes (pass-through). Always emit a placeholder so a
-    // console-side ADD on a topic that didn't carry the attribute at deploy
-    // time surfaces as drift (the comparator's top-level walk is
-    // state-keys-only; a missing key on the deploy-time baseline blinds
-    // detection forever).
-    const str: string[] = [
-      'DisplayName',
-      'KmsMasterKeyId',
-      'TracingConfig',
-      'SignatureVersion',
-      'FifoThroughputScope',
-    ];
+    // String attributes valid for any topic type — emit unconditionally so a
+    // console-side ADD surfaces as drift.
+    const str: string[] = ['DisplayName', 'KmsMasterKeyId', 'TracingConfig', 'SignatureVersion'];
     for (const key of str) {
       result[key] = attrs[key] ?? '';
+    }
+
+    // FifoThroughputScope is FIFO-only — emitting `''` as a placeholder on
+    // a standard topic would have `cdkd drift --revert` push the empty
+    // value back to AWS, which `SetTopicAttributes` rejects. Same
+    // type-discriminator-tagged pattern as the SQS DeduplicationScope /
+    // FifoThroughputLimit guards.
+    const isFifo = attrs['FifoTopic'] === 'true';
+    if (isFifo) {
+      result['FifoThroughputScope'] = attrs['FifoThroughputScope'] ?? '';
     }
 
     // JSON-document attributes — AWS returns a JSON string; cdkd state

--- a/src/provisioning/providers/sqs-queue-provider.ts
+++ b/src/provisioning/providers/sqs-queue-provider.ts
@@ -407,16 +407,21 @@ export class SQSQueueProvider implements ResourceProvider {
       if (v !== undefined) result[key] = v === 'true';
     }
 
-    // String attributes: always emit a placeholder so a console-side ADD
-    // on a queue that didn't carry the attribute at deploy time surfaces
-    // as drift.
-    const str: Array<keyof typeof CDK_TO_SQS_ATTRIBUTES> = [
-      'KmsMasterKeyId',
-      'DeduplicationScope',
-      'FifoThroughputLimit',
-    ];
-    for (const key of str) {
-      result[key] = attributes[key] ?? '';
+    // KmsMasterKeyId is valid for any queue type — emit unconditionally so a
+    // console-side KMS attach surfaces as drift.
+    result['KmsMasterKeyId'] = attributes['KmsMasterKeyId'] ?? '';
+
+    // DeduplicationScope and FifoThroughputLimit are FIFO-only attributes.
+    // AWS rejects `SetQueueAttributes(DeduplicationScope=...)` with
+    // "You can specify the DeduplicationScope only when FifoQueue is set
+    // to true" on standard queues. If we emit '' as a placeholder for
+    // standard queues, `cdkd drift --revert` would push it back to AWS
+    // and trigger that rejection. Type-discriminator-tagged: only emit
+    // when the queue is actually FIFO.
+    const isFifo = attributes['FifoQueue'] === 'true';
+    if (isFifo) {
+      result['DeduplicationScope'] = attributes['DeduplicationScope'] ?? '';
+      result['FifoThroughputLimit'] = attributes['FifoThroughputLimit'] ?? '';
     }
 
     // RedrivePolicy: AWS returns as a JSON string; cdkd state typically

--- a/tests/unit/provisioning/sns-topic-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/sns-topic-provider-readcurrentstate.test.ts
@@ -128,21 +128,21 @@ describe('SNSTopicProvider.readCurrentState', () => {
   // the resource with all optional fields undefined / empty. A future
   // refactor that drops a placeholder for any of these keys must update
   // this test consciously — silent regression is structurally prevented.
-  it('emits placeholders for every user-controllable top-level key on AWS minimum response', async () => {
-    // GetTopicAttributes — empty Attributes object (no DisplayName, no
-    // KmsMasterKeyId, no TracingConfig, no SignatureVersion, no
-    // FifoThroughputScope, no FifoTopic / ContentBasedDeduplication, no
-    // ArchivePolicy / DataProtectionPolicy).
+  it('emits placeholders for every user-controllable top-level key on AWS minimum response (standard topic)', async () => {
+    // GetTopicAttributes — empty Attributes object (standard topic, not FIFO).
     mockSend.mockResolvedValueOnce({ Attributes: {} });
     // ListTagsForResource — no user tags.
     mockSend.mockResolvedValueOnce({ Tags: [] });
 
     const result = await provider.readCurrentState(TOPIC_ARN, 'Logical', 'AWS::SNS::Topic');
 
+    // FifoThroughputScope is intentionally absent for standard topics —
+    // it's a FIFO-only attribute and emitting '' would have
+    // `cdkd drift --revert` push the empty value back to AWS, which
+    // SetTopicAttributes rejects.
     expect(Object.keys(result ?? {}).sort()).toEqual(
       [
         'DisplayName',
-        'FifoThroughputScope',
         'KmsMasterKeyId',
         'SignatureVersion',
         'Tags',
@@ -154,7 +154,16 @@ describe('SNSTopicProvider.readCurrentState', () => {
     expect(result?.KmsMasterKeyId).toBe('');
     expect(result?.TracingConfig).toBe('');
     expect(result?.SignatureVersion).toBe('');
-    expect(result?.FifoThroughputScope).toBe('');
     expect(result?.Tags).toEqual([]);
+  });
+
+  it('emits FifoThroughputScope placeholder when topic is FIFO', async () => {
+    mockSend.mockResolvedValueOnce({ Attributes: { FifoTopic: 'true' } });
+    mockSend.mockResolvedValueOnce({ Tags: [] });
+
+    const result = await provider.readCurrentState(TOPIC_ARN, 'Logical', 'AWS::SNS::Topic');
+
+    expect(result).toHaveProperty('FifoThroughputScope', '');
+    expect(result).toHaveProperty('FifoTopic', true);
   });
 });

--- a/tests/unit/provisioning/sqs-queue-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/sqs-queue-provider-readcurrentstate.test.ts
@@ -124,4 +124,36 @@ describe('SQSQueueProvider.readCurrentState', () => {
     const result = await provider.readCurrentState(QUEUE_URL, 'Logical', 'AWS::SQS::Queue');
     expect(result?.Tags).toEqual([]);
   });
+
+  it('omits FIFO-only attributes (DeduplicationScope / FifoThroughputLimit) on standard queues', async () => {
+    // Standard queue (FifoQueue absent / 'false') — DeduplicationScope and
+    // FifoThroughputLimit are FIFO-only; emitting `''` placeholders would
+    // have `cdkd drift --revert` push them back to AWS, which
+    // SetQueueAttributes rejects with "You can specify the
+    // DeduplicationScope only when FifoQueue is set to true".
+    mockSend.mockResolvedValueOnce({
+      Attributes: { VisibilityTimeout: '30' /* FifoQueue absent */ },
+    });
+    mockSend.mockResolvedValueOnce({ Tags: {} });
+
+    const result = await provider.readCurrentState(QUEUE_URL, 'Logical', 'AWS::SQS::Queue');
+
+    expect(result).not.toHaveProperty('DeduplicationScope');
+    expect(result).not.toHaveProperty('FifoThroughputLimit');
+    // KmsMasterKeyId is valid for any queue type — placeholder still emitted.
+    expect(result).toHaveProperty('KmsMasterKeyId', '');
+  });
+
+  it('emits FIFO-only attributes (DeduplicationScope / FifoThroughputLimit) on FIFO queues', async () => {
+    mockSend.mockResolvedValueOnce({
+      Attributes: { VisibilityTimeout: '30', FifoQueue: 'true' },
+    });
+    mockSend.mockResolvedValueOnce({ Tags: {} });
+
+    const result = await provider.readCurrentState(QUEUE_URL, 'Logical', 'AWS::SQS::Queue');
+
+    expect(result).toHaveProperty('DeduplicationScope', '');
+    expect(result).toHaveProperty('FifoThroughputLimit', '');
+    expect(result).toHaveProperty('FifoQueue', true);
+  });
 });


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced in Phase 1 (#152) and reported by a real user: `cdkd drift --revert` errors out on standard SQS queues with:

```
✗ AWS update failed — Failed to update SQS queue ...:
  You can specify the DeduplicationScope only when FifoQueue is set to true.
```

## Root cause

Phase 1 added always-emit placeholders for every user-controllable top-level key. Three attributes got placeholders that AWS only accepts on FIFO resources:

| Attribute | Provider | FIFO-only? | Placeholder I added |
| --- | --- | --- | --- |
| `DeduplicationScope` | SQS | yes | `?? ''` |
| `FifoThroughputLimit` | SQS | yes | `?? ''` |
| `FifoThroughputScope` | SNS | yes | `?? ''` |

When a standard (non-FIFO) queue's `state.observedProperties` carried these `''` placeholders, `cdkd drift --revert` pushed them through the regular update path → AWS rejected.

**This is the type-discriminator-tagged pattern from Phase 2b**: AppSync DataSource's `DynamoDBConfig` / `LambdaConfig` / `HttpConfig` are mutually exclusive on the parent's `Type` field, so I kept them guarded then. Same logic should have applied to SQS / SNS FIFO-only fields, but I missed it.

## Changes

- **SQS readCurrentState**: only emit `DeduplicationScope` / `FifoThroughputLimit` when `FifoQueue=true`. `KmsMasterKeyId` stays unconditionally emitted (valid for any queue type).
- **SNS readCurrentState**: only emit `FifoThroughputScope` when `FifoTopic=true`. The other 4 string attrs (`DisplayName` / `KmsMasterKeyId` / `TracingConfig` / `SignatureVersion`) stay unconditionally emitted.

## Live verification

User's `CdkSampleStack` has a standard SQS queue. Pre-fix observed:

```
['DeduplicationScope', 'FifoThroughputLimit', 'KmsMasterKeyId', ... ]
```

Post-fix, after `cdkd state refresh-observed`:

```
['KmsMasterKeyId', 'QueueName', 'VisibilityTimeout', ... ]
```

`DeduplicationScope` / `FifoThroughputLimit` no longer present → `cdkd drift --revert` no longer attempts to push them.

## Migration

Users with existing v0.50.x state where these placeholders leaked into `observedProperties` need to re-baseline:

- **`cdkd state refresh-observed <stack>`** — rewrites observed using the fixed read code (preferred when AWS is the intended source of truth)
- **`cdkd deploy <stack>`** — re-applies template intent (preferred when template is the intended source of truth)

## Test plan

- [x] `pnpm run typecheck` clean
- [x] `pnpm run lint` clean
- [x] `pnpm run build` succeeds
- [x] `npx vitest --run` — **1671 pass** (1668 prior + 3 new tests covering standard / FIFO branches)
- [x] Live-test on real CdkSampleStack: post-fix `state refresh-observed` produces correct observed shape; `cdkd drift` reports clean

## Retrospective

This is the same class of bug that #152 set out to prevent — but at a finer granularity: not just "always emit" vs "always skip", but **type-discriminator-tagged emit** for fields that are conditionally valid based on a sibling field's value.

Phase 2b correctly identified this for AppSync DataSource sub-configs but Phase 1 missed it for SQS / SNS FIFO-only fields. The structural test PR (#156) covered the user-reported representative providers but didn't include SQS — adding a SQS structural test in this PR ensures the standard / FIFO branching is covered going forward.

Future audit needed: Lambda EventSourceMapping `FunctionResponseTypes` (only valid for SQS/Kinesis/DynamoDB) and `SourceAccessConfigurations` (self-managed Kafka / MQ / MSK only) may have the same pattern. Tracked as a follow-up; not user-reported yet.
