### PR TITLE
docs(claude): clarify Node 24 + Vite+ task registration convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ registry.register('AWS::IAM::Role', new IAMRoleProvider());
 
 ### 2. Build System (Vite+)
 
-- Uses Vite+ tasks in `vite.config.ts`
+- New dev / build tasks (lint, format, audit scripts, codegen, etc.) are registered as Vite+ tasks in `vite.config.ts` and invoked via `vp run <task>`. This is the project convention — prefer it over `package.json` `"scripts"` entries or ad-hoc `node` invocations for anything that lives beyond a single PR.
 - `vp pack` builds the ESM package through tsdown with a Node 20 runtime target
 - The global `vp` CLI is pinned by `.mise.toml`; project Node.js is managed by Vite+ from `.node-version`
 
@@ -613,7 +613,10 @@ See [docs/provider-development.md](docs/provider-development.md) for details.
 
 ## Node.js Version
 
-- **Required**: Node.js >= 20.0.0 (from `package.json` engines field)
+- **`package.json` engines**: Node.js >= 20.0.0 (the lower bound users of cdkd must meet).
+- **Local dev / CI Node version**: 24.15.0, pinned by `.node-version` (managed by Vite+ / mise).
+- **`vp pack` build target**: Node 20 (the runtime cdkd ships to users).
+- **TypeScript type stripping**: Node 24 strips type annotations by default, so `node scripts/foo.ts` runs `.ts` files directly — no `tsx` / `ts-node` dev dependency needed. Use this for ad-hoc scripts under `scripts/`; prefer registering longer-lived scripts as Vite+ tasks in `vite.config.ts` (see "Build System" above).
 
 ## Workflow Rules
 


### PR DESCRIPTION
## Summary

Two-line clarifications to `CLAUDE.md` for ambiguities that misled at least one agent session (retrospective documented in the runbooks of https://github.com/go-to-k/cdkd/issues/390 / https://github.com/go-to-k/cdkd/issues/391 / https://github.com/go-to-k/cdkd/issues/392).

### 1. Node.js Version section

Previously listed only `package.json` engines (`>= 20.0.0`). Added:

- **Local pin**: 24.15.0 from `.node-version`.
- **Build target**: Node 20 from `vp pack` (explicit).
- **Type stripping**: Node 24 runs `.ts` files directly — no `tsx` / `ts-node` dev dep needed for ad-hoc scripts. Use this for `scripts/foo.ts`; register longer-lived scripts as Vite+ tasks (see §2).

### 2. Build System (Vite+) section

Previously said `"Uses Vite+ tasks in vite.config.ts"` without naming this as the registration convention. Reworded to state that new dev / build tasks are registered there and invoked via `vp run <task>`, preferred over `package.json` `"scripts"` entries or ad-hoc `node` invocations for anything beyond a single PR.

## Why

Both edits are clarifications of existing reality — verified against `.node-version`, `.mise.toml`, and the existing CLAUDE.md prose (the cmd-parse-stub-gate hook description already references "Node 24" incidentally, confirming the project does run on Node 24 locally). No behavior change.

## Diff

```
- Uses Vite+ tasks in `vite.config.ts`
+ New dev / build tasks (lint, format, audit scripts, codegen, etc.) are registered as Vite+ tasks in `vite.config.ts` and invoked via `vp run <task>`. This is the project convention — prefer it over `package.json` `"scripts"` entries or ad-hoc `node` invocations for anything that lives beyond a single PR.
```

```
- **Required**: Node.js >= 20.0.0 (from `package.json` engines field)
+ **`package.json` engines**: Node.js >= 20.0.0 (the lower bound users of cdkd must meet).
+ **Local dev / CI Node version**: 24.15.0, pinned by `.node-version` (managed by Vite+ / mise).
+ **`vp pack` build target**: Node 20 (the runtime cdkd ships to users).
+ **TypeScript type stripping**: Node 24 strips type annotations by default, so `node scripts/foo.ts` runs `.ts` files directly — no `tsx` / `ts-node` dev dependency needed. Use this for ad-hoc scripts under `scripts/`; prefer registering longer-lived scripts as Vite+ tasks in `vite.config.ts` (see "Build System" above).
```

## Test plan

- [x] CLAUDE.md is the only file touched.
- [x] Claims verified against on-disk reality (`.node-version` = 24.15.0; `.mise.toml` pins `vp` + `markgate`).
- [x] No code / behavior changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtaGohCvqga9P159dp6eDt)_