### PR TITLE
chore: gitignore .claude/worktrees/ + open backlog issue for deferred minor/nit items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ tests/benchmark/results-*.md
 
 # Claude Code runtime state
 .claude/scheduled_tasks.lock
+.claude/worktrees/


### PR DESCRIPTION
## Summary

Two small repo-config chores landing together:

1. **`.gitignore`**: add `.claude/worktrees/` so claude runtime sub-agent
   worktree checkouts cannot be swept into commits via `git add -A`.
   This caused a real slip in an earlier session where the directories
   were captured as gitlinks and recovery required `git reset --soft`.
   Grouped under the existing `# Claude Code runtime state` section
   alongside `.claude/scheduled_tasks.lock`.
2. **Backlog issue**: opened a GitHub issue (#241) to track the
   minor/nit items deferred across the 224 follow-up PR series
   (237 / 238 / 239) per the "in-scope polish" rule, so they don't
   fall off the radar.

## Test plan

- [x] `git check-ignore -v .claude/worktrees/agent-*/` resolves to
      line 46 of `.gitignore`
- [x] `git status` no longer lists `.claude/worktrees/` as untracked
- [x] All 2736 unit tests pass
- [x] No source / docs changes; check-docs short-circuits

Refs: #224
