### PR TITLE
feat(glue): SDK providers for Workflow/SecurityConfiguration with drift coverage

### DIFF
--- a/src/provisioning/providers/glue-provider.ts
+++ b/src/provisioning/providers/glue-provider.ts
@@ -11,6 +11,15 @@ import {
   GetTableCommand,
   GetTablesCommand,
   GetTagsCommand,
+  CreateWorkflowCommand,
+  UpdateWorkflowCommand,
+  DeleteWorkflowCommand,
+  GetWorkflowCommand,
+  ListWorkflowsCommand,
+  CreateSecurityConfigurationCommand,
+  DeleteSecurityConfigurationCommand,
+  GetSecurityConfigurationCommand,
+  GetSecurityConfigurationsCommand,
   EntityNotFoundException,
   type DatabaseInput,
   type TableInput,
@@ -18,12 +27,16 @@ import {
   type Column,
   type Order,
   type SerDeInfo,
+  type EncryptionConfiguration,
+  type S3Encryption,
+  type CloudWatchEncryption,
+  type JobBookmarksEncryption,
 } from '@aws-sdk/client-glue';
 import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { getLogger } from '../../utils/logger.js';
-import { ProvisioningError } from '../../utils/error-handler.js';
+import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
-import { CDK_PATH_TAG } from '../import-helpers.js';
+import { CDK_PATH_TAG, normalizeAwsTagsToCfn } from '../import-helpers.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -869,4 +882,670 @@ export class GlueProvider implements ResourceProvider {
     this.cachedAccountId = identity.Account;
     return this.cachedAccountId;
   }
+}
+
+// ─── AWS::Glue::Workflow ───────────────────────────────────────────
+//
+// Glue Workflow has a clean SDK update path (`UpdateWorkflow`) covering
+// every mutable top-level field — `Description`, `DefaultRunProperties`,
+// `MaxConcurrentRuns`. `Name` is immutable on create. Tags ride on
+// `CreateWorkflow.Tags` but cdkd updates them out-of-band via
+// `TagResource` / `UntagResource` (kept simple here — tag updates are
+// always done by `cdkd drift --revert` against the current AWS shape).
+//
+// Surface used by `cdkd drift`:
+//   - `readCurrentState` reads via `GetWorkflow` and reverse-maps every
+//     user-controllable top-level key to the CFn shape with PR #145
+//     always-emit placeholders (`Description: ''`, `DefaultRunProperties: {}`,
+//     `MaxConcurrentRuns: undefined` only when AWS reports nothing — same
+//     pattern used by other providers' optional integer fields).
+//   - `getDriftUnknownPaths` is empty: no AWS-managed read-only fields are
+//     templated into cdkd state for this type.
+
+/**
+ * SDK Provider for `AWS::Glue::Workflow`.
+ *
+ * Workflow is a top-level Glue catalog entry that orchestrates Triggers,
+ * Jobs, and Crawlers via a DAG. The CFn shape carries `Name` (required,
+ * immutable on create), `Description`, `DefaultRunProperties` (string→string
+ * map), `MaxConcurrentRuns`, and `Tags`.
+ *
+ * Read-update round-trip: `cdkd drift --revert` calls `update(...,
+ * awsCurrent, observedSnapshot)` so the same `UpdateWorkflow` payload is
+ * built from either side. `Description` and `DefaultRunProperties` use
+ * `!== undefined` gates so empty-string / empty-map values reach AWS
+ * (matches `feedback_update_optional_field_undefined_check.md`).
+ */
+export class GlueWorkflowProvider implements ResourceProvider {
+  private client: GlueClient | undefined;
+  private stsClient: STSClient | undefined;
+  private cachedAccountId: string | undefined;
+  private readonly providerRegion = process.env['AWS_REGION'];
+  private logger = getLogger().child('GlueWorkflowProvider');
+
+  handledProperties = new Map<string, ReadonlySet<string>>([
+    [
+      'AWS::Glue::Workflow',
+      new Set(['Name', 'Description', 'DefaultRunProperties', 'MaxConcurrentRuns', 'Tags']),
+    ],
+  ]);
+
+  private getClient(): GlueClient {
+    if (!this.client) {
+      this.client = new GlueClient(this.providerRegion ? { region: this.providerRegion } : {});
+    }
+    return this.client;
+  }
+
+  async create(
+    logicalId: string,
+    resourceType: string,
+    properties: Record<string, unknown>
+  ): Promise<ResourceCreateResult> {
+    this.logger.debug(`Creating Glue Workflow ${logicalId}`);
+
+    const name = properties['Name'] as string | undefined;
+    if (!name) {
+      throw new ProvisioningError(
+        `Name is required for Glue Workflow ${logicalId}`,
+        resourceType,
+        logicalId
+      );
+    }
+
+    try {
+      const tags = workflowTagsForCreate(properties['Tags']);
+      await this.getClient().send(
+        new CreateWorkflowCommand({
+          Name: name,
+          ...(properties['Description'] !== undefined && {
+            Description: properties['Description'] as string,
+          }),
+          ...(properties['DefaultRunProperties'] !== undefined && {
+            DefaultRunProperties: properties['DefaultRunProperties'] as Record<string, string>,
+          }),
+          ...(properties['MaxConcurrentRuns'] !== undefined && {
+            MaxConcurrentRuns: properties['MaxConcurrentRuns'] as number,
+          }),
+          ...(tags && { Tags: tags }),
+        })
+      );
+
+      this.logger.debug(`Successfully created Glue Workflow ${logicalId}: ${name}`);
+      return { physicalId: name, attributes: {} };
+    } catch (error) {
+      const cause = error instanceof Error ? error : undefined;
+      throw new ProvisioningError(
+        `Failed to create Glue Workflow ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,
+        resourceType,
+        logicalId,
+        undefined,
+        cause
+      );
+    }
+  }
+
+  async update(
+    logicalId: string,
+    physicalId: string,
+    resourceType: string,
+    properties: Record<string, unknown>,
+    _previousProperties: Record<string, unknown>
+  ): Promise<ResourceUpdateResult> {
+    this.logger.debug(`Updating Glue Workflow ${logicalId}: ${physicalId}`);
+
+    try {
+      await this.getClient().send(
+        new UpdateWorkflowCommand({
+          Name: physicalId,
+          ...(properties['Description'] !== undefined && {
+            Description: properties['Description'] as string,
+          }),
+          ...(properties['DefaultRunProperties'] !== undefined && {
+            DefaultRunProperties: properties['DefaultRunProperties'] as Record<string, string>,
+          }),
+          ...(properties['MaxConcurrentRuns'] !== undefined && {
+            MaxConcurrentRuns: properties['MaxConcurrentRuns'] as number,
+          }),
+        })
+      );
+
+      this.logger.debug(`Successfully updated Glue Workflow ${logicalId}`);
+      return { physicalId, wasReplaced: false };
+    } catch (error) {
+      const cause = error instanceof Error ? error : undefined;
+      throw new ProvisioningError(
+        `Failed to update Glue Workflow ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,
+        resourceType,
+        logicalId,
+        physicalId,
+        cause
+      );
+    }
+  }
+
+  async delete(
+    logicalId: string,
+    physicalId: string,
+    resourceType: string,
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
+  ): Promise<void> {
+    this.logger.debug(`Deleting Glue Workflow ${logicalId}: ${physicalId}`);
+
+    try {
+      await this.getClient().send(new DeleteWorkflowCommand({ Name: physicalId }));
+      this.logger.debug(`Successfully deleted Glue Workflow ${logicalId}`);
+    } catch (error) {
+      if (error instanceof EntityNotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
+        this.logger.debug(`Glue Workflow ${physicalId} does not exist, skipping deletion`);
+        return;
+      }
+      const cause = error instanceof Error ? error : undefined;
+      throw new ProvisioningError(
+        `Failed to delete Glue Workflow ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,
+        resourceType,
+        logicalId,
+        physicalId,
+        cause
+      );
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await -- explicit-override-only intentionally has no AWS calls
+  async getAttribute(
+    physicalId: string,
+    _resourceType: string,
+    attributeName: string
+  ): Promise<unknown> {
+    if (attributeName === 'Id' || attributeName === 'Ref' || attributeName === 'Name') {
+      return physicalId;
+    }
+    return undefined;
+  }
+
+  /**
+   * Read AWS-current Workflow shape via `GetWorkflow`. Surfaces every
+   * user-controllable top-level CFn key with always-emit placeholders
+   * (PR #145):
+   *  - `Description` → `?? ''`
+   *  - `DefaultRunProperties` → `?? {}`
+   *  - `MaxConcurrentRuns` → omitted when AWS reports `undefined` (no
+   *    AWS-side default to anchor a placeholder against; cdkd state may
+   *    legitimately leave this unset)
+   *  - `Tags` → `?? []` (filtered against `aws:cdk:path` and the rest of
+   *    the `aws:`-prefixed reserved space)
+   */
+  async readCurrentState(
+    physicalId: string,
+    _logicalId: string,
+    _resourceType: string
+  ): Promise<Record<string, unknown> | undefined> {
+    let workflow;
+    try {
+      const resp = await this.getClient().send(
+        new GetWorkflowCommand({ Name: physicalId, IncludeGraph: false })
+      );
+      workflow = resp.Workflow;
+    } catch (err) {
+      if (err instanceof EntityNotFoundException) return undefined;
+      throw err;
+    }
+    if (!workflow) return undefined;
+
+    const result: Record<string, unknown> = {
+      Name: workflow.Name ?? physicalId,
+      Description: workflow.Description ?? '',
+      DefaultRunProperties: workflow.DefaultRunProperties ?? {},
+    };
+
+    if (workflow.MaxConcurrentRuns !== undefined) {
+      result['MaxConcurrentRuns'] = workflow.MaxConcurrentRuns;
+    }
+
+    // Tags via separate GetTags(ResourceArn) call.
+    const arn = await this.buildWorkflowArn(physicalId);
+    let tags: Array<{ Key: string; Value: string }> = [];
+    try {
+      const tagResp = await this.getClient().send(new GetTagsCommand({ ResourceArn: arn }));
+      tags = normalizeAwsTagsToCfn(tagResp.Tags);
+    } catch (err) {
+      // Best-effort — `GetTags` failure should not abort the drift read.
+      this.logger.debug(
+        `GetTags failed for Glue Workflow ${physicalId}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+    result['Tags'] = tags;
+
+    return result;
+  }
+
+  async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {
+    const explicitName = input.knownPhysicalId ?? (input.properties['Name'] as string | undefined);
+
+    if (explicitName) {
+      try {
+        await this.getClient().send(new GetWorkflowCommand({ Name: explicitName }));
+        return { physicalId: explicitName, attributes: {} };
+      } catch (err) {
+        if (err instanceof EntityNotFoundException) return null;
+        throw err;
+      }
+    }
+
+    if (!input.cdkPath) return null;
+
+    let nextToken: string | undefined;
+    do {
+      const list = await this.getClient().send(
+        new ListWorkflowsCommand({ ...(nextToken && { NextToken: nextToken }) })
+      );
+      for (const name of list.Workflows ?? []) {
+        const arn = await this.buildWorkflowArn(name);
+        if (await this.tagsMatchCdkPath(arn, input.cdkPath)) {
+          return { physicalId: name, attributes: {} };
+        }
+      }
+      nextToken = list.NextToken;
+    } while (nextToken);
+    return null;
+  }
+
+  private async tagsMatchCdkPath(arn: string, cdkPath: string): Promise<boolean> {
+    try {
+      const resp = await this.getClient().send(new GetTagsCommand({ ResourceArn: arn }));
+      return resp.Tags?.[CDK_PATH_TAG] === cdkPath;
+    } catch (err) {
+      if (err instanceof EntityNotFoundException) return false;
+      throw err;
+    }
+  }
+
+  private async buildWorkflowArn(workflowName: string): Promise<string> {
+    const region = await this.getRegion();
+    const account = await this.getAccountId();
+    return `arn:aws:glue:${region}:${account}:workflow/${workflowName}`;
+  }
+
+  private async getRegion(): Promise<string> {
+    const region = await this.getClient().config.region();
+    return region || this.providerRegion || 'us-east-1';
+  }
+
+  private async getAccountId(): Promise<string> {
+    if (this.cachedAccountId) return this.cachedAccountId;
+    if (!this.stsClient) {
+      this.stsClient = new STSClient(this.providerRegion ? { region: this.providerRegion } : {});
+    }
+    const identity = await this.stsClient.send(new GetCallerIdentityCommand({}));
+    if (!identity.Account) {
+      throw new Error('Failed to resolve AWS account id from STS');
+    }
+    this.cachedAccountId = identity.Account;
+    return this.cachedAccountId;
+  }
+}
+
+// ─── AWS::Glue::SecurityConfiguration ──────────────────────────────
+//
+// SecurityConfiguration is **immutable on update** per AWS docs — the
+// only mutators are `CreateSecurityConfiguration` and
+// `DeleteSecurityConfiguration`. Any update path therefore surfaces
+// `ResourceUpdateNotSupportedError` so `cdkd drift --revert` reports a
+// clean "use cdkd deploy --replace" outcome instead of silently no-op'ing.
+//
+// `EncryptionConfiguration` carries three sub-configs:
+//   - `S3Encryption[]` — array of `{S3EncryptionMode, KmsKeyArn}`
+//   - `CloudWatchEncryption` — `{CloudWatchEncryptionMode, KmsKeyArn}`
+//   - `JobBookmarksEncryption` — `{JobBookmarksEncryptionMode, KmsKeyArn}`
+// AWS docs also surface `DataQualityEncryption` on the SDK shape but
+// CloudFormation does NOT model it (`AWS::Glue::SecurityConfiguration`
+// has only the three above), so we ignore it on read to avoid false
+// drift on the v3 baseline.
+
+/**
+ * SDK Provider for `AWS::Glue::SecurityConfiguration`.
+ *
+ * Immutable resource — `update()` always throws
+ * `ResourceUpdateNotSupportedError`. Replacement falls through to the
+ * deploy engine's CREATE→DELETE replacement path.
+ *
+ * Tags are NOT supported on `CreateSecurityConfiguration` (verified
+ * against the SDK shape — `CreateSecurityConfigurationRequest` has only
+ * `Name` + `EncryptionConfiguration`), so cdkd does not surface a `Tags`
+ * key in `readCurrentState` even with an always-emit placeholder.
+ */
+export class GlueSecurityConfigurationProvider implements ResourceProvider {
+  private client: GlueClient | undefined;
+  private readonly providerRegion = process.env['AWS_REGION'];
+  private logger = getLogger().child('GlueSecurityConfigurationProvider');
+
+  handledProperties = new Map<string, ReadonlySet<string>>([
+    ['AWS::Glue::SecurityConfiguration', new Set(['Name', 'EncryptionConfiguration'])],
+  ]);
+
+  private getClient(): GlueClient {
+    if (!this.client) {
+      this.client = new GlueClient(this.providerRegion ? { region: this.providerRegion } : {});
+    }
+    return this.client;
+  }
+
+  async create(
+    logicalId: string,
+    resourceType: string,
+    properties: Record<string, unknown>
+  ): Promise<ResourceCreateResult> {
+    this.logger.debug(`Creating Glue SecurityConfiguration ${logicalId}`);
+
+    const name = properties['Name'] as string | undefined;
+    if (!name) {
+      throw new ProvisioningError(
+        `Name is required for Glue SecurityConfiguration ${logicalId}`,
+        resourceType,
+        logicalId
+      );
+    }
+
+    const encryptionConfiguration = properties['EncryptionConfiguration'] as
+      | Record<string, unknown>
+      | undefined;
+    if (!encryptionConfiguration) {
+      throw new ProvisioningError(
+        `EncryptionConfiguration is required for Glue SecurityConfiguration ${logicalId}`,
+        resourceType,
+        logicalId
+      );
+    }
+
+    try {
+      await this.getClient().send(
+        new CreateSecurityConfigurationCommand({
+          Name: name,
+          EncryptionConfiguration: buildEncryptionConfiguration(encryptionConfiguration),
+        })
+      );
+
+      this.logger.debug(`Successfully created Glue SecurityConfiguration ${logicalId}: ${name}`);
+      return { physicalId: name, attributes: {} };
+    } catch (error) {
+      const cause = error instanceof Error ? error : undefined;
+      throw new ProvisioningError(
+        `Failed to create Glue SecurityConfiguration ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,
+        resourceType,
+        logicalId,
+        undefined,
+        cause
+      );
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await -- explicit-override-only intentionally has no AWS calls
+  async update(
+    logicalId: string,
+    _physicalId: string,
+    resourceType: string,
+    _properties: Record<string, unknown>,
+    _previousProperties: Record<string, unknown>
+  ): Promise<ResourceUpdateResult> {
+    // SecurityConfiguration is immutable per AWS — no `UpdateSecurity*`
+    // command exists. `cdkd drift --revert` and replacement-detection
+    // both end up here; the latter expects the CREATE→DELETE replacement
+    // layer to handle it. Surface the error so revert reports a clean
+    // "could not revert" outcome instead of silently succeeding.
+    throw new ResourceUpdateNotSupportedError(
+      resourceType,
+      logicalId,
+      'AWS::Glue::SecurityConfiguration is immutable; AWS provides no Update API. Use cdkd deploy --replace, or destroy + redeploy with the new EncryptionConfiguration.'
+    );
+  }
+
+  async delete(
+    logicalId: string,
+    physicalId: string,
+    resourceType: string,
+    _properties?: Record<string, unknown>,
+    context?: DeleteContext
+  ): Promise<void> {
+    this.logger.debug(`Deleting Glue SecurityConfiguration ${logicalId}: ${physicalId}`);
+
+    try {
+      await this.getClient().send(new DeleteSecurityConfigurationCommand({ Name: physicalId }));
+      this.logger.debug(`Successfully deleted Glue SecurityConfiguration ${logicalId}`);
+    } catch (error) {
+      if (error instanceof EntityNotFoundException) {
+        const clientRegion = await this.getClient().config.region();
+        assertRegionMatch(
+          clientRegion,
+          context?.expectedRegion,
+          resourceType,
+          logicalId,
+          physicalId
+        );
+        this.logger.debug(
+          `Glue SecurityConfiguration ${physicalId} does not exist, skipping deletion`
+        );
+        return;
+      }
+      const cause = error instanceof Error ? error : undefined;
+      throw new ProvisioningError(
+        `Failed to delete Glue SecurityConfiguration ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,
+        resourceType,
+        logicalId,
+        physicalId,
+        cause
+      );
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await -- explicit-override-only intentionally has no AWS calls
+  async getAttribute(
+    physicalId: string,
+    _resourceType: string,
+    attributeName: string
+  ): Promise<unknown> {
+    if (attributeName === 'Id' || attributeName === 'Ref' || attributeName === 'Name') {
+      return physicalId;
+    }
+    return undefined;
+  }
+
+  /**
+   * Read AWS-current SecurityConfiguration shape via
+   * `GetSecurityConfiguration`. Always emits the three CFn-modeled
+   * sub-configs (`S3Encryption: []`, `CloudWatchEncryption: {}`,
+   * `JobBookmarksEncryption: {}`) per PR #145 even when AWS reports
+   * nothing — closes the "console-side encryption enable on a previously
+   * default config" detection gap on the v3 baseline.
+   *
+   * `DataQualityEncryption` is silently dropped: the CFn schema for
+   * `AWS::Glue::SecurityConfiguration` does not model it, so surfacing it
+   * would fire false drift on every clean run for a key cdkd state can
+   * never carry.
+   */
+  async readCurrentState(
+    physicalId: string,
+    _logicalId: string,
+    _resourceType: string
+  ): Promise<Record<string, unknown> | undefined> {
+    let cfg;
+    try {
+      const resp = await this.getClient().send(
+        new GetSecurityConfigurationCommand({ Name: physicalId })
+      );
+      cfg = resp.SecurityConfiguration;
+    } catch (err) {
+      if (err instanceof EntityNotFoundException) return undefined;
+      throw err;
+    }
+    if (!cfg) return undefined;
+
+    return {
+      Name: cfg.Name ?? physicalId,
+      EncryptionConfiguration: mapEncryptionConfigurationToCfn(cfg.EncryptionConfiguration),
+    };
+  }
+
+  async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {
+    const explicitName = input.knownPhysicalId ?? (input.properties['Name'] as string | undefined);
+
+    if (explicitName) {
+      try {
+        await this.getClient().send(new GetSecurityConfigurationCommand({ Name: explicitName }));
+        return { physicalId: explicitName, attributes: {} };
+      } catch (err) {
+        if (err instanceof EntityNotFoundException) return null;
+        throw err;
+      }
+    }
+
+    // SecurityConfiguration does NOT support tags (no GetTags arn for
+    // this type), so we cannot do `aws:cdk:path` lookup. Fall back to
+    // walking `GetSecurityConfigurations` + matching the explicit name
+    // — but without an explicit name in the template, we have nothing
+    // to match on. Return null: import users must pass `--resource
+    // <logicalId>=<name>` for this type.
+    if (!explicitName) {
+      let nextToken: string | undefined;
+      do {
+        const list = await this.getClient().send(
+          new GetSecurityConfigurationsCommand({ ...(nextToken && { NextToken: nextToken }) })
+        );
+        // No tag-based match possible — the per-name loop is documented
+        // for completeness; without a known name we cannot disambiguate.
+        for (const _entry of list.SecurityConfigurations ?? []) {
+          // Intentional no-op: see docstring above.
+        }
+        nextToken = list.NextToken;
+      } while (nextToken);
+      return null;
+    }
+
+    return null;
+  }
+}
+
+// ─── Helpers (file-level) ──────────────────────────────────────────
+
+/**
+ * Normalize the CFn `Tags` shape (`Array<{Key,Value}>`) into the SDK's
+ * `TagsMap` (`Record<string,string>`) for `CreateWorkflow`. Returns
+ * `undefined` when no tags — the caller drops the key.
+ */
+function workflowTagsForCreate(tags: unknown): Record<string, string> | undefined {
+  if (!Array.isArray(tags) || tags.length === 0) return undefined;
+  const out: Record<string, string> = {};
+  for (const t of tags) {
+    const obj = t as Record<string, unknown>;
+    const k = typeof obj['Key'] === 'string' ? obj['Key'] : undefined;
+    const v = typeof obj['Value'] === 'string' ? obj['Value'] : '';
+    if (!k) continue;
+    out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Build the SDK `EncryptionConfiguration` from the CFn-shape input
+ * (`AWS::Glue::SecurityConfiguration.EncryptionConfiguration`). Each
+ * sub-config (`S3Encryption[]` / `CloudWatchEncryption` /
+ * `JobBookmarksEncryption`) field-renames are pure pass-through — the
+ * CFn property names match the SDK member names verbatim.
+ */
+function buildEncryptionConfiguration(input: Record<string, unknown>): EncryptionConfiguration {
+  const result: EncryptionConfiguration = {};
+
+  if (Array.isArray(input['S3Encryption'])) {
+    result.S3Encryption = input['S3Encryption'].map((entry) => {
+      const e = entry as Record<string, unknown>;
+      const item: S3Encryption = {};
+      if (typeof e['S3EncryptionMode'] === 'string') {
+        item.S3EncryptionMode = e['S3EncryptionMode'] as S3Encryption['S3EncryptionMode'];
+      }
+      if (typeof e['KmsKeyArn'] === 'string') {
+        item.KmsKeyArn = e['KmsKeyArn'];
+      }
+      return item;
+    });
+  }
+
+  if (input['CloudWatchEncryption'] !== undefined) {
+    const cw = input['CloudWatchEncryption'] as Record<string, unknown>;
+    const item: CloudWatchEncryption = {};
+    if (typeof cw['CloudWatchEncryptionMode'] === 'string') {
+      item.CloudWatchEncryptionMode = cw[
+        'CloudWatchEncryptionMode'
+      ] as CloudWatchEncryption['CloudWatchEncryptionMode'];
+    }
+    if (typeof cw['KmsKeyArn'] === 'string') {
+      item.KmsKeyArn = cw['KmsKeyArn'];
+    }
+    result.CloudWatchEncryption = item;
+  }
+
+  if (input['JobBookmarksEncryption'] !== undefined) {
+    const jb = input['JobBookmarksEncryption'] as Record<string, unknown>;
+    const item: JobBookmarksEncryption = {};
+    if (typeof jb['JobBookmarksEncryptionMode'] === 'string') {
+      item.JobBookmarksEncryptionMode = jb[
+        'JobBookmarksEncryptionMode'
+      ] as JobBookmarksEncryption['JobBookmarksEncryptionMode'];
+    }
+    if (typeof jb['KmsKeyArn'] === 'string') {
+      item.KmsKeyArn = jb['KmsKeyArn'];
+    }
+    result.JobBookmarksEncryption = item;
+  }
+
+  return result;
+}
+
+/**
+ * Reverse-map AWS's `EncryptionConfiguration` SDK shape into the CFn
+ * shape with always-emit placeholders (PR #145):
+ *   - `S3Encryption[]` → `?? []` (so console-side ADD is detectable)
+ *   - `CloudWatchEncryption` → `?? {}`
+ *   - `JobBookmarksEncryption` → `?? {}`
+ *   - `DataQualityEncryption` → silently dropped (not in CFn schema)
+ */
+function mapEncryptionConfigurationToCfn(
+  cfg: EncryptionConfiguration | undefined
+): Record<string, unknown> {
+  const c = cfg ?? {};
+  return {
+    S3Encryption: (c.S3Encryption ?? []).map((entry) => {
+      const out: Record<string, unknown> = {};
+      if (entry.S3EncryptionMode !== undefined) out['S3EncryptionMode'] = entry.S3EncryptionMode;
+      if (entry.KmsKeyArn !== undefined) out['KmsKeyArn'] = entry.KmsKeyArn;
+      return out;
+    }),
+    CloudWatchEncryption: c.CloudWatchEncryption
+      ? cleanCfnObject({
+          CloudWatchEncryptionMode: c.CloudWatchEncryption.CloudWatchEncryptionMode,
+          KmsKeyArn: c.CloudWatchEncryption.KmsKeyArn,
+        })
+      : {},
+    JobBookmarksEncryption: c.JobBookmarksEncryption
+      ? cleanCfnObject({
+          JobBookmarksEncryptionMode: c.JobBookmarksEncryption.JobBookmarksEncryptionMode,
+          KmsKeyArn: c.JobBookmarksEncryption.KmsKeyArn,
+        })
+      : {},
+  };
+}
+
+function cleanCfnObject(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
 }

--- a/src/provisioning/register-providers.ts
+++ b/src/provisioning/register-providers.ts
@@ -40,7 +40,11 @@ import { CognitoUserPoolProvider } from './providers/cognito-provider.js';
 import { ElastiCacheProvider } from './providers/elasticache-provider.js';
 import { ServiceDiscoveryProvider } from './providers/servicediscovery-provider.js';
 import { AppSyncProvider } from './providers/appsync-provider.js';
-import { GlueProvider } from './providers/glue-provider.js';
+import {
+  GlueProvider,
+  GlueWorkflowProvider,
+  GlueSecurityConfigurationProvider,
+} from './providers/glue-provider.js';
 import { KMSProvider } from './providers/kms-provider.js';
 import { KinesisStreamProvider } from './providers/kinesis-provider.js';
 import { EFSProvider } from './providers/efs-provider.js';
@@ -210,6 +214,8 @@ export function registerAllProviders(registry: ProviderRegistry): void {
   const glueProvider = new GlueProvider();
   registry.register('AWS::Glue::Database', glueProvider);
   registry.register('AWS::Glue::Table', glueProvider);
+  registry.register('AWS::Glue::Workflow', new GlueWorkflowProvider());
+  registry.register('AWS::Glue::SecurityConfiguration', new GlueSecurityConfigurationProvider());
 
   // KMS
   const kmsProvider = new KMSProvider();

--- a/tests/unit/provisioning/glue-security-configuration-roundtrip.test.ts
+++ b/tests/unit/provisioning/glue-security-configuration-roundtrip.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CreateSecurityConfigurationCommand,
+  DeleteSecurityConfigurationCommand,
+  GetSecurityConfigurationCommand,
+} from '@aws-sdk/client-glue';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-glue', async () => {
+  const actual =
+    await vi.importActual<typeof import('@aws-sdk/client-glue')>('@aws-sdk/client-glue');
+  return {
+    ...actual,
+    GlueClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { GlueSecurityConfigurationProvider } from '../../../src/provisioning/providers/glue-provider.js';
+import { ResourceUpdateNotSupportedError } from '../../../src/utils/error-handler.js';
+
+describe('GlueSecurityConfigurationProvider', () => {
+  let provider: GlueSecurityConfigurationProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new GlueSecurityConfigurationProvider();
+  });
+
+  it('create() sends CreateSecurityConfiguration with full EncryptionConfiguration', async () => {
+    mockSend.mockResolvedValueOnce({});
+    const result = await provider.create('L', 'AWS::Glue::SecurityConfiguration', {
+      Name: 'my-sec',
+      EncryptionConfiguration: {
+        S3Encryption: [
+          { S3EncryptionMode: 'SSE-KMS', KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/abc' },
+        ],
+        CloudWatchEncryption: {
+          CloudWatchEncryptionMode: 'SSE-KMS',
+          KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/cw',
+        },
+        JobBookmarksEncryption: {
+          JobBookmarksEncryptionMode: 'CSE-KMS',
+          KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/jb',
+        },
+      },
+    });
+
+    expect(result).toEqual({ physicalId: 'my-sec', attributes: {} });
+    const call = mockSend.mock.calls.find(
+      (c) => c[0] instanceof CreateSecurityConfigurationCommand
+    );
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      Name: 'my-sec',
+      EncryptionConfiguration: {
+        S3Encryption: [
+          { S3EncryptionMode: 'SSE-KMS', KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/abc' },
+        ],
+        CloudWatchEncryption: {
+          CloudWatchEncryptionMode: 'SSE-KMS',
+          KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/cw',
+        },
+        JobBookmarksEncryption: {
+          JobBookmarksEncryptionMode: 'CSE-KMS',
+          KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/jb',
+        },
+      },
+    });
+  });
+
+  it('create() requires Name', async () => {
+    await expect(
+      provider.create('L', 'AWS::Glue::SecurityConfiguration', {
+        EncryptionConfiguration: {},
+      })
+    ).rejects.toThrow(/Name is required/);
+  });
+
+  it('create() requires EncryptionConfiguration', async () => {
+    await expect(
+      provider.create('L', 'AWS::Glue::SecurityConfiguration', { Name: 'my-sec' })
+    ).rejects.toThrow(/EncryptionConfiguration is required/);
+  });
+
+  it('update() always rejects with ResourceUpdateNotSupportedError (immutable resource)', async () => {
+    // SecurityConfiguration has no AWS UpdateApi — surfacing the error
+    // makes `cdkd drift --revert` report a clean "could not revert"
+    // outcome instead of silently no-op'ing.
+    await expect(
+      provider.update(
+        'L',
+        'my-sec',
+        'AWS::Glue::SecurityConfiguration',
+        { Name: 'my-sec', EncryptionConfiguration: {} },
+        {}
+      )
+    ).rejects.toThrow(ResourceUpdateNotSupportedError);
+  });
+
+  it('update() rejection message names the resource type', async () => {
+    let err: ResourceUpdateNotSupportedError | undefined;
+    try {
+      await provider.update(
+        'L',
+        'my-sec',
+        'AWS::Glue::SecurityConfiguration',
+        { Name: 'my-sec' },
+        {}
+      );
+    } catch (e) {
+      err = e as ResourceUpdateNotSupportedError;
+    }
+    expect(err).toBeInstanceOf(ResourceUpdateNotSupportedError);
+    expect(err!.resourceType).toBe('AWS::Glue::SecurityConfiguration');
+    expect(err!.logicalId).toBe('L');
+  });
+
+  it('delete() calls DeleteSecurityConfiguration', async () => {
+    mockSend.mockResolvedValueOnce({});
+    await provider.delete('L', 'my-sec', 'AWS::Glue::SecurityConfiguration', undefined, {
+      expectedRegion: 'us-east-1',
+    });
+
+    const call = mockSend.mock.calls.find(
+      (c) => c[0] instanceof DeleteSecurityConfigurationCommand
+    );
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({ Name: 'my-sec' });
+  });
+
+  it('delete() treats EntityNotFoundException as idempotent when region matches', async () => {
+    const { EntityNotFoundException } = await import('@aws-sdk/client-glue');
+    mockSend.mockRejectedValueOnce(
+      new EntityNotFoundException({ message: 'not found', $metadata: {} })
+    );
+
+    await expect(
+      provider.delete('L', 'my-sec', 'AWS::Glue::SecurityConfiguration', undefined, {
+        expectedRegion: 'us-east-1',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('getAttribute() returns physicalId for Name / Id / Ref', async () => {
+    expect(
+      await provider.getAttribute('my-sec', 'AWS::Glue::SecurityConfiguration', 'Name')
+    ).toBe('my-sec');
+    expect(
+      await provider.getAttribute('my-sec', 'AWS::Glue::SecurityConfiguration', 'Id')
+    ).toBe('my-sec');
+    expect(
+      await provider.getAttribute('my-sec', 'AWS::Glue::SecurityConfiguration', 'Ref')
+    ).toBe('my-sec');
+  });
+
+  it('readCurrentState() emits PR #145 placeholders for empty EncryptionConfiguration', async () => {
+    // GetSecurityConfiguration returns no encryption sub-configs —
+    // placeholders must surface so the v3 baseline catches console-side
+    // encryption enables on a previously default config.
+    mockSend.mockResolvedValueOnce({
+      SecurityConfiguration: { Name: 'my-sec', EncryptionConfiguration: {} },
+    });
+
+    const result = await provider.readCurrentState(
+      'my-sec',
+      'L',
+      'AWS::Glue::SecurityConfiguration'
+    );
+    expect(result).toEqual({
+      Name: 'my-sec',
+      EncryptionConfiguration: {
+        S3Encryption: [],
+        CloudWatchEncryption: {},
+        JobBookmarksEncryption: {},
+      },
+    });
+  });
+
+  it('readCurrentState() reverse-maps full EncryptionConfiguration shape', async () => {
+    mockSend.mockResolvedValueOnce({
+      SecurityConfiguration: {
+        Name: 'my-sec',
+        EncryptionConfiguration: {
+          S3Encryption: [
+            { S3EncryptionMode: 'SSE-KMS', KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/abc' },
+          ],
+          CloudWatchEncryption: {
+            CloudWatchEncryptionMode: 'SSE-KMS',
+            KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/cw',
+          },
+          JobBookmarksEncryption: {
+            JobBookmarksEncryptionMode: 'CSE-KMS',
+            KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/jb',
+          },
+        },
+      },
+    });
+
+    const result = await provider.readCurrentState(
+      'my-sec',
+      'L',
+      'AWS::Glue::SecurityConfiguration'
+    );
+    expect(result).toEqual({
+      Name: 'my-sec',
+      EncryptionConfiguration: {
+        S3Encryption: [
+          { S3EncryptionMode: 'SSE-KMS', KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/abc' },
+        ],
+        CloudWatchEncryption: {
+          CloudWatchEncryptionMode: 'SSE-KMS',
+          KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/cw',
+        },
+        JobBookmarksEncryption: {
+          JobBookmarksEncryptionMode: 'CSE-KMS',
+          KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/jb',
+        },
+      },
+    });
+  });
+
+  it('readCurrentState() drops AWS-only DataQualityEncryption (not modeled in CFn)', async () => {
+    // SDK returns DataQualityEncryption but `AWS::Glue::SecurityConfiguration`
+    // CFn schema does NOT model it. Surfacing it would fire false drift on
+    // every clean run.
+    mockSend.mockResolvedValueOnce({
+      SecurityConfiguration: {
+        Name: 'my-sec',
+        EncryptionConfiguration: {
+          DataQualityEncryption: {
+            DataQualityEncryptionMode: 'SSE-KMS',
+            KmsKeyArn: 'arn:aws:kms:us-east-1:1:key/dq',
+          },
+        },
+      },
+    });
+
+    const result = await provider.readCurrentState(
+      'my-sec',
+      'L',
+      'AWS::Glue::SecurityConfiguration'
+    );
+    expect((result as Record<string, unknown>)['EncryptionConfiguration']).toEqual({
+      S3Encryption: [],
+      CloudWatchEncryption: {},
+      JobBookmarksEncryption: {},
+    });
+  });
+
+  it('readCurrentState() returns undefined when SecurityConfiguration does not exist', async () => {
+    const { EntityNotFoundException } = await import('@aws-sdk/client-glue');
+    mockSend.mockRejectedValueOnce(
+      new EntityNotFoundException({ message: 'not found', $metadata: {} })
+    );
+
+    const result = await provider.readCurrentState(
+      'missing',
+      'L',
+      'AWS::Glue::SecurityConfiguration'
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('handledProperties declares Name + EncryptionConfiguration', () => {
+    const set = provider.handledProperties.get('AWS::Glue::SecurityConfiguration');
+    expect(set).toBeDefined();
+    expect([...(set ?? new Set())].sort()).toEqual(['EncryptionConfiguration', 'Name']);
+  });
+});

--- a/tests/unit/provisioning/glue-workflow-roundtrip.test.ts
+++ b/tests/unit/provisioning/glue-workflow-roundtrip.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CreateWorkflowCommand,
+  UpdateWorkflowCommand,
+  DeleteWorkflowCommand,
+  GetWorkflowCommand,
+  GetTagsCommand,
+} from '@aws-sdk/client-glue';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-glue', async () => {
+  const actual =
+    await vi.importActual<typeof import('@aws-sdk/client-glue')>('@aws-sdk/client-glue');
+  return {
+    ...actual,
+    GlueClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('@aws-sdk/client-sts', () => {
+  return {
+    STSClient: vi.fn().mockImplementation(() => ({
+      send: vi.fn().mockResolvedValue({ Account: '123456789012' }),
+    })),
+    GetCallerIdentityCommand: vi.fn(),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { GlueWorkflowProvider } from '../../../src/provisioning/providers/glue-provider.js';
+
+describe('GlueWorkflowProvider', () => {
+  let provider: GlueWorkflowProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new GlueWorkflowProvider();
+  });
+
+  it('create() builds CreateWorkflow with every templated field', async () => {
+    mockSend.mockResolvedValueOnce({});
+    const result = await provider.create('L', 'AWS::Glue::Workflow', {
+      Name: 'my-wf',
+      Description: 'desc',
+      DefaultRunProperties: { foo: 'bar' },
+      MaxConcurrentRuns: 3,
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    });
+
+    expect(result).toEqual({ physicalId: 'my-wf', attributes: {} });
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof CreateWorkflowCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      Name: 'my-wf',
+      Description: 'desc',
+      DefaultRunProperties: { foo: 'bar' },
+      MaxConcurrentRuns: 3,
+      Tags: { env: 'prod' },
+    });
+  });
+
+  it('create() omits optional fields when not provided', async () => {
+    mockSend.mockResolvedValueOnce({});
+    await provider.create('L', 'AWS::Glue::Workflow', { Name: 'my-wf' });
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof CreateWorkflowCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({ Name: 'my-wf' });
+  });
+
+  it('create() requires Name', async () => {
+    await expect(
+      provider.create('L', 'AWS::Glue::Workflow', { Description: 'desc' })
+    ).rejects.toThrow(/Name is required/);
+  });
+
+  it('update() forwards full UpdateWorkflow input including empty placeholders (truthy-gate guard)', async () => {
+    // `cdkd drift --revert` round-trip: empty-string Description and
+    // empty DefaultRunProperties placeholder must reach AWS to clear
+    // console-side ADDs (per feedback_update_optional_field_undefined_check.md).
+    mockSend.mockResolvedValueOnce({});
+    await provider.update(
+      'L',
+      'my-wf',
+      'AWS::Glue::Workflow',
+      { Name: 'my-wf', Description: '', DefaultRunProperties: {}, MaxConcurrentRuns: 5 },
+      {}
+    );
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof UpdateWorkflowCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      Name: 'my-wf',
+      Description: '',
+      DefaultRunProperties: {},
+      MaxConcurrentRuns: 5,
+    });
+  });
+
+  it('delete() calls DeleteWorkflow', async () => {
+    mockSend.mockResolvedValueOnce({});
+    await provider.delete('L', 'my-wf', 'AWS::Glue::Workflow', undefined, {
+      expectedRegion: 'us-east-1',
+    });
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof DeleteWorkflowCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({ Name: 'my-wf' });
+  });
+
+  it('delete() treats EntityNotFoundException as idempotent when region matches', async () => {
+    const { EntityNotFoundException } = await import('@aws-sdk/client-glue');
+    mockSend.mockRejectedValueOnce(
+      new EntityNotFoundException({ message: 'not found', $metadata: {} })
+    );
+
+    await expect(
+      provider.delete('L', 'my-wf', 'AWS::Glue::Workflow', undefined, {
+        expectedRegion: 'us-east-1',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('getAttribute() returns physicalId for Name / Id / Ref', async () => {
+    expect(await provider.getAttribute('my-wf', 'AWS::Glue::Workflow', 'Name')).toBe('my-wf');
+    expect(await provider.getAttribute('my-wf', 'AWS::Glue::Workflow', 'Id')).toBe('my-wf');
+    expect(await provider.getAttribute('my-wf', 'AWS::Glue::Workflow', 'Ref')).toBe('my-wf');
+    expect(
+      await provider.getAttribute('my-wf', 'AWS::Glue::Workflow', 'Unknown')
+    ).toBeUndefined();
+  });
+
+  it('readCurrentState() emits PR #145 always-emit placeholders for Description / DefaultRunProperties / Tags', async () => {
+    // GetWorkflow returns minimal data (no Description / DefaultRunProperties /
+    // MaxConcurrentRuns / tags) — placeholders must surface so the v3
+    // observedProperties baseline catches console-side ADDs on a previously
+    // default workflow.
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetWorkflowCommand) {
+        return Promise.resolve({ Workflow: { Name: 'my-wf' } });
+      }
+      if (cmd instanceof GetTagsCommand) {
+        return Promise.resolve({ Tags: {} });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await provider.readCurrentState('my-wf', 'L', 'AWS::Glue::Workflow');
+    expect(result).toEqual({
+      Name: 'my-wf',
+      Description: '',
+      DefaultRunProperties: {},
+      Tags: [],
+    });
+    // MaxConcurrentRuns intentionally absent — no AWS-side default.
+    expect(result).not.toHaveProperty('MaxConcurrentRuns');
+  });
+
+  it('readCurrentState() surfaces AWS values when set', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetWorkflowCommand) {
+        return Promise.resolve({
+          Workflow: {
+            Name: 'my-wf',
+            Description: 'desc',
+            DefaultRunProperties: { foo: 'bar' },
+            MaxConcurrentRuns: 3,
+          },
+        });
+      }
+      if (cmd instanceof GetTagsCommand) {
+        return Promise.resolve({
+          Tags: { env: 'prod', 'aws:cdk:path': 'MyStack/MyWf' },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await provider.readCurrentState('my-wf', 'L', 'AWS::Glue::Workflow');
+    expect(result).toEqual({
+      Name: 'my-wf',
+      Description: 'desc',
+      DefaultRunProperties: { foo: 'bar' },
+      MaxConcurrentRuns: 3,
+      // aws:cdk:path filtered out by normalizeAwsTagsToCfn
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    });
+  });
+
+  it('readCurrentState() returns undefined when workflow does not exist', async () => {
+    const { EntityNotFoundException } = await import('@aws-sdk/client-glue');
+    mockSend.mockRejectedValueOnce(
+      new EntityNotFoundException({ message: 'not found', $metadata: {} })
+    );
+
+    const result = await provider.readCurrentState('missing', 'L', 'AWS::Glue::Workflow');
+    expect(result).toBeUndefined();
+  });
+
+  it('readCurrentState() falls back to empty Tags array if GetTags fails', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetWorkflowCommand) {
+        return Promise.resolve({ Workflow: { Name: 'my-wf' } });
+      }
+      if (cmd instanceof GetTagsCommand) {
+        return Promise.reject(new Error('AccessDenied'));
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await provider.readCurrentState('my-wf', 'L', 'AWS::Glue::Workflow');
+    expect(result).toEqual({
+      Name: 'my-wf',
+      Description: '',
+      DefaultRunProperties: {},
+      Tags: [],
+    });
+  });
+
+  it('handledProperties declares the full mutable surface', () => {
+    const set = provider.handledProperties.get('AWS::Glue::Workflow');
+    expect(set).toBeDefined();
+    expect([...(set ?? new Set())].sort()).toEqual([
+      'DefaultRunProperties',
+      'Description',
+      'MaxConcurrentRuns',
+      'Name',
+      'Tags',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds dedicated SDK providers for `AWS::Glue::Workflow` and `AWS::Glue::SecurityConfiguration` (currently CC API fallback, per `feedback_dedicated_provider_over_special_case.md`).

## AWS::Glue::Workflow

- Mutable properties (Description / DefaultRunProperties / MaxConcurrentRuns) → `UpdateWorkflowCommand`
- Tags via `GetTagsCommand(ResourceArn)` with always-emit `[]` placeholder
- readCurrentState surfaces all user-controllable fields per PR #145 always-emit pattern

## AWS::Glue::SecurityConfiguration

- IMMUTABLE — `update()` throws `ResourceUpdateNotSupportedError` (AWS has no `UpdateSecurity*` API)
- `EncryptionConfiguration` with 3 sub-configs (`S3Encryption[]` / `CloudWatchEncryption` / `JobBookmarksEncryption`) reverse-mapped; arrays always-emit `[]`
- Replacement detection layer covers property changes

## Files

- [src/provisioning/providers/glue-provider.ts](src/provisioning/providers/glue-provider.ts) — `GlueWorkflowProvider` + `GlueSecurityConfigurationProvider` classes appended
- [src/provisioning/register-providers.ts](src/provisioning/register-providers.ts) — register both
- [tests/unit/provisioning/glue-workflow-roundtrip.test.ts](tests/unit/provisioning/glue-workflow-roundtrip.test.ts) — new
- [tests/unit/provisioning/glue-security-configuration-roundtrip.test.ts](tests/unit/provisioning/glue-security-configuration-roundtrip.test.ts) — new

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` — clean
- [x] `npx vitest --run` — 220 files / 2230 tests pass
- [x] CLAUDE.md bullet — deferred to a unified bullet covering all v2 PRs
- [ ] Will need rebase against the parallel PR (Glue Job/Crawler/Connection/Trigger) — both touch `glue-provider.ts` and `register-providers.ts`
