### PR TITLE
test(integ): fix SSM sweep filters + harden export pre-flight/cleanup (#584)

### DIFF
--- a/tests/integration/export-nested-stack/verify.sh
+++ b/tests/integration/export-nested-stack/verify.sh
@@ -73,11 +73,14 @@ cleanup() {
   fi
   # 2. cdkd-managed state path: if the export never reached the
   #    state-cleanup step, destroy the cdkd-managed copy so the AWS
-  #    resources go away. Best-effort.
-  if [ -f "${REPO_ROOT}/dist/cli.js" ] && aws s3api head-object \
-      --bucket "${STATE_BUCKET}" \
-      --key "${PARENT_STATE_KEY}" \
-      --region "${REGION}" >/dev/null 2>&1; then
+  #    resources go away. Best-effort. Fire when EITHER the parent OR the
+  #    child state exists: a trap on INT/TERM mid-deploy can leave only the
+  #    child state written (NestedStackProvider.create persists it before
+  #    the parent finishes), and cdkd destroy <parent> still tears the whole
+  #    tree down (the SSM sweep below is the final backstop either way).
+  if [ -f "${REPO_ROOT}/dist/cli.js" ] && { \
+      aws s3api head-object --bucket "${STATE_BUCKET}" --key "${PARENT_STATE_KEY}" --region "${REGION}" >/dev/null 2>&1 || \
+      aws s3api head-object --bucket "${STATE_BUCKET}" --key "${CHILD_STATE_KEY}" --region "${REGION}" >/dev/null 2>&1; }; then
     echo "[verify] cleanup: cdkd destroy ${PARENT_STACK}"
     ${CLI} destroy "${PARENT_STACK}" \
       --state-bucket "${STATE_BUCKET}" \
@@ -85,8 +88,13 @@ cleanup() {
   fi
   # 3. Belt-and-braces: scrub any leftover SSM parameters / cdkd state
   #    keys.
+  # SSM describe-parameters Contains is CASE-SENSITIVE; this fixture deploys
+  # via cdkd, whose generateResourceName stack-name-prefixes the parameter
+  # (CdkdExportNestedStack-...), so the lowercase form never matched and the
+  # sweep silently reaped nothing. Match the actual prefix. (Originally
+  # fixed in #583, regressed by the PR B2 rewrite in #588; re-applied here.)
   for p in $(aws ssm describe-parameters --region "${REGION}" \
-    --parameter-filters "Key=Name,Option=Contains,Values=cdkdexportnestedstack" \
+    --parameter-filters "Key=Name,Option=Contains,Values=CdkdExportNestedStack" \
     --query 'Parameters[].Name' --output text 2>/dev/null || true); do
     echo "[verify] cleanup: aws ssm delete-parameter ${p}"
     aws ssm delete-parameter --name "${p}" --region "${REGION}" || true
@@ -112,6 +120,15 @@ if aws cloudformation describe-stacks --stack-name "${CHILD_CFN_STACK}" --region
 fi
 if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${PARENT_STATE_KEY}" --region "${REGION}" >/dev/null 2>&1; then
   echo "[verify] FAIL: cdkd state ${PARENT_STATE_KEY} already exists — clean up first"
+  echo "[verify]       run: aws s3 rm s3://${STATE_BUCKET}/${PARENT_STATE_KEY}"
+  exit 1
+fi
+# Symmetric child-state check: a prior partial failure can leave an orphan
+# child state at cdkd/<Parent>~Child/<region>/state.json without the parent
+# key, which the parent-only scan above would miss.
+if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${CHILD_STATE_KEY}" --region "${REGION}" >/dev/null 2>&1; then
+  echo "[verify] FAIL: cdkd state ${CHILD_STATE_KEY} already exists — clean up first"
+  echo "[verify]       run: aws s3 rm s3://${STATE_BUCKET}/${CHILD_STATE_KEY}"
   exit 1
 fi
 

--- a/tests/integration/import-nested-stack/verify.sh
+++ b/tests/integration/import-nested-stack/verify.sh
@@ -79,11 +79,22 @@ cleanup() {
   fi
   # 3. Belt-and-braces: scrub any leftover SSM parameters / cdkd state
   #    even when both 1 and 2 already cleaned up.
-  for p in $(aws ssm describe-parameters --region "${REGION}" \
-    --parameter-filters "Key=Name,Option=Contains,Values=cdkd-importnestedstack" \
-    --query 'Parameters[].Name' --output text 2>/dev/null || true); do
-    echo "[verify] cleanup: aws ssm delete-parameter ${p}"
-    aws ssm delete-parameter --name "${p}" --region "${REGION}" || true
+  # Unlike export-nested-stack (which deploys via cdkd, whose
+  # generateResourceName stack-name-prefixes the parameter so a single
+  # Contains=CdkdExportNestedStack filter matches), this fixture deploys
+  # via upstream `cdk deploy`, so CloudFormation auto-generates the SSM
+  # parameter names as `CFN-ParentParam-<rand>` / `CFN-ChildParam-<rand>`
+  # — there is NO stack-name token to filter on. SSM describe-parameters
+  # Contains also accepts only ONE value per filter, so sweep each
+  # logical-id token separately. (The old `cdkd-importnestedstack` filter
+  # — and a `CdkdImportNestedStack` variant — match nothing here.)
+  for token in ParentParam ChildParam; do
+    for p in $(aws ssm describe-parameters --region "${REGION}" \
+      --parameter-filters "Key=Name,Option=Contains,Values=${token}" \
+      --query 'Parameters[].Name' --output text 2>/dev/null || true); do
+      echo "[verify] cleanup: aws ssm delete-parameter ${p}"
+      aws ssm delete-parameter --name "${p}" --region "${REGION}" || true
+    done
   done
   aws s3 rm "s3://${STATE_BUCKET}/${PARENT_STATE_KEY}" --region "${REGION}" 2>/dev/null || true
   aws s3 rm "s3://${STATE_BUCKET}/${CHILD_STATE_KEY}" --region "${REGION}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Follow-up to #583 (cdkd #464 PR B1.5). #583 fixed the SSM `describe-parameters`
`Contains` case-sensitivity bug only in `export-nested-stack/verify.sh` and left
the sibling `import-nested-stack/verify.sh` carrying the same latent assertion
bug. This batches the four `/review-pr` nits collected in #584, plus a regression
caught along the way, and corrects the import-side fix after verifying the real
parameter names against AWS.

Test-harness only — **no cdkd source change**.

## Changes

1. **`import-nested-stack/verify.sh` — cleanup() SSM sweep filter.** The old
   `Values=cdkd-importnestedstack` matched nothing. #584 proposed
   `CdkdImportNestedStack`, but that matches nothing **either**: this fixture
   deploys via upstream `cdk deploy`, so CloudFormation auto-generates the SSM
   names as `CFN-ParentParam-<rand>` / `CFN-ChildParam-<rand>` — there is no
   stack-name token (verified live on AWS: `CFN-ParentParam-pErD4TNAOdYZ` /
   `CFN-ChildParam-4KXceFujkuGd`). SSM `Contains` accepts only one value per
   filter, so the sweep now loops the two logical-id tokens (`ParentParam`,
   `ChildParam`). Live-tested: the new sweep reaps planted `CFN-*Param-*` dummies.

2. **`export-nested-stack/verify.sh` — re-apply the SSM `Contains` case fix**
   (`cdkdexportnestedstack` -> `CdkdExportNestedStack`). The #583 fix (commit
   46f8cd0) was overwritten by the PR B2 rewrite in #588, which reintroduced the
   lowercase filter. This fixture deploys via cdkd, whose `generateResourceName`
   stack-name-prefixes the parameter, so a single PascalCase filter is correct
   here. (See the `feedback_new_fixture_old_fixture_silent_break` pattern.)

3. **`export-nested-stack/verify.sh` — pre-flight symmetric child-state check.**
   Add a `head-object` on `${CHILD_STATE_KEY}`. An orphan child state without the
   parent key would otherwise slip past the parent-only scan.

4. **`export-nested-stack/verify.sh` — pre-flight cleanup-command UX.** Both
   "state already exists" FAIL messages now print the exact `aws s3 rm ...`
   command to run.

5. **`export-nested-stack/verify.sh` — cleanup() child-only destroy.** Run
   `cdkd destroy` when EITHER the parent OR the child state exists. A trap on
   INT/TERM mid-deploy can leave only the child state written
   (`NestedStackProvider.create` persists it before the parent finishes); the
   previous parent-only guard skipped destroy in that window.

## Test plan

- `/check`: typecheck + lint + build + 359 test files / 5381 tests pass.
- `/run-integ export-nested-stack`: PASS, 0 orphans (deploy -> per-stack IMPORT
  export -> CFn delete-stack).
- `/run-integ import-nested-stack`: PASS x2, 0 orphans (cdk deploy -> cdkd import
  migration -> cdkd destroy, 0 errors).
- Failure-path live-tests (not exercised by clean integ runs): planted an orphan
  child-state object and confirmed the new pre-flight branch exits 1 with the
  cleanup command; planted `CFN-ParentParam-*` / `CFN-ChildParam-*` dummies and
  confirmed the two-loop sweep reaps both.

Closes #584
