### PR TITLE
chore(skills): migrate agent-facing skills + lint hook from pnpm to vp

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; echo \"$f\" | grep -qE '\\.(ts|tsx)$' && pnpm run lint:fix; } 2>/dev/null || true",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; echo \"$f\" | grep -qE '\\.(ts|tsx)$' && vp run lint:fix; } 2>/dev/null || true",
             "timeout": 30,
             "statusMessage": "Running lint:fix..."
           }

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -11,10 +11,10 @@ Run all local quality checks. Use during development to verify the current state
 
 Run these sequentially and report results:
 
-1. `pnpm run typecheck`
-2. `pnpm run lint:fix`
-3. `pnpm run build`
-4. `npx vitest --run`
+1. `vp run typecheck`
+2. `vp run lint:fix`
+3. `vp run build`
+4. `vp run test`
 
 ## Output
 

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -18,7 +18,7 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
 
 ## Steps
 
-1. **Build first**: Run `pnpm run build` to ensure dist/ is up to date.
+1. **Build first**: Run `vp run build` to ensure dist/ is up to date.
 
 2. **List available tests**: Run `ls tests/integration/` to discover all test directories dynamically. Do NOT rely on a hardcoded list.
 

--- a/.claude/skills/use-cdkd/SKILL.md
+++ b/.claude/skills/use-cdkd/SKILL.md
@@ -12,7 +12,7 @@ Build cdkd and output commands that can be pasted into another CDK project's ter
 1. **Build cdkd**:
 
    ```bash
-   pnpm run build
+   vp run build
    ```
 
 2. **Get the absolute path to the CLI**:
@@ -74,7 +74,7 @@ Build cdkd and output commands that can be pasted into another CDK project's ter
 
    To unlink later: `pnpm unlink --global cdkd` (from anywhere) or `pnpm rm --global cdkd`.
 
-   Note: `pnpm link --global` points to the current `dist/cli.js`, so re-running `pnpm run build` in the cdkd repo picks up changes automatically — no re-link needed.
+   Note: `pnpm link --global` points to the current `dist/cli.js`, so re-running `vp run build` in the cdkd repo picks up changes automatically — no re-link needed.
 
    ### Option B: Direct `node` invocation (no install needed)
 
@@ -127,7 +127,7 @@ Build cdkd and output commands that can be pasted into another CDK project's ter
 4. **Remind the user**:
    - `pnpm setup` + `pnpm link --global` is a one-time setup; after that just use `cdkd` anywhere
    - `pnpm setup` writes `PNPM_HOME` to your shell rc — open a new shell or `source` the rc before `pnpm link --global`
-   - Re-building cdkd (`pnpm run build`) automatically updates the linked global binary
+   - Re-building cdkd (`vp run build`) automatically updates the linked global binary
    - `--region` is optional if `AWS_REGION` or `CDK_DEFAULT_REGION` is set
    - `--state-bucket` auto-resolves to `cdkd-state-{accountId}-{region}` if omitted
    - Custom bucket can be set via `--state-bucket` flag, `CDKD_STATE_BUCKET` env var, or `context.cdkd.stateBucket` in cdk.json (priority: CLI > env > cdk.json)

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -17,10 +17,10 @@ Run each check and report pass/fail:
    [ -d node_modules ] || pnpm install
    ```
    `git worktree add` does NOT copy `node_modules`, so a fresh worktree's
-   `pnpm run typecheck` / `lint` / `build` and `npx vitest --run` all fail
-   with `tsc: command not found` / `Cannot find package 'vitest'` etc. —
+   `vp run typecheck` / `lint` / `build` and `vp run test` all fail
+   with `tsgo: command not found` / `Cannot find package 'vitest'` etc. —
    but the failure is easy to miss when the output is piped to `tail` (the
-   exit code reflects `tail`, not `pnpm`, and the `ELIFECYCLE` line gets
+   exit code reflects `tail`, not `vp`, and the failure line gets
    buried). If the pre-flight skips by way of an existing `node_modules`,
    confirm it is not stale by spot-checking `pnpm-lock.yaml` mtime ≤
    `node_modules/.modules.yaml` mtime. **Do not start step 1 until this
@@ -28,20 +28,20 @@ Run each check and report pass/fail:
    green.
 
 1. **Code quality**
-   - `pnpm run typecheck` passes
-   - `pnpm run lint` passes (run `lint:fix` first if needed)
-   - `pnpm run build` succeeds
+   - `vp run typecheck` passes
+   - `vp run lint` passes (run `lint:fix` first if needed)
+   - `vp run build` succeeds
    - When piping any of the above to `tail` / `head` / `grep` for log
-     truncation, **check the actual output content** for `ELIFECYCLE` /
-     `Command failed` / `Error` markers — `$?` after a pipeline reflects
+     truncation, **check the actual output content** for `Error` /
+     `Command failed` markers — `$?` after a pipeline reflects
      the LAST stage (usually 0), NOT the build tool's exit. The same
      applies to background-task completion notifications: the
      framework's `exit code 0` is the chained command's exit, not the
      pipeline head. When in doubt, capture the result without piping:
-     `pnpm run X > /tmp/out 2>&1; rc=$?; tail -3 /tmp/out; echo "[rc=$rc]"`.
+     `vp run X > /tmp/out 2>&1; rc=$?; tail -3 /tmp/out; echo "[rc=$rc]"`.
 
 2. **Tests**
-   - `npx vitest --run` - all unit tests pass
+   - `vp run test` - all unit tests pass
    - Report test count (files and tests)
    - **Test coverage check**: compare `git diff main...HEAD` for `src/` changes vs `tests/` changes. If new logic was added or modified in `src/` but no corresponding test files were added or updated, flag as **fail** and add the missing tests before proceeding
 
@@ -105,7 +105,7 @@ Run each check and report pass/fail:
 
 9. **Live-test changed behavior**
    - Unit tests verify code correctness; this step verifies *feature* correctness against the runtime the user actually sees.
-   - Build the latest source: `pnpm run build`
+   - Build the latest source: `vp run build`
    - For each user-visible change in the diff (CLI command, output format, flag, error message), run the actual command path against a real or fixture input and confirm the output matches the spec / CDK CLI parity claim:
      - CLI surface change → run `node dist/cli.js <subcommand> <args>` against `tests/integration/<example>/cdk.out` or a real state bucket; verify each output mode (`--long` / `--json` / patterns / etc.).
      - State-touching change → exercise it against a real / test state bucket (e.g. `cdkd-state-test`).


### PR DESCRIPTION
## Summary

cdkd migrated to Vite+ (`vp`) for build / test / lint orchestration, but **4 user-invocable skills** and the **PostToolUse lint hook** still referenced the pre-migration `pnpm run typecheck/lint/build` and `npx vitest --run` commands. PR #322 fixed this in 6 integ `verify.sh` files but missed these agent-facing surfaces.

**Why this matters:** the failures were *silent*. `pnpm run typecheck` reports "Missing script: typecheck" which the lint hook's `|| true` suppresses. `npx vitest --run` happens to run, but hits a hoisting error in 270/270 test files because vp's mock pipeline isn't wired through plain `vitest`. Combined, `/check` reported all-pass while actually running nothing of value — caught in passing during the Renovate PR (#325) session.

## Files changed

- `.claude/skills/check/SKILL.md` (4 sites) — the 4 sequential checks
- `.claude/skills/verify-pr/SKILL.md` (~9 sites) — worktree pre-flight note, code-quality + tests section, live-test build step
- `.claude/skills/use-cdkd/SKILL.md` (3 sites) — build / re-build hints
- `.claude/skills/run-integ/SKILL.md` (1 site) — pre-test build
- `.claude/settings.json` PostToolUse hook (1 site) — `lint:fix` on edited `.ts` / `.tsx`

## Preserved (intentionally NOT replaced)

- `pnpm setup` / `pnpm link --global` / `pnpm install` / `pnpm-lock.yaml` — pnpm-specific package-manager operations, not project task scripts.
- `npx --yes --package=renovate -- renovate-config-validator` — one-off external tool invocation in the validator path.

## Test plan

- [x] `grep -rE "pnpm run|npx vitest" .claude/` returns 0 matches
- [x] `python3 -c "import json; json.load(open('.claude/settings.json'))"` confirms the hook command edit kept settings.json as valid JSON
- [x] `vp run typecheck` / `lint:fix` / `build` / `test` (3192 tests pass) — verified against this worktree's main-equivalent src state during the Renovate PR session
- [ ] In the next session that uses `/check`, confirm the table reports real per-step results (not silent skips)

## Retrospective

The silent-skip pattern is fixed structurally by replacing the commands themselves. A defensive hook that grep-blocks `pnpm run` / `npx vitest` from landing in `.claude/skills/**` or `.claude/settings.json` is possible but probably overkill — the broader vp migration appears mostly complete now. Defer unless this regresses.
