### PR TITLE
test(integ): update-replace fixture passes --force-stateful-recreation for the ReplaceBucket rename

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -144,7 +144,6 @@ stepfunctions	2026-06-21T04:32:59Z	PASS	30	standard	SFN deploy 5 / destroy 5, 0 
 stepfunctions-s3-definition	2026-06-15T08:44:00Z	PASS	55	verify.sh	post-review re-run; DefinitionS3Location+asset fix; destroy clean
 throttle-wide-dag	2026-06-14T04:35:46Z	PASS		verify.sh	bug15 throttle-retry validated deploy+destroy clean
 update-policy-mutations	2026-06-20T19:39:38Z	PASS		verify.sh	first run; DeletionPolicy/UpdateReplacePolicy mutations + retain-on-replace; 5 del +2 retain; step6 cleanup -> 0 leftover
-update-replace	2026-06-13T11:42:29Z	PASS	71	verify.sh	#831 +Lambda/IAM/SG not-found post-destroy; 0 err
 vpc-lambda	2026-06-21T16:00:57Z	PASS	330	standard	stale-real re-run; 16 created/16 deleted 0 err; VPC+ENI clean (benign Pending detach-skip)
 vpc-lambda-cr-race	2026-06-21T11:00:28Z	PASS	343	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 vpc-lookup	2026-06-21T11:00:28Z	PASS	15	standard	sweep staleness re-run (re-verified PASS; ledger-restore)
@@ -212,3 +211,4 @@ synthetics-canary	2026-07-02T06:31:54Z	PASS	134	verify.sh	new fixture; remnant-c
 eventbridge-pipes	2026-07-02T12:49:57Z	PASS	114	verify.sh	new UPDATE phase (issue 960): BatchSize in-place, no spurious replacement
 scheduler-custom-group	2026-07-02T12:35:05Z	PASS	98	verify.sh	new fixture (issue 961): custom-group UPDATE + schedule-only removal + destroy clean
 eventbridge-scheduler	2026-07-02T12:35:05Z	PASS	57	verify.sh	regression for new Scheduler SDK provider routing (default group)
+update-replace	2026-07-02T16:38:15Z	PASS	77	verify.sh	fixture updated for stateful-replace guard (--force-stateful-recreation), 0 orphans

--- a/tests/integration/update-replace/verify.sh
+++ b/tests/integration/update-replace/verify.sh
@@ -176,10 +176,14 @@ esac
 echo "    OK (baseline): ReplaceBucket '${REPLACE_BUCKET_BEFORE}' exists (v1)"
 
 # --- Phase 1b: redeploy with CDKD_TEST_UPDATE=true --------------------
+# The ReplaceBucket rename is a property-driven S3 replacement; since the
+# stateful-replace guard (2026-06-29) it requires an explicit
+# --force-stateful-recreation confirmation (mirrors replacement-immutable-name).
 echo "==> Phase 1b: redeploy with CDKD_TEST_UPDATE=true"
 CDKD_TEST_UPDATE=true node "${LOCAL_DIST}" deploy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" \
   --region "${REGION}" \
+  --force-stateful-recreation \
   --yes
 
 STATE_AFTER=$(aws s3 cp "s3://${STATE_BUCKET}/${STATE_KEY}" - 2>/dev/null)


### PR DESCRIPTION
## Summary

The `update-replace` fixture's Phase 1b (ReplaceBucket rename) is a property-driven S3 replacement. Since the stateful-replace guard shipped (2026-06-29, the createOnly-fallback PR), that phase requires an explicit `--force-stateful-recreation` — without it the deploy hard-fails on `STATEFUL_REPLACE_BLOCKED`, so the fixture has been red on main. Mirrors the `replacement-immutable-name` fixture's rename phase, which was updated in the guard PR itself.

Note: this change was originally drafted directly in the main worktree by an earlier session and left uncommitted; it was preserved into this branch, comment-polished, and live-verified before landing.

## Verification

- `bash verify.sh` against real AWS: **PASS** (77s, all 16 assertions, clean destroy, 0 orphans). Ledger updated in the same commit.
- Tests-only change (fixture script + ledger) — no src surface.