### PR TITLE
ci: fail when provider-coverage tier1 cache drifts from register-providers.ts (closes #398)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,17 @@ jobs:
             exit 1
           fi
 
+      # Issue #398 — fail CI when the cached three-tier provider-coverage
+      # audit (docs/_generated/provider-coverage.json) Tier 1 list drifts
+      # from src/provisioning/register-providers.ts. Offline check (<1s,
+      # no AWS calls — the full regeneration via
+      # `vp run audit:coverage:regenerate` would take 10-30 min + AWS
+      # CFn DescribeType throttling and stays a manual / future-cron job
+      # per issue #398 Option A). Catches the "added a new provider but
+      # forgot to regen the audit cache" case structurally, mirroring
+      # the integ-coverage step above.
+      - run: vp run audit:coverage:check
+
   runtime-compat:
     runs-on: ubuntu-latest
     needs: check-build-test


### PR DESCRIPTION
## Summary

Closes go-to-k/cdkd#398 by picking the lightest option from the issue's three-option menu (CI cron / commit hook / Claude skill): wire `vp run audit:coverage:check` into the existing `check-build-test` CI job.

- **What it does**: the `--check` mode of `scripts/audit-provider-coverage.ts` (added by PR #401 / closed go-to-k/cdkd#390) compares the cached `docs/_generated/provider-coverage.json` Tier 1 list against the current `src/provisioning/register-providers.ts`. Exits 1 on drift.
- **Offline**: no AWS calls, no GitHub secrets, no IAM role setup needed. Runs in <1s alongside the existing typecheck / lint / test / build / integ-coverage steps.
- **What it catches**: contributor adds a new SDK provider but forgets to regen the audit cache. CI now fails with a clear error pointing at `vp run audit:coverage:regenerate` (the heavy 10-30 min AWS-bound regen) as the recovery command.

Mirrors the integ-coverage CI step shipped by go-to-k/cdkd#419 (issue go-to-k/cdkd#399) — same shape, different artifact.

## Out of scope

The full regeneration (`vp run audit:coverage:regenerate` — walks ~1500 public CFn types via `CloudFormation:ListTypes` + `DescribeType`, 10-30 min, AWS-throttled, requires CFn read creds) is intentionally NOT added here. That's go-to-k/cdkd#398 Option A's "weekly cron" territory — a separate concern with very different setup requirements (CI-scoped IAM role, scheduled workflow, auto-PR opening for cache updates). This PR ships only the cheap half that fits PR-time CI.

## Test plan

- [x] `vp run check` (178 files pass)
- [x] `vp run audit:coverage:check` against current main — exits 0 ("Cached Tier 1 (111 types) matches register-providers.ts (111 types).")
- [x] Inline spot-check: 11 LOC, single CI step, no logic
- [x] CI itself exercises the new step on this PR — first real-world validation
