### PR TITLE
docs: cdk bootstrap is not a prerequisite + upgrade flow for existing users

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ parsing → synthesis → asset publishing → per-stack deploy), see
 ## Prerequisites
 
 - **Node.js** >= 20.0.0
-- **AWS CDK Bootstrap: NOT required.** `cdkd bootstrap` creates everything cdkd needs — the S3 state bucket plus cdkd-owned asset storage (`cdkd-assets-{accountId}-{region}` bucket / `cdkd-container-assets-{accountId}-{region}` ECR repo) that asset publishing (Lambda code, Docker images) targets automatically, with template references rewritten to match (issue [#1002](https://github.com/go-to-k/cdkd/issues/1002); design in [docs/design/1002-cdkd-asset-storage.md](docs/design/1002-cdkd-asset-storage.md)). cdkd does not use CDK's bootstrap roles either (see the credentials note below), and it ignores the template's `BootstrapVersion` check. `cdk bootstrap` storage (`cdk-hnb659fds-assets-*`) is only involved when you deliberately stay in **legacy mode**: regions bootstrapped by cdkd < 0.232.0 (or with `--no-assets`) and not yet re-bootstrapped keep publishing there — byte-identical to older versions, but `cdk gc` cannot see cdkd-deployed stacks (no CloudFormation stack to scan) and may garbage-collect those assets, so re-running `cdkd bootstrap` is recommended (see [Upgrading from an earlier cdkd version](#upgrading-from-an-earlier-cdkd-version)) — or via `--use-cdk-bootstrap-assets`, which pins the legacy destinations for apps co-deployed through CloudFormation during a migration window. (`cdkd export` hands a stack back to the CFn / CDK CLI world, where `cdk bootstrap` is the CDK CLI's own prerequisite again.)
+- **AWS CDK Bootstrap: NOT required.** `cdkd bootstrap` creates everything cdkd needs — the S3 state bucket plus cdkd-owned asset storage (`cdkd-assets-{accountId}-{region}` bucket / `cdkd-container-assets-{accountId}-{region}` ECR repo) that asset publishing (Lambda code, Docker images) targets automatically, with template references rewritten to match (issue [#1002](https://github.com/go-to-k/cdkd/issues/1002); design in [docs/design/1002-cdkd-asset-storage.md](docs/design/1002-cdkd-asset-storage.md)). cdkd does not use CDK's bootstrap roles either (see the credentials note below), and it ignores the template's `BootstrapVersion` check. Asset storage is created per region — automatically on the first `cdkd deploy` into each region (see [Upgrading from an earlier cdkd version](#upgrading-from-an-earlier-cdkd-version)), or explicitly via `cdkd bootstrap --region <r>`. `cdk bootstrap` storage (`cdk-hnb659fds-assets-*`) is only involved when you deliberately stay in **legacy mode** (`--no-auto-asset-storage` / `cdkd bootstrap --no-assets`, or the `--use-cdk-bootstrap-assets` pin for apps co-deployed through CloudFormation during a migration window): legacy deploys keep publishing there — byte-identical to older versions, but `cdk gc` cannot see cdkd-deployed stacks (no CloudFormation stack to scan) and may garbage-collect those assets. (`cdkd export` hands a stack back to the CFn / CDK CLI world, where `cdk bootstrap` is the CDK CLI's own prerequisite again.)
 - **AWS credentials with admin-equivalent permissions** for the resources being deployed. cdkd does NOT route through CloudFormation, so CDK CLI's `cdk-hnb659fds-deploy-role-*` is NOT sufficient — see [`--role-arn`](docs/cli-reference.md).
 
 ## Installation
@@ -184,23 +184,22 @@ That's it. cdkd reads `--app` from `cdk.json` and auto-resolves the state bucket
 
 ### Upgrading from an earlier cdkd version
 
-**There is no breaking change — upgrading the binary alone changes nothing about where your assets go.** Regions bootstrapped by cdkd < 0.232.0 (before cdkd-owned asset storage existed) stay in **legacy mode**: deploys keep publishing assets to the CDK bootstrap bucket exactly as before, byte-identical, plus a one-line notice about the `cdk gc` hazard. Downgrading is equally safe: older binaries ignore the bootstrap marker, and both storages hold the same content-addressed objects.
+**There is no breaking change, and no manual step: just deploy.** The first `cdkd deploy` into each region auto-creates the cdkd-owned asset storage (asset bucket + ECR repo + per-region marker) — interactive runs are asked once per region (`[Y/n]`), `--yes` / CI runs create it automatically with an info line. Asset storage is per region because AWS requires Lambda code (S3) and container images (ECR) to live in the function's own region — the auto-create keys off each stack's `env.region`, so multi-region apps opt in region by region as they deploy. That deploy shows a one-time diff repointing `Code` / `Image` references to the cdkd storage — an ordinary in-place UPDATE (content identical, no replacement). `cdkd state info` shows which regions are opted in.
 
-To opt an already-bootstrapped region into cdkd-owned asset storage:
+Downgrading is equally safe: older binaries ignore the bootstrap marker and keep publishing to the CDK bootstrap destinations; both storages hold the same content-addressed objects.
+
+Prefer the explicit path (e.g. to pre-provision in CI before the first deploy)? The equivalent manual opt-in is:
 
 ```bash
-cdkd bootstrap   # re-run per region (--region <r> for others)
+cdkd bootstrap --region <r>   # re-run per region; the state bucket is left untouched (no --force)
 ```
 
-> **The region must be the one your stacks deploy to** (their `env.region`),
-> not your CLI default region. If your stack pins `ap-northeast-1` but your
-> shell defaults to `us-east-1`, run
-> `cdkd bootstrap --region ap-northeast-1` — otherwise deploys of that stack
-> stay in legacy mode and keep showing the `cdk gc` notice.
+To stay on CDK bootstrap storage instead:
 
-Re-running is the supported upgrade path — the existing state bucket is left untouched (no `--force` needed); only the asset bucket, ECR repo, and per-region marker are added. The first `cdkd deploy` afterward shows a one-time diff repointing `Code` / `Image` references to the cdkd storage — an ordinary in-place UPDATE (content identical, no replacement). Opt-in is per region, so a multi-region account can migrate one region at a time; `cdkd state info` shows which regions are opted in.
+- `--no-auto-asset-storage` (or `cdk.json` `context.cdkd.autoAssetStorage: false`) skips the auto-create — deploys into un-opted-in regions stay in **legacy mode** (assets go to the CDK bootstrap bucket, byte-identical to older versions, plus a one-line `cdk gc`-hazard notice naming the region).
+- `--use-cdk-bootstrap-assets` (or `cdk.json` `context.cdkd.useCdkBootstrapAssets: true`) pins the legacy destinations even for opted-in regions — for apps deployed via both CloudFormation and cdkd during a migration window. Also suppresses the notice.
 
-To keep using CDK bootstrap storage instead (e.g. the same app is also deployed via CloudFormation during a migration window), pin it with `--use-cdk-bootstrap-assets` or `cdk.json` `context.cdkd.useCdkBootstrapAssets: true` — this also suppresses the legacy-mode notice. See [`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap) for details.
+See [`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap) for details.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ parsing → synthesis → asset publishing → per-stack deploy), see
 ## Prerequisites
 
 - **Node.js** >= 20.0.0
-- **AWS CDK Bootstrap**: You must run `cdk bootstrap` before using cdkd. By default cdkd uses CDK's bootstrap bucket (`cdk-hnb659fds-assets-*`) for asset uploads (Lambda code, Docker images). Custom bootstrap qualifiers are supported — CDK embeds the correct bucket/repo names in the asset manifest during synthesis. Note: `cdk gc` cannot see cdkd-deployed stacks (no CloudFormation stack to scan) and may garbage-collect cdkd-published assets from the CDK bootstrap storage — run `cdkd bootstrap` to opt a region into cdkd-owned asset storage (`cdkd-assets-*` / `cdkd-container-assets-*`), which asset publishing then redirects to automatically, with template references rewritten to match (issue [#1002](https://github.com/go-to-k/cdkd/issues/1002); design in [docs/design/1002-cdkd-asset-storage.md](docs/design/1002-cdkd-asset-storage.md); `--use-cdk-bootstrap-assets` pins the legacy destinations for CFn-co-deployed apps).
+- **AWS CDK Bootstrap: NOT required.** `cdkd bootstrap` creates everything cdkd needs — the S3 state bucket plus cdkd-owned asset storage (`cdkd-assets-{accountId}-{region}` bucket / `cdkd-container-assets-{accountId}-{region}` ECR repo) that asset publishing (Lambda code, Docker images) targets automatically, with template references rewritten to match (issue [#1002](https://github.com/go-to-k/cdkd/issues/1002); design in [docs/design/1002-cdkd-asset-storage.md](docs/design/1002-cdkd-asset-storage.md)). cdkd does not use CDK's bootstrap roles either (see the credentials note below), and it ignores the template's `BootstrapVersion` check. `cdk bootstrap` storage (`cdk-hnb659fds-assets-*`) is only involved when you deliberately stay in **legacy mode**: regions bootstrapped by cdkd < 0.232.0 (or with `--no-assets`) and not yet re-bootstrapped keep publishing there — byte-identical to older versions, but `cdk gc` cannot see cdkd-deployed stacks (no CloudFormation stack to scan) and may garbage-collect those assets, so re-running `cdkd bootstrap` is recommended (see [Upgrading from an earlier cdkd version](#upgrading-from-an-earlier-cdkd-version)) — or via `--use-cdk-bootstrap-assets`, which pins the legacy destinations for apps co-deployed through CloudFormation during a migration window. (`cdkd export` hands a stack back to the CFn / CDK CLI world, where `cdk bootstrap` is the CDK CLI's own prerequisite again.)
 - **AWS credentials with admin-equivalent permissions** for the resources being deployed. cdkd does NOT route through CloudFormation, so CDK CLI's `cdk-hnb659fds-deploy-role-*` is NOT sufficient — see [`--role-arn`](docs/cli-reference.md).
 
 ## Installation
@@ -160,9 +160,8 @@ The installed binary is `cdkd`.
 > (`cdkd-assets-{accountId}-{region}` bucket +
 > `cdkd-container-assets-{accountId}-{region}` ECR repo — skip with
 > `--no-assets`; see [`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap)).
-> This is separate from `cdk bootstrap` (which sets up the
-> CDK asset bucket / ECR repo and is also required — see
-> [Prerequisites](#prerequisites)).
+> This replaces `cdk bootstrap`, which cdkd does not require — see
+> [Prerequisites](#prerequisites).
 
 ```bash
 # Bootstrap (creates S3 state bucket + asset storage — one-time setup per AWS account)
@@ -182,6 +181,26 @@ cdkd destroy
 ```
 
 That's it. cdkd reads `--app` from `cdk.json` and auto-resolves the state bucket from your AWS account ID (`cdkd-state-{accountId}`). If you bootstrapped under a previous cdkd version, the legacy region-suffixed name (`cdkd-state-{accountId}-{region}`) is still picked up automatically with a deprecation warning.
+
+### Upgrading from an earlier cdkd version
+
+**There is no breaking change — upgrading the binary alone changes nothing about where your assets go.** Regions bootstrapped by cdkd < 0.232.0 (before cdkd-owned asset storage existed) stay in **legacy mode**: deploys keep publishing assets to the CDK bootstrap bucket exactly as before, byte-identical, plus a one-line notice about the `cdk gc` hazard. Downgrading is equally safe: older binaries ignore the bootstrap marker, and both storages hold the same content-addressed objects.
+
+To opt an already-bootstrapped region into cdkd-owned asset storage:
+
+```bash
+cdkd bootstrap   # re-run per region (--region <r> for others)
+```
+
+> **The region must be the one your stacks deploy to** (their `env.region`),
+> not your CLI default region. If your stack pins `ap-northeast-1` but your
+> shell defaults to `us-east-1`, run
+> `cdkd bootstrap --region ap-northeast-1` — otherwise deploys of that stack
+> stay in legacy mode and keep showing the `cdk gc` notice.
+
+Re-running is the supported upgrade path — the existing state bucket is left untouched (no `--force` needed); only the asset bucket, ECR repo, and per-region marker are added. The first `cdkd deploy` afterward shows a one-time diff repointing `Code` / `Image` references to the cdkd storage — an ordinary in-place UPDATE (content identical, no replacement). Opt-in is per region, so a multi-region account can migrate one region at a time; `cdkd state info` shows which regions are opted in.
+
+To keep using CDK bootstrap storage instead (e.g. the same app is also deployed via CloudFormation during a migration window), pin it with `--use-cdk-bootstrap-assets` or `cdk.json` `context.cdkd.useCdkBootstrapAssets: true` — this also suppresses the legacy-mode notice. See [`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap) for details.
 
 ## Usage
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -223,7 +223,9 @@ and `publish-assets`; `synth` / `export` stay unrewritten by design.
 
 **Publish Destinations**:
 
-- Legacy mode (default): S3 `cdk-hnb659fds-assets-${AccountId}-${Region}/`,
+- Legacy mode (no bootstrap marker for the region — bootstrapped by
+  cdkd < 0.232.0 or with `--no-assets`): S3
+  `cdk-hnb659fds-assets-${AccountId}-${Region}/`,
   ECR `cdk-hnb659fds-container-assets-${AccountId}-${Region}`
 - cdkd-assets mode (region opted in via `cdkd bootstrap`): S3
   `cdkd-assets-${AccountId}-${Region}/`, ECR

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -961,7 +961,13 @@ Flags:
 
 Re-running `cdkd bootstrap` on an already-bootstrapped account does NOT
 require `--force` to add the asset storage — the state bucket is simply
-left as-is and the asset bucket / repo / marker are created.
+left as-is and the asset bucket / repo / marker are created. This is the
+upgrade path from cdkd versions before 0.232.0: until you re-run bootstrap,
+deploys in the region stay in **legacy mode** (publish to the CDK bootstrap
+destinations, byte-identical to older versions, plus a one-line `cdk gc`
+notice) — nothing breaks by upgrading the binary alone, and downgrading is
+safe in either mode (old binaries ignore the marker; both storages hold the
+same content-addressed objects).
 
 Bucket-squatting defense: bootstrap refuses to adopt an asset bucket owned
 by another account (predictable-name defense), and cdkd's asset-bucket S3

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -961,13 +961,16 @@ Flags:
 
 Re-running `cdkd bootstrap` on an already-bootstrapped account does NOT
 require `--force` to add the asset storage — the state bucket is simply
-left as-is and the asset bucket / repo / marker are created. This is the
-upgrade path from cdkd versions before 0.232.0: until you re-run bootstrap,
-deploys in the region stay in **legacy mode** (publish to the CDK bootstrap
-destinations, byte-identical to older versions, plus a one-line `cdk gc`
-notice) — nothing breaks by upgrading the binary alone, and downgrading is
-safe in either mode (old binaries ignore the marker; both storages hold the
-same content-addressed objects).
+left as-is and the asset bucket / repo / marker are created. Accounts
+bootstrapped by cdkd versions before 0.232.0 need no manual step at all:
+the first `cdkd deploy` into each region auto-creates the storage (see
+"Auto-create on first deploy" below); the explicit re-run is the
+pre-provisioning alternative. Deploys that opt out stay in **legacy mode**
+(publish to the CDK bootstrap destinations, byte-identical to older
+versions, plus a one-line `cdk gc` notice naming the region) — nothing
+breaks by upgrading the binary alone, and downgrading is safe in either
+mode (old binaries ignore the marker; both storages hold the same
+content-addressed objects).
 
 Bucket-squatting defense: bootstrap refuses to adopt an asset bucket owned
 by another account (predictable-name defense), and cdkd's asset-bucket S3

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -424,21 +424,31 @@ AssetPublisherError: Failed to publish asset: Access Denied
 
 #### Causes
 
-- Asset bucket (`cdk-hnb659fds-assets-*`) doesn't exist
-- CDK Bootstrap has not been run
+- Asset storage doesn't exist for the target: in cdkd-assets mode the
+  `cdkd-assets-*` bucket / `cdkd-container-assets-*` repo (someone deleted
+  them after bootstrap), in legacy mode the CDK bootstrap bucket
+  (`cdk-hnb659fds-assets-*`)
 - Insufficient IAM permissions
 
 #### Solutions
 
-**1. Run CDK Bootstrap (required prerequisite)**
+**1. Run `cdkd bootstrap` for the region**
 
-cdkd uses CDK's bootstrap bucket for asset uploads. The `cdkd bootstrap` command only creates the state management bucket — it does NOT create the asset bucket. You must run CDK bootstrap separately:
+`cdkd bootstrap` creates the state bucket AND cdkd-owned asset storage for
+`--region` (asset bucket + container-asset ECR repo + opt-in marker), so no
+`cdk bootstrap` is needed:
 
 ```bash
-npx cdk bootstrap aws://123456789012/us-east-1
+cdkd bootstrap --region us-east-1
 ```
 
-> **Custom bootstrap**: If you use a custom qualifier (e.g., `--qualifier myqualifier`), CDK synthesis will embed the custom bucket name in the asset manifest. cdkd reads destinations from the manifest, so custom bootstrap is fully supported.
+Regions bootstrapped by cdkd < 0.232.0 (or with `--no-assets`) run in
+**legacy mode** instead: assets go to the CDK bootstrap bucket, which then
+must exist (`npx cdk bootstrap aws://123456789012/us-east-1`). Re-running
+`cdkd bootstrap` opts the region into cdkd-owned storage — see
+[cli-reference.md](cli-reference.md#cdkd-bootstrap).
+
+> **Custom bootstrap**: If you use a custom qualifier (e.g., `--qualifier myqualifier`), CDK synthesis will embed the custom bucket name in the asset manifest. cdkd reads destinations from the manifest (and, in cdkd-assets mode, redirects default-bootstrap-shaped destinations to cdkd-owned storage), so custom qualifiers are fully supported.
 
 **2. Skip asset publishing**
 
@@ -449,7 +459,10 @@ node dist/cli.js deploy --app "..." --skip-assets
 
 **3. Check IAM permissions**
 
-The following permissions are required:
+cdkd publishes assets with the caller's credentials directly (it never
+assumes CDK's `cdk-hnb659fds-file-publishing-role-*`). The caller needs
+S3 read/write on the asset bucket — `cdkd-assets-*` in cdkd-assets mode,
+`cdk-hnb659fds-assets-*` in legacy mode:
 
 ```json
 {
@@ -461,16 +474,17 @@ The following permissions are required:
         "s3:PutObject",
         "s3:GetObject"
       ],
-      "Resource": "arn:aws:s3:::cdk-hnb659fds-assets-*/*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": "sts:AssumeRole",
-      "Resource": "arn:aws:iam::*:role/cdk-hnb659fds-file-publishing-role-*"
+      "Resource": [
+        "arn:aws:s3:::cdkd-assets-*/*",
+        "arn:aws:s3:::cdk-hnb659fds-assets-*/*"
+      ]
     }
   ]
 }
 ```
+
+(Docker image assets additionally need ECR push permissions on the
+container-asset repo.)
 
 ### Issue: Lambda Deployment Fails
 
@@ -494,8 +508,8 @@ The provided execution role does not have permissions to call CreateFunction.
 # Check asset manifest
 cat cdk.out/MyStack.assets.json
 
-# Check asset bucket
-aws s3 ls s3://cdk-hnb659fds-assets-${AWS_ACCOUNT_ID}-${AWS_REGION}/
+# Check asset bucket (cdkd-assets mode; use cdk-hnb659fds-assets-... in legacy mode)
+aws s3 ls s3://cdkd-assets-${AWS_ACCOUNT_ID}-${AWS_REGION}/
 ```
 
 **2. Check IAM Role dependencies**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -442,10 +442,13 @@ AssetPublisherError: Failed to publish asset: Access Denied
 cdkd bootstrap --region us-east-1
 ```
 
-Regions bootstrapped by cdkd < 0.232.0 (or with `--no-assets`) run in
-**legacy mode** instead: assets go to the CDK bootstrap bucket, which then
-must exist (`npx cdk bootstrap aws://123456789012/us-east-1`). Re-running
-`cdkd bootstrap` opts the region into cdkd-owned storage — see
+Normally this is automatic — the first `cdkd deploy` into a region
+auto-creates the storage (issue #1007), so this error usually means the
+auto-create was declined / opted out (`--no-auto-asset-storage`), failed
+(check the deploy output for the auto-create warning), or someone deleted
+the bucket/repo after opt-in. Deploys that stay in **legacy mode** publish
+to the CDK bootstrap bucket instead, which then must exist
+(`npx cdk bootstrap aws://123456789012/us-east-1`). See
 [cli-reference.md](cli-reference.md#cdkd-bootstrap).
 
 > **Custom bootstrap**: If you use a custom qualifier (e.g., `--qualifier myqualifier`), CDK synthesis will embed the custom bucket name in the asset manifest. cdkd reads destinations from the manifest (and, in cdkd-assets mode, redirects default-bootstrap-shaped destinations to cdkd-owned storage), so custom qualifiers are fully supported.


### PR DESCRIPTION
## Summary

Documentation follow-up to #1006 (cdk-bootstrap-free deploys) and #1008 (deploy-time asset-storage auto-create, issue #1007). Rewrites the stale "you must run `cdk bootstrap` before using cdkd" story:

- **README Prerequisites**: `cdk bootstrap` is now documented as NOT required — `cdkd bootstrap` creates everything cdkd needs, cdkd never uses CDK's bootstrap roles, and the template's `BootstrapVersion` SSM parameter is not resolved (#1006). CDK bootstrap storage is only involved in deliberate legacy mode (`--no-auto-asset-storage` / `--no-assets` / the `--use-cdk-bootstrap-assets` CFn-co-deploy pin). `cdkd export` back to the CFn world remains the CDK CLI's own prerequisite.
- **New README section "Upgrading from an earlier cdkd version"**: no breaking change and no manual step — the first deploy into each region auto-creates the storage (#1008); `cdkd bootstrap --region <r>` stays as the explicit pre-provisioning alternative; per-region rationale (Lambda same-region S3/ECR), one-time repointing UPDATE, downgrade safety, and both opt-outs.
- **Quick Start note**: no longer claims `cdk bootstrap` is "also required".
- **docs/cli-reference.md**: bootstrap upgrade-path paragraph aligned (auto-create first, explicit re-run as alternative; correct 0.232.0 version boundary).
- **docs/troubleshooting.md**: "Asset publishing failed" section no longer claims `cdkd bootstrap` "does NOT create the asset bucket" (stale since #1003) and no longer requires `cdk bootstrap`; IAM example no longer claims cdkd assumes CDK's `file-publishing-role` (cdkd publishes with caller credentials) and covers both asset-bucket names.
- **docs/architecture.md**: legacy-mode wording precision (marker-absent condition, not "default").

## Test plan

- [x] Docs-only diff (README.md + 3 docs files); `vp check` / build / 6543 unit tests green on the rebased branch.
- [x] Claims live-verified this session: `bootstrap-free-region` + `asset-auto-create` integs prove the "no cdk bootstrap" and "just deploy" stories against real AWS (see #1006 / #1008 test plans).
