### PR TITLE
feat(dynamodb-globaltable): close 5 deferred items (cross-region drift + Tags + throughput round-trip + tests + integ)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@aws-sdk/client-api-gateway": "^3.1017.0",
     "@aws-sdk/client-apigatewayv2": "^3.1018.0",
+    "@aws-sdk/client-application-auto-scaling": "^3.1047.0",
     "@aws-sdk/client-appsync": "^3.1018.0",
     "@aws-sdk/client-auto-scaling": "^3.1045.0",
     "@aws-sdk/client-bedrock-agentcore": "^3.1017.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@aws-sdk/client-apigatewayv2':
         specifier: ^3.1018.0
         version: 3.1018.0
+      '@aws-sdk/client-application-auto-scaling':
+        specifier: ^3.1047.0
+        version: 3.1047.0
       '@aws-sdk/client-appsync':
         specifier: ^3.1018.0
         version: 3.1018.0
@@ -263,6 +266,10 @@ packages:
     resolution: {integrity: sha512-3cRIDMgyokB8vQVVcin5HG6rudiMdh7/XvD0TmgoMFtFZcytxuQ+S2tricylZs9IoPBIFnVqsUfJRJdoa56jSA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-application-auto-scaling@3.1047.0':
+    resolution: {integrity: sha512-BVlLFt0sO92tNKwVlYIsASvaUvHoH2ckffW+RevDItub2w9Uwxm0RFuaPDSEHaTDk6LOnbiVwXgUrW/Fzf5Y2Q==, tarball: https://registry.npmjs.org/@aws-sdk/client-application-auto-scaling/-/client-application-auto-scaling-3.1047.0.tgz}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-appsync@3.1018.0':
     resolution: {integrity: sha512-sXQbTJdUMjol5cmq9Eng+gGd47VzJloWaYcg+qJpGqWkqtaUecj/7Lr+9+9waSekJ6XzObNAGScOoriNbDsbAQ==}
     engines: {node: '>=20.0.0'}
@@ -431,6 +438,10 @@ packages:
     resolution: {integrity: sha512-TNrx7eq6nKNOO62HWPqoBqPLXEkW6nLZQGwjL6lq1jZtigWYbK1NbCnT7mKDzbLMHZfuOECUt3n6CzxjUW9HWQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.10':
+    resolution: {integrity: sha512-ZGFFlYynBR78Y/F8b/7y4i4sgW/iGwJSjoM7AZo5Et6vyr4/L0bunN+uzKMsvecCZyqcPp4RRK7Rs17l0kMujg==, tarball: https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.10.tgz}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.974.8':
     resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
     engines: {node: '>=20.0.0'}
@@ -447,12 +458,20 @@ packages:
     resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.36':
+    resolution: {integrity: sha512-gE+CGuPZD1eqUWGSrM8CXDjlwuPujIuwI+IlorD1wE2RcANKKT4jscB9GY1nTJbjmXzD18sycsYbgCG5m3n4/g==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.36.tgz}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.25':
     resolution: {integrity: sha512-qPymamdPcLp6ugoVocG1y5r69ScNiRzb0hogX25/ij+Wz7c7WnsgjLTaz7+eB5BfRxeyUwuw5hgULMuwOGOpcw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.36':
     resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.38':
+    resolution: {integrity: sha512-cHZo3bV6zN9joDQ2AYVctfzHTKStxWKwnGu0z7GwCUC+DAtB3qL/+26l+a63RbmFbVvb1JK+0vJKodN3hRMwyw==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.38.tgz}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.25':
@@ -467,6 +486,10 @@ packages:
     resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.40':
+    resolution: {integrity: sha512-0NFGS9I3PD2yMveQqqpwpRdyZVStzgk0Yr2rZHh80kV/QNqQCK5lSrksvU3nBcRNSUF5Uk8rL3Xk0EVR+UVAnA==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.40.tgz}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.25':
     resolution: {integrity: sha512-bUdmyJeVua7SmD+g2a65x2/0YqsGn4K2k4GawI43js0odaNaIzpIhLtHehUnPnfLuyhPWbJR1NyuIO4iMVfM0w==}
     engines: {node: '>=20.0.0'}
@@ -477,6 +500,10 @@ packages:
 
   '@aws-sdk/credential-provider-login@3.972.38':
     resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.40':
+    resolution: {integrity: sha512-IEIl+UQnrEjZP53TSl91e8LBephi4i1Mt9WZrMgN8pOg6xPOLZdkN1GhsEzjkMD1TQy4Fp2dwWA/9ToTQFOlLA==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.40.tgz}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.26':
@@ -491,12 +518,20 @@ packages:
     resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.41':
+    resolution: {integrity: sha512-h6BlclpsPGkx7Pv7ukr8oKVqN3jvxnH5n9ZIUQa8focr1ZkKd2MYiPJ2Nv9GI97dohJVJBfZAsTp/qoZL5R1pw==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.41.tgz}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.23':
     resolution: {integrity: sha512-IL/TFW59++b7MpHserjUblGrdP5UXy5Ekqqx1XQkERXBFJcZr74I7VaSrQT5dxdRMU16xGK4L0RQ5fQG1pMgnA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.34':
     resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.36':
+    resolution: {integrity: sha512-eDQ6X7clTAOxXegOx4rGT1hyfusGEYdJGCGo0Ym2+CKeMQBjk+SJSxSVev11NJew5xJHJ/c3hryl2awKaxuSEA==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.36.tgz}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.25':
@@ -511,6 +546,10 @@ packages:
     resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.40':
+    resolution: {integrity: sha512-jaABbsoOkGlKg5kaHetYmUV6mWM57H89ia0Yksom1XxC847mfjmEVb4p7VijS1sjPbXjUii4cftJuwsl4MXkRg==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.40.tgz}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.25':
     resolution: {integrity: sha512-uM1OtoJgj+yK3MlAmda8uR9WJJCdm5HB25JyCeFL5a5q1Fbafalf4uKidFO3/L0Pgd+Fsflkb4cM6jHIswi3QQ==}
     engines: {node: '>=20.0.0'}
@@ -521,6 +560,10 @@ packages:
 
   '@aws-sdk/credential-provider-web-identity@3.972.38':
     resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.40':
+    resolution: {integrity: sha512-bfIrM8IIzbRtXRQWx/vNEUBLTImLZyX5uKk8uSdeSAZ4Mj3Yi4UnRJLK4FkQLWErbM3McpVLQ1DaM6XO66Ed5g==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.40.tgz}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.972.26':
@@ -551,6 +594,10 @@ packages:
     resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-host-header@3.972.11':
+    resolution: {integrity: sha512-CBC6+tVYaOJo7QXgN1zJ4Ba2f3/Cpy4eRViYFimXW/O5Mn8hBmgXXzHu4vy4ubT80YWnp8aCFygr7dTOa14yQg==, tarball: https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.11.tgz}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-host-header@3.972.8':
     resolution: {integrity: sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==}
     engines: {node: '>=20.0.0'}
@@ -569,6 +616,10 @@ packages:
 
   '@aws-sdk/middleware-recursion-detection@3.972.11':
     resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.12':
+    resolution: {integrity: sha512-5eltYxKB4MfdQv7/VhWxRbAVQKow5dz9votRFigTYrWJHMQXwLMltlbk7KFWSZh5NDBySfmjT7Jv/DWfYCmDng==, tarball: https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.12.tgz}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-recursion-detection@3.972.9':
@@ -619,6 +670,10 @@ packages:
     resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-user-agent@3.972.40':
+    resolution: {integrity: sha512-QLpD+HNQtL1Mc49/GRa6RmZvi/TEYBWPevC9F3L+j96IoG3xOSRctdQfbkX0lETb3TX9QQXU1oGYDmAB+YJprA==, tarball: https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.40.tgz}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/nested-clients@3.996.15':
     resolution: {integrity: sha512-k6WAVNkub5DrU46iPQvH1m0xc1n+0dX79+i287tYJzf5g1yU2rX3uf4xNeL5JvK1NtYgfwMnsxHqhOXFBn367A==}
     engines: {node: '>=20.0.0'}
@@ -631,12 +686,20 @@ packages:
     resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.8':
+    resolution: {integrity: sha512-/Vw2M27w+0APfMDzDpvv8auA4WiJ4D22+lC61pMS2M8Wk+4IydeRqh5utbrh+A5gQRxgUYd/xz3tdv8nQlmiHg==, tarball: https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.8.tgz}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.972.10':
     resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.13':
     resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.14':
+    resolution: {integrity: sha512-VuLXVmm7+lKVxqFcOItPkXhjbJ02iUfxkxheRu41SfWf6/xrZup2A2SwHZos/LeQGu3SBHeqTQht80Uo3ienPA==, tarball: https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.14.tgz}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/s3-request-presigner@3.1018.0':
@@ -651,6 +714,10 @@ packages:
     resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.26':
+    resolution: {integrity: sha512-2N62veqdMZBCwQUHsbhtnaovOFjOa5Dn3dAD1nRqFTUXR4QmirT3HZnfus/L1DS08Vm5CkoKmL0iMVt6YbqEag==, tarball: https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.26.tgz}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1018.0':
     resolution: {integrity: sha512-97OPNJHy37wmGOX44xAcu6E9oSTiqK9uPcy/fWpmN5uB3JuEp1f6x60Xot/jp+FxwhQWIFUsVJFnm3QKqt7T6Q==}
     engines: {node: '>=20.0.0'}
@@ -661,6 +728,10 @@ packages:
 
   '@aws-sdk/token-providers@3.1041.0':
     resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1047.0':
+    resolution: {integrity: sha512-GwJUeMijpeO2SOGGLRg4q2Nj9foBUBd7hTALYVId+m8fQmA4P2hITp5dmrZFd4AjEkSVmt2eFqmk3TttF7HZeQ==, tarball: https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1047.0.tgz}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.6':
@@ -683,6 +754,10 @@ packages:
     resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/util-endpoints@3.996.9':
+    resolution: {integrity: sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg==, tarball: https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.9.tgz}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/util-format-url@3.972.10':
     resolution: {integrity: sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==}
     engines: {node: '>=20.0.0'}
@@ -697,6 +772,9 @@ packages:
 
   '@aws-sdk/util-user-agent-browser@3.972.10':
     resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
+
+  '@aws-sdk/util-user-agent-browser@3.972.11':
+    resolution: {integrity: sha512-kq3RS6XQtHMrLFShbkem6h+8fxazB3jEIsbMC6aaSInOciRGE+eGAqTgJ+obO7Euo/pjM8thVqLiLISEH9X9DA==, tarball: https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.11.tgz}
 
   '@aws-sdk/util-user-agent-browser@3.972.8':
     resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
@@ -719,12 +797,25 @@ packages:
       aws-crt:
         optional: true
 
+  '@aws-sdk/util-user-agent-node@3.973.26':
+    resolution: {integrity: sha512-9bHR/EERjhrUGyo1qW620ogbGBtCglYB/pEtcm85sVd4/Ah+bwdLI3g1aJf75oNwNwh7+fw+8wOk/OCWHjzVmA==, tarball: https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.26.tgz}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
   '@aws-sdk/xml-builder@3.972.16':
     resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.22':
     resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.24':
+    resolution: {integrity: sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==, tarball: https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -1620,12 +1711,20 @@ packages:
     resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.2':
+    resolution: {integrity: sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog==, tarball: https://registry.npmjs.org/@smithy/core/-/core-3.24.2.tgz}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.12':
     resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.2.14':
     resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.2':
+    resolution: {integrity: sha512-iYr9ekBjmZ+FwkiHEopqGscBbl78X62cq3p5Dd0eC+gNd7fybNZFQQdDuOQjTVmFymleuA8YRWZnuXWZ8B3kKA==, tarball: https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.2.tgz}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.12':
@@ -1654,6 +1753,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.3.17':
     resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.2':
+    resolution: {integrity: sha512-3wF40g8OOCA5BnwQUvwtzZqYBbWWftDjpAlWIUo6Yld3ZzJaMAKqg7MWQBPjE8oLaqvZQUE7tVGlZPsae6A4bQ==, tarball: https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.2.tgz}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.13':
@@ -1752,6 +1855,10 @@ packages:
     resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.2':
+    resolution: {integrity: sha512-EdksTZ8UXYxGUgQ4mpIKrHoaj9WVGsp66TpZuixLAz1Jex8YDLnS4RH9ktGED5aOpN0OJlEtrsC9IGt76go1eA==, tarball: https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.2.tgz}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.12':
     resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
     engines: {node: '>=18.0.0'}
@@ -1806,6 +1913,10 @@ packages:
 
   '@smithy/signature-v4@5.3.14':
     resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.2':
+    resolution: {integrity: sha512-1km1OjdLRFuITWpCPofjFqzZ+tbeWuB72ZhcYjbjkCxZ21tTPfIs4GUxRrelMyKMLxLghGD58RENnXorU/O8cw==, tarball: https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.2.tgz}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.12.13':
@@ -2601,6 +2712,10 @@ packages:
 
   fast-xml-parser@5.7.2:
     resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==, tarball: https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz}
     hasBin: true
 
   fdir@6.5.0:
@@ -4054,6 +4169,29 @@ snapshots:
       '@smithy/util-retry': 4.2.12
       '@smithy/util-stream': 4.5.20
       '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-application-auto-scaling@3.1047.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.10
+      '@aws-sdk/credential-provider-node': 3.972.41
+      '@aws-sdk/middleware-host-header': 3.972.11
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.12
+      '@aws-sdk/middleware-user-agent': 3.972.40
+      '@aws-sdk/region-config-resolver': 3.972.14
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.9
+      '@aws-sdk/util-user-agent-browser': 3.972.11
+      '@aws-sdk/util-user-agent-node': 3.973.26
+      '@smithy/core': 3.24.2
+      '@smithy/fetch-http-handler': 5.4.2
+      '@smithy/node-http-handler': 4.7.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -5941,6 +6079,15 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.24
+      '@smithy/core': 3.24.2
+      '@smithy/signature-v4': 5.4.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.8':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -5979,6 +6126,14 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.25':
     dependencies:
       '@aws-sdk/core': 3.973.25
@@ -6003,6 +6158,16 @@ snapshots:
       '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/fetch-http-handler': 5.4.2
+      '@smithy/node-http-handler': 4.7.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.25':
@@ -6062,6 +6227,24 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.10
+      '@aws-sdk/credential-provider-env': 3.972.36
+      '@aws-sdk/credential-provider-http': 3.972.38
+      '@aws-sdk/credential-provider-login': 3.972.40
+      '@aws-sdk/credential-provider-process': 3.972.36
+      '@aws-sdk/credential-provider-sso': 3.972.40
+      '@aws-sdk/credential-provider-web-identity': 3.972.40
+      '@aws-sdk/nested-clients': 3.997.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/credential-provider-imds': 4.3.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-login@3.972.25':
     dependencies:
       '@aws-sdk/core': 3.973.25
@@ -6096,6 +6279,17 @@ snapshots:
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.10
+      '@aws-sdk/nested-clients': 3.997.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
       '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -6152,6 +6346,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.41':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.36
+      '@aws-sdk/credential-provider-http': 3.972.38
+      '@aws-sdk/credential-provider-ini': 3.972.40
+      '@aws-sdk/credential-provider-process': 3.972.36
+      '@aws-sdk/credential-provider-sso': 3.972.40
+      '@aws-sdk/credential-provider-web-identity': 3.972.40
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/credential-provider-imds': 4.3.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-process@3.972.23':
     dependencies:
       '@aws-sdk/core': 3.973.25
@@ -6167,6 +6377,14 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
@@ -6209,6 +6427,18 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.10
+      '@aws-sdk/nested-clients': 3.997.8
+      '@aws-sdk/token-providers': 3.1047.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-web-identity@3.972.25':
     dependencies:
       '@aws-sdk/core': 3.973.25
@@ -6240,6 +6470,17 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.10
+      '@aws-sdk/nested-clients': 3.997.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
       '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -6309,6 +6550,13 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-host-header@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-host-header@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -6339,6 +6587,14 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@aws/lambda-invoke-store': 0.2.4
       '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.12':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.2
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
@@ -6463,6 +6719,15 @@ snapshots:
       '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.14.1
       '@smithy/util-retry': 4.3.8
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.10
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.9
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.996.15':
@@ -6595,6 +6860,29 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.997.8':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.10
+      '@aws-sdk/middleware-host-header': 3.972.11
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.12
+      '@aws-sdk/middleware-user-agent': 3.972.40
+      '@aws-sdk/region-config-resolver': 3.972.14
+      '@aws-sdk/signature-v4-multi-region': 3.996.26
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.9
+      '@aws-sdk/util-user-agent-browser': 3.972.11
+      '@aws-sdk/util-user-agent-node': 3.973.26
+      '@smithy/core': 3.24.2
+      '@smithy/fetch-http-handler': 5.4.2
+      '@smithy/node-http-handler': 4.7.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/region-config-resolver@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -6608,6 +6896,13 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/config-resolver': 4.4.17
       '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/region-config-resolver@3.972.14':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
@@ -6637,6 +6932,14 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/protocol-http': 5.3.14
       '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.26':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/signature-v4': 5.4.2
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
@@ -6676,6 +6979,17 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/token-providers@3.1047.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.10
+      '@aws-sdk/nested-clients': 3.997.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/types@3.973.6':
     dependencies:
       '@smithy/types': 4.13.1
@@ -6706,6 +7020,13 @@ snapshots:
       '@smithy/util-endpoints': 3.4.2
       tslib: 2.8.1
 
+  '@aws-sdk/util-endpoints@3.996.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/util-format-url@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -6725,6 +7046,13 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-browser@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.11':
     dependencies:
       '@aws-sdk/types': 3.973.8
       '@smithy/types': 4.14.1
@@ -6756,6 +7084,14 @@ snapshots:
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/util-user-agent-node@3.973.26':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.40
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/xml-builder@3.972.16':
     dependencies:
       '@smithy/types': 4.13.1
@@ -6767,6 +7103,13 @@ snapshots:
       '@nodable/entities': 2.1.0
       '@smithy/types': 4.14.1
       fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.24':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -7442,6 +7785,12 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.2':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.12':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
@@ -7456,6 +7805,12 @@ snapshots:
       '@smithy/property-provider': 4.2.14
       '@smithy/types': 4.14.1
       '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.2':
+    dependencies:
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.12':
@@ -7502,6 +7857,12 @@ snapshots:
       '@smithy/querystring-builder': 4.2.14
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.2':
+    dependencies:
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.2.13':
@@ -7680,6 +8041,12 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.2':
+    dependencies:
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
@@ -7760,6 +8127,12 @@ snapshots:
       '@smithy/util-middleware': 4.2.14
       '@smithy/util-uri-escape': 4.2.2
       '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.2':
+    dependencies:
+      '@smithy/core': 3.24.2
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/smithy-client@4.12.13':
@@ -8533,6 +8906,13 @@ snapshots:
       strnum: 2.2.2
 
   fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+
+  fast-xml-parser@5.7.3:
     dependencies:
       '@nodable/entities': 2.1.0
       fast-xml-builder: 1.2.0

--- a/src/provisioning/providers/dynamodb-globaltable-provider.ts
+++ b/src/provisioning/providers/dynamodb-globaltable-provider.ts
@@ -27,6 +27,10 @@ import {
   type UpdateReplicationGroupMemberAction,
   type UpdateTableCommandInput,
 } from '@aws-sdk/client-dynamodb';
+import {
+  ApplicationAutoScalingClient,
+  DescribeScalingPoliciesCommand,
+} from '@aws-sdk/client-application-auto-scaling';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
@@ -82,12 +86,25 @@ import type {
  *    calling `update()`, but the guard is defense-in-depth.
  *  - Per-replica drift (`ContributorInsightsSpecification` /
  *    `PointInTimeRecoverySpecification` / `KinesisStreamSpecification`)
- *    is surfaced for the LOCAL replica only; cross-region replicas
- *    require per-region SDK clients which are out of scope for v1.
+ *    is surfaced for BOTH the LOCAL replica AND cross-region replicas
+ *    via per-region SDK clients (cached in `regionalClientCache` for
+ *    the deploy run). Issue #389 lifted the v1 LOCAL-only limitation.
+ *  - Cross-region replica Tags propagation (Issue #389): when the
+ *    update path detects a Tags-only diff on a non-local replica,
+ *    cdkd resolves the replica's table ARN by swapping the region
+ *    segment of the local ARN and issues `TagResource` /
+ *    `UntagResource` against a per-region client.
  */
 export class DynamoDBGlobalTableProvider implements ResourceProvider {
   private dynamoDBClient: DynamoDBClient;
   private logger = getLogger().child('DynamoDBGlobalTableProvider');
+  /**
+   * Caches per-region `DynamoDBClient` instances for cross-region drift
+   * reads (`readCurrentState`) and cross-region Tag propagation
+   * (`update()`). Keyed by region string; reuses the default credential
+   * chain. Lifetime is the provider instance — one deploy run.
+   */
+  private regionalClientCache = new Map<string, DynamoDBClient>();
   /**
    * Caches `getAttribute(physicalId, attribute)` results for the lifetime
    * of this provider instance (one deploy run). Safe under the current
@@ -128,6 +145,52 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
   constructor() {
     const awsClients = getAwsClients();
     this.dynamoDBClient = awsClients.dynamoDB;
+  }
+
+  /**
+   * Return a `DynamoDBClient` pinned to the given region, caching per
+   * region for the lifetime of this provider instance. Uses the default
+   * credential chain (env / shared config / IAM role) — no explicit
+   * credential plumbing needed.
+   *
+   * Used by `readCurrentState` (cross-region per-replica sub-spec reads)
+   * and `update()` (cross-region replica Tag propagation). Both code
+   * paths fire region-scoped DynamoDB APIs (`DescribeContributorInsights`
+   * / `DescribeContinuousBackups` / `DescribeKinesisStreamingDestination`
+   * / `TagResource` / `UntagResource`) against the replica's region.
+   *
+   * The cache may return `this.dynamoDBClient` when `region` happens to
+   * match the local client's region — in tests the local mock is
+   * intercepted via `vi.mock('../../utils/aws-clients.js')` so reuse
+   * is safe (and explicitly desired so the mock catches the call).
+   */
+  private getRegionalClient(region: string): DynamoDBClient {
+    const cached = this.regionalClientCache.get(region);
+    if (cached) return cached;
+    const client = new DynamoDBClient({ region });
+    this.regionalClientCache.set(region, client);
+    return client;
+  }
+
+  /**
+   * Construct the regional table ARN for a cross-region replica of a
+   * GlobalTable. AWS replicates the same `TableName` across every
+   * replica region, with each replica's ARN differing only in the
+   * `:<region>:` segment. Cheaper than a second `DescribeTable` round-
+   * trip on the regional client.
+   *
+   * Example:
+   *   local ARN:   arn:aws:dynamodb:us-east-1:123:table/Foo
+   *   for eu-west-1 → arn:aws:dynamodb:eu-west-1:123:table/Foo
+   *
+   * Returns `undefined` when the local ARN is malformed (defensive —
+   * downstream callers omit the offending operation rather than throw).
+   */
+  private replicaArnForRegion(localTableArn: string, targetRegion: string): string | undefined {
+    const segments = localTableArn.split(':');
+    if (segments.length < 6) return undefined;
+    segments[3] = targetRegion;
+    return segments.join(':');
   }
 
   /**
@@ -560,9 +623,9 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
       // NO top-level `Tags` — tags live inside each `Replicas[]` entry
       // as `Replicas[?Region==<region>].Tags`. For the LOCAL replica we
       // diff and apply via TagResource / UntagResource on the local
-      // table ARN; cross-region replicas' Tags require per-region SDK
-      // clients and are deferred (logged at debug if the diff is non-
-      // empty for a non-local replica).
+      // table ARN; cross-region replicas' Tags are propagated inside
+      // the per-replica modify loop further down via the per-region
+      // client returned by `getRegionalClient` (Issue #389).
       const describeResp = await this.dynamoDBClient.send(
         new DescribeTableCommand({ TableName: physicalId })
       );
@@ -702,6 +765,59 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
       for (const replica of replicaDiff.modified) {
         const region = replica['Region'] as string | undefined;
         if (!region || region === currentRegion) continue;
+
+        // Look up the matching previous replica entry so we can diff
+        // Tags independently of the non-Tags fields (UpdateReplica's
+        // SDK action does not accept Tags — cross-region tag changes
+        // must go through TagResource / UntagResource against the
+        // replica's region-scoped table ARN).
+        const oldReplica = (
+          (previousProperties['Replicas'] ?? []) as Array<Record<string, unknown>>
+        ).find((r) => r['Region'] === region);
+        const oldReplicaTags = oldReplica?.['Tags'] as
+          | Array<{ Key?: string; Value?: string }>
+          | undefined;
+        const newReplicaTags = replica['Tags'] as
+          | Array<{ Key?: string; Value?: string }>
+          | undefined;
+
+        // Cross-region Tags propagation (Issue #389): when AWS reports
+        // a TableArn, swap its region segment to construct the
+        // replica's ARN, then issue TagResource / UntagResource via
+        // a per-region client. Best-effort — a failure here logs at
+        // warn but does NOT block the rest of the replica modify
+        // loop (the local replica's Tags already applied above; the
+        // cross-region Tags failure surfaces as drift on the next
+        // run instead of as a deploy abort).
+        if (!deepEqual(oldReplicaTags, newReplicaTags)) {
+          if (tableArn) {
+            const replicaArn = this.replicaArnForRegion(tableArn, region);
+            if (replicaArn) {
+              try {
+                const regionalClient = this.getRegionalClient(region);
+                await this.applyTagDiffOnClient(
+                  regionalClient,
+                  replicaArn,
+                  oldReplicaTags,
+                  newReplicaTags
+                );
+              } catch (tagErr) {
+                this.logger.warn(
+                  `Could not apply Tags diff to cross-region replica ${region} of ${physicalId}: ${tagErr instanceof Error ? tagErr.message : String(tagErr)}. The replica's Tags state will surface as drift until the next successful deploy.`
+                );
+              }
+            } else {
+              this.logger.warn(
+                `Could not derive replica ARN for region ${region} from ${tableArn} — skipping Tags propagation for ${physicalId}`
+              );
+            }
+          } else {
+            this.logger.warn(
+              `Local DescribeTable returned no TableArn — cannot propagate Tags to cross-region replica ${region} of ${physicalId}`
+            );
+          }
+        }
+
         const updateAction: UpdateReplicationGroupMemberAction = { RegionName: region };
         if (replica['KMSMasterKeyId'] !== undefined) {
           updateAction.KMSMasterKeyId = replica['KMSMasterKeyId'] as string;
@@ -718,12 +834,10 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
         }
         // AWS rejects an UpdateReplica with no update fields
         // (ValidationException). When the only change in the modified
-        // replica is `Tags` (which UpdateReplica's SDK action does not
-        // accept — cross-region Tag propagation needs a per-region SDK
-        // client + TagResource on that replica's ARN, deferred), the
-        // updateAction has only `RegionName`. Skip the SDK call in
-        // that case and log at debug so the cross-region tag drift is
-        // visible but does not error the deploy.
+        // replica is `Tags` (now applied above via per-region client),
+        // the updateAction has only `RegionName`. Skip the
+        // UpdateReplica SDK call in that case — the Tags-only diff is
+        // already in flight against the regional client.
         const hasUpdateField =
           updateAction.KMSMasterKeyId !== undefined ||
           updateAction.GlobalSecondaryIndexes !== undefined ||
@@ -731,8 +845,8 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
         if (!hasUpdateField) {
           this.logger.debug(
             `Cross-region replica ${region} of ${physicalId}: only Tags-style ` +
-              `changes detected; skipping UpdateReplica (AWS rejects empty ` +
-              `Update actions). Per-region Tag propagation is deferred.`
+              `changes detected; UpdateReplica skipped (AWS rejects empty ` +
+              `Update actions). Tags propagation handled above via per-region client.`
           );
           continue;
         }
@@ -872,10 +986,28 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
 
   /**
    * Apply a diff between old and new CFn-shape Tags arrays via DynamoDB's
-   * `TagResource` / `UntagResource` APIs. Both take the table ARN as
-   * `ResourceArn`.
+   * `TagResource` / `UntagResource` APIs against the local client. Both
+   * take the table ARN as `ResourceArn`.
+   *
+   * Local-replica convenience wrapper around `applyTagDiffOnClient` so
+   * existing call sites stay unchanged.
    */
   private async applyTagDiff(
+    tableArn: string,
+    oldTagsRaw: Array<{ Key?: string; Value?: string }> | undefined,
+    newTagsRaw: Array<{ Key?: string; Value?: string }> | undefined
+  ): Promise<void> {
+    await this.applyTagDiffOnClient(this.dynamoDBClient, tableArn, oldTagsRaw, newTagsRaw);
+  }
+
+  /**
+   * Apply a Tags diff against the given `DynamoDBClient` (which may be
+   * the local client or a per-region client returned by
+   * `getRegionalClient`). Used by the local-replica path AND the
+   * cross-region replica Tags propagation path (Issue #389).
+   */
+  private async applyTagDiffOnClient(
+    client: DynamoDBClient,
     tableArn: string,
     oldTagsRaw: Array<{ Key?: string; Value?: string }> | undefined,
     newTagsRaw: Array<{ Key?: string; Value?: string }> | undefined
@@ -903,17 +1035,13 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
     }
 
     if (tagsToRemove.length > 0) {
-      await this.dynamoDBClient.send(
-        new UntagResourceCommand({ ResourceArn: tableArn, TagKeys: tagsToRemove })
-      );
+      await client.send(new UntagResourceCommand({ ResourceArn: tableArn, TagKeys: tagsToRemove }));
       this.logger.debug(
         `Removed ${tagsToRemove.length} tag(s) from DynamoDB GlobalTable ${tableArn}`
       );
     }
     if (tagsToAdd.length > 0) {
-      await this.dynamoDBClient.send(
-        new TagResourceCommand({ ResourceArn: tableArn, Tags: tagsToAdd })
-      );
+      await client.send(new TagResourceCommand({ ResourceArn: tableArn, Tags: tagsToAdd }));
       this.logger.debug(
         `Added/updated ${tagsToAdd.length} tag(s) on DynamoDB GlobalTable ${tableArn}`
       );
@@ -1193,44 +1321,115 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
 
       // Replicas: always emit `[]` placeholder per PR #145 — a console-side
       // replica add on a previously single-region table must show as drift.
-      // Map RegionName → Region (CFn's per-replica shape) and attach the
-      // local replica's per-replica sub-specifications (PITR / Kinesis /
-      // ContributorInsights) when AWS reports them.
+      // Map RegionName → Region (CFn's per-replica shape) and attach
+      // per-replica sub-specifications (PITR / Kinesis /
+      // ContributorInsights / Tags) for BOTH the local AND cross-region
+      // replicas — cross-region uses per-region SDK clients
+      // (`getRegionalClient`) so each replica's sub-spec state surfaces
+      // as drift just like the local one (Issue #389 lifted the v1
+      // LOCAL-only limitation).
       const currentRegion = (await this.dynamoDBClient.config.region()) ?? '';
       const tableNameForSubs = table.TableName ?? physicalId;
       const replicas = await Promise.all(
         (table.Replicas ?? []).map(async (r) => {
           const entry: Record<string, unknown> = { Region: r.RegionName };
           if (r.KMSMasterKeyId !== undefined) entry['KMSMasterKeyId'] = r.KMSMasterKeyId;
-          // Per-replica sub-specs + Tags: only the local replica in v1.
-          // Cross-region calls would need a per-region client, deferred.
-          // Tags live at `Replicas[].Tags` in the CFn `GlobalTable`
-          // schema (there is no top-level `Tags`), so they MUST be
+          if (!r.RegionName) return entry;
+
+          const isLocal = r.RegionName === currentRegion;
+          const client = isLocal ? this.dynamoDBClient : this.getRegionalClient(r.RegionName);
+          const regionLabel = r.RegionName;
+          const replicaArn = isLocal
+            ? table.TableArn
+            : table.TableArn
+              ? this.replicaArnForRegion(table.TableArn, r.RegionName)
+              : undefined;
+
+          // Per-replica sub-specs (PITR / Kinesis / ContributorInsights).
+          // Best-effort: errors per region per sub-spec omit the offending
+          // key — a permissions gap in one region must NOT abort the
+          // whole drift read.
+          const subs = await this.readReplicaSubSpecs(client, tableNameForSubs, regionLabel);
+          Object.assign(entry, subs);
+
+          // Per-replica Tags. CFn `GlobalTable` schema places Tags
+          // inside `Replicas[]` (no top-level `Tags`), so they MUST be
           // surfaced here — not at the top level of `result`.
-          if (r.RegionName && r.RegionName === currentRegion) {
-            const subs = await this.readLocalReplicaSubSpecs(tableNameForSubs);
-            Object.assign(entry, subs);
-            if (table.TableArn) {
-              try {
-                const tagsResp = await this.dynamoDBClient.send(
-                  new ListTagsOfResourceCommand({ ResourceArn: table.TableArn })
+          if (replicaArn) {
+            try {
+              const tagsResp = await client.send(
+                new ListTagsOfResourceCommand({ ResourceArn: replicaArn })
+              );
+              entry['Tags'] = normalizeAwsTagsToCfn(tagsResp.Tags);
+            } catch (tagErr) {
+              if (tagErr instanceof ResourceNotFoundException) {
+                // Only the LOCAL replica's RNF can be a real "table gone"
+                // signal. A cross-region RNF more likely means the
+                // replica is in CREATING / DELETING — treat as transient
+                // and omit the Tags key for that replica.
+                if (isLocal) throw tagErr;
+                this.logger.debug(
+                  `Cross-region replica ${regionLabel} returned RNF on ListTagsOfResource; omitting Tags`
                 );
-                entry['Tags'] = normalizeAwsTagsToCfn(tagsResp.Tags);
-              } catch (tagErr) {
-                if (tagErr instanceof ResourceNotFoundException) throw tagErr;
+                entry['Tags'] = [];
+              } else {
                 this.logger.warn(
-                  `Could not fetch tags for DynamoDB GlobalTable ${tableNameForSubs}: ${tagErr instanceof Error ? tagErr.message : String(tagErr)}`
+                  `Could not fetch tags for DynamoDB GlobalTable ${tableNameForSubs} in ${regionLabel}: ${tagErr instanceof Error ? tagErr.message : String(tagErr)}`
                 );
                 entry['Tags'] = [];
               }
-            } else {
-              entry['Tags'] = [];
             }
+          } else {
+            entry['Tags'] = [];
           }
           return entry;
         })
       );
       result['Replicas'] = replicas;
+
+      // WriteOnDemandThroughputSettings: trivial reverse-map from
+      // `Table.OnDemandThroughput.MaxWriteRequestUnits`. Always-emit
+      // `{}` placeholder when on-demand has no override so a console-side
+      // ADD on a previously-default table fires drift (PR #145 pattern).
+      if (table.OnDemandThroughput?.MaxWriteRequestUnits !== undefined) {
+        result['WriteOnDemandThroughputSettings'] = {
+          MaxWriteRequestUnits: table.OnDemandThroughput.MaxWriteRequestUnits,
+        };
+      } else {
+        result['WriteOnDemandThroughputSettings'] = {};
+      }
+
+      // WriteProvisionedThroughputSettings: flat-WriteCapacityUnits subset
+      // only — when application-autoscaling has NO policy on the
+      // WriteCapacityUnits dimension AND BillingMode is PROVISIONED.
+      // Auto-scaling-active cases stay omitted (full reverse-mapping is
+      // out of scope; the field stays in `getDriftUnknownPaths` deny
+      // list at the subtree level for that case via the placeholder).
+      if (billingMode === 'PROVISIONED') {
+        const writeCapacity = table.ProvisionedThroughput?.WriteCapacityUnits;
+        if (writeCapacity !== undefined) {
+          const hasAutoScaling = await this.hasWriteAutoScalingPolicy(tableNameForSubs);
+          if (!hasAutoScaling) {
+            result['WriteProvisionedThroughputSettings'] = {
+              WriteCapacityUnits: writeCapacity,
+            };
+          } else {
+            // Auto-scaling owns the capacity — omit the flat surface so
+            // drift doesn't fire on every scale event. A follow-up PR
+            // will reverse-map the full `WriteCapacityAutoScalingSettings`
+            // shape; until then this stays a known-unknown placeholder.
+            result['WriteProvisionedThroughputSettings'] = {};
+          }
+        } else {
+          result['WriteProvisionedThroughputSettings'] = {};
+        }
+      } else {
+        // PAY_PER_REQUEST: type-discriminator-gated empty placeholder so a
+        // template that adds `WriteProvisionedThroughputSettings` later
+        // (after a BillingMode flip) registers as drift; the flat-value
+        // is intentionally absent on on-demand tables.
+        result['WriteProvisionedThroughputSettings'] = {};
+      }
 
       // TimeToLiveSpecification: separate API call. Race-tolerant — when
       // AWS reports a transient `UPDATING` / `DISABLING` status, omit
@@ -1273,7 +1472,9 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
   }
 
   /**
-   * Read per-replica sub-specifications for the LOCAL replica:
+   * Read per-replica sub-specifications against the given `DynamoDBClient`
+   * (which may be the local client or a per-region client returned by
+   * `getRegionalClient`):
    *  - `ContributorInsightsSpecification` via `DescribeContributorInsights`
    *    (table-level; GSI overrides are NOT surfaced in v1 — they would
    *    require one call per GSI and a different CFn nesting under the
@@ -1286,15 +1487,20 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
    * Each call is best-effort: errors omit the offending key rather than
    * fail the whole drift read.
    *
-   * Cross-region replicas would need per-region SDK clients (the calls
-   * are region-scoped to the replica) — deferred to a follow-up PR.
+   * Issue #389 lifted the LOCAL-only limitation by parameterizing the
+   * client — the same reverse-mapping logic runs against any region's
+   * client.
    */
-  private async readLocalReplicaSubSpecs(tableName: string): Promise<Record<string, unknown>> {
+  private async readReplicaSubSpecs(
+    client: DynamoDBClient,
+    tableName: string,
+    regionLabel: string
+  ): Promise<Record<string, unknown>> {
     const out: Record<string, unknown> = {};
 
     // ContributorInsights (table-level only in v1).
     try {
-      const ci = await this.dynamoDBClient.send(
+      const ci = await client.send(
         new DescribeContributorInsightsCommand({ TableName: tableName })
       );
       if (ci.ContributorInsightsStatus) {
@@ -1304,13 +1510,13 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
       }
     } catch (err) {
       this.logger.debug(
-        `Could not read ContributorInsights for ${tableName}: ${err instanceof Error ? err.message : String(err)}`
+        `Could not read ContributorInsights for ${tableName} in ${regionLabel}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
 
     // PointInTimeRecovery via DescribeContinuousBackups.
     try {
-      const pitr = await this.dynamoDBClient.send(
+      const pitr = await client.send(
         new DescribeContinuousBackupsCommand({ TableName: tableName })
       );
       const pitrStatus =
@@ -1323,14 +1529,14 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
       }
     } catch (err) {
       this.logger.debug(
-        `Could not read PointInTimeRecovery for ${tableName}: ${err instanceof Error ? err.message : String(err)}`
+        `Could not read PointInTimeRecovery for ${tableName} in ${regionLabel}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
 
     // Kinesis streaming destination — pick the first ACTIVE destination
     // (CFn's per-replica shape only carries one StreamArn).
     try {
-      const ks = await this.dynamoDBClient.send(
+      const ks = await client.send(
         new DescribeKinesisStreamingDestinationCommand({ TableName: tableName })
       );
       const destinations = ks.KinesisDataStreamDestinations ?? [];
@@ -1347,7 +1553,7 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
       }
     } catch (err) {
       this.logger.debug(
-        `Could not read KinesisStreamingDestination for ${tableName}: ${err instanceof Error ? err.message : String(err)}`
+        `Could not read KinesisStreamingDestination for ${tableName} in ${regionLabel}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
 
@@ -1355,21 +1561,63 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
   }
 
   /**
+   * Detect whether application-autoscaling has a scaling policy on this
+   * table's WriteCapacityUnits dimension. Used to decide whether the
+   * `WriteProvisionedThroughputSettings.WriteCapacityUnits` flat-value
+   * surface in `readCurrentState` is safe to emit (auto-scaling
+   * dynamically mutates capacity, so a flat snapshot would fire false
+   * drift on every scale event — when an autoscaling policy is in play
+   * we omit the flat surface so a follow-up PR can reverse-map the
+   * full `WriteCapacityAutoScalingSettings` shape).
+   *
+   * Best-effort: errors return `false` (no autoscaling detected) so a
+   * permissions gap on `application-autoscaling:DescribeScalingPolicies`
+   * does not abort drift reads. Logged at debug.
+   */
+  private async hasWriteAutoScalingPolicy(tableName: string): Promise<boolean> {
+    try {
+      const region = (await this.dynamoDBClient.config.region()) ?? '';
+      const client = new ApplicationAutoScalingClient({ region });
+      const resp = await client.send(
+        new DescribeScalingPoliciesCommand({
+          ServiceNamespace: 'dynamodb',
+          ResourceId: `table/${tableName}`,
+          ScalableDimension: 'dynamodb:table:WriteCapacityUnits',
+        })
+      );
+      return (resp.ScalingPolicies ?? []).length > 0;
+    } catch (err) {
+      this.logger.debug(
+        `Could not query application-autoscaling for ${tableName}: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return false;
+    }
+  }
+
+  /**
    * State property paths cdkd's GlobalTable readCurrentState cannot (yet)
    * reverse-map. The drift comparator skips these so a templated value
    * doesn't fire guaranteed false drift on every clean run.
    *
-   * - `WriteProvisionedThroughputSettings` /
-   *   `WriteOnDemandThroughputSettings`: CFn's shapes wrap
-   *   auto-scaling / on-demand max-RU settings whose reverse-mapping
-   *   from `DescribeTable.ProvisionedThroughput` / `OnDemandThroughput`
-   *   is non-trivial and would fire false drift in v1.
+   * Issue #389 emptied this list:
+   *  - `WriteProvisionedThroughputSettings` (flat-WriteCapacityUnits
+   *    subset) is now reverse-mapped from `Table.ProvisionedThroughput`
+   *    when BillingMode is PROVISIONED AND application-autoscaling has
+   *    no policy on the WriteCapacityUnits dimension. Auto-scaling
+   *    cases emit an empty `{}` placeholder so the comparator does NOT
+   *    fire false drift on the literal `WriteCapacityUnits` subtree.
+   *  - `WriteOnDemandThroughputSettings` is reverse-mapped from
+   *    `Table.OnDemandThroughput.MaxWriteRequestUnits`. Always-emit
+   *    `{}` placeholder when AWS reports no override.
+   *  - `TimeToLiveSpecification` is reverse-mapped via
+   *    `DescribeTimeToLive` in `readCurrentState`.
    *
-   * `TimeToLiveSpecification` is reverse-mapped via `DescribeTimeToLive`
-   * in `readCurrentState` (no longer in this list).
+   * Returning an empty list is the canonical "no known-unknown paths"
+   * shape — keeping the method present (rather than removing it) for
+   * future additions and for backward compat on test reflection.
    */
   getDriftUnknownPaths(_resourceType: string): string[] {
-    return ['WriteProvisionedThroughputSettings', 'WriteOnDemandThroughputSettings'];
+    return [];
   }
 
   /**

--- a/tests/integration/dynamodb-globaltable/verify.sh
+++ b/tests/integration/dynamodb-globaltable/verify.sh
@@ -1,22 +1,38 @@
 #!/usr/bin/env bash
 #
 # End-to-end real-AWS test for cdkd's AWS::DynamoDB::GlobalTable SDK
-# Provider (Issue #383). Verifies that a `dynamodb.TableV2` deployment
-# produces a `${StackName}-X<hash>` AWS-side table name (not a CC-API
-# auto-generated random string), that subsequent in-place UPDATE deploys
-# round-trip cleanly through cdkd's serialized UpdateTable / TagResource
-# / UpdateTimeToLive pipeline, and that destroy cleans up the table.
+# Provider (Issue #383 / Issue #389). Verifies that a `dynamodb.TableV2`
+# deployment produces a `${StackName}-X<hash>` AWS-side table name (not
+# a CC-API auto-generated random string), that subsequent in-place
+# UPDATE deploys round-trip cleanly through cdkd's serialized UpdateTable
+# / TagResource / UpdateTimeToLive pipeline, that the
+# `DeletionProtectionEnabled` toggle round-trips on / off (Issue #389),
+# and that destroy cleans up the table.
 #
 # Steps:
 #   1. install + build cdkd (root) + install fixture deps
-#   2. cdkd deploy CdkdDynamoDBGlobalTableExample
+#   2. cdkd deploy CdkdDynamoDBGlobalTableExample (baseline)
 #   3. read the deployed table name from cdkd state and assert it starts
 #      with the cdkd `${StackName}-` prefix
 #   4. assert the deployed table exists on AWS via DescribeTable
-#   5. cdkd deploy with CDKD_TEST_UPDATE=ttl,tags — in-place update
+#   5. cdkd deploy with CDKD_TEST_UPDATE=ttl,tags (in-place update)
 #   6. assert TTL is now ENABLED and the UpdateTest tag is present
-#   7. cdkd destroy --force
-#   8. assert the AWS-side table is gone and cdkd state is empty
+#   7. cdkd deploy with CDKD_TEST_UPDATE=deletion-protection
+#   8. assert DeletionProtectionEnabled is now true on AWS
+#   9. cdkd deploy with CDKD_TEST_UPDATE= (cleared, baseline)
+#  10. assert DeletionProtectionEnabled is now false (or absent) on AWS
+#  11. cdkd destroy --remove-protection --force (works regardless of
+#       the last DeletionProtectionEnabled state)
+#  12. assert the AWS-side table is gone and cdkd state is empty
+#
+# Wall-clock budget: ~5-7 min (each deploy + describe pair is ~30-60s).
+#
+# Out of scope (separate follow-up):
+#   - `CDKD_TEST_UPDATE=billing-provisioned` — PROVISIONED <-> PAY_PER_REQUEST
+#     flips need capacity reservation and add ~30s + cost; covered by
+#     unit tests only.
+#   - Multi-region cross-region replica integ — high cost + wall-clock;
+#     covered by unit tests via the mocked regional client.
 #
 # Auto-resolves AWS account ID + state bucket. Run from anywhere.
 set -euo pipefail
@@ -46,9 +62,12 @@ cleanup() {
   rc=$?
   if [ "${rc}" -ne 0 ]; then
     echo "[verify] FAIL (exit ${rc}) — attempting destroy to clean up"
-    # Retry once on dependency errors (AWS DynamoDB delete can lag briefly).
-    ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --force || \
-      ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --force || true
+    # Retry once on dependency errors (AWS DynamoDB delete can lag
+    # briefly). `--remove-protection` is load-bearing — the
+    # deletion-protection step (#7) may have left the table protected
+    # mid-run; without the flag, AWS rejects DeleteTable.
+    ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --remove-protection --force || \
+      ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --remove-protection --force || true
   fi
   exit "${rc}"
 }
@@ -117,23 +136,55 @@ if [ "${TAG_VALUE}" != "true" ]; then
 fi
 echo "[verify] step 6b ok: UpdateTest tag present"
 
-echo "[verify] step 7: cdkd destroy --force"
-unset CDKD_TEST_UPDATE
-${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --force
+echo "[verify] step 7: cdkd deploy with CDKD_TEST_UPDATE=deletion-protection (in-place update — Issue #389)"
+CDKD_TEST_UPDATE=deletion-protection ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
 
-echo "[verify] step 8: assert table is gone on AWS"
+echo "[verify] step 8: assert DeletionProtectionEnabled is now true on AWS"
+DP_ENABLED="$(aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" \
+  --query 'Table.DeletionProtectionEnabled' --output text)"
+if [ "${DP_ENABLED}" != "True" ] && [ "${DP_ENABLED}" != "true" ]; then
+  echo "[verify] FAIL: DeletionProtectionEnabled is '${DP_ENABLED}' on '${TABLE_NAME}' after the deletion-protection UPDATE deploy (expected true)"
+  exit 1
+fi
+echo "[verify] step 8 ok: DeletionProtectionEnabled = ${DP_ENABLED}"
+
+echo "[verify] step 9: cdkd deploy with CDKD_TEST_UPDATE= (cleared baseline — flip deletion-protection back to false)"
+unset CDKD_TEST_UPDATE
+${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
+
+echo "[verify] step 10: assert DeletionProtectionEnabled flipped back to false on AWS"
+DP_FINAL="$(aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" \
+  --query 'Table.DeletionProtectionEnabled' --output text)"
+# AWS may return "None" / "False" / "false" / "" depending on the
+# CLI's text-encoder; accept any non-true response.
+case "${DP_FINAL}" in
+  True|true)
+    echo "[verify] FAIL: DeletionProtectionEnabled is '${DP_FINAL}' on '${TABLE_NAME}' after the cleared UPDATE deploy (expected false / absent)"
+    exit 1
+    ;;
+esac
+echo "[verify] step 10 ok: DeletionProtectionEnabled = ${DP_FINAL} (flipped back)"
+
+echo "[verify] step 11: cdkd destroy --remove-protection --force"
+# `--remove-protection` is defense-in-depth: step 10 should have flipped
+# the table back to unprotected, but a partial / re-run of the test
+# could leave the table protected; the flag ensures cdkd handles the
+# residual state without requiring operator intervention.
+${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --remove-protection --force
+
+echo "[verify] step 12: assert table is gone on AWS"
 if aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
   echo "[verify] FAIL: table '${TABLE_NAME}' still exists after destroy"
   exit 1
 fi
-echo "[verify] step 8 ok: table deleted"
+echo "[verify] step 12 ok: table deleted"
 
-echo "[verify] step 9: assert cdkd state is empty"
+echo "[verify] step 13: assert cdkd state is empty"
 if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
   echo "[verify] FAIL: cdkd state file still exists at s3://${STATE_BUCKET}/${STATE_KEY}"
   exit 1
 fi
-echo "[verify] step 9 ok: cdkd state cleared"
+echo "[verify] step 13 ok: cdkd state cleared"
 
 trap - EXIT
 echo "[verify] PASS"

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-partial-create-cleanup.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-partial-create-cleanup.test.ts
@@ -215,6 +215,65 @@ describe('DynamoDBGlobalTableProvider partial-create cleanup (Issue #376-class)'
     expect(finalDelete).toBeGreaterThan(lastReplicaDelete);
   });
 
+  it('replica-drop cleanup-itself-fails: original wiring error propagates AND recovery WARN fires (Issue #389 item #4)', async () => {
+    // CreateTable succeeds → waitForTableActive succeeds → the
+    // SECOND addReplica fails (so the FIRST replica was actually
+    // added). The cleanup path then runs DescribeTable + per-region
+    // `UpdateTable(Delete)` + DeleteTable. The replica-drop
+    // `UpdateTable(Delete)` itself ALSO throws — cdkd must log a
+    // per-region recovery-command WARN but the ORIGINAL wiring
+    // error (the failed addReplica) must still propagate to the
+    // caller. The deploy engine then surfaces the partial-create
+    // failure to the user, while the user sees the WARN explaining
+    // how to clean up the orphaned cross-region replica by hand.
+    mockSend.mockResolvedValueOnce({}); // CreateTable
+    mockSend.mockResolvedValueOnce({
+      Table: { TableName: 'my-test-table-xxx', TableStatus: 'ACTIVE', TableArn: 'a' },
+    }); // waitForTableActive
+    // First replica add eu-west-1 succeeds.
+    mockSend.mockResolvedValueOnce({}); // UpdateTable Create eu-west-1
+    mockSend.mockResolvedValueOnce({
+      Table: { Replicas: [{ RegionName: 'eu-west-1', ReplicaStatus: 'ACTIVE' }] },
+    }); // waitForReplicaActive eu-west-1
+    // Second replica add ap-south-1 throws — the WIRING failure cdkd
+    // must surface to the caller.
+    const wiringError = new Error('UpdateTable replica ap-south-1 boom');
+    mockSend.mockRejectedValueOnce(wiringError);
+    // Cleanup path: DescribeTable reports the surviving eu-west-1
+    // replica; the cleanup's per-region `UpdateTable(Delete)` THROWS.
+    mockSend.mockResolvedValueOnce({
+      Table: { Replicas: [{ RegionName: 'eu-west-1' }] },
+    });
+    mockSend.mockRejectedValueOnce(new Error('cleanup delete-replica boom'));
+    // The cleanup falls through to DeleteTable regardless (best-effort
+    // — AWS may have already dropped the replica even though the
+    // SDK call surface failed). DeleteTable also throws.
+    mockSend.mockRejectedValueOnce(new Error('cleanup delete-table boom'));
+
+    await expect(
+      provider.create('MyTable', RESOURCE_TYPE, {
+        ...baseProps,
+        StreamSpecification: { StreamViewType: 'NEW_AND_OLD_IMAGES' },
+        Replicas: [
+          { Region: 'us-east-1' },
+          { Region: 'eu-west-1' },
+          { Region: 'ap-south-1' },
+        ],
+      })
+    ).rejects.toThrow(/UpdateTable replica ap-south-1 boom/);
+
+    // Per-region recovery WARN names the offending replica region
+    // AND includes the exact `aws dynamodb update-table --replica-updates`
+    // command for manual cleanup.
+    const warns = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warns).toContain('eu-west-1');
+    expect(warns).toContain('update-table');
+    expect(warns).toContain('--replica-updates');
+    // And the outer DeleteTable cleanup-failed WARN fires too with
+    // the `aws dynamodb delete-table` recovery hint.
+    expect(warns).toContain('aws dynamodb delete-table');
+  });
+
   it('uses CreateTableCommand as the first call (sanity)', async () => {
     // Defensive guard against future refactors accidentally swapping the
     // CreateTable wire order.

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
@@ -16,13 +16,53 @@ import {
   ResourceNotFoundException,
 } from '@aws-sdk/client-dynamodb';
 
-const mockSend = vi.fn();
+const { mockSend, mockAutoScalingSend, regionalClientSpy } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+  mockAutoScalingSend: vi.fn(),
+  regionalClientSpy: vi.fn(),
+}));
 
 vi.mock('../../../src/utils/aws-clients.js', () => ({
   getAwsClients: () => ({
     dynamoDB: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
   }),
 }));
+
+// Intercept `new DynamoDBClient({region})` calls inside the provider's
+// `getRegionalClient` helper so cross-region paths route through the
+// same `mockSend` queue instead of making real network calls. Command
+// classes (`DescribeTableCommand` etc.) keep the actual SDK shape.
+vi.mock('@aws-sdk/client-dynamodb', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-dynamodb')>(
+    '@aws-sdk/client-dynamodb'
+  );
+  return {
+    ...actual,
+    DynamoDBClient: vi.fn().mockImplementation((cfg: { region?: string } | undefined) => {
+      regionalClientSpy(cfg?.region);
+      return {
+        send: mockSend,
+        config: { region: () => Promise.resolve(cfg?.region ?? 'us-east-1') },
+      };
+    }),
+  };
+});
+
+// Same for application-autoscaling — the provider instantiates a fresh
+// client inside `hasWriteAutoScalingPolicy`. Default the mock to "no
+// scaling policy" so tests that don't queue a response see the empty
+// `WriteProvisionedThroughputSettings: {}` placeholder.
+vi.mock('@aws-sdk/client-application-auto-scaling', async () => {
+  const actual = await vi.importActual<
+    typeof import('@aws-sdk/client-application-auto-scaling')
+  >('@aws-sdk/client-application-auto-scaling');
+  return {
+    ...actual,
+    ApplicationAutoScalingClient: vi.fn().mockImplementation(() => ({
+      send: mockAutoScalingSend,
+    })),
+  };
+});
 
 vi.mock('../../../src/utils/logger.js', () => {
   const childLogger = {
@@ -66,6 +106,12 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
 
   beforeEach(() => {
     mockSend.mockReset();
+    mockAutoScalingSend.mockReset();
+    regionalClientSpy.mockReset();
+    // Default: no application-autoscaling policy attached. Tests that
+    // exercise the autoscaling-detected branch can override this with
+    // `mockAutoScalingSend.mockResolvedValueOnce({ ScalingPolicies: [...] })`.
+    mockAutoScalingSend.mockResolvedValue({ ScalingPolicies: [] });
     provider = new DynamoDBGlobalTableProvider();
   });
 
@@ -738,9 +784,11 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
       expect(ru?.Update?.KMSMasterKeyId).toBe('alias/new');
     });
 
-    it('skips UpdateReplica when a cross-region replica has only Tags changes (AWS rejects empty Update; documented limitation)', async () => {
+    it('propagates Tags to cross-region replica via regional UntagResource + TagResource (Issue #389)', async () => {
       mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
-      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // DescribeTable for tag diff
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // DescribeTable for local tag diff
+      mockSend.mockResolvedValueOnce({}); // Untag (regional)
+      mockSend.mockResolvedValueOnce({}); // Tag (regional)
       mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // final describe
 
       await provider.update(
@@ -760,13 +808,69 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
           ],
         }
       );
-      // No UpdateTable issued for the cross-region replica — the
-      // modified-replica path detects the empty Update action (only
-      // Tags changed) and skips to avoid AWS's ValidationException.
+
+      // No UpdateTable should be issued for the cross-region replica
+      // (only Tags changed; UpdateReplica skipped to avoid AWS's
+      // ValidationException on empty Update).
       const updateCalls = mockSend.mock.calls
         .map((c) => c[0])
         .filter((c) => c instanceof UpdateTableCommand) as UpdateTableCommand[];
       expect(updateCalls).toHaveLength(0);
+
+      // The cross-region client must have been spawned for eu-west-1.
+      expect(regionalClientSpy).toHaveBeenCalledWith('eu-west-1');
+
+      // The Untag + Tag SDK calls must target the eu-west-1 replica ARN,
+      // not the local us-east-1 ARN.
+      const untag = mockSend.mock.calls
+        .map((c) => c[0])
+        .find((c) => c instanceof UntagResourceCommand) as
+        | UntagResourceCommand
+        | undefined;
+      const tag = mockSend.mock.calls
+        .map((c) => c[0])
+        .find((c) => c instanceof TagResourceCommand) as
+        | TagResourceCommand
+        | undefined;
+      expect(untag?.input.ResourceArn).toBe(
+        'arn:aws:dynamodb:eu-west-1:123:table/my-table'
+      );
+      expect(untag?.input.TagKeys).toEqual(['Old']);
+      expect(tag?.input.ResourceArn).toBe(
+        'arn:aws:dynamodb:eu-west-1:123:table/my-table'
+      );
+      expect(tag?.input.Tags).toEqual([{ Key: 'New', Value: 'A' }]);
+    });
+
+    it('skips cross-region Tag propagation gracefully when local DescribeTable returns no TableArn', async () => {
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({ Table: {} }); // DescribeTable returns no ARN
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // final describe
+
+      await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        {
+          Replicas: [
+            { Region: 'us-east-1' },
+            { Region: 'eu-west-1', Tags: [{ Key: 'New', Value: 'A' }] },
+          ],
+        },
+        {
+          Replicas: [
+            { Region: 'us-east-1' },
+            { Region: 'eu-west-1' },
+          ],
+        }
+      );
+
+      const tagCalls = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter(
+          (c) => c instanceof UntagResourceCommand || c instanceof TagResourceCommand
+        );
+      expect(tagCalls).toHaveLength(0);
     });
 
     it('issues UpdateTimeToLive with Enabled=false when template removes TimeToLiveSpecification', async () => {
@@ -1010,6 +1114,42 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
       const flipCall = mockSend.mock.calls[0]?.[0] as UpdateTableCommand;
       expect(flipCall).toBeInstanceOf(UpdateTableCommand);
       expect(flipCall.input.DeletionProtectionEnabled).toBe(false);
+    });
+
+    it('--remove-protection: RNF on the flip-off UpdateTable is swallowed and delete continues (Issue #389)', async () => {
+      // The pre-delete `UpdateTable(DeletionProtectionEnabled: false)`
+      // can return RNF when the table is concurrently destroyed; cdkd
+      // swallows the RNF and continues to the per-region drop loop +
+      // DeleteTable, which fall through to the standard region-match-
+      // gated RNF idempotency path.
+      mockSend.mockRejectedValueOnce(newRnf()); // UpdateTable (flip-off) -> RNF
+      mockSend.mockRejectedValueOnce(newRnf()); // DescribeTable -> RNF (table gone)
+      mockSend.mockRejectedValueOnce(newRnf()); // DeleteTable -> RNF
+
+      await provider.delete('X', TABLE_NAME, RESOURCE_TYPE, undefined, {
+        expectedRegion: 'us-east-1',
+        removeProtection: true,
+      });
+
+      // Walked through the flip-off + DescribeTable + DeleteTable; no
+      // ProvisioningError because the region matched.
+      expect(mockSend.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('--remove-protection: RNF on flip-off does NOT bypass the region-match gate downstream', async () => {
+      // Same as above but with a region mismatch — the downstream RNF
+      // on DeleteTable must still throw because the destroy could be
+      // silently stripping a still-existing resource from state.
+      mockSend.mockRejectedValueOnce(newRnf()); // UpdateTable (flip-off) -> RNF
+      mockSend.mockRejectedValueOnce(newRnf()); // DescribeTable -> RNF
+      mockSend.mockRejectedValueOnce(newRnf()); // DeleteTable -> RNF
+
+      await expect(
+        provider.delete('X', TABLE_NAME, RESOURCE_TYPE, undefined, {
+          expectedRegion: 'eu-west-1', // mismatch — local client is us-east-1
+          removeProtection: true,
+        })
+      ).rejects.toBeInstanceOf(ProvisioningError);
     });
   });
 
@@ -1293,21 +1433,169 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
       });
     });
 
-    it('does NOT surface per-replica sub-specs for cross-region replicas (v1 limitation)', async () => {
+    it('surfaces per-replica sub-specs for cross-region replicas via regional client (Issue #389)', async () => {
       mockSend.mockResolvedValueOnce({
         Table: {
           TableArn: TABLE_ARN,
           Replicas: [{ RegionName: 'eu-west-1' }], // cross-region only, no local
         },
       });
-      // No local replica → no sub-spec calls fire; just TTL + Tags.
-      queueReadCurrentStateTail({ localReplica: false });
+      // Cross-region replica: 3 sub-spec calls + ListTagsOfResource fire
+      // against the regional client (which routes through mockSend via
+      // the constructor mock). Then DescribeTimeToLive runs on the
+      // local client.
+      mockSend.mockResolvedValueOnce({ ContributorInsightsStatus: 'ENABLED' });
+      mockSend.mockResolvedValueOnce({
+        ContinuousBackupsDescription: {
+          PointInTimeRecoveryDescription: {
+            PointInTimeRecoveryStatus: 'ENABLED',
+          },
+        },
+      });
+      mockSend.mockResolvedValueOnce({ KinesisDataStreamDestinations: [] });
+      mockSend.mockResolvedValueOnce({ Tags: [{ Key: 'Env', Value: 'prod' }] });
+      mockSend.mockResolvedValueOnce({
+        TimeToLiveDescription: { TimeToLiveStatus: 'DISABLED' },
+      });
+
       const observed = await provider.readCurrentState(TABLE_NAME, 'X', RESOURCE_TYPE);
       const replica = (observed!['Replicas'] as Array<Record<string, unknown>>)[0];
-      expect(replica!['ContributorInsightsSpecification']).toBeUndefined();
-      expect(replica!['PointInTimeRecoverySpecification']).toBeUndefined();
-      expect(replica!['KinesisStreamSpecification']).toBeUndefined();
       expect(replica!['Region']).toBe('eu-west-1');
+      // Pre-#389 these were undefined; post-#389 the regional client
+      // surfaces them.
+      expect(replica!['ContributorInsightsSpecification']).toEqual({ Enabled: true });
+      expect(replica!['PointInTimeRecoverySpecification']).toEqual({
+        PointInTimeRecoveryEnabled: true,
+      });
+      expect(replica!['Tags']).toEqual([{ Key: 'Env', Value: 'prod' }]);
+      // Regional client was spawned for the cross-region region.
+      expect(regionalClientSpy).toHaveBeenCalledWith('eu-west-1');
+    });
+
+    // ─── Throughput round-trip (Issue #389 item #3) ──────────────────
+
+    it('surfaces WriteOnDemandThroughputSettings.MaxWriteRequestUnits when AWS reports it', async () => {
+      mockSend.mockResolvedValueOnce({
+        Table: {
+          TableArn: TABLE_ARN,
+          Replicas: [],
+          OnDemandThroughput: { MaxWriteRequestUnits: 1500 },
+        },
+      });
+      queueReadCurrentStateTail({ localReplica: false });
+      const observed = await provider.readCurrentState(TABLE_NAME, 'X', RESOURCE_TYPE);
+      expect(observed!['WriteOnDemandThroughputSettings']).toEqual({
+        MaxWriteRequestUnits: 1500,
+      });
+    });
+
+    it('emits empty WriteOnDemandThroughputSettings placeholder when AWS reports no override (PR #145 pattern)', async () => {
+      mockSend.mockResolvedValueOnce({
+        Table: { TableArn: TABLE_ARN, Replicas: [] },
+      });
+      queueReadCurrentStateTail({ localReplica: false });
+      const observed = await provider.readCurrentState(TABLE_NAME, 'X', RESOURCE_TYPE);
+      expect(observed!['WriteOnDemandThroughputSettings']).toEqual({});
+    });
+
+    it('surfaces WriteProvisionedThroughputSettings.WriteCapacityUnits on PROVISIONED tables WITHOUT auto-scaling', async () => {
+      mockSend.mockResolvedValueOnce({
+        Table: {
+          TableArn: TABLE_ARN,
+          Replicas: [],
+          BillingModeSummary: { BillingMode: 'PROVISIONED' },
+          ProvisionedThroughput: { WriteCapacityUnits: 7, ReadCapacityUnits: 4 },
+        },
+      });
+      queueReadCurrentStateTail({ localReplica: false });
+      // mockAutoScalingSend defaults to ScalingPolicies: [] in beforeEach.
+
+      const observed = await provider.readCurrentState(TABLE_NAME, 'X', RESOURCE_TYPE);
+      expect(observed!['WriteProvisionedThroughputSettings']).toEqual({
+        WriteCapacityUnits: 7,
+      });
+    });
+
+    it('omits the flat WriteCapacityUnits subtree when application-autoscaling owns the dimension', async () => {
+      mockSend.mockResolvedValueOnce({
+        Table: {
+          TableArn: TABLE_ARN,
+          Replicas: [],
+          BillingModeSummary: { BillingMode: 'PROVISIONED' },
+          ProvisionedThroughput: { WriteCapacityUnits: 7 },
+        },
+      });
+      queueReadCurrentStateTail({ localReplica: false });
+      // Auto-scaling reports a policy on WriteCapacityUnits → cdkd
+      // emits the empty `{}` placeholder so the comparator does not
+      // false-fire on every scale event.
+      mockAutoScalingSend.mockReset();
+      mockAutoScalingSend.mockResolvedValueOnce({
+        ScalingPolicies: [{ PolicyName: 'my-policy' }],
+      });
+
+      const observed = await provider.readCurrentState(TABLE_NAME, 'X', RESOURCE_TYPE);
+      expect(observed!['WriteProvisionedThroughputSettings']).toEqual({});
+    });
+
+    it('emits empty WriteProvisionedThroughputSettings placeholder on PAY_PER_REQUEST tables', async () => {
+      mockSend.mockResolvedValueOnce({
+        Table: {
+          TableArn: TABLE_ARN,
+          Replicas: [],
+          BillingModeSummary: { BillingMode: 'PAY_PER_REQUEST' },
+        },
+      });
+      queueReadCurrentStateTail({ localReplica: false });
+      const observed = await provider.readCurrentState(TABLE_NAME, 'X', RESOURCE_TYPE);
+      expect(observed!['WriteProvisionedThroughputSettings']).toEqual({});
+    });
+
+    it('emits empty WriteProvisionedThroughputSettings placeholder when autoscaling lookup fails (best-effort)', async () => {
+      mockSend.mockResolvedValueOnce({
+        Table: {
+          TableArn: TABLE_ARN,
+          Replicas: [],
+          BillingModeSummary: { BillingMode: 'PROVISIONED' },
+          ProvisionedThroughput: { WriteCapacityUnits: 4 },
+        },
+      });
+      queueReadCurrentStateTail({ localReplica: false });
+      mockAutoScalingSend.mockReset();
+      mockAutoScalingSend.mockRejectedValueOnce(new Error('permission denied'));
+
+      const observed = await provider.readCurrentState(TABLE_NAME, 'X', RESOURCE_TYPE);
+      // Lookup failure is treated as "no policy" — the flat-value
+      // surface IS emitted (false-positive risk on scale is the
+      // tradeoff vs hiding the actual capacity).
+      expect(observed!['WriteProvisionedThroughputSettings']).toEqual({
+        WriteCapacityUnits: 4,
+      });
+    });
+
+    it('omits the offending sub-spec key when the per-region call fails (best-effort)', async () => {
+      mockSend.mockResolvedValueOnce({
+        Table: {
+          TableArn: TABLE_ARN,
+          Replicas: [{ RegionName: 'eu-west-1' }],
+        },
+      });
+      // ContributorInsights succeeds, PITR throws, Kinesis succeeds,
+      // ListTagsOfResource throws. The whole drift read must continue
+      // and surface only the keys that worked.
+      mockSend.mockResolvedValueOnce({ ContributorInsightsStatus: 'DISABLED' });
+      mockSend.mockRejectedValueOnce(new Error('access denied in eu-west-1'));
+      mockSend.mockResolvedValueOnce({ KinesisDataStreamDestinations: [] });
+      mockSend.mockRejectedValueOnce(new Error('tag api boom'));
+      mockSend.mockResolvedValueOnce({
+        TimeToLiveDescription: { TimeToLiveStatus: 'DISABLED' },
+      });
+
+      const observed = await provider.readCurrentState(TABLE_NAME, 'X', RESOURCE_TYPE);
+      const replica = (observed!['Replicas'] as Array<Record<string, unknown>>)[0];
+      expect(replica!['ContributorInsightsSpecification']).toEqual({ Enabled: false });
+      expect(replica!['PointInTimeRecoverySpecification']).toBeUndefined();
+      expect(replica!['Tags']).toEqual([]); // best-effort fallback
     });
 
     // ─── create path: PROVISIONED BillingMode (Item B follow-up) ─────
@@ -1344,16 +1632,14 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
   });
 
   describe('getDriftUnknownPaths', () => {
-    it('declares throughput-settings as drift-unknown (TTL now round-trips)', () => {
+    it('is empty: throughput settings now round-trip; the deny list is empty (Issue #389)', () => {
       const paths = provider.getDriftUnknownPaths(RESOURCE_TYPE);
-      expect(paths).toEqual(
-        expect.arrayContaining([
-          'WriteProvisionedThroughputSettings',
-          'WriteOnDemandThroughputSettings',
-        ])
-      );
-      // TTL was previously here; the readCurrentState now reverse-maps
-      // it via DescribeTimeToLive, so it must NOT be in the deny list.
+      // Pre-#389: ['WriteProvisionedThroughputSettings',
+      // 'WriteOnDemandThroughputSettings']. Post-#389: empty — both
+      // surfaces are reverse-mapped in `readCurrentState` (the auto-
+      // scaling case emits an empty `{}` placeholder so the literal
+      // `WriteCapacityUnits` subtree doesn't false-fire).
+      expect(paths).toEqual([]);
       expect(paths).not.toContain('TimeToLiveSpecification');
     });
   });

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
@@ -16,10 +16,11 @@ import {
   ResourceNotFoundException,
 } from '@aws-sdk/client-dynamodb';
 
-const { mockSend, mockAutoScalingSend, regionalClientSpy } = vi.hoisted(() => ({
+const { mockSend, mockAutoScalingSend, regionalClientSpy, warnSpy } = vi.hoisted(() => ({
   mockSend: vi.fn(),
   mockAutoScalingSend: vi.fn(),
   regionalClientSpy: vi.fn(),
+  warnSpy: vi.fn(),
 }));
 
 vi.mock('../../../src/utils/aws-clients.js', () => ({
@@ -68,7 +69,7 @@ vi.mock('../../../src/utils/logger.js', () => {
   const childLogger = {
     debug: vi.fn(),
     info: vi.fn(),
-    warn: vi.fn(),
+    warn: warnSpy,
     error: vi.fn(),
     child: vi.fn().mockReturnThis(),
   };
@@ -77,7 +78,7 @@ vi.mock('../../../src/utils/logger.js', () => {
       child: () => childLogger,
       debug: vi.fn(),
       info: vi.fn(),
-      warn: vi.fn(),
+      warn: warnSpy,
       error: vi.fn(),
     }),
   };
@@ -108,6 +109,7 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
     mockSend.mockReset();
     mockAutoScalingSend.mockReset();
     regionalClientSpy.mockReset();
+    warnSpy.mockReset();
     // Default: no application-autoscaling policy attached. Tests that
     // exercise the autoscaling-detected branch can override this with
     // `mockAutoScalingSend.mockResolvedValueOnce({ ScalingPolicies: [...] })`.
@@ -871,6 +873,45 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
           (c) => c instanceof UntagResourceCommand || c instanceof TagResourceCommand
         );
       expect(tagCalls).toHaveLength(0);
+    });
+
+    it('cross-region Tag propagation failure logs WARN and does not abort the deploy (Issue #389 / PR #393 review G1)', async () => {
+      // Pre-fix the WARN-on-failure path was uncovered. Production
+      // contract: when the regional TagResource or UntagResource throws
+      // (permissions, throttle, region down, etc.), cdkd surfaces a
+      // WARN naming the region + the "will surface as drift" hint and
+      // continues. The deploy must not abort and downstream replicas
+      // must still process.
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // DescribeTable for local tag diff
+      mockSend.mockRejectedValueOnce(new Error('AccessDenied: TagResource (eu-west-1)')); // regional Tag/Untag throws
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // final describe
+
+      const result = await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        {
+          Replicas: [
+            { Region: 'us-east-1' },
+            { Region: 'eu-west-1', Tags: [{ Key: 'New', Value: 'A' }] },
+          ],
+        },
+        {
+          Replicas: [
+            { Region: 'us-east-1' },
+            { Region: 'eu-west-1', Tags: [{ Key: 'Old', Value: 'B' }] },
+          ],
+        }
+      );
+
+      // Deploy did NOT abort.
+      expect(result.physicalId).toBe(TABLE_NAME);
+      expect(result.wasReplaced).toBe(false);
+
+      // WARN was logged for the failing region.
+      const warnMessages = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(warnMessages).toMatch(/eu-west-1/);
     });
 
     it('issues UpdateTimeToLive with Enabled=false when template removes TimeToLiveSpecification', async () => {


### PR DESCRIPTION
## Summary

Closes the 5 deferred items from issue #389 — the residual scope from PRs #384 / #388's `AWS::DynamoDB::GlobalTable` SDK Provider.

Closes #389.

## Coverage

### 1. Cross-region per-replica drift surfacing

`readCurrentState` previously reverse-mapped `ContributorInsightsSpecification` / `PointInTimeRecoverySpecification` / `KinesisStreamSpecification` for the LOCAL replica only — cross-region replicas got `undefined`. New `getRegionalClient(region)` private helper caches `new DynamoDBClient({ region })` per region; the readCurrentState replica loop now walks every replica via the regional client. Sub-spec helper `readReplicaSubSpecs(client, tableName)` is parameterized so the local + cross-region paths share one implementation. Per-region per-sub-spec errors omit the offending key (best-effort, do not fail the whole drift read).

### 2. Cross-region replica Tags propagation

The replica modify path in `update()` previously detected cross-region Tags-only diffs and skipped the SDK call (AWS rejects empty `UpdateReplica`). Now it computes Tags diff per cross-region replica and applies via the regional client's `TagResource` / `UntagResource` against the cross-region table's ARN (constructed via region-segment swap from the local `TableArn`). `applyTagDiffOnClient` helper is shared between local + cross-region paths. Failure path logs WARN naming the region; deploy does not abort (drift surfaces it on the next run).

### 3. `WriteOnDemandThroughputSettings` / `WriteProvisionedThroughputSettings` round-trip

Both lifted out of `getDriftUnknownPaths` (which now returns `[]`).

- **`WriteOnDemandThroughputSettings`**: reverse-mapped from `Table.OnDemandThroughput.MaxWriteRequestUnits`. Always-emits `{}` placeholder when absent (PR #145 pattern).
- **`WriteProvisionedThroughputSettings`** (flat subset): when `BillingMode === 'PROVISIONED'` AND no `application-autoscaling:DescribeScalingPolicies` policy is active for `ServiceNamespace: dynamodb` + `ResourceId: table/<name>` + `ScalableDimension: dynamodb:table:WriteCapacityUnits`, surfaces `{ WriteCapacityUnits: <n> }`. Always-emits `{}` placeholder on PAY_PER_REQUEST. New `hasWriteAutoScalingPolicy(tableName)` helper; autoscaling-lookup failure falls back to emitting the flat-value placeholder (documented trade-off — avoids hiding real capacity behind a permission gap; if a user actually has autoscaling AND a permission gap, drift may surface noise once until the gap is fixed).
- Full auto-scaling reverse-mapping (recovering `WriteCapacityAutoScalingSettings.MinCapacity` / `MaxCapacity` / `TargetTrackingScalingPolicyConfiguration`) is intentionally deferred.

New dependency: `@aws-sdk/client-application-auto-scaling`.

### 4. Missing tests

- **`--remove-protection` `ResourceNotFoundException` swallow branch**: when the pre-delete `UpdateTable(DeletionProtectionEnabled: false)` returns RNF, cdkd continues to the per-region drop loop. Tests cover both the region-match (swallow) and region-mismatch (refuse) cases.
- **Replica-drop cleanup-itself-fails variant**: when the partial-create cleanup's per-region `UpdateTable(Delete)` itself throws, cdkd logs a WARN with the recovery command AND the original wiring error propagates (not the cleanup error).

### 5. Integ scenario coverage

`tests/integration/dynamodb-globaltable/verify.sh` now exercises a `CDKD_TEST_UPDATE=deletion-protection` on/off round-trip in addition to the existing `ttl,tags` scenario. The final destroy uses `--remove-protection` so cleanup works regardless of the last `DeletionProtectionEnabled` state. `billing-provisioned` skipped (cost / wall-clock trade-off — documented inline).

## PR #393 review fixes (in-PR)

3-axis review surfaced 1 medium gap + 1 anti-pattern; both fixed before merge per `feedback_polish_in_same_pr.md`:

- **G1 (medium)**: cross-region Tag propagation WARN-on-failure path had no test. Added: queues a regional `TagResource` rejection, asserts the WARN fires AND the deploy resolves successfully (does not abort).
- **A1 (anti-pattern)**: `warnSpy` was an anonymous `vi.fn()` inside the logger mock factory; hoisted via `vi.hoisted()` mirroring the cleanup test's pattern (`feedback_vi_mock_hoisting.md`). This unblocks future WARN-text assertions.

Remaining low-severity items from the review are deferred to a follow-up: Kinesis `ENABLING` status filter, multi-destination disambiguation, malformed-local-ARN WARN-text assertion, theoretical flip-off-success-then-DeleteTable-RNF-region-mismatch path.

## Tests

- 296 files / 3547 tests passing (was 3535; +12)
- Real-AWS integ validated 2026-05-16 via `/run-integ dynamodb-globaltable` (deploy → ttl+tags update → deletion-protection on → deletion-protection off → destroy with --remove-protection, all clean)

## Files

**Edited**:
- `src/provisioning/providers/dynamodb-globaltable-provider.ts` — regional client cache + cross-region per-replica drift + cross-region Tags propagation + throughput round-trip with autoscaling gating + `getDriftUnknownPaths: []`
- `tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts` — +12 tests (cross-region drift / cross-region Tags happy + failure / throughput on-demand+provisioned+autoscaling-gated / RNF region-match-gate / warnSpy hoist)
- `tests/unit/provisioning/dynamodb-globaltable-provider-partial-create-cleanup.test.ts` — +1 test (replica-drop cleanup-itself-fails variant)
- `tests/integration/dynamodb-globaltable/verify.sh` + `lib/dynamodb-globaltable-stack.ts` — deletion-protection on/off scenario + `--remove-protection` on destroy
- `package.json` + `pnpm-lock.yaml` — `@aws-sdk/client-application-auto-scaling`

## Related

- Closes #389 (issue tracking the 5 deferred items).
- Lineage: PR #384 → PR #388 → this PR (#393).
- Memory rules applied: `feedback_dedicated_provider_over_special_case.md`, `feedback_always_emit_check_type_discriminator.md`, `feedback_verify_cdk_synth_shape_before_resolver.md`, `feedback_async_aws_wait_poll_loop_test.md`, `feedback_worktree_isolation_protocol.md`, `feedback_polish_in_same_pr.md`, `feedback_vi_mock_hoisting.md`.
