### PR TITLE
docs(local-invoke): drop stale "v1 scope: Node.js runtimes only" docstring

### DIFF
--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -118,11 +118,13 @@ interface LocalInvokeOptions {
  * Emulator (RIE). Modeled on `sam local invoke` but reusing cdkd's
  * synthesis / asset / construct-path plumbing.
  *
- * v1 scope: Node.js runtimes only, Docker required. Literal env vars
- * pass through; intrinsic-valued env vars require `--from-state` to
- * substitute deployed physical IDs / attributes (PR 2). See
- * [docs/cli-reference.md](../../../docs/cli-reference.md) for the full
- * surface and out-of-scope items.
+ * Supports every current AWS Lambda runtime (Node.js, Python, Ruby,
+ * Java, .NET, and the OS-only `provided.al2` / `provided.al2023`) — see
+ * `src/local/runtime-image.ts` for the canonical supported set. Docker
+ * is required. Literal env vars pass through; intrinsic-valued env vars
+ * require `--from-state` to substitute deployed physical IDs /
+ * attributes. See [docs/cli-reference.md](../../../docs/cli-reference.md)
+ * for the full surface and out-of-scope items.
  */
 async function localInvokeCommand(target: string, options: LocalInvokeOptions): Promise<void> {
   const logger = getLogger();


### PR DESCRIPTION
## Summary

Drift-followup to issue 248. The `localInvokeCommand` docstring at the top of `src/cli/commands/local-invoke.ts` still said "v1 scope: Node.js runtimes only" — a leftover from PR 1 of #224 that drifted from reality as the supported set was broadened across Python (PR 4 of #224), Ruby (PR #254), Java (PR #256), .NET (PR #257), and `provided.al2` / `provided.al2023` (PR #258).

The fix replaces the stale enumeration with a pointer at `src/local/runtime-image.ts` (the canonical `SUPPORTED_RUNTIMES` table), so future runtime additions don't have to remember to update two places. Surfaced during a post-#248-completion stale-docstring grep — caught by `feedback_stale_docstring_after_partial_impl.md`.

Pure docstring change — no behavior diff, no test churn (2786 tests pass unchanged).

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` / `vitest --run` (253 files, 2786 tests, all pass — no test changes)
- [ ] CI: typecheck / lint / build / tests on GitHub Actions

Refs: 248
