### PR TITLE
test(hooks): isolate integ-broad-gate.test.sh from local markgate state

### DIFF
--- a/.claude/hooks/integ-broad-gate.test.sh
+++ b/.claude/hooks/integ-broad-gate.test.sh
@@ -35,7 +35,62 @@ fi
 cat "$GH_MOCK_PAYLOAD"
 EOF
 chmod +x "$GH_BIN_DIR/gh"
+
+# Mock `mise` and `markgate`: isolates the test from the local
+# repo's markgate state. Pre-PR (the design comment at the original
+# L93-98 noted "marker is currently no-marker on this branch") the
+# test relied on the user not having flipped `integ-broad` fresh —
+# but on a working checkout immediately after a successful
+# /run-integ bench-cdk-sample, the marker IS fresh and every "block"
+# case above silently returned exit 0 instead of 2. The mock here
+# pins markgate's verdict to whatever $MARKGATE_MOCK_VERDICT says
+# (default "stale" — what the block cases assume), so the test runs
+# the same on a fresh clone, in CI, and on a developer's checkout
+# with an arbitrary local marker state.
+#
+# The hook's `command -v mise` check picks up THIS mock first; the
+# pass-through form (`mise exec -- markgate <args>`) then routes to
+# the mocked `markgate` below — same code path the hook hits in
+# production when `mise` is installed.
+cat > "$GH_BIN_DIR/mise" <<'MISE_EOF'
+#!/usr/bin/env bash
+# Mock mise: pass-through for `mise exec -- <cmd> <args>`. Any other
+# subcommand exits 1 (the hook only uses `mise exec --`).
+if [ "$1" = "exec" ] && [ "$2" = "--" ]; then
+  shift 2
+  exec "$@"
+fi
+exit 1
+MISE_EOF
+chmod +x "$GH_BIN_DIR/mise"
+
+cat > "$GH_BIN_DIR/markgate" <<'MARKGATE_EOF'
+#!/usr/bin/env bash
+# Mock markgate: verdict pinned by $MARKGATE_MOCK_VERDICT
+# ("fresh" -> verify exits 0; anything else -> verify exits 1 and
+# status prints a parseable stale line). The hook's awk extractor
+# pulls "(reason)" out of `state:` for the error message.
+verdict="${MARKGATE_MOCK_VERDICT:-stale}"
+case "$1" in
+  verify)
+    [ "$verdict" = "fresh" ] && exit 0
+    exit 1
+    ;;
+  status)
+    if [ "$verdict" = "fresh" ]; then
+      printf 'key:        %s\nstate:      match\n' "$2"
+    else
+      printf 'key:        %s\nstate:      stale (marker missing)\n' "$2"
+    fi
+    exit 0
+    ;;
+esac
+exit 1
+MARKGATE_EOF
+chmod +x "$GH_BIN_DIR/markgate"
+
 export PATH="$GH_BIN_DIR:$PATH"
+export MARKGATE_MOCK_VERDICT="stale"
 
 pass=0
 fail=0
@@ -127,6 +182,14 @@ run_case "block: gh pr merge no-number, current branch touches cross-cutting" 2 
 
 run_case "pass: gh failure during PR files lookup (fail-open)" 0 \
   '{"tool_input":{"command":"gh pr merge 800"},"cwd":"."}' ""
+
+# --- Fresh marker path: cross-cutting diff + fresh integ-broad marker -> pass ---
+# Mirrors the just-after-/run-integ-bench-cdk-sample state. Pre-this-PR
+# the test never exercised this branch (marker was assumed missing on
+# CI / fresh clones); the mock above lets us pin it explicitly.
+MARKGATE_MOCK_VERDICT="fresh" run_case "pass: cross-cutting diff + fresh integ-broad marker" 0 \
+  '{"tool_input":{"command":"gh pr merge 900 --squash"},"cwd":"."}' \
+  '{"files":[{"path":"src/deployment/deploy-engine.ts"}]}'
 
 # ---- Summary ----
 


### PR DESCRIPTION
## Summary

- Fixes the `integ-broad-gate.test.sh` flake that surfaced during PR #435's smoke-test sweep.
- Stubs `mise` + `markgate` on the test's `$PATH` so the test no longer reads the developer's local `integ-broad` marker state.
- Adds a previously-missing positive case covering the "marker is fresh -> allow merge" branch.

## Root cause

Pre-PR the test relied on `markgate verify integ-broad` returning non-zero (= stale) at the moment the test ran. The design comment in the original `block:` block (around the original L93-98) acknowledged this:

> Marker is currently no-marker on this branch ... in CI / fresh-clone topology, no marker is the default.

That assumption breaks on a working checkout immediately after a successful `/run-integ bench-cdk-sample` — the `integ-broad` marker is fresh (`state: match (expires in ~14d)`) and every `block:` case silently returns exit 0 instead of 2, producing 6 spurious FAILs. The test passed on fresh clones but failed locally on a real-AWS-tested developer machine, which is the worst possible failure mode for a hook smoke test (silently wrong where you'd most want correctness).

## Fix

Same mocking pattern the test already uses for `gh` — extends it to `mise` and `markgate`:

- **`mise` mock**: pass-through for `mise exec -- <cmd> <args>` (the only form the production hook uses). Any other subcommand exits 1.
- **`markgate` mock**: verdict pinned by `$MARKGATE_MOCK_VERDICT`. Default `"stale"` → `verify` exits 1 + `status` prints a parseable `state: stale (marker missing)` line for the hook's awk extractor. Setting it to `"fresh"` (via a one-line env-var prefix on the new case) inverts the verdict.

The `mise` mock comes first on `$PATH` so the hook's `command -v mise` check picks it up, then the pass-through routes the `markgate` call to the mocked binary — same production code path the hook hits when `mise` is installed.

## New case (14, previously uncovered)

```bash
MARKGATE_MOCK_VERDICT="fresh" run_case "pass: cross-cutting diff + fresh integ-broad marker" 0 \
  '{"tool_input":{"command":"gh pr merge 900 --squash"},"cwd":"."}' \
  '{"files":[{"path":"src/deployment/deploy-engine.ts"}]}'
```

Asserts the gate returns exit 0 when the marker is fresh AND the PR touches cross-cutting code — the canonical post-`/run-integ` state. Pre-this-PR this branch was structurally invisible to the smoke test.

## Test plan

- [x] On a checkout with `mise exec -- markgate status integ-broad` reporting `state: match (expires in 11d12h)`:
  - Pre-fix: 8 pass, 6 fail (every `block:` case returned 0 instead of 2).
  - Post-fix: **14 pass, 0 fail**.
- [x] Production hook (`integ-broad-gate.sh`) untouched — `git diff main -- .claude/hooks/integ-broad-gate.sh` is empty.
- [x] Mock `mise` matches the production invocation form (`mise exec -- markgate verify integ-broad` + `mise exec -- markgate status integ-broad`).
- [x] Default `MARKGATE_MOCK_VERDICT="stale"` keeps the existing 6 `block:` cases asserting the block path.
