### PR TITLE
chore(hooks): broaden integ-coverage-matrix-gate matcher to catch `git -C` form (closes #433)

### DIFF
--- a/.claude/hooks/integ-coverage-matrix-gate.sh
+++ b/.claude/hooks/integ-coverage-matrix-gate.sh
@@ -42,6 +42,14 @@ input=$(cat 2>/dev/null || true)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
+# Optional entry log. Surface that the hook was invoked AT ALL via the
+# Claude Code harness; helps debug matcher-level bypasses (issue #433)
+# where the `if:` predicate in settings.json fails to fire for a form
+# the hook script itself would handle correctly. Off by default.
+if [[ -n "${CDKD_HOOK_DEBUG:-}" ]]; then
+  echo "[debug] integ-coverage-matrix-gate: entered (cmd=$cmd, cwd=$hook_cwd)" >&2
+fi
+
 # Only gate git commit — anything else passes through.
 if ! printf '%s' "$cmd" | grep -qE '\bgit[^|;&]*\bcommit\b'; then
   exit 0

--- a/.claude/hooks/integ-coverage-matrix-gate.test.sh
+++ b/.claude/hooks/integ-coverage-matrix-gate.test.sh
@@ -290,6 +290,60 @@ stage_all "$D"
 run_hook "$D"; rc=$?
 if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
 
+# --- Case 13: PR #432 bypass form (`git -C <abs> commit -F /tmp/file`) -> blocks ---
+# Pre-issue-#433 the hook script handled this form correctly when invoked
+# directly (the inner `git[^|;&]*commit` regex matches `git -C /abs commit`),
+# but the `if:` matcher in .claude/settings.json was `Bash(git commit*)`
+# which does NOT match commands starting with `git -C <path> commit ...`
+# — so the harness never invoked the hook for PR #432's first commit.
+# This test pins the hook-script behavior for the bypass form so that
+# even if the matcher is broadened (the actual fix), a regression in the
+# hook script itself still surfaces here.
+case_label "PR #432 bypass form (git -C <abs> commit -F /tmp/msg) -> blocks"
+D="$TMPDIR/case13"; init_repo "$D"
+mkdir -p "$D/tests/integration/foo/lib"
+cat > "$D/tests/integration/foo/lib/foo-stack.ts" <<'EOF'
+import * as cdk from 'aws-cdk-lib';
+export class FooStack extends cdk.Stack {}
+EOF
+stage_all "$D"
+echo "test msg" > "$TMPDIR/msg-case13"
+run_hook "$D" "git -C $D commit -F $TMPDIR/msg-case13"; rc=$?
+if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
+
+# --- Case 14: chained `git -C add ; git -C commit` form -> blocks ---
+# The other half of the PR #432 hypothesis: harness-issued chains of
+# `git -C <abs> add <files>; git -C <abs> commit -F /tmp/msg` need to
+# block when the staged set drifts the matrix.
+case_label "chained 'git -C add; git -C commit -F' form -> blocks"
+D="$TMPDIR/case14"; init_repo "$D"
+mkdir -p "$D/tests/integration/foo/lib"
+cat > "$D/tests/integration/foo/lib/foo-stack.ts" <<'EOF'
+import * as cdk from 'aws-cdk-lib';
+export class FooStack extends cdk.Stack {}
+EOF
+stage_all "$D"
+echo "test msg" > "$TMPDIR/msg-case14"
+chained="git -C $D add tests/integration/foo/lib/foo-stack.ts; git -C $D commit -F $TMPDIR/msg-case14"
+run_hook "$D" "$chained"; rc=$?
+if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
+
+# --- Case 15: CDKD_HOOK_DEBUG=1 surfaces an entry log line ---
+# Issue #433 acceptance criteria (optional): a [debug] log line at hook
+# entry so future bypasses surface visibly.
+case_label "CDKD_HOOK_DEBUG=1 surfaces entry log"
+D="$TMPDIR/case15"; init_repo "$D"
+mkdir -p "$D/tests/integration/foo/lib"
+echo 'export class FooStack {}' > "$D/tests/integration/foo/lib/foo-stack.ts"
+stage_all "$D"
+payload=$(printf '{"tool_input":{"command":"git -C %s commit -m test"},"cwd":"%s"}' "$D" "$D")
+stderr_out=$(CDKD_HOOK_DEBUG=1 printf '%s' "$payload" | CDKD_HOOK_DEBUG=1 bash "$HOOK" 2>&1 >/dev/null)
+if printf '%s' "$stderr_out" | grep -q '\[debug\] integ-coverage-matrix-gate: entered'; then
+  ok
+else
+  ng_msg "expected debug entry log; got: $stderr_out"
+fi
+
 echo
 echo "integ-coverage-matrix-gate.test.sh: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -112,7 +112,7 @@
           {
             "type": "command",
             "command": ".claude/hooks/integ-coverage-matrix-gate.sh",
-            "if": "Bash(git commit*)",
+            "if": "Bash(git commit*) or Bash(git -C * commit*)",
             "timeout": 15,
             "statusMessage": "Checking integ-coverage matrix is in sync..."
           },


### PR DESCRIPTION
## Summary

- Fixes a matcher-level bypass in `.claude/hooks/integ-coverage-matrix-gate.sh` that silently allowed PR #432's first commit through.
- Broadens the `if:` predicate to also match the `git -C <abs-path> commit ...` form (used by sub-agents under worktree isolation and any harness call that targets an absolute path).
- Adds three new smoke tests pinning the hook-script behavior on the exact bypass form + an optional `CDKD_HOOK_DEBUG=1` entry log line so future bypasses surface visibly.

## Root cause (issue #433)

PR #432's `af46bfe` staged `tests/integration/local-start-api/lib/local-start-api-stack.ts` (a new `apigw.RequestAuthorizer` L2 raising `AWS::ApiGateway::Authorizer` coverage from "covered by `api-cognito` (L1)" to "covered by `api-cognito` (L1) + `local-start-api` (L2)"). Regenerating the matrix at that sha produces a diff against the committed `docs/integ-coverage.md` + `docs/_generated/integ-coverage.json`. The hook should have fired.

Empirically: invoking the hook script directly with the exact `tool_input.command = "git -C /Users/... commit -F /tmp/msg"` payload **blocks** (exit 2, matrix-stale message). So the inner logic is fine.

The bypass is at the Claude Code matcher predicate `Bash(git commit*)`. The glob requires the substring `git commit`. In `git -C /Users/... commit -F /tmp/msg`, `-C <path>` sits between `git` and `commit`, so the substring isn't present and the matcher never fires — the harness skips the hook entirely.

## Fix

- `.claude/settings.json` — matcher now `Bash(git commit*) or Bash(git -C * commit*)`. Both forms invoke the hook; the hook's existing `cd <path>` / last-`git -C <path>` parsing handles the inner routing correctly.
- `.claude/hooks/integ-coverage-matrix-gate.sh` — optional `[debug]` entry log gated on `CDKD_HOOK_DEBUG=1`. Off by default; one-shot `CDKD_HOOK_DEBUG=1 …` lets a future bypass surface the "did the hook even run?" question visibly.
- `.claude/hooks/integ-coverage-matrix-gate.test.sh` — three new cases (15 total, was 12):
  - PR #432 bypass form: `git -C <abs> commit -F /tmp/msg` blocks.
  - Chained: `git -C <abs> add ...; git -C <abs> commit -F /tmp/msg` blocks.
  - `CDKD_HOOK_DEBUG=1` surfaces a `[debug] integ-coverage-matrix-gate: entered ...` line on stderr.

## Out of scope (follow-up)

Nine other hooks share the `"if": "Bash(git commit*)"` matcher and therefore the same latent `git -C <path>` bypass:

- `branch-gate.sh`
- `check-gate.sh`
- `commit-msg-heredoc-gate.sh`
- `commit-prefix-scope-gate.sh`
- `provider-docs-gate.sh`
- `provider-integ-gate.sh`
- `roundtrip-test-gate.sh`
- `internal-pr-labels-gate.sh`
- `cmd-parse-stub-gate.sh`

Their hook scripts all parse `git -C <path>` correctly. Suggest filing a follow-up issue to broaden their matchers in one mechanical pass. Out of scope for this PR — issue #433 is specifically about the integ-coverage-matrix-gate.

## Test plan

- [x] `bash .claude/hooks/integ-coverage-matrix-gate.test.sh` — 15/15 pass.
- [x] Reproduction case from the issue body: `git -C <abs> commit -F /tmp/msg` against a fixture repo with a scope-touching staged file blocks with the matrix-stale message at exit 2.
- [x] Hook script's inner `git[^|;&]*commit` regex confirmed to handle the bypass form (case 13 + 14).
- [x] Debug entry log surfaces only when `CDKD_HOOK_DEBUG=1` is set (case 15).
- [ ] (follow-up) Audit + broaden the other nine hooks listed above.
