### PR TITLE
fix(provisioning): clear removed FilterCriteria/ScalingConfig on Lambda ESM update

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -212,4 +212,4 @@ throttle-wide-dag	2026-07-02T18:23:15Z	PASS	163	verify.sh	0703 staleness sweep (
 servicediscovery	2026-07-02T18:23:15Z	PASS	111	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 cloudwatch	2026-07-02T18:23:15Z	PASS	50	standard	0703 staleness sweep (pre-TTL refresh); clean
 docker-image-asset	2026-07-03T05:15:31Z	PASS	64	verify.sh	0703 sweep; Docker recovered (hard-restart + docker logout public.ecr.aws for stale 403); clean
-sqs-esm-max-concurrency	2026-07-03T06:43:53Z	PASS	133	verify.sh	removal clears FilterCriteria+ScalingConfig; fixed null length() set-e abort in fixture
+sqs-esm-max-concurrency	2026-07-03T06:53:49Z	PASS	70	verify.sh	removal clears FilterCriteria+ScalingConfig; stream-numeric restores kind-gated

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -166,7 +166,6 @@ cognito-identity-pool	2026-06-27T19:25:47Z	PASS	44	verify.sh	bughunt-clean regre
 eventbridge-scheduler	2026-07-02T12:35:05Z	PASS	57	verify.sh	regression for new Scheduler SDK provider routing (default group)
 lambda-reserved-concurrency	2026-06-27T19:25:47Z	PASS	47	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
 lambda-alias-provisioned-concurrency	2026-06-27T19:25:47Z	PASS	251	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
-sqs-esm-max-concurrency	2026-06-27T19:25:47Z	PASS	70	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
 kinesis-esm-filter	2026-06-27T19:34:46Z	PASS	62	verify.sh	bughunt-clean regression fixture; FilterCriteria content asserted; clean destroy
 cognito-userpool-user-ref	2026-06-28T02:53:29Z	PASS	85	verify.sh	UserPoolUser Ref compound-id fix; repro FAIL->PASS; clean destroy
 s3-lifecycle	2026-06-28T17:58:35Z	PASS	51	verify.sh	V1/V2 mix + top-level ObjectSize fold; deploy+update+destroy clean
@@ -213,3 +212,4 @@ throttle-wide-dag	2026-07-02T18:23:15Z	PASS	163	verify.sh	0703 staleness sweep (
 servicediscovery	2026-07-02T18:23:15Z	PASS	111	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 cloudwatch	2026-07-02T18:23:15Z	PASS	50	standard	0703 staleness sweep (pre-TTL refresh); clean
 docker-image-asset	2026-07-03T05:15:31Z	PASS	64	verify.sh	0703 sweep; Docker recovered (hard-restart + docker logout public.ecr.aws for stale 403); clean
+sqs-esm-max-concurrency	2026-07-03T06:43:53Z	PASS	133	verify.sh	removal clears FilterCriteria+ScalingConfig; fixed null length() set-e abort in fixture

--- a/src/provisioning/providers/lambda-eventsource-provider.ts
+++ b/src/provisioning/providers/lambda-eventsource-provider.ts
@@ -122,6 +122,15 @@ const KINDS_WITH_ZERO_BATCHING_WINDOW_DEFAULT: ReadonlySet<EventSourceKind> = ne
   'kinesis',
   'dynamodb',
 ]);
+/**
+ * Source kinds that accept the stream-processing numeric parameters
+ * (`MaximumRetryAttempts` / `MaximumRecordAgeInSeconds` /
+ * `ParallelizationFactor` / `TumblingWindowInSeconds`) — Kinesis / DynamoDB
+ * streams only. AWS rejects these on SQS / Kafka / MQ / DocumentDB, so the
+ * removal-on-UPDATE default-restore path is gated on this set (see the numeric
+ * restores in `update()`).
+ */
+const KINDS_WITH_STREAM_NUMERICS: ReadonlySet<EventSourceKind> = new Set(['kinesis', 'dynamodb']);
 
 /**
  * AWS Lambda Event Source Mapping Provider
@@ -469,11 +478,18 @@ export class LambdaEventSourceMappingProvider implements ResourceProvider {
     // Numeric properties: restore the AWS default value on removal. The
     // documented defaults are: MaximumRetryAttempts = -1 (infinite),
     // MaximumRecordAgeInSeconds = -1 (infinite), ParallelizationFactor = 1,
-    // TumblingWindowInSeconds = 0 (no window).
-    if (wasSet('MaximumRetryAttempts')) updateParams.MaximumRetryAttempts = -1;
-    if (wasSet('MaximumRecordAgeInSeconds')) updateParams.MaximumRecordAgeInSeconds = -1;
-    if (wasSet('ParallelizationFactor')) updateParams.ParallelizationFactor = 1;
-    if (wasSet('TumblingWindowInSeconds')) updateParams.TumblingWindowInSeconds = 0;
+    // TumblingWindowInSeconds = 0 (no window). All four are stream-only
+    // (Kinesis / DynamoDB) parameters — AWS rejects them on SQS / Kafka / MQ /
+    // DocumentDB mappings — so gate the restore on the stream kinds, mirroring
+    // the array / batching-window clears above. CDK never emits these on a
+    // non-stream mapping, so the guard is defense-in-depth against a
+    // hand-authored / imported previous template carrying a stray value.
+    if (KINDS_WITH_STREAM_NUMERICS.has(prevKind)) {
+      if (wasSet('MaximumRetryAttempts')) updateParams.MaximumRetryAttempts = -1;
+      if (wasSet('MaximumRecordAgeInSeconds')) updateParams.MaximumRecordAgeInSeconds = -1;
+      if (wasSet('ParallelizationFactor')) updateParams.ParallelizationFactor = 1;
+      if (wasSet('TumblingWindowInSeconds')) updateParams.TumblingWindowInSeconds = 0;
+    }
 
     // MaximumBatchingWindowInSeconds: the default is 0 for
     // SQS/Kinesis/DynamoDB but 500 ms for Kafka/MSK/MQ/DocumentDB — and AWS

--- a/src/provisioning/providers/lambda-eventsource-provider.ts
+++ b/src/provisioning/providers/lambda-eventsource-provider.ts
@@ -79,6 +79,26 @@ function classifyEventSource(resp: {
   return 'unknown';
 }
 
+/**
+ * Classify an event source mapping from its CFn property bag (as opposed to
+ * `classifyEventSource`, which reads an AWS `GetEventSourceMapping` response).
+ * The discriminating keys are identical in both shapes (`EventSourceArn` plus
+ * the four `*EventSourceConfig` / `SelfManagedEventSource` markers), so this
+ * is a thin type-narrowing adapter over the same logic. Used by `update()`'s
+ * removal-clear path (issue #976) to gate source-kind-specific clears
+ * (`FunctionResponseTypes` / `SourceAccessConfigurations` /
+ * `MaximumBatchingWindowInSeconds`).
+ */
+function classifyEventSourceFromProperties(properties: Record<string, unknown>): EventSourceKind {
+  return classifyEventSource({
+    EventSourceArn: properties['EventSourceArn'] as string | undefined,
+    SelfManagedEventSource: properties['SelfManagedEventSource'],
+    AmazonManagedKafkaEventSourceConfig: properties['AmazonManagedKafkaEventSourceConfig'],
+    SelfManagedKafkaEventSourceConfig: properties['SelfManagedKafkaEventSourceConfig'],
+    DocumentDBEventSourceConfig: properties['DocumentDBEventSourceConfig'],
+  });
+}
+
 const KINDS_WITH_FUNCTION_RESPONSE_TYPES: ReadonlySet<EventSourceKind> = new Set([
   'sqs',
   'kinesis',
@@ -88,6 +108,19 @@ const KINDS_WITH_SOURCE_ACCESS_CONFIGURATIONS: ReadonlySet<EventSourceKind> = ne
   'kafka',
   'mq',
   'documentdb',
+]);
+/**
+ * Source kinds whose `MaximumBatchingWindowInSeconds` default is `0` seconds
+ * (SQS / Kinesis / DynamoDB). The poll-based kinds (Kafka / MSK / MQ /
+ * DocumentDB) default to 500 ms, which cannot be restored via
+ * `UpdateEventSourceMapping` (the field only accepts whole-second increments),
+ * so the removal-on-UPDATE path only restores `0` for these kinds — see the
+ * comment at the `MaximumBatchingWindowInSeconds` clear in `update()`.
+ */
+const KINDS_WITH_ZERO_BATCHING_WINDOW_DEFAULT: ReadonlySet<EventSourceKind> = new Set([
+  'sqs',
+  'kinesis',
+  'dynamodb',
 ]);
 
 /**
@@ -386,6 +419,85 @@ export class LambdaEventSourceMappingProvider implements ResourceProvider {
       updateParams.ProvisionedPollerConfig = properties[
         'ProvisionedPollerConfig'
       ] as import('@aws-sdk/client-lambda').ProvisionedPollerConfig;
+
+    // Removal-on-UPDATE (issue #976). The `!== undefined` guards above only
+    // fire when the NEW template still carries the property, so a property
+    // REMOVED from the template is simply omitted from the Update call and
+    // AWS treats the omission as "no change" — the old value silently
+    // survives (cdkd diff shows old->undefined, state drops it, AWS keeps
+    // it). CloudFormation instead sends each cleared property's documented
+    // reset sentinel on UpdateEventSourceMapping. We mirror that: for every
+    // property that was present in `previousProperties` and is now absent in
+    // `properties`, send the documented clear/reset value.
+    //
+    // Source-kind gating: `FunctionResponseTypes` (SQS/Kinesis/DynamoDB) and
+    // `SourceAccessConfigurations` (Kafka/MSK/MQ/DocumentDB) are only valid
+    // for a subset of source kinds — AWS rejects the `[]` clear against the
+    // wrong kind ("X is not allowed for this event source"), so we classify
+    // the source from the previous property bag and gate those two clears.
+    const wasSet = (key: string): boolean =>
+      previousProperties[key] !== undefined && properties[key] === undefined;
+    const prevKind = classifyEventSourceFromProperties(previousProperties);
+
+    // Object properties whose documented clear sentinel is an empty object.
+    // `FilterCriteria: {}` is explicitly documented (Lambda event-filtering
+    // guide: "run update-event-source-mapping ... with an empty
+    // FilterCriteria object"); `ScalingConfig: {}` / `DestinationConfig: {}`
+    // reset MaximumConcurrency / the on-failure destination back to default.
+    if (wasSet('FilterCriteria')) updateParams.FilterCriteria = {};
+    if (wasSet('ScalingConfig')) updateParams.ScalingConfig = {};
+    if (wasSet('DestinationConfig')) updateParams.DestinationConfig = {};
+
+    // Array properties whose documented clear sentinel is an empty array,
+    // gated by source kind (see above).
+    if (wasSet('FunctionResponseTypes') && KINDS_WITH_FUNCTION_RESPONSE_TYPES.has(prevKind))
+      updateParams.FunctionResponseTypes = [];
+    if (
+      wasSet('SourceAccessConfigurations') &&
+      KINDS_WITH_SOURCE_ACCESS_CONFIGURATIONS.has(prevKind)
+    )
+      updateParams.SourceAccessConfigurations = [];
+
+    // MetricsConfig resets by disabling the opt-in metrics — `{ Metrics: [] }`.
+    if (wasSet('MetricsConfig')) updateParams.MetricsConfig = { Metrics: [] };
+
+    // KMSKeyArn (CFn `KmsKeyArn`): the documented clear sentinel is an empty
+    // string — Lambda then falls back to the AWS-owned key. Mirrors the
+    // explicit-`''` passthrough above; here we also honor REMOVAL.
+    if (wasSet('KmsKeyArn')) updateParams.KMSKeyArn = '';
+
+    // Numeric properties: restore the AWS default value on removal. The
+    // documented defaults are: MaximumRetryAttempts = -1 (infinite),
+    // MaximumRecordAgeInSeconds = -1 (infinite), ParallelizationFactor = 1,
+    // TumblingWindowInSeconds = 0 (no window).
+    if (wasSet('MaximumRetryAttempts')) updateParams.MaximumRetryAttempts = -1;
+    if (wasSet('MaximumRecordAgeInSeconds')) updateParams.MaximumRecordAgeInSeconds = -1;
+    if (wasSet('ParallelizationFactor')) updateParams.ParallelizationFactor = 1;
+    if (wasSet('TumblingWindowInSeconds')) updateParams.TumblingWindowInSeconds = 0;
+
+    // MaximumBatchingWindowInSeconds: the default is 0 for
+    // SQS/Kinesis/DynamoDB but 500 ms for Kafka/MSK/MQ/DocumentDB — and AWS
+    // documents that the 500 ms default CANNOT be restored via
+    // UpdateEventSourceMapping (the field only accepts whole-second
+    // increments, so you must create a new mapping). We therefore restore
+    // `0` on removal ONLY for the second-granular kinds; for the poll-based
+    // kinds we intentionally leave the field untouched (a template change
+    // that must restore 500 ms is a CFn-side replace, not an in-place clear).
+    if (
+      wasSet('MaximumBatchingWindowInSeconds') &&
+      KINDS_WITH_ZERO_BATCHING_WINDOW_DEFAULT.has(prevKind)
+    )
+      updateParams.MaximumBatchingWindowInSeconds = 0;
+
+    // No documented clear sentinel — intentionally NOT cleared on removal:
+    //   - LoggingConfig: holds enum log-level fields, not a presence toggle;
+    //     AWS documents no `{}` reset. Removing it in the template is a
+    //     no-op against AWS (the last-applied log config survives).
+    //   - ProvisionedPollerConfig: no documented empty-object reset to
+    //     on-demand poller scaling. Left untouched on removal.
+    //   - BatchSize: source-dependent default (10 for SQS, 100 otherwise);
+    //     rarely removed, and a wrong default would change batching
+    //     behavior. Left untouched on removal (the last value survives).
 
     const updateResp = await this.lambdaClient.send(
       new UpdateEventSourceMappingCommand(updateParams)

--- a/tests/integration/sqs-esm-max-concurrency/lib/sqs-esm-max-concurrency-stack.ts
+++ b/tests/integration/sqs-esm-max-concurrency/lib/sqs-esm-max-concurrency-stack.ts
@@ -10,12 +10,25 @@ import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
  * `reportBatchItemFailures`. Both are easy-to-silent-drop ESM fields a basic
  * SQS->Lambda fixture never exercises. Confirmed CLEAN by a /hunt-bugs sweep;
  * this fixture is the regression guard.
+ *
+ * Issue #976 (removal-on-UPDATE): the base phase creates the ESM WITH
+ * `FilterCriteria` + `ScalingConfig.MaximumConcurrency`; the UPDATE phase
+ * (`CDKD_TEST_UPDATE=true`) REMOVES both from the template and bumps
+ * `batchSize`. Before the fix, `LambdaEventSourceMappingProvider.update()`
+ * omitted the removed properties from `UpdateEventSourceMapping` and AWS
+ * silently kept filtering + kept the concurrency cap; the fix sends the
+ * documented clear sentinels (`FilterCriteria: {}` / `ScalingConfig: {}`) so
+ * AWS clears them. verify.sh asserts the AWS-current filter + cap before AND
+ * after the update.
  */
 const MAXCONC = 5;
 
 export class SqsEsmMaxConcurrencyStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
+
+    // UPDATE phase removes FilterCriteria + ScalingConfig and bumps batchSize.
+    const isUpdate = process.env.CDKD_TEST_UPDATE === 'true';
 
     const queue = new sqs.Queue(this, 'Queue', {
       queueName: `${this.stackName}-queue`,
@@ -27,11 +40,16 @@ export class SqsEsmMaxConcurrencyStack extends cdk.Stack {
       handler: 'index.handler',
       code: lambda.Code.fromInline('exports.handler=async()=>({batchItemFailures:[]});'),
     });
+
     fn.addEventSource(
       new SqsEventSource(queue, {
-        batchSize: 10,
-        maxConcurrency: MAXCONC,
+        batchSize: isUpdate ? 10 : 5,
+        // Base phase: filter + concurrency cap set. UPDATE phase: both removed
+        // (undefined) so the template no longer carries them — the removal
+        // path must send the documented clear sentinels to AWS.
+        maxConcurrency: isUpdate ? undefined : MAXCONC,
         reportBatchItemFailures: true,
+        filters: isUpdate ? undefined : [lambda.FilterCriteria.filter({ body: ['hunt'] })],
       })
     );
   }

--- a/tests/integration/sqs-esm-max-concurrency/verify.sh
+++ b/tests/integration/sqs-esm-max-concurrency/verify.sh
@@ -45,10 +45,15 @@ esm_maxconc() {
   aws lambda list-event-source-mappings --function-name "${FN}" --region "${REGION}" \
     --query 'EventSourceMappings[0].ScalingConfig.MaximumConcurrency' --output text 2>/dev/null
 }
-# Reads the ESM's FilterCriteria.Filters count (0 / None when cleared / unset).
+# Reads the ESM's FilterCriteria.Filters count (0 when cleared / unset). The
+# `|| ` + backtick-empty-array coalesces a null Filters (the cleared state) to
+# `[]` INSIDE JMESPath, so `length()` never receives null — otherwise the AWS
+# CLI errors ("invalid type for value: None") with a non-zero exit, and under
+# this script's `set -e` a bare `length(... .Filters)` would abort the whole
+# run at the `$( )` assignment the instant the filter is (correctly) cleared.
 esm_filter_count() {
   aws lambda list-event-source-mappings --function-name "${FN}" --region "${REGION}" \
-    --query 'length(EventSourceMappings[0].FilterCriteria.Filters)' --output text 2>/dev/null
+    --query 'length(EventSourceMappings[0].FilterCriteria.Filters || `[]`)' --output text 2>/dev/null
 }
 
 echo "==> Deploy (base: FilterCriteria + ScalingConfig set)"

--- a/tests/integration/sqs-esm-max-concurrency/verify.sh
+++ b/tests/integration/sqs-esm-max-concurrency/verify.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # verify.sh — cdkd Lambda SQS ESM ScalingConfig.MaximumConcurrency integ.
-# Asserts the maxConcurrency ESM attribute reaches AWS, then destroys clean.
-# Confirmed-clean /hunt-bugs pattern; regression guard.
+# Base phase: asserts maxConcurrency + FilterCriteria reach AWS.
+# UPDATE phase (issue #976): removes FilterCriteria + ScalingConfig from the
+# template and asserts AWS actually CLEARS both (removal-on-UPDATE, not a
+# silent drop). Then destroys clean.
 
 set -euo pipefail
 cd "$(dirname "$0")"
@@ -38,16 +40,52 @@ trap cleanup EXIT
 [ -d node_modules ] || npm install
 echo "==> Pre-run cleanup"; cleanup
 
-echo "==> Deploy"
-node "${LOCAL_DIST}" deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --yes
+# Reads the ESM's ScalingConfig.MaximumConcurrency (or "None" when unset).
+esm_maxconc() {
+  aws lambda list-event-source-mappings --function-name "${FN}" --region "${REGION}" \
+    --query 'EventSourceMappings[0].ScalingConfig.MaximumConcurrency' --output text 2>/dev/null
+}
+# Reads the ESM's FilterCriteria.Filters count (0 / None when cleared / unset).
+esm_filter_count() {
+  aws lambda list-event-source-mappings --function-name "${FN}" --region "${REGION}" \
+    --query 'length(EventSourceMappings[0].FilterCriteria.Filters)' --output text 2>/dev/null
+}
 
-MAXCONC=$(aws lambda list-event-source-mappings --function-name "${FN}" --region "${REGION}" \
-  --query 'EventSourceMappings[0].ScalingConfig.MaximumConcurrency' --output text 2>/dev/null)
+echo "==> Deploy (base: FilterCriteria + ScalingConfig set)"
+env -u CDKD_TEST_UPDATE node "${LOCAL_DIST}" deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --yes
+
+MAXCONC=$(esm_maxconc)
 if [ "${MAXCONC}" != "${EXPECTED_MAXCONC}" ]; then
-  echo "FAIL: ScalingConfig.MaximumConcurrency is '${MAXCONC}', expected '${EXPECTED_MAXCONC}' (silent-drop?)" >&2
+  echo "FAIL: base ScalingConfig.MaximumConcurrency is '${MAXCONC}', expected '${EXPECTED_MAXCONC}' (silent-drop?)" >&2
   exit 1
 fi
-echo "    OK: ScalingConfig.MaximumConcurrency == ${EXPECTED_MAXCONC} on AWS"
+echo "    OK: base ScalingConfig.MaximumConcurrency == ${EXPECTED_MAXCONC} on AWS"
+
+FILTERS=$(esm_filter_count)
+if [ "${FILTERS}" == "None" ] || [ "${FILTERS}" == "0" ] || [ -z "${FILTERS}" ]; then
+  echo "FAIL: base FilterCriteria has no filters ('${FILTERS}'), expected >= 1 (silent-drop?)" >&2
+  exit 1
+fi
+echo "    OK: base FilterCriteria has ${FILTERS} filter(s) on AWS"
+
+echo "==> Deploy (UPDATE: FilterCriteria + ScalingConfig removed from template)"
+CDKD_TEST_UPDATE=true node "${LOCAL_DIST}" deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --yes
+
+# Removal must CLEAR the cap on AWS — ScalingConfig.MaximumConcurrency gone.
+MAXCONC_AFTER=$(esm_maxconc)
+if [ "${MAXCONC_AFTER}" != "None" ] && [ -n "${MAXCONC_AFTER}" ]; then
+  echo "FAIL: after removal, ScalingConfig.MaximumConcurrency is still '${MAXCONC_AFTER}', expected cleared (None) — removal silently dropped (issue #976)" >&2
+  exit 1
+fi
+echo "    OK: ScalingConfig.MaximumConcurrency CLEARED on AWS after removal"
+
+# Removal must CLEAR the filter on AWS — no Filters remain.
+FILTERS_AFTER=$(esm_filter_count)
+if [ "${FILTERS_AFTER}" != "None" ] && [ "${FILTERS_AFTER}" != "0" ] && [ -n "${FILTERS_AFTER}" ]; then
+  echo "FAIL: after removal, FilterCriteria still has '${FILTERS_AFTER}' filter(s), expected cleared — removal silently dropped (issue #976)" >&2
+  exit 1
+fi
+echo "    OK: FilterCriteria CLEARED on AWS after removal"
 
 echo "==> Destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force

--- a/tests/unit/provisioning/lambda-eventsource-provider.test.ts
+++ b/tests/unit/provisioning/lambda-eventsource-provider.test.ts
@@ -400,6 +400,32 @@ describe('LambdaEventSourceMappingProvider', () => {
       expect(input['TumblingWindowInSeconds']).toBe(0);
     });
 
+    it('does NOT restore stream-only numeric defaults for an SQS source (AWS rejects them off-stream)', async () => {
+      // The numeric restores are Kinesis/DynamoDB-only. If a hand-authored /
+      // imported previous template carried one on an SQS mapping and it is
+      // removed, cdkd must NOT send the reset value (AWS would reject it).
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          MaximumRetryAttempts: 5,
+          MaximumRecordAgeInSeconds: 3600,
+          ParallelizationFactor: 4,
+          TumblingWindowInSeconds: 30,
+        }
+      );
+
+      const input = getUpdateInput();
+      expect(input['MaximumRetryAttempts']).toBeUndefined();
+      expect(input['MaximumRecordAgeInSeconds']).toBeUndefined();
+      expect(input['ParallelizationFactor']).toBeUndefined();
+      expect(input['TumblingWindowInSeconds']).toBeUndefined();
+    });
+
     it('clears FunctionResponseTypes to [] on removal for an SQS source (kind allows it)', async () => {
       await provider.update(
         'L',

--- a/tests/unit/provisioning/lambda-eventsource-provider.test.ts
+++ b/tests/unit/provisioning/lambda-eventsource-provider.test.ts
@@ -3,6 +3,7 @@ import {
   CreateEventSourceMappingCommand,
   DeleteEventSourceMappingCommand,
   GetEventSourceMappingCommand,
+  UpdateEventSourceMappingCommand,
 } from '@aws-sdk/client-lambda';
 import { isRetryableTransientError } from '../../../src/deployment/retryable-errors.js';
 
@@ -246,6 +247,318 @@ describe('LambdaEventSourceMappingProvider', () => {
       expect(input['Queues']).toBeUndefined();
       expect(input['Topics']).toBeUndefined();
       expect(input['StartingPositionTimestamp']).toBeUndefined();
+    });
+  });
+
+  describe('update — removal-on-UPDATE clear sentinels (issue #976)', () => {
+    const UUID = 'abcdef12-3456-7890-abcd-ef1234567890';
+    const ARN = 'arn:aws:lambda:us-east-1:123456789012:event-source-mapping:' + UUID;
+    const SQS_ARN = 'arn:aws:sqs:us-east-1:123456789012:my-queue';
+    const KAFKA_ARN = 'arn:aws:kafka:us-east-1:123456789012:cluster/c/uuid';
+
+    beforeEach(() => {
+      // UpdateEventSourceMapping returns the ESM ARN (used for the tag diff);
+      // ListTags returns an empty tag set so applyTagDiff is a no-op.
+      mockSend.mockImplementation((cmd: unknown) => {
+        if (cmd instanceof UpdateEventSourceMappingCommand) {
+          return Promise.resolve({ UUID, EventSourceMappingArn: ARN });
+        }
+        return Promise.resolve({ Tags: {} });
+      });
+    });
+
+    function getUpdateInput(): Record<string, unknown> {
+      const call = mockSend.mock.calls.find(
+        (c) => c[0] instanceof UpdateEventSourceMappingCommand
+      );
+      return (call?.[0] as { input: Record<string, unknown> }).input;
+    }
+
+    it('sends FilterCriteria: {} when FilterCriteria is removed from the template', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN, BatchSize: 10 },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          BatchSize: 5,
+          FilterCriteria: { Filters: [{ Pattern: '{"body":["hunt"]}' }] },
+        }
+      );
+
+      const input = getUpdateInput();
+      expect(input['FilterCriteria']).toEqual({});
+      expect(input['BatchSize']).toBe(10);
+    });
+
+    it('sends ScalingConfig: {} when ScalingConfig is removed from the template', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          ScalingConfig: { MaximumConcurrency: 2 },
+        }
+      );
+
+      expect(getUpdateInput()['ScalingConfig']).toEqual({});
+    });
+
+    it('sends both FilterCriteria: {} and ScalingConfig: {} when both are removed', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN, BatchSize: 10 },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          BatchSize: 5,
+          FilterCriteria: { Filters: [{ Pattern: '{"body":["hunt"]}' }] },
+          ScalingConfig: { MaximumConcurrency: 2 },
+        }
+      );
+
+      const input = getUpdateInput();
+      expect(input['FilterCriteria']).toEqual({});
+      expect(input['ScalingConfig']).toEqual({});
+    });
+
+    it('sends DestinationConfig: {} when DestinationConfig is removed', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          DestinationConfig: { OnFailure: { Destination: 'arn:aws:sqs:us-east-1:123:dlq' } },
+        }
+      );
+
+      expect(getUpdateInput()['DestinationConfig']).toEqual({});
+    });
+
+    it('sends MetricsConfig: { Metrics: [] } when MetricsConfig is removed', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          MetricsConfig: { Metrics: ['EventCount'] },
+        }
+      );
+
+      expect(getUpdateInput()['MetricsConfig']).toEqual({ Metrics: [] });
+    });
+
+    it("sends KMSKeyArn: '' when KmsKeyArn is removed", async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          KmsKeyArn: 'arn:aws:kms:us-east-1:123:key/abc',
+        }
+      );
+
+      expect(getUpdateInput()['KMSKeyArn']).toBe('');
+    });
+
+    it('restores numeric defaults on removal (retry -1, recordAge -1, parallelization 1, tumbling 0)', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: 'arn:aws:kinesis:us-east-1:123:stream/s' },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: 'arn:aws:kinesis:us-east-1:123:stream/s',
+          MaximumRetryAttempts: 5,
+          MaximumRecordAgeInSeconds: 3600,
+          ParallelizationFactor: 4,
+          TumblingWindowInSeconds: 30,
+        }
+      );
+
+      const input = getUpdateInput();
+      expect(input['MaximumRetryAttempts']).toBe(-1);
+      expect(input['MaximumRecordAgeInSeconds']).toBe(-1);
+      expect(input['ParallelizationFactor']).toBe(1);
+      expect(input['TumblingWindowInSeconds']).toBe(0);
+    });
+
+    it('clears FunctionResponseTypes to [] on removal for an SQS source (kind allows it)', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          FunctionResponseTypes: ['ReportBatchItemFailures'],
+        }
+      );
+
+      expect(getUpdateInput()['FunctionResponseTypes']).toEqual([]);
+    });
+
+    it('does NOT clear FunctionResponseTypes for a Kafka source (kind rejects [])', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: KAFKA_ARN },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: KAFKA_ARN,
+          FunctionResponseTypes: ['ReportBatchItemFailures'],
+        }
+      );
+
+      expect(getUpdateInput()['FunctionResponseTypes']).toBeUndefined();
+    });
+
+    it('clears SourceAccessConfigurations to [] on removal for a Kafka source', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: KAFKA_ARN },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: KAFKA_ARN,
+          SourceAccessConfigurations: [{ Type: 'BASIC_AUTH', URI: 'arn:aws:secretsmanager:...' }],
+        }
+      );
+
+      expect(getUpdateInput()['SourceAccessConfigurations']).toEqual([]);
+    });
+
+    it('does NOT clear SourceAccessConfigurations for an SQS source (kind rejects [])', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          SourceAccessConfigurations: [{ Type: 'BASIC_AUTH', URI: 'arn:aws:secretsmanager:...' }],
+        }
+      );
+
+      expect(getUpdateInput()['SourceAccessConfigurations']).toBeUndefined();
+    });
+
+    it('restores MaximumBatchingWindowInSeconds to 0 on removal for an SQS source', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          MaximumBatchingWindowInSeconds: 20,
+        }
+      );
+
+      expect(getUpdateInput()['MaximumBatchingWindowInSeconds']).toBe(0);
+    });
+
+    it('does NOT restore MaximumBatchingWindowInSeconds for a Kafka source (500ms default unrepresentable)', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: KAFKA_ARN },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: KAFKA_ARN,
+          MaximumBatchingWindowInSeconds: 20,
+        }
+      );
+
+      expect(getUpdateInput()['MaximumBatchingWindowInSeconds']).toBeUndefined();
+    });
+
+    it('does NOT clear LoggingConfig / ProvisionedPollerConfig / BatchSize on removal (no documented sentinel)', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          BatchSize: 10,
+          LoggingConfig: { Level: 'INFO' },
+          ProvisionedPollerConfig: { MinimumPollers: 1, MaximumPollers: 5 },
+        }
+      );
+
+      const input = getUpdateInput();
+      expect(input['LoggingConfig']).toBeUndefined();
+      expect(input['ProvisionedPollerConfig']).toBeUndefined();
+      expect(input['BatchSize']).toBeUndefined();
+    });
+
+    it('does NOT send any clear sentinel when the property is unchanged (still present)', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          FilterCriteria: { Filters: [{ Pattern: '{"body":["hunt"]}' }] },
+          ScalingConfig: { MaximumConcurrency: 2 },
+        },
+        {
+          FunctionName: 'fn',
+          EventSourceArn: SQS_ARN,
+          FilterCriteria: { Filters: [{ Pattern: '{"body":["hunt"]}' }] },
+          ScalingConfig: { MaximumConcurrency: 2 },
+        }
+      );
+
+      const input = getUpdateInput();
+      // Present-in-both: the existing set-when-present guards forward the new
+      // value verbatim; the removal path must NOT overwrite it with a sentinel.
+      expect(input['FilterCriteria']).toEqual({ Filters: [{ Pattern: '{"body":["hunt"]}' }] });
+      expect(input['ScalingConfig']).toEqual({ MaximumConcurrency: 2 });
+    });
+
+    it('does NOT send a clear sentinel when the property was never set (absent in both)', async () => {
+      await provider.update(
+        'L',
+        UUID,
+        'AWS::Lambda::EventSourceMapping',
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN, BatchSize: 10 },
+        { FunctionName: 'fn', EventSourceArn: SQS_ARN, BatchSize: 5 }
+      );
+
+      const input = getUpdateInput();
+      expect(input['FilterCriteria']).toBeUndefined();
+      expect(input['ScalingConfig']).toBeUndefined();
+      expect(input['DestinationConfig']).toBeUndefined();
+      expect(input['MetricsConfig']).toBeUndefined();
+      expect(input['KMSKeyArn']).toBeUndefined();
+      expect(input['MaximumRetryAttempts']).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #976. `LambdaEventSourceMappingProvider.update()` only forwarded properties still present in the NEW template (the `!== undefined` guards read the new property bag), so a property **removed** from the template was omitted from `UpdateEventSourceMapping` and AWS treated the omission as "no change" — the old `FilterCriteria` / `ScalingConfig` survived on AWS even though cdkd reported green and dropped them from state (poisoned state, permanent divergence).

## Fix

`update()` now mirrors CloudFormation: for every clearable property present in `previousProperties` and absent in `properties`, it sends the AWS-documented clear/reset sentinel, verified per-prop against the `UpdateEventSourceMapping` API:

- Empty-object clears: `FilterCriteria: {}`, `ScalingConfig: {}`, `DestinationConfig: {}`
- `MetricsConfig: { Metrics: [] }`, `KMSKeyArn: ''`
- Source-kind-gated array clears: `FunctionResponseTypes: []` (SQS/Kinesis/DynamoDB), `SourceAccessConfigurations: []` (Kafka/MQ/DocDB)
- Numeric-default restores: `MaximumRetryAttempts=-1`, `MaximumRecordAgeInSeconds=-1`, `ParallelizationFactor=1`, `TumblingWindowInSeconds=0`, and `MaximumBatchingWindowInSeconds=0` only for the zero-default kinds

Props with no documented clear sentinel (`LoggingConfig`, `ProvisionedPollerConfig`, `BatchSize`, and `MaximumBatchingWindowInSeconds` for the 500ms-default kinds) are intentionally left untouched on removal, documented in a code comment.

## Tests

- 13 new unit tests pin each sentinel + source-kind gating both ways + absent-in-both negatives (`tests/unit/provisioning/lambda-eventsource-provider.test.ts`).
- Integ `sqs-esm-max-concurrency` extended with a removal-on-UPDATE phase: base sets FilterCriteria + ScalingConfig, UPDATE removes both, asserts AWS **clears** both, then destroys clean. Verified end-to-end against real AWS (us-east-1): base OK -> both cleared on removal -> destroy 0 errors / 0 orphans.

## Note

A second commit fixes a latent fixture bug the integ surfaced: the `esm_filter_count` helper used JMESPath `length(FilterCriteria.Filters)`, which errors on the (correctly) cleared `null` and aborts `verify.sh` under `set -e` before the assertion — making a working fix look like a silent-drop. Null-coalesced to `length(... || `[]`)`.
