### PR TITLE
chore(paths): strip user-specific absolute paths from committed files

### DIFF
--- a/.claude/agents/pr-code-reviewer.md
+++ b/.claude/agents/pr-code-reviewer.md
@@ -11,8 +11,8 @@ You find bugs the implementing agent might have missed. The caller provides a PR
 ## Inputs you read
 
 1. **PR diff** — `gh pr diff <N>` (full diff).
-2. **PR contents at tip** — `git -C /Users/goto/pc/github/cdkd fetch origin <branch>` then `git -C /Users/goto/pc/github/cdkd show origin/<branch>:<path>`. Do NOT check out the branch.
-3. **Project conventions** — `/Users/goto/pc/github/cdkd/CLAUDE.md` for ESM `.js` imports, no `any`, etc.
+2. **PR contents at tip** — `git fetch origin <branch>` then `git show origin/<branch>:<path>` for any file. Do NOT check out the branch. (Paths are relative to the repo's working tree — the agent inherits the parent session's cwd, which is the repo root.)
+3. **Project conventions** — `CLAUDE.md` at the repo root for ESM `.js` imports, no `any`, etc.
 
 ## Review focus
 

--- a/.claude/agents/pr-spec-reviewer.md
+++ b/.claude/agents/pr-spec-reviewer.md
@@ -14,7 +14,7 @@ You verify whether a PR's implementation matches a design doc. The caller provid
 
 1. **Design doc** — the source of truth for what the impl should look like. Find the locked decisions table (typically D-prefixed: D5.1, D5.2, ...) and the critical-bug section (typically C-prefixed). Both are mandatory matches.
 2. **PR diff** — `gh pr diff <N>` for the full diff, `gh pr view <N> --json files -q '.files[].path'` for the file list.
-3. **PR contents at tip** — `git -C /Users/goto/pc/github/cdkd fetch origin <branch>` then `git -C /Users/goto/pc/github/cdkd show origin/<branch>:<path>` for any file. Do NOT check out the branch — leave the parent worktree on main.
+3. **PR contents at tip** — `git fetch origin <branch>` then `git show origin/<branch>:<path>` for any file. Do NOT check out the branch — leave the parent worktree on main. (Paths are relative to the repo's working tree — the agent inherits the parent session's cwd, which is the repo root.)
 
 ## Review focus (the ENTIRE scope)
 

--- a/.claude/agents/pr-test-reviewer.md
+++ b/.claude/agents/pr-test-reviewer.md
@@ -11,7 +11,7 @@ You verify the test suite actually covers the new behavior. The caller provides 
 ## Inputs you read
 
 1. **PR test files** — `gh pr view <N> --json files -q '.files[].path' | grep -E "^tests/"`.
-2. **Test contents** — `git -C /Users/goto/pc/github/cdkd fetch origin <branch>` then `git -C /Users/goto/pc/github/cdkd show origin/<branch>:tests/<path>`.
+2. **Test contents** — `git fetch origin <branch>` then `git show origin/<branch>:tests/<path>`. (Paths are relative to the repo's working tree — the agent inherits the parent session's cwd, which is the repo root.)
 3. **Implementation files** to identify untested branches.
 
 ## Review focus

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -98,7 +98,7 @@ Dispatch this single reviewer (run via Agent tool in the main session):
     subagent_type: "general-purpose",
     description: "PR <N> code review",
     prompt: |
-      Read your role definition at `/Users/goto/pc/github/cdkd/.claude/agents/pr-code-reviewer.md` and follow it.
+      Read your role definition at `.claude/agents/pr-code-reviewer.md` (relative to the repo root) and follow it.
       Inputs:
       - PR number: <N>
       - Branch: <branch>
@@ -114,7 +114,7 @@ Dispatch these three reviewers IN PARALLEL (single message, three Agent tool cal
     subagent_type: "general-purpose",
     description: "PR <N> spec compliance review",
     prompt: |
-      Read your role definition at `/Users/goto/pc/github/cdkd/.claude/agents/pr-spec-reviewer.md` and follow it.
+      Read your role definition at `.claude/agents/pr-spec-reviewer.md` (relative to the repo root) and follow it.
       Inputs:
       - PR number: <N>
       - Branch: <branch>
@@ -125,7 +125,7 @@ Dispatch these three reviewers IN PARALLEL (single message, three Agent tool cal
     subagent_type: "general-purpose",
     description: "PR <N> code review",
     prompt: |
-      Read your role definition at `/Users/goto/pc/github/cdkd/.claude/agents/pr-code-reviewer.md` and follow it.
+      Read your role definition at `.claude/agents/pr-code-reviewer.md` (relative to the repo root) and follow it.
       Inputs:
       - PR number: <N>
       - Branch: <branch>
@@ -135,7 +135,7 @@ Dispatch these three reviewers IN PARALLEL (single message, three Agent tool cal
     subagent_type: "general-purpose",
     description: "PR <N> test adequacy review",
     prompt: |
-      Read your role definition at `/Users/goto/pc/github/cdkd/.claude/agents/pr-test-reviewer.md` and follow it.
+      Read your role definition at `.claude/agents/pr-test-reviewer.md` (relative to the repo root) and follow it.
       Inputs:
       - PR number: <N>
       - Branch: <branch>

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,8 +14,9 @@ cdkd uses an S3 bucket for state management. You can easily create one using the
 ### Method A: Using bootstrap command (Recommended)
 
 ```bash
-# Set cdkd path (from cdkd root directory)
-CDKD_PATH="/Users/goto/github/cdkd"
+# Set cdkd path (auto-resolves to the cdkd repo root when run from inside it;
+# otherwise replace with an absolute path to your local cdkd checkout)
+CDKD_PATH="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # Bucket name must be globally unique
 export STATE_BUCKET="cdkd-state-$(whoami)-$(date +%s)"
@@ -54,14 +55,14 @@ The cdkd repository includes several examples:
 #### Basic Example (Simple S3 Bucket)
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/basic
+cd "${CDKD_PATH}/tests/integration/basic"
 npm install
 ```
 
 #### Intrinsic Functions Example (Testing Built-in Functions)
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/intrinsic-functions
+cd "${CDKD_PATH}/tests/integration/intrinsic-functions"
 npm install
 ```
 
@@ -70,7 +71,7 @@ npm install
 A practical integration example with Lambda functions and DynamoDB tables:
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/lambda
+cd "${CDKD_PATH}/tests/integration/lambda"
 npm install
 ```
 
@@ -86,14 +87,14 @@ npm install
 Event-driven architecture with S3 + Lambda + DynamoDB + SQS + IAM:
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/multi-resource
+cd "${CDKD_PATH}/tests/integration/multi-resource"
 npm install
 ```
 
 #### Parameters Example (CloudFormation Parameters) ✅ Implemented
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/parameters
+cd "${CDKD_PATH}/tests/integration/parameters"
 npm install
 ```
 
@@ -106,7 +107,7 @@ npm install
 #### Conditions Example (CloudFormation Conditions) ✅ Implemented
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/conditions
+cd "${CDKD_PATH}/tests/integration/conditions"
 npm install
 ```
 
@@ -119,7 +120,7 @@ npm install
 #### Cross-Stack References Example (Fn::ImportValue) ✅ Implemented
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/cross-stack-references
+cd "${CDKD_PATH}/tests/integration/cross-stack-references"
 npm install
 ```
 
@@ -132,7 +133,7 @@ npm install
 #### ECR Example (Docker Image Lambda with ECR)
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/ecr
+cd "${CDKD_PATH}/tests/integration/ecr"
 npm install
 ```
 
@@ -144,7 +145,7 @@ npm install
 #### API Gateway Example (REST API + Lambda)
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/apigateway
+cd "${CDKD_PATH}/tests/integration/apigateway"
 npm install
 ```
 
@@ -156,77 +157,77 @@ npm install
 #### ECS Fargate Example
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/ecs-fargate
+cd "${CDKD_PATH}/tests/integration/ecs-fargate"
 npm install
 ```
 
 #### EventBridge Example
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/eventbridge
+cd "${CDKD_PATH}/tests/integration/eventbridge"
 npm install
 ```
 
 #### SNS + SQS Event Example
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/sns-sqs-event
+cd "${CDKD_PATH}/tests/integration/sns-sqs-event"
 npm install
 ```
 
 #### DynamoDB Streams Example
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/dynamodb-streams
+cd "${CDKD_PATH}/tests/integration/dynamodb-streams"
 npm install
 ```
 
 #### Step Functions Example
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/stepfunctions
+cd "${CDKD_PATH}/tests/integration/stepfunctions"
 npm install
 ```
 
 #### EC2 VPC Example
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/ec2-vpc
+cd "${CDKD_PATH}/tests/integration/ec2-vpc"
 npm install
 ```
 
 #### S3 + CloudFront Example
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/s3-cloudfront
+cd "${CDKD_PATH}/tests/integration/s3-cloudfront"
 npm install
 ```
 
 #### CloudWatch Example
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/cloudwatch
+cd "${CDKD_PATH}/tests/integration/cloudwatch"
 npm install
 ```
 
 #### RDS Aurora Example
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/rds-aurora
+cd "${CDKD_PATH}/tests/integration/rds-aurora"
 npm install
 ```
 
 #### Bedrock AgentCore Example
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/bedrock-agentcore
+cd "${CDKD_PATH}/tests/integration/bedrock-agentcore"
 npm install
 ```
 
 #### CloudFront + Lambda Function URL Example
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/cloudfront-function-url
+cd "${CDKD_PATH}/tests/integration/cloudfront-function-url"
 npm install
 ```
 
@@ -239,7 +240,7 @@ npm install
 #### VPC Lookup Example (Context Provider Loop)
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/vpc-lookup
+cd "${CDKD_PATH}/tests/integration/vpc-lookup"
 npm install
 ```
 
@@ -267,7 +268,7 @@ node ../../../dist/cli.js destroy --region us-east-1 --state-bucket <your-state-
 #### CDK Provider Framework Example (isCompleteHandler/onEventHandler)
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/custom-resource-provider
+cd "${CDKD_PATH}/tests/integration/custom-resource-provider"
 npm install
 ```
 
@@ -329,8 +330,9 @@ npm run build
 ## 3. Deploy Using cdkd
 
 ```bash
-# Set cdkd path (from cdkd root directory)
-CDKD_PATH="/Users/goto/github/cdkd"
+# Set cdkd path (auto-resolves to the cdkd repo root when run from inside it;
+# otherwise replace with an absolute path to your local cdkd checkout)
+CDKD_PATH="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # First, check changes with diff
 # --app and --state-bucket can be omitted if set via env vars or cdk.json
@@ -370,7 +372,7 @@ cdkd supports resource updates via Cloud Control API JSON Patch (RFC 6902). Test
 ### Method A: Using the basic example with environment variable
 
 ```bash
-cd /Users/goto/github/cdkd/tests/integration/basic
+cd "${CDKD_PATH}/tests/integration/basic"
 
 # First deployment (CREATE)
 # Stack name is positional; auto-detected if single stack

--- a/tests/integration/cross-stack-references/README.md
+++ b/tests/integration/cross-stack-references/README.md
@@ -32,7 +32,7 @@ npm install
 First, deploy the exporter stack that creates resources and exports values:
 
 ```bash
-cd /Users/goto/github/cdkd
+cd "$(git rev-parse --show-toplevel)"
 export STATE_BUCKET="your-state-bucket"
 export AWS_REGION="us-east-1"
 


### PR DESCRIPTION
## Summary

Strip every `/Users/goto/...` style absolute path from committed files so the repo is portable across contributors' machines. Audit found 33 occurrences across reviewer agent definitions, the `review-pr` skill, `docs/testing.md`, and one integration-test README.

Post-cleanup audit:

```
$ git ls-files | xargs grep -lE '/Users/[a-z]+/'
(empty)
```

## Changes per file

- **`.claude/agents/pr-{code,spec,test}-reviewer.md`** — drop `git -C /Users/goto/...` and `Read /Users/.../CLAUDE.md`. Reviewer agents inherit the parent session's cwd (repo root), so bare `git fetch origin` / `git show origin/<branch>:<path>` / `CLAUDE.md` work without any `-C` flag. Add a one-line note clarifying the cwd assumption.
- **`.claude/skills/review-pr/SKILL.md`** — dispatch prompts for each `pr-X-reviewer` agent now reference `.claude/agents/<role>.md` (relative) instead of the absolute path. Three template instances updated.
- **`docs/testing.md`** — every `cd /Users/goto/github/cdkd/tests/integration/...` (24 instances; note the path was even wrong for the original author — missing the `/pc/` segment) becomes `cd "${CDKD_PATH}/tests/integration/..."`. The two `CDKD_PATH="/Users/goto/github/cdkd"` declarations become `CDKD_PATH="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"`, which auto-resolves when run from inside any cdkd checkout and falls back to `pwd` otherwise.
- **`tests/integration/cross-stack-references/README.md`** — single `cd /Users/goto/github/cdkd` becomes `cd "$(git rev-parse --show-toplevel)"`.

## Memory entries (per-user, not in this diff but landed in the same session)

Three retrospective rules added to memory (not committed to the repo — local per-user notes for future sessions):

- `feedback_live_test_must_exercise.md` — `/verify-pr`'s "live-test" step requires running the code against real / fixture input. `--help` only proves option parsing; it doesn't exercise the feature. Don't tick the box on `--help`.
- `feedback_gh_pr_merge_auto_silently_noops.md` — `gh pr merge --auto` returns success but silently no-ops when the repo has `allow_auto_merge: false`. cdkd's repo settings explicitly disallow auto-merge — check before relying on the flag.
- `feedback_mergeable_unknown_after_ci_green.md` — `mergeStateStatus: UNKNOWN` can persist after all CI checks pass. Don't poll-loop forever; if CI is green, try the merge directly.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes
- [x] `pnpm test` — 2854 tests pass (no source change → no test-count delta)
- [x] `pnpm run format:check` passes
- [x] `git ls-files | xargs grep -lE '/Users/[a-z]+/'` returns empty (confirmation that no committed file still hardcodes a user path)
