### PR TITLE
test(integ): fix local-start-alb-from-state post-destroy assertion (state.json only)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -72,7 +72,6 @@ local-ecs-service-connect	2026-06-02T15:46:16Z	PASS	22	verify.sh	local integ ser
 local-invoke-agentcore	2026-06-02T15:46:16Z	PASS	93	verify.sh	local integ serial sweep: Docker clean (0 containers/networks), rc 0
 local-invoke-from-state	2026-06-02T15:46:16Z	PASS	57	verify.sh	local integ serial sweep: Docker clean (0 containers/networks), rc 0
 local-run-task-from-state	2026-06-02T15:46:16Z	PASS	98	verify.sh	local integ serial sweep: Docker clean (0 containers/networks), rc 0
-local-start-alb-from-state	2026-06-02T15:46:16Z	PASS	89	verify.sh	local integ serial sweep: Docker clean (0 containers/networks), rc 0
 local-invoke-from-cfn-stack	2026-06-02T15:46:16Z	PASS	92	verify.sh	local integ serial sweep: Docker clean (0 containers/networks), rc 0
 local-invoke-from-cfn-stack-multi-stack	2026-06-02T15:46:16Z	PASS	114	verify.sh	local integ serial sweep: Docker clean (0 containers/networks), rc 0
 local-invoke-agentcore-from-state	2026-06-02T15:46:16Z	PASS	55	verify.sh	local integ serial sweep: Docker clean (0 containers/networks), rc 0
@@ -162,3 +161,4 @@ iam-role-prefixed-name-update	2026-06-21T08:38:12Z	PASS	45	verify.sh	prefix-migr
 appconfig	2026-06-21T08:22:45Z	PASS	61	verify.sh	AppConfig compound-id Ref fix: chain creates, UPDATE v2, destroy clean
 lambda	2026-06-21T08:22:45Z	PASS	92	verify.sh	broad integ for intrinsic-resolver compound-Ref fix; 9 deleted 0 err
 dynamodb-sse	2026-06-21T08:22:45Z	PASS	43	verify.sh	SSESpecification SSEEnabled->Enabled mapping; SSE reaches AWS as KMS; destroy clean
+local-start-alb-from-state	2026-06-21T10:44:49Z	PASS	88	verify.sh	fixed verify.sh assertion (state.json only, ignore #885 deployments/); deploy+destroy clean 29 del 0 err

--- a/tests/integration/local-start-alb-from-state/verify.sh
+++ b/tests/integration/local-start-alb-from-state/verify.sh
@@ -241,16 +241,22 @@ ${CDKD} destroy "${STACK_NAME}" --region "${REGION}" --state-bucket "${STATE_BUC
 DEPLOYED=0
 
 echo "==> Verifying state is empty post-destroy"
-# `aws s3 ls` returns exit 1 when the prefix has zero objects (success
-# but empty). Under `set -o pipefail` that would terminate the script
-# BEFORE the final "test passed" echo; wrap the call in `|| true` so the
-# pipeline reports its own intent (number of lines == 0) cleanly.
+# Match ONLY the `state.json` object, not the whole prefix. Since #820/#885
+# the deployment-events store (`cdkd/<stack>/<region>/deployments/...`)
+# survives `destroy` by design, so a bare prefix listing is never empty
+# after teardown and would false-FAIL here. The destroy contract is that
+# `state.json` is gone; the informational events store is swept separately
+# (see /cleanup step 3.5).
+# `aws s3 ls --recursive` returns exit 1 when nothing matches (success but
+# empty). Under `set -o pipefail` that would terminate the script BEFORE the
+# final "test passed" echo; wrap the call in `|| true` so the pipeline
+# reports its own intent (number of matching lines == 0) cleanly.
 STATE_REMAINING=$(
-  (aws s3 ls "s3://${STATE_BUCKET}/cdkd/${STACK_NAME}/" --region "${REGION}" 2>/dev/null || true) \
-    | wc -l | tr -d ' '
+  (aws s3 ls "s3://${STATE_BUCKET}/cdkd/${STACK_NAME}/" --recursive --region "${REGION}" 2>/dev/null || true) \
+    | grep -c 'state\.json' || true
 )
 if [[ "${STATE_REMAINING}" -ne 0 ]]; then
-  echo "FAIL: cdkd state for ${STACK_NAME} still present after destroy"
+  echo "FAIL: cdkd state.json for ${STACK_NAME} still present after destroy"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Fixes a false-FAIL in the `local-start-alb-from-state` integ fixture's post-destroy assertion.

The check listed the whole `cdkd/<stack>/` S3 prefix and failed if **any** object remained. Since #820/#885 the deployment-events store (`cdkd/<stack>/<region>/deployments/...`) survives `destroy` **by design**, so the prefix is never empty after teardown — the assertion false-FAILed even though the real deploy + destroy was clean (29 deleted, 0 errors, no ALB/VPC orphan). This surfaced during the staleness sweep (#908).

**Fix:** match only the `state.json` object (the actual destroy contract) via `aws s3 ls --recursive | grep -c state.json`, mirroring how `/cleanup` step 3.5 distinguishes a live stack (has state.json) from a destroyed one whose informational events store lingers.

## Test plan
- [x] Unit tests pass (394 files, 6040 tests)
- [x] Integration test: `local-start-alb-from-state` re-run end-to-end against real AWS + Docker — deploy VPC+ALB+2 ECS Fargate services, `cdkd local start-alb --from-state`, destroy clean (29 deleted, 0 errors), **assertion now passes**. Docker clean, no ALB/VPC orphan.
- [x] Ledger updated (real clean PASS for local-start-alb-from-state)
