### PR TITLE
fix(local-start-service): PR #504 review follow-ups (#506)

### DIFF
--- a/docs/design/461-awsvpc-decision.md
+++ b/docs/design/461-awsvpc-decision.md
@@ -57,6 +57,24 @@ PR 8b of #224 closed the same shape for Lambda `VpcConfig` (issue #234): VPC-con
 
 No code-path changes are required — the existing warn path is correct.
 
+## Workarounds for users who need real host-network access
+
+Developers occasionally need a local task to reach a service bound to the host's loopback (e.g. a development database on `localhost:5432`). The bridge fallback puts each task on its own user network so `localhost` inside the container resolves to the container itself, not the host. Two workarounds:
+
+### `host.docker.internal` (Docker Desktop default)
+
+On Docker Desktop (macOS / Windows) the special hostname `host.docker.internal` resolves to the host's loopback gateway from inside any container, regardless of network driver. Tasks running under cdkd's bridge fallback can connect to a host service with `host.docker.internal:5432` (or whichever port). This is the recommended workaround — no flag change required, works against the existing bridge fallback.
+
+### `--network host` per-task escape hatch (future enhancement)
+
+Linux hosts that don't expose `host.docker.internal` (or workflows that want the task to bind directly to a host port) can use Docker's `host` network mode, which shares the host's network namespace with the container. **This is not currently exposed as a cdkd flag** — `cdkd local run-task` and `cdkd local start-service` always create a per-task user network so the metadata sidecar can serve task credentials on `169.254.170.2`. Threading a `--network-mode host` flag through would require either skipping the sidecar (and losing `--assume-task-role` credentials) or running the sidecar on the host network at a fixed port (which collides on `169.254.170.0/16` since the host loopback doesn't route the link-local range to the sidecar).
+
+If you have a concrete use case where neither `host.docker.internal` nor publishing a port on the bridge network (`docker run -p`) suffices, file a follow-up issue describing it; the design tradeoff above is reconsidered per-request, not added as a generic opt-in.
+
+### Why not auto-detect
+
+cdkd does not auto-detect Linux vs. Docker Desktop and switch network modes. The reasoning matches `feedback_aws_default_over_opinionated.md`: a per-host-OS behavioral split is invisible to users reading the same CDK app and would surface as "works on my Mac, breaks on the Linux CI runner" without an obvious cause.
+
 ## When to revisit
 
 Reopen #461 if any of the following happen:

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -113,7 +113,7 @@ async function localStartServiceCommand(
       }
     },
     (err) =>
-      getLogger().debug(
+      getLogger().warn(
         `service cleanup failed: ${err instanceof Error ? err.message : String(err)}`
       )
   );

--- a/src/local/ecs-service-resolver.ts
+++ b/src/local/ecs-service-resolver.ts
@@ -45,8 +45,17 @@ export interface ResolvedEcsService {
   /**
    * HealthCheckGracePeriodSeconds from the template. AWS defaults to 0
    * when the service has no load balancer, 30s with an ALB attached.
-   * cdkd uses this as the time-from-start before a failing task counts
-   * as "unhealthy" and triggers a restart. Defaults to 30s locally.
+   *
+   * **Currently not consumed by the runner.** cdkd's
+   * `ecs-service-runner.ts` is exit-code-driven (`docker wait` →
+   * `shouldRestart`); there is no health-check polling in v1 because
+   * health-check-driven restarts are only meaningful once the local
+   * load-balancer emulator lands (see [docs/design/461-awsvpc-decision.md]
+   * and the deferred LB scope in CLAUDE.md). The field is parsed,
+   * surfaced on `ResolvedEcsService`, and intentionally retained so the
+   * follow-up LB emulator PR can use it as the time-from-start before
+   * an unhealthy target-group health check counts toward a restart. The
+   * value defaults to 30s locally to match the AWS-with-ALB default.
    */
   healthCheckGracePeriodSeconds: number;
   /**

--- a/tests/integration/local-start-service/verify.sh
+++ b/tests/integration/local-start-service/verify.sh
@@ -112,6 +112,48 @@ if [[ "${NET_COUNT}" -lt 2 ]]; then
 fi
 echo "    OK: ${NET_COUNT} per-replica networks present"
 
+echo "==> Asserting per-replica subnet isolation (each network has a distinct /24 in 169.254.170-253)"
+# Regression guard for the per-replica subnet allocator in
+# ecs-service-runner.ts (`170 + (index % 84)`). The pre-PR assertion
+# only counted networks, so a collapsed allocator that put every
+# replica on the same /24 would still pass. Walk every network's
+# IPAM.Config[0].Subnet and assert (a) they are all distinct AND (b)
+# each is in the expected 169.254.<170-253>.0/24 range that
+# `buildReplicaSubnet(index)` allocates.
+NET_IDS=$(docker network ls --filter "name=cdkd-local-" --format '{{.ID}}')
+declare -a SUBNETS=()
+for net_id in ${NET_IDS}; do
+  SUBNET=$(docker network inspect "${net_id}" --format '{{(index .IPAM.Config 0).Subnet}}' 2>/dev/null || echo "")
+  if [[ -z "${SUBNET}" ]]; then
+    echo "FAIL: docker network ${net_id} has no IPAM.Config[0].Subnet"
+    docker network inspect "${net_id}"
+    exit 1
+  fi
+  echo "    network ${net_id}: subnet=${SUBNET}"
+  # Assert the subnet falls inside the allocator's range. The allocator
+  # emits `169.254.<170 + (index % 84)>.0/24` so the third octet must
+  # be in 170..253 inclusive.
+  if [[ ! "${SUBNET}" =~ ^169\.254\.([0-9]+)\.0/24$ ]]; then
+    echo "FAIL: subnet ${SUBNET} for network ${net_id} is not in the expected 169.254.X.0/24 shape"
+    exit 1
+  fi
+  OCTET="${BASH_REMATCH[1]}"
+  if (( OCTET < 170 || OCTET > 253 )); then
+    echo "FAIL: subnet ${SUBNET} third octet ${OCTET} is outside the allocator range 170..253"
+    exit 1
+  fi
+  SUBNETS+=("${SUBNET}")
+done
+
+# Assert every subnet is distinct (no duplicates). Sort + uniq + count.
+UNIQUE_SUBNET_COUNT=$(printf '%s\n' "${SUBNETS[@]}" | sort -u | wc -l | tr -d ' ')
+if [[ "${UNIQUE_SUBNET_COUNT}" -ne "${#SUBNETS[@]}" ]]; then
+  echo "FAIL: detected duplicate subnets across replicas — subnet allocator regression"
+  printf '    %s\n' "${SUBNETS[@]}"
+  exit 1
+fi
+echo "    OK: ${UNIQUE_SUBNET_COUNT} distinct subnets across ${#SUBNETS[@]} networks"
+
 echo "==> Sending SIGTERM to cdkd ($(echo $CDKD_PID))"
 kill -TERM "${CDKD_PID}"
 

--- a/tests/unit/local/ecs-service-runner.test.ts
+++ b/tests/unit/local/ecs-service-runner.test.ts
@@ -1,11 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
-// Mock `cleanupEcsRun` so ServiceController.shutdown() tests don't need
-// real docker. The mock records every call so we can assert "cleanup
-// ran AFTER bootReplica populated state" in the SIGTERM-mid-restart
-// race test below.
-const { mockCleanup } = vi.hoisted(() => ({
+// Mock `cleanupEcsRun` AND `runEcsTask` so ServiceController.shutdown()
+// + startEcsService / bootReplica / watchReplica tests don't need real
+// docker. The mocks record every call so we can assert ordering (e.g.
+// "cleanup ran AFTER bootReplica populated state" in the SIGTERM-mid-
+// restart race test) and trigger boot-failure paths.
+const { mockCleanup, mockRunTask } = vi.hoisted(() => ({
   mockCleanup: vi.fn<(state: unknown, opts: { keepRunning: boolean }) => Promise<void>>(),
+  mockRunTask:
+    vi.fn<(task: unknown, opts: unknown, state: unknown) => Promise<void>>(),
 }));
 
 vi.mock('../../../src/local/ecs-task-runner.js', async () => {
@@ -15,16 +18,19 @@ vi.mock('../../../src/local/ecs-task-runner.js', async () => {
   return {
     ...actual,
     cleanupEcsRun: mockCleanup,
+    runEcsTask: mockRunTask,
   };
 });
 
 import {
+  __setWaitForExitImpl,
   backoffDelayMs,
   computeReplicaCount,
   createServiceRunState,
   EcsServiceRunnerError,
   ServiceController,
   shouldRestart,
+  startEcsService,
   type ServiceReplicaInstance,
   type ServiceRunnerOptions,
 } from '../../../src/local/ecs-service-runner.js';
@@ -34,6 +40,14 @@ import type { EcsRunState } from '../../../src/local/ecs-task-runner.js';
 beforeEach(() => {
   mockCleanup.mockReset();
   mockCleanup.mockResolvedValue(undefined);
+  mockRunTask.mockReset();
+  mockRunTask.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  // Always restore the production waitForExit impl so a per-test
+  // override doesn't leak into the next test's watcher loop.
+  __setWaitForExitImpl(undefined);
 });
 
 describe('computeReplicaCount', () => {
@@ -315,5 +329,275 @@ describe('ServiceController.shutdown', () => {
     const controller = new ServiceController(service, runState, fakeOptions());
     await controller.shutdown();
     expect(mockCleanup).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('startEcsService / bootReplica lifecycle', () => {
+  // Helpers for the lifecycle tests below. The `startEcsService` entry
+  // point chains into `bootReplica` -> `runEcsTask` (mocked) and then
+  // wires `watchReplica` (which polls `waitForExitImpl`, also overridable
+  // via `__setWaitForExitImpl`). The tests below drive each piece
+  // independently so we can assert boot-failure cleanup ordering,
+  // restart-on-exit, and restart-policy degradation.
+  function makeService(desiredCount = 2): ResolvedEcsService {
+    return {
+      serviceName: 'svc-life',
+      serviceLogicalId: 'SvcLife',
+      desiredCount,
+      task: {
+        taskDefinitionLogicalId: 'TaskDef',
+        containers: [{ name: 'app', essential: true }],
+      } as unknown as ResolvedEcsService['task'],
+      stack: {} as ResolvedEcsService['stack'],
+      warnings: [],
+    } as unknown as ResolvedEcsService;
+  }
+
+  function makeOptions(
+    overrides: Partial<ServiceRunnerOptions> = {}
+  ): ServiceRunnerOptions {
+    return {
+      maxTasks: 84,
+      restartPolicy: 'on-failure',
+      taskOptions: {
+        cluster: 'cdkd-local',
+        containerHost: '127.0.0.1',
+        keepRunning: false,
+      },
+      ...overrides,
+    };
+  }
+
+  it('boot-failure on replica N>0 cleans up replicas 0..N-1', async () => {
+    // First replica boots successfully (mockRunTask resolves). Second
+    // replica's runEcsTask rejects, simulating e.g. an ECR pull failure
+    // mid-boot of replica 1. The CLI contract is "every replica is
+    // running before startEcsService returns" — so the boot failure
+    // surfaces as EcsServiceRunnerError. The implementation pushes each
+    // instance onto runState.replicas BEFORE awaiting bootReplica, so
+    // the outer-`finally` cleanup in the CLI walks `runState.replicas`
+    // and tears down the first replica even though boot of the second
+    // never completed.
+    mockRunTask
+      .mockImplementationOnce(async (_task, _opts, state) => {
+        // Populate replica 0's state so the eventual cleanup has
+        // something docker-shaped to release.
+        (state as EcsRunState).network = {
+          name: 'cdkd-local-svc-life-r0',
+          endpointsContainerId: 'sidecar-r0',
+        } as EcsRunState['network'];
+        (state as EcsRunState).startedContainers.push({ name: 'app', id: 'container-r0' });
+      })
+      .mockImplementationOnce(async () => {
+        throw new Error('docker run failed for replica 1 (ECR auth)');
+      });
+
+    const service = makeService(2);
+    const opts = makeOptions();
+    const runState = createServiceRunState();
+
+    await expect(startEcsService(service, opts, runState)).rejects.toThrow(
+      /Failed to boot replica 1 of service 'svc-life'/
+    );
+
+    // Replica 0 was pushed onto runState.replicas BEFORE its boot
+    // returned, AND replica 1 was pushed before its boot threw — both
+    // are tracked, so the CLI's outer-finally cleanup loop iterates
+    // both and cleanupEcsRun runs against each.
+    expect(runState.replicas).toHaveLength(2);
+    expect(runState.replicas[0]!.state.network?.endpointsContainerId).toBe('sidecar-r0');
+    expect(runState.replicas[1]!.lastError?.message).toMatch(/docker run failed for replica 1/);
+
+    // The runner itself does NOT auto-cleanup on boot failure —
+    // teardown is the CLI's responsibility (and the controller's
+    // shutdown handles it once the controller is constructed). For
+    // boot-failure-before-controller, the CLI walks runState.replicas
+    // directly. Simulate that path to verify the replica state is
+    // recoverable.
+    await Promise.all(
+      runState.replicas.map((r) =>
+        mockCleanup(r.state, { keepRunning: false }).catch(() => undefined)
+      )
+    );
+    expect(mockCleanup).toHaveBeenCalledTimes(2);
+    // Replica 0 cleanup sees the populated state with the docker
+    // network + sidecar handles, which is the load-bearing invariant
+    // for "no orphan resources on partial boot."
+    expect(mockCleanup.mock.calls[0]![0]).toBe(runState.replicas[0]!.state);
+  });
+
+  it('restart-on-exit fires runEcsTask again with exponential backoff', async () => {
+    // Make replica 0 boot succeed, then have its watcher loop observe
+    // an exit code 1 once, restart it, observe exit code 0, and stop.
+    let bootCount = 0;
+    mockRunTask.mockImplementation(async (_task, _opts, state) => {
+      bootCount += 1;
+      const s = state as EcsRunState;
+      s.network = {
+        name: `cdkd-local-svc-life-boot${bootCount}`,
+        endpointsContainerId: `sidecar-${bootCount}`,
+      } as EcsRunState['network'];
+      s.startedContainers.length = 0;
+      s.startedContainers.push({ name: 'app', id: `container-${bootCount}` });
+    });
+
+    // First wait: exit code 1 (triggers restart). Second wait: exit
+    // code 0 (still triggers restart under 'always' but NOT under
+    // 'on-failure'). We use 'on-failure' so the loop stops after one
+    // restart cycle.
+    const exits = [1, 0];
+    let exitIdx = 0;
+    __setWaitForExitImpl(async () => {
+      const code = exits[exitIdx] ?? 0;
+      exitIdx += 1;
+      return code;
+    });
+
+    const service = makeService(1);
+    const opts = makeOptions({ restartPolicy: 'on-failure' });
+    const runState = createServiceRunState();
+
+    const controller = await startEcsService(service, opts, runState);
+
+    // Drive the watcher loop forward. backoffDelayMs(0) is 1s — way
+    // too long for a unit test, so we instead poll for `bootCount === 2`
+    // with a tight overall timeout. The watcher runs in background;
+    // we drain microtasks via `setImmediate` repeatedly.
+    const deadline = Date.now() + 5000;
+    while (bootCount < 2 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    expect(bootCount).toBeGreaterThanOrEqual(2);
+    expect(mockRunTask).toHaveBeenCalledTimes(bootCount);
+    // The replica's restartCount reflects the watcher's increment.
+    expect(runState.replicas[0]!.restartCount).toBeGreaterThanOrEqual(1);
+
+    // Shut the service down so the watcher loop exits cleanly.
+    await controller.shutdown();
+  });
+
+  it("'none' restart policy leaves degraded replica down on non-zero exit", async () => {
+    let bootCount = 0;
+    mockRunTask.mockImplementation(async (_task, _opts, state) => {
+      bootCount += 1;
+      const s = state as EcsRunState;
+      s.network = {
+        name: `cdkd-local-svc-life-boot${bootCount}`,
+        endpointsContainerId: `sidecar-${bootCount}`,
+      } as EcsRunState['network'];
+      s.startedContainers.length = 0;
+      s.startedContainers.push({ name: 'app', id: `container-${bootCount}` });
+    });
+
+    // Watcher observes exit code 1; under 'none' policy no restart
+    // fires and the replica stays down forever (service runs degraded).
+    __setWaitForExitImpl(async () => 1);
+
+    const service = makeService(1);
+    const opts = makeOptions({ restartPolicy: 'none' });
+    const runState = createServiceRunState();
+
+    const controller = await startEcsService(service, opts, runState);
+
+    // Give the watcher loop a beat to observe the exit and mark the
+    // replica shuttingDown=true. `shouldRestart('none', ...) === false`
+    // so the watcher should not invoke runEcsTask a second time.
+    const deadline = Date.now() + 2000;
+    while (!runState.replicas[0]!.shuttingDown && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    // Boot fired once during startEcsService, and NOT again (policy=none).
+    expect(bootCount).toBe(1);
+    expect(mockRunTask).toHaveBeenCalledTimes(1);
+    // The replica IS marked shuttingDown by the watcher's no-restart
+    // branch so activeReplicaCount() reflects the degradation.
+    expect(runState.replicas[0]!.shuttingDown).toBe(true);
+    expect(controller.activeReplicaCount()).toBe(0);
+
+    await controller.shutdown();
+  });
+
+  it("'always' restart policy restarts on zero exit too", async () => {
+    let bootCount = 0;
+    mockRunTask.mockImplementation(async (_task, _opts, state) => {
+      bootCount += 1;
+      const s = state as EcsRunState;
+      s.network = {
+        name: `cdkd-local-svc-life-boot${bootCount}`,
+        endpointsContainerId: `sidecar-${bootCount}`,
+      } as EcsRunState['network'];
+      s.startedContainers.length = 0;
+      s.startedContainers.push({ name: 'app', id: `container-${bootCount}` });
+    });
+
+    // Successive zero-exits. Under 'always' the watcher restarts on
+    // every exit including 0, mirroring ECS Service deployment behavior.
+    __setWaitForExitImpl(async () => 0);
+
+    const service = makeService(1);
+    const opts = makeOptions({ restartPolicy: 'always' });
+    const runState = createServiceRunState();
+
+    const controller = await startEcsService(service, opts, runState);
+
+    // Wait for at least one restart cycle (bootCount >= 2).
+    const deadline = Date.now() + 5000;
+    while (bootCount < 2 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    expect(bootCount).toBeGreaterThanOrEqual(2);
+
+    await controller.shutdown();
+  });
+
+  it('successful startEcsService returns a controller with activeReplicaCount === desiredCount', async () => {
+    mockRunTask.mockImplementation(async (_task, _opts, state) => {
+      const s = state as EcsRunState;
+      s.network = {
+        name: 'cdkd-local-svc-life',
+        endpointsContainerId: 'sidecar',
+      } as EcsRunState['network'];
+      s.startedContainers.push({ name: 'app', id: 'container-x' });
+    });
+
+    // Watcher should not observe an exit during the test — return a
+    // never-resolving wait so the loop blocks past the assertions.
+    __setWaitForExitImpl(() => new Promise<number>(() => undefined));
+
+    const service = makeService(2);
+    const opts = makeOptions();
+    const runState = createServiceRunState();
+
+    const controller = await startEcsService(service, opts, runState);
+
+    expect(mockRunTask).toHaveBeenCalledTimes(2);
+    expect(runState.replicas).toHaveLength(2);
+    expect(controller.activeReplicaCount()).toBe(2);
+
+    await controller.shutdown();
+  });
+
+  it('controller.shutdown cleans up every active replica (multi-replica fan-out)', async () => {
+    mockRunTask.mockImplementation(async (_task, _opts, state) => {
+      const s = state as EcsRunState;
+      s.network = {
+        name: 'cdkd-local-svc-life',
+        endpointsContainerId: 'sidecar',
+      } as EcsRunState['network'];
+      s.startedContainers.push({ name: 'app', id: 'container-x' });
+    });
+    __setWaitForExitImpl(() => new Promise<number>(() => undefined));
+
+    const service = makeService(3);
+    const opts = makeOptions();
+    const runState = createServiceRunState();
+    const controller = await startEcsService(service, opts, runState);
+
+    expect(controller.activeReplicaCount()).toBe(3);
+
+    await controller.shutdown();
+    // 3 cleanup calls — one per replica.
+    expect(mockCleanup).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Summary

Bundles five minor follow-up nits from the PR #504 review of `cdkd local start-service`:

1. **Unit-test coverage gap** on the runner orchestration — adds 7 new tests in `tests/unit/local/ecs-service-runner.test.ts` exercising `startEcsService` / `bootReplica` / `watchReplica` / `ServiceController.shutdown` full-lifecycle scenarios that the existing pure-functional helper tests did not cover:
   - Boot-failure of replica N>0 — asserts both replicas land on `runState.replicas` AND the partially-booted replica's docker network + sidecar handles are recoverable from `state`.
   - Restart-on-exit loop with backoff — asserts `runEcsTask` fires a second time and `restartCount` increments after the watcher observes a non-zero exit.
   - `restart-policy: 'none'` — asserts the replica stays down, `runEcsTask` fires exactly once, and `activeReplicaCount()` reflects the degradation.
   - `restart-policy: 'always'` — asserts restart fires even on zero exit.
   - Successful boot — asserts `activeReplicaCount() === DesiredCount`.
   - Multi-replica shutdown fan-out — asserts every replica's `cleanupEcsRun` runs.

   The `--max-tasks` boundary (84 accepted, 85+ rejected) is already covered by the existing CLI-level tests in `tests/unit/cli/local-start-service.test.ts`.

2. **`healthCheckGracePeriodSeconds` docstring** in `ResolvedEcsService` — clarifies that the field is parsed and surfaced today but NOT consumed by the exit-code-driven runner. Spells out that the LB emulator follow-up will use it as the time-from-start before an unhealthy target-group health check counts toward a restart. Keeps the field on the type so the LB emulator PR does not have to re-add it; implementation stays deferred to the LB emulator scope (tracked in (#466)).

3. **`docs/design/461-awsvpc-decision.md` Workarounds section** — adds an end-of-doc section before "When to revisit" documenting the two paths for users whose tasks need host-network access:
   - `host.docker.internal` (Docker Desktop default; the recommended workaround, no flag change required).
   - `--network host` per-task escape hatch is NOT currently exposed as a cdkd flag, with an explicit rationale (would require either skipping the metadata sidecar or running it on a shared host port; design tradeoff documented per-request rather than added as a generic opt-in).

4. **Integ test subnet isolation** — strengthens `tests/integration/local-start-service/verify.sh` to inspect each replica's docker network IPAM via `docker network inspect <id> --format '{{(index .IPAM.Config 0).Subnet}}'` and assert (a) every subnet falls inside the allocator's documented `169.254.<170-253>.0/24` range AND (b) every subnet is distinct across replicas. Pre-fix the assertion only counted networks, so a regression that collapsed the per-replica subnet allocator onto a single /24 would still pass.

5. **CLI cleanup log level** — upgrades the `singleFlight` cleanup-failure handler in `src/cli/commands/local-start-service.ts` from `debug` to `warn` so cleanup failures are visible without `--verbose`. Matches the `local-start-api` precedent the issue cites.

## Test plan

- [x] `vp check --fix` (typecheck + lint + format) passes
- [x] `vp run build` passes
- [x] `vp run test` — all 4699 tests pass (7 new lifecycle tests added)
- [ ] `/run-integ local-start-service` runs end-to-end against real Docker and the new subnet-isolation assertions pass

Closes (#506).
