### PR TITLE
docs(readme): add vs-Express-mode benchmark table to Benchmark section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Drop-in CDK CLI for existing CDK apps — faster deploys via AWS SDK instead of 
 
 Numbers below are deploy-phase only (CDK app synthesis is identical between cdkd and AWS CDK — both run the same user code through `aws-cdk-lib`'s synthesizer — so synth time is excluded from the speedup calculation).
 
-### vs AWS Express mode — faster than AWS's own fast-deploy option
+### vs CloudFormation Express mode — faster than CloudFormation's own fast-deploy option
 
-AWS's new [Express mode](https://aws.amazon.com/about-aws/whats-new/2026/06/aws-cloudformation-cdk/) is a fast-deploy option that skips resource stabilization waits, similar in spirit to cdkd's `--no-wait`. Even so, cdkd is faster than Express on nearly every stack, and with `--no-wait` it pulls dramatically ahead on stacks dominated by async resources.
+CloudFormation's [Express mode](https://aws.amazon.com/about-aws/whats-new/2026/06/aws-cloudformation-cdk/) is a fast-deploy option that skips resource stabilization waits, similar in spirit to cdkd's `--no-wait`. Even so, cdkd is faster than Express on nearly every stack, and with `--no-wait` it pulls dramatically ahead on stacks dominated by async resources.
 
 | Stack | Normal (CFn) | Express | cdkd | cdkd `--no-wait` |
 | --- | ---: | ---: | ---: | ---: |
@@ -41,7 +41,7 @@ AWS's new [Express mode](https://aws.amazon.com/about-aws/whats-new/2026/06/aws-
 Best of 3 runs, deploy-phase only, seconds, `us-west-2`. The `VPC + Lambda + SQS + CloudFront` stack is 1 VPC (2 AZs, NAT Gateway, public + private subnets) + VPC Lambda + Lambda Function URL + CloudFront Distribution + SQS + EventSourceMapping + Consumer Lambda.
 
 - **~1.5–2x faster than Express on most stacks** — e.g. SQS finishes in 9s vs Express's 22s (~2.4x).
-- **Async-heavy stacks are where the gap explodes.** On the VPC + CloudFront stack, `cdkd --no-wait` finishes in 40s vs Express's 366s (~9x) — cdkd returns immediately and lets AWS finish CloudFront propagation + NAT Gateway stabilization in the background.
+- **Async-heavy stacks are where the gap explodes.** On the VPC + CloudFront stack, `cdkd --no-wait` finishes in 40s vs Express's 366s (~9x) — cdkd returns as soon as each create call returns, leaving CloudFront propagation and NAT Gateway stabilization to complete in the background.
 - **S3 is the one case where Express edges cdkd's default** (22s vs 23s). On a near-instant single-resource stack there is little left to parallelize, and `--no-wait` makes no difference there.
 
 ### SDK Provider path — **5.5x faster** (17.0s vs 94.4s)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,27 @@ Drop-in CDK CLI for existing CDK apps — faster deploys via AWS SDK instead of 
 
 Numbers below are deploy-phase only (CDK app synthesis is identical between cdkd and AWS CDK — both run the same user code through `aws-cdk-lib`'s synthesizer — so synth time is excluded from the speedup calculation).
 
+### vs AWS Express mode — faster than AWS's own fast-deploy option
+
+AWS's new [Express mode](https://aws.amazon.com/about-aws/whats-new/2026/06/aws-cloudformation-cdk/) is a fast-deploy option that skips resource stabilization waits, similar in spirit to cdkd's `--no-wait`. Even so, cdkd is faster than Express on nearly every stack, and with `--no-wait` it pulls dramatically ahead on stacks dominated by async resources.
+
+| Stack | Normal (CFn) | Express | cdkd | cdkd `--no-wait` |
+| --- | ---: | ---: | ---: | ---: |
+| VPC + Lambda + SQS + CloudFront | 562 | 366 | 197 | **40** |
+| DynamoDB | 34 | 34 | 19 | 15 |
+| DynamoDB + KMS | 71 | 55 | 27 | 27 |
+| EC2 | 44 | 31 | 27 | 26 |
+| Lambda | 55 | 34 | 23 | 22 |
+| S3 | 39 | 22 | 23 | 24 |
+| SQS | 83 | 22 | **9** | 9 |
+| SQS + CloudWatch | 87 | 44 | 30 | 31 |
+
+Best of 3 runs, deploy-phase only, seconds, `us-west-2`. The `VPC + Lambda + SQS + CloudFront` stack is 1 VPC (2 AZs, NAT Gateway, public + private subnets) + VPC Lambda + Lambda Function URL + CloudFront Distribution + SQS + EventSourceMapping + Consumer Lambda.
+
+- **~1.5–2x faster than Express on most stacks** — e.g. SQS finishes in 9s vs Express's 22s (~2.4x).
+- **Async-heavy stacks are where the gap explodes.** On the VPC + CloudFront stack, `cdkd --no-wait` finishes in 40s vs Express's 366s (~9x) — cdkd returns immediately and lets AWS finish CloudFront propagation + NAT Gateway stabilization in the background.
+- **S3 is the one case where Express edges cdkd's default** (22s vs 23s). On a near-instant single-resource stack there is little left to parallelize, and `--no-wait` makes no difference there.
+
 ### SDK Provider path — **5.5x faster** (17.0s vs 94.4s)
 
 Stack: S3 Bucket, DynamoDB Table, SQS Queue, SNS Topic, SSM Parameter (5 independent resources, fully parallelized by cdkd's DAG scheduler).


### PR DESCRIPTION
## Summary

Adds a **vs AWS Express mode** benchmark table to the `## Benchmark` section of the README, as the new headline of that section.

AWS recently shipped Express mode, a fast-deploy option that skips resource stabilization waits (similar in spirit to cdkd's `--no-wait`). This new table shows that cdkd is faster than Express on nearly every stack, and pulls dramatically ahead with `--no-wait` on async-heavy stacks (e.g. VPC + CloudFront: 40s vs Express's 366s, ~9x).

- 8-stack comparison: Normal (CFn) / Express / cdkd / cdkd `--no-wait`, best of 3 runs, deploy-phase only, `us-west-2`.
- Honest reporting: S3 is called out as the one case where Express slightly edges cdkd's default (22s vs 23s).
- The existing reproducible breakdowns (SDK Provider 5.5x / VPC+CloudFront 15x / CC API fallback 1.6x, backed by `tests/benchmark`) and the `up to 15x` headline are left unchanged below the new table.

## Notes

- Docs-only change (README.md); no source or behavior change.
- The new table is a separate measurement set from `tests/benchmark` (not reproducible via `run-benchmark.sh`), so it is presented as a standalone comparison.

## Test plan

- [x] typecheck / lint / build pass
- [x] `vp run test` — 406 files, 6213 tests pass (unaffected; docs-only)
- [x] docs consistency verified (`/check-docs`)
