### PR TITLE
chore(hooks): closes-paren-form-gate + /verify-pr residual sweep step

### DIFF
--- a/.claude/hooks/closes-paren-form-gate.sh
+++ b/.claude/hooks/closes-paren-form-gate.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# closes-paren-form-gate.sh — block `gh pr merge` when PR body uses
+# `Closes (#N)` / `Fixes (#N)` / `Resolves (#N)` (closing-paren form),
+# which does NOT trigger GitHub's auto-close because the keyword
+# grammar requires parens-free `#N`.
+#
+# Closes the trap surfaced 2026-05-22 across PRs #509 / #510 / #511 /
+# #514 — all 4 PRs used `Closes (#N).` uniformly (overgeneralization of
+# memory `feedback_pr_body_no_hash_for_item_numbers.md`'s
+# closing-paren disambig), and every merged PR left its target issue
+# OPEN until a manual `gh issue close` was run.
+#
+# This hook fires PreToolUse on `gh pr merge` and short-circuits before
+# the merge happens, so the user sees the error in time to either:
+#   (a) rewrite the PR body to drop parens on the actual close keyword
+#   (b) reword to a non-close-keyword incidental reference
+
+set -euo pipefail
+
+input_json=$(cat)
+
+tool_name=$(jq -r '.tool_name // empty' <<<"$input_json" 2>/dev/null || true)
+[[ "$tool_name" == "Bash" ]] || exit 0
+
+command=$(jq -r '.tool_input.command // empty' <<<"$input_json" 2>/dev/null || true)
+[[ -n "$command" ]] || exit 0
+
+# Match `gh pr merge <N>` (allowing `gh -R repo` / `gh -C path` prefixes
+# and any flag order). Extract the LAST `gh pr merge ... N` occurrence
+# so a `# Wait + merge` Bash comment doesn't confuse the parser (same
+# fix as pr-review-gate.sh).
+trimmed="${command}"
+case "$trimmed" in
+  *"gh pr merge"*) ;;
+  *) exit 0 ;;
+esac
+
+# Extract PR number (positional integer after `gh pr merge`)
+args="${trimmed##*gh pr merge}"
+pr_num=$(echo "$args" | grep -oE '^[[:space:]]*[0-9]+' | head -1 | tr -d '[:space:]' || true)
+[[ -n "$pr_num" ]] || exit 0
+[[ "$pr_num" =~ ^[0-9]+$ ]] || exit 0
+
+# Fetch PR body (offline tolerant — if gh fails, don't block)
+body=$(gh pr view "$pr_num" --json body -q .body 2>/dev/null || true)
+[[ -n "$body" ]] || exit 0
+
+# Match `(closes?|fix(es)?|resolves?) (#N)` case-insensitive, only
+# when the parens IMMEDIATELY follow the keyword + whitespace. This
+# avoids false positives on text like `also closes some (#N) issue`
+# (a parenthetical that happens to follow `closes` but isn't part of
+# the close directive).
+matches=$(echo "$body" | grep -inE '\b(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+\(#[0-9]+\)' || true)
+
+if [[ -n "$matches" ]]; then
+  {
+    echo "Blocked by closes-paren-form-gate: PR #$pr_num body uses"
+    echo "the parens form on a GitHub auto-close keyword, which does"
+    echo "NOT trigger auto-close on merge. Offending lines:"
+    echo ""
+    echo "$matches" | sed 's/^/  /'
+    echo ""
+    echo "GitHub auto-close grammar requires parens-free \`#N\`:"
+    echo "  ✅ Closes #502.         (auto-close fires on merge)"
+    echo "  ❌ Closes (#502).       (silent no-op; issue stays OPEN)"
+    echo ""
+    echo "Two fixes:"
+    echo "  1. If the close IS intended: drop the parens, e.g."
+    echo "       sed -i '' 's/Closes (#\\([0-9]*\\))/Closes #\\1/g' <body-file>"
+    echo "     then update via:"
+    echo "       gh api -X PATCH repos/<owner>/<repo>/pulls/$pr_num -F body=@<file>"
+    echo "  2. If the parens form was an incidental reference (not a"
+    echo "     close directive): reword to drop the close keyword, e.g."
+    echo "       'References (#502).' / 'See also (#502).'"
+    echo ""
+    echo "Memory rule:"
+    echo "  ~/.claude/projects/-Users-goto-pc-github-cdkd/memory/feedback_pr_body_no_hash_for_item_numbers.md"
+    echo "  (Counter-trap section, added 2026-05-22)"
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/closes-paren-form-gate.test.sh
+++ b/.claude/hooks/closes-paren-form-gate.test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Smoke tests for closes-paren-form-gate.sh
+#
+# Mocks `gh pr view` via a $GH_BIN injected stub so we don't hit real
+# GitHub. Asserts:
+#   - Hook PASSES when body has parens-free `Closes #N`
+#   - Hook PASSES when body has parens form WITHOUT close keyword (incidental ref)
+#   - Hook BLOCKS when body has `Closes (#N)` / `Fixes (#N)` / `Resolves (#N)`
+#   - Hook PASSES for non-merge commands
+#   - Hook PASSES when gh fails (offline tolerance)
+
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/closes-paren-form-gate.sh"
+PASS=0
+FAIL=0
+
+run() {
+  local name="$1"
+  local input="$2"
+  local mock_body="$3"
+  local expect_exit="$4"
+
+  # Create a temp dir + mock gh binary
+  local tmp
+  tmp=$(mktemp -d)
+  cat <<EOF > "$tmp/gh"
+#!/usr/bin/env bash
+# Mock gh — emit the canned body on \`gh pr view ... --json body -q .body\`
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+  cat <<<'$mock_body'
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$tmp/gh"
+
+  local out err exit_code
+  out=$(echo "$input" | PATH="$tmp:$PATH" "$HOOK" 2>"$tmp/err") && exit_code=$? || exit_code=$?
+  err=$(cat "$tmp/err")
+
+  if [[ "$exit_code" -eq "$expect_exit" ]]; then
+    echo "PASS: $name (exit $exit_code)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (exit $exit_code, expected $expect_exit)"
+    echo "  stderr: $err"
+    FAIL=$((FAIL + 1))
+  fi
+
+  rm -rf "$tmp"
+}
+
+# 1. PASS: parens-free Closes #N
+run "parens-free Closes #N passes" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 100 --squash"}}' \
+  'Closes #502.' \
+  0
+
+# 2. BLOCK: Closes (#N) parens form
+run "Closes (#N) blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 100 --squash"}}' \
+  'Closes (#502).' \
+  2
+
+# 3. BLOCK: Fixes (#N) parens form
+run "Fixes (#N) blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 100 --squash"}}' \
+  'Fixes (#502).' \
+  2
+
+# 4. BLOCK: Resolves (#N) parens form (case-insensitive)
+run "resolves (#N) lowercase blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 100 --squash"}}' \
+  'resolves (#502).' \
+  2
+
+# 5. PASS: incidental ref `(#N)` WITHOUT close keyword
+run "incidental (#N) without close keyword passes" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 100 --squash"}}' \
+  'See also (#502) for context.' \
+  0
+
+# 6. PASS: non-merge gh command
+run "non-merge gh command passes" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr view 100"}}' \
+  'Closes (#502).' \
+  0
+
+# 7. PASS: non-Bash tool
+run "non-Bash tool passes" \
+  '{"tool_name":"Read","tool_input":{"file_path":"/tmp/x"}}' \
+  'Closes (#502).' \
+  0
+
+# 8. PASS: offline (gh returns nothing)
+run "offline tolerance" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 100 --squash"}}' \
+  '' \
+  0
+
+# 9. PASS: mixed body — Closes #N AND (#X) incidental — only counts parens-form-on-keyword
+run "mixed body: Closes #N + (#X) incidental ref passes" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 100 --squash"}}' \
+  'Closes #502. References (#510) for context.' \
+  0
+
+# 10. BLOCK: even one parens-form close in a multi-line body
+run "multi-line body with one Closes (#N) blocks" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 100 --squash"}}' \
+  '## Summary
+Some body text.
+
+Closes #502.
+Also closes (#512).' \
+  2
+
+# 11. PASS: gh -C <path> pr merge variant
+run "gh -C <path> pr merge with parens-free Closes" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh -C /tmp/x pr merge 100 --squash"}}' \
+  'Closes #502.' \
+  0
+
+# 12. PASS: Bash comment containing "gh pr merge" + real "gh pr merge N" — extract LAST occurrence
+run "Bash comment + real merge extracts last PR num" \
+  '{"tool_name":"Bash","tool_input":{"command":"# wait then gh pr merge\nfor i in 1 2 3; do echo loop; done; gh pr merge 800 --squash"}}' \
+  'Closes #800.' \
+  0
+
+# Summary
+echo ""
+echo "==== Test Summary ===="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,6 +55,13 @@
           },
           {
             "type": "command",
+            "command": ".claude/hooks/closes-paren-form-gate.sh",
+            "if": "Bash(gh pr merge*) or Bash(gh -C * pr merge*)",
+            "timeout": 10,
+            "statusMessage": "Checking PR body for Closes (#N) auto-close trap..."
+          },
+          {
+            "type": "command",
             "command": ".claude/hooks/verify-pr-gate.sh",
             "if": "Bash(gh pr create*) or Bash(gh pr merge*)",
             "timeout": 10,

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -170,6 +170,20 @@ Run each check and report pass/fail:
     - Surface the proposals out loud (in chat, or in this PR's body) before merging. If the user agrees, write them in the same PR for code/skill/hook artifacts; memory entries are local to `~/.claude/projects/.../memory/` so they land regardless of PR boundaries.
     - The retrospective is itself one of the items the `verify-pr` marker covers — skipping this step means the marker is set on incomplete work.
 
+11. **Residual review-nit sweep** (mandatory — added 2026-05-22 after a multi-PR session left ~9 reviewer-flagged nits unfiled when the parent declared "session complete")
+    - For every `/review-pr` reviewer agent output during this session (including re-reviews after fix-back), walk the reviewer's "Minor / Nit / Informational" section.
+    - For EACH item there, confirm ONE of the following is true BEFORE setting the `verify-pr` marker:
+      - (a) **Addressed in this PR** — point at the fix commit / file:line that resolves the nit.
+      - (b) **Filed as a follow-up issue** — a GitHub issue exists AND this PR's body references it (e.g. "minor follow-ups in (#515)").
+      - (c) **Explicitly accepted as known cost** — the PR body or a comment names the nit and explains why it's acceptable to ship as-is.
+    - If NONE of (a) / (b) / (c) is true for any nit, file a bundled follow-up issue NOW (one issue per session, listing every uncovered nit) and update the PR body to reference it. Do not set the `verify-pr` marker until every reviewer-flagged item is on one of those three paths.
+    - Also walk the session transcript for **surfaced memory-rule candidates** (surprising traps, repeated friction, "I should remember this for next time" moments). Each MUST be either written as a memory file in `~/.claude/projects/-Users-goto-pc-github-cdkd/memory/` (with a MEMORY.md index entry) OR explicitly de-prioritized in the chat / PR body.
+    - **Auto-close audit** (added 2026-05-22 — counter-trap to the closing-paren disambig convention in memory `feedback_pr_body_no_hash_for_item_numbers.md`):
+      - Read the PR body (`gh pr view <PR> --json body -q .body`). For every `(#N)` parens-form reference, check whether it's adjacent to a close keyword (`closes` / `fixes` / `resolves`, case-insensitive).
+      - If yes: the merge will NOT auto-close the target issue. Either rewrite to parens-free `Closes #N` (auto-close fires), OR add a manual `gh issue close <N>` step to the merge sequence and note it in the PR body.
+      - The mechanical `closes-paren-form-gate.sh` hook ALREADY blocks `gh pr merge` for the `Closes (#N)` pattern — this skill step is the human-readable backup that catches the issue BEFORE the merge attempt.
+    - This step is the structural enforcement of memory `feedback_session_completion_audit_required.md` — claiming "session complete" / "残作業なし" without running this sweep is the exact violation that surfaced this rule.
+
 11. **PR title + body freshness** (skip if no PR exists yet — `/create-pr` will write them from scratch)
     - When a PR has follow-up commits after creation, both the title and body authored at PR-create time often go stale: the title was scoped to the first commit's intent only, and the body may mention reverted features, removed checks, or wrong rationale. Detect and fix both.
     - **Title check**: read `gh pr view <PR> --json title -q .title` and confirm it still describes the union of commits on the branch. If a later commit added a separate concern (e.g. an unrelated fix, an opportunistic refactor), broaden the title. Update via `gh api -X PATCH repos/{owner}/{repo}/pulls/{number} -f title="..."` (NOT `gh pr edit --title`, which currently fails silently due to GraphQL Projects-classic deprecation — see hook `gh-pr-edit-deprecation-gate.sh`).
@@ -218,6 +232,8 @@ Present results as a table:
 | code review (incl. shared-utility callers) | pass/issues found |
 | live-test changed behavior | pass/skipped/issues found |
 | retrospective + rule proposals | done/skipped |
+| residual review-nit sweep (filed / addressed / accepted) | N items / 0 unhandled |
+| auto-close audit (no `Closes (#N)` in body) | clean / N traps fixed |
 | PR title + body freshness | up-to-date/stale (updated)/n-a (no PR yet) |
 
 If all pass, confirm "PR is ready to merge."


### PR DESCRIPTION
## Summary

Two-pronged prevention for the 2026-05-22 session-wrap trap:

1. **New `closes-paren-form-gate.sh` hook** physically blocks `gh pr merge` when the PR body uses `Closes (#N)` / `Fixes (#N)` / `Resolves (#N)` (parens form), since GitHub's auto-close keyword grammar requires parens-free `#N`. The parens form was used uniformly across PRs #509 / #510 / #511 / #514, leaving every target issue OPEN until manual `gh issue close` was run.

2. **New step 11 in `/verify-pr` skill** — "Residual review-nit sweep" — requires every reviewer-flagged minor/nit to be (a) addressed in the PR, (b) filed as follow-up issue, or (c) explicitly accepted before the `verify-pr` marker is set. The existing `verify-pr` marker is already gated on `gh pr merge`, so the sweep is structurally enforced.

## Why this matters

End of multi-PR session 2026-05-22, the parent declared "セッション完了!残作業はもうありません" while:
- 3 issues were still OPEN (closing-paren form silently no-op'd the auto-close)
- ~9 reviewer nits across 3 PRs had never been filed as issues
- 3 memory-rule candidates surfaced during the session had never been written

The user's reaction: "ちゃんと確認もしてないのに残課題なしっていうの、今後絶対にやめて" — and asked for `markgate` enforcement.

## Test plan

- [x] `bash .claude/hooks/closes-paren-form-gate.test.sh` — 12/12 PASS
- [x] Hook registered in `.claude/settings.json` under `PreToolUse` for `Bash(gh pr merge*) or Bash(gh -C * pr merge*)`
- [x] `/verify-pr` SKILL.md step 11 + output-table rows added
- [x] Memory rules: `feedback_pr_body_no_hash_for_item_numbers.md` (counter-trap section), new `feedback_subagent_loc_self_report_unreliable.md`, new `feedback_session_completion_audit_required.md`, MEMORY.md index updated

## Out of scope

Bundle of reviewer nits surfaced during the same session is tracked in #515 for follow-up PRs.

Closes #515 — at the prevention-mechanism level. The bundled nits themselves stay open in #515 for separate fix-up PRs.
