### PR TITLE
fix(dynamodb-globaltable): neutralize DPE auto-disable WARN wording

### DIFF
--- a/src/provisioning/providers/dynamodb-globaltable-provider.ts
+++ b/src/provisioning/providers/dynamodb-globaltable-provider.ts
@@ -743,11 +743,17 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
         const flippingTrueToFalse =
           (oldDpe === true || awsDpe === true) && Boolean(newDpe ?? false) === false;
         if (flippingTrueToFalse && !templateExplicitlySetsDpe) {
+          // Neutral wording covers both flip directions:
+          //   - state DPE=true, AWS=true, new=undefined (property removed from CDK code)
+          //   - state DPE=false/undefined, AWS=true, new=undefined (console-side enable
+          //     + CDK code never set it)
+          // Both cases reach the same recovery path.
           this.logger.warn(
             `Auto-disabling DeletionProtectionEnabled on ${physicalId}: ` +
-              `the property was removed from the CDK code. AWS will accept ` +
-              `DeleteTable on this resource after this deploy. ` +
-              `If you meant to keep protection on, restore ` +
+              `the CDK code does not set 'deletionProtection: true' but AWS ` +
+              `has it enabled. AWS will accept DeleteTable on this resource ` +
+              `after this deploy. ` +
+              `If you meant to keep protection on, set ` +
               `'deletionProtection: true' in your CDK code; ` +
               `if you meant to disable it explicitly, set ` +
               `'deletionProtection: false' to silence this warning.`

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-roundtrip.test.ts
@@ -654,8 +654,8 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
       const warnMessages = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
       expect(warnMessages).toMatch(/Auto-disabling DeletionProtectionEnabled/);
       expect(warnMessages).toMatch(new RegExp(TABLE_NAME));
-      expect(warnMessages).toMatch(/removed from the CDK code/);
-      expect(warnMessages).toMatch(/restore 'deletionProtection: true'/);
+      expect(warnMessages).toMatch(/CDK code does not set 'deletionProtection: true'/);
+      expect(warnMessages).toMatch(/set 'deletionProtection: true' in your CDK code/);
     });
 
     it('Auto-disable WARN: NOT emitted when DPE is explicitly set to false (user opted in)', async () => {
@@ -684,6 +684,39 @@ describe('DynamoDBGlobalTableProvider round-trip', () => {
       expect(updateCalls[0]!.input.DeletionProtectionEnabled).toBe(false);
       const warnMessages = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
       expect(warnMessages).not.toMatch(/Auto-disabling DeletionProtectionEnabled/);
+    });
+
+    it('Auto-disable WARN: ALSO fires when state DPE=false but AWS console-enabled (drift recovery flip)', async () => {
+      // Edge case: at a past deploy state recorded DPE=false (explicit
+      // or AWS-default). An admin then enabled DeletionProtection via
+      // the AWS console. Template still omits DPE. The diff-from-state
+      // (false !== undefined) drives entry into the diff branch; the
+      // flip predicate fires because awsDpe===true. The neutral wording
+      // covers this case — "removed from CDK code" would be misleading
+      // (it was false, not true, in state).
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({
+        Table: { TableArn: TABLE_ARN, DeletionProtectionEnabled: true },
+      }); // AWS-current is true (console enabled)
+      mockSend.mockResolvedValueOnce({}); // UpdateTable (DPE flip off)
+      mockSend.mockResolvedValueOnce({ Table: { TableStatus: 'ACTIVE' } }); // wait
+      mockSend.mockResolvedValueOnce({ Table: { TableArn: TABLE_ARN } }); // final describe
+
+      await provider.update(
+        'X',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        { Replicas: [{ Region: 'us-east-1' }] }, // no DPE in new
+        { Replicas: [{ Region: 'us-east-1', DeletionProtectionEnabled: false }] } // state=false
+      );
+      const updateCalls = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter((c) => c instanceof UpdateTableCommand) as UpdateTableCommand[];
+      expect(updateCalls).toHaveLength(1);
+      expect(updateCalls[0]!.input.DeletionProtectionEnabled).toBe(false);
+      const warnMessages = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(warnMessages).toMatch(/Auto-disabling DeletionProtectionEnabled/);
+      expect(warnMessages).toMatch(/CDK code does not set 'deletionProtection: true'/);
     });
 
     it('Auto-disable WARN: NOT emitted when DPE was never on (no flip from true)', async () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #418's reviewer nit. PR #418 added the DPE auto-disable WARN with the message `"the property was removed from the CDK code"`. The reviewer correctly noted that this wording covers only the canonical case and is slightly misleading in a real edge case.

## The actual WARN trigger

The WARN gate is `dpeDiffersFromState || dpeDiffersFromAws`, then the inner predicate `(oldDpe === true || awsDpe === true) && new is false-equivalent && template doesn't explicitly set DPE`.

Two cases reach the WARN:

| state DPE | AWS DPE | template DPE | Pre-PR wording fit |
|-----------|---------|--------------|---------------------|
| `true`    | `true`  | absent       | ✅ "removed from CDK code" — accurate |
| `false`   | `true`  | absent       | ⚠️ "removed from CDK code" — misleading: the property was `false` in state, not `true`; admin enabled it via console between deploys |

The second case is real — drift recovery where an admin enables protection via the AWS console after cdkd recorded `DPE: false` (explicit or AWS-default). Template omits DPE on the next deploy → diff-from-state fires → flip predicate fires (awsDpe===true).

## The fix

Reword to `"the CDK code does not set 'deletionProtection: true' but AWS has it enabled"` — accurate in both cases. Recovery hint changes from `"restore 'deletionProtection: true'"` to `"set 'deletionProtection: true'"` so it reads naturally whether the property was ever there.

## Tests

- 301 files / 3858 tests passing (+1 new):
  - The pre-PR-#418 3 tests still pass (regex updated to match new wording).
  - New test: Case C drift recovery (state DPE=false, AWS console-enabled, template absent) — locks in that the WARN fires AND the new wording matches.
- Real-AWS integ unaffected — no behavior change in this PR.

## Out of scope

- The WARN trigger gate, the UpdateTable side effect, and the silence path (`deletionProtection: false`) are unchanged. This is purely a log-message fix.

## Related

- Closes the deferred Nit from PR #418's 1-reviewer review.
- Lineage: PR #384 → #388 → #393 → #397 → #403 → #410 → #415 → #418 → this.
