### PR TITLE
docs(features): document UpdatePolicy divergence + hunt-bugs parallel pre-synth note

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -39,6 +39,12 @@ gate, not just trust.
    global resource) can deploy/destroy concurrently as background tasks, but cap
    at ~4-5 in flight to avoid overloading the machine. One CDK app with several
    stacks (`cdkd deploy <StackName>` per stack) is the cleanest shape.
+   **Pre-synth once, then deploy from the assembly** — parallel deploys that
+   each re-synth collide on the shared `cdk.out` lock ("Another CLI is
+   currently synthing to cdk.out"). Run `npx cdk synth --all -q` once, then
+   `node dist/cli.js deploy <Stack> -a /tmp/cdkd-bughunt/cdk.out ...` per
+   stack: no synth happens at deploy time, so parallel is safe. (Without `-a`,
+   deploy stacks SERIALLY.)
 
 ## Workflow
 
@@ -67,7 +73,8 @@ is what arms the cleanup gate — see below):
 
 ### 3. Deploy (parallel, capped)
 
-Deploy each stack with `node dist/cli.js deploy <Stack> --state-bucket <bucket>`,
+Deploy each stack with `node dist/cli.js deploy <Stack> -a <path-to-cdk.out> --state-bucket <bucket>`
+(the pre-synthed assembly — see principle 4),
 up to ~4-5 concurrently as background tasks, each to its own log. Watch for:
 deploy-time errors, wrong replacement decisions (`Replacing X — immutable
 properties changed`), silent drops, custom-resource hangs. For each stack also

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -74,6 +74,7 @@ top-level features rather than table rows.
 | Custom Resources (CDK Provider) | ✅ | `isCompleteHandler` / `onEventHandler` async pattern detection |
 | DeletionPolicy: Retain | ✅ | Skip deletion for retained resources |
 | UpdateReplacePolicy: Retain | ✅ | Keep old resource on replacement |
+| UpdatePolicy | ⚠️ Ignored | `CodeDeployLambdaAliasUpdate` / ASG rolling-update policies are not processed — updates apply directly in one step (e.g. a Lambda alias flips instantly instead of CFn's gradual CodeDeploy canary shift). Intentional for dev/test iteration speed; the CodeDeploy application/deployment group resources themselves deploy fine (see `tests/integration/codedeploy-lambda-deployment-group`) |
 | Implicit delete dependencies | ✅ | VPC / IGW / EventBus / Subnet / RouteTable ordering |
 | Stack dependency resolution | ✅ | Auto-deploy dependency stacks, `-e` to skip |
 | Multi-stack parallel deploy | ✅ | Independent stacks deployed in parallel |


### PR DESCRIPTION
## Summary

Follow-ups from the bug-hunt sweep that shipped #948:

- **docs/supported-features.md**: add an `UpdatePolicy` row to the feature-parity table. cdkd does not process `UpdatePolicy` (`CodeDeployLambdaAliasUpdate`, ASG rolling-update policies) — updates apply directly in one step, e.g. a Lambda alias flips instantly instead of CloudFormation's gradual CodeDeploy canary shift. This is intentional (dev/test iteration speed) and was live-verified in the #948 sweep, but was previously documented only in the `codedeploy-lambda-deployment-group` fixture header — users scanning the parity table couldn't see it.
- **hunt-bugs skill**: record the parallel-deploy technique established in the same sweep — pre-synth once (`npx cdk synth --all -q`) and deploy each stack via `-a cdk.out`, which sidesteps the shared `cdk.out` synth-lock collision that previously forced serial deploys.

## Test plan

Docs/skill-only change — no code paths affected. Full suite still green (407 files / 6215 tests). The `UpdatePolicy` behavior described was verified against real AWS in the #948 sweep (alias flipped directly; grep confirms `UpdatePolicy` is only read as a template attribute, never processed).
