### PR TITLE
feat(diff): detect DeletionPolicy / UpdateReplacePolicy template-attribute changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ SDK Providers are preferred over Cloud Control API for performance -- they make 
 
 ```typescript
 interface StackState {
-  version: 1 | 2 | 3 | 4; // 1 = legacy, 2 = region-prefixed, 3 = +observedProperties, 4 = +imports[]
+  version: 1 | 2 | 3 | 4 | 5; // 1 = legacy, 2 = region-prefixed, 3 = +observedProperties, 4 = +imports[], 5 = +deletionPolicy/updateReplacePolicy
   stackName: string;
   region?: string;      // Required on version >= 2 (load-bearing for the S3 key)
   resources: Record<string, ResourceState>;
@@ -196,8 +196,22 @@ interface ResourceState {
   observedProperties?: Record<string, any>; // AWS-current snapshot at deploy time (drift baseline)
   attributes: Record<string, any>;          // For Fn::GetAtt resolution
   dependencies: string[];                   // For proper deletion order
+  deletionPolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate'; // v5+: template attribute recorded at deploy time
+  updateReplacePolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate'; // v5+: template attribute recorded at deploy time
 }
 ```
+
+**`deletionPolicy` / `updateReplacePolicy`** (schema v5+) are the CFn template
+attributes recorded at deploy time so the next `cdkd deploy` / `cdkd diff` can
+detect attribute-only flips that have no AWS API impact but still matter to
+cdkd's destroy-time `DeletionPolicy: Retain` skip (and to anyone reading the
+diff). Pre-v5, removing `removalPolicy: RemovalPolicy.DESTROY` from a CDK
+construct (= `DeletionPolicy` flips from `Delete` to `Retain` in the synth
+template) silently surfaced as `No changes detected` because `DiffCalculator`
+only compared `Properties`. v5 widens the diff comparator to walk these two
+attribute fields too; the UPDATE classification still fires when only these
+change, and the deploy engine refreshes the cdkd state record without
+calling any provider (there is no per-resource AWS API for either attribute).
 
 **`observedProperties`** is populated on each successful create / update by
 calling `provider.readCurrentState` fire-and-forget after the resource flips

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -221,13 +221,37 @@ next `cdkd drift` run sees a real AWS-current snapshot. Pass
 upgrade refresh; `cdkd state refresh-observed <stack>` remains the
 manual / non-deploy path for refreshing the baseline.
 
+### `version: 5` adds `deletionPolicy` / `updateReplacePolicy` (current writers)
+
+Schema `version: 5` adds two optional template-attribute fields to each
+`ResourceState`: `deletionPolicy` and `updateReplacePolicy`. They mirror the
+CloudFormation `DeletionPolicy` / `UpdateReplacePolicy` attributes that the
+synth template carried at the resource's last successful create / update.
+Writers always emit `version: 5`. The on-disk key layout is unchanged from
+`version: 2`; only the per-resource shape grew. v4 readers see a `version: 5`
+blob and fail clearly with the same "upgrade cdkd" error.
+
+`DiffCalculator` (v5+) compares both attributes against the template on
+every deploy / diff. A change there — typically a user removing
+`removalPolicy: RemovalPolicy.DESTROY` from a CDK construct (CDK then emits
+`DeletionPolicy: Retain` instead of `Delete`) — is now classified as
+`UPDATE` rather than silently swallowed as `No changes detected`. The
+attribute flip has no per-resource AWS API, so cdkd's deploy engine
+refreshes the cdkd state record only — no provider call. **v4 → v5
+upgrade is automatic on the next `cdkd deploy`**: state-update sites write
+the current template attributes (or `undefined` when the template does not
+carry the attribute) into the resource record, and the next deploy's
+comparator has a real baseline to diff against. `cdkd destroy`'s existing
+`DeletionPolicy: Retain` skip continues to read the template directly, so
+the v5 fields are not yet load-bearing on the destroy path.
+
 ## State Schema
 
 ### StackState (`state.json`)
 
 ```typescript
 interface StackState {
-  version: 1 | 2 | 3                       // 1 = legacy, 2 = region-prefixed, 3 = +observedProperties
+  version: 1 | 2 | 3 | 4 | 5               // 1 = legacy, 2 = region-prefixed, 3 = +observedProperties, 4 = +imports[], 5 = +deletionPolicy/updateReplacePolicy
   stackName: string                        // Stack name
   region?: string                          // Required on version >= 2
   resources: Record<string, ResourceState> // Logical ID → Resource state

--- a/src/analyzer/diff-calculator.ts
+++ b/src/analyzer/diff-calculator.ts
@@ -1,5 +1,12 @@
-import type { CloudFormationTemplate } from '../types/resource.js';
-import type { StackState, ChangeType, ResourceChange, PropertyChange } from '../types/state.js';
+import type { CloudFormationTemplate, TemplateResource } from '../types/resource.js';
+import type {
+  StackState,
+  ChangeType,
+  ResourceChange,
+  PropertyChange,
+  AttributeChange,
+  ResourceState,
+} from '../types/state.js';
 import { getLogger } from '../utils/logger.js';
 import { ReplacementRulesRegistry } from './replacement-rules.js';
 
@@ -110,8 +117,17 @@ export class DiffCalculator {
           desiredPropsForCompare
         );
 
-        if (propertyChanges.length > 0) {
-          // Properties changed -> UPDATE
+        // Schema v5+ template-attribute diff: `DeletionPolicy` /
+        // `UpdateReplacePolicy` may change without any property change. cdkd
+        // pre-v5 silently reported `No changes detected` for those, so a
+        // user who removed `RemovalPolicy.DESTROY` from their CDK code saw
+        // nothing happen on the next deploy. Detect them here too so the
+        // attribute flip is surfaced (and the deploy engine refreshes the
+        // value in state).
+        const attributeChanges = this.compareAttributes(currentResource, desiredResource);
+
+        if (propertyChanges.length > 0 || attributeChanges.length > 0) {
+          // Property and/or attribute changed -> UPDATE
           changes.set(logicalId, {
             logicalId,
             changeType: 'UPDATE',
@@ -119,8 +135,11 @@ export class DiffCalculator {
             currentProperties: currentResource.properties,
             desiredProperties: rawDesiredProps,
             propertyChanges,
+            ...(attributeChanges.length > 0 && { attributeChanges }),
           });
-          this.logger.debug(`UPDATE: ${logicalId} (${propertyChanges.length} property changes)`);
+          this.logger.debug(
+            `UPDATE: ${logicalId} (${propertyChanges.length} property changes, ${attributeChanges.length} attribute changes)`
+          );
         } else {
           // No changes -> NO_CHANGE
           changes.set(logicalId, {
@@ -177,6 +196,37 @@ export class DiffCalculator {
       }
     }
     return resolved;
+  }
+
+  /**
+   * Compare CloudFormation template-level attributes (`DeletionPolicy`,
+   * `UpdateReplacePolicy`) between cdkd state and the synth template.
+   *
+   * Schema v5+ records these in `ResourceState`; state written by an older
+   * cdkd binary has the fields undefined. Treating `undefined === undefined`
+   * as "no change" means the first post-upgrade deploy of an unchanged
+   * template doesn't spuriously fire an attribute diff.
+   */
+  private compareAttributes(
+    currentResource: ResourceState,
+    desiredResource: TemplateResource
+  ): AttributeChange[] {
+    const changes: AttributeChange[] = [];
+    if (currentResource.deletionPolicy !== desiredResource.DeletionPolicy) {
+      changes.push({
+        attribute: 'DeletionPolicy',
+        oldValue: currentResource.deletionPolicy,
+        newValue: desiredResource.DeletionPolicy,
+      });
+    }
+    if (currentResource.updateReplacePolicy !== desiredResource.UpdateReplacePolicy) {
+      changes.push({
+        attribute: 'UpdateReplacePolicy',
+        oldValue: currentResource.updateReplacePolicy,
+        newValue: desiredResource.UpdateReplacePolicy,
+      });
+    }
+    return changes;
   }
 
   /**

--- a/src/cli/commands/diff.ts
+++ b/src/cli/commands/diff.ts
@@ -286,6 +286,13 @@ async function diffCommand(
                 logger.info(`          new: ${newStr}`);
               }
             }
+            if (change.attributeChanges && change.attributeChanges.length > 0) {
+              for (const attrChange of change.attributeChanges) {
+                logger.info(`      - ${attrChange.attribute}: [metadata only, no AWS API call]`);
+                logger.info(`          old: ${attrChange.oldValue ?? '(unset)'}`);
+                logger.info(`          new: ${attrChange.newValue ?? '(unset)'}`);
+              }
+            }
             break;
           }
           case 'DELETE':

--- a/src/deployment/deploy-engine.ts
+++ b/src/deployment/deploy-engine.ts
@@ -1496,6 +1496,7 @@ export class DeployEngine {
         // Extract ALL dependencies from template (Ref, Fn::GetAtt, DependsOn)
         // so that deletion order is correct even without implicit type-based deps
         const dependencies = this.extractAllDependencies(template, logicalId);
+        const templateAttrs = this.extractTemplateAttributes(template, logicalId);
 
         stateResources[logicalId] = {
           physicalId: result.physicalId,
@@ -1503,6 +1504,7 @@ export class DeployEngine {
           properties: resolvedProps,
           ...(result.attributes && { attributes: result.attributes }),
           ...(dependencies && dependencies.length > 0 && { dependencies }),
+          ...templateAttrs,
         };
 
         this.kickOffObservedCapture(
@@ -1549,6 +1551,26 @@ export class DeployEngine {
         // Re-check diff after resolving intrinsic functions
         // DiffCalculator compares unresolved template vs resolved state, which may produce false positives
         if (JSON.stringify(resolvedProps) === JSON.stringify(currentProps)) {
+          // Attribute-only change (schema v5+): `DeletionPolicy` /
+          // `UpdateReplacePolicy` may have flipped without any AWS-side
+          // property change. There is no per-resource AWS API for those —
+          // refresh cdkd state alone and skip the provider call.
+          if (change.attributeChanges && change.attributeChanges.length > 0) {
+            const attrSummary = change.attributeChanges
+              .map((a) => `${a.attribute}: ${a.oldValue ?? '(unset)'} → ${a.newValue ?? '(unset)'}`)
+              .join(', ');
+            this.logger.info(`  ↻ ${logicalId} (${resourceType}) attribute update: ${attrSummary}`);
+            stateResources[logicalId] = {
+              ...currentResource,
+              ...this.extractTemplateAttributes(template, logicalId),
+            };
+            if (counts) counts.updated++;
+            if (progress) progress.current++;
+            const attrPrefix = progress ? `[${progress.current}/${progress.total}] ` : '  ';
+            renderer.removeTask(logicalId);
+            this.logger.info(`${attrPrefix}✅ ${logicalId} (${resourceType}) updated (metadata)`);
+            break;
+          }
           this.logger.debug(
             `Skipping ${logicalId}: no actual changes after intrinsic function resolution`
           );
@@ -1615,6 +1637,7 @@ export class DeployEngine {
             properties: resolvedProps,
             ...(createResult.attributes && { attributes: createResult.attributes }),
             ...(dependencies && dependencies.length > 0 && { dependencies }),
+            ...this.extractTemplateAttributes(template, logicalId),
           };
 
           this.kickOffObservedCapture(
@@ -1720,6 +1743,7 @@ export class DeployEngine {
             properties: resolvedProps,
             ...(result.attributes && { attributes: result.attributes }),
             ...(dependencies && dependencies.length > 0 && { dependencies }),
+            ...this.extractTemplateAttributes(template, logicalId),
           };
 
           this.kickOffObservedCapture(
@@ -1823,6 +1847,29 @@ export class DeployEngine {
     const parser = new TemplateParser();
     const deps = parser.extractDependencies(resource);
     return deps.size > 0 ? [...deps] : undefined;
+  }
+
+  /**
+   * Read `DeletionPolicy` / `UpdateReplacePolicy` from the synth template
+   * so they can be persisted in `ResourceState` (schema v5+). Always returns
+   * both keys (`undefined` when the template does not carry the attribute)
+   * so that spreading into an existing `ResourceState` reliably overrides a
+   * previously-recorded value back to `undefined` — required when the user
+   * removes the attribute from their CDK code. `JSON.stringify` then omits
+   * the `undefined` keys when state is serialized to S3.
+   */
+  private extractTemplateAttributes(
+    template: CloudFormationTemplate | undefined,
+    logicalId: string
+  ): {
+    deletionPolicy: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate' | undefined;
+    updateReplacePolicy: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate' | undefined;
+  } {
+    const resource = template?.Resources?.[logicalId];
+    return {
+      deletionPolicy: resource?.DeletionPolicy,
+      updateReplacePolicy: resource?.UpdateReplacePolicy,
+    };
   }
 
   // Type-based implicit deletion ordering rules are defined in

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -13,15 +13,23 @@
  *       references its outputs (strong reference, matches CloudFormation).
  *       Layout is the same as v3; only the stack-level shape grew. v3
  *       readers see v4 as `version: 4` and fail clearly.
+ * - 5 — adds `ResourceState.deletionPolicy` and `updateReplacePolicy`, the
+ *       CloudFormation template attributes recorded at deploy time. cdkd
+ *       compares these against the next deploy's template to detect
+ *       attribute-only changes (e.g. `RemovalPolicy.DESTROY` removed →
+ *       `DeletionPolicy: Retain` now in template), which previously fell
+ *       through DiffCalculator as `No changes detected`. Layout is the same
+ *       as v4; only the resource-level shape grew. v4 readers see v5 as
+ *       `version: 5` and fail clearly.
  *
  * cdkd readers handle every prior version. Writers always emit
  * `STATE_SCHEMA_VERSION_CURRENT`. An older cdkd binary that only knows an
  * earlier version will fail with a clear error when it encounters a higher
  * version, rather than silently mishandling the new format.
  */
-export type StateSchemaVersion = 1 | 2 | 3 | 4;
+export type StateSchemaVersion = 1 | 2 | 3 | 4 | 5;
 export const STATE_SCHEMA_VERSION_LEGACY: StateSchemaVersion = 1;
-export const STATE_SCHEMA_VERSION_CURRENT: StateSchemaVersion = 4;
+export const STATE_SCHEMA_VERSION_CURRENT: StateSchemaVersion = 5;
 
 /**
  * Every schema version this binary can read. Writers always emit
@@ -29,7 +37,7 @@ export const STATE_SCHEMA_VERSION_CURRENT: StateSchemaVersion = 4;
  * forward-migration, and an unknown / future version triggers an explicit
  * "upgrade cdkd" error in the parser.
  */
-export const STATE_SCHEMA_VERSIONS_READABLE: readonly StateSchemaVersion[] = [1, 2, 3, 4];
+export const STATE_SCHEMA_VERSIONS_READABLE: readonly StateSchemaVersion[] = [1, 2, 3, 4, 5];
 
 /**
  * One `Fn::ImportValue` reference recorded during a consumer stack's
@@ -128,6 +136,31 @@ export interface ResourceState {
 
   /** Additional metadata */
   metadata?: Record<string, unknown>;
+
+  /**
+   * CloudFormation `DeletionPolicy` attribute recorded at deploy time
+   * (schema v5+). Compared against the template on the next deploy so an
+   * attribute-only change (e.g. `RemovalPolicy.DESTROY` removed →
+   * `DeletionPolicy: Retain`) is surfaced as a diff instead of silently
+   * being marked `No changes`. Optional for backwards compatibility — v4
+   * state writes leave this undefined; the diff comparator treats
+   * `undefined` as "no attribute recorded" rather than "Delete" so the
+   * first post-upgrade deploy only fires the diff when the template
+   * actually carries the attribute.
+   *
+   * The `| undefined` is explicit (vs bare `?:`) so a state-update site
+   * can spread `{ ...current, deletionPolicy: undefined }` to clear a
+   * previously-recorded value when the user removes the attribute from
+   * their CDK code; under `exactOptionalPropertyTypes: true` a bare `?:`
+   * would reject the literal-undefined assignment.
+   */
+  deletionPolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate' | undefined;
+
+  /**
+   * CloudFormation `UpdateReplacePolicy` attribute recorded at deploy time
+   * (schema v5+). Same semantics as `deletionPolicy` above.
+   */
+  updateReplacePolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate' | undefined;
 }
 
 /**
@@ -173,6 +206,31 @@ export interface ResourceChange {
 
   /** Property-level changes (for UPDATE) */
   propertyChanges?: PropertyChange[];
+
+  /**
+   * `DeletionPolicy` / `UpdateReplacePolicy` attribute changes (schema v5+).
+   * Populated when the template attribute differs from the value recorded in
+   * cdkd state. AWS has no API to mutate these attributes per-resource, so
+   * the deploy engine handles the change by updating cdkd state only — no
+   * provider call. UPDATE classification still fires when only these change
+   * (DiffCalculator does not stay at `NO_CHANGE`), so users see the diff
+   * instead of `No changes detected`.
+   */
+  attributeChanges?: AttributeChange[];
+}
+
+/**
+ * Template-level resource attribute change (schema v5+).
+ *
+ * `DeletionPolicy` / `UpdateReplacePolicy` are CloudFormation template
+ * metadata — they have no AWS API per-resource and are mutated through the
+ * cdkd state record alone.
+ */
+export interface AttributeChange {
+  /** Attribute name: `DeletionPolicy` or `UpdateReplacePolicy`. */
+  attribute: 'DeletionPolicy' | 'UpdateReplacePolicy';
+  oldValue: string | undefined;
+  newValue: string | undefined;
 }
 
 /**

--- a/tests/unit/analyzer/diff-calculator.test.ts
+++ b/tests/unit/analyzer/diff-calculator.test.ts
@@ -192,3 +192,126 @@ describe('DiffCalculator - intrinsic-aware diff', () => {
     expect(changes.get('Bucket')?.changeType).toBe('CREATE');
   });
 });
+
+describe('DiffCalculator - DeletionPolicy / UpdateReplacePolicy attribute diff (schema v5)', () => {
+  it('reports UPDATE with attributeChanges when DeletionPolicy is added to a resource with no other changes', async () => {
+    const state = baseState();
+    state.resources['Table'] = {
+      physicalId: 'my-table',
+      resourceType: 'AWS::DynamoDB::GlobalTable',
+      properties: { BillingMode: 'PAY_PER_REQUEST' },
+      // Pre-v5 state: no deletionPolicy field.
+    };
+
+    const template: CloudFormationTemplate = {
+      Resources: {
+        Table: {
+          Type: 'AWS::DynamoDB::GlobalTable',
+          Properties: { BillingMode: 'PAY_PER_REQUEST' },
+          DeletionPolicy: 'Retain',
+          UpdateReplacePolicy: 'Retain',
+        },
+      },
+    };
+
+    const calc = new DiffCalculator();
+    const changes = await calc.calculateDiff(state, template);
+    const change = changes.get('Table');
+
+    expect(change?.changeType).toBe('UPDATE');
+    expect(change?.propertyChanges).toEqual([]);
+    expect(change?.attributeChanges).toEqual([
+      { attribute: 'DeletionPolicy', oldValue: undefined, newValue: 'Retain' },
+      { attribute: 'UpdateReplacePolicy', oldValue: undefined, newValue: 'Retain' },
+    ]);
+  });
+
+  it('reports UPDATE with attributeChanges when DeletionPolicy is removed (RemovalPolicy.DESTROY → default Retain on the canonical CDK case)', async () => {
+    const state = baseState();
+    state.resources['Bucket'] = {
+      physicalId: 'my-bucket',
+      resourceType: 'AWS::S3::Bucket',
+      properties: { BucketName: 'my-bucket' },
+      deletionPolicy: 'Delete',
+      updateReplacePolicy: 'Delete',
+    };
+
+    const template: CloudFormationTemplate = {
+      Resources: {
+        Bucket: {
+          Type: 'AWS::S3::Bucket',
+          Properties: { BucketName: 'my-bucket' },
+          // RemovalPolicy stripped: CDK now emits Retain (the CFn default for
+          // L2 constructs that wrap RemovalPolicy).
+          DeletionPolicy: 'Retain',
+          UpdateReplacePolicy: 'Retain',
+        },
+      },
+    };
+
+    const calc = new DiffCalculator();
+    const changes = await calc.calculateDiff(state, template);
+    const change = changes.get('Bucket');
+
+    expect(change?.changeType).toBe('UPDATE');
+    expect(change?.attributeChanges).toEqual([
+      { attribute: 'DeletionPolicy', oldValue: 'Delete', newValue: 'Retain' },
+      { attribute: 'UpdateReplacePolicy', oldValue: 'Delete', newValue: 'Retain' },
+    ]);
+  });
+
+  it('stays NO_CHANGE when state and template carry the same attribute value (including both-undefined)', async () => {
+    const state = baseState();
+    state.resources['Topic'] = {
+      physicalId: 'my-topic',
+      resourceType: 'AWS::SNS::Topic',
+      properties: {},
+      deletionPolicy: 'Retain',
+    };
+
+    const template: CloudFormationTemplate = {
+      Resources: {
+        Topic: {
+          Type: 'AWS::SNS::Topic',
+          Properties: {},
+          DeletionPolicy: 'Retain',
+        },
+      },
+    };
+
+    const calc = new DiffCalculator();
+    const changes = await calc.calculateDiff(state, template);
+    expect(changes.get('Topic')?.changeType).toBe('NO_CHANGE');
+  });
+
+  it('combines propertyChanges and attributeChanges in one UPDATE entry', async () => {
+    const state = baseState();
+    state.resources['Topic'] = {
+      physicalId: 'my-topic',
+      resourceType: 'AWS::SNS::Topic',
+      properties: { DisplayName: 'old' },
+      deletionPolicy: 'Delete',
+    };
+
+    const template: CloudFormationTemplate = {
+      Resources: {
+        Topic: {
+          Type: 'AWS::SNS::Topic',
+          Properties: { DisplayName: 'new' },
+          DeletionPolicy: 'Retain',
+        },
+      },
+    };
+
+    const calc = new DiffCalculator();
+    const changes = await calc.calculateDiff(state, template);
+    const change = changes.get('Topic');
+
+    expect(change?.changeType).toBe('UPDATE');
+    expect(change?.propertyChanges?.length).toBe(1);
+    expect(change?.propertyChanges?.[0]?.path).toBe('DisplayName');
+    expect(change?.attributeChanges).toEqual([
+      { attribute: 'DeletionPolicy', oldValue: 'Delete', newValue: 'Retain' },
+    ]);
+  });
+});

--- a/tests/unit/state/schema-v4-migration.test.ts
+++ b/tests/unit/state/schema-v4-migration.test.ts
@@ -7,11 +7,14 @@ import {
 } from '../../../src/types/state.js';
 
 describe('State schema v4 — Fn::ImportValue strong-reference field', () => {
-  it('current schema version is 4', () => {
-    expect(STATE_SCHEMA_VERSION_CURRENT).toBe(4);
+  it('version 4 remains readable after later schema bumps', () => {
+    // v4 is no longer CURRENT (see schema-v5-migration.test.ts) but
+    // readers must still accept v4 state for backwards compat.
+    expect(STATE_SCHEMA_VERSIONS_READABLE).toContain(4);
+    expect(STATE_SCHEMA_VERSION_CURRENT).toBeGreaterThanOrEqual(4);
   });
 
-  it('readers accept every prior version + the new one', () => {
+  it('readers accept every prior version + v4', () => {
     expect(STATE_SCHEMA_VERSIONS_READABLE).toContain(1);
     expect(STATE_SCHEMA_VERSIONS_READABLE).toContain(2);
     expect(STATE_SCHEMA_VERSIONS_READABLE).toContain(3);

--- a/tests/unit/state/schema-v5-migration.test.ts
+++ b/tests/unit/state/schema-v5-migration.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  STATE_SCHEMA_VERSION_CURRENT,
+  STATE_SCHEMA_VERSIONS_READABLE,
+  type ResourceState,
+} from '../../../src/types/state.js';
+
+describe('State schema v5 — DeletionPolicy / UpdateReplacePolicy attribute fields', () => {
+  it('current schema version is 5', () => {
+    expect(STATE_SCHEMA_VERSION_CURRENT).toBe(5);
+  });
+
+  it('readers accept every prior version + v5', () => {
+    expect(STATE_SCHEMA_VERSIONS_READABLE).toContain(1);
+    expect(STATE_SCHEMA_VERSIONS_READABLE).toContain(2);
+    expect(STATE_SCHEMA_VERSIONS_READABLE).toContain(3);
+    expect(STATE_SCHEMA_VERSIONS_READABLE).toContain(4);
+    expect(STATE_SCHEMA_VERSIONS_READABLE).toContain(5);
+  });
+
+  it('ResourceState.deletionPolicy / updateReplacePolicy are optional', () => {
+    const minimal: ResourceState = {
+      physicalId: 'arn:aws:s3:::my-bucket',
+      resourceType: 'AWS::S3::Bucket',
+      properties: {},
+    };
+    expect(minimal.deletionPolicy).toBeUndefined();
+    expect(minimal.updateReplacePolicy).toBeUndefined();
+  });
+
+  it('ResourceState round-trips deletionPolicy / updateReplacePolicy through JSON', () => {
+    const resource: ResourceState = {
+      physicalId: 'my-table',
+      resourceType: 'AWS::DynamoDB::GlobalTable',
+      properties: {},
+      deletionPolicy: 'Retain',
+      updateReplacePolicy: 'Retain',
+    };
+
+    const round = JSON.parse(JSON.stringify(resource)) as ResourceState;
+    expect(round.deletionPolicy).toBe('Retain');
+    expect(round.updateReplacePolicy).toBe('Retain');
+  });
+
+  it('JSON.stringify omits undefined attribute fields (v4 state stays v4-shaped on serialize)', () => {
+    const v4ish: ResourceState = {
+      physicalId: 'x',
+      resourceType: 'AWS::S3::Bucket',
+      properties: {},
+      deletionPolicy: undefined,
+      updateReplacePolicy: undefined,
+    };
+    const serialized = JSON.stringify(v4ish);
+    expect(serialized).not.toContain('deletionPolicy');
+    expect(serialized).not.toContain('updateReplacePolicy');
+  });
+});


### PR DESCRIPTION
## Summary

`cdkd deploy` / `cdkd diff` now detect changes to the CloudFormation `DeletionPolicy` / `UpdateReplacePolicy` template attributes. Previously, removing `removalPolicy: RemovalPolicy.DESTROY` from a CDK construct silently surfaced as `No changes detected` because `DiffCalculator` only compared `Properties`.

- State schema **v5**: adds `ResourceState.deletionPolicy` / `updateReplacePolicy` (both optional). Backwards-compatible with v4 reads; writers always emit v5.
- `DiffCalculator.compareAttributes()` compares both attributes against the template; populates `ResourceChange.attributeChanges` and classifies as `UPDATE`.
- `DeployEngine` records template attributes in state on every successful create/update. A new attribute-only UPDATE path refreshes cdkd state without calling any provider (there is no per-resource AWS API for these fields).
- `cdkd diff` per-resource output now prints `DeletionPolicy: old → new [metadata only, no AWS API call]` lines alongside property changes.

**Out of scope for this PR** (intentionally deferred):
- `cdkd destroy`'s existing `DeletionPolicy: Retain` skip continues to read the template directly; it does not yet consult state. v5 state fields are not load-bearing on the destroy path.
- `cdkd state destroy` (state-only, no template) still does NOT honor `DeletionPolicy: Retain`. Separate follow-up.

## Test plan

- [x] 9 new / updated unit tests:
  - `tests/unit/state/schema-v5-migration.test.ts` (NEW, 5 tests): version constant, ResourceState round-trip, undefined-field serialize behavior.
  - `tests/unit/analyzer/diff-calculator.test.ts` (4 new tests): attribute-only UPDATE, attribute removal flip, NO_CHANGE when same, combined property+attribute UPDATE.
  - `tests/unit/state/schema-v4-migration.test.ts` (updated): v4 stays readable post-v5 bump.
- [x] `vp check` (typecheck + lint + prettier) pass.
- [x] `vp run build` pass.
- [x] `vp test run` — 278 files, 3332 tests passed.
- [ ] **Live-test pending**: exercising the real diff against AWS requires deploying a stack with one policy and redeploying with the other. The unit tests cover the algorithmic surface; broad integ (`bench-cdk-sample` / `lambda`) would catch any deploy-engine regression introduced by the new attribute-only UPDATE branch.

## Notes

`feat:` prefix because users see new behavior (UPDATE classification + diff lines) on what used to be silent. State schema v5 reads are backwards-compatible with v4 — no migration required — but state written under v5 is unreadable by pre-v5 cdkd binaries (clear "upgrade cdkd" error rather than silent corruption).
