### PR TITLE
chore(hooks): remove non-English text from integ-schema-migration gate

### DIFF
--- a/.claude/hooks/integ-schema-migration-gate.sh
+++ b/.claude/hooks/integ-schema-migration-gate.sh
@@ -20,13 +20,13 @@
 #   (`undefined` field stripping, key ordering, schema version
 #   coercion) that only real round-trip catches.
 #
-#   The user instruction (recorded 2026-05-23) is absolute:
-#     "schema バージョン上げるなら、バージョン間の互換性もちゃんと
-#     保証する、つまりそれを実現する integ は絶対作って実行すること。"
-#   And:
-#     "ユーザーは何もしなくても裏側でいい感じに migrate してくれる
-#     ようにして。これは今後 schema バージョンあげる時は絶対保証する
-#     こと。"
+#   The contract this gate enforces is absolute: every schema bump
+#   MUST be transparently auto-migrated by the new binary AND verified
+#   by a real-AWS round-trip integ. Users must never have to run an
+#   explicit migrate command — the next read of a vN state file by
+#   the vN+1 binary auto-upgrades in memory, and the next write
+#   persists vN+1 silently. Schema bumps that violate transparent
+#   auto-migration are not shippable.
 #
 # How this gate enforces it:
 #

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -225,14 +225,9 @@ gates:
     # binary -> read works -> next write upgrades to vN+1 silently ->
     # destroy clean. Unit tests can't catch wire-format divergences
     # (`undefined` field stripping, key ordering, schema version
-    # coercion); only real round-trip does.
-    #
-    # The user instruction (recorded 2026-05-23):
-    #   "schema バージョン上げるなら、バージョン間の互換性もちゃんと
-    #    保証する、つまりそれを実現する integ は絶対作って実行すること。"
-    #   "ユーザーは何もしなくても裏側でいい感じに migrate して
-    #    くれるようにして。これは今後 schema バージョンあげる時は
-    #    絶対保証すること。"
+    # coercion); only real round-trip does. Users must never need to
+    # run an explicit migrate command for a schema bump — the binary
+    # auto-migrates on first write under the new version.
     #
     # Why a separate marker (vs. extending `integ-destroy` /
     # `integ-broad`): a destroy / broad integ flips its marker on


### PR DESCRIPTION
## Summary

Removes Japanese-language verbatim session quotes that landed in PR #521's `.markgate.yml` and `.claude/hooks/integ-schema-migration-gate.sh`. This repo is OSS and every committed artifact must be English-only per the workflow rule.

- `.markgate.yml` lines 230-235: removed the Japanese block, kept the technical rationale.
- `.claude/hooks/integ-schema-migration-gate.sh` lines 23-29: same shape, rewritten as a project-level contract statement.

No behavior change — gate enforcement logic and scope are unchanged.

## Test plan

- [ ] `grep -P '[\x{3040}-\x{30FF}\x{4E00}-\x{9FFF}]'` finds 0 matches in either file
- [ ] `.claude/hooks/integ-schema-migration-gate.test.sh` still passes (no logic touched)
- [ ] CI green
