### PR TITLE
docs(readme): clarify 15x benchmark requires --no-wait + add CloudFront to stack description

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ Stack: S3 Bucket, DynamoDB Table, SQS Queue, SNS Topic, SSM Parameter (5 indepen
 | --- | ---: | ---: | ---: |
 | Deploy | **17.0s** | **94.4s** | **5.5x** |
 
-### VPC + Lambda + SQS stack — **15x faster** (40s vs 599s)
+### VPC + CloudFront + Lambda stack — **15x faster with `--no-wait`** (40s vs 599s)
 
-Real-world stack: 1 VPC (2 AZs, NAT Gateway, public + private subnets) + Lambda Function (with `VpcConfig`) + SQS Queue + EventSourceMapping.
+Real-world stack: 1 VPC (2 AZs, NAT Gateway, public + private subnets) + Lambda Function (with `VpcConfig`) + Lambda Function URL (AWS_IAM) + CloudFront Distribution (OAC, caching disabled) + SQS Queue + EventSourceMapping + Consumer Lambda.
 
-| | AWS CDK (CFn) | cdkd `--no-wait` | Speedup |
+| | AWS CDK (CFn) | cdkd | cdkd `--no-wait` |
 | --- | ---: | ---: | ---: |
-| Deploy | **599s** | **40s** | **~15x** |
+| Deploy | **599s** | 197s (3.0x) | **40s (15.0x)** |
 
-cdkd's DAG scheduler dispatches `CloudFront::Distribution` / `Lambda::Url` / VPC Lambda in parallel with NAT Gateway stabilization (default behavior — pass `--no-aggressive-vpc-parallel` to opt out). `--no-wait` returns as soon as the create call returns, letting AWS finish async provisioning in the background. Both compound against CloudFormation's serial-leaning waits.
+The 15x figure requires `cdkd deploy --no-wait`, which returns as soon as each Create call returns and lets AWS finish CloudFront's ~5min propagation + NAT Gateway stabilization in the background. cdkd's default scheduler already parallelizes `CloudFront::Distribution` / `Lambda::Url` / VPC Lambda with NAT Gateway propagation (pass `--no-aggressive-vpc-parallel` to opt out); on this stack the default gives ~3x. `--no-wait` adds the rest of the gap by skipping the propagation waits entirely.
 
 ### Cloud Control API fallback path — **1.6x faster** (40.9s vs 64.9s)
 


### PR DESCRIPTION
## Summary

Clarify the VPC + Lambda + SQS benchmark subsection (added in PR 251) on two points:

1. **`--no-wait` is required for the 15x figure.** The table column was labeled `cdkd --no-wait` but the subsection title said "15x faster" without naming the flag. A reader scanning the section header could miss that cdkd default measures ~3x on the same stack — `--no-wait` adds the rest of the gap by skipping CloudFront's ~5min propagation and NAT Gateway stabilization. Section title now reads `**VPC + CloudFront + Lambda stack — 15x faster with --no-wait**`; the table adds the `cdkd` default column (3.0x) alongside the `cdkd --no-wait` column (15.0x).

2. **CloudFront / Lambda Function URL added to the stack description.** Both were in the actual benchmark stack but missing from the prose. CloudFront is load-bearing for the 15x — its propagation wait is the biggest single chunk that `--no-wait` skips. Updated description: `1 VPC ... + Lambda Function (with VpcConfig) + Lambda Function URL (AWS_IAM) + CloudFront Distribution (OAC, caching disabled) + SQS Queue + EventSourceMapping + Consumer Lambda`.

## Test plan

- [x] No source code changes — typecheck / lint / build / tests all pass (no-op for this PR).
- [x] Markdown lint: anchors unchanged, no broken links.
- [x] Live read: rendered README spot-check — section title now names `--no-wait`; table makes the with/without `--no-wait` difference explicit; stack description names every load-bearing resource.
