### PR TITLE
docs(claude-md): align Important Notes with README framing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Important Notes**:
 
-- NOT recommended for production use (development/testing environments only)
-- Educational and experimental project
-- NOT intended as a replacement for the official AWS CDK CLI
+- For dev/test workflows only — early in development, not yet production-ready
+- Complements the AWS CDK CLI rather than replacing it (use CDK CLI in production for full CloudFormation tooling)
+- Bidirectional CloudFormation migration via `cdkd import --migrate-from-cloudformation` / `cdkd export`
 
 ## Architecture
 
@@ -134,7 +134,7 @@ Unit tests under `tests/unit/**` (Vitest, AWS SDK mocked via `vi.mock()`). Integ
 
 ## Known Limitations
 
-- NOT recommended for production use
+- Not yet production-ready — use the AWS CDK CLI for production workloads (see "Important Notes" above)
 
 **Recently Implemented**: per-PR shipped-feature notes moved to
 [docs/changelog-cdkd.md](docs/changelog-cdkd.md). Past entries are preserved


### PR DESCRIPTION
## Summary

CLAUDE.md "Important Notes" carried the early "Educational / experimental project" + "NOT intended as a replacement" framing, while README.md has evolved into the more accurate "complements CDK CLI for dev/test + bidirectional CloudFormation migration" framing. This PR aligns the two so the developer-facing CLAUDE.md and the user-facing README describe cdkd's positioning consistently.

## Diff

```diff
 **Important Notes**:

-- NOT recommended for production use (development/testing environments only)
-- Educational and experimental project
-- NOT intended as a replacement for the official AWS CDK CLI
+- For dev/test workflows only — early in development, not yet production-ready
+- Complements the AWS CDK CLI rather than replacing it (use CDK CLI in production for full CloudFormation tooling)
+- Bidirectional CloudFormation migration via `cdkd import --migrate-from-cloudformation` / `cdkd export`
```

Plus a matching update to the `## Known Limitations` section:

```diff
 ## Known Limitations

-- NOT recommended for production use
+- Not yet production-ready — use the AWS CDK CLI for production workloads (see "Important Notes" above)
```

## What stays the same

- The opening paragraph still calls cdkd "experimental" — that label remains technically accurate for the developer-facing CLAUDE.md (cdkd bypasses CloudFormation, which IS an experimental design choice). README's user-facing framing has moved on but the developer-internal CLAUDE.md preserves the implementation reality.
- 208-line CLAUDE.md size is unchanged.
- Workflow Rules, State Schema, Provider Pattern, all other sections untouched.

## Clarifying "bidirectional"

To be precise: "bidirectional" here means **cdkd ↔ CloudFormation**:

- `cdkd import --migrate-from-cloudformation` adopts a CFn-managed stack into cdkd state.
- `cdkd export` hands a cdkd-managed stack back to CloudFormation.

This is NOT a "migrate to production" statement — production worthiness is orthogonal to which tool owns the stack at a given moment.

## Test plan

- [x] `wc -l CLAUDE.md` still 208.
- [ ] CI green.
- [ ] Confirm README's `## Quick start` / opening section and CLAUDE.md `## Project Overview` / `## Important Notes` describe cdkd consistently.

## Related

- PR #532 — the 208-line trim (this is incremental on top)
- PR #534 / #535 — nit + scope follow-ups
