### PR TITLE
test(integ): add cdkd-asset-storage / cdkd-gc scenario tags and annotate the asset-storage fixtures

### DIFF
--- a/docs/_generated/scenario-coverage.json
+++ b/docs/_generated/scenario-coverage.json
@@ -21,6 +21,14 @@
       "description": "CDK-defensive route DependsOn relaxation for VPC Lambda parallelization."
     },
     {
+      "tag": "cdkd-asset-storage",
+      "description": "cdkd-owned asset storage lifecycle against real AWS: `cdkd bootstrap` creates the asset bucket + container repo + per-region marker (default or custom `--asset-bucket` / `--container-repo` names), deploy-time asset-mode detection + publish redirection into the marker-named storage, and `cdkd bootstrap --destroy` marker-driven teardown with zero residue (issues #1002 / #1007 / #1010 / #1011)."
+    },
+    {
+      "tag": "cdkd-gc",
+      "description": "`cdkd gc` garbage-collection precision against real AWS: whole-bucket state-file reference scan keeps every referenced asset, an unreferenced seeded object is the only deletion candidate, `--dry-run` deletes nothing, `--older-than` age guard honored (issue #1012)."
+    },
+    {
       "tag": "cfn-macro-expansion",
       "description": "CloudFormation macro / `Fn::Transform` expansion via transient CFn changeset round-trip (SAM, AWS::Include, AWS::LanguageExtensions, custom macros). See `docs/design/463-cfn-macros.md`."
     },
@@ -344,18 +352,24 @@
     },
     {
       "name": "asset-auto-create",
-      "annotated": false,
-      "scenarios": []
+      "annotated": true,
+      "scenarios": [
+        "cdkd-asset-storage"
+      ]
     },
     {
       "name": "asset-bootstrap",
-      "annotated": false,
-      "scenarios": []
+      "annotated": true,
+      "scenarios": [
+        "cdkd-asset-storage"
+      ]
     },
     {
       "name": "asset-migration",
-      "annotated": false,
-      "scenarios": []
+      "annotated": true,
+      "scenarios": [
+        "cdkd-asset-storage"
+      ]
     },
     {
       "name": "aws-custom-resource",
@@ -798,7 +812,10 @@
     {
       "name": "gc-custom-asset-names",
       "annotated": true,
-      "scenarios": []
+      "scenarios": [
+        "cdkd-asset-storage",
+        "cdkd-gc"
+      ]
     },
     {
       "name": "getstackoutput-crossregion",
@@ -1692,6 +1709,23 @@
       ]
     },
     {
+      "scenario": "cdkd-asset-storage",
+      "description": "cdkd-owned asset storage lifecycle against real AWS: `cdkd bootstrap` creates the asset bucket + container repo + per-region marker (default or custom `--asset-bucket` / `--container-repo` names), deploy-time asset-mode detection + publish redirection into the marker-named storage, and `cdkd bootstrap --destroy` marker-driven teardown with zero residue (issues #1002 / #1007 / #1010 / #1011).",
+      "fixtures": [
+        "asset-auto-create",
+        "asset-bootstrap",
+        "asset-migration",
+        "gc-custom-asset-names"
+      ]
+    },
+    {
+      "scenario": "cdkd-gc",
+      "description": "`cdkd gc` garbage-collection precision against real AWS: whole-bucket state-file reference scan keeps every referenced asset, an unreferenced seeded object is the only deletion candidate, `--dry-run` deletes nothing, `--older-than` age guard honored (issue #1012).",
+      "fixtures": [
+        "gc-custom-asset-names"
+      ]
+    },
+    {
       "scenario": "cfn-macro-expansion",
       "description": "CloudFormation macro / `Fn::Transform` expansion via transient CFn changeset round-trip (SAM, AWS::Include, AWS::LanguageExtensions, custom macros). See `docs/design/463-cfn-macros.md`.",
       "fixtures": [
@@ -2211,9 +2245,6 @@
     "apigw-stage-throttling",
     "apigw-usage-plan-key",
     "appconfig",
-    "asset-auto-create",
-    "asset-bootstrap",
-    "asset-migration",
     "aws-custom-resource",
     "backup",
     "bootstrap-free-region",

--- a/docs/scenario-coverage.md
+++ b/docs/scenario-coverage.md
@@ -4,7 +4,7 @@
 
 Run `vp run scenario-coverage` to regenerate.
 
-**72 / 72 canonical scenarios** have at least one integ fixture exercising them. **152 / 231 integ fixtures** carry a `.scenarios.json` sidecar (with 0+ tags); the rest are un-annotated and contributor-reviewed below.
+**74 / 74 canonical scenarios** have at least one integ fixture exercising them. **155 / 231 integ fixtures** carry a `.scenarios.json` sidecar (with 0+ tags); the rest are un-annotated and contributor-reviewed below.
 
 ## How this is computed
 
@@ -26,7 +26,7 @@ This report is a visibility tool, not a commit-time gate. Many cdkd fixtures leg
 
 _None._ Every canonical scenario has at least one integ fixture tagged with it.
 
-## Per-scenario coverage (72 scenarios)
+## Per-scenario coverage (74 scenarios)
 
 | Scenario | Description | Integ Fixture(s) |
 |---|---|---|
@@ -35,6 +35,8 @@ _None._ Every canonical scenario has at least one integ fixture tagged with it.
 | `cc-api-getatt-enrichment-opensearch-domain` | CC-API attribute enrichment for `AWS::OpenSearchService::Domain` (no SDK provider): `Fn::GetAtt(<Domain>, DomainEndpoint / Arn)` must resolve to the real `*.es.amazonaws.com` endpoint / `arn:aws:es:...:domain/...` ARN via DescribeDomain, not fall through to the physicalId (the domain name). | [`opensearch-domain-getatt`](../tests/integration/opensearch-domain-getatt/) |
 | `cc-api-getatt-enrichment-redshift-cluster` | CC-API attribute enrichment for `AWS::Redshift::Cluster` (no SDK provider): `Fn::GetAtt(<Cluster>, Endpoint.Address / Endpoint.Port)` must resolve to the real Redshift endpoint via DescribeClusters, not fall through to the physicalId (the cluster id). | [`redshift-cluster-getatt`](../tests/integration/redshift-cluster-getatt/) |
 | `cdk-defensive-vpc-deps-relax` | CDK-defensive route DependsOn relaxation for VPC Lambda parallelization. | [`bench-cdk-sample`](../tests/integration/bench-cdk-sample/) |
+| `cdkd-asset-storage` | cdkd-owned asset storage lifecycle against real AWS: `cdkd bootstrap` creates the asset bucket + container repo + per-region marker (default or custom `--asset-bucket` / `--container-repo` names), deploy-time asset-mode detection + publish redirection into the marker-named storage, and `cdkd bootstrap --destroy` marker-driven teardown with zero residue (issues #1002 / #1007 / #1010 / #1011). | [`asset-auto-create`](../tests/integration/asset-auto-create/)<br>[`asset-bootstrap`](../tests/integration/asset-bootstrap/)<br>[`asset-migration`](../tests/integration/asset-migration/)<br>[`gc-custom-asset-names`](../tests/integration/gc-custom-asset-names/) |
+| `cdkd-gc` | `cdkd gc` garbage-collection precision against real AWS: whole-bucket state-file reference scan keeps every referenced asset, an unreferenced seeded object is the only deletion candidate, `--dry-run` deletes nothing, `--older-than` age guard honored (issue #1012). | [`gc-custom-asset-names`](../tests/integration/gc-custom-asset-names/) |
 | `cfn-macro-expansion` | CloudFormation macro / `Fn::Transform` expansion via transient CFn changeset round-trip (SAM, AWS::Include, AWS::LanguageExtensions, custom macros). See `docs/design/463-cfn-macros.md`. | [`macro-expansion`](../tests/integration/macro-expansion/) |
 | `cloudfront-oai-attribute-enrichment` | CloudFront OAI `S3CanonicalUserId` attribute enrichment (the attribute is not on `GetCloudFrontOriginAccessIdentity` directly). | [`s3-cloudfront`](../tests/integration/s3-cloudfront/) |
 | `conditions-and-if` | CloudFormation Conditions section + resource-level `Condition:` key + `Fn::If` / `Fn::Equals` / `Fn::And` / `Fn::Or` / `Fn::Not` evaluated by cdkd itself. Two deploys flip a CDK-context-driven CfnParameter Default so the SAME stack is asserted in both settings: condition-gated resource creation (PRESENT vs ABSENT on AWS), `Fn::If` property + tag branch values reaching AWS, and `Fn::If` -> `AWS::NoValue` genuinely OMITTING a property. | [`conditions-and-if`](../tests/integration/conditions-and-if/) |
@@ -103,7 +105,7 @@ _None._ Every canonical scenario has at least one integ fixture tagged with it.
 | `vpc-lambda-eni-release` | Lambda hyperplane ENI cleanup after DeleteFunction (5-30 min eventually consistent). | [`bench-cdk-sample`](../tests/integration/bench-cdk-sample/)<br>[`destroy-interrupt`](../tests/integration/destroy-interrupt/)<br>[`lambda`](../tests/integration/lambda/)<br>[`vpc-lambda`](../tests/integration/vpc-lambda/) |
 | `wide-dag-throttle-retry` | Wide (~100-resource: 80 SSM Parameters + 10 IAM Roles + 10 SNS Topics, 10-deep SSM Fn::Sub chain) single-stack burst deployed under a HIGH `--concurrency` to stress the concurrency limiter + event-driven DAG executor + throttle/retry classifier: a `TooManyRequests` / `Rate exceeded` / HTTP 429 during the burst must be RETRIED (deploy still succeeds) not fatal, the chained subset proves strict DAG ordering, and the destroy burst absorbs ~100 deletes with 0 orphans. | [`throttle-wide-dag`](../tests/integration/throttle-wide-dag/) |
 
-## Un-annotated fixtures (79)
+## Un-annotated fixtures (76)
 
 These integ fixtures have no `.scenarios.json` sidecar. They may or may not exercise a canonical scenario — contributor review needed. To opt out (per-service smoke tests with no canonical pattern), add a sidecar with `{ "scenarios": [] }`.
 
@@ -111,9 +113,6 @@ These integ fixtures have no `.scenarios.json` sidecar. They may or may not exer
 - [`apigw-stage-throttling`](../tests/integration/apigw-stage-throttling/)
 - [`apigw-usage-plan-key`](../tests/integration/apigw-usage-plan-key/)
 - [`appconfig`](../tests/integration/appconfig/)
-- [`asset-auto-create`](../tests/integration/asset-auto-create/)
-- [`asset-bootstrap`](../tests/integration/asset-bootstrap/)
-- [`asset-migration`](../tests/integration/asset-migration/)
 - [`aws-custom-resource`](../tests/integration/aws-custom-resource/)
 - [`backup`](../tests/integration/backup/)
 - [`bootstrap-free-region`](../tests/integration/bootstrap-free-region/)

--- a/scripts/build-scenario-coverage-matrix.ts
+++ b/scripts/build-scenario-coverage-matrix.ts
@@ -274,6 +274,12 @@ const KNOWN_SCENARIOS: Record<string, string> = {
     '`cdkd local invoke-agentcore` Bedrock AgentCore Runtime: HTTP `/invocations` / MCP `/mcp` / A2A `/a2a` / AGUI / WebSocket `--ws` protocols + inbound JWT auth verification + container artifact + CodeConfiguration managed-runtime source build.',
   'local-agentcore-from-state':
     '`cdkd local invoke-agentcore --from-state` end-to-end against a real-AWS deployed AgentCore Runtime — verifies the cdkd-port-specific 3-arg `createLocalStateProvider` shim resolves intrinsic-valued env vars (e.g. `Ref: <S3 bucket>`) against cdkd state after a real `cdkd deploy`.',
+
+  // ---- cdkd-owned asset storage / gc patterns ----
+  'cdkd-asset-storage':
+    'cdkd-owned asset storage lifecycle against real AWS: `cdkd bootstrap` creates the asset bucket + container repo + per-region marker (default or custom `--asset-bucket` / `--container-repo` names), deploy-time asset-mode detection + publish redirection into the marker-named storage, and `cdkd bootstrap --destroy` marker-driven teardown with zero residue (issues #1002 / #1007 / #1010 / #1011).',
+  'cdkd-gc':
+    '`cdkd gc` garbage-collection precision against real AWS: whole-bucket state-file reference scan keeps every referenced asset, an unreferenced seeded object is the only deletion candidate, `--dry-run` deletes nothing, `--older-than` age guard honored (issue #1012).',
 };
 
 interface ScenarioCoverageReport {

--- a/tests/integration/asset-auto-create/.scenarios.json
+++ b/tests/integration/asset-auto-create/.scenarios.json
@@ -1,0 +1,3 @@
+{
+  "scenarios": ["cdkd-asset-storage"]
+}

--- a/tests/integration/asset-bootstrap/.scenarios.json
+++ b/tests/integration/asset-bootstrap/.scenarios.json
@@ -1,0 +1,3 @@
+{
+  "scenarios": ["cdkd-asset-storage"]
+}

--- a/tests/integration/asset-migration/.scenarios.json
+++ b/tests/integration/asset-migration/.scenarios.json
@@ -1,0 +1,3 @@
+{
+  "scenarios": ["cdkd-asset-storage"]
+}

--- a/tests/integration/gc-custom-asset-names/.scenarios.json
+++ b/tests/integration/gc-custom-asset-names/.scenarios.json
@@ -1,3 +1,3 @@
 {
-  "scenarios": []
+  "scenarios": ["cdkd-asset-storage", "cdkd-gc"]
 }


### PR DESCRIPTION
## Summary

Adds two canonical `KNOWN_SCENARIOS` entries to `scripts/build-scenario-coverage-matrix.ts` so the cdkd-owned asset-storage feature area is visible in the scenario-coverage report:

- `cdkd-asset-storage` — bootstrap marker + default/custom names + publish redirection + `bootstrap --destroy` teardown (issues #1002 / #1007 / #1010 / #1011)
- `cdkd-gc` — `cdkd gc` reference-scan precision + age guard + dry-run semantics (issue #1012)

Tags the sidecars of the four fixtures that exercise them (`gc-custom-asset-names` gets both; `asset-bootstrap` / `asset-auto-create` / `asset-migration` get `cdkd-asset-storage`) and regenerates the matrices.

## Verification

`vp run scenario-coverage` validates every sidecar tag against `KNOWN_SCENARIOS` at parse time and passed: 74/74 scenarios covered, 155/231 fixtures annotated, 0 orphan tags. Docs/tooling-only change — no runtime code.

Closes #1051
