### PR TITLE
chore: gitignore worktree-local scratch files used by sub-agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,18 @@ tests/benchmark/results-*.md
 # verified; bound to the `pr-review` markgate gate's include scope so a
 # new push to the PR invalidates the marker automatically)
 .markgate-pr-review-sha
+
+# Worktree-local scratch files used by sub-agents for `git commit -F` /
+# `gh --body-file` / `gh api --field body=@<file>` payloads. The
+# `feedback_parallel_agent_tmp_paths.md` memory rule directs sub-agents
+# to use worktree-local files (NOT /tmp/...) to avoid collisions with
+# parallel sub-agents sharing /tmp. Without these patterns the files
+# stay untracked — but a sub-agent's `git add -A` / `git add .` in its
+# commit workflow stages them too, leading to follow-up "remove scratch
+# files" commits (surfaced across PRs #297 / #304 / #305).
+.commit-msg*.txt
+.commit-msg*.md
+.pr-body*.md
+.pr-body*.txt
+.gh-body*.md
+.gh-body*.txt


### PR DESCRIPTION
## Summary

Add `.gitignore` patterns for worktree-local scratch files used by sub-agents (`.commit-msg*.{txt,md}`, `.pr-body*.{md,txt}`, `.gh-body*.{md,txt}`).

## Why

Sub-agents using `git commit -F <file>` / `gh --body-file <file>` / `gh api --field body=@<file>` need a scratch file for the message body. Per the `feedback_parallel_agent_tmp_paths.md` memory rule they write the file to a worktree-local path (NOT `/tmp/...`) so parallel agents sharing /tmp don't collide.

**Follow-on trap**: when the sub-agent's commit workflow uses `git add -A` or `git add .`, the scratch file gets staged AND committed alongside the real diff. Surfaced across PRs #297 / #304 / #305 — each required a follow-up `chore: remove worktree-local scratch files accidentally committed` commit. PR #305 also tripped the internal-pr-labels-gate hook because the prose mentioned PRs.

## Defense

Two complementary layers:

1. **Mechanical (this PR)** — gitignore the common name shapes so `git add -A` / `git add .` skips them by default.
2. **Process** — the matching memory rule `feedback_subagent_scratch_files_committed.md` directs future sub-agent dispatches to (a) use one of the gitignored names, and (b) `rm -f <file>` after the commit / PR-create call returns. The mechanical defense is the load-bearing one — prompt discipline alone has failed 3 times in a row.

## Test plan

- [x] `git check-ignore -v` returns the expected `.gitignore` line for `.commit-msg.txt`, `.commit-msg-fix.txt`, `.pr-body.md`, `.pr-body-296.md`, `.gh-body.txt`.
- [x] `touch <file> && git status --short` shows NO entries for any of the five names.
- [x] `pnpm run typecheck` / `pnpm run lint` / `pnpm run build` / `npx vitest --run` (3156 tests pass) — no code changed but verified clean.

## Out of scope

- A pre-commit hook that blocks staging any of these names — overkill; the gitignore + memory rule combination already handles the common case mechanically, and a hook would just add noise for users who legitimately have files matching these names (uncommon but possible).
- Renaming the sub-agent dispatch templates to use a different naming convention — the current names are intuitive and already documented.
