### PR TITLE
fix(local): borrow CloudFront ResponseHeadersPolicy CORS for fronted Function URLs (#646)

### DIFF
--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -85,7 +85,11 @@ import {
 } from '../../local/lambda-resolver.js';
 import { materializeLayerFromArn } from '../../local/layer-arn-materializer.js';
 import { matchStacks } from '../stack-matcher.js';
-import { buildCorsConfigByApiId, type CorsConfig } from '../../local/cors-handler.js';
+import {
+  buildCorsConfigByApiId,
+  buildCorsConfigFromCloudFrontChain,
+  type CorsConfig,
+} from '../../local/cors-handler.js';
 import {
   attachStageContext,
   buildStageMap,
@@ -445,12 +449,24 @@ async function localStartApiCommand(
       routesWithAuth = filtered;
     }
 
-    // PR 8c: per-API CORS config. HTTP API v2 only (REST v1 OPTIONS
-    // Mock integrations are explicitly out of scope).
+    // PR 8c: per-API CORS config. HTTP API v2's `CorsConfiguration` +
+    // Function URL's own `Cors` (issue #644) + CORS borrowed from
+    // CloudFront ResponseHeadersPolicy when a CloudFront Distribution
+    // fronts the Function URL (issue #646 — production-correct CDK
+    // pattern where CORS is on the edge, not the origin). REST v1
+    // OPTIONS Mock integrations stay out of scope.
+    //
+    // Merge order: direct map last → Function URL's own `Cors` block
+    // wins over a CloudFront-borrowed config when both exist (matches
+    // AWS semantics: Function URL's own headers apply at the Lambda
+    // boundary; we only have one slot locally, so closer-to-Lambda
+    // wins). The two rarely coexist in practice.
     const corsConfigByApiId = new Map<string, CorsConfig>();
     for (const stack of targetStacks) {
-      const m = buildCorsConfigByApiId(stack.template);
-      for (const [k, v] of m) corsConfigByApiId.set(k, v);
+      const fromCloudFront = buildCorsConfigFromCloudFrontChain(stack.template);
+      for (const [k, v] of fromCloudFront) corsConfigByApiId.set(k, v);
+      const direct = buildCorsConfigByApiId(stack.template);
+      for (const [k, v] of direct) corsConfigByApiId.set(k, v);
     }
 
     // `--from-state` / `--from-cfn-stack` (issue #606): load deployed

--- a/src/local/cors-handler.ts
+++ b/src/local/cors-handler.ts
@@ -172,6 +172,181 @@ function pickStringArray(value: unknown): string[] {
 }
 
 /**
+ * Build a `fnUrlLogicalId → CorsConfig` map by tracing CloudFront →
+ * Function URL chains in the template (issue #646).
+ *
+ * Production-correct CDK pattern: Function URL fronted by a CloudFront
+ * Distribution where CORS is declared on the CloudFront
+ * `ResponseHeadersPolicy` (NOT on the Function URL itself). Without this
+ * helper, `cdkd local start-api` sees `Cors: null` on the Function URL
+ * and emits no preflight headers — even though the CDK code correctly
+ * declares the allowed origins on the CloudFront side.
+ *
+ * Detection: an `AWS::CloudFront::Distribution` whose `Origins[].DomainName`
+ * matches the canonical CDK 2.x shape
+ * `Fn::Select[2, Fn::Split['/', Fn::GetAtt[<FnUrlLogicalId>, 'FunctionUrl']]]`
+ * is the chain marker. For each such origin, we walk every cache behavior
+ * (`DefaultCacheBehavior` + `CacheBehaviors[]`), resolve their
+ * `ResponseHeadersPolicyId: { Ref: <RhpLogicalId> }` to the
+ * `AWS::CloudFront::ResponseHeadersPolicy` resource, and extract its
+ * `Properties.ResponseHeadersPolicyConfig.CorsConfig`.
+ *
+ * Schema mapping (CloudFront → internal `CorsConfig`):
+ *
+ *   AccessControlAllowOrigins.Items  → AllowOrigins
+ *   AccessControlAllowMethods.Items  → AllowMethods
+ *   AccessControlAllowHeaders.Items  → AllowHeaders
+ *   AccessControlExposeHeaders.Items → ExposeHeaders
+ *   AccessControlMaxAgeSec           → MaxAge
+ *   AccessControlAllowCredentials    → AllowCredentials
+ *   (OriginOverride is ignored — cdkd has only one config slot)
+ *
+ * Multiple distributions fronting the same Function URL: last write
+ * wins (rare in practice). Per-path CORS via `CacheBehaviors[]` is
+ * NOT supported in v1 — the `DefaultCacheBehavior`'s policy applies
+ * to all paths.
+ */
+export function buildCorsConfigFromCloudFrontChain(
+  template: CloudFormationTemplate
+): Map<string, CorsConfig> {
+  const out = new Map<string, CorsConfig>();
+  const resources = template.Resources ?? {};
+  for (const [, resource] of Object.entries(resources)) {
+    if (resource.Type !== 'AWS::CloudFront::Distribution') continue;
+    const distConfig = (resource.Properties ?? {})['DistributionConfig'];
+    if (!distConfig || typeof distConfig !== 'object') continue;
+    const dc = distConfig as Record<string, unknown>;
+
+    const origins = Array.isArray(dc['Origins']) ? (dc['Origins'] as unknown[]) : [];
+    for (const origin of origins) {
+      if (!origin || typeof origin !== 'object') continue;
+      const fnUrlLogicalId = pickFnUrlLogicalIdFromOriginDomainName(
+        (origin as Record<string, unknown>)['DomainName']
+      );
+      if (!fnUrlLogicalId) continue;
+
+      // Walk every cache behavior (default + per-path) and merge any
+      // CORS configs found. v1: last-write-wins on collision.
+      const cacheBehaviors: unknown[] = [
+        dc['DefaultCacheBehavior'],
+        ...(Array.isArray(dc['CacheBehaviors']) ? (dc['CacheBehaviors'] as unknown[]) : []),
+      ];
+      for (const behavior of cacheBehaviors) {
+        if (!behavior || typeof behavior !== 'object') continue;
+        const rhpId = pickRhpRefLogicalId(
+          (behavior as Record<string, unknown>)['ResponseHeadersPolicyId']
+        );
+        if (!rhpId) continue;
+        const rhpResource = resources[rhpId];
+        if (!rhpResource || rhpResource.Type !== 'AWS::CloudFront::ResponseHeadersPolicy') continue;
+        const rhpConfig = (rhpResource.Properties ?? {})['ResponseHeadersPolicyConfig'];
+        if (!rhpConfig || typeof rhpConfig !== 'object') continue;
+        const corsConfig = (rhpConfig as Record<string, unknown>)['CorsConfig'];
+        if (!corsConfig || typeof corsConfig !== 'object' || Array.isArray(corsConfig)) continue;
+        const parsed = parseCloudFrontCorsConfig(corsConfig as Record<string, unknown>);
+        if (parsed) out.set(fnUrlLogicalId, parsed);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Detect the canonical CDK 2.x `DomainName` shape that points a
+ * CloudFront Origin at a Function URL:
+ *   {Fn::Select: [2, {Fn::Split: ['/', {Fn::GetAtt: [<id>, 'FunctionUrl']}]}]}
+ * Returns the Function URL's logical ID, or undefined if the shape
+ * doesn't match.
+ */
+function pickFnUrlLogicalIdFromOriginDomainName(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const outer = value as Record<string, unknown>;
+  const sel = outer['Fn::Select'];
+  if (!Array.isArray(sel) || sel.length !== 2 || sel[0] !== 2) return undefined;
+  const split = sel[1];
+  if (!split || typeof split !== 'object') return undefined;
+  const splitArgs = (split as Record<string, unknown>)['Fn::Split'];
+  if (!Array.isArray(splitArgs) || splitArgs.length !== 2 || splitArgs[0] !== '/') return undefined;
+  const getAtt = splitArgs[1];
+  if (!getAtt || typeof getAtt !== 'object') return undefined;
+  const ga = (getAtt as Record<string, unknown>)['Fn::GetAtt'];
+  if (
+    !Array.isArray(ga) ||
+    ga.length !== 2 ||
+    typeof ga[0] !== 'string' ||
+    ga[1] !== 'FunctionUrl'
+  ) {
+    return undefined;
+  }
+  return ga[0];
+}
+
+/**
+ * Unwrap a `ResponseHeadersPolicyId` value to its referenced logical
+ * ID. CDK 2.x synthesizes this as `{ Ref: <id> }`. Returns undefined
+ * for the AWS-managed-policy ID form (literal UUID string) since
+ * cdkd can't fetch those — and for any non-Ref shape.
+ */
+function pickRhpRefLogicalId(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const ref = (value as Record<string, unknown>)['Ref'];
+  if (typeof ref !== 'string' || ref.length === 0) return undefined;
+  return ref;
+}
+
+/**
+ * Parse a CloudFront `ResponseHeadersPolicyConfig.CorsConfig` block
+ * into the internal `CorsConfig` shape. Schema differs from Function
+ * URL / HTTP API v2 (`AccessControl*` prefix + nested `Items` wrapper);
+ * see `buildCorsConfigFromCloudFrontChain` JSDoc for the field mapping.
+ *
+ * Returns undefined when every value-bearing field is missing.
+ */
+function parseCloudFrontCorsConfig(raw: Record<string, unknown>): CorsConfig | undefined {
+  const allowOrigins = pickItemsStringArray(raw['AccessControlAllowOrigins']);
+  const allowMethods = pickItemsStringArray(raw['AccessControlAllowMethods']);
+  const allowHeaders = pickItemsStringArray(raw['AccessControlAllowHeaders']);
+  const exposeHeaders = pickItemsStringArray(raw['AccessControlExposeHeaders']);
+  const maxAgeRaw = raw['AccessControlMaxAgeSec'];
+  const allowCreds = raw['AccessControlAllowCredentials'];
+
+  if (
+    allowOrigins.length === 0 &&
+    allowMethods.length === 0 &&
+    allowHeaders.length === 0 &&
+    exposeHeaders.length === 0 &&
+    maxAgeRaw === undefined &&
+    allowCreds === undefined
+  ) {
+    return undefined;
+  }
+
+  const config: CorsConfig = {
+    AllowOrigins: allowOrigins,
+    AllowMethods: allowMethods,
+    AllowHeaders: allowHeaders,
+    ExposeHeaders: exposeHeaders,
+  };
+  if (typeof maxAgeRaw === 'number' && Number.isFinite(maxAgeRaw)) {
+    config.MaxAge = Math.trunc(maxAgeRaw);
+  }
+  if (typeof allowCreds === 'boolean') {
+    config.AllowCredentials = allowCreds;
+  }
+  return config;
+}
+
+/**
+ * CloudFront `AccessControl*Origins/Methods/Headers` use a nested
+ * `Items: string[]` wrapper. Unwrap to a plain `string[]`.
+ */
+function pickItemsStringArray(value: unknown): string[] {
+  if (!value || typeof value !== 'object') return [];
+  const items = (value as Record<string, unknown>)['Items'];
+  return pickStringArray(items);
+}
+
+/**
  * The result of a successful preflight match. The HTTP server writes
  * `statusCode + headers` and ends the response with no body.
  */

--- a/tests/unit/local/cors-handler.test.ts
+++ b/tests/unit/local/cors-handler.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test';
 import {
   buildCorsConfigByApiId,
+  buildCorsConfigFromCloudFrontChain,
   matchPreflight,
   type CorsConfig,
 } from '../../../src/local/cors-handler.js';
@@ -174,6 +175,237 @@ describe('buildCorsConfigByApiId', () => {
       );
       expect(m.size).toBe(0);
     });
+  });
+});
+
+// Issue #646: CloudFront ResponseHeadersPolicy CORS borrowed for the
+// fronted Function URL. The canonical production-correct CDK pattern
+// puts CORS on the edge (CloudFront), not on the origin (Function URL).
+describe('buildCorsConfigFromCloudFrontChain (issue #646)', () => {
+  function fnUrlOriginDomainName(fnUrlLogicalId: string): unknown {
+    return {
+      'Fn::Select': [
+        2,
+        {
+          'Fn::Split': ['/', { 'Fn::GetAtt': [fnUrlLogicalId, 'FunctionUrl'] }],
+        },
+      ],
+    };
+  }
+
+  function rhpResource(corsConfig: unknown): TemplateResource {
+    return {
+      Type: 'AWS::CloudFront::ResponseHeadersPolicy',
+      Properties: {
+        ResponseHeadersPolicyConfig: { CorsConfig: corsConfig, Name: 'rhp' },
+      },
+    };
+  }
+
+  function distributionResource(args: {
+    fnUrlLogicalId: string;
+    rhpLogicalId?: string;
+  }): TemplateResource {
+    return {
+      Type: 'AWS::CloudFront::Distribution',
+      Properties: {
+        DistributionConfig: {
+          Origins: [
+            {
+              DomainName: fnUrlOriginDomainName(args.fnUrlLogicalId),
+              Id: 'origin-1',
+            },
+          ],
+          DefaultCacheBehavior: {
+            TargetOriginId: 'origin-1',
+            ...(args.rhpLogicalId !== undefined && {
+              ResponseHeadersPolicyId: { Ref: args.rhpLogicalId },
+            }),
+          },
+        },
+      },
+    };
+  }
+
+  it('extracts CORS from a CloudFront → Function URL chain', () => {
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'AWS_IAM', TargetFunctionArn: { Ref: 'Fn' } },
+        },
+        Dist: distributionResource({ fnUrlLogicalId: 'FnUrl', rhpLogicalId: 'Rhp' }),
+        Rhp: rhpResource({
+          AccessControlAllowOrigins: { Items: ['http://127.0.0.1:5050', 'https://dev.example.com'] },
+          AccessControlAllowMethods: { Items: ['POST'] },
+          AccessControlAllowHeaders: { Items: ['authorization', 'content-type'] },
+          AccessControlAllowCredentials: false,
+          AccessControlMaxAgeSec: 600,
+          OriginOverride: true,
+        }),
+      })
+    );
+    const cors = m.get('FnUrl');
+    expect(cors).toBeDefined();
+    expect(cors?.AllowOrigins).toEqual(['http://127.0.0.1:5050', 'https://dev.example.com']);
+    expect(cors?.AllowMethods).toEqual(['POST']);
+    expect(cors?.AllowHeaders).toEqual(['authorization', 'content-type']);
+    expect(cors?.AllowCredentials).toBe(false);
+    expect(cors?.MaxAge).toBe(600);
+  });
+
+  it('returns empty when the CloudFront distribution has no ResponseHeadersPolicy', () => {
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn' } },
+        },
+        Dist: distributionResource({ fnUrlLogicalId: 'FnUrl' }),
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it('returns empty when the ResponseHeadersPolicy has no CorsConfig', () => {
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn' } },
+        },
+        Dist: distributionResource({ fnUrlLogicalId: 'FnUrl', rhpLogicalId: 'Rhp' }),
+        Rhp: {
+          Type: 'AWS::CloudFront::ResponseHeadersPolicy',
+          Properties: { ResponseHeadersPolicyConfig: { Name: 'rhp' } },
+        },
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it('ignores CloudFront distributions whose origin is not a Function URL', () => {
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        Bucket: { Type: 'AWS::S3::Bucket', Properties: {} },
+        Dist: {
+          Type: 'AWS::CloudFront::Distribution',
+          Properties: {
+            DistributionConfig: {
+              Origins: [{ DomainName: 'static.example.com.s3.amazonaws.com', Id: 'origin-1' }],
+              DefaultCacheBehavior: {
+                TargetOriginId: 'origin-1',
+                ResponseHeadersPolicyId: { Ref: 'Rhp' },
+              },
+            },
+          },
+        },
+        Rhp: rhpResource({ AccessControlAllowOrigins: { Items: ['*'] } }),
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it('ignores AWS-managed RHP IDs (literal UUID, not Ref)', () => {
+    // CDK can set ResponseHeadersPolicyId to a literal AWS-managed-policy
+    // UUID. cdkd can't fetch those (they live in AWS), so we skip.
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn' } },
+        },
+        Dist: {
+          Type: 'AWS::CloudFront::Distribution',
+          Properties: {
+            DistributionConfig: {
+              Origins: [{ DomainName: fnUrlOriginDomainName('FnUrl'), Id: 'origin-1' }],
+              DefaultCacheBehavior: {
+                TargetOriginId: 'origin-1',
+                ResponseHeadersPolicyId: '67f7b8e0-7e4f-4e4c-a4f6-aws-managed',
+              },
+            },
+          },
+        },
+      })
+    );
+    expect(m.size).toBe(0);
+  });
+
+  it('maps multiple distributions / Function URLs independently', () => {
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl1: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn1' } },
+        },
+        FnUrl2: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn2' } },
+        },
+        Dist1: distributionResource({ fnUrlLogicalId: 'FnUrl1', rhpLogicalId: 'Rhp1' }),
+        Dist2: distributionResource({ fnUrlLogicalId: 'FnUrl2', rhpLogicalId: 'Rhp2' }),
+        Rhp1: rhpResource({ AccessControlAllowOrigins: { Items: ['https://a.example.com'] } }),
+        Rhp2: rhpResource({ AccessControlAllowOrigins: { Items: ['https://b.example.com'] } }),
+      })
+    );
+    expect(m.size).toBe(2);
+    expect(m.get('FnUrl1')?.AllowOrigins).toEqual(['https://a.example.com']);
+    expect(m.get('FnUrl2')?.AllowOrigins).toEqual(['https://b.example.com']);
+  });
+
+  it('walks both DefaultCacheBehavior and CacheBehaviors[]', () => {
+    // Per-path CORS: v1 applies last-write-wins across cache behaviors
+    // (no per-path routing). Confirms we DO walk CacheBehaviors[].
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn' } },
+        },
+        Dist: {
+          Type: 'AWS::CloudFront::Distribution',
+          Properties: {
+            DistributionConfig: {
+              Origins: [{ DomainName: fnUrlOriginDomainName('FnUrl'), Id: 'origin-1' }],
+              DefaultCacheBehavior: {
+                TargetOriginId: 'origin-1',
+                ResponseHeadersPolicyId: { Ref: 'RhpDefault' },
+              },
+              CacheBehaviors: [
+                {
+                  PathPattern: '/api/*',
+                  TargetOriginId: 'origin-1',
+                  ResponseHeadersPolicyId: { Ref: 'RhpApi' },
+                },
+              ],
+            },
+          },
+        },
+        RhpDefault: rhpResource({
+          AccessControlAllowOrigins: { Items: ['https://default.example.com'] },
+        }),
+        RhpApi: rhpResource({
+          AccessControlAllowOrigins: { Items: ['https://api.example.com'] },
+        }),
+      })
+    );
+    // Last-write-wins: CacheBehaviors[] iterated after DefaultCacheBehavior.
+    expect(m.get('FnUrl')?.AllowOrigins).toEqual(['https://api.example.com']);
+  });
+
+  it('tolerates a malformed CorsConfig (non-object) without throwing', () => {
+    const m = buildCorsConfigFromCloudFrontChain(
+      tpl({
+        FnUrl: {
+          Type: 'AWS::Lambda::Url',
+          Properties: { AuthType: 'NONE', TargetFunctionArn: { Ref: 'Fn' } },
+        },
+        Dist: distributionResource({ fnUrlLogicalId: 'FnUrl', rhpLogicalId: 'Rhp' }),
+        Rhp: rhpResource('not-an-object'),
+      })
+    );
+    expect(m.size).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

`cdkd local start-api` only honored CORS configs declared directly on the routed resource (HTTP API v2 `CorsConfiguration` per PR 8c / Function URL `Cors` per #644). The canonical production CDK pattern — **CloudFront in front of a Function URL with CORS on the CloudFront `ResponseHeadersPolicy`** — left local preflight requests unanswered.

User-visible symptom: browser hitting local Function URL gets blocked by CORS even when the CDK code correctly declares the origin (it was on the CloudFront side, never read locally). Reproduced against a real user stack with 5 Function URLs each fronted by a dedicated CloudFront Distribution + shared CORS allow-list including `http://127.0.0.1:5050` for dev.

## Scope: CORS headers only — NOT a CloudFront emulator

This PR is **purely a template-walk extension**. cdkd still doesn't emulate CloudFront (no caching, no edge functions, no signed URLs, no OAC auth). It just detects "where the CORS config is declared in the template" and brings it to the local Function URL server response. Production-correct CDK code unblocks local dev without any CDK changes.

## Implementation

### New helper `buildCorsConfigFromCloudFrontChain(template)` in [src/local/cors-handler.ts](src/local/cors-handler.ts)

Walks every `AWS::CloudFront::Distribution` and detects the canonical CDK 2.x chain marker on each `Origins[].DomainName`:

```
Fn::Select[2, Fn::Split['/', Fn::GetAtt[<FnUrlLogicalId>, 'FunctionUrl']]]
```

For matching chains, walks `DefaultCacheBehavior` + `CacheBehaviors[]`, resolves `ResponseHeadersPolicyId: { Ref: <RhpLogicalId> }` to its `AWS::CloudFront::ResponseHeadersPolicy` resource, and extracts `Properties.ResponseHeadersPolicyConfig.CorsConfig`.

CloudFront CORS schema differs from Function URL `Cors` (uses `AccessControl*` prefix + nested `Items` wrappers):

| CloudFront `CorsConfig` | Internal `CorsConfig` |
|---|---|
| `AccessControlAllowOrigins.Items[]` | `AllowOrigins` |
| `AccessControlAllowMethods.Items[]` | `AllowMethods` |
| `AccessControlAllowHeaders.Items[]` | `AllowHeaders` |
| `AccessControlExposeHeaders.Items[]` | `ExposeHeaders` |
| `AccessControlMaxAgeSec` | `MaxAge` |
| `AccessControlAllowCredentials` | `AllowCredentials` |
| `OriginOverride` | ignored |

A new private `parseCloudFrontCorsConfig` handles the schema normalization.

### Dispatcher merge ([src/cli/commands/local-start-api.ts:454](src/cli/commands/local-start-api.ts#L454))

```
CloudFront-borrowed map  (set first)
HTTP API v2 CorsConfiguration + Function URL direct Cors  (set second — wins on collision)
```

Function URL's own `Cors` block wins over a CloudFront-borrowed config when both exist (matches AWS semantics: Function URL's own headers apply at the Lambda boundary). They rarely coexist in practice.

## Out of scope (intentional)

- **AWS-managed RHP IDs** (literal UUID instead of `{ Ref: <id> }`) — cdkd can't fetch those policies (they live in AWS); silently skipped. The custom `ResponseHeadersPolicyConfig` pattern (which is what CDK emits for the dev's own CORS allow-list) is the targeted shape.
- **Per-path CORS** via `CacheBehaviors[].PathPattern` routing — v1 applies last-write-wins across all cache behaviors uniformly. Deferred until someone reports a real-world stack with per-path divergent CORS.
- **`OriginOverride` semantics** — ignored. cdkd has only one CORS config slot per Function URL; the CloudFront-merging-with-origin-headers nuance doesn't translate.
- **CloudFront emulation** at large (caching / signed URLs / edge functions / OAC) — explicitly out of scope.

## Test plan

- [x] `vp check --fix` passes (typecheck + lint + format)
- [x] `vp run build` passes
- [x] `vp run test` passes — 377 test files, 5788 tests (8 net new tests in this PR)
- [x] New tests in [tests/unit/local/cors-handler.test.ts](tests/unit/local/cors-handler.test.ts) cover: canonical CF chain extraction, no-RHP skip, no-CorsConfig skip, non-FnUrl origin skip, AWS-managed RHP UUID skip, multi-distribution mapping, `CacheBehaviors[]` walking with last-write-wins, malformed `CorsConfig` tolerance.

## Note for the merger

This PR touches `src/local/cors-handler.ts` + `src/cli/commands/local-start-api.ts` (both in the `integ-local` markgate gate scope). Before merging, run `/run-integ local-start-api` to refresh the marker.

Closes #646
