### PR TITLE
fix(hooks): pr-review-gate parses PR number from the LAST 'gh pr merge'

### DIFF
--- a/.claude/hooks/pr-review-gate.sh
+++ b/.claude/hooks/pr-review-gate.sh
@@ -69,8 +69,14 @@ cd "$REPO" 2>/dev/null || exit 0
 # values. If no numeric token is found, we fall back to gh's "PR for
 # current branch" semantics by passing no positional arg.
 pr_number=""
-# Strip everything up to and including `merge` so we only scan its args.
-args="${cmd#*merge}"
+# Strip everything up to and including the LAST `gh pr merge` so we only
+# scan its args. Greedy `##*PATTERN` (not the shortest `#*PATTERN`) so a
+# Bash comment containing the bare word "merge" earlier in the command
+# (e.g. `# Wait + merge\ngh pr merge 498`) doesn't cause us to read the
+# wrong token as the PR number. Matching on the full `gh pr merge` phrase
+# (not bare `merge`) is the load-bearing tightening — the prior `#*merge`
+# also matched merge inside `git merge`, `--no-merge`, branch names, etc.
+args="${cmd##*gh pr merge}"
 # shellcheck disable=SC2086
 set -- $args
 while [ $# -gt 0 ]; do

--- a/.claude/hooks/pr-review-gate.test.sh
+++ b/.claude/hooks/pr-review-gate.test.sh
@@ -286,6 +286,22 @@ run_case "gh pr merge <N> --auto + stale marker → block" 2 \
   medium stale "" \
   "gh pr merge 700 --auto"
 
+# 18. Command containing the bare word "merge" BEFORE the actual
+#     `gh pr merge` (typical: an inline `# Wait + merge` comment in
+#     a multi-line Bash script, OR a `git merge` / `npm run merge:foo`
+#     earlier in a `;`-chained command). Pre-fix the `${cmd#*merge}`
+#     short-match landed at the EARLIER `merge` token, and the next
+#     numeric token in the chain (loop counter, exit code, etc.) was
+#     erroneously parsed as the PR number. Post-fix `${cmd##*gh pr merge}`
+#     greedy-strips up to the LAST `gh pr merge` so the parse lands on
+#     the real PR number. Medium-tier fixture + stale marker → must
+#     still BLOCK (exit 2) on the post-fix parse — proving the
+#     comment-bearing shape doesn't fall into the parse-empty
+#     "current branch PR" fail-open path.
+run_case "command with 'merge' word before gh pr merge → still blocks" 2 \
+  medium stale "" \
+  "echo merge first; for i in 1 2 3; do echo loop; done; gh pr merge 800 --squash"
+
 echo
 echo "Pass: $pass  Fail: $fail"
 if [ "$fail" -gt 0 ]; then


### PR DESCRIPTION
## Summary

The pr-review-gate hook's PR-number parser used `${cmd#*merge}` (shortest match), so any Bash command containing the bare word "merge" BEFORE the actual `gh pr merge` — typically a comment like `# Wait + merge`, but also `git merge` / `npm run merge:foo` / branch names — landed the strip at the wrong "merge" and the next numeric token in the command (loop counter, exit code, line number) was parsed as the PR number.

Surfaced 2026-05-22 mid Wave 3 merge cycle: a `for i in 1 2 3; do ...; done; gh pr merge 498` shape tripped the gate with a misleading `PR #1 (73879 LOC, 480 files) requires 3-axis review` error — the parser had grabbed `1` and the hook had fetched PR (#1)'s stats.

Fix: tighten to `${cmd##*gh pr merge}` (greedy from start, eats up to the LAST `gh pr merge`).

## Test plan

- [x] New smoke test case 18 in `pr-review-gate.test.sh` exercises the canonical `echo merge first; for i in 1 2 3; do echo loop; done; gh pr merge 800 --squash` shape against the medium-tier fixture
- [x] Pre-fix behavior returned exit 0 (parse extracted `1` → fail-open path); post-fix returns exit 2 (correctly parses 800, blocks on stale marker)
- [x] All 18 existing cases still pass

Closes the parse-bug part of the session retrospective from PR (#494)..(#505).
