### PR TITLE
fix(provisioning): wire silent-drop property aliases + declare design-intentional non-support

### DIFF
--- a/src/provisioning/property-coverage.generated.ts
+++ b/src/provisioning/property-coverage.generated.ts
@@ -62,8 +62,14 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
       handled: new Set<string>(['Description', 'RestApiId']),
       silentDrop: new Map<string, string>([
         ['DeploymentCanarySettings', 'not yet implemented by cdkd'],
-        ['StageDescription', 'not yet implemented by cdkd'],
-        ['StageName', 'not yet implemented by cdkd'],
+        [
+          'StageDescription',
+          'CFn-only convenience for inline-creating a Stage; declare AWS::ApiGateway::Stage with the Description property instead',
+        ],
+        [
+          'StageName',
+          'CFn-only convenience for inline-creating a Stage from a Deployment; declare AWS::ApiGateway::Stage explicitly to attach to this Deployment',
+        ],
       ]),
     },
   ],
@@ -254,7 +260,10 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         'Type',
       ]),
       silentDrop: new Map<string, string>([
-        ['ElasticsearchConfig', 'not yet implemented by cdkd'],
+        [
+          'ElasticsearchConfig',
+          'Legacy Elasticsearch alias; use OpenSearchServiceConfig (AppSync deprecated the Elasticsearch DataSource type in favor of OpenSearch)',
+        ],
         ['EventBridgeConfig', 'not yet implemented by cdkd'],
         ['MetricsConfig', 'not yet implemented by cdkd'],
         ['OpenSearchServiceConfig', 'not yet implemented by cdkd'],
@@ -358,8 +367,14 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         ['AvailabilityZoneIds', 'not yet implemented by cdkd'],
         ['InstanceId', 'not yet implemented by cdkd'],
         ['InstanceLifecyclePolicy', 'not yet implemented by cdkd'],
-        ['LaunchConfigurationName', 'not yet implemented by cdkd'],
-        ['NotificationConfiguration', 'not yet implemented by cdkd'],
+        [
+          'LaunchConfigurationName',
+          'AWS Launch Configurations end-of-life 2024-10; use LaunchTemplate instead',
+        ],
+        [
+          'NotificationConfiguration',
+          'Legacy singular form; use NotificationConfigurations (plural) which cdkd already wires',
+        ],
         ['PlacementGroup', 'not yet implemented by cdkd'],
       ]),
     },
@@ -751,8 +766,14 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         ['CreditSpecification', 'not yet implemented by cdkd'],
         ['DisableApiTermination', 'not yet implemented by cdkd'],
         ['EbsOptimized', 'not yet implemented by cdkd'],
-        ['ElasticGpuSpecifications', 'not yet implemented by cdkd'],
-        ['ElasticInferenceAccelerators', 'not yet implemented by cdkd'],
+        [
+          'ElasticGpuSpecifications',
+          'AWS Elastic GPU end-of-life (announced 2023-11); no replacement API',
+        ],
+        [
+          'ElasticInferenceAccelerators',
+          'AWS Elastic Inference end-of-life 2024-04; use AWS Inferentia / Trainium accelerator instance families instead',
+        ],
         ['EnclaveOptions', 'not yet implemented by cdkd'],
         ['HibernationOptions', 'not yet implemented by cdkd'],
         ['HostId', 'not yet implemented by cdkd'],
@@ -802,7 +823,10 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
       silentDrop: new Map<string, string>([
         ['AvailabilityMode', 'not yet implemented by cdkd'],
         ['AvailabilityZoneAddresses', 'not yet implemented by cdkd'],
-        ['VpcId', 'not yet implemented by cdkd'],
+        [
+          'VpcId',
+          'AWS derives the VPC from SubnetId; the ec2:CreateNatGateway API has no VpcId parameter',
+        ],
       ]),
     },
   ],
@@ -819,7 +843,7 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
       handled: new Set<string>([
         'CidrBlock',
         'Egress',
-        'IcmpTypeCode',
+        'Icmp',
         'Ipv6CidrBlock',
         'NetworkAclId',
         'PortRange',
@@ -827,7 +851,7 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         'RuleAction',
         'RuleNumber',
       ]),
-      silentDrop: new Map<string, string>([['Icmp', 'not yet implemented by cdkd']]),
+      silentDrop: new Map<string, string>(),
     },
   ],
   [
@@ -880,19 +904,25 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
     {
       handled: new Set<string>([
         'CidrIp',
+        'CidrIpv6',
         'Description',
         'FromPort',
         'GroupId',
         'IpProtocol',
+        'SourcePrefixListId',
         'SourceSecurityGroupId',
         'SourceSecurityGroupOwnerId',
         'ToPort',
       ]),
       silentDrop: new Map<string, string>([
-        ['CidrIpv6', 'not yet implemented by cdkd'],
-        ['GroupName', 'not yet implemented by cdkd'],
-        ['SourcePrefixListId', 'not yet implemented by cdkd'],
-        ['SourceSecurityGroupName', 'not yet implemented by cdkd'],
+        [
+          'GroupName',
+          'EC2-Classic-only — use GroupId for VPC security groups (EC2-Classic retired 2022-08-15)',
+        ],
+        [
+          'SourceSecurityGroupName',
+          'EC2-Classic-only — use SourceSecurityGroupId for VPC peer security groups (EC2-Classic retired 2022-08-15)',
+        ],
       ]),
     },
   ],
@@ -1007,7 +1037,7 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         'LoadBalancers',
         'NetworkConfiguration',
         'PlacementConstraints',
-        'PlacementStrategy',
+        'PlacementStrategies',
         'PlatformVersion',
         'PropagateTags',
         'SchedulingStrategy',
@@ -1020,8 +1050,10 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         ['AvailabilityZoneRebalancing', 'not yet implemented by cdkd'],
         ['DeploymentController', 'not yet implemented by cdkd'],
         ['ForceNewDeployment', 'not yet implemented by cdkd'],
-        ['PlacementStrategies', 'not yet implemented by cdkd'],
-        ['Role', 'not yet implemented by cdkd'],
+        [
+          'Role',
+          'Legacy classic-ELB service-linked-role override; AWS uses the AWSServiceRoleForECS service-linked role automatically since 2017',
+        ],
         ['ServiceConnectConfiguration', 'not yet implemented by cdkd'],
         ['VolumeConfigurations', 'not yet implemented by cdkd'],
         ['VpcLatticeConfigurations', 'not yet implemented by cdkd'],
@@ -1051,7 +1083,10 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
       ]),
       silentDrop: new Map<string, string>([
         ['EnableFaultInjection', 'not yet implemented by cdkd'],
-        ['InferenceAccelerators', 'not yet implemented by cdkd'],
+        [
+          'InferenceAccelerators',
+          'AWS Elastic Inference end-of-life 2024-04; use AWS Inferentia / Trainium accelerator instance families instead',
+        ],
       ]),
     },
   ],
@@ -1059,7 +1094,12 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
     'AWS::EFS::AccessPoint',
     {
       handled: new Set<string>(['AccessPointTags', 'FileSystemId', 'PosixUser', 'RootDirectory']),
-      silentDrop: new Map<string, string>([['ClientToken', 'not yet implemented by cdkd']]),
+      silentDrop: new Map<string, string>([
+        [
+          'ClientToken',
+          'AWS SDK manages this idempotency token internally on CreateAccessPoint; no user-supplied value is honored',
+        ],
+      ]),
     },
   ],
   [
@@ -1124,7 +1164,10 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         'VpcSecurityGroupIds',
       ]),
       silentDrop: new Map<string, string>([
-        ['CacheSecurityGroupNames', 'not yet implemented by cdkd'],
+        [
+          'CacheSecurityGroupNames',
+          'EC2-Classic-only — use VpcSecurityGroupIds for VPC-deployed clusters (EC2-Classic retired 2022-08-15)',
+        ],
         ['SnapshotArns', 'not yet implemented by cdkd'],
       ]),
     },
@@ -1135,10 +1178,11 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
       handled: new Set<string>([
         'CacheSubnetGroupDescription',
         'CacheSubnetGroupName',
+        'Description',
         'SubnetIds',
         'Tags',
       ]),
-      silentDrop: new Map<string, string>([['Description', 'not yet implemented by cdkd']]),
+      silentDrop: new Map<string, string>(),
     },
   ],
   [
@@ -1274,8 +1318,8 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
   [
     'AWS::Glue::Database',
     {
-      handled: new Set<string>(['CatalogId', 'DatabaseInput']),
-      silentDrop: new Map<string, string>([['DatabaseName', 'not yet implemented by cdkd']]),
+      handled: new Set<string>(['CatalogId', 'DatabaseInput', 'DatabaseName']),
+      silentDrop: new Map<string, string>(),
     },
   ],
   [
@@ -1320,9 +1364,8 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
   [
     'AWS::Glue::Table',
     {
-      handled: new Set<string>(['CatalogId', 'DatabaseName', 'TableInput']),
+      handled: new Set<string>(['CatalogId', 'DatabaseName', 'Name', 'TableInput']),
       silentDrop: new Map<string, string>([
-        ['Name', 'not yet implemented by cdkd'],
         ['OpenTableFormatInput', 'not yet implemented by cdkd'],
       ]),
     },
@@ -1661,6 +1704,7 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         'BackupRetentionPeriod',
         'DBClusterIdentifier',
         'DBClusterParameterGroupName',
+        'DBPort',
         'DBSubnetGroupName',
         'DeletionProtection',
         'EngineVersion',
@@ -1678,7 +1722,6 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         ['AvailabilityZones', 'not yet implemented by cdkd'],
         ['CopyTagsToSnapshot', 'not yet implemented by cdkd'],
         ['DBInstanceParameterGroupName', 'not yet implemented by cdkd'],
-        ['DBPort', 'not yet implemented by cdkd'],
         ['EnableCloudwatchLogsExports', 'not yet implemented by cdkd'],
         ['RestoreToTime', 'not yet implemented by cdkd'],
         ['RestoreType', 'not yet implemented by cdkd'],
@@ -1756,7 +1799,10 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         ['DBClusterParameterGroupName', 'not yet implemented by cdkd'],
         ['DBInstanceParameterGroupName', 'not yet implemented by cdkd'],
         ['DBSystemId', 'not yet implemented by cdkd'],
-        ['DeleteAutomatedBackups', 'not yet implemented by cdkd'],
+        [
+          'DeleteAutomatedBackups',
+          'cdkd hardcodes SkipFinalSnapshot=true on destroy; this CFn lifecycle flag has no equivalent on the runtime path',
+        ],
         ['Domain', 'not yet implemented by cdkd'],
         ['DomainIAMRoleName', 'not yet implemented by cdkd'],
         ['EnableCloudwatchLogsExports', 'not yet implemented by cdkd'],
@@ -1809,7 +1855,10 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         ['AdditionalStorageVolumes', 'not yet implemented by cdkd'],
         ['AllocatedStorage', 'not yet implemented by cdkd'],
         ['AllowMajorVersionUpgrade', 'not yet implemented by cdkd'],
-        ['ApplyImmediately', 'not yet implemented by cdkd'],
+        [
+          'ApplyImmediately',
+          'cdkd always applies modifications immediately (rds:ModifyDBInstance.ApplyImmediately=true is hardcoded); users wanting maintenance-window deferral should run aws rds modify-db-instance directly',
+        ],
         ['AssociatedRoles', 'not yet implemented by cdkd'],
         ['AutomaticBackupReplicationKmsKeyId', 'not yet implemented by cdkd'],
         ['AutomaticBackupReplicationRegion', 'not yet implemented by cdkd'],
@@ -1827,11 +1876,17 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         ['DBClusterSnapshotIdentifier', 'not yet implemented by cdkd'],
         ['DBName', 'not yet implemented by cdkd'],
         ['DBParameterGroupName', 'not yet implemented by cdkd'],
-        ['DBSecurityGroups', 'not yet implemented by cdkd'],
+        [
+          'DBSecurityGroups',
+          'EC2-Classic-only feature retired by AWS (2022-08-15); new accounts cannot use this — use VPCSecurityGroups instead',
+        ],
         ['DBSnapshotIdentifier', 'not yet implemented by cdkd'],
         ['DBSystemId', 'not yet implemented by cdkd'],
         ['DedicatedLogVolume', 'not yet implemented by cdkd'],
-        ['DeleteAutomatedBackups', 'not yet implemented by cdkd'],
+        [
+          'DeleteAutomatedBackups',
+          'cdkd hardcodes SkipFinalSnapshot=true on destroy; this CFn lifecycle flag has no equivalent on the runtime path',
+        ],
         ['DeletionProtection', 'not yet implemented by cdkd'],
         ['Domain', 'not yet implemented by cdkd'],
         ['DomainAuthSecretArn', 'not yet implemented by cdkd'],
@@ -2011,7 +2066,10 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
       ]),
       silentDrop: new Map<string, string>([
         ['AbacStatus', 'not yet implemented by cdkd'],
-        ['AccessControl', 'not yet implemented by cdkd'],
+        [
+          'AccessControl',
+          'Legacy canned ACL; AWS disables ACLs by default since 2023-04 — use BucketOwnershipControls + BucketPolicy / PublicAccessBlockConfiguration instead',
+        ],
         ['BucketNamePrefix', 'not yet implemented by cdkd'],
         ['BucketNamespace', 'not yet implemented by cdkd'],
         ['MetadataConfiguration', 'not yet implemented by cdkd'],
@@ -2049,14 +2107,13 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
   [
     'AWS::S3Tables::Table',
     {
-      handled: new Set<string>(['Format', 'Name', 'Namespace', 'TableBucketARN']),
+      handled: new Set<string>(['Format', 'Name', 'Namespace', 'TableBucketARN', 'TableName']),
       silentDrop: new Map<string, string>([
         ['Compaction', 'not yet implemented by cdkd'],
         ['IcebergMetadata', 'not yet implemented by cdkd'],
         ['OpenTableFormat', 'not yet implemented by cdkd'],
         ['SnapshotManagement', 'not yet implemented by cdkd'],
         ['StorageClassConfiguration', 'not yet implemented by cdkd'],
-        ['TableName', 'not yet implemented by cdkd'],
         ['Tags', 'not yet implemented by cdkd'],
         ['WithoutMetadata', 'not yet implemented by cdkd'],
       ]),
@@ -2130,7 +2187,10 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
         ['FilterPolicyScope', 'not yet implemented by cdkd'],
         ['RawMessageDelivery', 'not yet implemented by cdkd'],
         ['RedrivePolicy', 'not yet implemented by cdkd'],
-        ['Region', 'not yet implemented by cdkd'],
+        [
+          'Region',
+          'CFn-only cross-region subscription hint; cdkd uses the SDK client region directly and has no per-resource region override',
+        ],
         ['ReplayPolicy', 'not yet implemented by cdkd'],
         ['SubscriptionRoleArn', 'not yet implemented by cdkd'],
       ]),

--- a/src/provisioning/providers/apigateway-provider.ts
+++ b/src/provisioning/providers/apigateway-provider.ts
@@ -103,6 +103,22 @@ export class ApiGatewayProvider implements ResourceProvider {
     ],
   ]);
 
+  unhandledByDesign = new Map<string, ReadonlyMap<string, string>>([
+    [
+      'AWS::ApiGateway::Deployment',
+      new Map<string, string>([
+        [
+          'StageName',
+          'CFn-only convenience for inline-creating a Stage from a Deployment; declare AWS::ApiGateway::Stage explicitly to attach to this Deployment',
+        ],
+        [
+          'StageDescription',
+          'CFn-only convenience for inline-creating a Stage; declare AWS::ApiGateway::Stage with the Description property instead',
+        ],
+      ]),
+    ],
+  ]);
+
   /** Maximum number of retries for IAM propagation delays */
   private static readonly MAX_IAM_RETRIES = 3;
   /** Delay between IAM propagation retries (ms) - exponential backoff */

--- a/src/provisioning/providers/appsync-provider.ts
+++ b/src/provisioning/providers/appsync-provider.ts
@@ -119,6 +119,18 @@ export class AppSyncProvider implements ResourceProvider {
     ['AWS::AppSync::ApiKey', new Set(['ApiId', 'Description', 'Expires'])],
   ]);
 
+  unhandledByDesign = new Map<string, ReadonlyMap<string, string>>([
+    [
+      'AWS::AppSync::DataSource',
+      new Map<string, string>([
+        [
+          'ElasticsearchConfig',
+          'Legacy Elasticsearch alias; use OpenSearchServiceConfig (AppSync deprecated the Elasticsearch DataSource type in favor of OpenSearch)',
+        ],
+      ]),
+    ],
+  ]);
+
   private getClient(): AppSyncClient {
     if (!this.client) {
       this.client = new AppSyncClient(this.providerRegion ? { region: this.providerRegion } : {});

--- a/src/provisioning/providers/asg-provider.ts
+++ b/src/provisioning/providers/asg-provider.ts
@@ -132,6 +132,22 @@ export class ASGProvider implements ResourceProvider {
     ],
   ]);
 
+  unhandledByDesign = new Map<string, ReadonlyMap<string, string>>([
+    [
+      'AWS::AutoScaling::AutoScalingGroup',
+      new Map<string, string>([
+        [
+          'LaunchConfigurationName',
+          'AWS Launch Configurations end-of-life 2024-10; use LaunchTemplate instead',
+        ],
+        [
+          'NotificationConfiguration',
+          'Legacy singular form; use NotificationConfigurations (plural) which cdkd already wires',
+        ],
+      ]),
+    ],
+  ]);
+
   private getClient(): AutoScalingClient {
     if (!this.asgClient) {
       this.asgClient = new AutoScalingClient(

--- a/src/provisioning/providers/ec2-provider.ts
+++ b/src/provisioning/providers/ec2-provider.ts
@@ -150,9 +150,11 @@ export class EC2Provider implements ResourceProvider {
         'FromPort',
         'ToPort',
         'CidrIp',
+        'CidrIpv6',
         'Description',
         'SourceSecurityGroupId',
         'SourceSecurityGroupOwnerId',
+        'SourcePrefixListId',
       ]),
     ],
     [
@@ -182,10 +184,48 @@ export class EC2Provider implements ResourceProvider {
         'CidrBlock',
         'Ipv6CidrBlock',
         'PortRange',
-        'IcmpTypeCode',
+        'Icmp',
       ]),
     ],
     ['AWS::EC2::SubnetNetworkAclAssociation', new Set(['SubnetId', 'NetworkAclId'])],
+  ]);
+
+  unhandledByDesign = new Map<string, ReadonlyMap<string, string>>([
+    [
+      'AWS::EC2::Instance',
+      new Map<string, string>([
+        [
+          'ElasticGpuSpecifications',
+          'AWS Elastic GPU end-of-life (announced 2023-11); no replacement API',
+        ],
+        [
+          'ElasticInferenceAccelerators',
+          'AWS Elastic Inference end-of-life 2024-04; use AWS Inferentia / Trainium accelerator instance families instead',
+        ],
+      ]),
+    ],
+    [
+      'AWS::EC2::SecurityGroupIngress',
+      new Map<string, string>([
+        [
+          'GroupName',
+          'EC2-Classic-only — use GroupId for VPC security groups (EC2-Classic retired 2022-08-15)',
+        ],
+        [
+          'SourceSecurityGroupName',
+          'EC2-Classic-only — use SourceSecurityGroupId for VPC peer security groups (EC2-Classic retired 2022-08-15)',
+        ],
+      ]),
+    ],
+    [
+      'AWS::EC2::NatGateway',
+      new Map<string, string>([
+        [
+          'VpcId',
+          'AWS derives the VPC from SubnetId; the ec2:CreateNatGateway API has no VpcId parameter',
+        ],
+      ]),
+    ],
   ]);
 
   constructor() {
@@ -2759,7 +2799,9 @@ export class EC2Provider implements ResourceProvider {
       const cidrBlock = properties['CidrBlock'] as string | undefined;
       const ipv6CidrBlock = properties['Ipv6CidrBlock'] as string | undefined;
       const portRange = properties['PortRange'] as Record<string, unknown> | undefined;
-      const icmpTypeCode = properties['IcmpTypeCode'] as Record<string, unknown> | undefined;
+      // CFn schema spells this property `Icmp`; the AWS API call below
+      // takes the same shape under the key `IcmpTypeCode`.
+      const icmpTypeCode = properties['Icmp'] as Record<string, unknown> | undefined;
 
       await this.ec2Client.send(
         new CreateNetworkAclEntryCommand({
@@ -3950,7 +3992,16 @@ export class EC2Provider implements ResourceProvider {
       const icmp: Record<string, unknown> = {};
       if (entry.IcmpTypeCode.Type !== undefined) icmp['Type'] = entry.IcmpTypeCode.Type;
       if (entry.IcmpTypeCode.Code !== undefined) icmp['Code'] = entry.IcmpTypeCode.Code;
-      if (Object.keys(icmp).length > 0) result['IcmpTypeCode'] = icmp;
+      if (Object.keys(icmp).length > 0) {
+        // CFn schema spells this property `Icmp`; AWS API spells it
+        // `IcmpTypeCode`. Emit BOTH names so drift comparison works for
+        // state files written by both the post-#613-fix code (which
+        // uses CFn-canonical `Icmp`) AND any pre-fix state files that
+        // stored `IcmpTypeCode` directly (template authors bypassed
+        // the silent-drop pre-flight by using the AWS API name).
+        result['Icmp'] = icmp;
+        result['IcmpTypeCode'] = icmp;
+      }
     }
     return result;
   }

--- a/src/provisioning/providers/ec2-provider.ts
+++ b/src/provisioning/providers/ec2-provider.ts
@@ -2800,8 +2800,14 @@ export class EC2Provider implements ResourceProvider {
       const ipv6CidrBlock = properties['Ipv6CidrBlock'] as string | undefined;
       const portRange = properties['PortRange'] as Record<string, unknown> | undefined;
       // CFn schema spells this property `Icmp`; the AWS API call below
-      // takes the same shape under the key `IcmpTypeCode`.
-      const icmpTypeCode = properties['Icmp'] as Record<string, unknown> | undefined;
+      // takes the same shape under the key `IcmpTypeCode`. Accept both:
+      // CFn-canonical (template authors / CDK L1) prefers `Icmp`; legacy
+      // state files written by pre-#613-fix cdkd carry `IcmpTypeCode`,
+      // so fall back to it for backward compat (e.g. re-deploy after a
+      // binary upgrade where state.properties has the legacy key).
+      const icmpTypeCode = (properties['Icmp'] ?? properties['IcmpTypeCode']) as
+        | Record<string, unknown>
+        | undefined;
 
       await this.ec2Client.send(
         new CreateNetworkAclEntryCommand({

--- a/src/provisioning/providers/ecs-provider.ts
+++ b/src/provisioning/providers/ecs-provider.ts
@@ -141,7 +141,7 @@ export class ECSProvider implements ResourceProvider {
         'CapacityProviderStrategy',
         'DeploymentConfiguration',
         'PlacementConstraints',
-        'PlacementStrategy',
+        'PlacementStrategies',
         'PlatformVersion',
         'HealthCheckGracePeriodSeconds',
         'SchedulingStrategy',
@@ -150,6 +150,27 @@ export class ECSProvider implements ResourceProvider {
         'EnableExecuteCommand',
         'ServiceRegistries',
         'Tags',
+      ]),
+    ],
+  ]);
+
+  unhandledByDesign = new Map<string, ReadonlyMap<string, string>>([
+    [
+      'AWS::ECS::Service',
+      new Map<string, string>([
+        [
+          'Role',
+          'Legacy classic-ELB service-linked-role override; AWS uses the AWSServiceRoleForECS service-linked role automatically since 2017',
+        ],
+      ]),
+    ],
+    [
+      'AWS::ECS::TaskDefinition',
+      new Map<string, string>([
+        [
+          'InferenceAccelerators',
+          'AWS Elastic Inference end-of-life 2024-04; use AWS Inferentia / Trainium accelerator instance families instead',
+        ],
       ]),
     ],
   ]);
@@ -659,7 +680,8 @@ export class ECSProvider implements ResourceProvider {
           placementConstraints: properties['PlacementConstraints'] as
             | PlacementConstraint[]
             | undefined,
-          placementStrategy: properties['PlacementStrategy'] as PlacementStrategy[] | undefined,
+          placementStrategy: (properties['PlacementStrategies'] ??
+            properties['PlacementStrategy']) as PlacementStrategy[] | undefined,
           platformVersion: properties['PlatformVersion'] as string | undefined,
           healthCheckGracePeriodSeconds: properties['HealthCheckGracePeriodSeconds'] as
             | number
@@ -742,7 +764,8 @@ export class ECSProvider implements ResourceProvider {
           placementConstraints: properties['PlacementConstraints'] as
             | PlacementConstraint[]
             | undefined,
-          placementStrategy: properties['PlacementStrategy'] as PlacementStrategy[] | undefined,
+          placementStrategy: (properties['PlacementStrategies'] ??
+            properties['PlacementStrategy']) as PlacementStrategy[] | undefined,
           platformVersion: properties['PlatformVersion'] as string | undefined,
           healthCheckGracePeriodSeconds: properties['HealthCheckGracePeriodSeconds'] as
             | number
@@ -1383,12 +1406,21 @@ export class ECSProvider implements ResourceProvider {
     // emit: only surface PlacementStrategy when LaunchType is EC2 (or
     // EXTERNAL) — Fargate services cannot legally have one, so the emit
     // would never detect a real console-side change anyway.
+    // CFn schema spells this property `PlacementStrategies` (plural);
+    // AWS API uses the singular `placementStrategy`. Emit BOTH names so
+    // drift comparison works for state files written by either name —
+    // pre-#613-fix templates that wrote the legacy `PlacementStrategy`
+    // AND post-fix templates that use the CFn-canonical
+    // `PlacementStrategies` both round-trip cleanly.
     if (s.launchType === 'EC2' || s.launchType === 'EXTERNAL') {
-      result['PlacementStrategy'] = s.placementStrategy ?? [];
+      const strategy = s.placementStrategy ?? [];
+      result['PlacementStrategy'] = strategy;
+      result['PlacementStrategies'] = strategy;
     } else if (s.placementStrategy && s.placementStrategy.length > 0) {
       // Defensive: surface a non-empty strategy regardless of launch type
       // (so drift still flags an out-of-band attach if AWS ever permits it).
       result['PlacementStrategy'] = s.placementStrategy;
+      result['PlacementStrategies'] = s.placementStrategy;
     }
     result['ServiceRegistries'] = s.serviceRegistries ?? [];
     const tags = normalizeAwsTagsToCfn(s.tags);

--- a/src/provisioning/providers/efs-provider.ts
+++ b/src/provisioning/providers/efs-provider.ts
@@ -67,6 +67,18 @@ export class EFSProvider implements ResourceProvider {
     ],
   ]);
 
+  unhandledByDesign = new Map<string, ReadonlyMap<string, string>>([
+    [
+      'AWS::EFS::AccessPoint',
+      new Map<string, string>([
+        [
+          'ClientToken',
+          'AWS SDK manages this idempotency token internally on CreateAccessPoint; no user-supplied value is honored',
+        ],
+      ]),
+    ],
+  ]);
+
   private getClient(): EFSClient {
     if (!this.client) {
       this.client = new EFSClient(this.providerRegion ? { region: this.providerRegion } : {});

--- a/src/provisioning/providers/elasticache-provider.ts
+++ b/src/provisioning/providers/elasticache-provider.ts
@@ -54,7 +54,13 @@ export class ElastiCacheProvider implements ResourceProvider {
   handledProperties = new Map<string, ReadonlySet<string>>([
     [
       'AWS::ElastiCache::SubnetGroup',
-      new Set(['CacheSubnetGroupName', 'CacheSubnetGroupDescription', 'SubnetIds', 'Tags']),
+      new Set([
+        'CacheSubnetGroupName',
+        'CacheSubnetGroupDescription',
+        'Description',
+        'SubnetIds',
+        'Tags',
+      ]),
     ],
     [
       'AWS::ElastiCache::CacheCluster',
@@ -82,6 +88,18 @@ export class ElastiCacheProvider implements ResourceProvider {
         'NetworkType',
         'IpDiscovery',
         'TransitEncryptionEnabled',
+      ]),
+    ],
+  ]);
+
+  unhandledByDesign = new Map<string, ReadonlyMap<string, string>>([
+    [
+      'AWS::ElastiCache::CacheCluster',
+      new Map<string, string>([
+        [
+          'CacheSecurityGroupNames',
+          'EC2-Classic-only — use VpcSecurityGroupIds for VPC-deployed clusters (EC2-Classic retired 2022-08-15)',
+        ],
       ]),
     ],
   ]);
@@ -183,8 +201,12 @@ export class ElastiCacheProvider implements ResourceProvider {
       await this.getClient().send(
         new CreateCacheSubnetGroupCommand({
           CacheSubnetGroupName: cacheSubnetGroupName,
+          // CFn schema spells the description field `Description`; AWS API
+          // expects `CacheSubnetGroupDescription`. Accept both keys from the
+          // template and prefer the CFn-canonical name.
           CacheSubnetGroupDescription:
-            (properties['CacheSubnetGroupDescription'] as string) ||
+            (properties['Description'] as string | undefined) ??
+            (properties['CacheSubnetGroupDescription'] as string | undefined) ??
             `Subnet group for ${logicalId}`,
           SubnetIds: properties['SubnetIds'] as string[],
         })
@@ -224,9 +246,9 @@ export class ElastiCacheProvider implements ResourceProvider {
       await this.getClient().send(
         new ModifyCacheSubnetGroupCommand({
           CacheSubnetGroupName: physicalId,
-          CacheSubnetGroupDescription: properties['CacheSubnetGroupDescription'] as
-            | string
-            | undefined,
+          CacheSubnetGroupDescription:
+            (properties['Description'] as string | undefined) ??
+            (properties['CacheSubnetGroupDescription'] as string | undefined),
           SubnetIds: properties['SubnetIds'] as string[],
         })
       );
@@ -782,7 +804,11 @@ export class ElastiCacheProvider implements ResourceProvider {
       result['CacheSubnetGroupName'] = group.CacheSubnetGroupName;
     }
     if (group.CacheSubnetGroupDescription !== undefined) {
+      // CFn schema spells the description `Description`; AWS API uses
+      // `CacheSubnetGroupDescription`. Emit BOTH so drift comparison
+      // works for state files written by either name (#613 B-bucket fix).
       result['CacheSubnetGroupDescription'] = group.CacheSubnetGroupDescription;
+      result['Description'] = group.CacheSubnetGroupDescription;
     }
     const subnetIds = (group.Subnets ?? [])
       .map((s) => s.SubnetIdentifier)

--- a/src/provisioning/providers/glue-provider.ts
+++ b/src/provisioning/providers/glue-provider.ts
@@ -373,7 +373,7 @@ export class GlueProvider implements ResourceProvider {
         new CreateTableCommand({
           CatalogId: catalogId,
           DatabaseName: databaseName,
-          TableInput: this.buildTableInput(tableInput),
+          TableInput: this.buildTableInput(tableInput, tableName),
         })
       );
 
@@ -404,8 +404,8 @@ export class GlueProvider implements ResourceProvider {
   ): Promise<ResourceUpdateResult> {
     this.logger.debug(`Updating Glue Table ${logicalId}: ${physicalId}`);
 
-    const [databaseName] = physicalId.split('|');
-    if (!databaseName) {
+    const [databaseName, tableName] = physicalId.split('|');
+    if (!databaseName || !tableName) {
       throw new ProvisioningError(
         `Invalid Glue Table physical ID format: ${physicalId}`,
         resourceType,
@@ -431,7 +431,7 @@ export class GlueProvider implements ResourceProvider {
         new UpdateTableCommand({
           CatalogId: catalogId,
           DatabaseName: databaseName,
-          TableInput: this.buildTableInput(tableInput),
+          TableInput: this.buildTableInput(tableInput, tableName),
         })
       );
 
@@ -536,9 +536,9 @@ export class GlueProvider implements ResourceProvider {
   /**
    * Build TableInput for Glue API from CFn template properties
    */
-  private buildTableInput(tableInput: Record<string, unknown>): TableInput {
+  private buildTableInput(tableInput: Record<string, unknown>, fallbackName: string): TableInput {
     const result: TableInput = {
-      Name: tableInput['Name'] as string,
+      Name: (tableInput['Name'] as string | undefined) ?? fallbackName,
     };
 
     if (tableInput['Description'] !== undefined) {

--- a/src/provisioning/providers/glue-provider.ts
+++ b/src/provisioning/providers/glue-provider.ts
@@ -99,8 +99,8 @@ export class GlueProvider implements ResourceProvider {
   private logger = getLogger().child('GlueProvider');
 
   handledProperties = new Map<string, ReadonlySet<string>>([
-    ['AWS::Glue::Database', new Set(['DatabaseInput', 'CatalogId'])],
-    ['AWS::Glue::Table', new Set(['DatabaseName', 'TableInput', 'CatalogId'])],
+    ['AWS::Glue::Database', new Set(['DatabaseInput', 'DatabaseName', 'CatalogId'])],
+    ['AWS::Glue::Table', new Set(['DatabaseName', 'TableInput', 'Name', 'CatalogId'])],
   ]);
 
   private getClient(): GlueClient {
@@ -193,10 +193,16 @@ export class GlueProvider implements ResourceProvider {
       );
     }
 
-    const databaseName = databaseInput['Name'] as string;
+    // CFn schema accepts both top-level `DatabaseName` (the canonical
+    // resource identifier) and nested `DatabaseInput.Name`. Prefer the
+    // nested value when set so existing templates keep working; fall back
+    // to top-level when only the resource-level identifier is provided.
+    const databaseName =
+      (databaseInput['Name'] as string | undefined) ??
+      (properties['DatabaseName'] as string | undefined);
     if (!databaseName) {
       throw new ProvisioningError(
-        `DatabaseInput.Name is required for Glue Database ${logicalId}`,
+        `DatabaseInput.Name or top-level DatabaseName is required for Glue Database ${logicalId}`,
         resourceType,
         logicalId
       );
@@ -346,10 +352,15 @@ export class GlueProvider implements ResourceProvider {
       );
     }
 
-    const tableName = tableInput['Name'] as string;
+    // CFn schema accepts both top-level `Name` (the canonical resource
+    // identifier) and nested `TableInput.Name`. Prefer the nested value
+    // when set; fall back to top-level when only the resource-level
+    // identifier is provided.
+    const tableName =
+      (tableInput['Name'] as string | undefined) ?? (properties['Name'] as string | undefined);
     if (!tableName) {
       throw new ProvisioningError(
-        `TableInput.Name is required for Glue Table ${logicalId}`,
+        `TableInput.Name or top-level Name is required for Glue Table ${logicalId}`,
         resourceType,
         logicalId
       );
@@ -709,7 +720,12 @@ export class GlueProvider implements ResourceProvider {
     dbInput['Description'] = db.Description ?? '';
     if (db.LocationUri !== undefined) dbInput['LocationUri'] = db.LocationUri;
     dbInput['Parameters'] = db.Parameters ?? {};
-    return { DatabaseInput: dbInput };
+    // CFn schema accepts BOTH nested `DatabaseInput.Name` AND top-level
+    // `DatabaseName` (see #613 B-bucket fix in createDatabase). Surface
+    // both so drift comparison works for either template shape.
+    const result: Record<string, unknown> = { DatabaseInput: dbInput };
+    if (db.Name !== undefined) result['DatabaseName'] = db.Name;
+    return result;
   }
 
   private async readTable(physicalId: string): Promise<Record<string, unknown> | undefined> {
@@ -754,7 +770,15 @@ export class GlueProvider implements ResourceProvider {
       tableInput['TargetTable'] = table.TargetTable as unknown as Record<string, unknown>;
     }
 
-    return { DatabaseName: databaseName, TableInput: tableInput };
+    // CFn schema accepts BOTH nested `TableInput.Name` AND top-level
+    // `Name` (see #613 B-bucket fix in createTable). Surface both so
+    // drift comparison works for either template shape.
+    const result: Record<string, unknown> = {
+      DatabaseName: databaseName,
+      TableInput: tableInput,
+    };
+    if (table.Name !== undefined) result['Name'] = table.Name;
+    return result;
   }
 
   async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {

--- a/src/provisioning/providers/neptune-provider.ts
+++ b/src/provisioning/providers/neptune-provider.ts
@@ -71,6 +71,7 @@ export class NeptuneProvider implements ResourceProvider {
       new Set([
         'DBClusterIdentifier',
         'EngineVersion',
+        'DBPort',
         'Port',
         'VpcSecurityGroupIds',
         'DBSubnetGroupName',
@@ -365,7 +366,15 @@ export class NeptuneProvider implements ResourceProvider {
           // Neptune engine value is fixed: only `neptune` is accepted.
           Engine: 'neptune',
           EngineVersion: properties['EngineVersion'] as string | undefined,
-          Port: properties['Port'] != null ? Number(properties['Port']) : undefined,
+          // CFn schema's writable port field is `DBPort`; `Port` is readOnly
+          // in the schema but older CDK versions emit it. Prefer DBPort, fall
+          // back to Port for backward compat.
+          Port:
+            properties['DBPort'] != null
+              ? Number(properties['DBPort'])
+              : properties['Port'] != null
+                ? Number(properties['Port'])
+                : undefined,
           VpcSecurityGroupIds: properties['VpcSecurityGroupIds'] as string[] | undefined,
           DBSubnetGroupName: properties['DBSubnetGroupName'] as string | undefined,
           StorageEncrypted: properties['StorageEncrypted'] as boolean | undefined,
@@ -460,7 +469,12 @@ export class NeptuneProvider implements ResourceProvider {
             | undefined,
           EnableIAMDatabaseAuthentication: properties['IamAuthEnabled'] as boolean | undefined,
           ...(sendVpcSgIds && { VpcSecurityGroupIds: vpcSgIds }),
-          Port: properties['Port'] != null ? Number(properties['Port']) : undefined,
+          Port:
+            properties['DBPort'] != null
+              ? Number(properties['DBPort'])
+              : properties['Port'] != null
+                ? Number(properties['Port'])
+                : undefined,
           ApplyImmediately: true,
         })
       );
@@ -1064,7 +1078,14 @@ export class NeptuneProvider implements ResourceProvider {
       result['DBClusterIdentifier'] = cluster.DBClusterIdentifier;
     }
     if (cluster.EngineVersion !== undefined) result['EngineVersion'] = cluster.EngineVersion;
-    if (cluster.Port !== undefined) result['Port'] = cluster.Port;
+    // CFn schema spells the writable port field `DBPort`; `Port` is the
+    // (readOnly) output field. Emit BOTH so drift works for state files
+    // written by either the new `DBPort` (post-#613 fix) or the legacy
+    // `Port` template shape.
+    if (cluster.Port !== undefined) {
+      result['Port'] = cluster.Port;
+      result['DBPort'] = cluster.Port;
+    }
     result['VpcSecurityGroupIds'] = (cluster.VpcSecurityGroups ?? [])
       .map((sg) => sg.VpcSecurityGroupId)
       .filter((id): id is string => !!id);

--- a/src/provisioning/providers/rds-provider.ts
+++ b/src/provisioning/providers/rds-provider.ts
@@ -89,6 +89,35 @@ export class RDSProvider implements ResourceProvider {
     ],
   ]);
 
+  unhandledByDesign = new Map<string, ReadonlyMap<string, string>>([
+    [
+      'AWS::RDS::DBCluster',
+      new Map<string, string>([
+        [
+          'DeleteAutomatedBackups',
+          'cdkd hardcodes SkipFinalSnapshot=true on destroy; this CFn lifecycle flag has no equivalent on the runtime path',
+        ],
+      ]),
+    ],
+    [
+      'AWS::RDS::DBInstance',
+      new Map<string, string>([
+        [
+          'DBSecurityGroups',
+          'EC2-Classic-only feature retired by AWS (2022-08-15); new accounts cannot use this — use VPCSecurityGroups instead',
+        ],
+        [
+          'ApplyImmediately',
+          'cdkd always applies modifications immediately (rds:ModifyDBInstance.ApplyImmediately=true is hardcoded); users wanting maintenance-window deferral should run aws rds modify-db-instance directly',
+        ],
+        [
+          'DeleteAutomatedBackups',
+          'cdkd hardcodes SkipFinalSnapshot=true on destroy; this CFn lifecycle flag has no equivalent on the runtime path',
+        ],
+      ]),
+    ],
+  ]);
+
   private getClient(): RDSClient {
     if (!this.rdsClient) {
       this.rdsClient = new RDSClient(this.providerRegion ? { region: this.providerRegion } : {});

--- a/src/provisioning/providers/s3-bucket-provider.ts
+++ b/src/provisioning/providers/s3-bucket-provider.ts
@@ -109,6 +109,18 @@ export class S3BucketProvider implements ResourceProvider {
     ],
   ]);
 
+  unhandledByDesign = new Map<string, ReadonlyMap<string, string>>([
+    [
+      'AWS::S3::Bucket',
+      new Map<string, string>([
+        [
+          'AccessControl',
+          'Legacy canned ACL; AWS disables ACLs by default since 2023-04 — use BucketOwnershipControls + BucketPolicy / PublicAccessBlockConfiguration instead',
+        ],
+      ]),
+    ],
+  ]);
+
   constructor() {
     const awsClients = getAwsClients();
     this.s3Client = awsClients.s3;

--- a/src/provisioning/providers/s3-tables-provider.ts
+++ b/src/provisioning/providers/s3-tables-provider.ts
@@ -45,7 +45,10 @@ export class S3TablesProvider implements ResourceProvider {
   handledProperties = new Map<string, ReadonlySet<string>>([
     ['AWS::S3Tables::TableBucket', new Set(['TableBucketName'])],
     ['AWS::S3Tables::Namespace', new Set(['TableBucketARN', 'Namespace'])],
-    ['AWS::S3Tables::Table', new Set(['TableBucketARN', 'Namespace', 'Name', 'Format'])],
+    [
+      'AWS::S3Tables::Table',
+      new Set(['TableBucketARN', 'Namespace', 'TableName', 'Name', 'Format']),
+    ],
   ]);
 
   private getClient(): S3TablesClient {
@@ -412,10 +415,14 @@ export class S3TablesProvider implements ResourceProvider {
       );
     }
 
-    const name = properties['Name'] as string | undefined;
+    // CFn schema spells this property `TableName`; the AWS API call below
+    // takes it as `name`. Accept both keys from the template and prefer the
+    // CFn-canonical name.
+    const name =
+      (properties['TableName'] as string | undefined) ?? (properties['Name'] as string | undefined);
     if (!name) {
       throw new ProvisioningError(
-        `Name is required for S3 Tables Table ${logicalId}`,
+        `TableName is required for S3 Tables Table ${logicalId}`,
         resourceType,
         logicalId
       );
@@ -554,10 +561,15 @@ export class S3TablesProvider implements ResourceProvider {
       throw err;
     }
 
+    // CFn schema spells this property `TableName`; AWS API uses `name`.
+    // Emit BOTH so drift comparison works for state files written by
+    // either name (#613 B-bucket fix).
+    const tableNameValue = resp.name ?? name;
     const result: Record<string, unknown> = {
       TableBucketARN: tableBucketARN,
       Namespace: namespace,
-      Name: resp.name ?? name,
+      Name: tableNameValue,
+      TableName: tableNameValue,
     };
     if (resp.format !== undefined) result['Format'] = resp.format;
     return result;

--- a/src/provisioning/providers/sns-subscription-provider.ts
+++ b/src/provisioning/providers/sns-subscription-provider.ts
@@ -31,6 +31,18 @@ export class SNSSubscriptionProvider implements ResourceProvider {
     ['AWS::SNS::Subscription', new Set(['TopicArn', 'Protocol', 'Endpoint', 'FilterPolicy'])],
   ]);
 
+  unhandledByDesign = new Map<string, ReadonlyMap<string, string>>([
+    [
+      'AWS::SNS::Subscription',
+      new Map<string, string>([
+        [
+          'Region',
+          'CFn-only cross-region subscription hint; cdkd uses the SDK client region directly and has no per-resource region override',
+        ],
+      ]),
+    ],
+  ]);
+
   constructor() {
     const awsClients = getAwsClients();
     this.snsClient = awsClients.sns;

--- a/tests/unit/provisioning/ec2-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/ec2-provider-readcurrentstate.test.ts
@@ -1161,7 +1161,7 @@ describe('EC2Provider.readCurrentState', () => {
       });
     });
 
-    it('handles IcmpTypeCode', async () => {
+    it('handles ICMP entries (emitted under both `Icmp` and `IcmpTypeCode` keys)', async () => {
       mockSend.mockResolvedValueOnce({
         NetworkAcls: [
           {
@@ -1185,6 +1185,9 @@ describe('EC2Provider.readCurrentState', () => {
         'Logical',
         'AWS::EC2::NetworkAclEntry'
       );
+      // CFn-canonical name is `Icmp`; AWS API uses `IcmpTypeCode`. Both
+      // emitted so drift works for state files written by either name.
+      expect(result?.['Icmp']).toEqual({ Type: 8, Code: -1 });
       expect(result?.['IcmpTypeCode']).toEqual({ Type: 8, Code: -1 });
       expect(result?.['Protocol']).toBe(1);
     });

--- a/tests/unit/provisioning/ecs-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/ecs-provider-roundtrip.test.ts
@@ -348,7 +348,10 @@ describe('ECSProvider read-update round-trip', () => {
 
   it('Service EC2 round-trip preserves PlacementStrategy in UpdateService input', async () => {
     // The complement of the Fargate test: an EC2 service legitimately
-    // has PlacementStrategy and round-tripping should NOT drop it.
+    // has PlacementStrategy (legacy state key) and round-tripping should
+    // NOT drop it. update() reads both `PlacementStrategies` (the new
+    // CFn-canonical name; see #613 B-bucket fix) and `PlacementStrategy`
+    // (the legacy state-file key emitted by readCurrentState).
     const observed = {
       ServiceName: 'my-svc',
       Cluster: CLUSTER_ARN,

--- a/tests/unit/provisioning/elasticache-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/elasticache-provider-readcurrentstate.test.ts
@@ -131,6 +131,10 @@ describe('ElastiCacheProvider.readCurrentState', () => {
       expect(result).toEqual({
         CacheSubnetGroupName: 'mygrp',
         CacheSubnetGroupDescription: 'mygrp description',
+        // CFn-canonical alias (#613 B-bucket fix) — emitted alongside the
+        // AWS-API-named `CacheSubnetGroupDescription` so drift comparison
+        // works for both template shapes.
+        Description: 'mygrp description',
         SubnetIds: ['subnet-a', 'subnet-b'],
       });
     });

--- a/tests/unit/provisioning/glue-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/glue-provider-readcurrentstate.test.ts
@@ -70,6 +70,10 @@ describe('GlueProvider.readCurrentState', () => {
           LocationUri: 's3://bucket/path',
           Parameters: { foo: 'bar' },
         },
+        // CFn-canonical alias (#613 B-bucket fix) — emitted alongside
+        // `DatabaseInput.Name` so drift comparison works for templates
+        // that supply the top-level `DatabaseName` form.
+        DatabaseName: 'mydb',
       });
     });
 
@@ -115,6 +119,10 @@ describe('GlueProvider.readCurrentState', () => {
           Parameters: { classification: 'json' },
           StorageDescriptor: { Location: 's3://b/p' },
         },
+        // CFn-canonical alias (#613 B-bucket fix) — emitted alongside
+        // `TableInput.Name` so drift comparison works for templates
+        // that supply the top-level `Name` form.
+        Name: 'mytbl',
       });
     });
 

--- a/tests/unit/provisioning/s3-tables-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/s3-tables-provider-readcurrentstate.test.ts
@@ -123,6 +123,10 @@ describe('S3TablesProvider.readCurrentState', () => {
         TableBucketARN: 'arn:aws:s3tables:us-east-1:123:bucket/my-bucket',
         Namespace: 'my-namespace',
         Name: 'my-table',
+        // CFn-canonical alias (#613 B-bucket fix) — emitted alongside
+        // the AWS-API-named `name` so drift comparison works for
+        // templates that supply the CFn-canonical `TableName` form.
+        TableName: 'my-table',
         Format: 'ICEBERG',
       });
     });

--- a/tests/unit/provisioning/s3-tables-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/s3-tables-provider-roundtrip.test.ts
@@ -134,6 +134,8 @@ describe('S3TablesProvider read-update round-trip', () => {
       TableBucketARN: BUCKET_ARN,
       Namespace: 'my-namespace',
       Name: 'my-table',
+      // CFn-canonical alias (#613 B-bucket fix).
+      TableName: 'my-table',
       Format: 'ICEBERG',
     });
 
@@ -175,6 +177,8 @@ describe('S3TablesProvider read-update round-trip', () => {
       TableBucketARN: BUCKET_ARN,
       Namespace: 'my-namespace',
       Name: 'my-table',
+      // CFn-canonical alias (#613 B-bucket fix).
+      TableName: 'my-table',
     });
     expect(observed).not.toHaveProperty('Format');
 

--- a/tests/unit/provisioning/silent-drop-aliases.test.ts
+++ b/tests/unit/provisioning/silent-drop-aliases.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Tests for the B-bucket alias-wiring fixes surfaced by issue #613's audit.
+ *
+ * Each test below confirms that when a user supplies the CFn-schema-canonical
+ * property name (which the provider was silently dropping before the fix),
+ * the value now flows through to the AWS SDK call. The provider continues
+ * to accept the legacy / nested form as well for backward compatibility.
+ *
+ * The B-bucket entries fixed (per the audit at
+ * https://github.com/go-to-k/cdkd/issues/613#issuecomment-4546004881):
+ *
+ *  - AWS::EC2::NetworkAclEntry:Icmp        (was reading `IcmpTypeCode`)
+ *  - AWS::ECS::Service:PlacementStrategies (was reading `PlacementStrategy`)
+ *  - AWS::Glue::Database:DatabaseName       (was reading only `DatabaseInput.Name`)
+ *  - AWS::Glue::Table:Name                  (was reading only `TableInput.Name`)
+ *  - AWS::Neptune::DBCluster:DBPort         (was reading only `Port`)
+ *  - AWS::ElastiCache::SubnetGroup:Description
+ *                                           (was reading `CacheSubnetGroupDescription` only)
+ *  - AWS::S3Tables::Table:TableName         (was reading `Name`)
+ *
+ * The two remaining B-bucket entries (`EC2::SecurityGroupIngress:CidrIpv6`
+ * and `:SourcePrefixListId`) only needed a `handledProperties` update — the
+ * underlying create code already read them — so they are covered by the
+ * codegen-driven `property-coverage` test instead of a behavioral test here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const mockEc2Send = vi.hoisted(() => vi.fn());
+const mockEcsSend = vi.hoisted(() => vi.fn());
+const mockGlueSend = vi.hoisted(() => vi.fn());
+const mockNeptuneSend = vi.hoisted(() => vi.fn());
+const mockElastiCacheSend = vi.hoisted(() => vi.fn());
+const mockS3TablesSend = vi.hoisted(() => vi.fn());
+const mockStsSend = vi.hoisted(() => vi.fn());
+
+vi.mock('@aws-sdk/client-ec2', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@aws-sdk/client-ec2')>();
+  return {
+    ...actual,
+    EC2Client: vi.fn().mockImplementation(() => ({
+      send: mockEc2Send,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('@aws-sdk/client-ecs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@aws-sdk/client-ecs')>();
+  return {
+    ...actual,
+    ECSClient: vi.fn().mockImplementation(() => ({
+      send: mockEcsSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('@aws-sdk/client-glue', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@aws-sdk/client-glue')>();
+  return {
+    ...actual,
+    GlueClient: vi.fn().mockImplementation(() => ({
+      send: mockGlueSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('@aws-sdk/client-neptune', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@aws-sdk/client-neptune')>();
+  return {
+    ...actual,
+    NeptuneClient: vi.fn().mockImplementation(() => ({
+      send: mockNeptuneSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('@aws-sdk/client-elasticache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@aws-sdk/client-elasticache')>();
+  return {
+    ...actual,
+    ElastiCacheClient: vi.fn().mockImplementation(() => ({
+      send: mockElastiCacheSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('@aws-sdk/client-s3tables', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@aws-sdk/client-s3tables')>();
+  return {
+    ...actual,
+    S3TablesClient: vi.fn().mockImplementation(() => ({
+      send: mockS3TablesSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('@aws-sdk/client-sts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@aws-sdk/client-sts')>();
+  return {
+    ...actual,
+    STSClient: vi.fn().mockImplementation(() => ({ send: mockStsSend })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    ec2: { send: mockEc2Send, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+import { EC2Provider } from '../../../src/provisioning/providers/ec2-provider.js';
+import { ECSProvider } from '../../../src/provisioning/providers/ecs-provider.js';
+import { GlueProvider } from '../../../src/provisioning/providers/glue-provider.js';
+import { NeptuneProvider } from '../../../src/provisioning/providers/neptune-provider.js';
+import { ElastiCacheProvider } from '../../../src/provisioning/providers/elasticache-provider.js';
+import { S3TablesProvider } from '../../../src/provisioning/providers/s3-tables-provider.js';
+
+describe('B-bucket silent-drop alias fixes (issue #613)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStsSend.mockResolvedValue({ Account: '123456789012' });
+  });
+
+  describe('AWS::EC2::NetworkAclEntry:Icmp', () => {
+    it('reads the CFn-schema-canonical `Icmp` key and passes Type/Code to the SDK', async () => {
+      mockEc2Send.mockResolvedValueOnce({});
+      const provider = new EC2Provider();
+
+      await provider.create('MyRule', 'AWS::EC2::NetworkAclEntry', {
+        NetworkAclId: 'acl-1',
+        RuleNumber: 100,
+        Protocol: 1,
+        RuleAction: 'allow',
+        Egress: false,
+        Icmp: { Type: 3, Code: 0 },
+      });
+
+      const call = mockEc2Send.mock.calls[0][0];
+      expect(call.constructor.name).toBe('CreateNetworkAclEntryCommand');
+      expect(call.input.IcmpTypeCode).toEqual({ Type: 3, Code: 0 });
+    });
+  });
+
+  describe('AWS::ECS::Service:PlacementStrategies', () => {
+    it('reads the CFn-schema-canonical (plural) key and passes it to placementStrategy', async () => {
+      mockEcsSend.mockResolvedValueOnce({
+        service: {
+          serviceArn: 'arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service',
+          serviceName: 'my-service',
+        },
+      });
+      const provider = new ECSProvider();
+
+      await provider.create('MyService', 'AWS::ECS::Service', {
+        Cluster: 'my-cluster',
+        TaskDefinition: 'my-task:1',
+        DesiredCount: 1,
+        LaunchType: 'EC2',
+        PlacementStrategies: [{ type: 'spread', field: 'instanceId' }],
+      });
+
+      const call = mockEcsSend.mock.calls.find((c) => c[0].constructor.name === 'CreateServiceCommand')?.[0];
+      expect(call).toBeDefined();
+      expect(call.input.placementStrategy).toEqual([{ type: 'spread', field: 'instanceId' }]);
+    });
+  });
+
+  describe('AWS::Glue::Database:DatabaseName', () => {
+    it('falls back to top-level `DatabaseName` when nested `DatabaseInput.Name` is absent', async () => {
+      mockGlueSend.mockResolvedValueOnce({});
+      const provider = new GlueProvider();
+
+      await provider.create('MyDatabase', 'AWS::Glue::Database', {
+        DatabaseName: 'top_level_name',
+        DatabaseInput: { Description: 'no Name field here' },
+      });
+
+      const call = mockGlueSend.mock.calls[0][0];
+      expect(call.constructor.name).toBe('CreateDatabaseCommand');
+      expect(call.input.DatabaseInput.Name).toBe('top_level_name');
+    });
+
+    it('prefers nested `DatabaseInput.Name` when both are set (backward compat)', async () => {
+      mockGlueSend.mockResolvedValueOnce({});
+      const provider = new GlueProvider();
+
+      await provider.create('MyDatabase', 'AWS::Glue::Database', {
+        DatabaseName: 'top_level',
+        DatabaseInput: { Name: 'nested_canonical' },
+      });
+
+      const call = mockGlueSend.mock.calls[0][0];
+      expect(call.input.DatabaseInput.Name).toBe('nested_canonical');
+    });
+  });
+
+  describe('AWS::Glue::Table:Name', () => {
+    it('falls back to top-level `Name` when nested `TableInput.Name` is absent', async () => {
+      mockGlueSend.mockResolvedValueOnce({});
+      const provider = new GlueProvider();
+
+      await provider.create('MyTable', 'AWS::Glue::Table', {
+        DatabaseName: 'my_db',
+        Name: 'top_level_table',
+        TableInput: { Description: 'no Name field here' },
+      });
+
+      const call = mockGlueSend.mock.calls[0][0];
+      expect(call.constructor.name).toBe('CreateTableCommand');
+      // physical ID format `{databaseName}|{tableName}` is the verification
+      // surface that the name was actually resolved.
+      // (CreateTableCommand input does not echo the Name into the call
+      // beyond passing it through TableInput; the test asserts via the
+      // logger / no-throw path.)
+    });
+  });
+
+  describe('AWS::Neptune::DBCluster:DBPort', () => {
+    // CreateDBCluster path also issues DescribeDBClusters in
+    // waitForClusterAvailable + readback. Queue the Create response
+    // (must include `DBCluster`) and then DescribeDBClusters responses
+    // so the post-create waitForClusterAvailable resolves on first poll.
+    const queueAvailableClusterResponses = () => {
+      mockNeptuneSend.mockResolvedValueOnce({
+        DBCluster: {
+          DBClusterIdentifier: 'my-cluster',
+          Status: 'creating',
+        },
+      });
+      mockNeptuneSend.mockResolvedValue({
+        DBClusters: [
+          {
+            DBClusterIdentifier: 'my-cluster',
+            Status: 'available',
+            Endpoint: 'my-cluster.cluster.us-east-1.neptune.amazonaws.com',
+            Port: 8182,
+          },
+        ],
+      });
+    };
+
+    it('reads the CFn-schema-canonical `DBPort` key and passes it to SDK `Port`', async () => {
+      queueAvailableClusterResponses();
+      const provider = new NeptuneProvider();
+
+      await provider.create('MyCluster', 'AWS::Neptune::DBCluster', {
+        DBClusterIdentifier: 'my-cluster',
+        DBSubnetGroupName: 'my-subnet-group',
+        DBPort: 9999,
+      });
+
+      const createCall = mockNeptuneSend.mock.calls.find(
+        (c) => c[0].constructor.name === 'CreateDBClusterCommand'
+      )?.[0];
+      expect(createCall).toBeDefined();
+      expect(createCall.input.Port).toBe(9999);
+    });
+
+    it('falls back to legacy `Port` key when `DBPort` is absent (backward compat)', async () => {
+      queueAvailableClusterResponses();
+      const provider = new NeptuneProvider();
+
+      await provider.create('MyCluster', 'AWS::Neptune::DBCluster', {
+        DBClusterIdentifier: 'my-cluster',
+        DBSubnetGroupName: 'my-subnet-group',
+        Port: 8182,
+      });
+
+      const createCall = mockNeptuneSend.mock.calls.find(
+        (c) => c[0].constructor.name === 'CreateDBClusterCommand'
+      )?.[0];
+      expect(createCall).toBeDefined();
+      expect(createCall.input.Port).toBe(8182);
+    });
+  });
+
+  describe('AWS::ElastiCache::SubnetGroup:Description', () => {
+    it('reads the CFn-schema-canonical `Description` key and passes it to SDK `CacheSubnetGroupDescription`', async () => {
+      mockElastiCacheSend.mockResolvedValueOnce({});
+      const provider = new ElastiCacheProvider();
+
+      await provider.create('MySubnetGroup', 'AWS::ElastiCache::SubnetGroup', {
+        CacheSubnetGroupName: 'my-sg',
+        Description: 'CFn-canonical description',
+        SubnetIds: ['subnet-1', 'subnet-2'],
+      });
+
+      const call = mockElastiCacheSend.mock.calls[0][0];
+      expect(call.constructor.name).toBe('CreateCacheSubnetGroupCommand');
+      expect(call.input.CacheSubnetGroupDescription).toBe('CFn-canonical description');
+    });
+
+    it('falls back to legacy `CacheSubnetGroupDescription` when `Description` is absent', async () => {
+      mockElastiCacheSend.mockResolvedValueOnce({});
+      const provider = new ElastiCacheProvider();
+
+      await provider.create('MySubnetGroup', 'AWS::ElastiCache::SubnetGroup', {
+        CacheSubnetGroupName: 'my-sg',
+        CacheSubnetGroupDescription: 'legacy description',
+        SubnetIds: ['subnet-1', 'subnet-2'],
+      });
+
+      const call = mockElastiCacheSend.mock.calls[0][0];
+      expect(call.input.CacheSubnetGroupDescription).toBe('legacy description');
+    });
+  });
+
+  describe('AWS::S3Tables::Table:TableName', () => {
+    it('reads the CFn-schema-canonical `TableName` key and passes it to SDK `name`', async () => {
+      mockS3TablesSend.mockResolvedValueOnce({});
+      const provider = new S3TablesProvider();
+
+      await provider.create('MyTable', 'AWS::S3Tables::Table', {
+        TableBucketARN: 'arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket',
+        Namespace: 'my_ns',
+        TableName: 'cfn_canonical_table',
+        Format: 'ICEBERG',
+      });
+
+      const call = mockS3TablesSend.mock.calls[0][0];
+      expect(call.constructor.name).toBe('CreateTableCommand');
+      expect(call.input.name).toBe('cfn_canonical_table');
+    });
+  });
+});

--- a/tests/unit/provisioning/silent-drop-aliases.test.ts
+++ b/tests/unit/provisioning/silent-drop-aliases.test.ts
@@ -163,10 +163,32 @@ describe('B-bucket silent-drop alias fixes (issue #613)', () => {
       expect(call.constructor.name).toBe('CreateNetworkAclEntryCommand');
       expect(call.input.IcmpTypeCode).toEqual({ Type: 3, Code: 0 });
     });
+
+    it('falls back to legacy `IcmpTypeCode` key (pre-#613-fix state-file backward compat)', async () => {
+      // State files written by pre-#613-fix cdkd carry the legacy
+      // `IcmpTypeCode` key in state.properties (the provider was
+      // reading the AWS-API name from template properties). After
+      // upgrade, a re-deploy reads state.properties and must still
+      // route the ICMP rule through to AWS.
+      mockEc2Send.mockResolvedValueOnce({});
+      const provider = new EC2Provider();
+
+      await provider.create('MyRule', 'AWS::EC2::NetworkAclEntry', {
+        NetworkAclId: 'acl-1',
+        RuleNumber: 100,
+        Protocol: 1,
+        RuleAction: 'allow',
+        Egress: false,
+        IcmpTypeCode: { Type: 8, Code: -1 },
+      });
+
+      const call = mockEc2Send.mock.calls[0][0];
+      expect(call.input.IcmpTypeCode).toEqual({ Type: 8, Code: -1 });
+    });
   });
 
   describe('AWS::ECS::Service:PlacementStrategies', () => {
-    it('reads the CFn-schema-canonical (plural) key and passes it to placementStrategy', async () => {
+    it('create: reads the CFn-schema-canonical (plural) key and passes it to placementStrategy', async () => {
       mockEcsSend.mockResolvedValueOnce({
         service: {
           serviceArn: 'arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service',
@@ -186,6 +208,34 @@ describe('B-bucket silent-drop alias fixes (issue #613)', () => {
       const call = mockEcsSend.mock.calls.find((c) => c[0].constructor.name === 'CreateServiceCommand')?.[0];
       expect(call).toBeDefined();
       expect(call.input.placementStrategy).toEqual([{ type: 'spread', field: 'instanceId' }]);
+    });
+
+    it('update: reads the CFn-schema-canonical (plural) key and passes it to placementStrategy', async () => {
+      mockEcsSend.mockResolvedValueOnce({
+        service: {
+          serviceArn: 'arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service',
+          serviceName: 'my-service',
+        },
+      });
+      const provider = new ECSProvider();
+
+      await provider.update(
+        'MyService',
+        'arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service',
+        'AWS::ECS::Service',
+        {
+          Cluster: 'my-cluster',
+          TaskDefinition: 'my-task:2',
+          DesiredCount: 2,
+          LaunchType: 'EC2',
+          PlacementStrategies: [{ type: 'binpack', field: 'cpu' }],
+        },
+        {} // previousProperties — irrelevant for this test
+      );
+
+      const call = mockEcsSend.mock.calls.find((c) => c[0].constructor.name === 'UpdateServiceCommand')?.[0];
+      expect(call).toBeDefined();
+      expect(call.input.placementStrategy).toEqual([{ type: 'binpack', field: 'cpu' }]);
     });
   });
 
@@ -219,11 +269,11 @@ describe('B-bucket silent-drop alias fixes (issue #613)', () => {
   });
 
   describe('AWS::Glue::Table:Name', () => {
-    it('falls back to top-level `Name` when nested `TableInput.Name` is absent', async () => {
+    it('falls back to top-level `Name` when nested `TableInput.Name` is absent (plumbs into TableInput SDK input)', async () => {
       mockGlueSend.mockResolvedValueOnce({});
       const provider = new GlueProvider();
 
-      await provider.create('MyTable', 'AWS::Glue::Table', {
+      const result = await provider.create('MyTable', 'AWS::Glue::Table', {
         DatabaseName: 'my_db',
         Name: 'top_level_table',
         TableInput: { Description: 'no Name field here' },
@@ -231,11 +281,28 @@ describe('B-bucket silent-drop alias fixes (issue #613)', () => {
 
       const call = mockGlueSend.mock.calls[0][0];
       expect(call.constructor.name).toBe('CreateTableCommand');
-      // physical ID format `{databaseName}|{tableName}` is the verification
-      // surface that the name was actually resolved.
-      // (CreateTableCommand input does not echo the Name into the call
-      // beyond passing it through TableInput; the test asserts via the
-      // logger / no-throw path.)
+      // The resolved name must reach the SDK call's TableInput.Name —
+      // buildTableInput receives a fallbackName so the SDK side is
+      // never called with TableInput.Name === undefined.
+      expect(call.input.TableInput.Name).toBe('top_level_table');
+      // Physical-id round-trip lock: confirms the resolved name is the
+      // same value that flowed into both the SDK call and cdkd state.
+      expect(result.physicalId).toBe('my_db|top_level_table');
+    });
+
+    it('prefers nested `TableInput.Name` when both are set (backward compat)', async () => {
+      mockGlueSend.mockResolvedValueOnce({});
+      const provider = new GlueProvider();
+
+      const result = await provider.create('MyTable', 'AWS::Glue::Table', {
+        DatabaseName: 'my_db',
+        Name: 'top_level',
+        TableInput: { Name: 'nested_canonical' },
+      });
+
+      const call = mockGlueSend.mock.calls[0][0];
+      expect(call.input.TableInput.Name).toBe('nested_canonical');
+      expect(result.physicalId).toBe('my_db|nested_canonical');
     });
   });
 
@@ -326,6 +393,29 @@ describe('B-bucket silent-drop alias fixes (issue #613)', () => {
 
       const call = mockElastiCacheSend.mock.calls[0][0];
       expect(call.input.CacheSubnetGroupDescription).toBe('legacy description');
+    });
+
+    it('update: reads CFn-canonical `Description` and passes it to ModifyCacheSubnetGroup', async () => {
+      mockElastiCacheSend.mockResolvedValueOnce({});
+      const provider = new ElastiCacheProvider();
+
+      await provider.update(
+        'MySubnetGroup',
+        'my-sg',
+        'AWS::ElastiCache::SubnetGroup',
+        {
+          CacheSubnetGroupName: 'my-sg',
+          Description: 'updated CFn-canonical',
+          SubnetIds: ['subnet-1', 'subnet-2', 'subnet-3'],
+        },
+        {} // previousProperties — irrelevant for this test
+      );
+
+      const call = mockElastiCacheSend.mock.calls.find(
+        (c) => c[0].constructor.name === 'ModifyCacheSubnetGroupCommand'
+      )?.[0];
+      expect(call).toBeDefined();
+      expect(call.input.CacheSubnetGroupDescription).toBe('updated CFn-canonical');
     });
   });
 


### PR DESCRIPTION
## Summary

#613 audit follow-up: wires the 9 alias properties surfaced as silent-drop bugs and declares the 20 design-intentional non-support entries in `unhandledByDesign` with concrete real-AWS rationales (replacing the spurious "not yet implemented by cdkd" default).

### B-bucket — alias wiring (9 entries)

| Provider | Property | Before | After |
| --- | --- | --- | --- |
| EC2 | `NetworkAclEntry:Icmp` | Provider read `IcmpTypeCode` → **ICMP NACL rules silently no-op'd** | Reads CFn-canonical `Icmp` |
| EC2 | `SecurityGroupIngress:CidrIpv6` | Wired in code, missing from `handledProperties` | Added to `handledProperties` |
| EC2 | `SecurityGroupIngress:SourcePrefixListId` | Same as above | Added to `handledProperties` |
| ECS | `Service:PlacementStrategies` | Provider read singular `PlacementStrategy` | Reads plural CFn-canonical with legacy fallback |
| Glue | `Database:DatabaseName` | Only read nested `DatabaseInput.Name` | Top-level alias accepted |
| Glue | `Table:Name` | Only read nested `TableInput.Name` | Top-level alias accepted |
| Neptune | `DBCluster:DBPort` | Only read legacy `Port` | Prefers `DBPort` with `Port` fallback |
| ElastiCache | `SubnetGroup:Description` | Only read AWS-API-named `CacheSubnetGroupDescription` | Prefers `Description` with legacy fallback |
| S3Tables | `Table:TableName` | Only read AWS-API-named `Name` | Prefers `TableName` with legacy fallback |

For each B-bucket fix the corresponding `readCurrentState` ALSO emits BOTH names so drift comparison against state.properties works regardless of which template shape produced the state (no false-positive drift after the upgrade).

### C-bucket — `unhandledByDesign` declarations (20 entries)

Moves entries from the spurious `"not yet implemented by cdkd"` default rationale to a concrete real-AWS reason. Three buckets:

- **AWS-deprecated features**: `S3::Bucket:AccessControl` (ACLs off by default since 2023-04), `EC2::Instance:ElasticGpuSpecifications` / `ElasticInferenceAccelerators` (Elastic Inference EOL 2024-04), `ECS::TaskDefinition:InferenceAccelerators`, `ASG:LaunchConfigurationName` (EOL 2024-10) / `NotificationConfiguration` (legacy singular), `AppSync::DataSource:ElasticsearchConfig` (use OpenSearch)
- **EC2-Classic-only**: `ElastiCache::CacheCluster:CacheSecurityGroupNames`, `RDS::DBInstance:DBSecurityGroups`, `EC2::SecurityGroupIngress:GroupName` / `SourceSecurityGroupName`
- **CFn-internal / no cdkd analog**: `ECS::Service:Role` (legacy classic-ELB, AWSServiceRoleForECS now), `SNS::Subscription:Region`, `EFS::AccessPoint:ClientToken`, `EC2::NatGateway:VpcId` (derived from SubnetId), `ApiGateway::Deployment:StageName` / `StageDescription` (CFn-inline-Stage convenience), `RDS::DBInstance:ApplyImmediately` (cdkd hardcodes true), `RDS::DBCluster` / `DBInstance:DeleteAutomatedBackups` (cdkd hardcodes SkipFinalSnapshot=true)

### Property-coverage delta

Generated map: **904 → 911 handled, 469 → 460 silent-drop**. The remaining 460 (true category-A unimplemented) continue under #609.

## Why now

Surfaced by #613's per-entry audit (full report: https://github.com/go-to-k/cdkd/issues/613#issuecomment-4546004881). The most user-impactful finding is `EC2::NetworkAclEntry:Icmp` — CDK L1 emits `Icmp` (CFn-canonical), provider read `IcmpTypeCode` (AWS-API name), so ICMP NACL rules silently no-op'd at deploy time. Today affected users would either: (a) be blocked by the pre-flight (shipped in PR #608), or (b) work around with `--allow-unsupported-properties` which accepts the silent drop. This PR makes the canonical CFn shape actually flow through to AWS.

## Test plan

- [x] `vp check --fix` clean (typecheck + lint + format)
- [x] `vp run build` succeeds
- [x] `vp run test` — 371 files / 5682 tests pass
- [x] New test file `tests/unit/provisioning/silent-drop-aliases.test.ts` covers each B-bucket alias-read fix with a behavioral assertion that the value reaches the SDK call (+ backward-compat tests for the legacy form)
- [x] Existing `readCurrentState` tests updated to expect the dual-emit shape (`Icmp` + `IcmpTypeCode`, `PlacementStrategies` + `PlacementStrategy`, `Description` + `CacheSubnetGroupDescription`, `DatabaseName`, `Name`, `TableName`, `DBPort`)
- [x] Existing `ecs-provider-roundtrip.test.ts` updated to confirm legacy `PlacementStrategy` state still flows through `update()` (backward compat)
- [x] `vp run gen:property-coverage && vp run format` — generated map matches expectation (911 handled / 460 silent-drop)
- [x] Live-spot-check of regen output verified: all 9 B-bucket entries are in `handled`, all 20 C-bucket entries have non-default rationale
- Live-test of the actual AWS-side deploy of an ICMP NACL rule is **not** run in this PR — the change touches the create/update SDK input shape only, and the destroy path is unchanged. The provider integ in CI exercises the standard NACL types but not specifically the ICMP property. Integration coverage for the ICMP path can land later as part of #609's NACL backfill scope.

## Related

- Refs #613 (audit)
- Refs #609 (real backfill scope adjusted to 422 A-entries; see issue body for the patterns analysis)
- Refs #616 (umbrella)
