### PR TITLE
fix(hooks): branch-gate doesn't over-trigger on commit/push as literal word (#281)

### DIFF
--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -33,11 +33,35 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || ec
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Only gate git commit / git push — any other command passes through.
-# `[^|;&]*` matches any flag/value pairs between `git` and the
-# subcommand (e.g. `git -C <path> commit`) WITHOUT crossing pipeline
-# separators. `git status; git commit` therefore still matches the
-# second segment via re-positioning.
-if ! printf '%s' "$cmd" | grep -qE '\bgit[^|;&]*\b(commit|push)\b'; then
+# The regex matches `git` + optional global flags (e.g. `-C <path>`,
+# `-c <key>=<value>`, `--no-pager`, `--git-dir=<path>`) + the literal
+# subcommand `commit` or `push`, anchored so that `commit` / `push`
+# must appear in the GIT SUBCOMMAND POSITION — not as a substring of
+# a refspec (`<sha>^{commit}`), a pathspec (`-- '*push*.md'`), or a
+# `--grep=push` query.
+#
+# Anchors:
+#   `\bgit`                   — `git` as a whole word, so `gitlab` /
+#                               `mygit` don't trip the gate. The leading
+#                               `\b` also makes `$(git commit)` and
+#                               `` `git commit` `` match because the
+#                               opening `(` / backtick is a non-word
+#                               boundary.
+#   `([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*`
+#                             — zero or more "flag tokens": each flag
+#                               (`-X` or `--foo[=val]`) optionally
+#                               followed by a separate non-flag value
+#                               token (covers `-C <path>` /
+#                               `-c <key>=<val>`).
+#   `[[:space:]]+(commit|push)` — the subcommand position.
+#   `([[:space:]]|$|[|;&`)])` — must end at a token boundary so
+#                               `commit.gpgSign=false` (a `-c` value)
+#                               is NOT counted as the subcommand;
+#                               also recognizes pipeline / subshell
+#                               separators so `$(git commit)`,
+#                               `git status; git commit`,
+#                               `` `git push` `` all match.
+if ! printf '%s' "$cmd" | grep -qE '\bgit([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+(commit|push)([[:space:]]|$|[|;&`)])'; then
   exit 0
 fi
 

--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -80,6 +80,51 @@ run_case "cd <feature> && git commit from main-cwd allowed" 0 \
 run_case "non-git target dir allowed (silent pass)" 0 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m wip"}}' "$TMPDIR")"
 
+# --- ALLOW cases for read-only `git` commands that contain the literal
+# words `commit` / `push` in args or refspecs (issue #281).
+#
+# Pre-fix the regex `\bgit[^|;&]*\b(commit|push)\b` matched any git
+# invocation that mentioned `commit` / `push` anywhere on the line —
+# blocking legitimate read-only ops like `git rev-parse <sha>^{commit}`
+# even on `main`. The tightened regex requires `commit` / `push` to
+# appear in the GIT SUBCOMMAND POSITION.
+
+# 7a. `git rev-parse <sha>^{commit}` — `^{commit}` is git's peel-to-commit
+#     syntax, NOT the commit subcommand. Must pass-through even on main.
+run_case "git rev-parse <sha>^{commit} on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git rev-parse abc123^{commit}"}}' "$main_repo")"
+
+# 7b. `git cat-file -e <sha>^{commit}` — same peel-to-commit; this is the
+#     exact repro from the issue body.
+run_case "git cat-file -e <sha>^{commit} on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git cat-file -e abc^{commit}"}}' "$main_repo")"
+
+# 7c. `git log --grep=commit` — `commit` is a literal in a search query,
+#     not the subcommand.
+run_case "git log --grep=commit on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git log --grep=commit"}}' "$main_repo")"
+
+# 7d. `git log --grep=push` — same shape for the `push` keyword.
+run_case "git log --grep=push on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git log --grep=push"}}' "$main_repo")"
+
+# 7e. `git diff <range> -- '*push*.md'` — `push` is part of a pathspec.
+run_case "git diff with push pathspec on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git diff abc def -- '\''*push*.md'\''"}}' "$main_repo")"
+
+# 7f. `git diff <range> -- '*commit*.md'` — same shape for `commit`.
+run_case "git diff with commit pathspec on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git diff abc def -- '\''*commit*.md'\''"}}' "$main_repo")"
+
+# 7g. `git rev-list HEAD..main --oneline | head -5` — read-only revlist
+#     that pipes into another command; no commit/push subcommand.
+run_case "git rev-list piped on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git rev-list HEAD..main --oneline | head -5"}}' "$main_repo")"
+
+# 7h. `git symbolic-ref HEAD` — pure read; trivially shouldn't trigger.
+run_case "git symbolic-ref HEAD on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git symbolic-ref HEAD"}}' "$main_repo")"
+
 # --- BLOCK cases ---
 
 # 7. Plain git commit when cwd is on main.
@@ -103,6 +148,17 @@ run_case "git -C <main> commit blocked" 2 \
 # 11. Last `git -C` wins: -C feature first, -C main second.
 run_case "last git -C wins (main last → blocked)" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git -C %s status; git -C %s commit -m oops"}}' "$feature_repo" "$feature_repo" "$main_repo")"
+
+# 11b. `git -c <key>=<val> commit` — global `-c` flag before commit
+#      subcommand. The tightened regex must not get confused by the
+#      `<key>=<val>` token (which can contain the literal substring
+#      `commit`, e.g. `commit.gpgSign=false`).
+run_case "git -c commit.gpgSign=false commit on main blocked" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git -c commit.gpgSign=false commit -m oops"}}' "$main_repo")"
+
+# 11c. `git push --force` on main — `--force` after the subcommand.
+run_case "git push --force on main blocked" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git push origin --force"}}' "$main_repo")"
 
 # --- Edge cases ---
 


### PR DESCRIPTION
## Summary

Closes #281. Tightens `.claude/hooks/branch-gate.sh`'s regex so it no longer over-triggers on commands containing `commit` / `push` as a literal word elsewhere than the git subcommand position.

## The bug

The old regex `\bgit[^|;&]*\b(commit|push)\b` matched any git invocation where `commit` / `push` appeared anywhere between `git` and the next pipeline separator. This included:

- `git rev-parse <sha>^{commit}` — `^{commit}` is git's "peel to commit object" syntax
- `git cat-file -e <sha>^{commit}` — same
- `git log --grep=commit` — search query
- `git diff abc def -- '*push*.md'` — pathspec
- `git -c commit.gpgSign=false ...` — config key containing `commit`

All read-only operations, but blocked on `main` because the regex saw `commit` / `push` as words.

Surfaced during the session-end audit (issue #281) when running `git cat-file -e <sha>^{commit}` to validate orphan-detection — the hook blocked it.

## Fix

New regex matches `commit` / `push` as the **subcommand position** specifically:

```
\bgit([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+(commit|push)([[:space:]]|$|[|;&`)])
```

Structure: `git` + zero-or-more `<flag>[ <non-flag-value>]` tokens (handles `-C <path>` / `-c <key>=<val>` / `--no-pager` / `--git-dir=<path>`) + space + literal `commit`/`push` + a token boundary (whitespace / end / pipeline / sub-shell separator).

The closing-boundary set includes `` ` `` and `)` so `$(git commit)` and `` `git push` `` still block while `commit.gpgSign=false` as a config value is correctly rejected as not-the-subcommand.

## Test plan

- [x] Smoke test `.claude/hooks/branch-gate.test.sh` — 13 → 23 cases (10 new). All 23 pass.
- [x] `pnpm run typecheck` / `lint` / `build` / `test` (2945) / `format:check` pass

10 new test cases:
- 8 new pass-through: refspec `^{commit}`, `--grep=commit/push`, pathspec `'*commit*.md'` / `'*push*.md'`, piped revlist, `symbolic-ref`
- 2 new block: `-c commit.gpgSign=false commit` (verifies the regex doesn't get confused by a config key containing `commit`), `push --force`

## Related

- #281 (this PR's issue)
- `.claude/hooks/branch-gate.sh` (the affected hook)
- Other narrow-regex hooks (`commit-msg-heredoc-gate`, `pr-body-item-number-gate`, etc.) were spot-checked and don't have the same over-trigger shape — out of scope per "one issue per session".
