### PR TITLE
fix(provisioning): wait for table ACTIVE after DynamoDB OnDemand/Warm throughput update

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -211,9 +211,9 @@ ecs-service-update-props	2026-07-03T07:12:17Z	PASS	50	verify.sh	EnableECSManaged
 s3-tables	2026-07-03T07:18:47Z	PASS	45	verify.sh	CC-routed Table Ref resolves to table name (#974); clean destroy
 multi-resource	2026-07-03T07:21:52Z	PASS	59	standard	broad integ for #974 intrinsic-resolver change; 17 created/deleted 0 errors
 ecr-scanning	2026-07-03T08:26:37Z	PASS	55	verify.sh	tag add/change/untag on update reach AWS; destroy clean
-dynamodb-streams	2026-07-03T08:36:26Z	PASS	87	verify.sh	StreamSpecification enable-on-UPDATE + StreamArn enrich reach AWS; destroy clean
 stepfunctions-logging	2026-07-03T08:44:32Z	PASS	52	verify.sh	logging/tracing removal-clear reaches AWS (OFF/0/False); destroy clean
 sns-inline-subscription	2026-07-03T09:04:10Z	PASS	47	verify.sh	inline sub create(in-try)+update+drift reach AWS; destroy clean
 backup	2026-07-03T09:10:59Z	PASS	48	verify.sh	BackupVaultArn GetAtt enrichment resolves real ARN; destroy clean
 launchtemplate-asg-inplace	2026-07-03T09:30:15Z	PASS	64	verify.sh	in-place GetAtt value change propagates to NO_CHANGE ASG same deploy; destroy clean
 bench-cdk-sample	2026-07-03T09:40:40Z	PASS	505	standard	broad regression for #985 diff-classifier; 39 created / 37 deleted+2 retain 0 errors
+dynamodb-streams	2026-07-03T10:26:01Z	PASS	86	verify.sh	OnDemand/Warm wait follow-up; destroy clean

--- a/src/provisioning/providers/dynamodb-table-provider.ts
+++ b/src/provisioning/providers/dynamodb-table-provider.ts
@@ -506,6 +506,9 @@ export class DynamoDBTableProvider implements ResourceProvider {
               OnDemandThroughput: properties['OnDemandThroughput'] as OnDemandThroughput,
             })
           );
+          // UpdateTable is async; wait for ACTIVE so later branches (SSE /
+          // Stream / GSI) don't race a still-UPDATING table.
+          await this.waitForTableActiveAfterUpdate(physicalId);
           this.logger.debug(`Updated OnDemandThroughput on DynamoDB table ${physicalId}`);
         }
       }
@@ -527,6 +530,9 @@ export class DynamoDBTableProvider implements ResourceProvider {
               WarmThroughput: properties['WarmThroughput'] as WarmThroughput,
             })
           );
+          // UpdateTable is async; wait for ACTIVE so later branches (SSE /
+          // Stream / GSI) don't race a still-UPDATING table.
+          await this.waitForTableActiveAfterUpdate(physicalId);
           this.logger.debug(`Updated WarmThroughput on DynamoDB table ${physicalId}`);
         }
       }

--- a/tests/unit/provisioning/dynamodb-table-provider-ondemand-throughput.test.ts
+++ b/tests/unit/provisioning/dynamodb-table-provider-ondemand-throughput.test.ts
@@ -118,6 +118,7 @@ describe('DynamoDBTableProvider OnDemandThroughput wiring', () => {
     it('issues UpdateTable with the new OnDemandThroughput when it changes', async () => {
       primeDescribeTable();
       mockSend.mockResolvedValueOnce({}); // UpdateTable
+      primeDescribeTable(); // waitForTableActiveAfterUpdate
 
       await provider.update(
         'L',
@@ -139,6 +140,7 @@ describe('DynamoDBTableProvider OnDemandThroughput wiring', () => {
     it('issues UpdateTable when OnDemandThroughput is newly added', async () => {
       primeDescribeTable();
       mockSend.mockResolvedValueOnce({}); // UpdateTable
+      primeDescribeTable(); // waitForTableActiveAfterUpdate
 
       await provider.update(
         'L',

--- a/tests/unit/provisioning/dynamodb-table-provider-warm-throughput.test.ts
+++ b/tests/unit/provisioning/dynamodb-table-provider-warm-throughput.test.ts
@@ -118,6 +118,7 @@ describe('DynamoDBTableProvider WarmThroughput wiring', () => {
     it('issues UpdateTable with the new WarmThroughput when it changes', async () => {
       primeDescribeTable();
       mockSend.mockResolvedValueOnce({}); // UpdateTable
+      primeDescribeTable(); // waitForTableActiveAfterUpdate
 
       await provider.update(
         'L',
@@ -139,6 +140,7 @@ describe('DynamoDBTableProvider WarmThroughput wiring', () => {
     it('issues UpdateTable when WarmThroughput is newly added', async () => {
       primeDescribeTable();
       mockSend.mockResolvedValueOnce({}); // UpdateTable
+      primeDescribeTable(); // waitForTableActiveAfterUpdate
 
       await provider.update(
         'L',

--- a/tests/unit/provisioning/providers/dynamodb-table-provider.test.ts
+++ b/tests/unit/provisioning/providers/dynamodb-table-provider.test.ts
@@ -648,6 +648,99 @@ describe('DynamoDBTableProvider backfill (#609)', () => {
     });
   });
 
+  describe('OnDemand/Warm throughput UpdateTable waits for ACTIVE (follow-up to #989)', () => {
+    // The command class of each send, in order. UpdateTable is async, so a
+    // combined update that changes OnDemandThroughput (or WarmThroughput) AND
+    // a later prop that issues its OWN UpdateTable (SSE / Stream / GSI) must
+    // wait for ACTIVE between the two UpdateTables — otherwise the second call
+    // races a still-UPDATING table and AWS throws ResourceInUseException.
+    const sentCommandNames = () =>
+      mockSend.mock.calls.map((c) => (c[0] as { constructor: { name: string } }).constructor.name);
+
+    it('waits (DescribeTable) between the OnDemandThroughput UpdateTable and a later SSE UpdateTable', async () => {
+      mockSend
+        .mockResolvedValueOnce(activeTable()) // DescribeTable (update reads current)
+        .mockResolvedValueOnce({}) // UpdateTable (OnDemandThroughput)
+        .mockResolvedValueOnce(activeTable()) // waitForTableActiveAfterUpdate (after OnDemand)
+        .mockResolvedValueOnce({}) // UpdateTable (SSE)
+        .mockResolvedValueOnce(activeTable()); // waitForTableActiveAfterUpdate (after SSE)
+
+      await provider.update(
+        'MyTable',
+        'MyTable',
+        'AWS::DynamoDB::Table',
+        {
+          ...baseCreateProps,
+          OnDemandThroughput: { MaxReadRequestUnits: 100, MaxWriteRequestUnits: 100 },
+          SSESpecification: { SSEEnabled: true },
+        },
+        {
+          ...baseCreateProps,
+          OnDemandThroughput: { MaxReadRequestUnits: 50, MaxWriteRequestUnits: 50 },
+          SSESpecification: { SSEEnabled: false },
+        }
+      );
+
+      // Ordered sequence pins the wait BETWEEN the two UpdateTables: the
+      // OnDemand UpdateTable, then a DescribeTable (the wait), then the SSE
+      // UpdateTable.
+      expect(sentCommandNames()).toEqual([
+        'DescribeTableCommand', // update reads current
+        'UpdateTableCommand', // OnDemandThroughput
+        'DescribeTableCommand', // waitForTableActiveAfterUpdate
+        'UpdateTableCommand', // SSESpecification
+        'DescribeTableCommand', // waitForTableActiveAfterUpdate
+      ]);
+
+      const updateInputs = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter((cmd) => cmd instanceof UpdateTableCommand)
+        .map((cmd) => (cmd as { input: Record<string, unknown> }).input);
+      expect(updateInputs[0].OnDemandThroughput).toBeDefined();
+      expect(updateInputs[1].SSESpecification).toBeDefined();
+    });
+
+    it('waits (DescribeTable) between the WarmThroughput UpdateTable and a later SSE UpdateTable', async () => {
+      mockSend
+        .mockResolvedValueOnce(activeTable()) // DescribeTable (update reads current)
+        .mockResolvedValueOnce({}) // UpdateTable (WarmThroughput)
+        .mockResolvedValueOnce(activeTable()) // waitForTableActiveAfterUpdate (after Warm)
+        .mockResolvedValueOnce({}) // UpdateTable (SSE)
+        .mockResolvedValueOnce(activeTable()); // waitForTableActiveAfterUpdate (after SSE)
+
+      await provider.update(
+        'MyTable',
+        'MyTable',
+        'AWS::DynamoDB::Table',
+        {
+          ...baseCreateProps,
+          WarmThroughput: { ReadUnitsPerSecond: 20000, WriteUnitsPerSecond: 20000 },
+          SSESpecification: { SSEEnabled: true },
+        },
+        {
+          ...baseCreateProps,
+          WarmThroughput: { ReadUnitsPerSecond: 12000, WriteUnitsPerSecond: 12000 },
+          SSESpecification: { SSEEnabled: false },
+        }
+      );
+
+      expect(sentCommandNames()).toEqual([
+        'DescribeTableCommand', // update reads current
+        'UpdateTableCommand', // WarmThroughput
+        'DescribeTableCommand', // waitForTableActiveAfterUpdate
+        'UpdateTableCommand', // SSESpecification
+        'DescribeTableCommand', // waitForTableActiveAfterUpdate
+      ]);
+
+      const updateInputs = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter((cmd) => cmd instanceof UpdateTableCommand)
+        .map((cmd) => (cmd as { input: Record<string, unknown> }).input);
+      expect(updateInputs[0].WarmThroughput).toBeDefined();
+      expect(updateInputs[1].SSESpecification).toBeDefined();
+    });
+  });
+
   describe('ContributorInsightsSpecification', () => {
     it('enables contributor insights with the mode on create', async () => {
       mockSend


### PR DESCRIPTION
## Summary

Follow-up to (#989) surfaced in that PR's review. `DynamoDBTableProvider.update()` fires the OnDemandThroughput and WarmThroughput `UpdateTable` calls without a following `waitForTableActiveAfterUpdate`, unlike the billing / SSE / Stream / GSI branches around them. `UpdateTable` is async, so a combined update that changes OnDemandThroughput (or WarmThroughput) AND a later property that issues its own `UpdateTable` (SSESpecification / StreamSpecification / GSI) could hit the second call while the table is still `UPDATING` — AWS returns `ResourceInUseException`.

This was a pre-existing gap (OnDemand -> GSI could already race), made more reachable by #989's new StreamSpecification branch. It fails loudly (exception), not as a silent divergence.

## Fix

Added `await this.waitForTableActiveAfterUpdate(physicalId)` after the `UpdateTableCommand` send in both the OnDemandThroughput and WarmThroughput branches, matching every other UpdateTable-riding branch.

## Tests

- Unit: a combined OnDemand+SSE (and Warm+SSE) update pins the ordered command sequence `UpdateTable(throughput) -> DescribeTable(wait) -> UpdateTable(SSE) -> DescribeTable(wait)`, proving the wait now fires between the two UpdateTables. Two pre-existing throughput-update tests gained the extra DescribeTable mock the new wait requires.
- Integ: re-ran `dynamodb-streams` on real AWS (us-east-1) — WarmThroughput + StreamSpecification enable-on-UPDATE + destroy all clean (10 resources, 0 errors, 0 orphans).
