### PR TITLE
chore(scripts): backport defensive listFixtures to sibling coverage scripts

### DIFF
--- a/scripts/build-cli-flag-coverage-matrix.ts
+++ b/scripts/build-cli-flag-coverage-matrix.ts
@@ -136,12 +136,19 @@ export function parseDeclaredFlags(content: string): string[] {
   return Array.from(longs).sort();
 }
 
-function listFixtures(): string[] {
-  if (!existsSync(INTEG_DIR)) return [];
-  return readdirSync(INTEG_DIR)
+export function listFixtures(integDir: string = INTEG_DIR): string[] {
+  if (!existsSync(integDir)) return [];
+  return readdirSync(integDir)
     .filter((name) => {
-      const p = join(INTEG_DIR, name);
-      return statSync(p).isDirectory();
+      // Ignore hidden directories (e.g. `.scratch/`, IDE folders); the
+      // matrix is scoped to real integ fixtures only.
+      if (name.startsWith('.')) return false;
+      const full = join(integDir, name);
+      try {
+        return statSync(full).isDirectory();
+      } catch {
+        return false;
+      }
     })
     .sort();
 }

--- a/scripts/build-integ-coverage-matrix.ts
+++ b/scripts/build-integ-coverage-matrix.ts
@@ -449,12 +449,19 @@ export function parseAllowNoIntegRationales(): Map<string, string> {
   return parseAllowNoIntegRationalesContent(content);
 }
 
-function listFixtures(): string[] {
-  if (!existsSync(INTEG_DIR)) return [];
-  return readdirSync(INTEG_DIR)
+export function listFixtures(integDir: string = INTEG_DIR): string[] {
+  if (!existsSync(integDir)) return [];
+  return readdirSync(integDir)
     .filter((name) => {
-      const p = join(INTEG_DIR, name);
-      return statSync(p).isDirectory();
+      // Ignore hidden directories (e.g. `.scratch/`, IDE folders); the
+      // matrix is scoped to real integ fixtures only.
+      if (name.startsWith('.')) return false;
+      const full = join(integDir, name);
+      try {
+        return statSync(full).isDirectory();
+      } catch {
+        return false;
+      }
     })
     .sort();
 }

--- a/tests/unit/scripts/build-cli-flag-coverage-matrix.test.ts
+++ b/tests/unit/scripts/build-cli-flag-coverage-matrix.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect } from 'vite-plus/test';
+import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   parseFlagSpec,
   parseOptionSpecsFromSource,
   parseDeclaredFlags,
   scanFlagsInShellScript,
+  listFixtures,
 } from '../../../scripts/build-cli-flag-coverage-matrix.js';
 
 describe('parseFlagSpec', () => {
@@ -158,5 +162,33 @@ describe('scanFlagsInShellScript', () => {
     const result = scanFlagsInShellScript(sh);
     expect(result.size).toBe(1);
     expect(result.has('--stack')).toBe(true);
+  });
+});
+
+describe('listFixtures', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cli-flag-cov-list-'));
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns an empty list when the directory does not exist', () => {
+    expect(listFixtures(join(tmpRoot, 'nope'))).toEqual([]);
+  });
+
+  it('lists immediate-child directories only, sorted', () => {
+    mkdirSync(join(tmpRoot, 'b-fixture'));
+    mkdirSync(join(tmpRoot, 'a-fixture'));
+    writeFileSync(join(tmpRoot, 'not-a-dir.txt'), '');
+    expect(listFixtures(tmpRoot)).toEqual(['a-fixture', 'b-fixture']);
+  });
+
+  it('skips hidden directories (`.foo/`, `.scratch/`)', () => {
+    mkdirSync(join(tmpRoot, 'a-fixture'));
+    mkdirSync(join(tmpRoot, '.hidden'));
+    mkdirSync(join(tmpRoot, '.scratch'));
+    expect(listFixtures(tmpRoot)).toEqual(['a-fixture']);
   });
 });

--- a/tests/unit/scripts/build-integ-coverage-matrix.test.ts
+++ b/tests/unit/scripts/build-integ-coverage-matrix.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vite-plus/test';
+import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   parseRegisteredTypes,
   parseAllowNoIntegRationalesContent,
@@ -6,6 +9,7 @@ import {
   scanL1Types,
   scanL2Types,
   scanLiteralTypes,
+  listFixtures,
 } from '../../../scripts/build-integ-coverage-matrix.js';
 
 describe('parseRegisteredTypes', () => {
@@ -298,5 +302,33 @@ describe('scanLiteralTypes', () => {
     const result = scanLiteralTypes(src);
     expect(result.size).toBe(1);
     expect(result.get('AWS::S3::Bucket')).toBe('literal');
+  });
+});
+
+describe('listFixtures', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'integ-cov-list-'));
+  });
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns an empty list when the directory does not exist', () => {
+    expect(listFixtures(join(tmpRoot, 'nope'))).toEqual([]);
+  });
+
+  it('lists immediate-child directories only, sorted', () => {
+    mkdirSync(join(tmpRoot, 'b-fixture'));
+    mkdirSync(join(tmpRoot, 'a-fixture'));
+    writeFileSync(join(tmpRoot, 'not-a-dir.txt'), '');
+    expect(listFixtures(tmpRoot)).toEqual(['a-fixture', 'b-fixture']);
+  });
+
+  it('skips hidden directories (`.foo/`, `.scratch/`)', () => {
+    mkdirSync(join(tmpRoot, 'a-fixture'));
+    mkdirSync(join(tmpRoot, '.hidden'));
+    mkdirSync(join(tmpRoot, '.scratch'));
+    expect(listFixtures(tmpRoot)).toEqual(['a-fixture']);
   });
 });


### PR DESCRIPTION
## Summary

- Backport `scripts/build-scenario-coverage-matrix.ts`'s defensive `listFixtures` (hidden-dir filter + `statSync` try/catch) to the two sibling coverage scripts (`build-integ-coverage-matrix.ts` + `build-cli-flag-coverage-matrix.ts`) so all three are structurally consistent.
- Export `listFixtures(integDir = INTEG_DIR)` from both siblings so the behavior is unit-testable.
- Add 3 new unit tests per sibling (no-dir / immediate-dirs-sorted / hidden-skipped), mirroring the scenario-coverage test block.

## Why preemptive hygiene (zero current impact)

`ls -la tests/integration/` has no hidden directories today, so regenerating either matrix produces NO diff to the `docs/` output. The fix protects against a future `.scratch/` / `.cache/` / IDE-folder showing up under `tests/integration/` that would otherwise:

- crash the unguarded `statSync(...).isDirectory()` call (current shape throws on broken symlinks / missing files);
- false-add the hidden directory to the fixture set (the matrix would silently include `.scratch` rows).

PR #425 (Phase 2B / scenario coverage) hit the same edge case during sub-agent review and shipped the defensive shape there. This PR closes the consistency gap left when the original PR #404 (Phase 1 / integ-coverage) and PR #419-ish (Phase 2A / cli-flag-coverage) shipped before the pattern was standardized.

## Test plan

- [x] `vp run test` — 303 files / 3914 tests pass (6 new tests added across the two sibling test files).
- [x] `vp run integ-coverage` + `vp run cli-flag-coverage` regenerated; no diff in `docs/_generated/` or `docs/integ-coverage.md` / `docs/cli-flag-coverage.md`.
- [x] `vp check --fix` clean (typecheck + lint + format).
- [x] `vp run build` clean.
- [x] Manual code review confirms the three scripts now share the same `listFixtures` shape.
