### PR TITLE
fix(synth): exclude AWS::CDK::Metadata from displayed resource count

### DIFF
--- a/src/cli/commands/synth.ts
+++ b/src/cli/commands/synth.ts
@@ -26,9 +26,8 @@ import type { CloudFormationTemplate } from '../../types/resource.js';
  * deploy-engine.ts `validateResourceTypes` call site).
  */
 export function countDeployableResources(template: CloudFormationTemplate): number {
-  return Object.values(template.Resources ?? {}).filter(
-    (r) => r.Type !== 'AWS::CDK::Metadata'
-  ).length;
+  return Object.values(template.Resources ?? {}).filter((r) => r.Type !== 'AWS::CDK::Metadata')
+    .length;
 }
 
 /**

--- a/src/cli/commands/synth.ts
+++ b/src/cli/commands/synth.ts
@@ -16,6 +16,20 @@ import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.
 import { AssemblyReader } from '../../synthesis/assembly-reader.js';
 import { resolveApp } from '../config-loader.js';
 import { toYaml } from '../../utils/yaml.js';
+import type { CloudFormationTemplate } from '../../types/resource.js';
+
+/**
+ * Count deployable resources in a synth template.
+ *
+ * Excludes `AWS::CDK::Metadata` (CDK-injected construct-tree marker; cdkd deploy
+ * also filters this out, so the two commands stay in sync — see
+ * deploy-engine.ts `validateResourceTypes` call site).
+ */
+export function countDeployableResources(template: CloudFormationTemplate): number {
+  return Object.values(template.Resources ?? {}).filter(
+    (r) => r.Type !== 'AWS::CDK::Metadata'
+  ).length;
+}
 
 /**
  * Synth command implementation
@@ -81,7 +95,7 @@ async function synthCommand(options: {
   logger.info(`\n✅ Synthesis complete! Found ${stacks.length} stack(s):`);
 
   for (const stack of stacks) {
-    const resourceCount = Object.keys(stack.template.Resources ?? {}).length;
+    const resourceCount = countDeployableResources(stack.template);
     const outputCount = Object.keys(stack.template.Outputs ?? {}).length;
 
     logger.info(`  • ${stack.stackName}`);

--- a/tests/unit/cli/synth-resource-count.test.ts
+++ b/tests/unit/cli/synth-resource-count.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { countDeployableResources } from '../../../src/cli/commands/synth.js';
+import type { CloudFormationTemplate } from '../../../src/types/resource.js';
+
+describe('countDeployableResources', () => {
+  it('excludes AWS::CDK::Metadata from the count', () => {
+    const template: CloudFormationTemplate = {
+      Resources: {
+        HistoryTable24A0CCCB: { Type: 'AWS::DynamoDB::GlobalTable', Properties: {} },
+        CDKMetadata: { Type: 'AWS::CDK::Metadata', Properties: { Analytics: 'v2:deflate64:...' } },
+      },
+    };
+
+    expect(countDeployableResources(template)).toBe(1);
+  });
+
+  it('returns 0 when only AWS::CDK::Metadata is present', () => {
+    const template: CloudFormationTemplate = {
+      Resources: {
+        CDKMetadata: { Type: 'AWS::CDK::Metadata', Properties: {} },
+      },
+    };
+
+    expect(countDeployableResources(template)).toBe(0);
+  });
+
+  it('returns 0 for an empty Resources map', () => {
+    expect(countDeployableResources({ Resources: {} })).toBe(0);
+  });
+
+  it('counts every non-CDK-Metadata resource', () => {
+    const template: CloudFormationTemplate = {
+      Resources: {
+        Bucket: { Type: 'AWS::S3::Bucket', Properties: {} },
+        Table: { Type: 'AWS::DynamoDB::Table', Properties: {} },
+        Fn: { Type: 'AWS::Lambda::Function', Properties: {} },
+        CDKMetadata: { Type: 'AWS::CDK::Metadata', Properties: {} },
+      },
+    };
+
+    expect(countDeployableResources(template)).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- `cdkd synth` reported `Resources: 2` for a single-resource stack because `Object.keys(template.Resources).length` counted the CDK-injected `AWS::CDK::Metadata` marker.
- `cdkd deploy` already filtered `AWS::CDK::Metadata` (see `deploy-engine.ts` `validateResourceTypes`), so the two commands were inconsistent.
- Hoist the filter into a shared `countDeployableResources(template)` helper exported from `src/cli/commands/synth.ts` and use it in the `synth` summary loop.

## Test plan

- [x] 4 new unit tests in `tests/unit/cli/synth-resource-count.test.ts` (CDKMetadata excluded / only-CDKMetadata returns 0 / empty Resources / multi-resource).
- [x] `vp run typecheck` / `vp run lint` / `vp run build` / `vp run test` (278 files, 3327 tests).
- [x] Live-tested against `cdk-sample` — a stack with a single `TableV2` resource now reports `Resources: 1` (was `Resources: 2`).
