### PR TITLE
docs: fix stale 'IAM inline-policy bodies out of scope for v1' line in cli-reference.md

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -481,7 +481,9 @@ metadata, not as user-managed `Tags` properties, so leaving them in would
 fire false-positive drift on every CDK-deployed resource. The remaining
 user tags are normalized to CFn's `[{Key, Value}]` shape (sorted by `Key`
 for stable comparison) and the result key is omitted entirely when AWS
-reports no user tags. IAM inline-policy bodies remain out of scope for v1;
+reports no user tags. IAM Role / User / Group inline-policy bodies are
+covered (paginated `List*Policies` + parallel `Get*Policy` round-trips
+with state-driven order reconciliation) since PR #175;
 see [src/types/resource.ts](../src/types/resource.ts) for the per-provider
 shape decisions.
 


### PR DESCRIPTION
## Summary

Fix a stale doc line in `docs/cli-reference.md`. The sentence claimed IAM inline-policy bodies were "out of scope for v1" — but PR #175 lifted IAM Role inline policies into `readCurrentState` (paginated `ListRolePolicies` + parallel `GetRolePolicy` with state-driven order reconciliation), and the same pattern was extended to IAM User and IAM Group via the shared `collectInlinePolicies` helper. Wording is now updated to match the actual coverage.

No code change.

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` / `vitest --run` — 2074 tests pass (no test diff)
- [x] All four markgate markers fresh (no integ-destroy refresh needed — docs change is outside `src/provisioning/providers/**` scope)

## Retrospective rule proposals

This is exactly the case `feedback_stale_docstring_after_partial_impl.md` covers — adding it to memory in this session was justified by the existence of more stale wording I had not initially detected. Today's audit pass found two locations (KMS docstring fixed in #193, this docs/cli-reference.md line fixed here). The pattern recurs at multi-PR-cycle granularity; the memory entry is the right tool for it (no good mechanical detection).
