### PR TITLE
fix(drift): round-trip audit for data-layer providers (PR 2/5)

### DIFF
--- a/src/provisioning/providers/dynamodb-table-provider.ts
+++ b/src/provisioning/providers/dynamodb-table-provider.ts
@@ -480,24 +480,50 @@ export class DynamoDBTableProvider implements ResourceProvider {
           WriteCapacityUnits: table.ProvisionedThroughput.WriteCapacityUnits,
         };
       }
-      if (table.StreamSpecification) {
+      // Class 1 guard: StreamSpecification.StreamViewType is only valid when
+      // a stream is enabled. AWS returns the StreamSpecification block on
+      // tables that USED TO have a stream (StreamEnabled: false, no
+      // StreamViewType) — emitting that placeholder back through a
+      // round-trip drift --revert would push a CFn-invalid shape (a
+      // StreamSpecification without StreamViewType is rejected). Only
+      // surface the block when the stream is actually enabled.
+      if (table.StreamSpecification?.StreamEnabled && table.StreamSpecification.StreamViewType) {
         result['StreamSpecification'] = {
-          StreamEnabled: table.StreamSpecification.StreamEnabled,
+          StreamEnabled: true,
           StreamViewType: table.StreamSpecification.StreamViewType,
         };
       }
-      result['GlobalSecondaryIndexes'] = table.GlobalSecondaryIndexes ?? [];
-      result['LocalSecondaryIndexes'] = table.LocalSecondaryIndexes ?? [];
-      // CFn's SSESpecification.SSEEnabled / KMSMasterKeyId / SSEType.
-      const sse: Record<string, unknown> = {
-        SSEEnabled: table.SSEDescription?.Status === 'ENABLED',
-      };
-      if (table.SSEDescription?.KMSMasterKeyArn !== undefined) {
-        sse['KMSMasterKeyId'] = table.SSEDescription.KMSMasterKeyArn;
+      // Class 2 guard: GSI / LSI placeholders. AWS omits these blocks when
+      // none exist; the previous `?? []` always-emitted an empty array
+      // which round-trips through `update()` as an instruction to "remove
+      // all GSIs", and on the LSI side LSIs are immutable post-create so
+      // the empty-array placeholder is a guaranteed AWS rejection on any
+      // future provider.update() that learns to handle the field. Only
+      // surface when AWS reports indexes.
+      if (table.GlobalSecondaryIndexes && table.GlobalSecondaryIndexes.length > 0) {
+        result['GlobalSecondaryIndexes'] = table.GlobalSecondaryIndexes;
       }
-      if (table.SSEDescription?.SSEType !== undefined)
-        sse['SSEType'] = table.SSEDescription.SSEType;
-      result['SSESpecification'] = sse;
+      if (table.LocalSecondaryIndexes && table.LocalSecondaryIndexes.length > 0) {
+        result['LocalSecondaryIndexes'] = table.LocalSecondaryIndexes;
+      }
+      // Class 1 guard: CFn's SSESpecification.KMSMasterKeyId / SSEType are
+      // only valid when SSEEnabled=true. AWS reports SSEDescription.Status
+      // = 'DISABLED' (or omits SSEDescription entirely) on tables without
+      // SSE; the previous always-emit `{ SSEEnabled: false }` placeholder
+      // round-trips fine when state matches but breaks the moment a
+      // future SSE-aware update() learns to read `SSESpecification` —
+      // `{ SSEEnabled: false, KMSMasterKeyId: '...' }` is rejected by
+      // AWS. Only surface the block when SSE is actually enabled.
+      if (table.SSEDescription?.Status === 'ENABLED') {
+        const sse: Record<string, unknown> = { SSEEnabled: true };
+        if (table.SSEDescription.KMSMasterKeyArn !== undefined) {
+          sse['KMSMasterKeyId'] = table.SSEDescription.KMSMasterKeyArn;
+        }
+        if (table.SSEDescription.SSEType !== undefined) {
+          sse['SSEType'] = table.SSEDescription.SSEType;
+        }
+        result['SSESpecification'] = sse;
+      }
       if (table.DeletionProtectionEnabled !== undefined) {
         result['DeletionProtectionEnabled'] = table.DeletionProtectionEnabled;
       }

--- a/src/provisioning/providers/elasticache-provider.ts
+++ b/src/provisioning/providers/elasticache-provider.ts
@@ -399,12 +399,22 @@ export class ElastiCacheProvider implements ResourceProvider {
     this.logger.debug(`Updating CacheCluster ${logicalId}: ${physicalId}`);
 
     try {
+      // Class 2 sanitization: `readCurrentState` always-emits
+      // `VpcSecurityGroupIds: []` for clusters without VPC SGs (legacy
+      // EC2-Classic, or transient state). Round-tripping an empty array
+      // through `ModifyCacheClusterCommand.SecurityGroupIds` makes AWS
+      // reject with "must specify at least one security group" — pass
+      // `undefined` instead so AWS treats the field as "no change".
+      // Drift detection is unaffected: state `[]` vs AWS `[sg-1]` still
+      // surfaces as drift on the read side.
+      const rawSgIds = properties['VpcSecurityGroupIds'] as string[] | undefined;
+      const sgIds = rawSgIds && rawSgIds.length > 0 ? rawSgIds : undefined;
       await this.getClient().send(
         new ModifyCacheClusterCommand({
           CacheClusterId: physicalId,
           NumCacheNodes:
             properties['NumCacheNodes'] != null ? Number(properties['NumCacheNodes']) : undefined,
-          SecurityGroupIds: properties['VpcSecurityGroupIds'] as string[] | undefined,
+          SecurityGroupIds: sgIds,
           CacheParameterGroupName: properties['CacheParameterGroupName'] as string | undefined,
           EngineVersion: properties['EngineVersion'] as string | undefined,
           PreferredMaintenanceWindow: properties['PreferredMaintenanceWindow'] as
@@ -732,7 +742,14 @@ export class ElastiCacheProvider implements ResourceProvider {
     }
     if (cluster.IpDiscovery !== undefined) result['IpDiscovery'] = cluster.IpDiscovery;
     if (cluster.NetworkType !== undefined) result['NetworkType'] = cluster.NetworkType;
-    if (cluster.TransitEncryptionEnabled !== undefined) {
+    // Class 1 gate: `TransitEncryptionEnabled` is redis-only on
+    // CreateCacheClusterCommand. AWS DescribeCacheClusters returns the
+    // field for both engines (false for memcached), but emitting it on
+    // a memcached cluster would, if any future `update()` change ships
+    // it to ModifyCacheClusterCommand, get rejected with "TransitEncryption
+    // is only valid for Redis". Gate the read-side emit on the engine
+    // discriminator so the placeholder cannot leak through round-trip.
+    if (cluster.Engine === 'redis' && cluster.TransitEncryptionEnabled !== undefined) {
       result['TransitEncryptionEnabled'] = cluster.TransitEncryptionEnabled;
     }
     if (cluster.CacheNodes?.[0]?.Endpoint?.Port !== undefined) {

--- a/src/provisioning/providers/kms-provider.ts
+++ b/src/provisioning/providers/kms-provider.ts
@@ -293,7 +293,13 @@ export class KMSProvider implements ResourceProvider {
         properties['Tags'] as Array<{ Key?: string; Value?: string }> | undefined
       );
 
-      // Update KeyPolicy if changed
+      // Update KeyPolicy if changed. Truthy gate (`&& newPolicyStr` below)
+      // is intentional: KMS rejects `PutKeyPolicy` with an empty / missing
+      // Policy ("KMS key policy must include the JSON statement..."), so
+      // empty / undefined newKeyPolicy must NOT round-trip to AWS. The
+      // `cdkd drift --revert` path doesn't reach this branch — KeyPolicy
+      // is declared in `getDriftUnknownPaths` (not in `observedProperties`),
+      // so neither side has it on a round-trip and the diff is a no-op.
       const newKeyPolicy = properties['KeyPolicy'];
       const oldKeyPolicy = previousProperties['KeyPolicy'];
       const newPolicyStr = newKeyPolicy
@@ -638,6 +644,37 @@ export class KMSProvider implements ResourceProvider {
       }
     }
     return result;
+  }
+
+  /**
+   * Declare state property paths cdkd cannot round-trip from AWS, so the
+   * drift comparator skips them instead of firing guaranteed false-
+   * positive drift on every clean run.
+   *
+   *  - `KeyPolicy`: cdkd does NOT call `GetKeyPolicy` in `readCurrentState`.
+   *    The policy body needs JSON parsing for comparison and a separate
+   *    SDK call; deferred to a follow-up. Until then, any user who
+   *    templates `KeyPolicy` would see guaranteed drift.
+   *  - `EnableKeyRotation` / `RotationPeriodInDays`: cdkd does NOT call
+   *    `GetKeyRotationStatus`. Same reason — deferred to a follow-up.
+   *    `EnableKeyRotation` is also a Class 1 candidate (only valid for
+   *    `KeySpec=SYMMETRIC_DEFAULT`); when we lift this gap the read side
+   *    must gate the emit on the discriminator.
+   *  - `BypassPolicyLockoutSafetyCheck` / `PendingWindowInDays`: not part
+   *    of the persisted AWS state visible via `DescribeKey` — both are
+   *    create / delete-time-only inputs.
+   */
+  getDriftUnknownPaths(resourceType: string): string[] {
+    if (resourceType === 'AWS::KMS::Key') {
+      return [
+        'KeyPolicy',
+        'EnableKeyRotation',
+        'RotationPeriodInDays',
+        'BypassPolicyLockoutSafetyCheck',
+        'PendingWindowInDays',
+      ];
+    }
+    return [];
   }
 
   private async readCurrentStateAlias(

--- a/src/provisioning/providers/rds-provider.ts
+++ b/src/provisioning/providers/rds-provider.ts
@@ -241,13 +241,24 @@ export class RDSProvider implements ResourceProvider {
     this.logger.debug(`Updating DBSubnetGroup ${logicalId}: ${physicalId}`);
 
     try {
-      await this.getClient().send(
-        new ModifyDBSubnetGroupCommand({
-          DBSubnetGroupName: physicalId,
-          DBSubnetGroupDescription: properties['DBSubnetGroupDescription'] as string | undefined,
-          SubnetIds: properties['SubnetIds'] as string[],
-        })
-      );
+      // Class 2 — `SubnetIds: []` would be rejected by AWS as a structurally
+      // invalid input (DBSubnetGroup requires ≥ 2 subnets in distinct AZs).
+      // readCurrentState emits `SubnetIds: []` as a placeholder when AWS
+      // happens to return no subnets; the round-trip must NOT translate
+      // that into a malformed SDK call. Skip the field when empty so the
+      // ModifyDBSubnetGroup call is a no-op for the subnet list.
+      const subnetIds = properties['SubnetIds'] as string[] | undefined;
+      const sendSubnetIds = subnetIds !== undefined && subnetIds.length > 0;
+      // The SDK input type marks `SubnetIds` as required; a description-
+      // only update is a legitimate use case that omits the field on the
+      // wire (AWS supports it). Cast the input shape to bypass the
+      // type-level requirement.
+      const modifyInput = {
+        DBSubnetGroupName: physicalId,
+        DBSubnetGroupDescription: properties['DBSubnetGroupDescription'] as string | undefined,
+        ...(sendSubnetIds && { SubnetIds: subnetIds }),
+      } as ConstructorParameters<typeof ModifyDBSubnetGroupCommand>[0];
+      await this.getClient().send(new ModifyDBSubnetGroupCommand(modifyInput));
 
       // Apply tag diff. RDS uses ARN-keyed AddTagsToResource /
       // RemoveTagsFromResource. DescribeDBSubnetGroups returns the ARN.
@@ -422,6 +433,23 @@ export class RDSProvider implements ResourceProvider {
       const serverlessV2Config = properties['ServerlessV2ScalingConfiguration'] as
         | { MinCapacity?: number; MaxCapacity?: number }
         | undefined;
+      // Class 2 — defence-in-depth on top of the readCurrentState gate.
+      // `{}` (or `{ MinCapacity: undefined, MaxCapacity: undefined }`)
+      // is structurally invalid as ModifyDBCluster input on
+      // non-serverless-v2 clusters; only ship the field when at least
+      // one capacity value is present.
+      const hasServerlessV2 =
+        serverlessV2Config !== undefined &&
+        (serverlessV2Config.MinCapacity !== undefined ||
+          serverlessV2Config.MaxCapacity !== undefined);
+
+      // Class 2 — `VpcSecurityGroupIds: []` would CLEAR all SGs on the
+      // cluster. readCurrentState always-emits `[]` for clusters that
+      // legitimately have no VPC SGs (Aurora-on-default-VPC etc.); the
+      // round-trip must NOT translate that placeholder into a destructive
+      // SDK call. Skip the field when the resolved value is empty.
+      const vpcSgIds = properties['VpcSecurityGroupIds'] as string[] | undefined;
+      const sendVpcSgIds = vpcSgIds !== undefined && vpcSgIds.length > 0;
 
       await this.getClient().send(
         new ModifyDBClusterCommand({
@@ -432,10 +460,10 @@ export class RDSProvider implements ResourceProvider {
             properties['BackupRetentionPeriod'] != null
               ? Number(properties['BackupRetentionPeriod'])
               : undefined,
-          VpcSecurityGroupIds: properties['VpcSecurityGroupIds'] as string[] | undefined,
+          ...(sendVpcSgIds && { VpcSecurityGroupIds: vpcSgIds }),
           MasterUserPassword: properties['MasterUserPassword'] as string | undefined,
           Port: properties['Port'] != null ? Number(properties['Port']) : undefined,
-          ...(serverlessV2Config && {
+          ...(hasServerlessV2 && {
             ServerlessV2ScalingConfiguration: {
               MinCapacity: serverlessV2Config.MinCapacity,
               MaxCapacity: serverlessV2Config.MaxCapacity,
@@ -1043,7 +1071,20 @@ export class RDSProvider implements ResourceProvider {
     if (cluster.DeletionProtection !== undefined) {
       result['DeletionProtection'] = cluster.DeletionProtection;
     }
-    {
+    // Class 1 — ServerlessV2ScalingConfiguration is only valid for Aurora
+    // Serverless v2 clusters. Emit only when AWS actually returns one or
+    // more of the discriminator fields (MinCapacity / MaxCapacity); on a
+    // provisioned-mode cluster AWS leaves the entire field undefined and
+    // emitting `{}` here would (a) round-trip through update() into
+    // `ModifyDBCluster` with `ServerlessV2ScalingConfiguration: { Min: u, Max: u }`
+    // which AWS rejects with "ServerlessV2ScalingConfiguration is only
+    // supported on Aurora Serverless v2 clusters", and (b) fire a
+    // false-positive drift on every non-serverless cluster (state has no
+    // such key). See docs/provider-development.md § 3b.
+    if (
+      cluster.ServerlessV2ScalingConfiguration?.MinCapacity !== undefined ||
+      cluster.ServerlessV2ScalingConfiguration?.MaxCapacity !== undefined
+    ) {
       const sc: Record<string, unknown> = {};
       if (cluster.ServerlessV2ScalingConfiguration?.MinCapacity !== undefined) {
         sc['MinCapacity'] = cluster.ServerlessV2ScalingConfiguration.MinCapacity;

--- a/src/provisioning/providers/secretsmanager-secret-provider.ts
+++ b/src/provisioning/providers/secretsmanager-secret-provider.ts
@@ -156,8 +156,22 @@ export class SecretsManagerSecretProvider implements ResourceProvider {
         SecretId: physicalId,
       };
       if (secretString) updateParams.SecretString = secretString;
-      if (properties['Description']) updateParams.Description = properties['Description'] as string;
-      if (properties['KmsKeyId']) updateParams.KmsKeyId = properties['KmsKeyId'] as string;
+      // `!== undefined` (not truthy): readCurrentState emits `Description: ''`
+      // as a placeholder for "no description set" so the drift comparator can
+      // detect a console-side description add. A truthy gate here would silently
+      // drop a user-intended `Description: ''` (clear-the-description) on
+      // `cdkd drift --revert`. AWS UpdateSecret accepts empty string for
+      // Description (treated as "no description").
+      if (properties['Description'] !== undefined)
+        updateParams.Description = properties['Description'] as string;
+      // `KmsKeyId`: same `!== undefined` semantics, but Class 2 sanitize at the
+      // write layer — readCurrentState emits `KmsKeyId: ''` as a placeholder
+      // when the secret uses the AWS-managed key (no KMS key set). Passing an
+      // empty string to UpdateSecret is rejected by AWS as an invalid ARN, so
+      // the placeholder must NOT reach the wire. Symmetric with the
+      // serializeRedrivePolicy pattern in sqs-queue-provider.ts.
+      if (properties['KmsKeyId'] !== undefined && properties['KmsKeyId'] !== '')
+        updateParams.KmsKeyId = properties['KmsKeyId'] as string;
 
       await this.smClient.send(new UpdateSecretCommand(updateParams));
 

--- a/tests/unit/provisioning/dynamodb-table-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/dynamodb-table-provider-readcurrentstate.test.ts
@@ -77,6 +77,12 @@ describe('DynamoDBTableProvider.readCurrentState', () => {
 
     expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(DescribeTableCommand);
     expect(mockSend.mock.calls[1]?.[0]).toBeInstanceOf(ListTagsOfResourceCommand);
+    // Class 1/2 placeholder guards (PR — drift --revert round-trip safety):
+    //  - GlobalSecondaryIndexes / LocalSecondaryIndexes are NOT emitted as
+    //    empty-array placeholders — the previous `?? []` round-tripped as
+    //    "remove all GSIs" / a guaranteed AWS rejection on LSI (immutable
+    //    post-create).
+    //  - SSESpecification is gated on Status === 'ENABLED' (it is here).
     expect(result).toEqual({
       TableName: 'my-table',
       KeySchema: [{ AttributeName: 'id', KeyType: 'HASH' }],
@@ -84,8 +90,6 @@ describe('DynamoDBTableProvider.readCurrentState', () => {
       BillingMode: 'PAY_PER_REQUEST',
       ProvisionedThroughput: { ReadCapacityUnits: 0, WriteCapacityUnits: 0 },
       StreamSpecification: { StreamEnabled: true, StreamViewType: 'NEW_IMAGE' },
-      GlobalSecondaryIndexes: [],
-      LocalSecondaryIndexes: [],
       SSESpecification: {
         SSEEnabled: true,
         KMSMasterKeyId: 'arn:aws:kms:us-east-1:123:key/abc',

--- a/tests/unit/provisioning/dynamodb-table-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/dynamodb-table-provider-roundtrip.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  DescribeTableCommand,
+  ListTagsOfResourceCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from '@aws-sdk/client-dynamodb';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    dynamoDB: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { DynamoDBTableProvider } from '../../../src/provisioning/providers/dynamodb-table-provider.js';
+
+const TABLE_NAME = 'my-table';
+const TABLE_ARN = 'arn:aws:dynamodb:us-east-1:123:table/my-table';
+
+/**
+ * Mechanical guard against Class 1 / Class 2 placeholder regressions on
+ * `cdkd drift --revert`'s readCurrentState → update round-trip. See
+ * `docs/provider-development.md` § 3b "Read-update round-trip test" and
+ * `tests/unit/provisioning/sns-topic-provider-roundtrip.test.ts` for the
+ * shape this mirrors.
+ *
+ * The DynamoDB provider's `update()` currently only mutates Tags via
+ * TagResource / UntagResource (other property changes flow through
+ * replacement = DELETE + CREATE). The round-trip guarantee we want here
+ * is therefore:
+ *
+ *  1. State == AWS-current (zero drift) → zero mutating SDK calls
+ *     (DescribeTable + ListTagsOfResource are reads; TagResource /
+ *     UntagResource are mutations and must NOT fire).
+ *  2. The readCurrentState shape never carries a Class 1 / Class 2
+ *     placeholder that would push an AWS-rejecting payload through any
+ *     future update() that learns to handle the field (GSI / LSI / SSE /
+ *     Stream — see `dynamodb-table-provider.ts` readCurrentState
+ *     comments for the per-field rationale).
+ */
+describe('DynamoDBTableProvider read-update round-trip', () => {
+  let provider: DynamoDBTableProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new DynamoDBTableProvider();
+  });
+
+  function mockDescribeTable(tableExtras: Record<string, unknown> = {}): void {
+    mockSend.mockImplementationOnce(async (cmd: unknown) => {
+      if (cmd instanceof DescribeTableCommand) {
+        return {
+          Table: {
+            TableName: TABLE_NAME,
+            TableArn: TABLE_ARN,
+            ...tableExtras,
+          },
+        };
+      }
+      throw new Error(`unexpected command: ${cmd?.constructor.name}`);
+    });
+  }
+
+  it('round-trip on no-drift snapshot is a logical no-op (no TagResource / UntagResource)', async () => {
+    // Stronger assertion for diff-based providers: state == AWS implies
+    // update() must make no AWS-side mutations.
+    mockDescribeTable();
+
+    const observed = {
+      TableName: TABLE_NAME,
+      KeySchema: [{ AttributeName: 'id', KeyType: 'HASH' }],
+      AttributeDefinitions: [{ AttributeName: 'id', AttributeType: 'S' }],
+      BillingMode: 'PAY_PER_REQUEST',
+      Tags: [{ Key: 'k', Value: 'v' }],
+    };
+
+    await provider.update('L', TABLE_NAME, 'AWS::DynamoDB::Table', observed, observed);
+
+    const tagMutations = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof TagResourceCommand || c[0] instanceof UntagResourceCommand
+    );
+    expect(tagMutations).toHaveLength(0);
+  });
+
+  it('Class 2 — table without GSI / LSI: readCurrentState omits empty-array placeholders', async () => {
+    // Round-trip safety: AWS rejects an empty-list "remove all GSIs"
+    // request on a table that has none, and LSIs are immutable
+    // post-create so even a stable "[]" placeholder is wrong shape for
+    // any future update() that learns to handle the field. The
+    // readCurrentState fix is to omit the keys entirely when AWS
+    // reports no indexes.
+    mockSend.mockResolvedValueOnce({
+      Table: {
+        TableName: TABLE_NAME,
+        TableArn: TABLE_ARN,
+        // GSI / LSI absent in this DescribeTable response.
+      },
+    });
+    mockSend.mockResolvedValueOnce({ Tags: [] });
+
+    const result = await provider.readCurrentState(TABLE_NAME, 'L', 'AWS::DynamoDB::Table');
+
+    expect(result).toBeDefined();
+    expect(result).not.toHaveProperty('GlobalSecondaryIndexes');
+    expect(result).not.toHaveProperty('LocalSecondaryIndexes');
+  });
+
+  it('Class 1 — table without SSE: readCurrentState omits SSESpecification placeholder', async () => {
+    // SSEDescription absent (or Status !== 'ENABLED') → SSESpecification
+    // must NOT be emitted. The previous always-emit `{ SSEEnabled: false }`
+    // placeholder was a CFn-invalid shape the moment a future update()
+    // started consuming SSESpecification (KMSMasterKeyId / SSEType are
+    // only valid when SSEEnabled=true).
+    mockSend.mockResolvedValueOnce({
+      Table: {
+        TableName: TABLE_NAME,
+        TableArn: TABLE_ARN,
+        // SSEDescription absent.
+      },
+    });
+    mockSend.mockResolvedValueOnce({ Tags: [] });
+
+    const result = await provider.readCurrentState(TABLE_NAME, 'L', 'AWS::DynamoDB::Table');
+
+    expect(result).toBeDefined();
+    expect(result).not.toHaveProperty('SSESpecification');
+  });
+
+  it('Class 1 — table with SSEDescription.Status=DISABLED also omits SSESpecification', async () => {
+    // AWS sometimes returns SSEDescription with Status=DISABLED on
+    // tables that previously had SSE; that block carries no
+    // KMSMasterKeyArn / SSEType and would only round-trip safely when
+    // gated to Status==='ENABLED'.
+    mockSend.mockResolvedValueOnce({
+      Table: {
+        TableName: TABLE_NAME,
+        TableArn: TABLE_ARN,
+        SSEDescription: { Status: 'DISABLED' },
+      },
+    });
+    mockSend.mockResolvedValueOnce({ Tags: [] });
+
+    const result = await provider.readCurrentState(TABLE_NAME, 'L', 'AWS::DynamoDB::Table');
+
+    expect(result).toBeDefined();
+    expect(result).not.toHaveProperty('SSESpecification');
+  });
+
+  it('Class 1 — table without streams: readCurrentState omits StreamSpecification placeholder', async () => {
+    // AWS may return StreamSpecification with StreamEnabled=false on
+    // tables that previously had a stream. CFn's StreamSpecification
+    // requires StreamViewType, so emitting the disabled block round-
+    // trips as a CFn-invalid shape. Gate emit on StreamEnabled=true +
+    // StreamViewType present.
+    mockSend.mockResolvedValueOnce({
+      Table: {
+        TableName: TABLE_NAME,
+        TableArn: TABLE_ARN,
+        StreamSpecification: { StreamEnabled: false },
+      },
+    });
+    mockSend.mockResolvedValueOnce({ Tags: [] });
+
+    const result = await provider.readCurrentState(TABLE_NAME, 'L', 'AWS::DynamoDB::Table');
+
+    expect(result).toBeDefined();
+    expect(result).not.toHaveProperty('StreamSpecification');
+  });
+
+  it('Class 1 — enabled stream is still surfaced (positive control)', async () => {
+    // Complement of the disabled-stream test: a real enabled stream
+    // SHOULD be emitted, with the CFn-shape StreamViewType.
+    mockSend.mockResolvedValueOnce({
+      Table: {
+        TableName: TABLE_NAME,
+        TableArn: TABLE_ARN,
+        StreamSpecification: { StreamEnabled: true, StreamViewType: 'NEW_AND_OLD_IMAGES' },
+      },
+    });
+    mockSend.mockResolvedValueOnce({ Tags: [] });
+
+    const result = await provider.readCurrentState(TABLE_NAME, 'L', 'AWS::DynamoDB::Table');
+
+    expect(result?.StreamSpecification).toEqual({
+      StreamEnabled: true,
+      StreamViewType: 'NEW_AND_OLD_IMAGES',
+    });
+  });
+
+  it('Class 1 — enabled SSE is still surfaced (positive control)', async () => {
+    mockSend.mockResolvedValueOnce({
+      Table: {
+        TableName: TABLE_NAME,
+        TableArn: TABLE_ARN,
+        SSEDescription: {
+          Status: 'ENABLED',
+          KMSMasterKeyArn: 'arn:aws:kms:us-east-1:123:key/abc',
+          SSEType: 'KMS',
+        },
+      },
+    });
+    mockSend.mockResolvedValueOnce({ Tags: [] });
+
+    const result = await provider.readCurrentState(TABLE_NAME, 'L', 'AWS::DynamoDB::Table');
+
+    expect(result?.SSESpecification).toEqual({
+      SSEEnabled: true,
+      KMSMasterKeyId: 'arn:aws:kms:us-east-1:123:key/abc',
+      SSEType: 'KMS',
+    });
+  });
+
+  it('Class 2 — populated GSI is still surfaced (positive control)', async () => {
+    mockSend.mockResolvedValueOnce({
+      Table: {
+        TableName: TABLE_NAME,
+        TableArn: TABLE_ARN,
+        GlobalSecondaryIndexes: [{ IndexName: 'gsi1' }],
+      },
+    });
+    mockSend.mockResolvedValueOnce({ Tags: [] });
+
+    const result = await provider.readCurrentState(TABLE_NAME, 'L', 'AWS::DynamoDB::Table');
+
+    expect(result?.GlobalSecondaryIndexes).toEqual([{ IndexName: 'gsi1' }]);
+    expect(result).not.toHaveProperty('LocalSecondaryIndexes');
+  });
+
+  it('round-trip on a tableless-of-everything observed (GSI/SSE/Stream all absent) is a no-op', async () => {
+    // End-to-end Class-1/Class-2 guard composed: read AWS, push the
+    // result straight back through update(). Even though update() only
+    // diffs Tags today, the round-trip must not surface any of the
+    // omitted placeholder keys to update() (and update() must not fire
+    // a TagResource / UntagResource call when tags also haven't
+    // changed).
+    mockSend.mockResolvedValueOnce({
+      Table: {
+        TableName: TABLE_NAME,
+        TableArn: TABLE_ARN,
+      },
+    });
+    mockSend.mockResolvedValueOnce({ Tags: [] });
+
+    const observed = await provider.readCurrentState(TABLE_NAME, 'L', 'AWS::DynamoDB::Table');
+    expect(observed).toBeDefined();
+
+    // Reset the mock and prime DescribeTable for the update() flow.
+    vi.clearAllMocks();
+    mockDescribeTable();
+
+    await provider.update(
+      'L',
+      TABLE_NAME,
+      'AWS::DynamoDB::Table',
+      observed as Record<string, unknown>,
+      observed as Record<string, unknown>
+    );
+
+    const tagMutations = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof TagResourceCommand || c[0] instanceof UntagResourceCommand
+    );
+    expect(tagMutations).toHaveLength(0);
+
+    // Sanity: we DID hit DescribeTable in update()'s tag-arn lookup but
+    // never ListTagsOfResource (update() doesn't read AWS-side tags).
+    expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(DescribeTableCommand);
+    expect(
+      mockSend.mock.calls.some((c) => c[0] instanceof ListTagsOfResourceCommand)
+    ).toBe(false);
+  });
+});

--- a/tests/unit/provisioning/elasticache-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/elasticache-provider-roundtrip.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ModifyCacheClusterCommand } from '@aws-sdk/client-elasticache';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-elasticache', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-elasticache')>(
+    '@aws-sdk/client-elasticache'
+  );
+  return {
+    ...actual,
+    ElastiCacheClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { ElastiCacheProvider } from '../../../src/provisioning/providers/elasticache-provider.js';
+
+const CLUSTER_ID = 'mycluster';
+
+describe('ElastiCacheProvider read-update round-trip', () => {
+  let provider: ElastiCacheProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ElastiCacheProvider();
+  });
+
+  it('Class 1 — memcached cluster does not surface redis-only TransitEncryptionEnabled', async () => {
+    // Mechanical guard for Class 1 placeholder regression on
+    // type-discriminator-dependent fields. See
+    // docs/provider-development.md § 3b.
+    //
+    // ElastiCache `TransitEncryptionEnabled` is redis-only on
+    // CreateCacheClusterCommand. AWS DescribeCacheClusters returns the
+    // field for both engines, but readCurrentState must NOT emit it on
+    // a memcached cluster. Otherwise drift --revert ships the
+    // placeholder to AWS and (if `update()` ever forwards it) the
+    // request is rejected.
+    mockSend.mockResolvedValueOnce({
+      CacheClusters: [
+        {
+          CacheClusterId: CLUSTER_ID,
+          Engine: 'memcached',
+          CacheNodeType: 'cache.t3.micro',
+          NumCacheNodes: 2,
+          // AWS routinely returns this field even on memcached.
+          TransitEncryptionEnabled: false,
+        },
+      ],
+    });
+
+    const observed = await provider.readCurrentState(
+      CLUSTER_ID,
+      'L',
+      'AWS::ElastiCache::CacheCluster'
+    );
+
+    expect(observed).toBeDefined();
+    expect(observed?.['Engine']).toBe('memcached');
+    // Class 1 gate: redis-only field absent on memcached snapshot.
+    expect(observed).not.toHaveProperty('TransitEncryptionEnabled');
+  });
+
+  it('Class 1 — redis cluster legitimately surfaces TransitEncryptionEnabled', async () => {
+    // The complement of the memcached test: a redis cluster legitimately
+    // has TransitEncryptionEnabled, so readCurrentState must emit it.
+    mockSend.mockResolvedValueOnce({
+      CacheClusters: [
+        {
+          CacheClusterId: CLUSTER_ID,
+          Engine: 'redis',
+          CacheNodeType: 'cache.t3.micro',
+          NumCacheNodes: 1,
+          TransitEncryptionEnabled: true,
+        },
+      ],
+    });
+
+    const observed = await provider.readCurrentState(
+      CLUSTER_ID,
+      'L',
+      'AWS::ElastiCache::CacheCluster'
+    );
+
+    expect(observed?.['Engine']).toBe('redis');
+    expect(observed?.['TransitEncryptionEnabled']).toBe(true);
+  });
+
+  it('Class 2 — round-trip sanitizes empty VpcSecurityGroupIds before ModifyCacheCluster', async () => {
+    // Class 2 round-trip guard: readCurrentState always-emits
+    // `VpcSecurityGroupIds: []` (the empty placeholder is needed for
+    // drift detection of console-side SG attach). Round-tripping that
+    // placeholder back through `update()` would, without sanitization,
+    // ship `SecurityGroupIds: []` to ModifyCacheClusterCommand — AWS
+    // rejects with "must specify at least one security group".
+    //
+    // Build observed snapshot directly. update() polls describe twice
+    // (waitForClusterAvailable + final attribute fetch); mock
+    // accordingly.
+    const observed: Record<string, unknown> = {
+      ClusterName: CLUSTER_ID,
+      Engine: 'redis',
+      CacheNodeType: 'cache.t3.micro',
+      NumCacheNodes: 1,
+      VpcSecurityGroupIds: [],
+    };
+
+    // ModifyCacheClusterCommand response.
+    mockSend.mockResolvedValueOnce({});
+    // waitForClusterAvailable: returns available immediately.
+    mockSend.mockResolvedValueOnce({
+      CacheClusters: [{ CacheClusterId: CLUSTER_ID, CacheClusterStatus: 'available' }],
+    });
+    // Final describe for attributes.
+    mockSend.mockResolvedValueOnce({
+      CacheClusters: [{ CacheClusterId: CLUSTER_ID, CacheClusterStatus: 'available' }],
+    });
+
+    await provider.update('L', CLUSTER_ID, 'AWS::ElastiCache::CacheCluster', observed, observed);
+
+    const modifyCall = mockSend.mock.calls.find((c) => c[0] instanceof ModifyCacheClusterCommand);
+    expect(modifyCall).toBeDefined();
+    const input = modifyCall![0].input as { SecurityGroupIds?: string[] };
+    // Empty array sanitized to undefined — AWS treats absent as "no change".
+    expect(input.SecurityGroupIds).toBeUndefined();
+  });
+
+  it('Class 2 — non-empty VpcSecurityGroupIds reaches AWS unchanged', async () => {
+    // Sibling case: the sanitization must not regress the non-empty
+    // path. State `['sg-1', 'sg-2']` should reach AWS as-is.
+    const observed: Record<string, unknown> = {
+      ClusterName: CLUSTER_ID,
+      Engine: 'redis',
+      VpcSecurityGroupIds: ['sg-1', 'sg-2'],
+    };
+
+    mockSend.mockResolvedValueOnce({});
+    mockSend.mockResolvedValueOnce({
+      CacheClusters: [{ CacheClusterId: CLUSTER_ID, CacheClusterStatus: 'available' }],
+    });
+    mockSend.mockResolvedValueOnce({
+      CacheClusters: [{ CacheClusterId: CLUSTER_ID, CacheClusterStatus: 'available' }],
+    });
+
+    await provider.update('L', CLUSTER_ID, 'AWS::ElastiCache::CacheCluster', observed, observed);
+
+    const modifyCall = mockSend.mock.calls.find((c) => c[0] instanceof ModifyCacheClusterCommand);
+    const input = modifyCall![0].input as { SecurityGroupIds?: string[] };
+    expect(input.SecurityGroupIds).toEqual(['sg-1', 'sg-2']);
+  });
+
+  it('truthy-gate — SnapshotRetentionLimit=0 reaches AWS (not silently dropped)', async () => {
+    // SnapshotRetentionLimit=0 means "disable automatic snapshots" per
+    // the AWS API. A truthy gate (`if (props['SnapshotRetentionLimit'])`)
+    // would silently drop the 0 and leave AWS-side retention untouched —
+    // surfacing as a drift --revert that reports `✓ reverted` but the
+    // very next drift run re-detects the same drift. Guard via `!= null`.
+    const observed: Record<string, unknown> = {
+      ClusterName: CLUSTER_ID,
+      Engine: 'redis',
+      SnapshotRetentionLimit: 0,
+    };
+
+    mockSend.mockResolvedValueOnce({});
+    mockSend.mockResolvedValueOnce({
+      CacheClusters: [{ CacheClusterId: CLUSTER_ID, CacheClusterStatus: 'available' }],
+    });
+    mockSend.mockResolvedValueOnce({
+      CacheClusters: [{ CacheClusterId: CLUSTER_ID, CacheClusterStatus: 'available' }],
+    });
+
+    await provider.update('L', CLUSTER_ID, 'AWS::ElastiCache::CacheCluster', observed, observed);
+
+    const modifyCall = mockSend.mock.calls.find((c) => c[0] instanceof ModifyCacheClusterCommand);
+    const input = modifyCall![0].input as { SnapshotRetentionLimit?: number };
+    expect(input.SnapshotRetentionLimit).toBe(0);
+  });
+
+  it('round-trip — full redis snapshot does not produce AWS-rejection-shaped inputs', async () => {
+    // End-to-end round-trip on a realistic redis snapshot. The
+    // round-trip must not produce any structurally-invalid AWS input
+    // (empty SG array, redis-only field on memcached, etc.).
+    const observed: Record<string, unknown> = {
+      ClusterName: CLUSTER_ID,
+      Engine: 'redis',
+      CacheNodeType: 'cache.t3.micro',
+      NumCacheNodes: 1,
+      CacheSubnetGroupName: 'default',
+      EngineVersion: '7.0',
+      CacheParameterGroupName: 'default.redis7',
+      PreferredMaintenanceWindow: 'sun:05:00-sun:06:00',
+      SnapshotRetentionLimit: 5,
+      AutoMinorVersionUpgrade: true,
+      Port: 6379,
+      VpcSecurityGroupIds: ['sg-abc'],
+      TransitEncryptionEnabled: true,
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    };
+
+    mockSend.mockResolvedValueOnce({});
+    mockSend.mockResolvedValueOnce({
+      CacheClusters: [{ CacheClusterId: CLUSTER_ID, CacheClusterStatus: 'available' }],
+    });
+    mockSend.mockResolvedValueOnce({
+      CacheClusters: [{ CacheClusterId: CLUSTER_ID, CacheClusterStatus: 'available' }],
+    });
+
+    await provider.update('L', CLUSTER_ID, 'AWS::ElastiCache::CacheCluster', observed, observed);
+
+    const modifyCall = mockSend.mock.calls.find((c) => c[0] instanceof ModifyCacheClusterCommand);
+    expect(modifyCall).toBeDefined();
+    const input = modifyCall![0].input as {
+      SecurityGroupIds?: string[];
+      SnapshotRetentionLimit?: number;
+      EngineVersion?: string;
+      AutoMinorVersionUpgrade?: boolean;
+    };
+    // Non-empty SG array preserved.
+    expect(input.SecurityGroupIds).toEqual(['sg-abc']);
+    expect(input.SnapshotRetentionLimit).toBe(5);
+    expect(input.EngineVersion).toBe('7.0');
+    expect(input.AutoMinorVersionUpgrade).toBe(true);
+  });
+});

--- a/tests/unit/provisioning/kms-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/kms-provider-roundtrip.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  EnableKeyRotationCommand,
+  DisableKeyRotationCommand,
+  UpdateKeyDescriptionCommand,
+  PutKeyPolicyCommand,
+  EnableKeyCommand,
+  DisableKeyCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+  UpdateAliasCommand,
+} from '@aws-sdk/client-kms';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-kms', async (importOriginal) => {
+  const orig = await importOriginal<Record<string, unknown>>();
+  return {
+    ...orig,
+    KMSClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { KMSProvider } from '../../../src/provisioning/providers/kms-provider.js';
+
+const KEY_ID = 'abcd-1234';
+const ALIAS_NAME = 'alias/my-key';
+
+/**
+ * Mutating SDK commands the round-trip test verifies do NOT fire when
+ * state == AWS. Any of these in mock.calls means the diff logic
+ * misclassified an "equal" snapshot as a change — the load-bearing bug
+ * `cdkd drift --revert` exposes via observed-property round-trip.
+ */
+const MUTATING_COMMANDS = [
+  EnableKeyRotationCommand,
+  DisableKeyRotationCommand,
+  UpdateKeyDescriptionCommand,
+  PutKeyPolicyCommand,
+  EnableKeyCommand,
+  DisableKeyCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+  UpdateAliasCommand,
+];
+
+function mutatingCalls(): unknown[] {
+  return mockSend.mock.calls.filter((c: unknown[]) =>
+    MUTATING_COMMANDS.some((Cmd) => c[0] instanceof Cmd)
+  );
+}
+
+describe('KMSProvider read-update round-trip', () => {
+  let provider: KMSProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSend.mockResolvedValue({});
+    provider = new KMSProvider();
+  });
+
+  it('symmetric key no-drift round-trip is a logical no-op (zero mutating SDK calls)', async () => {
+    // State == AWS implies update() must make no AWS-side mutations.
+    // The snapshot mirrors what readCurrentState produces for a
+    // SYMMETRIC_DEFAULT key: Description always-emitted ('' on no
+    // description), KeySpec / KeyUsage / Enabled / MultiRegion / Origin
+    // surfaced from DescribeKey, Tags always-emitted as []. KeyPolicy /
+    // EnableKeyRotation / RotationPeriodInDays are NOT in the snapshot
+    // because they are declared in getDriftUnknownPaths.
+    const observed = {
+      Description: 'my key',
+      KeySpec: 'SYMMETRIC_DEFAULT',
+      KeyUsage: 'ENCRYPT_DECRYPT',
+      Enabled: true,
+      MultiRegion: false,
+      Origin: 'AWS_KMS',
+      Tags: [{ Key: 'Foo', Value: 'Bar' }],
+    };
+
+    await provider.update('K', KEY_ID, 'AWS::KMS::Key', observed, observed);
+
+    expect(mutatingCalls()).toHaveLength(0);
+  });
+
+  it('symmetric key with empty description and no tags round-trips with zero mutating calls', async () => {
+    // The minimum-shape AWS response: Description '' (always-emit), no
+    // user tags (Tags: []). Truthy-gate regression on Description ('')
+    // would silently drop the empty string and look correct here, so
+    // this test pairs with the "drift --revert push '' explicitly" case
+    // — but the load-bearing assertion is "no mutating call when equal".
+    const observed = {
+      Description: '',
+      KeySpec: 'SYMMETRIC_DEFAULT',
+      KeyUsage: 'ENCRYPT_DECRYPT',
+      Enabled: true,
+      MultiRegion: false,
+      Origin: 'AWS_KMS',
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await provider.update('K', KEY_ID, 'AWS::KMS::Key', observed, observed);
+
+    expect(mutatingCalls()).toHaveLength(0);
+  });
+
+  it('asymmetric key round-trip does NOT push EnableKeyRotation (Class 1 — invalid for non-SYMMETRIC_DEFAULT)', async () => {
+    // Mechanical guard for Class 1 placeholder regression on
+    // EnableKeyRotation, which AWS rejects on asymmetric keys
+    // ("UnsupportedOperationException: Key rotation is not supported
+    // for asymmetric KMS keys"). readCurrentState must NOT emit it as
+    // an always-on placeholder — and getDriftUnknownPaths must keep it
+    // out of the round-trip diff. Either way EnableKeyRotation /
+    // DisableKeyRotation must NEVER fire on an asymmetric snapshot.
+    //
+    // See docs/provider-development.md § 3b "Read-update round-trip
+    // test" for the Class 1 rationale.
+    const observed = {
+      Description: 'asymmetric signing key',
+      KeySpec: 'RSA_2048',
+      KeyUsage: 'SIGN_VERIFY',
+      Enabled: true,
+      MultiRegion: false,
+      Origin: 'AWS_KMS',
+      Tags: [] as Array<{ Key: string; Value: string }>,
+      // EnableKeyRotation absent (correct: getDriftUnknownPaths
+      // declares it as unreadable, so observedProperties never carries
+      // it on round-trip).
+    };
+
+    await provider.update('K', KEY_ID, 'AWS::KMS::Key', observed, observed);
+
+    const rotationCalls = mockSend.mock.calls.filter(
+      (c: unknown[]) =>
+        c[0] instanceof EnableKeyRotationCommand || c[0] instanceof DisableKeyRotationCommand
+    );
+    expect(rotationCalls).toHaveLength(0);
+    expect(mutatingCalls()).toHaveLength(0);
+  });
+
+  it('alias no-drift round-trip on identical TargetKeyId still performs UpdateAlias (no diff path in updateAlias)', async () => {
+    // updateAlias does NOT diff old vs new — it always sends
+    // UpdateAlias. That's the documented contract for this provider
+    // (Alias has only one mutable field; the API call is cheap). This
+    // test pins the contract so a future "skip if no diff"
+    // optimization can't silently regress drift --revert correctness
+    // for aliases.
+    const observed = {
+      AliasName: ALIAS_NAME,
+      TargetKeyId: KEY_ID,
+    };
+
+    await provider.update('A', ALIAS_NAME, 'AWS::KMS::Alias', observed, observed);
+
+    const updateAliasCalls = mockSend.mock.calls.filter(
+      (c: unknown[]) => c[0] instanceof UpdateAliasCommand
+    );
+    expect(updateAliasCalls).toHaveLength(1);
+    const firstCall = updateAliasCalls[0] as unknown[];
+    expect((firstCall[0] as UpdateAliasCommand).input).toEqual({
+      AliasName: ALIAS_NAME,
+      TargetKeyId: KEY_ID,
+    });
+  });
+});
+
+describe('KMSProvider.getDriftUnknownPaths', () => {
+  it('declares unreadable AWS::KMS::Key paths so the drift comparator skips them', () => {
+    // KeyPolicy / EnableKeyRotation / RotationPeriodInDays are NOT
+    // round-trippable from AWS because cdkd does not call
+    // GetKeyPolicy / GetKeyRotationStatus in readCurrentState.
+    // BypassPolicyLockoutSafetyCheck / PendingWindowInDays are
+    // create / delete-time-only inputs not visible via DescribeKey.
+    // Without this declaration any user who templates these would see
+    // guaranteed false drift on every clean run.
+    const provider = new KMSProvider();
+    expect(provider.getDriftUnknownPaths('AWS::KMS::Key')).toEqual([
+      'KeyPolicy',
+      'EnableKeyRotation',
+      'RotationPeriodInDays',
+      'BypassPolicyLockoutSafetyCheck',
+      'PendingWindowInDays',
+    ]);
+  });
+
+  it('returns no unknown paths for AWS::KMS::Alias (every templatable field is read back)', () => {
+    const provider = new KMSProvider();
+    expect(provider.getDriftUnknownPaths('AWS::KMS::Alias')).toEqual([]);
+  });
+});

--- a/tests/unit/provisioning/rds-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/rds-provider-roundtrip.test.ts
@@ -1,0 +1,489 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ModifyDBClusterCommand,
+  ModifyDBInstanceCommand,
+  ModifyDBSubnetGroupCommand,
+  AddTagsToResourceCommand,
+  RemoveTagsFromResourceCommand,
+} from '@aws-sdk/client-rds';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-rds', async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    RDSClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { RDSProvider } from '../../../src/provisioning/providers/rds-provider.js';
+
+/**
+ * Round-trip tests for `cdkd drift --revert` against the RDS provider.
+ *
+ * `drift --revert` round-trips `observedProperties` (= a previous
+ * `readCurrentState` snapshot) back through `provider.update`. The risks
+ * documented in docs/provider-development.md § 3b ("Read-update round-trip
+ * test") are:
+ *
+ * - **Class 1**: a placeholder always emitted by readCurrentState that AWS
+ *   only accepts conditionally on a sibling discriminator. RDS specimen:
+ *   `ServerlessV2ScalingConfiguration` (Aurora-Serverless-v2 only).
+ * - **Class 2**: a placeholder that's structurally invalid as AWS input
+ *   regardless of context. RDS specimens: `VpcSecurityGroupIds: []` (would
+ *   CLEAR cluster SGs), `SubnetIds: []` (rejected by ModifyDBSubnetGroup).
+ * - **Truthy gate**: an `if (props['X'])` in update() that silently drops
+ *   `false` / `0` / `''`. RDS update methods use direct `as ... | undefined`
+ *   casts so falsy values do reach AWS — guarded here for regression.
+ */
+describe('RDSProvider read-update round-trip', () => {
+  let provider: RDSProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new RDSProvider();
+  });
+
+  // ─── DBInstance ───────────────────────────────────────────────────
+
+  it('DBInstance no-drift round-trip is a logical no-op (no AWS-rejection inputs)', async () => {
+    // ModifyDBInstance + DescribeDBInstance follow-up (for ARN). Tag diff
+    // is empty (state == AWS) so no Add/Remove call fires.
+    mockSend
+      .mockResolvedValueOnce({}) // ModifyDBInstance
+      .mockResolvedValueOnce({
+        DBInstances: [{ DBInstanceArn: 'arn:aws:rds:us-east-1:123:db:my-instance' }],
+      });
+
+    const observed = {
+      DBInstanceIdentifier: 'my-instance',
+      DBInstanceClass: 'db.t3.micro',
+      Engine: 'aurora-postgresql',
+      DBClusterIdentifier: 'my-cluster',
+      DBSubnetGroupName: 'my-sg',
+      PubliclyAccessible: false,
+      Tags: [{ Key: 'Foo', Value: 'Bar' }],
+    };
+
+    await provider.update(
+      'L',
+      'my-instance',
+      'AWS::RDS::DBInstance',
+      observed,
+      observed
+    );
+
+    // No Add/Remove tag calls (state == AWS).
+    const tagAddCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof AddTagsToResourceCommand
+    );
+    const tagRemoveCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof RemoveTagsFromResourceCommand
+    );
+    expect(tagAddCalls).toHaveLength(0);
+    expect(tagRemoveCalls).toHaveLength(0);
+  });
+
+  it('DBInstance round-trip: PubliclyAccessible=false reaches AWS (truthy-gate guard)', async () => {
+    // Truthy-gate regression guard: if someone refactors updateDBInstance
+    // to `if (props['PubliclyAccessible'])`, false would silently be
+    // dropped and `cdkd drift --revert` would report success while AWS
+    // stays unchanged. Verify the false value reaches the SDK call.
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        DBInstances: [{ DBInstanceArn: 'arn:aws:rds:us-east-1:123:db:my-instance' }],
+      });
+
+    const observed = {
+      DBInstanceClass: 'db.t3.micro',
+      PubliclyAccessible: false,
+    };
+
+    await provider.update(
+      'L',
+      'my-instance',
+      'AWS::RDS::DBInstance',
+      observed,
+      observed
+    );
+
+    const modifyCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof ModifyDBInstanceCommand
+    );
+    expect(modifyCall).toBeDefined();
+    const input = modifyCall![0].input as { PubliclyAccessible?: boolean };
+    expect(input.PubliclyAccessible).toBe(false);
+  });
+
+  // ─── DBCluster ────────────────────────────────────────────────────
+
+  it('Class 1 — DBCluster Aurora-Serverless-v2 round-trip preserves ServerlessV2ScalingConfiguration', async () => {
+    // The complement of the next test: a real Aurora Serverless v2
+    // cluster legitimately has ServerlessV2ScalingConfiguration, and the
+    // round-trip must ship it back to ModifyDBCluster intact.
+    mockSend
+      .mockResolvedValueOnce({}) // ModifyDBCluster
+      .mockResolvedValueOnce({
+        DBClusters: [{ DBClusterArn: 'arn:aws:rds:us-east-1:123:cluster:my-cluster' }],
+      });
+
+    const observed = {
+      DBClusterIdentifier: 'my-cluster',
+      Engine: 'aurora-postgresql',
+      EngineVersion: '15.3',
+      DeletionProtection: true,
+      BackupRetentionPeriod: 7,
+      ServerlessV2ScalingConfiguration: { MinCapacity: 0.5, MaxCapacity: 4 },
+      Tags: [{ Key: 'Owner', Value: 'team-a' }],
+    };
+
+    await provider.update(
+      'L',
+      'my-cluster',
+      'AWS::RDS::DBCluster',
+      observed,
+      observed
+    );
+
+    const modifyCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof ModifyDBClusterCommand
+    );
+    expect(modifyCall).toBeDefined();
+    const input = modifyCall![0].input as {
+      ServerlessV2ScalingConfiguration?: { MinCapacity?: number; MaxCapacity?: number };
+    };
+    expect(input.ServerlessV2ScalingConfiguration).toEqual({
+      MinCapacity: 0.5,
+      MaxCapacity: 4,
+    });
+  });
+
+  it('Class 1 — DBCluster (provisioned) round-trip does NOT ship ServerlessV2ScalingConfiguration to AWS', async () => {
+    // readCurrentState is now gated to NOT emit ServerlessV2ScalingConfiguration
+    // for a provisioned-mode cluster (no Min/Max present in AWS response).
+    // Even if a stale state file from before the fix carries the `{}` placeholder,
+    // updateDBCluster's defence-in-depth guard must drop it before ModifyDBCluster.
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        DBClusters: [{ DBClusterArn: 'arn:aws:rds:us-east-1:123:cluster:my-cluster' }],
+      });
+
+    // Stale-state shape: empty placeholder (what the pre-fix readCurrentState
+    // would have emitted on a provisioned cluster).
+    const observed = {
+      DBClusterIdentifier: 'my-cluster',
+      Engine: 'aurora-postgresql',
+      EngineVersion: '15.3',
+      ServerlessV2ScalingConfiguration: {} as Record<string, unknown>,
+    };
+
+    await provider.update(
+      'L',
+      'my-cluster',
+      'AWS::RDS::DBCluster',
+      observed,
+      observed
+    );
+
+    const modifyCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof ModifyDBClusterCommand
+    );
+    expect(modifyCall).toBeDefined();
+    const input = modifyCall![0].input as {
+      ServerlessV2ScalingConfiguration?: unknown;
+    };
+    // AWS rejects ServerlessV2ScalingConfiguration on a provisioned cluster.
+    // The guard must skip the field entirely.
+    expect(input.ServerlessV2ScalingConfiguration).toBeUndefined();
+  });
+
+  it('Class 2 — DBCluster round-trip with empty VpcSecurityGroupIds does NOT ship the field (would clear SGs)', async () => {
+    // `ModifyDBClusterCommand({ VpcSecurityGroupIds: [] })` would CLEAR
+    // every SG attached to the cluster. readCurrentState always emits
+    // `[]` when AWS reports no SGs (cluster on default VPC etc.) — the
+    // round-trip must NOT translate that placeholder into a destructive
+    // SDK call.
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        DBClusters: [{ DBClusterArn: 'arn:aws:rds:us-east-1:123:cluster:my-cluster' }],
+      });
+
+    const observed = {
+      DBClusterIdentifier: 'my-cluster',
+      Engine: 'aurora-postgresql',
+      VpcSecurityGroupIds: [] as string[],
+    };
+
+    await provider.update(
+      'L',
+      'my-cluster',
+      'AWS::RDS::DBCluster',
+      observed,
+      observed
+    );
+
+    const modifyCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof ModifyDBClusterCommand
+    );
+    expect(modifyCall).toBeDefined();
+    const input = modifyCall![0].input as { VpcSecurityGroupIds?: string[] };
+    expect(input.VpcSecurityGroupIds).toBeUndefined();
+  });
+
+  it('DBCluster non-empty VpcSecurityGroupIds DO reach AWS (positive control)', async () => {
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        DBClusters: [{ DBClusterArn: 'arn:aws:rds:us-east-1:123:cluster:my-cluster' }],
+      });
+
+    const observed = {
+      DBClusterIdentifier: 'my-cluster',
+      Engine: 'aurora-postgresql',
+      VpcSecurityGroupIds: ['sg-1', 'sg-2'],
+    };
+
+    await provider.update(
+      'L',
+      'my-cluster',
+      'AWS::RDS::DBCluster',
+      observed,
+      observed
+    );
+
+    const modifyCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof ModifyDBClusterCommand
+    );
+    const input = modifyCall![0].input as { VpcSecurityGroupIds?: string[] };
+    expect(input.VpcSecurityGroupIds).toEqual(['sg-1', 'sg-2']);
+  });
+
+  it('DBCluster round-trip: BackupRetentionPeriod=0 reaches AWS (truthy-gate guard)', async () => {
+    // BackupRetentionPeriod=0 means "no backups" — semantically meaningful.
+    // A truthy gate would silently drop it. The current code uses `!= null`
+    // which correctly admits 0; this test guards that contract.
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        DBClusters: [{ DBClusterArn: 'arn:aws:rds:us-east-1:123:cluster:my-cluster' }],
+      });
+
+    const observed = {
+      DBClusterIdentifier: 'my-cluster',
+      Engine: 'aurora-postgresql',
+      BackupRetentionPeriod: 0,
+    };
+
+    await provider.update(
+      'L',
+      'my-cluster',
+      'AWS::RDS::DBCluster',
+      observed,
+      observed
+    );
+
+    const modifyCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof ModifyDBClusterCommand
+    );
+    const input = modifyCall![0].input as { BackupRetentionPeriod?: number };
+    expect(input.BackupRetentionPeriod).toBe(0);
+  });
+
+  it('DBCluster round-trip: DeletionProtection=false reaches AWS (truthy-gate guard)', async () => {
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        DBClusters: [{ DBClusterArn: 'arn:aws:rds:us-east-1:123:cluster:my-cluster' }],
+      });
+
+    const observed = {
+      DBClusterIdentifier: 'my-cluster',
+      Engine: 'aurora-postgresql',
+      DeletionProtection: false,
+    };
+
+    await provider.update(
+      'L',
+      'my-cluster',
+      'AWS::RDS::DBCluster',
+      observed,
+      observed
+    );
+
+    const modifyCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof ModifyDBClusterCommand
+    );
+    const input = modifyCall![0].input as { DeletionProtection?: boolean };
+    expect(input.DeletionProtection).toBe(false);
+  });
+
+  // ─── DBSubnetGroup ────────────────────────────────────────────────
+
+  it('Class 2 — DBSubnetGroup round-trip with empty SubnetIds does NOT ship the field', async () => {
+    // ModifyDBSubnetGroup with `SubnetIds: []` is rejected by AWS
+    // (DBSubnetGroup requires ≥ 2 subnets in distinct AZs).
+    mockSend
+      .mockResolvedValueOnce({}) // ModifyDBSubnetGroup
+      .mockResolvedValueOnce({
+        DBSubnetGroups: [{ DBSubnetGroupArn: 'arn:aws:rds:us-east-1:123:subgrp:my-sg' }],
+      });
+
+    const observed = {
+      DBSubnetGroupName: 'my-sg',
+      DBSubnetGroupDescription: 'desc',
+      SubnetIds: [] as string[],
+    };
+
+    await provider.update(
+      'L',
+      'my-sg',
+      'AWS::RDS::DBSubnetGroup',
+      observed,
+      observed
+    );
+
+    const modifyCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof ModifyDBSubnetGroupCommand
+    );
+    expect(modifyCall).toBeDefined();
+    const input = modifyCall![0].input as { SubnetIds?: string[] };
+    expect(input.SubnetIds).toBeUndefined();
+  });
+
+  it('DBSubnetGroup non-empty SubnetIds DO reach AWS (positive control)', async () => {
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({
+        DBSubnetGroups: [{ DBSubnetGroupArn: 'arn:aws:rds:us-east-1:123:subgrp:my-sg' }],
+      });
+
+    const observed = {
+      DBSubnetGroupName: 'my-sg',
+      DBSubnetGroupDescription: 'desc',
+      SubnetIds: ['subnet-1', 'subnet-2'],
+    };
+
+    await provider.update(
+      'L',
+      'my-sg',
+      'AWS::RDS::DBSubnetGroup',
+      observed,
+      observed
+    );
+
+    const modifyCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof ModifyDBSubnetGroupCommand
+    );
+    const input = modifyCall![0].input as { SubnetIds?: string[] };
+    expect(input.SubnetIds).toEqual(['subnet-1', 'subnet-2']);
+  });
+
+  it('DBSubnetGroup no-drift round-trip produces zero tag mutations', async () => {
+    mockSend
+      .mockResolvedValueOnce({}) // ModifyDBSubnetGroup
+      .mockResolvedValueOnce({
+        DBSubnetGroups: [{ DBSubnetGroupArn: 'arn:aws:rds:us-east-1:123:subgrp:my-sg' }],
+      });
+
+    const observed = {
+      DBSubnetGroupName: 'my-sg',
+      DBSubnetGroupDescription: 'desc',
+      SubnetIds: ['subnet-1', 'subnet-2'],
+      Tags: [{ Key: 'k', Value: 'v' }],
+    };
+
+    await provider.update(
+      'L',
+      'my-sg',
+      'AWS::RDS::DBSubnetGroup',
+      observed,
+      observed
+    );
+
+    const tagAddCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof AddTagsToResourceCommand
+    );
+    const tagRemoveCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof RemoveTagsFromResourceCommand
+    );
+    expect(tagAddCalls).toHaveLength(0);
+    expect(tagRemoveCalls).toHaveLength(0);
+  });
+
+  // ─── readCurrentState gating (Class 1) ─────────────────────────────
+
+  it('readCurrentState — DBCluster (provisioned mode) does NOT emit ServerlessV2ScalingConfiguration', async () => {
+    // When AWS returns no ServerlessV2ScalingConfiguration (provisioned
+    // cluster), readCurrentState must NOT emit the `{}` placeholder.
+    // Otherwise drift fires false-positive on every provisioned cluster
+    // (state has no key) and revert sends an AWS-rejection-shape input.
+    mockSend.mockResolvedValueOnce({
+      DBClusters: [
+        {
+          DBClusterIdentifier: 'my-cluster',
+          Engine: 'aurora-postgresql',
+          EngineVersion: '15.3',
+          // ServerlessV2ScalingConfiguration intentionally absent.
+        },
+      ],
+    });
+
+    const result = await provider.readCurrentState(
+      'my-cluster',
+      'L',
+      'AWS::RDS::DBCluster'
+    );
+
+    expect(result).toBeDefined();
+    expect(result).not.toHaveProperty('ServerlessV2ScalingConfiguration');
+  });
+
+  it('readCurrentState — DBCluster (Aurora-Serverless-v2) DOES emit ServerlessV2ScalingConfiguration', async () => {
+    mockSend.mockResolvedValueOnce({
+      DBClusters: [
+        {
+          DBClusterIdentifier: 'my-cluster',
+          Engine: 'aurora-postgresql',
+          ServerlessV2ScalingConfiguration: { MinCapacity: 0.5, MaxCapacity: 4 },
+        },
+      ],
+    });
+
+    const result = await provider.readCurrentState(
+      'my-cluster',
+      'L',
+      'AWS::RDS::DBCluster'
+    );
+
+    expect(result?.ServerlessV2ScalingConfiguration).toEqual({
+      MinCapacity: 0.5,
+      MaxCapacity: 4,
+    });
+  });
+});

--- a/tests/unit/provisioning/secretsmanager-secret-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/secretsmanager-secret-provider-roundtrip.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  UpdateSecretCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+  ReplicateSecretToRegionsCommand,
+  RemoveRegionsFromReplicationCommand,
+} from '@aws-sdk/client-secrets-manager';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    secretsManager: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { SecretsManagerSecretProvider } from '../../../src/provisioning/providers/secretsmanager-secret-provider.js';
+
+const SECRET_ARN = 'arn:aws:secretsmanager:us-east-1:0:secret:my-secret-AbCdEf';
+
+describe('SecretsManagerSecretProvider read-update round-trip', () => {
+  let provider: SecretsManagerSecretProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSend.mockResolvedValue({});
+    provider = new SecretsManagerSecretProvider();
+  });
+
+  it('Class 2 — empty-string KmsKeyId placeholder is sanitized away on round-trip', async () => {
+    // Mechanical guard for Class 2 placeholder regression. See
+    // docs/provider-development.md § 3b "Read-update round-trip test".
+    //
+    // readCurrentState emits `KmsKeyId: ''` as a placeholder for "no
+    // customer-managed KMS key" (so the comparator's top-level walk can
+    // detect a console-side KmsKeyId set: state '' vs AWS '<arn>').
+    // `cdkd drift --revert` round-trips that placeholder back through
+    // update() (via buildRevertNewProperties' "AWS-current base" — the
+    // AWS-current value is itself the same '' placeholder when no key
+    // is set). AWS UpdateSecret rejects an empty-string KmsKeyId as an
+    // invalid ARN; the write layer must sanitize it to undefined so the
+    // wire payload omits the field entirely.
+    const observed = {
+      Name: 'my-secret',
+      Description: '',
+      KmsKeyId: '',
+      ReplicaRegions: [] as Array<Record<string, unknown>>,
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await provider.update('L', SECRET_ARN, 'AWS::SecretsManager::Secret', observed, observed);
+
+    // The sole UpdateSecret call must NOT carry an empty-string KmsKeyId.
+    const updateCalls = mockSend.mock.calls.filter((c) => c[0] instanceof UpdateSecretCommand);
+    for (const call of updateCalls) {
+      const input = call[0].input as { KmsKeyId?: string };
+      expect(input.KmsKeyId).toBeUndefined();
+    }
+  });
+
+  it('round-trip on no-drift snapshot triggers no Tag/Replica AWS calls', async () => {
+    // Stronger assertion for diff-based mutations: state == AWS implies
+    // update() must not fan out to TagResource / UntagResource /
+    // ReplicateSecretToRegions / RemoveRegionsFromReplication. (The
+    // single base UpdateSecret call is allowed — UpdateSecret with only
+    // SecretId is an AWS-side no-op and matches existing update() shape.)
+    const observed = {
+      Name: 'my-secret',
+      Description: 'human-readable',
+      KmsKeyId: 'arn:aws:kms:us-east-1:0:key/abcd',
+      ReplicaRegions: [{ Region: 'us-west-2', KmsKeyId: 'alias/aws/secretsmanager' }],
+      Tags: [{ Key: 'k', Value: 'v' }],
+    };
+
+    await provider.update('L', SECRET_ARN, 'AWS::SecretsManager::Secret', observed, observed);
+
+    const tagCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof TagResourceCommand || c[0] instanceof UntagResourceCommand
+    );
+    expect(tagCalls).toHaveLength(0);
+
+    const replicaCalls = mockSend.mock.calls.filter(
+      (c) =>
+        c[0] instanceof ReplicateSecretToRegionsCommand ||
+        c[0] instanceof RemoveRegionsFromReplicationCommand
+    );
+    expect(replicaCalls).toHaveLength(0);
+  });
+
+  it('round-trip on no-description / no-KMS / no-replicas snapshot succeeds without rejection-shape input', async () => {
+    // Bare-minimum secret (every optional field is the readCurrentState
+    // placeholder). The round-trip must not push any rejection-shape
+    // value to AWS — empty strings on Description/KmsKeyId, and empty
+    // arrays on ReplicaRegions/Tags must all be treated correctly:
+    //   - Description: '' is acceptable to UpdateSecret (clears desc).
+    //   - KmsKeyId: '' MUST be sanitized away (Class 2 — covered above).
+    //   - ReplicaRegions: [] / Tags: [] are diff-equal with previous,
+    //     so no Replica/Tag calls should fire.
+    const observed = {
+      Name: 'minimal-secret',
+      Description: '',
+      KmsKeyId: '',
+      ReplicaRegions: [] as Array<Record<string, unknown>>,
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await provider.update('L', SECRET_ARN, 'AWS::SecretsManager::Secret', observed, observed);
+
+    // Only an UpdateSecret-with-just-SecretId is allowed.
+    const updateCalls = mockSend.mock.calls.filter((c) => c[0] instanceof UpdateSecretCommand);
+    expect(updateCalls).toHaveLength(1);
+    const input = updateCalls[0]![0].input as Record<string, unknown>;
+    expect(input['SecretId']).toBe(SECRET_ARN);
+    expect(input['KmsKeyId']).toBeUndefined();
+
+    // No tag / replica fan-out.
+    const tagCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof TagResourceCommand || c[0] instanceof UntagResourceCommand
+    );
+    expect(tagCalls).toHaveLength(0);
+    const replicaCalls = mockSend.mock.calls.filter(
+      (c) =>
+        c[0] instanceof ReplicateSecretToRegionsCommand ||
+        c[0] instanceof RemoveRegionsFromReplicationCommand
+    );
+    expect(replicaCalls).toHaveLength(0);
+  });
+
+  it('Description="" reaches UpdateSecret (clear-the-description must not be silently dropped)', async () => {
+    // Truthy-gate guard: `if (properties['Description']) ...` would
+    // silently drop a user-intended `Description: ''` (clear). The fix
+    // is `!== undefined`, so '' must reach the wire. This is the
+    // semantic difference vs KmsKeyId (which AWS rejects on empty
+    // string and must therefore be sanitized away).
+    const previous = {
+      Name: 'my-secret',
+      Description: 'old description',
+      KmsKeyId: '',
+      ReplicaRegions: [] as Array<Record<string, unknown>>,
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+    const next = {
+      ...previous,
+      Description: '',
+    };
+
+    await provider.update('L', SECRET_ARN, 'AWS::SecretsManager::Secret', next, previous);
+
+    const updateCalls = mockSend.mock.calls.filter((c) => c[0] instanceof UpdateSecretCommand);
+    expect(updateCalls).toHaveLength(1);
+    const input = updateCalls[0]![0].input as Record<string, unknown>;
+    expect(input['Description']).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

PR 2/5 of the post-#162 provider round-trip audit. Audits the 5 data-layer providers for the 3 latent bug classes documented in `docs/provider-development.md § 3b` and adds round-trip property tests.

| Provider | Class 1 fix | Class 2 fix | Truthy gate fix | Round-trip tests |
|---|---|---|---|---|
| `DynamoDBTableProvider` | **3** (`SSESpecification` Status=ENABLED only, `StreamSpecification` StreamEnabled+StreamViewType only) | **2** (`GlobalSecondaryIndexes` / `LocalSecondaryIndexes` non-empty only) | — | 9 |
| `RDSProvider` | **1** (`ServerlessV2ScalingConfiguration` Aurora-Serverless-v2 only) | **2** sanitize (empty `VpcSecurityGroupIds` / `SubnetIds` → undefined) | — | 13 |
| `ElastiCacheProvider` | **1** (`TransitEncryptionEnabled` engine=redis only) | **1** sanitize (empty `SecurityGroupIds` → undefined) | — | 6 |
| `KMSProvider` | — | — | — (intentional truthy on `KeyPolicy` documented) | 6 + `getDriftUnknownPaths` for 5 unreadable fields |
| `SecretsManagerSecretProvider` | — | **1** sanitize (empty `KmsKeyId` → undefined) | **2** (`Description`, `KmsKeyId`) | 4 |

### Highlights

- **DynamoDB Class 1 cluster**: 3 sibling-discriminator gates (SSE Status, Stream enabled+viewType) prevent placeholder leaks on tables that have those features off.
- **RDS Aurora Serverless v2**: Provisioned-mode clusters no longer have `ServerlessV2ScalingConfiguration: {}` placeholder leaked into `ModifyDBCluster` (would have been rejected as invalid for non-Serverless-v2).
- **KMS unreadable-fields completeness**: 5 fields (`KeyPolicy`, `RotationPeriodInDays`, `BypassPolicyLockoutSafetyCheck`, `PendingWindowInDays`, etc.) registered via `getDriftUnknownPaths` so they no longer fire guaranteed-false-positive drift on every clean run.
- **SecretsManager `Description`**: Same truthy-gate bug class as IAM Role `Description` (PR #161); empty-string placeholder now reaches `UpdateSecret` to clear the description on `--revert`.

## Test plan

- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` clean
- [x] `npx vitest --run` — 1742 tests pass (was 1704; **38 new round-trip tests**)
- [x] `/run-integ dynamodb-streams` — deploy 9/9 in 19s, destroy 9/9 / 0 errors / 0 orphans

## Out of scope

PRs 3-5 will cover the remaining ~17 providers (network, compute/API, tail).
