### PR TITLE
fix(local): synthesize default prelude when RIE streaming response lacks separator (#664)

### DIFF
--- a/src/local/rie-client.ts
+++ b/src/local/rie-client.ts
@@ -397,23 +397,75 @@ export async function invokeRieStreaming(
     }
   }
 
+  // Whether we synthesized a default prelude because no separator was found
+  // in the response. See the issue #664 fix block below for the rationale.
+  let preludeSynthesized = false;
+
   if (separatorIdx < 0) {
-    clearTimeout(timer);
-    throw new Error(
-      `RIE streaming response ended before the prelude/body separator (got ${preludeBytes.length} bytes). ` +
-        `The handler likely threw before streaming the prelude — check container logs.`
-    );
+    // No prelude/body separator found in the entire response. Two real-world
+    // scenarios produce this — empirically verified 2026-05-27 for issue #664
+    // against `public.ecr.aws/lambda/nodejs:22`:
+    //
+    //   (1) The handler is wrapped by `awslambda.streamifyResponse(...)` AND
+    //       uses the documented `responseStream.setContentType('...')` +
+    //       `responseStream.write(...)` shortcut WITHOUT explicitly calling
+    //       `awslambda.HttpResponseStream.from(stream, metadata)`. Production
+    //       AWS Lambda + Function URL handles this — the runtime auto-completes
+    //       the prelude lazily — but RIE emits only the raw body bytes the
+    //       handler wrote, no prelude+separator framing. This is the most
+    //       common case in the wild (the `setContentType` shortcut appears in
+    //       most tutorials + AWS docs).
+    //
+    //   (2) The handler crashed mid-invoke and RIE emitted a Lambda error
+    //       envelope (`{"errorType":"...","errorMessage":"..."}`) instead of
+    //       the prelude+separator framing. RIE itself reports
+    //       `INVOKE RTDONE(status: success, produced bytes: 0)` because from
+    //       its perspective the handler never finalized the streaming
+    //       response; the envelope bytes are sidecar diagnostics.
+    //
+    // In BOTH cases the right move is to NOT reject the invocation. We
+    // synthesize a default prelude (status 200, `application/octet-stream`)
+    // and surface the buffered bytes as the HTTP body. Case (1) lets the
+    // handler work locally exactly as it does in production. Case (2)
+    // surfaces the Lambda error envelope verbatim so the dev can read it
+    // from the curl response (much better UX than cdkd swallowing the bytes
+    // behind a generic "RIE streaming invoke failed").
+    //
+    // The genuinely-empty case (zero buffered bytes — handler threw before
+    // any write AND RIE didn't emit a diagnostic envelope) still falls
+    // through to the original error path: there's no body worth surfacing,
+    // and the rapid log is the right place for the dev to read the cause.
+    if (preludeBytes.length === 0) {
+      clearTimeout(timer);
+      throw new Error(
+        `RIE streaming response ended with zero bytes. The handler likely threw before any write — check container logs.`
+      );
+    }
+    preludeSynthesized = true;
+    bodyTail = preludeBytes;
+    preludeBytes = Buffer.alloc(0);
   }
 
   let prelude: StreamingPrelude;
-  try {
-    prelude = parseStreamingPrelude(preludeBytes.toString('utf8'));
-  } catch (err) {
-    clearTimeout(timer);
-    reader.cancel().catch(() => undefined);
-    throw new Error(
-      `RIE streaming response prelude is not valid JSON: ${err instanceof Error ? err.message : String(err)}`
-    );
+  if (preludeSynthesized) {
+    // Default prelude when the handler bypassed `HttpResponseStream.from(...)`.
+    // `application/octet-stream` matches the documented AWS default; consumers
+    // that care about Content-Type should call `HttpResponseStream.from(...)`
+    // explicitly with the right metadata.
+    prelude = {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/octet-stream' },
+    };
+  } else {
+    try {
+      prelude = parseStreamingPrelude(preludeBytes.toString('utf8'));
+    } catch (err) {
+      clearTimeout(timer);
+      reader.cancel().catch(() => undefined);
+      throw new Error(
+        `RIE streaming response prelude is not valid JSON: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
   }
 
   // Build a Readable that emits any already-buffered body bytes first,

--- a/tests/integration/local-start-api/lambda-stream-url-set-content-type/index.mjs
+++ b/tests/integration/local-start-api/lambda-stream-url-set-content-type/index.mjs
@@ -1,0 +1,19 @@
+// Streaming Function URL handler that uses the documented
+// `responseStream.setContentType(...)` + `responseStream.write(...)` shortcut
+// WITHOUT explicitly calling `awslambda.HttpResponseStream.from(stream, metadata)`.
+//
+// This is the most common Function URL streaming idiom in AWS tutorials and
+// in real-world handlers — production Lambda + Function URL accepts it. Local
+// RIE does NOT emit the prelude+separator framing for this pattern, so cdkd
+// must synthesize a default prelude and surface the body bytes verbatim
+// (issue #664 fix).
+//
+// verify.sh asserts the response arrives with HTTP 200 + the expected body
+// bytes, mirroring what the deployed Function URL would return.
+
+export const handler = awslambda.streamifyResponse(async (event, responseStream) => {
+  responseStream.setContentType('text/event-stream');
+  responseStream.write(`data: ${JSON.stringify({ hello: 'world' })}\n\n`);
+  responseStream.write(`data: ${JSON.stringify({ count: 2 })}\n\n`);
+  responseStream.end();
+});

--- a/tests/integration/local-start-api/lib/local-start-api-stack.ts
+++ b/tests/integration/local-start-api/lib/local-start-api-stack.ts
@@ -358,5 +358,31 @@ export class LocalStartApiStack extends cdk.Stack {
       authType: lambda.FunctionUrlAuthType.NONE,
       invokeMode: lambda.InvokeMode.RESPONSE_STREAM,
     });
+
+    // Issue #664: a second streaming Function URL whose handler uses the
+    // `responseStream.setContentType(...)` + `responseStream.write(...)`
+    // shortcut WITHOUT explicitly calling
+    // `awslambda.HttpResponseStream.from(stream, metadata)`. Production AWS
+    // Lambda accepts this pattern; pre-#664 cdkd local rejected it because
+    // RIE emits no prelude+separator framing in that case. Post-fix cdkd
+    // synthesizes a default prelude (200 / application/octet-stream) and
+    // surfaces the body bytes verbatim — verify.sh asserts the route
+    // returns 200 + the expected SSE-style body.
+    const streamUrlSetContentTypeHandler = new lambda.Function(
+      this,
+      'StreamUrlSetContentTypeHandler',
+      {
+        runtime: lambda.Runtime.NODEJS_20_X,
+        handler: 'index.handler',
+        code: lambda.Code.fromAsset(
+          path.join(__dirname, '../lambda-stream-url-set-content-type')
+        ),
+        timeout: cdk.Duration.seconds(30),
+      }
+    );
+    streamUrlSetContentTypeHandler.addFunctionUrl({
+      authType: lambda.FunctionUrlAuthType.NONE,
+      invokeMode: lambda.InvokeMode.RESPONSE_STREAM,
+    });
   }
 }

--- a/tests/integration/local-start-api/verify.sh
+++ b/tests/integration/local-start-api/verify.sh
@@ -128,15 +128,21 @@ PORT_REST=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(.*REST API v1\
 # so the `(` boundary excludes it).
 PORT_FNURL=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(UrlHandler[A-F0-9]{8}\s+\(Function URL\)\)' "${LOG_FILE}" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|' | head -1)
 PORT_FNURL_STREAM=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(StreamUrlHandler[A-F0-9]{8}\s+\(Function URL\)\)' "${LOG_FILE}" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|' | head -1)
-if [[ -z "${PORT_HTTP}" || -z "${PORT_REST}" || -z "${PORT_FNURL}" || -z "${PORT_FNURL_STREAM}" ]]; then
+# Issue #664: a second streaming Function URL whose handler uses the
+# setContentType-only shortcut (no explicit `HttpResponseStream.from(...)`).
+# `StreamUrlSetContentTypeHandler[A-F0-9]{8}` is distinct from
+# `StreamUrlHandler[A-F0-9]{8}` (the `Set` infix breaks the latter regex).
+PORT_FNURL_STREAM_SCT=$(grep -E 'Server listening on http://[^[:space:]]+\s+\(StreamUrlSetContentTypeHandler[A-F0-9]{8}\s+\(Function URL\)\)' "${LOG_FILE}" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|' | head -1)
+if [[ -z "${PORT_HTTP}" || -z "${PORT_REST}" || -z "${PORT_FNURL}" || -z "${PORT_FNURL_STREAM}" || -z "${PORT_FNURL_STREAM_SCT}" ]]; then
   echo "FAIL: could not extract per-API port mappings. Log:"
   cat "${LOG_FILE}"
   exit 1
 fi
-echo "    HTTP API v2:           ${PORT_HTTP}"
-echo "    REST API v1:           ${PORT_REST}"
-echo "    Function URL:          ${PORT_FNURL}"
-echo "    Function URL (stream): ${PORT_FNURL_STREAM}"
+echo "    HTTP API v2:                  ${PORT_HTTP}"
+echo "    REST API v1:                  ${PORT_REST}"
+echo "    Function URL:                 ${PORT_FNURL}"
+echo "    Function URL (stream):        ${PORT_FNURL_STREAM}"
+echo "    Function URL (stream/SCT):    ${PORT_FNURL_STREAM_SCT}"
 
 # Verify the route table contains every route. Method-column width
 # varies per server (REST v1 with OPTIONS preflight rows has a wider
@@ -203,7 +209,7 @@ curl_assert() {
   local needle="$3"
   shift 3
   local response=""
-  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
     if response=$(curl -sf "$@" "${url}" 2>&1); then
       if echo "${response}" | grep -q "${needle}"; then
         echo "    [${label}] OK"
@@ -254,7 +260,7 @@ echo "==> Asserting streaming Function URL (#467)"
 STREAM_URL="http://127.0.0.1:${PORT_FNURL_STREAM}/anything"
 # First-request retry loop (cold container ~3-5s on first invoke).
 STREAM_RESPONSE=""
-for attempt in 1 2 3 4 5 6 7 8 9 10; do
+for _ in 1 2 3 4 5 6 7 8 9 10; do
   if STREAM_RESPONSE=$(curl -sf -i --no-buffer "${STREAM_URL}" 2>&1); then
     if echo "${STREAM_RESPONSE}" | grep -q 'hello-0'; then break; fi
   fi
@@ -302,6 +308,46 @@ if echo "${STREAM_RESPONSE}" | grep -q '"statusCode":200,"headers"'; then
   exit 1
 fi
 echo "    [streaming Function URL] OK"
+
+# Issue #664: streaming Function URL whose handler uses the documented
+# `responseStream.setContentType(...)` + `responseStream.write(...)`
+# shortcut WITHOUT explicitly calling
+# `awslambda.HttpResponseStream.from(stream, metadata)`. Production AWS
+# Lambda + Function URL handles this — the runtime auto-completes the
+# prelude — but RIE emits only the raw body bytes the handler wrote
+# (verified empirically 2026-05-27 against `public.ecr.aws/lambda/nodejs:22`).
+# Pre-#664 cdkd rejected the invocation with "RIE streaming response
+# ended before the prelude/body separator". Post-fix cdkd synthesizes a
+# default 200 / application/octet-stream prelude and surfaces the body
+# bytes verbatim so the handler runs locally as it does in production.
+echo "==> Asserting streaming Function URL (#664 — setContentType-only handler)"
+STREAM_URL_SCT="http://127.0.0.1:${PORT_FNURL_STREAM_SCT}/anything"
+STREAM_SCT_RESPONSE=""
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if STREAM_SCT_RESPONSE=$(curl -sf -i --no-buffer "${STREAM_URL_SCT}" 2>&1); then
+    if echo "${STREAM_SCT_RESPONSE}" | grep -q '"hello":"world"'; then break; fi
+  fi
+  sleep 1
+done
+if ! echo "${STREAM_SCT_RESPONSE}" | grep -qi '^HTTP/1.1 200'; then
+  echo "FAIL: setContentType-only streaming Function URL did not return 200. Response:"
+  echo "${STREAM_SCT_RESPONSE}"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+if ! echo "${STREAM_SCT_RESPONSE}" | grep -q '"hello":"world"'; then
+  echo "FAIL: setContentType-only streaming response missing first chunk body. Response:"
+  echo "${STREAM_SCT_RESPONSE}"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+if ! echo "${STREAM_SCT_RESPONSE}" | grep -q '"count":2'; then
+  echo "FAIL: setContentType-only streaming response missing second chunk body. Response:"
+  echo "${STREAM_SCT_RESPONSE}"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+echo "    [streaming Function URL — setContentType-only (#664)] OK"
 
 # PR 8c: CORS preflight interception. The HTTP API has CorsConfiguration
 # with `*` origins; verify.sh asserts the canonical preflight response.

--- a/tests/unit/local/rie-client-streaming.test.ts
+++ b/tests/unit/local/rie-client-streaming.test.ts
@@ -249,15 +249,55 @@ describe('invokeRieStreaming', () => {
     expect(body.length).toBe(0);
   });
 
-  it('rejects when the response ends before the separator arrives', async () => {
+  it('rejects when the response ends with zero bytes (handler crashed pre-write)', async () => {
+    // Genuinely empty response — RIE emitted nothing, handler threw before
+    // any output. Issue #664: rejected with a clear pointer to container logs
+    // (where the real error trace lives).
     nextStreamResponse = (_req, res) => {
       res.writeHead(200);
-      // Send only part of the prelude — no separator, no body.
-      res.end(Buffer.from('{"statusCode":200,"headers":{}'));
+      res.end();
     };
-    await expect(invokeRieStreaming('127.0.0.1', port, {}, 5000)).rejects.toThrow(
-      /ended before the prelude/
-    );
+    await expect(invokeRieStreaming('127.0.0.1', port, {}, 5000)).rejects.toThrow(/zero bytes/);
+  });
+
+  it('synthesizes a default prelude when the handler emits bytes without a separator (setContentType pattern)', async () => {
+    // Issue #664: a handler wrapped by `awslambda.streamifyResponse(...)` that
+    // uses `responseStream.setContentType(...)` + `responseStream.write(...)`
+    // WITHOUT explicitly calling `awslambda.HttpResponseStream.from(...)` —
+    // the documented AWS Lambda streaming shortcut — produces NO 8-NULL
+    // prelude separator on the RIE wire. Production AWS Lambda accepts this;
+    // pre-#664 cdkd rejected the invocation. Post-fix: cdkd synthesizes a
+    // default 200 / application/octet-stream prelude and surfaces every
+    // received byte as the body so the dev's handler runs locally as it does
+    // in production.
+    nextStreamResponse = (_req, res) => {
+      res.writeHead(200);
+      // SSE-style body the handler wrote — NO prelude, NO separator,
+      // just raw bytes.
+      res.end(Buffer.from('data: {"hello":"world"}\n\n'));
+    };
+    const result = await invokeRieStreaming('127.0.0.1', port, {}, 5000);
+    expect(result.prelude.statusCode).toBe(200);
+    expect(result.prelude.headers).toEqual({ 'Content-Type': 'application/octet-stream' });
+    const body = await collectBody(result);
+    expect(body.toString('utf8')).toBe('data: {"hello":"world"}\n\n');
+  });
+
+  it('synthesizes default prelude even when buffered bytes look like a partial JSON attempt', async () => {
+    // Companion to the setContentType test: even when the buffered bytes
+    // happen to LOOK like a partial JSON prelude attempt, surface them as
+    // body rather than reject. The Lambda error envelope shape
+    // (`{"errorType":...}`) lives in this space — the dev gets it back in
+    // the response body verbatim, which is the right diagnostic outcome.
+    nextStreamResponse = (_req, res) => {
+      res.writeHead(200);
+      res.end(Buffer.from('{"errorType":"InternalError","errorMessage":"boom"}'));
+    };
+    const result = await invokeRieStreaming('127.0.0.1', port, {}, 5000);
+    expect(result.prelude.statusCode).toBe(200);
+    expect(result.prelude.headers).toEqual({ 'Content-Type': 'application/octet-stream' });
+    const body = await collectBody(result);
+    expect(body.toString('utf8')).toBe('{"errorType":"InternalError","errorMessage":"boom"}');
   });
 
   it('rejects when the prelude is not valid JSON', async () => {


### PR DESCRIPTION
## Summary

`cdkd local start-api` against a Function URL Lambda whose handler is wrapped by `awslambda.streamifyResponse(...)` and uses the documented `responseStream.setContentType('text/event-stream')` + `responseStream.write(...)` shortcut **rejected the invocation** with:

```
RIE streaming invoke failed: RIE streaming response ended before the prelude/body separator (got N bytes). The handler likely threw before streaming the prelude — check container logs.
```

The handler actually succeeded — production AWS Lambda + Function URL accepts this pattern. RIE just doesn't emit the 8-NULL prelude/body separator unless the handler calls `awslambda.HttpResponseStream.from(stream, metadata)` explicitly.

Empirically verified 2026-05-27 against `public.ecr.aws/lambda/nodejs:22` while debugging a real SSE-streaming Function URL Lambda: pre-fix cdkd rejected every invocation; the wire showed N body bytes (53 / 230 / 259 across three test variants) but no separator.

## Changes

### `src/local/rie-client.ts:invokeRieStreaming`

[src/local/rie-client.ts:400](src/local/rie-client.ts#L400) — when the response ends without a separator AND we have non-zero buffered bytes, synthesize a default prelude `{ statusCode: 200, headers: { 'Content-Type': 'application/octet-stream' } }` and surface the buffered bytes as the HTTP body. The genuinely-empty case (zero buffered bytes) still falls through to a clearer "zero bytes — handler likely threw before any write" error.

Two real-world scenarios produce a separator-less response, both covered by this fix:

1. **setContentType-only handler** — the documented AWS streaming shortcut. Production Lambda + Function URL handles this; RIE doesn't.
2. **Lambda error envelope** — when the handler crashes and RIE emits `{"errorType":"...","errorMessage":"..."}` as a diagnostic blob instead of the prelude+separator framing. The dev gets the envelope verbatim in the response body (better UX than cdkd swallowing it behind a generic error).

### Tests

- **Replaced** the existing "rejects when ends before separator" test (its scenario — partial-prelude bytes — is exactly what the new fallback path handles) with a stricter "rejects when zero bytes" test that covers the genuine truly-empty handler crash.
- **Added** "synthesizes a default prelude when the handler emits bytes without a separator (setContentType pattern)" — the real-world user repro.
- **Added** "synthesizes default prelude even when buffered bytes look like a partial JSON attempt" — the Lambda error envelope path.

### Integ fixture

[tests/integration/local-start-api/lambda-stream-url-set-content-type/index.mjs](tests/integration/local-start-api/lambda-stream-url-set-content-type/index.mjs) — new handler using the bare `setContentType` + `write` pattern. Wired into the stack as `StreamUrlSetContentTypeHandler` with a separate Function URL. [verify.sh](tests/integration/local-start-api/verify.sh) extracts its port and asserts HTTP 200 + the expected SSE-style body across two chunks (`{"hello":"world"}` + `{"count":2}`).

### Polish

`for attempt in 1 2 3 4 5 6 7 8 9 10` → `for _ in 1 2 3 4 5 6 7 8 9 10` in the two existing retry loops in verify.sh (unused-loop-var cleanup the linter surfaces when the file is touched).

## Real-world impact

Pre-fix: every cdkd user trying to test a Function URL streaming Lambda locally that uses the documented `setContentType` shortcut (most tutorials, most real handlers) hit the rejection. The error message blamed the handler (`The handler likely threw before streaming the prelude`) even though the handler succeeded. Manual workaround: rewrite handlers to call `awslambda.HttpResponseStream.from(...)` explicitly.

Post-fix: the same handlers work locally as they do in production. No source change required.

## Test plan

- [x] `vp check --fix` passes (typecheck + lint + format)
- [x] `vp run build` passes
- [x] `vp test` passes — 384 test files, 5870 tests (3 new in this PR)
- [x] `/run-integ local-start-api` passed — including the new `StreamUrlSetContentTypeHandler` route asserting HTTP 200 + both SSE chunks; 0 Docker orphans post-run

Closes #664
