### PR TITLE
chore(scripts): polish refresh-cfn-schemas (PR #408 nits)

### DIFF
--- a/scripts/refresh-cfn-schemas.mjs
+++ b/scripts/refresh-cfn-schemas.mjs
@@ -33,7 +33,7 @@ import {
   DescribeTypeCommand,
 } from '@aws-sdk/client-cloudformation';
 import { mkdir, readFile, writeFile, readdir } from 'node:fs/promises';
-import { join, dirname, basename } from 'node:path';
+import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -57,16 +57,6 @@ const MAX_RETRIES = 6;
  */
 export function fixtureFilename(type) {
   return type.replace(/::/g, '-') + '.json';
-}
-
-/**
- * Inverse of fixtureFilename — recover the CFn type from a filename.
- *
- * @param {string} filename
- * @returns {string}
- */
-export function fixtureTypeFromFilename(filename) {
-  return basename(filename, '.json').replace(/-/g, '::');
 }
 
 /**
@@ -325,7 +315,7 @@ async function main() {
 
 // Allow `import { extractRegisteredTypes } from '../../scripts/refresh-cfn-schemas.mjs'`
 // in tests without running main().
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch((err) => {
     console.error(err);
     process.exit(1);


### PR DESCRIPTION
## Summary

Follow-up to PR #408 addressing two reviewer nits in `scripts/refresh-cfn-schemas.mjs`. No behavior change for the script's documented entry-point.

- **Nit 1 (dead export):** Remove `fixtureTypeFromFilename` — exported but never referenced anywhere in the repo. Drop the now-unused `basename` import.
- **Nit 2 (fragile main-detection):** Replace ``if (import.meta.url === `file://${process.argv[1]}`)`` with `if (process.argv[1] === fileURLToPath(import.meta.url))`. The new form is the canonical ESM pattern and is robust against paths containing spaces or symlinks (URL-encoded path components vs filesystem-decoded `process.argv[1]` would otherwise mismatch).

`fileURLToPath` was already imported in the file.

## Test plan

- [x] `vp test run property-coverage` — 116/116 passing
- [x] `vp check --fix` — typecheck + lint + format clean
- [x] `vp run build` — clean
- [x] `vp run test` — 3849/3849 passing
- [x] No docs changes (diff scope is `scripts/**` only; outside the `docs` markgate scope)
