### PR TITLE
test(local-ecs-service-connect): bump services to desiredCount 2

### DIFF
--- a/tests/integration/local-ecs-service-connect/lib/local-ecs-service-connect-stack.ts
+++ b/tests/integration/local-ecs-service-connect/lib/local-ecs-service-connect-stack.ts
@@ -6,24 +6,28 @@ import { Construct } from 'constructs';
  * Fixture for `cdkd local start-service` Service Connect + Cloud Map
  * emulation (Issue #460 — Phase 3 of #262).
  *
- * Two ECS Services sharing one Cloud Map namespace via Service Connect:
+ * Two ECS Services sharing one Cloud Map namespace via Service Connect,
+ * each at `desiredCount: 2` (#579 item (1), unblocked by the #585
+ * multi-replica host-port fix):
  *   - `orders` exposes a busybox netcat HTTP echo on port 80, named
  *     `orders-api` in its port mapping. Service Connect ClientAlias
- *     maps the bare `orders` short-name to that port. `desiredCount: 1`
- *     — producer-side multi-replica needs cdkd source work (per-replica
- *     host port allocation) before it can ship; tracked as a follow-up
- *     to #579. The OrdersTask publishes an explicit `hostPort: 8081`
- *     (see L101-109 comment) and cdkd's docker-runner always passes
- *     `-p host:container`, so a second replica would collide on host
- *     port 8081 today.
+ *     maps the bare `orders` short-name to that port. `desiredCount: 2`
+ *     exercises the producer side of the #585 fix: the OrdersTask
+ *     publishes an EXPLICIT `hostPort: 8081`, so this service proves
+ *     cdkd skips the `-p` host-port publish for a multi-replica service
+ *     even when the TaskDefinition declares an explicit host port (the
+ *     2nd replica would otherwise collide on host port 8081).
  *   - `frontend` is the consumer — it has Service Connect enabled too
  *     (so its own `frontend-api` is published), but the integ asserts
- *     it can reach `orders` via the `--add-host` DNS overlay cdkd
- *     injects from the shared Cloud Map registry. `desiredCount: 1`
- *     — frontend ALSO hits the docker-runner host-port-publish bug
- *     described above (containerPort 8080 → defaulted hostPort 8080
- *     → 2 replicas collide). The full #579 item (1) defer note is in
- *     the OrdersService inline comment.
+ *     BOTH replicas can reach `orders` via the `--add-host` DNS overlay
+ *     cdkd injects from the shared Cloud Map registry. `desiredCount: 2`
+ *     exercises the OMITTED-hostPort side of the #585 fix (frontend's
+ *     port mapping has no `hostPort`, which cdkd would otherwise default
+ *     to `containerPort` 8080 and collide on the 2nd replica) AND the
+ *     first-replica-wins alias resolution: both frontend replicas
+ *     inherit the same shared Cloud Map registry snapshot, so they must
+ *     resolve `orders` / `orders.cdkd-sc.local` to the SAME (first
+ *     registered) orders replica IP.
  *
  * Item (2) of #579 adds an `AWS::ServiceDiscovery::Service` resource
  * (`orders-discovery`) attached to the existing namespace, plus a
@@ -104,13 +108,15 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
           essential: true,
           // PortMappings.Name is the linchpin — Service Connect
           // references it via `Services[].PortName`. `hostPort: 8081`
-          // is set explicitly because cdkd's `docker run -p` would
-          // otherwise bind host port 80 (= containerPort by default),
-          // which fails to start on Docker Desktop 20.x (the container
-          // sits in `Created` state instead of erroring out). Peer
-          // discovery between containers goes through the per-task
-          // docker network on `containerPort: 80`, so the host-side
-          // mapping is irrelevant to what this integ asserts.
+          // is set explicitly so this multi-replica fixture exercises
+          // the EXPLICIT-hostPort branch of the #585 host-port-skip fix:
+          // with `desiredCount: 2`, cdkd skips the `-p` publish entirely
+          // for every replica, so neither the explicit 8081 nor a
+          // defaulted 80 is bound to the host (the 2nd replica would
+          // otherwise collide on host port 8081). Peer discovery between
+          // containers goes through the shared docker network on
+          // `containerPort: 80`, so dropping the host-side mapping does
+          // not affect what this integ asserts.
           portMappings: [
             { name: 'orders-api', containerPort: 80, hostPort: 8081, protocol: 'tcp' },
           ],
@@ -135,18 +141,14 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
     new ecs.CfnService(this, 'OrdersService', {
       cluster: cluster.ref,
       taskDefinition: ordersTask.ref,
-      // OrdersService stays at desiredCount: 1 — its TaskDefinition
-      // publishes an explicit `hostPort: 8081` (see L101-109 comment on
-      // OrdersTask) and cdkd's docker-runner currently always passes
-      // `-p host:container`, so two replicas would collide on host port
-      // 8081 ("Bind for 127.0.0.1:8081 failed: port is already
-      // allocated"). Producer-side multi-replica needs per-replica host
-      // port allocation in cdkd source — deferred to a follow-up issue
-      // for #579 (see PR body). FrontendService below DOES go
-      // desiredCount: 2 (no hostPort published, no collision), which
-      // exercises the per-replica subnet octet allocator + alias
-      // first-wins on the consumer side.
-      desiredCount: 1,
+      // OrdersService runs desiredCount: 2 (#579 item (1)). Its
+      // TaskDefinition publishes an EXPLICIT `hostPort: 8081`, so this
+      // service proves the #585 fix skips the `-p` host-port publish for
+      // a multi-replica service even with an explicit host port — the
+      // 2nd replica would otherwise fail with "Bind for 127.0.0.1:8081
+      // failed: port is already allocated". The shared docker network
+      // carries peer discovery on containerPort 80 regardless.
+      desiredCount: 2,
       launchType: 'EC2',
       serviceConnectConfiguration: {
         enabled: true,
@@ -205,19 +207,16 @@ export class LocalEcsServiceConnectStack extends cdk.Stack {
     new ecs.CfnService(this, 'FrontendService', {
       cluster: cluster.ref,
       taskDefinition: frontendTask.ref,
-      // FrontendService stays at desiredCount: 1 — same reason as
-      // OrdersService above. FrontendTask's portMappings omits
-      // `hostPort`, but cdkd's docker-runner defaults `hostPort` to
-      // `containerPort` (=8080) when omitted and always passes
-      // `-p host:container`, so two frontend replicas would collide
-      // on host port 8080 ("Bind for 127.0.0.1:8080 failed: port is
-      // already allocated"). #579 item (1) (desiredCount: 2 on EITHER
-      // service) requires cdkd source work — per-replica host port
-      // allocation OR an opt-out for the host-port publish — deferred
-      // to a follow-up issue. This integ fixture currently exercises
-      // only #579 item (2) (ServiceRegistries[] / Cloud Map service
-      // registration), which works fine at desiredCount: 1.
-      desiredCount: 1,
+      // FrontendService runs desiredCount: 2 (#579 item (1)).
+      // FrontendTask's portMappings OMITS `hostPort`, which cdkd would
+      // otherwise default to `containerPort` (=8080); the #585 fix skips
+      // the `-p` publish for this multi-replica service so the 2nd
+      // replica does not collide on host port 8080. Two frontend
+      // replicas also exercise first-replica-wins alias resolution:
+      // both consumers inherit the same shared Cloud Map registry
+      // snapshot, so both resolve `orders` to the SAME orders replica IP
+      // (asserted in verify.sh).
+      desiredCount: 2,
       launchType: 'EC2',
       serviceConnectConfiguration: {
         enabled: true,

--- a/tests/integration/local-ecs-service-connect/verify.sh
+++ b/tests/integration/local-ecs-service-connect/verify.sh
@@ -2,41 +2,43 @@
 # verify.sh — cdkd local start-service Service Connect + Cloud Map integ
 # test (Issue #460, no AWS deploy).
 #
-# Boots two ECS Services in a single `cdkd local start-service` call:
-#   1. `orders` (desiredCount: 1) — busybox netcat echo on port 80.
-#      Single replica registers in the in-process Cloud Map registry:
+# Boots two ECS Services in a single `cdkd local start-service` call,
+# each at `desiredCount: 2` (#579 item (1), unblocked by the #585
+# multi-replica host-port-skip fix):
+#   1. `orders` (desiredCount: 2) — busybox netcat echo on port 80.
+#      Both replicas register in the in-process Cloud Map registry:
 #        - Service Connect ClientAlias `orders`.
 #        - Cloud Map `orders-discovery` (#579 item (2)) via the
 #          ServiceRegistries[] branch of `publishReplicaToCloudMap`.
-#      Producer-side multi-replica (the original #579 item (1) ask) is
-#      blocked on cdkd source work — OrdersTask publishes an explicit
-#      hostPort: 8081 and cdkd's docker-runner always passes
-#      `-p host:container`, so 2 replicas would collide on host port
-#      8081. Tracked as a follow-up to #579.
-#   2. `frontend` consumer at desiredCount: 1 — frontend's
-#      portMappings omit `hostPort` but cdkd's docker-runner defaults
-#      it to `containerPort` (=8080), so 2 replicas would collide on
-#      host port 8080 the same way orders would on 8081. #579 item (1)
-#      (desiredCount: 2 on EITHER service) is therefore fully blocked
-#      on cdkd source work (per-replica host port allocation OR a
-#      `-p`-skip opt-out), tracked as a follow-up.
-#      The integ asserts the frontend container can reach `orders` via
-#      the docker `--add-host` overlay populated from cdkd's shared
-#      registry.
+#      OrdersTask publishes an EXPLICIT hostPort: 8081, so this proves
+#      the #585 fix skips the `-p` host-port publish for a multi-replica
+#      service even with an explicit host port — pre-fix the 2nd replica
+#      collided on host port 8081.
+#   2. `frontend` consumer at desiredCount: 2 — frontend's portMappings
+#      OMIT `hostPort` (cdkd would otherwise default it to
+#      `containerPort` 8080 and collide on the 2nd replica). Both
+#      replicas reach `orders` via the docker `--add-host` overlay
+#      populated from cdkd's shared registry.
 #
 # Asserts:
 #   - The boot banner reports both services running.
-#   - Exactly 1 `orders-*` container AND 1 `frontend-*` container
-#     are visible in `docker ps` (2 task containers + 1 metadata
-#     sidecar; #579 item (1)).
-#   - The frontend container has `orders.cdkd-sc.local` AND the bare
+#   - Exactly 2 `orders-*` containers AND 2 `frontend-*` containers
+#     are visible in `docker ps` (proves the #585 multi-replica
+#     host-port-skip fix — pre-fix the 2nd replica failed to boot with
+#     "port is already allocated"; #579 item (1)).
+#   - EACH frontend container has `orders.cdkd-sc.local` AND the bare
 #     `orders` alias mapped in its `/etc/hosts` (proves the Service
-#     Connect branch of `--add-host` flowed through).
-#   - The same frontend container ALSO has
-#     `orders-discovery.cdkd-sc.local` mapped to an orders-container
-#     IP (proves the ServiceRegistries[] branch is wired end-to-end;
-#     #579 item (2)).
-#   - `wget http://orders/` from inside the frontend container returns
+#     Connect branch of `--add-host` flowed through to every consumer
+#     replica).
+#   - EACH frontend container ALSO has `orders-discovery.cdkd-sc.local`
+#     mapped to an orders-container IP (proves the ServiceRegistries[]
+#     branch is wired end-to-end; #579 item (2)).
+#   - First-replica-wins alias resolution: BOTH frontend replicas
+#     resolve `orders` / `orders.cdkd-sc.local` /
+#     `orders-discovery.cdkd-sc.local` to the SAME orders replica IP
+#     (the first-registered one), since both consumers inherit the same
+#     shared Cloud Map registry snapshot (#579 item (1)).
+#   - `wget http://orders/` from inside a frontend container returns
 #     the orders server's `HELLO_ORDERS` payload (proves end-to-end
 #     networking).
 #   - SIGTERM tears down every container + network.
@@ -122,48 +124,52 @@ if [[ "${BOOTED}" -ne 1 ]]; then
   exit 1
 fi
 
-# #579 item (2): assert the expected container count. orders + frontend
-# both stay at desiredCount: 1 (item (1) deferred — see header for the
-# cdkd source bug that blocks multi-replica). We wait for the count to
-# settle since boot is sequential per service.
-echo "==> Asserting container count — exactly 1 orders + 1 frontend container"
+# #579 item (1): assert the expected container count. orders + frontend
+# both run desiredCount: 2 (unblocked by the #585 host-port-skip fix).
+# Pre-fix the 2nd replica of each service failed to boot with "port is
+# already allocated"; seeing 2 of each proves the fix. We wait for the
+# count to settle since boot is sequential per service.
+echo "==> Asserting container count — exactly 2 orders + 2 frontend containers"
 ORDERS_COUNT=0
 FRONTEND_COUNT=0
 for _ in $(seq 1 60); do
   ORDERS_COUNT=$(docker ps --filter "name=cdkd-local-cdkd-local-ecs-sc-orders-orders-" --format '{{.ID}}' | wc -l | tr -d ' ')
   FRONTEND_COUNT=$(docker ps --filter "name=cdkd-local-cdkd-local-ecs-sc-frontend-frontend-" --format '{{.ID}}' | wc -l | tr -d ' ')
-  if [[ "${ORDERS_COUNT}" -eq 1 && "${FRONTEND_COUNT}" -eq 1 ]]; then break; fi
+  if [[ "${ORDERS_COUNT}" -eq 2 && "${FRONTEND_COUNT}" -eq 2 ]]; then break; fi
   sleep 1
 done
-if [[ "${ORDERS_COUNT}" -ne 1 || "${FRONTEND_COUNT}" -ne 1 ]]; then
-  echo "FAIL: expected 1 orders + 1 frontend container, got orders=${ORDERS_COUNT} frontend=${FRONTEND_COUNT}"
+if [[ "${ORDERS_COUNT}" -ne 2 || "${FRONTEND_COUNT}" -ne 2 ]]; then
+  echo "FAIL: expected 2 orders + 2 frontend containers, got orders=${ORDERS_COUNT} frontend=${FRONTEND_COUNT}"
   docker ps -a --filter "name=cdkd-local-"
   echo "----- service output -----"
   cat "${OUT_FILE}"
   echo "--------------------------"
   exit 1
 fi
-echo "    OK: 1 orders + 1 frontend replica running"
+echo "    OK: 2 orders + 2 frontend replicas running (multi-replica host-port skip verified)"
 
-# Locate ONE frontend container so we can docker-exec into it. The
-# alias resolution should be identical across both replicas since the
-# registry snapshot is shared, so picking the first is sufficient.
-echo "==> Locating the frontend container"
-FRONTEND_ID=""
+# Collect BOTH frontend container IDs. The Service Connect / Cloud Map
+# alias resolution must be identical across both replicas (both inherit
+# the same shared registry snapshot — first-replica-wins), which the
+# per-replica /etc/hosts assertions below verify. The first ID also
+# drives the single-container wget connectivity check.
+echo "==> Locating the frontend containers"
+FRONTEND_IDS=""
 for i in $(seq 1 30); do
-  FRONTEND_ID=$(docker ps --filter "name=cdkd-local-cdkd-local-ecs-sc-frontend-frontend-" --format '{{.ID}}' | head -1)
-  if [[ -n "${FRONTEND_ID}" ]]; then break; fi
+  FRONTEND_IDS=$(docker ps --filter "name=cdkd-local-cdkd-local-ecs-sc-frontend-frontend-" --format '{{.ID}}')
+  if [[ "$(echo "${FRONTEND_IDS}" | wc -l | tr -d ' ')" -eq 2 ]]; then break; fi
   sleep 1
 done
+FRONTEND_ID=$(echo "${FRONTEND_IDS}" | head -1)
 if [[ -z "${FRONTEND_ID}" ]]; then
-  echo "FAIL: frontend container did not appear in docker ps within 30s"
+  echo "FAIL: frontend containers did not appear in docker ps within 30s"
   docker ps -a --filter "name=cdkd-local-"
   echo "----- service output -----"
   cat "${OUT_FILE}"
   echo "--------------------------"
   exit 1
 fi
-echo "    frontend container: ${FRONTEND_ID}"
+echo "    frontend containers: $(tr '\n' ' ' <<<"${FRONTEND_IDS}")"
 
 # Collect the orders container's docker network IP so the
 # `orders-discovery.cdkd-sc.local` resolution can be cross-checked
@@ -191,46 +197,73 @@ if [[ -z "${ORDERS_IPS}" ]]; then
   exit 1
 fi
 
-echo "==> Asserting docker --add-host overlay populated /etc/hosts in the frontend container"
-HOSTS_OUTPUT=$(docker exec "${FRONTEND_ID}" cat /etc/hosts || true)
-echo "----- /etc/hosts -----"
-echo "${HOSTS_OUTPUT}"
-echo "----------------------"
-if ! grep -q "orders.cdkd-sc.local" <<<"${HOSTS_OUTPUT}"; then
-  echo "FAIL: /etc/hosts does not contain orders.cdkd-sc.local (Service Connect fqdn missing)"
-  exit 1
-fi
-if ! grep -qE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders$" <<<"${HOSTS_OUTPUT}"; then
-  echo "FAIL: /etc/hosts does not contain a bare 'orders' alias (ClientAlias short-form missing)"
-  exit 1
-fi
-echo "    OK: orders.cdkd-sc.local + bare 'orders' alias both present (Service Connect branch)"
+# Per-replica /etc/hosts assertions across BOTH frontend replicas. Each
+# consumer must carry the Service Connect alias (`orders` short-form +
+# `orders.cdkd-sc.local` fqdn) AND the Cloud Map ServiceRegistries[]
+# alias (`orders-discovery.cdkd-sc.local`, #579 item (2)) — proving the
+# `--add-host` overlay flowed to EVERY consumer replica, not just one.
+echo "==> Asserting --add-host overlay in EACH frontend replica + first-replica-wins"
+ORDERS_ALIAS_IPS=""
+DISCOVERY_ALIAS_IPS=""
+for fid in ${FRONTEND_IDS}; do
+  HOSTS_OUTPUT=$(docker exec "${fid}" cat /etc/hosts || true)
+  echo "----- /etc/hosts (${fid}) -----"
+  echo "${HOSTS_OUTPUT}"
+  echo "-------------------------------"
+  if ! grep -q "orders.cdkd-sc.local" <<<"${HOSTS_OUTPUT}"; then
+    echo "FAIL: frontend ${fid} /etc/hosts missing orders.cdkd-sc.local (Service Connect fqdn)"
+    exit 1
+  fi
+  if ! grep -qE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders$" <<<"${HOSTS_OUTPUT}"; then
+    echo "FAIL: frontend ${fid} /etc/hosts missing bare 'orders' alias (ClientAlias short-form)"
+    exit 1
+  fi
+  if ! grep -qE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders-discovery\.cdkd-sc\.local$" <<<"${HOSTS_OUTPUT}"; then
+    echo "FAIL: frontend ${fid} /etc/hosts missing orders-discovery.cdkd-sc.local (ServiceRegistries[] branch)"
+    exit 1
+  fi
+  orders_ip=$(grep -oE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders$" <<<"${HOSTS_OUTPUT}" | awk '{print $1}' | head -1)
+  discovery_ip=$(grep -oE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders-discovery\.cdkd-sc\.local$" <<<"${HOSTS_OUTPUT}" | awk '{print $1}' | head -1)
+  if [[ -z "${orders_ip}" || -z "${discovery_ip}" ]]; then
+    echo "FAIL: frontend ${fid} — could not extract orders / orders-discovery IP from /etc/hosts"
+    exit 1
+  fi
+  ORDERS_ALIAS_IPS+="${orders_ip} "
+  DISCOVERY_ALIAS_IPS+="${discovery_ip} "
+done
+echo "    OK: every frontend replica carries orders / orders.cdkd-sc.local / orders-discovery.cdkd-sc.local"
 
-# #579 item (2): the ServiceRegistries[] branch of
-# `publishReplicaToCloudMap` registers `orders-discovery.cdkd-sc.local`
-# (= `<discoveryName>.<namespaceName>` from the
-# `AWS::ServiceDiscovery::Service` resource) against an orders replica
-# IP. Distinct from the Service Connect branch above — proves the
-# second Cloud Map mechanism is wired end-to-end.
-echo "==> Asserting Cloud Map ServiceRegistries[] entry (orders-discovery.cdkd-sc.local) in /etc/hosts"
-if ! grep -qE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders-discovery\.cdkd-sc\.local$" <<<"${HOSTS_OUTPUT}"; then
-  echo "FAIL: /etc/hosts does not contain orders-discovery.cdkd-sc.local (ServiceRegistries[] branch missing)"
+# First-replica-wins: both consumers inherit the same shared Cloud Map
+# registry snapshot, so every frontend replica must resolve `orders`
+# AND `orders-discovery.cdkd-sc.local` to the SAME (first-registered)
+# orders replica IP. Collapsing the collected IPs with `sort -u` must
+# yield exactly one IP per alias.
+UNIQ_ORDERS_IPS=$(tr ' ' '\n' <<<"${ORDERS_ALIAS_IPS}" | grep -v '^$' | sort -u)
+UNIQ_DISCOVERY_IPS=$(tr ' ' '\n' <<<"${DISCOVERY_ALIAS_IPS}" | grep -v '^$' | sort -u)
+if [[ "$(wc -l <<<"${UNIQ_ORDERS_IPS}" | tr -d ' ')" -ne 1 ]]; then
+  echo "FAIL: frontend replicas disagree on the 'orders' alias IP (expected one first-wins IP): ${ORDERS_ALIAS_IPS}"
   exit 1
 fi
-DISCOVERY_IP=$(grep -oE "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+[[:space:]]+orders-discovery\.cdkd-sc\.local$" <<<"${HOSTS_OUTPUT}" | awk '{print $1}' | head -1)
-if [[ -z "${DISCOVERY_IP}" ]]; then
-  echo "FAIL: could not extract IP for orders-discovery.cdkd-sc.local from /etc/hosts"
+if [[ "$(wc -l <<<"${UNIQ_DISCOVERY_IPS}" | tr -d ' ')" -ne 1 ]]; then
+  echo "FAIL: frontend replicas disagree on the 'orders-discovery.cdkd-sc.local' alias IP: ${DISCOVERY_ALIAS_IPS}"
   exit 1
 fi
+# The winning alias IP must be a REAL orders container IP, and both
+# aliases (Service Connect + Cloud Map) must point at the same replica.
+WIN_IP="${UNIQ_ORDERS_IPS}"
 MATCHED=0
 for ip in ${ORDERS_IPS}; do
-  if [[ "${ip}" == "${DISCOVERY_IP}" ]]; then MATCHED=1; break; fi
+  if [[ "${ip}" == "${WIN_IP}" ]]; then MATCHED=1; break; fi
 done
 if [[ "${MATCHED}" -ne 1 ]]; then
-  echo "FAIL: orders-discovery.cdkd-sc.local resolves to ${DISCOVERY_IP} which is not any orders container IP (${ORDERS_IPS})"
+  echo "FAIL: winning 'orders' alias IP ${WIN_IP} is not any orders container IP (${ORDERS_IPS})"
   exit 1
 fi
-echo "    OK: orders-discovery.cdkd-sc.local -> ${DISCOVERY_IP} (matches an orders container; ServiceRegistries[] branch verified)"
+if [[ "${UNIQ_DISCOVERY_IPS}" != "${WIN_IP}" ]]; then
+  echo "FAIL: orders-discovery alias IP (${UNIQ_DISCOVERY_IPS}) != orders alias IP (${WIN_IP}); both should point at the first-registered orders replica"
+  exit 1
+fi
+echo "    OK: every frontend replica resolves orders + orders-discovery to the same orders replica IP ${WIN_IP} (first-replica-wins verified)"
 
 echo "==> Asserting end-to-end HTTP connectivity from frontend → orders"
 RESPONSE=""


### PR DESCRIPTION
## Summary

Follow-on to PR #590 (the #585 multi-replica host-port-skip fix). Restores the
`local-ecs-service-connect` integ fixture to `desiredCount: 2` on both services
— the deferred item (1) of (#579), which was blocked on #585 until that source
fix landed.

## Changes

- `lib/local-ecs-service-connect-stack.ts`: `OrdersService` and
  `FrontendService` both go back to `desiredCount: 2`. OrdersTask keeps its
  EXPLICIT `hostPort: 8081` (exercises the explicit-hostPort skip branch);
  FrontendTask omits `hostPort` (exercises the defaulted-to-containerPort skip
  branch). Comments rewritten to describe the landed fix rather than the
  former blocker.
- `verify.sh` now asserts:
  - exactly **2 orders + 2 frontend** containers boot (pre-#585 the 2nd replica
    failed with `port is already allocated`),
  - **each** frontend replica carries the Service Connect (`orders` /
    `orders.cdkd-sc.local`) and Cloud Map ServiceRegistries[]
    (`orders-discovery.cdkd-sc.local`) aliases in `/etc/hosts`,
  - **first-replica-wins**: both frontend replicas resolve those aliases to the
    SAME (first-registered) orders replica IP, since both inherit the same
    shared Cloud Map registry snapshot.

## Test plan

- `/run-integ local-ecs-service-connect` against real Docker (no AWS deploy):
  2 orders + 2 frontend boot with no port collision, both consumers resolve
  `orders` / `orders-discovery` to the same orders replica IP (first-wins), the
  `wget http://orders/` end-to-end check passes, and SIGTERM tears every
  container + network down clean. Refreshes the `integ-local` marker.
- Full unit suite unaffected (test-only change, no `src/` touched).

Closes #585
