### PR TITLE
fix(dynamodb-globaltable): close 3 deferred nits from PR #410 review (AWS-aware DPE + TTL error wrap + helper refactor)

### DIFF
--- a/src/provisioning/providers/dynamodb-globaltable-provider.ts
+++ b/src/provisioning/providers/dynamodb-globaltable-provider.ts
@@ -375,17 +375,8 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
     // `AWS::DynamoDB::GlobalTable` (just like Tags). CDK 2.x's
     // `deletionProtection: true` synthesizes to
     // `Replicas[?Region==<deploy region>].DeletionProtectionEnabled`.
-    // Extract from the local replica entry; fall back to top-level
-    // for legacy / hand-authored templates that put it there.
-    const localReplicaForDP = replicas.find((r) => r['Region'] === currentRegion);
-    const dpePerReplica = localReplicaForDP?.['DeletionProtectionEnabled'];
-    const dpeTopLevel = properties['DeletionProtectionEnabled'];
-    const dpeResolved =
-      typeof dpePerReplica === 'boolean'
-        ? dpePerReplica
-        : typeof dpeTopLevel === 'boolean'
-          ? dpeTopLevel
-          : undefined;
+    // Extract via the shared module-level helper.
+    const dpeResolved = extractLocalDeletionProtection(properties, currentRegion);
     if (dpeResolved !== undefined) {
       createParams.DeletionProtectionEnabled = dpeResolved;
     }
@@ -715,21 +706,28 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
       // AWS allows combining these in a single call because they don't
       // conflict with each other or with each other's modes.
       // DeletionProtectionEnabled is per-replica in the CFn schema
-      // (same shape as Tags). Extract from `Replicas[?Region==local]`
-      // with a fall-through to top-level for legacy templates.
-      const extractLocalDP = (props: Record<string, unknown>): boolean | undefined => {
-        const replicas = (props['Replicas'] ?? []) as Array<Record<string, unknown>>;
-        const local = replicas.find((r) => r['Region'] === currentRegion);
-        const perReplica = local?.['DeletionProtectionEnabled'];
-        if (typeof perReplica === 'boolean') return perReplica;
-        const topLevel = props['DeletionProtectionEnabled'];
-        return typeof topLevel === 'boolean' ? topLevel : undefined;
-      };
-      const newDpe = extractLocalDP(properties);
-      const oldDpe = extractLocalDP(previousProperties);
+      // (same shape as Tags). Extract via shared module-level helper.
+      //
+      // **AWS-aware diff (migration fix)**: also compare against AWS's
+      // observed DPE from the DescribeTable response above. Pre-PR
+      // #410 cdkd was reading top-level DPE which was always
+      // undefined → no UpdateTable was issued, but state recorded
+      // the user's template intent (per-replica DPE=true). Post-fix,
+      // a no-change redeploy would see oldDpe=true vs newDpe=true
+      // and skip the update — but AWS still has DPE=false. By
+      // comparing against `awsDpe` from DescribeTable, we re-converge
+      // the actual AWS state to the template intent on any deploy,
+      // not just deploys with a template-side diff. Same logic
+      // doubles as protection against console-side drift.
+      const newDpe = extractLocalDeletionProtection(properties, currentRegion);
+      const oldDpe = extractLocalDeletionProtection(previousProperties, currentRegion);
+      const awsDpe = describeResp.Table?.DeletionProtectionEnabled;
       const flatUpdate: UpdateTableCommandInput = { TableName: physicalId };
       let flatChanged = false;
-      if (newDpe !== oldDpe) {
+      const dpeDiffersFromState = newDpe !== oldDpe;
+      const dpeDiffersFromAws =
+        newDpe !== undefined && typeof awsDpe === 'boolean' && Boolean(newDpe) !== awsDpe;
+      if (dpeDiffersFromState || dpeDiffersFromAws) {
         flatUpdate.DeletionProtectionEnabled = Boolean(newDpe ?? false);
         flatChanged = true;
       }
@@ -1102,15 +1100,40 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
       }
 
       // 7. TimeToLiveSpecification (separate API).
+      // AWS enforces a 4-hour rate limit on TTL changes per table
+      // ("Time to live has been modified multiple times within a fixed
+      // interval"). Catch and rewrap with an actionable hint pointing
+      // at the AWS-side limit, so a user redeploying a TTL-toggling
+      // stack twice in tight succession sees what's happening instead
+      // of a raw AWS error.
       if (
         !deepEqual(
           properties['TimeToLiveSpecification'],
           previousProperties['TimeToLiveSpecification']
         )
       ) {
+        const sendTtl = async (cmd: UpdateTimeToLiveCommand): Promise<void> => {
+          try {
+            await this.dynamoDBClient.send(cmd);
+          } catch (ttlErr) {
+            const msg = ttlErr instanceof Error ? ttlErr.message : String(ttlErr);
+            if (msg.includes('Time to live has been modified multiple times')) {
+              throw new ProvisioningError(
+                `AWS rejected TimeToLive update on ${physicalId}: ${msg}. ` +
+                  `AWS enforces a ~4-hour rate limit on TTL changes per table; ` +
+                  `wait and redeploy, or keep the previous TTL state in this deploy.`,
+                resourceType,
+                logicalId,
+                physicalId,
+                ttlErr instanceof Error ? ttlErr : undefined
+              );
+            }
+            throw ttlErr;
+          }
+        };
         const ttl = properties['TimeToLiveSpecification'] as Record<string, unknown> | undefined;
         if (ttl?.['AttributeName']) {
-          await this.dynamoDBClient.send(
+          await sendTtl(
             new UpdateTimeToLiveCommand({
               TableName: physicalId,
               TimeToLiveSpecification: {
@@ -1124,7 +1147,7 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
           // AttributeName to disable it. Pull from old props.
           const prevTtl = previousProperties['TimeToLiveSpecification'] as Record<string, unknown>;
           if (prevTtl['AttributeName']) {
-            await this.dynamoDBClient.send(
+            await sendTtl(
               new UpdateTimeToLiveCommand({
                 TableName: physicalId,
                 TimeToLiveSpecification: {
@@ -2427,6 +2450,32 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
  *    (per-replica, the deploy region's setting). Same literal-vs-auto-
  *    scaling-vs-default-5 precedence.
  */
+/**
+ * Extract the local replica's `DeletionProtectionEnabled` from a CFn
+ * properties shape. The `AWS::DynamoDB::GlobalTable` CFn schema places
+ * the field inside `Replicas[?Region==<region>].DeletionProtectionEnabled`;
+ * CDK 2.x's `deletionProtection: true` synthesizes there. Falls back
+ * to the top-level `DeletionProtectionEnabled` for legacy or
+ * hand-authored templates (the property doesn't formally exist at
+ * the top level in the CFn schema, but cdkd tolerates it as a
+ * pass-through to avoid breaking older state files).
+ *
+ * Returns `undefined` when neither shape carries a boolean — the
+ * caller treats that as "unset" and does not include the field in
+ * the SDK call.
+ */
+export function extractLocalDeletionProtection(
+  props: Record<string, unknown>,
+  region: string
+): boolean | undefined {
+  const replicas = (props['Replicas'] ?? []) as Array<Record<string, unknown>>;
+  const local = replicas.find((r) => r['Region'] === region);
+  const perReplica = local?.['DeletionProtectionEnabled'];
+  if (typeof perReplica === 'boolean') return perReplica;
+  const topLevel = props['DeletionProtectionEnabled'];
+  return typeof topLevel === 'boolean' ? topLevel : undefined;
+}
+
 export function derivePerCallProvisionedThroughput(
   properties: Record<string, unknown>,
   region: string

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
@@ -547,6 +547,105 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
       expect(createCall!.input.DeletionProtectionEnabled).toBe(true);
     });
 
+    it('AWS-aware DPE re-converge: fires UpdateTable when state and template both say true but AWS reports false (migration fix)', async () => {
+      // Migration scenario from pre-PR #410:
+      // - Pre-fix cdkd recorded state.properties.Replicas[0].DPE = true
+      //   (template intent), but never actually called UpdateTable
+      //   (it was reading top-level which was undefined).
+      // - AWS-side DPE is still false.
+      // - Post-fix update() must force the UpdateTable against AWS
+      //   when state-recorded oldDpe equals newDpe but AWS-current
+      //   differs. Same logic also covers console-side drift.
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({
+        Table: { TableArn: TABLE_ARN, DeletionProtectionEnabled: false },
+      }); // DescribeTable for ARN + AWS DPE
+      mockSend.mockResolvedValueOnce({}); // UpdateTable (forced by AWS-aware diff)
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // final describe
+
+      await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        { Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: true }] },
+        { Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: true }] }
+      );
+      const updateCalls = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter((c) => c instanceof UpdateTableCommand) as UpdateTableCommand[];
+      expect(updateCalls).toHaveLength(1);
+      expect(updateCalls[0]!.input.DeletionProtectionEnabled).toBe(true);
+    });
+
+    it('AWS-aware DPE: no UpdateTable when state, template, AND AWS all agree on DPE', async () => {
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({
+        Table: { TableArn: TABLE_ARN, DeletionProtectionEnabled: true },
+      }); // DescribeTable: AWS DPE matches template
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // final describe
+
+      await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        { Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: true }] },
+        { Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: true }] }
+      );
+      const updateCalls = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter((c) => c instanceof UpdateTableCommand);
+      expect(updateCalls).toHaveLength(0);
+    });
+
+    it('AWS-aware DPE: skips re-converge when template does NOT set DPE (no opinion → trust state/AWS)', async () => {
+      // When template doesn't carry DPE, cdkd should NOT force the
+      // field to false via the AWS-aware diff. The user hasn't
+      // opted in to manage DPE — drift detection handles surfacing
+      // any AWS-side console change.
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({
+        Table: { TableArn: TABLE_ARN, DeletionProtectionEnabled: true },
+      }); // AWS has DPE=true
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // final describe
+
+      await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        { Replicas: [{ Region: 'us-east-1' }] }, // no DPE in template
+        { Replicas: [{ Region: 'us-east-1' }] }
+      );
+      const updateCalls = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter((c) => c instanceof UpdateTableCommand);
+      expect(updateCalls).toHaveLength(0);
+    });
+
+    it('TTL rate limit error: rewraps AWS "Time to live has been modified multiple times" with a friendly hint', async () => {
+      // AWS enforces a ~4-hour TTL change rate limit per table. The
+      // raw error message is correct but not actionable. cdkd
+      // rewraps with a ProvisioningError that names the rate limit
+      // and points at the workaround.
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // DescribeTable for ARN
+      mockSend.mockRejectedValueOnce(
+        new Error('Time to live has been modified multiple times within a fixed interval')
+      );
+
+      await expect(
+        provider.update(
+          'X',
+          TABLE_NAME,
+          RESOURCE_TYPE,
+          {
+            TimeToLiveSpecification: { AttributeName: 'expiresAt', Enabled: true },
+          },
+          {}
+        )
+      ).rejects.toThrow(/4-hour rate limit on TTL changes/);
+    });
+
     it('issues a separate UpdateTable for BillingMode flip (PAY_PER_REQUEST -> PROVISIONED with capacity)', async () => {
       mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
       mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // DescribeTable for ARN


### PR DESCRIPTION
## Summary

Closes the 3 deferred nits from PR #410's 1-reviewer code review:

1. **AWS-aware `DeletionProtectionEnabled` diff** (migration silent fix). Pre-PR #410, cdkd was reading top-level DPE which was always `undefined` → no UpdateTable was issued. State recorded the user's template intent (per-replica DPE=true) but AWS-side stayed at `false`. After PR #410 fixed the read path, a no-change redeploy would see `oldDpe=true vs newDpe=true` and skip the update — but AWS still has DPE=false. This PR makes `update()` compare against AWS-observed DPE from the existing DescribeTable response and force UpdateTable when AWS-current diverges from the template intent. Same logic doubles as protection against console-side drift.

2. **TTL rate-limit friendly error wrap**. AWS enforces a ~4-hour rate limit on TimeToLive changes per table. The raw AWS error ("Time to live has been modified multiple times within a fixed interval") is correct but not actionable. `update()`'s `UpdateTimeToLive` call sites now catch this specific message and rewrap with a `ProvisioningError` naming the AWS limit and pointing at the workaround.

3. **`extractLocalDeletionProtection` module-level helper**. `create()` and `update()` previously duplicated the per-replica / top-level fallback closure for DPE extraction. Lifted into one exported function alongside the existing `diffReplicas` / `derivePerCallProvisionedThroughput` helpers. Keeps the two call sites from drifting independently.

## Tests

- 301 files / 3852 tests (was 3848; +4 new)
- 4 new tests cover:
  - AWS-aware DPE forces UpdateTable when state and template agree but AWS diverges (migration regression)
  - No UpdateTable when all three (state, template, AWS) agree
  - Skips re-converge when template doesn't set DPE (no opinion → trust state/AWS)
  - TTL rate-limit error rewrap
- Real-AWS default integ runs clean (no behavior regression on the structural teardown flow).

## Files

- `src/provisioning/providers/dynamodb-globaltable-provider.ts` — AWS-aware DPE diff, TTL error rewrap, `extractLocalDeletionProtection` helper.
- `tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts` — 4 new unit tests.

## Related

- Lineage: PR #384 → #388 → #393 → #397 → #403 → #410 → this. Every deferred item from the `AWS::DynamoDB::GlobalTable` provider series is now resolved AND validated.
- Memory rules applied: `feedback_polish_in_same_pr.md`, `feedback_subagent_invoke_memory_rules.md`.

## Out of scope

- Cross-provider extension of the AWS-aware diff pattern (other per-replica fields across the provider family). Defer to a separate concern.
