### PR TITLE
fix(import): SNS TopicPolicy + S3 BucketPolicy use operational id (#356)

### DIFF
--- a/src/provisioning/providers/s3-bucket-policy-provider.ts
+++ b/src/provisioning/providers/s3-bucket-policy-provider.ts
@@ -351,6 +351,8 @@ export class S3BucketPolicyProvider implements ResourceProvider {
  *   - must start and end with a letter or digit
  *   - no consecutive dots
  *   - no `xn--` prefix (reserved for IDN bucket names)
+ *   - no `-s3alias` suffix (reserved for S3 Access Point aliases)
+ *   - no `--ol-s3` suffix (reserved for S3 on Outposts)
  *
  * A practical pattern that excludes the obvious CFn-generated names like
  * `MyStack-MyBucketPolicy-XXXXXXXXXX` (which contain uppercase letters
@@ -362,5 +364,6 @@ function isS3BucketName(value: string): boolean {
   if (!/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/.test(value)) return false;
   if (value.includes('..')) return false;
   if (value.startsWith('xn--')) return false;
+  if (value.endsWith('-s3alias') || value.endsWith('--ol-s3')) return false;
   return true;
 }

--- a/src/provisioning/providers/s3-bucket-policy-provider.ts
+++ b/src/provisioning/providers/s3-bucket-policy-provider.ts
@@ -267,20 +267,100 @@ export class S3BucketPolicyProvider implements ResourceProvider {
   /**
    * Adopt an existing S3 bucket policy into cdkd state.
    *
-   * **Explicit override only.** An `S3::BucketPolicy` is a policy document
-   * attached to a bucket via `PutBucketPolicy` — it has no standalone
-   * identity and is not independently taggable. There is no `aws:cdk:path`
-   * tag to look up by; only the bucket itself is taggable.
+   * The operational identifier for an `S3::BucketPolicy` is the **bucket
+   * name** — every AWS SDK call (`PutBucketPolicy` / `GetBucketPolicy` /
+   * `DeleteBucketPolicy`) takes the bucket name via the `Bucket`
+   * parameter, and cdkd's `create()` records `properties.Bucket` as the
+   * resource's `physicalId` so subsequent `update()` / `delete()` /
+   * `readCurrentState()` calls hit the right bucket. A `BucketPolicy`
+   * has no standalone identity, no taggable ARN, and no `aws:cdk:path`
+   * lookup — only the bucket itself is taggable.
    *
-   * Users adopting an existing bucket policy should pass
-   * `--resource <logicalId>=<bucketName>` (matching the physical id
-   * format returned by `create()`).
+   * Resolution order (closes [#356](https://github.com/go-to-k/cdkd/issues/356)):
+   *
+   * 1. **`knownPhysicalId` if it matches an S3 bucket name shape.**
+   *    Preserves the `cdkd import --resource <logicalId>=<bucketName>`
+   *    path that has always worked.
+   * 2. **`properties.Bucket` if it is a literal bucket name.** Closes
+   *    the `--migrate-from-cloudformation` case: AWS CloudFormation's
+   *    `DescribeStackResources` returns the CFn-generated policy NAME
+   *    for `AWS::S3::BucketPolicy` (e.g.
+   *    `MyStack-MyBucketPolicy-XXXXXXXXXX`), which is NOT a valid S3
+   *    bucket name. The first time cdkd touches the imported state with
+   *    that name, `readCurrentState` → `GetBucketPolicy` rejects it.
+   * 3. **Hard error** when neither path resolves a bucket name. This
+   *    covers (a) `--migrate-from-cloudformation` against a CFn stack
+   *    whose template carries `Bucket: {Ref: <MyBucket>}` (the typical
+   *    CDK shape) when the referenced bucket is NOT in the importable
+   *    set (or hasn't been imported yet in the current run), and (b)
+   *    explicit `--resource <logicalId>=<non-bucket-name>` typos.
+   *    Pointing the user at `--resource <logicalId>=<bucketName>` is
+   *    the recovery path that always works.
+   *
+   * Intrinsic-valued `Bucket` (e.g. `{Ref: <MyBucket>}`) falls into
+   * branch 3 here even when the referenced sibling has been imported in
+   * the same run — `import()` is called BEFORE
+   * `resolveImportedProperties` runs the synth template's Properties
+   * through the intrinsic resolver, so the raw intrinsic object is what
+   * we see. The recovery message names `--resource` as the explicit
+   * escape hatch.
    */
   // eslint-disable-next-line @typescript-eslint/require-await -- explicit-override-only intentionally has no AWS calls
   async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {
-    if (input.knownPhysicalId) {
+    // 1. knownPhysicalId is a valid S3 bucket name — use it as-is
+    //    (existing `--resource <logicalId>=<bucketName>` path).
+    if (input.knownPhysicalId && isS3BucketName(input.knownPhysicalId)) {
       return { physicalId: input.knownPhysicalId, attributes: {} };
     }
-    return null;
+
+    // 2. Properties.Bucket is a literal bucket name — use it
+    //    (`--migrate-from-cloudformation` happy path when the template
+    //    carries a literal Bucket entry, plus the no-knownPhysicalId
+    //    auto path when properties is the only signal).
+    const bucket = input.properties['Bucket'];
+    if (typeof bucket === 'string' && isS3BucketName(bucket)) {
+      return { physicalId: bucket, attributes: {} };
+    }
+
+    // 3. No bucket name recoverable — hard error rather than null.
+    //    Returning null would silently mark the resource as
+    //    `skipped-not-found` in the import summary and bake the unusable
+    //    CFn-generated name into cdkd state for any caller passing
+    //    `knownPhysicalId`. Naming the explicit override is the
+    //    load-bearing recovery hint.
+    const knownNote = input.knownPhysicalId
+      ? ` Got knownPhysicalId='${input.knownPhysicalId}' (not a valid S3 bucket name; CloudFormation returns the policy resource NAME for AWS::S3::BucketPolicy, which is not the operational identifier).`
+      : '';
+    const bucketNote =
+      bucket !== undefined
+        ? ` Properties.Bucket=${JSON.stringify(bucket)} did not resolve to a literal bucket name (intrinsic-valued entries like {Ref: <Bucket>} are not resolved at import time).`
+        : ' Properties.Bucket is missing.';
+    throw new Error(
+      `Cannot determine bucket name for ${input.resourceType} '${input.logicalId}'.${knownNote}${bucketNote} ` +
+        `Re-run with --resource ${input.logicalId}=<bucketName> ` +
+        `(e.g. my-bucket-12345) to point cdkd at the bucket this policy is attached to.`
+    );
   }
+}
+
+/**
+ * Recognize an S3 bucket name. AWS rules
+ * (https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html):
+ *   - 3-63 characters
+ *   - lowercase letters, digits, hyphens, and dots
+ *   - must start and end with a letter or digit
+ *   - no consecutive dots
+ *   - no `xn--` prefix (reserved for IDN bucket names)
+ *
+ * A practical pattern that excludes the obvious CFn-generated names like
+ * `MyStack-MyBucketPolicy-XXXXXXXXXX` (which contain uppercase letters
+ * and exceed 63 chars in common cases) while accepting every normal CDK
+ * auto-generated and user-declared bucket name.
+ */
+function isS3BucketName(value: string): boolean {
+  if (value.length < 3 || value.length > 63) return false;
+  if (!/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/.test(value)) return false;
+  if (value.includes('..')) return false;
+  if (value.startsWith('xn--')) return false;
+  return true;
 }

--- a/src/provisioning/providers/sns-topic-policy-provider.ts
+++ b/src/provisioning/providers/sns-topic-policy-provider.ts
@@ -322,9 +322,7 @@ export class SNSTopicPolicyProvider implements ResourceProvider {
     //    auto path when properties is the only signal).
     const topics = input.properties['Topics'];
     if (Array.isArray(topics) && topics.length > 0) {
-      const allLiteralArns = topics.every(
-        (t) => typeof t === 'string' && isSnsTopicArn(t)
-      );
+      const allLiteralArns = topics.every((t) => typeof t === 'string' && isSnsTopicArn(t));
       if (allLiteralArns) {
         return { physicalId: (topics as string[]).join(','), attributes: {} };
       }

--- a/src/provisioning/providers/sns-topic-policy-provider.ts
+++ b/src/provisioning/providers/sns-topic-policy-provider.ts
@@ -269,22 +269,85 @@ export class SNSTopicPolicyProvider implements ResourceProvider {
   /**
    * Adopt an existing SNS topic policy into cdkd state.
    *
-   * **Explicit override only.** A `TopicPolicy` is an attachment to one or
-   * more SNS topics applied via `SetTopicAttributes(AttributeName=Policy)` —
-   * it has no standalone identity and is not independently taggable. There
-   * is no `aws:cdk:path` tag to look up by, and the policy has no name/ARN
-   * of its own.
+   * The operational identifier for a `TopicPolicy` is the **comma-joined
+   * list of SNS topic ARNs** the policy is attached to — every AWS SDK
+   * call (`SetTopicAttributes` / `GetTopicAttributes`) takes a topic ARN
+   * via the `TopicArn` parameter, and cdkd's `create()` records
+   * `topics.join(',')` as the resource's `physicalId` so subsequent
+   * `update()` / `delete()` / `readCurrentState()` calls hit the right
+   * topic(s). A `TopicPolicy` has no standalone identity, no taggable
+   * ARN, and no `aws:cdk:path` lookup — only the parent topics are
+   * taggable.
    *
-   * Users adopting an existing topic policy should pass
-   * `--resource <logicalId>=<comma-joined-topic-ARNs>` (matching the
-   * physical id format returned by `create()`).
+   * Resolution order (closes [#356](https://github.com/go-to-k/cdkd/issues/356)):
+   *
+   * 1. **`knownPhysicalId` if it is a comma-joined list of SNS topic ARNs.**
+   *    Preserves the `cdkd import --resource <logicalId>=<topic-arns>`
+   *    path that has always worked.
+   * 2. **`properties.Topics.join(',')` if every entry is a literal topic
+   *    ARN.** Closes the `--migrate-from-cloudformation` case: AWS
+   *    CloudFormation's `DescribeStackResources` returns the CFn-generated
+   *    policy NAME for `AWS::SNS::TopicPolicy` (e.g.
+   *    `MyStack-MyTopicPolicy-XXXXXXXXXX`), which is NOT a valid topic
+   *    ARN. The first time cdkd touches the imported state with that
+   *    name, `readCurrentState` → `GetTopicAttributes` rejects it.
+   * 3. **Hard error** when neither path resolves a topic-ARN list. This
+   *    covers (a) `--migrate-from-cloudformation` against a CFn stack
+   *    whose template carries `Topics: [{Ref: <MyTopic>}]` (the typical
+   *    CDK shape) when the referenced topic is NOT in the importable
+   *    set (or hasn't been imported yet in the current run), and (b)
+   *    explicit `--resource <logicalId>=<non-arn>` typos. Pointing the
+   *    user at `--resource <logicalId>=<topic-arns>` is the recovery
+   *    path that always works.
+   *
+   * Intrinsic-valued `Topics` entries (e.g. `{Ref: <MyTopic>}`) fall into
+   * branch 3 here even when the referenced sibling has been imported in
+   * the same run — `import()` is called BEFORE
+   * `resolveImportedProperties` runs the synth template's Properties
+   * through the intrinsic resolver, so the raw intrinsic object is what
+   * we see. The recovery message names `--resource` as the explicit
+   * escape hatch.
    */
   // eslint-disable-next-line @typescript-eslint/require-await -- explicit-override-only intentionally has no AWS calls
   async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {
-    if (input.knownPhysicalId) {
+    // 1. knownPhysicalId is a comma-joined list of SNS topic ARNs — use
+    //    it as-is (existing `--resource <logicalId>=<topic-arns>` path).
+    if (input.knownPhysicalId && isSnsTopicArnList(input.knownPhysicalId)) {
       return { physicalId: input.knownPhysicalId, attributes: {} };
     }
-    return null;
+
+    // 2. Properties.Topics is an array of literal topic ARNs — join and
+    //    use (`--migrate-from-cloudformation` happy path when the template
+    //    carries literal Topics entries, plus the no-knownPhysicalId
+    //    auto path when properties is the only signal).
+    const topics = input.properties['Topics'];
+    if (Array.isArray(topics) && topics.length > 0) {
+      const allLiteralArns = topics.every(
+        (t) => typeof t === 'string' && isSnsTopicArn(t)
+      );
+      if (allLiteralArns) {
+        return { physicalId: (topics as string[]).join(','), attributes: {} };
+      }
+    }
+
+    // 3. No topic-ARN list recoverable — hard error rather than null.
+    //    Returning null would silently mark the resource as
+    //    `skipped-not-found` in the import summary and bake the unusable
+    //    CFn-generated name into cdkd state for any caller passing
+    //    `knownPhysicalId`. Naming the explicit override is the
+    //    load-bearing recovery hint.
+    const knownNote = input.knownPhysicalId
+      ? ` Got knownPhysicalId='${input.knownPhysicalId}' (not a comma-joined list of SNS topic ARNs; CloudFormation returns the policy resource NAME for AWS::SNS::TopicPolicy, which is not the operational identifier).`
+      : '';
+    const topicsNote =
+      Array.isArray(topics) && topics.length > 0
+        ? ` Properties.Topics=${JSON.stringify(topics)} did not resolve to a list of literal topic ARNs (intrinsic-valued entries like {Ref: <Topic>} are not resolved at import time).`
+        : ' Properties.Topics is missing or empty.';
+    throw new Error(
+      `Cannot determine topic ARNs for ${input.resourceType} '${input.logicalId}'.${knownNote}${topicsNote} ` +
+        `Re-run with --resource ${input.logicalId}=<comma-joined-topic-ARNs> ` +
+        `(e.g. arn:aws:sns:${input.region}:<account>:<topic-name>) to point cdkd at the topic(s) this policy is attached to.`
+    );
   }
 
   /**
@@ -300,4 +363,31 @@ export class SNSTopicPolicyProvider implements ResourceProvider {
       })
     );
   }
+}
+
+/**
+ * Recognize a single SNS topic ARN. AWS standard form is
+ * `arn:<partition>:sns:<region>:<account>:<name>`; FIFO topics end in
+ * `.fifo`. Accepts every partition (`aws` / `aws-cn` / `aws-us-gov` /
+ * `aws-iso` / etc.) via the broader `arn:<partition>:sns:` prefix shape.
+ */
+function isSnsTopicArn(value: string): boolean {
+  return /^arn:[a-z0-9-]+:sns:[a-z0-9-]+:\d{12}:[\w.-]+$/.test(value);
+}
+
+/**
+ * Recognize a comma-joined list of SNS topic ARNs. cdkd's `create()`
+ * records `topics.join(',')` as the `physicalId`, so a single ARN
+ * (`arn:aws:sns:us-east-1:123456789012:my-topic`) is also accepted.
+ * Every comma-separated segment must be a valid SNS topic ARN — a CFn
+ * generated name like `MyStack-MyTopicPolicy-XXX` is correctly rejected
+ * because it does not match the ARN prefix, and a partially-valid
+ * mixture (one literal ARN + one CFn name) is also rejected so we fall
+ * back to the properties-based resolution rather than baking a half-bad
+ * list into state.
+ */
+function isSnsTopicArnList(value: string): boolean {
+  const segments = value.split(',');
+  if (segments.length === 0) return false;
+  return segments.every((s) => isSnsTopicArn(s));
 }

--- a/tests/unit/provisioning/s3-bucket-policy-provider.test.ts
+++ b/tests/unit/provisioning/s3-bucket-policy-provider.test.ts
@@ -115,6 +115,27 @@ describe('S3BucketPolicyProvider', () => {
       expect(result).toEqual({ physicalId: BUCKET_NAME, attributes: {} });
     });
 
+    it('rejects knownPhysicalId ending in `-s3alias` (reserved for S3 Access Point aliases)', async () => {
+      // AWS forbids bucket names ending in `-s3alias` — that suffix is
+      // reserved for the alias names of S3 Access Points and would be
+      // rejected by `PutBucketPolicy` at first call. cdkd's validator
+      // catches it up-front so the import falls back to properties.Bucket
+      // rather than baking the unusable value into state.
+      const aliasSuffixed = 'my-bucket-s3alias';
+      const result = await provider.import(makeInput({ knownPhysicalId: aliasSuffixed }));
+
+      expect(result).toEqual({ physicalId: BUCKET_NAME, attributes: {} });
+    });
+
+    it('rejects knownPhysicalId ending in `--ol-s3` (reserved for S3 on Outposts)', async () => {
+      // AWS forbids bucket names ending in `--ol-s3` — that suffix is
+      // reserved for S3 on Outposts and would be rejected downstream.
+      const outpostsSuffixed = 'my-bucket--ol-s3';
+      const result = await provider.import(makeInput({ knownPhysicalId: outpostsSuffixed }));
+
+      expect(result).toEqual({ physicalId: BUCKET_NAME, attributes: {} });
+    });
+
     it('throws actionable error when knownPhysicalId is a non-bucket-name AND properties.Bucket is missing', async () => {
       const cfnGeneratedName = 'MyStack-MyBucketPolicy-1ABCDEFGHIJKL';
       await expect(

--- a/tests/unit/provisioning/s3-bucket-policy-provider.test.ts
+++ b/tests/unit/provisioning/s3-bucket-policy-provider.test.ts
@@ -38,33 +38,138 @@ describe('S3BucketPolicyProvider', () => {
     provider = new S3BucketPolicyProvider();
   });
 
-  describe('import (explicit-override only)', () => {
-    function makeInput(overrides: Partial<{ knownPhysicalId: string }> = {}) {
+  describe('import (bucket-name resolution, closes #356)', () => {
+    const BUCKET_NAME = 'my-bucket';
+    const AUTOGEN_NAME = 'mystack-mybucket-1abcdef0';
+
+    function makeInput(
+      overrides: Partial<{
+        knownPhysicalId: string;
+        properties: Record<string, unknown>;
+      }> = {}
+    ) {
+      const { knownPhysicalId, properties: propOverride, ...rest } = overrides;
       return {
         logicalId: 'MyBucketPolicy',
         resourceType: 'AWS::S3::BucketPolicy',
         cdkPath: 'MyStack/MyBucketPolicy',
         stackName: 'MyStack',
         region: 'us-east-1',
-        properties: {
-          Bucket: 'my-bucket',
+        properties: propOverride ?? {
+          Bucket: BUCKET_NAME,
           PolicyDocument: { Version: '2012-10-17', Statement: [] },
         },
-        ...overrides,
+        ...(knownPhysicalId !== undefined && { knownPhysicalId }),
+        ...rest,
       };
     }
 
-    it('returns physicalId when knownPhysicalId is supplied (no AWS calls)', async () => {
-      const result = await provider.import(makeInput({ knownPhysicalId: 'my-bucket' }));
+    it('returns physicalId when knownPhysicalId is a valid S3 bucket name', async () => {
+      const result = await provider.import(makeInput({ knownPhysicalId: BUCKET_NAME }));
 
-      expect(result).toEqual({ physicalId: 'my-bucket', attributes: {} });
+      expect(result).toEqual({ physicalId: BUCKET_NAME, attributes: {} });
       expect(mockSend).not.toHaveBeenCalled();
     });
 
-    it('returns null when knownPhysicalId is not supplied (no auto lookup)', async () => {
+    it('returns physicalId when knownPhysicalId is a typical CDK-auto-generated bucket name', async () => {
+      const result = await provider.import(makeInput({ knownPhysicalId: AUTOGEN_NAME }));
+
+      expect(result).toEqual({ physicalId: AUTOGEN_NAME, attributes: {} });
+    });
+
+    it('falls back to properties.Bucket when knownPhysicalId is missing and Bucket is a literal name', async () => {
       const result = await provider.import(makeInput());
 
-      expect(result).toBeNull();
+      expect(result).toEqual({ physicalId: BUCKET_NAME, attributes: {} });
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('falls back to properties.Bucket when knownPhysicalId is the CFn-generated policy NAME (canonical #356 bug repro)', async () => {
+      // --migrate-from-cloudformation pre-populates knownPhysicalId from
+      // CloudFormation's `DescribeStackResources`. For AWS::S3::BucketPolicy,
+      // CFn returns the policy resource NAME (e.g. `MyStack-MyBucketPolicy-XXX`),
+      // which is not a valid S3 bucket name (uppercase letters, too long).
+      // Pre-fix this was returned verbatim and baked into cdkd state.
+      // Post-fix we ignore the unusable knownPhysicalId and derive the bucket
+      // name from `properties.Bucket`.
+      const cfnGeneratedName = 'MyStack-MyBucketPolicy-1ABCDEFGHIJKL';
+      const result = await provider.import(makeInput({ knownPhysicalId: cfnGeneratedName }));
+
+      expect(result).toEqual({ physicalId: BUCKET_NAME, attributes: {} });
+    });
+
+    it('rejects knownPhysicalId with uppercase letters (invalid S3 bucket name)', async () => {
+      // Uppercase characters violate the S3 naming rules. cdkd should
+      // ignore knownPhysicalId and fall back to properties.Bucket.
+      const upperCase = 'Bucket-With-Caps';
+      const result = await provider.import(makeInput({ knownPhysicalId: upperCase }));
+
+      expect(result).toEqual({ physicalId: BUCKET_NAME, attributes: {} });
+    });
+
+    it('rejects knownPhysicalId longer than 63 characters', async () => {
+      const tooLong = 'a'.repeat(64);
+      const result = await provider.import(makeInput({ knownPhysicalId: tooLong }));
+
+      // Falls back to the valid properties.Bucket.
+      expect(result).toEqual({ physicalId: BUCKET_NAME, attributes: {} });
+    });
+
+    it('throws actionable error when knownPhysicalId is a non-bucket-name AND properties.Bucket is missing', async () => {
+      const cfnGeneratedName = 'MyStack-MyBucketPolicy-1ABCDEFGHIJKL';
+      await expect(
+        provider.import(
+          makeInput({
+            knownPhysicalId: cfnGeneratedName,
+            properties: { PolicyDocument: { Version: '2012-10-17', Statement: [] } },
+          })
+        )
+      ).rejects.toThrow(
+        /Cannot determine bucket name for AWS::S3::BucketPolicy 'MyBucketPolicy'.*MyStack-MyBucketPolicy-1ABCDEFGHIJKL.*--resource MyBucketPolicy=<bucketName>/s
+      );
+    });
+
+    it('throws actionable error when knownPhysicalId is missing AND properties.Bucket is an unresolved intrinsic ({Ref: ...})', async () => {
+      // At import time, intrinsics in `properties` have NOT been resolved yet
+      // (resolveImportedProperties runs AFTER provider.import calls). The
+      // typical CDK shape `Bucket: {Ref: 'MyBucket'}` therefore arrives here
+      // as a raw object. Hard-erroring with a recovery hint is better than
+      // silently dropping to null and baking the intrinsic into state.
+      await expect(
+        provider.import(
+          makeInput({
+            properties: {
+              Bucket: { Ref: 'MyBucket' },
+              PolicyDocument: { Version: '2012-10-17', Statement: [] },
+            },
+          })
+        )
+      ).rejects.toThrow(
+        /Cannot determine bucket name.*Properties\.Bucket=\{"Ref":"MyBucket"\}.*--resource MyBucketPolicy=<bucketName>/s
+      );
+    });
+
+    it('throws actionable error when both knownPhysicalId and properties.Bucket are absent', async () => {
+      await expect(
+        provider.import(
+          makeInput({ properties: { PolicyDocument: { Version: '2012-10-17', Statement: [] } } })
+        )
+      ).rejects.toThrow(
+        /Cannot determine bucket name.*Properties\.Bucket is missing.*--resource MyBucketPolicy=<bucketName>/s
+      );
+    });
+
+    it('does not call AWS in any branch (offline-only import)', async () => {
+      await provider.import(makeInput()).catch(() => undefined);
+      await provider.import(makeInput({ knownPhysicalId: BUCKET_NAME })).catch(() => undefined);
+      await provider
+        .import(
+          makeInput({
+            knownPhysicalId: 'MyStack-X-1',
+            properties: { PolicyDocument: {} },
+          })
+        )
+        .catch(() => undefined);
       expect(mockSend).not.toHaveBeenCalled();
     });
   });

--- a/tests/unit/provisioning/sns-topic-policy-provider.test.ts
+++ b/tests/unit/provisioning/sns-topic-policy-provider.test.ts
@@ -38,34 +38,151 @@ describe('SNSTopicPolicyProvider', () => {
     provider = new SNSTopicPolicyProvider();
   });
 
-  describe('import (explicit-override only)', () => {
-    function makeInput(overrides: Partial<{ knownPhysicalId: string }> = {}) {
+  describe('import (topic-ARN resolution, closes #356)', () => {
+    const TOPIC_ARN = 'arn:aws:sns:us-east-1:123456789012:my-topic';
+    const TOPIC_ARN_2 = 'arn:aws:sns:us-east-1:123456789012:other-topic';
+    const FIFO_TOPIC_ARN = 'arn:aws:sns:us-west-2:123456789012:my-topic.fifo';
+
+    function makeInput(
+      overrides: Partial<{
+        knownPhysicalId: string;
+        properties: Record<string, unknown>;
+      }> = {}
+    ) {
+      const { knownPhysicalId, properties: propOverride, ...rest } = overrides;
       return {
         logicalId: 'MyTopicPolicy',
         resourceType: 'AWS::SNS::TopicPolicy',
         cdkPath: 'MyStack/MyTopicPolicy',
         stackName: 'MyStack',
         region: 'us-east-1',
-        properties: {
-          Topics: ['arn:aws:sns:us-east-1:123456789012:my-topic'],
+        properties: propOverride ?? {
+          Topics: [TOPIC_ARN],
           PolicyDocument: { Version: '2012-10-17', Statement: [] },
         },
-        ...overrides,
+        ...(knownPhysicalId !== undefined && { knownPhysicalId }),
+        ...rest,
       };
     }
 
-    it('returns physicalId when knownPhysicalId is supplied (no AWS calls)', async () => {
-      const physicalId = 'arn:aws:sns:us-east-1:123456789012:my-topic';
-      const result = await provider.import(makeInput({ knownPhysicalId: physicalId }));
+    it('returns physicalId when knownPhysicalId is a valid topic ARN', async () => {
+      const result = await provider.import(makeInput({ knownPhysicalId: TOPIC_ARN }));
 
-      expect(result).toEqual({ physicalId, attributes: {} });
+      expect(result).toEqual({ physicalId: TOPIC_ARN, attributes: {} });
       expect(mockSend).not.toHaveBeenCalled();
     });
 
-    it('returns null when knownPhysicalId is not supplied (no auto lookup)', async () => {
-      const result = await provider.import(makeInput());
+    it('returns physicalId when knownPhysicalId is a FIFO topic ARN', async () => {
+      const result = await provider.import(makeInput({ knownPhysicalId: FIFO_TOPIC_ARN }));
 
-      expect(result).toBeNull();
+      expect(result).toEqual({ physicalId: FIFO_TOPIC_ARN, attributes: {} });
+    });
+
+    it('returns physicalId when knownPhysicalId is a comma-joined list of topic ARNs', async () => {
+      const joined = `${TOPIC_ARN},${TOPIC_ARN_2}`;
+      const result = await provider.import(makeInput({ knownPhysicalId: joined }));
+
+      expect(result).toEqual({ physicalId: joined, attributes: {} });
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('falls back to properties.Topics when knownPhysicalId is missing and Topics are literal ARNs', async () => {
+      const result = await provider.import(
+        makeInput({
+          properties: {
+            Topics: [TOPIC_ARN, TOPIC_ARN_2],
+            PolicyDocument: { Version: '2012-10-17', Statement: [] },
+          },
+        })
+      );
+
+      expect(result).toEqual({
+        physicalId: `${TOPIC_ARN},${TOPIC_ARN_2}`,
+        attributes: {},
+      });
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('falls back to properties.Topics when knownPhysicalId is the CFn-generated policy NAME (canonical #356 bug repro)', async () => {
+      // --migrate-from-cloudformation pre-populates knownPhysicalId from
+      // CloudFormation's `DescribeStackResources`. For AWS::SNS::TopicPolicy,
+      // CFn returns the policy resource NAME (e.g. `MyStack-MyTopicPolicy-XXX`),
+      // which the SNS SDK rejects as an invalid topic ARN. Pre-fix this was
+      // returned verbatim and baked an unusable name into cdkd state.
+      // Post-fix we ignore the unusable knownPhysicalId and derive the
+      // topic-ARN list from `properties.Topics`.
+      const cfnGeneratedName = 'MyStack-MyTopicPolicy-1ABCDEFGHIJKL';
+      const result = await provider.import(makeInput({ knownPhysicalId: cfnGeneratedName }));
+
+      expect(result).toEqual({ physicalId: TOPIC_ARN, attributes: {} });
+    });
+
+    it('rejects knownPhysicalId where one segment is not an SNS ARN (partial-valid mixture)', async () => {
+      // A mixture of one valid ARN and a CFn-generated suffix should fall
+      // through to the properties-based resolution, not bake a half-bad
+      // list into state.
+      const mixed = `${TOPIC_ARN},MyStack-MyTopicPolicy-XXX`;
+      const result = await provider.import(makeInput({ knownPhysicalId: mixed }));
+
+      // The fallback uses properties.Topics, which is a valid single ARN.
+      expect(result).toEqual({ physicalId: TOPIC_ARN, attributes: {} });
+    });
+
+    it('throws actionable error when knownPhysicalId is a non-ARN AND properties.Topics is missing', async () => {
+      const cfnGeneratedName = 'MyStack-MyTopicPolicy-1ABCDEFGHIJKL';
+      await expect(
+        provider.import(
+          makeInput({
+            knownPhysicalId: cfnGeneratedName,
+            properties: { PolicyDocument: { Version: '2012-10-17', Statement: [] } },
+          })
+        )
+      ).rejects.toThrow(
+        /Cannot determine topic ARNs for AWS::SNS::TopicPolicy 'MyTopicPolicy'.*MyStack-MyTopicPolicy-1ABCDEFGHIJKL.*--resource MyTopicPolicy=<comma-joined-topic-ARNs>/s
+      );
+    });
+
+    it('throws actionable error when knownPhysicalId is missing AND properties.Topics[0] is an unresolved intrinsic ({Ref: ...})', async () => {
+      // At import time, intrinsics in `properties` have NOT been resolved yet
+      // (resolveImportedProperties runs AFTER provider.import calls). The
+      // typical CDK shape `Topics: [{Ref: 'MyTopic'}]` therefore arrives here
+      // as a raw object. Hard-erroring with a recovery hint is better than
+      // silently dropping to null and baking the intrinsic into state.
+      await expect(
+        provider.import(
+          makeInput({
+            properties: {
+              Topics: [{ Ref: 'MyTopic' }],
+              PolicyDocument: { Version: '2012-10-17', Statement: [] },
+            },
+          })
+        )
+      ).rejects.toThrow(
+        /Cannot determine topic ARNs.*Properties\.Topics=\[\{"Ref":"MyTopic"\}\].*--resource MyTopicPolicy=<comma-joined-topic-ARNs>/s
+      );
+    });
+
+    it('throws actionable error when both knownPhysicalId and properties.Topics are absent', async () => {
+      await expect(
+        provider.import(
+          makeInput({ properties: { PolicyDocument: { Version: '2012-10-17', Statement: [] } } })
+        )
+      ).rejects.toThrow(
+        /Cannot determine topic ARNs.*Properties\.Topics is missing or empty.*--resource MyTopicPolicy=<comma-joined-topic-ARNs>/s
+      );
+    });
+
+    it('does not call AWS in any branch (offline-only import)', async () => {
+      await provider.import(makeInput()).catch(() => undefined);
+      await provider.import(makeInput({ knownPhysicalId: TOPIC_ARN })).catch(() => undefined);
+      await provider
+        .import(
+          makeInput({
+            knownPhysicalId: 'MyStack-X-1',
+            properties: { PolicyDocument: {} },
+          })
+        )
+        .catch(() => undefined);
       expect(mockSend).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary

Closes #356.

`SNSTopicPolicyProvider.import()` and `S3BucketPolicyProvider.import()` returned `input.knownPhysicalId` verbatim. For `cdkd import --migrate-from-cloudformation`, that value comes from CloudFormation's `DescribeStackResources` and is the CFn-generated policy NAME (e.g. `MyStack-MyTopicPolicy-XXXXXXXXXX`), NOT the operational identifier each provider's `create()` records:

- SNS::TopicPolicy: `topics.join(',')` (comma-joined SNS topic ARNs)
- S3::BucketPolicy: `properties.Bucket` (the bucket name)

Pre-fix, downstream `delete()` / `readCurrentState()` passed the unusable CFn name to the AWS SDK as `TopicArn` / `Bucket`, surfacing as an invalid-parameter rejection or silently baking a broken id into cdkd state.

### Fix

Three-tier resolution in each provider's `import()`, mirroring the canonical pattern from PR #354 (`AWS::SQS::QueuePolicy`):

**SNS::TopicPolicy**

1. `knownPhysicalId` if it matches a comma-joined list of SNS topic ARNs (new `isSnsTopicArnList` helper — every comma-separated segment must be a valid SNS ARN; a partial-valid mixture like `<real-arn>,MyStack-X-XXX` is correctly rejected so we fall back to properties rather than baking a half-bad list into state).
2. `properties.Topics.join(',')` when every entry is a literal topic ARN.
3. Hard error with `--resource <id>=<comma-joined-topic-ARNs>` recovery hint.

**S3::BucketPolicy**

1. `knownPhysicalId` if it matches the S3 bucket-naming rules (new `isS3BucketName` helper — 3-63 chars, lowercase letters / digits / hyphens / dots, must start and end alphanumeric, no consecutive dots, no `xn--` prefix). This rejects CFn names like `MyStack-MyBucketPolicy-XXX` (uppercase letters + too long).
2. `properties.Bucket` when it is a literal bucket name.
3. Hard error with `--resource <id>=<bucketName>` recovery hint.

Both providers hard-error rather than returning null when neither path resolves — returning null would silently mark the resource `skipped-not-found` in the import summary and bake the bad name into cdkd state on any caller that passed `knownPhysicalId`. Naming the explicit override is the load-bearing recovery hint.

Catches intrinsic-valued `Topics: [{Ref: <Topic>}]` / `Bucket: {Ref: <Bucket>}` (raw at `provider.import()` time — `resolveImportedProperties` runs AFTER all `import()` calls) and typo'd overrides.

### Sibling-provider audit status

This closes the SNS::TopicPolicy + S3::BucketPolicy gaps that PR #354's "Sibling-provider audit" section identified as deferred. The remaining policy-shaped types (`AWS::Lambda::Permission`, `AWS::IAM::Policy`) need a different approach (parsing the parent's policy or the CFn name carries the operational id) and stay out of scope.

## Test plan

- [x] `vp run typecheck` — clean
- [x] `vp run lint:fix` — 0 warnings, 0 errors
- [x] `vp run build` — clean
- [x] `vp run test` — 276 files, 3309 tests pass
- [x] 10 new unit tests per provider (20 total) covering: knownPhysicalId-is-operational-id / fallback-to-properties / canonical CFn-name fallback (the #356 bug repro) / partial-valid mixture rejection (SNS only) / uppercase-letter rejection (S3 only) / length-over-63 rejection (S3 only) / hard error when neither resolves / intrinsic-`Ref` hard error / both-absent hard error / offline-only contract (no AWS calls in any branch)
- [ ] Real-AWS integ: not added — this is offline-only import-path logic; the existing import flow is already integ-covered, and the bug is structural (the CFn-generated name reaching `readCurrentState` would surface identically against an offline mock).
