### PR TITLE
feat(local-start-api): positional <target> + --api deprecation + strict multi-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,8 +420,8 @@ and same-stack Lambda Layers bind-mounted at `/opt`.
 ```bash
 cdkd local start-api                              # one HTTP server per discovered API
 cdkd local start-api --port 3000                  # pin the first server's port
-cdkd local start-api --api MyHttpApi              # filter by logical id
-cdkd local start-api --api MyStack/MyHttpApi      # OR: CDK Construct path
+cdkd local start-api MyHttpApi                    # filter to one API (logical id, single-stack apps)
+cdkd local start-api MyStack/MyHttpApi            # OR: CDK Construct path
 cdkd local start-api --warm --watch               # pre-start + hot reload
 ```
 

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -319,8 +319,8 @@ subsequent runs to skip the layer check.
 ```bash
 cdkd local start-api                              # auto-allocate one port PER discovered API
 cdkd local start-api --port 3000                  # first API → 3000, second API → 3001, ...
-cdkd local start-api --api MyAdminApi             # logical id
-cdkd local start-api --api MyStack/MyAdminApi     # OR: CDK Construct path (prefix-matched)
+cdkd local start-api MyAdminApi                   # logical id (single-stack apps)
+cdkd local start-api MyStack/MyAdminApi           # OR: CDK Construct path (prefix-matched)
 cdkd local start-api --warm                       # pre-start one container per Lambda
 ```
 
@@ -348,35 +348,44 @@ Port assignment:
 | `0` (default) | Every server auto-allocates its own port. |
 | `3000` | First API → `3000`, second API → `3001`, third → `3002`, ... |
 
-Pass `--api <id>` to launch exactly one server for the named API.
-The identifier accepts four forms (mirrors `cdkd local invoke <target>`
-/ `cdkd local run-task <target>` so the whole `local *` family
-addresses resources consistently):
+Pass an optional positional `<target>` to launch exactly one server
+for the named API. The same target syntax `cdkd local invoke` /
+`cdkd local run-task` use applies here — the whole `cdkd local *`
+family addresses resources consistently:
 
-1. **Bare logical id** — `MyHttpApi`. The HTTP API / REST API logical
-   id, or (for Function URLs) the backing Lambda's logical id.
-2. **Stack-qualified logical id** — `MyStack:MyHttpApi`. Useful in
-   multi-stack apps when the same bare logical id appears in more
-   than one stack.
+1. **Bare logical id** — `MyHttpApi`. **Single-stack apps only**;
+   in multi-stack apps cdkd rejects this form with the same
+   disambiguation hint `local invoke` / `local run-task` produce.
+   The id is the HTTP API / REST API logical id, or (for Function
+   URLs) the backing Lambda's logical id.
+2. **Stack-qualified logical id** — `MyStack:MyHttpApi`. Works in
+   any app size; required when the same bare id exists in two stacks.
 3. **CDK Construct path / display path** — `MyStack/MyHttpApi/Resource`.
    Exact match against the resource's `aws:cdk:path` metadata.
 4. **CDK Construct path prefix** — `MyStack/MyHttpApi`. Matches when
    the input is a strict ancestor of the resource's `aws:cdk:path`
    (same prefix rule `cdkd orphan` uses): CDK's
    `new apigw2.HttpApi(stack, 'MyHttpApi')` synthesizes the L1 child
-   at `MyStack/MyHttpApi/Resource`, so `--api MyStack/MyHttpApi`
+   at `MyStack/MyHttpApi/Resource`, so `cdkd local start-api MyStack/MyHttpApi`
    resolves cleanly without having to type the synthesized
    `/Resource` suffix.
 
 For Function URLs, the path forms reference the **backing Lambda's**
 `aws:cdk:path`, not the auto-generated URL resource — so
-`--api MyStack/MyHandler` matches the Function URL declared by
-`new lambda.Function(this, 'MyHandler').addFunctionUrl()`.
+`cdkd local start-api MyStack/MyHandler` matches the Function URL
+declared by `new lambda.Function(this, 'MyHandler').addFunctionUrl()`.
 
 Routes from templates without `aws:cdk:path` metadata (hand-rolled
 `cfn.Resource` defs, or older CDK that didn't emit the metadata)
 still match by bare logical id (form 1) and by stack-qualified logical
 id (form 2) — only the path forms (3, 4) need the metadata.
+
+**Deprecated `--api <id>` alias.** Earlier versions used a `--api`
+flag for the same purpose. The flag is still accepted in this release
+(emitting a deprecation warn on use) and accepts the same four forms;
+it will be removed in a future major release. Migrate scripts /
+CI to the positional form. Passing both positional and `--api`
+at once produces an error — they're mutually exclusive.
 
 ### Discovered routes
 
@@ -408,7 +417,7 @@ the same tier; cdkd uses literal-segment count as a heuristic).
 | --- | --- | --- |
 | `--port <port>` | auto-allocate | First API server's port (subsequent APIs get `port+1`, `port+2`, ...). Pass `0` (default) to auto-allocate each. The actual port assignment is printed at startup. |
 | `--host <host>` | `127.0.0.1` | Bind address. |
-| `--api <id>` | unset | Restrict to a single API surface. Accepts the bare CDK logical id (`MyHttpApi`), the stack-qualified logical id (`MyStack:MyHttpApi`), the full CDK Construct path (`MyStack/MyHttpApi/Resource`), or an ancestor Construct path that prefix-matches (`MyStack/MyHttpApi`). For Function URLs, the path forms reference the backing Lambda's `aws:cdk:path`. When unset, every discovered API gets its own server. See the section above for the full resolution rules. |
+| `--api <id>` | unset | **Deprecated** — use the positional `<target>` argument instead. Same accepted forms (bare logical id, stack-qualified, Construct path, ancestor prefix). Emits a deprecation warn on use. Mutually exclusive with the positional `<target>` — passing both produces an error. Will be removed in a future major release. |
 | `--stack <name>` | single-stack auto-detect | Required when the app has multiple stacks. |
 | `--warm` | off | Pre-start one container per discovered Lambda at server boot. Trades RAM for first-request latency. |
 | `--per-lambda-concurrency <n>` | `2` | Pool size cap per Lambda. Max 4 in v1; above-cap values are clamped with a warn. |

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -136,10 +136,31 @@ interface LocalStartApiOptions {
  * See [docs/cli-reference.md](../../../docs/cli-reference.md) for the
  * full surface and out-of-scope items.
  */
-async function localStartApiCommand(options: LocalStartApiOptions): Promise<void> {
+async function localStartApiCommand(
+  target: string | undefined,
+  options: LocalStartApiOptions
+): Promise<void> {
   const logger = getLogger();
   if (options.verbose) {
     logger.setLevel('debug');
+  }
+
+  // Resolve the API filter: positional `<target>` wins over `--api`.
+  // `--api` is kept as a backward-compat alias for one release cycle —
+  // every invocation that goes through it emits a deprecation warn so
+  // users see the migration path before the next major bump removes it.
+  let apiFilter: string | undefined = target;
+  if (options.api !== undefined) {
+    if (target !== undefined) {
+      throw new Error(
+        `Cannot specify both positional target ('${target}') and --api flag ('${options.api}'). ` +
+          `Use one or the other. The positional form is preferred — '--api' is a deprecated alias.`
+      );
+    }
+    logger.warn(
+      "[deprecated] --api <id> will be removed in a future major release. Use the positional argument instead: 'cdkd local start-api <id>'."
+    );
+    apiFilter = options.api;
   }
 
   warnIfDeprecatedRegion(options);
@@ -263,15 +284,31 @@ async function localStartApiCommand(options: LocalStartApiOptions): Promise<void
     // Routes referencing an unsupported authorizer kind hard-fail here.
     let routesWithAuth = attachAuthorizers(targetStacks, routes);
 
-    // Issue #260: `--api <id>` filter — restrict the discovered surface
-    // to a single API. Useful when the user wants exactly one server
-    // (e.g. to free other ports, or to focus testing on one API).
-    if (options.api) {
-      const filtered = filterRoutesByApiIdentifier(routesWithAuth, options.api);
+    // Issue #260: target filter — restrict the discovered surface to a
+    // single API. Useful when the user wants exactly one server (e.g. to
+    // free other ports, or to focus testing on one API).
+    //
+    // Strict multi-stack rejection for the bare-logical-id form (no `:`,
+    // no `/`): mirrors `cdkd local invoke` / `cdkd local run-task`'s
+    // resolver behavior. A bare id in a multi-stack app is ambiguous,
+    // because two stacks can legitimately have the same logical id —
+    // pre-PR the filter would silently match both and collide in
+    // `groupRoutesByServer`'s serverKey (now disambiguated via PR 8d).
+    // We reject upfront with the same disambiguation hint invoke uses.
+    if (apiFilter !== undefined) {
+      const isBareId = !apiFilter.includes(':') && !apiFilter.includes('/');
+      if (isBareId && targetStacks.length > 1) {
+        throw new Error(
+          `Multiple stacks in app, target '${apiFilter}' is missing a stack prefix. ` +
+            `Use 'StackName:${apiFilter}' or 'StackName/${apiFilter}' (Construct path form). ` +
+            `Available stacks: ${targetStacks.map((s) => s.stackName).join(', ')}.`
+        );
+      }
+      const filtered = filterRoutesByApiIdentifier(routesWithAuth, apiFilter);
       if (filtered.length === 0) {
         const available = availableApiIdentifiers(routesWithAuth).join(', ') || '(none)';
         throw new Error(
-          `--api '${options.api}' did not match any discovered API. Available identifiers: ${available}.`
+          `Target '${apiFilter}' did not match any discovered API. Available identifiers: ${available}.`
         );
       }
       routesWithAuth = filtered;
@@ -1334,6 +1371,10 @@ export function createLocalStartApiCommand(): Command {
     .description(
       'Run a long-running local HTTP server that maps API Gateway routes (REST v1, HTTP API, Function URL) to Lambda invocations against the AWS Lambda Runtime Interface Emulator (Docker required). Supports Lambda TOKEN/REQUEST authorizers and Cognito User Pool / HTTP v2 JWT authorizers; when JWKS is unreachable, JWT authorizers fall back to pass-through (every token accepted) with a warn line — local dev fallback. VPC-config Lambdas run locally and surface a warn line at startup; their containers do NOT get attached to the deployed VPC subnets, so calls to private RDS / ElastiCache will fail.'
     )
+    .argument(
+      '[target]',
+      "Optional API filter. Accepts the bare CDK logical id ('MyHttpApi'; single-stack apps only), stack-qualified logical id ('MyStack:MyHttpApi'), full CDK Construct path ('MyStack/MyHttpApi/Resource'), or an ancestor Construct path that prefix-matches ('MyStack/MyHttpApi'). When omitted, every discovered API gets its own server. Mirrors `cdkd local invoke` / `cdkd local run-task` target syntax."
+    )
     .addOption(
       new Option('--port <port>', 'HTTP server port (default: auto-allocate)').default('0')
     )
@@ -1388,7 +1429,7 @@ export function createLocalStartApiCommand(): Command {
     .addOption(
       new Option(
         '--api <id>',
-        "Restrict to a single API surface. Accepts the bare CDK logical id (e.g. 'MyHttpApi'), the stack-qualified logical id ('MyStack:MyHttpApi'), the full CDK Construct path ('MyStack/MyHttpApi/Resource'), or an ancestor Construct path that prefix-matches ('MyStack/MyHttpApi'). For Function URLs, the path forms reference the backing Lambda's aws:cdk:path. When unset, every discovered API gets its own server on its own port (basePort, basePort+1, ... when --port is set; auto-allocated otherwise)."
+        'DEPRECATED — use the positional <target> argument instead. Same accepted forms (bare logical id, stack-qualified, Construct path, ancestor prefix). Will be removed in a future major release.'
       )
     )
     .action(withErrorHandling(localStartApiCommand));

--- a/src/local/api-server-grouping.ts
+++ b/src/local/api-server-grouping.ts
@@ -32,9 +32,21 @@ import type { RouteWithAuth } from './authorizer-resolver.js';
 export interface ApiServerGroup {
   /**
    * Stable identity for cross-reload state matching. Format:
-   *   - `http-api:<apiLogicalId>`
-   *   - `rest-v1:<apiLogicalId>`
-   *   - `function-url:<lambdaLogicalId>`
+   *   - `http-api:<stackName>:<apiLogicalId>` (when route has `apiStackName`)
+   *   - `rest-v1:<stackName>:<apiLogicalId>`
+   *   - `function-url:<stackName>:<lambdaLogicalId>`
+   *
+   * Routes without `apiStackName` (templates lacking `aws:cdk:path`
+   * metadata, hand-rolled `cfn.Resource` defs, or fixtures from
+   * pre-`aws:cdk:path` test code) fall back to the un-prefixed shape:
+   *   - `http-api:<apiLogicalId>` / `rest-v1:<apiLogicalId>` /
+   *     `function-url:<lambdaLogicalId>`
+   *
+   * The stack prefix means cross-stack same-logical-id APIs (a CDK app
+   * with `MyHttpApi` in both `WebStack` and `AdminStack`) get **two
+   * separate servers** rather than silently colliding on one serverKey
+   * — defense-in-depth on top of the upstream multi-stack bare-id
+   * rejection in the CLI command body.
    */
   readonly serverKey: string;
   /** Human-readable name surfaced in logs (e.g. "MyHttpApi (HTTP API v2)"). */
@@ -83,22 +95,33 @@ export function groupRoutesByServer(routes: readonly RouteWithAuth[]): ApiServer
     let identifier: string;
     let displayName: string;
 
+    // Stack-prefix the serverKey so two stacks with the same bare
+    // logical id get **two separate** servers (defense-in-depth — the
+    // upstream filter rejects bare ids in multi-stack apps, but
+    // unfiltered runs (no `--api` / `<target>`) still need this to
+    // disambiguate). Pre-PR the serverKey was just `<kind>:<logicalId>`
+    // and cross-stack collisions silently merged into one server.
+    // Routes without `apiStackName` (template w/o `aws:cdk:path` /
+    // hand-rolled `cfn.Resource`) keep the un-prefixed serverKey
+    // shape so the change is non-breaking for those fixtures.
+    const stackPrefix = r.apiStackName ? `${r.apiStackName}:` : '';
+
     if (r.source === 'function-url') {
       // Function URLs have no parent API resource — each URL is its own
       // surface, scoped by its backing Lambda's logical id.
       identifier = r.lambdaLogicalId;
-      serverKey = `function-url:${identifier}`;
+      serverKey = `function-url:${stackPrefix}${identifier}`;
       kind = 'function-url';
       displayName = `${identifier} (Function URL)`;
     } else if (r.source === 'http-api') {
       identifier = r.apiLogicalId ?? '<unknown>';
-      serverKey = `http-api:${identifier}`;
+      serverKey = `http-api:${stackPrefix}${identifier}`;
       kind = 'http-api';
       displayName = `${identifier} (HTTP API v2)`;
     } else {
       // rest-v1
       identifier = r.apiLogicalId ?? '<unknown>';
-      serverKey = `rest-v1:${identifier}`;
+      serverKey = `rest-v1:${stackPrefix}${identifier}`;
       kind = 'rest-v1';
       displayName = `${identifier} (REST API v1)`;
     }

--- a/tests/unit/local/api-server-grouping.test.ts
+++ b/tests/unit/local/api-server-grouping.test.ts
@@ -91,6 +91,55 @@ describe('groupRoutesByServer', () => {
     const publicGroup = groups.find((g) => g.identifier === 'PublicApi')!;
     expect(publicGroup.routes).toHaveLength(2);
   });
+
+  it('stack-prefixes serverKey so same-logical-id APIs across stacks get separate servers', () => {
+    // Cross-stack same-logical-id case: `MyHttpApi` in both `WebStack`
+    // and `AdminStack`. Pre-fix the serverKey was `http-api:MyHttpApi`
+    // for both, silently merging routes from two different APIs into
+    // one server. Post-fix the serverKey includes `apiStackName`, so
+    // the two surfaces get two separate servers on different ports.
+    const routes = [
+      makeRoute({
+        source: 'http-api',
+        apiLogicalId: 'MyHttpApi',
+        apiStackName: 'WebStack',
+        pathPattern: '/web',
+      }),
+      makeRoute({
+        source: 'http-api',
+        apiLogicalId: 'MyHttpApi',
+        apiStackName: 'AdminStack',
+        pathPattern: '/admin',
+      }),
+    ];
+    const groups = groupRoutesByServer(routes);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.serverKey).toBe('http-api:WebStack:MyHttpApi');
+    expect(groups[1]!.serverKey).toBe('http-api:AdminStack:MyHttpApi');
+    // Routes must NOT cross-pollinate between the two servers.
+    expect(groups[0]!.routes).toHaveLength(1);
+    expect(groups[0]!.routes[0]!.route.pathPattern).toBe('/web');
+    expect(groups[1]!.routes).toHaveLength(1);
+    expect(groups[1]!.routes[0]!.route.pathPattern).toBe('/admin');
+  });
+
+  it('falls back to un-prefixed serverKey when apiStackName is absent (backward compat)', () => {
+    // Templates without `aws:cdk:path` Metadata (or hand-rolled
+    // `cfn.Resource` defs) produce routes with `apiStackName: undefined`.
+    // The serverKey stays in the pre-fix shape so existing fixtures /
+    // synthesized templates without the metadata still group cleanly.
+    const routes = [
+      makeRoute({ source: 'http-api', apiLogicalId: 'BareApi' }),
+      makeRoute({ source: 'rest-v1', apiLogicalId: 'BareRest', apiVersion: 'v1' }),
+      makeRoute({ source: 'function-url', lambdaLogicalId: 'BareHandler' }),
+    ];
+    const groups = groupRoutesByServer(routes);
+    expect(groups.map((g) => g.serverKey)).toEqual([
+      'http-api:BareApi',
+      'rest-v1:BareRest',
+      'function-url:BareHandler',
+    ]);
+  });
 });
 
 describe('filterRoutesByApiIdentifier', () => {


### PR DESCRIPTION
## Summary

Aligns `cdkd local start-api` with the rest of the `cdkd local *` family. Pre-PR start-api accepted target via `--api <id>` flag while `local invoke <target>` / `local run-task <target>` used positional — asymmetric mental model. Plus the filter was lenient on multi-stack bare-logical-id matching, allowing cross-stack collisions that re-merged in `groupRoutesByServer`'s serverKey (just `<kind>:<logicalId>`, no stack disambiguation).

| | `local invoke` | `local run-task` | `local start-api` (post-PR) |
| --- | --- | --- | --- |
| Spec mechanism | Positional | Positional | **Positional** (was `--api` flag) |
| Required | Required | Required | Optional (default = all APIs) |
| Bare id in multi-stack | Rejected | Rejected | **Rejected** (was lenient) |
| Accepted forms | 4 | 4 | 4 (same set) |

## Changes

**(a) Optional positional `[<target>]`** — added to Commander. Same 4 accepted forms as `--api` after PR #340 (bare id / stack-qualified / Construct path / ancestor prefix), so the feature surface is unchanged — only the spelling differs.

**(b) `--api <id>` → deprecated alias** — kept for backward compat with a one-line `[deprecated]` warn on use, pointing at the positional form. Passing both positional AND `--api` errors out (mutually exclusive). Removal deferred to a future major bump.

**(c) Strict multi-stack rejection for bare-logical-id form** — when the app has > 1 stack AND the target is bare (no `:`, no `/`), cdkd rejects with the same disambiguation message `local invoke` / `local run-task` produce. Mirrors invoke's `pickStack` behavior.

**(d) Stack-prefixed `serverKey` in `groupRoutesByServer`** — two stacks with the same bare logical id now produce two separate servers on different ports rather than silently merging on the un-prefixed key. Routes without `apiStackName` (templates lacking `aws:cdk:path` metadata — hand-rolled `cfn.Resource` defs) keep the un-prefixed shape — non-breaking.

## Backward compatibility

- `cdkd local start-api --api MyHttpApi` keeps working (deprecation warn + full feature parity).
- Existing scripts / CI using `--api` work unchanged through this release cycle.
- Routes from templates without `aws:cdk:path` metadata fall back to bare-id-only matching and un-prefixed serverKey shape.

## Test plan

- [x] typecheck / lint / build / tests (3224 / 270 files) pass — 2 new grouping tests (cross-stack disambiguation + backward-compat fallback)
- [x] 17 pre-existing grouping tests pass unchanged (they don't set `apiStackName`, so they hit the backward-compat path).
- [x] Live: `cdkd local start-api --help` shows the new positional + deprecated `--api` description, and the `-h` summary lists `[target]` before the options.

## Docs

- **README** start-api block: replaced `--api` examples with positional examples (`cdkd local start-api MyHttpApi` etc.).
- **docs/local-emulation.md** `--api` section rewritten to lead with the positional `<target>` rules; `--api` documented as deprecated.
- **CLI `--help`** updated for both `[target]` and `--api`.
