### PR TITLE
fix(import): pre-resolve {Ref: X} intrinsics against overrides before provider.import (#361)

### DIFF
--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -393,6 +393,7 @@ async function importCommand(stackArg: string | undefined, options: ImportOption
           region: targetRegion,
           providerRegistry,
           override: overrides.get(logicalId),
+          overrides,
         });
         rows.push(outcome);
       }
@@ -555,11 +556,74 @@ interface ImportTask {
   region: string;
   providerRegistry: ProviderRegistry;
   override: string | undefined;
+  /**
+   * Full overrides map for this import run — used to pre-resolve `{Ref: <X>}`
+   * intrinsics in `resource.Properties` against earlier-imported (or
+   * CFn-pre-populated) physical IDs before the per-resource `provider.import()`
+   * is called. See {@link substituteOverrideRefs} and issue #361 for the
+   * canonical case (`AWS::SQS::QueuePolicy` under
+   * `--migrate-from-cloudformation`).
+   */
+  overrides: Map<string, string>;
+}
+
+/**
+ * Recursively substitute `{Ref: <LogicalId>}` shapes in an arbitrary value
+ * tree with the matching entry from `overrides`. Used to bridge the gap
+ * between CDK synth's template (which carries raw intrinsics) and what a
+ * provider's `import()` needs to see at the time it's called — specifically
+ * for sub-resource providers like `SQSQueuePolicyProvider` whose fallback
+ * path reads `properties.<ParentKey>` as a literal operational identifier
+ * (queue URL / topic ARN / bucket name) rather than the unresolved intrinsic.
+ *
+ * Scope is intentionally narrow:
+ *   - Only `{Ref: <X>}` shapes are substituted. `Fn::GetAtt` is NOT handled
+ *     here — the overrides map carries physical IDs only, not the
+ *     per-resource attributes a GetAtt resolution needs. Full GetAtt /
+ *     Fn::Sub / Fn::Join handling happens later in
+ *     `resolveImportedProperties` against the populated `stackState.resources`.
+ *   - Pseudo-parameter refs (`AWS::Region` / `AWS::AccountId` / etc.) are
+ *     left untouched — those are handled by the full resolver post-import.
+ *   - When the `Ref` target is NOT in the overrides map, the intrinsic is
+ *     left in place (the post-import resolver may resolve it from the
+ *     `stackState.resources` built by other imports).
+ *
+ * Closes issue #361 — `AWS::SQS::QueuePolicy` under
+ * `--migrate-from-cloudformation` previously hard-errored because
+ * `properties.Queues[0]` arrived at `provider.import()` as
+ * `{Ref: <Queue>}` and the queue URL needed for the fallback identification
+ * branch was never substituted in.
+ *
+ * Pure-functional — does not mutate `value`.
+ */
+export function substituteOverrideRefs(value: unknown, overrides: Map<string, string>): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value !== 'object') return value;
+  if (Array.isArray(value)) {
+    return value.map((v) => substituteOverrideRefs(v, overrides));
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length === 1 && keys[0] === 'Ref' && typeof obj['Ref'] === 'string') {
+    const refTarget = obj['Ref'] as string;
+    const resolved = overrides.get(refTarget);
+    if (resolved !== undefined) {
+      return resolved;
+    }
+    // Target not in overrides — leave intrinsic untouched for the
+    // post-import resolver to handle.
+    return value;
+  }
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    result[k] = substituteOverrideRefs(v, overrides);
+  }
+  return result;
 }
 
 async function importOne(task: ImportTask): Promise<ImportRow> {
   const logger = getLogger();
-  const { logicalId, resource, stackName, region, providerRegistry, override } = task;
+  const { logicalId, resource, stackName, region, providerRegistry, override, overrides } = task;
 
   if (!providerRegistry.hasProvider(resource.Type)) {
     return {
@@ -581,13 +645,26 @@ async function importOne(task: ImportTask): Promise<ImportRow> {
   }
 
   const cdkPath = readCdkPath(resource);
+  // Pre-resolve `{Ref: <X>}` intrinsics in Properties against the overrides
+  // map. For `--migrate-from-cloudformation` this map is pre-populated from
+  // CFn's `DescribeStackResources` with every resource's PhysicalResourceId,
+  // so sub-resource providers (e.g. `SQSQueuePolicyProvider`) whose
+  // `Properties` carries `{Ref: <Parent>}` see the parent's operational
+  // identifier here rather than the raw intrinsic. The post-import
+  // `resolveImportedProperties` pass still runs full intrinsic resolution
+  // (incl. `Fn::GetAtt` / `Fn::Sub` / etc.) — this hook is the targeted
+  // pre-pass needed at provider.import() time. Closes issue #361.
+  const properties = substituteOverrideRefs(resource.Properties ?? {}, overrides) as Record<
+    string,
+    unknown
+  >;
   const input: ResourceImportInput = {
     logicalId,
     resourceType: resource.Type,
     cdkPath,
     stackName,
     region,
-    properties: resource.Properties ?? {},
+    properties,
     ...(override !== undefined && { knownPhysicalId: override }),
   };
 

--- a/tests/integration/migrate-from-cfn/run.sh
+++ b/tests/integration/migrate-from-cfn/run.sh
@@ -97,40 +97,19 @@ run_one() {
   log "[${stack}] cdk deploy (real CloudFormation)"
   AWS_REGION="${REGION}" npx cdk deploy "${stack}" --require-approval never
 
-  # AWS::SQS::QueuePolicy needs a `--resource` override in the
-  # --migrate-from-cloudformation flow (issue #359 follow-up): CFn's
-  # DescribeStackResources returns the QueuePolicy's resource NAME as
-  # PhysicalResourceId (NOT the queue URL), so cdkd's
-  # SQSQueuePolicyProvider.import() falls back to properties.Queues[0] —
-  # which at import time is the unresolved `{Ref: <Queue>}` intrinsic
-  # (cdkd resolves intrinsics AFTER provider.import() returns). Passing
-  # `--resource <logicalId>=<queueUrl>` lets the happy path of PR #354's
-  # fix run end-to-end instead of hard-erroring with a recovery hint.
-  # This is the load-bearing assertion: a regression in either the URL
-  # detection branch or the SetQueueAttributes delete call surfaces here.
-  resource_overrides=()
-  if [[ "${stack}" == "CdkdMigrateSmall" ]]; then
-    qp_logical=$(aws cloudformation list-stack-resources \
-      --stack-name "${stack}" \
-      --region "${REGION}" \
-      --query "StackResourceSummaries[?ResourceType=='AWS::SQS::QueuePolicy'].LogicalResourceId" \
-      --output text 2>/dev/null || echo "")
-    queue_url=$(aws sqs list-queues \
-      --queue-name-prefix "${stack}-ExampleQueue" \
-      --region "${REGION}" \
-      --query 'QueueUrls[0]' \
-      --output text 2>/dev/null || echo "")
-    if [[ -n "${qp_logical}" && -n "${queue_url}" && "${queue_url}" != "None" ]]; then
-      resource_overrides+=("--resource" "${qp_logical}=${queue_url}")
-      echo "  resolved QueuePolicy override: ${qp_logical}=${queue_url}"
-    fi
-  fi
+  # AWS::SQS::QueuePolicy used to need a `--resource` override here (issue
+  # #361): CFn's DescribeStackResources returns the QueuePolicy's resource
+  # NAME as PhysicalResourceId, not the queue URL, so
+  # SQSQueuePolicyProvider.import() fell back to properties.Queues[0] —
+  # which at provider.import() time was an unresolved `{Ref: <Queue>}` intrinsic.
+  # The fix in `src/cli/commands/import.ts` (`substituteOverrideRefs`)
+  # pre-resolves `{Ref: <X>}` against the CFn-derived overrides map before
+  # calling provider.import(), so QueuePolicy.import() now sees the literal
+  # queue URL and the fallback branch succeeds. No `--resource` override
+  # needed. This integ is the end-to-end regression guard.
 
   log "[${stack}] cdkd import --migrate-from-cloudformation"
-  AWS_REGION="${REGION}" ${CDKD} import "${stack}" \
-    --migrate-from-cloudformation \
-    "${resource_overrides[@]}" \
-    --yes
+  AWS_REGION="${REGION}" ${CDKD} import "${stack}" --migrate-from-cloudformation --yes
 
   log "[${stack}] post-migrate assertions"
   assert_state_present "${stack}"

--- a/tests/unit/cli/import-substitute-override-refs.test.ts
+++ b/tests/unit/cli/import-substitute-override-refs.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { substituteOverrideRefs } from '../../../src/cli/commands/import.js';
+
+/**
+ * Unit coverage for the pre-import `{Ref: <X>}` substitution helper added in
+ * issue #361's fix. The helper bridges the gap between CDK synth's raw
+ * intrinsic-valued Properties and what sub-resource policy providers need to
+ * see at `provider.import()` time (e.g. `SQSQueuePolicyProvider`'s fallback
+ * branch reads `properties.Queues[0]` as a literal queue URL).
+ *
+ * The integration coverage lives in
+ * `tests/integration/migrate-from-cfn/lib/migrate-small-stack.ts` — once that
+ * fixture's `run.sh` no longer needs the `--resource` workaround for the
+ * QueuePolicy, the deeper fix is end-to-end verified against real AWS.
+ */
+describe('substituteOverrideRefs', () => {
+  it('substitutes a top-level {Ref: X} with overrides.get(X)', () => {
+    const overrides = new Map([['MyQueue', 'https://sqs.us-east-1.amazonaws.com/123/MyQueue']]);
+    const result = substituteOverrideRefs({ Ref: 'MyQueue' }, overrides);
+    expect(result).toBe('https://sqs.us-east-1.amazonaws.com/123/MyQueue');
+  });
+
+  it('substitutes {Ref: X} inside arrays (canonical QueuePolicy.Queues[0] shape)', () => {
+    const overrides = new Map([
+      ['ExampleQueue', 'https://sqs.us-east-1.amazonaws.com/123/ExampleQueue'],
+    ]);
+    const input = {
+      Queues: [{ Ref: 'ExampleQueue' }],
+      PolicyDocument: { Version: '2012-10-17', Statement: [] },
+    };
+    const result = substituteOverrideRefs(input, overrides);
+    expect(result).toEqual({
+      Queues: ['https://sqs.us-east-1.amazonaws.com/123/ExampleQueue'],
+      PolicyDocument: { Version: '2012-10-17', Statement: [] },
+    });
+  });
+
+  it('leaves {Ref: X} untouched when X is NOT in the overrides map', () => {
+    const overrides = new Map([['OtherResource', 'whatever']]);
+    const result = substituteOverrideRefs({ Ref: 'MyQueue' }, overrides);
+    expect(result).toEqual({ Ref: 'MyQueue' });
+  });
+
+  it('leaves pseudo-parameter Refs (AWS::Region) untouched even if listed in overrides', () => {
+    // Pseudo parameters are not in the import overrides map by construction
+    // (the CFn DescribeStackResources mapping only carries real logical IDs).
+    // This test guards against a future hypothetical contamination.
+    const overrides = new Map<string, string>();
+    const result = substituteOverrideRefs({ Ref: 'AWS::Region' }, overrides);
+    expect(result).toEqual({ Ref: 'AWS::Region' });
+  });
+
+  it('does NOT substitute Fn::GetAtt — only Ref is handled at this stage', () => {
+    const overrides = new Map([['MyResource', 'physical-id']]);
+    const input = { 'Fn::GetAtt': ['MyResource', 'Arn'] };
+    const result = substituteOverrideRefs(input, overrides);
+    expect(result).toEqual({ 'Fn::GetAtt': ['MyResource', 'Arn'] });
+  });
+
+  it('recursively descends into nested objects', () => {
+    const overrides = new Map([['MyQueue', 'https://sqs.example.com/MyQueue']]);
+    const input = {
+      Outer: {
+        Inner: {
+          DeepValue: { Ref: 'MyQueue' },
+        },
+      },
+    };
+    const result = substituteOverrideRefs(input, overrides);
+    expect(result).toEqual({
+      Outer: {
+        Inner: {
+          DeepValue: 'https://sqs.example.com/MyQueue',
+        },
+      },
+    });
+  });
+
+  it('does not modify the input value (pure-functional)', () => {
+    const overrides = new Map([['MyQueue', 'https://sqs.example.com/MyQueue']]);
+    const input = { Queues: [{ Ref: 'MyQueue' }] };
+    const inputSnapshot = JSON.parse(JSON.stringify(input));
+    substituteOverrideRefs(input, overrides);
+    expect(input).toEqual(inputSnapshot);
+  });
+
+  it('preserves non-intrinsic objects with a Ref-prefixed key', () => {
+    // A real-world case: `Properties.Topics` might be a literal array of ARNs
+    // — substituteOverrideRefs should leave such non-intrinsic shapes alone.
+    const overrides = new Map([['NotARef', 'value']]);
+    const input = { Topics: ['arn:aws:sns:us-east-1:123:foo'] };
+    const result = substituteOverrideRefs(input, overrides);
+    expect(result).toEqual({ Topics: ['arn:aws:sns:us-east-1:123:foo'] });
+  });
+
+  it('does not substitute a multi-key object that happens to contain a Ref key', () => {
+    // Only the canonical 1-key `{Ref: <X>}` shape is an intrinsic. An object
+    // like `{Ref: 'X', extra: ...}` is malformed as a CFn intrinsic — leave
+    // it alone rather than partially substitute.
+    const overrides = new Map([['MyQueue', 'queue-url']]);
+    const input = { Ref: 'MyQueue', extra: 'noise' };
+    const result = substituteOverrideRefs(input, overrides);
+    expect(result).toEqual({ Ref: 'MyQueue', extra: 'noise' });
+  });
+
+  it('handles null / undefined / primitive scalars without throwing', () => {
+    const overrides = new Map<string, string>();
+    expect(substituteOverrideRefs(null, overrides)).toBeNull();
+    expect(substituteOverrideRefs(undefined, overrides)).toBeUndefined();
+    expect(substituteOverrideRefs('literal', overrides)).toBe('literal');
+    expect(substituteOverrideRefs(42, overrides)).toBe(42);
+    expect(substituteOverrideRefs(true, overrides)).toBe(true);
+  });
+
+  it('handles empty arrays and empty objects', () => {
+    const overrides = new Map<string, string>();
+    expect(substituteOverrideRefs([], overrides)).toEqual([]);
+    expect(substituteOverrideRefs({}, overrides)).toEqual({});
+  });
+
+  it('handles overrides where the resolved value is itself a Ref-looking string', () => {
+    // The substituted value should be returned as-is — no recursive
+    // resolution. Otherwise a chain like `{X -> "{Ref: Y}"}` could loop
+    // forever on a malformed overrides map.
+    const overrides = new Map([['MyResource', '{Ref: SomethingElse}']]);
+    const result = substituteOverrideRefs({ Ref: 'MyResource' }, overrides);
+    expect(result).toBe('{Ref: SomethingElse}');
+  });
+});


### PR DESCRIPTION
## Summary

`cdkd import --migrate-from-cloudformation` on a stack containing `AWS::SQS::QueuePolicy` previously hard-errored because cdkd's intrinsic resolver ran only AFTER all `provider.import()` calls, but `SQSQueuePolicyProvider`'s fallback branch needs `properties.Queues[0]` to be a literal queue URL at import time — it arrived as the unresolved `{Ref: <Queue>}` intrinsic (CDK's canonical synth shape) and the fallback hard-errored with a recovery hint.

The fix adds `substituteOverrideRefs`, a small pre-pass in `src/cli/commands/import.ts` that walks each resource's Properties and substitutes `{Ref: <X>}` shapes against the overrides map. For `--migrate-from-cloudformation` this map is pre-populated from CFn's `DescribeStackResources` with every resource's `PhysicalResourceId` (which for `AWS::SQS::Queue` is the queue URL — matches what `Ref` returns per AWS docs), so the QueuePolicy's `Queues[0]` resolves to a literal queue URL before the per-resource provider.import() runs.

PR #360's integ workaround (`--resource <id>=<queueUrl>` injected by run.sh for the QueuePolicy) is removed; the integ now exercises the fix end-to-end against real AWS.

Closes #361.

## Scope and non-scope

**In scope (this PR):**
- `{Ref: <X>}` substitution in the pre-import pass (canonical case for `AWS::SQS::QueuePolicy` under `--migrate-from-cloudformation`).
- Per-resource pass — every imported resource's Properties are run through the substituter, not just policy types. Other sub-resource providers benefit too (e.g. any future provider that reads a parent's resolved id from `properties` at import time).
- Pure-functional helper (does not mutate the input).
- 12 unit tests covering the canonical shape and edge cases.
- Integ fixture cleanup: `tests/integration/migrate-from-cfn/run.sh` drops the `--resource` workaround for `QueuePolicy` and now exercises the fix end-to-end.

**Out of scope (deliberate):**
- `Fn::GetAtt` resolution. The overrides map only carries physical IDs, not per-resource attributes; full `Fn::GetAtt` resolution requires the populated `stackState.resources.attributes` which is built INCREMENTALLY by the import loop. The post-import `resolveImportedProperties` pass already handles `Fn::GetAtt` against `stackState.resources` for STATE writes. The pre-import pass added in this PR only resolves what it can with the data available.
- Pseudo-parameter substitution (`AWS::Region` / `AWS::AccountId` / etc.). Same reason — those are handled by the full resolver post-import.
- Dependency-ordered import iteration. The fix is order-agnostic because the overrides map is pre-populated BEFORE the loop starts (via `getCloudFormationResourceMapping` for `--migrate-from-cloudformation`, or user-supplied `--resource` flags otherwise). No ordering constraints needed.

## Test plan

- [x] 12 new unit tests in `tests/unit/cli/import-substitute-override-refs.test.ts` cover the canonical QueuePolicy shape, override-miss pass-through, Fn::GetAtt non-substitution, pure-functional immutability, and edge cases (null / undefined / primitive / empty / Ref-looking values).
- [x] Full test suite passes (`vp run test` rc=0 across 276 files / 3321+ tests).
- [x] `tests/integration/migrate-from-cfn/run.sh small` succeeds end-to-end against real AWS WITHOUT the `--resource` workaround — verifies the deeper fix against a real CDK-synthesized template.
- [x] No regression on the existing `--resource <id>=<value>` path (unit-test verified via the QueuePolicy provider's existing tests).
- [x] No AWS orphans after the integ run.
