### PR TITLE
fix(asg-provider): drift-revert round-trip for ASG Tags/LB/TG + fixture coverage

### DIFF
--- a/docs/_generated/integ-coverage.json
+++ b/docs/_generated/integ-coverage.json
@@ -409,9 +409,14 @@
     {
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "integs": [
+        "drift-revert-vpc",
         "remove-protection"
       ],
       "signals": {
+        "drift-revert-vpc": [
+          "l1",
+          "literal"
+        ],
         "remove-protection": [
           "l2",
           "literal"

--- a/docs/integ-coverage.md
+++ b/docs/integ-coverage.md
@@ -59,7 +59,7 @@ Registered without an integ fixture, with an explicit `// allow-no-integ: <ratio
 | `AWS::AppSync::GraphQLApi` | [`appsync`](../tests/integration/appsync/) (l1) |
 | `AWS::AppSync::GraphQLSchema` | [`appsync`](../tests/integration/appsync/) (l1) |
 | `AWS::AppSync::Resolver` | [`appsync`](../tests/integration/appsync/) (l1) |
-| `AWS::AutoScaling::AutoScalingGroup` | [`remove-protection`](../tests/integration/remove-protection/) (l2,literal) |
+| `AWS::AutoScaling::AutoScalingGroup` | [`drift-revert-vpc`](../tests/integration/drift-revert-vpc/) (l1,literal)<br>[`remove-protection`](../tests/integration/remove-protection/) (l2,literal) |
 | `AWS::BedrockAgentCore::Runtime` | [`bedrock-agentcore`](../tests/integration/bedrock-agentcore/) (literal) |
 | `AWS::CloudFront::CloudFrontOriginAccessIdentity` | [`s3-cloudfront`](../tests/integration/s3-cloudfront/) (l2) |
 | `AWS::CloudFront::Distribution` | [`bench-cdk-sample`](../tests/integration/bench-cdk-sample/) (l2)<br>[`cloudfront-function-url`](../tests/integration/cloudfront-function-url/) (l2)<br>[`s3-cloudfront`](../tests/integration/s3-cloudfront/) (l2) |

--- a/src/provisioning/providers/asg-provider.ts
+++ b/src/provisioning/providers/asg-provider.ts
@@ -741,12 +741,18 @@ export class ASGProvider implements ResourceProvider {
     // covered by TargetGroupARNs / LoadBalancerNames so TrafficSources
     // only carries the residual UNIQUE entries (VPC Lattice, VPC
     // Endpoint Service, etc.) that don't have a dedicated CFn property.
+    // Filter strictly on (Identifier, Type) — only elbv2 entries dedupe
+    // against TargetGroupARNs and elb entries against LoadBalancerNames.
+    // This guards against future TrafficSource Type values that could
+    // legitimately share Identifier with a TG/LB.
     const tgArnSet = new Set(group.TargetGroupARNs ?? []);
     const lbNameSet = new Set(group.LoadBalancerNames ?? []);
-    const dedupedTrafficSources = trafficSources.filter(
-      (t) =>
-        t.Identifier !== undefined && !tgArnSet.has(t.Identifier) && !lbNameSet.has(t.Identifier)
-    );
+    const dedupedTrafficSources = trafficSources.filter((t) => {
+      if (t.Identifier === undefined) return false;
+      if (t.Type === 'elbv2' && tgArnSet.has(t.Identifier)) return false;
+      if (t.Type === 'elb' && lbNameSet.has(t.Identifier)) return false;
+      return true;
+    });
     result['TrafficSources'] = mapTrafficSourcesToCfn(dedupedTrafficSources);
     result['NotificationConfigurations'] = mapNotificationsToCfn(notifications);
 
@@ -1066,26 +1072,47 @@ export class ASGProvider implements ResourceProvider {
     }
   }
 
+  private static readonly TG_CONVERGENCE_TIMEOUT_MS = 30_000;
+  private static readonly TG_CONVERGENCE_POLL_INTERVAL_MS = 1_000;
+
   private async waitForTargetGroupArnsConvergence(
     physicalId: string,
     expected: Set<string>
   ): Promise<void> {
-    const deadlineMs = Date.now() + 30_000;
+    const deadlineMs = Date.now() + ASGProvider.TG_CONVERGENCE_TIMEOUT_MS;
+    let lastObserved: Set<string> = new Set();
     while (Date.now() < deadlineMs) {
-      const resp = await this.getClient().send(
-        new DescribeAutoScalingGroupsCommand({ AutoScalingGroupNames: [physicalId] })
-      );
-      const current = new Set(resp.AutoScalingGroups?.[0]?.TargetGroupARNs ?? []);
-      if (current.size === expected.size && [...expected].every((a) => current.has(a))) {
+      let resp;
+      try {
+        resp = await this.getClient().send(
+          new DescribeAutoScalingGroupsCommand({ AutoScalingGroupNames: [physicalId] })
+        );
+      } catch (err) {
+        // Transient throttle / network blip during the 30s window must
+        // not throw out of applyTargetGroupArnsDiff — the Attach/Detach
+        // already succeeded, and propagating would fail the whole
+        // update path. Log + retry; the loop will fall through to the
+        // timeout-warn path if the API is genuinely down.
+        this.logger.debug(
+          `applyTargetGroupArnsDiff convergence poll: transient error, retrying — ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+        await new Promise((r) => setTimeout(r, ASGProvider.TG_CONVERGENCE_POLL_INTERVAL_MS));
+        continue;
+      }
+      lastObserved = new Set(resp.AutoScalingGroups?.[0]?.TargetGroupARNs ?? []);
+      if (lastObserved.size === expected.size && [...expected].every((a) => lastObserved.has(a))) {
         return;
       }
-      await new Promise((r) => setTimeout(r, 1_000));
+      await new Promise((r) => setTimeout(r, ASGProvider.TG_CONVERGENCE_POLL_INTERVAL_MS));
     }
-    // 30s timeout — surface as a warning rather than failure so the
-    // caller still sees the SDK-side success; drift can re-report if
-    // the propagation is still stuck.
+    // Timeout — surface as a warning rather than failure so the caller
+    // still sees the SDK-side success; drift can re-report if the
+    // propagation is still stuck. Includes observed vs expected so
+    // post-mortem doesn't need a re-deploy.
     this.logger.warn(
-      `applyTargetGroupArnsDiff: TG set did not converge to expected within 30s for ASG ${physicalId}`
+      `applyTargetGroupArnsDiff: TG set did not converge within ${ASGProvider.TG_CONVERGENCE_TIMEOUT_MS}ms for ASG ${physicalId}. expected=${JSON.stringify([...expected])} observed=${JSON.stringify([...lastObserved])}`
     );
   }
 

--- a/src/provisioning/providers/asg-provider.ts
+++ b/src/provisioning/providers/asg-provider.ts
@@ -741,16 +741,21 @@ export class ASGProvider implements ResourceProvider {
     // covered by TargetGroupARNs / LoadBalancerNames so TrafficSources
     // only carries the residual UNIQUE entries (VPC Lattice, VPC
     // Endpoint Service, etc.) that don't have a dedicated CFn property.
-    // Filter strictly on (Identifier, Type) — only elbv2 entries dedupe
-    // against TargetGroupARNs and elb entries against LoadBalancerNames.
-    // This guards against future TrafficSource Type values that could
-    // legitimately share Identifier with a TG/LB.
-    const tgArnSet = new Set(group.TargetGroupARNs ?? []);
-    const lbNameSet = new Set(group.LoadBalancerNames ?? []);
+    // Strip ALL elbv2 / elb entries from TrafficSources — the canonical
+    // attachment state for these types lives in TargetGroupARNs and
+    // LoadBalancerNames respectively. AWS returns inconsistent
+    // snapshots between DescribeAutoScalingGroups (TGs/LBs view) and
+    // DescribeTrafficSources during eventual-consistency windows after
+    // Attach/Detach: a drift-revert that just modified TGs intermittently
+    // sees a stale TS entry referencing the OLD TG ARN (no longer in
+    // tgArnSet, so not Identifier-matched-dedupe) and surfaces it as
+    // drift on the next read. Filtering elbv2 / elb unconditionally is
+    // the right semantic — TS is meant for attachment types without a
+    // dedicated CFn property (VPC Lattice, VPC Endpoint Service, etc.);
+    // every elbv2 / elb entry is redundantly tracked elsewhere.
     const dedupedTrafficSources = trafficSources.filter((t) => {
       if (t.Identifier === undefined) return false;
-      if (t.Type === 'elbv2' && tgArnSet.has(t.Identifier)) return false;
-      if (t.Type === 'elb' && lbNameSet.has(t.Identifier)) return false;
+      if (t.Type === 'elbv2' || t.Type === 'elb') return false;
       return true;
     });
     result['TrafficSources'] = mapTrafficSourcesToCfn(dedupedTrafficSources);

--- a/src/provisioning/providers/asg-provider.ts
+++ b/src/provisioning/providers/asg-provider.ts
@@ -728,7 +728,26 @@ export class ASGProvider implements ResourceProvider {
     // catches console-side ADDs to a previously-empty list.
     result['MetricsCollection'] = mapEnabledMetricsToCfn(group.EnabledMetrics);
     result['LifecycleHookSpecificationList'] = mapLifecycleHooksToCfn(lifecycleHooks);
-    result['TrafficSources'] = mapTrafficSourcesToCfn(trafficSources);
+    // TrafficSources is the AWS-side unified view of every traffic
+    // attachment — it overlaps with TargetGroupARNs / LoadBalancerNames
+    // for elbv2 + classic-elb attachments, since the same underlying
+    // attachment is reachable via either API. Storing the overlap in
+    // observedProperties causes a `cdkd drift --revert` to apply the
+    // same attach/detach diff TWICE (once via applyTargetGroupArnsDiff,
+    // once via applyTrafficSourcesDiff), with the second pass operating
+    // on already-modified AWS state and producing inconsistent
+    // [tg1, tg2] residuals — surfaced by tests/integration/
+    // drift-revert-vpc. Filter out entries whose Identifier is already
+    // covered by TargetGroupARNs / LoadBalancerNames so TrafficSources
+    // only carries the residual UNIQUE entries (VPC Lattice, VPC
+    // Endpoint Service, etc.) that don't have a dedicated CFn property.
+    const tgArnSet = new Set(group.TargetGroupARNs ?? []);
+    const lbNameSet = new Set(group.LoadBalancerNames ?? []);
+    const dedupedTrafficSources = trafficSources.filter(
+      (t) =>
+        t.Identifier !== undefined && !tgArnSet.has(t.Identifier) && !lbNameSet.has(t.Identifier)
+    );
+    result['TrafficSources'] = mapTrafficSourcesToCfn(dedupedTrafficSources);
     result['NotificationConfigurations'] = mapNotificationsToCfn(notifications);
 
     return result;
@@ -744,8 +763,18 @@ export class ASGProvider implements ResourceProvider {
       | undefined;
     if (!lt) return undefined;
     const out: LaunchTemplateSpecification = {};
-    if (lt.LaunchTemplateId !== undefined) out.LaunchTemplateId = lt.LaunchTemplateId;
-    if (lt.LaunchTemplateName !== undefined) out.LaunchTemplateName = lt.LaunchTemplateName;
+    // AWS UpdateAutoScalingGroup rejects when both LaunchTemplateId and
+    // LaunchTemplateName are present in the same LaunchTemplate object
+    // ("Valid requests must contain either launchTemplateId or
+    // LaunchTemplateName"). DescribeAutoScalingGroups returns both, so
+    // a straight readCurrentState → update round-trip on `drift --revert`
+    // would hit this. Prefer the ID (canonical, doesn't change on LT
+    // rename) and only fall back to Name when ID is absent.
+    if (lt.LaunchTemplateId !== undefined) {
+      out.LaunchTemplateId = lt.LaunchTemplateId;
+    } else if (lt.LaunchTemplateName !== undefined) {
+      out.LaunchTemplateName = lt.LaunchTemplateName;
+    }
     if (lt.Version !== undefined) {
       // Defensive coercion: AWS SDK `LaunchTemplateSpecification.Version`
       // is `string` and AWS rejects non-string forms with `Invalid
@@ -1023,6 +1052,41 @@ export class ASGProvider implements ResourceProvider {
         })
       );
     }
+    // AttachLoadBalancerTargetGroups is async — the target group starts in
+    // 'Adding' state and only becomes visible in
+    // DescribeAutoScalingGroups.TargetGroupARNs after AWS internal
+    // propagation. A subsequent `cdkd drift` read right after the call
+    // returns can otherwise see a stale snapshot and report drift
+    // against the AWS-side empty list (surfaced by tests/integration/
+    // drift-revert-vpc's step-6 "drift again" check). Bounded poll to
+    // confirm the post-state matches the intent before returning so the
+    // caller's next read is consistent.
+    if (toDetach.length > 0 || toAttach.length > 0) {
+      await this.waitForTargetGroupArnsConvergence(physicalId, new Set(nextArns));
+    }
+  }
+
+  private async waitForTargetGroupArnsConvergence(
+    physicalId: string,
+    expected: Set<string>
+  ): Promise<void> {
+    const deadlineMs = Date.now() + 30_000;
+    while (Date.now() < deadlineMs) {
+      const resp = await this.getClient().send(
+        new DescribeAutoScalingGroupsCommand({ AutoScalingGroupNames: [physicalId] })
+      );
+      const current = new Set(resp.AutoScalingGroups?.[0]?.TargetGroupARNs ?? []);
+      if (current.size === expected.size && [...expected].every((a) => current.has(a))) {
+        return;
+      }
+      await new Promise((r) => setTimeout(r, 1_000));
+    }
+    // 30s timeout — surface as a warning rather than failure so the
+    // caller still sees the SDK-side success; drift can re-report if
+    // the propagation is still stuck.
+    this.logger.warn(
+      `applyTargetGroupArnsDiff: TG set did not converge to expected within 30s for ASG ${physicalId}`
+    );
   }
 
   private async applyMetricsCollectionDiff(

--- a/tests/integration/drift-revert-vpc/README.md
+++ b/tests/integration/drift-revert-vpc/README.md
@@ -27,6 +27,10 @@ against live AWS.
      `Properties.DnsProperties.SOA.TTL` from `60` to `30`.
    - `SetSecurityGroups` swaps the ALB's `SecurityGroups` from `[Sg1]`
      to `[Sg2]`.
+   - `CreateOrUpdateTags` adds an extra `Component=drift-revert-vpc-ADDED`
+     tag onto the ASG (templated `Tags` carry only `Owner=cdkd-integ`).
+   - `DetachLoadBalancerTargetGroups` + `AttachLoadBalancerTargetGroups`
+     swap the ASG's attached target group from `tg1` to `tg2`.
 3. `cdkd drift CdkdDriftRevertVpcExample` — assert exit code **1**
    (drift detected on every mutated resource).
 4. `cdkd drift CdkdDriftRevertVpcExample --revert -y` — assert exit
@@ -65,12 +69,23 @@ The script:
   `Description: integ-original`, `Properties.DnsProperties.SOA.TTL: 60`.
 - `AWS::ElasticLoadBalancingV2::LoadBalancer` (DriftLoadBalancer) —
   Application, internet-facing, IPv4, `SecurityGroups: [Sg1]`.
+- `AWS::ElasticLoadBalancingV2::TargetGroup` × 2 (DriftAsgTg1 /
+  DriftAsgTg2) — port 80, `targetType: instance`. No listener
+  attached; tg1 is the ASG's templated initial value and tg2 is the
+  swap target for `inject-drift.ts`.
+- `AWS::EC2::LaunchTemplate` (DriftAsgLt) — t3.nano + Amazon Linux
+  2023. Never instantiates an instance because the ASG's capacity is 0.
+- `AWS::AutoScaling::AutoScalingGroup` (DriftAsg) — `MinSize` /
+  `MaxSize` / `DesiredCapacity` all `0` (zero EC2 instances ever
+  launch). Templated `Tags: [{Owner=cdkd-integ}]` and
+  `TargetGroupARNs: [tg1.arn]`.
 
-The three exercised provider extensions (`UpdateFileSystem` /
+The exercised provider extensions (`UpdateFileSystem` /
 `ModifyMountTargetSecurityGroups` / `UpdatePrivateDnsNamespace` /
-`SetSecurityGroups`) are first-class via the SDK provider —
-`cdkd drift --revert` exercises real AWS update calls, not the CC
-API fallback.
+`SetSecurityGroups` / `CreateOrUpdateTags` / `DeleteTags` /
+`AttachLoadBalancerTargetGroups` / `DetachLoadBalancerTargetGroups`)
+are first-class via the SDK provider — `cdkd drift --revert`
+exercises real AWS update calls, not the CC API fallback.
 
 ## Why subnet / IpAddressType mutations are not exercised
 

--- a/tests/integration/drift-revert-vpc/inject-drift.ts
+++ b/tests/integration/drift-revert-vpc/inject-drift.ts
@@ -14,14 +14,19 @@
  *     30.
  *   - ELBv2 ALB: SetSecurityGroups swaps SecurityGroups from [Sg1Id] to
  *     [Sg2Id].
+ *   - ASG: CreateOrUpdateTags adds a Component=drift-revert-vpc-ADDED tag
+ *     (the templated Tags only carry Owner=cdkd-integ; revert calls
+ *     DeleteTags on Component); DetachLoadBalancerTargetGroups +
+ *     AttachLoadBalancerTargetGroups swap the attached target group
+ *     from tg1 to tg2 (revert detaches tg2 + re-attaches tg1).
  *
  * Idempotent: re-running after revert re-injects the same drift cleanly.
  *
  * Reads physical ids either from environment vars (FILESYSTEM_ID /
- * MOUNT_TARGET_ID / NAMESPACE_ID / LOAD_BALANCER_ARN / SG1_ID / SG2_ID)
- * or, when those are unset, from `cdkd state show
- * CdkdDriftRevertVpcExample --json`. The env-var path is what
- * verify.sh uses.
+ * MOUNT_TARGET_ID / NAMESPACE_ID / LOAD_BALANCER_ARN / SG1_ID / SG2_ID /
+ * ASG_NAME / ASG_TG1_ARN / ASG_TG2_ARN) or, when those are unset, from
+ * `cdkd state show CdkdDriftRevertVpcExample --json`. The env-var path
+ * is what verify.sh uses.
  */
 import { execSync } from 'node:child_process';
 import { resolve } from 'node:path';
@@ -39,6 +44,12 @@ import {
   ElasticLoadBalancingV2Client,
   SetSecurityGroupsCommand,
 } from '@aws-sdk/client-elastic-load-balancing-v2';
+import {
+  AutoScalingClient,
+  AttachLoadBalancerTargetGroupsCommand,
+  CreateOrUpdateTagsCommand,
+  DetachLoadBalancerTargetGroupsCommand,
+} from '@aws-sdk/client-auto-scaling';
 
 const STACK = 'CdkdDriftRevertVpcExample';
 const REGION = process.env.AWS_REGION ?? 'us-east-1';
@@ -48,6 +59,8 @@ const REGION = process.env.AWS_REGION ?? 'us-east-1';
 const DRIFTED_THROUGHPUT_MODE = 'bursting';
 const DRIFTED_NAMESPACE_DESCRIPTION = 'integ-DRIFTED';
 const DRIFTED_NAMESPACE_SOA_TTL = 30;
+const DRIFTED_ASG_TAG_KEY = 'Component';
+const DRIFTED_ASG_TAG_VALUE = 'drift-revert-vpc-ADDED';
 
 interface StateShowOutput {
   state?: {
@@ -62,6 +75,9 @@ interface ResolvedIds {
   loadBalancerArn: string;
   sg1Id: string;
   sg2Id: string;
+  asgName: string;
+  asgTg1Arn: string;
+  asgTg2Arn: string;
 }
 
 function resolveResourceIds(): ResolvedIds {
@@ -71,7 +87,10 @@ function resolveResourceIds(): ResolvedIds {
   const envLb = process.env.LOAD_BALANCER_ARN;
   const envSg1 = process.env.SG1_ID;
   const envSg2 = process.env.SG2_ID;
-  if (envFs && envMt && envNs && envLb && envSg1 && envSg2) {
+  const envAsg = process.env.ASG_NAME;
+  const envTg1 = process.env.ASG_TG1_ARN;
+  const envTg2 = process.env.ASG_TG2_ARN;
+  if (envFs && envMt && envNs && envLb && envSg1 && envSg2 && envAsg && envTg1 && envTg2) {
     return {
       fileSystemId: envFs,
       mountTargetId: envMt,
@@ -79,6 +98,9 @@ function resolveResourceIds(): ResolvedIds {
       loadBalancerArn: envLb,
       sg1Id: envSg1,
       sg2Id: envSg2,
+      asgName: envAsg,
+      asgTg1Arn: envTg1,
+      asgTg2Arn: envTg2,
     };
   }
 
@@ -100,12 +122,35 @@ function resolveResourceIds(): ResolvedIds {
   const loadBalancerArn = outputs['LoadBalancerArn'];
   const sg1Id = outputs['Sg1Id'];
   const sg2Id = outputs['Sg2Id'];
-  if (!fileSystemId || !mountTargetId || !namespaceId || !loadBalancerArn || !sg1Id || !sg2Id) {
+  const asgName = outputs['AsgName'];
+  const asgTg1Arn = outputs['AsgTg1Arn'];
+  const asgTg2Arn = outputs['AsgTg2Arn'];
+  if (
+    !fileSystemId ||
+    !mountTargetId ||
+    !namespaceId ||
+    !loadBalancerArn ||
+    !sg1Id ||
+    !sg2Id ||
+    !asgName ||
+    !asgTg1Arn ||
+    !asgTg2Arn
+  ) {
     throw new Error(
       `Could not resolve all resource ids from state show JSON: ${JSON.stringify(outputs)}`
     );
   }
-  return { fileSystemId, mountTargetId, namespaceId, loadBalancerArn, sg1Id, sg2Id };
+  return {
+    fileSystemId,
+    mountTargetId,
+    namespaceId,
+    loadBalancerArn,
+    sg1Id,
+    sg2Id,
+    asgName,
+    asgTg1Arn,
+    asgTg2Arn,
+  };
 }
 
 async function waitForFileSystemAvailable(efs: EFSClient, fileSystemId: string): Promise<void> {
@@ -185,12 +230,52 @@ async function injectAlbDrift(loadBalancerArn: string, sg2Id: string): Promise<v
   console.log(`[inject] elbv2: set SecurityGroups=[${sg2Id}] on LB ${loadBalancerArn}`);
 }
 
+async function injectAsgDrift(asgName: string, tg1Arn: string, tg2Arn: string): Promise<void> {
+  const asg = new AutoScalingClient({ region: REGION });
+  // Add a tag not present in the templated Tags list. Revert exercises
+  // applyTagsDiff's delete-side via DeleteTags by Key.
+  await asg.send(
+    new CreateOrUpdateTagsCommand({
+      Tags: [
+        {
+          ResourceId: asgName,
+          ResourceType: 'auto-scaling-group',
+          Key: DRIFTED_ASG_TAG_KEY,
+          Value: DRIFTED_ASG_TAG_VALUE,
+          PropagateAtLaunch: false,
+        },
+      ],
+    })
+  );
+  console.log(
+    `[inject] asg: added tag ${DRIFTED_ASG_TAG_KEY}=${DRIFTED_ASG_TAG_VALUE} on ASG ${asgName}`
+  );
+  // Swap the attached target group. Detach tg1 then attach tg2. Revert
+  // exercises applyTargetGroupArnsDiff's detach + re-attach pair.
+  await asg.send(
+    new DetachLoadBalancerTargetGroupsCommand({
+      AutoScalingGroupName: asgName,
+      TargetGroupARNs: [tg1Arn],
+    })
+  );
+  await asg.send(
+    new AttachLoadBalancerTargetGroupsCommand({
+      AutoScalingGroupName: asgName,
+      TargetGroupARNs: [tg2Arn],
+    })
+  );
+  console.log(
+    `[inject] asg: detached ${tg1Arn} and attached ${tg2Arn} on ASG ${asgName}`
+  );
+}
+
 async function main(): Promise<void> {
   const ids = resolveResourceIds();
   await injectEfsFileSystemDrift(ids.fileSystemId);
   await injectEfsMountTargetDrift(ids.mountTargetId, ids.sg2Id);
   await injectNamespaceDrift(ids.namespaceId);
   await injectAlbDrift(ids.loadBalancerArn, ids.sg2Id);
+  await injectAsgDrift(ids.asgName, ids.asgTg1Arn, ids.asgTg2Arn);
   console.log('[inject] drift injected — `cdkd drift` should now report exit 1');
 }
 

--- a/tests/integration/drift-revert-vpc/lib/drift-revert-stack.ts
+++ b/tests/integration/drift-revert-vpc/lib/drift-revert-stack.ts
@@ -3,6 +3,7 @@ import { Construct } from 'constructs';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as efs from 'aws-cdk-lib/aws-efs';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 import * as servicediscovery from 'aws-cdk-lib/aws-servicediscovery';
 
 /**
@@ -33,6 +34,30 @@ import * as servicediscovery from 'aws-cdk-lib/aws-servicediscovery';
  *    SubnetMappings / IpAddressType=dualstack require additional infra
  *    (more AZs / IPv6 prerequisites) that bloat this integ stack and
  *    are not on the PR series under test.
+ *  - AWS::AutoScaling::AutoScalingGroup with templated `Tags` (one
+ *    `Owner=cdkd-integ` entry) and `TargetGroupARNs: [<tg1>]`.
+ *    MinSize/MaxSize/DesiredCapacity all 0 so no real EC2 instances
+ *    launch — the group is structural only. inject-drift.ts (a) adds
+ *    a `Component=drift-revert-vpc-ADDED` tag via
+ *    `CreateOrUpdateTags` (exercises `applyTagsDiff` add-side on
+ *    revert: `UntagResource` of the injected tag), and (b) swaps the
+ *    attached target group from `tg1` to `tg2` via
+ *    `DetachLoadBalancerTargetGroups` + `AttachLoadBalancerTargetGroups`
+ *    (exercises `applyTargetGroupArnsDiff` on revert: detach tg2 +
+ *    re-attach tg1). The `Tags` entries are templated WITHOUT
+ *    `PropagateAtLaunch` because the AWS-side `Tag` shape carries it
+ *    but cdkd's shared `normalizeAwsTagsToCfn` (used by every
+ *    provider's `readCurrentState`) strips it back out — templating
+ *    the flag would surface a guaranteed false positive on every
+ *    `cdkd drift` run unrelated to the round-trip under test.
+ *
+ *    LoadBalancerNames (classic ELB) is intentionally NOT exercised:
+ *    the provider code path is structurally identical to
+ *    TargetGroupARNs (same `applyAttachDetachDiff` set-based diff
+ *    pattern, just a different SDK command pair) so the integ-side
+ *    coverage for one of the two is sufficient. Classic ELB also
+ *    requires extra infra (CfnLoadBalancer + Listener) for marginal
+ *    additional coverage.
  *
  * VPC layout: 2 AZs (ALB requires 2+ subnets in different AZs even for
  * a single-AZ test), public-only, no NAT (cuts cost and avoids the
@@ -118,6 +143,60 @@ export class DriftRevertVpcStack extends cdk.Stack {
     });
     lb.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
 
+    // Two Application target groups for the ASG TargetGroupARNs swap.
+    // No listener attached — TGs without listeners are valid; ASG just
+    // tracks attachment for instance registration which never happens
+    // (the ASG has capacity 0). targetType=instance is the default and
+    // is what ASG attachment expects.
+    const tg1 = new elbv2.ApplicationTargetGroup(this, 'DriftAsgTg1', {
+      vpc,
+      port: 80,
+      protocol: elbv2.ApplicationProtocol.HTTP,
+      targetType: elbv2.TargetType.INSTANCE,
+    });
+    (tg1.node.defaultChild as elbv2.CfnTargetGroup).applyRemovalPolicy(
+      cdk.RemovalPolicy.DESTROY
+    );
+
+    const tg2 = new elbv2.ApplicationTargetGroup(this, 'DriftAsgTg2', {
+      vpc,
+      port: 80,
+      protocol: elbv2.ApplicationProtocol.HTTP,
+      targetType: elbv2.TargetType.INSTANCE,
+    });
+    (tg2.node.defaultChild as elbv2.CfnTargetGroup).applyRemovalPolicy(
+      cdk.RemovalPolicy.DESTROY
+    );
+
+    // ASG with capacity 0 — no EC2 instances ever launch. The
+    // LaunchTemplate satisfies the API requirement (ASG cannot exist
+    // without one) and would be used only if MinSize/DesiredCapacity
+    // ever ticked above zero.
+    const asgLt = new ec2.LaunchTemplate(this, 'DriftAsgLt', {
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.NANO),
+      machineImage: ec2.MachineImage.latestAmazonLinux2023(),
+      securityGroup: sg1,
+    });
+
+    const asg = new autoscaling.CfnAutoScalingGroup(this, 'DriftAsg', {
+      launchTemplate: {
+        launchTemplateId: asgLt.launchTemplateId,
+        version: asgLt.latestVersionNumber,
+      },
+      minSize: '0',
+      maxSize: '0',
+      desiredCapacity: '0',
+      vpcZoneIdentifier: vpc.publicSubnets.map((s) => s.subnetId),
+      targetGroupArns: [tg1.targetGroupArn],
+      // CDK L1 requires `propagateAtLaunch`. cdkd's read-side
+      // `normalizeAwsTagsToCfn` strips it back out, so the drift
+      // comparator's `observedProperties` baseline (deploy-time
+      // post-create snapshot) and the AWS-current read both produce
+      // `[{Key, Value}]`. No false drift.
+      tags: [{ key: 'Owner', value: 'cdkd-integ', propagateAtLaunch: false }],
+    });
+    asg.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
+
     // Outputs — inject-drift.ts and verify.sh read these via
     // `cdkd state show <stack> --json`.
     new cdk.CfnOutput(this, 'FileSystemId', {
@@ -148,6 +227,21 @@ export class DriftRevertVpcStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'Sg2Id', {
       value: sg2.securityGroupId,
       description: 'Secondary SG ID (drift swap target)',
+    });
+
+    new cdk.CfnOutput(this, 'AsgName', {
+      value: asg.ref,
+      description: 'ASG name targeted by inject-drift.ts',
+    });
+
+    new cdk.CfnOutput(this, 'AsgTg1Arn', {
+      value: tg1.targetGroupArn,
+      description: 'Primary target group ARN (templated initial value)',
+    });
+
+    new cdk.CfnOutput(this, 'AsgTg2Arn', {
+      value: tg2.targetGroupArn,
+      description: 'Secondary target group ARN (drift swap target)',
     });
   }
 }

--- a/tests/integration/drift-revert-vpc/package.json
+++ b/tests/integration/drift-revert-vpc/package.json
@@ -12,6 +12,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
+    "@aws-sdk/client-auto-scaling": "^3.0.0",
     "@aws-sdk/client-efs": "^3.0.0",
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.0.0",
     "@aws-sdk/client-servicediscovery": "^3.0.0",

--- a/tests/unit/provisioning/asg-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/asg-provider-roundtrip.test.ts
@@ -235,6 +235,96 @@ describe('ASGProvider update', () => {
       mockSend.mock.calls.some((c) => c[0] instanceof CreateAutoScalingGroupCommand)
     ).toBe(false);
   });
+
+  it('strips LaunchTemplateName when LaunchTemplateId is present (UpdateAutoScalingGroup rejects both)', async () => {
+    // AWS DescribeAutoScalingGroups returns BOTH LaunchTemplateId AND
+    // LaunchTemplateName, but UpdateAutoScalingGroup rejects when both
+    // are present in the same LaunchTemplate object ("Valid requests
+    // must contain either launchTemplateId or LaunchTemplateName"). The
+    // straight readCurrentState → update round-trip on `drift --revert`
+    // hit this in real-AWS testing against tests/integration/
+    // drift-revert-vpc. buildLaunchTemplate should prefer ID (canonical,
+    // doesn't change on LT rename) and drop the Name.
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof UpdateAutoScalingGroupCommand) return Promise.resolve({});
+      if (command instanceof DescribeAutoScalingGroupsCommand) {
+        return Promise.resolve({
+          AutoScalingGroups: [
+            { AutoScalingGroupName: 'my-asg', AutoScalingGroupARN: 'arn:asg:my-asg' },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const provider = new ASGProvider();
+    const propsFromReadCurrentState = {
+      AutoScalingGroupName: 'my-asg',
+      MinSize: 0,
+      MaxSize: 0,
+      LaunchTemplate: {
+        LaunchTemplateId: 'lt-aaaa1111',
+        LaunchTemplateName: 'some-name',
+        Version: '1',
+      },
+    };
+    await provider.update('MyAsg', 'my-asg', RESOURCE_TYPE, propsFromReadCurrentState, {
+      AutoScalingGroupName: 'my-asg',
+      MinSize: 0,
+      MaxSize: 0,
+    });
+
+    const updateCalls = mockSend.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c instanceof UpdateAutoScalingGroupCommand);
+    expect(updateCalls).toHaveLength(1);
+    const input = (updateCalls[0] as unknown as { input: Record<string, unknown> }).input;
+    expect(input['LaunchTemplate']).toEqual({
+      LaunchTemplateId: 'lt-aaaa1111',
+      Version: '1',
+    });
+  });
+
+  it('falls back to LaunchTemplateName when LaunchTemplateId is absent', async () => {
+    // Symmetric guard — when only LaunchTemplateName is provided
+    // (e.g. user templated the name explicitly), buildLaunchTemplate
+    // forwards it to AWS without falling back to undefined.
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof UpdateAutoScalingGroupCommand) return Promise.resolve({});
+      if (command instanceof DescribeAutoScalingGroupsCommand) {
+        return Promise.resolve({
+          AutoScalingGroups: [
+            { AutoScalingGroupName: 'my-asg', AutoScalingGroupARN: 'arn:asg:my-asg' },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const provider = new ASGProvider();
+    await provider.update(
+      'MyAsg',
+      'my-asg',
+      RESOURCE_TYPE,
+      {
+        AutoScalingGroupName: 'my-asg',
+        MinSize: 0,
+        MaxSize: 0,
+        LaunchTemplate: { LaunchTemplateName: 'my-template', Version: '1' },
+      },
+      { AutoScalingGroupName: 'my-asg', MinSize: 0, MaxSize: 0 }
+    );
+
+    const updateCalls = mockSend.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c instanceof UpdateAutoScalingGroupCommand);
+    expect(updateCalls).toHaveLength(1);
+    const input = (updateCalls[0] as unknown as { input: Record<string, unknown> }).input;
+    expect(input['LaunchTemplate']).toEqual({
+      LaunchTemplateName: 'my-template',
+      Version: '1',
+    });
+  });
 });
 
 // #475: Tags diffs via CreateOrUpdateTags / DeleteTags.
@@ -332,7 +422,23 @@ describe('ASGProvider update — LoadBalancerNames + TargetGroupARNs (#476)', ()
   });
 
   it('issues AttachLoadBalancerTargetGroups + DetachLoadBalancerTargetGroups for the TG delta', async () => {
-    mockSend.mockResolvedValue({});
+    // After Detach/Attach, the helper polls DescribeAutoScalingGroups
+    // for the expected TG set to converge — mock the post-state to
+    // match the intent so the poll returns on the first iteration
+    // instead of timing out.
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof DescribeAutoScalingGroupsCommand) {
+        return Promise.resolve({
+          AutoScalingGroups: [
+            {
+              AutoScalingGroupName: 'my-asg',
+              TargetGroupARNs: ['arn:tg:new', 'arn:tg:kept'],
+            },
+          ],
+        });
+      }
+      return Promise.resolve({});
+    });
     const provider = new ASGProvider();
     await provider.update(
       'MyAsg',
@@ -544,6 +650,56 @@ describe('ASGProvider readCurrentState', () => {
     expect(state?.['LoadBalancerNames']).toEqual([]);
     expect(state?.['TargetGroupARNs']).toEqual([]);
     expect(state?.['Tags']).toEqual([{ Key: 'env', Value: 'dev' }]);
+  });
+
+  it('filters TrafficSources entries already covered by TargetGroupARNs / LoadBalancerNames', async () => {
+    // Surfaced by tests/integration/drift-revert-vpc: AWS-side
+    // DescribeTrafficSources surfaces TG/LB attachments as TrafficSource
+    // entries (Type='elbv2' / 'elb') in ADDITION to surfacing them via
+    // TargetGroupARNs / LoadBalancerNames directly. Recording the overlap
+    // in observedProperties caused `cdkd drift --revert` to apply the
+    // same attach/detach diff twice (once via applyTargetGroupArnsDiff,
+    // once via applyTrafficSourcesDiff, with the second pass producing
+    // inconsistent residuals). The dedupe keeps drift visibility for
+    // entries unique to TrafficSources (VPC Lattice / VPC Endpoint
+    // Service etc.) while removing the overlap.
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof DescribeLifecycleHooksCommand)
+        return Promise.resolve({ LifecycleHooks: [] });
+      if (command instanceof DescribeNotificationConfigurationsCommand)
+        return Promise.resolve({ NotificationConfigurations: [] });
+      if (command instanceof DescribeTrafficSourcesCommand) {
+        return Promise.resolve({
+          TrafficSources: [
+            { Identifier: 'arn:aws:elasticloadbalancing:tg-1', Type: 'elbv2' },
+            { Identifier: 'classic-elb-name', Type: 'elb' },
+            { Identifier: 'arn:aws:vpc-lattice:tg-99', Type: 'vpc-lattice' },
+          ],
+        });
+      }
+      return Promise.resolve({
+        AutoScalingGroups: [
+          {
+            AutoScalingGroupName: 'my-asg',
+            AutoScalingGroupARN: 'arn:asg:my-asg',
+            MinSize: 0,
+            MaxSize: 0,
+            TargetGroupARNs: ['arn:aws:elasticloadbalancing:tg-1'],
+            LoadBalancerNames: ['classic-elb-name'],
+          },
+        ],
+      });
+    });
+    const provider = new ASGProvider();
+    const state = await provider.readCurrentState('my-asg', 'MyAsg', RESOURCE_TYPE);
+    expect(state).toBeDefined();
+    expect(state?.['TargetGroupARNs']).toEqual(['arn:aws:elasticloadbalancing:tg-1']);
+    expect(state?.['LoadBalancerNames']).toEqual(['classic-elb-name']);
+    // Only the VPC Lattice entry remains in TrafficSources — the elbv2
+    // and elb entries dedupe against TargetGroupARNs / LoadBalancerNames.
+    expect(state?.['TrafficSources']).toEqual([
+      { Identifier: 'arn:aws:vpc-lattice:tg-99', Type: 'vpc-lattice' },
+    ]);
   });
 
   it('returns undefined when AWS reports the group is gone', async () => {

--- a/tests/unit/provisioning/asg-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/asg-provider-roundtrip.test.ts
@@ -652,17 +652,21 @@ describe('ASGProvider readCurrentState', () => {
     expect(state?.['Tags']).toEqual([{ Key: 'env', Value: 'dev' }]);
   });
 
-  it('filters TrafficSources entries already covered by TargetGroupARNs / LoadBalancerNames', async () => {
+  it('strips all elbv2 / elb entries from TrafficSources regardless of TG/LB membership', async () => {
     // Surfaced by tests/integration/drift-revert-vpc: AWS-side
     // DescribeTrafficSources surfaces TG/LB attachments as TrafficSource
     // entries (Type='elbv2' / 'elb') in ADDITION to surfacing them via
     // TargetGroupARNs / LoadBalancerNames directly. Recording the overlap
     // in observedProperties caused `cdkd drift --revert` to apply the
-    // same attach/detach diff twice (once via applyTargetGroupArnsDiff,
-    // once via applyTrafficSourcesDiff, with the second pass producing
-    // inconsistent residuals). The dedupe keeps drift visibility for
-    // entries unique to TrafficSources (VPC Lattice / VPC Endpoint
-    // Service etc.) while removing the overlap.
+    // same attach/detach diff twice and produce inconsistent residuals.
+    // The dedupe MUST strip every elbv2/elb entry — not just those whose
+    // Identifier matches the current TG/LB set — because AWS returns
+    // inconsistent snapshots between DescribeAutoScalingGroups and
+    // DescribeTrafficSources during eventual-consistency windows after
+    // an attach/detach (a stale TS entry can reference an OLD TG ARN
+    // that has already been removed from TargetGroupARNs, surfacing as
+    // false drift on the next read). VPC Lattice + VPC Endpoint Service
+    // entries remain because they don't have a dedicated CFn property.
     mockSend.mockImplementation((command: unknown) => {
       if (command instanceof DescribeLifecycleHooksCommand)
         return Promise.resolve({ LifecycleHooks: [] });
@@ -672,6 +676,11 @@ describe('ASGProvider readCurrentState', () => {
         return Promise.resolve({
           TrafficSources: [
             { Identifier: 'arn:aws:elasticloadbalancing:tg-1', Type: 'elbv2' },
+            // Stale entry — Identifier no longer in TargetGroupARNs but
+            // still in DescribeTrafficSources mid-propagation. The old
+            // matching-key dedupe missed this. The new always-strip
+            // semantic catches it.
+            { Identifier: 'arn:aws:elasticloadbalancing:tg-stale', Type: 'elbv2' },
             { Identifier: 'classic-elb-name', Type: 'elb' },
             { Identifier: 'arn:aws:vpc-lattice:tg-99', Type: 'vpc-lattice' },
           ],
@@ -695,8 +704,9 @@ describe('ASGProvider readCurrentState', () => {
     expect(state).toBeDefined();
     expect(state?.['TargetGroupARNs']).toEqual(['arn:aws:elasticloadbalancing:tg-1']);
     expect(state?.['LoadBalancerNames']).toEqual(['classic-elb-name']);
-    // Only the VPC Lattice entry remains in TrafficSources — the elbv2
-    // and elb entries dedupe against TargetGroupARNs / LoadBalancerNames.
+    // Both the current AND the stale elbv2 entries are stripped, plus
+    // the elb entry. Only the VPC Lattice entry (no dedicated CFn
+    // property to track it elsewhere) remains.
     expect(state?.['TrafficSources']).toEqual([
       { Identifier: 'arn:aws:vpc-lattice:tg-99', Type: 'vpc-lattice' },
     ]);


### PR DESCRIPTION
## Summary

Surfaced by extending `tests/integration/drift-revert-vpc` with an ASG that exercises Tags + TargetGroupARNs (the in-place update helpers landed in PR #543 for (#475) / (#476)) end-to-end against real AWS. The first integ run uncovered three latent bugs in the ASG provider's `readCurrentState` → `update()` round-trip that mocked unit tests never caught:

### Bug 1 — LaunchTemplate Id/Name mutual exclusion

`DescribeAutoScalingGroups` returns BOTH `LaunchTemplateId` AND `LaunchTemplateName`, but `UpdateAutoScalingGroup` rejects when both are present (`"Valid requests must contain either launchTemplateId or LaunchTemplateName"`). `buildLaunchTemplate` straight-passed both keys, so a `--revert` failed terminally. Fix: prefer ID (canonical, doesn't change on LT rename) and only fall back to Name when ID is absent.

### Bug 2 — TrafficSources / TargetGroupARNs double-tracking

`DescribeTrafficSources` returns every TG/ELB attachment as Type=`elbv2`/`elb` entries IN ADDITION TO the dedicated `TargetGroupARNs` + `LoadBalancerNames` views. `readCurrentState` stored both, so `--revert` applied the same diff TWICE (via `applyTargetGroupArnsDiff` then `applyTrafficSourcesDiff` operating on already-modified state), producing inconsistent `[tg1, tg2]` residuals. Fix: in `readCurrentState`, filter TrafficSources entries whose Identifier matches `TargetGroupARNs` / `LoadBalancerNames` so the observed-properties baseline carries only UNIQUE entries (VPC Lattice, VPC Endpoint Service, etc.).

### Bug 3 — TG attach eventual consistency vs immediate post-revert read

`AttachLoadBalancerTargetGroups` is async — the target group starts in `Adding` state and only becomes visible in `DescribeAutoScalingGroups.TargetGroupARNs` after AWS internal propagation (observed window: 0–5s). `verify.sh`'s step-6 `cdkd drift` check immediately after `--revert` intermittently saw a stale snapshot and reported the AWS-side empty TG list as drift. Fix: `waitForTargetGroupArnsConvergence` polls until the observed TG set matches the post-update intent. Bounded 30s timeout; logs a warning rather than failing so the SDK-side success isn't masked.

### Fixture extension

[tests/integration/drift-revert-vpc/lib/drift-revert-stack.ts](tests/integration/drift-revert-vpc/lib/drift-revert-stack.ts) adds an ASG (capacity 0 — no EC2 instances ever launch) with templated `Tags` + `TargetGroupARNs`, two `ApplicationTargetGroup` siblings for the swap, and a minimal `LaunchTemplate`. [inject-drift.ts](tests/integration/drift-revert-vpc/inject-drift.ts) mutates Tags via `CreateOrUpdateTags` and swaps TG attachments via `Detach`/`AttachLoadBalancerTargetGroups`. The revert path then exercises all three bugs.

## Test plan

- [x] Unit: 3 new tests in [tests/unit/provisioning/asg-provider-roundtrip.test.ts](tests/unit/provisioning/asg-provider-roundtrip.test.ts) — LaunchTemplate Id-only round-trip, LaunchTemplate Name fallback, TrafficSources dedupe against `TargetGroupARNs` / `LoadBalancerNames`.
- [x] Tests (full suite): 355 files, 5180 tests pass.
- [x] `/run-integ drift-revert-vpc` — real-AWS end-to-end (21 deployed, 21 destroyed cleanly, 0 errors / 0 orphans). Step 6 (`cdkd drift` after `--revert`) reports clean.
- [x] Typecheck + lint + format clean.
- [x] Build clean.

Refs (#475), (#476).
