### PR TITLE
docs(readme): reorder sections — Benchmark first, Local execution above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,105 +211,6 @@ matrix (`--concurrency`, `--no-aggressive-vpc-parallel`,
 including the synth-driven per-resource `cdkd orphan <constructPath>`
 variant, and stage / wildcard pattern matching.
 
-## Importing existing resources
-
-`cdkd import` adopts AWS resources that are already deployed (via
-`cdk deploy`, manual creation, or another tool) into cdkd state so the
-next `cdkd deploy` updates them in-place instead of CREATEing duplicates.
-
-`cdkd import --migrate-from-cloudformation` extends this to migrate a
-**whole CloudFormation stack** off CFn in a single command: cdkd reads
-the source CFn stack's `(logicalId, physicalId)` mappings, adopts every
-resource into cdkd state, then retires the source CFn stack (injects
-`DeletionPolicy: Retain` + `UpdateReplacePolicy: Retain` on every
-resource → `UpdateStack` → `DeleteStack`) so the AWS resources stay
-intact but are no longer tracked by CFn. After the command finishes,
-the stack is managed by `cdkd deploy`. This is the reverse direction
-of `cdkd export` (see below).
-
-```bash
-# Adopt a whole stack previously deployed by cdk deploy (tag-based auto-lookup).
-cdkd import MyStack --yes
-
-# Adopt only specific resources (CDK CLI parity).
-cdkd import MyStack --resource MyBucket=my-bucket-name
-
-# Migrate off CloudFormation in one shot — adopt + retire the source CFn stack.
-cdkd import MyStack --migrate-from-cloudformation --yes
-```
-
-See **[docs/import.md](docs/import.md)** for the full guide: three import
-modes (auto / selective / hybrid), `--resource-mapping` CDK CLI
-compatibility, CloudFormation migration flow, provider coverage, and the
-parity matrix vs upstream `cdk import`.
-
-## Exporting a stack back to CloudFormation
-
-`cdkd export` is the mirror of `cdkd import`: it hands a cdkd-managed
-stack back to CloudFormation via a CFn `ChangeSetType=IMPORT` changeset.
-AWS resources are unchanged across the migration; cdkd state for the
-exported stack is deleted on success. From then on the stack is managed
-by `cdk deploy` / `aws cloudformation`. Accepts JSON and YAML templates
-(shorthand intrinsics round-trip).
-
-```bash
-cdkd export MyStack                           # confirmation prompt; CFn stack name = cdkd stack name
-cdkd export MyStack --cfn-stack-name MyStack-CFn
-cdkd export MyStack --dry-run                 # print the import plan, do not call CFn
-cdkd export MyStack --include-non-importable  # 2-phase: IMPORT importable + CFn-CREATE Custom Resources
-cdkd export MyApp                             # nested-stack tree: leaf-first per-stack IMPORT loop
-```
-
-**Lambda-backed Custom Resources** (`Custom::*` /
-`AWS::CloudFormation::CustomResource`) are NOT directly CFn-importable.
-`--include-non-importable` opts into a 2-phase migration that re-CREATEs
-them through CFn — the Custom Resource Lambda must be idempotent.
-**Nested stacks** are supported via a leaf-first per-stack IMPORT loop
-(AWS rejects `--include-nested-stacks` for IMPORT changesets).
-
-See **[docs/import.md](docs/import.md)** for the full guide — Custom Resource
-2-phase flow, nested-stack adoption mechanics (`--cfn-child-stack-name`
-per-child overrides, AWS's "Nest an existing stack" pattern), and the
-design rationale at [docs/design/464-nested-stacks-export-import.md](docs/design/464-nested-stacks-export-import.md).
-
-## Drift detection
-
-`cdkd drift` (state-driven; no synth) compares each managed resource
-against AWS reality and reports divergence — including console-side
-changes to keys you did NOT template (S3 public-access-block, IAM Role
-tags, Lambda env keys, etc.).
-
-```bash
-cdkd drift                       # auto-detect single stack, exit 1 if drift
-cdkd drift MyStack --json        # machine-readable, for CI gating
-cdkd drift MyStack --accept --yes   # state ← AWS (catch up after a console edit)
-cdkd drift MyStack --revert --yes   # AWS ← state (undo a console edit)
-cdkd state refresh-observed MyStack # populate the drift baseline without redeploying
-```
-
-See **[docs/cli-reference.md `cdkd drift`](docs/cli-reference.md#cdkd-drift)**
-for the full reference: `--no-capture-observed-state` deploy opt-out
-(per-command vs per-project, mid-flight reversibility), v2→v3 state
-upgrade flow, exit codes, and what changes when capture is off.
-
-## Orphan vs destroy
-
-`destroy` deletes the AWS resources **and** the state record;
-`orphan` deletes **only** the state record (AWS resources stay
-intact, just no longer tracked by cdkd). Mirrors aws-cdk-cli's
-`cdk orphan`.
-
-Two `orphan` variants at different granularities:
-
-- `cdkd orphan <constructPath>...` — synth-driven, **per-resource**.
-  Rewrites every sibling reference (Ref / Fn::GetAtt / Fn::Sub /
-  dependencies) so the next deploy doesn't re-create the orphan.
-- `cdkd state orphan <stack>...` — state-driven, **whole-stack**.
-  Removes the entire state record. Works without the CDK app.
-
-Both `cdkd destroy` (synth-driven) and `cdkd state destroy`
-(state-driven, no synth) delete AWS resources + state.
-
 ## `--no-wait`: skip async-resource waits
 
 CloudFront / RDS / ElastiCache / NAT Gateway typically take 1–15
@@ -417,6 +318,105 @@ Mid-deploy state is also saved per-resource as work completes, so even
 if cdkd itself crashes between the failure and the rollback, the state
 file accurately reflects what's on AWS and a follow-up `cdkd destroy`
 won't orphan anything.
+
+## Importing existing resources
+
+`cdkd import` adopts AWS resources that are already deployed (via
+`cdk deploy`, manual creation, or another tool) into cdkd state so the
+next `cdkd deploy` updates them in-place instead of CREATEing duplicates.
+
+`cdkd import --migrate-from-cloudformation` extends this to migrate a
+**whole CloudFormation stack** off CFn in a single command: cdkd reads
+the source CFn stack's `(logicalId, physicalId)` mappings, adopts every
+resource into cdkd state, then retires the source CFn stack (injects
+`DeletionPolicy: Retain` + `UpdateReplacePolicy: Retain` on every
+resource → `UpdateStack` → `DeleteStack`) so the AWS resources stay
+intact but are no longer tracked by CFn. After the command finishes,
+the stack is managed by `cdkd deploy`. This is the reverse direction
+of `cdkd export` (see below).
+
+```bash
+# Adopt a whole stack previously deployed by cdk deploy (tag-based auto-lookup).
+cdkd import MyStack --yes
+
+# Adopt only specific resources (CDK CLI parity).
+cdkd import MyStack --resource MyBucket=my-bucket-name
+
+# Migrate off CloudFormation in one shot — adopt + retire the source CFn stack.
+cdkd import MyStack --migrate-from-cloudformation --yes
+```
+
+See **[docs/import.md](docs/import.md)** for the full guide: three import
+modes (auto / selective / hybrid), `--resource-mapping` CDK CLI
+compatibility, CloudFormation migration flow, provider coverage, and the
+parity matrix vs upstream `cdk import`.
+
+## Exporting a stack back to CloudFormation
+
+`cdkd export` is the mirror of `cdkd import`: it hands a cdkd-managed
+stack back to CloudFormation via a CFn `ChangeSetType=IMPORT` changeset.
+AWS resources are unchanged across the migration; cdkd state for the
+exported stack is deleted on success. From then on the stack is managed
+by `cdk deploy` / `aws cloudformation`. Accepts JSON and YAML templates
+(shorthand intrinsics round-trip).
+
+```bash
+cdkd export MyStack                           # confirmation prompt; CFn stack name = cdkd stack name
+cdkd export MyStack --cfn-stack-name MyStack-CFn
+cdkd export MyStack --dry-run                 # print the import plan, do not call CFn
+cdkd export MyStack --include-non-importable  # 2-phase: IMPORT importable + CFn-CREATE Custom Resources
+cdkd export MyApp                             # nested-stack tree: leaf-first per-stack IMPORT loop
+```
+
+**Lambda-backed Custom Resources** (`Custom::*` /
+`AWS::CloudFormation::CustomResource`) are NOT directly CFn-importable.
+`--include-non-importable` opts into a 2-phase migration that re-CREATEs
+them through CFn — the Custom Resource Lambda must be idempotent.
+**Nested stacks** are supported via a leaf-first per-stack IMPORT loop
+(AWS rejects `--include-nested-stacks` for IMPORT changesets).
+
+See **[docs/import.md](docs/import.md)** for the full guide — Custom Resource
+2-phase flow, nested-stack adoption mechanics (`--cfn-child-stack-name`
+per-child overrides, AWS's "Nest an existing stack" pattern), and the
+design rationale at [docs/design/464-nested-stacks-export-import.md](docs/design/464-nested-stacks-export-import.md).
+
+## Drift detection
+
+`cdkd drift` (state-driven; no synth) compares each managed resource
+against AWS reality and reports divergence — including console-side
+changes to keys you did NOT template (S3 public-access-block, IAM Role
+tags, Lambda env keys, etc.).
+
+```bash
+cdkd drift                       # auto-detect single stack, exit 1 if drift
+cdkd drift MyStack --json        # machine-readable, for CI gating
+cdkd drift MyStack --accept --yes   # state ← AWS (catch up after a console edit)
+cdkd drift MyStack --revert --yes   # AWS ← state (undo a console edit)
+cdkd state refresh-observed MyStack # populate the drift baseline without redeploying
+```
+
+See **[docs/cli-reference.md `cdkd drift`](docs/cli-reference.md#cdkd-drift)**
+for the full reference: `--no-capture-observed-state` deploy opt-out
+(per-command vs per-project, mid-flight reversibility), v2→v3 state
+upgrade flow, exit codes, and what changes when capture is off.
+
+## Orphan vs destroy
+
+`destroy` deletes the AWS resources **and** the state record;
+`orphan` deletes **only** the state record (AWS resources stay
+intact, just no longer tracked by cdkd). Mirrors aws-cdk-cli's
+`cdk orphan`.
+
+Two `orphan` variants at different granularities:
+
+- `cdkd orphan <constructPath>...` — synth-driven, **per-resource**.
+  Rewrites every sibling reference (Ref / Fn::GetAtt / Fn::Sub /
+  dependencies) so the next deploy doesn't re-create the orphan.
+- `cdkd state orphan <stack>...` — state-driven, **whole-stack**.
+  Removes the entire state record. Works without the CDK app.
+
+Both `cdkd destroy` (synth-driven) and `cdkd state destroy`
+(state-driven, no synth) delete AWS resources + state.
 
 ## VPC route DependsOn relaxation (on by default)
 

--- a/README.md
+++ b/README.md
@@ -159,208 +159,57 @@ cdkd has three command families:
   use them to inspect / clean up state when the source is gone or
   you don't want to synth. `cdkd state destroy` is the CDK-app-free
   counterpart of `cdkd destroy`.
-- **`cdkd local ...` subcommands** (`local invoke`, `local start-api`,
-  `local run-task`, `local start-service`) run synthesized workloads
-  locally inside Docker containers. The Lambda variants (`local invoke` /
-  `local start-api`) bundle the AWS Lambda Runtime Interface Emulator
-  (RIE); `local invoke` runs a single Lambda once, and `local start-api`
-  stands up a long-running HTTP server that maps API Gateway / HTTP API /
-  Function URL routes to local Lambda invocations. `local run-task` is
-  the ECS one-shot counterpart — it locates an
-  `AWS::ECS::TaskDefinition` from the synthesized template and stands
-  up every container in `dependsOn` order on a per-task docker network
-  with the AWS-published metadata endpoints sidecar, so containers see
-  `ECS_CONTAINER_METADATA_URI_V4` (and optionally task-role creds via
-  `--assume-task-role`) just like they would on Fargate / ECS.
-  `local start-service` is the long-running counterpart for
-  `AWS::ECS::Service`: it discovers the service, chains into the same
-  per-task machinery for each `DesiredCount` replica (clamped by
-  `--max-tasks`), and keeps every replica running until `^C` — failed
-  replicas restart per `--restart-policy on-failure|always|none`. It
-  also accepts multiple service targets in one invocation
-  (`cdkd local start-service Stack/Orders Stack/Frontend`); per-service
-  `AWS::ServiceDiscovery::PrivateDnsNamespace` / `Service` +
-  `ServiceConnectConfiguration` / `ServiceRegistries[]` blocks are
-  parsed and each booted replica's container IP is published to a
-  shared in-process Cloud Map registry, then injected into the next
-  service's containers via docker `--add-host <fqdn>:<ip>` so
-  `wget http://orders/` from inside the `frontend` container resolves
-  via `/etc/hosts` to the orders replica (boot targets in
-  producer-then-consumer order; see [docs/local-emulation.md](docs/local-emulation.md)
-  for v1 limitations — first-wins for multi-replica routing, no SRV
-  records, no Envoy L7). No AWS API calls beyond optional STS / Secrets
-  resolution, no state bucket needed. Local load-balancer emulation and
-  `--watch` hot-reload for `start-service` are deferred to follow-up
-  PRs.
+- **`cdkd local ...` subcommands** (`local invoke` / `start-api` /
+  `run-task` / `start-service`) run synthesized workloads locally
+  inside Docker containers — no AWS deploy needed. Modeled on
+  `sam local *` but reads CDK state directly via `--from-state`
+  (cdkd-managed) or `--from-cfn-stack` (CFn-managed). See
+  [Local execution](#local-execution).
 
 Options like `--app`, `--state-bucket`, and `--context` can be omitted if configured via `cdk.json` or environment variables (`CDKD_APP`, `CDKD_STATE_BUCKET`).
 
 ```bash
-# Bootstrap (create S3 bucket for state)
-cdkd bootstrap \
-  --state-bucket my-cdkd-state \
-  --region us-east-1
-
-# Synthesize only
-cdkd synth --app "node app.ts"
-
-# List all stacks in the CDK app (alias: ls)
-cdkd list
-cdkd ls
-cdkd list --long              # YAML records with id/name/environment
-cdkd list --long --json       # same, but JSON
-cdkd list --show-dependencies # id + dependency list per stack
-cdkd list 'MyStage/*'         # filter by display path (CDK CLI parity)
-
-# Deploy from a pre-synthesized cloud assembly directory
-cdkd deploy --app cdk.out
-
-# Deploy (single stack auto-detected, reads --app from cdk.json)
-cdkd deploy
-
-# Deploy specific stack(s)
-cdkd deploy MyStack
-cdkd deploy Stack1 Stack2
-
-# Deploy all stacks
+# Synth + deploy
+cdkd synth
+cdkd deploy                         # single-stack auto-detected
+cdkd deploy MyStack                 # by name (or 'MyStage/Api' display path)
 cdkd deploy --all
+cdkd deploy --dry-run               # plan only, no changes
+cdkd deploy --no-rollback           # Terraform-style: keep partial state on failure
+cdkd deploy --no-wait               # skip multi-minute waits (CloudFront / RDS / NAT)
 
-# Deploy with wildcard (matched against the physical CloudFormation stack name)
-cdkd deploy 'My*'
-
-# Deploy stacks under a CDK Stage using the hierarchical path (CDK CLI parity)
-# Patterns containing '/' are routed to the CDK display path; both forms work:
-cdkd deploy 'MyStage/*'        # all stacks under MyStage
-cdkd deploy MyStage/Api        # specific stack by display path
-cdkd deploy MyStage-Api        # same stack by physical CloudFormation name
-
-# Deploy with context values
-cdkd deploy -c env=staging -c featureFlag=true
-
-# Deploy with explicit options
-cdkd deploy MyStack \
-  --app "node app.ts" \
-  --state-bucket my-cdkd-state \
-  --verbose
-
-# Show diff (what would change)
+# Inspect what would change
 cdkd diff MyStack
-cdkd diff MyParent --recursive       # also diff every nested-stack child vs its own state (#555 A5)
-cdkd diff MyParent --recursive --json  # nested {stack, changes, children: [...]} JSON
-cdkd diff MyStack --fail             # exit 1 when any change is detected (CI gate; matches cdk diff --fail)
+cdkd diff MyStack --fail            # exit 1 on any change (CI gate)
 
-# Detect drift between cdkd state and AWS reality (state-only; no synth)
-# Exits 0 with no drift, 1 when drift is detected, 2 on partial revert failure.
-cdkd drift MyStack
-cdkd drift --all --json
+# Drift detection — compare state vs AWS reality (no synth)
+cdkd drift MyStack                  # exit 1 if drift
+cdkd drift MyStack --accept --yes   # state ← AWS
+cdkd drift MyStack --revert --yes   # AWS ← state
 
-# Resolve drift: state ← AWS (catch up state with manual console changes)
-cdkd drift MyStack --accept --yes
-
-# Resolve drift: AWS ← state (push state values back into AWS via provider.update)
-cdkd drift MyStack --revert --yes
-
-# Refresh the deploy-time AWS snapshot used as drift baseline.
-# Optional — `cdkd deploy` itself auto-refreshes on the first deploy after
-# upgrading from a pre-v3 cdkd binary (= state schema `version: 2`), in
-# parallel with the deploy at no critical-path cost. This command is the
-# manual / non-deploy path: run it when you want the baseline refreshed
-# without redeploying (e.g. for resources that won't change in any
-# near-future deploy). Idempotent on the same v3 state — see "Drift
-# detection" below for the full upgrade story.
-cdkd state refresh-observed MyStack
-
-# Dry run (plan only, no changes)
-cdkd deploy --dry-run
-
-# Deploy with no rollback on failure (Terraform-style)
-cdkd deploy --no-rollback
-
-# Deploy only the specified stack (skip dependency auto-inclusion)
-cdkd deploy -e MyStack
-
-# Skip the multi-minute wait on async resources (CloudFront, RDS, NAT GW, etc.)
-cdkd deploy --no-wait
-
-# Synth + build + publish assets only (no deploy) — typical CI split
-cdkd publish-assets
-
-# Destroy resources
+# Asset / destroy / unlock
+cdkd publish-assets                 # synth + upload only (typical CI split)
 cdkd destroy MyStack
-cdkd destroy --all --force
+cdkd force-unlock MyStack           # clear stale lock from an interrupted deploy
 
-# Force-unlock a stale lock from interrupted deploy
-cdkd force-unlock MyStack
-
-# Adopt already-deployed AWS resources into cdkd state.
-# See docs/import.md for the full guide (auto / selective / hybrid modes,
-# --resource overrides, --resource-mapping CDK CLI compatibility).
-cdkd import MyStack --dry-run
+# Adopt existing AWS resources into cdkd state
 cdkd import MyStack --yes
 
-# Inspect state-bucket info on demand (bucket name, region, source, schema version, stack count).
-# Routine commands (deploy / destroy / etc.) no longer print the bucket banner by default —
-# pass --verbose to surface it in their debug logs, or use this subcommand for an explicit answer.
-cdkd state info
-cdkd state info --json        # JSON output for tooling
-cdkd state info --state-bucket my-bucket  # explicit bucket; reports Source: --state-bucket flag
-
-# List stacks registered in the cdkd state bucket
-cdkd state list
-cdkd state ls --long          # include resource count, last-modified, lock status
-cdkd state list --json        # JSON output (alone, or combined with --long)
-cdkd state list --tree        # parent → child stack tree (nested stacks; #555 A3)
-cdkd state list --tree --json # tree as nested JSON
-
-# List resources of a single stack from state
-cdkd state resources MyStack          # aligned columns: LogicalID, Type, PhysicalID
-cdkd state resources MyStack --long   # per-resource block with dependencies and attributes
-cdkd state resources MyStack --json   # full JSON array
-
-# Show full state record for a stack (metadata, outputs, all resources incl. properties)
-cdkd state show MyStack
-cdkd state show MyStack --json              # raw {state, lock} JSON
-cdkd state show MyParent --show-nested      # recursively show every nested-stack child (#555 A4)
-cdkd state show MyParent --show-nested --json  # tree as nested {state, lock, children: [...]} JSON
-
-# Orphan one or more RESOURCES from cdkd's state (does NOT delete AWS resources).
-# Per-resource, mirrors aws-cdk-cli's `cdk orphan --unstable=orphan`.
-# Synth-driven — needs --app / cdk.json. Construct paths use CDK's L2-style form
-# (`<StackName>/<Path/To/Construct>`); the synthesized `/Resource` suffix is
-# matched implicitly. Passing an L2 wrapper that contains multiple CFn resources
-# orphans every child under it (matches upstream's prefix-match semantics).
-cdkd orphan MyStack/MyTable                    # confirmation prompt (y/N)
-cdkd orphan MyStack/MyTable --yes
-cdkd orphan MyStack/MyTable MyStack/MyBucket   # multiple resources, same stack
-cdkd orphan MyStack/MyTable --dry-run          # print rewrite audit, no save
-cdkd orphan MyStack/MyTable --force            # also fall back to cached
-                                               # attributes when live fetch fails
-
-# State-driven counterpart that orphans a WHOLE STACK's state record
-# (no CDK app needed — works against the bucket).
-cdkd state orphan MyStack             # confirmation prompt (y/N)
-cdkd state orphan MyStack --yes       # skip confirmation
-cdkd state orphan StackA StackB --force # also bypass the locked-stack refusal
-
-# Destroy a stack's AWS resources AND remove its state record, without
-# requiring the CDK app (no synth — works from any working directory).
-cdkd state destroy MyStack            # per-stack confirmation prompt
-cdkd state destroy MyStack OtherStack --yes
-cdkd state destroy --all -y           # every stack in the bucket
-cdkd state destroy MyStack --region us-east-1
+# State-bucket-only commands (no CDK app needed)
+cdkd state info                     # bucket name, region, schema version
+cdkd state list                     # one row per (stackName, region)
+cdkd state list --tree              # parent → child nested-stack tree
+cdkd state show MyStack             # full state record
+cdkd state resources MyStack        # logical id / type / physical id
+cdkd state destroy MyStack          # delete AWS resources + state, no CDK app
+cdkd state orphan MyStack           # remove state record only (AWS resources stay)
 ```
 
-## Compatibility
-
-cdkd supports the standard CloudFormation surface — intrinsic functions,
-pseudo parameters, parameters / conditions, cross-stack / cross-region
-references, asset publishing, custom resources, and so on. See
-**[docs/supported-features.md](docs/supported-features.md)** for the
-full reference. For per-resource-type provisioning support (SDK Providers
-vs Cloud Control API fallback), see
-**[docs/supported-resources.md](docs/supported-resources.md)**.
-
-**Property-level coverage is incremental.** SDK Providers wire most but not every CFn property of a supported type. cdkd fails fast at pre-flight when a template uses a not-yet-implemented property, with the property name + a 1-click issue link. `--allow-unsupported-properties <Type>:<Prop>,...` is the safety valve when this is too strict (e.g. mid-life update on an existing resource); avoid it on security-meaningful properties (encryption / IAM / TLS). See [docs/cli-reference.md](docs/cli-reference.md#--allow-unsupported-properties-deploy).
+See **[docs/cli-reference.md](docs/cli-reference.md)** for the full flag
+matrix (`--concurrency`, `--no-aggressive-vpc-parallel`,
+`--allow-unsupported-properties`, `--role-arn`, etc.), per-command details
+including the synth-driven per-resource `cdkd orphan <constructPath>`
+variant, and stage / wildcard pattern matching.
 
 ## Importing existing resources
 
@@ -631,6 +480,18 @@ cdkd publish-assets -a cdk.out       # skip synth, use pre-synthesized assembly
 
 See [docs/cli-reference.md](docs/cli-reference.md#publish-assets-synth--build--publish-no-deploy)
 for stack-selection rules and concurrency knobs.
+
+## Compatibility
+
+cdkd supports the standard CloudFormation surface — intrinsic functions,
+pseudo parameters, parameters / conditions, cross-stack / cross-region
+references, asset publishing, custom resources, and so on. See
+**[docs/supported-features.md](docs/supported-features.md)** for the
+full reference. For per-resource-type provisioning support (SDK Providers
+vs Cloud Control API fallback), see
+**[docs/supported-resources.md](docs/supported-resources.md)**.
+
+**Property-level coverage is incremental.** SDK Providers wire most but not every CFn property of a supported type. cdkd fails fast at pre-flight when a template uses a not-yet-implemented property, with the property name + a 1-click issue link. `--allow-unsupported-properties <Type>:<Prop>,...` is the safety valve when this is too strict (e.g. mid-life update on an existing resource); avoid it on security-meaningful properties (encryption / IAM / TLS). See [docs/cli-reference.md](docs/cli-reference.md#--allow-unsupported-properties-deploy).
 
 ## State Management
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,45 @@ Reproduce the first two with `./tests/benchmark/run-benchmark.sh all`. See [test
 
 > **Note**: Resource types not covered by either SDK Providers or Cloud Control API cannot be deployed with cdkd. Deployment fails with a clear error message naming the type + a 1-click issue link.
 
+## How it works
+
+```
+┌─────────────────┐
+│  Your CDK App   │  (aws-cdk-lib)
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ cdkd Synthesis  │  Subprocess + Cloud Assembly parser
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ CloudFormation  │
+│   Template      │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ cdkd Engine     │
+│ - DAG Analysis  │  Dependency graph construction
+│ - Diff Calc     │  Compare with existing resources
+│ - Parallel Exec │  Event-driven dispatch
+└────────┬────────┘
+         │
+    ┌────┴────┐
+    ▼         ▼
+┌────────┐ ┌────────┐
+│  SDK   │ │ Cloud  │
+│Provider│ │Control │  Fallback for many
+│        │ │  API   │  additional types
+└────────┘ └────────┘
+```
+
+For a step-by-step walkthrough of the full `cdkd deploy` pipeline (CLI
+parsing → synthesis → asset publishing → per-stack deploy), see
+[docs/architecture.md](docs/architecture.md#5-end-to-end-pipeline-walkthrough-cdkd-deploy).
+
 ## Prerequisites
 
 - **Node.js** >= 20.0.0
@@ -323,79 +362,6 @@ vs Cloud Control API fallback), see
 
 **Property-level coverage is incremental.** SDK Providers wire most but not every CFn property of a supported type. cdkd fails fast at pre-flight when a template uses a not-yet-implemented property, with the property name + a 1-click issue link. `--allow-unsupported-properties <Type>:<Prop>,...` is the safety valve when this is too strict (e.g. mid-life update on an existing resource); avoid it on security-meaningful properties (encryption / IAM / TLS). See [docs/cli-reference.md](docs/cli-reference.md#--allow-unsupported-properties-deploy).
 
-## Local execution
-
-The `cdkd local` family runs AWS workloads on the developer's machine
-via Docker — Lambda functions, API Gateway routes, ECS tasks, and
-long-running ECS services — without an AWS deploy. Modeled on `sam local *` but reuses cdkd's
-synthesis / asset / construct-path plumbing — no `template.yaml` to
-maintain, no `cdk synth | sam ...` round-trip.
-
-| Subcommand | Emulates |
-| --- | --- |
-| `cdkd local invoke <target>` | One-shot Lambda invoke via the AWS Lambda Runtime Interface Emulator (RIE) |
-| `cdkd local start-api` | Long-running HTTP server for REST v1 / HTTP API / Function URL routes |
-| `cdkd local run-task <target>` | ECS RunTask — every container in a task definition started on a per-task docker network |
-| `cdkd local start-service <target>` | Long-running ECS Service emulator — `DesiredCount` replicas with restart-on-exit (no local load balancer in v1) |
-
-Requires Docker. Pass `--from-state` (cdkd-deployed) or
-`--from-cfn-stack` (cdk-deployed / CFn-managed) to substitute deployed
-physical IDs into intrinsic-valued env vars / secrets / image URIs;
-without either, intrinsic values are dropped with a per-key warning
-(matches `sam local *`). The two flags are mutually exclusive.
-
-### `local invoke`
-
-```bash
-cdkd local invoke MyStack/Handler                    # one-shot invoke
-cdkd local invoke MyStack/Handler --event events/get.json
-cdkd local invoke MyStack/Handler --from-state       # OR --from-cfn-stack
-```
-
-All AWS Lambda runtimes (Node.js / Python / Ruby / Java / .NET /
-`provided.al2023`), ZIP and container Lambdas, same-stack Lambda Layers
-bind-mounted at `/opt`.
-
-### `local start-api`
-
-```bash
-cdkd local start-api                                 # one HTTP server per discovered API
-cdkd local start-api MyStack/MyHttpApi --watch       # filter + hot reload
-cdkd local start-api --from-state                    # OR --from-cfn-stack
-```
-
-REST v1 + HTTP API v2 + Function URL with all integration kinds
-(AWS_PROXY / MOCK / HTTP_PROXY / HTTP / AWS Lambda non-proxy via
-hand-rolled VTL), authorizers (Lambda / Cognito / HTTP v2 JWT /
-REST v1 AWS_IAM SigV4), CORS, stage variables, `--watch` hot reload.
-
-### `local run-task`
-
-```bash
-cdkd local run-task MyStack/MyService/TaskDef
-cdkd local run-task MyTaskDef --from-state           # OR --from-cfn-stack
-```
-
-Every container in the task definition on a per-task docker network
-with the AWS-published ECS metadata sidecar.
-
-### `local start-service`
-
-```bash
-cdkd local start-service MyStack/Orders MyStack/Web  # multiple services in one invocation
-cdkd local start-service MyStack/Orders --from-state # OR --from-cfn-stack
-```
-
-Long-running ECS Service emulator: `DesiredCount` replicas with
-restart-on-exit, cross-service Service Connect / Cloud Map DNS
-discovery (peer containers reach each other by `<discoveryName>.<namespace>`).
-No local load-balancer in v1.
-
-See **[docs/local-emulation.md](docs/local-emulation.md)** for the
-full reference — runtimes, target resolution, every flag, integration
-and authorizer detail, route precedence, container pool, networking,
-`--from-cfn-stack` semantics, v1 scope.
-
 ## Importing existing resources
 
 `cdkd import` adopts AWS resources that are already deployed (via
@@ -495,45 +461,6 @@ Two `orphan` variants at different granularities:
 Both `cdkd destroy` (synth-driven) and `cdkd state destroy`
 (state-driven, no synth) delete AWS resources + state.
 
-## How it works
-
-```
-┌─────────────────┐
-│  Your CDK App   │  (aws-cdk-lib)
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ cdkd Synthesis  │  Subprocess + Cloud Assembly parser
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ CloudFormation  │
-│   Template      │
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ cdkd Engine     │
-│ - DAG Analysis  │  Dependency graph construction
-│ - Diff Calc     │  Compare with existing resources
-│ - Parallel Exec │  Event-driven dispatch
-└────────┬────────┘
-         │
-    ┌────┴────┐
-    ▼         ▼
-┌────────┐ ┌────────┐
-│  SDK   │ │ Cloud  │
-│Provider│ │Control │  Fallback for many
-│        │ │  API   │  additional types
-└────────┘ └────────┘
-```
-
-For a step-by-step walkthrough of the full `cdkd deploy` pipeline (CLI
-parsing → synthesis → asset publishing → per-stack deploy), see
-[docs/architecture.md](docs/architecture.md#5-end-to-end-pipeline-walkthrough-cdkd-deploy).
-
 ## `--no-wait`: skip async-resource waits
 
 CloudFront / RDS / ElastiCache / NAT Gateway typically take 1–15
@@ -548,19 +475,78 @@ See [docs/cli-reference.md](docs/cli-reference.md#--no-wait-skip-async-resource-
 for per-resource caveats (NAT egress, RDS final-snapshot timing,
 etc.).
 
-## VPC route DependsOn relaxation (on by default)
+## Local execution
 
-CDK injects defensive `DependsOn` from VPC Lambdas onto private-subnet
-routes. The dependency is real at runtime but NOT required at deploy
-time. cdkd drops it by default so CloudFront + Lambda::Url propagation
-runs in parallel with NAT stabilization (~50% faster on VPC+Lambda+CloudFront
-stacks; bench-cdk-sample 398s → 181s). Pass
-`cdkd deploy --no-aggressive-vpc-parallel` to opt out (e.g. when a
-Custom Resource synchronously invokes a VPC Lambda outside cdkd's
-Lambda-ServiceToken Active wait).
+The `cdkd local` family runs AWS workloads on the developer's machine
+via Docker — Lambda functions, API Gateway routes, ECS tasks, and
+long-running ECS services — without an AWS deploy. Modeled on `sam local *` but reuses cdkd's
+synthesis / asset / construct-path plumbing — no `template.yaml` to
+maintain, no `cdk synth | sam ...` round-trip.
 
-See [docs/cli-reference.md](docs/cli-reference.md) for the full
-type-pair allowlist and trade-off notes.
+| Subcommand | Emulates |
+| --- | --- |
+| `cdkd local invoke <target>` | One-shot Lambda invoke via the AWS Lambda Runtime Interface Emulator (RIE) |
+| `cdkd local start-api` | Long-running HTTP server for REST v1 / HTTP API / Function URL routes |
+| `cdkd local run-task <target>` | ECS RunTask — every container in a task definition started on a per-task docker network |
+| `cdkd local start-service <target>` | Long-running ECS Service emulator — `DesiredCount` replicas with restart-on-exit (no local load balancer in v1) |
+
+Requires Docker. Pass `--from-state` (cdkd-deployed) or
+`--from-cfn-stack` (cdk-deployed / CFn-managed) to substitute deployed
+physical IDs into intrinsic-valued env vars / secrets / image URIs;
+without either, intrinsic values are dropped with a per-key warning
+(matches `sam local *`). The two flags are mutually exclusive.
+
+### `local invoke`
+
+```bash
+cdkd local invoke MyStack/Handler                    # one-shot invoke
+cdkd local invoke MyStack/Handler --event events/get.json
+cdkd local invoke MyStack/Handler --from-state       # OR --from-cfn-stack
+```
+
+All AWS Lambda runtimes (Node.js / Python / Ruby / Java / .NET /
+`provided.al2023`), ZIP and container Lambdas, same-stack Lambda Layers
+bind-mounted at `/opt`.
+
+### `local start-api`
+
+```bash
+cdkd local start-api                                 # one HTTP server per discovered API
+cdkd local start-api MyStack/MyHttpApi --watch       # filter + hot reload
+cdkd local start-api --from-state                    # OR --from-cfn-stack
+```
+
+REST v1 + HTTP API v2 + Function URL with all integration kinds
+(AWS_PROXY / MOCK / HTTP_PROXY / HTTP / AWS Lambda non-proxy via
+hand-rolled VTL), authorizers (Lambda / Cognito / HTTP v2 JWT /
+REST v1 AWS_IAM SigV4), CORS, stage variables, `--watch` hot reload.
+
+### `local run-task`
+
+```bash
+cdkd local run-task MyStack/MyService/TaskDef
+cdkd local run-task MyTaskDef --from-state           # OR --from-cfn-stack
+```
+
+Every container in the task definition on a per-task docker network
+with the AWS-published ECS metadata sidecar.
+
+### `local start-service`
+
+```bash
+cdkd local start-service MyStack/Orders MyStack/Web  # multiple services in one invocation
+cdkd local start-service MyStack/Orders --from-state # OR --from-cfn-stack
+```
+
+Long-running ECS Service emulator: `DesiredCount` replicas with
+restart-on-exit, cross-service Service Connect / Cloud Map DNS
+discovery (peer containers reach each other by `<discoveryName>.<namespace>`).
+No local load-balancer in v1.
+
+See **[docs/local-emulation.md](docs/local-emulation.md)** for the
+full reference — runtimes, target resolution, every flag, integration
+and authorizer detail, route precedence, container pool, networking,
+`--from-cfn-stack` semantics, v1 scope.
 
 ## Rollback behavior
 
@@ -582,6 +568,20 @@ Mid-deploy state is also saved per-resource as work completes, so even
 if cdkd itself crashes between the failure and the rollback, the state
 file accurately reflects what's on AWS and a follow-up `cdkd destroy`
 won't orphan anything.
+
+## VPC route DependsOn relaxation (on by default)
+
+CDK injects defensive `DependsOn` from VPC Lambdas onto private-subnet
+routes. The dependency is real at runtime but NOT required at deploy
+time. cdkd drops it by default so CloudFront + Lambda::Url propagation
+runs in parallel with NAT stabilization (~50% faster on VPC+Lambda+CloudFront
+stacks; bench-cdk-sample 398s → 181s). Pass
+`cdkd deploy --no-aggressive-vpc-parallel` to opt out (e.g. when a
+Custom Resource synchronously invokes a VPC Lambda outside cdkd's
+Lambda-ServiceToken Active wait).
+
+See [docs/cli-reference.md](docs/cli-reference.md) for the full
+type-pair allowlist and trade-off notes.
 
 ## `--remove-protection`: one-shot bypass for protected resources
 

--- a/README.md
+++ b/README.md
@@ -13,23 +13,6 @@ Drop-in CDK CLI for existing CDK apps — faster deploys via AWS SDK instead of 
 > [!IMPORTANT]
 > cdkd is for dev/test workflows only — early in development, not yet production-ready.
 
-## Features
-
-- **Synthesis orchestration**: CDK app subprocess execution, Cloud Assembly parsing, context provider loop
-- **Asset handling**: Self-implemented asset publisher for S3 file assets (ZIP packaging) and Docker images (ECR)
-- **Context resolution**: Self-implemented context provider loop for Vpc.fromLookup(), AZ, SSM, HostedZone, etc.
-- **Hybrid provisioning**: SDK Providers for fast direct API calls, Cloud Control API fallback for broad resource coverage
-- **Diff calculation**: Self-implemented resource/property-level diff between desired template and current state
-- **S3-based state management**: No DynamoDB required, uses S3 conditional writes for locking
-- **DAG-based parallelization**: Analyze `Ref`/`Fn::GetAtt` dependencies and execute in parallel
-- **Rollback on failure**: When a deploy errors mid-stack, cdkd rolls back the resources it just created so the stack state stays consistent (CloudFormation parity — but cdkd does this without round-tripping through CFn). Pass `cdkd deploy --no-rollback` to skip rollback and keep the partial state for Terraform-style inspection / repair. See [Rollback behavior](#rollback-behavior).
-- **`--no-wait` for async resources**: Skip the multi-minute wait on CloudFront / RDS / ElastiCache / NAT Gateway and return as soon as the create call returns (CloudFormation always blocks)
-- **VPC route DependsOn relaxation (on by default)**: Drop CDK-injected defensive `DependsOn` edges from VPC Lambdas onto private-subnet routes so `CloudFront::Distribution` and `Lambda::Url` start their ~3-min propagation in parallel with NAT Gateway stabilization (~50% faster on VPC + Lambda + CloudFront stacks). Pass `--no-aggressive-vpc-parallel` to opt out.
-- **Local execution** (`cdkd local invoke` / `start-api` / `run-task` / `start-service`): run Lambdas, API Gateway routes, ECS tasks and long-running ECS services from your CDK code via Docker. All AWS Lambda runtimes, container Lambdas, REST v1 / HTTP v2 / Function URL routes, Service Connect / Cloud Map. Works for both `cdkd deploy`-managed (`--from-state`) AND `cdk deploy`-managed (`--from-cfn-stack`) stacks. See [Local execution](#local-execution).
-- **Bidirectional CloudFormation migration**: `cdkd import --migrate-from-cloudformation` adopts existing CFn stacks (including `cdk deploy`-managed) into cdkd state without re-creating resources; `cdkd export` hands a cdkd stack back to CloudFormation when production-ready. See [Importing](#importing-existing-resources) / [Exporting](#exporting-a-stack-back-to-cloudformation).
-
-> **Note**: Resource types not covered by either SDK Providers or Cloud Control API cannot be deployed with cdkd. Deployment fails with a clear error message naming the type + a 1-click issue link.
-
 ## Benchmark
 
 **cdkd deploys up to 15x faster than AWS CDK (CloudFormation)** on SDK-Provider-handled stacks; the per-stack speedup widens with size and parallelism, and drops to ~1.5-3x on stacks dominated by Cloud Control API fallback resources.
@@ -64,44 +47,22 @@ Stack: SSM Document × 3 + Athena WorkGroup × 2 (no SDK provider — CC API fal
 
 Reproduce the first two with `./tests/benchmark/run-benchmark.sh all`. See [tests/benchmark/README.md](tests/benchmark/README.md) for details.
 
-## How it works
+## Features
 
-```
-┌─────────────────┐
-│  Your CDK App   │  (aws-cdk-lib)
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ cdkd Synthesis  │  Subprocess + Cloud Assembly parser
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ CloudFormation  │
-│   Template      │
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ cdkd Engine     │
-│ - DAG Analysis  │  Dependency graph construction
-│ - Diff Calc     │  Compare with existing resources
-│ - Parallel Exec │  Event-driven dispatch
-└────────┬────────┘
-         │
-    ┌────┴────┐
-    ▼         ▼
-┌────────┐ ┌────────┐
-│  SDK   │ │ Cloud  │
-│Provider│ │Control │  Fallback for many
-│        │ │  API   │  additional types
-└────────┘ └────────┘
-```
+- **Synthesis orchestration**: CDK app subprocess execution, Cloud Assembly parsing, context provider loop
+- **Asset handling**: Self-implemented asset publisher for S3 file assets (ZIP packaging) and Docker images (ECR)
+- **Context resolution**: Self-implemented context provider loop for Vpc.fromLookup(), AZ, SSM, HostedZone, etc.
+- **Hybrid provisioning**: SDK Providers for fast direct API calls, Cloud Control API fallback for broad resource coverage
+- **Diff calculation**: Self-implemented resource/property-level diff between desired template and current state
+- **S3-based state management**: No DynamoDB required, uses S3 conditional writes for locking
+- **DAG-based parallelization**: Analyze `Ref`/`Fn::GetAtt` dependencies and execute in parallel
+- **Rollback on failure**: When a deploy errors mid-stack, cdkd rolls back the resources it just created so the stack state stays consistent (CloudFormation parity — but cdkd does this without round-tripping through CFn). Pass `cdkd deploy --no-rollback` to skip rollback and keep the partial state for Terraform-style inspection / repair. See [Rollback behavior](#rollback-behavior).
+- **`--no-wait` for async resources**: Skip the multi-minute wait on CloudFront / RDS / ElastiCache / NAT Gateway and return as soon as the create call returns (CloudFormation always blocks)
+- **VPC route DependsOn relaxation (on by default)**: Drop CDK-injected defensive `DependsOn` edges from VPC Lambdas onto private-subnet routes so `CloudFront::Distribution` and `Lambda::Url` start their ~3-min propagation in parallel with NAT Gateway stabilization (~50% faster on VPC + Lambda + CloudFront stacks). Pass `--no-aggressive-vpc-parallel` to opt out.
+- **Local execution** (`cdkd local invoke` / `start-api` / `run-task` / `start-service`): run Lambdas, API Gateway routes, ECS tasks and long-running ECS services from your CDK code via Docker. All AWS Lambda runtimes, container Lambdas, REST v1 / HTTP v2 / Function URL routes, Service Connect / Cloud Map. Works for both `cdkd deploy`-managed (`--from-state`) AND `cdk deploy`-managed (`--from-cfn-stack`) stacks. See [Local execution](#local-execution).
+- **Bidirectional CloudFormation migration**: `cdkd import --migrate-from-cloudformation` adopts existing CFn stacks (including `cdk deploy`-managed) into cdkd state without re-creating resources; `cdkd export` hands a cdkd stack back to CloudFormation when production-ready. See [Importing](#importing-existing-resources) / [Exporting](#exporting-a-stack-back-to-cloudformation).
 
-For a step-by-step walkthrough of the full `cdkd deploy` pipeline (CLI
-parsing → synthesis → asset publishing → per-stack deploy), see
-[docs/architecture.md](docs/architecture.md#5-end-to-end-pipeline-walkthrough-cdkd-deploy).
+> **Note**: Resource types not covered by either SDK Providers or Cloud Control API cannot be deployed with cdkd. Deployment fails with a clear error message naming the type + a 1-click issue link.
 
 ## Prerequisites
 
@@ -362,55 +323,6 @@ vs Cloud Control API fallback), see
 
 **Property-level coverage is incremental.** SDK Providers wire most but not every CFn property of a supported type. cdkd fails fast at pre-flight when a template uses a not-yet-implemented property, with the property name + a 1-click issue link. `--allow-unsupported-properties <Type>:<Prop>,...` is the safety valve when this is too strict (e.g. mid-life update on an existing resource); avoid it on security-meaningful properties (encryption / IAM / TLS). See [docs/cli-reference.md](docs/cli-reference.md#--allow-unsupported-properties-deploy).
 
-## Rollback behavior
-
-When a deploy fails mid-stack (e.g. a resource hits a validation error
-or AWS rejects the request), cdkd by default **rolls back the
-already-completed resources in the same deploy** so the stack state
-stays consistent — every resource cdkd just created in this run is
-deleted in reverse dependency order, the state record is updated to
-match, and the CLI exits non-zero. Resources that existed before this
-deploy are NOT touched.
-
-Pass `cdkd deploy --no-rollback` to skip the rollback (Terraform-style:
-the partial state is preserved so you can `cdkd state show <stack>`,
-inspect what landed, fix the underlying issue, and re-run `cdkd deploy`
-to continue from the half-deployed state). Recommended only when you
-plan to manually inspect / repair; the default is safer for CI.
-
-Mid-deploy state is also saved per-resource as work completes, so even
-if cdkd itself crashes between the failure and the rollback, the state
-file accurately reflects what's on AWS and a follow-up `cdkd destroy`
-won't orphan anything.
-
-## `--no-wait`: skip async-resource waits
-
-CloudFront / RDS / ElastiCache / NAT Gateway typically take 1–15
-minutes to fully provision. By default cdkd waits (matching CFn).
-`cdkd deploy --no-wait` returns as soon as the create call returns
-and lets AWS finish in the background — handy for CI where nothing
-in the deploy flow needs the resource fully active. **Deploy-only**:
-`cdkd destroy` always waits (NAT in `deleting` state holds ENIs and
-would `DependencyViolation` sibling deletes).
-
-See [docs/cli-reference.md](docs/cli-reference.md#--no-wait-skip-async-resource-waits)
-for per-resource caveats (NAT egress, RDS final-snapshot timing,
-etc.).
-
-## VPC route DependsOn relaxation (on by default)
-
-CDK injects defensive `DependsOn` from VPC Lambdas onto private-subnet
-routes. The dependency is real at runtime but NOT required at deploy
-time. cdkd drops it by default so CloudFront + Lambda::Url propagation
-runs in parallel with NAT stabilization (~50% faster on VPC+Lambda+CloudFront
-stacks; bench-cdk-sample 398s → 181s). Pass
-`cdkd deploy --no-aggressive-vpc-parallel` to opt out (e.g. when a
-Custom Resource synchronously invokes a VPC Lambda outside cdkd's
-Lambda-ServiceToken Active wait).
-
-See [docs/cli-reference.md](docs/cli-reference.md) for the full
-type-pair allowlist and trade-off notes.
-
 ## Local execution
 
 The `cdkd local` family runs AWS workloads on the developer's machine
@@ -582,6 +494,94 @@ Two `orphan` variants at different granularities:
 
 Both `cdkd destroy` (synth-driven) and `cdkd state destroy`
 (state-driven, no synth) delete AWS resources + state.
+
+## How it works
+
+```
+┌─────────────────┐
+│  Your CDK App   │  (aws-cdk-lib)
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ cdkd Synthesis  │  Subprocess + Cloud Assembly parser
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ CloudFormation  │
+│   Template      │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ cdkd Engine     │
+│ - DAG Analysis  │  Dependency graph construction
+│ - Diff Calc     │  Compare with existing resources
+│ - Parallel Exec │  Event-driven dispatch
+└────────┬────────┘
+         │
+    ┌────┴────┐
+    ▼         ▼
+┌────────┐ ┌────────┐
+│  SDK   │ │ Cloud  │
+│Provider│ │Control │  Fallback for many
+│        │ │  API   │  additional types
+└────────┘ └────────┘
+```
+
+For a step-by-step walkthrough of the full `cdkd deploy` pipeline (CLI
+parsing → synthesis → asset publishing → per-stack deploy), see
+[docs/architecture.md](docs/architecture.md#5-end-to-end-pipeline-walkthrough-cdkd-deploy).
+
+## `--no-wait`: skip async-resource waits
+
+CloudFront / RDS / ElastiCache / NAT Gateway typically take 1–15
+minutes to fully provision. By default cdkd waits (matching CFn).
+`cdkd deploy --no-wait` returns as soon as the create call returns
+and lets AWS finish in the background — handy for CI where nothing
+in the deploy flow needs the resource fully active. **Deploy-only**:
+`cdkd destroy` always waits (NAT in `deleting` state holds ENIs and
+would `DependencyViolation` sibling deletes).
+
+See [docs/cli-reference.md](docs/cli-reference.md#--no-wait-skip-async-resource-waits)
+for per-resource caveats (NAT egress, RDS final-snapshot timing,
+etc.).
+
+## VPC route DependsOn relaxation (on by default)
+
+CDK injects defensive `DependsOn` from VPC Lambdas onto private-subnet
+routes. The dependency is real at runtime but NOT required at deploy
+time. cdkd drops it by default so CloudFront + Lambda::Url propagation
+runs in parallel with NAT stabilization (~50% faster on VPC+Lambda+CloudFront
+stacks; bench-cdk-sample 398s → 181s). Pass
+`cdkd deploy --no-aggressive-vpc-parallel` to opt out (e.g. when a
+Custom Resource synchronously invokes a VPC Lambda outside cdkd's
+Lambda-ServiceToken Active wait).
+
+See [docs/cli-reference.md](docs/cli-reference.md) for the full
+type-pair allowlist and trade-off notes.
+
+## Rollback behavior
+
+When a deploy fails mid-stack (e.g. a resource hits a validation error
+or AWS rejects the request), cdkd by default **rolls back the
+already-completed resources in the same deploy** so the stack state
+stays consistent — every resource cdkd just created in this run is
+deleted in reverse dependency order, the state record is updated to
+match, and the CLI exits non-zero. Resources that existed before this
+deploy are NOT touched.
+
+Pass `cdkd deploy --no-rollback` to skip the rollback (Terraform-style:
+the partial state is preserved so you can `cdkd state show <stack>`,
+inspect what landed, fix the underlying issue, and re-run `cdkd deploy`
+to continue from the half-deployed state). Recommended only when you
+plan to manually inspect / repair; the default is safer for CI.
+
+Mid-deploy state is also saved per-resource as work completes, so even
+if cdkd itself crashes between the failure and the rollback, the state
+file accurately reflects what's on AWS and a follow-up `cdkd destroy`
+won't orphan anything.
 
 ## `--remove-protection`: one-shot bypass for protected resources
 


### PR DESCRIPTION
## Summary

PR #622 evolved from a pure reorder to **reorder + targeted trim** after user review surfaced additional length issues. (Memory rule normally says don't mix trim with reorder, but user iterating on the same PR makes split-PR overhead larger than the multi-axis-diff cost; opting in to the mix.)

Cumulative effect against `main`:

- **Net -139 LOC** (717 → 578)
- Single file: `README.md`
- 5 internal anchor links still resolve
- 22 `##` sections preserved (no section added or removed)

## What changed

### Section reorder (commits ed905a4 / 8a631b3 / 7771396)

The new top-to-bottom order:

1. **Benchmark** — 5.5x / 15x numbers above the fold (was below Features)
2. **Features** — top-of-doc impact summary
3. **How it works** — architecture diagram next to Features (was mid-doc; user-requested back to its main position)
4. Prerequisites → Installation → Quick Start → Usage — setup-path unchanged
5. Importing → Exporting → Drift detection → Orphan vs destroy — user-facing operations grouped together
6. **`--no-wait`** → **Local execution** → **Rollback behavior** → **VPC route DependsOn relaxation** — mid-doc deploy / command block in this exact order
7. `--remove-protection` / `publish-assets` — niche destroy / CI commands
8. **Compatibility** — moved DOWN from position 8 (right after Usage) to position 18 (between publish-assets and State Management). It sets expectations / limitations rather than describing a benefit; reads better as reference material here.
9. State Management / Stack Outputs / Exit codes / License — tail reference block

### Content trim (commit 7771396)

- **Usage section "cdkd local ..." bullet**: 33 lines → 5. Per-command detail (RIE, ECS metadata sidecar, replica orchestration, Cloud Map / Service Connect) deferred to the dedicated `## Local execution` section and `docs/local-emulation.md`.
- **Bash command-examples block**: 154 lines → ~36. Kept one canonical invocation per command; dropped heavily-commented variants. Pointer to `docs/cli-reference.md` added for the full flag matrix.

## Test plan

- [x] No content drift in the reorder phase (sorted-line diff returned empty after each reorder commit).
- [x] Trim phase deletes only deferred-to-docs content; every removed bullet has a doc home (`docs/local-emulation.md`, `docs/cli-reference.md`, `docs/import.md`).
- [x] All 5 internal `[text](#anchor)` links resolve.
- [x] `vp check --fix` / `vp run build` / `vp run test` pass (5672 tests, no src changes).
- [x] English-only.

## Out of scope

- Further structural changes — bring up in chat / future PR.
