### PR TITLE
test(import,retire-cfn-stack): cover nested-stack adoption follow-ups

### DIFF
--- a/src/cli/commands/retire-cfn-stack.ts
+++ b/src/cli/commands/retire-cfn-stack.ts
@@ -839,37 +839,14 @@ async function injectRetainPoliciesRecursiveInternal(
 }
 
 /**
- * Ask CloudFormation directly which physical id corresponds to each logical
- * id in the named stack. Used by `cdkd import --migrate-from-cloudformation`
- * to side-step cdkd's tag-based auto-lookup (which can't find resources
- * deployed by upstream `cdk deploy` — that flow doesn't propagate
- * `aws:cdk:path` as an AWS tag, and AWS reserves the `aws:` tag prefix so
- * we can't add it ourselves either).
+ * Walk a CloudFormation stack and every nested child recursively, returning
+ * the full {@link CfnStackResourceTree} rooted at `rootStackName`. Used by
+ * `cdkd import --migrate-from-cloudformation` to drive BOTH per-child state
+ * writes AND the recursive `injectRetainPoliciesRecursive` walk — both
+ * consumers share this single `DescribeStackResources` tree so an
+ * arbitrarily-deep nesting only costs one round-trip per stack.
  *
- * Pulls the entire stack with `DescribeStackResources` (one round-trip,
- * unbounded result by spec — CFn caps stacks at 500 resources). Resources
- * whose `PhysicalResourceId` is missing (rare; typically an import-failed
- * resource or `AWS::CDK::Metadata`) are skipped silently — the caller
- * already iterates the synthesized template separately and will surface
- * those as `skipped-no-impl` / `skipped-not-found`.
- */
-export async function getCloudFormationResourceMapping(
-  cfnStackName: string,
-  cfnClient: CloudFormationClient
-): Promise<Map<string, string>> {
-  const resp = await cfnClient.send(new DescribeStackResourcesCommand({ StackName: cfnStackName }));
-  const map = new Map<string, string>();
-  for (const r of resp.StackResources ?? []) {
-    if (!r.LogicalResourceId || !r.PhysicalResourceId) continue;
-    map.set(r.LogicalResourceId, r.PhysicalResourceId);
-  }
-  return map;
-}
-
-/**
- * Recursive variant of {@link getCloudFormationResourceMapping} that returns
- * the full nested-stack tree rooted at `rootStackName`. For each
- * `AWS::CloudFormation::Stack` row in the root's resources, recursively
+ * For each `AWS::CloudFormation::Stack` row in the root's resources, recursively
  * calls `DescribeStackResources(<child ARN>)` (AWS accepts the ARN as
  * `StackName`) to populate the child node, and so on to arbitrary depth.
  *

--- a/tests/unit/cli/import.test.ts
+++ b/tests/unit/cli/import.test.ts
@@ -3,6 +3,14 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { CloudFormationTemplate } from '../../../src/types/resource.js';
+// Type-only import — erased at runtime, so it does NOT trigger the
+// `vi.mock('../../../src/cli/commands/retire-cfn-stack.js', ...)` factory
+// below. Re-typing the hoisted `mockGetCfnResourceTree` spy against the
+// real `CfnStackResourceTree` interface keeps the mock and source in
+// sync — drift between the mocked tree shape and the real interface
+// would otherwise surface as a runtime crash only when a test exercises
+// a yet-unmocked field.
+import type { CfnStackResourceTree } from '../../../src/cli/commands/retire-cfn-stack.js';
 
 const errorSpy = vi.hoisted(() => vi.fn());
 const infoSpy = vi.hoisted(() => vi.fn());
@@ -61,35 +69,31 @@ vi.mock('../../../src/utils/aws-clients.ts', () => ({
 const mockRetireCloudFormationStack = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => Promise<{ outcome: string }>>()
 );
-const mockGetCfnResourceMapping = vi.hoisted(() =>
-  vi.fn<(...args: unknown[]) => Promise<Map<string, string>>>()
-);
-// Mock for the recursive tree walker added in PR for issue #464. The
-// returned shape mirrors `CfnStackResourceTree` from retire-cfn-stack.ts —
-// every test that doesn't exercise nested-stack rows can rely on the
-// default empty-tree return below (the import.ts dispatch loop only
-// fires nested-stack short-circuit logic when `tree.nested.size > 0`,
-// so an empty Map keeps the existing test surface unchanged).
+// Mock for the recursive tree walker added in PR for issue #464. Typed
+// directly against the real `CfnStackResourceTree` interface (imported
+// type-only above) so any drift between the source shape and what tests
+// stub here is caught at compile time. Every test that doesn't exercise
+// nested-stack rows can rely on the default empty-tree return wired up
+// in `beforeEach` below (the import.ts dispatch loop only fires
+// nested-stack short-circuit logic when `tree.nested.size > 0`, so an
+// empty Map keeps the existing test surface unchanged).
 const mockGetCfnResourceTree = vi.hoisted(() =>
-  vi.fn<
-    (...args: unknown[]) => Promise<{
-      stackName: string;
-      physicalId: string;
-      resources: Map<string, string>;
-      nested: Map<string, unknown>;
-    }>
-  >()
+  vi.fn<(...args: unknown[]) => Promise<CfnStackResourceTree>>()
 );
-vi.mock('../../../src/cli/commands/retire-cfn-stack.js', () => ({
-  retireCloudFormationStack: mockRetireCloudFormationStack,
-  getCloudFormationResourceMapping: mockGetCfnResourceMapping,
-  getCloudFormationResourceTree: mockGetCfnResourceTree,
-  // The shared NESTED_STACK_RESOURCE_TYPE constant used by import.ts to
-  // detect `AWS::CloudFormation::Stack` rows. Must match the real value
-  // exported from retire-cfn-stack.ts or the dispatch-loop short-circuit
-  // would silently mis-trigger.
-  NESTED_STACK_RESOURCE_TYPE: 'AWS::CloudFormation::Stack',
-}));
+vi.mock('../../../src/cli/commands/retire-cfn-stack.js', async () => {
+  // Pull the real module's `NESTED_STACK_RESOURCE_TYPE` constant via
+  // `vi.importActual` so the test mock can't silently drift from the
+  // production value — any change to the constant in retire-cfn-stack.ts
+  // is automatically reflected here.
+  const actual = await vi.importActual<typeof import('../../../src/cli/commands/retire-cfn-stack.js')>(
+    '../../../src/cli/commands/retire-cfn-stack.js'
+  );
+  return {
+    retireCloudFormationStack: mockRetireCloudFormationStack,
+    getCloudFormationResourceTree: mockGetCfnResourceTree,
+    NESTED_STACK_RESOURCE_TYPE: actual.NESTED_STACK_RESOURCE_TYPE,
+  };
+});
 
 const mockVerifyBucketExists = vi.fn<() => Promise<void>>();
 const mockGetState = vi.fn<
@@ -221,8 +225,6 @@ describe('cdkd import', () => {
     readlineClose.mockReset();
     mockRetireCloudFormationStack.mockReset();
     mockRetireCloudFormationStack.mockResolvedValue({ outcome: 'retired' });
-    mockGetCfnResourceMapping.mockReset();
-    mockGetCfnResourceMapping.mockResolvedValue(new Map());
     mockGetCfnResourceTree.mockReset();
     mockGetCfnResourceTree.mockResolvedValue({
       stackName: 'S',
@@ -1302,11 +1304,9 @@ describe('cdkd import', () => {
       mockHasProvider.mockReturnValue(true);
       const importSpy = vi.fn(async () => ({ physicalId: cfnPhysical, attributes: {} }));
       mockGetProvider.mockReturnValue({ import: importSpy });
-      // PR for issue #464 replaced the flat `getCloudFormationResourceMapping`
-      // call with the recursive `getCloudFormationResourceTree` walker —
-      // the migration code path now consumes `tree.resources` instead of
-      // a bare Map. Top-level migration tests don't exercise nesting, so
-      // `nested` stays empty.
+      // Migration code path consumes `tree.resources` from the recursive
+      // `getCloudFormationResourceTree` walker. Top-level migration tests
+      // don't exercise nesting, so `nested` stays empty.
       mockGetCfnResourceTree.mockResolvedValue({
         stackName: 'S',
         physicalId: 'S',
@@ -1494,12 +1494,15 @@ describe('cdkd import', () => {
       mockGetProvider.mockReturnValue({
         import: vi.fn(async () => ({ physicalId: 'b', attributes: {} })),
       });
-      mockGetCfnResourceMapping.mockResolvedValue(
-        new Map([
+      mockGetCfnResourceTree.mockResolvedValue({
+        stackName: 'S',
+        physicalId: 'S',
+        resources: new Map([
           ['MyBucket', 'b-physical'],
           ['Untouched', 'u-physical'],
-        ])
-      );
+        ]),
+        nested: new Map(),
+      });
 
       await runImport(['import', '--app', 'x', '--yes', '--migrate-from-cloudformation']);
 
@@ -1814,6 +1817,255 @@ describe('cdkd import', () => {
             (c) => (c as unknown[])[0] === 'P'
           );
           expect(rootReleases).toHaveLength(1);
+        } finally {
+          rmSync(tmpdirPath, { recursive: true, force: true });
+        }
+      });
+
+      it('errors with clear message when STS GetCallerIdentity returns no Account', async () => {
+        // The recursive nested-stack flow needs the caller's AWS account ID
+        // to synthesize the cdkd-local ARN it writes into the parent's
+        // state for the nested-stack row (mirrors what
+        // `NestedStackProvider.create` does at deploy time — issue #464).
+        // When STS returns no `Account`, the flow must abort up front with
+        // an actionable message instead of silently writing a malformed
+        // ARN downstream.
+        const tmpdirPath = mkdtempSync(join(tmpdir(), 'cdkd-import-nested-sts-'));
+        try {
+          const childTemplatePath = join(tmpdirPath, 'Child.nested.template.json');
+          (await import('node:fs')).writeFileSync(
+            childTemplatePath,
+            JSON.stringify({
+              Resources: { B: { Type: 'AWS::S3::Bucket', Properties: {} } },
+            })
+          );
+          const tmpl = template({
+            Child: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'x' } },
+          });
+          mockSynthesize.mockResolvedValue({
+            stacks: [{ ...stackInfo('P', tmpl), nestedTemplates: { Child: childTemplatePath } }],
+          });
+          mockHasProvider.mockImplementation((t: string) => t !== 'AWS::CloudFormation::Stack');
+          mockGetProvider.mockReturnValue({
+            import: vi.fn(async () => ({ physicalId: 'b', attributes: {} })),
+          });
+          const childArn = 'arn:aws:cloudformation:us-east-1:123:stack/Child/uuid';
+          mockGetCfnResourceTree.mockResolvedValue({
+            stackName: 'P',
+            physicalId: 'P',
+            resources: new Map([['Child', childArn]]),
+            nested: new Map([
+              [
+                'Child',
+                {
+                  stackName: childArn,
+                  physicalId: childArn,
+                  resources: new Map([['B', 'b']]),
+                  nested: new Map(),
+                },
+              ],
+            ]),
+          });
+          // Override the STS GetCallerIdentity response for this single
+          // call — return an empty object (no `Account` field).
+          stsSend.mockResolvedValueOnce({} as never);
+
+          await expect(
+            runImport(['import', 'P', '--app', 'x', '--yes', '--migrate-from-cloudformation'])
+          ).rejects.toThrow();
+          const lastError = String(errorSpy.mock.calls.at(-1)?.[0]);
+          expect(lastError).toMatch(/STS GetCallerIdentity returned no Account/);
+          // Bail-out happens before any state write or retire round-trip.
+          expect(mockSaveState).not.toHaveBeenCalled();
+          expect(mockRetireCloudFormationStack).not.toHaveBeenCalled();
+        } finally {
+          rmSync(tmpdirPath, { recursive: true, force: true });
+        }
+      });
+
+      it('writes child state recursively for depth-2 (grandchild) nested stacks', async () => {
+        // Verifies `importNestedStackChildrenRecursive` recurses past the
+        // first level — for a Parent → Child → Grandchild tree, three
+        // `saveState` calls must land: one for the root, one for the
+        // child (keyed `P~Child`), one for the grandchild (keyed
+        // `P~Child~Grandchild`). Each child carries the v6 parent-link
+        // fields pointing one level up.
+        const tmpdirPath = mkdtempSync(join(tmpdir(), 'cdkd-import-nested-d2-'));
+        try {
+          const childTemplatePath = join(tmpdirPath, 'Child.nested.template.json');
+          const grandchildTemplatePath = join(tmpdirPath, 'Grandchild.nested.template.json');
+          // Grandchild leaf template.
+          (await import('node:fs')).writeFileSync(
+            grandchildTemplatePath,
+            JSON.stringify({
+              Resources: {
+                GrandchildBucket: { Type: 'AWS::S3::Bucket', Properties: {} },
+              },
+            })
+          );
+          // Child template carries one leaf bucket + the grandchild
+          // nested-stack row. Metadata['aws:asset:path'] is what
+          // `indexGrandchildTemplatePaths` reads to find the grandchild
+          // file on disk — use the leaf filename so `path.join(dir, ...)`
+          // resolves to the actual file.
+          (await import('node:fs')).writeFileSync(
+            childTemplatePath,
+            JSON.stringify({
+              Resources: {
+                ChildBucket: { Type: 'AWS::S3::Bucket', Properties: {} },
+                Grandchild: {
+                  Type: 'AWS::CloudFormation::Stack',
+                  Properties: { TemplateURL: 'x' },
+                  Metadata: { 'aws:asset:path': 'Grandchild.nested.template.json' },
+                },
+              },
+            })
+          );
+          const tmpl = template({
+            Child: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'x' } },
+          });
+          mockSynthesize.mockResolvedValue({
+            stacks: [{ ...stackInfo('P', tmpl), nestedTemplates: { Child: childTemplatePath } }],
+          });
+          mockHasProvider.mockImplementation((t: string) => t !== 'AWS::CloudFormation::Stack');
+          mockGetProvider.mockReturnValue({
+            import: vi.fn(async () => ({ physicalId: 'phys', attributes: {} })),
+          });
+          const childArn = 'arn:aws:cloudformation:us-east-1:123:stack/Child/uuid-c';
+          const grandchildArn =
+            'arn:aws:cloudformation:us-east-1:123:stack/Grandchild/uuid-g';
+          mockGetCfnResourceTree.mockResolvedValue({
+            stackName: 'P',
+            physicalId: 'P',
+            resources: new Map([['Child', childArn]]),
+            nested: new Map([
+              [
+                'Child',
+                {
+                  stackName: childArn,
+                  physicalId: childArn,
+                  resources: new Map([
+                    ['ChildBucket', 'cb-real'],
+                    ['Grandchild', grandchildArn],
+                  ]),
+                  nested: new Map([
+                    [
+                      'Grandchild',
+                      {
+                        stackName: grandchildArn,
+                        physicalId: grandchildArn,
+                        resources: new Map([['GrandchildBucket', 'gb-real']]),
+                        nested: new Map(),
+                      },
+                    ],
+                  ]),
+                },
+              ],
+            ]),
+          });
+
+          await runImport(['import', 'P', '--app', 'x', '--yes', '--migrate-from-cloudformation']);
+
+          // Three saveState calls — root, child, grandchild.
+          const saveCalls = mockSaveState.mock.calls.map((c) => (c as unknown[])[0]);
+          expect(saveCalls).toContain('P');
+          expect(saveCalls).toContain('P~Child');
+          expect(saveCalls).toContain('P~Child~Grandchild');
+
+          // Region is propagated parent → child → grandchild.
+          const grandSave = mockSaveState.mock.calls.find(
+            (c) => (c as unknown[])[0] === 'P~Child~Grandchild'
+          ) as unknown as [
+            string,
+            string,
+            {
+              parentStack?: string;
+              parentLogicalId?: string;
+              parentRegion?: string;
+              resources: Record<string, unknown>;
+            },
+          ];
+          expect(grandSave[1]).toBe('us-east-1');
+          // Parent-link fields point one level up (NOT to the root).
+          expect(grandSave[2].parentStack).toBe('P~Child');
+          expect(grandSave[2].parentLogicalId).toBe('Grandchild');
+          expect(grandSave[2].parentRegion).toBe('us-east-1');
+          expect(Object.keys(grandSave[2].resources)).toContain('GrandchildBucket');
+        } finally {
+          rmSync(tmpdirPath, { recursive: true, force: true });
+        }
+      });
+
+      it('rejects absolute aws:asset:path on grandchild nested templates', async () => {
+        // `indexGrandchildTemplatePaths` refuses absolute paths on
+        // grandchild nested-stack rows — `path.join(dir, '/abs/foo')`
+        // would silently bypass the cloud assembly's directory and
+        // point outside cdk.out, so the recursive walker fails up front
+        // with a clear error.
+        const tmpdirPath = mkdtempSync(join(tmpdir(), 'cdkd-import-nested-abs-'));
+        try {
+          const childTemplatePath = join(tmpdirPath, 'Child.nested.template.json');
+          // Child carries a grandchild nested-stack row with an absolute
+          // `aws:asset:path`.
+          (await import('node:fs')).writeFileSync(
+            childTemplatePath,
+            JSON.stringify({
+              Resources: {
+                Grandchild: {
+                  Type: 'AWS::CloudFormation::Stack',
+                  Properties: { TemplateURL: 'x' },
+                  Metadata: { 'aws:asset:path': '/abs/foo.json' },
+                },
+              },
+            })
+          );
+          const tmpl = template({
+            Child: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'x' } },
+          });
+          mockSynthesize.mockResolvedValue({
+            stacks: [{ ...stackInfo('P', tmpl), nestedTemplates: { Child: childTemplatePath } }],
+          });
+          mockHasProvider.mockImplementation((t: string) => t !== 'AWS::CloudFormation::Stack');
+          mockGetProvider.mockReturnValue({
+            import: vi.fn(async () => ({ physicalId: 'phys', attributes: {} })),
+          });
+          const childArn = 'arn:aws:cloudformation:us-east-1:123:stack/Child/uuid';
+          const grandchildArn =
+            'arn:aws:cloudformation:us-east-1:123:stack/Grandchild/uuid';
+          mockGetCfnResourceTree.mockResolvedValue({
+            stackName: 'P',
+            physicalId: 'P',
+            resources: new Map([['Child', childArn]]),
+            nested: new Map([
+              [
+                'Child',
+                {
+                  stackName: childArn,
+                  physicalId: childArn,
+                  resources: new Map([['Grandchild', grandchildArn]]),
+                  nested: new Map([
+                    [
+                      'Grandchild',
+                      {
+                        stackName: grandchildArn,
+                        physicalId: grandchildArn,
+                        resources: new Map(),
+                        nested: new Map(),
+                      },
+                    ],
+                  ]),
+                },
+              ],
+            ]),
+          });
+
+          await expect(
+            runImport(['import', 'P', '--app', 'x', '--yes', '--migrate-from-cloudformation'])
+          ).rejects.toThrow();
+          const lastError = String(errorSpy.mock.calls.at(-1)?.[0]);
+          expect(lastError).toMatch(/grandchild nested-stack/);
+          expect(lastError).toMatch(/absolute/);
+          expect(lastError).toMatch(/Grandchild/);
         } finally {
           rmSync(tmpdirPath, { recursive: true, force: true });
         }

--- a/tests/unit/cli/retire-cfn-stack.test.ts
+++ b/tests/unit/cli/retire-cfn-stack.test.ts
@@ -122,7 +122,6 @@ import {
   retireCloudFormationStack,
   injectRetainPolicies,
   injectRetainPoliciesRecursive,
-  getCloudFormationResourceMapping,
   getCloudFormationResourceTree,
   RecursiveRetainInjectionError,
   type CfnStackResourceTree,
@@ -672,52 +671,6 @@ describe('retireCloudFormationStack', () => {
   });
 });
 
-describe('getCloudFormationResourceMapping', () => {
-  it('returns a Map<logicalId, physicalId> for every stack resource', async () => {
-    const { client, calls } = buildCfnClient({
-      DescribeStackResources: {
-        StackResources: [
-          { LogicalResourceId: 'MyBucket', PhysicalResourceId: 'my-actual-bucket' },
-          { LogicalResourceId: 'MyTopic', PhysicalResourceId: 'arn:aws:sns:...:my-topic' },
-        ],
-      },
-    });
-
-    const mapping = await getCloudFormationResourceMapping('S', client as never);
-
-    expect(calls.map((c) => c.name)).toEqual(['DescribeStackResources']);
-    expect(calls[0]!.input['StackName']).toBe('S');
-    expect(mapping.get('MyBucket')).toBe('my-actual-bucket');
-    expect(mapping.get('MyTopic')).toBe('arn:aws:sns:...:my-topic');
-    expect(mapping.size).toBe(2);
-  });
-
-  it('skips entries missing LogicalResourceId or PhysicalResourceId', async () => {
-    const { client } = buildCfnClient({
-      DescribeStackResources: {
-        StackResources: [
-          { LogicalResourceId: 'Good', PhysicalResourceId: 'phys' },
-          { LogicalResourceId: 'NoPhys' }, // mid-create or import-failed
-          { PhysicalResourceId: 'NoLogical' }, // shouldn't happen but defensive
-        ],
-      },
-    });
-
-    const mapping = await getCloudFormationResourceMapping('S', client as never);
-
-    expect([...mapping.entries()]).toEqual([['Good', 'phys']]);
-  });
-
-  it('returns an empty map when the stack has no resources', async () => {
-    const { client } = buildCfnClient({
-      DescribeStackResources: { StackResources: [] },
-    });
-
-    const mapping = await getCloudFormationResourceMapping('Empty', client as never);
-    expect(mapping.size).toBe(0);
-  });
-});
-
 // ---------------------------------------------------------------------------
 // PR for issue #464 — recursive nested-stack support tests
 // ---------------------------------------------------------------------------
@@ -846,6 +799,50 @@ describe('getCloudFormationResourceTree', () => {
     await getCloudFormationResourceTree('Root', { send } as never);
     expect(inflight.max).toBeGreaterThanOrEqual(2);
   });
+
+  it('propagates child-level DescribeStackResources failures via Promise.all rejection', async () => {
+    // Sibling children are fetched via `Promise.all` for parallelism —
+    // if ANY child-level DescribeStackResources rejects, the rejection
+    // must propagate out of the walker (caller's `cdkd import
+    // --migrate-from-cloudformation` flow aborts before any state write
+    // / Retain injection runs). Without this, a transient child-level
+    // AWS failure would silently produce a partial tree and downstream
+    // `validateNestedStackShape` would surface as a confusing
+    // "BOnly was reported by AWS but the synth template only lists
+    // AOnly" mismatch.
+    const childAArn = 'arn:aws:cloudformation:...:stack/ChildA/uuid-a';
+    const childBArn = 'arn:aws:cloudformation:...:stack/ChildB/uuid-b';
+    const send = vi.fn(async (cmd: FakeCommand) => {
+      const stackName = cmd.input['StackName'] as string;
+      if (stackName === 'Root') {
+        return {
+          StackResources: [
+            {
+              LogicalResourceId: 'ChildA',
+              PhysicalResourceId: childAArn,
+              ResourceType: 'AWS::CloudFormation::Stack',
+            },
+            {
+              LogicalResourceId: 'ChildB',
+              PhysicalResourceId: childBArn,
+              ResourceType: 'AWS::CloudFormation::Stack',
+            },
+          ],
+        };
+      }
+      if (stackName === childAArn) {
+        return { StackResources: [] };
+      }
+      if (stackName === childBArn) {
+        throw new Error('AWS: ChildB disappeared');
+      }
+      throw new Error(`Unexpected DescribeStackResources for '${stackName}'`);
+    });
+
+    await expect(
+      getCloudFormationResourceTree('Root', { send } as never)
+    ).rejects.toThrow(/AWS: ChildB disappeared/);
+  });
 });
 
 describe('injectRetainPoliciesRecursive', () => {
@@ -943,6 +940,205 @@ describe('injectRetainPoliciesRecursive', () => {
       'https://example.com/old-child.json'
     );
     expect(result.modified).toBe(true);
+  });
+
+  it('depth-2 (parent → child → grandchild) → recursive injection on every level + grandchild upload + parent + child URL rewrites', async () => {
+    // Verifies that the recursion goes more than one level deep — that is,
+    // the child's own `injectRetainPoliciesRecursiveInternal` call walks
+    // into ITS nested-stack rows the same way the root parent's call does.
+    // Concretely: a depth-2 tree (P → Child → Grandchild) should produce
+    // (a) two `GetTemplate` round-trips (child + grandchild), (b) two
+    // PutObject uploads (modified child body + modified grandchild body),
+    // (c) Retain injected on every non-nested-stack resource at every
+    // level, (d) `TemplateURL` rewritten on the parent's Child row AND
+    // on the child's Grandchild row.
+    const childArn = 'arn:aws:cloudformation:...:stack/Child/uuid-c';
+    const grandchildArn = 'arn:aws:cloudformation:...:stack/Grandchild/uuid-g';
+    const parentBody = JSON.stringify({
+      Resources: {
+        ParentBucket: { Type: 'AWS::S3::Bucket' },
+        Child: {
+          Type: 'AWS::CloudFormation::Stack',
+          Properties: { TemplateURL: 'https://example.com/old-child.json' },
+        },
+      },
+    });
+    const childBody = JSON.stringify({
+      Resources: {
+        ChildBucket: { Type: 'AWS::S3::Bucket' },
+        Grandchild: {
+          Type: 'AWS::CloudFormation::Stack',
+          Properties: { TemplateURL: 'https://example.com/old-grandchild.json' },
+        },
+      },
+    });
+    const grandchildBody = JSON.stringify({
+      Resources: { GrandchildBucket: { Type: 'AWS::S3::Bucket' } },
+    });
+    const tree: CfnStackResourceTree = {
+      stackName: 'P',
+      physicalId: 'P',
+      resources: new Map([['ParentBucket', 'pb'], ['Child', childArn]]),
+      nested: new Map([
+        [
+          'Child',
+          {
+            stackName: childArn,
+            physicalId: childArn,
+            resources: new Map([['ChildBucket', 'cb'], ['Grandchild', grandchildArn]]),
+            nested: new Map([
+              [
+                'Grandchild',
+                {
+                  stackName: grandchildArn,
+                  physicalId: grandchildArn,
+                  resources: new Map([['GrandchildBucket', 'gb']]),
+                  nested: new Map(),
+                },
+              ],
+            ]),
+          },
+        ],
+      ]),
+    };
+
+    const cfnCalls: { name: string; StackName: string }[] = [];
+    const send = vi.fn(async (cmd: FakeCommand) => {
+      cfnCalls.push({ name: cmd._name, StackName: cmd.input['StackName'] as string });
+      if (cmd._name === 'GetTemplate') {
+        const stackName = cmd.input['StackName'];
+        if (stackName === childArn) return { TemplateBody: childBody };
+        if (stackName === grandchildArn) return { TemplateBody: grandchildBody };
+      }
+      throw new Error(`Unexpected CFn command: ${cmd._name}(${JSON.stringify(cmd.input)})`);
+    });
+
+    const result = await injectRetainPoliciesRecursive(parentBody, 'P', tree, {
+      cfnClient: { send } as never,
+      stateBucket: 'state-bucket',
+    });
+
+    // CFn: one GetTemplate per nesting level (child + grandchild). Order
+    // doesn't matter for correctness, but the existing depth-1 test
+    // pins order so we do too — depth-first: child first, then
+    // grandchild (which is awaited inside the child's recursion).
+    expect(cfnCalls.map((c) => c.name)).toEqual(['GetTemplate', 'GetTemplate']);
+    expect(cfnCalls.map((c) => c.StackName).sort()).toEqual([childArn, grandchildArn].sort());
+
+    // S3: one PutObject per uploaded transient (modified child body +
+    // modified grandchild body).
+    const puts = s3SendCalls.filter((c) => c.name === 'PutObject');
+    expect(puts).toHaveLength(2);
+    const keys = puts.map((p) => String(p.input['Key']));
+    expect(keys.some((k) => k.includes('__nested__Child'))).toBe(true);
+    expect(keys.some((k) => k.includes('__nested__Grandchild'))).toBe(true);
+    // Caller receives 2 cleanup callbacks to drain in `finally`.
+    expect(result.cleanups).toHaveLength(2);
+
+    // Parent body: Retain on ParentBucket, NOT on Child (skip rule),
+    // TemplateURL on the Child row rewritten away from the original.
+    const parsedParent = JSON.parse(result.body);
+    expect(parsedParent.Resources.ParentBucket.DeletionPolicy).toBe('Retain');
+    expect(parsedParent.Resources.ParentBucket.UpdateReplacePolicy).toBe('Retain');
+    expect(parsedParent.Resources.Child.DeletionPolicy).toBeUndefined();
+    expect(parsedParent.Resources.Child.UpdateReplacePolicy).toBeUndefined();
+    expect(parsedParent.Resources.Child.Properties.TemplateURL).toMatch(/^https:\/\//);
+    expect(parsedParent.Resources.Child.Properties.TemplateURL).not.toBe(
+      'https://example.com/old-child.json'
+    );
+
+    // Child body inside the uploaded transient: Retain on ChildBucket,
+    // NOT on Grandchild (skip rule), TemplateURL on the Grandchild row
+    // rewritten away from the original.
+    const childPut = puts.find((p) => String(p.input['Key']).includes('__nested__Child'))!;
+    const parsedChild = JSON.parse(childPut.input['Body'] as string);
+    expect(parsedChild.Resources.ChildBucket.DeletionPolicy).toBe('Retain');
+    expect(parsedChild.Resources.ChildBucket.UpdateReplacePolicy).toBe('Retain');
+    expect(parsedChild.Resources.Grandchild.DeletionPolicy).toBeUndefined();
+    expect(parsedChild.Resources.Grandchild.UpdateReplacePolicy).toBeUndefined();
+    expect(parsedChild.Resources.Grandchild.Properties.TemplateURL).toMatch(/^https:\/\//);
+    expect(parsedChild.Resources.Grandchild.Properties.TemplateURL).not.toBe(
+      'https://example.com/old-grandchild.json'
+    );
+
+    // Grandchild body inside the uploaded transient: Retain on
+    // GrandchildBucket (leaf-level Retain injection at depth 2).
+    const grandchildPut = puts.find((p) =>
+      String(p.input['Key']).includes('__nested__Grandchild')
+    )!;
+    const parsedGrandchild = JSON.parse(grandchildPut.input['Body'] as string);
+    expect(parsedGrandchild.Resources.GrandchildBucket.DeletionPolicy).toBe('Retain');
+    expect(parsedGrandchild.Resources.GrandchildBucket.UpdateReplacePolicy).toBe('Retain');
+
+    expect(result.modified).toBe(true);
+  });
+
+  it('rejects when modified nested-stack template exceeds the 1 MB CloudFormation TemplateURL limit', async () => {
+    // Defensive guard against a 1 MB+ child template — the
+    // CloudFormation `TemplateURL` ceiling is structurally non-negotiable,
+    // so the recursive flow must reject up front before any S3 upload
+    // happens (a transient over 1 MB would be a wasted round-trip we
+    // couldn't submit anyway, AND the size check must precede the
+    // upload so `cleanups` carries 0 entries on the rejection path).
+    const childArn = 'arn:aws:cloudformation:...:stack/Child/uuid-big';
+    const parentBody = JSON.stringify({
+      Resources: {
+        Child: {
+          Type: 'AWS::CloudFormation::Stack',
+          Properties: { TemplateURL: 'x' },
+        },
+      },
+    });
+    // Pad the child template so the post-Retain-injection body crosses
+    // 1 MB. The `Description` field is forwarded verbatim through the
+    // CFn parse/stringify roundtrip, so stuffing 1.1 MB of `a`s in
+    // Properties.Description guarantees overflow.
+    const padding = 'a'.repeat(1_100_000);
+    const childBody = JSON.stringify({
+      Resources: {
+        Bucket: { Type: 'AWS::S3::Bucket', Properties: { Description: padding } },
+      },
+    });
+    const tree: CfnStackResourceTree = {
+      stackName: 'P',
+      physicalId: 'P',
+      resources: new Map([['Child', childArn]]),
+      nested: new Map([
+        [
+          'Child',
+          {
+            stackName: childArn,
+            physicalId: childArn,
+            resources: new Map([['Bucket', 'b']]),
+            nested: new Map(),
+          },
+        ],
+      ]),
+    };
+    const send = vi.fn(async (cmd: FakeCommand) => {
+      if (cmd._name === 'GetTemplate') return { TemplateBody: childBody };
+      throw new Error(`Unexpected CFn command: ${cmd._name}`);
+    });
+
+    let thrown: unknown;
+    try {
+      await injectRetainPoliciesRecursive(parentBody, 'P', tree, {
+        cfnClient: { send } as never,
+        stateBucket: 'state-bucket',
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    // Wrapped in RecursiveRetainInjectionError so caller's `finally` can
+    // still drain whatever cleanups accumulated (zero in this case, since
+    // the size check fires BEFORE the upload).
+    expect(thrown).toBeInstanceOf(RecursiveRetainInjectionError);
+    const err = thrown as RecursiveRetainInjectionError;
+    expect(err.message).toMatch(/exceeds the CloudFormation TemplateURL limit/);
+    expect(err.cleanups).toHaveLength(0);
+    // No PutObject ever issued — the size guard runs before upload.
+    expect(s3SendCalls.filter((c) => c.name === 'PutObject')).toHaveLength(0);
   });
 
   it('throws RecursiveRetainInjectionError carrying partial cleanups on mid-walk failure', async () => {


### PR DESCRIPTION
## Summary

Addresses the residual nits from PR #564 (`cdkd import --migrate-from-cloudformation` recursive nested-stack support, issue #464 PR A):

**Test coverage additions** (test-reviewer items):

- Depth-2 (grandchild) Retain injection in `injectRetainPoliciesRecursive` — previously only depth-1 was covered.
- `injectRetainPoliciesRecursive` child template > 1 MB CloudFormation TemplateURL limit rejection.
- `getCloudFormationResourceTree` mid-walk `Promise.all` rejection (child-level `DescribeStackResources` failure).
- `importNestedStackChildrenRecursive` grandchild state-write recursion (depth-2 v6 state-key shape).
- `indexGrandchildTemplatePaths` absolute-path rejection on grandchild nested templates.
- STS `GetCallerIdentity` missing-`Account` branch in the `--migrate-from-cloudformation` flow.

**Code-quality nits** (code-reviewer items):

- Delete dead `getCloudFormationResourceMapping` export. Zero production callers after PR #564 (the recursive `getCloudFormationResourceTree` replaced it); only test code referenced the export. The function's tests + the `import.test.ts` mock entry are removed alongside.

**Test-infra nits** (test-reviewer items):

- `tests/unit/cli/import.test.ts`'s `vi.mock('../../../src/cli/commands/retire-cfn-stack.js', ...)` now uses `vi.importActual` for `NESTED_STACK_RESOURCE_TYPE` (no more hand-copied literal) and re-types `mockGetCfnResourceTree` against the real `CfnStackResourceTree` interface (no more inline duck-typed shape). Future fields on `CfnStackResourceTree` will silently break the mock at type-check time instead of silently passing.

Refs #566 (closes every item listed as open in the issue body except the two explicitly-deferred low-priority ones — see "Deferred" below).

## Deferred (intentionally not in this PR)

The issue body lists two items as low-priority / explicitly deferred; this PR ships without them:

- **Tree walker filtering of resources missing `PhysicalResourceId`** — the issue notes "structurally identical to the covered flat-map case, low risk." Skipping per the issue's own assessment.
- **`Properties` fallback assignment when the value is non-object** — the issue notes "CFn rejects such templates upstream so the practical risk is zero, but noting." Not worth the test fixture.

## Test plan

- [x] `vp check --fix` — pass (0 lint/type errors in 217 files)
- [x] `vp run build` — pass
- [x] `vp run test` — 357 files / 5269 tests pass (+6 new tests from the additions above; +0 regressions)
- [x] Diff scope confirmed: 3 files (`src/cli/commands/retire-cfn-stack.ts`, `tests/unit/cli/import.test.ts`, `tests/unit/cli/retire-cfn-stack.test.ts`). Does NOT touch `src/provisioning/providers/**`, `destroy.ts`, `deploy-engine.ts`, or `src/local/**` — so `integ-destroy` / `integ-broad` / `integ-local` gates are correctly n/a for this PR.
