### PR TITLE
fix(analyzer): Fn::Sub 1-arg body produces no DAG edge to same-stack resource (#275)

### DIFF
--- a/src/analyzer/template-parser.ts
+++ b/src/analyzer/template-parser.ts
@@ -101,6 +101,55 @@ export class TemplateParser {
       return;
     }
 
+    // Check for Fn::Sub
+    // 1-arg form: "Fn::Sub": "string with ${X} or ${X.Attr}"
+    // 2-arg form: "Fn::Sub": ["string with ${X}", { X: <value> }]
+    // Per the CloudFormation spec, when ${X} appears in the body and X is NOT
+    // in the explicit variable map (2-arg form), X resolves to Ref X — which
+    // can point at a same-stack resource. The DAG must treat that as a real
+    // dependency edge so the referenced resource is created first; otherwise
+    // the resolver races and falls back to the literal placeholder, which AWS
+    // rejects (see #275).
+    if ('Fn::Sub' in obj) {
+      const subValue = obj['Fn::Sub'];
+      let body: string | undefined;
+      let mapKeys: Set<string> | undefined;
+      if (typeof subValue === 'string') {
+        body = subValue;
+      } else if (
+        Array.isArray(subValue) &&
+        subValue.length >= 1 &&
+        typeof subValue[0] === 'string'
+      ) {
+        body = subValue[0];
+        const variables: unknown = subValue[1];
+        if (variables && typeof variables === 'object' && !Array.isArray(variables)) {
+          const varMap = variables as Record<string, unknown>;
+          mapKeys = new Set(Object.keys(varMap));
+          // Recurse into the variable-map values — they may contain Ref / GetAtt
+          // intrinsics that produce their own dependencies.
+          Object.values(varMap).forEach((v) => this.extractRefsFromValue(v, dependencies));
+        }
+      }
+      if (body !== undefined) {
+        for (const match of body.matchAll(/\$\{([^}]+)\}/g)) {
+          const placeholder = match[1];
+          if (!placeholder) continue;
+          // ${X.AttrName} is an implicit Fn::GetAtt — depend on X (the prefix).
+          // ${X} is an implicit Ref to X.
+          const dot = placeholder.indexOf('.');
+          const name = dot >= 0 ? placeholder.slice(0, dot) : placeholder;
+          if (!name) continue;
+          // Skip pseudo parameters (AWS::Region, AWS::AccountId, etc.).
+          if (name.startsWith('AWS::')) continue;
+          // Skip names provided by the 2-arg variable map.
+          if (mapKeys?.has(name)) continue;
+          dependencies.add(name);
+        }
+      }
+      return;
+    }
+
     // Recursively process all values
     Object.values(obj).forEach((v) => this.extractRefsFromValue(v, dependencies));
   }

--- a/tests/unit/analyzer/dag-builder.test.ts
+++ b/tests/unit/analyzer/dag-builder.test.ts
@@ -170,6 +170,123 @@ describe('DagBuilder', () => {
       expect(graph.hasEdge('BucketB', 'BucketC')).toBe(true);
     });
 
+    it('extracts implicit Ref dependency from Fn::Sub 1-arg form ${X}', () => {
+      // #275: Fn::Sub: "...${MyRepo}..." with no variable map is an
+      // implicit Ref to a same-stack resource. Without a DAG edge the
+      // resolver races and falls back to the literal placeholder.
+      const template: CloudFormationTemplate = {
+        Resources: {
+          MyRepo: {
+            Type: 'AWS::ECR::Repository',
+            Properties: {},
+          },
+          NginxTaskDef: {
+            Type: 'AWS::ECS::TaskDefinition',
+            Properties: {
+              ContainerDefinitions: [
+                {
+                  Name: 'web',
+                  Image: {
+                    'Fn::Sub':
+                      '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${MyRepo}:latest',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const graph = dagBuilder.buildGraph(template);
+
+      expect(graph.nodeCount()).toBe(2);
+      expect(graph.hasEdge('MyRepo', 'NginxTaskDef')).toBe(true);
+    });
+
+    it('extracts implicit GetAtt dependency from Fn::Sub ${X.Attr} dotted form', () => {
+      const template: CloudFormationTemplate = {
+        Resources: {
+          MyRepo: {
+            Type: 'AWS::ECR::Repository',
+            Properties: {},
+          },
+          MyParam: {
+            Type: 'AWS::SSM::Parameter',
+            Properties: {
+              Type: 'String',
+              Value: { 'Fn::Sub': 'arn=${MyRepo.Arn}' },
+            },
+          },
+        },
+      };
+
+      const graph = dagBuilder.buildGraph(template);
+
+      expect(graph.hasEdge('MyRepo', 'MyParam')).toBe(true);
+    });
+
+    it('does NOT extract pseudo parameters from Fn::Sub bodies as dependencies', () => {
+      const template: CloudFormationTemplate = {
+        Resources: {
+          MyParam: {
+            Type: 'AWS::SSM::Parameter',
+            Properties: {
+              Type: 'String',
+              Value: {
+                'Fn::Sub': 'acct=${AWS::AccountId};region=${AWS::Region}',
+              },
+            },
+          },
+        },
+      };
+
+      const graph = dagBuilder.buildGraph(template);
+
+      expect(graph.nodeCount()).toBe(1);
+      expect(graph.edgeCount()).toBe(0);
+    });
+
+    it('skips names provided by Fn::Sub 2-arg variable map (but recurses into map values)', () => {
+      // The 2-arg form's variable map shadows same-stack lookups; names in
+      // the map MUST NOT produce a same-stack dependency edge. But the
+      // values inside the map can carry their own Ref / GetAtt intrinsics
+      // that should produce edges.
+      const template: CloudFormationTemplate = {
+        Resources: {
+          Bucket: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {},
+          },
+          // "MyRepo" — there is no resource named that; the map shadows
+          // would not surface a missing-dep warning if the parser handled
+          // it correctly.
+          MyParam: {
+            Type: 'AWS::SSM::Parameter',
+            Properties: {
+              Type: 'String',
+              Value: {
+                'Fn::Sub': [
+                  'name=${MyRepo}/bucket=${BucketArn}',
+                  {
+                    MyRepo: 'literal-from-map',
+                    BucketArn: { 'Fn::GetAtt': ['Bucket', 'Arn'] },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+
+      const graph = dagBuilder.buildGraph(template);
+
+      // Only Bucket → MyParam (via the map's GetAtt value); the bare
+      // ${MyRepo} placeholder is shadowed by the map and does not
+      // produce an edge to a non-existent resource.
+      expect(graph.nodeCount()).toBe(2);
+      expect(graph.hasEdge('Bucket', 'MyParam')).toBe(true);
+    });
+
     it('should detect circular dependencies', () => {
       const template: CloudFormationTemplate = {
         Resources: {

--- a/tests/unit/deployment/intrinsic-functions.test.ts
+++ b/tests/unit/deployment/intrinsic-functions.test.ts
@@ -948,3 +948,85 @@ describe('IntrinsicFunctionResolver - Fn::GetAtt LaunchTemplate.LatestVersionNum
     expect(result).toBe('2');
   });
 });
+
+describe('IntrinsicFunctionResolver - Fn::Sub same-stack implicit Ref', () => {
+  // Per the CloudFormation spec, when ${X} appears in a 1-arg Fn::Sub body
+  // and X is not in the explicit variable map (the 2-arg form's second
+  // element), then if X is a resource logical id in the same stack it
+  // resolves as Ref X. See #275 — cdkd's resolver already routes through
+  // resolveRef, so once the DAG fix makes the same-stack resource deploy
+  // first, ${MyRepo} substitutes correctly.
+  let resolver: IntrinsicFunctionResolver;
+
+  beforeEach(() => {
+    resolver = new IntrinsicFunctionResolver();
+    resetAccountInfoCache();
+  });
+
+  const makeContext = (
+    extra: Partial<ResolverContext> = {}
+  ): ResolverContext => ({
+    template: { Resources: {} },
+    resources: {
+      MyRepo: {
+        physicalId: 'cdkmyrepo123-abcdef',
+        resourceType: 'AWS::ECR::Repository',
+        properties: {},
+        attributes: { Arn: 'arn:aws:ecr:us-east-1:123456789012:repository/cdkmyrepo123-abcdef' },
+        dependencies: [],
+      },
+    },
+    ...extra,
+  });
+
+  it('resolves bare ${X} to the same-stack resource physical id', async () => {
+    const result = await resolver.resolve({ 'Fn::Sub': '${MyRepo}' }, makeContext());
+    expect(result).toBe('cdkmyrepo123-abcdef');
+  });
+
+  it('substitutes ${X} embedded in a surrounding template string', async () => {
+    const result = await resolver.resolve(
+      { 'Fn::Sub': 'prefix/${MyRepo}:tag' },
+      makeContext()
+    );
+    expect(result).toBe('prefix/cdkmyrepo123-abcdef:tag');
+  });
+
+  it('resolves a real ECR image URI shape combining pseudo parameters + same-stack ref', async () => {
+    // The exact body shape from #275's integ fixture.
+    const result = await resolver.resolve(
+      {
+        'Fn::Sub':
+          '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${MyRepo}:latest',
+      },
+      makeContext()
+    );
+    expect(result).toBe(
+      '123456789012.dkr.ecr.us-east-1.amazonaws.com/cdkmyrepo123-abcdef:latest'
+    );
+  });
+
+  it('resolves ${X.Attr} dotted form as implicit Fn::GetAtt', async () => {
+    const result = await resolver.resolve({ 'Fn::Sub': '${MyRepo.Arn}' }, makeContext());
+    expect(result).toBe('arn:aws:ecr:us-east-1:123456789012:repository/cdkmyrepo123-abcdef');
+  });
+
+  it('two-arg form variable map takes precedence over same-stack lookup', async () => {
+    // When X appears in the 2-arg variable map, that wins regardless of
+    // whether a same-stack resource named X exists.
+    const result = await resolver.resolve(
+      { 'Fn::Sub': ['${MyRepo}', { MyRepo: 'literal-from-map' }] },
+      makeContext()
+    );
+    expect(result).toBe('literal-from-map');
+  });
+
+  it('keeps the placeholder literal when ${X} is not a resource / parameter / pseudo', async () => {
+    const result = await resolver.resolve(
+      { 'Fn::Sub': 'value=${NotARealResource}' },
+      makeContext()
+    );
+    // Existing behavior: warn + keep ${NotARealResource} as-is.
+    expect(result).toBe('value=${NotARealResource}');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #275. Discovered by `/run-integ local-run-task-from-state` (PR #274's fixture) during this session — first real-AWS exercise of PR #267's `--from-state` Tier 2 path, which surfaced this latent deploy-time bug.

## Root cause

The intrinsic *resolver* was already correct — `resolveSub` falls through to `resolveRef` which checks `context.resources`. The bug was in **DAG dependency extraction**: `TemplateParser.extractRefsFromValue` only scanned `Ref` and `Fn::GetAtt` intrinsics, so a `Fn::Sub: "...${MyRepo}..."` body produced **no DAG edge** from the consumer to MyRepo. Both resources got dispatched at level 0 in parallel; NginxTaskDef tried to resolve `${MyRepo}` before MyRepo's create call completed, the lookup failed, `resolveSub`'s catch kept the literal placeholder, and AWS rejected the ECS Image as "invalid characters".

Repro from `/run-integ` log:

```
Ref MyRepo not found (not a resource, parameter, or pseudo parameter)
Fn::Sub variable MyRepo not found, keeping placeholder
Failed to create NginxTaskDef: ... Container.image contains invalid characters.
[1/2] ✅ MyRepo (AWS::ECR::Repository) created  ← log order is completion order, not dispatch order
Rolling back 1 completed operation(s)...
```

## Fix

`src/analyzer/template-parser.ts` — extended `extractRefsFromValue` to scan `Fn::Sub`:

- **1-arg form** (`Fn::Sub: "body with ${X} and ${X.Attr}"`): scan placeholders, treat `${X}` as `Ref: X` dependency and `${X.Attr}` as `Fn::GetAtt: [X, Attr]` dependency. Skip `${AWS::*}` pseudo parameters (no edge).
- **2-arg form** (`Fn::Sub: ["body", {X: someRef}]`): harvest the variable-map keys to shadow same-stack lookups (matches CloudFormation spec), AND recursively walk the map values so any nested `Ref` / `Fn::GetAtt` inside the map still produces edges.

The resolver itself needed no change — closing the DAG race makes the existing fall-through path see populated state.

## Tests

10 new cases, all passing; full suite 2921 / 2921:

- `tests/unit/analyzer/dag-builder.test.ts` — 4 cases: 1-arg `${X}` ECR URI shape (the #275 repro), `${X.Attr}` dotted form → GetAtt edge, pseudo-only body produces no edge, 2-arg map shadows while still recursing into map values for nested GetAtt.
- `tests/unit/deployment/intrinsic-functions.test.ts` — 6 resolver-side cases: bare `${X}` → physicalId, embedded substitution, full ECR URI from the integ fixture, dotted GetAtt fallback, 2-arg map precedence, unresolved-keeps-literal regression guard.

## Cross-cutting finding

Other intrinsics (`Fn::Join` / `Fn::Select` / `Fn::Split` / `Fn::If` / etc.) carry their arguments as nested object trees (e.g. `{Ref: "X"}`) that `extractRefsFromValue` already walks recursively — they have no parallel gap. Only `Fn::Sub`'s string-body form needed special-case scanning.

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` / `test` (2921) / `format:check` pass
- [x] Repro fixture (`tests/integration/local-run-task-from-state/`) will be re-exercised via `/run-integ local-run-task-from-state` after this PR merges → should now reach the `cdkd local run-task --from-state` step (the integ's actual goal). Marker-set unblocks PR #274.

## Related

- #275 (this PR's issue)
- PR #267 (introduced the now-fixed `--from-state` Tier 2 — Tier 2 needed deploy to succeed, which this PR enables)
- PR #274 (the integ fixture that surfaced this bug)
- #271 (CDK 2.x `Fn::Join` shape — separate concern in `src/local/ecs-task-resolver.ts`, parallel fix-back in flight)
- memory `feedback_live_test_must_exercise.md` (resolver / template-processing paths surface bugs only via real-AWS integ; closes the loop)
