### PR TITLE
chore(local): address PR #744 reviewer nits (trap order, sweep doc, unused arg)

### DIFF
--- a/src/cli/commands/local-start-service.ts
+++ b/src/cli/commands/local-start-service.ts
@@ -40,9 +40,13 @@ export interface LocalStartServiceOptions extends EcsServiceEmulatorOptions {
  * `cdkl start-service` strategy — name one or more ECS services and the engine
  * boots their replicas. There is no front-door listener (services are reached
  * directly via their published container ports). Mirrors `albStrategy` in
- * shape, with `frontDoor` omitted and `lbPortOverrides` empty.
+ * shape, with `frontDoor` omitted and `lbPortOverrides` empty. No-arg to match
+ * cdk-local's bundled `serviceStrategy()` signature exactly — start-service
+ * has no per-invocation options that branch the strategy shape (unlike
+ * `albStrategy(options)`, which threads `--lb-port` parses into
+ * `lbPortOverrides`).
  */
-export function serviceStrategy(_options: EcsServiceEmulatorOptions): EmulatorStrategy {
+export function serviceStrategy(): EmulatorStrategy {
   return {
     pickEntries: (stacks) => listTargets(stacks).ecsServices,
     pickerMessage: 'Select one or more ECS services to run',
@@ -122,12 +126,7 @@ export function createLocalStartServiceCommand(): Command {
     )
     .action(
       withErrorHandling(async (targets: string[], options: LocalStartServiceOptions) => {
-        await runEcsServiceEmulator(
-          targets,
-          options,
-          serviceStrategy(options),
-          cdkdExtraStateProviders
-        );
+        await runEcsServiceEmulator(targets, options, serviceStrategy(), cdkdExtraStateProviders);
       })
     );
 

--- a/tests/integration/local-start-service-watch-fast/verify.sh
+++ b/tests/integration/local-start-service-watch-fast/verify.sh
@@ -39,12 +39,9 @@ HOST_PORT=8087
 
 SERVER_CJS="webapp/server.cjs"
 DOCKERFILE="webapp/Dockerfile"
-SERVER_CJS_BACKUP="$(mktemp)"
-DOCKERFILE_BACKUP="$(mktemp)"
-cp "${SERVER_CJS}" "${SERVER_CJS_BACKUP}"
-cp "${DOCKERFILE}" "${DOCKERFILE_BACKUP}"
-
-LOG_FILE="$(mktemp)"
+SERVER_CJS_BACKUP=""
+DOCKERFILE_BACKUP=""
+LOG_FILE=""
 CDKD_PID=""
 
 term_server() {
@@ -65,11 +62,11 @@ term_server() {
 restore_source() {
   # Put the committed v1 source back so the working tree is unchanged
   # whether the test passed, failed, or was interrupted mid-edit.
-  if [[ -f "${SERVER_CJS_BACKUP}" ]]; then
+  if [[ -n "${SERVER_CJS_BACKUP:-}" && -f "${SERVER_CJS_BACKUP}" ]]; then
     cp "${SERVER_CJS_BACKUP}" "${SERVER_CJS}"
     rm -f "${SERVER_CJS_BACKUP}"
   fi
-  if [[ -f "${DOCKERFILE_BACKUP}" ]]; then
+  if [[ -n "${DOCKERFILE_BACKUP:-}" && -f "${DOCKERFILE_BACKUP}" ]]; then
     cp "${DOCKERFILE_BACKUP}" "${DOCKERFILE}"
     rm -f "${DOCKERFILE_BACKUP}"
   fi
@@ -78,13 +75,31 @@ restore_source() {
 cleanup() {
   term_server
   restore_source
+  # Project convention: integ tests do NOT run in parallel (one /run-integ
+  # invocation at a time). The broad cdkd-local-* sweep is therefore safe
+  # AND robust — if cdkd's own SIGTERM-driven cleanup missed anything
+  # (e.g. process killed before teardown), the sweep catches it. If integ
+  # parallelism is ever introduced, narrow these filters to a per-run
+  # network suffix captured from the boot log.
   docker ps -a --filter "name=cdkd-local-" --format '{{.ID}}' \
     | xargs -r docker rm -f >/dev/null 2>&1 || true
   docker network ls --filter "name=cdkd-local-" --format '{{.ID}}' \
     | xargs -r docker network rm >/dev/null 2>&1 || true
-  rm -f "${LOG_FILE}"
+  if [[ -n "${LOG_FILE:-}" ]]; then
+    rm -f "${LOG_FILE}"
+  fi
 }
+# Install the trap BEFORE any mktemp/cp so a SIGINT in the pre-boot window
+# still triggers restore_source + cleanup. The trap body is null-safe for
+# the unset-backup case via the [[ -n ... ]] guards in restore_source / cleanup.
 trap cleanup EXIT INT TERM
+
+SERVER_CJS_BACKUP="$(mktemp)"
+DOCKERFILE_BACKUP="$(mktemp)"
+cp "${SERVER_CJS}" "${SERVER_CJS_BACKUP}"
+cp "${DOCKERFILE}" "${DOCKERFILE_BACKUP}"
+
+LOG_FILE="$(mktemp)"
 
 # Pre-test orphan sweep - a failed previous run can leak cdkd-local-* state.
 echo "==> Pre-test orphan sweep"

--- a/tests/unit/cli/local-start-service.test.ts
+++ b/tests/unit/cli/local-start-service.test.ts
@@ -4,7 +4,6 @@ import {
   serviceStrategy,
 } from '../../../src/cli/commands/local-start-service.js';
 import { LocalStartServiceError } from '../../../src/utils/error-handler.js';
-import type { EcsServiceEmulatorOptions } from '../../../src/cli/commands/ecs-service-emulator.js';
 import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
 
 describe('createLocalStartServiceCommand', () => {
@@ -164,23 +163,13 @@ describe('serviceStrategy (engine plumbing for runEcsServiceEmulator)', () => {
   // `serviceStrategy` is the load-bearing logic the engine consumes per CLI
   // invocation — the engine's `runEcsServiceEmulator` calls each field on the
   // returned `EmulatorStrategy` exactly once + this test pins each field's
-  // contract without spinning up the engine.
-
-  function makeOptions(over: Partial<EcsServiceEmulatorOptions> = {}): EcsServiceEmulatorOptions {
-    return {
-      output: 'cdk.out',
-      verbose: false,
-      cluster: 'cdkd-local',
-      containerHost: '127.0.0.1',
-      pull: true,
-      maxTasks: 3,
-      restartPolicy: 'on-failure',
-      ...over,
-    } as EcsServiceEmulatorOptions;
-  }
+  // contract without spinning up the engine. `serviceStrategy()` is a no-arg
+  // factory (matches cdk-local upstream); start-service has no per-invocation
+  // options that branch the strategy shape, unlike `albStrategy(options)`
+  // which threads `--lb-port` parses into `lbPortOverrides`.
 
   it('declares the picker text + noun the engine surfaces in TTY mode', () => {
-    const strategy = serviceStrategy(makeOptions());
+    const strategy = serviceStrategy();
     expect(strategy.pickerMessage).toMatch(/Select.*ECS services/i);
     expect(strategy.pickerNoun).toBe('ECS services');
   });
@@ -189,7 +178,7 @@ describe('serviceStrategy (engine plumbing for runEcsServiceEmulator)', () => {
     // Engine calls strategy.onMissing() when no <target> is supplied in a
     // non-interactive context. The thrown class is cdkd's so the surface
     // matches the rest of cdkd's error handling.
-    const strategy = serviceStrategy(makeOptions());
+    const strategy = serviceStrategy();
     const err = strategy.onMissing();
     expect(err).toBeInstanceOf(LocalStartServiceError);
     // The message embeds `getEmbedConfig().cliName` (= 'cdkd local' under
@@ -201,7 +190,7 @@ describe('serviceStrategy (engine plumbing for runEcsServiceEmulator)', () => {
     // start-service has no front-door / listener layer (unlike start-alb),
     // so the override map MUST be empty even when --lb-port-like options
     // ride through the shared options bag.
-    const strategy = serviceStrategy(makeOptions());
+    const strategy = serviceStrategy();
     expect(strategy.lbPortOverrides).toEqual({});
   });
 
@@ -212,7 +201,7 @@ describe('serviceStrategy (engine plumbing for runEcsServiceEmulator)', () => {
     // own `serviceStrategy` (the bundled `cdkl start-service`) sets it; the
     // cdkd-local copy must match so Phase 4 of cdk-local#214 (bind-mount
     // source fast path) fires for `cdkd local start-service --watch`.
-    const strategy = serviceStrategy(makeOptions());
+    const strategy = serviceStrategy();
     expect(strategy.supportsWatch).toBe(true);
   });
 
@@ -221,7 +210,7 @@ describe('serviceStrategy (engine plumbing for runEcsServiceEmulator)', () => {
     // serviceStrategy.resolveBoots only needs to forward the chosen target
     // strings. The return shape pins the contract: ServiceBoot[] + empty
     // warnings + no frontDoor (start-service has no listeners).
-    const strategy = serviceStrategy(makeOptions());
+    const strategy = serviceStrategy();
     const stacks: StackInfo[] = [];
     const out = strategy.resolveBoots(stacks, ['MyStack:Orders', 'MyStack:Web']);
     expect(out.boots).toEqual([{ target: 'MyStack:Orders' }, { target: 'MyStack:Web' }]);
@@ -234,7 +223,7 @@ describe('serviceStrategy (engine plumbing for runEcsServiceEmulator)', () => {
     // so the Cloud Map registry populates BEFORE consumers' `docker run`
     // reads it. The engine boots sequentially; the strategy MUST NOT
     // re-order chosenTargets.
-    const strategy = serviceStrategy(makeOptions());
+    const strategy = serviceStrategy();
     const out = strategy.resolveBoots(
       [],
       ['Stack:Producer', 'Stack:Middle', 'Stack:Consumer']
@@ -250,7 +239,7 @@ describe('serviceStrategy (engine plumbing for runEcsServiceEmulator)', () => {
     // Edge: an empty target list comes from the TTY picker if the user
     // cancels mid-selection. The engine then surfaces "no runnable target"
     // via its own check; the strategy itself MUST NOT throw.
-    const strategy = serviceStrategy(makeOptions());
+    const strategy = serviceStrategy();
     const out = strategy.resolveBoots([], []);
     expect(out.boots).toEqual([]);
     expect(out.warnings).toEqual([]);


### PR DESCRIPTION
## Summary

Follow-up to [PR #744](https://github.com/go-to-k/cdkd/pull/744). Addresses the three Minor / Nit findings the `pr-code-reviewer` agent flagged on #744 (reviewer recommended "ship as-is; tracking-only" on the original PR, but they're cheap to fix cleanly here):

1. **`tests/integration/local-start-service-watch-fast/verify.sh` — trap-order fix.** Install the `trap cleanup EXIT INT TERM` BEFORE the `mktemp` + `cp` calls so a SIGINT in the previously-unprotected ~3-line pre-boot window still triggers `restore_source` + cleanup. The trap body is null-safe for the unset-backup case via new `[[ -n ... ]]` guards in `restore_source` / `cleanup`. Zero behavior change on the happy path; eliminates a 2-tmpfile leak edge case.

2. **Same `verify.sh` — broad-sweep documenting comment.** Add an inline comment on the `cdkd-local-*` post-test sweep explaining why it's kept broad (project convention: integ tests don't run in parallel; the broad sweep is more robust against crashed cdkd processes that didn't clean up after themselves) and a future-awareness pointer (if integ parallelism is ever introduced, narrow to a per-run network suffix captured from the boot log). No runtime change.

3. **`src/cli/commands/local-start-service.ts` — drop unused `_options` arg from `serviceStrategy()`.** Matches cdk-local's bundled `serviceStrategy()` signature exactly. `start-service` has no per-invocation options that branch the strategy shape (unlike `albStrategy(options)`, which threads `--lb-port` parses into `lbPortOverrides`). The single call site in `createLocalStartServiceCommand` and 5 call sites in the unit test all collapse from `serviceStrategy(makeOptions())` / `serviceStrategy(options)` to `serviceStrategy()`. The now-unused `makeOptions` factory and its `EcsServiceEmulatorOptions` type import are removed from the test.

## Diff highlights

- `src/cli/commands/local-start-service.ts` — `serviceStrategy(_options): EmulatorStrategy` → `serviceStrategy(): EmulatorStrategy`; one call site + JSDoc updated
- `tests/integration/local-start-service-watch-fast/verify.sh` — trap install reordered + null-safe guards + broad-sweep comment
- `tests/unit/cli/local-start-service.test.ts` — 5 call sites collapsed; `makeOptions` factory + `EcsServiceEmulatorOptions` import removed

42 insertions / 39 deletions across 3 files. No public API change. No docs touched. No behavior change for users.

## Verification

- `vp check --fix`: typecheck + lint + format → pass
- `vp run build` → pass
- `vp run test` → **5406 / 5406 tests pass** (test count unchanged from #744 — refactor only, no new test cases)
- `/run-integ local-start-service-watch-fast` → **PASS** end-to-end against real Docker (Phase 4 fast path v1→v2 + rebuild fallback v2→v3 + clean SIGTERM teardown). Confirms the trap-order change, the sweep comment, and the no-arg `serviceStrategy()` all work together.

## Test plan

- [x] `vp check --fix` / `vp run build` / `vp run test`
- [x] `/run-integ local-start-service-watch-fast` (Docker integ — no AWS deploy)

No related issue to close.
