### PR TITLE
chore(deps): bump cdk-local to ^0.59.0 + migrate internal imports to cdk-local/internal

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@aws-sdk/client-wafv2": "^3.1017.0",
     "@aws-sdk/s3-request-presigner": "^3.1016.0",
     "archiver": "^7.0.0",
-    "cdk-local": "^0.53.0",
+    "cdk-local": "^0.59.0",
     "chokidar": "^5.0.0",
     "commander": "^12.0.0",
     "graphlib": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@aws-sdk/client-wafv2": "^3.1017.0",
     "@aws-sdk/s3-request-presigner": "^3.1016.0",
     "archiver": "^7.0.0",
-    "cdk-local": "^0.34.0",
+    "cdk-local": "^0.53.0",
     "chokidar": "^5.0.0",
     "commander": "^12.0.0",
     "graphlib": "^2.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,8 +153,8 @@ importers:
         specifier: ^2.0.0
         version: 2.244.0(constructs@10.6.0)
       cdk-local:
-        specifier: ^0.34.0
-        version: 0.34.0(@aws-cdk/cli-plugin-contract@2.182.2)(@aws-cdk/cloud-assembly-schema@53.27.0)(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: ^0.53.0
+        version: 0.53.0(@aws-cdk/cli-plugin-contract@2.182.2)(@aws-cdk/cloud-assembly-schema@53.27.0)(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0)
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -468,6 +468,10 @@ packages:
     resolution: {integrity: sha512-BiGKMjrkAJkyse1ECpVyxVYugf82FB3cM9zgKpx3boFuWobyolG5ri6XjoMIY8fpHddaO8ZClXEedACyelSLWA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-s3@3.1056.0':
+    resolution: {integrity: sha512-WfMZEM2eC96anIT0RzR/QmhaefWKsNjOHNv09ORBkcA++ULBnm1fRau+KKGEIbr5nDnf9BTG7E7U3oOVklQS8g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-s3tables@3.1019.0':
     resolution: {integrity: sha512-ImbGGfVdoaXbFuLaroCLqZWK/ijbK2z7v2kl+ZPjS3tthzRUMeaTed9ztR4SSGpzy8Mvhj53FP0bAutkWJEajw==}
     engines: {node: '>=20.0.0'}
@@ -524,12 +528,20 @@ packages:
     resolution: {integrity: sha512-ppamm04uoj3hhNO5IlQSs5D6rWX1fWkzcn6a4pZrojk8Y6ObY9wzLDdT/Eq3gv6O9hOebi9tYTNB8b8fQj9XJw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.15':
+    resolution: {integrity: sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.974.8':
     resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/crc64-nvme@3.972.5':
     resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.9':
+    resolution: {integrity: sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-cognito-identity@3.972.37':
@@ -556,6 +568,10 @@ packages:
     resolution: {integrity: sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.41':
+    resolution: {integrity: sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.25':
     resolution: {integrity: sha512-qPymamdPcLp6ugoVocG1y5r69ScNiRzb0hogX25/ij+Wz7c7WnsgjLTaz7+eB5BfRxeyUwuw5hgULMuwOGOpcw==}
     engines: {node: '>=20.0.0'}
@@ -574,6 +590,10 @@ packages:
 
   '@aws-sdk/credential-provider-http@3.972.42':
     resolution: {integrity: sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.43':
+    resolution: {integrity: sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.25':
@@ -600,6 +620,10 @@ packages:
     resolution: {integrity: sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.45':
+    resolution: {integrity: sha512-sJe5ZWibO4s7RWjFQ8Zol76KxoJcIYyEZH1/wxQSBMSIAAxzaJ8cS/ITAaIHWUQvDKQdt18+cJAHKWB7n1Jmrg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.25':
     resolution: {integrity: sha512-bUdmyJeVua7SmD+g2a65x2/0YqsGn4K2k4GawI43js0odaNaIzpIhLtHehUnPnfLuyhPWbJR1NyuIO4iMVfM0w==}
     engines: {node: '>=20.0.0'}
@@ -622,6 +646,10 @@ packages:
 
   '@aws-sdk/credential-provider-login@3.972.44':
     resolution: {integrity: sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.45':
+    resolution: {integrity: sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.26':
@@ -648,6 +676,10 @@ packages:
     resolution: {integrity: sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.46':
+    resolution: {integrity: sha512-cS4w0jzDRb1jOlkiJS3y80OxddHzkky/MN9k3NYs5jganNKVLjF0lpvjlwS118oGMr3cdAfOlVdo8gLurTSE7w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.23':
     resolution: {integrity: sha512-IL/TFW59++b7MpHserjUblGrdP5UXy5Ekqqx1XQkERXBFJcZr74I7VaSrQT5dxdRMU16xGK4L0RQ5fQG1pMgnA==}
     engines: {node: '>=20.0.0'}
@@ -666,6 +698,10 @@ packages:
 
   '@aws-sdk/credential-provider-process@3.972.40':
     resolution: {integrity: sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.41':
+    resolution: {integrity: sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.25':
@@ -692,6 +728,10 @@ packages:
     resolution: {integrity: sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.45':
+    resolution: {integrity: sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.25':
     resolution: {integrity: sha512-uM1OtoJgj+yK3MlAmda8uR9WJJCdm5HB25JyCeFL5a5q1Fbafalf4uKidFO3/L0Pgd+Fsflkb4cM6jHIswi3QQ==}
     engines: {node: '>=20.0.0'}
@@ -716,6 +756,10 @@ packages:
     resolution: {integrity: sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-web-identity@3.972.45':
+    resolution: {integrity: sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-providers@3.1054.0':
     resolution: {integrity: sha512-/tK0QmOL1vUqOgqRMLTJlvHRAp+7GTfdPgrfgD5T0WBmExdlaFsVwzR7mUQlmYoY8mExqoRH4UEt2I3snsMLrg==}
     engines: {node: '>=20.0.0'}
@@ -738,6 +782,10 @@ packages:
     peerDependencies:
       '@aws-sdk/client-s3': ^3.1054.0
 
+  '@aws-sdk/middleware-bucket-endpoint@3.972.17':
+    resolution: {integrity: sha512-lbDmWuHenc+kiwCNrxz4MyN6nkxCWyTXPIWuspJN0ibziu+8CXci7vI1bK9MAkwy8cwJOEXNu0gBM5S0uTGRIg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-bucket-endpoint@3.972.8':
     resolution: {integrity: sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==}
     engines: {node: '>=20.0.0'}
@@ -746,8 +794,16 @@ packages:
     resolution: {integrity: sha512-1503Y5Xk14SdXY0ucXwc08CY+aVuoY1tmQxsR/apwAVAwcLT7FFzqjYJYLq8JOkKJyzIB8M6J27e1ZcagGK+Fg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-expect-continue@3.972.14':
+    resolution: {integrity: sha512-3TNFEVGO4sWZj9TEXOCZLzGEctXHnaO4fk2EQ8KVaboTbwHmEPEQrm17Xb9koImUIXEw0sgi2xtHjg7LuTS3rA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-expect-continue@3.972.8':
     resolution: {integrity: sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.23':
+    resolution: {integrity: sha512-4nPKARo2lfKvQGUt2fPA5NlS/mEohckdxpuC9ecbjVfj7B7NFFYHeTg+Bf5BEQwdn3yRfUIzFiEkPp8Yuaw3wA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-flexible-checksums@3.974.5':
@@ -764,6 +820,10 @@ packages:
 
   '@aws-sdk/middleware-host-header@3.972.8':
     resolution: {integrity: sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.11':
+    resolution: {integrity: sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-location-constraint@3.972.8':
@@ -818,8 +878,16 @@ packages:
     resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-s3@3.972.44':
+    resolution: {integrity: sha512-8HQsRg1NpX8vR4vNl1E8pyLnqZroq9VSL2vZQVSgBqp6wv6365LzYD08/c9FFh/9FTg7YRc7aTtEmXF0ir/pqg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-sdk-sqs@3.972.17':
     resolution: {integrity: sha512-LnzPRRoDXGtlFV2G1p2rsY6fRKrbf6Pvvc21KliSLw3+NmQca2+Aa1QIMRbpQvZYedsSqkGYwxe+qvXwQ2uxDw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.11':
+    resolution: {integrity: sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-ssec@3.972.8':
@@ -852,6 +920,10 @@ packages:
 
   '@aws-sdk/nested-clients@3.997.12':
     resolution: {integrity: sha512-Js2VYaCM269feB0cs0cGmlIhdOgT9aMqzdBx68lCy6kVCYfzr0T36ovUFDvfUmatkuBeyBJhCwaLBh7P8meH5Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.13':
+    resolution: {integrity: sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.6':
@@ -898,6 +970,10 @@ packages:
     resolution: {integrity: sha512-Few9FoQqOt/0KSvZYP+qdW0dfOhfQ9N+gl2UUDvCPW6mkPKHli9LMbKxWj+wZ5zKPaOoqxuR3Hhy3OTpndkfSw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.30':
+    resolution: {integrity: sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1018.0':
     resolution: {integrity: sha512-97OPNJHy37wmGOX44xAcu6E9oSTiqK9uPcy/fWpmN5uB3JuEp1f6x60Xot/jp+FxwhQWIFUsVJFnm3QKqt7T6Q==}
     engines: {node: '>=20.0.0'}
@@ -919,7 +995,11 @@ packages:
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1054.0':
-    resolution: {integrity: sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==, tarball: https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1054.0.tgz}
+    resolution: {integrity: sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1056.0':
+    resolution: {integrity: sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.6':
@@ -1942,6 +2022,10 @@ packages:
     resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==, tarball: https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.5':
+    resolution: {integrity: sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.12':
     resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
     engines: {node: '>=18.0.0'}
@@ -1952,6 +2036,10 @@ packages:
 
   '@smithy/credential-provider-imds@4.3.2':
     resolution: {integrity: sha512-iYr9ekBjmZ+FwkiHEopqGscBbl78X62cq3p5Dd0eC+gNd7fybNZFQQdDuOQjTVmFymleuA8YRWZnuXWZ8B3kKA==, tarball: https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.2.tgz}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.5':
+    resolution: {integrity: sha512-yiF8xHpdkaTfzLVqFzsP6WvNghEK+qZzLYWFD13L2SsFhbXwBGlxdocKF95qjr7s5lE5NRage+EJFK4mAsx88Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.12':
@@ -1988,6 +2076,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.4.4':
     resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==, tarball: https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.4.tgz}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.5':
+    resolution: {integrity: sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.13':
@@ -2094,6 +2186,10 @@ packages:
     resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==, tarball: https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.4.tgz}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.5':
+    resolution: {integrity: sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.12':
     resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
     engines: {node: '>=18.0.0'}
@@ -2152,6 +2248,10 @@ packages:
 
   '@smithy/signature-v4@5.4.2':
     resolution: {integrity: sha512-1km1OjdLRFuITWpCPofjFqzZ+tbeWuB72ZhcYjbjkCxZ21tTPfIs4GUxRrelMyKMLxLghGD58RENnXorU/O8cw==, tarball: https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.2.tgz}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.5':
+    resolution: {integrity: sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.12.13':
@@ -2704,8 +2804,8 @@ packages:
   cdk-from-cfn@0.300.0:
     resolution: {integrity: sha512-BtTAthyg3EeBoO0o77A3PMfwID7mvm3R1BvM/avjwfPHbSnt598vv0qGGSZMM0KPM77DB5UtK6/z4VhBto4VJw==}
 
-  cdk-local@0.34.0:
-    resolution: {integrity: sha512-VhLtCcxCaUZjpQ6Fz7KVihzRXDIoKje5PN+lD1wraDYK5MCAawAoeJdF6hR3Co9u0sEPLtQ+fBf5Moo3rQhybw==}
+  cdk-local@0.53.0:
+    resolution: {integrity: sha512-jYAFwWfhjnhcNEHaqb2wOtCBVnFMq7ugBc4krlmjNEvtMyEk6/r0OAeh19B/ygbAXxN0jHs6eOfqA2KprHxD0A==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -3022,6 +3122,9 @@ packages:
 
   fflate@0.8.1:
     resolution: {integrity: sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -6145,6 +6248,27 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-s3@3.1056.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/credential-provider-node': 3.972.46
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.17
+      '@aws-sdk/middleware-expect-continue': 3.972.14
+      '@aws-sdk/middleware-flexible-checksums': 3.974.23
+      '@aws-sdk/middleware-location-constraint': 3.972.11
+      '@aws-sdk/middleware-sdk-s3': 3.972.44
+      '@aws-sdk/middleware-ssec': 3.972.11
+      '@aws-sdk/signature-v4-multi-region': 3.996.30
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/client-s3tables@3.1019.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -6635,6 +6759,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.15':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.26
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.5
+      '@smithy/signature-v4': 5.4.5
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.8':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -6655,6 +6790,11 @@ snapshots:
   '@aws-sdk/crc64-nvme@3.972.5':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.9':
+    dependencies:
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-cognito-identity@3.972.37':
@@ -6702,6 +6842,14 @@ snapshots:
       '@aws-sdk/core': 3.974.14
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -6758,6 +6906,16 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/fetch-http-handler': 5.4.4
       '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -6868,6 +7026,22 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/credential-provider-env': 3.972.41
+      '@aws-sdk/credential-provider-http': 3.972.43
+      '@aws-sdk/credential-provider-login': 3.972.45
+      '@aws-sdk/credential-provider-process': 3.972.41
+      '@aws-sdk/credential-provider-sso': 3.972.45
+      '@aws-sdk/credential-provider-web-identity': 3.972.45
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/credential-provider-imds': 4.3.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.25':
     dependencies:
       '@aws-sdk/core': 3.974.14
@@ -6927,6 +7101,15 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.12
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -7025,6 +7208,20 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.46':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.41
+      '@aws-sdk/credential-provider-http': 3.972.43
+      '@aws-sdk/credential-provider-ini': 3.972.45
+      '@aws-sdk/credential-provider-process': 3.972.41
+      '@aws-sdk/credential-provider-sso': 3.972.45
+      '@aws-sdk/credential-provider-web-identity': 3.972.45
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/credential-provider-imds': 4.3.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.23':
     dependencies:
       '@aws-sdk/core': 3.973.25
@@ -7064,6 +7261,14 @@ snapshots:
       '@aws-sdk/core': 3.974.14
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -7138,6 +7343,16 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/token-providers': 3.1056.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.25':
     dependencies:
       '@aws-sdk/core': 3.973.25
@@ -7203,6 +7418,15 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-web-identity@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-providers@3.1054.0':
     dependencies:
       '@aws-sdk/client-cognito-identity': 3.1054.0
@@ -7255,6 +7479,14 @@ snapshots:
       stream-browserify: 3.0.0
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-bucket-endpoint@3.972.17':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-bucket-endpoint@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -7274,11 +7506,30 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-expect-continue@3.972.14':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-expect-continue@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.23':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/crc64-nvme': 3.972.9
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-flexible-checksums@3.974.5':
@@ -7317,6 +7568,12 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-location-constraint@3.972.8':
@@ -7439,6 +7696,15 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-s3@3.972.44':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/signature-v4-multi-region': 3.996.30
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-sdk-sqs@3.972.17':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -7446,6 +7712,12 @@ snapshots:
       '@smithy/types': 4.13.1
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-ssec@3.972.8':
@@ -7597,6 +7869,19 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.13':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/signature-v4-multi-region': 3.996.30
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/nested-clients@3.997.6':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -7739,6 +8024,13 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.30':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/signature-v4': 5.4.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1018.0':
     dependencies:
       '@aws-sdk/core': 3.974.14
@@ -7795,6 +8087,15 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.12
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1056.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -8649,6 +8950,12 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.5':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.12':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
@@ -8669,6 +8976,12 @@ snapshots:
     dependencies:
       '@smithy/core': 3.24.2
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.12':
@@ -8726,6 +9039,12 @@ snapshots:
   '@smithy/fetch-http-handler@5.4.4':
     dependencies:
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.5':
+    dependencies:
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -8917,6 +9236,12 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
@@ -9003,6 +9328,12 @@ snapshots:
     dependencies:
       '@smithy/core': 3.24.2
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/smithy-client@4.12.13':
@@ -9510,26 +9841,31 @@ snapshots:
 
   cdk-from-cfn@0.300.0: {}
 
-  cdk-local@0.34.0(@aws-cdk/cli-plugin-contract@2.182.2)(@aws-cdk/cloud-assembly-schema@53.27.0)(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0):
+  cdk-local@0.53.0(@aws-cdk/cli-plugin-contract@2.182.2)(@aws-cdk/cloud-assembly-schema@53.27.0)(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0):
     dependencies:
       '@aws-cdk/cloud-assembly-api': 2.2.4(@aws-cdk/cloud-assembly-schema@53.27.0)
       '@aws-cdk/toolkit-lib': 1.26.2(@aws-cdk/cli-plugin-contract@2.182.2)
+      '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/client-cloudformation': 3.1018.0
       '@aws-sdk/client-ecr': 3.1019.0
       '@aws-sdk/client-eventbridge': 3.1018.0
       '@aws-sdk/client-kinesis': 3.1018.0
       '@aws-sdk/client-lambda': 3.1018.0
+      '@aws-sdk/client-s3': 3.1056.0
       '@aws-sdk/client-secrets-manager': 3.1018.0
       '@aws-sdk/client-sfn': 3.1018.0
       '@aws-sdk/client-sns': 3.1018.0
       '@aws-sdk/client-sqs': 3.1018.0
       '@aws-sdk/client-ssm': 3.1018.0
       '@aws-sdk/client-sts': 3.1018.0
+      '@clack/core': 1.3.1
       '@clack/prompts': 1.4.0
+      '@smithy/signature-v4': 5.4.5
       aws-cdk-lib: 2.244.0(constructs@10.6.0)
       chokidar: 5.0.0
       commander: 12.1.0
       constructs: 10.6.0
+      fflate: 0.8.3
       graphlib: 2.1.8
       ws: 8.20.0
     transitivePeerDependencies:
@@ -9883,6 +10219,8 @@ snapshots:
       picomatch: 4.0.4
 
   fflate@0.8.1: {}
+
+  fflate@0.8.3: {}
 
   figures@2.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,8 +153,8 @@ importers:
         specifier: ^2.0.0
         version: 2.244.0(constructs@10.6.0)
       cdk-local:
-        specifier: ^0.53.0
-        version: 0.53.0(@aws-cdk/cli-plugin-contract@2.182.2)(@aws-cdk/cloud-assembly-schema@53.27.0)(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: ^0.59.0
+        version: 0.59.0(@aws-cdk/cli-plugin-contract@2.182.2)(@aws-cdk/cloud-assembly-schema@53.27.0)(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0)
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -564,10 +564,6 @@ packages:
     resolution: {integrity: sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.39.tgz}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.40':
-    resolution: {integrity: sha512-jjT0p0Y7KZtcvExYiPCLJnqM9lkXDV1KBEg/13OE2DXv/9batzlyJHVKUEnRNJccY0O2Sul17E1su38CgdBhGQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-env@3.972.41':
     resolution: {integrity: sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==}
     engines: {node: '>=20.0.0'}
@@ -586,10 +582,6 @@ packages:
 
   '@aws-sdk/credential-provider-http@3.972.41':
     resolution: {integrity: sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.41.tgz}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.42':
-    resolution: {integrity: sha512-+3fsKtWybe5BjKEUA3/07oh7Ayfd82IED2+gyyaVfS/4PU78E3TaOQxSGOJ1t7Imefoidw/ne9QA7apX8wEnJg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.43':
@@ -616,10 +608,6 @@ packages:
     resolution: {integrity: sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.43.tgz}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.44':
-    resolution: {integrity: sha512-gZFw5wBefCIPg9vpT+gV5FdhfNKhYTVDZa1IsZCcn3SRoYUOJ/E05vwIogkJoonqBL0ttBGi5vhthX7xceekRg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-ini@3.972.45':
     resolution: {integrity: sha512-sJe5ZWibO4s7RWjFQ8Zol76KxoJcIYyEZH1/wxQSBMSIAAxzaJ8cS/ITAaIHWUQvDKQdt18+cJAHKWB7n1Jmrg==}
     engines: {node: '>=20.0.0'}
@@ -642,10 +630,6 @@ packages:
 
   '@aws-sdk/credential-provider-login@3.972.43':
     resolution: {integrity: sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.43.tgz}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.44':
-    resolution: {integrity: sha512-QqEGHfQeZgUDqh7zpqHufrZ8T644ELEWvB+4gUdewLyRw4IRF+6CJqeQuRWqucZdQzoQeMh7fNAD9BWxFAdNig==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.45':
@@ -672,10 +656,6 @@ packages:
     resolution: {integrity: sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.44.tgz}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.45':
-    resolution: {integrity: sha512-3YCv52ExXIRz3LAVNysevd+s7akSpg9dl39v9LJ7dOQH+s5rHi3jMZYQyxwMmglxQGMuzYRfQ0o1VSP2UOlIRw==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-node@3.972.46':
     resolution: {integrity: sha512-cS4w0jzDRb1jOlkiJS3y80OxddHzkky/MN9k3NYs5jganNKVLjF0lpvjlwS118oGMr3cdAfOlVdo8gLurTSE7w==}
     engines: {node: '>=20.0.0'}
@@ -694,10 +674,6 @@ packages:
 
   '@aws-sdk/credential-provider-process@3.972.39':
     resolution: {integrity: sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.39.tgz}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.40':
-    resolution: {integrity: sha512-cXaozlgJCOwmE6D7x4npcPdyk7kiFZdrGjN3D6tXXtItJJMNGPafDfAJn4YQmciMooG/X+b0Y6RTqdVVMx26jg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.41':
@@ -724,10 +700,6 @@ packages:
     resolution: {integrity: sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.43.tgz}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.44':
-    resolution: {integrity: sha512-YePoj5kQuPmE0MHnyftXCfsO8ZSBd2kDr50XEIUrdejSbGFlayYvUuCohdb8drhGhPm6b65o7H1eC26EZhwUvA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-sso@3.972.45':
     resolution: {integrity: sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==}
     engines: {node: '>=20.0.0'}
@@ -750,10 +722,6 @@ packages:
 
   '@aws-sdk/credential-provider-web-identity@3.972.43':
     resolution: {integrity: sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==, tarball: https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.43.tgz}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.44':
-    resolution: {integrity: sha512-Ys/JJe++8Z2Y5meR1taMBaVcrGBA0/XsVTQR+qOKZbdNyg+8Jlv5rYZSwh8SqEHY00goSOZy7PHzZ2rLNQxDLg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.45':
@@ -992,10 +960,6 @@ packages:
 
   '@aws-sdk/token-providers@3.1052.0':
     resolution: {integrity: sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==, tarball: https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1052.0.tgz}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1054.0':
-    resolution: {integrity: sha512-hG9YKApmZOw+drJ9Nuoaf/OvC8e5W1+3eoLeN5p2uVCZRWsv27teIS0b4kiH6Sfv3WMmamqYJxmE2WMwyp/L/A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1056.0':
@@ -2804,8 +2768,8 @@ packages:
   cdk-from-cfn@0.300.0:
     resolution: {integrity: sha512-BtTAthyg3EeBoO0o77A3PMfwID7mvm3R1BvM/avjwfPHbSnt598vv0qGGSZMM0KPM77DB5UtK6/z4VhBto4VJw==}
 
-  cdk-local@0.53.0:
-    resolution: {integrity: sha512-jYAFwWfhjnhcNEHaqb2wOtCBVnFMq7ugBc4krlmjNEvtMyEk6/r0OAeh19B/ygbAXxN0jHs6eOfqA2KprHxD0A==}
+  cdk-local@0.59.0:
+    resolution: {integrity: sha512-Mc037JfJKO999OL01d1GedJvQZHaloCZleY/HOmGPfKKC50tTLxnGcwtTgkNfX8lpun+UpuvS+udxcm82uAaYQ==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -4531,11 +4495,11 @@ snapshots:
       '@aws-cdk/cloud-assembly-api': 2.2.4(@aws-cdk/cloud-assembly-schema@53.27.0)
       '@aws-cdk/cloud-assembly-schema': 53.27.0
       '@aws-sdk/client-ecr': 3.1019.0
-      '@aws-sdk/client-s3': 3.1018.0
+      '@aws-sdk/client-s3': 3.1056.0
       '@aws-sdk/client-secrets-manager': 3.1018.0
       '@aws-sdk/client-sts': 3.1018.0
       '@aws-sdk/credential-providers': 3.1054.0
-      '@aws-sdk/lib-storage': 3.1054.0(@aws-sdk/client-s3@3.1018.0)
+      '@aws-sdk/lib-storage': 3.1054.0(@aws-sdk/client-s3@3.1056.0)
       '@smithy/config-resolver': 4.4.17
       '@smithy/node-config-provider': 4.3.14
       archiver: 7.0.1
@@ -4605,14 +4569,14 @@ snapshots:
       '@aws-sdk/client-kms': 3.1018.0
       '@aws-sdk/client-lambda': 3.1018.0
       '@aws-sdk/client-route-53': 3.1018.0
-      '@aws-sdk/client-s3': 3.1018.0
+      '@aws-sdk/client-s3': 3.1056.0
       '@aws-sdk/client-secrets-manager': 3.1018.0
       '@aws-sdk/client-sfn': 3.1018.0
       '@aws-sdk/client-ssm': 3.1018.0
       '@aws-sdk/client-sts': 3.1018.0
       '@aws-sdk/credential-providers': 3.1054.0
       '@aws-sdk/ec2-metadata-service': 3.1054.0
-      '@aws-sdk/lib-storage': 3.1054.0(@aws-sdk/client-s3@3.1018.0)
+      '@aws-sdk/lib-storage': 3.1054.0(@aws-sdk/client-s3@3.1056.0)
       '@smithy/middleware-endpoint': 4.4.32
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -5359,12 +5323,12 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.14
-      '@aws-sdk/credential-provider-node': 3.972.45
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/credential-provider-node': 3.972.46
       '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/node-http-handler': 4.7.4
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -6799,9 +6763,9 @@ snapshots:
 
   '@aws-sdk/credential-provider-cognito-identity@3.972.37':
     dependencies:
-      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/nested-clients': 3.997.13
       '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -6832,14 +6796,6 @@ snapshots:
   '@aws-sdk/credential-provider-env@3.972.39':
     dependencies:
       '@aws-sdk/core': 3.974.13
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-env@3.972.40':
-    dependencies:
-      '@aws-sdk/core': 3.974.14
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
@@ -6892,16 +6848,6 @@ snapshots:
   '@aws-sdk/credential-provider-http@3.972.41':
     dependencies:
       '@aws-sdk/core': 3.974.13
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/node-http-handler': 4.7.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.42':
-    dependencies:
-      '@aws-sdk/core': 3.974.14
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
       '@smithy/fetch-http-handler': 5.4.4
@@ -7010,22 +6956,6 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.44':
-    dependencies:
-      '@aws-sdk/core': 3.974.14
-      '@aws-sdk/credential-provider-env': 3.972.40
-      '@aws-sdk/credential-provider-http': 3.972.42
-      '@aws-sdk/credential-provider-login': 3.972.44
-      '@aws-sdk/credential-provider-process': 3.972.40
-      '@aws-sdk/credential-provider-sso': 3.972.44
-      '@aws-sdk/credential-provider-web-identity': 3.972.44
-      '@aws-sdk/nested-clients': 3.997.12
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/credential-provider-imds': 4.3.2
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-ini@3.972.45':
     dependencies:
       '@aws-sdk/core': 3.974.15
@@ -7090,15 +7020,6 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.13
       '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-login@3.972.44':
-    dependencies:
-      '@aws-sdk/core': 3.974.14
-      '@aws-sdk/nested-clients': 3.997.12
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
@@ -7194,20 +7115,6 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-node@3.972.45':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.40
-      '@aws-sdk/credential-provider-http': 3.972.42
-      '@aws-sdk/credential-provider-ini': 3.972.44
-      '@aws-sdk/credential-provider-process': 3.972.40
-      '@aws-sdk/credential-provider-sso': 3.972.44
-      '@aws-sdk/credential-provider-web-identity': 3.972.44
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/credential-provider-imds': 4.3.2
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-node@3.972.46':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.972.41
@@ -7251,14 +7158,6 @@ snapshots:
   '@aws-sdk/credential-provider-process@3.972.39':
     dependencies:
       '@aws-sdk/core': 3.974.13
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-process@3.972.40':
-    dependencies:
-      '@aws-sdk/core': 3.974.14
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
@@ -7333,16 +7232,6 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.44':
-    dependencies:
-      '@aws-sdk/core': 3.974.14
-      '@aws-sdk/nested-clients': 3.997.12
-      '@aws-sdk/token-providers': 3.1054.0
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-sso@3.972.45':
     dependencies:
       '@aws-sdk/core': 3.974.15
@@ -7409,15 +7298,6 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-web-identity@3.972.44':
-    dependencies:
-      '@aws-sdk/core': 3.974.14
-      '@aws-sdk/nested-clients': 3.997.12
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-web-identity@3.972.45':
     dependencies:
       '@aws-sdk/core': 3.974.15
@@ -7430,20 +7310,20 @@ snapshots:
   '@aws-sdk/credential-providers@3.1054.0':
     dependencies:
       '@aws-sdk/client-cognito-identity': 3.1054.0
-      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/core': 3.974.15
       '@aws-sdk/credential-provider-cognito-identity': 3.972.37
-      '@aws-sdk/credential-provider-env': 3.972.40
-      '@aws-sdk/credential-provider-http': 3.972.42
-      '@aws-sdk/credential-provider-ini': 3.972.44
-      '@aws-sdk/credential-provider-login': 3.972.44
-      '@aws-sdk/credential-provider-node': 3.972.45
-      '@aws-sdk/credential-provider-process': 3.972.40
-      '@aws-sdk/credential-provider-sso': 3.972.44
-      '@aws-sdk/credential-provider-web-identity': 3.972.44
-      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/credential-provider-env': 3.972.41
+      '@aws-sdk/credential-provider-http': 3.972.43
+      '@aws-sdk/credential-provider-ini': 3.972.45
+      '@aws-sdk/credential-provider-login': 3.972.45
+      '@aws-sdk/credential-provider-node': 3.972.46
+      '@aws-sdk/credential-provider-process': 3.972.41
+      '@aws-sdk/credential-provider-sso': 3.972.45
+      '@aws-sdk/credential-provider-web-identity': 3.972.45
+      '@aws-sdk/nested-clients': 3.997.13
       '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/credential-provider-imds': 4.3.2
+      '@smithy/core': 3.24.5
+      '@smithy/credential-provider-imds': 4.3.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -7459,8 +7339,8 @@ snapshots:
   '@aws-sdk/ec2-metadata-service@3.1054.0':
     dependencies:
       '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/node-http-handler': 4.7.4
+      '@smithy/core': 3.24.5
+      '@smithy/node-http-handler': 4.7.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -7469,10 +7349,10 @@ snapshots:
       mnemonist: 0.38.3
       tslib: 2.8.1
 
-  '@aws-sdk/lib-storage@3.1054.0(@aws-sdk/client-s3@3.1018.0)':
+  '@aws-sdk/lib-storage@3.1054.0(@aws-sdk/client-s3@3.1056.0)':
     dependencies:
-      '@aws-sdk/client-s3': 3.1018.0
-      '@smithy/core': 3.24.4
+      '@aws-sdk/client-s3': 3.1056.0
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       buffer: 5.6.0
       events: 3.3.0
@@ -8076,15 +7956,6 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.13
       '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1054.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.14
-      '@aws-sdk/nested-clients': 3.997.12
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
@@ -9841,7 +9712,7 @@ snapshots:
 
   cdk-from-cfn@0.300.0: {}
 
-  cdk-local@0.53.0(@aws-cdk/cli-plugin-contract@2.182.2)(@aws-cdk/cloud-assembly-schema@53.27.0)(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0):
+  cdk-local@0.59.0(@aws-cdk/cli-plugin-contract@2.182.2)(@aws-cdk/cloud-assembly-schema@53.27.0)(aws-cdk-lib@2.244.0(constructs@10.6.0))(constructs@10.6.0):
     dependencies:
       '@aws-cdk/cloud-assembly-api': 2.2.4(@aws-cdk/cloud-assembly-schema@53.27.0)
       '@aws-cdk/toolkit-lib': 1.26.2(@aws-cdk/cli-plugin-contract@2.182.2)

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -97,7 +97,7 @@ import {
   type ResolvedStage,
 } from '../../local/stage-resolver.js';
 import { createFileWatcher, type FileWatcher } from '../../local/file-watcher.js';
-import { createWatchPredicates, resolveWatchConfig } from 'cdk-local';
+import { createWatchPredicates, resolveWatchConfig } from 'cdk-local/internal';
 import { type NextStateMaterial } from '../../local/reload-orchestrator.js';
 import {
   attachAuthorizers,

--- a/src/local/api-gateway-event.ts
+++ b/src/local/api-gateway-event.ts
@@ -12,4 +12,4 @@ export {
   type HttpRequestSnapshot,
   type MatchedRouteContext,
   type AuthorizerEventOverlay,
-} from 'cdk-local';
+} from 'cdk-local/internal';

--- a/src/local/api-gateway-response.ts
+++ b/src/local/api-gateway-response.ts
@@ -6,4 +6,4 @@
  * instead of carrying a byte-identical copy. See cdk-local's
  * `src/local/api-gateway-response.ts`.
  */
-export { translateLambdaResponse, type TranslatedHttpResponse } from 'cdk-local';
+export { translateLambdaResponse, type TranslatedHttpResponse } from 'cdk-local/internal';

--- a/src/local/api-server-grouping.ts
+++ b/src/local/api-server-grouping.ts
@@ -12,4 +12,4 @@ export {
   filterRoutesByApiIdentifier,
   groupRoutesByServer,
   type ApiServerGroup,
-} from 'cdk-local';
+} from 'cdk-local/internal';

--- a/src/local/authorizer-cache.ts
+++ b/src/local/authorizer-cache.ts
@@ -9,4 +9,4 @@ export {
   createAuthorizerCache,
   type AuthorizerCache,
   type CachedAuthorizerResult,
-} from 'cdk-local';
+} from 'cdk-local/internal';

--- a/src/local/authorizer-resolver.ts
+++ b/src/local/authorizer-resolver.ts
@@ -7,4 +7,4 @@
  * instead of carrying a byte-identical copy. See cdk-local's
  * `src/local/authorizer-resolver.ts`.
  */
-export { attachAuthorizers, type AuthorizerInfo, type RouteWithAuth } from 'cdk-local';
+export { attachAuthorizers, type AuthorizerInfo, type RouteWithAuth } from 'cdk-local/internal';

--- a/src/local/cloud-map-registry.ts
+++ b/src/local/cloud-map-registry.ts
@@ -8,4 +8,4 @@
  * `ecs-service-runner.ts` imports it alongside the class. See cdk-local's
  * `src/local/cloud-map-registry.ts`.
  */
-export { CloudMapRegistry, type RegistrationHandle } from 'cdk-local';
+export { CloudMapRegistry, type RegistrationHandle } from 'cdk-local/internal';

--- a/src/local/cloud-map-resolver.ts
+++ b/src/local/cloud-map-resolver.ts
@@ -10,4 +10,4 @@
  * re-exported from cdk-local via `./ecs-task-resolver.js` so the throw and every
  * host-side `instanceof` / `toThrow` share one class identity.
  */
-export { buildCloudMapIndex, type CloudMapIndex } from 'cdk-local';
+export { buildCloudMapIndex, type CloudMapIndex } from 'cdk-local/internal';

--- a/src/local/cognito-jwt.ts
+++ b/src/local/cognito-jwt.ts
@@ -12,4 +12,4 @@ export {
   verifyCognitoJwt,
   verifyJwtAuthorizer,
   type JwksCache,
-} from 'cdk-local';
+} from 'cdk-local/internal';

--- a/src/local/cors-handler.ts
+++ b/src/local/cors-handler.ts
@@ -12,4 +12,4 @@ export {
   buildCorsConfigFromCloudFrontChain,
   matchPreflight,
   type CorsConfig,
-} from 'cdk-local';
+} from 'cdk-local/internal';

--- a/src/local/docker-image-builder.ts
+++ b/src/local/docker-image-builder.ts
@@ -20,7 +20,7 @@ import {
   buildContainerImage as buildContainerImageImpl,
   LocalInvokeBuildError as CdkLocalLocalInvokeBuildError,
   type BuildContainerImageOptions,
-} from 'cdk-local';
+} from 'cdk-local/internal';
 import { LocalInvokeBuildError } from '../utils/error-handler.js';
 
 export { architectureToPlatform };

--- a/src/local/docker-inspect.ts
+++ b/src/local/docker-inspect.ts
@@ -5,4 +5,4 @@
  * and cdkd consumes it verbatim instead of carrying a byte-identical
  * copy. See cdk-local's `src/local/docker-inspect.ts`.
  */
-export { getContainerNetworkIp } from 'cdk-local';
+export { getContainerNetworkIp } from 'cdk-local/internal';

--- a/src/local/docker-version.ts
+++ b/src/local/docker-version.ts
@@ -6,4 +6,4 @@
  * verbatim instead of carrying a byte-identical copy. See cdk-local's
  * `src/local/docker-version.ts`.
  */
-export { HOST_GATEWAY_MIN_VERSION, probeHostGatewaySupport } from 'cdk-local';
+export { HOST_GATEWAY_MIN_VERSION, probeHostGatewaySupport } from 'cdk-local/internal';

--- a/src/local/ecs-task-resolver.ts
+++ b/src/local/ecs-task-resolver.ts
@@ -1,6 +1,6 @@
 import { dirname, isAbsolute, resolve } from 'node:path';
 import { existsSync, statSync } from 'node:fs';
-import { EcsTaskResolutionError } from 'cdk-local';
+import { EcsTaskResolutionError } from 'cdk-local/internal';
 import type { StackInfo } from '../synthesis/assembly-reader.js';
 import type { TemplateResource } from '../types/resource.js';
 import { buildCdkPathIndex, resolveCdkPathToLogicalIds } from '../cli/cdk-path.js';

--- a/src/local/env-resolver.ts
+++ b/src/local/env-resolver.ts
@@ -7,4 +7,4 @@
  * verbatim instead of carrying a byte-identical copy. See cdk-local's
  * `src/local/env-resolver.ts`.
  */
-export { resolveEnvVars, type EnvOverrideFile } from 'cdk-local';
+export { resolveEnvVars, type EnvOverrideFile } from 'cdk-local/internal';

--- a/src/local/file-watcher.ts
+++ b/src/local/file-watcher.ts
@@ -7,4 +7,4 @@
  * `createWatchPredicates` / `resolveWatchConfig` (imported directly from
  * `cdk-local`). See cdk-local's `src/local/file-watcher.ts`.
  */
-export { createFileWatcher, type FileWatcher, type FileWatcherOptions } from 'cdk-local';
+export { createFileWatcher, type FileWatcher, type FileWatcherOptions } from 'cdk-local/internal';

--- a/src/local/http-server.ts
+++ b/src/local/http-server.ts
@@ -16,4 +16,4 @@ export {
   type ServerState,
   type StartedApiServer,
   type MtlsServerConfig,
-} from 'cdk-local';
+} from 'cdk-local/internal';

--- a/src/local/integration-response-selector.ts
+++ b/src/local/integration-response-selector.ts
@@ -16,4 +16,4 @@ export {
   selectIntegrationResponse,
   tryParseStatus,
   type IntegrationResponseEntry,
-} from 'cdk-local';
+} from 'cdk-local/internal';

--- a/src/local/intrinsic-image.ts
+++ b/src/local/intrinsic-image.ts
@@ -13,4 +13,4 @@ export {
   substituteImagePlaceholders,
   tryResolveImageFnJoin,
   type ImageResolutionContext,
-} from 'cdk-local';
+} from 'cdk-local/internal';

--- a/src/local/intrinsic-lambda-arn.ts
+++ b/src/local/intrinsic-lambda-arn.ts
@@ -6,4 +6,4 @@
  * consumes it verbatim instead of carrying a byte-identical copy. See
  * cdk-local's `src/local/intrinsic-lambda-arn.ts`.
  */
-export { resolveLambdaArnIntrinsic, type LambdaArnResolveOutcome } from 'cdk-local';
+export { resolveLambdaArnIntrinsic, type LambdaArnResolveOutcome } from 'cdk-local/internal';

--- a/src/local/intrinsic-utils.ts
+++ b/src/local/intrinsic-utils.ts
@@ -4,4 +4,4 @@
  * cdk-local and cdkd consumes it verbatim instead of carrying a
  * byte-identical copy. See cdk-local's `src/local/intrinsic-utils.ts`.
  */
-export { pickRefLogicalId } from 'cdk-local';
+export { pickRefLogicalId } from 'cdk-local/internal';

--- a/src/local/layer-arn-materializer.ts
+++ b/src/local/layer-arn-materializer.ts
@@ -7,4 +7,4 @@
  * carrying a byte-identical copy. See cdk-local's
  * `src/local/layer-arn-materializer.ts`.
  */
-export { materializeLayerFromArn } from 'cdk-local';
+export { materializeLayerFromArn } from 'cdk-local/internal';

--- a/src/local/parameter-mapping.ts
+++ b/src/local/parameter-mapping.ts
@@ -10,4 +10,4 @@ export {
   resolveSelectionExpression,
   type RequestParameterContext,
   type ResolveParametersOutcome,
-} from 'cdk-local';
+} from 'cdk-local/internal';

--- a/src/local/route-discovery.ts
+++ b/src/local/route-discovery.ts
@@ -5,4 +5,8 @@
  * consumes it verbatim instead of carrying a byte-identical copy. See
  * cdk-local's `src/local/route-discovery.ts`.
  */
-export { discoverRoutes, type DiscoveredRoute, type RestV1IntegrationConfig } from 'cdk-local';
+export {
+  discoverRoutes,
+  type DiscoveredRoute,
+  type RestV1IntegrationConfig,
+} from 'cdk-local/internal';

--- a/src/local/route-matcher.ts
+++ b/src/local/route-matcher.ts
@@ -4,4 +4,4 @@
  * lives in cdk-local and cdkd consumes it verbatim instead of carrying a
  * byte-identical copy. See cdk-local's `src/local/route-matcher.ts`.
  */
-export { matchRoute, type RouteMatchResult } from 'cdk-local';
+export { matchRoute, type RouteMatchResult } from 'cdk-local/internal';

--- a/src/local/runtime-image.ts
+++ b/src/local/runtime-image.ts
@@ -10,4 +10,4 @@ export {
   resolveRuntimeCodeMountPath,
   resolveRuntimeFileExtension,
   resolveRuntimeImage,
-} from 'cdk-local';
+} from 'cdk-local/internal';

--- a/src/local/sigv4-verify.ts
+++ b/src/local/sigv4-verify.ts
@@ -10,4 +10,4 @@
  * flag via the `sigV4StrictByDefault` / `sigV4OptFlag` embedConfig fields.
  * See cdk-local's `src/local/sigv4-verify.ts`.
  */
-export { defaultCredentialsLoader, type CredentialsLoader } from 'cdk-local';
+export { defaultCredentialsLoader, type CredentialsLoader } from 'cdk-local/internal';

--- a/src/local/stage-resolver.ts
+++ b/src/local/stage-resolver.ts
@@ -5,4 +5,4 @@
  * implementation lives in cdk-local and cdkd consumes it verbatim instead of
  * carrying a byte-identical copy. See cdk-local's `src/local/stage-resolver.ts`.
  */
-export { attachStageContext, buildStageMap, type ResolvedStage } from 'cdk-local';
+export { attachStageContext, buildStageMap, type ResolvedStage } from 'cdk-local/internal';

--- a/src/local/vtl-engine.ts
+++ b/src/local/vtl-engine.ts
@@ -78,7 +78,7 @@
  * acceptable and not in the contract.
  */
 
-import { VtlEvaluationError } from 'cdk-local';
+import { VtlEvaluationError } from 'cdk-local/internal';
 
 /**
  * Bindings available to a VTL template evaluation. Built up by

--- a/src/local/websocket-body.ts
+++ b/src/local/websocket-body.ts
@@ -1,4 +1,4 @@
-import { bufferToBody as bufferToBodyImpl } from 'cdk-local';
+import { bufferToBody as bufferToBodyImpl } from 'cdk-local/internal';
 
 /**
  * Thin spy-friendly wrapper over cdk-local's `bufferToBody` (which owns

--- a/src/local/websocket-event.ts
+++ b/src/local/websocket-event.ts
@@ -11,4 +11,4 @@ export {
   buildMessageEvent,
   type WebSocketHandshakeSnapshot,
   type WebSocketLambdaEvent,
-} from 'cdk-local';
+} from 'cdk-local/internal';

--- a/src/local/websocket-mgmt-api.ts
+++ b/src/local/websocket-mgmt-api.ts
@@ -11,4 +11,4 @@ export {
   buildMgmtEndpointEnvUrl,
   handleConnectionsRequest,
   parseConnectionsPath,
-} from 'cdk-local';
+} from 'cdk-local/internal';

--- a/src/local/websocket-route-discovery.ts
+++ b/src/local/websocket-route-discovery.ts
@@ -11,4 +11,4 @@ export {
   parseSelectionExpressionPath,
   type DiscoveredWebSocketApi,
   type WebSocketRouteEntry,
-} from 'cdk-local';
+} from 'cdk-local/internal';


### PR DESCRIPTION
## Summary

Closes #709.

cdk-local 0.48.0 split its export surface — low-level local-execution building blocks (route discovery, intrinsic resolution, API Gateway event/response builders, `cognito-jwt`, `sigv4-verify`, `docker-image-builder`, the file-watcher, etc.) moved behind the `cdk-local/internal` subpath and the main `cdk-local` entry no longer re-exports them. cdkd pinned `^0.34.0` and was insulated until now.

This PR bundles the dep bump (`0.34.0 -> ^0.59.0`) with the internal-symbol import split since the two are inseparable: the bump breaks without the split (cdkd's `from 'cdk-local'` of internal symbols fail to resolve), and the split breaks without the bump (the installed cdk-local doesn't have `/internal`).

## Classification

Per-import-statement classification against cdk-local's `src/index.ts` (public, semver-stable) vs `src/internal.ts` (internal, no semver guarantee). No mixed-symbol imports — every `from 'cdk-local'` line in cdkd is purely public or purely internal, so each is either kept verbatim or rewritten in full.

**Public** (stays `'cdk-local'`) — 4 sites:
- `src/cli/commands/local-invoke.ts` (`setEmbedConfig`)
- `src/cli/commands/local-state-source.ts` (state-source helpers)
- `src/local/state-resolver.ts` (`substituteAgainstState*`)
- `tests/unit/cli/local-embed-config.test.ts` (`getEmbedConfig` / `resetEmbedConfig`)

**Internal** (rewritten to `'cdk-local/internal'`) — 33 sites under `src/cli/commands/local-start-api.ts` and `src/local/**`.

## Non-goals

No shim-coverage expansion. cdk-local 0.34 -> 0.59 added agentcore / start-alb / agentcore-a2a internal helpers, but cdkd has no caller for them yet, so those stay un-shimmed per issue #709's "do NOT proactively shim every new cdk-local internal" guidance.

## Version pin

Bumped to `^0.59.0` (current latest at PR creation time). The initial draft pinned `^0.53.0` based on an earlier `npm view` query; spec review flagged that 6 minor versions had been published in parallel during this session, so a follow-up commit bumped to `^0.59.0` per issue #709's "current latest at bump time" directive. The 0.53 -> 0.59 internal-surface delta is purely additive (agentcore-a2a-client + 2 protocol constants), all unused by cdkd.

## Accepted follow-ups (informational)

- **Test-coverage observation**: `/run-integ local-start-api` was not exercised in this PR. The HTTP API shim group (`route-discovery` / `authorizer-resolver` / `cors-handler` / `parameter-mapping` / `vtl-engine` / `websocket-*`) is covered by cdkd's 5303 unit tests and by the typecheck against the new cdk-local version, but end-to-end Docker-side coverage of that shim group was not run. The `integ-local` gate's refresh requirement is satisfied by `/run-integ local-invoke` (which exercises the runtime-image / docker-image-builder / intrinsic-image shims). Accepted as known cost: a `local-start-api` integ is a 15-25 min real-Docker run, and the inherited-behavior audit (per memory rule `feedback_shimmed_dep_bump_sweep_inherited_behavior_docs.md`) found no claims that would silently rot in the 0.34 -> 0.59 jump.

## Test plan

- [x] `vp check --fix`: pass (no type / lint / format errors)
- [x] `vp run build`: ok
- [x] `vp run test`: 359 files, 5303 tests, all pass against cdk-local 0.59.0 — confirms no signature drift across the 0.34 -> 0.59 minor gap in shimmed modules
- [x] `/run-integ local-invoke`: 5/5 Docker-side tests pass — refreshes `integ-local` gate
- [x] `/run-integ lambda`: 9 resources deployed + 9 destroyed (0 errors, 0 orphans) — refreshes `integ-destroy` + `integ-broad` gates
- [x] cdk-local 0.34 -> 0.59 inherited-behavior audit (per memory rule `feedback_shimmed_dep_bump_sweep_inherited_behavior_docs.md`): docs/local-emulation.md's `cdk-local@0.10.0` references are historical facts and remain accurate; no stale claims
- [x] 3-axis reviewer pass on 84f2cee8 + 1-reviewer follow-up pass on 805c2ea6 (bump commit): all clean
