### PR TITLE
feat(dynamodb-globaltable): validate multi-region integ + regional client region-assertion tests (Closes #407)

### DIFF
--- a/src/provisioning/providers/dynamodb-globaltable-provider.ts
+++ b/src/provisioning/providers/dynamodb-globaltable-provider.ts
@@ -371,8 +371,23 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
       createParams.SSESpecification = sseInput;
     }
 
-    if (properties['DeletionProtectionEnabled'] !== undefined) {
-      createParams.DeletionProtectionEnabled = properties['DeletionProtectionEnabled'] as boolean;
+    // DeletionProtectionEnabled is per-replica in the CFn schema for
+    // `AWS::DynamoDB::GlobalTable` (just like Tags). CDK 2.x's
+    // `deletionProtection: true` synthesizes to
+    // `Replicas[?Region==<deploy region>].DeletionProtectionEnabled`.
+    // Extract from the local replica entry; fall back to top-level
+    // for legacy / hand-authored templates that put it there.
+    const localReplicaForDP = replicas.find((r) => r['Region'] === currentRegion);
+    const dpePerReplica = localReplicaForDP?.['DeletionProtectionEnabled'];
+    const dpeTopLevel = properties['DeletionProtectionEnabled'];
+    const dpeResolved =
+      typeof dpePerReplica === 'boolean'
+        ? dpePerReplica
+        : typeof dpeTopLevel === 'boolean'
+          ? dpeTopLevel
+          : undefined;
+    if (dpeResolved !== undefined) {
+      createParams.DeletionProtectionEnabled = dpeResolved;
     }
     if (properties['TableClass']) {
       createParams.TableClass = properties['TableClass'] as
@@ -699,14 +714,23 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
       // 3. Non-conflicting flat fields in one combined UpdateTable.
       // AWS allows combining these in a single call because they don't
       // conflict with each other or with each other's modes.
+      // DeletionProtectionEnabled is per-replica in the CFn schema
+      // (same shape as Tags). Extract from `Replicas[?Region==local]`
+      // with a fall-through to top-level for legacy templates.
+      const extractLocalDP = (props: Record<string, unknown>): boolean | undefined => {
+        const replicas = (props['Replicas'] ?? []) as Array<Record<string, unknown>>;
+        const local = replicas.find((r) => r['Region'] === currentRegion);
+        const perReplica = local?.['DeletionProtectionEnabled'];
+        if (typeof perReplica === 'boolean') return perReplica;
+        const topLevel = props['DeletionProtectionEnabled'];
+        return typeof topLevel === 'boolean' ? topLevel : undefined;
+      };
+      const newDpe = extractLocalDP(properties);
+      const oldDpe = extractLocalDP(previousProperties);
       const flatUpdate: UpdateTableCommandInput = { TableName: physicalId };
       let flatChanged = false;
-      if (
-        properties['DeletionProtectionEnabled'] !== previousProperties['DeletionProtectionEnabled']
-      ) {
-        flatUpdate.DeletionProtectionEnabled = Boolean(
-          properties['DeletionProtectionEnabled'] ?? false
-        );
+      if (newDpe !== oldDpe) {
+        flatUpdate.DeletionProtectionEnabled = Boolean(newDpe ?? false);
         flatChanged = true;
       }
       if (

--- a/tests/integration/dynamodb-globaltable/lib/dynamodb-globaltable-stack.ts
+++ b/tests/integration/dynamodb-globaltable/lib/dynamodb-globaltable-stack.ts
@@ -85,13 +85,20 @@ export class DynamoDBGlobalTableStack extends cdk.Stack {
                   targetUtilizationPercent: 70,
                 })
               : ddb.Capacity.fixed(5),
-            writeCapacity: useAutoScaling
-              ? ddb.Capacity.autoscaled({
-                  minCapacity: 5,
-                  maxCapacity: 100,
-                  targetUtilizationPercent: 70,
-                })
-              : ddb.Capacity.fixed(5),
+            // CDK 2.244+ disallows `Capacity.fixed()` for `writeCapacity`
+            // on `TableV2` (the construct synthesizes
+            // `AWS::DynamoDB::GlobalTable`, where write capacity must
+            // be auto-scaled — Aurora-style replicas do not support a
+            // fixed write throughput). Always use autoscaled write
+            // capacity; the `useAutoScaling=false` integ scenario
+            // still differentiates by using FIXED read + autoscaled
+            // write (matches what a typical TableV2 user gets when
+            // asking for PROVISIONED).
+            writeCapacity: ddb.Capacity.autoscaled({
+              minCapacity: 5,
+              maxCapacity: 100,
+              targetUtilizationPercent: 70,
+            }),
           })
         : ddb.Billing.onDemand(),
       removalPolicy: cdk.RemovalPolicy.DESTROY,

--- a/tests/integration/dynamodb-globaltable/verify.sh
+++ b/tests/integration/dynamodb-globaltable/verify.sh
@@ -18,17 +18,23 @@
 #   3. read the deployed table name from cdkd state and assert it starts
 #      with the cdkd `${StackName}-` prefix
 #   4. assert the deployed table exists on AWS via DescribeTable
-#   5. cdkd deploy with CDKD_TEST_UPDATE=ttl,tags (in-place update)
-#   6. assert TTL is now ENABLED and the UpdateTest tag is present
-#   7. cdkd deploy with CDKD_TEST_UPDATE=deletion-protection
+#   5. cdkd deploy with CDKD_TEST_UPDATE=deletion-protection
 #   8. assert DeletionProtectionEnabled is now true on AWS
-#   9. cdkd deploy with CDKD_TEST_UPDATE=billing-provisioned
+#   9. cdkd deploy with CDKD_TEST_UPDATE=deletion-protection,billing-provisioned
 #       (Issue #402 Item C — BillingMode round-trip)
 #  10. assert BillingMode is now PROVISIONED on AWS
-#  11. cdkd deploy with CDKD_TEST_UPDATE=autoscaling
+#  11. cdkd deploy with CDKD_TEST_UPDATE=deletion-protection,autoscaling
 #       (Issue #402 Item B — table-level write + per-replica read autoscaling)
 #  12. assert RegisterScalableTarget + PutScalingPolicy reached AWS via
 #       application-autoscaling describe-scaling-policies
+#  12b-e: optional cross-region (CDKD_INTEG_MULTI_REGION=1, see below).
+#  12f. cdkd deploy with CDKD_TEST_UPDATE=...,ttl,tags (TTL toggle MUST be
+#       LAST among structural changes — AWS's "Time to live has been
+#       modified multiple times within a fixed interval" rate limit fires
+#       when an UpdateTable structural change happens within ~1 hour after
+#       a UpdateTimeToLive call. Deferring TTL to the end keeps the only
+#       TTL state changes to enable-here → disable-at-step-13.)
+#  12g. assert TTL is now ENABLED and the UpdateTest tag is present
 #  13. cdkd deploy with CDKD_TEST_UPDATE= (cleared, baseline)
 #  14. assert DeletionProtectionEnabled is now false (or absent) on AWS,
 #       BillingMode flipped back to PAY_PER_REQUEST, AND the scaling
@@ -45,7 +51,8 @@
 #   round-trip. Adds ~15-25 min (replica provisioning is 5-10 min per
 #   region and per direction) and ~$0.10-0.20 in cross-region replication.
 #   The default `bash verify.sh` invocation does NOT run this — it stays
-#   under 8 min as before.
+#   under 8 min as before. Runs BEFORE the TTL toggle so the
+#   cross-region UpdateTable is not blocked by AWS's TTL rate limit.
 #
 # Auto-resolves AWS account ID + state bucket. Run from anywhere.
 set -euo pipefail
@@ -127,29 +134,17 @@ echo "[verify] step 4: assert table exists on AWS"
 aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null
 echo "[verify] step 4 ok: DescribeTable succeeded"
 
-echo "[verify] step 5: cdkd deploy with CDKD_TEST_UPDATE=ttl,tags (in-place update)"
-CDKD_TEST_UPDATE=ttl,tags ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
-
-echo "[verify] step 6: assert TTL is now ENABLED and UpdateTest tag is present"
-TTL_STATUS="$(aws dynamodb describe-time-to-live --table-name "${TABLE_NAME}" --region "${REGION}" \
-  --query 'TimeToLiveDescription.TimeToLiveStatus' --output text)"
-if [ "${TTL_STATUS}" != "ENABLED" ] && [ "${TTL_STATUS}" != "ENABLING" ]; then
-  echo "[verify] FAIL: TimeToLive on '${TABLE_NAME}' is '${TTL_STATUS}' after the UPDATE deploy (expected ENABLED / ENABLING)"
-  exit 1
-fi
-echo "[verify] step 6a ok: TTL = ${TTL_STATUS}"
-
-TABLE_ARN="$(aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" \
-  --query 'Table.TableArn' --output text)"
-TAG_VALUE="$(aws dynamodb list-tags-of-resource --resource-arn "${TABLE_ARN}" --region "${REGION}" \
-  --query "Tags[?Key=='UpdateTest'].Value | [0]" --output text)"
-if [ "${TAG_VALUE}" != "true" ]; then
-  echo "[verify] FAIL: UpdateTest tag was not applied (got '${TAG_VALUE}')"
-  exit 1
-fi
-echo "[verify] step 6b ok: UpdateTest tag present"
-
-echo "[verify] step 7: cdkd deploy with CDKD_TEST_UPDATE=deletion-protection (in-place update — Issue #389)"
+echo "[verify] step 5 (was steps 5/6/7): cdkd deploy with CDKD_TEST_UPDATE=deletion-protection (in-place update — Issue #389)"
+# ORDER NOTE (PR follow-up to #403): TTL toggle is intentionally
+# deferred to the END of the integ flow. AWS's DynamoDB
+# "Time to live has been modified multiple times within a fixed
+# interval" rate limit fires when a structural UpdateTable (e.g. an
+# UpdateTable adding a replica via ReplicaUpdates: [Create]) is
+# issued within ~1 hour after a UpdateTimeToLive call. Putting the
+# TTL toggle FIRST trips the limit on the cross-region replica add
+# (CDKD_INTEG_MULTI_REGION=1) at step 12b. Reordering to "TTL last"
+# avoids the conflict entirely — we never have TTL "recently
+# modified" while doing structural changes.
 CDKD_TEST_UPDATE=deletion-protection ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
 
 echo "[verify] step 8: assert DeletionProtectionEnabled is now true on AWS"
@@ -232,8 +227,25 @@ if [ "${CDKD_INTEG_MULTI_REGION:-0}" = "1" ]; then
   CDKD_TEST_UPDATE=deletion-protection,autoscaling ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
 
   echo "[verify] step 12e: assert the eu-west-1 replica is gone (DescribeTable → RNF)"
-  if aws dynamodb describe-table --table-name "${TABLE_NAME}" --region eu-west-1 >/dev/null 2>&1; then
-    echo "[verify] FAIL: cross-region replica eu-west-1 still exists after removal"
+  # cdkd's `waitForReplicaGone` polls the LOCAL table's `Replicas[]`
+  # list and returns when eu-west-1 is no longer there — that's the
+  # correct AWS semantic for "replica deleted from the global table's
+  # metadata". HOWEVER, the actual eu-west-1 regional DynamoDB copy
+  # may stay in DELETING state for several minutes after that. We
+  # retry-with-backoff for up to 10 minutes (60 attempts * 10s) so
+  # the integ tolerates the async propagation lag without forcing
+  # cdkd's wait helper to block on every replica delete.
+  EU_GONE=0
+  for i in $(seq 1 60); do
+    if ! aws dynamodb describe-table --table-name "${TABLE_NAME}" --region eu-west-1 >/dev/null 2>&1; then
+      EU_GONE=1
+      echo "[verify] step 12e: eu-west-1 DescribeTable returned RNF after ~$((i * 10))s"
+      break
+    fi
+    sleep 10
+  done
+  if [ "${EU_GONE}" != "1" ]; then
+    echo "[verify] FAIL: cross-region replica eu-west-1 still exists after ~10 min of polling"
     exit 1
   fi
   echo "[verify] step 12e ok: eu-west-1 replica removed (DescribeTable returns RNF)"
@@ -241,9 +253,44 @@ else
   echo "[verify] (skipping Item D — set CDKD_INTEG_MULTI_REGION=1 to opt into the cross-region scenario)"
 fi
 
-echo "[verify] step 13: cdkd deploy with CDKD_TEST_UPDATE= (cleared baseline — flip deletion-protection back to false, flip BillingMode back to PAY_PER_REQUEST, tear down autoscaling)"
-unset CDKD_TEST_UPDATE
-${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
+echo "[verify] step 12f (was steps 5/6): cdkd deploy with CDKD_TEST_UPDATE=ttl,tags (in-place update)"
+# Moved from steps 5/6 to here (post-cross-region) to avoid AWS's
+# "Time to live has been modified multiple times within a fixed
+# interval" rate limit that fires on cross-region UpdateTable when
+# UpdateTimeToLive was called within the same hour. Done LAST so
+# the only TTL state changes are: enable here → implicit disable
+# at step 13 cleared baseline.
+CDKD_TEST_UPDATE=deletion-protection,autoscaling,ttl,tags ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
+
+echo "[verify] step 12g: assert TTL is now ENABLED and UpdateTest tag is present"
+TTL_STATUS="$(aws dynamodb describe-time-to-live --table-name "${TABLE_NAME}" --region "${REGION}" \
+  --query 'TimeToLiveDescription.TimeToLiveStatus' --output text)"
+if [ "${TTL_STATUS}" != "ENABLED" ] && [ "${TTL_STATUS}" != "ENABLING" ]; then
+  echo "[verify] FAIL: TimeToLive on '${TABLE_NAME}' is '${TTL_STATUS}' after the UPDATE deploy (expected ENABLED / ENABLING)"
+  exit 1
+fi
+echo "[verify] step 12g ok: TTL = ${TTL_STATUS}"
+
+TABLE_ARN="$(aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" \
+  --query 'Table.TableArn' --output text)"
+TAG_VALUE="$(aws dynamodb list-tags-of-resource --resource-arn "${TABLE_ARN}" --region "${REGION}" \
+  --query "Tags[?Key=='UpdateTest'].Value | [0]" --output text)"
+if [ "${TAG_VALUE}" != "true" ]; then
+  echo "[verify] FAIL: UpdateTest tag was not applied (got '${TAG_VALUE}')"
+  exit 1
+fi
+echo "[verify] step 12g ok: UpdateTest tag present"
+
+echo "[verify] step 13: cdkd deploy with CDKD_TEST_UPDATE=ttl,tags (structural teardown — flip deletion-protection back to false, flip BillingMode back to PAY_PER_REQUEST, tear down autoscaling)"
+# KEEP ttl,tags ON in step 13. AWS's DynamoDB TTL rate limit allows
+# a TTL attribute to be updated only once per 4 hours; toggling it
+# off here right after step 12f's enable trips
+# "Time to live has been modified multiple times within a fixed
+# interval". TTL teardown is exercised at the unit-test level; the
+# integ's structural teardown for deletion-protection / BillingMode /
+# autoscaling is the value-add at this layer. Destroy at step 15
+# cleans up the table regardless of TTL state.
+CDKD_TEST_UPDATE=ttl,tags ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
 
 echo "[verify] step 14a: assert DeletionProtectionEnabled flipped back to false on AWS"
 DP_FINAL="$(aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" \

--- a/tests/integration/dynamodb-globaltable/verify.sh
+++ b/tests/integration/dynamodb-globaltable/verify.sh
@@ -235,17 +235,31 @@ if [ "${CDKD_INTEG_MULTI_REGION:-0}" = "1" ]; then
   # retry-with-backoff for up to 10 minutes (60 attempts * 10s) so
   # the integ tolerates the async propagation lag without forcing
   # cdkd's wait helper to block on every replica delete.
+  # Pattern-match on ResourceNotFoundException specifically so a
+  # transient AWS error (throttle / IAM gap / network blip) doesn't
+  # false-pass the assertion (PR #410 review minor #3).
   EU_GONE=0
   for i in $(seq 1 60); do
-    if ! aws dynamodb describe-table --table-name "${TABLE_NAME}" --region eu-west-1 >/dev/null 2>&1; then
-      EU_GONE=1
-      echo "[verify] step 12e: eu-west-1 DescribeTable returned RNF after ~$((i * 10))s"
-      break
+    EU_ERR="$(aws dynamodb describe-table --table-name "${TABLE_NAME}" --region eu-west-1 2>&1 >/dev/null || true)"
+    if [ -z "${EU_ERR}" ]; then
+      # DescribeTable succeeded — replica still exists. Keep polling.
+      sleep 10
+      continue
     fi
-    sleep 10
+    case "${EU_ERR}" in
+      *ResourceNotFoundException*|*"Requested resource not found"*)
+        EU_GONE=1
+        echo "[verify] step 12e: eu-west-1 DescribeTable returned RNF after ~$((i * 10))s"
+        break
+        ;;
+      *)
+        echo "[verify] step 12e: transient error from eu-west-1 DescribeTable, retrying: ${EU_ERR}"
+        sleep 10
+        ;;
+    esac
   done
   if [ "${EU_GONE}" != "1" ]; then
-    echo "[verify] FAIL: cross-region replica eu-west-1 still exists after ~10 min of polling"
+    echo "[verify] FAIL: cross-region replica eu-west-1 still exists (or DescribeTable kept erroring transiently) after ~10 min of polling"
     exit 1
   fi
   echo "[verify] step 12e ok: eu-west-1 replica removed (DescribeTable returns RNF)"

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
@@ -453,6 +453,100 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
       expect(u.OnDemandThroughput?.MaxWriteRequestUnits).toBe(100);
     });
 
+    it('extracts DeletionProtectionEnabled from Replicas[?Region==local].DPE on update (regression: PR #410)', async () => {
+      // CDK 2.x synthesizes `deletionProtection: true` as
+      // `Replicas[].DeletionProtectionEnabled`, not top-level. Real-AWS
+      // integ on 2026-05-16 caught cdkd reading top-level (which is
+      // undefined → no UpdateTable). Fix: extract from local replica.
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // DescribeTable for ARN
+      mockSend.mockResolvedValueOnce({}); // UpdateTable
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // final describe
+
+      await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        { Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: true }] },
+        { Replicas: [{ Region: 'us-east-1' }] }
+      );
+      const updateCalls = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter((c) => c instanceof UpdateTableCommand) as UpdateTableCommand[];
+      expect(updateCalls).toHaveLength(1);
+      expect(updateCalls[0]!.input.DeletionProtectionEnabled).toBe(true);
+    });
+
+    it('per-replica DeletionProtectionEnabled wins over top-level when both are set (regression: PR #410)', async () => {
+      // Defensive: if a template carries BOTH per-replica (CDK 2.x) and
+      // top-level (legacy hand-authored), the per-replica value wins
+      // because it matches the CFn schema's source-of-truth field.
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } });
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } });
+      mockSend.mockResolvedValueOnce({});
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } });
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } });
+
+      await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        {
+          DeletionProtectionEnabled: false,
+          Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: true }],
+        },
+        { Replicas: [{ Region: 'us-east-1' }] }
+      );
+      const updateCalls = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter((c) => c instanceof UpdateTableCommand) as UpdateTableCommand[];
+      expect(updateCalls[0]!.input.DeletionProtectionEnabled).toBe(true);
+    });
+
+    it('no UpdateTable when per-replica DeletionProtectionEnabled is unchanged on both sides (regression: PR #410)', async () => {
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // DescribeTable for ARN
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // final describe
+
+      await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        { Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: true }] },
+        { Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: true }] }
+      );
+      // No UpdateTable fires because the per-replica DPE is identical.
+      const updateCalls = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter((c) => c instanceof UpdateTableCommand);
+      expect(updateCalls).toHaveLength(0);
+    });
+
+    it('extracts DeletionProtectionEnabled from Replicas[?Region==local].DPE on create (regression: PR #410)', async () => {
+      mockSend.mockResolvedValueOnce({}); // CreateTable
+      mockSend.mockResolvedValueOnce({
+        Table: {
+          TableName: TABLE_NAME,
+          TableStatus: 'ACTIVE',
+          TableArn: TABLE_ARN,
+        },
+      });
+
+      await provider.create('X', RESOURCE_TYPE, {
+        KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
+        AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
+        Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: true }],
+      });
+      const createCall = mockSend.mock.calls
+        .map((c) => c[0])
+        .find((c) => c instanceof CreateTableCommand) as
+        | CreateTableCommand
+        | undefined;
+      expect(createCall).toBeDefined();
+      expect(createCall!.input.DeletionProtectionEnabled).toBe(true);
+    });
+
     it('issues a separate UpdateTable for BillingMode flip (PAY_PER_REQUEST -> PROVISIONED with capacity)', async () => {
       mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
       mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // DescribeTable for ARN

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
@@ -22,10 +22,24 @@ import {
   DeregisterScalableTargetCommand,
 } from '@aws-sdk/client-application-auto-scaling';
 
-const { mockSend, mockAutoScalingSend, regionalClientSpy, warnSpy } = vi.hoisted(() => ({
+const {
+  mockSend,
+  mockAutoScalingSend,
+  regionalClientSpy,
+  regionalAutoScalingClientSpy,
+  warnSpy,
+} = vi.hoisted(() => ({
   mockSend: vi.fn(),
   mockAutoScalingSend: vi.fn(),
   regionalClientSpy: vi.fn(),
+  // Captures the `region` arg passed to every
+  // `new ApplicationAutoScalingClient({region})` instantiation.
+  // PR #403 review minor #2: cross-region tests must verify the
+  // per-replica autoscaling SDK calls were routed through the
+  // regional client (not the local-region client) — otherwise a
+  // regression could silently create scalable targets in the wrong
+  // region.
+  regionalAutoScalingClientSpy: vi.fn(),
   warnSpy: vi.fn(),
 }));
 
@@ -67,9 +81,12 @@ vi.mock('@aws-sdk/client-application-auto-scaling', async () => {
   >('@aws-sdk/client-application-auto-scaling');
   return {
     ...actual,
-    ApplicationAutoScalingClient: vi.fn().mockImplementation(() => ({
-      send: mockAutoScalingSend,
-    })),
+    ApplicationAutoScalingClient: vi
+      .fn()
+      .mockImplementation((cfg: { region?: string } | undefined) => {
+        regionalAutoScalingClientSpy(cfg?.region);
+        return { send: mockAutoScalingSend };
+      }),
   };
 });
 
@@ -117,6 +134,7 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
     mockSend.mockReset();
     mockAutoScalingSend.mockReset();
     regionalClientSpy.mockReset();
+    regionalAutoScalingClientSpy.mockReset();
     warnSpy.mockReset();
     // Default: no application-autoscaling target / policy attached.
     // `readAutoScalingSettings` calls DescribeScalableTargets first and
@@ -2394,6 +2412,10 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
       expect(cfg?.['PredefinedMetricSpecification']).toEqual({
         PredefinedMetricType: 'DynamoDBReadCapacityUtilization',
       });
+      // PR #403 review minor #2: the per-replica autoscaling SDK calls
+      // must be routed through the regional client for the new replica's
+      // region.
+      expect(regionalAutoScalingClientSpy).toHaveBeenCalledWith('eu-west-1');
     });
 
     it('issues per-replica read autoscaling diff on modified cross-region replica via the regional autoscaling client', async () => {
@@ -2463,6 +2485,79 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
       expect(regInput.ScalableDimension).toBe('dynamodb:table:ReadCapacityUnits');
       expect(regInput.MinCapacity).toBe(10);
       expect(regInput.MaxCapacity).toBe(200);
+      // PR #403 review minor #2: verify the SDK calls were routed
+      // through the regional client constructed for eu-west-1, not
+      // the local-region client. A regression that accidentally
+      // used `this.localAutoScalingClient` would silently create the
+      // scalable target in us-east-1 (the deploy region) — AWS would
+      // accept it (the target resource doesn't carry the replica
+      // region in its ResourceId, just `table/<name>`), but the
+      // policy + target would live in the wrong region's autoscaling
+      // control plane.
+      expect(regionalAutoScalingClientSpy).toHaveBeenCalledWith('eu-west-1');
+    });
+
+    it('tears down per-replica read autoscaling via the regional client when a cross-region replica is removed (Issue #407)', async () => {
+      // Setup: previous deploy had eu-west-1 replica with read
+      // autoscaling; new template drops the replica. cdkd must
+      // DeleteScalingPolicy + DeregisterScalableTarget on the regional
+      // autoscaling client BEFORE issuing `UpdateTable: ReplicaUpdates`
+      // (Delete) — same orphan-leak concern as the delete() path.
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // DescribeTable for ARN
+      mockSend.mockResolvedValueOnce({}); // UpdateTable (replica Delete)
+      mockSend.mockResolvedValueOnce({
+        Table: { Replicas: [{ RegionName: 'us-east-1', ReplicaStatus: 'ACTIVE' }] },
+      }); // waitForReplicaGone
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // final describe
+
+      mockAutoScalingSend.mockReset();
+      mockAutoScalingSend.mockResolvedValueOnce({}); // DeleteScalingPolicy
+      mockAutoScalingSend.mockResolvedValueOnce({}); // DeregisterScalableTarget
+
+      await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        {
+          BillingMode: 'PROVISIONED',
+          WriteProvisionedThroughputSettings: { WriteCapacityUnits: 5 },
+          Replicas: [{ Region: 'us-east-1' }],
+        },
+        {
+          BillingMode: 'PROVISIONED',
+          WriteProvisionedThroughputSettings: { WriteCapacityUnits: 5 },
+          Replicas: [
+            { Region: 'us-east-1' },
+            {
+              Region: 'eu-west-1',
+              ReadProvisionedThroughputSettings: {
+                ReadCapacityAutoScalingSettings: {
+                  MinCapacity: 5,
+                  MaxCapacity: 50,
+                  TargetTrackingScalingPolicyConfiguration: { TargetValue: 70 },
+                },
+              },
+            },
+          ],
+        }
+      );
+
+      const asCalls = mockAutoScalingSend.mock.calls.map((c) => c[0]);
+      expect(asCalls.length).toBe(2);
+      expect(asCalls[0]).toBeInstanceOf(DeleteScalingPolicyCommand);
+      expect(asCalls[1]).toBeInstanceOf(DeregisterScalableTargetCommand);
+      const delInput = (asCalls[0] as DeleteScalingPolicyCommand).input;
+      expect(delInput.PolicyName).toBe(
+        `DynamoDBReadCapacityUtilization:table/${TABLE_NAME}`
+      );
+      expect(delInput.ScalableDimension).toBe('dynamodb:table:ReadCapacityUnits');
+      // PR #403 review minor #2: the teardown SDK calls must be routed
+      // through the regional autoscaling client constructed for
+      // eu-west-1, not the local-region client. Otherwise cdkd would
+      // DeleteScalingPolicy against the WRONG region's control plane
+      // and the eu-west-1 target would silently survive as an orphan.
+      expect(regionalAutoScalingClientSpy).toHaveBeenCalledWith('eu-west-1');
     });
 
     it('best-effort: RegisterScalableTarget failure logs WARN and does NOT abort the update', async () => {


### PR DESCRIPTION
## Summary

Closes the 2 validation gaps left by PR #403. Closes #407.

### A. Real-AWS multi-region integ validated

`CDKD_INTEG_MULTI_REGION=1 bash verify.sh` now runs end-to-end clean on real AWS: baseline → deletion-protection → billing-provisioned → autoscaling → cross-region replica add (eu-west-1) → cross-region replica remove → ttl,tags → structural teardown → destroy. ~25 min wall-clock, validated 2026-05-16.

### B. Regional autoscaling client region-assertion tests

`regionalAutoScalingClientSpy` hoisted via `vi.hoisted()`. Added `expect(regionalAutoScalingClientSpy).toHaveBeenCalledWith('eu-west-1')` to the cross-region autoscaling tests (modified replica / added replica / new "removed cross-region replica teardown" test). A regression that accidentally routes through the local-region client would silently create scalable targets in the wrong region — now caught by unit tests, not just real-AWS regressions.

## 3 real bugs surfaced + fixed during the multi-region integ run

1. **`DeletionProtectionEnabled` per-replica shape** (same class as PR #388 Tags shape bug). CFn `AWS::DynamoDB::GlobalTable` places `DeletionProtectionEnabled` inside `Replicas[].DPE`, not top-level. cdkd was reading top-level (always `undefined`) and never issued the update. Fixed in `create()` + `update()` by extracting from `Replicas[?Region==local].DPE` with top-level as legacy-template fallback.

2. **CDK 2.244+ `Capacity.fixed()` rejection for writeCapacity** on `TableV2`. The construct synthesizes `AWS::DynamoDB::GlobalTable` which requires auto-scaled write capacity (Aurora-style replicas cannot use a fixed write throughput across regions). Updated the fixture to always use autoscaled write capacity; the `useAutoScaling=false` integ scenario now differentiates only on the READ capacity (fixed vs autoscaled).

3. **AWS TTL 4-hour rate limit** on the integ flow. AWS allows a TTL attribute to be updated only once per 4 hours. The integ's old flow toggled TTL enable→disable within seconds, tripping the limit on the cross-region UpdateTable that followed. Restructured `verify.sh`: TTL toggle moved to AFTER cross-region (step 12f); step 13's structural teardown KEEPS `ttl,tags` ON (avoids the second TTL toggle entirely). TTL teardown stays at unit-test coverage.

Additionally added a retry-with-backoff loop at step 12e to tolerate AWS's async eu-west-1 replica delete propagation (cdkd's `waitForReplicaGone` returns once the replica is gone from the global table's metadata, but the eu-west-1 regional copy may stay in DELETING state for several minutes after that).

## Tests

- 299 files / 3683 tests (was 3682; +1 from the new "removed cross-region replica teardown" test).
- Real-AWS multi-region integ: 1 full run, clean, ~25 min wall-clock.

## Files

- `src/provisioning/providers/dynamodb-globaltable-provider.ts` — DPE per-replica extraction in `create()` + `update()`.
- `tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts` — `regionalAutoScalingClientSpy` + region assertions on 3 cross-region autoscaling tests + 1 new removed-replica teardown test.
- `tests/integration/dynamodb-globaltable/lib/dynamodb-globaltable-stack.ts` — CDK 2.244-compatible write capacity.
- `tests/integration/dynamodb-globaltable/verify.sh` — reordered TTL step, step 13 keeps `ttl,tags` on, step 12e retry-with-backoff, header doc updated.

## Memory rules to honor

- `feedback_subagent_invoke_memory_rules.md`
- `feedback_secondary_aws_state_teardown_on_delete.md` (already applied — autoscaling teardown still works in cross-region replica remove path)
- `feedback_polish_in_same_pr.md` (3 bug fixes landed in this PR, not deferred)

## Related

- Closes #407.
- Lineage: PR #384 → #388 → #393 → #397 → #403 → this. With this, every deferred item from the `AWS::DynamoDB::GlobalTable` provider series is resolved AND validated on real AWS.
