### PR TITLE
fix(local): WebSocket #531 MINORs — accountId / apiCdkPath / test gaps

### DIFF
--- a/src/local/websocket-event.ts
+++ b/src/local/websocket-event.ts
@@ -81,6 +81,7 @@ export interface WebSocketRequestContextBase {
   apiId: string;
   authorizer: null;
   identity: {
+    accountId: string;
     sourceIp: string;
     userAgent: string;
   };
@@ -135,6 +136,13 @@ function buildRequestContext(
     apiId: MOCK_API_ID,
     authorizer: null,
     identity: {
+      // Mirror AWS-deployed WebSocket events: `requestContext.identity.accountId`
+      // carries the API owner's account id. Local emulation hard-codes the
+      // shared mock account so handler code reading this field is non-undefined,
+      // matching the deployed surface. The constant is exported via
+      // `WEBSOCKET_MOCK_CONSTANTS` so integ tests + handlers can assert against
+      // the same value.
+      accountId: MOCK_ACCOUNT_ID,
       sourceIp: snapshot.sourceIp ?? '127.0.0.1',
       userAgent: snapshot.userAgent ?? '',
     },

--- a/src/local/websocket-route-discovery.ts
+++ b/src/local/websocket-route-discovery.ts
@@ -213,7 +213,7 @@ function discoverOneApi(
     apiLogicalId: logicalId,
     apiStackName: stackName,
     declaredAt,
-    ...(apiCdkPath !== '' && { apiCdkPath }),
+    ...(apiCdkPath !== undefined && { apiCdkPath }),
     routeSelectionExpression,
     stage,
     routes,
@@ -469,8 +469,9 @@ function pickRefLogicalId(value: unknown): string | null {
   return null;
 }
 
-function readApiCdkPath(logicalId: string, template: CloudFormationTemplate): string {
+function readApiCdkPath(logicalId: string, template: CloudFormationTemplate): string | undefined {
   const resource = template.Resources?.[logicalId];
-  if (!resource) return '';
-  return readCdkPath(resource);
+  if (!resource) return undefined;
+  const path = readCdkPath(resource);
+  return path === '' ? undefined : path;
 }

--- a/tests/unit/local/websocket-event.test.ts
+++ b/tests/unit/local/websocket-event.test.ts
@@ -44,6 +44,11 @@ describe('buildConnectEvent', () => {
     expect(event.requestContext.authorizer).toBeNull();
     expect(event.requestContext.identity.sourceIp).toBe('127.0.0.1');
     expect(event.requestContext.identity.userAgent).toBe('wscat/1.0');
+    // #531 N1 + m3-code: AWS-deployed WebSocket events carry
+    // `requestContext.identity.accountId`; local emulation populates it
+    // from the shared mock account so handler code reading the field is
+    // non-undefined.
+    expect(event.requestContext.identity.accountId).toBe('123456789012');
     expect(event.requestContext.messageDirection).toBe('IN');
     expect(typeof event.requestContext.requestId).toBe('string');
     expect(event.requestContext.requestId.length).toBeGreaterThan(0);

--- a/tests/unit/local/websocket-route-discovery.test.ts
+++ b/tests/unit/local/websocket-route-discovery.test.ts
@@ -349,6 +349,82 @@ describe('parseSelectionExpressionPath', () => {
   });
 });
 
+// #531 m2-test: `parseSelectionExpressionPath` is only ever called on
+// expressions that passed `assertSupportedSelectionExpression` at
+// discovery time, but the discovery-side validator is the actual
+// boundary that user-supplied templates hit. Pin the rejection set so a
+// future grammar relaxation can't silently leak unsupported shapes into
+// the dispatcher.
+describe('selection expression validation rejection set (#531 m2)', () => {
+  const ApiResource = {
+    Type: 'AWS::ApiGatewayV2::Api',
+    Properties: {
+      ProtocolType: 'WEBSOCKET',
+    },
+  } as const;
+  // Build a stack with a hand-picked RouteSelectionExpression and assert
+  // the discovery surface error mentions exactly that string. The lambda
+  // / integration / route boilerplate matches the other tests in this
+  // file.
+  function tryExpression(expr: string): string | undefined {
+    const stack = buildStack('S', {
+      MyHandler: buildLambda(),
+      WsApi: {
+        ...ApiResource,
+        Properties: {
+          ...ApiResource.Properties,
+          RouteSelectionExpression: expr,
+        },
+      },
+      Integ: buildIntegration(),
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: {
+          ApiId: { Ref: 'WsApi' },
+          RouteKey: '$connect',
+          Target: { 'Fn::Join': ['', ['integrations/', { Ref: 'Integ' }]] },
+        },
+      },
+    });
+    const { errors } = discoverWebSocketApis([stack]);
+    return errors[0];
+  }
+
+  it.each([
+    // Trailing dot: regex requires at least one identifier after each
+    // dot; a bare trailing dot fails the `[A-Za-z_]` class.
+    '$request.body.',
+    // Nested trailing dot
+    '$request.body.action.',
+    // Uppercase prefix: regex is case-sensitive, matches AWS-deployed
+    // case-sensitive selection expressions.
+    '$REQUEST.body.action',
+    // Mixed-case middle: the leading `$request.body.` is literal.
+    '$Request.Body.action',
+    // Leading / trailing whitespace
+    ' $request.body.action',
+    '$request.body.action ',
+    // Identifier starting with a digit
+    '$request.body.1action',
+    // Empty key segment in the middle
+    '$request.body..action',
+    // Hyphen in identifier (regex only allows `[A-Za-z0-9_]`)
+    '$request.body.my-action',
+    // Array-index access (called out by the reviewer as a candidate for
+    // future support — must error today)
+    '$request.body[0]',
+    // Header / context shapes (already tested above; included here for
+    // grouping)
+    '$request.header.action',
+    '$context.connectionId',
+  ])('rejects %j with an actionable error', (expr) => {
+    const err = tryExpression(expr);
+    expect(err).toBeDefined();
+    expect(err).toContain(expr);
+    expect(err).toContain('not supported');
+  });
+});
+
 // B2 (#526): non-NONE `AuthorizationType` on any Route belonging to a
 // WebSocket API must tag the parent API as `unsupported`. cdkd v1 does
 // not emulate WebSocket authorizers; silently admitting unauthenticated

--- a/tests/unit/local/websocket-server.test.ts
+++ b/tests/unit/local/websocket-server.test.ts
@@ -344,6 +344,65 @@ describe('attachWebSocketServer end-to-end', () => {
     }
   });
 
+  // #531 m1-test: Node Lambda runtime emits `{errorMessage, errorType,
+  // stackTrace}` envelopes when a handler throws (or hits an unhandled
+  // promise rejection). The $connect verdict path at
+  // `invokeRouteAndDecideAuth` (websocket-server.ts) must treat this
+  // shape as a deny — AWS-deployed WebSocket APIs do not admit
+  // connections whose `$connect` handler threw. The
+  // `errorMessage`-without-`statusCode` precedence has no prior unit
+  // coverage; this test pins it.
+  it('denies $connect when handler returns Lambda error envelope (errorMessage without statusCode)', async () => {
+    rieModule.__resetQueue();
+    rieModule.__queueInvokeResult({
+      errorMessage: 'Cannot read properties of undefined',
+      errorType: 'TypeError',
+      stackTrace: ['at handler (/var/task/index.js:5:1)'],
+    });
+
+    const pool = buildFakePool();
+    const api = buildApi([{ routeKey: '$connect' }]);
+    const { port, close } = await startTestServer({
+      apis: [{ api, apiPath: '/prod' }],
+      pool,
+    });
+    try {
+      const ws = await openWebSocket(port, '/prod');
+      const closure = await awaitClose(ws);
+      expect(closure.code).toBe(1008);
+    } finally {
+      await close();
+    }
+  });
+
+  // #531 m1-test (cont.): when both `statusCode` AND `errorMessage` are
+  // present, `statusCode` wins — matches AWS-deployed behavior for
+  // handlers that build a response payload after catching their own
+  // exception.
+  it('admits $connect when statusCode: 200 is present even alongside errorMessage', async () => {
+    rieModule.__resetQueue();
+    rieModule.__queueInvokeResult({
+      statusCode: 200,
+      errorMessage: 'recoverable',
+    });
+
+    const pool = buildFakePool();
+    const api = buildApi([{ routeKey: '$connect' }]);
+    const { port, close } = await startTestServer({
+      apis: [{ api, apiPath: '/prod' }],
+      pool,
+    });
+    try {
+      const ws = await openWebSocket(port, '/prod');
+      await new Promise((r) => setTimeout(r, 50));
+      expect(ws.readyState).toBe(WebSocket.OPEN);
+      ws.close();
+      await awaitClose(ws);
+    } finally {
+      await close();
+    }
+  });
+
   it('admits $connect with no statusCode / no errorMessage (lenient AWS default)', async () => {
     rieModule.__resetQueue();
     rieModule.__queueInvokeResult({});


### PR DESCRIPTION
## Summary

Pick the high-value items off [#531](https://github.com/go-to-k/cdkd/issues/531)'s 21-item MINORs bundle from PR #524's 3-axis review.

- **N1 + m3-code**: `requestContext.identity.accountId` was undefined on every WebSocket event. AWS-deployed events carry it; local emulation now populates from the existing `MOCK_ACCOUNT_ID` constant so handler code reading the field matches the deployed surface.
- **N5**: `readApiCdkPath` returned `''` for missing-Metadata cases; switch to `string | undefined` and gate the spread on `!== undefined`. Internal-only cleanup, no behavior change on synthesized templates.
- **m1-test**: pin the Lambda runtime error envelope deny path (`{errorMessage, errorType, stackTrace}` without `statusCode` → 1008) and the statusCode-wins-over-errorMessage precedence. Previously uncovered by unit tests.
- **m2-test**: pin the rejection set for `assertSupportedSelectionExpression` — trailing dot, uppercase prefix, whitespace padding, hyphen, empty segment, array-index. Each shape produces an actionable error that names the offending expression.

Remaining items on the issue are pure documentation nits, environment-specific (Linux dockerd `host.docker.internal`), or already covered by tests added in #538 / #539 / #540. Full audit table will be posted on issue #531 at close time.

## Test plan

- [x] Unit tests pass (352 files, 5104 tests)
- [x] `vp check --fix` clean (lint + format + typecheck)
- [x] `vp run build` clean
- [x] No CLI / docs surface changed (internal event-shape + test additions only)
- [ ] CI passes
- [ ] After merge: close #531 with the audit table
