### PR TITLE
fix(nested-stack): cross-platform absolute-path check in indexGrandchildTemplates

### DIFF
--- a/src/provisioning/providers/nested-stack-provider.ts
+++ b/src/provisioning/providers/nested-stack-provider.ts
@@ -17,6 +17,19 @@ import {
 import { getLogger } from '../../utils/logger.js';
 
 /**
+ * Returns `true` when `p` is absolute on the current platform OR begins
+ * with a forward slash. The `startsWith('/')` arm covers the cross-platform
+ * leak where `path.isAbsolute('/abs/foo')` returns `true` on POSIX but
+ * `false` on Windows (Windows absolute paths require a drive letter or
+ * UNC root) — a POSIX-style absolute path embedded in a synth template
+ * generated on Linux and consumed on a Windows host would slip past
+ * `path.isAbsolute()` alone. Exported for unit testing.
+ */
+export function isAbsoluteCrossPlatform(p: string): boolean {
+  return path.isAbsolute(p) || p.startsWith('/');
+}
+
+/**
  * Provider for `AWS::CloudFormation::Stack` — cdkd's recursive nested-stack
  * adapter. Issue [#459](https://github.com/go-to-k/cdkd/issues/459); see
  * [docs/design/459-nested-stacks.md](../../../docs/design/459-nested-stacks.md)
@@ -40,20 +53,6 @@ import { getLogger } from '../../utils/logger.js';
  * ARN with `cdkd-local` partition so any downstream consumer that
  * accidentally uses it as a real AWS ARN fails loudly.
  */
-
-/**
- * Returns `true` when `p` is absolute on the current platform OR begins
- * with a forward slash. The `startsWith('/')` arm covers the cross-platform
- * leak where `path.isAbsolute('/abs/foo')` returns `true` on POSIX but
- * `false` on Windows (Windows absolute paths require a drive letter or
- * UNC root) — a POSIX-style absolute path embedded in a synth template
- * generated on Linux and consumed on a Windows host would slip past
- * `path.isAbsolute()` alone. Exported for unit testing.
- */
-export function isAbsoluteCrossPlatform(p: string): boolean {
-  return path.isAbsolute(p) || p.startsWith('/');
-}
-
 export class NestedStackProvider implements ResourceProvider {
   private logger = getLogger().child('NestedStackProvider');
 

--- a/src/provisioning/providers/nested-stack-provider.ts
+++ b/src/provisioning/providers/nested-stack-provider.ts
@@ -40,6 +40,20 @@ import { getLogger } from '../../utils/logger.js';
  * ARN with `cdkd-local` partition so any downstream consumer that
  * accidentally uses it as a real AWS ARN fails loudly.
  */
+
+/**
+ * Returns `true` when `p` is absolute on the current platform OR begins
+ * with a forward slash. The `startsWith('/')` arm covers the cross-platform
+ * leak where `path.isAbsolute('/abs/foo')` returns `true` on POSIX but
+ * `false` on Windows (Windows absolute paths require a drive letter or
+ * UNC root) — a POSIX-style absolute path embedded in a synth template
+ * generated on Linux and consumed on a Windows host would slip past
+ * `path.isAbsolute()` alone. Exported for unit testing.
+ */
+export function isAbsoluteCrossPlatform(p: string): boolean {
+  return path.isAbsolute(p) || p.startsWith('/');
+}
+
 export class NestedStackProvider implements ResourceProvider {
   private logger = getLogger().child('NestedStackProvider');
 
@@ -501,7 +515,7 @@ export class NestedStackProvider implements ResourceProvider {
       // produces `/abs/foo` (POSIX) which silently bypasses our `dir`
       // resolution and points outside cdk.out. Refuse loudly rather than
       // accept a path we cannot trust.
-      if (path.isAbsolute(assetPath)) {
+      if (isAbsoluteCrossPlatform(assetPath)) {
         throw new Error(
           `NestedStackProvider: nested-stack '${grandLogicalId}' has ` +
             `Metadata['aws:asset:path']='${assetPath}' which is absolute. ` +

--- a/tests/unit/provisioning/nested-stack-provider.test.ts
+++ b/tests/unit/provisioning/nested-stack-provider.test.ts
@@ -3,7 +3,10 @@ import { writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { NestedStackProvider } from '../../../src/provisioning/providers/nested-stack-provider.js';
+import {
+  NestedStackProvider,
+  isAbsoluteCrossPlatform,
+} from '../../../src/provisioning/providers/nested-stack-provider.js';
 import {
   withNestedStackContext,
   type NestedStackProviderContext,
@@ -361,6 +364,27 @@ describe('NestedStackProvider', () => {
           provider.create('Child', 'AWS::CloudFormation::Stack', {})
         )
       ).rejects.toThrow(/which is absolute/);
+    });
+  });
+
+  describe('isAbsoluteCrossPlatform()', () => {
+    // POSIX-style absolute paths are rejected on every platform.
+    // `path.isAbsolute('/abs/foo')` returns `true` on POSIX but `false`
+    // on Windows (Windows absolute paths require a drive letter or UNC
+    // root), so the `startsWith('/')` fallback is what guarantees the
+    // rejection holds when a Linux-synthesized template is consumed on
+    // a Windows host.
+    it('accepts relative paths', () => {
+      expect(isAbsoluteCrossPlatform('foo/bar.json')).toBe(false);
+      expect(isAbsoluteCrossPlatform('./foo/bar.json')).toBe(false);
+      expect(isAbsoluteCrossPlatform('../foo/bar.json')).toBe(false);
+      expect(isAbsoluteCrossPlatform('foo.json')).toBe(false);
+    });
+
+    it('rejects POSIX-style absolute paths regardless of host platform', () => {
+      expect(isAbsoluteCrossPlatform('/abs/foo')).toBe(true);
+      expect(isAbsoluteCrossPlatform('/foo.json')).toBe(true);
+      expect(isAbsoluteCrossPlatform('/')).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds a `startsWith('/')` fallback to the absolute-path defensive check in `NestedStackProvider.indexGrandchildTemplates` so a POSIX-style absolute path embedded in a synth template generated on Linux is rejected even when consumed on a Windows host (where `path.isAbsolute('/abs/foo')` returns `false` because Windows absolute paths require a drive letter or UNC root).
- Extracts the check into an exported `isAbsoluteCrossPlatform()` helper so the secondary arm can be unit-tested directly. The ESM module namespace for `node:path` is frozen, so `vi.spyOn(path, 'isAbsolute')` can't simulate Windows behavior on a POSIX host — testing through the helper is the cleanest route.

Closes the B4 item of #556. B1–B3 shipped in #561.

## Test plan

- [x] Existing POSIX-absolute rejection test still passes (now via the OR's first arm).
- [x] New `isAbsoluteCrossPlatform()` tests cover relative paths (false) and POSIX-style absolute paths (true) explicitly, so the rule survives a future split / refactor of the OR.
- [x] Full unit suite (357 files, 5266 tests) green.
- [x] `nested-stack` integ deploy + destroy clean against real AWS (0 errors, 0 orphans).
