### PR TITLE
docs(readme): add orphan and export examples to Usage block

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,12 @@ cdkd drift MyStack --revert --yes   # AWS ← state
 # Asset / destroy / unlock
 cdkd publish-assets                 # synth + upload only (typical CI split)
 cdkd destroy MyStack
+cdkd orphan MyStack/MyBucket        # drop one resource from state (AWS resource stays)
 cdkd force-unlock MyStack           # clear stale lock from an interrupted deploy
 
-# Adopt existing AWS resources into cdkd state
-cdkd import MyStack --yes
+# Migrate between cdkd and CloudFormation
+cdkd import MyStack --yes           # adopt existing AWS resources into cdkd state
+cdkd export MyStack                 # hand a cdkd-managed stack back to CloudFormation
 
 # State-bucket-only commands (no CDK app needed)
 cdkd state info                     # bucket name, region, schema version


### PR DESCRIPTION
## Summary

- `README.md` Usage example block had `publish-assets` but no `orphan` / `export` entries even though both are top-level commands with their own README sections later. Add one example each so the quick-scan block matches the full command surface.
- Rename the trailing block header from "Adopt existing AWS resources into cdkd state" to "Migrate between cdkd and CloudFormation" since both directions (import + export) now live there.

## Test plan

- [x] `vp run typecheck` / `vp run lint` / `vp run build` / `vp run test` (5911 tests) all green.
- [x] Verified `cdkd orphan` / `cdkd export` / `cdkd publish-assets` appear in `node dist/cli.js --help` output.
- [x] Each example matches the syntax already documented in the dedicated README sections (`cdkd orphan <constructPath>...` and `cdkd export MyStack`).
