### PR TITLE
feat(deploy): enumerate downstream Fn::ImportValue consumers in --recreate-via-cc-api warn

### DIFF
--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -21,6 +21,7 @@ import {
   probeAndRevalidateStateful,
 } from '../../deployment/recreate-targets.js';
 import { promptRecreateConfirm } from './recreate-confirm-prompt.js';
+import { findDownstreamConsumers } from './recreate-downstream-consumers.js';
 import { Synthesizer } from '../../synthesis/synthesizer.js';
 import { AssetPublisher } from '../../assets/asset-publisher.js';
 import { S3StateBackend } from '../../state/s3-state-backend.js';
@@ -490,6 +491,17 @@ async function deployCommand(
           }
           recreateViaCcApiTargets = new Set(validation.targets.map((t) => t.logicalId));
           if (recreateViaCcApiTargets.size > 0) {
+            // Issue [#650] — enumerate downstream `Fn::ImportValue`
+            // consumers via the state bucket walk so the warn block
+            // names them by stack. Soft-fail (returns []) on read
+            // errors — the generic caveat still surfaces below.
+            const downstreamConsumers = await findDownstreamConsumers({
+              producerStack: stackInfo.stackName,
+              producerRegion: stackRegion,
+              stateBackend: stackStateBackend,
+              baseRegion,
+            });
+
             // Issue [#649] — interactive [y/N] prompt. Mirrors the
             // existing prefix-rename prompt structure: per-stack, with
             // --yes / -y short-circuiting to the warn-log surface that
@@ -500,6 +512,7 @@ async function deployCommand(
               stackName: stackInfo.stackName,
               targets: validation.targets,
               yes: options.yes ?? false,
+              downstreamConsumers,
             });
             if (!proceed) {
               return;

--- a/src/cli/commands/recreate-confirm-prompt.ts
+++ b/src/cli/commands/recreate-confirm-prompt.ts
@@ -27,11 +27,22 @@
 import readline from 'node:readline/promises';
 import { getLogger } from '../../utils/logger.js';
 import type { RecreateTarget } from '../../deployment/recreate-targets.js';
+import {
+  renderDownstreamConsumers,
+  type DownstreamConsumer,
+} from './recreate-downstream-consumers.js';
 
 export async function promptRecreateConfirm(input: {
   stackName: string;
   targets: ReadonlyArray<RecreateTarget>;
   yes: boolean;
+  /**
+   * Optional per-target downstream consumer enumeration (issue [#650]).
+   * Empty / undefined → no per-target consumer list is rendered (the
+   * generic caveat still fires). When supplied, each entry is rendered
+   * below the corresponding target.
+   */
+  downstreamConsumers?: ReadonlyArray<DownstreamConsumer>;
 }): Promise<boolean> {
   if (input.targets.length === 0) return true;
 
@@ -53,6 +64,13 @@ export async function promptRecreateConfirm(input: {
         `    DATA: all data in ${t.logicalId} will be lost (no automatic data migration)`
       );
     }
+  }
+  // Issue [#650] — per-target downstream consumer enumeration.
+  // Fires once (consumers are stack-wide, not per-target — every
+  // Fn::ImportValue from this stack lands in the same list).
+  if (input.downstreamConsumers && input.downstreamConsumers.length > 0) {
+    const rendered = renderDownstreamConsumers(input.stackName, input.downstreamConsumers);
+    if (rendered) logger.warn(rendered);
   }
   logger.warn(
     '  The destroy + recreate cycle is per-resource; sibling resources are unaffected. ' +

--- a/src/cli/commands/recreate-downstream-consumers.ts
+++ b/src/cli/commands/recreate-downstream-consumers.ts
@@ -36,6 +36,7 @@
  */
 
 import type { S3StateBackend } from '../../state/s3-state-backend.js';
+import { getLogger } from '../../utils/logger.js';
 
 /**
  * One downstream consumer of a recreate target's outputs.
@@ -52,7 +53,7 @@ export interface DownstreamConsumer {
    * detects `'ImportValue'`; `'GetStackOutput'` is reserved for a
    * future schema bump that adds `outputReads[]` tracking.
    */
-  intrinsic: 'ImportValue';
+  intrinsic: 'ImportValue' | 'GetStackOutput';
 }
 
 /**
@@ -73,7 +74,21 @@ export async function findDownstreamConsumers(input: {
   /** Default-region fallback for legacy v1 state records that lack `region`. */
   baseRegion: string;
 }): Promise<DownstreamConsumer[]> {
-  const refs = await input.stateBackend.listStacks();
+  const logger = getLogger().child('recreate-downstream');
+  // Outer soft-fail: a transient `ListObjectsV2` IAM denial / 5xx on
+  // the state bucket must NOT abort the deploy. The warn block is
+  // informational; the generic caveat that follows already covers the
+  // "we couldn't enumerate" case.
+  let refs: Awaited<ReturnType<S3StateBackend['listStacks']>>;
+  try {
+    refs = await input.stateBackend.listStacks();
+  } catch (err) {
+    logger.debug(
+      `findDownstreamConsumers: listStacks failed; ` +
+        `falling back to empty enumeration. ${err instanceof Error ? err.message : String(err)}`
+    );
+    return [];
+  }
   const results = await Promise.all(
     refs.map(async (ref) => {
       const region = ref.region ?? input.baseRegion;
@@ -96,10 +111,14 @@ export async function findDownstreamConsumers(input: {
           exportName: entry.exportName,
           intrinsic: 'ImportValue',
         }));
-      } catch {
+      } catch (err) {
         // An unreadable single state file shouldn't tank the entire
-        // enumeration — return null and let the caller render
-        // whatever consumers were found in other stacks.
+        // enumeration — log at debug and return null; the caller still
+        // renders whatever consumers were found in other stacks.
+        logger.debug(
+          `findDownstreamConsumers: skip ${ref.stackName} (${region}); ` +
+            `${err instanceof Error ? err.message : String(err)}`
+        );
         return null;
       }
     })

--- a/src/cli/commands/recreate-downstream-consumers.ts
+++ b/src/cli/commands/recreate-downstream-consumers.ts
@@ -1,0 +1,136 @@
+/**
+ * Downstream-consumer enumeration for the `--recreate-via-cc-api` warn
+ * block (issue [#650]).
+ *
+ * A recreated resource gets a fresh physical id (most types — Lambda
+ * Functions with a user-supplied `functionName` reuse the name, but
+ * the AWS-side resource is new). Any **downstream cdkd stack** that
+ * imports the producer's outputs via `Fn::ImportValue` (or reads via
+ * `Fn::GetStackOutput`) will see a STALE value until that downstream
+ * stack is re-deployed.
+ *
+ * The cdkd state bucket already has the data needed to enumerate
+ * `Fn::ImportValue` consumers — every stack's `state.json` carries an
+ * `imports[]` list of `(sourceStack, sourceRegion, exportName)`
+ * triples written at deploy time by the intrinsic resolver (see
+ * `src/deployment/intrinsic-function-resolver.ts` and the schema v4
+ * note in `.claude/rules/state-schema.md`).
+ *
+ * **v1 scope (#650)**: `Fn::ImportValue` consumers ONLY. cdkd's
+ * `Fn::GetStackOutput` is intentionally NOT tracked in `imports[]`
+ * (the design treats it as a weak reference — see
+ * `src/types/state.ts` `StateImportEntry`'s JSDoc). Detecting
+ * `Fn::GetStackOutput` consumers would require a separate
+ * `outputReads[]` field on `StackState` — a schema bump out of scope
+ * for this PR. The warn block continues to surface the generic
+ * "downstream consumers will need a re-deploy" caveat so users with
+ * `Fn::GetStackOutput`-only consumers see the warning even though we
+ * cannot name them.
+ *
+ * The walk is per-stack: `ListStacks` returns a flat list of
+ * (stackName, region) refs and we read each state's `imports[]`. The
+ * cost is O(M) S3 reads where M = total stacks in the bucket. The
+ * existing `scanActiveConsumers` in `destroy-runner.ts` uses the same
+ * shape for the destroy-time strong-reference refusal — this helper
+ * exists as its read-only sibling for the recreate-warn use case.
+ */
+
+import type { S3StateBackend } from '../../state/s3-state-backend.js';
+
+/**
+ * One downstream consumer of a recreate target's outputs.
+ */
+export interface DownstreamConsumer {
+  /** The consumer stack name. */
+  consumerStack: string;
+  /** The consumer stack's region. */
+  consumerRegion: string;
+  /** The export the consumer reads from the producer. */
+  exportName: string;
+  /**
+   * Which intrinsic surfaced the cross-stack reference. v1 only
+   * detects `'ImportValue'`; `'GetStackOutput'` is reserved for a
+   * future schema bump that adds `outputReads[]` tracking.
+   */
+  intrinsic: 'ImportValue';
+}
+
+/**
+ * Walk every stack in the cdkd state bucket and find consumers whose
+ * `imports[]` reference the producer `(producerStack, producerRegion)`.
+ *
+ * Skips the producer itself (self-imports are invalid in CFn / cdkd).
+ *
+ * Soft-fails per consumer: an unreadable state file is logged at debug
+ * and skipped — the warn block falls back to "we couldn't enumerate
+ * downstream consumers" rather than blocking the deploy. The caller
+ * always proceeds; this is informational only.
+ */
+export async function findDownstreamConsumers(input: {
+  producerStack: string;
+  producerRegion: string;
+  stateBackend: S3StateBackend;
+  /** Default-region fallback for legacy v1 state records that lack `region`. */
+  baseRegion: string;
+}): Promise<DownstreamConsumer[]> {
+  const refs = await input.stateBackend.listStacks();
+  const results = await Promise.all(
+    refs.map(async (ref) => {
+      const region = ref.region ?? input.baseRegion;
+      // Skip self (a stack importing its own output is invalid).
+      if (ref.stackName === input.producerStack && region === input.producerRegion) {
+        return null;
+      }
+      try {
+        const got = await input.stateBackend.getState(ref.stackName, region);
+        const imports = got?.state.imports;
+        if (!imports || imports.length === 0) return null;
+        const matches = imports.filter(
+          (entry) =>
+            entry.sourceStack === input.producerStack && entry.sourceRegion === input.producerRegion
+        );
+        if (matches.length === 0) return null;
+        return matches.map<DownstreamConsumer>((entry) => ({
+          consumerStack: ref.stackName,
+          consumerRegion: region,
+          exportName: entry.exportName,
+          intrinsic: 'ImportValue',
+        }));
+      } catch {
+        // An unreadable single state file shouldn't tank the entire
+        // enumeration — return null and let the caller render
+        // whatever consumers were found in other stacks.
+        return null;
+      }
+    })
+  );
+  return results.filter((r): r is DownstreamConsumer[] => r !== null).flat();
+}
+
+/**
+ * Render the per-consumer subset of the warn block as a multi-line
+ * string suitable for piping into the logger. Returns `null` when the
+ * enumeration is empty (caller skips the subsection in that case).
+ *
+ * Shape:
+ * ```
+ *   Downstream consumers of <ProducerStack>'s outputs (will need re-deploy):
+ *     - StackB (region) reads ExportName via Fn::ImportValue
+ *     - StackC (region) reads OtherExport via Fn::ImportValue
+ * ```
+ */
+export function renderDownstreamConsumers(
+  producerStack: string,
+  consumers: ReadonlyArray<DownstreamConsumer>
+): string | null {
+  if (consumers.length === 0) return null;
+  const lines: string[] = [
+    `  Downstream consumers of ${producerStack}'s outputs (will need re-deploy after this run):`,
+  ];
+  for (const c of consumers) {
+    lines.push(
+      `    - ${c.consumerStack} (${c.consumerRegion}) reads ${c.exportName} via Fn::${c.intrinsic}`
+    );
+  }
+  return lines.join('\n');
+}

--- a/tests/unit/cli/commands/recreate-confirm-prompt.test.ts
+++ b/tests/unit/cli/commands/recreate-confirm-prompt.test.ts
@@ -144,6 +144,45 @@ describe('promptRecreateConfirm (#649)', () => {
     expect(warnLines).not.toContain('**DATA LOSS** OtherFn');
   });
 
+  it('renders downstream consumer enumeration when supplied (#650)', async () => {
+    await promptRecreateConfirm({
+      stackName: 'Producer',
+      targets: [target()],
+      yes: true,
+      downstreamConsumers: [
+        {
+          consumerStack: 'StackB',
+          consumerRegion: 'us-east-1',
+          exportName: 'ProducerArn',
+          intrinsic: 'ImportValue',
+        },
+        {
+          consumerStack: 'StackC',
+          consumerRegion: 'us-east-1',
+          exportName: 'OtherArn',
+          intrinsic: 'ImportValue',
+        },
+      ],
+    });
+    const warnLines = warnSpy.mock.calls.map((c) => c[0] as string).join('\n');
+    expect(warnLines).toContain("Downstream consumers of Producer's outputs");
+    expect(warnLines).toContain('- StackB (us-east-1) reads ProducerArn via Fn::ImportValue');
+    expect(warnLines).toContain('- StackC (us-east-1) reads OtherArn via Fn::ImportValue');
+    expect(warnLines).toContain('per-resource; sibling resources are unaffected');
+  });
+
+  it('skips downstream enumeration section when the list is empty (#650)', async () => {
+    await promptRecreateConfirm({
+      stackName: 'Producer',
+      targets: [target()],
+      yes: true,
+      downstreamConsumers: [],
+    });
+    const warnLines = warnSpy.mock.calls.map((c) => c[0] as string).join('\n');
+    expect(warnLines).not.toContain("Downstream consumers of Producer's outputs");
+    expect(warnLines).toContain('per-resource; sibling resources are unaffected');
+  });
+
   it('throws an actionable error in a non-TTY environment when --yes is not set', async () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
     await expect(

--- a/tests/unit/cli/commands/recreate-downstream-consumers.test.ts
+++ b/tests/unit/cli/commands/recreate-downstream-consumers.test.ts
@@ -206,6 +206,23 @@ describe('findDownstreamConsumers (#650)', () => {
     expect(out.every((c) => c.consumerStack === 'StackB')).toBe(true);
   });
 
+  it('soft-fails on listStacks error (deploy must not abort on transient S3 list failure)', async () => {
+    const backend = {
+      listStacks: vi.fn(async () => {
+        throw new Error('AccessDeniedException on ListObjectsV2');
+      }),
+      getState: vi.fn(),
+    } as unknown as S3StateBackend;
+    const out = await findDownstreamConsumers({
+      producerStack: 'Producer',
+      producerRegion: 'us-east-1',
+      stateBackend: backend,
+      baseRegion: 'us-east-1',
+    });
+    expect(out).toEqual([]);
+    expect(backend.getState).not.toHaveBeenCalled();
+  });
+
   it('falls back to baseRegion when ref.region is missing (legacy v1 records)', async () => {
     const backend = mockBackend(
       [{ stackName: 'StackB' /* no region */ }],

--- a/tests/unit/cli/commands/recreate-downstream-consumers.test.ts
+++ b/tests/unit/cli/commands/recreate-downstream-consumers.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for the #650 downstream-consumer enumeration helper.
+ *
+ * Covers:
+ *   - Empty stacks → no consumers
+ *   - Multiple consumer stacks → all returned
+ *   - Self-import skip (producer importing its own output is invalid)
+ *   - Mismatch region → not returned
+ *   - Mismatch producer name → not returned
+ *   - Unreadable state on one stack → skip + return remaining matches
+ *   - Multiple imports on the same consumer → all entries returned
+ *   - renderDownstreamConsumers output shape
+ */
+
+import { describe, it, expect, vi } from 'vite-plus/test';
+import {
+  findDownstreamConsumers,
+  renderDownstreamConsumers,
+  type DownstreamConsumer,
+} from '../../../../src/cli/commands/recreate-downstream-consumers.js';
+import type { S3StateBackend } from '../../../../src/state/s3-state-backend.js';
+import type { StackState, StateImportEntry } from '../../../../src/types/state.js';
+
+function st(
+  stackName: string,
+  region: string,
+  imports: StateImportEntry[] | undefined
+): StackState {
+  return {
+    version: 7,
+    stackName,
+    region,
+    resources: {},
+    outputs: {},
+    ...(imports ? { imports } : {}),
+    lastModified: 0,
+  };
+}
+
+function mockBackend(
+  refs: Array<{ stackName: string; region?: string }>,
+  states: Map<string, StackState | null>
+): S3StateBackend {
+  return {
+    listStacks: vi.fn(async () => refs),
+    getState: vi.fn(async (stackName: string, region: string) => {
+      const key = `${stackName}|${region}`;
+      const state = states.get(key);
+      if (state === undefined) return null;
+      if (state === null) throw new Error('state read failed');
+      return { state, etag: 'e' };
+    }),
+  } as unknown as S3StateBackend;
+}
+
+describe('findDownstreamConsumers (#650)', () => {
+  it('returns empty when no stacks have imports referencing the producer', async () => {
+    const backend = mockBackend(
+      [
+        { stackName: 'StackA', region: 'us-east-1' },
+        { stackName: 'StackB', region: 'us-east-1' },
+      ],
+      new Map([
+        ['StackA|us-east-1', st('StackA', 'us-east-1', undefined)],
+        ['StackB|us-east-1', st('StackB', 'us-east-1', [])],
+      ])
+    );
+    const out = await findDownstreamConsumers({
+      producerStack: 'Producer',
+      producerRegion: 'us-east-1',
+      stateBackend: backend,
+      baseRegion: 'us-east-1',
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('returns every consumer that imports the producer', async () => {
+    const backend = mockBackend(
+      [
+        { stackName: 'Producer', region: 'us-east-1' },
+        { stackName: 'StackB', region: 'us-east-1' },
+        { stackName: 'StackC', region: 'us-east-1' },
+        { stackName: 'StackD', region: 'us-east-1' },
+      ],
+      new Map([
+        ['Producer|us-east-1', st('Producer', 'us-east-1', [])],
+        [
+          'StackB|us-east-1',
+          st('StackB', 'us-east-1', [
+            { sourceStack: 'Producer', sourceRegion: 'us-east-1', exportName: 'ArnA' },
+          ]),
+        ],
+        [
+          'StackC|us-east-1',
+          st('StackC', 'us-east-1', [
+            { sourceStack: 'Producer', sourceRegion: 'us-east-1', exportName: 'ArnB' },
+          ]),
+        ],
+        // Sibling that imports a different producer — should NOT be returned.
+        [
+          'StackD|us-east-1',
+          st('StackD', 'us-east-1', [
+            { sourceStack: 'OtherProducer', sourceRegion: 'us-east-1', exportName: 'X' },
+          ]),
+        ],
+      ])
+    );
+    const out = await findDownstreamConsumers({
+      producerStack: 'Producer',
+      producerRegion: 'us-east-1',
+      stateBackend: backend,
+      baseRegion: 'us-east-1',
+    });
+    expect(out.map((c) => c.consumerStack).sort()).toEqual(['StackB', 'StackC']);
+    expect(out.every((c) => c.intrinsic === 'ImportValue')).toBe(true);
+  });
+
+  it('skips the producer itself (self-imports are invalid)', async () => {
+    const backend = mockBackend(
+      [{ stackName: 'Producer', region: 'us-east-1' }],
+      new Map([
+        [
+          'Producer|us-east-1',
+          st('Producer', 'us-east-1', [
+            { sourceStack: 'Producer', sourceRegion: 'us-east-1', exportName: 'SelfArn' },
+          ]),
+        ],
+      ])
+    );
+    const out = await findDownstreamConsumers({
+      producerStack: 'Producer',
+      producerRegion: 'us-east-1',
+      stateBackend: backend,
+      baseRegion: 'us-east-1',
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('does NOT match a producer in a different region (cross-region scope)', async () => {
+    const backend = mockBackend(
+      [{ stackName: 'StackB', region: 'us-east-1' }],
+      new Map([
+        [
+          'StackB|us-east-1',
+          st('StackB', 'us-east-1', [
+            { sourceStack: 'Producer', sourceRegion: 'us-west-2', exportName: 'ArnA' },
+          ]),
+        ],
+      ])
+    );
+    const out = await findDownstreamConsumers({
+      producerStack: 'Producer',
+      producerRegion: 'us-east-1',
+      stateBackend: backend,
+      baseRegion: 'us-east-1',
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('soft-fails on unreadable state (returns what was read)', async () => {
+    const backend = mockBackend(
+      [
+        { stackName: 'StackB', region: 'us-east-1' },
+        { stackName: 'StackC', region: 'us-east-1' },
+      ],
+      new Map<string, StackState | null>([
+        ['StackB|us-east-1', null], // throws on read
+        [
+          'StackC|us-east-1',
+          st('StackC', 'us-east-1', [
+            { sourceStack: 'Producer', sourceRegion: 'us-east-1', exportName: 'ArnC' },
+          ]),
+        ],
+      ])
+    );
+    const out = await findDownstreamConsumers({
+      producerStack: 'Producer',
+      producerRegion: 'us-east-1',
+      stateBackend: backend,
+      baseRegion: 'us-east-1',
+    });
+    expect(out.map((c) => c.consumerStack)).toEqual(['StackC']);
+  });
+
+  it('returns multiple matches when a single consumer imports several outputs', async () => {
+    const backend = mockBackend(
+      [{ stackName: 'StackB', region: 'us-east-1' }],
+      new Map([
+        [
+          'StackB|us-east-1',
+          st('StackB', 'us-east-1', [
+            { sourceStack: 'Producer', sourceRegion: 'us-east-1', exportName: 'ArnA' },
+            { sourceStack: 'Producer', sourceRegion: 'us-east-1', exportName: 'ArnB' },
+            { sourceStack: 'OtherProducer', sourceRegion: 'us-east-1', exportName: 'X' },
+          ]),
+        ],
+      ])
+    );
+    const out = await findDownstreamConsumers({
+      producerStack: 'Producer',
+      producerRegion: 'us-east-1',
+      stateBackend: backend,
+      baseRegion: 'us-east-1',
+    });
+    expect(out.map((c) => c.exportName).sort()).toEqual(['ArnA', 'ArnB']);
+    expect(out.every((c) => c.consumerStack === 'StackB')).toBe(true);
+  });
+
+  it('falls back to baseRegion when ref.region is missing (legacy v1 records)', async () => {
+    const backend = mockBackend(
+      [{ stackName: 'StackB' /* no region */ }],
+      new Map([
+        [
+          'StackB|us-east-1', // resolved via baseRegion
+          st('StackB', 'us-east-1', [
+            { sourceStack: 'Producer', sourceRegion: 'us-east-1', exportName: 'ArnA' },
+          ]),
+        ],
+      ])
+    );
+    const out = await findDownstreamConsumers({
+      producerStack: 'Producer',
+      producerRegion: 'us-east-1',
+      stateBackend: backend,
+      baseRegion: 'us-east-1',
+    });
+    expect(out.map((c) => c.consumerStack)).toEqual(['StackB']);
+  });
+});
+
+describe('renderDownstreamConsumers (#650)', () => {
+  function c(overrides: Partial<DownstreamConsumer> = {}): DownstreamConsumer {
+    return {
+      consumerStack: 'StackB',
+      consumerRegion: 'us-east-1',
+      exportName: 'ProducerArn',
+      intrinsic: 'ImportValue',
+      ...overrides,
+    };
+  }
+
+  it('returns null on empty input (caller skips the subsection)', () => {
+    expect(renderDownstreamConsumers('Producer', [])).toBe(null);
+  });
+
+  it('renders a header + one line per consumer', () => {
+    const rendered = renderDownstreamConsumers('Producer', [
+      c(),
+      c({ consumerStack: 'StackC', exportName: 'OtherArn' }),
+    ]);
+    expect(rendered).not.toBe(null);
+    expect(rendered!).toContain("Downstream consumers of Producer's outputs");
+    expect(rendered!).toContain('- StackB (us-east-1) reads ProducerArn via Fn::ImportValue');
+    expect(rendered!).toContain('- StackC (us-east-1) reads OtherArn via Fn::ImportValue');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #650.

`cdkd deploy --recreate-via-cc-api <id>` now names every downstream cdkd stack that imports the producer's outputs via `Fn::ImportValue`. The warn block lists each consumer by stack name, region, and export name so users can plan multi-stack re-deploys without walking the state bucket by hand.

v1 scope: `Fn::ImportValue` consumers only. `Fn::GetStackOutput` is intentionally NOT tracked in cdkd's `state.imports[]` (weak-reference design per `src/types/state.ts`); detecting those consumers would require a schema bump and is out of scope. The generic "downstream consumers will need a re-deploy" caveat still fires below the enumeration so `Fn::GetStackOutput`-only consumers are still warned about, just not named.

## Implementation

- `src/cli/commands/recreate-downstream-consumers.ts` — new `findDownstreamConsumers({ producerStack, producerRegion, stateBackend, baseRegion })` helper. Walks `ListStacks` → for each ref, reads state's `imports[]` → filters by `(sourceStack, sourceRegion)` match. Soft-fails per-state (unreadable state → skip + continue). Mirrors the existing `scanActiveConsumers` shape in `destroy-runner.ts` (used for the destroy-time strong-reference refusal).
- `src/cli/commands/recreate-confirm-prompt.ts` — accepts new optional `downstreamConsumers` field and renders the enumeration above the generic caveat when supplied.
- `src/cli/commands/deploy.ts` — calls `findDownstreamConsumers` before `promptRecreateConfirm` and threads the result.

Cost: O(M) S3 reads where M = total stacks in the bucket. Acceptable — recreate is per-resource explicit so the enumeration fires at most once per stack in a deploy run.

## Test plan

- [x] Unit tests at `tests/unit/cli/commands/recreate-downstream-consumers.test.ts`: 8 cases (no-imports / multi-consumer / self-skip / cross-region mismatch / soft-fail on unreadable / multi-import-per-consumer / legacy-region fallback / render shape).
- [x] Unit tests at `tests/unit/cli/commands/recreate-confirm-prompt.test.ts`: 2 new cases (renders consumer enumeration when supplied / skips section when empty).
- [x] `/run-integ recreate-via-cc-api` — feature integ. 3 deleted, 0 errors, 0 orphans.
- [x] `/run-integ lambda` — broad-integ-set member for the cross-cutting `deploy.ts` touch. 8 deleted, 0 errors, 0 orphans.
- [x] `vp check --fix && vp run build && vp run test` — 5840 / 5840 tests pass.

## Out of scope

- `Fn::GetStackOutput` enumeration — requires a `state.outputReads[]` schema bump. Will be filed as a separate follow-up if user demand surfaces.
