### PR TITLE
fix(deployment): Ref on AWS::Backup::BackupSelection returns the bare SelectionId

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -213,7 +213,7 @@ multi-resource	2026-07-03T07:21:52Z	PASS	59	standard	broad integ for #974 intrin
 ecr-scanning	2026-07-03T08:26:37Z	PASS	55	verify.sh	tag add/change/untag on update reach AWS; destroy clean
 stepfunctions-logging	2026-07-03T08:44:32Z	PASS	52	verify.sh	logging/tracing removal-clear reaches AWS (OFF/0/False); destroy clean
 sns-inline-subscription	2026-07-03T09:04:10Z	PASS	47	verify.sh	inline sub create(in-try)+update+drift reach AWS; destroy clean
-backup	2026-07-03T09:10:59Z	PASS	48	verify.sh	BackupVaultArn GetAtt enrichment resolves real ARN; destroy clean
 launchtemplate-asg-inplace	2026-07-03T09:30:15Z	PASS	64	verify.sh	in-place GetAtt value change propagates to NO_CHANGE ASG same deploy; destroy clean
-bench-cdk-sample	2026-07-03T09:40:40Z	PASS	505	standard	broad regression for #985 diff-classifier; 39 created / 37 deleted+2 retain 0 errors
 dynamodb-streams	2026-07-03T10:26:01Z	PASS	86	verify.sh	OnDemand/Warm wait follow-up; destroy clean
+backup	2026-07-03T11:11:09Z	PASS	58	verify.sh	Ref on BackupSelection returns bare SelectionId (#995); destroy clean
+bench-cdk-sample	2026-07-03T11:11:09Z	PASS	578	standard	broad for #995 intrinsic-resolver change; 39 created/37 del+2 retain 0 err

--- a/src/deployment/intrinsic-function-resolver.ts
+++ b/src/deployment/intrinsic-function-resolver.ts
@@ -269,6 +269,22 @@ export function cfnRefValueFromPhysicalId(
       return tableName;
     }
   }
+  // AWS::Backup::BackupSelection: CFn's `Ref` returns `BackupSelectionId` (the
+  // bare SelectionId; docs-verified), but the Cloud Control primaryIdentifier
+  // cdkd stores as the physical id is the compound `Id` = `<SelectionId>_<BackupPlanId>`
+  // joined by an UNDERSCORE (not a pipe, so the REF_RETURNS_SEGMENT_*_PIPE
+  // extractions do not apply). Rather than string-split on `_` (a fragile
+  // assumption about the separator + segment order), recover the bare
+  // SelectionId from the enriched `SelectionId` attribute the CC read-back
+  // already populated (PR #992). Falls through to the raw physical id when the
+  // attribute is absent — same graceful degradation as the S3Tables case
+  // above (issue #995).
+  if (resourceType === 'AWS::Backup::BackupSelection' && stateLookup) {
+    const selectionId = stateLookup(['SelectionId']);
+    if (selectionId) {
+      return selectionId;
+    }
+  }
   // AWS::WAFv2::WebACL is the inverse of the usual divergence: CFn's `Ref` IS
   // the pipe-joined compound `name|id|scope` (docs-explicit, e.g.
   // `my-webacl-name|1234a1a-...|REGIONAL`), which matches the CC identifier —

--- a/src/provisioning/cloud-control-provider.ts
+++ b/src/provisioning/cloud-control-provider.ts
@@ -1327,16 +1327,22 @@ export class CloudControlProvider implements ResourceProvider {
 
       case 'AWS::Backup::BackupSelection': {
         // BackupSelection's CC primaryIdentifier is a single `Id` whose VALUE
-        // is the compound `<SelectionId>|<BackupPlanId>` (pipe-joined) — CFn's
-        // Ref returns the SelectionId. `Fn::GetAtt(<Selection>, 'SelectionId')`
-        // would otherwise fall through to the compound physicalId. Extract the
-        // SelectionId from the compound id (before the pipe), and prefer the CC
-        // read-back model's value when available. Best-effort.
+        // is the compound `<SelectionId>_<BackupPlanId>` joined by an UNDERSCORE
+        // (both segments are UUIDs, so `_` is unambiguous) — CFn's Ref returns
+        // the SelectionId. `Fn::GetAtt(<Selection>, 'SelectionId')` would
+        // otherwise fall through to the compound physicalId. Extract the
+        // SelectionId from the compound id (before the first underscore) as a
+        // best-effort fallback, and prefer the CC read-back model's value when
+        // available (issue #995 corrected the separator from `|` to `_`).
         if (!enriched['SelectionId'] || !enriched['BackupPlanId']) {
-          const compoundSegments = physicalId.split('|');
-          if (compoundSegments.length >= 2) {
-            if (!enriched['SelectionId']) enriched['SelectionId'] = compoundSegments[0];
-            if (!enriched['BackupPlanId']) enriched['BackupPlanId'] = compoundSegments[1];
+          const firstUnderscore = physicalId.indexOf('_');
+          if (firstUnderscore > 0) {
+            if (!enriched['SelectionId']) {
+              enriched['SelectionId'] = physicalId.substring(0, firstUnderscore);
+            }
+            if (!enriched['BackupPlanId']) {
+              enriched['BackupPlanId'] = physicalId.substring(firstUnderscore + 1);
+            }
           }
           const model = await this.readBackupResourceModel(resourceType, physicalId);
           if (model) {

--- a/tests/integration/backup/lib/backup-stack.ts
+++ b/tests/integration/backup/lib/backup-stack.ts
@@ -49,8 +49,9 @@ export class BackupStack extends cdk.Stack {
     });
 
     // A tag-based selection exercises AWS::Backup::BackupSelection (its CC
-    // primaryIdentifier is the compound `<SelectionId>|<BackupPlanId>`).
-    plan.addSelection('Selection', {
+    // primaryIdentifier is the compound `Id` = `<SelectionId>_<BackupPlanId>`,
+    // joined by an UNDERSCORE).
+    const selection = plan.addSelection('Selection', {
       resources: [
         backup.BackupResource.fromTag('cdkd-backup-integ', 'true'),
       ],
@@ -60,6 +61,14 @@ export class BackupStack extends cdk.Stack {
     // whose enrichment this integ regression-guards.
     new cdk.CfnOutput(this, 'VaultArn', {
       value: vault.backupVaultArn,
+    });
+
+    // `Ref` on the selection: CFn returns the bare BackupSelectionId (issue
+    // #995). cdkd must return the same, NOT the compound `Id`. Reach the L1
+    // child to emit a raw `{Ref: <logicalId>}`.
+    const cfnSelection = selection.node.defaultChild as backup.CfnBackupSelection;
+    new cdk.CfnOutput(this, 'SelectionRef', {
+      value: cfnSelection.ref,
     });
   }
 }

--- a/tests/integration/backup/verify.sh
+++ b/tests/integration/backup/verify.sh
@@ -53,6 +53,22 @@ cleanup() {
   done
   aws backup delete-backup-vault --backup-vault-name "${VAULT}" \
     --region "${REGION}" >/dev/null 2>&1 || true
+  # The tag-based selection creates an IAM role (CDK default) that a direct
+  # backup-resource cleanup above does NOT remove; delete it so a re-run's
+  # fresh deploy does not collide with `Role ... already exists`.
+  for ROLE in $(aws iam list-roles \
+      --query "Roles[?starts_with(RoleName, '${STACK}-PlanSelectionRole')].RoleName" \
+      --output text 2>/dev/null); do
+    for POL in $(aws iam list-attached-role-policies --role-name "${ROLE}" \
+        --query 'AttachedPolicies[].PolicyArn' --output text 2>/dev/null); do
+      aws iam detach-role-policy --role-name "${ROLE}" --policy-arn "${POL}" >/dev/null 2>&1 || true
+    done
+    for INLINE in $(aws iam list-role-policies --role-name "${ROLE}" \
+        --query 'PolicyNames[]' --output text 2>/dev/null); do
+      aws iam delete-role-policy --role-name "${ROLE}" --policy-name "${INLINE}" >/dev/null 2>&1 || true
+    done
+    aws iam delete-role --role-name "${ROLE}" >/dev/null 2>&1 || true
+  done
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1 || true
@@ -105,6 +121,30 @@ case "${STATE_VAULT_ARN}" in
   arn:aws:backup:*) echo "    state vault attribute BackupVaultArn is a real ARN: ${STATE_VAULT_ARN}" ;;
   *) echo "FAIL: state vault attribute BackupVaultArn is not an ARN: '${STATE_VAULT_ARN}'" >&2; exit 1 ;;
 esac
+
+# `Ref` on the BackupSelection must resolve to the bare BackupSelectionId, NOT
+# the compound `Id` (`<SelectionId>_<BackupPlanId>`) — issue #995. Assert the
+# SelectionRef output EQUALS the real SelectionId from AWS (an EQUALITY check,
+# not a "lacks a delimiter" check: the compound separator is `_`, so a
+# `grep -v |` style assertion would false-pass on the composite).
+SELECTION_REF=$(echo "${STATE}" | jq -r \
+  '[.outputs | to_entries[] | select(.key | startswith("SelectionRef")) | .value] | first // (.outputs.SelectionRef // "")')
+echo "    SelectionRef output: ${SELECTION_REF}"
+REAL_SELECTION_ID=$(aws backup list-backup-selections --backup-plan-id "${PLAN_ID_FOR_ASSERT:-$(aws backup list-backup-plans --region "${REGION}" --query "BackupPlansList[?BackupPlanName=='${PLAN}'].BackupPlanId | [0]" --output text)}" \
+  --region "${REGION}" --query 'BackupSelectionsList[0].SelectionId' --output text 2>/dev/null)
+echo "    AWS real SelectionId: ${REAL_SELECTION_ID}"
+if [ -z "${REAL_SELECTION_ID}" ] || [ "${REAL_SELECTION_ID}" = "None" ]; then
+  echo "FAIL: could not read the real SelectionId from AWS to compare against" >&2
+  exit 1
+fi
+if [ "${SELECTION_REF}" != "${REAL_SELECTION_ID}" ]; then
+  echo "FAIL: Ref on BackupSelection is '${SELECTION_REF}' but should equal the bare SelectionId '${REAL_SELECTION_ID}' (issue #995 — returning the compound Id)" >&2
+  exit 1
+fi
+case "${SELECTION_REF}" in
+  *_*) echo "FAIL: SelectionRef still contains an underscore (compound Id leaked): '${SELECTION_REF}'" >&2; exit 1 ;;
+esac
+echo "    SelectionRef resolved to the bare SelectionId (Ref segment fix #995 works)"
 
 # --- Phase 2: destroy --------------------------------------------------
 echo "==> Phase 2: destroy"

--- a/tests/unit/deployment/intrinsic-functions.test.ts
+++ b/tests/unit/deployment/intrinsic-functions.test.ts
@@ -3175,6 +3175,62 @@ describe('IntrinsicFunctionResolver - Ref to AWS::ApiGateway::Model', () => {
     expect(result).toBe(bareArn);
   });
 
+  // AWS::Backup::BackupSelection (issue #995): CFn `Ref` returns the bare
+  // BackupSelectionId, but the CC primaryIdentifier cdkd stores is the compound
+  // `Id` = `<SelectionId>_<BackupPlanId>` (UNDERSCORE-joined, so the pipe
+  // extractions never apply). The bare SelectionId is recovered from the
+  // enriched `SelectionId` attribute (PR #992), not by splitting the compound.
+  it('Ref to a BackupSelection resolves to the bare SelectionId attribute, not the compound Id', async () => {
+    const template: CloudFormationTemplate = {
+      Resources: { R: { Type: 'AWS::Backup::BackupSelection', Properties: {} } },
+    };
+    const context: ResolverContext = {
+      template,
+      resources: {
+        R: {
+          physicalId:
+            'b2e56751-988c-4a67-8d1a-dfb727929059_025bd996-eb8b-4979-8831-d8e96bded9c5',
+          resourceType: 'AWS::Backup::BackupSelection',
+          properties: {},
+          attributes: {
+            SelectionId: 'b2e56751-988c-4a67-8d1a-dfb727929059',
+            BackupPlanId: '025bd996-eb8b-4979-8831-d8e96bded9c5',
+          },
+          dependencies: [],
+        },
+      },
+    };
+
+    const result = await resolver.resolve({ Ref: 'R' }, context);
+    expect(result).toBe('b2e56751-988c-4a67-8d1a-dfb727929059');
+  });
+
+  // Defensive: a BackupSelection whose state carries no enriched SelectionId
+  // (torn / pre-#992 state) falls back to the raw compound physical id rather
+  // than emitting a broken value — least-surprising, same as the S3Tables case.
+  it('Ref to a BackupSelection with no SelectionId attribute falls back to the compound physical id', async () => {
+    const compound =
+      'b2e56751-988c-4a67-8d1a-dfb727929059_025bd996-eb8b-4979-8831-d8e96bded9c5';
+    const template: CloudFormationTemplate = {
+      Resources: { R: { Type: 'AWS::Backup::BackupSelection', Properties: {} } },
+    };
+    const context: ResolverContext = {
+      template,
+      resources: {
+        R: {
+          physicalId: compound,
+          resourceType: 'AWS::Backup::BackupSelection',
+          properties: {},
+          attributes: {},
+          dependencies: [],
+        },
+      },
+    };
+
+    const result = await resolver.resolve({ Ref: 'R' }, context);
+    expect(result).toBe(compound);
+  });
+
   // The SDK-compound path must NOT consult the state lookup — its physical id
   // has a pipe, so the after-pipe extraction returns the table name directly
   // even when the properties carry a different / stale TableName. Guards that

--- a/tests/unit/provisioning/cloud-control-provider.test.ts
+++ b/tests/unit/provisioning/cloud-control-provider.test.ts
@@ -1201,10 +1201,10 @@ describe('CloudControlProvider Backup attribute enrichment (CC-API routing, issu
       BackupPlanId: 'plan-from-model',
     });
 
-    // CC primaryIdentifier value is `<SelectionId>|<BackupPlanId>`.
+    // CC primaryIdentifier value is `<SelectionId>_<BackupPlanId>` (underscore).
     const enriched = await enrich(
       'AWS::Backup::BackupSelection',
-      'sel-abcdef|plan-1234',
+      'sel-abcdef_plan-1234',
       {}
     );
 
@@ -1212,18 +1212,19 @@ describe('CloudControlProvider Backup attribute enrichment (CC-API routing, issu
     expect(enriched['BackupPlanId']).toBe('plan-from-model');
   });
 
-  it('BackupSelection: falls back to the compound-id split when the CC read fails', async () => {
+  it('BackupSelection: falls back to the compound-id split (before first underscore) when the CC read fails', async () => {
     mockCloudControlSend.mockRejectedValueOnce(
       Object.assign(new Error('access denied'), { name: 'AccessDeniedException' })
     );
 
     const enriched = await enrich(
       'AWS::Backup::BackupSelection',
-      'sel-abcdef|plan-1234',
+      'sel-abcdef_plan-1234',
       {}
     );
 
-    // The split fallback still resolves both without the read-back.
+    // The split fallback still resolves both without the read-back: the
+    // compound `Id` is `<SelectionId>_<BackupPlanId>`, split on the first `_`.
     expect(enriched['SelectionId']).toBe('sel-abcdef');
     expect(enriched['BackupPlanId']).toBe('plan-1234');
   });


### PR DESCRIPTION
## Summary

`{Ref: <AWS::Backup::BackupSelection>}` returned the compound Cloud Control primaryIdentifier `Id` (`<SelectionId>_<BackupPlanId>`) instead of the bare `SelectionId` that CloudFormation returns.

Per the AWS docs (AWS::Backup::BackupSelection → Return values → Ref): **"`Ref` returns `BackupSelectionId`"** — the bare SelectionId.

`Fn::GetAtt(<Selection>, 'SelectionId')` already resolved correctly (PR #992 enriches the bare `SelectionId` into `attributes` via a Cloud Control `GetResource` read-back); only the `Ref` path was affected.

## Verified (real AWS, us-east-1)

- physicalId (CC primaryIdentifier `Id`): `<SelectionId>_<BackupPlanId>` — joined by an **underscore** `_` (both segments are UUIDs), SelectionId first. Confirmed against `backup:ListBackupSelections`.
- The compound uses `_`, NOT `|`, so the existing `REF_RETURNS_SEGMENT_*_PIPE` mechanisms (which split on `|`) cannot recover the SelectionId.

## Fix

Rather than string-split the compound on `_` (a fragile assumption about the separator + segment order), `cfnRefValueFromPhysicalId` now recovers the bare `SelectionId` for `AWS::Backup::BackupSelection` from the enriched `SelectionId` attribute (already populated by #992's read-back) via the existing `stateLookup` seam — the same robust pattern as the `AWS::S3Tables::Table` #974 case. Falls back to the raw physical id when the attribute is absent (graceful degradation, no worse than before).

## Tests

- Unit: `Ref` on a BackupSelection with an enriched `SelectionId` attribute resolves to the bare id; without the attribute it falls back to the compound physical id.
- Integ: extended the `backup` fixture with a `Ref`-on-selection `CfnOutput`. verified live on real AWS that the `SelectionRef` output **equals the real SelectionId** from `backup:ListBackupSelections` (an equality check, not a "lacks a delimiter" check — the compound separator is `_`, so a delimiter-absence assertion would false-pass). Destroy clean (4 resources, 0 errors, 0 orphans). Also hardened the fixture cleanup() to delete the tag-selection IAM role so a re-run's fresh deploy does not collide.
- Broad: re-ran `bench-cdk-sample` (39-resource VPC+NAT+CF+Lambda+SQS) since this touches the cross-cutting `intrinsic-function-resolver.ts` — 39 created, 37 deleted + 2 policy-retained, 0 errors, 0 orphans.


## In-PR consistency fix (from review)

PR #992's `enrichResourceAttributes` BackupSelection case split the compound `Id` on `|` (pipe) in its best-effort fallback — but the real separator is `_` (underscore), so that fallback was effectively dead (it relied entirely on the CC read-back). Corrected the fallback to split on the first `_`, and updated the two #992 unit tests to use underscore-joined compounds. The happy path (CC `GetResource` read-back) is unchanged and already integ-verified; this only fixes the read-back-failure fallback.

Closes #995
