### PR TITLE
feat(local-start-api): --api accepts CDK Construct path + stack-qualified logical id

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,8 @@ and same-stack Lambda Layers bind-mounted at `/opt`.
 ```bash
 cdkd local start-api                              # one HTTP server per discovered API
 cdkd local start-api --port 3000                  # pin the first server's port
+cdkd local start-api --api MyHttpApi              # filter by logical id
+cdkd local start-api --api MyStack/MyHttpApi      # OR: CDK Construct path
 cdkd local start-api --warm --watch               # pre-start + hot reload
 ```
 

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -317,10 +317,11 @@ the Lambda base image (~600MB once per machine). Pass `--no-pull` on
 subsequent runs to skip the layer check.
 
 ```bash
-cdkd local start-api                       # auto-allocate one port PER discovered API
-cdkd local start-api --port 3000           # first API → 3000, second API → 3001, ...
-cdkd local start-api --api MyAdminApi      # serve only the named API
-cdkd local start-api --warm                # pre-start one container per Lambda
+cdkd local start-api                              # auto-allocate one port PER discovered API
+cdkd local start-api --port 3000                  # first API → 3000, second API → 3001, ...
+cdkd local start-api --api MyAdminApi             # logical id
+cdkd local start-api --api MyStack/MyAdminApi     # OR: CDK Construct path (prefix-matched)
+cdkd local start-api --warm                       # pre-start one container per Lambda
 ```
 
 ### One server per API (v0.81+)
@@ -347,9 +348,35 @@ Port assignment:
 | `0` (default) | Every server auto-allocates its own port. |
 | `3000` | First API → `3000`, second API → `3001`, third → `3002`, ... |
 
-Pass `--api <id>` to launch exactly one server for the named API; the
-identifier matches the HTTP API / REST API logical id, or (for
-Function URLs) the backing Lambda's logical id.
+Pass `--api <id>` to launch exactly one server for the named API.
+The identifier accepts four forms (mirrors `cdkd local invoke <target>`
+/ `cdkd local run-task <target>` so the whole `local *` family
+addresses resources consistently):
+
+1. **Bare logical id** — `MyHttpApi`. The HTTP API / REST API logical
+   id, or (for Function URLs) the backing Lambda's logical id.
+2. **Stack-qualified logical id** — `MyStack:MyHttpApi`. Useful in
+   multi-stack apps when the same bare logical id appears in more
+   than one stack.
+3. **CDK Construct path / display path** — `MyStack/MyHttpApi/Resource`.
+   Exact match against the resource's `aws:cdk:path` metadata.
+4. **CDK Construct path prefix** — `MyStack/MyHttpApi`. Matches when
+   the input is a strict ancestor of the resource's `aws:cdk:path`
+   (same prefix rule `cdkd orphan` uses): CDK's
+   `new apigw2.HttpApi(stack, 'MyHttpApi')` synthesizes the L1 child
+   at `MyStack/MyHttpApi/Resource`, so `--api MyStack/MyHttpApi`
+   resolves cleanly without having to type the synthesized
+   `/Resource` suffix.
+
+For Function URLs, the path forms reference the **backing Lambda's**
+`aws:cdk:path`, not the auto-generated URL resource — so
+`--api MyStack/MyHandler` matches the Function URL declared by
+`new lambda.Function(this, 'MyHandler').addFunctionUrl()`.
+
+Routes from templates without `aws:cdk:path` metadata (hand-rolled
+`cfn.Resource` defs, or older CDK that didn't emit the metadata)
+still match by bare logical id (form 1) and by stack-qualified logical
+id (form 2) — only the path forms (3, 4) need the metadata.
 
 ### Discovered routes
 
@@ -381,7 +408,7 @@ the same tier; cdkd uses literal-segment count as a heuristic).
 | --- | --- | --- |
 | `--port <port>` | auto-allocate | First API server's port (subsequent APIs get `port+1`, `port+2`, ...). Pass `0` (default) to auto-allocate each. The actual port assignment is printed at startup. |
 | `--host <host>` | `127.0.0.1` | Bind address. |
-| `--api <id>` | unset | Restrict to a single API surface by its CDK logical id (HTTP API / REST API logical id; for Function URLs, the backing Lambda's logical id). When unset, every discovered API gets its own server. |
+| `--api <id>` | unset | Restrict to a single API surface. Accepts the bare CDK logical id (`MyHttpApi`), the stack-qualified logical id (`MyStack:MyHttpApi`), the full CDK Construct path (`MyStack/MyHttpApi/Resource`), or an ancestor Construct path that prefix-matches (`MyStack/MyHttpApi`). For Function URLs, the path forms reference the backing Lambda's `aws:cdk:path`. When unset, every discovered API gets its own server. See the section above for the full resolution rules. |
 | `--stack <name>` | single-stack auto-detect | Required when the app has multiple stacks. |
 | `--warm` | off | Pre-start one container per discovered Lambda at server boot. Trades RAM for first-request latency. |
 | `--per-lambda-concurrency <n>` | `2` | Pool size cap per Lambda. Max 4 in v1; above-cap values are clamped with a warn. |

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -1388,7 +1388,7 @@ export function createLocalStartApiCommand(): Command {
     .addOption(
       new Option(
         '--api <id>',
-        "Restrict to a single API surface by its logical id (HTTP API / REST API logical id, or the backing Lambda's logical id for Function URLs). When unset, every discovered API gets its own server on its own port (basePort, basePort+1, ... when --port is set; auto-allocated otherwise)."
+        "Restrict to a single API surface. Accepts the bare CDK logical id (e.g. 'MyHttpApi'), the stack-qualified logical id ('MyStack:MyHttpApi'), the full CDK Construct path ('MyStack/MyHttpApi/Resource'), or an ancestor Construct path that prefix-matches ('MyStack/MyHttpApi'). For Function URLs, the path forms reference the backing Lambda's aws:cdk:path. When unset, every discovered API gets its own server on its own port (basePort, basePort+1, ... when --port is set; auto-allocated otherwise)."
       )
     )
     .action(withErrorHandling(localStartApiCommand));

--- a/src/local/api-server-grouping.ts
+++ b/src/local/api-server-grouping.ts
@@ -167,10 +167,7 @@ export function filterRoutesByApiIdentifier(
  * for test coverage only — the production code path goes through
  * `filterRoutesByApiIdentifier`.
  */
-export function routeMatchesIdentifier(
-  route: RouteWithAuth['route'],
-  identifier: string
-): boolean {
+export function routeMatchesIdentifier(route: RouteWithAuth['route'], identifier: string): boolean {
   const bareId = route.source === 'function-url' ? route.lambdaLogicalId : route.apiLogicalId;
   if (bareId && bareId === identifier) return true;
   if (route.apiStackName) {
@@ -198,7 +195,8 @@ export function availableApiIdentifiers(routes: readonly RouteWithAuth[]): strin
   const out: string[] = [];
   for (const rwa of routes) {
     const r = rwa.route;
-    const bareId = r.source === 'function-url' ? r.lambdaLogicalId : (r.apiLogicalId ?? '<unknown>');
+    const bareId =
+      r.source === 'function-url' ? r.lambdaLogicalId : (r.apiLogicalId ?? '<unknown>');
     const primary = r.apiCdkPath ?? bareId;
     if (!seen.has(primary)) {
       seen.add(primary);

--- a/src/local/api-server-grouping.ts
+++ b/src/local/api-server-grouping.ts
@@ -127,13 +127,28 @@ export function groupRoutesByServer(routes: readonly RouteWithAuth[]): ApiServer
 /**
  * Filter the route list to a single API by user-supplied identifier.
  *
- * Matches against both the parent API logical id (HTTP API / REST v1)
- * AND the Function URL's backing-Lambda logical id, so users can pass
- * any of:
+ * Accepts four input forms — matches the rest of the `cdkd local *`
+ * target-resolution family (`local invoke <target>` /
+ * `local run-task <target>`) for consistency:
  *
- *   - The HTTP API logical id (e.g. `MyHttpApi`)
- *   - The REST API logical id (e.g. `MyRestApi`)
- *   - The Lambda logical id backing a Function URL (e.g. `GoHandler`)
+ *   1. **Bare logical id** (`MyHttpApi`) — exact match on the parent
+ *      API's logical id, or on the backing Lambda's logical id for
+ *      Function URLs.
+ *   2. **Stack-qualified logical id** (`MyStack:MyHttpApi`) — exact
+ *      match on `<stackName>:<logicalId>`. Useful in multi-stack apps
+ *      where the same bare logical id appears in two stacks.
+ *   3. **CDK Construct path / display path** (`MyStack/MyHttpApi`) —
+ *      exact match on the resource's `aws:cdk:path` metadata.
+ *   4. **CDK Construct path prefix** — when the input is a strict
+ *      ancestor of the resource's `aws:cdk:path` (i.e.
+ *      `cdkPath.startsWith(input + '/')`). Mirrors the prefix rule
+ *      `cdkd orphan` uses so an L2 wrapper path resolves to its L1
+ *      child (`MyStack/MyHttpApi` matches `MyStack/MyHttpApi/Resource`).
+ *
+ * Routes discovered before this field set was added (or routes where
+ * the synthesized template doesn't carry `aws:cdk:path` metadata —
+ * e.g. hand-rolled `cfn.Resource` defs) silently fall through to the
+ * bare-logical-id-only path so the change is non-breaking.
  *
  * Returns an empty array when no route matches — the caller is
  * responsible for surfacing a "no API matched" error with the list of
@@ -143,29 +158,51 @@ export function filterRoutesByApiIdentifier(
   routes: readonly RouteWithAuth[],
   identifier: string
 ): RouteWithAuth[] {
-  return routes.filter((rwa) => {
-    const r = rwa.route;
-    if (r.source === 'function-url') {
-      return r.lambdaLogicalId === identifier;
-    }
-    return r.apiLogicalId === identifier;
-  });
+  return routes.filter((rwa) => routeMatchesIdentifier(rwa.route, identifier));
+}
+
+/**
+ * Predicate behind {@link filterRoutesByApiIdentifier} and
+ * {@link availableApiIdentifiers}'s primary-form selection. Exported
+ * for test coverage only — the production code path goes through
+ * `filterRoutesByApiIdentifier`.
+ */
+export function routeMatchesIdentifier(
+  route: RouteWithAuth['route'],
+  identifier: string
+): boolean {
+  const bareId = route.source === 'function-url' ? route.lambdaLogicalId : route.apiLogicalId;
+  if (bareId && bareId === identifier) return true;
+  if (route.apiStackName) {
+    if (bareId && identifier === `${route.apiStackName}:${bareId}`) return true;
+  }
+  if (route.apiCdkPath) {
+    if (identifier === route.apiCdkPath) return true;
+    if (route.apiCdkPath.startsWith(`${identifier}/`)) return true;
+  }
+  return false;
 }
 
 /**
  * Enumerate every distinct API identifier in the route list, in the
  * order they were discovered. Useful for the "available APIs" error
  * message when `--api <id>` doesn't match.
+ *
+ * Returns the **primary form** per API (CDK Construct path when
+ * available, else bare logical id) — the "available identifiers" hint
+ * stays compact while pointing users at the form most likely to round-
+ * trip across rename refactors.
  */
 export function availableApiIdentifiers(routes: readonly RouteWithAuth[]): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const rwa of routes) {
     const r = rwa.route;
-    const id = r.source === 'function-url' ? r.lambdaLogicalId : (r.apiLogicalId ?? '<unknown>');
-    if (!seen.has(id)) {
-      seen.add(id);
-      out.push(id);
+    const bareId = r.source === 'function-url' ? r.lambdaLogicalId : (r.apiLogicalId ?? '<unknown>');
+    const primary = r.apiCdkPath ?? bareId;
+    if (!seen.has(primary)) {
+      seen.add(primary);
+      out.push(primary);
     }
   }
   return out;

--- a/src/local/route-discovery.ts
+++ b/src/local/route-discovery.ts
@@ -1,3 +1,4 @@
+import { readCdkPath } from '../cli/cdk-path.js';
 import type { StackInfo } from '../synthesis/assembly-reader.js';
 import type { CloudFormationTemplate, TemplateResource } from '../types/resource.js';
 import { RouteDiscoveryError } from '../utils/error-handler.js';
@@ -54,6 +55,25 @@ export interface DiscoveredRoute {
    */
   apiLogicalId?: string;
   /**
+   * Name of the stack the parent API resource (or backing Lambda for
+   * Function URLs) lives in. Populated for every route so the
+   * `--api` filter can accept the **stack-qualified logical id**
+   * form (`MyStack:MyHttpApi`) — mirrors `cdkd local invoke` /
+   * `cdkd local run-task` target syntax.
+   */
+  apiStackName?: string;
+  /**
+   * CDK Construct path (`aws:cdk:path` metadata) of the parent API
+   * resource (or the backing Lambda for Function URLs). Populated
+   * for every route when the synthesized resource carries the
+   * metadata. Used by `--api` to accept the **CDK display path**
+   * form (`MyStack/MyHttpApi`) with prefix-rule matching (matches
+   * the input exactly OR when the input is the parent L2 path that
+   * resolves down to this resource's L1 child) — mirrors the same
+   * prefix rule `cdkd orphan` uses.
+   */
+  apiCdkPath?: string;
+  /**
    * Stage variables for the route's selected Stage (PR 8c). `null` when
    * the route's Stage has no Variables, or for routes without a Stage
    * (Function URLs). Populated by `attachStageContext` after discovery
@@ -91,7 +111,7 @@ export function discoverRoutes(stacks: readonly StackInfo[]): DiscoveredRoute[] 
             routes.push(...discoverHttpApiRoute(logicalId, resource, template, stack.stackName));
             break;
           case 'AWS::Lambda::Url':
-            routes.push(...discoverFunctionUrl(logicalId, resource, stack.stackName));
+            routes.push(...discoverFunctionUrl(logicalId, resource, template, stack.stackName));
             break;
           default:
             // Filter the known parent types early so we don't log noise.
@@ -174,6 +194,7 @@ function discoverRestV1Method(
 
   const httpMethod = stringifyValue(props['HttpMethod'] ?? 'ANY');
   const stage = pickRestV1Stage(restApiLogicalId, template);
+  const restApiCdkPath = readApiCdkPath(restApiLogicalId, template);
 
   return [
     {
@@ -184,6 +205,8 @@ function discoverRestV1Method(
       apiVersion: 'v1',
       stage,
       apiLogicalId: restApiLogicalId,
+      apiStackName: stackName,
+      ...(restApiCdkPath !== undefined && { apiCdkPath: restApiCdkPath }),
       declaredAt: `${stackName}/${logicalId}`,
     },
   ];
@@ -383,6 +406,7 @@ function discoverHttpApiRoute(
 
   // RouteKey grammar: `<METHOD> <path>` or `$default`.
   const { method, pathPattern } = parseRouteKey(routeKey);
+  const apiCdkPath = readApiCdkPath(apiLogicalId, template);
 
   return [
     {
@@ -393,6 +417,8 @@ function discoverHttpApiRoute(
       apiVersion: 'v2',
       stage: '$default',
       apiLogicalId,
+      apiStackName: stackName,
+      ...(apiCdkPath !== undefined && { apiCdkPath }),
       declaredAt: `${stackName}/${logicalId}`,
     },
   ];
@@ -410,6 +436,7 @@ function discoverHttpApiRoute(
 function discoverFunctionUrl(
   logicalId: string,
   resource: TemplateResource,
+  template: CloudFormationTemplate,
   stackName: string
 ): DiscoveredRoute[] {
   const props = resource.Properties ?? {};
@@ -433,6 +460,10 @@ function discoverFunctionUrl(
     targetArn,
     `${stackName}/${logicalId}.TargetFunctionArn`
   );
+  // Function URLs identify by their backing Lambda — surface the Lambda's
+  // cdk path so `--api MyStack/MyHandler` (the natural CDK Construct path
+  // for the Function, not the auto-generated URL child) matches.
+  const lambdaCdkPath = readApiCdkPath(lambdaLogicalId, template);
 
   return [
     {
@@ -442,9 +473,27 @@ function discoverFunctionUrl(
       source: 'function-url',
       apiVersion: 'v2',
       stage: '$default',
+      apiStackName: stackName,
+      ...(lambdaCdkPath !== undefined && { apiCdkPath: lambdaCdkPath }),
       declaredAt: `${stackName}/${logicalId}`,
     },
   ];
+}
+
+/**
+ * Read the `aws:cdk:path` metadata of the resource at `logicalId`,
+ * returning the empty string when the resource is missing or the
+ * metadata isn't set. Hides the "may be missing for a hand-rolled
+ * `cfn.Resource`" branch from every call site.
+ */
+function readApiCdkPath(
+  logicalId: string,
+  template: CloudFormationTemplate
+): string | undefined {
+  const resource = template.Resources?.[logicalId];
+  if (!resource) return undefined;
+  const path = readCdkPath(resource);
+  return path || undefined;
 }
 
 /**

--- a/src/local/route-discovery.ts
+++ b/src/local/route-discovery.ts
@@ -486,10 +486,7 @@ function discoverFunctionUrl(
  * metadata isn't set. Hides the "may be missing for a hand-rolled
  * `cfn.Resource`" branch from every call site.
  */
-function readApiCdkPath(
-  logicalId: string,
-  template: CloudFormationTemplate
-): string | undefined {
+function readApiCdkPath(logicalId: string, template: CloudFormationTemplate): string | undefined {
   const resource = template.Resources?.[logicalId];
   if (!resource) return undefined;
   const path = readCdkPath(resource);

--- a/tests/unit/local/api-server-grouping.test.ts
+++ b/tests/unit/local/api-server-grouping.test.ts
@@ -17,6 +17,8 @@ function makeRoute(partial: Partial<DiscoveredRoute>): RouteWithAuth {
     stage: partial.stage ?? '$default',
     declaredAt: partial.declaredAt ?? 'Stack/Method',
     ...(partial.apiLogicalId !== undefined && { apiLogicalId: partial.apiLogicalId }),
+    ...(partial.apiStackName !== undefined && { apiStackName: partial.apiStackName }),
+    ...(partial.apiCdkPath !== undefined && { apiCdkPath: partial.apiCdkPath }),
   };
   return { route, authorizer: undefined };
 }
@@ -93,32 +95,133 @@ describe('groupRoutesByServer', () => {
 
 describe('filterRoutesByApiIdentifier', () => {
   const routes = [
-    makeRoute({ source: 'http-api', apiLogicalId: 'PublicApi', pathPattern: '/p' }),
-    makeRoute({ source: 'http-api', apiLogicalId: 'AdminApi', pathPattern: '/a' }),
-    makeRoute({ source: 'function-url', lambdaLogicalId: 'GoHandler', apiLogicalId: undefined }),
+    makeRoute({
+      source: 'http-api',
+      apiLogicalId: 'PublicApi',
+      apiStackName: 'WebStack',
+      apiCdkPath: 'WebStack/PublicApi/Resource',
+      pathPattern: '/p',
+    }),
+    makeRoute({
+      source: 'http-api',
+      apiLogicalId: 'AdminApi',
+      apiStackName: 'AdminStack',
+      apiCdkPath: 'AdminStack/AdminApi/Resource',
+      pathPattern: '/a',
+    }),
+    makeRoute({
+      source: 'function-url',
+      lambdaLogicalId: 'GoHandler',
+      apiLogicalId: undefined,
+      apiStackName: 'BackendStack',
+      apiCdkPath: 'BackendStack/GoHandler',
+    }),
   ];
 
-  it('matches HTTP API by apiLogicalId', () => {
+  it('matches HTTP API by bare logical id (form 1)', () => {
     const result = filterRoutesByApiIdentifier(routes, 'PublicApi');
     expect(result).toHaveLength(1);
     expect(result[0]!.route.apiLogicalId).toBe('PublicApi');
   });
 
-  it('matches Function URLs by backing Lambda logical id', () => {
+  it('matches Function URLs by backing Lambda logical id (form 1)', () => {
     const result = filterRoutesByApiIdentifier(routes, 'GoHandler');
     expect(result).toHaveLength(1);
     expect(result[0]!.route.source).toBe('function-url');
   });
 
+  it('matches HTTP API by stack-qualified logical id (form 2)', () => {
+    const result = filterRoutesByApiIdentifier(routes, 'WebStack:PublicApi');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.route.apiLogicalId).toBe('PublicApi');
+  });
+
+  it('matches Function URL by stack-qualified Lambda logical id (form 2)', () => {
+    const result = filterRoutesByApiIdentifier(routes, 'BackendStack:GoHandler');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.route.source).toBe('function-url');
+  });
+
+  it('matches HTTP API by exact CDK Construct path (form 3)', () => {
+    const result = filterRoutesByApiIdentifier(routes, 'WebStack/PublicApi/Resource');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.route.apiLogicalId).toBe('PublicApi');
+  });
+
+  it('matches Function URL by exact CDK Construct path (form 3)', () => {
+    const result = filterRoutesByApiIdentifier(routes, 'BackendStack/GoHandler');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.route.source).toBe('function-url');
+  });
+
+  it('matches HTTP API by L2 Construct-path prefix → synthesized L1 child (form 4)', () => {
+    // CDK's `new apigatewayv2.HttpApi(stack, 'PublicApi')` emits L1 child
+    // at `WebStack/PublicApi/Resource`; users would type the L2 path
+    // `WebStack/PublicApi` and expect prefix-rule resolution — same UX
+    // as `cdkd orphan`.
+    const result = filterRoutesByApiIdentifier(routes, 'WebStack/PublicApi');
+    expect(result).toHaveLength(1);
+    expect(result[0]!.route.apiLogicalId).toBe('PublicApi');
+  });
+
+  it('does NOT prefix-match on partial path component (boundary check)', () => {
+    // `WebStack/Public` is a partial component of `WebStack/PublicApi/...`,
+    // NOT an ancestor cdk path — must not match. The trailing-`/` rule
+    // protects against this.
+    expect(filterRoutesByApiIdentifier(routes, 'WebStack/Public')).toEqual([]);
+  });
+
   it('returns an empty array on no match (caller surfaces error)', () => {
     expect(filterRoutesByApiIdentifier(routes, 'Nope')).toEqual([]);
+  });
+
+  it('falls back to bare-logical-id-only when apiCdkPath/apiStackName are missing', () => {
+    // Backward compat: routes discovered from a synthesized template
+    // without `aws:cdk:path` metadata (e.g. hand-rolled `cfn.Resource`)
+    // keep the pre-PR behavior — bare logical id matches, but the new
+    // forms don't.
+    const sparse = [
+      makeRoute({ source: 'http-api', apiLogicalId: 'BareApi', pathPattern: '/b' }),
+    ];
+    expect(filterRoutesByApiIdentifier(sparse, 'BareApi')).toHaveLength(1);
+    expect(filterRoutesByApiIdentifier(sparse, 'Stack:BareApi')).toEqual([]);
+    expect(filterRoutesByApiIdentifier(sparse, 'Stack/BareApi')).toEqual([]);
   });
 });
 
 describe('availableApiIdentifiers', () => {
-  it('returns distinct identifiers in first-seen order', () => {
+  it('returns CDK Construct path when present (preferred primary form)', () => {
     const routes = [
-      makeRoute({ source: 'http-api', apiLogicalId: 'PublicApi' }),
+      makeRoute({
+        source: 'http-api',
+        apiLogicalId: 'PublicApi',
+        apiCdkPath: 'WebStack/PublicApi/Resource',
+      }),
+      makeRoute({
+        source: 'http-api',
+        apiLogicalId: 'PublicApi',
+        apiCdkPath: 'WebStack/PublicApi/Resource',
+      }),
+      makeRoute({
+        source: 'http-api',
+        apiLogicalId: 'AdminApi',
+        apiCdkPath: 'AdminStack/AdminApi/Resource',
+      }),
+      makeRoute({
+        source: 'function-url',
+        lambdaLogicalId: 'GoHandler',
+        apiCdkPath: 'BackendStack/GoHandler',
+      }),
+    ];
+    expect(availableApiIdentifiers(routes)).toEqual([
+      'WebStack/PublicApi/Resource',
+      'AdminStack/AdminApi/Resource',
+      'BackendStack/GoHandler',
+    ]);
+  });
+
+  it('falls back to bare logical id when apiCdkPath is missing', () => {
+    const routes = [
       makeRoute({ source: 'http-api', apiLogicalId: 'PublicApi' }),
       makeRoute({ source: 'http-api', apiLogicalId: 'AdminApi' }),
       makeRoute({ source: 'function-url', lambdaLogicalId: 'GoHandler' }),

--- a/tests/unit/local/route-discovery.test.ts
+++ b/tests/unit/local/route-discovery.test.ts
@@ -62,6 +62,7 @@ describe('discoverRoutes — REST v1', () => {
         apiVersion: 'v1',
         stage: 'prod',
         apiLogicalId: 'Api',
+        apiStackName: 'S',
         declaredAt: 'S/Method',
       },
     ]);
@@ -371,6 +372,7 @@ describe('discoverRoutes — HTTP API v2', () => {
       apiVersion: 'v2',
       stage: '$default',
       apiLogicalId: 'Api',
+      apiStackName: 'S',
       declaredAt: 'S/Route',
     });
   });
@@ -485,6 +487,7 @@ describe('discoverRoutes — Function URL', () => {
       source: 'function-url',
       apiVersion: 'v2',
       stage: '$default',
+      apiStackName: 'S',
       declaredAt: 'S/Url',
     });
   });
@@ -511,6 +514,117 @@ describe('discoverRoutes — Function URL', () => {
       },
     });
     expect(() => discoverRoutes([stack])).toThrow(RouteDiscoveryError);
+  });
+});
+
+describe('discoverRoutes — aws:cdk:path propagation', () => {
+  // The discovery layer surfaces the parent API's (or the backing
+  // Lambda's, for Function URLs) `aws:cdk:path` Metadata so the
+  // `--api` filter in `filterRoutesByApiIdentifier` can accept the
+  // CDK Construct path form — same UX rule the rest of `cdkd local *`
+  // family uses.
+
+  it('propagates RestApi aws:cdk:path to REST v1 routes', () => {
+    const stack = buildStack('S', {
+      Api: {
+        Type: 'AWS::ApiGateway::RestApi',
+        Properties: {},
+        Metadata: { 'aws:cdk:path': 'WebStack/MyRestApi/Resource' },
+      },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'AWS_PROXY',
+            Uri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+          },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0]!;
+    expect(route.apiCdkPath).toBe('WebStack/MyRestApi/Resource');
+    expect(route.apiStackName).toBe('S');
+  });
+
+  it('propagates HTTP API aws:cdk:path to v2 routes', () => {
+    const stack = buildStack('S', {
+      Api: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: { ProtocolType: 'HTTP' },
+        Metadata: { 'aws:cdk:path': 'WebStack/MyHttpApi/Resource' },
+      },
+      Integ: {
+        Type: 'AWS::ApiGatewayV2::Integration',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          IntegrationType: 'AWS_PROXY',
+          IntegrationUri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+        },
+      },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'Api' },
+          RouteKey: 'GET /items',
+          Target: { 'Fn::Join': ['/', ['integrations', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0]!;
+    expect(route.apiCdkPath).toBe('WebStack/MyHttpApi/Resource');
+    expect(route.apiStackName).toBe('S');
+  });
+
+  it('propagates the BACKING LAMBDA aws:cdk:path to Function URLs (not the URL resource)', () => {
+    // For Function URLs, the natural CDK Construct path is the
+    // Function's path (the URL is an auto-generated child). Users
+    // expect `--api MyStack/MyHandler` to match — so surface the
+    // Lambda's cdk path, not the URL's own.
+    const stack = buildStack('S', {
+      Fn: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {},
+        Metadata: { 'aws:cdk:path': 'BackendStack/GoHandler/Resource' },
+      },
+      Url: {
+        Type: 'AWS::Lambda::Url',
+        Properties: { AuthType: 'NONE', TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] } },
+        Metadata: { 'aws:cdk:path': 'BackendStack/GoHandler/FunctionUrl' },
+      },
+    });
+    const route = discoverRoutes([stack])[0]!;
+    expect(route.source).toBe('function-url');
+    expect(route.apiCdkPath).toBe('BackendStack/GoHandler/Resource');
+    expect(route.apiStackName).toBe('S');
+  });
+
+  it('omits apiCdkPath when the parent resource has no aws:cdk:path metadata', () => {
+    // Backward compat path — hand-rolled CFn resources or templates
+    // without the metadata stay matchable by bare logical id (and
+    // by stack-qualified logical id, since `apiStackName` is always
+    // set from the StackInfo).
+    const stack = buildStack('S', {
+      Api: { Type: 'AWS::ApiGateway::RestApi', Properties: {} },
+      Method: {
+        Type: 'AWS::ApiGateway::Method',
+        Properties: {
+          HttpMethod: 'GET',
+          RestApiId: { Ref: 'Api' },
+          ResourceId: { 'Fn::GetAtt': ['Api', 'RootResourceId'] },
+          Integration: {
+            Type: 'AWS_PROXY',
+            Uri: { 'Fn::GetAtt': ['Handler', 'Arn'] },
+          },
+        },
+      },
+    });
+    const route = discoverRoutes([stack])[0]!;
+    expect(route.apiCdkPath).toBeUndefined();
+    expect(route.apiStackName).toBe('S');
+    expect(route.apiLogicalId).toBe('Api');
   });
 });
 


### PR DESCRIPTION
## Summary

`cdkd local start-api --api <id>` pre-fix accepted only the bare CDK logical id, while the rest of the `cdkd local *` family (`local invoke <target>` / `local run-task <target>`) accepted three forms via the shared prefix-rule pattern. Asymmetric UX trap: typing `--api MyStack/MyHttpApi` (the natural Construct path users see in their CDK code) hit "did not match any discovered API".

This PR aligns `--api` with the rest of the family. Four accepted forms (the path-prefix rule mirrors `cdkd orphan`):

| Form | Example |
| --- | --- |
| Bare logical id | `MyHttpApi` |
| Stack-qualified logical id | `MyStack:MyHttpApi` |
| Full CDK Construct path | `MyStack/MyHttpApi/Resource` |
| Ancestor Construct path (prefix-matched) | `MyStack/MyHttpApi` → matches the synthesized L1 child at `MyStack/MyHttpApi/Resource` |

For Function URLs, the path forms reference the **backing Lambda's** `aws:cdk:path`, not the auto-generated URL child — so `--api MyStack/MyHandler` matches a Function URL declared by `new lambda.Function(this, 'MyHandler').addFunctionUrl()`.

## Implementation

- `DiscoveredRoute` gains two optional fields: `apiStackName` (always populated) and `apiCdkPath` (populated from the parent API's — or backing Lambda's — `aws:cdk:path` Metadata when present).
- `filterRoutesByApiIdentifier` rewritten to try every form. Falls back to bare-logical-id matching when the new fields are absent (template without `aws:cdk:path` — e.g. hand-rolled `cfn.Resource` defs) → **non-breaking**.
- `availableApiIdentifiers` (the "no API matched" error hint) prefers the CDK Construct path when available — the form most likely to round-trip across rename refactors.

## Backward compatibility

- Pre-existing routes match by bare logical id (form 1) and stack-qualified logical id (form 2) regardless of metadata.
- Existing CI / docs / scripts using `--api <bare-logical-id>` work unchanged (form 1 is tried first).

## Docs

- `docs/local-emulation.md` `--api` flag description rewritten with all four forms + the Function URL caveat.
- `README.md` start-api section adds a `--api MyStack/MyHttpApi` Construct-path example next to the bare-logical-id one.
- CLI option help string (`cdkd local start-api --help`) enumerates all four forms.

## Test plan

- [x] typecheck / lint / build / tests (3222 / 270 files) pass — 12 net-new tests
- [x] 11 new tests in `tests/unit/local/api-server-grouping.test.ts` covering every accepted form + path-prefix boundary + backward-compat fallback
- [x] 4 new tests in `tests/unit/local/route-discovery.test.ts` for `aws:cdk:path` metadata propagation (REST v1 / HTTP API / Function URL / no-metadata)
- [x] Pre-existing 17 grouping tests + 21 route-discovery tests still pass unchanged
- [x] Full suite green (3222 tests)
