### PR TITLE
test(integ): add missing lambda-non-proxy handler for local-start-api-rest-v1-non-proxy

### DIFF
--- a/tests/integration/local-start-api-rest-v1-non-proxy/.gitignore
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/.gitignore
@@ -1,0 +1,3 @@
+# Override the parent integ .gitignore so the Lambda handler source
+# (which must literally be index.js for the Node.js runtime) is tracked.
+!lambda-non-proxy/*.js

--- a/tests/integration/local-start-api-rest-v1-non-proxy/lambda-non-proxy/index.js
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/lambda-non-proxy/index.js
@@ -1,0 +1,4 @@
+exports.handler = async (event) => {
+  const name = event && typeof event.name === 'string' && event.name.length > 0 ? event.name : 'world';
+  return { greeting: `Hello, ${name}` };
+};


### PR DESCRIPTION
## Summary

- Add `tests/integration/local-start-api-rest-v1-non-proxy/lambda-non-proxy/index.js` (a minimal CommonJS handler returning `{ greeting: "Hello, <name>" }`).
- Add a per-fixture `.gitignore` with `!lambda-non-proxy/*.js` so the handler is tracked, matching the convention used by every other Node-handler fixture in this repo (`local-invoke/.gitignore`, `local-start-api/.gitignore`, etc.).

## Why

PR #505 / issue #457 (2026-05-22) introduced the `local-start-api-rest-v1-non-proxy/` fixture but never committed the asset directory referenced by the stack (`lambda.Code.fromAsset(path.join(__dirname, '../lambda-non-proxy'))` at [`lib/local-start-api-rest-v1-non-proxy-stack.ts:47`](../tree/main/tests/integration/local-start-api-rest-v1-non-proxy/lib/local-start-api-rest-v1-non-proxy-stack.ts#L47)). Root cause: the parent `tests/integration/.gitignore` un-conditionally excludes `*.js` (treating them as TS build artifacts), and every Node-handler fixture must override via its own `.gitignore` with `!<dir>/*.js`. This fixture was missing BOTH the override file and the handler source, so synth has errored with `«CannotFindAsset» Cannot find asset at .../lambda-non-proxy` since the fixture landed. The integ has therefore never been runnable end-to-end against real Docker.

The handler contract is dictated by the REST v1 non-AWS_PROXY integration shape: the request template synthesizes `{action, name}`, and the response template wraps `$input.json("$.greeting")` into `{"data": <value>}`. The minimal handler returns `{ greeting: "Hello, <name>" }`, which the response template shapes into `{"data": "Hello, Alice"}` — exactly what `verify.sh` asserts.

The same fix landed in [`cdk-local#11`](https://github.com/go-to-k/cdk-local/pull/11) (merged 2026-05-27); this PR is the cdkd-side counterpart.

## Test plan

- [x] `/run-integ local-start-api-rest-v1-non-proxy` PASS — all 4 routes (MOCK 200 / MOCK 404 / HTTP_PROXY tolerant / POST /aws-lambda) returned the expected status and body.
- [x] Docker `cdkd-local-*` container + network sweep clean (0 orphans).
- [x] `integ-local` markgate marker refreshed.
- [ ] CI green.

## Related

- cdk-local PR #11 (this fix's mirror in the cdk-local package; merged earlier today).
- cdkd PR #505 / issue #457 (the originating PR whose missing handler this corrects).
- Memory rule `feedback_lambda_fixture_gitignore_handler_pair.md` captures the pattern for future fixture-scaffolding work.
