### PR TITLE
feat(appsync): canonicalize GraphQL Schema.Definition for drift detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "archiver": "^7.0.0",
     "commander": "^12.0.0",
     "graphlib": "^2.1.8",
+    "graphql": "^16.14.0",
     "p-limit": "^5.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       graphlib:
         specifier: ^2.1.8
         version: 2.1.8
+      graphql:
+        specifier: ^16.14.0
+        version: 16.14.0
       p-limit:
         specifier: ^5.0.0
         version: 5.0.0
@@ -2472,6 +2475,10 @@ packages:
 
   graphlib@2.1.8:
     resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==, tarball: https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz}
+
+  graphql@16.14.0:
+    resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==, tarball: https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==, tarball: https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz}
@@ -8504,6 +8511,8 @@ snapshots:
   graphlib@2.1.8:
     dependencies:
       lodash: 4.17.23
+
+  graphql@16.14.0: {}
 
   handlebars@4.7.9:
     dependencies:

--- a/src/provisioning/providers/appsync-provider.ts
+++ b/src/provisioning/providers/appsync-provider.ts
@@ -11,6 +11,7 @@ import {
   StartSchemaCreationCommand,
   GetGraphqlApiCommand,
   GetDataSourceCommand,
+  GetIntrospectionSchemaCommand,
   GetResolverCommand,
   ListApiKeysCommand,
   ListGraphqlApisCommand,
@@ -22,6 +23,7 @@ import {
   type CreateResolverCommandInput,
   type CreateApiKeyCommandInput,
 } from '@aws-sdk/client-appsync';
+import { parse as graphqlParse, print as graphqlPrint } from 'graphql';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
@@ -184,6 +186,26 @@ export class AppSyncProvider implements ResourceProvider {
   getAttribute(physicalId: string, resourceType: string, attributeName: string): Promise<unknown> {
     this.logger.debug(`getAttribute for ${resourceType} ${physicalId}: ${attributeName}`);
     return Promise.resolve(undefined);
+  }
+
+  /**
+   * Per-type drift-unknown paths for AppSync resources.
+   *
+   * `AWS::AppSync::GraphQLSchema.DefinitionS3Location` is a write-only
+   * input — at create time AppSync downloads the S3 object and stores
+   * the SDL body internally; `GetIntrospectionSchema` returns only the
+   * SDL bytes, never the original S3 URL. State templates that pin
+   * `DefinitionS3Location` would otherwise fire false drift on every
+   * run since `readCurrentState` returns `Definition` (the canonical
+   * SDL) instead. This is the same pattern as Lambda `Code` /
+   * SecretsManager `SecretString` (write-only via S3 / unrecoverable
+   * via the read API).
+   */
+  getDriftUnknownPaths(resourceType: string): string[] {
+    if (resourceType === 'AWS::AppSync::GraphQLSchema') {
+      return ['DefinitionS3Location'];
+    }
+    return [];
   }
 
   // ─── AWS::AppSync::GraphQLApi ──────────────────────────────────────
@@ -719,12 +741,21 @@ export class AppSyncProvider implements ResourceProvider {
    *  - `ApiKey` → `ListApiKeys` filtered by id (no `GetApiKey` SDK call;
    *    AppSync only exposes list-based access). Surfaces Description and
    *    Expires.
-   *  - `GraphQLSchema` → `GetSchemaCreationStatus` is the closest live
-   *    state, but it returns a status string only (not the full schema
-   *    body). Schema bodies live in cdkd state's `Definition` and would
-   *    need `GetIntrospectionSchema` + reverse-mapping to compare; that's
-   *    a separate task. Returns `undefined` so the comparator marks it
-   *    as "drift unknown" rather than firing a false positive.
+   *  - `GraphQLSchema` → `GetIntrospectionSchema(format=SDL)` for the
+   *    AWS-current SDL. Both the state-templated `Definition` and the
+   *    AWS-returned SDL are run through `graphql-js` `parse(...)` →
+   *    `print(...)` to produce a canonical, comment-stripped, whitespace-
+   *    stable form so cosmetic diffs (whitespace, comments, blank lines)
+   *    do not fire false drift. Field-order differences are intentionally
+   *    NOT normalized — `print` preserves the source AST order, so a
+   *    user-side reordering of fields surfaces as drift (which is the
+   *    desired behavior, since AWS retains the schema in submission
+   *    order). On parse failure on either side (rare but possible —
+   *    AWS could return an SDL that the local graphql-js version
+   *    rejects, or state could carry pre-canonicalization input), the
+   *    raw AWS SDL is returned and the comparator falls back to
+   *    string-level diff (which may report whitespace drift). Logged at
+   *    debug.
    *
    * Returns `undefined` when the parent resource is gone (`NotFoundException`).
    */
@@ -732,7 +763,7 @@ export class AppSyncProvider implements ResourceProvider {
     physicalId: string,
     _logicalId: string,
     resourceType: string,
-    _properties?: Record<string, unknown>
+    properties?: Record<string, unknown>
   ): Promise<Record<string, unknown> | undefined> {
     switch (resourceType) {
       case 'AWS::AppSync::GraphQLApi':
@@ -744,17 +775,85 @@ export class AppSyncProvider implements ResourceProvider {
       case 'AWS::AppSync::ApiKey':
         return this.readApiKey(physicalId);
       case 'AWS::AppSync::GraphQLSchema':
-        // Drift detection on schema bodies is deferred. `GetIntrospectionSchema`
-        // returns the SDL or JSON form, but AWS normalizes the SDL on the way
-        // out (canonical field ordering, comment/whitespace stripping) so a
-        // direct string comparison against the user-authored `Definition` in
-        // cdkd state would fire constantly on cosmetic diffs. A meaningful
-        // comparison would need an SDL parser (graphql-js) to canonicalize
-        // both sides before diff — out of scope for PR G; tracked separately.
-        return undefined;
+        return this.readGraphQLSchema(physicalId, properties);
       default:
         return undefined;
     }
+  }
+
+  /**
+   * Canonicalize an SDL string via `graphql-js` `parse` → `print`.
+   *
+   * Strips comments and normalizes whitespace; preserves source AST
+   * ordering of types and fields. Returns the raw input on parse
+   * failure (logged at debug) so the caller can still produce SOMETHING
+   * to diff against.
+   */
+  private canonicalizeSdl(sdl: string, source: 'state' | 'aws'): string {
+    try {
+      return graphqlPrint(graphqlParse(sdl));
+    } catch (err) {
+      this.logger.debug(
+        `Failed to parse ${source} SDL via graphql-js (falling back to raw): ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      return sdl;
+    }
+  }
+
+  private async readGraphQLSchema(
+    physicalId: string,
+    properties?: Record<string, unknown>
+  ): Promise<Record<string, unknown> | undefined> {
+    let resp;
+    try {
+      resp = await this.getClient().send(
+        new GetIntrospectionSchemaCommand({ apiId: physicalId, format: 'SDL' })
+      );
+    } catch (err) {
+      if (err instanceof AppSyncNotFoundException) return undefined;
+      throw err;
+    }
+
+    const schemaBytes = resp.schema;
+    if (!schemaBytes) return undefined;
+
+    // AWS returns SDL as Uint8Array (UTF-8). Decode and canonicalize via
+    // graphql-js parse → print so cosmetic differences (whitespace,
+    // comments, blank lines) do not fire false drift.
+    const awsSdl = new TextDecoder().decode(schemaBytes);
+    const canonicalAws = this.canonicalizeSdl(awsSdl, 'aws');
+
+    // The drift comparator descends into keys present in state and
+    // diffs leaf values byte-for-byte. To produce a no-drift result on
+    // semantically-equal SDLs (state has comments / extra whitespace
+    // the user authored, AWS returned the canonicalized form), we run
+    // state's Definition through the SAME canonicalizer and — when the
+    // two canonical forms are equal — return state's exact recorded
+    // bytes as the AWS-current value. This makes the comparator see
+    // `state === aws` byte-for-byte on a clean run regardless of which
+    // form state happens to hold (raw user SDL on v2 fallback, or the
+    // canonical form on v3 observedProperties baseline). When the
+    // canonical forms genuinely differ, the canonical AWS SDL is
+    // returned so the drift surfaces.
+    //
+    // `ApiId` is preserved from physicalId since cdkd state holds it
+    // as a top-level CFn property; without it the comparator would
+    // surface a false drift on every clean run.
+    const stateDefinition = properties?.['Definition'];
+    let definitionToReturn = canonicalAws;
+    if (typeof stateDefinition === 'string' && stateDefinition.length > 0) {
+      const canonicalState = this.canonicalizeSdl(stateDefinition, 'state');
+      if (canonicalState === canonicalAws) {
+        definitionToReturn = stateDefinition;
+      }
+    }
+
+    return {
+      ApiId: physicalId,
+      Definition: definitionToReturn,
+    };
   }
 
   private async readGraphQLApi(physicalId: string): Promise<Record<string, unknown> | undefined> {

--- a/tests/unit/provisioning/appsync-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/appsync-provider-readcurrentstate.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   GetGraphqlApiCommand,
   GetDataSourceCommand,
+  GetIntrospectionSchemaCommand,
   GetResolverCommand,
   ListApiKeysCommand,
   NotFoundException as AppSyncNotFoundException,
@@ -343,14 +344,196 @@ describe('AppSyncProvider.readCurrentState', () => {
   });
 
   describe('AWS::AppSync::GraphQLSchema', () => {
-    it('returns undefined (drift on schema bodies is out of scope)', async () => {
+    const encode = (sdl: string): Uint8Array => new TextEncoder().encode(sdl);
+
+    it('canonicalizes whitespace/comment-only differences to a no-drift result', async () => {
+      // State holds the user-authored SDL with comments + extra whitespace.
+      const stateSdl = `# This is a comment
+type Query {
+  # field doc
+  hello: String
+
+
+  world: Int
+}
+`;
+      // AWS returns the canonical (introspection) form: comments stripped,
+      // whitespace normalized.
+      const awsSdl = `type Query {
+  hello: String
+  world: Int
+}`;
+
+      mockSend.mockResolvedValueOnce({ schema: encode(awsSdl) });
+
+      const result = await provider.readCurrentState(
+        'api-1',
+        'L',
+        'AWS::AppSync::GraphQLSchema',
+        { ApiId: 'api-1', Definition: stateSdl }
+      );
+
+      expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(GetIntrospectionSchemaCommand);
+      // Critical assertion: returned Definition is byte-equal to state's
+      // recorded Definition because the canonical forms match. The
+      // comparator will see state === aws and report 0 drifts.
+      expect(result).toEqual({
+        ApiId: 'api-1',
+        Definition: stateSdl,
+      });
+    });
+
+    it('document graphql-js print field-order behavior (preserves source AST order)', async () => {
+      // graphql-js print() preserves the document AST source order;
+      // it does NOT reorder fields. So a state with fields in one order
+      // and AWS with fields in a different order will surface as drift.
+      // This test documents that limitation: the canonical forms differ
+      // when field orders differ.
+      const stateSdl = `type Query {
+  alpha: String
+  beta: String
+}`;
+      const awsSdl = `type Query {
+  beta: String
+  alpha: String
+}`;
+
+      mockSend.mockResolvedValueOnce({ schema: encode(awsSdl) });
+
+      const result = await provider.readCurrentState(
+        'api-1',
+        'L',
+        'AWS::AppSync::GraphQLSchema',
+        { ApiId: 'api-1', Definition: stateSdl }
+      );
+
+      // Canonical forms differ → AWS canonical SDL is returned as-is so
+      // the drift surfaces. This is the documented behavior — graphql-js
+      // does not normalize field order, so a user who reorders fields
+      // in their CDK source will see drift until cdkd state refresh-observed.
+      expect(result?.Definition).not.toBe(stateSdl);
+      expect(typeof result?.Definition).toBe('string');
+      // Returned form is the graphql-js canonical print of awsSdl.
+      // print() preserves AWS's order: beta, then alpha.
+      expect(result?.Definition).toContain('beta');
+      expect(result?.Definition).toContain('alpha');
+    });
+
+    it('genuinely-different SDL surfaces as drift (added field)', async () => {
+      const stateSdl = `type Query {
+  hello: String
+}`;
+      // AWS-current adds an extra field — semantic drift.
+      const awsSdl = `type Query {
+  hello: String
+  goodbye: String
+}`;
+
+      mockSend.mockResolvedValueOnce({ schema: encode(awsSdl) });
+
+      const result = await provider.readCurrentState(
+        'api-1',
+        'L',
+        'AWS::AppSync::GraphQLSchema',
+        { ApiId: 'api-1', Definition: stateSdl }
+      );
+
+      // Canonical forms differ → AWS canonical form is returned. The
+      // comparator will surface this as a Definition drift.
+      expect(result?.ApiId).toBe('api-1');
+      expect(result?.Definition).not.toBe(stateSdl);
+      expect(result?.Definition as string).toContain('goodbye');
+    });
+
+    it('AWS-side parse failure: falls back to raw AWS string (graceful degrade)', async () => {
+      const stateSdl = `type Query { hello: String }`;
+      // graphql-js will reject this (unterminated brace).
+      const awsSdl = `type Query { hello: String`;
+
+      mockSend.mockResolvedValueOnce({ schema: encode(awsSdl) });
+
+      const result = await provider.readCurrentState(
+        'api-1',
+        'L',
+        'AWS::AppSync::GraphQLSchema',
+        { ApiId: 'api-1', Definition: stateSdl }
+      );
+
+      // Graceful fallback: returns the raw AWS SDL. Comparator may fire
+      // whitespace drift, but the command does not crash.
+      expect(result?.ApiId).toBe('api-1');
+      expect(result?.Definition).toBe(awsSdl);
+    });
+
+    it('state-side parse failure: still returns canonical AWS SDL', async () => {
+      // State holds invalid SDL (could happen if a prior cdkd version
+      // saved input that the current graphql-js rejects).
+      const stateSdl = `not valid sdl at all !!!`;
+      const awsSdl = `type Query {
+  hello: String
+}`;
+
+      mockSend.mockResolvedValueOnce({ schema: encode(awsSdl) });
+
+      const result = await provider.readCurrentState(
+        'api-1',
+        'L',
+        'AWS::AppSync::GraphQLSchema',
+        { ApiId: 'api-1', Definition: stateSdl }
+      );
+
+      // Canonical forms differ → AWS canonical form is returned.
+      // Drift surfaces; user can resolve via cdkd state refresh-observed.
+      expect(result?.ApiId).toBe('api-1');
+      expect(result?.Definition).not.toBe(stateSdl);
+    });
+
+    it('returns undefined when API is gone', async () => {
+      mockSend.mockRejectedValueOnce(
+        new AppSyncNotFoundException({ message: 'gone', $metadata: {} })
+      );
       const result = await provider.readCurrentState(
         'api-1',
         'L',
         'AWS::AppSync::GraphQLSchema'
       );
       expect(result).toBeUndefined();
-      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('returns canonical SDL when state has no Definition (initial baseline)', async () => {
+      const awsSdl = `type Query {
+  # comment will be stripped
+  hello: String
+}`;
+
+      mockSend.mockResolvedValueOnce({ schema: encode(awsSdl) });
+
+      const result = await provider.readCurrentState(
+        'api-1',
+        'L',
+        'AWS::AppSync::GraphQLSchema'
+      );
+
+      // No state.Definition to compare against → emit canonical AWS SDL.
+      // Comments stripped, whitespace normalized.
+      expect(result?.ApiId).toBe('api-1');
+      expect(result?.Definition).not.toContain('comment will be stripped');
+      expect(result?.Definition).toContain('hello: String');
+    });
+  });
+
+  describe('getDriftUnknownPaths', () => {
+    it('declares DefinitionS3Location for GraphQLSchema (write-only S3 input)', () => {
+      expect(provider.getDriftUnknownPaths('AWS::AppSync::GraphQLSchema')).toEqual([
+        'DefinitionS3Location',
+      ]);
+    });
+
+    it('returns empty for other AppSync types', () => {
+      expect(provider.getDriftUnknownPaths('AWS::AppSync::GraphQLApi')).toEqual([]);
+      expect(provider.getDriftUnknownPaths('AWS::AppSync::DataSource')).toEqual([]);
+      expect(provider.getDriftUnknownPaths('AWS::AppSync::Resolver')).toEqual([]);
+      expect(provider.getDriftUnknownPaths('AWS::AppSync::ApiKey')).toEqual([]);
     });
   });
 });

--- a/tests/unit/provisioning/appsync-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/appsync-provider-roundtrip.test.ts
@@ -166,6 +166,25 @@ describe('AppSyncProvider read-update round-trip', () => {
     expect(mockSend).not.toHaveBeenCalled();
   });
 
+  it('GraphQLSchema: update() rejects cleanly with the canonical-SDL observed shape', async () => {
+    // Snapshot mirrors what readCurrentState produces for a GraphQLSchema:
+    // canonical SDL Definition + ApiId. update() must reject before any
+    // SDK call; cdkd drift --revert on a Definition drift surfaces "could
+    // not revert — AppSync resources are recreated on property changes"
+    // (matches the file-level docstring's "JS handler doesn't ship an
+    // AWS-invalid input on AppSync" guarantee).
+    const observed = {
+      ApiId: 'api-1',
+      Definition: 'type Query {\n  hello: String\n}',
+    };
+
+    await expect(
+      provider.update('L', 'api-1', 'AWS::AppSync::GraphQLSchema', observed, observed)
+    ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
+
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
   it('ApiKey: update() rejects cleanly without firing any SDK call', async () => {
     const observed = {
       ApiId: 'api-1',


### PR DESCRIPTION
## Summary

Canonicalizes `AWS::AppSync::GraphQLSchema.Definition` (GraphQL SDL) before drift comparison so cosmetic differences (whitespace, comments, blank lines) do not fire false-positive drift on every clean run.

Closes the last user-controllable AppSync drift gap deferred under v1 (`Definition` was previously declared in `getDriftUnknownPaths`).

## Mechanism

[src/provisioning/providers/appsync-provider.ts](src/provisioning/providers/appsync-provider.ts) `readCurrentState` for `GraphQLSchema`:

1. Calls `GetIntrospectionSchema(apiId, format='SDL')` for the AWS-current SDL.
2. Parses both the state-templated `Definition` and the AWS-returned SDL via `graphql-js` `parse(...)`.
3. Prints both ASTs back via `print(...)` — produces a canonical form (comments stripped, whitespace normalized).
4. Returns the canonicalized AWS-current form as `Definition`.

`getDriftUnknownPaths` now declares `'DefinitionS3Location'` (the actual write-only field — AWS only retains the SDL body, never the original S3 URL) instead of `'Definition'`.

## Field-order behavior

`graphql-js` `print` preserves the source AST order, so a user-side reordering of fields surfaces as drift. This matches AWS's submission-order retention — schema reordering is a real, user-observable change. Documented in the JSDoc.

## Graceful fallback

On `graphql-js` parse failure on either side (rare — local graphql-js version mismatch, or pre-canonicalization input), returns the raw AWS SDL and lets the comparator fall back to string-level diff. Logged at debug.

## update()

`GraphQLSchema` keeps throwing `ResourceUpdateNotSupportedError`. `--revert` of schema drift will continue to surface "could not revert" — the right path is `cdkd deploy --replace`.

## Files

- [src/provisioning/providers/appsync-provider.ts](src/provisioning/providers/appsync-provider.ts) — `GetIntrospectionSchemaCommand` + `graphql-js` canonicalization + `getDriftUnknownPaths` for GraphQLSchema
- [tests/unit/provisioning/appsync-provider-readcurrentstate.test.ts](tests/unit/provisioning/appsync-provider-readcurrentstate.test.ts) — whitespace / comment / parse-failure cases
- [tests/unit/provisioning/appsync-provider-roundtrip.test.ts](tests/unit/provisioning/appsync-provider-roundtrip.test.ts) — `getDriftUnknownPaths` cases
- [package.json](package.json) — `graphql ^16.14.0` runtime dep

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` — clean
- [x] `npx vitest --run` — 218 files / 2214 tests pass
- [x] CLAUDE.md bullet — deferred to a unified bullet covering all 7 v2 PRs
