### PR TITLE
fix(local): HTTP API v2 --stage override + Layer resolver string-form + cpSync mode-preservation comment (closes 3 items in 241)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1153,12 +1153,15 @@ that case.
 - **`--stage <name>`**: select a Stage by `StageName`. Applied per-API
   — a `--stage prod` override against an app with three APIs picks
   the matching Stage on each. APIs without a matching Stage get
-  `stageVariables: null` and surface a warn line at startup. For
-  REST v1 routes, the selected stage name is also threaded into
-  `event.requestContext.stage`. For HTTP API v2 routes, the flag
-  drives `event.stageVariables` only — `event.requestContext.stage`
-  is always `'$default'` (AWS-side limitation: HTTP API only exposes
-  one stage to the integration event).
+  `stageVariables: null` and surface a warn line at startup. The
+  resolved stage name is threaded into `event.requestContext.stage`
+  for **both** REST v1 and HTTP API v2 routes. AWS supports named
+  stages on HTTP API v2 (`CreateStage` accepts any name; `$default`
+  is the auto-deploy default but not the only option), so a v2
+  template that pins a named Stage gets that name surfaced through
+  the integration event — matching what the deployed endpoint would
+  emit. v2 APIs without a templated Stage continue to use
+  `'$default'`.
 - **Function URL** routes don't have a Stage — `stageVariables` stays
   `null` regardless of the flag.
 - **Intrinsic-valued entries** (`Ref`, `Fn::GetAtt`, `Fn::Sub`) in

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -571,6 +571,29 @@ export function materializeLambdaLayers(layers: { logicalId: string; assetPath: 
     // makes later layers overwrite earlier ones — the load-bearing
     // half of AWS's "last layer wins" semantic. cpSync merges into the
     // existing target rather than replacing it.
+    //
+    // **Contract pinned (Node 20+)**: cdkd relies on three default
+    // behaviors of `fs.cpSync` that future readers should NOT change
+    // without auditing every Lambda Layer the integ test exercises:
+    //   - `mode` defaults to preserving the source's file-mode bits,
+    //     including the `+x` execute bit. AWS layers commonly ship
+    //     executable scripts under `bin/` (e.g. layer-version shipped
+    //     binaries, the Python `bin/python` shim) and a Lambda handler
+    //     that runs `bin/<script>` from `/opt` would fail with a bare
+    //     "Permission denied" otherwise. Equivalent to `cp -a` semantics
+    //     for the bits Lambda actually cares about.
+    //   - `verbatimSymlinks` defaults to true on Node 20+; symlinks in
+    //     the source are copied as symlinks (not dereferenced), which
+    //     matches how AWS extracts a layer ZIP into `/opt`. Some build
+    //     tools emit symlinks inside the layer asset directory and we
+    //     don't want to silently flatten them.
+    //   - `force: true` (above) makes a later layer's entry overwrite
+    //     the previous layer's same-path entry; mirrors AWS's
+    //     last-layer-wins file-collision rule.
+    // The first two are Node 20+ defaults and require no explicit flag;
+    // we document them here so a future "tighten the cpSync options"
+    // refactor doesn't accidentally drop the `+x` bit or dereference
+    // symlinks and silently break `/opt/bin/...` layers in the field.
     cpSync(layer.assetPath, tmpDir, { recursive: true, force: true });
   }
   return {

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -805,6 +805,25 @@ function materializeLambdaLayers(
   if (layers.length === 1) return layers[0]!.assetPath;
   const dir = mkdtempSync(path.join(tmpdir(), 'cdkd-local-start-api-layers-'));
   for (const layer of layers) {
+    // `recursive: true` enables the directory copy. `force: true`
+    // implements AWS's "last layer wins" file-collision semantic: a
+    // later layer's entry at the same relative path overwrites the
+    // earlier one.
+    //
+    // **Contract pinned (Node 20+)**: this call relies on `fs.cpSync`
+    // defaults that the integ-test fixture (`tests/integration/local-
+    // invoke-layers/`) exercises end-to-end, and that future
+    // refactors must NOT silently drop:
+    //   - `mode` defaults to preserving the source's file-mode bits,
+    //     including `+x`. AWS layers commonly ship executable scripts
+    //     under `bin/` and a handler that runs `/opt/bin/<script>`
+    //     would otherwise fail with "Permission denied".
+    //   - `verbatimSymlinks` defaults to true on Node 20+; symlinks
+    //     are copied as symlinks (not dereferenced), matching AWS's
+    //     layer-ZIP extraction into `/opt`.
+    // Mirrors the same contract pinned in `local-invoke.ts`'s
+    // `materializeLambdaLayers`; keep the two call sites in sync if
+    // they ever consolidate into one helper.
     cpSync(layer.assetPath, dir, { recursive: true, force: true });
   }
   layerTmpDirs.add(dir);

--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -599,10 +599,20 @@ export function resolveLambdaLayers(
  * Walk a single Layers-array entry and return the referenced layer's
  * logical ID — or `undefined` for shapes we don't try to resolve in v1.
  *
- * Accepted shapes (what CDK actually synthesizes):
+ * Accepted shapes (what CDK actually synthesizes — JSON-only):
  *   - `{Ref: '<LayerLogicalId>'}`
  *   - `{Fn::GetAtt: ['<LayerLogicalId>', 'Ref']}` (rare; LayerVersion's
  *     Ref form is usually emitted as a flat `Ref`)
+ *
+ * Intentionally **rejected**: the YAML-only string form
+ * `{Fn::GetAtt: '<LogicalId>.<attr>'}`. CloudFormation YAML accepts the
+ * dot-shorthand and converts it to the array form on the wire, but
+ * CloudFormation JSON (the output of `cdk synth`, which is the only
+ * thing cdkd ingests) never emits the string form. Treating it as
+ * resolvable here would silently accept hand-edited / malformed templates
+ * that no real CDK flow can produce; instead we fall through to the
+ * standard "cdkd cannot resolve this Layers entry locally" error so the
+ * user sees the offending shape called out.
  */
 function pickLayerLogicalId(entry: unknown): string | undefined {
   if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) return undefined;
@@ -611,7 +621,9 @@ function pickLayerLogicalId(entry: unknown): string | undefined {
   if ('Fn::GetAtt' in obj) {
     const arg = obj['Fn::GetAtt'];
     if (Array.isArray(arg) && typeof arg[0] === 'string') return arg[0];
-    if (typeof arg === 'string') return arg.split('.')[0];
+    // Deliberately not: `if (typeof arg === 'string') return arg.split('.')[0]`.
+    // See docstring above — the string form is YAML-only and CFn JSON
+    // never emits it.
   }
   return undefined;
 }

--- a/src/local/stage-resolver.ts
+++ b/src/local/stage-resolver.ts
@@ -66,11 +66,14 @@ export interface ResolvedStage {
  *
  *   - **Match found**: API enters the result map with the picked
  *     Stage's `StageName` + variables. `attachStageContext` then sets
- *     `route.stageVariables` from the resolved Stage AND (for REST v1
- *     routes only) overrides `route.stage` with the picked Stage's
- *     `StageName`. HTTP API v2 routes keep `route.stage = '$default'`
- *     even on a matched stage because that's the only stage HTTP API
- *     exposes via `requestContext.stage`.
+ *     `route.stageVariables` from the resolved Stage AND overrides
+ *     `route.stage` with the picked Stage's `StageName` for **both**
+ *     REST v1 and HTTP API v2 routes. HTTP API v2's auto-deploy default
+ *     is `'$default'`, but AWS also supports named stages (the
+ *     `CreateStage` API accepts any name); when the template carries a
+ *     named v2 Stage we surface that name through `requestContext.stage`
+ *     so a handler that reads `event.requestContext.stage` sees the
+ *     same value AWS would surface in the deployed environment.
  */
 export function buildStageMap(
   template: CloudFormationTemplate,
@@ -177,9 +180,9 @@ function toResolvedStage(
 }
 
 /**
- * Mutate every route in `routes` to set `stageVariables` and (for
- * REST v1 / HTTP API routes) override `stage` with the resolved Stage's
- * `StageName`. Function URL routes are left untouched.
+ * Mutate every route in `routes` to set `stageVariables` and (for routes
+ * that map to a resolved Stage) override `stage` with the resolved
+ * Stage's `StageName`. Function URL routes are left untouched.
  *
  * Invariants:
  *
@@ -192,11 +195,12 @@ function toResolvedStage(
  *
  *   - Routes whose `apiLogicalId` IS in the map get `stageVariables` set
  *     to the resolved Stage's variables (`null` when the Stage has none),
- *     and (for REST v1) the route's `stage` is overridden with the
- *     Stage's `StageName`. HTTP API v2 routes keep `stage: '$default'`
- *     because that's the only stage HTTP API exposes to the integration
- *     event — the AWS-side `requestContext.stage` is always `'$default'`
- *     for HTTP API.
+ *     and `route.stage` is overridden with the Stage's `StageName` for
+ *     **both** REST v1 and HTTP API v2 routes. HTTP API v2's default
+ *     auto-deployed stage is `$default`, but AWS supports named stages
+ *     on v2 too (`CreateStage` accepts any name) — when the template
+ *     carries one, surface it through `requestContext.stage` so the
+ *     local event matches what AWS would emit at the deployed endpoint.
  */
 export function attachStageContext(
   routes: DiscoveredRoute[],
@@ -213,9 +217,7 @@ export function attachStageContext(
       continue;
     }
     route.stageVariables = stage.variables;
-    if (route.source === 'rest-v1') {
-      route.stage = stage.stageName;
-    }
+    route.stage = stage.stageName;
   }
 }
 

--- a/tests/unit/local/lambda-resolver.test.ts
+++ b/tests/unit/local/lambda-resolver.test.ts
@@ -552,6 +552,38 @@ describe('resolveLambdaTarget', () => {
     expect(result.layers.map((l) => l.logicalId)).toEqual(['LayerA', 'LayerB', 'LayerC']);
   });
 
+  it("rejects the YAML-only Fn::GetAtt string form ('LogicalId.attr') — CFn JSON never emits it", () => {
+    // Issue #241 item 5: CloudFormation YAML accepts the dot-shorthand
+    // `Fn::GetAtt: '<LogicalId>.<attr>'` and converts it to the array
+    // form on the wire, but CDK's `cdk synth` output (CFn JSON, the only
+    // thing cdkd ingests) never emits the string form. Surfacing it as
+    // resolvable would silently accept hand-edited / malformed templates;
+    // we hard-error so the offending shape is called out.
+    const stack = buildStack(
+      'MyStack',
+      {
+        Fn: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            Runtime: 'nodejs20.x',
+            Handler: 'index.handler',
+            Layers: [{ 'Fn::GetAtt': 'MyLayer.Ref' }],
+          },
+          Metadata: { 'aws:asset:path': 'asset.fn' },
+        },
+        MyLayer: {
+          Type: 'AWS::Lambda::LayerVersion',
+          Properties: {},
+          Metadata: { 'aws:asset:path': 'asset.layer1' },
+        },
+      },
+      tmpRoot
+    );
+    expect(() => resolveLambdaTarget('MyStack:Fn', [stack])).toThrow(
+      /cdkd cannot resolve locally.*Only same-stack Ref \/ Fn::GetAtt/
+    );
+  });
+
   it('rejects literal-ARN layer entries (cross-account / pre-existing — out of scope)', () => {
     const stack = buildStack(
       'MyStack',

--- a/tests/unit/local/stage-resolver.test.ts
+++ b/tests/unit/local/stage-resolver.test.ts
@@ -208,7 +208,11 @@ describe('attachStageContext', () => {
     expect(routes[0]!.stageVariables).toEqual({ foo: 'bar' });
   });
 
-  it('does NOT override stage name on HTTP API v2 routes (always $default)', () => {
+  it('overrides stage name + sets variables on HTTP API v2 routes too (named v2 stages are surfaced)', () => {
+    // Pre-issue #241 item 4: v2 routes kept `stage: '$default'` even
+    // when the template carried a named v2 Stage. AWS supports named
+    // stages on HTTP API v2 (CreateStage accepts any name), so the
+    // local event should mirror what the deployed endpoint would emit.
     const routes = [route({ apiLogicalId: 'Api', source: 'http-api', apiVersion: 'v2' })];
     const stageMap = new Map<string, ResolvedStage>([
       [
@@ -222,8 +226,26 @@ describe('attachStageContext', () => {
       ],
     ]);
     attachStageContext(routes, stageMap);
-    expect(routes[0]!.stage).toBe('$default');
+    expect(routes[0]!.stage).toBe('prod');
     expect(routes[0]!.stageVariables).toEqual({ foo: 'bar' });
+  });
+
+  it('keeps stage at $default when the resolved v2 Stage is named $default', () => {
+    const routes = [route({ apiLogicalId: 'Api', source: 'http-api', apiVersion: 'v2' })];
+    const stageMap = new Map<string, ResolvedStage>([
+      [
+        'Api',
+        {
+          stageLogicalId: 'Stage',
+          stageName: '$default',
+          apiVersion: 'v2',
+          variables: { theme: 'dark' },
+        },
+      ],
+    ]);
+    attachStageContext(routes, stageMap);
+    expect(routes[0]!.stage).toBe('$default');
+    expect(routes[0]!.stageVariables).toEqual({ theme: 'dark' });
   });
 
   it('sets stageVariables: null on Function URL routes (no apiLogicalId)', () => {
@@ -282,9 +304,12 @@ describe('attachStageContext', () => {
     attachStageContext(routes, m);
     expect(routes[0]!.stageVariables).toEqual({ region: 'us-east-1' });
     expect(routes[1]!.stageVariables).toBeNull();
-    // Both v2 routes keep stage='$default' (HTTP API only exposes
-    // $default to the integration event regardless of matched stage).
-    expect(routes[0]!.stage).toBe('$default');
+    // ApiA matched the `prod` Stage, so its v2 route gets stage='prod'
+    // (issue #241 item 4 — v2 named stages are now surfaced through
+    // requestContext.stage, not silently flattened to $default). ApiB
+    // has no matching Stage in the map, so the discovery-time
+    // placeholder ($default for HTTP API v2) is preserved.
+    expect(routes[0]!.stage).toBe('prod');
     expect(routes[1]!.stage).toBe('$default');
   });
 });


### PR DESCRIPTION
Resolves items 4, 5, 6 of [issue 241](https://github.com/go-to-k/cdkd/issues/241). The remaining items stay open.

## Item 4 — `--stage <name>` override rewrites `route.stage` for HTTP API v2 too

`src/local/stage-resolver.ts`. Pre-fix, `attachStageContext` only rewrote `route.stage` for `rest-v1`. HTTP API v2 routes kept `route.stage === '$default'` regardless of which Stage matched. The original defense was "HTTP API only exposes `$default`", but AWS `CreateStage` accepts any name on HTTP API v2 — `$default` is the auto-deploy default, not the only option. When the template carries a named v2 Stage and `--stage <name>` matches it, surfacing that name through `event.requestContext.stage` lets the local event mirror what the deployed endpoint would emit. APIs that don't match any Stage keep the discovery-time placeholder (`'$default'` for v2 / Function URL).

Unit test added: with a v2 API + Stage `prod` + `--stage prod`, `route.stage === 'prod'` and `route.stageVariables` populated. Second case asserts a v2 Stage literally named `$default` still passes through as `$default`. The existing "per-API stage override mismatch" test was updated for the new behavior (ApiA's matched v2 route now reports `prod`, ApiB's unmatched v2 route stays at `$default`).

## Item 5 — `pickLayerLogicalId` rejects the YAML-only `Fn::GetAtt` string form

`src/local/lambda-resolver.ts`. CloudFormation YAML accepts the dot-shorthand `Fn::GetAtt: '<LogicalId>.<attr>'` and converts it to the array form on the wire, but `cdk synth` (CFn JSON, the only thing cdkd ingests) never emits the string form. Treating it as resolvable silently accepted hand-edited / malformed templates that no real CDK flow can produce — option (a) from the issue. Dropped the `arg.split('.')[0]` branch so the string form falls through to the existing "cdkd cannot resolve this Layers entry locally" error path. Per-pattern docstring explains the rejection so a future reader doesn't reintroduce it.

Unit test added: `Fn::GetAtt: 'MyLayer.Ref'` (string form) on a `Layers` entry now throws with the standard cdkd error message.

Out of scope per the original task brief: the sibling helpers `pickReferencedLogicalId` in `local-invoke.ts` (used for the `--from-state` role-arn hint) and `parseGetAtt` in `state-resolver.ts` (used for env-var substitution from cdkd state) are different concerns (state substitution / role hint, not template validation); both still accept the YAML string form. Open issue 241 covers the audit if a broader policy is wanted.

## Item 6 — `cpSync` Node-20+ contract pin (comment-only)

`src/cli/commands/local-invoke.ts` `materializeLambdaLayers` and `src/cli/commands/local-start-api.ts`'s server-boot pre-merge. Added a docstring above each `cpSync(..., { recursive: true, force: true })` call pinning the two Node-20+ defaults this code load-bears on:

- `mode` defaults to preserving the source's file-mode bits, including the `+x` execute bit. AWS layers commonly ship executable scripts under `bin/` (e.g. layer-version-shipped binaries, the Python `bin/python` shim); a handler that runs `/opt/bin/<script>` from `/opt` would fail with "Permission denied" if the bit were dropped.
- `verbatimSymlinks` defaults to true on Node 20+; symlinks in the source are copied as symlinks (not dereferenced), matching how AWS extracts a layer ZIP into `/opt`.

Comment-only — no runtime change. The comment exists so a future "tighten the cpSync options" refactor doesn't accidentally drop the `+x` bit or dereference symlinks and silently break `/opt/bin/...` layers in the field. Both call sites pin the same contract; if they ever consolidate into one helper, the pin stays.

## Test plan

- [x] `pnpm run typecheck` — pass
- [x] `pnpm run lint` — pass
- [x] `pnpm run build` — pass
- [x] `npx vitest --run` — 2738 tests pass (253 files; +2 new, 2 updated)
- [x] `bash tests/integration/local-start-api/verify.sh` — all routes + CORS + REST v1 stage + authorizer pass green
- [x] `bash tests/integration/local-invoke-layers/verify.sh` — 3 of 3 layer-merge tests pass
- [x] One-shot live-test of Item 4 against a fixture template (v2 API + named `prod` Stage + `--stage prod`) confirms `route.stage === 'prod'` post-fix
- [x] `docs/cli-reference.md` `--stage <name>` section updated to reflect the new v2 behavior; README only references cli-reference and was not affected

## What this does NOT close from issue 241

Items 1, 2, 3, 7, 8, 9, 10 (and any others) stay open. This is a 3-item slice from the backlog.
