### PR TITLE
chore(compat): add offline compat-corpus compatibility measurement tool

### DIFF
--- a/scripts/compat-corpus-fixtures.ts
+++ b/scripts/compat-corpus-fixtures.ts
@@ -1,0 +1,300 @@
+/**
+ * scripts/compat-corpus-fixtures.ts
+ *
+ * Optional corpus generator for `scripts/compat-corpus.ts`. Synthesizes a
+ * diverse set of typical CDK stacks (env-agnostic, so pseudo-params /
+ * `Fn::GetAZs` / `Fn::Select` appear realistically) into a temp dir, then
+ * point `compat-corpus` at it for ad-hoc compatibility measurement:
+ *
+ *   node scripts/compat-corpus-fixtures.ts            # synth to default out dir
+ *   node scripts/compat-corpus-fixtures.ts <out-dir>  # synth to a chosen dir
+ *   vp run compat-corpus <out-dir>                    # then measure
+ *
+ * Each stack synths in its OWN `App` so one construct failure (e.g. a CDK
+ * version that renamed a construct) does not abort the rest. Uses the
+ * repo's own `aws-cdk-lib` via a `createRequire` rooted at the repo's
+ * `package.json` — no hardcoded user paths.
+ *
+ * This is a dev convenience only. It is NOT a CI gate and writes nothing
+ * into the repo tree (output defaults to the OS temp dir).
+ */
+
+import { createRequire } from 'node:module';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), '..');
+
+// Resolve aws-cdk-lib from the repo's own node_modules.
+const require = createRequire(join(REPO_ROOT, 'package.json'));
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const cdk: any = require('aws-cdk-lib');
+const {
+  App,
+  Stack,
+  Duration,
+  aws_s3: s3,
+  aws_lambda: lambda,
+  aws_dynamodb: dynamodb,
+  aws_iam: iam,
+  aws_sns: sns,
+  aws_sqs: sqs,
+  aws_kms: kms,
+  aws_ec2: ec2,
+  aws_ecs: ecs,
+  aws_ecs_patterns: ecsp,
+  aws_rds: rds,
+  aws_apigateway: apigw,
+  aws_cloudfront: cloudfront,
+  aws_cloudfront_origins: origins,
+  aws_cognito: cognito,
+  aws_stepfunctions: sfn,
+  aws_events: events,
+  aws_events_targets: targets,
+  aws_logs: logs,
+  aws_secretsmanager: secrets,
+  aws_ssm: ssm,
+  aws_certificatemanager: acm,
+  aws_elasticache: elasticache,
+  aws_wafv2: wafv2,
+  aws_route53: route53,
+  aws_sns_subscriptions: subs,
+  custom_resources: cr,
+} = cdk;
+
+const fn = (s: any): any =>
+  new lambda.Function(s, 'Fn', {
+    runtime: lambda.Runtime.NODEJS_20_X,
+    handler: 'index.handler',
+    code: lambda.Code.fromInline('exports.handler=async()=>({statusCode:200});'),
+  });
+
+type StackBuilder = [name: string, build: (s: any) => void];
+
+const stacks: StackBuilder[] = [
+  [
+    'lambda-dynamodb',
+    (s) => {
+      const t = new dynamodb.Table(s, 'T', {
+        partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
+      });
+      t.grantReadWriteData(fn(s));
+    },
+  ],
+  [
+    's3-kms',
+    (s) => {
+      const k = new kms.Key(s, 'K');
+      new s3.Bucket(s, 'B', {
+        encryption: s3.BucketEncryption.KMS,
+        encryptionKey: k,
+        enforceSSL: true,
+      });
+    },
+  ],
+  [
+    'sns-sqs',
+    (s) => {
+      const q = new sqs.Queue(s, 'Q');
+      const tp = new sns.Topic(s, 'Tp');
+      tp.addSubscription(new subs.SqsSubscription(q));
+    },
+  ],
+  [
+    'apigw-lambda',
+    (s) => {
+      const api = new apigw.RestApi(s, 'Api');
+      api.root.addMethod('GET', new apigw.LambdaIntegration(fn(s)));
+    },
+  ],
+  [
+    'cognito',
+    (s) => {
+      const up = new cognito.UserPool(s, 'UP');
+      up.addClient('Client');
+      up.addDomain('D', { cognitoDomain: { domainPrefix: 'compat-corpus-pool-xyz' } });
+    },
+  ],
+  [
+    'stepfunctions',
+    (s) => {
+      const wait = new sfn.Wait(s, 'W', { time: sfn.WaitTime.duration(Duration.seconds(1)) });
+      new sfn.StateMachine(s, 'SM', { definitionBody: sfn.DefinitionBody.fromChainable(wait) });
+    },
+  ],
+  [
+    'events-lambda',
+    (s) => {
+      const r = new events.Rule(s, 'R', { schedule: events.Schedule.rate(Duration.minutes(5)) });
+      r.addTarget(new targets.LambdaFunction(fn(s)));
+    },
+  ],
+  ['vpc-only', (s) => { new ec2.Vpc(s, 'Vpc', { maxAzs: 2, natGateways: 1 }); }],
+  [
+    'rds',
+    (s) => {
+      const vpc = new ec2.Vpc(s, 'Vpc', { maxAzs: 2, natGateways: 1 });
+      new rds.DatabaseInstance(s, 'Db', {
+        engine: rds.DatabaseInstanceEngine.postgres({
+          version: rds.PostgresEngineVersion.VER_16,
+        }),
+        vpc,
+        instanceType: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
+      });
+    },
+  ],
+  [
+    'ecs-fargate-alb',
+    (s) => {
+      const vpc = new ec2.Vpc(s, 'Vpc', { maxAzs: 2, natGateways: 1 });
+      const cluster = new ecs.Cluster(s, 'C', { vpc });
+      new ecsp.ApplicationLoadBalancedFargateService(s, 'Svc', {
+        cluster,
+        memoryLimitMiB: 512,
+        cpu: 256,
+        taskImageOptions: {
+          image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+        },
+      });
+    },
+  ],
+  [
+    'cloudfront-oac',
+    (s) => {
+      const b = new s3.Bucket(s, 'B');
+      new cloudfront.Distribution(s, 'D', {
+        defaultBehavior: { origin: origins.S3BucketOrigin.withOriginAccessControl(b) },
+      });
+    },
+  ],
+  [
+    'iam-managed-policy',
+    (s) => {
+      const mp = new iam.ManagedPolicy(s, 'MP', {
+        statements: [new iam.PolicyStatement({ actions: ['s3:GetObject'], resources: ['*'] })],
+      });
+      const role = new iam.Role(s, 'Role', {
+        assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      });
+      role.addManagedPolicy(mp);
+    },
+  ],
+  [
+    'acm-cert',
+    (s) => {
+      new acm.Certificate(s, 'Cert', {
+        domainName: 'compat.example.com',
+        validation: acm.CertificateValidation.fromDns(),
+      });
+    },
+  ],
+  [
+    'secrets-ssm',
+    (s) => {
+      new secrets.Secret(s, 'Sec');
+      new ssm.StringParameter(s, 'P', { stringValue: 'hello' });
+    },
+  ],
+  ['logs', (s) => { new logs.LogGroup(s, 'LG', { retention: logs.RetentionDays.ONE_WEEK }); }],
+  [
+    'elasticache',
+    (s) => {
+      const vpc = new ec2.Vpc(s, 'Vpc', { maxAzs: 2, natGateways: 0 });
+      const sg = new elasticache.CfnSubnetGroup(s, 'SG', {
+        description: 'compat-corpus',
+        subnetIds: vpc.privateSubnets.map((x: any) => x.subnetId),
+      });
+      const cc = new elasticache.CfnCacheCluster(s, 'CC', {
+        cacheNodeType: 'cache.t3.micro',
+        engine: 'redis',
+        numCacheNodes: 1,
+        cacheSubnetGroupName: sg.ref,
+      });
+      cc.addDependency(sg);
+    },
+  ],
+  [
+    'wafv2',
+    (s) => {
+      new wafv2.CfnWebACL(s, 'ACL', {
+        defaultAction: { allow: {} },
+        scope: 'REGIONAL',
+        visibilityConfig: {
+          cloudWatchMetricsEnabled: true,
+          metricName: 'm',
+          sampledRequestsEnabled: true,
+        },
+        rules: [],
+      });
+    },
+  ],
+  [
+    'route53',
+    (s) => {
+      const z = new route53.HostedZone(s, 'Z', { zoneName: 'compat.example.com' });
+      new route53.ARecord(s, 'A', { zone: z, target: route53.RecordTarget.fromIpAddresses('1.2.3.4') });
+    },
+  ],
+  [
+    'dynamodb-autoscaling',
+    (s) => {
+      const t = new dynamodb.Table(s, 'T', {
+        partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
+        billingMode: dynamodb.BillingMode.PROVISIONED,
+      });
+      t.autoScaleReadCapacity({ minCapacity: 1, maxCapacity: 10 }).scaleOnUtilization({
+        targetUtilizationPercent: 70,
+      });
+    },
+  ],
+  [
+    'lambda-custom-resource',
+    (s) => {
+      new cr.AwsCustomResource(s, 'CR', {
+        onCreate: {
+          service: 'SSM',
+          action: 'getParameter',
+          parameters: { Name: 'x' },
+          physicalResourceId: cr.PhysicalResourceId.of('x'),
+        },
+        policy: cr.AwsCustomResourcePolicy.fromSdkCalls({
+          resources: cr.AwsCustomResourcePolicy.ANY_RESOURCE,
+        }),
+      });
+    },
+  ],
+];
+
+function main(): void {
+  const argDir = process.argv[2];
+  const out = argDir ? resolve(argDir) : mkdtempSync(join(tmpdir(), 'cdkd-compat-corpus-'));
+  if (argDir) {
+    // Caller-chosen dir: start clean so stale templates don't pollute.
+    rmSync(out, { recursive: true, force: true });
+  }
+
+  let ok = 0;
+  let fail = 0;
+  for (const [name, build] of stacks) {
+    try {
+      const app = new App({ outdir: join(out, name) });
+      const stack = new Stack(app, name);
+      build(stack);
+      app.synth();
+      ok++;
+    } catch (e) {
+      fail++;
+      const msg = String((e as Error)?.message ?? e).split('\n')[0];
+      process.stderr.write(`SYNTH FAIL ${name}: ${msg}\n`);
+    }
+  }
+  process.stderr.write(`\nsynthed ok=${ok} fail=${fail} into ${out}\n`);
+  // Print the dir to stdout so it can be captured:
+  //   DIR=$(node scripts/compat-corpus-fixtures.ts); vp run compat-corpus "$DIR"
+  process.stdout.write(`${out}\n`);
+}
+
+main();

--- a/scripts/compat-corpus.ts
+++ b/scripts/compat-corpus.ts
@@ -1,0 +1,680 @@
+/**
+ * scripts/compat-corpus.ts
+ *
+ * Offline cdkd compatibility verdict over a corpus of CloudFormation
+ * `*.template.json` files.
+ *
+ * For every template it scans, the tool computes two verdicts per stack:
+ *
+ *   RUNTIME = what cdkd's pre-flight does TODAY. `CloudControlProvider.
+ *             isSupportedResourceType` is OPTIMISTIC: it blocklists ~17
+ *             resource types and lets every other `AWS::*` through. So a
+ *             genuinely-unsupported type passes pre-flight and then fails
+ *             mid-deploy with a confusing Cloud Control error.
+ *   TRUTH   = what will actually deploy. The authoritative unsupported set
+ *             is `docs/_generated/provider-coverage.json` -> `tier3`
+ *             (AWS `ProvisioningType: NON_PROVISIONABLE` per DescribeType).
+ *             SDK-registered types (tier1) and real Cloud Control types
+ *             (tier2) deploy; tier3 does not.
+ *
+ * The DELTA between the two — types that pass pre-flight but are tier3 —
+ * is the headline insight: the "silent tier-3 surface" where cdkd accepts
+ * a template at pre-flight and then breaks partway through a deploy.
+ *
+ * Inputs to the verdict (all read locally, no AWS calls):
+ *   - SDK-registered types: parsed from
+ *     `src/provisioning/register-providers.ts` (explicit
+ *     `registry.register('AWS::X::Y', ...)` calls). Static parse over a
+ *     dynamic import — importing the module constructs real AWS SDK
+ *     clients, which is unnecessary and brittle here. Mirrors the parser
+ *     in `scripts/audit-provider-coverage.ts`.
+ *   - The tier3 set: read from the cached provider-coverage JSON.
+ *   - The runtime blocklist: replicated from
+ *     `CloudControlProvider.isSupportedResourceType` (see
+ *     `RUNTIME_UNSUPPORTED_TYPES` below). Replicating the ~17-entry set is
+ *     cleaner than importing the built `dist/index.js` (which would force a
+ *     fresh `vp run build` before every measurement); a unit test guards
+ *     the replica against drift from the source.
+ *   - Intrinsics: the resolver in `src/deployment/intrinsic-function-
+ *     resolver.ts` handles `Ref` + 16 `Fn::*`. Any OTHER `Fn::*` key in a
+ *     template is a compat blocker (the resolver would leave it unresolved).
+ *
+ * `AWS::CDK::Metadata` is excluded before judging (mirrors
+ * `deploy-engine.ts` — it's a skipped sentinel, never deployed).
+ *
+ * Usage:
+ *   node scripts/compat-corpus.ts <dir> [<dir> ...]
+ *   node scripts/compat-corpus.ts --json <dir> [<dir> ...]
+ *   (or: vp run compat-corpus <dir> ...)
+ *
+ * Each `<dir>` is scanned recursively for `*.template.json` files
+ * (`node_modules` directories are skipped). Missing dirs, empty dirs, and
+ * malformed JSON files are reported and skipped, not fatal.
+ *
+ * Exit codes:
+ *   0  the run completed (regardless of how many templates were judged
+ *      incompatible — incompatibility is a finding, not a tool failure).
+ *   1  no valid template was found across every input dir, or a usage /
+ *      argument error.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), '..');
+const REGISTER_PROVIDERS_PATH = resolve(REPO_ROOT, 'src/provisioning/register-providers.ts');
+const PROVIDER_COVERAGE_PATH = resolve(REPO_ROOT, 'docs/_generated/provider-coverage.json');
+
+/**
+ * The CDK sentinel resource type. Never deployed by cdkd — excluded
+ * before any verdict. Mirrors `src/deployment/deploy-engine.ts`, which
+ * filters it out before validating resource types.
+ */
+export const CDK_METADATA_TYPE = 'AWS::CDK::Metadata';
+
+/**
+ * Resource types cdkd's runtime pre-flight blocklists.
+ *
+ * Replicated VERBATIM from `CloudControlProvider.isSupportedResourceType`
+ * in `src/provisioning/cloud-control-provider.ts`. A unit test cross-checks
+ * this set against the source so the two cannot silently drift.
+ *
+ * The pre-flight is intentionally optimistic: anything NOT in this set and
+ * NOT a custom resource passes if it starts with `AWS::`. That optimism is
+ * exactly what creates the silent tier-3 surface this tool measures.
+ */
+export const RUNTIME_UNSUPPORTED_TYPES: ReadonlySet<string> = new Set([
+  // IAM (most types not supported)
+  'AWS::IAM::Role',
+  'AWS::IAM::Policy',
+  'AWS::IAM::ManagedPolicy',
+  'AWS::IAM::User',
+  'AWS::IAM::Group',
+  'AWS::IAM::InstanceProfile',
+  // Lambda layers
+  'AWS::Lambda::LayerVersion',
+  // S3 bucket policies (use SDK instead)
+  'AWS::S3::BucketPolicy',
+  // CloudFormation-specific resources
+  'AWS::CloudFormation::Stack',
+  'AWS::CloudFormation::WaitCondition',
+  'AWS::CloudFormation::WaitConditionHandle',
+  'AWS::CloudFormation::CustomResource',
+  // CDK-specific resources
+  'AWS::CDK::Metadata',
+  'Custom::CDKBucketDeployment',
+  'Custom::S3AutoDeleteObjects',
+  // Route53 hosted zones (complex)
+  'AWS::Route53::HostedZone',
+  // ACM certificates (validation complexity)
+  'AWS::CertificateManager::Certificate',
+]);
+
+/**
+ * The intrinsic functions cdkd's resolver handles: `Ref` plus 16 `Fn::*`.
+ * Mirrors `src/deployment/intrinsic-function-resolver.ts`. Any other
+ * `Fn::*` key encountered in a template is an unresolved-intrinsic compat
+ * blocker. `Fn::Transform` is treated separately (macro expansion, handled
+ * by the synthesis layer) and is NOT flagged here.
+ */
+export const HANDLED_FN: ReadonlySet<string> = new Set([
+  'Fn::GetAtt',
+  'Fn::Join',
+  'Fn::Sub',
+  'Fn::Select',
+  'Fn::Split',
+  'Fn::If',
+  'Fn::Equals',
+  'Fn::And',
+  'Fn::Or',
+  'Fn::Not',
+  'Fn::ImportValue',
+  'Fn::GetStackOutput',
+  'Fn::FindInMap',
+  'Fn::Base64',
+  'Fn::GetAZs',
+  'Fn::Cidr',
+]);
+
+/** A custom resource — handled by cdkd outside the provider registry. */
+export function isCustomResource(resourceType: string): boolean {
+  return (
+    resourceType.startsWith('Custom::') ||
+    resourceType.startsWith('AWS::CloudFormation::CustomResource')
+  );
+}
+
+/**
+ * Replicate the RUNTIME pre-flight verdict — `ProviderRegistry.hasProvider`,
+ * NOT `isSupportedResourceType` alone. The real registry checks the SDK
+ * provider map FIRST and the custom-resource path LAST, so a type that is
+ * Cloud-Control-blocklisted but SDK-registered (IAM::Role, S3::BucketPolicy,
+ * Lambda::LayerVersion, Route53::HostedZone) still passes pre-flight, and so
+ * does any custom resource. Mirroring only the blocklist (ignoring the SDK
+ * map + custom path) under-counts RUNTIME badly.
+ */
+export function isRuntimeSupported(
+  resourceType: string,
+  sdkTypes: ReadonlySet<string>
+): boolean {
+  if (sdkTypes.has(resourceType)) return true; // SDK provider wins first
+  if (isCustomResource(resourceType)) return true; // custom-resource path
+  if (resourceType === CDK_METADATA_TYPE) return true; // skipped sentinel
+  if (RUNTIME_UNSUPPORTED_TYPES.has(resourceType)) return false;
+  return resourceType.startsWith('AWS::'); // Cloud Control optimistic fallthrough
+}
+
+/**
+ * The TRUTH verdict for a single resource type: will cdkd actually be able
+ * to deploy it?
+ *
+ * - SDK-registered types (tier1) always deploy.
+ * - Custom resources are handled by cdkd's custom-resource path.
+ * - `AWS::CDK::Metadata` is a skipped sentinel (never reaches here in
+ *   practice, but defended for safety).
+ * - tier3 (AWS `NON_PROVISIONABLE`) types cannot deploy.
+ * - Everything else (tier1 + tier2) deploys.
+ */
+export function isTrulySupported(
+  resourceType: string,
+  sdkTypes: ReadonlySet<string>,
+  tier3: ReadonlySet<string>
+): boolean {
+  if (sdkTypes.has(resourceType)) return true;
+  if (isCustomResource(resourceType)) return true;
+  if (resourceType === CDK_METADATA_TYPE) return true;
+  // Mirror hasProvider's final fallthrough: a non-SDK, non-custom type only
+  // deploys via Cloud Control, which cdkd only attempts for AWS:: namespaces
+  // (third-party CFN registry types like MyOrg::Svc::Type are rejected at
+  // pre-flight). A tier2 (real-CC) type is exactly "AWS:: and not tier3".
+  return resourceType.startsWith('AWS::') && !tier3.has(resourceType);
+}
+
+/**
+ * Recursively collect every intrinsic key (`Ref` and `Fn::*`) used
+ * anywhere in a JSON node. `Ref` only counts when it is the SOLE key of an
+ * object (the CFn intrinsic shape) so a property literally named "Ref"
+ * does not produce a false positive.
+ */
+export function collectIntrinsics(node: unknown, found: Set<string>): void {
+  if (Array.isArray(node)) {
+    for (const item of node) collectIntrinsics(item, found);
+    return;
+  }
+  if (node !== null && typeof node === 'object') {
+    const obj = node as Record<string, unknown>;
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      if (key.startsWith('Fn::')) found.add(key);
+      if (key === 'Ref' && keys.length === 1) found.add('Ref');
+    }
+    for (const key of keys) collectIntrinsics(obj[key], found);
+  }
+}
+
+/**
+ * Find every `Fn::*` intrinsic in a template that cdkd's resolver does NOT
+ * handle. `Ref` is always handled; `Fn::Transform` is macro-expansion (out
+ * of the resolver's scope, handled upstream) and is not flagged.
+ */
+export function findUnknownIntrinsics(template: TemplateShape): string[] {
+  const found = new Set<string>();
+  collectIntrinsics(template.Resources ?? {}, found);
+  collectIntrinsics(template.Outputs ?? {}, found);
+  collectIntrinsics(template.Conditions ?? {}, found);
+  return [...found].filter(
+    (key) => key.startsWith('Fn::') && key !== 'Fn::Transform' && !HANDLED_FN.has(key)
+  );
+}
+
+/** Minimal structural view of a CFn template the verdict needs. */
+export interface TemplateShape {
+  Resources?: Record<string, { Type?: unknown } | null>;
+  Outputs?: Record<string, unknown>;
+  Conditions?: Record<string, unknown>;
+}
+
+/**
+ * Extract the deployable resource types of a template: the distinct
+ * `Type` values, excluding the `AWS::CDK::Metadata` sentinel and any
+ * resource lacking a string `Type`.
+ */
+export function extractResourceTypes(template: TemplateShape): string[] {
+  const resources = template.Resources;
+  if (!resources || typeof resources !== 'object') return [];
+  const types = new Set<string>();
+  for (const resource of Object.values(resources)) {
+    const type = resource?.Type;
+    if (typeof type === 'string' && type !== CDK_METADATA_TYPE) {
+      types.add(type);
+    }
+  }
+  return [...types];
+}
+
+/** Per-template verdict produced by {@link judgeTemplate}. */
+export interface TemplateVerdict {
+  /** Resource types that fail cdkd's RUNTIME pre-flight. */
+  readonly runtimeBad: string[];
+  /** Resource types that will fail to deploy (TRUTH). */
+  readonly truthBad: string[];
+  /**
+   * The silent tier-3 surface: types that PASS pre-flight but will FAIL
+   * mid-deploy. The headline insight.
+   */
+  readonly silentTier3: string[];
+  /** `Fn::*` intrinsics in the template cdkd's resolver cannot handle. */
+  readonly unknownIntrinsics: string[];
+  /** True when the template passes RUNTIME pre-flight (optimistic). */
+  readonly runtimePass: boolean;
+  /** True when the template will actually deploy (TRUTH). */
+  readonly truthPass: boolean;
+}
+
+/**
+ * Judge a single template against both verdicts. Pure function — all
+ * inputs are explicit, no filesystem access. The verdict-defining helper
+ * worth unit-testing.
+ */
+export function judgeTemplate(
+  template: TemplateShape,
+  sdkTypes: ReadonlySet<string>,
+  tier3: ReadonlySet<string>
+): TemplateVerdict {
+  const types = extractResourceTypes(template);
+  const runtimeBad = types.filter((t) => !isRuntimeSupported(t, sdkTypes));
+  const truthBad = types.filter((t) => !isTrulySupported(t, sdkTypes, tier3));
+  const silentTier3 = types.filter(
+    (t) => isRuntimeSupported(t, sdkTypes) && !isTrulySupported(t, sdkTypes, tier3)
+  );
+  const unknownIntrinsics = findUnknownIntrinsics(template);
+  const runtimePass = runtimeBad.length === 0 && unknownIntrinsics.length === 0;
+  const truthPass = truthBad.length === 0 && unknownIntrinsics.length === 0;
+  return { runtimeBad, truthBad, silentTier3, unknownIntrinsics, runtimePass, truthPass };
+}
+
+/**
+ * Parse `registry.register('AWS::Service::Type', ...)` calls out of the
+ * provider-registration source. Mirrors the parser in
+ * `scripts/audit-provider-coverage.ts` (and the matrix builder); the
+ * static parse avoids constructing real SDK clients.
+ */
+export function parseRegisteredTypes(source: string): Set<string> {
+  const result = new Set<string>();
+  const pattern = /registry\.register\(\s*['"](AWS::[A-Za-z0-9:]+)['"]/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(source)) !== null) {
+    const typeName = match[1];
+    if (typeName !== undefined) result.add(typeName);
+  }
+  return result;
+}
+
+/** Shape of the cached provider-coverage JSON this tool consumes. */
+interface ProviderCoverage {
+  tier3?: unknown;
+}
+
+/**
+ * Read the tier3 (genuinely-unsupported) set from the cached
+ * provider-coverage JSON. Tolerates the entries being plain strings or
+ * `{type}`-shaped objects (the spike defended both shapes).
+ */
+export function extractTier3(coverage: ProviderCoverage): Set<string> {
+  const raw = Array.isArray(coverage.tier3) ? coverage.tier3 : [];
+  const out = new Set<string>();
+  for (const entry of raw) {
+    if (typeof entry === 'string') {
+      out.add(entry);
+    } else if (entry && typeof entry === 'object') {
+      const obj = entry as Record<string, unknown>;
+      // Pick the first value that is actually a string — `??` would stop at a
+      // non-string (e.g. numeric `type`) and drop a valid `typeName`/`name`.
+      const name = [obj.type, obj.typeName, obj.name].find((v) => typeof v === 'string');
+      if (typeof name === 'string') out.add(name);
+    }
+  }
+  return out;
+}
+
+/**
+ * Recursively collect every `*.template.json` path under `dir`, skipping
+ * `node_modules` directories. Unreadable entries are skipped (best-effort
+ * walk). Returns `{ files, missing }` so a missing top-level dir can be
+ * reported distinctly from an empty one.
+ */
+function findTemplates(dir: string): { files: string[]; missing: boolean } {
+  let entries: string[];
+  try {
+    const st = statSync(dir);
+    if (!st.isDirectory()) {
+      // A file passed directly: accept it if it looks like a template.
+      return { files: dir.endsWith('.template.json') ? [dir] : [], missing: false };
+    }
+    entries = readdirSync(dir);
+  } catch {
+    return { files: [], missing: true };
+  }
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry === 'node_modules') continue;
+    const full = join(dir, entry);
+    let st: ReturnType<typeof statSync>;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      files.push(...findTemplates(full).files);
+    } else if (entry.endsWith('.template.json')) {
+      files.push(full);
+    }
+  }
+  return { files, missing: false };
+}
+
+/** Rank a frequency map as `[type, count]` pairs, most-frequent first. */
+export function rankFrequency(map: Map<string, number>): Array<[string, number]> {
+  return [...map.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+}
+
+/** Aggregated corpus measurement produced by {@link measureCorpus}. */
+export interface CorpusReport {
+  readonly dirs: string[];
+  readonly missingDirs: string[];
+  readonly totalFiles: number;
+  readonly malformedFiles: string[];
+  /** Templates with a parseable `Resources` block (the judged denominator). */
+  readonly total: number;
+  readonly runtimePass: number;
+  readonly truthPass: number;
+  /**
+   * The headline metric: # of templates that PASS the optimistic runtime
+   * pre-flight yet contain at least one tier-3 type that will fail
+   * mid-deploy. Counted per-template (not `runtimePass - truthPass`, which
+   * can go negative when blocklisted-but-supported types like IAM::Role
+   * make runtime stricter than truth).
+   */
+  readonly silentTier3Templates: number;
+  /** type -> # of templates where it passes pre-flight but is tier3. */
+  readonly silentTier3: Array<[string, number]>;
+  /** type -> # of templates where it genuinely cannot deploy. */
+  readonly trulyUnsupported: Array<[string, number]>;
+  /** unknown `Fn::*` -> # of templates containing it. */
+  readonly unknownIntrinsics: Array<[string, number]>;
+}
+
+/**
+ * Walk every input dir, judge each template, and aggregate. This is the
+ * IO-bearing orchestrator; the per-template verdict logic lives in the
+ * pure {@link judgeTemplate}.
+ */
+export function measureCorpus(
+  dirs: string[],
+  sdkTypes: ReadonlySet<string>,
+  tier3: ReadonlySet<string>
+): CorpusReport {
+  const files: string[] = [];
+  const missingDirs: string[] = [];
+  for (const dir of dirs) {
+    const { files: found, missing } = findTemplates(dir);
+    if (missing) missingDirs.push(dir);
+    files.push(...found);
+  }
+
+  let total = 0;
+  let runtimePass = 0;
+  let truthPass = 0;
+  let silentTier3Templates = 0;
+  const malformed: string[] = [];
+  const silentTier3 = new Map<string, number>();
+  const trulyUnsupported = new Map<string, number>();
+  const unknownIntrinsics = new Map<string, number>();
+
+  for (const file of files) {
+    let template: TemplateShape;
+    try {
+      template = JSON.parse(readFileSync(file, 'utf8')) as TemplateShape;
+    } catch {
+      malformed.push(file);
+      continue;
+    }
+    if (!template || typeof template !== 'object') {
+      malformed.push(file);
+      continue;
+    }
+    if (!template.Resources || typeof template.Resources !== 'object') {
+      // Not a deployable CFn template (no Resources block) — skip silently;
+      // CDK emits asset/manifest JSON that happens to share the suffix only
+      // for real stacks, but defensive against odd inputs.
+      continue;
+    }
+    total++;
+    const verdict = judgeTemplate(template, sdkTypes, tier3);
+    if (verdict.runtimePass) runtimePass++;
+    if (verdict.truthPass) truthPass++;
+    if (verdict.runtimePass && !verdict.truthPass && verdict.silentTier3.length > 0) {
+      silentTier3Templates++;
+    }
+    for (const t of verdict.truthBad) {
+      trulyUnsupported.set(t, (trulyUnsupported.get(t) ?? 0) + 1);
+    }
+    for (const t of verdict.silentTier3) {
+      silentTier3.set(t, (silentTier3.get(t) ?? 0) + 1);
+    }
+    for (const fn of new Set(verdict.unknownIntrinsics)) {
+      unknownIntrinsics.set(fn, (unknownIntrinsics.get(fn) ?? 0) + 1);
+    }
+  }
+
+  return {
+    dirs,
+    missingDirs,
+    totalFiles: files.length,
+    malformedFiles: malformed,
+    total,
+    runtimePass,
+    truthPass,
+    silentTier3Templates,
+    silentTier3: rankFrequency(silentTier3),
+    trulyUnsupported: rankFrequency(trulyUnsupported),
+    unknownIntrinsics: rankFrequency(unknownIntrinsics),
+  };
+}
+
+function pct(n: number, total: number): string {
+  if (total === 0) return '0.0';
+  return ((100 * n) / total).toFixed(1);
+}
+
+/** Render the human-readable report to a string (one block per corpus run). */
+export function renderReport(report: CorpusReport, sdkTypes: ReadonlySet<string>): string {
+  const lines: string[] = [];
+  const { total } = report;
+
+  lines.push('');
+  lines.push(`=== cdkd compatibility over ${total} template(s) ===`);
+  lines.push(`Scanned dirs : ${report.dirs.join(', ')}`);
+  if (report.missingDirs.length > 0) {
+    lines.push(`Missing dirs : ${report.missingDirs.join(', ')} (skipped)`);
+  }
+  if (report.malformedFiles.length > 0) {
+    lines.push(`Malformed    : ${report.malformedFiles.length} file(s) skipped (invalid JSON)`);
+  }
+  lines.push('');
+  lines.push(
+    `RUNTIME pre-flight passes : ${report.runtimePass}/${total}  (${pct(report.runtimePass, total)}%)   <- optimistic isSupportedResourceType`
+  );
+  lines.push(
+    `TRUTH  will-deploy        : ${report.truthPass}/${total}  (${pct(report.truthPass, total)}%)   <- provider-coverage tier3 oracle`
+  );
+  lines.push(
+    `SILENT tier-3 surface     : ${report.silentTier3Templates}/${total}  (${pct(report.silentTier3Templates, total)}%)   <- pass pre-flight but contain a tier-3 will-fail type (the headline gap)`
+  );
+
+  lines.push('');
+  lines.push('--- silent tier-3 surface: types that PASS pre-flight but FAIL mid-deploy ---');
+  if (report.silentTier3.length === 0) {
+    lines.push('  (none in this corpus)');
+  } else {
+    for (const [type, count] of report.silentTier3) {
+      lines.push(`  ${String(count).padStart(4)}  ${type}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('--- all genuinely-unsupported types in corpus (TRUTH oracle) ---');
+  if (report.trulyUnsupported.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const [type, count] of report.trulyUnsupported) {
+      const tag = sdkTypes.has(type) ? '' : ' [tier3]';
+      lines.push(`  ${String(count).padStart(4)}  ${type}${tag}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('--- unknown intrinsics (Fn::* the resolver cannot handle, silently passed today) ---');
+  if (report.unknownIntrinsics.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const [fn, count] of report.unknownIntrinsics) {
+      lines.push(`  ${String(count).padStart(4)}  ${fn}`);
+    }
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/** Parsed CLI args. */
+export interface CliArgs {
+  readonly json: boolean;
+  readonly help: boolean;
+  readonly dirs: string[];
+}
+
+export function parseCliArgs(argv: readonly string[]): CliArgs {
+  let json = false;
+  let help = false;
+  const dirs: string[] = [];
+  for (const arg of argv) {
+    if (arg === '--json') json = true;
+    else if (arg === '--help' || arg === '-h') help = true;
+    else dirs.push(arg);
+  }
+  return { json, help, dirs };
+}
+
+const HELP_TEXT = [
+  'Usage: node scripts/compat-corpus.ts [--json] <dir> [<dir> ...]',
+  '',
+  'Measure cdkd compatibility over a corpus of CloudFormation',
+  '*.template.json files (scanned recursively; node_modules skipped).',
+  '',
+  '  --json   Emit the aggregated report as JSON instead of human text.',
+  '  --help   Show this help.',
+  '',
+  'Two verdicts per template:',
+  '  RUNTIME  what cdkd pre-flight accepts today (optimistic).',
+  '  TRUTH    what will actually deploy (provider-coverage tier3 oracle).',
+  'The DELTA is the silent tier-3 surface — the headline finding.',
+].join('\n');
+
+export interface CliIO {
+  readonly log: (msg: string) => void;
+  readonly error: (msg: string) => void;
+  setExitCode(code: number): void;
+}
+
+const consoleIO: CliIO = {
+  log: (msg) => console.log(msg),
+  error: (msg) => console.error(msg),
+  setExitCode: (code) => {
+    process.exitCode = code;
+  },
+};
+
+export function run(argv: readonly string[], io: CliIO = consoleIO): void {
+  const args = parseCliArgs(argv);
+  if (args.help) {
+    io.log(HELP_TEXT);
+    return;
+  }
+  if (args.dirs.length === 0) {
+    io.error('[compat-corpus] no input directory supplied');
+    io.error(HELP_TEXT);
+    io.setExitCode(1);
+    return;
+  }
+
+  let sdkTypes: Set<string>;
+  let tier3: Set<string>;
+  try {
+    sdkTypes = parseRegisteredTypes(readFileSync(REGISTER_PROVIDERS_PATH, 'utf8'));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    io.error(`[compat-corpus] cannot read register-providers.ts: ${msg}`);
+    io.setExitCode(1);
+    return;
+  }
+  try {
+    const coverage = JSON.parse(readFileSync(PROVIDER_COVERAGE_PATH, 'utf8')) as ProviderCoverage;
+    tier3 = extractTier3(coverage);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    io.error(`[compat-corpus] cannot read provider-coverage.json: ${msg}`);
+    io.error('[compat-corpus] run `vp run audit:coverage:regenerate` to (re)build it');
+    io.setExitCode(1);
+    return;
+  }
+
+  const report = measureCorpus(args.dirs, sdkTypes, tier3);
+
+  if (report.total === 0) {
+    io.error('[compat-corpus] no valid CloudFormation templates found in input dir(s)');
+    if (report.missingDirs.length > 0) {
+      io.error(`[compat-corpus] missing dir(s): ${report.missingDirs.join(', ')}`);
+    }
+    io.setExitCode(1);
+    return;
+  }
+
+  if (args.json) {
+    io.log(
+      JSON.stringify(
+        {
+          dirs: report.dirs,
+          missingDirs: report.missingDirs,
+          totalFiles: report.totalFiles,
+          malformedFiles: report.malformedFiles,
+          total: report.total,
+          runtimePass: report.runtimePass,
+          truthPass: report.truthPass,
+          silentTier3Templates: report.silentTier3Templates,
+          silentTier3: report.silentTier3.map(([type, count]) => ({ type, count })),
+          trulyUnsupported: report.trulyUnsupported.map(([type, count]) => ({ type, count })),
+          unknownIntrinsics: report.unknownIntrinsics.map(([fn, count]) => ({ fn, count })),
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  io.log(renderReport(report, sdkTypes));
+}
+
+/** True when run directly (`node scripts/compat-corpus.ts`), not imported. */
+export function isMainModule(argv1: string | undefined, scriptPath: string): boolean {
+  if (!argv1) return false;
+  return resolve(argv1) === scriptPath;
+}
+
+if (isMainModule(process.argv[1], __filename)) {
+  run(process.argv.slice(2));
+}

--- a/tests/unit/scripts/compat-corpus.test.ts
+++ b/tests/unit/scripts/compat-corpus.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  CDK_METADATA_TYPE,
+  RUNTIME_UNSUPPORTED_TYPES,
+  HANDLED_FN,
+  isCustomResource,
+  isRuntimeSupported,
+  isTrulySupported,
+  collectIntrinsics,
+  findUnknownIntrinsics,
+  extractResourceTypes,
+  judgeTemplate,
+  parseRegisteredTypes,
+  extractTier3,
+  rankFrequency,
+  measureCorpus,
+  parseCliArgs,
+  run,
+  type CliIO,
+} from '../../../scripts/compat-corpus.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), '../../..');
+
+const SDK = new Set(['AWS::S3::Bucket', 'AWS::IAM::Role', 'AWS::Lambda::Function']);
+const TIER3 = new Set(['AWS::AppMesh::GatewayRoute', 'AWS::AmazonMQ::ConfigurationAssociation']);
+
+describe('isCustomResource', () => {
+  it('matches Custom:: prefix and AWS::CloudFormation::CustomResource', () => {
+    expect(isCustomResource('Custom::MyThing')).toBe(true);
+    expect(isCustomResource('AWS::CloudFormation::CustomResource')).toBe(true);
+    expect(isCustomResource('AWS::S3::Bucket')).toBe(false);
+  });
+});
+
+describe('isRuntimeSupported (replica of ProviderRegistry.hasProvider)', () => {
+  // The real registry checks the SDK map first, then isSupportedResourceType,
+  // then the custom-resource path — so a CC-blocklisted type that IS
+  // SDK-registered still passes pre-flight.
+  const sdk = new Set(['AWS::IAM::Role', 'AWS::S3::Bucket', 'AWS::Route53::HostedZone']);
+
+  it('accepts CC-blocklisted types that have an SDK provider (SDK map wins first)', () => {
+    expect(isRuntimeSupported('AWS::IAM::Role', sdk)).toBe(true);
+    expect(isRuntimeSupported('AWS::Route53::HostedZone', sdk)).toBe(true);
+  });
+  it('accepts custom resources (custom-resource path)', () => {
+    expect(isRuntimeSupported('Custom::Foo', sdk)).toBe(true);
+    expect(isRuntimeSupported('AWS::CloudFormation::CustomResource', sdk)).toBe(true);
+  });
+  it('rejects blocklisted types with no SDK provider', () => {
+    expect(isRuntimeSupported('AWS::CloudFormation::WaitCondition', sdk)).toBe(false);
+    expect(isRuntimeSupported('AWS::CertificateManager::Certificate', sdk)).toBe(false);
+  });
+  it('optimistically accepts any other AWS:: type (the silent-tier3 trap)', () => {
+    expect(isRuntimeSupported('AWS::AppMesh::GatewayRoute', sdk)).toBe(true);
+    expect(isRuntimeSupported('AWS::S3::Bucket', sdk)).toBe(true);
+  });
+  it('rejects non-AWS:: types', () => {
+    expect(isRuntimeSupported('Foo::Bar::Baz', sdk)).toBe(false);
+  });
+});
+
+describe('isTrulySupported (provider-coverage oracle)', () => {
+  it('accepts SDK-registered types', () => {
+    expect(isTrulySupported('AWS::IAM::Role', SDK, TIER3)).toBe(true);
+  });
+  it('accepts custom resources and the CDK metadata sentinel', () => {
+    expect(isTrulySupported('Custom::Foo', SDK, TIER3)).toBe(true);
+    expect(isTrulySupported(CDK_METADATA_TYPE, SDK, TIER3)).toBe(true);
+  });
+  it('rejects tier3 types', () => {
+    expect(isTrulySupported('AWS::AppMesh::GatewayRoute', SDK, TIER3)).toBe(false);
+  });
+  it('accepts tier2 (CC-API fallback) types not in tier3', () => {
+    expect(isTrulySupported('AWS::SomeService::SomeType', SDK, TIER3)).toBe(true);
+  });
+  it('rejects non-AWS:: third-party registry types (cdkd pre-flight rejects them)', () => {
+    // hasProvider's final fallthrough is startsWith('AWS::'); a CFN
+    // public/private registry type is neither SDK, custom, nor AWS::, so it
+    // never deploys — TRUTH must agree with RUNTIME here, not over-accept.
+    expect(isTrulySupported('MyOrg::Svc::Type', SDK, TIER3)).toBe(false);
+    expect(isTrulySupported('Alexa::ASK::Skill', SDK, TIER3)).toBe(false);
+  });
+});
+
+describe('collectIntrinsics', () => {
+  it('finds Fn::* keys and single-key Ref', () => {
+    const found = new Set<string>();
+    collectIntrinsics(
+      { a: { Ref: 'X' }, b: { 'Fn::Sub': 'hi' }, c: { 'Fn::Join': ['', []] } },
+      found
+    );
+    expect([...found].sort()).toEqual(['Fn::Join', 'Fn::Sub', 'Ref']);
+  });
+  it('does NOT treat a multi-key object with a Ref property as an intrinsic Ref', () => {
+    const found = new Set<string>();
+    collectIntrinsics({ Ref: 'X', Other: 1 }, found);
+    expect(found.has('Ref')).toBe(false);
+  });
+  it('recurses arrays', () => {
+    const found = new Set<string>();
+    collectIntrinsics([{ 'Fn::GetAtt': ['R', 'Arn'] }], found);
+    expect([...found]).toEqual(['Fn::GetAtt']);
+  });
+});
+
+describe('findUnknownIntrinsics', () => {
+  it('returns empty when every Fn:: is handled', () => {
+    const tmpl = { Resources: { R: { Type: 'AWS::S3::Bucket', Properties: { N: { 'Fn::Sub': 'x' } } } } };
+    expect(findUnknownIntrinsics(tmpl)).toEqual([]);
+  });
+  it('flags an unknown Fn:: intrinsic', () => {
+    const tmpl = { Resources: { R: { Type: 'AWS::S3::Bucket', Properties: { N: { 'Fn::Length': [] } } } } };
+    expect(findUnknownIntrinsics(tmpl)).toEqual(['Fn::Length']);
+  });
+  it('never flags Fn::Transform (macro, handled upstream)', () => {
+    const tmpl = { Resources: { R: { Type: 'AWS::S3::Bucket', Properties: { 'Fn::Transform': {} } } } };
+    expect(findUnknownIntrinsics(tmpl)).toEqual([]);
+  });
+  it('scans Outputs and Conditions too', () => {
+    const tmpl = {
+      Resources: { R: { Type: 'AWS::S3::Bucket' } },
+      Outputs: { O: { Value: { 'Fn::Length': [] } } },
+      Conditions: { C: { 'Fn::Contains': [] } },
+    };
+    expect(findUnknownIntrinsics(tmpl).sort()).toEqual(['Fn::Contains', 'Fn::Length']);
+  });
+});
+
+describe('extractResourceTypes', () => {
+  it('dedupes and excludes AWS::CDK::Metadata', () => {
+    const tmpl = {
+      Resources: {
+        A: { Type: 'AWS::S3::Bucket' },
+        B: { Type: 'AWS::S3::Bucket' },
+        M: { Type: CDK_METADATA_TYPE },
+        N: { Type: 'AWS::IAM::Role' },
+      },
+    };
+    expect(extractResourceTypes(tmpl).sort()).toEqual(['AWS::IAM::Role', 'AWS::S3::Bucket']);
+  });
+  it('skips resources without a string Type', () => {
+    const tmpl = { Resources: { A: { Type: 123 as unknown as string }, B: null } };
+    expect(extractResourceTypes(tmpl)).toEqual([]);
+  });
+  it('returns empty for missing Resources', () => {
+    expect(extractResourceTypes({})).toEqual([]);
+  });
+});
+
+describe('judgeTemplate', () => {
+  it('passes both verdicts for a template of non-blocklisted, non-tier3 types', () => {
+    // AWS::S3::Bucket is SDK-registered and not runtime-blocklisted;
+    // AWS::SomeService::SomeType stands in for a tier2 CC-API type (passes
+    // optimistic pre-flight AND is not tier3).
+    const tmpl = {
+      Resources: { A: { Type: 'AWS::S3::Bucket' }, B: { Type: 'AWS::SomeService::SomeType' } },
+    };
+    const v = judgeTemplate(tmpl, SDK, TIER3);
+    expect(v.runtimePass).toBe(true);
+    expect(v.truthPass).toBe(true);
+    expect(v.silentTier3).toEqual([]);
+  });
+
+  it('surfaces a silent tier-3 type: passes runtime, fails truth', () => {
+    const tmpl = {
+      Resources: { A: { Type: 'AWS::S3::Bucket' }, G: { Type: 'AWS::AppMesh::GatewayRoute' } },
+    };
+    const v = judgeTemplate(tmpl, SDK, TIER3);
+    expect(v.runtimePass).toBe(true); // optimistic pre-flight lets it through
+    expect(v.truthPass).toBe(false); // tier3 => will fail mid-deploy
+    expect(v.silentTier3).toEqual(['AWS::AppMesh::GatewayRoute']);
+    expect(v.truthBad).toEqual(['AWS::AppMesh::GatewayRoute']);
+  });
+
+  it('a CC-blocklisted-but-SDK-registered type (IAM::Role) passes both verdicts', () => {
+    // IAM::Role is in the CC blocklist, but the real registry's SDK map is
+    // checked first, so pre-flight passes — and it deploys via the SDK
+    // provider. Both verdicts must agree (no false silent-tier3).
+    const tmpl = { Resources: { R: { Type: 'AWS::IAM::Role' } } };
+    const v = judgeTemplate(tmpl, SDK, TIER3);
+    expect(v.runtimePass).toBe(true);
+    expect(v.truthPass).toBe(true);
+    expect(v.silentTier3).toEqual([]);
+    expect(v.runtimeBad).toEqual([]);
+  });
+
+  it('an unknown intrinsic fails both verdicts', () => {
+    const tmpl = {
+      Resources: { A: { Type: 'AWS::S3::Bucket', Properties: { N: { 'Fn::Length': [] } } } },
+    };
+    const v = judgeTemplate(tmpl, SDK, TIER3);
+    expect(v.runtimePass).toBe(false);
+    expect(v.truthPass).toBe(false);
+    expect(v.unknownIntrinsics).toEqual(['Fn::Length']);
+  });
+});
+
+describe('parseRegisteredTypes', () => {
+  it('extracts registry.register("AWS::X::Y") calls', () => {
+    const src = `
+      registry.register('AWS::IAM::Role', new R());
+      registry.register("AWS::S3::Bucket", new B());
+    `;
+    expect([...parseRegisteredTypes(src)].sort()).toEqual(['AWS::IAM::Role', 'AWS::S3::Bucket']);
+  });
+});
+
+describe('extractTier3', () => {
+  it('reads a plain-string tier3 list', () => {
+    expect([...extractTier3({ tier3: ['AWS::A::B', 'AWS::C::D'] })].sort()).toEqual([
+      'AWS::A::B',
+      'AWS::C::D',
+    ]);
+  });
+  it('reads object-shaped entries (type / typeName / name)', () => {
+    const out = extractTier3({
+      tier3: [{ type: 'AWS::A::B' }, { typeName: 'AWS::C::D' }, { name: 'AWS::E::F' }],
+    });
+    expect([...out].sort()).toEqual(['AWS::A::B', 'AWS::C::D', 'AWS::E::F']);
+  });
+  it('tolerates a missing tier3 field', () => {
+    expect(extractTier3({}).size).toBe(0);
+  });
+});
+
+describe('rankFrequency', () => {
+  it('sorts by count desc, then name asc', () => {
+    const m = new Map([
+      ['b', 1],
+      ['a', 2],
+      ['c', 2],
+    ]);
+    expect(rankFrequency(m)).toEqual([
+      ['a', 2],
+      ['c', 2],
+      ['b', 1],
+    ]);
+  });
+});
+
+describe('parseCliArgs', () => {
+  it('parses --json and dirs', () => {
+    expect(parseCliArgs(['--json', 'a', 'b'])).toEqual({ json: true, help: false, dirs: ['a', 'b'] });
+  });
+  it('parses --help / -h', () => {
+    expect(parseCliArgs(['-h']).help).toBe(true);
+    expect(parseCliArgs(['--help']).help).toBe(true);
+  });
+});
+
+describe('measureCorpus (filesystem walk)', () => {
+  it('reports a missing dir without throwing', () => {
+    const report = measureCorpus(['/nonexistent/dir/xyz'], SDK, TIER3);
+    expect(report.missingDirs).toEqual(['/nonexistent/dir/xyz']);
+    expect(report.total).toBe(0);
+  });
+});
+
+describe('RUNTIME_UNSUPPORTED_TYPES drift guard', () => {
+  it('matches the unsupportedTypes set in cloud-control-provider.ts', () => {
+    const src = readFileSync(
+      resolve(REPO_ROOT, 'src/provisioning/cloud-control-provider.ts'),
+      'utf8'
+    );
+    // Extract the body of the `unsupportedTypes = new Set([ ... ])` literal
+    // and pull every quoted type token out of it.
+    const blockMatch = src.match(/unsupportedTypes\s*=\s*new Set\(\[([\s\S]*?)\]\)/);
+    expect(blockMatch).not.toBeNull();
+    const body = blockMatch![1];
+    const types = new Set<string>();
+    const re = /['"]([A-Za-z0-9:]+::[A-Za-z0-9:]+)['"]/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(body)) !== null) types.add(m[1]);
+    expect(types.size).toBeGreaterThan(0);
+    expect([...types].sort()).toEqual([...RUNTIME_UNSUPPORTED_TYPES].sort());
+  });
+});
+
+describe('HANDLED_FN drift guard', () => {
+  it('has exactly the 16 Fn::* the architecture rule documents', () => {
+    // Sanity: Ref is handled separately, so HANDLED_FN holds the 16 Fn::*.
+    expect(HANDLED_FN.size).toBe(16);
+    expect(HANDLED_FN.has('Fn::Cidr')).toBe(true);
+    expect(HANDLED_FN.has('Fn::GetStackOutput')).toBe(true);
+  });
+});
+
+describe('run (end-to-end CLI dispatch)', () => {
+  function makeIO(): { io: CliIO; out: string[]; err: string[]; exit: number | undefined } {
+    const out: string[] = [];
+    const err: string[] = [];
+    const state = { exit: undefined as number | undefined };
+    const io: CliIO = {
+      log: (m) => out.push(m),
+      error: (m) => err.push(m),
+      setExitCode: (c) => {
+        state.exit = c;
+      },
+    };
+    return { io, out, err, get exit() { return state.exit; } };
+  }
+
+  it('prints help with --help and does not set a non-zero exit', () => {
+    const h = makeIO();
+    run(['--help'], h.io);
+    expect(h.out.join('\n')).toContain('Usage: node scripts/compat-corpus.ts');
+    expect(h.exit).toBeUndefined();
+  });
+
+  it('errors (exit 1) with no input dirs', () => {
+    const h = makeIO();
+    run([], h.io);
+    expect(h.exit).toBe(1);
+    expect(h.err.join('\n')).toContain('no input directory supplied');
+  });
+
+  it('errors (exit 1) when no valid templates are found', () => {
+    const h = makeIO();
+    run(['/nonexistent/dir/xyz'], h.io);
+    expect(h.exit).toBe(1);
+    expect(h.err.join('\n')).toContain('no valid CloudFormation templates found');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -232,6 +232,10 @@ export default defineConfig({
         command: 'node --experimental-strip-types scripts/build-scenario-coverage-matrix.ts',
         cache: false,
       },
+      'compat-corpus': {
+        command: 'node --experimental-strip-types scripts/compat-corpus.ts',
+        cache: false,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Adds an **offline cdkd-compatibility measurement tool** so "how compatible is cdkd with existing CDK code?" becomes a measurable number instead of an anecdote. Pure dev/CI tooling under `scripts/` (not shipped in `dist/`); not a CI gate.

`scripts/compat-corpus.ts` (`vp run compat-corpus <dir>...`) scans a corpus of synthesized CloudFormation `*.template.json` files and reports, per corpus:

- **TRUTH (will-deploy)** — judged against the provider-coverage `tier3` set (AWS `ProvisioningType: NON_PROVISIONABLE` — the genuinely-unsupported types), SDK-registered types parsed from `register-providers.ts`, the custom-resource path, and the `AWS::CDK::Metadata` skip. This is the load-bearing metric.
- **RUNTIME (pre-flight passes)** — a replica of `ProviderRegistry.hasProvider` (SDK map first, then the Cloud-Control `isSupportedResourceType` blocklist+optimistic fallthrough, then the custom-resource path).
- **Silent tier-3 surface** — types that PASS pre-flight today but will FAIL mid-deploy (the headline compatibility gap this whole effort targets).
- **Unknown intrinsics** — `Fn::*` the resolver cannot handle.

`scripts/compat-corpus-fixtures.ts` synths a diverse 20-stack CDK corpus via the repo's `aws-cdk-lib` for ad-hoc measurement (portable `createRequire` resolution, no hardcoded paths). Registered as the `compat-corpus` Vite+ task.

## Review fix (caught during this PR's review)

The initial `isRuntimeSupported` mirrored only `isSupportedResourceType`'s blocklist — it ignored the SDK map and the custom-resource path. That under-counted RUNTIME badly (a CC-blocklisted-but-SDK-registered type like `AWS::IAM::Role` was wrongly marked a runtime failure; live RUNTIME read 45% vs the true ~90%). Fixed to mirror `ProviderRegistry.hasProvider` (SDK map wins first; custom + metadata handled), and the unit tests were corrected to assert the real semantics rather than the bug.

## Test plan

- 37 unit tests in `tests/unit/scripts/compat-corpus.test.ts`, including drift guards that cross-check `RUNTIME_UNSUPPORTED_TYPES` against `cloud-control-provider.ts` and `HANDLED_FN` against the 16 documented intrinsics.
- Full suite green (362 files).
- Live-tested: `vp run compat-corpus` on a 20-template corpus reports RUNTIME 90% / TRUTH 95% / silent-tier-3 0, with `AWS::CertificateManager::Certificate` as the only genuinely-unsupported type — matching the spike.
