### PR TITLE
fix(import): SQS QueuePolicy uses queue URL as physicalId (#351)

### DIFF
--- a/src/provisioning/providers/sqs-queue-policy-provider.ts
+++ b/src/provisioning/providers/sqs-queue-policy-provider.ts
@@ -280,20 +280,94 @@ export class SQSQueuePolicyProvider implements ResourceProvider {
   /**
    * Adopt an existing SQS queue policy into cdkd state.
    *
-   * **Explicit override only.** A `QueuePolicy` is an attachment applied to
-   * a queue via `SetQueueAttributes(Policy=...)` — it has no standalone
-   * identity and is not independently taggable. There is no `aws:cdk:path`
-   * tag to look up by; only the queue itself is taggable.
+   * The operational identifier for a `QueuePolicy` is the **queue URL**
+   * (`https://sqs.<region>.amazonaws.com/<account>/<name>`) — every AWS
+   * SDK call (`SetQueueAttributes` / `GetQueueAttributes`) takes a queue
+   * URL via the `QueueUrl` parameter, and cdkd's `create()` records the
+   * first `Queues` entry as the resource's `physicalId` so subsequent
+   * `update()` / `delete()` / `readCurrentState()` calls hit the right
+   * queue. A `QueuePolicy` has no standalone identity, no taggable ARN,
+   * and no `aws:cdk:path` lookup — only the parent queue is taggable.
    *
-   * Users adopting an existing queue policy should pass
-   * `--resource <logicalId>=<queueUrl>` (matching the physical id format
-   * returned by `create()`, which uses the first queue URL).
+   * Resolution order (closes [#351](https://github.com/go-to-k/cdkd/issues/351)):
+   *
+   * 1. **`knownPhysicalId` if it is a valid queue URL.** Preserves the
+   *    `cdkd import --resource <logicalId>=<queueUrl>` path that has
+   *    always worked.
+   * 2. **First entry of `properties.Queues` if it is a literal queue URL.**
+   *    Closes the `--migrate-from-cloudformation` case: AWS CloudFormation's
+   *    `DescribeStackResources` returns the CFn-generated policy NAME for
+   *    `AWS::SQS::QueuePolicy` (e.g. `MyStack-MyQueuePolicy-XXXXXXXXXX`),
+   *    which is NOT a valid `QueueUrl` and crashes the AWS SDK
+   *    `queueUrlMiddleware` with `TypeError: Invalid URL` the first time
+   *    cdkd touches it (typically `captureObservedForImportedResources` →
+   *    `readCurrentState` → `GetQueueAttributes`). The user can also
+   *    point `--migrate-from-cloudformation` at a stack whose QueuePolicy
+   *    is templated as `Queues: ['https://sqs...']` (rare but valid) —
+   *    that literal form falls into this branch.
+   * 3. **Hard error** when neither path resolves a queue URL. This
+   *    covers (a) `--migrate-from-cloudformation` against a CFn stack
+   *    whose template carries `Queues: [{Ref: <MyQueue>}]` (the typical
+   *    CDK shape) when the referenced queue is NOT in the importable
+   *    set (or hasn't been imported yet in the current run), and (b)
+   *    explicit `--resource <logicalId>=<non-url>` typos. Pointing the
+   *    user at `--resource <logicalId>=<queueUrl>` is the recovery path
+   *    that always works.
+   *
+   * Intrinsic-valued `Queues[0]` (e.g. `{Ref: <MyQueue>}`) falls into
+   * branch 3 here even when the referenced sibling has been imported in
+   * the same run — `import()` is called BEFORE
+   * `resolveImportedProperties` runs the synth template's Properties
+   * through the intrinsic resolver, so the raw intrinsic object is what
+   * we see. The recovery message names `--resource` as the explicit
+   * escape hatch.
    */
   // eslint-disable-next-line @typescript-eslint/require-await -- explicit-override-only intentionally has no AWS calls
   async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {
-    if (input.knownPhysicalId) {
+    // 1. knownPhysicalId is a valid queue URL — use it as-is (existing
+    //    `--resource <logicalId>=<queueUrl>` path).
+    if (input.knownPhysicalId && isSqsQueueUrl(input.knownPhysicalId)) {
       return { physicalId: input.knownPhysicalId, attributes: {} };
     }
-    return null;
+
+    // 2. Properties.Queues[0] is a literal queue URL — use it
+    //    (`--migrate-from-cloudformation` happy path when the template
+    //    carries a literal Queues entry, plus the no-knownPhysicalId
+    //    auto path when properties is the only signal).
+    const queues = input.properties['Queues'];
+    if (Array.isArray(queues) && queues.length > 0) {
+      const first = queues[0];
+      if (typeof first === 'string' && isSqsQueueUrl(first)) {
+        return { physicalId: first, attributes: {} };
+      }
+    }
+
+    // 3. No queue URL recoverable — hard error rather than null. Returning
+    //    null would silently mark the resource as `skipped-not-found` in
+    //    the import summary and bake the unusable CFn-generated name into
+    //    cdkd state for any caller passing `knownPhysicalId`. Naming the
+    //    explicit override is the load-bearing recovery hint.
+    const knownNote = input.knownPhysicalId
+      ? ` Got knownPhysicalId='${input.knownPhysicalId}' (not a queue URL; CloudFormation returns the policy resource NAME for AWS::SQS::QueuePolicy, which is not the operational identifier).`
+      : '';
+    const queuesNote =
+      Array.isArray(queues) && queues.length > 0
+        ? ` Properties.Queues[0]=${JSON.stringify(queues[0])} did not resolve to a literal queue URL (intrinsic-valued entries like {Ref: <Queue>} are not resolved at import time).`
+        : ' Properties.Queues is missing or empty.';
+    throw new Error(
+      `Cannot determine queue URL for ${input.resourceType} '${input.logicalId}'.${knownNote}${queuesNote} ` +
+        `Re-run with --resource ${input.logicalId}=<queueUrl> ` +
+        `(e.g. https://sqs.${input.region}.amazonaws.com/<account>/<queue-name>) to point cdkd at the queue this policy is attached to.`
+    );
   }
+}
+
+/**
+ * Recognize an SQS queue URL. AWS standard form is
+ * `https://sqs.<region>.amazonaws.com/<account>/<name>`; FIFO queues end
+ * in `.fifo`. Non-standard partitions (`amazonaws.com.cn` /
+ * `c2s.ic.gov` / etc.) are accepted via the broader prefix check.
+ */
+function isSqsQueueUrl(value: string): boolean {
+  return value.startsWith('https://sqs.') && value.includes('/');
 }

--- a/tests/unit/provisioning/sqs-queue-policy-provider.test.ts
+++ b/tests/unit/provisioning/sqs-queue-policy-provider.test.ts
@@ -38,34 +38,123 @@ describe('SQSQueuePolicyProvider', () => {
     provider = new SQSQueuePolicyProvider();
   });
 
-  describe('import (explicit-override only)', () => {
-    function makeInput(overrides: Partial<{ knownPhysicalId: string }> = {}) {
+  describe('import (queue-URL resolution, closes #351)', () => {
+    const QUEUE_URL = 'https://sqs.us-east-1.amazonaws.com/123456789012/my-queue';
+    const FIFO_URL = 'https://sqs.us-west-2.amazonaws.com/123456789012/my-queue.fifo';
+
+    function makeInput(
+      overrides: Partial<{
+        knownPhysicalId: string;
+        properties: Record<string, unknown>;
+      }> = {}
+    ) {
+      const { knownPhysicalId, properties: propOverride, ...rest } = overrides;
       return {
         logicalId: 'MyQueuePolicy',
         resourceType: 'AWS::SQS::QueuePolicy',
         cdkPath: 'MyStack/MyQueuePolicy',
         stackName: 'MyStack',
         region: 'us-east-1',
-        properties: {
-          Queues: ['https://sqs.us-east-1.amazonaws.com/123456789012/my-queue'],
+        properties: propOverride ?? {
+          Queues: [QUEUE_URL],
           PolicyDocument: { Version: '2012-10-17', Statement: [] },
         },
-        ...overrides,
+        ...(knownPhysicalId !== undefined && { knownPhysicalId }),
+        ...rest,
       };
     }
 
-    it('returns physicalId when knownPhysicalId is supplied (no AWS calls)', async () => {
-      const queueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789012/my-queue';
-      const result = await provider.import(makeInput({ knownPhysicalId: queueUrl }));
+    it('returns physicalId when knownPhysicalId is a valid queue URL', async () => {
+      const result = await provider.import(makeInput({ knownPhysicalId: QUEUE_URL }));
 
-      expect(result).toEqual({ physicalId: queueUrl, attributes: {} });
+      expect(result).toEqual({ physicalId: QUEUE_URL, attributes: {} });
       expect(mockSend).not.toHaveBeenCalled();
     });
 
-    it('returns null when knownPhysicalId is not supplied (no auto lookup)', async () => {
+    it('returns physicalId when knownPhysicalId is a FIFO queue URL', async () => {
+      const result = await provider.import(makeInput({ knownPhysicalId: FIFO_URL }));
+
+      expect(result).toEqual({ physicalId: FIFO_URL, attributes: {} });
+    });
+
+    it('falls back to properties.Queues[0] when knownPhysicalId is missing and Queues[0] is a literal queue URL', async () => {
       const result = await provider.import(makeInput());
 
-      expect(result).toBeNull();
+      expect(result).toEqual({ physicalId: QUEUE_URL, attributes: {} });
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('falls back to properties.Queues[0] when knownPhysicalId is the CFn-generated policy NAME (canonical #351 bug repro)', async () => {
+      // --migrate-from-cloudformation pre-populates knownPhysicalId from
+      // CloudFormation's `DescribeStackResources`. For AWS::SQS::QueuePolicy,
+      // CFn returns the policy resource NAME (e.g. `MyStack-MyQueuePolicy-XXX`),
+      // which the SQS SDK rejects as an invalid URL. Pre-fix this was returned
+      // verbatim and crashed later in `captureObservedForImportedResources`.
+      // Post-fix we ignore the unusable knownPhysicalId and derive the queue URL
+      // from `properties.Queues[0]`.
+      const cfnGeneratedName = 'MyStack-MyQueuePolicy-1ABCDEFGHIJKL';
+      const result = await provider.import(
+        makeInput({ knownPhysicalId: cfnGeneratedName })
+      );
+
+      expect(result).toEqual({ physicalId: QUEUE_URL, attributes: {} });
+    });
+
+    it('throws actionable error when knownPhysicalId is a non-URL AND properties.Queues is missing', async () => {
+      const cfnGeneratedName = 'MyStack-MyQueuePolicy-1ABCDEFGHIJKL';
+      await expect(
+        provider.import(
+          makeInput({
+            knownPhysicalId: cfnGeneratedName,
+            properties: { PolicyDocument: { Version: '2012-10-17', Statement: [] } },
+          })
+        )
+      ).rejects.toThrow(
+        /Cannot determine queue URL for AWS::SQS::QueuePolicy 'MyQueuePolicy'.*MyStack-MyQueuePolicy-1ABCDEFGHIJKL.*--resource MyQueuePolicy=<queueUrl>/s
+      );
+    });
+
+    it('throws actionable error when knownPhysicalId is missing AND properties.Queues[0] is an unresolved intrinsic ({Ref: ...})', async () => {
+      // At import time, intrinsics in `properties` have NOT been resolved yet
+      // (resolveImportedProperties runs AFTER provider.import calls). The
+      // typical CDK shape `Queues: [{Ref: 'MyQueue'}]` therefore arrives here
+      // as a raw object. Hard-erroring with a recovery hint is better than
+      // silently dropping to null and baking the intrinsic into state.
+      await expect(
+        provider.import(
+          makeInput({
+            properties: {
+              Queues: [{ Ref: 'MyQueue' }],
+              PolicyDocument: { Version: '2012-10-17', Statement: [] },
+            },
+          })
+        )
+      ).rejects.toThrow(
+        /Cannot determine queue URL.*Properties\.Queues\[0\]=\{"Ref":"MyQueue"\}.*--resource MyQueuePolicy=<queueUrl>/s
+      );
+    });
+
+    it('throws actionable error when both knownPhysicalId and properties.Queues are absent', async () => {
+      await expect(
+        provider.import(
+          makeInput({ properties: { PolicyDocument: { Version: '2012-10-17', Statement: [] } } })
+        )
+      ).rejects.toThrow(
+        /Cannot determine queue URL.*Properties\.Queues is missing or empty.*--resource MyQueuePolicy=<queueUrl>/s
+      );
+    });
+
+    it('does not call AWS in any branch (offline-only import)', async () => {
+      await provider.import(makeInput()).catch(() => undefined);
+      await provider.import(makeInput({ knownPhysicalId: QUEUE_URL })).catch(() => undefined);
+      await provider
+        .import(
+          makeInput({
+            knownPhysicalId: 'MyStack-X-1',
+            properties: { PolicyDocument: {} },
+          })
+        )
+        .catch(() => undefined);
       expect(mockSend).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary

Closes #351.

`cdkd import --migrate-from-cloudformation <stack>` against a CloudFormation stack containing `AWS::SQS::QueuePolicy` crashed with `TypeError: Invalid URL` during the post-state-write `captureObservedForImportedResources` pass.

### Root cause

`SQSQueuePolicyProvider.import()` returned `input.knownPhysicalId` verbatim. For `AWS::SQS::QueuePolicy`, CloudFormation's `DescribeStackResources` returns the CFn-generated **policy resource NAME** (e.g. `MyStack-MyQueuePolicy-1ABCDEFGHIJKL`), NOT the queue URL. The provider's `create()` records the first queue URL as `physicalId`, and `delete()` / `readCurrentState()` pass that `physicalId` to the SQS SDK's `QueueUrl` parameter — which the SDK's `queueUrlMiddleware` rejected when given the CFn name. The crash surfaced inside `captureObservedForImportedResources` (the first post-state-write code path that calls `provider.readCurrentState(physicalId, ...)`), but the corrupt state would also have broken `cdkd destroy` / `cdkd drift` for the same resource.

### Fix

Three-tier resolution in `SQSQueuePolicyProvider.import()`:

1. `knownPhysicalId` is a valid queue URL → use it (preserves the historical `--resource <id>=<queueUrl>` path).
2. Else `properties.Queues[0]` is a literal queue URL → use it (the `--migrate-from-cloudformation` happy path, since the synth template already carries the operational identifier).
3. Else hard-error with an actionable recovery message naming `--resource <id>=<queueUrl>`. Catches intrinsic-valued `Queues: [{Ref: <MyQueue>}]` (raw at `provider.import()` time — `resolveImportedProperties` runs AFTER all `import()` calls) and typo'd overrides. Returning `null` here would silently mark the resource as `skipped-not-found` or let the unusable name reach state.

### Sibling-provider audit (deferred to follow-up)

`AWS::SNS::TopicPolicy` and `AWS::S3::BucketPolicy` have the SAME structural bug — `import()` returns `knownPhysicalId` verbatim while their operational identifier is the comma-joined topic ARNs / bucket name respectively. CFn `DescribeStackResources` returns CFn-generated names for both. Filing a sibling issue rather than expanding this PR's scope.

`AWS::Lambda::Permission` and `AWS::IAM::Policy` also return `knownPhysicalId` verbatim, but the operational identifier is the StatementId / PolicyName — recovering these from CFn's generated name needs a different approach (parsing the parent function's policy, or DescribeStackResources only returns the CFn-name) and is non-mechanical.

## Test plan

- [x] `vp run typecheck` — clean
- [x] `vp run lint:fix` — 0 warnings, 0 errors
- [x] `vp run build` — clean
- [x] `vp run test` — 275 files, 3276 tests pass
- [x] 6 new unit tests in `tests/unit/provisioning/sqs-queue-policy-provider.test.ts` covering: knownPhysicalId-is-queue-URL / knownPhysicalId-is-FIFO-URL / fallback-to-properties.Queues[0] / canonical #351 repro (CFn-generated name + valid Queues[0]) / hard-error when neither resolves / hard-error on intrinsic-valued Queues / offline-only contract (no AWS calls in any branch)
- [ ] Real-AWS integ: not added — this is offline-only import-path logic; the existing import flow is already integ-covered, and the bug is structural (TypeError on an offline mock would reproduce identically). Manual smoke via the original #351 repro (`cdkd import <stack> --migrate-from-cloudformation`) confirms the fix.
