### PR TITLE
test(provider-coverage): correct misleading rationale for Glue Crawler LineageConfiguration

### DIFF
--- a/tests/fixtures/cfn-schemas/_todo-backfill.json
+++ b/tests/fixtures/cfn-schemas/_todo-backfill.json
@@ -637,7 +637,7 @@
       "CacheSubnetGroupDescription": "SDK input field name; CFn schema names the same field 'Description'. Investigate whether to rename in a follow-up."
     },
     "AWS::Glue::Crawler": {
-      "LineageConfiguration": "Schema snapshot (2026-05) does not include this property; AWS may have deprecated/renamed it. Verify against current AWS docs in a follow-up."
+      "LineageConfiguration": "Provider's createCrawler/updateCrawler wires this field via the SDK (glue-provider.ts:2277, 2386); the property is live in AWS but cloudformation:DescribeType (CFn registry schema) does NOT surface it. Likely a registry-schema-vs-user-guide-doc lag on AWS's side. Tolerated until AWS publishes it in the registry."
     },
     "AWS::Glue::Job": {
       "SourceControlDetails": "Schema snapshot (2026-05) does not include this property. Verify in a follow-up."


### PR DESCRIPTION
## Summary

Follow-up to PR #408 review nit 3. The `bogusTolerated` entry for
`AWS::Glue::Crawler.LineageConfiguration` in
`tests/fixtures/cfn-schemas/_todo-backfill.json` carried a misleading
rationale claiming AWS may have deprecated/renamed the property.

In fact, the cdkd Glue provider actively wires `LineageConfiguration`
through to `CreateCrawlerCommand` and `UpdateCrawlerCommand`:

- `src/provisioning/providers/glue-provider.ts:2277` (createCrawler)
- `src/provisioning/providers/glue-provider.ts:2386` (convertCrawlerProperties for update)

So the property is live in AWS today. The real reason it lands in
`bogusTolerated` is that `cloudformation:DescribeType` (the CFn registry
schema snapshot used by the property-coverage safety-net test) does NOT
surface the field — a registry-schema-vs-user-guide-doc lag on AWS's
side, not a provider bug.

Updated rationale spells this out and includes the provider line numbers
so a future reader can verify the claim in seconds.

## Changes

- `tests/fixtures/cfn-schemas/_todo-backfill.json` — single-line
  rationale string update for the Glue Crawler `LineageConfiguration`
  entry. No code or behavior change; the entry remains tolerated.

## Test plan

- [x] `vp test run property-coverage` — 116/116 still passing
- [x] `vp run check` — format + lint clean
- [x] `vp run typecheck` / `vp run build` / `vp run test` — full suite green (3849 tests)
