### PR TITLE
test(local): lock down SigV4 verifier ignores service-name (#626)

### DIFF
--- a/tests/unit/local/http-server.test.ts
+++ b/tests/unit/local/http-server.test.ts
@@ -1103,6 +1103,16 @@ function signFunctionUrlRequest(opts: {
   secretAccessKey: string;
   region: string;
   amzDate: string;
+  /**
+   * Service name embedded in the SigV4 credential scope. AWS SDK clients
+   * use `service=lambda` when signing Function URL requests, but the
+   * verifier does NOT pin the service name — it only checks the
+   * access-key-id matches the dev's local creds and the canonical-request
+   * hash matches. Tests pass `service: 'execute-api'` (or other non-
+   * `'lambda'` values) to lock down that "service name is informational"
+   * contract. Defaults to `'lambda'` for backward compatibility.
+   */
+  service?: string;
 }): { authorization: string; headers: Record<string, string> } {
   const headers = { ...opts.headers };
   if (!headers['x-amz-date']) headers['x-amz-date'] = opts.amzDate;
@@ -1132,7 +1142,7 @@ function signFunctionUrlRequest(opts: {
   // the verifier only checks the access-key-id matches the dev's local
   // creds and the canonical-request hash matches, so the service name
   // in the credential scope is not load-bearing for the verify step.
-  const service = 'lambda';
+  const service = opts.service ?? 'lambda';
   const credentialScope = `${date}/${opts.region}/${service}/aws4_request`;
   const stringToSign = [
     'AWS4-HMAC-SHA256',
@@ -1309,6 +1319,55 @@ describe('startApiServer — Function URL AWS_IAM (#621)', () => {
       expect(body.Message).toBe('Forbidden');
       expect(invokeRieMock).not.toHaveBeenCalled();
       expect((pool.acquire as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+    }
+  });
+
+  // Locks down the verifier's documented "service name in the credential
+  // scope is informational, not load-bearing" contract (#626). The signer
+  // that AWS SDK clients use for Function URLs sets `service=lambda`, but
+  // curl `--aws-sigv4` and other dev tooling routinely sign with off-
+  // service values (e.g. `service=execute-api`). The verifier reconstructs
+  // the canonical request from the same `(date, region, service)` scope
+  // the request itself carries — it does NOT pin `service` to any
+  // particular value — so a request signed with `service=execute-api`
+  // must reach the Lambda handler the same way `service=lambda` does. A
+  // future verifier change that silently starts pinning service would
+  // flip this test from green to red.
+  it('valid SigV4 with off-service credential scope (execute-api) → 200', async () => {
+    invokeRieMock.mockImplementation(async () => ({
+      raw: '',
+      payload: { statusCode: 200, body: 'ok' },
+    }));
+    const route = functionUrlIamRoute();
+    const server = await startApiServer({
+      state: { routes: [route], pool: makePool(), corsConfigByApiId: new Map() },
+      rieTimeoutMs: 1000,
+      host: '127.0.0.1',
+      port: 0,
+      sigV4CredentialsLoader: stubCredentialsLoader({ accessKeyId, secretAccessKey }),
+    });
+    try {
+      const path = '/items/42';
+      const amzDate = nowAmzDate();
+      const { authorization, headers } = signFunctionUrlRequest({
+        method: 'GET',
+        path,
+        headers: { host: `${server.host}:${server.port}` },
+        accessKeyId,
+        secretAccessKey,
+        region: 'us-east-1',
+        amzDate,
+        // Deliberately NOT 'lambda' — locks down the "service is
+        // informational" contract documented in #626.
+        service: 'execute-api',
+      });
+      const r = await fetch(`http://${server.host}:${server.port}${path}`, {
+        headers: { authorization, ...headers },
+      });
+      expect(r.status).toBe(200);
+      expect(invokeRieMock).toHaveBeenCalledTimes(1);
     } finally {
       await server.close();
     }


### PR DESCRIPTION
## Summary

Adds a focused regression test that signs a Function URL `AuthType: AWS_IAM` request with `service: 'execute-api'` (instead of the AWS-SDK-default `'lambda'`) and asserts the request still reaches the Lambda handler.

This locks down the documented behavior of `src/local/sigv4-verify.ts:verifySigV4`: the service name in the credential scope is **informational, not load-bearing**. The verifier only checks that the canonical-request hash matches; the service field is not pinned.

A future change to the verifier that silently starts pinning the service name would have flowed straight to production unnoticed — the existing valid-SigV4 tests all sign with `service: 'lambda'` (the AWS SDK default for Function URLs), so they would still pass. With this guard in place, any such regression is caught at unit-test time.

## Changes

- `tests/unit/local/http-server.test.ts` — extends the `signFunctionUrlRequest` helper to accept an optional `service` field (defaults to `'lambda'` so the pre-existing three tests are byte-for-byte unchanged), and adds one new `it(...)` covering the `service: 'execute-api'` case.

No source code change. Pure test addition.

## Out of scope

- Whether the verifier *should* pin service name. AWS Function URLs sign with `service=lambda` per AWS SDK convention, but local dev tooling routinely accepts off-service signatures (`curl --aws-sigv4` for prototyping etc.). Pinning would tighten security at the cost of dev ergonomics — separate design discussion if anyone wants to open it.

## Test plan

- [x] `vp check --fix` passes (typecheck + lint + format, 0 warnings / 0 errors)
- [x] `vp run build` passes
- [x] `vp run test` passes — 371 test files, 5695 tests (one new test in this PR)
- [x] The new test asserts the Lambda handler IS invoked when SigV4 signs with `service: 'execute-api'` — i.e., the verifier ignores service name as documented

Closes #626
