### PR TITLE
test(glue,s3): add deferred round-trip tests for #214 + #215

### DIFF
--- a/tests/unit/provisioning/glue-connection-roundtrip.test.ts
+++ b/tests/unit/provisioning/glue-connection-roundtrip.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CreateConnectionCommand,
+  UpdateConnectionCommand,
+  DeleteConnectionCommand,
+  GetConnectionCommand,
+} from '@aws-sdk/client-glue';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-glue', async () => {
+  const actual =
+    await vi.importActual<typeof import('@aws-sdk/client-glue')>('@aws-sdk/client-glue');
+  return {
+    ...actual,
+    GlueClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { GlueConnectionProvider } from '../../../src/provisioning/providers/glue-provider.js';
+
+describe('GlueConnectionProvider', () => {
+  let provider: GlueConnectionProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new GlueConnectionProvider();
+    mockSend.mockResolvedValue({});
+  });
+
+  it('create() builds CreateConnection with full ConnectionInput surface', async () => {
+    const result = await provider.create('L', 'AWS::Glue::Connection', {
+      ConnectionInput: {
+        Name: 'my-connection',
+        ConnectionType: 'JDBC',
+        Description: 'My JDBC connection',
+        ConnectionProperties: {
+          JDBC_CONNECTION_URL: 'jdbc:mysql://my-rds.example.com:3306/mydb',
+          USERNAME: 'admin',
+          PASSWORD: 'secret',
+        },
+        MatchCriteria: ['MyMatchCriteria'],
+        PhysicalConnectionRequirements: {
+          AvailabilityZone: 'us-east-1a',
+          SecurityGroupIdList: ['sg-12345'],
+          SubnetId: 'subnet-12345',
+        },
+      },
+      CatalogId: '123456789012',
+    });
+
+    expect(result).toEqual({ physicalId: 'my-connection', attributes: {} });
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof CreateConnectionCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      CatalogId: '123456789012',
+      ConnectionInput: {
+        Name: 'my-connection',
+        ConnectionType: 'JDBC',
+        Description: 'My JDBC connection',
+        ConnectionProperties: {
+          JDBC_CONNECTION_URL: 'jdbc:mysql://my-rds.example.com:3306/mydb',
+          USERNAME: 'admin',
+          PASSWORD: 'secret',
+        },
+        MatchCriteria: ['MyMatchCriteria'],
+        PhysicalConnectionRequirements: {
+          AvailabilityZone: 'us-east-1a',
+          SecurityGroupIdList: ['sg-12345'],
+          SubnetId: 'subnet-12345',
+        },
+      },
+    });
+  });
+
+  it('create() omits CatalogId when not provided and falls back to logicalId for Name when ConnectionInput.Name absent', async () => {
+    await provider.create('L', 'AWS::Glue::Connection', {
+      ConnectionInput: {
+        ConnectionType: 'NETWORK',
+        ConnectionProperties: {},
+      },
+    });
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof CreateConnectionCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      ConnectionInput: {
+        Name: 'L',
+        ConnectionType: 'NETWORK',
+        ConnectionProperties: {},
+      },
+    });
+  });
+
+  it('create() fails when ConnectionInput is missing', async () => {
+    await expect(
+      provider.create('L', 'AWS::Glue::Connection', { CatalogId: '123' })
+    ).rejects.toThrow(/ConnectionInput is required/);
+  });
+
+  it('update() forwards UpdateConnection with name + ConnectionInput', async () => {
+    await provider.update(
+      'L',
+      'my-connection',
+      'AWS::Glue::Connection',
+      {
+        ConnectionInput: {
+          Name: 'my-connection',
+          ConnectionType: 'JDBC',
+          ConnectionProperties: { JDBC_CONNECTION_URL: 'jdbc:mysql://new-host/db' },
+          Description: 'updated',
+        },
+      },
+      {}
+    );
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof UpdateConnectionCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      Name: 'my-connection',
+      ConnectionInput: {
+        Name: 'my-connection',
+        ConnectionType: 'JDBC',
+        ConnectionProperties: { JDBC_CONNECTION_URL: 'jdbc:mysql://new-host/db' },
+        Description: 'updated',
+      },
+    });
+  });
+
+  it('update() fails when ConnectionInput is missing on update', async () => {
+    await expect(
+      provider.update(
+        'L',
+        'my-connection',
+        'AWS::Glue::Connection',
+        { CatalogId: '123' },
+        {}
+      )
+    ).rejects.toThrow(/ConnectionInput is required/);
+  });
+
+  it('delete() calls DeleteConnection with optional CatalogId', async () => {
+    await provider.delete(
+      'L',
+      'my-connection',
+      'AWS::Glue::Connection',
+      { CatalogId: '123456789012' },
+      { expectedRegion: 'us-east-1' }
+    );
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof DeleteConnectionCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      ConnectionName: 'my-connection',
+      CatalogId: '123456789012',
+    });
+  });
+
+  it('delete() omits CatalogId when not in properties', async () => {
+    await provider.delete('L', 'my-connection', 'AWS::Glue::Connection', undefined, {
+      expectedRegion: 'us-east-1',
+    });
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof DeleteConnectionCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({ ConnectionName: 'my-connection' });
+  });
+
+  it('delete() treats EntityNotFoundException as idempotent when region matches', async () => {
+    const { EntityNotFoundException } = await import('@aws-sdk/client-glue');
+    mockSend.mockRejectedValueOnce(
+      new EntityNotFoundException({ message: 'not found', $metadata: {} })
+    );
+
+    await expect(
+      provider.delete('L', 'my-connection', 'AWS::Glue::Connection', undefined, {
+        expectedRegion: 'us-east-1',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('getAttribute() returns physicalId for Id / Ref / Name', async () => {
+    expect(await provider.getAttribute('my-connection', 'AWS::Glue::Connection', 'Id')).toBe(
+      'my-connection'
+    );
+    expect(await provider.getAttribute('my-connection', 'AWS::Glue::Connection', 'Ref')).toBe(
+      'my-connection'
+    );
+    expect(await provider.getAttribute('my-connection', 'AWS::Glue::Connection', 'Name')).toBe(
+      'my-connection'
+    );
+    expect(
+      await provider.getAttribute('my-connection', 'AWS::Glue::Connection', 'Unknown')
+    ).toBeUndefined();
+  });
+
+  it('readCurrentState() emits PR #145 always-emit placeholders inside ConnectionInput on a default Connection', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetConnectionCommand) {
+        return Promise.resolve({ Connection: { Name: 'my-connection' } });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await provider.readCurrentState('my-connection', 'L', 'AWS::Glue::Connection');
+    expect(result).toEqual({
+      ConnectionInput: {
+        Name: 'my-connection',
+        ConnectionType: '',
+        Description: '',
+        MatchCriteria: [],
+        ConnectionProperties: {},
+        SparkProperties: {},
+        AthenaProperties: {},
+        PythonProperties: {},
+        PhysicalConnectionRequirements: {},
+      },
+    });
+  });
+
+  it('readCurrentState() surfaces AWS values when Connection is fully configured', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetConnectionCommand) {
+        return Promise.resolve({
+          Connection: {
+            Name: 'my-connection',
+            ConnectionType: 'JDBC',
+            Description: 'desc',
+            MatchCriteria: ['critA'],
+            ConnectionProperties: { JDBC_CONNECTION_URL: 'jdbc:mysql://host/db' },
+            PhysicalConnectionRequirements: {
+              AvailabilityZone: 'us-east-1a',
+              SecurityGroupIdList: ['sg-12345'],
+              SubnetId: 'subnet-12345',
+            },
+          },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await provider.readCurrentState('my-connection', 'L', 'AWS::Glue::Connection');
+    expect(result).toEqual({
+      ConnectionInput: {
+        Name: 'my-connection',
+        ConnectionType: 'JDBC',
+        Description: 'desc',
+        MatchCriteria: ['critA'],
+        ConnectionProperties: { JDBC_CONNECTION_URL: 'jdbc:mysql://host/db' },
+        SparkProperties: {},
+        AthenaProperties: {},
+        PythonProperties: {},
+        PhysicalConnectionRequirements: {
+          AvailabilityZone: 'us-east-1a',
+          SecurityGroupIdList: ['sg-12345'],
+          SubnetId: 'subnet-12345',
+        },
+      },
+    });
+  });
+
+  it('readCurrentState() returns undefined when connection does not exist', async () => {
+    const { EntityNotFoundException } = await import('@aws-sdk/client-glue');
+    mockSend.mockRejectedValueOnce(
+      new EntityNotFoundException({ message: 'not found', $metadata: {} })
+    );
+
+    const result = await provider.readCurrentState('missing', 'L', 'AWS::Glue::Connection');
+    expect(result).toBeUndefined();
+  });
+
+  it('readCurrentState() forwards CatalogId from properties to GetConnection input', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetConnectionCommand) {
+        return Promise.resolve({
+          Connection: { Name: 'my-connection', ConnectionType: 'JDBC' },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    await provider.readCurrentState('my-connection', 'L', 'AWS::Glue::Connection', {
+      CatalogId: '123456789012',
+    });
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof GetConnectionCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      Name: 'my-connection',
+      CatalogId: '123456789012',
+    });
+  });
+
+  it('handledProperties declares the documented surface', () => {
+    const set = provider.handledProperties.get('AWS::Glue::Connection');
+    expect(set).toBeDefined();
+    expect([...(set ?? new Set())].sort()).toEqual(['CatalogId', 'ConnectionInput']);
+  });
+});

--- a/tests/unit/provisioning/glue-crawler-roundtrip.test.ts
+++ b/tests/unit/provisioning/glue-crawler-roundtrip.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CreateCrawlerCommand,
+  UpdateCrawlerCommand,
+  DeleteCrawlerCommand,
+  GetCrawlerCommand,
+  GetTagsCommand,
+  StartCrawlerScheduleCommand,
+  StopCrawlerScheduleCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from '@aws-sdk/client-glue';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-glue', async () => {
+  const actual =
+    await vi.importActual<typeof import('@aws-sdk/client-glue')>('@aws-sdk/client-glue');
+  return {
+    ...actual,
+    GlueClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('@aws-sdk/client-sts', () => {
+  return {
+    STSClient: vi.fn().mockImplementation(() => ({
+      send: vi.fn().mockResolvedValue({ Account: '123456789012' }),
+    })),
+    GetCallerIdentityCommand: vi.fn(),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { GlueCrawlerProvider } from '../../../src/provisioning/providers/glue-provider.js';
+
+describe('GlueCrawlerProvider', () => {
+  let provider: GlueCrawlerProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new GlueCrawlerProvider();
+    mockSend.mockResolvedValue({});
+  });
+
+  it('create() builds CreateCrawler with required Role / Targets and full optional surface', async () => {
+    const result = await provider.create('L', 'AWS::Glue::Crawler', {
+      Name: 'my-crawler',
+      Role: 'arn:aws:iam::123456789012:role/GlueCrawlerRole',
+      Targets: {
+        S3Targets: [{ Path: 's3://my-bucket/data' }],
+      },
+      DatabaseName: 'my-db',
+      Description: 'My crawler',
+      Schedule: { ScheduleExpression: 'cron(0 12 * * ? *)' },
+      Classifiers: ['my-classifier'],
+      TablePrefix: 'tbl_',
+      Configuration: '{"Version":1.0}',
+      CrawlerSecurityConfiguration: 'my-sec-config',
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    });
+
+    expect(result).toEqual({ physicalId: 'my-crawler', attributes: {} });
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof CreateCrawlerCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      Name: 'my-crawler',
+      Role: 'arn:aws:iam::123456789012:role/GlueCrawlerRole',
+      Targets: { S3Targets: [{ Path: 's3://my-bucket/data' }] },
+      DatabaseName: 'my-db',
+      Description: 'My crawler',
+      // CFn structured Schedule unwrapped to bare cron string for the SDK
+      Schedule: 'cron(0 12 * * ? *)',
+      Classifiers: ['my-classifier'],
+      TablePrefix: 'tbl_',
+      Configuration: '{"Version":1.0}',
+      CrawlerSecurityConfiguration: 'my-sec-config',
+      Tags: { env: 'prod' },
+    });
+  });
+
+  it('create() accepts a bare-string Schedule for forward-compat', async () => {
+    await provider.create('L', 'AWS::Glue::Crawler', {
+      Name: 'my-crawler',
+      Role: 'arn:aws:iam::123456789012:role/GlueCrawlerRole',
+      Targets: { S3Targets: [{ Path: 's3://my-bucket/' }] },
+      Schedule: 'cron(0 0 * * ? *)',
+    });
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof CreateCrawlerCommand);
+    expect(call![0].input).toMatchObject({ Schedule: 'cron(0 0 * * ? *)' });
+  });
+
+  it('create() fails when Role is missing', async () => {
+    await expect(
+      provider.create('L', 'AWS::Glue::Crawler', {
+        Name: 'my-crawler',
+        Targets: { S3Targets: [] },
+      })
+    ).rejects.toThrow(/Role is required/);
+  });
+
+  it('create() fails when Targets is missing', async () => {
+    await expect(
+      provider.create('L', 'AWS::Glue::Crawler', {
+        Name: 'my-crawler',
+        Role: 'arn:aws:iam::123456789012:role/GlueCrawlerRole',
+      })
+    ).rejects.toThrow(/Targets is required/);
+  });
+
+  it('update() forwards UpdateCrawler with name + new Role / Targets / common fields', async () => {
+    await provider.update(
+      'L',
+      'my-crawler',
+      'AWS::Glue::Crawler',
+      {
+        Role: 'arn:aws:iam::123456789012:role/GlueCrawlerRole-v2',
+        Targets: { S3Targets: [{ Path: 's3://my-bucket-v2/' }] },
+        DatabaseName: 'my-db-v2',
+        Description: 'updated',
+        Schedule: { ScheduleExpression: 'cron(0 6 * * ? *)' },
+      },
+      {}
+    );
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof UpdateCrawlerCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      Name: 'my-crawler',
+      Role: 'arn:aws:iam::123456789012:role/GlueCrawlerRole-v2',
+      Targets: { S3Targets: [{ Path: 's3://my-bucket-v2/' }] },
+      DatabaseName: 'my-db-v2',
+      Description: 'updated',
+      Schedule: 'cron(0 6 * * ? *)',
+    });
+  });
+
+  it('update() reconciles Tag diff via TagResource + UntagResource when tags change', async () => {
+    await provider.update(
+      'L',
+      'my-crawler',
+      'AWS::Glue::Crawler',
+      {
+        Tags: [{ Key: 'env', Value: 'prod' }],
+      },
+      {
+        Tags: [{ Key: 'env', Value: 'dev' }, { Key: 'old', Value: 'remove-me' }],
+      }
+    );
+
+    const tagAdd = mockSend.mock.calls.find((c) => c[0] instanceof TagResourceCommand);
+    const tagRemove = mockSend.mock.calls.find((c) => c[0] instanceof UntagResourceCommand);
+    expect(tagAdd).toBeDefined();
+    expect(tagRemove).toBeDefined();
+    expect(tagAdd![0].input).toEqual({
+      ResourceArn: 'arn:aws:glue:us-east-1:123456789012:crawler/my-crawler',
+      TagsToAdd: { env: 'prod' },
+    });
+    expect(tagRemove![0].input).toEqual({
+      ResourceArn: 'arn:aws:glue:us-east-1:123456789012:crawler/my-crawler',
+      TagsToRemove: ['old'],
+    });
+  });
+
+  it('update() does not call TagResource / UntagResource when tags are unchanged', async () => {
+    const tags = [{ Key: 'env', Value: 'prod' }];
+    await provider.update(
+      'L',
+      'my-crawler',
+      'AWS::Glue::Crawler',
+      { Tags: tags },
+      { Tags: tags }
+    );
+
+    expect(mockSend.mock.calls.find((c) => c[0] instanceof TagResourceCommand)).toBeUndefined();
+    expect(mockSend.mock.calls.find((c) => c[0] instanceof UntagResourceCommand)).toBeUndefined();
+  });
+
+  it('delete() calls DeleteCrawler', async () => {
+    await provider.delete('L', 'my-crawler', 'AWS::Glue::Crawler', undefined, {
+      expectedRegion: 'us-east-1',
+    });
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof DeleteCrawlerCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({ Name: 'my-crawler' });
+  });
+
+  it('delete() treats EntityNotFoundException as idempotent when region matches', async () => {
+    const { EntityNotFoundException } = await import('@aws-sdk/client-glue');
+    mockSend.mockRejectedValueOnce(
+      new EntityNotFoundException({ message: 'not found', $metadata: {} })
+    );
+
+    await expect(
+      provider.delete('L', 'my-crawler', 'AWS::Glue::Crawler', undefined, {
+        expectedRegion: 'us-east-1',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('getAttribute() returns physicalId for Id / Ref / Name', async () => {
+    expect(await provider.getAttribute('my-crawler', 'AWS::Glue::Crawler', 'Id')).toBe('my-crawler');
+    expect(await provider.getAttribute('my-crawler', 'AWS::Glue::Crawler', 'Ref')).toBe(
+      'my-crawler'
+    );
+    expect(await provider.getAttribute('my-crawler', 'AWS::Glue::Crawler', 'Name')).toBe(
+      'my-crawler'
+    );
+    expect(
+      await provider.getAttribute('my-crawler', 'AWS::Glue::Crawler', 'Unknown')
+    ).toBeUndefined();
+  });
+
+  it('readCurrentState() emits PR #145 always-emit placeholders for every user-controllable field on a default Crawler', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetCrawlerCommand) {
+        return Promise.resolve({ Crawler: { Name: 'my-crawler' } });
+      }
+      if (cmd instanceof GetTagsCommand) {
+        return Promise.resolve({ Tags: {} });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await provider.readCurrentState('my-crawler', 'L', 'AWS::Glue::Crawler');
+    expect(result).toEqual({
+      Name: 'my-crawler',
+      Role: '',
+      Targets: {},
+      DatabaseName: '',
+      Description: '',
+      Schedule: {},
+      Classifiers: [],
+      TablePrefix: '',
+      SchemaChangePolicy: {},
+      RecrawlPolicy: {},
+      LineageConfiguration: {},
+      LakeFormationConfiguration: {},
+      Configuration: '',
+      CrawlerSecurityConfiguration: '',
+      Tags: [],
+    });
+  });
+
+  it('readCurrentState() reverse-maps SDK Schedule.ScheduleExpression into CFn structured shape', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetCrawlerCommand) {
+        return Promise.resolve({
+          Crawler: {
+            Name: 'my-crawler',
+            Role: 'arn:aws:iam::123456789012:role/GlueCrawlerRole',
+            Targets: { S3Targets: [{ Path: 's3://my-bucket/data' }] },
+            DatabaseName: 'my-db',
+            Description: 'desc',
+            Schedule: { ScheduleExpression: 'cron(0 12 * * ? *)', State: 'SCHEDULED' },
+            Classifiers: ['my-classifier'],
+          },
+        });
+      }
+      if (cmd instanceof GetTagsCommand) {
+        return Promise.resolve({
+          Tags: { env: 'prod', 'aws:cdk:path': 'MyStack/MyCrawler' },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await provider.readCurrentState('my-crawler', 'L', 'AWS::Glue::Crawler');
+    expect(result).toMatchObject({
+      Name: 'my-crawler',
+      Role: 'arn:aws:iam::123456789012:role/GlueCrawlerRole',
+      Targets: { S3Targets: [{ Path: 's3://my-bucket/data' }] },
+      DatabaseName: 'my-db',
+      Description: 'desc',
+      // SDK Schedule.{ScheduleExpression,State} -> CFn structured wrapper
+      Schedule: { ScheduleExpression: 'cron(0 12 * * ? *)' },
+      Classifiers: ['my-classifier'],
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    });
+  });
+
+  it('readCurrentState() returns undefined when crawler does not exist', async () => {
+    const { EntityNotFoundException } = await import('@aws-sdk/client-glue');
+    mockSend.mockRejectedValueOnce(
+      new EntityNotFoundException({ message: 'not found', $metadata: {} })
+    );
+
+    const result = await provider.readCurrentState('missing', 'L', 'AWS::Glue::Crawler');
+    expect(result).toBeUndefined();
+  });
+
+  it('startSchedule() and stopSchedule() call StartCrawlerSchedule / StopCrawlerSchedule', async () => {
+    await provider.startSchedule('my-crawler');
+    await provider.stopSchedule('my-crawler');
+
+    const startCall = mockSend.mock.calls.find((c) => c[0] instanceof StartCrawlerScheduleCommand);
+    const stopCall = mockSend.mock.calls.find((c) => c[0] instanceof StopCrawlerScheduleCommand);
+    expect(startCall).toBeDefined();
+    expect(stopCall).toBeDefined();
+    expect(startCall![0].input).toEqual({ CrawlerName: 'my-crawler' });
+    expect(stopCall![0].input).toEqual({ CrawlerName: 'my-crawler' });
+  });
+
+  it('handledProperties declares the full mutable surface', () => {
+    const set = provider.handledProperties.get('AWS::Glue::Crawler');
+    expect(set).toBeDefined();
+    expect(set?.has('Name')).toBe(true);
+    expect(set?.has('Role')).toBe(true);
+    expect(set?.has('Targets')).toBe(true);
+    expect(set?.has('Schedule')).toBe(true);
+    expect(set?.has('Configuration')).toBe(true);
+    expect(set?.has('Tags')).toBe(true);
+  });
+});

--- a/tests/unit/provisioning/glue-job-roundtrip.test.ts
+++ b/tests/unit/provisioning/glue-job-roundtrip.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CreateJobCommand,
+  UpdateJobCommand,
+  DeleteJobCommand,
+  GetJobCommand,
+  GetTagsCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from '@aws-sdk/client-glue';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-glue', async () => {
+  const actual =
+    await vi.importActual<typeof import('@aws-sdk/client-glue')>('@aws-sdk/client-glue');
+  return {
+    ...actual,
+    GlueClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('@aws-sdk/client-sts', () => {
+  return {
+    STSClient: vi.fn().mockImplementation(() => ({
+      send: vi.fn().mockResolvedValue({ Account: '123456789012' }),
+    })),
+    GetCallerIdentityCommand: vi.fn(),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { GlueJobProvider } from '../../../src/provisioning/providers/glue-provider.js';
+
+describe('GlueJobProvider', () => {
+  let provider: GlueJobProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new GlueJobProvider();
+    mockSend.mockResolvedValue({});
+  });
+
+  it('create() builds CreateJob with required Role / Command and templated Tags', async () => {
+    const result = await provider.create('L', 'AWS::Glue::Job', {
+      Name: 'my-job',
+      Role: 'arn:aws:iam::123456789012:role/GlueJobRole',
+      Command: {
+        Name: 'glueetl',
+        ScriptLocation: 's3://my-bucket/scripts/job.py',
+        PythonVersion: '3',
+      },
+      Description: 'My Glue job',
+      MaxCapacity: 2.0,
+      MaxRetries: 3,
+      Timeout: 2880,
+      GlueVersion: '4.0',
+      DefaultArguments: { '--job-bookmark-option': 'job-bookmark-enable' },
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    });
+
+    expect(result).toEqual({ physicalId: 'my-job', attributes: {} });
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof CreateJobCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      Name: 'my-job',
+      Role: 'arn:aws:iam::123456789012:role/GlueJobRole',
+      Command: {
+        Name: 'glueetl',
+        ScriptLocation: 's3://my-bucket/scripts/job.py',
+        PythonVersion: '3',
+      },
+      Description: 'My Glue job',
+      MaxCapacity: 2.0,
+      MaxRetries: 3,
+      Timeout: 2880,
+      GlueVersion: '4.0',
+      DefaultArguments: { '--job-bookmark-option': 'job-bookmark-enable' },
+      Tags: { env: 'prod' },
+    });
+  });
+
+  it('create() omits optional fields when not provided', async () => {
+    await provider.create('L', 'AWS::Glue::Job', {
+      Name: 'my-job',
+      Role: 'arn:aws:iam::123456789012:role/GlueJobRole',
+      Command: { Name: 'glueetl' },
+    });
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof CreateJobCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      Name: 'my-job',
+      Role: 'arn:aws:iam::123456789012:role/GlueJobRole',
+      Command: { Name: 'glueetl' },
+    });
+  });
+
+  it('create() fails when Role is missing', async () => {
+    await expect(
+      provider.create('L', 'AWS::Glue::Job', {
+        Name: 'my-job',
+        Command: { Name: 'glueetl' },
+      })
+    ).rejects.toThrow(/Role is required/);
+  });
+
+  it('create() fails when Command is missing', async () => {
+    await expect(
+      provider.create('L', 'AWS::Glue::Job', {
+        Name: 'my-job',
+        Role: 'arn:aws:iam::123456789012:role/GlueJobRole',
+      })
+    ).rejects.toThrow(/Command is required/);
+  });
+
+  it('update() forwards JobUpdate with Command + Role + common fields', async () => {
+    await provider.update(
+      'L',
+      'my-job',
+      'AWS::Glue::Job',
+      {
+        Name: 'my-job',
+        Role: 'arn:aws:iam::123456789012:role/GlueJobRole-v2',
+        Command: { Name: 'glueetl', ScriptLocation: 's3://my-bucket/scripts/job-v2.py' },
+        Description: 'updated',
+        MaxRetries: 5,
+        Timeout: 1440,
+      },
+      {}
+    );
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof UpdateJobCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      JobName: 'my-job',
+      JobUpdate: {
+        Command: { Name: 'glueetl', ScriptLocation: 's3://my-bucket/scripts/job-v2.py' },
+        Description: 'updated',
+        MaxRetries: 5,
+        Timeout: 1440,
+        Role: 'arn:aws:iam::123456789012:role/GlueJobRole-v2',
+      },
+    });
+  });
+
+  it('update() round-trips empty placeholders (Description: "" / DefaultArguments: {}) so drift --revert can clear console-side ADDs', async () => {
+    // Per feedback_update_optional_field_undefined_check.md: empty
+    // string / empty map MUST reach AWS so console-side ADDs revert.
+    await provider.update(
+      'L',
+      'my-job',
+      'AWS::Glue::Job',
+      {
+        Name: 'my-job',
+        Description: '',
+        DefaultArguments: {},
+      },
+      { Description: 'old description', DefaultArguments: { '--foo': 'bar' } }
+    );
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof UpdateJobCommand);
+    expect(call).toBeDefined();
+    const input = call![0].input as { JobUpdate: Record<string, unknown> };
+    expect(input.JobUpdate.Description).toBe('');
+    expect(input.JobUpdate.DefaultArguments).toEqual({});
+  });
+
+  it('update() reconciles Tag diff via TagResource + UntagResource when tags change', async () => {
+    await provider.update(
+      'L',
+      'my-job',
+      'AWS::Glue::Job',
+      {
+        Name: 'my-job',
+        Tags: [
+          { Key: 'env', Value: 'prod' },
+          { Key: 'team', Value: 'data' },
+        ],
+      },
+      {
+        Tags: [
+          { Key: 'env', Value: 'dev' },
+          { Key: 'old', Value: 'remove-me' },
+        ],
+      }
+    );
+
+    const tagAdd = mockSend.mock.calls.find((c) => c[0] instanceof TagResourceCommand);
+    const tagRemove = mockSend.mock.calls.find((c) => c[0] instanceof UntagResourceCommand);
+    expect(tagAdd).toBeDefined();
+    expect(tagRemove).toBeDefined();
+    expect(tagAdd![0].input).toEqual({
+      ResourceArn: 'arn:aws:glue:us-east-1:123456789012:job/my-job',
+      TagsToAdd: { env: 'prod', team: 'data' },
+    });
+    expect(tagRemove![0].input).toEqual({
+      ResourceArn: 'arn:aws:glue:us-east-1:123456789012:job/my-job',
+      TagsToRemove: ['old'],
+    });
+  });
+
+  it('update() does not call TagResource / UntagResource when tags are unchanged', async () => {
+    const tags = [{ Key: 'env', Value: 'prod' }];
+    await provider.update(
+      'L',
+      'my-job',
+      'AWS::Glue::Job',
+      { Name: 'my-job', Tags: tags },
+      { Tags: tags }
+    );
+
+    expect(mockSend.mock.calls.find((c) => c[0] instanceof TagResourceCommand)).toBeUndefined();
+    expect(mockSend.mock.calls.find((c) => c[0] instanceof UntagResourceCommand)).toBeUndefined();
+  });
+
+  it('delete() calls DeleteJob', async () => {
+    await provider.delete('L', 'my-job', 'AWS::Glue::Job', undefined, {
+      expectedRegion: 'us-east-1',
+    });
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof DeleteJobCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({ JobName: 'my-job' });
+  });
+
+  it('delete() treats EntityNotFoundException as idempotent when region matches', async () => {
+    const { EntityNotFoundException } = await import('@aws-sdk/client-glue');
+    mockSend.mockRejectedValueOnce(
+      new EntityNotFoundException({ message: 'not found', $metadata: {} })
+    );
+
+    await expect(
+      provider.delete('L', 'my-job', 'AWS::Glue::Job', undefined, {
+        expectedRegion: 'us-east-1',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('getAttribute() returns physicalId for Id / Ref / Name', async () => {
+    expect(await provider.getAttribute('my-job', 'AWS::Glue::Job', 'Id')).toBe('my-job');
+    expect(await provider.getAttribute('my-job', 'AWS::Glue::Job', 'Ref')).toBe('my-job');
+    expect(await provider.getAttribute('my-job', 'AWS::Glue::Job', 'Name')).toBe('my-job');
+    expect(await provider.getAttribute('my-job', 'AWS::Glue::Job', 'Unknown')).toBeUndefined();
+  });
+
+  it('readCurrentState() emits PR #145 always-emit placeholders for every user-controllable field on a default Job', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetJobCommand) {
+        return Promise.resolve({ Job: { Name: 'my-job' } });
+      }
+      if (cmd instanceof GetTagsCommand) {
+        return Promise.resolve({ Tags: {} });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await provider.readCurrentState('my-job', 'L', 'AWS::Glue::Job');
+    expect(result).toEqual({
+      Name: 'my-job',
+      Role: '',
+      Command: {},
+      Description: '',
+      LogUri: '',
+      DefaultArguments: {},
+      NonOverridableArguments: {},
+      Connections: { Connections: [] },
+      MaxRetries: 0,
+      Timeout: 0,
+      ExecutionProperty: { MaxConcurrentRuns: 1 },
+      NotificationProperty: { NotifyDelayAfter: 0 },
+      GlueVersion: '',
+      NumberOfWorkers: 0,
+      WorkerType: '',
+      MaxCapacity: 0,
+      AllocatedCapacity: 0,
+      SecurityConfiguration: '',
+      ExecutionClass: '',
+      JobMode: '',
+      JobRunQueuingEnabled: false,
+      MaintenanceWindow: '',
+      SourceControlDetails: {},
+      Tags: [],
+    });
+  });
+
+  it('readCurrentState() surfaces AWS values when Job is fully configured', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetJobCommand) {
+        return Promise.resolve({
+          Job: {
+            Name: 'my-job',
+            Role: 'arn:aws:iam::123456789012:role/GlueJobRole',
+            Command: {
+              Name: 'glueetl',
+              ScriptLocation: 's3://my-bucket/scripts/job.py',
+              PythonVersion: '3',
+            },
+            Description: 'desc',
+            MaxRetries: 3,
+            Timeout: 2880,
+            GlueVersion: '4.0',
+            DefaultArguments: { '--foo': 'bar' },
+            ExecutionProperty: { MaxConcurrentRuns: 5 },
+            NumberOfWorkers: 2,
+            WorkerType: 'G.1X',
+          },
+        });
+      }
+      if (cmd instanceof GetTagsCommand) {
+        return Promise.resolve({
+          Tags: { env: 'prod', 'aws:cdk:path': 'MyStack/MyJob' },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await provider.readCurrentState('my-job', 'L', 'AWS::Glue::Job');
+    expect(result).toMatchObject({
+      Name: 'my-job',
+      Role: 'arn:aws:iam::123456789012:role/GlueJobRole',
+      Command: {
+        Name: 'glueetl',
+        ScriptLocation: 's3://my-bucket/scripts/job.py',
+        PythonVersion: '3',
+      },
+      Description: 'desc',
+      MaxRetries: 3,
+      Timeout: 2880,
+      GlueVersion: '4.0',
+      DefaultArguments: { '--foo': 'bar' },
+      ExecutionProperty: { MaxConcurrentRuns: 5 },
+      NumberOfWorkers: 2,
+      WorkerType: 'G.1X',
+      // aws:cdk:path filtered out by normalizeAwsTagsToCfn
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    });
+  });
+
+  it('readCurrentState() returns undefined when job does not exist', async () => {
+    const { EntityNotFoundException } = await import('@aws-sdk/client-glue');
+    mockSend.mockRejectedValueOnce(
+      new EntityNotFoundException({ message: 'not found', $metadata: {} })
+    );
+
+    const result = await provider.readCurrentState('missing', 'L', 'AWS::Glue::Job');
+    expect(result).toBeUndefined();
+  });
+
+  it('readCurrentState() falls back to empty Tags array when GetTags fails', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetJobCommand) {
+        return Promise.resolve({ Job: { Name: 'my-job' } });
+      }
+      if (cmd instanceof GetTagsCommand) {
+        return Promise.reject(new Error('AccessDenied'));
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await provider.readCurrentState('my-job', 'L', 'AWS::Glue::Job');
+    expect(result?.Tags).toEqual([]);
+  });
+
+  it('handledProperties declares the full mutable surface', () => {
+    const set = provider.handledProperties.get('AWS::Glue::Job');
+    expect(set).toBeDefined();
+    expect(set?.has('Name')).toBe(true);
+    expect(set?.has('Role')).toBe(true);
+    expect(set?.has('Command')).toBe(true);
+    expect(set?.has('Tags')).toBe(true);
+    expect(set?.has('GlueVersion')).toBe(true);
+    expect(set?.has('NumberOfWorkers')).toBe(true);
+  });
+});

--- a/tests/unit/provisioning/glue-trigger-roundtrip.test.ts
+++ b/tests/unit/provisioning/glue-trigger-roundtrip.test.ts
@@ -1,0 +1,411 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  CreateTriggerCommand,
+  UpdateTriggerCommand,
+  DeleteTriggerCommand,
+  GetTriggerCommand,
+  GetTagsCommand,
+  StartTriggerCommand,
+  StopTriggerCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from '@aws-sdk/client-glue';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-glue', async () => {
+  const actual =
+    await vi.importActual<typeof import('@aws-sdk/client-glue')>('@aws-sdk/client-glue');
+  return {
+    ...actual,
+    GlueClient: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('@aws-sdk/client-sts', () => {
+  return {
+    STSClient: vi.fn().mockImplementation(() => ({
+      send: vi.fn().mockResolvedValue({ Account: '123456789012' }),
+    })),
+    GetCallerIdentityCommand: vi.fn(),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { GlueTriggerProvider } from '../../../src/provisioning/providers/glue-provider.js';
+
+describe('GlueTriggerProvider', () => {
+  let provider: GlueTriggerProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new GlueTriggerProvider();
+    mockSend.mockResolvedValue({});
+  });
+
+  it('create() builds CreateTrigger with full SCHEDULED-trigger surface', async () => {
+    const result = await provider.create('L', 'AWS::Glue::Trigger', {
+      Name: 'my-trigger',
+      Type: 'SCHEDULED',
+      Schedule: 'cron(0 12 * * ? *)',
+      Actions: [{ JobName: 'my-job', Arguments: { '--foo': 'bar' } }],
+      Description: 'My trigger',
+      StartOnCreation: true,
+      WorkflowName: 'my-workflow',
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    });
+
+    expect(result).toEqual({ physicalId: 'my-trigger', attributes: {} });
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof CreateTriggerCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      Name: 'my-trigger',
+      Type: 'SCHEDULED',
+      Schedule: 'cron(0 12 * * ? *)',
+      Actions: [{ JobName: 'my-job', Arguments: { '--foo': 'bar' } }],
+      Description: 'My trigger',
+      StartOnCreation: true,
+      WorkflowName: 'my-workflow',
+      Tags: { env: 'prod' },
+    });
+  });
+
+  it('create() builds CreateTrigger with CONDITIONAL Predicate and EventBatchingCondition', async () => {
+    await provider.create('L', 'AWS::Glue::Trigger', {
+      Name: 'my-cond-trigger',
+      Type: 'CONDITIONAL',
+      Actions: [{ JobName: 'downstream' }],
+      Predicate: {
+        Logical: 'ANY',
+        Conditions: [
+          {
+            LogicalOperator: 'EQUALS',
+            JobName: 'upstream',
+            State: 'SUCCEEDED',
+          },
+        ],
+      },
+      EventBatchingCondition: { BatchSize: 5, BatchWindow: 30 },
+    });
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof CreateTriggerCommand);
+    expect(call![0].input).toMatchObject({
+      Name: 'my-cond-trigger',
+      Type: 'CONDITIONAL',
+      Predicate: {
+        Logical: 'ANY',
+        Conditions: [
+          { LogicalOperator: 'EQUALS', JobName: 'upstream', State: 'SUCCEEDED' },
+        ],
+      },
+      EventBatchingCondition: { BatchSize: 5, BatchWindow: 30 },
+    });
+  });
+
+  it('create() fails when Type is missing', async () => {
+    await expect(
+      provider.create('L', 'AWS::Glue::Trigger', {
+        Name: 'my-trigger',
+        Actions: [{ JobName: 'j' }],
+      })
+    ).rejects.toThrow(/Type is required/);
+  });
+
+  it('create() fails when Actions is missing', async () => {
+    await expect(
+      provider.create('L', 'AWS::Glue::Trigger', { Name: 'my-trigger', Type: 'ON_DEMAND' })
+    ).rejects.toThrow(/Actions is required/);
+  });
+
+  it('update() with ACTIVATED trigger executes Stop -> Update -> Start (state preserved across update)', async () => {
+    // GetTrigger returns ACTIVATED — provider must Stop, Update, then Start.
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetTriggerCommand) {
+        return Promise.resolve({ Trigger: { Name: 'my-trigger', State: 'ACTIVATED' } });
+      }
+      return Promise.resolve({});
+    });
+
+    await provider.update(
+      'L',
+      'my-trigger',
+      'AWS::Glue::Trigger',
+      {
+        Description: 'updated',
+        Actions: [{ JobName: 'my-job-v2' }],
+      },
+      {}
+    );
+
+    // Order matters: GetTrigger -> StopTrigger -> UpdateTrigger -> StartTrigger
+    const callTypes = mockSend.mock.calls.map((c) => c[0].constructor.name);
+    const stopIdx = callTypes.indexOf(StopTriggerCommand.name);
+    const updateIdx = callTypes.indexOf(UpdateTriggerCommand.name);
+    const startIdx = callTypes.indexOf(StartTriggerCommand.name);
+
+    expect(stopIdx).toBeGreaterThanOrEqual(0);
+    expect(updateIdx).toBeGreaterThan(stopIdx);
+    expect(startIdx).toBeGreaterThan(updateIdx);
+  });
+
+  it('update() with DEACTIVATED trigger calls Update only — no Stop / Start', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetTriggerCommand) {
+        return Promise.resolve({ Trigger: { Name: 'my-trigger', State: 'DEACTIVATED' } });
+      }
+      return Promise.resolve({});
+    });
+
+    await provider.update(
+      'L',
+      'my-trigger',
+      'AWS::Glue::Trigger',
+      { Description: 'updated' },
+      {}
+    );
+
+    const stop = mockSend.mock.calls.find((c) => c[0] instanceof StopTriggerCommand);
+    const update = mockSend.mock.calls.find((c) => c[0] instanceof UpdateTriggerCommand);
+    const start = mockSend.mock.calls.find((c) => c[0] instanceof StartTriggerCommand);
+    expect(stop).toBeUndefined();
+    expect(update).toBeDefined();
+    expect(start).toBeUndefined();
+  });
+
+  it('update() forwards UpdateTrigger.TriggerUpdate with all mutable fields when provided', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetTriggerCommand) {
+        return Promise.resolve({ Trigger: { Name: 'my-trigger', State: 'DEACTIVATED' } });
+      }
+      return Promise.resolve({});
+    });
+
+    await provider.update(
+      'L',
+      'my-trigger',
+      'AWS::Glue::Trigger',
+      {
+        Description: 'updated',
+        Schedule: 'cron(0 6 * * ? *)',
+        Actions: [{ JobName: 'my-job-v2' }],
+        Predicate: {
+          Logical: 'ANY',
+          Conditions: [{ JobName: 'upstream', State: 'SUCCEEDED' }],
+        },
+        EventBatchingCondition: { BatchSize: 10, BatchWindow: 60 },
+      },
+      {}
+    );
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof UpdateTriggerCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({
+      Name: 'my-trigger',
+      TriggerUpdate: {
+        Description: 'updated',
+        Schedule: 'cron(0 6 * * ? *)',
+        Actions: [{ JobName: 'my-job-v2' }],
+        Predicate: {
+          Logical: 'ANY',
+          Conditions: [{ JobName: 'upstream', State: 'SUCCEEDED' }],
+        },
+        EventBatchingCondition: { BatchSize: 10, BatchWindow: 60 },
+      },
+    });
+  });
+
+  it('update() reconciles Tag diff via TagResource + UntagResource when tags change', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetTriggerCommand) {
+        return Promise.resolve({ Trigger: { Name: 'my-trigger', State: 'DEACTIVATED' } });
+      }
+      return Promise.resolve({});
+    });
+
+    await provider.update(
+      'L',
+      'my-trigger',
+      'AWS::Glue::Trigger',
+      { Tags: [{ Key: 'env', Value: 'prod' }] },
+      {
+        Tags: [
+          { Key: 'env', Value: 'dev' },
+          { Key: 'old', Value: 'remove-me' },
+        ],
+      }
+    );
+
+    const tagAdd = mockSend.mock.calls.find((c) => c[0] instanceof TagResourceCommand);
+    const tagRemove = mockSend.mock.calls.find((c) => c[0] instanceof UntagResourceCommand);
+    expect(tagAdd).toBeDefined();
+    expect(tagRemove).toBeDefined();
+    expect(tagAdd![0].input).toEqual({
+      ResourceArn: 'arn:aws:glue:us-east-1:123456789012:trigger/my-trigger',
+      TagsToAdd: { env: 'prod' },
+    });
+    expect(tagRemove![0].input).toEqual({
+      ResourceArn: 'arn:aws:glue:us-east-1:123456789012:trigger/my-trigger',
+      TagsToRemove: ['old'],
+    });
+  });
+
+  it('delete() calls DeleteTrigger', async () => {
+    await provider.delete('L', 'my-trigger', 'AWS::Glue::Trigger', undefined, {
+      expectedRegion: 'us-east-1',
+    });
+
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof DeleteTriggerCommand);
+    expect(call).toBeDefined();
+    expect(call![0].input).toEqual({ Name: 'my-trigger' });
+  });
+
+  it('delete() treats EntityNotFoundException as idempotent when region matches', async () => {
+    const { EntityNotFoundException } = await import('@aws-sdk/client-glue');
+    mockSend.mockRejectedValueOnce(
+      new EntityNotFoundException({ message: 'not found', $metadata: {} })
+    );
+
+    await expect(
+      provider.delete('L', 'my-trigger', 'AWS::Glue::Trigger', undefined, {
+        expectedRegion: 'us-east-1',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('getAttribute() returns physicalId for Id / Ref / Name', async () => {
+    expect(await provider.getAttribute('my-trigger', 'AWS::Glue::Trigger', 'Id')).toBe(
+      'my-trigger'
+    );
+    expect(await provider.getAttribute('my-trigger', 'AWS::Glue::Trigger', 'Ref')).toBe(
+      'my-trigger'
+    );
+    expect(await provider.getAttribute('my-trigger', 'AWS::Glue::Trigger', 'Name')).toBe(
+      'my-trigger'
+    );
+    expect(
+      await provider.getAttribute('my-trigger', 'AWS::Glue::Trigger', 'Unknown')
+    ).toBeUndefined();
+  });
+
+  it('readCurrentState() emits PR #145 always-emit placeholders for every user-controllable field on a default Trigger', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetTriggerCommand) {
+        return Promise.resolve({ Trigger: { Name: 'my-trigger' } });
+      }
+      if (cmd instanceof GetTagsCommand) {
+        return Promise.resolve({ Tags: {} });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await provider.readCurrentState('my-trigger', 'L', 'AWS::Glue::Trigger');
+    expect(result).toEqual({
+      Name: 'my-trigger',
+      Type: '',
+      Schedule: '',
+      Description: '',
+      WorkflowName: '',
+      Actions: [],
+      Predicate: {},
+      EventBatchingCondition: {},
+      Tags: [],
+    });
+  });
+
+  it('readCurrentState() surfaces AWS values when Trigger is fully configured', async () => {
+    mockSend.mockImplementation((cmd) => {
+      if (cmd instanceof GetTriggerCommand) {
+        return Promise.resolve({
+          Trigger: {
+            Name: 'my-trigger',
+            Type: 'CONDITIONAL',
+            Schedule: '',
+            Description: 'desc',
+            WorkflowName: 'my-wf',
+            Actions: [{ JobName: 'downstream', Arguments: { '--x': 'y' } }],
+            Predicate: {
+              Logical: 'ANY',
+              Conditions: [
+                {
+                  LogicalOperator: 'EQUALS',
+                  JobName: 'upstream',
+                  State: 'SUCCEEDED',
+                },
+              ],
+            },
+            EventBatchingCondition: { BatchSize: 5, BatchWindow: 30 },
+          },
+        });
+      }
+      if (cmd instanceof GetTagsCommand) {
+        return Promise.resolve({
+          Tags: { env: 'prod', 'aws:cdk:path': 'MyStack/MyTrigger' },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await provider.readCurrentState('my-trigger', 'L', 'AWS::Glue::Trigger');
+    expect(result).toMatchObject({
+      Name: 'my-trigger',
+      Type: 'CONDITIONAL',
+      Description: 'desc',
+      WorkflowName: 'my-wf',
+      Actions: [{ JobName: 'downstream', Arguments: { '--x': 'y' } }],
+      Predicate: {
+        Logical: 'ANY',
+        Conditions: [{ LogicalOperator: 'EQUALS', JobName: 'upstream', State: 'SUCCEEDED' }],
+      },
+      EventBatchingCondition: { BatchSize: 5, BatchWindow: 30 },
+      Tags: [{ Key: 'env', Value: 'prod' }],
+    });
+  });
+
+  it('readCurrentState() returns undefined when trigger does not exist', async () => {
+    const { EntityNotFoundException } = await import('@aws-sdk/client-glue');
+    mockSend.mockRejectedValueOnce(
+      new EntityNotFoundException({ message: 'not found', $metadata: {} })
+    );
+
+    const result = await provider.readCurrentState('missing', 'L', 'AWS::Glue::Trigger');
+    expect(result).toBeUndefined();
+  });
+
+  it('handledProperties declares the full mutable surface', () => {
+    const set = provider.handledProperties.get('AWS::Glue::Trigger');
+    expect(set).toBeDefined();
+    expect([...(set ?? new Set())].sort()).toEqual([
+      'Actions',
+      'Description',
+      'EventBatchingCondition',
+      'Name',
+      'Predicate',
+      'Schedule',
+      'StartOnCreation',
+      'Tags',
+      'Type',
+      'WorkflowName',
+    ]);
+  });
+});

--- a/tests/unit/provisioning/s3-bucket-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/s3-bucket-provider-roundtrip.test.ts
@@ -3,10 +3,28 @@ import {
   GetBucketTaggingCommand,
   PutBucketEncryptionCommand,
   PutBucketCorsCommand,
+  DeleteBucketCorsCommand,
   PutBucketLifecycleConfigurationCommand,
+  DeleteBucketLifecycleCommand,
   PutBucketVersioningCommand,
   PutBucketTaggingCommand,
   DeleteBucketTaggingCommand,
+  PutBucketWebsiteCommand,
+  DeleteBucketWebsiteCommand,
+  PutBucketLoggingCommand,
+  PutBucketNotificationConfigurationCommand,
+  PutBucketReplicationCommand,
+  DeleteBucketReplicationCommand,
+  PutObjectLockConfigurationCommand,
+  PutBucketAccelerateConfigurationCommand,
+  PutBucketMetricsConfigurationCommand,
+  DeleteBucketMetricsConfigurationCommand,
+  PutBucketAnalyticsConfigurationCommand,
+  DeleteBucketAnalyticsConfigurationCommand,
+  PutBucketIntelligentTieringConfigurationCommand,
+  DeleteBucketIntelligentTieringConfigurationCommand,
+  PutBucketInventoryConfigurationCommand,
+  DeleteBucketInventoryConfigurationCommand,
 } from '@aws-sdk/client-s3';
 
 const mockSend = vi.fn();
@@ -299,5 +317,1013 @@ describe('S3BucketProvider read-update round-trip', () => {
 
     expect(mockSend.mock.calls[4]?.[0]).toBeInstanceOf(GetBucketTaggingCommand);
     expect(result?.Tags).toEqual([{ Key: 'Owner', Value: 'platform' }]);
+  });
+});
+
+// =====================================================================
+// PR #215 sub-config update / delete round-trips
+// =====================================================================
+//
+// applySubConfigDiffs() walks each of the 12 sub-configs and issues:
+//   - undefined -> defined: Put*Command
+//   - defined -> undefined: Delete*Command (or Put-with-cleared-body for
+//     APIs that have no Delete counterpart — Logging / Notification /
+//     ObjectLock / Accelerate)
+//   - defined -> defined (different): Put*Command
+//   - unchanged: no SDK call
+//
+// The 4 array-shaped configs (Metrics / Analytics / IntelligentTiering /
+// Inventory) diff per `Id` so add / remove / change are fired
+// independently for each id.
+// =====================================================================
+
+describe('S3BucketProvider sub-config diff (PR #215)', () => {
+  let provider: S3BucketProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new S3BucketProvider();
+    mockSend.mockResolvedValue({});
+  });
+
+  /**
+   * Filter the SDK mock calls to a single command class — used as the
+   * primary assertion point so unrelated commands (PutBucketVersioning
+   * etc. fired by applyConfiguration) don't pollute the assertion.
+   */
+  function callsOf(cmdClass: new (...args: never[]) => unknown): unknown[] {
+    return mockSend.mock.calls.filter((c) => c[0] instanceof cmdClass).map((c) => c[0]);
+  }
+
+  // -------------------------------------------------------------------
+  // LifecycleConfiguration (Put + Delete)
+  // -------------------------------------------------------------------
+
+  it('LifecycleConfiguration: absent -> present fires PutBucketLifecycleConfiguration', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        LifecycleConfiguration: {
+          Rules: [{ Id: 'r1', Status: 'Enabled', ExpirationInDays: 30 }],
+        },
+      },
+      { BucketName: BUCKET_NAME }
+    );
+    expect(callsOf(PutBucketLifecycleConfigurationCommand)).toHaveLength(1);
+    expect(callsOf(DeleteBucketLifecycleCommand)).toHaveLength(0);
+  });
+
+  it('LifecycleConfiguration: present -> absent fires DeleteBucketLifecycle', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME },
+      {
+        BucketName: BUCKET_NAME,
+        LifecycleConfiguration: {
+          Rules: [{ Id: 'r1', Status: 'Enabled', ExpirationInDays: 30 }],
+        },
+      }
+    );
+    expect(callsOf(DeleteBucketLifecycleCommand)).toHaveLength(1);
+    expect(callsOf(PutBucketLifecycleConfigurationCommand)).toHaveLength(0);
+  });
+
+  it('LifecycleConfiguration: unchanged fires neither Put nor Delete', async () => {
+    const cfg = { Rules: [{ Id: 'r1', Status: 'Enabled', ExpirationInDays: 30 }] };
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME, LifecycleConfiguration: cfg },
+      { BucketName: BUCKET_NAME, LifecycleConfiguration: cfg }
+    );
+    expect(callsOf(PutBucketLifecycleConfigurationCommand)).toHaveLength(0);
+    expect(callsOf(DeleteBucketLifecycleCommand)).toHaveLength(0);
+  });
+
+  it('LifecycleConfiguration: present -> present (different) fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        LifecycleConfiguration: {
+          Rules: [{ Id: 'r1', Status: 'Enabled', ExpirationInDays: 60 }],
+        },
+      },
+      {
+        BucketName: BUCKET_NAME,
+        LifecycleConfiguration: {
+          Rules: [{ Id: 'r1', Status: 'Enabled', ExpirationInDays: 30 }],
+        },
+      }
+    );
+    expect(callsOf(PutBucketLifecycleConfigurationCommand)).toHaveLength(1);
+    expect(callsOf(DeleteBucketLifecycleCommand)).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------
+  // CorsConfiguration (Put + Delete)
+  // -------------------------------------------------------------------
+
+  it('CorsConfiguration: absent -> present fires PutBucketCors', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        CorsConfiguration: {
+          CorsRules: [{ AllowedOrigins: ['*'], AllowedMethods: ['GET'] }],
+        },
+      },
+      { BucketName: BUCKET_NAME }
+    );
+    expect(callsOf(PutBucketCorsCommand)).toHaveLength(1);
+    expect(callsOf(DeleteBucketCorsCommand)).toHaveLength(0);
+  });
+
+  it('CorsConfiguration: present -> absent fires DeleteBucketCors', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME },
+      {
+        BucketName: BUCKET_NAME,
+        CorsConfiguration: {
+          CorsRules: [{ AllowedOrigins: ['*'], AllowedMethods: ['GET'] }],
+        },
+      }
+    );
+    expect(callsOf(DeleteBucketCorsCommand)).toHaveLength(1);
+    expect(callsOf(PutBucketCorsCommand)).toHaveLength(0);
+  });
+
+  it('CorsConfiguration: unchanged fires neither Put nor Delete', async () => {
+    const cfg = { CorsRules: [{ AllowedOrigins: ['*'], AllowedMethods: ['GET'] }] };
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME, CorsConfiguration: cfg },
+      { BucketName: BUCKET_NAME, CorsConfiguration: cfg }
+    );
+    expect(callsOf(PutBucketCorsCommand)).toHaveLength(0);
+    expect(callsOf(DeleteBucketCorsCommand)).toHaveLength(0);
+  });
+
+  it('CorsConfiguration: present -> present (different) fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        CorsConfiguration: {
+          CorsRules: [{ AllowedOrigins: ['https://example.com'], AllowedMethods: ['GET'] }],
+        },
+      },
+      {
+        BucketName: BUCKET_NAME,
+        CorsConfiguration: {
+          CorsRules: [{ AllowedOrigins: ['*'], AllowedMethods: ['GET'] }],
+        },
+      }
+    );
+    expect(callsOf(PutBucketCorsCommand)).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------
+  // WebsiteConfiguration (Put + Delete)
+  // -------------------------------------------------------------------
+
+  it('WebsiteConfiguration: absent -> present fires PutBucketWebsite', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        WebsiteConfiguration: { IndexDocument: 'index.html' },
+      },
+      { BucketName: BUCKET_NAME }
+    );
+    expect(callsOf(PutBucketWebsiteCommand)).toHaveLength(1);
+    expect(callsOf(DeleteBucketWebsiteCommand)).toHaveLength(0);
+  });
+
+  it('WebsiteConfiguration: present -> absent fires DeleteBucketWebsite', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME },
+      {
+        BucketName: BUCKET_NAME,
+        WebsiteConfiguration: { IndexDocument: 'index.html' },
+      }
+    );
+    expect(callsOf(DeleteBucketWebsiteCommand)).toHaveLength(1);
+    expect(callsOf(PutBucketWebsiteCommand)).toHaveLength(0);
+  });
+
+  it('WebsiteConfiguration: unchanged fires no SDK call', async () => {
+    const cfg = { IndexDocument: 'index.html' };
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME, WebsiteConfiguration: cfg },
+      { BucketName: BUCKET_NAME, WebsiteConfiguration: cfg }
+    );
+    expect(callsOf(PutBucketWebsiteCommand)).toHaveLength(0);
+    expect(callsOf(DeleteBucketWebsiteCommand)).toHaveLength(0);
+  });
+
+  it('WebsiteConfiguration: present -> present (different) fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        WebsiteConfiguration: { IndexDocument: 'main.html' },
+      },
+      {
+        BucketName: BUCKET_NAME,
+        WebsiteConfiguration: { IndexDocument: 'index.html' },
+      }
+    );
+    expect(callsOf(PutBucketWebsiteCommand)).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------
+  // LoggingConfiguration (Put-only — no Delete API; clear via empty Put)
+  // -------------------------------------------------------------------
+
+  it('LoggingConfiguration: absent -> present fires PutBucketLogging', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        LoggingConfiguration: { DestinationBucketName: 'log-bucket', LogFilePrefix: 'logs/' },
+      },
+      { BucketName: BUCKET_NAME }
+    );
+    const calls = callsOf(PutBucketLoggingCommand);
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as { input: { BucketLoggingStatus: { LoggingEnabled: object } } }).input)
+      .toMatchObject({
+        Bucket: BUCKET_NAME,
+        BucketLoggingStatus: {
+          LoggingEnabled: { TargetBucket: 'log-bucket', TargetPrefix: 'logs/' },
+        },
+      });
+  });
+
+  it('LoggingConfiguration: present -> absent fires PutBucketLogging with empty BucketLoggingStatus', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME },
+      {
+        BucketName: BUCKET_NAME,
+        LoggingConfiguration: { DestinationBucketName: 'log-bucket' },
+      }
+    );
+    const calls = callsOf(PutBucketLoggingCommand);
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as { input: { BucketLoggingStatus: object } }).input.BucketLoggingStatus)
+      .toEqual({});
+  });
+
+  it('LoggingConfiguration: unchanged fires no SDK call', async () => {
+    const cfg = { DestinationBucketName: 'log-bucket', LogFilePrefix: 'logs/' };
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME, LoggingConfiguration: cfg },
+      { BucketName: BUCKET_NAME, LoggingConfiguration: cfg }
+    );
+    expect(callsOf(PutBucketLoggingCommand)).toHaveLength(0);
+  });
+
+  it('LoggingConfiguration: present -> present (different prefix) fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        LoggingConfiguration: { DestinationBucketName: 'log-bucket', LogFilePrefix: 'new/' },
+      },
+      {
+        BucketName: BUCKET_NAME,
+        LoggingConfiguration: { DestinationBucketName: 'log-bucket', LogFilePrefix: 'old/' },
+      }
+    );
+    expect(callsOf(PutBucketLoggingCommand)).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------
+  // NotificationConfiguration (Put-only — empty NotificationConfiguration clears)
+  // -------------------------------------------------------------------
+
+  it('NotificationConfiguration: absent -> present fires PutBucketNotificationConfiguration', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        NotificationConfiguration: {
+          TopicConfigurations: [
+            { Topic: 'arn:aws:sns:us-east-1:1:my-topic', Event: 's3:ObjectCreated:*' },
+          ],
+        },
+      },
+      { BucketName: BUCKET_NAME }
+    );
+    expect(callsOf(PutBucketNotificationConfigurationCommand)).toHaveLength(1);
+  });
+
+  it('NotificationConfiguration: present -> absent fires Put with empty NotificationConfiguration', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME },
+      {
+        BucketName: BUCKET_NAME,
+        NotificationConfiguration: {
+          TopicConfigurations: [
+            { Topic: 'arn:aws:sns:us-east-1:1:my-topic', Event: 's3:ObjectCreated:*' },
+          ],
+        },
+      }
+    );
+    const calls = callsOf(PutBucketNotificationConfigurationCommand);
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as { input: { NotificationConfiguration: object } }).input
+      .NotificationConfiguration).toEqual({});
+  });
+
+  it('NotificationConfiguration: unchanged fires no SDK call', async () => {
+    const cfg = {
+      TopicConfigurations: [
+        { Topic: 'arn:aws:sns:us-east-1:1:my-topic', Event: 's3:ObjectCreated:*' },
+      ],
+    };
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME, NotificationConfiguration: cfg },
+      { BucketName: BUCKET_NAME, NotificationConfiguration: cfg }
+    );
+    expect(callsOf(PutBucketNotificationConfigurationCommand)).toHaveLength(0);
+  });
+
+  it('NotificationConfiguration: present -> present (different) fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        NotificationConfiguration: {
+          TopicConfigurations: [
+            { Topic: 'arn:aws:sns:us-east-1:1:other', Event: 's3:ObjectCreated:*' },
+          ],
+        },
+      },
+      {
+        BucketName: BUCKET_NAME,
+        NotificationConfiguration: {
+          TopicConfigurations: [
+            { Topic: 'arn:aws:sns:us-east-1:1:my-topic', Event: 's3:ObjectCreated:*' },
+          ],
+        },
+      }
+    );
+    expect(callsOf(PutBucketNotificationConfigurationCommand)).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------
+  // ReplicationConfiguration (Put + Delete)
+  // -------------------------------------------------------------------
+
+  it('ReplicationConfiguration: absent -> present fires PutBucketReplication', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        ReplicationConfiguration: {
+          Role: 'arn:aws:iam::1:role/repl',
+          Rules: [
+            {
+              Id: 'r1',
+              Status: 'Enabled',
+              Destination: { Bucket: 'arn:aws:s3:::dest-bucket' },
+            },
+          ],
+        },
+      },
+      { BucketName: BUCKET_NAME }
+    );
+    expect(callsOf(PutBucketReplicationCommand)).toHaveLength(1);
+    expect(callsOf(DeleteBucketReplicationCommand)).toHaveLength(0);
+  });
+
+  it('ReplicationConfiguration: present -> absent fires DeleteBucketReplication', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME },
+      {
+        BucketName: BUCKET_NAME,
+        ReplicationConfiguration: {
+          Role: 'arn:aws:iam::1:role/repl',
+          Rules: [
+            {
+              Id: 'r1',
+              Status: 'Enabled',
+              Destination: { Bucket: 'arn:aws:s3:::dest-bucket' },
+            },
+          ],
+        },
+      }
+    );
+    expect(callsOf(DeleteBucketReplicationCommand)).toHaveLength(1);
+    expect(callsOf(PutBucketReplicationCommand)).toHaveLength(0);
+  });
+
+  it('ReplicationConfiguration: unchanged fires no SDK call', async () => {
+    const cfg = {
+      Role: 'arn:aws:iam::1:role/repl',
+      Rules: [
+        {
+          Id: 'r1',
+          Status: 'Enabled',
+          Destination: { Bucket: 'arn:aws:s3:::dest-bucket' },
+        },
+      ],
+    };
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME, ReplicationConfiguration: cfg },
+      { BucketName: BUCKET_NAME, ReplicationConfiguration: cfg }
+    );
+    expect(callsOf(PutBucketReplicationCommand)).toHaveLength(0);
+    expect(callsOf(DeleteBucketReplicationCommand)).toHaveLength(0);
+  });
+
+  it('ReplicationConfiguration: present -> present (different role) fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        ReplicationConfiguration: {
+          Role: 'arn:aws:iam::1:role/repl-v2',
+          Rules: [
+            {
+              Id: 'r1',
+              Status: 'Enabled',
+              Destination: { Bucket: 'arn:aws:s3:::dest-bucket' },
+            },
+          ],
+        },
+      },
+      {
+        BucketName: BUCKET_NAME,
+        ReplicationConfiguration: {
+          Role: 'arn:aws:iam::1:role/repl',
+          Rules: [
+            {
+              Id: 'r1',
+              Status: 'Enabled',
+              Destination: { Bucket: 'arn:aws:s3:::dest-bucket' },
+            },
+          ],
+        },
+      }
+    );
+    expect(callsOf(PutBucketReplicationCommand)).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------
+  // ObjectLockConfiguration (Put-only — clearing fires Put with empty Rule)
+  // -------------------------------------------------------------------
+
+  it('ObjectLockConfiguration: absent -> present fires PutObjectLockConfiguration', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        ObjectLockConfiguration: {
+          ObjectLockEnabled: 'Enabled',
+          Rule: { DefaultRetention: { Mode: 'GOVERNANCE', Days: 30 } },
+        },
+      },
+      { BucketName: BUCKET_NAME }
+    );
+    expect(callsOf(PutObjectLockConfigurationCommand)).toHaveLength(1);
+  });
+
+  it('ObjectLockConfiguration: present -> absent fires Put with bucket-level enable only (clears Rule)', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME },
+      {
+        BucketName: BUCKET_NAME,
+        ObjectLockConfiguration: {
+          ObjectLockEnabled: 'Enabled',
+          Rule: { DefaultRetention: { Mode: 'GOVERNANCE', Days: 30 } },
+        },
+      }
+    );
+    const calls = callsOf(PutObjectLockConfigurationCommand);
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as { input: { ObjectLockConfiguration: object } }).input
+      .ObjectLockConfiguration).toEqual({ ObjectLockEnabled: 'Enabled' });
+  });
+
+  it('ObjectLockConfiguration: unchanged fires no SDK call', async () => {
+    const cfg = {
+      ObjectLockEnabled: 'Enabled',
+      Rule: { DefaultRetention: { Mode: 'GOVERNANCE', Days: 30 } },
+    };
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME, ObjectLockConfiguration: cfg },
+      { BucketName: BUCKET_NAME, ObjectLockConfiguration: cfg }
+    );
+    expect(callsOf(PutObjectLockConfigurationCommand)).toHaveLength(0);
+  });
+
+  it('ObjectLockConfiguration: present -> present (different days) fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        ObjectLockConfiguration: {
+          ObjectLockEnabled: 'Enabled',
+          Rule: { DefaultRetention: { Mode: 'GOVERNANCE', Days: 60 } },
+        },
+      },
+      {
+        BucketName: BUCKET_NAME,
+        ObjectLockConfiguration: {
+          ObjectLockEnabled: 'Enabled',
+          Rule: { DefaultRetention: { Mode: 'GOVERNANCE', Days: 30 } },
+        },
+      }
+    );
+    expect(callsOf(PutObjectLockConfigurationCommand)).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------
+  // AccelerateConfiguration (Put-only — Suspended clears)
+  // -------------------------------------------------------------------
+
+  it('AccelerateConfiguration: absent -> Enabled fires PutBucketAccelerateConfiguration', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        AccelerateConfiguration: { AccelerationStatus: 'Enabled' },
+      },
+      { BucketName: BUCKET_NAME }
+    );
+    expect(callsOf(PutBucketAccelerateConfigurationCommand)).toHaveLength(1);
+  });
+
+  it('AccelerateConfiguration: present -> absent fires Put with Status=Suspended', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME },
+      {
+        BucketName: BUCKET_NAME,
+        AccelerateConfiguration: { AccelerationStatus: 'Enabled' },
+      }
+    );
+    const calls = callsOf(PutBucketAccelerateConfigurationCommand);
+    expect(calls).toHaveLength(1);
+    expect(
+      (calls[0] as { input: { AccelerateConfiguration: { Status: string } } }).input
+        .AccelerateConfiguration.Status
+    ).toBe('Suspended');
+  });
+
+  it('AccelerateConfiguration: unchanged fires no SDK call', async () => {
+    const cfg = { AccelerationStatus: 'Enabled' };
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME, AccelerateConfiguration: cfg },
+      { BucketName: BUCKET_NAME, AccelerateConfiguration: cfg }
+    );
+    expect(callsOf(PutBucketAccelerateConfigurationCommand)).toHaveLength(0);
+  });
+
+  it('AccelerateConfiguration: Enabled -> Suspended fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        AccelerateConfiguration: { AccelerationStatus: 'Suspended' },
+      },
+      {
+        BucketName: BUCKET_NAME,
+        AccelerateConfiguration: { AccelerationStatus: 'Enabled' },
+      }
+    );
+    expect(callsOf(PutBucketAccelerateConfigurationCommand)).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------
+  // MetricsConfigurations[] — per-id diff
+  // -------------------------------------------------------------------
+
+  it('MetricsConfigurations: new id fires Put for that id', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        MetricsConfigurations: [{ Id: 'm1' }],
+      },
+      { BucketName: BUCKET_NAME }
+    );
+    const calls = callsOf(PutBucketMetricsConfigurationCommand);
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as { input: { Id: string } }).input.Id).toBe('m1');
+    expect(callsOf(DeleteBucketMetricsConfigurationCommand)).toHaveLength(0);
+  });
+
+  it('MetricsConfigurations: removed id fires Delete for that id', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME },
+      {
+        BucketName: BUCKET_NAME,
+        MetricsConfigurations: [{ Id: 'm1' }],
+      }
+    );
+    const calls = callsOf(DeleteBucketMetricsConfigurationCommand);
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as { input: { Id: string } }).input.Id).toBe('m1');
+    expect(callsOf(PutBucketMetricsConfigurationCommand)).toHaveLength(0);
+  });
+
+  it('MetricsConfigurations: changed body for same id fires Put (overwrites)', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        MetricsConfigurations: [{ Id: 'm1', Prefix: 'docs/' }],
+      },
+      {
+        BucketName: BUCKET_NAME,
+        MetricsConfigurations: [{ Id: 'm1', Prefix: 'images/' }],
+      }
+    );
+    expect(callsOf(PutBucketMetricsConfigurationCommand)).toHaveLength(1);
+    expect(callsOf(DeleteBucketMetricsConfigurationCommand)).toHaveLength(0);
+  });
+
+  it('MetricsConfigurations: mixed add/remove/unchanged fires expected calls', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        MetricsConfigurations: [
+          { Id: 'kept', Prefix: 'a/' },
+          { Id: 'added', Prefix: 'b/' },
+        ],
+      },
+      {
+        BucketName: BUCKET_NAME,
+        MetricsConfigurations: [
+          { Id: 'kept', Prefix: 'a/' },
+          { Id: 'removed', Prefix: 'c/' },
+        ],
+      }
+    );
+
+    const puts = callsOf(PutBucketMetricsConfigurationCommand);
+    const deletes = callsOf(DeleteBucketMetricsConfigurationCommand);
+    expect(puts).toHaveLength(1);
+    expect(deletes).toHaveLength(1);
+    expect((puts[0] as { input: { Id: string } }).input.Id).toBe('added');
+    expect((deletes[0] as { input: { Id: string } }).input.Id).toBe('removed');
+  });
+
+  // -------------------------------------------------------------------
+  // AnalyticsConfigurations[] — per-id diff
+  // -------------------------------------------------------------------
+
+  it('AnalyticsConfigurations: new id fires Put for that id', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        AnalyticsConfigurations: [{ Id: 'a1' }],
+      },
+      { BucketName: BUCKET_NAME }
+    );
+    expect(callsOf(PutBucketAnalyticsConfigurationCommand)).toHaveLength(1);
+    expect(callsOf(DeleteBucketAnalyticsConfigurationCommand)).toHaveLength(0);
+  });
+
+  it('AnalyticsConfigurations: removed id fires Delete', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME },
+      {
+        BucketName: BUCKET_NAME,
+        AnalyticsConfigurations: [{ Id: 'a1' }],
+      }
+    );
+    expect(callsOf(DeleteBucketAnalyticsConfigurationCommand)).toHaveLength(1);
+  });
+
+  it('AnalyticsConfigurations: changed body for same id fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        AnalyticsConfigurations: [{ Id: 'a1', Prefix: 'after/' }],
+      },
+      {
+        BucketName: BUCKET_NAME,
+        AnalyticsConfigurations: [{ Id: 'a1', Prefix: 'before/' }],
+      }
+    );
+    expect(callsOf(PutBucketAnalyticsConfigurationCommand)).toHaveLength(1);
+  });
+
+  it('AnalyticsConfigurations: mixed add/remove/unchanged fires expected calls', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        AnalyticsConfigurations: [
+          { Id: 'kept' },
+          { Id: 'added' },
+        ],
+      },
+      {
+        BucketName: BUCKET_NAME,
+        AnalyticsConfigurations: [
+          { Id: 'kept' },
+          { Id: 'removed' },
+        ],
+      }
+    );
+    expect(callsOf(PutBucketAnalyticsConfigurationCommand)).toHaveLength(1);
+    expect(callsOf(DeleteBucketAnalyticsConfigurationCommand)).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------
+  // IntelligentTieringConfigurations[] — per-id diff
+  // -------------------------------------------------------------------
+
+  it('IntelligentTieringConfigurations: new id fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        IntelligentTieringConfigurations: [
+          { Id: 'it1', Tierings: [{ AccessTier: 'ARCHIVE_ACCESS', Days: 90 }] },
+        ],
+      },
+      { BucketName: BUCKET_NAME }
+    );
+    expect(callsOf(PutBucketIntelligentTieringConfigurationCommand)).toHaveLength(1);
+  });
+
+  it('IntelligentTieringConfigurations: removed id fires Delete', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME },
+      {
+        BucketName: BUCKET_NAME,
+        IntelligentTieringConfigurations: [
+          { Id: 'it1', Tierings: [{ AccessTier: 'ARCHIVE_ACCESS', Days: 90 }] },
+        ],
+      }
+    );
+    expect(callsOf(DeleteBucketIntelligentTieringConfigurationCommand)).toHaveLength(1);
+  });
+
+  it('IntelligentTieringConfigurations: changed Tierings.Days for same id fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        IntelligentTieringConfigurations: [
+          { Id: 'it1', Tierings: [{ AccessTier: 'ARCHIVE_ACCESS', Days: 180 }] },
+        ],
+      },
+      {
+        BucketName: BUCKET_NAME,
+        IntelligentTieringConfigurations: [
+          { Id: 'it1', Tierings: [{ AccessTier: 'ARCHIVE_ACCESS', Days: 90 }] },
+        ],
+      }
+    );
+    expect(callsOf(PutBucketIntelligentTieringConfigurationCommand)).toHaveLength(1);
+  });
+
+  it('IntelligentTieringConfigurations: mixed add/remove/unchanged fires expected calls', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        IntelligentTieringConfigurations: [
+          { Id: 'kept', Tierings: [{ AccessTier: 'ARCHIVE_ACCESS', Days: 90 }] },
+          { Id: 'added', Tierings: [{ AccessTier: 'DEEP_ARCHIVE_ACCESS', Days: 180 }] },
+        ],
+      },
+      {
+        BucketName: BUCKET_NAME,
+        IntelligentTieringConfigurations: [
+          { Id: 'kept', Tierings: [{ AccessTier: 'ARCHIVE_ACCESS', Days: 90 }] },
+          { Id: 'removed', Tierings: [{ AccessTier: 'ARCHIVE_ACCESS', Days: 90 }] },
+        ],
+      }
+    );
+    expect(callsOf(PutBucketIntelligentTieringConfigurationCommand)).toHaveLength(1);
+    expect(callsOf(DeleteBucketIntelligentTieringConfigurationCommand)).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------
+  // InventoryConfigurations[] — per-id diff
+  // -------------------------------------------------------------------
+
+  it('InventoryConfigurations: new id fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        InventoryConfigurations: [
+          {
+            Id: 'inv1',
+            Destination: { BucketArn: 'arn:aws:s3:::inv-bucket', Format: 'CSV' },
+            ScheduleFrequency: 'Weekly',
+          },
+        ],
+      },
+      { BucketName: BUCKET_NAME }
+    );
+    expect(callsOf(PutBucketInventoryConfigurationCommand)).toHaveLength(1);
+  });
+
+  it('InventoryConfigurations: removed id fires Delete', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      { BucketName: BUCKET_NAME },
+      {
+        BucketName: BUCKET_NAME,
+        InventoryConfigurations: [
+          {
+            Id: 'inv1',
+            Destination: { BucketArn: 'arn:aws:s3:::inv-bucket', Format: 'CSV' },
+            ScheduleFrequency: 'Weekly',
+          },
+        ],
+      }
+    );
+    expect(callsOf(DeleteBucketInventoryConfigurationCommand)).toHaveLength(1);
+  });
+
+  it('InventoryConfigurations: changed body for same id fires Put', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        InventoryConfigurations: [
+          {
+            Id: 'inv1',
+            Destination: { BucketArn: 'arn:aws:s3:::inv-bucket', Format: 'CSV' },
+            ScheduleFrequency: 'Daily',
+          },
+        ],
+      },
+      {
+        BucketName: BUCKET_NAME,
+        InventoryConfigurations: [
+          {
+            Id: 'inv1',
+            Destination: { BucketArn: 'arn:aws:s3:::inv-bucket', Format: 'CSV' },
+            ScheduleFrequency: 'Weekly',
+          },
+        ],
+      }
+    );
+    expect(callsOf(PutBucketInventoryConfigurationCommand)).toHaveLength(1);
+  });
+
+  it('InventoryConfigurations: mixed add/remove/unchanged fires expected calls', async () => {
+    await provider.update(
+      'L',
+      BUCKET_NAME,
+      'AWS::S3::Bucket',
+      {
+        BucketName: BUCKET_NAME,
+        InventoryConfigurations: [
+          {
+            Id: 'kept',
+            Destination: { BucketArn: 'arn:aws:s3:::inv-bucket', Format: 'CSV' },
+            ScheduleFrequency: 'Weekly',
+          },
+          {
+            Id: 'added',
+            Destination: { BucketArn: 'arn:aws:s3:::inv-bucket', Format: 'Parquet' },
+            ScheduleFrequency: 'Daily',
+          },
+        ],
+      },
+      {
+        BucketName: BUCKET_NAME,
+        InventoryConfigurations: [
+          {
+            Id: 'kept',
+            Destination: { BucketArn: 'arn:aws:s3:::inv-bucket', Format: 'CSV' },
+            ScheduleFrequency: 'Weekly',
+          },
+          {
+            Id: 'removed',
+            Destination: { BucketArn: 'arn:aws:s3:::inv-bucket', Format: 'CSV' },
+            ScheduleFrequency: 'Weekly',
+          },
+        ],
+      }
+    );
+    expect(callsOf(PutBucketInventoryConfigurationCommand)).toHaveLength(1);
+    expect(callsOf(DeleteBucketInventoryConfigurationCommand)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Closes the deferred test coverage from #214 and #215 in a single follow-up
PR. Adds 108 new unit-test cases across 5 files; the full test suite grows
from 221 files / 2260 tests to 225 files / 2368 tests.

### #214 — 4 new test files (60 cases) for the new Glue providers

| File | Cases | Provider |
| --- | --- | --- |
| `tests/unit/provisioning/glue-job-roundtrip.test.ts` | 16 | `GlueJobProvider` |
| `tests/unit/provisioning/glue-crawler-roundtrip.test.ts` | 15 | `GlueCrawlerProvider` |
| `tests/unit/provisioning/glue-connection-roundtrip.test.ts` | 14 | `GlueConnectionProvider` |
| `tests/unit/provisioning/glue-trigger-roundtrip.test.ts` | 15 | `GlueTriggerProvider` |

Each suite covers the standard surface — `create()` happy-path + missing-required-field guards, `update()` field forwarding (incl. drift `--revert` empty-placeholder round-trip per `feedback_update_optional_field_undefined_check.md`), `delete()` happy-path + `EntityNotFoundException` idempotency, `getAttribute()` for `Id` / `Ref` / `Name`, `readCurrentState()` PR #145 always-emit placeholders + populated-AWS values + `EntityNotFoundException` -> `undefined` + `GetTags` failure fallback, plus `handledProperties` shape assertion.

Trigger-specific extras:
- `update()` ACTIVATED -> DEACTIVATED -> UPDATE -> ACTIVATED (Stop -> Update -> Start) state-machine ordering
- `update()` DEACTIVATED -> just Update (no Stop / Start)

Crawler-specific extras:
- Bare-string `Schedule` accepted in addition to the CFn `{ ScheduleExpression: ... }` shape
- `startSchedule()` / `stopSchedule()` SDK call sanity

### #215 — 49 new cases extending `s3-bucket-provider-roundtrip.test.ts`

Covers all 12 sub-configs that PR #215 wired through `applySubConfigDiffs`. For each non-array sub-config (8 types):

- absent -> present: fires `Put*Command`
- present -> absent: fires `Delete*Command`, OR `Put*Command` with cleared body for the 4 APIs that have no Delete counterpart (Logging / Notification / ObjectLock / Accelerate)
- unchanged: no SDK call
- present -> present (different): fires `Put*Command`

For the 4 array-shaped sub-configs (Metrics / Analytics / IntelligentTiering / Inventory) — per-`Id` diff:

- new id: `Put` for that id
- removed id: `Delete` for that id
- changed body for same id: `Put` (overwrites)
- mixed (added + removed + unchanged): expected `Put` + `Delete` calls

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `npx vitest --run` — 225 files / 2368 tests pass
