### PR TITLE
refactor(efs): serialize each immutable prop independently for the CreationToken

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -200,6 +200,6 @@ s3-lifecycle	2026-06-28T17:58:35Z	PASS	51	verify.sh	V1/V2 mix + top-level Object
 inplace-attr-propagation	2026-06-29T02:40:51Z	PASS	47	verify.sh	in-place upstream attr propagates to GetAtt dependent
 lambda-env-removal	2026-06-29T03:14:52Z	PASS	61	verify.sh	nested map key (Lambda env var) removal reaches AWS
 s3-replication-and-filter	2026-06-29T05:06:19Z	PASS	55	verify.sh	And filter create+update+destroy, orph clean
-efs-immutable-replacement	2026-06-29T06:27:27Z	PASS	95	verify.sh	createOnly replacement + stateful guard + EFS token, orph clean
 replacement-immutable-name	2026-06-29T06:27:27Z	PASS	130	verify.sh	6-type rename w/ --force-stateful-recreation, orph clean
 bench-cdk-sample	2026-06-29T06:27:27Z	PASS	420	standard	broad VPC/NAT/CF/Lambda, 37+2retained 0err, loggroups swept
+efs-immutable-replacement	2026-06-29T07:14:02Z	PASS	95	verify.sh	token-robustness refactor re-verified, orph clean

--- a/src/provisioning/providers/efs-provider.ts
+++ b/src/provisioning/providers/efs-provider.ts
@@ -391,18 +391,25 @@ export class EFSProvider implements ResourceProvider {
     // exists; a bare `cdkd-${logicalId}` token collides with the old FS's token
     // and EFS rejects the create with "already exists with creation token ..."
     // because the immutable params differ). Hash ONLY the immutable (createOnly)
-    // inputs, key-sorted so the digest is stable against mutable-prop churn and
-    // object key reordering: identical immutable inputs (a retry) hash to the
-    // same token, while a replacement — which by definition changed an immutable
-    // property — hashes to a different token, so the new FS coexists with the old.
-    const immutableForToken: Record<string, unknown> = {
-      AvailabilityZoneName: properties['AvailabilityZoneName'],
-      Encrypted: properties['Encrypted'],
-      KmsKeyId: properties['KmsKeyId'],
-      PerformanceMode: properties['PerformanceMode'],
-    };
+    // inputs, in a FIXED order, each value serialized independently with
+    // `JSON.stringify`: identical immutable inputs (a retry) hash to the same
+    // token, while a replacement — which by definition changed an immutable
+    // property — hashes to a different token, so the new FS coexists with the
+    // old. Per-value `JSON.stringify` (rather than `JSON.stringify(obj,
+    // allowlist)`, whose array replacer recursively strips nested keys) keeps
+    // the digest faithful for any value shape — defensive even though these
+    // four properties are always intrinsic-resolved scalars by create() time.
     const tokenHash = createHash('sha256')
-      .update(JSON.stringify(immutableForToken, Object.keys(immutableForToken).sort()))
+      .update(
+        [
+          properties['AvailabilityZoneName'],
+          properties['Encrypted'],
+          properties['KmsKeyId'],
+          properties['PerformanceMode'],
+        ]
+          .map((v) => JSON.stringify(v ?? null))
+          .join(' ')
+      )
       .digest('hex')
       .slice(0, 12);
     const creationToken = `cdkd-${logicalId}-${tokenHash}`;

--- a/tests/unit/provisioning/providers/efs-provider.test.ts
+++ b/tests/unit/provisioning/providers/efs-provider.test.ts
@@ -123,6 +123,14 @@ describe('EFSProvider', () => {
           FileSystemTags: [{ Key: 'x', Value: 'y' }],
         });
         expect(aWithMutable).toBe(a);
+        // Robustness: two DISTINCT nested-object immutable values (defensive —
+        // intrinsics are resolved to scalars by create() time, but a future leak
+        // must not collapse two different values to one token, as a recursive
+        // key-allowlist serialization would). Per-value JSON.stringify keeps them
+        // distinct.
+        const obj1 = await tokenFor({ KmsKeyId: { Ref: 'KeyOne' } });
+        const obj2 = await tokenFor({ KmsKeyId: { Ref: 'KeyTwo' } });
+        expect(obj1).not.toBe(obj2);
       });
 
       it('should create file system with tags and encryption', async () => {


### PR DESCRIPTION
## Summary

Follow-up hardening of the EFS `CreationToken` hash introduced in PR #943.

The previous form `JSON.stringify(immutableForToken, sortedKeys)` uses an **array
replacer**, which `JSON.stringify` applies **recursively** as a key allowlist: a
nested-object value (e.g. an unresolved `KmsKeyId: { Ref: ... }`) would have its
inner keys stripped and serialize to `{}`, collapsing two distinct values to the
**same** idempotency token. This cannot fire today — the four immutable
properties (`AvailabilityZoneName` / `Encrypted` / `KmsKeyId` / `PerformanceMode`)
are intrinsic-resolved scalars by `create()` time and cast as `string` / `boolean`
before the SDK call — but the faithful form removes the latent fragility a
reviewer flagged on #943.

## Fix

Hash the immutable subset in a **fixed order**, with each value serialized
**independently** via `JSON.stringify(v ?? null)`:

```ts
const tokenHash = createHash('sha256')
  .update([AvailabilityZoneName, Encrypted, KmsKeyId, PerformanceMode]
    .map((v) => JSON.stringify(v ?? null)).join(' '))
  .digest('hex').slice(0, 12);
```

Token shape (`cdkd-<logicalId>-<12 hex>`) and all behavior are unchanged:
- stable across retries of the same create (idempotent),
- different on an immutable-property change (a replacement's new FS coexists),
- stable on mutable-only churn (only the immutable subset is hashed).

## Test plan

- **Unit:** the existing EFS-token test (stable / different-on-immutable /
  mutable-only-stable) still passes; **adds** an assertion that two **distinct
  nested-object** values produce **different** tokens (the old array-replacer
  would have collapsed both to `{}` → same token). Full suite: 6205 tests pass.
- **Integ:** `efs-immutable-replacement` re-run end-to-end against real AWS
  (deploy maxIO → diff reports replacement → blocked without the flag → forced
  replacement produces a new FileSystemId → destroy clean, 0 orphans) — confirms
  the token still differs on replacement after the refactor.
