### PR TITLE
test(integ): synthesize ServiceConnectDefaults in ecs-fargate fixture (useForServiceConnect)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -28,9 +28,9 @@ local-invoke	2026-06-01T21:12:13Z	PASS	20	verify.sh	rc ok, orph clean
 local-start-service	2026-06-01T21:12:13Z	PASS	22	verify.sh	rc ok, orph clean
 apigateway	2026-06-01T21:12:13Z	PASS	45	verify.sh	rc ok, orph clean
 sns-sqs-event	2026-06-01T21:12:13Z	PASS	63	verify.sh	rc ok, orph clean
-ecs-fargate	2026-06-01T21:12:13Z	FAIL	171	verify.sh	F5 ECS Cluster serviceConnectDefaults.namespace silent-drop (deploy/destroy OK)
 cognito	2026-06-01T21:12:13Z	PASS	45	standard	rc ok, orph clean
 multi-stack-deps	2026-06-01T21:31:46Z	PASS		standard	F1 fix verified: deploy/destroy --all clean (cross-stack ordering)
 cross-stack-references	2026-06-01T21:31:46Z	PASS		standard	F1 fix verified: deploy/destroy --all clean (cross-stack ordering)
 multi-resource	2026-06-01T21:45:58Z	PASS		standard	F4 fix verified: single-run clean destroy (ESM in-use now retried)
 import-value-strong-ref	2026-06-02T02:13:34Z	PASS		verify.sh	F3 fixed: version-agnostic schema assertion (>= 4); deploy+strong-ref+destroy clean
+ecs-fargate	2026-06-02T02:28:23Z	PASS		verify.sh	F5 fixed: fixture now sets useForServiceConnect:true so ServiceConnectDefaults is synthesized; ns ARN round-trips via CreateCluster; 18 created/18 deleted 0 errors

--- a/tests/integration/ecs-fargate/lib/ecs-fargate-stack.ts
+++ b/tests/integration/ecs-fargate/lib/ecs-fargate-stack.ts
@@ -40,6 +40,14 @@ export class EcsFargateStack extends cdk.Stack {
       clusterName: `cdkd-ecs-fargate-test`,
       defaultCloudMapNamespace: {
         name: 'cdkd-test.local',
+        // `useForServiceConnect: true` is what makes CDK set the CfnCluster's
+        // `ServiceConnectDefaults: { Namespace: <namespaceArn> }`. Without it,
+        // `defaultCloudMapNamespace` only wires the namespace for the Service's
+        // serviceConnectConfiguration and leaves the Cluster property unset —
+        // so the verify.sh ServiceConnectDefaults assertion (added with the
+        // #609 backfill in PR #726) could never pass. This makes the fixture
+        // actually synthesize the property the backfill is meant to exercise.
+        useForServiceConnect: true,
       },
     });
 


### PR DESCRIPTION
## What

Add `useForServiceConnect: true` to the `ecs-fargate` integ fixture's
`defaultCloudMapNamespace`, so the synthesized `AWS::ECS::Cluster` actually
carries `ServiceConnectDefaults: { Namespace: Fn::GetAtt(<namespace>, Arn) }`.

## Why

The fixture configured `defaultCloudMapNamespace: { name: 'cdkd-test.local' }`
without `useForServiceConnect: true`. CDK only sets the CfnCluster's
`ServiceConnectDefaults` when that flag is true — verified directly in
`aws-cdk-lib`:

```js
useForServiceConnect && (this._cfnCluster.serviceConnectDefaults = {namespace: sdNamespace.namespaceArn})
```

Without it, the synthesized cluster carried only `ClusterName`, so verify.sh's
`cluster.serviceConnectDefaults.namespace` assertion — added with the #609
ServiceConnectDefaults backfill in PR #726 — could never pass. The 2026-06-02
regression sweep flagged `ecs-fargate` as FAIL on exactly this assertion even
though deploy + destroy were otherwise clean.

`ECSClusterProvider.create()`'s `ServiceConnectDefaults` handling was correct
all along; the fixture simply never synthesized the property the backfill was
meant to exercise, so #726 shipped that path unverified. This closes that gap.

## Verification

Real-AWS run (`us-east-1`):

- deploy: 18/18 created — `ClusterDefaultServiceDiscoveryNamespace` created
  before the `Cluster` (the new `Fn::GetAtt` edge orders the DAG correctly).
- assertion: `DescribeClusters` reports
  `serviceConnectDefaults.namespace == arn:aws:servicediscovery:...:namespace/ns-...`
  — the resolved namespace ARN round-trips through `CreateCluster`.
- destroy: 18 deleted, 0 errors, 0 orphans.

Ledger row (`docs/_generated/integ-last-run.tsv`) flipped to PASS.

## Scope

Fixture-only (`tests/integration/ecs-fargate/lib/ecs-fargate-stack.ts`) + the
integ-results ledger. No `src/` change, so no integ-destroy / integ-broad /
integ-local gate applies (though the run was a clean real-AWS deploy+destroy).
