### PR TITLE
docs(drift): Class 1/2/truthy-gate guardrails + round-trip property tests

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -61,6 +61,17 @@ Run each check and report pass/fail:
    - Verify all callers of changed functions handle the new behavior
    - Verify type definitions are consistent with implementation
    - **Shared-utility regression check**: if any file under `src/utils/**` (or another widely-imported module) changed, list every importer (`grep -rl "from '\.\./.*utils/<file>'" src tests`) and walk through each one to confirm the new behavior is correct for them. A change to a shared helper is only "done" when every caller has been considered.
+   - **Internal-interface contract change check**: if the diff changes the **semantics** of arguments an interface receives — even if the type signature is unchanged — list every implementer and walk through each one. Examples that count as a contract change: `provider.update`'s `newProperties` shifting from "full desired state" to "partial / overlay / etc."; an intrinsic resolver's input format changing; a state schema field's invariant changing. The risk is implementers that silently treat the old shape's invariants as load-bearing (e.g. `SNSTopicProvider.update` treating `newProps[K] === undefined` as "remove K from AWS"). PR #161 hit this — the first-pass design ("drifted-only partial newProperties") had to be reworked after audit found `SNSTopicProvider` and `IAMRoleProvider.updateManagedPolicies` would silently clear non-drifted attrs. **Audit BEFORE writing tests against the new design**, not after — discovering the breaks via tests-after-design forces a design rework and invalidates the tests already written.
+     ```bash
+     # For provider interface changes:
+     grep -rln "implements ResourceProvider" src/provisioning/providers/
+     # For each implementer, read the body of the affected method and write
+     # down what it assumes about the argument's shape — truthy gates,
+     # diff-based "absent = remove" semantics, JSON.parse on stringly-typed
+     # input, etc. The new contract must preserve every assumption that
+     # is load-bearing, OR every implementer must be updated in the same PR.
+     ```
+     See `feedback_internal_contract_audit_first.md` for the full pattern.
 
 9. **Live-test changed behavior**
    - Unit tests verify code correctness; this step verifies *feature* correctness against the runtime the user actually sees.

--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -1007,6 +1007,91 @@ getDriftUnknownPaths(): string[] {
 
 The comparator does exact-match + `entry + '.'` prefix-match — listing `'Policies'` skips `Policies`, `Policies.Foo`, `Policies[0].PolicyDocument`, etc. Pair this with a docstring explaining why the field is unreadable so a future PR can lift the gap.
 
+#### Two failure modes when an always-emit placeholder round-trips through `update()`
+
+`cdkd drift --revert` round-trips `observedProperties` (the snapshot `readCurrentState` produced) back through `provider.update`. That code path is what surfaces every shape-mismatch bug between the read side (`readCurrentState` output) and the write side (AWS create/update API input). Two failure classes have been observed; both must be designed around BEFORE adding a new `readCurrentState`.
+
+**Class 1 — type-discriminator-dependent fields.** A field is only valid on AWS when a sibling discriminator says so. Examples: SQS `DeduplicationScope` / `FifoThroughputLimit` (FIFO-only — `FifoQueue=true`), SNS `FifoThroughputScope` (`FifoTopic=true`), AppSync DataSource shape (`DynamoDBConfig` / `LambdaConfig` / `HttpConfig` discriminated by `Type`). Emitting a `''` placeholder for these on a discriminator-false resource means `--revert` pushes it back and AWS rejects with "You can specify X only when Y is set to true". **Fix:** guard the emit on the sibling discriminator — only emit when the discriminator is true. Pattern documented in `feedback_always_emit_check_type_discriminator.md`. Drift detection is not lost: the discriminator-false state cannot legally have the field on AWS, so console-side ADD is impossible.
+
+**Class 2 — structurally-incomplete-when-empty fields.** An empty-object / empty-array placeholder is structurally invalid as AWS input because a sub-field is required. Example: SQS `RedrivePolicy: {}` rejects with "Redrive policy does not contain mandatory attribute: maxReceiveCount" because `deadLetterTargetArn` and `maxReceiveCount` are required. Other Class 2 candidates: Lambda `DeadLetterConfig` (TargetArn required), Lambda `VpcConfig` (SubnetIds + SecurityGroupIds required), EventBridge / SNS `DeadLetterConfig`, ECS `NetworkConfiguration` (awsvpcConfiguration.subnets required), various `LoggingConfiguration` shapes. **Fix:** keep the placeholder on the read side (drift detection requires it), and **sanitize at the wire layer in `create()` / `update()`** by translating the empty placeholder to whatever AWS accepts as "clear this field" — usually empty string. Canonical pattern in `serializeRedrivePolicy` ([src/provisioning/providers/sqs-queue-provider.ts](../src/provisioning/providers/sqs-queue-provider.ts)):
+
+```typescript
+function serializeRedrivePolicy(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'object' && Object.keys(value as Record<string, unknown>).length === 0) {
+    return '';  // AWS-documented way to clear RedrivePolicy
+  }
+  return JSON.stringify(value);
+}
+```
+
+Pattern documented in `feedback_class2_placeholder_round_trip.md`.
+
+#### `update()` must gate optional fields on `!== undefined`, not truthy
+
+Truthy gates (`if (properties['X']) { ... }`) silently drop empty string `''`, numeric `0`, boolean `false`, and empty array `[]` (where the CFn type allows it). For `cdkd deploy` this is mostly invisible. For `cdkd drift --revert` it is a load-bearing bug: when state has no description but AWS does, the desired value to push back is `Description: ''`. A truthy gate drops it, the AWS update succeeds with no actual change, `--revert` reports `✓ reverted`, and the very next `cdkd drift` re-detects the same drift — silent fail mode. **Fix:** use `if (properties['X'] !== undefined)` so explicit-empty values reach AWS:
+
+```typescript
+// IAM Role example (PR #161 fix):
+if (properties['Description'] !== undefined) {
+  updateParams.Description = properties['Description'] as string;
+}
+```
+
+Truthy gates are correct ONLY for fields where the value range excludes the falsy form (e.g. boolean flags where `false` means "use default", or `Path` where empty is invalid). Add a code comment when the truthy form is intentional. Pattern documented in `feedback_update_optional_field_undefined_check.md`.
+
+#### Read-update round-trip test (mandatory for any provider with `readCurrentState`)
+
+The above failure modes (Class 1, Class 2, truthy gate) all surface only on the `cdkd drift --revert` code path, which round-trips `observedProperties` (= a previous `readCurrentState` snapshot) back through `provider.update`. Document review and code grep cannot catch every instance — write a test that exercises the round-trip mechanically:
+
+```typescript
+it('round-trip: readCurrentState placeholders survive update() without AWS-invalid inputs', async () => {
+  // 1. Mock SDK to return the AWS-minimum response (only required
+  //    fields, optionals undefined). readCurrentState should emit
+  //    every always-emit placeholder.
+  mockSend.mockResolvedValueOnce({ /* minimum SDK shape */ });
+  // ...
+
+  const observed = await provider.readCurrentState(physicalId, 'L', RESOURCE_TYPE);
+  // Spot-check the placeholders are present (this is the always-emit
+  // contract, see "Test convention" earlier in this section).
+  expect(observed?.RedrivePolicy).toEqual({});  // Class 2 placeholder
+  // ...
+
+  // 2. Reset mocks and set up update() expectations.
+  vi.clearAllMocks();
+  mockSend.mockResolvedValueOnce({});  // SDK update call
+  // ...
+
+  // 3. Round-trip: pass observed as both new (desired) and old (previous).
+  //    No drift → update should be a logical no-op on AWS.
+  await provider.update('L', physicalId, RESOURCE_TYPE, observed!, observed!);
+
+  // 4. Assert: no SDK call sent a value AWS would reject.
+  //    Per-provider — list the AWS-rejection-shaped values you know of:
+  const setAttrsCall = mockSend.mock.calls.find(
+    (c) => c[0] instanceof SetQueueAttributesCommand
+  );
+  if (setAttrsCall) {
+    const attrs = setAttrsCall[0].input.Attributes;
+    if (attrs.RedrivePolicy !== undefined) {
+      // Class 2: '{}' would fail "Redrive policy does not contain
+      // mandatory attribute: maxReceiveCount"
+      expect(attrs.RedrivePolicy).not.toBe('{}');
+    }
+    // ... other per-provider rejection-shape checks
+  }
+});
+```
+
+The round-trip test catches all three classes mechanically:
+
+- **Class 1** — discriminator-false placeholders that AWS rejects when shipped: assert the relevant `SetXxxAttributes` / `UpdateXxx` call does NOT include the discriminator-only attribute when the discriminator is false in the mock setup.
+- **Class 2** — structurally-incomplete placeholders: assert the AWS API call does NOT contain the empty-object / empty-array shape AWS validates and rejects (e.g. `RedrivePolicy: '{}'`, `VpcConfig: {}`).
+- **Truthy gate** — assert that empty-string / 0 / false placeholder values DO reach the relevant AWS API call (e.g. `UpdateRoleCommand` input must contain `Description: ''` when `observedProperties.Description === ''`).
+
+See [tests/unit/provisioning/sqs-queue-provider-update.test.ts](../tests/unit/provisioning/sqs-queue-provider-update.test.ts) (Class 2 round-trip), [tests/unit/provisioning/iam-role-provider.test.ts](../tests/unit/provisioning/iam-role-provider.test.ts) (truthy-gate round-trip), and [tests/unit/provisioning/sns-topic-provider-roundtrip.test.ts](../tests/unit/provisioning/sns-topic-provider-roundtrip.test.ts) (Class 1 round-trip) for canonical examples.
+
 ### 4. Logging
 
 - `info`: Successful operations

--- a/tests/unit/provisioning/iam-role-provider.test.ts
+++ b/tests/unit/provisioning/iam-role-provider.test.ts
@@ -458,5 +458,61 @@ describe('IAMRoleProvider', () => {
       const input = updateCall![0].input as { Description?: string };
       expect(input).not.toHaveProperty('Description');
     });
+
+    it('round-trip: empty-string Description placeholder reaches UpdateRoleCommand (truthy-gate guard)', async () => {
+      // Mechanical guard for the truthy-gate regression. See
+      // docs/provider-development.md § 3b "Read-update round-trip test".
+      //
+      // The IAM Role bug class:
+      //   - readCurrentState emits Description: '' as the always-emit
+      //     placeholder when AWS has no description.
+      //   - update() must propagate '' to UpdateRoleCommand so AWS clears
+      //     the description on revert. A truthy gate (`if (props['X'])`)
+      //     would silently drop '' and `cdkd drift --revert` would
+      //     report "reverted" but the next drift re-detects the same
+      //     drift (the original silent fail mode).
+
+      // Build observed snapshot directly (matches what readCurrentState
+      // would produce for a role with no description) — readCurrentState
+      // is exercised by its own dedicated test file.
+      const observed = {
+        RoleName: 'my-role',
+        Path: '/',
+        AssumeRolePolicyDocument: { Version: '2012-10-17', Statement: [] },
+        Description: '',
+        MaxSessionDuration: 3600,
+        ManagedPolicyArns: [] as string[],
+        Tags: [] as Array<{ Key: string; Value: string }>,
+      };
+
+      // Round-trip: pass observed as both new (desired) and old.
+      mockSend.mockResolvedValueOnce({}); // UpdateRoleCommand
+      mockSend.mockResolvedValueOnce({}); // updateManagedPolicies (no-op)
+      mockSend.mockResolvedValueOnce({}); // updateInlinePolicies (no-op)
+      mockSend.mockResolvedValueOnce({}); // updateTags (no-op)
+      mockSend.mockResolvedValueOnce({
+        Role: {
+          RoleName: 'my-role',
+          Arn: 'arn:aws:iam::0:role/my-role',
+          Path: '/',
+          RoleId: 'role-id',
+        },
+      });
+
+      await provider.update('L', 'my-role', 'AWS::IAM::Role', observed, observed);
+
+      // Truthy-gate assertion: UpdateRole MUST receive the empty
+      // Description so AWS clears it. The previous truthy gate would
+      // have dropped this and the test would fail.
+      const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateRoleCommand);
+      expect(updateCall).toBeDefined();
+      const input = updateCall![0].input as {
+        RoleName: string;
+        Description?: string;
+        MaxSessionDuration?: number;
+      };
+      expect(input.Description).toBe('');
+      expect(input.MaxSessionDuration).toBe(3600);
+    });
   });
 });

--- a/tests/unit/provisioning/sns-topic-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/sns-topic-provider-roundtrip.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SetTopicAttributesCommand } from '@aws-sdk/client-sns';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    sns: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { SNSTopicProvider } from '../../../src/provisioning/providers/sns-topic-provider.js';
+
+const STANDARD_TOPIC_ARN = 'arn:aws:sns:us-east-1:0:standard-topic';
+const FIFO_TOPIC_ARN = 'arn:aws:sns:us-east-1:0:fifo-topic.fifo';
+
+describe('SNSTopicProvider read-update round-trip', () => {
+  let provider: SNSTopicProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new SNSTopicProvider();
+  });
+
+  it('Class 1 — standard topic (FifoTopic=false) does not send FIFO-only attrs to AWS on round-trip', async () => {
+    // Mechanical guard for Class 1 placeholder regression on type-
+    // discriminator-dependent fields. See docs/provider-development.md
+    // § 3b "Read-update round-trip test".
+    //
+    // SNS FifoThroughputScope is FIFO-only. On a STANDARD topic
+    // readCurrentState must NOT emit it as a placeholder (or, if it
+    // does, the round-trip update() must not push it). Either way the
+    // SetTopicAttributes call for FifoThroughputScope must NEVER
+    // happen on a standard topic — AWS rejects with
+    // "FifoThroughputScope is only valid on FIFO topics".
+
+    // Build observed snapshot directly (matches what readCurrentState
+    // would produce for a standard topic — readCurrentState is
+    // exercised by its own dedicated test file).
+    const observed = {
+      TopicName: 'standard-topic',
+      DisplayName: '',
+      KmsMasterKeyId: '',
+      ContentBasedDeduplication: false,
+      TracingConfig: '',
+      SignatureVersion: '',
+      Tags: [] as Array<{ Key: string; Value: string }>,
+      // FifoTopic absent on standard topic. FifoThroughputScope
+      // intentionally NOT in the snapshot — the Class 1 guard kicks in
+      // at readCurrentState (not emitted on standard topic).
+    };
+
+    // Round-trip
+    await provider.update('L', STANDARD_TOPIC_ARN, 'AWS::SNS::Topic', observed, observed);
+
+    // Assert: no SetTopicAttributes call ever set FifoThroughputScope
+    // (or any other FIFO-only attribute). All attrs in the snapshot
+    // are equal between new and old, so the diff-based update should
+    // produce zero SetTopicAttributes calls.
+    const setAttrCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof SetTopicAttributesCommand
+    );
+    for (const call of setAttrCalls) {
+      const input = call[0].input as { AttributeName: string };
+      expect(input.AttributeName).not.toBe('FifoThroughputScope');
+    }
+  });
+
+  it('round-trip on no-drift snapshot is a logical no-op (zero SetTopicAttributes calls)', async () => {
+    // Stronger assertion for diff-based providers: state == AWS
+    // implies update() must make no AWS-side mutations. PR #161
+    // verified this by switching drift --revert to "AWS-current base
+    // + drifted overlay" — but the round-trip test is the structural
+    // guard for the next time someone changes update()'s diff logic.
+    const observed = {
+      TopicName: 'standard-topic',
+      DisplayName: 'my-display',
+      KmsMasterKeyId: 'alias/aws/sns',
+      ContentBasedDeduplication: false,
+      TracingConfig: 'PassThrough',
+      SignatureVersion: '1',
+      Tags: [{ Key: 'k', Value: 'v' }],
+    };
+
+    await provider.update('L', STANDARD_TOPIC_ARN, 'AWS::SNS::Topic', observed, observed);
+
+    const setAttrCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof SetTopicAttributesCommand
+    );
+    expect(setAttrCalls).toHaveLength(0);
+  });
+
+  it('FIFO topic round-trip emits FIFO-only attrs without AWS rejection', async () => {
+    // The complement of the standard-topic test: a FIFO topic
+    // legitimately has FifoThroughputScope, and round-tripping should
+    // NOT produce a rejection-shape input.
+    const observed = {
+      TopicName: 'fifo-topic.fifo',
+      FifoTopic: true,
+      DisplayName: '',
+      KmsMasterKeyId: '',
+      ContentBasedDeduplication: true,
+      TracingConfig: '',
+      SignatureVersion: '',
+      FifoThroughputScope: 'Topic',
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await provider.update('L', FIFO_TOPIC_ARN, 'AWS::SNS::Topic', observed, observed);
+
+    // No drift → no SetTopicAttributes calls.
+    const setAttrCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof SetTopicAttributesCommand
+    );
+    expect(setAttrCalls).toHaveLength(0);
+  });
+});

--- a/tests/unit/provisioning/sqs-queue-provider-update.test.ts
+++ b/tests/unit/provisioning/sqs-queue-provider-update.test.ts
@@ -114,4 +114,45 @@ describe('SQSQueueProvider.update', () => {
     expect(result.attributes?.['Arn']).toBe('arn:aws:sqs:us-east-1:0:q');
     expect(mockSend.mock.calls.some((c) => c[0] instanceof GetQueueAttributesCommand)).toBe(true);
   });
+
+  it('round-trip: readCurrentState placeholders survive update() without AWS-invalid inputs', async () => {
+    // Mechanical guard for Class 2 placeholder regression. See
+    // docs/provider-development.md § 3b "Read-update round-trip test".
+    //
+    // 1. AWS-minimum response (queue with no DLQ, no KMS, no tags)
+    //    triggers the always-emit placeholders that BIT us in PR #161.
+    mockSend.mockResolvedValueOnce({
+      Attributes: { VisibilityTimeout: '30', DelaySeconds: '0' },
+    });
+    mockSend.mockResolvedValueOnce({ Tags: {} });
+
+    const observed = await provider.readCurrentState(QUEUE_URL, 'L', 'AWS::SQS::Queue');
+    // Spot-check the Class 2 placeholder is present (the always-emit
+    // contract — see § 3b "emits placeholders for every user-controllable
+    // top-level key").
+    expect(observed?.['RedrivePolicy']).toEqual({});
+    expect(observed?.['KmsMasterKeyId']).toBe('');
+
+    // 2. Round-trip the snapshot through update(). No drift → AWS
+    //    state should not change.
+    vi.clearAllMocks();
+    mockSend.mockResolvedValueOnce({}); // SetQueueAttributesCommand
+    mockSend.mockResolvedValueOnce({ Attributes: { QueueArn: 'arn:aws:sqs:us-east-1:0:q' } });
+
+    await provider.update('L', QUEUE_URL, 'AWS::SQS::Queue', observed!, observed!);
+
+    // 3. Assert no AWS-rejection-shaped values reached the SDK.
+    const setAttrsCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof SetQueueAttributesCommand
+    );
+    expect(setAttrsCall).toBeDefined();
+    const attrs = (setAttrsCall![0].input as { Attributes: Record<string, string> }).Attributes;
+    // Class 2: empty-object RedrivePolicy must NEVER be sent as "{}"
+    // — AWS rejects with "Redrive policy does not contain mandatory
+    // attribute: maxReceiveCount". `serializeRedrivePolicy` translates
+    // {} -> "" (the documented "clear" form).
+    if (attrs['RedrivePolicy'] !== undefined) {
+      expect(attrs['RedrivePolicy']).not.toBe('{}');
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #161. That PR fixed two bugs in `cdkd drift --revert` (SQS `RedrivePolicy: {}` rejected, IAM Role `Description: ''` silently dropped) but the underlying **bug class** — placeholder values from `readCurrentState` failing to round-trip through `provider.update` — is structural and likely latent in other providers. This PR adds the guardrails to catch recurrences.

### Mechanical guards (test-time)

Round-trip property tests covering the 3 known bug classes — each builds an `observedProperties` snapshot with all-placeholders, round-trips it through `update(observed, observed)`, and asserts no AWS-rejection-shaped SDK input is produced:

| Test | Class | What it asserts |
|---|---|---|
| `sqs-queue-provider-update.test.ts` (extended) | **Class 2** structurally-incomplete | `RedrivePolicy: {}` is NEVER serialized as JSON `"{}"` (AWS rejects with `maxReceiveCount` required) |
| `iam-role-provider.test.ts` (extended) | **truthy gate** | `Description: ''` MUST reach `UpdateRoleCommand` (truthy `if (props['Description'])` would silently drop) |
| `sns-topic-provider-roundtrip.test.ts` (new) | **Class 1** type-discriminator | `FifoThroughputScope` is NEVER sent on a standard topic (AWS rejects "only valid on FIFO topics"); FIFO topic complement also covered |

5 new tests, 1688 total tests pass.

### Documentation guards (review-time)

`docs/provider-development.md § 3b` extended with three new subsections:

- **Two failure modes when an always-emit placeholder round-trips through update()** — names Class 1 (type-discriminator) and Class 2 (structurally-incomplete), shows the canonical `serializeRedrivePolicy` pattern.
- **update() must gate optional fields on `!== undefined`, not truthy** — IAM Role Description regression as the worked example.
- **Read-update round-trip test (mandatory for any provider with readCurrentState)** — the test convention with example.

### Process guards (skill-time)

`/verify-pr` step 8 extended with an explicit **internal-interface-contract caller audit**: when a diff changes the SEMANTICS of an interface's argument (not just the type signature), list every implementer and walk through each one BEFORE writing tests against the new design. PR #161's first-pass design ("drifted-only partial newProperties") had to be reworked after audit found `SNSTopicProvider.update` and `IAMRoleProvider.updateManagedPolicies` would silently clear non-drifted attrs.

### Memory entries (AI-context, not in this PR)

Three new memory entries (auto-loaded for future sessions, live in `~/.claude/projects/.../memory/` so outside the repo):

- `feedback_class2_placeholder_round_trip.md`
- `feedback_update_optional_field_undefined_check.md`
- `feedback_internal_contract_audit_first.md`

### Out of scope

The remaining 23+ providers' round-trip tests. The convention is documented; they can be added per-provider as each is next touched (lazy migration) or as a follow-up audit PR.

## Test plan

- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` clean
- [x] `npx vitest --run` — 1688 tests pass (5 new round-trip)
- [x] `integ-destroy` gate still fresh (no `src/provisioning/**` changes)
- [x] `docs/provider-development.md` examples reference real code (`serializeRedrivePolicy`, IAM Role gate, test files) — verified all paths exist
