### PR TITLE
test(integ): cover PR #331 regression class — ECR Repository.Arn in migrate-from-cfn fixture

### DIFF
--- a/tests/integration/migrate-from-cfn/lib/migrate-small-stack.ts
+++ b/tests/integration/migrate-from-cfn/lib/migrate-small-stack.ts
@@ -1,6 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
 import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as apigwv2Integ from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
@@ -31,6 +33,19 @@ import { Construct } from 'constructs';
  *     (auto-emitted by `autoDeleteObjects: true` on an S3 Bucket)
  * Adding all three to this fixture ensures the migrate-from-cfn path is
  * structurally covered against this regression class going forward.
+ *
+ * Also extended (PR #331 regression guard) with an `AWS::ECR::Repository`
+ * referenced via `repo.repositoryArn` in an IAM policy statement. Pre-#331
+ * the resolver had no per-type Arn handler for `AWS::ECR::Repository`, so
+ * `Fn::GetAtt: [<EcrRepo>, 'Arn']` fell through to the default branch and
+ * returned the bare physicalId (the repo name). `cdkd diff` against
+ * imported state emitted `Unknown attribute Arn for resource type
+ * AWS::ECR::Repository, returning physical ID`, and downstream
+ * `Fn::Split(':', physicalId)` produced a 1-element array that triggered
+ * `Fn::Select(N, ...)` out-of-bounds warnings. Post-#331 the resolver
+ * returns `arn:${partition}:ecr:${region}:${accountId}:repository/${id}`.
+ * The integ's `run.sh` adds a `cdkd diff` step that asserts neither
+ * warning appears in the output.
  */
 export class MigrateSmallStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -99,5 +114,29 @@ export class MigrateSmallStack extends cdk.Stack {
     // is the third canonical failure shape — and the one most likely to
     // bite any non-trivial CDK app since EVERY L2 grant emits a Policy.
     bucket.grantRead(handler);
+
+    // ECR Repository + IAM grant referencing `repo.repositoryArn` —
+    // CDK synthesizes this as `Fn::GetAtt: [<EcrRepo>, 'Arn']` inside
+    // the IAM policy's `Resource` field. Pre-#331 the resolver had no
+    // per-type handler for `AWS::ECR::Repository.Arn` and fell through
+    // to the default branch (return physicalId = bare repo name),
+    // producing `Unknown attribute Arn for resource type AWS::ECR::Repository`
+    // and downstream `Fn::Select` out-of-bounds errors on any CDK
+    // pattern that parses the ARN. Post-#331 the resolver returns the
+    // real ARN. The integ's `run.sh` runs `cdkd diff` against the
+    // imported state and asserts neither warning appears.
+    const ecrRepo = new ecr.Repository(this, 'EcrRepo', {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      emptyOnDelete: true,
+    });
+    const ecrConsumer = new iam.Role(this, 'EcrConsumer', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+    ecrConsumer.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['ecr:GetAuthorizationToken', 'ecr:BatchGetImage'],
+        resources: [ecrRepo.repositoryArn],
+      })
+    );
   }
 }

--- a/tests/integration/migrate-from-cfn/run.sh
+++ b/tests/integration/migrate-from-cfn/run.sh
@@ -105,6 +105,26 @@ run_one() {
   assert_cfn_gone "${stack}"
   assert_migrate_tmp_empty
 
+  # PR #331 regression guard: cdkd diff must not warn about
+  # `AWS::ECR::Repository.Arn` falling back to physical id, and the
+  # downstream `Fn::Split` / `Fn::Select` chain must resolve cleanly.
+  # The small fixture's ECR Repository + IAM policy referencing
+  # `repo.repositoryArn` is the load-bearing input here.
+  if [[ "${stack}" == "CdkdMigrateSmall" ]]; then
+    log "[${stack}] cdkd diff (PR #331 regression guard for AWS::ECR::Repository.Arn)"
+    diff_output=$(AWS_REGION="${REGION}" ${CDKD} diff "${stack}" 2>&1 || true)
+    echo "${diff_output}"
+    if echo "${diff_output}" | grep -q "Unknown attribute Arn for resource type AWS::ECR::Repository"; then
+      echo "ASSERTION FAILED: PR #331 regression — ECR Repository.Arn handler missing from intrinsic resolver" >&2
+      exit 1
+    fi
+    if echo "${diff_output}" | grep -q "Fn::Select: index .* out of bounds (array length: 1)"; then
+      echo "ASSERTION FAILED: PR #331 regression — Fn::Select OOB on ECR ARN parse" >&2
+      exit 1
+    fi
+    echo "  ok: no ECR Arn fallback / Fn::Select OOB warnings in cdkd diff"
+  fi
+
   log "[${stack}] cdkd destroy"
   AWS_REGION="${REGION}" ${CDKD} destroy "${stack}" --force
 


### PR DESCRIPTION
## Summary

PR #331 added per-type `Arn` / `RepositoryUri` handlers for `AWS::ECR::Repository` in `IntrinsicFunctionResolver`. The bug surface was `cdkd diff` / `cdkd deploy` emitting:

```
Unknown attribute Arn for resource type AWS::ECR::Repository, returning physical ID
Fn::Select: index 4 out of bounds (array length: 1)
Fn::Select: index 3 out of bounds (array length: 1)
```

Both warning categories were originally surfaced by a user-driven `CdkSampleStack` roundtrip workflow. The pre-existing `migrate-from-cfn` integ fixture did not include `AWS::ECR::Repository` so the resolver fallback was never exercised end-to-end against real AWS — pre-#331 the integ would have stayed green even with the bug present, AND would have stayed green if a future change regressed the same code path.

This PR is the structural follow-up to PR #334 (which covered PR #332's bug class). Same pattern: extend the nearest integ fixture to mirror the user-reported failure shape.

## Changes

| File | Change |
|---|---|
| `tests/integration/migrate-from-cfn/lib/migrate-small-stack.ts` | Adds `AWS::ECR::Repository` + `AWS::IAM::Role` + `AWS::IAM::Policy` that references `repo.repositoryArn` — CDK synthesizes `Fn::GetAtt: [<EcrRepo>, 'Arn']` inside the IAM policy's `Resource` field |
| `tests/integration/migrate-from-cfn/run.sh` | Adds a `cdkd diff` step after import + before destroy that asserts neither warning appears |

## Asserts (run.sh)

```bash
if echo "${diff_output}" | grep -q "Unknown attribute Arn for resource type AWS::ECR::Repository"; then
  echo "ASSERTION FAILED: PR #331 regression — ECR Repository.Arn handler missing from intrinsic resolver" >&2
  exit 1
fi
if echo "${diff_output}" | grep -q "Fn::Select: index .* out of bounds (array length: 1)"; then
  echo "ASSERTION FAILED: PR #331 regression — Fn::Select OOB on ECR ARN parse" >&2
  exit 1
fi
```

Asserts BOTH directions — the per-type handler AND the downstream `Fn::Split` / `Fn::Select` chain it enables.

## Verified on v0.94.14

`AWS_REGION=us-east-1 STATE_BUCKET=cdkd-state-... bash run.sh small`:

```
=== [CdkdMigrateSmall] cdkd diff (PR #331 regression guard for AWS::ECR::Repository.Arn) ===
...
  ok: no ECR Arn fallback / Fn::Select OOB warnings in cdkd diff

=== [CdkdMigrateSmall] cdkd destroy ===
  ✓ Stack CdkdMigrateSmall destroyed (17 deleted, 0 errors)
=== ALL CHECKS PASSED ===
```

## Scope / impact

- Test-only change (no `src/` touched, no behavior change)
- Template size: ~16KB (still well under the 51,200-byte inline `TemplateBody` limit — `MigrateLargeStack`'s TemplateURL upload path is unaffected)
- Combined with PR #334, the `migrate-from-cfn` small fixture now covers all four canonical failure shapes from the original bug report (Lambda Permission / IAM Policy / Custom::* via #334; ECR Repository.Arn via this PR)

## Test plan

- [x] `vp run typecheck` / `vp run lint` / `vp run build` pass
- [x] Full unit suite: 270 files / 3210 tests pass (test-only PR — no new unit tests)
- [x] `bash tests/integration/migrate-from-cfn/run.sh small` passes end-to-end on v0.94.14, including the new `cdkd diff` regression guard
