### PR TITLE
fix(export): auto pre-delete + phase-2 CREATE for AWS::IAM::Policy

### DIFF
--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -449,7 +449,17 @@ export interface RecreateBeforePhase2Entry {
  * sibling ApiGwV2 type has `[create, delete, list, read, update]`).
  */
 const IMPORT_UNSUPPORTED_RECREATABLE_TYPES: ReadonlySet<string> = new Set([
+  // AWS::ApiGatewayV2::Stage — `handlers: []`. HttpApi auto-emits `$default`.
   'AWS::ApiGatewayV2::Stage',
+  // AWS::IAM::Policy — `handlers: ['create', 'delete', 'update']` (no `read`/
+  // `list`). Inline policies attached to roles / users / groups don't have a
+  // first-class AWS resource id, so CFn IMPORT can't look them up. cdkd's
+  // own IAMPolicyProvider issues `iam:PutRolePolicy` / `PutUserPolicy` /
+  // `PutGroupPolicy` per attachment target; CFn phase-2 CREATE uses the
+  // exact same APIs, so pre-delete + phase-2-CREATE round-trips cleanly.
+  // CDK auto-emits this type for L2 grants (ECS Task Execution Role
+  // ECR pull policy, Lambda execution role inline policies, etc.).
+  'AWS::IAM::Policy',
 ]);
 
 /**
@@ -502,6 +512,78 @@ const PRE_DELETE_HANDLERS: Record<string, PreDeleteHandler> = {
         return;
       }
       throw err;
+    }
+  },
+  'AWS::IAM::Policy': async (entry) => {
+    // Mirrors IAMPolicyProvider.delete (src/provisioning/providers/
+    // iam-policy-provider.ts): inline policy attachments are stored per-
+    // target via PutRolePolicy/PutUserPolicy/PutGroupPolicy, so deletion
+    // is per-target too. State carries Roles/Users/Groups arrays
+    // capturing the attachment set at deploy time.
+    const {
+      IAMClient,
+      DeleteRolePolicyCommand,
+      DeleteUserPolicyCommand,
+      DeleteGroupPolicyCommand,
+      NoSuchEntityException,
+    } = await import('@aws-sdk/client-iam');
+
+    // physicalId is either the bare policy name (SDK provider format) or
+    // legacy `policyName:roleName` (CC API pre-SDK-provider state). The
+    // SDK provider's own delete normalizes via the same split; mirror it
+    // so pre-v0.74-ish state still produces the correct policy name.
+    const policyName = entry.physicalId.includes(':')
+      ? entry.physicalId.split(':')[0]
+      : entry.physicalId;
+    if (!policyName) {
+      throw new Error(
+        `cdkd state's physicalId for ${entry.logicalId} (${entry.resourceType}) is empty / invalid`
+      );
+    }
+
+    const roles = entry.properties['Roles'] as string[] | undefined;
+    const users = entry.properties['Users'] as string[] | undefined;
+    const groups = entry.properties['Groups'] as string[] | undefined;
+    const hasAttachment = (roles?.length ?? 0) + (users?.length ?? 0) + (groups?.length ?? 0) > 0;
+    if (!hasAttachment) {
+      throw new Error(
+        `cdkd state's properties for ${entry.logicalId} (${entry.resourceType}) has no ` +
+          `Roles/Users/Groups attachment recorded — cannot pre-delete the inline policy. ` +
+          `State may be from a pre-v0.74 cdkd binary; re-run \`cdkd state refresh-observed\` ` +
+          `before export.`
+      );
+    }
+
+    const client = new IAMClient({});
+
+    // Each per-target send is idempotent on NoSuchEntityException
+    // (matches IAMPolicyProvider.delete; covers partial-retry safety
+    // after a previous pre-delete attempt succeeded for some targets).
+    // Other errors propagate so phase 2 doesn't proceed against a
+    // policy still attached to AWS.
+    const deleteSafely = async (op: () => Promise<unknown>): Promise<void> => {
+      try {
+        await op();
+      } catch (err) {
+        if (err instanceof NoSuchEntityException) return;
+        throw err;
+      }
+    };
+
+    for (const roleName of roles ?? []) {
+      await deleteSafely(() =>
+        client.send(new DeleteRolePolicyCommand({ RoleName: roleName, PolicyName: policyName }))
+      );
+    }
+    for (const userName of users ?? []) {
+      await deleteSafely(() =>
+        client.send(new DeleteUserPolicyCommand({ UserName: userName, PolicyName: policyName }))
+      );
+    }
+    for (const groupName of groups ?? []) {
+      await deleteSafely(() =>
+        client.send(new DeleteGroupPolicyCommand({ GroupName: groupName, PolicyName: policyName }))
+      );
     }
   },
 };
@@ -748,9 +830,11 @@ async function exportCommand(stackArg: string | undefined, options: ExportOption
           logger.info(`  ${r.logicalId} (${r.resourceType}) — physicalId: ${r.physicalId}`);
         }
         logger.info(
-          '  Brief unavailability window (~10s for Stage; HttpApi endpoint URL is ' +
-            'unchanged because it embeds ApiId, not StageName). Pass ' +
-            '--no-recreate-import-unsupported to block instead.'
+          '  Brief unavailability window per type (~10s for Stage; HttpApi endpoint URL ' +
+            'is unchanged because it embeds ApiId, not StageName. IAM::Policy: the inline ' +
+            'policy attachment is dropped from each Role/User/Group between phases — any ' +
+            'in-flight AWS API call that depends on the granted permission will fail until ' +
+            'CFn re-CREATEs in phase 2). Pass --no-recreate-import-unsupported to block instead.'
         );
         logger.info('');
       }

--- a/tests/integration/export/lib/export-stack.ts
+++ b/tests/integration/export/lib/export-stack.ts
@@ -80,6 +80,25 @@ export class ExportStack extends cdk.Stack {
       ],
     });
 
+    // ── Inline IAM Policy (IMPORT-unsupported recreate path) ───────
+    // `AWS::IAM::Policy` is the type CDK emits for L2 grants like ECS
+    // Task Execution Role's ECR-pull policy. CFn schema reports it with
+    // `handlers: ['create', 'delete', 'update']` — no read/list, so it's
+    // not IMPORT-able. cdkd auto-handles via pre-delete + phase-2-CREATE
+    // (same mechanism as Stage). Inline `new iam.Policy(...)` with
+    // `roles: [role]` produces this exact CFn type. Brief permission gap
+    // between the SDK DeleteRolePolicy and CFn's phase-2 PutRolePolicy.
+    new iam.Policy(this, 'InlinePolicy', {
+      policyName: `cdkd-export-inline-${suffix}`,
+      statements: [
+        new iam.PolicyStatement({
+          actions: ['logs:PutLogEvents'],
+          resources: ['*'],
+        }),
+      ],
+      roles: [role],
+    });
+
     // Trivial idempotent backing Lambda. Works under BOTH cdkd's
     // Custom Resource invocation (which can use the return value as
     // the response payload) AND real CloudFormation's Custom Resource

--- a/tests/integration/export/verify.sh
+++ b/tests/integration/export/verify.sh
@@ -119,6 +119,28 @@ case "${VARIANT}" in
       echo "[verify] FAIL: dry-run plan does not list AWS::ApiGatewayV2::Stage as recreate target"
       exit 1
     fi
+    # AWS::IAM::Policy must also surface in recreate (same shape as Stage —
+    # CFn schema reports no read/list handler, so it's IMPORT-unsupported).
+    # Fixture has an inline iam.Policy attached to the CR role. Catches the
+    # bug from real-AWS dogfooding on 2026-05-12 where IAM::Policy was
+    # erroneously sent to phase-1 IMPORT and would have been rejected.
+    if ! grep -q 'AWS::IAM::Policy.*recreate\|AWS::IAM::Policy.*physicalId' /tmp/verify-dry-run.log; then
+      # Fallback regex: the plan output for recreateBeforePhase2 entries
+      # has the shape `  <logicalId> (AWS::IAM::Policy) — physicalId: <id>`.
+      if ! grep -q 'AWS::IAM::Policy' /tmp/verify-dry-run.log; then
+        echo "[verify] FAIL: dry-run plan does not mention AWS::IAM::Policy at all"
+        exit 1
+      fi
+      # AWS::IAM::Policy is in the plan SOMEWHERE — ensure it's in the
+      # recreate-before-phase-2 section, not phase-1 imports.
+      if grep -E 'Import plan for CloudFormation stack' -A 200 /tmp/verify-dry-run.log \
+         | grep -B 1 '(AWS::IAM::Policy)' \
+         | grep -q '←'; then
+        echo "[verify] FAIL: AWS::IAM::Policy is in phase-1 imports — should be in recreate"
+        echo "[verify] (IAM::Policy must be in IMPORT_UNSUPPORTED_RECREATABLE_TYPES)"
+        exit 1
+      fi
+    fi
 
     # Regression guard for the dry-run permissiveness fix: dry-run without
     # --include-non-importable should NOT hard-error. The user's first
@@ -264,9 +286,14 @@ case "${VARIANT}" in
         exit 1
       fi
     done
-    # IMPORT-unsupported re-CREATE (phase 2): AWS::ApiGatewayV2::Stage was
-    # pre-deleted between phases, then CFn UPDATE re-CREATEd it fresh.
-    # Closes cdkd issue #307.
+    # IMPORT-unsupported re-CREATE (phase 2): AWS::ApiGatewayV2::Stage AND
+    # AWS::IAM::Policy are pre-deleted between phases, then CFn UPDATE
+    # re-CREATEs them fresh. Closes cdkd issue #307 + the IAM::Policy
+    # case (added 2026-05-12 from real-AWS dogfooding).
+    if ! echo "${RESOURCES}" | grep -q 'AWS::IAM::Policy'; then
+      echo "[verify] FAIL: AWS::IAM::Policy not found in CFn stack (pre-delete + phase-2 CREATE missed)"
+      exit 1
+    fi
     if ! echo "${RESOURCES}" | grep -q 'AWS::ApiGatewayV2::Stage'; then
       echo "[verify] FAIL: AWS::ApiGatewayV2::Stage not found in CFn stack (pre-delete + phase-2 CREATE missed)"
       exit 1

--- a/tests/unit/cli/export.test.ts
+++ b/tests/unit/cli/export.test.ts
@@ -460,6 +460,14 @@ describe('isImportUnsupportedRecreatableType', () => {
     expect(isImportUnsupportedRecreatableType('AWS::ApiGatewayV2::Stage')).toBe(true);
   });
 
+  it('matches AWS::IAM::Policy (no read/list handler; inline policy has no AWS-side id)', () => {
+    // CDK auto-emits this type for L2 grants (ECS Task Execution Role ECR-pull
+    // policy, Lambda execution-role inline policies, etc.). Found via real
+    // export against cdk-sample on 2026-05-12 — the dry-run plan put it in
+    // phase-1 imports, real run would fail at CreateChangeSet.
+    expect(isImportUnsupportedRecreatableType('AWS::IAM::Policy')).toBe(true);
+  });
+
   it('does NOT match sibling ApiGwV2 types (they have IMPORT handlers)', () => {
     expect(isImportUnsupportedRecreatableType('AWS::ApiGatewayV2::Api')).toBe(false);
     expect(isImportUnsupportedRecreatableType('AWS::ApiGatewayV2::Integration')).toBe(false);
@@ -664,6 +672,225 @@ describe('invokePreDeleteHandler', () => {
         properties: { ApiId: 'doptkc8n2i' },
       })
     ).rejects.toThrow(/AccessDenied/);
+  });
+
+  // ─── AWS::IAM::Policy handler tests ──────────────────────────────
+  //
+  // Inline policy attachments are per-target (Roles / Users / Groups).
+  // The handler walks each target list and issues the appropriate Delete
+  // call. NoSuchEntityException is idempotent (matches IAMPolicyProvider.
+  // delete in src/provisioning/providers/iam-policy-provider.ts).
+
+  it('AWS::IAM::Policy handler walks Roles and issues DeleteRolePolicy per role', async () => {
+    const sendCalls: { cmdName: string; input: Record<string, unknown> }[] = [];
+    vi.doMock('@aws-sdk/client-iam', () => ({
+      IAMClient: class {
+        async send(cmd: { __cmdName: string; input: Record<string, unknown> }) {
+          sendCalls.push({ cmdName: cmd.__cmdName, input: cmd.input });
+        }
+      },
+      DeleteRolePolicyCommand: class {
+        readonly __cmdName = 'DeleteRolePolicy';
+        constructor(public input: Record<string, unknown>) {}
+      },
+      DeleteUserPolicyCommand: class {
+        readonly __cmdName = 'DeleteUserPolicy';
+        constructor(public input: Record<string, unknown>) {}
+      },
+      DeleteGroupPolicyCommand: class {
+        readonly __cmdName = 'DeleteGroupPolicy';
+        constructor(public input: Record<string, unknown>) {}
+      },
+      NoSuchEntityException: class extends Error {
+        readonly name = 'NoSuchEntityException';
+      },
+    }));
+    const { invokePreDeleteHandler: handler } = await import(
+      '../../../src/cli/commands/export.js'
+    );
+
+    await handler('AWS::IAM::Policy', {
+      logicalId: 'EcrPullPolicy',
+      resourceType: 'AWS::IAM::Policy',
+      physicalId: 'ecr-pull-policy',
+      properties: { Roles: ['RoleA', 'RoleB'] },
+    });
+
+    expect(sendCalls).toHaveLength(2);
+    expect(sendCalls[0]).toEqual({
+      cmdName: 'DeleteRolePolicy',
+      input: { RoleName: 'RoleA', PolicyName: 'ecr-pull-policy' },
+    });
+    expect(sendCalls[1]).toEqual({
+      cmdName: 'DeleteRolePolicy',
+      input: { RoleName: 'RoleB', PolicyName: 'ecr-pull-policy' },
+    });
+  });
+
+  it('AWS::IAM::Policy handler walks Users + Groups when set', async () => {
+    const sendCalls: { cmdName: string; input: Record<string, unknown> }[] = [];
+    vi.doMock('@aws-sdk/client-iam', () => ({
+      IAMClient: class {
+        async send(cmd: { __cmdName: string; input: Record<string, unknown> }) {
+          sendCalls.push({ cmdName: cmd.__cmdName, input: cmd.input });
+        }
+      },
+      DeleteRolePolicyCommand: class {
+        readonly __cmdName = 'DeleteRolePolicy';
+        constructor(public input: Record<string, unknown>) {}
+      },
+      DeleteUserPolicyCommand: class {
+        readonly __cmdName = 'DeleteUserPolicy';
+        constructor(public input: Record<string, unknown>) {}
+      },
+      DeleteGroupPolicyCommand: class {
+        readonly __cmdName = 'DeleteGroupPolicy';
+        constructor(public input: Record<string, unknown>) {}
+      },
+      NoSuchEntityException: class extends Error {
+        readonly name = 'NoSuchEntityException';
+      },
+    }));
+    const { invokePreDeleteHandler: handler } = await import(
+      '../../../src/cli/commands/export.js'
+    );
+
+    await handler('AWS::IAM::Policy', {
+      logicalId: 'P',
+      resourceType: 'AWS::IAM::Policy',
+      physicalId: 'p',
+      properties: { Users: ['UserA'], Groups: ['GroupA', 'GroupB'] },
+    });
+
+    expect(sendCalls.map((c) => c.cmdName)).toEqual([
+      'DeleteUserPolicy',
+      'DeleteGroupPolicy',
+      'DeleteGroupPolicy',
+    ]);
+  });
+
+  it('AWS::IAM::Policy handler normalizes legacy `policyName:roleName` physicalId', async () => {
+    // Pre-v0.74 state (CC API code path) stored physicalId as
+    // `policyName:roleName`. The provider's own delete strips the suffix;
+    // the pre-delete handler mirrors that so legacy state still produces
+    // the bare policy name as input to DeleteRolePolicy.
+    const sendCalls: Record<string, unknown>[] = [];
+    vi.doMock('@aws-sdk/client-iam', () => ({
+      IAMClient: class {
+        async send(cmd: { input: Record<string, unknown> }) {
+          sendCalls.push(cmd.input);
+        }
+      },
+      DeleteRolePolicyCommand: class {
+        constructor(public input: Record<string, unknown>) {}
+      },
+      DeleteUserPolicyCommand: class {
+        constructor(public input: Record<string, unknown>) {}
+      },
+      DeleteGroupPolicyCommand: class {
+        constructor(public input: Record<string, unknown>) {}
+      },
+      NoSuchEntityException: class extends Error {
+        readonly name = 'NoSuchEntityException';
+      },
+    }));
+    const { invokePreDeleteHandler: handler } = await import(
+      '../../../src/cli/commands/export.js'
+    );
+
+    await handler('AWS::IAM::Policy', {
+      logicalId: 'P',
+      resourceType: 'AWS::IAM::Policy',
+      physicalId: 'my-policy:my-role', // legacy CC-API shape
+      properties: { Roles: ['my-role'] },
+    });
+
+    expect(sendCalls).toEqual([{ RoleName: 'my-role', PolicyName: 'my-policy' }]);
+  });
+
+  it('AWS::IAM::Policy handler treats NoSuchEntityException as idempotent success', async () => {
+    // After a partial pre-delete retry — some targets succeeded last time,
+    // re-running the export hits AWS with "already gone" on those. Must
+    // continue, not abort.
+    class FakeNoSuchEntity extends Error {
+      readonly name = 'NoSuchEntityException';
+    }
+    let callIndex = 0;
+    vi.doMock('@aws-sdk/client-iam', () => ({
+      IAMClient: class {
+        async send() {
+          // Throw on the first send (already-gone Role); second send (live
+          // Role) succeeds. The handler must not abort on the first.
+          if (callIndex++ === 0) {
+            throw new FakeNoSuchEntity('Policy not found on role');
+          }
+          // success — no return value needed
+        }
+      },
+      DeleteRolePolicyCommand: class {
+        constructor(public input: Record<string, unknown>) {}
+      },
+      DeleteUserPolicyCommand: class {
+        constructor(public input: Record<string, unknown>) {}
+      },
+      DeleteGroupPolicyCommand: class {
+        constructor(public input: Record<string, unknown>) {}
+      },
+      NoSuchEntityException: FakeNoSuchEntity,
+    }));
+    const { invokePreDeleteHandler: handler } = await import(
+      '../../../src/cli/commands/export.js'
+    );
+
+    // Two Roles: first one returns NoSuchEntity, second one succeeds.
+    // The handler must complete without throwing.
+    await expect(
+      handler('AWS::IAM::Policy', {
+        logicalId: 'P',
+        resourceType: 'AWS::IAM::Policy',
+        physicalId: 'p',
+        properties: { Roles: ['AlreadyGoneRole', 'LiveRole'] },
+      })
+    ).resolves.toBeUndefined();
+    expect(callIndex).toBe(2);
+  });
+
+  it('AWS::IAM::Policy handler throws when state has no Roles/Users/Groups attachment', async () => {
+    // Defensive: state schema invariant says every IAM::Policy has at least
+    // one attachment. If state is corrupt and all three arrays are
+    // empty/missing, abort with a clear error rather than silently no-op
+    // (which would let phase-2 proceed against a still-attached policy).
+    vi.doMock('@aws-sdk/client-iam', () => ({
+      IAMClient: class {
+        async send() {
+          throw new Error('should not reach AWS');
+        }
+      },
+      DeleteRolePolicyCommand: class {
+        constructor(public input: Record<string, unknown>) {}
+      },
+      DeleteUserPolicyCommand: class {
+        constructor(public input: Record<string, unknown>) {}
+      },
+      DeleteGroupPolicyCommand: class {
+        constructor(public input: Record<string, unknown>) {}
+      },
+      NoSuchEntityException: class extends Error {
+        readonly name = 'NoSuchEntityException';
+      },
+    }));
+    const { invokePreDeleteHandler: handler } = await import(
+      '../../../src/cli/commands/export.js'
+    );
+
+    await expect(
+      handler('AWS::IAM::Policy', {
+        logicalId: 'P',
+        resourceType: 'AWS::IAM::Policy',
+        physicalId: 'p',
+        properties: {}, // no Roles/Users/Groups
+      })
+    ).rejects.toThrow(/no Roles\/Users\/Groups attachment/);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the second IMPORT-unsupported type discovered via dogfooding (the first was `AWS::ApiGatewayV2::Stage` in PR #309). `AWS::IAM::Policy` has `handlers: ['create', 'delete', 'update']` in the CFn schema — no `read`/`list`, so AWS rejects it from IMPORT changesets. CDK auto-emits this type for L2 grants like ECS Task Execution Role's ECR-pull policy.

Pre-PR: `cdkd export --dry-run` on cdk-sample's CdkSampleStack put `MyConstructMyEcrTaskDefinitionExecutionRoleDefaultPolicy36563E38 (AWS::IAM::Policy)` in phase-1 imports. The real run would have hit `CreateChangeSet rejected: ResourceTypes [AWS::IAM::Policy] are not supported for Import`.

## Fix

Same shape as the Stage handler in PR #309:

1. Add `AWS::IAM::Policy` to `IMPORT_UNSUPPORTED_RECREATABLE_TYPES`.
2. Add `PRE_DELETE_HANDLERS['AWS::IAM::Policy']`: walks state's `Roles` / `Users` / `Groups` arrays and issues `iam:DeleteRolePolicy` / `DeleteUserPolicy` / `DeleteGroupPolicy` per target. Mirrors `IAMPolicyProvider.delete` (`src/provisioning/providers/iam-policy-provider.ts`) including legacy `policyName:roleName` physicalId normalization for pre-v0.74 CC-API state. `NoSuchEntityException` is idempotent (partial-retry safety).
3. Phase-2 UPDATE: CFn sees the inline policy in the synth template, issues `PutRolePolicy` (re-creates the same attachment cdkd deleted). Brief permission gap between SDK Delete and CFn Create — documented in the confirmation prompt's warning.

## Tests

- 1 new `isImportUnsupportedRecreatableType` test
- 5 new `invokePreDeleteHandler` tests covering Roles / Users+Groups walks, legacy physicalId, NoSuchEntity idempotency, no-attachment corrupt-state error
- Integ fixture: new `new iam.Policy(this, 'InlinePolicy', { policyName: ..., statements: [...], roles: [role] })` attached to the CR role
- verify.sh: asserts (a) IAM::Policy in dry-run plan's recreate-before-phase-2 section (not phase-1), (b) IAM::Policy in final CFn stack post-phase-2
- **Real-AWS integ PASS**: phase-1 imports 8 + phase-2 CR CREATE 1 + 2 recreate (Stage + IAM::Policy), `UPDATE_COMPLETE`, cdkd state cleared, 0 orphans

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` clean
- [x] 3183 unit tests pass
- [x] Live-test against cdk-sample's CdkSampleStack: dry-run plan correctly moves IAM::Policy from phase-1 to recreate
- [x] Real-AWS integ end-to-end PASS, 0 orphans, integ-destroy marker fresh
