### PR TITLE
fix(local): resolve Fn::Select + Fn::Split in --from-state env vars (#636)

### DIFF
--- a/src/local/state-resolver.ts
+++ b/src/local/state-resolver.ts
@@ -39,6 +39,19 @@
  *     `ecs.Secret.fromSsmParameter` shape CDK synthesizes is
  *     `Fn::Join` with pseudo-parameter `Ref`s + a `Ref` to the
  *     parameter; without Fn::Join support the secret silently drops).
+ *   - `Fn::Select: [<index>, <list>]` — picks the indexed element of an
+ *     array. Index may be a number or a numeric string (CFn templates
+ *     often carry the string form). The list argument may be a literal
+ *     array of intrinsics OR an intrinsic that resolves to a
+ *     `string[]` (today: only `Fn::Split`). Out-of-bounds / negative /
+ *     non-finite index reports unresolved. Closes issue #636 — the
+ *     `Fn.select(N, Fn.split(':', secret.secretArn))` shape CDK
+ *     synthesizes for parsing secret ARN segments.
+ *   - `Fn::Split: [<delimiter>, <string>]` — splits a string into a
+ *     `string[]`. **Only valid INSIDE `Fn::Select`** — at the env-var
+ *     top level the result is an array which can't be an env-var
+ *     value, so the top-level dispatcher reports unresolved with a
+ *     clear reason.
  *   - `Ref: AWS::AccountId` / `AWS::Region` / `AWS::Partition` /
  *     `AWS::URLSuffix` — substituted from the optional
  *     `pseudoParameters` bag the caller supplies. When the bag is
@@ -78,9 +91,9 @@
  *
  *   - Cross-region `Fn::ImportValue` (tracked under #451).
  *   - Cross-account `Fn::GetStackOutput.RoleArn` (tracked under #449).
- *   - Other intrinsics (`Fn::Select`, `Fn::Split`, `Fn::If`, etc.).
- *     Anything beyond the supported set is reported as unresolved and the
- *     env var is dropped, matching PR 1's "warn-and-drop" semantics.
+ *   - Other intrinsics (`Fn::If`, `Fn::FindInMap`, etc.). Anything
+ *     beyond the supported set is reported as unresolved and the env
+ *     var is dropped, matching PR 1's "warn-and-drop" semantics.
  *
  * Failure mode: per-key best-effort. When a substitution can't be
  * produced (state missing for the referenced logical ID, attribute not
@@ -242,10 +255,23 @@ export function substituteAgainstState(
   if (intrinsic === 'Fn::Join') {
     return resolveJoin(arg, context);
   }
+  if (intrinsic === 'Fn::Select') {
+    return resolveSelect(arg, context);
+  }
+  if (intrinsic === 'Fn::Split') {
+    // `Fn::Split` returns a string[]; an array cannot be an env-var
+    // value, so at the top level we always reject it with a clear
+    // reason. It's still resolvable inside `Fn::Select` via
+    // `resolveAny` below.
+    return {
+      kind: 'unresolved',
+      reason: `Fn::Split returns an array, which is not a valid env-var value (use Fn::Select to pick one element)`,
+    };
+  }
 
   return {
     kind: 'unresolved',
-    reason: `unsupported intrinsic '${intrinsic}' (supported: Ref, Fn::GetAtt, Fn::Sub, Fn::Join)`,
+    reason: `unsupported intrinsic '${intrinsic}' (supported: Ref, Fn::GetAtt, Fn::Sub, Fn::Join, Fn::Select, Fn::Split)`,
   };
 }
 
@@ -504,6 +530,12 @@ function resolveJoin(arg: unknown, context: SubstitutionContext): StateSubstitut
     };
   }
 
+  // Each element MUST resolve to a scalar — `Fn::Join` of arrays is not
+  // a thing in CFn. We deliberately call `substituteAgainstState` (the
+  // scalar-only top-level dispatcher) rather than `resolveAny` so that a
+  // bare `Fn::Split` element gets the same warn-and-drop UX as at the
+  // top level. (Inside `Fn::Select`, `resolveAny` IS used to admit
+  // arrays — that asymmetry mirrors `intrinsic-image.ts`.)
   const parts: string[] = [];
   for (let i = 0; i < elements.length; i += 1) {
     const sub = substituteAgainstState(elements[i], context);
@@ -516,6 +548,173 @@ function resolveJoin(arg: unknown, context: SubstitutionContext): StateSubstitut
     parts.push(String(sub.value));
   }
   return { kind: 'literal', value: parts.join(delimiterRaw) };
+}
+
+/**
+ * `Fn::Select: [<index>, <list>]` — pick the indexed element of an
+ * array. Mirrors the semantics of `resolveImageIntrinsic`'s `Fn::Select`
+ * branch in `src/local/intrinsic-image.ts` so the two resolvers behave
+ * the same way for the same template shape.
+ *
+ *   - Index may be a number (`0`) OR a numeric string (`'0'`) — CFn
+ *     templates often carry the string form after a JSON round-trip.
+ *   - List may be a resolved-array intrinsic (today only `Fn::Split`
+ *     produces a `string[]`) OR a literal `[...]` array of intrinsics
+ *     resolved on the fly.
+ *   - Out-of-bounds / negative / non-finite index reports unresolved.
+ */
+function resolveSelect(arg: unknown, context: SubstitutionContext): StateSubstitutionResult {
+  if (!Array.isArray(arg) || arg.length !== 2) {
+    return {
+      kind: 'unresolved',
+      reason: `Fn::Select expects [index, list], got ${
+        Array.isArray(arg) ? `array of length ${arg.length}` : typeof arg
+      }`,
+    };
+  }
+  const [rawIndex, listArg] = arg as [unknown, unknown];
+
+  let index: number | undefined;
+  if (typeof rawIndex === 'number') {
+    index = rawIndex;
+  } else if (typeof rawIndex === 'string' && /^-?\d+$/.test(rawIndex)) {
+    index = Number.parseInt(rawIndex, 10);
+  }
+  if (index === undefined || !Number.isFinite(index)) {
+    return {
+      kind: 'unresolved',
+      reason: `Fn::Select index must be a finite number (or numeric string), got ${typeof rawIndex}`,
+    };
+  }
+  if (index < 0) {
+    return {
+      kind: 'unresolved',
+      reason: `Fn::Select index must be non-negative, got ${index}`,
+    };
+  }
+
+  // Resolve the list arg through the array-tolerant helper so a nested
+  // `Fn::Split` produces a real `string[]`.
+  const list = resolveAny(listArg, context);
+  if (list.kind === 'unresolved') {
+    return {
+      kind: 'unresolved',
+      reason: `Fn::Select list: ${list.reason}`,
+    };
+  }
+
+  if (Array.isArray(list.value)) {
+    if (index >= list.value.length) {
+      return {
+        kind: 'unresolved',
+        reason: `Fn::Select index ${index} out of bounds (list length ${list.value.length})`,
+      };
+    }
+    const picked = list.value[index]!;
+    return { kind: 'literal', value: picked };
+  }
+
+  // The list arg resolved to a scalar — that's not a valid list. Most
+  // common cause: the template author passed a single intrinsic that
+  // resolves to a string instead of a `Fn::Split` / literal array.
+  return {
+    kind: 'unresolved',
+    reason: `Fn::Select list must resolve to an array, got ${typeof list.value}`,
+  };
+}
+
+/**
+ * `Fn::Split: [<delimiter>, <string>]` — split a string into a
+ * `string[]`. Only callable through `resolveAny` (i.e. inside
+ * `Fn::Select`); the top-level dispatcher rejects bare `Fn::Split`
+ * since an array cannot be an env-var value.
+ *
+ * The string argument can itself be an intrinsic (typical CDK shape:
+ * `Fn::Split: [':', { 'Fn::GetAtt': [<Secret>, 'SecretArn'] }]`); it's
+ * resolved through `substituteAgainstState` so we don't accidentally
+ * admit nested-array shapes there.
+ */
+function resolveSplitAsArray(
+  arg: unknown,
+  context: SubstitutionContext
+): { kind: 'literal'; value: string[] } | { kind: 'unresolved'; reason: string } {
+  if (!Array.isArray(arg) || arg.length !== 2) {
+    return {
+      kind: 'unresolved',
+      reason: `Fn::Split expects [delimiter, string], got ${
+        Array.isArray(arg) ? `array of length ${arg.length}` : typeof arg
+      }`,
+    };
+  }
+  const [delim, src] = arg as [unknown, unknown];
+  if (typeof delim !== 'string') {
+    return {
+      kind: 'unresolved',
+      reason: `Fn::Split delimiter must be a string, got ${typeof delim}`,
+    };
+  }
+  const sub = substituteAgainstState(src, context);
+  if (sub.kind !== 'literal') {
+    return {
+      kind: 'unresolved',
+      reason: `Fn::Split string argument: ${sub.reason}`,
+    };
+  }
+  if (typeof sub.value !== 'string') {
+    return {
+      kind: 'unresolved',
+      reason: `Fn::Split string argument must resolve to a string, got ${typeof sub.value}`,
+    };
+  }
+  return { kind: 'literal', value: sub.value.split(delim) };
+}
+
+/**
+ * Array-tolerant resolver used by `Fn::Select`'s `list` argument.
+ * Returns either the scalar `StateSubstitutionResult` shape (delegating
+ * to `substituteAgainstState`) OR a `{kind: 'literal', value: string[]}`
+ * when the node is `Fn::Split` / a literal array of intrinsics.
+ *
+ * Top-level `substituteAgainstState` deliberately doesn't go through
+ * this helper — env-var values can't be arrays, and the asymmetry
+ * matches `intrinsic-image.ts`'s `resolveImageIntrinsic` (scalar) vs
+ * `resolveImageIntrinsicAny` (scalar OR array) split.
+ */
+function resolveAny(
+  value: unknown,
+  context: SubstitutionContext
+):
+  | { kind: 'literal'; value: string | number | boolean | string[] }
+  | { kind: 'unresolved'; reason: string } {
+  // Literal arrays of intrinsics: resolve each element to a scalar.
+  if (Array.isArray(value)) {
+    const out: string[] = [];
+    for (let i = 0; i < value.length; i += 1) {
+      const sub = substituteAgainstState(value[i], context);
+      if (sub.kind !== 'literal') {
+        return {
+          kind: 'unresolved',
+          reason: `list element [${i}]: ${sub.reason}`,
+        };
+      }
+      out.push(String(sub.value));
+    }
+    return { kind: 'literal', value: out };
+  }
+
+  // Direct `Fn::Split` intrinsic — produces an array.
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value as Record<string, unknown>).length === 1 &&
+    Object.prototype.hasOwnProperty.call(value, 'Fn::Split')
+  ) {
+    return resolveSplitAsArray((value as Record<string, unknown>)['Fn::Split'], context);
+  }
+
+  // Anything else: fall back to the scalar top-level dispatcher.
+  return substituteAgainstState(value, context);
 }
 
 /**
@@ -575,7 +774,9 @@ export async function substituteAgainstStateAsync(
     intrinsic === 'Ref' ||
     intrinsic === 'Fn::GetAtt' ||
     intrinsic === 'Fn::Sub' ||
-    intrinsic === 'Fn::Join'
+    intrinsic === 'Fn::Join' ||
+    intrinsic === 'Fn::Select' ||
+    intrinsic === 'Fn::Split'
   ) {
     return substituteAgainstState(value, context);
   }
@@ -589,7 +790,7 @@ export async function substituteAgainstStateAsync(
 
   return {
     kind: 'unresolved',
-    reason: `unsupported intrinsic '${intrinsic}' (supported: Ref, Fn::GetAtt, Fn::Sub, Fn::Join, Fn::ImportValue, Fn::GetStackOutput)`,
+    reason: `unsupported intrinsic '${intrinsic}' (supported: Ref, Fn::GetAtt, Fn::Sub, Fn::Join, Fn::Select, Fn::Split, Fn::ImportValue, Fn::GetStackOutput)`,
   };
 }
 

--- a/tests/unit/local/state-resolver.test.ts
+++ b/tests/unit/local/state-resolver.test.ts
@@ -162,12 +162,15 @@ describe('substituteAgainstState', () => {
     }
   });
 
-  it('reports unresolved for unsupported intrinsics (Fn::ImportValue, Fn::Select, etc.)', () => {
-    const r2 = substituteAgainstState({ 'Fn::ImportValue': 'OtherStackExport' }, {});
-    expect(r2.kind).toBe('unresolved');
+  it('reports unresolved for unsupported intrinsics (Fn::ImportValue, Fn::If, etc.)', () => {
+    const r1 = substituteAgainstState({ 'Fn::ImportValue': 'OtherStackExport' }, {});
+    expect(r1.kind).toBe('unresolved');
 
-    const r3 = substituteAgainstState({ 'Fn::Select': [0, ['a', 'b']] }, {});
-    expect(r3.kind).toBe('unresolved');
+    const r2 = substituteAgainstState(
+      { 'Fn::If': ['Cond', 'a', 'b'] } as Record<string, unknown>,
+      {}
+    );
+    expect(r2.kind).toBe('unresolved');
   });
 
   it('reports unresolved for objects with multiple keys (not a valid intrinsic shape)', () => {
@@ -319,6 +322,205 @@ describe('substituteAgainstState', () => {
       kind: 'literal',
       value: 'arn:aws:ssm:us-east-1:123456789012:parameter//app/param',
     });
+  });
+});
+
+/**
+ * Test suite for issue #636 — `Fn::Select` + `Fn::Split` support so the
+ * canonical CDK `Fn.select(N, Fn.split(':', secret.secretArn))` shape
+ * resolves instead of warn-and-dropping the env var.
+ */
+describe('substituteAgainstState (Fn::Select / Fn::Split)', () => {
+  it('picks the indexed element from a literal-array list under Fn::Select', () => {
+    const r = substituteAgainstState({ 'Fn::Select': [1, ['a', 'b', 'c']] }, {});
+    expect(r).toEqual({ kind: 'literal', value: 'b' });
+  });
+
+  it('resolves Fn::Select over Fn::Split over a literal ARN string', () => {
+    // Common CDK pattern: parse the 7th `:`-segment off a secret ARN.
+    const arn = 'arn:aws:secretsmanager:us-east-1:123:secret:mysecret-AbCdEf';
+    const r = substituteAgainstState(
+      { 'Fn::Select': [6, { 'Fn::Split': [':', arn] }] },
+      {}
+    );
+    expect(r).toEqual({ kind: 'literal', value: 'mysecret-AbCdEf' });
+  });
+
+  it('resolves Fn::Select over Fn::Split over a Fn::GetAtt with a state-recorded attribute', () => {
+    // The canonical `Fn.select(6, Fn.split(':', secret.secretArn))` shape.
+    const resources: Record<string, ResourceState> = {
+      MySecret: res('secret-physical-id', {
+        Arn: 'arn:aws:secretsmanager:us-east-1:123:secret:mysecret-AbCdEf',
+      }),
+    };
+    const r = substituteAgainstState(
+      {
+        'Fn::Select': [
+          6,
+          { 'Fn::Split': [':', { 'Fn::GetAtt': ['MySecret', 'Arn'] }] },
+        ],
+      },
+      resources
+    );
+    expect(r).toEqual({ kind: 'literal', value: 'mysecret-AbCdEf' });
+  });
+
+  it('accepts a numeric-string index (the CFn template shape after JSON round-trip)', () => {
+    const r = substituteAgainstState(
+      { 'Fn::Select': ['0', ['first', 'second']] },
+      {}
+    );
+    expect(r).toEqual({ kind: 'literal', value: 'first' });
+  });
+
+  it('resolves Fn::Select with intrinsic-valued literal-array elements', () => {
+    const resources: Record<string, ResourceState> = {
+      MyTable: res('tbl-deployed'),
+    };
+    const r = substituteAgainstState(
+      { 'Fn::Select': [1, ['first', { Ref: 'MyTable' }, 'third']] },
+      resources
+    );
+    expect(r).toEqual({ kind: 'literal', value: 'tbl-deployed' });
+  });
+
+  it('rejects bare Fn::Split at the top level (arrays are not valid env-var values)', () => {
+    const r = substituteAgainstState({ 'Fn::Split': [':', 'a:b:c'] }, {});
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.reason).toContain('Fn::Split');
+      expect(r.reason).toContain('array');
+    }
+  });
+
+  it('reports unresolved on out-of-bounds Fn::Select index', () => {
+    const r = substituteAgainstState({ 'Fn::Select': [5, ['a', 'b']] }, {});
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.reason).toContain('out of bounds');
+    }
+  });
+
+  it('reports unresolved on negative Fn::Select index', () => {
+    const r = substituteAgainstState({ 'Fn::Select': [-1, ['a', 'b']] }, {});
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.reason).toContain('non-negative');
+    }
+  });
+
+  it('reports unresolved on non-numeric Fn::Select index', () => {
+    const r = substituteAgainstState(
+      { 'Fn::Select': ['not-a-number', ['a', 'b']] },
+      {}
+    );
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.reason).toContain('finite number');
+    }
+  });
+
+  it('rejects malformed Fn::Select argument shapes', () => {
+    const r1 = substituteAgainstState({ 'Fn::Select': 'not-an-array' }, {});
+    expect(r1.kind).toBe('unresolved');
+    if (r1.kind === 'unresolved') expect(r1.reason).toContain('Fn::Select expects');
+
+    const r2 = substituteAgainstState({ 'Fn::Select': [0] }, {});
+    expect(r2.kind).toBe('unresolved');
+  });
+
+  it('rejects Fn::Select when the list arg resolves to a scalar (not an array)', () => {
+    const resources: Record<string, ResourceState> = {
+      MyTable: res('scalar-value'),
+    };
+    const r = substituteAgainstState(
+      { 'Fn::Select': [0, { Ref: 'MyTable' }] },
+      resources
+    );
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.reason).toContain('must resolve to an array');
+    }
+  });
+
+  it('propagates Fn::Split inner-string resolution failures through Fn::Select', () => {
+    const r = substituteAgainstState(
+      {
+        'Fn::Select': [0, { 'Fn::Split': [':', { Ref: 'NotInState' }] }],
+      },
+      {}
+    );
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.reason).toContain('NotInState');
+    }
+  });
+
+  it('rejects malformed Fn::Split shape under Fn::Select', () => {
+    const r = substituteAgainstState(
+      { 'Fn::Select': [0, { 'Fn::Split': 'not-an-array' }] },
+      {}
+    );
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.reason).toContain('Fn::Split expects');
+    }
+  });
+
+  it('rejects Fn::Split with non-string delimiter under Fn::Select', () => {
+    const r = substituteAgainstState(
+      { 'Fn::Select': [0, { 'Fn::Split': [42, 'a:b'] }] },
+      {}
+    );
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.reason).toContain('delimiter must be a string');
+    }
+  });
+
+  it('keeps Fn::Join element-level resolution scalar-only (rejects nested Fn::Split element)', () => {
+    // Join elements must be scalars in CFn; a bare Fn::Split inside a
+    // Join element should fall under the top-level Fn::Split rejection.
+    const r = substituteAgainstState(
+      { 'Fn::Join': ['-', ['x', { 'Fn::Split': [':', 'a:b'] }]] },
+      {}
+    );
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.reason).toContain('Fn::Join element [1]');
+      expect(r.reason).toContain('Fn::Split');
+    }
+  });
+});
+
+describe('substituteAgainstStateAsync (Fn::Select / Fn::Split)', () => {
+  it('resolves Fn::Select through the async dispatcher (delegates to sync path)', async () => {
+    const resources: Record<string, ResourceState> = {
+      MySecret: res('secret-physical-id', {
+        Arn: 'arn:aws:secretsmanager:us-east-1:123:secret:mysecret-AbCdEf',
+      }),
+    };
+    const r = await substituteAgainstStateAsync(
+      {
+        'Fn::Select': [
+          6,
+          { 'Fn::Split': [':', { 'Fn::GetAtt': ['MySecret', 'Arn'] }] },
+        ],
+      },
+      resources
+    );
+    expect(r).toEqual({ kind: 'literal', value: 'mysecret-AbCdEf' });
+  });
+
+  it('rejects bare Fn::Split at the async top level', async () => {
+    const r = await substituteAgainstStateAsync(
+      { 'Fn::Split': [':', 'a:b:c'] },
+      {}
+    );
+    expect(r.kind).toBe('unresolved');
+    if (r.kind === 'unresolved') {
+      expect(r.reason).toContain('Fn::Split');
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

`cdkd local invoke|start-api|run-task|start-service --from-state` warned-and-dropped Lambda env vars / ECS container env vars / ECS secrets whose value was an `Fn::Select` (or `Fn::Split`) intrinsic. The substitution layer in [src/local/state-resolver.ts](src/local/state-resolver.ts) only accepted `Ref` / `Fn::GetAtt` / `Fn::Sub` / `Fn::Join`.

A common CDK 2.x pattern that hit this:

```ts
new lambda.Function(this, 'Fn', {
  environment: {
    SECRET_NAME: Fn.select(6, Fn.split(':', secret.secretArn)),
    //                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    //                       Fn::Select over Fn::Split — common ARN parser
  },
});
```

cdkd warned `"unsupported intrinsic 'Fn::Select'"` and dropped the env var. The `--env-vars SECRET_NAME=...` workaround is tedious for stacks that lean on `Fn.select` heavily.

## Implementation

Added `Fn::Select` + `Fn::Split` arms to BOTH dispatchers in [src/local/state-resolver.ts](src/local/state-resolver.ts) — the sync dispatcher (line ~245) and the async dispatcher (line ~590) which supports the extra `Fn::ImportValue` / `Fn::GetStackOutput` intrinsics. Both follow the same shape; the async dispatcher delegates to the sync one for the legacy intrinsics, so the new arms drop into both with no duplication.

**Approach**: Option (b) parallel `resolveAny` helper, mirroring `intrinsic-image.ts`'s `resolveImageIntrinsic` / `resolveImageIntrinsicAny` split exactly:

- `resolveAny` returns scalar OR `string[]` (the latter only valid inside `Fn::Select`).
- `Fn::Select` consumes its `list` argument through it.
- The top-level `resolveValue` stays scalar-only — arrays cannot be env var values, so a bare top-level `Fn::Split` returns `unresolved` with a clear reason.
- `Fn::Join`'s elements still resolve through the scalar-only helper (matches CFn's deploy-time semantics — a bare `Fn::Split` inside a `Fn::Join` element falls under the top-level Fn::Split rejection, covered by a test).

### Resolution semantics

- `Fn::Split: [delim, str]` → returns `string[]`. Only valid inside `Fn::Select`.
- `Fn::Select: [index, list]`:
  - Accepts numeric AND numeric-string index (the latter matches what CFn templates often carry).
  - Returns `unresolved` on out-of-bounds / negative / non-finite index (mirrors CFn's deploy-time behavior).
  - Accepts both a resolved-array list AND a literal `[...]` array of intrinsics (each resolved on the fly).

### Error-message update

Both dispatcher `unsupported intrinsic` errors now include the new supported set:

```
unsupported intrinsic '<X>' (supported: Ref, Fn::GetAtt, Fn::Sub, Fn::Join, Fn::Select, Fn::Split, ...)
```

## What this does NOT add

- `Fn::FindInMap` / `Fn::If` / `Fn::Equals` / `Fn::And` / `Fn::Or` / `Fn::Not` / `Fn::Cidr` / `Fn::GetAZs` / `Fn::Base64` — none reported as user pain today. File a follow-up issue per intrinsic when a user hits one.

## Test plan

- [x] `vp check --fix` passes
- [x] `vp run build` passes
- [x] `vp run test` passes — 373 test files, 5734 tests (17 net new tests in this PR)
- [x] New tests cover: literal-array list, `Fn::Split` over literal ARN, `Fn::Split` over `Fn::GetAtt` with state-resolved attr, top-level `Fn::Split` rejection, out-of-bounds / negative / non-finite index, numeric-string index, async-dispatcher `Fn::Select` arm exercise.

## Note for the merger

This PR touches `src/local/state-resolver.ts` which is in the `integ-local` markgate gate scope. Before merging, run `/run-integ local-start-api` to refresh the marker. **PR #639 (#637 follow-up)** is opened in parallel and also touches `src/local/**` — one `/run-integ local-start-api` run is sufficient to refresh both.

Closes #636
