### PR TITLE
feat(deploy): interactive [y/N] prompt for --recreate-via-cc-api

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -667,12 +667,20 @@ false sense of granularity.
 
 ### Interactive confirmation
 
-`cdkd deploy --recreate-via-cc-api <id>` logs a `WARN` line listing each
-target + the `stateful` reason (when applicable) before the deploy
-proceeds. Combine with `--yes` for non-interactive CI runs. Future
-follow-up may add an interactive `[y/N]` prompt (per design §4); v1
-ships the warn-log-then-proceed surface since the user already opted in
-explicitly per-resource at the CLI.
+`cdkd deploy --recreate-via-cc-api <id>` prints a per-target plan
+(logical id + resource type + `stateful` reason where applicable) and
+then asks `Continue? (y/N)` before any AWS call. Default is `N`
+(destructive — the destroy + recreate cycle is irreversible per
+resource). Combine with `--yes` / `-y` for non-interactive CI runs;
+the plan is then warn-logged once and the deploy proceeds without
+prompting. Non-TTY runs without `--yes` are rejected with an
+actionable error rather than hanging on a closed stdin.
+
+For stateful targets (those reaching pre-flight only because the user
+opted in with `--force-stateful-recreation`), the prompt prefixes each
+row with `**DATA LOSS**` and emits an explicit `DATA: all data in
+<logical id> will be lost` caveat — the third "stop and think" moment
+on top of the two-flag opt-in.
 
 ### Cross-stack reference propagation
 

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -20,6 +20,7 @@ import {
   renderRecreateTargetsErrors,
   probeAndRevalidateStateful,
 } from '../../deployment/recreate-targets.js';
+import { promptRecreateConfirm } from './recreate-confirm-prompt.js';
 import { Synthesizer } from '../../synthesis/synthesizer.js';
 import { AssetPublisher } from '../../assets/asset-publisher.js';
 import { S3StateBackend } from '../../state/s3-state-backend.js';
@@ -489,22 +490,20 @@ async function deployCommand(
           }
           recreateViaCcApiTargets = new Set(validation.targets.map((t) => t.logicalId));
           if (recreateViaCcApiTargets.size > 0) {
-            logger.warn(
-              `--recreate-via-cc-api will destroy + recreate ${recreateViaCcApiTargets.size} ` +
-                `resource(s) via Cloud Control API on stack ${stackInfo.stackName}:`
-            );
-            for (const t of validation.targets) {
-              const stateNote =
-                t.statefulReason !== null
-                  ? ` ⚠ stateful (${t.statefulReason}) — --force-stateful-recreation acknowledged`
-                  : '';
-              logger.warn(`  - ${t.logicalId} (${t.resourceType})${stateNote}`);
+            // Issue [#649] — interactive [y/N] prompt. Mirrors the
+            // existing prefix-rename prompt structure: per-stack, with
+            // --yes / -y short-circuiting to the warn-log surface that
+            // v1 shipped. Stateful targets get a **DATA LOSS** prefix
+            // as a third "stop and think" moment beyond the explicit
+            // --force-stateful-recreation opt-in.
+            const proceed = await promptRecreateConfirm({
+              stackName: stackInfo.stackName,
+              targets: validation.targets,
+              yes: options.yes ?? false,
+            });
+            if (!proceed) {
+              return;
             }
-            logger.warn(
-              `  The destroy + recreate cycle is per-resource; sibling resources are unaffected. ` +
-                `Downstream consumers of any recreated resource's outputs (Fn::GetStackOutput / ` +
-                `Fn::ImportValue) will need a re-deploy to see the new physical id.`
-            );
           }
         }
 

--- a/src/cli/commands/recreate-confirm-prompt.ts
+++ b/src/cli/commands/recreate-confirm-prompt.ts
@@ -1,0 +1,90 @@
+/**
+ * Interactive confirmation prompt for `cdkd deploy --recreate-via-cc-api`
+ * (issue [#649]).
+ *
+ * Mirror of {@link ../prefix-migration-check.ts}'s `promptMigrationConfirm`
+ * but for the recreate-via-cc-api destroy+recreate cycle:
+ *
+ *   - `opts.yes` (CDK CLI parity `-y` / `--yes`) skips the prompt and
+ *     prints the per-target plan as a `WARN` block (the existing v1
+ *     surface). CI use case.
+ *   - When `opts.yes` is false, the prompt fires after the per-target
+ *     plan. Default is `N` because the side effect is destructive
+ *     (a per-resource destroy + recreate cycle).
+ *   - Non-TTY guard: if `opts.yes` is false AND stdin is not a TTY,
+ *     throws with an actionable message rather than hanging or
+ *     silently declining. CI runs without `--yes` would otherwise look
+ *     like a successful skipped-deploy.
+ *
+ * The per-target plan surfaces a **DATA LOSS** prefix for stateful
+ * targets (those with a non-null `statefulReason` after the live
+ * `s3:ListObjectsV2` probe — see issue [#648]); these reached pre-flight
+ * only because the user opted in with `--force-stateful-recreation`,
+ * so the prompt's **DATA LOSS** wording is the third "stop and think"
+ * moment.
+ */
+
+import readline from 'node:readline/promises';
+import { getLogger } from '../../utils/logger.js';
+import type { RecreateTarget } from '../../deployment/recreate-targets.js';
+
+export async function promptRecreateConfirm(input: {
+  stackName: string;
+  targets: ReadonlyArray<RecreateTarget>;
+  yes: boolean;
+}): Promise<boolean> {
+  if (input.targets.length === 0) return true;
+
+  const logger = getLogger();
+  logger.warn('');
+  logger.warn(
+    `--recreate-via-cc-api will destroy + recreate ${input.targets.length} ` +
+      `resource(s) via Cloud Control API on stack ${input.stackName}:`
+  );
+  for (const t of input.targets) {
+    const stateful = t.statefulReason !== null;
+    const dataLossPrefix = stateful ? '**DATA LOSS** ' : '';
+    const stateNote = stateful
+      ? ` — stateful (${t.statefulReason}); --force-stateful-recreation acknowledged`
+      : '';
+    logger.warn(`  - ${dataLossPrefix}${t.logicalId} (${t.resourceType})${stateNote}`);
+    if (stateful) {
+      logger.warn(
+        `    DATA: all data in ${t.logicalId} will be lost (no automatic data migration)`
+      );
+    }
+  }
+  logger.warn(
+    '  The destroy + recreate cycle is per-resource; sibling resources are unaffected. ' +
+      "Downstream consumers of any recreated resource's outputs (Fn::GetStackOutput / " +
+      'Fn::ImportValue) will need a re-deploy to see the new physical id.'
+  );
+
+  if (input.yes) return true;
+
+  // Non-TTY guard: reject explicitly rather than hanging on a closed
+  // stdin or silently treating EOF as decline. CI runs without `--yes`
+  // would otherwise look like a successful skipped-deploy; surface the
+  // misconfiguration with an actionable error instead.
+  if (process.stdin.isTTY !== true) {
+    throw new Error(
+      '--recreate-via-cc-api confirm prompt cannot run in a non-interactive ' +
+        'environment. Pass --yes / -y to confirm the destroy + recreate cycle, ' +
+        'or run the deploy from a real terminal.'
+    );
+  }
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  try {
+    const answer = await rl.question('\nContinue? (y/N): ');
+    const trimmed = answer.trim().toLowerCase();
+    if (trimmed === 'y' || trimmed === 'yes') return true;
+    logger.info('Deploy cancelled — no resources modified.');
+    return false;
+  } finally {
+    rl.close();
+  }
+}

--- a/tests/unit/cli/commands/recreate-confirm-prompt.test.ts
+++ b/tests/unit/cli/commands/recreate-confirm-prompt.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for the #649 interactive prompt for `--recreate-via-cc-api`.
+ *
+ * Covers:
+ *   - `--yes` short-circuit (prompt skipped, plan still warn-logged)
+ *   - interactive `y` / `n` / EOL responses
+ *   - DATA LOSS prefix + DATA caveat for stateful targets
+ *   - generic downstream caveat appended once per call
+ *   - empty target list → no-op (returns true)
+ *   - non-TTY without --yes → throws actionable error
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import type { RecreateTarget } from '../../../../src/deployment/recreate-targets.js';
+
+const warnSpy = vi.fn();
+const infoSpy = vi.fn();
+vi.mock('../../../../src/utils/logger.js', () => ({
+  getLogger: () => ({
+    warn: warnSpy,
+    info: infoSpy,
+    debug: vi.fn(),
+    error: vi.fn(),
+    child: () => ({ warn: warnSpy, info: infoSpy, debug: vi.fn(), error: vi.fn() }),
+  }),
+}));
+
+const readlineQuestion = vi.fn();
+vi.mock('node:readline/promises', () => ({
+  default: {
+    createInterface: () => ({ question: readlineQuestion, close: vi.fn() }),
+  },
+}));
+
+const { promptRecreateConfirm } = await import(
+  '../../../../src/cli/commands/recreate-confirm-prompt.js'
+);
+
+function target(overrides: Partial<RecreateTarget> = {}): RecreateTarget {
+  return {
+    logicalId: 'MyLambda',
+    resourceType: 'AWS::Lambda::Function',
+    physicalId: 'fn-pid',
+    statefulReason: null,
+    ...overrides,
+  };
+}
+
+describe('promptRecreateConfirm (#649)', () => {
+  const origIsTTY = process.stdin.isTTY;
+
+  beforeEach(() => {
+    warnSpy.mockReset();
+    infoSpy.mockReset();
+    readlineQuestion.mockReset();
+    // Default to TTY=true so prompt path runs; per-test overrides.
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: origIsTTY, configurable: true });
+  });
+
+  it('returns true without prompting when target list is empty', async () => {
+    const result = await promptRecreateConfirm({ stackName: 'S', targets: [], yes: false });
+    expect(result).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(readlineQuestion).not.toHaveBeenCalled();
+  });
+
+  it('--yes short-circuits the prompt and warn-logs the plan', async () => {
+    const result = await promptRecreateConfirm({
+      stackName: 'MyStack',
+      targets: [target()],
+      yes: true,
+    });
+    expect(result).toBe(true);
+    expect(readlineQuestion).not.toHaveBeenCalled();
+    const warnLines = warnSpy.mock.calls.map((c) => c[0] as string).join('\n');
+    expect(warnLines).toContain('--recreate-via-cc-api will destroy + recreate 1');
+    expect(warnLines).toContain('MyLambda (AWS::Lambda::Function)');
+    expect(warnLines).toContain('per-resource; sibling resources are unaffected');
+  });
+
+  it('returns true on "y" response', async () => {
+    readlineQuestion.mockResolvedValueOnce('y');
+    const result = await promptRecreateConfirm({
+      stackName: 'S',
+      targets: [target()],
+      yes: false,
+    });
+    expect(result).toBe(true);
+    expect(readlineQuestion).toHaveBeenCalledTimes(1);
+    expect(readlineQuestion.mock.calls[0]![0]).toMatch(/Continue\? \(y\/N\)/);
+  });
+
+  it('returns true on "yes" / case-insensitive', async () => {
+    readlineQuestion.mockResolvedValueOnce('YES');
+    const result = await promptRecreateConfirm({
+      stackName: 'S',
+      targets: [target()],
+      yes: false,
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns false on "n" response and logs "Deploy cancelled"', async () => {
+    readlineQuestion.mockResolvedValueOnce('n');
+    const result = await promptRecreateConfirm({
+      stackName: 'S',
+      targets: [target()],
+      yes: false,
+    });
+    expect(result).toBe(false);
+    expect(infoSpy.mock.calls.some((c) => String(c[0]).includes('Deploy cancelled'))).toBe(true);
+  });
+
+  it('returns false on bare EOL (empty input) — default-no', async () => {
+    readlineQuestion.mockResolvedValueOnce('');
+    const result = await promptRecreateConfirm({
+      stackName: 'S',
+      targets: [target()],
+      yes: false,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('prefixes stateful targets with **DATA LOSS** and appends DATA caveat', async () => {
+    readlineQuestion.mockResolvedValueOnce('y');
+    await promptRecreateConfirm({
+      stackName: 'S',
+      targets: [
+        target({ logicalId: 'MyDB', resourceType: 'AWS::RDS::DBInstance', statefulReason: 'always' }),
+        target({ logicalId: 'OtherFn' }),
+      ],
+      yes: false,
+    });
+    const warnLines = warnSpy.mock.calls.map((c) => c[0] as string).join('\n');
+    expect(warnLines).toContain('**DATA LOSS** MyDB (AWS::RDS::DBInstance)');
+    expect(warnLines).toContain('--force-stateful-recreation acknowledged');
+    expect(warnLines).toContain('DATA: all data in MyDB will be lost (no automatic data migration)');
+    // Non-stateful target has neither.
+    expect(warnLines).toContain('- OtherFn (AWS::Lambda::Function)');
+    expect(warnLines).not.toContain('**DATA LOSS** OtherFn');
+  });
+
+  it('throws an actionable error in a non-TTY environment when --yes is not set', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    await expect(
+      promptRecreateConfirm({ stackName: 'S', targets: [target()], yes: false })
+    ).rejects.toThrow(/--recreate-via-cc-api confirm prompt cannot run in a non-interactive/);
+    expect(readlineQuestion).not.toHaveBeenCalled();
+  });
+
+  it('still skips the prompt in a non-TTY environment when --yes IS set (CI path)', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    const result = await promptRecreateConfirm({
+      stackName: 'S',
+      targets: [target()],
+      yes: true,
+    });
+    expect(result).toBe(true);
+    expect(readlineQuestion).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #649.

Wires an interactive `Continue? (y/N)` prompt into the `--recreate-via-cc-api` deploy path. Default is `N` — the destroy + recreate cycle is per-resource irreversible. `--yes` / `-y` short-circuits to the v1 warn-log surface for CI runs.

Mirrors the existing prefix-rename prompt structure: per-stack, with TTY guard, `--yes` skip, and friendly error on non-interactive runs without `--yes`.

## Implementation

- `src/cli/commands/recreate-confirm-prompt.ts` — new `promptRecreateConfirm` helper. Per-target plan + stateful **DATA LOSS** prefix + DATA caveat for stateful targets (those reaching pre-flight only because the user opted in with `--force-stateful-recreation`).
- `src/cli/commands/deploy.ts` — calls the helper after `validateRecreateTargets` clears + replaces the existing inline warn block.
- `docs/cli-reference.md` — Interactive confirmation section reflects the now-live prompt.

## Spec mapping

- v1 ships warn-log-then-proceed (post-PR #643): replaced.
- Design doc §4 calls for `**DATA LOSS**` heading on stateful + `DATA: All data in <id> will be lost` caveat: shipped.
- CI use case `--yes`: preserved (warn-log path is the `--yes` branch).
- Multi-stack deploys: prompt fires per-stack (matches the existing prefix-rename prompt structure).
- Non-TTY without `--yes`: rejected with actionable error (matches `promptMigrationConfirm`'s pattern).

## Test plan

- [x] Unit tests at `tests/unit/cli/commands/recreate-confirm-prompt.test.ts`: 9 new cases covering `--yes` short-circuit / `y`/`yes`/`n`/empty-EOL responses / DATA LOSS + caveat / empty target list / non-TTY rejection / non-TTY + `--yes` CI path.
- [x] `/run-integ recreate-via-cc-api` — feature integ (uses `--yes`, exercises the CI short-circuit + warn-log path). Phase 1–4 clean, 0 errors, 0 orphans.
- [x] `/run-integ lambda` — broad-integ-set member for the cross-cutting `deploy.ts` touch. 8 deleted, 0 errors, 0 orphans.
- [x] `vp check --fix && vp run build && vp run test` — 5829 / 5829 tests pass.

## Notes

The interactive prompt itself cannot be tested in an integ (no TTY); unit tests with mocked readline cover the prompt-true / prompt-false / non-TTY paths. The integ exercises the `--yes` short-circuit which is the only path users hit in CI.
