### PR TITLE
fix(local): resolve canonical fromImageAsset image URI (#637)

### DIFF
--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -37,7 +37,10 @@ import { resolveRuntimeFileExtension, resolveRuntimeImage } from '../../local/ru
 import { ensureDockerAvailable, pullImage } from '../../local/docker-runner.js';
 import { architectureToPlatform, buildContainerImage } from '../../local/docker-image-builder.js';
 import { parseEcrUri, pullEcrImage } from '../../local/ecr-puller.js';
-import { tryResolveImageFnJoin } from '../../local/intrinsic-image.js';
+import {
+  derivePseudoParametersFromRegion,
+  tryResolveImageFnJoin,
+} from '../../local/intrinsic-image.js';
 import {
   AssetManifestLoader,
   getDockerImageBySourceHash,
@@ -1746,7 +1749,8 @@ export function resolveLambdaByLogicalId(
       code['ImageUri'],
       logicalId,
       stack.stackName,
-      stack.template.Resources ?? {}
+      stack.template.Resources ?? {},
+      stack.region
     );
     if (imageUri !== undefined) {
       return resolveImageLambda({
@@ -1812,23 +1816,18 @@ export function resolveLambdaByLogicalId(
  * `lambda.DockerImageCode.fromImageAsset`), and `Fn::Join` (the
  * canonical shape for `lambda.DockerImageCode.fromImageAsset` in
  * CDK 2.x, which emits a `Fn::Join` over the literal bootstrap ECR
- * URI with `${AWS::URLSuffix}` — issue #627).
+ * URI with `${AWS::URLSuffix}` — issues #627 + #637).
  *
  * The `Fn::Join` arm routes through the shared
  * `tryResolveImageFnJoin` helper (`src/local/intrinsic-image.ts`) used
- * by `cdkd local invoke`. Like the sibling `lambda-resolver.ts`, we
- * pass `undefined` for the `ImageResolutionContext` — start-api
- * doesn't load cdkd state up front, so same-stack ECR refs surface
- * as `needs-state` and pseudo-parameter-only shapes (`Ref:
- * AWS::URLSuffix`) surface as `not-applicable`. Both cases throw a
- * clear error that names the actual root cause instead of falling
- * through to the ZIP branch's misleading "no Runtime" hard error.
- *
- * Pseudo-parameter substitution (`${AWS::URLSuffix}` → `amazonaws.com`)
- * is deliberately not implemented here — `lambda-resolver.ts` (the
- * canonical sibling) also defers it, and shipping one-sided support
- * would surprise users. Tracked separately as the issue's optional
- * follow-up.
+ * by `cdkd local invoke`. When the synth template recorded a deploy
+ * region (`stack.region`), we derive `{ urlSuffix, partition, region }`
+ * via `derivePseudoParametersFromRegion` and pass it as the resolver's
+ * `pseudoParameters` block so the canonical `${AWS::URLSuffix}` shape
+ * resolves cleanly (issue #637). Same-stack ECR refs still surface as
+ * `needs-state` (those require `--from-state`); a Join that references
+ * `${AWS::AccountId}` without state still surfaces as `not-applicable`
+ * with a more specific error message naming the missing parameter.
  *
  * Returns `undefined` when the field is absent or non-recognized,
  * which routes the caller to the ZIP branch (with its existing
@@ -1838,7 +1837,8 @@ function extractImageUri(
   value: unknown,
   logicalId: string,
   stackName: string,
-  resources: Record<string, TemplateResource>
+  resources: Record<string, TemplateResource>,
+  region: string | undefined
 ): string | undefined {
   if (typeof value === 'string' && value.length > 0) return value;
   if (value && typeof value === 'object' && !Array.isArray(value)) {
@@ -1848,9 +1848,20 @@ function extractImageUri(
     if (Array.isArray(sub) && typeof sub[0] === 'string') return sub[0];
 
     if ('Fn::Join' in obj) {
-      // Shared resolver — no state / pseudo parameters context. Same
-      // shape as `lambda-resolver.ts:extractImageUri` (issue #286 Gap 2).
-      const joinResolved = tryResolveImageFnJoin(value, resources, undefined);
+      // Issue #637: derive the region-knowable pseudo parameters
+      // (`urlSuffix` / `partition` / `region`) and pass them as
+      // resolver context so the canonical `lambda.DockerImageCode
+      // .fromImageAsset` shape resolves without `--from-state`.
+      // `accountId` stays undefined — the canonical shape has it
+      // as a literal in the template, and a Join that genuinely
+      // references `${AWS::AccountId}` falls back to the
+      // `not-applicable` branch below with a clear error.
+      const pseudoParameters = derivePseudoParametersFromRegion(region);
+      const joinResolved = tryResolveImageFnJoin(
+        value,
+        resources,
+        pseudoParameters ? { pseudoParameters } : undefined
+      );
       if (joinResolved.kind === 'resolved') return joinResolved.uri;
       if (joinResolved.kind === 'needs-state') {
         throw new Error(
@@ -1867,20 +1878,19 @@ function extractImageUri(
             '(delimiter "" with nested Fn::Select/Fn::Split over an ECR Repository Arn GetAtt + Ref to the repo).'
         );
       }
-      // `not-applicable` — the shape is `Fn::Join` but the resolver
-      // couldn't reduce every element and there's no same-stack ECR
-      // Repository ref. The most common cause is a `Ref: AWS::URLSuffix`
-      // / other pseudo-parameter (the canonical CDK 2.x
-      // `lambda.DockerImageCode.fromImageAsset` shape) that needs
-      // `pseudoParameters` context, not yet plumbed through
-      // `cdkd local start-api`. Surface a clear error instead of
-      // falling through to ZIP-branch validation, which would error
-      // with the unrelated "no Runtime" message.
+      // `not-applicable` — the Join couldn't reduce every element
+      // AND there's no same-stack ECR Repository ref. With #637's
+      // pseudo-parameter plumbing the typical remaining cause is
+      // `${AWS::AccountId}` (needs an STS call or `--from-state`)
+      // or an unknown region (`stack.region` was undefined so we
+      // couldn't derive `urlSuffix`). Either way, surface a clear
+      // error instead of falling through to ZIP-branch validation.
+      const accountIdHint = pseudoParameters
+        ? ' (likely \\${AWS::AccountId}, which cdkd cannot derive without --from-state or STS)'
+        : ` (cdkd could not derive AWS pseudo parameters because stack.region was undefined)`;
       throw new Error(
-        `Lambda '${logicalId}' in ${stackName} has an Fn::Join Code.ImageUri that cdkd local start-api cannot resolve. ` +
-          'The shape likely references AWS pseudo parameters (e.g. ${AWS::URLSuffix}) — ' +
-          'the canonical CDK 2.x lambda.DockerImageCode.fromImageAsset synthesized shape. ' +
-          'Workarounds: pin a fully-literal public image URI, or wait for the follow-up that substitutes ${AWS::URLSuffix} against the current region.'
+        `Lambda '${logicalId}' in ${stackName} has an Fn::Join Code.ImageUri that cdkd local start-api cannot resolve${accountIdHint}. ` +
+          'Workarounds: deploy first and run with --from-state, or pin a fully-literal public image URI.'
       );
     }
   }

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -1886,7 +1886,7 @@ function extractImageUri(
       // couldn't derive `urlSuffix`). Either way, surface a clear
       // error instead of falling through to ZIP-branch validation.
       const accountIdHint = pseudoParameters
-        ? ' (likely \\${AWS::AccountId}, which cdkd cannot derive without --from-state or STS)'
+        ? ' (likely ${AWS::AccountId}, which cdkd cannot derive without --from-state or STS)'
         : ` (cdkd could not derive AWS pseudo parameters because stack.region was undefined)`;
       throw new Error(
         `Lambda '${logicalId}' in ${stackName} has an Fn::Join Code.ImageUri that cdkd local start-api cannot resolve${accountIdHint}. ` +

--- a/src/local/intrinsic-image.ts
+++ b/src/local/intrinsic-image.ts
@@ -60,6 +60,59 @@ export interface ImageResolutionContext {
 }
 
 /**
+ * Derive the AWS pseudo parameters that are trivially knowable from the
+ * deploy region alone, without any STS call or cdkd state load.
+ * `urlSuffix` and `partition` follow the canonical AWS partition rules:
+ *
+ *   - region prefix `cn-*`        → partition `aws-cn`,     urlSuffix `amazonaws.com.cn`
+ *   - region prefix `us-gov-*`    → partition `aws-us-gov`, urlSuffix `amazonaws.com`
+ *   - region prefix `us-iso-*`    → partition `aws-iso`,    urlSuffix `c2s.ic.gov`
+ *   - region prefix `us-isob-*`   → partition `aws-iso-b`,  urlSuffix `sc2s.sgov.gov`
+ *   - everything else (`us-east-1` / `eu-west-2` / `ap-northeast-1` / etc.)
+ *                                 → partition `aws`,        urlSuffix `amazonaws.com`
+ *
+ * `accountId` is optional pass-through (caller decides whether to populate
+ * it). The bootstrap-ECR URI shape that `lambda.DockerImageCode.fromImageAsset`
+ * synthesizes carries account-id + region as literal strings in the template,
+ * so only `urlSuffix` / `partition` / `region` are required to resolve it
+ * (issue #637).
+ *
+ * Returns `undefined` when `region` is undefined / empty so the caller can
+ * fall through cleanly. The shape mirrors `ImageResolutionContext.pseudoParameters`
+ * so the result drops straight into a context literal.
+ */
+export function derivePseudoParametersFromRegion(
+  region: string | undefined,
+  accountId?: string
+): { accountId?: string; region: string; partition: string; urlSuffix: string } | undefined {
+  if (!region || typeof region !== 'string' || region.length === 0) return undefined;
+  let partition: string;
+  let urlSuffix: string;
+  if (region.startsWith('cn-')) {
+    partition = 'aws-cn';
+    urlSuffix = 'amazonaws.com.cn';
+  } else if (region.startsWith('us-gov-')) {
+    partition = 'aws-us-gov';
+    urlSuffix = 'amazonaws.com';
+  } else if (region.startsWith('us-isob-')) {
+    partition = 'aws-iso-b';
+    urlSuffix = 'sc2s.sgov.gov';
+  } else if (region.startsWith('us-iso-')) {
+    partition = 'aws-iso';
+    urlSuffix = 'c2s.ic.gov';
+  } else {
+    partition = 'aws';
+    urlSuffix = 'amazonaws.com';
+  }
+  return {
+    ...(accountId !== undefined && { accountId }),
+    region,
+    partition,
+    urlSuffix,
+  };
+}
+
+/**
  * Outcome of attempting to resolve a `Fn::Join`-shaped image URI against
  * the substitution context. Discriminated so the caller can route each
  * case to the right error / classification path.

--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -599,7 +599,7 @@ function extractImageUri(
       // plumbing the typical remaining cause is `${AWS::AccountId}`
       // (needs an STS call or `--from-state`) or an unknown region.
       const accountIdHint = pseudoParameters
-        ? ' (likely \\${AWS::AccountId}, which cdkd cannot derive without --from-state or STS)'
+        ? ' (likely ${AWS::AccountId}, which cdkd cannot derive without --from-state or STS)'
         : ` (cdkd could not derive AWS pseudo parameters because stack.region was undefined)`;
       throw new LocalInvokeResolutionError(
         `Lambda '${logicalId}' in ${stackName} has an Fn::Join Code.ImageUri that cdkd local invoke cannot resolve${accountIdHint}. ` +

--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -4,7 +4,7 @@ import type { StackInfo } from '../synthesis/assembly-reader.js';
 import type { TemplateResource } from '../types/resource.js';
 import { buildCdkPathIndex, resolveCdkPathToLogicalIds } from '../cli/cdk-path.js';
 import { matchStacks } from '../cli/stack-matcher.js';
-import { tryResolveImageFnJoin } from './intrinsic-image.js';
+import { derivePseudoParametersFromRegion, tryResolveImageFnJoin } from './intrinsic-image.js';
 import { stringifyValue } from '../utils/stringify.js';
 
 /**
@@ -395,7 +395,13 @@ function extractLambdaProperties(
   const ephemeralStorageMb = extractEphemeralStorageMb(props, logicalId);
 
   const code = (props['Code'] ?? {}) as Record<string, unknown>;
-  const imageUri = extractImageUri(code['ImageUri'], logicalId, stack.stackName, resources);
+  const imageUri = extractImageUri(
+    code['ImageUri'],
+    logicalId,
+    stack.stackName,
+    resources,
+    stack.region
+  );
 
   if (imageUri !== undefined) {
     return extractImageLambdaProperties({
@@ -546,7 +552,8 @@ function extractImageUri(
   value: unknown,
   logicalId: string,
   stackName: string,
-  resources: Record<string, TemplateResource>
+  resources: Record<string, TemplateResource>,
+  region: string | undefined
 ): string | undefined {
   if (typeof value === 'string' && value.length > 0) return value;
   if (value && typeof value === 'object' && !Array.isArray(value)) {
@@ -556,17 +563,21 @@ function extractImageUri(
     // Fn::Sub array form: [template, vars]. The first element is the template.
     if (Array.isArray(sub) && typeof sub[0] === 'string') return sub[0];
 
-    // `Fn::Join` — try the shared ECR-URI resolver. We deliberately pass
-    // no `ImageResolutionContext` here; `cdkd local invoke` doesn't load
-    // cdkd state up front (issue #286, v1 scope), so only `Fn::Join`
-    // shapes with no AWS pseudo-parameter refs AND no same-stack ECR
-    // Repository refs resolve cleanly. SAME-STACK shapes return
-    // `needs-state` and we surface a clear hint. Imported-repo shapes
-    // that reference `Ref: AWS::URLSuffix` return `not-applicable` (no
-    // ECR Repository ref in the tree); see the explicit `Fn::Join`
-    // detection below.
+    // `Fn::Join` — try the shared ECR-URI resolver. Issue #637 plumbed
+    // region-derived pseudo parameters (`urlSuffix` / `partition` /
+    // `region`) through here so the canonical
+    // `lambda.DockerImageCode.fromImageAsset` shape (only intrinsic in
+    // the URI is `${AWS::URLSuffix}`) resolves without `--from-state`.
+    // Same-stack ECR refs still return `needs-state`; a Join that
+    // genuinely references `${AWS::AccountId}` without state returns
+    // `not-applicable` with a more specific error.
     if ('Fn::Join' in obj) {
-      const joinResolved = tryResolveImageFnJoin(value, resources, undefined);
+      const pseudoParameters = derivePseudoParametersFromRegion(region);
+      const joinResolved = tryResolveImageFnJoin(
+        value,
+        resources,
+        pseudoParameters ? { pseudoParameters } : undefined
+      );
       if (joinResolved.kind === 'resolved') return joinResolved.uri;
       if (joinResolved.kind === 'needs-state') {
         throw new LocalInvokeResolutionError(
@@ -583,17 +594,16 @@ function extractImageUri(
             '(delimiter "" with nested Fn::Select/Fn::Split over an ECR Repository Arn GetAtt + Ref to the repo).'
         );
       }
-      // `not-applicable` — the shape is `Fn::Join` but the resolver
-      // couldn't reduce every element and there's no same-stack ECR
-      // Repository ref. The most common cause is a `Ref: AWS::URLSuffix`
-      // / other pseudo-parameter that needs `pseudoParameters` context
-      // (not yet plumbed through `cdkd local invoke`). Surface a clear
-      // error instead of falling through to ZIP-branch validation,
-      // which would error with the unrelated "no Runtime" message.
+      // `not-applicable` — Join couldn't reduce every element AND no
+      // same-stack ECR Repository ref. With #637's pseudo-parameter
+      // plumbing the typical remaining cause is `${AWS::AccountId}`
+      // (needs an STS call or `--from-state`) or an unknown region.
+      const accountIdHint = pseudoParameters
+        ? ' (likely \\${AWS::AccountId}, which cdkd cannot derive without --from-state or STS)'
+        : ` (cdkd could not derive AWS pseudo parameters because stack.region was undefined)`;
       throw new LocalInvokeResolutionError(
-        `Lambda '${logicalId}' in ${stackName} has an Fn::Join Code.ImageUri that cdkd local invoke cannot resolve. ` +
-          'The shape likely references AWS pseudo parameters (e.g. ${AWS::URLSuffix}) for an imported ECR repository. ' +
-          'Workarounds: rebuild via lambda.DockerImageCode.fromImageAsset, or pin a fully-literal public image URI.'
+        `Lambda '${logicalId}' in ${stackName} has an Fn::Join Code.ImageUri that cdkd local invoke cannot resolve${accountIdHint}. ` +
+          'Workarounds: deploy first and run with --from-state, or pin a fully-literal public image URI.'
       );
     }
   }

--- a/tests/unit/cli/local-start-api-container.test.ts
+++ b/tests/unit/cli/local-start-api-container.test.ts
@@ -19,13 +19,17 @@ import type { TemplateResource } from '../../../src/types/resource.js';
  * still requires Handler on the ZIP branch).
  */
 
-function makeStack(resources: Record<string, TemplateResource>): StackInfo {
+function makeStack(
+  resources: Record<string, TemplateResource>,
+  region?: string
+): StackInfo {
   return {
     stackName: 'S',
     displayName: 'S',
     artifactId: 'S',
     template: { Resources: resources },
     dependencyNames: [],
+    ...(region !== undefined && { region }),
   } as unknown as StackInfo;
 }
 
@@ -245,36 +249,81 @@ describe('resolveLambdaByLogicalId — IMAGE branch (issue #453)', () => {
    * the actual root cause (pseudo-param substitution / same-stack ECR
    * ref needing state) instead.
    */
-  describe('Code.ImageUri Fn::Join (issue #627)', () => {
-    it('throws a clear error (mentioning AWS::URLSuffix) for the canonical fromImageAsset bootstrap-ECR shape', () => {
-      // The exact shape `cdk synth` emits for
-      // `lambda.DockerImageCode.fromImageAsset(...)` — literal account /
-      // region / repo path bracketing `Ref: AWS::URLSuffix`.
-      const joinResource: TemplateResource = {
-        Type: 'AWS::Lambda::Function',
-        Properties: {
-          Code: {
-            ImageUri: {
-              'Fn::Join': [
-                '',
-                [
-                  '123456789012.dkr.ecr.us-east-1.',
-                  { Ref: 'AWS::URLSuffix' },
-                  '/cdk-hnb659fds-container-assets-123456789012-us-east-1:abc123',
-                ],
+  describe('Code.ImageUri Fn::Join (issues #627 + #637)', () => {
+    // The exact shape `cdk synth` emits for
+    // `lambda.DockerImageCode.fromImageAsset(...)` — literal account /
+    // region / repo path bracketing `Ref: AWS::URLSuffix`.
+    const fromImageAssetJoin = (region: string): TemplateResource => ({
+      Type: 'AWS::Lambda::Function',
+      Properties: {
+        Code: {
+          ImageUri: {
+            'Fn::Join': [
+              '',
+              [
+                `123456789012.dkr.ecr.${region}.`,
+                { Ref: 'AWS::URLSuffix' },
+                `/cdk-hnb659fds-container-assets-123456789012-${region}:abc123`,
               ],
-            },
+            ],
           },
-          PackageType: 'Image',
         },
-      };
+        PackageType: 'Image',
+      },
+    });
+
+    it('resolves canonical fromImageAsset bootstrap-ECR shape under aws partition (issue #637)', () => {
+      // #637 plumbs `derivePseudoParametersFromRegion` into the resolver
+      // so the canonical fromImageAsset shape — only intrinsic is
+      // `${AWS::URLSuffix}` — substitutes to `amazonaws.com` and the
+      // Lambda boots locally.
+      const resolved = resolveLambdaByLogicalId('Fn', [
+        makeStack({ Fn: fromImageAssetJoin('us-east-1') }, 'us-east-1'),
+      ]);
+      expect(resolved.kind).toBe('image');
+      if (resolved.kind !== 'image') return;
+      expect(resolved.imageUri).toBe(
+        '123456789012.dkr.ecr.us-east-1.amazonaws.com/cdk-hnb659fds-container-assets-123456789012-us-east-1:abc123'
+      );
+    });
+
+    it('resolves canonical fromImageAsset shape under aws-cn partition (issue #637)', () => {
+      const resolved = resolveLambdaByLogicalId('Fn', [
+        makeStack({ Fn: fromImageAssetJoin('cn-north-1') }, 'cn-north-1'),
+      ]);
+      expect(resolved.kind).toBe('image');
+      if (resolved.kind !== 'image') return;
+      expect(resolved.imageUri).toBe(
+        '123456789012.dkr.ecr.cn-north-1.amazonaws.com.cn/cdk-hnb659fds-container-assets-123456789012-cn-north-1:abc123'
+      );
+    });
+
+    it('resolves canonical fromImageAsset shape under aws-us-gov partition (issue #637)', () => {
+      // GovCloud uses urlSuffix amazonaws.com (same as commercial), but
+      // partition is aws-us-gov (not visible in the URI itself — the
+      // partition matters for service ARNs elsewhere).
+      const resolved = resolveLambdaByLogicalId('Fn', [
+        makeStack({ Fn: fromImageAssetJoin('us-gov-west-1') }, 'us-gov-west-1'),
+      ]);
+      expect(resolved.kind).toBe('image');
+      if (resolved.kind !== 'image') return;
+      expect(resolved.imageUri).toBe(
+        '123456789012.dkr.ecr.us-gov-west-1.amazonaws.com/cdk-hnb659fds-container-assets-123456789012-us-gov-west-1:abc123'
+      );
+    });
+
+    it('throws a clear error when stack.region is undefined (fallback path)', () => {
+      // No region context means we cannot derive urlSuffix / partition,
+      // so the canonical fromImageAsset shape falls back to the
+      // pre-#637 `not-applicable` branch. The error message names the
+      // root cause specifically (stack.region was undefined).
       expect(() =>
-        resolveLambdaByLogicalId('Fn', [makeStack({ Fn: joinResource })])
-      ).toThrow(/AWS::URLSuffix/);
-      // Critically: the post-fix error must NOT be the pre-fix
-      // misleading "no Runtime" message.
+        resolveLambdaByLogicalId('Fn', [makeStack({ Fn: fromImageAssetJoin('us-east-1') })])
+      ).toThrow(/stack\.region was undefined/);
+      // Regression guard against #627's pre-fix misleading "no Runtime"
+      // hard error.
       expect(() =>
-        resolveLambdaByLogicalId('Fn', [makeStack({ Fn: joinResource })])
+        resolveLambdaByLogicalId('Fn', [makeStack({ Fn: fromImageAssetJoin('us-east-1') })])
       ).not.toThrow(/no Runtime property/);
     });
 

--- a/tests/unit/local/intrinsic-image.test.ts
+++ b/tests/unit/local/intrinsic-image.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test';
 import {
+  derivePseudoParametersFromRegion,
   substituteImagePlaceholders,
   tryResolveImageFnJoin,
   type ImageResolutionContext,
@@ -264,5 +265,85 @@ describe('substituteImagePlaceholders', () => {
 
   it('leaves unrecognized placeholders untouched', () => {
     expect(substituteImagePlaceholders('${Unknown}/x', {}, undefined)).toBe('${Unknown}/x');
+  });
+});
+
+describe('derivePseudoParametersFromRegion (issue #637)', () => {
+  it('returns aws partition for standard commercial regions', () => {
+    expect(derivePseudoParametersFromRegion('us-east-1')).toEqual({
+      region: 'us-east-1',
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+    expect(derivePseudoParametersFromRegion('eu-west-2')).toEqual({
+      region: 'eu-west-2',
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+    expect(derivePseudoParametersFromRegion('ap-northeast-1')).toEqual({
+      region: 'ap-northeast-1',
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+  });
+
+  it('returns aws-cn partition + .com.cn urlSuffix for China regions', () => {
+    expect(derivePseudoParametersFromRegion('cn-north-1')).toEqual({
+      region: 'cn-north-1',
+      partition: 'aws-cn',
+      urlSuffix: 'amazonaws.com.cn',
+    });
+    expect(derivePseudoParametersFromRegion('cn-northwest-1')).toEqual({
+      region: 'cn-northwest-1',
+      partition: 'aws-cn',
+      urlSuffix: 'amazonaws.com.cn',
+    });
+  });
+
+  it('returns aws-us-gov partition for GovCloud regions (urlSuffix stays .com)', () => {
+    expect(derivePseudoParametersFromRegion('us-gov-west-1')).toEqual({
+      region: 'us-gov-west-1',
+      partition: 'aws-us-gov',
+      urlSuffix: 'amazonaws.com',
+    });
+    expect(derivePseudoParametersFromRegion('us-gov-east-1')).toEqual({
+      region: 'us-gov-east-1',
+      partition: 'aws-us-gov',
+      urlSuffix: 'amazonaws.com',
+    });
+  });
+
+  it('returns aws-iso / aws-iso-b partitions for ISO regions', () => {
+    // us-isob-* must be checked BEFORE us-iso-* (prefix overlap).
+    expect(derivePseudoParametersFromRegion('us-iso-east-1')).toEqual({
+      region: 'us-iso-east-1',
+      partition: 'aws-iso',
+      urlSuffix: 'c2s.ic.gov',
+    });
+    expect(derivePseudoParametersFromRegion('us-isob-east-1')).toEqual({
+      region: 'us-isob-east-1',
+      partition: 'aws-iso-b',
+      urlSuffix: 'sc2s.sgov.gov',
+    });
+  });
+
+  it('passes accountId through when supplied', () => {
+    expect(derivePseudoParametersFromRegion('us-east-1', '123456789012')).toEqual({
+      accountId: '123456789012',
+      region: 'us-east-1',
+      partition: 'aws',
+      urlSuffix: 'amazonaws.com',
+    });
+  });
+
+  it('omits accountId field when not supplied', () => {
+    const result = derivePseudoParametersFromRegion('us-east-1');
+    expect(result).toBeDefined();
+    expect(result).not.toHaveProperty('accountId');
+  });
+
+  it('returns undefined for empty / falsy region', () => {
+    expect(derivePseudoParametersFromRegion(undefined)).toBeUndefined();
+    expect(derivePseudoParametersFromRegion('')).toBeUndefined();
   });
 });

--- a/tests/unit/local/lambda-resolver.test.ts
+++ b/tests/unit/local/lambda-resolver.test.ts
@@ -17,7 +17,8 @@ import type { CloudFormationTemplate, TemplateResource } from '../../../src/type
 function buildStack(
   stackName: string,
   resources: Record<string, TemplateResource>,
-  cdkOutDir: string
+  cdkOutDir: string,
+  region?: string
 ): StackInfo {
   const template: CloudFormationTemplate = { Resources: resources };
   // Materialize each asset.* directory referenced by Metadata.aws:asset:path
@@ -41,6 +42,7 @@ function buildStack(
     template,
     assetManifestPath: manifestPath,
     dependencyNames: [],
+    ...(region !== undefined && { region }),
   };
 }
 
@@ -541,6 +543,80 @@ describe('resolveLambdaTarget', () => {
     );
     expect(() => resolveLambdaTarget('MyStack:ImportedRepoFn', [stack])).toThrow(
       /Fn::Join Code\.ImageUri that cdkd local invoke cannot resolve/
+    );
+  });
+
+  it('resolves canonical fromImageAsset Fn::Join Code.ImageUri using region-derived URLSuffix (issue #637)', () => {
+    // The canonical `lambda.DockerImageCode.fromImageAsset(...)` shape:
+    // literal account / region / repo path + `Ref: AWS::URLSuffix`.
+    // Pre-#637 this surfaced `not-applicable` and required `--from-state`
+    // even though the only intrinsic was URLSuffix (derivable from
+    // region). Post-#637 the resolver substitutes URLSuffix using
+    // `stack.region` and the URI resolves cleanly.
+    const stack = buildStack(
+      'MyStack',
+      {
+        AssetFn: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            PackageType: 'Image',
+            Code: {
+              ImageUri: {
+                'Fn::Join': [
+                  '',
+                  [
+                    '123456789012.dkr.ecr.us-east-1.',
+                    { Ref: 'AWS::URLSuffix' },
+                    '/cdk-hnb659fds-container-assets-123456789012-us-east-1:abc123',
+                  ],
+                ],
+              },
+            },
+          },
+        },
+      },
+      tmpRoot,
+      'us-east-1'
+    );
+    const resolved = resolveLambdaTarget('MyStack:AssetFn', [stack]);
+    expect(resolved.kind).toBe('image');
+    if (resolved.kind !== 'image') return;
+    expect(resolved.imageUri).toBe(
+      '123456789012.dkr.ecr.us-east-1.amazonaws.com/cdk-hnb659fds-container-assets-123456789012-us-east-1:abc123'
+    );
+  });
+
+  it('resolves canonical fromImageAsset shape against aws-cn partition (issue #637)', () => {
+    const stack = buildStack(
+      'MyStack',
+      {
+        AssetFn: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            PackageType: 'Image',
+            Code: {
+              ImageUri: {
+                'Fn::Join': [
+                  '',
+                  [
+                    '123456789012.dkr.ecr.cn-north-1.',
+                    { Ref: 'AWS::URLSuffix' },
+                    '/cdk-hnb659fds-container-assets-123456789012-cn-north-1:abc123',
+                  ],
+                ],
+              },
+            },
+          },
+        },
+      },
+      tmpRoot,
+      'cn-north-1'
+    );
+    const resolved = resolveLambdaTarget('MyStack:AssetFn', [stack]);
+    expect(resolved.kind).toBe('image');
+    if (resolved.kind !== 'image') return;
+    expect(resolved.imageUri).toBe(
+      '123456789012.dkr.ecr.cn-north-1.amazonaws.com.cn/cdk-hnb659fds-container-assets-123456789012-cn-north-1:abc123'
     );
   });
 


### PR DESCRIPTION
## Summary

`cdkd local start-api` and `cdkd local invoke` hard-errored on the canonical CDK 2.x `lambda.DockerImageCode.fromImageAsset(...)` synthesized shape — `Fn::Join` over the literal bootstrap ECR repo URI with `${AWS::URLSuffix}` as the only intrinsic — even though the `${AWS::URLSuffix}` value is trivially derivable from the deploy region.

This was the deferred follow-up from PR #632 (closes #627) where the error message was rewritten to clearly point at the gap. This PR actually closes the gap.

## Implementation

### New helper

`derivePseudoParametersFromRegion(region, accountId?)` in [src/local/intrinsic-image.ts](src/local/intrinsic-image.ts) — derives `{urlSuffix, partition, region [, accountId]}` from the region prefix, following AWS partition rules:

| Region prefix | Partition | URLSuffix |
| --- | --- | --- |
| `cn-*` | `aws-cn` | `amazonaws.com.cn` |
| `us-gov-*` | `aws-us-gov` | `amazonaws.com` |
| `us-isob-*` | `aws-iso-b` | `sc2s.sgov.gov` |
| `us-iso-*` | `aws-iso` | `c2s.ic.gov` |
| else | `aws` | `amazonaws.com` |

Returns `undefined` for missing / empty region so the caller can fall through cleanly.

### Both call sites updated in lockstep (per the issue's "lockstep" requirement)

- [src/cli/commands/local-start-api.ts](src/cli/commands/local-start-api.ts):`extractImageUri` and [src/local/lambda-resolver.ts](src/local/lambda-resolver.ts):`extractImageUri` now accept a `region` parameter and pass `{pseudoParameters: derivePseudoParametersFromRegion(region)}` as `tryResolveImageFnJoin`'s context.

- `not-applicable` error messages updated to be more specific:
  - When pseudo parameters WERE derivable (region known), the remaining cause is `${AWS::AccountId}` which still needs `--from-state` or STS — error names this explicitly.
  - When region was undefined (fallback path), error names that as the root cause and points at `--from-state` / a literal image URI as workarounds.

- `region` is sourced from `stack.region` (already populated on `StackInfo` from CDK synth's environment block). No new plumbing through the dispatcher.

### What this does NOT fix (intentionally deferred)

- **Same-stack ECR refs** (`Ref: <SameStackEcrRepo>`): still requires `--from-state` (the `needs-state` arm). Out of scope — separate issue if needed.
- **`${AWS::AccountId}` in image URIs without `--from-state`**: would need an STS `GetCallerIdentity` call. Bootstrap-ECR URI has account-id as a literal in the template, so this isn't needed for the canonical CDK shape — deferred until someone hits a real-world case.

## Test plan

- [x] `vp check --fix` passes (typecheck + lint + format, 0 warnings / 0 errors)
- [x] `vp run build` passes
- [x] `vp run test` passes — 373 test files, 5729 tests (12 net new tests in this PR)
- [x] **New** unit tests:
  - 7 tests for `derivePseudoParametersFromRegion`: aws / aws-cn / aws-us-gov / aws-iso / aws-iso-b partitions, accountId pass-through, empty region
  - 3 tests in `local-start-api-container.test.ts`: canonical fromImageAsset resolves under aws / aws-cn / aws-us-gov partitions
  - 1 test in `local-start-api-container.test.ts`: canonical shape WITHOUT region throws clear error mentioning `stack.region was undefined` (regression guard for the fallback path)
  - 2 tests in `lambda-resolver.test.ts`: same canonical shape resolution under aws + aws-cn partitions
- [x] **Pre-existing tests preserved**:
  - The pre-#637 throw test in `local-start-api-container.test.ts` (canonical shape → throws `/AWS::URLSuffix/`) was REPLACED with the new behavior (resolves with region; throws "region undefined" without). This is the only test that changed behavior — explicitly noted so the reviewer can confirm the update is intended.
  - The `lambda-resolver.test.ts` imported-repo Fn::Join test (no region, no ECR ref) STILL throws with the same error prefix — `buildStack` left region undefined, so the no-region fallback path fires.

## Note for the merger

This PR touches `src/cli/commands/local-start-api.ts` AND `src/local/**` which are both in the `integ-local` markgate gate scope. Before merging, run `/run-integ local-start-api` to refresh the marker.

Closes #637
