### PR TITLE
chore(skills): /verify-pr mergeStateStatus check + /review-pr auto-gen LOC bias

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -27,6 +27,16 @@ The skill itself never spawns reviewers. It reads PR stats, applies the heuristi
 
    Compute `loc = a + d`.
 
+   **Subtract auto-generated LOC** before computing the tier — generated artifacts under `docs/_generated/**` (provider-coverage matrices, integ-coverage matrices, snapshot fixtures, etc.) and lockfiles (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`) inflate LOC without adding reviewer surface. Reviewers do not (and cannot meaningfully) audit these files line-by-line; they only verify the SCRIPT that produced them. Compute `loc` from the diff with these paths excluded:
+
+   ```bash
+   excluded=$(gh pr view <N> --json files \
+     -q '[.files[] | select(.path | test("^docs/_generated/|/pnpm-lock\\.yaml$|/package-lock\\.json$|/yarn\\.lock$")) | .additions + .deletions] | add // 0')
+   loc=$(( a + d - excluded ))
+   ```
+
+   Caught in PR #404 (issue #392): 4286 raw LOC → 3-axis tier, but ~2900 LOC was auto-generated `docs/_generated/integ-coverage.json` + `docs/integ-coverage.md`. Substantive surface was ~1100 LOC, which is squarely 1-reviewer tier. Auto-gen exclusion produces the right answer without sacrificing rigor on the substantive code. Note: `fc` is NOT adjusted — a 12-file diff is still cross-cutting even when 2 of the files are generated.
+
 2. **Determine the base tier** from `(loc, fc)` per the heuristic:
 
    | Condition | Base tier |
@@ -217,5 +227,6 @@ These three PRs are the calibration set. Running this skill against them should 
 | #237 | 4515 LOC, 24 files (incl. `src/local/cognito-jwt.ts`, `lambda-authorizer.ts`) | 3-axis (loc >= 1000 AND fc >= 10) | up (security surface) → clamps at 3-axis | **3-axis** |
 | #236 | 269 LOC, 9 files (incl. `src/local/docker-image-builder.ts`, `ecr-puller.ts`) | inline (loc < 300) | up (process-launch surface) → 1-reviewer | **1-reviewer** |
 | #344 | 1488 LOC, 13 files (all `.md` — `docs/plans/*.md` deletes + `CLAUDE.md` / `docs/*.md` / `tests/integration/*/README.md` link-fix) | 3-axis (loc >= 1000 AND fc >= 10) | down (every path is `.md`, matches `**/*.md` in pure-docs bucket) → 1-reviewer | **1-reviewer** |
+| #404 | 4286 raw LOC → ~1100 after subtracting `docs/_generated/integ-coverage.json` (2724 LOC) + `docs/integ-coverage.md` (~170 LOC) auto-gen, 19 files (scripts/, hooks, fixtures, sidecar JSON) | 3-axis (`fc >= 10` still triggers — file count not adjusted for auto-gen) | none (mixed paths exclude pure docs/infra + tests-only bias) | **3-axis** (file count alone, even after LOC adjustment) — but if PR had been split per memory `feedback_split_tooling_from_backfill.md` (tool vs backfill), each half would be 1-reviewer |
 
 If the skill output diverges from these, the heuristic or the trigger lists have drifted — re-read this file and the linked memory entry before trusting the recommendation.

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -48,7 +48,8 @@ Run each check and report pass/fail:
 3. **CI status**
    - If PR number is not provided as argument, auto-detect via `gh pr view --json number -q .number`
    - If no PR exists for current branch, use the `AskUserQuestion` tool to ask for the PR number
-   - `gh pr checks <PR-number>` - all checks pass
+   - **FIRST: `gh pr view <PR> --json mergeStateStatus,mergeable -q '"mergeable=\(.mergeable) state=\(.mergeStateStatus)"'`** — when this returns `mergeable=CONFLICTING state=DIRTY`, the CI workflow will NEVER fire on the PR no matter how long you wait (empirically observed PR #404 — wasted ~70 min thinking GitHub Actions was broken). Close+reopen, empty commits, and `git push --force-with-lease` of unchanged content all fail to re-trigger. Resolution: `git fetch origin main && git rebase origin/main`, resolve conflicts, `git push --force-with-lease` — CI fires within ~30s of the push. See memory `feedback_pr_conflict_blocks_ci.md` for the full diagnostic checklist.
+   - Only after `mergeStateStatus` is `CLEAN` / `UNSTABLE` / `BLOCKED` / `BEHIND`: `gh pr checks <PR-number>` - all checks pass
    - If checks are pending, wait and recheck
 
 4. **Working tree**


### PR DESCRIPTION
## Summary

Two skill updates from the PR #404 retro. Skills-only change; no source code touched.

- **`/verify-pr` step 3** — make `gh pr view <N> --json mergeStateStatus,mergeable` the FIRST CI-status command. The DIRTY-mergeable-state silently prevents CI from firing on the PR; close+reopen, empty commits, and force-pushing unchanged content all fail to retrigger. Documented in memory `feedback_pr_conflict_blocks_ci.md` since 2026-05-08 but missed mid-session — promoting to a load-bearing skill step closes the gap. Wasted ~70 min on PR #404 before realising.
- **`/review-pr` step 1** — subtract auto-generated LOC (`docs/_generated/**` + `pnpm-lock.yaml` / `package-lock.json` / `yarn.lock`) from the tier calculation. PR #404 added to the calibration table to demonstrate the new behaviour + cross-link to memory `feedback_split_tooling_from_backfill.md` for the "split tooling from backfill" rule that would have avoided the over-large tier for PR #404 in the first place. File count (`fc`) is intentionally NOT adjusted — a 12-file diff is still cross-cutting even when 2 of the files are generated.

The retro also considered two new hooks (`mergeStateStatus-check-gate.sh` to block `gh pr merge` on DIRTY; `empty-commit-warn-gate.sh` to warn on `git commit --allow-empty`). Both declined — `gh pr merge` already refuses to merge a DIRTY PR, and empty commits produce no lasting harm. Documented in memory `feedback_hooks_with_marginal_value.md` so the proposal doesn't resurface every session.

## Test plan

- [x] `vp run check` (177 files pass)
- [x] `vp run test` (300 files / 3849 tests pass — no test impact from skills-only edit)
- [x] Inline spot-check: 13 LOC additions across 2 skill files; mechanical text changes, no logic
