### PR TITLE
chore: introduce Renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard"],
+  "timezone": "Asia/Tokyo",
+  "labels": ["dependencies"],
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 10,
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["^@aws-sdk/"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "aws-sdk",
+      "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["^@aws-sdk/"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "aws-sdk (major)",
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackagePatterns": ["^@aws-sdk/"],
+      "groupName": "dev-dependencies",
+      "automerge": true
+    },
+    {
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackagePatterns": ["^@aws-sdk/"],
+      "groupName": "runtime-dependencies",
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "excludePackagePatterns": ["^@aws-sdk/"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchPackageNames": ["node"],
+      "enabled": false
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "automerge": true
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -7,13 +7,13 @@
   "prConcurrentLimit": 10,
   "packageRules": [
     {
-      "matchPackagePatterns": ["^@aws-sdk/"],
+      "matchPackageNames": ["/^@aws-sdk//"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "aws-sdk",
       "automerge": true
     },
     {
-      "matchPackagePatterns": ["^@aws-sdk/"],
+      "matchPackageNames": ["/^@aws-sdk//"],
       "matchUpdateTypes": ["major"],
       "groupName": "aws-sdk (major)",
       "dependencyDashboardApproval": true
@@ -21,20 +21,20 @@
     {
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "excludePackagePatterns": ["^@aws-sdk/"],
+      "matchPackageNames": ["!/^@aws-sdk//"],
       "groupName": "dev-dependencies",
       "automerge": true
     },
     {
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "excludePackagePatterns": ["^@aws-sdk/"],
+      "matchPackageNames": ["!/^@aws-sdk//"],
       "groupName": "runtime-dependencies",
       "automerge": true
     },
     {
       "matchUpdateTypes": ["major"],
-      "excludePackagePatterns": ["^@aws-sdk/"],
+      "matchPackageNames": ["!/^@aws-sdk//"],
       "dependencyDashboardApproval": true
     },
     {


### PR DESCRIPTION
## Summary

- Add `renovate.json` at the repo root to enable [Renovate](https://docs.renovatebot.com/) for automated dependency updates.
- Configuration tailored to cdkd:
  - **3 grouped batches** to avoid flooding `main` with semantic-release runs:
    - `aws-sdk` — minor/patch on the `@aws-sdk/*` family (30+ packages)
    - `dev-dependencies` — vitest / eslint / typescript / etc.
    - `runtime-dependencies` — graphlib / archiver / chokidar / etc.
  - Patch + minor are auto-merged (CI must pass first).
  - Major updates require dependency-dashboard approval (separate PRs per major bump).
  - Node engine pin is excluded (managed by Vite+ via `.node-version`).
  - `lockFileMaintenance` runs weekly (Monday before 6am Asia/Tokyo) to refresh `pnpm-lock.yaml` transitive entries.
  - Vulnerability alerts auto-merged with a `security` label.
- Uses the modern `matchPackageNames` regex syntax (`/^@aws-sdk//`, `!/^@aws-sdk//`) instead of the deprecated `matchPackagePatterns` / `excludePackagePatterns`.

Verified via `renovate-config-validator`: config validates with no warnings.

## Follow-up needed (NOT in this PR)

After merge, the Renovate GitHub App must be installed against `go-to-k/cdkd` (https://github.com/apps/renovate) before any PR will fire — this is a one-time external action.

## Test plan

- [x] `renovate-config-validator renovate.json` — passes
- [x] `vp run typecheck` — passes
- [x] `vp run lint:fix` — 0 warnings, 0 errors
- [x] `vp run build` — passes
- [x] `vp run test` — 270 files, 3192 tests pass
- [ ] After merge: install Renovate GitHub App against the repo
- [ ] After install: verify Renovate Dashboard issue appears
- [ ] After Dashboard: verify the first grouped PR for `aws-sdk` minor/patch (if any pending) is auto-mergeable

## Retrospective note (out of scope for this PR)

4 user-invocable skills under `.claude/skills/` still reference the pre-Vite+ toolchain (`pnpm run typecheck/lint/build`, `npx vitest --run`); commit d139ee8 fixed only the integ `verify.sh` files. Filed for a separate follow-up PR.
