### PR TITLE
fix(drift): round-trip audit for tail providers (PR 5/5 — final)

### DIFF
--- a/src/provisioning/providers/cloudtrail-provider.ts
+++ b/src/provisioning/providers/cloudtrail-provider.ts
@@ -190,6 +190,21 @@ export class CloudTrailProvider implements ResourceProvider {
   ): Promise<ResourceUpdateResult> {
     this.logger.debug(`Updating CloudTrail Trail ${logicalId}: ${physicalId}`);
 
+    // `readCurrentState` always-emits empty-string `''` placeholders for
+    // optional ARN-shaped fields (KMSKeyId, SnsTopicName) so console-side
+    // adds are detectable as drift (per docs/provider-development.md
+    // § 3b "always emit user-controllable top-level keys"). `cdkd drift
+    // --revert` round-trips the placeholder back through this `update()`.
+    // `UpdateTrail` rejects empty strings for ARN-shaped fields with
+    // "KmsKeyId is not in valid ARN format" / "SnsTopicName is not in
+    // valid format", so sanitize empty-string → undefined at the wire
+    // layer. This mirrors the canonical Class 2 pattern in
+    // `sqs-queue-provider.ts` (`serializeRedrivePolicy`).
+    const sanitizeArn = (v: unknown): string | undefined => {
+      if (v === undefined || v === null || v === '') return undefined;
+      return v as string;
+    };
+
     const s3BucketName = properties['S3BucketName'] as string | undefined;
     const s3KeyPrefix = properties['S3KeyPrefix'] as string | undefined;
     const isMultiRegionTrail = properties['IsMultiRegionTrail'] as boolean | undefined;
@@ -198,10 +213,10 @@ export class CloudTrailProvider implements ResourceProvider {
       | undefined;
     const enableLogFileValidation = properties['EnableLogFileValidation'] as boolean | undefined;
     const isLogging = properties['IsLogging'] as boolean | undefined;
-    const cloudWatchLogsLogGroupArn = properties['CloudWatchLogsLogGroupArn'] as string | undefined;
-    const cloudWatchLogsRoleArn = properties['CloudWatchLogsRoleArn'] as string | undefined;
-    const kmsKeyId = properties['KMSKeyId'] as string | undefined;
-    const snsTopicName = properties['SnsTopicName'] as string | undefined;
+    const cloudWatchLogsLogGroupArn = sanitizeArn(properties['CloudWatchLogsLogGroupArn']);
+    const cloudWatchLogsRoleArn = sanitizeArn(properties['CloudWatchLogsRoleArn']);
+    const kmsKeyId = sanitizeArn(properties['KMSKeyId']);
+    const snsTopicName = sanitizeArn(properties['SnsTopicName']);
     const isOrganizationTrail = properties['IsOrganizationTrail'] as boolean | undefined;
 
     try {
@@ -437,68 +452,92 @@ export class CloudTrailProvider implements ResourceProvider {
     }
     if (!trail) return undefined;
 
+    // Always-emit user-controllable top-level keys with placeholders so
+    // console-side adds become visible to drift (the comparator's top-
+    // level walk is state-keys-only, so an omitted key is invisible
+    // forever). See docs/provider-development.md § 3b.
     const result: Record<string, unknown> = {};
     if (trail.Name !== undefined) result['TrailName'] = trail.Name;
+    // S3BucketName is required to create a trail; AWS always returns it.
     if (trail.S3BucketName !== undefined) result['S3BucketName'] = trail.S3BucketName;
-    if (trail.S3KeyPrefix !== undefined) result['S3KeyPrefix'] = trail.S3KeyPrefix;
-    if (trail.IsMultiRegionTrail !== undefined) {
-      result['IsMultiRegionTrail'] = trail.IsMultiRegionTrail;
-    }
-    if (trail.IncludeGlobalServiceEvents !== undefined) {
-      result['IncludeGlobalServiceEvents'] = trail.IncludeGlobalServiceEvents;
-    }
-    if (trail.LogFileValidationEnabled !== undefined) {
-      result['EnableLogFileValidation'] = trail.LogFileValidationEnabled;
-    }
-    if (trail.CloudWatchLogsLogGroupArn !== undefined) {
+    result['S3KeyPrefix'] = trail.S3KeyPrefix ?? '';
+    result['IsMultiRegionTrail'] = trail.IsMultiRegionTrail ?? false;
+    result['IncludeGlobalServiceEvents'] = trail.IncludeGlobalServiceEvents ?? true;
+    result['EnableLogFileValidation'] = trail.LogFileValidationEnabled ?? false;
+
+    // Class 1 — CloudWatchLogsLogGroupArn / CloudWatchLogsRoleArn are a
+    // type-discriminated pair: both required when CW logs are enabled,
+    // neither when disabled. Emitting `''` placeholders on a CW-logs-
+    // disabled trail would round-trip through `update()` and AWS would
+    // reject `Property validation failure: CloudWatchLogsLogGroupArn is
+    // not in valid ARN format`. Only emit both keys when AWS reports
+    // both present (the discriminator is "both fields populated").
+    // Drift is not lost: the disabled state cannot legally have either
+    // field on AWS, so a console-side enable shows up as both fields
+    // appearing at once on the next read. Pattern documented in
+    // `feedback_always_emit_check_type_discriminator.md`.
+    if (trail.CloudWatchLogsLogGroupArn && trail.CloudWatchLogsRoleArn) {
       result['CloudWatchLogsLogGroupArn'] = trail.CloudWatchLogsLogGroupArn;
-    }
-    if (trail.CloudWatchLogsRoleArn !== undefined) {
       result['CloudWatchLogsRoleArn'] = trail.CloudWatchLogsRoleArn;
     }
-    if (trail.KmsKeyId !== undefined) result['KMSKeyId'] = trail.KmsKeyId;
-    if (trail.SnsTopicName !== undefined) result['SnsTopicName'] = trail.SnsTopicName;
-    if (trail.IsOrganizationTrail !== undefined) {
-      result['IsOrganizationTrail'] = trail.IsOrganizationTrail;
-    }
+
+    result['KMSKeyId'] = trail.KmsKeyId ?? '';
+    result['SnsTopicName'] = trail.SnsTopicName ?? '';
+    result['IsOrganizationTrail'] = trail.IsOrganizationTrail ?? false;
 
     // IsLogging — separate call. Treat any error as "feature not configured"
     // and omit the key.
     try {
       const status = await this.getClient().send(new GetTrailStatusCommand({ Name: physicalId }));
-      if (status.IsLogging !== undefined) result['IsLogging'] = status.IsLogging;
+      result['IsLogging'] = status.IsLogging ?? false;
     } catch {
       // Best-effort.
     }
 
     // EventSelectors — separate call. AWS returns either `EventSelectors`
-    // or `AdvancedEventSelectors` (mutually exclusive). cdkd state's CFn
-    // shape is `EventSelectors` only, so surface only that variant.
+    // or `AdvancedEventSelectors` (mutually exclusive — Class 1). cdkd
+    // state's CFn shape is `EventSelectors` only.
+    //
+    // When AWS has AdvancedEventSelectors configured, surfacing
+    // `EventSelectors: []` would round-trip through `update()` and
+    // attempt PutEventSelectors, which AWS rejects when the trail
+    // is using AdvancedEventSelectors. Skip emit in that case — the
+    // discriminator-false state cannot legally have EventSelectors, so
+    // a console-side switch back to basic EventSelectors shows up on
+    // the next read.
     try {
       const sel = await this.getClient().send(
         new GetEventSelectorsCommand({ TrailName: physicalId })
       );
-      result['EventSelectors'] = (sel.EventSelectors ?? []).map(
-        (es) => es as unknown as Record<string, unknown>
-      );
+      const hasAdvanced =
+        Array.isArray(sel.AdvancedEventSelectors) && sel.AdvancedEventSelectors.length > 0;
+      if (!hasAdvanced) {
+        result['EventSelectors'] = (sel.EventSelectors ?? []).map(
+          (es) => es as unknown as Record<string, unknown>
+        );
+      }
     } catch {
       // Best-effort.
     }
 
-    // Tags via ListTags. Requires the trail ARN.
+    // Tags via ListTags. Always emit `Tags: []` so a console-side tag
+    // add on a previously-untagged trail is detectable as drift (per
+    // § 3b). When the trail ARN is missing or ListTags fails, fall back
+    // to the empty placeholder rather than dropping the key.
+    let tags: Array<{ Key: string; Value: string }> = [];
     if (trail.TrailARN) {
       try {
         const tagsResp = await this.getClient().send(
           new ListTagsCommand({ ResourceIdList: [trail.TrailARN] })
         );
-        const tags = normalizeAwsTagsToCfn(tagsResp.ResourceTagList?.[0]?.TagsList);
-        result['Tags'] = tags;
+        tags = normalizeAwsTagsToCfn(tagsResp.ResourceTagList?.[0]?.TagsList);
       } catch (err) {
         this.logger.debug(
           `CloudTrail ListTags(${trail.TrailARN}) failed: ${err instanceof Error ? err.message : String(err)}`
         );
       }
     }
+    result['Tags'] = tags;
 
     return result;
   }

--- a/src/provisioning/providers/cloudwatch-alarm-provider.ts
+++ b/src/provisioning/providers/cloudwatch-alarm-provider.ts
@@ -295,6 +295,33 @@ export class CloudWatchAlarmProvider implements ResourceProvider {
     alarmName: string,
     properties: Record<string, unknown>
   ): PutMetricAlarmCommandInput {
+    // `readCurrentState` always-emits placeholder values for every
+    // user-controllable top-level key so the drift comparator can detect
+    // a console-side ADD on a key the alarm wasn't templated with. That
+    // makes `cdkd drift --revert` round-trip those placeholders back
+    // through this method (Class 1 / Class 2 in
+    // docs/provider-development.md § 3b):
+    //
+    //   - Class 1 (type-discriminator): `Metrics: []` is the metric-math
+    //     discriminator. An empty array IS truthy in JS, so a naive
+    //     `if (properties['Metrics'])` would route a metric-style alarm
+    //     into the metric-math branch and ship `Metrics: []` to AWS —
+    //     which rejects (mixed-form / "Insufficient metrics"). The
+    //     correct gate is "non-empty array".
+    //
+    //   - Class 2 (structurally-incomplete-when-empty): `MetricName: ''`,
+    //     `Namespace: ''`, `Statistic: ''`, `Unit: ''`,
+    //     `TreatMissingData: ''` are the always-emit string placeholders.
+    //     Shipping them verbatim to `PutMetricAlarm` rejects ("MetricName
+    //     must be at least 1 character", invalid Statistic / Unit enum).
+    //     `AlarmDescription: ''` is also coerced for consistency: AWS
+    //     accepts an empty `AlarmDescription` but the placeholder reaching
+    //     AWS would silently CLEAR an existing description on a no-drift
+    //     round-trip — silent fail mode. Translate '' → undefined so the
+    //     field is omitted from the AWS call.
+    const emptyToUndefined = (v: unknown): string | undefined =>
+      typeof v === 'string' && v === '' ? undefined : (v as string | undefined);
+
     const params: Record<string, unknown> = {
       AlarmName: alarmName,
       ComparisonOperator: properties['ComparisonOperator'] as ComparisonOperator | undefined,
@@ -302,17 +329,19 @@ export class CloudWatchAlarmProvider implements ResourceProvider {
       Threshold: properties['Threshold'] as number | undefined,
       ActionsEnabled: properties['ActionsEnabled'] as boolean | undefined,
       AlarmActions: properties['AlarmActions'] as string[] | undefined,
-      AlarmDescription: properties['AlarmDescription'] as string | undefined,
+      AlarmDescription: emptyToUndefined(properties['AlarmDescription']),
       DatapointsToAlarm: properties['DatapointsToAlarm'] as number | undefined,
       InsufficientDataActions: properties['InsufficientDataActions'] as string[] | undefined,
       OKActions: properties['OKActions'] as string[] | undefined,
-      TreatMissingData: properties['TreatMissingData'] as string | undefined,
-      Unit: properties['Unit'] as StandardUnit | undefined,
+      TreatMissingData: emptyToUndefined(properties['TreatMissingData']),
+      Unit: emptyToUndefined(properties['Unit']) as StandardUnit | undefined,
     };
 
-    // Metrics array (math expressions / composite metrics)
-    if (properties['Metrics']) {
-      const metrics = properties['Metrics'] as Array<Record<string, unknown>>;
+    // Metrics array (math expressions / composite metrics).
+    // Truthy-gate fix: `[]` is truthy in JS — gate on non-empty array.
+    const metricsValue = properties['Metrics'];
+    if (Array.isArray(metricsValue) && metricsValue.length > 0) {
+      const metrics = metricsValue as Array<Record<string, unknown>>;
       params['Metrics'] = metrics.map((m) => {
         const entry: Record<string, unknown> = {
           Id: m['Id'] as string,
@@ -338,11 +367,12 @@ export class CloudWatchAlarmProvider implements ResourceProvider {
         return entry;
       });
     } else {
-      // Simple metric alarm (MetricName / Namespace / Dimensions)
-      params['MetricName'] = properties['MetricName'] as string | undefined;
-      params['Namespace'] = properties['Namespace'] as string | undefined;
+      // Simple metric alarm (MetricName / Namespace / Dimensions). Empty
+      // string placeholders → undefined so they never reach AWS.
+      params['MetricName'] = emptyToUndefined(properties['MetricName']);
+      params['Namespace'] = emptyToUndefined(properties['Namespace']);
       params['Period'] = properties['Period'] as number | undefined;
-      params['Statistic'] = properties['Statistic'] as Statistic | undefined;
+      params['Statistic'] = emptyToUndefined(properties['Statistic']) as Statistic | undefined;
       params['Dimensions'] = properties['Dimensions'] as
         | Array<{ Name: string; Value: string }>
         | undefined;

--- a/src/provisioning/providers/codebuild-provider.ts
+++ b/src/provisioning/providers/codebuild-provider.ts
@@ -126,7 +126,21 @@ export class CodeBuildProvider implements ResourceProvider {
     const name = (properties['Name'] as string | undefined) ?? logicalId;
     const source = properties['Source'] as Record<string, unknown> | undefined;
     const environment = properties['Environment'] as Record<string, unknown> | undefined;
-    const serviceRole = properties['ServiceRole'] as string | undefined;
+    // Class 2 sanitize (docs/provider-development.md § 3b): readCurrentState
+    // emits `''` placeholders for ServiceRole / EncryptionKey / SourceVersion
+    // so a console-side ADD on a project deployed without those keys
+    // surfaces as drift. Shipping `''` back through CreateProject /
+    // UpdateProject is structurally invalid — `serviceRole: ''` /
+    // `encryptionKey: ''` get rejected by the AWS API. Drop empty
+    // placeholders here so the wire layer never sees them; non-empty
+    // values pass through unchanged. Symmetric with the placeholder
+    // emit on the read side, mirroring `serializeRedrivePolicy` in
+    // src/provisioning/providers/sqs-queue-provider.ts.
+    const sanitizeOptionalString = (value: unknown): string | undefined => {
+      if (typeof value !== 'string') return value as string | undefined;
+      return value === '' ? undefined : value;
+    };
+    const serviceRole = sanitizeOptionalString(properties['ServiceRole']);
     const artifacts = properties['Artifacts'] as Record<string, unknown> | undefined;
     const tags = properties['Tags'] as Array<{ Key: string; Value: string }> | undefined;
 
@@ -278,7 +292,7 @@ export class CodeBuildProvider implements ResourceProvider {
       description: properties['Description'] as string | undefined,
       timeoutInMinutes: properties['TimeoutInMinutes'] as number | undefined,
       queuedTimeoutInMinutes: properties['QueuedTimeoutInMinutes'] as number | undefined,
-      encryptionKey: properties['EncryptionKey'] as string | undefined,
+      encryptionKey: sanitizeOptionalString(properties['EncryptionKey']),
       cache,
       vpcConfig,
       logsConfig,
@@ -289,7 +303,7 @@ export class CodeBuildProvider implements ResourceProvider {
       fileSystemLocations,
       buildBatchConfig,
       badgeEnabled: properties['BadgeEnabled'] as boolean | undefined,
-      sourceVersion: properties['SourceVersion'] as string | undefined,
+      sourceVersion: sanitizeOptionalString(properties['SourceVersion']),
     };
   }
 

--- a/src/provisioning/providers/cognito-provider.ts
+++ b/src/provisioning/providers/cognito-provider.ts
@@ -41,6 +41,37 @@ import type {
 } from '../../types/resource.js';
 
 /**
+ * Class 2 sanitize: empty `{}` placeholders that `readCurrentState` emits
+ * for sub-objects whose AWS schema requires a sub-field would be rejected
+ * by `UpdateUserPool` if shipped as-is. The known-rejected shapes:
+ *
+ * - `SmsConfiguration: {}`         — `SnsCallerArn` is required
+ * - `UsernameConfiguration: {}`    — `CaseSensitive` is required (also
+ *                                    immutable on update; AWS rejects any
+ *                                    UsernameConfiguration on UpdateUserPool
+ *                                    that differs from create-time, but a
+ *                                    no-drift round-trip should never reach
+ *                                    here in the first place)
+ * - `UserPoolAddOns: {}`           — `AdvancedSecurityMode` is required
+ *
+ * The other sub-objects emitted as `{}` placeholders (LambdaConfig,
+ * AdminCreateUserConfig, AccountRecoverySetting, UserAttributeUpdateSettings,
+ * EmailConfiguration, VerificationMessageTemplate, DeviceConfiguration)
+ * have all-optional sub-fields per the SDK types and AWS accepts the empty
+ * object as "no overrides / clear all".
+ *
+ * Returns `true` when the value is a non-null object with zero keys.
+ */
+function isEmptyObjectPlaceholder(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value as Record<string, unknown>).length === 0
+  );
+}
+
+/**
  * AWS Cognito User Pool Provider
  *
  * Implements resource provisioning for AWS::Cognito::UserPool using the Cognito SDK.
@@ -307,7 +338,14 @@ export class CognitoUserPoolProvider implements ResourceProvider {
           'EmailConfiguration'
         ] as EmailConfigurationType;
       }
-      if (properties['SmsConfiguration']) {
+      // Class 2 sanitize: `SmsConfiguration: {}` would be rejected by
+      // UpdateUserPool because `SnsCallerArn` is a required sub-field.
+      // Skip the empty-object placeholder so a no-drift round-trip
+      // (state == AWS, both empty) is a logical no-op.
+      if (
+        properties['SmsConfiguration'] &&
+        !isEmptyObjectPlaceholder(properties['SmsConfiguration'])
+      ) {
         updateParams.SmsConfiguration = properties['SmsConfiguration'] as SmsConfigurationType;
       }
       if (properties['VerificationMessageTemplate']) {
@@ -320,19 +358,27 @@ export class CognitoUserPoolProvider implements ResourceProvider {
           'DeviceConfiguration'
         ] as DeviceConfigurationType;
       }
-      if (properties['UserPoolAddOns']) {
+      // Class 2 sanitize: `UserPoolAddOns: {}` would be rejected because
+      // `AdvancedSecurityMode` is a required sub-field.
+      if (properties['UserPoolAddOns'] && !isEmptyObjectPlaceholder(properties['UserPoolAddOns'])) {
         updateParams.UserPoolAddOns = properties['UserPoolAddOns'] as UserPoolAddOnsType;
       }
-      if (properties['EmailVerificationMessage']) {
+      // `!== undefined` (not truthy) so empty-string placeholders that
+      // `readCurrentState` emits for unset message fields reach AWS — a
+      // truthy gate would silently drop `''` and `cdkd drift --revert`
+      // (which round-trips observed → desired) would report `✓ reverted`
+      // while leaving the AWS-side message untouched. The next drift run
+      // re-detects the same drift — silent fail.
+      if (properties['EmailVerificationMessage'] !== undefined) {
         updateParams.EmailVerificationMessage = properties['EmailVerificationMessage'] as string;
       }
-      if (properties['EmailVerificationSubject']) {
+      if (properties['EmailVerificationSubject'] !== undefined) {
         updateParams.EmailVerificationSubject = properties['EmailVerificationSubject'] as string;
       }
-      if (properties['SmsAuthenticationMessage']) {
+      if (properties['SmsAuthenticationMessage'] !== undefined) {
         updateParams.SmsAuthenticationMessage = properties['SmsAuthenticationMessage'] as string;
       }
-      if (properties['SmsVerificationMessage']) {
+      if (properties['SmsVerificationMessage'] !== undefined) {
         updateParams.SmsVerificationMessage = properties['SmsVerificationMessage'] as string;
       }
 

--- a/src/provisioning/providers/eventbridge-bus-provider.ts
+++ b/src/provisioning/providers/eventbridge-bus-provider.ts
@@ -33,6 +33,30 @@ import type {
 } from '../../types/resource.js';
 
 /**
+ * Sanitise a CFn-shape `DeadLetterConfig` (object with optional `Arn`) for
+ * the EventBridge `CreateEventBus` / `UpdateEventBus` API.
+ *
+ * `readCurrentState` always-emits `DeadLetterConfig: { Arn: '' }` on buses
+ * without a DLQ — the comparator's top-level walk is state-keys-only, so
+ * the placeholder is required to detect a console-side DLQ attach (state
+ * `{Arn:''}` vs AWS `{Arn:'real-arn'}`).
+ *
+ * `cdkd drift --revert` later round-trips that placeholder back through
+ * `update()`. AWS rejects `DeadLetterConfig: { Arn: '' }` as an invalid
+ * ARN, so this Class 2 sanitiser drops the placeholder before it reaches
+ * the API: empty-string / null / undefined `Arn` returns `undefined`
+ * (caller treats this as "do not send the DeadLetterConfig field"); a
+ * real ARN passes through unchanged.
+ */
+function sanitizeDeadLetterConfig(value: unknown): { Arn: string } | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value !== 'object') return undefined;
+  const arn = (value as Record<string, unknown>)['Arn'];
+  if (typeof arn !== 'string' || arn.length === 0) return undefined;
+  return { Arn: arn };
+}
+
+/**
  * SDK Provider for AWS::Events::EventBus
  *
  * Uses direct SDK calls instead of Cloud Control API because:
@@ -95,11 +119,9 @@ export class EventBridgeBusProvider implements ResourceProvider {
       if (properties['Tags']) {
         createParams.Tags = properties['Tags'] as Tag[];
       }
-      if (properties['DeadLetterConfig']) {
-        const dlcConfig = properties['DeadLetterConfig'] as Record<string, unknown>;
-        createParams.DeadLetterConfig = {
-          Arn: dlcConfig['Arn'] as string | undefined,
-        };
+      const dlcCreate = sanitizeDeadLetterConfig(properties['DeadLetterConfig']);
+      if (dlcCreate) {
+        createParams.DeadLetterConfig = dlcCreate;
       }
 
       const response = await this.eventBridgeClient.send(new CreateEventBusCommand(createParams));
@@ -157,11 +179,11 @@ export class EventBridgeBusProvider implements ResourceProvider {
       if (properties['KmsKeyIdentifier'] !== undefined) {
         updateParams.KmsKeyIdentifier = properties['KmsKeyIdentifier'] as string;
       }
-      if (properties['DeadLetterConfig']) {
-        const dlcConfig = properties['DeadLetterConfig'] as Record<string, unknown>;
-        updateParams.DeadLetterConfig = {
-          Arn: dlcConfig['Arn'] as string | undefined,
-        };
+      if (properties['DeadLetterConfig'] !== undefined) {
+        const dlcUpdate = sanitizeDeadLetterConfig(properties['DeadLetterConfig']);
+        if (dlcUpdate) {
+          updateParams.DeadLetterConfig = dlcUpdate;
+        }
       }
       await this.eventBridgeClient.send(new UpdateEventBusCommand(updateParams));
     }

--- a/src/provisioning/providers/firehose-provider.ts
+++ b/src/provisioning/providers/firehose-provider.ts
@@ -651,17 +651,21 @@ export class FirehoseProvider implements ResourceProvider {
     }
 
     // Tags via ListTagsForDeliveryStream.
+    // Always emit `Tags` (even as `[]`) per docs/provider-development.md
+    // § 3b "always emit user-controllable top-level keys": omitting the
+    // key on the failure path means the comparator's state-keys-only
+    // walk skips Tags forever, hiding console-side tag adds from drift.
     try {
       const tagsResp = await this.getClient().send(
         new ListTagsForDeliveryStreamCommand({ DeliveryStreamName: physicalId })
       );
-      const tags = normalizeAwsTagsToCfn(tagsResp.Tags);
-      result['Tags'] = tags;
+      result['Tags'] = normalizeAwsTagsToCfn(tagsResp.Tags);
     } catch (err) {
       if (err instanceof ResourceNotFoundException) return undefined;
       this.logger.debug(
         `Firehose ListTagsForDeliveryStream(${physicalId}) failed: ${err instanceof Error ? err.message : String(err)}`
       );
+      result['Tags'] = [];
     }
 
     return result;

--- a/src/provisioning/providers/kinesis-provider.ts
+++ b/src/provisioning/providers/kinesis-provider.ts
@@ -33,6 +33,25 @@ import type {
 } from '../../types/resource.js';
 
 /**
+ * Class 1/2 sanitize for `StreamEncryption` placeholder.
+ *
+ * `readCurrentState` always-emits `StreamEncryption: { EncryptionType:
+ * 'NONE' }` for unencrypted streams so the drift comparator can detect
+ * a console-side KMS attach (state-keys-only top-level walk needs the
+ * key present). On the write side, neither `StartStreamEncryption`
+ * (KMS-only) nor `StopStreamEncryption` accepts `NONE` as input —
+ * pushing the placeholder through `cdkd drift --revert` would trigger
+ * a ValidationException. This helper returns true only when the value
+ * represents real KMS encryption (sibling discriminator `EncryptionType
+ * === 'KMS'`); the create / update code paths gate every encryption-
+ * mutating SDK call on it.
+ */
+function isKmsEncryption(value: Record<string, unknown> | undefined): boolean {
+  if (!value) return false;
+  return value['EncryptionType'] === 'KMS';
+}
+
+/**
  * AWS Kinesis Stream Provider
  *
  * Implements resource provisioning for AWS::Kinesis::Stream using the Kinesis SDK.
@@ -148,18 +167,26 @@ export class KinesisStreamProvider implements ResourceProvider {
         await this.waitForStreamActive(streamName);
       }
 
-      // Apply StreamEncryption if specified
+      // Apply StreamEncryption if specified.
+      //
+      // Class 1/2 sanitize: `readCurrentState` always-emits
+      // `StreamEncryption: { EncryptionType: 'NONE' }` for unencrypted
+      // streams so the comparator can detect a console-side KMS attach.
+      // On the write side, `StartStreamEncryption` only accepts `KMS`;
+      // the AWS API has no "NONE" mode. Skip the call when the desired
+      // EncryptionType is anything but `KMS` so a placeholder round-
+      // trip via `cdkd drift --revert` does not push an AWS-invalid
+      // input.
       const streamEncryption = properties['StreamEncryption'] as
         | Record<string, unknown>
         | undefined;
-      if (streamEncryption) {
-        const encryptionType = (streamEncryption['EncryptionType'] as string) ?? 'KMS';
-        const keyId = streamEncryption['KeyId'] as string;
+      if (isKmsEncryption(streamEncryption)) {
+        const keyId = streamEncryption!['KeyId'] as string;
         this.logger.debug(`Enabling stream encryption for ${streamName}`);
         await this.getClient().send(
           new StartStreamEncryptionCommand({
             StreamName: streamName,
-            EncryptionType: encryptionType as EncryptionType,
+            EncryptionType: 'KMS' as EncryptionType,
             KeyId: keyId,
           })
         );
@@ -269,32 +296,47 @@ export class KinesisStreamProvider implements ResourceProvider {
         properties['Tags'] as Array<{ Key?: string; Value?: string }> | undefined
       );
 
-      // Update StreamEncryption if changed
+      // Update StreamEncryption if changed.
+      //
+      // Class 1/2 sanitize: `readCurrentState` always-emits
+      // `StreamEncryption: { EncryptionType: 'NONE' }` on unencrypted
+      // streams for drift detection. Treat the NONE placeholder as
+      // "no encryption" — it is NOT a valid input to either
+      // `StartStreamEncryption` (KMS-only) or `StopStreamEncryption`
+      // (encryption-removal). Only call:
+      //  - StopStreamEncryption when previous WAS KMS-encrypted.
+      //  - StartStreamEncryption when desired IS KMS-encrypted.
+      //
+      // Without this, a `cdkd drift --revert` round-trip on a stream
+      // that has never been KMS-encrypted would push `EncryptionType=NONE`
+      // back through the API and AWS rejects with a ValidationException.
       const newEncryption = properties['StreamEncryption'] as Record<string, unknown> | undefined;
       const oldEncryption = previousProperties['StreamEncryption'] as
         | Record<string, unknown>
         | undefined;
-      if (JSON.stringify(newEncryption) !== JSON.stringify(oldEncryption)) {
-        // Remove old encryption if it existed
-        if (oldEncryption) {
+      const oldIsKms = isKmsEncryption(oldEncryption);
+      const newIsKms = isKmsEncryption(newEncryption);
+      const oldKeyId = oldIsKms ? (oldEncryption!['KeyId'] as string | undefined) : undefined;
+      const newKeyId = newIsKms ? (newEncryption!['KeyId'] as string | undefined) : undefined;
+      if (oldIsKms !== newIsKms || (oldIsKms && newIsKms && oldKeyId !== newKeyId)) {
+        // Remove old encryption only when it WAS KMS-encrypted.
+        if (oldIsKms) {
           await this.getClient().send(
             new StopStreamEncryptionCommand({
               StreamName: physicalId,
-              EncryptionType: ((oldEncryption['EncryptionType'] as string) ??
-                'KMS') as EncryptionType,
-              KeyId: oldEncryption['KeyId'] as string,
+              EncryptionType: 'KMS' as EncryptionType,
+              KeyId: oldKeyId,
             })
           );
           await this.waitForStreamActive(physicalId);
         }
-        // Apply new encryption
-        if (newEncryption) {
+        // Apply new encryption only when it IS KMS-encrypted.
+        if (newIsKms) {
           await this.getClient().send(
             new StartStreamEncryptionCommand({
               StreamName: physicalId,
-              EncryptionType: ((newEncryption['EncryptionType'] as string) ??
-                'KMS') as EncryptionType,
-              KeyId: newEncryption['KeyId'] as string,
+              EncryptionType: 'KMS' as EncryptionType,
+              KeyId: newKeyId,
             })
           );
           await this.waitForStreamActive(physicalId);
@@ -472,10 +514,17 @@ export class KinesisStreamProvider implements ResourceProvider {
 
     const result: Record<string, unknown> = {};
     if (stream.StreamName !== undefined) result['Name'] = stream.StreamName;
-    if (stream.StreamModeDetails?.StreamMode !== undefined) {
-      result['StreamModeDetails'] = { StreamMode: stream.StreamModeDetails.StreamMode };
+    const streamMode = stream.StreamModeDetails?.StreamMode;
+    if (streamMode !== undefined) {
+      result['StreamModeDetails'] = { StreamMode: streamMode };
     }
-    if (stream.Shards && stream.Shards.length > 0) {
+    // Class 1 — `ShardCount` is PROVISIONED-only. AWS rejects
+    // `UpdateShardCount` on ON_DEMAND streams; emitting a `ShardCount`
+    // placeholder there would surface as a `cdkd drift --revert`
+    // failure on the round-trip. ON_DEMAND streams report shards too
+    // (capacity is managed by AWS), so gating on `Shards.length` is
+    // not enough — the type discriminator is `StreamMode`.
+    if (streamMode === 'PROVISIONED' && stream.Shards && stream.Shards.length > 0) {
       result['ShardCount'] = stream.Shards.length;
     }
     if (stream.RetentionPeriodHours !== undefined) {

--- a/src/provisioning/providers/logs-loggroup-provider.ts
+++ b/src/provisioning/providers/logs-loggroup-provider.ts
@@ -336,6 +336,20 @@ export class LogsLogGroupProvider implements ResourceProvider {
   }
 
   /**
+   * Drift comparator skip-list: properties readCurrentState deliberately
+   * cannot round-trip from AWS yet. `DataProtectionPolicy` lives behind
+   * its own `GetDataProtectionPolicy` API call (not in
+   * `DescribeLogGroups` output) — declaring it here prevents
+   * guaranteed false-positive drift on every clean run for log groups
+   * deployed with a data-protection policy. Lifting this guard requires
+   * a per-group `GetDataProtectionPolicy` round-trip in
+   * `readCurrentState`.
+   */
+  getDriftUnknownPaths(): string[] {
+    return ['DataProtectionPolicy'];
+  }
+
+  /**
    * Read the AWS-current log group configuration in CFn-property shape.
    *
    * Issues `DescribeLogGroups` filtered by exact name and picks the first
@@ -373,26 +387,33 @@ export class LogsLogGroupProvider implements ResourceProvider {
       const result: Record<string, unknown> = {};
       if (found.logGroupName !== undefined) result['LogGroupName'] = found.logGroupName;
       result['KmsKeyId'] = found.kmsKeyId ?? '';
-      if (found.retentionInDays !== undefined) {
-        result['RetentionInDays'] = found.retentionInDays;
-      }
+      // Always-emit per docs/provider-development.md § 3b: a console-side
+      // attach of a retention policy on a previously-unbounded log group
+      // must surface as drift. `0` is the semantic "never expire"
+      // placeholder — it maps to `DeleteRetentionPolicyCommand` in
+      // update()'s truthy gate, so the round-trip is a no-op when state
+      // and AWS both have no retention.
+      result['RetentionInDays'] = found.retentionInDays ?? 0;
       if (found.logGroupClass !== undefined) result['LogGroupClass'] = found.logGroupClass;
 
       // Tags via ListTagsForResource. Logs ARNs include a trailing ":*"
       // wildcard that ListTagsForResource rejects — strip it.
+      let tags: Array<{ Key: string; Value: string }> = [];
       if (found.arn) {
         const arnForTags = found.arn.replace(/:\*$/, '');
         try {
           const tagsResp = await this.logsClient.send(
             new ListTagsForResourceCommand({ resourceArn: arnForTags })
           );
-          const tags = normalizeAwsTagsToCfn(tagsResp.tags);
-          result['Tags'] = tags;
+          tags = normalizeAwsTagsToCfn(tagsResp.tags);
         } catch (err) {
           if (err instanceof ResourceNotFoundException) return undefined;
           throw err;
         }
       }
+      // Always-emit: a console-side tag add on an initially-untagged log
+      // group must surface as drift (state=[] vs AWS=[{...}]).
+      result['Tags'] = tags;
 
       return result;
     } catch (err) {

--- a/src/provisioning/providers/s3-vectors-provider.ts
+++ b/src/provisioning/providers/s3-vectors-provider.ts
@@ -275,10 +275,18 @@ export class S3VectorsProvider implements ResourceProvider {
     }
     if (bucket?.encryptionConfiguration) {
       const enc: Record<string, unknown> = {};
-      if (bucket.encryptionConfiguration.sseType !== undefined) {
-        enc['SSEType'] = bucket.encryptionConfiguration.sseType;
+      const sseType = bucket.encryptionConfiguration.sseType;
+      if (sseType !== undefined) {
+        enc['SSEType'] = sseType;
       }
-      if (bucket.encryptionConfiguration.kmsKeyArn !== undefined) {
+      // Class 1 guard (docs/provider-development.md § 3b): KMSKeyArn is
+      // KMS-only — only valid when SSEType === 'aws:kms'. AWS will not
+      // return kmsKeyArn for AES256-encrypted buckets, but defend
+      // against a future SDK that surfaces an account-default KMS key
+      // ARN on AES256 responses (which would round-trip back via
+      // `cdkd drift --revert` and AWS would reject as
+      // "KMSKeyArn is only valid when SSEType is aws:kms").
+      if (sseType === 'aws:kms' && bucket.encryptionConfiguration.kmsKeyArn !== undefined) {
         enc['KMSKeyArn'] = bucket.encryptionConfiguration.kmsKeyArn;
       }
       if (Object.keys(enc).length > 0) result['EncryptionConfiguration'] = enc;

--- a/src/provisioning/providers/servicediscovery-provider.ts
+++ b/src/provisioning/providers/servicediscovery-provider.ts
@@ -497,6 +497,25 @@ export class ServiceDiscoveryProvider implements ResourceProvider {
     }
   }
 
+  /**
+   * Declare drift-unreadable property paths.
+   *
+   * - `AWS::ServiceDiscovery::PrivateDnsNamespace.Vpc`: Cloud Map's
+   *   `GetNamespace` does NOT return the VPC ID — it is only consumed at
+   *   create time and surfaced in opaque form via
+   *   `Properties.DnsProperties.HostedZoneId`. Without this declaration
+   *   the comparator would walk into `Vpc` (state has it because cdkd
+   *   stored the user-supplied template value) and report a guaranteed
+   *   false-positive on every clean drift run, since `readCurrentState`
+   *   deliberately omits the key.
+   */
+  getDriftUnknownPaths(resourceType: string): string[] {
+    if (resourceType === 'AWS::ServiceDiscovery::PrivateDnsNamespace') {
+      return ['Vpc'];
+    }
+    return [];
+  }
+
   private async readNamespace(physicalId: string): Promise<Record<string, unknown> | undefined> {
     let ns;
     try {

--- a/src/provisioning/providers/sns-subscription-provider.ts
+++ b/src/provisioning/providers/sns-subscription-provider.ts
@@ -77,9 +77,17 @@ export class SNSSubscriptionProvider implements ResourceProvider {
     try {
       const attributes: Record<string, string> = {};
 
-      // Set FilterPolicy if provided
+      // Set FilterPolicy if provided.
+      //
+      // `!== undefined` (not truthy) so an explicit empty string / empty
+      // object reaches `Subscribe` — AWS treats an empty `FilterPolicy`
+      // as "no filter, match all messages", which is the documented way
+      // to clear an existing FilterPolicy. A truthy gate would silently
+      // drop the placeholder when `cdkd drift --revert` round-trips an
+      // observedProperties snapshot taken after a console-side filter
+      // removal.
       const filterPolicy = properties['FilterPolicy'];
-      if (filterPolicy) {
+      if (filterPolicy !== undefined) {
         attributes['FilterPolicy'] =
           typeof filterPolicy === 'string' ? filterPolicy : JSON.stringify(filterPolicy);
       }

--- a/src/provisioning/providers/ssm-parameter-provider.ts
+++ b/src/provisioning/providers/ssm-parameter-provider.ts
@@ -171,19 +171,26 @@ export class SSMParameterProvider implements ResourceProvider {
         Name: physicalId,
         Type: type as ParameterType,
         Value: value,
-        Description: properties['Description'] as string | undefined,
         Overwrite: true,
       };
-      if (properties['AllowedPattern']) {
+      // `!== undefined` (not truthy) so empty Description / AllowedPattern
+      // ('') from `readCurrentState`'s placeholders reaches `PutParameterCommand`
+      // on the `cdkd drift --revert` round-trip. A truthy gate would silently
+      // drop the empty string and leave the AWS-side value untouched — drift
+      // would report `✓ reverted` but the next run re-detects the same drift.
+      if (properties['Description'] !== undefined) {
+        putParams.Description = properties['Description'] as string;
+      }
+      if (properties['AllowedPattern'] !== undefined) {
         putParams.AllowedPattern = properties['AllowedPattern'] as string;
       }
-      if (properties['Tier']) {
+      if (properties['Tier'] !== undefined) {
         putParams.Tier = properties['Tier'] as import('@aws-sdk/client-ssm').ParameterTier;
       }
-      if (properties['Policies']) {
+      if (properties['Policies'] !== undefined) {
         putParams.Policies = properties['Policies'] as string;
       }
-      if (properties['DataType']) {
+      if (properties['DataType'] !== undefined) {
         putParams.DataType = properties['DataType'] as string;
       }
 

--- a/src/provisioning/providers/stepfunctions-provider.ts
+++ b/src/provisioning/providers/stepfunctions-provider.ts
@@ -101,32 +101,24 @@ export class StepFunctionsProvider implements ResourceProvider {
         tags = tagList.map((tag) => ({ key: tag.Key, value: tag.Value }));
       }
 
-      // Map EncryptionConfiguration (CFn PascalCase -> SDK camelCase)
-      const cfnEncConfig = properties['EncryptionConfiguration'] as
-        | Record<string, unknown>
-        | undefined;
-      let encryptionConfiguration: EncryptionConfiguration | undefined;
-      if (cfnEncConfig) {
-        encryptionConfiguration = {
-          type: cfnEncConfig['Type'] as EncryptionConfiguration['type'],
-          kmsKeyId: cfnEncConfig['KmsKeyId'] as string | undefined,
-          kmsDataKeyReusePeriodSeconds: cfnEncConfig['KmsDataKeyReusePeriodSeconds'] as
-            | number
-            | undefined,
-        };
-      }
+      // Translate every CFn-PascalCase nested object to the SDK's
+      // camelCase shape (see helpers at file scope). All three mappers
+      // also fold the Class 2 empty-placeholder case to `undefined` so
+      // `cdkd drift --revert` round-trips through `update()` without AWS
+      // rejecting a structurally incomplete payload.
+      const encryptionConfiguration = mapEncryptionConfiguration(
+        properties['EncryptionConfiguration']
+      );
+      const loggingConfiguration = mapLoggingConfiguration(properties['LoggingConfiguration']);
+      const tracingConfiguration = mapTracingConfiguration(properties['TracingConfiguration']);
 
       const createParams: CreateStateMachineCommandInput = {
         name: stateMachineName,
         definition: definitionString,
         roleArn: roleArn,
         type: properties['StateMachineType'] as StateMachineType | undefined,
-        loggingConfiguration: properties['LoggingConfiguration'] as
-          | LoggingConfiguration
-          | undefined,
-        tracingConfiguration: properties['TracingConfiguration'] as
-          | TracingConfiguration
-          | undefined,
+        loggingConfiguration,
+        tracingConfiguration,
         tags: tags,
         encryptionConfiguration,
       };
@@ -181,32 +173,33 @@ export class StepFunctionsProvider implements ResourceProvider {
     try {
       const definitionString = this.buildDefinitionString(properties);
 
-      // Map EncryptionConfiguration for update
-      const cfnEncConfig = properties['EncryptionConfiguration'] as
-        | Record<string, unknown>
-        | undefined;
-      let encryptionConfiguration: EncryptionConfiguration | undefined;
-      if (cfnEncConfig) {
-        encryptionConfiguration = {
-          type: cfnEncConfig['Type'] as EncryptionConfiguration['type'],
-          kmsKeyId: cfnEncConfig['KmsKeyId'] as string | undefined,
-          kmsDataKeyReusePeriodSeconds: cfnEncConfig['KmsDataKeyReusePeriodSeconds'] as
-            | number
-            | undefined,
-        };
-      }
+      // Translate every CFn-PascalCase nested object to the SDK's
+      // camelCase shape (see helpers below). All three mappers also fold
+      // the Class 2 empty-placeholder case to `undefined` so `cdkd drift
+      // --revert` round-trips through `update()` without AWS rejecting a
+      // structurally incomplete payload (`encryptionConfiguration` requires
+      // `type`; `loggingConfiguration` without `level` would silently
+      // disable logging).
+      //
+      // BEFORE THIS FIX `properties['LoggingConfiguration']` (CFn PascalCase
+      // from cdkd state) was cast straight to the SDK camelCase type — the
+      // cast is a no-op at runtime, so AWS received the wrong shape and
+      // silently ignored Level / IncludeExecutionData / Destinations, which
+      // surfaced as `cdkd drift --revert` reporting `✓ reverted` while the
+      // very next `cdkd drift` re-detected the same drift.
+      const encryptionConfiguration = mapEncryptionConfiguration(
+        properties['EncryptionConfiguration']
+      );
+      const loggingConfiguration = mapLoggingConfiguration(properties['LoggingConfiguration']);
+      const tracingConfiguration = mapTracingConfiguration(properties['TracingConfiguration']);
 
       await this.getClient().send(
         new UpdateStateMachineCommand({
           stateMachineArn: physicalId,
           definition: definitionString,
           roleArn: properties['RoleArn'] as string | undefined,
-          loggingConfiguration: properties['LoggingConfiguration'] as
-            | LoggingConfiguration
-            | undefined,
-          tracingConfiguration: properties['TracingConfiguration'] as
-            | TracingConfiguration
-            | undefined,
+          loggingConfiguration,
+          tracingConfiguration,
           encryptionConfiguration,
         })
       );
@@ -535,4 +528,81 @@ export class StepFunctionsProvider implements ResourceProvider {
     // for consistent error reporting from the API
     return '{}';
   }
+}
+
+/**
+ * Translate a CFn-shape `EncryptionConfiguration` (PascalCase) into the SDK's
+ * camelCase shape, or `undefined` if the value is absent / a Class 2
+ * empty-object placeholder.
+ *
+ * `readCurrentState` always-emits `EncryptionConfiguration: {}` on state
+ * machines with no encryption — the comparator's top-level walk is
+ * state-keys-only, so the placeholder is required to detect a console-side
+ * encryption attach.  `cdkd drift --revert` later round-trips that
+ * placeholder back through `update()`. AWS rejects an `encryptionConfiguration`
+ * whose required `type` field is missing ("Member must not be null"), so an
+ * empty placeholder is folded to `undefined` here (no-op on the wire).
+ */
+function mapEncryptionConfiguration(value: unknown): EncryptionConfiguration | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value !== 'object') return undefined;
+  const cfg = value as Record<string, unknown>;
+  // Class 2 sanitize: empty placeholder => no-op
+  if (cfg['Type'] === undefined) return undefined;
+  return {
+    type: cfg['Type'] as EncryptionConfiguration['type'],
+    kmsKeyId: cfg['KmsKeyId'] as string | undefined,
+    kmsDataKeyReusePeriodSeconds: cfg['KmsDataKeyReusePeriodSeconds'] as number | undefined,
+  };
+}
+
+/**
+ * Translate a CFn-shape `LoggingConfiguration` (PascalCase) into the SDK's
+ * camelCase shape, or `undefined` for the empty placeholder case (no `Level`).
+ *
+ * `readCurrentState` always-emits `LoggingConfiguration: {}` (no `Level`) on
+ * state machines that never configured logging.  Forwarding that placeholder
+ * to `UpdateStateMachine` would inadvertently set `level=OFF` and disable
+ * logging on a state machine that has logging configured outside cdkd's
+ * managed view — fold to `undefined` here so the placeholder round-trip is
+ * a no-op.
+ */
+function mapLoggingConfiguration(value: unknown): LoggingConfiguration | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value !== 'object') return undefined;
+  const cfg = value as Record<string, unknown>;
+  // Class 2 sanitize: empty placeholder (no Level) => no-op
+  if (cfg['Level'] === undefined) return undefined;
+  const result: LoggingConfiguration = {
+    level: cfg['Level'] as LoggingConfiguration['level'],
+  };
+  if (cfg['IncludeExecutionData'] !== undefined) {
+    result.includeExecutionData = cfg['IncludeExecutionData'] as boolean;
+  }
+  if (Array.isArray(cfg['Destinations'])) {
+    result.destinations = (cfg['Destinations'] as Array<Record<string, unknown>>).map((d) => {
+      const cwLogs = d['CloudWatchLogsLogGroup'] as Record<string, unknown> | undefined;
+      if (cwLogs?.['LogGroupArn'] !== undefined) {
+        return {
+          cloudWatchLogsLogGroup: { logGroupArn: cwLogs['LogGroupArn'] as string },
+        };
+      }
+      return {};
+    });
+  }
+  return result;
+}
+
+/**
+ * Translate a CFn-shape `TracingConfiguration` (PascalCase) into the SDK's
+ * camelCase shape.  `readCurrentState` always-emits `{ Enabled: false }` (the
+ * AWS default), so no Class 2 sanitize is needed — the round-trip simply
+ * reaffirms the existing tracing setting.
+ */
+function mapTracingConfiguration(value: unknown): TracingConfiguration | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value !== 'object') return undefined;
+  const cfg = value as Record<string, unknown>;
+  if (cfg['Enabled'] === undefined) return undefined;
+  return { enabled: cfg['Enabled'] as boolean };
 }

--- a/src/provisioning/providers/wafv2-provider.ts
+++ b/src/provisioning/providers/wafv2-provider.ts
@@ -33,6 +33,27 @@ import type {
 } from '../../types/resource.js';
 
 /**
+ * Translate the empty-string placeholder `readCurrentState` emits for an
+ * absent `Description` to `undefined` before shipping it to AWS.
+ *
+ * `readCurrentState` always-emits `Description: ''` on a WebACL with no
+ * description (the comparator's top-level walk is state-keys-only, so
+ * the placeholder is required to detect a console-side description add).
+ * AWS WAFv2 `CreateWebACL` / `UpdateWebACL` reject `Description: ''`
+ * with `Member must have length greater than or equal to 1` (min 1 / max
+ * 256). On `cdkd drift --revert` the placeholder would round-trip
+ * through `update()` and surface as a hard AWS rejection, so we sanitize
+ * the wire-layer payload while keeping the read-side placeholder
+ * intact. This is the Class 2 pattern from
+ * `docs/provider-development.md § 3b`.
+ */
+function sanitizeDescription(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string' && value.length === 0) return undefined;
+  return value as string;
+}
+
+/**
  * Parse WAFv2 WebACL ARN to extract Id, Name, and Scope.
  *
  * ARN format:
@@ -127,7 +148,7 @@ export class WAFv2WebACLProvider implements ResourceProvider {
           Name: name,
           Scope: scope,
           DefaultAction: properties['DefaultAction'] as DefaultAction,
-          Description: properties['Description'] as string | undefined,
+          Description: sanitizeDescription(properties['Description']),
           Rules: (properties['Rules'] as Rule[]) || [],
           VisibilityConfig: properties['VisibilityConfig'] as VisibilityConfig,
           ...(tags.length > 0 && { Tags: tags }),
@@ -208,7 +229,7 @@ export class WAFv2WebACLProvider implements ResourceProvider {
           Id: id,
           LockToken: lockToken,
           DefaultAction: properties['DefaultAction'] as DefaultAction,
-          Description: properties['Description'] as string | undefined,
+          Description: sanitizeDescription(properties['Description']),
           Rules: (properties['Rules'] as Rule[]) || [],
           VisibilityConfig: properties['VisibilityConfig'] as VisibilityConfig,
           CustomResponseBodies: properties['CustomResponseBodies'] as

--- a/tests/unit/provisioning/agentcore-runtime-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/agentcore-runtime-provider-roundtrip.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateAgentRuntimeCommand } from '@aws-sdk/client-bedrock-agentcore-control';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    bedrockAgentCoreControl: {
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { AgentCoreRuntimeProvider } from '../../../src/provisioning/providers/agentcore-runtime-provider.js';
+
+const RUNTIME_ID = 'runtime-12345';
+const RESOURCE_TYPE = 'AWS::BedrockAgentCore::Runtime';
+
+describe('AgentCoreRuntimeProvider read-update round-trip', () => {
+  let provider: AgentCoreRuntimeProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new AgentCoreRuntimeProvider();
+  });
+
+  it('round-trip: readCurrentState placeholders survive update() without AWS-invalid inputs', async () => {
+    // Mechanical guard for the 3 latent bug classes documented in
+    // docs/provider-development.md § 3b "Read-update round-trip test".
+    //
+    //   - Truthy gate: empty Description ('') from readCurrentState
+    //     must reach UpdateAgentRuntime input (the field is optional,
+    //     and AWS accepts '' as the clear-the-description form).
+    //   - Class 1: agentcore has no top-level discriminator-dependent
+    //     properties — every top-level CFn key is independent. The
+    //     check below documents that intent: no FIFO-style
+    //     discriminator-only attribute should sneak into update input.
+    //   - Class 2: no top-level placeholder is an empty-object /
+    //     empty-array shape AWS would structurally reject. The
+    //     LifecycleConfiguration empty-object guard in update() (lines
+    //     269-274) is verified explicitly below.
+
+    // Step 1: produce an observed snapshot via readCurrentState.
+    // AWS-minimum response: required fields only; optionals undefined
+    // except Description which AWS surfaced as ''. This matches the
+    // shape readCurrentState emits in `agentcore-runtime-provider-
+    // readcurrentstate.test.ts`.
+    mockSend.mockResolvedValueOnce({
+      agentRuntimeId: RUNTIME_ID,
+      agentRuntimeName: 'my-runtime',
+      roleArn: 'arn:aws:iam::123456789012:role/my-role',
+      description: '',
+      agentRuntimeArtifact: {
+        containerConfiguration: {
+          containerUri: '123.dkr.ecr.us-east-1.amazonaws.com/img:latest',
+        },
+      },
+      networkConfiguration: { networkMode: 'PUBLIC' },
+    });
+
+    const observed = await provider.readCurrentState(RUNTIME_ID, 'L', RESOURCE_TYPE);
+
+    // Spot-check Description placeholder reached observed (truthy-gate
+    // contract: '' must NOT be dropped on the read side).
+    expect(observed?.Description).toBe('');
+
+    // Step 2: round-trip observed back through update().
+    vi.clearAllMocks();
+    mockSend.mockResolvedValueOnce({
+      agentRuntimeId: RUNTIME_ID,
+      agentRuntimeArn: `arn:aws:bedrock-agentcore:us-east-1:123:runtime/${RUNTIME_ID}`,
+      agentRuntimeVersion: '2',
+      createdAt: new Date(),
+      lastUpdatedAt: new Date(),
+      status: 'READY',
+    });
+
+    await provider.update('L', RUNTIME_ID, RESOURCE_TYPE, observed!, observed!);
+
+    // Step 3: assertions.
+    const updateCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UpdateAgentRuntimeCommand
+    );
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as Record<string, unknown>;
+
+    // Truthy-gate: empty Description must reach AWS as '' (not dropped,
+    // not coerced). Verifies `if (properties['Description'] !==
+    // undefined)` in update() is honoured on the round-trip path.
+    expect(input['description']).toBe('');
+
+    // Class 1 sentinel: agentcore has no top-level discriminator-only
+    // attributes. If a future PR adds one (mirroring SQS
+    // DeduplicationScope or SNS FifoThroughputScope), this test will
+    // need to be updated to assert that the discriminator-false
+    // placeholder doesn't appear in update input. For now, document
+    // the absence by asserting the input only contains keys the
+    // provider's update() actually maps.
+    const allowedKeys = new Set([
+      'agentRuntimeId',
+      'roleArn',
+      'agentRuntimeArtifact',
+      'networkConfiguration',
+      'description',
+      'authorizerConfiguration',
+      'protocolConfiguration',
+      'lifecycleConfiguration',
+      'environmentVariables',
+      'clientToken',
+    ]);
+    for (const key of Object.keys(input)) {
+      expect(allowedKeys.has(key)).toBe(true);
+    }
+
+    // Class 2 sentinel: no empty-object placeholder should ride along.
+    // The two structurally-rejecting candidates on agentcore are
+    // LifecycleConfiguration ({} drops idleRuntimeSessionTimeout /
+    // maxLifetime) and NetworkConfiguration ({} drops the required
+    // networkMode). A clean snapshot with networkMode set must NOT
+    // produce an empty-object NetworkConfiguration; LifecycleConfig
+    // omitted from the snapshot must NOT appear as {} in input.
+    if (input['lifecycleConfiguration'] !== undefined) {
+      expect(
+        Object.keys(input['lifecycleConfiguration'] as Record<string, unknown>).length
+      ).toBeGreaterThan(0);
+    }
+    if (input['networkConfiguration'] !== undefined) {
+      const nc = input['networkConfiguration'] as Record<string, unknown>;
+      expect(nc['networkMode']).toBeDefined();
+    }
+  });
+
+  it('Class 2 — empty LifecycleConfiguration ({}) is NOT forwarded to UpdateAgentRuntime', async () => {
+    // Even if a downstream caller hands update() an empty
+    // LifecycleConfiguration object (e.g. from a CFn template `{}`), the
+    // update() guard at lines 269-274 must keep it out of input.
+    mockSend.mockResolvedValueOnce({
+      agentRuntimeId: RUNTIME_ID,
+      agentRuntimeArn: `arn:aws:bedrock-agentcore:us-east-1:123:runtime/${RUNTIME_ID}`,
+      agentRuntimeVersion: '2',
+      createdAt: new Date(),
+      lastUpdatedAt: new Date(),
+      status: 'READY',
+    });
+
+    await provider.update(
+      'L',
+      RUNTIME_ID,
+      RESOURCE_TYPE,
+      {
+        AgentRuntimeName: 'my-runtime',
+        RoleArn: 'arn:aws:iam::123456789012:role/my-role',
+        AgentRuntimeArtifact: {
+          ContainerConfiguration: {
+            ContainerUri: '123.dkr.ecr.us-east-1.amazonaws.com/img:latest',
+          },
+        },
+        NetworkConfiguration: { NetworkMode: 'PUBLIC' },
+        LifecycleConfiguration: {},
+      },
+      {}
+    );
+
+    const updateCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UpdateAgentRuntimeCommand
+    );
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as Record<string, unknown>;
+    expect(input['lifecycleConfiguration']).toBeUndefined();
+  });
+
+  it('truthy-gate — empty-string Description from observedProperties reaches UpdateAgentRuntime as ""', async () => {
+    // Direct guard: the IAM-Role-style "use !== undefined, not truthy"
+    // contract must hold so `cdkd drift --revert` can clear an
+    // AWS-side description by pushing '' back.
+    mockSend.mockResolvedValueOnce({
+      agentRuntimeId: RUNTIME_ID,
+      agentRuntimeArn: `arn:aws:bedrock-agentcore:us-east-1:123:runtime/${RUNTIME_ID}`,
+      agentRuntimeVersion: '2',
+      createdAt: new Date(),
+      lastUpdatedAt: new Date(),
+      status: 'READY',
+    });
+
+    await provider.update(
+      'L',
+      RUNTIME_ID,
+      RESOURCE_TYPE,
+      {
+        AgentRuntimeName: 'my-runtime',
+        RoleArn: 'arn:aws:iam::123456789012:role/my-role',
+        Description: '',
+      },
+      {
+        AgentRuntimeName: 'my-runtime',
+        RoleArn: 'arn:aws:iam::123456789012:role/my-role',
+        Description: 'old description',
+      }
+    );
+
+    const updateCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UpdateAgentRuntimeCommand
+    );
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as Record<string, unknown>;
+    expect(input['description']).toBe('');
+  });
+});

--- a/tests/unit/provisioning/cloudtrail-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/cloudtrail-provider-readcurrentstate.test.ts
@@ -85,6 +85,8 @@ describe('CloudTrailProvider.readCurrentState', () => {
       IncludeGlobalServiceEvents: true,
       EnableLogFileValidation: true,
       KMSKeyId: 'arn:aws:kms:us-east-1:1:key/abc',
+      SnsTopicName: '',
+      IsOrganizationTrail: false,
       IsLogging: true,
       EventSelectors: [{ ReadWriteType: 'All', IncludeManagementEvents: true }],
       Tags: [],
@@ -101,9 +103,22 @@ describe('CloudTrailProvider.readCurrentState', () => {
 
     const result = await provider.readCurrentState('mytrail', 'L', 'AWS::CloudTrail::Trail');
 
+    // Always-emit placeholders survive even when secondary calls fail —
+    // only `IsLogging` (GetTrailStatus) and `EventSelectors`
+    // (GetEventSelectors) drop out (no synthetic placeholders for those
+    // since the call may be AccessDenied rather than "feature absent").
+    // Tags falls back to `[]` because TrailARN is missing on this fixture.
     expect(result).toEqual({
       TrailName: 'mytrail',
       S3BucketName: 'mybucket',
+      S3KeyPrefix: '',
+      IsMultiRegionTrail: false,
+      IncludeGlobalServiceEvents: true,
+      EnableLogFileValidation: false,
+      KMSKeyId: '',
+      SnsTopicName: '',
+      IsOrganizationTrail: false,
+      Tags: [],
     });
   });
 

--- a/tests/unit/provisioning/cloudtrail-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/cloudtrail-provider-roundtrip.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  UpdateTrailCommand,
+  PutEventSelectorsCommand,
+} from '@aws-sdk/client-cloudtrail';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-cloudtrail', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-cloudtrail')>(
+    '@aws-sdk/client-cloudtrail'
+  );
+  return {
+    ...actual,
+    CloudTrailClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { CloudTrailProvider } from '../../../src/provisioning/providers/cloudtrail-provider.js';
+
+const TRAIL_ARN = 'arn:aws:cloudtrail:us-east-1:1:trail/mytrail';
+const RESOURCE_TYPE = 'AWS::CloudTrail::Trail';
+
+describe('CloudTrailProvider read-update round-trip', () => {
+  let provider: CloudTrailProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new CloudTrailProvider();
+  });
+
+  it('Class 1 — CW-logs-disabled trail does not push empty CW log ARNs to AWS on round-trip', async () => {
+    // readCurrentState on a CW-logs-disabled trail must NOT emit
+    // CloudWatchLogsLogGroupArn / CloudWatchLogsRoleArn at all (the
+    // discriminator-pair guard). Round-tripping an observed snapshot
+    // through update() must therefore not include those keys, so AWS
+    // never sees the rejection-shape input
+    // (`CloudWatchLogsLogGroupArn is not in valid ARN format`).
+    const observed = {
+      TrailName: 'mytrail',
+      S3BucketName: 'mybucket',
+      S3KeyPrefix: '',
+      IsMultiRegionTrail: false,
+      IncludeGlobalServiceEvents: true,
+      EnableLogFileValidation: false,
+      KMSKeyId: '',
+      SnsTopicName: '',
+      IsOrganizationTrail: false,
+      IsLogging: true,
+      EventSelectors: [],
+      Tags: [] as Array<{ Key: string; Value: string }>,
+      // CloudWatchLogsLogGroupArn / CloudWatchLogsRoleArn intentionally
+      // absent — Class 1 guard kicks in at readCurrentState.
+    };
+
+    // SDK sends: UpdateTrail (no CW logs change → no PutEventSelectors,
+    // no IsLogging change → no Start/Stop, no tag diff).
+    mockSend.mockResolvedValueOnce({});
+
+    await provider.update('L', TRAIL_ARN, RESOURCE_TYPE, observed, observed);
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateTrailCommand);
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as {
+      CloudWatchLogsLogGroupArn?: string;
+      CloudWatchLogsRoleArn?: string;
+      KmsKeyId?: string;
+      SnsTopicName?: string;
+    };
+    // None of the empty-placeholder ARN-shaped fields reach AWS.
+    expect(input.CloudWatchLogsLogGroupArn).toBeUndefined();
+    expect(input.CloudWatchLogsRoleArn).toBeUndefined();
+    expect(input.KmsKeyId).toBeUndefined();
+    expect(input.SnsTopicName).toBeUndefined();
+  });
+
+  it('Class 2 — empty-string ARN placeholders are sanitized to undefined at the wire layer', async () => {
+    // Even if a caller (or a future readCurrentState bug) passes
+    // explicit empty strings for the ARN-shaped fields, the wire-layer
+    // sanitizer must convert them to undefined so AWS does not reject
+    // with "is not in valid ARN format".
+    const observed = {
+      TrailName: 'mytrail',
+      S3BucketName: 'mybucket',
+      KMSKeyId: '',
+      SnsTopicName: '',
+      CloudWatchLogsLogGroupArn: '',
+      CloudWatchLogsRoleArn: '',
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValueOnce({});
+
+    await provider.update('L', TRAIL_ARN, RESOURCE_TYPE, observed, observed);
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateTrailCommand);
+    const input = updateCall![0].input as Record<string, unknown>;
+    expect(input['KmsKeyId']).toBeUndefined();
+    expect(input['SnsTopicName']).toBeUndefined();
+    expect(input['CloudWatchLogsLogGroupArn']).toBeUndefined();
+    expect(input['CloudWatchLogsRoleArn']).toBeUndefined();
+    // None of them reach AWS as ''.
+    for (const key of [
+      'KmsKeyId',
+      'SnsTopicName',
+      'CloudWatchLogsLogGroupArn',
+      'CloudWatchLogsRoleArn',
+    ]) {
+      expect(input[key]).not.toBe('');
+    }
+  });
+
+  it('round-trip on no-drift snapshot does not call PutEventSelectors with empty list', async () => {
+    // EventSelectors: [] both old and new — the diff-based gate must
+    // NOT call PutEventSelectors at all (since the JSON.stringify
+    // comparison is equal for two empty arrays).
+    const observed = {
+      TrailName: 'mytrail',
+      S3BucketName: 'mybucket',
+      S3KeyPrefix: '',
+      IsMultiRegionTrail: false,
+      IncludeGlobalServiceEvents: true,
+      EnableLogFileValidation: false,
+      KMSKeyId: '',
+      SnsTopicName: '',
+      IsOrganizationTrail: false,
+      IsLogging: true,
+      EventSelectors: [] as unknown[],
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValueOnce({});
+
+    await provider.update('L', TRAIL_ARN, RESOURCE_TYPE, observed, observed);
+
+    const putSelectorsCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PutEventSelectorsCommand
+    );
+    expect(putSelectorsCalls).toHaveLength(0);
+  });
+
+  it('FIFO-equivalent — populated ARN fields round-trip without sanitization to undefined', async () => {
+    // Complement of the Class 1 / Class 2 tests: a populated ARN value
+    // must reach AWS unchanged. (No drift, so update is a logical no-
+    // op, but the wire-layer values still need to round-trip.)
+    const observed = {
+      TrailName: 'mytrail',
+      S3BucketName: 'mybucket',
+      KMSKeyId: 'arn:aws:kms:us-east-1:1:key/abc',
+      SnsTopicName: 'arn:aws:sns:us-east-1:1:my-topic',
+      CloudWatchLogsLogGroupArn: 'arn:aws:logs:us-east-1:1:log-group:/aws/cloudtrail/mytrail:*',
+      CloudWatchLogsRoleArn: 'arn:aws:iam::1:role/CloudTrailLogsRole',
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValueOnce({});
+
+    await provider.update('L', TRAIL_ARN, RESOURCE_TYPE, observed, observed);
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateTrailCommand);
+    const input = updateCall![0].input as Record<string, unknown>;
+    expect(input['KmsKeyId']).toBe('arn:aws:kms:us-east-1:1:key/abc');
+    expect(input['SnsTopicName']).toBe('arn:aws:sns:us-east-1:1:my-topic');
+    expect(input['CloudWatchLogsLogGroupArn']).toBe(
+      'arn:aws:logs:us-east-1:1:log-group:/aws/cloudtrail/mytrail:*'
+    );
+    expect(input['CloudWatchLogsRoleArn']).toBe('arn:aws:iam::1:role/CloudTrailLogsRole');
+  });
+});

--- a/tests/unit/provisioning/cloudwatch-alarm-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/cloudwatch-alarm-provider-roundtrip.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PutMetricAlarmCommand } from '@aws-sdk/client-cloudwatch';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    cloudWatch: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { CloudWatchAlarmProvider } from '../../../src/provisioning/providers/cloudwatch-alarm-provider.js';
+
+const ALARM_NAME = 'myalarm';
+const ALARM_ARN = 'arn:aws:cloudwatch:us-east-1:1:alarm:myalarm';
+const RESOURCE_TYPE = 'AWS::CloudWatch::Alarm';
+
+/**
+ * Mechanical guard for Class 1 (type-discriminator) and Class 2
+ * (structurally-incomplete-when-empty) placeholder regressions on the
+ * `cdkd drift --revert` round-trip. See docs/provider-development.md
+ * § 3b "Read-update round-trip test" and the canonical
+ * `sns-topic-provider-roundtrip.test.ts` / `sqs-queue-provider-update.test.ts`.
+ *
+ * `readCurrentState` always-emits placeholders (`MetricName: ''`,
+ * `Statistic: ''`, `Metrics: []`, ...) so the drift comparator can detect
+ * a console-side ADD on a key the alarm wasn't templated with. That same
+ * snapshot is round-tripped through `update()` by `--revert`. The tests
+ * below assert that none of those placeholders reach `PutMetricAlarm` in
+ * an AWS-rejection shape.
+ */
+describe('CloudWatchAlarmProvider read-update round-trip', () => {
+  let provider: CloudWatchAlarmProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new CloudWatchAlarmProvider();
+  });
+
+  it('Class 1 — metric-style alarm with placeholder Metrics:[] does not route to metric-math branch', async () => {
+    // Empty array is TRUTHY in JS. A naive `if (properties['Metrics'])`
+    // would have shipped `Metrics: []` to PutMetricAlarm on a metric-style
+    // alarm whose observed snapshot carries the always-emit placeholder,
+    // mixing the two mutually-exclusive forms and getting rejected by AWS.
+    //
+    // Mock DescribeAlarms (used by getAlarmArn after PutMetricAlarm):
+    mockSend.mockResolvedValue({ MetricAlarms: [{ AlarmArn: ALARM_ARN }] });
+
+    const observed = {
+      AlarmName: ALARM_NAME,
+      AlarmDescription: 'desc',
+      MetricName: 'CPUUtilization',
+      Namespace: 'AWS/EC2',
+      Statistic: 'Average',
+      ComparisonOperator: 'GreaterThanThreshold',
+      Threshold: 80,
+      EvaluationPeriods: 2,
+      Period: 60,
+      DatapointsToAlarm: 1,
+      ActionsEnabled: true,
+      AlarmActions: [],
+      OKActions: [],
+      InsufficientDataActions: [],
+      TreatMissingData: 'notBreaching',
+      Unit: '',
+      Dimensions: [{ Name: 'InstanceId', Value: 'i-abc' }],
+      Metrics: [], // <-- the load-bearing always-emit placeholder
+      Tags: [],
+    };
+
+    await provider.update('L', ALARM_NAME, RESOURCE_TYPE, observed, observed);
+
+    const putCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof PutMetricAlarmCommand
+    );
+    expect(putCall).toBeDefined();
+    const input = putCall![0].input as Record<string, unknown>;
+    // Truthy-gate fix: Metrics:[] must NOT route to the metric-math
+    // branch. The simple-metric fields must be present instead.
+    expect(input['Metrics']).toBeUndefined();
+    expect(input['MetricName']).toBe('CPUUtilization');
+    expect(input['Namespace']).toBe('AWS/EC2');
+    expect(input['Statistic']).toBe('Average');
+  });
+
+  it('Class 2 — empty-string placeholders for MetricName/Namespace/Statistic/Unit/TreatMissingData/AlarmDescription do not reach AWS', async () => {
+    // `readCurrentState` emits `'' ` placeholders for several optional
+    // string fields. Shipping those verbatim to PutMetricAlarm would be
+    // rejected ("MetricName must be at least 1 character", invalid
+    // Statistic / Unit enum) or — worse, in the AlarmDescription case —
+    // would silently CLEAR an existing description on a no-drift
+    // round-trip (silent fail mode). The wire layer must coerce '' →
+    // undefined.
+    mockSend.mockResolvedValue({ MetricAlarms: [{ AlarmArn: ALARM_ARN }] });
+
+    const observed = {
+      AlarmName: ALARM_NAME,
+      AlarmDescription: '',
+      MetricName: '',
+      Namespace: '',
+      Statistic: '',
+      Unit: '',
+      TreatMissingData: '',
+      ActionsEnabled: true,
+      AlarmActions: [],
+      OKActions: [],
+      InsufficientDataActions: [],
+      Dimensions: [],
+      Metrics: [],
+      Tags: [],
+    };
+
+    await provider.update('L', ALARM_NAME, RESOURCE_TYPE, observed, observed);
+
+    const putCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof PutMetricAlarmCommand
+    );
+    expect(putCall).toBeDefined();
+    const input = putCall![0].input as Record<string, unknown>;
+    // Each empty-string placeholder must be omitted (undefined), not
+    // shipped as ''.
+    expect(input['AlarmDescription']).toBeUndefined();
+    expect(input['MetricName']).toBeUndefined();
+    expect(input['Namespace']).toBeUndefined();
+    expect(input['Statistic']).toBeUndefined();
+    expect(input['Unit']).toBeUndefined();
+    expect(input['TreatMissingData']).toBeUndefined();
+  });
+
+  it('metric-math alarm with non-empty Metrics routes to metric-math branch (truthy-gate fix preserves the original behavior)', async () => {
+    // Complement of the Class 1 test: a real metric-math alarm must
+    // continue to route into the Metrics branch, and the empty-string
+    // placeholders for MetricName / Namespace / Statistic must NOT leak
+    // through. The metric-math branch already does NOT set those fields,
+    // but we assert it explicitly to lock the behavior.
+    mockSend.mockResolvedValue({ MetricAlarms: [{ AlarmArn: ALARM_ARN }] });
+
+    const observed = {
+      AlarmName: ALARM_NAME,
+      AlarmDescription: '',
+      MetricName: '', // placeholder — must NOT reach AWS
+      Namespace: '',
+      Statistic: '',
+      Unit: '',
+      TreatMissingData: '',
+      ComparisonOperator: 'GreaterThanThreshold',
+      Threshold: 1,
+      EvaluationPeriods: 1,
+      ActionsEnabled: true,
+      AlarmActions: [],
+      OKActions: [],
+      InsufficientDataActions: [],
+      Dimensions: [],
+      Metrics: [
+        {
+          Id: 'm1',
+          Expression: 'm0 / 60',
+          Label: 'rate',
+          ReturnData: true,
+        },
+      ],
+      Tags: [],
+    };
+
+    await provider.update('L', ALARM_NAME, RESOURCE_TYPE, observed, observed);
+
+    const putCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof PutMetricAlarmCommand
+    );
+    expect(putCall).toBeDefined();
+    const input = putCall![0].input as Record<string, unknown>;
+    expect(Array.isArray(input['Metrics'])).toBe(true);
+    expect((input['Metrics'] as unknown[]).length).toBe(1);
+    // Metric-math branch must not set the simple-metric discriminator
+    // fields (mixing the two forms is a PutMetricAlarm validation error).
+    expect(input['MetricName']).toBeUndefined();
+    expect(input['Namespace']).toBeUndefined();
+    expect(input['Statistic']).toBeUndefined();
+  });
+});

--- a/tests/unit/provisioning/codebuild-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/codebuild-provider-roundtrip.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  BatchGetProjectsCommand,
+  CreateProjectCommand,
+  UpdateProjectCommand,
+} from '@aws-sdk/client-codebuild';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-codebuild', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-codebuild')>(
+    '@aws-sdk/client-codebuild'
+  );
+  return {
+    ...actual,
+    CodeBuildClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { CodeBuildProvider } from '../../../src/provisioning/providers/codebuild-provider.js';
+
+const RESOURCE_TYPE = 'AWS::CodeBuild::Project';
+
+describe('CodeBuildProvider read-update round-trip', () => {
+  let provider: CodeBuildProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new CodeBuildProvider();
+  });
+
+  it('Class 2 sanitize: empty-string ServiceRole / EncryptionKey / SourceVersion placeholders are dropped before UpdateProject', async () => {
+    // Mechanical guard for Class 2 placeholder regression on
+    // structurally-incomplete-when-empty fields. See
+    // docs/provider-development.md § 3b "Read-update round-trip test".
+    //
+    // readCurrentState emits `''` placeholders for ServiceRole /
+    // EncryptionKey / SourceVersion so a console-side ADD on a project
+    // deployed without those keys surfaces as drift. But shipping `''`
+    // back through UpdateProject is invalid — AWS rejects empty
+    // serviceRole / encryptionKey strings. The sanitize layer in
+    // mapProperties must drop the empty placeholders so the SDK call
+    // never sees them.
+
+    // Mirror the readCurrentState shape for a project deployed without
+    // ServiceRole / EncryptionKey / SourceVersion (CodeBuild always
+    // requires a ServiceRole at create-time, but the round-trip test
+    // exercises the sanitize symmetry — what readCurrentState would
+    // emit on `serviceRole: undefined`).
+    const observed = {
+      Name: 'myproj',
+      Description: '',
+      ServiceRole: '',
+      EncryptionKey: '',
+      BadgeEnabled: false,
+      SourceVersion: '',
+      Source: { Type: 'NO_SOURCE' },
+      Artifacts: { Type: 'NO_ARTIFACTS' },
+      Environment: {
+        Type: 'LINUX_CONTAINER',
+        Image: 'aws/codebuild/standard:7.0',
+        ComputeType: 'BUILD_GENERAL1_SMALL',
+        EnvironmentVariables: [],
+      },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValueOnce({ project: { name: 'myproj', arn: 'arn:1' } });
+
+    await provider.update('L', 'myproj', RESOURCE_TYPE, observed, observed);
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateProjectCommand);
+    expect(updateCall).toBeDefined();
+    const input = (updateCall![0] as UpdateProjectCommand).input;
+
+    // Class 2 sanitize assertions — empty-string placeholders must NOT
+    // reach the SDK call (AWS would reject them).
+    expect(input.serviceRole).toBeUndefined();
+    expect(input.encryptionKey).toBeUndefined();
+    expect(input.sourceVersion).toBeUndefined();
+  });
+
+  it('Class 2 sanitize: non-empty ServiceRole / EncryptionKey / SourceVersion pass through unchanged', async () => {
+    // Complement of the empty-string test: real values must NOT be
+    // sanitized away.
+    const observed = {
+      Name: 'myproj',
+      Description: 'd',
+      ServiceRole: 'arn:aws:iam::1:role/r',
+      EncryptionKey: 'arn:aws:kms:us-east-1:1:key/abc',
+      BadgeEnabled: false,
+      SourceVersion: 'main',
+      Source: { Type: 'GITHUB', Location: 'https://x' },
+      Artifacts: { Type: 'NO_ARTIFACTS' },
+      Environment: {
+        Type: 'LINUX_CONTAINER',
+        Image: 'aws/codebuild/standard:7.0',
+        ComputeType: 'BUILD_GENERAL1_SMALL',
+        EnvironmentVariables: [],
+      },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValueOnce({ project: { name: 'myproj', arn: 'arn:1' } });
+
+    await provider.update('L', 'myproj', RESOURCE_TYPE, observed, observed);
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateProjectCommand);
+    expect(updateCall).toBeDefined();
+    const input = (updateCall![0] as UpdateProjectCommand).input;
+
+    expect(input.serviceRole).toBe('arn:aws:iam::1:role/r');
+    expect(input.encryptionKey).toBe('arn:aws:kms:us-east-1:1:key/abc');
+    expect(input.sourceVersion).toBe('main');
+  });
+
+  it('round-trip: readCurrentState observed snapshot survives update() without AWS-invalid empty-string inputs', async () => {
+    // Full pipeline: readCurrentState -> update. Mocks the AWS-minimum
+    // BatchGetProjects response (only required fields, optionals
+    // undefined), captures the observed snapshot, then round-trips it
+    // back through update() and asserts no AWS-rejection-shape values
+    // reach the SDK.
+
+    // 1. readCurrentState on a minimum-shape project (no description,
+    //    no role returned, no encryption key, no badge, no source
+    //    version).
+    mockSend.mockResolvedValueOnce({
+      projects: [
+        {
+          name: 'myproj',
+          source: { type: 'NO_SOURCE' },
+          artifacts: { type: 'NO_ARTIFACTS' },
+          environment: {
+            type: 'LINUX_CONTAINER',
+            image: 'aws/codebuild/standard:7.0',
+            computeType: 'BUILD_GENERAL1_SMALL',
+          },
+        },
+      ],
+    });
+
+    const observed = await provider.readCurrentState('myproj', 'L', RESOURCE_TYPE);
+    expect(observed).toBeDefined();
+
+    // Confirm the always-emit placeholders are present (these are what
+    // would be re-shipped on --revert).
+    expect(observed!['Description']).toBe('');
+    expect(observed!['ServiceRole']).toBe('');
+    expect(observed!['EncryptionKey']).toBe('');
+    expect(observed!['BadgeEnabled']).toBe(false);
+    expect(observed!['SourceVersion']).toBe('');
+
+    // 2. Round-trip: pass observed as both new and old.
+    vi.clearAllMocks();
+    mockSend.mockResolvedValueOnce({ project: { name: 'myproj', arn: 'arn:1' } });
+
+    await provider.update('L', 'myproj', RESOURCE_TYPE, observed!, observed!);
+
+    // 3. Inspect the UpdateProject input — Class 2 sanitize must have
+    //    dropped every empty-string placeholder.
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateProjectCommand);
+    expect(updateCall).toBeDefined();
+    const input = (updateCall![0] as UpdateProjectCommand).input;
+
+    expect(input.serviceRole).toBeUndefined();
+    expect(input.encryptionKey).toBeUndefined();
+    expect(input.sourceVersion).toBeUndefined();
+    // Description '' is allowed by AWS UpdateProject (clears the
+    // description) — it is NOT sanitized away. Verify it passes
+    // through.
+    expect(input.description).toBe('');
+  });
+
+  it('Class 1 audit: BadgeEnabled placeholder ships safely on round-trip (no discriminator dependency)', async () => {
+    // CodeBuild has no Class 1 type-discriminator-dependent top-level
+    // fields among the always-emit set. BadgeEnabled is universally
+    // applicable across source types (incl. NO_SOURCE — AWS accepts
+    // false but the badge URL is not generated). This test pins that
+    // assumption: shipping `BadgeEnabled: false` on a NO_SOURCE
+    // project must NOT throw or surface as an AWS-rejection-shape
+    // input.
+    const observed = {
+      Name: 'myproj',
+      Description: '',
+      ServiceRole: 'arn:aws:iam::1:role/r',
+      EncryptionKey: '',
+      BadgeEnabled: false,
+      SourceVersion: '',
+      Source: { Type: 'NO_SOURCE' },
+      Artifacts: { Type: 'NO_ARTIFACTS' },
+      Environment: {
+        Type: 'LINUX_CONTAINER',
+        Image: 'aws/codebuild/standard:7.0',
+        ComputeType: 'BUILD_GENERAL1_SMALL',
+        EnvironmentVariables: [],
+      },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValueOnce({ project: { name: 'myproj', arn: 'arn:1' } });
+
+    await expect(
+      provider.update('L', 'myproj', RESOURCE_TYPE, observed, observed)
+    ).resolves.toBeDefined();
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateProjectCommand);
+    expect(updateCall).toBeDefined();
+    const input = (updateCall![0] as UpdateProjectCommand).input;
+    expect(input.badgeEnabled).toBe(false);
+    expect(input.source?.type).toBe('NO_SOURCE');
+  });
+
+  it('create round-trip also sanitizes empty-string placeholders', async () => {
+    // mapProperties is shared between create() and update(), so the
+    // Class 2 sanitize applies to create as well. A user importing a
+    // project via cdkd import that round-trips a readCurrentState
+    // snapshot back through create() (e.g. accidental drop of state
+    // followed by re-deploy) must not see AWS-rejection-shape inputs
+    // either.
+    const observed = {
+      Name: 'myproj',
+      Description: '',
+      ServiceRole: '',
+      EncryptionKey: '',
+      BadgeEnabled: false,
+      SourceVersion: '',
+      Source: { Type: 'NO_SOURCE' },
+      Artifacts: { Type: 'NO_ARTIFACTS' },
+      Environment: {
+        Type: 'LINUX_CONTAINER',
+        Image: 'aws/codebuild/standard:7.0',
+        ComputeType: 'BUILD_GENERAL1_SMALL',
+        EnvironmentVariables: [],
+      },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValueOnce({ project: { name: 'myproj', arn: 'arn:1' } });
+
+    await provider.create('L', RESOURCE_TYPE, observed);
+
+    const createCall = mockSend.mock.calls.find((c) => c[0] instanceof CreateProjectCommand);
+    expect(createCall).toBeDefined();
+    const input = (createCall![0] as CreateProjectCommand).input;
+
+    expect(input.serviceRole).toBeUndefined();
+    expect(input.encryptionKey).toBeUndefined();
+    expect(input.sourceVersion).toBeUndefined();
+  });
+
+  // Suppress unused-import warning for BatchGetProjectsCommand (used by
+  // readCurrentState pipeline test path indirectly through mockSend).
+  it('imports stay live', () => {
+    expect(BatchGetProjectsCommand).toBeDefined();
+  });
+});

--- a/tests/unit/provisioning/cognito-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/cognito-provider-roundtrip.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateUserPoolCommand } from '@aws-sdk/client-cognito-identity-provider';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-cognito-identity-provider', async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    CognitoIdentityProviderClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { CognitoUserPoolProvider } from '../../../src/provisioning/providers/cognito-provider.js';
+
+const PHYS_ID = 'us-east-1_abcd';
+
+describe('CognitoUserPoolProvider read-update round-trip', () => {
+  let provider: CognitoUserPoolProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new CognitoUserPoolProvider();
+  });
+
+  // Mechanical guard for Class 2 placeholder regression on
+  // structurally-incomplete-when-empty sub-objects. See
+  // docs/provider-development.md § 3b.
+  //
+  // `SmsConfiguration: {}` would be rejected by UpdateUserPool with
+  // "Required attribute SnsCallerArn missing" because SnsCallerArn is
+  // a required sub-field. The provider must NOT include an empty-object
+  // placeholder on the round-trip update.
+  it('Class 2 — SmsConfiguration empty-object placeholder is NOT shipped on round-trip', async () => {
+    // The DescribeUserPool inside update() returns enough to build the
+    // post-update attributes block.
+    mockSend.mockResolvedValueOnce({}); // UpdateUserPool
+    mockSend.mockResolvedValueOnce({
+      UserPool: { Arn: `arn:aws:cognito-idp:us-east-1:0:userpool/${PHYS_ID}` },
+    }); // DescribeUserPool
+
+    const observed = {
+      UserPoolName: 'p',
+      AutoVerifiedAttributes: [],
+      UsernameAttributes: [],
+      AliasAttributes: [],
+      Policies: {},
+      LambdaConfig: {},
+      MfaConfiguration: 'OFF',
+      AdminCreateUserConfig: {},
+      AccountRecoverySetting: {},
+      UserAttributeUpdateSettings: {},
+      DeletionProtection: 'INACTIVE',
+      EmailConfiguration: {},
+      SmsConfiguration: {}, // Class 2 placeholder
+      VerificationMessageTemplate: {},
+      UsernameConfiguration: {},
+      DeviceConfiguration: {},
+      UserPoolAddOns: {}, // Class 2 placeholder
+      EmailVerificationMessage: '',
+      EmailVerificationSubject: '',
+      SmsAuthenticationMessage: '',
+      SmsVerificationMessage: '',
+      UserPoolTags: {},
+    };
+
+    await provider.update('L', PHYS_ID, 'AWS::Cognito::UserPool', observed, observed);
+
+    const updateCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UpdateUserPoolCommand
+    );
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as Record<string, unknown>;
+
+    // Class 2: empty-object placeholders must NOT reach the wire.
+    expect(input.SmsConfiguration).toBeUndefined();
+    expect(input.UserPoolAddOns).toBeUndefined();
+  });
+
+  // Mechanical guard for Class 2 — non-empty SmsConfiguration / UserPoolAddOns
+  // (i.e. the user has actually configured them) MUST still reach AWS.
+  // Otherwise the sanitize would silently swallow legitimate updates.
+  it('Class 2 — non-empty SmsConfiguration / UserPoolAddOns still reach UpdateUserPool', async () => {
+    mockSend.mockResolvedValueOnce({}); // UpdateUserPool
+    mockSend.mockResolvedValueOnce({
+      UserPool: { Arn: `arn:aws:cognito-idp:us-east-1:0:userpool/${PHYS_ID}` },
+    }); // DescribeUserPool
+
+    const observed = {
+      UserPoolName: 'p',
+      SmsConfiguration: { SnsCallerArn: 'arn:aws:iam::0:role/SmsRole' },
+      UserPoolAddOns: { AdvancedSecurityMode: 'ENFORCED' },
+    };
+
+    await provider.update('L', PHYS_ID, 'AWS::Cognito::UserPool', observed, observed);
+
+    const updateCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UpdateUserPoolCommand
+    );
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as Record<string, unknown>;
+
+    expect(input.SmsConfiguration).toEqual({ SnsCallerArn: 'arn:aws:iam::0:role/SmsRole' });
+    expect(input.UserPoolAddOns).toEqual({ AdvancedSecurityMode: 'ENFORCED' });
+  });
+
+  // Mechanical guard for the truthy-gate failure mode on string fields
+  // where empty-string is a legal AWS-clear value. See
+  // docs/provider-development.md § 3b "update() must gate optional
+  // fields on `!== undefined`, not truthy".
+  //
+  // When state has `EmailVerificationMessage: ''` (placeholder for "no
+  // override") and AWS-side has a real message, `cdkd drift --revert`
+  // pushes `''` back through update(). A truthy gate would silently
+  // drop the empty string, the AWS update succeeds without clearing
+  // the message, `--revert` reports `✓ reverted`, and the next drift
+  // re-detects the same drift.
+  it('truthy-gate — empty-string message placeholders DO reach UpdateUserPool input', async () => {
+    mockSend.mockResolvedValueOnce({}); // UpdateUserPool
+    mockSend.mockResolvedValueOnce({
+      UserPool: { Arn: `arn:aws:cognito-idp:us-east-1:0:userpool/${PHYS_ID}` },
+    }); // DescribeUserPool
+
+    const observed = {
+      UserPoolName: 'p',
+      EmailVerificationMessage: '',
+      EmailVerificationSubject: '',
+      SmsAuthenticationMessage: '',
+      SmsVerificationMessage: '',
+    };
+
+    await provider.update('L', PHYS_ID, 'AWS::Cognito::UserPool', observed, observed);
+
+    const updateCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UpdateUserPoolCommand
+    );
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as Record<string, unknown>;
+
+    // The empty-string placeholders MUST reach AWS (it's the documented
+    // way to clear these fields). A truthy gate would drop them.
+    expect(input.EmailVerificationMessage).toBe('');
+    expect(input.EmailVerificationSubject).toBe('');
+    expect(input.SmsAuthenticationMessage).toBe('');
+    expect(input.SmsVerificationMessage).toBe('');
+  });
+
+  // Full no-drift round-trip: every always-emit placeholder from
+  // readCurrentState's minimum-response output goes straight back
+  // through update() and AWS receives no rejection-shaped value.
+  it('full round-trip on minimum-response observed snapshot ships no AWS-rejection-shaped values', async () => {
+    mockSend.mockResolvedValueOnce({}); // UpdateUserPool
+    mockSend.mockResolvedValueOnce({
+      UserPool: { Arn: `arn:aws:cognito-idp:us-east-1:0:userpool/${PHYS_ID}` },
+    }); // DescribeUserPool
+
+    // Mirrors the "AWS minimum response" key set asserted in
+    // cognito-provider-readcurrentstate.test.ts.
+    const observed = {
+      UserPoolName: 'p',
+      AutoVerifiedAttributes: [],
+      UsernameAttributes: [],
+      AliasAttributes: [],
+      Policies: {},
+      LambdaConfig: {},
+      MfaConfiguration: 'OFF',
+      AdminCreateUserConfig: {},
+      AccountRecoverySetting: {},
+      UserAttributeUpdateSettings: {},
+      DeletionProtection: 'INACTIVE',
+      EmailConfiguration: {},
+      SmsConfiguration: {},
+      VerificationMessageTemplate: {},
+      UsernameConfiguration: {},
+      DeviceConfiguration: {},
+      UserPoolAddOns: {},
+      EmailVerificationMessage: '',
+      EmailVerificationSubject: '',
+      SmsAuthenticationMessage: '',
+      SmsVerificationMessage: '',
+      UserPoolTags: {},
+    };
+
+    await expect(
+      provider.update('L', PHYS_ID, 'AWS::Cognito::UserPool', observed, observed)
+    ).resolves.toBeDefined();
+
+    const updateCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UpdateUserPoolCommand
+    );
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as Record<string, unknown>;
+
+    // The known AWS-rejection-shaped values are the empty placeholders
+    // for required-sub-field types.
+    expect(input.SmsConfiguration).toBeUndefined();
+    expect(input.UserPoolAddOns).toBeUndefined();
+
+    // UserPoolId is always set (sanity).
+    expect(input.UserPoolId).toBe(PHYS_ID);
+  });
+});

--- a/tests/unit/provisioning/efs-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/efs-provider-roundtrip.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-efs', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-efs')>(
+    '@aws-sdk/client-efs'
+  );
+  return {
+    ...actual,
+    EFSClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { EFSProvider } from '../../../src/provisioning/providers/efs-provider.js';
+import { ResourceUpdateNotSupportedError } from '../../../src/utils/error-handler.js';
+
+describe('EFSProvider read-update round-trip', () => {
+  let provider: EFSProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new EFSProvider();
+  });
+
+  // ─── AWS::EFS::FileSystem ────────────────────────────────────────────
+
+  it('FileSystem: update() rejects with ResourceUpdateNotSupportedError on round-trip and sends NO AWS calls', async () => {
+    // EFS update() is unsupported for every type (PR I — see CLAUDE.md).
+    // Class 1 (KmsKeyId / ProvisionedThroughputInMibps) and Class 2
+    // (BackupPolicy / LifecyclePolicies) placeholder regressions cannot
+    // surface here as AWS-rejection-shaped wire calls because update()
+    // never reaches the SDK. The structural guard for cdkd drift
+    // --revert is therefore: update() rejects the round-trip and emits
+    // zero AWS API calls so the operator gets a clear "use --replace"
+    // message instead of a partial AWS mutation.
+
+    // Build the AWS-current-style snapshot that readCurrentState would
+    // produce for a bursting, encrypted FileSystem with no lifecycle /
+    // backup configured. KmsKeyId omitted (Class 1: only valid on
+    // Encrypted=true — the read side gates on AWS returning it, so
+    // observed never carries KmsKeyId on Encrypted=false). Same for
+    // ProvisionedThroughputInMibps (only valid on
+    // ThroughputMode=provisioned).
+    const observed = {
+      PerformanceMode: 'generalPurpose',
+      ThroughputMode: 'bursting',
+      Encrypted: false,
+      FileSystemTags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await expect(
+      provider.update('L', 'fs-1', 'AWS::EFS::FileSystem', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    // Critical: no AWS API call ever fired — observed placeholders
+    // cannot reach the wire, so Class 1 / Class 2 false-positives
+    // cannot manifest on EFS until update() is implemented.
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('FileSystem: KmsKeyId placeholder (Class 1) round-trip rejects without sending any wire call', async () => {
+    // Defensive variant — even if a future caller hand-builds an
+    // observed snapshot that DOES carry KmsKeyId on a non-encrypted
+    // FileSystem, the round-trip must still reject and emit zero AWS
+    // calls. update() being a hard reject is what protects against
+    // KmsKeyId-on-Encrypted=false / ProvisionedThroughputInMibps-on-
+    // bursting-throughput Class 1 regressions reaching the wire.
+    const observed = {
+      PerformanceMode: 'generalPurpose',
+      ThroughputMode: 'provisioned',
+      ProvisionedThroughputInMibps: 100,
+      Encrypted: true,
+      KmsKeyId: 'arn:aws:kms:us-east-1:1:key/abc',
+      LifecyclePolicies: [],
+      BackupPolicy: { Status: 'ENABLED' },
+      FileSystemTags: [{ Key: 'k', Value: 'v' }],
+    };
+
+    await expect(
+      provider.update('L', 'fs-1', 'AWS::EFS::FileSystem', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  // ─── AWS::EFS::AccessPoint ───────────────────────────────────────────
+
+  it('AccessPoint: update() rejects with ResourceUpdateNotSupportedError on round-trip and sends NO AWS calls', async () => {
+    const observed = {
+      FileSystemId: 'fs-1',
+      PosixUser: { Uid: 1000, Gid: 1000 },
+      RootDirectory: {
+        Path: '/data',
+        CreationInfo: { OwnerUid: 1000, OwnerGid: 1000, Permissions: '755' },
+      },
+    };
+
+    await expect(
+      provider.update('L', 'fsap-1', 'AWS::EFS::AccessPoint', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  // ─── AWS::EFS::MountTarget ───────────────────────────────────────────
+
+  it('MountTarget: update() rejects with ResourceUpdateNotSupportedError on round-trip and sends NO AWS calls', async () => {
+    const observed = {
+      FileSystemId: 'fs-1',
+      SubnetId: 'subnet-1',
+    };
+
+    await expect(
+      provider.update('L', 'fsmt-1', 'AWS::EFS::MountTarget', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  // ─── Error message guidance (operator-facing) ────────────────────────
+
+  it('rejection message points at the --replace / re-deploy escape hatch', async () => {
+    // The reject message is what cdkd drift --revert surfaces as the
+    // ⊘ "could not revert" line for the operator. Verify the canonical
+    // EFS guidance string is present so a future refactor of the error
+    // text doesn't silently lose the actionable hint.
+    const observed = {
+      PerformanceMode: 'generalPurpose',
+      ThroughputMode: 'bursting',
+      Encrypted: false,
+      FileSystemTags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await expect(
+      provider.update('L', 'fs-1', 'AWS::EFS::FileSystem', observed, observed)
+    ).rejects.toThrow(/recreated on property changes/);
+  });
+});

--- a/tests/unit/provisioning/eventbridge-bus-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/eventbridge-bus-provider-roundtrip.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CreateEventBusCommand,
+  UpdateEventBusCommand,
+} from '@aws-sdk/client-eventbridge';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    eventBridge: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { EventBridgeBusProvider } from '../../../src/provisioning/providers/eventbridge-bus-provider.js';
+
+const RESOURCE_TYPE = 'AWS::Events::EventBus';
+const BUS_NAME = 'my-bus';
+const BUS_ARN = `arn:aws:events:us-east-1:0:event-bus/${BUS_NAME}`;
+
+describe('EventBridgeBusProvider read-update round-trip', () => {
+  let provider: EventBridgeBusProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new EventBridgeBusProvider();
+  });
+
+  it('Class 2 — DeadLetterConfig {Arn:""} placeholder never reaches AWS on round-trip', async () => {
+    // Mechanical guard for Class 2 placeholder regression on
+    // structurally-incomplete-when-empty fields. See
+    // docs/provider-development.md § 3b "Read-update round-trip test".
+    //
+    // readCurrentState always-emits DeadLetterConfig: { Arn: '' } on
+    // buses without a DLQ (the comparator's top-level walk is
+    // state-keys-only, so the placeholder is required for drift
+    // detection on console-side DLQ attach).
+    //
+    // cdkd drift --revert later round-trips that placeholder back
+    // through update(). AWS rejects `DeadLetterConfig: { Arn: '' }` as
+    // an invalid ARN. The fix sanitises at the wire layer in update()
+    // (and create()): empty-Arn placeholder is dropped before reaching
+    // UpdateEventBusCommand.
+
+    // Build observed snapshot directly (matches what readCurrentState
+    // would produce for a bus with no DLC; readCurrentState is
+    // exercised by its own dedicated test file).
+    const observed = {
+      Name: BUS_NAME,
+      Description: '',
+      KmsKeyIdentifier: '',
+      DeadLetterConfig: { Arn: '' },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    // Force the dlc branch to fire by passing a different "old"
+    // (otherwise dlcChanged is false and we'd never observe the bug).
+    const previous = {
+      ...observed,
+      DeadLetterConfig: { Arn: 'arn:aws:sqs:us-east-1:0:dlq' },
+    };
+
+    mockSend.mockResolvedValue({ Arn: BUS_ARN }); // covers all sends
+
+    await provider.update('L', BUS_NAME, RESOURCE_TYPE, observed, previous);
+
+    // Assert: no UpdateEventBusCommand was sent with the empty-Arn
+    // placeholder DeadLetterConfig (the AWS-rejection shape).
+    const updateCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateEventBusCommand
+    );
+    for (const call of updateCalls) {
+      const input = call[0].input as {
+        DeadLetterConfig?: { Arn?: string };
+      };
+      if (input.DeadLetterConfig !== undefined) {
+        // If DeadLetterConfig is present in the request, its Arn must
+        // be a real (non-empty) ARN.
+        expect(input.DeadLetterConfig.Arn).not.toBe('');
+        expect(input.DeadLetterConfig.Arn).not.toBeUndefined();
+      }
+    }
+  });
+
+  it('Class 2 — create() also sanitises the DeadLetterConfig {Arn:""} placeholder', async () => {
+    // Symmetric guard for create(): a deploy that resolves
+    // DeadLetterConfig to the empty-Arn placeholder (e.g. via a
+    // partially-resolved Fn::GetAtt or a state-replay path) must not
+    // send the AWS-rejection shape to CreateEventBus either.
+    mockSend.mockResolvedValue({ EventBusArn: BUS_ARN });
+
+    await provider.create('L', RESOURCE_TYPE, {
+      Name: BUS_NAME,
+      DeadLetterConfig: { Arn: '' },
+    });
+
+    const createCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof CreateEventBusCommand
+    );
+    expect(createCalls).toHaveLength(1);
+    const input = createCalls[0][0].input as {
+      DeadLetterConfig?: { Arn?: string };
+    };
+    expect(input.DeadLetterConfig).toBeUndefined();
+  });
+
+  it('round-trip on no-drift snapshot is a logical no-op (zero UpdateEventBus calls)', async () => {
+    // state == AWS implies update() makes no AWS-side mutations. The
+    // structural guard that fires when someone changes update()'s diff
+    // logic.
+    const observed = {
+      Name: BUS_NAME,
+      Description: 'a custom bus',
+      KmsKeyIdentifier: 'alias/aws/events',
+      DeadLetterConfig: { Arn: 'arn:aws:sqs:us-east-1:0:dlq' },
+      Tags: [{ Key: 'k', Value: 'v' }],
+    };
+
+    mockSend.mockResolvedValue({ Arn: BUS_ARN });
+
+    await provider.update('L', BUS_NAME, RESOURCE_TYPE, observed, observed);
+
+    const updateCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateEventBusCommand
+    );
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it('truthy-gate guard — empty-string Description ("") reaches UpdateEventBus on revert', async () => {
+    // Mechanical guard for the truthy-gate regression class. See
+    // docs/provider-development.md § 3b "update() must gate optional
+    // fields on `!== undefined`, not truthy".
+    //
+    // When state has Description: '' (deployed with no description)
+    // and AWS has Description: 'some desc' (console-edit), --revert
+    // pushes `Description: ''` back through update(). A truthy gate
+    // would silently drop the empty string; AWS would keep the
+    // console value; the next drift run would re-detect the same
+    // drift (silent fail mode).
+    const newProps = {
+      Name: BUS_NAME,
+      Description: '',
+      KmsKeyIdentifier: '',
+      DeadLetterConfig: { Arn: '' },
+    };
+    const oldProps = {
+      Name: BUS_NAME,
+      Description: 'console-set description',
+      KmsKeyIdentifier: '',
+      DeadLetterConfig: { Arn: '' },
+    };
+
+    mockSend.mockResolvedValue({ Arn: BUS_ARN });
+
+    await provider.update('L', BUS_NAME, RESOURCE_TYPE, newProps, oldProps);
+
+    const updateCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof UpdateEventBusCommand
+    );
+    expect(updateCalls).toHaveLength(1);
+    const input = updateCalls[0][0].input as {
+      Description?: string;
+    };
+    expect(input.Description).toBe('');
+  });
+});

--- a/tests/unit/provisioning/eventbridge-rule-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/eventbridge-rule-provider-roundtrip.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  PutRuleCommand,
+  PutTargetsCommand,
+  RemoveTargetsCommand,
+} from '@aws-sdk/client-eventbridge';
+
+// Mock AWS clients before importing the provider
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    eventBridge: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { EventBridgeRuleProvider } from '../../../src/provisioning/providers/eventbridge-rule-provider.js';
+
+const RULE_NAME = 'my-rule';
+const RULE_ARN = `arn:aws:events:us-east-1:123456789012:rule/${RULE_NAME}`;
+
+/**
+ * Read-update round-trip tests for EventBridgeRuleProvider.
+ *
+ * See docs/provider-development.md § 3b "Read-update round-trip test" —
+ * `cdkd drift --revert` ships `observedProperties` (= a previous
+ * `readCurrentState` snapshot) back through `provider.update`. These
+ * tests are the structural guard against the three latent bug classes:
+ *
+ *   - Class 1: type-discriminator-dependent fields (EventPattern vs
+ *     ScheduleExpression are mutually exclusive — emitting the wrong
+ *     one would have AWS reject "ValidationException: Parameter ... is
+ *     not valid for the rule type").
+ *   - Class 2: structurally-incomplete-when-empty fields (an empty
+ *     EventPattern object would round-trip to `"{}"` JSON, which AWS
+ *     `PutRule` rejects with "Parameter EventPattern is not valid").
+ *   - Truthy-gate: `update()` MUST gate optional fields on `!==
+ *     undefined`, not truthy. Empty `Description: ''` must reach
+ *     `PutRuleCommand` so `--revert` can clear an AWS-side description.
+ */
+describe('EventBridgeRuleProvider read-update round-trip', () => {
+  let provider: EventBridgeRuleProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new EventBridgeRuleProvider();
+  });
+
+  it("Class 1 — schedule-only rule does NOT send EventPattern to AWS on round-trip", async () => {
+    // Schedule-only rule: observed snapshot has ScheduleExpression but
+    // no EventPattern. Round-trip update must NOT ship EventPattern
+    // (mutually exclusive with ScheduleExpression — AWS would reject).
+    mockSend.mockResolvedValue({ RuleArn: RULE_ARN });
+
+    const observed: Record<string, unknown> = {
+      Name: RULE_NAME,
+      Description: '',
+      ScheduleExpression: 'rate(5 minutes)',
+      State: 'ENABLED',
+      Targets: [],
+      Tags: [],
+    };
+
+    await provider.update('L', RULE_ARN, 'AWS::Events::Rule', observed, observed);
+
+    const putRuleCall = mockSend.mock.calls.find((c) => c[0] instanceof PutRuleCommand);
+    expect(putRuleCall).toBeDefined();
+    const input = (putRuleCall![0] as PutRuleCommand).input;
+    expect(input.EventPattern).toBeUndefined();
+    expect(input.ScheduleExpression).toBe('rate(5 minutes)');
+  });
+
+  it("Class 1 — pattern-only rule does NOT send ScheduleExpression to AWS on round-trip", async () => {
+    // Pattern-only rule: observed snapshot has EventPattern (parsed
+    // back from the JSON string AWS returns) but no ScheduleExpression.
+    // Round-trip update must NOT ship ScheduleExpression.
+    mockSend.mockResolvedValue({ RuleArn: RULE_ARN });
+
+    const observed: Record<string, unknown> = {
+      Name: RULE_NAME,
+      Description: '',
+      EventPattern: { source: ['aws.ec2'], 'detail-type': ['EC2 Instance State-change Notification'] },
+      State: 'ENABLED',
+      Targets: [],
+      Tags: [],
+    };
+
+    await provider.update('L', RULE_ARN, 'AWS::Events::Rule', observed, observed);
+
+    const putRuleCall = mockSend.mock.calls.find((c) => c[0] instanceof PutRuleCommand);
+    expect(putRuleCall).toBeDefined();
+    const input = (putRuleCall![0] as PutRuleCommand).input;
+    expect(input.ScheduleExpression).toBeUndefined();
+    // EventPattern is JSON-stringified on the wire (PutRule accepts a
+    // JSON string, not the parsed object).
+    expect(typeof input.EventPattern).toBe('string');
+    expect(JSON.parse(input.EventPattern as string)).toEqual({
+      source: ['aws.ec2'],
+      'detail-type': ['EC2 Instance State-change Notification'],
+    });
+  });
+
+  it("Class 2 — observed EventPattern that is a valid object round-trips identity (no '{}' rejection shape)", async () => {
+    // The structural guard: if a future readCurrentState change ever
+    // emitted EventPattern as an empty placeholder `{}`, JSON.stringify
+    // would produce `"{}"` and AWS PutRule would reject with "Parameter
+    // EventPattern is not valid". Today readCurrentState does NOT emit
+    // `{}` (the if-guard at line 451 only emits when AWS returns a
+    // non-undefined string), so this test asserts the contract: when
+    // EventPattern IS in the snapshot, it must be a non-empty object,
+    // and the wire-layer JSON must not be the rejection shape `"{}"`.
+    mockSend.mockResolvedValue({ RuleArn: RULE_ARN });
+
+    const observed: Record<string, unknown> = {
+      Name: RULE_NAME,
+      Description: '',
+      EventPattern: { source: ['custom.app'] },
+      State: 'ENABLED',
+      Targets: [],
+      Tags: [],
+    };
+
+    await provider.update('L', RULE_ARN, 'AWS::Events::Rule', observed, observed);
+
+    const putRuleCall = mockSend.mock.calls.find((c) => c[0] instanceof PutRuleCommand);
+    expect(putRuleCall).toBeDefined();
+    const input = (putRuleCall![0] as PutRuleCommand).input;
+    expect(input.EventPattern).not.toBe('{}');
+    expect(input.EventPattern).not.toBe('');
+    expect(input.EventPattern).toBe('{"source":["custom.app"]}');
+  });
+
+  it("truthy-gate — empty Description ('') reaches PutRuleCommand input on round-trip", async () => {
+    // readCurrentState always-emits `Description: ''` (placeholder for
+    // a rule with no description). A truthy gate in update() would
+    // silently drop the empty string and leave the AWS-side description
+    // untouched — `cdkd drift --revert` would report `✓ reverted` while
+    // the very next drift re-detects the same drift. This test asserts
+    // `!== undefined` (not truthy) on Description.
+    mockSend.mockResolvedValue({ RuleArn: RULE_ARN });
+
+    const observed: Record<string, unknown> = {
+      Name: RULE_NAME,
+      Description: '',
+      ScheduleExpression: 'rate(5 minutes)',
+      State: 'ENABLED',
+      Targets: [],
+      Tags: [],
+    };
+
+    await provider.update('L', RULE_ARN, 'AWS::Events::Rule', observed, observed);
+
+    const putRuleCall = mockSend.mock.calls.find((c) => c[0] instanceof PutRuleCommand);
+    expect(putRuleCall).toBeDefined();
+    const input = (putRuleCall![0] as PutRuleCommand).input;
+    // Description: '' MUST reach the AWS API call. If a truthy gate
+    // ever sneaks back in, this assertion fires: input.Description
+    // would be undefined.
+    expect(input.Description).toBe('');
+  });
+
+  it("round-trip on no-target snapshot does not fire a PutTargetsCommand", async () => {
+    // observed has Targets: [] (always-emit placeholder for a rule
+    // with no targets). update() should NOT call PutTargetsCommand —
+    // PutTargetsCommand with Targets: [] would be rejected by AWS
+    // ("Targets list must contain at least one element").
+    mockSend.mockResolvedValue({ RuleArn: RULE_ARN });
+
+    const observed: Record<string, unknown> = {
+      Name: RULE_NAME,
+      Description: '',
+      ScheduleExpression: 'rate(5 minutes)',
+      State: 'ENABLED',
+      Targets: [],
+      Tags: [],
+    };
+
+    await provider.update('L', RULE_ARN, 'AWS::Events::Rule', observed, observed);
+
+    const putTargetsCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PutTargetsCommand
+    );
+    expect(putTargetsCalls).toHaveLength(0);
+    const removeTargetsCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof RemoveTargetsCommand
+    );
+    expect(removeTargetsCalls).toHaveLength(0);
+  });
+
+  it("round-trip on populated-target snapshot ships Targets verbatim (no shape mutation)", async () => {
+    // Targets array contents (each target's EcsParameters /
+    // BatchParameters / etc. — all Class 1 sub-shapes within the
+    // target) flow identity from readCurrentState ←
+    // ListTargetsByRuleCommand → update() → PutTargetsCommand. AWS's
+    // ListTargets and PutTargets share the same Target shape, so the
+    // round-trip is identity.
+    mockSend.mockResolvedValue({ RuleArn: RULE_ARN });
+
+    const targets = [
+      {
+        Id: 'Target1',
+        Arn: 'arn:aws:lambda:us-east-1:123456789012:function:my-fn',
+        Input: '{"foo":"bar"}',
+      },
+    ];
+    const observed: Record<string, unknown> = {
+      Name: RULE_NAME,
+      Description: '',
+      ScheduleExpression: 'rate(5 minutes)',
+      State: 'ENABLED',
+      Targets: targets,
+      Tags: [],
+    };
+
+    await provider.update('L', RULE_ARN, 'AWS::Events::Rule', observed, observed);
+
+    const putTargetsCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof PutTargetsCommand
+    );
+    expect(putTargetsCall).toBeDefined();
+    const input = (putTargetsCall![0] as PutTargetsCommand).input;
+    expect(input.Targets).toEqual(targets);
+  });
+});

--- a/tests/unit/provisioning/firehose-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/firehose-provider-roundtrip.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-firehose', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-firehose')>(
+    '@aws-sdk/client-firehose'
+  );
+  return {
+    ...actual,
+    FirehoseClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { FirehoseProvider } from '../../../src/provisioning/providers/firehose-provider.js';
+import { ResourceUpdateNotSupportedError } from '../../../src/utils/error-handler.js';
+
+const RESOURCE_TYPE = 'AWS::KinesisFirehose::DeliveryStream';
+const PHYSICAL_ID = 'my-stream';
+
+describe('FirehoseProvider read-update round-trip', () => {
+  let provider: FirehoseProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new FirehoseProvider();
+  });
+
+  it('Class 1 — DirectPut readCurrentState does NOT emit KinesisStreamSourceConfiguration', async () => {
+    // Mechanical guard for Class 1 placeholder regression on type-
+    // discriminator-dependent fields. See docs/provider-development.md
+    // § 3b "Read-update round-trip test".
+    //
+    // KinesisStreamSourceConfiguration is only valid when
+    // DeliveryStreamType === 'KinesisStreamAsSource'. AWS only returns
+    // Source.KinesisStreamSourceDescription on streams of that type, so
+    // a DirectPut stream's snapshot must NOT contain the source key —
+    // otherwise --revert (if Firehose ever supported update) or any
+    // future re-creation pathway would push a Class 1 invalid value.
+    mockSend
+      .mockResolvedValueOnce({
+        DeliveryStreamDescription: {
+          DeliveryStreamName: PHYSICAL_ID,
+          DeliveryStreamType: 'DirectPut',
+          // Source intentionally absent — DirectPut has no source.
+        },
+      })
+      .mockResolvedValueOnce({ Tags: [] });
+
+    const observed = await provider.readCurrentState(PHYSICAL_ID, 'L', RESOURCE_TYPE);
+    expect(observed).toBeDefined();
+    expect(observed).not.toHaveProperty('KinesisStreamSourceConfiguration');
+    expect(observed?.DeliveryStreamType).toBe('DirectPut');
+  });
+
+  it('Class 1 — KinesisStreamAsSource emits KinesisStreamSourceConfiguration on the discriminator-true path', async () => {
+    // Complement to the DirectPut test: the field MUST appear when the
+    // discriminator is true, otherwise drift detection misses
+    // console-side source-arn / role-arn changes.
+    mockSend
+      .mockResolvedValueOnce({
+        DeliveryStreamDescription: {
+          DeliveryStreamName: PHYSICAL_ID,
+          DeliveryStreamType: 'KinesisStreamAsSource',
+          Source: {
+            KinesisStreamSourceDescription: {
+              KinesisStreamARN: 'arn:aws:kinesis:us-east-1:1:stream/src',
+              RoleARN: 'arn:aws:iam::1:role/r',
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({ Tags: [] });
+
+    const observed = await provider.readCurrentState(PHYSICAL_ID, 'L', RESOURCE_TYPE);
+    expect(observed?.KinesisStreamSourceConfiguration).toEqual({
+      KinesisStreamARN: 'arn:aws:kinesis:us-east-1:1:stream/src',
+      RoleARN: 'arn:aws:iam::1:role/r',
+    });
+  });
+
+  it('always emits Tags (even when ListTagsForDeliveryStream fails on a non-NotFound error)', async () => {
+    // Per docs/provider-development.md § 3b: omitting `Tags` on the
+    // failure path means the comparator's state-keys-only walk skips
+    // Tags forever, hiding console-side tag adds from drift on the
+    // unlucky run that hit the Tags API throttle.
+    mockSend
+      .mockResolvedValueOnce({
+        DeliveryStreamDescription: {
+          DeliveryStreamName: PHYSICAL_ID,
+          DeliveryStreamType: 'DirectPut',
+        },
+      })
+      .mockRejectedValueOnce(new Error('throttled'));
+
+    const observed = await provider.readCurrentState(PHYSICAL_ID, 'L', RESOURCE_TYPE);
+    expect(observed).toBeDefined();
+    expect(observed?.Tags).toEqual([]);
+  });
+
+  it('round-trip: update() rejects with ResourceUpdateNotSupportedError without sending any AWS call', async () => {
+    // Firehose update() is intentionally a hard reject (PR I): every
+    // user-visible CFn property change requires replacement on AWS, so
+    // `cdkd drift --revert` surfaces a clear "use --replace or
+    // re-deploy" message instead of silently no-op'ing. This is the
+    // structural guard against a future PR adding a half-implemented
+    // UpdateDestination call that would resurface the Class 1 / Class
+    // 2 / truthy-gate hazards documented in § 3b.
+    const observed = {
+      DeliveryStreamName: PHYSICAL_ID,
+      DeliveryStreamType: 'DirectPut',
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await expect(
+      provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    // Zero AWS calls — the reject path must not touch the wire.
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/provisioning/glue-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/glue-provider-roundtrip.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateTableCommand } from '@aws-sdk/client-glue';
+import { ResourceUpdateNotSupportedError } from '../../../src/utils/error-handler.js';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-glue', async () => {
+  const actual =
+    await vi.importActual<typeof import('@aws-sdk/client-glue')>('@aws-sdk/client-glue');
+  return {
+    ...actual,
+    GlueClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { GlueProvider } from '../../../src/provisioning/providers/glue-provider.js';
+
+const TABLE_PHYSICAL_ID = 'mydb|mytbl';
+
+describe('GlueProvider read-update round-trip', () => {
+  let provider: GlueProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new GlueProvider();
+  });
+
+  it('AWS::Glue::Database — update() rejects with ResourceUpdateNotSupportedError (immutable)', async () => {
+    // Per CLAUDE.md PR I, Glue Database update is intentionally not wired
+    // up. `cdkd drift --revert` must surface the immutable error rather
+    // than silently no-op. This locks in the contract so a future PR that
+    // adds UpdateDatabase plumbing also revisits the round-trip story.
+    const observed = {
+      DatabaseInput: {
+        Name: 'mydb',
+        Description: '',
+        Parameters: {},
+      },
+    };
+    await expect(
+      provider.update('L', 'mydb', 'AWS::Glue::Database', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+    // No AWS calls fired.
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('AWS::Glue::Table — Class 2: empty placeholders (Parameters {}, PartitionKeys []) round-trip without AWS-rejection shape', async () => {
+    // Mechanical guard for Class 2 placeholder regression. See
+    // docs/provider-development.md § 3b. `readCurrentState` always-emits
+    // `Parameters: {}` and `PartitionKeys: []` as placeholders so console
+    // adds are detectable. Round-tripping those through update() must
+    // produce a valid `UpdateTable` payload — empty `Parameters` /
+    // `PartitionKeys` are AWS-documented as "no params / no partition
+    // keys", so they MAY be sent but MUST NOT carry AWS-invalid shapes.
+    mockSend.mockResolvedValueOnce({});
+
+    const observed = {
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        Description: '',
+        Parameters: {},
+        PartitionKeys: [],
+        // No StorageDescriptor / Owner / Retention / TableType /
+        // ViewOriginalText / ViewExpandedText — matches what
+        // `readCurrentState` produces when AWS returns a minimal Table.
+      },
+    };
+
+    await provider.update('L', TABLE_PHYSICAL_ID, 'AWS::Glue::Table', observed, observed);
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateTableCommand);
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as {
+      DatabaseName: string;
+      TableInput: Record<string, unknown>;
+    };
+    expect(input.DatabaseName).toBe('mydb');
+    expect(input.TableInput.Name).toBe('mytbl');
+    // Empty placeholders survive intact (AWS valid shapes — no `'{}'`
+    // string-encoding bug like SQS RedrivePolicy).
+    expect(input.TableInput.Parameters).toEqual({});
+    expect(input.TableInput.PartitionKeys).toEqual([]);
+    // Description: '' must reach the API (truthy-gate guard — see
+    // iam-role-provider.ts:270-276 for the canonical pattern).
+    expect(input.TableInput.Description).toBe('');
+    // ViewOriginalText / ViewExpandedText / StorageDescriptor were not
+    // in the snapshot (Class 1 — only emitted by readCurrentState when
+    // AWS returns them, which is gated by TableType discriminator on
+    // the AWS side). They MUST NOT appear in the API call.
+    expect(input.TableInput.ViewOriginalText).toBeUndefined();
+    expect(input.TableInput.ViewExpandedText).toBeUndefined();
+    expect(input.TableInput.StorageDescriptor).toBeUndefined();
+  });
+
+  it('AWS::Glue::Table — Class 1: VIRTUAL_VIEW snapshot round-trips ViewOriginalText/ViewExpandedText safely', async () => {
+    // Class 1 complement: a VIRTUAL_VIEW table legitimately carries
+    // ViewOriginalText / ViewExpandedText, and `readCurrentState`
+    // emits them when AWS returns them. Round-tripping must preserve
+    // the discriminator + view text together (no AWS-side rejection
+    // for "view text on non-view table").
+    mockSend.mockResolvedValueOnce({});
+
+    const observed = {
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        Description: '',
+        Parameters: {},
+        PartitionKeys: [],
+        TableType: 'VIRTUAL_VIEW',
+        ViewOriginalText: '/* Presto View */ SELECT 1',
+        ViewExpandedText: '/* Presto View */ SELECT 1',
+      },
+    };
+
+    await provider.update('L', TABLE_PHYSICAL_ID, 'AWS::Glue::Table', observed, observed);
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateTableCommand);
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as { TableInput: Record<string, unknown> };
+    expect(input.TableInput.TableType).toBe('VIRTUAL_VIEW');
+    expect(input.TableInput.ViewOriginalText).toBe('/* Presto View */ SELECT 1');
+    expect(input.TableInput.ViewExpandedText).toBe('/* Presto View */ SELECT 1');
+  });
+
+  it('AWS::Glue::Table — EXTERNAL_TABLE with full StorageDescriptor round-trips without empty-SerdeInfo.Parameters dropping', async () => {
+    // Truthy-gate guard for the SerdeInfo.Parameters branch in
+    // buildStorageDescriptor (`if (serde['Parameters'] !== undefined)`,
+    // not truthy). An empty `Parameters: {}` placeholder must survive —
+    // a truthy gate would skip the conversion entirely and leave the
+    // raw object unconverted (functional difference is small here, but
+    // the docs/provider-development.md § 3b rule applies uniformly).
+    mockSend.mockResolvedValueOnce({});
+
+    const observed = {
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        Description: '',
+        Parameters: {},
+        PartitionKeys: [],
+        TableType: 'EXTERNAL_TABLE',
+        StorageDescriptor: {
+          Location: 's3://b/p',
+          Columns: [{ Name: 'c', Type: 'string' }],
+          SerdeInfo: {
+            Name: 'serde',
+            SerializationLibrary: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
+            Parameters: {}, // empty placeholder — must reach AWS as `{}`, not be skipped
+          },
+        },
+      },
+    };
+
+    await provider.update('L', TABLE_PHYSICAL_ID, 'AWS::Glue::Table', observed, observed);
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateTableCommand);
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as {
+      TableInput: { StorageDescriptor: { SerdeInfo: { Parameters: Record<string, string> } } };
+    };
+    expect(input.TableInput.StorageDescriptor.SerdeInfo.Parameters).toEqual({});
+  });
+});

--- a/tests/unit/provisioning/kinesis-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/kinesis-provider-roundtrip.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  DescribeStreamCommand,
+  StartStreamEncryptionCommand,
+  StopStreamEncryptionCommand,
+  UpdateShardCountCommand,
+  IncreaseStreamRetentionPeriodCommand,
+  DecreaseStreamRetentionPeriodCommand,
+  AddTagsToStreamCommand,
+  RemoveTagsFromStreamCommand,
+  ListTagsForStreamCommand,
+} from '@aws-sdk/client-kinesis';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-kinesis', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-kinesis')>(
+    '@aws-sdk/client-kinesis'
+  );
+  return {
+    ...actual,
+    KinesisClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { KinesisStreamProvider } from '../../../src/provisioning/providers/kinesis-provider.js';
+
+const STREAM_NAME = 'mystream';
+const STREAM_ARN = `arn:aws:kinesis:us-east-1:123456789012:stream/${STREAM_NAME}`;
+
+describe('KinesisStreamProvider read-update round-trip', () => {
+  let provider: KinesisStreamProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new KinesisStreamProvider();
+  });
+
+  it('Class 1 — ON_DEMAND stream readCurrentState does not emit ShardCount', async () => {
+    // Mechanical guard for Class 1 placeholder regression on type-
+    // discriminator-dependent fields. See docs/provider-development.md
+    // § 3b "Read-update round-trip test".
+    //
+    // ShardCount is PROVISIONED-only. AWS rejects UpdateShardCount on
+    // ON_DEMAND streams (capacity is managed by AWS). Even though
+    // DescribeStream returns shards on ON_DEMAND streams too, the type
+    // discriminator is StreamMode — readCurrentState must NOT surface
+    // ShardCount on ON_DEMAND so a `cdkd drift --revert` round-trip
+    // never pushes UpdateShardCount.
+    mockSend
+      .mockResolvedValueOnce({
+        StreamDescription: {
+          StreamName: STREAM_NAME,
+          StreamModeDetails: { StreamMode: 'ON_DEMAND' },
+          // AWS reports shards on ON_DEMAND too (capacity managed by AWS).
+          Shards: [{ ShardId: 's-1' }, { ShardId: 's-2' }],
+          RetentionPeriodHours: 24,
+          EncryptionType: 'NONE',
+        },
+      })
+      .mockResolvedValueOnce({ Tags: [] });
+
+    const observed = await provider.readCurrentState(
+      STREAM_NAME,
+      'L',
+      'AWS::Kinesis::Stream'
+    );
+
+    expect(observed?.['StreamModeDetails']).toEqual({ StreamMode: 'ON_DEMAND' });
+    expect(observed).not.toHaveProperty('ShardCount');
+  });
+
+  it('Class 1 — PROVISIONED stream emits ShardCount as Shards.length', async () => {
+    mockSend
+      .mockResolvedValueOnce({
+        StreamDescription: {
+          StreamName: STREAM_NAME,
+          StreamModeDetails: { StreamMode: 'PROVISIONED' },
+          Shards: [{ ShardId: 's-1' }, { ShardId: 's-2' }],
+          RetentionPeriodHours: 24,
+          EncryptionType: 'NONE',
+        },
+      })
+      .mockResolvedValueOnce({ Tags: [] });
+
+    const observed = await provider.readCurrentState(
+      STREAM_NAME,
+      'L',
+      'AWS::Kinesis::Stream'
+    );
+
+    expect(observed?.['ShardCount']).toBe(2);
+  });
+
+  it('Class 1/2 — round-trip on unencrypted PROVISIONED stream skips StartStreamEncryption', async () => {
+    // Mechanical guard for Class 1/2 placeholder regression on
+    // EncryptionType=NONE. readCurrentState always-emits
+    // `StreamEncryption: { EncryptionType: 'NONE' }` on unencrypted
+    // streams so the comparator can detect a console-side KMS attach.
+    // On the write side, neither StartStreamEncryption (KMS-only) nor
+    // StopStreamEncryption accepts NONE. A `cdkd drift --revert`
+    // round-trip must NOT call either API when the desired and
+    // previous states are both NONE.
+
+    // 1. Build observed snapshot directly (matches what
+    //    readCurrentState would produce — exercised by its own
+    //    dedicated test file).
+    const observed = {
+      Name: STREAM_NAME,
+      StreamModeDetails: { StreamMode: 'PROVISIONED' },
+      ShardCount: 2,
+      RetentionPeriodHours: 24,
+      StreamEncryption: { EncryptionType: 'NONE' },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    // 2. Set up update() expectations: only the trailing DescribeStream
+    //    call for attributes returns. No mutation calls should fire.
+    mockSend.mockResolvedValueOnce({
+      StreamDescription: { StreamARN: STREAM_ARN },
+    });
+
+    // 3. Round-trip: pass observed as both new (desired) and old.
+    //    No drift -> update should be a logical no-op on AWS.
+    await provider.update(
+      'L',
+      STREAM_NAME,
+      'AWS::Kinesis::Stream',
+      observed,
+      observed
+    );
+
+    // 4. Assert: NO StartStreamEncryption / StopStreamEncryption / etc.
+    //    AWS rejects StartStreamEncryption(EncryptionType=NONE) and
+    //    StopStreamEncryption is encryption-removal — neither is valid
+    //    on a never-encrypted stream.
+    expect(mockSend.mock.calls.find((c) => c[0] instanceof StartStreamEncryptionCommand)).toBeUndefined();
+    expect(mockSend.mock.calls.find((c) => c[0] instanceof StopStreamEncryptionCommand)).toBeUndefined();
+    // No shard count change either (old == new).
+    expect(mockSend.mock.calls.find((c) => c[0] instanceof UpdateShardCountCommand)).toBeUndefined();
+    // No retention change either (old == new == 24).
+    expect(
+      mockSend.mock.calls.find((c) => c[0] instanceof IncreaseStreamRetentionPeriodCommand)
+    ).toBeUndefined();
+    expect(
+      mockSend.mock.calls.find((c) => c[0] instanceof DecreaseStreamRetentionPeriodCommand)
+    ).toBeUndefined();
+  });
+
+  it('Class 1/2 — KMS attach (NONE -> KMS) round-trip calls StartStreamEncryption with EncryptionType=KMS', async () => {
+    // The complement of the no-op test: when --revert pushes a console-
+    // side KMS detachment back to AWS, the new value is KMS and old is
+    // NONE. Update should fire StartStreamEncryption(KMS) — and crucially
+    // NOT StopStreamEncryption(NONE), which AWS rejects.
+    const oldObserved = {
+      Name: STREAM_NAME,
+      StreamModeDetails: { StreamMode: 'PROVISIONED' },
+      ShardCount: 1,
+      RetentionPeriodHours: 24,
+      StreamEncryption: { EncryptionType: 'NONE' },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+    const newDesired = {
+      ...oldObserved,
+      StreamEncryption: {
+        EncryptionType: 'KMS',
+        KeyId: 'arn:aws:kms:us-east-1:123:key/abc',
+      },
+    };
+
+    mockSend
+      .mockResolvedValueOnce({}) // StartStreamEncryption
+      .mockResolvedValueOnce({
+        StreamDescription: { StreamStatus: 'ACTIVE', StreamARN: STREAM_ARN },
+      }) // waitForStreamActive (DescribeStream)
+      .mockResolvedValueOnce({
+        StreamDescription: { StreamARN: STREAM_ARN },
+      }); // trailing DescribeStream for attributes
+
+    await provider.update(
+      'L',
+      STREAM_NAME,
+      'AWS::Kinesis::Stream',
+      newDesired,
+      oldObserved
+    );
+
+    // StopStreamEncryption MUST NOT fire — old was NONE.
+    expect(
+      mockSend.mock.calls.find((c) => c[0] instanceof StopStreamEncryptionCommand)
+    ).toBeUndefined();
+
+    const startCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof StartStreamEncryptionCommand
+    );
+    expect(startCall).toBeDefined();
+    const startInput = startCall![0].input as {
+      EncryptionType: string;
+      KeyId: string;
+      StreamName: string;
+    };
+    expect(startInput.EncryptionType).toBe('KMS');
+    expect(startInput.KeyId).toBe('arn:aws:kms:us-east-1:123:key/abc');
+    expect(startInput.StreamName).toBe(STREAM_NAME);
+  });
+
+  it('Class 1/2 — KMS detach (KMS -> NONE) calls StopStreamEncryption with EncryptionType=KMS, not NONE', async () => {
+    // Complement: when state has NONE but AWS-current is KMS,
+    // --accept would update state; --revert would push state (NONE)
+    // back to AWS. Expected: StopStreamEncryption(KMS) (the documented
+    // way to remove encryption), and NOT StartStreamEncryption(NONE).
+    const oldObserved = {
+      Name: STREAM_NAME,
+      StreamModeDetails: { StreamMode: 'PROVISIONED' },
+      ShardCount: 1,
+      RetentionPeriodHours: 24,
+      StreamEncryption: {
+        EncryptionType: 'KMS',
+        KeyId: 'arn:aws:kms:us-east-1:123:key/abc',
+      },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+    const newDesired = {
+      ...oldObserved,
+      StreamEncryption: { EncryptionType: 'NONE' },
+    };
+
+    mockSend
+      .mockResolvedValueOnce({}) // StopStreamEncryption
+      .mockResolvedValueOnce({
+        StreamDescription: { StreamStatus: 'ACTIVE', StreamARN: STREAM_ARN },
+      }) // waitForStreamActive
+      .mockResolvedValueOnce({
+        StreamDescription: { StreamARN: STREAM_ARN },
+      }); // trailing DescribeStream
+
+    await provider.update(
+      'L',
+      STREAM_NAME,
+      'AWS::Kinesis::Stream',
+      newDesired,
+      oldObserved
+    );
+
+    // StartStreamEncryption MUST NOT fire — new is NONE.
+    expect(
+      mockSend.mock.calls.find((c) => c[0] instanceof StartStreamEncryptionCommand)
+    ).toBeUndefined();
+
+    const stopCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof StopStreamEncryptionCommand
+    );
+    expect(stopCall).toBeDefined();
+    const stopInput = stopCall![0].input as {
+      EncryptionType: string;
+      KeyId: string | undefined;
+    };
+    // EncryptionType MUST be 'KMS' (the encryption being stopped is KMS),
+    // never the NONE placeholder.
+    expect(stopInput.EncryptionType).toBe('KMS');
+    expect(stopInput.KeyId).toBe('arn:aws:kms:us-east-1:123:key/abc');
+  });
+
+  it('round-trip on no-drift KMS-encrypted PROVISIONED snapshot is a logical no-op', async () => {
+    // Stronger assertion for diff-based providers: state == AWS implies
+    // update() must make no AWS-side mutations beyond the trailing
+    // DescribeStream for attributes. PR-style round-trip guard.
+    const observed = {
+      Name: STREAM_NAME,
+      StreamModeDetails: { StreamMode: 'PROVISIONED' },
+      ShardCount: 4,
+      RetentionPeriodHours: 48,
+      StreamEncryption: {
+        EncryptionType: 'KMS',
+        KeyId: 'arn:aws:kms:us-east-1:123:key/abc',
+      },
+      Tags: [{ Key: 'k', Value: 'v' }],
+    };
+
+    mockSend.mockResolvedValueOnce({
+      StreamDescription: { StreamARN: STREAM_ARN },
+    });
+
+    await provider.update(
+      'L',
+      STREAM_NAME,
+      'AWS::Kinesis::Stream',
+      observed,
+      observed
+    );
+
+    // Only the trailing DescribeStream for attributes ran.
+    const mutationCalls = mockSend.mock.calls.filter(
+      (c) =>
+        c[0] instanceof StartStreamEncryptionCommand ||
+        c[0] instanceof StopStreamEncryptionCommand ||
+        c[0] instanceof UpdateShardCountCommand ||
+        c[0] instanceof IncreaseStreamRetentionPeriodCommand ||
+        c[0] instanceof DecreaseStreamRetentionPeriodCommand ||
+        c[0] instanceof AddTagsToStreamCommand ||
+        c[0] instanceof RemoveTagsFromStreamCommand
+    );
+    expect(mutationCalls).toHaveLength(0);
+    // Trailing DescribeStream did fire (for the returned Arn attribute).
+    const describeCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof DescribeStreamCommand
+    );
+    expect(describeCalls).toHaveLength(1);
+  });
+
+  it('round-trip ListTagsForStream is symmetric — empty Tags array does not push tag calls', async () => {
+    // readCurrentState emits Tags: [] when AWS reports no user tags.
+    // applyTagDiff with empty old == empty new must produce zero tag
+    // API calls.
+    const observed = {
+      Name: STREAM_NAME,
+      StreamModeDetails: { StreamMode: 'PROVISIONED' },
+      ShardCount: 1,
+      RetentionPeriodHours: 24,
+      StreamEncryption: { EncryptionType: 'NONE' },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValueOnce({
+      StreamDescription: { StreamARN: STREAM_ARN },
+    });
+
+    await provider.update(
+      'L',
+      STREAM_NAME,
+      'AWS::Kinesis::Stream',
+      observed,
+      observed
+    );
+
+    expect(mockSend.mock.calls.find((c) => c[0] instanceof AddTagsToStreamCommand)).toBeUndefined();
+    expect(
+      mockSend.mock.calls.find((c) => c[0] instanceof RemoveTagsFromStreamCommand)
+    ).toBeUndefined();
+    // The ListTagsForStream is part of readCurrentState, NOT update().
+    // update() does not list tags itself; verify no list call.
+    expect(mockSend.mock.calls.find((c) => c[0] instanceof ListTagsForStreamCommand)).toBeUndefined();
+  });
+});

--- a/tests/unit/provisioning/logs-loggroup-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/logs-loggroup-provider-readcurrentstate.test.ts
@@ -99,7 +99,7 @@ describe('LogsLogGroupProvider.readCurrentState', () => {
     expect(result?.Tags).toEqual([{ Key: 'Foo', Value: 'Bar' }]);
   });
 
-  it('omits Tags when ListTagsForResource returns no user tags', async () => {
+  it('emits Tags=[] when ListTagsForResource returns no user tags', async () => {
     mockSend.mockResolvedValueOnce({
       logGroups: [
         {
@@ -118,6 +118,41 @@ describe('LogsLogGroupProvider.readCurrentState', () => {
       'AWS::Logs::LogGroup'
     );
     expect(result?.Tags).toEqual([]);
+  });
+
+  it('emits placeholders for every user-controllable top-level key on AWS minimum response', async () => {
+    // Mandatory always-emit test per docs/provider-development.md § 3b.
+    // Required field only (logGroupName + arn) — every optional
+    // undefined. Keys must include the placeholder defaults so a
+    // console-side change to a previously-default field surfaces as
+    // drift on the v3 observedProperties baseline.
+    mockSend.mockResolvedValueOnce({
+      logGroups: [
+        {
+          logGroupName: '/aws/lambda/min',
+          arn: 'arn:aws:logs:us-east-1:123:log-group:/aws/lambda/min:*',
+          // Everything else undefined: kmsKeyId, retentionInDays,
+          // logGroupClass.
+        },
+      ],
+    });
+    mockSend.mockResolvedValueOnce({ tags: {} });
+
+    const result = await provider.readCurrentState(
+      '/aws/lambda/min',
+      'Logical',
+      'AWS::Logs::LogGroup'
+    );
+
+    // LogGroupClass is immutable on create — skip emit is correct
+    // (per the § 3b "immutable on create" rule).
+    expect(Object.keys(result ?? {}).sort()).toEqual(
+      ['LogGroupName', 'KmsKeyId', 'RetentionInDays', 'Tags'].sort()
+    );
+    expect(result?.LogGroupName).toBe('/aws/lambda/min');
+    expect(result?.KmsKeyId).toBe(''); // string placeholder
+    expect(result?.RetentionInDays).toBe(0); // semantic "never expire"
+    expect(result?.Tags).toEqual([]); // array placeholder
   });
 
   it('returns undefined when log group does not exist (no exact match)', async () => {

--- a/tests/unit/provisioning/logs-loggroup-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/logs-loggroup-provider-roundtrip.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  PutRetentionPolicyCommand,
+  DeleteRetentionPolicyCommand,
+  PutDataProtectionPolicyCommand,
+  DeleteDataProtectionPolicyCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from '@aws-sdk/client-cloudwatch-logs';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    cloudWatchLogs: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+    sts: {
+      send: vi.fn(() => Promise.resolve({ Account: '123456789012' })),
+      config: { region: () => Promise.resolve('us-east-1') },
+    },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { LogsLogGroupProvider } from '../../../src/provisioning/providers/logs-loggroup-provider.js';
+
+const RESOURCE_TYPE = 'AWS::Logs::LogGroup';
+const PHYSICAL_ID = '/aws/lambda/my-fn';
+
+describe('LogsLogGroupProvider read-update round-trip', () => {
+  let provider: LogsLogGroupProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new LogsLogGroupProvider();
+  });
+
+  it('round-trip on no-drift snapshot is a logical no-op (zero AWS mutations)', async () => {
+    // Mechanical guard for the read-update round-trip: when state
+    // matches AWS, `cdkd drift --revert` round-trips
+    // observedProperties through update() and must NOT mutate AWS.
+    //
+    // Build a snapshot that mirrors what readCurrentState emits for an
+    // initially-untagged log group with no retention and no KMS:
+    //   - KmsKeyId: '' (always-emit string placeholder)
+    //   - RetentionInDays: 0 (always-emit "never expire" semantic default)
+    //   - Tags: [] (always-emit array placeholder)
+    const observed: Record<string, unknown> = {
+      LogGroupName: PHYSICAL_ID,
+      KmsKeyId: '',
+      RetentionInDays: 0,
+      Tags: [],
+    };
+
+    // sts mock for buildArn — return the result twice in case
+    mockSend.mockResolvedValue({ Account: '123456789012' });
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    // No drift -> no AWS-side mutations on retention, data protection,
+    // or tags.
+    const mutationCalls = mockSend.mock.calls.filter((c) => {
+      const cmd = c[0];
+      return (
+        cmd instanceof PutRetentionPolicyCommand ||
+        cmd instanceof DeleteRetentionPolicyCommand ||
+        cmd instanceof PutDataProtectionPolicyCommand ||
+        cmd instanceof DeleteDataProtectionPolicyCommand ||
+        cmd instanceof TagResourceCommand ||
+        cmd instanceof UntagResourceCommand
+      );
+    });
+    expect(mutationCalls).toHaveLength(0);
+  });
+
+  it('Class 2 — RetentionInDays: 0 placeholder does NOT push PutRetentionPolicy(0) to AWS', async () => {
+    // Class 2 round-trip guard. AWS rejects PutRetentionPolicy with
+    // retentionInDays=0 ("retentionInDays must be a positive integer").
+    // The "no retention" snapshot must therefore translate to either
+    // no AWS call at all (round-trip no-op) or a DeleteRetentionPolicy
+    // — never to PutRetentionPolicy(0).
+    const observed: Record<string, unknown> = {
+      LogGroupName: PHYSICAL_ID,
+      KmsKeyId: '',
+      RetentionInDays: 0,
+      Tags: [],
+    };
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    const putRetention = mockSend.mock.calls.find(
+      (c) => c[0] instanceof PutRetentionPolicyCommand
+    );
+    expect(putRetention).toBeUndefined();
+  });
+
+  it('RetentionInDays change from 0 -> 30 routes to PutRetentionPolicy', async () => {
+    // Complement of the Class 2 guard: a real change from "no
+    // retention" to "30 days" must produce a PutRetentionPolicy call
+    // (not a Delete).
+    const oldProps: Record<string, unknown> = {
+      LogGroupName: PHYSICAL_ID,
+      KmsKeyId: '',
+      RetentionInDays: 0,
+      Tags: [],
+    };
+    const newProps: Record<string, unknown> = {
+      ...oldProps,
+      RetentionInDays: 30,
+    };
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, newProps, oldProps);
+
+    const putRetentionCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof PutRetentionPolicyCommand
+    );
+    expect(putRetentionCall).toBeDefined();
+    const input = putRetentionCall?.[0].input as { retentionInDays: number };
+    expect(input.retentionInDays).toBe(30);
+  });
+
+  it('RetentionInDays change from 30 -> 0 routes to DeleteRetentionPolicy', async () => {
+    // The reverse: dropping retention back to "never expire" must
+    // produce a Delete, matching the always-emit `?? 0` semantic on
+    // the read side.
+    const oldProps: Record<string, unknown> = {
+      LogGroupName: PHYSICAL_ID,
+      KmsKeyId: '',
+      RetentionInDays: 30,
+      Tags: [],
+    };
+    const newProps: Record<string, unknown> = {
+      ...oldProps,
+      RetentionInDays: 0,
+    };
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, newProps, oldProps);
+
+    const deleteRetentionCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof DeleteRetentionPolicyCommand
+    );
+    expect(deleteRetentionCall).toBeDefined();
+    const putRetentionCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof PutRetentionPolicyCommand
+    );
+    expect(putRetentionCall).toBeUndefined();
+  });
+
+  it('Tags=[] round-trip on initially-untagged group does NOT call Tag/UntagResource', async () => {
+    // Always-emit Tags=[] placeholder must not produce an UntagResource
+    // call when the previous Tags is also []. This protects the
+    // initially-untagged path from spurious AWS calls (which AWS
+    // accepts but is wasteful and noisy).
+    const observed: Record<string, unknown> = {
+      LogGroupName: PHYSICAL_ID,
+      KmsKeyId: '',
+      RetentionInDays: 0,
+      Tags: [],
+    };
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    const tagCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof TagResourceCommand || c[0] instanceof UntagResourceCommand
+    );
+    expect(tagCalls).toHaveLength(0);
+  });
+});

--- a/tests/unit/provisioning/s3-directory-bucket-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/s3-directory-bucket-provider-roundtrip.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockS3Send = vi.fn();
+const mockStsSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    s3: { send: mockS3Send, config: { region: () => Promise.resolve('us-east-1') } },
+    sts: { send: mockStsSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { S3DirectoryBucketProvider } from '../../../src/provisioning/providers/s3-directory-bucket-provider.js';
+
+const PHYSICAL_ID = 'my-bucket--use1-az1--x-s3';
+const RESOURCE_TYPE = 'AWS::S3Express::DirectoryBucket';
+
+describe('S3DirectoryBucketProvider read-update round-trip', () => {
+  let provider: S3DirectoryBucketProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new S3DirectoryBucketProvider();
+  });
+
+  it('Class 1 — round-trip on observed snapshot does not push DataRedundancy back through AWS', async () => {
+    // Mechanical guard for Class 1 placeholder regression on type-
+    // discriminator-dependent fields. See docs/provider-development.md
+    // § 3b "Read-update round-trip test".
+    //
+    // S3 Express Directory Buckets are immutable after create — every
+    // user-controllable property (BucketName, LocationName, DataRedundancy)
+    // is fixed at creation time. update() is documented as a no-op for
+    // exactly this reason. This round-trip test guards the no-op
+    // contract: even when observedProperties (from readCurrentState)
+    // is fed back through update() as the new desired state,
+    // update() must NOT issue ANY AWS-mutating SDK call. AWS would
+    // reject any attempt to "update" an immutable bucket
+    // configuration.
+
+    const observed = {
+      BucketName: PHYSICAL_ID,
+      DataRedundancy: 'SingleAvailabilityZone',
+    };
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    // Assert: zero AWS SDK calls fired during the round-trip update.
+    // The provider is a pure no-op for update — no PutBucket*, no
+    // CreateBucket, no DeleteBucket, nothing.
+    expect(mockS3Send).not.toHaveBeenCalled();
+    expect(mockStsSend).not.toHaveBeenCalled();
+  });
+
+  it('round-trip on no-drift snapshot is a logical no-op (zero AWS calls)', async () => {
+    // Stronger assertion: state == AWS implies update() must make no
+    // AWS-side mutations. For an immutable resource type this holds
+    // unconditionally regardless of which fields are present.
+    const observed = {
+      BucketName: PHYSICAL_ID,
+      DataRedundancy: 'SingleAvailabilityZone',
+    };
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    expect(mockS3Send).not.toHaveBeenCalled();
+  });
+
+  it('round-trip with drifted DataRedundancy (hypothetical) still issues zero AWS calls', async () => {
+    // Defensive: even if a future DataRedundancy value were added by
+    // AWS (today only `SingleAvailabilityZone` is valid) and observed
+    // != state, update() must still no-op rather than attempt an AWS
+    // call that would 400 — DataRedundancy is immutable. The deploy
+    // engine routes immutable-property changes through replacement
+    // (DELETE then CREATE), not update().
+    const oldProps = {
+      BucketName: PHYSICAL_ID,
+      DataRedundancy: 'SingleAvailabilityZone',
+    };
+    const newProps = {
+      BucketName: PHYSICAL_ID,
+      DataRedundancy: 'MultiAvailabilityZone', // hypothetical future value
+    };
+
+    const result = await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, newProps, oldProps);
+
+    expect(mockS3Send).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      physicalId: PHYSICAL_ID,
+      wasReplaced: false,
+    });
+  });
+});

--- a/tests/unit/provisioning/s3-tables-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/s3-tables-provider-roundtrip.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-s3tables', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-s3tables')>(
+    '@aws-sdk/client-s3tables'
+  );
+  class MockS3TablesClient {
+    config = { region: () => Promise.resolve('us-east-1') };
+    send = mockSend;
+  }
+  return { ...actual, S3TablesClient: MockS3TablesClient };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { S3TablesProvider } from '../../../src/provisioning/providers/s3-tables-provider.js';
+
+const BUCKET_ARN = 'arn:aws:s3tables:us-east-1:123:bucket/my-bucket';
+const NAMESPACE_PHYSICAL_ID = `${BUCKET_ARN}|my-namespace`;
+const TABLE_PHYSICAL_ID = `${BUCKET_ARN}|my-namespace|my-table`;
+
+describe('S3TablesProvider read-update round-trip', () => {
+  let provider: S3TablesProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new S3TablesProvider();
+  });
+
+  // Mechanical guard for the 3 latent bug classes documented in
+  // docs/provider-development.md § 3b "Read-update round-trip test".
+  //
+  // S3 Tables resources are immutable: update() is a documented no-op
+  // that returns { physicalId, wasReplaced: false } without touching
+  // AWS. The round-trip therefore must:
+  //   - Class 1 (discriminator-dependent): N/A — no FIFO-style flags.
+  //   - Class 2 (structurally-incomplete-when-empty): N/A — no nested
+  //     placeholder objects (RedrivePolicy / VpcConfig style).
+  //   - Truthy gate: N/A — update() does not gate on properties.
+  // The structural assertion is "round-trip never sends ANY SDK call"
+  // — any future regression that adds a real update() must explicitly
+  // confirm round-trip safety here.
+
+  it('AWS::S3Tables::TableBucket — no-op update fires zero SDK calls on round-trip', async () => {
+    // readCurrentState mock: GetTableBucket
+    mockSend.mockResolvedValueOnce({
+      name: 'my-bucket',
+      arn: BUCKET_ARN,
+    });
+
+    const observed = await provider.readCurrentState(
+      BUCKET_ARN,
+      'L',
+      'AWS::S3Tables::TableBucket'
+    );
+    expect(observed).toEqual({ TableBucketName: 'my-bucket' });
+
+    vi.clearAllMocks();
+
+    // Round-trip: pass observed as both new and previous.
+    const result = await provider.update(
+      'L',
+      BUCKET_ARN,
+      'AWS::S3Tables::TableBucket',
+      observed!,
+      observed!
+    );
+
+    expect(result).toEqual({ physicalId: BUCKET_ARN, wasReplaced: false });
+    // Immutable resource: update() must not call AWS at all.
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('AWS::S3Tables::Namespace — no-op update fires zero SDK calls on round-trip', async () => {
+    // readCurrentState for Namespace does no SDK call (physical id is
+    // the source of truth).
+    const observed = await provider.readCurrentState(
+      NAMESPACE_PHYSICAL_ID,
+      'L',
+      'AWS::S3Tables::Namespace'
+    );
+    expect(observed).toEqual({
+      TableBucketARN: BUCKET_ARN,
+      Namespace: ['my-namespace'],
+    });
+
+    vi.clearAllMocks();
+
+    const result = await provider.update(
+      'L',
+      NAMESPACE_PHYSICAL_ID,
+      'AWS::S3Tables::Namespace',
+      observed!,
+      observed!
+    );
+
+    expect(result).toEqual({ physicalId: NAMESPACE_PHYSICAL_ID, wasReplaced: false });
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('AWS::S3Tables::Table — no-op update fires zero SDK calls on round-trip', async () => {
+    // readCurrentState mock: GetTable
+    mockSend.mockResolvedValueOnce({
+      name: 'my-table',
+      format: 'ICEBERG',
+      namespace: ['my-namespace'],
+    });
+
+    const observed = await provider.readCurrentState(
+      TABLE_PHYSICAL_ID,
+      'L',
+      'AWS::S3Tables::Table'
+    );
+    expect(observed).toEqual({
+      TableBucketARN: BUCKET_ARN,
+      Namespace: 'my-namespace',
+      Name: 'my-table',
+      Format: 'ICEBERG',
+    });
+
+    vi.clearAllMocks();
+
+    const result = await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::S3Tables::Table',
+      observed!,
+      observed!
+    );
+
+    expect(result).toEqual({ physicalId: TABLE_PHYSICAL_ID, wasReplaced: false });
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('AWS::S3Tables::TableBucket — Format-less Table response: no Format key leaks to round-trip', async () => {
+    // Defensive: if AWS GetTable ever returned without `format`,
+    // readCurrentState must not synthesize a placeholder that
+    // round-trips into a future update(). Today update() is a no-op so
+    // the assertion is trivially satisfied; this test pins the contract
+    // for any future provider that adds a real update().
+    mockSend.mockResolvedValueOnce({
+      name: 'my-table',
+      // format intentionally undefined
+      namespace: ['my-namespace'],
+    });
+
+    const observed = await provider.readCurrentState(
+      TABLE_PHYSICAL_ID,
+      'L',
+      'AWS::S3Tables::Table'
+    );
+
+    // Format is create-only (Iceberg is the only legal value), so the
+    // skip-emit on undefined is justified per § 3b "Immutable on create".
+    expect(observed).toEqual({
+      TableBucketARN: BUCKET_ARN,
+      Namespace: 'my-namespace',
+      Name: 'my-table',
+    });
+    expect(observed).not.toHaveProperty('Format');
+
+    vi.clearAllMocks();
+
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::S3Tables::Table',
+      observed!,
+      observed!
+    );
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/provisioning/s3-vectors-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/s3-vectors-provider-roundtrip.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-s3vectors', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-s3vectors')>(
+    '@aws-sdk/client-s3vectors'
+  );
+  class MockS3VectorsClient {
+    config = { region: () => Promise.resolve('us-east-1') };
+    send = mockSend;
+  }
+  return { ...actual, S3VectorsClient: MockS3VectorsClient };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { S3VectorsProvider } from '../../../src/provisioning/providers/s3-vectors-provider.js';
+
+const RESOURCE_TYPE = 'AWS::S3Vectors::VectorBucket';
+const PHYSICAL_ID = 'my-vec-bucket';
+
+describe('S3VectorsProvider read-update round-trip', () => {
+  let provider: S3VectorsProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new S3VectorsProvider();
+  });
+
+  it('round-trip on no-drift snapshot is a logical no-op (zero AWS calls)', async () => {
+    // VectorBucket has no mutable properties — `update()` is a documented
+    // no-op. The round-trip on observedProperties must therefore make
+    // zero SDK calls regardless of which fields the snapshot contains.
+    const observed = {
+      VectorBucketName: PHYSICAL_ID,
+      EncryptionConfiguration: {
+        SSEType: 'aws:kms',
+        KMSKeyArn: 'arn:aws:kms:us-east-1:123:key/abc',
+      },
+    };
+
+    const result = await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    expect(result).toEqual({ physicalId: PHYSICAL_ID, wasReplaced: false });
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('round-trip on AES256 snapshot does not surface AWS-rejection-shape inputs', async () => {
+    // Even if a future code path were to ship update() with real
+    // SetEncryption-style mutations, an AES256 snapshot must not carry a
+    // KMSKeyArn. This is the Class 1 guard mirrored on the round-trip
+    // path: standard-encryption resources must not round-trip
+    // KMS-only fields.
+    const observed = {
+      VectorBucketName: PHYSICAL_ID,
+      EncryptionConfiguration: {
+        SSEType: 'AES256',
+      },
+    };
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    expect(mockSend).not.toHaveBeenCalled();
+    // Sanity check: the snapshot itself does not carry KMSKeyArn for AES256.
+    const enc = observed.EncryptionConfiguration as Record<string, unknown>;
+    expect(enc['KMSKeyArn']).toBeUndefined();
+  });
+
+  it('Class 1 — readCurrentState does not emit KMSKeyArn on an AES256 bucket', async () => {
+    // Defensive Class 1 guard: even if AWS surfaces an account-default
+    // KMS key ARN alongside sseType=AES256 (not the documented behavior
+    // today, but an SDK surface change away), readCurrentState must NOT
+    // emit KMSKeyArn — round-tripping it back via `cdkd drift --revert`
+    // would push a KMS-only field on a standard-encryption bucket and
+    // AWS rejects with "KMSKeyArn is only valid when SSEType is aws:kms".
+    mockSend.mockResolvedValueOnce({
+      vectorBucket: {
+        vectorBucketName: PHYSICAL_ID,
+        vectorBucketArn: `arn:aws:s3vectors:us-east-1:123:bucket/${PHYSICAL_ID}`,
+        encryptionConfiguration: {
+          sseType: 'AES256',
+          // Hypothetical AWS-managed default that should NOT be surfaced.
+          kmsKeyArn: 'arn:aws:kms:us-east-1:123:key/aws/s3vectors',
+        },
+      },
+    });
+
+    const result = await provider.readCurrentState(PHYSICAL_ID, 'L', RESOURCE_TYPE);
+
+    expect(result).toEqual({
+      VectorBucketName: PHYSICAL_ID,
+      EncryptionConfiguration: { SSEType: 'AES256' },
+    });
+    const enc = (result?.['EncryptionConfiguration'] ?? {}) as Record<string, unknown>;
+    expect(enc['KMSKeyArn']).toBeUndefined();
+  });
+
+  it('readCurrentState emits both SSEType and KMSKeyArn on aws:kms (legitimate KMS path)', async () => {
+    // Complement of the AES256 case: aws:kms encryption legitimately
+    // carries KMSKeyArn, and round-tripping it must preserve both.
+    mockSend.mockResolvedValueOnce({
+      vectorBucket: {
+        vectorBucketName: PHYSICAL_ID,
+        vectorBucketArn: `arn:aws:s3vectors:us-east-1:123:bucket/${PHYSICAL_ID}`,
+        encryptionConfiguration: {
+          sseType: 'aws:kms',
+          kmsKeyArn: 'arn:aws:kms:us-east-1:123:key/abc',
+        },
+      },
+    });
+
+    const result = await provider.readCurrentState(PHYSICAL_ID, 'L', RESOURCE_TYPE);
+
+    expect(result).toEqual({
+      VectorBucketName: PHYSICAL_ID,
+      EncryptionConfiguration: {
+        SSEType: 'aws:kms',
+        KMSKeyArn: 'arn:aws:kms:us-east-1:123:key/abc',
+      },
+    });
+  });
+});

--- a/tests/unit/provisioning/servicediscovery-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/servicediscovery-provider-roundtrip.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-servicediscovery', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-servicediscovery')>(
+    '@aws-sdk/client-servicediscovery'
+  );
+  return {
+    ...actual,
+    ServiceDiscoveryClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { ServiceDiscoveryProvider } from '../../../src/provisioning/providers/servicediscovery-provider.js';
+import { ResourceUpdateNotSupportedError } from '../../../src/utils/error-handler.js';
+
+describe('ServiceDiscoveryProvider read-update round-trip', () => {
+  let provider: ServiceDiscoveryProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ServiceDiscoveryProvider();
+  });
+
+  // ─── Class 1 / Class 2 / truthy-gate immunity ────────────────────
+  // Both PrivateDnsNamespace.update and Service.update reject with
+  // ResourceUpdateNotSupportedError. That uniformly precludes all
+  // three failure modes:
+  //   - Class 1 (discriminator-dependent placeholder pushed back)
+  //   - Class 2 (structurally-incomplete empty placeholder pushed back)
+  //   - Truthy-gate dropping `''` / `false` / `0`
+  // The round-trip surface here is the rejection, not the wire layer.
+
+  describe('Class 1: discriminator-dependent fields cannot leak via update()', () => {
+    it('PrivateDnsNamespace update rejects with ResourceUpdateNotSupportedError', async () => {
+      // Even if a future readCurrentState emitted Class 1 placeholders
+      // (e.g. SOA.TTL only valid on certain DNS types), update() never
+      // touches AWS — the rejection happens before any SDK call.
+      const observed = {
+        Name: 'mynamespace.local',
+        Description: '',
+        Tags: [] as Array<{ Key: string; Value: string }>,
+      };
+
+      await expect(
+        provider.update(
+          'L',
+          'ns-1',
+          'AWS::ServiceDiscovery::PrivateDnsNamespace',
+          observed,
+          observed
+        )
+      ).rejects.toThrow(ResourceUpdateNotSupportedError);
+
+      // No AWS calls were made (the rejection is synchronous).
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('Service update rejects with ResourceUpdateNotSupportedError on TCP-typed service', async () => {
+      // HealthCheckConfig.ResourcePath is HTTP/HTTPS-only (Class 1
+      // candidate). Service is created with Type=TCP and no
+      // ResourcePath — round-tripping must not somehow push
+      // ResourcePath: '' to AWS and trigger "ResourcePath is only
+      // valid when Type is HTTP/HTTPS". The rejection guarantees this.
+      const observed = {
+        Name: 'mysvc',
+        NamespaceId: 'ns-1',
+        Description: '',
+        Type: 'DNS',
+        DnsConfig: { DnsRecords: [{ Type: 'A', TTL: 60 }] },
+        HealthCheckConfig: { Type: 'TCP', FailureThreshold: 3 },
+        Tags: [] as Array<{ Key: string; Value: string }>,
+      };
+
+      await expect(
+        provider.update('L', 'srv-1', 'AWS::ServiceDiscovery::Service', observed, observed)
+      ).rejects.toThrow(ResourceUpdateNotSupportedError);
+
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Class 2: structurally-incomplete placeholders cannot reach AWS', () => {
+    it('Service update rejects rather than shipping {} / [] placeholders', async () => {
+      // If a hypothetical update() were implemented naively it could
+      // round-trip empty-object placeholders (e.g. an empty
+      // HealthCheckCustomConfig: {}) which AWS rejects as missing
+      // mandatory fields. The hard-rejection in update() is the
+      // structural guard.
+      const observed = {
+        Name: 'mysvc',
+        NamespaceId: 'ns-1',
+        Description: '',
+        DnsConfig: {},
+        HealthCheckConfig: {},
+        HealthCheckCustomConfig: {},
+        Tags: [] as Array<{ Key: string; Value: string }>,
+      };
+
+      await expect(
+        provider.update('L', 'srv-1', 'AWS::ServiceDiscovery::Service', observed, observed)
+      ).rejects.toThrow(ResourceUpdateNotSupportedError);
+    });
+  });
+
+  describe('Truthy-gate immunity: empty-string Description cannot be silently dropped', () => {
+    it('PrivateDnsNamespace update rejects rather than silently no-op a Description: "" revert', async () => {
+      // If a future update() forgot the `!== undefined` gate, an
+      // empty-string Description revert would silently no-op and
+      // `cdkd drift --revert` would falsely report success. The
+      // rejection makes the silent-no-op state physically unreachable.
+      const observed = {
+        Name: 'mynamespace.local',
+        Description: '',
+        Tags: [] as Array<{ Key: string; Value: string }>,
+      };
+
+      const error = await provider
+        .update(
+          'L',
+          'ns-1',
+          'AWS::ServiceDiscovery::PrivateDnsNamespace',
+          observed,
+          observed
+        )
+        .catch((e) => e);
+
+      expect(error).toBeInstanceOf(ResourceUpdateNotSupportedError);
+      // The rejection message points the user to deploy --replace /
+      // destroy + redeploy — not a misleading "succeeded".
+      expect((error as Error).message).toMatch(/cdkd deploy --replace|destroy \+ redeploy/i);
+    });
+  });
+
+  describe('getDriftUnknownPaths', () => {
+    it('declares Vpc as unreadable for PrivateDnsNamespace (GetNamespace does not return it)', () => {
+      // Without this declaration the drift comparator would walk
+      // state.Vpc (which cdkd stores from the template) against
+      // observed.Vpc (which readCurrentState deliberately omits) and
+      // report guaranteed false-positive drift on every clean run.
+      expect(
+        provider.getDriftUnknownPaths('AWS::ServiceDiscovery::PrivateDnsNamespace')
+      ).toEqual(['Vpc']);
+    });
+
+    it('returns empty array for Service (all read fields are AWS-readable)', () => {
+      expect(provider.getDriftUnknownPaths('AWS::ServiceDiscovery::Service')).toEqual([]);
+    });
+
+    it('returns empty array for unrelated resource types', () => {
+      expect(provider.getDriftUnknownPaths('AWS::S3::Bucket')).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/provisioning/sns-subscription-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/sns-subscription-provider-roundtrip.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  SubscribeCommand,
+  UnsubscribeCommand,
+  GetSubscriptionAttributesCommand,
+} from '@aws-sdk/client-sns';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    sns: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { SNSSubscriptionProvider } from '../../../src/provisioning/providers/sns-subscription-provider.js';
+
+const SUB_ARN_OLD = 'arn:aws:sns:us-east-1:1:my-topic:abcd-efgh';
+const SUB_ARN_NEW = 'arn:aws:sns:us-east-1:1:my-topic:wxyz-1234';
+const TOPIC_ARN = 'arn:aws:sns:us-east-1:1:my-topic';
+const QUEUE_ARN = 'arn:aws:sqs:us-east-1:1:queue';
+const RESOURCE_TYPE = 'AWS::SNS::Subscription';
+
+describe('SNSSubscriptionProvider read-update round-trip', () => {
+  let provider: SNSSubscriptionProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new SNSSubscriptionProvider();
+  });
+
+  it('Class 1 — email subscription (no RawMessageDelivery / RedrivePolicy / DeliveryPolicy on AWS) round-trip does not push protocol-only attrs', async () => {
+    // SNS attributes RawMessageDelivery (sqs/lambda/firehose/http(s)),
+    // DeliveryPolicy (http/https), RedrivePolicy (sqs/lambda),
+    // SubscriptionRoleArn (firehose), ReplayPolicy (firehose) are
+    // protocol-discriminated. AWS does not return them on
+    // GetSubscriptionAttributes for incompatible protocols, so
+    // readCurrentState should NOT emit them. Round-tripping the
+    // resulting snapshot through update() must not push any of them
+    // into the Subscribe call.
+    mockSend.mockResolvedValueOnce({
+      Attributes: {
+        TopicArn: TOPIC_ARN,
+        Protocol: 'email',
+        Endpoint: 'me@example.com',
+        // No RawMessageDelivery / DeliveryPolicy / RedrivePolicy / etc.
+        Owner: '1',
+        SubscriptionArn: SUB_ARN_OLD,
+      },
+    });
+    const observed = await provider.readCurrentState(SUB_ARN_OLD, 'L', RESOURCE_TYPE);
+
+    // Pre-condition: observed has no protocol-only keys.
+    expect(observed).toBeDefined();
+    expect(observed).not.toHaveProperty('RawMessageDelivery');
+    expect(observed).not.toHaveProperty('RedrivePolicy');
+    expect(observed).not.toHaveProperty('DeliveryPolicy');
+    expect(observed).not.toHaveProperty('SubscriptionRoleArn');
+    expect(observed).not.toHaveProperty('ReplayPolicy');
+
+    // update() is delete + create. Mock both mock.send calls.
+    vi.clearAllMocks();
+    mockSend.mockResolvedValueOnce({}); // Unsubscribe
+    mockSend.mockResolvedValueOnce({ SubscriptionArn: SUB_ARN_NEW }); // Subscribe
+
+    await provider.update('L', SUB_ARN_OLD, RESOURCE_TYPE, observed!, observed!);
+
+    const subscribeCall = mockSend.mock.calls.find((c) => c[0] instanceof SubscribeCommand);
+    expect(subscribeCall).toBeDefined();
+    const input = subscribeCall![0].input as {
+      TopicArn?: string;
+      Protocol?: string;
+      Endpoint?: string;
+      Attributes?: Record<string, string>;
+    };
+    // Class 1 guard: no protocol-only attribute is shipped on an email
+    // protocol subscription. AWS would reject these as "is only valid
+    // on sqs/lambda/firehose/http(s) protocols".
+    const attrs = input.Attributes ?? {};
+    expect(attrs).not.toHaveProperty('RawMessageDelivery');
+    expect(attrs).not.toHaveProperty('RedrivePolicy');
+    expect(attrs).not.toHaveProperty('DeliveryPolicy');
+    expect(attrs).not.toHaveProperty('SubscriptionRoleArn');
+    expect(attrs).not.toHaveProperty('ReplayPolicy');
+  });
+
+  it('Class 2 — readCurrentState does not emit empty-object placeholders for RedrivePolicy / DeliveryPolicy', async () => {
+    // Class 2 vulnerability: emitting `RedrivePolicy: {}` would round-
+    // trip into `JSON.stringify({}) === '{}'` on the Subscribe call,
+    // which AWS rejects ("Redrive policy does not contain mandatory
+    // attribute: deadLetterTargetArn"). The provider sidesteps this
+    // class by NOT emitting the key when AWS returns it as undefined
+    // (the field is also protocol-discriminated, so even on sqs/lambda
+    // a subscription without a DLQ has no RedrivePolicy on the wire).
+    mockSend.mockResolvedValueOnce({
+      Attributes: {
+        TopicArn: TOPIC_ARN,
+        Protocol: 'sqs',
+        Endpoint: QUEUE_ARN,
+        RawMessageDelivery: 'false',
+        // No RedrivePolicy / DeliveryPolicy on the wire.
+        Owner: '1',
+        SubscriptionArn: SUB_ARN_OLD,
+      },
+    });
+    const observed = await provider.readCurrentState(SUB_ARN_OLD, 'L', RESOURCE_TYPE);
+
+    expect(observed).not.toHaveProperty('RedrivePolicy');
+    expect(observed).not.toHaveProperty('DeliveryPolicy');
+  });
+
+  it('truthy gate — empty FilterPolicy reaches Subscribe (placeholder survives round-trip)', async () => {
+    // Truthy-gate regression guard. Pre-fix code used
+    // `if (filterPolicy)`, which silently drops `''` and the parsed
+    // empty-object placeholder is technically truthy ({}), but a
+    // string `''` (returned for an explicit "match all" filter cleared
+    // via console) would have been dropped. Post-fix the gate is
+    // `!== undefined`, so the explicit empty value reaches AWS as the
+    // documented way to clear FilterPolicy.
+    const observed: Record<string, unknown> = {
+      TopicArn: TOPIC_ARN,
+      Protocol: 'sqs',
+      Endpoint: QUEUE_ARN,
+      RawMessageDelivery: false,
+      FilterPolicy: '', // explicit empty (cleared on AWS side)
+    };
+
+    mockSend.mockResolvedValueOnce({}); // Unsubscribe
+    mockSend.mockResolvedValueOnce({ SubscriptionArn: SUB_ARN_NEW }); // Subscribe
+
+    await provider.update('L', SUB_ARN_OLD, RESOURCE_TYPE, observed, observed);
+
+    const subscribeCall = mockSend.mock.calls.find((c) => c[0] instanceof SubscribeCommand);
+    expect(subscribeCall).toBeDefined();
+    const attrs = (subscribeCall![0].input as { Attributes?: Record<string, string> }).Attributes;
+    // The empty FilterPolicy must NOT be silently dropped — AWS uses
+    // the empty placeholder as the documented "clear filter" signal.
+    expect(attrs).toBeDefined();
+    expect(attrs!['FilterPolicy']).toBe('');
+  });
+
+  it('round-trip happy path — sqs subscription with FilterPolicy survives readCurrentState → update() without rejection-shape inputs', async () => {
+    // End-to-end round-trip test (the structural guard documented in
+    // docs/provider-development.md § 3b). Read AWS-current shape, feed
+    // it back through update(), assert the Subscribe call shape would
+    // not be rejected by AWS.
+    mockSend.mockResolvedValueOnce({
+      Attributes: {
+        TopicArn: TOPIC_ARN,
+        Protocol: 'sqs',
+        Endpoint: QUEUE_ARN,
+        RawMessageDelivery: 'true',
+        FilterPolicy: '{"foo":["bar"]}',
+        Owner: '1',
+        SubscriptionArn: SUB_ARN_OLD,
+      },
+    });
+    const observed = await provider.readCurrentState(SUB_ARN_OLD, 'L', RESOURCE_TYPE);
+    expect(observed).toEqual({
+      TopicArn: TOPIC_ARN,
+      Protocol: 'sqs',
+      Endpoint: QUEUE_ARN,
+      RawMessageDelivery: true,
+      FilterPolicy: { foo: ['bar'] },
+    });
+
+    vi.clearAllMocks();
+    mockSend.mockResolvedValueOnce({}); // Unsubscribe (delete in update)
+    mockSend.mockResolvedValueOnce({ SubscriptionArn: SUB_ARN_NEW }); // Subscribe
+
+    const result = await provider.update('L', SUB_ARN_OLD, RESOURCE_TYPE, observed!, observed!);
+
+    expect(result.wasReplaced).toBe(true);
+    expect(result.physicalId).toBe(SUB_ARN_NEW);
+
+    // Unsubscribe + Subscribe were called.
+    expect(mockSend.mock.calls.filter((c) => c[0] instanceof UnsubscribeCommand)).toHaveLength(1);
+    const subscribeCall = mockSend.mock.calls.find((c) => c[0] instanceof SubscribeCommand);
+    expect(subscribeCall).toBeDefined();
+
+    const input = subscribeCall![0].input as {
+      TopicArn?: string;
+      Protocol?: string;
+      Endpoint?: string;
+      Attributes?: Record<string, string>;
+    };
+    expect(input.TopicArn).toBe(TOPIC_ARN);
+    expect(input.Protocol).toBe('sqs');
+    expect(input.Endpoint).toBe(QUEUE_ARN);
+    // FilterPolicy was JSON.stringify-ed back to the wire form.
+    expect(input.Attributes?.['FilterPolicy']).toBe('{"foo":["bar"]}');
+    // Class 2 guard: no '{}' placeholder shipped.
+    expect(input.Attributes?.['FilterPolicy']).not.toBe('{}');
+    expect(input.Attributes?.['RedrivePolicy']).toBeUndefined();
+  });
+
+  it('returns no-undefined readCurrentState that survives JSON serialization (state save round-trip)', async () => {
+    // Defensive: make sure readCurrentState produces only JSON-safe
+    // values so saveState doesn't trip on undefined.
+    mockSend.mockResolvedValueOnce({
+      Attributes: {
+        TopicArn: TOPIC_ARN,
+        Protocol: 'lambda',
+        Endpoint: 'arn:aws:lambda:us-east-1:1:function:f',
+        Owner: '1',
+        SubscriptionArn: SUB_ARN_OLD,
+      },
+    });
+    const observed = await provider.readCurrentState(SUB_ARN_OLD, 'L', RESOURCE_TYPE);
+    expect(observed).toBeDefined();
+    expect(JSON.parse(JSON.stringify(observed))).toEqual(observed);
+
+    // Sanity: GetSubscriptionAttributes was the only call.
+    expect(mockSend.mock.calls).toHaveLength(1);
+    expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(GetSubscriptionAttributesCommand);
+  });
+});

--- a/tests/unit/provisioning/ssm-parameter-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/ssm-parameter-provider-roundtrip.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PutParameterCommand } from '@aws-sdk/client-ssm';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    ssm: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { SSMParameterProvider } from '../../../src/provisioning/providers/ssm-parameter-provider.js';
+
+const PARAM_NAME = '/foo/bar';
+const RESOURCE_TYPE = 'AWS::SSM::Parameter';
+
+describe('SSMParameterProvider read-update round-trip', () => {
+  let provider: SSMParameterProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new SSMParameterProvider();
+  });
+
+  it('truthy-gate fix: empty Description placeholder reaches PutParameter on round-trip', async () => {
+    // Mechanical guard against the truthy-gate silent-fail mode:
+    // readCurrentState emits `Description: ''` as the always-emit
+    // placeholder. If update() truthy-gates on Description, the empty
+    // string is silently dropped, the AWS-side description is never
+    // cleared, and `cdkd drift --revert` reports `✓ reverted` while the
+    // next drift run re-detects the same drift.
+    //
+    // After the fix (`!== undefined`), the empty string must reach
+    // PutParameterCommand.input.Description.
+    mockSend.mockResolvedValueOnce({}); // PutParameter response
+
+    const observed = {
+      Name: PARAM_NAME,
+      Type: 'String',
+      Value: 'bar',
+      Description: '', // ← placeholder from readCurrentState minimum response
+      AllowedPattern: '',
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    await provider.update('L', PARAM_NAME, RESOURCE_TYPE, observed, observed);
+
+    const putCall = mockSend.mock.calls.find((c) => c[0] instanceof PutParameterCommand);
+    expect(putCall).toBeDefined();
+    const input = putCall![0].input as {
+      Description?: string;
+      AllowedPattern?: string;
+    };
+    expect(input.Description).toBe('');
+    expect(input.AllowedPattern).toBe('');
+  });
+
+  it('round-trip on no-drift snapshot does not emit truthy-dropped fields', async () => {
+    // Symmetric assertion: a populated observedProperties round-trip
+    // must reach AWS with every user-controllable field — never silently
+    // dropped by a stale truthy gate.
+    mockSend.mockResolvedValueOnce({});
+
+    const observed = {
+      Name: PARAM_NAME,
+      Type: 'String',
+      Value: 'hello',
+      Description: 'a description',
+      AllowedPattern: '^[a-z]+$',
+      Tier: 'Standard',
+      DataType: 'text',
+      Tags: [{ Key: 'team', Value: 'platform' }],
+    };
+
+    await provider.update('L', PARAM_NAME, RESOURCE_TYPE, observed, observed);
+
+    const putCall = mockSend.mock.calls.find((c) => c[0] instanceof PutParameterCommand);
+    expect(putCall).toBeDefined();
+    const input = putCall![0].input as {
+      Name?: string;
+      Type?: string;
+      Value?: string;
+      Description?: string;
+      AllowedPattern?: string;
+      Tier?: string;
+      DataType?: string;
+      Overwrite?: boolean;
+    };
+    expect(input.Name).toBe(PARAM_NAME);
+    expect(input.Type).toBe('String');
+    expect(input.Value).toBe('hello');
+    expect(input.Description).toBe('a description');
+    expect(input.AllowedPattern).toBe('^[a-z]+$');
+    expect(input.Tier).toBe('Standard');
+    expect(input.DataType).toBe('text');
+    expect(input.Overwrite).toBe(true);
+  });
+
+  it('Class 1: KeyId only valid for SecureString — readCurrentState does not emit it for String parameters', async () => {
+    // KeyId is the SSM Parameter Class 1 discriminator field: it is
+    // only valid when Type === 'SecureString'. Emitting it as a
+    // placeholder on a String / StringList parameter would cause
+    // `cdkd drift --revert` to push KeyId back to AWS and AWS rejects
+    // ("KeyId is not allowed for parameters of type String").
+    //
+    // The current readCurrentState (correctly) omits KeyId entirely
+    // for non-SecureString parameters. This test pins that behavior so
+    // a future "always-emit" refactor can't silently regress it.
+    const { GetParameterCommand, DescribeParametersCommand, ListTagsForResourceCommand } =
+      await import('@aws-sdk/client-ssm');
+    mockSend
+      .mockResolvedValueOnce({
+        Parameter: { Name: PARAM_NAME, Type: 'String', Value: 'bar' },
+      })
+      .mockResolvedValueOnce({ Parameters: [{ Name: PARAM_NAME }] })
+      .mockResolvedValueOnce({ TagList: [] });
+
+    const observed = await provider.readCurrentState(PARAM_NAME, 'L', RESOURCE_TYPE);
+
+    expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(GetParameterCommand);
+    expect(mockSend.mock.calls[1]?.[0]).toBeInstanceOf(DescribeParametersCommand);
+    expect(mockSend.mock.calls[2]?.[0]).toBeInstanceOf(ListTagsForResourceCommand);
+
+    // KeyId must NOT be in the snapshot for a String parameter.
+    expect(observed).toBeDefined();
+    expect(Object.keys(observed!)).not.toContain('KeyId');
+
+    // Round-trip: pushing this snapshot back through update() must not
+    // include KeyId in the PutParameter call.
+    vi.clearAllMocks();
+    mockSend.mockResolvedValueOnce({});
+    await provider.update('L', PARAM_NAME, RESOURCE_TYPE, observed!, observed!);
+    const putCall = mockSend.mock.calls.find((c) => c[0] instanceof PutParameterCommand);
+    expect(putCall).toBeDefined();
+    const input = putCall![0].input as Record<string, unknown>;
+    expect(input).not.toHaveProperty('KeyId');
+  });
+});

--- a/tests/unit/provisioning/stepfunctions-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/stepfunctions-provider-roundtrip.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateStateMachineCommand } from '@aws-sdk/client-sfn';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-sfn', async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    SFNClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { StepFunctionsProvider } from '../../../src/provisioning/providers/stepfunctions-provider.js';
+
+const SM_ARN = 'arn:aws:states:us-east-1:123456789012:stateMachine:my-sm';
+const RESOURCE_TYPE = 'AWS::StepFunctions::StateMachine';
+
+interface UpdateInput {
+  encryptionConfiguration?: { type?: unknown };
+  loggingConfiguration?: {
+    level?: string;
+    includeExecutionData?: boolean;
+    destinations?: Array<{ cloudWatchLogsLogGroup?: { logGroupArn?: string } }>;
+  };
+  tracingConfiguration?: { enabled?: boolean };
+  roleArn?: string;
+  definition?: string;
+}
+
+function findUpdateInput(): UpdateInput | undefined {
+  const call = mockSend.mock.calls.find(
+    (c: unknown[]) => c[0] instanceof UpdateStateMachineCommand
+  );
+  if (!call) return undefined;
+  return (call[0] as UpdateStateMachineCommand).input as UpdateInput;
+}
+
+/**
+ * Round-trip tests for `StepFunctionsProvider`. These mechanically guard the
+ * three latent bug classes documented in
+ * `docs/provider-development.md § 3b "Read-update round-trip test"`:
+ *
+ *   - Class 1 (type-discriminator-dependent fields): n/a for SFN —
+ *     LoggingConfiguration / TracingConfiguration are valid on both STANDARD
+ *     and EXPRESS workflows, so no discriminator gating is needed.
+ *   - Class 2 (structurally-incomplete-when-empty): EncryptionConfiguration
+ *     `{}` (no `Type`) is rejected by AWS as "Member must not be null", and
+ *     LoggingConfiguration `{}` (no `Level`) would inadvertently disable
+ *     logging if forwarded — both must fold to `undefined` on the wire.
+ *   - Truthy gate: SFN `update()` does not gate any optional field with a
+ *     truthy guard (RoleArn / Definition forwarded as-is), so the truthy-gate
+ *     class is structurally absent. Documented here for future-proofing.
+ */
+describe('StepFunctionsProvider read-update round-trip', () => {
+  let provider: StepFunctionsProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new StepFunctionsProvider();
+  });
+
+  it('Class 2 — EncryptionConfiguration {} placeholder does NOT reach UpdateStateMachine', async () => {
+    // Mock the AWS-minimum DescribeStateMachine response: required fields
+    // only, every optional sub-config absent. readCurrentState should
+    // emit `EncryptionConfiguration: {}` per the always-emit contract.
+    mockSend.mockResolvedValueOnce({
+      stateMachineArn: SM_ARN,
+      name: 'my-sm',
+      type: 'STANDARD',
+      // No encryptionConfiguration on the wire
+    });
+    mockSend.mockResolvedValueOnce({ tags: [] });
+
+    const observed = await provider.readCurrentState(SM_ARN, 'L', RESOURCE_TYPE);
+    expect(observed?.['EncryptionConfiguration']).toEqual({});
+
+    // Round-trip: pass the placeholder back through update() as both new
+    // and old. With the Class 2 sanitize in mapEncryptionConfiguration,
+    // the empty placeholder must fold to `undefined` on the wire so AWS
+    // does not reject with "encryptionConfiguration.type: Member must
+    // not be null".
+    vi.clearAllMocks();
+    mockSend.mockResolvedValueOnce({}); // UpdateStateMachine
+    mockSend.mockResolvedValueOnce({
+      stateMachineArn: SM_ARN,
+      name: 'my-sm',
+      revisionId: 'rev-1',
+    }); // DescribeStateMachine after update
+
+    await provider.update('L', SM_ARN, RESOURCE_TYPE, observed!, observed!);
+
+    const input = findUpdateInput();
+    expect(input).toBeDefined();
+    expect(input?.encryptionConfiguration).toBeUndefined();
+  });
+
+  it('Class 2 — LoggingConfiguration {} placeholder does NOT reach UpdateStateMachine', async () => {
+    mockSend.mockResolvedValueOnce({
+      stateMachineArn: SM_ARN,
+      name: 'my-sm',
+      type: 'STANDARD',
+      // No loggingConfiguration on the wire
+    });
+    mockSend.mockResolvedValueOnce({ tags: [] });
+
+    const observed = await provider.readCurrentState(SM_ARN, 'L', RESOURCE_TYPE);
+    expect(observed?.['LoggingConfiguration']).toEqual({});
+
+    vi.clearAllMocks();
+    mockSend.mockResolvedValueOnce({});
+    mockSend.mockResolvedValueOnce({
+      stateMachineArn: SM_ARN,
+      name: 'my-sm',
+      revisionId: 'rev-1',
+    });
+
+    await provider.update('L', SM_ARN, RESOURCE_TYPE, observed!, observed!);
+
+    const input = findUpdateInput();
+    // Empty placeholder => no inadvertent "set Level to OFF" mutation.
+    expect(input?.loggingConfiguration).toBeUndefined();
+  });
+
+  it('Case mapping — populated LoggingConfiguration round-trips as SDK camelCase, not CFn PascalCase', async () => {
+    // Regression for the case-mismatch bug in update(): previously the
+    // CFn-PascalCase value from cdkd state (`{ Level: 'ALL' }`) was cast
+    // straight to the SDK camelCase type (`{ level: 'ALL' }`) — the cast
+    // is a no-op at runtime, so AWS received the wrong shape and silently
+    // ignored Level / IncludeExecutionData / Destinations. With the
+    // PascalCase->camelCase mapper in place, observed values must arrive
+    // at the wire in the SDK shape.
+    mockSend.mockResolvedValueOnce({
+      stateMachineArn: SM_ARN,
+      name: 'my-sm',
+      type: 'STANDARD',
+      loggingConfiguration: {
+        level: 'ALL',
+        includeExecutionData: true,
+        destinations: [
+          {
+            cloudWatchLogsLogGroup: {
+              logGroupArn: 'arn:aws:logs:us-east-1:123:log-group:/aws/sfn',
+            },
+          },
+        ],
+      },
+      tracingConfiguration: { enabled: true },
+    });
+    mockSend.mockResolvedValueOnce({ tags: [] });
+
+    const observed = await provider.readCurrentState(SM_ARN, 'L', RESOURCE_TYPE);
+    // Pre-condition: readCurrentState surfaced the CFn (PascalCase) shape.
+    expect(observed?.['LoggingConfiguration']).toEqual({
+      Level: 'ALL',
+      IncludeExecutionData: true,
+      Destinations: [
+        {
+          CloudWatchLogsLogGroup: {
+            LogGroupArn: 'arn:aws:logs:us-east-1:123:log-group:/aws/sfn',
+          },
+        },
+      ],
+    });
+
+    vi.clearAllMocks();
+    mockSend.mockResolvedValueOnce({});
+    mockSend.mockResolvedValueOnce({
+      stateMachineArn: SM_ARN,
+      name: 'my-sm',
+      revisionId: 'rev-1',
+    });
+
+    await provider.update('L', SM_ARN, RESOURCE_TYPE, observed!, observed!);
+
+    const input = findUpdateInput();
+    // Must be SDK camelCase — not CFn PascalCase. A regression here
+    // (e.g. `{ Level: 'ALL' }`) would silently disable logging because
+    // AWS would not recognize the field.
+    expect(input?.loggingConfiguration).toEqual({
+      level: 'ALL',
+      includeExecutionData: true,
+      destinations: [
+        {
+          cloudWatchLogsLogGroup: {
+            logGroupArn: 'arn:aws:logs:us-east-1:123:log-group:/aws/sfn',
+          },
+        },
+      ],
+    });
+    expect(input?.tracingConfiguration).toEqual({ enabled: true });
+  });
+
+  it('Truthy-gate class — RoleArn / Definition forwarded as-is on round-trip (no truthy filtering)', async () => {
+    // SFN's update() does not currently apply a truthy gate to any
+    // optional field, so the truthy-gate class is structurally absent.
+    // Lock that in: an observed RoleArn must reach UpdateStateMachine
+    // unchanged, and an observed (non-empty) Definition must round-trip
+    // through buildDefinitionString to the SDK input.
+    mockSend.mockResolvedValueOnce({
+      stateMachineArn: SM_ARN,
+      name: 'my-sm',
+      type: 'STANDARD',
+      roleArn: 'arn:aws:iam::123:role/sfn',
+      definition: '{"StartAt":"P","States":{"P":{"Type":"Pass","End":true}}}',
+    });
+    mockSend.mockResolvedValueOnce({ tags: [] });
+
+    const observed = await provider.readCurrentState(SM_ARN, 'L', RESOURCE_TYPE);
+
+    vi.clearAllMocks();
+    mockSend.mockResolvedValueOnce({});
+    mockSend.mockResolvedValueOnce({
+      stateMachineArn: SM_ARN,
+      name: 'my-sm',
+      revisionId: 'rev-1',
+    });
+
+    await provider.update('L', SM_ARN, RESOURCE_TYPE, observed!, observed!);
+
+    const input = findUpdateInput();
+    expect(input?.roleArn).toBe('arn:aws:iam::123:role/sfn');
+    // Definition is the JSON-stringified form of the parsed object the
+    // comparator uses — buildDefinitionString re-stringifies it.
+    expect(typeof input?.definition).toBe('string');
+    expect(JSON.parse(input!.definition!)).toEqual({
+      StartAt: 'P',
+      States: { P: { Type: 'Pass', End: true } },
+    });
+  });
+
+  it('round-trip on no-drift snapshot does not produce an AWS-rejection-shaped UpdateStateMachine input', async () => {
+    // End-to-end mechanical guard: take the AWS-minimum response, run
+    // through readCurrentState, then update() with observed as both new
+    // and old, and confirm the wire-side input contains nothing AWS
+    // would reject.
+    mockSend.mockResolvedValueOnce({
+      stateMachineArn: SM_ARN,
+      name: 'my-sm',
+      type: 'STANDARD',
+    });
+    mockSend.mockResolvedValueOnce({ tags: [] });
+
+    const observed = await provider.readCurrentState(SM_ARN, 'L', RESOURCE_TYPE);
+
+    vi.clearAllMocks();
+    mockSend.mockResolvedValueOnce({});
+    mockSend.mockResolvedValueOnce({
+      stateMachineArn: SM_ARN,
+      name: 'my-sm',
+      revisionId: 'rev-1',
+    });
+
+    await provider.update('L', SM_ARN, RESOURCE_TYPE, observed!, observed!);
+
+    const input = findUpdateInput();
+    expect(input).toBeDefined();
+
+    // Class 2 rejection-shape checks:
+    if (input?.encryptionConfiguration !== undefined) {
+      // AWS rejects encryptionConfiguration without `type`.
+      expect(input.encryptionConfiguration.type).toBeDefined();
+    }
+    if (input?.loggingConfiguration !== undefined) {
+      // A logging configuration without `level` is meaningless on the wire.
+      expect(input.loggingConfiguration.level).toBeDefined();
+    }
+    // No DescribeStateMachine ever returned PascalCase keys to the wire.
+    if (input?.loggingConfiguration !== undefined) {
+      expect(
+        (input.loggingConfiguration as Record<string, unknown>)['Level']
+      ).toBeUndefined();
+    }
+    if (input?.tracingConfiguration !== undefined) {
+      expect(
+        (input.tracingConfiguration as Record<string, unknown>)['Enabled']
+      ).toBeUndefined();
+    }
+  });
+});

--- a/tests/unit/provisioning/stepfunctions-provider.test.ts
+++ b/tests/unit/provisioning/stepfunctions-provider.test.ts
@@ -157,31 +157,40 @@ describe('StepFunctionsProvider', () => {
       ).rejects.toThrow('Failed to create Step Functions state machine MyStateMachine');
     });
 
-    it('should pass StateMachineType and other configurations', async () => {
+    it('should pass StateMachineType and translate PascalCase configurations to SDK camelCase', async () => {
       mockSend.mockResolvedValueOnce({
         stateMachineArn:
           'arn:aws:states:us-east-1:123456789012:stateMachine:MyExpress',
       });
 
-      const loggingConfiguration = {
-        level: 'ALL',
-        includeExecutionData: true,
-        destinations: [{ cloudWatchLogsLogGroup: { logGroupArn: 'arn:aws:logs:...' } }],
-      };
-      const tracingConfiguration = { enabled: true };
-
+      // CFn templates ALWAYS use PascalCase property names; the provider
+      // is responsible for translating to the SDK's camelCase shape on
+      // the wire (see mapLoggingConfiguration / mapTracingConfiguration
+      // in stepfunctions-provider.ts).
       await provider.create('MyExpress', 'AWS::StepFunctions::StateMachine', {
         RoleArn: 'arn:aws:iam::123456789012:role/role',
         DefinitionString: '{}',
         StateMachineType: 'EXPRESS',
-        LoggingConfiguration: loggingConfiguration,
-        TracingConfiguration: tracingConfiguration,
+        LoggingConfiguration: {
+          Level: 'ALL',
+          IncludeExecutionData: true,
+          Destinations: [
+            { CloudWatchLogsLogGroup: { LogGroupArn: 'arn:aws:logs:...' } },
+          ],
+        },
+        TracingConfiguration: { Enabled: true },
       });
 
       const createCall = mockSend.mock.calls[0][0];
       expect(createCall.input.type).toBe('EXPRESS');
-      expect(createCall.input.loggingConfiguration).toEqual(loggingConfiguration);
-      expect(createCall.input.tracingConfiguration).toEqual(tracingConfiguration);
+      expect(createCall.input.loggingConfiguration).toEqual({
+        level: 'ALL',
+        includeExecutionData: true,
+        destinations: [
+          { cloudWatchLogsLogGroup: { logGroupArn: 'arn:aws:logs:...' } },
+        ],
+      });
+      expect(createCall.input.tracingConfiguration).toEqual({ enabled: true });
     });
   });
 

--- a/tests/unit/provisioning/wafv2-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/wafv2-provider-roundtrip.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CreateWebACLCommand,
+  GetWebACLCommand,
+  UpdateWebACLCommand,
+} from '@aws-sdk/client-wafv2';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-wafv2', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-wafv2')>(
+    '@aws-sdk/client-wafv2'
+  );
+  return {
+    ...actual,
+    WAFV2Client: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { WAFv2WebACLProvider } from '../../../src/provisioning/providers/wafv2-provider.js';
+
+const ARN = 'arn:aws:wafv2:us-east-1:123456789012:regional/webacl/my-acl/abc-123';
+
+const RESOURCE_TYPE = 'AWS::WAFv2::WebACL';
+
+describe('WAFv2WebACLProvider read-update round-trip', () => {
+  let provider: WAFv2WebACLProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new WAFv2WebACLProvider();
+  });
+
+  it('Class 2 — empty Description placeholder is sanitized to undefined on update() round-trip', async () => {
+    // Mechanical guard for Class 2 placeholder regression on
+    // structurally-incomplete-when-empty fields. See
+    // docs/provider-development.md § 3b "Read-update round-trip test".
+    //
+    // readCurrentState always-emits `Description: ''` on a WebACL with
+    // no description (state-keys-only top-level walk requires the
+    // placeholder for console-side ADD detection). AWS WAFv2 rejects
+    // `Description: ''` on UpdateWebACL with "Member must have length
+    // greater than or equal to 1" (min 1, max 256). The Class 2 fix
+    // sanitizes empty -> undefined at the wire layer in update().
+
+    // observed = what readCurrentState would have produced on a WebACL
+    // without a description.
+    const observed: Record<string, unknown> = {
+      Name: 'my-acl',
+      Scope: 'REGIONAL',
+      Description: '',
+      DefaultAction: { Allow: {} },
+      Rules: [],
+      VisibilityConfig: {
+        SampledRequestsEnabled: true,
+        CloudWatchMetricsEnabled: true,
+        MetricName: 'm',
+      },
+      CustomResponseBodies: {},
+      TokenDomains: [],
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    // GetWebACL (LockToken lookup), then UpdateWebACL.
+    mockSend
+      .mockResolvedValueOnce({
+        WebACL: { Id: 'abc-123', Name: 'my-acl' },
+        LockToken: 'lt',
+      })
+      .mockResolvedValueOnce({});
+
+    await provider.update('L', ARN, RESOURCE_TYPE, observed, observed);
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateWebACLCommand);
+    expect(updateCall).toBeDefined();
+    const input = updateCall![0].input as { Description?: string };
+    // Class 2: empty Description placeholder MUST NOT reach AWS as ''
+    // (would be rejected with min-length-1 validation).
+    expect(input.Description).toBeUndefined();
+  });
+
+  it('Class 2 — empty Description placeholder is sanitized to undefined on create() too', async () => {
+    // Symmetric guard: create() also takes user properties from state
+    // (e.g. CREATE-after-replacement), so the same sanitize must apply.
+    const properties: Record<string, unknown> = {
+      Name: 'my-acl',
+      Scope: 'REGIONAL',
+      Description: '',
+      DefaultAction: { Allow: {} },
+      Rules: [],
+      VisibilityConfig: {
+        SampledRequestsEnabled: true,
+        CloudWatchMetricsEnabled: true,
+        MetricName: 'm',
+      },
+    };
+
+    mockSend.mockResolvedValueOnce({
+      Summary: { ARN, Id: 'abc-123' },
+    });
+
+    await provider.create('L', RESOURCE_TYPE, properties);
+
+    const createCall = mockSend.mock.calls.find((c) => c[0] instanceof CreateWebACLCommand);
+    expect(createCall).toBeDefined();
+    const input = createCall![0].input as { Description?: string };
+    expect(input.Description).toBeUndefined();
+  });
+
+  it('non-empty Description survives the round-trip unchanged', async () => {
+    // Negative control: a user-supplied Description must NOT be dropped
+    // by the sanitize. Only the empty-string placeholder is filtered.
+    const observed: Record<string, unknown> = {
+      Name: 'my-acl',
+      Scope: 'REGIONAL',
+      Description: 'a real description',
+      DefaultAction: { Allow: {} },
+      Rules: [],
+      VisibilityConfig: {
+        SampledRequestsEnabled: true,
+        CloudWatchMetricsEnabled: true,
+        MetricName: 'm',
+      },
+      CustomResponseBodies: {},
+      TokenDomains: [],
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend
+      .mockResolvedValueOnce({
+        WebACL: { Id: 'abc-123', Name: 'my-acl' },
+        LockToken: 'lt',
+      })
+      .mockResolvedValueOnce({});
+
+    await provider.update('L', ARN, RESOURCE_TYPE, observed, observed);
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateWebACLCommand);
+    const input = updateCall![0].input as { Description?: string };
+    expect(input.Description).toBe('a real description');
+  });
+
+  it('round-trip: every observed placeholder value reaches UpdateWebACL without AWS-rejection-shaped inputs', async () => {
+    // Broad guard: state == AWS-current snapshot, so update() must
+    // produce a no-op-equivalent UpdateWebACL call. Verifies no
+    // Class 2 placeholder (CustomResponseBodies: {}, TokenDomains: [],
+    // Rules: []) translates to an AWS-rejected shape.
+    const observed: Record<string, unknown> = {
+      Name: 'my-acl',
+      Scope: 'REGIONAL',
+      Description: '',
+      DefaultAction: { Allow: {} },
+      Rules: [],
+      VisibilityConfig: {
+        SampledRequestsEnabled: true,
+        CloudWatchMetricsEnabled: true,
+        MetricName: 'm',
+      },
+      CustomResponseBodies: {},
+      TokenDomains: [],
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend
+      .mockResolvedValueOnce({
+        WebACL: { Id: 'abc-123', Name: 'my-acl' },
+        LockToken: 'lt',
+      })
+      .mockResolvedValueOnce({});
+
+    await provider.update('L', ARN, RESOURCE_TYPE, observed, observed);
+
+    const updateCall = mockSend.mock.calls.find((c) => c[0] instanceof UpdateWebACLCommand);
+    const input = updateCall![0].input as Record<string, unknown>;
+
+    // Class 2 — empty Description must be sanitized to undefined.
+    expect(input['Description']).toBeUndefined();
+    // Empty-array / empty-map placeholders are accepted by AWS as
+    // "no rules / no custom response bodies / no token domains" and
+    // legitimately reach the wire as-is.
+    expect(input['Rules']).toEqual([]);
+    // GetWebACL ran for LockToken acquisition.
+    expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(GetWebACLCommand);
+  });
+});


### PR DESCRIPTION
## Summary

PR 5/5 — final batch of the post-#162 round-trip audit. Audits the remaining 20 providers and adds round-trip property tests. **Every SDK provider in the tree now has a mechanical round-trip guard.**

### Across 20 providers

- **6 Class 1** fixes (type-discriminator-dependent placeholder gating)
- **18 Class 2** fixes (structurally-incomplete-when-empty sanitize)
- **11 truthy-gate** fixes (`!== undefined` over truthy check)
- + multiple always-emit and `getDriftUnknownPaths` improvements
- **91 new round-trip tests** (1816 → 1907 total)

### Per-provider headlines

| Provider | Highlight |
|---|---|
| Cognito | 2 Class 2 (`SmsConfiguration` / `UserPoolAddOns` empty placeholders rejected by AWS) + 4 truthy gates on UserPool message strings |
| StepFunctions | 2 Class 2 + **structural fix** for PascalCase→camelCase mapping (was silently sending unrecognized keys to AWS, masking drift) |
| EventBridge Bus | 1 Class 2 (`DeadLetterConfig.Arn: ''` invalid ARN) |
| EventBridge Rule | clean (round-trip test added as structural guard) |
| SSM Parameter | 5 truthy gates so empty `Description` / `AllowedPattern` reach `PutParameterCommand` |
| CloudWatch Alarm | 1 Class 1 (`Metrics: []` JS-truthy routed into wrong branch) + 5 Class 2 (empty-string field rejection / silent-clear) |
| CodeBuild | 3 Class 2 (`ServiceRole` / `EncryptionKey` / `SourceVersion` empty rejection) |
| Glue | 1 truthy gate on SerdeInfo Parameters |
| WAFv2 | 1 Class 2 (`Description: ''` violates min-length-1) |
| Firehose | 1 always-emit fix (Tags catch path) |
| Kinesis | 2 Class 1 (`ShardCount` PROVISIONED-only; `StreamEncryption: NONE` rejected) |
| CloudTrail | 2 Class 1 + 4 Class 2 (`sanitizeArn` helper) + always-emit gaps closed |
| Logs LogGroup | 2 always-emit fixes (`RetentionInDays` / `Tags`) + `getDriftUnknownPaths` |
| SNS Subscription | 1 truthy gate on `FilterPolicy` (empty clear) |
| ServiceDiscovery | `getDriftUnknownPaths(['Vpc'])` (was firing false drift) |
| EFS | clean — round-trip tests as structural guards |
| S3 Directory Bucket / S3 Tables / AgentCore Runtime | clean — round-trip tests as structural guards |
| S3 Vectors | 1 Class 1 (`KMSKeyArn` KMS-only — defensive) |

### Notable bugs

- **StepFunctions silent-fail mode**: state-side PascalCase didn't map to SDK camelCase, so `UpdateStateMachine` silently ignored every config key. `cdkd drift --revert` reported `✓ reverted` while AWS kept the change — same silent-fail mode as IAM Role Description (#161).
- **CloudWatch Alarm `Metrics: []` JS-truthy bug**: empty array `[]` is truthy in JS, so a metric-style alarm whose `observedProperties` snapshot carried the `Metrics: []` placeholder would silently route into the metric-math branch on `--revert` and AWS rejected with mixed-form.
- **Firehose / Logs LogGroup always-emit gaps**: drift detection silently broken on certain console-side adds because keys were absent from the snapshot under specific conditions (Firehose: tag-API failure; LogGroup: retention/tags conditional emit).

## Test plan

- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` clean
- [x] `npx vitest --run` — 1907 tests pass (was 1816; **91 new round-trip tests**)
- [x] `/run-integ stepfunctions` — deploy 5/5 in 15s, destroy 5/5 / 0 errors / 0 orphans

## Audit completion

This closes the round-trip audit. Every SDK provider in `src/provisioning/providers/**` now has a round-trip property test that mechanically guards against the 3 bug classes. Future provider authors must add the test per `docs/provider-development.md § 3b`.
