### PR TITLE
fix(tests): use 'vp run build' instead of stale 'pnpm run build' in 6 verify.sh files (#321)

### DIFF
--- a/tests/integration/docdb-neptune/verify.sh
+++ b/tests/integration/docdb-neptune/verify.sh
@@ -46,8 +46,8 @@ TIMEOUT_OVERRIDES=(
 )
 
 echo "[verify] step 1: install + build cdkd"
-pnpm --dir "${REPO_ROOT}" install
-pnpm --dir "${REPO_ROOT}" run build
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
 
 cd "${TEST_DIR}"
 if [ ! -d node_modules ]; then

--- a/tests/integration/drift-revert-vpc/verify.sh
+++ b/tests/integration/drift-revert-vpc/verify.sh
@@ -33,8 +33,8 @@ STATE_BUCKET="${STATE_BUCKET:-cdkd-state-${ACCOUNT_ID}}"
 echo "[verify] region=${REGION} stack=${STACK} state-bucket=${STATE_BUCKET}"
 
 echo "[verify] step 1: install + build cdkd"
-pnpm --dir "${REPO_ROOT}" install
-pnpm --dir "${REPO_ROOT}" run build
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
 
 cd "${TEST_DIR}"
 if [ ! -d node_modules ]; then

--- a/tests/integration/drift-revert/verify.sh
+++ b/tests/integration/drift-revert/verify.sh
@@ -27,8 +27,8 @@ STATE_BUCKET="${STATE_BUCKET:-cdkd-state-${ACCOUNT_ID}}"
 echo "[verify] region=${REGION} stack=${STACK} state-bucket=${STATE_BUCKET}"
 
 echo "[verify] step 1: install + build cdkd"
-pnpm --dir "${REPO_ROOT}" install
-pnpm --dir "${REPO_ROOT}" run build
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
 
 cd "${TEST_DIR}"
 if [ ! -d node_modules ]; then

--- a/tests/integration/local-invoke-from-state/verify.sh
+++ b/tests/integration/local-invoke-from-state/verify.sh
@@ -43,8 +43,8 @@ STATE_BUCKET="${STATE_BUCKET:-cdkd-state-${ACCOUNT_ID}}"
 echo "[verify] region=${REGION} stack=${STACK} state-bucket=${STATE_BUCKET}"
 
 echo "[verify] step 1a: install + build cdkd"
-pnpm --dir "${REPO_ROOT}" install
-pnpm --dir "${REPO_ROOT}" run build
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
 
 cd "${TEST_DIR}"
 if [ ! -d node_modules ]; then

--- a/tests/integration/local-run-task-from-state/verify.sh
+++ b/tests/integration/local-run-task-from-state/verify.sh
@@ -69,8 +69,8 @@ STATE_BUCKET="${STATE_BUCKET:-cdkd-state-${ACCOUNT_ID}}"
 echo "[verify] region=${REGION} stack=${STACK} state-bucket=${STATE_BUCKET}"
 
 echo "[verify] step 1a: install + build cdkd"
-pnpm --dir "${REPO_ROOT}" install
-pnpm --dir "${REPO_ROOT}" run build
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
 
 cd "${TEST_DIR}"
 if [ ! -d node_modules ]; then

--- a/tests/integration/remove-protection/verify.sh
+++ b/tests/integration/remove-protection/verify.sh
@@ -34,8 +34,8 @@ STATE_BUCKET="${STATE_BUCKET:-cdkd-state-${ACCOUNT_ID}}"
 echo "[verify] region=${REGION} stack=${STACK} state-bucket=${STATE_BUCKET}"
 
 echo "[verify] step 1: install + build cdkd"
-pnpm --dir "${REPO_ROOT}" install
-pnpm --dir "${REPO_ROOT}" run build
+(cd "${REPO_ROOT}" && pnpm install)
+(cd "${REPO_ROOT}" && vp run build)
 
 cd "${TEST_DIR}"
 if [ ! -d node_modules ]; then


### PR DESCRIPTION
## Summary

Closes #321. 6 integration test `verify.sh` files were using stale `pnpm run build` / `pnpm --dir ... install` — broken since PR #317's vp migration removed the `build` script from `package.json`. Mechanical replacement:

```bash
# before
pnpm --dir "${REPO_ROOT}" install
pnpm --dir "${REPO_ROOT}" run build
# after
(cd "${REPO_ROOT}" && pnpm install)
(cd "${REPO_ROOT}" && vp run build)
```

Affected files (all fixed):

- `tests/integration/docdb-neptune/verify.sh`
- `tests/integration/drift-revert-vpc/verify.sh`
- `tests/integration/drift-revert/verify.sh`
- `tests/integration/local-invoke-from-state/verify.sh`
- `tests/integration/local-run-task-from-state/verify.sh`
- `tests/integration/remove-protection/verify.sh`

(`tests/integration/export/verify.sh` was already fixed in PR #320.)

## Test plan

- [x] No source code change → typecheck / lint / build / tests all pass unchanged (270 files, 3192 tests).
- [x] CI workflows unaffected — they invoke `vp run test` / `vp run build` directly, not via verify.sh.
- [ ] Local `/run-integ <name>` against any of the 6 fixed verify.sh files should now reach step 2 (previously aborted at step 1's `pnpm run build`). Not exercised in this PR (each integ takes 10-30 min of real AWS); proven by PR #320's identical fix on `tests/integration/export/verify.sh` which ran end-to-end.
