### PR TITLE
docs(supported-resources,import): add 7 new SDK provider entries from v2 push

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -272,7 +272,14 @@ template's logical id, and adopts it. Works under `auto` (default) and
 - AWS::StepFunctions::StateMachine
 - AWS::Glue::Database
 - AWS::Glue::Table
+- AWS::Glue::Job
+- AWS::Glue::Crawler
+- AWS::Glue::Connection
+- AWS::Glue::Trigger
+- AWS::Glue::Workflow
+- AWS::Glue::SecurityConfiguration
 - AWS::Kinesis::Stream
+- AWS::Kinesis::StreamConsumer
 - AWS::KinesisFirehose::DeliveryStream
 - AWS::WAFv2::WebACL
 - AWS::EFS::FileSystem

--- a/docs/supported-resources.md
+++ b/docs/supported-resources.md
@@ -108,9 +108,16 @@ message naming the unsupported type.
 | **GraphQL** | AWS::AppSync::ApiKey | SDK Provider | ✅ |
 | **Analytics** | AWS::Glue::Database | SDK Provider | ✅ |
 | **Analytics** | AWS::Glue::Table | SDK Provider | ✅ |
+| **Analytics** | AWS::Glue::Job | SDK Provider | ✅ |
+| **Analytics** | AWS::Glue::Crawler | SDK Provider | ✅ |
+| **Analytics** | AWS::Glue::Connection | SDK Provider | ✅ |
+| **Analytics** | AWS::Glue::Trigger | SDK Provider | ✅ |
+| **Analytics** | AWS::Glue::Workflow | SDK Provider | ✅ |
+| **Analytics** | AWS::Glue::SecurityConfiguration | SDK Provider | ✅ |
 | **Encryption** | AWS::KMS::Key | SDK Provider | ✅ |
 | **Encryption** | AWS::KMS::Alias | SDK Provider | ✅ |
 | **Streaming** | AWS::Kinesis::Stream | SDK Provider | ✅ |
+| **Streaming** | AWS::Kinesis::StreamConsumer | SDK Provider | ✅ |
 | **Streaming** | AWS::KinesisFirehose::DeliveryStream | SDK Provider | ✅ |
 | **Storage** | AWS::EFS::FileSystem | SDK Provider | ✅ |
 | **Storage** | AWS::EFS::MountTarget | SDK Provider | ✅ |


### PR DESCRIPTION
## Summary

Closes the docs gap for the v2 drift coverage push (#210-#216, v0.61.0 → v0.65.0).

Per CLAUDE.md "Adding a New SDK Provider" rule 5: every new SDK provider must add an entry to **both** `docs/supported-resources.md` (deploy/manage capability table) and `docs/import.md` (import-side coverage). The 7 PRs added 7 new resource types but missed both files.

## Added entries

| Type | Section | PR |
|---|---|---|
| `AWS::Glue::Job` | Auto-lookup | #214 |
| `AWS::Glue::Crawler` | Auto-lookup | #214 |
| `AWS::Glue::Connection` | Auto-lookup | #214 |
| `AWS::Glue::Trigger` | Auto-lookup | #214 |
| `AWS::Glue::Workflow` | Auto-lookup | #213 |
| `AWS::Glue::SecurityConfiguration` | Auto-lookup | #213 |
| `AWS::Kinesis::StreamConsumer` | Auto-lookup | #212 |

All 7 are SDK Provider with auto-lookup via `aws:cdk:path` tag (matches the rest of the Auto-lookup section's pattern in `docs/import.md`).

## README.md

Intentionally left unchanged — its provider description is abstract (`90+ dedicated SDK Providers`) and not a per-type enumeration.

## Test plan

- [x] `pnpm run typecheck` — clean (docs only)
- [x] markgate `check` + `docs` set
