### PR TITLE
chore(integ-coverage): PR #404 nit cleanup

### DIFF
--- a/.claude/hooks/provider-integ-gate.sh
+++ b/.claude/hooks/provider-integ-gate.sh
@@ -145,10 +145,26 @@ else
   allowlist_blob=$(git -C "$target_dir" show "HEAD:$ALLOWLIST_FILE" 2>/dev/null || true)
 fi
 
-# Pure-shell JSON-key extraction is fragile; prefer `jq` when available
-# (every dev machine running cdkd already has it, see provider-docs-gate.sh).
-# Fall back to a regex grep that handles the common case.
-if [[ -n "$allowlist_blob" ]] && command -v jq >/dev/null 2>&1; then
+# Parse the allow-list via `jq`. cdkd's hooks require `jq` globally —
+# the input-payload parser at the top of this file already calls
+# `jq -r '.tool_input.command'`, so a no-jq install would silently
+# fail at the input-parsing step (cmd="" → grep miss → exit 0
+# pass-through) and never reach this allow-list parser. Earlier
+# revisions of this hook carried a regex-grep fallback for "jq
+# missing"; removed in the PR #404 cleanup since (a) it was untestable
+# (PATH strip kills input parsing first), (b) it was speculative
+# defense-in-depth with no real failure mode the rest of the hook
+# would notice, and (c) keeping two parsers in sync is its own
+# correctness risk.
+#
+# Rationale validity rule: non-empty string after
+# `gsub("^\\s+|\\s+$"; "")` — whitespace-only does NOT exempt the
+# type. Keys starting with `$` are documentation metadata
+# (`$schema-doc`, `$why-sidecar`) and are skipped. Mirrors the
+# matrix script's `parseAllowNoIntegRationalesContent` in
+# scripts/build-integ-coverage-matrix.ts so the two parsers agree
+# on what counts as allow-listed.
+if [[ -n "$allowlist_blob" ]]; then
   allow_listed=$(printf '%s' "$allowlist_blob" \
     | jq -r 'to_entries
         | map(select(.key | startswith("$") | not))
@@ -156,15 +172,7 @@ if [[ -n "$allowlist_blob" ]] && command -v jq >/dev/null 2>&1; then
         | .[].key' 2>/dev/null \
     | sort -u)
 else
-  # The value-half regex (`"[^"]*[^[:space:]"][^"]*"`) requires the value
-  # to contain at least one non-whitespace non-quote character — matches
-  # the jq path's `gsub("^\\s+|\\s+$"; "") | length > 0` rule so the two
-  # parsers agree on whether a value like "   " (whitespace-only) is a
-  # valid rationale. A naive `"[^"]+"` would accept whitespace-only.
-  allow_listed=$(printf '%s\n' "$allowlist_blob" \
-    | grep -E '^[[:space:]]*"AWS::[A-Za-z0-9]+::[A-Za-z0-9]+"[[:space:]]*:[[:space:]]*"[^"]*[^[:space:]"][^"]*"' \
-    | sed -E 's/^[[:space:]]*"(AWS::[A-Za-z0-9]+::[A-Za-z0-9]+)".*/\1/' \
-    | sort -u)
+  allow_listed=""
 fi
 
 # Read the staged blob of every tests/integration/*/lib/*.ts and

--- a/.claude/hooks/provider-integ-gate.test.sh
+++ b/.claude/hooks/provider-integ-gate.test.sh
@@ -74,7 +74,15 @@ add_register() {
 }
 
 # add_integ_fixture <dir> <fixture-name> <body>
-# body is appended verbatim into lib/<name>-stack.ts.
+#
+# `body` is appended verbatim into `lib/<name>-stack.ts` between the
+# constructor's `super(...)` call and the closing brace. The helper
+# does NOT auto-indent the body — the caller is responsible for the
+# leading whitespace on each line. Multi-line bodies must include the
+# indent on every line (a literal `\n    ` between statements). This
+# is fine for the hook's correctness because the hook does a literal
+# string grep — indent doesn't matter for type detection. Callers
+# that pass a single line don't need to worry.
 add_integ_fixture() {
   local dir="$1" name="$2" body="$3"
   mkdir -p "$dir/tests/integration/$name/lib"
@@ -296,6 +304,45 @@ case_label "sidecar value is whitespace-only -> block"
 D="$TMPDIR/case15"; init_repo "$D"
 add_register "$D" "AWS::Foo::Bar"
 printf '{ "AWS::Foo::Bar": "   " }\n' > "$D/.claude/integ-coverage-allowlist.json"
+stage_all "$D"
+run_hook "$D"; rc=$?
+if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
+
+# --- Case 16: multi-line body in `add_integ_fixture` is preserved ---
+# Documents that callers must include their own indent on each line;
+# the hook's literal-string match still detects the type regardless of
+# indent. Regression guard against future refactors that auto-indent
+# the body — those would change the file content but not the hook's
+# behaviour, so this test asserts the detection path stays robust to
+# the surrounding whitespace.
+case_label "multi-line fixture body -> hook still detects literal type"
+D="$TMPDIR/case16"; init_repo "$D"
+add_register "$D" "AWS::Foo::Bar"
+add_integ_fixture "$D" "foo" "// covers: AWS::Foo::Bar
+new cdk.CfnResource(this, 'X', {
+  type: 'AWS::Foo::Bar',
+  properties: {},
+});"
+stage_all "$D"
+run_hook "$D"; rc=$?
+if [[ $rc -eq 0 ]]; then ok; else ng 0 "$rc"; fi
+
+# --- Case 17: sidecar with object value is rejected (not a string rationale) ---
+# Mirrors the unit-test coverage of `parseAllowNoIntegRationalesContent`
+# but at the hook level. The jq filter requires `.value | type ==
+# "string"`, so an object value like `{"reason": "wrapped"}` must NOT
+# count as a valid rationale. Without the type guard, a careless edit
+# could accidentally exempt a type with no actual rationale string.
+case_label "sidecar with object value -> block (not a valid string rationale)"
+D="$TMPDIR/case17"; init_repo "$D"
+add_register "$D" "AWS::Foo::Bar"
+cat > "$D/.claude/integ-coverage-allowlist.json" <<'EOF'
+{
+  "AWS::Foo::Bar": {
+    "reason": "wrapped object instead of plain string"
+  }
+}
+EOF
 stage_all "$D"
 run_hook "$D"; rc=$?
 if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi

--- a/scripts/build-integ-coverage-matrix.ts
+++ b/scripts/build-integ-coverage-matrix.ts
@@ -777,5 +777,16 @@ function main(): void {
 }
 
 if (isMainModule()) {
-  main();
+  try {
+    main();
+  } catch (err) {
+    // Surface a one-line context message so a missing / unreadable
+    // register-providers.ts or a broken sidecar JSON produces an
+    // actionable error rather than a raw stack trace. Internal tool;
+    // exit 1 is appropriate.
+    process.stderr.write(
+      `integ-coverage: failed — ${(err as Error).message}\n`
+    );
+    process.exit(1);
+  }
 }


### PR DESCRIPTION
## Summary

Small follow-up to PR #404, addressing 4 reviewer nits that were skipped at merge time. Inline-tier per the updated `/review-pr` heuristic (96 LOC, 3 files, no security surface).

- **Matrix script `main()` try/catch** ([scripts/build-integ-coverage-matrix.ts](scripts/build-integ-coverage-matrix.ts)) — bad input (missing `register-providers.ts`, malformed sidecar) now produces a one-line context message via `stderr` + `exit 1`, not a raw stack trace.

- **Hook fallback removed** ([.claude/hooks/provider-integ-gate.sh](.claude/hooks/provider-integ-gate.sh)) — the speculative regex-grep fallback for "jq missing" was dead code: cdkd's hooks all require jq for input-payload parsing (the very first `jq -r '.tool_input.command'` call at the top of the hook), so a no-jq install fails silently at input parsing and the allow-list parser is never reached. Removing the fallback eliminates the two-parsers-in-sync correctness risk. Docstring updated to spell out the jq-required contract.

- **Multi-line fixture body smoke test** ([.claude/hooks/provider-integ-gate.test.sh](.claude/hooks/provider-integ-gate.test.sh)) — regression guard for the heredoc interpolation pattern in `add_integ_fixture`. Future refactors that auto-indent the body would change file content but not hook behaviour; this case asserts the detection path stays robust to surrounding whitespace.

- **Object-value sidecar rejection smoke test** — mirrors the existing unit-test coverage of `parseAllowNoIntegRationalesContent` at the hook level. A `{"AWS::Foo::Bar": {"reason": "..."}}` sidecar (object value, not string) must NOT exempt the type; the jq filter's `.value | type == "string"` guard is now smoke-tested too.

17 smoke tests pass (was 15). Inline docstring on `add_integ_fixture` documents the per-line indent assumption so future contributors know callers own the indent.

## Test plan

- [x] `vp run check` (typecheck + lint + format pass on 178 files)
- [x] `vp run test` (300 files / 3853 tests pass — no test impact from the main() try/catch addition)
- [x] `bash .claude/hooks/provider-integ-gate.test.sh` — 17/17 smoke tests pass
- [x] `vp run integ-coverage` — 99/111 covered, 12 allow-listed, 0 orphans (unchanged from merged PR #404)
