### PR TITLE
fix(drift): round-trip audit for Lambda providers (PR 1/5)

### DIFF
--- a/src/provisioning/providers/lambda-eventsource-provider.ts
+++ b/src/provisioning/providers/lambda-eventsource-provider.ts
@@ -22,6 +22,74 @@ import type {
 } from '../../types/resource.js';
 
 /**
+ * Classify an event source mapping by its `EventSourceArn` so that
+ * `readCurrentState` can gate type-discriminator-dependent CFn fields.
+ *
+ * Several `AWS::Lambda::EventSourceMapping` properties are only valid
+ * when the source is a specific service. Always-emitting placeholders
+ * (`[]` / `''`) for the wrong source type causes
+ * `cdkd drift --revert` to round-trip those placeholders back through
+ * `UpdateEventSourceMappingCommand`, where AWS rejects them:
+ *
+ * - `FunctionResponseTypes` is only valid for SQS / DynamoDB Streams /
+ *   Kinesis Streams (where `ReportBatchItemFailures` makes sense).
+ *   Pushing `[]` against a Kafka or MQ source is rejected with
+ *   "FunctionResponseTypes is not allowed for this event source".
+ * - `SourceAccessConfigurations` is only valid for self-managed Kafka /
+ *   MSK / MQ. Pushing `[]` against SQS / Kinesis / DynamoDB is rejected
+ *   similarly.
+ */
+type EventSourceKind =
+  | 'sqs'
+  | 'kinesis'
+  | 'dynamodb'
+  | 'kafka' // both MSK and self-managed Kafka
+  | 'mq'
+  | 'documentdb'
+  | 'unknown';
+
+function classifyEventSource(resp: {
+  EventSourceArn?: string | undefined;
+  SelfManagedEventSource?: unknown;
+  AmazonManagedKafkaEventSourceConfig?: unknown;
+  SelfManagedKafkaEventSourceConfig?: unknown;
+  DocumentDBEventSourceConfig?: unknown;
+}): EventSourceKind {
+  // Self-managed Kafka has no EventSourceArn — it carries
+  // SelfManagedEventSource instead.
+  if (resp.SelfManagedEventSource !== undefined) return 'kafka';
+  if (resp.SelfManagedKafkaEventSourceConfig !== undefined) return 'kafka';
+  if (resp.AmazonManagedKafkaEventSourceConfig !== undefined) return 'kafka';
+  if (resp.DocumentDBEventSourceConfig !== undefined) return 'documentdb';
+  const arn = resp.EventSourceArn;
+  if (!arn) return 'unknown';
+  // arn:aws:<service>:<region>:<account>:<rest>
+  if (arn.startsWith('arn:aws:sqs:') || arn.startsWith('arn:aws-cn:sqs:')) return 'sqs';
+  if (arn.startsWith('arn:aws:kinesis:') || arn.startsWith('arn:aws-cn:kinesis:')) return 'kinesis';
+  if (arn.startsWith('arn:aws:dynamodb:') || arn.startsWith('arn:aws-cn:dynamodb:'))
+    return 'dynamodb';
+  if (arn.startsWith('arn:aws:kafka:') || arn.startsWith('arn:aws-cn:kafka:')) return 'kafka';
+  if (arn.startsWith('arn:aws:mq:') || arn.startsWith('arn:aws-cn:mq:')) return 'mq';
+  if (arn.startsWith('arn:aws:rds:') || arn.startsWith('arn:aws-cn:rds:')) {
+    // DocumentDB cluster ARNs use the `rds` service prefix, but are
+    // disambiguated above by `DocumentDBEventSourceConfig`.
+    return 'documentdb';
+  }
+  return 'unknown';
+}
+
+const KINDS_WITH_FUNCTION_RESPONSE_TYPES: ReadonlySet<EventSourceKind> = new Set([
+  'sqs',
+  'kinesis',
+  'dynamodb',
+]);
+const KINDS_WITH_SOURCE_ACCESS_CONFIGURATIONS: ReadonlySet<EventSourceKind> = new Set([
+  'kafka',
+  'mq',
+  'documentdb',
+]);
+
+/**
  * AWS Lambda Event Source Mapping Provider
  *
  * Implements resource provisioning for AWS::Lambda::EventSourceMapping using the Lambda SDK.
@@ -192,10 +260,15 @@ export class LambdaEventSourceMappingProvider implements ResourceProvider {
       UUID: physicalId,
       FunctionName: properties['FunctionName'] as string,
     };
-    if (properties['BatchSize']) updateParams.BatchSize = properties['BatchSize'] as number;
+    // Use `!== undefined` (not truthy) for any field where a falsy value
+    // is a meaningful AWS input: `0` for the *Window/*Age second-counts
+    // disables / infinite-ifies the feature, and `[]` for the array
+    // properties is the documented way to clear a previously-set list.
+    if (properties['BatchSize'] !== undefined)
+      updateParams.BatchSize = properties['BatchSize'] as number;
     if (properties['Enabled'] !== undefined)
       updateParams.Enabled = properties['Enabled'] as boolean;
-    if (properties['MaximumBatchingWindowInSeconds'])
+    if (properties['MaximumBatchingWindowInSeconds'] !== undefined)
       updateParams.MaximumBatchingWindowInSeconds = properties[
         'MaximumBatchingWindowInSeconds'
       ] as number;
@@ -203,33 +276,33 @@ export class LambdaEventSourceMappingProvider implements ResourceProvider {
       updateParams.MaximumRetryAttempts = properties['MaximumRetryAttempts'] as number;
     if (properties['BisectBatchOnFunctionError'] !== undefined)
       updateParams.BisectBatchOnFunctionError = properties['BisectBatchOnFunctionError'] as boolean;
-    if (properties['MaximumRecordAgeInSeconds'])
+    if (properties['MaximumRecordAgeInSeconds'] !== undefined)
       updateParams.MaximumRecordAgeInSeconds = properties['MaximumRecordAgeInSeconds'] as number;
-    if (properties['ParallelizationFactor'])
+    if (properties['ParallelizationFactor'] !== undefined)
       updateParams.ParallelizationFactor = properties['ParallelizationFactor'] as number;
-    if (properties['FilterCriteria'])
+    if (properties['FilterCriteria'] !== undefined)
       updateParams.FilterCriteria = properties['FilterCriteria'] as {
         Filters?: Array<{ Pattern?: string }>;
       };
-    if (properties['DestinationConfig'])
+    if (properties['DestinationConfig'] !== undefined)
       updateParams.DestinationConfig = properties[
         'DestinationConfig'
       ] as import('@aws-sdk/client-lambda').DestinationConfig;
-    if (properties['TumblingWindowInSeconds'])
+    if (properties['TumblingWindowInSeconds'] !== undefined)
       updateParams.TumblingWindowInSeconds = properties['TumblingWindowInSeconds'] as number;
-    if (properties['FunctionResponseTypes'])
+    if (properties['FunctionResponseTypes'] !== undefined)
       updateParams.FunctionResponseTypes = properties[
         'FunctionResponseTypes'
       ] as import('@aws-sdk/client-lambda').FunctionResponseType[];
-    if (properties['SourceAccessConfigurations'])
+    if (properties['SourceAccessConfigurations'] !== undefined)
       updateParams.SourceAccessConfigurations = properties[
         'SourceAccessConfigurations'
       ] as import('@aws-sdk/client-lambda').SourceAccessConfiguration[];
-    if (properties['ScalingConfig'])
+    if (properties['ScalingConfig'] !== undefined)
       updateParams.ScalingConfig = properties[
         'ScalingConfig'
       ] as import('@aws-sdk/client-lambda').ScalingConfig;
-    if (properties['DocumentDBEventSourceConfig'])
+    if (properties['DocumentDBEventSourceConfig'] !== undefined)
       updateParams.DocumentDBEventSourceConfig = properties[
         'DocumentDBEventSourceConfig'
       ] as import('@aws-sdk/client-lambda').DocumentDBEventSourceConfig;
@@ -429,10 +502,23 @@ export class LambdaEventSourceMappingProvider implements ResourceProvider {
     if (resp.TumblingWindowInSeconds !== undefined) {
       result['TumblingWindowInSeconds'] = resp.TumblingWindowInSeconds;
     }
-    result['FunctionResponseTypes'] = resp.FunctionResponseTypes
-      ? [...resp.FunctionResponseTypes]
-      : [];
-    result['SourceAccessConfigurations'] = resp.SourceAccessConfigurations ?? [];
+    // Class-1 type-discriminator gating: only emit `FunctionResponseTypes`
+    // / `SourceAccessConfigurations` placeholders when the source kind
+    // actually supports them. AWS rejects round-trip writes of empty
+    // arrays for the wrong source kind via `UpdateEventSourceMappingCommand`.
+    const kind = classifyEventSource(resp);
+    if (KINDS_WITH_FUNCTION_RESPONSE_TYPES.has(kind)) {
+      result['FunctionResponseTypes'] = resp.FunctionResponseTypes
+        ? [...resp.FunctionResponseTypes]
+        : [];
+    } else if (resp.FunctionResponseTypes !== undefined) {
+      result['FunctionResponseTypes'] = [...resp.FunctionResponseTypes];
+    }
+    if (KINDS_WITH_SOURCE_ACCESS_CONFIGURATIONS.has(kind)) {
+      result['SourceAccessConfigurations'] = resp.SourceAccessConfigurations ?? [];
+    } else if (resp.SourceAccessConfigurations !== undefined) {
+      result['SourceAccessConfigurations'] = resp.SourceAccessConfigurations;
+    }
     if (resp.SelfManagedEventSource !== undefined) {
       result['SelfManagedEventSource'] = resp.SelfManagedEventSource;
     }

--- a/src/provisioning/providers/lambda-layer-provider.ts
+++ b/src/provisioning/providers/lambda-layer-provider.ts
@@ -12,7 +12,7 @@ import {
 } from '@aws-sdk/client-lambda';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
-import { ProvisioningError } from '../../utils/error-handler.js';
+import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import { CDK_PATH_TAG } from '../import-helpers.js';
@@ -122,28 +122,41 @@ export class LambdaLayerVersionProvider implements ResourceProvider {
   }
 
   /**
-   * Update a Lambda layer version
+   * Update a Lambda layer version.
    *
-   * Lambda layer versions are immutable. An update publishes a new version.
-   * The new LayerVersionArn becomes the physical ID.
+   * Lambda layer versions are immutable on AWS — there is no API to mutate
+   * `Content` / `CompatibleRuntimes` / `CompatibleArchitectures` /
+   * `Description` / `LicenseInfo` of an existing version. The only path to
+   * a "new value" is publishing a new version (new LayerVersionArn).
+   *
+   * Why this rejects with `ResourceUpdateNotSupportedError` instead of
+   * silently publishing a new version:
+   *
+   *   - `cdkd drift --revert` calls `update(observed, observed)` to push
+   *     state values back into AWS. For an immutable resource that cannot
+   *     have its in-place value changed, the only AWS-side effect of an
+   *     "update" is leaking a duplicate version of the same content,
+   *     which is never what `--revert` should do.
+   *   - On the deploy path, content / runtime / arch changes flow
+   *     through CDK's hash-based logical naming, which produces a fresh
+   *     logical ID and a CREATE+DELETE in cdkd's diff — `update()` is
+   *     not the path taken in practice. Users who hit this on a non-CDK
+   *     template should re-deploy with `--replace`.
    */
   async update(
     logicalId: string,
-    physicalId: string,
+    _physicalId: string,
     resourceType: string,
-    properties: Record<string, unknown>,
+    _properties: Record<string, unknown>,
     _previousProperties: Record<string, unknown>
   ): Promise<ResourceUpdateResult> {
-    this.logger.debug(`Updating Lambda layer version ${logicalId}: ${physicalId}`);
-
-    // Layer versions are immutable - publish a new version
-    const createResult = await this.create(logicalId, resourceType, properties);
-
-    return {
-      physicalId: createResult.physicalId,
-      wasReplaced: true,
-      attributes: createResult.attributes ?? {},
-    };
+    return Promise.reject(
+      new ResourceUpdateNotSupportedError(
+        resourceType,
+        logicalId,
+        'Lambda layer versions are immutable on AWS; re-deploy with cdkd deploy --replace, or change the resource definition to publish a new version'
+      )
+    );
   }
 
   /**

--- a/src/provisioning/providers/lambda-url-provider.ts
+++ b/src/provisioning/providers/lambda-url-provider.ts
@@ -113,9 +113,33 @@ export class LambdaUrlProvider implements ResourceProvider {
     physicalId: string,
     _resourceType: string,
     properties: Record<string, unknown>,
-    _previousProperties: Record<string, unknown>
+    previousProperties: Record<string, unknown>
   ): Promise<ResourceUpdateResult> {
     this.logger.debug(`Updating Lambda URL ${logicalId}: ${physicalId}`);
+
+    // Diff-based no-op: when `cdkd drift --revert` round-trips the
+    // observed snapshot back through `update()` on a no-drift resource,
+    // the new and previous property maps are identical. Skip the AWS
+    // call entirely in that case so the round-trip is a logical no-op
+    // (matches the SNS / SQS provider pattern; mechanical guard
+    // documented in `tests/unit/provisioning/lambda-url-provider-roundtrip.test.ts`).
+    const handled = this.handledProperties.get('AWS::Lambda::Url') ?? new Set<string>();
+    let changed = false;
+    for (const key of handled) {
+      if (
+        JSON.stringify(properties[key] ?? null) !== JSON.stringify(previousProperties[key] ?? null)
+      ) {
+        changed = true;
+        break;
+      }
+    }
+    if (!changed) {
+      return {
+        physicalId,
+        wasReplaced: false,
+        attributes: {},
+      };
+    }
 
     const authType = (properties['AuthType'] as FunctionUrlAuthType) || 'NONE';
     const cors = properties['Cors'] as Record<string, unknown> | undefined;
@@ -124,9 +148,23 @@ export class LambdaUrlProvider implements ResourceProvider {
       FunctionName: physicalId,
       AuthType: authType,
     };
-    if (properties['InvokeMode']) updateParams.InvokeMode = properties['InvokeMode'] as InvokeMode;
+    if (properties['InvokeMode'] !== undefined)
+      updateParams.InvokeMode = properties['InvokeMode'] as InvokeMode;
+    // Class 2 sanitize: `readCurrentState` always-emits a `Cors` placeholder
+    // with empty arrays for `AllowOrigins` / `AllowMethods` / `AllowHeaders`
+    // / `ExposeHeaders` so a console-side CORS toggle on a URL configured
+    // without CORS surfaces as drift. On `cdkd drift --revert` that
+    // placeholder round-trips back through `update()` — sending an
+    // all-empty `Cors` to AWS would needlessly mutate the URL to
+    // "CORS-configured-but-empty" instead of "no CORS". Mirror
+    // `serializeRedrivePolicy` in `sqs-queue-provider.ts` and treat the
+    // empty-shape placeholder as "no CORS" (omit `Cors` from the
+    // UpdateFunctionUrlConfig input entirely).
     if (cors) {
-      updateParams.Cors = this.buildCorsConfig(cors);
+      const builtCors = this.buildCorsConfig(cors);
+      if (Object.keys(builtCors).length > 0) {
+        updateParams.Cors = builtCors;
+      }
     }
 
     const response = await this.lambdaClient.send(new UpdateFunctionUrlConfigCommand(updateParams));
@@ -301,15 +339,36 @@ export class LambdaUrlProvider implements ResourceProvider {
   }
 
   /**
-   * Build CORS configuration from CDK properties
+   * Build CORS configuration from CDK properties.
+   *
+   * Empty arrays from `readCurrentState`'s always-emit placeholder
+   * (`AllowOrigins: []`, `AllowMethods: []`, `AllowHeaders: []`,
+   * `ExposeHeaders: []`) are intentionally dropped here — emitting them
+   * to AWS would configure CORS with empty allowlists instead of
+   * leaving CORS unset. The caller (`update()` / `create()`) treats an
+   * empty `Cors` object as "no CORS configured" and omits it from the
+   * SDK input. `MaxAge` uses `!== undefined` so the valid AWS input
+   * `MaxAge: 0` (= "do not cache preflight responses") is preserved.
    */
   private buildCorsConfig(cors: Record<string, unknown>): import('@aws-sdk/client-lambda').Cors {
     const config: import('@aws-sdk/client-lambda').Cors = {};
-    if (cors['AllowOrigins']) config.AllowOrigins = cors['AllowOrigins'] as string[];
-    if (cors['AllowMethods']) config.AllowMethods = cors['AllowMethods'] as string[];
-    if (cors['AllowHeaders']) config.AllowHeaders = cors['AllowHeaders'] as string[];
-    if (cors['ExposeHeaders']) config.ExposeHeaders = cors['ExposeHeaders'] as string[];
-    if (cors['MaxAge']) config.MaxAge = cors['MaxAge'] as number;
+    const allowOrigins = cors['AllowOrigins'];
+    if (Array.isArray(allowOrigins) && allowOrigins.length > 0) {
+      config.AllowOrigins = allowOrigins as string[];
+    }
+    const allowMethods = cors['AllowMethods'];
+    if (Array.isArray(allowMethods) && allowMethods.length > 0) {
+      config.AllowMethods = allowMethods as string[];
+    }
+    const allowHeaders = cors['AllowHeaders'];
+    if (Array.isArray(allowHeaders) && allowHeaders.length > 0) {
+      config.AllowHeaders = allowHeaders as string[];
+    }
+    const exposeHeaders = cors['ExposeHeaders'];
+    if (Array.isArray(exposeHeaders) && exposeHeaders.length > 0) {
+      config.ExposeHeaders = exposeHeaders as string[];
+    }
+    if (cors['MaxAge'] !== undefined) config.MaxAge = cors['MaxAge'] as number;
     if (cors['AllowCredentials'] !== undefined)
       config.AllowCredentials = cors['AllowCredentials'] as boolean;
     return config;

--- a/tests/unit/provisioning/lambda-eventsource-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/lambda-eventsource-provider-readcurrentstate.test.ts
@@ -58,6 +58,10 @@ describe('LambdaEventSourceMappingProvider.readCurrentState', () => {
     );
 
     expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(GetEventSourceMappingCommand);
+    // SQS source supports FunctionResponseTypes but not
+    // SourceAccessConfigurations — the placeholder is type-discriminator-
+    // gated so a `cdkd drift --revert` round-trip cannot push a
+    // `SourceAccessConfigurations: []` to AWS (which would be rejected).
     expect(result).toEqual({
       FunctionName: 'arn:aws:lambda:us-east-1:123:function:fn',
       EventSourceArn: 'arn:aws:sqs:us-east-1:123:my-queue',
@@ -66,7 +70,6 @@ describe('LambdaEventSourceMappingProvider.readCurrentState', () => {
       MaximumRetryAttempts: 3,
       Enabled: true,
       FunctionResponseTypes: [],
-      SourceAccessConfigurations: [],
     });
   });
 

--- a/tests/unit/provisioning/lambda-eventsource-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/lambda-eventsource-provider-roundtrip.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateEventSourceMappingCommand } from '@aws-sdk/client-lambda';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    lambda: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { LambdaEventSourceMappingProvider } from '../../../src/provisioning/providers/lambda-eventsource-provider.js';
+
+const UUID = 'abcdef12-3456-7890-abcd-ef1234567890';
+
+describe('LambdaEventSourceMappingProvider read-update round-trip', () => {
+  let provider: LambdaEventSourceMappingProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new LambdaEventSourceMappingProvider();
+    // UpdateEventSourceMappingCommand returns the mapping ARN — keep
+    // the mock generic so the tag-diff branch in update() is satisfied.
+    mockSend.mockResolvedValue({
+      EventSourceMappingArn: `arn:aws:lambda:us-east-1:123:event-source-mapping:${UUID}`,
+    });
+  });
+
+  it('Class 1 — SQS source round-trip does NOT push SourceAccessConfigurations to AWS', async () => {
+    // Mechanical guard for Class 1 placeholder regression on SQS sources.
+    // SourceAccessConfigurations is only valid for Kafka / MQ / DocumentDB —
+    // pushing `[]` against an SQS source is rejected by
+    // UpdateEventSourceMappingCommand. The Class 1 guard kicks in at
+    // readCurrentState (not emitted on SQS) so the field never reaches
+    // update().
+    const observed = {
+      FunctionName: 'arn:aws:lambda:us-east-1:123:function:fn',
+      EventSourceArn: 'arn:aws:sqs:us-east-1:123:my-queue',
+      BatchSize: 10,
+      Enabled: true,
+      FunctionResponseTypes: [] as string[],
+      // SourceAccessConfigurations intentionally absent (Class-1 guarded out)
+    };
+
+    await provider.update('L', UUID, 'AWS::Lambda::EventSourceMapping', observed, observed);
+
+    const updateCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UpdateEventSourceMappingCommand
+    );
+    expect(updateCall).toBeDefined();
+    const input = updateCall?.[0].input as { SourceAccessConfigurations?: unknown };
+    expect(input.SourceAccessConfigurations).toBeUndefined();
+  });
+
+  it('Class 1 — Kafka source round-trip does NOT push FunctionResponseTypes to AWS', async () => {
+    // FunctionResponseTypes is only valid for SQS / Kinesis / DynamoDB
+    // (the sources where ReportBatchItemFailures applies). Pushing `[]`
+    // against a Kafka source is rejected.
+    const observed = {
+      FunctionName: 'arn:aws:lambda:us-east-1:123:function:fn',
+      EventSourceArn: 'arn:aws:kafka:us-east-1:123:cluster/my-cluster/abc',
+      BatchSize: 100,
+      Enabled: true,
+      SourceAccessConfigurations: [] as Array<{ Type?: string; URI?: string }>,
+      // FunctionResponseTypes intentionally absent (Class-1 guarded out)
+    };
+
+    await provider.update('L', UUID, 'AWS::Lambda::EventSourceMapping', observed, observed);
+
+    const updateCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UpdateEventSourceMappingCommand
+    );
+    expect(updateCall).toBeDefined();
+    const input = updateCall?.[0].input as { FunctionResponseTypes?: unknown };
+    expect(input.FunctionResponseTypes).toBeUndefined();
+  });
+
+  it('Kinesis source round-trip preserves StartingPosition / ParallelizationFactor without rejection', async () => {
+    // Kinesis-specific fields are populated and survive the round-trip
+    // — the truthy-gate fix ensures `0`-valued fields like
+    // TumblingWindowInSeconds (used to disable) reach AWS.
+    const observed = {
+      FunctionName: 'arn:aws:lambda:us-east-1:123:function:fn',
+      EventSourceArn: 'arn:aws:kinesis:us-east-1:123:stream/my-stream',
+      BatchSize: 50,
+      StartingPosition: 'LATEST',
+      ParallelizationFactor: 2,
+      MaximumRecordAgeInSeconds: -1, // infinite — falsy under truthy-gate, must reach AWS
+      TumblingWindowInSeconds: 0, // disabled — falsy under truthy-gate, must reach AWS
+      MaximumBatchingWindowInSeconds: 0, // disabled — falsy under truthy-gate
+      Enabled: true,
+      FunctionResponseTypes: [] as string[],
+    };
+
+    await provider.update('L', UUID, 'AWS::Lambda::EventSourceMapping', observed, observed);
+
+    const updateCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UpdateEventSourceMappingCommand
+    );
+    expect(updateCall).toBeDefined();
+    const input = updateCall?.[0].input as {
+      ParallelizationFactor?: number;
+      MaximumRecordAgeInSeconds?: number;
+      TumblingWindowInSeconds?: number;
+      MaximumBatchingWindowInSeconds?: number;
+      SourceAccessConfigurations?: unknown;
+    };
+    expect(input.ParallelizationFactor).toBe(2);
+    // Falsy-but-meaningful values must reach AWS — this is the truthy-gate fix.
+    expect(input.MaximumRecordAgeInSeconds).toBe(-1);
+    expect(input.TumblingWindowInSeconds).toBe(0);
+    expect(input.MaximumBatchingWindowInSeconds).toBe(0);
+    // Class-1 guard: Kinesis does not get SourceAccessConfigurations.
+    expect(input.SourceAccessConfigurations).toBeUndefined();
+  });
+
+  it('round-trip on no-drift snapshot does not push placeholder arrays of the wrong source kind', async () => {
+    // Stronger assertion: state == AWS implies update() must not push
+    // anything that would round-trip-reject. The Class-1 guard keeps
+    // wrong-kind placeholders from ever entering state, so this is the
+    // structural guard for the next change to readCurrentState/update.
+    const observed = {
+      FunctionName: 'arn:aws:lambda:us-east-1:123:function:fn',
+      EventSourceArn: 'arn:aws:dynamodb:us-east-1:123:table/my-table/stream/2024',
+      BatchSize: 100,
+      StartingPosition: 'TRIM_HORIZON',
+      Enabled: true,
+      FunctionResponseTypes: [] as string[],
+      // No SourceAccessConfigurations — DynamoDB Streams doesn't support it.
+    };
+
+    await provider.update('L', UUID, 'AWS::Lambda::EventSourceMapping', observed, observed);
+
+    const updateCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UpdateEventSourceMappingCommand
+    );
+    expect(updateCall).toBeDefined();
+    const input = updateCall?.[0].input as Record<string, unknown>;
+    expect(input.SourceAccessConfigurations).toBeUndefined();
+  });
+});

--- a/tests/unit/provisioning/lambda-function-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/lambda-function-provider-roundtrip.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  GetFunctionCommand,
+  UpdateFunctionConfigurationCommand,
+  UpdateFunctionCodeCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from '@aws-sdk/client-lambda';
+
+// Mock AWS clients before importing the provider
+const mockLambdaSend = vi.fn();
+const mockEc2Send = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    lambda: {
+      send: mockLambdaSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    },
+    ec2: { send: mockEc2Send },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+// SDK waiter polls GetFunction; short-circuit it.
+vi.mock('@aws-sdk/client-lambda', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-lambda')>(
+    '@aws-sdk/client-lambda'
+  );
+  return {
+    ...actual,
+    waitUntilFunctionUpdatedV2: vi.fn().mockResolvedValue({ state: 'SUCCESS' }),
+  };
+});
+
+import { LambdaFunctionProvider } from '../../../src/provisioning/providers/lambda-function-provider.js';
+
+const FUNCTION_NAME = 'fn-roundtrip';
+
+describe('LambdaFunctionProvider read-update round-trip', () => {
+  let provider: LambdaFunctionProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new LambdaFunctionProvider();
+  });
+
+  it('Class 2 — non-VPC observed snapshot round-trips without AWS-rejection-shape input', async () => {
+    // Mechanical guard for Class 2 placeholder regression on
+    // structurally-incomplete-when-empty fields (VpcConfig). See
+    // docs/provider-development.md § 3b "Read-update round-trip test".
+    //
+    // readCurrentState always-emits VpcConfig with empty arrays for
+    // non-VPC functions (the placeholder is required so the comparator's
+    // top-level walk detects a console-side VPC attach). Round-tripping
+    // that placeholder via update() must NOT produce a VpcConfig payload
+    // that AWS rejects (e.g. SubnetIds: undefined, partial-shape input).
+    //
+    // The diff in update() compares state vs previous via JSON.stringify;
+    // when state == previous (no drift), no UpdateFunctionConfigurationCommand
+    // should fire at all.
+    mockLambdaSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetFunctionCommand) {
+        return Promise.resolve({
+          Configuration: { FunctionArn: `arn:aws:lambda:us-east-1:0:function:${FUNCTION_NAME}`, FunctionName: FUNCTION_NAME },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    // Snapshot matches what readCurrentState produces for a non-VPC
+    // function: every always-emit placeholder is present.
+    const observed = {
+      FunctionName: FUNCTION_NAME,
+      Runtime: 'nodejs20.x',
+      Handler: 'index.handler',
+      Role: 'arn:aws:iam::0:role/exec',
+      Timeout: 3,
+      MemorySize: 128,
+      PackageType: 'Zip',
+      Description: '',
+      Environment: { Variables: {} },
+      Layers: [] as string[],
+      Architectures: ['x86_64'],
+      TracingConfig: { Mode: 'PassThrough' },
+      VpcConfig: {
+        SubnetIds: [] as string[],
+        SecurityGroupIds: [] as string[],
+        Ipv6AllowedForDualStack: false,
+      },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await provider.update('L', FUNCTION_NAME, 'AWS::Lambda::Function', observed, observed);
+
+    // No drift → no UpdateFunctionConfigurationCommand fires (the
+    // JSON.stringify diff in update() detects "no config change" and
+    // skips the call entirely).
+    const updateConfigCalls = mockLambdaSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateFunctionConfigurationCommand
+    );
+    expect(updateConfigCalls).toHaveLength(0);
+
+    // No drift → no UpdateFunctionCodeCommand either (Code subtree is
+    // declared via getDriftUnknownPaths, but the diff guard also short-
+    // circuits on equal Code values; here Code is absent on both sides).
+    const updateCodeCalls = mockLambdaSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateFunctionCodeCommand
+    );
+    expect(updateCodeCalls).toHaveLength(0);
+
+    // No drift → no tag mutations.
+    const tagCalls = mockLambdaSend.mock.calls.filter(
+      (c) => c[0] instanceof TagResourceCommand || c[0] instanceof UntagResourceCommand
+    );
+    expect(tagCalls).toHaveLength(0);
+  });
+
+  it('Class 2 — VPC observed snapshot round-trips without AWS-rejection-shape input', async () => {
+    // Complement of the non-VPC test: when the function IS attached to
+    // a VPC, the snapshot has populated SubnetIds / SecurityGroupIds.
+    // Round-tripping must still produce zero AWS-side mutations when
+    // state == observed.
+    mockLambdaSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetFunctionCommand) {
+        return Promise.resolve({
+          Configuration: { FunctionArn: `arn:aws:lambda:us-east-1:0:function:${FUNCTION_NAME}`, FunctionName: FUNCTION_NAME },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const observed = {
+      FunctionName: FUNCTION_NAME,
+      Runtime: 'nodejs20.x',
+      Handler: 'index.handler',
+      Role: 'arn:aws:iam::0:role/exec',
+      Timeout: 30,
+      MemorySize: 256,
+      PackageType: 'Zip',
+      Description: 'a function',
+      Environment: { Variables: { FOO: 'bar' } },
+      Layers: ['arn:aws:lambda:us-east-1:0:layer:l1:1'],
+      Architectures: ['arm64'],
+      TracingConfig: { Mode: 'Active' },
+      EphemeralStorage: { Size: 1024 },
+      VpcConfig: {
+        SubnetIds: ['subnet-a'],
+        SecurityGroupIds: ['sg-1'],
+        Ipv6AllowedForDualStack: false,
+      },
+      Tags: [{ Key: 'Foo', Value: 'Bar' }],
+    };
+
+    await provider.update('L', FUNCTION_NAME, 'AWS::Lambda::Function', observed, observed);
+
+    const updateConfigCalls = mockLambdaSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateFunctionConfigurationCommand
+    );
+    expect(updateConfigCalls).toHaveLength(0);
+
+    const updateCodeCalls = mockLambdaSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateFunctionCodeCommand
+    );
+    expect(updateCodeCalls).toHaveLength(0);
+
+    const tagCalls = mockLambdaSend.mock.calls.filter(
+      (c) => c[0] instanceof TagResourceCommand || c[0] instanceof UntagResourceCommand
+    );
+    expect(tagCalls).toHaveLength(0);
+  });
+
+  it('round-trip on no-drift snapshot is a logical no-op (zero AWS-mutating calls)', async () => {
+    // Stronger assertion for diff-based providers: state == AWS implies
+    // update() must make no AWS-side mutations. The structural guard
+    // for the next time someone changes update()'s diff logic.
+    mockLambdaSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetFunctionCommand) {
+        return Promise.resolve({
+          Configuration: { FunctionArn: `arn:aws:lambda:us-east-1:0:function:${FUNCTION_NAME}`, FunctionName: FUNCTION_NAME },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const observed = {
+      FunctionName: FUNCTION_NAME,
+      Runtime: 'nodejs20.x',
+      Handler: 'index.handler',
+      Role: 'arn:aws:iam::0:role/exec',
+      Timeout: 3,
+      MemorySize: 128,
+      PackageType: 'Zip',
+      Description: '',
+      Environment: { Variables: {} },
+      Layers: [] as string[],
+      Architectures: ['x86_64'],
+      TracingConfig: { Mode: 'PassThrough' },
+      VpcConfig: {
+        SubnetIds: [] as string[],
+        SecurityGroupIds: [] as string[],
+        Ipv6AllowedForDualStack: false,
+      },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await provider.update('L', FUNCTION_NAME, 'AWS::Lambda::Function', observed, observed);
+
+    // Strongest possible guarantee: every mutating Lambda command class
+    // is checked here. Only the read-only GetFunctionCommand may fire
+    // (we need its FunctionArn for the tag-diff path).
+    const mutatingCalls = mockLambdaSend.mock.calls.filter(
+      (c) =>
+        c[0] instanceof UpdateFunctionConfigurationCommand ||
+        c[0] instanceof UpdateFunctionCodeCommand ||
+        c[0] instanceof TagResourceCommand ||
+        c[0] instanceof UntagResourceCommand
+    );
+    expect(mutatingCalls).toHaveLength(0);
+  });
+});

--- a/tests/unit/provisioning/lambda-layer-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/lambda-layer-provider-roundtrip.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  PublishLayerVersionCommand,
+  DeleteLayerVersionCommand,
+} from '@aws-sdk/client-lambda';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    lambda: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { LambdaLayerVersionProvider } from '../../../src/provisioning/providers/lambda-layer-provider.js';
+import { ResourceUpdateNotSupportedError } from '../../../src/utils/error-handler.js';
+
+const LAYER_VERSION_ARN = 'arn:aws:lambda:us-east-1:123456789012:layer:my-layer:5';
+
+describe('LambdaLayerVersionProvider read-update round-trip', () => {
+  let provider: LambdaLayerVersionProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new LambdaLayerVersionProvider();
+  });
+
+  it('round-trip on no-drift snapshot makes ZERO mutating SDK calls (immutable resource)', async () => {
+    // Lambda layer versions are immutable on AWS. `cdkd drift --revert`
+    // calls update(observed, observed) to push state values back into
+    // AWS. For an immutable resource, the only "update" path AWS exposes
+    // is publishing a new version — which on a no-drift round-trip is
+    // pure leak (duplicate content, new ARN). The provider must reject
+    // up front with ResourceUpdateNotSupportedError instead of firing
+    // a PublishLayerVersionCommand.
+    const observed = {
+      LayerName: 'my-layer',
+      Description: 'utility layer',
+      CompatibleRuntimes: ['nodejs20.x'],
+      CompatibleArchitectures: ['x86_64'],
+      LicenseInfo: 'MIT',
+    };
+
+    await expect(
+      provider.update(
+        'MyLayer',
+        LAYER_VERSION_ARN,
+        'AWS::Lambda::LayerVersion',
+        observed,
+        observed
+      )
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    // Crucially: NO mutating Lambda SDK calls fired.
+    const publishCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PublishLayerVersionCommand
+    );
+    const deleteCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof DeleteLayerVersionCommand
+    );
+    expect(publishCalls).toHaveLength(0);
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  it('round-trip with empty CompatibleRuntimes / CompatibleArchitectures absent makes ZERO mutating SDK calls', async () => {
+    // Verifies the Class 2 guard: readCurrentState gates these arrays
+    // on `length > 0`, so a layer with no runtimes / no architectures
+    // produces a snapshot WITHOUT those keys (not `[]`). The round-trip
+    // must still reject cleanly without sending an invalid empty-array
+    // PublishLayerVersion input.
+    const observed = {
+      LayerName: 'my-layer',
+      // CompatibleRuntimes / CompatibleArchitectures / Description /
+      // LicenseInfo all absent — readCurrentState does not emit empty
+      // placeholders for these.
+    };
+
+    await expect(
+      provider.update(
+        'MyLayer',
+        LAYER_VERSION_ARN,
+        'AWS::Lambda::LayerVersion',
+        observed,
+        observed
+      )
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    expect(
+      mockSend.mock.calls.filter((c) => c[0] instanceof PublishLayerVersionCommand)
+    ).toHaveLength(0);
+  });
+
+  it('error message names the resource type and points at --replace', async () => {
+    // The user-facing message must direct users to the right escape
+    // hatch (cdkd deploy --replace) rather than leaving them stuck on
+    // an immutable update rejection.
+    const observed = { LayerName: 'my-layer' };
+
+    try {
+      await provider.update(
+        'MyLayer',
+        LAYER_VERSION_ARN,
+        'AWS::Lambda::LayerVersion',
+        observed,
+        observed
+      );
+      throw new Error('expected update() to reject');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResourceUpdateNotSupportedError);
+      const e = err as ResourceUpdateNotSupportedError;
+      expect(e.resourceType).toBe('AWS::Lambda::LayerVersion');
+      expect(e.logicalId).toBe('MyLayer');
+      expect(e.message).toContain('--replace');
+    }
+  });
+});

--- a/tests/unit/provisioning/lambda-permission-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/lambda-permission-provider-roundtrip.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AddPermissionCommand, RemovePermissionCommand } from '@aws-sdk/client-lambda';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    lambda: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { LambdaPermissionProvider } from '../../../src/provisioning/providers/lambda-permission-provider.js';
+
+const PHYSICAL_ID = 'AllowSnsInvoke';
+
+describe('LambdaPermissionProvider read-update round-trip', () => {
+  let provider: LambdaPermissionProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: RemovePermission and AddPermission both succeed.
+    mockSend.mockResolvedValue({});
+    provider = new LambdaPermissionProvider();
+  });
+
+  it('round-trip on state==AWS produces exactly one Remove + one Add (remove+add design contract)', async () => {
+    // Lambda Permission's update() is structurally remove+add (no in-place
+    // UpdatePermission API). Unlike diff-based providers (SNS / SQS), state ==
+    // AWS does NOT yield zero SDK calls — it yields exactly one remove and
+    // one add. This test pins that contract so a future "skip if no diff"
+    // optimization can't silently regress drift --revert correctness.
+    const observed = {
+      FunctionName: 'my-function',
+      Action: 'lambda:InvokeFunction',
+      Principal: 'sns.amazonaws.com',
+      SourceArn: 'arn:aws:sns:us-east-1:123456789012:my-topic',
+    };
+
+    await provider.update(
+      'AllowSnsInvoke',
+      PHYSICAL_ID,
+      'AWS::Lambda::Permission',
+      observed,
+      observed
+    );
+
+    const removeCalls = mockSend.mock.calls.filter(
+      (c: unknown[]) => c[0] instanceof RemovePermissionCommand
+    );
+    const addCalls = mockSend.mock.calls.filter(
+      (c: unknown[]) => c[0] instanceof AddPermissionCommand
+    );
+    expect(removeCalls).toHaveLength(1);
+    expect(addCalls).toHaveLength(1);
+  });
+
+  it('Class 2 guard — permission with no SourceArn/SourceAccount/PrincipalOrgID/EventSourceToken does NOT send empty-string conditions to AWS', async () => {
+    // The Class 2 bug class: readCurrentState's optional condition fields
+    // (SourceArn / SourceAccount / PrincipalOrgID / EventSourceToken) must
+    // not surface as empty-string placeholders that the write layer then
+    // forwards to AddPermission. AWS rejects empty SourceArn with a
+    // ValidationException; if a future readCurrentState change ever
+    // started always-emitting these as '', drift --revert would crash.
+    //
+    // readCurrentState today only emits these keys when the policy
+    // statement actually has them — verified in the dedicated
+    // readCurrentState test file. This round-trip test is the structural
+    // guard against a regression in either layer.
+    const observed = {
+      FunctionName: 'my-function',
+      Action: 'lambda:InvokeFunction',
+      Principal: '*',
+      // No SourceArn, SourceAccount, PrincipalOrgID, EventSourceToken.
+    };
+
+    await provider.update('AllowAny', PHYSICAL_ID, 'AWS::Lambda::Permission', observed, observed);
+
+    const addCalls = mockSend.mock.calls.filter(
+      (c: unknown[]) => c[0] instanceof AddPermissionCommand
+    );
+    expect(addCalls).toHaveLength(1);
+    const firstAdd = addCalls[0] as [AddPermissionCommand];
+    const input = firstAdd[0].input as Record<string, unknown>;
+    // Optional fields must be entirely absent — not '' / null / undefined-as-key.
+    expect(input).not.toHaveProperty('SourceArn');
+    expect(input).not.toHaveProperty('SourceAccount');
+    expect(input).not.toHaveProperty('PrincipalOrgID');
+    expect(input).not.toHaveProperty('EventSourceToken');
+    expect(input).not.toHaveProperty('FunctionUrlAuthType');
+    // Required fields must be present and correctly populated.
+    expect(input['FunctionName']).toBe('my-function');
+    expect(input['Action']).toBe('lambda:InvokeFunction');
+    expect(input['Principal']).toBe('*');
+  });
+
+  it('round-trip with full optional fields preserves them on AddPermission', async () => {
+    // Complement to the Class 2 guard: when readCurrentState legitimately
+    // emits SourceArn / SourceAccount, the round-trip must forward them
+    // unchanged so AWS rebuilds the same statement.
+    const observed = {
+      FunctionName: 'my-function',
+      Action: 'lambda:InvokeFunction',
+      Principal: 's3.amazonaws.com',
+      SourceArn: 'arn:aws:s3:::my-bucket',
+      SourceAccount: '123456789012',
+    };
+
+    await provider.update('AllowS3', PHYSICAL_ID, 'AWS::Lambda::Permission', observed, observed);
+
+    const addCalls = mockSend.mock.calls.filter(
+      (c: unknown[]) => c[0] instanceof AddPermissionCommand
+    );
+    expect(addCalls).toHaveLength(1);
+    const firstAdd = addCalls[0] as [AddPermissionCommand];
+    const input = firstAdd[0].input as Record<string, unknown>;
+    expect(input['SourceArn']).toBe('arn:aws:s3:::my-bucket');
+    expect(input['SourceAccount']).toBe('123456789012');
+    expect(input['Principal']).toBe('s3.amazonaws.com');
+  });
+});

--- a/tests/unit/provisioning/lambda-url-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/lambda-url-provider-roundtrip.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateFunctionUrlConfigCommand } from '@aws-sdk/client-lambda';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    lambda: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { LambdaUrlProvider } from '../../../src/provisioning/providers/lambda-url-provider.js';
+
+const TARGET_FN_ARN = 'arn:aws:lambda:us-east-1:123456789012:function:my-fn';
+
+describe('LambdaUrlProvider read-update round-trip', () => {
+  let provider: LambdaUrlProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new LambdaUrlProvider();
+  });
+
+  it('Class 2 — URL with no CORS does not send all-empty Cors to AWS on round-trip', async () => {
+    // Mechanical guard for Class 2 placeholder regression on
+    // structurally-incomplete-when-empty fields. See
+    // docs/provider-development.md § 3b "Read-update round-trip test".
+    //
+    // `readCurrentState` always-emits a `Cors` placeholder with empty
+    // arrays for every sub-list so a console-side CORS toggle on a URL
+    // configured without CORS surfaces as drift. On `cdkd drift
+    // --revert` that placeholder must NOT round-trip into AWS as
+    // `Cors: { AllowOrigins: [], AllowMethods: [], ... }` — that would
+    // configure CORS-with-empty-allowlists instead of leaving CORS unset.
+    const observed = {
+      TargetFunctionArn: TARGET_FN_ARN,
+      AuthType: 'NONE',
+      InvokeMode: 'BUFFERED',
+      Cors: {
+        AllowOrigins: [],
+        AllowMethods: [],
+        AllowHeaders: [],
+        ExposeHeaders: [],
+      },
+    };
+
+    // Force the diff-based no-op gate open by changing one harmless
+    // field, so we can inspect the actual UpdateFunctionUrlConfigCommand
+    // payload that would be sent to AWS.
+    const next = { ...observed, AuthType: 'AWS_IAM' };
+
+    mockSend.mockResolvedValueOnce({
+      FunctionUrl: 'https://abc.lambda-url.us-east-1.on.aws/',
+      FunctionArn: TARGET_FN_ARN,
+    });
+
+    await provider.update('L', TARGET_FN_ARN, 'AWS::Lambda::Url', next, observed);
+
+    const updateCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateFunctionUrlConfigCommand
+    );
+    expect(updateCalls).toHaveLength(1);
+    const input = updateCalls[0]?.[0].input as { Cors?: unknown };
+    // Class 2: an all-empty Cors must NOT reach AWS — it's the read-side
+    // "no CORS configured" placeholder, not a real CORS configuration.
+    expect(input.Cors).toBeUndefined();
+  });
+
+  it('round-trip on no-drift snapshot is a logical no-op (zero UpdateFunctionUrlConfigCommand calls)', async () => {
+    // Stronger assertion for the diff-based no-op gate: state == AWS
+    // implies update() must make no AWS-side mutations, so `cdkd drift
+    // --revert` on a no-drift resource cannot accidentally clobber the
+    // URL config.
+    const observed = {
+      TargetFunctionArn: TARGET_FN_ARN,
+      AuthType: 'AWS_IAM',
+      InvokeMode: 'BUFFERED',
+      Cors: {
+        AllowOrigins: [],
+        AllowMethods: [],
+        AllowHeaders: [],
+        ExposeHeaders: [],
+      },
+    };
+
+    await provider.update('L', TARGET_FN_ARN, 'AWS::Lambda::Url', observed, observed);
+
+    const updateCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateFunctionUrlConfigCommand
+    );
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it('URL with CORS configured: round-trip preserves CORS fields without rejection', async () => {
+    // The complement of the no-CORS test: a URL with real CORS
+    // configured must round-trip through update() with the CORS payload
+    // intact. Catches the over-eager Class 2 sanitize regression
+    // (dropping legitimate non-empty arrays).
+    const observed = {
+      TargetFunctionArn: TARGET_FN_ARN,
+      AuthType: 'NONE',
+      InvokeMode: 'BUFFERED',
+      Cors: {
+        AllowOrigins: ['https://example.com'],
+        AllowMethods: ['GET', 'POST'],
+        AllowHeaders: ['Content-Type'],
+        ExposeHeaders: [],
+        MaxAge: 0,
+        AllowCredentials: false,
+      },
+    };
+
+    // Force the diff-based no-op gate open with a harmless field change.
+    const next = { ...observed, AuthType: 'AWS_IAM' };
+
+    mockSend.mockResolvedValueOnce({
+      FunctionUrl: 'https://abc.lambda-url.us-east-1.on.aws/',
+      FunctionArn: TARGET_FN_ARN,
+    });
+
+    await provider.update('L', TARGET_FN_ARN, 'AWS::Lambda::Url', next, observed);
+
+    const updateCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateFunctionUrlConfigCommand
+    );
+    expect(updateCalls).toHaveLength(1);
+    const input = updateCalls[0]?.[0].input as {
+      Cors?: {
+        AllowOrigins?: string[];
+        AllowMethods?: string[];
+        AllowHeaders?: string[];
+        ExposeHeaders?: string[];
+        MaxAge?: number;
+        AllowCredentials?: boolean;
+      };
+    };
+    expect(input.Cors).toBeDefined();
+    expect(input.Cors?.AllowOrigins).toEqual(['https://example.com']);
+    expect(input.Cors?.AllowMethods).toEqual(['GET', 'POST']);
+    expect(input.Cors?.AllowHeaders).toEqual(['Content-Type']);
+    // ExposeHeaders empty array is sanitized away (Class 2).
+    expect(input.Cors?.ExposeHeaders).toBeUndefined();
+    // Truthy-gate guard: MaxAge: 0 is a valid AWS input (= "do not
+    // cache preflight responses") and must reach the AWS call.
+    expect(input.Cors?.MaxAge).toBe(0);
+    expect(input.Cors?.AllowCredentials).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

PR 1/5 of the post-#162 provider round-trip audit. Audits the 5 Lambda providers for the 3 latent bug classes (Class 1 type-discriminator placeholder, Class 2 structurally-incomplete placeholder, truthy gate) documented in `docs/provider-development.md § 3b` and adds round-trip property tests to all of them.

| Provider | Class 1 fix | Class 2 fix | Truthy gate fix | Round-trip tests |
|---|---|---|---|---|
| `LambdaFunctionProvider` | — | — (already correct) | — | 3 |
| `LambdaEventSourceProvider` | **2** (`FunctionResponseTypes`, `SourceAccessConfigurations` gated on source kind) | — | **11** (`BatchSize`, `MaximumBatchingWindowInSeconds=0`, `MaximumRecordAgeInSeconds=-1`, `ParallelizationFactor`, `TumblingWindowInSeconds=0`, etc.) | 4 |
| `LambdaUrlProvider` | — | **1** (`Cors: {}` empty-arrays form omitted from `UpdateFunctionUrlConfigCommand`) | **2** (`MaxAge: 0`, `InvokeMode`) | 3 |
| `LambdaLayerProvider` | — | — | — | 3 + **structural fix**: `update()` now rejects with `ResourceUpdateNotSupportedError` instead of always-replacing via `create()` (which leaked duplicate `LayerVersion`s on no-drift `--revert`) |
| `LambdaPermissionProvider` | — | — | — | 3 |

### Highlights

- **Lambda EventSource source-kind gating**: New `classifyEventSource` helper infers source kind from `EventSourceArn` prefix or sibling config; `FunctionResponseTypes` (SQS/Kinesis/DynamoDB-only) and `SourceAccessConfigurations` (Kafka/MQ/DocumentDB-only) are now only emitted on matching sources.
- **Lambda Url `Cors: {}` round-trip**: `update()` short-circuits on JSON-equality diff over handled properties; `buildCorsConfig` rewritten to drop empty/non-array `Allow*`/`ExposeHeaders` and gate `MaxAge` on `!== undefined`; the resulting `{}` is omitted from the SDK input so AWS doesn't reconfigure to "CORS with empty allowlists".
- **Lambda Layer immutable contract**: `update()` no longer publishes a new layer version per call — it now rejects up front. Real-world deploy flows (CDK hash-based naming) hit CREATE+DELETE so this does not regress deploy.

## Test plan

- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` clean
- [x] `npx vitest --run` — 1704 tests pass (was 1688; **16 new round-trip tests**)
- [x] `/run-integ lambda` — deploy 7/7 in 45s, destroy 7/7 / 0 errors / 0 orphans

## Out of scope

PRs 2-5 will cover the remaining 23+ providers in the same pattern (data layer, network, compute/API, tail).
