### PR TITLE
fix(export): make --dry-run permissive on missing --include-non-importable

### DIFF
--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -700,6 +700,10 @@ async function exportCommand(stackArg: string | undefined, options: ExportOption
         }
       );
 
+      // `blocked` resources are genuinely unfixable (nested stacks, missing
+      // state, etc.) — nothing the user can do at runtime resolves them.
+      // Hard-fail in both dry-run and real-run paths; printing the plan
+      // here is unhelpful because there is no path forward.
       if (blocked.length > 0) {
         logger.error('The following resources block migration:');
         for (const b of blocked) {
@@ -709,20 +713,6 @@ async function exportCommand(stackArg: string | undefined, options: ExportOption
           `${blocked.length} resource(s) block migration. Either destroy them first ` +
             `(cdkd destroy / cdkd state destroy cherry-picked), or remove them from the ` +
             `CDK app and re-synthesize.`
-        );
-      }
-
-      if (phase2Creates.length > 0 && !options.includeNonImportable) {
-        logger.error('The following resources cannot be imported into CloudFormation:');
-        for (const p of phase2Creates) {
-          logger.error(`  - ${p.logicalId} (${p.resourceType}): CFn cannot import this type`);
-        }
-        throw new Error(
-          `${phase2Creates.length} non-importable resource(s) detected (Custom::*). ` +
-            `Pass --include-non-importable to run a 2-phase migration: phase 1 imports ` +
-            `the importable resources; phase 2 CFn-CREATEs the non-importable ones ` +
-            `(re-invoking each Custom Resource's backing Lambda onCreate handler — ` +
-            `make sure those are idempotent). Or destroy these resources first.`
         );
       }
 
@@ -765,9 +755,40 @@ async function exportCommand(stackArg: string | undefined, options: ExportOption
         logger.info('');
       }
 
+      // `--include-non-importable` is a real-run safety gate (Custom Resource
+      // onCreate re-invocation needs to be idempotent — see CLAUDE.md). On
+      // `--dry-run` we WARN instead of hard-erroring so the user sees the
+      // full plan + the gate they'll need to flip for the real run. Erroring
+      // out before printPlan defeats the point of dry-run.
       if (options.dryRun) {
+        if (phase2Creates.length > 0 && !options.includeNonImportable) {
+          logger.warn(
+            `${phase2Creates.length} non-importable resource(s) detected (Custom::*). ` +
+              `A real run (without --dry-run) would require --include-non-importable ` +
+              `to run a 2-phase migration: phase 1 imports the importable resources; ` +
+              `phase 2 CFn-CREATEs the non-importable ones (re-invoking each Custom ` +
+              `Resource's backing Lambda onCreate handler — make sure those are idempotent).`
+          );
+        }
         logger.info('--dry-run: no CloudFormation changeset will be created.');
         return;
+      }
+
+      // Real run: hard error on missing --include-non-importable so the user
+      // explicitly opts into the CR re-invocation semantics before phase 2
+      // touches AWS.
+      if (phase2Creates.length > 0 && !options.includeNonImportable) {
+        logger.error('The following resources cannot be imported into CloudFormation:');
+        for (const p of phase2Creates) {
+          logger.error(`  - ${p.logicalId} (${p.resourceType}): CFn cannot import this type`);
+        }
+        throw new Error(
+          `${phase2Creates.length} non-importable resource(s) detected (Custom::*). ` +
+            `Pass --include-non-importable to run a 2-phase migration: phase 1 imports ` +
+            `the importable resources; phase 2 CFn-CREATEs the non-importable ones ` +
+            `(re-invoking each Custom Resource's backing Lambda onCreate handler — ` +
+            `make sure those are idempotent). Or destroy these resources first.`
+        );
       }
 
       if (!options.yes) {

--- a/tests/integration/export/verify.sh
+++ b/tests/integration/export/verify.sh
@@ -119,6 +119,35 @@ case "${VARIANT}" in
       echo "[verify] FAIL: dry-run plan does not list AWS::ApiGatewayV2::Stage as recreate target"
       exit 1
     fi
+
+    # Regression guard for the dry-run permissiveness fix: dry-run without
+    # --include-non-importable should NOT hard-error. The user's first
+    # interaction with cdkd export is typically `cdkd export <stack> --dry-run`
+    # (per the cdk-sample/cdkd-export.md guide) — if cdkd aborts before
+    # printing the plan, the dry-run flag's purpose (preview without side
+    # effects) is defeated. Instead it should print the full plan + WARN
+    # that --include-non-importable is needed for the real run.
+    echo "[verify] step 3b: cdkd export --dry-run WITHOUT --include-non-importable"
+    ${CLI} export "${STACK}" \
+      --state-bucket "${STATE_BUCKET}" \
+      --dry-run \
+      -y \
+      --verbose 2>&1 | tee /tmp/verify-dry-run-no-flag.log
+    if [ "${PIPESTATUS[0]}" -ne 0 ]; then
+      echo "[verify] FAIL: dry-run without --include-non-importable exited non-zero"
+      echo "[verify] (dry-run must be permissive — see fix/export-dry-run-permissive)"
+      exit 1
+    fi
+    if ! grep -qE 'non-importable resource.+detected' /tmp/verify-dry-run-no-flag.log; then
+      echo "[verify] FAIL: dry-run without --include-non-importable did not warn about Custom Resources"
+      exit 1
+    fi
+    if ! grep -q 'A real run (without --dry-run) would require --include-non-importable' /tmp/verify-dry-run-no-flag.log; then
+      echo "[verify] FAIL: dry-run did not surface the real-run hint about --include-non-importable"
+      exit 1
+    fi
+    echo "[verify] step 3b ok: dry-run is permissive + emits the real-run hint"
+
     echo "[verify] step 4: verify CFn stack does NOT exist (dry-run)"
     if aws cloudformation describe-stacks --stack-name "${CFN_STACK}" --region "${REGION}" >/dev/null 2>&1; then
       echo "[verify] FAIL: dry-run created a CFn stack — should not happen"


### PR DESCRIPTION
## Summary

`cdkd export --dry-run` was aborting BEFORE printing the import plan when the stack contained any `Custom::*` resource without `--include-non-importable`. The dry-run flag's purpose is "preview without side effects" — failing on a real-run safety gate defeats the point.

User reproducer (real session against cdk-sample's CdkSampleStack):

```
❯ cdkd export --dry-run
Synthesizing CDK app to read template...
...
Migrating cdkd stack 'CdkSampleStack' (us-east-1) → CloudFormation stack 'CdkSampleStack'
The following resources cannot be imported into CloudFormation:
  - MyConstructMyBucketAutoDeleteObjectsCustomResourceE0739477 (Custom::S3AutoDeleteObjects): CFn cannot import this type
Error: 1 non-importable resource(s) detected (Custom::*). Pass --include-non-importable to run a 2-phase migration: ...
```

The user followed the cdk-sample/cdkd-export.md guide step 2 (which says "run `cdkd export --dry-run` to see the plan") and never saw the plan.

## Fix

Restructured the gate ordering in `src/cli/commands/export.ts`:

- `blocked` resources (nested stacks, missing state) still hard-error in both dry-run and real-run paths — those are genuinely unfixable.
- `phase2Creates` without `--include-non-importable` is now a **WARN** on dry-run (printed alongside the plan) and an **ERROR** on real-run.
- The dry-run path prints the full plan, then emits a one-line warn telling the user what flag the real run will need.

Other paths unchanged: empty-state warn, no-importable-phase-1 hard error, phase-2 + recreate-before-phase-2 announcements.

## Live test (against the user's actual CdkSampleStack)

Pre-fix:
```
Migrating cdkd stack 'CdkSampleStack' ...
Error: 1 non-importable resource(s) detected (Custom::*). Pass --include-non-importable to run...
```

Post-fix:
```
Migrating cdkd stack 'CdkSampleStack' ...
[full Import plan for CloudFormation stack 'CdkSampleStack' with 28 phase-1 resources]
Phase 2 will CREATE 1 non-importable resource(s):
  MyConstructMyBucketAutoDeleteObjectsCustomResourceE0739477 (Custom::S3AutoDeleteObjects)
Phase 2 will also re-CREATE 1 IMPORT-unsupported resource(s) ...
  MyConstructMyHttpApiDefaultStage655B4AD3 (AWS::ApiGatewayV2::Stage) — physicalId: $default
[warn] 1 non-importable resource(s) detected (Custom::*). A real run (without --dry-run) would require --include-non-importable ...
--dry-run: no CloudFormation changeset will be created.
[exit 0]
```

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` clean
- [x] 3177 unit tests pass
- [x] Live-test against real CdkSampleStack (28 phase-1 + 1 phase-2 CR + 1 Stage recreate): dry-run prints plan + warn, exits 0
- [x] Integ regression guard added at `tests/integration/export/verify.sh`: the `dry-run` variant now also runs `cdkd export --dry-run` WITHOUT `--include-non-importable` and asserts exit 0 + the real-run hint appears in output
- [x] Doc: `cdk-sample/cdkd-export.md` step 2 wording aligned with the new flow (separate commit on cdk-sample)
