### PR TITLE
docs(readme): tone down top-of-README warning + sharpen local dev bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,14 @@ Drop-in CDK CLI for existing CDK apps — faster deploys via AWS SDK instead of 
 
 - **Drop-in CDK compatible** — your existing CDK app code runs as-is.
 - **Up to 15x faster deploys than the AWS CDK CLI (CloudFormation)**
-- **Run AWS resources locally without deploying** — invoke Lambdas, run ECS tasks, and serve API Gateway routes from Docker.
+- **Local dev for CDK apps** — invoke Lambdas, serve API Gateway routes, and run ECS tasks directly from your CDK code, no `cdk synth → sam local` round-trip.
 
 ![cdkd demo](https://github.com/user-attachments/assets/0128730d-186d-4bd3-abea-aabc80ba4dd5)
 
 **cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration and SAM-style local execution; use the AWS CDK CLI in production for full CloudFormation tooling. Bidirectional migration is supported — [import an existing CloudFormation stack](#importing-existing-resources) into cdkd for iteration, or [export back to CloudFormation](#exporting-a-stack-back-to-cloudformation) when ready for production.
 
-> **⚠️ WARNING: NOT PRODUCTION READY**
->
-> An experimental project exploring direct SDK provisioning as an alternative to the AWS CDK CLI — **NOT a replacement** and **NOT suitable for production use**. Features are incomplete, APIs may change without notice, and bugs may affect your AWS infrastructure. Use at your own risk in development / testing environments only.
+> [!IMPORTANT]
+> cdkd is for dev/test workflows only — early in development, not yet production-ready.
 
 ## Features
 


### PR DESCRIPTION
## Summary

Two README tweaks to the opening section. No code, no CLI, no docs/* / CLAUDE.md changes.

### 1. Tone down the top-of-README warning

**Before** — 5-line block:

> **⚠️ WARNING: NOT PRODUCTION READY**
>
> An experimental project exploring direct SDK provisioning as an alternative to the AWS CDK CLI — **NOT a replacement** and **NOT suitable for production use**. Features are incomplete, APIs may change without notice, and bugs may affect your AWS infrastructure. Use at your own risk in development / testing environments only.

**After** — 1 line in a GitHub `[!IMPORTANT]` admonition:

> [!IMPORTANT]
> cdkd is for dev/test workflows only — early in development, not yet production-ready.

Why:
- The previous block stacked five negatives (`WARNING` / `NOT PRODUCTION READY` / `NOT a replacement` / `NOT suitable` / `at your own risk`) and reads like a hazard label, harsher than the project's actual maturity warrants.
- The role split (dev/test vs production) and the bidirectional migration story (`cdkd import` / `export`) were already covered in the paragraph immediately above, so the warning block was duplicating positioning content. The new line only carries the maturity signal.
- The GitHub `[!IMPORTANT]` admonition restores the visual callout (purple icon + label) that the bare blockquote alternative would have lost.

### 2. Sharpen the local-dev bullet

**Before:**
> Run AWS resources locally without deploying — invoke Lambdas, run ECS tasks, and serve API Gateway routes from Docker.

**After:**
> Local dev for CDK apps — invoke Lambdas, serve API Gateway routes, and run ECS tasks directly from your CDK code, no `cdk synth → sam local` round-trip.

Why: names the concrete pain `cdkd local *` removes (the CDK + SAM round-trip every CDK user knows) instead of describing the feature in generic terms.

## Test plan

- [x] `git diff` reviewed — exactly 2 lines removed, 3 lines added, no other changes
- [x] Repo-wide grep for the removed warning phrases (`NOT PRODUCTION READY` / `NOT a replacement` / `NOT suitable for production` / `Use at your own risk`) and the removed bullet wording (`Run AWS resources locally`) — zero hits anywhere in the repo, no stale references
- [x] `/check-docs` passed — README-only change, no code/CLI/state surface touched, no documentation inconsistencies
- [x] GitHub admonition rendering verified locally (`[!IMPORTANT]` renders as the purple Important callout in GitHub-flavored Markdown)
