### PR TITLE
feat(local-run-task): TaskRoleArn intrinsics + Fn::Sub resolution + orchestrator tests

### DIFF
--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -16,7 +16,8 @@ import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
-import { resolveApp, resolveStateBucketWithDefault } from '../config-loader.js';
+import { resolveApp } from '../config-loader.js';
+import { loadStateForStack } from './local-state-loader.js';
 import {
   resolveLambdaTarget,
   type ResolvedImageLambda,
@@ -48,8 +49,6 @@ import {
   AssetManifestLoader,
   getDockerImageBySourceHash,
 } from '../../assets/asset-manifest-loader.js';
-import { S3StateBackend } from '../../state/s3-state-backend.js';
-import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
 import { singleFlight } from '../../utils/single-flight.js';
 import type { StackState } from '../../types/state.js';
 import { createLocalStartApiCommand } from './local-start-api.js';
@@ -901,120 +900,6 @@ function materializeInlineCode(handler: string, source: string, fileExtension: s
   mkdirSync(path.dirname(filePath), { recursive: true });
   writeFileSync(filePath, source, 'utf-8');
   return dir;
-}
-
-/**
- * Load cdkd state for the target stack so `--from-state` can substitute
- * intrinsic-valued env vars.
- *
- * Failure mode: returns `undefined` and logs at warn for every "expected"
- * miss (no state file, multi-region ambiguity without `--stack-region`,
- * bucket-resolution failure). `--from-state` is opt-in and the caller's
- * fallback is the existing PR 1 warn-and-drop, so a broken state file
- * shouldn't abort the whole invoke. Genuine errors (auth failures, etc.)
- * still propagate.
- *
- * Mirrors the orphan command's state-loading shape but without the lock
- * or save path — `cdkd local invoke` is purely read-only against state.
- */
-async function loadStateForStack(
-  stackName: string,
-  synthRegion: string | undefined,
-  opts: {
-    stackRegion?: string;
-    stateBucket?: string;
-    statePrefix: string;
-    region?: string;
-    profile?: string;
-  }
-): Promise<{ state: StackState; region: string } | undefined> {
-  const logger = getLogger();
-
-  // Region resolution chain: --region > AWS_REGION > AWS_DEFAULT_REGION >
-  // synth-derived stack region > us-east-1. The state-bucket S3 client is
-  // re-targeted to the bucket's actual region inside the backend, but the
-  // initial AWS clients still need a sensible default.
-  const region =
-    opts.region ??
-    process.env['AWS_REGION'] ??
-    process.env['AWS_DEFAULT_REGION'] ??
-    synthRegion ??
-    'us-east-1';
-
-  let stateBucket: string;
-  try {
-    stateBucket = await resolveStateBucketWithDefault(opts.stateBucket, region);
-  } catch (err) {
-    logger.warn(
-      `--from-state: could not resolve state bucket: ${err instanceof Error ? err.message : String(err)}. Falling back to PR 1 warn-and-drop semantics.`
-    );
-    return undefined;
-  }
-
-  const awsClients = new AwsClients({
-    ...(opts.region !== undefined && { region: opts.region }),
-    ...(opts.profile !== undefined && { profile: opts.profile }),
-  });
-  setAwsClients(awsClients);
-
-  try {
-    const stateConfig = { bucket: stateBucket, prefix: opts.statePrefix };
-    const stateBackend = new S3StateBackend(awsClients.s3, stateConfig, {
-      ...(opts.region !== undefined && { region: opts.region }),
-      ...(opts.profile !== undefined && { profile: opts.profile }),
-    });
-    await stateBackend.verifyBucketExists();
-
-    // Disambiguate: if the user passed --stack-region, use it; else if the
-    // synthesized stack carries a region, prefer that; else fall back to
-    // the single state record for this stack name. Multi-region ambiguity
-    // → warn and bail (mirrors `cdkd state show`'s semantics, just without
-    // the hard-error treatment so an opt-in --from-state degrades cleanly).
-    const refs = (await stateBackend.listStacks()).filter((r) => r.stackName === stackName);
-    if (refs.length === 0) {
-      logger.warn(
-        `--from-state: no cdkd state found for stack '${stackName}' in bucket '${stateBucket}'. ` +
-          `Was it deployed via 'cdkd deploy'? Falling back to PR 1 warn-and-drop semantics.`
-      );
-      return undefined;
-    }
-
-    let targetRegion: string;
-    if (opts.stackRegion) {
-      const found = refs.find((r) => r.region === opts.stackRegion);
-      if (!found) {
-        const seen = refs.map((r) => r.region ?? '(legacy)').join(', ');
-        logger.warn(
-          `--from-state: stack '${stackName}' has no state in region '${opts.stackRegion}' (available: ${seen}). Falling back.`
-        );
-        return undefined;
-      }
-      targetRegion = opts.stackRegion;
-    } else if (synthRegion && refs.some((r) => r.region === synthRegion)) {
-      targetRegion = synthRegion;
-    } else if (refs.length === 1) {
-      targetRegion = refs[0]!.region ?? synthRegion ?? region;
-    } else {
-      const seen = refs.map((r) => r.region ?? '(legacy)').join(', ');
-      logger.warn(
-        `--from-state: stack '${stackName}' has state in multiple regions (${seen}). ` +
-          `Re-run with --stack-region <region>. Falling back.`
-      );
-      return undefined;
-    }
-
-    const stateData = await stateBackend.getState(stackName, targetRegion);
-    if (!stateData) {
-      logger.warn(
-        `--from-state: state record for '${stackName}' (${targetRegion}) returned empty. Falling back.`
-      );
-      return undefined;
-    }
-    logger.debug(`--from-state: loaded state for ${stackName} (${targetRegion})`);
-    return { state: stateData.state, region: targetRegion };
-  } finally {
-    awsClients.destroy();
-  }
 }
 
 /**

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -14,7 +14,10 @@ import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
-import { resolveEcsTaskTarget } from '../../local/ecs-task-resolver.js';
+import {
+  resolveEcsTaskTarget,
+  TASK_ROLE_ACCOUNT_PLACEHOLDER,
+} from '../../local/ecs-task-resolver.js';
 import {
   cleanupEcsRun,
   createEcsRunState,
@@ -127,21 +130,24 @@ async function localRunTaskCommand(target: string, options: LocalRunTaskOptions)
     };
     process.on('SIGINT', sigintHandler);
 
-    // `--assume-task-role` branches: bare flag (boolean `true`) needs the
+    // `--assume-task-role` branches: bare flag (boolean `true`) uses the
     // task definition's resolved `TaskRoleArn`; otherwise the user-supplied
-    // ARN is used. When the template only carries an intrinsic-valued
-    // TaskRoleArn, cdkd's static resolver returns `undefined` — we
-    // surface a clear hard error pointing the user at the explicit form.
+    // ARN is used. The resolver emits a synth-time placeholder ARN
+    // (`arn:aws:iam::${AWS::AccountId}:role/<LogicalId>`) when TaskRoleArn
+    // references an inline same-stack IAM Role; we fill in the account
+    // segment lazily via STS only when bare `--assume-task-role` is set,
+    // so the STS round-trip does not fire on the common pass-through path.
     let assumedCredentials: RunEcsTaskOptions['taskCredentials'];
     let resolvedRoleArn: string | undefined;
     if (options.assumeTaskRole === true) {
       if (!task.taskRoleArn) {
         throw new Error(
-          `--assume-task-role passed without an ARN but the task definition's TaskRoleArn could not be resolved statically. ` +
+          `--assume-task-role passed without an ARN but the task definition has no resolvable TaskRoleArn. ` +
+            `Either the task definition does not set TaskRoleArn, or it points at a resource cdkd cannot resolve to an IAM Role at synth time. ` +
             `Pass the ARN explicitly: --assume-task-role <arn>`
         );
       }
-      resolvedRoleArn = task.taskRoleArn;
+      resolvedRoleArn = await resolvePlaceholderAccount(task.taskRoleArn, options.region);
       assumedCredentials = await assumeTaskRole(resolvedRoleArn, options.region);
     } else if (typeof options.assumeTaskRole === 'string') {
       resolvedRoleArn = options.assumeTaskRole;
@@ -187,6 +193,32 @@ async function localRunTaskCommand(target: string, options: LocalRunTaskOptions)
   } finally {
     if (sigintHandler) process.off('SIGINT', sigintHandler);
     if (!options.detach) await cleanup();
+  }
+}
+
+/**
+ * If `arn` contains the `${AWS::AccountId}` placeholder emitted by the
+ * resolver for inline same-stack IAM Roles, substitute the live caller
+ * account via STS `GetCallerIdentity`. Otherwise pass through unchanged.
+ * Lazy: callers should only invoke this when the resolved ARN is actually
+ * going to be used (i.e. on the bare `--assume-task-role` path).
+ */
+async function resolvePlaceholderAccount(arn: string, region: string | undefined): Promise<string> {
+  if (!arn.includes(TASK_ROLE_ACCOUNT_PLACEHOLDER)) return arn;
+  const { STSClient, GetCallerIdentityCommand } = await import('@aws-sdk/client-sts');
+  const sts = new STSClient({ ...(region && { region }) });
+  try {
+    const identity = await sts.send(new GetCallerIdentityCommand({}));
+    const account = identity.Account;
+    if (!account) {
+      throw new Error(
+        `--assume-task-role: GetCallerIdentity returned no Account; cannot resolve placeholder ARN '${arn}'. ` +
+          `Pass the ARN explicitly: --assume-task-role <arn>`
+      );
+    }
+    return arn.split(TASK_ROLE_ACCOUNT_PLACEHOLDER).join(account);
+  } finally {
+    sts.destroy();
   }
 }
 

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -6,6 +6,7 @@ import {
   contextOptions,
   deprecatedRegionOption,
   parseContextOptions,
+  stateOptions,
   warnIfDeprecatedRegion,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
@@ -15,9 +16,14 @@ import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.
 import { resolveApp } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
 import {
+  derivePartitionAndUrlSuffix,
+  detectEcsImageResolutionNeeds,
+  parseEcsTarget,
   resolveEcsTaskTarget,
   TASK_ROLE_ACCOUNT_PLACEHOLDER,
+  type EcsImageResolutionContext,
 } from '../../local/ecs-task-resolver.js';
+import type { StackInfo } from '../../synthesis/assembly-reader.js';
 import {
   cleanupEcsRun,
   createEcsRunState,
@@ -25,6 +31,8 @@ import {
   type EcsRunState,
   type RunEcsTaskOptions,
 } from '../../local/ecs-task-runner.js';
+import { matchStacks } from '../stack-matcher.js';
+import { loadStateForStack } from './local-state-loader.js';
 
 interface LocalRunTaskOptions {
   app?: string;
@@ -49,6 +57,22 @@ interface LocalRunTaskOptions {
   platform?: string;
   keepRunning: boolean;
   detach: boolean;
+  /**
+   * Issue #264: read cdkd's S3 state for the target stack so the resolver
+   * can substitute `Fn::Sub` placeholders that reference a same-stack
+   * `AWS::ECR::Repository`. Tier 1 (pseudo parameters only) does NOT need
+   * this flag — STS GetCallerIdentity + the resolved region cover those.
+   * Off by default.
+   */
+  fromState: boolean;
+  stateBucket?: string;
+  statePrefix: string;
+  /**
+   * Region of the cdkd state record to read. Required only when the
+   * same stack name has state in multiple regions. Mirrors
+   * `cdkd local invoke --stack-region`.
+   */
+  stackRegion?: string;
 }
 
 /**
@@ -113,7 +137,13 @@ async function localRunTaskCommand(target: string, options: LocalRunTaskOptions)
     };
     const { stacks } = await synthesizer.synthesize(synthOpts);
 
-    const task = resolveEcsTaskTarget(target, stacks);
+    // Issue #264: build the optional substitution context BEFORE resolving
+    // the target, so `Fn::Sub`-shaped ECR image URIs (pseudo parameters +
+    // same-stack ECR Repository refs) get rewritten in-place during
+    // `parseContainerImage`. STS / state-load are lazy — we only fire them
+    // when at least one stack's template references the placeholders.
+    const imageContext = await buildEcsImageResolutionContext(target, stacks, options);
+    const task = resolveEcsTaskTarget(target, stacks, imageContext);
     logger.info(
       `Target: ${task.stack.stackName}/${task.taskDefinitionLogicalId} (family=${task.family}, containers=${task.containers.length})`
     );
@@ -255,6 +285,110 @@ async function assumeTaskRole(
 }
 
 /**
+ * Build the substitution context the ECS task resolver consumes (issue
+ * #264). Returns `undefined` when no container's `Image` field needs
+ * substitution — the resolver behaves as before in that case.
+ *
+ * Tier 1 (pseudo parameters) fires `sts:GetCallerIdentity` once for
+ * `${AWS::AccountId}`; region / partition / URL suffix come from the CLI
+ * (`--region` → env vars → synth-derived stack region). Tier 2
+ * (`--from-state`) reuses the shared state-loader to pull cdkd's S3 state
+ * for the candidate stack — same warn-and-fall-back error policy as
+ * `cdkd local invoke --from-state`.
+ */
+async function buildEcsImageResolutionContext(
+  target: string,
+  stacks: StackInfo[],
+  options: LocalRunTaskOptions
+): Promise<EcsImageResolutionContext | undefined> {
+  const logger = getLogger();
+  const parsed = parseEcsTarget(target);
+  const candidate = pickCandidateStack(parsed.stackPattern, stacks);
+  if (!candidate) return undefined;
+
+  const needs = detectEcsImageResolutionNeeds(candidate);
+  if (!needs.needsPseudoParameters && !needs.needsStateResources) return undefined;
+
+  const ctx: EcsImageResolutionContext = {};
+
+  if (needs.needsPseudoParameters) {
+    const region =
+      options.region ??
+      process.env['AWS_REGION'] ??
+      process.env['AWS_DEFAULT_REGION'] ??
+      candidate.region;
+    if (!region) {
+      logger.warn(
+        'Container Image references ${AWS::Region} but cdkd could not determine the target region. ' +
+          'Pass --region, set AWS_REGION, or declare env.region on the CDK stack.'
+      );
+    }
+    let accountId: string | undefined;
+    try {
+      accountId = await resolveCallerAccountId(region);
+    } catch (err) {
+      logger.warn(
+        `Container Image references \${AWS::AccountId} but STS GetCallerIdentity failed: ${err instanceof Error ? err.message : String(err)}. ` +
+          'Substitution will be skipped; the resolver will surface its existing error.'
+      );
+    }
+    const partitionAndSuffix = region ? derivePartitionAndUrlSuffix(region) : undefined;
+    ctx.pseudoParameters = {
+      ...(accountId !== undefined && { accountId }),
+      ...(region !== undefined && { region }),
+      ...(partitionAndSuffix && {
+        partition: partitionAndSuffix.partition,
+        urlSuffix: partitionAndSuffix.urlSuffix,
+      }),
+    };
+  }
+
+  if (options.fromState && needs.needsStateResources) {
+    const loaded = await loadStateForStack(candidate.stackName, candidate.region, {
+      ...(options.stackRegion !== undefined && { stackRegion: options.stackRegion }),
+      ...(options.stateBucket !== undefined && { stateBucket: options.stateBucket }),
+      statePrefix: options.statePrefix,
+      ...(options.region !== undefined && { region: options.region }),
+      ...(options.profile !== undefined && { profile: options.profile }),
+    });
+    if (loaded) {
+      ctx.stateResources = loaded.state.resources;
+    }
+  } else if (!options.fromState && needs.needsStateResources) {
+    logger.warn(
+      'Container Image references a same-stack AWS::ECR::Repository. Pass --from-state to substitute the deployed repository URI ' +
+        '(requires the stack to have been deployed via cdkd deploy). Otherwise the resolver will surface its existing error.'
+    );
+  }
+
+  return ctx;
+}
+
+function pickCandidateStack(
+  stackPattern: string | null,
+  stacks: StackInfo[]
+): StackInfo | undefined {
+  if (stackPattern === null) {
+    if (stacks.length === 1) return stacks[0];
+    return undefined;
+  }
+  const matched = matchStacks(stacks, [stackPattern]);
+  if (matched.length === 1) return matched[0];
+  return undefined;
+}
+
+async function resolveCallerAccountId(region: string | undefined): Promise<string | undefined> {
+  const { STSClient, GetCallerIdentityCommand } = await import('@aws-sdk/client-sts');
+  const sts = new STSClient({ ...(region && { region }) });
+  try {
+    const identity = await sts.send(new GetCallerIdentityCommand({}));
+    return identity.Account;
+  } finally {
+    sts.destroy();
+  }
+}
+
+/**
  * Read the `--env-vars` JSON file using the same SAM-style shape as
  * `cdkd local invoke --env-vars`: top-level keys are container names, with
  * `Parameters` reserved for global entries.
@@ -346,9 +480,26 @@ export function createLocalRunTaskCommand(): Command {
           'Useful in CI smoke tests; caller manages container lifecycle.'
       ).default(false)
     )
+    .addOption(
+      new Option(
+        '--from-state',
+        'Read cdkd S3 state for the target stack and substitute Fn::Sub / Fn::GetAtt references to ' +
+          'same-stack AWS::ECR::Repository resources with the deployed URI. ' +
+          'Off by default — only the AWS pseudo-parameter tier (${AWS::AccountId} / ${AWS::Region}) ' +
+          'is resolved without this flag.'
+      ).default(false)
+    )
+    .addOption(
+      new Option(
+        '--stack-region <region>',
+        'Region of the cdkd state record to read (used with --from-state when the same stack name has state in multiple regions).'
+      )
+    )
     .action(withErrorHandling(localRunTaskCommand));
 
-  [...commonOptions, ...appOptions, ...contextOptions].forEach((opt) => cmd.addOption(opt));
+  [...commonOptions, ...appOptions, ...contextOptions, ...stateOptions].forEach((opt) =>
+    cmd.addOption(opt)
+  );
   cmd.addOption(deprecatedRegionOption);
   return cmd;
 }

--- a/src/cli/commands/local-state-loader.ts
+++ b/src/cli/commands/local-state-loader.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared `--from-state` state-loading helper for `cdkd local invoke` and
+ * `cdkd local run-task`. Extracted from `local-invoke.ts` so both commands
+ * route through one code path — same region resolution chain, same
+ * multi-region disambiguation, same warn-and-fall-back error policy.
+ *
+ * `--from-state` is opt-in: a broken state file shouldn't abort the
+ * invoke, so every "expected" miss (no record, ambiguous region without
+ * `--stack-region`, bucket resolution failure) logs at warn and returns
+ * `undefined`. Auth failures and other genuine errors propagate.
+ *
+ * Read-only against state — no lock acquisition or save path here.
+ */
+
+import { getLogger } from '../../utils/logger.js';
+import { AwsClients, setAwsClients } from '../../utils/aws-clients.js';
+import { S3StateBackend } from '../../state/s3-state-backend.js';
+import { resolveStateBucketWithDefault } from '../config-loader.js';
+import type { StackState } from '../../types/state.js';
+
+export interface LoadStateForStackOptions {
+  stackRegion?: string;
+  stateBucket?: string;
+  statePrefix: string;
+  region?: string;
+  profile?: string;
+  /**
+   * Logger prefix surfaced on every warn line — the `cdkd local invoke`
+   * caller uses `--from-state` so the existing UX stays identical; the
+   * run-task caller passes the same string for consistency.
+   */
+  logPrefix?: string;
+}
+
+export async function loadStateForStack(
+  stackName: string,
+  synthRegion: string | undefined,
+  opts: LoadStateForStackOptions
+): Promise<{ state: StackState; region: string } | undefined> {
+  const logger = getLogger();
+  const prefix = opts.logPrefix ?? '--from-state';
+
+  const region =
+    opts.region ??
+    process.env['AWS_REGION'] ??
+    process.env['AWS_DEFAULT_REGION'] ??
+    synthRegion ??
+    'us-east-1';
+
+  let stateBucket: string;
+  try {
+    stateBucket = await resolveStateBucketWithDefault(opts.stateBucket, region);
+  } catch (err) {
+    logger.warn(
+      `${prefix}: could not resolve state bucket: ${err instanceof Error ? err.message : String(err)}. Falling back.`
+    );
+    return undefined;
+  }
+
+  const awsClients = new AwsClients({
+    ...(opts.region !== undefined && { region: opts.region }),
+    ...(opts.profile !== undefined && { profile: opts.profile }),
+  });
+  setAwsClients(awsClients);
+
+  try {
+    const stateConfig = { bucket: stateBucket, prefix: opts.statePrefix };
+    const stateBackend = new S3StateBackend(awsClients.s3, stateConfig, {
+      ...(opts.region !== undefined && { region: opts.region }),
+      ...(opts.profile !== undefined && { profile: opts.profile }),
+    });
+    await stateBackend.verifyBucketExists();
+
+    const refs = (await stateBackend.listStacks()).filter((r) => r.stackName === stackName);
+    if (refs.length === 0) {
+      logger.warn(
+        `${prefix}: no cdkd state found for stack '${stackName}' in bucket '${stateBucket}'. ` +
+          `Was it deployed via 'cdkd deploy'? Falling back.`
+      );
+      return undefined;
+    }
+
+    let targetRegion: string;
+    if (opts.stackRegion) {
+      const found = refs.find((r) => r.region === opts.stackRegion);
+      if (!found) {
+        const seen = refs.map((r) => r.region ?? '(legacy)').join(', ');
+        logger.warn(
+          `${prefix}: stack '${stackName}' has no state in region '${opts.stackRegion}' (available: ${seen}). Falling back.`
+        );
+        return undefined;
+      }
+      targetRegion = opts.stackRegion;
+    } else if (synthRegion && refs.some((r) => r.region === synthRegion)) {
+      targetRegion = synthRegion;
+    } else if (refs.length === 1) {
+      targetRegion = refs[0]!.region ?? synthRegion ?? region;
+    } else {
+      const seen = refs.map((r) => r.region ?? '(legacy)').join(', ');
+      logger.warn(
+        `${prefix}: stack '${stackName}' has state in multiple regions (${seen}). ` +
+          `Re-run with --stack-region <region>. Falling back.`
+      );
+      return undefined;
+    }
+
+    const stateData = await stateBackend.getState(stackName, targetRegion);
+    if (!stateData) {
+      logger.warn(
+        `${prefix}: state record for '${stackName}' (${targetRegion}) returned empty. Falling back.`
+      );
+      return undefined;
+    }
+    logger.debug(`${prefix}: loaded state for ${stackName} (${targetRegion})`);
+    return { state: stateData.state, region: targetRegion };
+  } finally {
+    awsClients.destroy();
+  }
+}

--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -36,9 +36,22 @@ export interface ResolvedEcsTask {
    * through unchanged.
    */
   networkMode: 'bridge' | 'awsvpc' | 'host' | 'none';
-  /** Resolved task role ARN, or the raw intrinsic when unresolvable at synth time. */
+  /**
+   * Resolved task role ARN. Surfaced as either:
+   *   - a flat string ARN passed through verbatim from the template, OR
+   *   - a synth-time placeholder of the shape
+   *     `arn:aws:iam::${AWS::AccountId}:role/<RoleLogicalId>` when the
+   *     `TaskRoleArn` is a `Ref` / `Fn::GetAtt` against an `AWS::IAM::Role`
+   *     in the same stack. The CLI substitutes the placeholder account
+   *     segment lazily via STS `GetCallerIdentity` when (and only when)
+   *     `--assume-task-role` is used in its bare form.
+   *   - `undefined` when the template's `TaskRoleArn` is missing OR is an
+   *     intrinsic that doesn't reference a same-stack IAM Role (e.g.
+   *     points at a non-IAM-Role resource type or is an unsupported
+   *     intrinsic shape — see `resolveRoleArn`).
+   */
   taskRoleArn?: string;
-  /** Resolved execution role ARN. cdkd only consults this when surfacing config. */
+  /** Resolved execution role ARN. Follows the same shape as `taskRoleArn`. */
   executionRoleArn?: string;
   containers: ResolvedEcsContainer[];
   volumes: ResolvedEcsVolume[];
@@ -631,11 +644,25 @@ function parseVolume(raw: unknown, idx: number, taskLogicalId: string): Resolved
 }
 
 /**
+ * Synth-time placeholder marker used in the account-id segment of an ARN
+ * when the role's account cannot be known statically (the role is defined
+ * inline as an `AWS::IAM::Role` in the same stack). The CLI replaces this
+ * with the live account via STS `GetCallerIdentity` lazily — only when
+ * `--assume-task-role` is used in its bare form and the resolved ARN
+ * still contains this marker.
+ */
+export const TASK_ROLE_ACCOUNT_PLACEHOLDER = '${AWS::AccountId}';
+
+/**
  * Resolve a Task / Execution role ARN reference. Accepts a flat string ARN,
  * a `Ref` / `Fn::GetAtt[..., 'Arn']` against an `AWS::IAM::Role` in the
- * same stack (no state load needed — we surface the synth-time placeholder
- * when the value is intrinsic, so `--assume-task-role` can later route off
- * the explicit ARN the user passes).
+ * same stack. Returns a synth-time placeholder ARN of the shape
+ * `arn:aws:iam::${AWS::AccountId}:role/<RoleLogicalId>` when the
+ * referenced resource is an inline IAM Role (the account segment is filled
+ * in by the CLI lazily via STS). Returns `undefined` when the reference
+ * cannot be resolved to an IAM Role (e.g. the logical id is missing,
+ * points at some other resource type, or the value is some unsupported
+ * intrinsic shape).
  */
 function resolveRoleArn(
   value: unknown,
@@ -646,27 +673,24 @@ function resolveRoleArn(
   if (typeof value !== 'object') return undefined;
   const obj = value as Record<string, unknown>;
 
+  let refLogicalId: string | undefined;
   if ('Ref' in obj && typeof obj['Ref'] === 'string') {
-    const refLogicalId = obj['Ref'];
-    const role = resources[refLogicalId];
-    if (role?.Type === 'AWS::IAM::Role') {
-      // No state to resolve against — return undefined so caller surfaces
-      // a clear "no resolvable task role" message. The user passes the
-      // ARN explicitly via `--assume-task-role <arn>`.
-      return undefined;
-    }
-  }
-  if ('Fn::GetAtt' in obj) {
+    refLogicalId = obj['Ref'];
+  } else if ('Fn::GetAtt' in obj) {
     const arg = obj['Fn::GetAtt'];
     if (Array.isArray(arg) && typeof arg[0] === 'string') {
-      const refLogicalId = arg[0];
-      const role = resources[refLogicalId];
-      if (role?.Type === 'AWS::IAM::Role') {
-        return undefined;
-      }
+      // Accept `[<LogicalId>, 'Arn']`; other attribute names (rare on IAM
+      // Role refs) fall through to undefined since the placeholder we emit
+      // is always the role ARN shape.
+      const attr = typeof arg[1] === 'string' ? arg[1] : '';
+      if (attr === '' || attr === 'Arn') refLogicalId = arg[0];
     }
   }
-  return undefined;
+  if (refLogicalId === undefined) return undefined;
+
+  const role = resources[refLogicalId];
+  if (role?.Type !== 'AWS::IAM::Role') return undefined;
+  return `arn:aws:iam::${TASK_ROLE_ACCOUNT_PLACEHOLDER}:role/${refLogicalId}`;
 }
 
 function pickString(value: unknown): string | undefined {

--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -4,6 +4,7 @@ import type { StackInfo } from '../synthesis/assembly-reader.js';
 import type { TemplateResource } from '../types/resource.js';
 import { buildCdkPathIndex, resolveCdkPathToLogicalIds } from '../cli/cdk-path.js';
 import { matchStacks } from '../cli/stack-matcher.js';
+import type { ResourceState } from '../types/state.js';
 
 /**
  * Result of resolving a `cdkd local run-task <target>` argument back to a
@@ -129,6 +130,61 @@ export class EcsTaskResolutionError extends Error {
 }
 
 /**
+ * Derive the AWS partition / URL suffix for an AWS region. Same mapping
+ * CloudFormation applies to `${AWS::Partition}` / `${AWS::URLSuffix}`.
+ * Exported so the CLI can keep the STS hop minimal — caller passes the
+ * region in once, this returns the matching partition + suffix.
+ */
+export function derivePartitionAndUrlSuffix(region: string): {
+  partition: string;
+  urlSuffix: string;
+} {
+  if (region.startsWith('cn-')) return { partition: 'aws-cn', urlSuffix: 'amazonaws.com.cn' };
+  if (region.startsWith('us-gov-')) return { partition: 'aws-us-gov', urlSuffix: 'amazonaws.com' };
+  if (region.startsWith('us-iso-')) return { partition: 'aws-iso', urlSuffix: 'c2s.ic.gov' };
+  if (region.startsWith('us-isob-')) return { partition: 'aws-iso-b', urlSuffix: 'sc2s.sgov.gov' };
+  return { partition: 'aws', urlSuffix: 'amazonaws.com' };
+}
+
+/**
+ * Optional substitution data fed into `parseContainerImage`. Closes issue
+ * #264 — container `Image` fields shaped as `Fn::Sub` against AWS pseudo
+ * parameters (`${AWS::AccountId}` / `${AWS::Region}` / `${AWS::Partition}` /
+ * `${AWS::URLSuffix}`) and / or same-stack `AWS::ECR::Repository` refs are
+ * resolvable at runtime when the caller can supply the account ID + region
+ * (Tier 1, no state needed) and optionally the cdkd state-recorded
+ * `physicalId` map (Tier 2, `--from-state`).
+ *
+ * The CLI command resolves both blocks lazily — STS is only invoked when
+ * at least one container's `Image` references the pseudo parameters — and
+ * passes the resolved shape here. The resolver itself stays pure and
+ * synchronous.
+ */
+export interface EcsImageResolutionContext {
+  /**
+   * Resolved AWS pseudo parameters. When undefined for a given key, the
+   * substitution is treated as missing and the value passes through to
+   * the existing error path. Caller is expected to populate every key
+   * when it populates any (we derive partition / URL suffix from region
+   * in the CLI layer).
+   */
+  pseudoParameters?: {
+    accountId?: string;
+    region?: string;
+    partition?: string;
+    urlSuffix?: string;
+  };
+  /**
+   * `state.resources` from cdkd's S3 state record for the target stack,
+   * loaded by the CLI command before resolution when `--from-state` is
+   * passed. Used to substitute `${<LogicalId>}` against an
+   * `AWS::ECR::Repository` and the `Fn::GetAtt` `RepositoryUri` shape.
+   * Undefined when `--from-state` is not in effect.
+   */
+  stateResources?: Record<string, ResourceState>;
+}
+
+/**
  * Parse a `target` argument into (optional stack pattern, path-or-id).
  * Mirrors `lambda-resolver.parseTarget` exactly — same accepted forms,
  * same single-stack auto-detect rule.
@@ -137,6 +193,93 @@ export interface ParsedEcsTarget {
   stackPattern: string | null;
   pathOrId: string;
   isPath: boolean;
+}
+
+/**
+ * Walk the matched stack's template and report whether any container's
+ * `Image` field needs Tier 1 (pseudo-parameter) or Tier 2 (state-recorded
+ * ECR Repository) substitution. The CLI uses this to make the STS /
+ * state-load calls lazy — flat strings / cdk-asset shapes / Fn::Sub bodies
+ * with no recognized placeholders skip both calls entirely.
+ *
+ * The probe is per-stack rather than per-target because we don't run the
+ * full target resolver until the substitution context is built; cheap
+ * O(resources) scan over the template's task definitions is sufficient.
+ */
+export interface EcsImageResolutionNeeds {
+  /** Any `Fn::Sub` body references an `AWS::*` pseudo parameter. */
+  needsPseudoParameters: boolean;
+  /**
+   * Any `Fn::Sub` body references an `AWS::ECR::Repository` logical ID,
+   * OR any `Fn::GetAtt: [<Repo>, 'RepositoryUri' | 'Arn']` is present.
+   */
+  needsStateResources: boolean;
+}
+
+export function detectEcsImageResolutionNeeds(stack: StackInfo): EcsImageResolutionNeeds {
+  const resources = stack.template.Resources ?? {};
+  let needsPseudoParameters = false;
+  let needsStateResources = false;
+
+  for (const res of Object.values(resources)) {
+    if (res.Type !== 'AWS::ECS::TaskDefinition') continue;
+    const props = res.Properties ?? {};
+    const containers = Array.isArray(props['ContainerDefinitions'])
+      ? props['ContainerDefinitions']
+      : [];
+    for (const c of containers) {
+      if (!c || typeof c !== 'object') continue;
+      const image = (c as Record<string, unknown>)['Image'];
+      const need = inspectImageForSubstitutions(image, resources);
+      if (need.pseudo) needsPseudoParameters = true;
+      if (need.state) needsStateResources = true;
+      if (needsPseudoParameters && needsStateResources) break;
+    }
+    if (needsPseudoParameters && needsStateResources) break;
+  }
+  return { needsPseudoParameters, needsStateResources };
+}
+
+function inspectImageForSubstitutions(
+  image: unknown,
+  resources: Record<string, TemplateResource>
+): { pseudo: boolean; state: boolean } {
+  if (!image || typeof image !== 'object') return { pseudo: false, state: false };
+  const obj = image as Record<string, unknown>;
+
+  // Fn::GetAtt direct shape against an ECR::Repository — Tier 2 only.
+  const getAtt = obj['Fn::GetAtt'];
+  if (getAtt !== undefined) {
+    let lid: string | undefined;
+    if (Array.isArray(getAtt) && typeof getAtt[0] === 'string') lid = getAtt[0];
+    else if (typeof getAtt === 'string') lid = getAtt.split('.')[0];
+    if (lid && resources[lid]?.Type === 'AWS::ECR::Repository') {
+      return { pseudo: false, state: true };
+    }
+  }
+
+  // Fn::Sub body: scan every `${...}` placeholder.
+  let sub: string | undefined;
+  const subRaw = obj['Fn::Sub'];
+  if (typeof subRaw === 'string') sub = subRaw;
+  else if (Array.isArray(subRaw) && typeof subRaw[0] === 'string') sub = subRaw[0];
+  if (!sub) return { pseudo: false, state: false };
+
+  let pseudo = false;
+  let state = false;
+  const placeholderRegex = /\$\{([^}]+)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = placeholderRegex.exec(sub)) !== null) {
+    const key = m[1]!;
+    if (key.startsWith('AWS::')) {
+      pseudo = true;
+      continue;
+    }
+    const dot = key.indexOf('.');
+    const lid = dot === -1 ? key : key.slice(0, dot);
+    if (resources[lid]?.Type === 'AWS::ECR::Repository') state = true;
+  }
+  return { pseudo, state };
 }
 
 export function parseEcsTarget(target: string): ParsedEcsTarget {
@@ -165,8 +308,18 @@ export function parseEcsTarget(target: string): ParsedEcsTarget {
  * Resolve a parsed target against the synthesized stacks. Throws
  * `EcsTaskResolutionError` with an actionable message (listing every
  * available task definition in the matched stack) on any miss.
+ *
+ * Optional `context` (issue #264): when the caller can supply AWS
+ * pseudo-parameter values (Tier 1) and / or cdkd state-recorded resources
+ * (Tier 2), `Fn::Sub`-shaped ECR image URIs that reference
+ * `${AWS::AccountId}` / `${AWS::Region}` / a same-stack
+ * `AWS::ECR::Repository` are substituted before classification.
  */
-export function resolveEcsTaskTarget(target: string, stacks: StackInfo[]): ResolvedEcsTask {
+export function resolveEcsTaskTarget(
+  target: string,
+  stacks: StackInfo[],
+  context?: EcsImageResolutionContext
+): ResolvedEcsTask {
   if (stacks.length === 0) {
     throw new EcsTaskResolutionError('No stacks found in the synthesized assembly.');
   }
@@ -215,7 +368,7 @@ export function resolveEcsTaskTarget(target: string, stacks: StackInfo[]): Resol
     );
   }
 
-  return extractTaskDefinitionProperties(stack, logicalId, resource);
+  return extractTaskDefinitionProperties(stack, logicalId, resource, context);
 }
 
 function pickStack(parsed: ParsedEcsTarget, stacks: StackInfo[]): StackInfo {
@@ -247,7 +400,8 @@ function pickStack(parsed: ParsedEcsTarget, stacks: StackInfo[]): StackInfo {
 function extractTaskDefinitionProperties(
   stack: StackInfo,
   logicalId: string,
-  resource: TemplateResource
+  resource: TemplateResource,
+  context?: EcsImageResolutionContext
 ): ResolvedEcsTask {
   const props = resource.Properties ?? {};
   const warnings: string[] = [];
@@ -288,7 +442,7 @@ function extractTaskDefinitionProperties(
     throw new EcsTaskResolutionError(`Task definition '${logicalId}' has no ContainerDefinitions.`);
   }
   const containers = rawContainers.map((c, idx) =>
-    parseContainerDefinition(c, idx, logicalId, resources, stack)
+    parseContainerDefinition(c, idx, logicalId, resources, stack, context)
   );
 
   const rawVolumes = props['Volumes'];
@@ -340,7 +494,8 @@ function parseContainerDefinition(
   idx: number,
   taskLogicalId: string,
   resources: Record<string, TemplateResource>,
-  stack: StackInfo
+  stack: StackInfo,
+  context?: EcsImageResolutionContext
 ): ResolvedEcsContainer {
   if (!raw || typeof raw !== 'object') {
     throw new EcsTaskResolutionError(
@@ -355,7 +510,7 @@ function parseContainerDefinition(
     );
   }
 
-  const image = parseContainerImage(c['Image'], name, taskLogicalId, resources, stack);
+  const image = parseContainerImage(c['Image'], name, taskLogicalId, resources, stack, context);
 
   const command = pickStringArray(c['Command']);
   const entryPoint = pickStringArray(c['EntryPoint']);
@@ -509,14 +664,40 @@ function parseContainerDefinition(
  *     asset hash so the runner can route through `docker-build.ts`.
  *   - Any other public URI (`public.ecr.aws/...`, `docker.io/...`,
  *     `nginx:latest`, etc.) — `kind: 'public'`, runner does a `docker pull`.
+ *
+ * Two-tier substitution (issue #264):
+ *   - **Tier 1** — when `context.pseudoParameters` is populated, AWS pseudo
+ *     parameters in `Fn::Sub` bodies (`${AWS::AccountId}` / `${AWS::Region}` /
+ *     `${AWS::Partition}` / `${AWS::URLSuffix}`) are substituted before
+ *     regex matching. The CLI resolves these via STS + region env once
+ *     per invocation.
+ *   - **Tier 2** — when `context.stateResources` is populated
+ *     (`--from-state`), `${<LogicalId>}` placeholders that resolve to an
+ *     `AWS::ECR::Repository` are substituted with the state-recorded
+ *     `physicalId`, and `Fn::GetAtt: [<Repo>, 'RepositoryUri']` shapes
+ *     are resolved via the same state record.
+ *
+ * Tier 3 (cross-account / cross-region pull) is deferred — `pullEcrImage`
+ * surfaces the same workaround pointer it already does.
  */
 function parseContainerImage(
   raw: unknown,
   containerName: string,
   taskLogicalId: string,
   resources: Record<string, TemplateResource>,
-  _stack: StackInfo
+  _stack: StackInfo,
+  context?: EcsImageResolutionContext
 ): ResolvedEcsImage {
+  // Tier 2: handle `Fn::GetAtt: [<Repo>, 'RepositoryUri']` directly — it
+  // produces a complete `<acct>.dkr.ecr.<region>.amazonaws.com/<name>` URI
+  // we can match against the ECR regex below. The tag is whatever the
+  // template provides; for the bare GetAtt shape there is none, which is
+  // unusual but we surface the resulting tagless URI rather than guess.
+  const getAttImage = tryResolveImageGetAtt(raw, resources, context);
+  if (getAttImage) {
+    return classifyResolvedImage(getAttImage);
+  }
+
   const flat = extractImageString(raw);
   if (!flat) {
     throw new EcsTaskResolutionError(
@@ -535,34 +716,185 @@ function parseContainerImage(
     return out;
   }
 
-  // Account-scoped ECR repo.
-  const ecrMatch = /^(\d{12})\.dkr\.ecr\.([^.]+)\.amazonaws\.com(?:\.cn)?\//.exec(flat);
-  if (ecrMatch) {
-    return { kind: 'ecr', uri: flat, account: ecrMatch[1]!, region: ecrMatch[2]! };
-  }
+  // Substitute pseudo parameters + same-stack ECR Ref placeholders into
+  // the flat string when context is supplied. Pure string-rewrite —
+  // unresolved placeholders pass through verbatim so the post-walk
+  // diagnostics below can route to the precise error message.
+  const substituted = substituteImagePlaceholders(flat, resources, context);
 
-  // A ref to a same-stack ECR repository (Fn::Sub embeds it). We can't
-  // resolve the repo URI without state; surface a clearer error than
-  // letting the runner try to `docker pull` a placeholder.
-  if (flat.includes('${') && flat.includes('AWS::AccountId')) {
-    throw new EcsTaskResolutionError(
-      `Container '${containerName}' in task '${taskLogicalId}' has an Image that references AWS pseudo parameters (${flat}). ` +
-        'cdkd local run-task v1 cannot resolve account-scoped ECR repos at synth time. ' +
-        'Build the image locally (CDK ContainerImage.fromAsset) or pin to a public image to test locally.'
-    );
-  }
-  // A Ref / GetAtt to a same-stack ECR::Repository that we cannot resolve
-  // statically. Match against the resources map to surface a precise hint.
-  for (const [refLogicalId, res] of Object.entries(resources)) {
-    if (res.Type === 'AWS::ECR::Repository' && flat.includes(refLogicalId)) {
+  // Unresolved `${...}` placeholders survived substitution. Surface a
+  // precise hint BEFORE the ECR regex match — otherwise a leftover
+  // `${MyRepo}` in the path portion would still match the host-portion
+  // regex and silently produce a broken URI for `docker pull` to fail on.
+  if (substituted.includes('${')) {
+    const unresolvedRepoRef = findUnresolvedEcrRepositoryRef(substituted, resources);
+    if (unresolvedRepoRef) {
       throw new EcsTaskResolutionError(
-        `Container '${containerName}' in task '${taskLogicalId}' references same-stack ECR repository '${refLogicalId}'. ` +
-          'cdkd local run-task v1 cannot resolve the repository URI without state — build via ContainerImage.fromAsset or pin a public image.'
+        `Container '${containerName}' in task '${taskLogicalId}' references same-stack ECR repository '${unresolvedRepoRef}'. ` +
+          'cdkd local run-task v1 cannot resolve the repository URI without state — ' +
+          'pass --from-state (the stack must have been deployed via cdkd deploy), ' +
+          'build via ContainerImage.fromAsset, or pin a public image.'
       );
     }
+    if (substituted.includes('AWS::')) {
+      throw new EcsTaskResolutionError(
+        `Container '${containerName}' in task '${taskLogicalId}' has an Image that references AWS pseudo parameters (${substituted}). ` +
+          'cdkd could not resolve them: confirm AWS credentials are configured so STS GetCallerIdentity succeeds, ' +
+          'and that --region / AWS_REGION names the target region. ' +
+          'Workaround: build the image locally (ContainerImage.fromAsset) or pin a public image.'
+      );
+    }
+    // Some other placeholder survived (e.g. a Parameter ref). Surface as
+    // a generic resolver failure rather than letting it slip through as
+    // a "public" image.
+    throw new EcsTaskResolutionError(
+      `Container '${containerName}' in task '${taskLogicalId}' has an Image with unresolved \${...} placeholders (${substituted}). ` +
+        'cdkd local run-task v1 only resolves AWS pseudo parameters and same-stack AWS::ECR::Repository refs.'
+    );
   }
 
-  return { kind: 'public', uri: flat };
+  // Account-scoped ECR repo.
+  const ecrMatch = /^(\d{12})\.dkr\.ecr\.([^.]+)\.amazonaws\.com(?:\.cn)?\//.exec(substituted);
+  if (ecrMatch) {
+    return { kind: 'ecr', uri: substituted, account: ecrMatch[1]!, region: ecrMatch[2]! };
+  }
+
+  return { kind: 'public', uri: substituted };
+}
+
+/**
+ * When the flat string still contains `${X}` after substitution, check
+ * whether `X` (or `X.<attr>`) names a same-stack `AWS::ECR::Repository`.
+ * Returns the logical ID of the offending repo for a precise error
+ * message; `undefined` otherwise.
+ */
+function findUnresolvedEcrRepositoryRef(
+  substituted: string,
+  resources: Record<string, TemplateResource>
+): string | undefined {
+  const placeholderRegex = /\$\{([^}]+)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = placeholderRegex.exec(substituted)) !== null) {
+    const key = m[1]!;
+    if (key.startsWith('AWS::')) continue;
+    const dot = key.indexOf('.');
+    const lid = dot === -1 ? key : key.slice(0, dot);
+    if (resources[lid]?.Type === 'AWS::ECR::Repository') return lid;
+  }
+  return undefined;
+}
+
+/**
+ * Classify a fully-substituted image URI (Tier 1 / Tier 2 produced a
+ * concrete string) into the `ResolvedEcsImage` shape. Splits out so the
+ * `Fn::GetAtt` path can share the regex-match branches.
+ */
+function classifyResolvedImage(uri: string): ResolvedEcsImage {
+  if (uri.includes('cdk-hnb659fds-container-assets-')) {
+    const hashMatch = /:([a-f0-9]{8,})$/.exec(uri);
+    const out: ResolvedEcsImage = { kind: 'cdk-asset' };
+    if (hashMatch) out.assetHash = hashMatch[1]!;
+    return out;
+  }
+  const ecrMatch = /^(\d{12})\.dkr\.ecr\.([^.]+)\.amazonaws\.com(?:\.cn)?\//.exec(uri);
+  if (ecrMatch) {
+    return { kind: 'ecr', uri, account: ecrMatch[1]!, region: ecrMatch[2]! };
+  }
+  return { kind: 'public', uri };
+}
+
+/**
+ * Substitute Tier 1 (pseudo-parameter) and Tier 2 (state-recorded ECR
+ * Repository physical id) placeholders inside a `Fn::Sub`-derived flat
+ * string. Substitutions are best-effort per placeholder: every `${...}`
+ * we recognize is replaced; unknown placeholders (or recognized ones for
+ * which we have no value) pass through untouched so the caller's error
+ * path can name them.
+ */
+function substituteImagePlaceholders(
+  flat: string,
+  resources: Record<string, TemplateResource>,
+  context: EcsImageResolutionContext | undefined
+): string {
+  if (!flat.includes('${')) return flat;
+  return flat.replace(/\$\{([^}]+)\}/g, (full, key: string) => {
+    if (context?.pseudoParameters) {
+      if (key === 'AWS::AccountId' && context.pseudoParameters.accountId) {
+        return context.pseudoParameters.accountId;
+      }
+      if (key === 'AWS::Region' && context.pseudoParameters.region) {
+        return context.pseudoParameters.region;
+      }
+      if (key === 'AWS::Partition' && context.pseudoParameters.partition) {
+        return context.pseudoParameters.partition;
+      }
+      if (key === 'AWS::URLSuffix' && context.pseudoParameters.urlSuffix) {
+        return context.pseudoParameters.urlSuffix;
+      }
+    }
+    if (context?.stateResources) {
+      const dot = key.indexOf('.');
+      const logicalId = dot === -1 ? key : key.slice(0, dot);
+      const refResource = resources[logicalId];
+      const stateEntry = context.stateResources[logicalId];
+      if (refResource?.Type === 'AWS::ECR::Repository' && stateEntry) {
+        if (dot === -1) {
+          // `${<Repo>}` → the repository's physical id (its Name).
+          return stateEntry.physicalId;
+        }
+        const attr = key.slice(dot + 1);
+        const cached = stateEntry.attributes?.[attr];
+        if (typeof cached === 'string') return cached;
+      }
+    }
+    return full;
+  });
+}
+
+/**
+ * Handle the discrete `Fn::GetAtt: [<Repo>, 'RepositoryUri']` /
+ * `'<Repo>.RepositoryUri'` shape against state-recorded resources. CDK
+ * occasionally emits this instead of `Fn::Sub` when the user writes
+ * `ContainerImage.fromEcrRepository(repo, tag)` and the tag is a literal.
+ * Returns the resolved URI string on hit, `undefined` on miss (the caller
+ * falls through to `extractImageString` for `Fn::Sub` / `Fn::Join` / `Ref`).
+ */
+function tryResolveImageGetAtt(
+  raw: unknown,
+  resources: Record<string, TemplateResource>,
+  context: EcsImageResolutionContext | undefined
+): string | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const obj = raw as Record<string, unknown>;
+  const arg = obj['Fn::GetAtt'];
+  if (arg === undefined) return undefined;
+
+  let logicalId: string | undefined;
+  let attr: string | undefined;
+  if (
+    Array.isArray(arg) &&
+    arg.length === 2 &&
+    typeof arg[0] === 'string' &&
+    typeof arg[1] === 'string'
+  ) {
+    logicalId = arg[0];
+    attr = arg[1];
+  } else if (typeof arg === 'string') {
+    const dot = arg.indexOf('.');
+    if (dot > 0 && dot < arg.length - 1) {
+      logicalId = arg.slice(0, dot);
+      attr = arg.slice(dot + 1);
+    }
+  }
+  if (!logicalId || !attr) return undefined;
+
+  const refResource = resources[logicalId];
+  if (refResource?.Type !== 'AWS::ECR::Repository') return undefined;
+  if (attr !== 'RepositoryUri' && attr !== 'Arn') return undefined;
+
+  const cached = context?.stateResources?.[logicalId]?.attributes?.[attr];
+  if (typeof cached === 'string' && cached.length > 0) return cached;
+  return undefined;
 }
 
 function extractImageString(value: unknown): string | undefined {

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -331,7 +331,7 @@ export function buildDependencyGraph(containers: ResolvedEcsContainer[]): graphl
   return g;
 }
 
-function topoSort(g: graphlib.Graph, containers: ResolvedEcsContainer[]): string[] {
+export function topoSort(g: graphlib.Graph, containers: ResolvedEcsContainer[]): string[] {
   // graphlib.alg.topsort returns roots LAST given our edge direction; we
   // need dependencies (B) first, so we reverse. Fall back to template
   // order on a tie (preserves the user's intent for siblings with no

--- a/tests/unit/cli/local-run-task.test.ts
+++ b/tests/unit/cli/local-run-task.test.ts
@@ -63,4 +63,32 @@ describe('createLocalRunTaskCommand', () => {
     const parsed = cmd.parse(['node', 'cdkd', 'TD', '--no-pull'], { from: 'user' });
     expect(parsed.opts().pull).toBe(false);
   });
+
+  it('declares the --from-state and --stack-region options (issue #264)', () => {
+    const longs = cmd.options.map((o) => o.long);
+    expect(longs).toContain('--from-state');
+    expect(longs).toContain('--stack-region');
+    expect(longs).toContain('--state-bucket');
+    expect(longs).toContain('--state-prefix');
+  });
+
+  it('parses --from-state as fromState=true', () => {
+    const fresh = createLocalRunTaskCommand();
+    const parsed = fresh.parse(['node', 'cdkd', 'TD', '--from-state'], { from: 'user' });
+    expect(parsed.opts().fromState).toBe(true);
+  });
+
+  it('defaults --from-state to false', () => {
+    const fresh = createLocalRunTaskCommand();
+    const parsed = fresh.parse(['node', 'cdkd', 'TD'], { from: 'user' });
+    expect(parsed.opts().fromState).toBe(false);
+  });
+
+  it('parses --stack-region <region> as stackRegion=<region>', () => {
+    const fresh = createLocalRunTaskCommand();
+    const parsed = fresh.parse(['node', 'cdkd', 'TD', '--stack-region', 'us-west-2'], {
+      from: 'user',
+    });
+    expect(parsed.opts().stackRegion).toBe('us-west-2');
+  });
 });

--- a/tests/unit/local/ecs-task-resolver.test.ts
+++ b/tests/unit/local/ecs-task-resolver.test.ts
@@ -3,6 +3,7 @@ import {
   EcsTaskResolutionError,
   parseEcsTarget,
   resolveEcsTaskTarget,
+  TASK_ROLE_ACCOUNT_PLACEHOLDER,
 } from '../../../src/local/ecs-task-resolver.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 import type { CloudFormationTemplate, TemplateResource } from '../../../src/types/resource.js';
@@ -250,5 +251,71 @@ describe('resolveEcsTaskTarget', () => {
       TD: makeTaskDef({ cdkPath: 'S1/Foo/TaskDef' }),
     });
     expect(() => resolveEcsTaskTarget('S1:NotThere', [stack])).toThrow(/did not match/);
+  });
+
+  describe('TaskRoleArn resolution', () => {
+    function makeRole(): TemplateResource {
+      return {
+        Type: 'AWS::IAM::Role',
+        Properties: { AssumeRolePolicyDocument: { Version: '2012-10-17', Statement: [] } },
+      };
+    }
+
+    it('passes through a flat string ARN unchanged', () => {
+      const stack = buildStack('S1', {
+        TD: makeTaskDef({ taskRoleArn: 'arn:aws:iam::111111111111:role/MyRole' }),
+      });
+      const r = resolveEcsTaskTarget('TD', [stack]);
+      expect(r.taskRoleArn).toBe('arn:aws:iam::111111111111:role/MyRole');
+    });
+
+    it('surfaces a placeholder ARN when TaskRoleArn is {Ref: <IAM::Role>}', () => {
+      const stack = buildStack('S1', {
+        MyRole: makeRole(),
+        TD: makeTaskDef({ taskRoleArn: { Ref: 'MyRole' } }),
+      });
+      const r = resolveEcsTaskTarget('TD', [stack]);
+      expect(r.taskRoleArn).toBe(`arn:aws:iam::${TASK_ROLE_ACCOUNT_PLACEHOLDER}:role/MyRole`);
+    });
+
+    it('surfaces a placeholder ARN when TaskRoleArn is {Fn::GetAtt: [<IAM::Role>, "Arn"]}', () => {
+      const stack = buildStack('S1', {
+        MyRole: makeRole(),
+        TD: makeTaskDef({ taskRoleArn: { 'Fn::GetAtt': ['MyRole', 'Arn'] } }),
+      });
+      const r = resolveEcsTaskTarget('TD', [stack]);
+      expect(r.taskRoleArn).toBe(`arn:aws:iam::${TASK_ROLE_ACCOUNT_PLACEHOLDER}:role/MyRole`);
+    });
+
+    it('returns undefined when TaskRoleArn references a non-IAM-Role resource type', () => {
+      const stack = buildStack('S1', {
+        Bucket: { Type: 'AWS::S3::Bucket', Properties: {} },
+        TD: makeTaskDef({ taskRoleArn: { Ref: 'Bucket' } }),
+      });
+      const r = resolveEcsTaskTarget('TD', [stack]);
+      expect(r.taskRoleArn).toBeUndefined();
+    });
+
+    it('returns undefined when TaskRoleArn references a missing logical id', () => {
+      const stack = buildStack('S1', {
+        TD: makeTaskDef({ taskRoleArn: { Ref: 'DoesNotExist' } }),
+      });
+      const r = resolveEcsTaskTarget('TD', [stack]);
+      expect(r.taskRoleArn).toBeUndefined();
+    });
+
+    it('returns undefined when TaskRoleArn is an unsupported intrinsic shape', () => {
+      const stack = buildStack('S1', {
+        TD: makeTaskDef({ taskRoleArn: { 'Fn::Sub': '${SomeParam}' } }),
+      });
+      const r = resolveEcsTaskTarget('TD', [stack]);
+      expect(r.taskRoleArn).toBeUndefined();
+    });
+
+    it('returns undefined when TaskRoleArn is absent', () => {
+      const stack = buildStack('S1', { TD: makeTaskDef({}) });
+      const r = resolveEcsTaskTarget('TD', [stack]);
+      expect(r.taskRoleArn).toBeUndefined();
+    });
   });
 });

--- a/tests/unit/local/ecs-task-resolver.test.ts
+++ b/tests/unit/local/ecs-task-resolver.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  derivePartitionAndUrlSuffix,
+  detectEcsImageResolutionNeeds,
   EcsTaskResolutionError,
   parseEcsTarget,
   resolveEcsTaskTarget,
@@ -7,6 +9,7 @@ import {
 } from '../../../src/local/ecs-task-resolver.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 import type { CloudFormationTemplate, TemplateResource } from '../../../src/types/resource.js';
+import type { ResourceState } from '../../../src/types/state.js';
 
 function buildStack(name: string, resources: Record<string, TemplateResource>): StackInfo {
   const template: CloudFormationTemplate = { Resources: resources };
@@ -99,7 +102,10 @@ describe('resolveEcsTaskTarget', () => {
 
   it('falls back to logical id when no family', () => {
     const stack = buildStack('S1', {
-      TD: { Type: 'AWS::ECS::TaskDefinition', Properties: { ContainerDefinitions: [{ Name: 'a', Image: 'nginx' }] } },
+      TD: {
+        Type: 'AWS::ECS::TaskDefinition',
+        Properties: { ContainerDefinitions: [{ Name: 'a', Image: 'nginx' }] },
+      },
     });
     const r = resolveEcsTaskTarget('TD', [stack]);
     expect(r.family).toBe('TD');
@@ -157,7 +163,9 @@ describe('resolveEcsTaskTarget', () => {
     expect(app.secrets).toEqual([
       { name: 'API_KEY', valueFrom: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:k' },
     ]);
-    expect(app.mountPoints).toEqual([{ sourceVolume: 'shared', containerPath: '/data', readOnly: true }]);
+    expect(app.mountPoints).toEqual([
+      { sourceVolume: 'shared', containerPath: '/data', readOnly: true },
+    ]);
     expect(app.dependsOn).toEqual([{ containerName: 'sidecar', condition: 'START' }]);
     expect(app.healthCheck?.command).toEqual(['CMD', 'true']);
     expect(app.essential).toBe(false);
@@ -166,7 +174,9 @@ describe('resolveEcsTaskTarget', () => {
 
   it('extracts RuntimePlatform when X86_64/LINUX', () => {
     const stack = buildStack('S1', {
-      TD: makeTaskDef({ runtimePlatform: { CpuArchitecture: 'ARM64', OperatingSystemFamily: 'LINUX' } }),
+      TD: makeTaskDef({
+        runtimePlatform: { CpuArchitecture: 'ARM64', OperatingSystemFamily: 'LINUX' },
+      }),
     });
     const r = resolveEcsTaskTarget('TD', [stack]);
     expect(r.runtimePlatform).toEqual({ cpuArchitecture: 'ARM64', operatingSystemFamily: 'LINUX' });
@@ -231,7 +241,9 @@ describe('resolveEcsTaskTarget', () => {
   it('rejects an unresolved AccountId pseudo-parameter image', () => {
     const stack = buildStack('S1', {
       TD: makeTaskDef({
-        image: { 'Fn::Sub': '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/myrepo:latest' },
+        image: {
+          'Fn::Sub': '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/myrepo:latest',
+        },
       }),
     });
     expect(() => resolveEcsTaskTarget('TD', [stack])).toThrow(/pseudo parameters/);
@@ -317,5 +329,220 @@ describe('resolveEcsTaskTarget', () => {
       const r = resolveEcsTaskTarget('TD', [stack]);
       expect(r.taskRoleArn).toBeUndefined();
     });
+  });
+
+  it('resolves Fn::Sub pseudo-parameter ECR image via Tier 1 context', () => {
+    const stack = buildStack('S1', {
+      TD: makeTaskDef({
+        image: {
+          'Fn::Sub': '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/myrepo:latest',
+        },
+      }),
+    });
+    const r = resolveEcsTaskTarget('TD', [stack], {
+      pseudoParameters: {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        partition: 'aws',
+        urlSuffix: 'amazonaws.com',
+      },
+    });
+    const img = r.containers[0]!.image;
+    expect(img.kind).toBe('ecr');
+    if (img.kind === 'ecr') {
+      expect(img.uri).toBe('123456789012.dkr.ecr.us-east-1.amazonaws.com/myrepo:latest');
+      expect(img.account).toBe('123456789012');
+      expect(img.region).toBe('us-east-1');
+    }
+  });
+
+  it('resolves Fn::Sub with cn-north-1 partition into amazonaws.com.cn URI', () => {
+    const stack = buildStack('S1', {
+      TD: makeTaskDef({
+        image: {
+          'Fn::Sub': '${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/myrepo:latest',
+        },
+      }),
+    });
+    const r = resolveEcsTaskTarget('TD', [stack], {
+      pseudoParameters: {
+        accountId: '210987654321',
+        region: 'cn-north-1',
+        partition: 'aws-cn',
+        urlSuffix: 'amazonaws.com.cn',
+      },
+    });
+    const img = r.containers[0]!.image;
+    expect(img.kind).toBe('ecr');
+    if (img.kind === 'ecr') {
+      expect(img.uri).toBe('210987654321.dkr.ecr.cn-north-1.amazonaws.com.cn/myrepo:latest');
+    }
+  });
+
+  it('hard-errors with --from-state hint when Fn::Sub references a same-stack ECR Repo and no state was provided', () => {
+    const stack = buildStack('S1', {
+      MyRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+      TD: makeTaskDef({
+        image: {
+          'Fn::Sub': '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${MyRepo}:tag',
+        },
+      }),
+    });
+    // Tier 1 only — substitutes pseudo parameters but leaves `${MyRepo}` for state.
+    expect(() =>
+      resolveEcsTaskTarget('TD', [stack], {
+        pseudoParameters: {
+          accountId: '123456789012',
+          region: 'us-east-1',
+          partition: 'aws',
+          urlSuffix: 'amazonaws.com',
+        },
+      })
+    ).toThrow(/--from-state/);
+  });
+
+  it('resolves Fn::Sub with same-stack ECR Repo Ref via Tier 2 state', () => {
+    const stack = buildStack('S1', {
+      MyRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+      TD: makeTaskDef({
+        image: {
+          'Fn::Sub': '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${MyRepo}:tag',
+        },
+      }),
+    });
+    const stateResources: Record<string, ResourceState> = {
+      MyRepo: {
+        physicalId: 'deployed-repo-name',
+        resourceType: 'AWS::ECR::Repository',
+        properties: {},
+        attributes: {
+          RepositoryUri: '123456789012.dkr.ecr.us-east-1.amazonaws.com/deployed-repo-name',
+        },
+        dependencies: [],
+      },
+    };
+    const r = resolveEcsTaskTarget('TD', [stack], {
+      pseudoParameters: {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        partition: 'aws',
+        urlSuffix: 'amazonaws.com',
+      },
+      stateResources,
+    });
+    const img = r.containers[0]!.image;
+    expect(img.kind).toBe('ecr');
+    if (img.kind === 'ecr') {
+      expect(img.uri).toBe('123456789012.dkr.ecr.us-east-1.amazonaws.com/deployed-repo-name:tag');
+    }
+  });
+
+  it('resolves Fn::GetAtt [Repo, RepositoryUri] via Tier 2 state', () => {
+    const stack = buildStack('S1', {
+      MyRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+      TD: makeTaskDef({
+        image: { 'Fn::GetAtt': ['MyRepo', 'RepositoryUri'] },
+      }),
+    });
+    const stateResources: Record<string, ResourceState> = {
+      MyRepo: {
+        physicalId: 'deployed-repo-name',
+        resourceType: 'AWS::ECR::Repository',
+        properties: {},
+        attributes: {
+          RepositoryUri: '123456789012.dkr.ecr.us-east-1.amazonaws.com/deployed-repo-name',
+        },
+        dependencies: [],
+      },
+    };
+    const r = resolveEcsTaskTarget('TD', [stack], { stateResources });
+    const img = r.containers[0]!.image;
+    expect(img.kind).toBe('ecr');
+    if (img.kind === 'ecr') {
+      expect(img.uri).toBe('123456789012.dkr.ecr.us-east-1.amazonaws.com/deployed-repo-name');
+    }
+  });
+
+  it('plain string image stays a public pass-through regardless of context', () => {
+    const stack = buildStack('S1', { TD: makeTaskDef({ image: 'nginx:alpine' }) });
+    const r = resolveEcsTaskTarget('TD', [stack], {
+      pseudoParameters: { accountId: '123', region: 'us-east-1' },
+    });
+    expect(r.containers[0]!.image.kind).toBe('public');
+  });
+});
+
+describe('derivePartitionAndUrlSuffix', () => {
+  it('returns aws / amazonaws.com for commercial regions', () => {
+    expect(derivePartitionAndUrlSuffix('us-east-1')).toEqual({
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+    expect(derivePartitionAndUrlSuffix('eu-west-1')).toEqual({
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+  });
+  it('returns aws-cn / amazonaws.com.cn for cn-* regions', () => {
+    expect(derivePartitionAndUrlSuffix('cn-north-1')).toEqual({
+      partition: 'aws-cn',
+      urlSuffix: 'amazonaws.com.cn',
+    });
+  });
+  it('returns aws-us-gov / amazonaws.com for us-gov-* regions', () => {
+    expect(derivePartitionAndUrlSuffix('us-gov-west-1')).toEqual({
+      partition: 'aws-us-gov',
+      urlSuffix: 'amazonaws.com',
+    });
+  });
+});
+
+describe('detectEcsImageResolutionNeeds', () => {
+  it('returns false/false for plain string + cdk-asset images', () => {
+    const stack = buildStack('S1', {
+      A: makeTaskDef({ image: 'nginx:alpine' }),
+      B: makeTaskDef({
+        image: {
+          'Fn::Sub':
+            '${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/cdk-hnb659fds-container-assets-${AWS::AccountId}-${AWS::Region}:deadbeefcafef00d',
+        },
+      }),
+    });
+    // cdk-asset shape DOES include pseudo placeholders — we still report
+    // needsPseudoParameters=true so the CLI can supply them; the
+    // resolver's cdk-asset branch wins downstream regardless.
+    const needs = detectEcsImageResolutionNeeds(stack);
+    expect(needs.needsPseudoParameters).toBe(true);
+    expect(needs.needsStateResources).toBe(false);
+  });
+  it('flags pseudo-parameter-only Fn::Sub as Tier 1 only', () => {
+    const stack = buildStack('S1', {
+      TD: makeTaskDef({
+        image: { 'Fn::Sub': '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/r:t' },
+      }),
+    });
+    const needs = detectEcsImageResolutionNeeds(stack);
+    expect(needs.needsPseudoParameters).toBe(true);
+    expect(needs.needsStateResources).toBe(false);
+  });
+  it('flags Fn::Sub with same-stack ECR Repo as Tier 1 + Tier 2', () => {
+    const stack = buildStack('S1', {
+      MyRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+      TD: makeTaskDef({
+        image: { 'Fn::Sub': '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${MyRepo}:t' },
+      }),
+    });
+    const needs = detectEcsImageResolutionNeeds(stack);
+    expect(needs.needsPseudoParameters).toBe(true);
+    expect(needs.needsStateResources).toBe(true);
+  });
+  it('flags Fn::GetAtt against an ECR Repository as Tier 2 only', () => {
+    const stack = buildStack('S1', {
+      MyRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+      TD: makeTaskDef({ image: { 'Fn::GetAtt': ['MyRepo', 'RepositoryUri'] } }),
+    });
+    const needs = detectEcsImageResolutionNeeds(stack);
+    expect(needs.needsPseudoParameters).toBe(false);
+    expect(needs.needsStateResources).toBe(true);
   });
 });

--- a/tests/unit/local/ecs-task-runner-runner.test.ts
+++ b/tests/unit/local/ecs-task-runner-runner.test.ts
@@ -1,0 +1,805 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  ResolvedEcsContainer,
+  ResolvedEcsTask,
+  ResolvedEcsVolume,
+} from '../../../src/local/ecs-task-resolver.js';
+
+// =====================================================================
+// Mocking strategy
+// =====================================================================
+// `runEcsTask` calls these helpers in order:
+//   1. prepareImages → pullImage / pullEcrImage / buildDockerImage
+//   2. resolveEcsSecrets (ecs-secrets-resolver)
+//   3. createTaskNetwork (ecs-network)
+//   4. realizeDockerVolumes → execFileAsync('docker', ['volume', 'create', ...])
+//   5. Per-container start loop:
+//        - awaitDependencies → execFileAsync('docker', ['wait', id])
+//          OR execFileAsync('docker', ['inspect', '--format', '{{.State.Health.Status}}', id])
+//        - execFileAsync('docker', args) → returns container id
+//        - streamContainerLogs → spawn('docker', ['logs', '-f', id])
+//   6. waitForContainerExit on the essential container
+//   7. destroyTaskNetwork on cleanup
+//
+// child_process.execFile MUST support both 3-arg `execFile(cmd, args, cb)`
+// (used by `promisify(execFile)(cmd, args)`) AND 4-arg
+// `execFile(cmd, args, opts, cb)` shapes (used by `execFileAsync(cmd, args,
+// { maxBuffer })`). See `feedback_mock_execfile_3and4arg.md`.
+//
+// Each test sets `execFileResponder` to a per-test callback that returns
+// the stdout/stderr/err for one invocation. We capture every call in
+// `captured.calls` for assertions.
+
+const captured = vi.hoisted(() => ({
+  calls: [] as { cmd: string; args: string[]; opts: unknown }[],
+  // Per-test responder; defaults to "return synthetic id".
+  responder: undefined as
+    | ((cmd: string, args: string[]) =>
+        | { stdout?: string; stderr?: string; err?: Error }
+        | Promise<{ stdout?: string; stderr?: string; err?: Error }>)
+    | undefined,
+}));
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    execFile: (...allArgs: unknown[]) => {
+      const cb = allArgs[allArgs.length - 1] as (
+        err: Error | null,
+        res?: { stdout: string; stderr: string }
+      ) => void;
+      const cmd = allArgs[0] as string;
+      const args = allArgs[1] as string[];
+      const opts = allArgs.length === 4 ? allArgs[2] : undefined;
+      captured.calls.push({ cmd, args, opts });
+      const respond = (
+        out: { stdout?: string; stderr?: string; err?: Error } | void
+      ): void => {
+        if (out?.err) {
+          // Match the SDK shape — provider code reads `err.stderr` /
+          // `err.message`. Tack the captured stderr on so the error path
+          // surfaces useful text.
+          const e = out.err as Error & { stderr?: string };
+          if (out.stderr !== undefined) e.stderr = out.stderr;
+          cb(e);
+          return;
+        }
+        cb(null, { stdout: out?.stdout ?? 'fake-id\n', stderr: out?.stderr ?? '' });
+      };
+      const r = captured.responder?.(cmd, args);
+      if (r && 'then' in r) {
+        (r as Promise<{ stdout?: string; stderr?: string; err?: Error }>).then(respond);
+      } else {
+        respond(r as { stdout?: string; stderr?: string; err?: Error } | void);
+      }
+      return { kill: (): void => {} } as never;
+    },
+    spawn: (_cmd: string, _args: string[]) => {
+      // streamContainerLogs uses this. Return a fake proc that registers
+      // no-op handlers; the runner only `kill('SIGTERM')`s it on cleanup.
+      const handlers: Record<string, ((arg?: unknown) => void)[]> = {};
+      const proc = {
+        killed: false,
+        stdout: {
+          on: (e: string, h: (chunk: Buffer) => void): unknown => {
+            (handlers['stdout-' + e] = handlers['stdout-' + e] || []).push(
+              h as unknown as (arg?: unknown) => void
+            );
+            return proc;
+          },
+        },
+        stderr: {
+          on: (e: string, h: (chunk: Buffer) => void): unknown => {
+            (handlers['stderr-' + e] = handlers['stderr-' + e] || []).push(
+              h as unknown as (arg?: unknown) => void
+            );
+            return proc;
+          },
+        },
+        on: (e: string, h: (arg?: unknown) => void): unknown => {
+          (handlers[e] = handlers[e] || []).push(h);
+          return proc;
+        },
+        kill: (_sig?: string): boolean => {
+          proc.killed = true;
+          return true;
+        },
+      };
+      return proc as never;
+    },
+  };
+});
+
+// docker-runner: pullImage / removeContainer get stubbed so we never hit
+// real docker. DockerRunnerError must come from the actual module so
+// `instanceof` checks the runner depends on stay correct.
+const dockerRunnerStubs = vi.hoisted(() => ({
+  pullImage: vi.fn(async (_image: string, _skip: boolean): Promise<void> => undefined),
+  removeContainer: vi.fn(async (_id: string): Promise<void> => undefined),
+}));
+vi.mock('../../../src/local/docker-runner.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/local/docker-runner.js')>(
+    '../../../src/local/docker-runner.js'
+  );
+  return {
+    ...actual,
+    pullImage: dockerRunnerStubs.pullImage,
+    removeContainer: dockerRunnerStubs.removeContainer,
+  };
+});
+
+// ecr-puller
+const ecrStubs = vi.hoisted(() => ({
+  pullEcrImage: vi.fn(async (uri: string, _opts: unknown): Promise<string> => uri),
+}));
+vi.mock('../../../src/local/ecr-puller.js', () => ({
+  pullEcrImage: ecrStubs.pullEcrImage,
+}));
+
+// docker-build (asset path)
+const dockerBuildStubs = vi.hoisted(() => ({
+  buildDockerImage: vi.fn(
+    async (_asset: unknown, _ctx: string, _tag: string, _opts: unknown): Promise<void> => undefined
+  ),
+}));
+vi.mock('../../../src/assets/docker-build.js', () => ({
+  buildDockerImage: dockerBuildStubs.buildDockerImage,
+}));
+
+// ecs-network
+const networkStubs = vi.hoisted(() => ({
+  createTaskNetwork: vi.fn(async (_opts: unknown) => ({
+    networkName: 'cdkd-local-task-fake',
+    sidecarContainerId: 'sidecar-fake',
+  })),
+  destroyTaskNetwork: vi.fn(async (_net: unknown): Promise<void> => undefined),
+  buildMetadataEnv: vi.fn((opts: { containerName: string; roleArn?: string; region?: string }) => {
+    const env: Record<string, string> = {
+      ECS_CONTAINER_METADATA_URI_V4: `http://169.254.170.2/v4/${opts.containerName}`,
+    };
+    if (opts.roleArn) env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = `/role/${opts.roleArn}`;
+    if (opts.region) env['AWS_REGION'] = opts.region;
+    return env;
+  }),
+}));
+vi.mock('../../../src/local/ecs-network.js', () => ({
+  createTaskNetwork: networkStubs.createTaskNetwork,
+  destroyTaskNetwork: networkStubs.destroyTaskNetwork,
+  buildMetadataEnv: networkStubs.buildMetadataEnv,
+}));
+
+// ecs-secrets-resolver
+const secretsStubs = vi.hoisted(() => ({
+  resolveEcsSecrets: vi.fn(
+    async (
+      entries: { containerName: string; name: string; valueFrom: string }[]
+    ): Promise<{ containerName: string; name: string; valueFrom: string; value: string }[]> =>
+      entries.map((e) => ({ ...e, value: `resolved-${e.name}` }))
+  ),
+}));
+vi.mock('../../../src/local/ecs-secrets-resolver.js', () => ({
+  resolveEcsSecrets: secretsStubs.resolveEcsSecrets,
+}));
+
+// asset-manifest-loader: mock the class so the cdk-asset image branch
+// doesn't try to read cdk.out from disk.
+const manifestStubs = vi.hoisted(() => ({
+  loadManifest: vi.fn(
+    async (
+      _cdkOut: string,
+      _stack: string
+    ): Promise<{
+      dockerImages: Record<string, { source: { directory: string } }>;
+    } | null> => ({
+      dockerImages: {
+        h0: { source: { directory: '/tmp/asset-h0' } },
+        h1: { source: { directory: '/tmp/asset-h1' } },
+      },
+    })
+  ),
+}));
+vi.mock('../../../src/assets/asset-manifest-loader.js', () => ({
+  AssetManifestLoader: class {
+    async loadManifest(cdkOut: string, stack: string): Promise<unknown> {
+      return manifestStubs.loadManifest(cdkOut, stack);
+    }
+  },
+}));
+
+import {
+  cleanupEcsRun,
+  createEcsRunState,
+  runEcsTask,
+  type EcsRunState,
+  type RunEcsTaskOptions,
+} from '../../../src/local/ecs-task-runner.js';
+import { DockerRunnerError } from '../../../src/local/docker-runner.js';
+
+// ---------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------
+
+function makeContainer(over: Partial<ResolvedEcsContainer> = {}): ResolvedEcsContainer {
+  return {
+    name: 'app',
+    image: { kind: 'public', uri: 'nginx:alpine' },
+    environment: {},
+    secrets: [],
+    portMappings: [],
+    mountPoints: [],
+    dependsOn: [],
+    links: [],
+    essential: true,
+    ulimits: [],
+    ...over,
+  };
+}
+
+function makeTask(over: Partial<ResolvedEcsTask> = {}): ResolvedEcsTask {
+  return {
+    stack: {
+      stackName: 'S1',
+      displayName: 'S1',
+      artifactId: 'S1',
+      template: { Resources: {} },
+      dependencyNames: [],
+    },
+    taskDefinitionLogicalId: 'TD',
+    resource: { Type: 'AWS::ECS::TaskDefinition' },
+    family: 'fam',
+    networkMode: 'bridge',
+    containers: [makeContainer()],
+    volumes: [],
+    warnings: [],
+    ...over,
+  };
+}
+
+function baseOptions(over: Partial<RunEcsTaskOptions> = {}): RunEcsTaskOptions {
+  return {
+    cluster: 'cdkd-local',
+    containerHost: '127.0.0.1',
+    skipPull: true,
+    keepRunning: false,
+    detach: false,
+    ...over,
+  };
+}
+
+// Track docker `run` calls (the actual container starts) — distinct from
+// `volume create` / `wait` / `inspect` calls — so tests can assert order
+// and per-container args.
+function dockerRunCalls(): { cmd: string; args: string[]; opts: unknown }[] {
+  return captured.calls.filter((c) => c.args[0] === 'run');
+}
+
+function counterByLeadArg(): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const c of captured.calls) {
+    const lead = c.args[0] ?? '';
+    out[lead] = (out[lead] ?? 0) + 1;
+  }
+  return out;
+}
+
+beforeEach(() => {
+  captured.calls = [];
+  captured.responder = undefined;
+  dockerRunnerStubs.pullImage.mockClear();
+  dockerRunnerStubs.removeContainer.mockClear();
+  ecrStubs.pullEcrImage.mockClear();
+  dockerBuildStubs.buildDockerImage.mockClear();
+  networkStubs.createTaskNetwork.mockClear();
+  networkStubs.destroyTaskNetwork.mockClear();
+  secretsStubs.resolveEcsSecrets.mockClear();
+  manifestStubs.loadManifest.mockClear();
+});
+
+afterEach(() => {
+  captured.responder = undefined;
+});
+
+// =====================================================================
+// G1: runEcsTask end-to-end via mocks
+// =====================================================================
+
+describe('runEcsTask — image preparation (G1)', () => {
+  // Default responder: every docker call succeeds; container ids cycle
+  // c1, c2, ...; `docker wait` returns exit 0.
+  function happyDockerResponder() {
+    let containerIdSeq = 0;
+    return (_cmd: string, args: string[]) => {
+      if (args[0] === 'run') return { stdout: `c${++containerIdSeq}\n` };
+      if (args[0] === 'wait') return { stdout: '0\n' };
+      return { stdout: '' };
+    };
+  }
+
+  it('public image kind → calls pullImage and uses image.uri unchanged', async () => {
+    captured.responder = happyDockerResponder();
+    const c = makeContainer({ image: { kind: 'public', uri: 'busybox:latest' } });
+    const state = createEcsRunState();
+    const result = await runEcsTask(makeTask({ containers: [c] }), baseOptions(), state);
+
+    expect(result.exitCode).toBe(0);
+    expect(dockerRunnerStubs.pullImage).toHaveBeenCalledWith('busybox:latest', true);
+    // Container's docker run got the public image URI verbatim.
+    const runCall = dockerRunCalls()[0]!;
+    expect(runCall.args).toContain('busybox:latest');
+  });
+
+  it('ecr image kind → routes through pullEcrImage and propagates region', async () => {
+    captured.responder = happyDockerResponder();
+    ecrStubs.pullEcrImage.mockImplementationOnce(async (uri) => `${uri}-pulled-tag`);
+    const c = makeContainer({
+      image: {
+        kind: 'ecr',
+        uri: '123.dkr.ecr.us-east-1.amazonaws.com/repo:tag',
+        account: '123',
+        region: 'us-east-1',
+      },
+    });
+    const state = createEcsRunState();
+    await runEcsTask(
+      makeTask({ containers: [c] }),
+      baseOptions({ region: 'us-east-1' }),
+      state
+    );
+    expect(ecrStubs.pullEcrImage).toHaveBeenCalledTimes(1);
+    const [uri, opts] = ecrStubs.pullEcrImage.mock.calls[0]!;
+    expect(uri).toBe('123.dkr.ecr.us-east-1.amazonaws.com/repo:tag');
+    expect(opts).toMatchObject({ skipPull: true, region: 'us-east-1' });
+  });
+
+  it('cdk-asset image kind → loadManifest + buildDockerImage with stable tag', async () => {
+    captured.responder = happyDockerResponder();
+    const c = makeContainer({ image: { kind: 'cdk-asset', assetHash: 'h0' } });
+    const task = makeTask({
+      containers: [c],
+      stack: {
+        stackName: 'S1',
+        displayName: 'S1',
+        artifactId: 'S1',
+        template: { Resources: {} },
+        dependencyNames: [],
+        assetManifestPath: '/tmp/cdk.out/S1.assets.json',
+      },
+    });
+    const state = createEcsRunState();
+    await runEcsTask(task, baseOptions(), state);
+    expect(manifestStubs.loadManifest).toHaveBeenCalledWith('/tmp/cdk.out', 'S1');
+    expect(dockerBuildStubs.buildDockerImage).toHaveBeenCalledTimes(1);
+    const [asset, ctx, tag] = dockerBuildStubs.buildDockerImage.mock.calls[0]!;
+    expect(asset).toEqual({ source: { directory: '/tmp/asset-h0' } });
+    expect(ctx).toBe('/tmp/cdk.out');
+    expect(typeof tag).toBe('string');
+    expect((tag as string).startsWith('cdkd-local-run-task-')).toBe(true);
+  });
+
+  it('cdk-asset with no asset manifest path → throws EcsTaskRunnerError', async () => {
+    captured.responder = happyDockerResponder();
+    const c = makeContainer({ image: { kind: 'cdk-asset', assetHash: 'h0' } });
+    // Task with no assetManifestPath — the cdk-asset branch demands it.
+    const state = createEcsRunState();
+    await expect(runEcsTask(makeTask({ containers: [c] }), baseOptions(), state)).rejects.toThrow(
+      /asset manifest/i
+    );
+  });
+});
+
+describe('runEcsTask — docker volume realization (G1)', () => {
+  function happyDockerResponder() {
+    let seq = 0;
+    return (_cmd: string, args: string[]) => {
+      if (args[0] === 'run') return { stdout: `c${++seq}\n` };
+      if (args[0] === 'wait') return { stdout: '0\n' };
+      return { stdout: '' };
+    };
+  }
+
+  it('happy path: docker volume create with driver/opts/labels + recorded in state.dockerVolumeNames', async () => {
+    captured.responder = happyDockerResponder();
+    const dockerVol: ResolvedEcsVolume = {
+      name: 'data',
+      kind: 'docker',
+      dockerVolumeConfig: {
+        scope: 'task',
+        driver: 'local',
+        driverOpts: { type: 'tmpfs' },
+        labels: { foo: 'bar' },
+      },
+    };
+    const c = makeContainer({
+      mountPoints: [{ sourceVolume: 'data', containerPath: '/d', readOnly: false }],
+    });
+    const state = createEcsRunState();
+    await runEcsTask(makeTask({ containers: [c], volumes: [dockerVol] }), baseOptions(), state);
+    const volCreate = captured.calls.find(
+      (call) => call.args[0] === 'volume' && call.args[1] === 'create'
+    );
+    expect(volCreate).toBeDefined();
+    expect(volCreate!.args).toContain('--driver');
+    expect(volCreate!.args).toContain('local');
+    expect(volCreate!.args).toContain('--opt');
+    expect(volCreate!.args).toContain('type=tmpfs');
+    expect(volCreate!.args).toContain('--label');
+    expect(volCreate!.args).toContain('foo=bar');
+    expect(state.dockerVolumeNames).toHaveLength(1);
+    expect(state.dockerVolumeNames[0]!).toMatch(/^cdkd-local-data-/);
+  });
+
+  it('docker volume create failure → throws DockerRunnerError, no container starts', async () => {
+    let seq = 0;
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'volume' && args[1] === 'create') {
+        return { err: new Error('rejected'), stderr: 'docker: volume name in use' };
+      }
+      if (args[0] === 'run') return { stdout: `c${++seq}\n` };
+      return { stdout: '' };
+    };
+    const dockerVol: ResolvedEcsVolume = {
+      name: 'data',
+      kind: 'docker',
+      dockerVolumeConfig: { scope: 'task' },
+    };
+    const c = makeContainer({
+      mountPoints: [{ sourceVolume: 'data', containerPath: '/d', readOnly: false }],
+    });
+    const state = createEcsRunState();
+    await expect(
+      runEcsTask(makeTask({ containers: [c], volumes: [dockerVol] }), baseOptions(), state)
+    ).rejects.toBeInstanceOf(DockerRunnerError);
+    // No `docker run` should have fired.
+    expect(dockerRunCalls()).toHaveLength(0);
+  });
+});
+
+describe('runEcsTask — awaitDependencies (G1)', () => {
+  it('START condition is a no-op — no docker wait/inspect calls for the dep', async () => {
+    let seq = 0;
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'run') return { stdout: `c${++seq}\n` };
+      if (args[0] === 'wait') return { stdout: '0\n' };
+      return { stdout: '' };
+    };
+    const a = makeContainer({ name: 'a' });
+    const b = makeContainer({
+      name: 'b',
+      dependsOn: [{ containerName: 'a', condition: 'START' }],
+    });
+    const state = createEcsRunState();
+    await runEcsTask(makeTask({ containers: [a, b] }), baseOptions(), state);
+    // Exactly one `docker wait` for the essential container's exit (b is
+    // essential here because both containers default `essential: true`
+    // and `b` is at task.containers[1] — selection picks first
+    // `essential` match, so `a` is essential. The wait is on `a`'s id.)
+    const counts = counterByLeadArg();
+    expect(counts.run).toBe(2);
+    // Only the final exit wait, no per-dep waits for START.
+    expect(counts.wait).toBe(1);
+  });
+
+  it('COMPLETE condition awaits docker wait on the dep before starting dependent', async () => {
+    let seq = 0;
+    const callOrder: string[] = [];
+    captured.responder = (_cmd: string, args: string[]) => {
+      callOrder.push(args.join(' '));
+      if (args[0] === 'run') return { stdout: `c${++seq}\n` };
+      if (args[0] === 'wait') return { stdout: '0\n' };
+      return { stdout: '' };
+    };
+    const a = makeContainer({ name: 'a', essential: false });
+    const b = makeContainer({
+      name: 'b',
+      essential: true,
+      dependsOn: [{ containerName: 'a', condition: 'COMPLETE' }],
+    });
+    const state = createEcsRunState();
+    await runEcsTask(makeTask({ containers: [a, b] }), baseOptions(), state);
+
+    // Order observed:
+    //   run (start a) → wait c1 (COMPLETE for a) → run (start b) → wait c2 (essential exit)
+    const runIdx = callOrder.findIndex((s) => s.startsWith('run'));
+    const waitDepIdx = callOrder.findIndex(
+      (s, i) => i > runIdx && s.startsWith('wait')
+    );
+    const run2Idx = callOrder.findIndex((s, i) => i > waitDepIdx && s.startsWith('run'));
+    expect(runIdx).toBeGreaterThanOrEqual(0);
+    expect(waitDepIdx).toBeGreaterThan(runIdx);
+    expect(run2Idx).toBeGreaterThan(waitDepIdx);
+  });
+
+  it('SUCCESS condition rejects when dep exits non-zero', async () => {
+    let seq = 0;
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'run') return { stdout: `c${++seq}\n` };
+      // The dependency container's wait returns exit 7.
+      if (args[0] === 'wait') return { stdout: '7\n' };
+      return { stdout: '' };
+    };
+    const a = makeContainer({ name: 'a', essential: false });
+    const b = makeContainer({
+      name: 'b',
+      dependsOn: [{ containerName: 'a', condition: 'SUCCESS' }],
+    });
+    const state = createEcsRunState();
+    await expect(
+      runEcsTask(makeTask({ containers: [a, b] }), baseOptions(), state)
+    ).rejects.toThrow(/exited 7/);
+  });
+
+  it('HEALTHY condition polls docker inspect until status=healthy', async () => {
+    let seq = 0;
+    let healthCalls = 0;
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'run') return { stdout: `c${++seq}\n` };
+      if (args[0] === 'wait') return { stdout: '0\n' };
+      if (args[0] === 'inspect') {
+        healthCalls += 1;
+        return { stdout: healthCalls < 3 ? 'starting\n' : 'healthy\n' };
+      }
+      return { stdout: '' };
+    };
+    const a = makeContainer({ name: 'a', essential: false });
+    const b = makeContainer({
+      name: 'b',
+      dependsOn: [{ containerName: 'a', condition: 'HEALTHY' }],
+    });
+    const state = createEcsRunState();
+    await runEcsTask(makeTask({ containers: [a, b] }), baseOptions(), state);
+    expect(healthCalls).toBeGreaterThanOrEqual(3);
+  }, 15_000);
+
+  it('HEALTHY: status=unhealthy → rejects without further polling', async () => {
+    let seq = 0;
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'run') return { stdout: `c${++seq}\n` };
+      if (args[0] === 'wait') return { stdout: '0\n' };
+      if (args[0] === 'inspect') return { stdout: 'unhealthy\n' };
+      return { stdout: '' };
+    };
+    const a = makeContainer({ name: 'a', essential: false });
+    const b = makeContainer({
+      name: 'b',
+      dependsOn: [{ containerName: 'a', condition: 'HEALTHY' }],
+    });
+    const state = createEcsRunState();
+    await expect(
+      runEcsTask(makeTask({ containers: [a, b] }), baseOptions(), state)
+    ).rejects.toThrow(/unhealthy/);
+  });
+
+  it('HEALTHY: transient docker inspect failure is retried, then recovers', async () => {
+    let seq = 0;
+    let inspectCalls = 0;
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'run') return { stdout: `c${++seq}\n` };
+      if (args[0] === 'wait') return { stdout: '0\n' };
+      if (args[0] === 'inspect') {
+        inspectCalls += 1;
+        if (inspectCalls === 1) return { err: new Error('transient'), stderr: 'no such container' };
+        return { stdout: 'healthy\n' };
+      }
+      return { stdout: '' };
+    };
+    const a = makeContainer({ name: 'a', essential: false });
+    const b = makeContainer({
+      name: 'b',
+      dependsOn: [{ containerName: 'a', condition: 'HEALTHY' }],
+    });
+    const state = createEcsRunState();
+    await runEcsTask(makeTask({ containers: [a, b] }), baseOptions(), state);
+    expect(inspectCalls).toBeGreaterThanOrEqual(2);
+  }, 15_000);
+});
+
+describe('runEcsTask — exit propagation + essential selection (G1)', () => {
+  it('exit code of essential container becomes RunEcsTaskResult.exitCode', async () => {
+    let seq = 0;
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'run') return { stdout: `c${++seq}\n` };
+      if (args[0] === 'wait') return { stdout: '42\n' };
+      return { stdout: '' };
+    };
+    const c = makeContainer({ name: 'svc', essential: true });
+    const state = createEcsRunState();
+    const r = await runEcsTask(makeTask({ containers: [c] }), baseOptions(), state);
+    expect(r.exitCode).toBe(42);
+    expect(r.essentialContainerName).toBe('svc');
+  });
+
+  it('when no container is explicitly essential, the first container is used as essential', async () => {
+    let seq = 0;
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'run') return { stdout: `c${++seq}\n` };
+      if (args[0] === 'wait') return { stdout: '0\n' };
+      return { stdout: '' };
+    };
+    // Both essential: false — falsy. The orchestrator's `find(c.essential) ?? containers[0]` picks first.
+    const a = makeContainer({ name: 'first', essential: false });
+    const b = makeContainer({ name: 'second', essential: false });
+    const state = createEcsRunState();
+    const r = await runEcsTask(makeTask({ containers: [a, b] }), baseOptions(), state);
+    expect(r.essentialContainerName).toBe('first');
+  });
+
+  it('--detach short-circuits — every container starts, no essential wait, exitCode=0', async () => {
+    let seq = 0;
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'run') return { stdout: `c${++seq}\n` };
+      // If docker wait is called, return exit 99 so we can detect it in
+      // the result.exitCode — when --detach works correctly we never call
+      // wait at all, so exitCode stays 0.
+      if (args[0] === 'wait') return { stdout: '99\n' };
+      return { stdout: '' };
+    };
+    const a = makeContainer({ name: 'a' });
+    const b = makeContainer({ name: 'b' });
+    const state = createEcsRunState();
+    const r = await runEcsTask(
+      makeTask({ containers: [a, b] }),
+      baseOptions({ detach: true }),
+      state
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.essentialContainerName).toBeUndefined();
+    expect(counterByLeadArg().wait).toBeUndefined();
+    expect(state.startedContainers).toHaveLength(2);
+    // No log streams should have been added in detach mode.
+    expect(state.logStoppers).toHaveLength(0);
+  });
+
+  it('startedContainers is recorded in start order so cleanup can roll back', async () => {
+    let seq = 0;
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'run') return { stdout: `c${++seq}\n` };
+      if (args[0] === 'wait') return { stdout: '0\n' };
+      return { stdout: '' };
+    };
+    const a = makeContainer({ name: 'alpha' });
+    const b = makeContainer({
+      name: 'beta',
+      dependsOn: [{ containerName: 'alpha', condition: 'START' }],
+    });
+    const state = createEcsRunState();
+    await runEcsTask(makeTask({ containers: [a, b] }), baseOptions(), state);
+    expect(state.startedContainers.map((c) => c.name)).toEqual(['alpha', 'beta']);
+  });
+});
+
+describe('runEcsTask — empty task and pre-network failures (G1)', () => {
+  it('empty containers list throws EcsTaskRunnerError before any docker call', async () => {
+    const state = createEcsRunState();
+    await expect(
+      runEcsTask(makeTask({ containers: [] }), baseOptions(), state)
+    ).rejects.toThrow(/no containers/);
+    expect(captured.calls).toHaveLength(0);
+    expect(networkStubs.createTaskNetwork).not.toHaveBeenCalled();
+  });
+
+  it('docker run failure for a container surfaces as DockerRunnerError', async () => {
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'run') return { err: new Error('boom'), stderr: 'image not found' };
+      return { stdout: '' };
+    };
+    const c = makeContainer();
+    const state = createEcsRunState();
+    await expect(runEcsTask(makeTask({ containers: [c] }), baseOptions(), state)).rejects.toThrow(
+      DockerRunnerError
+    );
+  });
+});
+
+// =====================================================================
+// G2: cleanupEcsRun expanded coverage
+// =====================================================================
+
+describe('cleanupEcsRun — keepRunning + ordering (G2)', () => {
+  it('keepRunning=true skips docker stop / rm on user containers but tears down sidecar+network', async () => {
+    captured.responder = () => ({ stdout: '' });
+    const state: EcsRunState = {
+      network: { networkName: 'cdkd-local-task-x', sidecarContainerId: 'sidecar-x' },
+      dockerVolumeNames: [],
+      startedContainers: [
+        { name: 'a', id: 'cid-a' },
+        { name: 'b', id: 'cid-b' },
+      ],
+      logStoppers: [],
+    };
+    await cleanupEcsRun(state, { keepRunning: true });
+    // No `docker stop` / `docker rm` invocations.
+    const stops = captured.calls.filter((c) => c.args[0] === 'stop');
+    expect(stops).toHaveLength(0);
+    expect(dockerRunnerStubs.removeContainer).not.toHaveBeenCalled();
+    // Network teardown ran.
+    expect(networkStubs.destroyTaskNetwork).toHaveBeenCalledTimes(1);
+    // state.startedContainers is intentionally left in place when keepRunning.
+    expect(state.startedContainers).toHaveLength(2);
+    expect(state.network).toBeUndefined();
+  });
+
+  it('keepRunning=false: per-container stop/rm errors are swallowed and cleanup continues', async () => {
+    // docker stop fails on the FIRST container, rm fails on the SECOND.
+    let stopCalls = 0;
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'stop') {
+        stopCalls += 1;
+        if (stopCalls === 1)
+          return { err: new Error('stop failed'), stderr: 'container in invalid state' };
+      }
+      return { stdout: '' };
+    };
+    let rmCalls = 0;
+    dockerRunnerStubs.removeContainer.mockImplementation(async () => {
+      rmCalls += 1;
+      if (rmCalls === 2) throw new Error('rm failed');
+    });
+    const state: EcsRunState = {
+      network: { networkName: 'n', sidecarContainerId: 's' },
+      dockerVolumeNames: [],
+      startedContainers: [
+        { name: 'a', id: 'cid-a' },
+        { name: 'b', id: 'cid-b' },
+      ],
+      logStoppers: [],
+    };
+    await expect(cleanupEcsRun(state, { keepRunning: false })).resolves.toBeUndefined();
+    // Both containers were attempted (errors swallowed):
+    expect(rmCalls).toBe(2);
+    // Network teardown still runs.
+    expect(networkStubs.destroyTaskNetwork).toHaveBeenCalledTimes(1);
+    expect(state.startedContainers).toEqual([]);
+  });
+
+  it('docker volume rm runs AFTER container teardown (volumes drained last)', async () => {
+    const order: string[] = [];
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'stop') order.push('stop:' + args[args.length - 1]);
+      if (args[0] === 'volume' && args[1] === 'rm') order.push('volume-rm:' + args[2]);
+      return { stdout: '' };
+    };
+    dockerRunnerStubs.removeContainer.mockImplementation(async (id: string) => {
+      order.push('rm:' + id);
+    });
+    networkStubs.destroyTaskNetwork.mockImplementation(async () => {
+      order.push('destroy-network');
+    });
+    const state: EcsRunState = {
+      network: { networkName: 'n', sidecarContainerId: 's' },
+      dockerVolumeNames: ['vol-1', 'vol-2'],
+      startedContainers: [{ name: 'a', id: 'cid-a' }],
+      logStoppers: [],
+    };
+    await cleanupEcsRun(state, { keepRunning: false });
+
+    // Expected ordering: container stop/rm → destroy-network → volume rm.
+    const idxRm = order.findIndex((o) => o.startsWith('rm:'));
+    const idxNet = order.indexOf('destroy-network');
+    const idxVol = order.findIndex((o) => o.startsWith('volume-rm:'));
+    expect(idxRm).toBeGreaterThanOrEqual(0);
+    expect(idxNet).toBeGreaterThan(idxRm);
+    expect(idxVol).toBeGreaterThan(idxNet);
+    expect(state.dockerVolumeNames).toEqual([]);
+  });
+
+  it('docker volume rm failure is swallowed and remaining volumes still attempted', async () => {
+    const volRms: string[] = [];
+    captured.responder = (_cmd: string, args: string[]) => {
+      if (args[0] === 'volume' && args[1] === 'rm') {
+        volRms.push(args[2]!);
+        if (args[2] === 'vol-1') return { err: new Error('in use'), stderr: 'volume in use' };
+      }
+      return { stdout: '' };
+    };
+    const state: EcsRunState = {
+      network: undefined,
+      dockerVolumeNames: ['vol-1', 'vol-2'],
+      startedContainers: [],
+      logStoppers: [],
+    };
+    await cleanupEcsRun(state, { keepRunning: false });
+    expect(volRms).toEqual(['vol-1', 'vol-2']);
+    expect(state.dockerVolumeNames).toEqual([]);
+  });
+});

--- a/tests/unit/local/ecs-task-runner.test.ts
+++ b/tests/unit/local/ecs-task-runner.test.ts
@@ -5,6 +5,7 @@ import {
   cleanupEcsRun,
   createEcsRunState,
   EcsTaskRunnerError,
+  topoSort,
 } from '../../../src/local/ecs-task-runner.js';
 import type {
   ResolvedEcsContainer,
@@ -313,5 +314,90 @@ describe('cleanupEcsRun', () => {
     });
     await expect(cleanupEcsRun(state, { keepRunning: false })).resolves.toBeUndefined();
     expect(state.logStoppers).toEqual([]);
+  });
+});
+
+describe('topoSort (G3)', () => {
+  it('preserves template order for two independent containers', () => {
+    const a = makeContainer({ name: 'a' });
+    const b = makeContainer({ name: 'b' });
+    const g = buildDependencyGraph([a, b]);
+    expect(topoSort(g, [a, b])).toEqual(['a', 'b']);
+    // Reversed input still respects template order in the input array
+    // — the tiebreak key is the array index of `containers`, not name.
+    const g2 = buildDependencyGraph([b, a]);
+    expect(topoSort(g2, [b, a])).toEqual(['b', 'a']);
+  });
+
+  it('diamond: D depends on B+C, both depend on A → A first, B/C in template order, D last', () => {
+    const A = makeContainer({ name: 'A' });
+    const B = makeContainer({
+      name: 'B',
+      dependsOn: [{ containerName: 'A', condition: 'START' }],
+    });
+    const C = makeContainer({
+      name: 'C',
+      dependsOn: [{ containerName: 'A', condition: 'START' }],
+    });
+    const D = makeContainer({
+      name: 'D',
+      dependsOn: [
+        { containerName: 'B', condition: 'START' },
+        { containerName: 'C', condition: 'START' },
+      ],
+    });
+    const containers = [A, B, C, D];
+    const g = buildDependencyGraph(containers);
+    const order = topoSort(g, containers);
+    // A must be before B / C; B / C must be before D.
+    expect(order.indexOf('A')).toBeLessThan(order.indexOf('B'));
+    expect(order.indexOf('A')).toBeLessThan(order.indexOf('C'));
+    expect(order.indexOf('B')).toBeLessThan(order.indexOf('D'));
+    expect(order.indexOf('C')).toBeLessThan(order.indexOf('D'));
+    expect(order.indexOf('A')).toBe(0);
+    expect(order.indexOf('D')).toBe(3);
+    // Template-order tiebreak: B (index 1) comes before C (index 2).
+    expect(order.indexOf('B')).toBeLessThan(order.indexOf('C'));
+  });
+
+  it('multiple independent roots come out in template order', () => {
+    const r1 = makeContainer({ name: 'r1' });
+    const r2 = makeContainer({ name: 'r2' });
+    const r3 = makeContainer({ name: 'r3' });
+    const containers = [r1, r2, r3];
+    const g = buildDependencyGraph(containers);
+    expect(topoSort(g, containers)).toEqual(['r1', 'r2', 'r3']);
+  });
+
+  it('chain A->B->C in template order keeps deps before dependents', () => {
+    const A = makeContainer({ name: 'A' });
+    const B = makeContainer({
+      name: 'B',
+      dependsOn: [{ containerName: 'A', condition: 'START' }],
+    });
+    const C = makeContainer({
+      name: 'C',
+      dependsOn: [{ containerName: 'B', condition: 'START' }],
+    });
+    const containers = [A, B, C];
+    const g = buildDependencyGraph(containers);
+    const order = topoSort(g, containers);
+    expect(order.indexOf('A')).toBeLessThan(order.indexOf('B'));
+    expect(order.indexOf('B')).toBeLessThan(order.indexOf('C'));
+  });
+
+  it('cyclic graph rejection lives in buildDependencyGraph (not topoSort)', () => {
+    // Sanity check: cycle rejection happens BEFORE topoSort is ever
+    // called, so cyclic graphs never reach this function. This documents
+    // the contract — a defensive test inside topoSort would never fire.
+    const a = makeContainer({
+      name: 'a',
+      dependsOn: [{ containerName: 'b', condition: 'START' }],
+    });
+    const b = makeContainer({
+      name: 'b',
+      dependsOn: [{ containerName: 'a', condition: 'START' }],
+    });
+    expect(() => buildDependencyGraph([a, b])).toThrow(EcsTaskRunnerError);
   });
 });


### PR DESCRIPTION
## Summary

Three follow-up commits on `cdkd local run-task` Phase 1 (#263), bundled in one PR because they all touch overlapping files (`src/local/ecs-task-resolver.ts`, `src/cli/commands/local-run-task.ts`, `tests/unit/local/ecs-task-resolver.test.ts`) and serializing them would mean three rounds of rebase-vs-merge-conflict instead of one.

## Commits

### 1. `fix(local-run-task): emit synth-time placeholder for TaskRoleArn intrinsics`

Closes the spec drift PR #263's review flagged: `--assume-task-role` bare flag used to hard-error when the template's `TaskRoleArn` was `{Ref: <Role>}` or `{Fn::GetAtt: [<Role>, 'Arn']}` (the typical CDK shape — `taskRole: new Role(...)`). The resolver returned `undefined` because the role's physical ARN isn't synth-time-derivable.

Fix: `resolveRoleArn` now emits `arn:aws:iam::${AWS::AccountId}:role/<RoleLogicalId>` when the intrinsic targets a same-stack `AWS::IAM::Role`. The CLI's `resolvePlaceholderAccount` helper substitutes `${AWS::AccountId}` via STS `GetCallerIdentity` **only when the resolved ARN contains the placeholder** — bare `--assume-task-role` with a flat-string template ARN doesn't fire STS, and the no-flag path doesn't either.

### 2. `test(local/ecs-task-runner): cover runEcsTask orchestrator, cleanupEcsRun, topoSort`

Closes test gaps G1/G2/G3 from PR #263's pr-test-reviewer pass. 27 new unit tests in `tests/unit/local/ecs-task-runner-runner.test.ts` (new file) + appendix to existing `ecs-task-runner.test.ts`:

- **G1 — `runEcsTask` end-to-end via mocks**: all 3 image branches (public / ecr / cdk-asset), docker-volume happy + failure, all 4 dependsOn conditions (START / COMPLETE / SUCCESS / HEALTHY), `--detach` short-circuit, essential-container fallback, exit-code propagation, docker-run failure.
- **G2 — `cleanupEcsRun` expansion**: `keepRunning: true` skips user containers but tears down sidecar+network, per-step errors swallowed, strict ordering of `docker volume rm` after container teardown.
- **G3 — `topoSort`**: two-container tiebreak, diamond dependency, multiple roots, cycle-rejection contract.

Mock plumbing follows `feedback_mock_execfile_3and4arg.md`: covers both 3-arg and 4-arg forms of `child_process.execFile`.

Side effect: `topoSort` exported (was private) so tests can drive it directly. No behavior or call-site change.

### 3. `feat(local-run-task): resolve Fn::Sub ECR images (Tier 1 pseudo / Tier 2 state)`

Closes #264. Two-tier resolution for `ContainerImage.fromEcrRepository(repo)` style images, previously hard-errored as a v1 punt:

- **Tier 1 — AWS pseudo-parameter resolution (no state)**: `${AWS::AccountId}` → STS `GetCallerIdentity` (lazy, cached for the run); `${AWS::Region}` → `--region` / `AWS_REGION`; `${AWS::Partition}` → derived (`cn-*` → `aws-cn`, `us-gov-*` → `aws-us-gov`, else `aws`); `${AWS::URLSuffix}` → matches partition. After substitution the URI routes through the existing `kind: 'ecr'` path.
- **Tier 2 — same-stack `AWS::ECR::Repository` `Ref` / `Fn::GetAtt RepositoryUri` (state)**: opt-in via new `--from-state` flag (mirrors `cdkd local invoke --from-state`). When set, cdkd loads state for the target stack and substitutes `${<RepoLogicalId>}` with the deployed physical name. When `--from-state` is NOT set, the error message now points at `--from-state` as the way to resolve the case instead of the previous "use ContainerImage.fromAsset" only.
- **Tier 3 — cross-account / cross-region**: unchanged hard-error in `pullEcrImage` (caller account / region mismatch). Same workaround pointer (`--role-arn` for cross-acct).

New shared helper `src/cli/commands/local-state-loader.ts` extracted from `local-invoke.ts` so both `cdkd local invoke --from-state` and `cdkd local run-task --from-state` go through one impl.

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` / `test` / `format:check` all pass
- [x] `pnpm test` — 2911 tests pass (PR #266 base was 2860; +51 across the three commits — 7 TaskRoleArn + 27 orchestrator + 17 Fn::Sub)
- [x] Live-test `cdkd local invoke` against cdk-sample post-rebase — Lambda invokes cleanly (regression guard for the shared-state-loader extraction)
- [ ] Live-test `cdkd local run-task --from-state` against a deployed stack — requires `cdkd deploy` of cdk-sample first; deferred to follow-up. Tier 1 pseudo-param path is exercised structurally via unit tests + the existing live-test on PR #263.

## Follow-ups

- Update [cdkd docs/cli-reference.md](docs/cli-reference.md) and [cdk-sample local-runtimes.md](https://github.com/go-to-k/cdk-sample/blob/main/local-runtimes.md) to document the `--from-state` flag once this PR merges.

Closes #264.
