### PR TITLE
docs(readme): CFn-migration prose in import section + --include-non-importable in export section

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,16 @@ v1 scope notes.
 `cdk deploy`, manual creation, or another tool) into cdkd state so the
 next `cdkd deploy` updates them in-place instead of CREATEing duplicates.
 
+`cdkd import --migrate-from-cloudformation` extends this to migrate a
+**whole CloudFormation stack** off CFn in a single command: cdkd reads
+the source CFn stack's `(logicalId, physicalId)` mappings, adopts every
+resource into cdkd state, then retires the source CFn stack (injects
+`DeletionPolicy: Retain` + `UpdateReplacePolicy: Retain` on every
+resource → `UpdateStack` → `DeleteStack`) so the AWS resources stay
+intact but are no longer tracked by CFn. After the command finishes,
+the stack is managed by `cdkd deploy`. This is the reverse direction
+of `cdkd export` (see below).
+
 ```bash
 # Adopt a whole stack previously deployed by cdk deploy (tag-based auto-lookup).
 cdkd import MyStack --yes
@@ -479,17 +489,28 @@ AWS resources are unchanged across the migration; cdkd state for the
 exported stack is deleted on success. From then on the stack is managed
 by `cdk deploy` / `aws cloudformation`.
 
+Lambda-backed Custom Resources (`Custom::*` and
+`AWS::CloudFormation::CustomResource`) are NOT directly CFn-importable.
+`cdkd export --include-non-importable` opts into a 2-phase migration
+to handle them: phase 1 IMPORT changeset adopts every importable
+resource, then phase 2 UPDATE changeset re-CREATEs the Custom Resources
+through CFn — which re-invokes each backing Lambda's onCreate handler.
+The Custom Resource Lambda must be idempotent AND must POST to
+`event.ResponseURL` per the cfn-response protocol. Without the flag,
+the command refuses to proceed and the user is expected to destroy
+the offending resources (or accept abandoning them) first. Nested
+`AWS::CloudFormation::Stack` references always block (CFn can neither
+adopt nor recreate them).
+
 ```bash
 cdkd export MyStack                           # confirmation prompt; CFn stack name = cdkd stack name
 cdkd export MyStack --cfn-stack-name MyStack-CFn
 cdkd export MyStack --dry-run                 # print the import plan, do not call CFn
 cdkd export MyStack --template path.json      # skip synth, use a pre-rendered JSON template
+cdkd export MyStack --include-non-importable  # 2-phase: IMPORT importable + CFn-CREATE Custom Resources
 ```
 
-MVP scope: JSON templates only (CDK-generated). The command refuses to
-proceed if any resource is not CFn-importable (Lambda-backed Custom
-Resources, nested `AWS::CloudFormation::Stack` references); destroy or
-accept abandoning those resources first.
+MVP scope: JSON templates only (CDK-generated).
 
 ## Drift detection
 


### PR DESCRIPTION
## Summary

User-noticed gaps in README's import / export sections:

- **Importing existing resources** had `cdkd import --migrate-from-cloudformation` in the command example but **no prose** mentioning that the command can migrate a whole CloudFormation stack off CFn — readers scanning prose only miss this capability entirely.
- **Exporting a stack back to CloudFormation** had **no mention** of `--include-non-importable` (neither prose nor example). The "MVP scope" prose claimed the command "refuses to proceed if any resource is not CFn-importable (...); destroy or accept abandoning those resources first" — which is now wrong: the 2-phase `--include-non-importable` flow lets users keep their Custom Resources via post-import CFn-CREATE.

This PR:

- Adds a prose paragraph in the import section describing the CFn → cdkd migration capability, including the retirement mechanic (Retain policy injection → UpdateStack → DeleteStack) so readers understand AWS resources survive.
- Adds a prose paragraph in the export section describing the 2-phase `--include-non-importable` flow and its Lambda-idempotency / cfn-response requirement.
- Adds `cdkd export MyStack --include-non-importable` as a 5th command example.
- Drops the stale "destroy or accept abandoning" line that pre-dated the `--include-non-importable` opt-in.

Pure README prose addition. No behavior change.

## Test plan

- [x] typecheck / lint / build / tests (3224 / 270 files) pass
- [x] Diff is README only (29 lines: +25 / -4)
- [x] Both sections now have **prose + example** for every advertised flag — no flag mentioned in examples without prose context, and no stale prose line still claiming an unsupported behavior
