### PR TITLE
fix(drift): round-trip audit for network providers (PR 3/5)

### DIFF
--- a/src/provisioning/providers/cloudfront-oai-provider.ts
+++ b/src/provisioning/providers/cloudfront-oai-provider.ts
@@ -291,6 +291,25 @@ export class CloudFrontOAIProvider implements ResourceProvider {
   }
 
   /**
+   * State property paths the comparator must skip during drift detection.
+   *
+   * `CloudFrontOriginAccessIdentityConfig.CallerReference` is set by cdkd
+   * to `logicalId` at create time regardless of what the CDK template
+   * specified, so it ends up in `state.properties` (from the resolved
+   * template) but is intentionally not surfaced by `readCurrentState`. A
+   * keys-from-state walk would otherwise compare `state.CallerReference`
+   * against `aws=undefined` and fire a guaranteed false positive on every
+   * clean run for any stack whose template templated CallerReference.
+   *
+   * The field is also immutable in AWS — the OAI's CallerReference cannot
+   * change post-create — so omitting it from drift is also semantically
+   * correct.
+   */
+  getDriftUnknownPaths(): string[] {
+    return ['CloudFrontOriginAccessIdentityConfig.CallerReference'];
+  }
+
+  /**
    * Adopt an existing CloudFront Origin Access Identity into cdkd state.
    *
    * **Explicit override only.** OAIs do not support tags — their identity

--- a/src/provisioning/providers/ec2-provider.ts
+++ b/src/provisioning/providers/ec2-provider.ts
@@ -55,7 +55,7 @@ import {
 } from '@aws-sdk/client-ec2';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
-import { ProvisioningError } from '../../utils/error-handler.js';
+import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { CDK_PATH_TAG } from '../import-helpers.js';
 import type {
@@ -290,7 +290,14 @@ export class EC2Provider implements ResourceProvider {
       case 'AWS::EC2::NetworkAcl':
       case 'AWS::EC2::NetworkAclEntry':
       case 'AWS::EC2::SubnetNetworkAclAssociation':
-        return { physicalId, wasReplaced: false };
+        // Reject loudly instead of silently no-op'ing on
+        // `cdkd drift --revert`. Same rationale as Subnet / IGW /
+        // NatGateway / RouteTable above. See PR I.
+        throw new ResourceUpdateNotSupportedError(
+          resourceType,
+          logicalId,
+          'destroy + redeploy. The property surface for this resource type is effectively immutable in cdkd today.'
+        );
       default:
         throw new ProvisioningError(
           `Unsupported resource type: ${resourceType}`,
@@ -479,25 +486,37 @@ export class EC2Provider implements ResourceProvider {
     this.logger.debug(`Updating VPC ${logicalId}: ${physicalId}`);
 
     try {
-      // Update DNS settings
-      if (properties['EnableDnsHostnames'] !== undefined) {
-        const value =
-          properties['EnableDnsHostnames'] === true || properties['EnableDnsHostnames'] === 'true';
+      // Coerce CFn-string-or-bool ("true" | true) into a real boolean so the
+      // diff below treats `"true"` and `true` as the same value.
+      const asBool = (v: unknown): boolean | undefined => {
+        if (v === undefined) return undefined;
+        return v === true || v === 'true';
+      };
+
+      // Update DNS settings — diff-based so a no-op round-trip
+      // (`update(state, state)` from `cdkd drift --revert`) produces zero
+      // ModifyVpcAttribute calls. AWS treats ModifyVpcAttribute as
+      // idempotent, but the canonical round-trip guard ("state==AWS
+      // produces zero mutating SDK calls") is the structural check that
+      // catches future regressions in the diff logic.
+      const newDnsHostnames = asBool(properties['EnableDnsHostnames']);
+      const oldDnsHostnames = asBool(previousProperties['EnableDnsHostnames']);
+      if (newDnsHostnames !== undefined && newDnsHostnames !== oldDnsHostnames) {
         await this.ec2Client.send(
           new ModifyVpcAttributeCommand({
             VpcId: physicalId,
-            EnableDnsHostnames: { Value: value },
+            EnableDnsHostnames: { Value: newDnsHostnames },
           })
         );
       }
 
-      if (properties['EnableDnsSupport'] !== undefined) {
-        const value =
-          properties['EnableDnsSupport'] === true || properties['EnableDnsSupport'] === 'true';
+      const newDnsSupport = asBool(properties['EnableDnsSupport']);
+      const oldDnsSupport = asBool(previousProperties['EnableDnsSupport']);
+      if (newDnsSupport !== undefined && newDnsSupport !== oldDnsSupport) {
         await this.ec2Client.send(
           new ModifyVpcAttributeCommand({
             VpcId: physicalId,
-            EnableDnsSupport: { Value: value },
+            EnableDnsSupport: { Value: newDnsSupport },
           })
         );
       }
@@ -716,8 +735,21 @@ export class EC2Provider implements ResourceProvider {
   }
 
   private updateSubnet(logicalId: string, physicalId: string): Promise<ResourceUpdateResult> {
-    this.logger.debug(`Updating Subnet ${logicalId}: ${physicalId} (no-op, immutable properties)`);
-    return Promise.resolve({ physicalId, wasReplaced: false });
+    // Subnet is immutable on every property cdkd's `readCurrentState`
+    // surfaces (VpcId / CidrBlock / AvailabilityZone are CREATE-only;
+    // MapPublicIpOnLaunch is mutable via ModifySubnetAttribute but cdkd
+    // does not yet wire that path through `update()`). Reject loudly
+    // instead of silently no-op'ing — `cdkd drift --revert` would
+    // otherwise report `✓ reverted` and the next drift run would
+    // re-detect the same drift. See PR I in CLAUDE.md.
+    void physicalId;
+    return Promise.reject(
+      new ResourceUpdateNotSupportedError(
+        'AWS::EC2::Subnet',
+        logicalId,
+        'destroy + redeploy the Subnet (and the resources that depend on it). Subnet properties are immutable in AWS.'
+      )
+    );
   }
 
   private async deleteSubnet(
@@ -887,8 +919,17 @@ export class EC2Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string
   ): Promise<ResourceUpdateResult> {
-    this.logger.debug(`Updating InternetGateway ${logicalId}: ${physicalId} (no-op)`);
-    return Promise.resolve({ physicalId, wasReplaced: false });
+    // IGW has no mutable properties cdkd surfaces (Tags would be the
+    // only candidate; not in `readCurrentState`). Reject loudly instead
+    // of silently no-op'ing on `cdkd drift --revert`. See PR I.
+    void physicalId;
+    return Promise.reject(
+      new ResourceUpdateNotSupportedError(
+        'AWS::EC2::InternetGateway',
+        logicalId,
+        'destroy + redeploy the InternetGateway. IGW properties are immutable in AWS.'
+      )
+    );
   }
 
   private async deleteInternetGateway(
@@ -979,8 +1020,14 @@ export class EC2Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string
   ): Promise<ResourceUpdateResult> {
-    this.logger.debug(`Updating VPCGatewayAttachment ${logicalId}: ${physicalId} (no-op)`);
-    return Promise.resolve({ physicalId, wasReplaced: false });
+    void physicalId;
+    return Promise.reject(
+      new ResourceUpdateNotSupportedError(
+        'AWS::EC2::VPCGatewayAttachment',
+        logicalId,
+        'destroy + redeploy the VPCGatewayAttachment. The (VpcId, InternetGatewayId) pair is immutable.'
+      )
+    );
   }
 
   private async deleteVpcGatewayAttachment(
@@ -1131,12 +1178,22 @@ export class EC2Provider implements ResourceProvider {
   }
 
   private updateNatGateway(logicalId: string, physicalId: string): Promise<ResourceUpdateResult> {
-    // NAT gateway has no in-place mutable properties (Tags handled
-    // separately if needed). Property changes that map here are
-    // already detected as immutable by the engine and trigger
-    // DELETE + CREATE upstream.
-    this.logger.debug(`Updating NatGateway ${logicalId}: ${physicalId} (no-op)`);
-    return Promise.resolve({ physicalId, wasReplaced: false });
+    // NAT Gateway is immutable on every property cdkd's
+    // `readCurrentState` surfaces (SubnetId / ConnectivityType /
+    // AllocationId / PrivateIpAddress are all CREATE-only). The deploy
+    // engine's replacement detection already routes property changes to
+    // DELETE + CREATE upstream of this method — `update()` is reached
+    // only via `cdkd drift --revert`, where silently no-op'ing would
+    // make the user think drift was reverted while AWS keeps the
+    // console-side change. Reject loudly instead. See PR I.
+    void physicalId;
+    return Promise.reject(
+      new ResourceUpdateNotSupportedError(
+        'AWS::EC2::NatGateway',
+        logicalId,
+        'destroy + redeploy the NatGateway (and the dependent Routes). NAT Gateway properties are immutable in AWS.'
+      )
+    );
   }
 
   private async deleteNatGateway(
@@ -1266,8 +1323,14 @@ export class EC2Provider implements ResourceProvider {
   }
 
   private updateRouteTable(logicalId: string, physicalId: string): Promise<ResourceUpdateResult> {
-    this.logger.debug(`Updating RouteTable ${logicalId}: ${physicalId} (no-op)`);
-    return Promise.resolve({ physicalId, wasReplaced: false });
+    void physicalId;
+    return Promise.reject(
+      new ResourceUpdateNotSupportedError(
+        'AWS::EC2::RouteTable',
+        logicalId,
+        'destroy + redeploy the RouteTable (and its associated Routes / SubnetRouteTableAssociations). VpcId is immutable.'
+      )
+    );
   }
 
   private async deleteRouteTable(
@@ -1370,9 +1433,17 @@ export class EC2Provider implements ResourceProvider {
     physicalId: string,
     resourceType: string,
     properties: Record<string, unknown>,
-    _previousProperties: Record<string, unknown>
+    previousProperties: Record<string, unknown>
   ): Promise<ResourceUpdateResult> {
     this.logger.debug(`Updating Route ${logicalId}: ${physicalId}`);
+
+    // No-op short-circuit: a `cdkd drift --revert` round-trip can call
+    // update() with new == old when only sibling resources drifted.
+    // Without this guard, the delete + recreate path below would
+    // needlessly churn a Route that AWS already has in the right shape.
+    if (JSON.stringify(properties) === JSON.stringify(previousProperties)) {
+      return { physicalId, wasReplaced: false };
+    }
 
     // Route updates require replacement (DestinationCidrBlock and RouteTableId are immutable)
     // For target changes, we delete and recreate
@@ -1505,10 +1576,14 @@ export class EC2Provider implements ResourceProvider {
     logicalId: string,
     physicalId: string
   ): Promise<ResourceUpdateResult> {
-    this.logger.debug(
-      `Updating SubnetRouteTableAssociation ${logicalId}: ${physicalId} (no-op, requires replacement)`
+    void physicalId;
+    return Promise.reject(
+      new ResourceUpdateNotSupportedError(
+        'AWS::EC2::SubnetRouteTableAssociation',
+        logicalId,
+        'destroy + redeploy the association. (SubnetId, RouteTableId) is immutable.'
+      )
     );
-    return Promise.resolve({ physicalId, wasReplaced: false });
   }
 
   private async deleteSubnetRouteTableAssociation(
@@ -1892,6 +1967,13 @@ export class EC2Provider implements ResourceProvider {
     previousProperties: Record<string, unknown>
   ): Promise<ResourceUpdateResult> {
     this.logger.debug(`Updating SecurityGroupIngress ${logicalId}: ${physicalId}`);
+
+    // No-op short-circuit (mirrors `updateRoute`): a `cdkd drift --revert`
+    // round-trip can call update() with new == old, which without this
+    // guard would needlessly revoke + re-authorize the rule.
+    if (JSON.stringify(properties) === JSON.stringify(previousProperties)) {
+      return { physicalId, wasReplaced: false };
+    }
 
     // SecurityGroupIngress updates require replacement: revoke old, authorize new
     try {

--- a/src/provisioning/providers/elbv2-provider.ts
+++ b/src/provisioning/providers/elbv2-provider.ts
@@ -423,7 +423,20 @@ export class ELBv2Provider implements ResourceProvider {
     this.logger.debug(`Updating TargetGroup ${logicalId}: ${physicalId}`);
 
     try {
-      const matcher = properties['Matcher'] as { HttpCode?: string; GrpcCode?: string } | undefined;
+      // Class 2 sanitize at the wire layer: `readCurrentState` always-emits
+      // `Matcher: {}` for non-HTTP/HTTPS target groups (TCP / UDP / GENEVE
+      // never carry HttpCode / GrpcCode). Without this guard, `cdkd drift
+      // --revert` round-trips the `{}` placeholder back through
+      // `ModifyTargetGroup`, which AWS rejects: "Matcher must contain
+      // either HttpCode or GrpcCode". Treat the empty object the same as
+      // an absent Matcher — drop the key from the API input.
+      const rawMatcher = properties['Matcher'] as
+        | { HttpCode?: string; GrpcCode?: string }
+        | undefined;
+      const matcher =
+        rawMatcher && (rawMatcher.HttpCode !== undefined || rawMatcher.GrpcCode !== undefined)
+          ? rawMatcher
+          : undefined;
 
       await this.getClient().send(
         new ModifyTargetGroupCommand({

--- a/src/provisioning/providers/route53-provider.ts
+++ b/src/provisioning/providers/route53-provider.ts
@@ -628,9 +628,11 @@ export class Route53Provider implements ResourceProvider {
       }
     }
 
-    // Routing policy properties
+    // Routing policy properties — use `!== undefined` (not truthy) so a
+    // valid falsy value from observedProperties (e.g. weight=0) is not
+    // silently dropped on `cdkd drift --revert` round-trips.
     const setIdentifier = properties['SetIdentifier'] as string | undefined;
-    if (setIdentifier) {
+    if (setIdentifier !== undefined) {
       recordSet.SetIdentifier = setIdentifier;
     }
 
@@ -640,12 +642,12 @@ export class Route53Provider implements ResourceProvider {
     }
 
     const region = properties['Region'] as string | undefined;
-    if (region) {
+    if (region !== undefined) {
       recordSet.Region = region as ResourceRecordSet['Region'];
     }
 
     const failover = properties['Failover'] as string | undefined;
-    if (failover) {
+    if (failover !== undefined) {
       recordSet.Failover = failover as ResourceRecordSet['Failover'];
     }
 
@@ -658,20 +660,20 @@ export class Route53Provider implements ResourceProvider {
     }
 
     const healthCheckId = properties['HealthCheckId'] as string | undefined;
-    if (healthCheckId) {
+    if (healthCheckId !== undefined) {
       recordSet.HealthCheckId = healthCheckId;
     }
 
     const geoLocation = properties['GeoLocation'] as Record<string, unknown> | undefined;
     if (geoLocation) {
       recordSet.GeoLocation = {
-        ...(geoLocation['ContinentCode']
+        ...(geoLocation['ContinentCode'] !== undefined
           ? { ContinentCode: geoLocation['ContinentCode'] as string }
           : {}),
-        ...(geoLocation['CountryCode']
+        ...(geoLocation['CountryCode'] !== undefined
           ? { CountryCode: geoLocation['CountryCode'] as string }
           : {}),
-        ...(geoLocation['SubdivisionCode']
+        ...(geoLocation['SubdivisionCode'] !== undefined
           ? { SubdivisionCode: geoLocation['SubdivisionCode'] as string }
           : {}),
       };
@@ -952,12 +954,19 @@ export class Route53Provider implements ResourceProvider {
       }
       result['HostedZoneConfig'] = cfg;
     }
-    result['VPCs'] = (resp.VPCs ?? []).map((v) => {
-      const out: Record<string, unknown> = {};
-      if (v.VPCId !== undefined) out['VPCId'] = v.VPCId;
-      if (v.VPCRegion !== undefined) out['VPCRegion'] = v.VPCRegion;
-      return out;
-    });
+    // Class 1: VPCs is a private-zone-only field. AWS rejects
+    // AssociateVPCWithHostedZone on public zones, and emitting an empty
+    // [] placeholder on a public zone fires false drift against state
+    // that has no VPCs key. Gate on PrivateZone === true (the
+    // discriminator) so public zones don't carry the placeholder.
+    if (resp.HostedZone.Config?.PrivateZone === true) {
+      result['VPCs'] = (resp.VPCs ?? []).map((v) => {
+        const out: Record<string, unknown> = {};
+        if (v.VPCId !== undefined) out['VPCId'] = v.VPCId;
+        if (v.VPCRegion !== undefined) out['VPCRegion'] = v.VPCRegion;
+        return out;
+      });
+    }
 
     // HostedZoneTags via ListTagsForResource. Route 53 ResourceId is the
     // zone id WITHOUT the "/hostedzone/" prefix.
@@ -1008,11 +1017,21 @@ export class Route53Provider implements ResourceProvider {
       Name: name,
       Type: type,
     };
-    if (recordSet.TTL !== undefined) result['TTL'] = recordSet.TTL;
-    // CFn / cdkd state shape is string[]; SDK is [{Value}].
-    result['ResourceRecords'] = (recordSet.ResourceRecords ?? [])
-      .map((r) => r.Value)
-      .filter((v): v is string => typeof v === 'string');
+    // Class 1: TTL and ResourceRecords are mutually exclusive with
+    // AliasTarget — AWS rejects ChangeResourceRecordSets that carries
+    // both. Gate the standard-record fields on `!AliasTarget` so an
+    // alias record's observed snapshot does NOT carry placeholder
+    // `TTL` / `ResourceRecords: []` that would (a) fire false drift
+    // against state which legitimately lacks those keys and (b) round-
+    // trip into a structurally-invalid ChangeResourceRecordSets input
+    // if buildResourceRecordSet is ever changed to forward both.
+    if (!recordSet.AliasTarget) {
+      if (recordSet.TTL !== undefined) result['TTL'] = recordSet.TTL;
+      // CFn / cdkd state shape is string[]; SDK is [{Value}].
+      result['ResourceRecords'] = (recordSet.ResourceRecords ?? [])
+        .map((r) => r.Value)
+        .filter((v): v is string => typeof v === 'string');
+    }
     if (recordSet.AliasTarget) {
       const at: Record<string, unknown> = {};
       if (recordSet.AliasTarget.HostedZoneId !== undefined) {

--- a/tests/unit/provisioning/cloudfront-oai-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/cloudfront-oai-provider-roundtrip.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateCloudFrontOriginAccessIdentityCommand } from '@aws-sdk/client-cloudfront';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    cloudFront: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { CloudFrontOAIProvider } from '../../../src/provisioning/providers/cloudfront-oai-provider.js';
+
+const OAI_ID = 'E1ABCDEF123456';
+
+describe('CloudFrontOAIProvider read-update round-trip', () => {
+  let provider: CloudFrontOAIProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new CloudFrontOAIProvider();
+  });
+
+  it('round-trip on empty Comment passes Comment: "" through to AWS (truthy-gate guard)', async () => {
+    // Mechanical guard for the truthy-gate failure mode. See
+    // docs/provider-development.md § 3b "Read-update round-trip test".
+    //
+    // If `update()` ever regresses to `if (config?.Comment) { ... }`,
+    // an empty string would be silently dropped — and the
+    // UpdateCloudFrontOriginAccessIdentity input would carry whatever
+    // the prior code path left there. Round-tripping
+    // `observedProperties` with `Comment: ''` (a legitimate value
+    // that means "no comment") must reach AWS as `Comment: ''`, not
+    // be coerced to undefined.
+
+    // Get returns a non-empty AWS-current Comment so the round-trip
+    // is exercising state="" overriding AWS=non-empty.
+    mockSend.mockResolvedValueOnce({
+      ETag: 'etag-abc',
+      CloudFrontOriginAccessIdentity: {
+        Id: OAI_ID,
+        S3CanonicalUserId: 'canonical',
+        CloudFrontOriginAccessIdentityConfig: {
+          CallerReference: 'OAILogical',
+          Comment: 'previous comment',
+        },
+      },
+    });
+    mockSend.mockResolvedValueOnce({}); // Update OK
+
+    const observed = {
+      CloudFrontOriginAccessIdentityConfig: {
+        Comment: '',
+      },
+    };
+
+    await provider.update(
+      'OAILogical',
+      OAI_ID,
+      'AWS::CloudFront::CloudFrontOriginAccessIdentity',
+      observed,
+      observed
+    );
+
+    const updateCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateCloudFrontOriginAccessIdentityCommand
+    );
+    expect(updateCalls).toHaveLength(1);
+
+    const input = updateCalls[0]![0].input as {
+      Id: string;
+      IfMatch: string;
+      CloudFrontOriginAccessIdentityConfig: { CallerReference: string; Comment: string };
+    };
+    expect(input.Id).toBe(OAI_ID);
+    expect(input.IfMatch).toBe('etag-abc');
+    expect(input.CloudFrontOriginAccessIdentityConfig.Comment).toBe('');
+    // CallerReference is immutable; round-trip must preserve the
+    // current AWS-side value rather than fall through to logicalId or
+    // empty.
+    expect(input.CloudFrontOriginAccessIdentityConfig.CallerReference).toBe('OAILogical');
+  });
+
+  it('round-trip on no-drift snapshot pushes the same Comment back (logical no-op)', async () => {
+    // Stronger assertion mirroring `sns-topic-provider-roundtrip.test.ts`:
+    // when state == AWS, the round-trip must NOT mutate the AWS-side
+    // resource. OAI's update() always issues Get + Update by API
+    // shape, so "no mutation" is structurally observable as "the
+    // Update input's Comment matches the AWS-current Comment".
+    mockSend.mockResolvedValueOnce({
+      ETag: 'etag-abc',
+      CloudFrontOriginAccessIdentity: {
+        Id: OAI_ID,
+        S3CanonicalUserId: 'canonical',
+        CloudFrontOriginAccessIdentityConfig: {
+          CallerReference: 'OAILogical',
+          Comment: 'my OAI',
+        },
+      },
+    });
+    mockSend.mockResolvedValueOnce({}); // Update OK
+
+    const observed = {
+      CloudFrontOriginAccessIdentityConfig: {
+        Comment: 'my OAI',
+      },
+    };
+
+    await provider.update(
+      'OAILogical',
+      OAI_ID,
+      'AWS::CloudFront::CloudFrontOriginAccessIdentity',
+      observed,
+      observed
+    );
+
+    const updateCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateCloudFrontOriginAccessIdentityCommand
+    );
+    expect(updateCalls).toHaveLength(1);
+
+    const input = updateCalls[0]![0].input as {
+      CloudFrontOriginAccessIdentityConfig: { CallerReference: string; Comment: string };
+    };
+    expect(input.CloudFrontOriginAccessIdentityConfig.Comment).toBe('my OAI');
+    expect(input.CloudFrontOriginAccessIdentityConfig.CallerReference).toBe('OAILogical');
+  });
+
+  it('declares CloudFrontOriginAccessIdentityConfig.CallerReference as drift-unknown', async () => {
+    // Guard against the false-positive-drift bug: state.properties
+    // (from the resolved template) carries CallerReference, but
+    // readCurrentState intentionally does not surface it (cdkd always
+    // sets it to logicalId at create time). Without this declaration
+    // the comparator would fire drift on every clean run for any
+    // stack whose template templated CallerReference. Field is
+    // immutable in AWS post-create, so omitting it is also
+    // semantically correct.
+    expect(provider.getDriftUnknownPaths?.()).toEqual([
+      'CloudFrontOriginAccessIdentityConfig.CallerReference',
+    ]);
+  });
+});

--- a/tests/unit/provisioning/ec2-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/ec2-provider-roundtrip.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ModifyVpcAttributeCommand,
+  CreateTagsCommand,
+  DeleteTagsCommand,
+  CreateRouteCommand,
+  DeleteRouteCommand,
+  AuthorizeSecurityGroupIngressCommand,
+  AuthorizeSecurityGroupEgressCommand,
+  RevokeSecurityGroupIngressCommand,
+  RevokeSecurityGroupEgressCommand,
+  DescribeInstancesCommand,
+} from '@aws-sdk/client-ec2';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    ec2: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { EC2Provider } from '../../../src/provisioning/providers/ec2-provider.js';
+import { ResourceUpdateNotSupportedError } from '../../../src/utils/error-handler.js';
+
+/**
+ * Round-trip guard tests for `EC2Provider.update`: when `cdkd drift
+ * --revert` round-trips `observedProperties` through `update(state, state)`
+ * (= no-drift snapshot), the provider must NOT emit spurious mutating SDK
+ * calls, and resource types whose every readable property is immutable
+ * must reject loudly with `ResourceUpdateNotSupportedError` instead of
+ * silently no-op'ing.
+ *
+ * See `docs/provider-development.md § 3b` and the canonical
+ * `tests/unit/provisioning/sns-topic-provider-roundtrip.test.ts`.
+ */
+describe('EC2Provider read-update round-trip', () => {
+  let provider: EC2Provider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new EC2Provider();
+  });
+
+  // Helpers — count mutating SDK calls (anything that writes to AWS).
+  const mutatingCommandTypes: Array<new (...args: unknown[]) => unknown> = [
+    ModifyVpcAttributeCommand,
+    CreateTagsCommand,
+    DeleteTagsCommand,
+    CreateRouteCommand,
+    DeleteRouteCommand,
+    AuthorizeSecurityGroupIngressCommand,
+    AuthorizeSecurityGroupEgressCommand,
+    RevokeSecurityGroupIngressCommand,
+    RevokeSecurityGroupEgressCommand,
+  ];
+  const countMutatingCalls = (): number =>
+    mockSend.mock.calls.filter((c) =>
+      mutatingCommandTypes.some((cmd) => c[0] instanceof cmd)
+    ).length;
+
+  describe('AWS::EC2::VPC (mutable: DNS attrs + Tags)', () => {
+    it('round-trip on no-drift state produces zero mutating SDK calls', async () => {
+      // Both DNS attrs are diff-based — equal new vs old means no
+      // ModifyVpcAttribute fires. Tags equal means no CreateTags/DeleteTags.
+      const state = {
+        CidrBlock: '10.0.0.0/16',
+        EnableDnsHostnames: true,
+        EnableDnsSupport: true,
+        Tags: [{ Key: 'aws:cdk:path', Value: 'Stack/Vpc' }],
+      };
+
+      const result = await provider.update('Vpc', 'vpc-123', 'AWS::EC2::VPC', state, state);
+
+      expect(result.physicalId).toBe('vpc-123');
+      expect(result.wasReplaced).toBe(false);
+      expect(countMutatingCalls()).toBe(0);
+    });
+
+    it('round-trip is robust to "true" string vs true boolean equivalence', async () => {
+      // CFn often serialises booleans as strings in templates; the diff
+      // must treat `"true"` and `true` as the same value or `--revert`
+      // would re-write DNS settings on every run.
+      const state = {
+        EnableDnsHostnames: 'true',
+        EnableDnsSupport: 'true',
+        Tags: [],
+      };
+      const observed = {
+        EnableDnsHostnames: true,
+        EnableDnsSupport: true,
+        Tags: [],
+      };
+
+      await provider.update('Vpc', 'vpc-123', 'AWS::EC2::VPC', state, observed);
+
+      expect(countMutatingCalls()).toBe(0);
+    });
+
+    it('actual DNS drift fires ModifyVpcAttribute exactly once per changed attr', async () => {
+      // Sanity: the diff is correctly detecting a real change too.
+      mockSend.mockResolvedValue({}); // every send succeeds
+      const newProps = { EnableDnsHostnames: true, EnableDnsSupport: true, Tags: [] };
+      const oldProps = { EnableDnsHostnames: false, EnableDnsSupport: true, Tags: [] };
+
+      await provider.update('Vpc', 'vpc-123', 'AWS::EC2::VPC', newProps, oldProps);
+
+      const modifyCalls = mockSend.mock.calls.filter(
+        (c) => c[0] instanceof ModifyVpcAttributeCommand
+      );
+      expect(modifyCalls).toHaveLength(1);
+    });
+  });
+
+  describe('AWS::EC2::SecurityGroup (Tags + ingress/egress rule diff)', () => {
+    it('round-trip on no-drift state with empty rule lists produces zero calls', async () => {
+      // Class 2 candidate — empty rule list `[]` is the always-emit
+      // shape some providers' readCurrentState would produce. The diff
+      // helper must treat `[] vs []` as zero calls (not "drop the empty
+      // list and authorize nothing", which would accidentally fire).
+      const state = {
+        GroupName: 'sg-name',
+        GroupDescription: 'desc',
+        VpcId: 'vpc-1',
+        SecurityGroupIngress: [],
+        SecurityGroupEgress: [],
+        Tags: [],
+      };
+
+      await provider.update('Sg', 'sg-1', 'AWS::EC2::SecurityGroup', state, state);
+
+      expect(countMutatingCalls()).toBe(0);
+    });
+
+    it('round-trip on no-drift state with non-empty ingress + egress rules produces zero calls', async () => {
+      // The rule diff must hash-match identical rules and produce no
+      // revoke/authorize.
+      const rule = {
+        IpProtocol: 'tcp',
+        FromPort: 443,
+        ToPort: 443,
+        CidrIp: '0.0.0.0/0',
+        Description: 'HTTPS',
+      };
+      const state = {
+        GroupDescription: 'desc',
+        VpcId: 'vpc-1',
+        SecurityGroupIngress: [rule],
+        SecurityGroupEgress: [rule],
+        Tags: [{ Key: 'aws:cdk:path', Value: 'Stack/Sg' }],
+      };
+
+      await provider.update('Sg', 'sg-1', 'AWS::EC2::SecurityGroup', state, state);
+
+      expect(countMutatingCalls()).toBe(0);
+    });
+
+    it('actual rule add fires AuthorizeSecurityGroupIngress once', async () => {
+      mockSend.mockResolvedValue({});
+      const oldProps = {
+        VpcId: 'vpc-1',
+        SecurityGroupIngress: [],
+        SecurityGroupEgress: [],
+        Tags: [],
+      };
+      const newProps = {
+        VpcId: 'vpc-1',
+        SecurityGroupIngress: [
+          { IpProtocol: 'tcp', FromPort: 80, ToPort: 80, CidrIp: '0.0.0.0/0' },
+        ],
+        SecurityGroupEgress: [],
+        Tags: [],
+      };
+
+      await provider.update('Sg', 'sg-1', 'AWS::EC2::SecurityGroup', newProps, oldProps);
+
+      const authIngress = mockSend.mock.calls.filter(
+        (c) => c[0] instanceof AuthorizeSecurityGroupIngressCommand
+      );
+      expect(authIngress).toHaveLength(1);
+    });
+  });
+
+  describe('AWS::EC2::Instance (Tags only mutable)', () => {
+    it('round-trip on no-drift state produces zero mutating calls (DescribeInstances is read-only)', async () => {
+      // updateInstance always issues DescribeInstances at the end to
+      // refresh attributes — that's a read, not a mutation, so it must
+      // not count against the round-trip guard.
+      mockSend.mockResolvedValueOnce({
+        Reservations: [
+          {
+            Instances: [
+              {
+                InstanceId: 'i-1',
+                PrivateIpAddress: '10.0.0.10',
+                Placement: { AvailabilityZone: 'us-east-1a' },
+              },
+            ],
+          },
+        ],
+      });
+      const state = {
+        ImageId: 'ami-1',
+        InstanceType: 't3.micro',
+        SubnetId: 'subnet-1',
+        Tags: [{ Key: 'env', Value: 'prod' }],
+      };
+
+      await provider.update('Instance', 'i-1', 'AWS::EC2::Instance', state, state);
+
+      // DescribeInstances is read-only — it's allowed.
+      const describeCalls = mockSend.mock.calls.filter(
+        (c) => c[0] instanceof DescribeInstancesCommand
+      );
+      expect(describeCalls).toHaveLength(1);
+      // No CreateTags / DeleteTags / ModifyVpcAttribute / etc.
+      expect(countMutatingCalls()).toBe(0);
+    });
+  });
+
+  describe('AWS::EC2::Route (immutable: short-circuit on no-drift)', () => {
+    it('round-trip on no-drift state does NOT delete + recreate', async () => {
+      // Pre-PR: updateRoute unconditionally called deleteRoute +
+      // createRoute. On a `cdkd drift --revert` round-trip with
+      // state == AWS, this would needlessly churn the route.
+      const state = {
+        RouteTableId: 'rtb-1',
+        DestinationCidrBlock: '0.0.0.0/0',
+        NatGatewayId: 'nat-1',
+      };
+
+      const result = await provider.update(
+        'Route',
+        'rtb-1|0.0.0.0/0',
+        'AWS::EC2::Route',
+        state,
+        state
+      );
+
+      expect(result.wasReplaced).toBe(false);
+      expect(countMutatingCalls()).toBe(0);
+    });
+
+    it('actual target change still triggers delete + recreate (replacement)', async () => {
+      mockSend.mockResolvedValue({});
+      const oldProps = {
+        RouteTableId: 'rtb-1',
+        DestinationCidrBlock: '0.0.0.0/0',
+        GatewayId: 'igw-1',
+      };
+      const newProps = {
+        RouteTableId: 'rtb-1',
+        DestinationCidrBlock: '0.0.0.0/0',
+        NatGatewayId: 'nat-1',
+      };
+
+      const result = await provider.update(
+        'Route',
+        'rtb-1|0.0.0.0/0',
+        'AWS::EC2::Route',
+        newProps,
+        oldProps
+      );
+
+      expect(result.wasReplaced).toBe(true);
+      const deleted = mockSend.mock.calls.some((c) => c[0] instanceof DeleteRouteCommand);
+      const created = mockSend.mock.calls.some((c) => c[0] instanceof CreateRouteCommand);
+      expect(deleted).toBe(true);
+      expect(created).toBe(true);
+    });
+  });
+
+  describe('Immutable resource types reject with ResourceUpdateNotSupportedError', () => {
+    // PR I pattern: every resource type whose every readable property is
+    // immutable must reject `update()` loudly so `cdkd drift --revert`
+    // does not report `✓ reverted` on a console-side change AWS will
+    // keep.
+    const immutableCases: Array<[string, string]> = [
+      ['AWS::EC2::Subnet', 'subnet-1'],
+      ['AWS::EC2::InternetGateway', 'igw-1'],
+      ['AWS::EC2::VPCGatewayAttachment', 'igw-1|vpc-1'],
+      ['AWS::EC2::NatGateway', 'nat-1'],
+      ['AWS::EC2::RouteTable', 'rtb-1'],
+      ['AWS::EC2::SubnetRouteTableAssociation', 'rtbassoc-1'],
+      ['AWS::EC2::NetworkAcl', 'acl-1'],
+      ['AWS::EC2::NetworkAclEntry', 'acl-1|100|ingress'],
+      ['AWS::EC2::SubnetNetworkAclAssociation', 'aclassoc-1'],
+    ];
+
+    it.each(immutableCases)(
+      '%s rejects with ResourceUpdateNotSupportedError on round-trip',
+      async (resourceType, physicalId) => {
+        const props = { Foo: 'bar' };
+        await expect(
+          provider.update('L', physicalId, resourceType, props, props)
+        ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+        // No mutating SDK calls fired — the throw happened before any
+        // network IO.
+        expect(countMutatingCalls()).toBe(0);
+      }
+    );
+  });
+
+  describe('AWS::EC2::SecurityGroupIngress (immutable rule, short-circuit)', () => {
+    it('round-trip on no-drift state does NOT revoke + re-authorize', async () => {
+      const state = {
+        GroupId: 'sg-1',
+        IpProtocol: 'tcp',
+        FromPort: 22,
+        ToPort: 22,
+        CidrIp: '10.0.0.0/8',
+      };
+
+      const result = await provider.update(
+        'Ing',
+        'sg-1|tcp|22|22|10.0.0.0/8',
+        'AWS::EC2::SecurityGroupIngress',
+        state,
+        state
+      );
+
+      expect(result.wasReplaced).toBe(false);
+      expect(countMutatingCalls()).toBe(0);
+    });
+  });
+});

--- a/tests/unit/provisioning/elbv2-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/elbv2-provider-roundtrip.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ModifyTargetGroupCommand,
+  ModifyListenerCommand,
+} from '@aws-sdk/client-elastic-load-balancing-v2';
+import { ResourceUpdateNotSupportedError } from '../../../src/utils/error-handler.js';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-elastic-load-balancing-v2', async () => {
+  const actual = await vi.importActual<
+    typeof import('@aws-sdk/client-elastic-load-balancing-v2')
+  >('@aws-sdk/client-elastic-load-balancing-v2');
+  return {
+    ...actual,
+    ElasticLoadBalancingV2Client: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { ELBv2Provider } from '../../../src/provisioning/providers/elbv2-provider.js';
+
+const LB_ARN = 'arn:aws:elasticloadbalancing:us-east-1:0:loadbalancer/app/mylb/abc';
+const TG_ARN = 'arn:aws:elasticloadbalancing:us-east-1:0:targetgroup/mytg/abc';
+const LISTENER_ARN = 'arn:aws:elasticloadbalancing:us-east-1:0:listener/app/mylb/abc/def';
+
+describe('ELBv2Provider read-update round-trip', () => {
+  let provider: ELBv2Provider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ELBv2Provider();
+  });
+
+  // ─── LoadBalancer (immutable update) ──────────────────────────────
+
+  it('LoadBalancer.update rejects with ResourceUpdateNotSupportedError; no spurious AWS calls', async () => {
+    // LB updates are immutable in cdkd — the only safe round-trip
+    // outcome is a clear error, NOT a silent no-op against AWS. The
+    // drift --revert summary surfaces this as "could not revert" (vs
+    // generic "AWS update failed").
+    const observed = {
+      Name: 'mylb',
+      Subnets: ['subnet-a', 'subnet-b'],
+      SecurityGroups: ['sg-1'],
+      Scheme: 'internet-facing',
+      Type: 'application',
+      IpAddressType: 'ipv4',
+      Tags: [],
+    };
+
+    await expect(
+      provider.update('L', LB_ARN, 'AWS::ElasticLoadBalancingV2::LoadBalancer', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    // No AWS calls — the error fires before any send().
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  // ─── TargetGroup ──────────────────────────────────────────────────
+
+  it('Class 2 — TargetGroup TCP no-drift round-trip does NOT push Matcher: {} to ModifyTargetGroup', async () => {
+    // Class 2 mechanical guard. readCurrentState always-emits
+    // `Matcher: {}` so console-side ADD of HttpCode is detectable;
+    // ModifyTargetGroup rejects an empty Matcher with "Matcher must
+    // contain either HttpCode or GrpcCode". The wire layer in
+    // updateTargetGroup must drop the placeholder.
+    const observed = {
+      Name: 'mytg',
+      Protocol: 'TCP',
+      Port: 80,
+      VpcId: 'vpc-1',
+      TargetType: 'instance',
+      HealthCheckProtocol: 'TCP',
+      HealthCheckPort: 'traffic-port',
+      HealthCheckEnabled: true,
+      HealthCheckIntervalSeconds: 30,
+      HealthCheckTimeoutSeconds: 10,
+      HealthyThresholdCount: 5,
+      UnhealthyThresholdCount: 2,
+      // Matcher always-emit placeholder for non-HTTP target groups
+      Matcher: {},
+      Tags: [],
+    };
+
+    // ModifyTargetGroup → DescribeTargetGroups → DescribeTags (no tag diff)
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ TargetGroups: [{ TargetGroupName: 'mytg' }] })
+      .mockResolvedValueOnce({ TagDescriptions: [{ ResourceArn: TG_ARN, Tags: [] }] });
+
+    await provider.update(
+      'L',
+      TG_ARN,
+      'AWS::ElasticLoadBalancingV2::TargetGroup',
+      observed,
+      observed
+    );
+
+    const modifyCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof ModifyTargetGroupCommand
+    );
+    expect(modifyCalls).toHaveLength(1);
+    const input = modifyCalls[0]?.[0].input as { Matcher?: unknown };
+    // The fix: empty-object Matcher is dropped from API input.
+    expect(input.Matcher).toBeUndefined();
+  });
+
+  it('TargetGroup HTTP with non-empty Matcher round-trip preserves Matcher in ModifyTargetGroup', async () => {
+    // Complement to the Class 2 guard: a real Matcher must still flow
+    // through unchanged (only `{}` is the rejection-shape).
+    const observed = {
+      Name: 'mytg',
+      Protocol: 'HTTP',
+      Port: 80,
+      VpcId: 'vpc-1',
+      TargetType: 'instance',
+      HealthCheckProtocol: 'HTTP',
+      HealthCheckPort: 'traffic-port',
+      HealthCheckPath: '/health',
+      HealthCheckEnabled: true,
+      Matcher: { HttpCode: '200' },
+      Tags: [],
+    };
+
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ TargetGroups: [{ TargetGroupName: 'mytg' }] })
+      .mockResolvedValueOnce({ TagDescriptions: [{ ResourceArn: TG_ARN, Tags: [] }] });
+
+    await provider.update(
+      'L',
+      TG_ARN,
+      'AWS::ElasticLoadBalancingV2::TargetGroup',
+      observed,
+      observed
+    );
+
+    const modifyCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof ModifyTargetGroupCommand
+    );
+    expect(modifyCalls).toHaveLength(1);
+    const input = modifyCalls[0]?.[0].input as { Matcher?: { HttpCode?: string } };
+    expect(input.Matcher).toEqual({ HttpCode: '200' });
+  });
+
+  it('Class 1 — TargetGroup TargetType=lambda no-drift round-trip does NOT push HealthCheckPath / Matcher to ModifyTargetGroup', async () => {
+    // Class 1 mechanical guard. Lambda target groups don't carry
+    // HealthCheckPath / Matcher in the AWS-current snapshot
+    // (readCurrentState only emits HealthCheckPath when AWS returned
+    // it). The Matcher placeholder still appears as `{}` and must be
+    // dropped at the wire layer (Class 2 fix subsumes the Class 1
+    // case here).
+    const observed = {
+      Name: 'mytg-lambda',
+      VpcId: 'vpc-1',
+      TargetType: 'lambda',
+      // HealthCheckProtocol is also not standard on lambda targets —
+      // observed snapshot may omit it entirely (readCurrentState only
+      // emits when AWS returned it).
+      HealthCheckEnabled: false,
+      Matcher: {},
+      Tags: [],
+    };
+
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ TargetGroups: [{ TargetGroupName: 'mytg-lambda' }] })
+      .mockResolvedValueOnce({ TagDescriptions: [{ ResourceArn: TG_ARN, Tags: [] }] });
+
+    await provider.update(
+      'L',
+      TG_ARN,
+      'AWS::ElasticLoadBalancingV2::TargetGroup',
+      observed,
+      observed
+    );
+
+    const modifyCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof ModifyTargetGroupCommand
+    );
+    expect(modifyCalls).toHaveLength(1);
+    const input = modifyCalls[0]?.[0].input as {
+      Matcher?: unknown;
+      HealthCheckPath?: unknown;
+    };
+    // Lambda TG has no HealthCheckPath in observed, so it must not be in API input.
+    expect(input.HealthCheckPath).toBeUndefined();
+    // And the empty Matcher placeholder must be dropped.
+    expect(input.Matcher).toBeUndefined();
+  });
+
+  // ─── Listener ─────────────────────────────────────────────────────
+
+  it('Listener HTTPS no-drift round-trip preserves Certificates in ModifyListener', async () => {
+    // HTTPS listener has Certificates legitimately. The round-trip
+    // through ModifyListener must include them (otherwise --revert
+    // would clear the cert on AWS even when state and AWS agree).
+    const observed = {
+      LoadBalancerArn: LB_ARN,
+      Port: 443,
+      Protocol: 'HTTPS',
+      SslPolicy: 'ELBSecurityPolicy-2016-08',
+      Certificates: [{ CertificateArn: 'arn:aws:acm:us-east-1:0:certificate/abc' }],
+      DefaultActions: [
+        { Type: 'forward', TargetGroupArn: TG_ARN },
+      ] as Array<Record<string, unknown>>,
+    };
+
+    mockSend.mockResolvedValueOnce({});
+
+    await provider.update(
+      'L',
+      LISTENER_ARN,
+      'AWS::ElasticLoadBalancingV2::Listener',
+      observed,
+      observed
+    );
+
+    const modifyCalls = mockSend.mock.calls.filter((c) => c[0] instanceof ModifyListenerCommand);
+    expect(modifyCalls).toHaveLength(1);
+    const input = modifyCalls[0]?.[0].input as {
+      Certificates?: Array<{ CertificateArn?: string }>;
+      Protocol?: string;
+      SslPolicy?: string;
+    };
+    expect(input.Certificates).toEqual([
+      { CertificateArn: 'arn:aws:acm:us-east-1:0:certificate/abc' },
+    ]);
+    expect(input.Protocol).toBe('HTTPS');
+    expect(input.SslPolicy).toBe('ELBSecurityPolicy-2016-08');
+  });
+
+  it('Class 1 — Listener HTTP no-drift round-trip does NOT include Certificates in ModifyListener', async () => {
+    // Class 1 mechanical guard. HTTP listeners don't carry
+    // Certificates / SslPolicy on the AWS-current side; readListener
+    // only emits Certificates with the always-emit `[]` placeholder
+    // and SslPolicy not at all. ModifyListener must NOT receive
+    // `Certificates: []` (AWS rejects "Certificates can only be set
+    // on HTTPS / TLS listeners"). The convertCertificates helper
+    // returns undefined on empty input, dropping the key.
+    const observed = {
+      LoadBalancerArn: LB_ARN,
+      Port: 80,
+      Protocol: 'HTTP',
+      // Always-emit placeholder for Certificates
+      Certificates: [] as Array<Record<string, unknown>>,
+      DefaultActions: [
+        { Type: 'forward', TargetGroupArn: TG_ARN },
+      ] as Array<Record<string, unknown>>,
+      // SslPolicy not in observed — readListener gates the emit on
+      // AWS returning it (HTTP listeners get nothing).
+    };
+
+    mockSend.mockResolvedValueOnce({});
+
+    await provider.update(
+      'L',
+      LISTENER_ARN,
+      'AWS::ElasticLoadBalancingV2::Listener',
+      observed,
+      observed
+    );
+
+    const modifyCalls = mockSend.mock.calls.filter((c) => c[0] instanceof ModifyListenerCommand);
+    expect(modifyCalls).toHaveLength(1);
+    const input = modifyCalls[0]?.[0].input as {
+      Certificates?: unknown;
+      SslPolicy?: unknown;
+      Protocol?: string;
+    };
+    expect(input.Certificates).toBeUndefined();
+    expect(input.SslPolicy).toBeUndefined();
+    expect(input.Protocol).toBe('HTTP');
+  });
+
+  // ─── Cross-type sanity check: state == AWS produces no rejection-shape ──
+
+  it('round-trip across resource types produces no AWS-rejection-shaped inputs', async () => {
+    // Aggregate guard: every wire-layer call from a no-drift
+    // round-trip must produce inputs AWS accepts as idempotent.
+    // Specifically:
+    //  - ModifyTargetGroup must not contain Matcher: {} (Class 2)
+    //  - ModifyListener must not contain Certificates: [] (Class 1)
+    const tgObserved = {
+      Name: 'mytg',
+      Protocol: 'TCP',
+      Port: 80,
+      VpcId: 'vpc-1',
+      TargetType: 'instance',
+      HealthCheckProtocol: 'TCP',
+      HealthCheckEnabled: true,
+      Matcher: {},
+      Tags: [],
+    };
+    const listenerObserved = {
+      LoadBalancerArn: LB_ARN,
+      Port: 80,
+      Protocol: 'HTTP',
+      Certificates: [] as Array<Record<string, unknown>>,
+      DefaultActions: [
+        { Type: 'forward', TargetGroupArn: TG_ARN },
+      ] as Array<Record<string, unknown>>,
+    };
+
+    // TG: ModifyTargetGroup → DescribeTargetGroups → DescribeTags
+    mockSend
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ TargetGroups: [{ TargetGroupName: 'mytg' }] })
+      .mockResolvedValueOnce({ TagDescriptions: [{ ResourceArn: TG_ARN, Tags: [] }] });
+    await provider.update(
+      'TG',
+      TG_ARN,
+      'AWS::ElasticLoadBalancingV2::TargetGroup',
+      tgObserved,
+      tgObserved
+    );
+
+    // Listener: ModifyListener
+    mockSend.mockResolvedValueOnce({});
+    await provider.update(
+      'LST',
+      LISTENER_ARN,
+      'AWS::ElasticLoadBalancingV2::Listener',
+      listenerObserved,
+      listenerObserved
+    );
+
+    const modifyTGCall = mockSend.mock.calls.find((c) => c[0] instanceof ModifyTargetGroupCommand);
+    const modifyListenerCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof ModifyListenerCommand
+    );
+
+    const tgInput = modifyTGCall?.[0].input as { Matcher?: unknown };
+    expect(tgInput.Matcher).toBeUndefined();
+
+    const listenerInput = modifyListenerCall?.[0].input as { Certificates?: unknown };
+    expect(listenerInput.Certificates).toBeUndefined();
+  });
+});

--- a/tests/unit/provisioning/providers/ec2-provider.test.ts
+++ b/tests/unit/provisioning/providers/ec2-provider.test.ts
@@ -846,16 +846,19 @@ describe('EC2Provider - NatGateway', () => {
   });
 
   describe('updateNatGateway', () => {
-    it('is a no-op (NAT gateway has no in-place mutable properties)', async () => {
-      const result = await provider.update(
-        'Nat',
-        'nat-12345',
-        'AWS::EC2::NatGateway',
-        { SubnetId: 'subnet-abc' },
-        { SubnetId: 'subnet-abc' }
-      );
-
-      expect(result).toEqual({ physicalId: 'nat-12345', wasReplaced: false });
+    it('rejects with ResourceUpdateNotSupportedError (every readable property is immutable)', async () => {
+      // Pre-PR (PR I follow-up for EC2): a silent no-op stub. That made
+      // `cdkd drift --revert` report `✓ reverted` on a console-side
+      // change that AWS would actually keep. Reject loudly instead.
+      await expect(
+        provider.update(
+          'Nat',
+          'nat-12345',
+          'AWS::EC2::NatGateway',
+          { SubnetId: 'subnet-abc' },
+          { SubnetId: 'subnet-abc' }
+        )
+      ).rejects.toMatchObject({ code: 'RESOURCE_UPDATE_NOT_SUPPORTED' });
       expect(mockSend).not.toHaveBeenCalled();
     });
   });

--- a/tests/unit/provisioning/route53-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/route53-provider-readcurrentstate.test.ts
@@ -168,11 +168,16 @@ describe('Route53Provider.readCurrentState', () => {
         'AWS::Route53::RecordSet'
       );
 
+      // Class 1 gate: alias records do NOT carry TTL / ResourceRecords
+      // placeholders in the observed snapshot — those fields are
+      // mutually exclusive with AliasTarget per AWS, so emitting `[]`
+      // would (a) fire false drift against state that never had the
+      // key and (b) round-trip into a structurally-invalid
+      // ChangeResourceRecordSets input.
       expect(result).toEqual({
         HostedZoneId: 'Z1',
         Name: 'alias.example.com.',
         Type: 'A',
-        ResourceRecords: [],
         AliasTarget: {
           HostedZoneId: 'Z2',
           DNSName: 'lb-1.us-east-1.elb.amazonaws.com.',

--- a/tests/unit/provisioning/route53-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/route53-provider-roundtrip.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ChangeResourceRecordSetsCommand,
+  UpdateHostedZoneCommentCommand,
+} from '@aws-sdk/client-route-53';
+
+// Mechanical guard for the 3 latent bug classes (Class 1 / Class 2 /
+// truthy gate) that surface only on `cdkd drift --revert` round-trips
+// through `provider.update()`. See docs/provider-development.md § 3b
+// "Read-update round-trip test" and the canonical SQS / SNS tests.
+//
+// The shape of the round-trip is:
+//   1. Build an `observed` snapshot the same way `readCurrentState`
+//      would produce it (we exercise readCurrentState via mocks here so
+//      the snapshot is the actual provider output, not a hand-crafted
+//      stand-in).
+//   2. Pass that snapshot back through `update()` as both `new` and
+//      `old` (state == AWS-current).
+//   3. Assert no AWS-side mutation rejects on the round-trip:
+//      - HostedZone: UpdateHostedZoneComment may fire (it is
+//        idempotent) but no AssociateVPCWithHostedZone / Disassociate
+//        on a public zone.
+//      - RecordSet: ChangeResourceRecordSets must NOT carry both
+//        AliasTarget AND ResourceRecords (AWS rejects).
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-route-53', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-route-53')>(
+    '@aws-sdk/client-route-53'
+  );
+  return {
+    ...actual,
+    Route53Client: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { Route53Provider } from '../../../src/provisioning/providers/route53-provider.js';
+
+describe('Route53Provider read-update round-trip', () => {
+  let provider: Route53Provider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new Route53Provider();
+  });
+
+  // ─── HostedZone ──────────────────────────────────────────────────
+
+  it('public HostedZone: round-trip does not emit a VPCs placeholder', async () => {
+    // Class 1 guard: VPCs is private-zone-only. On a public zone
+    // readCurrentState must NOT carry `VPCs: []`, otherwise the
+    // observedProperties baseline fires false drift against state
+    // (which doesn't have the key on public zones) AND the round-trip
+    // would attempt to re-associate VPCs the zone never had.
+    mockSend
+      .mockResolvedValueOnce({
+        HostedZone: {
+          Id: '/hostedzone/Z1',
+          Name: 'example.com.',
+          Config: { Comment: 'public', PrivateZone: false },
+        },
+        VPCs: [],
+      })
+      .mockResolvedValueOnce({ ResourceTagSet: { ResourceId: 'Z1', Tags: [] } });
+
+    const observed = await provider.readCurrentState('Z1', 'L', 'AWS::Route53::HostedZone');
+
+    expect(observed).toBeDefined();
+    expect(observed).not.toHaveProperty('VPCs');
+    expect(observed?.['HostedZoneTags']).toEqual([]);
+
+    // Now round-trip the snapshot through update().
+    mockSend.mockReset();
+    // update() walks: UpdateHostedZoneComment, ChangeTagsForResource
+    // (skipped — empty tag array), CreateQueryLoggingConfig (skipped —
+    // no QueryLoggingConfig in snapshot), syncVPCAssociations (early-
+    // returns when desiredVpcs is empty/undefined), GetHostedZone for
+    // NameServers.
+    mockSend
+      .mockResolvedValueOnce({}) // UpdateHostedZoneComment
+      .mockResolvedValueOnce({
+        HostedZone: { Id: '/hostedzone/Z1', Name: 'example.com.' },
+        DelegationSet: { NameServers: ['ns-1.example.com'] },
+      });
+
+    await provider.update(
+      'L',
+      'Z1',
+      'AWS::Route53::HostedZone',
+      observed as Record<string, unknown>,
+      observed as Record<string, unknown>
+    );
+
+    // No AssociateVPCWithHostedZone / Disassociate calls on a public
+    // zone — the absent-VPCs gate must hold through the round-trip.
+    const associateCalls = mockSend.mock.calls.filter((c) => {
+      const name = c[0]?.constructor?.name as string | undefined;
+      return name === 'AssociateVPCWithHostedZoneCommand' ||
+        name === 'DisassociateVPCFromHostedZoneCommand';
+    });
+    expect(associateCalls).toHaveLength(0);
+  });
+
+  it('private HostedZone: round-trip preserves VPCs and triggers no Associate/Disassociate', async () => {
+    // Complement of the public-zone test: a private zone legitimately
+    // has VPCs and the snapshot must surface them. The round-trip
+    // through update()'s syncVPCAssociations must be a logical no-op
+    // (state == AWS, so neither add nor remove).
+    mockSend
+      .mockResolvedValueOnce({
+        HostedZone: {
+          Id: '/hostedzone/Z2',
+          Name: 'internal.example.com.',
+          Config: { Comment: 'private', PrivateZone: true },
+        },
+        VPCs: [
+          { VPCId: 'vpc-aaa', VPCRegion: 'us-east-1' },
+          { VPCId: 'vpc-bbb', VPCRegion: 'us-west-2' },
+        ],
+      })
+      .mockResolvedValueOnce({ ResourceTagSet: { ResourceId: 'Z2', Tags: [] } });
+
+    const observed = await provider.readCurrentState('Z2', 'L', 'AWS::Route53::HostedZone');
+
+    expect(observed?.['VPCs']).toEqual([
+      { VPCId: 'vpc-aaa', VPCRegion: 'us-east-1' },
+      { VPCId: 'vpc-bbb', VPCRegion: 'us-west-2' },
+    ]);
+
+    // Round-trip through update(): syncVPCAssociations re-fetches
+    // current VPCs and diffs against desired.
+    mockSend.mockReset();
+    mockSend
+      .mockResolvedValueOnce({}) // UpdateHostedZoneComment
+      .mockResolvedValueOnce({
+        // GetHostedZone inside syncVPCAssociations
+        HostedZone: { Id: '/hostedzone/Z2', Name: 'internal.example.com.' },
+        VPCs: [
+          { VPCId: 'vpc-aaa', VPCRegion: 'us-east-1' },
+          { VPCId: 'vpc-bbb', VPCRegion: 'us-west-2' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        // GetHostedZone for NameServers
+        HostedZone: { Id: '/hostedzone/Z2', Name: 'internal.example.com.' },
+        DelegationSet: { NameServers: ['ns-3.example.com'] },
+      });
+
+    await provider.update(
+      'L',
+      'Z2',
+      'AWS::Route53::HostedZone',
+      observed as Record<string, unknown>,
+      observed as Record<string, unknown>
+    );
+
+    const associateCalls = mockSend.mock.calls.filter((c) => {
+      const name = c[0]?.constructor?.name as string | undefined;
+      return name === 'AssociateVPCWithHostedZoneCommand' ||
+        name === 'DisassociateVPCFromHostedZoneCommand';
+    });
+    expect(associateCalls).toHaveLength(0);
+  });
+
+  // ─── RecordSet ───────────────────────────────────────────────────
+
+  it('A-record (TTL + ResourceRecords): round-trip ChangeResourceRecordSets has TTL/ResourceRecords and no AliasTarget', async () => {
+    mockSend.mockResolvedValueOnce({
+      ResourceRecordSets: [
+        {
+          Name: 'a.example.com.',
+          Type: 'A',
+          TTL: 300,
+          ResourceRecords: [{ Value: '1.2.3.4' }, { Value: '5.6.7.8' }],
+        },
+      ],
+    });
+
+    const observed = await provider.readCurrentState(
+      'Z1|a.example.com.|A',
+      'L',
+      'AWS::Route53::RecordSet'
+    );
+    expect(observed).toEqual({
+      HostedZoneId: 'Z1',
+      Name: 'a.example.com.',
+      Type: 'A',
+      TTL: 300,
+      ResourceRecords: ['1.2.3.4', '5.6.7.8'],
+    });
+
+    mockSend.mockReset();
+    mockSend.mockResolvedValueOnce({}); // ChangeResourceRecordSets
+
+    await provider.update(
+      'L',
+      'Z1|a.example.com.|A',
+      'AWS::Route53::RecordSet',
+      observed as Record<string, unknown>,
+      observed as Record<string, unknown>
+    );
+
+    const changeCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof ChangeResourceRecordSetsCommand
+    );
+    expect(changeCalls).toHaveLength(1);
+
+    const input = (
+      changeCalls[0]![0] as ChangeResourceRecordSetsCommand
+    ).input as {
+      ChangeBatch: { Changes: Array<{ Action: string; ResourceRecordSet: any }> };
+    };
+    const rrs = input.ChangeBatch.Changes[0]!.ResourceRecordSet;
+    expect(rrs.Name).toBe('a.example.com.');
+    expect(rrs.Type).toBe('A');
+    expect(rrs.TTL).toBe(300);
+    expect(rrs.ResourceRecords).toEqual([
+      { Value: '1.2.3.4' },
+      { Value: '5.6.7.8' },
+    ]);
+    // Critically: AliasTarget must be absent for a standard record.
+    expect(rrs.AliasTarget).toBeUndefined();
+  });
+
+  it('alias record: round-trip ChangeResourceRecordSets has AliasTarget and NEITHER TTL NOR ResourceRecords', async () => {
+    // Class 1 guard: TTL / ResourceRecords are mutually exclusive with
+    // AliasTarget per AWS. If readCurrentState carried `[]` /
+    // placeholder TTL on an alias record, the round-trip update would
+    // reject with `InvalidChangeBatch: Tried to create an alias that
+    // targets ... but the alias is not allowed to have a TTL / RRs`.
+    mockSend.mockResolvedValueOnce({
+      ResourceRecordSets: [
+        {
+          Name: 'alias.example.com.',
+          Type: 'A',
+          AliasTarget: {
+            HostedZoneId: 'Z2',
+            DNSName: 'lb-1.us-east-1.elb.amazonaws.com.',
+            EvaluateTargetHealth: false,
+          },
+        },
+      ],
+    });
+
+    const observed = await provider.readCurrentState(
+      'Z1|alias.example.com.|A',
+      'L',
+      'AWS::Route53::RecordSet'
+    );
+    expect(observed).toEqual({
+      HostedZoneId: 'Z1',
+      Name: 'alias.example.com.',
+      Type: 'A',
+      AliasTarget: {
+        HostedZoneId: 'Z2',
+        DNSName: 'lb-1.us-east-1.elb.amazonaws.com.',
+        EvaluateTargetHealth: false,
+      },
+    });
+    // Class 1: alias snapshot does NOT carry TTL / ResourceRecords.
+    expect(observed).not.toHaveProperty('TTL');
+    expect(observed).not.toHaveProperty('ResourceRecords');
+
+    mockSend.mockReset();
+    mockSend.mockResolvedValueOnce({}); // ChangeResourceRecordSets
+
+    await provider.update(
+      'L',
+      'Z1|alias.example.com.|A',
+      'AWS::Route53::RecordSet',
+      observed as Record<string, unknown>,
+      observed as Record<string, unknown>
+    );
+
+    const changeCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof ChangeResourceRecordSetsCommand
+    );
+    expect(changeCalls).toHaveLength(1);
+
+    const input = (
+      changeCalls[0]![0] as ChangeResourceRecordSetsCommand
+    ).input as {
+      ChangeBatch: { Changes: Array<{ Action: string; ResourceRecordSet: any }> };
+    };
+    const rrs = input.ChangeBatch.Changes[0]!.ResourceRecordSet;
+    expect(rrs.AliasTarget).toEqual({
+      HostedZoneId: 'Z2',
+      DNSName: 'lb-1.us-east-1.elb.amazonaws.com.',
+      EvaluateTargetHealth: false,
+    });
+    // Critically: TTL and ResourceRecords must be absent — AWS rejects
+    // alias records that carry either field.
+    expect(rrs.TTL).toBeUndefined();
+    expect(rrs.ResourceRecords).toBeUndefined();
+  });
+
+  it('round-trip on a no-drift snapshot makes only the idempotent UPSERT-shape calls', async () => {
+    // Stronger structural assertion: on state == AWS, round-trip
+    // should make at most one UPSERT (or zero if the provider becomes
+    // diff-based). It must NEVER make a CREATE or DELETE — those are
+    // the failure modes the placeholder-driven false drift would
+    // produce.
+    mockSend.mockResolvedValueOnce({
+      ResourceRecordSets: [
+        {
+          Name: 'a.example.com.',
+          Type: 'A',
+          TTL: 300,
+          ResourceRecords: [{ Value: '1.2.3.4' }],
+        },
+      ],
+    });
+
+    const observed = await provider.readCurrentState(
+      'Z1|a.example.com.|A',
+      'L',
+      'AWS::Route53::RecordSet'
+    );
+
+    mockSend.mockReset();
+    mockSend.mockResolvedValueOnce({});
+
+    await provider.update(
+      'L',
+      'Z1|a.example.com.|A',
+      'AWS::Route53::RecordSet',
+      observed as Record<string, unknown>,
+      observed as Record<string, unknown>
+    );
+
+    const changeCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof ChangeResourceRecordSetsCommand
+    );
+    for (const call of changeCalls) {
+      const input = (call[0] as ChangeResourceRecordSetsCommand).input as {
+        ChangeBatch: { Changes: Array<{ Action: string }> };
+      };
+      for (const change of input.ChangeBatch.Changes) {
+        // CREATE/DELETE on a no-drift round-trip is the bug we're
+        // guarding against.
+        expect(change.Action).toBe('UPSERT');
+      }
+    }
+  });
+
+  it('weighted record (Weight=0): round-trip preserves the falsy weight (truthy-gate guard)', async () => {
+    // Truthy-gate guard: `if (weight)` would silently drop a weighted
+    // record with Weight=0 (a valid AWS configuration meaning "this
+    // record is never returned"). The fix is `!== undefined`.
+    mockSend.mockResolvedValueOnce({
+      ResourceRecordSets: [
+        {
+          Name: 'w.example.com.',
+          Type: 'A',
+          TTL: 60,
+          ResourceRecords: [{ Value: '10.0.0.1' }],
+          SetIdentifier: 'primary',
+          Weight: 0,
+        },
+      ],
+    });
+
+    const observed = await provider.readCurrentState(
+      'Z1|w.example.com.|A',
+      'L',
+      'AWS::Route53::RecordSet'
+    );
+    expect(observed?.['Weight']).toBe(0);
+    expect(observed?.['SetIdentifier']).toBe('primary');
+
+    mockSend.mockReset();
+    mockSend.mockResolvedValueOnce({});
+
+    await provider.update(
+      'L',
+      'Z1|w.example.com.|A',
+      'AWS::Route53::RecordSet',
+      observed as Record<string, unknown>,
+      observed as Record<string, unknown>
+    );
+
+    const changeCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof ChangeResourceRecordSetsCommand
+    );
+    expect(changeCalls).toHaveLength(1);
+    const input = (
+      changeCalls[0]![0] as ChangeResourceRecordSetsCommand
+    ).input as {
+      ChangeBatch: { Changes: Array<{ ResourceRecordSet: any }> };
+    };
+    const rrs = input.ChangeBatch.Changes[0]!.ResourceRecordSet;
+    // Weight=0 must survive the round-trip — silently dropping it
+    // would change the routing behavior on `cdkd drift --revert`.
+    expect(rrs.Weight).toBe(0);
+    expect(rrs.SetIdentifier).toBe('primary');
+  });
+
+  // Sanity check that the HostedZone path still issues the comment
+  // update (the only mutating call we expect on a no-drift round-trip
+  // for HostedZone — it is idempotent).
+  it('public HostedZone round-trip issues UpdateHostedZoneComment exactly once', async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        HostedZone: {
+          Id: '/hostedzone/Z1',
+          Name: 'example.com.',
+          Config: { Comment: 'public', PrivateZone: false },
+        },
+        VPCs: [],
+      })
+      .mockResolvedValueOnce({ ResourceTagSet: { ResourceId: 'Z1', Tags: [] } });
+
+    const observed = await provider.readCurrentState('Z1', 'L', 'AWS::Route53::HostedZone');
+
+    mockSend.mockReset();
+    mockSend
+      .mockResolvedValueOnce({}) // UpdateHostedZoneComment
+      .mockResolvedValueOnce({
+        HostedZone: { Id: '/hostedzone/Z1', Name: 'example.com.' },
+        DelegationSet: { NameServers: ['ns-1.example.com'] },
+      });
+
+    await provider.update(
+      'L',
+      'Z1',
+      'AWS::Route53::HostedZone',
+      observed as Record<string, unknown>,
+      observed as Record<string, unknown>
+    );
+
+    const commentCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateHostedZoneCommentCommand
+    );
+    expect(commentCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

PR 3/5 of the post-#162 provider round-trip audit. Audits the 5 network providers and adds round-trip property tests.

| Provider | Class 1 fix | Class 2 fix | Truthy gate fix | Round-trip tests |
|---|---|---|---|---|
| `EC2Provider` (multi-resource) | — | — | — | **19** + structural fix: 9 immutable types switched from silent-no-op to `ResourceUpdateNotSupportedError`; VPC DNS attrs diff-based; Route / SecurityGroupIngress short-circuit on no-drift |
| `CloudFrontDistributionProvider` | N/A (no `readCurrentState` — falls back to CC API) | N/A | N/A | 0 (out of scope for the 3 read-update bug classes) |
| `CloudFrontOAIProvider` | — | — | — (truthy on `Comment: ''` correctly handled) | 3 + `getDriftUnknownPaths('CloudFrontOriginAccessIdentityConfig.CallerReference')` (would have fired guaranteed-false-positive drift on every clean run) |
| `Route53Provider` | **2** (`VPCs` private-zone-only; `TTL` / `ResourceRecords` not on alias records) | — | **6** (`Weight=0` and 5 defense-in-depth in `buildResourceRecordSet`) | 7 |
| `ELBv2Provider` | 1 | **1** (TargetGroup `Matcher: {}` Class 1+2 combined — included only when `HttpCode` or `GrpcCode` set; AWS rejected the empty placeholder for non-HTTP TGs with "Matcher must contain either HttpCode or GrpcCode") | — | 7 |

### Highlights

- **EC2 silent-fail bug**: `Subnet.update()` was a silent no-op stub despite `readCurrentState` correctly emitting the mutable `MapPublicIpOnLaunch` field. Same silent-fail mode as the IAM Role Description bug (#161) — `cdkd drift --revert` would report `✓ reverted` while AWS kept the change. 9 immutable EC2 types now reject up front with `ResourceUpdateNotSupportedError`. Real bug found, real bug fixed.
- **CloudFront OAI false-positive drift**: `CallerReference` is in state but unreadable from AWS. Added to `getDriftUnknownPaths` so it stops firing on every clean run.
- **ELBv2 TargetGroup `Matcher: {}`**: classic Class 1+2 combined — the empty-object placeholder for non-HTTP TGs (Lambda / TCP / UDP / GENEVE) was leaking into `ModifyTargetGroup` via a `&&` truthy spread (`{}` is truthy in JS). Now only included when `HttpCode` or `GrpcCode` is set.

## Test plan

- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` clean
- [x] `npx vitest --run` — 1778 tests pass (was 1742; **36 new round-trip tests**)
- [x] `/run-integ ec2-vpc` — deploy 20/20 in 28s, destroy 20/20 / 0 errors / 0 orphans

## Out of scope

PRs 4-5 will cover the remaining ~13 providers (compute/API, tail).
