### PR TITLE
fix(local): honor AWS::Lambda::Url.Cors block in start-api preflight (#644)

### DIFF
--- a/src/local/cors-handler.ts
+++ b/src/local/cors-handler.ts
@@ -80,18 +80,36 @@ export interface CorsConfig {
 }
 
 /**
- * Build a `apiLogicalId → CorsConfig | undefined` map. Walks the
- * template once, picks every `AWS::ApiGatewayV2::Api`, and extracts its
- * `Properties.CorsConfiguration` if any. APIs without CorsConfiguration
- * (or whose CorsConfiguration is malformed) are NOT entered into the map.
+ * Build a `logicalId → CorsConfig | undefined` map. Walks the template
+ * once and picks two CORS-bearing resource types:
+ *
+ *   - `AWS::ApiGatewayV2::Api` → `Properties.CorsConfiguration`
+ *     (HTTP API v2; the original PR 8c surface)
+ *   - `AWS::Lambda::Url` → `Properties.Cors` (Function URL; issue #644)
+ *
+ * Both blocks are field-for-field identical in CFn schema (same
+ * `AllowOrigins` / `AllowMethods` / `AllowHeaders` / `ExposeHeaders` /
+ * `MaxAge` / `AllowCredentials`), so a single parser handles both. The
+ * map key is the resource's own logical ID — that ID is later looked up
+ * against `DiscoveredRoute.apiLogicalId` (set to the surface-bearing
+ * resource at route-discovery time) so the preflight interceptor finds
+ * the right config.
+ *
+ * Resources without a CORS block (or whose block is malformed) are NOT
+ * entered into the map.
  */
 export function buildCorsConfigByApiId(template: CloudFormationTemplate): Map<string, CorsConfig> {
   const out = new Map<string, CorsConfig>();
   const resources = template.Resources ?? {};
   for (const [logicalId, resource] of Object.entries(resources)) {
-    if (resource.Type !== 'AWS::ApiGatewayV2::Api') continue;
-    const props = resource.Properties ?? {};
-    const raw = props['CorsConfiguration'];
+    let raw: unknown;
+    if (resource.Type === 'AWS::ApiGatewayV2::Api') {
+      raw = (resource.Properties ?? {})['CorsConfiguration'];
+    } else if (resource.Type === 'AWS::Lambda::Url') {
+      raw = (resource.Properties ?? {})['Cors'];
+    } else {
+      continue;
+    }
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
     const parsed = parseCorsConfiguration(raw as Record<string, unknown>);
     if (parsed) out.set(logicalId, parsed);

--- a/src/local/route-discovery.ts
+++ b/src/local/route-discovery.ts
@@ -85,13 +85,19 @@ export interface DiscoveredRoute {
    */
   stage: string;
   /**
-   * Logical ID of the parent API resource:
+   * Logical ID of the resource that owns this route's surface-level
+   * config (CORS, stage variables, etc.):
    *   - REST v1 routes: the `AWS::ApiGateway::RestApi`.
    *   - HTTP API routes: the `AWS::ApiGatewayV2::Api`.
-   *   - Function URL routes: `undefined` (Function URLs aren't grouped
-   *     under an API).
+   *   - Function URL routes: the `AWS::Lambda::Url` itself (issue #644
+   *     — the Function URL is its own surface-config-bearing resource;
+   *     it carries the `Cors` block that `buildCorsConfigByApiId`
+   *     surfaces).
    *
-   * Used by the CORS handler + stage-resolver to look up per-API config.
+   * Used by the CORS handler + stage-resolver to look up per-surface
+   * config. Despite the name `apiLogicalId`, the value is "the
+   * surface-config-bearing resource" rather than literally "an API
+   * resource" — that distinction is load-bearing for Function URLs.
    */
   apiLogicalId?: string;
   /**
@@ -1157,6 +1163,15 @@ function discoverFunctionUrl(
     apiVersion: 'v2',
     stage: '$default',
     apiStackName: stackName,
+    // Issue #644: set `apiLogicalId` to the AWS::Lambda::Url's own
+    // logical ID so the CORS preflight interceptor can look up the
+    // Function URL's `Cors` block via `buildCorsConfigByApiId`. The
+    // pre-fix design left this undefined ("Function URLs aren't
+    // grouped under a parent API"); the new semantics is that
+    // `apiLogicalId` points at the CORS-config-bearing resource
+    // (HTTP API v2's `AWS::ApiGatewayV2::Api` OR Function URL's
+    // `AWS::Lambda::Url`), which is the only consumer of the field.
+    apiLogicalId: logicalId,
     ...(lambdaCdkPath !== undefined && { apiCdkPath: lambdaCdkPath }),
     declaredAt: `${stackName}/${logicalId}`,
   };

--- a/tests/unit/local/cors-handler.test.ts
+++ b/tests/unit/local/cors-handler.test.ts
@@ -73,6 +73,108 @@ describe('buildCorsConfigByApiId', () => {
     );
     expect(m.size).toBe(0);
   });
+
+  // Issue #644: Function URL Cors block extraction. The CFn schema for
+  // AWS::Lambda::Url.Cors is field-for-field identical to HTTP API v2's
+  // CorsConfiguration, so the same parser handles both.
+  describe('AWS::Lambda::Url.Cors (issue #644)', () => {
+    it('extracts Cors from AWS::Lambda::Url', () => {
+      const m = buildCorsConfigByApiId(
+        tpl({
+          Url: {
+            Type: 'AWS::Lambda::Url',
+            Properties: {
+              AuthType: 'AWS_IAM',
+              TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] },
+              Cors: {
+                AllowOrigins: ['http://127.0.0.1:5050'],
+                AllowMethods: ['POST'],
+                AllowHeaders: ['Authorization', 'Content-Type'],
+                AllowCredentials: true,
+                MaxAge: 600,
+              },
+            },
+          },
+        })
+      );
+      const cors = m.get('Url');
+      expect(cors).toBeDefined();
+      expect(cors?.AllowOrigins).toEqual(['http://127.0.0.1:5050']);
+      expect(cors?.AllowMethods).toEqual(['POST']);
+      expect(cors?.AllowHeaders).toEqual(['Authorization', 'Content-Type']);
+      expect(cors?.AllowCredentials).toBe(true);
+      expect(cors?.MaxAge).toBe(600);
+    });
+
+    it('skips Function URLs without a Cors block', () => {
+      const m = buildCorsConfigByApiId(
+        tpl({
+          Url: {
+            Type: 'AWS::Lambda::Url',
+            Properties: { AuthType: 'NONE', TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] } },
+          },
+        })
+      );
+      expect(m.size).toBe(0);
+    });
+
+    it('returns empty for a Function URL with a fully blank Cors block', () => {
+      const m = buildCorsConfigByApiId(
+        tpl({
+          Url: {
+            Type: 'AWS::Lambda::Url',
+            Properties: {
+              AuthType: 'NONE',
+              TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] },
+              Cors: {},
+            },
+          },
+        })
+      );
+      expect(m.size).toBe(0);
+    });
+
+    it('merges Function URL entries with HTTP API v2 entries (different logical IDs)', () => {
+      const m = buildCorsConfigByApiId(
+        tpl({
+          HttpApi: {
+            Type: 'AWS::ApiGatewayV2::Api',
+            Properties: {
+              ProtocolType: 'HTTP',
+              CorsConfiguration: { AllowOrigins: ['*'] },
+            },
+          },
+          FnUrl: {
+            Type: 'AWS::Lambda::Url',
+            Properties: {
+              AuthType: 'NONE',
+              TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] },
+              Cors: { AllowOrigins: ['http://localhost:3000'] },
+            },
+          },
+        })
+      );
+      expect(m.size).toBe(2);
+      expect(m.get('HttpApi')?.AllowOrigins).toEqual(['*']);
+      expect(m.get('FnUrl')?.AllowOrigins).toEqual(['http://localhost:3000']);
+    });
+
+    it('tolerates a malformed Cors block (non-object) without throwing', () => {
+      const m = buildCorsConfigByApiId(
+        tpl({
+          Url: {
+            Type: 'AWS::Lambda::Url',
+            Properties: {
+              AuthType: 'NONE',
+              TargetFunctionArn: { 'Fn::GetAtt': ['Fn', 'Arn'] },
+              Cors: 'not-an-object',
+            },
+          },
+        })
+      );
+      expect(m.size).toBe(0);
+    });
+  });
 });
 
 describe('matchPreflight', () => {

--- a/tests/unit/local/route-discovery.test.ts
+++ b/tests/unit/local/route-discovery.test.ts
@@ -905,6 +905,7 @@ describe('discoverRoutes — Function URL', () => {
       apiVersion: 'v2',
       stage: '$default',
       apiStackName: 'S',
+      apiLogicalId: 'Url', // issue #644: Function URL's own logical ID (CORS-config-bearing)
       declaredAt: 'S/Url',
       invokeMode: 'BUFFERED',
     });


### PR DESCRIPTION
## Summary

`cdkd local start-api` ignored the `Cors` property on `AWS::Lambda::Url` resources, so a browser hitting a local Function URL with a cross-origin request was blocked by CORS:

```
Access to fetch at 'http://127.0.0.1:60924/' from origin 'http://127.0.0.1:5050' has been blocked by CORS policy:
Response to preflight request doesn't pass access control check:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

This was the canonical CDK pattern (SPA on Vite dev server calling a Function URL Lambda for backend API) — worked against deployed AWS, broken against `cdkd local start-api`.

## Root cause

PR 8c built the CORS preflight pipeline against `AWS::ApiGatewayV2::Api.CorsConfiguration` only. Two structural gaps for Function URL:

1. **`buildCorsConfigByApiId`** filtered to `ApiGatewayV2::Api` only — ignored `AWS::Lambda::Url.Cors` (which has an **identical CFn schema**: same `AllowOrigins` / `AllowMethods` / `AllowHeaders` / `ExposeHeaders` / `MaxAge` / `AllowCredentials` fields).
2. **Function URL routes** intentionally left `apiLogicalId` undefined ("Function URLs aren't grouped under a parent API"). [src/local/http-server.ts:823](src/local/http-server.ts#L823) short-circuits on `!route.apiLogicalId`, so Function URL OPTIONS preflight requests fell through to the catch-all `ANY /{proxy+}` route.

Net effect: Function URL preflight requests dispatched to the Lambda, which either errored or returned a 200 with no `Access-Control-Allow-Origin` header → browser blocks the request.

## Changes

- **`src/local/cors-handler.ts`** — extend `buildCorsConfigByApiId` to walk both `AWS::ApiGatewayV2::Api` (`CorsConfiguration`) AND `AWS::Lambda::Url` (`Cors`). Map key is the resource's own logical ID. Single parser handles both shapes (no new parser needed; the two CFn schemas are field-for-field identical).

- **`src/local/route-discovery.ts`** — set `apiLogicalId` on Function URL routes to the `AWS::Lambda::Url`'s own logical ID. Update field JSDoc to reflect new semantics: `apiLogicalId` points at the **surface-config-bearing resource** (HTTP API v2's `AWS::ApiGatewayV2::Api` OR Function URL's `AWS::Lambda::Url`), not strictly the "API container". `apiLogicalId` is only consumed by `cors-handler.ts` + `stage-resolver.ts` (verified via grep); the semantic shift doesn't affect other consumers.

- **No change** to `src/local/http-server.ts:maybeHandleCorsPreflight` — the existing gate works correctly once Function URL routes have a populated `apiLogicalId` and the cors map has an entry for that ID. The `explicit-OPTIONS-route bypass` filter (`method === 'OPTIONS'` only) is precise enough that the synthetic `ANY /{proxy+}` Function URL route doesn't suppress preflight.

## Test plan

- [x] `vp check --fix` passes
- [x] `vp run build` passes
- [x] `vp run test` passes — 374 test files, 5761 tests (5 net new tests in this PR)
- [x] New tests in `tests/unit/local/cors-handler.test.ts` (Function URL Cors extraction, no-Cors skip, fully-blank Cors skip, merge with HTTP API v2 entries, malformed Cors tolerance)
- [x] Existing `tests/unit/local/route-discovery.test.ts` test for NONE-auth Function URL updated to expect `apiLogicalId: 'Url'` (the only test that changed behavior — explicitly noted so the reviewer can confirm the update is intended)
- [x] Manually verified against a real user stack: 5 Function URL Lambdas with `Cors` blocks now respond to OPTIONS preflight from a cross-origin Vite dev server.

## Note for the merger

This PR touches `src/local/cors-handler.ts` + `src/local/route-discovery.ts` (both in the `integ-local` markgate gate scope). Before merging, run `/run-integ local-start-api` to refresh the marker.

Closes #644
