### PR TITLE
fix(local): close PR #267 minor latent items — topoSort / state-loader globalClients / test wording (#269)

### DIFF
--- a/src/cli/commands/local-state-loader.ts
+++ b/src/cli/commands/local-state-loader.ts
@@ -13,7 +13,7 @@
  */
 
 import { getLogger } from '../../utils/logger.js';
-import { AwsClients, setAwsClients } from '../../utils/aws-clients.js';
+import { AwsClients, resetAwsClients, setAwsClients } from '../../utils/aws-clients.js';
 import { S3StateBackend } from '../../state/s3-state-backend.js';
 import { resolveStateBucketWithDefault } from '../config-loader.js';
 import type { StackState } from '../../types/state.js';
@@ -114,6 +114,10 @@ export async function loadStateForStack(
     logger.debug(`${prefix}: loaded state for ${stackName} (${targetRegion})`);
     return { state: stateData.state, region: targetRegion };
   } finally {
-    awsClients.destroy();
+    // `resetAwsClients()` destroys the underlying clients AND clears the
+    // module-global `globalClients` reference. Bare `awsClients.destroy()`
+    // would leave a destroyed instance pointed at by the global, which a
+    // later caller of `getAwsClients()` would silently reuse.
+    resetAwsClients();
   }
 }

--- a/src/local/ecs-task-runner.ts
+++ b/src/local/ecs-task-runner.ts
@@ -332,19 +332,47 @@ export function buildDependencyGraph(containers: ResolvedEcsContainer[]): graphl
 }
 
 export function topoSort(g: graphlib.Graph, containers: ResolvedEcsContainer[]): string[] {
-  // graphlib.alg.topsort returns roots LAST given our edge direction; we
-  // need dependencies (B) first, so we reverse. Fall back to template
-  // order on a tie (preserves the user's intent for siblings with no
-  // dependsOn relation).
-  const sorted = graphlib.alg.topsort(g);
+  // Layered topological sort with template-order tiebreak. Each node's
+  // depth = max(depth of nodes it depends on) + 1; nodes with no
+  // dependencies are at depth 0. Sorting by (depth, templateIndex)
+  // guarantees dependencies are listed before dependents (valid topo
+  // order) AND that siblings at the same depth follow the user's
+  // template order. The pre-fix double-sort (`topsort.reverse().sort()`)
+  // re-ranked globally by template index and could violate topo order
+  // when an adversarial template listed a dependent BEFORE its
+  // dependency.
+  //
+  // Edges point dependent -> dependency; a node's depth is one more
+  // than the max depth of any node it points to. Cycles are rejected up
+  // front in `buildDependencyGraph`, so memoized recursion terminates.
+  const depth = new Map<string, number>();
+  const computeDepth = (name: string): number => {
+    const cached = depth.get(name);
+    if (cached !== undefined) return cached;
+    let max = -1;
+    const successors = g.successors(name) ?? [];
+    for (const s of successors) {
+      const d = computeDepth(s);
+      if (d > max) max = d;
+    }
+    const result = max + 1;
+    depth.set(name, result);
+    return result;
+  };
+  for (const node of g.nodes()) computeDepth(node);
+
   const byPosition = new Map<string, number>();
   containers.forEach((c, idx) => byPosition.set(c.name, idx));
-  return [...sorted].reverse().sort((a, b) => {
-    // Sort within the topological order is deliberately stable; we use
-    // template position as the secondary key. graphlib's algorithm
-    // already produced a valid topological order; we only re-rank ties.
-    return (byPosition.get(a) ?? 0) - (byPosition.get(b) ?? 0);
-  });
+
+  return containers
+    .map((c) => c.name)
+    .filter((n) => depth.has(n))
+    .sort((a, b) => {
+      const da = depth.get(a)!;
+      const db = depth.get(b)!;
+      if (da !== db) return da - db;
+      return (byPosition.get(a) ?? 0) - (byPosition.get(b) ?? 0);
+    });
 }
 
 /**

--- a/tests/unit/cli/local-state-loader.test.ts
+++ b/tests/unit/cli/local-state-loader.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted mocks so vi.mock factories can reference them safely.
+// (See feedback_vi_mock_hoisting.md.)
+const mocks = vi.hoisted(() => ({
+  resolveStateBucketWithDefaultMock: vi.fn(),
+  verifyBucketExistsMock: vi.fn(),
+  listStacksMock: vi.fn(),
+  getStateMock: vi.fn(),
+}));
+
+vi.mock('../../../src/cli/config-loader.js', () => ({
+  resolveStateBucketWithDefault: mocks.resolveStateBucketWithDefaultMock,
+}));
+
+vi.mock('../../../src/state/s3-state-backend.js', () => ({
+  S3StateBackend: vi.fn().mockImplementation(() => ({
+    verifyBucketExists: mocks.verifyBucketExistsMock,
+    listStacks: mocks.listStacksMock,
+    getState: mocks.getStateMock,
+  })),
+}));
+
+import { loadStateForStack } from '../../../src/cli/commands/local-state-loader.js';
+import { getAwsClients, resetAwsClients } from '../../../src/utils/aws-clients.js';
+
+describe('loadStateForStack — globalClients lifecycle', () => {
+  beforeEach(() => {
+    resetAwsClients();
+    mocks.resolveStateBucketWithDefaultMock.mockReset();
+    mocks.verifyBucketExistsMock.mockReset();
+    mocks.listStacksMock.mockReset();
+    mocks.getStateMock.mockReset();
+  });
+
+  afterEach(() => {
+    resetAwsClients();
+  });
+
+  it('resets globalClients after a successful load so no destroyed reference leaks', async () => {
+    mocks.resolveStateBucketWithDefaultMock.mockResolvedValue('test-bucket');
+    mocks.verifyBucketExistsMock.mockResolvedValue(undefined);
+    mocks.listStacksMock.mockResolvedValue([{ stackName: 'MyStack', region: 'us-east-1' }]);
+    mocks.getStateMock.mockResolvedValue({
+      state: { stackName: 'MyStack', resources: {} },
+      etag: 'abc',
+    });
+
+    const result = await loadStateForStack('MyStack', 'us-east-1', {
+      statePrefix: 'cdkd',
+      region: 'us-east-1',
+    });
+
+    expect(result?.region).toBe('us-east-1');
+    // After loadStateForStack returns, globalClients must be null —
+    // getAwsClients() should construct a fresh instance, not return the
+    // destroyed one set inside the helper.
+    const fresh = getAwsClients();
+    const fresh2 = getAwsClients();
+    expect(fresh).toBe(fresh2); // same fresh instance returned twice
+    // Sanity-check the fresh instance is usable (no thrown "client destroyed").
+    expect(() => fresh.s3).not.toThrow();
+  });
+
+  it('resets globalClients after a bucket-resolution failure (warn-and-fall-back path)', async () => {
+    mocks.resolveStateBucketWithDefaultMock.mockRejectedValue(new Error('bucket lookup failed'));
+
+    const result = await loadStateForStack('MyStack', 'us-east-1', {
+      statePrefix: 'cdkd',
+      region: 'us-east-1',
+    });
+
+    expect(result).toBeUndefined();
+    // No AwsClients was constructed on the early-return path; the global
+    // should still be null and a subsequent getAwsClients() call must
+    // produce a fresh instance.
+    const fresh = getAwsClients();
+    expect(() => fresh.s3).not.toThrow();
+  });
+
+  it('resets globalClients after a mid-flow error (e.g. verifyBucketExists rejects)', async () => {
+    mocks.resolveStateBucketWithDefaultMock.mockResolvedValue('test-bucket');
+    mocks.verifyBucketExistsMock.mockRejectedValue(new Error('access denied'));
+
+    await expect(
+      loadStateForStack('MyStack', 'us-east-1', {
+        statePrefix: 'cdkd',
+        region: 'us-east-1',
+      })
+    ).rejects.toThrow('access denied');
+
+    // Even on a thrown error, the finally must reset the global.
+    const fresh = getAwsClients();
+    expect(() => fresh.s3).not.toThrow();
+  });
+});

--- a/tests/unit/local/ecs-task-runner-runner.test.ts
+++ b/tests/unit/local/ecs-task-runner-runner.test.ts
@@ -623,7 +623,7 @@ describe('runEcsTask — exit propagation + essential selection (G1)', () => {
     expect(r.essentialContainerName).toBe('svc');
   });
 
-  it('when no container is explicitly essential, the first container is used as essential', async () => {
+  it('when every container has essential: false, the first container drives the result (find ?? fallback)', async () => {
     let seq = 0;
     captured.responder = (_cmd: string, args: string[]) => {
       if (args[0] === 'run') return { stdout: `c${++seq}\n` };

--- a/tests/unit/local/ecs-task-runner.test.ts
+++ b/tests/unit/local/ecs-task-runner.test.ts
@@ -400,4 +400,25 @@ describe('topoSort (G3)', () => {
     });
     expect(() => buildDependencyGraph([a, b])).toThrow(EcsTaskRunnerError);
   });
+
+  it('adversarial template order [C, B, A] with C->B->A still yields a valid topo order', () => {
+    // Template lists dependent BEFORE its dependency. CDK-synthesized
+    // output never does this, but hand-written CFn or future CDK
+    // customizations could. The pre-fix double-sort re-ranked globally
+    // by template index and produced [C, B, A] — violating the
+    // dependsOn contract (C would start before A had even launched).
+    const A = makeContainer({ name: 'A' });
+    const B = makeContainer({
+      name: 'B',
+      dependsOn: [{ containerName: 'A', condition: 'START' }],
+    });
+    const C = makeContainer({
+      name: 'C',
+      dependsOn: [{ containerName: 'B', condition: 'START' }],
+    });
+    const containers = [C, B, A];
+    const g = buildDependencyGraph(containers);
+    const order = topoSort(g, containers);
+    expect(order).toEqual(['A', 'B', 'C']);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #269. Three minor latent items found by PR #267's retroactive review.

## Changes

### (a) `topoSort` — replace double-sort with layered Kahn

`src/local/ecs-task-runner.ts:topoSort` used `[...nodes].reverse().sort((a,b) => byPosition(a) - byPosition(b))` — the final global `.sort()` re-ranked everything by template index, violating topological order on adversarial input (template lists a dependent BEFORE its dependency).

Replaced with a layered Kahn-style sort: per-node depth = `max(depth of successors) + 1`, then sort by `(depth, templateIndex)`. Dependencies always precede dependents; siblings at the same depth preserve template order.

New unit test in `tests/unit/local/ecs-task-runner.test.ts` for adversarial input: `[C, B, A]` with `C → B → A` deps now yields `[A, B, C]` (previously `[C, B, A]`).

### (b) `loadStateForStack` — reset `globalClients` in finally

`src/cli/commands/local-state-loader.ts:loadStateForStack` called `setAwsClients(...)` then `awsClients.destroy()` in `finally` without clearing the module-global. Latent — no current downstream reader of `globalClients` after this helper returns — but a real foot-gun for any future caller.

Fixed by replacing `awsClients.destroy()` with `resetAwsClients()` (destroys underlying clients AND clears the global).

**Wider applicability check**: audited every other `setAwsClients` + `awsClients.destroy()` call site (drift / deploy / destroy / diff / import / export / state / orphan / bootstrap / force-unlock / state-migrate / destroy-runner — 12 sites). All are **command entry points** where the process exits immediately after the `finally` block, so the stale-global leak is structural rather than practical. Only `local-state-loader.ts` is a **helper called mid-command**, so it's the only site where `resetAwsClients()` is load-bearing.

New unit test file `tests/unit/cli/local-state-loader.test.ts` (3 tests) covers globalClients reset on success / bucket-resolution failure / mid-flow throw.

### (c) Test description wording

`tests/unit/local/ecs-task-runner-runner.test.ts` had a test described as "no container is explicitly essential" but the body set both containers to `essential: false` explicitly. Renamed to "every container has essential: false (first-container fallback)" to match what the test actually exercises.

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` / `test` (2949, +4 from 2945) / `format:check` pass

## Merge gate

This PR touches `src/local/ecs-task-runner.ts` which is in `integ-local` markgate scope. Marker will need re-set by `/run-integ local-run-task-from-state` before merge.

## Related

- #269 (this PR's issue)
- PR #267 (the source of the latent items)
- memory `feedback_polish_in_same_pr.md` (3 items bundled, all closing one issue)
