### PR TITLE
test(integ): reap nested-stack SSM params by exact name in cleanup trap

### DIFF
--- a/tests/integration/export-nested-stack/verify.sh
+++ b/tests/integration/export-nested-stack/verify.sh
@@ -44,6 +44,14 @@ STATE_BUCKET="${STATE_BUCKET:-cdkd-state-${ACCOUNT_ID}}"
 PARENT_STATE_KEY="cdkd/${PARENT_STACK}/${REGION}/state.json"
 CHILD_STATE_KEY="cdkd/${CHILD_CDKD_STACK}/${REGION}/state.json"
 
+# Captured in step 5 once the cdkd state read succeeds. Initialized empty so
+# the cleanup trap can reference them under `set -u` even when it fires before
+# step 5. cleanup() deletes by these exact physical names — far more robust
+# than the name-prefix Contains sweep, whose filter has to track the deploy
+# path's naming scheme by hand (it has silently rotted twice; see #583/#588).
+PARENT_PARAM_NAME=""
+CHILD_PARAM_NAME=""
+
 echo "[verify] region=${REGION} parent=${PARENT_STACK} child-cfn=${CHILD_CFN_STACK} state-bucket=${STATE_BUCKET}"
 
 cleanup() {
@@ -86,13 +94,22 @@ cleanup() {
       --state-bucket "${STATE_BUCKET}" \
       --force 2>&1 || true
   fi
-  # 3. Belt-and-braces: scrub any leftover SSM parameters / cdkd state
-  #    keys.
-  # SSM describe-parameters Contains is CASE-SENSITIVE; this fixture deploys
-  # via cdkd, whose generateResourceName stack-name-prefixes the parameter
-  # (CdkdExportNestedStack-...), so the lowercase form never matched and the
-  # sweep silently reaped nothing. Match the actual prefix. (Originally
-  # fixed in #583, regressed by the PR B2 rewrite in #588; re-applied here.)
+  # 3a. Primary SSM reap: delete by the exact physical names captured in
+  #     step 5. This is naming-scheme-independent, so it cannot rot the way
+  #     the Contains sweep below has. Empty until step 5 runs, so a trap that
+  #     fires earlier falls through to 3b.
+  for n in "${PARENT_PARAM_NAME}" "${CHILD_PARAM_NAME}"; do
+    [ -n "${n}" ] || continue
+    echo "[verify] cleanup: aws ssm delete-parameter ${n}"
+    aws ssm delete-parameter --name "${n}" --region "${REGION}" 2>/dev/null || true
+  done
+  # 3b. Last-resort fuzzy fallback for the case where the trap fired before
+  #     step 5 captured the names. SSM describe-parameters Contains is
+  #     CASE-SENSITIVE; this fixture deploys via cdkd, whose
+  #     generateResourceName stack-name-prefixes the parameter
+  #     (CdkdExportNestedStack-...), so match that prefix. (This filter was
+  #     wrong/regressed in #583/#588; 3a is the durable fix, this stays as a
+  #     belt-and-braces backstop.)
   for p in $(aws ssm describe-parameters --region "${REGION}" \
     --parameter-filters "Key=Name,Option=Contains,Values=CdkdExportNestedStack" \
     --query 'Parameters[].Name' --output text 2>/dev/null || true); do

--- a/tests/integration/import-nested-stack/verify.sh
+++ b/tests/integration/import-nested-stack/verify.sh
@@ -49,6 +49,15 @@ STATE_BUCKET="${STATE_BUCKET:-cdkd-state-${ACCOUNT_ID}}"
 PARENT_STATE_KEY="cdkd/${PARENT_STACK}/${REGION}/state.json"
 CHILD_STATE_KEY="cdkd/${PARENT_STACK}~Child/${REGION}/state.json"
 
+# Captured in step 6 once describe-stack-resources resolves the physical
+# names. Initialized empty so the cleanup trap can reference them under
+# `set -u` even when it fires before step 6. cleanup() deletes by these exact
+# physical names — far more robust than the logical-id Contains sweep, whose
+# filter has to track the deploy path's naming scheme by hand (it was wrong
+# from the start here; see #584).
+PARENT_PARAM_NAME=""
+CHILD_PARAM_NAME=""
+
 echo "[verify] region=${REGION} parent=${PARENT_STACK} state-bucket=${STATE_BUCKET}"
 
 cleanup() {
@@ -77,17 +86,22 @@ cleanup() {
     aws cloudformation delete-stack --stack-name "${PARENT_STACK}" --region "${REGION}" || true
     aws cloudformation wait stack-delete-complete --stack-name "${PARENT_STACK}" --region "${REGION}" || true
   fi
-  # 3. Belt-and-braces: scrub any leftover SSM parameters / cdkd state
-  #    even when both 1 and 2 already cleaned up.
-  # Unlike export-nested-stack (which deploys via cdkd, whose
-  # generateResourceName stack-name-prefixes the parameter so a single
-  # Contains=CdkdExportNestedStack filter matches), this fixture deploys
-  # via upstream `cdk deploy`, so CloudFormation auto-generates the SSM
-  # parameter names as `CFN-ParentParam-<rand>` / `CFN-ChildParam-<rand>`
-  # — there is NO stack-name token to filter on. SSM describe-parameters
-  # Contains also accepts only ONE value per filter, so sweep each
-  # logical-id token separately. (The old `cdkd-importnestedstack` filter
-  # — and a `CdkdImportNestedStack` variant — match nothing here.)
+  # 3a. Primary SSM reap: delete by the exact physical names captured in
+  #     step 6. This is naming-scheme-independent, so it cannot rot the way
+  #     the Contains sweep below did. Empty until step 6 runs, so a trap that
+  #     fires earlier falls through to 3b.
+  for n in "${PARENT_PARAM_NAME}" "${CHILD_PARAM_NAME}"; do
+    [ -n "${n}" ] || continue
+    echo "[verify] cleanup: aws ssm delete-parameter ${n}"
+    aws ssm delete-parameter --name "${n}" --region "${REGION}" 2>/dev/null || true
+  done
+  # 3b. Last-resort fuzzy fallback for the case where the trap fired before
+  #     step 6 captured the names. This fixture deploys via upstream
+  #     `cdk deploy`, so CloudFormation auto-generates the SSM names as
+  #     `CFN-ParentParam-<rand>` / `CFN-ChildParam-<rand>` — there is NO
+  #     stack-name token to filter on, and SSM Contains accepts only ONE
+  #     value per filter, so sweep each logical-id token separately. (3a is
+  #     the durable fix; this stays as a belt-and-braces backstop.)
   for token in ParentParam ChildParam; do
     for p in $(aws ssm describe-parameters --region "${REGION}" \
       --parameter-filters "Key=Name,Option=Contains,Values=${token}" \


### PR DESCRIPTION
## Summary

Follow-up to #584 / #593. Makes the belt-and-braces SSM cleanup in the two
nested-stack integ fixtures robust against naming-scheme drift, so it stops
silently rotting.

**Background.** The cleanup trap's SSM reap relied solely on an
`aws ssm describe-parameters --parameter-filters Option=Contains` filter whose
value had to be hand-kept in sync with the deploy path's physical-naming
scheme. That filter rotted silently:

- `export-nested-stack` (deploys via cdkd → `CdkdExportNestedStack-*`): fixed in
  #583, regressed by the PR B2 rewrite in #588, re-fixed in #593.
- `import-nested-stack` (deploys via upstream `cdk deploy` → CloudFormation
  auto-names `CFN-ParentParam-<rand>` / `CFN-ChildParam-<rand>`, no stack
  token): wrong from the start until #593.

Because the sweep only runs on a cleanup-failure path, a clean integ run never
exercises it, so a wrong filter stays latent — the exact trap that produced
#584.

## Change

Both scripts already capture the exact SSM parameter physical names during the
run (export step 5, import step 6). Delete by those exact names as the primary
reap (**3a**), keeping the Contains sweep only as a last-resort fallback
(**3b**) for the window where the trap fires before the names are captured:

- Initialize `PARENT_PARAM_NAME` / `CHILD_PARAM_NAME` empty before the trap so
  they are safe to reference under `set -u` when it fires early.
- `cleanup()` 3a deletes each non-empty captured name via
  `aws ssm delete-parameter --name` — naming-scheme-independent, cannot rot.
- `cleanup()` 3b keeps the (now-correct) Contains sweep as the fuzzy backstop.

Test-harness only — **no cdkd source change**.

## Test plan

- `/check`: typecheck + lint + build + 359 test files / 5392 tests pass.
- Targeted live-test of the new 3a layer:
  - empty vars (early-trap case): clean no-op under `set -u`.
  - vars set: reaps both a cdkd-style name (`CdkdExportNestedStack-ParentParam`)
    and a CFN-style name (`CFN-ChildParam-<rand>`) by exact match.
- `/run-integ export-nested-stack`: PASS, 0 orphans (step 5 confirms
  `/CdkdExportNestedStack-ParentParam`).
- `/run-integ import-nested-stack`: PASS, 0 orphans (step 6 confirms
  `CFN-ParentParam-<rand>` / `CFN-ChildParam-<rand>`).

Refs #584, #593.
