### PR TITLE
fix(local): forward --profile-resolved credentials to Lambda container (#654)

### DIFF
--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -484,6 +484,20 @@ async function localStartApiCommand(
       ? await loadStateForRoutedStacks(targetStacks, routes, routesWithAuth, options)
       : new Map<string, StackStateBundle>();
 
+    // Issue #654: resolve `--profile <p>` to a concrete credential set
+    // ONCE at boot for forwarding into every Lambda container that
+    // doesn't have its own `--assume-role`. Drives the SDK's default
+    // credential provider chain (SSO / IAM Identity Center / fromIni /
+    // role-assumption profiles all handled uniformly — same chain that
+    // already resolves `--profile` for cdkd's own CFn / CC API clients).
+    // Resolved here so a stack with N Lambdas pays one STS round-trip.
+    // SSO temp creds typically last 1h+; long-running `--watch` sessions
+    // outliving the creds need a cdkd restart (auto-refresh deferred,
+    // see issue #654).
+    const profileCredentials = options.profile
+      ? await resolveProfileCredentials(options.profile)
+      : undefined;
+
     // Build the per-Lambda spec map. Every reachable logical ID is
     // resolved to its asset / inline code, env vars, optional STS creds
     // (--assume-role), optional --debug-port reservation. The container
@@ -507,6 +521,7 @@ async function localStartApiCommand(
         stateByStack,
         skipPull: options.pull === false,
         ...(options.layerRoleArn !== undefined && { layerRoleArn: options.layerRoleArn }),
+        ...(profileCredentials && { profileCredentials }),
       });
       specs.set(logicalId, spec);
     }
@@ -1345,6 +1360,15 @@ async function buildContainerSpec(args: {
    * cross-account role that can read all of them.
    */
   layerRoleArn?: string;
+  /**
+   * Issue #654: profile-resolved credentials to forward into the Lambda
+   * container's env when `--profile <p>` is set AND this Lambda has no
+   * `--assume-role` mapping. Resolved once at server boot via
+   * `resolveProfileCredentials` and shared across every spec build.
+   * Undefined when `--profile` is unset (the pre-fix path stays in
+   * effect — `forwardAwsEnv` copies `process.env.AWS_*`).
+   */
+  profileCredentials?: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
 }): Promise<ContainerSpec> {
   const {
     logicalId,
@@ -1359,6 +1383,7 @@ async function buildContainerSpec(args: {
     stateByStack,
     skipPull,
     layerRoleArn,
+    profileCredentials,
   } = args;
   const lambda = resolveLambdaByLogicalId(logicalId, stacks);
 
@@ -1472,6 +1497,32 @@ async function buildContainerSpec(args: {
     if (stsRegion) dockerEnv['AWS_REGION'] = stsRegion;
   } else {
     forwardAwsEnv(dockerEnv);
+    // Issue #654: when `--profile <p>` is set AND this Lambda has no
+    // `--assume-role` mapping, overlay the profile-resolved credentials
+    // on top of whatever `forwardAwsEnv` copied from `process.env`. The
+    // overlay covers SSO / IAM Identity Center / regular access key /
+    // role-assumption profiles uniformly (resolved via the SDK's
+    // default credential chain). Without this overlay, a dev who runs
+    // `cdkd local start-api --profile mates_dev` AND has no
+    // `AWS_ACCESS_KEY_ID` env var (the common SSO / Identity Center
+    // case) sees the Lambda boot with no creds → handler's AWS SDK
+    // call fails with `Could not load credentials from any providers`.
+    //
+    // Region from forwardAwsEnv is preserved — only the credential
+    // triple is overlaid. Existing precedence: assume-role > profile >
+    // forwarded process env.
+    if (profileCredentials) {
+      dockerEnv['AWS_ACCESS_KEY_ID'] = profileCredentials.accessKeyId;
+      dockerEnv['AWS_SECRET_ACCESS_KEY'] = profileCredentials.secretAccessKey;
+      if (profileCredentials.sessionToken) {
+        dockerEnv['AWS_SESSION_TOKEN'] = profileCredentials.sessionToken;
+      } else {
+        // The profile resolved to long-lived creds (no session token).
+        // Strip any inherited session token to avoid the SDK trying
+        // to use a mismatched (long-lived AKID + foreign session).
+        delete dockerEnv['AWS_SESSION_TOKEN'];
+      }
+    }
   }
 
   if (debugPort !== undefined) {
@@ -2147,6 +2198,64 @@ function forwardAwsEnv(env: Record<string, string>): void {
   for (const key of passThrough) {
     const value = process.env[key];
     if (value !== undefined) env[key] = value;
+  }
+}
+
+/**
+ * Issue #654: resolve `--profile <p>` to a concrete credential set
+ * for forwarding to Lambda containers.
+ *
+ * The dev's AWS credentials may live in any of:
+ *   - `~/.aws/sso/cache/*.json` (AWS IAM Identity Center / legacy SSO)
+ *   - `~/.aws/credentials` (regular long-lived access keys)
+ *   - `~/.aws/config` profiles with `role_arn` + `source_profile` (chained AssumeRole)
+ *   - `credential_process` external resolvers
+ *
+ * `forwardAwsEnv` only reads `process.env.AWS_*`, which is empty for
+ * every shape except "user manually exported the env vars". The
+ * Lambda container therefore boots without creds and the handler's
+ * AWS SDK call fails with `Could not load credentials from any providers`.
+ *
+ * This helper constructs a transient `STSClient({ profile })` to drive
+ * the SDK's default credential provider chain — same code path cdkd's
+ * own CFn / CC API clients use when `--profile` is set, so SSO / IAM
+ * Identity Center / role-assumption profiles all resolve the same way
+ * they already do for cdkd's outbound calls. We then extract the
+ * resolved `AwsCredentialIdentity` via `sts.config.credentials()` and
+ * return the underlying `{ accessKeyId, secretAccessKey, sessionToken? }`
+ * for env-var injection.
+ *
+ * Called ONCE at server boot; the resolved creds are reused for every
+ * Lambda container's env overlay (when `--assume-role` is not set for
+ * that Lambda — assume-role wins per the existing precedence). SSO
+ * temp creds typically last 1h+, so a single resolve is fine for the
+ * common dev session; long-running `--watch` sessions that outlive
+ * the creds need a cdkd restart (deferred refresh out of scope for
+ * v1, see issue #654).
+ */
+export async function resolveProfileCredentials(
+  profile: string
+): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string }> {
+  const { STSClient } = await import('@aws-sdk/client-sts');
+  const sts = new STSClient({ profile });
+  try {
+    const credsProvider = sts.config.credentials;
+    const creds = typeof credsProvider === 'function' ? await credsProvider() : credsProvider;
+    if (!creds || !creds.accessKeyId || !creds.secretAccessKey) {
+      throw new Error(
+        `--profile '${profile}': credential provider chain resolved without usable credentials. ` +
+          'Check `aws sso login --profile ' +
+          profile +
+          '` for SSO profiles, or `~/.aws/credentials` / `~/.aws/config` for regular profiles.'
+      );
+    }
+    return {
+      accessKeyId: creds.accessKeyId,
+      secretAccessKey: creds.secretAccessKey,
+      ...(creds.sessionToken && { sessionToken: creds.sessionToken }),
+    };
+  } finally {
+    sts.destroy();
   }
 }
 

--- a/tests/unit/cli/local-start-api-profile-creds.test.ts
+++ b/tests/unit/cli/local-start-api-profile-creds.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+import { resolveProfileCredentials } from '../../../src/cli/commands/local-start-api.js';
+
+// Issue #654: `--profile <p>` should resolve to a concrete credential set
+// for forwarding to Lambda containers. The helper drives the SDK's default
+// credential provider chain — covering SSO / IAM Identity Center / fromIni /
+// role-assumption profiles — so a dev using `aws sso login --profile X`
+// gets working creds inside the local Lambda without `eval $(aws configure
+// export-credentials ...)` gymnastics.
+
+const credsProviderMock = vi.fn();
+const stsDestroyMock = vi.fn();
+const stsCtorMock = vi.fn();
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: vi.fn().mockImplementation((config: unknown) => {
+    stsCtorMock(config);
+    return {
+      config: { credentials: credsProviderMock },
+      destroy: stsDestroyMock,
+    };
+  }),
+}));
+
+describe('resolveProfileCredentials (issue #654)', () => {
+  beforeEach(() => {
+    credsProviderMock.mockReset();
+    stsDestroyMock.mockReset();
+    stsCtorMock.mockReset();
+  });
+
+  it('resolves a profile to {accessKeyId, secretAccessKey, sessionToken}', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-TEMP',
+      secretAccessKey: 'SECRET-TEMP',
+      sessionToken: 'SESSION-TEMP',
+    });
+    const creds = await resolveProfileCredentials('mates_dev');
+    expect(creds).toEqual({
+      accessKeyId: 'AKIA-TEMP',
+      secretAccessKey: 'SECRET-TEMP',
+      sessionToken: 'SESSION-TEMP',
+    });
+    // STSClient constructed with the profile threaded through.
+    expect(stsCtorMock).toHaveBeenCalledWith({ profile: 'mates_dev' });
+    // Destroy called for cleanup.
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+
+  it('omits sessionToken when profile resolved to long-lived creds', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-LONG',
+      secretAccessKey: 'SECRET-LONG',
+    });
+    const creds = await resolveProfileCredentials('long-lived-profile');
+    expect(creds).toEqual({
+      accessKeyId: 'AKIA-LONG',
+      secretAccessKey: 'SECRET-LONG',
+    });
+    expect(creds).not.toHaveProperty('sessionToken');
+  });
+
+  it('throws a clear error when the provider chain returns no creds', async () => {
+    credsProviderMock.mockResolvedValue(undefined);
+    await expect(resolveProfileCredentials('broken-profile')).rejects.toThrow(
+      /broken-profile.*resolved without usable credentials.*aws sso login/s
+    );
+    // STS still destroyed on the failure path (finally block).
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+
+  it('throws a clear error when the provider chain returns partial creds', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-PARTIAL',
+      // secretAccessKey missing
+    });
+    await expect(resolveProfileCredentials('partial-profile')).rejects.toThrow(
+      /partial-profile.*resolved without usable credentials/
+    );
+  });
+
+  it('propagates underlying provider errors (e.g. expired SSO token)', async () => {
+    credsProviderMock.mockRejectedValue(
+      new Error('The SSO session associated with this profile has expired')
+    );
+    await expect(resolveProfileCredentials('expired-sso-profile')).rejects.toThrow(
+      /SSO session.*expired/
+    );
+    // STS destroyed on rejection too.
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

`cdkd local start-api --profile <p>` resolved the profile for cdkd's OWN AWS calls (CFn lookup, STS, etc.) but the Lambda container's runtime got only what was in `process.env.AWS_*` — empty for SSO / IAM Identity Center / regular `fromIni` profiles. The handler's AWS SDK calls therefore failed with `Could not load credentials from any providers`, even when the dev was correctly logged in with `aws sso login --profile <p>`.

This was the common enterprise dev setup: SSO-authenticated profile + Lambda needs Secrets Manager / Bedrock / etc.

## Changes

### New exported helper `resolveProfileCredentials`

[src/cli/commands/local-start-api.ts:2225](src/cli/commands/local-start-api.ts#L2225). Constructs a transient `STSClient({ profile })`, drives the SDK's default credential provider chain (covers SSO / IAM Identity Center / `fromIni` / `credential_process` / role-assumption profiles uniformly — same chain cdkd's own clients already use), and extracts the resolved `{ accessKeyId, secretAccessKey, sessionToken? }` from `sts.config.credentials()`.

Called ONCE at server boot in [src/cli/commands/local-start-api.ts](src/cli/commands/local-start-api.ts) main flow; resolved creds are reused for every Lambda container that doesn't have its own `--assume-role`.

### Credential precedence (codifies existing semantics + new layer)

For a given Lambda's container `AWS_*` env, highest priority wins:

1. `--assume-role <Lambda>=<arn>` (per-Lambda STS creds) — pre-existing, unchanged
2. `--assume-role <arn>` (global STS creds) — pre-existing, unchanged
3. **NEW**: `--profile <p>` resolved + cached (this PR) — when no `--assume-role` for this Lambda; preserves region from `forwardAwsEnv` and only overlays the credential triple
4. `process.env.AWS_*` forwarded (pre-existing) — when `--profile` not set
5. Placeholder (WebSocket-only fallback for SDK init) — unchanged

Strips inherited `AWS_SESSION_TOKEN` when the profile resolves to long-lived creds (mismatched AKID + foreign session would otherwise cause SDK error inside the container).

## Out of scope

- **Auto-refresh of expiring creds** — SSO temp creds typically last 1h+; long-running `--watch` sessions outliving the creds need a cdkd restart. A future PR could re-resolve on expiry with a warn line.
- **Same fix for `local-invoke` / `local-run-task` / `local-start-service`** — same gap likely exists. Deferred so this PR stays focused; file follow-ups per-command if needed.
- **Profile-aware SDK config file inside the container** — we resolve to env vars only. Handlers using `fromIni({ profile })` explicitly inside their code will still fail. Niche pattern.

## Test plan

- [x] `vp check --fix` passes (typecheck + lint + format)
- [x] `vp run build` passes
- [x] `vp run test` passes — 378 test files, 5812 tests (5 net new tests in this PR)
- [x] New tests cover: resolved-with-sessionToken, resolved-long-lived (no sessionToken), provider-returned-undefined, partial-creds reject, underlying-error propagation (e.g. expired SSO token)

## Real-world impact

Without this fix: `cdkd local start-api --from-cfn-stack <stack> --profile <sso-profile>` boots cleanly but every Lambda that uses an AWS SDK fails locally. Users needed the workaround `eval "$(aws configure export-credentials --profile <p> --format env)"` BEFORE running cdkd.

With this fix: works out of the box — `aws sso login --profile <p>` once + `cdkd local start-api --profile <p>` and the Lambda container's `secretsmanager:GetSecretValue` (or any other AWS SDK call) succeeds with the dev's permissions.

## Note for the merger

This PR touches `src/cli/commands/local-start-api.ts` (in `integ-local` markgate gate scope). Before merging, run `/run-integ local-start-api` to refresh the marker.

Closes #654
