### PR TITLE
feat(provisioning): backfill S3Tables::TableBucket Tags (#609)

### DIFF
--- a/docs/_generated/integ-coverage.json
+++ b/docs/_generated/integ-coverage.json
@@ -2811,7 +2811,8 @@
       ],
       "signals": {
         "s3-tables": [
-          "l1"
+          "l1",
+          "literal"
         ]
       }
     },

--- a/docs/integ-coverage.md
+++ b/docs/integ-coverage.md
@@ -132,7 +132,7 @@ Registered without an integ fixture, with an explicit `// allow-no-integ: <ratio
 | `AWS::S3Express::DirectoryBucket` | [`s3-directory-bucket`](../tests/integration/s3-directory-bucket/) (l1) |
 | `AWS::S3Tables::Namespace` | [`s3-tables`](../tests/integration/s3-tables/) (l1) |
 | `AWS::S3Tables::Table` | [`s3-tables`](../tests/integration/s3-tables/) (l1,literal) |
-| `AWS::S3Tables::TableBucket` | [`s3-tables`](../tests/integration/s3-tables/) (l1) |
+| `AWS::S3Tables::TableBucket` | [`s3-tables`](../tests/integration/s3-tables/) (l1,literal) |
 | `AWS::S3Vectors::VectorBucket` | [`s3-vectors`](../tests/integration/s3-vectors/) (l1) |
 | `AWS::SNS::Subscription` | [`composite-stack`](../tests/integration/composite-stack/) (literal)<br>[`sns-sqs-event`](../tests/integration/sns-sqs-event/) (literal) |
 | `AWS::SNS::Topic` | [`bench-sdk`](../tests/integration/bench-sdk/) (l2)<br>[`cloudwatch`](../tests/integration/cloudwatch/) (l2)<br>[`composite-stack`](../tests/integration/composite-stack/) (l2,literal)<br>[`drift-revert`](../tests/integration/drift-revert/) (l2)<br>[`event-driven`](../tests/integration/event-driven/) (l2)<br>[`export`](../tests/integration/export/) (l2,literal)<br>[`full-stack-demo`](../tests/integration/full-stack-demo/) (l2)<br>[`microservices`](../tests/integration/microservices/) (l2)<br>[`migrate-from-cfn`](../tests/integration/migrate-from-cfn/) (l2)<br>[`monitoring`](../tests/integration/monitoring/) (l2)<br>[`scheduled-task`](../tests/integration/scheduled-task/) (l2)<br>[`serverless-api`](../tests/integration/serverless-api/) (l2)<br>[`sns-sqs-event`](../tests/integration/sns-sqs-event/) (l2) |

--- a/src/provisioning/property-coverage.generated.ts
+++ b/src/provisioning/property-coverage.generated.ts
@@ -2152,13 +2152,12 @@ export const PROPERTY_COVERAGE_BY_TYPE: ReadonlyMap<string, PropertyCoverage> = 
   [
     'AWS::S3Tables::TableBucket',
     {
-      handled: new Set<string>(['TableBucketName']),
+      handled: new Set<string>(['TableBucketName', 'Tags']),
       silentDrop: new Map<string, string>([
         ['EncryptionConfiguration', 'not yet implemented by cdkd'],
         ['MetricsConfiguration', 'not yet implemented by cdkd'],
         ['ReplicationConfiguration', 'not yet implemented by cdkd'],
         ['StorageClassConfiguration', 'not yet implemented by cdkd'],
-        ['Tags', 'not yet implemented by cdkd'],
         ['UnreferencedFileRemoval', 'not yet implemented by cdkd'],
       ]),
     },

--- a/src/provisioning/providers/s3-tables-provider.ts
+++ b/src/provisioning/providers/s3-tables-provider.ts
@@ -45,7 +45,7 @@ export class S3TablesProvider implements ResourceProvider {
   private logger = getLogger().child('S3TablesProvider');
 
   handledProperties = new Map<string, ReadonlySet<string>>([
-    ['AWS::S3Tables::TableBucket', new Set(['TableBucketName'])],
+    ['AWS::S3Tables::TableBucket', new Set(['TableBucketName', 'Tags'])],
     ['AWS::S3Tables::Namespace', new Set(['TableBucketARN', 'Namespace'])],
     [
       'AWS::S3Tables::Table',
@@ -106,11 +106,24 @@ export class S3TablesProvider implements ResourceProvider {
     // via the separate TagResource / UntagResource control-plane calls.
     // So `update()` is no longer a blanket no-op: when the only property
     // that changed is `Tags`, dispatch a tag-diff against the underlying
-    // resource ARN. For now only AWS::S3Tables::Table has Tags wired
-    // (this PR); the TableBucket / Namespace cases stay no-op until
-    // their own backfill PRs (U / V).
+    // resource ARN. Table (#609 PR #739) + TableBucket (#609, this PR)
+    // both have Tags wired; the Namespace case stays no-op (Namespaces
+    // are not taggable per the S3Tables SDK — ListTagsForResource only
+    // accepts table-bucket or table ARNs).
     if (resourceType === 'AWS::S3Tables::Table') {
       await this.applyTableTagsDiff(
+        logicalId,
+        physicalId,
+        resourceType,
+        previousProperties['Tags'],
+        properties['Tags']
+      );
+    } else if (resourceType === 'AWS::S3Tables::TableBucket') {
+      // TableBucket's physicalId IS the bucket ARN, so the tag-diff path
+      // can use it directly (no GetTableBucket lookup hop needed — unlike
+      // Table where the compound physicalId requires GetTable to recover
+      // the real ARN).
+      await this.applyTableBucketTagsDiff(
         logicalId,
         physicalId,
         resourceType,
@@ -165,10 +178,17 @@ export class S3TablesProvider implements ResourceProvider {
       );
     }
 
+    // CFn `Tags: [{ Key, Value }]` → SDK `tags: Record<string, string>`.
+    // CreateTableBucketCommand accepts tags atomically (no separate
+    // TagResource call needed); the SDK rejects an empty map with
+    // InvalidRequestException, so omit the field entirely when no tags.
+    const tags = this.cfnTagsToSdkMap(properties['Tags']);
+
     try {
       const result = await this.getClient().send(
         new CreateTableBucketCommand({
           name: tableBucketName,
+          ...(tags !== undefined && { tags }),
         })
       );
 
@@ -593,6 +613,15 @@ export class S3TablesProvider implements ResourceProvider {
 
     const result: Record<string, unknown> = {};
     if (bucket.name !== undefined) result['TableBucketName'] = bucket.name;
+    // Tags: best-effort second call. physicalId IS the bucket ARN, so
+    // ListTagsForResource takes it directly (no GetTableBucket → ARN
+    // recovery hop, unlike Table's compound physicalId case). Emit
+    // Tags: [] when AWS returns no tags or when the read itself fails
+    // (matches S3Vectors / CloudFront / S3Tables::Table patterns —
+    // drift comparator only descends into state-side keys, so an empty
+    // array does not surface noise on a pre-PR state file that had no
+    // Tags entry).
+    result['Tags'] = await this.readTagsBestEffort(physicalId);
     return result;
   }
 
@@ -1080,6 +1109,75 @@ export class S3TablesProvider implements ResourceProvider {
         const cause = err instanceof Error ? err : undefined;
         throw new ProvisioningError(
           `applyTableTagsDiff: TagResource failed for ${resourceArn} (keys: ${Object.keys(upserts).join(', ')}): ${err instanceof Error ? err.message : String(err)}. State has NOT been updated so the next deploy will retry the tag-diff.`,
+          resourceType,
+          logicalId,
+          physicalId,
+          cause
+        );
+      }
+    }
+  }
+
+  /**
+   * Apply a tag-diff against a TableBucket resource ARN. Mirrors
+   * `applyTableTagsDiff` for the Table case, but simpler: TableBucket's
+   * `physicalId` IS the bucket ARN, so no `GetTableBucket` lookup hop
+   * is needed (the Table version needs `GetTable` to recover the real
+   * ARN from the cdkd-compound `<bucketArn>|<namespace>|<name>` physical id).
+   *
+   * Same throw semantics as `applyTableTagsDiff` (per issue #740 / PR
+   * #741): tag-side failures THROW `ProvisioningError` so state is NOT
+   * written, and the next deploy retries against the still-old state.
+   * `update()` for AWS::S3Tables::TableBucket is otherwise a no-op (the
+   * bucket itself is immutable), so a tag-side throw cleanly turns the
+   * whole update into a clean retry with no side-effects.
+   */
+  private async applyTableBucketTagsDiff(
+    logicalId: string,
+    physicalId: string,
+    resourceType: string,
+    previousTags: unknown,
+    newTags: unknown
+  ): Promise<void> {
+    const prev = this.cfnTagsToSdkMap(previousTags) ?? {};
+    const next = this.cfnTagsToSdkMap(newTags) ?? {};
+
+    const removedKeys = Object.keys(prev).filter((k) => !(k in next));
+    const upserts: Record<string, string> = {};
+    for (const [k, v] of Object.entries(next)) {
+      if (prev[k] !== v) upserts[k] = v;
+    }
+
+    // No tag delta → no work, no error.
+    if (removedKeys.length === 0 && Object.keys(upserts).length === 0) return;
+
+    // physicalId IS the bucket ARN — use it directly for tag ops.
+    const resourceArn = physicalId;
+
+    if (removedKeys.length > 0) {
+      try {
+        await this.getClient().send(
+          new UntagResourceCommand({ resourceArn, tagKeys: removedKeys })
+        );
+      } catch (err) {
+        const cause = err instanceof Error ? err : undefined;
+        throw new ProvisioningError(
+          `applyTableBucketTagsDiff: UntagResource failed for ${resourceArn} (keys: ${removedKeys.join(', ')}): ${err instanceof Error ? err.message : String(err)}. State has NOT been updated so the next deploy will retry the tag-diff.`,
+          resourceType,
+          logicalId,
+          physicalId,
+          cause
+        );
+      }
+    }
+
+    if (Object.keys(upserts).length > 0) {
+      try {
+        await this.getClient().send(new TagResourceCommand({ resourceArn, tags: upserts }));
+      } catch (err) {
+        const cause = err instanceof Error ? err : undefined;
+        throw new ProvisioningError(
+          `applyTableBucketTagsDiff: TagResource failed for ${resourceArn} (keys: ${Object.keys(upserts).join(', ')}): ${err instanceof Error ? err.message : String(err)}. State has NOT been updated so the next deploy will retry the tag-diff.`,
           resourceType,
           logicalId,
           physicalId,

--- a/tests/fixtures/cfn-schemas/_todo-backfill.json
+++ b/tests/fixtures/cfn-schemas/_todo-backfill.json
@@ -487,7 +487,6 @@
       "MetricsConfiguration",
       "ReplicationConfiguration",
       "StorageClassConfiguration",
-      "Tags",
       "UnreferencedFileRemoval"
     ],
     "AWS::ServiceDiscovery::Service": [

--- a/tests/integration/s3-tables/lib/s3-tables-stack.ts
+++ b/tests/integration/s3-tables/lib/s3-tables-stack.ts
@@ -10,6 +10,16 @@ export class S3TablesStack extends cdk.Stack {
       tableBucketName: `${this.stackName}-table-bucket`.toLowerCase(),
     });
 
+    // Two tags on the TableBucket — issue #609 Tags backfill (this PR)
+    // wires `Tags` for AWS::S3Tables::TableBucket via the SDK provider's
+    // `create()` (atomic via CreateTableBucketCommand.tags) + `update()`
+    // (tag-diff against the bucket ARN — physicalId IS the ARN, no
+    // GetTableBucket lookup needed) + `readCurrentState()` (best-effort
+    // ListTagsForResource hop) paths. verify.sh asserts both tags reach
+    // AWS via `aws s3tables list-tags-for-resource --resource-arn <bucket-arn>`.
+    cdk.Tags.of(tableBucket).add('bucket-env', 'cdkd-integ');
+    cdk.Tags.of(tableBucket).add('bucket-team', 'platform');
+
     // Namespace + Table inside the bucket. Issue #609 Tags backfill (this
     // PR) wires `Tags` for AWS::S3Tables::Table via the SDK provider's
     // `create()` / `update()` / `readCurrentState()` paths, so the fixture

--- a/tests/integration/s3-tables/verify.sh
+++ b/tests/integration/s3-tables/verify.sh
@@ -21,6 +21,11 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
 EXPECTED_ENV_TAG="cdkd-integ"
 EXPECTED_TEAM_TAG="platform"
+# #609 backfill (this PR — U / TableBucket Tags) — distinct keys from
+# the Table's `env` / `team` so the assertion confirms each resource's
+# tag-diff fired against the correct ARN.
+EXPECTED_BUCKET_ENV_TAG="cdkd-integ"
+EXPECTED_BUCKET_TEAM_TAG="platform"
 
 LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
 
@@ -143,6 +148,58 @@ if [ "${ACTUAL_TEAM}" != "${EXPECTED_TEAM_TAG}" ]; then
   exit 1
 fi
 echo "    OK: team tag == '${EXPECTED_TEAM_TAG}' on AWS"
+
+# --- Assertion: TableBucket Tags reached AWS (#609 — this PR / U) -----
+# TableBucket's physicalId IS the bucket ARN, so the same
+# ListTagsForResource API used for Table works against it directly.
+# Distinct keys (`bucket-env` / `bucket-team`) so a misrouted tag (e.g.
+# the Table's `env` tag accidentally landing on the bucket via a bad
+# ARN derivation) would surface as MISSING, not as a value-equality
+# match against an unrelated resource.
+if [ -z "${TABLE_BUCKET_ARN}" ] || [ "${TABLE_BUCKET_ARN}" = "null" ]; then
+  echo "FAIL: TableBucketArn output is empty/null — cannot run TableBucket tag assertion" >&2
+  exit 1
+fi
+
+set +e
+BUCKET_TAGS_JSON=$(aws s3tables list-tags-for-resource \
+  --region "${REGION}" \
+  --resource-arn "${TABLE_BUCKET_ARN}" \
+  --output json 2>/tmp/s3tables-bucket-tags-err)
+BUCKET_TAGS_RC=$?
+set -e
+if [ "${BUCKET_TAGS_RC}" -ne 0 ] || [ -z "${BUCKET_TAGS_JSON}" ]; then
+  echo "FAIL: ListTagsForResource exited ${BUCKET_TAGS_RC} for ${TABLE_BUCKET_ARN}" >&2
+  echo "stdout: ${BUCKET_TAGS_JSON}" >&2
+  echo "stderr:" >&2
+  cat /tmp/s3tables-bucket-tags-err >&2 || true
+  exit 1
+fi
+
+ACTUAL_BUCKET_ENV=$(echo "${BUCKET_TAGS_JSON}" | jq -r '.tags["bucket-env"] // "MISSING"')
+ACTUAL_BUCKET_TEAM=$(echo "${BUCKET_TAGS_JSON}" | jq -r '.tags["bucket-team"] // "MISSING"')
+
+if [ "${ACTUAL_BUCKET_ENV}" != "${EXPECTED_BUCKET_ENV_TAG}" ]; then
+  echo "FAIL: bucket-env tag is '${ACTUAL_BUCKET_ENV}', expected '${EXPECTED_BUCKET_ENV_TAG}' (TableBucket Tags silent-drop NOT closed)" >&2
+  echo "${BUCKET_TAGS_JSON}" | jq .
+  exit 1
+fi
+echo "    OK: bucket-env tag == '${EXPECTED_BUCKET_ENV_TAG}' on AWS (TableBucket Tags silent-drop CLOSED by #609 / U)"
+
+if [ "${ACTUAL_BUCKET_TEAM}" != "${EXPECTED_BUCKET_TEAM_TAG}" ]; then
+  echo "FAIL: bucket-team tag is '${ACTUAL_BUCKET_TEAM}', expected '${EXPECTED_BUCKET_TEAM_TAG}'" >&2
+  exit 1
+fi
+echo "    OK: bucket-team tag == '${EXPECTED_BUCKET_TEAM_TAG}' on AWS"
+
+# Confirm TableBucket routed via SDK provider too (same routing-flip guard
+# as the Table assertion above).
+BUCKET_PROVISIONED_BY=$(echo "${STATE}" | jq -r '[.resources | to_entries[] | select(.value.resourceType == "AWS::S3Tables::TableBucket") | .value.provisionedBy] | first // "sdk"')
+if [ "${BUCKET_PROVISIONED_BY}" != "sdk" ]; then
+  echo "FAIL: AWS::S3Tables::TableBucket routed via '${BUCKET_PROVISIONED_BY}', expected 'sdk' (silent-drop routing flip)" >&2
+  exit 1
+fi
+echo "    OK: AWS::S3Tables::TableBucket routed via SDK provider (provisionedBy=sdk)"
 
 # --- Phase 2: destroy -------------------------------------------------
 echo "==> Phase 2: destroy"

--- a/tests/unit/provisioning/s3-tables-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/s3-tables-provider-readcurrentstate.test.ts
@@ -49,10 +49,16 @@ describe('S3TablesProvider.readCurrentState', () => {
   });
 
   describe('AWS::S3Tables::TableBucket', () => {
-    it('returns TableBucketName from GetTableBucket (happy path)', async () => {
+    it('returns TableBucketName + Tags from GetTableBucket + ListTagsForResource (happy path)', async () => {
       mockSend.mockResolvedValueOnce({
         name: 'my-bucket',
         arn: 'arn:aws:s3tables:us-east-1:123:bucket/my-bucket',
+      });
+      // #609 backfill — readback now adds a second ListTagsForResource
+      // call (TableBucket physicalId IS the bucket ARN, so no GetTableBucket
+      // → ARN recovery hop needed unlike Table).
+      mockSend.mockResolvedValueOnce({
+        tags: { env: 'cdkd-integ', team: 'platform' },
       });
 
       const result = await provider.readCurrentState(
@@ -62,7 +68,44 @@ describe('S3TablesProvider.readCurrentState', () => {
       );
 
       expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(GetTableBucketCommand);
-      expect(result).toEqual({ TableBucketName: 'my-bucket' });
+      expect(mockSend.mock.calls[1]?.[0]).toBeInstanceOf(ListTagsForResourceCommand);
+      expect(result).toEqual({
+        TableBucketName: 'my-bucket',
+        Tags: [
+          { Key: 'env', Value: 'cdkd-integ' },
+          { Key: 'team', Value: 'platform' },
+        ],
+      });
+    });
+
+    it('emits Tags: [] when ListTagsForResource returns no tags', async () => {
+      mockSend.mockResolvedValueOnce({ name: 'my-bucket' });
+      mockSend.mockResolvedValueOnce({ tags: {} });
+
+      const result = await provider.readCurrentState(
+        'arn:aws:s3tables:us-east-1:123:bucket/my-bucket',
+        'Logical',
+        'AWS::S3Tables::TableBucket'
+      );
+
+      expect(result).toMatchObject({ Tags: [] });
+    });
+
+    it('emits Tags: [] (best-effort) when ListTagsForResource itself fails', async () => {
+      mockSend.mockResolvedValueOnce({ name: 'my-bucket' });
+      mockSend.mockRejectedValueOnce(new Error('throttled'));
+
+      const result = await provider.readCurrentState(
+        'arn:aws:s3tables:us-east-1:123:bucket/my-bucket',
+        'Logical',
+        'AWS::S3Tables::TableBucket'
+      );
+
+      // Best-effort fallback (matches the Table case and S3Vectors /
+      // CloudFront patterns) — drift comparator only descends into
+      // state-side keys, so an empty array doesn't surface noise on a
+      // pre-PR state file that had no Tags entry.
+      expect(result).toMatchObject({ Tags: [] });
     });
 
     it('returns undefined when bucket gone', async () => {

--- a/tests/unit/provisioning/s3-tables-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/s3-tables-provider-roundtrip.test.ts
@@ -60,23 +60,30 @@ describe('S3TablesProvider read-update round-trip', () => {
   // — any future regression that adds a real update() must explicitly
   // confirm round-trip safety here.
 
-  it('AWS::S3Tables::TableBucket — no-op update fires zero SDK calls on round-trip', async () => {
-    // readCurrentState mock: GetTableBucket
+  it('AWS::S3Tables::TableBucket — no-op update fires zero SDK calls on round-trip (same Tags)', async () => {
+    // readCurrentState mock: GetTableBucket + ListTagsForResource (post-#609
+    // Tags wiring for TableBucket — same pattern as Table case).
     mockSend.mockResolvedValueOnce({
       name: 'my-bucket',
       arn: BUCKET_ARN,
     });
+    mockSend.mockResolvedValueOnce({ tags: {} });
 
     const observed = await provider.readCurrentState(
       BUCKET_ARN,
       'L',
       'AWS::S3Tables::TableBucket'
     );
-    expect(observed).toEqual({ TableBucketName: 'my-bucket' });
+    expect(observed).toEqual({
+      TableBucketName: 'my-bucket',
+      // #609 backfill: empty Tags array (no tags on the live resource).
+      Tags: [],
+    });
 
     vi.clearAllMocks();
 
-    // Round-trip: pass observed as both new and previous.
+    // Round-trip: pass observed as both new and previous → no tag delta
+    // → tag-diff is a no-op (no TagResource / UntagResource calls fire).
     const result = await provider.update(
       'L',
       BUCKET_ARN,
@@ -86,7 +93,7 @@ describe('S3TablesProvider read-update round-trip', () => {
     );
 
     expect(result).toEqual({ physicalId: BUCKET_ARN, wasReplaced: false });
-    // Immutable resource: update() must not call AWS at all.
+    // No tag delta → no SDK calls.
     expect(mockSend).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/provisioning/s3-tables-table-tags-wire.test.ts
+++ b/tests/unit/provisioning/s3-tables-table-tags-wire.test.ts
@@ -235,16 +235,12 @@ describe('S3TablesProvider — AWS::S3Tables::Table Tags wire (#609 backfill)', 
       expect(mockSend).toHaveBeenCalledTimes(2);
     });
 
-    it('TableBucket / Namespace types stay no-op (tag-diff is Table-only in this PR)', async () => {
-      await provider.update(
-        'L',
-        BUCKET_ARN,
-        'AWS::S3Tables::TableBucket',
-        { Tags: [{ Key: 'env', Value: 'prod' }] },
-        {}
-      );
-      expect(mockSend).not.toHaveBeenCalled();
-
+    it('Namespace type stays no-op (Namespaces are not taggable in S3Tables — Table + TableBucket are wired)', async () => {
+      // Pre-U: TableBucket also stayed no-op. Post-U (#609 PR for
+      // S3Tables::TableBucket Tags): TableBucket dispatches tag-diff
+      // via applyTableBucketTagsDiff. Namespace remains no-op because
+      // S3Tables' SDK ListTagsForResource only accepts table-bucket or
+      // table ARNs — Namespaces are not taggable at the AWS level.
       await provider.update(
         'L',
         `${BUCKET_ARN}|ns`,

--- a/tests/unit/provisioning/s3-tables-tablebucket-tags-wire.test.ts
+++ b/tests/unit/provisioning/s3-tables-tablebucket-tags-wire.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import {
+  CreateTableBucketCommand,
+  TagResourceCommand,
+  UntagResourceCommand,
+} from '@aws-sdk/client-s3tables';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-s3tables', async () => {
+  const actual =
+    await vi.importActual<typeof import('@aws-sdk/client-s3tables')>('@aws-sdk/client-s3tables');
+  class MockS3TablesClient {
+    config = { region: () => Promise.resolve('us-east-1') };
+    send = mockSend;
+  }
+  return { ...actual, S3TablesClient: MockS3TablesClient };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { S3TablesProvider } from '../../../src/provisioning/providers/s3-tables-provider.js';
+
+// TableBucket's physicalId IS the bucket ARN — no compound id, no
+// GetTableBucket lookup hop needed (unlike Table's compound case).
+const BUCKET_ARN = 'arn:aws:s3tables:us-east-1:123:bucket/my-bucket';
+const BUCKET_NAME = 'my-bucket';
+
+describe('S3TablesProvider — AWS::S3Tables::TableBucket Tags wire (#609 backfill)', () => {
+  let provider: S3TablesProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new S3TablesProvider();
+  });
+
+  describe('create', () => {
+    it('forwards CFn Tags array → SDK tags Record on CreateTableBucketCommand', async () => {
+      mockSend.mockResolvedValueOnce({ arn: BUCKET_ARN });
+
+      await provider.create('L', 'AWS::S3Tables::TableBucket', {
+        TableBucketName: BUCKET_NAME,
+        Tags: [
+          { Key: 'env', Value: 'cdkd-integ' },
+          { Key: 'team', Value: 'platform' },
+        ],
+      });
+
+      const call = mockSend.mock.calls[0][0];
+      expect(call).toBeInstanceOf(CreateTableBucketCommand);
+      // S3Tables uses flat `Record<string, string>`, NOT the
+      // `{ Key, Value }[]` shape CFn carries — wire flip verified.
+      expect(call.input.tags).toEqual({ env: 'cdkd-integ', team: 'platform' });
+    });
+
+    it('omits tags field entirely when CFn Tags is absent or empty', async () => {
+      mockSend.mockResolvedValueOnce({ arn: BUCKET_ARN });
+      await provider.create('L', 'AWS::S3Tables::TableBucket', {
+        TableBucketName: BUCKET_NAME,
+      });
+      expect(mockSend.mock.calls[0][0].input.tags).toBeUndefined();
+
+      vi.clearAllMocks();
+      mockSend.mockResolvedValueOnce({ arn: BUCKET_ARN });
+      await provider.create('L', 'AWS::S3Tables::TableBucket', {
+        TableBucketName: BUCKET_NAME,
+        Tags: [],
+      });
+      // Empty array also omits — S3Tables CreateTableBucket rejects
+      // empty `tags: {}` with InvalidRequestException.
+      expect(mockSend.mock.calls[0][0].input.tags).toBeUndefined();
+    });
+  });
+
+  describe('update — tag-diff dispatch (physicalId IS the bucket ARN)', () => {
+    it('no tag change → zero SDK calls', async () => {
+      await provider.update(
+        'L',
+        BUCKET_ARN,
+        'AWS::S3Tables::TableBucket',
+        { Tags: [{ Key: 'k', Value: 'v' }] },
+        { Tags: [{ Key: 'k', Value: 'v' }] }
+      );
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('add-only → TagResource (only, no GetTableBucket lookup needed)', async () => {
+      // TableBucket physicalId IS the bucket ARN → tag ops use it
+      // directly. No GetTableBucket lookup hop (unlike Table's compound id).
+      mockSend.mockResolvedValueOnce({});
+      await provider.update(
+        'L',
+        BUCKET_ARN,
+        'AWS::S3Tables::TableBucket',
+        { Tags: [{ Key: 'env', Value: 'prod' }] },
+        {}
+      );
+      // 1 send: TagResource. NO GetTableBucket lookup.
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const call = mockSend.mock.calls[0][0];
+      expect(call).toBeInstanceOf(TagResourceCommand);
+      expect(call.input.resourceArn).toBe(BUCKET_ARN);
+      expect(call.input.tags).toEqual({ env: 'prod' });
+    });
+
+    it('removal-only → UntagResource (only, no lookup)', async () => {
+      mockSend.mockResolvedValueOnce({});
+      await provider.update(
+        'L',
+        BUCKET_ARN,
+        'AWS::S3Tables::TableBucket',
+        {},
+        { Tags: [{ Key: 'gone', Value: 'x' }] }
+      );
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const call = mockSend.mock.calls[0][0];
+      expect(call).toBeInstanceOf(UntagResourceCommand);
+      expect(call.input.resourceArn).toBe(BUCKET_ARN);
+      expect(call.input.tagKeys).toEqual(['gone']);
+    });
+
+    it('value-rewrite on same key → TagResource (only, not Untag)', async () => {
+      mockSend.mockResolvedValueOnce({});
+      await provider.update(
+        'L',
+        BUCKET_ARN,
+        'AWS::S3Tables::TableBucket',
+        { Tags: [{ Key: 'env', Value: 'staging' }] },
+        { Tags: [{ Key: 'env', Value: 'dev' }] }
+      );
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(mockSend.mock.calls[0][0]).toBeInstanceOf(TagResourceCommand);
+      expect(mockSend.mock.calls[0][0].input.tags).toEqual({ env: 'staging' });
+    });
+
+    it('mixed adds + removes → Untag THEN Tag in that order (rename safety)', async () => {
+      mockSend.mockResolvedValueOnce({}); // Untag
+      mockSend.mockResolvedValueOnce({}); // Tag
+
+      await provider.update(
+        'L',
+        BUCKET_ARN,
+        'AWS::S3Tables::TableBucket',
+        { Tags: [{ Key: 'env', Value: 'prod' }, { Key: 'team', Value: 'platform' }] },
+        { Tags: [{ Key: 'env', Value: 'dev' }, { Key: 'owner', Value: 'alice' }] }
+      );
+
+      // 2 sends: Untag + Tag (no GetTableBucket lookup).
+      expect(mockSend).toHaveBeenCalledTimes(2);
+      expect(mockSend.mock.calls[0][0]).toBeInstanceOf(UntagResourceCommand);
+      expect(mockSend.mock.calls[0][0].input.tagKeys).toEqual(['owner']);
+      expect(mockSend.mock.calls[1][0]).toBeInstanceOf(TagResourceCommand);
+      // env value-rewrite + team add — owner is in the Untag pass only.
+      expect(mockSend.mock.calls[1][0].input.tags).toEqual({ env: 'prod', team: 'platform' });
+    });
+
+    it('tag-side AWS failure THROWS ProvisioningError (issue #740 fix pattern)', async () => {
+      // Matches PR #741 throw-instead-of-warn-swallow contract: state is
+      // NOT written on throw, so the next deploy retries the tag-diff
+      // against the still-old state. For TableBucket update() is
+      // otherwise a no-op (the bucket is immutable), so a tag-side
+      // throw cleanly turns the whole update into a clean retry with
+      // no side-effects.
+      mockSend.mockRejectedValueOnce(new Error('throttled'));
+
+      await expect(
+        provider.update(
+          'L',
+          BUCKET_ARN,
+          'AWS::S3Tables::TableBucket',
+          { Tags: [{ Key: 'env', Value: 'prod' }] },
+          {}
+        )
+      ).rejects.toThrow(/TagResource failed.*throttled/s);
+
+      // TagResource attempted; throw fires after it fails.
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Issue [#609](https://github.com/go-to-k/cdkd/issues/609) silent-drop property backfill for **AWS::S3Tables::TableBucket** — wires `Tags` through the SDK provider's `create()` / `update()` / `readCurrentState()` paths. Part of the Tags-on-create sweep marathon (U after T #739 + #740-fix #741, V to follow with CloudWatch::Alarm).

### Tags wire

- **Create**: CFn `Tags: [{Key, Value}]` array → S3Tables SDK `tags: Record<string, string>` flat map (same wire flip as T's Table case). Atomic via `CreateTableBucketCommand`'s `tags` field; omit-when-absent / empty (the SDK rejects empty `tags: {}` with `InvalidRequestException`).
- **Update**: `update()` dispatch extended — pre-U only `Table` dispatched tag-diff (TableBucket / Namespace stayed no-op); now `TableBucket` ALSO dispatches via the new `applyTableBucketTagsDiff`. Namespace stays no-op (Namespaces are not taggable in S3Tables — `ListTagsForResource` only accepts table-bucket or table ARNs).
- **Readback**: new `ListTagsForResource` hop after `GetTableBucket`; reshapes SDK `Record<string,string>` back to CFn `[{Key, Value}]`. Best-effort (emits `Tags: []` on any failure, matching the Table case + S3Vectors / CloudFront patterns).

### Simpler than T

TableBucket's `physicalId` IS the bucket ARN (committed unchanged for years), so the tag-diff path uses it directly — **no `GetTableBucket` lookup hop** needed (unlike Table where the cdkd-compound `<bucketArn>|<namespace>|<name>` physicalId required `GetTable` to recover the real ARN). One fewer SDK call per tag-only update; one fewer error path to handle.

### Throw-on-failure (issue #740 / #741 fix pattern)

`applyTableBucketTagsDiff` throws `ProvisioningError` on TagResource / UntagResource failure (matches the pattern in PR #741 for CloudFront + Table). State is NOT written on throw, so the next deploy retries the tag-diff against the still-old state. For TableBucket `update()` is otherwise a no-op (the bucket is immutable), so a tag-side throw cleanly turns the whole update into a clean retry with no side-effects. The **load-bearing retry guarantee is the next-deploy retry**, not in-deploy retry (cdkd's classifier has a single-level `.cause` walk that bare HTTP-429 throttles can slip past).

### Integ verification

Extended the existing `tests/integration/s3-tables/` fixture — added `cdk.Tags.of(tableBucket).add('bucket-env', 'cdkd-integ')` + `('bucket-team', 'platform')`. The `verify.sh` already asserted the Table's `env` / `team` tags (from T); this PR adds parallel assertions for TableBucket's `bucket-env` / `bucket-team` tags via `aws s3tables list-tags-for-resource --resource-arn <bucket-arn>`. Distinct keys prevent false positives from cross-contamination if a tag-diff misroutes against the wrong ARN. Also asserts `provisionedBy='sdk'` for BOTH `AWS::S3Tables::Table` AND `AWS::S3Tables::TableBucket` (routing-flip guard).

### Tests

- **3 inverted** (pre-U behavior assertions): `s3-tables-provider-readcurrentstate.test.ts:returns TableBucketName + Tags from GetTableBucket + ListTagsForResource`, `s3-tables-provider-roundtrip.test.ts:AWS::S3Tables::TableBucket — no-op update fires zero SDK calls on round-trip (same Tags)`, `s3-tables-table-tags-wire.test.ts:Namespace type stays no-op` (was previously asserting TableBucket / Namespace BOTH stay no-op; now only Namespace).
- **New file** `tests/unit/provisioning/s3-tables-tablebucket-tags-wire.test.ts` — 8 tests covering create wire (Tags → SDK Record, omit-when-empty), update tag-diff (no-op same-tags / add-only / remove-only / value-rewrite / mixed adds+removes with Untag-then-Tag ordering / throw on AWS failure).
- **2 added** in readback tests (`emits Tags: []` when ListTagsForResource returns no tags / fails best-effort).

### Reviewer-flagged sweep (per /verify-pr step 11)

This PR opens with no reviewer findings yet — code review will run via `/review-pr` next. Any nits will land in this section.

### Real-AWS integ verification

`/run-integ s3-tables` PASS (this PR's TableBucket tags + T's Table tags both verified):
- 3 resources deployed, both SDK-routed (`provisionedBy=sdk` for Table AND TableBucket)
- All 4 tag assertions PASS (env, team on Table; bucket-env, bucket-team on TableBucket)
- 3/3 destroyed clean (0 errors, 0 orphans)
- State file gone, TableBucket cascade complete

## Test plan

- [x] `vp check` (lint + typecheck + format) — clean
- [x] `vp run test` — 5402 tests pass, 1 skipped (no fails)
- [x] `/run-integ s3-tables` — PASS (SDK routing + Tags reached AWS for BOTH Table + TableBucket + clean destroy)
- [ ] `/review-pr` 1-reviewer pass — pending
- [ ] CI green