### PR TITLE
fix(local): use absolute GitHub URLs in user-facing docs references (#641)

### DIFF
--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -1234,7 +1234,7 @@ function warnVpcConfigLambdas(
       const vpcConfig = props['VpcConfig'];
       if (vpcConfig && typeof vpcConfig === 'object' && Object.keys(vpcConfig).length > 0) {
         logger.warn(
-          `Lambda ${logicalId} has VpcConfig — local container will reach external services via the host's network, NOT through the deployed VPC's NAT/private subnets. Calls to private RDS/ElastiCache will fail. See docs/cli-reference.md (cdkd local start-api — Limitations) for details.`
+          `Lambda ${logicalId} has VpcConfig — local container will reach external services via the host's network, NOT through the deployed VPC's NAT/private subnets. Calls to private RDS/ElastiCache will fail. See https://github.com/go-to-k/cdkd/blob/main/docs/cli-reference.md (cdkd local start-api — Limitations) for details.`
         );
       }
       break;
@@ -1267,7 +1267,7 @@ function warnIamRoutes(routesWithAuth: readonly RouteWithAuth[]): boolean {
       `verifies SigV4 signatures against your local AWS credentials, but does NOT emulate IAM ` +
       `policy evaluation (resource / action / condition rules). Signature-verified callers reach ` +
       `the handler under their own identity; downstream authorization is the dev's responsibility. ` +
-      `See docs/cli-reference.md (cdkd local start-api — AWS_IAM authorizer) for details.`
+      `See https://github.com/go-to-k/cdkd/blob/main/docs/cli-reference.md (cdkd local start-api — AWS_IAM authorizer) for details.`
   );
   for (const declaredAt of iamRoutes) {
     logger.warn(`  - ${declaredAt}`);
@@ -2705,7 +2705,7 @@ export function resolveMtlsConfig(
 export function createLocalStartApiCommand(): Command {
   const startApi = new Command('start-api')
     .description(
-      'Run a long-running local HTTP server that maps API Gateway routes (REST v1, HTTP API, Function URL) to Lambda invocations against the AWS Lambda Runtime Interface Emulator (Docker required). Supports Lambda TOKEN/REQUEST authorizers, Cognito User Pool / HTTP v2 JWT authorizers, and AWS_IAM auth (REST v1 `AuthorizationType: AWS_IAM` and Function URL `AuthType: AWS_IAM` — SigV4 signature verification only; IAM policy evaluation is NOT emulated; see docs/local-emulation.md). When JWKS is unreachable, JWT authorizers fall back to pass-through (every token accepted) with a warn line — local dev fallback. VPC-config Lambdas run locally and surface a warn line at startup; their containers do NOT get attached to the deployed VPC subnets, so calls to private RDS / ElastiCache will fail.'
+      'Run a long-running local HTTP server that maps API Gateway routes (REST v1, HTTP API, Function URL) to Lambda invocations against the AWS Lambda Runtime Interface Emulator (Docker required). Supports Lambda TOKEN/REQUEST authorizers, Cognito User Pool / HTTP v2 JWT authorizers, and AWS_IAM auth (REST v1 `AuthorizationType: AWS_IAM` and Function URL `AuthType: AWS_IAM` — SigV4 signature verification only; IAM policy evaluation is NOT emulated; see https://github.com/go-to-k/cdkd/blob/main/docs/local-emulation.md). When JWKS is unreachable, JWT authorizers fall back to pass-through (every token accepted) with a warn line — local dev fallback. VPC-config Lambdas run locally and surface a warn line at startup; their containers do NOT get attached to the deployed VPC subnets, so calls to private RDS / ElastiCache will fail.'
     )
     .argument(
       '[target]',

--- a/src/local/route-discovery.ts
+++ b/src/local/route-discovery.ts
@@ -678,7 +678,7 @@ function buildAwsIntegrationConfig(
   if (!isLambda) {
     return {
       kind: 'unsupported',
-      reason: `${stackName}/${logicalId}: REST v1 AWS integration targeting a non-Lambda service (Uri ${shortJson(uri)}) is not emulated locally in cdkd v1. Lambda non-proxy AWS integrations are supported; direct AWS service integrations (S3 / SQS / SNS / DynamoDB) require deploying to AWS. See docs/local-emulation.md.`,
+      reason: `${stackName}/${logicalId}: REST v1 AWS integration targeting a non-Lambda service (Uri ${shortJson(uri)}) is not emulated locally in cdkd v1. Lambda non-proxy AWS integrations are supported; direct AWS service integrations (S3 / SQS / SNS / DynamoDB) require deploying to AWS. See https://github.com/go-to-k/cdkd/blob/main/docs/local-emulation.md.`,
     };
   }
   const arnOutcome = resolveLambdaArnOutcome(uri);

--- a/src/utils/role-arn.ts
+++ b/src/utils/role-arn.ts
@@ -177,7 +177,7 @@ export async function assumeRoleForCrossAccountStateRead(roleArn: string): Promi
         throw new Error(
           `AssumeRole into ${roleArn} failed: ${message}. ` +
             `If this is a trust-policy issue, the producer's role must allow sts:AssumeRole ` +
-            `from the consumer's principal. See docs/cross-stack-references.md for the trust-policy template.`,
+            `from the consumer's principal. See https://github.com/go-to-k/cdkd/blob/main/docs/cross-stack-references.md for the trust-policy template.`,
           { cause: err instanceof Error ? err : undefined }
         );
       }


### PR DESCRIPTION
## Summary

User-facing runtime warnings and the `cdkd local start-api --help` text pointed to `docs/<file>.md` as repo-relative paths. Users who installed cdkd via `npm install -g cdkd` (or any non-clone install path) have no `docs/` directory locally — the link was dead.

Surfaced today on a real-user workflow that hit:

```
5 route(s) declare AuthorizationType: AWS_IAM — cdkd local start-api verifies SigV4 signatures
against your local AWS credentials, but does NOT emulate IAM policy evaluation. ...
See docs/cli-reference.md (cdkd local start-api — AWS_IAM authorizer) for details.
                                                                         ^^^^^^^^^^
                                                                         this path doesn't exist on the user's box
```

## Changes

Rewrite 5 user-facing references to absolute GitHub URLs of the form `https://github.com/go-to-k/cdkd/blob/main/docs/<file>.md`. The `/blob/main/` form tracks the current default branch (resilient to future branch renames) and the docs themselves don't move frequently, so the URL stays correct over time.

Affected sites (runtime-emitted strings only):

- [src/cli/commands/local-start-api.ts:1237](src/cli/commands/local-start-api.ts#L1237) — VpcConfig warn ("calls to private RDS/ElastiCache will fail")
- [src/cli/commands/local-start-api.ts:1267](src/cli/commands/local-start-api.ts#L1267) — AWS_IAM authorizer warn (the one surfaced today)
- [src/cli/commands/local-start-api.ts:2708](src/cli/commands/local-start-api.ts#L2708) — `--help` text (also visible to every user running `cdkd local start-api --help`)
- [src/local/route-discovery.ts:681](src/local/route-discovery.ts#L681) — REST v1 non-Lambda AWS integration 501 reason
- [src/utils/role-arn.ts:180](src/utils/role-arn.ts#L180) — cross-stack-references trust-policy hint in `AssumeRole` failure message

## NOT touched (intentional)

Code comments under `src/provisioning/providers/**` and JSDoc comments elsewhere — those are for maintainers reading the source, not runtime user-facing strings. Per the issue's "Out of scope" notes, relative `docs/...` paths inside comments are fine.

Verified via `grep -rn 'docs/[a-z-]*\.md' src/ | grep -vE 'github\.com|//|/\*|\*'` — empty post-fix.

## Out of scope

- `vp run audit:doc-urls` lint task to prevent the regression — deferred to a follow-up. The current PR is a mechanical substitution; adding a linter is a separate concern.

## Test plan

- [x] `vp check --fix` passes (typecheck + lint + format, 0 warnings / 0 errors)
- [x] `vp run build` passes
- [x] `vp run test` passes — 374 test files, 5756 tests (no test changes; the strings being substituted are not asserted by any existing test)
- [x] `grep` audit shows no remaining user-facing repo-relative paths

## Note for the merger

This PR touches `src/cli/commands/local-start-api.ts`, `src/local/route-discovery.ts`, AND `src/utils/role-arn.ts`. The first two are in the `integ-local` markgate gate scope. `src/utils/role-arn.ts` is in the `pr-review` gate's up-bias trigger list (security-sensitive surface) — but the PR is `inline` tier per the size heuristic (3 files, ~10 LOC of pure string substitution), so the up-bias would put it at `1-reviewer`. Worth a quick code-review pass to confirm the substitution is mechanical-only (no behavior change).

Before merging, run `/run-integ local-start-api` to refresh the `integ-local` marker.

Closes #641
