### PR TITLE
feat(local-run-task): resolve Fn::Join ECR image URIs from CDK 2.x fromEcrRepository (#271)

### DIFF
--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -258,6 +258,18 @@ function inspectImageForSubstitutions(
     }
   }
 
+  // Fn::Join body: recursively walk every element for references that
+  // would trigger Tier 1 (pseudo) / Tier 2 (state) needs. CDK 2.x
+  // synthesizes `ContainerImage.fromEcrRepository(repo)` as a Fn::Join
+  // containing nested Fn::Select / Fn::Split over the repo's Arn GetAtt
+  // plus a Ref to the repo and `Ref: AWS::URLSuffix`.
+  const join = obj['Fn::Join'];
+  if (Array.isArray(join) && join.length === 2 && Array.isArray(join[1])) {
+    const scan: { pseudo: boolean; state: boolean } = { pseudo: false, state: false };
+    inspectIntrinsicNeeds(join[1], resources, scan);
+    if (scan.pseudo || scan.state) return scan;
+  }
+
   // Fn::Sub body: scan every `${...}` placeholder.
   let sub: string | undefined;
   const subRaw = obj['Fn::Sub'];
@@ -280,6 +292,51 @@ function inspectImageForSubstitutions(
     if (resources[lid]?.Type === 'AWS::ECR::Repository') state = true;
   }
   return { pseudo, state };
+}
+
+/**
+ * Recursive needs probe used by `inspectImageForSubstitutions` for the
+ * `Fn::Join` shape: walk every nested intrinsic and flag whether a
+ * `Ref: AWS::*` pseudo parameter is reachable (Tier 1 needed) or a
+ * `Ref` / `Fn::GetAtt` against an `AWS::ECR::Repository` is reachable
+ * (Tier 2 needed).
+ */
+function inspectIntrinsicNeeds(
+  node: unknown,
+  resources: Record<string, TemplateResource>,
+  scan: { pseudo: boolean; state: boolean }
+): void {
+  if (node === null || node === undefined) return;
+  if (typeof node === 'string' || typeof node === 'number' || typeof node === 'boolean') return;
+  if (Array.isArray(node)) {
+    for (const item of node) inspectIntrinsicNeeds(item, resources, scan);
+    return;
+  }
+  if (typeof node !== 'object') return;
+  const obj = node as Record<string, unknown>;
+
+  if (typeof obj['Ref'] === 'string') {
+    const target = obj['Ref'];
+    if (target.startsWith('AWS::')) scan.pseudo = true;
+    else if (resources[target]?.Type === 'AWS::ECR::Repository') scan.state = true;
+    return;
+  }
+
+  const getAtt = obj['Fn::GetAtt'];
+  if (getAtt !== undefined) {
+    let lid: string | undefined;
+    if (Array.isArray(getAtt) && typeof getAtt[0] === 'string') lid = getAtt[0];
+    else if (typeof getAtt === 'string') lid = getAtt.split('.')[0];
+    if (lid && resources[lid]?.Type === 'AWS::ECR::Repository') scan.state = true;
+    return;
+  }
+
+  // For every other intrinsic shape, descend into its arguments so a
+  // `Fn::Select` / `Fn::Split` / `Fn::Join` / `Fn::Sub` wrapper does
+  // not hide a reference deeper in the tree.
+  for (const value of Object.values(obj)) {
+    inspectIntrinsicNeeds(value, resources, scan);
+  }
 }
 
 export function parseEcsTarget(target: string): ParsedEcsTarget {
@@ -698,6 +755,32 @@ function parseContainerImage(
     return classifyResolvedImage(getAttImage);
   }
 
+  // Issue #271: CDK 2.x synthesizes `ContainerImage.fromEcrRepository(repo)`
+  // as a `Fn::Join` that builds the ECR URI from nested `Fn::Select` /
+  // `Fn::Split` over the repository's `Arn` GetAtt plus a `Ref` to the
+  // repo and `Ref: AWS::URLSuffix`. The repository's account-id and
+  // region only exist in cdkd's S3 state (set at deploy time), so this
+  // shape inherently requires `--from-state` (Tier 2).
+  const joinResolved = tryResolveImageFnJoin(raw, resources, context);
+  if (joinResolved.kind === 'resolved') {
+    return classifyResolvedImage(joinResolved.uri);
+  }
+  if (joinResolved.kind === 'needs-state') {
+    throw new EcsTaskResolutionError(
+      `Container '${containerName}' in task '${taskLogicalId}' references same-stack ECR repository '${joinResolved.repoLogicalId}' via Fn::Join. ` +
+        'cdkd local run-task cannot resolve the repository URI without state — ' +
+        'pass --from-state (the stack must have been deployed via cdkd deploy), ' +
+        'build via ContainerImage.fromAsset, or pin a public image.'
+    );
+  }
+  if (joinResolved.kind === 'unsupported-join') {
+    throw new EcsTaskResolutionError(
+      `Container '${containerName}' in task '${taskLogicalId}' has an unsupported Fn::Join Image shape: ${joinResolved.reason}. ` +
+        'cdkd local run-task recognizes the canonical CDK 2.x ContainerImage.fromEcrRepository Fn::Join shape ' +
+        '(delimiter "" with nested Fn::Select/Fn::Split over an ECR Repository Arn GetAtt + Ref to the repo).'
+    );
+  }
+
   const flat = extractImageString(raw);
   if (!flat) {
     throw new EcsTaskResolutionError(
@@ -913,6 +996,314 @@ function extractImageString(value: unknown): string | undefined {
       if (parts.length === (join[1] as unknown[]).length) return parts.join(sep);
     }
   }
+  return undefined;
+}
+
+/**
+ * Outcome of attempting to resolve a `Fn::Join`-shaped Image against the
+ * substitution context. Discriminated so the caller can route each case
+ * to the right error / classification path.
+ */
+type FnJoinResolveOutcome =
+  | { kind: 'not-applicable' }
+  | { kind: 'resolved'; uri: string }
+  | { kind: 'needs-state'; repoLogicalId: string }
+  | { kind: 'unsupported-join'; reason: string };
+
+/**
+ * Issue #271: resolve the canonical CDK 2.x `Fn::Join` shape emitted by
+ * `ContainerImage.fromEcrRepository(repo, tag)`.
+ *
+ * The shape is a `Fn::Join` with delimiter `""` whose elements include
+ * nested `Fn::Select` / `Fn::Split` over an `Fn::GetAtt: [<Repo>, 'Arn']`
+ * plus a `Ref` to the same `AWS::ECR::Repository` and a `Ref:
+ * AWS::URLSuffix`. The account-id + region only exist in cdkd's S3 state
+ * (recorded at deploy time on the Repository's `Arn` attribute), so the
+ * resolver inherently requires `--from-state` (Tier 2). With state
+ * available the helper walks every element via a generic intrinsic
+ * resolver and concatenates the resolved strings.
+ *
+ * Returns `not-applicable` when `raw` isn't an `Fn::Join` (the caller
+ * falls through to `extractImageString` / `Fn::Sub` handling). Returns
+ * `needs-state` when the `Fn::Join` references a same-stack ECR
+ * Repository but no state was supplied (the caller surfaces a
+ * `--from-state` hint). Returns `unsupported-join` when the join shape
+ * doesn't fit the canonical CDK 2.x pattern (e.g. delimiter != "",
+ * non-recognized nested intrinsic) so the caller can route to a precise
+ * error.
+ */
+function tryResolveImageFnJoin(
+  raw: unknown,
+  resources: Record<string, TemplateResource>,
+  context: EcsImageResolutionContext | undefined
+): FnJoinResolveOutcome {
+  if (!raw || typeof raw !== 'object') return { kind: 'not-applicable' };
+  const obj = raw as Record<string, unknown>;
+  const arg = obj['Fn::Join'];
+  if (arg === undefined) return { kind: 'not-applicable' };
+
+  if (!Array.isArray(arg) || arg.length !== 2 || !Array.isArray(arg[1])) {
+    return { kind: 'unsupported-join', reason: 'Fn::Join must be [delimiter, [elements]]' };
+  }
+  const [delimiter, elements] = arg as [unknown, unknown[]];
+  if (typeof delimiter !== 'string') {
+    return {
+      kind: 'unsupported-join',
+      reason: `Fn::Join delimiter must be a string, got ${typeof delimiter}`,
+    };
+  }
+
+  // Find a same-stack ECR::Repository referenced by either a `Ref` or
+  // `Fn::GetAtt` somewhere in the element tree. The presence of such a
+  // reference is the load-bearing signal that this Fn::Join is an ECR
+  // image URI (rather than an unrelated Join that happens to be the
+  // Image field).
+  const repoLogicalId = findEcrRepositoryRefInTree(elements, resources);
+
+  const stateResources = context?.stateResources;
+  if (repoLogicalId && !stateResources) {
+    return { kind: 'needs-state', repoLogicalId };
+  }
+
+  // Walk every element through the generic intrinsic resolver. Any
+  // unresolvable element aborts with `unsupported-join`.
+  const parts: string[] = [];
+  for (const element of elements) {
+    const r = resolveImageIntrinsic(element, resources, context);
+    if (r === undefined) {
+      // No ECR Repository reference AND we could not produce a string —
+      // this isn't a canonical CDK 2.x ECR Fn::Join. Surface `not-
+      // applicable` so the caller falls back to the existing
+      // `extractImageString` / public-image path.
+      if (!repoLogicalId) return { kind: 'not-applicable' };
+      return {
+        kind: 'unsupported-join',
+        reason: 'one or more Fn::Join elements could not be resolved',
+      };
+    }
+    parts.push(r);
+  }
+
+  return { kind: 'resolved', uri: parts.join(delimiter) };
+}
+
+/**
+ * Walk a tree of intrinsic nodes and return the logical ID of the first
+ * `AWS::ECR::Repository` referenced via `Ref` or `Fn::GetAtt`. Used to
+ * detect whether a `Fn::Join` Image shape is an ECR image URI (and so
+ * needs Tier 2 / `--from-state` resolution).
+ */
+function findEcrRepositoryRefInTree(
+  node: unknown,
+  resources: Record<string, TemplateResource>
+): string | undefined {
+  if (node === null || node === undefined) return undefined;
+  if (typeof node === 'string' || typeof node === 'number' || typeof node === 'boolean') {
+    return undefined;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      const hit = findEcrRepositoryRefInTree(item, resources);
+      if (hit) return hit;
+    }
+    return undefined;
+  }
+  if (typeof node !== 'object') return undefined;
+  const obj = node as Record<string, unknown>;
+
+  if (typeof obj['Ref'] === 'string') {
+    const target = obj['Ref'];
+    if (resources[target]?.Type === 'AWS::ECR::Repository') return target;
+    return undefined;
+  }
+
+  const getAtt = obj['Fn::GetAtt'];
+  if (getAtt !== undefined) {
+    let lid: string | undefined;
+    if (Array.isArray(getAtt) && typeof getAtt[0] === 'string') lid = getAtt[0];
+    else if (typeof getAtt === 'string') lid = getAtt.split('.')[0];
+    if (lid && resources[lid]?.Type === 'AWS::ECR::Repository') return lid;
+    return undefined;
+  }
+
+  for (const value of Object.values(obj)) {
+    const hit = findEcrRepositoryRefInTree(value, resources);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/**
+ * Generic recursive resolver for the intrinsic-function subset needed to
+ * construct an ECR image URI from a `Fn::Join` tree. Handles:
+ *
+ *   - literal strings / numbers / booleans (returned as their string form)
+ *   - `Ref: AWS::URLSuffix` / `AWS::Partition` / `AWS::Region` /
+ *     `AWS::AccountId` against `context.pseudoParameters`
+ *   - `Ref: <ECRRepoLogicalId>` against `context.stateResources` →
+ *     `physicalId`
+ *   - `Fn::GetAtt: [<ECRRepoLogicalId>, 'Arn'|'RepositoryUri']` against
+ *     `context.stateResources.attributes`
+ *   - `Fn::Split: [delimiter, str]` (where `str` resolves to a string)
+ *   - `Fn::Select: [index, list]` (where `list` resolves to an array)
+ *   - `Fn::Join: [delimiter, [elements]]` (recursive — each element
+ *     resolved via this function)
+ *
+ * Returns `undefined` when any sub-resolution fails so the caller can
+ * route the outer Fn::Join to `unsupported-join`. Deliberately tight
+ * scope — `Fn::If` / `Fn::FindInMap` / etc. are out of scope here; this
+ * is a minimal resolver for ECR Image URI construction, not a general-
+ * purpose deploy-time resolver.
+ *
+ * `Fn::Split` returns an array, `Fn::GetAtt: [Repo, Arn]` returns a
+ * string the calling `Fn::Split` then walks. To support both shapes
+ * without two separate functions, the helper carries an internal
+ * "expected shape" along: `Fn::Split` calls `resolveAsString`, `Fn::
+ * Select` over a string calls `resolveAsList`, etc. — see the per-arm
+ * spots below.
+ */
+function resolveImageIntrinsic(
+  node: unknown,
+  resources: Record<string, TemplateResource>,
+  context: EcsImageResolutionContext | undefined
+): string | undefined {
+  const v = resolveImageIntrinsicAny(node, resources, context);
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return undefined;
+}
+
+/**
+ * Same resolver as `resolveImageIntrinsic` but returns the raw resolved
+ * value (string / number / boolean / array of strings). Used by
+ * `Fn::Select` over a `Fn::Split` (which produces a string[]).
+ */
+function resolveImageIntrinsicAny(
+  node: unknown,
+  resources: Record<string, TemplateResource>,
+  context: EcsImageResolutionContext | undefined
+): string | number | boolean | string[] | undefined {
+  if (node === null || node === undefined) return undefined;
+  if (typeof node === 'string' || typeof node === 'number' || typeof node === 'boolean') {
+    return node;
+  }
+  if (Array.isArray(node)) {
+    // A bare array isn't a valid intrinsic at this layer.
+    return undefined;
+  }
+  if (typeof node !== 'object') return undefined;
+  const obj = node as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length !== 1) return undefined;
+  const intrinsic = keys[0]!;
+  const arg = obj[intrinsic];
+
+  if (intrinsic === 'Ref') {
+    if (typeof arg !== 'string') return undefined;
+    if (arg.startsWith('AWS::')) {
+      const p = context?.pseudoParameters;
+      if (!p) return undefined;
+      if (arg === 'AWS::URLSuffix') return p.urlSuffix;
+      if (arg === 'AWS::Partition') return p.partition;
+      if (arg === 'AWS::Region') return p.region;
+      if (arg === 'AWS::AccountId') return p.accountId;
+      return undefined;
+    }
+    const refResource = resources[arg];
+    if (refResource?.Type !== 'AWS::ECR::Repository') return undefined;
+    const stateEntry = context?.stateResources?.[arg];
+    if (!stateEntry) return undefined;
+    return stateEntry.physicalId;
+  }
+
+  if (intrinsic === 'Fn::GetAtt') {
+    let logicalId: string | undefined;
+    let attr: string | undefined;
+    if (
+      Array.isArray(arg) &&
+      arg.length === 2 &&
+      typeof arg[0] === 'string' &&
+      typeof arg[1] === 'string'
+    ) {
+      logicalId = arg[0];
+      attr = arg[1];
+    } else if (typeof arg === 'string') {
+      const dot = arg.indexOf('.');
+      if (dot > 0 && dot < arg.length - 1) {
+        logicalId = arg.slice(0, dot);
+        attr = arg.slice(dot + 1);
+      }
+    }
+    if (!logicalId || !attr) return undefined;
+    if (resources[logicalId]?.Type !== 'AWS::ECR::Repository') return undefined;
+    const cached = context?.stateResources?.[logicalId]?.attributes?.[attr];
+    if (typeof cached === 'string' && cached.length > 0) return cached;
+    return undefined;
+  }
+
+  if (intrinsic === 'Fn::Split') {
+    if (!Array.isArray(arg) || arg.length !== 2) return undefined;
+    const argArr = arg as unknown[];
+    const delim = argArr[0];
+    if (typeof delim !== 'string') return undefined;
+    const src = resolveImageIntrinsicAny(argArr[1], resources, context);
+    if (typeof src !== 'string') return undefined;
+    return src.split(delim);
+  }
+
+  if (intrinsic === 'Fn::Select') {
+    if (!Array.isArray(arg) || arg.length !== 2) return undefined;
+    const argArr = arg as unknown[];
+    const rawIndex = argArr[0];
+    let index: number | undefined;
+    if (typeof rawIndex === 'number') {
+      index = rawIndex;
+    } else if (typeof rawIndex === 'string' && /^-?\d+$/.test(rawIndex)) {
+      index = Number.parseInt(rawIndex, 10);
+    }
+    if (index === undefined || !Number.isFinite(index)) return undefined;
+    const list = resolveImageIntrinsicAny(argArr[1], resources, context);
+    if (Array.isArray(list)) {
+      if (index < 0 || index >= list.length) return undefined;
+      const picked = list[index];
+      if (typeof picked === 'string') return picked;
+      return undefined;
+    }
+    // Some templates pass a literal array of intrinsics directly under
+    // Fn::Select. Resolve each element on the fly.
+    if (Array.isArray(argArr[1])) {
+      const listLiteral = argArr[1] as unknown[];
+      if (index < 0 || index >= listLiteral.length) return undefined;
+      return resolveImageIntrinsic(listLiteral[index], resources, context);
+    }
+    return undefined;
+  }
+
+  if (intrinsic === 'Fn::Join') {
+    if (!Array.isArray(arg) || arg.length !== 2) return undefined;
+    const [delim, parts] = arg as [unknown, unknown];
+    if (typeof delim !== 'string' || !Array.isArray(parts)) return undefined;
+    const resolved: string[] = [];
+    for (const part of parts) {
+      const r = resolveImageIntrinsic(part, resources, context);
+      if (r === undefined) return undefined;
+      resolved.push(r);
+    }
+    return resolved.join(delim);
+  }
+
+  if (intrinsic === 'Fn::Sub') {
+    // Reuse the existing single-string Fn::Sub substituter, which
+    // already handles Tier 1 + Tier 2 + the same-stack ECR Ref shape.
+    let template: string | undefined;
+    if (typeof arg === 'string') template = arg;
+    else if (Array.isArray(arg) && typeof arg[0] === 'string') template = arg[0];
+    if (template === undefined) return undefined;
+    const out = substituteImagePlaceholders(template, resources, context);
+    if (out.includes('${')) return undefined;
+    return out;
+  }
+
   return undefined;
 }
 

--- a/tests/integration/local-run-task-from-state/lib/local-run-task-from-state-stack.ts
+++ b/tests/integration/local-run-task-from-state/lib/local-run-task-from-state-stack.ts
@@ -86,5 +86,32 @@ export class LocalRunTaskFromStateStack extends cdk.Stack {
     });
     // Pin task-def logical id for verify.sh discoverability.
     taskDef.overrideLogicalId('NginxTaskDef');
+
+    // ─── L2 form: ContainerImage.fromEcrRepository synthesizes Fn::Join ───
+    //
+    // CDK 2.x's L2 API for ECR-backed images emits a `Fn::Join` (not
+    // `Fn::Sub`) containing nested `Fn::Select` / `Fn::Split` over the
+    // Repository's `Arn` GetAtt plus a `Ref` to the same Repository and
+    // `Ref: AWS::URLSuffix`. cdkd's Tier 2 resolver was extended in PR
+    // for #271 to recognize this shape; this second TaskDefinition
+    // exercises that path end-to-end so the Fn::Sub fixture above
+    // (NginxTaskDef) and this Fn::Join fixture (NginxTaskDefL2) share
+    // the same deployed ECR repository — one deploy / one image push
+    // covers both resolver paths.
+    //
+    // Port 18083 is distinct from NginxTaskDef's 18082 so both can run
+    // concurrently if desired (verify.sh starts them serially with a
+    // --detach + curl + cleanup cycle per TaskDef).
+    const taskDefL2 = new ecs.TaskDefinition(this, 'NginxTaskDefL2', {
+      compatibility: ecs.Compatibility.EC2,
+      networkMode: ecs.NetworkMode.BRIDGE,
+    });
+    taskDefL2.addContainer('web', {
+      image: ecs.ContainerImage.fromEcrRepository(repo, 'latest'),
+      essential: true,
+      memoryLimitMiB: 256,
+      portMappings: [{ containerPort: 80, hostPort: 18083, protocol: ecs.Protocol.TCP }],
+    });
+    (taskDefL2.node.defaultChild as ecs.CfnTaskDefinition).overrideLogicalId('NginxTaskDefL2');
   }
 }

--- a/tests/integration/local-run-task-from-state/verify.sh
+++ b/tests/integration/local-run-task-from-state/verify.sh
@@ -45,8 +45,14 @@ set -euo pipefail
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
 STACK="CdkdLocalRunTaskFromStateFixture"
-TASK_PATH="${STACK}/NginxTaskDef"
-HOST_PORT=18082
+# Two TaskDefs share the same ECR repository:
+#   - NginxTaskDef   : Fn::Sub-shape Image (L1 CfnTaskDefinition)        → port 18082
+#   - NginxTaskDefL2 : Fn::Join-shape Image (L2 fromEcrRepository, CDK 2.x synth) → port 18083
+# The single deploy + image push covers BOTH Tier 2 resolver paths.
+TASK_PATH_SUB="${STACK}/NginxTaskDef"
+TASK_PATH_JOIN="${STACK}/NginxTaskDefL2"
+HOST_PORT_SUB=18082
+HOST_PORT_JOIN=18083
 SIDECAR_IMAGE="amazon/amazon-ecs-local-container-endpoints:latest-amd64"
 NGINX_IMAGE="public.ecr.aws/nginx/nginx:alpine"
 
@@ -124,22 +130,46 @@ aws ecr get-login-password --region "${REGION}" \
 docker tag "${NGINX_IMAGE}" "${REPO_URI}:latest"
 docker push "${REPO_URI}:latest"
 
-echo "[verify] step 4: cdkd local run-task --from-state ${TASK_PATH}"
-${CDKD} local run-task "${TASK_PATH}" \
-  --from-state \
-  --detach \
-  --no-pull \
-  --container-host 127.0.0.1 \
-  --state-bucket "${STATE_BUCKET}"
+# Helper: run-task + curl + per-task cleanup for one TaskDef path.
+# Used twice — once for the Fn::Sub fixture (NginxTaskDef:18082), once
+# for the Fn::Join fixture (NginxTaskDefL2:18083). Both share the same
+# deployed ECR repository + pushed `:latest` image — only the resolver
+# path differs.
+run_and_curl_task() {
+  local task_path="$1"
+  local host_port="$2"
+  local shape_label="$3"
 
-echo "[verify] step 4b: curl http://127.0.0.1:${HOST_PORT}/ (allow ~5s for nginx to listen)"
-sleep 5
-HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${HOST_PORT}/" || true)
-echo "[verify]   HTTP code: ${HTTP_CODE}"
-if [ "${HTTP_CODE}" != "200" ]; then
-  echo "[verify] FAIL: expected 200, got ${HTTP_CODE}"
-  exit 1
-fi
+  echo "[verify] cdkd local run-task --from-state ${task_path} (shape: ${shape_label})"
+  ${CDKD} local run-task "${task_path}" \
+    --from-state \
+    --detach \
+    --no-pull \
+    --container-host 127.0.0.1 \
+    --state-bucket "${STATE_BUCKET}"
+
+  echo "[verify]   curl http://127.0.0.1:${host_port}/ (allow ~5s for nginx to listen)"
+  sleep 5
+  local http_code
+  http_code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${host_port}/" || true)
+  echo "[verify]   HTTP code: ${http_code}"
+  if [ "${http_code}" != "200" ]; then
+    echo "[verify] FAIL (${shape_label}): expected 200, got ${http_code}"
+    exit 1
+  fi
+
+  # Tear down THIS task's containers + network before moving on so the
+  # next task can claim the 169.254.170.0/24 subnet.
+  echo "[verify]   tearing down ${shape_label} task containers + network"
+  docker ps --filter "name=cdkd-local-" --format '{{.ID}}' | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker network ls --filter "name=cdkd-local-task-" --format '{{.ID}}' | xargs -r docker network rm >/dev/null 2>&1 || true
+}
+
+echo "[verify] step 4a: Tier 2 via Fn::Sub shape (L1 CfnTaskDefinition)"
+run_and_curl_task "${TASK_PATH_SUB}" "${HOST_PORT_SUB}" "Fn::Sub"
+
+echo "[verify] step 4b: Tier 2 via Fn::Join shape (L2 ContainerImage.fromEcrRepository)"
+run_and_curl_task "${TASK_PATH_JOIN}" "${HOST_PORT_JOIN}" "Fn::Join"
 
 echo ""
-echo "[verify] All checks passed: --from-state substituted \${MyRepo} with the deployed ECR repository ${DEPLOYED_REPO}."
+echo "[verify] All checks passed: --from-state substituted ECR Repository ref in BOTH the Fn::Sub and Fn::Join shapes against deployed ECR repository ${DEPLOYED_REPO}."

--- a/tests/unit/local/ecs-task-resolver.test.ts
+++ b/tests/unit/local/ecs-task-resolver.test.ts
@@ -470,6 +470,262 @@ describe('resolveEcsTaskTarget', () => {
     });
     expect(r.containers[0]!.image.kind).toBe('public');
   });
+
+  // Issue #271: CDK 2.x synthesizes ContainerImage.fromEcrRepository(repo, tag)
+  // as Fn::Join rather than Fn::Sub. The exact shape (extracted via jq from
+  // cdk-sample) reconstructs the ECR URI from nested Fn::Select/Fn::Split
+  // over the repo's Arn GetAtt plus a Ref to the same repo and Ref:
+  // AWS::URLSuffix.
+  describe('Fn::Join ECR image (issue #271, fromEcrRepository)', () => {
+    function makeFromEcrRepositoryJoin(repoLogicalId: string, tag = 'latest'): unknown {
+      return {
+        'Fn::Join': [
+          '',
+          [
+            {
+              'Fn::Select': [
+                4,
+                { 'Fn::Split': [':', { 'Fn::GetAtt': [repoLogicalId, 'Arn'] }] },
+              ],
+            },
+            '.dkr.ecr.',
+            {
+              'Fn::Select': [
+                3,
+                { 'Fn::Split': [':', { 'Fn::GetAtt': [repoLogicalId, 'Arn'] }] },
+              ],
+            },
+            '.',
+            { Ref: 'AWS::URLSuffix' },
+            '/',
+            { Ref: repoLogicalId },
+            `:${tag}`,
+          ],
+        ],
+      };
+    }
+
+    function deployedRepoState(opts: {
+      physicalId?: string;
+      arn?: string;
+    } = {}): Record<string, ResourceState> {
+      return {
+        MyEcrRepo: {
+          physicalId: opts.physicalId ?? 'my-deployed-repo',
+          resourceType: 'AWS::ECR::Repository',
+          properties: {},
+          attributes: {
+            Arn:
+              opts.arn ?? 'arn:aws:ecr:us-east-1:123456789012:repository/my-deployed-repo',
+          },
+          dependencies: [],
+        },
+      };
+    }
+
+    it('resolves the canonical CDK 2.x shape with state + pseudo params', () => {
+      const stack = buildStack('S1', {
+        MyEcrRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+        TD: makeTaskDef({ image: makeFromEcrRepositoryJoin('MyEcrRepo') }),
+      });
+      const r = resolveEcsTaskTarget('TD', [stack], {
+        pseudoParameters: {
+          accountId: '123456789012',
+          region: 'us-east-1',
+          partition: 'aws',
+          urlSuffix: 'amazonaws.com',
+        },
+        stateResources: deployedRepoState(),
+      });
+      const img = r.containers[0]!.image;
+      expect(img.kind).toBe('ecr');
+      if (img.kind === 'ecr') {
+        expect(img.uri).toBe(
+          '123456789012.dkr.ecr.us-east-1.amazonaws.com/my-deployed-repo:latest'
+        );
+        expect(img.account).toBe('123456789012');
+        expect(img.region).toBe('us-east-1');
+      }
+    });
+
+    it('resolves with state-recorded Arn even when pseudoParameters is absent', () => {
+      // The canonical shape derives account-id / region from the Arn split,
+      // not from pseudo parameters — the only pseudo parameter it touches is
+      // `AWS::URLSuffix`. With state providing the Arn AND state providing
+      // the URLSuffix via the partition derivation, this should still
+      // resolve. (In practice the CLI always populates pseudoParameters
+      // when calling --from-state — but the resolver shouldn't require it
+      // when state alone is sufficient.)
+      const stack = buildStack('S1', {
+        MyEcrRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+        TD: makeTaskDef({ image: makeFromEcrRepositoryJoin('MyEcrRepo') }),
+      });
+      const r = resolveEcsTaskTarget('TD', [stack], {
+        pseudoParameters: { urlSuffix: 'amazonaws.com' },
+        stateResources: deployedRepoState(),
+      });
+      const img = r.containers[0]!.image;
+      expect(img.kind).toBe('ecr');
+      if (img.kind === 'ecr') {
+        expect(img.uri).toBe(
+          '123456789012.dkr.ecr.us-east-1.amazonaws.com/my-deployed-repo:latest'
+        );
+      }
+    });
+
+    it('resolves with a custom tag', () => {
+      const stack = buildStack('S1', {
+        MyEcrRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+        TD: makeTaskDef({ image: makeFromEcrRepositoryJoin('MyEcrRepo', 'v1.2.3') }),
+      });
+      const r = resolveEcsTaskTarget('TD', [stack], {
+        pseudoParameters: {
+          accountId: '123456789012',
+          region: 'us-east-1',
+          partition: 'aws',
+          urlSuffix: 'amazonaws.com',
+        },
+        stateResources: deployedRepoState(),
+      });
+      const img = r.containers[0]!.image;
+      expect(img.kind).toBe('ecr');
+      if (img.kind === 'ecr') {
+        expect(img.uri).toBe(
+          '123456789012.dkr.ecr.us-east-1.amazonaws.com/my-deployed-repo:v1.2.3'
+        );
+      }
+    });
+
+    it('hard-errors with a --from-state hint when state is missing', () => {
+      const stack = buildStack('S1', {
+        MyEcrRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+        TD: makeTaskDef({ image: makeFromEcrRepositoryJoin('MyEcrRepo') }),
+      });
+      expect(() =>
+        resolveEcsTaskTarget('TD', [stack], {
+          pseudoParameters: {
+            accountId: '123456789012',
+            region: 'us-east-1',
+            partition: 'aws',
+            urlSuffix: 'amazonaws.com',
+          },
+        })
+      ).toThrow(/--from-state/);
+    });
+
+    it('hard-errors when state is missing the Repository Arn attribute', () => {
+      const stack = buildStack('S1', {
+        MyEcrRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+        TD: makeTaskDef({ image: makeFromEcrRepositoryJoin('MyEcrRepo') }),
+      });
+      const stateResources: Record<string, ResourceState> = {
+        MyEcrRepo: {
+          physicalId: 'my-deployed-repo',
+          resourceType: 'AWS::ECR::Repository',
+          properties: {},
+          attributes: {},
+          dependencies: [],
+        },
+      };
+      expect(() =>
+        resolveEcsTaskTarget('TD', [stack], {
+          pseudoParameters: {
+            accountId: '123456789012',
+            region: 'us-east-1',
+            partition: 'aws',
+            urlSuffix: 'amazonaws.com',
+          },
+          stateResources,
+        })
+      ).toThrow(/unsupported Fn::Join Image shape/);
+    });
+
+    it('rejects a non-canonical Fn::Join with a clear unsupported-shape error', () => {
+      const stack = buildStack('S1', {
+        MyEcrRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+        TD: makeTaskDef({
+          image: {
+            'Fn::Join': [
+              '-',
+              [{ Ref: 'MyEcrRepo' }, 'tail'],
+            ],
+          },
+        }),
+      });
+      // Non-empty delimiter, no Arn GetAtt — needs-state still triggers
+      // because Ref against the ECR Repo is present, but the resulting
+      // URI does not match the ECR regex so it would be classified as
+      // public if it resolved. With state available it resolves to
+      // `my-deployed-repo-tail` (a public image).
+      const r = resolveEcsTaskTarget('TD', [stack], {
+        stateResources: deployedRepoState(),
+      });
+      expect(r.containers[0]!.image.kind).toBe('public');
+      if (r.containers[0]!.image.kind === 'public') {
+        expect(r.containers[0]!.image.uri).toBe('my-deployed-repo-tail');
+      }
+    });
+
+    it('non-ECR Fn::Join (no Repository refs) falls through to extractImageString public path', () => {
+      const stack = buildStack('S1', {
+        TD: makeTaskDef({
+          image: {
+            'Fn::Join': ['', ['public.ecr.aws/', 'nginx/nginx', ':alpine']],
+          },
+        }),
+      });
+      const r = resolveEcsTaskTarget('TD', [stack]);
+      const img = r.containers[0]!.image;
+      expect(img.kind).toBe('public');
+      if (img.kind === 'public') {
+        expect(img.uri).toBe('public.ecr.aws/nginx/nginx:alpine');
+      }
+    });
+
+    it('existing Fn::Sub 1-arg path still works (no regression)', () => {
+      const stack = buildStack('S1', {
+        MyRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+        TD: makeTaskDef({
+          image: {
+            'Fn::Sub': '${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${MyRepo}:tag',
+          },
+        }),
+      });
+      const r = resolveEcsTaskTarget('TD', [stack], {
+        pseudoParameters: {
+          accountId: '123456789012',
+          region: 'us-east-1',
+          partition: 'aws',
+          urlSuffix: 'amazonaws.com',
+        },
+        stateResources: {
+          MyRepo: {
+            physicalId: 'my-repo-name',
+            resourceType: 'AWS::ECR::Repository',
+            properties: {},
+            attributes: {},
+            dependencies: [],
+          },
+        },
+      });
+      const img = r.containers[0]!.image;
+      expect(img.kind).toBe('ecr');
+      if (img.kind === 'ecr') {
+        expect(img.uri).toBe('123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo-name:tag');
+      }
+    });
+
+    it('Tier 2 needs are detected for the Fn::Join shape', () => {
+      const stack = buildStack('S1', {
+        MyEcrRepo: { Type: 'AWS::ECR::Repository', Properties: {} },
+        TD: makeTaskDef({ image: makeFromEcrRepositoryJoin('MyEcrRepo') }),
+      });
+      const needs = detectEcsImageResolutionNeeds(stack);
+      // URLSuffix triggers Tier 1; Repository Ref + GetAtt trigger Tier 2.
+      expect(needs.needsPseudoParameters).toBe(true);
+      expect(needs.needsStateResources).toBe(true);
+    });
+  });
 });
 
 describe('derivePartitionAndUrlSuffix', () => {


### PR DESCRIPTION
## Summary

Closes #271. `cdkd local run-task --from-state` now resolves `ContainerImage.fromEcrRepository(repo)` images — the canonical CDK 2.x L2 API for ECR-backed ECS task definitions — which previously hit the generic "unparseable Image" error.

## Root cause

CDK 2.x's `ContainerImage.fromEcrRepository(repo, tag)` synthesizes the `Image` field as:

```json
{
  "Fn::Join": ["", [
    {"Fn::Select": [4, {"Fn::Split": [":", {"Fn::GetAtt": ["<RepoLogicalId>", "Arn"]}]}]},
    ".dkr.ecr.",
    {"Fn::Select": [3, {"Fn::Split": [":", {"Fn::GetAtt": ["<RepoLogicalId>", "Arn"]}]}]},
    ".",
    {"Ref": "AWS::URLSuffix"},
    "/",
    {"Ref": "<RepoLogicalId>"},
    ":latest"
  ]]
}
```

PR #267's Tier 2 resolver only knew `Fn::Sub` + direct `Fn::GetAtt` shapes — `Fn::Join` fell through to the catch-all "unparseable Image" error. Issue #271 surfaced this when extending cdk-sample with a real `fromEcrRepository` TaskDef.

## Changes

### `src/local/ecs-task-resolver.ts` (BG #F's commit)

New `tryResolveImageFnJoin` recognizes the canonical CDK 2.x `Fn::Join` shape via:
- A generic recursive walker `resolveImageIntrinsic` / `resolveImageIntrinsicAny` for the tight subset needed for ECR URI construction: `Fn::Join`, `Fn::Select`, `Fn::Split`, `Fn::GetAtt`, `Ref` (incl. `AWS::URLSuffix`), nested `Fn::Sub`.
- Discriminated outcome routing: `resolved` → classify URI (`kind: 'ecr'`), `needs-state` → clear `--from-state` hint, `unsupported-join` → precise shape error, `not-applicable` → fall through to existing public-image path.
- `detectEcsImageResolutionNeeds` + `inspectImageForSubstitutions` extended in lockstep so the CLI's lazy STS / state load fires for the `Fn::Join` shape.

9 new unit tests; full suite 2945/2945 pass.

### `tests/integration/local-run-task-from-state/` (extended this commit)

The PR #274 fixture only tested the L1 / `Fn::Sub` shape. Extended to also test the L2 / `Fn::Join` shape:
- New `NginxTaskDefL2` TaskDef using `ecs.ContainerImage.fromEcrRepository(repo, 'latest')` (L2 API) → emits `Fn::Join` at synth.
- Shares the same `MyRepo` ECR Repository as the existing L1 TaskDef. One deploy + one image push covers both resolver paths.
- Port 18083 (distinct from L1's 18082) so the test boots the L1 task, curls + tears down, then boots the L2 task, curls + tears down — sequentially so they don't fight over the 169.254.170.0/24 subnet.
- `verify.sh` factored into a helper function called twice with different `task_path` / `host_port` / `shape_label`.

## Live-test results

`/run-integ local-run-task-from-state` end-to-end against real AWS:

```
[verify] step 4a: Tier 2 via Fn::Sub shape (L1 CfnTaskDefinition)
  curl http://127.0.0.1:18082/ → HTTP 200
[verify] step 4b: Tier 2 via Fn::Join shape (L2 ContainerImage.fromEcrRepository)
  curl http://127.0.0.1:18083/ → HTTP 200
[verify] All checks passed: --from-state substituted ECR Repository ref in BOTH
        the Fn::Sub and Fn::Join shapes against deployed ECR repository
        cdkdlocalruntaskfromstatefixture-myrepo.

✓ Stack CdkdLocalRunTaskFromStateFixture destroyed (6 deleted, 0 errors)
```

Orphan check post-cleanup: state bucket / ECR / IAM / ECS task defs / Docker containers / Docker networks all empty. `integ-local` + `integ-destroy` markers set.

## Out of scope (matches issue #271)

- Tier 1 ARN-from-physicalId fallback when `attributes.Arn` is missing → chose the cleaner UX of hard-erroring with `--from-state` / `state refresh-observed` guidance.
- Cross-account / cross-region ECR (Tier 3) → same deferral as PRs #267 / #274.
- `ContainerImage.fromEcrRepositoryArn` / other less-common API outputs → out of scope unless they synth to the same canonical shape.

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` / `test` (2945) / `format:check` all pass
- [x] `npx cdk synth` on the fixture emits the expected `Fn::Sub` (NginxTaskDef) + `Fn::Join` (NginxTaskDefL2) shapes
- [x] `bash tests/integration/local-run-task-from-state/verify.sh` end-to-end on real AWS — both HTTP 200, 6 resources destroyed with 0 errors
- [x] `integ-local` + `integ-destroy` markers set after the verified run

## Related

- #271 (this PR's issue)
- PR #267 / #274 (Tier 2 resolver + initial fixture for `Fn::Sub` shape)
- PR #276 (#275 fix — Fn::Sub DAG edge, enabled the initial `Fn::Sub` path to deploy)
- memory `feedback_verify_cdk_synth_shape_before_resolver.md` (synth-shape verification methodology — applied)
