### PR TITLE
test(integration): local-run-task-from-state for Tier 2 ECR Repository resolution

### DIFF
--- a/tests/integration/local-run-task-from-state/.gitignore
+++ b/tests/integration/local-run-task-from-state/.gitignore
@@ -1,0 +1,2 @@
+# Nothing to override here — the fixture has no JS leaf files. The parent
+# integ .gitignore traps *.js / *.d.ts / node_modules etc. as usual.

--- a/tests/integration/local-run-task-from-state/bin/app.ts
+++ b/tests/integration/local-run-task-from-state/bin/app.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { LocalRunTaskFromStateStack } from '../lib/local-run-task-from-state-stack';
+
+const app = new cdk.App();
+
+new LocalRunTaskFromStateStack(app, 'CdkdLocalRunTaskFromStateFixture', {
+  description: 'Fixture stack for cdkd local run-task --from-state Tier 2 ECR Repository resolution integ test',
+});

--- a/tests/integration/local-run-task-from-state/cdk.json
+++ b/tests/integration/local-run-task-from-state/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/app.ts"
+}

--- a/tests/integration/local-run-task-from-state/lib/local-run-task-from-state-stack.ts
+++ b/tests/integration/local-run-task-from-state/lib/local-run-task-from-state-stack.ts
@@ -1,0 +1,90 @@
+import * as cdk from 'aws-cdk-lib';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import { Construct } from 'constructs';
+
+/**
+ * Fixture stack for `cdkd local run-task --from-state` Tier 2 ECR
+ * Repository resolution integ test.
+ *
+ * One same-stack `AWS::ECR::Repository` + one `AWS::ECS::TaskDefinition`
+ * whose container `Image` is shaped as a single-arg `Fn::Sub` that
+ * references the deployed repository's CloudFormation logical id
+ * directly:
+ *
+ *   { "Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${MyRepo}:latest" }
+ *
+ * This is the **exact** shape that `cdkd local run-task --from-state`'s
+ * Tier 2 resolver (introduced in PR #267, closes #264) is designed to
+ * substitute: `${AWS::AccountId}` / `${AWS::Region}` come from pseudo
+ * parameters (Tier 1) and `${MyRepo}` is looked up in cdkd state for
+ * the deployed Repository's physical id (Tier 2).
+ *
+ * Key design decisions:
+ *
+ * 1. **Logical id is pinned via `overrideLogicalId('MyRepo')`**. cdkd's
+ *    Tier 2 resolver matches the `${MyRepo}` placeholder against the
+ *    template's resource logical ids; without the override, CDK appends
+ *    an 8-char hash suffix (e.g. `MyRepoF4F48043`) and the placeholder
+ *    in the L1 TaskDefinition would have to track that suffix.
+ *
+ * 2. **L1 `CfnTaskDefinition` is used directly** (not CDK's L2
+ *    `ContainerImage.fromEcrRepository(repo)`). The L2 form synthesizes
+ *    a `Fn::Join` shape with nested `Fn::Select` / `Fn::Split` /
+ *    `Fn::GetAtt`, which the Tier 2 resolver does **not** yet handle —
+ *    tracked separately as a follow-up (issue #271). The L1 path here
+ *    pins the synthesized template to the actually-supported `Fn::Sub`
+ *    shape so the integ exercises real Tier 2 behavior end-to-end.
+ *
+ * 3. **Single-arg `Fn::Sub`** (template string only — no variable map).
+ *    cdkd's resolver scans the flat template string for `${...}`
+ *    placeholders and treats each non-AWS-pseudo name as a logical id
+ *    lookup. A 2-arg `Fn::Sub` with a variable map would route the
+ *    placeholder name through the map, which cdkd doesn't unwind.
+ *
+ * Repository carries `removalPolicy: DESTROY` so `cdkd destroy` can
+ * reclaim it; `autoDeleteImages` is intentionally **not** set — pushed
+ * images are deleted by `verify.sh`'s cleanup trap via the AWS CLI
+ * before destroy runs, so the deletion path stays AWS-native and the
+ * fixture has zero dependencies on CDK custom-resource handlers.
+ */
+export class LocalRunTaskFromStateStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const repo = new ecr.Repository(this, 'MyRepo', {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+    // Pin the logical id so the Fn::Sub placeholder matches verbatim.
+    (repo.node.defaultChild as ecr.CfnRepository).overrideLogicalId('MyRepo');
+
+    // L1 TaskDefinition so we control the exact synthesized shape.
+    // Single-arg Fn::Sub: cdkd's Tier 2 resolver walks the flat template
+    // string for `${...}` placeholders and substitutes pseudo-parameters
+    // (Tier 1) + same-stack `AWS::ECR::Repository` logical ids (Tier 2).
+    const taskDef = new ecs.CfnTaskDefinition(this, 'NginxTaskDef', {
+      family: 'cdkd-local-run-task-from-state-fixture',
+      requiresCompatibilities: ['EC2'],
+      networkMode: 'bridge',
+      containerDefinitions: [
+        {
+          name: 'web',
+          image: cdk.Fn.sub(
+            '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${MyRepo}:latest'
+          ),
+          essential: true,
+          memory: 256,
+          portMappings: [
+            {
+              containerPort: 80,
+              hostPort: 18082,
+              protocol: 'tcp',
+            },
+          ],
+        },
+      ],
+    });
+    // Pin task-def logical id for verify.sh discoverability.
+    taskDef.overrideLogicalId('NginxTaskDef');
+  }
+}

--- a/tests/integration/local-run-task-from-state/package.json
+++ b/tests/integration/local-run-task-from-state/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdkd-integ-local-run-task-from-state",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Integration test fixture for cdkd local run-task --from-state (Tier 2 ECR Repository resolution)",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0",
+    "ts-node": "^10.0.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.169.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/tests/integration/local-run-task-from-state/tsconfig.json
+++ b/tests/integration/local-run-task-from-state/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "outDir": "dist"
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/local-run-task-from-state/verify.sh
+++ b/tests/integration/local-run-task-from-state/verify.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# End-to-end real-AWS validation for `cdkd local run-task --from-state`
+# Tier 2 ECR Repository resolution (PR #267, closes #264).
+#
+# Why this exists: the existing `tests/integration/local-run-task/` and
+# `local-run-task-multi-container/` integs only use public images
+# (`public.ecr.aws/nginx/nginx:alpine` etc.), so the `--from-state` path
+# is unit-tested but never exercised against real AWS. This integ closes
+# that gap by deploying a same-stack `AWS::ECR::Repository`, pushing a
+# tiny image to it, and running the task whose `Image` is a `Fn::Sub`
+# reference to that repository's deployed physical id.
+#
+# Critical design decision (see lib/local-run-task-from-state-stack.ts):
+# the synthesized `Image` is shaped as the 1-arg `Fn::Sub` form, NOT
+# `Fn::Join`. CDK 2.x's `ContainerImage.fromEcrRepository(repo)`
+# synthesizes a `Fn::Join` with nested `Fn::Select` / `Fn::Split` /
+# `Fn::GetAtt`, which the Tier 2 resolver does NOT yet handle (issue
+# #271). The fixture uses `CfnTaskDefinition` directly with an explicit
+# `cdk.Fn.sub(...)` so the round-trip exercises the actually-supported
+# `Fn::Sub` path.
+#
+# Steps:
+#   1. install + build cdkd (root) + install fixture deps + docker pull
+#   2. cdkd deploy CdkdLocalRunTaskFromStateFixture (creates the ECR
+#      repository)
+#   3. push a tiny nginx image to the deployed repository
+#   4. cdkd local run-task --from-state — verify Tier 2 substituted the
+#      `${MyRepo}` placeholder with the deployed physical name, the
+#      container started against the pushed image, and the host port is
+#      reachable
+#   5. clean up: docker rm + docker network rm via trap; aws ecr
+#      batch-delete-image to empty the repo (cdkd destroy fails if a repo
+#      has images); cdkd destroy --force
+#
+# Run via `/run-integ local-run-task-from-state` (recommended) or directly:
+#
+#     bash tests/integration/local-run-task-from-state/verify.sh
+#
+# Requires Docker AND AWS credentials with deploy permissions in the
+# target account.
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION="${REGION}"
+STACK="CdkdLocalRunTaskFromStateFixture"
+TASK_PATH="${STACK}/NginxTaskDef"
+HOST_PORT=18082
+SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
+NGINX_IMAGE="public.ecr.aws/nginx/nginx:alpine"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_DIR="${REPO_ROOT}/tests/integration/local-run-task-from-state"
+CDKD="node ${REPO_ROOT}/dist/cli.js"
+
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+STATE_BUCKET="${STATE_BUCKET:-cdkd-state-${ACCOUNT_ID}}"
+echo "[verify] region=${REGION} stack=${STACK} state-bucket=${STATE_BUCKET}"
+
+echo "[verify] step 1a: install + build cdkd"
+pnpm --dir "${REPO_ROOT}" install
+pnpm --dir "${REPO_ROOT}" run build
+
+cd "${TEST_DIR}"
+if [ ! -d node_modules ]; then
+  npm install --no-audit --no-fund --prefer-offline
+fi
+
+echo "[verify] step 1b: verifying Docker is available"
+docker version --format '{{.Server.Version}}' >/dev/null
+
+echo "[verify] step 1c: pulling fixture images"
+docker pull "${SIDECAR_IMAGE}"
+docker pull "${NGINX_IMAGE}"
+
+# Cleanup trap: empty ECR repo (cdkd destroy fails if it has images),
+# cdkd destroy, then docker rm orphan containers + networks. Runs on
+# every exit path (including SIGINT and FAIL).
+DEPLOYED_REPO=""
+cleanup() {
+  rc=$?
+  set +e
+  echo "[verify] cleanup (exit ${rc}) — emptying repo + destroying stack + tearing down docker"
+
+  # Sweep local docker containers + networks first (cheap, low-risk).
+  docker ps --filter "name=cdkd-local-" --format '{{.ID}}' | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkd-local-task-" --format '{{.ID}}' | xargs -r docker network rm >/dev/null 2>&1 || true
+
+  # Empty the ECR repository so cdkd destroy can remove it. If we never
+  # resolved the deployed repo name (stack failed before step 2b), best
+  # effort: pull it from state.
+  if [ -z "${DEPLOYED_REPO}" ]; then
+    DEPLOYED_REPO="$(${CDKD} state resources "${STACK}" --state-bucket "${STATE_BUCKET}" --json 2>/dev/null \
+      | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{const j=JSON.parse(d);for(const r of j){if(r.resourceType==="AWS::ECR::Repository"){console.log(r.physicalId);process.exit(0)}}}catch(e){}process.exit(1)})' 2>/dev/null)"
+  fi
+  if [ -n "${DEPLOYED_REPO}" ]; then
+    IMAGE_IDS_JSON="$(aws ecr list-images --repository-name "${DEPLOYED_REPO}" --region "${REGION}" --query 'imageIds' --output json 2>/dev/null || echo '[]')"
+    if [ "${IMAGE_IDS_JSON}" != "[]" ] && [ -n "${IMAGE_IDS_JSON}" ]; then
+      aws ecr batch-delete-image --repository-name "${DEPLOYED_REPO}" --region "${REGION}" --image-ids "${IMAGE_IDS_JSON}" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  ${CDKD} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --force 2>&1 | tail -5 || true
+
+  exit "${rc}"
+}
+trap cleanup EXIT
+
+echo "[verify] step 2: cdkd deploy ${STACK}"
+${CDKD} deploy "${STACK}" --state-bucket "${STATE_BUCKET}"
+
+echo "[verify] step 2b: reading deployed ECR repository name from cdkd state"
+DEPLOYED_REPO="$(${CDKD} state resources "${STACK}" --state-bucket "${STATE_BUCKET}" --json \
+  | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const j=JSON.parse(d);for(const r of j){if(r.resourceType==="AWS::ECR::Repository"){console.log(r.physicalId);process.exit(0)}}process.exit(1)})')"
+echo "[verify]   deployed repo: ${DEPLOYED_REPO}"
+[ -n "${DEPLOYED_REPO}" ] || { echo "[verify] FAIL: could not read deployed repo name from state"; exit 1; }
+
+REPO_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${DEPLOYED_REPO}"
+
+echo "[verify] step 3: tag + push nginx into ${REPO_URI}:latest"
+aws ecr get-login-password --region "${REGION}" \
+  | docker login --username AWS --password-stdin "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com" >/dev/null
+docker tag "${NGINX_IMAGE}" "${REPO_URI}:latest"
+docker push "${REPO_URI}:latest"
+
+echo "[verify] step 4: cdkd local run-task --from-state ${TASK_PATH}"
+${CDKD} local run-task "${TASK_PATH}" \
+  --from-state \
+  --detach \
+  --no-pull \
+  --container-host 127.0.0.1 \
+  --state-bucket "${STATE_BUCKET}"
+
+echo "[verify] step 4b: curl http://127.0.0.1:${HOST_PORT}/ (allow ~5s for nginx to listen)"
+sleep 5
+HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${HOST_PORT}/" || true)
+echo "[verify]   HTTP code: ${HTTP_CODE}"
+if [ "${HTTP_CODE}" != "200" ]; then
+  echo "[verify] FAIL: expected 200, got ${HTTP_CODE}"
+  exit 1
+fi
+
+echo ""
+echo "[verify] All checks passed: --from-state substituted \${MyRepo} with the deployed ECR repository ${DEPLOYED_REPO}."


### PR DESCRIPTION
## Summary

New in-repo integration test that exercises `cdkd local run-task --from-state` Tier 2 ECR Repository resolution end-to-end against real AWS — closes the coverage gap surfaced after PR #267 (Fn::Sub-shape ECR image URI resolution was unit-tested but never exercised against deployed state).

cdk-sample was extended in parallel (commit `9fb0a1e` at https://github.com/go-to-k/cdk-sample) for manual verification, but cdk-sample isn't in this repo — contributors don't have it. This PR adds the equivalent fixture inside `tests/integration/local-run-task-from-state/` so CI and `/run-integ` can exercise it without cdk-sample.

## Stack contents

Minimal — real AWS but cheap (ECR repo + a pushed `:latest` tag, no compute):

- 1 `AWS::ECR::Repository` (`removalPolicy: DESTROY`; logical id pinned to `MyRepo` via `overrideLogicalId` so the placeholder substitution matches a known name).
- 1 `AWS::ECS::TaskDefinition` (`Compatibility.EC2` + `NetworkMode.BRIDGE`, single `web` container, 256 MiB, `containerPort: 80 → hostPort: 18082` — different from the existing `local-run-task/` fixture's 18080).

Defined with **L1 `CfnTaskDefinition`** instead of L2 `ContainerImage.fromEcrRepository(repo)` so the synthesized `Image` is the 1-arg `Fn::Sub` shape PR #267's Tier 2 resolver supports — NOT CDK 2.x's `Fn::Join` (tracked separately as #271).

Synth shape verified locally:

```bash
$ jq -r '.Resources | to_entries[] | select(.value.Type=="AWS::ECS::TaskDefinition") | .value.Properties.ContainerDefinitions[0].Image' cdk.out/CdkdLocalRunTaskFromStateFixture.template.json
{
  "Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${MyRepo}:latest"
}
```

## verify.sh flow (real-AWS end-to-end)

1. `cdkd deploy CdkdLocalRunTaskFromStateFixture` (real ECR repo creation).
2. Resolve deployed ECR repo physical name from cdkd state.
3. `docker pull public.ecr.aws/nginx/nginx:alpine` + `docker tag` + ECR login + `docker push :latest`.
4. `cdkd local run-task -a cdk.out --from-state CdkdLocalRunTaskFromStateFixture/.../NginxTaskDef --detach` — Tier 2 resolver substitutes `${MyRepo}` with the deployed physical name, pulls the image via the existing ECR auth path.
5. `curl http://127.0.0.1:18082/` — expect HTTP 200.
6. Cleanup trap (runs on every exit path): `aws ecr batch-delete-image` to empty the repo, `cdkd destroy --force`, sweep orphan containers + networks.

## Out of scope (intentional)

- **`Fn::Join` shape from CDK 2.x's `fromEcrRepository`** — tracked as #271. This fixture validates the actually-implemented `Fn::Sub` resolver only.
- **Cross-account / cross-region ECR** — same as PR #267's Tier 3 deferral.

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` / `test` (2911 tests) / `format:check` pass
- [x] `cd tests/integration/local-run-task-from-state && npx cdk synth --quiet` exits 0; emits the expected 1-arg `Fn::Sub` Image
- [ ] **Merge requirement**: `/run-integ local-run-task-from-state` (real AWS deploy + push + invoke + destroy) must succeed before this PR can merge. The new `integ-local` markgate gate (PR #273) enforces this structurally — `gh pr merge` will block until the marker is set by a successful integ run.

## Related

- PR #267 (introduced `--from-state` Tier 2; unit-tested, no integ until this PR)
- PR #273 (introduced the `integ-local` markgate gate that enforces this very integ before merge)
- #271 (Fn::Join shape follow-up)
- memory `feedback_verify_cdk_synth_shape_before_resolver.md` (synth-shape verification methodology — applied here)
