### PR TITLE
fix(providers): residual work from PR #400 + rds-aurora integ extension for DBProxyEndpoint

### DIFF
--- a/src/provisioning/providers/rds-dbproxy-endpoint-provider.ts
+++ b/src/provisioning/providers/rds-dbproxy-endpoint-provider.ts
@@ -30,7 +30,7 @@ import type {
 } from '../../types/resource.js';
 
 const POLL_INTERVAL_MS = 5000;
-const POLL_TIMEOUT_MS = 15 * 60 * 1000;
+const POLL_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
  * AWS RDS DBProxyEndpoint Provider
@@ -146,14 +146,21 @@ export class RDSDBProxyEndpointProvider implements ResourceProvider {
     let status: string | undefined;
     while (Date.now() < deadline) {
       try {
+        // NOTE: filter by DBProxyEndpointName only — passing both
+        // `DBProxyName` AND `DBProxyEndpointName` returned an empty array
+        // during the create poll on real AWS (eventual-consistency-window
+        // bug observed 2026-05-16 rds-aurora integ). The endpoint name is
+        // already a unique identifier per region.
         const describe = await client.send(
           new DescribeDBProxyEndpointsCommand({
-            DBProxyName: dbProxyName,
             DBProxyEndpointName: dbProxyEndpointName,
           })
         );
         const ep = describe.DBProxyEndpoints?.[0];
         status = ep?.Status;
+        this.logger.debug(
+          `DBProxyEndpoint ${dbProxyEndpointName} poll: status=${status ?? 'not-yet-visible'}`
+        );
         if (status === 'available') {
           endpoint = ep?.Endpoint;
           arn = ep?.DBProxyEndpointArn;
@@ -251,6 +258,12 @@ export class RDSDBProxyEndpointProvider implements ResourceProvider {
       }
     }
 
+    // Invalidate attribute cache BEFORE applyTagDiff so the ARN warm-up
+    // applyTagDiff performs survives across the update() call boundary
+    // (PR #400 review M1: previously evicting after applyTagDiff wasted
+    // the warm-up the next update() pays a Describe to re-create).
+    this.invalidateAttributeCache(physicalId);
+
     await this.applyTagDiff(
       physicalId,
       previousProperties['Tags'],
@@ -258,8 +271,6 @@ export class RDSDBProxyEndpointProvider implements ResourceProvider {
       resourceType,
       logicalId
     );
-
-    this.invalidateAttributeCache(physicalId);
 
     return { physicalId, wasReplaced: false };
   }

--- a/src/provisioning/providers/rds-dbproxy-provider.ts
+++ b/src/provisioning/providers/rds-dbproxy-provider.ts
@@ -30,7 +30,7 @@ import type {
 } from '../../types/resource.js';
 
 const POLL_INTERVAL_MS = 5000;
-const POLL_TIMEOUT_MS = 15 * 60 * 1000;
+const POLL_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
  * AWS RDS DBProxy Provider
@@ -275,6 +275,12 @@ export class RDSDBProxyProvider implements ResourceProvider {
       }
     }
 
+    // Invalidate attribute cache BEFORE applyTagDiff so the ARN warm-up
+    // applyTagDiff performs survives across the update() call boundary
+    // (PR #400 review M1: previously evicting after applyTagDiff wasted
+    // the warm-up the next update() pays a Describe to re-create).
+    this.invalidateAttributeCache(physicalId);
+
     // Tag diff via separate Add/Remove APIs.
     await this.applyTagDiff(
       physicalId,
@@ -283,11 +289,6 @@ export class RDSDBProxyProvider implements ResourceProvider {
       resourceType,
       logicalId
     );
-
-    // Invalidate attribute cache so subsequent getAttribute reads pick up
-    // the latest Endpoint / etc. (Endpoint is immutable in practice; this
-    // is defense-in-depth for any future AWS-side change).
-    this.invalidateAttributeCache(physicalId);
 
     return { physicalId, wasReplaced: false };
   }
@@ -499,6 +500,15 @@ export class RDSDBProxyProvider implements ResourceProvider {
     resourceType: string,
     logicalId: string
   ): Promise<void> {
+    const oldMap = this.toTagMap(oldTags);
+    const newMap = this.toTagMap(newTags);
+
+    // Tag-map equality short-circuit BEFORE the ARN-lookup Describe — skips
+    // the wasted Describe when no tag diff exists (PR #400 review M1).
+    const sameKeys = oldMap.size === newMap.size && [...oldMap.keys()].every((k) => newMap.has(k));
+    const sameValues = sameKeys && [...oldMap.entries()].every(([k, v]) => newMap.get(k) === v);
+    if (sameValues) return;
+
     const client = this.getClient();
 
     const arnCacheKey = `${physicalId}:DBProxyArn`;
@@ -519,9 +529,6 @@ export class RDSDBProxyProvider implements ResourceProvider {
       }
     }
     if (!arn) return;
-
-    const oldMap = this.toTagMap(oldTags);
-    const newMap = this.toTagMap(newTags);
 
     const toRemove: string[] = [];
     const toAdd: Tag[] = [];

--- a/tests/integration/rds-aurora/lib/rds-aurora-stack.ts
+++ b/tests/integration/rds-aurora/lib/rds-aurora-stack.ts
@@ -74,6 +74,17 @@ export class RdsAuroraStack extends cdk.Stack {
       requireTLS: false,
     });
 
+    // Add a READ_ONLY DBProxyEndpoint to exercise the
+    // AWS::RDS::DBProxyEndpoint SDK provider end-to-end. Reuses the
+    // cluster's VPC subnets + security group.
+    proxy.addEndpoint('ReaderEndpoint', {
+      dbProxyEndpointName: `${cdk.Stack.of(this).stackName.toLowerCase()}-reader`,
+      vpc,
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      securityGroups: [securityGroup],
+      targetRole: rds.ProxyEndpointTargetRole.READ_ONLY,
+    });
+
     // Outputs
     new cdk.CfnOutput(this, 'ProxyEndpoint', {
       value: proxy.endpoint,

--- a/tests/unit/provisioning/rds-dbproxy-endpoint-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/rds-dbproxy-endpoint-provider-roundtrip.test.ts
@@ -216,6 +216,54 @@ describe('RDSDBProxyEndpointProvider', () => {
       expect(mockSend.mock.calls[2]![0].constructor.name).toBe('AddTagsToResourceCommand');
       expect(mockSend.mock.calls[2]![0].input.Tags).toEqual([{ Key: 'new', Value: 'v' }]);
     });
+
+    // PR #400 review M2: tag-diff edge case tests.
+    it('Tags diff: value change with same key issues Add (not Remove)', async () => {
+      mockSend
+        .mockResolvedValueOnce({ DBProxyEndpoints: [{ DBProxyEndpointArn: EP_ARN }] })
+        .mockResolvedValueOnce({}); // AddTags only
+      await provider.update(
+        'EP',
+        EP_NAME,
+        RESOURCE_TYPE,
+        { Tags: [{ Key: 'env', Value: 'prod' }] },
+        { Tags: [{ Key: 'env', Value: 'dev' }] }
+      );
+      expect(mockSend.mock.calls[1]![0].constructor.name).toBe('AddTagsToResourceCommand');
+      expect(mockSend.mock.calls[1]![0].input.Tags).toEqual([{ Key: 'env', Value: 'prod' }]);
+    });
+
+    it('Tags diff: asymmetric sizes (old=1, new=2) issues Add only', async () => {
+      mockSend
+        .mockResolvedValueOnce({ DBProxyEndpoints: [{ DBProxyEndpointArn: EP_ARN }] })
+        .mockResolvedValueOnce({});
+      await provider.update(
+        'EP',
+        EP_NAME,
+        RESOURCE_TYPE,
+        {
+          Tags: [
+            { Key: 'a', Value: '1' },
+            { Key: 'b', Value: '2' },
+          ],
+        },
+        { Tags: [{ Key: 'a', Value: '1' }] }
+      );
+      expect(mockSend.mock.calls[1]![0].constructor.name).toBe('AddTagsToResourceCommand');
+      expect(mockSend.mock.calls[1]![0].input.Tags).toEqual([{ Key: 'b', Value: '2' }]);
+    });
+
+    it('Tags diff: undefined-to-[] is no-op (both treated as empty)', async () => {
+      await provider.update(
+        'EP',
+        EP_NAME,
+        RESOURCE_TYPE,
+        { Tags: [] },
+        { Tags: undefined }
+      );
+      // Tag diff short-circuit fires: no Describe, no Modify.
+      expect(mockSend).not.toHaveBeenCalled();
+    });
   });
 
   describe('delete', () => {

--- a/tests/unit/provisioning/rds-dbproxy-provider.test.ts
+++ b/tests/unit/provisioning/rds-dbproxy-provider.test.ts
@@ -144,20 +144,18 @@ describe('RDSDBProxyProvider', () => {
   });
 
   describe('update', () => {
-    it('is a no-op when nothing changed', async () => {
+    it('is a no-op when nothing changed (tag-diff short-circuits Describe)', async () => {
       const props = {
         Auth: [{ AuthScheme: 'SECRETS', SecretArn: 'arn:aws:secretsmanager:us-east-1:123:secret:db' }],
         RoleArn: ROLE_ARN,
         Tags: [{ Key: 'k', Value: 'v' }],
       };
-      mockSend.mockResolvedValueOnce({
-        DBProxies: [{ DBProxyArn: PROXY_ARN }],
-      }); // DescribeDBProxies for tag-arn lookup
       const result = await provider.update('Proxy', PROXY_NAME, RESOURCE_TYPE, props, props);
       expect(result.physicalId).toBe(PROXY_NAME);
       expect(result.wasReplaced).toBe(false);
-      // 1 Describe for tag-arn lookup, no Modify, no Add/Remove tags.
-      expect(mockSend).toHaveBeenCalledTimes(1);
+      // PR #400 review M1 fix: tag-map equality short-circuit means
+      // no Describe is needed for the ARN cache.
+      expect(mockSend).not.toHaveBeenCalled();
     });
 
     it('rejects when EngineFamily differs (immutable)', async () => {
@@ -245,6 +243,33 @@ describe('RDSDBProxyProvider', () => {
       expect(mockSend.mock.calls[1]![0].input.TagKeys).toEqual(['removed']);
       expect(mockSend.mock.calls[2]![0].constructor.name).toBe('AddTagsToResourceCommand');
       expect(mockSend.mock.calls[2]![0].input.Tags).toEqual([{ Key: 'new', Value: 'v' }]);
+    });
+
+    // PR #400 review M2: tag-diff edge case tests.
+    it('Tags diff: value change with same key issues Add only', async () => {
+      mockSend
+        .mockResolvedValueOnce({ DBProxies: [{ DBProxyArn: PROXY_ARN }] })
+        .mockResolvedValueOnce({});
+      await provider.update(
+        'Proxy',
+        PROXY_NAME,
+        RESOURCE_TYPE,
+        { Tags: [{ Key: 'env', Value: 'prod' }] },
+        { Tags: [{ Key: 'env', Value: 'dev' }] }
+      );
+      expect(mockSend.mock.calls[1]![0].constructor.name).toBe('AddTagsToResourceCommand');
+      expect(mockSend.mock.calls[1]![0].input.Tags).toEqual([{ Key: 'env', Value: 'prod' }]);
+    });
+
+    it('Tags diff: undefined-to-[] is no-op short-circuits Describe', async () => {
+      await provider.update(
+        'Proxy',
+        PROXY_NAME,
+        RESOURCE_TYPE,
+        { Tags: [] },
+        { Tags: undefined }
+      );
+      expect(mockSend).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Residual work from PR #400 + extends real-AWS coverage. Three categories:

### 1. rds-aurora integ extension: `AWS::RDS::DBProxyEndpoint` (the deferred validation)

Pre-PR the rds-aurora integ created a `DatabaseProxy` (with its built-in endpoint) but no explicit `AWS::RDS::DBProxyEndpoint` resource. PR #400's `RDSDBProxyEndpointProvider` had unit-test coverage only — no real-AWS validation. This PR extends the fixture to create a READ_ONLY DBProxyEndpoint on top of the existing proxy, so the integ exercises the new SDK provider end-to-end on real AWS.

### 2. PR #400 review M1 fix: `applyTagDiff` ARN-cache lifecycle

Both `RDSDBProxyProvider` and `RDSDBProxyEndpointProvider` now:
- Run the tag-map equality short-circuit BEFORE the ARN-lookup Describe (skips the wasted call when tags are unchanged).
- Invalidate the attribute cache BEFORE `applyTagDiff`, not after, so the ARN warm-up `applyTagDiff` performs survives across the `update()` call boundary.

Previously DBProxy's `applyTagDiff` was missing the tag-map short-circuit (review M1 caught the wasted Describe). Endpoint had it from day 1; backporting makes the family consistent.

### 3. PR #400 review M2 fix: tag-diff edge case tests

5 new tests across both providers covering:
- Value change with same key (Add-only, no Remove)
- Asymmetric Tags array sizes (old=1, new=2)
- undefined-to-[] short-circuit (both maps empty)

## Bug fixes surfaced by the real-AWS validation

**Bug 1: `DescribeDBProxyEndpoints` filter conflict on create poll.** The poll passed BOTH `DBProxyName` AND `DBProxyEndpointName` — AWS returned an empty array during the create eventual-consistency window, causing a 15-min timeout with `last status: unknown`. Fixed by filtering with `DBProxyEndpointName` only (already unique per region). Real-AWS validated: with the filter fix, status flips from `creating` to `available` in ~2 min consistently.

**Bug 2: Poll timeout too short.** Bumped `POLL_TIMEOUT_MS` from 15 min to 30 min in both `rds-dbproxy-provider.ts` and `rds-dbproxy-endpoint-provider.ts` — matches the RDS family wait budget set in PR #394 for cluster / instance polls. Bug 1 was bounded but if AWS provisioning ever does take 15+ min, the larger budget catches it.

**Debug log addition:** each poll iteration in `RDSDBProxyEndpointProvider.create` now logs the AWS-returned status (or `not-yet-visible`). Makes poll-loop diagnostics surface in `--verbose` mode. Helped catch Bug 1.

## Test plan

- [x] Unit tests pass (3622 total, **5 new** for tag-diff edge cases across both providers).
- [x] Real-AWS rds-aurora integ deploy: **20/20 created, 0 errors**. New `DBProxyEndpoint` resource (`AuroraProxyReaderEndpoint5091D2E5`) goes from `creating` → `available` in 2 min via the new SDK provider path.
- [x] Real-AWS rds-aurora integ destroy: **20/20 deleted, 0 errors**. DBProxyEndpoint deletes cleanly through the SDK provider path; the writer instance's 30 min wait budget (from PR #394) carries it through AWS's slower-than-15-min delete.
- [x] All markers fresh: check / docs / verify-pr / integ-destroy / integ-broad.

## Closes follow-up items

- **PR #400 review M1**: tag-map equality short-circuit was missing on DBProxy (Endpoint had it from day 1). Backported.
- **PR #400 review M2**: tag-diff edge case tests. Added 5 new tests.
- **PR #400 follow-up scope**: rds-aurora integ extension exercising `AWS::RDS::DBProxyEndpoint` end-to-end. Done.

## Follow-up (deliberately out of scope)

- per-property mutability matrix audit for drift `--revert` round-trip on the full DBProxy family — separate concern, not blocking.
