### PR TITLE
feat(review-pr): add **/*.md to pure-docs down-bias bucket

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -54,7 +54,7 @@ The skill itself never spawns reviewers. It reads PR stats, applies the heuristi
 
    **Down-bias triggers** (move tier DOWN by one step, never below inline) — only fires when ALL paths fall in the listed buckets:
 
-   - **Pure docs/infra**: every path matches one of `.gitignore`, `CLAUDE.md`, `README.md`, `docs/**`, `.claude/skills/**`, `.claude/agents/**`, `.claude/hooks/**`, `.claude/settings*.json`, `.markgate.yml`, `package.json` (top-level deps only — count as docs-ish for review purposes when the diff is dep bumps)
+   - **Pure docs/infra**: every path matches one of `.gitignore`, `CLAUDE.md`, `README.md`, `**/*.md`, `docs/**`, `.claude/skills/**`, `.claude/agents/**`, `.claude/hooks/**`, `.claude/settings*.json`, `.markgate.yml`, `package.json` (top-level deps only — count as docs-ish for review purposes when the diff is dep bumps). The `**/*.md` entry catches markdown anywhere outside `docs/**` — most commonly integ-test READMEs (`tests/integration/*/README.md`) that are written for human readers but live under `tests/**`. Added after PR #344 surfaced a 13-file markdown-only cleanup that the strict path-bucket rule mis-categorized as mixed-bucket and forced into 3-axis review.
    - **Test-only**: every path matches `tests/**`
 
    If both up- and down-bias triggers fire (e.g. a tests-only diff that touches a security-sensitive provider's test file), prefer up-bias — security wins.
@@ -216,5 +216,6 @@ These three PRs are the calibration set. Running this skill against them should 
 | #240 | 390 LOC, 4 files (`.claude/hooks/*`, `CLAUDE.md`, `.claude/settings.json`) | inline (fc < 5) | down (pure infra) → clamps at inline | **inline** |
 | #237 | 4515 LOC, 24 files (incl. `src/local/cognito-jwt.ts`, `lambda-authorizer.ts`) | 3-axis (loc >= 1000 AND fc >= 10) | up (security surface) → clamps at 3-axis | **3-axis** |
 | #236 | 269 LOC, 9 files (incl. `src/local/docker-image-builder.ts`, `ecr-puller.ts`) | inline (loc < 300) | up (process-launch surface) → 1-reviewer | **1-reviewer** |
+| #344 | 1488 LOC, 13 files (all `.md` — `docs/plans/*.md` deletes + `CLAUDE.md` / `docs/*.md` / `tests/integration/*/README.md` link-fix) | 3-axis (loc >= 1000 AND fc >= 10) | down (every path is `.md`, matches `**/*.md` in pure-docs bucket) → 1-reviewer | **1-reviewer** |
 
 If the skill output diverges from these, the heuristic or the trigger lists have drifted — re-read this file and the linked memory entry before trusting the recommendation.


### PR DESCRIPTION
## Summary

Adds `**/*.md` to the `/review-pr` skill's pure-docs down-bias bucket so markdown anywhere outside `docs/**` (most commonly `tests/integration/*/README.md`) participates in the bias that drops 3-axis review down to 1-reviewer for functionally docs-only PRs.

## Why

PR #344 was a 13-file markdown-only cleanup (deleted 7 historical plan files + link-rot fix-ups in CLAUDE.md, docs/*, and 2 integ-test READMEs). The heuristic flagged 3-axis because `loc >= 1000 AND fc >= 10`, but the pure-docs down-bias did NOT fire — the bucket required ALL paths in `docs/** | CLAUDE.md | README.md | ...`, and the 2 integ READMEs are under `tests/integration/**`. Without the bias, /review-pr recommended 3-axis review for what was functionally mechanical markdown editing.

## Risk analysis

- **Mixed-bucket protection preserved**: the ALL-paths-in-bucket rule still gates the bias, so a markdown change paired with a `.ts` edit still bypasses down-bias and gets the full review the `.ts` change warrants.
- **Worst-case false positive**: a markdown-only PR with security-relevant content (e.g. a new SECURITY.md or breaking-change MIGRATION.md). Bias is only 1 step (3-axis → 1-reviewer, never to inline directly from 3-axis), so a code-quality reviewer still runs in this case. Not a complete skip.
- **Calibration check**: re-running the heuristic against existing reference PRs (#240, #237, #236) produces unchanged tiers — their paths either matched a more specific bucket entry (#240) or contained `.ts` files that prevented down-bias from firing regardless (#237, #236).

## Test plan

- [x] Re-applied heuristic mentally against PR #344 with the new rule → 3-axis with down-bias → 1-reviewer (matches what the user and reviewer actually agreed on for #344)
- [x] No tests/CI changes needed — `/review-pr` is a skill markdown file, not source code
