### PR TITLE
chore(hooks): broaden `git -C <path>` matcher coverage across remaining gates (follow-up to #434)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,21 +7,21 @@
           {
             "type": "command",
             "command": ".claude/hooks/branch-gate.sh",
-            "if": "Bash(git commit*) or Bash(git push*)",
+            "if": "Bash(git commit*) or Bash(git push*) or Bash(git -C * commit*) or Bash(git -C * push*)",
             "timeout": 10,
             "statusMessage": "Checking current branch..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/post-merge-orphan-push-gate.sh",
-            "if": "Bash(git push*)",
+            "if": "Bash(git push*) or Bash(git -C * push*)",
             "timeout": 10,
             "statusMessage": "Checking for already-merged PR on this branch..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/check-gate.sh",
-            "if": "Bash(git commit*)",
+            "if": "Bash(git commit*) or Bash(git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking /check marker..."
           },
@@ -35,7 +35,7 @@
           {
             "type": "command",
             "command": ".claude/hooks/integ-local-gate.sh",
-            "if": "Bash(gh pr merge*) or Bash(git merge*)",
+            "if": "Bash(gh pr merge*) or Bash(git merge*) or Bash(git -C * merge*)",
             "timeout": 10,
             "statusMessage": "Checking integ-local marker..."
           },
@@ -63,7 +63,7 @@
           {
             "type": "command",
             "command": ".claude/hooks/commit-msg-heredoc-gate.sh",
-            "if": "Bash(git commit*)",
+            "if": "Bash(git commit*) or Bash(git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking commit message format..."
           },
@@ -91,21 +91,21 @@
           {
             "type": "command",
             "command": ".claude/hooks/roundtrip-test-gate.sh",
-            "if": "Bash(git commit*)",
+            "if": "Bash(git commit*) or Bash(git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking new SDK provider has round-trip test..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/provider-docs-gate.sh",
-            "if": "Bash(git commit*)",
+            "if": "Bash(git commit*) or Bash(git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking new provider registration has docs entries..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/provider-integ-gate.sh",
-            "if": "Bash(git commit*)",
+            "if": "Bash(git commit*) or Bash(git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking new provider registration has integ coverage..."
           },
@@ -119,21 +119,21 @@
           {
             "type": "command",
             "command": ".claude/hooks/internal-pr-labels-gate.sh",
-            "if": "Bash(git commit*)",
+            "if": "Bash(git commit*) or Bash(git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking user-facing docs for internal PR labels..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/cmd-parse-stub-gate.sh",
-            "if": "Bash(git commit*)",
+            "if": "Bash(git commit*) or Bash(git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking test files for cmd.parse without action stub..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/commit-prefix-scope-gate.sh",
-            "if": "Bash(git commit*)",
+            "if": "Bash(git commit*) or Bash(git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking commit prefix matches user-visible scope..."
           }


### PR DESCRIPTION
## Summary

- Follow-up to PR #434 (issue #433).
- PR #434 fixed the `Bash(git commit*)` matcher on **one** hook (`integ-coverage-matrix-gate.sh`). Nine other PreToolUse hooks share the same matcher pattern and the same latent `git -C <abs-path> commit` bypass. This PR closes the class.

## Why

Claude Code's `Bash(<glob>)` predicate matches the substring (`git commit`, `git push`, `git merge`) **literally** in the command string. A harness-issued call shaped `git -C /Users/... commit -F /tmp/msg` (used by sub-agents under `isolation: worktree` and by parent calls with absolute paths) places `-C <path>` between `git` and `commit` so the substring is not present — the matcher never fires and the hook script never runs, even though the hook's inner `git[^|;&]*commit` parser would handle the form correctly if invoked.

## Changes

Single file, `.claude/settings.json`. Ten `if:` predicates broadened:

| Hook | Before | After |
| --- | --- | --- |
| `branch-gate.sh` | `Bash(git commit*) or Bash(git push*)` | adds `or Bash(git -C * commit*) or Bash(git -C * push*)` |
| `post-merge-orphan-push-gate.sh` | `Bash(git push*)` | adds `or Bash(git -C * push*)` |
| `check-gate.sh` | `Bash(git commit*)` | adds `or Bash(git -C * commit*)` |
| `commit-msg-heredoc-gate.sh` | `Bash(git commit*)` | adds `or Bash(git -C * commit*)` |
| `roundtrip-test-gate.sh` | `Bash(git commit*)` | adds `or Bash(git -C * commit*)` |
| `provider-docs-gate.sh` | `Bash(git commit*)` | adds `or Bash(git -C * commit*)` |
| `provider-integ-gate.sh` | `Bash(git commit*)` | adds `or Bash(git -C * commit*)` |
| `internal-pr-labels-gate.sh` | `Bash(git commit*)` | adds `or Bash(git -C * commit*)` |
| `cmd-parse-stub-gate.sh` | `Bash(git commit*)` | adds `or Bash(git -C * commit*)` |
| `commit-prefix-scope-gate.sh` | `Bash(git commit*)` | adds `or Bash(git -C * commit*)` |
| `integ-local-gate.sh` | `Bash(gh pr merge*) or Bash(git merge*)` | adds `or Bash(git -C * merge*)` |

## Out of scope (intentional)

- **`gh` family matchers** (`integ-destroy-gate`, `integ-broad-gate`, `pr-review-gate`, `verify-pr-gate`, `gh-pr-edit-deprecation-gate`, `pr-body-item-number-gate`): `gh` has no `-C <path>` flag — nothing to broaden.
- **`gh-label-validity-gate`**: already uses leading-wildcard patterns (`Bash(*--label*)`).
- **Hook scripts themselves**: every script already parses `git -C <path>` correctly (mirrors `branch-gate.sh`'s pattern). Only the matcher predicates needed widening; no `.sh` changes.

## Test plan

- [x] `python3 -c 'import json; json.load(open(".claude/settings.json"))'` — JSON valid.
- [x] `bash .claude/hooks/*.test.sh` — 13/14 green. The one outlier (`integ-broad-gate.test.sh` case "no-number, current branch touches cross-cutting") fails because it depends on the local `integ-broad` markgate marker being stale (currently fresh on the working checkout, `state: match (expires in 11d12h)`). Passes on a fresh clone with no markgate state. **Pre-existing test design issue**, `git diff main` confirms zero changes to `integ-broad-gate.sh` and its test.
- [x] `git diff main -- .claude/hooks/` is empty — only `settings.json` changed.
- [x] Manual smoke: invoking the affected hooks directly with the `git -C <abs-path> commit ...` payload returns the expected exit code (this is the existing PR #434 path; verified there).
