### PR TITLE
test(nested-stack): pin overrideLogicalId('Child') so state key matches README

### DIFF
--- a/docs/_generated/integ-coverage.json
+++ b/docs/_generated/integ-coverage.json
@@ -439,10 +439,14 @@
       "resourceType": "AWS::CloudFormation::Stack",
       "integs": [
         "import-nested-stack",
+        "nested-stack",
         "nested-stack-deep"
       ],
       "signals": {
         "import-nested-stack": [
+          "literal"
+        ],
+        "nested-stack": [
           "literal"
         ],
         "nested-stack-deep": [

--- a/docs/integ-coverage.md
+++ b/docs/integ-coverage.md
@@ -61,7 +61,7 @@ Registered without an integ fixture, with an explicit `// allow-no-integ: <ratio
 | `AWS::AppSync::Resolver` | [`appsync`](../tests/integration/appsync/) (l1) |
 | `AWS::AutoScaling::AutoScalingGroup` | [`drift-revert-vpc`](../tests/integration/drift-revert-vpc/) (l1,literal)<br>[`remove-protection`](../tests/integration/remove-protection/) (l2,literal) |
 | `AWS::BedrockAgentCore::Runtime` | [`bedrock-agentcore`](../tests/integration/bedrock-agentcore/) (literal) |
-| `AWS::CloudFormation::Stack` | [`import-nested-stack`](../tests/integration/import-nested-stack/) (literal)<br>[`nested-stack-deep`](../tests/integration/nested-stack-deep/) (literal) |
+| `AWS::CloudFormation::Stack` | [`import-nested-stack`](../tests/integration/import-nested-stack/) (literal)<br>[`nested-stack`](../tests/integration/nested-stack/) (literal)<br>[`nested-stack-deep`](../tests/integration/nested-stack-deep/) (literal) |
 | `AWS::CloudFront::CloudFrontOriginAccessIdentity` | [`s3-cloudfront`](../tests/integration/s3-cloudfront/) (l2) |
 | `AWS::CloudFront::Distribution` | [`bench-cdk-sample`](../tests/integration/bench-cdk-sample/) (l2)<br>[`cloudfront-function-url`](../tests/integration/cloudfront-function-url/) (l2)<br>[`s3-cloudfront`](../tests/integration/s3-cloudfront/) (l2) |
 | `AWS::CloudTrail::Trail` | [`infra-security`](../tests/integration/infra-security/) (l2,literal) |

--- a/tests/integration/nested-stack/lib/nested-stack-example.ts
+++ b/tests/integration/nested-stack/lib/nested-stack-example.ts
@@ -25,6 +25,13 @@ class ChildNestedStack extends cdk.NestedStack {
   constructor(scope: Construct, id: string, props?: cdk.NestedStackProps) {
     super(scope, id, props);
 
+    // Pin the AWS::CloudFormation::Stack logical id so the cdkd state key
+    // (`<parent>~<logicalId>`) matches the README's documented `~Child`
+    // shape instead of the CDK auto-generated `~<Name>NestedStack<Name>
+    // NestedStackResource<hash>` compound. See memory rule
+    // `feedback_cdk_nested_stack_overridelogical_id.md` + issue #575.
+    (this.nestedStackResource as cdk.CfnResource).overrideLogicalId('Child');
+
     this.bucket = new s3.Bucket(this, 'Bucket', {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });


### PR DESCRIPTION
## Summary

Pins `overrideLogicalId('Child')` on `tests/integration/nested-stack/lib/nested-stack-example.ts` so the cdkd state key matches what the fixture's README documents.

Closes #575.

## Problem

The README documents the state key as:

```
s3://cdkd-state-{accountId}/cdkd/NestedStackExample~Child/{region}/state.json
```

But the actual deployed state key was the CDK auto-generated compound (empirically observed during PR #572's A2 live-test):

```
s3://cdkd-state-{accountId}/cdkd/NestedStackExample~ChildNestedStackChildNestedStackResourceC40294CA/{region}/state.json
```

CDK auto-generates `<Name>NestedStack<Name>NestedStackResource<hash>` as the `AWS::CloudFormation::Stack` logical id when the construct's `nestedStackResource` is not pinned via `overrideLogicalId`. The newer `tests/integration/nested-stack-deep/` fixture (PR #569, A1 of #555) correctly applies this pattern; this PR brings the existing single-level fixture in line.

## Change

One construct-side edit in `lib/nested-stack-example.ts`:

```ts
(this.nestedStackResource as cdk.CfnResource).overrideLogicalId('Child');
```

## Verification

Real-AWS via `/run-integ nested-stack`:

| Phase | Result |
|-------|--------|
| Deploy | 5.88s, 2 created at top-level + 3 in nested child |
| State key | `cdkd/NestedStackExample~Child/us-east-1/state.json` ← matches README |
| Destroy | 5 resources removed across 2 nested levels, 0 errors |
| Orphan check | `aws s3 ls s3://cdkd-state-{accountId}/cdkd/` clean for NestedStackExample |

`integ-destroy` markgate marker refreshed against the new fixture shape.

## Caveat

This is a state-key shape change. Any developer with a previously-deployed `NestedStackExample` integ stack would have state at the OLD `~ChildNestedStack...<hash>` key. They should either:

1. `cdkd state destroy NestedStackExample` first (destroys old-key child + parent cleanly via the pre-PR pinning), then redeploy with this PR's binary → state lands at new `~Child` key, OR
2. `aws s3 rm s3://cdkd-state-{accountId}/cdkd/NestedStackExample~ChildNestedStack...<hash>/<region>/ --recursive` to orphan the old child state record, then `cdkd state destroy NestedStackExample` to clean up the dangling parent reference (uses the same idempotent-missing-child semantic in `NestedStackProvider.delete` that PR #572 relies on for the `cdkd destroy <parent>` cascade after `cdkd state destroy <child>` was run as an escape hatch).

Both paths are tested-by-construction by the existing integ fixtures and PR #572's A2 implementation; no new code path is introduced.

## References

- Issue: #575
- Memory rule: `feedback_cdk_nested_stack_overridelogical_id.md` (existed pre-session; surfaced again here)
- A1 PR #569 — `nested-stack-deep` fixture (already applies the pattern)
- A2 PR #572 — where the README/deployed-state divergence was empirically observed

## Test plan

- [x] `/check` (5291 tests pass)
- [x] `/run-integ nested-stack` — clean deploy + destroy, 0 orphans
- [x] State key shape verified against README
- [x] `/verify-pr`
