### PR TITLE
docs(design/460): carve out warn-and-continue for ProxyConfiguration

### DIFF
--- a/docs/design/460-ecs-service-connect.md
+++ b/docs/design/460-ecs-service-connect.md
@@ -38,6 +38,20 @@ Hard-rejected at boot with an actionable error (mirrors PR 8a's class-4
   v1 emulates the AWS-managed Service Connect config only. The user-supplied
   Envoy `bootstrap.yaml` shape varies enough that auto-translating it is a
   separate concern.
+
+  *Carve-out from the "hard-rejected" intro above*: this bullet is
+  implemented as a resolver `warnings.push(...)` (warn-and-continue), not
+  a throw — unlike the sibling `PublicDnsNamespace` / `HttpNamespace`
+  non-goals which DO throw `EcsTaskResolutionError` at boot. The asymmetry
+  is intentional: CDK ECS L2 constructs (e.g. `appmesh.VirtualNode`'s
+  `addToTaskDefinition`) auto-inject `ProxyConfiguration` at synth time, so
+  a hard reject would refuse to run common app shapes locally even when the
+  proxy is not load-bearing for the dev's test. Warning surfaces the
+  divergence to the user while letting the business container run.
+  Honoring `proxyConfiguration` end-to-end is deferred to Layer B (Envoy
+  sidecar). See [PR #577](https://github.com/go-to-k/cdkd/pull/577) +
+  [issue #578](https://github.com/go-to-k/cdkd/issues/578) for the
+  divergence history.
 - **mTLS / TLS termination** between services. Service Connect supports TLS
   termination at the Envoy sidecar (when the user attaches a `tlsConfiguration`);
   v1 routes plaintext only.


### PR DESCRIPTION
## Summary

Closes #578 via option (1): amend `docs/design/460-ecs-service-connect.md` § 2 inline to document the `ProxyConfiguration` warn-and-continue carve-out + rationale.

PR #577 shipped a soft `warnings.push(...)` for `taskDefinition.ProxyConfiguration` (was silently dropped pre-PR — the actual fix from issue #544). The 3-axis review of #577 flagged that the soft-warn diverges from § 2's blanket "Hard-rejected at boot with an actionable error" intro — the sibling non-goals (`PublicDnsNamespace` / `HttpNamespace`) DO throw `EcsTaskResolutionError`. Issue #578 framed the divergence + three resolution options.

This PR ships option (1): amend the design doc to explicitly carve out a "warn-and-continue" treatment for `ProxyConfiguration`, with the rationale (CDK ECS L2 constructs auto-inject `ProxyConfiguration` via `appmesh.VirtualNode.addToTaskDefinition`, so a hard reject would refuse to run common app shapes locally even when the proxy is not load-bearing for the dev's test). Honoring `ProxyConfiguration` end-to-end remains deferred to Layer B (Envoy sidecar).

No code change. Pure 14-line annotation on the existing bullet.

## Test plan

- [x] `vp check --fix` — pass (217 files clean; docs-only diff so format/lint/typecheck untouched by the change)
- [x] No tests affected — diff is `docs/design/**` only, no `src/**` or `tests/**`.
- [x] No integration tests required — diff scope does not trigger `integ-destroy` / `integ-broad` / `integ-local` / `integ-schema-migration` gates.
- [x] Markers refreshed: check + docs + verify-pr.
