### PR TITLE
chore: bump markgate to 0.3.3 (config lint mirrors runtime)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,2 @@
 [tools]
-"ubi:go-to-k/markgate" = "0.3.2"
+"ubi:go-to-k/markgate" = "0.3.3"


### PR DESCRIPTION
## Summary

Bump markgate pin from `0.3.2` → `0.3.3`.

`v0.3.3` is a fix release ([markgate#48](https://github.com/go-to-k/markgate/pull/48)): `markgate config lint` now mirrors `markgate run`'s runtime validation, so configs the runtime would reject at exit 2 (undeclared `composes` / `requires` refs, `hash: files` without `include`, malformed `ttl`, gate cycles, both `composes` and `requires` set, etc.) are now caught at lint time too.

## Why this is a one-line PR

- **No breaking changes for cdkd.** The YAML schema (`requires` / `ttl` / `hash: files`) is unchanged between 0.3.2 and 0.3.3.
- **cdkd's `.markgate.yml` already passes the new strict lint.** Verified locally with `markgate config lint` against the 0.3.3 binary (exit 0, no findings). Every gate already has a sane shape — `requires: [check, docs]` references declared gates, no cycles, all `hash: files` gates have an `include`, `ttl: 14d` is a well-formed duration.
- No companion code or doc changes needed. CLAUDE.md text "markgate 0.3+ feature" remains accurate.

## Test plan

- [x] `pnpm run typecheck` (exit 0)
- [x] `pnpm run lint` (exit 0)
- [x] `pnpm run build` (exit 0)
- [x] `npx vitest --run` (225 files, 2368 tests, all pass — same surface as #222, no test changes)
- [x] `markgate config lint` against `.markgate.yml` on the 0.3.3 binary (exit 0)
- [x] `mise install` resolves and installs `0.3.3` from ubi
