### PR TITLE
docs(readme): refresh title + tagline for clearer one-line value prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# cdkd
+# cdkd (CDK Direct)
 
-**cdkd** (CDK Direct) — a from-scratch CDK CLI that provisions via AWS SDK instead of CloudFormation.
+Drop-in CDK CLI for existing CDK apps — faster deploys via AWS SDK instead of CloudFormation, with local emulation for Lambda, API Gateway, and ECS.
 
 - **Drop-in CDK compatible** — your existing CDK app code runs as-is.
 - **Up to 15x faster deploys than the AWS CDK CLI (CloudFormation)**


### PR DESCRIPTION
## Summary

Refresh the README's H1 + tagline so the project's value prop reads in a single self-contained sentence, aligned with the GitHub About string.

- **H1**: `# cdkd` → `# cdkd (CDK Direct)`. The abbreviation expansion is now visible on first scroll instead of being relegated to the bold re-introduction below.
- **Tagline**: replaces the prior `**cdkd** (CDK Direct) — a from-scratch CDK CLI that provisions via AWS SDK instead of CloudFormation.` with a single em-dash sentence that surfaces three concrete value props:
  1. drop-in compatibility with existing CDK apps,
  2. faster deploys via AWS SDK instead of CloudFormation,
  3. local emulation for Lambda, API Gateway, and ECS.
- Removes the redundant `**cdkd** (CDK Direct) —` bold re-introduction sitting right under the H1.

The bullet list below the tagline (`Drop-in CDK compatible`, `Up to 15x faster deploys`, `Run AWS resources locally without deploying`) is retained as the detail-expansion of the new one-liner. No content changes anywhere else.

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` all pass
- [x] `npx vitest --run` — 268 files / 3127 tests pass
- [x] No stale references to the prior tagline wording (`grep "a from-scratch CDK CLI that provisions via AWS SDK"` returns no matches)
- [x] Tagline self-consistency: each of the three value props in the new tagline maps 1:1 to one of the three bullets immediately below it
