### PR TITLE
test(analyzer): close out 0702-sweep review nits + safe verify.sh dist path

### DIFF
--- a/src/analyzer/replacement-rules.ts
+++ b/src/analyzer/replacement-rules.ts
@@ -187,6 +187,13 @@ export class ReplacementRulesRegistry {
         'TracingConfig',
         'Layers',
         'FileSystemConfigs',
+        // Architectures is mutable in place (CFn "Update requires: No
+        // interruption") — the provider re-sends the code with the new
+        // instruction set via UpdateFunctionCode. Classified explicitly
+        // (rather than relying on the DescribeType createOnly fallback) so
+        // the intent is pinned and the classification is free of a network
+        // round-trip.
+        'Architectures',
       ]),
     });
 

--- a/tests/integration/apigateway/verify.sh
+++ b/tests/integration/apigateway/verify.sh
@@ -25,7 +25,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 API_NAME="cdkd-hello-api"
 STAGE_NAME="prod"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/apigw-stage-throttling/verify.sh
+++ b/tests/integration/apigw-stage-throttling/verify.sh
@@ -36,7 +36,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 API_NAME="cdkd-stage-throttling-api"
 STAGE_NAME="test"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/apigw-usage-plan-key/verify.sh
+++ b/tests/integration/apigw-usage-plan-key/verify.sh
@@ -14,7 +14,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 API_NAME="${STACK}-api"
 KEY_NAME="${STACK}-key"
 PLAN_NAME="${STACK}-plan"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 api_id() {
   aws apigateway get-rest-apis --region "${REGION}" \

--- a/tests/integration/appconfig/verify.sh
+++ b/tests/integration/appconfig/verify.sh
@@ -30,7 +30,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 APP_NAME="${STACK}-app"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 app_id() {
   aws appconfig list-applications --region "${REGION}" \

--- a/tests/integration/aws-custom-resource/verify.sh
+++ b/tests/integration/aws-custom-resource/verify.sh
@@ -26,7 +26,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 PARAM_NAME="/cdkd-awscr/value"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 sweep_log_groups() {
   for lg in $(aws logs describe-log-groups \

--- a/tests/integration/bucket-deployment/verify.sh
+++ b/tests/integration/bucket-deployment/verify.sh
@@ -25,7 +25,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 MARKER="cdkd bucket-deployment integ marker v1"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Resolved after Phase 1 from the stack output.
 SITE_BUCKET=""

--- a/tests/integration/cc-api-fallback-transitions/verify.sh
+++ b/tests/integration/cc-api-fallback-transitions/verify.sh
@@ -42,7 +42,10 @@ TRANSITION_KEY="cdkd/${TRANSITION_STACK}/${REGION}/state.json"
 OVERRIDE_FN="cdkd-cc-api-override-probe"
 TRANSITION_FN="cdkd-cc-api-transition-probe"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Read the AWS-side RuntimeManagementConfig.UpdateRuntimeOn setting for a
 # function. Returns the value ('FunctionUpdate' / 'Auto') or empty when the

--- a/tests/integration/cc-api-fallback/verify.sh
+++ b/tests/integration/cc-api-fallback/verify.sh
@@ -21,7 +21,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 FN_NAME="cdkd-cc-api-fallback-probe"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probe"

--- a/tests/integration/ci-cd/verify.sh
+++ b/tests/integration/ci-cd/verify.sh
@@ -21,7 +21,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 EXPECTED_AUTO_RETRY_LIMIT=2
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: destroying stack via cdkd state destroy, dropping state only on clean destroy"

--- a/tests/integration/cloudfront-function-url/verify.sh
+++ b/tests/integration/cloudfront-function-url/verify.sh
@@ -23,7 +23,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 EXPLICIT_SID="ExplicitFnUrlPermission"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/codedeploy-lambda-deployment-group/verify.sh
+++ b/tests/integration/codedeploy-lambda-deployment-group/verify.sh
@@ -37,7 +37,10 @@ FN_NAME="cdkd-codedeploy-canary-fn"
 APP_NAME="cdkd-codedeploy-integ-app"
 DG_NAME="cdkd-codedeploy-integ-dg"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 sweep_log_groups() {
   for lg in $(aws logs describe-log-groups \

--- a/tests/integration/cognito-custom-attribute-add/verify.sh
+++ b/tests/integration/cognito-custom-attribute-add/verify.sh
@@ -28,7 +28,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 POOL_NAME="cdkd-cognito-attr-add-test"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 pool_id() {
   aws cognito-idp list-user-pools --max-results 60 --region "${REGION}" \

--- a/tests/integration/cognito-identity-pool/verify.sh
+++ b/tests/integration/cognito-identity-pool/verify.sh
@@ -11,7 +11,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 IDP_NAME="${STACK}_idp"
 UP_NAME="${STACK}-up"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Resolve the identity pool id by its name (list is paginated; grep ours).
 idp_id() {

--- a/tests/integration/cognito-lambda-triggers/verify.sh
+++ b/tests/integration/cognito-lambda-triggers/verify.sh
@@ -25,7 +25,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 POOL_NAME="cdkd-cognito-triggers-pool"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 sweep_log_groups() {
   for lg in $(aws logs describe-log-groups \

--- a/tests/integration/cognito-resource-server/verify.sh
+++ b/tests/integration/cognito-resource-server/verify.sh
@@ -27,7 +27,10 @@ STACK="CognitoResourceServerStack"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/cognito-userpool-user-ref/verify.sh
+++ b/tests/integration/cognito-userpool-user-ref/verify.sh
@@ -16,7 +16,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 POOL_NAME="${STACK}-pool"
 USERNAME="admin"
 GROUP="admins"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 pool_id() {
   aws cognito-idp list-user-pools --max-results 60 --region "${REGION}" \

--- a/tests/integration/cognito/verify.sh
+++ b/tests/integration/cognito/verify.sh
@@ -26,7 +26,10 @@ STACK="CognitoStack"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/conditions-and-if/verify.sh
+++ b/tests/integration/conditions-and-if/verify.sh
@@ -37,7 +37,10 @@ TIER_LABEL_PARAM="/cdkd-conditions-if/${ACCOUNT_ID}/tier-label"
 PREMIUM_ONLY_PARAM="/cdkd-conditions-if/${ACCOUNT_ID}/premium-only"
 PREMIUM_PRIMARY_PARAM="/cdkd-conditions-if/${ACCOUNT_ID}/premium-primary"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Captured at deploy time so cleanup / absence checks can find the topic.
 TOPIC_ARN=""

--- a/tests/integration/conditions-update-2/verify.sh
+++ b/tests/integration/conditions-update-2/verify.sh
@@ -55,7 +55,10 @@ REF_HOLDER_PARAM="/cdkd-conditions-update-2/${ACCOUNT_ID}/ref-holder"
 DLQ_NAME="cdkd-conditions-update-2-dlq-${ACCOUNT_ID}"
 WORK_QUEUE_NAME="cdkd-conditions-update-2-work-${ACCOUNT_ID}"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Captured at deploy time so cleanup / attribute checks can find the queues.
 WORK_QUEUE_URL=""

--- a/tests/integration/custom-resource-getatt-data/verify.sh
+++ b/tests/integration/custom-resource-getatt-data/verify.sh
@@ -36,7 +36,10 @@ PARAM_COMPUTED="${PARAM_PREFIX}/computed"
 PARAM_ANOTHER="${PARAM_PREFIX}/another"
 PARAM_NUMERIC="${PARAM_PREFIX}/numeric"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 LAMBDA_ARN=""
 

--- a/tests/integration/data-analytics/verify.sh
+++ b/tests/integration/data-analytics/verify.sh
@@ -26,7 +26,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 DB_NAME_FALLBACK="$(echo "${STACK}-analytics-db" | tr '[:upper:]' '[:lower:]')"
 ICEBERG_TABLE_NAME="events_iceberg"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/deep-getatt-chains/verify.sh
+++ b/tests/integration/deep-getatt-chains/verify.sh
@@ -53,7 +53,10 @@ FUNCTION_NAME="cdkd-getatt-chain-fn"
 FIXTURE_TAG_KEY="cdkd:integ-fixture"
 FIXTURE_TAG_VALUE="deep-getatt-chains"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 fail() {
   echo "[verify] FAIL: $*" >&2

--- a/tests/integration/destroy-interrupt/verify.sh
+++ b/tests/integration/destroy-interrupt/verify.sh
@@ -35,7 +35,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 LOCK_KEY="cdkd/${STACK}/${REGION}/lock.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # --- helpers ----------------------------------------------------------
 

--- a/tests/integration/docker-image-asset/verify.sh
+++ b/tests/integration/docker-image-asset/verify.sh
@@ -38,7 +38,10 @@ STACK="CdkdDockerImageAssetExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Resolved after deploy (used by cleanup's direct ECR sweep on the failure
 # path). The CDK-managed container-assets repo for the default bootstrap

--- a/tests/integration/dynamodb-autoscaling/verify.sh
+++ b/tests/integration/dynamodb-autoscaling/verify.sh
@@ -31,7 +31,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 TABLE_NAME="cdkd-autoscaling-test-table"
 RESOURCE_ID="table/${TABLE_NAME}"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 deregister_targets() {
   for dim in dynamodb:table:ReadCapacityUnits dynamodb:table:WriteCapacityUnits; do

--- a/tests/integration/dynamodb-gsi-update/verify.sh
+++ b/tests/integration/dynamodb-gsi-update/verify.sh
@@ -30,7 +30,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 TABLE_NAME="cdkd-gsi-update-test-table"
 GSI_NAME="gsi1"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/dynamodb-ondemand/verify.sh
+++ b/tests/integration/dynamodb-ondemand/verify.sh
@@ -45,7 +45,10 @@ PROV_INITIAL_WRITE=5
 PROV_UPDATED_READ=20
 PROV_UPDATED_WRITE=10
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/dynamodb-sse/verify.sh
+++ b/tests/integration/dynamodb-sse/verify.sh
@@ -22,7 +22,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 TABLE_NAME="cdkd-dynamodb-sse-table"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/dynamodb-stream-filter/verify.sh
+++ b/tests/integration/dynamodb-stream-filter/verify.sh
@@ -24,7 +24,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 TABLE_NAME="cdkd-ddb-stream-filter"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 sweep_log_groups() {
   for lg in $(aws logs describe-log-groups \

--- a/tests/integration/dynamodb-streams/verify.sh
+++ b/tests/integration/dynamodb-streams/verify.sh
@@ -25,7 +25,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 EXPECTED_READ=12000
 EXPECTED_WRITE=4000
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # The fixture's EventsTable has no explicit tableName, so CDK auto-generates
 # the physical name; we resolve it from cdkd state after deploy.

--- a/tests/integration/dynamodb-tableclass-switch/verify.sh
+++ b/tests/integration/dynamodb-tableclass-switch/verify.sh
@@ -32,7 +32,10 @@ STACK="CdkdDynamodbTableclassSwitchExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/dynamodb-ttl-attr-change/verify.sh
+++ b/tests/integration/dynamodb-ttl-attr-change/verify.sh
@@ -27,7 +27,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 TABLE_NAME="cdkd-ttl-attr-change-test"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/ec2-instance/verify.sh
+++ b/tests/integration/ec2-instance/verify.sh
@@ -36,7 +36,10 @@ STACK="Ec2InstanceStack"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 INSTANCE_ID=""
 

--- a/tests/integration/ecr-scanning/verify.sh
+++ b/tests/integration/ecr-scanning/verify.sh
@@ -23,7 +23,10 @@ STACK="CdkdEcrScanningExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 REPO="cdkdecrscanningexample-repo"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/ecs-fargate/verify.sh
+++ b/tests/integration/ecs-fargate/verify.sh
@@ -26,7 +26,10 @@ STACK="EcsFargateStack"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/efs-immutable-replacement/verify.sh
+++ b/tests/integration/efs-immutable-replacement/verify.sh
@@ -25,7 +25,10 @@ STACK="CdkdEfsImmutableReplacementExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 TAG_NAME="${STACK}-fs"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 fs_id_by_tag() {
   aws efs describe-file-systems --region "${REGION}" \

--- a/tests/integration/efs-standalone/verify.sh
+++ b/tests/integration/efs-standalone/verify.sh
@@ -24,7 +24,10 @@ STACK="EfsStandaloneStack"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/elasticache-replicationgroup-getatt/verify.sh
+++ b/tests/integration/elasticache-replicationgroup-getatt/verify.sh
@@ -19,7 +19,10 @@ REGION="${AWS_REGION:-us-east-1}"
 ADDR_PARAM="/cdkd-integ/elasticache-rg/primary-endpoint-address"
 PORT_PARAM="/cdkd-integ/elasticache-rg/primary-endpoint-port"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 DEPLOY_LOG="$(mktemp -t ecrg-deploy.XXXXXX)"
 
 # AWS DescribeReplicationGroups + describe-parameters can throttle right after a

--- a/tests/integration/eventbridge-api-destination/verify.sh
+++ b/tests/integration/eventbridge-api-destination/verify.sh
@@ -27,7 +27,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 CONN="cdkdeventbridgeapidestinationexample-conn"
 DEST="cdkdeventbridgeapidestinationexample-dest"
 RULE="cdkdeventbridgeapidestinationexample-rule"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/eventbridge-input-transformer/verify.sh
+++ b/tests/integration/eventbridge-input-transformer/verify.sh
@@ -30,7 +30,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 RULE_NAME="cdkd-eb-transform-rule"
 QUEUE_NAME="cdkd-eb-transform-q"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 queue_url() {
   aws sqs get-queue-url --queue-name "${QUEUE_NAME}" --region "${REGION}" \

--- a/tests/integration/eventbridge-pipes/verify.sh
+++ b/tests/integration/eventbridge-pipes/verify.sh
@@ -12,7 +12,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 PIPE="${STACK}-pipe"
 SRC="${STACK}-src"
 TGT="${STACK}-tgt"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup"

--- a/tests/integration/eventbridge-scheduler/verify.sh
+++ b/tests/integration/eventbridge-scheduler/verify.sh
@@ -11,7 +11,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 FN="${STACK}-fn"
 SCHED="${STACK}-sched"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup"

--- a/tests/integration/eventbridge/verify.sh
+++ b/tests/integration/eventbridge/verify.sh
@@ -19,7 +19,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 BUS_NAME="cdkd-test-bus-${ACCOUNT_ID}"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/eventsourcemapping-race/verify.sh
+++ b/tests/integration/eventsourcemapping-race/verify.sh
@@ -34,7 +34,10 @@ STACK="CdkdEsmRaceExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Resolved from cdkd state after deploy.
 FUNCTION_NAME=""

--- a/tests/integration/fifo-sqs-event-source/verify.sh
+++ b/tests/integration/fifo-sqs-event-source/verify.sh
@@ -29,7 +29,10 @@ QUEUE_NAME="cdkd-fifo-sqs-source.fifo"
 FN_NAME="cdkd-fifo-sqs-consumer"
 TABLE_NAME="cdkd-fifo-sqs-seen"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 sweep_log_groups() {
   for lg in $(aws logs describe-log-groups \

--- a/tests/integration/getstackoutput-crossregion/verify.sh
+++ b/tests/integration/getstackoutput-crossregion/verify.sh
@@ -43,7 +43,10 @@ CONSUMER_LOCK_KEY="cdkd/${CONSUMER_STACK}/${CONSUMER_REGION}/lock.json"
 PRODUCER_PARAM_NAME="/cdkd/getstackoutput-crossregion/producer"
 CONSUMER_PARAM_NAME="/cdkd/getstackoutput-crossregion/consumer"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probes (both regions)"

--- a/tests/integration/glue-securityconfig-replace/verify.sh
+++ b/tests/integration/glue-securityconfig-replace/verify.sh
@@ -33,7 +33,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 SEC_CONFIG="cdkd-replace-test-secconfig"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/glue-update-hardening/verify.sh
+++ b/tests/integration/glue-update-hardening/verify.sh
@@ -31,7 +31,10 @@ WORKFLOW_NAME_FALLBACK="${LOWER}-workflow"
 CRAWLER_NAME_FALLBACK="${LOWER}-crawler"
 TRIGGER_NAME_FALLBACK="${LOWER}-trigger"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/iam-propagation-stress/verify.sh
+++ b/tests/integration/iam-propagation-stress/verify.sh
@@ -44,7 +44,10 @@ STACK="CdkdIamPropagationStressExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Physical ids captured from state in Phase 1, used by the destroy assertions.
 FN_NAME=""

--- a/tests/integration/iam-role-policies-drift-clean/verify.sh
+++ b/tests/integration/iam-role-policies-drift-clean/verify.sh
@@ -40,7 +40,10 @@ FN_NAME="cdkd-iam-drift-clean-test-fn"
 QUEUE_NAME="cdkd-iam-drift-clean-test-queue"
 ROLE_NAME="cdkd-iam-drift-clean-test-role"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/iam-role-prefixed-name-update/verify.sh
+++ b/tests/integration/iam-role-prefixed-name-update/verify.sh
@@ -32,7 +32,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 ROLE_NAME="${STACK}-role"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 delete_role() {
   for p in $(aws iam list-role-policies --role-name "${ROLE_NAME}" \

--- a/tests/integration/inplace-attr-propagation/verify.sh
+++ b/tests/integration/inplace-attr-propagation/verify.sh
@@ -28,7 +28,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 BASE="/${STACK}/base"
 DERIVED="/${STACK}/derived"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 param() {
   aws ssm get-parameter --name "$1" --region "${REGION}" --query 'Parameter.Value' --output text 2>/dev/null

--- a/tests/integration/kinesis-esm-filter/verify.sh
+++ b/tests/integration/kinesis-esm-filter/verify.sh
@@ -11,7 +11,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 FN="${STACK}-fn"
 STREAM="${STACK}-stream"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup"

--- a/tests/integration/kinesis-stream-mode-switch/verify.sh
+++ b/tests/integration/kinesis-stream-mode-switch/verify.sh
@@ -34,7 +34,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 STREAM_NAME="cdkd-kinesis-mode-switch-$(date +%s)"
 export CDKD_KINESIS_STREAM_NAME="${STREAM_NAME}"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/lambda-alias-provisioned-concurrency/verify.sh
+++ b/tests/integration/lambda-alias-provisioned-concurrency/verify.sh
@@ -11,7 +11,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 FN="${STACK}-fn"
 ALIAS="live"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup"

--- a/tests/integration/lambda-arch-switch/verify.sh
+++ b/tests/integration/lambda-arch-switch/verify.sh
@@ -32,7 +32,12 @@ STACK="CdkdLambdaArchSwitchExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path WITHOUT a `cd` into dist/ that would fail
+# cryptically (aborting the script under `set -e`) when dist/ has not been
+# built yet — let the friendly `[ ! -f "${LOCAL_DIST}" ]` guard below report
+# it instead. We are already in the fixture dir (cd above), which is three
+# levels below the repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/lambda-destinations/verify.sh
+++ b/tests/integration/lambda-destinations/verify.sh
@@ -35,7 +35,10 @@ FN_NAME="cdkd-lambda-dest-fn"
 SUCCESS_Q="cdkd-lambda-dest-success"
 FAILURE_Q="cdkd-lambda-dest-failure"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 sweep_log_groups() {
   for lg in $(aws logs describe-log-groups \

--- a/tests/integration/lambda-env-removal/verify.sh
+++ b/tests/integration/lambda-env-removal/verify.sh
@@ -26,7 +26,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 FN="${STACK}-fn"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 envvar() {
   # Print the value of env var $1 on the function (empty if absent).

--- a/tests/integration/lambda-event-invoke-config-update/verify.sh
+++ b/tests/integration/lambda-event-invoke-config-update/verify.sh
@@ -34,7 +34,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 FN_NAME="cdkd-event-invoke-config-update-test-fn"
 DLQ_NAME="cdkd-event-invoke-config-update-test-dlq"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/lambda-layer-version-update/verify.sh
+++ b/tests/integration/lambda-layer-version-update/verify.sh
@@ -34,7 +34,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 LAYER_NAME="cdkd-layer-version-update-test"
 FN_NAME="cdkd-layer-version-update-test-fn"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/lambda-log-retention/verify.sh
+++ b/tests/integration/lambda-log-retention/verify.sh
@@ -25,7 +25,10 @@ STACK="CdkdLambdaLogRetentionExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Resolved after Phase 1 from the stack output.
 FUNCTION_NAME=""

--- a/tests/integration/lambda-reserved-concurrency/verify.sh
+++ b/tests/integration/lambda-reserved-concurrency/verify.sh
@@ -11,7 +11,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 FN="${STACK}-fn"
 EXPECTED_RESERVED=5
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup"

--- a/tests/integration/lambda/verify.sh
+++ b/tests/integration/lambda/verify.sh
@@ -19,7 +19,10 @@ STACK="LambdaStack"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/loggroup-class-guard/verify.sh
+++ b/tests/integration/loggroup-class-guard/verify.sh
@@ -32,7 +32,10 @@ STACK="CdkdLoggroupClassGuardExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/loggroup-kms-associate/verify.sh
+++ b/tests/integration/loggroup-kms-associate/verify.sh
@@ -32,7 +32,10 @@ STACK="CdkdLoggroupKmsAssociateExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/multi-asset/verify.sh
+++ b/tests/integration/multi-asset/verify.sh
@@ -55,7 +55,10 @@ STACK="CdkdMultiAssetExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Resolved after deploy (used by cleanup's direct ECR sweep on the failure
 # path). The CDK-managed container-assets repo + the image tag (asset hash).

--- a/tests/integration/nodejs-function/verify.sh
+++ b/tests/integration/nodejs-function/verify.sh
@@ -24,7 +24,10 @@ STACK="CdkdNodejsFunctionExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 FUNCTION_NAME=""
 

--- a/tests/integration/opensearch-domain-getatt/verify.sh
+++ b/tests/integration/opensearch-domain-getatt/verify.sh
@@ -20,7 +20,10 @@ REGION="${AWS_REGION:-us-east-1}"
 ENDPOINT_PARAM="/cdkd-integ/opensearch-domain/endpoint"
 ARN_PARAM="/cdkd-integ/opensearch-domain/arn"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 DEPLOY_LOG="$(mktemp -t osd-deploy.XXXXXX)"
 
 export AWS_RETRY_MODE=adaptive

--- a/tests/integration/propagation-races-2/verify.sh
+++ b/tests/integration/propagation-races-2/verify.sh
@@ -34,7 +34,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 FIXTURE_TAG_KEY="cdkd:integ-fixture"
 FIXTURE_TAG_VALUE="propagation-races-2"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Resolved physical ids (populated post-deploy; used by assertions + cleanup).
 INSTANCE_ID=""

--- a/tests/integration/rds-aurora/verify.sh
+++ b/tests/integration/rds-aurora/verify.sh
@@ -34,7 +34,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 EXPECTED_MONITORING_INTERVAL=60
 EXPECTED_IAM_AUTH="true"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Auto-generated physical name; resolved from cdkd state after deploy.
 DB_CLUSTER_ID=""

--- a/tests/integration/rds-dbinstance-backfill/verify.sh
+++ b/tests/integration/rds-dbinstance-backfill/verify.sh
@@ -48,7 +48,10 @@ EXPECTED_MASTER_USERNAME="postgres"
 EXPECTED_MONITORING_INTERVAL=60
 EXPECTED_IAM_AUTH="true"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # The fixture's DBInstance has no explicit instanceIdentifier, so CDK
 # auto-generates the physical name; resolve it from cdkd state after deploy.

--- a/tests/integration/rds-full-stack/verify.sh
+++ b/tests/integration/rds-full-stack/verify.sh
@@ -49,7 +49,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 SSM_PARAM_NAME="/cdkd/rds-full-stack/db-endpoint"
 EXPECTED_APP_NAME="cdkd-rds-full-stack"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Physical ids resolved from cdkd state after deploy; used by the trap so a
 # partial-failure run still cleans up in the RDS-safe order.

--- a/tests/integration/recreate-mixed-direction/verify.sh
+++ b/tests/integration/recreate-mixed-direction/verify.sh
@@ -23,7 +23,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 FWD_FN_NAME="cdkd-recreate-mixed-direction-fwd"
 BACK_FN_NAME="cdkd-recreate-mixed-direction-back"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probes"

--- a/tests/integration/recreate-via-cc-api/verify.sh
+++ b/tests/integration/recreate-via-cc-api/verify.sh
@@ -28,7 +28,10 @@ FN_NAME="cdkd-recreate-via-cc-api-probe"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)
 BUCKET_NAME="cdkd-recreate-via-cc-api-probe-${ACCOUNT_ID}"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probe"

--- a/tests/integration/recreate-via-sdk-provider/verify.sh
+++ b/tests/integration/recreate-via-sdk-provider/verify.sh
@@ -28,7 +28,10 @@ STACK="CdkdRecreateViaSdkProvider"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 FN_NAME="cdkd-recreate-via-sdk-provider-probe"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probe"

--- a/tests/integration/redshift-cluster-getatt/verify.sh
+++ b/tests/integration/redshift-cluster-getatt/verify.sh
@@ -18,7 +18,10 @@ REGION="${AWS_REGION:-us-east-1}"
 ADDR_PARAM="/cdkd-integ/redshift-cluster/endpoint-address"
 PORT_PARAM="/cdkd-integ/redshift-cluster/endpoint-port"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 DEPLOY_LOG="$(mktemp -t rsc-deploy.XXXXXX)"
 
 export AWS_RETRY_MODE=adaptive

--- a/tests/integration/replacement-fanout/verify.sh
+++ b/tests/integration/replacement-fanout/verify.sh
@@ -44,7 +44,10 @@ STACK="CdkdReplacementFanoutExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/replacement-immutable-name/verify.sh
+++ b/tests/integration/replacement-immutable-name/verify.sh
@@ -31,7 +31,10 @@ STACK="CdkdReplacementImmutableNameExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # --- existence helpers (async-delete aware where needed) ---------------
 stream_live() {

--- a/tests/integration/route53/verify.sh
+++ b/tests/integration/route53/verify.sh
@@ -35,7 +35,10 @@ SET_IDENTIFIER="geo-use1"
 CIDR_SET_IDENTIFIER="cidr-office"
 EXPECTED_CIDR_LOCATION="office"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/s3-asset-deploy/verify.sh
+++ b/tests/integration/s3-asset-deploy/verify.sh
@@ -35,7 +35,10 @@ STACK="CdkdS3AssetDeployExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/s3-cloudfront/verify.sh
+++ b/tests/integration/s3-cloudfront/verify.sh
@@ -22,7 +22,10 @@ STACK="S3CloudFrontStack"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/s3-event-notification/verify.sh
+++ b/tests/integration/s3-event-notification/verify.sh
@@ -28,7 +28,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 TABLE_NAME="cdkd-s3evt-events"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Resolved after we know the account id (bucket name embeds it).
 BUCKET_NAME=""

--- a/tests/integration/s3-lifecycle/verify.sh
+++ b/tests/integration/s3-lifecycle/verify.sh
@@ -32,7 +32,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 BUCKET_NAME="cdkd-lifecycle-test-${ACCOUNT_ID}"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/s3-object-lock/verify.sh
+++ b/tests/integration/s3-object-lock/verify.sh
@@ -27,7 +27,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 BUCKET_NAME="cdkd-objectlock-test-${ACCOUNT_ID}"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/s3-replication-and-filter/verify.sh
+++ b/tests/integration/s3-replication-and-filter/verify.sh
@@ -32,7 +32,10 @@ ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 SRC_BUCKET="cdkd-repl-src-${ACCOUNT_ID}"
 DST_BUCKET="cdkd-repl-dst-${ACCOUNT_ID}"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/s3-tables/verify.sh
+++ b/tests/integration/s3-tables/verify.sh
@@ -32,6 +32,9 @@ EXPECTED_TEAM_TAG="platform"
 EXPECTED_BUCKET_ENV_TAG="cdkd-integ"
 EXPECTED_BUCKET_TEAM_TAG="platform"
 
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
 LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 TABLE_ARN=""

--- a/tests/integration/s3-vectors/verify.sh
+++ b/tests/integration/s3-vectors/verify.sh
@@ -18,7 +18,10 @@ STACK="S3VectorsStack"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/scheduler-custom-group/verify.sh
+++ b/tests/integration/scheduler-custom-group/verify.sh
@@ -13,7 +13,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 GROUP="${STACK}-grp"
 SCHED="${STACK}-sched"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup"

--- a/tests/integration/schema-v5-to-v6-migration/verify.sh
+++ b/tests/integration/schema-v5-to-v6-migration/verify.sh
@@ -36,7 +36,10 @@ PARAM_NAME="/cdkd/schema-v5-to-v6-migration/probe"
 # bumps to whatever v6 actually shipped as.
 V5_CDKD_VERSION="0.139.0"
 V5_TMPDIR=""
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probe"

--- a/tests/integration/schema-v6-to-v7-migration/verify.sh
+++ b/tests/integration/schema-v6-to-v7-migration/verify.sh
@@ -36,7 +36,10 @@ PARAM_NAME="/cdkd/schema-v6-to-v7-migration/probe"
 # bumps to whatever v7 actually shipped as.
 V6_CDKD_VERSION="0.159.3"
 V6_TMPDIR=""
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probe"

--- a/tests/integration/schema-v7-to-v8-migration/verify.sh
+++ b/tests/integration/schema-v7-to-v8-migration/verify.sh
@@ -43,7 +43,10 @@ CONSUMER_PARAM_NAME="/cdkd/schema-v7-to-v8-migration/consumer"
 # bumps to whatever v8 actually shipped as.
 V7_CDKD_VERSION="0.167.1"
 V7_TMPDIR=""
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probes"

--- a/tests/integration/sdk-ccapi-crossref/verify.sh
+++ b/tests/integration/sdk-ccapi-crossref/verify.sh
@@ -46,7 +46,10 @@ FN_NAME="cdkd-crossref-fn"
 ROLE_NAME="cdkd-crossref-exec-role"
 PARAM_NAME="/cdkd/crossref/stream-arn"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probes"

--- a/tests/integration/secrets-dynamic-ref/verify.sh
+++ b/tests/integration/secrets-dynamic-ref/verify.sh
@@ -57,7 +57,10 @@ EXPECTED_PASSWORD="cdkd-known-pw-123"
 EXPECTED_FULL='{"username":"cdkd-user","password":"cdkd-known-pw-123"}'
 EXPECTED_SSM="cdkd-known-ssm-value"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # mask <value> -> echoes a masked form (first 2 chars + length) so logs never
 # leak the resolved secret value. Empty -> "<empty>".

--- a/tests/integration/secrets-rotation-schedule/verify.sh
+++ b/tests/integration/secrets-rotation-schedule/verify.sh
@@ -33,7 +33,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 SECRET_NAME="${STACK}-secret"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 sweep_log_groups() {
   for lg in $(aws logs describe-log-groups --region "${REGION}" \

--- a/tests/integration/serverless-api/verify.sh
+++ b/tests/integration/serverless-api/verify.sh
@@ -37,7 +37,10 @@ STAGE_NAME='$default'
 ROUTE_KEY='$default'
 REQUEST_AUTHORIZER_NAME="request-authorizer"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/servicediscovery/verify.sh
+++ b/tests/integration/servicediscovery/verify.sh
@@ -22,7 +22,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
 SERVICE_NAME="cdkd-svcdisc-service"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/sg-circular-dependency/verify.sh
+++ b/tests/integration/sg-circular-dependency/verify.sh
@@ -40,7 +40,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 FIXTURE_TAG_KEY="cdkd:integ-fixture"
 FIXTURE_TAG_VALUE="sg-circular-dependency"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # Captured ids (best-effort) so the cleanup trap can revoke-then-delete
 # directly if cdkd's own destroy ordering fails.

--- a/tests/integration/sns-event-source/verify.sh
+++ b/tests/integration/sns-event-source/verify.sh
@@ -26,7 +26,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 TABLE_NAME="cdkd-sns-evt-msgs"
 TOPIC_NAME="cdkd-sns-evt-topic"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 TOPIC_ARN=""
 

--- a/tests/integration/sns-sqs-event/verify.sh
+++ b/tests/integration/sns-sqs-event/verify.sh
@@ -28,7 +28,10 @@ DLQ_NAME="cdkd-sns-sqs-test-dlq"
 PRIMARY_QUEUE_NAME="cdkd-sns-sqs-test-primary"
 SECONDARY_QUEUE_NAME="cdkd-sns-sqs-test-secondary"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/sns-subscription-filter/verify.sh
+++ b/tests/integration/sns-subscription-filter/verify.sh
@@ -25,7 +25,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 TOPIC_NAME="cdkd-sns-filter-topic"
 QUEUE_NAME="cdkd-sns-filter-queue"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/sqs-esm-max-concurrency/verify.sh
+++ b/tests/integration/sqs-esm-max-concurrency/verify.sh
@@ -14,7 +14,10 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 FN="${STACK}-fn"
 QUEUE="${STACK}-queue"
 EXPECTED_MAXCONC=5
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup"

--- a/tests/integration/stepfunctions-logging/verify.sh
+++ b/tests/integration/stepfunctions-logging/verify.sh
@@ -32,7 +32,10 @@ STACK="CdkdStepfunctionsLoggingExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/stepfunctions-s3-definition/verify.sh
+++ b/tests/integration/stepfunctions-s3-definition/verify.sh
@@ -33,7 +33,10 @@ STACK="StepFunctionsS3Stack"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/integration/synthetics-canary/verify.sh
+++ b/tests/integration/synthetics-canary/verify.sh
@@ -15,7 +15,10 @@ REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 CANARY="cdkd-integ-canary"
 BUCKET="$(echo "${STACK}" | tr '[:upper:]' '[:lower:]')-artifacts"
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 sweep_canary_backend() {
   # Synthetics provisions a backing Lambda (cwsyn-<name>-<uuid>) + log group.

--- a/tests/integration/throttle-wide-dag/verify.sh
+++ b/tests/integration/throttle-wide-dag/verify.sh
@@ -56,7 +56,10 @@ TOTAL=$((PARAM_COUNT + ROLE_COUNT + TOPIC_COUNT))
 ROLE_PREFIX="${STACK}-role-"
 TOPIC_PREFIX="${STACK}-topic-"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 DEPLOY_LOG="$(mktemp -t throttle-deploy.XXXXXX)"
 DESTROY_LOG="$(mktemp -t throttle-destroy.XXXXXX)"

--- a/tests/integration/update-replace/verify.sh
+++ b/tests/integration/update-replace/verify.sh
@@ -38,7 +38,10 @@ STACK="CdkdUpdateReplaceExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 
-LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"
+# Resolve the built CLI path without a `cd` into dist/ that fails cryptically
+# (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
+# reports it instead. We are in the fixture dir, three levels below repo root.
+LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"

--- a/tests/unit/analyzer/replacement-rules-lambda-architectures.test.ts
+++ b/tests/unit/analyzer/replacement-rules-lambda-architectures.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { ReplacementRulesRegistry } from '../../../src/analyzer/replacement-rules.js';
+
+/**
+ * `Architectures` on AWS::Lambda::Function is mutable in place (CFn "Update
+ * requires: No interruption" — the provider re-sends the code with the new
+ * instruction set via UpdateFunctionCode). It is now classified EXPLICITLY in
+ * the registry's `updateableProperties` rather than relying on the DescribeType
+ * `createOnlyProperties` fallback (which is behaviorally correct — Architectures
+ * is not create-only — but costs a network round-trip and does not pin intent).
+ *
+ * `isClassified` returning true is the load-bearing assertion: it proves the
+ * registry has an explicit opinion, so the schema-fallback path in
+ * DiffCalculator.compareProperties never runs for this property.
+ */
+const LAMBDA = 'AWS::Lambda::Function';
+
+describe('ReplacementRulesRegistry — Lambda Function Architectures (explicit updateable)', () => {
+  const registry = new ReplacementRulesRegistry();
+
+  it('classifies Architectures explicitly (not via the createOnly fallback)', () => {
+    expect(registry.isClassified(LAMBDA, 'Architectures')).toBe(true);
+  });
+
+  it('does NOT require replacement on an x86_64 -> arm64 Architectures change', () => {
+    expect(
+      registry.requiresReplacement(LAMBDA, 'Architectures', ['x86_64'], ['arm64'])
+    ).toBe(false);
+  });
+});

--- a/tests/unit/provisioning/lambda-function-provider.test.ts
+++ b/tests/unit/provisioning/lambda-function-provider.test.ts
@@ -1220,6 +1220,78 @@ describe('LambdaFunctionProvider', () => {
       expect(codeCall).toBeUndefined();
     });
 
+    it('treats an empty-array previous Architectures ([]) as the default x86_64 (drift-baseline no-op)', async () => {
+      // readCurrentState emits `Architectures: []` when GetFunction omits the
+      // field (a non-arm64 function), so a drift-baseline UPDATE compares
+      // previous `[]` against a template default `['x86_64']`. normalizeArchitectures
+      // maps both to ['x86_64'], so this must be a no-op — not a needless
+      // arch-switch code redeploy.
+      mockLambdaSend.mockResolvedValueOnce({
+        Configuration: {
+          FunctionName: 'fn-empty-arch',
+          FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:fn-empty-arch',
+        },
+      }); // final attribute fetch (no config / code mutation expected before it)
+      await provider.update(
+        'Fn',
+        'fn-empty-arch',
+        'AWS::Lambda::Function',
+        {
+          Role: 'arn:aws:iam::123456789012:role/exec',
+          Code: { S3Bucket: 'b', S3Key: 'k' },
+          Architectures: ['x86_64'],
+        },
+        {
+          Role: 'arn:aws:iam::123456789012:role/exec',
+          Code: { S3Bucket: 'b', S3Key: 'k' },
+          Architectures: [],
+        }
+      );
+
+      const codeCall = mockLambdaSend.mock.calls.find(
+        (c) => c[0] instanceof UpdateFunctionCodeCommand
+      );
+      expect(codeCall).toBeUndefined();
+    });
+
+    it('fires ONE UpdateFunctionCode carrying both the new code and the new Architectures on a combined arch+code change', async () => {
+      // A code change and an arch switch both ride on UpdateFunctionCode; the
+      // provider folds them into a single call so the deploy does not issue
+      // two code deployments.
+      mockLambdaSend
+        .mockResolvedValueOnce({}) // UpdateFunctionCode
+        .mockResolvedValueOnce({ Configuration: { LastUpdateStatus: 'Successful' } }) // waiter
+        .mockResolvedValueOnce({
+          Configuration: {
+            FunctionName: 'fn-combo',
+            FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:fn-combo',
+          },
+        }); // final attribute fetch
+      await provider.update(
+        'Fn',
+        'fn-combo',
+        'AWS::Lambda::Function',
+        {
+          Role: 'arn:aws:iam::123456789012:role/exec',
+          Code: { S3Bucket: 'b', S3Key: 'k-new' },
+          Architectures: ['arm64'],
+        },
+        {
+          Role: 'arn:aws:iam::123456789012:role/exec',
+          Code: { S3Bucket: 'b', S3Key: 'k-old' },
+          Architectures: ['x86_64'],
+        }
+      );
+
+      const codeCalls = mockLambdaSend.mock.calls.filter(
+        (c) => c[0] instanceof UpdateFunctionCodeCommand
+      );
+      expect(codeCalls).toHaveLength(1);
+      const codeCmd = codeCalls[0]?.[0] as UpdateFunctionCodeCommand;
+      expect(codeCmd.input.S3Key).toBe('k-new');
+      expect(codeCmd.input.Architectures).toEqual(['arm64']);
+    });
+
     it('throws ProvisioningError when the post-update waiter sees LastUpdateStatus === Failed', async () => {
       mockLambdaSend
         .mockResolvedValueOnce({}) // UpdateFunctionConfiguration

--- a/tests/unit/provisioning/providers/dynamodb-table-provider.test.ts
+++ b/tests/unit/provisioning/providers/dynamodb-table-provider.test.ts
@@ -82,6 +82,9 @@ const inputOfCommand = (Command: new (input: never) => unknown): unknown => {
 const commandSent = (Command: new (input: never) => unknown): boolean =>
   mockSend.mock.calls.some((call) => call[0] instanceof Command);
 
+const countOfCommand = (Command: new (input: never) => unknown): number =>
+  mockSend.mock.calls.filter((call) => call[0] instanceof Command).length;
+
 describe('DynamoDBTableProvider backfill (#609)', () => {
   let provider: DynamoDBTableProvider;
 
@@ -599,8 +602,17 @@ describe('DynamoDBTableProvider backfill (#609)', () => {
         { ...baseCreateProps, TableClass: 'STANDARD_INFREQUENT_ACCESS' }
       );
 
-      const input = inputOfCommand(UpdateTableCommand) as { TableClass?: string };
+      const input = inputOfCommand(UpdateTableCommand) as {
+        TableClass?: string;
+        BillingMode?: string;
+        ProvisionedThroughput?: unknown;
+      };
       expect(input.TableClass).toBe('STANDARD');
+      // The revert is a class-only change: unchanged BillingMode / throughput
+      // must NOT ride along (AWS rejects an UpdateTable re-asserting current
+      // values). Removing TableClass alone must not reopen the throughput path.
+      expect(input.BillingMode).toBeUndefined();
+      expect(input.ProvisionedThroughput).toBeUndefined();
     });
 
     it('does not send TableClass (or any UpdateTable) when the class is unchanged', async () => {
@@ -687,6 +699,10 @@ describe('DynamoDBTableProvider backfill (#609)', () => {
       expect(input.TableClass).toBe('STANDARD_INFREQUENT_ACCESS');
       expect(input.BillingMode).toBe('PROVISIONED');
       expect(input.ProvisionedThroughput?.ReadCapacityUnits).toBe(2);
+      // The class change and the billing switch must be folded into a SINGLE
+      // UpdateTable — DynamoDB rejects a second UpdateTable while the first is
+      // still applying, so a two-call implementation would fail the deploy.
+      expect(countOfCommand(UpdateTableCommand)).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #958. Test-hardening + a latent-foot-gun sweep from the 2026-07-02 bug-hunt reviews. Part 1 of the issue (the `AWS::Logs::LogGroup` `KmsKeyId` silent-drop bug) already shipped on main via PR #959; this PR closes out the residual review nits.

## Changes

- **`Architectures` explicit classification** (`src/analyzer/replacement-rules.ts`): classify `AWS::Lambda::Function.Architectures` explicitly in `updateableProperties` instead of relying on the DescribeType createOnly fallback. Behaviorally identical (x86_64->arm64 stays non-replacing) but cheaper + pins intent. New unit test `replacement-rules-lambda-architectures.test.ts`.
- **DynamoDB TableClass test hardening** (from the #951 review): the combined TableClass+BillingMode case now asserts exactly ONE `UpdateTableCommand` (call-count, not just first-match); the removal-reverts case asserts BillingMode/ProvisionedThroughput are omitted.
- **Lambda Architectures test hardening** (from the #952 review): pins the `[]`->`['x86_64']` readback normalization as a drift-baseline no-op; adds a combined arch+code single-`UpdateFunctionCode` case.
- **Safe `verify.sh` dist path (106 fixtures)**: `LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"` crashes with a cryptic `cd` error (aborting under `set -e`) BEFORE the friendly "build dist first" guard when `dist/` is unbuilt. Switched every fixture to the cd-free `${PWD}/../../../dist/cli.js` form so the friendly guard fires instead. All 106 pass `bash -n`; live-tested that the new form reaches the friendly guard while the old form crashes.

## Tests

Test-hardening only — no runtime behavior change (the `Architectures` reclassification is behaviorally identical). Full suite: 412 files / 6384 tests pass. No real-AWS integ gate applies (no provider / deploy / destroy / local / schema code touched).
