### PR TITLE
fix(release): clear npm publish warnings on bin path + repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "cdkd": "./dist/cli.js"
+    "cdkd": "dist/cli.js"
   },
   "files": [
     "dist",
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/go-to-k/cdkd.git"
+    "url": "git+https://github.com/go-to-k/cdkd.git"
   },
   "homepage": "https://github.com/go-to-k/cdkd",
   "bugs": {


### PR DESCRIPTION
## Summary

Every release fired two cosmetic warnings during `npm publish`:

```
npm warn publish "bin[cdkd]" script name dist/cli.js was invalid and removed
npm warn publish "repository.url" was normalized to "git+https://github.com/go-to-k/cdkd.git"
```

Both harmless (npm auto-corrected the published metadata) but `npm pkg fix` flags them as repair targets. Applied its exact suggestions:

- `bin.cdkd`: `"./dist/cli.js"` → `"dist/cli.js"` (drop `./` prefix)
- `repository.url`: `"https://..."` → `"git+https://..."` (add `git+` scheme)

## Risk

- No behavior change — the published tarball already had these normalized values. This just makes the source agree so the warnings stop firing.
- Verified with `npm publish --dry-run` locally: both warnings gone.

## Test plan

- [x] `npm publish --dry-run` no longer emits either warning
- [x] `vp run typecheck` / `lint` / `build` / `test` (3365 tests pass)
- [x] `npm pack --dry-run` shows the same files / bin entry as before
