### PR TITLE
fix(provisioning): untag removed ECR repository tags on update

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -127,7 +127,6 @@ vpc-lambda-cr-race	2026-06-21T11:00:28Z	PASS	343	standard	sweep-4..8 staleness r
 vpc-lookup	2026-06-21T11:00:28Z	PASS	15	standard	sweep staleness re-run (re-verified PASS; ledger-restore)
 vpc-nat-gateway	2026-06-21T17:00:38Z	PASS	145	verify.sh	stale-real re-run; deploy 21 + destroy 21 (split by subshell-death, re-destroyed clean); NAT GW gone
 glue-securityconfig-replace	2026-06-21T15:47:49Z	PASS	46	verify.sh	--replace + Glue S3Encryptions silent-drop fix; 0 orphans
-ecr-scanning	2026-06-21T17:00:53Z	PASS		verify.sh	ECR scanOnPush + KMS encryption CFn->SDK casing; create+update reach AWS; 0 orphans
 lambda-event-invoke-config-update	2026-06-21T16:20:26Z	PASS		verify.sh	deploy+drift-clean+update+destroy clean, 0 orphans
 eventbridge-api-destination	2026-06-21T18:24:53Z	PASS	90	verify.sh	ConnectionArn+ApiDest Arn enrichment verified, destroy clean 0 orphans
 conditions-and-if	2026-06-21T18:17:20Z	PASS		verify.sh	first run (never-run); CFn Conditions + Fn::If 2-phase premium/basic; 14 assertions; clean destroy 0 err
@@ -214,3 +213,4 @@ sqs-esm-max-concurrency	2026-07-03T06:53:49Z	PASS	70	verify.sh	removal clears Fi
 ecs-service-update-props	2026-07-03T07:12:17Z	PASS	50	verify.sh	EnableECSManagedTags+PropagateTags mapping; non-ECS-controller LB/SR now throws not drops
 s3-tables	2026-07-03T07:18:47Z	PASS	45	verify.sh	CC-routed Table Ref resolves to table name (#974); clean destroy
 multi-resource	2026-07-03T07:21:52Z	PASS	59	standard	broad integ for #974 intrinsic-resolver change; 17 created/deleted 0 errors
+ecr-scanning	2026-07-03T08:26:37Z	PASS	55	verify.sh	tag add/change/untag on update reach AWS; destroy clean

--- a/src/provisioning/providers/ecr-provider.ts
+++ b/src/provisioning/providers/ecr-provider.ts
@@ -11,6 +11,7 @@ import {
   PutImageScanningConfigurationCommand,
   PutImageTagMutabilityCommand,
   TagResourceCommand,
+  UntagResourceCommand,
   ListTagsForResourceCommand,
   LifecyclePolicyNotFoundException,
   RepositoryNotFoundException,
@@ -328,7 +329,10 @@ export class ECRProvider implements ResourceProvider {
         }
       }
 
-      // Update Tags if changed
+      // Update Tags if changed. `TagResource` is additive-only, so a tag
+      // dropped from the template (partial removal) — or the entire `Tags`
+      // property removed (full removal, `newTags === undefined`) — would
+      // survive on AWS unless we explicitly `UntagResource` the removed keys.
       const newTags = properties['Tags'] as Tag[] | undefined;
       const oldTags = previousProperties['Tags'] as Tag[] | undefined;
       if (JSON.stringify(newTags) !== JSON.stringify(oldTags)) {
@@ -337,13 +341,33 @@ export class ECRProvider implements ResourceProvider {
           new DescribeRepositoriesCommand({ repositoryNames: [physicalId] })
         );
         const repoArn = describeResponse.repositories?.[0]?.repositoryArn;
-        if (repoArn && newTags) {
-          await this.getClient().send(
-            new TagResourceCommand({
-              resourceArn: repoArn,
-              tags: newTags,
-            })
+        if (repoArn) {
+          // Untag keys present in the old set but absent from the new set.
+          // `newTags === undefined` is treated as "remove all old tags".
+          const newKeys = new Set(
+            (newTags ?? []).map((t) => t.Key).filter((k): k is string => !!k)
           );
+          const removedKeys = (oldTags ?? [])
+            .map((t) => t.Key)
+            .filter((k): k is string => !!k && !newKeys.has(k));
+          if (removedKeys.length > 0) {
+            await this.getClient().send(
+              new UntagResourceCommand({
+                resourceArn: repoArn,
+                tagKeys: removedKeys,
+              })
+            );
+          }
+          // Apply added / changed tags. Skip the call when the new set is
+          // empty (a pure removal has nothing left to add).
+          if (newTags && newTags.length > 0) {
+            await this.getClient().send(
+              new TagResourceCommand({
+                resourceArn: repoArn,
+                tags: newTags,
+              })
+            );
+          }
           this.logger.debug(`Updated tags for ${physicalId}`);
         }
       }

--- a/tests/integration/ecr-scanning/lib/ecr-scanning-stack.ts
+++ b/tests/integration/ecr-scanning/lib/ecr-scanning-stack.ts
@@ -15,8 +15,13 @@ import * as kms from 'aws-cdk-lib/aws-kms';
  * true` never reached AWS. This fixture asserts scanOnPush actually reaches AWS
  * on create AND that toggling it off via UPDATE reaches AWS.
  *
- * Phase 1 (no env): scanOnPush true + a lifecycle rule.
- * Phase 2 (CDKD_TEST_UPDATE=true): scanOnPush false.
+ * Phase 1 (no env): scanOnPush true + a lifecycle rule + two Tags
+ *   (`env=dev`, `team=platform`).
+ * Phase 2 (CDKD_TEST_UPDATE=true): scanOnPush false; the `env` tag value is
+ *   CHANGED to `prod` and the `team` tag is REMOVED. This exercises the
+ *   update() tag-diff: `ECRProvider.update()` used to call `TagResourceCommand`
+ *   only (additive), so a removed tag survived on AWS (issue #981). The fix
+ *   untags the removed key(s) via `UntagResourceCommand` before re-tagging.
  */
 export class EcrScanningStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -33,7 +38,7 @@ export class EcrScanningStack extends cdk.Stack {
       pendingWindow: cdk.Duration.days(7),
     });
 
-    new ecr.Repository(this, 'Repo', {
+    const repo = new ecr.Repository(this, 'Repo', {
       repositoryName: `${this.stackName.toLowerCase()}-repo`,
       imageScanOnPush: !isUpdate,
       imageTagMutability: ecr.TagMutability.IMMUTABLE,
@@ -43,5 +48,12 @@ export class EcrScanningStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       emptyOnDelete: true,
     });
+
+    // Phase 1: env=dev, team=platform. Phase 2: env changed to prod, team
+    // removed entirely (untag path).
+    cdk.Tags.of(repo).add('env', isUpdate ? 'prod' : 'dev');
+    if (!isUpdate) {
+      cdk.Tags.of(repo).add('team', 'platform');
+    }
   }
 }

--- a/tests/integration/ecr-scanning/verify.sh
+++ b/tests/integration/ecr-scanning/verify.sh
@@ -8,10 +8,16 @@
 # ignored and scanOnPush silently reset to false. `imageScanOnPush: true` never
 # reached AWS. (Same casing trap silently dropped a KMS repo's KmsKey.)
 #
+# ALSO covers issue #981: ECRProvider.update() applied Tags changes with
+# TagResourceCommand only (additive), so a tag removed from the template
+# survived on AWS. The fix untags removed keys via UntagResourceCommand.
+#
 # Phases:
-#   1. Deploy with imageScanOnPush=true. Assert AWS reports scanOnPush=true.
-#   2. Re-deploy (CDKD_TEST_UPDATE=true) with imageScanOnPush=false. Assert AWS
-#      now reports scanOnPush=false (the update path maps casing too).
+#   1. Deploy with imageScanOnPush=true + Tags env=dev, team=platform. Assert
+#      AWS reports scanOnPush=true and both tags are present.
+#   2. Re-deploy (CDKD_TEST_UPDATE=true) with imageScanOnPush=false, env changed
+#      to prod, team REMOVED. Assert scanOnPush=false, env=prod, team untagged,
+#      and exactly one user tag remains.
 #   3. Destroy + assert the repo is gone and the cdkd state file is removed.
 #
 # Required env vars: STATE_BUCKET; AWS_REGION (defaults us-east-1).
@@ -56,6 +62,27 @@ scan_on_push() {
     --query 'repositories[0].imageScanningConfiguration.scanOnPush' --output text
 }
 
+# Read a single tag's value via list-tags-for-resource. Emits the value or
+# 'NONE' when the key is absent (JMESPath `[?Key==...] | [0].Value` -> null ->
+# printed as literal "None" by --output text; we normalize to NONE for the
+# comparison).
+repo_arn() {
+  aws ecr describe-repositories --repository-names "${REPO}" --region "${REGION}" \
+    --query 'repositories[0].repositoryArn' --output text
+}
+tag_value() {
+  local key="$1"
+  aws ecr list-tags-for-resource --resource-arn "$(repo_arn)" --region "${REGION}" \
+    --query "tags[?Key=='${key}'] | [0].Value" --output text
+}
+# Count of user tags (excludes AWS-managed aws:* tags, which ECR does not add
+# for a cdkd deploy). Guard the JMESPath length() against a null tags field so
+# an empty list does not abort the script under set -e.
+user_tag_count() {
+  aws ecr list-tags-for-resource --resource-arn "$(repo_arn)" --region "${REGION}" \
+    --query "length(tags[?!starts_with(Key, 'aws:')] || \`[]\`)" --output text
+}
+
 # --- Phase 1: deploy with scanOnPush=true -----------------------------
 echo "==> Phase 1: deploy ECR repo with imageScanOnPush=true"
 env -u CDKD_TEST_UPDATE node "${LOCAL_DIST}" deploy "${STACK}" \
@@ -79,6 +106,14 @@ case "${KMSKEY1}" in
 esac
 echo "    encryptionType=KMS + kmsKey reached AWS"
 
+# Tags on create: env=dev, team=platform.
+ENVTAG1="$(tag_value env)"
+TEAMTAG1="$(tag_value team)"
+echo "    tags (Phase 1): env=${ENVTAG1} team=${TEAMTAG1}"
+[ "${ENVTAG1}" = "dev" ] || { echo "FAIL: expected env=dev on create, got '${ENVTAG1}'" >&2; exit 1; }
+[ "${TEAMTAG1}" = "platform" ] || { echo "FAIL: expected team=platform on create, got '${TEAMTAG1}'" >&2; exit 1; }
+echo "    both tags reached AWS on create"
+
 # --- Phase 2: UPDATE scanOnPush=false ---------------------------------
 echo "==> Phase 2: re-deploy with imageScanOnPush=false (UPDATE)"
 CDKD_TEST_UPDATE=true node "${LOCAL_DIST}" deploy "${STACK}" \
@@ -88,6 +123,17 @@ SOP2="$(scan_on_push)"
 echo "    scanOnPush (Phase 2): ${SOP2}"
 [ "${SOP2}" = "False" ] || { echo "FAIL: expected scanOnPush=false after update, got '${SOP2}'" >&2; exit 1; }
 echo "    scanOnPush=false reached AWS"
+
+# Tags after update: env changed dev->prod, team REMOVED. Pre-fix (issue #981)
+# update() called TagResourceCommand only, so `team` survived on AWS.
+ENVTAG2="$(tag_value env)"
+TEAMTAG2="$(tag_value team)"
+UTC2="$(user_tag_count)"
+echo "    tags (Phase 2): env=${ENVTAG2} team=${TEAMTAG2} user_tag_count=${UTC2}"
+[ "${ENVTAG2}" = "prod" ] || { echo "FAIL: expected env=prod after update, got '${ENVTAG2}'" >&2; exit 1; }
+[ "${TEAMTAG2}" = "None" ] || { echo "FAIL: expected team tag to be UNTAGGED after update, still present as '${TEAMTAG2}'" >&2; exit 1; }
+[ "${UTC2}" = "1" ] || { echo "FAIL: expected exactly 1 user tag after update (env only), got '${UTC2}'" >&2; exit 1; }
+echo "    removed tag untagged + changed tag updated on AWS"
 
 # --- Phase 3: destroy --------------------------------------------------
 echo "==> Phase 3: destroy"
@@ -102,4 +148,4 @@ if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/n
 fi
 echo "    cdkd state removed"
 
-echo "[verify] PASS — ECR scanOnPush reaches AWS on create + update (CFn->SDK casing), 3 phases passed"
+echo "[verify] PASS — ECR scanOnPush (CFn->SDK casing) + tag add/change/untag on update reach AWS, 3 phases passed"

--- a/tests/unit/provisioning/providers/ecr-provider.test.ts
+++ b/tests/unit/provisioning/providers/ecr-provider.test.ts
@@ -37,6 +37,8 @@ import {
   DescribeRepositoriesCommand,
   ListTagsForResourceCommand,
   RepositoryNotFoundException,
+  TagResourceCommand,
+  UntagResourceCommand,
 } from '@aws-sdk/client-ecr';
 
 describe('ECRProvider import', () => {
@@ -142,5 +144,106 @@ describe('ECRProvider import', () => {
     const result = await provider.import(makeInput({ knownPhysicalId: 'missing' }));
 
     expect(result).toBeNull();
+  });
+});
+
+describe('ECRProvider update Tags', () => {
+  let provider: ECRProvider;
+  const repoArn = 'arn:aws:ecr:us-east-1:123456789012:repository/my-repo';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ECRProvider();
+  });
+
+  // The update() Tags block issues, in order:
+  //   1. DescribeRepositories (to resolve the ARN for tag ops)
+  //   2. UntagResource (removed keys) — only when there are removed keys
+  //   3. TagResource (new set) — only when the new set is non-empty
+  //   4. DescribeRepositories (final attribute read)
+  function mockDescribeResponses() {
+    const describeResponse = {
+      repositories: [
+        {
+          repositoryName: 'my-repo',
+          repositoryArn: repoArn,
+          repositoryUri: '123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo',
+        },
+      ],
+    };
+    mockSend.mockResolvedValue(describeResponse);
+  }
+
+  it('partial removal: untags removed keys and tags the changed/new ones', async () => {
+    mockDescribeResponses();
+
+    await provider.update(
+      'MyRepo',
+      'my-repo',
+      'AWS::ECR::Repository',
+      {
+        Tags: [
+          { Key: 'env', Value: 'prod' }, // changed value
+          { Key: 'owner', Value: 'team-a' }, // new key
+        ],
+      },
+      {
+        Tags: [
+          { Key: 'env', Value: 'dev' }, // changed
+          { Key: 'costcenter', Value: 'cc-1' }, // removed
+        ],
+      }
+    );
+
+    const untagCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UntagResourceCommand
+    );
+    const tagCall = mockSend.mock.calls.find((c) => c[0] instanceof TagResourceCommand);
+
+    expect(untagCall).toBeDefined();
+    expect(untagCall![0].input).toEqual({
+      resourceArn: repoArn,
+      tagKeys: ['costcenter'],
+    });
+
+    expect(tagCall).toBeDefined();
+    expect(tagCall![0].input).toEqual({
+      resourceArn: repoArn,
+      tags: [
+        { Key: 'env', Value: 'prod' },
+        { Key: 'owner', Value: 'team-a' },
+      ],
+    });
+  });
+
+  it('full removal: untags all old keys and does NOT call TagResource', async () => {
+    mockDescribeResponses();
+
+    await provider.update(
+      'MyRepo',
+      'my-repo',
+      'AWS::ECR::Repository',
+      {}, // Tags property removed entirely
+      {
+        Tags: [
+          { Key: 'env', Value: 'dev' },
+          { Key: 'costcenter', Value: 'cc-1' },
+        ],
+      }
+    );
+
+    const untagCall = mockSend.mock.calls.find(
+      (c) => c[0] instanceof UntagResourceCommand
+    );
+    const tagCall = mockSend.mock.calls.find((c) => c[0] instanceof TagResourceCommand);
+
+    expect(untagCall).toBeDefined();
+    expect(untagCall![0].input).toEqual({
+      resourceArn: repoArn,
+      tagKeys: ['env', 'costcenter'],
+    });
+
+    // A pure removal has nothing left to add — TagResource must NOT fire.
+    expect(tagCall).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

`ECRProvider.update()` applied `Tags` changes with `TagResourceCommand` only — it never called `UntagResourceCommand`. Two silent-drop shapes resulted:

1. **Partial removal**: a tag dropped from the template survived on AWS (added/changed keys did apply).
2. **Full removal**: removing the whole `Tags` property was a complete no-op — the `if (repoArn && newTags)` guard skipped the call entirely.

In both cases `cdkd diff` showed the change, deploy reported green, state recorded the new (tagless) shape — phantom-clean — while AWS kept the stale tags.

## Fix

`update()` now computes removed keys (old keys absent from the new set) and issues an `UntagResourceCommand` for them, treating `newTags === undefined` as "remove all old tags", then applies added/changed tags via `TagResourceCommand` only when the new set is non-empty. This matches CloudFormation, which removes tags that leave the template.

## Tests

- Unit: (a) partial removal untags the removed key and tags the changed/new keys; (b) full removal untags everything and does NOT call `TagResource`. Both pin the exact command inputs.
- Integ: extended `ecr-scanning` with a tag-removal UPDATE phase — verified live on real AWS (us-east-1) that the removed tag is untagged and the changed tag updated; destroy clean (0 errors, 0 orphans).

Closes #981
