### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ cdk.context.json
 
 # Benchmark artifacts
 tests/benchmark/results-*.md
+
+# Claude Code runtime state
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

Adds `.claude/scheduled_tasks.lock` to `.gitignore`. The file is per-session / per-machine Claude Code runtime state (sessionId / pid / acquiredAt JSON) — no value tracking it. Without this, every developer running a Claude Code session sees the lock file as untracked in `git status`.

Mechanical fix; surfaced during the PR #173 retrospective when the file kept appearing in `git status` output across the session.

## Test plan

- [x] `git status` no longer shows the lock file as untracked
- [x] No code / docs / behavior changes
- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` / `npx vitest --run` all unaffected (1938 tests pass)
