### PR TITLE
test(provisioning): cover the combined ServiceDiscovery Service update path (#609 follow-up)

### DIFF
--- a/tests/unit/provisioning/servicediscovery-provider-service-attributes.test.ts
+++ b/tests/unit/provisioning/servicediscovery-provider-service-attributes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import {
   CreateServiceCommand,
   DeleteServiceCommand,
+  UpdateServiceCommand,
   UpdateServiceAttributesCommand,
   DeleteServiceAttributesCommand,
 } from '@aws-sdk/client-servicediscovery';
@@ -199,6 +200,51 @@ describe('ServiceDiscoveryProvider — ServiceAttributes backfill (#609)', () =>
           { ServiceAttributes: { team: 'cdkd' } }
         )
       ).rejects.toThrow();
+    });
+
+    it('combines a ServiceChange + attribute upsert + attribute removal in one update', async () => {
+      // The three mutation paths are independent and all fire in the same
+      // update() call: UpdateService (ServiceChange body) then
+      // UpdateServiceAttributes (upsert) then DeleteServiceAttributes (remove).
+      mockSend
+        .mockResolvedValueOnce({}) // UpdateService — no OperationId, polling skipped
+        .mockResolvedValueOnce({}) // UpdateServiceAttributes
+        .mockResolvedValueOnce({}); // DeleteServiceAttributes
+
+      const result = await provider.update(
+        'Svc',
+        'srv-1',
+        TYPE,
+        {
+          Description: 'new description',
+          ServiceAttributes: { team: 'cdkd', tier: 'frontend' },
+        },
+        {
+          Description: 'old description',
+          ServiceAttributes: { team: 'cdkd', tier: 'backend', stale: 'gone' },
+        }
+      );
+
+      expect(result).toEqual({ physicalId: 'srv-1', wasReplaced: false });
+
+      // 1. ServiceChange carried Description via UpdateService.
+      const svcChange = callOf(UpdateServiceCommand);
+      expect(svcChange).toBeDefined();
+      expect((svcChange!.input as { Service?: Record<string, unknown> }).Service).toEqual({
+        Description: 'new description',
+      });
+
+      // 2. Only the changed attribute key (`tier`) is upserted (`team` unchanged).
+      const upsert = callOf(UpdateServiceAttributesCommand);
+      expect(upsert).toBeDefined();
+      expect(upsert!.input).toEqual({ ServiceId: 'srv-1', Attributes: { tier: 'frontend' } });
+
+      // 3. The key present only in the old state (`stale`) is removed.
+      const del = callOf(DeleteServiceAttributesCommand);
+      expect(del).toBeDefined();
+      expect(del!.input).toEqual({ ServiceId: 'srv-1', Attributes: ['stale'] });
+
+      expect(mockSend).toHaveBeenCalledTimes(3);
     });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to the `AWS::ServiceDiscovery::Service` `ServiceAttributes` backfill (PR #881, issue #609).

That PR covered each `update()` sub-path in isolation — `ServiceChange`-only, attribute upsert-only, attribute remove-only, no-op, and throw — but did not cover the case where all three mutation paths fire in a **single** `update()` call.

This PR adds one test asserting that an `update()` with a changed `Description` plus a `ServiceAttributes` map that both changes a key and drops a key issues exactly three SDK calls, with the correct inputs:

1. `UpdateService` carrying the `ServiceChange` body (`Description`).
2. `UpdateServiceAttributes` upserting **only** the changed key (`tier`), not the unchanged `team`.
3. `DeleteServiceAttributes` removing the key present only in the previous state (`stale`).

Tests-only; no source change. Closes the combined-update-path gap noted (and accepted as low-value at the time) during PR #881's review.

## Test plan

- `vp run test tests/unit/provisioning/servicediscovery-provider-service-attributes.test.ts` — 9 pass (8 prior + 1 new combined-path).
- Full suite: `vp run test` — all green.
