### PR TITLE
fix(local): close Service Connect / Cloud Map review nits

### DIFF
--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -93,6 +93,13 @@ async function localStartServiceCommand(
 
   warnIfDeprecatedRegion(options);
 
+  // Commander resolves `--no-pull` to `options.pull = false` (the
+  // default is true). Compute the "should we skip docker pull?" flag
+  // once here so the shared-network creation, the per-target task
+  // boot, and any future call site share one source of truth (Issue
+  // #544 NIT 2).
+  const skipPull = options.pull === false;
+
   if (!targets || targets.length === 0) {
     throw new LocalStartServiceError(
       'cdkd local start-service requires at least one <target>. ' +
@@ -249,7 +256,7 @@ async function localStartServiceCommand(
     try {
       sharedNetwork = await createSharedSvcNetwork({
         prefix: options.cluster,
-        skipPull: options.pull === false,
+        skipPull,
         cluster: options.cluster,
       });
     } catch (err) {
@@ -285,7 +292,14 @@ async function localStartServiceCommand(
     // booted later automatically see earlier services' registrations
     // and have them substituted via `--add-host` at boot.
     for (const pt of perTarget) {
-      pt.controller = await bootOneTarget(pt.target, pt.runState, stacks, options, discovery);
+      pt.controller = await bootOneTarget(
+        pt.target,
+        pt.runState,
+        stacks,
+        options,
+        discovery,
+        skipPull
+      );
     }
 
     const summary = perTarget
@@ -320,7 +334,8 @@ async function bootOneTarget(
   runState: ServiceRunState,
   stacks: StackInfo[],
   options: LocalStartServiceOptions,
-  discovery: ServiceDiscoveryContext
+  discovery: ServiceDiscoveryContext,
+  skipPull: boolean
 ): Promise<ServiceController> {
   const logger = getLogger();
 
@@ -405,7 +420,7 @@ async function bootOneTarget(
   const taskOpts: RunEcsTaskOptions = {
     cluster: options.cluster,
     containerHost: options.containerHost,
-    skipPull: options.pull === false,
+    skipPull,
     keepRunning: false,
     detach: true,
   };
@@ -620,19 +635,23 @@ function parsePositiveInt(raw: string, flagName: string): number {
 
 /**
  * Hard cap on `--max-tasks` driven by the per-replica subnet allocator
- * in `ecs-service-runner.ts:bootReplica` (`170 + (index % 84)`). The
- * `% 84` modulo wraps at index 84, collapsing replica 84's `/24` onto
- * replica 0's allocation. Docker rejects the duplicate-subnet network
- * creation with a cryptic "Pool overlaps with other one on this address
- * space" error 30s into the boot — by which time some early replicas
- * may have spent docker-run budget. Reject at parse time so the user
+ * in `ecs-service-runner.ts:pickSubnetOctet`. The allocator walks the
+ * link-local /24 range `169.254.170.0..169.254.253.0` and **skips 171**
+ * because that octet is owned by the shared-service network
+ * (`SHARED_SVC_SUBNET_OCTET`) — assigning a per-replica network the
+ * same /24 would have docker reject the duplicate-subnet `network
+ * create`. The usable count is therefore 83 (Issue #544); beyond
+ * that, the modulo-wrap collapses replica N's `/24` onto replica 0's
+ * allocation and docker rejects the duplicate-subnet network creation
+ * with a cryptic "Pool overlaps with other one on this address space"
+ * error 30s into the boot — by which time some early replicas may
+ * have spent docker-run budget. Reject at parse time so the user
  * gets an actionable error before any boot work fires.
  *
- * 84 is the count of usable link-local /24 octets in the range
- * `169.254.170.0..169.254.253.0` (255 reserved for broadcast). Raising
- * this requires extending the allocator to walk a different IP range.
+ * Raising this requires extending the allocator to walk a different
+ * IP range.
  */
-export const MAX_TASKS_SUBNET_RANGE_CAP = 84;
+export const MAX_TASKS_SUBNET_RANGE_CAP = 83;
 
 function parseMaxTasks(raw: string): number {
   const parsed = parsePositiveInt(raw, '--max-tasks');

--- a/src/local/cloud-map-registry.ts
+++ b/src/local/cloud-map-registry.ts
@@ -1,3 +1,5 @@
+import { getLogger } from '../utils/logger.js';
+
 /**
  * Phase 3 of #262 (Issue #460) — in-process Cloud Map / Service Connect
  * service registry consumed by `cdkd local start-service` to surface a
@@ -99,8 +101,13 @@ export class CloudMapRegistry {
   /**
    * Map<alias, fqdn> — secondary index for ClientAlias short forms.
    * Multiple aliases can point at the same fqdn; one alias only points
-   * at one fqdn (last write wins, with a warn surfaced by the resolver
-   * when a cross-namespace collision is detected — see design §O6).
+   * at one fqdn. **First-wins on collision** — consistent with design
+   * §O6's namespace-level first-wins rule for `PrivateDnsNamespace`. A
+   * collision (two services declaring the same `ClientAlias.DnsName`)
+   * emits a `logger.warn` so users can debug "why does
+   * `wget http://api/` reach service B instead of service A" without
+   * silently shadowing the prior binding. Idempotent re-register of
+   * the same `(alias, targetFqdn)` pair is a no-op and does NOT warn.
    */
   private readonly aliasIndex: Map<string, string> = new Map();
 
@@ -142,8 +149,13 @@ export class CloudMapRegistry {
    * suffix). Cloud Map / Service Connect does NOT auto-create such
    * aliases — they're populated by `ClientAliases[].DnsName` entries in
    * the consumer service's `ServiceConnectConfiguration`. Aliases are
-   * scoped per-CLI-invocation and last-write-wins on collision (the
-   * resolver surfaces a `warn` when this happens — see §O6).
+   * scoped per-CLI-invocation and **first-wins on collision** —
+   * consistent with design §O6's namespace-level first-wins rule. The
+   * first registration sticks; later attempts to bind the same alias
+   * to a different fqdn are ignored and a `logger.warn` is emitted so
+   * users can debug "why does `wget http://api/` reach service B
+   * instead of service A". Re-registering the same `(alias,
+   * targetFqdn)` pair is idempotent and does NOT warn.
    *
    * @param alias The bare discovery name (e.g. `orders` for an alias to
    *              `orders.cdkd-local.local`).
@@ -156,6 +168,21 @@ export class CloudMapRegistry {
     }
     if (!targetFqdn) {
       throw new Error('CloudMapRegistry.registerAlias: targetFqdn must be a non-empty string.');
+    }
+    const existing = this.aliasIndex.get(alias);
+    if (existing !== undefined) {
+      // Idempotent re-register from the same source — no-op, no warn.
+      if (existing === targetFqdn) return;
+      // Cross-source collision: first-wins. Keep the existing binding
+      // and surface a warn so users can debug surprising routing.
+      getLogger()
+        .child('cloud-map-registry')
+        .warn(
+          `ClientAlias DnsName collision: '${alias}' was already mapped to '${existing}'; ` +
+            `keeping first-wins binding and ignoring new mapping to '${targetFqdn}'. ` +
+            'Likely cause: two Service Connect services declared the same ClientAlias.DnsName.'
+        );
+      return;
     }
     this.aliasIndex.set(alias, targetFqdn);
   }

--- a/src/local/ecs-service-resolver.ts
+++ b/src/local/ecs-service-resolver.ts
@@ -270,7 +270,11 @@ export function extractServiceProperties(
   // are now first-class. Parse + surface; the registry/runner layer
   // handles cross-service publish + DNS overlay.
   const serviceConnect = extractServiceConnect(props['ServiceConnectConfiguration'], task);
-  const serviceRegistries = extractServiceRegistries(props['ServiceRegistries']);
+  const serviceRegistries = extractServiceRegistries(
+    props['ServiceRegistries'],
+    serviceLogicalId,
+    warnings
+  );
 
   const out: ResolvedEcsService = {
     stack,
@@ -397,8 +401,20 @@ function extractServiceConnect(
  * canonical `Fn::GetAtt: [<CloudMapServiceLogicalId>, 'Arn']` shape;
  * cdkd surfaces the logical id (the AWS-side ARN is irrelevant
  * locally — the registry is in-process).
+ *
+ * Issue #544 — entries with a literal-string `RegistryArn` (rare
+ * locally — would imply the user bound to an existing Cloud Map
+ * service deployed out-of-band) are skipped with a warning, since the
+ * in-process registry cannot resolve an external Cloud Map service
+ * back to its `(namespace, name)` pair. Pre-fix this was a silent
+ * `continue` and the user got no feedback about why the registration
+ * didn't show up.
  */
-function extractServiceRegistries(raw: unknown): ReadonlyArray<ResolvedServiceRegistry> {
+function extractServiceRegistries(
+  raw: unknown,
+  serviceLogicalId: string,
+  warnings: string[]
+): ReadonlyArray<ResolvedServiceRegistry> {
   if (!Array.isArray(raw)) return [];
   const out: ResolvedServiceRegistry[] = [];
   for (const entry of raw) {
@@ -409,7 +425,14 @@ function extractServiceRegistries(raw: unknown): ReadonlyArray<ResolvedServiceRe
     if (typeof registryArn === 'string') {
       // Already a literal ARN (rare locally — would imply the user
       // bound to an existing Cloud Map service deployed out-of-band).
-      // We can't resolve it; surface a warn upstream by skipping.
+      // We can't resolve it via the in-process registry; warn + skip.
+      warnings.push(
+        `ECS Service '${serviceLogicalId}' ServiceRegistries[] entry has a literal-string ` +
+          `RegistryArn ('${registryArn}'); cdkd cannot resolve external Cloud Map services ` +
+          'locally. Skipping this registration; peer services will not discover this endpoint ' +
+          'through the in-process registry. Use Fn::GetAtt: [<CloudMapServiceLogicalId>, "Arn"] ' +
+          'instead so cdkd can resolve the namespace + service name from the synthesized template.'
+      );
       continue;
     }
     if (registryArn && typeof registryArn === 'object' && !Array.isArray(registryArn)) {

--- a/src/local/ecs-service-runner.ts
+++ b/src/local/ecs-service-runner.ts
@@ -11,7 +11,7 @@ import type { ResolvedEcsService } from './ecs-service-resolver.js';
 import type { CloudMapRegistry, RegistrationHandle } from './cloud-map-registry.js';
 import type { CloudMapIndex } from './cloud-map-resolver.js';
 import { getContainerNetworkIp } from './docker-inspect.js';
-import type { TaskNetwork } from './ecs-network.js';
+import { SHARED_SVC_SUBNET_OCTET, type TaskNetwork } from './ecs-network.js';
 
 /**
  * Phase 2 of #262 — long-running ECS Service emulator. Wraps the existing
@@ -208,6 +208,49 @@ export function backoffDelayMs(restartCount: number): number {
   const cap = 30_000;
   const factor = Math.pow(2, Math.min(restartCount, 10));
   return Math.min(base * factor, cap);
+}
+
+/**
+ * Maximum number of replica indices the per-replica subnet allocator
+ * can serve without modulo-wrap collision. The allocator below walks
+ * the link-local /24 range `169.254.170.0..169.254.253.0` (84 octets)
+ * and **skips 171** because that octet is owned by the shared-service
+ * network in design § 5 Option A (see `SHARED_SVC_SUBNET_OCTET`), so
+ * the usable count is 83. The CLI's `--max-tasks` parser enforces this
+ * cap before any boot work fires.
+ */
+export const SUBNET_ALLOCATOR_RANGE = 83;
+
+/**
+ * Defensive per-replica subnet octet allocator (Issue #544). Only used
+ * when callers bypass the CLI's `sharedNetwork` construction — i.e.
+ * test paths that hand-build `ServiceRunnerOptions.discovery` without
+ * `sharedNetwork`, or the bare `cdkd local run-task`-shaped path that
+ * runs one network per task. Production `cdkd local start-service`
+ * runs always go through the shared network (design § 5 Option A) so
+ * this allocator is unreachable in the standard path.
+ *
+ * Returns the second-from-last octet of the per-replica /24 (170 →
+ * `169.254.170.0/24`). Walks the 83-slot output range
+ * `[170, 172, 173, ..., 253]` — 171 is intentionally **skipped**
+ * because it's reserved for the shared-service network sidecar
+ * (`SHARED_SVC_SUBNET_OCTET`), and assigning a per-replica network
+ * the same /24 would have docker reject the duplicate-subnet
+ * `network create` with the cryptic "Pool overlaps with other one on
+ * this address space" error.
+ */
+export function pickSubnetOctet(index: number): number {
+  const slot = ((index % SUBNET_ALLOCATOR_RANGE) + SUBNET_ALLOCATOR_RANGE) % SUBNET_ALLOCATOR_RANGE;
+  // Output sequence: index 0 -> 170, index 1 -> 172, index 2 -> 173, ...
+  // The range [170..253] has 84 entries; we drop one (SHARED_SVC_SUBNET_OCTET)
+  // to keep every replica's subnet disjoint from the shared-service network.
+  const base = 170;
+  const candidate = base + slot;
+  // Skip SHARED_SVC_SUBNET_OCTET by shifting every slot >= its offset
+  // up by one. With base=170 and SHARED_SVC_SUBNET_OCTET=171, this
+  // collapses to "slot 0 -> 170; slot 1+ -> 172..253" but stays
+  // defensive if either constant moves in the future.
+  return candidate < SHARED_SVC_SUBNET_OCTET ? candidate : candidate + 1;
 }
 
 /**
@@ -518,9 +561,13 @@ async function bootReplica(
   //   - Without a shared network (defensive fallback for callers
   //     that bypass the CLI's shared-context construction), the
   //     pre-Option-A formula applies: each replica gets a per-replica
-  //     subnet octet `170 + index` so concurrent replicas don't
-  //     collide on a single /24 — but design § 5 Option B already
-  //     rejected this for cross-service routing reasons.
+  //     subnet octet from `pickSubnetOctet()` so concurrent replicas
+  //     don't collide on a single /24 — but design § 5 Option B
+  //     already rejected this for cross-service routing reasons.
+  //     The allocator skips SHARED_SVC_SUBNET_OCTET (Issue #544) so
+  //     a hand-built ServiceRunnerOptions.discovery that DOES
+  //     pre-create the shared network doesn't collide on the same
+  //     /24 here.
   const sharedNetwork = options.discovery?.sharedNetwork;
   const networkAliasesByContainer = buildNetworkAliasesByContainer(service);
   const perReplicaTaskOptions: RunEcsTaskOptions = {
@@ -535,7 +582,7 @@ async function bootReplica(
     detach: true,
     ...(sharedNetwork
       ? { existingNetwork: sharedNetwork }
-      : { subnetOctet: 170 + (instance.index % 84) }),
+      : { subnetOctet: pickSubnetOctet(instance.index) }),
     ...(addHostFlags.length > 0 ? { addHostFlags } : {}),
     ...(networkAliasesByContainer.size > 0 ? { networkAliasesByContainer } : {}),
   };

--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -652,6 +652,19 @@ function extractTaskDefinitionProperties(
     );
   }
 
+  // Issue #544 — `ProxyConfiguration` (custom App Mesh / Envoy bootstrap)
+  // is NOT honored by `cdkd local start-service` / `cdkd local run-task`
+  // in v1. Design § 2 hard-rejects custom Envoy bootstrap; locally we
+  // run the user's containers without the configured proxy and surface
+  // a warn so users aren't surprised by the missing sidecar.
+  if (props['ProxyConfiguration']) {
+    warnings.push(
+      `Task definition '${logicalId}' declares 'ProxyConfiguration' (custom Envoy / App Mesh bootstrap), ` +
+        "which is NOT honored by 'cdkd local start-service' / 'cdkd local run-task' in v1. " +
+        'Local execution will run without the configured proxy. See design doc § 2 for the rationale.'
+    );
+  }
+
   const resources = stack.template.Resources ?? {};
 
   const subContext = buildSubstitutionContextFromImageContext(context);

--- a/tests/unit/cli/local-start-service.test.ts
+++ b/tests/unit/cli/local-start-service.test.ts
@@ -96,24 +96,32 @@ describe('createLocalStartServiceCommand', () => {
     expect(parsed.opts().pull).toBe(false);
   });
 
-  it('accepts --max-tasks at the subnet-allocator cap (84)', () => {
+  it('accepts --max-tasks at the subnet-allocator cap (83)', () => {
+    // Issue #544 — the cap dropped from 84 to 83 because the
+    // per-replica subnet allocator (`pickSubnetOctet`) skips
+    // SHARED_SVC_SUBNET_OCTET (171) to avoid colliding with the
+    // shared-service network /24.
     const fresh = createLocalStartServiceCommand();
     fresh.action(() => {});
-    const parsed = fresh.parse(['node', 'cdkd', 'Svc', '--max-tasks', '84'], { from: 'user' });
-    expect(parsed.opts().maxTasks).toBe(84);
+    const parsed = fresh.parse(['node', 'cdkd', 'Svc', '--max-tasks', '83'], { from: 'user' });
+    expect(parsed.opts().maxTasks).toBe(83);
   });
 
-  it('rejects --max-tasks above the subnet-allocator cap (85)', () => {
+  it('rejects --max-tasks above the subnet-allocator cap (84)', () => {
     // The per-replica subnet allocator in `ecs-service-runner.ts`
-    // (`170 + (index % 84)`) wraps at index 84, collapsing replica 84's
-    // /24 onto replica 0's allocation and causing Docker to reject the
-    // duplicate-subnet network creation. Surfacing the cap at parse
-    // time gives the user an actionable error before any boot work.
+    // (`pickSubnetOctet`) serves 83 distinct octets out of the
+    // link-local /24 range 169.254.170.0..169.254.253.0 (one octet,
+    // SHARED_SVC_SUBNET_OCTET=171, is reserved for the shared-service
+    // network). At index 83 the modulo wraps and collapses the /24
+    // onto an earlier replica's allocation, causing Docker to reject
+    // the duplicate-subnet network creation. Surfacing the cap at
+    // parse time gives the user an actionable error before any boot
+    // work.
     const fresh = createLocalStartServiceCommand();
     fresh.action(() => {});
     expect(() =>
-      fresh.parse(['node', 'cdkd', 'Svc', '--max-tasks', '85'], { from: 'user' })
-    ).toThrow(/--max-tasks 85 exceeds the per-replica link-local \/24 subnet allocator's range \(84\)/);
+      fresh.parse(['node', 'cdkd', 'Svc', '--max-tasks', '84'], { from: 'user' })
+    ).toThrow(/--max-tasks 84 exceeds the per-replica link-local \/24 subnet allocator's range \(83\)/);
   });
 
   it('rejects --max-tasks 100 (PR #504 review canonical case)', () => {
@@ -121,6 +129,6 @@ describe('createLocalStartServiceCommand', () => {
     fresh.action(() => {});
     expect(() =>
       fresh.parse(['node', 'cdkd', 'Svc', '--max-tasks', '100'], { from: 'user' })
-    ).toThrow(/--max-tasks 100 exceeds.*84/);
+    ).toThrow(/--max-tasks 100 exceeds.*83/);
   });
 });

--- a/tests/unit/local/cloud-map-registry.test.ts
+++ b/tests/unit/local/cloud-map-registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { CloudMapRegistry } from '../../../src/local/cloud-map-registry.js';
 
 describe('CloudMapRegistry', () => {
@@ -116,6 +116,58 @@ describe('CloudMapRegistry', () => {
       const r = new CloudMapRegistry();
       expect(() => r.registerAlias('', 'a.b')).toThrow(/alias must be a non-empty string/);
       expect(() => r.registerAlias('a', '')).toThrow(/targetFqdn must be a non-empty string/);
+    });
+  });
+
+  describe('registerAlias collision (Issue #544 — first-wins, design § O6)', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      // The logger routes warn lines through console.warn. Capture them
+      // so we can assert the collision message fires (and does not fire
+      // for idempotent same-source re-register).
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('first-wins on alias DnsName collision (later mapping ignored + warn fires)', () => {
+      const r = new CloudMapRegistry();
+      r.register('namespace.local', 'svcA', { ip: '1.1.1.1', port: 80, ownerKey: 'A:r0' });
+      r.register('namespace.local', 'svcB', { ip: '2.2.2.2', port: 80, ownerKey: 'B:r0' });
+      r.registerAlias('api', 'svcA.namespace.local');
+      // Second registration of the SAME alias to a DIFFERENT target —
+      // first-wins per design § O6, the new mapping is dropped + warn.
+      r.registerAlias('api', 'svcB.namespace.local');
+
+      const endpoints = r.lookupAlias('api');
+      expect(endpoints?.length).toBe(1);
+      expect(endpoints?.[0]?.ip).toBe('1.1.1.1');
+
+      const warnMessages = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(
+        warnMessages.some(
+          (m) => /ClientAlias DnsName collision/.test(m) && /'api'/.test(m) && /first-wins/.test(m)
+        )
+      ).toBe(true);
+    });
+
+    it('idempotent re-register of same-source mapping does not warn', () => {
+      const r = new CloudMapRegistry();
+      r.register('namespace.local', 'svcA', { ip: '1.1.1.1', port: 80, ownerKey: 'A:r0' });
+      r.registerAlias('api', 'svcA.namespace.local');
+      // Same alias → same target re-registered (e.g. a service was
+      // re-resolved after a restart) — no-op, no warn.
+      r.registerAlias('api', 'svcA.namespace.local');
+
+      const endpoints = r.lookupAlias('api');
+      expect(endpoints?.length).toBe(1);
+      expect(endpoints?.[0]?.ip).toBe('1.1.1.1');
+
+      const warnMessages = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(warnMessages.some((m) => /ClientAlias DnsName collision/.test(m))).toBe(false);
     });
   });
 

--- a/tests/unit/local/ecs-service-runner.test.ts
+++ b/tests/unit/local/ecs-service-runner.test.ts
@@ -36,12 +36,15 @@ import {
   computeReplicaCount,
   createServiceRunState,
   EcsServiceRunnerError,
+  pickSubnetOctet,
   ServiceController,
   shouldRestart,
   startEcsService,
+  SUBNET_ALLOCATOR_RANGE,
   type ServiceReplicaInstance,
   type ServiceRunnerOptions,
 } from '../../../src/local/ecs-service-runner.js';
+import { SHARED_SVC_SUBNET_OCTET } from '../../../src/local/ecs-network.js';
 import type { ResolvedEcsService } from '../../../src/local/ecs-service-resolver.js';
 import type { EcsRunState } from '../../../src/local/ecs-task-runner.js';
 
@@ -890,6 +893,783 @@ describe('Cloud Map / Service Connect registry integration (Issue #460)', () => 
     expect(registry.lookup('cdkd-local.local', 'frontend-cloudmap')).toBeUndefined();
   });
 });
+
+describe('publishReplicaToCloudMap warn / fallback branches (Issue #544)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // The logger routes warn through console.warn. Capture so we can
+    // assert each warn-bearing branch in publishReplicaToCloudMap.
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('namespace mismatch: warns and still registers under the literal Service Connect namespace', async () => {
+    mockRunTask.mockImplementation(async (_task, _opts, state) => {
+      const s = state as EcsRunState;
+      s.network = {
+        networkName: 'cdkd-local-svc-r0',
+        sidecarContainerId: 'sidecar-r0',
+        sidecarIp: '169.254.170.2',
+      } as EcsRunState['network'];
+      s.startedContainers.push({ name: 'app', id: 'container-r0' });
+    });
+    __setWaitForExitImpl(() => new Promise<number>(() => undefined));
+
+    const { CloudMapRegistry } = await import('../../../src/local/cloud-map-registry.js');
+    const registry = new CloudMapRegistry();
+
+    const service: ResolvedEcsService = {
+      serviceName: 'orders',
+      serviceLogicalId: 'OrdersSvc',
+      desiredCount: 1,
+      task: {
+        taskDefinitionLogicalId: 'TD',
+        family: 'orders',
+        containers: [
+          {
+            name: 'app',
+            essential: true,
+            portMappings: [{ name: 'orders-api', containerPort: 80, protocol: 'tcp' }],
+          },
+        ],
+      } as unknown as ResolvedEcsService['task'],
+      stack: { stackName: 'StackA' } as ResolvedEcsService['stack'],
+      serviceConnect: {
+        namespaceName: 'mismatching.local',
+        services: [
+          {
+            portName: 'orders-api',
+            containerPort: 80,
+            discoveryName: 'orders',
+            clientAliases: [],
+          },
+        ],
+      },
+      serviceRegistries: [],
+      warnings: [],
+    } as unknown as ResolvedEcsService;
+
+    const opts: ServiceRunnerOptions = {
+      maxTasks: 83,
+      restartPolicy: 'on-failure',
+      taskOptions: { cluster: 'cdkd-local', containerHost: '127.0.0.1', keepRunning: false },
+      discovery: {
+        registry,
+        cloudMapIndexByStack: new Map([
+          [
+            'StackA',
+            {
+              namespacesByLogicalId: new Map(),
+              // Only 'matching.local' is in the index — the service's
+              // 'mismatching.local' will trigger the warn branch.
+              namespacesByName: new Map([
+                ['matching.local', { logicalId: 'Ns', name: 'matching.local' }],
+              ]),
+              servicesByLogicalId: new Map(),
+              warnings: [],
+            },
+          ],
+        ]),
+      },
+    };
+    const runState = createServiceRunState();
+    const controller = await startEcsService(service, opts, runState);
+
+    // Registration STILL happened — against the literal namespace.
+    const endpoints = registry.lookup('mismatching.local', 'orders');
+    expect(endpoints?.length).toBe(1);
+    expect(endpoints?.[0]?.ip).toBe('10.0.0.10');
+
+    // Warn fired about the mismatch.
+    const warnMessages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(
+      warnMessages.some(
+        (m) => /does not match/.test(m) && /mismatching\.local/.test(m)
+      )
+    ).toBe(true);
+
+    await controller.shutdown();
+  });
+
+  it('ServiceRegistries.containerPort undefined: falls back to essential containers first portMapping', async () => {
+    mockRunTask.mockImplementation(async (_task, _opts, state) => {
+      const s = state as EcsRunState;
+      s.network = {
+        networkName: 'cdkd-local-svc-r0',
+        sidecarContainerId: 'sidecar-r0',
+        sidecarIp: '169.254.170.2',
+      } as EcsRunState['network'];
+      s.startedContainers.push({ name: 'app', id: 'container-r0' });
+    });
+    __setWaitForExitImpl(() => new Promise<number>(() => undefined));
+
+    const { CloudMapRegistry } = await import('../../../src/local/cloud-map-registry.js');
+    const registry = new CloudMapRegistry();
+
+    const service: ResolvedEcsService = {
+      serviceName: 'frontend',
+      serviceLogicalId: 'FrontendSvc',
+      desiredCount: 1,
+      task: {
+        taskDefinitionLogicalId: 'TD',
+        family: 'frontend',
+        containers: [
+          {
+            name: 'app',
+            essential: true,
+            // First port mapping should be the fallback when
+            // ServiceRegistries[].containerPort is undefined.
+            portMappings: [{ name: 'http', containerPort: 9999, protocol: 'tcp' }],
+          },
+        ],
+      } as unknown as ResolvedEcsService['task'],
+      stack: { stackName: 'StackA' } as ResolvedEcsService['stack'],
+      // containerPort intentionally omitted — exercises the fallback.
+      serviceRegistries: [{ cloudMapServiceLogicalId: 'CloudMapSvc' }],
+      warnings: [],
+    } as unknown as ResolvedEcsService;
+
+    const opts: ServiceRunnerOptions = {
+      maxTasks: 83,
+      restartPolicy: 'on-failure',
+      taskOptions: { cluster: 'cdkd-local', containerHost: '127.0.0.1', keepRunning: false },
+      discovery: {
+        registry,
+        cloudMapIndexByStack: new Map([
+          [
+            'StackA',
+            {
+              namespacesByLogicalId: new Map(),
+              namespacesByName: new Map(),
+              servicesByLogicalId: new Map([
+                [
+                  'CloudMapSvc',
+                  {
+                    logicalId: 'CloudMapSvc',
+                    namespaceLogicalId: 'Ns',
+                    namespaceName: 'cdkd-local.local',
+                    name: 'frontend-cm',
+                    dnsRecords: [{ type: 'A' as const, ttlSeconds: 60 }],
+                  },
+                ],
+              ]),
+              warnings: [],
+            },
+          ],
+        ]),
+      },
+    };
+    const runState = createServiceRunState();
+    const controller = await startEcsService(service, opts, runState);
+
+    // Port should have fallen back to the essential containers first
+    // port mapping (9999), NOT the missing override (undefined).
+    const endpoints = registry.lookup('cdkd-local.local', 'frontend-cm');
+    expect(endpoints?.length).toBe(1);
+    expect(endpoints?.[0]?.port).toBe(9999);
+
+    await controller.shutdown();
+  });
+
+  it('ServiceRegistries with no resolvable port (no portMappings and no override): warn + skip', async () => {
+    mockRunTask.mockImplementation(async (_task, _opts, state) => {
+      const s = state as EcsRunState;
+      s.network = {
+        networkName: 'cdkd-local-svc-r0',
+        sidecarContainerId: 'sidecar-r0',
+        sidecarIp: '169.254.170.2',
+      } as EcsRunState['network'];
+      s.startedContainers.push({ name: 'app', id: 'container-r0' });
+    });
+    __setWaitForExitImpl(() => new Promise<number>(() => undefined));
+
+    const { CloudMapRegistry } = await import('../../../src/local/cloud-map-registry.js');
+    const registry = new CloudMapRegistry();
+
+    const service: ResolvedEcsService = {
+      serviceName: 'frontend',
+      serviceLogicalId: 'FrontendSvc',
+      desiredCount: 1,
+      task: {
+        taskDefinitionLogicalId: 'TD',
+        family: 'frontend',
+        containers: [
+          {
+            name: 'app',
+            essential: true,
+            // Empty portMappings + no ServiceRegistries.containerPort
+            // override => no resolvable port => warn + skip.
+            portMappings: [],
+          },
+        ],
+      } as unknown as ResolvedEcsService['task'],
+      stack: { stackName: 'StackA' } as ResolvedEcsService['stack'],
+      serviceRegistries: [{ cloudMapServiceLogicalId: 'CloudMapSvc' }],
+      warnings: [],
+    } as unknown as ResolvedEcsService;
+
+    const opts: ServiceRunnerOptions = {
+      maxTasks: 83,
+      restartPolicy: 'on-failure',
+      taskOptions: { cluster: 'cdkd-local', containerHost: '127.0.0.1', keepRunning: false },
+      discovery: {
+        registry,
+        cloudMapIndexByStack: new Map([
+          [
+            'StackA',
+            {
+              namespacesByLogicalId: new Map(),
+              namespacesByName: new Map(),
+              servicesByLogicalId: new Map([
+                [
+                  'CloudMapSvc',
+                  {
+                    logicalId: 'CloudMapSvc',
+                    namespaceLogicalId: 'Ns',
+                    namespaceName: 'cdkd-local.local',
+                    name: 'frontend-cm',
+                    dnsRecords: [{ type: 'A' as const, ttlSeconds: 60 }],
+                  },
+                ],
+              ]),
+              warnings: [],
+            },
+          ],
+        ]),
+      },
+    };
+    const runState = createServiceRunState();
+    const controller = await startEcsService(service, opts, runState);
+
+    // Nothing registered — warn fired and the entry was skipped.
+    expect(registry.lookup('cdkd-local.local', 'frontend-cm')).toBeUndefined();
+    const warnMessages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(
+      warnMessages.some(
+        (m) => /no resolvable container port/.test(m) && /FrontendSvc/.test(m)
+      )
+    ).toBe(true);
+
+    await controller.shutdown();
+  });
+});
+
+describe('Cross-service Cloud Map ordering (Issue #544 — sequential boot snapshot)', () => {
+  it('second service\'s addHostFlags snapshot includes the first service\'s fqdn (Option A invariant)', async () => {
+    // Mock runTask to also remember the addHostFlags it received per
+    // call, so we can assert the second boots `--add-host` snapshot
+    // contained the first service's fqdn. The implementation snapshots
+    // addHostFlags inside bootReplica BEFORE the per-replica registry
+    // publish runs, so the producer-then-consumer boot order ensures
+    // the consumer sees the producer in its snapshot.
+    const seenAddHostFlags: string[][] = [];
+    mockRunTask.mockImplementation(async (_task, opts, state) => {
+      const o = opts as { addHostFlags?: string[] };
+      seenAddHostFlags.push(o.addHostFlags ? [...o.addHostFlags] : []);
+      const s = state as EcsRunState;
+      const idx = seenAddHostFlags.length - 1;
+      s.network = {
+        networkName: `cdkd-local-svc-r${idx}`,
+        sidecarContainerId: `sidecar-r${idx}`,
+        sidecarIp: '169.254.171.2',
+      } as EcsRunState['network'];
+      s.startedContainers.push({ name: 'app', id: `container-r${idx}` });
+    });
+    mockGetContainerIp.mockImplementation(async (_id, _net) => {
+      // Distinct IPs per call so the cross-service overlay is visible.
+      const callCount = mockGetContainerIp.mock.calls.length;
+      return `10.0.0.${10 + callCount}`;
+    });
+    __setWaitForExitImpl(() => new Promise<number>(() => undefined));
+
+    const { CloudMapRegistry } = await import('../../../src/local/cloud-map-registry.js');
+    const registry = new CloudMapRegistry();
+
+    function makeOrdersService(): ResolvedEcsService {
+      return {
+        serviceName: 'orders',
+        serviceLogicalId: 'OrdersSvc',
+        desiredCount: 1,
+        task: {
+          taskDefinitionLogicalId: 'OrdersTD',
+          family: 'orders',
+          containers: [
+            {
+              name: 'app',
+              essential: true,
+              portMappings: [{ name: 'orders-api', containerPort: 80, protocol: 'tcp' }],
+            },
+          ],
+        } as unknown as ResolvedEcsService['task'],
+        stack: { stackName: 'StackA' } as ResolvedEcsService['stack'],
+        serviceConnect: {
+          namespaceName: 'cdkd-local.local',
+          services: [
+            {
+              portName: 'orders-api',
+              containerPort: 80,
+              discoveryName: 'orders',
+              clientAliases: [],
+            },
+          ],
+        },
+        serviceRegistries: [],
+        warnings: [],
+      } as unknown as ResolvedEcsService;
+    }
+
+    function makeFrontendService(): ResolvedEcsService {
+      return {
+        serviceName: 'frontend',
+        serviceLogicalId: 'FrontendSvc',
+        desiredCount: 1,
+        task: {
+          taskDefinitionLogicalId: 'FrontendTD',
+          family: 'frontend',
+          containers: [
+            {
+              name: 'app',
+              essential: true,
+              portMappings: [{ name: 'frontend-api', containerPort: 8080, protocol: 'tcp' }],
+            },
+          ],
+        } as unknown as ResolvedEcsService['task'],
+        stack: { stackName: 'StackA' } as ResolvedEcsService['stack'],
+        serviceConnect: {
+          namespaceName: 'cdkd-local.local',
+          services: [
+            {
+              portName: 'frontend-api',
+              containerPort: 8080,
+              discoveryName: 'frontend',
+              clientAliases: [],
+            },
+          ],
+        },
+        serviceRegistries: [],
+        warnings: [],
+      } as unknown as ResolvedEcsService;
+    }
+
+    const opts: ServiceRunnerOptions = {
+      maxTasks: 83,
+      restartPolicy: 'on-failure',
+      taskOptions: { cluster: 'cdkd-local', containerHost: '127.0.0.1', keepRunning: false },
+      discovery: {
+        registry,
+        cloudMapIndexByStack: new Map([
+          [
+            'StackA',
+            {
+              namespacesByLogicalId: new Map(),
+              namespacesByName: new Map([
+                ['cdkd-local.local', { logicalId: 'Ns', name: 'cdkd-local.local' }],
+              ]),
+              servicesByLogicalId: new Map(),
+              warnings: [],
+            },
+          ],
+        ]),
+      },
+    };
+
+    // Boot orders FIRST so it registers before frontend's bootReplica
+    // snapshots the registry into `--add-host` flags.
+    const ordersRunState = createServiceRunState();
+    const ordersCtrl = await startEcsService(makeOrdersService(), opts, ordersRunState);
+
+    const frontendRunState = createServiceRunState();
+    const frontendCtrl = await startEcsService(makeFrontendService(), opts, frontendRunState);
+
+    expect(seenAddHostFlags).toHaveLength(2);
+    // Orders booted first — registry was empty, no --add-host flags.
+    expect(seenAddHostFlags[0]).toEqual([]);
+    // Frontend booted second — snapshot of registry includes orders.
+    const frontendFlags = seenAddHostFlags[1]!;
+    const frontendMap = parseAddHostFlagsLocal(frontendFlags);
+    expect(frontendMap['orders.cdkd-local.local']).toBeDefined();
+
+    await ordersCtrl.shutdown();
+    await frontendCtrl.shutdown();
+  });
+});
+
+describe('watchReplica restart re-registers Cloud Map endpoints (Issue #544)', () => {
+  it('after restart, replica re-publishes its registry handles via bootReplica', async () => {
+    let bootCount = 0;
+    mockRunTask.mockImplementation(async (_task, _opts, state) => {
+      bootCount += 1;
+      const s = state as EcsRunState;
+      s.network = {
+        networkName: `cdkd-local-svc-boot${bootCount}`,
+        sidecarContainerId: `sidecar-${bootCount}`,
+        sidecarIp: '169.254.171.2',
+      } as EcsRunState['network'];
+      s.startedContainers.length = 0;
+      s.startedContainers.push({ name: 'app', id: `container-${bootCount}` });
+    });
+    // Distinct IPs per call so we can tell pre-restart and post-restart
+    // registrations apart.
+    mockGetContainerIp.mockImplementation(async () => {
+      const c = mockGetContainerIp.mock.calls.length;
+      return `10.0.0.${10 + c}`;
+    });
+    // First wait: exit code 1 → triggers restart. Second wait blocks.
+    const exits = [1];
+    let exitIdx = 0;
+    __setWaitForExitImpl(async () => {
+      const code = exits[exitIdx];
+      exitIdx += 1;
+      if (code === undefined) {
+        return new Promise<number>(() => undefined);
+      }
+      return code;
+    });
+    __setSleepImpl(() => new Promise<void>((resolve) => setImmediate(resolve)));
+
+    const { CloudMapRegistry } = await import('../../../src/local/cloud-map-registry.js');
+    const registry = new CloudMapRegistry();
+    const service: ResolvedEcsService = {
+      serviceName: 'orders',
+      serviceLogicalId: 'OrdersSvc',
+      desiredCount: 1,
+      task: {
+        taskDefinitionLogicalId: 'TD',
+        family: 'orders',
+        containers: [
+          {
+            name: 'app',
+            essential: true,
+            portMappings: [{ name: 'orders-api', containerPort: 80, protocol: 'tcp' }],
+          },
+        ],
+      } as unknown as ResolvedEcsService['task'],
+      stack: { stackName: 'StackA' } as ResolvedEcsService['stack'],
+      serviceConnect: {
+        namespaceName: 'cdkd-local.local',
+        services: [
+          {
+            portName: 'orders-api',
+            containerPort: 80,
+            discoveryName: 'orders',
+            clientAliases: [],
+          },
+        ],
+      },
+      serviceRegistries: [],
+      warnings: [],
+    } as unknown as ResolvedEcsService;
+
+    const opts: ServiceRunnerOptions = {
+      maxTasks: 83,
+      restartPolicy: 'on-failure',
+      taskOptions: { cluster: 'cdkd-local', containerHost: '127.0.0.1', keepRunning: false },
+      discovery: {
+        registry,
+        cloudMapIndexByStack: new Map([
+          [
+            'StackA',
+            {
+              namespacesByLogicalId: new Map(),
+              namespacesByName: new Map([
+                ['cdkd-local.local', { logicalId: 'Ns', name: 'cdkd-local.local' }],
+              ]),
+              servicesByLogicalId: new Map(),
+              warnings: [],
+            },
+          ],
+        ]),
+      },
+    };
+    const runState = createServiceRunState();
+    const controller = await startEcsService(service, opts, runState);
+
+    // Wait for the restart cycle to complete (bootCount >= 2).
+    const deadline = Date.now() + 5000;
+    while (bootCount < 2 && Date.now() < deadline) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    expect(bootCount).toBeGreaterThanOrEqual(2);
+
+    // After restart completes the registry should once again have an
+    // endpoint for the service — the watcher unregistered the old
+    // handle on restart, and bootReplica re-published a NEW handle.
+    const deadline2 = Date.now() + 2000;
+    while (
+      Date.now() < deadline2 &&
+      (registry.lookup('cdkd-local.local', 'orders')?.length ?? 0) === 0
+    ) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    const endpoints = registry.lookup('cdkd-local.local', 'orders');
+    expect(endpoints?.length).toBe(1);
+    // The post-restart endpoint owner key includes the new restartCount.
+    // We don't pin the exact IP value (depends on mockGetContainerIp
+    // call ordering across other test branches) — only that SOMETHING
+    // is registered post-restart.
+
+    await controller.shutdown();
+  });
+});
+
+describe('ServiceRegistries literal-string RegistryArn warn (Issue #544)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('extractServiceRegistries warns when a literal string RegistryArn is supplied (no GetAtt)', async () => {
+    // Drive the resolver end-to-end — it is the resolver that builds
+    // the ResolvedServiceRegistry list and emits the warn via the
+    // service-level warnings[] array. This pre-fix path was a silent
+    // continue.
+    const { resolveEcsServiceTarget } = await import(
+      '../../../src/local/ecs-service-resolver.js'
+    );
+    const stack = {
+      stackName: 'StackA',
+      displayName: 'StackA',
+      artifactId: 'StackA',
+      dependencyNames: [],
+      template: {
+        Resources: {
+          TD: {
+            Type: 'AWS::ECS::TaskDefinition',
+            Properties: {
+              Family: 'fam',
+              NetworkMode: 'bridge',
+              ContainerDefinitions: [
+                {
+                  Name: 'app',
+                  Image: 'public.ecr.aws/nginx/nginx:alpine',
+                  PortMappings: [{ ContainerPort: 80, Protocol: 'tcp' }],
+                },
+              ],
+            },
+          },
+          Svc: {
+            Type: 'AWS::ECS::Service',
+            Properties: {
+              TaskDefinition: { Ref: 'TD' },
+              DesiredCount: 1,
+              ServiceRegistries: [
+                {
+                  // Literal-string RegistryArn — the pre-fix branch
+                  // silently dropped this. Post-fix: warn surfaced via
+                  // service.warnings.
+                  RegistryArn:
+                    'arn:aws:servicediscovery:us-east-1:111111111111:service/srv-external',
+                },
+              ],
+            },
+          },
+        },
+      },
+    } as unknown as Parameters<typeof resolveEcsServiceTarget>[1][0];
+
+    const service = resolveEcsServiceTarget('StackA:Svc', [stack]);
+    expect(service.serviceRegistries).toEqual([]);
+    expect(
+      service.warnings.some(
+        (w: string) =>
+          /literal-string/.test(w) &&
+          /RegistryArn/.test(w) &&
+          /Fn::GetAtt/.test(w)
+      )
+    ).toBe(true);
+  });
+});
+
+describe('Two services with same ClientAlias.DnsName (Issue #544 — first-wins regression test)', () => {
+  it('second services duplicate ClientAlias is ignored; first-wins binding survives', async () => {
+    let bootCount = 0;
+    mockRunTask.mockImplementation(async (_task, _opts, state) => {
+      bootCount += 1;
+      const s = state as EcsRunState;
+      s.network = {
+        networkName: `cdkd-local-svc-r${bootCount}`,
+        sidecarContainerId: `sidecar-r${bootCount}`,
+        sidecarIp: '169.254.171.2',
+      } as EcsRunState['network'];
+      s.startedContainers.push({ name: 'app', id: `container-r${bootCount}` });
+    });
+    mockGetContainerIp.mockImplementation(async () => {
+      const c = mockGetContainerIp.mock.calls.length;
+      // svcA at 10.0.0.11; svcB at 10.0.0.12.
+      return `10.0.0.${10 + c}`;
+    });
+    __setWaitForExitImpl(() => new Promise<number>(() => undefined));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const { CloudMapRegistry } = await import(
+        '../../../src/local/cloud-map-registry.js'
+      );
+      const registry = new CloudMapRegistry();
+
+      const opts: ServiceRunnerOptions = {
+        maxTasks: 83,
+        restartPolicy: 'on-failure',
+        taskOptions: { cluster: 'cdkd-local', containerHost: '127.0.0.1', keepRunning: false },
+        discovery: {
+          registry,
+          cloudMapIndexByStack: new Map([
+            [
+              'StackA',
+              {
+                namespacesByLogicalId: new Map(),
+                namespacesByName: new Map([
+                  ['cdkd-local.local', { logicalId: 'Ns', name: 'cdkd-local.local' }],
+                ]),
+                servicesByLogicalId: new Map(),
+                warnings: [],
+              },
+            ],
+          ]),
+        },
+      };
+
+      // Both services declare ClientAlias.DnsName: 'api' — first-wins.
+      const svcA: ResolvedEcsService = {
+        serviceName: 'svcA',
+        serviceLogicalId: 'SvcA',
+        desiredCount: 1,
+        task: {
+          taskDefinitionLogicalId: 'TD_A',
+          family: 'a',
+          containers: [
+            {
+              name: 'app',
+              essential: true,
+              portMappings: [{ name: 'a-port', containerPort: 80, protocol: 'tcp' }],
+            },
+          ],
+        } as unknown as ResolvedEcsService['task'],
+        stack: { stackName: 'StackA' } as ResolvedEcsService['stack'],
+        serviceConnect: {
+          namespaceName: 'cdkd-local.local',
+          services: [
+            {
+              portName: 'a-port',
+              containerPort: 80,
+              discoveryName: 'svcA',
+              clientAliases: [{ dnsName: 'api', port: 80 }],
+            },
+          ],
+        },
+        serviceRegistries: [],
+        warnings: [],
+      } as unknown as ResolvedEcsService;
+
+      const svcB: ResolvedEcsService = {
+        serviceName: 'svcB',
+        serviceLogicalId: 'SvcB',
+        desiredCount: 1,
+        task: {
+          taskDefinitionLogicalId: 'TD_B',
+          family: 'b',
+          containers: [
+            {
+              name: 'app',
+              essential: true,
+              portMappings: [{ name: 'b-port', containerPort: 80, protocol: 'tcp' }],
+            },
+          ],
+        } as unknown as ResolvedEcsService['task'],
+        stack: { stackName: 'StackA' } as ResolvedEcsService['stack'],
+        serviceConnect: {
+          namespaceName: 'cdkd-local.local',
+          services: [
+            {
+              portName: 'b-port',
+              containerPort: 80,
+              discoveryName: 'svcB',
+              // Same DnsName 'api' as svcA — the second binding loses.
+              clientAliases: [{ dnsName: 'api', port: 80 }],
+            },
+          ],
+        },
+        serviceRegistries: [],
+        warnings: [],
+      } as unknown as ResolvedEcsService;
+
+      const ctrlA = await startEcsService(svcA, opts, createServiceRunState());
+      const ctrlB = await startEcsService(svcB, opts, createServiceRunState());
+
+      // The alias 'api' resolves to the FIRST service registered (svcA).
+      const aliasEndpoints = registry.lookupAlias('api');
+      expect(aliasEndpoints?.length).toBe(1);
+      // svcA's fqdn was registered with IP 10.0.0.11 (first
+      // mockGetContainerIp call). svcA's first-wins binding for 'api'
+      // points at svcA.cdkd-local.local → 10.0.0.11.
+      expect(aliasEndpoints?.[0]?.ip).toBe('10.0.0.11');
+
+      // The collision warn fired on svcB's attempt.
+      const warnMessages = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(
+        warnMessages.some(
+          (m) => /ClientAlias DnsName collision/.test(m) && /'api'/.test(m)
+        )
+      ).toBe(true);
+
+      await ctrlA.shutdown();
+      await ctrlB.shutdown();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+
+describe('pickSubnetOctet (Issue #544 — defensive subnet allocator)', () => {
+  it('skips SHARED_SVC_SUBNET_OCTET so per-replica networks do not collide with the shared network /24', () => {
+    for (let i = 0; i < 200; i += 1) {
+      expect(pickSubnetOctet(i)).not.toBe(SHARED_SVC_SUBNET_OCTET);
+    }
+  });
+
+  it('returns octets in the link-local /24 range (170..253)', () => {
+    for (let i = 0; i < 200; i += 1) {
+      const octet = pickSubnetOctet(i);
+      expect(octet).toBeGreaterThanOrEqual(170);
+      expect(octet).toBeLessThanOrEqual(253);
+    }
+  });
+
+  it('first SUBNET_ALLOCATOR_RANGE slots are all distinct (no within-window wrap collision)', () => {
+    const seen = new Set<number>();
+    for (let i = 0; i < SUBNET_ALLOCATOR_RANGE; i += 1) {
+      seen.add(pickSubnetOctet(i));
+    }
+    expect(seen.size).toBe(SUBNET_ALLOCATOR_RANGE);
+    expect(seen.has(SHARED_SVC_SUBNET_OCTET)).toBe(false);
+  });
+
+  it('slot 0 maps to 170 (pre-existing first-replica baseline preserved)', () => {
+    expect(pickSubnetOctet(0)).toBe(170);
+  });
+
+  it('slot 1 maps to 172 (the slot that pre-fix returned SHARED_SVC_SUBNET_OCTET)', () => {
+    expect(pickSubnetOctet(1)).toBe(172);
+  });
+});
+
+function parseAddHostFlagsLocal(flags: ReadonlyArray<string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < flags.length; i += 2) {
+    if (flags[i] !== '--add-host') continue;
+    const [name, ip] = (flags[i + 1] ?? '').split(':');
+    if (name && ip) out[name] = ip;
+  }
+  return out;
+}
 
 describe('buildNetworkAliasesByContainer', () => {
   function makeService(

--- a/tests/unit/local/ecs-task-resolver.test.ts
+++ b/tests/unit/local/ecs-task-resolver.test.ts
@@ -33,6 +33,7 @@ function makeTaskDef(opts: {
   runtimePlatform?: unknown;
   taskRoleArn?: unknown;
   executionRoleArn?: unknown;
+  proxyConfiguration?: unknown;
 }): TemplateResource {
   const containers = opts.containers ?? [
     {
@@ -50,6 +51,7 @@ function makeTaskDef(opts: {
   if (opts.runtimePlatform !== undefined) props['RuntimePlatform'] = opts.runtimePlatform;
   if (opts.taskRoleArn !== undefined) props['TaskRoleArn'] = opts.taskRoleArn;
   if (opts.executionRoleArn !== undefined) props['ExecutionRoleArn'] = opts.executionRoleArn;
+  if (opts.proxyConfiguration !== undefined) props['ProxyConfiguration'] = opts.proxyConfiguration;
   const r: TemplateResource = {
     Type: 'AWS::ECS::TaskDefinition',
     Properties: props,
@@ -118,6 +120,36 @@ describe('resolveEcsTaskTarget', () => {
     const r = resolveEcsTaskTarget('TD', [stack]);
     expect(r.networkMode).toBe('awsvpc');
     expect(r.warnings.some((w) => /awsvpc/i.test(w))).toBe(true);
+  });
+
+  it('Issue #544 — warns when ProxyConfiguration (App Mesh / Envoy) is declared', () => {
+    const stack = buildStack('S1', {
+      TD: makeTaskDef({
+        proxyConfiguration: {
+          Type: 'APPMESH',
+          ContainerName: 'envoy',
+          ProxyConfigurationProperties: [
+            { Name: 'AppPorts', Value: '8080' },
+            { Name: 'ProxyEgressPort', Value: '15001' },
+          ],
+        },
+      }),
+    });
+    const r = resolveEcsTaskTarget('TD', [stack]);
+    expect(
+      r.warnings.some(
+        (w) =>
+          /ProxyConfiguration/.test(w) &&
+          /NOT honored/.test(w) &&
+          /without the configured proxy/.test(w)
+      )
+    ).toBe(true);
+  });
+
+  it('Issue #544 — does NOT warn about ProxyConfiguration when absent', () => {
+    const stack = buildStack('S1', { TD: makeTaskDef({}) });
+    const r = resolveEcsTaskTarget('TD', [stack]);
+    expect(r.warnings.some((w) => /ProxyConfiguration/.test(w))).toBe(false);
   });
 
   it('rejects EFSVolumeConfiguration with a routing hint', () => {


### PR DESCRIPTION
## Summary

Closes the residual nits from PR #522's 3-axis review of Service Connect + Cloud Map (Phase 3 of issue #460).

### Spec drifts (behavior changes)

- **`ClientAlias.DnsName` collisions are now first-wins with a warn.** `CloudMapRegistry.registerAlias()` previously used `Map.set` unconditionally (last-wins). The new behavior is first-wins (consistent with design § O6's namespace-level rule) and emits a `logger.warn` on collision so users can debug "why does `wget http://api/` reach service B instead of service A". Idempotent re-register of the same `(alias, fqdn)` mapping stays silent.
- **Unsupported `taskDefinition.ProxyConfiguration` now surfaces a resolver warning** via the existing `warnings: string[]` channel (was silently dropped). Matches design § 2's hard-reject of custom App Mesh / Envoy bootstrap. Honoring `proxyConfiguration` is still deferred (design Layer B).
- **Literal-string `ServiceRegistries[].RegistryArn` now warns at resolver time** instead of silently `continue`-ing. The canonical CDK 2.x shape is `Fn::GetAtt: [<NsLogicalId>, 'Arn']`; a hand-authored literal string is not resolvable to a Cloud Map service in cdkd's index.

### Code NITs

- Extracted the defensive per-replica subnet allocator into an exported `pickSubnetOctet` helper. The new allocator skips `SHARED_SVC_SUBNET_OCTET = 171` so the fallback path cannot collide with the shared-service network. `MAX_TASKS_SUBNET_RANGE_CAP` drops from 84 to 83 to keep the cap aligned with the allocator's 83-slot range.
- `skipPull` is now computed once in `local-start-service.ts`'s action handler and threaded through `bootOneTarget` (was duplicated at two call sites).

### Tests (+16)

`cloud-map-registry.test.ts`:
- First-wins on alias DnsName collision.
- Idempotent re-register of same-source mapping stays silent.

`ecs-task-resolver.test.ts`:
- ProxyConfiguration warning fires when declared.
- No warning when absent.

`ecs-service-runner.test.ts` (9 new tests across 6 describe blocks):
- `publishReplicaToCloudMap` namespace-mismatch warn-and-register-against-literal.
- `publishReplicaToCloudMap` containerPort fallback to first portMapping.
- `publishReplicaToCloudMap` no-resolvable-port warn-and-skip.
- Cross-service registry-publish ordering snapshot (second service's `addHostFlags` sees first's fqdn).
- `watchReplica` restart re-registers Cloud Map endpoints after `bootReplica` completes.
- Literal-string `ServiceRegistries[].RegistryArn` warn at resolver.
- Two services with same `ClientAlias.DnsName` → first-wins regression.
- `pickSubnetOctet` skips `SHARED_SVC_SUBNET_OCTET` + 83-slot range + first-slot baseline.

`local-start-service.test.ts`:
- Updated 3 existing `MAX_TASKS_SUBNET_RANGE_CAP` tests from 84 to 83 to track the cap drop.

## Intentionally deferred (per issue body)

The issue's "Integ test extensions" section lists three nice-to-have integ extensions that are not in this PR:

- `desiredCount: 2` per service in the integ fixture — multi-replica `--add-host` ordering proof.
- One `ServiceRegistries[]` entry alongside Service Connect in the integ fixture.
- `awsvpc`-mode integ fixture once #461 lands.

These are tracked under the same issue for a future PR.

## Test plan

- [x] `vp check --fix` — pass (217 files clean)
- [x] `vp run build` — pass
- [x] `vp run test` — 357 files / 5307 tests pass (+16 new, 0 regressions; baseline was 5291)
- [x] `/run-integ local-ecs-service-connect` — passed end-to-end. Frontend container's `/etc/hosts` showed both `orders.cdkd-sc.local` and the bare `orders` alias mapped to `169.254.171.3`. `wget http://orders/` from frontend reached the orders server's `HELLO_ORDERS` payload. SIGTERM teardown clean. `docker ps --filter name=cdkd-local-` and `docker network ls --filter name=cdkd-local-` both empty post-run.
