### PR TITLE
docs(readme): clarify cdkd complements the AWS CDK CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Drop-in CDK CLI for existing CDK apps — faster deploys via AWS SDK instead of 
 
 ![cdkd demo](https://github.com/user-attachments/assets/0128730d-186d-4bd3-abea-aabc80ba4dd5)
 
+**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration and SAM-style local execution; use the AWS CDK CLI in production for full CloudFormation tooling. Bidirectional migration is supported — [import an existing CloudFormation stack](#importing-existing-resources) into cdkd for iteration, or [export back to CloudFormation](#exporting-a-stack-back-to-cloudformation) when ready for production.
+
 > **⚠️ WARNING: NOT PRODUCTION READY**
 >
 > An experimental project exploring direct SDK provisioning as an alternative to the AWS CDK CLI — **NOT a replacement** and **NOT suitable for production use**. Features are incomplete, APIs may change without notice, and bugs may affect your AWS infrastructure. Use at your own risk in development / testing environments only.


### PR DESCRIPTION
## Summary

- Add a one-paragraph callout in `README.md` between the demo GIF and the `NOT PRODUCTION READY` warning to clarify cdkd's positioning relative to the AWS CDK CLI.
- The callout: cdkd complements rather than replaces the AWS CDK CLI; use cdkd in dev/test for rapid iteration and SAM-style local execution, use the AWS CDK CLI in production for full CloudFormation tooling. Bidirectional migration via `cdkd import --migrate-from-cloudformation` and `cdkd export` is linked inline.
- Placed before the warning so the positive positioning lands first; readers see "complements, not replaces" before the warning's tone takes over.
- Both links jump to existing in-README sections (`#importing-existing-resources`, `#exporting-a-stack-back-to-cloudformation`) so there is no external dependency.

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` pass
- [x] `npx vitest --run` — 270 files / 3156 tests pass
- [x] Anchor targets verified to exist verbatim in README (`## Importing existing resources` at L378, `## Exporting a stack back to CloudFormation` at L400)
- [x] GitHub auto-anchor generation rule applied to compute link targets; both match the existing headings
