### PR TITLE
docs: clarify cdkd state refresh-observed + fill v2→v3 upgrade flow in cli-reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,11 +314,13 @@ cdkd drift MyStack --accept --yes
 cdkd drift MyStack --revert --yes
 
 # Refresh the deploy-time AWS snapshot used as drift baseline.
-# Run this once after upgrading from a pre-v3 cdkd binary (= state schema
-# `version: 2`) so console-side changes to keys you didn't template can
-# be detected for resources that won't change in any near-future deploy.
-# Same idempotent behavior on the same v3 state — see "Drift detection"
-# below for the full upgrade story.
+# Optional — `cdkd deploy` itself auto-refreshes on the first deploy after
+# upgrading from a pre-v3 cdkd binary (= state schema `version: 2`), in
+# parallel with the deploy at no critical-path cost. This command is the
+# manual / non-deploy path: run it when you want the baseline refreshed
+# without redeploying (e.g. for resources that won't change in any
+# near-future deploy). Idempotent on the same v3 state — see "Drift
+# detection" below for the full upgrade story.
 cdkd state refresh-observed MyStack
 
 # Dry run (plan only, no changes)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -170,6 +170,22 @@ escape-hatch order is: `--no-capture-observed-state` (CLI) overrides
 `cdk.json context.cdkd.captureObservedState` (project) overrides the
 default `true`.
 
+### v2 → v3 schema upgrade flow
+
+When `cdkd deploy` loads state and finds resources without
+`observedProperties` (typical the first time you deploy after upgrading
+from cdkd <0.49 / state schema `version: 2`), it kicks off
+`provider.readCurrentState` for each in parallel with the rest of the
+deploy and drains the result into state at the final save. The deploy
+critical path does NOT wait on these — cost is bounded by the longest
+single `readCurrentState` (~200-300ms in practice), once. Subsequent
+deploys are unaffected. Honors `--no-capture-observed-state` (skips
+both regular capture and this upgrade refresh).
+
+`cdkd state refresh-observed <stack>` remains the manual / non-deploy
+path — useful when you want to refresh the baseline without redeploying
+(e.g. for resources that won't change in any near-future deploy).
+
 ## Per-resource timeout
 
 Both `cdkd deploy` and `cdkd destroy` (including `cdkd state destroy`)


### PR DESCRIPTION
## Summary

Fixes two stale-doc gaps left by the v3 schema work:

### 1. README.md `cdkd state refresh-observed` guidance was misleading after v0.51.0

PR #170 / v0.51.0 made `cdkd deploy` auto-refresh `observedProperties` on v2 → v3 schema upgrade in parallel with the deploy. README.md still told users to "Run this once after upgrading from a pre-v3 cdkd binary" — which is no longer the right framing. The manual command is now for refreshing the baseline **without redeploying** (e.g. for resources that won't change in any near-future deploy), not the upgrade path.

### 2. `docs/cli-reference.md` was missing the v2 → v3 upgrade flow section

README's drift section already points to `docs/cli-reference.md` "for the full reference: ..., v2→v3 state upgrade flow, exit codes, ...". But that section didn't exist in cli-reference.md. PR adds a short paragraph mirroring the one already in `docs/state-management.md` so the cross-reference resolves.

Both fixes together make the README + `docs/cli-reference.md` + `docs/state-management.md` trio consistent on the auto-refresh behavior.

## Test plan

- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` clean (no src changed)
- [x] `npx vitest --run` — 210 files / 1938 tests pass
- [x] **Live-test post-PR-D-merge**: `/run-integ drift-revert` ran the verify.sh-dispatch path end-to-end against AWS:
  - PR D's skill change works as designed: `verify.sh` was detected and dispatched to via `AWS_REGION=us-east-1 STATE_BUCKET=<bucket> bash verify.sh`
  - Full 7-step flow ran clean: deploy → drift inject → drift detect (exit 1) → drift --revert -y → drift clean (exit 0) → destroy (6/6 deleted, 0 errors)
  - 0 orphans across S3 / IAM / SNS / Lambda
  - `mise exec -- markgate set integ-destroy` recorded
- [x] No code changes — docs-only PR

## Files

- `README.md` — line 316-322 comment rewritten
- `docs/cli-reference.md` — new "v2 → v3 schema upgrade flow" subsection added under `--no-capture-observed-state`
