### PR TITLE
fix(local): WebSocket robustness MAJORs (#527)

### DIFF
--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -49,6 +49,7 @@ import {
   type AttachedWebSocketServer,
 } from '../../local/websocket-server.js';
 import { buildMgmtEndpointEnvUrl } from '../../local/websocket-mgmt-api.js';
+import { HOST_GATEWAY_MIN_VERSION, probeHostGatewaySupport } from '../../local/docker-version.js';
 import { warnSsrfRiskyUri } from '../../local/rest-v1-integrations.js';
 import {
   createContainerPool,
@@ -683,6 +684,42 @@ async function localStartApiCommand(
   const wsServers: BootedWebSocketServer[] = [];
   const initialWsApis = initialMaterial.webSocketApis ?? [];
   warnUnsupportedWebSocketApis(initialWsApis, logger);
+
+  // Issue #527 M2: probe Docker server version ONCE per session before
+  // any WebSocket API attaches. The `--add-host=host.docker.internal:host-gateway`
+  // mapping cdkd injects requires Docker 20.10+; older daemons silently
+  // fail with `ENOTFOUND host.docker.internal` at SDK-call time. Only
+  // probe when at least one ATTACHABLE WebSocket API exists — HTTP /
+  // REST-only sessions don't use the host-gateway mapping and shouldn't
+  // pay the docker subprocess hop. `unsupported`-tagged APIs are also
+  // skipped (they never enter the attach loop).
+  const attachableWsApis = initialWsApis.filter((api) => !api.unsupported);
+  if (attachableWsApis.length > 0) {
+    try {
+      const probe = await probeHostGatewaySupport();
+      if (!probe.supported) {
+        throw new Error(
+          `cdkd local start-api requires Docker ${HOST_GATEWAY_MIN_VERSION.major}.${HOST_GATEWAY_MIN_VERSION.minor}+ ` +
+            `for WebSocket API support (--add-host=host.docker.internal:host-gateway needs the 20.10 host-gateway alias). ` +
+            `Detected server version: ${probe.rawVersion || '<empty>'}. ` +
+            `Upgrade Docker, or remove the WebSocket API from this app to fall back to HTTP-only start-api.`
+        );
+      }
+      if (probe.parsed === null) {
+        logger.warn(
+          `Docker server version "${probe.rawVersion}" did not match the canonical "<major>.<minor>" shape; ` +
+            `assuming host-gateway support. If WebSocket containers fail to reach the local server, ` +
+            `verify your Docker-compatible CLI honors --add-host=host.docker.internal:host-gateway.`
+        );
+      }
+    } catch (err) {
+      // Re-throw with our wrapping intact for the "supported=false" case
+      // above; everything else (docker missing, daemon down) bubbles up
+      // with the docker-cmd helper's original message.
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
   for (const api of initialWsApis) {
     // Skip APIs flagged unsupported at discovery — typical cause is a
     // non-NONE `AuthorizationType` on `$connect` (cdkd v1 does not

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -695,28 +695,21 @@ async function localStartApiCommand(
   // skipped (they never enter the attach loop).
   const attachableWsApis = initialWsApis.filter((api) => !api.unsupported);
   if (attachableWsApis.length > 0) {
-    try {
-      const probe = await probeHostGatewaySupport();
-      if (!probe.supported) {
-        throw new Error(
-          `cdkd local start-api requires Docker ${HOST_GATEWAY_MIN_VERSION.major}.${HOST_GATEWAY_MIN_VERSION.minor}+ ` +
-            `for WebSocket API support (--add-host=host.docker.internal:host-gateway needs the 20.10 host-gateway alias). ` +
-            `Detected server version: ${probe.rawVersion || '<empty>'}. ` +
-            `Upgrade Docker, or remove the WebSocket API from this app to fall back to HTTP-only start-api.`
-        );
-      }
-      if (probe.parsed === null) {
-        logger.warn(
-          `Docker server version "${probe.rawVersion}" did not match the canonical "<major>.<minor>" shape; ` +
-            `assuming host-gateway support. If WebSocket containers fail to reach the local server, ` +
-            `verify your Docker-compatible CLI honors --add-host=host.docker.internal:host-gateway.`
-        );
-      }
-    } catch (err) {
-      // Re-throw with our wrapping intact for the "supported=false" case
-      // above; everything else (docker missing, daemon down) bubbles up
-      // with the docker-cmd helper's original message.
-      throw err instanceof Error ? err : new Error(String(err));
+    const probe = await probeHostGatewaySupport();
+    if (!probe.supported) {
+      throw new Error(
+        `cdkd local start-api requires Docker ${HOST_GATEWAY_MIN_VERSION.major}.${HOST_GATEWAY_MIN_VERSION.minor}+ ` +
+          `for WebSocket API support (--add-host=host.docker.internal:host-gateway needs the 20.10 host-gateway alias). ` +
+          `Detected server version: ${probe.rawVersion || '<empty — daemon unreachable or output stripped>'}. ` +
+          `Upgrade Docker, or remove the WebSocket API from this app to fall back to HTTP-only start-api.`
+      );
+    }
+    if (probe.parsed === null) {
+      logger.warn(
+        `Docker server version "${probe.rawVersion}" did not match the canonical "<major>.<minor>" shape; ` +
+          `assuming host-gateway support. If WebSocket containers fail to reach the local server, ` +
+          `verify your Docker-compatible CLI honors --add-host=host.docker.internal:host-gateway.`
+      );
     }
   }
 

--- a/src/local/docker-version.ts
+++ b/src/local/docker-version.ts
@@ -92,9 +92,21 @@ export async function probeHostGatewaySupport(): Promise<HostGatewayProbeResult>
   });
   const rawVersion = result.stdout.trim();
   const parsed = parseDockerVersion(rawVersion);
-  // Treat unparseable versions as "supported" — podman / finch /
-  // nerdctl emit version strings cdkd can't always compare against
-  // Docker's. Defer to the warn path rather than refuse the boot.
+  // Empty stdout is treated as `supported=false` — `docker version
+  // --format '{{.Server.Version}}'` returning an empty string is much
+  // more likely a broken probe (daemon unreachable, permission stripped
+  // output, format string mismatch on a forked CLI) than a podman /
+  // finch shape. Masking it as "unknown engine, proceed" would defeat
+  // the whole point of the probe — the caller's error path surfaces
+  // the empty string explicitly so the user can diagnose the
+  // underlying daemon failure. Surfaced by PR #539 review.
+  if (rawVersion === '') {
+    return { rawVersion, parsed: null, supported: false };
+  }
+  // Treat unparseable-but-non-empty versions as "supported" — podman /
+  // finch / nerdctl emit version strings cdkd can't always compare
+  // against Docker's. Defer to the warn path rather than refuse the
+  // boot.
   const supported = parsed === null || compareDockerVersions(parsed, HOST_GATEWAY_MIN_VERSION) >= 0;
   return { rawVersion, parsed, supported };
 }

--- a/src/local/docker-version.ts
+++ b/src/local/docker-version.ts
@@ -1,0 +1,100 @@
+import { runDockerStreaming } from '../utils/docker-cmd.js';
+
+/**
+ * Lower bound for `--add-host=<name>:host-gateway` support. The
+ * `host-gateway` magic alias was introduced in Docker 20.10 (October
+ * 2020) and is the load-bearing primitive cdkd uses to let Lambda
+ * containers reach the host's `cdkd local start-api` server on Linux
+ * native dockerd. Without it, the AWS_ENDPOINT_URL_APIGATEWAYMANAGEMENTAPI
+ * override fails with `ENOTFOUND host.docker.internal` at SDK-call time.
+ *
+ * Docker Desktop (macOS / Windows) ships `host.docker.internal` as
+ * a built-in alias regardless of the engine version, but the probe
+ * still fires there to keep the error path uniform — the `host-gateway`
+ * flag itself is harmless on Docker Desktop.
+ *
+ * Issue #527 M2.
+ */
+export const HOST_GATEWAY_MIN_VERSION: ParsedDockerVersion = { major: 20, minor: 10, patch: 0 };
+
+export interface ParsedDockerVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/**
+ * Parse a Docker server version string (`20.10.21` / `24.0.7-rd` /
+ * `27.3.1+podman` etc.) into a comparable `{major, minor, patch}` tuple.
+ * Returns `null` on any unparseable input — the caller treats that as
+ * "version unknown, skip the comparison and let the user proceed with
+ * a warn" rather than hard-failing on a Docker-compatible CLI binary
+ * that doesn't follow Docker's version-string conventions
+ * (e.g. podman / finch).
+ */
+export function parseDockerVersion(raw: string): ParsedDockerVersion | null {
+  const trimmed = raw.trim();
+  const match = /^(\d+)\.(\d+)(?:\.(\d+))?/.exec(trimmed);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: match[3] !== undefined ? Number(match[3]) : 0,
+  };
+}
+
+/**
+ * Compare two `ParsedDockerVersion` tuples. Returns negative when `a <
+ * b`, zero when equal, positive when `a > b`. Patch-level differences
+ * are part of the ordering so a future bump (e.g. 20.10.0 -> 20.10.5
+ * to fix a CVE-related regression) can be expressed if needed.
+ */
+export function compareDockerVersions(a: ParsedDockerVersion, b: ParsedDockerVersion): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+}
+
+export interface HostGatewayProbeResult {
+  /** Reported Docker server version string ("20.10.21" / "27.3.1" / etc.). */
+  rawVersion: string;
+  /** Parsed tuple, `null` when the raw string didn't match `<int>.<int>(.<int>)?`. */
+  parsed: ParsedDockerVersion | null;
+  /**
+   * `true` when the parsed version is ≥ {@link HOST_GATEWAY_MIN_VERSION}
+   * (or `null` parsed — see {@link parseDockerVersion} for the
+   * unknown-version policy: defer to the warn path rather than hard-fail).
+   */
+  supported: boolean;
+}
+
+/**
+ * Probe the Docker server's version to gate the `--add-host=...:host-gateway`
+ * mapping that WebSocket Lambda containers need to reach the host
+ * server. Issued ONCE per `cdkd local start-api` invocation at WebSocket
+ * attach time — HTTP-only / REST-only sessions skip the probe entirely.
+ *
+ * Throws when:
+ *   1. The docker subprocess itself fails (binary missing, daemon down,
+ *      permission error) — the caller's catch surfaces the original
+ *      error so the user knows to install / start Docker.
+ *   2. The probe succeeds but the parsed version is < the supported
+ *      minimum — caller decides whether to error or warn (the WebSocket
+ *      attach loop errors; HTTP-only sessions never call this).
+ *
+ * Implementation: `docker version --format '{{.Server.Version}}'`
+ * returns the daemon's version (not the client's) so a brand-new
+ * client against an old daemon is still caught.
+ */
+export async function probeHostGatewaySupport(): Promise<HostGatewayProbeResult> {
+  const result = await runDockerStreaming(['version', '--format', '{{.Server.Version}}'], {
+    streamLive: false,
+  });
+  const rawVersion = result.stdout.trim();
+  const parsed = parseDockerVersion(rawVersion);
+  // Treat unparseable versions as "supported" — podman / finch /
+  // nerdctl emit version strings cdkd can't always compare against
+  // Docker's. Defer to the warn path rather than refuse the boot.
+  const supported = parsed === null || compareDockerVersions(parsed, HOST_GATEWAY_MIN_VERSION) >= 0;
+  return { rawVersion, parsed, supported };
+}

--- a/src/local/websocket-server.ts
+++ b/src/local/websocket-server.ts
@@ -153,14 +153,19 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
   const enqueueDispatch = (connectionId: string, work: () => Promise<void>): Promise<void> => {
     const prev = dispatchChainsByConnection.get(connectionId) ?? Promise.resolve();
     const next = prev.then(work);
-    dispatchChainsByConnection.set(
-      connectionId,
-      next.finally(() => {
-        if (dispatchChainsByConnection.get(connectionId) === next) {
-          dispatchChainsByConnection.delete(connectionId);
-        }
-      })
-    );
+    // Store `next` directly in the Map (NOT `next.finally(...)`): the
+    // `=== next` identity check below would never match if we stored
+    // the finally-wrapper, and the entry would leak permanently — the
+    // pre-fix bug surfaced in PR #539 review. Storing `next` keeps the
+    // chain semantics (the next enqueue picks up `next` as its `prev`
+    // and the finally-tap runs at the same logical time as `next`
+    // resolves) while making the cleanup branch reachable.
+    dispatchChainsByConnection.set(connectionId, next);
+    void next.finally(() => {
+      if (dispatchChainsByConnection.get(connectionId) === next) {
+        dispatchChainsByConnection.delete(connectionId);
+      }
+    });
     return next;
   };
 

--- a/src/local/websocket-server.ts
+++ b/src/local/websocket-server.ts
@@ -142,6 +142,35 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
     apiPaths.push(cfg.apiPath);
   }
 
+  // Per-connection serialized dispatch chain (Issue #527 M1). AWS
+  // WebSocket APIs invoke handlers SERIALLY per connection — frame N+1
+  // never starts dispatching until frame N's handler returns. Without
+  // this chain, three rapid frames from one client race the warm-pool
+  // entry and produce out-of-order handler invocations, breaking
+  // ordering-dependent handlers (chat history, conversational state).
+  // Across-connection dispatch stays parallel via separate map entries.
+  const dispatchChainsByConnection = new Map<string, Promise<void>>();
+  const enqueueDispatch = (connectionId: string, work: () => Promise<void>): Promise<void> => {
+    const prev = dispatchChainsByConnection.get(connectionId) ?? Promise.resolve();
+    const next = prev.then(work);
+    dispatchChainsByConnection.set(
+      connectionId,
+      next.finally(() => {
+        if (dispatchChainsByConnection.get(connectionId) === next) {
+          dispatchChainsByConnection.delete(connectionId);
+        }
+      })
+    );
+    return next;
+  };
+
+  // In-flight $disconnect dispatches tracked so close() can bound the
+  // graceful-shutdown drain (Issue #527 M3). A hung $disconnect handler
+  // pre-fix would leak its rieTimeoutMs (60s+) past close()'s 5s
+  // socket-close timeout — the Node process couldn't exit until SIGKILL
+  // or the verify.sh 120s grace.
+  const inFlightDisconnects = new Set<Promise<void>>();
+
   const upgradeListener = (req: IncomingMessage, socket: Duplex, head: Buffer): void => {
     const url = req.url ?? '/';
     const pathOnly = url.split('?', 1)[0]!;
@@ -311,38 +340,55 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
 
     // Attach the real listeners NOW. From this point forward, the
     // standard dispatch path runs for every incoming frame.
+    //
+    // Per-connection dispatch is SERIALIZED via `enqueueDispatch` (Issue
+    // #527 M1). Each new frame chains onto the previous one's promise,
+    // so handler N+1 starts only after handler N returns — matching
+    // AWS-deployed semantics.
     ws.on('message', (raw, isBinary) => {
       const { body, isBase64Encoded } = websocketBody.bufferToBody(raw, isBinary);
       logger.debug(
         `WebSocket message received for connection ${connectionId}: ${body.slice(0, 200)}`
       );
-      void dispatchMessage(connectionId, cfg, body, isBase64Encoded, handshakeSnapshot).catch(
-        (err) => {
-          logger.error(
-            `WebSocket message dispatch failed (connection ${connectionId}): ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`
-          );
-          try {
-            ws.send(
-              JSON.stringify({
-                message: 'Internal server error',
-                connectionId,
-                requestId: randomUUID(),
-              })
+      void enqueueDispatch(connectionId, () =>
+        dispatchMessage(connectionId, cfg, body, isBase64Encoded, handshakeSnapshot).catch(
+          (err) => {
+            logger.error(
+              `WebSocket message dispatch failed (connection ${connectionId}): ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`
             );
-          } catch {
-            /* socket may already be closed */
+            try {
+              ws.send(
+                JSON.stringify({
+                  message: 'Internal server error',
+                  connectionId,
+                  requestId: randomUUID(),
+                })
+              );
+            } catch {
+              /* socket may already be closed */
+            }
           }
-        }
+        )
       );
     });
     ws.on('close', (code, reason) => {
-      void onDisconnect(connectionId, cfg, handshakeSnapshot, code, reason.toString('utf-8')).catch(
-        (err) => {
+      const reasonText = reason.toString('utf-8');
+      // $disconnect runs AFTER any in-flight message dispatch for this
+      // connection completes — same chain ensures the handler observes
+      // a consistent end-of-stream rather than racing the last frame.
+      // Track the promise so close()'s graceful-shutdown drain (Issue
+      // #527 M3) can bound how long it waits for a hung handler.
+      const disconnectPromise = enqueueDispatch(connectionId, () =>
+        onDisconnect(connectionId, cfg, handshakeSnapshot, code, reasonText).catch((err) => {
           logger.warn(
             `WebSocket $disconnect dispatch failed (connection ${connectionId}): ${err instanceof Error ? err.message : String(err)}`
           );
-        }
+        })
       );
+      inFlightDisconnects.add(disconnectPromise);
+      void disconnectPromise.finally(() => {
+        inFlightDisconnects.delete(disconnectPromise);
+      });
     });
     ws.on('error', (err) => {
       logger.debug(
@@ -350,18 +396,21 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
       );
     });
 
-    // Drain any frames buffered pre-verdict synchronously. Each frame
-    // goes through the same dispatcher as a real-time frame —
-    // bufferToBody allocation runs here (post-admit, bounded count)
-    // not at frame-receive time (pre-admit, unbounded by attacker).
+    // Drain any frames buffered pre-verdict via the same per-connection
+    // chain so they dispatch in arrival order ahead of any new frames
+    // that land while the drain is in flight. bufferToBody allocation
+    // runs here (post-admit, bounded count) not at frame-receive time
+    // (pre-admit, unbounded by attacker).
     for (const frame of preVerdictFrames) {
       const { body, isBase64Encoded } = websocketBody.bufferToBody(frame.raw, frame.isBinary);
-      void dispatchMessage(connectionId, cfg, body, isBase64Encoded, handshakeSnapshot).catch(
-        (err) => {
-          logger.error(
-            `WebSocket buffered-message dispatch failed (connection ${connectionId}): ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`
-          );
-        }
+      void enqueueDispatch(connectionId, () =>
+        dispatchMessage(connectionId, cfg, body, isBase64Encoded, handshakeSnapshot).catch(
+          (err) => {
+            logger.error(
+              `WebSocket buffered-message dispatch failed (connection ${connectionId}): ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`
+            );
+          }
+        )
       );
     }
     preVerdictFrames.length = 0;
@@ -436,6 +485,13 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
     await invokeRoute(disconnectRoute.targetLambdaLogicalId, event, opts.pool, rieTimeoutMs);
   };
 
+  // Bounded total drain window for in-flight $disconnect dispatches
+  // during graceful shutdown (Issue #527 M3). 5s is long enough for a
+  // well-behaved handler to flush logs / close db connections, short
+  // enough that a hung handler can't hold the process open for
+  // rieTimeoutMs (60s+) waiting on SIGKILL or the verify.sh 120s grace.
+  const SHUTDOWN_DRAIN_MS = 5_000;
+
   let closed = false;
   return {
     registry,
@@ -466,6 +522,25 @@ export function attachWebSocketServer(opts: AttachOptions): AttachedWebSocketSer
           })
       );
       await Promise.all(closes);
+      // Drain in-flight $disconnect dispatches with a bounded ceiling.
+      // A handler that exceeds SHUTDOWN_DRAIN_MS keeps running in the
+      // background but no longer blocks the process exit.
+      if (inFlightDisconnects.size > 0) {
+        const drainStartCount = inFlightDisconnects.size;
+        const drainComplete = Promise.allSettled(Array.from(inFlightDisconnects));
+        const drainResult = await Promise.race([
+          drainComplete.then(() => 'complete' as const),
+          new Promise<'timeout'>((resolve) =>
+            setTimeout(() => resolve('timeout'), SHUTDOWN_DRAIN_MS).unref()
+          ),
+        ]);
+        if (drainResult === 'timeout' && inFlightDisconnects.size > 0) {
+          logger.warn(
+            `WebSocket graceful shutdown drained for ${SHUTDOWN_DRAIN_MS}ms; ` +
+              `${inFlightDisconnects.size}/${drainStartCount} $disconnect handlers still in flight — leaking past shutdown.`
+          );
+        }
+      }
       await new Promise<void>((resolve) => {
         wss.close(() => resolve());
       });

--- a/tests/unit/local/docker-version.test.ts
+++ b/tests/unit/local/docker-version.test.ts
@@ -1,0 +1,103 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, vi } from 'vite-plus/test';
+import {
+  compareDockerVersions,
+  HOST_GATEWAY_MIN_VERSION,
+  parseDockerVersion,
+  probeHostGatewaySupport,
+} from '../../../src/local/docker-version.js';
+
+describe('parseDockerVersion', () => {
+  it('parses canonical "<major>.<minor>.<patch>"', () => {
+    expect(parseDockerVersion('20.10.21')).toEqual({ major: 20, minor: 10, patch: 21 });
+    expect(parseDockerVersion('27.3.1')).toEqual({ major: 27, minor: 3, patch: 1 });
+  });
+  it('parses "<major>.<minor>" with implicit patch=0', () => {
+    expect(parseDockerVersion('24.0')).toEqual({ major: 24, minor: 0, patch: 0 });
+  });
+  it('strips Docker Desktop / rootless / podman suffixes', () => {
+    expect(parseDockerVersion('24.0.7-rd')).toEqual({ major: 24, minor: 0, patch: 7 });
+    expect(parseDockerVersion('27.3.1+podman')).toEqual({ major: 27, minor: 3, patch: 1 });
+    expect(parseDockerVersion('20.10.21-ce')).toEqual({ major: 20, minor: 10, patch: 21 });
+  });
+  it('tolerates leading / trailing whitespace', () => {
+    expect(parseDockerVersion('  20.10.21\n')).toEqual({ major: 20, minor: 10, patch: 21 });
+  });
+  it('returns null on unparseable input (podman / finch / nerdctl shapes)', () => {
+    expect(parseDockerVersion('')).toBeNull();
+    expect(parseDockerVersion('not-a-version')).toBeNull();
+    expect(parseDockerVersion('podman version 4.6.1')).toBeNull();
+  });
+});
+
+describe('compareDockerVersions', () => {
+  it('orders by major, then minor, then patch', () => {
+    expect(compareDockerVersions({ major: 20, minor: 10, patch: 0 }, { major: 19, minor: 99, patch: 99 })).toBeGreaterThan(0);
+    expect(compareDockerVersions({ major: 20, minor: 10, patch: 0 }, { major: 20, minor: 10, patch: 1 })).toBeLessThan(0);
+    expect(compareDockerVersions({ major: 20, minor: 10, patch: 0 }, { major: 20, minor: 10, patch: 0 })).toBe(0);
+  });
+  it('returns positive for newer-than-min versions', () => {
+    expect(
+      compareDockerVersions({ major: 27, minor: 3, patch: 1 }, HOST_GATEWAY_MIN_VERSION)
+    ).toBeGreaterThan(0);
+  });
+  it('returns negative for older-than-min versions', () => {
+    expect(
+      compareDockerVersions({ major: 19, minor: 3, patch: 8 }, HOST_GATEWAY_MIN_VERSION)
+    ).toBeLessThan(0);
+    expect(
+      compareDockerVersions({ major: 20, minor: 9, patch: 0 }, HOST_GATEWAY_MIN_VERSION)
+    ).toBeLessThan(0);
+  });
+});
+
+vi.mock('../../../src/utils/docker-cmd.js', () => ({
+  runDockerStreaming: vi.fn(),
+}));
+
+const dockerCmd = (await import('../../../src/utils/docker-cmd.js')) as unknown as {
+  runDockerStreaming: ReturnType<typeof vi.fn>;
+};
+
+describe('probeHostGatewaySupport', () => {
+  it('returns supported=true for Docker 20.10', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({ stdout: '20.10.21\n', stderr: '' });
+    const probe = await probeHostGatewaySupport();
+    expect(probe).toEqual({
+      rawVersion: '20.10.21',
+      parsed: { major: 20, minor: 10, patch: 21 },
+      supported: true,
+    });
+  });
+  it('returns supported=true for Docker 27+', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({ stdout: '27.3.1\n', stderr: '' });
+    const probe = await probeHostGatewaySupport();
+    expect(probe.supported).toBe(true);
+  });
+  it('returns supported=false for Docker 19.x (pre-20.10)', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({ stdout: '19.03.15\n', stderr: '' });
+    const probe = await probeHostGatewaySupport();
+    expect(probe.supported).toBe(false);
+    expect(probe.parsed).toEqual({ major: 19, minor: 3, patch: 15 });
+  });
+  it('returns supported=false for Docker 20.9 (just below the bar)', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({ stdout: '20.9.0\n', stderr: '' });
+    const probe = await probeHostGatewaySupport();
+    expect(probe.supported).toBe(false);
+  });
+  it('returns supported=true with parsed=null for unparseable version strings (podman / finch fallback)', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({
+      stdout: 'podman version 4.6.1\n',
+      stderr: '',
+    });
+    const probe = await probeHostGatewaySupport();
+    expect(probe.parsed).toBeNull();
+    expect(probe.supported).toBe(true); // defer to warn path, not hard-fail
+    expect(probe.rawVersion).toBe('podman version 4.6.1');
+  });
+  it('lets a docker subprocess failure bubble up unchanged (binary missing / daemon down)', async () => {
+    const fakeErr = new Error('Failed to find and execute \'docker\'');
+    dockerCmd.runDockerStreaming.mockRejectedValueOnce(fakeErr);
+    await expect(probeHostGatewaySupport()).rejects.toThrow(/Failed to find and execute/);
+  });
+});

--- a/tests/unit/local/docker-version.test.ts
+++ b/tests/unit/local/docker-version.test.ts
@@ -95,6 +95,24 @@ describe('probeHostGatewaySupport', () => {
     expect(probe.supported).toBe(true); // defer to warn path, not hard-fail
     expect(probe.rawVersion).toBe('podman version 4.6.1');
   });
+  it('returns supported=false for empty stdout (daemon unreachable / output stripped)', async () => {
+    // Surfaced by PR #539 review: pre-fix the empty-stdout case
+    // returned `supported=true` (warn-and-pass) because the
+    // unparseable-version branch short-circuited before checking for
+    // the empty string. Empty stdout from `docker version` is much
+    // more likely a broken probe than a real-but-unparseable engine.
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    const probe = await probeHostGatewaySupport();
+    expect(probe.rawVersion).toBe('');
+    expect(probe.parsed).toBeNull();
+    expect(probe.supported).toBe(false);
+  });
+  it('returns supported=false for whitespace-only stdout', async () => {
+    dockerCmd.runDockerStreaming.mockResolvedValueOnce({ stdout: '   \n  ', stderr: '' });
+    const probe = await probeHostGatewaySupport();
+    expect(probe.rawVersion).toBe('');
+    expect(probe.supported).toBe(false);
+  });
   it('lets a docker subprocess failure bubble up unchanged (binary missing / daemon down)', async () => {
     const fakeErr = new Error('Failed to find and execute \'docker\'');
     dockerCmd.runDockerStreaming.mockRejectedValueOnce(fakeErr);

--- a/tests/unit/local/websocket-server.test.ts
+++ b/tests/unit/local/websocket-server.test.ts
@@ -726,3 +726,140 @@ describe('$connect-deny listener safety (B4 regression guard)', () => {
     }
   });
 });
+
+// Issue #527 M1: per-connection message dispatch is SERIALIZED via a
+// promise chain. AWS WebSocket APIs invoke handlers serially per
+// connection (frame N+1 never starts dispatching until frame N's
+// handler returns); without the chain, three rapid frames race the
+// warm-pool entry and produce out-of-order handler invocations.
+describe('per-connection dispatch serialization (M1)', () => {
+  beforeEach(() => {
+    rieModule.__resetQueue();
+    rieModule.invokeRie.mockClear();
+  });
+  it('dispatches frames in arrival order for a single connection', async () => {
+    rieModule.__resetQueue();
+    rieModule.__queueInvokeResult({ statusCode: 200 }); // $connect
+
+    // Each $default invocation records its start order then sleeps a
+    // descending amount. If dispatch were parallel, frame 0's 100ms
+    // sleep would finish AFTER frames 1 / 2 (50ms / 10ms) — exit
+    // order would be reversed. With the chain, exit order matches
+    // arrival order regardless of per-call sleep.
+    const startOrder: number[] = [];
+    const endOrder: number[] = [];
+    rieModule.invokeRie.mockImplementationOnce(async () => ({
+      payload: { statusCode: 200 },
+      raw: '{"statusCode":200}',
+    }));
+    const sleeps = [100, 50, 10];
+    for (let i = 0; i < sleeps.length; i += 1) {
+      const ms = sleeps[i]!;
+      const idx = i;
+      rieModule.invokeRie.mockImplementationOnce(async () => {
+        startOrder.push(idx);
+        await new Promise((r) => setTimeout(r, ms));
+        endOrder.push(idx);
+        return { payload: {}, raw: '{}' };
+      });
+    }
+
+    const pool = buildFakePool();
+    const api = buildApi([
+      { routeKey: '$connect', lambda: 'ConnectFn' },
+      { routeKey: '$default', lambda: 'DefaultFn' },
+    ]);
+    const { port, close } = await startTestServer({
+      apis: [{ api, apiPath: '/prod' }],
+      pool,
+    });
+    try {
+      const ws = await openWebSocket(port, '/prod');
+      ws.send(JSON.stringify({ action: 'a', seq: 0 }));
+      ws.send(JSON.stringify({ action: 'b', seq: 1 }));
+      ws.send(JSON.stringify({ action: 'c', seq: 2 }));
+      // Wait for all 3 $default handlers to fully complete (NOT just
+      // be invoked). With serialization, total wall-clock is
+      // ~100+50+10 = 160ms; ceiling 2s leaves room for scheduler jitter.
+      await waitFor(() => endOrder.length >= 3, 2000);
+      expect(rieModule.invokeRie).toHaveBeenCalledTimes(4);
+      // Arrival order is preserved on both start AND end. Pre-fix the
+      // parallel dispatch would have endOrder = [2, 1, 0].
+      expect(startOrder).toEqual([0, 1, 2]);
+      expect(endOrder).toEqual([0, 1, 2]);
+      ws.close();
+      await awaitClose(ws);
+    } finally {
+      await close();
+    }
+  });
+});
+
+// Issue #527 M3: graceful shutdown drains in-flight $disconnect
+// dispatches with a bounded ceiling. A hung handler pre-fix would leak
+// its rieTimeoutMs (60s+) past close()'s 5s socket-close timeout.
+describe('graceful shutdown bounded drain (M3)', () => {
+  beforeEach(() => {
+    rieModule.__resetQueue();
+    rieModule.invokeRie.mockClear();
+  });
+  it('logs a warn naming the leaking $disconnect count when drain times out', async () => {
+    rieModule.__resetQueue();
+    rieModule.__queueInvokeResult({ statusCode: 200 }); // $connect for the live conn
+    // $disconnect hangs longer than the 5s drain window.
+    rieModule.invokeRie.mockImplementation(async (_id: string, _meta: unknown, event: any) => {
+      const routeKey = event?.requestContext?.routeKey;
+      if (routeKey === '$connect') return { payload: { statusCode: 200 }, raw: '{}' };
+      // Sleep past the drain window — exact value doesn't matter past 5s.
+      await new Promise((r) => setTimeout(r, 10_000).unref?.());
+      return { payload: {}, raw: '{}' };
+    });
+
+    const pool = buildFakePool();
+    const api = buildApi([
+      { routeKey: '$connect', lambda: 'ConnectFn' },
+      { routeKey: '$disconnect', lambda: 'DisconnectFn' },
+    ]);
+    const server = createServer((_req, res) => {
+      res.statusCode = 404;
+      res.end();
+    });
+    const attached = attachWebSocketServer({
+      httpServer: server,
+      apis: [{ api, apiPath: '/prod' }],
+      pool,
+      rieTimeoutMs: 60_000,
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    const warnSpy = vi.spyOn(ConsoleLogger.prototype, 'warn');
+    try {
+      const ws = await openWebSocket(port, '/prod');
+      await waitFor(() => attached.registry.size() === 1, 1000);
+      // Closing the WebSocket fires the close listener, which kicks off
+      // $disconnect. Then immediately call attached.close() which awaits
+      // the drain. The drain hits the 5s ceiling and the warn fires.
+      // We do NOT await ws's close event here because attached.close
+      // itself drives the close to completion.
+      ws.close();
+      const t0 = Date.now();
+      await attached.close();
+      const elapsed = Date.now() - t0;
+      // Drain ceiling = 5000ms; some scheduler jitter accepted.
+      expect(elapsed).toBeGreaterThanOrEqual(4_500);
+      expect(elapsed).toBeLessThan(7_500);
+      const drainWarns = warnSpy.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].includes('graceful shutdown drained for')
+      );
+      expect(drainWarns).toHaveLength(1);
+      expect(drainWarns[0]![0]).toContain('still in flight');
+    } finally {
+      warnSpy.mockRestore();
+      rieModule.invokeRie.mockReset();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        server.closeAllConnections?.();
+      });
+    }
+  }, 10_000);
+});


### PR DESCRIPTION
## Summary

Three robustness MAJORs surfaced by PR #524's 3-axis review, deferred to keep #524's merge scope tight.

Closes #527.

### M1 — Per-connection dispatch serialization

`src/local/websocket-server.ts` fired `void dispatchMessage(...)` per incoming frame without chaining, so three rapid frames from one client raced the warm-pool entry and produced out-of-order handler invocations. AWS WebSocket APIs serialize handler invocations per connection; cdkd now matches that via a per-connection promise chain (`dispatchChainsByConnection` Map keyed by `connectionId`). Pre-verdict drain frames + post-admit real-time frames + the close-driven $disconnect dispatch all chain through the same map entry, so end-of-stream is observed only after the last in-flight message handler returns.

Across-connection dispatch stays parallel via separate map entries — chat-app broadcast latency between two clients is unaffected.

### M2 — Docker server version probe gates host-gateway support

`--add-host=host.docker.internal:host-gateway` requires Docker 20.10+. Older daemons silently failed with `ENOTFOUND host.docker.internal` at SDK-call time inside the Lambda container. New `src/local/docker-version.ts` probes the server version once at WebSocket attach time (HTTP-only / REST-only sessions skip the probe) and refuses the boot with a clear "upgrade Docker, or remove the WebSocket API" error when the version is too old. Unparseable version strings (podman / finch / nerdctl) fall through to a warn instead of a hard-fail — they may or may not honor the flag, and a wrong-call refusal would break users who DO have a compatible engine.

### M3 — Graceful shutdown drains $disconnect with a bounded ceiling

`close()` awaited each socket's `'close'` event with a 5s defensive timeout but did NOT await the in-flight $disconnect dispatch behind the close listener. A hung handler then leaked its `rieTimeoutMs` (60s+) past `close()` and held the Node process open until SIGKILL. New `inFlightDisconnects: Set<Promise<void>>` is populated in the close listener and drained in `close()` via `Promise.race` against a 5s ceiling (`SHUTDOWN_DRAIN_MS`). A handler that exceeds the ceiling keeps running in the background but no longer blocks process exit; a warn line names the leaking count.

## Out of scope (folded out)

`#531` items N1 + N3 + m3 (mock accountId on identity, IPv6 sourceIp normalization, unused MOCK_ACCOUNT_ID re-export) were considered for folding into this PR but deferred to keep scope tight. They will land in the next #531 cleanup PR or alongside #528's integ coverage expansion.

## Notes

- No CLI surface change (no new flag, no env var change).
- No schema change.
- The Docker version probe is the FIRST time `cdkd local start-api` short-circuits on environment-detection — the error names the minimum required version explicitly and points at "remove the WebSocket API" as the alternative, so HTTP-only users on older Docker are not blocked.

## Test plan

- [x] Unit tests pass (352 files, 5088 tests; 16 new tests in this PR)
- [x] Integration test: `/run-integ local-start-api-websocket` — all 4 routes exercised end-to-end ($connect / $default / sendMessage / broadcast PostToConnection / $disconnect); zero Docker orphans after teardown
- [x] Live-test: the M2 docker version probe fires at boot (verified via the integ test running against Docker Desktop reports the canonical version string)
- [x] No new CLI flags; existing surface unchanged
