### PR TITLE
fix(integ): unbreak all local-* integ fixtures on Node 24 ESM + scope-cross check in /verify-pr

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -68,6 +68,15 @@ Run each check and report pass/fail:
      ```
      If this exits non-zero, run `/run-integ <relevant-test>` (e.g. `bench-cdk-sample`) and confirm it reports 0 errors / 0 orphans — the skill itself will then call `markgate set integ-destroy`.
      CI is necessary but not sufficient — it does not exercise real-AWS destroy. The gate is the structural enforcement of that fact.
+   - **For local-execution-touching PRs** (any change under `src/local/**`, `src/cli/commands/local-*.ts`, `tests/integration/local-*/**`): the `integ-local` markgate gate physically blocks `gh pr merge` when its marker is stale (see `.claude/hooks/integ-local-gate.sh`). The merge-time gate has a known blind spot: it reads the **local working tree** digest, and when `gh pr merge` runs from a parent worktree still on pre-PR `main`, the digest matches the old content and the gate passes silently — so an unverified local-execution change can reach main via the merge-from-parent path. `/verify-pr` runs in the PR's own worktree (post-PR content), so verifying the marker here closes that gap structurally:
+     ```bash
+     # Only check when the PR diff actually touches the gate scope.
+     # Mirrors how `gh pr merge` is checked, but in the worktree that has the PR's content.
+     if git diff main...HEAD --name-only | grep -qE '^src/local/|^src/cli/commands/local-|^tests/integration/local-'; then
+       mise exec -- markgate verify integ-local
+     fi
+     ```
+     If this exits non-zero (digest differs OR expired by TTL), run `/run-integ local-<test>` against a test that exercises the changed surface — `local-start-api` for HTTP-server / route-discovery / authorizer / container-pool changes, `local-invoke` for Lambda-runtime / ZIP-asset changes, `local-run-task` for ECS changes, `local-invoke-container` for container-Lambda changes, `local-invoke-layers` for Lambda Layers changes. The integ skill calls `markgate set integ-local` itself when the Docker-side check passes. As with `integ-destroy`, CI is necessary but not sufficient — it does not exercise Docker-based local execution.
    - For each region this PR may have created resources in (typically `us-east-1`), spot-check the most failure-prone resource types — VPCs (`describe-vpcs --filters "Name=tag:Name,Values=Cdkd*/Vpc"`), Lambda hyperplane ENIs (`describe-network-interfaces --filters "Name=description,Values=AWS Lambda VPC ENI-*"`), CloudFront Distributions, NAT Gateways. Any match against a stack name in this PR's diff = orphan, must be cleaned up before merge.
 
 7. **No stale references**
@@ -163,6 +172,8 @@ Present results as a table:
 | working tree | clean/dirty |
 | docs consistency | pass/fail |
 | leftover resources | none/found |
+| integ-destroy marker (deletion-touching PRs only) | fresh/stale/n-a |
+| integ-local marker (local-execution-touching PRs only) | fresh/stale/n-a |
 | code review (incl. shared-utility callers) | pass/issues found |
 | live-test changed behavior | pass/skipped/issues found |
 | retrospective + rule proposals | done/skipped |

--- a/tests/integration/local-invoke-container/lib/local-invoke-container-stack.ts
+++ b/tests/integration/local-invoke-container/lib/local-invoke-container-stack.ts
@@ -1,7 +1,10 @@
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Fixture stack for `cdkd local invoke` container-Lambda integ test (PR 5).

--- a/tests/integration/local-invoke-dotnet/lib/local-invoke-dotnet-stack.ts
+++ b/tests/integration/local-invoke-dotnet/lib/local-invoke-dotnet-stack.ts
@@ -1,8 +1,11 @@
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Fixture stack for `cdkd local invoke` .NET integ test (issue #248,

--- a/tests/integration/local-invoke-from-state/lib/local-invoke-from-state-stack.ts
+++ b/tests/integration/local-invoke-from-state/lib/local-invoke-from-state-stack.ts
@@ -1,8 +1,11 @@
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as s3 from 'aws-cdk-lib/aws-s3';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Fixture stack for `cdkd local invoke --from-state` (PR 2).

--- a/tests/integration/local-invoke-java/lib/local-invoke-java-stack.ts
+++ b/tests/integration/local-invoke-java/lib/local-invoke-java-stack.ts
@@ -1,8 +1,11 @@
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Fixture stack for `cdkd local invoke` Java integ test (issue #248,

--- a/tests/integration/local-invoke-layers/lib/local-invoke-layers-stack.ts
+++ b/tests/integration/local-invoke-layers/lib/local-invoke-layers-stack.ts
@@ -1,7 +1,10 @@
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Fixture stack for `cdkd local invoke` Lambda Layers integ test

--- a/tests/integration/local-invoke-provided/lib/local-invoke-provided-stack.ts
+++ b/tests/integration/local-invoke-provided/lib/local-invoke-provided-stack.ts
@@ -1,8 +1,11 @@
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Fixture stack for `cdkd local invoke` provided.* + go1.x integ test

--- a/tests/integration/local-invoke-python/lib/local-invoke-python-stack.ts
+++ b/tests/integration/local-invoke-python/lib/local-invoke-python-stack.ts
@@ -1,7 +1,10 @@
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Fixture stack for `cdkd local invoke` Python integ test (PR 4 of #224).

--- a/tests/integration/local-invoke-ruby/lib/local-invoke-ruby-stack.ts
+++ b/tests/integration/local-invoke-ruby/lib/local-invoke-ruby-stack.ts
@@ -1,8 +1,11 @@
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Fixture stack for `cdkd local invoke` Ruby integ test (issue #248).

--- a/tests/integration/local-invoke/lib/local-invoke-stack.ts
+++ b/tests/integration/local-invoke/lib/local-invoke-stack.ts
@@ -1,7 +1,10 @@
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Fixture stack for `cdkd local invoke` integ test.

--- a/tests/integration/local-start-api/lib/local-start-api-stack.ts
+++ b/tests/integration/local-start-api/lib/local-start-api-stack.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { fileURLToPath } from 'node:url';
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as apigw from 'aws-cdk-lib/aws-apigateway';
@@ -6,6 +7,8 @@ import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as apigwv2_integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import * as apigwv2_authorizers from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Fixture stack for `cdkd local start-api` integ test.

--- a/tests/integration/local-start-api/verify.sh
+++ b/tests/integration/local-start-api/verify.sh
@@ -107,15 +107,20 @@ if [[ "${READY}" -eq 0 ]]; then
 fi
 
 echo "==> Server log preview:"
-head -40 "${LOG_FILE}" | sed 's/^/    /'
+head -60 "${LOG_FILE}" | sed 's/^/    /'
 
 # Extract per-API ports from "Server listening on http://host:PORT (Kind)"
 # lines. PR #341 launches one server per API, so each route family has
 # its own port — using a single $PORT for every curl would only hit
 # the HTTP API v2 server.
-PORT_HTTP=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(.*HTTP API v2\)' "${LOG_FILE}" | sed -E 's|.*:([0-9]+).*|\1|' | head -1)
-PORT_REST=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(.*REST API v1\)' "${LOG_FILE}" | sed -E 's|.*:([0-9]+).*|\1|' | head -1)
-PORT_FNURL=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(.*Function URL\)' "${LOG_FILE}" | sed -E 's|.*:([0-9]+).*|\1|' | head -1)
+#
+# Sed regex tightening: anchor the port on the `http://host:` segment
+# (the `[^:]+` host class refuses to cross another `:`) so a future
+# DisplayName containing `:NNN` (e.g. user-defined logical IDs or
+# qualifiers like "v2:edge") can't shadow the real port.
+PORT_HTTP=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(.*HTTP API v2\)' "${LOG_FILE}" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|' | head -1)
+PORT_REST=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(.*REST API v1\)' "${LOG_FILE}" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|' | head -1)
+PORT_FNURL=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(.*Function URL\)' "${LOG_FILE}" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|' | head -1)
 if [[ -z "${PORT_HTTP}" || -z "${PORT_REST}" || -z "${PORT_FNURL}" ]]; then
   echo "FAIL: could not extract per-API port mappings. Log:"
   cat "${LOG_FILE}"

--- a/tests/integration/local-start-api/verify.sh
+++ b/tests/integration/local-start-api/verify.sh
@@ -80,24 +80,50 @@ ${CDKD} local start-api \
   >"${LOG_FILE}" 2>&1 &
 SERVER_PID=$!
 
-# Wait for the "Server listening" line — D8.4 marker.
-echo "==> Waiting for server to come up"
+# Wait for ALL three "Server listening" lines — PR #341 / issue #260
+# launches one HTTP server per API (HTTP API v2 + REST API v1 +
+# Function URL), each on its own port (--port N → N, N+1, N+2). The
+# pre-#341 single-server marker check would race past readiness if
+# the first server bound before the others.
+echo "==> Waiting for all servers (3 expected) to come up"
+EXPECTED_SERVERS=3
 READY=0
 for i in $(seq 1 60); do
-  if grep -q "Server listening" "${LOG_FILE}"; then
+  # `grep -c` outputs "0" AND exits non-zero on zero matches, so a
+  # naive `|| echo 0` concatenates both into "0\n0" and trips up
+  # the `[[ ... -ge ... ]]` arithmetic. Capture stdout, then default
+  # to 0 only when grep actually failed (file missing etc.).
+  count=$(grep -c "Server listening" "${LOG_FILE}" 2>/dev/null) || count=0
+  if [[ "${count}" -ge "${EXPECTED_SERVERS}" ]]; then
     READY=1
     break
   fi
   sleep 0.5
 done
 if [[ "${READY}" -eq 0 ]]; then
-  echo "FAIL: server did not print 'Server listening' within 30s. Log:"
+  echo "FAIL: only ${count}/${EXPECTED_SERVERS} servers came up within 30s. Log:"
   cat "${LOG_FILE}"
   exit 1
 fi
 
 echo "==> Server log preview:"
-head -30 "${LOG_FILE}" | sed 's/^/    /'
+head -40 "${LOG_FILE}" | sed 's/^/    /'
+
+# Extract per-API ports from "Server listening on http://host:PORT (Kind)"
+# lines. PR #341 launches one server per API, so each route family has
+# its own port — using a single $PORT for every curl would only hit
+# the HTTP API v2 server.
+PORT_HTTP=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(.*HTTP API v2\)' "${LOG_FILE}" | sed -E 's|.*:([0-9]+).*|\1|' | head -1)
+PORT_REST=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(.*REST API v1\)' "${LOG_FILE}" | sed -E 's|.*:([0-9]+).*|\1|' | head -1)
+PORT_FNURL=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(.*Function URL\)' "${LOG_FILE}" | sed -E 's|.*:([0-9]+).*|\1|' | head -1)
+if [[ -z "${PORT_HTTP}" || -z "${PORT_REST}" || -z "${PORT_FNURL}" ]]; then
+  echo "FAIL: could not extract per-API port mappings. Log:"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+echo "    HTTP API v2: ${PORT_HTTP}"
+echo "    REST API v1: ${PORT_REST}"
+echo "    Function URL: ${PORT_FNURL}"
 
 # Verify the route table contains every route. Use plain `grep -F` so
 # the `{proxy+}` curly-braces and slashes don't need to be escaped.
@@ -143,18 +169,17 @@ curl_assert() {
 }
 
 echo "==> Smoke-testing routes via curl"
-curl_assert "GET /items/42" "http://127.0.0.1:${PORT}/items/42" '"id":"42"'
-curl_assert "POST /items" "http://127.0.0.1:${PORT}/items" '"body"' \
+curl_assert "GET /items/42" "http://127.0.0.1:${PORT_HTTP}/items/42" '"id":"42"'
+curl_assert "POST /items" "http://127.0.0.1:${PORT_HTTP}/items" '"body"' \
   -X POST -H 'Content-Type: application/json' -d '{"x":1}'
 # PR 8c: REST v1 stage variables — the prod Stage carries
-# Variables: { STAGE: 'prod', LOG_LEVEL: 'info' }.
+# Variables: { STAGE: 'prod', LOG_LEVEL: 'info' }. Note this lives on
+# the dedicated REST v1 server (own port, per PR #341).
 curl_assert "ANY /v1/anything (stage variables)" \
-  "http://127.0.0.1:${PORT}/v1/anything" '"STAGE":"prod"'
-# Function URL is mounted at /{proxy+} so any other path lands there.
-# After the literal /v1 prefix has been claimed by the REST route, the
-# proxy fallback only fires on paths that don't match REST — try a
-# distinct prefix.
-curl_assert "Function URL fallback" "http://127.0.0.1:${PORT}/url-only/ping" '"functionUrl":true'
+  "http://127.0.0.1:${PORT_REST}/v1/anything" '"STAGE":"prod"'
+# Function URL is a separate server on its own port. The Function URL
+# greedy proxy answers any path on its server.
+curl_assert "Function URL fallback" "http://127.0.0.1:${PORT_FNURL}/url-only/ping" '"functionUrl":true'
 
 # PR 8c: CORS preflight interception. The HTTP API has CorsConfiguration
 # with `*` origins; verify.sh asserts the canonical preflight response.
@@ -163,7 +188,7 @@ PREFLIGHT_HEADERS=$(curl -s -i -o - -X OPTIONS \
   -H 'Origin: https://example.com' \
   -H 'Access-Control-Request-Method: POST' \
   -H 'Access-Control-Request-Headers: Content-Type' \
-  "http://127.0.0.1:${PORT}/items" 2>&1)
+  "http://127.0.0.1:${PORT_HTTP}/items" 2>&1)
 if ! echo "${PREFLIGHT_HEADERS}" | grep -qi '^HTTP/1.1 204'; then
   echo "FAIL: CORS preflight did not return 204. Response:"
   echo "${PREFLIGHT_HEADERS}"
@@ -194,7 +219,7 @@ echo "    [CORS preflight] OK"
 # authorizer Deny's; with the Bearer token the route handler runs and
 # echoes the authorizer's context map.
 echo "==> Authorizer pass: GET /protected without token -> 401 (HTTP v2 deny)"
-auth_status=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT}/protected")
+auth_status=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT_HTTP}/protected")
 if [[ "${auth_status}" != "401" ]]; then
   echo "FAIL: expected 401 from authorizer deny, got ${auth_status}"
   cat "${LOG_FILE}"
@@ -203,7 +228,7 @@ fi
 echo "    [GET /protected (deny)] OK (status=401)"
 
 curl_assert "GET /protected (allow)" \
-  "http://127.0.0.1:${PORT}/protected" \
+  "http://127.0.0.1:${PORT_HTTP}/protected" \
   '"protected":true' \
   -H 'Authorization: Bearer let-me-in'
 


### PR DESCRIPTION
## Summary
- **Fix**: All 10 `local-*` integration test fixtures (`local-invoke{,-container,-from-state,-layers,-python,-ruby,-java,-dotnet,-provided}`, `local-start-api`) failed `cdk synth` on Node 24 with `ReferenceError: __dirname is not defined in ES module scope`. The fixture `package.json` sets `"type": "module"` and Node 24's native TypeScript loader treats `.ts` files as ESM, where `__dirname` isn't injected. Adds the canonical ESM polyfill (`fileURLToPath(import.meta.url)` + `path.dirname`) to each affected stack file. No source changes; no runtime behavior change.
- **Fix**: `tests/integration/local-start-api/verify.sh` hardcoded `$PORT` for every curl, but PR #341 ("one HTTP server per API") put REST API v1 on `--port+1` and Function URL on `--port+2`. The stage-variables and Function URL fallback assertions failed against the new multi-server topology. verify.sh now waits for all 3 "Server listening" lines, parses each API's port from those lines, and routes each curl to the matching port.
- **Skill**: Extends `/verify-pr` step 6 with a parallel `integ-local` markgate verify subsection alongside the existing `integ-destroy` one. Closes the structural gap behind why PRs #340 / #341 merged without an integ run: the merge-time `integ-local-gate.sh` checks the **local working tree** digest, and `gh pr merge` from a pre-PR parent worktree silently passes against the old content. `/verify-pr` runs in the PR's own worktree (post-PR content), so verifying the marker here closes the gap structurally.

## Why
Pre-fix, every `local-*` integ was structurally unrunnable on Node 24 — a latent rot none of the previous PRs caught because the integ-local marker only invalidates on `src/local/**` / `src/cli/commands/local-*.ts` / `tests/integration/local-*/**` content changes, NOT on Node version / dependency upgrades that change runtime semantics. The `.node-version` bump to 24.15 turned every fixture's `__dirname` into a synth-time crash, and nobody noticed because /verify-pr didn't have the scope-cross check above.

## Test plan
- [x] Unit tests pass (270 files, 3224 tests)
- [x] `/run-integ local-start-api` — 8/8 smoke assertions pass (`GET /items/42`, `POST /items`, stage variables on REST v1, Function URL fallback, CORS preflight, authorizer deny + allow). 0 orphan Docker containers / networks after teardown.
- [x] `markgate set integ-local` after clean run
- [x] Documentation consistency check: short-circuit (no `src/**` / `docs/**` / `README.md` / `CLAUDE.md` touched)
