### PR TITLE
chore(repo): auto-resolve integ-ledger conflicts with merge=union

### DIFF
--- a/.claude/skills/pick-integ/SKILL.md
+++ b/.claude/skills/pick-integ/SKILL.md
@@ -36,17 +36,22 @@ the orchestrator runs the chosen tests via `/run-integ` (which records each run 
    ```bash
    LEDGER="docs/_generated/integ-last-run.tsv"
    now=$(date -u +%s)
+   # The ledger merges with the union driver (.gitattributes), so a rare
+   # same-test collision can leave duplicate rows — the LAST row per test is
+   # authoritative (deduped below before any staleness math).
+   DEDUPED="$(mktemp)"
+   awk -F'\t' 'NR==1{print; next} {last[$1]=$0; order[$1]=NR} END{for (t in last) print last[t]}' "$LEDGER" > "$DEDUPED"
    # never-run: fixtures with no ledger row
    comm -23 \
      <(ls -d tests/integration/*/ | sed 's#tests/integration/##;s#/##' | sort) \
-     <(awk -F'\t' 'NR>1{print $1}' "$LEDGER" | sort)
+     <(awk -F'\t' 'NR>1{print $1}' "$DEDUPED" | sort)
    # stale (>14d) or failing, from the ledger:
    awk -F'\t' -v now="$now" 'NR>1 {
      cmd="date -u -j -f %Y-%m-%dT%H:%M:%SZ \""$2"\" +%s 2>/dev/null || date -u -d \""$2"\" +%s 2>/dev/null";
      cmd | getline t; close(cmd);
      age=int((now-t)/86400);
      if ($3=="FAIL" || age>14) printf "%s\tage=%sd\tresult=%s\t%s\n",$1,age,$3,$6
-   }' "$LEDGER"
+   }' "$DEDUPED"
    ```
    (The `date` line handles both BSD/macOS `-j -f` and GNU `-d`.)
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# The integ ledger is an append-ish, one-row-per-test TSV updated by every
+# /run-integ invocation. Parallel-agent PRs almost always touch DIFFERENT
+# test rows, so the union driver auto-resolves what was previously a
+# guaranteed manual conflict on every rebase (three hand-unions in one
+# session on 2026-07-02). The rare same-test collision leaves BOTH rows in
+# the file; consumers are defensive: /run-integ's awk update drops every
+# existing row for the test before appending, and /pick-integ reads the
+# LAST row per test as authoritative.
+docs/_generated/integ-last-run.tsv merge=union


### PR DESCRIPTION
## Summary

Every parallel-agent PR touches a different row of `docs/_generated/integ-last-run.tsv`, yet each merge to main turned the ledger into a guaranteed manual rebase conflict (hand-unioned three times in one session on 2026-07-02, PR #957).

- `.gitattributes`: `merge=union` for the ledger — the different-rows case (the overwhelmingly common one) auto-resolves.
- Same-test collision (rare) leaves both rows in the file, so consumers are defensive: `/run-integ` already drops every existing row for the test before appending; `/pick-integ` now dedupes to the LAST row per test before any staleness math.

## Test plan

Doc/infra-only change (no src). The pick-integ awk dedup was exercised locally against the current ledger (duplicate-free input passes through unchanged).