### PR TITLE
feat(provisioning): in-place update for Firehose RedshiftDestinationConfiguration

### DIFF
--- a/src/provisioning/providers/firehose-provider.ts
+++ b/src/provisioning/providers/firehose-provider.ts
@@ -41,6 +41,20 @@ import type {
 } from '../../types/resource.js';
 
 /**
+ * CFn destination property names that this provider can apply
+ * in-place via UpdateDestinationCommand. Other destination types
+ * still hard-reject in update() with a tightened error pointing at
+ * the per-shape reverse-mapper follow-up issue (#549).
+ *
+ * Membership grows as each follow-up PR lands. Keep alphabetical
+ * to minimize merge conflicts when multiple follow-ups race.
+ */
+const SUPPORTED_UPDATE_DESTINATIONS: ReadonlySet<string> = new Set([
+  'ExtendedS3DestinationConfiguration',
+  'RedshiftDestinationConfiguration',
+]);
+
+/**
  * SDK Provider for AWS Kinesis Firehose resources
  *
  * Supports:
@@ -453,11 +467,7 @@ export class FirehoseProvider implements ResourceProvider {
     }
 
     const activeDest = destKey ?? prevDestKey;
-    const SUPPORTED_DESTINATIONS = new Set([
-      'ExtendedS3DestinationConfiguration',
-      'RedshiftDestinationConfiguration',
-    ]);
-    if (activeDest && !SUPPORTED_DESTINATIONS.has(activeDest)) {
+    if (activeDest && !SUPPORTED_UPDATE_DESTINATIONS.has(activeDest)) {
       // Some other destination type — check whether it actually changed,
       // and reject only if it did. Tags-only diffs against e.g. a Splunk
       // delivery stream should NOT throw.
@@ -961,6 +971,11 @@ export class FirehoseProvider implements ResourceProvider {
       result.CloudWatchLoggingOptions = config[
         'CloudWatchLoggingOptions'
       ] as RedshiftDestinationUpdate['CloudWatchLoggingOptions'];
+    }
+    if (config['SecretsManagerConfiguration'] !== undefined) {
+      result.SecretsManagerConfiguration = config[
+        'SecretsManagerConfiguration'
+      ] as RedshiftDestinationUpdate['SecretsManagerConfiguration'];
     }
     return result;
   }

--- a/src/provisioning/providers/firehose-provider.ts
+++ b/src/provisioning/providers/firehose-provider.ts
@@ -13,6 +13,7 @@ import {
   type S3DestinationConfiguration,
   type ExtendedS3DestinationConfiguration,
   type ExtendedS3DestinationUpdate,
+  type RedshiftDestinationUpdate,
   type S3DestinationUpdate,
   type Tag,
   type HttpEndpointDestinationConfiguration,
@@ -397,16 +398,29 @@ export class FirehoseProvider implements ResourceProvider {
    *     `DescribeDeliveryStream` call, then applies the diff. Only fires
    *     when the destination shape actually differs.
    *
+   *   - `RedshiftDestinationConfiguration` (#549) — same flow as
+   *     ExtendedS3: `DescribeDeliveryStream` recovers VersionId +
+   *     DestinationId, then `UpdateDestinationCommand` issues the
+   *     diff with a `RedshiftDestinationUpdate` payload produced by
+   *     {@link mapRedshiftConfigToUpdate}. Handles `CopyCommand`,
+   *     `RetryOptions`, `S3Configuration` → `S3Update`,
+   *     `S3BackupConfiguration` → `S3BackupUpdate`,
+   *     `ProcessingConfiguration`, `S3BackupMode`,
+   *     `CloudWatchLoggingOptions`, `Username` / `Password` /
+   *     `RoleARN` / `ClusterJDBCURL`.
+   *
    * Other destination types (`S3DestinationConfiguration`,
-   * `HttpEndpointDestinationConfiguration`, `RedshiftDestinationConfiguration`,
+   * `HttpEndpointDestinationConfiguration`,
    * `ElasticsearchDestinationConfiguration`,
    * `AmazonopensearchserviceDestinationConfiguration`,
    * `SplunkDestinationConfiguration`,
-   * `AmazonOpenSearchServerlessDestinationConfiguration`) stay rejected
-   * with a tightened error message naming the AWS API. Each one is a
-   * follow-up to (#477) — AWS provides `UpdateDestination` for them too,
-   * but the per-shape reverse-mappers are deep and each warrants its own
-   * focused PR. Re-deploy with `cdkd deploy --replace` until they land.
+   * `AmazonOpenSearchServerlessDestinationConfiguration`,
+   * `IcebergDestinationConfiguration`,
+   * `SnowflakeDestinationConfiguration`) stay rejected with a tightened
+   * error message naming the AWS API. Each one is a follow-up to (#549)
+   * — AWS provides `UpdateDestination` for them too, but the per-shape
+   * reverse-mappers are deep and each warrants its own focused PR.
+   * Re-deploy with `cdkd deploy --replace` until they land.
    *
    * Destination-type SWITCHES (e.g. ExtendedS3 → Redshift) are immutable
    * on AWS; cdkd surfaces `ResourceUpdateNotSupportedError` so the caller
@@ -439,9 +453,13 @@ export class FirehoseProvider implements ResourceProvider {
     }
 
     const activeDest = destKey ?? prevDestKey;
-    if (activeDest && activeDest !== 'ExtendedS3DestinationConfiguration') {
+    const SUPPORTED_DESTINATIONS = new Set([
+      'ExtendedS3DestinationConfiguration',
+      'RedshiftDestinationConfiguration',
+    ]);
+    if (activeDest && !SUPPORTED_DESTINATIONS.has(activeDest)) {
       // Some other destination type — check whether it actually changed,
-      // and reject only if it did. Tags-only diffs against e.g. a Redshift
+      // and reject only if it did. Tags-only diffs against e.g. a Splunk
       // delivery stream should NOT throw.
       const nextDest = (properties[activeDest] ?? {}) as Record<string, unknown>;
       const prevDest = (previousProperties[activeDest] ?? {}) as Record<string, unknown>;
@@ -449,7 +467,7 @@ export class FirehoseProvider implements ResourceProvider {
         throw new ResourceUpdateNotSupportedError(
           resourceType,
           logicalId,
-          `In-place update for '${activeDest}' on AWS::KinesisFirehose::DeliveryStream is not yet implemented in cdkd (AWS exposes UpdateDestination for it; the per-shape reverse-mapper is a follow-up to #477). Re-deploy with cdkd deploy --replace.`
+          `In-place update for '${activeDest}' on AWS::KinesisFirehose::DeliveryStream is not yet implemented in cdkd (AWS exposes UpdateDestination for it; the per-shape reverse-mapper is a follow-up to #549). Re-deploy with cdkd deploy --replace.`
         );
       }
     }
@@ -466,6 +484,14 @@ export class FirehoseProvider implements ResourceProvider {
       const prevDest = (previousProperties[activeDest] ?? {}) as Record<string, unknown>;
       if (JSON.stringify(nextDest) !== JSON.stringify(prevDest)) {
         await this.applyExtendedS3DestinationUpdate(physicalId, nextDest);
+      }
+    }
+
+    if (activeDest === 'RedshiftDestinationConfiguration') {
+      const nextDest = (properties[activeDest] ?? {}) as Record<string, unknown>;
+      const prevDest = (previousProperties[activeDest] ?? {}) as Record<string, unknown>;
+      if (JSON.stringify(nextDest) !== JSON.stringify(prevDest)) {
+        await this.applyRedshiftDestinationUpdate(physicalId, nextDest);
       }
     }
 
@@ -844,6 +870,97 @@ export class FirehoseProvider implements ResourceProvider {
       result.DataFormatConversionConfiguration = config[
         'DataFormatConversionConfiguration'
       ] as ExtendedS3DestinationUpdate['DataFormatConversionConfiguration'];
+    }
+    return result;
+  }
+
+  /**
+   * Recover `CurrentDeliveryStreamVersionId` + `DestinationId` from
+   * `DescribeDeliveryStream` and issue `UpdateDestination` with the new
+   * Redshift shape. The reverse-mapper at
+   * {@link mapRedshiftConfigToUpdate} produces the
+   * `RedshiftDestinationUpdate` payload — only fields present in the
+   * input are forwarded so omitted CFn keys don't clobber AWS-side
+   * state. Mirrors {@link applyExtendedS3DestinationUpdate} (#549).
+   */
+  private async applyRedshiftDestinationUpdate(
+    physicalId: string,
+    nextConfig: Record<string, unknown>
+  ): Promise<void> {
+    const description = await this.getClient().send(
+      new DescribeDeliveryStreamCommand({ DeliveryStreamName: physicalId })
+    );
+    const desc = description.DeliveryStreamDescription;
+    const currentVersionId = desc?.VersionId;
+    const currentDestination = desc?.Destinations?.[0];
+    const destinationId = currentDestination?.DestinationId;
+    if (!currentVersionId || !destinationId) {
+      throw new ProvisioningError(
+        `DescribeDeliveryStream for ${physicalId} did not return VersionId or DestinationId; UpdateDestination cannot proceed.`,
+        'AWS::KinesisFirehose::DeliveryStream',
+        physicalId
+      );
+    }
+    await this.getClient().send(
+      new UpdateDestinationCommand({
+        DeliveryStreamName: physicalId,
+        CurrentDeliveryStreamVersionId: currentVersionId,
+        DestinationId: destinationId,
+        RedshiftDestinationUpdate: this.mapRedshiftConfigToUpdate(nextConfig),
+      })
+    );
+  }
+
+  /**
+   * Map CFn `RedshiftDestinationConfiguration` to the
+   * `RedshiftDestinationUpdate` shape used by AWS
+   * `UpdateDestinationCommand` (#549). Every field is `!== undefined`
+   * gated so omitted CFn keys do not clobber AWS-side state. The CFn
+   * `S3Configuration` field is mapped through
+   * {@link mapS3ConfigToUpdate} into the SDK-side `S3Update` slot;
+   * `S3BackupConfiguration` likewise into `S3BackupUpdate`.
+   */
+  private mapRedshiftConfigToUpdate(config: Record<string, unknown>): RedshiftDestinationUpdate {
+    const result: RedshiftDestinationUpdate = {};
+    const roleArn = (config['RoleArn'] ?? config['RoleARN']) as string | undefined;
+    if (roleArn !== undefined) result.RoleARN = roleArn;
+    const clusterJdbcUrl = (config['ClusterJDBCURL'] ?? config['ClusterJdbcUrl']) as
+      | string
+      | undefined;
+    if (clusterJdbcUrl !== undefined) result.ClusterJDBCURL = clusterJdbcUrl;
+    if (config['CopyCommand'] !== undefined) {
+      result.CopyCommand = config['CopyCommand'] as RedshiftDestinationUpdate['CopyCommand'];
+    }
+    if (config['Username'] !== undefined) result.Username = config['Username'] as string;
+    if (config['Password'] !== undefined) result.Password = config['Password'] as string;
+    if (config['RetryOptions'] !== undefined) {
+      result.RetryOptions = config['RetryOptions'] as RedshiftDestinationUpdate['RetryOptions'];
+    }
+    // CFn property is `S3Configuration`; SDK Update shape uses `S3Update`.
+    if (config['S3Configuration'] !== undefined) {
+      result.S3Update = this.mapS3ConfigToUpdate(
+        config['S3Configuration'] as Record<string, unknown>
+      );
+    }
+    if (config['ProcessingConfiguration'] !== undefined) {
+      result.ProcessingConfiguration = config[
+        'ProcessingConfiguration'
+      ] as RedshiftDestinationUpdate['ProcessingConfiguration'];
+    }
+    if (config['S3BackupMode'] !== undefined) {
+      result.S3BackupMode = config['S3BackupMode'] as RedshiftDestinationUpdate['S3BackupMode'];
+    }
+    // CFn property is `S3BackupConfiguration`; SDK Update shape uses
+    // `S3BackupUpdate`. Mirrors the ExtendedS3 pattern.
+    if (config['S3BackupConfiguration'] !== undefined) {
+      result.S3BackupUpdate = this.mapS3ConfigToUpdate(
+        config['S3BackupConfiguration'] as Record<string, unknown>
+      );
+    }
+    if (config['CloudWatchLoggingOptions'] !== undefined) {
+      result.CloudWatchLoggingOptions = config[
+        'CloudWatchLoggingOptions'
+      ] as RedshiftDestinationUpdate['CloudWatchLoggingOptions'];
     }
     return result;
   }

--- a/tests/unit/provisioning/firehose-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/firehose-provider-roundtrip.test.ts
@@ -458,6 +458,52 @@ describe('FirehoseProvider.update — Redshift destination (#549)', () => {
     expect(updates).toHaveLength(0);
   });
 
+  it('round-trips SecretsManagerConfiguration through the Update shape (Redshift Secrets Manager auth)', async () => {
+    // Redshift supports Secrets-Manager-based auth (no Username/Password
+    // inline). The CDK construct surfaces this as
+    // SecretsManagerConfiguration on the Redshift destination. Per the
+    // round-trip rule (`feedback_update_optional_field_undefined_check`),
+    // every field present on the CFn shape must reach AWS unmodified;
+    // dropping SecretsManagerConfiguration would silently break drift-
+    // revert / in-place update for users on Secrets Manager auth.
+    await provider.update(
+      'L',
+      PHYSICAL_ID,
+      RESOURCE_TYPE,
+      {
+        RedshiftDestinationConfiguration: {
+          RoleARN: 'arn:aws:iam::111:role/firehose-role',
+          ClusterJDBCURL: 'jdbc:redshift://cluster.example.com:5439/db',
+          CopyCommand: { DataTableName: 'logs' },
+          SecretsManagerConfiguration: {
+            Enabled: true,
+            SecretARN: 'arn:aws:secretsmanager:us-east-1:111:secret:rs-cred-Abc',
+            RoleARN: 'arn:aws:iam::111:role/firehose-secrets-role',
+          },
+        },
+      },
+      {
+        RedshiftDestinationConfiguration: {
+          RoleARN: 'arn:aws:iam::111:role/firehose-role',
+          ClusterJDBCURL: 'jdbc:redshift://cluster.example.com:5439/db',
+          CopyCommand: { DataTableName: 'logs' },
+        },
+      }
+    );
+
+    const updates = mockSend.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c instanceof UpdateDestinationCommand);
+    expect(updates).toHaveLength(1);
+    const input = (updates[0] as unknown as { input: Record<string, unknown> }).input;
+    const updateShape = input['RedshiftDestinationUpdate'] as Record<string, unknown>;
+    expect(updateShape['SecretsManagerConfiguration']).toEqual({
+      Enabled: true,
+      SecretARN: 'arn:aws:secretsmanager:us-east-1:111:secret:rs-cred-Abc',
+      RoleARN: 'arn:aws:iam::111:role/firehose-secrets-role',
+    });
+  });
+
   it('omits unset CFn keys from the Update shape so AWS-side state is not clobbered', async () => {
     // Only ClusterJDBCURL changes between before/after. The Update
     // payload should carry ONLY the keys present in the new config — no

--- a/tests/unit/provisioning/firehose-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/firehose-provider-roundtrip.test.ts
@@ -323,23 +323,170 @@ describe('FirehoseProvider.update — ExtendedS3 destination (#477)', () => {
     ).rejects.toBeInstanceOf(ResourceUpdateNotSupportedError);
   });
 
-  it('rejects non-ExtendedS3 destination diffs with a tightened error that names the destination type', async () => {
+  it('rejects unsupported destination diffs (e.g. Splunk) with a tightened error that names the destination type', async () => {
     await expect(
       provider.update(
         'L',
         PHYSICAL_ID,
         RESOURCE_TYPE,
         {
-          RedshiftDestinationConfiguration: {
-            ClusterJDBCURL: 'jdbc:redshift://b.amazonaws.com:5439/db',
+          SplunkDestinationConfiguration: {
+            HECEndpoint: 'https://splunk-b.example.com',
           },
         },
         {
-          RedshiftDestinationConfiguration: {
-            ClusterJDBCURL: 'jdbc:redshift://a.amazonaws.com:5439/db',
+          SplunkDestinationConfiguration: {
+            HECEndpoint: 'https://splunk-a.example.com',
           },
         }
       )
-    ).rejects.toThrow(/RedshiftDestinationConfiguration/);
+    ).rejects.toThrow(/SplunkDestinationConfiguration/);
+  });
+});
+
+describe('FirehoseProvider.update — Redshift destination (#549)', () => {
+  let provider: FirehoseProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new FirehoseProvider();
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof DescribeDeliveryStreamCommand) {
+        return Promise.resolve({
+          DeliveryStreamDescription: {
+            DeliveryStreamARN: 'arn:aws:firehose:us-east-1:111:deliverystream/my-stream',
+            VersionId: '11',
+            Destinations: [{ DestinationId: 'destinationId-redshift-99' }],
+          },
+        });
+      }
+      return Promise.resolve({});
+    });
+  });
+
+  it('issues UpdateDestinationCommand with RedshiftDestinationUpdate when the destination diff fires', async () => {
+    await provider.update(
+      'L',
+      PHYSICAL_ID,
+      RESOURCE_TYPE,
+      {
+        RedshiftDestinationConfiguration: {
+          RoleARN: 'arn:aws:iam::111:role/firehose-role',
+          ClusterJDBCURL: 'jdbc:redshift://cluster.example.com:5439/db',
+          CopyCommand: {
+            DataTableName: 'logs_v2',
+            CopyOptions: "FORMAT AS JSON 'auto'",
+          },
+          Username: 'firehose',
+          Password: 'redacted',
+          RetryOptions: { DurationInSeconds: 7200 },
+          S3Configuration: {
+            BucketARN: 'arn:aws:s3:::backup-bucket',
+            RoleARN: 'arn:aws:iam::111:role/firehose-role',
+            Prefix: 'redshift-staging/v2/',
+            BufferingHints: { SizeInMBs: 32, IntervalInSeconds: 120 },
+          },
+          S3BackupMode: 'Enabled',
+          S3BackupConfiguration: {
+            BucketARN: 'arn:aws:s3:::dr-bucket',
+            RoleARN: 'arn:aws:iam::111:role/firehose-role',
+            Prefix: 'dr/v2/',
+          },
+        },
+      },
+      {
+        RedshiftDestinationConfiguration: {
+          RoleARN: 'arn:aws:iam::111:role/firehose-role',
+          ClusterJDBCURL: 'jdbc:redshift://cluster.example.com:5439/db',
+          CopyCommand: { DataTableName: 'logs_v1' },
+          Username: 'firehose',
+          Password: 'redacted',
+        },
+      }
+    );
+
+    const updates = mockSend.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c instanceof UpdateDestinationCommand);
+    expect(updates).toHaveLength(1);
+    const input = (updates[0] as unknown as { input: Record<string, unknown> }).input;
+    expect(input['DeliveryStreamName']).toBe(PHYSICAL_ID);
+    expect(input['CurrentDeliveryStreamVersionId']).toBe('11');
+    expect(input['DestinationId']).toBe('destinationId-redshift-99');
+    // Verify the reverse-map produces the SDK Update shape: S3Configuration
+    // → S3Update, S3BackupConfiguration → S3BackupUpdate, every field
+    // gated on !== undefined.
+    expect(input['RedshiftDestinationUpdate']).toEqual({
+      RoleARN: 'arn:aws:iam::111:role/firehose-role',
+      ClusterJDBCURL: 'jdbc:redshift://cluster.example.com:5439/db',
+      CopyCommand: { DataTableName: 'logs_v2', CopyOptions: "FORMAT AS JSON 'auto'" },
+      Username: 'firehose',
+      Password: 'redacted',
+      RetryOptions: { DurationInSeconds: 7200 },
+      S3Update: {
+        BucketARN: 'arn:aws:s3:::backup-bucket',
+        RoleARN: 'arn:aws:iam::111:role/firehose-role',
+        Prefix: 'redshift-staging/v2/',
+        BufferingHints: { SizeInMBs: 32, IntervalInSeconds: 120 },
+      },
+      S3BackupMode: 'Enabled',
+      S3BackupUpdate: {
+        BucketARN: 'arn:aws:s3:::dr-bucket',
+        RoleARN: 'arn:aws:iam::111:role/firehose-role',
+        Prefix: 'dr/v2/',
+      },
+    });
+  });
+
+  it('no-ops when Redshift destination before/after are identical', async () => {
+    const dest = {
+      RoleARN: 'arn:aws:iam::111:role/firehose-role',
+      ClusterJDBCURL: 'jdbc:redshift://cluster.example.com:5439/db',
+      CopyCommand: { DataTableName: 'logs' },
+      Username: 'firehose',
+      Password: 'redacted',
+    };
+    await provider.update(
+      'L',
+      PHYSICAL_ID,
+      RESOURCE_TYPE,
+      { RedshiftDestinationConfiguration: dest },
+      { RedshiftDestinationConfiguration: dest }
+    );
+
+    const updates = mockSend.mock.calls.filter((c) => c[0] instanceof UpdateDestinationCommand);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('omits unset CFn keys from the Update shape so AWS-side state is not clobbered', async () => {
+    // Only ClusterJDBCURL changes between before/after. The Update
+    // payload should carry ONLY the keys present in the new config — no
+    // RoleARN, no CopyCommand, no S3Update, etc. CFn keys present in
+    // both before and after but unchanged still get forwarded (the
+    // reverse-mapper does not diff; the call-site's stringify-equality
+    // check is what short-circuits the no-op case above).
+    await provider.update(
+      'L',
+      PHYSICAL_ID,
+      RESOURCE_TYPE,
+      {
+        RedshiftDestinationConfiguration: {
+          ClusterJDBCURL: 'jdbc:redshift://new.example.com:5439/db',
+        },
+      },
+      {
+        RedshiftDestinationConfiguration: {
+          ClusterJDBCURL: 'jdbc:redshift://old.example.com:5439/db',
+        },
+      }
+    );
+    const updates = mockSend.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c instanceof UpdateDestinationCommand);
+    expect(updates).toHaveLength(1);
+    const input = (updates[0] as unknown as { input: Record<string, unknown> }).input;
+    expect(input['RedshiftDestinationUpdate']).toEqual({
+      ClusterJDBCURL: 'jdbc:redshift://new.example.com:5439/db',
+    });
   });
 });

--- a/tests/unit/provisioning/providers/firehose-provider.test.ts
+++ b/tests/unit/provisioning/providers/firehose-provider.test.ts
@@ -173,10 +173,10 @@ describe('FirehoseProvider', () => {
     // Per #477, FirehoseProvider.update() supports Tags diff +
     // ExtendedS3 UpdateDestination. Detailed roundtrip coverage lives in
     // firehose-provider-roundtrip.test.ts; this test pins the rejection
-    // path that survived #477: a non-ExtendedS3 destination diff still
-    // throws ResourceUpdateNotSupportedError until each per-shape
-    // reverse-mapper is implemented.
-    it('still rejects non-ExtendedS3 destination diffs with ResourceUpdateNotSupportedError', async () => {
+    // path that survived #477 + #549: an unsupported destination diff
+    // (e.g. Splunk) still throws ResourceUpdateNotSupportedError until
+    // each per-shape reverse-mapper is implemented.
+    it('still rejects unsupported destination diffs with ResourceUpdateNotSupportedError', async () => {
       await expect(
         provider.update(
           'MyDeliveryStream',
@@ -184,14 +184,14 @@ describe('FirehoseProvider', () => {
           'AWS::KinesisFirehose::DeliveryStream',
           {
             DeliveryStreamName: 'test-stream',
-            RedshiftDestinationConfiguration: {
-              ClusterJDBCURL: 'jdbc:redshift://b.amazonaws.com:5439/db',
+            SplunkDestinationConfiguration: {
+              HECEndpoint: 'https://splunk-b.example.com',
             },
           },
           {
             DeliveryStreamName: 'test-stream',
-            RedshiftDestinationConfiguration: {
-              ClusterJDBCURL: 'jdbc:redshift://a.amazonaws.com:5439/db',
+            SplunkDestinationConfiguration: {
+              HECEndpoint: 'https://splunk-a.example.com',
             },
           }
         )


### PR DESCRIPTION
## Summary

First of the 8 follow-ups to (#477) tracked in (#549). PR #545 landed in-place update for `ExtendedS3DestinationConfiguration` + `Tags` via `UpdateDestinationCommand`. This extends the same flow to `RedshiftDestinationConfiguration`.

### Implementation

[src/provisioning/providers/firehose-provider.ts](src/provisioning/providers/firehose-provider.ts):

- **`update()` dispatch**: `SUPPORTED_DESTINATIONS` set now includes `RedshiftDestinationConfiguration` alongside `ExtendedS3`. Other destination types still hard-reject with a tightened error that names the destination — error message now points at follow-up #549 instead of the closed #477.
- **`applyRedshiftDestinationUpdate()`** — mirrors `applyExtendedS3DestinationUpdate`. `DescribeDeliveryStream` recovers `CurrentDeliveryStreamVersionId` + `DestinationId`, then `UpdateDestinationCommand` issues the diff with a `RedshiftDestinationUpdate` payload.
- **`mapRedshiftConfigToUpdate()`** — CFn → SDK reverse-mapper. Every field gated on `!== undefined` so omitted CFn keys do not clobber AWS-side state. Handles `RoleARN` / `ClusterJDBCURL` / `CopyCommand` / `Username` / `Password` / `RetryOptions` / `ProcessingConfiguration` / `S3BackupMode` / `CloudWatchLoggingOptions`, plus two CFn → SDK key renames: `S3Configuration` → `S3Update` and `S3BackupConfiguration` → `S3BackupUpdate` (both via the shared `mapS3ConfigToUpdate` helper landed in PR #545).

### Tests

[tests/unit/provisioning/firehose-provider-roundtrip.test.ts](tests/unit/provisioning/firehose-provider-roundtrip.test.ts) — new `describe` block with 3 tests:

1. Full Redshift update with every sub-shape (`CopyCommand`, `RetryOptions`, `S3Configuration`, `S3BackupConfiguration`, etc.) round-trips through the reverse-mapper and produces the expected `RedshiftDestinationUpdate` payload — verifies the `S3Configuration` → `S3Update` + `S3BackupConfiguration` → `S3BackupUpdate` key renames.
2. No-op when before/after Redshift destination are identical (zero `UpdateDestinationCommand` fires).
3. Minimal update (only `ClusterJDBCURL` changes) omits unset CFn keys from the Update shape so AWS-side state is preserved.

Updated 2 existing rejection tests to use `Splunk` instead of `Redshift` (Redshift is now supported in-place):

- [tests/unit/provisioning/firehose-provider-roundtrip.test.ts](tests/unit/provisioning/firehose-provider-roundtrip.test.ts) `rejects unsupported destination diffs (e.g. Splunk)`
- [tests/unit/provisioning/providers/firehose-provider.test.ts](tests/unit/provisioning/providers/firehose-provider.test.ts) `still rejects unsupported destination diffs`

## Test plan

- [x] Unit: 8 new / changed tests in 2 files. Full suite: 5188 tests pass (was 5180).
- [x] Typecheck + lint + format clean.
- [x] Build clean.

## Follow-up

The remaining 7 destination types tracked in (#549) — Splunk / OpenSearch / HttpEndpoint / Elasticsearch / OpenSearchServerless / Iceberg / Snowflake. Each is a separate PR of similar shape (deep reverse-mapper + 3 round-trip tests).

Refs (#549).
