### PR TITLE
chore(docs,skill): post-v5 followups — README schema bump, /check uses vp check

### DIFF
--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -11,10 +11,9 @@ Run all local quality checks. Use during development to verify the current state
 
 Run these sequentially and report results:
 
-1. `vp run typecheck`
-2. `vp run lint:fix`
-3. `vp run build`
-4. `vp run test`
+1. `vp check --fix` — typecheck + lint + Prettier formatting, with auto-fix. **Use this, not `vp run lint:fix`**: the CI workflow runs `vp check` (which includes Prettier), and `lint:fix` does NOT touch Prettier formatting — so a `lint:fix`-only run passes locally but CI fails with `Formatting issues found` on the same branch. See memory rule `feedback_vp_check_vs_lint_fix.md` for the underlying gotcha and PR #363 for a concrete trap.
+2. `vp run build`
+3. `vp run test`
 
 ## Output
 
@@ -22,8 +21,7 @@ Report as a table:
 
 | Check | Result |
 |-------|--------|
-| typecheck | pass/fail |
-| lint | pass/fail |
+| typecheck + lint + format (`vp check --fix`) | pass/fail |
 | build | pass/fail |
 | tests (N files, M tests) | pass/fail |
 

--- a/README.md
+++ b/README.md
@@ -358,7 +358,11 @@ state.json remains the canonical source of truth, and strong-reference
 safety checks scan it directly rather than trusting the index.
 
 See **[docs/cross-stack-references.md](docs/cross-stack-references.md)**
-for the full design (schema v4, lifecycle, locking, failure modes).
+for the full design (`Fn::ImportValue` strong-reference rules added in
+state schema v4, lifecycle, locking, failure modes). State schema is at
+v5 since v0.100.0; `DeletionPolicy` / `UpdateReplacePolicy` changes
+between deploys are now detected and surfaced (see
+[docs/state-management.md](docs/state-management.md)).
 
 ## Rollback behavior
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -245,6 +245,17 @@ comparator has a real baseline to diff against. `cdkd destroy`'s existing
 `DeletionPolicy: Retain` skip continues to read the template directly, so
 the v5 fields are not yet load-bearing on the destroy path.
 
+> **Upgrade note (v4 → v5)** — the **first** `cdkd deploy` after
+> upgrading from a v0.99.x binary will classify every resource whose
+> template carries a `DeletionPolicy` or `UpdateReplacePolicy` as
+> `UPDATE` and print one `↻ <logicalId> attribute update: ...` line +
+> a `Updated: N (metadata)` summary entry. **No AWS API call fires for
+> any of these resources** — cdkd is just recording the attribute value
+> into its own state file so the next diff has a baseline. The deploy
+> finishes in seconds regardless of resource count. Subsequent deploys
+> only surface `UPDATE` for resources whose template attribute actually
+> changed.
+
 ## State Schema
 
 ### StackState (`state.json`)


### PR DESCRIPTION
## Summary

Three small followups after PR #364 (schema v5 + DeletionPolicy/UpdateReplacePolicy diff detection) and the PR #363 Prettier-formatting CI trap.

- **README.md**: schema reference bumped from v4 → v5 (line 361) + brief mention of DeletionPolicy / UpdateReplacePolicy diff detection.
- **docs/state-management.md**: added explicit "Upgrade note (v4 → v5)" callout so users upgrading to v0.100.0 know the first deploy will show `Updated: N (metadata)` for every resource carrying a `DeletionPolicy` / `UpdateReplacePolicy` in its synth template — no AWS API fires, just state refresh.
- **.claude/skills/check/SKILL.md**: replaced `vp run typecheck` + `vp run lint:fix` with the single `vp check --fix` (which also runs Prettier). PR #363 burned a round-trip on this: `lint:fix` passed locally, then CI's `vp check` flagged Prettier formatting and failed. Memory rule `feedback_vp_check_vs_lint_fix.md` already records the gotcha; this commit makes the `/check` skill enforce it structurally so the next agent doesn't repeat the trap.

## Test plan

- [x] `vp check` clean (typecheck + lint + Prettier).
- [x] No source changes; pure docs / skill update.
