### PR TITLE
fix(ecr-login): actionable error when docker credential helper blocks ECR login

### DIFF
--- a/src/assets/docker-asset-publisher.ts
+++ b/src/assets/docker-asset-publisher.ts
@@ -4,7 +4,7 @@ import {
   DescribeImagesCommand,
 } from '@aws-sdk/client-ecr';
 import type { DockerImageAsset } from '../types/assets.js';
-import { runDockerStreaming } from '../utils/docker-cmd.js';
+import { formatDockerLoginError, runDockerStreaming } from '../utils/docker-cmd.js';
 import { getLogger } from '../utils/logger.js';
 import { AssetError } from '../utils/error-handler.js';
 import { buildDockerImage } from './docker-build.js';
@@ -210,7 +210,9 @@ export class DockerAssetPublisher {
       });
     } catch (err) {
       const e = err as { stderr?: string; message?: string };
-      throw new AssetError(`ECR login failed: ${e.stderr?.trim() || e.message || String(err)}`);
+      throw new AssetError(
+        `ECR login failed: ${formatDockerLoginError(e.stderr || e.message || String(err), endpoint)}`
+      );
     }
   }
 

--- a/src/local/ecr-puller.ts
+++ b/src/local/ecr-puller.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { ECRClient, GetAuthorizationTokenCommand } from '@aws-sdk/client-ecr';
 import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
-import { getDockerCmd, runDockerStreaming } from '../utils/docker-cmd.js';
+import { formatDockerLoginError, getDockerCmd, runDockerStreaming } from '../utils/docker-cmd.js';
 import { LocalInvokeBuildError } from '../utils/error-handler.js';
 import { getLogger } from '../utils/logger.js';
 
@@ -169,7 +169,7 @@ async function ecrLogin(client: ECRClient, accountId: string, region: string): P
   } catch (err) {
     const e = err as { stderr?: string; message?: string };
     throw new LocalInvokeBuildError(
-      `ECR login failed: ${e.stderr?.trim() || e.message || String(err)}`
+      `ECR login failed: ${formatDockerLoginError(e.stderr || e.message || String(err), endpoint)}`
     );
   }
 }

--- a/src/utils/docker-cmd.ts
+++ b/src/utils/docker-cmd.ts
@@ -167,15 +167,20 @@ export async function spawnStreaming(
 /**
  * Format the stderr from a failed `docker login` so the surfaced cdkd
  * error gives the user an actionable workaround when the underlying
- * failure is the well-known macOS osxkeychain credential-helper bug
- * (which has nothing to do with cdkd, AWS, or IAM perms — the docker
- * CLI itself fails to save the auth token to the keychain because an
- * entry for the same hostname already exists in stale state).
+ * failure is a credential-helper persistence bug (which has nothing to
+ * do with cdkd, AWS, or IAM perms — the docker CLI itself fails to
+ * save the auth token to the platform's credential store). The most
+ * common shape is `osxkeychain` on macOS rejecting an overwrite for
+ * an existing entry, but `wincred` (Windows), `pass` (Linux), and
+ * `secretservice` (Linux) hit the same class of `Error saving
+ * credentials` failure, so the rewritten message stays platform-
+ * agnostic — `docker logout <endpoint>` is the correct recovery on
+ * every backend.
  *
- * Detected docker / docker-credential-osxkeychain output patterns:
+ * Detected docker / docker-credential-* output patterns:
  *   - `error storing credentials - err: exit status 1, out: \`The
- *     specified item already exists in the keychain.\``
- *   - `Error saving credentials: ...`
+ *     specified item already exists in the keychain.\`` (osxkeychain)
+ *   - `Error saving credentials: ...` (any backend)
  *
  * Non-matching failures (genuine IAM / network / endpoint problems)
  * pass through with just the stderr trimmed — the original message
@@ -183,16 +188,17 @@ export async function spawnStreaming(
  */
 export function formatDockerLoginError(stderr: string, endpoint: string): string {
   const trimmed = stderr.trim();
-  const isKeychainCollision =
+  const isCredentialHelperFailure =
     trimmed.includes('already exists in the keychain') ||
     trimmed.includes('Error saving credentials');
-  if (isKeychainCollision) {
+  if (isCredentialHelperFailure) {
     return (
-      `docker's credential helper failed to save the ECR auth token. ` +
-      `The "already exists in the keychain" / "Error saving credentials" output is a known ` +
-      `Docker Desktop + macOS osxkeychain bug — unrelated to cdkd, AWS credentials, or IAM perms. ` +
-      `Quick fix: run \`docker logout ${endpoint}\` to clear the stale keychain entry, then retry the cdkd command. ` +
-      `Permanent fix: edit ~/.docker/config.json and remove (or empty) the "credsStore": "osxkeychain" entry. ` +
+      `docker's credential helper (osxkeychain on macOS / wincred on Windows / pass / secretservice on Linux) ` +
+      `failed to persist the ECR auth token. The "already exists in the keychain" / "Error saving credentials" ` +
+      `output is a known docker-credential-helpers issue — unrelated to cdkd, AWS credentials, or IAM perms. ` +
+      `Quick fix: run \`docker logout ${endpoint}\` to clear the stale entry, then retry the cdkd command. ` +
+      `Permanent fix: edit ~/.docker/config.json and remove (or empty) the platform-specific "credsStore" entry ` +
+      `(e.g. "osxkeychain" → "" or "desktop" on macOS Docker Desktop). ` +
       `Original docker stderr: ${trimmed}`
     );
   }

--- a/src/utils/docker-cmd.ts
+++ b/src/utils/docker-cmd.ts
@@ -164,6 +164,41 @@ export async function spawnStreaming(
   });
 }
 
+/**
+ * Format the stderr from a failed `docker login` so the surfaced cdkd
+ * error gives the user an actionable workaround when the underlying
+ * failure is the well-known macOS osxkeychain credential-helper bug
+ * (which has nothing to do with cdkd, AWS, or IAM perms — the docker
+ * CLI itself fails to save the auth token to the keychain because an
+ * entry for the same hostname already exists in stale state).
+ *
+ * Detected docker / docker-credential-osxkeychain output patterns:
+ *   - `error storing credentials - err: exit status 1, out: \`The
+ *     specified item already exists in the keychain.\``
+ *   - `Error saving credentials: ...`
+ *
+ * Non-matching failures (genuine IAM / network / endpoint problems)
+ * pass through with just the stderr trimmed — the original message
+ * stays load-bearing for diagnosis.
+ */
+export function formatDockerLoginError(stderr: string, endpoint: string): string {
+  const trimmed = stderr.trim();
+  const isKeychainCollision =
+    trimmed.includes('already exists in the keychain') ||
+    trimmed.includes('Error saving credentials');
+  if (isKeychainCollision) {
+    return (
+      `docker's credential helper failed to save the ECR auth token. ` +
+      `The "already exists in the keychain" / "Error saving credentials" output is a known ` +
+      `Docker Desktop + macOS osxkeychain bug — unrelated to cdkd, AWS credentials, or IAM perms. ` +
+      `Quick fix: run \`docker logout ${endpoint}\` to clear the stale keychain entry, then retry the cdkd command. ` +
+      `Permanent fix: edit ~/.docker/config.json and remove (or empty) the "credsStore": "osxkeychain" entry. ` +
+      `Original docker stderr: ${trimmed}`
+    );
+  }
+  return trimmed;
+}
+
 function mergeEnv(overrides: Record<string, string | undefined>): NodeJS.ProcessEnv {
   const merged: NodeJS.ProcessEnv = { ...process.env };
   for (const [k, v] of Object.entries(overrides)) {

--- a/tests/unit/utils/docker-cmd.test.ts
+++ b/tests/unit/utils/docker-cmd.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
-import { getDockerCmd, runDockerStreaming, spawnStreaming } from '../../../src/utils/docker-cmd.js';
+import {
+  formatDockerLoginError,
+  getDockerCmd,
+  runDockerStreaming,
+  spawnStreaming,
+} from '../../../src/utils/docker-cmd.js';
 
 describe('getDockerCmd', () => {
   let originalEnv: string | undefined;
@@ -131,5 +136,47 @@ describe('runDockerStreaming / spawnStreaming machinery', () => {
       if (original === undefined) delete process.env['CDK_DOCKER'];
       else process.env['CDK_DOCKER'] = original;
     }
+  });
+});
+
+// `formatDockerLoginError` — pattern-detect the macOS osxkeychain
+// credential-helper bug and surface an actionable `docker logout
+// <endpoint>` workaround instead of the raw cryptic docker stderr.
+describe('formatDockerLoginError', () => {
+  const endpoint = 'https://123456789012.dkr.ecr.us-east-1.amazonaws.com';
+
+  it("rewrites the 'already exists in the keychain' osxkeychain collision", () => {
+    const stderr =
+      'Error saving credentials: error storing credentials - err: exit status 1, ' +
+      'out: `The specified item already exists in the keychain.`';
+    const out = formatDockerLoginError(stderr, endpoint);
+    expect(out).toMatch(/Quick fix: run `docker logout https:\/\/123456789012\.dkr\.ecr\.us-east-1\.amazonaws\.com`/);
+    expect(out).toMatch(/known Docker Desktop \+ macOS osxkeychain bug/);
+    expect(out).toMatch(/credsStore/); // permanent-fix hint
+    expect(out).toContain(stderr); // original stderr preserved for diagnosis
+  });
+
+  it("also catches the bare 'Error saving credentials' shape without the keychain string", () => {
+    // Some docker-credential-* helpers (pass-store, secretservice) emit
+    // the saving-credentials prefix but a different out-line — same root
+    // cause (the credential helper can't persist), so route to the same
+    // workaround.
+    const stderr = 'Error saving credentials: pass not initialized for user';
+    const out = formatDockerLoginError(stderr, endpoint);
+    expect(out).toMatch(/docker logout /);
+  });
+
+  it('passes a non-credential-helper error through verbatim (trimmed)', () => {
+    const stderr =
+      '\n  Error response from daemon: Get "https://123456789012.dkr.ecr.us-east-1.amazonaws.com/v2/": net/http: TLS handshake timeout  \n';
+    const out = formatDockerLoginError(stderr, endpoint);
+    expect(out).toBe(
+      'Error response from daemon: Get "https://123456789012.dkr.ecr.us-east-1.amazonaws.com/v2/": net/http: TLS handshake timeout'
+    );
+    expect(out).not.toMatch(/docker logout /);
+  });
+
+  it('handles an empty stderr cleanly', () => {
+    expect(formatDockerLoginError('', endpoint)).toBe('');
   });
 });

--- a/tests/unit/utils/docker-cmd.test.ts
+++ b/tests/unit/utils/docker-cmd.test.ts
@@ -151,7 +151,11 @@ describe('formatDockerLoginError', () => {
       'out: `The specified item already exists in the keychain.`';
     const out = formatDockerLoginError(stderr, endpoint);
     expect(out).toMatch(/Quick fix: run `docker logout https:\/\/123456789012\.dkr\.ecr\.us-east-1\.amazonaws\.com`/);
-    expect(out).toMatch(/known Docker Desktop \+ macOS osxkeychain bug/);
+    // Platform-agnostic wording (osxkeychain / wincred / pass / secretservice all hit
+    // the same class) — the user-facing message must NOT pin the diagnosis to macOS
+    // when the same workaround applies on Windows + Linux too.
+    expect(out).toMatch(/docker-credential-helpers issue/);
+    expect(out).toMatch(/osxkeychain on macOS \/ wincred on Windows \/ pass \/ secretservice on Linux/);
     expect(out).toMatch(/credsStore/); // permanent-fix hint
     expect(out).toContain(stderr); // original stderr preserved for diagnosis
   });


### PR DESCRIPTION
## Summary
- `docker login --password-stdin <ecr-endpoint>` (called by `cdkd deploy`'s ECR push path and `cdkd local invoke`'s ECR pull fallback) fails with `Error saving credentials: error storing credentials - err: exit status 1, out: \`The specified item already exists in the keychain.\`` whenever the docker CLI's credential helper (`osxkeychain` on macOS, `wincred` on Windows, `pass` / `secretservice` on Linux) has a stale entry for that ECR endpoint and rejects the overwrite of a freshly-issued ECR auth token. The failure is unrelated to cdkd / AWS / IAM perms — it's a known docker-credential-helpers issue.
- Pre-fix the cdkd error surfaced only the raw docker stderr, leaving users to grep the message and figure out the recovery themselves. Post-fix the new `formatDockerLoginError` helper in [src/utils/docker-cmd.ts](src/utils/docker-cmd.ts) pattern-matches the two characteristic substrings (`already exists in the keychain` / `Error saving credentials`) and rewrites the error to embed the exact recovery one-liner (`docker logout <endpoint>`) plus a pointer at the permanent fix (drop the platform-specific `credsStore` entry from `~/.docker/config.json`, e.g. `"osxkeychain"` → `""` or `"desktop"` on macOS Docker Desktop). The original docker stderr is preserved at the end of the message for diagnosis. Non-matching failures (genuine IAM / network errors) pass through with just `.trim()` — the original message stays load-bearing.
- The rewritten message is intentionally platform-agnostic — same `docker logout <endpoint>` workaround applies on Linux + Windows backends, even though the most commonly reported shape is macOS osxkeychain.
- Wired into both ECR-login call sites: [src/assets/docker-asset-publisher.ts](src/assets/docker-asset-publisher.ts) (deploy-time ECR push) and [src/local/ecr-puller.ts](src/local/ecr-puller.ts) (`cdkd local invoke` ECR pull fallback).

## Example error output (post-fix)

```
ECR login failed: docker's credential helper (osxkeychain on macOS / wincred on Windows / pass / secretservice on Linux) failed to persist the ECR auth token. The "already exists in the keychain" / "Error saving credentials" output is a known docker-credential-helpers issue — unrelated to cdkd, AWS credentials, or IAM perms. Quick fix: run `docker logout https://123456789012.dkr.ecr.us-east-1.amazonaws.com` to clear the stale entry, then retry the cdkd command. Permanent fix: edit ~/.docker/config.json and remove (or empty) the platform-specific "credsStore" entry (e.g. "osxkeychain" → "" or "desktop" on macOS Docker Desktop). Original docker stderr: Error saving credentials: error storing credentials - err: exit status 1, out: `The specified item already exists in the keychain.`
```

## Test plan
- [x] `vp run build` — typecheck + bundle pass
- [x] `vp run test` — 3979 tests pass (305 files), including 4 unit tests in [tests/unit/utils/docker-cmd.test.ts](tests/unit/utils/docker-cmd.test.ts) covering: the `already exists in the keychain` osxkeychain collision rewrite (platform list + `docker-credential-helpers issue` phrase locked in), the bare `Error saving credentials` shape (pass / secretservice backends), the pass-through case for genuine non-credential errors (`net/http: TLS handshake timeout`), and the empty-stderr edge.
- [x] `/run-integ local-invoke-container` — 4/4 container-Lambda invoke cases pass (build → invoke → --event → --env-vars override → --no-build cache hit), 0 orphan docker containers, 0 orphan docker networks. Confirms the `src/utils/docker-cmd.ts` streaming spawn changes don't regress the Docker-based local-execution path on the same scope `src/local/ecr-puller.ts` is part of.
- [x] Manual verification: the user hit this exact error on `cdkd deploy` against a new AWS account whose ECR endpoint had a stale keychain entry from an unrelated source. `docker logout https://<endpoint>` resolved the immediate blocker; this PR makes the next person who hits it self-serviceable without external grep.
- [x] PR #438 round 1 code review (pr-code-reviewer agent): Clean (Ship it) + 2 nits. nit #1 (platform-agnostic wording) is addressed in commit 879e5c0 (`drop macOS-specific framing`). nit #2 (case sensitivity of `String.includes`) accepted as-is — docker stderr format is stable across minor versions and `.trim()` pass-through is a safe failure mode.

## Non-scope
- The `cdk-assets-lib` parity question (does CDK CLI skip `docker login` when a fresh credential already exists in `~/.docker/config.json`?) is left for a separate PR if real-world evidence warrants it. cdkd's current behavior of unconditionally re-logging in matches the existing publisher contract.
