### PR TITLE
feat(local): mirror cdk-local start-api UX (env-vars display path + multi-stack --from-cfn-stack inference + bare-form docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,11 @@ bind-mounted at `/opt`.
 cdkd local start-api                                 # one HTTP server per discovered API
 cdkd local start-api MyStack/MyHttpApi --watch       # filter + hot reload
 cdkd local start-api --from-state                    # OR --from-cfn-stack
+
+# Typical shape — the bare `--from-cfn-stack` flag auto-resolves to the
+# routed stack's name (here `MyStack`). Pass an explicit value only when
+# the deployed CFn stack name differs from the CDK stack name.
+cdkd local start-api MyStack/MyHttpApi --from-cfn-stack
 ```
 
 REST v1 + HTTP API v2 + Function URL with all integration kinds

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -33,7 +33,12 @@ Shared across all three subcommands:
   to iterate faster.
 - `--env-vars <file>` — SAM-compatible JSON override:
   `{"LogicalId":{"KEY":"VALUE"}, "Parameters":{...}}`. `null` clears a
-  key.
+  key. For Lambda (`local invoke` / `local start-api`) the function-specific
+  key may also be a **CDK display path** (`MyStack/MyHandler` — the same
+  form `cdkd local invoke <target>` accepts), matched against the
+  resource's `Metadata['aws:cdk:path']`. Logical-ID and display-path
+  entries coexist; if both list the same key, the later JSON entry wins
+  (matches SAM's apply-in-order semantics).
 - `--no-pull` — Skip `docker pull` (per-command semantics differ;
   consult each section).
 - `--from-state` — Resolve intrinsic-valued properties against cdkd's
@@ -115,7 +120,7 @@ in the resolved stack so the user can copy/paste a valid one.
 | --- | --- | --- |
 | `-e, --event <file>` | `{}` | JSON event payload file. |
 | `--event-stdin` | off | Read event JSON from stdin (mutually exclusive with `--event`). |
-| `--env-vars <file>` | — | JSON env-var overrides, SAM-compatible shape: `{"LogicalId":{"KEY":"VALUE"}}` plus an optional top-level `"Parameters"` block applied to every invoke. `null` clears a key. |
+| `--env-vars <file>` | — | JSON env-var overrides, SAM-compatible shape: `{"LogicalId":{"KEY":"VALUE"}}` plus an optional top-level `"Parameters"` block applied to every invoke. `null` clears a key. The function-specific key may also be a **CDK display path** (`MyStack/MyHandler` — same form `cdkd local invoke <target>` accepts). Both forms coexist; later JSON entry wins on conflict (SAM apply-in-order). |
 | `--no-pull` | off | Skip `docker pull`. Semantics differ by code path: **ZIP Lambdas** — skip pulling the public Lambda base image. **Container Lambdas, local-build path** — no-op (docker build's default does not refresh the FROM cache). **Container Lambdas, ECR-pull fallback** — skip `docker pull` AND error if the image is not in the local cache (re-run without `--no-pull` or pre-pull manually). |
 | `--no-build` | off | Skip `docker build` on the **Container Lambdas, local-build path** (`Code.ImageUri`). Requires the deterministic `cdkd-local-invoke-<hash>` tag to already be in the local docker registry from a prior `cdkd local invoke` (or manual `docker build`); errors clearly when missing. **No-op for ZIP Lambdas** (no docker build runs there) AND for the **Container Lambdas, ECR-pull fallback** (use `--no-pull` to control that path). Compatible with `--no-pull`. |
 | `--ecr-role-arn <arn>` | — | Role ARN to assume before authenticating against ECR on the **Container Lambdas, ECR-pull fallback** path. Issues `sts:AssumeRole` via the default credential chain and uses the resulting temp creds for `ecr:GetAuthorizationToken` + `docker pull`. Required for cross-account pulls when the caller's identity does not already have direct cross-account access. Same-account / same-region pulls do not need this flag; cross-account without the flag falls back to the caller's credentials (succeeds when an IAM resource policy on the ECR repo grants the caller directly, else AWS surfaces `AccessDenied`). No-op when `--no-pull` is set. |
@@ -596,18 +601,18 @@ the same tier; cdkd uses literal-segment count as a heuristic).
 | `--port <port>` | auto-allocate | First API server's port (subsequent APIs get `port+1`, `port+2`, ...). Pass `0` (default) to auto-allocate each. The actual port assignment is printed at startup. |
 | `--host <host>` | `127.0.0.1` | Bind address. |
 | `--api <id>` | unset | **Deprecated** — use the positional `<target>` argument instead. Same accepted forms (bare logical id, stack-qualified, Construct path, ancestor prefix). Emits a deprecation warn on use. Mutually exclusive with the positional `<target>` — passing both produces an error. Will be removed in a future major release. |
-| `--stack <name>` | single-stack auto-detect | Required when the app has multiple stacks. |
+| `--stack <name>` | single-stack auto-detect | Required when the app has multiple stacks AND no other selector identifies the target. In multi-stack apps the synth stack is picked from the first match of: (1) `--stack <name>`, (2) `--from-cfn-stack <explicit-name>`, (3) the positional target's stack-name prefix (e.g. `MyStack/MyApi` → `MyStack`). |
 | `--warm` | off | Pre-start one container per discovered Lambda at server boot. Trades RAM for first-request latency. |
 | `--per-lambda-concurrency <n>` | `2` | Pool size cap per Lambda. Max 4 in v1; above-cap values are clamped with a warn. |
 | `--no-pull` | off | Skip `docker pull`. |
 | `--container-host <host>` | `127.0.0.1` | IP the host uses to bind/probe the RIE port. Must be a numeric IP — `docker run -p <ip>:<port>:8080` rejects hostnames like `host.docker.internal`. |
 | `--debug-port-base <port>` | unset | Allocate a contiguous `--inspect-brk` port range across Lambdas (one per Lambda). |
-| `--env-vars <file>` | unset | SAM-shape JSON: `{"LogicalId":{"KEY":"VALUE"}, "Parameters":{...}}`. Same format as `cdkd local invoke`. |
+| `--env-vars <file>` | unset | SAM-shape JSON: `{"LogicalId":{"KEY":"VALUE"}, "Parameters":{...}}`. Same format as `cdkd local invoke` — the function-specific key may also be a **CDK display path** (`MyStack/MyHandler`). |
 | `--assume-role <arn-or-pair>` | unset | Repeatable. Bare `<arn>` = global default; `<LogicalId>=<arn>` = per-Lambda override. Per-Lambda > global > unset (developer creds passed through). |
 | `--watch` | off | Hot reload: re-synth + re-discover routes when `cdk.out/` or any routed Lambda's asset directory changes. 500ms debounce. Synth failures keep the previous version serving (warn-and-continue, never crashes the server). |
 | `--stage <name>` | first attached | Select an API Gateway Stage by `StageName`. Drives `event.stageVariables` (REST v1 + HTTP API v2). When the override doesn't match any Stage on a given API, that API's routes get `stageVariables: null` and the CLI emits a warn line up front. |
 | `--from-state` | off | Read cdkd S3 state for every routed stack and substitute `Ref` / `Fn::GetAtt` / `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters (`${AWS::AccountId}` / `${AWS::Region}` / `${AWS::Partition}` / `${AWS::URLSuffix}`) in Lambda env vars with the deployed physical IDs / attributes. Off by default — keeps the pre-PR literal-only / warn-and-drop behavior. Mirrors `cdkd local invoke --from-state` and `cdkd local run-task --from-state`. Re-runs against fresh state on every hot-reload firing (`--watch`). State load failures degrade per-stack to warn-and-fall-back so a missing or unreadable state file never aborts the server. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `DescribeStackResources` and substitute `Ref` / `Fn::ImportValue` in Lambda env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). Bare form uses the cdkd stack name per routed stack; pass an explicit value when a single CFn stack should serve every routed stack. **Mutually exclusive with `--from-state`**. `Fn::GetAtt` is warn-and-dropped in v1. Same warn-and-drop semantics as `cdkd local invoke --from-cfn-stack`. |
+| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `DescribeStackResources` and substitute `Ref` / `Fn::ImportValue` in Lambda env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). **The bare form is the typical shape** — `cdkd local start-api MyStack/MyApi --from-cfn-stack` resolves to the routed stack's CDK name (`MyStack` here) per routed stack. Pass an explicit value (`--from-cfn-stack <name>`) only when the deployed CFn stack name differs from the CDK stack name (e.g. CDK's `stackName` prop was overridden); the explicit form is rejected when more than one stack is routed in one invocation. **Mutually exclusive with `--from-state`**. `Fn::GetAtt` is warn-and-dropped in v1. Same warn-and-drop semantics as `cdkd local invoke --from-cfn-stack`. |
 | `--state-bucket <bucket>` | auto | S3 bucket containing cdkd state. Falls back to `CDKD_STATE_BUCKET` env or `cdk.json context.cdkd.stateBucket`, then the default `cdkd-state-{accountId}`. Only used with `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Only used with `--from-state`. |
 | `--stack-region <region>` | auto | Region of the state record to read. Required for `--from-state` when the same stack name has state in multiple regions. Also drives the CFn client region for `--from-cfn-stack`. |

--- a/src/cli/cdk-path.ts
+++ b/src/cli/cdk-path.ts
@@ -16,6 +16,22 @@ export function readCdkPath(resource: TemplateResource): string {
 }
 
 /**
+ * Same lookup as `readCdkPath`, but returns `undefined` instead of an
+ * empty string when no `aws:cdk:path` metadata is present.
+ *
+ * Use this variant when the caller passes the value into APIs whose
+ * contract distinguishes "no path known" from "empty path". For example,
+ * `resolveEnvVars(logicalId, displayPath, ...)` short-circuits the
+ * display-path lookup when `displayPath` is `undefined`, but an empty
+ * string `''` would still hit the loop and could spuriously match a
+ * malformed override key.
+ */
+export function readCdkPathOrUndefined(resource: TemplateResource): string | undefined {
+  const path = readCdkPath(resource);
+  return path === '' ? undefined : path;
+}
+
+/**
  * Build a `Map<cdkPath, logicalId>` from a synthesized template.
  *
  * Used by `cdkd orphan <constructPath>` to translate user-supplied

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -17,6 +17,7 @@ import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
+import { readCdkPathOrUndefined } from '../cdk-path.js';
 import { createLocalStateProvider } from './local-state-source.js';
 import {
   resolveLambdaTarget,
@@ -456,16 +457,21 @@ async function localInvokeCommand(target: string, options: LocalInvokeOptions): 
     // is off) are warned about and dropped; the user can override them via
     // --env-vars (SAM-shape).
     const overrides = readEnvOverridesFile(options.envVars);
-    const envResult = resolveEnvVars(lambda.logicalId, templateEnv, overrides);
+    const lambdaCdkPath = readCdkPathOrUndefined(lambda.resource);
+    const envResult = resolveEnvVars(lambda.logicalId, lambdaCdkPath, templateEnv, overrides);
     for (const key of envResult.unresolved) {
       // The state-resolver already warned for keys it tried + failed on, so
       // suppress the per-key duplicate warn here. The `--env-vars` /
       // wait-for-state hints still fire for the no-flag path, which is the
       // original PR 1 UX.
       if (stateAudit && stateAudit.unresolved.some((u) => u.key === key)) continue;
+      // Prefer the L2 form (`MyStack/MyFn`) in the suggestion since that
+      // matches the README guidance and `cdkd local invoke` target shape;
+      // the resolver's prefix rule accepts either form.
+      const overrideKeyExample = lambdaCdkPath?.replace(/\/Resource$/, '') ?? lambda.logicalId;
       logger.warn(
         `Environment variable ${key} contains a CloudFormation intrinsic and was dropped. ` +
-          `Override it with --env-vars (e.g. {"${lambda.logicalId}":{"${key}":"<literal>"}}), or pass --from-state (cdkd-deployed) / --from-cfn-stack (cdk-deployed) to recover deployed values.`
+          `Override it with --env-vars (e.g. {"${overrideKeyExample}":{"${key}":"<literal>"}}), or pass --from-state (cdkd-deployed) / --from-cfn-stack (cdk-deployed) to recover deployed values.`
       );
     }
 

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -19,6 +19,7 @@ import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
 import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
+import { readCdkPathOrUndefined } from '../cdk-path.js';
 import {
   createLocalStateProvider,
   isCfnFlagPresent,
@@ -373,9 +374,48 @@ async function localStartApiCommand(
     };
     const { stacks } = await synthesizer.synthesize(synthOpts);
 
-    const targetStacks = pickTargetStacks(stacks, options.stack);
+    // When the user passes an explicit `--from-cfn-stack <name>` AND has
+    // not also passed `--stack`, infer the synth target from the CFn
+    // stack name — typical CDK apps deploy each stack under its own
+    // stack-name, so the same value selects the synth target unambiguously.
+    // `--from-cfn-stack` without a value (bare flag => `true`) is left to
+    // the regular single-stack auto-pick path.
+    const cfnStackFallback =
+      typeof options.fromCfnStack === 'string' ? options.fromCfnStack : undefined;
+    // Improvement B: positional target prefix → synth stack inference.
+    // `cdkd local start-api MyStack/MyApi` (no `--stack`, no `--from-cfn-stack`)
+    // extracts `MyStack` from the target's `<StackName>/<construct>`
+    // shape and uses it as a third fallback for stack selection. Targets
+    // without a `/` separator (bare logical id) leave this undefined so
+    // the existing single-stack auto-pick path is untouched.
+    const targetStackPrefix =
+      target?.includes('/') === true ? target.slice(0, target.indexOf('/')) : undefined;
+    const targetStacks = pickTargetStacks(
+      stacks,
+      options.stack,
+      cfnStackFallback,
+      targetStackPrefix
+    );
     if (targetStacks.length === 0) {
-      throw new Error('No stacks matched. Pass --stack <name> or run from a single-stack app.');
+      throw new Error(
+        'No stacks matched. Pass --stack <name> (or --from-cfn-stack <name>) or run from a single-stack app.'
+      );
+    }
+
+    // Improvement A: when the user passed `--from-cfn-stack <explicit>`
+    // AND that value already equals the routed stack's `stackName`, the
+    // explicit value is redundant — the bare-flag form auto-resolves to
+    // the same value. Surface a single info-level tip so the user knows
+    // they can drop the value next time. Skipped on multi-stack runs
+    // (too many edge cases to keep the message useful).
+    const routedStackNames = targetStacks.map((s) => s.stackName);
+    if (
+      shouldEmitFromCfnRedundancyTip(options.fromCfnStack, routedStackNames) &&
+      routedStackNames[0] !== undefined
+    ) {
+      logger.info(
+        `tip: --from-cfn-stack value matches the routed stack name (${routedStackNames[0]}); you can omit the value: \`cdkd local start-api ... --from-cfn-stack\` (bare flag) resolves to the same value.`
+      );
     }
 
     const routes = discoverRoutes(targetStacks);
@@ -1175,10 +1215,27 @@ async function localStartApiCommand(
  * Match the `--stack` pattern (or single-stack auto-detect) to a list
  * of stacks the route-discovery walks. Mirrors the deploy/diff matcher
  * routing rules.
+ *
+ * @internal exported for unit tests.
  */
-function pickTargetStacks(stacks: StackInfo[], pattern: string | undefined): StackInfo[] {
-  if (pattern) {
-    return matchStacks(stacks, [pattern]);
+export function pickTargetStacks(
+  stacks: StackInfo[],
+  pattern: string | undefined,
+  cfnStackFallback?: string,
+  targetFallback?: string
+): StackInfo[] {
+  // Resolution chain (first non-empty wins):
+  //   1. `--stack <pattern>`                            (explicit)
+  //   2. `--from-cfn-stack <explicit-name>`             (PR #44 mirror)
+  //   3. positional target's stack-name prefix          (PR #45 mirror)
+  //      e.g. `cdkd local start-api MyStack/MyApi` infers `MyStack`.
+  //
+  // CDK apps typically deploy each synth stack under its own stack-name,
+  // so any of the three values identifies the synth target unambiguously
+  // without the user having to repeat themselves via `--stack`.
+  const effective = pattern ?? cfnStackFallback ?? targetFallback;
+  if (effective) {
+    return matchStacks(stacks, [effective]);
   }
   if (stacks.length === 1) return stacks;
   if (stacks.length === 0) return [];
@@ -1186,8 +1243,30 @@ function pickTargetStacks(stacks: StackInfo[], pattern: string | undefined): Sta
   // its routes — but for v1 we require an explicit selection so users
   // don't accidentally serve a side-stack's API.
   throw new Error(
-    `Multi-stack app: pass --stack <name> to pick a target. Available stacks: ${stacks.map((s) => s.stackName).join(', ')}.`
+    `Multi-stack app: pass --stack <name>, --from-cfn-stack <name>, or a stack-qualified target like "<StackName>/<construct>" to pick a target. Available stacks: ${stacks.map((s) => s.stackName).join(', ')}.`
   );
+}
+
+/**
+ * Decide whether the `--from-cfn-stack <name>` redundancy tip should
+ * fire for the current invocation. Fires only when:
+ *  - `fromCfnStack` is a non-empty STRING (explicit value, not bare `true`)
+ *  - exactly ONE stack is routed
+ *  - the explicit value equals the routed stack's `stackName`
+ *
+ * Extracted as a pure function so it can be unit-tested without booting
+ * the full server. See improvement A in the start-api UX PR.
+ *
+ * @internal exported for unit tests.
+ */
+export function shouldEmitFromCfnRedundancyTip(
+  fromCfnStack: string | boolean | undefined,
+  routedStackNames: readonly string[]
+): boolean {
+  if (typeof fromCfnStack !== 'string') return false;
+  if (fromCfnStack.length === 0) return false;
+  if (routedStackNames.length !== 1) return false;
+  return fromCfnStack === routedStackNames[0];
 }
 
 /**
@@ -1526,7 +1605,8 @@ async function buildContainerSpec(args: {
       );
     }
   }
-  const envResult = resolveEnvVars(logicalId, templateEnv, overrides);
+  const lambdaCdkPath = readCdkPathOrUndefined(lambda.resource);
+  const envResult = resolveEnvVars(logicalId, lambdaCdkPath, templateEnv, overrides);
   for (const key of envResult.unresolved) {
     // The state-resolver already warned for keys it tried + failed on
     // (defensive: substituteEnvVarsFromState drops unresolved keys from
@@ -1534,9 +1614,13 @@ async function buildContainerSpec(args: {
     // `cdkd local invoke --from-state`'s safety dedupe in case the
     // state-resolver evolves).
     if (stateAudit && stateAudit.unresolved.some((u) => u.key === key)) continue;
+    // Prefer the L2 form (`MyStack/MyFn`) in the suggestion since that
+    // matches the README guidance and `cdkd local invoke` target shape;
+    // the resolver's prefix rule accepts either form.
+    const overrideKeyExample = lambdaCdkPath?.replace(/\/Resource$/, '') ?? logicalId;
     getLogger().warn(
       `Lambda ${logicalId}: env var ${key} contains a CloudFormation intrinsic and was dropped. ` +
-        `Override it with --env-vars (e.g. {"${logicalId}":{"${key}":"<literal>"}}) ` +
+        `Override it with --env-vars (e.g. {"${overrideKeyExample}":{"${key}":"<literal>"}}) ` +
         `or pass --from-state to recover deployed values.`
     );
   }

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -344,6 +344,14 @@ async function localStartApiCommand(
   // `defaultCredentialsLoader` for the caching contract.
   let sigV4CredentialsLoader: CredentialsLoader | undefined;
   const sigV4WarnedForeignIds = new Set<string>();
+  // One-shot guard for the `--from-cfn-stack <name>` redundancy tip
+  // (improvement A). `synthesizeAndBuild` runs on every `--watch` hot
+  // reload firing, so without this flag the tip would re-emit on every
+  // reload — noisy. The flag flips on the first emission and stays
+  // `true` for the rest of the server lifetime; subsequent reloads see
+  // the gate and skip the emission. Per-`localStartApiCommand`-invocation
+  // (new server boot starts with a fresh `false`).
+  const fromCfnTipEmitted: { value: boolean } = { value: false };
 
   /**
    * One synth + discover + build pass. Returns the next-state
@@ -408,15 +416,21 @@ async function localStartApiCommand(
     // the same value. Surface a single info-level tip so the user knows
     // they can drop the value next time. Skipped on multi-stack runs
     // (too many edge cases to keep the message useful).
+    //
+    // `synthesizeAndBuild` re-runs on every `--watch` hot reload firing,
+    // so the emission is gated by `fromCfnTipEmitted.value` (one-shot per
+    // server lifetime) — see `tryEmitFromCfnRedundancyTipOnce`.
     const routedStackNames = targetStacks.map((s) => s.stackName);
-    if (
-      shouldEmitFromCfnRedundancyTip(options.fromCfnStack, routedStackNames) &&
-      routedStackNames[0] !== undefined
-    ) {
-      logger.info(
-        `tip: --from-cfn-stack value matches the routed stack name (${routedStackNames[0]}); you can omit the value: \`cdkd local start-api ... --from-cfn-stack\` (bare flag) resolves to the same value.`
-      );
-    }
+    tryEmitFromCfnRedundancyTipOnce(
+      options.fromCfnStack,
+      routedStackNames,
+      fromCfnTipEmitted,
+      (routedStackName) => {
+        logger.info(
+          `tip: --from-cfn-stack value matches the routed stack name (${routedStackName}); you can omit the value: \`cdkd local start-api ... --from-cfn-stack\` (bare flag) resolves to the same value.`
+        );
+      }
+    );
 
     const routes = discoverRoutes(targetStacks);
     // #462: WebSocket APIs (ProtocolType: 'WEBSOCKET') are discovered
@@ -1267,6 +1281,39 @@ export function shouldEmitFromCfnRedundancyTip(
   if (fromCfnStack.length === 0) return false;
   if (routedStackNames.length !== 1) return false;
   return fromCfnStack === routedStackNames[0];
+}
+
+/**
+ * One-shot wrapper around `shouldEmitFromCfnRedundancyTip` for the
+ * `--watch` hot-reload path. `synthesizeAndBuild` re-runs on every
+ * reload firing, so without a gate the tip would re-emit on every
+ * reload — noisy. This helper consults the caller-supplied ref:
+ *  - If the predicate fires AND the ref is still `false`, calls `emit`
+ *    and flips the ref to `true`.
+ *  - On subsequent invocations the ref is `true` and the helper is a
+ *    no-op for the rest of the ref's lifetime.
+ *  - When the predicate does NOT fire (no `--from-cfn-stack` value /
+ *    intentionally-different value / multi-stack run), the ref stays
+ *    `false` so a future reload whose synthesized stacks change in a
+ *    way that DOES make the value redundant still emits the tip once.
+ *
+ * The ref is owned by `localStartApiCommand` (one per server boot), so
+ * independent server invocations get independent flags.
+ *
+ * @internal exported for unit tests.
+ */
+export function tryEmitFromCfnRedundancyTipOnce(
+  fromCfnStack: string | boolean | undefined,
+  routedStackNames: readonly string[],
+  emittedRef: { value: boolean },
+  emit: (routedStackName: string) => void
+): void {
+  if (emittedRef.value) return;
+  if (!shouldEmitFromCfnRedundancyTip(fromCfnStack, routedStackNames)) return;
+  const routedStackName = routedStackNames[0];
+  if (routedStackName === undefined) return;
+  emit(routedStackName);
+  emittedRef.value = true;
 }
 
 /**

--- a/src/local/env-resolver.ts
+++ b/src/local/env-resolver.ts
@@ -10,17 +10,24 @@
  * variable is **dropped** rather than silently substituted with garbage
  * (a bad env var that "exists" is harder to debug than one that's missing).
  *
- * `--env-vars <file>` overrides match SAM's shape (D5):
+ * `--env-vars <file>` overrides match SAM's shape (D5), with the
+ * additional CDK ergonomics that a function-specific entry can be keyed
+ * by either the CloudFormation logical ID or the CDK display path
+ * (`Metadata['aws:cdk:path']`):
  *
  *   {
  *     "Parameters":           { "GLOBAL_KEY": "value" },
- *     "MyHandlerLogicalId":   { "FUNCTION_KEY": "value" }
+ *     "MyHandlerLogicalId":   { "FUNCTION_KEY": "value" },
+ *     "MyStack/MyHandler":    { "FUNCTION_KEY": "value" }
  *   }
  *
  * Override merge order (lowest to highest priority):
  *   1. Template literal env vars
  *   2. `Parameters` (global, applied to every invoke)
- *   3. Function-specific entry keyed by logical ID
+ *   3. Function-specific entries (logical-ID or display-path keyed)
+ *      applied in JSON insertion order, so a later key wins on conflict.
+ *      This matches SAM's apply-in-order semantics; pick one form per
+ *      function to avoid surprises.
  *
  * The override file may also clear a variable by setting it to `null`
  * (matches SAM behavior).
@@ -36,8 +43,11 @@ export interface EnvResolutionResult {
 export interface EnvOverrideFile {
   /** Variables applied to every function invocation. */
   Parameters?: Record<string, string | null>;
-  /** Function-specific overrides keyed by logical ID. */
-  [logicalId: string]: Record<string, string | null> | undefined;
+  /**
+   * Function-specific overrides keyed by either the CloudFormation
+   * logical ID or the CDK display path (`Metadata['aws:cdk:path']`).
+   */
+  [logicalIdOrDisplayPath: string]: Record<string, string | null> | undefined;
 }
 
 /**
@@ -46,6 +56,15 @@ export interface EnvOverrideFile {
  * @param logicalId         The function's CloudFormation logical ID. Used
  *                          to look up function-specific overrides in the
  *                          `--env-vars` file.
+ * @param displayPath       The function's CDK display path
+ *                          (`Metadata['aws:cdk:path']`, e.g.
+ *                          `"MyStack/MyHandler"`), or `undefined` when
+ *                          the resource has no path metadata. Display-path
+ *                          keys in the override file are matched against
+ *                          this value in addition to `logicalId`. Pass
+ *                          `undefined` rather than the logical ID when no
+ *                          path is known, so the override lookup does not
+ *                          accidentally double-match the same key.
  * @param templateEnv       The function's `Properties.Environment.Variables`
  *                          object from the synthesized template, or
  *                          `undefined` when the function has no env vars.
@@ -54,6 +73,7 @@ export interface EnvOverrideFile {
  */
 export function resolveEnvVars(
   logicalId: string,
+  displayPath: string | undefined,
   templateEnv: Record<string, unknown> | undefined,
   overrides?: EnvOverrideFile
 ): EnvResolutionResult {
@@ -72,9 +92,28 @@ export function resolveEnvVars(
 
   if (overrides) {
     applyOverrideMap(resolved, overrides.Parameters);
-    const fnOverrides = overrides[logicalId];
-    if (fnOverrides && typeof fnOverrides === 'object') {
-      applyOverrideMap(resolved, fnOverrides);
+    // Iterate non-Parameters keys in JSON insertion order so a
+    // logical-ID + display-path collision applies later-wins (SAM-compat).
+    //
+    // Display-path matching mirrors the prefix rule the rest of cdkd
+    // uses for `cdkd local invoke <target>` (`src/cli/cdk-path.ts`
+    // `resolveCdkPathToLogicalIds`): an override key matches when the
+    // resource's `aws:cdk:path` is exactly that key OR starts with
+    // `key + "/"`. That lets a user write `MyStack/MyFn` (the L2 form
+    // they read from CDK app code, same form `cdkd local invoke`
+    // accepts) and have it match the synthesized L1 resource at
+    // `MyStack/MyFn/Resource` — without forcing them to look up the
+    // `/Resource` suffix.
+    for (const [key, val] of Object.entries(overrides)) {
+      if (key === 'Parameters') continue;
+      if (!val || typeof val !== 'object') continue;
+      if (key === logicalId) {
+        applyOverrideMap(resolved, val);
+        continue;
+      }
+      if (displayPath && (displayPath === key || displayPath.startsWith(`${key}/`))) {
+        applyOverrideMap(resolved, val);
+      }
     }
   }
 

--- a/tests/integration/local-invoke/verify.sh
+++ b/tests/integration/local-invoke/verify.sh
@@ -35,7 +35,7 @@ echo "==> Synthesizing fixture CDK app"
 ${CDKD} synth >/dev/null
 
 # Test 1 — asset-backed Lambda echoes event + env var
-echo "==> [1/4] Invoking EchoHandler with default empty event"
+echo "==> [1/5] Invoking EchoHandler with default empty event"
 RESULT_1=$(${CDKD} local invoke CdkdLocalInvokeFixture/EchoHandler --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_1}"
 echo "${RESULT_1}" | grep -q '"greeting":"hello"' || {
@@ -44,7 +44,7 @@ echo "${RESULT_1}" | grep -q '"greeting":"hello"' || {
 }
 
 # Test 2 — event payload via --event
-echo "==> [2/4] Invoking EchoHandler with --event payload"
+echo "==> [2/5] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
@@ -55,12 +55,12 @@ echo "${RESULT_2}" | grep -q '"key":"value"' || {
   exit 1
 }
 
-# Test 3 — --env-vars override
-echo "==> [3/4] Invoking EchoHandler with --env-vars override"
+# Test 3 — --env-vars override (Parameters)
+echo "==> [3/5] Invoking EchoHandler with --env-vars Parameters block"
 ENV_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}"' EXIT
-# Logical ID is what the CDK construct synthesizes to. Use a wildcard
-# Parameters block so the test doesn't break if the L1 logical ID changes.
+# Use a wildcard `Parameters` block so the test doesn't break if the
+# L1 logical ID changes.
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
 RESULT_3=$(${CDKD} local invoke CdkdLocalInvokeFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_3}"
@@ -69,17 +69,31 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
   exit 1
 }
 
-# Test 4 — inline (Code.ZipFile) Lambda
-echo "==> [4/4] Invoking InlineHandler (Code.ZipFile)"
-INLINE_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${INLINE_EVENT}"' EXIT
-echo '{"hi":"there"}' > "${INLINE_EVENT}"
-RESULT_4=$(${CDKD} local invoke CdkdLocalInvokeFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
+# Test 4 — --env-vars function-specific key by display path
+echo "==> [4/5] Invoking EchoHandler with --env-vars display-path key"
+DP_ENV_FILE=$(mktemp)
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${DP_ENV_FILE}"' EXIT
+# The display-path key matches `Metadata['aws:cdk:path']` — i.e. the
+# same form `cdkd local invoke <target>` already accepts.
+echo '{"CdkdLocalInvokeFixture/EchoHandler":{"GREETING":"path-key-overridden"}}' > "${DP_ENV_FILE}"
+RESULT_4=$(${CDKD} local invoke CdkdLocalInvokeFixture/EchoHandler --env-vars "${DP_ENV_FILE}" --no-pull 2>/dev/null | tail -1)
 echo "    response: ${RESULT_4}"
-echo "${RESULT_4}" | grep -q '"inlineEcho":{"hi":"there"}' || {
-  echo "FAIL: expected inlineEcho={hi:there}, got: ${RESULT_4}"
+echo "${RESULT_4}" | grep -q '"greeting":"path-key-overridden"' || {
+  echo "FAIL: expected greeting=path-key-overridden, got: ${RESULT_4}"
+  exit 1
+}
+
+# Test 5 — inline (Code.ZipFile) Lambda
+echo "==> [5/5] Invoking InlineHandler (Code.ZipFile)"
+INLINE_EVENT=$(mktemp)
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${DP_ENV_FILE}" "${INLINE_EVENT}"' EXIT
+echo '{"hi":"there"}' > "${INLINE_EVENT}"
+RESULT_5=$(${CDKD} local invoke CdkdLocalInvokeFixture/InlineHandler --event "${INLINE_EVENT}" --no-pull 2>/dev/null | tail -1)
+echo "    response: ${RESULT_5}"
+echo "${RESULT_5}" | grep -q '"inlineEcho":{"hi":"there"}' || {
+  echo "FAIL: expected inlineEcho={hi:there}, got: ${RESULT_5}"
   exit 1
 }
 
 echo ""
-echo "==> All 4 local-invoke tests passed"
+echo "==> All 5 local-invoke tests passed"

--- a/tests/unit/cli/local-start-api-pick-target-stacks.test.ts
+++ b/tests/unit/cli/local-start-api-pick-target-stacks.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vite-plus/test';
+import { describe, expect, it, vi } from 'vite-plus/test';
 import {
   pickTargetStacks,
   shouldEmitFromCfnRedundancyTip,
+  tryEmitFromCfnRedundancyTipOnce,
 } from '../../../src/cli/commands/local-start-api.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 
@@ -110,5 +111,78 @@ describe('shouldEmitFromCfnRedundancyTip', () => {
 
   it('does not fire when no stack is routed', () => {
     expect(shouldEmitFromCfnRedundancyTip('MyStack', [])).toBe(false);
+  });
+});
+
+describe('tryEmitFromCfnRedundancyTipOnce', () => {
+  it('emits once and flips the ref to true on the first redundant invocation', () => {
+    const emit = vi.fn();
+    const ref = { value: false };
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], ref, emit);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith('MyStack');
+    expect(ref.value).toBe(true);
+  });
+
+  it('skips subsequent redundant invocations once the ref is true (--watch hot-reload re-run)', () => {
+    const emit = vi.fn();
+    const ref = { value: false };
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], ref, emit);
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], ref, emit);
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], ref, emit);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(ref.value).toBe(true);
+  });
+
+  it('leaves the ref false on a non-redundant invocation and fires later when conditions become redundant', () => {
+    const emit = vi.fn();
+    const ref = { value: false };
+    // First call: --from-cfn-stack absent → predicate returns false, ref stays false.
+    tryEmitFromCfnRedundancyTipOnce(undefined, ['MyStack'], ref, emit);
+    expect(emit).not.toHaveBeenCalled();
+    expect(ref.value).toBe(false);
+    // Later (e.g. user restarts the server with --from-cfn-stack <name> and
+    // the synth resolves to the same stack name) the predicate fires and
+    // the helper emits its one-shot tip.
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], ref, emit);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(ref.value).toBe(true);
+  });
+
+  it('does not fire when the explicit value differs from the routed stack name (intentional different CFn stack)', () => {
+    const emit = vi.fn();
+    const ref = { value: false };
+    tryEmitFromCfnRedundancyTipOnce('OtherStack', ['MyStack'], ref, emit);
+    tryEmitFromCfnRedundancyTipOnce('OtherStack', ['MyStack'], ref, emit);
+    expect(emit).not.toHaveBeenCalled();
+    expect(ref.value).toBe(false);
+  });
+
+  it('does not fire on multi-stack runs (out of scope)', () => {
+    const emit = vi.fn();
+    const ref = { value: false };
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack', 'Other'], ref, emit);
+    expect(emit).not.toHaveBeenCalled();
+    expect(ref.value).toBe(false);
+  });
+
+  it('uses independent flags for independent server invocations (each localStartApiCommand call gets a fresh ref)', () => {
+    // Two independent refs model two independent `localStartApiCommand`
+    // invocations (e.g. user Ctrl+Cs the first server and boots a second).
+    // The first server's emission must not bleed into the second's gate.
+    const refA = { value: false };
+    const refB = { value: false };
+    const emitA = vi.fn();
+    const emitB = vi.fn();
+    // First server: emits and flips its own ref.
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], refA, emitA);
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], refA, emitA);
+    expect(emitA).toHaveBeenCalledTimes(1);
+    expect(refA.value).toBe(true);
+    // Second server: independent ref → starts at false, still emits once.
+    expect(refB.value).toBe(false);
+    tryEmitFromCfnRedundancyTipOnce('MyStack', ['MyStack'], refB, emitB);
+    expect(emitB).toHaveBeenCalledTimes(1);
+    expect(refB.value).toBe(true);
   });
 });

--- a/tests/unit/cli/local-start-api-pick-target-stacks.test.ts
+++ b/tests/unit/cli/local-start-api-pick-target-stacks.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  pickTargetStacks,
+  shouldEmitFromCfnRedundancyTip,
+} from '../../../src/cli/commands/local-start-api.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+
+function stack(name: string): StackInfo {
+  return {
+    stackName: name,
+    template: { Resources: {} },
+  } as unknown as StackInfo;
+}
+
+describe('pickTargetStacks', () => {
+  const A = stack('A');
+  const B = stack('B');
+
+  describe('single-stack app', () => {
+    it('auto-picks the only stack when --stack is omitted', () => {
+      expect(pickTargetStacks([A], undefined)).toEqual([A]);
+    });
+  });
+
+  describe('--stack pattern (explicit)', () => {
+    it('matches by stack name', () => {
+      expect(pickTargetStacks([A, B], 'A')).toEqual([A]);
+    });
+
+    it('wins over a --from-cfn-stack fallback (CFn fallback only fires when --stack is omitted)', () => {
+      expect(pickTargetStacks([A, B], 'A', 'B')).toEqual([A]);
+    });
+
+    it('wins over both cfnStackFallback AND targetFallback', () => {
+      expect(pickTargetStacks([A, B], 'A', 'B', 'C')).toEqual([A]);
+    });
+
+    it('returns empty when no stack matches the pattern', () => {
+      expect(pickTargetStacks([A, B], 'Other')).toEqual([]);
+    });
+  });
+
+  describe('--from-cfn-stack fallback', () => {
+    it('disambiguates a multi-stack app when its value matches a stack name', () => {
+      expect(pickTargetStacks([A, B], undefined, 'B')).toEqual([B]);
+    });
+
+    it('returns empty when the CFn stack name does not match any synth stack (caller surfaces a clearer error)', () => {
+      expect(pickTargetStacks([A, B], undefined, 'Other')).toEqual([]);
+    });
+
+    it('wins over the targetFallback when both are supplied', () => {
+      expect(pickTargetStacks([A, B], undefined, 'B', 'A')).toEqual([B]);
+    });
+
+    it('is ignored when undefined (bare --from-cfn-stack flag => the regular multi-stack rejection still fires)', () => {
+      expect(() => pickTargetStacks([A, B], undefined, undefined)).toThrowError(
+        /Multi-stack app/
+      );
+    });
+  });
+
+  describe('targetFallback (positional target prefix)', () => {
+    it('selects the stack whose name matches the target prefix', () => {
+      expect(pickTargetStacks([A, B], undefined, undefined, 'A')).toEqual([A]);
+    });
+
+    it('returns empty when the target prefix matches no stack', () => {
+      expect(pickTargetStacks([A, B], undefined, undefined, 'Other')).toEqual([]);
+    });
+
+    it('is ignored when undefined (bare target => the regular single-stack auto-pick path applies)', () => {
+      expect(pickTargetStacks([A], undefined, undefined, undefined)).toEqual([A]);
+    });
+  });
+
+  describe('error message', () => {
+    it('lists every available stack name and mentions all three selection routes', () => {
+      expect(() => pickTargetStacks([A, B], undefined)).toThrowError(
+        /Multi-stack app: pass --stack <name>, --from-cfn-stack <name>, or a stack-qualified target like "<StackName>\/<construct>" to pick a target\. Available stacks: A, B\./
+      );
+    });
+  });
+});
+
+describe('shouldEmitFromCfnRedundancyTip', () => {
+  it('fires when the explicit value equals the single routed stack name', () => {
+    expect(shouldEmitFromCfnRedundancyTip('MyStack', ['MyStack'])).toBe(true);
+  });
+
+  it('does not fire when --from-cfn-stack is bare (true)', () => {
+    expect(shouldEmitFromCfnRedundancyTip(true, ['MyStack'])).toBe(false);
+  });
+
+  it('does not fire when --from-cfn-stack is absent', () => {
+    expect(shouldEmitFromCfnRedundancyTip(undefined, ['MyStack'])).toBe(false);
+  });
+
+  it('does not fire on multi-stack runs (out of scope)', () => {
+    expect(shouldEmitFromCfnRedundancyTip('MyStack', ['MyStack', 'Other'])).toBe(false);
+  });
+
+  it('does not fire when the explicit value differs from the routed stack name (intentional different CFn stack)', () => {
+    expect(shouldEmitFromCfnRedundancyTip('OtherStack', ['MyStack'])).toBe(false);
+  });
+
+  it('does not fire when the explicit value is an empty string', () => {
+    expect(shouldEmitFromCfnRedundancyTip('', ['MyStack'])).toBe(false);
+  });
+
+  it('does not fire when no stack is routed', () => {
+    expect(shouldEmitFromCfnRedundancyTip('MyStack', [])).toBe(false);
+  });
+});

--- a/tests/unit/local/env-resolver.test.ts
+++ b/tests/unit/local/env-resolver.test.ts
@@ -1,73 +1,229 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { resolveEnvVars } from '../../../src/local/env-resolver.js';
+import { resolveEnvVars, type EnvOverrideFile } from '../../../src/local/env-resolver.js';
+
+const LOGICAL = 'MyHandler1234ABCD';
+// The full L1 form CDK encodes into `Metadata['aws:cdk:path']`.
+const L1_PATH = 'MyStack/MyHandler/Resource';
+// The L2 construct path the user actually reads from CDK app code, and
+// the same form `cdkd local invoke` accepts as a target.
+const L2_PATH = 'MyStack/MyHandler';
+const L1_NESTED_PATH = 'MyStack/Nested/MyHandler/Resource';
+const L2_NESTED_PATH = 'MyStack/Nested/MyHandler';
 
 describe('resolveEnvVars', () => {
-  it('returns empty result when the function has no Environment.Variables', () => {
-    expect(resolveEnvVars('Handler', undefined)).toEqual({ resolved: {}, unresolved: [] });
-  });
-
-  it('keeps literal string / number / boolean values', () => {
-    const result = resolveEnvVars('Handler', { A: 'a', B: 42, C: true });
-    expect(result.resolved).toEqual({ A: 'a', B: '42', C: 'true' });
-    expect(result.unresolved).toEqual([]);
-  });
-
-  it('drops intrinsic-valued entries and reports them as unresolved', () => {
-    const result = resolveEnvVars('Handler', {
-      LITERAL: 'ok',
-      TABLE: { Ref: 'MyTable' },
-      ARN: { 'Fn::GetAtt': ['MyTable', 'Arn'] },
+  describe('template-only path (no overrides)', () => {
+    it('returns empty result when the function has no Environment.Variables', () => {
+      expect(resolveEnvVars('Handler', undefined, undefined)).toEqual({
+        resolved: {},
+        unresolved: [],
+      });
     });
-    expect(result.resolved).toEqual({ LITERAL: 'ok' });
-    expect(result.unresolved.sort()).toEqual(['ARN', 'TABLE']);
-  });
 
-  it('applies global Parameters before function-specific overrides', () => {
-    const result = resolveEnvVars(
-      'MyHandler',
-      { LITERAL: 'from-template' },
-      {
-        Parameters: { GLOBAL_ONLY: 'from-global', LITERAL: 'overridden-by-global' },
-        MyHandler: { LITERAL: 'overridden-by-fn', FN_ONLY: 'from-fn' },
-      }
-    );
-    expect(result.resolved).toEqual({
-      LITERAL: 'overridden-by-fn',
-      GLOBAL_ONLY: 'from-global',
-      FN_ONLY: 'from-fn',
+    it('keeps literal string / number / boolean values', () => {
+      const result = resolveEnvVars('Handler', undefined, { A: 'a', B: 42, C: true });
+      expect(result.resolved).toEqual({ A: 'a', B: '42', C: 'true' });
+      expect(result.unresolved).toEqual([]);
+    });
+
+    it('drops intrinsic-valued entries and reports them as unresolved', () => {
+      const result = resolveEnvVars('Handler', undefined, {
+        LITERAL: 'ok',
+        TABLE: { Ref: 'MyTable' },
+        ARN: { 'Fn::GetAtt': ['MyTable', 'Arn'] },
+      });
+      expect(result.resolved).toEqual({ LITERAL: 'ok' });
+      expect(result.unresolved.sort()).toEqual(['ARN', 'TABLE']);
     });
   });
 
-  it('clears a key when override value is null (SAM compatibility)', () => {
-    const result = resolveEnvVars(
-      'MyHandler',
-      { KEY: 'from-template' },
-      { MyHandler: { KEY: null } }
-    );
-    expect(result.resolved).toEqual({});
+  describe('--env-vars: Parameters (global) overlay', () => {
+    it('applies global Parameters before function-specific overrides', () => {
+      const result = resolveEnvVars(
+        'MyHandler',
+        undefined,
+        { LITERAL: 'from-template' },
+        {
+          Parameters: { GLOBAL_ONLY: 'from-global', LITERAL: 'overridden-by-global' },
+          MyHandler: { LITERAL: 'overridden-by-fn', FN_ONLY: 'from-fn' },
+        }
+      );
+      expect(result.resolved).toEqual({
+        LITERAL: 'overridden-by-fn',
+        GLOBAL_ONLY: 'from-global',
+        FN_ONLY: 'from-fn',
+      });
+    });
+
+    it('clears a key when override value is null (SAM compatibility)', () => {
+      const result = resolveEnvVars(
+        'MyHandler',
+        undefined,
+        { KEY: 'from-template' },
+        { MyHandler: { KEY: null } }
+      );
+      expect(result.resolved).toEqual({});
+    });
   });
 
-  it('ignores override entries for other functions', () => {
-    const result = resolveEnvVars(
-      'MyHandler',
-      { KEY: 'a' },
-      { OtherHandler: { KEY: 'should-not-apply' } }
-    );
-    expect(result.resolved).toEqual({ KEY: 'a' });
+  describe('--env-vars: function-specific entry — logical-ID key', () => {
+    it('ignores override entries for other functions', () => {
+      const result = resolveEnvVars(
+        'MyHandler',
+        undefined,
+        { KEY: 'a' },
+        { OtherHandler: { KEY: 'should-not-apply' } }
+      );
+      expect(result.resolved).toEqual({ KEY: 'a' });
+    });
+
+    it('substitutes the template intrinsic with an override when provided', () => {
+      // Common workflow: template has Ref-valued env, user supplies a literal
+      // via --env-vars to make it concrete for local invoke.
+      const result = resolveEnvVars(
+        'MyHandler',
+        undefined,
+        { TABLE_NAME: { Ref: 'MyTable' } },
+        { MyHandler: { TABLE_NAME: 'literal-table' } }
+      );
+      expect(result.resolved).toEqual({ TABLE_NAME: 'literal-table' });
+      // Note: it's still reported as unresolved at the template level so the
+      // caller can decide whether to emit a warning. The override's success
+      // is observable via `resolved`.
+      expect(result.unresolved).toEqual(['TABLE_NAME']);
+    });
   });
 
-  it('substitutes the template intrinsic with an override when provided', () => {
-    // Common workflow: template has Ref-valued env, user supplies a literal
-    // via --env-vars to make it concrete for local invoke.
-    const result = resolveEnvVars(
-      'MyHandler',
-      { TABLE_NAME: { Ref: 'MyTable' } },
-      { MyHandler: { TABLE_NAME: 'literal-table' } }
-    );
-    expect(result.resolved).toEqual({ TABLE_NAME: 'literal-table' });
-    // Note: it's still reported as unresolved at the template level so the
-    // caller can decide whether to emit a warning. The override's success
-    // is observable via `resolved`.
-    expect(result.unresolved).toEqual(['TABLE_NAME']);
+  describe('--env-vars: function-specific entry — display-path key', () => {
+    it('matches the exact L1 metadata path', () => {
+      const overrides: EnvOverrideFile = {
+        [L1_PATH]: { LITERAL: 'fn-specific', FN_ONLY: 'f' },
+      };
+      const result = resolveEnvVars(LOGICAL, L1_PATH, { LITERAL: 'template' }, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'fn-specific', FN_ONLY: 'f' });
+    });
+
+    it('matches the L2 construct path (prefix of the L1 metadata path)', () => {
+      // This is the natural form the user reads from CDK app code and the
+      // same shape `cdkd local invoke` accepts as a target.
+      const overrides: EnvOverrideFile = {
+        [L2_PATH]: { LITERAL: 'fn-specific', FN_ONLY: 'f' },
+      };
+      const result = resolveEnvVars(LOGICAL, L1_PATH, { LITERAL: 'template' }, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'fn-specific', FN_ONLY: 'f' });
+    });
+
+    it('matches a nested-stack L2 construct path', () => {
+      const overrides: EnvOverrideFile = {
+        [L2_NESTED_PATH]: { NESTED_ONLY: 'on' },
+      };
+      const result = resolveEnvVars(LOGICAL, L1_NESTED_PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ NESTED_ONLY: 'on' });
+    });
+
+    it('matches a parent stack path (prefix applies to every function under it)', () => {
+      // Key `MyStack` is a prefix of `MyStack/MyHandler/Resource` so the
+      // override fires; this lets a user set a stack-wide override without
+      // listing every function (same UX as `Parameters` scoped to one
+      // stack).
+      const overrides: EnvOverrideFile = {
+        MyStack: { STACK_WIDE: 'yes' },
+      };
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ STACK_WIDE: 'yes' });
+    });
+
+    it('display-path key with null clears a templateEnv-supplied key', () => {
+      const overrides: EnvOverrideFile = { [L2_PATH]: { LITERAL: null } };
+      const result = resolveEnvVars(
+        LOGICAL,
+        L1_PATH,
+        { LITERAL: 'template', KEEP: 'k' },
+        overrides
+      );
+      expect(result.resolved).toEqual({ KEEP: 'k' });
+    });
+
+    it('does not partial-match within a path segment (no false positive on siblings)', () => {
+      // displayPath `MyStack/MyHandlerBackup/Resource` shares a string
+      // prefix with the key `MyStack/MyHandler`, but the prefix rule
+      // requires a `/` boundary — so this MUST NOT match. Without the
+      // `${key}/` slash boundary `MyHandler` would erroneously match
+      // `MyHandlerBackup`.
+      const overrides: EnvOverrideFile = {
+        [L2_PATH]: { FN_ONLY: 'should-not-apply' },
+      };
+      const result = resolveEnvVars(
+        LOGICAL,
+        'MyStack/MyHandlerBackup/Resource',
+        { LITERAL: 'template' },
+        overrides
+      );
+      expect(result.resolved).toEqual({ LITERAL: 'template' });
+    });
+
+    it('does not match a different display path', () => {
+      const overrides: EnvOverrideFile = {
+        'OtherStack/OtherHandler': { FN_ONLY: 'should-not-apply' },
+      };
+      const result = resolveEnvVars(LOGICAL, L1_PATH, { LITERAL: 'template' }, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'template' });
+    });
+
+    it('skips the display-path lookup when displayPath is undefined', () => {
+      const overrides: EnvOverrideFile = {
+        [L2_PATH]: { FN_ONLY: 'should-not-apply' },
+      };
+      const result = resolveEnvVars(LOGICAL, undefined, { LITERAL: 'template' }, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'template' });
+    });
+  });
+
+  describe('--env-vars: conflict resolution between logical-ID and display-path keys', () => {
+    it('applies later JSON insertion wins (display path after logical ID)', () => {
+      const overrides: EnvOverrideFile = {
+        [LOGICAL]: { LITERAL: 'from-logical-id' },
+        [L2_PATH]: { LITERAL: 'from-display-path' },
+      };
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'from-display-path' });
+    });
+
+    it('applies later JSON insertion wins (logical ID after display path)', () => {
+      const overrides: EnvOverrideFile = {
+        [L2_PATH]: { LITERAL: 'from-display-path' },
+        [LOGICAL]: { LITERAL: 'from-logical-id' },
+      };
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ LITERAL: 'from-logical-id' });
+    });
+
+    it('merges non-conflicting keys from both forms', () => {
+      const overrides: EnvOverrideFile = {
+        [LOGICAL]: { FROM_LOGICAL: 'L' },
+        [L2_PATH]: { FROM_PATH: 'P' },
+      };
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ FROM_LOGICAL: 'L', FROM_PATH: 'P' });
+    });
+  });
+
+  describe('--env-vars: misc', () => {
+    it('ignores non-object entries (loose-shape tolerance)', () => {
+      const overrides = {
+        Parameters: { GLOBAL: 'g' },
+        [LOGICAL]: 'a-string-not-a-map',
+      } as unknown as EnvOverrideFile;
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ GLOBAL: 'g' });
+    });
+
+    it('Parameters layer applies even when no function-specific key matches', () => {
+      const overrides: EnvOverrideFile = {
+        Parameters: { GLOBAL: 'g' },
+        OtherFn99: { FN_ONLY: 'no-match' },
+      };
+      const result = resolveEnvVars(LOGICAL, L1_PATH, undefined, overrides);
+      expect(result.resolved).toEqual({ GLOBAL: 'g' });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Mirrors three recent **cdk-local** UX PRs into cdkd's `src/local/**` and `src/cli/commands/local-*.ts` duplicates (Phase 3 shim-ka is not yet done, so the changes do not auto-follow via library import — manual mirror).

- **PR #41 mirror**: `resolveEnvVars(...)` accepts a `displayPath` arg so `--env-vars` function-specific keys can be either a CloudFormation logical ID (`MyHandler1234ABCD`) OR a CDK display path (`MyStack/MyHandler` — same shape `cdkd local invoke <target>` accepts). Prefix matching uses the same `key + "/"` boundary rule as `src/cli/cdk-path.ts`. New `readCdkPathOrUndefined()` helper in `src/cli/cdk-path.ts`; `local-invoke.ts` + `local-start-api.ts` both thread it through. Logical-ID and display-path entries coexist; later JSON entry wins on conflict (SAM apply-in-order).
- **PR #44 mirror**: `pickTargetStacks` accepts a `cfnStackFallback` — explicit `--from-cfn-stack <name>` (no `--stack`) infers the synth target since CDK apps typically deploy each stack under its own stack-name.
- **PR #45 mirror**: `pickTargetStacks` accepts a 4th `targetFallback` — the positional target's stack-name prefix (e.g. `cdkd local start-api MyStack/MyApi` infers `MyStack`). Resolution chain (first non-empty wins): `--stack` → `--from-cfn-stack <explicit>` → positional target prefix → multi-stack rejection. Also adds `shouldEmitFromCfnRedundancyTip` — fires when explicit `--from-cfn-stack <name>` equals the routed stack name, suggesting the user can drop the value. Multi-stack rejection error text updated to enumerate all three selection routes.

## File diffs

- `src/local/env-resolver.ts` — `resolveEnvVars(logicalId, displayPath, templateEnv, overrides?)` 4-arg signature; insertion-order non-Parameters loop with logical-ID OR display-path prefix match.
- `src/cli/cdk-path.ts` — new exported `readCdkPathOrUndefined(resource)` (returns `undefined` instead of `''` on miss).
- `src/cli/commands/local-invoke.ts` — pass `lambda.resource`'s display path through; warn message's example key prefers the L2 form (strips trailing `/Resource`).
- `src/cli/commands/local-start-api.ts` — display-path threading for env resolution; `pickTargetStacks(...)` 4-arg signature exported; `cfnStackFallback` + `targetStackPrefix` wired at the call site; redundancy tip at server boot; multi-stack rejection text updated.
- `tests/unit/local/env-resolver.test.ts` — extended for the 4-arg signature and the full display-path matrix (exact L1 / L2 prefix / nested / parent / no-false-positive / conflict resolution / undefined displayPath / null-clear / loose-shape tolerance).
- `tests/unit/cli/local-start-api-pick-target-stacks.test.ts` — new file. `pickTargetStacks` 4-arg precedence + full `shouldEmitFromCfnRedundancyTip` truth table.
- `README.md` — start-api block adds the bare `--from-cfn-stack` example.
- `docs/local-emulation.md` — `--env-vars` row + start-api `--stack` / `--from-cfn-stack` rows enumerate the three selection routes and the bare-form-is-typical guidance.

## Per-file deviation from cdk-local

- Error messages use `cdkd local start-api` not `cdkl start-api` (cdkd-specific command name).
- `local-invoke.ts` / `local-start-api.ts` warn messages thread `--from-state` / `--from-cfn-stack` (cdkd's two state-source flags) instead of cdk-local's single `--from-cfn-stack`.
- `docs/cli-reference.md` does NOT get the row update — cdkd's cli-reference.md only carries a pointer to `docs/local-emulation.md` for the `cdkd local *` family, while cdk-local's cli-reference.md duplicates the start-api flag table.
- cdkd's README does not have a standalone "Override env vars" section to update (cdk-local's README has fuller content); the env-vars override guidance lives in `docs/local-emulation.md`.

## Test plan

- [x] `vp run typecheck` — 0 errors
- [x] `vp run lint` — 0 warnings, 0 errors
- [x] `vp run format:check` — clean
- [x] `vp run test` — 5943 passed, 1 skipped (no regressions)
- [x] `vp run build` — clean ESM bundle
- [ ] `/run-integ local-invoke` — verifies the new display-path-key + new warn message wording against a real Docker invoke (refreshes `integ-local` marker)
