### PR TITLE
test: fix verify.sh cleanup to use 'cdkd state destroy --yes' not '--force'

### DIFF
--- a/tests/integration/apigateway/verify.sh
+++ b/tests/integration/apigateway/verify.sh
@@ -34,7 +34,7 @@ cleanup() {
   # should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --force >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true

--- a/tests/integration/cc-api-fallback-transitions/verify.sh
+++ b/tests/integration/cc-api-fallback-transitions/verify.sh
@@ -59,8 +59,8 @@ cleanup() {
   # cleanup should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${OVERRIDE_STACK}" --region "${REGION}" --force >/dev/null 2>&1
-    node "${LOCAL_DIST}" state destroy "${TRANSITION_STACK}" --region "${REGION}" --force >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${OVERRIDE_STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${TRANSITION_STACK}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${OVERRIDE_FN}" --region "${REGION}" >/dev/null 2>&1 || true
   aws lambda delete-function --function-name "${TRANSITION_FN}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/cc-api-fallback/verify.sh
+++ b/tests/integration/cc-api-fallback/verify.sh
@@ -29,7 +29,7 @@ cleanup() {
   # cleanup should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --force >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/dynamodb-ondemand/verify.sh
+++ b/tests/integration/dynamodb-ondemand/verify.sh
@@ -32,7 +32,7 @@ cleanup() {
   # cleanup should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --force >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws dynamodb delete-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/dynamodb-streams/verify.sh
+++ b/tests/integration/dynamodb-streams/verify.sh
@@ -38,7 +38,7 @@ cleanup() {
   # cleanup should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --force >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${TABLE_NAME}" ]; then
     aws dynamodb delete-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/recreate-mixed-direction/verify.sh
+++ b/tests/integration/recreate-mixed-direction/verify.sh
@@ -29,7 +29,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probes"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --force >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FWD_FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   aws lambda delete-function --function-name "${BACK_FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/recreate-via-cc-api/verify.sh
+++ b/tests/integration/recreate-via-cc-api/verify.sh
@@ -37,7 +37,7 @@ cleanup() {
   # cleanup should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --force >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   # Empty + delete the S3 probe bucket if it leaked from a prior run.

--- a/tests/integration/recreate-via-sdk-provider/verify.sh
+++ b/tests/integration/recreate-via-sdk-provider/verify.sh
@@ -34,7 +34,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probe"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --force >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/schema-v5-to-v6-migration/verify.sh
+++ b/tests/integration/schema-v5-to-v6-migration/verify.sh
@@ -43,7 +43,7 @@ cleanup() {
   set +e
   # Try the v6 binary's destroy first (cleanest path).
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --force >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Direct API fallback so a half-deployed AWS resource doesn't leak.
   aws ssm delete-parameter --name "${PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/schema-v6-to-v7-migration/verify.sh
+++ b/tests/integration/schema-v6-to-v7-migration/verify.sh
@@ -43,7 +43,7 @@ cleanup() {
   set +e
   # Try the v7 binary's destroy first (cleanest path).
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --force >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Direct API fallback so a half-deployed AWS resource doesn't leak.
   aws ssm delete-parameter --name "${PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/schema-v7-to-v8-migration/verify.sh
+++ b/tests/integration/schema-v7-to-v8-migration/verify.sh
@@ -52,8 +52,8 @@ cleanup() {
   # producer last — Fn::GetStackOutput is a weak reference so order
   # doesn't strictly matter, but mirrors real-world recommended order.
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${CONSUMER_STACK}" --region "${REGION}" --force >/dev/null 2>&1
-    node "${LOCAL_DIST}" state destroy "${PRODUCER_STACK}" --region "${REGION}" --force >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${CONSUMER_STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${PRODUCER_STACK}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Direct API fallback so a half-deployed AWS resource doesn't leak.
   aws ssm delete-parameter --name "${CONSUMER_PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/serverless-api/verify.sh
+++ b/tests/integration/serverless-api/verify.sh
@@ -47,12 +47,12 @@ cleanup() {
   destroy_rc=0
   if [ -x "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
-      --region "${REGION}" --force >/dev/null 2>&1
+      --region "${REGION}" --yes >/dev/null 2>&1
     destroy_rc=$?
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then
     # Only force-remove the state key when `state destroy` SUCCEEDED. A clean
-    # `state destroy --force` already removes state; a FAILED one must leave
+    # `state destroy --yes` already removes state; a FAILED one must leave
     # state behind so the resources it could not delete are NOT orphaned (and
     # so a retry / diagnosis can still find them). The lock key is always safe
     # to drop so a subsequent run can acquire it.

--- a/tests/integration/sns-sqs-event/verify.sh
+++ b/tests/integration/sns-sqs-event/verify.sh
@@ -37,7 +37,7 @@ cleanup() {
   # should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --force >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Mechanical test-infrastructure fix. The `cdkd state destroy` subcommand accepts `-y` / `--yes` to skip its confirmation prompt — it does NOT accept `--force` (fails with `error: unknown option '--force'`). The top-level `cdkd destroy` accepts BOTH, so the two are easy to conflate.

~13 integ-fixture `verify.sh` cleanup() traps invoked `state destroy ... --force`. The bad flag was masked on the happy path — the error was swallowed by `>/dev/null 2>&1`, and the real teardown is done by each fixture's separate Phase-2 top-level `cdkd destroy ... --force` — so it only bit a FAILED deploy, where the cleanup() trap is the sole cleanup path and could never actually clear the leftover (post-rollback) state. A real-AWS `ci-cd` run surfaced it (that fixture's cleanup line was not redirected, so the error printed loudly). `ci-cd` was fixed in its own PR; this sweep covers the remaining offenders.

16 edits across 13 files: every `node ... state destroy ... --force` becomes `--yes` (15 command lines + 1 now-stale comment in `serverless-api`). No top-level `destroy --force` line was touched (those are valid). No source, test-logic, or changelog change.

## Test plan

- [x] `grep` confirms zero `state destroy ... --force` remain under `tests/integration/`; every remaining `--force` is a top-level `cdkd destroy` / `cdk destroy` invocation (untouched).
- [x] `cdkd state destroy --yes` was already validated end-to-end by the `ci-cd` real-AWS integ (deploy + clean destroy) when that fixture's verify.sh was fixed; this PR applies the identical proven flag mechanically to the rest.
- [x] `/check`: typecheck + lint + build + 5274 tests / 359 files pass.
