### PR TITLE
fix(dynamodb-globaltable): warn on DPE auto-disable when property removed from CDK code

### DIFF
--- a/src/provisioning/providers/dynamodb-globaltable-provider.ts
+++ b/src/provisioning/providers/dynamodb-globaltable-provider.ts
@@ -728,6 +728,31 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
       const dpeDiffersFromAws =
         newDpe !== undefined && typeof awsDpe === 'boolean' && Boolean(newDpe) !== awsDpe;
       if (dpeDiffersFromState || dpeDiffersFromAws) {
+        // **Auto-disable WARN**: cdkd's diff semantics treat
+        // "absent property in template" as "revert to default", which
+        // matches CFn / CDK CLI parity. For DPE specifically this
+        // means: removing `deletionProtection: true` from CDK code
+        // silently disables protection on AWS. That's a refactoring
+        // footgun (e.g. moving the prop into a config helper but
+        // mistyping the destination, or accidentally deleting the
+        // line during a cleanup). Surface a WARN so the user has
+        // visibility before the next destroy. WARN only — no behavior
+        // change; the user can still proceed if they really mean to
+        // disable protection.
+        const templateExplicitlySetsDpe = newDpe !== undefined;
+        const flippingTrueToFalse =
+          (oldDpe === true || awsDpe === true) && Boolean(newDpe ?? false) === false;
+        if (flippingTrueToFalse && !templateExplicitlySetsDpe) {
+          this.logger.warn(
+            `Auto-disabling DeletionProtectionEnabled on ${physicalId}: ` +
+              `the property was removed from the CDK code. AWS will accept ` +
+              `DeleteTable on this resource after this deploy. ` +
+              `If you meant to keep protection on, restore ` +
+              `'deletionProtection: true' in your CDK code; ` +
+              `if you meant to disable it explicitly, set ` +
+              `'deletionProtection: false' to silence this warning.`
+          );
+        }
         flatUpdate.DeletionProtectionEnabled = Boolean(newDpe ?? false);
         flatChanged = true;
       }

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
@@ -622,6 +622,95 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
       expect(updateCalls).toHaveLength(0);
     });
 
+    it('Auto-disable WARN: surfaces a WARN when DPE flips true→false because the template property was removed', async () => {
+      // Refactoring footgun: user removes `deletionProtection: true`
+      // from CDK code (e.g. moving it into a config helper but
+      // mistyping). cdkd's CFn-parity semantics flip AWS-side DPE
+      // off — which is correct per CDK / CFn behavior but is a
+      // data-loss risk. WARN gives the user visibility before the
+      // next destroy.
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({
+        Table: { TableArn: TABLE_ARN, DeletionProtectionEnabled: true },
+      }); // DescribeTable for ARN + AWS DPE
+      mockSend.mockResolvedValueOnce({}); // UpdateTable (DPE flip off)
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // final describe
+
+      await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        { Replicas: [{ Region: 'us-east-1' }] }, // DPE absent in new
+        { Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: true }] }
+      );
+      // The UpdateTable was still issued (no behavior change).
+      const updateCalls = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter((c) => c instanceof UpdateTableCommand) as UpdateTableCommand[];
+      expect(updateCalls).toHaveLength(1);
+      expect(updateCalls[0]!.input.DeletionProtectionEnabled).toBe(false);
+      // The WARN was emitted naming the table + the recovery hint.
+      const warnMessages = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(warnMessages).toMatch(/Auto-disabling DeletionProtectionEnabled/);
+      expect(warnMessages).toMatch(new RegExp(TABLE_NAME));
+      expect(warnMessages).toMatch(/removed from the CDK code/);
+      expect(warnMessages).toMatch(/restore 'deletionProtection: true'/);
+    });
+
+    it('Auto-disable WARN: NOT emitted when DPE is explicitly set to false (user opted in)', async () => {
+      // The WARN is for the "property removed" case only. An explicit
+      // `deletionProtection: false` is a user-opted-in disable — no
+      // surprise, no need to warn.
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } });
+      mockSend.mockResolvedValueOnce({
+        Table: { TableArn: TABLE_ARN, DeletionProtectionEnabled: true },
+      });
+      mockSend.mockResolvedValueOnce({});
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } });
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } });
+
+      await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        { Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: false }] },
+        { Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: true }] }
+      );
+      const updateCalls = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter((c) => c instanceof UpdateTableCommand) as UpdateTableCommand[];
+      expect(updateCalls).toHaveLength(1);
+      expect(updateCalls[0]!.input.DeletionProtectionEnabled).toBe(false);
+      const warnMessages = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(warnMessages).not.toMatch(/Auto-disabling DeletionProtectionEnabled/);
+    });
+
+    it('Auto-disable WARN: NOT emitted when DPE was never on (no flip from true)', async () => {
+      // Sanity: state DPE=false, template removes the prop (still
+      // undefined → defaults to false). The diff dpeDiffersFromState
+      // fires (false !== undefined) so an UpdateTable IS issued —
+      // but the value is false→false (no actual flip on AWS), so
+      // no WARN should fire because the user never had protection on.
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({
+        Table: { TableArn: TABLE_ARN, DeletionProtectionEnabled: false },
+      }); // DescribeTable for ARN + AWS DPE
+      mockSend.mockResolvedValueOnce({}); // UpdateTable (no-op flip)
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait post-update
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // final describe
+
+      await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        { Replicas: [{ Region: 'us-east-1' }] },
+        { Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: false }] }
+      );
+      const warnMessages = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(warnMessages).not.toMatch(/Auto-disabling DeletionProtectionEnabled/);
+    });
+
     it('TTL rate limit error: rewraps AWS "Time to live has been modified multiple times" with a friendly hint', async () => {
       // AWS enforces a ~4-hour TTL change rate limit per table. The
       // raw error message is correct but not actionable. cdkd


### PR DESCRIPTION
## Summary

Adds a safety-net WARN to `AWS::DynamoDB::GlobalTable`'s `update()` for the case where `DeletionProtectionEnabled` flips `true → false` because the `deletionProtection` property was REMOVED from the CDK code (vs explicitly set to `false`).

## Why

PR #410 review surfaced this as a "pre-existing behavior worth flagging": cdkd's diff semantics treat "absent property in template" as "revert to AWS default", matching CFn / CDK CLI parity. For most fields this is fine. For `deletionProtection` specifically, it's a data-loss footgun:

- User writes `new dynamodb.TableV2(this, 'X', { deletionProtection: true })`.
- Later refactor accidentally drops the prop (e.g., moving it into a config helper but mistyping the destination).
- Next `cdkd deploy` silently flips AWS-side DPE to `false`.
- Subsequent `cdkd destroy` succeeds — protection is gone, table is gone.

No behavior change in this PR — cdkd still applies the CFn-parity diff. The WARN gives the user visibility before the destroy step makes the data loss irreversible. The user can:
- Restore `deletionProtection: true` in CDK code and redeploy (protection back on).
- Set `deletionProtection: false` explicitly to silence the warning (signals intentional disable).

## WARN message

```
WARNING: Auto-disabling DeletionProtectionEnabled on <table>: the property was
removed from the CDK code. AWS will accept DeleteTable on this resource after
this deploy. If you meant to keep protection on, restore 'deletionProtection: true'
in your CDK code; if you meant to disable it explicitly, set
'deletionProtection: false' to silence this warning.
```

## Tests

- 301 files / 3856 tests passing (+3 new):
  - WARN surfaced when DPE flips true→false on property removal.
  - WARN NOT emitted when DPE is explicitly set to `false` (user opted in).
  - WARN NOT emitted when DPE was never on (no flip from true).
- Real-AWS default integ runs clean (no behavior regression on existing structural teardown flow).

## Files

- `src/provisioning/providers/dynamodb-globaltable-provider.ts` — WARN inside the AWS-aware DPE diff branch in `update()`.
- `tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts` — 3 new unit tests.

## Out of scope

- Generalizing the WARN to other safety-sensitive fields (Lambda DLQ removal, S3 enforceSSL removal, etc.). The pattern is incremental — add the WARN to each provider as the safety concern surfaces, rather than a cross-provider sweep.
- Changing cdkd's "absent property = revert to default" semantics. That's a wider design discussion (CFn parity vs no-opinion preservation) that warrants its own RFC.

## Related

- Closes the "pre-existing behavior worth flagging" item from PR #410's 1-reviewer review.
- Lineage: PR #384 → #388 → #393 → #397 → #403 → #410 → #415 → this. With this, every reviewer-flagged item from the `AWS::DynamoDB::GlobalTable` provider series is addressed.
