### PR TITLE
test(integ): version-agnostic schema-version assertion in import-value-strong-ref

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -3,7 +3,6 @@ bench-cdk-sample	2026-06-01T21:12:13Z	PASS		standard	rc ok, orph clean
 lambda	2026-06-01T21:12:13Z	PASS		standard	rc ok, orph clean
 vpc-nat-gateway	2026-06-01T21:12:13Z	PASS		standard	rc ok, orph clean
 dynamodb-streams	2026-06-01T21:12:13Z	PASS		standard	rc ok, orph clean
-import-value-strong-ref	2026-06-01T21:12:13Z	FAIL		verify.sh	F3 STALE TEST: verify.sh expects schema v4 but actual v8; deploy+strong-ref OK (not a bug)
 composite-stack	2026-06-01T21:12:13Z	PASS		standard	rc ok, orph clean
 nested-stack	2026-06-01T21:12:13Z	PASS		standard	rc ok, orph clean
 custom-resource-provider	2026-06-01T21:12:13Z	FAIL		standard	F2 CR framework role 403 lambda:GetFunction (likely IAM statement-drop); investigate
@@ -34,3 +33,4 @@ cognito	2026-06-01T21:12:13Z	PASS	45	standard	rc ok, orph clean
 multi-stack-deps	2026-06-01T21:31:46Z	PASS		standard	F1 fix verified: deploy/destroy --all clean (cross-stack ordering)
 cross-stack-references	2026-06-01T21:31:46Z	PASS		standard	F1 fix verified: deploy/destroy --all clean (cross-stack ordering)
 multi-resource	2026-06-01T21:45:58Z	PASS		standard	F4 fix verified: single-run clean destroy (ESM in-use now retried)
+import-value-strong-ref	2026-06-02T02:13:34Z	PASS		verify.sh	F3 fixed: version-agnostic schema assertion (>= 4); deploy+strong-ref+destroy clean

--- a/tests/integration/import-value-strong-ref/verify.sh
+++ b/tests/integration/import-value-strong-ref/verify.sh
@@ -72,8 +72,11 @@ if [[ "${IMPORTS_COUNT}" -lt 1 ]]; then
 fi
 echo "    consumer state.imports[]: ${IMPORTS_COUNT} entries (✓)"
 SCHEMA_V=$(echo "${CONSUMER_STATE}" | python3 -c 'import sys, json; print(json.load(sys.stdin)["version"])')
-if [[ "${SCHEMA_V}" != "4" ]]; then
-  echo "FAIL: consumer state schema version is ${SCHEMA_V}, expected 4"
+# imports[] has been recorded since schema v4; assert version-agnostically (>= 4)
+# so a later schema bump (now at v8) does not re-break this test. The imports[]
+# presence is asserted separately above.
+if [[ "${SCHEMA_V}" -lt 4 ]]; then
+  echo "FAIL: consumer state schema version is ${SCHEMA_V}, expected >= 4 (imports[] supported since v4)"
   exit 1
 fi
 echo "    consumer state schema version: ${SCHEMA_V} (✓)"
@@ -182,8 +185,8 @@ ${CDKD} destroy ${CONSUMER} --region "${AWS_REGION}" --state-bucket "${STATE_BUC
 ${CDKD} deploy --all --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET}"
 CONSUMER_STATE_V4=$(aws s3 cp "s3://${STATE_BUCKET}/${CONSUMER_STATE_KEY}" - 2>/dev/null)
 V4_VERSION=$(echo "${CONSUMER_STATE_V4}" | python3 -c 'import sys, json; print(json.load(sys.stdin)["version"])')
-if [[ "${V4_VERSION}" != "4" ]]; then
-  echo "FAIL: consumer state version after redeploy is ${V4_VERSION}, expected 4"
+if [[ "${V4_VERSION}" -lt 4 ]]; then
+  echo "FAIL: consumer state version after redeploy is ${V4_VERSION}, expected >= 4"
   exit 1
 fi
 V4_IMPORTS=$(echo "${CONSUMER_STATE_V4}" | python3 -c 'import sys, json; print(len(json.load(sys.stdin).get("imports", [])))')


### PR DESCRIPTION
## What

Make the `import-value-strong-ref` integ's two consumer-state schema-version
assertions version-agnostic (`>= 4` instead of `== 4`).

## Why

The `verify.sh` hardcoded `schema version == 4` in two spots. The state schema
has since advanced to v8, so the 2026-06-02 regression sweep saw this fixture
FAIL purely on the stale assertion — the actual behavior under test (cross-stack
`Fn::ImportValue` strong-reference deploy, `imports[]` recording, destroy) was
all clean. This is test rot, not a product regression.

`imports[]` has been recorded on consumer state since schema v4, so asserting
`>= 4` is the correct invariant: it keeps verifying the field is present while
no longer re-breaking on every future schema bump. The `imports[]` presence and
count are still asserted separately.

## Verification

Real-AWS re-run of `verify.sh` against `us-east-1`: rc=0, "All
import-value-strong-ref smoke tests passed", "all state files removed". No
orphans. Ledger row (`docs/_generated/integ-last-run.tsv`) flipped to PASS.

## Scope

tests-only (`verify.sh`) + the integ-results ledger. No `src/` change, so no
integ-destroy / integ-broad / integ-local gate applies.
