### PR TITLE
fix(export): preserve phase-1 overlay in phase-2 UPDATE to prevent silent REPLACE

### DIFF
--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -1065,10 +1065,19 @@ async function exportCommand(stackArg: string | undefined, options: ExportOption
       const phase2Count = phase2Creates.length + recreateBeforePhase2.length;
       if (phase2Count > 0) {
         try {
+          // Apply the phase-1 overlay onto each imported resource in the
+          // phase-2 template — without this, CFn sees "Name property
+          // removal" between phase-1 (overlayed) and phase-2 (raw synth)
+          // and silently REPLACES every imported resource whose Name is
+          // an immutable property (IAM Role, S3 Bucket, etc.). See
+          // applyImportOverlayForPhase2's docstring for the empirical
+          // motivation (cdk-sample 2026-05-12 incident: 24 resources
+          // silently REPLACED during phase-2 cleanup).
+          const phase2Template = applyImportOverlayForPhase2(template, phase1Imports);
           await executeUpdateChangeSet(
             awsClients.cloudFormation,
             cfnStackName,
-            template,
+            phase2Template,
             cfnParameters
           );
           const parts: string[] = [];
@@ -1752,6 +1761,60 @@ function overlayResourceIdentifierOnProperties(resource: unknown, entry: ImportP
     properties[field] = value;
   }
   return { ...r, Properties: properties };
+}
+
+/**
+ * Build the phase-2 UPDATE template: full synth template with cdkd's
+ * `ResourceIdentifier` overlay applied to every phase-1 import. This keeps
+ * the CFn-managed template's `Properties` consistent with what cdkd
+ * imported in phase 1 — preventing CFn from seeing a "Name property
+ * removed / changed" diff between the phase-1 IMPORT'd state (overlay
+ * applied) and a raw phase-2 synth template (overlay absent), which would
+ * trigger silent REPLACEMENT of every imported resource whose Name is an
+ * immutable property (IAM Role, S3 Bucket, ECR Repository, Lambda
+ * Function, etc.).
+ *
+ * **Why this matters** — discovered via real-AWS dogfooding 2026-05-12:
+ * pre-fix `cdkd export` against cdk-sample's CdkSampleStack silently
+ * REPLACED 24 resources during phase-2 `UPDATE_COMPLETE_CLEANUP_IN_PROGRESS`,
+ * including the S3 Bucket and ECR Repository. cdk-sample's
+ * `autoDeleteObjects: true` happened to mask the data-loss visibility,
+ * but on a production stack this would have wiped the S3 contents and
+ * ECR images.
+ *
+ * The overlay then persists into the final CFn-managed template. When
+ * the user runs `cdk deploy` after the migration, CDK synth produces
+ * the raw unprefixed Name → CFn proposes REPLACEMENT → the user decides
+ * (accept the replace, update CDK code to use the cdkd-prefixed name,
+ * or migrate data first). That deferred-to-cdk-deploy REPLACE is the
+ * documented post-export caveat — same as upstream `cdk import` — and
+ * it now happens with explicit user consent instead of silently during
+ * the cdkd export operation itself.
+ *
+ * Resources outside `phase1Imports` (phase-2 CREATE Custom Resources,
+ * pre-delete + recreate targets like Stage / IAM::Policy) are passed
+ * through unchanged — they get CREATEd from synth and don't have any
+ * pre-existing Properties state to preserve.
+ *
+ * Exported for unit testing.
+ */
+export function applyImportOverlayForPhase2(
+  template: Record<string, unknown>,
+  phase1Imports: ImportPlanEntry[]
+): Record<string, unknown> {
+  const result = JSON.parse(JSON.stringify(template)) as Record<string, unknown>;
+  const resources = result['Resources'];
+  if (!resources || typeof resources !== 'object' || Array.isArray(resources)) {
+    return result;
+  }
+  const resourcesMap = resources as Record<string, unknown>;
+  for (const entry of phase1Imports) {
+    const r = resourcesMap[entry.logicalId];
+    if (r !== undefined) {
+      resourcesMap[entry.logicalId] = overlayResourceIdentifierOnProperties(r, entry);
+    }
+  }
+  return result;
 }
 
 /**

--- a/tests/integration/export/verify.sh
+++ b/tests/integration/export/verify.sh
@@ -310,6 +310,47 @@ case "${VARIANT}" in
     fi
     echo "[verify] step 4b ok"
 
+    # Regression guard: phase-2 UPDATE must NOT have caused silent
+    # REPLACEMENT of any phase-1-imported resource. The bug discovered
+    # via cdk-sample dogfooding 2026-05-12: cdkd export's phase-2 used
+    # the raw synth template (no overlay) → CFn saw "Name property
+    # removed" between phase-1 (overlayed) and phase-2 (raw) → silently
+    # REPLACEd 24 imported resources during UPDATE_COMPLETE_CLEANUP_IN_PROGRESS.
+    # Fix: applyImportOverlayForPhase2 keeps the overlay in phase-2's
+    # template. To assert the fix held, walk stack events and confirm
+    # no DELETE_COMPLETE events occurred during the phase-2 cleanup window
+    # for any resource that was supposed to be imported (= NOT phase2Creates
+    # and NOT recreateBeforePhase2).
+    echo "[verify] step 4c: assert no silent REPLACE during phase-2 cleanup"
+    REPLACE_VICTIMS=$(aws cloudformation describe-stack-events \
+      --stack-name "${CFN_STACK}" --region "${REGION}" --max-items 200 --output json 2>&1 |
+      python3 -c "
+import json, sys
+events = json.load(sys.stdin).get('StackEvents', [])
+# Resources that legitimately get phase-2 DELETE: only the
+# recreate-before-phase-2 targets (Stage, IAM::Policy). They're
+# pre-deleted by cdkd BEFORE the UPDATE changeset runs, so they
+# do NOT appear as DELETE_COMPLETE in stack events (cdkd deleted
+# them via SDK, not via CFn changeset).
+#
+# Any phase-1-imported resource appearing as DELETE_COMPLETE
+# in the UPDATE_COMPLETE_CLEANUP_IN_PROGRESS window is a REPLACE
+# victim (the silent-replace bug).
+deleted = set()
+for ev in events:
+    if ev.get('ResourceStatus') == 'DELETE_COMPLETE' and ev['LogicalResourceId'] != '${CFN_STACK}':
+        deleted.add(ev['LogicalResourceId'])
+for lid in sorted(deleted):
+    print(lid)
+")
+    if [ -n "${REPLACE_VICTIMS}" ]; then
+      echo "[verify] FAIL: phase-2 UPDATE silently REPLACED imported resources:"
+      echo "${REPLACE_VICTIMS}" | sed 's/^/  - /'
+      echo "[verify] (the applyImportOverlayForPhase2 fix regressed — phase-2 sees Name property removal)"
+      exit 1
+    fi
+    echo "[verify] step 4c ok: no silent REPLACE happened"
+
     echo "[verify] step 5: verify cdkd state is GONE"
     STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
     if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" --region "${REGION}" >/dev/null 2>&1; then

--- a/tests/unit/cli/export.test.ts
+++ b/tests/unit/cli/export.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  applyImportOverlayForPhase2,
   filterTemplateForImport,
   hasCompositeIdSplitter,
   injectDeletionPolicyForImport,
@@ -269,6 +270,199 @@ describe('filterTemplateForImport', () => {
       { logicalId: 'Keep', resourceType: 'AWS::S3::Bucket', physicalId: 'b', resourceIdentifier: { BucketName: 'b' } },
     ]);
     expect('Outputs' in result).toBe(false);
+  });
+});
+
+describe('applyImportOverlayForPhase2', () => {
+  // Closes the silent-REPLACE bug discovered via cdk-sample dogfooding
+  // 2026-05-12: cdkd export's phase-2 UPDATE used the raw synth template
+  // (no overlay), so CFn saw `Properties.RoleName: 'CdkSampleStack-X'`
+  // (from phase-1 overlay) → `Properties.RoleName: (absent)` (raw synth)
+  // and replaced every imported resource whose Name is immutable.
+
+  it('overlays Name properties on phase-1 imports (mirrors filterTemplateForImport)', () => {
+    // The CDK code did not set RoleName; synth template has no RoleName
+    // on the resource. cdkd state has the auto-generated prefixed name
+    // as physicalId. Phase-2 template must surface that name in
+    // Properties.RoleName so CFn doesn't see "Name removal" vs the
+    // phase-1 IMPORT'd state.
+    const synth = {
+      Resources: {
+        Role: {
+          Type: 'AWS::IAM::Role',
+          Properties: {
+            AssumeRolePolicyDocument: { Version: '2012-10-17', Statement: [] },
+          },
+        },
+      },
+    };
+    const result = applyImportOverlayForPhase2(synth, [
+      {
+        logicalId: 'Role',
+        resourceType: 'AWS::IAM::Role',
+        physicalId: 'CdkSampleStack-Role',
+        resourceIdentifier: { RoleName: 'CdkSampleStack-Role' },
+      },
+    ]);
+    const role = (result['Resources'] as Record<string, Record<string, unknown>>)['Role']!;
+    const properties = role['Properties'] as Record<string, unknown>;
+    expect(properties['RoleName']).toBe('CdkSampleStack-Role');
+    // Existing Properties preserved
+    expect(properties['AssumeRolePolicyDocument']).toEqual({
+      Version: '2012-10-17',
+      Statement: [],
+    });
+  });
+
+  it('does NOT touch resources outside phase1Imports (phase-2 CREATE / recreate stay raw)', () => {
+    // Custom Resources go through phase-2 CREATE from raw synth; recreate-
+    // before-phase-2 entries (Stage / IAM::Policy) are deleted from AWS
+    // and CFn re-CREATEs from raw synth. Neither should have overlay
+    // applied — they have no "phase-1 import'd state" to keep consistent.
+    const synth = {
+      Resources: {
+        Role: { Type: 'AWS::IAM::Role', Properties: {} },
+        CR: {
+          Type: 'Custom::S3AutoDeleteObjects',
+          Properties: { ServiceToken: 'arn:...' },
+        },
+        Stage: {
+          Type: 'AWS::ApiGatewayV2::Stage',
+          Properties: { StageName: '$default', ApiId: { Ref: 'Api' } },
+        },
+      },
+    };
+    const result = applyImportOverlayForPhase2(synth, [
+      {
+        logicalId: 'Role',
+        resourceType: 'AWS::IAM::Role',
+        physicalId: 'CdkSampleStack-Role',
+        resourceIdentifier: { RoleName: 'CdkSampleStack-Role' },
+      },
+      // CR and Stage are NOT in phase1Imports
+    ]);
+    const resources = result['Resources'] as Record<string, Record<string, unknown>>;
+    expect((resources['Role']!['Properties'] as Record<string, unknown>)['RoleName']).toBe(
+      'CdkSampleStack-Role'
+    );
+    expect(resources['CR']!['Properties']).toEqual({ ServiceToken: 'arn:...' });
+    expect(resources['Stage']!['Properties']).toEqual({
+      StageName: '$default',
+      ApiId: { Ref: 'Api' },
+    });
+  });
+
+  it('honors propertiesOverlay narrowing (sub-resources do NOT get IntegrationId etc. written)', () => {
+    // The phase-1 overlay narrows for sub-resource types whose
+    // primaryIdentifier includes a read-only Property (IntegrationId,
+    // RouteId, Lambda::Permission's Id). Phase-2 overlay must respect
+    // the same narrowing — writing those into Properties would have CFn
+    // reject the changeset with "Encountered unsupported property".
+    const synth = {
+      Resources: {
+        Integ: {
+          Type: 'AWS::ApiGatewayV2::Integration',
+          Properties: { ApiId: { Ref: 'Api' }, IntegrationType: 'AWS_PROXY' },
+        },
+      },
+    };
+    const result = applyImportOverlayForPhase2(synth, [
+      {
+        logicalId: 'Integ',
+        resourceType: 'AWS::ApiGatewayV2::Integration',
+        physicalId: 'integ-abc',
+        resourceIdentifier: { ApiId: 'api-xyz', IntegrationId: 'integ-abc' },
+        propertiesOverlay: { ApiId: 'api-xyz' },
+      },
+    ]);
+    const integ = (result['Resources'] as Record<string, Record<string, unknown>>)['Integ']!;
+    const properties = integ['Properties'] as Record<string, unknown>;
+    expect(properties['ApiId']).toBe('api-xyz');
+    // IntegrationId is read-only and must NOT be in Properties
+    expect(properties).not.toHaveProperty('IntegrationId');
+    expect(properties['IntegrationType']).toBe('AWS_PROXY');
+  });
+
+  it('deep-clones the input so the caller can still use the raw synth template', () => {
+    // The phase-1 code path also reads from the same synth template
+    // (filterTemplateForImport runs separately). Mutating the input
+    // here would cross-contaminate.
+    const synth = {
+      Resources: {
+        Role: { Type: 'AWS::IAM::Role', Properties: {} },
+      },
+    };
+    applyImportOverlayForPhase2(synth, [
+      {
+        logicalId: 'Role',
+        resourceType: 'AWS::IAM::Role',
+        physicalId: 'CdkSampleStack-Role',
+        resourceIdentifier: { RoleName: 'CdkSampleStack-Role' },
+      },
+    ]);
+    // Original input untouched
+    expect((synth.Resources.Role as { Properties: Record<string, unknown> }).Properties).toEqual(
+      {}
+    );
+  });
+
+  it('preserves Outputs (unlike filterTemplateForImport which strips them)', () => {
+    // Phase-2 UPDATE template restores Outputs that phase-1 had to strip
+    // (CFn IMPORT rejects Outputs). The overlay function must leave them
+    // alone.
+    const synth = {
+      Resources: {
+        Role: { Type: 'AWS::IAM::Role', Properties: {} },
+      },
+      Outputs: {
+        RoleArn: { Value: { 'Fn::GetAtt': ['Role', 'Arn'] } },
+      },
+    };
+    const result = applyImportOverlayForPhase2(synth, [
+      {
+        logicalId: 'Role',
+        resourceType: 'AWS::IAM::Role',
+        physicalId: 'CdkSampleStack-Role',
+        resourceIdentifier: { RoleName: 'CdkSampleStack-Role' },
+      },
+    ]);
+    expect(result['Outputs']).toEqual({
+      RoleArn: { Value: { 'Fn::GetAtt': ['Role', 'Arn'] } },
+    });
+  });
+
+  it('handles template without Resources section gracefully', () => {
+    // Defensive: cdkd's executeUpdateChangeSet call site already ensures
+    // a Resources section exists, but tolerate the empty case to keep
+    // the helper composable.
+    const result = applyImportOverlayForPhase2({}, []);
+    expect(result).toEqual({});
+  });
+
+  it('skips imports whose logicalId is missing from the template (defensive)', () => {
+    // Edge case: cdkd state has a resource not in the current synth
+    // (e.g. user removed it from CDK code). buildImportPlan would have
+    // flagged this earlier, but the overlay helper itself must not crash.
+    const synth = {
+      Resources: { Role: { Type: 'AWS::IAM::Role', Properties: {} } },
+    };
+    const result = applyImportOverlayForPhase2(synth, [
+      {
+        logicalId: 'Role',
+        resourceType: 'AWS::IAM::Role',
+        physicalId: 'r',
+        resourceIdentifier: { RoleName: 'r' },
+      },
+      {
+        logicalId: 'MissingFromTemplate',
+        resourceType: 'AWS::SNS::Topic',
+        physicalId: 't',
+        resourceIdentifier: { TopicArn: 't' },
+      },
+    ]);
+    const resources = result['Resources'] as Record<string, Record<string, unknown>>;
+    expect(resources).toHaveProperty('Role');
+    expect(resources).not.toHaveProperty('MissingFromTemplate');
   });
 });
 


### PR DESCRIPTION
## Summary

Critical bug fix. `cdkd export` silently REPLACED imported resources during phase-2 UPDATE — discovered via dogfooding on cdk-sample (2026-05-12, 24 resources replaced in a single export, including S3 Bucket and ECR Repository).

## Root cause

cdkd export's phase-1 IMPORT requires `Properties.<NameField>` (RoleName / BucketName / etc.) to match the `ResourceIdentifier` passed to the CFn changeset. cdkd's `filterTemplateForImport` accomplishes this by overlaying the prefixed physical id into Properties.

cdkd's phase-2 UPDATE then submitted the **raw synth template** (no overlay) directly to `executeUpdateChangeSet`. CFn saw:

- **Phase-1 IMPORT'd state**: `Properties.RoleName: 'CdkSampleStack-MyConstructRoleF44D44CF'` (cdkd overlay)
- **Phase-2 UPDATE template**: `Properties.RoleName: (absent)` (raw synth — CDK didn't emit a Name)
- **CFn**: "Immutable property `RoleName` removed → REPLACE this resource"

CFn then DELETEd the existing resource and CREATEd a new one with a CFn-auto-generated name. All in `UPDATE_COMPLETE_CLEANUP_IN_PROGRESS`, invisible from the cdkd output.

Stack events from the real cdk-sample run:

```
07:14:20 IMPORT_COMPLETE
07:15:44 UPDATE_IN_PROGRESS
07:16:53–07:17:10  ← 24 resources DELETE_COMPLETE during CLEANUP
07:17:10 UPDATE_COMPLETE
```

Affected types in the user's stack: `AWS::S3::Bucket`, `AWS::S3::BucketPolicy`, `AWS::ECR::Repository`, `AWS::IAM::Role` (×5), `AWS::Lambda::Function` (×5), `AWS::Lambda::Permission` (×8), `AWS::ECS::TaskDefinition` (×2), CR provider Role + Lambda.

## Fix

New exported helper `applyImportOverlayForPhase2(template, phase1Imports)` in `src/cli/commands/export.ts`:

1. Deep-clones the synth template
2. Re-applies the phase-1 overlay (via existing `overlayResourceIdentifierOnProperties`) onto every phase-1-imported resource
3. Leaves phase-2-create resources (`Custom::*`) and recreate-before-phase-2 resources (Stage, IAM::Policy) unchanged — they're CREATEd from synth and have no phase-1 state to preserve

Phase-2 call site now passes `phase2Template` (overlay applied) instead of raw `template`.

## Why this is the right fix vs alternatives

| Option | Pros | Cons |
| --- | --- | --- |
| **Apply overlay in phase-2 (this PR)** | Phase-2 sees no diff → no REPLACE. Documented caveat (`cdk deploy` proposes REPLACE) finally holds. | Overlay persists; first `cdk deploy` will propose REPLACE (= documented caveat) |
| Drop overlay from phase-1 | Symmetry between phases | Breaks phase-1 IMPORT — CFn requires Properties to match ResourceIdentifier |
| Strip Name from phase-1 ResourceIdentifier | Symmetry | CFn IMPORT changeset rejects missing identifiers |

## Caveats hold post-fix

Post-export `cdk deploy` against the migrated stack will now propose REPLACE on imported resources whose Name was overlayed. This is the **documented post-export caveat** (same as upstream `cdk import`) and now happens with **explicit user consent** instead of silently during the cdkd export operation itself.

## Test plan

- [x] `pnpm run typecheck` / `lint` / `build` clean
- [x] 3190 unit tests pass (7 new for `applyImportOverlayForPhase2`)
- [x] Integ regression guard at `tests/integration/export/verify.sh` step 4c: walks `describe-stack-events` for any `DELETE_COMPLETE` during phase-2 cleanup and FAILS the integ if any phase-1-imported resource was silently REPLACEd
- [x] Real-AWS integ PASS: 8 phase-1 imports + 1 phase-2 CR + 2 IMPORT-unsupported re-CREATE, **0 silent REPLACE**, 0 orphans
- [x] `mise exec -- markgate verify integ-destroy` green
