### PR TITLE
fix(local): set CORS headers on actual responses, not just preflight (#652)

### DIFF
--- a/src/local/cors-handler.ts
+++ b/src/local/cors-handler.ts
@@ -1,3 +1,4 @@
+import type { ServerResponse } from 'node:http';
 import type { CloudFormationTemplate } from '../types/resource.js';
 
 /**
@@ -432,6 +433,80 @@ export function matchPreflight(
   responseHeaders['vary'] = 'Origin';
 
   return { statusCode: 204, headers: responseHeaders };
+}
+
+/**
+ * Apply CORS headers to an **actual** (non-preflight) response. CORS
+ * spec requires that 2xx / 4xx / 5xx responses all carry
+ * `Access-Control-Allow-Origin` (only preflight responses also need
+ * `Allow-Methods` / `Allow-Headers` / `Max-Age`) — without it the
+ * browser blocks the response body from JS regardless of status code.
+ *
+ * Looks up the route's `apiLogicalId` in `corsConfigByApiId`. When a
+ * matching config + the request Origin satisfies `AllowOrigins`, sets:
+ *
+ *   - `Access-Control-Allow-Origin: <origin or *>`  (always)
+ *   - `Vary: Origin`                                (when origin echoed)
+ *   - `Access-Control-Allow-Credentials: true`      (when configured)
+ *   - `Access-Control-Expose-Headers: <list>`       (when configured)
+ *
+ * `Allow-Methods` / `Allow-Headers` / `Max-Age` are preflight-only and
+ * deliberately NOT set on actual responses.
+ *
+ * Caller must invoke this BEFORE writing the response body (otherwise
+ * `res.headersSent` flips and `setHeader` becomes a no-op). Idempotent:
+ * a second call with the same args overwrites the same headers.
+ *
+ * No-op when:
+ *   - `route.apiLogicalId` is undefined (no surface-config-bearing
+ *     resource — e.g. routes discovered before issue #644's apiLogicalId
+ *     plumbing existed; harmless on routes without CORS to apply)
+ *   - The route's API has no entry in `corsConfigByApiId`
+ *   - The request has no `Origin` header (non-CORS request — same
+ *     posture as the matchPreflight gate)
+ *   - The Origin is not in the AllowOrigins list (browser will block
+ *     anyway; we don't smuggle through unauthorized origins by accident)
+ */
+export function applyCorsResponseHeaders(
+  res: ServerResponse,
+  apiLogicalId: string | undefined,
+  corsConfigByApiId: Map<string, CorsConfig>,
+  requestOrigin: string | undefined
+): void {
+  if (!apiLogicalId) return;
+  const cors = corsConfigByApiId.get(apiLogicalId);
+  if (!cors) return;
+  if (!requestOrigin) return;
+  const originMatch = matchOrigin(requestOrigin, cors.AllowOrigins);
+  if (!originMatch) return;
+
+  // RFC 6749 / fetch spec: `Allow-Origin: *` is invalid alongside
+  // `Allow-Credentials: true`. When credentials allowed AND the config
+  // had `*`, echo the request Origin instead.
+  const allowOrigin = originMatch === '*' && cors.AllowCredentials !== true ? '*' : requestOrigin;
+  res.setHeader('Access-Control-Allow-Origin', allowOrigin);
+
+  if (allowOrigin !== '*') {
+    // The response varies by Origin; without `Vary: Origin` a shared
+    // cache (browser / CDN) might serve the wrong-origin cached copy
+    // and break the security model. Append to existing Vary if any.
+    const existing = res.getHeader('Vary');
+    if (typeof existing === 'string' && existing.length > 0) {
+      const tokens = existing.split(',').map((t) => t.trim());
+      if (!tokens.some((t) => t.toLowerCase() === 'origin')) {
+        res.setHeader('Vary', `${existing}, Origin`);
+      }
+    } else {
+      res.setHeader('Vary', 'Origin');
+    }
+  }
+
+  if (cors.AllowCredentials === true) {
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
+  if (cors.ExposeHeaders.length > 0) {
+    res.setHeader('Access-Control-Expose-Headers', cors.ExposeHeaders.join(','));
+  }
 }
 
 /**

--- a/src/local/http-server.ts
+++ b/src/local/http-server.ts
@@ -25,7 +25,7 @@ import {
   type RestV1IntegrationOutcome,
 } from './rest-v1-integrations.js';
 import { randomUUID } from 'node:crypto';
-import { matchPreflight, type CorsConfig } from './cors-handler.js';
+import { applyCorsResponseHeaders, matchPreflight, type CorsConfig } from './cors-handler.js';
 import type { AuthorizerInfo, RouteWithAuth } from './authorizer-resolver.js';
 import type { AuthorizerCache, CachedAuthorizerResult } from './authorizer-cache.js';
 import { buildAuthorizerContextShape } from './authorizer-context.js';
@@ -402,6 +402,19 @@ async function handleRequest(
     return;
   }
 
+  // Issue #652: apply CORS headers to ACTUAL responses (preflight is
+  // handled above by `maybeHandleCorsPreflight`). The browser blocks
+  // 2xx / 4xx / 5xx response bodies from JS unless
+  // `Access-Control-Allow-Origin` is set on the actual response too.
+  // Closure captures the route + state + request Origin so every
+  // response-write call site in this handler can apply CORS without
+  // re-deriving them. Idempotent: safe to call multiple times (a later
+  // call overwrites the headers from an earlier one).
+  const requestOrigin = pickFirstHeaderValue(collectHeaders(req), 'origin') ?? undefined;
+  const applyCors = (): void => {
+    applyCorsResponseHeaders(res, match.route.apiLogicalId, state.corsConfigByApiId, requestOrigin);
+  };
+
   // Synthetic CORS preflight (REST v1 MOCK preflight): respond with
   // the captured status + headers directly, no Lambda invocation. Runs
   // BEFORE the authorizer pass — preflight requests do not carry
@@ -416,6 +429,7 @@ async function handleRequest(
   // reason as HTTP 501 so the user sees exactly what went wrong WHEN
   // they hit the route, while the rest of the API surface stays up.
   if (match.route.unsupported) {
+    applyCors();
     writeNotImplemented(res, match.route.unsupported.reason);
     return;
   }
@@ -485,10 +499,12 @@ async function handleRequest(
       // on HTTP v2, 403 on Function URL AWS_IAM) — matches deployed
       // behavior on Lambda authorizer exceptions / SigV4 verification
       // failures.
+      applyCors();
       writeAuthRejection(res, match.route.apiVersion, 'policy-deny', authorizer.kind);
       return;
     }
     if (!outcome.result.allow) {
+      applyCors();
       writeAuthRejection(
         res,
         match.route.apiVersion,
@@ -512,6 +528,7 @@ async function handleRequest(
   // `RequestParameterContext.authorizer` so `$context.authorizer.X`
   // selection expressions resolve correctly.
   if (match.route.serviceIntegration) {
+    applyCors();
     await handleServiceIntegrationRequest(req, res, match, bodyBuf, opts, authorizer, authResult);
     return;
   }
@@ -530,12 +547,14 @@ async function handleRequest(
         state,
         opts
       );
+      applyCors();
       writeIntegrationOutcome(res, outcome);
     } catch (err) {
       logger.error(
         `REST v1 ${match.route.restV1Integration.kind} dispatch failed for ${match.route.declaredAt}: ${err instanceof Error ? err.message : String(err)}`
       );
       if (!res.headersSent) {
+        applyCors();
         writeError(res, 502);
       } else {
         res.end();
@@ -551,6 +570,7 @@ async function handleRequest(
     logger.error(
       `Failed to acquire container for ${match.route.lambdaLogicalId}: ${err instanceof Error ? err.message : String(err)}`
     );
+    applyCors();
     writeError(res, 502);
     return;
   }
@@ -572,6 +592,7 @@ async function handleRequest(
         opts.rieTimeoutMs
       );
       try {
+        applyCors();
         writeStreamingResponse(res, streamResult, () => state.pool.release(handle));
       } catch (writeErr) {
         // `writeStreamingResponse` threw synchronously — typically from
@@ -609,6 +630,7 @@ async function handleRequest(
         }`
       );
       if (!res.headersSent) {
+        applyCors();
         writeError(res, 502);
       } else {
         res.end();
@@ -635,12 +657,14 @@ async function handleRequest(
       // Multiple Set-Cookie headers — Node's setHeader accepts an array.
       res.setHeader('set-cookie', translated.cookies);
     }
+    applyCors();
     res.end(translated.body);
   } catch (err) {
     logger.error(
       `RIE invoke failed for ${match.route.lambdaLogicalId}: ${err instanceof Error ? err.message : String(err)}`
     );
     if (!res.headersSent) {
+      applyCors();
       writeError(res, 502);
     } else {
       res.end();

--- a/tests/unit/local/cors-handler.test.ts
+++ b/tests/unit/local/cors-handler.test.ts
@@ -1,11 +1,35 @@
 import { describe, expect, it } from 'vite-plus/test';
 import {
+  applyCorsResponseHeaders,
   buildCorsConfigByApiId,
   buildCorsConfigFromCloudFrontChain,
   matchPreflight,
   type CorsConfig,
 } from '../../../src/local/cors-handler.js';
 import type { CloudFormationTemplate, TemplateResource } from '../../../src/types/resource.js';
+
+/**
+ * Minimal stub for `ServerResponse`'s set/get/header interface used by
+ * `applyCorsResponseHeaders`. Captures `setHeader` calls into a map for
+ * assertion-friendly inspection. Only the surface
+ * `applyCorsResponseHeaders` touches is implemented.
+ */
+function mockRes(): {
+  setHeader: (name: string, value: string | string[]) => void;
+  getHeader: (name: string) => string | string[] | undefined;
+  headers: Map<string, string | string[]>;
+} {
+  const headers = new Map<string, string | string[]>();
+  return {
+    headers,
+    setHeader(name: string, value: string | string[]) {
+      headers.set(name, value);
+    },
+    getHeader(name: string) {
+      return headers.get(name);
+    },
+  };
+}
 
 function tpl(resources: Record<string, TemplateResource>): CloudFormationTemplate {
   return { Resources: resources };
@@ -693,5 +717,164 @@ describe('matchPreflight', () => {
     // (404 / user OPTIONS handler). Pinning the null contract here
     // because callers depend on "no preflight headers in null result".
     expect(r).toBeNull();
+  });
+});
+
+// Issue #652: actual responses (2xx / 4xx / 5xx) need Allow-Origin too,
+// not just preflight. Without it the browser blocks the body from JS
+// even when the request itself succeeded server-side.
+describe('applyCorsResponseHeaders (issue #652)', () => {
+  const config: CorsConfig = {
+    AllowOrigins: ['http://127.0.0.1:5050', 'https://dev.example.com'],
+    AllowMethods: ['GET', 'POST'],
+    AllowHeaders: ['content-type', 'authorization'],
+    ExposeHeaders: [],
+  };
+  const map = new Map<string, CorsConfig>([['Url', config]]);
+
+  it('sets Allow-Origin echoing the request Origin on a matched API + matched Origin', () => {
+    const res = mockRes();
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      map,
+      'http://127.0.0.1:5050'
+    );
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://127.0.0.1:5050');
+    expect(res.headers.get('Vary')).toBe('Origin');
+  });
+
+  it('no-op when route has no apiLogicalId', () => {
+    const res = mockRes();
+    applyCorsResponseHeaders(res as never, undefined, map, 'http://127.0.0.1:5050');
+    expect(res.headers.size).toBe(0);
+  });
+
+  it('no-op when API has no CORS config (route is not in the map)', () => {
+    const res = mockRes();
+    applyCorsResponseHeaders(res as never, 'OtherApi', map, 'http://127.0.0.1:5050');
+    expect(res.headers.size).toBe(0);
+  });
+
+  it('no-op when request has no Origin header (non-CORS request)', () => {
+    const res = mockRes();
+    applyCorsResponseHeaders(res as never, 'Url', map, undefined);
+    expect(res.headers.size).toBe(0);
+  });
+
+  it('no-op when Origin is not in AllowOrigins (do not smuggle through)', () => {
+    const res = mockRes();
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      map,
+      'https://evil.example.com'
+    );
+    expect(res.headers.size).toBe(0);
+  });
+
+  it('uses literal `*` when AllowOrigins has `*` AND AllowCredentials is not true', () => {
+    const wildcardConfig: CorsConfig = {
+      AllowOrigins: ['*'],
+      AllowMethods: ['GET'],
+      AllowHeaders: [],
+      ExposeHeaders: [],
+    };
+    const res = mockRes();
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      new Map([['Url', wildcardConfig]]),
+      'https://anyone.example.com'
+    );
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    // Vary: Origin NOT set when serving `*` (response is identical
+    // across origins).
+    expect(res.headers.has('Vary')).toBe(false);
+  });
+
+  it('echoes Origin (not `*`) + sets Allow-Credentials when AllowCredentials is true', () => {
+    const credsConfig: CorsConfig = {
+      AllowOrigins: ['*'],
+      AllowMethods: ['GET'],
+      AllowHeaders: [],
+      ExposeHeaders: [],
+      AllowCredentials: true,
+    };
+    const res = mockRes();
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      new Map([['Url', credsConfig]]),
+      'https://app.example.com'
+    );
+    // Per fetch spec: `*` is invalid alongside Allow-Credentials, so
+    // echo the request Origin instead.
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example.com');
+    expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    expect(res.headers.get('Vary')).toBe('Origin');
+  });
+
+  it('sets Expose-Headers when configured', () => {
+    const exposeConfig: CorsConfig = {
+      AllowOrigins: ['http://127.0.0.1:5050'],
+      AllowMethods: ['GET'],
+      AllowHeaders: [],
+      ExposeHeaders: ['X-Request-Id', 'X-Trace-Id'],
+    };
+    const res = mockRes();
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      new Map([['Url', exposeConfig]]),
+      'http://127.0.0.1:5050'
+    );
+    expect(res.headers.get('Access-Control-Expose-Headers')).toBe('X-Request-Id,X-Trace-Id');
+  });
+
+  it('does NOT set preflight-only headers (Allow-Methods / Allow-Headers / Max-Age)', () => {
+    const fullConfig: CorsConfig = {
+      AllowOrigins: ['http://127.0.0.1:5050'],
+      AllowMethods: ['GET', 'POST'],
+      AllowHeaders: ['Authorization'],
+      ExposeHeaders: [],
+      MaxAge: 600,
+    };
+    const res = mockRes();
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      new Map([['Url', fullConfig]]),
+      'http://127.0.0.1:5050'
+    );
+    // Allow-Origin yes; preflight-only headers no.
+    expect(res.headers.has('Access-Control-Allow-Origin')).toBe(true);
+    expect(res.headers.has('Access-Control-Allow-Methods')).toBe(false);
+    expect(res.headers.has('Access-Control-Allow-Headers')).toBe(false);
+    expect(res.headers.has('Access-Control-Max-Age')).toBe(false);
+  });
+
+  it('appends to existing Vary header instead of overwriting', () => {
+    const res = mockRes();
+    res.setHeader('Vary', 'Accept-Encoding');
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      map,
+      'http://127.0.0.1:5050'
+    );
+    expect(res.headers.get('Vary')).toBe('Accept-Encoding, Origin');
+  });
+
+  it('does NOT duplicate Origin in Vary when already present', () => {
+    const res = mockRes();
+    res.setHeader('Vary', 'Origin, Accept-Encoding');
+    applyCorsResponseHeaders(
+      res as never,
+      'Url',
+      map,
+      'http://127.0.0.1:5050'
+    );
+    expect(res.headers.get('Vary')).toBe('Origin, Accept-Encoding');
   });
 });


### PR DESCRIPTION
## Summary

cdkd local start-api added `Access-Control-Allow-Origin` only to **preflight (OPTIONS) responses**. Actual responses (Lambda success 2xx, auth rejections 4xx, dispatcher errors 5xx) carried no CORS headers. Per CORS spec the actual response also needs `Allow-Origin` for the browser to expose the body to JS — so even with #644 / #646 fixing preflight, the browser STILL blocked the response.

**Symptom**: preflight succeeded (#646 working), Lambda returned 502 (separate cause), the 502 carried no `Allow-Origin`, browser blocked with "Failed to fetch" + CORS error. User couldn't even see the real Lambda error body to debug.

## Changes

### New exported helper [src/local/cors-handler.ts](src/local/cors-handler.ts): `applyCorsResponseHeaders`

Given a route's `apiLogicalId` + the cors map + the request `Origin`, sets on the response:

- `Access-Control-Allow-Origin: <origin or *>` (always when matched)
- `Vary: Origin` (when origin echoed, NOT for `*`)
- `Access-Control-Allow-Credentials: true` (when configured)
- `Access-Control-Expose-Headers: <list>` (when configured)

`Allow-Methods` / `Allow-Headers` / `Max-Age` are **preflight-only** and deliberately NOT set on actual responses.

No-op when:
- Route has no `apiLogicalId` (issue #644 plumbing covers Function URL + HTTP v2; older code paths skip silently)
- Route's API has no CORS config in `state.corsConfigByApiId`
- Request has no `Origin` header (non-CORS request)
- Origin is not in `AllowOrigins` (do not smuggle through)

When `AllowCredentials` AND wildcard `AllowOrigins` coexist, echoes request Origin instead of `*` (per fetch spec). Appends to existing `Vary` header instead of overwriting; de-dupes `Origin`.

### Call site plumbing in [src/local/http-server.ts](src/local/http-server.ts)

`handleRequest` declares a `const applyCors = ()` closure right after route match, then calls it before EVERY response-write site:

- `writeNotImplemented` (unsupported route)
- `writeAuthRejection` (auth error + policy-deny, both arms)
- `handleServiceIntegrationRequest` (HTTP v2 service integration)
- `writeIntegrationOutcome` + the catch's `writeError` (REST v1 dispatch)
- container acquire failure `writeError`
- `writeStreamingResponse` + the streaming catch's `writeError`
- Lambda success `res.end` + the invoke catch's `writeError`

The 404-on-no-match write at the top of the handler (before route match) cannot apply CORS because there's no route to look up. Browser will fail the request CORS-error-style — correct semantics: the path is not part of our API surface.

## Test plan

- [x] `vp check --fix` passes (typecheck + lint + format, 0 warnings / 0 errors)
- [x] `vp run build` passes
- [x] `vp run test` passes — 377 test files, 5807 tests (11 net new tests in this PR)
- [x] New tests cover: matched / no apiLogicalId / no config / no origin / non-matching origin / wildcard / `Allow-Credentials` + wildcard / `Expose-Headers` / preflight-only-headers-not-set / `Vary` append / `Vary` dedupe

## Note for the merger

This PR touches `src/local/http-server.ts` + `src/local/cors-handler.ts` (both in `integ-local` markgate gate scope). Before merging, run `/run-integ local-start-api` to refresh the marker.

## Trio of CORS fixes ship together

- #644 (v0.161.x): honor `AWS::Lambda::Url.Cors` block
- #646 (v0.162.1): borrow CloudFront ResponseHeadersPolicy CORS for fronted Function URLs
- **This PR**: set CORS headers on actual responses, not just preflight

All three are required for a real-world Vite-dev-server → CloudFront-fronted-Function-URL stack to work end-to-end against `cdkd local start-api`.

Closes #652
