### PR TITLE
fix(pr-review-gate): resolve marker scope via git-common-dir for worktree-shared state

### DIFF
--- a/.claude/hooks/pr-review-gate.sh
+++ b/.claude/hooks/pr-review-gate.sh
@@ -25,7 +25,27 @@
 set -u
 
 # Resolve repo root from script location.
-REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Prefer the main working tree (shared across `git worktree` instances)
+# so markgate marker state is consistent regardless of which worktree
+# triggered the hook. `gh pr merge` is a working-tree-agnostic remote
+# operation, but markgate's marker is stored per-cwd — so the merge
+# command landing in a different worktree from where `/review-pr` ran
+# would see a stale marker. `git rev-parse --git-common-dir` returns
+# the shared `.git` for worktrees (the main repo's `.git`) and a
+# relative `.git` from the main repo itself; its parent is the main
+# working tree in both cases. Falls back to SCRIPT_REPO on any git
+# error so a non-git checkout (rare, but cheap to support) still works.
+if git_common=$(git -C "$SCRIPT_REPO" rev-parse --git-common-dir 2>/dev/null); then
+  case "$git_common" in
+    /*) abs_common="$git_common" ;;
+    *)  abs_common="$SCRIPT_REPO/$git_common" ;;
+  esac
+  REPO="$(cd "$(dirname "$abs_common")" 2>/dev/null && pwd)" || REPO="$SCRIPT_REPO"
+else
+  REPO="$SCRIPT_REPO"
+fi
 
 # Extract the command from the PreToolUse payload.
 cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")

--- a/.claude/hooks/pr-review-gate.test.sh
+++ b/.claude/hooks/pr-review-gate.test.sh
@@ -12,7 +12,22 @@
 set -u
 
 HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pr-review-gate.sh"
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Match the hook's worktree-shared sentinel resolution: prefer the main
+# working tree (shared across `git worktree` instances) via
+# `git rev-parse --git-common-dir`. From the main repo this is a no-op;
+# from a worktree this redirects to the parent repo so the test
+# fixture sentinel lands where the hook will actually read it.
+if git_common=$(git -C "$SCRIPT_REPO" rev-parse --git-common-dir 2>/dev/null); then
+  case "$git_common" in
+    /*) abs_common="$git_common" ;;
+    *)  abs_common="$SCRIPT_REPO/$git_common" ;;
+  esac
+  REPO_ROOT="$(cd "$(dirname "$abs_common")" 2>/dev/null && pwd)" || REPO_ROOT="$SCRIPT_REPO"
+else
+  REPO_ROOT="$SCRIPT_REPO"
+fi
 
 # Per-run scratch dir for shim binaries; cleaned on EXIT.
 SHIM_DIR="$(mktemp -d)"

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -89,8 +89,20 @@ The skill itself never spawns reviewers. It reads PR stats, applies the heuristi
      # set` implicitly binds the marker to that sha. A subsequent push
      # to the PR will invalidate the marker (the next /review-pr run
      # rewrites the sentinel and markgate's digest reports stale).
-     gh pr view <N> --json headRefOid -q .headRefOid > .markgate-pr-review-sha
-     mise exec -- markgate set pr-review
+     #
+     # `git worktree`-aware: cd into the main working tree first so
+     # the sentinel + markgate state land where the gate hook reads
+     # them. The hook resolves its scope via
+     # `git rev-parse --git-common-dir` (the shared `.git` dir, or
+     # the main repo's `.git` from a worktree); markgate's marker
+     # store is per-cwd, so running from a worktree would land in a
+     # different store than the hook checks. `gh pr merge` itself is
+     # working-tree-agnostic — the cwd at merge time may not match
+     # the cwd at marker-set time. cd to the shared main tree to
+     # avoid the divergence.
+     main_tree=$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)
+     gh pr view <N> --json headRefOid -q .headRefOid > "$main_tree/.markgate-pr-review-sha"
+     ( cd "$main_tree" && mise exec -- markgate set pr-review )
      ```
 
    For the `inline` tier, the marker is NOT set — the gate's heuristic


### PR DESCRIPTION
## Summary

`gh pr merge` is a working-tree-agnostic remote operation, but the pre-fix `pr-review-gate` hook computed `REPO` from `${BASH_SOURCE[0]}` (the script's own location). When `/review-pr` runs in a worktree (the common case for an in-flight feature branch) and `gh pr merge` later runs from a different cwd, markgate's per-cwd marker store diverges and the gate refuses a freshly-set marker as "mismatch".

This surfaced in PR #338's merge flow: marker was set inside the worktree, but `gh pr merge` ran from the main repo where the marker file pointed to a previous PR's HEAD sha → the hook blocked the merge with `Marker state: bound to <prev-sha> (mismatch)`.

This PR:

- **Hook** (`.claude/hooks/pr-review-gate.sh`): resolve `REPO` via `git rev-parse --git-common-dir` → the shared `.git` directory's parent. From the main repo this is a no-op; from any worktree this redirects to the main working tree. Falls back to the script's repo on any git error so non-git checkouts still work.
- **Skill** (`.claude/skills/review-pr/SKILL.md` step 6): instruct the orchestrator to `cd "$main_tree"` (derived via `git rev-parse --path-format=absolute --git-common-dir | xargs dirname`) before writing the sentinel + running `markgate set`, so the marker lands where the hook will read it.
- **Test** (`.claude/hooks/pr-review-gate.test.sh`): mirror the hook's resolution so the fixture sentinel is written where the hook reads it. All 17 existing test cases pass under both main-repo and worktree execution after the change.

**Scope**: only `pr-review-gate.sh` is changed in this PR. Other gates (`check`, `docs`, `verify-pr`, `integ-destroy`, `integ-local`) gate `git commit` or `gh pr merge` too, but `git commit` is inherently bound to one worktree (no drift), and the `integ-*` gates already fire AFTER `pr-review-gate` does so they share the same upstream hop. If a future worktree-related issue surfaces against any of them, the same pattern transplants.

## Test plan

- [x] typecheck / lint / build / tests (3210 / 270 files) pass
- [x] `bash .claude/hooks/pr-review-gate.test.sh` → 17 / 17 pass under the worktree (where the hook + sentinel resolve to a different path than the test's cwd)
- [x] Manual: `git rev-parse --path-format=absolute --git-common-dir | xargs dirname` returns `/Users/goto/pc/github/cdkd` from both the main repo AND a worktree
- [x] Live: setting the marker after `cd "$main_tree"` makes `gh pr merge` proceed cleanly (verified during PR #338's merge after a manual cd hop — the same flow this PR codifies)
