### PR TITLE
fix(deploy): resolve Ref of API Gateway Model / RequestValidator to the ref segment, not the compound physical id

### DIFF
--- a/docs/_generated/integ-coverage.json
+++ b/docs/_generated/integ-coverage.json
@@ -4112,6 +4112,8 @@
     }
   ],
   "unknownTypesInIntegs": [
+    "AWS::ApiGateway::Model",
+    "AWS::ApiGateway::RequestValidator",
     "AWS::ApiGateway::RestApi",
     "AWS::ApplicationAutoScaling::ScalableTarget",
     "AWS::Athena::NamedQuery",

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -120,7 +120,6 @@ serverless-api	2026-06-15T06:49:27Z	PASS	48	verify.sh	AuthorizerCredentialsArn r
 servicediscovery	2026-06-15T07:22:22Z	PASS	108	verify.sh	ServiceAttributes reached AWS; clean destroy 0 orphans
 cloudwatch	2026-06-15T07:39:23Z	PASS	47	standard	Alarm create+destroy clean 0 orphans (#609 unhandledByDesign cleanup)
 stepfunctions-s3-definition	2026-06-15T08:44:00Z	PASS	55	verify.sh	post-review re-run; DefinitionS3Location+asset fix; destroy clean
-apigateway	2026-06-20T18:40:52Z	PASS		verify.sh	added {proxy+} ANY method; proxy route reached Lambda; 0 err 0 orphan
 s3-event-notification	2026-06-20T18:40:52Z	PASS		verify.sh	S3->Lambda notification fired (DynamoDB record); 3 phases pass, clean destroy, 0 orphan
 lambda-log-retention	2026-06-20T18:40:52Z	PASS		verify.sh	logRetention 7 + in-place UPDATE to 14 (Custom::LogRetention); clean destroy, 0 orphan
 bucket-deployment	2026-06-20T18:40:52Z	PASS		verify.sh	Custom::CDKBucketDeployment synced asset; clean destroy, 0 orphan
@@ -129,7 +128,6 @@ dynamodb-globaltable	2026-06-20T17:59:38Z	PASS		verify.sh	BillingMode/autoscalin
 dynamodb-gsi-update	2026-06-20T18:10:27Z	PASS		verify.sh	#887 add-GSI in-place UPDATE (no replacement); 3 phases pass, clean destroy
 dynamodb-ondemand	2026-06-20T18:12:58Z	PASS		verify.sh	BillingMode/ProvisionedThroughput in-place UPDATE (#887 regression); 3 deleted 0 errors
 bench-cdk-sample	2026-06-20T18:28:56Z	PASS		standard	39 created; destroy 37 del +2 retain-policy LogGroups (swept); 0 errors
-lambda	2026-06-20T18:33:28Z	PASS		verify.sh	RecursiveLoop+ReservedConcurrentExecutions backfills; 9 deleted 0 errors, clean
 microservices	2026-06-20T18:47:03Z	PASS		standard	19 created; 19 deleted 0 errors; state+SNS+SQS+ESM clean (broad)
 multi-resource	2026-06-20T18:50:10Z	PASS		standard	17 created; 17 deleted 0 errors; 3 Lambda LogGroups swept (broad)
 export	2026-06-20T18:58:28Z	PASS		verify.sh	export->CFn migration + no-replacement diff guard (#319) + CFn stack cleanup; clean (broad)
@@ -153,3 +151,5 @@ monitoring	2026-06-21T04:34:50Z	PASS	40	standard	CW alarms/dashboard deploy 7 / 
 data-pipeline	2026-06-21T04:36:15Z	PASS	42	standard	deploy 7 / destroy 7, 0 err
 schema-v7-to-v8-migration	2026-06-21T04:48:25Z	PASS	89	verify.sh	FIXED #751: consumer-only deploy no longer pulls weak GetStackOutput producer into closure
 multi-stack-deps	2026-06-21T04:50:36Z	PASS	60	standard	3-stack deploy order Network->Data->App, destroy reverse, 0 err (post-#751-fix non-regression)
+apigateway	2026-06-21T05:45:25Z	PASS	51	verify.sh	Model/RequestValidator Ref fix; 200/400 asserted; 0 orph
+lambda	2026-06-21T05:48:06Z	PASS	84	verify.sh	broad integ for intrinsic-resolver Ref fix; 0 orph

--- a/docs/integ-coverage.md
+++ b/docs/integ-coverage.md
@@ -146,10 +146,12 @@ Registered without an integ fixture, with an explicit `// allow-no-integ: <ratio
 | `AWS::StepFunctions::StateMachine` | [`iam-propagation-stress`](../tests/integration/iam-propagation-stress/) (l2)<br>[`stepfunctions`](../tests/integration/stepfunctions/) (l2)<br>[`stepfunctions-s3-definition`](../tests/integration/stepfunctions-s3-definition/) (l1) |
 | `AWS::WAFv2::WebACL` | [`wafv2`](../tests/integration/wafv2/) (l1,literal) |
 
-## Resource types referenced in integs without an SDK Provider (30)
+## Resource types referenced in integs without an SDK Provider (32)
 
 These resource types appear in integ fixtures but no SDK Provider is registered for them — they fall through to the Cloud Control API fallback. Listed here for visibility; not actionable on its own.
 
+- `AWS::ApiGateway::Model`
+- `AWS::ApiGateway::RequestValidator`
 - `AWS::ApiGateway::RestApi`
 - `AWS::ApplicationAutoScaling::ScalableTarget`
 - `AWS::Athena::NamedQuery`

--- a/src/deployment/intrinsic-function-resolver.ts
+++ b/src/deployment/intrinsic-function-resolver.ts
@@ -26,6 +26,16 @@ import type { ExportIndexStore } from '../state/export-index-store.js';
 export const AWS_NO_VALUE = Symbol('AWS::NoValue');
 
 /**
+ * Resource types whose CloudFormation `Ref` returns the segment AFTER the pipe
+ * in cdkd's compound Cloud Control physical id `<restApiId>|<ref>` (rather than
+ * the whole physical id). See {@link IntrinsicFunctionResolver.resolveRefValue}.
+ */
+const REF_RETURNS_SEGMENT_AFTER_PIPE = new Set<string>([
+  'AWS::ApiGateway::Model',
+  'AWS::ApiGateway::RequestValidator',
+]);
+
+/**
  * Intrinsic-function keys the resolver knows how to handle.
  *
  * A CloudFormation intrinsic is ALWAYS a single-key object — `{ "Ref": ... }`
@@ -640,8 +650,9 @@ export class IntrinsicFunctionResolver {
     // Check if it's a resource
     const resource = context.resources[logicalId];
     if (resource) {
-      this.logger.debug(`Resolved Ref to resource: ${logicalId} -> ${resource.physicalId}`);
-      return resource.physicalId;
+      const refValue = this.resolveRefValue(resource);
+      this.logger.debug(`Resolved Ref to resource: ${logicalId} -> ${refValue}`);
+      return refValue;
     }
 
     // Check if it's a parameter
@@ -663,6 +674,41 @@ export class IntrinsicFunctionResolver {
     // Not found
     this.logger.warn(`Ref ${logicalId} not found (not a resource, parameter, or pseudo parameter)`);
     throw new Error(`Ref ${logicalId} not found`);
+  }
+
+  /**
+   * Resolve the value a CloudFormation `Ref` returns for a resource.
+   *
+   * For most resource types `Ref` returns the physical id, which is what cdkd
+   * stores. But for a few types CFn's `Ref` returns a sub-component of the
+   * physical id, and returning the raw physical id breaks downstream consumers.
+   *
+   * Two API Gateway child types are provisioned via Cloud Control (no SDK
+   * provider), whose primary identifier — and thus cdkd's physical id — is the
+   * compound `<restApiId>|<ref>`, while CFn's `Ref` returns only the `<ref>`
+   * segment:
+   *   - `AWS::ApiGateway::Model` → Ref is the model NAME; physical id is
+   *     `<restApiId>|<modelName>`. A method wiring
+   *     `RequestModels: { "application/json": { "Ref": <Model> } }` would
+   *     otherwise get the compound id and API Gateway rejects it with
+   *     "Invalid model identifier specified".
+   *   - `AWS::ApiGateway::RequestValidator` → Ref is the RequestValidatorId;
+   *     physical id is `<restApiId>|<requestValidatorId>`. A method wiring
+   *     `RequestValidatorId: { "Ref": <Validator> }` would otherwise get the
+   *     compound id and API Gateway rejects it with
+   *     "Invalid Request Validator identifier specified".
+   * In both cases the `Ref` value is the segment after the pipe (RestApiId is
+   * the first identifier component).
+   */
+  private resolveRefValue(resource: ResourceState): string {
+    const physicalId = resource.physicalId;
+    if (REF_RETURNS_SEGMENT_AFTER_PIPE.has(resource.resourceType)) {
+      const pipeIdx = physicalId.indexOf('|');
+      if (pipeIdx >= 0) {
+        return physicalId.substring(pipeIdx + 1);
+      }
+    }
+    return physicalId;
   }
 
   /**

--- a/tests/integration/apigateway/README.md
+++ b/tests/integration/apigateway/README.md
@@ -23,6 +23,15 @@ This stack includes the following resources:
 7. **Stage config props (#609)**: `tracingEnabled` (X-Ray) + stage `variables` set
    via `deployOptions` ride on the Stage's own CreateStage / UpdateStage call.
    `verify.sh` asserts both reached AWS via `aws apigateway get-stage`.
+8. **Request validation (`Ref` resolution fix)**: a Model (JSON schema) +
+   RequestValidator + a POST /pets method referencing both. Regression-covers
+   the `Ref` fix for `AWS::ApiGateway::Model` / `::RequestValidator` — both are
+   Cloud-Control-provisioned, so cdkd's physical id is the compound
+   `<restApiId>|<ref>` while CFn's `Ref` returns only the `<ref>` segment;
+   passing the compound id made API Gateway reject the method with "Invalid
+   model identifier specified" / "Invalid Request Validator identifier
+   specified". `verify.sh` curls a valid body (-> 200) and an invalid body
+   missing the required `name` (-> 400, rejected by the validator).
 
 ## Deploy
 

--- a/tests/integration/apigateway/lib/apigateway-stack.ts
+++ b/tests/integration/apigateway/lib/apigateway-stack.ts
@@ -34,10 +34,21 @@ import * as apigateway from 'aws-cdk-lib/aws-apigateway';
  *   makes the Deployment snapshot miss the new method). verify.sh curls an
  *   arbitrary sub-path and asserts it reaches the Lambda.
  *
+ * - Request validation: a Model (JSON schema) + RequestValidator + a POST
+ *   method referencing both. Regression-covers the `Ref` resolution fix for
+ *   AWS::ApiGateway::Model (Ref -> model name) and ::RequestValidator (Ref ->
+ *   validator id) — both Cloud-Control-provisioned, so their physical id is the
+ *   compound `<restApiId>|<ref>` while CFn's Ref returns only `<ref>`. Passing
+ *   the compound id made API Gateway reject the method with "Invalid model
+ *   identifier specified" / "Invalid Request Validator identifier specified".
+ *   verify.sh curls a valid + invalid body and asserts 200 / 400.
+ *
  * covers: AWS::ApiGateway::Method
  * covers: AWS::ApiGateway::Resource
  * covers: AWS::ApiGateway::Stage
  * covers: AWS::ApiGateway::Deployment
+ * covers: AWS::ApiGateway::Model
+ * covers: AWS::ApiGateway::RequestValidator
  */
 export class ApiGatewayStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -124,6 +135,43 @@ exports.handler = async (event) => {
       authType: 'custom',
       authorizerUri: `arn:aws:apigateway:${this.region}:lambda:path/2015-03-31/functions/${handler.functionArn}/invocations`,
       identitySource: 'method.request.header.Authorization',
+    });
+
+    // Request validation: a Model (JSON schema) + a RequestValidator + a POST
+    // method that references BOTH. Regression-covers the `Ref` resolution fix
+    // for the two API Gateway child types that are Cloud-Control-provisioned
+    // (no SDK provider), so cdkd's physical id is the compound
+    // `<restApiId>|<ref>` while CFn's `Ref` returns only the `<ref>` segment:
+    //   - AWS::ApiGateway::Model — `RequestModels` value `{ Ref: <Model> }`
+    //     must resolve to the model NAME, not `<restApiId>|<name>`, else AWS
+    //     rejects the method with "Invalid model identifier specified".
+    //   - AWS::ApiGateway::RequestValidator — `RequestValidatorId` value
+    //     `{ Ref: <Validator> }` must resolve to the validator id, not
+    //     `<restApiId>|<id>`, else AWS rejects with "Invalid Request Validator
+    //     identifier specified".
+    // verify.sh curls a valid + an invalid body and asserts 200 / 400.
+    const petModel = api.addModel('PetModel', {
+      contentType: 'application/json',
+      modelName: 'Pet',
+      schema: {
+        schema: apigateway.JsonSchemaVersion.DRAFT4,
+        title: 'Pet',
+        type: apigateway.JsonSchemaType.OBJECT,
+        required: ['name'],
+        properties: {
+          name: { type: apigateway.JsonSchemaType.STRING },
+          age: { type: apigateway.JsonSchemaType.INTEGER },
+        },
+      },
+    });
+    const bodyValidator = api.addRequestValidator('BodyValidator', {
+      validateRequestBody: true,
+      validateRequestParameters: false,
+    });
+    const pets = api.root.addResource('pets');
+    pets.addMethod('POST', new apigateway.LambdaIntegration(handler), {
+      requestValidator: bodyValidator,
+      requestModels: { 'application/json': petModel },
     });
 
     // Outputs

--- a/tests/integration/apigateway/verify.sh
+++ b/tests/integration/apigateway/verify.sh
@@ -146,6 +146,31 @@ if ! echo "${PROXY_BODY}" | grep -q "Hello from cdkd!"; then
 fi
 echo "    OK: {proxy+} ANY method routed to the Lambda (proxy path)"
 
+# --- Assertion 5: request validation (Model + RequestValidator Ref) ----
+# POST /pets is wired with a RequestValidator (validateRequestBody) + a Model
+# requiring `name`. This exercises the `Ref` resolution fix: the method's
+# RequestModels `{ Ref: <Model> }` and RequestValidatorId `{ Ref: <Validator> }`
+# must resolve to the model NAME / validator id, NOT cdkd's compound
+# `<restApiId>|<ref>` physical id (which AWS rejects at method-create time).
+# A valid body must reach the Lambda (200); an invalid body (missing required
+# `name`) must be rejected by the validator BEFORE the Lambda (400).
+PETS_URL="${API_URL}/pets"
+VALID_CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "${PETS_URL}" \
+  -H 'Content-Type: application/json' -d '{"name":"rex","age":3}')
+if [ "${VALID_CODE}" != "200" ]; then
+  echo "FAIL: POST /pets with a valid body returned HTTP ${VALID_CODE}, expected 200" >&2
+  exit 1
+fi
+echo "    OK: POST /pets valid body -> 200 (Model + RequestValidator Ref resolved)"
+
+INVALID_CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "${PETS_URL}" \
+  -H 'Content-Type: application/json' -d '{"age":3}')
+if [ "${INVALID_CODE}" != "400" ]; then
+  echo "FAIL: POST /pets with an invalid body returned HTTP ${INVALID_CODE}, expected 400" >&2
+  exit 1
+fi
+echo "    OK: POST /pets invalid body -> 400 (request validator enforced)"
+
 # --- Phase 2: destroy -------------------------------------------------
 echo "==> Phase 2: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \

--- a/tests/unit/deployment/intrinsic-functions.test.ts
+++ b/tests/unit/deployment/intrinsic-functions.test.ts
@@ -2605,3 +2605,115 @@ describe('IntrinsicFunctionResolver - AWS::EC2::Instance Fn::GetAtt (live Descri
     expect(result).toBe('i-0123456789abcdef0');
   });
 });
+
+describe('IntrinsicFunctionResolver - Ref to AWS::ApiGateway::Model', () => {
+  let resolver: IntrinsicFunctionResolver;
+
+  beforeEach(() => {
+    resolver = new IntrinsicFunctionResolver();
+  });
+
+  // CFn `Ref` of an AWS::ApiGateway::Model returns the model NAME, but the model
+  // is provisioned via Cloud Control whose primary identifier (cdkd's physical
+  // id) is the compound `<restApiId>|<modelName>`. A method's RequestModels
+  // wiring `{ "application/json": { "Ref": <Model> } }` would otherwise receive
+  // `<restApiId>|<modelName>` and API Gateway rejects it with "Invalid model
+  // identifier specified". The resolver must return just the model name.
+  it('Ref returns the model name, not the compound <restApiId>|<modelName> physical id', async () => {
+    const template: CloudFormationTemplate = {
+      Resources: {
+        PetModel: { Type: 'AWS::ApiGateway::Model', Properties: { Name: 'Pet' } },
+      },
+    };
+    const context: ResolverContext = {
+      template,
+      resources: {
+        PetModel: {
+          physicalId: 'tdo7p9w58k|Pet',
+          resourceType: 'AWS::ApiGateway::Model',
+          properties: { Name: 'Pet' },
+          attributes: {},
+          dependencies: [],
+        },
+      },
+    };
+
+    const result = await resolver.resolve({ Ref: 'PetModel' }, context);
+    expect(result).toBe('Pet');
+  });
+
+  // Same bug class for AWS::ApiGateway::RequestValidator: CFn `Ref` returns the
+  // RequestValidatorId, but the Cloud Control physical id is the compound
+  // `<restApiId>|<requestValidatorId>`. A method wiring
+  // `RequestValidatorId: { "Ref": <Validator> }` would otherwise get the
+  // compound id and API Gateway rejects it with "Invalid Request Validator
+  // identifier specified".
+  it('Ref to AWS::ApiGateway::RequestValidator returns the validator id, not the compound physical id', async () => {
+    const template: CloudFormationTemplate = {
+      Resources: {
+        BodyValidator: { Type: 'AWS::ApiGateway::RequestValidator', Properties: {} },
+      },
+    };
+    const context: ResolverContext = {
+      template,
+      resources: {
+        BodyValidator: {
+          physicalId: 'tdo7p9w58k|abc123',
+          resourceType: 'AWS::ApiGateway::RequestValidator',
+          properties: {},
+          attributes: {},
+          dependencies: [],
+        },
+      },
+    };
+
+    const result = await resolver.resolve({ Ref: 'BodyValidator' }, context);
+    expect(result).toBe('abc123');
+  });
+
+  it('Ref falls back to the raw physical id when there is no pipe separator', async () => {
+    const template: CloudFormationTemplate = {
+      Resources: {
+        PetModel: { Type: 'AWS::ApiGateway::Model', Properties: { Name: 'Pet' } },
+      },
+    };
+    const context: ResolverContext = {
+      template,
+      resources: {
+        PetModel: {
+          physicalId: 'Pet',
+          resourceType: 'AWS::ApiGateway::Model',
+          properties: { Name: 'Pet' },
+          attributes: {},
+          dependencies: [],
+        },
+      },
+    };
+
+    const result = await resolver.resolve({ Ref: 'PetModel' }, context);
+    expect(result).toBe('Pet');
+  });
+
+  it('Ref to a non-Model resource still returns the full physical id', async () => {
+    const template: CloudFormationTemplate = {
+      Resources: {
+        Q: { Type: 'AWS::SQS::Queue', Properties: {} },
+      },
+    };
+    const context: ResolverContext = {
+      template,
+      resources: {
+        Q: {
+          physicalId: 'https://sqs.us-east-1.amazonaws.com/123456789012/my-queue',
+          resourceType: 'AWS::SQS::Queue',
+          properties: {},
+          attributes: {},
+          dependencies: [],
+        },
+      },
+    };
+
+    const result = await resolver.resolve({ Ref: 'Q' }, context);
+    expect(result).toBe('https://sqs.us-east-1.amazonaws.com/123456789012/my-queue');
+  });
+});


### PR DESCRIPTION
## Summary

A `/hunt-bugs` sweep deploying a REST API with **request validation** (a daily
CDK pattern: a Model + RequestValidator + a validated method) hit a real bug:
every other resource created cleanly, then the validated method failed at CREATE
and the whole deploy rolled back with **"Invalid model identifier specified"**
(and, once that was fixed, **"Invalid Request Validator identifier specified"**).

Root cause: `AWS::ApiGateway::Model` and `AWS::ApiGateway::RequestValidator` are
provisioned via Cloud Control (no SDK provider), so cdkd's physical id is the CC
**primaryIdentifier** — the compound `<restApiId>|<ref>`. But CloudFormation's
`Ref` for these types returns only the `<ref>` segment (the model NAME / the
RequestValidatorId). `resolveRef` returned the raw physical id unconditionally,
so a method wiring `RequestModels: { "application/json": { "Ref": <Model> } }` /
`RequestValidatorId: { "Ref": <Validator> }` received the compound id and API
Gateway rejected it.

## Fix

`resolveRefValue(resource)` extracts the segment after the pipe for the two
Cloud-Control-provisioned API Gateway child types whose CFn `Ref` returns a
sub-component (`REF_RETURNS_SEGMENT_AFTER_PIPE`). All other types are unaffected
(`Ref` == physical id, byte-identical path). Falls back to the full id when
there is no pipe.

This is the `Ref` sibling of the known GetAtt gaps (ECS Service.Name etc.) — the
recurring root cause is that a CC primaryIdentifier is not what CFn's
`Ref`/`GetAtt` returns.

## Test plan

- **Unit** (`tests/unit/deployment/intrinsic-functions.test.ts`): Model `Ref` ->
  name, RequestValidator `Ref` -> id, no-pipe fallback, non-Model/Validator
  types still return the full physical id.
- **Integ** (`tests/integration/apigateway`): extended with a Model +
  RequestValidator + a POST /pets method referencing both; `verify.sh` curls a
  valid body (-> 200) and an invalid body missing the required `name`
  (-> 400, rejected by the validator). Ran clean against real AWS
  (deploy + 200/400 asserts + destroy, 0 errors / 0 orphans).
- **Broad integ** (`lambda`): ran clean (cross-cutting resolver change).
- Full suite: 394 files / 6029 tests pass; typecheck / lint / build clean.
