### PR TITLE
fix(local): mount profile-aware credentials file for fromIni({ profile }) handlers

### DIFF
--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -54,6 +54,10 @@ import {
   getDockerImageBySourceHash,
 } from '../../assets/asset-manifest-loader.js';
 import { singleFlight } from '../../utils/single-flight.js';
+import {
+  writeProfileCredentialsFile,
+  type ProfileCredentialsFile,
+} from './local-profile-credentials-file.js';
 import type { StackState } from '../../types/state.js';
 import { createLocalStartApiCommand, resolveProfileCredentials } from './local-start-api.js';
 import { createLocalRunTaskCommand } from './local-run-task.js';
@@ -198,6 +202,11 @@ async function localInvokeCommand(target: string, options: LocalInvokeOptions): 
   let containerId: string | undefined;
   let stopLogs: (() => void) | undefined;
   let sigintHandler: (() => void) | undefined;
+  // Issue #2 deferred from #655: synthesized AWS shared credentials file
+  // (one INI section) bind-mounted into the container so handlers using
+  // `fromIni({ profile })` explicitly resolve to the same creds.
+  // Disposed in the shared `cleanup` single-flight.
+  let profileCredsFile: ProfileCredentialsFile | undefined;
 
   /**
    * Unified cleanup for both the success / failure unwind path AND the
@@ -267,6 +276,17 @@ async function localInvokeCommand(target: string, options: LocalInvokeOptions): 
           }
         }
       }
+      if (profileCredsFile) {
+        try {
+          await profileCredsFile.dispose();
+        } catch (err) {
+          getLogger().debug(
+            `Failed to remove profile credentials tmpdir ${profileCredsFile.hostPath}: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      }
     },
     (err) => {
       getLogger().debug(`cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -292,6 +312,20 @@ async function localInvokeCommand(target: string, options: LocalInvokeOptions): 
     const profileCredentials = options.profile
       ? await resolveProfileCredentials(options.profile)
       : undefined;
+
+    // Issue #2 deferred from #655: synthesize an AWS shared credentials
+    // file with the resolved creds under `[<options.profile>]` so handler
+    // code that uses `fromIni({ profile: '<options.profile>' })` explicitly
+    // (instead of the default credential chain) resolves to the same
+    // creds locally. Mounted read-only into the container at the path
+    // pointed to by `AWS_SHARED_CREDENTIALS_FILE` (set below). The
+    // default-chain path (most handlers) keeps working through the
+    // existing env-var injection; this file is the additive layer for
+    // the explicit-profile case. Disposed in the shared `cleanup`
+    // single-flight below.
+    if (options.profile && profileCredentials) {
+      profileCredsFile = await writeProfileCredentialsFile(options.profile, profileCredentials);
+    }
 
     // Synthesize. Default is "synth every time" (Q2 recommendation C):
     // safe-by-default, with `-a/--app cdk.out` as the explicit opt-out
@@ -530,6 +564,14 @@ async function localInvokeCommand(target: string, options: LocalInvokeOptions): 
       // `process.env`. See `applyProfileCredentialsOverlay`'s doc for
       // the full precedence table + session-token-strip rationale.
       applyProfileCredentialsOverlay(dockerEnv, profileCredentials, false);
+      // Issue #2 deferred from #655: point the container's SDK chain at
+      // the bind-mounted credentials file so `fromIni({ profile })` calls
+      // inside the handler resolve to the same creds. `AWS_PROFILE` makes
+      // `fromIni()` (no explicit arg) ALSO use this profile.
+      if (profileCredsFile) {
+        dockerEnv['AWS_SHARED_CREDENTIALS_FILE'] = profileCredsFile.containerPath;
+        dockerEnv['AWS_PROFILE'] = profileCredsFile.profileName;
+      }
     }
 
     // Optional inspector: --debug-port enables `node --inspect-brk` inside
@@ -569,10 +611,25 @@ async function localInvokeCommand(target: string, options: LocalInvokeOptions): 
       );
     }
     logger.info(`Starting container (image=${imagePlan.image}, port=${hostPort})...`);
+    // Issue #2 deferred from #655: append the profile credentials file
+    // bind-mount to the existing extraMounts (which already carry the
+    // /opt layer mount when present). Read-only — the container has no
+    // business writing to its credentials file; a writable mount would
+    // let a compromised handler tamper with the host-side temp file.
+    const extraMountsWithProfile = profileCredsFile
+      ? [
+          ...(imagePlan.extraMounts ?? []),
+          {
+            hostPath: profileCredsFile.hostPath,
+            containerPath: profileCredsFile.containerPath,
+            readOnly: true,
+          },
+        ]
+      : imagePlan.extraMounts;
     containerId = await runDetached({
       image: imagePlan.image,
       mounts: imagePlan.mounts,
-      extraMounts: imagePlan.extraMounts,
+      extraMounts: extraMountsWithProfile,
       env: dockerEnv,
       cmd: imagePlan.cmd,
       hostPort,

--- a/src/cli/commands/local-profile-credentials-file.ts
+++ b/src/cli/commands/local-profile-credentials-file.ts
@@ -1,0 +1,134 @@
+// Profile-aware credentials file mount for cdkd local Lambda containers.
+//
+// Background: PR #655 / #657 forward `--profile <p>`-resolved credentials to
+// the Lambda container as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` /
+// `AWS_SESSION_TOKEN` env vars. The SDK's default credential provider chain
+// reads those env vars, so the common handler pattern
+// (`new SecretsManagerClient({ region })`) works.
+//
+// What this module adds: handlers that explicitly call
+// `fromIni({ profile: '<name>' })` bypass the env-var chain and look for
+// `[<name>]` in `~/.aws/credentials` (or `AWS_SHARED_CREDENTIALS_FILE`).
+// Inside the Lambda container neither file exists by default, so those
+// handlers fail locally even when production AWS Lambda + IAM-role-baked-
+// profile setups (Lambda Layer with credentials etc.) make them work.
+//
+// Fix: when `--profile <name>` is passed, ALSO write a temp credentials
+// file with the resolved creds under `[<name>]`, bind-mount it into the
+// container, and set `AWS_SHARED_CREDENTIALS_FILE=<containerPath>` +
+// `AWS_PROFILE=<name>` env vars. Now both code paths work:
+//
+//   - Default chain: reads `AWS_ACCESS_KEY_ID` etc. (existing behavior)
+//   - `fromIni({ profile: '<name>' })`: reads the mounted file via
+//     `AWS_SHARED_CREDENTIALS_FILE`, finds `[<name>]`, returns the same
+//     resolved creds
+//
+// The profile NAME inside the container matches what the user passed via
+// `--profile` so handler code `fromIni({ profile: '<name>' })` matches
+// without source changes.
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Path inside the container where the credentials file is mounted. Fixed
+ * (not user-configurable) so the env-var injection is stable. `/cdkd-aws/`
+ * is outside `/var/task` (the Lambda code mount) and outside `/root/`
+ * (which the user's handler may bind-mount or modify), so there is no
+ * collision risk with the user's payload.
+ */
+export const CONTAINER_AWS_CREDENTIALS_PATH = '/cdkd-aws/credentials';
+
+/**
+ * Resolved profile credentials file ready to mount into a Lambda container.
+ *
+ * `hostPath` is the absolute path on the host (`/tmp/cdkd-profile-creds-<rand>/credentials`).
+ * `dispose` removes the host-side file + its parent tempdir; safe to call
+ * multiple times (idempotent rm).
+ */
+export interface ProfileCredentialsFile {
+  hostPath: string;
+  containerPath: string;
+  profileName: string;
+  dispose: () => Promise<void>;
+}
+
+/**
+ * Write a temporary AWS shared-credentials file containing the resolved
+ * `--profile <name>` credentials, ready to bind-mount into a Lambda
+ * container at {@link CONTAINER_AWS_CREDENTIALS_PATH}.
+ *
+ * The file content is the standard `[profile-name]` INI shape:
+ *
+ *   [<profileName>]
+ *   aws_access_key_id = <accessKeyId>
+ *   aws_secret_access_key = <secretAccessKey>
+ *   aws_session_token = <sessionToken>   ← only when present
+ *
+ * `aws_session_token` is omitted when the resolved profile produced
+ * long-lived (non-STS) credentials, mirroring the same logic
+ * `applyProfileCredentialsOverlay` uses for env-var injection.
+ *
+ * Caller is responsible for invoking `dispose()` when the container pool
+ * tears down (e.g., on `SIGINT` via `singleFlight` cleanup). Leaving the
+ * file behind in `/tmp` is a security smell (temp credentials live on
+ * disk).
+ */
+export async function writeProfileCredentialsFile(
+  profileName: string,
+  creds: { accessKeyId: string; secretAccessKey: string; sessionToken?: string }
+): Promise<ProfileCredentialsFile> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'cdkd-profile-creds-'));
+  const hostPath = path.join(dir, 'credentials');
+  const lines: string[] = [
+    `[${profileName}]`,
+    `aws_access_key_id = ${creds.accessKeyId}`,
+    `aws_secret_access_key = ${creds.secretAccessKey}`,
+  ];
+  if (creds.sessionToken) {
+    lines.push(`aws_session_token = ${creds.sessionToken}`);
+  }
+  // Trailing newline for POSIX-text-file convention; some INI parsers
+  // (including AWS SDK's older versions) reject files without a final
+  // newline.
+  await writeFile(hostPath, lines.join('\n') + '\n', { mode: 0o600 });
+  return {
+    hostPath,
+    containerPath: CONTAINER_AWS_CREDENTIALS_PATH,
+    profileName,
+    dispose: async () => {
+      // `recursive: true` removes the credentials file + its parent
+      // tempdir in one shot. `force: true` makes the dispose idempotent
+      // (multiple cleanup paths call this on SIGINT, single-flight
+      // teardown, etc.).
+      await rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Build the docker-args fragment that mounts a profile credentials file
+ * into the container + sets the env vars the SDK chain needs.
+ *
+ * Returns an array of `docker run` args that the caller splices into its
+ * own argv builder. Empty array when `file` is `undefined` (the
+ * `--profile` flag was not set).
+ *
+ * The `:ro` mount flag is load-bearing — the container has no business
+ * writing to its credentials file; a writable mount would let a
+ * compromised handler tamper with the host-side temp file.
+ */
+export function buildProfileCredentialsDockerArgs(
+  file: ProfileCredentialsFile | undefined
+): string[] {
+  if (!file) return [];
+  return [
+    '-v',
+    `${file.hostPath}:${file.containerPath}:ro`,
+    '-e',
+    `AWS_SHARED_CREDENTIALS_FILE=${file.containerPath}`,
+    '-e',
+    `AWS_PROFILE=${file.profileName}`,
+  ];
+}

--- a/src/cli/commands/local-profile-credentials-file.ts
+++ b/src/cli/commands/local-profile-credentials-file.ts
@@ -79,6 +79,23 @@ export async function writeProfileCredentialsFile(
   profileName: string,
   creds: { accessKeyId: string; secretAccessKey: string; sessionToken?: string }
 ): Promise<ProfileCredentialsFile> {
+  // PR #670 code review finding #2: validate the profile name before
+  // interpolating into the INI section header / AWS_PROFILE env var.
+  // The injection surface is local-dev-only (the caller is the user's
+  // own `--profile <name>` arg) so this is hardening, not security
+  // boundary — but a value containing `]` would silently start a second
+  // INI section, and a value containing newlines would break the
+  // `-e AWS_PROFILE=...` docker-run env line. Reject at the helper
+  // boundary so the caller never has to think about it.
+  if (profileName === '') {
+    throw new Error('writeProfileCredentialsFile: profile name must not be empty.');
+  }
+  if (/[\r\n[\]]/.test(profileName)) {
+    throw new Error(
+      `writeProfileCredentialsFile: profile name '${profileName}' contains a forbidden character ` +
+        `(any of CR, LF, '[', ']' would corrupt the INI file or the docker -e env var).`
+    );
+  }
   const dir = await mkdtemp(path.join(tmpdir(), 'cdkd-profile-creds-'));
   const hostPath = path.join(dir, 'credentials');
   const lines: string[] = [

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -1586,19 +1586,27 @@ async function buildContainerSpec(args: {
         delete dockerEnv['AWS_SESSION_TOKEN'];
       }
     }
-  }
 
-  // Issue #2 deferred from #655 (profile-aware SDK config inside
-  // container): when the server boot synthesized a credentials file via
-  // `writeProfileCredentialsFile(options.profile, ...)`, point the
-  // container's SDK chain at the bind-mounted path so
-  // `fromIni({ profile: '<name>' })` calls inside the handler resolve
-  // to the same creds as the default chain. `AWS_PROFILE` makes
-  // `fromIni()` (no explicit arg) ALSO use this profile — both code
-  // paths converge on the same `[<name>]` section.
-  if (profileCredsFile) {
-    dockerEnv['AWS_SHARED_CREDENTIALS_FILE'] = profileCredsFile.containerPath;
-    dockerEnv['AWS_PROFILE'] = profileCredsFile.profileName;
+    // Issue #2 deferred from #655 (profile-aware SDK config inside
+    // container): when the server boot synthesized a credentials file via
+    // `writeProfileCredentialsFile(options.profile, ...)`, point the
+    // container's SDK chain at the bind-mounted path so
+    // `fromIni({ profile: '<name>' })` calls inside the handler resolve
+    // to the same creds as the default chain. `AWS_PROFILE` makes
+    // `fromIni()` (no explicit arg) ALSO use this profile — both code
+    // paths converge on the same `[<name>]` section.
+    //
+    // GATED on `!roleArn` (nested in the assume-role-NOT-effective branch)
+    // so the existing precedence "assume-role > profile > env" holds for
+    // the file path too. Without this nesting, a handler in an
+    // assume-role'd Lambda that called `fromIni({ profile: '<name>' })`
+    // explicitly would silently bypass the execution-role creds and use
+    // the `--profile <name>` creds — breaking the documented precedence
+    // (PR #670 code review finding #1).
+    if (profileCredsFile) {
+      dockerEnv['AWS_SHARED_CREDENTIALS_FILE'] = profileCredsFile.containerPath;
+      dockerEnv['AWS_PROFILE'] = profileCredsFile.profileName;
+    }
   }
 
   if (debugPort !== undefined) {

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -110,6 +110,10 @@ import {
 } from '../../local/cognito-jwt.js';
 import { defaultCredentialsLoader, type CredentialsLoader } from '../../local/sigv4-verify.js';
 import { singleFlight } from '../../utils/single-flight.js';
+import {
+  writeProfileCredentialsFile,
+  type ProfileCredentialsFile,
+} from './local-profile-credentials-file.js';
 
 interface LocalStartApiOptions {
   app?: string;
@@ -305,6 +309,14 @@ async function localStartApiCommand(
   // shutdown path is the single owner of cleanup so leaks are
   // bounded by server lifetime).
   const layerTmpDirs = new Set<string>();
+  // Issue #2 deferred from #655: synthesized AWS shared credentials
+  // file bind-mounted into every Lambda container so handlers using
+  // `fromIni({ profile })` explicitly resolve to the same creds as the
+  // default chain. Created ONCE at server boot (NOT on hot reload —
+  // re-resolving profile creds is fine for env vars but rewriting the
+  // file mid-flight would race with running containers' SDK reads).
+  // Disposed in the cleanup chain. Undefined when `--profile` is unset.
+  let profileCredsFile: ProfileCredentialsFile | undefined;
   // Track every Lambda asset directory the server is currently
   // referencing; the file watcher uses this list to know what to
   // watch beyond `cdk.out/`. The value is updated AFTER the reload
@@ -498,6 +510,31 @@ async function localStartApiCommand(
       ? await resolveProfileCredentials(options.profile)
       : undefined;
 
+    // Issue #2 deferred from #655: when `--profile <p>` is set, ALSO
+    // synthesize a shared AWS credentials file with the resolved creds
+    // under `[<p>]` and bind-mount it into every Lambda container at
+    // `/cdkd-aws/credentials`. This lets handlers that use
+    // `fromIni({ profile: '<p>' })` explicitly inside their code (instead
+    // of the default credential chain) resolve to the same creds locally.
+    // The default-chain path (most handlers) keeps working through the
+    // existing `AWS_*` env-var injection — the file is the additive
+    // layer for the explicit-profile case.
+    //
+    // Caveat: under `--watch` hot reload, `profileCredentials` re-resolves
+    // and the new env vars flow to the next cold start, but the on-disk
+    // file is NOT re-written. Long-running sessions whose SSO temp creds
+    // expire need a cdkd restart (matches the auto-refresh-deferred
+    // stance for env vars from #655).
+    //
+    // Assigned to outer-scope `profileCredsFile` so the cleanup chain
+    // (`runCleanup`) disposes the file at shutdown. Only ever assigned
+    // on the FIRST synthesizeAndBuild (initial server boot) — hot
+    // reload sees the variable already set and skips re-writing per
+    // the caveat above.
+    if (options.profile && profileCredentials && !profileCredsFile) {
+      profileCredsFile = await writeProfileCredentialsFile(options.profile, profileCredentials);
+    }
+
     // Build the per-Lambda spec map. Every reachable logical ID is
     // resolved to its asset / inline code, env vars, optional STS creds
     // (--assume-role), optional --debug-port reservation. The container
@@ -522,6 +559,7 @@ async function localStartApiCommand(
         skipPull: options.pull === false,
         ...(options.layerRoleArn !== undefined && { layerRoleArn: options.layerRoleArn }),
         ...(profileCredentials && { profileCredentials }),
+        ...(profileCredsFile && { profileCredsFile }),
       });
       specs.set(logicalId, spec);
     }
@@ -1077,6 +1115,20 @@ async function localStartApiCommand(
         );
       }
     }
+    // Issue #2 deferred from #655: dispose the synthesized profile
+    // credentials file (one INI file under `/tmp/cdkd-profile-creds-*/`).
+    // Leaving temp credential files on disk after process exit is a
+    // security smell; `dispose()` rm's the tempdir recursively + force,
+    // so re-entrant calls (signal-mid-finally race) are safe.
+    if (profileCredsFile) {
+      try {
+        await profileCredsFile.dispose();
+      } catch (err) {
+        logger.warn(
+          `Failed to remove profile credentials tmpdir ${profileCredsFile.hostPath}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
   });
   const shutdown = async (signal: string, exitCode: number): Promise<void> => {
     if (shutdownStarted) {
@@ -1369,6 +1421,16 @@ async function buildContainerSpec(args: {
    * effect — `forwardAwsEnv` copies `process.env.AWS_*`).
    */
   profileCredentials?: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
+  /**
+   * Issue #2 deferred from #655: when set, a synthesized AWS shared
+   * credentials file (one INI section, the resolved `[<profile-name>]`
+   * block) the container should bind-mount + reference via
+   * `AWS_SHARED_CREDENTIALS_FILE` + `AWS_PROFILE` env vars. Lets handlers
+   * that use `fromIni({ profile })` explicitly inside their code resolve
+   * to the same creds locally. Undefined when `--profile` was not
+   * passed.
+   */
+  profileCredsFile?: ProfileCredentialsFile;
 }): Promise<ContainerSpec> {
   const {
     logicalId,
@@ -1384,6 +1446,7 @@ async function buildContainerSpec(args: {
     skipPull,
     layerRoleArn,
     profileCredentials,
+    profileCredsFile,
   } = args;
   const lambda = resolveLambdaByLogicalId(logicalId, stacks);
 
@@ -1525,6 +1588,19 @@ async function buildContainerSpec(args: {
     }
   }
 
+  // Issue #2 deferred from #655 (profile-aware SDK config inside
+  // container): when the server boot synthesized a credentials file via
+  // `writeProfileCredentialsFile(options.profile, ...)`, point the
+  // container's SDK chain at the bind-mounted path so
+  // `fromIni({ profile: '<name>' })` calls inside the handler resolve
+  // to the same creds as the default chain. `AWS_PROFILE` makes
+  // `fromIni()` (no explicit arg) ALSO use this profile — both code
+  // paths converge on the same `[<name>]` section.
+  if (profileCredsFile) {
+    dockerEnv['AWS_SHARED_CREDENTIALS_FILE'] = profileCredsFile.containerPath;
+    dockerEnv['AWS_PROFILE'] = profileCredsFile.profileName;
+  }
+
   if (debugPort !== undefined) {
     dockerEnv['NODE_OPTIONS'] = `--inspect-brk=0.0.0.0:${debugPort}`;
   }
@@ -1551,6 +1627,12 @@ async function buildContainerSpec(args: {
       ...(optDir !== undefined && { optDir }),
       ...(debugPort !== undefined && { debugPort }),
       ...(tmpfs !== undefined && { tmpfs }),
+      ...(profileCredsFile && {
+        profileCredentialsFile: {
+          hostPath: profileCredsFile.hostPath,
+          containerPath: profileCredsFile.containerPath,
+        },
+      }),
     };
     return spec;
   }
@@ -1572,6 +1654,12 @@ async function buildContainerSpec(args: {
     containerHost,
     ...(debugPort !== undefined && { debugPort }),
     ...(tmpfs !== undefined && { tmpfs }),
+    ...(profileCredsFile && {
+      profileCredentialsFile: {
+        hostPath: profileCredsFile.hostPath,
+        containerPath: profileCredsFile.containerPath,
+      },
+    }),
   };
   return spec;
 }

--- a/src/local/container-pool.ts
+++ b/src/local/container-pool.ts
@@ -116,6 +116,23 @@ interface ContainerSpecBase {
    * for Lambdas not backing a WebSocket API.
    */
   extraHosts?: { host: string; ip: string }[];
+  /**
+   * Issue #2-deferred-from-#655 — when `cdkd local *` is invoked with
+   * `--profile <name>`, this is the host path of a synthesized AWS shared
+   * credentials file (one INI section, the resolved `[<name>]` block).
+   * The pool bind-mounts it read-only at the container path so SDK calls
+   * via `fromIni({ profile: '<name>' })` inside the handler find their
+   * profile locally — production AWS Lambda doesn't ship `~/.aws/`, so
+   * this is purely a local-development convenience to keep handler code
+   * portable without source changes.
+   *
+   * Set in `local-start-api.ts` / `local-invoke.ts`'s startup flow
+   * alongside the `AWS_SHARED_CREDENTIALS_FILE` + `AWS_PROFILE` env
+   * entries (already in `env`) so the SDK's default chain + explicit
+   * `fromIni({ profile })` both resolve to the same creds. Unset when
+   * `--profile` was not passed (the env-var-only path stays in effect).
+   */
+  profileCredentialsFile?: { hostPath: string; containerPath: string };
 }
 
 export interface ZipContainerSpec extends ContainerSpecBase {
@@ -324,6 +341,22 @@ export function createContainerPool(
       const optMount = spec.optDir
         ? [{ hostPath: spec.optDir, containerPath: '/opt', readOnly: true }]
         : [];
+      // Append the profile credentials file mount (issue #2 deferred from
+      // #655) when --profile was passed. Read-only — the container has no
+      // business writing to its credentials file, and a writable mount
+      // would let a compromised handler tamper with the host-side temp
+      // file. Combined with `optMount` since Docker accepts an array of
+      // -v args (no conflict with the /opt layer mount).
+      const extraMounts = spec.profileCredentialsFile
+        ? [
+            ...optMount,
+            {
+              hostPath: spec.profileCredentialsFile.hostPath,
+              containerPath: spec.profileCredentialsFile.containerPath,
+              readOnly: true,
+            },
+          ]
+        : optMount;
       // provided.al2 / provided.al2023 require the deployment package at
       // /var/runtime (where the base image's hardcoded entrypoint exec's
       // /var/runtime/bootstrap); every other runtime expects /var/task.
@@ -332,7 +365,7 @@ export function createContainerPool(
       containerId = await runDetached({
         image,
         mounts: [{ hostPath: spec.codeDir, containerPath: containerCodePath, readOnly: true }],
-        extraMounts: optMount,
+        extraMounts,
         env: spec.env,
         cmd: [spec.lambda.handler],
         hostPort,
@@ -355,6 +388,15 @@ export function createContainerPool(
       containerId = await runDetached({
         image: spec.image,
         mounts: [],
+        ...(spec.profileCredentialsFile && {
+          extraMounts: [
+            {
+              hostPath: spec.profileCredentialsFile.hostPath,
+              containerPath: spec.profileCredentialsFile.containerPath,
+              readOnly: true,
+            },
+          ],
+        }),
         env: spec.env,
         cmd: spec.command,
         hostPort,

--- a/tests/unit/cli/local-profile-credentials-file.test.ts
+++ b/tests/unit/cli/local-profile-credentials-file.test.ts
@@ -85,6 +85,33 @@ describe('writeProfileCredentialsFile', () => {
     await expect(file.dispose()).resolves.toBeUndefined();
   });
 
+  it('rejects an empty profile name (would write an `[]` header)', async () => {
+    await expect(
+      writeProfileCredentialsFile('', { accessKeyId: 'A', secretAccessKey: 'B' })
+    ).rejects.toThrow(/must not be empty/);
+  });
+
+  it("rejects a profile name containing ']' (would inject a second INI section)", async () => {
+    await expect(
+      writeProfileCredentialsFile('a]\n[evil', { accessKeyId: 'A', secretAccessKey: 'B' })
+    ).rejects.toThrow(/forbidden character/);
+  });
+
+  it("rejects a profile name containing '[' (would corrupt the INI section header)", async () => {
+    await expect(
+      writeProfileCredentialsFile('a[b', { accessKeyId: 'A', secretAccessKey: 'B' })
+    ).rejects.toThrow(/forbidden character/);
+  });
+
+  it('rejects a profile name containing CR/LF (would break the docker -e env line)', async () => {
+    await expect(
+      writeProfileCredentialsFile('a\nb', { accessKeyId: 'A', secretAccessKey: 'B' })
+    ).rejects.toThrow(/forbidden character/);
+    await expect(
+      writeProfileCredentialsFile('a\rb', { accessKeyId: 'A', secretAccessKey: 'B' })
+    ).rejects.toThrow(/forbidden character/);
+  });
+
   it('uses the profile name the caller passed (matches handler-side fromIni({ profile }))', async () => {
     // Real-world case: user passes `--profile my-team-dev`; handler code
     // has `fromIni({ profile: 'my-team-dev' })`. The INI section header

--- a/tests/unit/cli/local-profile-credentials-file.test.ts
+++ b/tests/unit/cli/local-profile-credentials-file.test.ts
@@ -1,0 +1,137 @@
+import { readFile, stat } from 'node:fs/promises';
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  buildProfileCredentialsDockerArgs,
+  CONTAINER_AWS_CREDENTIALS_PATH,
+  writeProfileCredentialsFile,
+} from '../../../src/cli/commands/local-profile-credentials-file.js';
+
+describe('writeProfileCredentialsFile', () => {
+  it('writes a valid AWS INI section with sessionToken when present', async () => {
+    const file = await writeProfileCredentialsFile('dev-sso', {
+      accessKeyId: 'AKIA-EXAMPLE',
+      secretAccessKey: 'SECRET-EXAMPLE',
+      sessionToken: 'SESSION-EXAMPLE',
+    });
+    try {
+      const body = await readFile(file.hostPath, 'utf8');
+      expect(body).toBe(
+        '[dev-sso]\n' +
+          'aws_access_key_id = AKIA-EXAMPLE\n' +
+          'aws_secret_access_key = SECRET-EXAMPLE\n' +
+          'aws_session_token = SESSION-EXAMPLE\n'
+      );
+      expect(file.containerPath).toBe(CONTAINER_AWS_CREDENTIALS_PATH);
+      expect(file.profileName).toBe('dev-sso');
+    } finally {
+      await file.dispose();
+    }
+  });
+
+  it('omits aws_session_token when the profile resolved to long-lived creds', async () => {
+    const file = await writeProfileCredentialsFile('long-lived', {
+      accessKeyId: 'AKIA-LIVED',
+      secretAccessKey: 'SECRET-LIVED',
+    });
+    try {
+      const body = await readFile(file.hostPath, 'utf8');
+      expect(body).toBe(
+        '[long-lived]\n' +
+          'aws_access_key_id = AKIA-LIVED\n' +
+          'aws_secret_access_key = SECRET-LIVED\n'
+      );
+      expect(body).not.toContain('aws_session_token');
+    } finally {
+      await file.dispose();
+    }
+  });
+
+  it('writes the file with 0o600 permissions (owner-only readable)', async () => {
+    const file = await writeProfileCredentialsFile('perm-check', {
+      accessKeyId: 'AKIA-P',
+      secretAccessKey: 'SECRET-P',
+    });
+    try {
+      const stats = await stat(file.hostPath);
+      // mode & 0o777 isolates the permission bits from file-type flags.
+      // 0o600 = owner read+write only, no group/other access.
+      // Credential files on disk must not be world-readable.
+      expect(stats.mode & 0o777).toBe(0o600);
+    } finally {
+      await file.dispose();
+    }
+  });
+
+  it('dispose() removes the file + tempdir', async () => {
+    const file = await writeProfileCredentialsFile('cleanup', {
+      accessKeyId: 'AKIA-C',
+      secretAccessKey: 'SECRET-C',
+    });
+    // File exists pre-dispose.
+    await expect(stat(file.hostPath)).resolves.toBeDefined();
+    await file.dispose();
+    // Gone post-dispose.
+    await expect(stat(file.hostPath)).rejects.toThrow();
+  });
+
+  it('dispose() is idempotent (safe to call from concurrent cleanup paths)', async () => {
+    const file = await writeProfileCredentialsFile('idempotent', {
+      accessKeyId: 'AKIA-I',
+      secretAccessKey: 'SECRET-I',
+    });
+    await file.dispose();
+    // Second call must not throw — single-flight cleanup runners +
+    // SIGINT-mid-finally races can both fire dispose simultaneously.
+    await expect(file.dispose()).resolves.toBeUndefined();
+  });
+
+  it('uses the profile name the caller passed (matches handler-side fromIni({ profile }))', async () => {
+    // Real-world case: user passes `--profile my-team-dev`; handler code
+    // has `fromIni({ profile: 'my-team-dev' })`. The INI section header
+    // MUST match exactly or the SDK throws "Profile 'my-team-dev' could
+    // not be found".
+    const file = await writeProfileCredentialsFile('my-team-dev', {
+      accessKeyId: 'A',
+      secretAccessKey: 'B',
+    });
+    try {
+      const body = await readFile(file.hostPath, 'utf8');
+      expect(body.startsWith('[my-team-dev]\n')).toBe(true);
+    } finally {
+      await file.dispose();
+    }
+  });
+});
+
+describe('buildProfileCredentialsDockerArgs', () => {
+  it('returns empty when no file is provided (--profile not set)', () => {
+    expect(buildProfileCredentialsDockerArgs(undefined)).toEqual([]);
+  });
+
+  it('emits -v mount + AWS_SHARED_CREDENTIALS_FILE + AWS_PROFILE env when file is provided', () => {
+    const args = buildProfileCredentialsDockerArgs({
+      hostPath: '/tmp/cdkd-profile-creds-xyz/credentials',
+      containerPath: '/cdkd-aws/credentials',
+      profileName: 'dev',
+      dispose: async () => undefined,
+    });
+    expect(args).toEqual([
+      '-v',
+      '/tmp/cdkd-profile-creds-xyz/credentials:/cdkd-aws/credentials:ro',
+      '-e',
+      'AWS_SHARED_CREDENTIALS_FILE=/cdkd-aws/credentials',
+      '-e',
+      'AWS_PROFILE=dev',
+    ]);
+  });
+
+  it('uses :ro suffix on the mount (compromised handler must not tamper with the host file)', () => {
+    const args = buildProfileCredentialsDockerArgs({
+      hostPath: '/host/path',
+      containerPath: '/container/path',
+      profileName: 'p',
+      dispose: async () => undefined,
+    });
+    expect(args[1]).toMatch(/:ro$/);
+  });
+});


### PR DESCRIPTION
## Summary

Deferred follow-up from #655 / #657 / #658 (profile credential forwarding to Lambda containers).

Pre-fix: cdkd forwards `--profile <p>`-resolved credentials to Lambda containers as `AWS_*` environment variables only. Handlers using the SDK's default credential chain (`new SecretsManagerClient({ region })`) work fine. Handlers that explicitly call `fromIni({ profile: '<p>' })` to pin a specific profile **bypass the env-var chain** and look for `[<p>]` in `~/.aws/credentials` (or `AWS_SHARED_CREDENTIALS_FILE`) — which doesn't exist inside the container, so local execution fails.

Post-fix: when `--profile <p>` is set, ALSO synthesize a one-section AWS shared credentials file, bind-mount it read-only into the container, and set `AWS_SHARED_CREDENTIALS_FILE` + `AWS_PROFILE` env vars. Both code paths now converge to the same resolved creds — no handler source changes required.

## Changes

### New helper `src/cli/commands/local-profile-credentials-file.ts`

`writeProfileCredentialsFile(name, creds)` → `{hostPath, containerPath, profileName, dispose}`. Writes a `/tmp/cdkd-profile-creds-*/credentials` file (mode `0o600`) with one `[<name>]` INI section carrying the resolved AKID / SAK / sessionToken? Caller invokes `dispose()` in their cleanup chain (idempotent — safe under concurrent SIGINT / finally races).

Also exports `buildProfileCredentialsDockerArgs(file)` for callers that prefer the formatter shape (kept exported even though the current consumers inline the mount build, so future ECS callers can adopt one canonical shape).

### `src/local/container-pool.ts:ContainerSpecBase`

Adds `profileCredentialsFile?: { hostPath; containerPath }`. Both ZIP and IMAGE branches append `{hostPath, containerPath, readOnly: true}` to `extraMounts` when present. Read-only — a compromised handler must not tamper with the host-side file.

### `src/cli/commands/local-start-api.ts`

Outer-scope `let profileCredsFile: ProfileCredentialsFile | undefined` declared alongside `inlineTmpDirs` / `layerTmpDirs`. Inside `synthesizeAndBuild`, when `--profile` is set AND `profileCredsFile` is not yet assigned (first invocation only — hot reload skips re-writing the file), call `writeProfileCredentialsFile(options.profile, profileCredentials)`. Threaded through `buildContainerSpec` into the per-Lambda spec; disposed in the existing `runCleanup` single-flight at shutdown.

`buildContainerSpec`: when `profileCredsFile` is provided, set `dockerEnv.AWS_SHARED_CREDENTIALS_FILE` + `dockerEnv.AWS_PROFILE` AND set `profileCredentialsFile` on the spec.

### `src/cli/commands/local-invoke.ts`

Outer-scope `let profileCredsFile` declared alongside `containerId` / `stopLogs` / `imagePlan`. Created after `resolveProfileCredentials`; mount appended to `imagePlan.extraMounts` before the `runDetached` call; env vars set in the same `if (!assumeSucceeded)` block as the existing overlay; disposed in the existing `cleanup` single-flight.

## Out of scope

- **ECS** (`local-run-task` / `local-start-service`): same gap exists but `fromIni({ profile })` use inside ECS task containers is rarer (TaskRole is the canonical pattern). Defer until a concrete user case surfaces.
- **`AWS_CONFIG_FILE`** for SSO-derived `fromIni` resolution that requires `~/.aws/config` (e.g. `source_profile` chains): not needed — the resolved temp creds we write are already post-SSO-resolution, so handlers don't re-do the SSO flow.
- **SSO auto-refresh under `--watch`**: the file is written ONCE at server boot. If SSO temp creds expire mid-session, the env-var overlay re-resolves on hot reload but the file does not — `fromIni({ profile })` users get stale creds. Same caveat as the env-var path; SSO auto-refresh is the unified follow-up.

## Test plan

- [x] `vp check --fix` passes (typecheck + lint + format)
- [x] `vp run build` passes
- [x] `vp test` passes — 5883 tests (9 net new)
- [x] New unit tests cover: INI format (with + without sessionToken), file permissions (0o600), idempotent dispose, profile-name fidelity, docker-args formatter (empty + happy + :ro)
- [x] `/run-integ local-invoke` passed — 4/4 (no regression on the no-`--profile` path)
- [x] `/run-integ local-start-api` passed — full smoke test (CORS / authorizer / REST v1 / service-integrations / streaming Function URL); 0 Docker orphans post-run

## Real-world impact

Local development of multi-account / profile-pinned handlers now works without source changes. The default-chain pattern (most handlers) is unaffected.
