### PR TITLE
fix(cli): say 'Reading cloud assembly' for pre-synth -a across all commands

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -202,4 +202,4 @@ s3-replication-and-filter	2026-06-29T05:06:19Z	PASS	55	verify.sh	And filter crea
 replacement-immutable-name	2026-06-29T06:27:27Z	PASS	130	verify.sh	6-type rename w/ --force-stateful-recreation, orph clean
 bench-cdk-sample	2026-06-29T06:27:27Z	PASS	420	standard	broad VPC/NAT/CF/Lambda, 37+2retained 0err, loggroups swept
 efs-immutable-replacement	2026-06-29T07:14:02Z	PASS	95	verify.sh	token-robustness refactor re-verified, orph clean
-lambda	2026-06-29T15:25:17Z	PASS	77	verify.sh	RecursiveLoop+ReservedConcurrency backfill; destroy 9 del 0 err; orph clean
+lambda	2026-06-29T15:57:31Z	PASS	89	verify.sh	synth-label PR revalidation; destroy 9 del 0 err; orph clean

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -22,7 +22,7 @@ import {
 } from '../../deployment/recreate-targets.js';
 import { promptRecreateConfirm } from './recreate-confirm-prompt.js';
 import { findDownstreamConsumers } from './recreate-downstream-consumers.js';
-import { Synthesizer, isPreSynthesizedAssembly } from '../../synthesis/synthesizer.js';
+import { Synthesizer, synthesisStatusMessage } from '../../synthesis/synthesizer.js';
 import { AssetPublisher } from '../../assets/asset-publisher.js';
 import { S3StateBackend } from '../../state/s3-state-backend.js';
 import type { DeploymentRunResult } from '../../types/deployment-events.js';
@@ -227,9 +227,7 @@ async function deployCommand(
   try {
     // 1. Synthesize CDK app (or read a pre-synthesized assembly when --app
     // points at an existing directory — synthesis is skipped in that case).
-    logger.info(
-      cyan(isPreSynthesizedAssembly(app) ? 'Reading cloud assembly...' : 'Synthesizing CDK app...')
-    );
+    logger.info(cyan(synthesisStatusMessage(app, 'Synthesizing CDK app...')));
     const synthesizer = new Synthesizer();
     const context = parseContextOptions(options.context);
     const result = await synthesizer.synthesize({

--- a/src/cli/commands/diff.ts
+++ b/src/cli/commands/diff.ts
@@ -11,7 +11,7 @@ import {
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { withErrorHandling, CdkdError } from '../../utils/error-handler.js';
-import { Synthesizer } from '../../synthesis/synthesizer.js';
+import { Synthesizer, synthesisStatusMessage } from '../../synthesis/synthesizer.js';
 import { S3StateBackend } from '../../state/s3-state-backend.js';
 import { DiffCalculator } from '../../analyzer/diff-calculator.js';
 import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
@@ -112,7 +112,7 @@ async function diffCommand(
 
   try {
     // 1. Synthesize CDK app
-    logger.info('Synthesizing CDK app...');
+    logger.info(synthesisStatusMessage(app, 'Synthesizing CDK app...'));
     const synthesizer = new Synthesizer();
     const context = parseContextOptions(options.context);
     const result = await synthesizer.synthesize({

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -32,7 +32,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
-import { Synthesizer } from '../../synthesis/synthesizer.js';
+import { Synthesizer, synthesisStatusMessage } from '../../synthesis/synthesizer.js';
 import { S3StateBackend } from '../../state/s3-state-backend.js';
 import { LockManager } from '../../state/lock-manager.js';
 import {
@@ -744,7 +744,7 @@ async function exportCommand(stackArg: string | undefined, options: ExportOption
             'OR a pre-rendered CFn template (--template <path>).'
         );
       }
-      logger.info('Synthesizing CDK app to read template...');
+      logger.info(synthesisStatusMessage(appCmd, 'Synthesizing CDK app to read template...'));
       const synthesizer = new Synthesizer();
       const context = parseContextOptions(options.context);
       const result = await synthesizer.synthesize({

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -12,7 +12,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
-import { Synthesizer } from '../../synthesis/synthesizer.js';
+import { Synthesizer, synthesisStatusMessage } from '../../synthesis/synthesizer.js';
 import { S3StateBackend } from '../../state/s3-state-backend.js';
 import { LockManager } from '../../state/lock-manager.js';
 import { ProviderRegistry } from '../../provisioning/provider-registry.js';
@@ -177,7 +177,7 @@ async function importCommand(stackArg: string | undefined, options: ImportOption
       );
     }
 
-    logger.info('Synthesizing CDK app to read template...');
+    logger.info(synthesisStatusMessage(appCmd, 'Synthesizing CDK app to read template...'));
     const synthesizer = new Synthesizer();
     const context = parseContextOptions(options.context);
     const result = await synthesizer.synthesize({

--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -16,7 +16,11 @@ import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { CdkdError, withErrorHandling } from '../../utils/error-handler.js';
 import { listTargets } from 'cdk-local';
 import { resolveSingleTarget } from '../../local/target-picker.js';
-import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
+import {
+  Synthesizer,
+  synthesisStatusMessage,
+  type SynthesisOptions,
+} from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
 import { readCdkPathOrUndefined } from '../cdk-path.js';
 import { createLocalStateProvider, resolveCfnFallbackRegion } from './local-state-source.js';
@@ -301,7 +305,7 @@ async function localInvokeAgentCoreCommand(
       );
     }
 
-    logger.info('Synthesizing CDK app...');
+    logger.info(synthesisStatusMessage(appCmd, 'Synthesizing CDK app...'));
     const synthesizer = new Synthesizer();
     const context = parseContextOptions(options.context);
     const synthOpts: SynthesisOptions = {

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -15,7 +15,11 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
-import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
+import {
+  Synthesizer,
+  synthesisStatusMessage,
+  type SynthesisOptions,
+} from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
 import { readCdkPathOrUndefined } from '../cdk-path.js';
 import { createLocalStateProvider } from './local-state-source.js';
@@ -368,7 +372,7 @@ async function localInvokeCommand(target: string, options: LocalInvokeOptions): 
       throw new Error('No CDK app specified. Pass --app, set CDKD_APP, or add "app" to cdk.json.');
     }
 
-    logger.info('Synthesizing CDK app...');
+    logger.info(synthesisStatusMessage(appCmd, 'Synthesizing CDK app...'));
     const synthesizer = new Synthesizer();
     const context = parseContextOptions(options.context);
     const synthOpts: SynthesisOptions = {

--- a/src/cli/commands/local-run-task.ts
+++ b/src/cli/commands/local-run-task.ts
@@ -12,7 +12,11 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
-import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
+import {
+  Synthesizer,
+  synthesisStatusMessage,
+  type SynthesisOptions,
+} from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
 import { ensureDockerAvailable } from '../../local/docker-runner.js';
 import { resolveHostGatewayExtraHosts } from '../../local/docker-version.js';
@@ -170,7 +174,7 @@ async function localRunTaskCommand(target: string, options: LocalRunTaskOptions)
       throw new Error('No CDK app specified. Pass --app, set CDKD_APP, or add "app" to cdk.json.');
     }
 
-    logger.info('Synthesizing CDK app...');
+    logger.info(synthesisStatusMessage(appCmd, 'Synthesizing CDK app...'));
     const synthesizer = new Synthesizer();
     const context = parseContextOptions(options.context);
     const synthOpts: SynthesisOptions = {

--- a/src/cli/commands/local-start-api.ts
+++ b/src/cli/commands/local-start-api.ts
@@ -18,7 +18,11 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
-import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
+import {
+  Synthesizer,
+  synthesisStatusMessage,
+  type SynthesisOptions,
+} from '../../synthesis/synthesizer.js';
 import { resolveApp } from '../config-loader.js';
 import { readCdkPathOrUndefined } from '../cdk-path.js';
 import {
@@ -385,7 +389,7 @@ async function localStartApiCommand(
    * Hot reload picks up authorizer-config changes via this re-run.
    */
   const synthesizeAndBuild = async (): Promise<NextStateMaterial> => {
-    logger.info('Synthesizing CDK app...');
+    logger.info(synthesisStatusMessage(appCmd, 'Synthesizing CDK app...'));
     const synthesizer = new Synthesizer();
     const context = parseContextOptions(options.context);
     const synthOpts: SynthesisOptions = {

--- a/src/cli/commands/orphan.ts
+++ b/src/cli/commands/orphan.ts
@@ -12,7 +12,7 @@ import {
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
-import { Synthesizer } from '../../synthesis/synthesizer.js';
+import { Synthesizer, synthesisStatusMessage } from '../../synthesis/synthesizer.js';
 import { S3StateBackend } from '../../state/s3-state-backend.js';
 import { LockManager } from '../../state/lock-manager.js';
 import { setAwsClients, AwsClients } from '../../utils/aws-clients.js';
@@ -146,7 +146,7 @@ async function orphanCommand(pathArgs: string[], options: OrphanOptions): Promis
       );
     }
 
-    logger.info('Synthesizing CDK app to read template...');
+    logger.info(synthesisStatusMessage(appCmd, 'Synthesizing CDK app to read template...'));
     const synthesizer = new Synthesizer();
     const context = parseContextOptions(options.context);
     const result = await synthesizer.synthesize({

--- a/src/cli/commands/publish-assets.ts
+++ b/src/cli/commands/publish-assets.ts
@@ -12,7 +12,11 @@ import { bold, green } from '../../utils/colors.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { PartialFailureError, withErrorHandling } from '../../utils/error-handler.js';
 import { AssetPublisher } from '../../assets/asset-publisher.js';
-import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
+import {
+  Synthesizer,
+  synthesisStatusMessage,
+  type SynthesisOptions,
+} from '../../synthesis/synthesizer.js';
 import type { StackInfo } from '../../synthesis/assembly-reader.js';
 import { WorkGraph } from '../../deployment/work-graph.js';
 import { resolveApp } from '../config-loader.js';
@@ -81,7 +85,7 @@ async function publishAssetsCommand(
   }
 
   // 1. Synthesize CDK app (or read pre-synthesized assembly when --app is a dir).
-  logger.info('Synthesizing CDK app...');
+  logger.info(synthesisStatusMessage(app, 'Synthesizing CDK app...'));
   const synthesizer = new Synthesizer();
   const context = parseContextOptions(options.context);
   const synthOptions: SynthesisOptions = {

--- a/src/cli/commands/synth.ts
+++ b/src/cli/commands/synth.ts
@@ -13,7 +13,11 @@ import { getLogger } from '../../utils/logger.js';
 import { bold, green } from '../../utils/colors.js';
 import { applyRoleArnIfSet } from '../../utils/role-arn.js';
 import { withErrorHandling } from '../../utils/error-handler.js';
-import { Synthesizer, type SynthesisOptions } from '../../synthesis/synthesizer.js';
+import {
+  Synthesizer,
+  synthesisStatusMessage,
+  type SynthesisOptions,
+} from '../../synthesis/synthesizer.js';
 import { AssemblyReader } from '../../synthesis/assembly-reader.js';
 import { resolveApp } from '../config-loader.js';
 import { toYaml } from '../../utils/yaml.js';
@@ -65,7 +69,7 @@ async function synthCommand(options: {
   }
   options.app = app;
 
-  logger.info('Synthesizing CDK app...');
+  logger.info(synthesisStatusMessage(app, 'Synthesizing CDK app...'));
   logger.debug('App command:', options.app);
   logger.debug('Output directory:', options.output);
 

--- a/src/synthesis/synthesizer.ts
+++ b/src/synthesis/synthesizer.ts
@@ -29,6 +29,24 @@ export function isPreSynthesizedAssembly(app: string): boolean {
 }
 
 /**
+ * Pick the user-facing status line a command prints right before it invokes
+ * {@link Synthesizer.synthesize}. When `--app` is a pre-synthesized assembly
+ * directory, synthesis is skipped, so "Reading cloud assembly..." is accurate;
+ * otherwise the command's own `synthesizingMessage` (e.g. "Synthesizing CDK
+ * app...") is used. `app` may be undefined (the synthesize() call will then
+ * throw the usual "no app specified" error) — that case keeps the synthesizing
+ * message.
+ */
+export function synthesisStatusMessage(
+  app: string | undefined,
+  synthesizingMessage: string
+): string {
+  return app !== undefined && isPreSynthesizedAssembly(app)
+    ? 'Reading cloud assembly...'
+    : synthesizingMessage;
+}
+
+/**
  * Synthesis options
  */
 export interface SynthesisOptions {

--- a/tests/unit/cli/import.test.ts
+++ b/tests/unit/cli/import.test.ts
@@ -125,6 +125,7 @@ vi.mock('../../../src/synthesis/synthesizer.js', () => ({
   Synthesizer: vi.fn().mockImplementation(() => ({
     synthesize: mockSynthesize,
   })),
+  synthesisStatusMessage: (_app: unknown, msg: string) => msg,
 }));
 
 vi.mock('../../../src/provisioning/register-providers.js', () => ({

--- a/tests/unit/cli/orphan.test.ts
+++ b/tests/unit/cli/orphan.test.ts
@@ -63,6 +63,7 @@ vi.mock('../../../src/synthesis/synthesizer.js', () => ({
   Synthesizer: vi.fn().mockImplementation(() => ({
     synthesize: mockSynthesize,
   })),
+  synthesisStatusMessage: (_app: unknown, msg: string) => msg,
 }));
 
 const mockRegisterAllProviders = vi.hoisted(() => vi.fn());

--- a/tests/unit/cli/publish-assets.test.ts
+++ b/tests/unit/cli/publish-assets.test.ts
@@ -9,6 +9,7 @@ vi.mock('../../../src/synthesis/synthesizer.js', () => ({
   Synthesizer: vi.fn().mockImplementation(() => ({
     synthesize: mockSynthesize,
   })),
+  synthesisStatusMessage: (_app: unknown, msg: string) => msg,
 }));
 
 // AssetPublisher — addAssetsToGraph + executeNode are the surface the command

--- a/tests/unit/synthesis/is-pre-synthesized-assembly.test.ts
+++ b/tests/unit/synthesis/is-pre-synthesized-assembly.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { isPreSynthesizedAssembly } from '../../../src/synthesis/synthesizer.js';
+import {
+  isPreSynthesizedAssembly,
+  synthesisStatusMessage,
+} from '../../../src/synthesis/synthesizer.js';
 
 // Kept in its own file (no node:fs mock) so the helper runs against real fs.
 // synthesizer.test.ts mocks node:fs, which would shadow existsSync / statSync.
@@ -33,5 +36,39 @@ describe('isPreSynthesizedAssembly', () => {
     const file = join(tmp, 'cdk.out');
     writeFileSync(file, 'not a directory');
     expect(isPreSynthesizedAssembly(file)).toBe(false);
+  });
+});
+
+describe('synthesisStatusMessage', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'cdkd-synthmsg-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns "Reading cloud assembly..." for a pre-synthesized directory', () => {
+    expect(synthesisStatusMessage(tmp, 'Synthesizing CDK app...')).toBe('Reading cloud assembly...');
+  });
+
+  it('returns the synthesizing message for a CDK app command', () => {
+    expect(synthesisStatusMessage('node app.ts', 'Synthesizing CDK app...')).toBe(
+      'Synthesizing CDK app...'
+    );
+  });
+
+  it('preserves each command-specific synthesizing message for a command', () => {
+    expect(synthesisStatusMessage('node app.ts', 'Synthesizing CDK app to read template...')).toBe(
+      'Synthesizing CDK app to read template...'
+    );
+  });
+
+  it('returns the synthesizing message when app is undefined', () => {
+    expect(synthesisStatusMessage(undefined, 'Synthesizing CDK app...')).toBe(
+      'Synthesizing CDK app...'
+    );
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #945. That PR fixed the misleading `Synthesizing CDK app...`
status line for `cdkd deploy -a <dir>` (a pre-synthesized assembly directory
skips synthesis). This extends the same fix to **every** command that
synthesizes through `Synthesizer.synthesize`:

- `diff`, `synth`, `import`, `export`, `orphan`, `publish-assets`
- `local invoke`, `local run-task`, `local start-api`, `local invoke-agentcore`

When `-a` points at a pre-synthesized assembly **directory**, each now logs
`Reading cloud assembly...`; a `--app` **command** (e.g. `node app.ts`) still
logs the command's synthesizing message (`Synthesizing CDK app...` /
`Synthesizing CDK app to read template...`).

The message choice is centralized in a new exported
`synthesisStatusMessage(app, synthesizingMessage)` helper next to
`isPreSynthesizedAssembly` (single source of the branch); `deploy.ts` is
refactored to use it too, replacing its inline ternary.

## Test plan

- [x] New unit tests for `synthesisStatusMessage` (dir → "Reading cloud
      assembly..."; command / undefined → passthrough message).
- [x] Updated the `synthesizer.js` mock factory in `import` / `orphan` /
      `publish-assets` unit tests to expose the new helper.
- [x] Full suite green: 406 files, 6213 tests.
- [x] Live-tested against a pre-synth `cdk.out`:
      `diff -a cdk.out` / `synth -a cdk.out` → `Reading cloud assembly...`;
      `diff -a "node bin/lambda.js"` → `Synthesizing CDK app...`.
- [x] Broad real-AWS integ (`/run-integ lambda`) — deploy + destroy clean
      (9 deleted, 0 errors, 0 orphans) since `deploy.ts` is in the
      integ-broad gate scope.

Pure status-string change; no behavior change to synthesis, deploy, or any
AWS interaction.
