### PR TITLE
docs: add npm/downloads/license badges to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # cdkd (CDK Direct)
 
+[![npm version](https://img.shields.io/npm/v/@go-to-k/cdkd.svg)](https://www.npmjs.com/package/@go-to-k/cdkd)
+[![Downloads](https://img.shields.io/npm/dw/@go-to-k/cdkd.svg)](https://www.npmjs.com/package/@go-to-k/cdkd)
+[![License: Apache-2.0](https://img.shields.io/npm/l/@go-to-k/cdkd.svg)](./LICENSE)
+
 Drop-in CDK CLI for existing CDK apps — faster deploys via AWS SDK instead of CloudFormation, plus local emulation for Lambda, API Gateway, and ECS.
 
 - **Drop-in CDK compatible** — your existing CDK app code runs as-is.


### PR DESCRIPTION
## Summary

Adds the same three badges that cdk-local uses to the top of the README, just under the title:

- npm version
- weekly downloads
- license (Apache-2.0)

Package name is adapted to cdkd's scoped npm package `@go-to-k/cdkd` (cdk-local's are unscoped); badge set and order are otherwise identical to cdk-local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013GVG1rSMcbozRAc1TWkKpN)_