### PR TITLE
docs(readme): shrink the Upgrading section to a summary + pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,30 +188,13 @@ That's it. cdkd reads `--app` from `cdk.json` and auto-resolves the state bucket
 
 ### Upgrading from an earlier cdkd version
 
-**There is no breaking change, and no manual step: just deploy.** The first `cdkd deploy` into each region auto-creates the cdkd-owned asset storage (asset bucket + ECR repo + per-region marker) — interactive runs are asked once per region (`[Y/n]`), `--yes` / CI runs create it automatically with an info line. Asset storage is per region because AWS requires Lambda code (S3) and container images (ECR) to live in the function's own region — the auto-create keys off each stack's `env.region`, so multi-region apps opt in region by region as they deploy. That deploy shows a one-time diff repointing `Code` / `Image` references to the cdkd storage — an ordinary in-place UPDATE (content identical, no replacement). `cdkd state info` shows which regions are opted in.
-
-Downgrading is equally safe: older binaries ignore the bootstrap marker and keep publishing to the CDK bootstrap destinations; both storages hold the same content-addressed objects.
-
-Prefer the explicit path (e.g. to pre-provision in CI before the first deploy)? The equivalent manual opt-in is:
-
-```bash
-cdkd bootstrap --region <r>   # re-run per region; the state bucket is left untouched (no --force)
-```
-
-To stay on CDK bootstrap storage instead:
-
-- `--no-auto-asset-storage` (or `cdk.json` `context.cdkd.autoAssetStorage: false`) skips the auto-create — deploys into un-opted-in regions stay in **legacy mode** (assets go to the CDK bootstrap bucket, byte-identical to older versions, plus a one-line `cdk gc`-hazard notice naming the region).
-- `--use-cdk-bootstrap-assets` (or `cdk.json` `context.cdkd.useCdkBootstrapAssets: true`) pins the legacy destinations even for opted-in regions — for apps deployed via both CloudFormation and cdkd during a migration window. Also suppresses the notice.
-
-Notes on the relationship with `cdk bootstrap`:
-
-- cdkd never uses CDK's bootstrap roles (it deploys with the caller's credentials)
-  and does not resolve the template's `BootstrapVersion` parameter, so a region
-  never touched by `cdk bootstrap` works fine.
-- `cdkd export` hands a stack back to the CloudFormation / CDK CLI world, where
-  `cdk bootstrap` is the CDK CLI's own prerequisite again.
-
-See [`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap) for details.
+**No breaking change, no manual step: just deploy.** The first `cdkd deploy` into
+each region auto-creates the cdkd-owned asset storage (interactive runs are asked
+once per region, `--yes` / CI runs create it automatically) and shows a one-time
+in-place UPDATE repointing asset references — content identical, no replacement.
+Downgrading is safe too (older binaries ignore the marker). Explicit pre-provisioning
+(`cdkd bootstrap --region <r>`), legacy-mode opt-outs, and how this relates to
+`cdk bootstrap`: see [`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap).
 
 ## Usage
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -972,6 +972,13 @@ breaks by upgrading the binary alone, and downgrading is safe in either
 mode (old binaries ignore the marker; both storages hold the same
 content-addressed objects).
 
+Relationship with `cdk bootstrap`: cdkd never uses CDK's bootstrap roles
+(it deploys with the caller's credentials) and does not resolve the
+template's `BootstrapVersion` parameter, so a region never touched by
+`cdk bootstrap` works fine. `cdkd export` hands a stack back to the
+CloudFormation / CDK CLI world, where `cdk bootstrap` is the CDK CLI's own
+prerequisite again.
+
 Bucket-squatting defense: bootstrap refuses to adopt an asset bucket owned
 by another account (predictable-name defense), and cdkd's asset-bucket S3
 calls pass `ExpectedBucketOwner`. Deleting the asset bucket/repo while the


### PR DESCRIPTION
## Summary

Follow-up to #1013 (user feedback): the "Upgrading from an earlier cdkd version" section near Quick Start had grown to ~25 lines. README now keeps an 8-line summary — no breaking change / just deploy / one-time repointing UPDATE / downgrade safe — and points at `docs/cli-reference.md#cdkd-bootstrap`, which already documents the auto-create behavior, both legacy-mode opt-outs, and the explicit `cdkd bootstrap --region <r>` path. The "relationship with `cdk bootstrap`" notes (no bootstrap roles / no `BootstrapVersion` resolution / `cdkd export` caveat) move into that cli-reference section instead of duplicating in the README.

## Test plan

- [x] Docs-only diff; `vp check` + 6543 unit tests green; link target verified.
