### PR TITLE
docs: add asset build & publish step to README architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,16 @@ Reproduce the first two with `./tests/benchmark/run-benchmark.sh all`. See [test
          │
          ▼
 ┌─────────────────┐
+│ Asset Build &   │  S3 ZIP upload / ECR image build & push
+│   Publish       │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
 │ cdkd Engine     │
 │ - DAG Analysis  │  Dependency graph construction
 │ - Diff Calc     │  Compare with existing resources
-│ - Parallel Exec │  Event-driven dispatch
+│ - Parallel Exec │  Dispatch on deps complete (no level barrier)
 └────────┬────────┘
          │
     ┌────┴────┐


### PR DESCRIPTION
## What

Updates the "How it works" ASCII diagram in `README.md`:

1. **Adds an `Asset Build & Publish` box** between the CloudFormation Template and the cdkd Engine. The diagram previously jumped straight from the template to the engine, omitting asset handling (S3 file asset ZIP upload, Docker image build & ECR push) entirely — a distinctive part of cdkd's pipeline. Asset publishing gates each stack's own deploy (wired as an `asset-publish → stack` DAG dependency in the CLI-layer `WorkGraph`), so it belongs upstream of the engine box.

2. **Sharpens the `Parallel Exec` annotation** from `Event-driven dispatch` to `Dispatch on deps complete (no level barrier)`. The old wording did not convey the load-bearing property — a resource fires the moment its own dependencies complete, with no level-synchronized barrier (`DagExecutor` re-dispatches on every node completion; the `executionLevels` in `deploy-engine.ts` is used only for an informational log line, not scheduling).

## Why

Diagram-vs-code consistency. Both changes make the overview match the actual `cdkd deploy` pipeline (`src/cli/commands/deploy.ts` asset→stack wiring, `src/deployment/dag-executor.ts` event-driven dispatch). No source or behavior change.

## Scope

Documentation only — `README.md`, one hunk (+7/-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBCPpWwN3ownjnagUX1Nxb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBCPpWwN3ownjnagUX1Nxb)_