### PR TITLE
test(docker-runner): add direct unit assertions for containerPort

### DIFF
--- a/tests/unit/local/docker-runner.test.ts
+++ b/tests/unit/local/docker-runner.test.ts
@@ -416,6 +416,42 @@ describe('runDetached', () => {
     const opts = lastCall[2] as { env?: Record<string, string> };
     expect(opts.env?.['AWS_SECRET_ACCESS_KEY']).toBe('real-secret');
   });
+
+  // PR #717 added `DockerRunOptions.containerPort` (defaults to 8080 so the
+  // existing RIE Lambda local-invoke path is unchanged; MCP runtimes pass
+  // 8000, A2A runtimes pass 9000). The default + explicit-override paths
+  // are exercised end-to-end by the local-invoke / local-invoke-agentcore
+  // integ tests; these two cases nail the docker `-p` flag shape directly
+  // at the unit layer so a regression that inverts the ternary surfaces
+  // without a Docker run (closes G3 in the PR #717 3-axis review).
+  it('publishes containerPort defaulting to 8080 when omitted (Lambda RIE path)', async () => {
+    await runDetached({
+      image: 'my-image:latest',
+      mounts: [],
+      env: {},
+      cmd: [],
+      hostPort: 56789,
+    });
+    const args = lastArgs();
+    const pIdx = args.indexOf('-p');
+    expect(pIdx).toBeGreaterThanOrEqual(0);
+    expect(args[pIdx + 1]).toBe('127.0.0.1:56789:8080');
+  });
+
+  it('publishes hostPort:containerPort when containerPort is explicit (MCP / A2A path)', async () => {
+    await runDetached({
+      image: 'my-image:latest',
+      mounts: [],
+      env: {},
+      cmd: [],
+      hostPort: 56789,
+      containerPort: 8000,
+    });
+    const args = lastArgs();
+    const pIdx = args.indexOf('-p');
+    expect(pIdx).toBeGreaterThanOrEqual(0);
+    expect(args[pIdx + 1]).toBe('127.0.0.1:56789:8000');
+  });
 });
 
 // `pullImage` exercises `runDockerStreaming` (default compact log level


### PR DESCRIPTION
## Summary

Closes [G3 from the PR #717 3-axis review](https://github.com/go-to-k/cdkd/pull/717#issuecomment-): the new `DockerRunOptions.containerPort` field had no direct unit assertion at the test layer — it was exercised end-to-end only via `/run-integ local-invoke-agentcore`. A regression that inverts the ternary in `src/local/docker-runner.ts:239` (`${opts.containerPort ?? 8080}`) would slip through `vp run test` without a Docker run.

Add two unit cases nailing the docker `-p` flag shape directly:

- **Default path**: `containerPort` omitted → `-p 127.0.0.1:<hostPort>:8080` (preserves the existing RIE Lambda local-invoke behavior for every caller that does not pass `containerPort`).
- **Explicit override**: `containerPort: 8000` → `-p 127.0.0.1:<hostPort>:8000` (the MCP / A2A runtime path the agentcore command uses; 9000 follows the same code path).

## Non-goals

- No production code change.
- The end-to-end Docker-side verification is unchanged — `/run-integ local-invoke-agentcore` (20 scenarios passing) remains the integration-layer guarantee.

## Test plan

- [x] `vp check --fix`: pass
- [x] `vp run build`: pass
- [x] `vp run test tests/unit/local/docker-runner.test.ts`: 28 tests pass (was 26; +2 new cases)
- [x] `vp run test`: full suite pass (no regressions)
