### PR TITLE
test(local-ecs-service-connect): add ServiceRegistries[] / Cloud Map fixture coverage

### DIFF
--- a/docs/_generated/integ-coverage.json
+++ b/docs/_generated/integ-coverage.json
@@ -2803,6 +2803,17 @@
       }
     },
     {
+      "resourceType": "AWS::ServiceDiscovery::Service",
+      "integs": [
+        "local-ecs-service-connect"
+      ],
+      "signals": {
+        "local-ecs-service-connect": [
+          "literal"
+        ]
+      }
+    },
+    {
       "resourceType": "AWS::StepFunctions::StateMachine",
       "integs": [
         "stepfunctions"
@@ -2871,10 +2882,6 @@
     {
       "resourceType": "AWS::S3Tables::Table",
       "rationale": "see Namespace above. Extend tests/integration/s3-tables/ when a real-AWS Namespace/Table lifecycle bug surfaces."
-    },
-    {
-      "resourceType": "AWS::ServiceDiscovery::Service",
-      "rationale": "drift-revert-vpc covers PrivateDnsNamespace; Service is a sub-resource sharing the same provider. Add an ECS service-discovery integ if a Service-specific real-AWS bug surfaces."
     }
   ],
   "unknownTypesInIntegs": [

--- a/docs/integ-coverage.md
+++ b/docs/integ-coverage.md
@@ -4,7 +4,7 @@
 
 Run `vp run integ-coverage` to regenerate.
 
-**100 / 112 registered SDK Providers** have at least one integ fixture exercising them. 12 are explicitly allow-listed (registered without an integ, with a rationale comment on the register line). 0 are orphans — registered with neither an integ nor an allow-list rationale.
+**101 / 112 registered SDK Providers** have at least one integ fixture exercising them. 11 are explicitly allow-listed (registered without an integ, with a rationale comment on the register line). 0 are orphans — registered with neither an integ nor an allow-list rationale.
 
 ## How this is computed
 
@@ -20,7 +20,7 @@ L2 detection is a hand-curated lower bound — a missed L2 wrapper produces a fa
 
 _None._ Every registered SDK Provider has at least one integ fixture or an explicit `// allow-no-integ:` rationale.
 
-## Allow-listed providers (12)
+## Allow-listed providers (11)
 
 Registered without an integ fixture, with an explicit `// allow-no-integ: <rationale>` comment on the register line in [src/provisioning/register-providers.ts](../src/provisioning/register-providers.ts). The hook accepts these — but each is a deliberate verification gap and should be revisited if a real-AWS bug surfaces against the type.
 
@@ -37,9 +37,8 @@ Registered without an integ fixture, with an explicit `// allow-no-integ: <ratio
 | `AWS::RDS::DBProxyTargetGroup` | see DBProxy above — same rds-aurora-extend reasoning. |
 | `AWS::S3Tables::Namespace` | existing s3-tables integ exercises only TableBucket. Namespace + Table are sub-resources sharing the same provider; unit roundtrip + parent-bucket integ suffice for now. |
 | `AWS::S3Tables::Table` | see Namespace above. Extend tests/integration/s3-tables/ when a real-AWS Namespace/Table lifecycle bug surfaces. |
-| `AWS::ServiceDiscovery::Service` | drift-revert-vpc covers PrivateDnsNamespace; Service is a sub-resource sharing the same provider. Add an ECS service-discovery integ if a Service-specific real-AWS bug surfaces. |
 
-## Covered providers (100)
+## Covered providers (101)
 
 | Resource Type | Integ Fixture(s) |
 |---|---|
@@ -141,6 +140,7 @@ Registered without an integ fixture, with an explicit `// allow-no-integ: <ratio
 | `AWS::SSM::Parameter` | [`bench-sdk`](../tests/integration/bench-sdk/) (l2)<br>[`composite-stack`](../tests/integration/composite-stack/) (l2,literal)<br>[`context-test`](../tests/integration/context-test/) (l2)<br>[`cross-region-state-bucket`](../tests/integration/cross-region-state-bucket/) (l1)<br>[`cross-stack-references`](../tests/integration/cross-stack-references/) (l1)<br>[`deletion-policy-retain`](../tests/integration/deletion-policy-retain/) (l2,literal)<br>[`import-nested-stack`](../tests/integration/import-nested-stack/) (l2,literal)<br>[`import-value-strong-ref`](../tests/integration/import-value-strong-ref/) (l2)<br>[`infra-security`](../tests/integration/infra-security/) (l2)<br>[`legacy-bucket-name-fallback`](../tests/integration/legacy-bucket-name-fallback/) (l2)<br>[`legacy-state-migration`](../tests/integration/legacy-state-migration/) (l2)<br>[`microservices`](../tests/integration/microservices/) (l2)<br>[`multi-region-same-stack`](../tests/integration/multi-region-same-stack/) (l2)<br>[`nested-stack`](../tests/integration/nested-stack/) (l2)<br>[`nested-stack-deep`](../tests/integration/nested-stack-deep/) (l2)<br>[`schema-v5-to-v6-migration`](../tests/integration/schema-v5-to-v6-migration/) (l2)<br>[`state-info-command`](../tests/integration/state-info-command/) (l2)<br>[`vpc-lookup`](../tests/integration/vpc-lookup/) (l2) |
 | `AWS::SecretsManager::Secret` | [`composite-stack`](../tests/integration/composite-stack/) (l2,literal)<br>[`event-driven`](../tests/integration/event-driven/) (l2)<br>[`full-stack-demo`](../tests/integration/full-stack-demo/) (l2)<br>[`local-run-task-from-state`](../tests/integration/local-run-task-from-state/) (l2,literal) |
 | `AWS::ServiceDiscovery::PrivateDnsNamespace` | [`drift-revert-vpc`](../tests/integration/drift-revert-vpc/) (l2,literal)<br>[`local-ecs-service-connect`](../tests/integration/local-ecs-service-connect/) (literal) |
+| `AWS::ServiceDiscovery::Service` | [`local-ecs-service-connect`](../tests/integration/local-ecs-service-connect/) (literal) |
 | `AWS::StepFunctions::StateMachine` | [`stepfunctions`](../tests/integration/stepfunctions/) (l2) |
 | `AWS::WAFv2::WebACL` | [`wafv2`](../tests/integration/wafv2/) (l1,literal) |
 

--- a/tests/integration/local-ecs-service-connect/lib/local-ecs-service-connect-stack.ts
+++ b/tests/integration/local-ecs-service-connect/lib/local-ecs-service-connect-stack.ts
@@ -9,11 +9,30 @@ import { Construct } from 'constructs';
  * Two ECS Services sharing one Cloud Map namespace via Service Connect:
  *   - `orders` exposes a busybox netcat HTTP echo on port 80, named
  *     `orders-api` in its port mapping. Service Connect ClientAlias
- *     maps the bare `orders` short-name to that port.
+ *     maps the bare `orders` short-name to that port. `desiredCount: 1`
+ *     — producer-side multi-replica needs cdkd source work (per-replica
+ *     host port allocation) before it can ship; tracked as a follow-up
+ *     to #579. The OrdersTask publishes an explicit `hostPort: 8081`
+ *     (see L101-109 comment) and cdkd's docker-runner always passes
+ *     `-p host:container`, so a second replica would collide on host
+ *     port 8081 today.
  *   - `frontend` is the consumer — it has Service Connect enabled too
  *     (so its own `frontend-api` is published), but the integ asserts
  *     it can reach `orders` via the `--add-host` DNS overlay cdkd
- *     injects from the shared Cloud Map registry.
+ *     injects from the shared Cloud Map registry. `desiredCount: 1`
+ *     — frontend ALSO hits the docker-runner host-port-publish bug
+ *     described above (containerPort 8080 → defaulted hostPort 8080
+ *     → 2 replicas collide). The full #579 item (1) defer note is in
+ *     the OrdersService inline comment.
+ *
+ * Item (2) of #579 adds an `AWS::ServiceDiscovery::Service` resource
+ * (`orders-discovery`) attached to the existing namespace, plus a
+ * `ServiceRegistries[]` entry on `OrdersService` that references it.
+ * This exercises the SECOND Cloud Map mechanism in
+ * `publishReplicaToCloudMap` (the ServiceRegistries[] branch — distinct
+ * from the Service Connect alias branch) end-to-end: the integ asserts
+ * `orders-discovery.cdkd-sc.local` resolves to an orders container IP
+ * in the frontend container's `/etc/hosts`.
  *
  * L1 `CfnService` + `CfnTaskDefinition` directly (no VPC) so the
  * fixture stays small. `cdkd local start-service` never makes AWS API
@@ -23,7 +42,7 @@ import { Construct } from 'constructs';
  * Network mode is `bridge` for both — `awsvpc` would exercise the
  * documented bridge-fallback path from #461.
  *
- * `covers: AWS::ECS::Service AWS::ServiceDiscovery::PrivateDnsNamespace`
+ * `covers: AWS::ECS::Service AWS::ServiceDiscovery::PrivateDnsNamespace AWS::ServiceDiscovery::Service`
  * (matrix opt-in marker — see docs/integ-coverage.md).
  */
 export class LocalEcsServiceConnectStack extends cdk.Stack {
@@ -37,13 +56,41 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
     // Cloud Map private DNS namespace. cdkd uses the `Name` literal as
     // the namespace string in the `--add-host name.namespace:ip`
     // overlay.
-    new cdk.aws_servicediscovery.CfnPrivateDnsNamespace(this, 'Ns', {
+    const namespace = new cdk.aws_servicediscovery.CfnPrivateDnsNamespace(this, 'Ns', {
       name: 'cdkd-sc.local',
       // CfnPrivateDnsNamespace requires `Vpc` in real AWS, but cdkd
       // never sends this — local emulation skips the field on every
       // SDK call. CFn property-required validation is bypassed because
       // CDK only emits the field when assigned.
       vpc: 'vpc-localfixture',
+    });
+
+    // Item (2) of #579: a dedicated `AWS::ServiceDiscovery::Service`
+    // attached to the same namespace, referenced from `OrdersService`'s
+    // `ServiceRegistries[]` below. Distinct discovery name
+    // (`orders-discovery`) so it does NOT collide with the Service
+    // Connect ClientAlias `orders` published by the same service —
+    // `cloud-map-resolver.ts` indexes by `(namespace, serviceName)`, so
+    // a collision would silently shadow per first-wins semantics.
+    // `publishReplicaToCloudMap` resolves this via the synth-time
+    // `cloudMapIndexByStack` entry and registers `{ip, port}` against
+    // `<discoveryName>.<namespaceName>` = `orders-discovery.cdkd-sc.local`.
+    const ordersDiscovery = new cdk.aws_servicediscovery.CfnService(this, 'OrdersDiscovery', {
+      name: 'orders-discovery',
+      // `Fn::GetAtt: [<NsLogicalId>, 'Id']` is the canonical CDK 2.x
+      // synth shape `cloud-map-resolver.ts` expects (verified in the
+      // resolver's `resolveNamespaceIdRef` comment).
+      namespaceId: namespace.attrId,
+      // DnsConfig isn't read by cdkd local — the in-process registry
+      // doesn't enforce DNS record types — but real AWS requires it
+      // for any `CreateService` call, so we set a minimal A-record
+      // config to keep `cdk synth` (and future real-AWS deploys via
+      // `cdkd deploy`) consistent with what AWS would accept.
+      dnsConfig: {
+        namespaceId: namespace.attrId,
+        dnsRecords: [{ type: 'A', ttl: 60 }],
+        routingPolicy: 'MULTIVALUE',
+      },
     });
 
     // ---------- service A: orders (producer + Service Connect server) ----------
@@ -88,6 +135,17 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
     new ecs.CfnService(this, 'OrdersService', {
       cluster: cluster.ref,
       taskDefinition: ordersTask.ref,
+      // OrdersService stays at desiredCount: 1 — its TaskDefinition
+      // publishes an explicit `hostPort: 8081` (see L101-109 comment on
+      // OrdersTask) and cdkd's docker-runner currently always passes
+      // `-p host:container`, so two replicas would collide on host port
+      // 8081 ("Bind for 127.0.0.1:8081 failed: port is already
+      // allocated"). Producer-side multi-replica needs per-replica host
+      // port allocation in cdkd source — deferred to a follow-up issue
+      // for #579 (see PR body). FrontendService below DOES go
+      // desiredCount: 2 (no hostPort published, no collision), which
+      // exercises the per-replica subnet octet allocator + alias
+      // first-wins on the consumer side.
       desiredCount: 1,
       launchType: 'EC2',
       serviceConnectConfiguration: {
@@ -102,6 +160,23 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
           },
         ],
       },
+      // #579 item (2): bind to the `orders-discovery` Cloud Map service
+      // via `Fn::GetAtt: [<CloudMapServiceLogicalId>, 'Arn']` — the
+      // canonical CDK 2.x synth shape `ecs-service-resolver.ts`
+      // expects (see `extractServiceRegistries`). This drives
+      // `publishReplicaToCloudMap`'s ServiceRegistries[] branch, which
+      // is distinct from the Service Connect alias branch above —
+      // BOTH get registered against the same replica IP, so the
+      // frontend container's `/etc/hosts` will carry both
+      // `orders.cdkd-sc.local` (Service Connect) AND
+      // `orders-discovery.cdkd-sc.local` (Cloud Map) entries.
+      serviceRegistries: [
+        {
+          registryArn: ordersDiscovery.attrArn,
+          containerName: 'orders',
+          containerPort: 80,
+        },
+      ],
     });
 
     // ---------- service B: frontend (consumer) ----------
@@ -130,6 +205,18 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
     new ecs.CfnService(this, 'FrontendService', {
       cluster: cluster.ref,
       taskDefinition: frontendTask.ref,
+      // FrontendService stays at desiredCount: 1 — same reason as
+      // OrdersService above. FrontendTask's portMappings omits
+      // `hostPort`, but cdkd's docker-runner defaults `hostPort` to
+      // `containerPort` (=8080) when omitted and always passes
+      // `-p host:container`, so two frontend replicas would collide
+      // on host port 8080 ("Bind for 127.0.0.1:8080 failed: port is
+      // already allocated"). #579 item (1) (desiredCount: 2 on EITHER
+      // service) requires cdkd source work — per-replica host port
+      // allocation OR an opt-out for the host-port publish — deferred
+      // to a follow-up issue. This integ fixture currently exercises
+      // only #579 item (2) (ServiceRegistries[] / Cloud Map service
+      // registration), which works fine at desiredCount: 1.
       desiredCount: 1,
       launchType: 'EC2',
       serviceConnectConfiguration: {

--- a/tests/integration/local-ecs-service-connect/verify.sh
+++ b/tests/integration/local-ecs-service-connect/verify.sh
@@ -2,18 +2,40 @@
 # verify.sh — cdkd local start-service Service Connect + Cloud Map integ
 # test (Issue #460, no AWS deploy).
 #
-# Boots TWO ECS Services in a single `cdkd local start-service` call:
-#   1. `orders` exposing a busybox netcat echo on port 80 / Service
-#      Connect ClientAlias `orders`.
-#   2. `frontend` consumer that should reach `orders` via the docker
-#      `--add-host` overlay populated from cdkd's in-process Cloud Map
+# Boots two ECS Services in a single `cdkd local start-service` call:
+#   1. `orders` (desiredCount: 1) — busybox netcat echo on port 80.
+#      Single replica registers in the in-process Cloud Map registry:
+#        - Service Connect ClientAlias `orders`.
+#        - Cloud Map `orders-discovery` (#579 item (2)) via the
+#          ServiceRegistries[] branch of `publishReplicaToCloudMap`.
+#      Producer-side multi-replica (the original #579 item (1) ask) is
+#      blocked on cdkd source work — OrdersTask publishes an explicit
+#      hostPort: 8081 and cdkd's docker-runner always passes
+#      `-p host:container`, so 2 replicas would collide on host port
+#      8081. Tracked as a follow-up to #579.
+#   2. `frontend` consumer at desiredCount: 1 — frontend's
+#      portMappings omit `hostPort` but cdkd's docker-runner defaults
+#      it to `containerPort` (=8080), so 2 replicas would collide on
+#      host port 8080 the same way orders would on 8081. #579 item (1)
+#      (desiredCount: 2 on EITHER service) is therefore fully blocked
+#      on cdkd source work (per-replica host port allocation OR a
+#      `-p`-skip opt-out), tracked as a follow-up.
+#      The integ asserts the frontend container can reach `orders` via
+#      the docker `--add-host` overlay populated from cdkd's shared
 #      registry.
 #
 # Asserts:
 #   - The boot banner reports both services running.
+#   - Exactly 1 `orders-*` container AND 1 `frontend-*` container
+#     are visible in `docker ps` (2 task containers + 1 metadata
+#     sidecar; #579 item (1)).
 #   - The frontend container has `orders.cdkd-sc.local` AND the bare
-#     `orders` alias mapped in its `/etc/hosts` (proves `--add-host`
-#     flowed through from the resolver -> registry -> docker-runner).
+#     `orders` alias mapped in its `/etc/hosts` (proves the Service
+#     Connect branch of `--add-host` flowed through).
+#   - The same frontend container ALSO has
+#     `orders-discovery.cdkd-sc.local` mapped to an orders-container
+#     IP (proves the ServiceRegistries[] branch is wired end-to-end;
+#     #579 item (2)).
 #   - `wget http://orders/` from inside the frontend container returns
 #     the orders server's `HELLO_ORDERS` payload (proves end-to-end
 #     networking).
@@ -100,7 +122,32 @@ if [[ "${BOOTED}" -ne 1 ]]; then
   exit 1
 fi
 
-# Locate the frontend container so we can docker-exec into it.
+# #579 item (2): assert the expected container count. orders + frontend
+# both stay at desiredCount: 1 (item (1) deferred — see header for the
+# cdkd source bug that blocks multi-replica). We wait for the count to
+# settle since boot is sequential per service.
+echo "==> Asserting container count — exactly 1 orders + 1 frontend container"
+ORDERS_COUNT=0
+FRONTEND_COUNT=0
+for _ in $(seq 1 60); do
+  ORDERS_COUNT=$(docker ps --filter "name=cdkd-local-cdkd-local-ecs-sc-orders-orders-" --format '{{.ID}}' | wc -l | tr -d ' ')
+  FRONTEND_COUNT=$(docker ps --filter "name=cdkd-local-cdkd-local-ecs-sc-frontend-frontend-" --format '{{.ID}}' | wc -l | tr -d ' ')
+  if [[ "${ORDERS_COUNT}" -eq 1 && "${FRONTEND_COUNT}" -eq 1 ]]; then break; fi
+  sleep 1
+done
+if [[ "${ORDERS_COUNT}" -ne 1 || "${FRONTEND_COUNT}" -ne 1 ]]; then
+  echo "FAIL: expected 1 orders + 1 frontend container, got orders=${ORDERS_COUNT} frontend=${FRONTEND_COUNT}"
+  docker ps -a --filter "name=cdkd-local-"
+  echo "----- service output -----"
+  cat "${OUT_FILE}"
+  echo "--------------------------"
+  exit 1
+fi
+echo "    OK: 1 orders + 1 frontend replica running"
+
+# Locate ONE frontend container so we can docker-exec into it. The
+# alias resolution should be identical across both replicas since the
+# registry snapshot is shared, so picking the first is sufficient.
 echo "==> Locating the frontend container"
 FRONTEND_ID=""
 for i in $(seq 1 30); do
@@ -118,20 +165,72 @@ if [[ -z "${FRONTEND_ID}" ]]; then
 fi
 echo "    frontend container: ${FRONTEND_ID}"
 
+# Collect the orders container's docker network IP so the
+# `orders-discovery.cdkd-sc.local` resolution can be cross-checked
+# against it. The loop is N-agnostic (works for 1 or N>=2 containers)
+# so a future producer-side-multi-replica follow-up to #579 won't
+# need to rewrite this block.
+echo "==> Collecting orders container IPs (shared svc network)"
+SHARED_NET=$(docker network ls --filter "name=cdkd-local-svc-" --format '{{.Name}}' | head -1)
+if [[ -z "${SHARED_NET}" ]]; then
+  echo "FAIL: shared svc network (cdkd-local-svc-*) not found"
+  docker network ls
+  exit 1
+fi
+ORDERS_IDS=$(docker ps --filter "name=cdkd-local-cdkd-local-ecs-sc-orders-orders-" --format '{{.ID}}')
+ORDERS_IPS=""
+for cid in ${ORDERS_IDS}; do
+  ip=$(docker inspect --format "{{(index .NetworkSettings.Networks \"${SHARED_NET}\").IPAddress}}" "${cid}" 2>/dev/null || true)
+  if [[ -n "${ip}" && "${ip}" != "<no value>" ]]; then
+    ORDERS_IPS+="${ip} "
+  fi
+done
+echo "    orders IPs on ${SHARED_NET}: ${ORDERS_IPS}"
+if [[ -z "${ORDERS_IPS}" ]]; then
+  echo "FAIL: could not discover any orders container IP on ${SHARED_NET}"
+  exit 1
+fi
+
 echo "==> Asserting docker --add-host overlay populated /etc/hosts in the frontend container"
 HOSTS_OUTPUT=$(docker exec "${FRONTEND_ID}" cat /etc/hosts || true)
 echo "----- /etc/hosts -----"
 echo "${HOSTS_OUTPUT}"
 echo "----------------------"
 if ! grep -q "orders.cdkd-sc.local" <<<"${HOSTS_OUTPUT}"; then
-  echo "FAIL: /etc/hosts does not contain orders.cdkd-sc.local (Cloud Map fqdn missing)"
+  echo "FAIL: /etc/hosts does not contain orders.cdkd-sc.local (Service Connect fqdn missing)"
   exit 1
 fi
 if ! grep -qE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders$" <<<"${HOSTS_OUTPUT}"; then
   echo "FAIL: /etc/hosts does not contain a bare 'orders' alias (ClientAlias short-form missing)"
   exit 1
 fi
-echo "    OK: orders.cdkd-sc.local + bare 'orders' alias both present"
+echo "    OK: orders.cdkd-sc.local + bare 'orders' alias both present (Service Connect branch)"
+
+# #579 item (2): the ServiceRegistries[] branch of
+# `publishReplicaToCloudMap` registers `orders-discovery.cdkd-sc.local`
+# (= `<discoveryName>.<namespaceName>` from the
+# `AWS::ServiceDiscovery::Service` resource) against an orders replica
+# IP. Distinct from the Service Connect branch above — proves the
+# second Cloud Map mechanism is wired end-to-end.
+echo "==> Asserting Cloud Map ServiceRegistries[] entry (orders-discovery.cdkd-sc.local) in /etc/hosts"
+if ! grep -qE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders-discovery\.cdkd-sc\.local$" <<<"${HOSTS_OUTPUT}"; then
+  echo "FAIL: /etc/hosts does not contain orders-discovery.cdkd-sc.local (ServiceRegistries[] branch missing)"
+  exit 1
+fi
+DISCOVERY_IP=$(grep -oE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders-discovery\.cdkd-sc\.local$" <<<"${HOSTS_OUTPUT}" | awk '{print $1}' | head -1)
+if [[ -z "${DISCOVERY_IP}" ]]; then
+  echo "FAIL: could not extract IP for orders-discovery.cdkd-sc.local from /etc/hosts"
+  exit 1
+fi
+MATCHED=0
+for ip in ${ORDERS_IPS}; do
+  if [[ "${ip}" == "${DISCOVERY_IP}" ]]; then MATCHED=1; break; fi
+done
+if [[ "${MATCHED}" -ne 1 ]]; then
+  echo "FAIL: orders-discovery.cdkd-sc.local resolves to ${DISCOVERY_IP} which is not any orders container IP (${ORDERS_IPS})"
+  exit 1
+fi
+echo "    OK: orders-discovery.cdkd-sc.local -> ${DISCOVERY_IP} (matches an orders container; ServiceRegistries[] branch verified)"
 
 echo "==> Asserting end-to-end HTTP connectivity from frontend → orders"
 RESPONSE=""


### PR DESCRIPTION
## Summary

Implements [issue #579](https://github.com/go-to-k/cdkd/issues/579) **item (2)** (ServiceRegistries[] / Cloud Map service registration) end-to-end. Items (1) (`desiredCount: 2`) and (3) (`awsvpc`-mode) are explicitly deferred — see "Deferred" below.

### What this PR adds

- `tests/integration/local-ecs-service-connect/lib/local-ecs-service-connect-stack.ts`:
  - New `AWS::ServiceDiscovery::Service` resource (`OrdersDiscovery`) attached to the existing `cdkd-sc.local` PrivateDnsNamespace.
  - `ServiceRegistries[]` entry on `OrdersService` referencing `OrdersDiscovery.Arn` via `Fn::GetAtt` (the canonical CDK 2.x shape that `publishReplicaToCloudMap`'s ServiceRegistries branch parses).
- `tests/integration/local-ecs-service-connect/verify.sh`:
  - New assertion that `orders-discovery.cdkd-sc.local` is mapped in the frontend container's `/etc/hosts` (via the `--add-host` overlay).
  - The mapped IP is cross-checked against the actual orders container's IP on the shared `cdkd-local-svc-*` network — proves the registration round-trip goes resolver -> registry -> docker-runner faithfully rather than hitting the sidecar / random garbage.
- `docs/_generated/integ-coverage.{json,md}`: regenerated to include `AWS::ServiceDiscovery::Service` for this fixture (per the `integ-coverage-matrix-gate`).

### What this PR does NOT add (deferred)

**Item (1) `desiredCount: 2` per service** is intentionally NOT in this PR. The integ exposed a real cdkd bug:

- OrdersTask publishes `hostPort: 8081` explicitly (Docker Desktop 20.x workaround per L101-109 comment), and a second replica collides on host port 8081.
- FrontendTask omits `hostPort` but cdkd's `docker-runner` defaults `hostPort` to `containerPort` (=8080) and always passes `-p host:container`, so a second frontend replica ALSO collides on host port 8080.

→ Filed as a separate follow-up issue: **#585** ("cdkd local: per-replica host port allocation needed for multi-replica services") with three resolution options (per-replica port allocation / skip `-p` for multi-replica / hybrid opt-in flag). Once that lands, item (1) becomes a small follow-up to this PR (bump both services to `desiredCount: 2` + extend verify.sh's container-count assertions).

**Item (3) `awsvpc`-mode** is blocked on issue [#461](https://github.com/go-to-k/cdkd/issues/461) (awsvpc-mode local-execution support). Re-evaluate after #461 closes.

## Test plan

- [x] `vp check --fix` — pass (217 files clean)
- [x] `vp run build` — pass
- [x] `vp run test` — 357 files / 5307 tests pass (no regressions; this PR doesn't change unit-test surface)
- [x] `vp run integ-coverage` — regenerated docs/_generated matrix to include `AWS::ServiceDiscovery::Service` (matches the new fixture)
- [x] `/run-integ local-ecs-service-connect` — passed end-to-end:
  - `/etc/hosts` in the frontend container shows BOTH `orders.cdkd-sc.local` (Service Connect alias branch) AND `orders-discovery.cdkd-sc.local` (ServiceRegistries[] / Cloud Map service branch) mapped to `169.254.171.3` (the orders container's IP on the shared svc network).
  - `wget http://orders/` from frontend reaches the orders server's `HELLO_ORDERS` payload.
  - SIGTERM teardown clean. `docker ps --filter name=cdkd-local-` and `docker network ls --filter name=cdkd-local-` both empty post-run.

## References

- Issue #579 (deferred items tracker)
- Follow-up #585 (cdkd source: per-replica host port allocation — blocks item (1))
- Blocker for item (3): issue #461
- Original Service Connect / Cloud Map PR: #522 (Phase 3 of #460)
- Design doc: [docs/design/460-ecs-service-connect.md](https://github.com/go-to-k/cdkd/blob/main/docs/design/460-ecs-service-connect.md)
