### PR TITLE
chore(verify-pr): add integ-broad row to Output table

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -203,6 +203,7 @@ Present results as a table:
 | docs consistency | pass/fail |
 | leftover resources | none/found |
 | integ-destroy marker (deletion-touching PRs only) | fresh/stale/n-a |
+| integ-broad marker (cross-cutting deploy/destroy PRs only) | fresh/stale/n-a |
 | integ-local marker (local-execution-touching PRs only) | fresh/stale/n-a |
 | code review (incl. shared-utility callers) | pass/issues found |
 | live-test changed behavior | pass/skipped/issues found |


### PR DESCRIPTION
## Summary

Final audit loose-end: the `integ-broad` markgate gate (PR #349) added a verification step to `/verify-pr` step 6's CROSS-CUTTING CHECK, but the Output table at the bottom of the skill only listed `integ-destroy` and `integ-local` markers. Add the missing `integ-broad marker (cross-cutting deploy/destroy PRs only)` row so the report-table matches the actual verifications.

## What changed

- `.claude/skills/verify-pr/SKILL.md` — one new row in the Output table

## Why

Documentation completeness only — no behavior change. The verify step itself was already in place; this just adds the corresponding row to the result table the skill renders.

## Test plan

- [x] No code paths touched
- [x] No new tests needed (markdown-only change)
