### PR TITLE
fix(deploy): prefix-migration check false-positive on auto-generated names

### DIFF
--- a/src/cli/commands/prefix-migration-check.ts
+++ b/src/cli/commands/prefix-migration-check.ts
@@ -1,6 +1,9 @@
 import * as readline from 'node:readline/promises';
 import { getLogger } from '../../utils/logger.js';
-import { PATTERN_B_RESOURCE_TYPES } from '../../provisioning/resource-name.js';
+import {
+  PATTERN_B_NAME_PROPERTIES,
+  PATTERN_B_RESOURCE_TYPES,
+} from '../../provisioning/resource-name.js';
 import type { StackState } from '../../types/state.js';
 
 /**
@@ -21,11 +24,32 @@ export interface PendingRename {
 
 /**
  * Inspect `state` and return the list of Pattern B resources whose
- * `physicalId` starts with `${stackName}-` (= the legacy prefixed
- * name). These are the resources `cdkd deploy --no-prefix-user-supplied-names`
- * will silently propose for REPLACEMENT, because the new template
- * intent is the unprefixed name. The caller surfaces them to the user
+ * `physicalId` starts with `${stackName}-` AND was originally given a
+ * user-supplied physical name (state's recorded `properties[<NameField>]`
+ * is set). These are the resources whose next deploy under the v0.94.0
+ * default would silently propose REPLACEMENT, because the new template
+ * intent is the unprefixed user-supplied name. The caller surfaces them
  * via {@link promptMigrationConfirm} before any provider call runs.
+ *
+ * **Why the user-supplied gate** (load-bearing): Pattern B types accept
+ * BOTH user-supplied names (`new iam.Role(this, 'X', { roleName: 'foo' })`)
+ * AND auto-generated logical-id-fallback names (`new iam.Role(this, 'X')`).
+ * Pre-v0.94 the prefix was applied to BOTH. Post-v0.94 the prefix is
+ * applied only to the auto-generated path; user-supplied names are taken
+ * verbatim. So:
+ *
+ *   - User-supplied name in pre-v0.94 state (`Properties.RoleName: 'foo'`,
+ *     physicalId `MyStack-foo`) → next deploy computes `foo` →
+ *     REPLACE pending. Flag.
+ *   - Auto-generated name in pre-v0.94 state (no `Properties.RoleName`,
+ *     physicalId `MyStack-MyConstructRoleF44D44CF`) → next deploy
+ *     STILL computes `MyStack-MyConstructRoleF44D44CF` (`userSupplied:
+ *     false` keeps the prefix regardless of the v0.94.0 default flip).
+ *     NO REPLACE pending. Do NOT flag.
+ *
+ * The naive prefix-startsWith check (without the user-supplied gate)
+ * surfaces a false-positive WARNING on every auto-generated name in
+ * every pre-v0.94 stack. Closes that bug.
  *
  * Pattern A resources are intentionally NOT considered — they never got
  * the prefix on a user-supplied name to begin with, so the flag is a
@@ -33,8 +57,10 @@ export interface PendingRename {
  *
  * Returns an empty array when state is `undefined` (first-time deploy
  * with no existing state — nothing to migrate), when no resource is of
- * a Pattern B type, or when every Pattern B resource is already
- * unprefixed (e.g. the stack was originally deployed with the flag on).
+ * a Pattern B type, when every Pattern B resource is already unprefixed
+ * (e.g. the stack was originally deployed with the flag on), OR when
+ * every prefix-style Pattern B resource is auto-generated (the common
+ * case for stacks that never opted into user-supplied names).
  */
 export function findPendingPrefixRenames(
   stackName: string,
@@ -50,6 +76,17 @@ export function findPendingPrefixRenames(
     if (!patternB.has(resource.resourceType)) continue;
     if (typeof resource.physicalId !== 'string') continue;
     if (!resource.physicalId.startsWith(prefix)) continue;
+
+    // Gate on user-supplied. The deploy engine only drops the prefix
+    // for resources whose name property was explicitly set in CDK
+    // code. State records this as `properties[<NameField>]`. Empty
+    // string or undefined means the resource went through the
+    // logical-id fallback path — prefix kept regardless of the
+    // v0.94.0 default flip — no REPLACE pending.
+    const nameProperty = PATTERN_B_NAME_PROPERTIES[resource.resourceType];
+    if (!nameProperty) continue; // defensive: should be set for every Pattern B type
+    const userSuppliedName = resource.properties?.[nameProperty];
+    if (typeof userSuppliedName !== 'string' || userSuppliedName === '') continue;
 
     const newPhysicalId = resource.physicalId.slice(prefix.length);
     // Edge case: physicalId is exactly `${stackName}-` (= empty

--- a/src/provisioning/resource-name.ts
+++ b/src/provisioning/resource-name.ts
@@ -126,6 +126,33 @@ export const PATTERN_B_RESOURCE_TYPES: readonly string[] = [
 ] as const;
 
 /**
+ * For each Pattern B resource type, the CFn template `Properties` field
+ * the user sets to supply a physical name (`new iam.Role(this, 'X',
+ * { roleName: 'my-role' })` → `Properties.RoleName: 'my-role'`).
+ *
+ * Used by the prefix-migration check to distinguish user-supplied
+ * physical names (which the v0.94.0 default flip would actually
+ * REPLACE on next deploy) from auto-generated logical-id-fallback
+ * names (which keep the prefix in BOTH old and new default — no
+ * REPLACE pending). Without this discriminator, the migration
+ * check naively flags every prefix-style physicalId regardless of
+ * its origin, surfacing a false-positive WARNING on auto-generated
+ * names that won't actually be touched.
+ *
+ * Keep in sync with `PATTERN_B_RESOURCE_TYPES` and with each
+ * provider's `Properties[<NameField>]` lookup in
+ * `src/provisioning/providers/`.
+ */
+export const PATTERN_B_NAME_PROPERTIES: Readonly<Record<string, string>> = {
+  'AWS::IAM::Role': 'RoleName',
+  'AWS::IAM::User': 'UserName',
+  'AWS::IAM::Group': 'GroupName',
+  'AWS::IAM::InstanceProfile': 'InstanceProfileName',
+  'AWS::ElasticLoadBalancingV2::LoadBalancer': 'Name',
+  'AWS::ElasticLoadBalancingV2::TargetGroup': 'Name',
+};
+
+/**
  * Options for generating a resource name.
  */
 export interface ResourceNameOptions {

--- a/tests/unit/cli/prefix-migration-check.test.ts
+++ b/tests/unit/cli/prefix-migration-check.test.ts
@@ -15,11 +15,50 @@ vi.mock('node:readline/promises', () => {
 
 import * as readline from 'node:readline/promises';
 
-function makeResource(physicalId: string, resourceType: string): ResourceState {
+/**
+ * Per-Pattern-B-type CFn property that the user sets to supply a name.
+ * Mirrors `PATTERN_B_NAME_PROPERTIES` in `src/provisioning/resource-name.ts`.
+ * Used by `makeResource` to populate state's `properties[<NameField>]`
+ * when a test scenario wants to simulate a user-supplied name.
+ */
+const NAME_PROPS: Record<string, string> = {
+  'AWS::IAM::Role': 'RoleName',
+  'AWS::IAM::User': 'UserName',
+  'AWS::IAM::Group': 'GroupName',
+  'AWS::IAM::InstanceProfile': 'InstanceProfileName',
+  'AWS::ElasticLoadBalancingV2::LoadBalancer': 'Name',
+  'AWS::ElasticLoadBalancingV2::TargetGroup': 'Name',
+};
+
+function makeResource(
+  physicalId: string,
+  resourceType: string,
+  options: {
+    /**
+     * The user-supplied physical name recorded in state's
+     * `properties[<NameField>]`. Set this when the test scenario
+     * simulates a Pattern B resource the user explicitly named via
+     * `new iam.Role(this, 'X', { roleName: 'foo' })`. Leave undefined
+     * (default) to simulate an auto-generated logical-id-fallback name
+     * — `findPendingPrefixRenames` MUST skip those (no REPLACE pending
+     * even when physicalId carries the legacy prefix, because the
+     * deploy engine's `userSupplied: false` path keeps the prefix
+     * regardless of the v0.94.0 default flip).
+     */
+    userSuppliedName?: string;
+  } = {}
+): ResourceState {
+  const properties: Record<string, unknown> = {};
+  if (options.userSuppliedName !== undefined) {
+    const nameProp = NAME_PROPS[resourceType];
+    if (nameProp) {
+      properties[nameProp] = options.userSuppliedName;
+    }
+  }
   return {
     physicalId,
     resourceType,
-    properties: {},
+    properties,
     attributes: {},
     dependencies: [],
   };
@@ -69,10 +108,12 @@ describe('findPendingPrefixRenames', () => {
 
   it('flags only the prefixed Pattern B resources when mixed with Pattern A and unprefixed Pattern B', () => {
     const state = makeState({
-      // Pattern B, prefixed — should flag
-      RoleA: makeResource('MyStack-role-a', 'AWS::IAM::Role'),
+      // Pattern B, prefixed, user-supplied — should flag
+      RoleA: makeResource('MyStack-role-a', 'AWS::IAM::Role', {
+        userSuppliedName: 'role-a',
+      }),
       // Pattern B, unprefixed — should pass through
-      RoleB: makeResource('role-b', 'AWS::IAM::Role'),
+      RoleB: makeResource('role-b', 'AWS::IAM::Role', { userSuppliedName: 'role-b' }),
       // Pattern A, prefixed (the prefix is real but the flag doesn't affect Pattern A) — must NOT flag
       Bucket: makeResource('MyStack-bucket', 'AWS::S3::Bucket'),
       // Pattern A, unprefixed
@@ -91,12 +132,18 @@ describe('findPendingPrefixRenames', () => {
 
   it('covers every Pattern B type', () => {
     const state = makeState({
-      Role: makeResource('MyStack-r', 'AWS::IAM::Role'),
-      User: makeResource('MyStack-u', 'AWS::IAM::User'),
-      Group: makeResource('MyStack-g', 'AWS::IAM::Group'),
-      Profile: makeResource('MyStack-p', 'AWS::IAM::InstanceProfile'),
-      Lb: makeResource('MyStack-lb', 'AWS::ElasticLoadBalancingV2::LoadBalancer'),
-      Tg: makeResource('MyStack-tg', 'AWS::ElasticLoadBalancingV2::TargetGroup'),
+      Role: makeResource('MyStack-r', 'AWS::IAM::Role', { userSuppliedName: 'r' }),
+      User: makeResource('MyStack-u', 'AWS::IAM::User', { userSuppliedName: 'u' }),
+      Group: makeResource('MyStack-g', 'AWS::IAM::Group', { userSuppliedName: 'g' }),
+      Profile: makeResource('MyStack-p', 'AWS::IAM::InstanceProfile', {
+        userSuppliedName: 'p',
+      }),
+      Lb: makeResource('MyStack-lb', 'AWS::ElasticLoadBalancingV2::LoadBalancer', {
+        userSuppliedName: 'lb',
+      }),
+      Tg: makeResource('MyStack-tg', 'AWS::ElasticLoadBalancingV2::TargetGroup', {
+        userSuppliedName: 'tg',
+      }),
     });
     const pending = findPendingPrefixRenames('MyStack', state);
     expect(pending).toHaveLength(6);
@@ -115,7 +162,9 @@ describe('findPendingPrefixRenames', () => {
     // which should always match state.stackName, but the helper relies
     // on the argument so a mismatch is caught at the source.
     const state = makeState({
-      Role: makeResource('OtherStack-role-a', 'AWS::IAM::Role'),
+      Role: makeResource('OtherStack-role-a', 'AWS::IAM::Role', {
+        userSuppliedName: 'role-a',
+      }),
     });
     expect(findPendingPrefixRenames('MyStack', state)).toEqual([]);
     expect(findPendingPrefixRenames('OtherStack', state)).toEqual([
@@ -126,6 +175,56 @@ describe('findPendingPrefixRenames', () => {
         newPhysicalId: 'role-a',
       },
     ]);
+  });
+
+  it('does NOT flag auto-generated names (false-positive regression for #310-class bug)', () => {
+    // Pre-v0.94 the prefix was applied to BOTH user-supplied AND
+    // auto-generated names (`new iam.Role(this, 'X')` without `roleName`
+    // → state physicalId `MyStack-MyConstructRoleF44D44CF`). Post-v0.94
+    // the prefix is applied ONLY to the auto-generated path; user-
+    // supplied names are taken verbatim. So an auto-generated name
+    // STILL has the same prefix under the new default — no REPLACE
+    // pending. Surfacing a WARNING for these is a false positive that
+    // bit real users on every pre-v0.94 stack.
+    //
+    // The discriminator is `state.properties[<NameField>]`: present →
+    // user-supplied → flag; absent → auto-generated → skip.
+    const state = makeState({
+      // Auto-generated (no RoleName in properties). MUST NOT flag.
+      AutoRole: makeResource(
+        'MyStack-MyConstructRoleF44D44CF',
+        'AWS::IAM::Role'
+        // no userSuppliedName option → properties.RoleName stays unset
+      ),
+      // User-supplied. MUST flag.
+      UserRole: makeResource('MyStack-my-role', 'AWS::IAM::Role', {
+        userSuppliedName: 'my-role',
+      }),
+      // Auto-generated LB. MUST NOT flag.
+      AutoLb: makeResource('MyStack-AutoLb', 'AWS::ElasticLoadBalancingV2::LoadBalancer'),
+    });
+    const pending = findPendingPrefixRenames('MyStack', state);
+    expect(pending).toEqual([
+      {
+        logicalId: 'UserRole',
+        resourceType: 'AWS::IAM::Role',
+        oldPhysicalId: 'MyStack-my-role',
+        newPhysicalId: 'my-role',
+      },
+    ]);
+  });
+
+  it('does NOT flag a Pattern B resource whose name property is the empty string', () => {
+    // Defensive: an empty-string name is functionally equivalent to
+    // unset — the deploy engine's `generateResourceNameWithFallback`
+    // treats `''` as "no user-supplied value" and falls through to
+    // the logical-id path. The migration check must match.
+    const state = makeState({
+      Role: makeResource('MyStack-MyConstructRoleX', 'AWS::IAM::Role', {
+        userSuppliedName: '',
+      }),
+    });
+    expect(findPendingPrefixRenames('MyStack', state)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Fix a false-positive WARNING in v0.94.0's prefix-migration check.

`cdkd deploy` against any pre-v0.94 stack with auto-generated Pattern B names (IAM Role / User / Group / InstanceProfile / ELBv2 LB / TargetGroup) prints:

```
WARNING: --no-prefix-user-supplied-names will REPLACE N resource(s) ...
  - MyConstructRoleF44D44CF (AWS::IAM::Role): CdkSampleStack-MyConstructRoleF44D44CF -> MyConstructRoleF44D44CF
  ...
```

…even though the deploy engine would NOT actually REPLACE those resources — auto-generated names go through the `userSupplied: false` path in `generateResourceNameWithFallback` and keep the prefix regardless of `skipPrefix`.

## Root cause

`findPendingPrefixRenames` (src/cli/commands/prefix-migration-check.ts) was checking only `physicalId.startsWith('${stackName}-')`. It did not look at `state.properties[<NameField>]` to distinguish user-supplied vs auto-generated.

The deploy engine's actual rule:
```typescript
const shouldPrefix = currentStackName && !(userSupplied && getCurrentSkipPrefix());
```
So only resources where `userSupplied: true` (= `properties.RoleName` is set) actually drop the prefix under the new default.

## Fix

In `findPendingPrefixRenames`, after the prefix-startsWith check, gate on `state.properties[<NameField>]` being a non-empty string. New `PATTERN_B_NAME_PROPERTIES` map carries the per-type mapping next to `PATTERN_B_RESOURCE_TYPES` (kept in sync via shared module).

## Test plan

- [x] 18/18 unit tests pass in `tests/unit/cli/prefix-migration-check.test.ts` (3 updated to populate `properties[<NameField>]`, 2 new for the auto-generated regression guard + empty-string guard)
- [x] 3177 total unit tests pass
- [x] Live-test against real `CdkSampleStack` (the bug report's actual stack — 5 auto-generated IAM Roles with prefix-style physicalIds):
  - Pre-fix: WARNING + prompt + 5 entries listed
  - Post-fix: WARNING gone, `cdkd deploy` reports "No changes detected. Stack is up to date."
- [x] `pnpm run typecheck` / `lint` / `build` clean

## Backward compat

No state schema change. No CLI flag change. Existing scripts using `--prefix-user-supplied-names` still work. The only user-visible change is the WARNING no longer fires for auto-generated names — it still correctly fires for user-supplied names where REPLACEMENT really is pending.
