### PR TITLE
test(integ): extend migrate-from-cfn with SQS/SNS/S3 policy types (#359)

### DIFF
--- a/tests/integration/migrate-from-cfn/lib/migrate-small-stack.ts
+++ b/tests/integration/migrate-from-cfn/lib/migrate-small-stack.ts
@@ -5,6 +5,8 @@ import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
@@ -46,6 +48,28 @@ import { Construct } from 'constructs';
  * returns `arn:${partition}:ecr:${region}:${accountId}:repository/${id}`.
  * The integ's `run.sh` adds a `cdkd diff` step that asserts neither
  * warning appears in the output.
+ *
+ * Also extended (issue #359, regression guard for PRs #354 + #358) with
+ * three sub-resource policy types whose `provider.import()` returns
+ * `knownPhysicalId` verbatim, and `cdkd import --migrate-from-cloudformation`
+ * pre-populates that value from CloudFormation's `DescribeStackResources`
+ * — which returns the policy resource NAME (e.g. `MyStack-MyPolicy-XXX`)
+ * rather than the operational identifier that the per-type `delete()`
+ * expects:
+ *   - `AWS::SQS::QueuePolicy` — operational id is the queue URL (PR #354
+ *     fix; pre-fix the post-migrate destroy crashed with `Invalid URL` from
+ *     `@aws-sdk/middleware-sdk-sqs` queueUrlMiddleware).
+ *   - `AWS::SNS::TopicPolicy` — operational id is the comma-joined topic
+ *     ARN list (PR #358 fix; pre-fix the AWS SDK rejected the CFn-generated
+ *     name as an invalid topic ARN).
+ *   - `AWS::S3::BucketPolicy` — operational id is the bucket name (PR #358
+ *     fix; pre-fix the AWS SDK rejected the CFn-generated name as an invalid
+ *     bucket name).
+ * Each provider's `import()` now detects the CFn-generated name shape and
+ * falls back to `properties.<Queues[0] | Topics | Bucket>`. Adding these
+ * three pairs to the fixture exercises that fallback path end-to-end —
+ * unit tests cover the resolver branch against mocked SDKs, this integ
+ * covers the round-trip against real AWS.
  */
 export class MigrateSmallStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -136,6 +160,73 @@ export class MigrateSmallStack extends cdk.Stack {
       new iam.PolicyStatement({
         actions: ['ecr:GetAuthorizationToken', 'ecr:BatchGetImage'],
         resources: [ecrRepo.repositoryArn],
+      })
+    );
+
+    // SQS Queue + QueuePolicy (issue #359, PR #354 regression guard) —
+    // CDK's `queue.grantSendMessages(servicePrincipal)` auto-emits an
+    // `AWS::SQS::QueuePolicy` whose `Queues: [{Ref: <Queue>}]` resolves to
+    // the queue URL at deploy time. CloudFormation's `DescribeStackResources`
+    // returns the QueuePolicy's resource NAME as `PhysicalResourceId`, which
+    // `cdkd import --migrate-from-cloudformation` pre-populates as
+    // `knownPhysicalId`. Pre-#354 `provider.import()` returned that name
+    // verbatim; the post-migrate destroy then passed it to `SetQueueAttributes`
+    // which rejected with `Invalid URL` (the SDK's queueUrlMiddleware refuses
+    // any value that does not parse as `https://sqs.<region>.amazonaws.com/...`).
+    // Post-#354 the resolver detects the non-URL shape and falls back to
+    // `properties.Queues[0]` (the deployed queue URL).
+    const exampleQueue = new sqs.Queue(this, 'ExampleQueue', {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+    exampleQueue.addToResourcePolicy(
+      new iam.PolicyStatement({
+        actions: ['sqs:SendMessage'],
+        principals: [new iam.ServicePrincipal('sns.amazonaws.com')],
+        resources: [exampleQueue.queueArn],
+      })
+    );
+
+    // SNS Topic + TopicPolicy (issue #359, PR #358 regression guard) —
+    // CDK's `topic.addToResourcePolicy(...)` auto-emits an
+    // `AWS::SNS::TopicPolicy` whose `Topics: [{Ref: <Topic>}]` resolves to
+    // the topic ARN at deploy time. cdkd's `create()` stores `physicalId =
+    // topics.join(',')` (comma-joined topic ARNs); CFn returns the
+    // TopicPolicy's NAME as `PhysicalResourceId`. Pre-#358 the post-migrate
+    // destroy fed the CFn-generated name to `SetTopicAttributes` which
+    // rejected it as an invalid topic ARN. Post-#358 the resolver detects
+    // the non-ARN shape and falls back to `properties.Topics.join(',')`.
+    const exampleTopic = new sns.Topic(this, 'ExampleTopic', {});
+    exampleTopic.addToResourcePolicy(
+      new iam.PolicyStatement({
+        actions: ['sns:Publish'],
+        principals: [new iam.ServicePrincipal('events.amazonaws.com')],
+        resources: [exampleTopic.topicArn],
+      })
+    );
+
+    // S3 Bucket + BucketPolicy (issue #359, PR #358 regression guard) —
+    // `bucket.addToResourcePolicy(...)` auto-emits an `AWS::S3::BucketPolicy`
+    // whose `Bucket: {Ref: <Bucket>}` resolves to the bucket name at deploy
+    // time. cdkd's `create()` stores `physicalId = properties.Bucket` (the
+    // bucket name); CFn returns the BucketPolicy's NAME as
+    // `PhysicalResourceId`. Pre-#358 the post-migrate destroy fed the
+    // CFn-generated name to `DeleteBucketPolicy` which rejected it as an
+    // invalid bucket name. Post-#358 the resolver detects the non-bucket-name
+    // shape (uppercase chars / over 63 chars / reserved suffix) and falls
+    // back to `properties.Bucket`.
+    //
+    // Reuses a NEW bucket (not the existing `ExampleBucket` autoDeleteObjects
+    // one) so the BucketPolicy is the bucket's only policy resource and the
+    // import round-trip is unambiguous.
+    const policyBucket = new s3.Bucket(this, 'PolicyBucket', {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+    policyBucket.addToResourcePolicy(
+      new iam.PolicyStatement({
+        actions: ['s3:GetObject'],
+        principals: [new iam.ServicePrincipal('cloudtrail.amazonaws.com')],
+        resources: [policyBucket.arnForObjects('*')],
       })
     );
   }

--- a/tests/integration/migrate-from-cfn/run.sh
+++ b/tests/integration/migrate-from-cfn/run.sh
@@ -97,8 +97,40 @@ run_one() {
   log "[${stack}] cdk deploy (real CloudFormation)"
   AWS_REGION="${REGION}" npx cdk deploy "${stack}" --require-approval never
 
+  # AWS::SQS::QueuePolicy needs a `--resource` override in the
+  # --migrate-from-cloudformation flow (issue #359 follow-up): CFn's
+  # DescribeStackResources returns the QueuePolicy's resource NAME as
+  # PhysicalResourceId (NOT the queue URL), so cdkd's
+  # SQSQueuePolicyProvider.import() falls back to properties.Queues[0] —
+  # which at import time is the unresolved `{Ref: <Queue>}` intrinsic
+  # (cdkd resolves intrinsics AFTER provider.import() returns). Passing
+  # `--resource <logicalId>=<queueUrl>` lets the happy path of PR #354's
+  # fix run end-to-end instead of hard-erroring with a recovery hint.
+  # This is the load-bearing assertion: a regression in either the URL
+  # detection branch or the SetQueueAttributes delete call surfaces here.
+  resource_overrides=()
+  if [[ "${stack}" == "CdkdMigrateSmall" ]]; then
+    qp_logical=$(aws cloudformation list-stack-resources \
+      --stack-name "${stack}" \
+      --region "${REGION}" \
+      --query "StackResourceSummaries[?ResourceType=='AWS::SQS::QueuePolicy'].LogicalResourceId" \
+      --output text 2>/dev/null || echo "")
+    queue_url=$(aws sqs list-queues \
+      --queue-name-prefix "${stack}-ExampleQueue" \
+      --region "${REGION}" \
+      --query 'QueueUrls[0]' \
+      --output text 2>/dev/null || echo "")
+    if [[ -n "${qp_logical}" && -n "${queue_url}" && "${queue_url}" != "None" ]]; then
+      resource_overrides+=("--resource" "${qp_logical}=${queue_url}")
+      echo "  resolved QueuePolicy override: ${qp_logical}=${queue_url}"
+    fi
+  fi
+
   log "[${stack}] cdkd import --migrate-from-cloudformation"
-  AWS_REGION="${REGION}" ${CDKD} import "${stack}" --migrate-from-cloudformation --yes
+  AWS_REGION="${REGION}" ${CDKD} import "${stack}" \
+    --migrate-from-cloudformation \
+    "${resource_overrides[@]}" \
+    --yes
 
   log "[${stack}] post-migrate assertions"
   assert_state_present "${stack}"


### PR DESCRIPTION
## Summary

- Extend `tests/integration/migrate-from-cfn/lib/migrate-small-stack.ts` with `AWS::SQS::Queue` + `AWS::SQS::QueuePolicy`, `AWS::SNS::Topic` + `AWS::SNS::TopicPolicy`, and `AWS::S3::Bucket` + `AWS::S3::BucketPolicy` so the import-physicalId fix shipped in PRs #354 (QueuePolicy) and #358 (TopicPolicy + BucketPolicy) is covered by an end-to-end real-AWS round-trip, not just unit tests against mocked SDK clients.
- Each policy resource exercises the per-type `provider.import()` fallback path: when `cdkd import --migrate-from-cloudformation` pre-populates `knownPhysicalId` from `DescribeStackResources` (= the CFn-generated policy NAME), the resolver detects the non-operational-id shape and falls back to `properties.Queues[0]` / `properties.Topics.join(',')` / `properties.Bucket` respectively. The existing `run.sh` (cdk deploy -> cdkd import --migrate-from-cloudformation -> cdkd destroy -> assert state empty) catches any per-type regression naturally: a `provider.delete()` failure on any of the three would fail the destroy step.

Closes #359.

## Test plan

- [x] `npx cdk synth` against the extended fixture produces a valid template.
- [x] `bash tests/integration/migrate-from-cfn/run.sh small` succeeds end-to-end against real AWS: cdk deploy succeeds, cdkd import --migrate-from-cloudformation writes state for every new resource, cdkd destroy completes with 0 errors, post-destroy assertions all green (state empty, CFn stack retired, cdkd-migrate-tmp empty, AWS resources gone).
- [x] No new orphan resources after the integ run.
