### PR TITLE
feat(deploy): symmetric blockedAlreadyCcApi refusal for --recreate-via-cc-api

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -597,8 +597,12 @@ When to use it:
 When NOT to use it:
 
 - The resource is already `provisionedBy: 'cc-api'` (sticky). The
-  update path already routes via CC; the recreate is a no-op (cdkd
-  detects this case and skips with an info log).
+  update path already routes via CC; the recreate is a no-op. As of
+  #665 cdkd refuses pre-flight with `blockedAlreadyCcApi` — the
+  destroy + recreate cycle would produce identical end state at the
+  cost of unnecessary downtime. Mirror of the `blockedAlreadySdk`
+  refusal on the reverse direction (#651). Fix: drop the flag for that
+  resource.
 - Fresh deploy (the resource is not yet in cdkd state). #614's
   auto-route handles fresh silent-drop deploys automatically — no flag
   needed.

--- a/src/deployment/recreate-targets.ts
+++ b/src/deployment/recreate-targets.ts
@@ -116,6 +116,15 @@ export interface RecreateTargetsValidation {
    */
   blockedAlreadySdk: RecreateTarget[];
   /**
+   * #665: `--recreate-via-cc-api <id>` named on a resource whose
+   * recorded `provisionedBy` is already `'cc-api'`. Forward migration
+   * is a no-op for these; refuse with a clear message rather than
+   * silently destroy + recreate. Mirror of {@link blockedAlreadySdk}
+   * for the forward direction, addressing the pre-existing asymmetry
+   * in #615.
+   */
+  blockedAlreadyCcApi: RecreateTarget[];
+  /**
    * #651: `--recreate-via-sdk-provider <id>` named on a resource type
    * for which cdkd has no SDK provider registered (Tier 2 CC-only).
    * The destroy + recreate would just route via CC again, making the
@@ -175,6 +184,7 @@ export function validateRecreateTargets(input: {
   > = [];
   const blockedMultiRegionTargets: Array<RecreateTarget> = [];
   const blockedAlreadySdk: RecreateTarget[] = [];
+  const blockedAlreadyCcApi: RecreateTarget[] = [];
   const blockedNoSdkProvider: RecreateTarget[] = [];
 
   const conflictSet = new Set(conflictingDirections);
@@ -245,6 +255,14 @@ export function validateRecreateTargets(input: {
           ambiguousIntent.push({ logicalId, resourceType, property });
         }
       }
+
+      // #665 already-CC refusal (mirror of #651's blockedAlreadySdk):
+      // the resource is ALREADY sticky on 'cc-api' so forward migration
+      // is a no-op. Refuse rather than silently destroy + recreate
+      // (wasted downtime + AWS API churn, identical end state).
+      if (recordedResource.provisionedBy === 'cc-api') {
+        blockedAlreadyCcApi.push(target);
+      }
     } else {
       // #651 inverse ambiguous-intent: the template uses a silent-drop
       // property that is NOT in `--allow-unsupported-properties`. The
@@ -290,6 +308,7 @@ export function validateRecreateTargets(input: {
     blockedStatefulTargets,
     blockedMultiRegionTargets,
     blockedAlreadySdk,
+    blockedAlreadyCcApi,
     blockedNoSdkProvider,
     conflictingDirections,
   };
@@ -428,6 +447,24 @@ export function renderRecreateTargetsErrors(validation: RecreateTargetsValidatio
     lines.push(
       `  Fix: remove --recreate-via-sdk-provider <id> for these resources. ` +
         `They are already SDK-managed (or pre-v7 legacy state, treated as SDK).`
+    );
+  }
+
+  // #665 — mirror of blockedAlreadySdk for the forward direction.
+  if (validation.blockedAlreadyCcApi.length > 0) {
+    if (lines.length > 0) lines.push('');
+    lines.push(
+      `--recreate-via-cc-api named ${validation.blockedAlreadyCcApi.length} ` +
+        `resource(s) that are ALREADY sticky on Cloud Control API (the ` +
+        `migration is a no-op):`
+    );
+    for (const blocked of validation.blockedAlreadyCcApi) {
+      lines.push(`  - ${blocked.logicalId} (${blocked.resourceType})`);
+    }
+    lines.push(
+      `  Fix: remove --recreate-via-cc-api <id> for these resources. ` +
+        `They are already CC-managed; a destroy + recreate cycle would ` +
+        `produce the same end state at the cost of unnecessary downtime.`
     );
   }
 

--- a/tests/unit/deployment/recreate-targets.test.ts
+++ b/tests/unit/deployment/recreate-targets.test.ts
@@ -604,6 +604,89 @@ describe('validateRecreateTargets — #651 reverse direction (--recreate-via-sdk
   });
 });
 
+describe('validateRecreateTargets — #665 symmetric forward refusal (--recreate-via-cc-api on already-cc-api)', () => {
+  it('rejects --recreate-via-cc-api on a resource currently provisionedBy: cc-api (no-op)', () => {
+    const template: CloudFormationTemplate = {
+      Resources: { MyLambda: { Type: 'AWS::Lambda::Function', Properties: {} } },
+    };
+    const state = st('S', {
+      MyLambda: res('AWS::Lambda::Function', { provisionedBy: 'cc-api' }),
+    });
+    const v = validateRecreateTargets({
+      template,
+      state,
+      recreateViaCcApi: ['MyLambda'],
+      allowUnsupportedProperties: new Set(),
+      forceStatefulRecreation: false,
+    });
+    expect(v.blockedAlreadyCcApi.map((t) => t.logicalId)).toEqual(['MyLambda']);
+    const error = renderRecreateTargetsErrors(v);
+    expect(error).toContain('ALREADY sticky on Cloud Control API');
+    expect(error).toContain('migration is a no-op');
+    expect(error).toContain('remove --recreate-via-cc-api');
+  });
+
+  it('accepts --recreate-via-cc-api on a resource currently provisionedBy: sdk (legitimate forward migration)', () => {
+    const template: CloudFormationTemplate = {
+      Resources: { MyLambda: { Type: 'AWS::Lambda::Function', Properties: {} } },
+    };
+    const state = st('S', {
+      MyLambda: res('AWS::Lambda::Function', { provisionedBy: 'sdk' }),
+    });
+    const v = validateRecreateTargets({
+      template,
+      state,
+      recreateViaCcApi: ['MyLambda'],
+      allowUnsupportedProperties: new Set(),
+      forceStatefulRecreation: false,
+    });
+    expect(v.blockedAlreadyCcApi).toEqual([]);
+    expect(v.targets.map((t) => t.logicalId)).toEqual(['MyLambda']);
+    expect(v.targets[0]!.direction).toBe('to-cc-api');
+    expect(renderRecreateTargetsErrors(v)).toBeNull();
+  });
+
+  it('accepts --recreate-via-cc-api on a resource with no provisionedBy field (legacy pre-v7 state, treated as SDK)', () => {
+    const template: CloudFormationTemplate = {
+      Resources: { MyLambda: { Type: 'AWS::Lambda::Function', Properties: {} } },
+    };
+    const state = st('S', {
+      MyLambda: res('AWS::Lambda::Function'), // no provisionedBy
+    });
+    const v = validateRecreateTargets({
+      template,
+      state,
+      recreateViaCcApi: ['MyLambda'],
+      allowUnsupportedProperties: new Set(),
+      forceStatefulRecreation: false,
+    });
+    expect(v.blockedAlreadyCcApi).toEqual([]);
+    expect(renderRecreateTargetsErrors(v)).toBeNull();
+  });
+
+  it('blockedAlreadyCcApi does NOT fire for the reverse direction (--recreate-via-sdk-provider on cc-api is the intended path)', () => {
+    const template: CloudFormationTemplate = {
+      Resources: { MyLambda: { Type: 'AWS::Lambda::Function', Properties: {} } },
+    };
+    const state = st('S', {
+      MyLambda: res('AWS::Lambda::Function', { provisionedBy: 'cc-api' }),
+    });
+    const v = validateRecreateTargets({
+      template,
+      state,
+      recreateViaCcApi: [],
+      recreateViaSdkProvider: ['MyLambda'],
+      allowUnsupportedProperties: new Set(),
+      forceStatefulRecreation: false,
+      hasSdkProvider: () => true,
+    });
+    expect(v.blockedAlreadyCcApi).toEqual([]);
+    // The reverse direction PASSES this case — this is exactly the user's goal.
+    expect(v.targets[0]!.direction).toBe('to-sdk');
+    expect(renderRecreateTargetsErrors(v)).toBeNull();
+  });
+});
+
 describe('probeStatefulRecreateTargetsAsync (#648)', () => {
   function s3Target(overrides: Partial<RecreateTarget> = {}): RecreateTarget {
     return {
@@ -740,6 +823,7 @@ describe('probeAndRevalidateStateful (#648)', () => {
       blockedStatefulTargets: [],
       blockedMultiRegionTargets: [],
       blockedAlreadySdk: [],
+      blockedAlreadyCcApi: [],
       blockedNoSdkProvider: [],
       conflictingDirections: [],
     };
@@ -768,6 +852,7 @@ describe('probeAndRevalidateStateful (#648)', () => {
       blockedStatefulTargets: [],
       blockedMultiRegionTargets: [],
       blockedAlreadySdk: [],
+      blockedAlreadyCcApi: [],
       blockedNoSdkProvider: [],
       conflictingDirections: [],
     };


### PR DESCRIPTION
## Summary

Closes #665.

Adds the missing forward-direction mirror of #651's `blockedAlreadySdk`: naming a logical id whose recorded `provisionedBy` is already `'cc-api'` in `--recreate-via-cc-api` now refuses pre-flight with a clear error, the same way `--recreate-via-sdk-provider` refuses an already-SDK target.

The asymmetry was flagged by the 3-axis code reviewer on PR #663 as a pre-existing #615 trap. The reverse-direction PR added `blockedAlreadySdk` for the SDK migration; this PR closes the loop by adding the symmetric `blockedAlreadyCcApi` for the CC migration. Tracked via #665.

## Why

`cdkd deploy MyStack --recreate-via-cc-api MyLambda` on a resource that's already `provisionedBy: 'cc-api'` runs a destroy + recreate cycle that lands the resource in the exact same state. Pre-#665, this slipped through silently — wasting downtime + AWS API churn for zero benefit. The reverse direction has refused this since #651 ships; the forward direction now does the same.

## Implementation (minimal)

- `src/deployment/recreate-targets.ts` — new `blockedAlreadyCcApi: RecreateTarget[]` field on `RecreateTargetsValidation`; populated in the `to-cc-api` branch when `recordedResource.provisionedBy === 'cc-api'`; rendered in `renderRecreateTargetsErrors` with mirror wording of `blockedAlreadySdk`.
- `tests/unit/deployment/recreate-targets.test.ts` — 4 new cases:
  - rejects `--recreate-via-cc-api` on already-`'cc-api'` resource
  - accepts `--recreate-via-cc-api` on `'sdk'` resource (legitimate forward migration)
  - accepts `--recreate-via-cc-api` on legacy pre-v7 state (treated as SDK)
  - reverse direction (`--recreate-via-sdk-provider` on `'cc-api'`) is UNAFFECTED (that's exactly the user's intent)
- `docs/cli-reference.md` — updates the existing "When NOT to use it" bullet from "skips with info log" to "refuses pre-flight with `blockedAlreadyCcApi`".

No deploy-engine change. No CLI flag change. No integ change needed — the validator catches before any AWS call.

## Test plan

- [x] Unit tests pass (5860 → 5864, +4 new).
- [x] `vp check --fix && vp run build && vp run test` — all green.
- [x] No new code path that needs integ coverage (validator-only change; the existing `recreate-via-cc-api` integ still exercises the happy path).

## Scope notes

- The pre-flight error message uses the umbrella prefix where appropriate but the `blockedAlreadyCcApi` block specifically names `--recreate-via-cc-api` (direction-specific category).
- The error message uses `Closes #665` so the issue auto-closes on merge.
