### PR TITLE
fix(drift): round-trip audit for compute/API providers (PR 4/5)

### DIFF
--- a/src/provisioning/providers/apigateway-provider.ts
+++ b/src/provisioning/providers/apigateway-provider.ts
@@ -361,15 +361,25 @@ export class ApiGatewayProvider implements ResourceProvider {
     logicalId: string,
     _resourceType: string
   ): Promise<void> {
-    const patchOperations = cloudWatchRoleArn
-      ? [
-          {
-            op: 'replace' as const,
-            path: '/cloudwatchRoleArn',
-            value: cloudWatchRoleArn,
-          },
-        ]
-      : [];
+    // Use `!== undefined` rather than a truthy gate so that an explicit
+    // empty string `''` (the cdkd-state representation of "no
+    // CloudWatchRole configured", produced by readCurrentStateAccount
+    // and by deleteAccount) reaches AWS as a legitimate
+    // `replace /cloudwatchRoleArn ''` patch operation. A truthy gate
+    // would silently drop `''` and produce an empty patchOperations
+    // list, so `cdkd drift --revert` would succeed with no actual
+    // AWS-side change and the very next `cdkd drift` would re-detect
+    // the same drift — a silent fail mode.
+    const patchOperations =
+      cloudWatchRoleArn !== undefined
+        ? [
+            {
+              op: 'replace' as const,
+              path: '/cloudwatchRoleArn',
+              value: cloudWatchRoleArn,
+            },
+          ]
+        : [];
 
     for (let attempt = 1; attempt <= ApiGatewayProvider.MAX_IAM_RETRIES; attempt++) {
       try {
@@ -1525,7 +1535,23 @@ export class ApiGatewayProvider implements ResourceProvider {
       if (resp.authorizationType !== undefined) {
         result['AuthorizationType'] = resp.authorizationType;
       }
-      result['AuthorizerId'] = resp.authorizerId ?? '';
+      // Class 1 (type-discriminator-dependent fields, see
+      // docs/provider-development.md § 3b). AuthorizerId is only valid
+      // when AuthorizationType is CUSTOM or COGNITO_USER_POOLS — AWS
+      // rejects PutMethod with "Invalid authorizer ID specified" or
+      // "Authorizer not found" when sent on AuthorizationType=NONE /
+      // AWS_IAM. Emitting `''` as a placeholder on a NONE method would
+      // make `cdkd drift --revert`'s round-trip push that empty value
+      // back, but Method.update currently throws
+      // ResourceUpdateNotSupportedError so the AWS-rejection path
+      // doesn't fire today; this gate is the structural defense for
+      // when Method.update gains a real implementation. Drift
+      // detection is not lost: a NONE method cannot legally have
+      // AuthorizerId on AWS, so a console-side ADD is impossible.
+      const authType = resp.authorizationType;
+      if (authType === 'CUSTOM' || authType === 'COGNITO_USER_POOLS') {
+        result['AuthorizerId'] = resp.authorizerId ?? '';
+      }
       result['Integration'] = resp.methodIntegration ?? {};
       result['MethodResponses'] = resp.methodResponses ?? {};
       return result;

--- a/src/provisioning/providers/apigatewayv2-provider.ts
+++ b/src/provisioning/providers/apigatewayv2-provider.ts
@@ -775,7 +775,25 @@ export class ApiGatewayV2Provider implements ResourceProvider {
       result['Name'] = resp.Name ?? '';
       if (resp.ProtocolType !== undefined) result['ProtocolType'] = resp.ProtocolType;
       result['Description'] = resp.Description ?? '';
-      result['CorsConfiguration'] = resp.CorsConfiguration ?? {};
+
+      // Class 1 — CorsConfiguration is HTTP-only. Emitting `{}` as a
+      // placeholder on a WEBSOCKET API would have `cdkd drift --revert`
+      // push the empty value back to AWS, which `UpdateApi` rejects with
+      // "CORS configuration is only supported for HTTP APIs".
+      // Same pattern as the SNS FifoThroughputScope guard.
+      if (resp.ProtocolType === 'HTTP') {
+        result['CorsConfiguration'] = resp.CorsConfiguration ?? {};
+      }
+
+      // Class 1 — RouteSelectionExpression is required (and meaningful)
+      // only for WEBSOCKET. HTTP APIs default it to `$request.method
+      // $request.path` server-side and the field is not user-controlled,
+      // so emitting it on HTTP APIs would surface AWS-managed defaults
+      // as drift.
+      if (resp.ProtocolType === 'WEBSOCKET' && resp.RouteSelectionExpression !== undefined) {
+        result['RouteSelectionExpression'] = resp.RouteSelectionExpression;
+      }
+
       // Tags from the same GetApi response (returned as a tag-name → value map).
       const tags = normalizeAwsTagsToCfn(resp.Tags);
       result['Tags'] = tags;
@@ -821,7 +839,20 @@ export class ApiGatewayV2Provider implements ResourceProvider {
       );
       const result: Record<string, unknown> = { ApiId: apiId };
       if (resp.IntegrationType !== undefined) result['IntegrationType'] = resp.IntegrationType;
-      result['IntegrationUri'] = resp.IntegrationUri ?? '';
+
+      // Class 1 — IntegrationUri is meaningless on MOCK integrations.
+      // AWS rejects an empty-string placeholder on MOCK with "Integration
+      // URI is not supported for MOCK integrations". Only emit when the
+      // discriminator (IntegrationType) requires a URI.
+      const uriRequired =
+        resp.IntegrationType === 'AWS' ||
+        resp.IntegrationType === 'AWS_PROXY' ||
+        resp.IntegrationType === 'HTTP' ||
+        resp.IntegrationType === 'HTTP_PROXY';
+      if (uriRequired) {
+        result['IntegrationUri'] = resp.IntegrationUri ?? '';
+      }
+
       result['IntegrationMethod'] = resp.IntegrationMethod ?? '';
       result['PayloadFormatVersion'] = resp.PayloadFormatVersion ?? '';
       return result;
@@ -845,8 +876,23 @@ export class ApiGatewayV2Provider implements ResourceProvider {
       const result: Record<string, unknown> = { ApiId: apiId };
       if (resp.RouteKey !== undefined) result['RouteKey'] = resp.RouteKey;
       result['Target'] = resp.Target ?? '';
-      result['AuthorizationType'] = resp.AuthorizationType ?? '';
-      result['AuthorizerId'] = resp.AuthorizerId ?? '';
+
+      // Class 2 — AuthorizationType empty placeholder. AWS uses `'NONE'`
+      // (not `''`) as the no-auth sentinel; emitting `''` would have
+      // `cdkd drift --revert` push an AWS-rejected value back. Map the
+      // missing case to `'NONE'`, matching the AWS-documented default.
+      result['AuthorizationType'] = resp.AuthorizationType ?? 'NONE';
+
+      // Class 1 — AuthorizerId and AuthorizationScopes are meaningful
+      // only when AuthorizationType is not NONE. Emitting empty
+      // placeholders on a no-auth route would push AWS-rejected values
+      // back through `--revert`.
+      if (resp.AuthorizationType && resp.AuthorizationType !== 'NONE') {
+        result['AuthorizerId'] = resp.AuthorizerId ?? '';
+        result['AuthorizationScopes'] = resp.AuthorizationScopes
+          ? [...resp.AuthorizationScopes]
+          : [];
+      }
       return result;
     } catch (err) {
       if (err instanceof NotFoundException) return undefined;
@@ -869,9 +915,22 @@ export class ApiGatewayV2Provider implements ResourceProvider {
       if (resp.AuthorizerType !== undefined) result['AuthorizerType'] = resp.AuthorizerType;
       result['Name'] = resp.Name ?? '';
       result['IdentitySource'] = resp.IdentitySource ? [...resp.IdentitySource] : [];
-      result['JwtConfiguration'] = resp.JwtConfiguration ?? {};
-      result['AuthorizerUri'] = resp.AuthorizerUri ?? '';
-      result['AuthorizerPayloadFormatVersion'] = resp.AuthorizerPayloadFormatVersion ?? '';
+
+      // Class 1 — JwtConfiguration / AuthorizerUri / AuthorizerPayloadFormatVersion
+      // are AuthorizerType-discriminated. JwtConfiguration is JWT-only;
+      // AuthorizerUri / AuthorizerPayloadFormatVersion are REQUEST-only.
+      // Emitting placeholders on the wrong type would have
+      // `cdkd drift --revert` push AWS-rejected values back through
+      // `UpdateAuthorizer` ("JwtConfiguration is only valid for JWT
+      // authorizers" / "AuthorizerUri is only valid for REQUEST
+      // authorizers"). Same pattern as the SNS FifoThroughputScope
+      // guard.
+      if (resp.AuthorizerType === 'JWT') {
+        result['JwtConfiguration'] = resp.JwtConfiguration ?? {};
+      } else if (resp.AuthorizerType === 'REQUEST') {
+        result['AuthorizerUri'] = resp.AuthorizerUri ?? '';
+        result['AuthorizerPayloadFormatVersion'] = resp.AuthorizerPayloadFormatVersion ?? '';
+      }
       return result;
     } catch (err) {
       if (err instanceof NotFoundException) return undefined;

--- a/src/provisioning/providers/appsync-provider.ts
+++ b/src/provisioning/providers/appsync-provider.ts
@@ -809,8 +809,17 @@ export class AppSyncProvider implements ResourceProvider {
     const result: Record<string, unknown> = { ApiId: apiId };
     if (ds.name !== undefined) result['Name'] = ds.name;
     if (ds.type !== undefined) result['Type'] = ds.type;
+    // Description is optional; emit '' as placeholder so a console-side
+    // Description add surfaces as drift on the v2-fallback path. Empty
+    // string is a valid AWS input for Description.
     result['Description'] = ds.description ?? '';
-    result['ServiceRoleArn'] = ds.serviceRoleArn ?? '';
+    // ServiceRoleArn must be a valid IAM ARN when present. Don't emit a
+    // '' placeholder — the round-trip would try to push an empty string
+    // back to AWS, which fails ARN format validation. Class 2: only
+    // emit when AWS reports a real value.
+    if (ds.serviceRoleArn !== undefined && ds.serviceRoleArn !== '') {
+      result['ServiceRoleArn'] = ds.serviceRoleArn;
+    }
     // DataSource has type-tagged sub-configs (DynamoDBConfig / LambdaConfig /
     // HttpConfig / etc.) that are mutually exclusive based on `Type`. Only
     // emit the matching shape when its discriminator is non-empty so the
@@ -857,22 +866,47 @@ export class AppSyncProvider implements ResourceProvider {
     const result: Record<string, unknown> = { ApiId: apiId };
     if (resolver.typeName !== undefined) result['TypeName'] = resolver.typeName;
     if (resolver.fieldName !== undefined) result['FieldName'] = resolver.fieldName;
-    result['DataSourceName'] = resolver.dataSourceName ?? '';
-    result['RequestMappingTemplate'] = resolver.requestMappingTemplate ?? '';
-    result['ResponseMappingTemplate'] = resolver.responseMappingTemplate ?? '';
     if (resolver.kind !== undefined) result['Kind'] = resolver.kind;
-    result['PipelineConfig'] = {
-      Functions: resolver.pipelineConfig?.functions ? [...resolver.pipelineConfig.functions] : [],
-    };
-    {
-      const runtime: Record<string, unknown> = {};
-      if (resolver.runtime?.name !== undefined) runtime['Name'] = resolver.runtime.name;
-      if (resolver.runtime?.runtimeVersion !== undefined) {
+
+    // Resolver shape is type-discriminator-tagged on `Kind`:
+    //   - Kind=UNIT     → DataSourceName is required, PipelineConfig is N/A
+    //   - Kind=PIPELINE → PipelineConfig.Functions is required, DataSourceName is N/A
+    // AWS rejects `CreateResolver` / `UpdateResolver` when these are
+    // crossed (e.g. PipelineConfig on a UNIT resolver, DataSourceName on
+    // a PIPELINE resolver). Class 1: gate on the discriminator.
+    const kind = resolver.kind ?? 'UNIT';
+    if (kind === 'PIPELINE') {
+      result['PipelineConfig'] = {
+        Functions: resolver.pipelineConfig?.functions ? [...resolver.pipelineConfig.functions] : [],
+      };
+    } else {
+      // UNIT (or unspecified — AWS defaults to UNIT)
+      if (resolver.dataSourceName !== undefined && resolver.dataSourceName !== '') {
+        result['DataSourceName'] = resolver.dataSourceName;
+      }
+    }
+
+    // VTL vs JS resolver shape is discriminated by the presence of `runtime`
+    // on the AWS response:
+    //   - VTL → RequestMappingTemplate / ResponseMappingTemplate (strings)
+    //   - JS  → Code (string) + Runtime ({ Name, RuntimeVersion })
+    // AWS rejects mixing the two. Class 1: gate on whether `runtime` is
+    // returned by AWS.
+    if (resolver.runtime?.name) {
+      // JS resolver — emit Code + Runtime; do NOT emit VTL templates.
+      result['Code'] = resolver.code ?? '';
+      const runtime: Record<string, unknown> = { Name: resolver.runtime.name };
+      if (resolver.runtime.runtimeVersion !== undefined) {
         runtime['RuntimeVersion'] = resolver.runtime.runtimeVersion;
       }
       result['Runtime'] = runtime;
+    } else {
+      // VTL resolver — emit Request/ResponseMappingTemplate placeholders so
+      // a console-side template change surfaces as drift; do NOT emit Code
+      // / Runtime (they'd be rejected as invalid for a VTL resolver).
+      result['RequestMappingTemplate'] = resolver.requestMappingTemplate ?? '';
+      result['ResponseMappingTemplate'] = resolver.responseMappingTemplate ?? '';
     }
-    result['Code'] = resolver.code ?? '';
     return result;
   }
 

--- a/src/provisioning/providers/ecr-provider.ts
+++ b/src/provisioning/providers/ecr-provider.ts
@@ -1,7 +1,9 @@
 import {
   ECRClient,
   CreateRepositoryCommand,
+  DeleteLifecyclePolicyCommand,
   DeleteRepositoryCommand,
+  DeleteRepositoryPolicyCommand,
   DescribeRepositoriesCommand,
   GetLifecyclePolicyCommand,
   PutLifecyclePolicyCommand,
@@ -222,7 +224,15 @@ export class ECRProvider implements ResourceProvider {
         this.logger.debug(`Updated image tag mutability for ${physicalId}`);
       }
 
-      // Update LifecyclePolicy if changed
+      // Update LifecyclePolicy if changed.
+      //
+      // The truthy gate `newLifecycle?.LifecyclePolicyText` covers both
+      // (a) the no-policy state (`undefined`) and (b) the placeholder
+      // shape `{}`/`{ LifecyclePolicyText: '' }`. When the diff is
+      // "old=Set / new=Cleared", we explicitly issue
+      // `DeleteLifecyclePolicy` instead of silently dropping the change
+      // — otherwise `cdkd drift --revert` reports `✓ reverted` while AWS
+      // still has the old policy attached.
       const newLifecycle = properties['LifecyclePolicy'] as
         | { LifecyclePolicyText?: string }
         | undefined;
@@ -238,21 +248,48 @@ export class ECRProvider implements ResourceProvider {
             })
           );
           this.logger.debug(`Updated lifecycle policy for ${physicalId}`);
+        } else if (oldLifecycle?.LifecyclePolicyText) {
+          try {
+            await this.getClient().send(
+              new DeleteLifecyclePolicyCommand({ repositoryName: physicalId })
+            );
+            this.logger.debug(`Deleted lifecycle policy for ${physicalId}`);
+          } catch (err) {
+            if (!(err instanceof LifecyclePolicyNotFoundException)) throw err;
+          }
         }
       }
 
-      // Update RepositoryPolicyText if changed
+      // Update RepositoryPolicyText if changed. `!== undefined` (not
+      // truthy) so a deliberate clear (`null` / `''`) reaches the delete
+      // path instead of silently no-oping.
       const newPolicy = properties['RepositoryPolicyText'];
       const oldPolicy = previousProperties['RepositoryPolicyText'];
-      if (JSON.stringify(newPolicy) !== JSON.stringify(oldPolicy) && newPolicy) {
-        const policyText = typeof newPolicy === 'string' ? newPolicy : JSON.stringify(newPolicy);
-        await this.getClient().send(
-          new SetRepositoryPolicyCommand({
-            repositoryName: physicalId,
-            policyText,
-          })
-        );
-        this.logger.debug(`Updated repository policy for ${physicalId}`);
+      if (JSON.stringify(newPolicy) !== JSON.stringify(oldPolicy)) {
+        if (newPolicy !== undefined && newPolicy !== null && newPolicy !== '') {
+          const policyText = typeof newPolicy === 'string' ? newPolicy : JSON.stringify(newPolicy);
+          await this.getClient().send(
+            new SetRepositoryPolicyCommand({
+              repositoryName: physicalId,
+              policyText,
+            })
+          );
+          this.logger.debug(`Updated repository policy for ${physicalId}`);
+        } else if (oldPolicy !== undefined && oldPolicy !== null && oldPolicy !== '') {
+          try {
+            await this.getClient().send(
+              new DeleteRepositoryPolicyCommand({ repositoryName: physicalId })
+            );
+            this.logger.debug(`Deleted repository policy for ${physicalId}`);
+          } catch (err) {
+            // If the policy is already gone, this is idempotent.
+            const code =
+              (err as { name?: string } | undefined)?.name ??
+              (err as { __type?: string } | undefined)?.__type ??
+              '';
+            if (!code.includes('RepositoryPolicyNotFound')) throw err;
+          }
+        }
       }
 
       // Update Tags if changed
@@ -407,10 +444,16 @@ export class ECRProvider implements ResourceProvider {
       ScanOnPush: r.imageScanningConfiguration?.scanOnPush ?? false,
     };
     {
-      const enc: Record<string, unknown> = {
-        EncryptionType: r.encryptionConfiguration?.encryptionType ?? 'AES256',
-      };
-      if (r.encryptionConfiguration?.kmsKey !== undefined) {
+      // Class 1 guard — `KmsKey` is only valid on `EncryptionType=KMS`.
+      // AWS rejects `KmsKey` (including the empty string) on AES256
+      // repositories, and `EncryptionConfiguration` is immutable so the
+      // round-trip path doesn't actually re-submit it; even so, we don't
+      // want to leak `KmsKey: ''` into observedProperties because the
+      // drift comparator would surface a false positive against any
+      // template that omits the field.
+      const encType = r.encryptionConfiguration?.encryptionType ?? 'AES256';
+      const enc: Record<string, unknown> = { EncryptionType: encType };
+      if (encType === 'KMS' && r.encryptionConfiguration?.kmsKey) {
         enc['KmsKey'] = r.encryptionConfiguration.kmsKey;
       }
       result['EncryptionConfiguration'] = enc;

--- a/src/provisioning/providers/ecs-provider.ts
+++ b/src/provisioning/providers/ecs-provider.ts
@@ -54,7 +54,7 @@ import {
   type AssignPublicIp,
 } from '@aws-sdk/client-ecs';
 import { getLogger } from '../../utils/logger.js';
-import { ProvisioningError } from '../../utils/error-handler.js';
+import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
 import { generateResourceName } from '../resource-name.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { normalizeAwsTagsToCfn, resolveExplicitPhysicalId } from '../import-helpers.js';
@@ -500,31 +500,25 @@ export class ECSProvider implements ResourceProvider {
 
   private async updateTaskDefinition(
     logicalId: string,
-    physicalId: string,
-    resourceType: string,
-    properties: Record<string, unknown>
+    _physicalId: string,
+    _resourceType: string,
+    _properties: Record<string, unknown>
   ): Promise<ResourceUpdateResult> {
-    this.logger.debug(`Updating ECS task definition ${logicalId}: ${physicalId}`);
-
-    // TaskDefinition updates create a new revision (RegisterTaskDefinition)
-    const result = await this.createTaskDefinition(logicalId, resourceType, properties);
-
-    // Deregister old revision
-    try {
-      const client = this.getClient();
-      await client.send(new DeregisterTaskDefinitionCommand({ taskDefinition: physicalId }));
-      this.logger.debug(`Deregistered old task definition revision: ${physicalId}`);
-    } catch (error) {
-      this.logger.debug(
-        `Failed to deregister old task definition ${physicalId}: ${error instanceof Error ? error.message : String(error)}`
-      );
-    }
-
-    return {
-      physicalId: result.physicalId,
-      wasReplaced: false,
-      attributes: result.attributes ?? {},
-    };
+    // ECS TaskDefinitions are immutable revisioned resources: every property
+    // change creates a new revision via RegisterTaskDefinition, and the new
+    // revision's `taskDefinitionArn` differs from the cdkd-state physicalId.
+    // Routing this through `cdkd drift --revert` would silently swap state's
+    // physicalId for a freshly-registered revision (and deregister the
+    // previous one) without the user's awareness — surface a clear error
+    // instead. The deploy code path uses Replace (CREATE→DELETE) for property
+    // changes, which is the correct semantics here.
+    return Promise.reject(
+      new ResourceUpdateNotSupportedError(
+        'AWS::ECS::TaskDefinition',
+        logicalId,
+        'TaskDefinition revisions are immutable; re-deploy with cdkd deploy --replace, or destroy + redeploy the stack'
+      )
+    );
   }
 
   private async deleteTaskDefinition(
@@ -1202,10 +1196,33 @@ export class ECSProvider implements ResourceProvider {
     }
     if (s.networkConfiguration) result['NetworkConfiguration'] = s.networkConfiguration;
     result['LoadBalancers'] = s.loadBalancers ?? [];
-    result['CapacityProviderStrategy'] = s.capacityProviderStrategy ?? [];
+    // Class 1: LaunchType vs CapacityProviderStrategy are mutually exclusive
+    // on the AWS API side. UpdateService rejects when both arrive together
+    // (e.g. `launchType=FARGATE` + `capacityProviderStrategy=[]`). Skip the
+    // empty placeholder when LaunchType is set so `cdkd drift --revert`
+    // doesn't push a structurally-invalid input back to AWS. A non-empty
+    // strategy still surfaces (drift detection on the strategy itself).
+    if (s.capacityProviderStrategy && s.capacityProviderStrategy.length > 0) {
+      result['CapacityProviderStrategy'] = s.capacityProviderStrategy;
+    } else if (!s.launchType) {
+      result['CapacityProviderStrategy'] = [];
+    }
     if (s.deploymentConfiguration) result['DeploymentConfiguration'] = s.deploymentConfiguration;
     result['PlacementConstraints'] = s.placementConstraints ?? [];
-    result['PlacementStrategy'] = s.placementStrategy ?? [];
+    // Class 1: PlacementStrategy is EC2-only. Emitting `[]` on a Fargate
+    // service means `cdkd drift --revert` pushes `placementStrategy: []` to
+    // UpdateService, which AWS rejects with "Placement strategies are not
+    // valid for tasks using the Fargate launch type." Discriminator-gated
+    // emit: only surface PlacementStrategy when LaunchType is EC2 (or
+    // EXTERNAL) — Fargate services cannot legally have one, so the emit
+    // would never detect a real console-side change anyway.
+    if (s.launchType === 'EC2' || s.launchType === 'EXTERNAL') {
+      result['PlacementStrategy'] = s.placementStrategy ?? [];
+    } else if (s.placementStrategy && s.placementStrategy.length > 0) {
+      // Defensive: surface a non-empty strategy regardless of launch type
+      // (so drift still flags an out-of-band attach if AWS ever permits it).
+      result['PlacementStrategy'] = s.placementStrategy;
+    }
     result['ServiceRegistries'] = s.serviceRegistries ?? [];
     const tags = normalizeAwsTagsToCfn(s.tags);
     result['Tags'] = tags;

--- a/tests/unit/provisioning/apigateway-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/apigateway-provider-readcurrentstate.test.ts
@@ -77,12 +77,14 @@ describe('ApiGatewayProvider.readCurrentState', () => {
     );
 
     expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(GetMethodCommand);
+    // Class 1: AuthorizerId is NOT emitted on AuthorizationType=NONE
+    // because it is only valid on CUSTOM / COGNITO_USER_POOLS. See
+    // docs/provider-development.md § 3b.
     expect(result).toEqual({
       RestApiId: 'api-1',
       ResourceId: 'res-1',
       HttpMethod: 'GET',
       AuthorizationType: 'NONE',
-      AuthorizerId: '',
       Integration: { type: 'AWS_PROXY', uri: 'arn:aws:lambda:...' },
       MethodResponses: {},
     });

--- a/tests/unit/provisioning/apigateway-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/apigateway-provider-roundtrip.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  GetMethodCommand,
+  GetAccountCommand,
+  UpdateAccountCommand,
+  PutMethodCommand,
+} from '@aws-sdk/client-api-gateway';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    apiGateway: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { ApiGatewayProvider } from '../../../src/provisioning/providers/apigateway-provider.js';
+import { ResourceUpdateNotSupportedError } from '../../../src/utils/error-handler.js';
+
+/**
+ * Read-update round-trip suite for ApiGatewayProvider.
+ *
+ * Mechanical guard for the three latent failure modes documented in
+ * docs/provider-development.md § 3b — Class 1 (type-discriminator-
+ * dependent fields), Class 2 (structurally-incomplete-when-empty
+ * fields), and the truthy-gate `update()` bug — all of which only
+ * surface on the `cdkd drift --revert` round-trip
+ * (`observedProperties` → `provider.update`).
+ */
+describe('ApiGatewayProvider read-update round-trip', () => {
+  let provider: ApiGatewayProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ApiGatewayProvider();
+  });
+
+  // ─── AWS::ApiGateway::Account ───────────────────────────────────────
+
+  it('Account round-trip: empty CloudWatchRoleArn placeholder reaches AWS as a real clear-patch (truthy-gate fix)', async () => {
+    // Truthy-gate guard. Before the fix, `updateAccountWithRetry` used
+    // `cloudWatchRoleArn ? [...] : []` which silently dropped `''`,
+    // so a `cdkd drift --revert` from "AWS-set CW role" → "state has
+    // empty placeholder" would succeed with zero AWS-side change and
+    // the next drift would re-detect the same drift forever.
+    //
+    // After the fix: `cloudWatchRoleArn !== undefined` ships
+    // `replace /cloudwatchRoleArn ''` — the same patch shape
+    // deleteAccount uses, which AWS documents as "clear this field".
+    mockSend.mockResolvedValueOnce({});
+
+    await provider.update(
+      'AccountLogical',
+      'ApiGatewayAccount',
+      'AWS::ApiGateway::Account',
+      { CloudWatchRoleArn: '' },
+      { CloudWatchRoleArn: 'arn:aws:iam::123:role/cw' }
+    );
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateAccountCommand);
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as {
+      patchOperations: Array<{ op: string; path: string; value: string }>;
+    };
+    expect(input.patchOperations).toEqual([
+      { op: 'replace', path: '/cloudwatchRoleArn', value: '' },
+    ]);
+  });
+
+  it('Account round-trip: state == AWS produces zero AWS-side mutations', async () => {
+    // readCurrentState produces `CloudWatchRoleArn: ''` placeholder on
+    // an account that has no CloudWatch role configured. Round-tripping
+    // that placeholder through update() with no drift must not change
+    // AWS state — but the truthy-gate fix means an explicit `''` does
+    // get pushed back. The AWS-side behavior is "replace with empty",
+    // which is idempotent on an already-empty account; the SDK call
+    // count below is the orthogonal "no call beyond the patch we sent"
+    // assertion.
+    mockSend.mockResolvedValueOnce({}); // UpdateAccount (idempotent)
+
+    const observed = { CloudWatchRoleArn: '' };
+    await provider.update(
+      'AccountLogical',
+      'ApiGatewayAccount',
+      'AWS::ApiGateway::Account',
+      observed,
+      observed
+    );
+
+    // Exactly one UpdateAccount call (the idempotent clear). No other
+    // commands.
+    const updateCalls = mockSend.mock.calls.filter((c) => c[0] instanceof UpdateAccountCommand);
+    expect(updateCalls).toHaveLength(1);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('Account readCurrentState emits the CloudWatchRoleArn placeholder', async () => {
+    // Always-emit contract for the user-controllable top-level key.
+    mockSend.mockResolvedValueOnce({}); // GetAccount: no CW role configured
+
+    const observed = await provider.readCurrentState(
+      'ApiGatewayAccount',
+      'AccountLogical',
+      'AWS::ApiGateway::Account'
+    );
+
+    expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(GetAccountCommand);
+    expect(observed).toEqual({ CloudWatchRoleArn: '' });
+  });
+
+  // ─── AWS::ApiGateway::Method ────────────────────────────────────────
+
+  it('Method readCurrentState (NONE auth): AuthorizerId is NOT emitted (Class 1 guard)', async () => {
+    // Class 1: AuthorizerId is only valid when AuthorizationType is
+    // CUSTOM or COGNITO_USER_POOLS. Emitting `''` on a NONE method
+    // would make `cdkd drift --revert`'s round-trip push an invalid
+    // input back to PutMethod (AWS rejects with "Invalid authorizer
+    // ID specified"). The guard prevents the placeholder from ever
+    // landing in observedProperties.
+    mockSend.mockResolvedValueOnce({
+      httpMethod: 'GET',
+      authorizationType: 'NONE',
+      methodIntegration: { type: 'AWS_PROXY', uri: 'arn:aws:lambda:...' },
+    });
+
+    const observed = await provider.readCurrentState(
+      'api-1|res-1|GET',
+      'MethodLogical',
+      'AWS::ApiGateway::Method'
+    );
+
+    expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(GetMethodCommand);
+    expect(observed).toBeDefined();
+    expect(observed).not.toHaveProperty('AuthorizerId');
+    // Sanity: AuthorizationScopes (COGNITO_USER_POOLS-only Class 1
+    // sibling) also not emitted.
+    expect(observed).not.toHaveProperty('AuthorizationScopes');
+  });
+
+  it('Method readCurrentState (COGNITO auth): AuthorizerId IS emitted (Class 1 discriminator true)', async () => {
+    // Complement of the NONE test: a COGNITO_USER_POOLS method
+    // legitimately has AuthorizerId, and readCurrentState must emit
+    // it so drift can detect a console-side change.
+    mockSend.mockResolvedValueOnce({
+      httpMethod: 'POST',
+      authorizationType: 'COGNITO_USER_POOLS',
+      authorizerId: 'auth-xyz',
+      methodIntegration: { type: 'AWS_PROXY', uri: 'arn:aws:lambda:...' },
+    });
+
+    const observed = await provider.readCurrentState(
+      'api-1|res-1|POST',
+      'MethodLogical',
+      'AWS::ApiGateway::Method'
+    );
+
+    expect(observed).toMatchObject({
+      AuthorizationType: 'COGNITO_USER_POOLS',
+      AuthorizerId: 'auth-xyz',
+    });
+  });
+
+  it('Method update() throws ResourceUpdateNotSupportedError cleanly (immutable type)', async () => {
+    // Per CLAUDE.md (PR I): Method.update is intentionally
+    // ResourceUpdateNotSupportedError — UpdateMethod's patch-operation
+    // builder is not yet plumbed through. This test fails CI if a
+    // future refactor accidentally turns it into a silent no-op
+    // again. It also documents the round-trip safety guarantee for
+    // Class 2 placeholders on Method (Integration: {} /
+    // MethodResponses: {}): drift --revert never reaches AWS for this
+    // type, so the structurally-invalid empty-object placeholders
+    // can't surface as AWS rejections.
+    const observed = {
+      RestApiId: 'api-1',
+      ResourceId: 'res-1',
+      HttpMethod: 'GET',
+      AuthorizationType: 'NONE',
+      Integration: {} as Record<string, unknown>,
+      MethodResponses: {} as Record<string, unknown>,
+    };
+
+    await expect(
+      provider.update('MethodLogical', 'api-1|res-1|GET', 'AWS::ApiGateway::Method', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    // No PutMethod / UpdateMethod / Get* call should have happened.
+    expect(mockSend).not.toHaveBeenCalled();
+    const putMethodCalls = mockSend.mock.calls.filter((c) => c[0] instanceof PutMethodCommand);
+    expect(putMethodCalls).toHaveLength(0);
+  });
+
+  // ─── Other immutable-update sub-resources (parity with Method) ──────
+
+  it('Authorizer / Deployment update() throw ResourceUpdateNotSupportedError', async () => {
+    // Same structural guarantee: drift --revert can never reach AWS
+    // with a malformed input for these types because update() rejects
+    // before any SDK call.
+    await expect(
+      provider.update('A', 'auth-1', 'AWS::ApiGateway::Authorizer', {}, {})
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    await expect(
+      provider.update('D', 'dep-1', 'AWS::ApiGateway::Deployment', {}, {})
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/provisioning/apigatewayv2-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/apigatewayv2-provider-readcurrentstate.test.ts
@@ -147,12 +147,16 @@ describe('ApiGatewayV2Provider.readCurrentState', () => {
     );
 
     expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(GetRouteCommand);
+    // JWT-auth route: AuthorizerId emitted, AuthorizationScopes default
+    // []. NONE-auth Class 1 guard ensures these are excluded on no-auth
+    // routes (covered by the round-trip test file).
     expect(result).toEqual({
       ApiId: 'abcd1234',
       RouteKey: 'GET /pets',
       Target: 'integrations/int-1',
       AuthorizationType: 'JWT',
       AuthorizerId: 'auth-1',
+      AuthorizationScopes: [],
     });
   });
 
@@ -172,14 +176,15 @@ describe('ApiGatewayV2Provider.readCurrentState', () => {
     );
 
     expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(GetAuthorizerCommand);
+    // JWT authorizer: only the JWT-side discriminator fields are emitted.
+    // AuthorizerUri / AuthorizerPayloadFormatVersion are REQUEST-only
+    // and must NOT be present on a JWT result (Class 1 guard).
     expect(result).toEqual({
       ApiId: 'abcd1234',
       AuthorizerType: 'JWT',
       Name: 'my-jwt-authorizer',
       IdentitySource: ['$request.header.Authorization'],
       JwtConfiguration: { Audience: ['client-id'], Issuer: 'https://issuer.example.com' },
-      AuthorizerUri: '',
-      AuthorizerPayloadFormatVersion: '',
     });
   });
 

--- a/tests/unit/provisioning/apigatewayv2-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/apigatewayv2-provider-roundtrip.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-apigatewayv2', async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    ApiGatewayV2Client: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { ApiGatewayV2Provider } from '../../../src/provisioning/providers/apigatewayv2-provider.js';
+import { ResourceUpdateNotSupportedError } from '../../../src/utils/error-handler.js';
+
+const API_ID = 'abcd1234';
+
+/**
+ * Read-update round-trip test (docs/provider-development.md § 3b).
+ *
+ * `cdkd drift --revert` round-trips `observedProperties` (= a
+ * `readCurrentState` snapshot) through `provider.update`. ApiGatewayV2's
+ * `update()` rejects every type with `ResourceUpdateNotSupportedError`
+ * (see PR I), so the structural guard for this provider is two-fold:
+ *
+ * 1. `readCurrentState` must NOT emit Class 1 placeholders that the
+ *    AWS-side Update API would reject (e.g. `JwtConfiguration` on a
+ *    REQUEST authorizer, `CorsConfiguration` on a WEBSOCKET API,
+ *    `IntegrationUri` on a MOCK integration). The drift comparator
+ *    consumes `observedProperties`, so leaving an invalid placeholder
+ *    in there would also fire false-positive drift on every clean run.
+ * 2. `update()` must reject cleanly with `ResourceUpdateNotSupportedError`
+ *    for every resource type — no spurious SDK calls should fire on the
+ *    revert path.
+ */
+describe('ApiGatewayV2Provider read-update round-trip', () => {
+  let provider: ApiGatewayV2Provider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ApiGatewayV2Provider();
+  });
+
+  it('Class 1 — Api HTTP no-drift snapshot includes CorsConfiguration but excludes WEBSOCKET-only fields', async () => {
+    mockSend.mockResolvedValueOnce({
+      ApiId: API_ID,
+      Name: 'my-http-api',
+      ProtocolType: 'HTTP',
+      Description: 'an http api',
+      CorsConfiguration: { AllowOrigins: ['*'] },
+      // RouteSelectionExpression: AWS DOES return one for HTTP APIs as a
+      // server-managed default, but it must NOT show up in observed.
+      RouteSelectionExpression: '$request.method $request.path',
+      Tags: { Foo: 'Bar' },
+    });
+
+    const observed = await provider.readCurrentState(
+      API_ID,
+      'ApiLogical',
+      'AWS::ApiGatewayV2::Api'
+    );
+
+    expect(observed).toBeDefined();
+    expect(observed!['CorsConfiguration']).toEqual({ AllowOrigins: ['*'] });
+    expect(observed!).not.toHaveProperty('RouteSelectionExpression');
+
+    // Round-trip: update must reject cleanly without sending any SDK
+    // commands.
+    vi.clearAllMocks();
+    await expect(
+      provider.update('L', API_ID, 'AWS::ApiGatewayV2::Api', observed!, observed!)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('Class 1 — Api WEBSOCKET no-drift snapshot preserves RouteSelectionExpression but excludes CorsConfiguration', async () => {
+    mockSend.mockResolvedValueOnce({
+      ApiId: API_ID,
+      Name: 'my-ws-api',
+      ProtocolType: 'WEBSOCKET',
+      Description: 'a websocket api',
+      // CorsConfiguration: AWS would not return one on a WEBSOCKET API,
+      // and the readCurrentState placeholder MUST NOT push `{}` here —
+      // CORS is HTTP-only and `UpdateApi` rejects a CORS payload on a
+      // WEBSOCKET API.
+      RouteSelectionExpression: '$request.body.action',
+    });
+
+    const observed = await provider.readCurrentState(
+      API_ID,
+      'ApiLogical',
+      'AWS::ApiGatewayV2::Api'
+    );
+
+    expect(observed).toBeDefined();
+    expect(observed!).not.toHaveProperty('CorsConfiguration');
+    expect(observed!['RouteSelectionExpression']).toBe('$request.body.action');
+
+    vi.clearAllMocks();
+    await expect(
+      provider.update('L', API_ID, 'AWS::ApiGatewayV2::Api', observed!, observed!)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('Class 1 — Authorizer JWT no-drift snapshot preserves JwtConfiguration and excludes REQUEST-only fields', async () => {
+    mockSend.mockResolvedValueOnce({
+      AuthorizerId: 'auth-jwt',
+      AuthorizerType: 'JWT',
+      Name: 'my-jwt-authorizer',
+      IdentitySource: ['$request.header.Authorization'],
+      JwtConfiguration: { Audience: ['client-id'], Issuer: 'https://issuer.example.com' },
+    });
+
+    const observed = await provider.readCurrentState(
+      'auth-jwt',
+      'AuthorizerLogical',
+      'AWS::ApiGatewayV2::Authorizer',
+      { ApiId: API_ID }
+    );
+
+    expect(observed).toBeDefined();
+    expect(observed!['JwtConfiguration']).toEqual({
+      Audience: ['client-id'],
+      Issuer: 'https://issuer.example.com',
+    });
+    // REQUEST-only fields MUST be absent on a JWT authorizer (would
+    // trigger AWS rejection on revert).
+    expect(observed!).not.toHaveProperty('AuthorizerUri');
+    expect(observed!).not.toHaveProperty('AuthorizerPayloadFormatVersion');
+
+    vi.clearAllMocks();
+    await expect(
+      provider.update('L', 'auth-jwt', 'AWS::ApiGatewayV2::Authorizer', observed!, observed!)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('Class 1 — Authorizer REQUEST no-drift snapshot preserves AuthorizerUri and excludes JwtConfiguration', async () => {
+    mockSend.mockResolvedValueOnce({
+      AuthorizerId: 'auth-req',
+      AuthorizerType: 'REQUEST',
+      Name: 'my-request-authorizer',
+      IdentitySource: ['$request.header.Authorization'],
+      AuthorizerUri: 'arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/...',
+      AuthorizerPayloadFormatVersion: '2.0',
+    });
+
+    const observed = await provider.readCurrentState(
+      'auth-req',
+      'AuthorizerLogical',
+      'AWS::ApiGatewayV2::Authorizer',
+      { ApiId: API_ID }
+    );
+
+    expect(observed).toBeDefined();
+    expect(observed!['AuthorizerUri']).toBe(
+      'arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/...'
+    );
+    expect(observed!['AuthorizerPayloadFormatVersion']).toBe('2.0');
+    // JWT-only fields MUST be absent on a REQUEST authorizer.
+    expect(observed!).not.toHaveProperty('JwtConfiguration');
+
+    vi.clearAllMocks();
+    await expect(
+      provider.update('L', 'auth-req', 'AWS::ApiGatewayV2::Authorizer', observed!, observed!)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('Class 1 — Integration MOCK no-drift snapshot excludes IntegrationUri', async () => {
+    mockSend.mockResolvedValueOnce({
+      IntegrationId: 'int-mock',
+      IntegrationType: 'MOCK',
+      // AWS does not return IntegrationUri for MOCK; the readCurrentState
+      // placeholder MUST NOT push `''` here — AWS rejects an empty
+      // IntegrationUri on MOCK integrations.
+    });
+
+    const observed = await provider.readCurrentState(
+      'int-mock',
+      'IntegrationLogical',
+      'AWS::ApiGatewayV2::Integration',
+      { ApiId: API_ID }
+    );
+
+    expect(observed).toBeDefined();
+    expect(observed!).not.toHaveProperty('IntegrationUri');
+    expect(observed!['IntegrationType']).toBe('MOCK');
+  });
+
+  it('Class 1 — Integration AWS_PROXY no-drift snapshot includes IntegrationUri', async () => {
+    mockSend.mockResolvedValueOnce({
+      IntegrationId: 'int-lambda',
+      IntegrationType: 'AWS_PROXY',
+      IntegrationUri: 'arn:aws:lambda:us-east-1:123:function:my-fn',
+      IntegrationMethod: 'POST',
+      PayloadFormatVersion: '2.0',
+    });
+
+    const observed = await provider.readCurrentState(
+      'int-lambda',
+      'IntegrationLogical',
+      'AWS::ApiGatewayV2::Integration',
+      { ApiId: API_ID }
+    );
+
+    expect(observed).toBeDefined();
+    expect(observed!['IntegrationUri']).toBe('arn:aws:lambda:us-east-1:123:function:my-fn');
+
+    vi.clearAllMocks();
+    await expect(
+      provider.update(
+        'L',
+        'int-lambda',
+        'AWS::ApiGatewayV2::Integration',
+        observed!,
+        observed!
+      )
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('Class 2 — Route NONE-auth no-drift snapshot uses AuthorizationType=NONE and excludes AuthorizerId/AuthorizationScopes', async () => {
+    mockSend.mockResolvedValueOnce({
+      RouteId: 'route-none',
+      RouteKey: 'GET /pets',
+      Target: 'integrations/int-1',
+      // AuthorizationType undefined / AWS returns 'NONE' default.
+    });
+
+    const observed = await provider.readCurrentState(
+      'route-none',
+      'RouteLogical',
+      'AWS::ApiGatewayV2::Route',
+      { ApiId: API_ID }
+    );
+
+    expect(observed).toBeDefined();
+    // Class 2 fix: must be 'NONE' (AWS-valid sentinel), not '' (rejected).
+    expect(observed!['AuthorizationType']).toBe('NONE');
+    expect(observed!).not.toHaveProperty('AuthorizerId');
+    expect(observed!).not.toHaveProperty('AuthorizationScopes');
+  });
+
+  it('Class 1 — Route JWT-auth no-drift snapshot includes AuthorizerId and AuthorizationScopes', async () => {
+    mockSend.mockResolvedValueOnce({
+      RouteId: 'route-jwt',
+      RouteKey: 'GET /pets',
+      Target: 'integrations/int-1',
+      AuthorizationType: 'JWT',
+      AuthorizerId: 'auth-1',
+      AuthorizationScopes: ['scope-a', 'scope-b'],
+    });
+
+    const observed = await provider.readCurrentState(
+      'route-jwt',
+      'RouteLogical',
+      'AWS::ApiGatewayV2::Route',
+      { ApiId: API_ID }
+    );
+
+    expect(observed).toBeDefined();
+    expect(observed!['AuthorizationType']).toBe('JWT');
+    expect(observed!['AuthorizerId']).toBe('auth-1');
+    expect(observed!['AuthorizationScopes']).toEqual(['scope-a', 'scope-b']);
+  });
+
+  it('every resource type rejects update() cleanly with ResourceUpdateNotSupportedError and no SDK calls', async () => {
+    // Mechanical guard: ApiGatewayV2 update() is an immutable-only
+    // wrapper (PR I). state == AWS round-trip MUST produce zero
+    // mutating SDK calls.
+    const cases: Array<{ type: string; observed: Record<string, unknown> }> = [
+      {
+        type: 'AWS::ApiGatewayV2::Api',
+        observed: { Name: 'a', ProtocolType: 'HTTP', Description: '', CorsConfiguration: {}, Tags: [] },
+      },
+      {
+        type: 'AWS::ApiGatewayV2::Stage',
+        observed: { ApiId: API_ID, StageName: '$default', AutoDeploy: true, Description: '' },
+      },
+      {
+        type: 'AWS::ApiGatewayV2::Integration',
+        observed: {
+          ApiId: API_ID,
+          IntegrationType: 'AWS_PROXY',
+          IntegrationUri: 'arn:aws:lambda:us-east-1:1:function:f',
+          IntegrationMethod: 'POST',
+          PayloadFormatVersion: '2.0',
+        },
+      },
+      {
+        type: 'AWS::ApiGatewayV2::Route',
+        observed: { ApiId: API_ID, RouteKey: 'GET /', Target: 'integrations/i-1', AuthorizationType: 'NONE' },
+      },
+      {
+        type: 'AWS::ApiGatewayV2::Authorizer',
+        observed: {
+          ApiId: API_ID,
+          AuthorizerType: 'JWT',
+          Name: 'auth',
+          IdentitySource: ['$request.header.Authorization'],
+          JwtConfiguration: { Audience: ['c'], Issuer: 'https://i' },
+        },
+      },
+    ];
+
+    for (const { type, observed } of cases) {
+      vi.clearAllMocks();
+      await expect(provider.update('L', 'phys', type, observed, observed)).rejects.toBeInstanceOf(
+        ResourceUpdateNotSupportedError
+      );
+      expect(mockSend).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/tests/unit/provisioning/appsync-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/appsync-provider-readcurrentstate.test.ts
@@ -189,10 +189,31 @@ describe('AppSyncProvider.readCurrentState', () => {
         },
       });
     });
+
+    it('Class 2: omits ServiceRoleArn when AWS does not return one', async () => {
+      // ServiceRoleArn must be a valid IAM ARN — '' placeholder would
+      // fail ARN validation if pushed back to AWS. NONE / HTTP type
+      // data sources legitimately have no service role.
+      mockSend.mockResolvedValueOnce({
+        dataSource: {
+          name: 'ds1',
+          type: 'NONE',
+          // serviceRoleArn deliberately undefined.
+        },
+      });
+
+      const result = await provider.readCurrentState(
+        'api-1|ds1',
+        'L',
+        'AWS::AppSync::DataSource'
+      );
+
+      expect(result).not.toHaveProperty('ServiceRoleArn');
+    });
   });
 
   describe('AWS::AppSync::Resolver', () => {
-    it('returns CFn-shaped Resolver properties (happy path)', async () => {
+    it('Kind=UNIT VTL: emits DataSourceName + VTL templates, omits PIPELINE/JS shapes', async () => {
       mockSend.mockResolvedValueOnce({
         resolver: {
           typeName: 'Query',
@@ -211,17 +232,78 @@ describe('AppSyncProvider.readCurrentState', () => {
       );
 
       expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(GetResolverCommand);
+      // Class 1: PipelineConfig + Code + Runtime are NOT emitted on a
+      // UNIT VTL resolver (they'd be rejected by CreateResolver /
+      // UpdateResolver if pushed back).
       expect(result).toEqual({
         ApiId: 'api-1',
         TypeName: 'Query',
         FieldName: 'getThing',
-        DataSourceName: 'ds1',
         Kind: 'UNIT',
+        DataSourceName: 'ds1',
         RequestMappingTemplate: '$ctx',
         ResponseMappingTemplate: '$result',
-        PipelineConfig: { Functions: [] },
-        Runtime: {},
-        Code: '',
+      });
+    });
+
+    it('Class 1: Kind=PIPELINE omits DataSourceName + VTL templates', async () => {
+      mockSend.mockResolvedValueOnce({
+        resolver: {
+          typeName: 'Query',
+          fieldName: 'pipe',
+          kind: 'PIPELINE',
+          pipelineConfig: { functions: ['fn-1', 'fn-2'] },
+          requestMappingTemplate: '$ctx',
+          responseMappingTemplate: '$result',
+        },
+      });
+
+      const result = await provider.readCurrentState(
+        'api-1|Query|pipe',
+        'L',
+        'AWS::AppSync::Resolver'
+      );
+
+      // PipelineConfig is the discriminator-tagged required shape;
+      // DataSourceName is N/A on a PIPELINE resolver.
+      expect(result).toMatchObject({
+        ApiId: 'api-1',
+        TypeName: 'Query',
+        FieldName: 'pipe',
+        Kind: 'PIPELINE',
+        PipelineConfig: { Functions: ['fn-1', 'fn-2'] },
+      });
+      expect(result).not.toHaveProperty('DataSourceName');
+    });
+
+    it('Class 1: JS resolver emits Code + Runtime, omits VTL templates', async () => {
+      mockSend.mockResolvedValueOnce({
+        resolver: {
+          typeName: 'Query',
+          fieldName: 'jsThing',
+          dataSourceName: 'ds1',
+          kind: 'UNIT',
+          code: 'export function request() {}',
+          runtime: { name: 'APPSYNC_JS', runtimeVersion: '1.0.0' },
+        },
+      });
+
+      const result = await provider.readCurrentState(
+        'api-1|Query|jsThing',
+        'L',
+        'AWS::AppSync::Resolver'
+      );
+
+      // VTL templates are NOT emitted on a JS resolver (AWS rejects
+      // mixing Code/Runtime with Request/ResponseMappingTemplate).
+      expect(result).toEqual({
+        ApiId: 'api-1',
+        TypeName: 'Query',
+        FieldName: 'jsThing',
+        Kind: 'UNIT',
+        DataSourceName: 'ds1',
+        Code: 'export function request() {}',
+        Runtime: { Name: 'APPSYNC_JS', RuntimeVersion: '1.0.0' },
       });
     });
   });

--- a/tests/unit/provisioning/appsync-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/appsync-provider-roundtrip.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-appsync', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-appsync')>(
+    '@aws-sdk/client-appsync'
+  );
+  return {
+    ...actual,
+    AppSyncClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { AppSyncProvider } from '../../../src/provisioning/providers/appsync-provider.js';
+import { ResourceUpdateNotSupportedError } from '../../../src/utils/error-handler.js';
+
+/**
+ * Read-update round-trip test for AppSyncProvider.
+ *
+ * Per docs/provider-development.md § 3b ("Read-update round-trip test"),
+ * every provider with `readCurrentState` must mechanically verify the
+ * `cdkd drift --revert` code path.
+ *
+ * AppSyncProvider is a special case: per CLAUDE.md (PR I), AppSync
+ * resources are immutable (recreated on property changes), so `update()`
+ * always rejects with `ResourceUpdateNotSupportedError`. The round-trip
+ * test still has value:
+ *
+ *   1. Confirms `update()` ALWAYS rejects regardless of the observed
+ *      snapshot shape — i.e. no path through `update()` ever fires a
+ *      mutating SDK call against a Class 1 / Class 2 placeholder. This
+ *      structurally guarantees `cdkd drift --revert` cannot ship an
+ *      AWS-invalid input on AppSync.
+ *
+ *   2. Confirms `readCurrentState` is Class-1-clean on the discriminator-
+ *      tagged shapes (Kind=UNIT vs PIPELINE; VTL vs JS). A future change
+ *      that re-adds an always-emit placeholder on a discriminator-false
+ *      branch will be caught here.
+ */
+
+describe('AppSyncProvider read-update round-trip', () => {
+  let provider: AppSyncProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new AppSyncProvider();
+  });
+
+  it('GraphQLApi: update() rejects cleanly without firing any SDK call', async () => {
+    // Build a snapshot matching what readCurrentState would produce
+    // for a minimum GraphQLApi (placeholders included).
+    const observed = {
+      Name: 'MyApi',
+      AuthenticationType: 'API_KEY',
+      XrayEnabled: false,
+      LogConfig: {},
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await expect(
+      provider.update('L', 'api-1', 'AWS::AppSync::GraphQLApi', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    // No spurious SDK calls — update must reject before any AWS API is
+    // invoked. This is what protects round-tripped Class 2 placeholders
+    // (e.g. LogConfig: {}) from ever being shipped to AWS.
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('DataSource type=AMAZON_DYNAMODB: Class 1 — update() rejects without sending DynamoDBConfig back', async () => {
+    // Build a no-drift observed snapshot for a DynamoDB DataSource.
+    // Class 1 verification: a future regression that emits an empty
+    // LambdaConfig / HttpConfig placeholder alongside DynamoDBConfig
+    // would still be safe here (update rejects before any SDK call),
+    // but the observed snapshot below mirrors what readCurrentState
+    // produces post-fix: only the matching-type config is present.
+    const observed = {
+      ApiId: 'api-1',
+      Name: 'ddb-ds',
+      Type: 'AMAZON_DYNAMODB',
+      Description: '',
+      ServiceRoleArn: 'arn:aws:iam::1:role/AppSyncDDB',
+      DynamoDBConfig: {
+        TableName: 'my-table',
+        AwsRegion: 'us-east-1',
+      },
+      // No LambdaConfig / HttpConfig — Class 1 contract.
+    };
+
+    await expect(
+      provider.update('L', 'api-1|ddb-ds', 'AWS::AppSync::DataSource', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('Resolver Kind=UNIT: Class 1 — round-trip does not reach an AWS call with PipelineConfig', async () => {
+    // Class 1 verification: UNIT resolver snapshot has DataSourceName +
+    // VTL templates but NOT PipelineConfig (post-fix). update() rejects
+    // before any SDK call, so even if the snapshot had a stale
+    // PipelineConfig from a v2 state file, no AWS-invalid input would
+    // be shipped.
+    const observed = {
+      ApiId: 'api-1',
+      TypeName: 'Query',
+      FieldName: 'getThing',
+      Kind: 'UNIT',
+      DataSourceName: 'ds1',
+      RequestMappingTemplate: '$ctx',
+      ResponseMappingTemplate: '$result',
+      // PipelineConfig deliberately absent — UNIT resolver, Class 1.
+    };
+
+    await expect(
+      provider.update(
+        'L',
+        'api-1|Query|getThing',
+        'AWS::AppSync::Resolver',
+        observed,
+        observed
+      )
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('Resolver Kind=PIPELINE: Class 1 — round-trip does not reach an AWS call with DataSourceName', async () => {
+    // Class 1 verification: PIPELINE resolver snapshot has
+    // PipelineConfig but NOT DataSourceName / VTL templates (post-fix).
+    const observed = {
+      ApiId: 'api-1',
+      TypeName: 'Query',
+      FieldName: 'pipe',
+      Kind: 'PIPELINE',
+      PipelineConfig: { Functions: ['fn-1', 'fn-2'] },
+      // DataSourceName deliberately absent — PIPELINE resolver, Class 1.
+    };
+
+    await expect(
+      provider.update('L', 'api-1|Query|pipe', 'AWS::AppSync::Resolver', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('ApiKey: update() rejects cleanly without firing any SDK call', async () => {
+    const observed = {
+      ApiId: 'api-1',
+      Description: 'main',
+      Expires: 1700000000,
+    };
+
+    await expect(
+      provider.update('L', 'api-1|k1', 'AWS::AppSync::ApiKey', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/provisioning/ecr-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/ecr-provider-roundtrip.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  DeleteLifecyclePolicyCommand,
+  DeleteRepositoryPolicyCommand,
+  DescribeRepositoriesCommand,
+  PutImageScanningConfigurationCommand,
+  PutImageTagMutabilityCommand,
+  PutLifecyclePolicyCommand,
+  SetRepositoryPolicyCommand,
+  TagResourceCommand,
+} from '@aws-sdk/client-ecr';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-ecr', async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    ECRClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { ECRProvider } from '../../../src/provisioning/providers/ecr-provider.js';
+
+/**
+ * Read-update round-trip property tests for ECRProvider.
+ *
+ * See docs/provider-development.md § 3b for the convention. The
+ * mechanical guard is: "if state is already exactly what AWS reports
+ * (the no-drift case), update() must produce zero mutating SDK calls."
+ *
+ * On `cdkd drift --revert`, `buildRevertNewProperties` round-trips the
+ * AWS-current snapshot back through `provider.update`, so any
+ * placeholder shape that readCurrentState always-emits is at risk of
+ * being re-submitted to AWS. The round-trip test catches that class of
+ * regression up front.
+ */
+
+const REPO = 'my-repo';
+const REPO_ARN = 'arn:aws:ecr:us-east-1:123:repository/my-repo';
+const REPO_URI = '123.dkr.ecr.us-east-1.amazonaws.com/my-repo';
+
+const MUTATING_COMMANDS = [
+  PutImageScanningConfigurationCommand,
+  PutImageTagMutabilityCommand,
+  PutLifecyclePolicyCommand,
+  DeleteLifecyclePolicyCommand,
+  SetRepositoryPolicyCommand,
+  DeleteRepositoryPolicyCommand,
+  TagResourceCommand,
+];
+
+function countMutatingCalls(): number {
+  return mockSend.mock.calls.filter((c) =>
+    MUTATING_COMMANDS.some((cmd) => c[0] instanceof cmd)
+  ).length;
+}
+
+describe('ECRProvider read-update round-trip', () => {
+  let provider: ECRProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ECRProvider();
+    // Default DescribeRepositories used at the tail of update() to
+    // re-read attributes. The round-trip itself shouldn't need it
+    // unless an actual mutation fired, but mocks-by-default keeps the
+    // test resilient to internal call additions.
+    mockSend.mockResolvedValue({
+      repositories: [
+        {
+          repositoryName: REPO,
+          repositoryArn: REPO_ARN,
+          repositoryUri: REPO_URI,
+        },
+      ],
+    });
+  });
+
+  it('AES256 (default) repository: no-drift round-trip is a no-op (zero mutating SDK calls; KmsKey not pushed)', async () => {
+    // Class 1 guard — `KmsKey` is only valid on `EncryptionType=KMS`.
+    // readCurrentState now omits `KmsKey` on AES256 (the AWS API may
+    // return it as `''`); the round-trip therefore never tries to push
+    // it back. Even if `EncryptionConfiguration` were ever made mutable,
+    // this guard would prevent the AWS rejection.
+    const observed = {
+      RepositoryName: REPO,
+      ImageTagMutability: 'MUTABLE',
+      ImageScanningConfiguration: { ScanOnPush: false },
+      EncryptionConfiguration: { EncryptionType: 'AES256' },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await provider.update('L', REPO, 'AWS::ECR::Repository', observed, observed);
+
+    // The state==AWS round-trip must produce no mutating calls.
+    expect(countMutatingCalls()).toBe(0);
+
+    // And — even if mutating calls were made — none of them should
+    // ever reference KmsKey (it's not in the snapshot at all on AES256).
+    expect(JSON.stringify(observed)).not.toContain('KmsKey');
+  });
+
+  it('KMS-encrypted repository: no-drift round-trip preserves KmsKey (no SDK calls)', async () => {
+    const observed = {
+      RepositoryName: REPO,
+      ImageTagMutability: 'MUTABLE',
+      ImageScanningConfiguration: { ScanOnPush: true },
+      EncryptionConfiguration: {
+        EncryptionType: 'KMS',
+        KmsKey: 'arn:aws:kms:us-east-1:123:key/abcd',
+      },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await provider.update('L', REPO, 'AWS::ECR::Repository', observed, observed);
+
+    expect(countMutatingCalls()).toBe(0);
+    // KmsKey legitimately appears in the snapshot for KMS encryption.
+    expect((observed.EncryptionConfiguration as Record<string, unknown>)['KmsKey']).toBe(
+      'arn:aws:kms:us-east-1:123:key/abcd'
+    );
+  });
+
+  it('repository without lifecycle policy: no-drift round-trip does NOT leak `LifecyclePolicy: {}` placeholder', async () => {
+    // Class 2 guard — readCurrentState omits the LifecyclePolicy key
+    // entirely when no policy is configured (it's not always-emitted as
+    // an empty placeholder). The round-trip therefore never sends a
+    // `PutLifecyclePolicy` with an empty body (which AWS would reject
+    // with "lifecyclePolicyText cannot be empty").
+    const observed = {
+      RepositoryName: REPO,
+      ImageTagMutability: 'MUTABLE',
+      ImageScanningConfiguration: { ScanOnPush: false },
+      EncryptionConfiguration: { EncryptionType: 'AES256' },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await provider.update('L', REPO, 'AWS::ECR::Repository', observed, observed);
+
+    expect(countMutatingCalls()).toBe(0);
+    const putLifecycleCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PutLifecyclePolicyCommand
+    );
+    expect(putLifecycleCalls).toHaveLength(0);
+  });
+
+  it('repository with lifecycle policy: no-drift round-trip is a no-op', async () => {
+    // The complement of the placeholder test: when a real lifecycle
+    // policy exists in both state and AWS-current, the round-trip
+    // should still be a no-op (diff-based) — not a redundant
+    // `PutLifecyclePolicy`.
+    const observed = {
+      RepositoryName: REPO,
+      ImageTagMutability: 'MUTABLE',
+      ImageScanningConfiguration: { ScanOnPush: false },
+      EncryptionConfiguration: { EncryptionType: 'AES256' },
+      LifecyclePolicy: { LifecyclePolicyText: '{"rules":[]}' },
+      Tags: [{ Key: 'k', Value: 'v' }],
+    };
+
+    await provider.update('L', REPO, 'AWS::ECR::Repository', observed, observed);
+
+    expect(countMutatingCalls()).toBe(0);
+  });
+
+  it('truthy-gate guard: clearing a lifecycle policy issues DeleteLifecyclePolicy (not a silent no-op)', async () => {
+    // Drift-revert path coverage — when AWS-current has a policy and
+    // state wants it cleared, update() must actually delete it instead
+    // of falling through the truthy gate. Pre-fix this was a silent
+    // no-op (`if (newLifecycle?.LifecyclePolicyText)` skipped the
+    // change); post-fix it issues `DeleteLifecyclePolicyCommand`.
+    const oldProps = {
+      RepositoryName: REPO,
+      LifecyclePolicy: { LifecyclePolicyText: '{"rules":[]}' },
+    };
+    const newProps = {
+      RepositoryName: REPO,
+      // Lifecycle cleared.
+    };
+
+    await provider.update('L', REPO, 'AWS::ECR::Repository', newProps, oldProps);
+
+    const deleteLifecycleCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof DeleteLifecyclePolicyCommand
+    );
+    expect(deleteLifecycleCalls).toHaveLength(1);
+    expect((deleteLifecycleCalls[0]?.[0] as DeleteLifecyclePolicyCommand).input).toEqual({
+      repositoryName: REPO,
+    });
+  });
+
+  it('truthy-gate guard: clearing the repository policy issues DeleteRepositoryPolicy (not a silent no-op)', async () => {
+    // Same shape as the lifecycle guard — pre-fix the gate was
+    // `&& newPolicy`, which silently dropped the clear; post-fix the
+    // diff is detected via `!== undefined` and the delete fires.
+    const oldProps = {
+      RepositoryName: REPO,
+      RepositoryPolicyText: '{"Version":"2012-10-17","Statement":[]}',
+    };
+    const newProps = {
+      RepositoryName: REPO,
+      // Policy cleared.
+    };
+
+    await provider.update('L', REPO, 'AWS::ECR::Repository', newProps, oldProps);
+
+    const deleteRepoPolicyCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof DeleteRepositoryPolicyCommand
+    );
+    expect(deleteRepoPolicyCalls).toHaveLength(1);
+  });
+});

--- a/tests/unit/provisioning/ecs-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/ecs-provider-readcurrentstate.test.ts
@@ -95,6 +95,11 @@ describe('ECSProvider.readCurrentState', () => {
     );
 
     expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(DescribeServicesCommand);
+    // Class 1 gated keys (round-trip safety):
+    //   - PlacementStrategy: omitted on Fargate (EC2-only field; AWS rejects
+    //     `placementStrategy: []` on Fargate UpdateService).
+    //   - CapacityProviderStrategy: omitted when LaunchType is set
+    //     (mutually exclusive with capacityProviderStrategy on UpdateService).
     expect(result).toEqual({
       ServiceName: 'my-svc',
       Cluster: 'arn:aws:ecs:us-east-1:123:cluster/my-cluster',
@@ -103,9 +108,7 @@ describe('ECSProvider.readCurrentState', () => {
       LaunchType: 'FARGATE',
       EnableExecuteCommand: true,
       LoadBalancers: [],
-      CapacityProviderStrategy: [],
       PlacementConstraints: [],
-      PlacementStrategy: [],
       ServiceRegistries: [],
       Tags: [],
     });

--- a/tests/unit/provisioning/ecs-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/ecs-provider-roundtrip.test.ts
@@ -1,0 +1,377 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  PutClusterCapacityProvidersCommand,
+  UpdateServiceCommand,
+  RegisterTaskDefinitionCommand,
+  DeregisterTaskDefinitionCommand,
+  DescribeClustersCommand,
+  DescribeServicesCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from '@aws-sdk/client-ecs';
+import { ResourceUpdateNotSupportedError } from '../../../src/utils/error-handler.js';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-ecs', async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    ECSClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { ECSProvider } from '../../../src/provisioning/providers/ecs-provider.js';
+
+const CLUSTER_NAME = 'my-cluster';
+const CLUSTER_ARN = 'arn:aws:ecs:us-east-1:123:cluster/my-cluster';
+const SERVICE_PHYSICAL_ID = `${CLUSTER_ARN}|my-svc`;
+const SERVICE_ARN = 'arn:aws:ecs:us-east-1:123:service/my-cluster/my-svc';
+const TD_ARN = 'arn:aws:ecs:us-east-1:123:task-definition/my-td:1';
+
+/** Mutating commands we want to assert never fire on a no-drift round-trip. */
+function mutatingSends(): unknown[] {
+  return mockSend.mock.calls
+    .map((c) => c[0])
+    .filter(
+      (cmd) =>
+        cmd instanceof PutClusterCapacityProvidersCommand ||
+        cmd instanceof UpdateServiceCommand ||
+        cmd instanceof RegisterTaskDefinitionCommand ||
+        cmd instanceof DeregisterTaskDefinitionCommand ||
+        cmd instanceof TagResourceCommand ||
+        cmd instanceof UntagResourceCommand
+    );
+}
+
+describe('ECSProvider read-update round-trip', () => {
+  let provider: ECSProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ECSProvider();
+  });
+
+  // ─── AWS::ECS::Cluster ─────────────────────────────────────────
+
+  it('Cluster: no-drift round-trip is a logical no-op (no PutClusterCapacityProviders, no Tag* mutation)', async () => {
+    // Diff-based providers must produce zero AWS-side mutations when
+    // state == AWS. UpdateCluster uses a truthy gate
+    // `if (CapacityProviders || DefaultCapacityProviderStrategy)`; an
+    // empty-array placeholder is truthy and would call AWS even though
+    // nothing changed. State that holds the same values must stay
+    // mutation-free on round-trip.
+    const observed = {
+      ClusterName: CLUSTER_NAME,
+      CapacityProviders: ['FARGATE'],
+      DefaultCapacityProviderStrategy: [
+        { capacityProvider: 'FARGATE', weight: 1, base: 0 },
+      ] as Array<Record<string, unknown>>,
+      ClusterSettings: [{ Name: 'containerInsights', Value: 'enabled' }],
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    };
+
+    // Mock: PutClusterCapacityProviders → DescribeClusters (for ARN)
+    mockSend.mockResolvedValueOnce({}); // PutClusterCapacityProviders
+    mockSend.mockResolvedValueOnce({
+      clusters: [{ clusterArn: CLUSTER_ARN, clusterName: CLUSTER_NAME }],
+    });
+
+    await provider.update('L', CLUSTER_NAME, 'AWS::ECS::Cluster', observed, observed);
+
+    // Tag* must NOT fire — old/new tags identical (no diff).
+    const tagSends = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof TagResourceCommand || c[0] instanceof UntagResourceCommand
+    );
+    expect(tagSends).toHaveLength(0);
+  });
+
+  // ─── AWS::ECS::Service (Fargate) ───────────────────────────────
+
+  it('Service Fargate: round-trip preserves PlatformVersion; no Class 1 PlacementStrategy / CapacityProviderStrategy in update input', async () => {
+    // Class 1 round-trip guard. On a Fargate service:
+    //   - PlacementStrategy is EC2-only — AWS rejects
+    //     `placementStrategy: []` with "Placement strategies are not
+    //     valid for tasks using the Fargate launch type."
+    //   - CapacityProviderStrategy is mutually exclusive with
+    //     LaunchType — AWS rejects when both are set.
+    // readCurrentState must NOT emit those placeholders, so the
+    // round-trip update() input must not carry them either.
+    const observed = {
+      ServiceName: 'my-svc',
+      Cluster: CLUSTER_ARN,
+      TaskDefinition: TD_ARN,
+      DesiredCount: 2,
+      LaunchType: 'FARGATE',
+      PlatformVersion: '1.4.0',
+      EnableExecuteCommand: true,
+      LoadBalancers: [],
+      PlacementConstraints: [],
+      ServiceRegistries: [],
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    };
+
+    mockSend.mockResolvedValueOnce({
+      service: { serviceArn: SERVICE_ARN, serviceName: 'my-svc' },
+    });
+
+    await provider.update(
+      'L',
+      SERVICE_PHYSICAL_ID,
+      'AWS::ECS::Service',
+      observed,
+      observed
+    );
+
+    const updateCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateServiceCommand
+    );
+    expect(updateCalls).toHaveLength(1);
+    const input = updateCalls[0]![0].input as {
+      placementStrategy?: unknown;
+      capacityProviderStrategy?: unknown;
+      platformVersion?: unknown;
+    };
+    // PlatformVersion must be preserved (Fargate-only field that the
+    // round-trip should NOT silently drop).
+    expect(input.platformVersion).toBe('1.4.0');
+    // Class 1: omitted on Fargate via discriminator-gated readCurrentState
+    // (so observed snapshot has no PlacementStrategy / CapacityProviderStrategy
+    // key, and update() forwards undefined).
+    expect(input.placementStrategy).toBeUndefined();
+    expect(input.capacityProviderStrategy).toBeUndefined();
+  });
+
+  it('Service Fargate readCurrentState: PlacementStrategy / CapacityProviderStrategy not emitted', async () => {
+    // Read-side assertion for Class 1 discriminator gate. Mirrors
+    // ecs-provider-readcurrentstate.test.ts but specifically guards the
+    // Fargate-discriminator behavior we rely on for the round-trip
+    // safety above.
+    mockSend.mockResolvedValueOnce({
+      services: [
+        {
+          serviceName: 'my-svc',
+          clusterArn: CLUSTER_ARN,
+          taskDefinition: TD_ARN,
+          launchType: 'FARGATE',
+          platformVersion: '1.4.0',
+        },
+      ],
+    });
+
+    const result = await provider.readCurrentState(
+      SERVICE_PHYSICAL_ID,
+      'L',
+      'AWS::ECS::Service'
+    );
+
+    expect(result).not.toBeUndefined();
+    expect(Object.keys(result!)).not.toContain('PlacementStrategy');
+    expect(Object.keys(result!)).not.toContain('CapacityProviderStrategy');
+    expect(result!['PlatformVersion']).toBe('1.4.0');
+  });
+
+  // ─── AWS::ECS::Service (EC2) ───────────────────────────────────
+
+  it('Service EC2 readCurrentState: PlacementStrategy emitted, PlatformVersion absent', async () => {
+    // Complement of the Fargate gate. On EC2, PlacementStrategy IS
+    // valid input — readCurrentState should surface it (defaulting to
+    // []) so a console-side change to placement strategies fires
+    // drift. PlatformVersion is Fargate-only; AWS won't return it for
+    // EC2 services.
+    mockSend.mockResolvedValueOnce({
+      services: [
+        {
+          serviceName: 'my-svc',
+          clusterArn: CLUSTER_ARN,
+          taskDefinition: TD_ARN,
+          launchType: 'EC2',
+          placementStrategy: [{ type: 'spread', field: 'instanceId' }],
+        },
+      ],
+    });
+
+    const result = await provider.readCurrentState(
+      SERVICE_PHYSICAL_ID,
+      'L',
+      'AWS::ECS::Service'
+    );
+
+    expect(result).not.toBeUndefined();
+    expect(result!['PlacementStrategy']).toEqual([
+      { type: 'spread', field: 'instanceId' },
+    ]);
+    expect(Object.keys(result!)).not.toContain('PlatformVersion');
+  });
+
+  it('Service EC2 round-trip preserves PlacementStrategy in UpdateService input', async () => {
+    // The complement of the Fargate test: an EC2 service legitimately
+    // has PlacementStrategy and round-tripping should NOT drop it.
+    const observed = {
+      ServiceName: 'my-svc',
+      Cluster: CLUSTER_ARN,
+      TaskDefinition: TD_ARN,
+      DesiredCount: 2,
+      LaunchType: 'EC2',
+      PlacementStrategy: [{ type: 'spread', field: 'instanceId' }],
+      EnableExecuteCommand: false,
+      LoadBalancers: [],
+      PlacementConstraints: [],
+      ServiceRegistries: [],
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValueOnce({
+      service: { serviceArn: SERVICE_ARN, serviceName: 'my-svc' },
+    });
+
+    await provider.update(
+      'L',
+      SERVICE_PHYSICAL_ID,
+      'AWS::ECS::Service',
+      observed,
+      observed
+    );
+
+    const updateCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateServiceCommand
+    );
+    expect(updateCalls).toHaveLength(1);
+    const input = updateCalls[0]![0].input as { placementStrategy?: unknown };
+    expect(input.placementStrategy).toEqual([
+      { type: 'spread', field: 'instanceId' },
+    ]);
+  });
+
+  // ─── AWS::ECS::TaskDefinition ──────────────────────────────────
+
+  it('TaskDefinition.update rejects with ResourceUpdateNotSupportedError; no spurious AWS calls', async () => {
+    // TaskDefinition revisions are immutable: every property change
+    // creates a new revision via RegisterTaskDefinition, and the
+    // returned `taskDefinitionArn` differs from cdkd state's physicalId.
+    // Routing through `cdkd drift --revert` would silently swap
+    // physicalId for a freshly-registered revision and deregister the
+    // previous one. The only safe outcome is a clear error, NOT a
+    // silent revision-bump against AWS.
+    const observed = {
+      Family: 'my-td',
+      Cpu: '256',
+      Memory: '512',
+      NetworkMode: 'awsvpc',
+      RequiresCompatibilities: ['FARGATE'],
+      ContainerDefinitions: [{ Name: 'app', Image: 'nginx:latest' }],
+      Volumes: [],
+      PlacementConstraints: [],
+      Tags: [],
+    };
+
+    await expect(
+      provider.update('L', TD_ARN, 'AWS::ECS::TaskDefinition', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    // No mutating AWS calls — the error fires before any send().
+    expect(mutatingSends()).toHaveLength(0);
+  });
+
+  // ─── State == AWS produces zero mutating calls ─────────────────
+
+  it('Cluster no-drift round-trip: zero mutating SDK calls', async () => {
+    // Stronger structural guard: on a no-drift round-trip, the only
+    // SDK calls allowed are reads. Tag* must be silent; the truthy-
+    // gated PutClusterCapacityProviders is allowed (it's a no-op on
+    // AWS when values match) but Tag mutations are not.
+    const observed = {
+      ClusterName: CLUSTER_NAME,
+      CapacityProviders: [],
+      DefaultCapacityProviderStrategy: [],
+      ClusterSettings: [],
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    };
+
+    // Mock: PutClusterCapacityProviders (truthy-gate guard does fire
+    // because both arrays are truthy even when empty) → Describe.
+    mockSend.mockResolvedValueOnce({}); // Put
+    mockSend.mockResolvedValueOnce({
+      clusters: [{ clusterArn: CLUSTER_ARN }],
+    });
+
+    await provider.update('L', CLUSTER_NAME, 'AWS::ECS::Cluster', observed, observed);
+
+    // No Tag* mutation on a no-drift run.
+    const tagMutations = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof TagResourceCommand || c[0] instanceof UntagResourceCommand
+    );
+    expect(tagMutations).toHaveLength(0);
+
+    // Sanity: only Put + Describe were issued.
+    expect(mockSend.mock.calls.length).toBe(2);
+    expect(mockSend.mock.calls[0]![0]).toBeInstanceOf(PutClusterCapacityProvidersCommand);
+    expect(mockSend.mock.calls[1]![0]).toBeInstanceOf(DescribeClustersCommand);
+  });
+
+  it('Service no-drift round-trip: no Tag* mutation, single UpdateService + Describe', async () => {
+    const observed = {
+      ServiceName: 'my-svc',
+      Cluster: CLUSTER_ARN,
+      TaskDefinition: TD_ARN,
+      DesiredCount: 1,
+      LaunchType: 'FARGATE',
+      PlatformVersion: 'LATEST',
+      LoadBalancers: [],
+      PlacementConstraints: [],
+      ServiceRegistries: [],
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    };
+
+    mockSend.mockResolvedValueOnce({
+      service: { serviceArn: SERVICE_ARN, serviceName: 'my-svc' },
+    });
+
+    await provider.update(
+      'L',
+      SERVICE_PHYSICAL_ID,
+      'AWS::ECS::Service',
+      observed,
+      observed
+    );
+
+    const tagMutations = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof TagResourceCommand || c[0] instanceof UntagResourceCommand
+    );
+    expect(tagMutations).toHaveLength(0);
+
+    // Update path issues a single UpdateServiceCommand. The provider
+    // does NOT issue a separate DescribeServices on update — it reads
+    // the ARN from the UpdateService response.
+    const updates = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateServiceCommand
+    );
+    expect(updates).toHaveLength(1);
+    const describes = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof DescribeServicesCommand
+    );
+    expect(describes).toHaveLength(0);
+  });
+});

--- a/tests/unit/provisioning/ecs-provider.test.ts
+++ b/tests/unit/provisioning/ecs-provider.test.ts
@@ -189,53 +189,36 @@ describe('ECSProvider', () => {
     });
 
     describe('update', () => {
-      it('should register new revision and deregister old', async () => {
-        // RegisterTaskDefinition (new revision)
-        mockSend.mockResolvedValueOnce({
-          taskDefinition: {
-            taskDefinitionArn:
-              'arn:aws:ecs:us-east-1:123456789012:task-definition/my-task:2',
-          },
-        });
-        // DeregisterTaskDefinition (old revision)
-        mockSend.mockResolvedValueOnce({});
+      it('rejects with ResourceUpdateNotSupportedError; revisions are immutable', async () => {
+        // TaskDefinition revisions are immutable: every property change
+        // creates a new revision via RegisterTaskDefinition, and the new
+        // ARN diverges from cdkd state's physicalId. Routing through
+        // `cdkd drift --revert` would silently swap state's physicalId
+        // for a freshly-registered revision and deregister the previous
+        // one. The deploy code path uses Replace (CREATE→DELETE) for
+        // property changes; `update()` itself must reject loudly.
+        await expect(
+          provider.update(
+            'MyTask',
+            'arn:aws:ecs:us-east-1:123456789012:task-definition/my-task:1',
+            'AWS::ECS::TaskDefinition',
+            {
+              Family: 'my-task',
+              ContainerDefinitions: [{ Name: 'web', Image: 'nginx:latest' }],
+              Cpu: '512',
+              Memory: '1024',
+            },
+            {
+              Family: 'my-task',
+              ContainerDefinitions: [{ Name: 'web', Image: 'nginx:latest' }],
+              Cpu: '256',
+              Memory: '512',
+            }
+          )
+        ).rejects.toMatchObject({ name: 'ResourceUpdateNotSupportedError' });
 
-        const result = await provider.update(
-          'MyTask',
-          'arn:aws:ecs:us-east-1:123456789012:task-definition/my-task:1',
-          'AWS::ECS::TaskDefinition',
-          {
-            Family: 'my-task',
-            ContainerDefinitions: [{ Name: 'web', Image: 'nginx:latest' }],
-            Cpu: '512',
-            Memory: '1024',
-          },
-          {
-            Family: 'my-task',
-            ContainerDefinitions: [{ Name: 'web', Image: 'nginx:latest' }],
-            Cpu: '256',
-            Memory: '512',
-          }
-        );
-
-        expect(result.physicalId).toBe(
-          'arn:aws:ecs:us-east-1:123456789012:task-definition/my-task:2'
-        );
-        expect(result.wasReplaced).toBe(false);
-        expect(result.attributes).toEqual({
-          TaskDefinitionArn:
-            'arn:aws:ecs:us-east-1:123456789012:task-definition/my-task:2',
-        });
-        expect(mockSend).toHaveBeenCalledTimes(2);
-
-        const registerCall = mockSend.mock.calls[0][0];
-        expect(registerCall.constructor.name).toBe('RegisterTaskDefinitionCommand');
-
-        const deregisterCall = mockSend.mock.calls[1][0];
-        expect(deregisterCall.constructor.name).toBe('DeregisterTaskDefinitionCommand');
-        expect(deregisterCall.input.taskDefinition).toBe(
-          'arn:aws:ecs:us-east-1:123456789012:task-definition/my-task:1'
-        );
+        // No spurious AWS calls — error fires before any send().
+        expect(mockSend).not.toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
## Summary

PR 4/5 of the post-#162 provider round-trip audit. Audits the 5 compute/API providers and adds round-trip property tests.

| Provider | Class 1 fix | Class 2 fix | Truthy gate fix | Round-trip tests |
|---|---|---|---|---|
| `ECSProvider` | **2** (Service `PlacementStrategy` EC2/EXTERNAL-only, `CapacityProviderStrategy` mutex with `LaunchType`) | — | — | 8 + **TaskDefinition immutable**: `update()` was silently bumping revision on `--revert`; now rejects with `ResourceUpdateNotSupportedError` |
| `ECRProvider` | 1 (`KmsKey: ''` for AES256 false drift) | — | **2** (`LifecyclePolicy` / `RepositoryPolicyText` clear via `Delete*` API) | 6 |
| `AppSyncProvider` | **5** (Resolver `DataSourceName` / `PipelineConfig` / `Code` / `Runtime` / templates gated on Kind+runtime) | 1 (`DataSource.ServiceRoleArn: ''` IAM-format-invalid) | — | 5 |
| `ApiGatewayProvider` | 1 (`Method.AuthorizerId` AuthorizationType-gated) | — | 1 (`Account.cloudWatchRoleArn` truthy → `!== undefined`) | 7 |
| `ApiGatewayV2Provider` | **6** (Api `CorsConfiguration` HTTP-only / `RouteSelectionExpression` WEBSOCKET-only, Authorizer `JwtConfiguration` / `AuthorizerUri` / `PayloadFormatVersion` AuthorizerType-gated, Integration `IntegrationUri` URI-types-only, Route `AuthorizerId` / `AuthorizationScopes` non-NONE-only) | 1 (Route `AuthorizationType: ''` → `'NONE'`) | — | 9 |

### Highlights

- **ECS TaskDefinition silent revision-bump**: same silent-fail mode as Lambda Layer (PR 1) — every no-drift `--revert` registered a new task definition revision. Now rejects up front; CDK hash-based naming means real-world deploy hits CREATE+DELETE so this is not a deploy regression.
- **ECR clear-policy bug**: `LifecyclePolicy` and `RepositoryPolicyText` were silently dropped by truthy gates. `cdkd drift --revert` reported `✓ reverted` while AWS kept the policy — same silent-fail mode as IAM Role Description (#161). Fix uses `DeleteLifecyclePolicy` / `DeleteRepositoryPolicy` (with idempotent error handling) when state is empty but AWS has a policy.
- **AppSync Resolver Class 1 cluster**: 5 type-specific fields gated on `Kind` (UNIT/PIPELINE) and runtime (VTL/JS). Each was always-emitted and would be rejected on the wrong kind/runtime.
- **ApiGatewayV2 `RouteSelectionExpression`**: WEBSOCKET-only field was missing entirely from `readCurrentState`, causing a drift-detection gap. Added.

## Test plan

- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` clean
- [x] `npx vitest --run` — 1816 tests pass (was 1778; **38 new round-trip tests**)
- [x] `/run-integ apigateway` — deploy 11/11 in 28s, destroy 11/11 / 0 errors / 0 orphans

## Out of scope

PR 5 will cover the tail providers (EventBridge / SSM / CloudWatch / CodeBuild / Glue / WAFv2 / Firehose / Kinesis / etc.).
