### PR TITLE
docs: fix stale 'deferred' docstring on KMSProvider.readCurrentState

### DIFF
--- a/src/provisioning/providers/kms-provider.ts
+++ b/src/provisioning/providers/kms-provider.ts
@@ -568,10 +568,10 @@ export class KMSProvider implements ResourceProvider {
    * Dispatches by resource type:
    *   - `AWS::KMS::Key` → `DescribeKey`. Surfaces `Description`, `KeySpec`,
    *     `KeyUsage`, `Enabled`, `MultiRegion`, `Origin`. `KeyPolicy` is
-   *     intentionally NOT retrieved — `GetKeyPolicy` is a separate call
-   *     and the policy body needs JSON parsing for comparison; deferred
-   *     to a follow-up. `EnableKeyRotation` / `RotationPeriodInDays`
-   *     would require `GetKeyRotationStatus`; also deferred.
+   *     additionally retrieved via `GetKeyPolicy` (URL-decoded JSON-parsed)
+   *     and `EnableKeyRotation` / `RotationPeriodInDays` via
+   *     `GetKeyRotationStatus` (Class 1 discriminator-gated on `KeySpec`
+   *     since asymmetric keys reject the call).
    *   - `AWS::KMS::Alias` → `ListAliases` filtered to the alias name.
    *     Surfaces `AliasName`, `TargetKeyId`. `ListAliases` is paginated
    *     since there's no direct "describe one alias" API.


### PR DESCRIPTION
## Summary

Fix a stale docstring on `KMSProvider.readCurrentState`. PR #175 lifted `KeyPolicy` / `EnableKeyRotation` / `RotationPeriodInDays` out of `getDriftUnknownPaths` and into `readCurrentState` (via `GetKeyPolicy` and `GetKeyRotationStatus`), but the JSDoc was not updated. The old wording said the fields were "deferred to a follow-up" — that contradicts the actual behavior post-#175.

No code change — comment only.

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` / `vitest --run` — 2013 tests across 211 files, all pass (no test diff — comment-only)
- [x] `bash tests/integration/drift-revert/verify.sh` — refreshes the `integ-destroy` gate marker (the gate's scope includes `src/provisioning/providers/**` so even a comment-only change there requires the integ refresh)
- [x] All four markgate markers fresh

## Retrospective rule proposals

This stale docstring was found by an audit triggered by the user's "残タスクや問題はもうない？" question. The pattern is captured in a new memory entry `feedback_stale_docstring_after_partial_impl.md`: when implementing a previously-deferred field, grep for "deferred" / "intentionally NOT" / "out of scope" wording in the touched file and update it. Mechanical detection is too varied to gate via hook, so this stays in memory as a habit cue.
