### PR TITLE
fix(local): forward --profile-resolved credentials to ECS metadata sidecar (#658)

### DIFF
--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -15,6 +15,7 @@ import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
+import { resolveProfileCredentials } from './local-start-api.js';
 import {
   applyCrossStackResolverToTask,
   derivePartitionAndUrlSuffix,
@@ -263,6 +264,18 @@ async function localRunTaskCommand(target: string, options: LocalRunTaskOptions)
       assumedCredentials = await assumeTaskRole(resolvedRoleArn, options.region);
     }
 
+    // Issue #658: when `--assume-task-role` is NOT effective but
+    // `--profile <p>` IS set, resolve the profile via the SDK's default
+    // credential provider chain (SSO / IAM Identity Center / fromIni /
+    // role-assumption) and forward the resulting `{AKID, SAK,
+    // sessionToken?}` to the metadata-endpoints sidecar. Without this,
+    // the sidecar starts inside a fresh container with no SSO config and
+    // no `~/.aws/credentials`, so every user container that hits
+    // `169.254.170.2/role/<role>` gets a credential-provider failure.
+    // Same gap class as #654/#655, which shipped the equivalent forward
+    // for `cdkd local start-api`'s Lambda container path.
+    const sidecarCredentials = await resolveSidecarCredentials(options, assumedCredentials);
+
     const envOverrides = readEnvOverridesFile(options.envVars);
 
     const runOpts: RunEcsTaskOptions = {
@@ -273,7 +286,7 @@ async function localRunTaskCommand(target: string, options: LocalRunTaskOptions)
       detach: options.detach,
     };
     if (envOverrides) runOpts.envOverrides = envOverrides;
-    if (assumedCredentials) runOpts.taskCredentials = assumedCredentials;
+    if (sidecarCredentials) runOpts.taskCredentials = sidecarCredentials;
     if (resolvedRoleArn) runOpts.taskRoleArn = resolvedRoleArn;
     if (options.platform) runOpts.platformOverride = options.platform;
     if (options.region) runOpts.region = options.region;
@@ -508,6 +521,36 @@ function readEnvOverridesFile(
     throw new Error(`--env-vars file '${filePath}' must contain a JSON object at the top level.`);
   }
   return parsed as Record<string, Record<string, string | null> | undefined>;
+}
+
+/**
+ * Issue #658: pick the credentials forwarded to the AWS-published
+ * `amazon-ecs-local-container-endpoints` sidecar. Precedence:
+ *   1. `--assume-task-role <arn>` (or bare `--assume-task-role` against
+ *      a resolvable `TaskRoleArn`) → STS-assumed temp creds. Highest
+ *      priority — when the user opted in to IAM emulation, those creds
+ *      drive the sidecar regardless of `--profile`.
+ *   2. `--profile <p>` → resolved via {@link resolveProfileCredentials}
+ *      (the SDK's default credential provider chain — SSO / IAM
+ *      Identity Center / fromIni / role-assumption). NEW in this PR.
+ *   3. Neither set → `undefined`; the sidecar runs with its own
+ *      default credential chain (typically empty inside a fresh
+ *      container — user containers will get 4xx from the credentials
+ *      endpoint, mimicking IAM-misconfigured prod).
+ *
+ * Extracted as an exported helper so a unit test can exercise every
+ * branch without having to mock the full Synth + Docker + AWS pipeline
+ * (the strategy PR #655 used for the Lambda container path).
+ */
+export async function resolveSidecarCredentials(
+  options: { profile?: string },
+  assumedCredentials:
+    | { accessKeyId: string; secretAccessKey: string; sessionToken?: string }
+    | undefined
+): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string } | undefined> {
+  if (assumedCredentials) return assumedCredentials;
+  if (options.profile) return resolveProfileCredentials(options.profile);
+  return undefined;
 }
 
 export function createLocalRunTaskCommand(): Command {

--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -16,6 +16,7 @@ import { singleFlight } from '../../utils/single-flight.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
+import { resolveProfileCredentials } from './local-start-api.js';
 import {
   applyCrossStackResolverToTask,
   derivePartitionAndUrlSuffix,
@@ -275,15 +276,29 @@ async function localStartServiceCommand(
     // metadata endpoint to every container. Per-service IAM role
     // emulation in multi-service runs is NOT supported in v1 — each
     // service's `TaskRoleArn` flows into its container env via
-    // `buildMetadataEnv`, but the sidecar itself uses the user's
-    // default AWS credential chain. Users who need per-service IAM
+    // `buildMetadataEnv`, but the sidecar itself runs without per-
+    // service credentials.
+    //
+    // Issue #658: when `--profile <p>` is set, the resolved credentials
+    // are forwarded to the sidecar so its `/role/<role-arn>` endpoint
+    // serves them to user containers. Without this, the sidecar starts
+    // inside a fresh container with no SSO config / no
+    // `~/.aws/credentials` and falls back to its own (empty) default
+    // chain, breaking every container that hits 169.254.171.2. Without
+    // `--profile`, the sidecar continues to use its own default chain
+    // (pre-existing behavior). Per-service `--assume-task-role
+    // <Service>=<arn>` overrides are independent — they flow into
+    // `buildMetadataEnv` per container and are unrelated to the
+    // SIDECAR's own startup credentials. Users who need per-service IAM
     // role emulation should split their run into multiple
     // `cdkd local start-service` invocations.
+    const sidecarCredentials = await resolveSharedSidecarCredentials(options);
     try {
       sharedNetwork = await createSharedSvcNetwork({
         prefix: options.cluster,
         skipPull,
         cluster: options.cluster,
+        ...(sidecarCredentials !== undefined && { credentials: sidecarCredentials }),
       });
     } catch (err) {
       throw new LocalStartServiceError(
@@ -723,6 +738,38 @@ function parseRestartPolicy(raw: string): 'on-failure' | 'always' | 'none' {
   throw new LocalStartServiceError(
     `--restart-policy must be one of 'on-failure', 'always', or 'none' (got '${raw}').`
   );
+}
+
+/**
+ * Issue #658: pick the credentials forwarded to the AWS-published
+ * `amazon-ecs-local-container-endpoints` sidecar. `cdkd local
+ * start-service`'s sidecar is SHARED across every replica boot in one
+ * CLI invocation (design § 5 Option A), so this resolves ONCE at
+ * startup. Precedence:
+ *   1. `--profile <p>` → resolved via {@link resolveProfileCredentials}
+ *      (the SDK's default credential provider chain — SSO / IAM
+ *      Identity Center / fromIni / role-assumption). NEW in this PR.
+ *   2. Not set → `undefined`; the sidecar runs with its own default
+ *      credential chain (typically empty inside a fresh container —
+ *      user containers will get 4xx from the credentials endpoint).
+ *
+ * Note: per-service `--assume-task-role <Service>=<arn>` overrides are
+ * INTENTIONALLY NOT consulted here. The shared sidecar has no concept
+ * of per-service IAM — per-service `TaskRoleArn` flows into each
+ * container's env via `buildMetadataEnv` at boot time, where the
+ * sidecar's `/role/<role-arn>` path resolves per-request. The shared
+ * sidecar's OWN startup credentials govern only the fallback path
+ * (containers that did not bind a `TaskRoleArn`).
+ *
+ * Extracted as an exported helper so a unit test can exercise both
+ * branches without having to mock the full Synth + Docker + AWS
+ * pipeline (the strategy PR #655 used for the Lambda container path).
+ */
+export async function resolveSharedSidecarCredentials(options: {
+  profile?: string;
+}): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string } | undefined> {
+  if (options.profile) return resolveProfileCredentials(options.profile);
+  return undefined;
 }
 
 export function createLocalStartServiceCommand(): Command {

--- a/tests/unit/cli/local-run-task-profile-creds.test.ts
+++ b/tests/unit/cli/local-run-task-profile-creds.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+import { resolveSidecarCredentials } from '../../../src/cli/commands/local-run-task.js';
+
+// Issue #658: `cdkd local run-task --profile <p>` (without
+// `--assume-task-role`) used to resolve the profile for cdkd's OWN AWS
+// calls but the AWS-published `amazon-ecs-local-container-endpoints`
+// sidecar started with empty `AWS_*` env, so every user container that
+// hit `169.254.170.2/role/<role>` got a credential-provider failure.
+// This test exercises the small `resolveSidecarCredentials` helper that
+// drives the new precedence: assumed-creds win when set; otherwise the
+// profile chain is resolved; otherwise undefined (the pre-existing
+// "sidecar uses its own default chain" path).
+//
+// Same gap class as #654/#655 (which shipped for `cdkd local start-api`'s
+// Lambda container env overlay); the helper-extraction pattern mirrors
+// PR #655's `resolveProfileCredentials` test surface.
+
+const credsProviderMock = vi.fn();
+const stsDestroyMock = vi.fn();
+const stsCtorMock = vi.fn();
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: vi.fn().mockImplementation((config: unknown) => {
+    stsCtorMock(config);
+    return {
+      config: { credentials: credsProviderMock },
+      destroy: stsDestroyMock,
+    };
+  }),
+}));
+
+describe('resolveSidecarCredentials (issue #658)', () => {
+  beforeEach(() => {
+    credsProviderMock.mockReset();
+    stsDestroyMock.mockReset();
+    stsCtorMock.mockReset();
+  });
+
+  it('returns the assumed credentials verbatim when --assume-task-role is effective (assume wins over --profile)', async () => {
+    const assumed = {
+      accessKeyId: 'AKIA-ASSUMED',
+      secretAccessKey: 'SECRET-ASSUMED',
+      sessionToken: 'SESSION-ASSUMED',
+    };
+    // Both `--profile` AND `--assume-task-role` set; assume must win.
+    const result = await resolveSidecarCredentials({ profile: 'my-sso' }, assumed);
+    expect(result).toBe(assumed);
+    // The SDK STS client must NOT be touched on this path — the assumed
+    // creds came from an earlier STS hop, the sidecar resolver is a no-op.
+    expect(stsCtorMock).not.toHaveBeenCalled();
+    expect(credsProviderMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves --profile via the SDK default chain when --assume-task-role is NOT effective', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+      sessionToken: 'SESSION-PROFILE',
+    });
+    const result = await resolveSidecarCredentials({ profile: 'my-sso' }, undefined);
+    expect(result).toEqual({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+      sessionToken: 'SESSION-PROFILE',
+    });
+    // STSClient instantiated with the profile so SSO / fromIni resolve.
+    expect(stsCtorMock).toHaveBeenCalledWith({ profile: 'my-sso' });
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+
+  it('returns undefined when neither --profile nor --assume-task-role is set (sidecar falls back to its own default chain)', async () => {
+    const result = await resolveSidecarCredentials({}, undefined);
+    expect(result).toBeUndefined();
+    // No AWS calls at all — pre-existing "lowest precedence" path.
+    expect(stsCtorMock).not.toHaveBeenCalled();
+    expect(credsProviderMock).not.toHaveBeenCalled();
+  });
+
+  it('propagates resolveProfileCredentials errors (expired SSO etc.) — no silent fallback', async () => {
+    credsProviderMock.mockRejectedValue(
+      new Error('The SSO session associated with this profile has expired')
+    );
+    await expect(
+      resolveSidecarCredentials({ profile: 'expired-sso' }, undefined)
+    ).rejects.toThrow(/SSO session.*expired/);
+  });
+});

--- a/tests/unit/cli/local-start-service-profile-creds.test.ts
+++ b/tests/unit/cli/local-start-service-profile-creds.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+import { resolveSharedSidecarCredentials } from '../../../src/cli/commands/local-start-service.js';
+
+// Issue #658: `cdkd local start-service --profile <p>` used to resolve
+// the profile for cdkd's OWN AWS calls but the AWS-published shared
+// `amazon-ecs-local-container-endpoints` sidecar (one per CLI
+// invocation, design § 5 Option A) started with empty `AWS_*` env, so
+// every replica's containers hit `169.254.171.2/role/<role>` and got
+// credential-provider failures. This test exercises the small
+// `resolveSharedSidecarCredentials` helper that drives the new
+// precedence: the per-CLI sidecar has no concept of `--assume-task-role`
+// (that flag is per-container via `buildMetadataEnv`), so this is the
+// simpler of the two siblings — `--profile` set → resolve, else
+// undefined.
+
+const credsProviderMock = vi.fn();
+const stsDestroyMock = vi.fn();
+const stsCtorMock = vi.fn();
+
+vi.mock('@aws-sdk/client-sts', () => ({
+  STSClient: vi.fn().mockImplementation((config: unknown) => {
+    stsCtorMock(config);
+    return {
+      config: { credentials: credsProviderMock },
+      destroy: stsDestroyMock,
+    };
+  }),
+}));
+
+describe('resolveSharedSidecarCredentials (issue #658)', () => {
+  beforeEach(() => {
+    credsProviderMock.mockReset();
+    stsDestroyMock.mockReset();
+    stsCtorMock.mockReset();
+  });
+
+  it('resolves --profile via the SDK default chain when set', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+      sessionToken: 'SESSION-PROFILE',
+    });
+    const result = await resolveSharedSidecarCredentials({ profile: 'my-sso' });
+    expect(result).toEqual({
+      accessKeyId: 'AKIA-PROFILE',
+      secretAccessKey: 'SECRET-PROFILE',
+      sessionToken: 'SESSION-PROFILE',
+    });
+    // STSClient instantiated with the profile so SSO / fromIni resolve.
+    expect(stsCtorMock).toHaveBeenCalledWith({ profile: 'my-sso' });
+    expect(stsDestroyMock).toHaveBeenCalledOnce();
+  });
+
+  it('omits sessionToken when the profile resolved to long-lived creds', async () => {
+    credsProviderMock.mockResolvedValue({
+      accessKeyId: 'AKIA-LONG',
+      secretAccessKey: 'SECRET-LONG',
+    });
+    const result = await resolveSharedSidecarCredentials({ profile: 'long-lived' });
+    expect(result).toEqual({
+      accessKeyId: 'AKIA-LONG',
+      secretAccessKey: 'SECRET-LONG',
+    });
+    expect(result).not.toHaveProperty('sessionToken');
+  });
+
+  it('returns undefined when --profile is NOT set (sidecar falls back to its own default chain)', async () => {
+    const result = await resolveSharedSidecarCredentials({});
+    expect(result).toBeUndefined();
+    // No AWS calls at all — pre-existing behavior preserved.
+    expect(stsCtorMock).not.toHaveBeenCalled();
+    expect(credsProviderMock).not.toHaveBeenCalled();
+  });
+
+  it('propagates resolveProfileCredentials errors (expired SSO etc.) — no silent fallback', async () => {
+    credsProviderMock.mockRejectedValue(
+      new Error('The SSO session associated with this profile has expired')
+    );
+    await expect(
+      resolveSharedSidecarCredentials({ profile: 'expired-sso' })
+    ).rejects.toThrow(/SSO session.*expired/);
+  });
+});


### PR DESCRIPTION
## Summary

`cdkd local run-task --profile <p>` (and `cdkd local start-service`) resolved the profile for cdkd's OWN AWS calls but the AWS-published `amazon-ecs-local-container-endpoints` sidecar started with empty `AWS_*` env — empty for SSO / IAM Identity Center / `fromIni` profiles. The sidecar's default credential chain inside a fresh container has no SSO config / no `~/.aws/credentials`, so every container hitting `169.254.170.2/role/<role>` got a credential-provider failure. Handler SDK calls then failed with `Could not load credentials from any providers`.

Same gap class as #654/#655 (which shipped for `cdkd local start-api`'s Lambda container path in v0.162.3); this PR fixes the equivalent gap at the ECS sidecar boundary.

## Changes

### `local-run-task`: new helper `resolveSidecarCredentials`

[src/cli/commands/local-run-task.ts:544](src/cli/commands/local-run-task.ts#L544). Picks the credentials forwarded to the sidecar with precedence:

1. `--assume-task-role` STS-assumed creds (pre-existing, unchanged, highest)
2. **NEW**: `--profile <p>` → resolved via `resolveProfileCredentials` (the SDK's default chain — SSO / IAM Identity Center / `fromIni` / role-assumption)
3. Neither set → `undefined` (sidecar uses its own default chain — pre-existing behavior)

Wired into the existing `RunEcsTaskOptions.taskCredentials` slot at [src/cli/commands/local-run-task.ts:289](src/cli/commands/local-run-task.ts#L289), which `ecs-task-runner.ts` already threads into `createTaskNetwork({ credentials })`. No plumbing adjustment in `ecs-network.ts` / `ecs-task-runner.ts` / `ecs-service-runner.ts` — they already accept the optional `credentials` field shipped for `--assume-task-role`.

### `local-start-service`: new helper `resolveSharedSidecarCredentials`

[src/cli/commands/local-start-service.ts:760](src/cli/commands/local-start-service.ts#L760). The shared sidecar (one per CLI invocation, design § 5 Option A) has no concept of per-service IAM at startup, so precedence is simpler:

1. **NEW**: `--profile <p>` → resolved (this PR)
2. Not set → `undefined` (pre-existing)

Per-service `--assume-task-role <Service>=<arn>` overrides are INTENTIONALLY NOT consulted here — they flow into per-container `taskCredentials` and through `buildMetadataEnv` to the sidecar's `/role/<role-arn>` path, unrelated to the SIDECAR's own startup credentials. The pre-existing comment at lines 277-294 is updated to reflect the new behavior.

### Why a separate helper per command (no shared `local-profile-credentials.ts`)

`local-run-task` has the assume-role-wins-over-profile rule; `local-start-service` does not (no `--assume-task-role` at CLI level; per-service overrides are routed differently). Pushing both into a single helper would require an `assumeOverride?: Credentials` arg with different semantics per caller — the per-command helpers state the precedence more clearly. Hoisting `resolveProfileCredentials` itself out of `local-start-api.ts` is also deferred — it's already shared via direct import.

## Out of scope (separate enhancements)

- Auto-refresh of expiring SSO creds during a long-running `cdkd local start-service` session.
- Profile-aware SDK config file inside the container for handlers using `fromIni({ profile })` explicitly inside their code.
- Per-service `--profile <Service>=<p>` mapping (today: per-service `--assume-task-role <Service>=<arn>` covers per-service IAM; per-service `--profile` is a niche extension).

## Test plan

- [x] `vp check --fix` passes (typecheck + lint + format)
- [x] `vp run build` passes
- [x] `vp test` passes — 381 test files, 5837 tests (8 net new in this PR)
- [x] New tests cover both helpers: assume-task-role-wins / profile-only / no-flag-undefined / underlying-error-propagation
- [x] `/run-integ local-run-task` — passed (Docker sidecar + nginx fixture, HTTP 200 from 127.0.0.1:18080); 0 Docker orphans post-run

Closes #658
