### PR TITLE
fix(provisioning): tag-side AWS failures THROW instead of warn-swallow (closes #740)

### DIFF
--- a/src/provisioning/providers/cloudfront-distribution-provider.ts
+++ b/src/provisioning/providers/cloudfront-distribution-provider.ts
@@ -648,9 +648,15 @@ export class CloudFrontDistributionProvider implements ResourceProvider {
    * deploy engine sees a failed update() and (a) does NOT write the new
    * properties.Tags into state — the next deploy retries the tag-diff
    * against the still-old state, (b) surfaces the failure to the user
-   * via the standard error path, (c) lets the engine's `withRetry`
-   * classifier pick up transient AWS errors (throttling) and retry
-   * automatically within the same deploy.
+   * via the standard error path. The deploy engine's `withRetry` MAY
+   * pick up some transient AWS errors via the cause-message-pattern
+   * match (`retryable-errors.ts`'s `RETRYABLE_ERROR_MESSAGE_PATTERNS`),
+   * but bare HTTP 429 throttles wrapped by update()'s outer catch reach
+   * the classifier two levels deep and slip past its single-level
+   * `.cause` walk — so the **load-bearing retry guarantee is the
+   * next-deploy retry**, not in-deploy retry. This is acceptable: the
+   * user sees the failure, can react, and the next `cdkd deploy`
+   * re-fires the tag-diff against the still-old state cleanly.
    *
    * Trade-off: a tag-side failure flips an otherwise-successful
    * `UpdateDistribution` into a deploy failure, and the retry will

--- a/src/provisioning/providers/cloudfront-distribution-provider.ts
+++ b/src/provisioning/providers/cloudfront-distribution-provider.ts
@@ -201,14 +201,22 @@ export class CloudFrontDistributionProvider implements ResourceProvider {
       // first so a renamed key (e.g. value-only edit on key K) is not
       // accidentally cleared by a stale UntagResource pass.
       //
-      // Tags are best-effort post-step: a tag-side failure must not flip
-      // an otherwise-successful UpdateDistribution into a deploy-engine
-      // failure (the engine would then schedule a retry that re-issues
-      // the already-applied UpdateDistribution against the same etag,
-      // which is idempotent but adds noise to the next deploy). We log a
-      // warn instead so the user sees the unapplied tag delta but the
-      // deploy still progresses.
-      await this.tryApplyTagDiff(arn, previousProperties['Tags'], properties['Tags'], physicalId);
+      // Tag-side failures THROW (issue #740 fix): a swallow leaves state
+      // recording the new Tags as applied while AWS-side tags stay stale
+      // forever (next deploy sees no diff → no retry). The trade-off is
+      // that a TagResource throttle flips the whole update into a deploy
+      // failure; the retry will re-issue UpdateDistribution against the
+      // already-current config (AWS accepts as a no-op) before re-firing
+      // the tag-diff. That secondary noise is much cheaper than the
+      // silent tag drift the pre-#740 swallow caused.
+      await this.applyTagDiff(
+        arn,
+        previousProperties['Tags'],
+        properties['Tags'],
+        physicalId,
+        logicalId,
+        resourceType
+      );
 
       this.logger.debug(`Updated CloudFront Distribution ${physicalId}`);
 
@@ -629,41 +637,54 @@ export class CloudFrontDistributionProvider implements ResourceProvider {
   }
 
   /**
-   * Apply a tag diff to a distribution, best-effort.
+   * Apply a tag diff to a distribution.
    *
    * CloudFront has no atomic overlay API for tags — `TagResource` adds /
    * overwrites and `UntagResource` removes. Run the removal first, then
    * the upsert, so a same-key value rewrite (which lands in `upserts`)
    * is not accidentally cleared by a stale Untag.
    *
-   * Errors are logged but not rethrown — `update()` already succeeded
-   * the `UpdateDistribution` call before this is invoked, so propagating
-   * a tag-side error would flip a successful config update into a deploy
-   * failure that triggers an idempotent retry. A `warn` surfaces the
-   * unapplied delta to the operator without breaking the deploy.
+   * Errors are RETHROWN as `ProvisioningError` (issue #740 fix) so the
+   * deploy engine sees a failed update() and (a) does NOT write the new
+   * properties.Tags into state — the next deploy retries the tag-diff
+   * against the still-old state, (b) surfaces the failure to the user
+   * via the standard error path, (c) lets the engine's `withRetry`
+   * classifier pick up transient AWS errors (throttling) and retry
+   * automatically within the same deploy.
+   *
+   * Trade-off: a tag-side failure flips an otherwise-successful
+   * `UpdateDistribution` into a deploy failure, and the retry will
+   * re-issue UpdateDistribution against the (now-current) config —
+   * AWS accepts the no-op idempotently. The cost of that secondary
+   * noise is much lower than the cost of silent tag drift the pre-#740
+   * swallow caused.
    *
    * The ARN is unexpectedly absent only on a hypothetical SDK regression
    * (`GetDistribution` returns ARN as a required string in every SDK
    * shape verified so far). When that happens AND a tag delta exists,
-   * log a warn so the silent-drop this PR is closing does not silently
-   * resurface; when no delta exists, return without needing ARN.
+   * THROW so the silent-drop does not silently resurface; when no delta
+   * exists, return without needing ARN.
    */
-  private async tryApplyTagDiff(
+  private async applyTagDiff(
     arn: string | undefined,
     previousTags: unknown,
     newTags: unknown,
-    physicalId: string
+    physicalId: string,
+    logicalId: string,
+    resourceType: string
   ): Promise<void> {
     const { removed, upserts } = this.computeTagDiff(previousTags, newTags);
     if (removed.length === 0 && upserts.length === 0) return;
 
     if (!arn) {
-      this.logger.warn(
+      throw new ProvisioningError(
         `CloudFront Distribution ${physicalId}: GetDistribution returned no ARN; ` +
-          `skipping tag diff (removed=${removed.length}, upserts=${upserts.length}). ` +
-          `Tags on AWS may drift from the template.`
+          `cannot apply tag diff (removed=${removed.length}, upserts=${upserts.length}). ` +
+          `Refusing to silently drop the tag update — retry on next deploy or check SDK version.`,
+        resourceType,
+        logicalId,
+        physicalId
       );
-      return;
     }
 
     try {
@@ -688,10 +709,15 @@ export class CloudFrontDistributionProvider implements ResourceProvider {
         );
       }
     } catch (err) {
-      this.logger.warn(
+      const cause = err instanceof Error ? err : undefined;
+      throw new ProvisioningError(
         `CloudFront Distribution ${physicalId}: tag diff failed (removed=${removed.length}, ` +
           `upserts=${upserts.length}): ${err instanceof Error ? err.message : String(err)}. ` +
-          `UpdateDistribution itself succeeded; tags on AWS may drift from the template until the next deploy.`
+          `UpdateDistribution succeeded but TagResource/UntagResource did not — state has NOT been updated so the next deploy will retry the tag-diff.`,
+        resourceType,
+        logicalId,
+        physicalId,
+        cause
       );
     }
   }

--- a/src/provisioning/providers/s3-tables-provider.ts
+++ b/src/provisioning/providers/s3-tables-provider.ts
@@ -110,7 +110,13 @@ export class S3TablesProvider implements ResourceProvider {
     // (this PR); the TableBucket / Namespace cases stay no-op until
     // their own backfill PRs (U / V).
     if (resourceType === 'AWS::S3Tables::Table') {
-      await this.applyTableTagsDiff(physicalId, previousProperties['Tags'], properties['Tags']);
+      await this.applyTableTagsDiff(
+        logicalId,
+        physicalId,
+        resourceType,
+        previousProperties['Tags'],
+        properties['Tags']
+      );
     } else {
       this.logger.debug(`Update is no-op for ${resourceType} ${logicalId}`);
     }
@@ -979,31 +985,29 @@ export class S3TablesProvider implements ResourceProvider {
    * value-only rewrite on key K isn't accidentally cleared by a stale
    * UntagResource pass (matches the CloudFront / S3Vectors pattern).
    *
-   * Tag ops are best-effort post-step in update(): a tag-side failure
-   * MUST NOT flip the deploy engine into a retry that would re-issue
-   * the no-op `update()` body. Log at warn instead so the user sees
-   * the unapplied delta but the deploy still progresses.
+   * Tag-side failures THROW `ProvisioningError` (issue #740 fix): a
+   * silent swallow would let the deploy engine write the new properties.Tags
+   * to state as if applied, and the next deploy's diff (template Tags
+   * vs new state Tags) sees no change → tag-diff never re-fires → AWS
+   * tags stay stale forever. Throwing means: (a) state is NOT written,
+   * (b) the next deploy retries the tag-diff against the still-old
+   * state, (c) the engine's `withRetry` classifier picks up transient
+   * AWS errors (throttle) and retries within the same deploy. For
+   * the S3Tables Table case `update()` is otherwise a no-op (the
+   * Table itself is immutable), so a tag-side throw cleanly turns
+   * the whole update into a retry without side-effects.
+   *
+   * The malformed-physicalId / GetTable-NotFound branches throw too
+   * — both indicate a state-vs-AWS divergence the user needs to see,
+   * not silently skip past.
    */
   private async applyTableTagsDiff(
+    logicalId: string,
     physicalId: string,
+    resourceType: string,
     previousTags: unknown,
     newTags: unknown
   ): Promise<void> {
-    const parts = physicalId.split('|');
-    if (parts.length < 3) {
-      this.logger.warn(
-        `applyTableTagsDiff: cannot derive table ARN from physicalId '${physicalId}' — skipping tag-diff`
-      );
-      return;
-    }
-    const [tableBucketARN, namespace, name] = parts;
-    if (!tableBucketARN || !namespace || !name) {
-      this.logger.warn(
-        `applyTableTagsDiff: cannot derive table ARN from malformed physicalId '${physicalId}' (empty part after split) — skipping tag-diff`
-      );
-      return;
-    }
-
     const prev = this.cfnTagsToSdkMap(previousTags) ?? {};
     const next = this.cfnTagsToSdkMap(newTags) ?? {};
 
@@ -1013,17 +1017,39 @@ export class S3TablesProvider implements ResourceProvider {
       if (prev[k] !== v) upserts[k] = v;
     }
 
+    // No tag delta → no work, no error.
     if (removedKeys.length === 0 && Object.keys(upserts).length === 0) return;
+
+    const parts = physicalId.split('|');
+    if (parts.length < 3) {
+      throw new ProvisioningError(
+        `applyTableTagsDiff: cannot derive table ARN from physicalId '${physicalId}' (expected '<bucketArn>|<namespace>|<name>') — refusing to silently drop the tag update`,
+        resourceType,
+        logicalId,
+        physicalId
+      );
+    }
+    const [tableBucketARN, namespace, name] = parts;
+    if (!tableBucketARN || !namespace || !name) {
+      throw new ProvisioningError(
+        `applyTableTagsDiff: cannot derive table ARN from malformed physicalId '${physicalId}' (empty part after split) — refusing to silently drop the tag update`,
+        resourceType,
+        logicalId,
+        physicalId
+      );
+    }
 
     // Tag APIs need the REAL table ARN (not cdkd's compound physical id
     // and not a guessed derivation from the parts — AWS rejects every
     // form except its own). Look it up via GetTable.
     const resourceArn = await this.lookupTableArn(tableBucketARN, namespace, name);
     if (!resourceArn) {
-      this.logger.warn(
-        `applyTableTagsDiff: GetTable returned no tableARN for ${physicalId} — skipping tag-diff (table gone? state out-of-sync?)`
+      throw new ProvisioningError(
+        `applyTableTagsDiff: GetTable returned no tableARN for ${physicalId} — table is gone or state is out-of-sync. Refusing to silently drop the tag update (run \`cdkd state orphan ${logicalId}\` to clean up if the table was deleted out-of-band).`,
+        resourceType,
+        logicalId,
+        physicalId
       );
-      return;
     }
 
     if (removedKeys.length > 0) {
@@ -1032,8 +1058,13 @@ export class S3TablesProvider implements ResourceProvider {
           new UntagResourceCommand({ resourceArn, tagKeys: removedKeys })
         );
       } catch (err) {
-        this.logger.warn(
-          `applyTableTagsDiff: UntagResource failed for ${resourceArn} (keys: ${removedKeys.join(', ')}): ${err instanceof Error ? err.message : String(err)}`
+        const cause = err instanceof Error ? err : undefined;
+        throw new ProvisioningError(
+          `applyTableTagsDiff: UntagResource failed for ${resourceArn} (keys: ${removedKeys.join(', ')}): ${err instanceof Error ? err.message : String(err)}. State has NOT been updated so the next deploy will retry the tag-diff.`,
+          resourceType,
+          logicalId,
+          physicalId,
+          cause
         );
       }
     }
@@ -1042,8 +1073,13 @@ export class S3TablesProvider implements ResourceProvider {
       try {
         await this.getClient().send(new TagResourceCommand({ resourceArn, tags: upserts }));
       } catch (err) {
-        this.logger.warn(
-          `applyTableTagsDiff: TagResource failed for ${resourceArn} (keys: ${Object.keys(upserts).join(', ')}): ${err instanceof Error ? err.message : String(err)}`
+        const cause = err instanceof Error ? err : undefined;
+        throw new ProvisioningError(
+          `applyTableTagsDiff: TagResource failed for ${resourceArn} (keys: ${Object.keys(upserts).join(', ')}): ${err instanceof Error ? err.message : String(err)}. State has NOT been updated so the next deploy will retry the tag-diff.`,
+          resourceType,
+          logicalId,
+          physicalId,
+          cause
         );
       }
     }

--- a/src/provisioning/providers/s3-tables-provider.ts
+++ b/src/provisioning/providers/s3-tables-provider.ts
@@ -991,11 +991,15 @@ export class S3TablesProvider implements ResourceProvider {
    * vs new state Tags) sees no change → tag-diff never re-fires → AWS
    * tags stay stale forever. Throwing means: (a) state is NOT written,
    * (b) the next deploy retries the tag-diff against the still-old
-   * state, (c) the engine's `withRetry` classifier picks up transient
-   * AWS errors (throttle) and retries within the same deploy. For
-   * the S3Tables Table case `update()` is otherwise a no-op (the
-   * Table itself is immutable), so a tag-side throw cleanly turns
-   * the whole update into a retry without side-effects.
+   * state. The deploy engine's `withRetry` MAY pick up transient AWS
+   * errors via the cause-message-pattern match in `retryable-errors.ts`,
+   * but bare HTTP 429 throttles can slip past the classifier's
+   * single-level `.cause` walk depending on wrapping — so the
+   * **load-bearing retry guarantee is the next-deploy retry**, not
+   * in-deploy retry. For the S3Tables Table case `update()` is
+   * otherwise a no-op (the Table itself is immutable), so a tag-side
+   * throw cleanly turns the whole update into a retry without
+   * side-effects.
    *
    * The malformed-physicalId / GetTable-NotFound branches throw too
    * — both indicate a state-vs-AWS divergence the user needs to see,
@@ -1045,7 +1049,7 @@ export class S3TablesProvider implements ResourceProvider {
     const resourceArn = await this.lookupTableArn(tableBucketARN, namespace, name);
     if (!resourceArn) {
       throw new ProvisioningError(
-        `applyTableTagsDiff: GetTable returned no tableARN for ${physicalId} — table is gone or state is out-of-sync. Refusing to silently drop the tag update (run \`cdkd state orphan ${logicalId}\` to clean up if the table was deleted out-of-band).`,
+        `applyTableTagsDiff: GetTable returned no tableARN for ${physicalId} — table is gone or state is out-of-sync. Refusing to silently drop the tag update (run 'cdkd state orphan ${logicalId}' to clean up if the table was deleted out-of-band).`,
         resourceType,
         logicalId,
         physicalId

--- a/tests/unit/provisioning/cloudfront-distribution-provider.test.ts
+++ b/tests/unit/provisioning/cloudfront-distribution-provider.test.ts
@@ -604,11 +604,12 @@ describe('CloudFrontDistributionProvider', () => {
       expect(mockSend).toHaveBeenCalledTimes(3);
     });
 
-    it('update with tag diff but missing ARN warns and skips (does not throw)', async () => {
+    it('update with tag diff but missing ARN THROWS (issue #740 — refuses to silently drop the tag update)', async () => {
       // Defensive guard against a hypothetical SDK regression where
-      // GetDistribution stops returning ARN. A silent drop here would
-      // exactly reintroduce the silent-drop this PR closes — assert
-      // that the warn fires AND no Tag/Untag send is attempted.
+      // GetDistribution stops returning ARN. Pre-#740 this was a warn-
+      // and-skip (silent tag drop); now we throw so state is not written
+      // and the next deploy retries — surfaces the SDK regression to the
+      // operator instead of silently accruing AWS-side tag drift.
       mockSend.mockResolvedValueOnce({
         ETag: 'E1',
         DistributionConfig: { CallerReference: 'orig', Enabled: true },
@@ -618,26 +619,24 @@ describe('CloudFrontDistributionProvider', () => {
         Distribution: { Id: 'EDFDVBD6EXAMPLE', DomainName: 'd1.cloudfront.net' /* no ARN */ },
       });
 
-      await provider.update(
-        'MyDistribution',
-        'EDFDVBD6EXAMPLE',
-        'AWS::CloudFront::Distribution',
-        {
-          DistributionConfig: { Enabled: true },
-          Tags: [{ Key: 'NewKey', Value: 'NewVal' }],
-        },
-        {
-          DistributionConfig: { Enabled: true },
-        }
-      );
+      await expect(
+        provider.update(
+          'MyDistribution',
+          'EDFDVBD6EXAMPLE',
+          'AWS::CloudFront::Distribution',
+          {
+            DistributionConfig: { Enabled: true },
+            Tags: [{ Key: 'NewKey', Value: 'NewVal' }],
+          },
+          {
+            DistributionConfig: { Enabled: true },
+          }
+        )
+      ).rejects.toThrow(/GetDistribution returned no ARN/);
 
-      // GetConfig + Update + GetDistribution = 3 (no Tag/Untag, no throw)
+      // GetConfig + Update + GetDistribution = 3 sends fired before throw.
+      // No Tag/Untag attempted (we throw before reaching the AWS tag call).
       expect(mockSend).toHaveBeenCalledTimes(3);
-      // The warn is the load-bearing user-visible signal — without it
-      // the silent drop would silently reintroduce itself.
-      expect(childLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('GetDistribution returned no ARN')
-      );
     });
 
     it('update with NO tag diff and no ARN does NOT warn (no-op skip is silent)', async () => {
@@ -668,13 +667,18 @@ describe('CloudFrontDistributionProvider', () => {
       expect(childLogger.warn).not.toHaveBeenCalled();
     });
 
-    it('update tag-side failure is logged but does NOT propagate (UpdateDistribution succeeded)', async () => {
-      // The deploy engine treats provider.update() failure as a need to
-      // retry. Since UpdateDistribution already committed before the tag
-      // call, an exception here would force an idempotent retry against
-      // the same etag — noisy but not destructive. The provider chooses
-      // warn-and-continue so the user sees the unapplied tag delta
-      // without rolling the whole deploy step.
+    it('update tag-side failure THROWS (issue #740 — was warn-swallow, now propagates as ProvisioningError)', async () => {
+      // Pre-#740: warn-and-continue let the deploy engine record the new
+      // properties.Tags into state as if applied. AWS-side tags then
+      // stayed stale FOREVER (next deploy sees no diff → no retry).
+      //
+      // Post-#740: throw a ProvisioningError so state is NOT written.
+      // The next deploy compares the still-old state Tags vs new template
+      // Tags → tag-diff re-fires. UpdateDistribution will re-issue against
+      // the now-current config but AWS accepts that as a no-op idempotently.
+      //
+      // The trade-off (extra UpdateDistribution noise on retry) is much
+      // cheaper than silent tag drift.
       const arn = 'arn:aws:cloudfront::123456789012:distribution/EDFDVBD6EXAMPLE';
       mockSend.mockResolvedValueOnce({
         ETag: 'E1',
@@ -686,30 +690,21 @@ describe('CloudFrontDistributionProvider', () => {
       });
       mockSend.mockRejectedValueOnce(new Error('AccessDeniedException: tag policy denies')); // TagResource
 
-      const result = await provider.update(
-        'MyDistribution',
-        'EDFDVBD6EXAMPLE',
-        'AWS::CloudFront::Distribution',
-        {
-          DistributionConfig: { Enabled: true },
-          Tags: [{ Key: 'NewKey', Value: 'NewVal' }],
-        },
-        { DistributionConfig: { Enabled: true } }
-      );
+      await expect(
+        provider.update(
+          'MyDistribution',
+          'EDFDVBD6EXAMPLE',
+          'AWS::CloudFront::Distribution',
+          {
+            DistributionConfig: { Enabled: true },
+            Tags: [{ Key: 'NewKey', Value: 'NewVal' }],
+          },
+          { DistributionConfig: { Enabled: true } }
+        )
+      ).rejects.toThrow(/tag diff failed.*AccessDeniedException/s);
 
-      // update() returns normally (no throw) and the result is intact —
-      // wasReplaced=false, attributes carry the new domainName etc.
-      expect(result.physicalId).toBe('EDFDVBD6EXAMPLE');
-      expect(result.wasReplaced).toBe(false);
-      // The warn surfaces the unapplied delta with the failure message
-      // so the operator can investigate; this guards against a future
-      // `catch {}` swallow regression.
-      expect(childLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('tag diff failed')
-      );
-      expect(childLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('AccessDeniedException')
-      );
+      // GetConfig + Update + GetDistribution + TagResource = 4 sends attempted.
+      expect(mockSend).toHaveBeenCalledTimes(4);
     });
 
     it('update mixed adds + removes issues Untag then Tag in that order', async () => {

--- a/tests/unit/provisioning/s3-tables-table-tags-wire.test.ts
+++ b/tests/unit/provisioning/s3-tables-table-tags-wire.test.ts
@@ -207,14 +207,20 @@ describe('S3TablesProvider — AWS::S3Tables::Table Tags wire (#609 backfill)', 
       expect(mockSend.mock.calls[2][0].input.tags).toEqual({ env: 'prod', team: 'platform' });
     });
 
-    it('tag-side AWS failure is best-effort — does NOT throw (deploy progresses)', async () => {
-      // GetTable succeeds, TagResource fails — the whole update() still
-      // resolves (warn-log only, no throw).
+    it('tag-side AWS failure THROWS ProvisioningError (issue #740 — was warn-swallow, now propagates)', async () => {
+      // Pre-#740: warn-swallowed the throttle, let update() resolve, and
+      // the deploy engine recorded the new properties.Tags into state as
+      // if applied. AWS-side tags then stayed stale forever (next deploy
+      // sees no diff → no retry).
+      //
+      // Post-#740: throw a ProvisioningError so state is NOT written and
+      // the next deploy retries the tag-diff against the still-old state.
+      // For the S3Tables Table case update() is otherwise a no-op (Table
+      // itself is immutable), so a tag-side throw cleanly turns the whole
+      // update into a clean retry with no side-effects.
       mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN });
       mockSend.mockRejectedValueOnce(new Error('throttled'));
 
-      // Must not throw — the deploy engine's outer retry would otherwise
-      // re-issue the no-op update() body unnecessarily.
       await expect(
         provider.update(
           'L',
@@ -223,7 +229,10 @@ describe('S3TablesProvider — AWS::S3Tables::Table Tags wire (#609 backfill)', 
           { Tags: [{ Key: 'env', Value: 'prod' }] },
           {}
         )
-      ).resolves.toEqual({ physicalId: PHYSICAL_ID, wasReplaced: false });
+      ).rejects.toThrow(/TagResource failed.*throttled/s);
+
+      // GetTable + TagResource attempted; throw fires after TagResource fails.
+      expect(mockSend).toHaveBeenCalledTimes(2);
     });
 
     it('TableBucket / Namespace types stay no-op (tag-diff is Table-only in this PR)', async () => {


### PR DESCRIPTION
## Summary

Closes [#740](https://github.com/go-to-k/cdkd/issues/740) — coordinated fix across the 2 providers that ship the Tags-on-update pattern.

### The bug

Both [CloudFront's `tryApplyTagDiff`](https://github.com/go-to-k/cdkd/pull/733) and [S3Tables::Table's `applyTableTagsDiff`](https://github.com/go-to-k/cdkd/pull/739) caught `TagResource` / `UntagResource` failures with `try/catch` and only warn-logged. `update()` then returned success unconditionally. The deploy engine wrote the new `properties.Tags` into state as if applied. Next deploy compared (new template Tags) against (just-written new state Tags), saw no diff, and **never retried** — a single transient throttle silently corrupted tag state until the user manually edited state or recreated the resource.

### The fix

Replace warn-swallow with a typed `ProvisioningError` in both providers:

- state is NOT written when `update()` throws → next deploy's diff (still-old state Tags vs new template Tags) re-fires the tag-diff naturally.
- non-transient failures (`AccessDenied`, invalid tag) surface to the user via the standard error path — they see the failure in the deploy output and can react.
- the **load-bearing retry guarantee is the next-deploy retry**, not in-deploy retry. cdkd's retry classifier (`isRetryableTransientError`) walks only ONE level of `.cause`, and CloudFront's `update()` outer catch double-wraps the thrown `ProvisioningError` — so bare HTTP 429 throttles can slip past the classifier's status-code check. Provider comments tone-corrected to reflect this; a follow-up could either widen the classifier's cause walk or drop CF's outer rewrap.

### Trade-offs (acknowledged)

- **CloudFront**: `UpdateDistribution` is called BEFORE the tag-diff. A tag-side throw means `UpdateDistribution` already committed. The next deploy will re-issue `UpdateDistribution` against the now-current config — AWS accepts that as a no-op idempotently. Cheaper than silent tag drift.
- **S3Tables::Table**: `update()` is otherwise a no-op (Table itself is immutable; tag-diff is the only mutable surface), so a tag-side throw cleanly turns the whole update into a clean retry with no side-effects.

### Per-provider details

**CloudFront** (`cloudfront-distribution-provider.ts`):
- Method renamed `tryApplyTagDiff` → `applyTagDiff` (the `try` prefix implied swallow; now it propagates).
- The missing-ARN defensive branch also throws (was warn-and-skip pre-#740).

**S3Tables::Table** (`s3-tables-provider.ts`):
- `applyTableTagsDiff` signature extended with `logicalId` + `resourceType` so the thrown `ProvisioningError` carries standard cdkd error context.
- The malformed-physicalId / GetTable-NotFound branches throw too — both indicate a state-vs-AWS divergence the user needs to see, not silently skip past. The NotFound throw includes a pointer to `cdkd state orphan <logicalId>` for the out-of-band-deletion case.

### Tests

3 tests inverted from "warn + return" to "throws ProvisioningError":
- `cloudfront-distribution-provider.test.ts:update with tag diff but missing ARN THROWS`
- `cloudfront-distribution-provider.test.ts:update tag-side failure THROWS`
- `s3-tables-table-tags-wire.test.ts:tag-side AWS failure THROWS ProvisioningError`

All other existing tests (~17 across the 2 providers' Tags wire) continue to pass — happy-path semantics unchanged.

### Reviewer-flagged sweep (per /verify-pr step 11)

- **Overstated in-deploy retry doc** (1 reviewer minor finding): provider comments + commit message claimed the engine's `withRetry` classifier would pick up transient throttles within the same deploy. The classifier's single-level `.cause` walk + CF's outer-catch double-wrap means this is overstated. Toned down both provider comments + this PR body to reflect that the **next-deploy retry** is the load-bearing guarantee.
- **CF / S3Tables outer-catch asymmetry** (1 reviewer minor finding, deferred): CloudFront's `update()` double-wraps thrown `ProvisioningError`; S3Tables passes through. Should be unified in a follow-up (small refactor; doesn't affect correctness of this PR).
- **Escaped backtick rendering literally** (1 reviewer nit): the S3Tables GetTable-NotFound throw message used `` `cdkd state orphan ${id}` `` which renders the leading `\`` as literal text. Switched to single quotes. Fixed in this PR.

### Integ verification

- `/run-integ s3-tables` passed clean against the just-merged T fixture: SDK routing confirmed (`provisionedBy=sdk`), both tags reached AWS via `ListTagsForResource`, 3/3 resources destroyed clean (0 errors, 0 orphans). The happy-path behavior is unchanged from pre-#740 (the swallow-throw flip only affects failure paths, which are unit-tested with mocked rejections).

## Test plan

- [x] `vp check` (lint + typecheck + format) — clean
- [x] `vp run test` — 5393 tests pass, 1 skipped (no fails)
- [x] `/run-integ s3-tables` — PASS (SDK routing + Tags reached AWS + clean destroy)
- [x] `/review-pr` 1-reviewer pass — no blockers, 3 minor/nit findings addressed (1 deferred to follow-up)
- [ ] CI green