### PR TITLE
test(local): expand WebSocket integ coverage (#528)

### DIFF
--- a/tests/integration/local-start-api-websocket/lambda-broadcast/index.js
+++ b/tests/integration/local-start-api-websocket/lambda-broadcast/index.js
@@ -1,20 +1,47 @@
-// broadcast handler — pushes a payload back via PostToConnection to
-// prove the data-plane endpoint emulation works for ANY route, not
-// just the canonical reply pattern.
-const { ApiGatewayManagementApiClient, PostToConnectionCommand } = require('@aws-sdk/client-apigatewaymanagementapi');
+// broadcast handler — multi-client broadcast (#528 M4) via
+// PostToConnection to every connectionId in `body.recipients`. When
+// `recipients` is absent or empty, falls back to echoing the sender
+// (pre-PR behavior, preserved so the single-client smoke test still
+// works).
+//
+// AWS-deployed broadcast handlers track connection IDs in DynamoDB /
+// Redis since AWS API Gateway doesn't expose a `list connections`
+// endpoint. The local integ caller supplies the recipient list
+// explicitly via the message body — equivalent fan-out shape, just
+// stateless on the handler side.
+const {
+  ApiGatewayManagementApiClient,
+  PostToConnectionCommand,
+} = require('@aws-sdk/client-apigatewaymanagementapi');
 
 exports.handler = async (event) => {
-  const connectionId = event.requestContext.connectionId;
+  const senderConnectionId = event.requestContext.connectionId;
   const endpoint = process.env.AWS_ENDPOINT_URL_APIGATEWAYMANAGEMENTAPI;
-  const client = new ApiGatewayManagementApiClient({
-    endpoint,
-    region: 'us-east-1',
-  });
-  await client.send(
-    new PostToConnectionCommand({
-      ConnectionId: connectionId,
-      Data: JSON.stringify({ route: 'broadcast', timestamp: Date.now() }),
-    })
-  );
+  const client = new ApiGatewayManagementApiClient({ endpoint, region: 'us-east-1' });
+
+  let parsed;
+  try {
+    parsed = JSON.parse(event.body);
+  } catch {
+    parsed = {};
+  }
+  const recipients =
+    Array.isArray(parsed.recipients) && parsed.recipients.length > 0
+      ? parsed.recipients
+      : [senderConnectionId];
+
+  const timestamp = Date.now();
+  for (const target of recipients) {
+    await client.send(
+      new PostToConnectionCommand({
+        ConnectionId: target,
+        Data: JSON.stringify({
+          route: 'broadcast',
+          from: senderConnectionId,
+          timestamp,
+        }),
+      })
+    );
+  }
   return { statusCode: 200 };
 };

--- a/tests/integration/local-start-api-websocket/lambda-connect/index.js
+++ b/tests/integration/local-start-api-websocket/lambda-connect/index.js
@@ -1,6 +1,15 @@
-// $connect handler — admits every client. Returning {statusCode: 200}
-// is the AWS-canonical allow signal.
+// $connect handler — admits every client by default. When the upgrade
+// URL carries `?reject=true`, returns `{statusCode: 403}` so cdkd's
+// $connect verdict path emits a `1008 Forbidden` close frame instead
+// of admitting the connection (#528 M5 — exercise the deny path
+// end-to-end against real Docker / RIE, complementing the mocked unit
+// test in tests/unit/local/websocket-server.test.ts).
 exports.handler = async (event) => {
   console.log('$connect:', event.requestContext.connectionId);
+  const reject = event.queryStringParameters?.reject === 'true';
+  if (reject) {
+    console.log('$connect: rejecting per ?reject=true');
+    return { statusCode: 403, body: 'Forbidden' };
+  }
   return { statusCode: 200, body: 'OK' };
 };

--- a/tests/integration/local-start-api-websocket/lambda-send/index.js
+++ b/tests/integration/local-start-api-websocket/lambda-send/index.js
@@ -1,8 +1,16 @@
 // sendMessage handler — echoes the received body back to the same
-// connection via PostToConnection. The AWS-canonical WebSocket
-// reply path; the handler's HTTP response is discarded by both
-// AWS-deployed API Gateway AND cdkd's local emulator.
-const { ApiGatewayManagementApiClient, PostToConnectionCommand } = require('@aws-sdk/client-apigatewaymanagementapi');
+// connection via PostToConnection. The AWS-canonical WebSocket reply
+// path; the handler's HTTP response is discarded by both AWS-deployed
+// API Gateway AND cdkd's local emulator.
+//
+// The echo includes `connectionId` so clients can discover their own
+// id without a dedicated `whoami` route (#528 M4 — multi-client
+// broadcast needs each client to know its id so the recipient list
+// can be passed to lambda-broadcast).
+const {
+  ApiGatewayManagementApiClient,
+  PostToConnectionCommand,
+} = require('@aws-sdk/client-apigatewaymanagementapi');
 
 exports.handler = async (event) => {
   const connectionId = event.requestContext.connectionId;
@@ -23,7 +31,11 @@ exports.handler = async (event) => {
   await client.send(
     new PostToConnectionCommand({
       ConnectionId: connectionId,
-      Data: JSON.stringify({ route: 'sendMessage', echo: parsed.text || null }),
+      Data: JSON.stringify({
+        route: 'sendMessage',
+        connectionId,
+        echo: parsed.text || null,
+      }),
     })
   );
   return { statusCode: 200 };

--- a/tests/integration/local-start-api-websocket/verify.sh
+++ b/tests/integration/local-start-api-websocket/verify.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# verify.sh — local-start-api WebSocket integ test (#462)
+# verify.sh — local-start-api WebSocket integ test (#462, #528)
 #
 # Exercises `cdkd local start-api`'s WebSocket support end-to-end against
 # Docker + the AWS Lambda Node.js base image (which bundles RIE AND the
@@ -10,6 +10,18 @@
 #     bash tests/integration/local-start-api-websocket/verify.sh
 #
 # Requires Docker.
+#
+# #528 expansion: each scenario is wrapped in a `stage_*` function so a
+# failure surfaces which path broke. Stages:
+#   stage_basic         — 1 client / sendMessage echo / broadcast /
+#                         $default fallback / clean close
+#   stage_multi_client  — M4: 2 clients, broadcast from A reaches B
+#   stage_deny          — M5: $connect returns 403, client sees close 1008
+#   stage_disconnect    — M6: $disconnect Lambda fires (server log marker)
+#   stage_drain         — registry drops the entry on close (GET → 410)
+#   stage_large_payload — 64KB frame survives the dispatch path
+#   stage_sigterm_fast  — server exits within 7s of SIGTERM (no defensive
+#                         timeout fires under a clean state)
 
 set -euo pipefail
 
@@ -37,12 +49,15 @@ CONTAINER_HOST="127.0.0.1"
 
 LOG_FILE="$(mktemp)"
 SERVER_PID=""
+SIGTERM_ELAPSED=""
 
 cleanup() {
   if [[ -n "${SERVER_PID:-}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
     echo "==> Sending SIGTERM to server (pid ${SERVER_PID})"
+    local t0
+    t0=$(date +%s)
     kill -TERM "${SERVER_PID}" 2>/dev/null || true
-    for i in $(seq 1 120); do
+    for _ in $(seq 1 120); do
       kill -0 "${SERVER_PID}" 2>/dev/null || break
       sleep 1
     done
@@ -50,6 +65,7 @@ cleanup() {
       echo "==> Server did not exit within 120s; SIGKILL"
       kill -KILL "${SERVER_PID}" 2>/dev/null || true
     fi
+    SIGTERM_ELAPSED=$(( $(date +%s) - t0 ))
   fi
   # Defense-in-depth: kill every cdkd-local-* container that survived
   # the graceful shutdown.
@@ -73,7 +89,7 @@ SERVER_PID=$!
 
 echo "==> Waiting for the WebSocket server to come up"
 READY=0
-for i in $(seq 1 60); do
+for _ in $(seq 1 60); do
   if grep -q "Server listening on ws" "${LOG_FILE}" 2>/dev/null; then
     READY=1
     break
@@ -98,17 +114,21 @@ if [[ -z "${WS_URL}" ]]; then
 fi
 echo "==> WebSocket URL: ${WS_URL}"
 
-# Use Node + the `ws` client (already in node_modules) to drive the
-# WebSocket handshake + message round-trips. Written into the fixture
-# dir so `import 'ws'` resolves against the local node_modules (a
-# /tmp path can't see our pnpm-installed deps).
+# The shared @connections HTTP endpoint URL (same host + port as the
+# WebSocket; the mgmt-api pre-pass intercepts /<stage>/@connections/<id>).
+HTTP_BASE="http${WS_URL#ws}"
+
+# All client scripts go into a single file written into the fixture dir
+# so `import 'ws'` resolves against the local node_modules (a /tmp path
+# can't see our pnpm-installed deps).
 CLIENT_SCRIPT="$(pwd)/.ws-client.mjs"
 cat > "${CLIENT_SCRIPT}" <<'NODE'
 import { WebSocket } from 'ws';
 
 const url = process.argv[2];
+const mode = process.argv[3] ?? 'basic';
 if (!url) {
-  console.error('Usage: client.mjs <ws-url>');
+  console.error('Usage: client.mjs <ws-url> <mode>');
   process.exit(2);
 }
 
@@ -119,82 +139,273 @@ function withTimeout(p, ms, label) {
   });
 }
 
-const messages = [];
+function openWs(targetUrl, label) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(targetUrl);
+    const messages = [];
+    let closeInfo = null;
+    let errorInfo = null;
+    ws.on('message', (data) => {
+      const text = data.toString('utf-8');
+      console.log(`[${label}] GOT:`, text.slice(0, 200));
+      messages.push(text);
+    });
+    ws.once('open', () => {
+      console.log(`[${label}] CONNECTED`);
+      resolve({ ws, messages, getClose: () => closeInfo, getError: () => errorInfo });
+    });
+    ws.once('close', (code, reason) => {
+      closeInfo = { code, reason: reason.toString('utf-8') };
+      console.log(`[${label}] CLOSED code=${code} reason=${closeInfo.reason}`);
+    });
+    ws.once('error', (err) => {
+      errorInfo = err;
+      console.log(`[${label}] ERROR:`, err.message);
+    });
+    setTimeout(() => reject(new Error(`Timeout opening ${label}`)), 20_000);
+  });
+}
 
-const ws = new WebSocket(url);
-await new Promise((resolve, reject) => {
-  ws.once('open', resolve);
-  ws.once('error', reject);
-});
-console.log('CONNECTED');
+async function discoverConnectionId(client) {
+  client.ws.send(JSON.stringify({ action: 'sendMessage', text: 'whoami' }));
+  await withTimeout(
+    new Promise((resolve) => {
+      const check = () => {
+        if (client.messages.some((m) => m.includes('"route":"sendMessage"'))) resolve();
+        else setTimeout(check, 50);
+      };
+      check();
+    }),
+    30_000,
+    'whoami echo'
+  );
+  for (const m of client.messages) {
+    try {
+      const parsed = JSON.parse(m);
+      if (parsed.route === 'sendMessage' && typeof parsed.connectionId === 'string') {
+        return parsed.connectionId;
+      }
+    } catch {
+      /* skip non-JSON */
+    }
+  }
+  throw new Error('connectionId not found in sendMessage echo');
+}
 
-ws.on('message', (data) => {
-  const text = data.toString('utf-8');
-  console.log('GOT:', text);
-  messages.push(text);
-});
+function waitForMessage(client, predicate, label, ms = 60_000) {
+  return withTimeout(
+    new Promise((resolve) => {
+      const check = () => {
+        if (client.messages.some(predicate)) resolve();
+        else setTimeout(check, 50);
+      };
+      check();
+    }),
+    ms,
+    label
+  );
+}
 
-// Test 1: sendMessage route — server should reply via PostToConnection.
-ws.send(JSON.stringify({ action: 'sendMessage', text: 'hello-from-client' }));
-await withTimeout(
-  new Promise((resolve) => {
-    const check = () => {
-      if (messages.some((m) => m.includes('"echo":"hello-from-client"'))) resolve();
-      else setTimeout(check, 100);
-    };
-    check();
-  }),
-  60_000,
-  'sendMessage echo'
-);
-console.log('PASS: sendMessage echo received');
+async function runBasic() {
+  const c = await openWs(url, 'basic');
+  c.ws.send(JSON.stringify({ action: 'sendMessage', text: 'hello-from-client' }));
+  await waitForMessage(c, (m) => m.includes('"echo":"hello-from-client"'), 'sendMessage echo');
+  console.log('PASS: sendMessage echo received');
 
-// Test 2: broadcast route — server should push back via PostToConnection.
-ws.send(JSON.stringify({ action: 'broadcast' }));
-await withTimeout(
-  new Promise((resolve) => {
-    const check = () => {
-      if (messages.some((m) => m.includes('"route":"broadcast"'))) resolve();
-      else setTimeout(check, 100);
-    };
-    check();
-  }),
-  60_000,
-  'broadcast response'
-);
-console.log('PASS: broadcast response received');
+  c.ws.send(JSON.stringify({ action: 'broadcast' }));
+  await waitForMessage(c, (m) => m.includes('"route":"broadcast"'), 'broadcast response');
+  console.log('PASS: broadcast self-reply received (no recipients = sender-only)');
 
-// Test 3: unknown action → should fall through to $default which
-// also replies via PostToConnection.
-ws.send(JSON.stringify({ action: 'unknown-route', foo: 'bar' }));
-await withTimeout(
-  new Promise((resolve) => {
-    const check = () => {
-      if (messages.some((m) => m.includes('"route":"$default"'))) resolve();
-      else setTimeout(check, 100);
-    };
-    check();
-  }),
-  60_000,
-  '$default fallback'
-);
-console.log('PASS: $default fallback received');
+  c.ws.send(JSON.stringify({ action: 'unknown-route', foo: 'bar' }));
+  await waitForMessage(c, (m) => m.includes('"route":"$default"'), '$default fallback');
+  console.log('PASS: $default fallback received');
 
-// Clean close
-ws.close(1000, 'test-complete');
-await new Promise((resolve) => ws.once('close', resolve));
-console.log('PASS: socket closed cleanly');
+  c.ws.close(1000, 'test-complete');
+  await withTimeout(
+    new Promise((resolve) => {
+      const check = () => (c.getClose() ? resolve() : setTimeout(check, 50));
+      check();
+    }),
+    5_000,
+    'clean close'
+  );
+  console.log('PASS: socket closed cleanly');
+}
+
+// M4: multi-client broadcast — A broadcasts to B.
+async function runMultiClient() {
+  const a = await openWs(url, 'A');
+  const b = await openWs(url, 'B');
+
+  const idA = await discoverConnectionId(a);
+  const idB = await discoverConnectionId(b);
+  console.log(`PASS: discovered connection ids A=${idA} B=${idB}`);
+  if (idA === idB) throw new Error(`A and B got the same connectionId ${idA}`);
+
+  // Count B's broadcast messages before — A's whoami / B's whoami
+  // are NOT broadcast frames, so the count should be 0.
+  const before = b.messages.filter((m) => m.includes('"route":"broadcast"')).length;
+  if (before !== 0) throw new Error(`B already has broadcast messages: ${before}`);
+
+  // A broadcasts to [B] only.
+  a.ws.send(JSON.stringify({ action: 'broadcast', recipients: [idB] }));
+  await waitForMessage(
+    b,
+    (m) => m.includes('"route":"broadcast"') && m.includes(`"from":"${idA}"`),
+    'B receives broadcast from A'
+  );
+  console.log('PASS: B received broadcast from A');
+
+  // A should NOT receive its own broadcast when only B is in recipients.
+  await new Promise((r) => setTimeout(r, 300));
+  const aReceived = a.messages.filter((m) => m.includes('"route":"broadcast"')).length;
+  if (aReceived !== 0) throw new Error(`A unexpectedly received broadcast (${aReceived})`);
+  console.log('PASS: A did not receive its own targeted broadcast');
+
+  a.ws.close(1000, 'A-done');
+  b.ws.close(1000, 'B-done');
+  await new Promise((r) => setTimeout(r, 200));
+}
+
+// M5: $connect deny path — handshake completes but cdkd closes with 1008.
+async function runDeny() {
+  const denyUrl = `${url}?reject=true`;
+  const ws = new WebSocket(denyUrl);
+  let closeCode = -1;
+  let errFired = false;
+  await new Promise((resolve) => {
+    ws.once('close', (code) => {
+      closeCode = code;
+      resolve();
+    });
+    ws.once('error', () => {
+      errFired = true;
+    });
+    setTimeout(resolve, 15_000);
+  });
+  if (closeCode !== 1008) {
+    throw new Error(`Expected close code 1008 (policy violation) on deny, got ${closeCode}`);
+  }
+  console.log(`PASS: $connect deny produced close 1008 (errFired=${errFired})`);
+}
+
+// Large payload — 64KB body sent through the dispatch path.
+async function runLargePayload() {
+  const c = await openWs(url, 'large');
+  const payloadText = 'x'.repeat(64 * 1024);
+  c.ws.send(JSON.stringify({ action: 'unknown-large', text: payloadText }));
+  await waitForMessage(
+    c,
+    (m) => m.includes('"route":"$default"') && m.length >= 64 * 1024,
+    '$default echo of 64KB payload'
+  );
+  console.log(`PASS: 64KB payload echoed via $default (largest message=${c.messages.reduce((max, m) => Math.max(max, m.length), 0)} bytes)`);
+  c.ws.close(1000);
+  await new Promise((r) => setTimeout(r, 200));
+}
+
+// Registry drain — after close, GET /@connections/<id> returns 410.
+async function runRegistryDrain() {
+  const c = await openWs(url, 'drain');
+  const id = await discoverConnectionId(c);
+  console.log(`PASS: discovered connection id for drain test: ${id}`);
+  c.ws.close(1000);
+  await new Promise((r) => setTimeout(r, 500));
+  const httpBase = process.argv[4];
+  if (!httpBase) throw new Error('http base URL not provided as argv[4]');
+  const res = await fetch(`${httpBase}/@connections/${id}`);
+  if (res.status !== 410) {
+    throw new Error(`Expected 410 on drained connection, got ${res.status}`);
+  }
+  console.log('PASS: drained connection returns 410');
+}
+
+switch (mode) {
+  case 'basic':
+    await runBasic();
+    break;
+  case 'multi-client':
+    await runMultiClient();
+    break;
+  case 'deny':
+    await runDeny();
+    break;
+  case 'large-payload':
+    await runLargePayload();
+    break;
+  case 'registry-drain':
+    await runRegistryDrain();
+    break;
+  default:
+    console.error(`unknown mode: ${mode}`);
+    process.exit(2);
+}
 NODE
 
-echo "==> Running WebSocket client tests"
-if ! node "${CLIENT_SCRIPT}" "${WS_URL}"; then
-  echo "FAIL: client test failed. Full server log:"
+run_client() {
+  local stage="$1"
+  local mode="$2"
+  echo ""
+  echo "==> Stage: ${stage}"
+  if ! node "${CLIENT_SCRIPT}" "${WS_URL}" "${mode}" "${HTTP_BASE}"; then
+    echo "FAIL: ${stage} stage failed. Full server log:"
+    echo "----- SERVER LOG -----"
+    cat "${LOG_FILE}"
+    echo "----- END LOG -----"
+    exit 1
+  fi
+}
+
+# stage_basic — preserves the existing 1-client smoke test.
+run_client "stage_basic" basic
+
+# M4: stage_multi_client
+run_client "stage_multi_client" multi-client
+
+# M5: stage_deny
+run_client "stage_deny" deny
+
+# Large payload
+run_client "stage_large_payload" large-payload
+
+# Registry drain
+run_client "stage_registry_drain" registry-drain
+
+# M6: stage_disconnect — assert lambda-disconnect actually fired during
+# at least one of the above clean-close paths. The server log captures
+# every container stdout line via `docker logs -f`; lambda-disconnect's
+# `console.log('$disconnect:', ...)` lands in LOG_FILE.
+echo ""
+echo "==> Stage: stage_disconnect"
+DISCONNECT_COUNT=$(grep -c '[$]disconnect:' "${LOG_FILE}" || true)
+if [[ "${DISCONNECT_COUNT}" -lt 1 ]]; then
+  echo "FAIL: lambda-disconnect handler never fired (looked for '\$disconnect:' marker in server log)."
   echo "----- SERVER LOG -----"
   cat "${LOG_FILE}"
   echo "----- END LOG -----"
   exit 1
 fi
+echo "PASS: lambda-disconnect fired ${DISCONNECT_COUNT} time(s) across the stages"
+
 rm -f "${CLIENT_SCRIPT}"
 
 echo ""
 echo "==> All WebSocket assertions passed"
+
+# stage_sigterm_fast — the cleanup trap will SIGTERM the server when the
+# script exits. The trap captures SIGTERM_ELAPSED; we verify it is <7s
+# (M3 sets SHUTDOWN_DRAIN_MS=5s, plus a 2s buffer for the close-frame
+# round-trip + wss.close cleanup). A wedged shutdown that hits the
+# 120s SIGKILL would pass verify.sh silently pre-PR; this assertion
+# fires post-cleanup to catch that regression.
+trap '
+cleanup
+if [[ -n "${SIGTERM_ELAPSED}" ]]; then
+  echo "==> Stage: stage_sigterm_fast (elapsed=${SIGTERM_ELAPSED}s)"
+  if [[ "${SIGTERM_ELAPSED}" -ge 7 ]]; then
+    echo "FAIL: stage_sigterm_fast — server took ${SIGTERM_ELAPSED}s to exit (expected <7s, $(($SIGTERM_ELAPSED - 5))s past the 5s drain ceiling)."
+    exit 1
+  fi
+  echo "PASS: stage_sigterm_fast — server exited within ${SIGTERM_ELAPSED}s"
+fi
+' EXIT INT TERM


### PR DESCRIPTION
## Summary

Six MAJOR integ-coverage gaps surfaced by PR #524's 3-axis review. Each addressed as a separate `stage_*` in `verify.sh` so a failure surfaces which scenario broke. Pre-PR the integ only exercised 1 client + 3 reply patterns against itself; canonical WebSocket use cases (broadcast, deny, drain, large payload, shutdown speed) were uncovered.

Closes #528.

### Stages added

- **stage_multi_client (M4)** — 2 ws clients, broadcast from A reaches B but not A. Each client discovers its own `connectionId` via the sendMessage echo (`lambda-send` now includes it in the response — the only handler change since AWS API Gateway has no `list connections` endpoint and real broadcast handlers track recipients in external state).
- **stage_deny (M5)** — `lambda-connect` now returns `{statusCode: 403}` when the upgrade URL carries `?reject=true`. Asserts close frame 1008 (policy violation), complementing the mocked unit test. Catches close-frame propagation regressions a unit mock can't observe.
- **stage_disconnect (M6)** — grep server log for `$disconnect:` markers. Asserts ≥1 fired across the preceding stages. Pre-PR the clean-close path asserted only that `ws.close()` resolved.
- **stage_registry_drain** — after clean close, GET `/<stage>/@connections/<closed-id>` returns 410.
- **stage_large_payload** — 64KB body through $default. Exercises the multi-fragment buffer path bufferToBody handles but the smoke test never reached.
- **stage_sigterm_fast** — cleanup trap captures SIGTERM → exit elapsed time. Asserts < 7s (M3 SHUTDOWN_DRAIN_MS=5s + 2s close-frame buffer). A wedged shutdown that hits the 120s SIGKILL fallback would pass `verify.sh` silently pre-PR; this assertion fires post-cleanup to catch that regression.

### Files

- `lambda-broadcast/index.js` — `recipients: string[]` fan-out via `PostToConnection`. Falls back to echoing the sender so the basic stage still works.
- `lambda-send/index.js` — echo now includes `connectionId`.
- `lambda-connect/index.js` — returns 403 when `?reject=true`.
- `verify.sh` — refactored into `stage_*` functions + one shared client script with per-stage dispatch via argv.

## Out of scope

- The #531 N1/N3/m3 fold (mock accountId / IPv6 sourceIp / unused MOCK_ACCOUNT_ID) was deferred. Not folded here either — purely integ coverage in this PR. Will land in the next #531 cleanup PR.
- No `src/` changes; purely test/fixture additions.

## Test plan

- [x] `/run-integ local-start-api-websocket` end-to-end against real Docker — 7 stages, all pass. Server log shows lambda-disconnect fired 5 times across the stages. SIGTERM → exit elapsed: 1s. Zero Docker orphans after teardown.
- [x] Unit tests pass (5090 tests, unchanged from PR #539 baseline).
- [x] `vp check --fix` clean.
- [x] No CLI surface change; no schema change.
