### PR TITLE
fix(local): forward --profile-resolved credentials to local-invoke Lambda container (#657)

### DIFF
--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -1285,7 +1285,7 @@ function forwardAwsEnv(env: Record<string, string>): void {
  * `process.env.AWS_*`. The overlay covers SSO / IAM Identity Center /
  * fromIni / role-assumption profiles uniformly (resolved via the SDK's
  * default credential chain in `resolveProfileCredentials`). Without
- * this overlay, a dev who runs `cdkd local invoke --profile mates_dev`
+ * this overlay, a dev who runs `cdkd local invoke --profile dev`
  * AND has no `AWS_ACCESS_KEY_ID` env var (the common SSO / Identity
  * Center case) sees the Lambda boot with no creds → handler's AWS SDK
  * call fails with `Could not load credentials from any providers`.

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -55,7 +55,7 @@ import {
 } from '../../assets/asset-manifest-loader.js';
 import { singleFlight } from '../../utils/single-flight.js';
 import type { StackState } from '../../types/state.js';
-import { createLocalStartApiCommand } from './local-start-api.js';
+import { createLocalStartApiCommand, resolveProfileCredentials } from './local-start-api.js';
 import { createLocalRunTaskCommand } from './local-run-task.js';
 import { createLocalStartServiceCommand } from './local-start-service.js';
 
@@ -280,6 +280,18 @@ async function localInvokeCommand(target: string, options: LocalInvokeOptions): 
     await applyRoleArnIfSet({ roleArn: options.roleArn, region: options.region });
 
     await ensureDockerAvailable();
+
+    // Issue #657: when `--profile <p>` is set, resolve the profile to a
+    // concrete credential set ONCE up-front so it can be overlaid onto
+    // the Lambda container's env after `forwardAwsEnv` (which only reads
+    // `process.env.AWS_*` — empty for SSO / IAM Identity Center / fromIni
+    // profiles). Same fix shape as PR #655 (issue #654) for the
+    // `cdkd local start-api` family; the helper itself is exported from
+    // `local-start-api.ts` and shared. Resolved once per invoke
+    // (per the issue spec: "ONCE per invoke (NOT per-container)").
+    const profileCredentials = options.profile
+      ? await resolveProfileCredentials(options.profile)
+      : undefined;
 
     // Synthesize. Default is "synth every time" (Q2 recommendation C):
     // safe-by-default, with `-a/--app cdk.out` as the explicit opt-out
@@ -511,6 +523,13 @@ async function localInvokeCommand(target: string, options: LocalInvokeOptions): 
     }
     if (!assumeSucceeded) {
       forwardAwsEnv(dockerEnv);
+      // Issue #657: when `--profile <p>` was supplied AND assume-role
+      // did not produce creds for this Lambda (either not asked for or
+      // STS failed), overlay the profile-resolved {AKID, SAK,
+      // sessionToken?} on top of whatever `forwardAwsEnv` copied from
+      // `process.env`. See `applyProfileCredentialsOverlay`'s doc for
+      // the full precedence table + session-token-strip rationale.
+      applyProfileCredentialsOverlay(dockerEnv, profileCredentials, false);
     }
 
     // Optional inspector: --debug-port enables `node --inspect-brk` inside
@@ -1257,6 +1276,55 @@ function forwardAwsEnv(env: Record<string, string>): void {
   for (const key of passThrough) {
     const value = process.env[key];
     if (value !== undefined) env[key] = value;
+  }
+}
+
+/**
+ * Issue #657: overlay `--profile <p>`-resolved credentials onto the
+ * Lambda container's env block AFTER `forwardAwsEnv` has copied
+ * `process.env.AWS_*`. The overlay covers SSO / IAM Identity Center /
+ * fromIni / role-assumption profiles uniformly (resolved via the SDK's
+ * default credential chain in `resolveProfileCredentials`). Without
+ * this overlay, a dev who runs `cdkd local invoke --profile mates_dev`
+ * AND has no `AWS_ACCESS_KEY_ID` env var (the common SSO / Identity
+ * Center case) sees the Lambda boot with no creds → handler's AWS SDK
+ * call fails with `Could not load credentials from any providers`.
+ *
+ * Precedence (codifies existing semantics + this new layer):
+ *   1. `--assume-role <arn>` (per-Lambda STS creds) — unchanged
+ *   2. NEW: `--profile <p>` resolved + cached (this helper)
+ *   3. `process.env.AWS_*` forwarded — when `--profile` not set
+ *
+ * Region from `forwardAwsEnv` is preserved — only the credential
+ * triple is overlaid.
+ *
+ * When the resolved profile is long-lived (no `sessionToken`), any
+ * inherited `AWS_SESSION_TOKEN` is stripped — a mismatched (long-
+ * lived AKID + foreign session) would otherwise cause an SDK error
+ * inside the container.
+ *
+ * No-op when `profileCreds` is `undefined` (profile not set) or when
+ * `assumeRoleActive` is true (assume-role already won; its STS-issued
+ * creds must not be clobbered by the profile overlay).
+ *
+ * Exported for unit-test isolation (see `local-invoke-profile-creds.test.ts`).
+ */
+export function applyProfileCredentialsOverlay(
+  env: Record<string, string>,
+  profileCreds: { accessKeyId: string; secretAccessKey: string; sessionToken?: string } | undefined,
+  assumeRoleActive: boolean
+): void {
+  if (!profileCreds) return;
+  if (assumeRoleActive) return;
+  env['AWS_ACCESS_KEY_ID'] = profileCreds.accessKeyId;
+  env['AWS_SECRET_ACCESS_KEY'] = profileCreds.secretAccessKey;
+  if (profileCreds.sessionToken) {
+    env['AWS_SESSION_TOKEN'] = profileCreds.sessionToken;
+  } else {
+    // The profile resolved to long-lived creds (no session token).
+    // Strip any inherited session token to avoid the SDK trying to
+    // use a mismatched (long-lived AKID + foreign session).
+    delete env['AWS_SESSION_TOKEN'];
   }
 }
 

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -1503,7 +1503,7 @@ async function buildContainerSpec(args: {
     // overlay covers SSO / IAM Identity Center / regular access key /
     // role-assumption profiles uniformly (resolved via the SDK's
     // default credential chain). Without this overlay, a dev who runs
-    // `cdkd local start-api --profile mates_dev` AND has no
+    // `cdkd local start-api --profile dev` AND has no
     // `AWS_ACCESS_KEY_ID` env var (the common SSO / Identity Center
     // case) sees the Lambda boot with no creds → handler's AWS SDK
     // call fails with `Could not load credentials from any providers`.

--- a/tests/unit/cli/local-invoke-profile-creds.test.ts
+++ b/tests/unit/cli/local-invoke-profile-creds.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vite-plus/test';
+import { applyProfileCredentialsOverlay } from '../../../src/cli/commands/local-invoke.js';
+
+// Issue #657: `cdkd local invoke --profile <p>` should forward the
+// profile-resolved credentials to the Lambda container's env block.
+// Same gap, same fix shape as PR #655 (issue #654) for `cdkd local
+// start-api`. `resolveProfileCredentials` itself is already tested in
+// `local-start-api-profile-creds.test.ts`; this file covers the
+// OVERLAY logic that wires the resolved creds into the container env
+// after `forwardAwsEnv` has copied `process.env.AWS_*`.
+
+describe('applyProfileCredentialsOverlay (issue #657)', () => {
+  let originalSessionToken: string | undefined;
+
+  beforeEach(() => {
+    // Snapshot any caller-side AWS_SESSION_TOKEN so the strip test
+    // below can simulate the "inherited env" state without leaking.
+    originalSessionToken = process.env['AWS_SESSION_TOKEN'];
+  });
+
+  afterEach(() => {
+    if (originalSessionToken === undefined) {
+      delete process.env['AWS_SESSION_TOKEN'];
+    } else {
+      process.env['AWS_SESSION_TOKEN'] = originalSessionToken;
+    }
+  });
+
+  it('overlays profile creds (incl. sessionToken) onto dockerEnv when --profile set and no --assume-role', () => {
+    // Caller flow: forwardAwsEnv first (leaves some pre-existing
+    // process.env values), THEN this overlay. We pre-populate dockerEnv
+    // with a stale AWS_SESSION_TOKEN to prove the SSO sessionToken from
+    // the profile wins over what process.env carried.
+    const dockerEnv: Record<string, string> = {
+      AWS_REGION: 'us-east-1',
+      AWS_SESSION_TOKEN: 'stale-from-process-env',
+    };
+    const profileCreds = {
+      accessKeyId: 'AKIA-SSO',
+      secretAccessKey: 'SECRET-SSO',
+      sessionToken: 'SESSION-FROM-PROFILE',
+    };
+
+    applyProfileCredentialsOverlay(dockerEnv, profileCreds, /* assumeRoleActive */ false);
+
+    expect(dockerEnv['AWS_ACCESS_KEY_ID']).toBe('AKIA-SSO');
+    expect(dockerEnv['AWS_SECRET_ACCESS_KEY']).toBe('SECRET-SSO');
+    expect(dockerEnv['AWS_SESSION_TOKEN']).toBe('SESSION-FROM-PROFILE');
+    // Region from forwardAwsEnv is preserved — overlay touches creds only.
+    expect(dockerEnv['AWS_REGION']).toBe('us-east-1');
+  });
+
+  it('strips inherited AWS_SESSION_TOKEN when profile resolves to long-lived creds (no sessionToken)', () => {
+    // Pre-populate the env with a stray inherited session token (as
+    // forwardAwsEnv would have done if process.env.AWS_SESSION_TOKEN
+    // was set in the dev's shell). When the profile resolves to a
+    // long-lived AKID + SAK, that stray session token MUST be stripped
+    // — mixing a long-lived AKID with a foreign session token causes
+    // the SDK inside the container to error.
+    const dockerEnv: Record<string, string> = {
+      AWS_REGION: 'us-east-1',
+      AWS_ACCESS_KEY_ID: 'AKIA-FORWARDED',
+      AWS_SECRET_ACCESS_KEY: 'SECRET-FORWARDED',
+      AWS_SESSION_TOKEN: 'INHERITED-FOREIGN-SESSION',
+    };
+    const profileCreds = {
+      accessKeyId: 'AKIA-LONG',
+      secretAccessKey: 'SECRET-LONG',
+      // sessionToken intentionally absent — long-lived creds
+    };
+
+    applyProfileCredentialsOverlay(dockerEnv, profileCreds, /* assumeRoleActive */ false);
+
+    expect(dockerEnv['AWS_ACCESS_KEY_ID']).toBe('AKIA-LONG');
+    expect(dockerEnv['AWS_SECRET_ACCESS_KEY']).toBe('SECRET-LONG');
+    expect(dockerEnv).not.toHaveProperty('AWS_SESSION_TOKEN');
+    expect(dockerEnv['AWS_REGION']).toBe('us-east-1');
+  });
+
+  it('preserves assume-role STS creds when --assume-role is active (overlay no-ops)', () => {
+    // Caller flow when assume-role succeeded: dockerEnv already holds
+    // STS-issued temp creds. The overlay must NOT clobber them even
+    // if --profile was also passed — assume-role takes precedence per
+    // the documented precedence table.
+    const dockerEnv: Record<string, string> = {
+      AWS_REGION: 'us-east-1',
+      AWS_ACCESS_KEY_ID: 'AKIA-ASSUMED',
+      AWS_SECRET_ACCESS_KEY: 'SECRET-ASSUMED',
+      AWS_SESSION_TOKEN: 'SESSION-ASSUMED',
+    };
+    const profileCreds = {
+      accessKeyId: 'AKIA-PROFILE-SHOULD-BE-IGNORED',
+      secretAccessKey: 'SECRET-PROFILE-SHOULD-BE-IGNORED',
+      sessionToken: 'SESSION-PROFILE-SHOULD-BE-IGNORED',
+    };
+
+    applyProfileCredentialsOverlay(dockerEnv, profileCreds, /* assumeRoleActive */ true);
+
+    expect(dockerEnv['AWS_ACCESS_KEY_ID']).toBe('AKIA-ASSUMED');
+    expect(dockerEnv['AWS_SECRET_ACCESS_KEY']).toBe('SECRET-ASSUMED');
+    expect(dockerEnv['AWS_SESSION_TOKEN']).toBe('SESSION-ASSUMED');
+  });
+
+  it('no-ops when --profile is not set (regression guard: forwarded process.env wins)', () => {
+    // Caller flow when --profile is absent: profileCredentials is
+    // undefined. The overlay must leave the env untouched so the
+    // pre-#657 forwardAwsEnv-only behavior is preserved exactly.
+    const dockerEnv: Record<string, string> = {
+      AWS_REGION: 'us-east-1',
+      AWS_ACCESS_KEY_ID: 'AKIA-FROM-PROCESS-ENV',
+      AWS_SECRET_ACCESS_KEY: 'SECRET-FROM-PROCESS-ENV',
+      AWS_SESSION_TOKEN: 'SESSION-FROM-PROCESS-ENV',
+    };
+    const before = { ...dockerEnv };
+
+    applyProfileCredentialsOverlay(dockerEnv, undefined, /* assumeRoleActive */ false);
+
+    expect(dockerEnv).toEqual(before);
+  });
+});

--- a/tests/unit/cli/local-start-api-profile-creds.test.ts
+++ b/tests/unit/cli/local-start-api-profile-creds.test.ts
@@ -35,14 +35,14 @@ describe('resolveProfileCredentials (issue #654)', () => {
       secretAccessKey: 'SECRET-TEMP',
       sessionToken: 'SESSION-TEMP',
     });
-    const creds = await resolveProfileCredentials('mates_dev');
+    const creds = await resolveProfileCredentials('dev-sso');
     expect(creds).toEqual({
       accessKeyId: 'AKIA-TEMP',
       secretAccessKey: 'SECRET-TEMP',
       sessionToken: 'SESSION-TEMP',
     });
     // STSClient constructed with the profile threaded through.
-    expect(stsCtorMock).toHaveBeenCalledWith({ profile: 'mates_dev' });
+    expect(stsCtorMock).toHaveBeenCalledWith({ profile: 'dev-sso' });
     // Destroy called for cleanup.
     expect(stsDestroyMock).toHaveBeenCalledOnce();
   });


### PR DESCRIPTION
## Summary

`cdkd local invoke --profile <p>` resolved the profile for cdkd's OWN AWS calls (CFn lookup, STS, etc.) but the Lambda container's runtime got only what was in `process.env.AWS_*` — empty for SSO / IAM Identity Center / regular `fromIni` profiles. The handler's AWS SDK calls therefore failed with `Could not load credentials from any providers`, even when the dev was correctly logged in with `aws sso login --profile <p>`.

Same gap, same fix shape as #654/#655 (which shipped for `cdkd local start-api` in v0.162.3).

## Changes

### Reuse the exported helper from #655

[src/cli/commands/local-invoke.ts:284](src/cli/commands/local-invoke.ts#L284) — imports `resolveProfileCredentials` from `./local-start-api.js` (already exported by #655). Resolved ONCE per invoke after `ensureDockerAvailable()` and before the per-Lambda container env is materialized.

### New exported helper `applyProfileCredentialsOverlay`

[src/cli/commands/local-invoke.ts:1318](src/cli/commands/local-invoke.ts#L1318). Pure overlay function that mutates a docker `env` record AFTER `forwardAwsEnv` has copied `process.env.AWS_*`. Sets `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from the resolved profile; sets `AWS_SESSION_TOKEN` if the profile has one, otherwise STRIPS any inherited `AWS_SESSION_TOKEN` (long-lived AKID + foreign session would otherwise cause an SDK error inside the container).

Called at [src/cli/commands/local-invoke.ts:529](src/cli/commands/local-invoke.ts#L529) inside the existing `if (!assumeSucceeded)` branch — so the overlay fires both when (a) `--assume-role` wasn't set AND (b) `--assume-role` was set but STS failed. The `assumeRoleActive` parameter is defensive — always `false` at the call site since the call is already gated on `!assumeSucceeded`, but keeping it explicit documents the precedence intent in the helper signature and lets the unit test exercise the safety-net branch.

### Credential precedence (codifies existing semantics + new layer)

For the Lambda container's `AWS_*` env, highest priority wins:

1. `--assume-role <Lambda>=<arn>` / `--assume-role <arn>` (STS-issued creds) — pre-existing, unchanged
2. **NEW**: `--profile <p>` resolved + cached (this PR) — when no `--assume-role` succeeds; preserves region from `forwardAwsEnv` and only overlays the credential triple
3. `process.env.AWS_*` forwarded (pre-existing) — when `--profile` not set

### Bundled chore: sanitize real-PJ identifier from #655's docstring + test

PR #655 (v0.162.3) shipped `mates_dev` as the example profile name in `src/cli/commands/local-start-api.ts`'s docstring and in `tests/unit/cli/local-start-api-profile-creds.test.ts`'s `expect(stsCtorMock).toHaveBeenCalledWith({ profile: 'mates_dev' })`. The string originated as the user's real AWS SSO profile name during the live-debug session and slipped through. Replaced with neutral `dev` (docstring) / `dev-sso` (test). Bundled into this PR because the sanitized files are exactly the local-* profile-creds family this PR builds on — a separate chore PR for 3 string literals would not earn its own review cycle.

## Out of scope (separate issue)

- ECS sidecar fix for `local-run-task` / `local-start-service` — filed as #658, opened in parallel.
- Auto-refresh of expiring SSO creds in long-running sessions — deferred (re-run cdkd when SSO creds expire).
- Profile-aware SDK config file inside the container for handlers using `fromIni({ profile })` explicitly — niche pattern.

## Test plan

- [x] `vp check --fix` passes (typecheck + lint + format)
- [x] `vp run build` passes
- [x] `vp test` passes — 380 test files, 5833 tests (4 net new + 1 sanitize-touched in this PR)
- [x] New tests cover: profile-with-sessionToken overlay, long-lived-strips-inherited-SESSION_TOKEN, assume-role-wins-over-profile, no-profile-regression-guard
- [x] `/run-integ local-invoke` — 4/4 passed (asset-backed echo, --event payload, --env-vars override, inline Code.ZipFile); 0 Docker orphans post-run

Closes #657
