### PR TITLE
chore(.claude): /review-pr skill for size-based reviewer-count recommendation

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: review-pr
+description: Recommend the right reviewer count for a PR based on size + bias factors. Outputs a concrete plan (inline spot-check / 1 reviewer / 3-axis parallel) plus ready-to-paste Agent dispatch prompts when reviewers are warranted.
+argument-hint: "<PR-number>"
+---
+
+# PR Review Recommendation
+
+Decide how much review rigor a PR actually warrants — and surface the dispatch prompts for the orchestrator to copy-paste. Running all 3 reviewer agents on every PR is expensive (~25 min) and drains attention; running none on a large security-sensitive PR misses bugs. This skill applies the heuristic codified in `~/.claude/projects/-Users-goto-pc-github-cdkd/memory/feedback_pr_review_scale_rule.md`.
+
+The skill itself never spawns reviewers. It reads PR stats, applies the heuristic, and prints a recommendation. The **main session orchestrator** (the parent reading this skill's output) is responsible for actually issuing the `Agent` tool calls when the recommendation says to.
+
+## Inputs
+
+- **Required**: PR number (positional). Example: `/review-pr 237`.
+
+## Steps
+
+1. **Fetch PR stats** via `gh`:
+
+   ```bash
+   gh pr view <N> --json additions,deletions,changedFiles,title,headRefName,files \
+     -q '{a: .additions, d: .deletions, fc: .changedFiles, title: .title, branch: .headRefName, paths: [.files[].path]}'
+   ```
+
+   Record: `additions` (`a`), `deletions` (`d`), `changedFiles` (`fc`), `title`, `branch`, list of file `paths`.
+
+   Compute `loc = a + d`.
+
+2. **Determine the base tier** from `(loc, fc)` per the heuristic:
+
+   | Condition | Base tier |
+   |-----------|-----------|
+   | `loc < 300` OR `fc < 5` | **inline** (inline spot-check by the orchestrator) |
+   | `300 <= loc < 1000` AND `5 <= fc < 10` | **1-reviewer** (single code-quality pass) |
+   | `loc >= 1000` OR `fc >= 10` | **3-axis** (spec + code + test in parallel) |
+
+   The two boundary conditions overlap intentionally — a 200-LOC / 12-file PR triggers 3-axis via the file count even though LOC is small (a 12-file diff has cross-cutting risk regardless of LOC), and a 5000-LOC / 3-file PR triggers 3-axis via LOC (rare in practice but covered).
+
+3. **Compute bias factors** by scanning the `paths` list:
+
+   **Up-bias triggers** (move tier UP by one step, never above 3-axis):
+
+   - Any path matches **security / process-launch surface**:
+     - `src/utils/role-arn.ts`
+     - `src/local/cognito-jwt.ts`
+     - `src/local/lambda-authorizer.ts`
+     - `src/local/docker-runner.ts`
+     - `src/local-invoke/docker-runner.ts`
+     - `src/local/docker-image-builder.ts`
+     - `src/local/ecr-puller.ts`
+   - Any path under `src/provisioning/providers/**` (deletion-sensitive — within the `integ-destroy` markgate scope; real-AWS regressions cost cleanup time)
+   - Branch has > 1 fix-back commit (heuristic for "multiple sub-agents wrote the diff" — count commits whose message starts with `fix:` / `fix(` via `git log main..<branch> --oneline | grep -cE '^[a-f0-9]+ fix(\(|:)'`)
+
+   **Down-bias triggers** (move tier DOWN by one step, never below inline) — only fires when ALL paths fall in the listed buckets:
+
+   - **Pure docs/infra**: every path matches one of `.gitignore`, `CLAUDE.md`, `README.md`, `docs/**`, `.claude/skills/**`, `.claude/agents/**`, `.claude/hooks/**`, `.markgate.yml`, `package.json` (top-level deps only — count as docs-ish for review purposes when the diff is dep bumps)
+   - **Test-only**: every path matches `tests/**`
+
+   If both up- and down-bias triggers fire (e.g. a tests-only diff that touches a security-sensitive provider's test file), prefer up-bias — security wins.
+
+4. **Apply the bias** to compute the final tier:
+
+   - `inline` + up → `1-reviewer`
+   - `1-reviewer` + up → `3-axis`
+   - `3-axis` + up → `3-axis` (clamp)
+   - `3-axis` + down → `1-reviewer`
+   - `1-reviewer` + down → `inline`
+   - `inline` + down → `inline` (clamp)
+
+5. **Render the recommendation** in the format below.
+
+## Output template
+
+```
+Recommendation: <inline | 1-reviewer | 3-axis>
+
+PR #<N>: <title>
+Stats: +<additions> / -<deletions> = <loc> LOC, <fc> files
+Branch: <branch>
+
+Base tier (from stats): <base>
+Bias factors:
+  - <factor 1, or "none">
+  - <factor 2>
+Applied bias: <up / down / none>
+Final tier: <final>
+
+Rationale: <one line — e.g. "Small infra-only diff; orchestrator can spot-check in 5 min." / "Touches src/local/cognito-jwt.ts (credential surface), bumps base tier up.">
+```
+
+Then, **if final tier is `1-reviewer`**, emit:
+
+```
+Dispatch this single reviewer (run via Agent tool in the main session):
+
+  Agent {
+    subagent_type: "general-purpose",
+    description: "PR <N> code review",
+    prompt: |
+      Read your role definition at `/Users/goto/pc/github/cdkd/.claude/agents/pr-code-reviewer.md` and follow it.
+      Inputs:
+      - PR number: <N>
+      - Branch: <branch>
+  }
+```
+
+**If final tier is `3-axis`**, emit:
+
+```
+Dispatch these three reviewers IN PARALLEL (single message, three Agent tool calls):
+
+  Agent {
+    subagent_type: "general-purpose",
+    description: "PR <N> spec compliance review",
+    prompt: |
+      Read your role definition at `/Users/goto/pc/github/cdkd/.claude/agents/pr-spec-reviewer.md` and follow it.
+      Inputs:
+      - PR number: <N>
+      - Branch: <branch>
+      - Design doc: <ASK THE USER — the orchestrator should fill this in before dispatching; spec review is meaningless without a design doc to compare against. If no design doc exists for this PR, downgrade to 1-reviewer instead.>
+  }
+
+  Agent {
+    subagent_type: "general-purpose",
+    description: "PR <N> code review",
+    prompt: |
+      Read your role definition at `/Users/goto/pc/github/cdkd/.claude/agents/pr-code-reviewer.md` and follow it.
+      Inputs:
+      - PR number: <N>
+      - Branch: <branch>
+  }
+
+  Agent {
+    subagent_type: "general-purpose",
+    description: "PR <N> test adequacy review",
+    prompt: |
+      Read your role definition at `/Users/goto/pc/github/cdkd/.claude/agents/pr-test-reviewer.md` and follow it.
+      Inputs:
+      - PR number: <N>
+      - Branch: <branch>
+  }
+```
+
+**If final tier is `inline`**, emit:
+
+```
+No reviewer dispatch — orchestrator should spot-check inline:
+
+  - `gh pr diff <N>` — read the full diff in one pass
+  - For each changed file, ask: is it correct, complete, necessary?
+  - Estimated time: 5 min
+
+If during the inline read you discover a non-obvious bug class (cross-cutting state machine, race, security-sensitive logic), STOP and re-run /review-pr <N> after manually adding the file path to the up-bias trigger list locally, or just dispatch a code reviewer by hand.
+```
+
+## Important
+
+- **Never auto-dispatch** the Agent tool from inside this skill. Skills run in the main conversation; this skill's job is to *recommend*, the orchestrator's job is to *act*.
+- The orchestrator can extend each reviewer prompt with PR-specific context (concerns to deep-dive, design doc path for spec-reviewer, files to focus on). Treat the dispatch blocks as starting templates, not final prompts.
+- For 3-axis dispatches: the spec reviewer needs a design doc path. If no design doc exists for the PR (small features, bug fixes, refactors), downgrade to 1-reviewer rather than dispatching spec-reviewer with no inputs.
+- Thresholds are heuristics, not laws. When in doubt, ask: "would I be comfortable spot-checking this in 5 minutes?" — if yes, inline; if no, dispatch.
+- For an honest reading of the trade-off, see `~/.claude/projects/-Users-goto-pc-github-cdkd/memory/feedback_pr_review_scale_rule.md`.
+
+## Dry-run reference (sanity check)
+
+These three PRs are the calibration set. Running this skill against them should produce:
+
+| PR | Stats | Base tier | Bias | Final |
+|----|-------|-----------|------|-------|
+| #240 | 390 LOC, 4 files (`.claude/hooks/*`, `CLAUDE.md`, `.claude/settings.json`) | inline (fc < 5) | down (pure infra) → clamps at inline | **inline** |
+| #237 | 4515 LOC, 24 files (incl. `src/local/cognito-jwt.ts`, `lambda-authorizer.ts`) | 3-axis (loc >= 1000 AND fc >= 10) | up (security surface) → clamps at 3-axis | **3-axis** |
+| #236 | 269 LOC, 9 files (incl. `src/local/docker-image-builder.ts`, `ecr-puller.ts`) | inline (loc < 300) | up (process-launch surface) → 1-reviewer | **1-reviewer** |
+
+If the skill output diverges from these, the heuristic or the trigger lists have drifted — re-read this file and the linked memory entry before trusting the recommendation.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -54,7 +54,7 @@ The skill itself never spawns reviewers. It reads PR stats, applies the heuristi
 
    **Down-bias triggers** (move tier DOWN by one step, never below inline) — only fires when ALL paths fall in the listed buckets:
 
-   - **Pure docs/infra**: every path matches one of `.gitignore`, `CLAUDE.md`, `README.md`, `docs/**`, `.claude/skills/**`, `.claude/agents/**`, `.claude/hooks/**`, `.markgate.yml`, `package.json` (top-level deps only — count as docs-ish for review purposes when the diff is dep bumps)
+   - **Pure docs/infra**: every path matches one of `.gitignore`, `CLAUDE.md`, `README.md`, `docs/**`, `.claude/skills/**`, `.claude/agents/**`, `.claude/hooks/**`, `.claude/settings*.json`, `.markgate.yml`, `package.json` (top-level deps only — count as docs-ish for review purposes when the diff is dep bumps)
    - **Test-only**: every path matches `tests/**`
 
    If both up- and down-bias triggers fire (e.g. a tests-only diff that touches a security-sensitive provider's test file), prefer up-bias — security wins.


### PR DESCRIPTION
## Summary

Codify the PR review-rigor-by-size heuristic from `feedback_pr_review_scale_rule.md` as a runnable skill at `.claude/skills/review-pr/SKILL.md`.

- Take a PR number, fetch stats via `gh pr view`, output one of three recommendations: inline spot-check / 1 reviewer / 3-axis parallel.
- Compute the base tier from `loc` and `changedFiles`; apply up-bias for security / process-launch / deletion-sensitive surfaces; apply down-bias for pure docs/infra or test-only diffs.
- For 1-reviewer and 3-axis outputs, emit ready-to-paste Agent dispatch prompts pointing at the existing `.claude/agents/pr-{spec,code,test}-reviewer.md` role files. The skill never auto-dispatches; the main session orchestrator copies the prompts into Agent tool calls.
- Skill body embeds a dry-run reference table calibrated against PRs 240 (inline / 390 LOC pure infra), 237 (3-axis / 4515 LOC auth surface), 236 (1-reviewer / 269 LOC process-launch surface) so future drift surfaces on the next read of the skill.

No source / test / doc changes — pure infrastructure under `.claude/skills/**`.

The companion CLAUDE.md prose documenting the same rule is in a parallel branch `chore/document-pr-review-scale-rule` to avoid a merge conflict on the same paragraph.

## Test plan

- [x] Manual heuristic dry-run against PR 240 → inline (matches expected)
- [x] Manual heuristic dry-run against PR 237 → 3-axis (matches expected)
- [x] Manual heuristic dry-run against PR 236 → 1-reviewer (matches expected)
- [x] /check (typecheck, lint, build, 2736 tests) green
- [x] /check-docs short-circuit (no docs-visible surface touched)
- [x] /verify-pr full checklist (live-test recorded as the dry-run table above)
