### PR TITLE
test(provisioning): catch stale bogus-tolerated entries when AWS adds the property

### DIFF
--- a/tests/unit/provisioning/property-coverage.test.ts
+++ b/tests/unit/provisioning/property-coverage.test.ts
@@ -251,4 +251,27 @@ describe('SDK Provider property coverage', () => {
     }
     expect(problems, problems.join('\n')).toEqual([]);
   });
+
+  // Staleness guard: when AWS later adds a property previously listed in
+  // `bogusTolerated[type][prop]`, the entry silently sits in the JSON unused —
+  // the schema now has the property, so the coverage classifier finds it via
+  // `handled` / `unaccounted` paths, and the `bogusTolerated` rationale is
+  // never consulted again. The rationale becomes a lie and should be removed.
+  // This surfaces those dead rationales explicitly so they get cleaned up.
+  it('no bogus-tolerated entry has become stale (schema now contains the property)', () => {
+    const stale: string[] = [];
+    for (const [type, entries] of Object.entries(bogusTolerance)) {
+      const fixture = loadSchemaFixture(type);
+      if (!fixture) continue; // covered by an earlier test
+      const schemaSet = new Set(fixture.properties);
+      for (const prop of Object.keys(entries)) {
+        if (schemaSet.has(prop)) {
+          stale.push(
+            `bogusTolerated.${type}.${prop} — property is NOW in the CFn schema; remove the tolerance entry`
+          );
+        }
+      }
+    }
+    expect(stale, stale.join('\n')).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #408 (which closed issue #391 and introduced the `bogusTolerated` mechanism in `tests/fixtures/cfn-schemas/_todo-backfill.json`).

Addresses the structural nit from PR #408 review: the `bogusTolerated` block has a **silent staleness** bug. When AWS later adds back a property previously listed under `bogusTolerated[type][prop]` (because cdkd worked around a missing/typo'd field, or AWS un-deprecated something), the entry sits in the JSON unused. The schema now has the property, so the coverage classifier finds it via the `handled` / `unaccounted` paths, and the `bogusTolerated` rationale is never consulted again — the rationale becomes a lie and the entry rots indefinitely.

This PR adds a sub-test that surfaces those dead rationales explicitly so they get cleaned up.

## What the test does

Walks every `bogusTolerated[type][prop]` entry, loads the matching CFn schema fixture, and fails when `fixture.properties.includes(prop)` is true. Failure message names the exact entry to remove:

```
bogusTolerated.AWS::Foo::Bar.SomeProp — property is NOW in the CFn schema; remove the tolerance entry
```

## Day-1 verification

Audited all 12 day-1 entries from PR #408 against their schema fixtures — none are stale (every listed prop is still genuinely absent from the CFn schema snapshot, so the rationale stands):

- `AWS::AutoScaling::AutoScalingGroup.DefaultCooldown` — OK
- `AWS::BedrockAgentCore::Runtime.ClientToken` — OK
- `AWS::DynamoDB::GlobalTable.TableClass`, `.DeletionProtectionEnabled` — OK
- `AWS::EC2::NetworkAclEntry.IcmpTypeCode` — OK
- `AWS::ECS::Service.PlacementStrategy` — OK
- `AWS::ElastiCache::SubnetGroup.CacheSubnetGroupDescription` — OK
- `AWS::Glue::Crawler.LineageConfiguration` — OK
- `AWS::Glue::Job.SourceControlDetails` — OK
- `AWS::Neptune::DBInstance.DeletionProtection` — OK
- `AWS::S3Tables::Table.Name`, `.Format` — OK

So the test passes cleanly on day 1.

## Test count

117/117 passing (was 116 before this PR).

## Test plan

- [x] `vp test run property-coverage` — 117/117 passes
- [x] `vp run check` — typecheck/lint/format clean
- [x] Manual verification: every day-1 `bogusTolerated` entry is absent from its CFn schema fixture's `properties` array
- [x] No `src/**` changes — tests-only PR
