### PR TITLE
docs: frame --allow-unsupported-properties as a safety valve with when-to-use guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Drop-in CDK CLI for existing CDK apps — faster deploys via AWS SDK instead of 
 - **Bidirectional CloudFormation migration**: `cdkd import` adopts AWS-deployed resources (including `cdk deploy`-managed CloudFormation stacks via `--migrate-from-cloudformation`) into cdkd state without re-creating them; `cdkd export` hands a cdkd-managed stack back to CloudFormation when you're ready to move to production. See [Importing existing resources](#importing-existing-resources) and [Exporting a stack back to CloudFormation](#exporting-a-stack-back-to-cloudformation).
 
 > **Note**: Resource types not covered by either SDK Providers or Cloud Control API cannot be deployed with cdkd. If you encounter an unsupported resource type, deployment will fail with a clear error message.
+>
+> **Property-level coverage is incremental.** SDK Providers wire most but not every CFn property of a supported type — when a template uses a top-level property the provider has not implemented yet, cdkd fails fast at pre-flight with the silently-dropped property name, rationale, and a 1-click GitHub issue link to request support. The `--allow-unsupported-properties <Type>:<Prop>,...` flag is the **safety valve** when this is too strict for your situation (e.g. mid-life update on an existing resource that cannot be recreated): it accepts the silent drop explicitly, per-property. **Do not use it on security-meaningful properties** (encryption / IAM / TLS settings) — the deployed resource will be missing the control you intended. See [docs/cli-reference.md `--allow-unsupported-properties`](docs/cli-reference.md#--allow-unsupported-properties-deploy) for the full safety-valve guidance.
 
 ## Benchmark
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -517,6 +517,76 @@ which CFn itself tolerates. Read-only properties (AWS-managed Arns, Ids,
 etc.) also pass through silently; you cannot set them from the template
 side and they are no-ops if they appear there.
 
+### When to use this flag (safety-valve guidance)
+
+The flag is the **safety valve** for situations where cdkd's fail-fast
+pre-flight is too strict for your immediate needs. cdkd defaults to
+fail-fast because silent drop is a real bug class (the deployed resource
+is missing fields the user wrote); the flag lets you accept the drop
+explicitly when the alternative is worse.
+
+The contract is: *cdkd promises to tell you about silent drops instead
+of hiding them. You then choose what to do — wait, work around, recreate,
+or explicitly accept the drop.* The flag is the "explicitly accept" branch.
+It does not change cdkd's behavior; it changes what cdkd warns you about.
+
+#### Use the flag when
+
+- **Mid-life update on an existing SDK-managed resource that you cannot
+  recreate.** AWS added a new property, CDK supports it, but cdkd's
+  provider has not caught up yet. Recreating the resource is unacceptable
+  (stateful data, downtime, ARN references from other stacks). The flag
+  accepts the silent drop until provider support lands.
+- **You are prototyping** and the missing field does not affect what you
+  are testing.
+- **You filed an upstream issue** (the error message contains a 1-click
+  pre-filled GitHub issue link) and want to continue your work while
+  waiting for the fix.
+
+#### Do NOT use the flag when
+
+- **The dropped property is security-meaningful** — e.g. `KmsKeyArn`,
+  `MonitoringRoleArn`, `MasterUserSecret`, IAM policy attachments,
+  resource-policy fields, encryption settings, TLS configuration.
+  Silent drop here is a real-world incident: the resource will be
+  deployed without the security control you intended, often without an
+  obvious failure mode at runtime.
+- **The dropped property's absence silently changes runtime behavior**
+  that your tests do not catch — e.g. `LoggingConfig` changing log
+  format, `ReservedConcurrentExecutions` removing throttling
+  protection, `DeadLetterConfig` removing retry destination.
+- **You can recreate the resource.** A fresh `cdkd destroy <stack>
+  && cdkd deploy <stack>` cycle is preferable to accepting a silent
+  drop on a long-lived resource — recreated resources will be wired
+  via whatever path cdkd's pre-flight allows next deploy.
+
+#### Decision summary
+
+| Situation | Recommended action |
+| --- | --- |
+| Fresh deploy, no state yet, can recreate | Wait for provider support, or accept silent drop with the flag |
+| Existing resource, recreation acceptable | `cdkd destroy <stack> && cdkd deploy <stack>` — fresh creation goes through the path cdkd currently supports |
+| Existing resource, recreation NOT acceptable | This flag (per-property opt-in), acknowledging silent drop |
+| Property is security-meaningful | Pause the deploy. File an issue (1-click link in the error). Wait for provider support OR downgrade the requirement until support lands. Do **not** use the flag. |
+| You are not sure whether the property is security-meaningful | Default to "do not use the flag" — read the AWS docs for that property first |
+
+#### What the flag is NOT
+
+- **NOT** a request to cdkd to start handling the property. The provider
+  is unchanged; the property is still silently dropped at write time.
+  The deployed resource is missing the field.
+- **NOT** a way to retry an unsupported deploy. The "support" never
+  arrives via the flag — it arrives via a provider PR or a future
+  Cloud Control fallback.
+- **NOT** persisted in cdkd state. Every deploy must pass the flag if
+  the silent drop is still relevant; rotating the flag out only works
+  once the provider catches up.
+
+cdkd is currently a dev/test tool (see "Important Notes" in CLAUDE.md);
+the safety valve is the right escape hatch for that audience. For
+production workloads, use the AWS CDK CLI until cdkd's property
+coverage matches your needs.
+
 ## `--role-arn`
 
 Assume a different IAM role for cdkd's AWS API calls. Equivalent env


### PR DESCRIPTION
## Summary

`--allow-unsupported-properties` shipped in PR #608 with a mechanical
description but no guidance on when it is appropriate to reach for, or
when it is dangerous. Users seeing the fail-fast error need to make an
informed call: silently dropping a security setting on a Lambda or RDS
instance is materially different from silently dropping a log-format
preference, and the docs did not surface that distinction.

This is a pure docs PR — no behavior change.

### Changes

**`docs/cli-reference.md`** — appended a "When to use this flag
(safety-valve guidance)" subsection to the existing
`--allow-unsupported-properties` section:

- Mental model: cdkd warns about silent drops, the user decides what to do
- Use the flag when: mid-life update on an existing un-recreatable resource, prototyping, filed an upstream issue
- Do NOT use when: property is security-meaningful, absence silently changes runtime behavior, the resource can be recreated
- Decision summary table (fresh / existing / security-meaningful / unsure)
- What the flag is NOT (not a support request, not a retry, not persisted in state)

**`README.md`** — added a "Property-level coverage is incremental" note
alongside the existing type-level coverage note, one-line summary + link to the cli-reference section.

## Why now

Two follow-up issues surfaced this framing as missing:

1. Mid-life update gap: when a resource is already in state (SDK-managed) and a new silent-drop property is introduced in a template update, the only escape is `--allow-unsupported-properties` (CC API fallback won't fire for non-fresh deploys). Users need to know what to do.
2. Security-meaningful properties (`KmsKeyArn`, `MasterUserSecret`, etc.) silently dropped via this flag would be real incidents. The docs need to warn explicitly.

## Test plan

- [x] `vp check --fix` clean (no lint/format violations)
- [x] `vp run build` succeeds
- [x] `vp run test` — 365 files / 5591 tests pass (unchanged by this PR)
- [x] Anchor `#--allow-unsupported-properties-deploy` matches existing usage in `docs/supported-resources.md:52` (PR #608)
- [x] Markdown lint (`MD060`/`MD028`) clean after `| --- | --- |` table-separator + merged blockquote fixes
- [x] No code surface touched; no integ required

## Related follow-up issues (filed in the same session)

- #613 — Audit silent-drop list for misclassifications (B: aliased / C: design-intentional vs A: truly unimplemented) — refines #609's backfill scope
- #614 — Cloud Control API greenfield fallback for unhandled top-level properties — closes the fresh-deploy UX gap
- #615 — `--migrate-sdk-to-cc-api` flag for the mid-life property gap on existing SDK-managed resources
