### PR TITLE
test(integ): cover PR #332 regression class in migrate-from-cfn small fixture

### DIFF
--- a/tests/integration/migrate-from-cfn/lib/migrate-small-stack.ts
+++ b/tests/integration/migrate-from-cfn/lib/migrate-small-stack.ts
@@ -1,4 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
+import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as apigwv2Integ from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
@@ -11,14 +14,36 @@ import { Construct } from 'constructs';
  * Resources are deliberately ones cdkd has SDK Provider support for, so the
  * post-migrate `cdkd destroy` exercises the full provider path rather than
  * the Cloud Control API fallback.
+ *
+ * Extended (PR #332 regression guard) with the sub-resource types whose
+ * `delete()` reads intrinsic-valued properties from state — the class of
+ * bug fixed by PR #332. Pre-#332 `cdkd import` wrote the synth template's
+ * Properties literal (including raw `Fn::GetAtt` / `Ref`) verbatim into
+ * `state.properties`, and the post-migrate `cdkd destroy` then passed those
+ * raw intrinsics to AWS, which rejected them. Three failure patterns from
+ * the original bug report (CdkSampleStack):
+ *   - `AWS::Lambda::Permission.FunctionName: {Fn::GetAtt: [<Fn>, 'Arn']}`
+ *     (auto-emitted by every API Gateway / HttpApi → Lambda integration)
+ *   - `AWS::IAM::Policy.Roles[0]: {Ref: <Role>}`
+ *     (auto-emitted by every CDK L2 grant — e.g. `bucket.grantRead(role)`
+ *     or the auto-delete-objects Lambda's execution role policy)
+ *   - `Custom::S3AutoDeleteObjects.ServiceToken: {Fn::GetAtt: [<Fn>, 'Arn']}`
+ *     (auto-emitted by `autoDeleteObjects: true` on an S3 Bucket)
+ * Adding all three to this fixture ensures the migrate-from-cfn path is
+ * structurally covered against this regression class going forward.
  */
 export class MigrateSmallStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    new s3.Bucket(this, 'ExampleBucket', {
+    // S3 Bucket with `autoDeleteObjects: true` — auto-emits a
+    // `Custom::S3AutoDeleteObjects` resource whose ServiceToken is a raw
+    // `Fn::GetAtt` intrinsic. Pre-#332 the post-migrate destroy crashed
+    // with `serviceToken.startsWith is not a function`; post-#332 the
+    // intrinsic is resolved at import time so destroy sees a real ARN.
+    const bucket = new s3.Bucket(this, 'ExampleBucket', {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
-      autoDeleteObjects: false,
+      autoDeleteObjects: true,
       versioned: true,
     });
 
@@ -45,5 +70,34 @@ export class MigrateSmallStack extends cdk.Stack {
       },
       documentType: 'Command',
     });
+
+    // Lambda + HttpApi route — the HttpLambdaIntegration auto-emits an
+    // `AWS::Lambda::Permission` whose `FunctionName` is `{Fn::GetAtt:
+    // [<Fn>, 'Arn']}`. This is the first canonical failure shape — pre-#332
+    // the post-migrate destroy crashed with "Value '{Fn::GetAtt: ...}' at
+    // 'functionName' failed to satisfy constraint".
+    const handler = new lambda.Function(this, 'RouteHandler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline(
+        'exports.handler = async () => ({ statusCode: 200, body: "ok" });'
+      ),
+    });
+
+    const httpApi = new apigwv2.HttpApi(this, 'TestHttpApi');
+    httpApi.addRoutes({
+      path: '/ping',
+      methods: [apigwv2.HttpMethod.GET],
+      integration: new apigwv2Integ.HttpLambdaIntegration('PingIntegration', handler),
+    });
+
+    // CDK L2 grant — auto-emits a standalone `AWS::IAM::Policy`
+    // (`RouteHandlerServiceRoleDefaultPolicy*`) whose `Roles[0]` is a raw
+    // `{Ref: <RoleLogicalId>}` intrinsic. Pre-#332 the post-migrate destroy
+    // crashed with "The specified value for roleName is invalid" because
+    // the raw intrinsic was passed verbatim to `DeleteRolePolicy`. This
+    // is the third canonical failure shape — and the one most likely to
+    // bite any non-trivial CDK app since EVERY L2 grant emits a Policy.
+    bucket.grantRead(handler);
   }
 }


### PR DESCRIPTION
## Summary

PR #332 fixed `cdkd import` storing raw CFn intrinsics in `state.properties`, which broke `cdkd destroy` for sub-resource types whose `delete()` reads properties at delete time. The original bug was discovered via an ad-hoc user workflow (cdk-sample export → `cdk deploy` → `cdkd import --migrate-from-cloudformation` → `cdkd destroy`) — and the pre-existing `migrate-from-cfn` integ fixture would NOT have caught it because its small stack only deployed S3 + SSM Document, neither of which stores intrinsic-valued properties.

This PR extends the small fixture with the three canonical failure shapes from the original bug report so the regression class is structurally covered going forward.

## Resource types added

| CFn type | Intrinsic shape | How emitted |
|---|---|---|
| `AWS::Lambda::Permission` | `FunctionName: {Fn::GetAtt: [<Fn>, 'Arn']}` | `HttpLambdaIntegration` auto-emits the Permission |
| `AWS::IAM::Policy` | `Roles[0]: {Ref: <Role>}` | `bucket.grantRead(handler)` L2 grant emits `RouteHandlerServiceRoleDefaultPolicy` |
| `Custom::S3AutoDeleteObjects` | `ServiceToken: {Fn::GetAtt: [<Fn>, 'Arn']}` | `s3.Bucket({ autoDeleteObjects: true })` |

All three were the exact failure shapes that crashed the user's `cdkd destroy` pre-v0.94.13.

## Verified on v0.94.14

`AWS_REGION=us-east-1 STATE_BUCKET=cdkd-state-... bash run.sh small`:

```
=== [CdkdMigrateSmall] cdk deploy (real CloudFormation) ===   ✓
=== [CdkdMigrateSmall] cdkd import --migrate-from-cloudformation ===   ✓
=== [CdkdMigrateSmall] post-migrate assertions ===
  ok: cdkd state written
  ok: CloudFormation stack retired
  ok: cdkd-migrate-tmp/ is empty (transient template cleaned up)
=== [CdkdMigrateSmall] cdkd destroy ===
  ✓ Stack CdkdMigrateSmall destroyed (14 deleted, 0 errors)
=== [CdkdMigrateSmall] post-destroy assertions ===
  ok: cdkd state cleaned
=== ALL CHECKS PASSED ===
```

14/14 resources destroyed cleanly. Pre-#332 the destroy would have failed on all three sub-resource types with `1 validation error detected: Value '{Fn::GetAtt: ...}' at 'functionName' failed to satisfy constraint` / `The specified value for roleName is invalid` / `serviceToken.startsWith is not a function`.

## Scope / impact

- Test-only change (no `src/` touched, no behavior change)
- Template size: ~14KB (well under the 51,200-byte inline `TemplateBody` limit — `MigrateLargeStack`'s TemplateURL upload path is unaffected)
- The `large` stack is untouched (still tests the >51,200-byte TemplateURL upload path with a single padded Lambda)

## Test plan

- [x] `vp run typecheck` / `vp run lint` / `vp run build` pass
- [x] Full unit suite: 270 files / 3210 tests pass (no new unit tests — this is integ-only)
- [x] `bash tests/integration/migrate-from-cfn/run.sh small` passes end-to-end on v0.94.14 (real-AWS deploy + import + destroy)
