### PR TITLE
chore(.claude/skills/verify-pr): wire /review-pr into step 8

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -75,7 +75,14 @@ Run each check and report pass/fail:
    - Check `src/index.ts` exports are consistent
 
 8. **Code review**
-   - `git diff main...HEAD` — review the actual diff
+   - **First, run `/review-pr <N>`** to get a size-appropriate review plan. The skill outputs one of:
+     - **inline spot-check** (small PR, < 300 LOC OR < 5 files, no security-sensitive paths) — read the diff yourself in this step; no sub-agent dispatch.
+     - **1 reviewer** (medium PR, 300-1000 LOC) — dispatch a single `pr-code-reviewer` agent (the skill emits a ready-to-paste Agent call).
+     - **3-axis parallel** (large PR ≥ 1000 LOC OR security-sensitive paths) — dispatch all three of `pr-spec-reviewer` / `pr-code-reviewer` / `pr-test-reviewer` in parallel (single message, three Agent tool calls).
+
+     The skill applies bias factors (security surfaces bump up; pure-infra / docs / tests-only bump down). Trust the recommendation; override only when you have a concrete reason (note the reason here).
+   - Synthesize the reviewer reports (or your inline read) into a pass / issues-found verdict. Any blocker → fix-back loop before continuing.
+   - `git diff main...HEAD` — confirm the diff is what you reviewed (no last-minute commits slipped through).
    - For each change: is it correct? complete? necessary?
    - Check for:
      - Logic errors or unhandled edge cases


### PR DESCRIPTION
## Summary

Wire `/review-pr` (PR 244) into `/verify-pr` step 8 (Code review). Previously step 8 was a prose-only "review the diff yourself" instruction that under-scoped large PRs and over-dispatched on tiny PRs. Now the orchestrator runs `/review-pr <N>` first to get a size-aware plan (inline spot-check / 1 reviewer / 3-axis parallel) with bias factors auto-applied (security surfaces bump up; pure-infra / docs / tests-only bump down), then dispatches the right reviewers based on the recommendation.

No new gate, no new marker — the existing `verify-pr` marker continues to gate merge. Only the routing of step 8 changes.

## Test plan

- [x] `/verify-pr`'s step 8 prose now opens with the `/review-pr` call.
- [x] `verify-pr` marker still settable after a clean walk-through.
- [x] No code changes; pure skill-body documentation edit. Typecheck / lint / build / tests are no-op pass.

Refs: 244 (/review-pr skill)
