### PR TITLE
fix(local): post-#524 WebSocket audit follow-ups

### DIFF
--- a/docs/design/462-websocket-api.md
+++ b/docs/design/462-websocket-api.md
@@ -28,7 +28,7 @@ Make `AWS::ApiGatewayV2::Api` with `ProtocolType: 'WEBSOCKET'` invocable by `cdk
 - **WebSocket API authorizers** (Lambda + IAM + Cognito on `$connect`) — sibling sub-item like REST/HTTP authorizers (issue #234's WebSocket-equivalent follow-up). Will land in a `cdkd local start-api` PR8b-WebSocket-equivalent.
 - **Connection-ID stability across server restarts** — every restart is a fresh registry; same ephemeral-pool semantics as RIE container restarts. AWS-side connection IDs are opaque and randomly-generated per connection, so the spec doesn't promise stability either.
 - **Connection-level rate limits / message-size limits** — AWS enforces 32KB frame / 128KB message / 2hr idle disconnect; local enforces none. Add an opt-in `--ws-strict-limits` later if real workloads hit this.
-- **`apigatewaymanagementapi:GetConnection` / `DeleteConnection`** — low-priority API surface; add incrementally once `PostToConnection` is solid.
+- ~~**`apigatewaymanagementapi:GetConnection` / `DeleteConnection`** — low-priority API surface; add incrementally once `PostToConnection` is solid.~~ **Shipped in PR #524**: `GET /@connections/<id>` returns AWS-shape `{ConnectedAt, Identity, LastActiveAt}` (LastActiveAt = current time — the local server doesn't track per-message activity), `DELETE /@connections/<id>` force-closes via `ws.close(1000)` and reuses the standard close listener to fire `$disconnect`. Implementation in [src/local/websocket-mgmt-api.ts](../../src/local/websocket-mgmt-api.ts).
 - **`@request.header.*` / `@request.querystring.*` route-selection expressions** — non-body-driven selection; defer to a follow-up after observing how often real apps use it.
 
 ### Won't do
@@ -204,8 +204,8 @@ The AWS `apigatewaymanagementapi` lets handlers push messages back to connected 
 
 ```
 POST /@connections/<connectionId>      -> send message
-GET  /@connections/<connectionId>      -> get connection metadata (out of scope v1)
-DELETE /@connections/<connectionId>    -> force-disconnect (out of scope v1)
+GET  /@connections/<connectionId>      -> get connection metadata (shipped in PR #524)
+DELETE /@connections/<connectionId>    -> force-disconnect (shipped in PR #524)
 ```
 
 The endpoint URL pattern is `https://<api-id>.execute-api.<region>.amazonaws.com/<stage>`. Three intercept strategies were considered:

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -48,6 +48,7 @@ import {
   handleManagementRequest,
   type AttachedWebSocketServer,
 } from '../../local/websocket-server.js';
+import { buildMgmtEndpointEnvUrl } from '../../local/websocket-mgmt-api.js';
 import { warnSsrfRiskyUri } from '../../local/rest-v1-integrations.js';
 import {
   createContainerPool,
@@ -785,7 +786,7 @@ async function localStartApiCommand(
     // The pre-fix endpoint dropped `/${stage}` and any SDK call
     // that included the stage segment hit a 404 against the local
     // parser.
-    const mgmtEndpoint = `http://host.docker.internal:${started.port}/${api.stage}`;
+    const mgmtEndpoint = buildMgmtEndpointEnvUrl('host.docker.internal', started.port, api.stage);
     const hostGatewayMapping: { host: string; ip: string }[] = [
       { host: 'host.docker.internal', ip: 'host-gateway' },
     ];

--- a/src/local/websocket-body.ts
+++ b/src/local/websocket-body.ts
@@ -1,0 +1,32 @@
+/**
+ * Convert a ws-emitted message buffer into the AWS-canonical event
+ * body + `isBase64Encoded` discriminator. Text frames (opcode 0x1) pass
+ * through as UTF-8 with `isBase64Encoded: false`; binary frames
+ * (opcode 0x2) are base64-encoded with `isBase64Encoded: true`. Matches
+ * AWS-deployed WebSocket API event shape exactly — handlers decode via
+ * `Buffer.from(event.body, event.isBase64Encoded ? 'base64' : 'utf8')`.
+ *
+ * Closes the data-integrity bug where every byte > 0x7F on a binary
+ * frame was silently corrupted by handlers that trusted the previously
+ * hardcoded `isBase64Encoded: false` flag and UTF-8-decoded the
+ * base64-encoded body.
+ *
+ * Lives in its own module so the B4 regression test can install a
+ * `vi.fn()` spy that intercepts EVERY call — same-module references in
+ * `websocket-server.ts` would bypass the export-binding spy. See
+ * Issue #537 item 6.
+ */
+export function bufferToBody(
+  raw: Buffer | ArrayBuffer | Buffer[],
+  isBinary: boolean
+): { body: string; isBase64Encoded: boolean } {
+  const buf: Buffer = Array.isArray(raw)
+    ? Buffer.concat(raw)
+    : Buffer.isBuffer(raw)
+      ? raw
+      : Buffer.from(raw);
+  if (isBinary) {
+    return { body: buf.toString('base64'), isBase64Encoded: true };
+  }
+  return { body: buf.toString('utf-8'), isBase64Encoded: false };
+}

--- a/src/local/websocket-mgmt-api.ts
+++ b/src/local/websocket-mgmt-api.ts
@@ -120,6 +120,25 @@ export function parseConnectionsPath(url: string): {
 }
 
 /**
+ * Build the per-Lambda env-var URL the cdkd local server injects as
+ * `AWS_ENDPOINT_URL_APIGATEWAYMANAGEMENTAPI`. The URL MUST include the
+ * `/<stage>` segment to mirror the AWS-deployed apigatewaymanagementapi
+ * endpoint `https://<api-id>.execute-api.<region>.amazonaws.com/<stage>`:
+ * SDK clients built from `domainName + stage` produce
+ * `POST /<stage>/@connections/<id>`, and the local `parseConnectionsPath`
+ * regex above requires the matching prefix. Without `/<stage>` the
+ * deployed-shape SDK call hits a 404 against the local parser
+ * (BLOCKER B1, #526).
+ *
+ * Lives next to `parseConnectionsPath` so the producer + consumer of
+ * the URL shape stay in lockstep — change one, the other's tests fail.
+ * Issue #537 item 7.
+ */
+export function buildMgmtEndpointEnvUrl(host: string, port: number, stage: string): string {
+  return `http://${host}:${port}/${stage}`;
+}
+
+/**
  * `decodeURIComponent` throws `URIError` on malformed input
  * (`%`-escape with non-hex tail). We treat that as a not-found rather
  * than a server error — symmetric with AWS-deployed behavior, which

--- a/src/local/websocket-route-discovery.ts
+++ b/src/local/websocket-route-discovery.ts
@@ -242,11 +242,27 @@ function collectAuthRoutesForApi(
     const parentRef = pickRefLogicalId(props['ApiId']);
     if (parentRef !== apiLogicalId) continue;
     const authType = props['AuthorizationType'];
-    if (typeof authType !== 'string' || authType.length === 0) continue;
-    if (authType === 'NONE') continue;
+    // AWS-default when omitted is `NONE`. An absent property is the
+    // only safe pass-through path.
+    if (authType === undefined) continue;
     const routeKey = props['RouteKey'];
+    const routeKeyForReport = typeof routeKey === 'string' ? routeKey : '<unknown>';
+    // Fail-closed on any shape we cannot positively prove is `'NONE'`:
+    // empty string, `null`, intrinsic-valued (`{Ref: ...}` / `{Fn::Sub: ...}`
+    // / other object), or numeric. Silently admitting an
+    // intrinsic-valued `AuthorizationType` would re-introduce the
+    // pre-fix BLOCKER-B2 security gap for the uncommon-but-valid CDK
+    // path that passes a context value through.
+    if (typeof authType !== 'string' || authType.length === 0) {
+      result.push({
+        routeKey: routeKeyForReport,
+        authorizationType: '<intrinsic-or-malformed>',
+      });
+      continue;
+    }
+    if (authType === 'NONE') continue;
     result.push({
-      routeKey: typeof routeKey === 'string' ? routeKey : '<unknown>',
+      routeKey: routeKeyForReport,
       authorizationType: authType,
     });
   }

--- a/src/local/websocket-server.ts
+++ b/src/local/websocket-server.ts
@@ -21,6 +21,11 @@ import {
 } from './websocket-mgmt-api.js';
 import type { DiscoveredWebSocketApi } from './websocket-route-discovery.js';
 import { parseSelectionExpressionPath } from './websocket-route-discovery.js';
+// Namespaced import so the B4 regression test (Issue #537 item 6) can
+// spy on `bufferToBody` and intercept every internal call. A direct
+// `import { bufferToBody }` would bind to a local reference the test
+// spy cannot reach.
+import * as websocketBody from './websocket-body.js';
 
 /**
  * Wire a WebSocket API into a long-lived `node:http`'s `upgrade`
@@ -171,6 +176,13 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
   // no `bufferToBody` allocation work — and cap the buffer length at
   // this number. Excess frames are dropped (a warn line names the
   // overflow once per connection).
+  //
+  // Trade-off: 100 frames × ~4 KiB typical text frame ≈ ~400 KiB upper
+  // bound per connection (~40 MiB for the default 100-server total) —
+  // small enough that an attacker cannot exhaust memory by opening many
+  // connections, large enough that a legitimate burst client (e.g. a
+  // chat UI sending its initial state on connect) absorbs ~1s of
+  // pre-verdict traffic at typical 100 frame/s rates without dropping.
   const MAX_PRE_VERDICT_FRAMES = 100;
 
   // Per-connection driver. The lifecycle is:
@@ -221,7 +233,7 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
         if (!preVerdictOverflow) {
           preVerdictOverflow = true;
           logger.warn(
-            `WebSocket connection ${connectionId}: pre-verdict message buffer overflowed (>${MAX_PRE_VERDICT_FRAMES} frames). Excess frames dropped — client is sending faster than the $connect handler can resolve.`
+            `WebSocket connection ${connectionId}: pre-verdict message buffer overflowed (>${MAX_PRE_VERDICT_FRAMES} frames). Excess frames dropped — client is sending faster than the $connect handler can resolve. (api=${cfg.api.declaredAt})`
           );
         }
         return;
@@ -300,7 +312,7 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
     // Attach the real listeners NOW. From this point forward, the
     // standard dispatch path runs for every incoming frame.
     ws.on('message', (raw, isBinary) => {
-      const { body, isBase64Encoded } = bufferToBody(raw, isBinary);
+      const { body, isBase64Encoded } = websocketBody.bufferToBody(raw, isBinary);
       logger.debug(
         `WebSocket message received for connection ${connectionId}: ${body.slice(0, 200)}`
       );
@@ -343,7 +355,7 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
     // bufferToBody allocation runs here (post-admit, bounded count)
     // not at frame-receive time (pre-admit, unbounded by attacker).
     for (const frame of preVerdictFrames) {
-      const { body, isBase64Encoded } = bufferToBody(frame.raw, frame.isBinary);
+      const { body, isBase64Encoded } = websocketBody.bufferToBody(frame.raw, frame.isBinary);
       void dispatchMessage(connectionId, cfg, body, isBase64Encoded, handshakeSnapshot).catch(
         (err) => {
           logger.error(
@@ -642,30 +654,9 @@ function safeDecode(s: string): string | null {
   }
 }
 
-/**
- * Convert a ws-emitted message buffer into the AWS-canonical event
- * body + `isBase64Encoded` discriminator. Text frames (opcode 0x1) pass
- * through as UTF-8 with `isBase64Encoded: false`; binary frames
- * (opcode 0x2) are base64-encoded with `isBase64Encoded: true`. Matches
- * AWS-deployed WebSocket API event shape exactly — handlers decode via
- * `Buffer.from(event.body, event.isBase64Encoded ? 'base64' : 'utf8')`.
- *
- * Closes the data-integrity bug where every byte > 0x7F on a binary
- * frame was silently corrupted by handlers that trusted the previously
- * hardcoded `isBase64Encoded: false` flag and UTF-8-decoded the
- * base64-encoded body.
- */
-export function bufferToBody(
-  raw: Buffer | ArrayBuffer | Buffer[],
-  isBinary: boolean
-): { body: string; isBase64Encoded: boolean } {
-  const buf: Buffer = Array.isArray(raw)
-    ? Buffer.concat(raw)
-    : Buffer.isBuffer(raw)
-      ? raw
-      : Buffer.from(raw);
-  if (isBinary) {
-    return { body: buf.toString('base64'), isBase64Encoded: true };
-  }
-  return { body: buf.toString('utf-8'), isBase64Encoded: false };
-}
+// `bufferToBody` lives in `./websocket-body.ts` and is re-exported here
+// so existing callers (and the existing test surface) continue to read
+// from `websocket-server.js`. The internal callers below import via the
+// `* as websocketBody` namespace so the B4 regression test can spy on
+// the export and intercept every internal call — Issue #537 item 6.
+export { bufferToBody } from './websocket-body.js';

--- a/tests/unit/local/websocket-mgmt-api.test.ts
+++ b/tests/unit/local/websocket-mgmt-api.test.ts
@@ -3,6 +3,7 @@ import { IncomingMessage, ServerResponse } from 'node:http';
 import { Socket } from 'node:net';
 import { EventEmitter } from 'node:events';
 import {
+  buildMgmtEndpointEnvUrl,
   ConnectionRegistry,
   handleConnectionsRequest,
   parseConnectionsPath,
@@ -146,6 +147,53 @@ describe('parseConnectionsPath', () => {
     // Two segments before @connections — would match if regex allowed
     // greedy prefixes, but we only accept ONE optional segment.
     expect(parseConnectionsPath('/v1/prod/@connections/abc')).toBeNull();
+  });
+
+  // Issue #537 item 9: B1 regex edge cases. These all flow through
+  // `^/(?:[^/]+/)?@connections/([^/]+)/?$` — pin the behavior so a
+  // regex rewrite in the future surfaces the change in CI.
+  it('rejects double-slash before @connections (empty stage segment)', () => {
+    // `//@connections/abc` reads as stage='' under a permissive prefix.
+    // Our regex requires `[^/]+/` (>=1 char) so this correctly fails.
+    expect(parseConnectionsPath('//@connections/abc')).toBeNull();
+  });
+  it('rejects a trailing path segment after the connection id', () => {
+    // `/@connections/abc/extra` — the trailing `/extra` is unknown to
+    // the AWS API plane and must not be silently truncated.
+    expect(parseConnectionsPath('/@connections/abc/extra')).toBeNull();
+    expect(parseConnectionsPath('/prod/@connections/abc/extra')).toBeNull();
+  });
+  it('matches a single trailing slash with no stage prefix', () => {
+    // Already covered above; pinned here as a sibling assertion to the
+    // stage-prefix + trailing-slash test for the no-stage form.
+    expect(parseConnectionsPath('/@connections/abc/')).toEqual({ connectionId: 'abc' });
+  });
+});
+
+// Issue #537 item 7: assert the Lambda-container env-var URL includes
+// `/<stage>`. The pre-fix CLI dropped the stage segment and any
+// SDK-built `POST /<stage>/@connections/<id>` hit a 404 against the
+// local parser. Producer (this helper) + consumer
+// (parseConnectionsPath) live in lockstep — a regression here would
+// re-introduce the 404.
+describe('buildMgmtEndpointEnvUrl', () => {
+  it('produces http://<host>:<port>/<stage> with the stage suffix', () => {
+    expect(buildMgmtEndpointEnvUrl('host.docker.internal', 4001, 'prod')).toBe(
+      'http://host.docker.internal:4001/prod'
+    );
+  });
+  it('does NOT drop the stage suffix (B1 #526 regression guard)', () => {
+    const url = buildMgmtEndpointEnvUrl('host.docker.internal', 4001, 'prod');
+    expect(url.endsWith('/prod')).toBe(true);
+  });
+  it('output is parseable end-to-end by parseConnectionsPath', () => {
+    // Simulate the round-trip: SDK builds the per-connection URL from
+    // the env-var endpoint + the AWS-deployed shape; the local server
+    // must accept it. Pins the producer/consumer contract on one test.
+    const env = buildMgmtEndpointEnvUrl('host.docker.internal', 4001, 'prod');
+    const stagePath = new URL(env).pathname; // '/prod'
+    const sdkPath = `${stagePath}/@connections/conn-1`; // '/prod/@connections/conn-1'
+    expect(parseConnectionsPath(sdkPath)).toEqual({ connectionId: 'conn-1' });
   });
 });
 

--- a/tests/unit/local/websocket-route-discovery.test.ts
+++ b/tests/unit/local/websocket-route-discovery.test.ts
@@ -451,6 +451,78 @@ describe('discoverWebSocketApis B2 authorizer admission guard', () => {
     expect(reason).toContain('$default [AuthorizationType=CUSTOM]');
   });
 
+  // Issue #537 item 8: defense-in-depth for AuthorizationType shapes that
+  // are neither the literal `'NONE'` string nor `undefined`. Includes
+  // typo'd known names, hypothetical future AWS additions, and the
+  // intrinsic-valued / structurally-malformed shapes from item 1.
+  it('tags API as unsupported for typo\'d AuthorizationType (IAM, not AWS_IAM)', () => {
+    const { apis } = discoverWebSocketApis([buildAuthApi('IAM')]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('IAM');
+  });
+  it('tags API as unsupported for hypothetical future AuthorizationType (LAMBDA)', () => {
+    const { apis } = discoverWebSocketApis([buildAuthApi('LAMBDA')]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('LAMBDA');
+  });
+  it('tags API as unsupported when AuthorizationType is `null` (fail-closed)', () => {
+    const stack = buildStack('NullAuth', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: {
+          ProtocolType: 'WEBSOCKET',
+          Name: 'WsApi',
+          RouteSelectionExpression: '$request.body.action',
+        },
+      },
+      ConnectIntegration: buildIntegration(),
+      ConnectRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: 'integrations/ConnectIntegration',
+          AuthorizationType: null,
+        },
+      },
+    });
+    const { apis } = discoverWebSocketApis([stack]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('<intrinsic-or-malformed>');
+  });
+  it('tags API as unsupported when AuthorizationType is an empty string (fail-closed)', () => {
+    const { apis } = discoverWebSocketApis([buildAuthApi('')]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('<intrinsic-or-malformed>');
+  });
+  it('tags API as unsupported when AuthorizationType is an intrinsic ({Ref}) — defense-in-depth', () => {
+    const stack = buildStack('RefAuth', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: {
+          ProtocolType: 'WEBSOCKET',
+          Name: 'WsApi',
+          RouteSelectionExpression: '$request.body.action',
+        },
+      },
+      ConnectIntegration: buildIntegration(),
+      ConnectRoute: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: 'integrations/ConnectIntegration',
+          AuthorizationType: { Ref: 'AuthTypeParam' },
+        },
+      },
+    });
+    const { apis } = discoverWebSocketApis([stack]);
+    expect(apis[0]!.unsupported).toBeDefined();
+    expect(apis[0]!.unsupported!.reason).toContain('<intrinsic-or-malformed>');
+  });
+
   it('does NOT tag the API when only $disconnect / non-$connect routes have NONE auth', () => {
     const stack = buildStack('S', {
       MyHandler: buildLambda(),

--- a/tests/unit/local/websocket-server.test.ts
+++ b/tests/unit/local/websocket-server.test.ts
@@ -8,6 +8,11 @@ import {
   bufferToBody,
   type AttachOptions,
 } from '../../../src/local/websocket-server.js';
+// Namespace import so vi.spyOn(websocketBody, 'bufferToBody') intercepts
+// the same export the production code reads via its namespace import
+// (Issue #537 item 6).
+import * as websocketBody from '../../../src/local/websocket-body.js';
+import { ConsoleLogger } from '../../../src/utils/logger.js';
 import type { DiscoveredWebSocketApi } from '../../../src/local/websocket-route-discovery.js';
 import type { ContainerPool, ContainerHandle } from '../../../src/local/container-pool.js';
 
@@ -119,6 +124,21 @@ function awaitClose(ws: WebSocket): Promise<{ code: number; reason: string }> {
   return new Promise((resolve) => {
     ws.once('close', (code, reason) => resolve({ code, reason: reason.toString('utf-8') }));
   });
+}
+
+/**
+ * Poll `predicate` every 10ms until it returns true or `timeoutMs`
+ * elapses. Resolves either way; the caller checks the spied mock to
+ * decide pass/fail. Replaces fixed `setTimeout(r, 100)` waits with a
+ * race-free wait — under CI load the 100ms budget can be exhausted by
+ * scheduler jitter (Issue #537 item 11).
+ */
+async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
 }
 
 describe('attachWebSocketServer end-to-end', () => {
@@ -419,6 +439,23 @@ describe('bufferToBody (B3 regression guard)', () => {
       isBase64Encoded: false,
     });
   });
+
+  // Issue #537 item 10: zero-byte binary frame should produce
+  // `{body: '', isBase64Encoded: true}` (NOT throw, NOT silently coerce
+  // to text). Empty Buffers come up in WebSocket protocols that use a
+  // zero-length frame as a sentinel.
+  it('returns empty body + isBase64Encoded=true for zero-byte binary frames', () => {
+    expect(bufferToBody(Buffer.from([]), true)).toEqual({
+      body: '',
+      isBase64Encoded: true,
+    });
+  });
+  it('returns empty body + isBase64Encoded=false for zero-byte text frames', () => {
+    expect(bufferToBody(Buffer.from([]), false)).toEqual({
+      body: '',
+      isBase64Encoded: false,
+    });
+  });
 });
 
 // B3 (#526) end-to-end: binary frames must surface as
@@ -449,7 +486,10 @@ describe('binary frame dispatch (B3 end-to-end)', () => {
       // Send a binary frame containing non-ASCII bytes.
       const binaryPayload = Buffer.from([0xff, 0xfe, 0x80, 0x42, 0x00]);
       ws.send(binaryPayload, { binary: true });
-      await new Promise((r) => setTimeout(r, 100));
+      // Poll for the $default dispatch (Issue #537 item 11 — replaces
+      // a fixed 100ms setTimeout that CI scheduler jitter could
+      // exhaust). 1000ms ceiling matches the issue's recommendation.
+      await waitFor(() => rieModule.invokeRie.mock.calls.length >= 2);
       // 2 invokeRie calls: $connect + $default (binary message).
       expect(rieModule.invokeRie).toHaveBeenCalledTimes(2);
       const messageCall = rieModule.invokeRie.mock.calls.at(-1) as any;
@@ -484,7 +524,8 @@ describe('binary frame dispatch (B3 end-to-end)', () => {
     try {
       const ws = await openWebSocket(port, '/prod');
       ws.send('{"action":"unknown","text":"hello"}'); // text frame
-      await new Promise((r) => setTimeout(r, 100));
+      // Poll until $default dispatch lands (Issue #537 item 11).
+      await waitFor(() => rieModule.invokeRie.mock.calls.length >= 2);
       const messageCall = rieModule.invokeRie.mock.calls.at(-1) as any;
       expect(messageCall[2].isBase64Encoded).toBe(false);
       expect(messageCall[2].body).toBe('{"action":"unknown","text":"hello"}');
@@ -517,6 +558,13 @@ describe('$connect-deny listener safety (B4 regression guard)', () => {
       apis: [{ api, apiPath: '/prod' }],
       pool,
     });
+
+    // Issue #537 item 6: install a spy on the bufferToBody export the
+    // production code reads via its namespace import. A frame that
+    // arrived during the close-handshake window MUST NOT reach
+    // bufferToBody — the pre-fix bug was the listener allocating
+    // Buffer.toString output on every frame even after deny.
+    const bodySpy = vi.spyOn(websocketBody, 'bufferToBody');
     try {
       // Connect with an immediate send race; the client gets denied
       // but might fire send before the close lands.
@@ -546,8 +594,135 @@ describe('$connect-deny listener safety (B4 regression guard)', () => {
       expect(rieModule.invokeRie).toHaveBeenCalledTimes(1);
       const onlyCall = rieModule.invokeRie.mock.calls[0] as any;
       expect(onlyCall[2].requestContext.routeKey).toBe('$connect');
+      // Item 6 assertion: bufferToBody was never called for any of the
+      // denied frames. The pre-listener stores raw refs ONLY; no
+      // allocation work runs until the admit path (which we never
+      // reached). Pins the structural fix.
+      expect(bodySpy).not.toHaveBeenCalled();
     } finally {
+      bodySpy.mockRestore();
       await close();
+    }
+  });
+
+  // Issue #537 item 4: send >MAX_PRE_VERDICT_FRAMES (100) frames during
+  // the pre-verdict window with an ADMIT verdict. Assert (a) the warn
+  // line fires exactly once, (b) the connection still completes, (c)
+  // dispatch volume is capped at 100 — frames beyond the cap are
+  // silently dropped (verified via the warn-fires-once assertion).
+  it('drops frames past MAX_PRE_VERDICT_FRAMES with a single warn on admit', async () => {
+    rieModule.__resetQueue();
+
+    // Delay the $connect verdict so the client can spam frames.
+    let releaseConnect: (() => void) | null = null;
+    rieModule.invokeRie.mockImplementationOnce(async () => {
+      await new Promise<void>((r) => {
+        releaseConnect = r;
+      });
+      return { payload: { statusCode: 200 }, raw: '{"statusCode":200}' };
+    });
+    // Queue 100 $default responses for the buffered drain (cap = 100).
+    for (let i = 0; i < 100; i += 1) {
+      rieModule.__queueInvokeResult({});
+    }
+
+    const pool = buildFakePool();
+    const api = buildApi([
+      { routeKey: '$connect', lambda: 'ConnectFn' },
+      { routeKey: '$default', lambda: 'DefaultFn' },
+    ]);
+    const { port, close } = await startTestServer({
+      apis: [{ api, apiPath: '/prod' }],
+      pool,
+    });
+    const warnSpy = vi.spyOn(ConsoleLogger.prototype, 'warn');
+    try {
+      const ws = await openWebSocket(port, '/prod');
+      // Spam 150 frames during the pre-verdict await window.
+      for (let i = 0; i < 150; i += 1) {
+        ws.send(`frame-${i}`);
+      }
+      // Wait for the server to receive all 150 frames before releasing
+      // the verdict.
+      await new Promise((r) => setTimeout(r, 100));
+      releaseConnect?.();
+      // Wait for $connect + drain to settle (101 invokeRie calls expected).
+      await waitFor(() => rieModule.invokeRie.mock.calls.length >= 101);
+      // The cap is enforced: only 100 buffered frames drained, NOT 150.
+      // Cap = 100, plus 1 for $connect, total 101.
+      expect(rieModule.invokeRie).toHaveBeenCalledTimes(101);
+      // The warn line for the buffer-overflow fires exactly once.
+      const overflowWarns = warnSpy.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].includes('pre-verdict message buffer overflowed')
+      );
+      expect(overflowWarns).toHaveLength(1);
+      // Item 3 follow-up: the warn line carries the API's declaredAt.
+      expect(overflowWarns[0]![0]).toContain('api=S/WsApi');
+      ws.close();
+      await awaitClose(ws);
+    } finally {
+      warnSpy.mockRestore();
+      await close();
+    }
+  });
+
+  // Issue #537 item 5: $connect verdict resolves AFTER the client has
+  // already disconnected. The post-await `ws.readyState !== OPEN`
+  // branch must (a) skip registry insertion, (b) skip $disconnect
+  // Lambda dispatch (no listeners were attached pre-await, so 'close'
+  // never fired into onDisconnect).
+  it('skips registration + $disconnect when client closes during $connect await', async () => {
+    rieModule.__resetQueue();
+    // Delay the $connect verdict so the client can disconnect first.
+    let releaseConnect: (() => void) | null = null;
+    rieModule.invokeRie.mockImplementationOnce(async () => {
+      await new Promise<void>((r) => {
+        releaseConnect = r;
+      });
+      return { payload: { statusCode: 200 }, raw: '{"statusCode":200}' };
+    });
+
+    const pool = buildFakePool();
+    const api = buildApi([
+      { routeKey: '$connect', lambda: 'ConnectFn' },
+      { routeKey: '$disconnect', lambda: 'DisconnectFn' },
+    ]);
+    const server = createServer((_req, res) => {
+      res.statusCode = 404;
+      res.end();
+    });
+    const attached = attachWebSocketServer({
+      httpServer: server,
+      apis: [{ api, apiPath: '/prod' }],
+      pool,
+      rieTimeoutMs: 2000,
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    try {
+      const ws = await openWebSocket(port, '/prod');
+      // Client disconnects WHILE the verdict is still pending.
+      ws.close(1000, 'client-gone');
+      await awaitClose(ws);
+      // Wait briefly for the close to flush through the server.
+      await new Promise((r) => setTimeout(r, 50));
+      // Now release the $connect verdict — the post-await branch
+      // should observe readyState !== OPEN and bail.
+      releaseConnect?.();
+      // Give the post-await branch a tick to run.
+      await new Promise((r) => setTimeout(r, 100));
+      // (a) Registry has no entry — the connection was never registered.
+      expect(attached.registry.size()).toBe(0);
+      // (b) $disconnect Lambda was NEVER invoked: only $connect ran.
+      expect(rieModule.invokeRie).toHaveBeenCalledTimes(1);
+      const onlyCall = rieModule.invokeRie.mock.calls[0] as any;
+      expect(onlyCall[2].requestContext.routeKey).toBe('$connect');
+    } finally {
+      await attached.close();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        server.closeAllConnections?.();
+      });
     }
   });
 });


### PR DESCRIPTION
## Summary

Post-#524 WebSocket audit residue from the 3-axis review (spec / code / test). PR #524 shipped with BLOCKERS fixed in commit `d0530d9` plus a 3-axis post-fix sign-off where each reviewer surfaced minor / nit items and deferred them to keep the merge scope tight. This PR bundles those 12 items.

Closes #537.

### Security defense-in-depth

1. `collectAuthRoutesForApi`: non-string `AuthorizationType` shapes (`{Ref: 'param'}`, `null`, empty string) now fail-closed and tag the API as unsupported with `<intrinsic-or-malformed>` in the reason. Pre-fix the route was silently treated as `NONE` — same class of gap as BLOCKER B2 closed for plain `'AWS_IAM'` / `'CUSTOM'` strings.

### Robustness comments

2. `MAX_PRE_VERDICT_FRAMES = 100` now has an inline trade-off comment (100 frames × ~4 KiB ≈ ~400 KiB per connection vs ~1s burst-client allowance during $connect handshake).
3. Pre-verdict buffer-overflow warn line now appends the API's `declaredAt` so multi-API setups can triage which API saw the overflow.

### Test coverage gaps

4. New 150-frame overflow test: spam frames during the pre-verdict await window, assert the cap is enforced (100 dispatch calls, not 150), the warn fires exactly once, and the API context is present in the warn line.
5. New `readyState !== OPEN` post-await test: $connect verdict resolves AFTER the client disconnects mid-await; assert no registry insertion + no $disconnect Lambda dispatch.
6. B4 regression test extended with a `vi.spyOn(bufferToBody)` assertion of zero calls. Required extracting `bufferToBody` into its own `src/local/websocket-body.ts` module so the spy on the exported binding intercepts the internal namespace import — a same-module direct call (the prior shape) would bypass the spy and the assertion would trivially pass.
7. `buildMgmtEndpointEnvUrl` helper extracted to `src/local/websocket-mgmt-api.ts` so the producer (CLI env-var override) and consumer (`parseConnectionsPath`) of the `/<stage>/@connections/<id>` shape stay in lockstep. New unit tests pin the `/${api.stage}` suffix and the end-to-end round-trip via `parseConnectionsPath`.
8. New AuthorizationType edge-case tests: typo'd `'IAM'`, hypothetical future `'LAMBDA'`, `null`, empty string, and `{Ref: 'AuthTypeParam'}` — all assert the API is tagged unsupported.
9. New `parseConnectionsPath` regex edge-case tests: `//@connections/abc` (empty stage segment), `/@connections/abc/extra` (trailing path), `/prod/@connections/abc/extra`, and the no-stage trailing-slash form. Pin behavior for future regex rewrites.
10. New zero-byte binary / text frame tests for `bufferToBody`: `Buffer.from([])` returns `{body: '', isBase64Encoded: <isBinary>}`.

### Test stability

11. B3 binary-frame e2e tests now poll for `invokeRie.mock.calls.length >= 2` with a 1000ms timeout instead of a fixed 100ms `setTimeout`. New `waitFor` helper at the top of the file. Reduces CI flake under scheduler jitter.

### Spec drift (informational)

12. Design doc `462-websocket-api.md` updated: `GetConnection` and `DeleteConnection` were marked "out of scope v1" but PR #524 shipped them. Both the "Out of scope" bullet and the `@connections` API table now reflect the shipped status.

## Notes

- All changes are isolated to `src/local/websocket-*` plus the test files. No CLI surface change. No new flag. No schema change.
- The `bufferToBody` extraction preserves the public export from `websocket-server.ts` via a re-export, so existing callers still read from the same path.
- `buildMgmtEndpointEnvUrl` replaces an inline string template at one CLI call site; the URL shape is unchanged.

## Test plan

- [x] Unit tests pass (351 files, 5072 tests; including the 14 new tests in this PR)
- [x] Integration test: `/run-integ local-start-api-websocket` — all 4 routes exercised end-to-end ($connect, $default, sendMessage, broadcast PostToConnection, $disconnect); zero Docker orphans after teardown
- [x] Documentation updated: `docs/design/462-websocket-api.md` reflects the shipped `GetConnection` / `DeleteConnection` endpoints
- [x] Live-test: WebSocket integ test exercised the actual mgmt-endpoint env URL injection + the parsed-connection-path round-trip end-to-end
