### PR TITLE
fix(local): return 403 for REST v1 AWS_IAM rejection (#625)

### DIFF
--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -887,11 +887,15 @@ Outcomes:
     behavior diverge only by absence of identity context — never by
     location.
 - **No / malformed `Authorization` header**, **signature mismatch
-  under the dev's own credentials**, or any other rejection → 401 / 403
+  under the dev's own credentials**, or any other rejection → 403
   matching the deployed response:
-  - REST v1: 401 (`missing-identity`) / 403 (`policy-deny`).
+  - REST v1: 403 (`{"message":"Missing Authentication Token"}`) for
+    missing-identity, 403 (`{"message":"Forbidden"}`) for policy-deny —
+    matches AWS-deployed API Gateway REST v1 IAM rejection (lowercase
+    `message`).
   - Function URL: 403 (`{"Message":"Forbidden"}`) for both deny kinds —
-    matches Lambda's deployed Function URL IAM rejection.
+    matches Lambda's deployed Function URL IAM rejection (capital
+    `Message`).
 - **Different `Credential` access-key-id than the dev has** →
   warn-and-pass. The local server cannot reproduce a signing key it
   doesn't have, and refusing every foreign-identity request would

--- a/src/local/http-server.ts
+++ b/src/local/http-server.ts
@@ -1248,6 +1248,11 @@ function buildOverlay(
 
 /**
  * Map the authorizer rejection to an HTTP status code and body.
+ *   - REST v1 with AWS_IAM (issue #625) → 403 for both deny kinds (the
+ *     deployed REST v1 SigV4 layer rejects unsigned requests with 403
+ *     `{"message":"Missing Authentication Token"}` and signature/policy
+ *     failures with 403 `{"message":"Forbidden"}` — lowercase `message`
+ *     distinguishes the REST v1 shape from the Function URL shape below).
  *   - REST v1, missing identity → 401 `{"message":"Unauthorized"}`
  *     (matches deployed behavior; the route reaches the Method but no
  *     identity source is present so the authorizer never runs).
@@ -1257,7 +1262,9 @@ function buildOverlay(
  *     collapses both into the same response).
  *   - Function URL with AWS_IAM (issue #621) → 403 `{"Message":"Forbidden"}`
  *     for both deny kinds (matches Lambda's deployed Function URL IAM
- *     behavior — the AWS SigV4 layer rejects with 403, not 401).
+ *     behavior — the AWS SigV4 layer rejects with 403, not 401). Note the
+ *     capital `Message` — distinct from REST v1 AWS_IAM's lowercase
+ *     `message`.
  */
 export function writeAuthRejection(
   res: ServerResponse,
@@ -1265,6 +1272,18 @@ export function writeAuthRejection(
   denyKind: 'missing-identity' | 'policy-deny',
   authorizerKind?: AuthorizerInfo['kind']
 ): void {
+  // REST v1 with AWS_IAM rides the same SigV4 verifier as the v2 path
+  // (PR #447), but the AWS-deployed REST v1 surface rejects with 403 +
+  // lowercase `message` — distinct from both v1's default authorizer
+  // 401 (the non-IAM path below) and Function URL's capital `Message`.
+  if (apiVersion === 'v1' && authorizerKind === 'iam') {
+    if (denyKind === 'missing-identity') {
+      writeError(res, 403, '{"message":"Missing Authentication Token"}');
+      return;
+    }
+    writeError(res, 403, '{"message":"Forbidden"}');
+    return;
+  }
   // Function URLs are v2-shaped but Lambda's IAM rejection differs from
   // API Gateway v2's default 401 — match the deployed response so a dev
   // exercising AWS_IAM Function URLs sees the same status code locally.

--- a/tests/unit/local/http-server.test.ts
+++ b/tests/unit/local/http-server.test.ts
@@ -100,6 +100,27 @@ describe('writeAuthRejection', () => {
     expect(res.statusCode).toBe(403);
     expect(res.capturedBody).toBe('{"Message":"Forbidden"}');
   });
+
+  it('REST v1 + IAM + missing-identity → 403 Missing Authentication Token (#625)', () => {
+    // REST v1 with AWS_IAM also rejects unsigned requests with 403, not
+    // the v1 default 401. Body uses lowercase `message` — distinct from
+    // Function URL's capital `Message` — and the deployed REST v1 surface
+    // returns "Missing Authentication Token" when no signature is present.
+    const res = makeResponse();
+    writeAuthRejection(res, 'v1', 'missing-identity', 'iam');
+    expect(res.statusCode).toBe(403);
+    expect(res.capturedBody).toBe('{"message":"Missing Authentication Token"}');
+  });
+
+  it('REST v1 + IAM + policy-deny → 403 Forbidden (#625)', () => {
+    // REST v1 with AWS_IAM, SigV4 verification ran and failed (bad
+    // signature / wrong account / policy deny). Status mirrors AWS API
+    // Gateway's deployed REST v1 IAM rejection: 403 + lowercase `message`.
+    const res = makeResponse();
+    writeAuthRejection(res, 'v1', 'policy-deny', 'iam');
+    expect(res.statusCode).toBe(403);
+    expect(res.capturedBody).toBe('{"message":"Forbidden"}');
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

`cdkd local start-api`'s `writeAuthRejection` returned `401 {"message":"Unauthorized"}` for REST v1 + IAM + missing-identity, while AWS-deployed API Gateway REST v1 with `AuthorizationType: AWS_IAM` returns 403 in BOTH cases (`{"message":"Missing Authentication Token"}` and `{"message":"Forbidden"}`).

This was a parity gap left by PR #624 (Function URL AWS_IAM): #624 added a `(v2, iam) → 403` carve-out to mirror Lambda's deployed Function URL behavior, but the pre-existing v1 + iam path kept the old 401.

## Changes

- **`src/local/http-server.ts`** — extend the existing `(v2 && iam)` branch in `writeAuthRejection` to also handle `(v1 && iam)`:
  - `missing-identity` → 403 + `{"message":"Missing Authentication Token"}`
  - `policy-deny` → 403 + `{"message":"Forbidden"}`

  Note the lowercase `message` for REST v1 (distinct from Function URL's capital `Message`) — both match the exact AWS-deployed shape. JSDoc updated to call out the lowercase-vs-capital distinction.

- **`tests/unit/local/http-server.test.ts`** — adds 2 unit tests mirroring the existing v2+iam tests' shape: v1+iam+missing-identity and v1+iam+policy-deny, each asserting status code + body.

- **`docs/local-emulation.md`** — updates the rejection-status documentation block to reflect the new 403-for-both behavior (was inline-documented as "REST v1: 401 / 403"; now correctly "REST v1: 403 / 403").

## Scope notes

The upstream wiring (`detectRestV1Authorizer` emitting `kind: 'iam'`, the request-path call sites passing `authorizer.kind` to `writeAuthRejection`) was **already in place from PR #447**. Only the rejection branch itself needed the fix — no plumbing change.

## Test plan

- [x] `vp check --fix` passes (typecheck + lint + format, 0 warnings / 0 errors)
- [x] `vp run build` passes
- [x] `vp run test` passes — 371 test files, 5696 tests (2 new tests in this PR)
- [x] New tests assert exact status + body shape (`{"message":"..."}`) for both rejection kinds
- [x] Docs change aligns with the new behavior

Closes #625
