### PR TITLE
test(apigateway): drop CloudWatch role from integ fixture to avoid retain-cycle flakiness

### DIFF
--- a/tests/integration/apigateway/lib/apigateway-stack.ts
+++ b/tests/integration/apigateway/lib/apigateway-stack.ts
@@ -47,9 +47,20 @@ exports.handler = async (event) => {
     // an OPTIONS method on every resource that has any non-OPTIONS method,
     // each one carrying both `Integration.IntegrationResponses` and
     // `MethodResponses`.
+    //
+    // `cloudWatchRole: false` skips CDK's auto-emitted `AWS::ApiGateway::Account`
+    // + its IAM Role for stage access logging. Both are emitted with
+    // `DeletionPolicy: Retain` (the Account resource is account-scoped
+    // singleton; CDK retains the supporting role by inference). On every
+    // re-run of this integ test, the previously-retained IAM Role
+    // (`<StackName>-HelloApiCloudWatchRole...`) blocks the next deploy with
+    // `Role with name ... already exists`. The CloudWatch logging path is
+    // not exercised by this smoke test, so disabling it altogether is the
+    // cleanest way to keep the fixture self-contained across runs.
     const api = new apigateway.RestApi(this, 'HelloApi', {
       restApiName: 'cdkd-hello-api',
       description: 'A simple API Gateway + Lambda example for cdkd testing',
+      cloudWatchRole: false,
       defaultCorsPreflightOptions: {
         allowOrigins: apigateway.Cors.ALL_ORIGINS,
         allowMethods: apigateway.Cors.ALL_METHODS,


### PR DESCRIPTION
## Summary

Drop `AWS::ApiGateway::Account` + its supporting `AWS::IAM::Role` from the `apigateway` integ fixture by setting `cloudWatchRole: false` on the `RestApi` props. CDK emits both with `DeletionPolicy: Retain` (Account is an account-scoped singleton; CDK retains the supporting role by inference). On every re-run of the integ test, the previously-retained IAM Role (`<StackName>-HelloApiCloudWatchRole...`) blocked the next deploy with `Role with name ... already exists` — every fresh run had to manually `aws iam delete-role` first before deploy could succeed. The CloudWatch logging path is not exercised by this smoke test, so disabling it altogether is the cleanest self-contained fix.

Surfaced in PR #374's `/run-integ apigateway` run (which first hit the retained role from PR #373's integ run and required pre-flight manual cleanup).

Resource count: 13 → 11. CORS preflight regression coverage from PR #373's fixture extension is preserved (OPTIONS methods at both `/` and `/hello` are still emitted by `defaultCorsPreflightOptions`).

## Test plan

- [x] `vp check --fix` (typecheck + lint + Prettier) — pass
- [x] `vp run build` — pass
- [x] `vp run test` — 281 files, 3388 tests, pass
- [x] **Two back-to-back `/run-integ apigateway` cycles against `us-east-1` with no manual cleanup in between**:
  - Run 1: 11/11 created, `curl -X OPTIONS` → 204 + `Access-Control-Allow-Origin: *` + `Access-Control-Allow-Methods: OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD`, destroy 11 deleted / 0 retained / 0 errors
  - Run 2 (the critical anti-flakiness check): no pre-flight orphan, deploy succeeded on first attempt 11/11, destroy 11 deleted / 0 retained / 0 errors
