### PR TITLE
fix(drift): S3 Bucket Tags always-emit + audit closure for missed providers (PR 6)

### DIFF
--- a/src/provisioning/providers/s3-bucket-provider.ts
+++ b/src/provisioning/providers/s3-bucket-provider.ts
@@ -976,19 +976,32 @@ export class S3BucketProvider implements ResourceProvider {
       this.logger.debug(`Applied EventBridge notification to bucket ${bucketName}`);
     }
 
-    // CORS Configuration
+    // CORS Configuration. Skip empty-rules placeholder (Class 2): AWS
+    // rejects `PutBucketCors` with zero rules. The empty array can reach
+    // here from a `--revert` round-trip if a future readCurrentState
+    // emits `CorsConfiguration: { CorsRules: [] }` as the always-emit
+    // placeholder.
     const corsConfig = properties['CorsConfiguration'] as
       | { CorsRules: Array<Record<string, unknown>> }
       | undefined;
-    if (corsConfig?.CorsRules) {
+    if (
+      corsConfig?.CorsRules &&
+      Array.isArray(corsConfig.CorsRules) &&
+      corsConfig.CorsRules.length > 0
+    ) {
       await this.applyCorsConfiguration(bucketName, corsConfig);
     }
 
-    // Lifecycle Configuration
+    // Lifecycle Configuration. Skip empty-rules placeholder (Class 2):
+    // AWS rejects `PutBucketLifecycleConfiguration` with zero rules.
     const lifecycleConfig = properties['LifecycleConfiguration'] as
       | { Rules: Array<Record<string, unknown>> }
       | undefined;
-    if (lifecycleConfig?.Rules) {
+    if (
+      lifecycleConfig?.Rules &&
+      Array.isArray(lifecycleConfig.Rules) &&
+      lifecycleConfig.Rules.length > 0
+    ) {
       await this.applyLifecycleConfiguration(bucketName, lifecycleConfig);
     }
 
@@ -1000,11 +1013,21 @@ export class S3BucketProvider implements ResourceProvider {
       await this.applyPublicAccessBlockConfiguration(bucketName, publicAccessBlock);
     }
 
-    // Bucket Encryption
+    // Bucket Encryption. Skip empty-rules placeholder (Class 2): AWS
+    // rejects `PutBucketEncryption` when the rules array is empty
+    // (`ServerSideEncryptionConfiguration must contain at least one
+    // Rule`). `readCurrentState` always-emits
+    // `BucketEncryption: { ServerSideEncryptionConfiguration: [] }` for
+    // buckets without explicit SSE — that placeholder must NOT be pushed
+    // back through `update()` on a `cdkd drift --revert` round-trip.
     const bucketEncryption = properties['BucketEncryption'] as
       | { ServerSideEncryptionConfiguration: Array<Record<string, unknown>> }
       | undefined;
-    if (bucketEncryption?.ServerSideEncryptionConfiguration) {
+    if (
+      bucketEncryption?.ServerSideEncryptionConfiguration &&
+      Array.isArray(bucketEncryption.ServerSideEncryptionConfiguration) &&
+      bucketEncryption.ServerSideEncryptionConfiguration.length > 0
+    ) {
       await this.applyBucketEncryption(bucketName, bucketEncryption);
     }
 
@@ -1380,13 +1403,20 @@ export class S3BucketProvider implements ResourceProvider {
     // `normalizeAwsTagsToCfn` filters out aws:* auto-injected tags (notably
     // CDK's `aws:cdk:path`) and sorts the result by Key for stable
     // comparison against state.
+    //
+    // Always-emit placeholder per docs/provider-development.md § 3b: even
+    // when the bucket has no user tags (NoSuchTagSet, or only filtered
+    // aws:* tags) we MUST emit `Tags: []`, otherwise observedProperties
+    // never carries the key and a console-side tag ADD on a previously
+    // untagged bucket is silently invisible to drift.
     try {
       const resp = await this.s3Client.send(new GetBucketTaggingCommand({ Bucket: physicalId }));
-      const tags = normalizeAwsTagsToCfn(resp.TagSet);
-      result['Tags'] = tags;
+      result['Tags'] = normalizeAwsTagsToCfn(resp.TagSet);
     } catch (err) {
       const e = err as { name?: string };
-      if (e.name !== 'NoSuchTagSet') {
+      if (e.name === 'NoSuchTagSet') {
+        result['Tags'] = [];
+      } else {
         throw err;
       }
     }

--- a/tests/unit/provisioning/iam-instance-profile-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/iam-instance-profile-provider-roundtrip.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  AddRoleToInstanceProfileCommand,
+  GetInstanceProfileCommand,
+  RemoveRoleFromInstanceProfileCommand,
+} from '@aws-sdk/client-iam';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    iam: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { IAMInstanceProfileProvider } from '../../../src/provisioning/providers/iam-instance-profile-provider.js';
+
+const PHYSICAL_ID = 'my-instance-profile';
+const RESOURCE_TYPE = 'AWS::IAM::InstanceProfile';
+
+describe('IAMInstanceProfileProvider read-update round-trip', () => {
+  let provider: IAMInstanceProfileProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new IAMInstanceProfileProvider();
+  });
+
+  it('round-trip on no-drift snapshot is a logical no-op (zero AWS mutations)', async () => {
+    // Class 2 placeholder safety: empty Roles: [] from readCurrentState
+    // must round-trip through update() without producing
+    // Add/RemoveRoleFromInstanceProfile calls. The diff-based update
+    // iterates the role lists, so empty == empty produces zero AWS-side
+    // mutations by construction — but assert it mechanically so a
+    // future refactor that breaks the contract is caught immediately.
+    const observed = {
+      InstanceProfileName: PHYSICAL_ID,
+      Path: '/',
+      Roles: [] as string[],
+    };
+
+    // GetInstanceProfile is called at the end of update() to refresh
+    // attributes. Mock its response.
+    mockSend.mockResolvedValueOnce({
+      InstanceProfile: { Arn: `arn:aws:iam::123:instance-profile/${PHYSICAL_ID}` },
+    });
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    const addCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof AddRoleToInstanceProfileCommand
+    );
+    const removeCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof RemoveRoleFromInstanceProfileCommand
+    );
+    expect(addCalls).toHaveLength(0);
+    expect(removeCalls).toHaveLength(0);
+  });
+
+  it('round-trip on no-drift snapshot with attached role is a logical no-op', async () => {
+    // Same shape as the empty-roles case but with one role attached on
+    // both sides. The diff (newRoles minus oldRoles, oldRoles minus
+    // newRoles) is empty so no AWS-side mutations should fire.
+    const observed = {
+      InstanceProfileName: PHYSICAL_ID,
+      Path: '/',
+      Roles: ['my-role'],
+    };
+
+    mockSend.mockResolvedValueOnce({
+      InstanceProfile: { Arn: `arn:aws:iam::123:instance-profile/${PHYSICAL_ID}` },
+    });
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    const addCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof AddRoleToInstanceProfileCommand
+    );
+    const removeCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof RemoveRoleFromInstanceProfileCommand
+    );
+    expect(addCalls).toHaveLength(0);
+    expect(removeCalls).toHaveLength(0);
+  });
+
+  it('round-trip refreshes Arn attribute via GetInstanceProfile', async () => {
+    // The end-of-update GetInstanceProfile must run so attributes stay
+    // in sync — otherwise sibling Fn::GetAtt resolutions go stale after
+    // a --revert. This is a structural safeguard against an
+    // optimization that drops the Get when no diff is detected.
+    const observed = {
+      InstanceProfileName: PHYSICAL_ID,
+      Path: '/',
+      Roles: [] as string[],
+    };
+
+    mockSend.mockResolvedValueOnce({
+      InstanceProfile: { Arn: `arn:aws:iam::123:instance-profile/${PHYSICAL_ID}` },
+    });
+
+    const result = await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    const getCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof GetInstanceProfileCommand
+    );
+    expect(getCalls).toHaveLength(1);
+    expect(result.attributes?.Arn).toBe(`arn:aws:iam::123:instance-profile/${PHYSICAL_ID}`);
+    expect(result.wasReplaced).toBe(false);
+  });
+
+  it('drifted Roles → diff produces minimal Add/Remove calls', async () => {
+    // Sanity check the diff logic: removing role-a and adding role-b
+    // should produce exactly one Remove and one Add, not a full
+    // detach/reattach.
+    const oldProps = {
+      InstanceProfileName: PHYSICAL_ID,
+      Path: '/',
+      Roles: ['role-a'],
+    };
+    const newProps = {
+      InstanceProfileName: PHYSICAL_ID,
+      Path: '/',
+      Roles: ['role-b'],
+    };
+
+    mockSend
+      .mockResolvedValueOnce({}) // RemoveRoleFromInstanceProfile
+      .mockResolvedValueOnce({}) // AddRoleToInstanceProfile
+      .mockResolvedValueOnce({
+        InstanceProfile: { Arn: `arn:aws:iam::123:instance-profile/${PHYSICAL_ID}` },
+      });
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, newProps, oldProps);
+
+    const removeCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof RemoveRoleFromInstanceProfileCommand
+    );
+    const addCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof AddRoleToInstanceProfileCommand
+    );
+    expect(removeCalls).toHaveLength(1);
+    expect((removeCalls[0]![0] as RemoveRoleFromInstanceProfileCommand).input.RoleName).toBe(
+      'role-a'
+    );
+    expect(addCalls).toHaveLength(1);
+    expect((addCalls[0]![0] as AddRoleToInstanceProfileCommand).input.RoleName).toBe('role-b');
+  });
+});

--- a/tests/unit/provisioning/iam-policy-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/iam-policy-provider-roundtrip.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  PutRolePolicyCommand,
+  PutGroupPolicyCommand,
+  PutUserPolicyCommand,
+  DeleteRolePolicyCommand,
+  DeleteGroupPolicyCommand,
+  DeleteUserPolicyCommand,
+} from '@aws-sdk/client-iam';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    iam: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { IAMPolicyProvider } from '../../../src/provisioning/providers/iam-policy-provider.js';
+
+const RESOURCE_TYPE = 'AWS::IAM::Policy';
+const PHYSICAL_ID = 'my-policy';
+
+describe('IAMPolicyProvider read-update round-trip', () => {
+  let provider: IAMPolicyProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSend.mockResolvedValue({});
+    provider = new IAMPolicyProvider();
+  });
+
+  it('round-trip on no-drift snapshot does not emit AWS-rejection-shaped inputs (Roles target)', async () => {
+    // Mechanical guard for the read-update round-trip per
+    // docs/provider-development.md § 3b. AWS::IAM::Policy is an inline
+    // policy attached via PutRolePolicy / PutGroupPolicy / PutUserPolicy.
+    // The observed snapshot readCurrentState produces echoes back the
+    // state-recorded target lists plus the AWS-current PolicyDocument
+    // and PolicyName. When --revert round-trips that snapshot back
+    // through update():
+    //   - PolicyDocument is always non-empty (early return guards it)
+    //   - Roles / Groups / Users come from state, not AWS, so an "AWS
+    //     minimum response" cannot empty them out as a placeholder
+    //   - No Class 1 (no type-discriminator-dependent fields exist)
+    //   - No Class 2 (no `?? {}` / `?? []` placeholders that AWS would
+    //     reject as structurally incomplete)
+    //
+    // The remaining failure mode worth guarding mechanically: the
+    // PolicyDocument shipped to PutRolePolicy must be the JSON string
+    // form (not the parsed-object form readCurrentState returns), and
+    // no Delete*Policy call should fire on a no-drift round-trip
+    // (would orphan the inline policy on AWS).
+    const policyDoc = {
+      Version: '2012-10-17',
+      Statement: [{ Effect: 'Allow', Action: 's3:GetObject', Resource: '*' }],
+    };
+    const observed = {
+      PolicyName: 'my-policy',
+      PolicyDocument: policyDoc,
+      Roles: ['my-role'],
+    };
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    // Exactly one PutRolePolicy call (the idempotent re-attach). No
+    // Group/User Put, no Delete* of any kind on a no-drift round-trip.
+    const putRoleCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PutRolePolicyCommand
+    );
+    expect(putRoleCalls).toHaveLength(1);
+    const putInput = putRoleCalls[0]?.[0].input as {
+      RoleName: string;
+      PolicyName: string;
+      PolicyDocument: unknown;
+    };
+    expect(putInput.RoleName).toBe('my-role');
+    expect(putInput.PolicyName).toBe('my-policy');
+    // PolicyDocument MUST be a JSON string — IAM rejects an object.
+    expect(typeof putInput.PolicyDocument).toBe('string');
+    expect(JSON.parse(putInput.PolicyDocument as string)).toEqual(policyDoc);
+
+    // No Group / User puts.
+    expect(
+      mockSend.mock.calls.filter((c) => c[0] instanceof PutGroupPolicyCommand)
+    ).toHaveLength(0);
+    expect(
+      mockSend.mock.calls.filter((c) => c[0] instanceof PutUserPolicyCommand)
+    ).toHaveLength(0);
+
+    // No Delete* on a no-drift round-trip — would silently orphan the
+    // inline policy on AWS while drift --revert reports success.
+    expect(
+      mockSend.mock.calls.filter(
+        (c) =>
+          c[0] instanceof DeleteRolePolicyCommand ||
+          c[0] instanceof DeleteGroupPolicyCommand ||
+          c[0] instanceof DeleteUserPolicyCommand
+      )
+    ).toHaveLength(0);
+  });
+
+  it('round-trip with Groups target uses PutGroupPolicy, no Delete*', async () => {
+    const policyDoc = { Version: '2012-10-17', Statement: [] };
+    const observed = {
+      PolicyName: 'my-policy',
+      PolicyDocument: policyDoc,
+      Groups: ['my-group'],
+    };
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    const putGroupCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PutGroupPolicyCommand
+    );
+    expect(putGroupCalls).toHaveLength(1);
+    const input = putGroupCalls[0]?.[0].input as {
+      GroupName: string;
+      PolicyDocument: unknown;
+    };
+    expect(input.GroupName).toBe('my-group');
+    expect(typeof input.PolicyDocument).toBe('string');
+
+    expect(
+      mockSend.mock.calls.filter(
+        (c) =>
+          c[0] instanceof DeleteRolePolicyCommand ||
+          c[0] instanceof DeleteGroupPolicyCommand ||
+          c[0] instanceof DeleteUserPolicyCommand
+      )
+    ).toHaveLength(0);
+  });
+
+  it('round-trip with Users target uses PutUserPolicy, no Delete*', async () => {
+    const policyDoc = { Version: '2012-10-17', Statement: [] };
+    const observed = {
+      PolicyName: 'my-policy',
+      PolicyDocument: policyDoc,
+      Users: ['my-user'],
+    };
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    const putUserCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PutUserPolicyCommand
+    );
+    expect(putUserCalls).toHaveLength(1);
+    const input = putUserCalls[0]?.[0].input as {
+      UserName: string;
+      PolicyDocument: unknown;
+    };
+    expect(input.UserName).toBe('my-user');
+    expect(typeof input.PolicyDocument).toBe('string');
+
+    expect(
+      mockSend.mock.calls.filter(
+        (c) =>
+          c[0] instanceof DeleteRolePolicyCommand ||
+          c[0] instanceof DeleteGroupPolicyCommand ||
+          c[0] instanceof DeleteUserPolicyCommand
+      )
+    ).toHaveLength(0);
+  });
+
+  it('PolicyDocument string form survives round-trip without double-encoding', async () => {
+    // Defensive: if a user happens to record PolicyDocument in state as
+    // a string (rare but allowed by `typeof policyDocument === 'string'`
+    // in create/update), the round-trip must not double-stringify it
+    // (`"\"{\\\"Version\\\"...\""`) on its way back to AWS.
+    const policyDocStr = JSON.stringify({ Version: '2012-10-17', Statement: [] });
+    const observed = {
+      PolicyName: 'my-policy',
+      PolicyDocument: policyDocStr,
+      Roles: ['my-role'],
+    };
+
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed, observed);
+
+    const putCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof PutRolePolicyCommand
+    );
+    const input = putCall?.[0].input as { PolicyDocument: unknown };
+    // Should equal the original string, not JSON.stringify(originalString).
+    expect(input.PolicyDocument).toBe(policyDocStr);
+  });
+});

--- a/tests/unit/provisioning/iam-user-group-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/iam-user-group-provider-roundtrip.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  GetUserCommand,
+  GetGroupCommand,
+  PutUserPolicyCommand,
+  DeleteUserPolicyCommand,
+  PutGroupPolicyCommand,
+  DeleteGroupPolicyCommand,
+  AttachUserPolicyCommand,
+  DetachUserPolicyCommand,
+  AttachGroupPolicyCommand,
+  DetachGroupPolicyCommand,
+  AddUserToGroupCommand,
+  RemoveUserFromGroupCommand,
+  PutUserPermissionsBoundaryCommand,
+  DeleteUserPermissionsBoundaryCommand,
+  CreateLoginProfileCommand,
+  UpdateLoginProfileCommand,
+  DeleteLoginProfileCommand,
+  TagUserCommand,
+  UntagUserCommand,
+} from '@aws-sdk/client-iam';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    iam: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { IAMUserGroupProvider } from '../../../src/provisioning/providers/iam-user-group-provider.js';
+
+const USER_NAME = 'alice';
+const GROUP_NAME = 'engineers';
+
+/**
+ * Mechanical guard for the three latent bug classes documented in
+ * docs/provider-development.md § 3b "Read-update round-trip test":
+ *
+ *   - Class 1 (discriminator-dependent fields): N/A for IAM User/Group —
+ *     no fields are gated by sibling discriminators. Tested as
+ *     "no discriminator-only attribute reaches AWS" by negative
+ *     assertion (no FIFO-style API calls happen).
+ *   - Class 2 (structurally-incomplete-when-empty fields): N/A for
+ *     IAM User/Group — array placeholders (`ManagedPolicyArns: []`,
+ *     `Groups: []`) are diff-applied via Set semantics, so empty-array
+ *     is never sent to AWS as input. The round-trip test asserts no
+ *     Attach/Detach/AddUser/RemoveUser commands fire on a no-drift
+ *     snapshot.
+ *   - Truthy gate: `update()` uses `!== undefined` for
+ *     `PermissionsBoundary`, and the `LoginProfile` / `Policies` /
+ *     array-diff paths handle the round-trip case correctly. The
+ *     round-trip test asserts a no-drift `observedProperties` snapshot
+ *     produces ZERO mutating SDK calls — the structural defense
+ *     against a future refactor that re-introduces a truthy gate or
+ *     a Class 2 placeholder shipping back to AWS.
+ */
+describe('IAMUserGroupProvider read-update round-trip', () => {
+  let provider: IAMUserGroupProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new IAMUserGroupProvider();
+  });
+
+  // ─── AWS::IAM::User ───────────────────────────────────────────────
+
+  it('User: round-trip on no-drift snapshot is a logical no-op (zero mutating SDK calls)', async () => {
+    // updateUser ends with a GetUser to refresh attributes; mock that.
+    mockSend.mockResolvedValueOnce({
+      User: { UserName: USER_NAME, Arn: `arn:aws:iam::123:user/${USER_NAME}` },
+    });
+
+    // Snapshot matches what readCurrentState emits on the happy path
+    // (see iam-user-group-provider-readcurrentstate.test.ts).
+    const observed = {
+      UserName: USER_NAME,
+      Path: '/team/',
+      PermissionsBoundary: 'arn:aws:iam::aws:policy/Boundary',
+      ManagedPolicyArns: ['arn:aws:iam::aws:policy/ReadOnlyAccess'],
+      Groups: ['engineers', 'admins'],
+    };
+
+    await provider.update('L', USER_NAME, 'AWS::IAM::User', observed, observed);
+
+    // Diff-based update on identical input should make zero AWS-side
+    // mutations. Only the trailing GetUserCommand is allowed.
+    const mutatingCommands = [
+      PutUserPermissionsBoundaryCommand,
+      DeleteUserPermissionsBoundaryCommand,
+      AttachUserPolicyCommand,
+      DetachUserPolicyCommand,
+      AddUserToGroupCommand,
+      RemoveUserFromGroupCommand,
+      PutUserPolicyCommand,
+      DeleteUserPolicyCommand,
+      CreateLoginProfileCommand,
+      UpdateLoginProfileCommand,
+      DeleteLoginProfileCommand,
+      TagUserCommand,
+      UntagUserCommand,
+    ];
+    for (const Cmd of mutatingCommands) {
+      const calls = mockSend.mock.calls.filter((c) => c[0] instanceof Cmd);
+      expect(calls).toHaveLength(0);
+    }
+  });
+
+  it('User: round-trip with empty ManagedPolicyArns and Groups arrays does not emit Class-2-shaped requests', async () => {
+    // Class 2 guard: a user with NO managed policies and NO groups
+    // produces `ManagedPolicyArns: []` / `Groups: []` placeholders from
+    // readCurrentState. Round-tripping must NOT translate the empty
+    // arrays into an AWS-rejection-shaped Attach/Add call.
+    mockSend.mockResolvedValueOnce({
+      User: { UserName: USER_NAME, Arn: `arn:aws:iam::123:user/${USER_NAME}` },
+    });
+
+    const observed = {
+      UserName: USER_NAME,
+      ManagedPolicyArns: [] as string[],
+      Groups: [] as string[],
+    };
+
+    await provider.update('L', USER_NAME, 'AWS::IAM::User', observed, observed);
+
+    expect(mockSend.mock.calls.filter((c) => c[0] instanceof AttachUserPolicyCommand)).toHaveLength(
+      0
+    );
+    expect(mockSend.mock.calls.filter((c) => c[0] instanceof AddUserToGroupCommand)).toHaveLength(
+      0
+    );
+    expect(
+      mockSend.mock.calls.filter((c) => c[0] instanceof DetachUserPolicyCommand)
+    ).toHaveLength(0);
+    expect(
+      mockSend.mock.calls.filter((c) => c[0] instanceof RemoveUserFromGroupCommand)
+    ).toHaveLength(0);
+  });
+
+  it('User: drift in ManagedPolicyArns produces Attach/Detach diff (sanity)', async () => {
+    // Positive complement: a real diff DOES produce the expected
+    // mutating calls. Guards against the round-trip test passing
+    // because update() became silently inert.
+    mockSend
+      .mockResolvedValueOnce({}) // AttachUserPolicy
+      .mockResolvedValueOnce({}) // DetachUserPolicy
+      .mockResolvedValueOnce({
+        User: { UserName: USER_NAME, Arn: `arn:aws:iam::123:user/${USER_NAME}` },
+      });
+
+    const oldProps = {
+      UserName: USER_NAME,
+      ManagedPolicyArns: ['arn:aws:iam::aws:policy/Old'],
+      Groups: [] as string[],
+    };
+    const newProps = {
+      UserName: USER_NAME,
+      ManagedPolicyArns: ['arn:aws:iam::aws:policy/New'],
+      Groups: [] as string[],
+    };
+
+    await provider.update('L', USER_NAME, 'AWS::IAM::User', newProps, oldProps);
+
+    expect(mockSend.mock.calls.filter((c) => c[0] instanceof AttachUserPolicyCommand)).toHaveLength(
+      1
+    );
+    expect(mockSend.mock.calls.filter((c) => c[0] instanceof DetachUserPolicyCommand)).toHaveLength(
+      1
+    );
+  });
+
+  // ─── AWS::IAM::Group ──────────────────────────────────────────────
+
+  it('Group: round-trip on no-drift snapshot is a logical no-op (zero mutating SDK calls)', async () => {
+    mockSend.mockResolvedValueOnce({
+      Group: { GroupName: GROUP_NAME, Arn: `arn:aws:iam::123:group/${GROUP_NAME}` },
+    });
+
+    const observed = {
+      GroupName: GROUP_NAME,
+      Path: '/',
+      ManagedPolicyArns: ['arn:aws:iam::aws:policy/AmazonS3FullAccess'],
+    };
+
+    await provider.update('L', GROUP_NAME, 'AWS::IAM::Group', observed, observed);
+
+    const mutatingCommands = [
+      AttachGroupPolicyCommand,
+      DetachGroupPolicyCommand,
+      PutGroupPolicyCommand,
+      DeleteGroupPolicyCommand,
+    ];
+    for (const Cmd of mutatingCommands) {
+      const calls = mockSend.mock.calls.filter((c) => c[0] instanceof Cmd);
+      expect(calls).toHaveLength(0);
+    }
+  });
+
+  it('Group: round-trip with empty ManagedPolicyArns array does not emit Class-2-shaped requests', async () => {
+    mockSend.mockResolvedValueOnce({
+      Group: { GroupName: GROUP_NAME, Arn: `arn:aws:iam::123:group/${GROUP_NAME}` },
+    });
+
+    const observed = {
+      GroupName: GROUP_NAME,
+      ManagedPolicyArns: [] as string[],
+    };
+
+    await provider.update('L', GROUP_NAME, 'AWS::IAM::Group', observed, observed);
+
+    expect(
+      mockSend.mock.calls.filter((c) => c[0] instanceof AttachGroupPolicyCommand)
+    ).toHaveLength(0);
+    expect(
+      mockSend.mock.calls.filter((c) => c[0] instanceof DetachGroupPolicyCommand)
+    ).toHaveLength(0);
+  });
+
+  // ─── AWS::IAM::UserToGroupAddition ────────────────────────────────
+
+  it('UserToGroupAddition: round-trip on no-drift snapshot is a logical no-op (zero mutating SDK calls)', async () => {
+    // UserToGroupAddition has no readCurrentState (membership-only), but
+    // observedProperties on this resource type falls back to `properties`
+    // per the v3 schema fallback path. Round-trip should still be inert
+    // when new and old match.
+    const observed = {
+      GroupName: GROUP_NAME,
+      Users: ['alice', 'bob'],
+    };
+
+    await provider.update(
+      'L',
+      'logicalAddition',
+      'AWS::IAM::UserToGroupAddition',
+      observed,
+      observed
+    );
+
+    expect(mockSend.mock.calls.filter((c) => c[0] instanceof AddUserToGroupCommand)).toHaveLength(
+      0
+    );
+    expect(
+      mockSend.mock.calls.filter((c) => c[0] instanceof RemoveUserFromGroupCommand)
+    ).toHaveLength(0);
+  });
+});

--- a/tests/unit/provisioning/s3-bucket-policy-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/s3-bucket-policy-provider-roundtrip.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PutBucketPolicyCommand } from '@aws-sdk/client-s3';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    s3: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { S3BucketPolicyProvider } from '../../../src/provisioning/providers/s3-bucket-policy-provider.js';
+
+const RESOURCE_TYPE = 'AWS::S3::BucketPolicy';
+const BUCKET_NAME = 'my-bucket';
+
+describe('S3BucketPolicyProvider read-update round-trip', () => {
+  let provider: S3BucketPolicyProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new S3BucketPolicyProvider();
+  });
+
+  it('round-trip: readCurrentState placeholders survive update() without AWS-invalid inputs', async () => {
+    // 1. Mock GetBucketPolicy to return a typical policy document.
+    const policy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 's3:GetObject',
+          Resource: `arn:aws:s3:::${BUCKET_NAME}/*`,
+        },
+      ],
+    };
+    mockSend.mockResolvedValueOnce({ Policy: JSON.stringify(policy) });
+
+    const observed = await provider.readCurrentState(BUCKET_NAME, 'L', RESOURCE_TYPE);
+    expect(observed).toEqual({
+      Bucket: BUCKET_NAME,
+      PolicyDocument: policy,
+    });
+
+    // 2. Reset mocks and round-trip the snapshot back through update().
+    vi.clearAllMocks();
+    mockSend.mockResolvedValueOnce({}); // PutBucketPolicy reply
+
+    await provider.update('L', BUCKET_NAME, RESOURCE_TYPE, observed!, observed!);
+
+    // 3. Assertions: every PutBucketPolicy must carry the required Bucket
+    //    and a non-empty Policy string AWS will accept. There is no
+    //    Class 1 / Class 2 placeholder for this resource type — both
+    //    top-level keys are required and the PolicyDocument body comes
+    //    straight from AWS, so no rejection-shape can sneak in.
+    const putCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PutBucketPolicyCommand
+    );
+    expect(putCalls).toHaveLength(1);
+    const input = putCalls[0]![0].input as { Bucket?: string; Policy?: string };
+    expect(input.Bucket).toBe(BUCKET_NAME);
+    expect(typeof input.Policy).toBe('string');
+    expect(input.Policy).not.toBe('');
+    expect(input.Policy).not.toBe('{}');
+    // Round-tripped Policy must be valid JSON the round-trip can read.
+    expect(() => JSON.parse(input.Policy ?? '')).not.toThrow();
+    // And the parsed body must be equal to the observed PolicyDocument
+    // (i.e. update() did not corrupt the shape on the way to AWS).
+    expect(JSON.parse(input.Policy ?? '')).toEqual(policy);
+  });
+
+  it('truthy-gate audit: PolicyDocument is required on update(), so empty values still hard-fail (not silently dropped)', async () => {
+    // S3 BucketPolicy has only two top-level fields and both are
+    // required. There is no optional field for a truthy-vs-undefined
+    // gate to silently drop. Confirm the contract: empty / missing
+    // PolicyDocument throws ProvisioningError instead of issuing a
+    // PutBucketPolicy with a bogus body — the inverse of the IAM Role
+    // truthy-gate failure mode where `Description: ''` was silently
+    // dropped from UpdateRole.
+    await expect(
+      provider.update('L', BUCKET_NAME, RESOURCE_TYPE, { Bucket: BUCKET_NAME }, {})
+    ).rejects.toThrow(/PolicyDocument is required/);
+
+    expect(
+      mockSend.mock.calls.filter((c) => c[0] instanceof PutBucketPolicyCommand)
+    ).toHaveLength(0);
+  });
+
+  it('round-trip preserves a string-form PolicyDocument as well as object form', async () => {
+    // CFn permits PolicyDocument in either object or pre-serialized
+    // string form (the latter common when user inlines a JSON literal).
+    // create() / update() handles both via the `typeof === 'string'`
+    // branch; readCurrentState always JSON.parses to object form. The
+    // round-trip from a string-form input must still produce a valid
+    // PutBucketPolicy.
+    const stringPolicy = JSON.stringify({
+      Version: '2012-10-17',
+      Statement: [{ Effect: 'Deny', Principal: '*', Action: '*', Resource: '*' }],
+    });
+
+    mockSend.mockResolvedValueOnce({});
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      RESOURCE_TYPE,
+      { Bucket: BUCKET_NAME, PolicyDocument: stringPolicy },
+      { Bucket: BUCKET_NAME, PolicyDocument: stringPolicy }
+    );
+
+    const putCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PutBucketPolicyCommand
+    );
+    expect(putCalls).toHaveLength(1);
+    const input = putCalls[0]![0].input as { Policy?: string };
+    expect(input.Policy).toBe(stringPolicy);
+  });
+});

--- a/tests/unit/provisioning/s3-bucket-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/s3-bucket-provider-readcurrentstate.test.ts
@@ -156,6 +156,7 @@ describe('S3BucketProvider.readCurrentState', () => {
         IgnorePublicAcls: false,
         RestrictPublicBuckets: false,
       },
+      Tags: [],
     });
   });
 
@@ -166,10 +167,11 @@ describe('S3BucketProvider.readCurrentState', () => {
   // refactor that drops a placeholder for any of these keys must update
   // this test consciously — silent regression is structurally prevented.
   //
-  // Note: the S3 provider's `Tags` key is set inside a try-block that
-  // catches `NoSuchTagSet` without writing the key — so the
-  // minimum-response shape deliberately does NOT include `Tags`. This
-  // mirrors the existing not-configured test above.
+  // The `Tags` key MUST be in the minimum-response shape: a bucket with
+  // no user tags must still expose `Tags: []` so a console-side tag ADD
+  // on a previously untagged bucket is detectable as drift (the
+  // comparator's top-level walk is state-keys-only — observed without a
+  // `Tags` key would silently miss the change).
   it('emits placeholders for every user-controllable top-level key on AWS minimum response', async () => {
     // HeadBucket
     mockSend.mockResolvedValueOnce({});
@@ -189,6 +191,7 @@ describe('S3BucketProvider.readCurrentState', () => {
         'BucketEncryption',
         'BucketName',
         'PublicAccessBlockConfiguration',
+        'Tags',
         'VersioningConfiguration',
       ].sort()
     );
@@ -200,5 +203,6 @@ describe('S3BucketProvider.readCurrentState', () => {
       IgnorePublicAcls: false,
       RestrictPublicBuckets: false,
     });
+    expect(result?.Tags).toEqual([]);
   });
 });

--- a/tests/unit/provisioning/s3-bucket-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/s3-bucket-provider-roundtrip.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  GetBucketTaggingCommand,
+  PutBucketEncryptionCommand,
+  PutBucketCorsCommand,
+  PutBucketLifecycleConfigurationCommand,
+  PutBucketVersioningCommand,
+  PutBucketTaggingCommand,
+  DeleteBucketTaggingCommand,
+} from '@aws-sdk/client-s3';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    s3: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { S3BucketProvider } from '../../../src/provisioning/providers/s3-bucket-provider.js';
+
+const BUCKET_NAME = 'my-bucket';
+
+/**
+ * Build a "feature not configured" error matching AWS error shape. The
+ * provider keys off `error.name`.
+ */
+function notConfigured(name: string): Error {
+  const err = new Error(`${name}: not configured`);
+  err.name = name;
+  return err;
+}
+
+describe('S3BucketProvider read-update round-trip', () => {
+  let provider: S3BucketProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new S3BucketProvider();
+  });
+
+  // -------------------------------------------------------------------
+  // Tags fix verification (the user-reported bug)
+  // -------------------------------------------------------------------
+
+  it('Tags fix — readCurrentState emits Tags: [] when bucket has no user tags (NoSuchTagSet)', async () => {
+    // Pre-fix the catch path silently dropped the Tags key, so
+    // observedProperties had no Tags entry on previously-untagged
+    // buckets. The drift comparator's state-keys-only top-level walk
+    // skipped the field forever — a console-side tag ADD was silently
+    // invisible.
+    //
+    // Post-fix the catch path emits `Tags: []` so the next drift run
+    // sees `state=[]` vs `aws=[{Key,Value}]` and reports the change.
+
+    // HeadBucket
+    mockSend.mockResolvedValueOnce({});
+    // GetBucketVersioning — never configured
+    mockSend.mockResolvedValueOnce({});
+    // GetBucketEncryption — absent
+    mockSend.mockRejectedValueOnce(notConfigured('ServerSideEncryptionConfigurationNotFoundError'));
+    // GetPublicAccessBlock — absent
+    mockSend.mockRejectedValueOnce(notConfigured('NoSuchPublicAccessBlockConfiguration'));
+    // GetBucketTagging — NoSuchTagSet (bucket has zero user tags)
+    mockSend.mockRejectedValueOnce(notConfigured('NoSuchTagSet'));
+
+    const result = await provider.readCurrentState(BUCKET_NAME, 'L', 'AWS::S3::Bucket');
+
+    // Critical: Tags MUST be present (as []), not omitted.
+    expect(result).toBeDefined();
+    expect(Object.keys(result ?? {})).toContain('Tags');
+    expect(result?.Tags).toEqual([]);
+  });
+
+  it('Tags fix — readCurrentState emits Tags: [] when AWS returns only filtered aws:* tags', async () => {
+    // `normalizeAwsTagsToCfn` filters `aws:cdk:path` etc. — the bucket
+    // looks like it has zero user tags from cdkd's point of view. The
+    // emit must still be `Tags: []`, not omitted.
+
+    // HeadBucket
+    mockSend.mockResolvedValueOnce({});
+    // GetBucketVersioning
+    mockSend.mockResolvedValueOnce({});
+    // GetBucketEncryption — absent
+    mockSend.mockRejectedValueOnce(notConfigured('ServerSideEncryptionConfigurationNotFoundError'));
+    // GetPublicAccessBlock — absent
+    mockSend.mockRejectedValueOnce(notConfigured('NoSuchPublicAccessBlockConfiguration'));
+    // GetBucketTagging — only aws:* tag (filtered out)
+    mockSend.mockResolvedValueOnce({
+      TagSet: [{ Key: 'aws:cdk:path', Value: 'MyStack/MyBucket/Resource' }],
+    });
+
+    const result = await provider.readCurrentState(BUCKET_NAME, 'L', 'AWS::S3::Bucket');
+
+    expect(result?.Tags).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------
+  // No-drift round-trip — state == AWS implies zero mutating SDK calls
+  // for the tag path (the diff-aware applyTagDiff). The unconditional
+  // applyConfiguration paths (Versioning / PAB) DO re-PUT but only with
+  // the same observed shape, which AWS accepts as a no-op.
+  // -------------------------------------------------------------------
+
+  it('round-trip on no-drift snapshot does not issue PutBucketTagging or DeleteBucketTagging', async () => {
+    const observed = {
+      BucketName: BUCKET_NAME,
+      VersioningConfiguration: { Status: 'Suspended' },
+      BucketEncryption: { ServerSideEncryptionConfiguration: [] },
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: false,
+        BlockPublicPolicy: false,
+        IgnorePublicAcls: false,
+        RestrictPublicBuckets: false,
+      },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    // applyConfiguration unconditionally fires PutBucketVersioning +
+    // PutPublicAccessBlock (both safe no-ops with the observed shape).
+    // BucketEncryption is now skipped on empty rules (Class 2 fix).
+    mockSend.mockResolvedValue({});
+
+    await provider.update('L', BUCKET_NAME, 'AWS::S3::Bucket', observed, observed);
+
+    // Tag diff should detect [] === [] and emit zero tag-mutating calls.
+    const putTagging = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PutBucketTaggingCommand
+    );
+    const deleteTagging = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof DeleteBucketTaggingCommand
+    );
+    expect(putTagging).toHaveLength(0);
+    expect(deleteTagging).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------
+  // Class 2 — empty placeholder must NOT round-trip into AWS API call
+  // -------------------------------------------------------------------
+
+  it('Class 2 — empty BucketEncryption placeholder does not produce PutBucketEncryption call', async () => {
+    // readCurrentState always-emits
+    // `BucketEncryption: { ServerSideEncryptionConfiguration: [] }` for
+    // buckets without explicit SSE. AWS rejects PutBucketEncryption
+    // with zero rules ("ServerSideEncryptionConfiguration must contain
+    // at least one Rule"), so applyConfiguration must skip the empty
+    // placeholder on the round-trip.
+    const observed = {
+      BucketName: BUCKET_NAME,
+      VersioningConfiguration: { Status: 'Suspended' },
+      BucketEncryption: { ServerSideEncryptionConfiguration: [] },
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: false,
+        BlockPublicPolicy: false,
+        IgnorePublicAcls: false,
+        RestrictPublicBuckets: false,
+      },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValue({});
+
+    await provider.update('L', BUCKET_NAME, 'AWS::S3::Bucket', observed, observed);
+
+    const putEncryption = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PutBucketEncryptionCommand
+    );
+    expect(putEncryption).toHaveLength(0);
+  });
+
+  it('Class 2 — empty CorsConfiguration.CorsRules does not produce PutBucketCors call', async () => {
+    // `applyCorsConfiguration` would call AWS with `CORSRules: []`
+    // which AWS rejects ("Number of CorsRules must be at least 1").
+    const observed = {
+      BucketName: BUCKET_NAME,
+      CorsConfiguration: { CorsRules: [] },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValue({});
+
+    await provider.update('L', BUCKET_NAME, 'AWS::S3::Bucket', observed, observed);
+
+    const putCors = mockSend.mock.calls.filter((c) => c[0] instanceof PutBucketCorsCommand);
+    expect(putCors).toHaveLength(0);
+  });
+
+  it('Class 2 — empty LifecycleConfiguration.Rules does not produce PutBucketLifecycleConfiguration call', async () => {
+    // `applyLifecycleConfiguration` would call AWS with `Rules: []`
+    // which AWS rejects.
+    const observed = {
+      BucketName: BUCKET_NAME,
+      LifecycleConfiguration: { Rules: [] },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValue({});
+
+    await provider.update('L', BUCKET_NAME, 'AWS::S3::Bucket', observed, observed);
+
+    const putLifecycle = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PutBucketLifecycleConfigurationCommand
+    );
+    expect(putLifecycle).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------
+  // Tag diff still works correctly on real drift
+  // -------------------------------------------------------------------
+
+  it('tag drift round-trip — adding a console-side tag on a previously-untagged bucket fires PutBucketTagging', async () => {
+    // observed = AWS-current snapshot (post console-side ADD)
+    // state = empty Tags
+    const stateProps = {
+      BucketName: BUCKET_NAME,
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+    const awsCurrent = {
+      BucketName: BUCKET_NAME,
+      Tags: [{ Key: 'NewTag', Value: 'fromConsole' }],
+    };
+
+    mockSend.mockResolvedValue({});
+
+    // --revert: drive AWS back to state ([])
+    await provider.update('L', BUCKET_NAME, 'AWS::S3::Bucket', stateProps, awsCurrent);
+
+    const deleteCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof DeleteBucketTaggingCommand
+    );
+    // Going from [{...}] -> [] uses DeleteBucketTagging in the provider.
+    expect(deleteCalls.length).toBeGreaterThan(0);
+  });
+
+  it('versioning placeholder round-trips safely (Suspended -> Suspended is an AWS-accepted no-op)', async () => {
+    // PutBucketVersioning with Status=Suspended on a bucket that's
+    // never been versioned is documented as safe by AWS. The unguarded
+    // re-PUT on round-trip is intentional — Suspended placeholder must
+    // be safely round-trippable so console-side Enable surfaces.
+    const observed = {
+      BucketName: BUCKET_NAME,
+      VersioningConfiguration: { Status: 'Suspended' },
+      Tags: [] as Array<{ Key: string; Value: string }>,
+    };
+
+    mockSend.mockResolvedValue({});
+
+    await provider.update('L', BUCKET_NAME, 'AWS::S3::Bucket', observed, observed);
+
+    const versioningCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof PutBucketVersioningCommand
+    );
+    // The provider unconditionally fires when VersioningConfiguration
+    // is present. The point of the test is: when it does, the input is
+    // shape-valid (Status: 'Suspended'), not an AWS-rejection shape.
+    expect(versioningCalls).toHaveLength(1);
+    const input = versioningCalls[0]?.[0].input as {
+      VersioningConfiguration: { Status: string };
+    };
+    expect(input.VersioningConfiguration.Status).toBe('Suspended');
+  });
+
+  // -------------------------------------------------------------------
+  // Sanity: GetBucketTagging is still consulted correctly when tags
+  // exist (regression guard for the catch-path edit).
+  // -------------------------------------------------------------------
+
+  it('readCurrentState happy-path — GetBucketTagging success branch still emits user tags', async () => {
+    mockSend.mockResolvedValueOnce({}); // HeadBucket
+    mockSend.mockResolvedValueOnce({ Status: 'Enabled' }); // Versioning
+    mockSend.mockRejectedValueOnce(notConfigured('ServerSideEncryptionConfigurationNotFoundError'));
+    mockSend.mockRejectedValueOnce(notConfigured('NoSuchPublicAccessBlockConfiguration'));
+    // GetBucketTagging — real user tag present
+    mockSend.mockResolvedValueOnce({
+      TagSet: [{ Key: 'Owner', Value: 'platform' }],
+    });
+
+    const result = await provider.readCurrentState(BUCKET_NAME, 'L', 'AWS::S3::Bucket');
+
+    expect(mockSend.mock.calls[4]?.[0]).toBeInstanceOf(GetBucketTaggingCommand);
+    expect(result?.Tags).toEqual([{ Key: 'Owner', Value: 'platform' }]);
+  });
+});

--- a/tests/unit/provisioning/sns-topic-policy-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/sns-topic-policy-provider-roundtrip.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  SetTopicAttributesCommand,
+  GetTopicAttributesCommand,
+} from '@aws-sdk/client-sns';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    sns: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { SNSTopicPolicyProvider } from '../../../src/provisioning/providers/sns-topic-policy-provider.js';
+
+const TOPIC_ARN_1 = 'arn:aws:sns:us-east-1:123456789012:topic-a';
+const TOPIC_ARN_2 = 'arn:aws:sns:us-east-1:123456789012:topic-b';
+const PHYSICAL_ID = `${TOPIC_ARN_1},${TOPIC_ARN_2}`;
+const RESOURCE_TYPE = 'AWS::SNS::TopicPolicy';
+
+const SAMPLE_POLICY = {
+  Version: '2012-10-17',
+  Statement: [
+    {
+      Sid: 'AllowPublish',
+      Effect: 'Allow',
+      Principal: { Service: 'events.amazonaws.com' },
+      Action: 'sns:Publish',
+      Resource: TOPIC_ARN_1,
+    },
+  ],
+};
+
+describe('SNSTopicPolicyProvider read-update round-trip', () => {
+  let provider: SNSTopicPolicyProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new SNSTopicPolicyProvider();
+  });
+
+  it('readCurrentState surfaces Topics + JSON-parsed PolicyDocument', async () => {
+    // GetTopicAttributes for first topic in the comma-joined physicalId.
+    mockSend.mockResolvedValueOnce({
+      Attributes: {
+        Policy: JSON.stringify(SAMPLE_POLICY),
+        TopicArn: TOPIC_ARN_1,
+      },
+    });
+
+    const observed = await provider.readCurrentState(PHYSICAL_ID, 'L', RESOURCE_TYPE);
+
+    expect(observed).toBeDefined();
+    expect(observed?.Topics).toEqual([TOPIC_ARN_1, TOPIC_ARN_2]);
+    expect(observed?.PolicyDocument).toEqual(SAMPLE_POLICY);
+
+    // Verify GetTopicAttributes was called against the FIRST topic only
+    // (provider's documented single-topic-fetch optimisation).
+    const getCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof GetTopicAttributesCommand
+    );
+    expect(getCall).toBeDefined();
+    expect((getCall![0] as GetTopicAttributesCommand).input.TopicArn).toBe(TOPIC_ARN_1);
+  });
+
+  it('round-trip: readCurrentState output survives update() without AWS-invalid inputs', async () => {
+    // Mechanical guard for Class 1 / Class 2 / truthy-gate regressions
+    // on the read-then-update round-trip path (cdkd drift --revert).
+    // See docs/provider-development.md § 3b.
+
+    // 1. readCurrentState
+    mockSend.mockResolvedValueOnce({
+      Attributes: {
+        Policy: JSON.stringify(SAMPLE_POLICY),
+        TopicArn: TOPIC_ARN_1,
+      },
+    });
+    const observed = await provider.readCurrentState(PHYSICAL_ID, 'L', RESOURCE_TYPE);
+    expect(observed).toBeDefined();
+
+    // 2. Reset and prep update mocks (one SetTopicAttributes per topic).
+    vi.clearAllMocks();
+    mockSend.mockResolvedValue({});
+
+    // 3. Round-trip: pass observed snapshot back through update().
+    await provider.update('L', PHYSICAL_ID, RESOURCE_TYPE, observed!, observed!);
+
+    // 4. Assertions on every SetTopicAttributes call.
+    const setCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof SetTopicAttributesCommand
+    );
+    expect(setCalls.length).toBeGreaterThan(0);
+
+    for (const call of setCalls) {
+      const input = (call[0] as SetTopicAttributesCommand).input;
+      expect(input.AttributeName).toBe('Policy');
+      // Class 2 guard: never ship the empty-object placeholder shape
+      // back to AWS — SetTopicAttributes(Policy='{}') is rejected as
+      // "Policy statement must contain Resources" by SNS.
+      expect(input.AttributeValue).not.toBe('{}');
+      expect(input.AttributeValue).not.toBe('');
+
+      // The serialised body must round-trip JSON-equal to the snapshot.
+      // (cdkd's update() always JSON.stringify's an object PolicyDocument.)
+      expect(JSON.parse(input.AttributeValue!)).toEqual(SAMPLE_POLICY);
+    }
+
+    // Both topics in physicalId received SetTopicAttributes — provider
+    // mirrors the policy onto every listed topic.
+    const targetedArns = setCalls.map(
+      (c) => (c[0] as SetTopicAttributesCommand).input.TopicArn
+    );
+    expect(targetedArns.sort()).toEqual([TOPIC_ARN_1, TOPIC_ARN_2].sort());
+  });
+
+  it('update() accepts a string PolicyDocument (already-serialised) without re-stringifying', async () => {
+    // Truthy-gate-adjacent guard: the provider passes the value to
+    // setTopicPolicy verbatim when it's already a string. A regression
+    // that double-stringified ('"{...}"') would silently push a
+    // string-literal-shaped policy AWS treats as "invalid policy".
+    mockSend.mockResolvedValue({});
+
+    const policyAsString = JSON.stringify(SAMPLE_POLICY);
+    await provider.update(
+      'L',
+      PHYSICAL_ID,
+      RESOURCE_TYPE,
+      { Topics: [TOPIC_ARN_1], PolicyDocument: policyAsString },
+      { Topics: [TOPIC_ARN_1], PolicyDocument: '{}' }
+    );
+
+    const setCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof SetTopicAttributesCommand
+    );
+    expect(setCall).toBeDefined();
+    const input = (setCall![0] as SetTopicAttributesCommand).input;
+    expect(input.AttributeValue).toBe(policyAsString);
+    // Not double-stringified.
+    expect(input.AttributeValue).not.toBe(JSON.stringify(policyAsString));
+  });
+});

--- a/tests/unit/provisioning/sqs-queue-policy-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/sqs-queue-policy-provider-roundtrip.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SetQueueAttributesCommand } from '@aws-sdk/client-sqs';
+
+const mockSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    sqs: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { SQSQueuePolicyProvider } from '../../../src/provisioning/providers/sqs-queue-policy-provider.js';
+
+const QUEUE_URL = 'https://sqs.us-east-1.amazonaws.com/123/my-queue';
+const RESOURCE_TYPE = 'AWS::SQS::QueuePolicy';
+
+describe('SQSQueuePolicyProvider read-update round-trip', () => {
+  let provider: SQSQueuePolicyProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new SQSQueuePolicyProvider();
+    // SetQueueAttributesCommand response is empty
+    mockSend.mockResolvedValue({});
+  });
+
+  it('round-trip: observed snapshot survives update() with a valid Policy attribute', async () => {
+    // Mechanical guard for the round-trip code path used by `cdkd drift
+    // --revert`. See docs/provider-development.md § 3b.
+    //
+    // For SQS::QueuePolicy:
+    //   - Class 1 (type-discriminator-dependent fields): N/A — no
+    //     discriminator in the 2-field shape (Queues, PolicyDocument).
+    //   - Class 2 (structurally-incomplete-when-empty): N/A —
+    //     readCurrentState returns `undefined` when no Policy is
+    //     attached (state never carries an empty placeholder for
+    //     PolicyDocument).
+    //   - Truthy gate: update() validates with `!policyDocument`, but
+    //     PolicyDocument cannot legally be falsy in observed state
+    //     (readCurrentState returns undefined, not `{}` / null).
+    //
+    // This test exercises the happy round-trip: an observed snapshot
+    // produced by readCurrentState is fed back into update(), and the
+    // SetQueueAttributes call must carry a valid (non-empty,
+    // non-malformed) Policy attribute.
+    const policy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: { Service: 'events.amazonaws.com' },
+          Action: 'sqs:SendMessage',
+          Resource: 'arn:aws:sqs:us-east-1:123:my-queue',
+        },
+      ],
+    };
+    const observed = {
+      Queues: [QUEUE_URL],
+      PolicyDocument: policy,
+    };
+
+    await provider.update('L', QUEUE_URL, RESOURCE_TYPE, observed, observed);
+
+    const setAttrCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof SetQueueAttributesCommand
+    );
+    expect(setAttrCalls).toHaveLength(1);
+    const input = setAttrCalls[0]![0].input as {
+      QueueUrl: string;
+      Attributes: { Policy: string };
+    };
+    expect(input.QueueUrl).toBe(QUEUE_URL);
+    // Policy is JSON-serialised back to a string for SetQueueAttributes.
+    // Must NOT be the empty string (would clear the policy on AWS) nor
+    // '{}' (AWS rejects with malformed policy document).
+    expect(input.Attributes.Policy).not.toBe('');
+    expect(input.Attributes.Policy).not.toBe('{}');
+    expect(JSON.parse(input.Attributes.Policy)).toEqual(policy);
+  });
+
+  it('round-trip preserves a string-form PolicyDocument verbatim', async () => {
+    // readCurrentState falls back to the raw string if JSON.parse fails
+    // (line 273-276 of sqs-queue-policy-provider.ts). The string form
+    // must survive update() unchanged — JSON.stringify on a string
+    // would double-encode it.
+    const policyStr = '{"Version":"2012-10-17","Statement":[]}';
+    const observed = {
+      Queues: [QUEUE_URL],
+      PolicyDocument: policyStr,
+    };
+
+    await provider.update('L', QUEUE_URL, RESOURCE_TYPE, observed, observed);
+
+    const setAttrCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof SetQueueAttributesCommand
+    );
+    expect(setAttrCalls).toHaveLength(1);
+    const input = setAttrCalls[0]![0].input as {
+      Attributes: { Policy: string };
+    };
+    expect(input.Attributes.Policy).toBe(policyStr);
+  });
+});


### PR DESCRIPTION
## Summary

User-reported bug fix + audit completion for 6 providers that the 5-PR category plan (#163-167) missed.

### The user-reported bug

`cdkd drift` did NOT detect a console-side tag ADD on an S3 bucket that initially had no tags. Root cause: same class as the Firehose Tags catch-path bug fixed in PR 5 — `s3-bucket-provider.ts` read path caught `NoSuchTagSet` (no tags on bucket) without emitting `Tags: []`. The observed snapshot lacked the key entirely; the drift comparator's state-keys-only top-level walk then never compared.

### Per-provider results

| Provider | Class 1 | Class 2 | Truthy | Tests |
|---|---|---|---|---|
| **`S3BucketProvider`** | — | **3** (`BucketEncryption` / `CorsConfiguration` / `LifecycleConfiguration` empty array sanitize) | — | 9 + **the Tags always-emit fix** |
| `S3BucketPolicyProvider` | — | — | — | 3 |
| `IAMPolicyProvider` | — | — | — | 4 (inline `AWS::IAM::Policy` only; `ManagedPolicy` is in CC API deny-list) |
| `IAMInstanceProfileProvider` | — | — | — | 4 |
| `IAMUserGroupProvider` | — | — | — | 6 |
| `SNSTopicPolicyProvider` | — | — | — | 3 |
| `SQSQueuePolicyProvider` | — | — | — | 2 |

3 Class 2 fixes + the user-reported Tags bug + 31 new round-trip tests (1907 → 1938).

### Existing-state migration

Users who deployed before this fix have an `observedProperties` snapshot that lacks Tags. To pick up the fix on existing state, run **once** after upgrading:

```bash
cdkd state refresh-observed <stack>
```

Future drift runs will then detect Tags drift correctly.

## Test plan

- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` clean
- [x] `npx vitest --run` — 1938 tests pass (was 1907; **31 new round-trip tests**)
- [x] `/run-integ basic` — deploy 2/2 in 37s, destroy 2/2 / 0 errors / 0 orphans

## Audit completion (real this time)

This finally closes the round-trip audit. **Every provider in `src/provisioning/providers/**` that has a `readCurrentState` now has a round-trip property test** that mechanically guards against the 3 bug classes. The 5-PR category plan missed the policy sub-resources and S3 mainline; this PR adds them.

The miss was a process gap — categorisation by service category accidentally split S3 across "Data" / "Network" / "tail" without ever including `s3-bucket-provider.ts` itself. Future audits should grep providers without round-trip tests as the source of truth, not category lists.
