### PR TITLE
test(integ): fail fast on a foreign bootstrap marker instead of deleting live asset storage

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -215,7 +215,6 @@ launchtemplate-asg-inplace	2026-07-03T09:30:15Z	PASS	64	verify.sh	in-place GetAt
 dynamodb-streams	2026-07-03T10:26:01Z	PASS	86	verify.sh	OnDemand/Warm wait follow-up; destroy clean
 backup	2026-07-03T11:11:09Z	PASS	58	verify.sh	Ref on BackupSelection returns bare SelectionId (#995); destroy clean
 bench-cdk-sample	2026-07-03T11:11:09Z	PASS	578	standard	broad for #995 intrinsic-resolver change; 39 created/37 del+2 retain 0 err
-asset-bootstrap	2026-07-15T01:59:00Z	PASS	88	verify.sh	new #1002 PR1 fixture: legacy notice, bootstrap storage+marker, cdkd-assets detect, deleted-repo hard error, clean destroy
 bootstrap-free-region	2026-07-16T15:34:01Z	PASS	81	verify.sh	re-run after PR 1015 review fix-back (region-resolver owner header), 0 orphans
 ses-identity	2026-07-16T15:54:15Z	PASS	182	verify.sh	new fixture, 3 phases clean, orph clean
 eventbridge-archive	2026-07-16T15:54:15Z	PASS	53	verify.sh	new fixture, 3 phases clean, orph clean
@@ -232,3 +231,4 @@ gc-custom-asset-names	2026-07-16T17:50:46Z	PASS	188	verify.sh	us-west-2 (us-east
 gc-custom-asset-names	2026-07-16T18:11:36Z	PASS	169	verify.sh	us-west-2; re-run after review hardening (own-marker guard); clean
 asset-auto-create	2026-07-17T06:52:34Z	PASS	150	verify.sh	ca-central-1; own-marker guard + prerun-scoped cleanup (issue-1052); 0 orphans
 asset-migration	2026-07-17T06:59:52Z	PASS	780	verify.sh	us-west-2; own-marker guard + no-auto-asset-storage phase-1 fix (issue-1052); nested+ECR legs; 0 orphans
+asset-bootstrap	2026-07-17T07:11:51Z	PASS	120	verify.sh	us-west-2; own-marker guard + no-auto-asset-storage phase-1 + state-info cross-region fix (1054); 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -216,8 +216,6 @@ dynamodb-streams	2026-07-03T10:26:01Z	PASS	86	verify.sh	OnDemand/Warm wait follo
 backup	2026-07-03T11:11:09Z	PASS	58	verify.sh	Ref on BackupSelection returns bare SelectionId (#995); destroy clean
 bench-cdk-sample	2026-07-03T11:11:09Z	PASS	578	standard	broad for #995 intrinsic-resolver change; 39 created/37 del+2 retain 0 err
 asset-bootstrap	2026-07-15T01:59:00Z	PASS	88	verify.sh	new #1002 PR1 fixture: legacy notice, bootstrap storage+marker, cdkd-assets detect, deleted-repo hard error, clean destroy
-asset-migration	2026-07-15T05:59:16Z	PASS	800	verify.sh	PR2 #1002 final: +skip-assets phase +opt-out child assert; repoint incl nested+ECR; destroy clean
-asset-auto-create	2026-07-16T14:11:56Z	PASS	149	verify.sh	3 phases incl. --skip-assets no-auto-create leg (PR 1008 review fix-back), 0 orphans
 bootstrap-free-region	2026-07-16T15:34:01Z	PASS	81	verify.sh	re-run after PR 1015 review fix-back (region-resolver owner header), 0 orphans
 ses-identity	2026-07-16T15:54:15Z	PASS	182	verify.sh	new fixture, 3 phases clean, orph clean
 eventbridge-archive	2026-07-16T15:54:15Z	PASS	53	verify.sh	new fixture, 3 phases clean, orph clean
@@ -232,3 +230,5 @@ multi-resource	2026-07-17T05:02:58Z	PASS	79	standard	broad refresh for deploy-en
 local-run-task-cdkd-assets	2026-07-16T17:53:49Z	PASS	95	verify.sh	classifier regression for issue-1025 marker-based repo match; docker sweep clean
 gc-custom-asset-names	2026-07-16T17:50:46Z	PASS	188	verify.sh	us-west-2 (us-east-1 marker in use); bootstrap custom names + publish + gc + teardown clean
 gc-custom-asset-names	2026-07-16T18:11:36Z	PASS	169	verify.sh	us-west-2; re-run after review hardening (own-marker guard); clean
+asset-auto-create	2026-07-17T06:52:34Z	PASS	150	verify.sh	ca-central-1; own-marker guard + prerun-scoped cleanup (issue-1052); 0 orphans
+asset-migration	2026-07-17T06:59:52Z	PASS	780	verify.sh	us-west-2; own-marker guard + no-auto-asset-storage phase-1 fix (issue-1052); nested+ECR legs; 0 orphans

--- a/tests/integration/asset-auto-create/verify.sh
+++ b/tests/integration/asset-auto-create/verify.sh
@@ -6,7 +6,13 @@
 #
 #   Guard:   the target region must have neither the CDK bootstrap SSM
 #            parameter nor the CDK bootstrap asset bucket, and no cdkd
-#            bootstrap marker (pre-run cleanup removes one if present).
+#            bootstrap marker — a pre-existing marker means the region's
+#            default-named asset storage is genuinely in use (real assets
+#            may live there since #1002 PR 2), so the fixture fails fast
+#            instead of deleting it (issue #1052). The guard makes the
+#            EXIT-trap cleanup safe: any marker/bucket/repo present at
+#            exit was created by THIS run. The pre-run cleanup pass only
+#            deletes stack-scoped leftovers.
 #   Phase 1: deploy with --yes and NO prior bootstrap -> the auto-create
 #            info line + bucket/repo/marker creation appear in the deploy
 #            output; no legacy `cdk gc` notice; Lambda Code.S3Bucket points
@@ -45,7 +51,12 @@ CONTAINER_REPO="cdkd-container-assets-${ACCOUNT_ID}-${REGION}"
 CDK_SSM_PARAM="/cdk-bootstrap/hnb659fds/version"
 
 cleanup() {
-  echo "==> Cleanup: dropping stack state/resources + asset storage + marker"
+  # $1 = "prerun" skips the asset-storage deletion: a marker/bucket/repo
+  # that exists BEFORE this run is live storage we must not delete (the
+  # marker guard below fails fast on it instead). Without the arg (EXIT
+  # trap), asset storage is cleaned too — the guard guarantees anything
+  # present at exit was created by this run (issue #1052).
+  echo "==> Cleanup: dropping stack state/resources${1:+ (stack-scoped only)}"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
@@ -55,13 +66,17 @@ cleanup() {
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/" --recursive >/dev/null 2>&1 || true
-    aws s3 rm "s3://${STATE_BUCKET}/${MARKER_KEY}" >/dev/null 2>&1 || true
   fi
-  # Canonical per-region cdkd asset storage on the dedicated test account —
-  # objects are content-addressed and re-publishable, so force-remove.
-  aws s3 rb "s3://${ASSET_BUCKET}" --force >/dev/null 2>&1 || true
-  aws ecr delete-repository --repository-name "${CONTAINER_REPO}" \
-    --region "${REGION}" --force >/dev/null 2>&1 || true
+  if [ "${1:-}" != "prerun" ]; then
+    if [ -n "${STATE_BUCKET:-}" ]; then
+      aws s3 rm "s3://${STATE_BUCKET}/${MARKER_KEY}" >/dev/null 2>&1 || true
+    fi
+    # Storage created by THIS run (auto-create) — objects are
+    # content-addressed and re-publishable, so force-remove.
+    aws s3 rb "s3://${ASSET_BUCKET}" --force >/dev/null 2>&1 || true
+    aws ecr delete-repository --repository-name "${CONTAINER_REPO}" \
+      --region "${REGION}" --force >/dev/null 2>&1 || true
+  fi
   aws logs describe-log-groups --log-group-name-prefix "/aws/lambda/${STACK}" \
     --region "${REGION}" --query 'logGroups[].logGroupName' --output text 2>/dev/null |
     tr '\t' '\n' | while read -r lg; do
@@ -94,13 +109,24 @@ if aws s3api head-bucket --bucket "cdk-hnb659fds-assets-${ACCOUNT_ID}-${REGION}"
 fi
 echo "    OK: ${REGION} is cdk-bootstrap-free"
 
+# Own-marker guard (issue #1052): a pre-existing cdkd bootstrap marker means
+# the region's default-named asset storage is genuinely in use — this
+# fixture creates AND deletes that storage, so never proceed over it.
+if aws s3 cp "s3://${STATE_BUCKET}/${MARKER_KEY}" - >/dev/null 2>&1; then
+  echo "FAIL: region ${REGION} already has a cdkd bootstrap marker (live asset storage)." >&2
+  echo "      Pick a marker-free region via CDKD_AUTO_CREATE_REGION." >&2
+  echo "      If this is a leftover from a previous crashed run of this fixture, clean it" >&2
+  echo "      up first: node dist/cli.js bootstrap --destroy --region ${REGION} --yes" >&2
+  exit 1
+fi
+
 echo "==> Installing fixture deps"
 if [ ! -d node_modules ]; then
   pnpm install --ignore-workspace --prefer-offline
 fi
 
-echo "==> Pre-run cleanup"
-cleanup
+echo "==> Pre-run cleanup (stack-scoped only)"
+cleanup prerun
 
 GC_NOTICE="may garbage-collect"
 AUTO_CREATE_LINE="Creating cdkd asset storage for region '${REGION}'"

--- a/tests/integration/asset-bootstrap/verify.sh
+++ b/tests/integration/asset-bootstrap/verify.sh
@@ -123,9 +123,15 @@ GC_NOTICE="may garbage-collect"
 
 # --- Phase 1: deploy WITHOUT marker (legacy mode) -------------------------
 echo "==> Phase 1: deploy without marker (legacy mode expected)"
+# --no-auto-asset-storage: since issue #1007 a --yes deploy into an
+# un-opted-in region AUTO-CREATES the asset storage instead of falling
+# back to legacy mode — this phase tests the legacy fallback + gc notice,
+# so auto-create must be disabled (the auto-create path has its own
+# fixture, asset-auto-create).
 DEPLOY_OUT=$(node "${LOCAL_DIST}" deploy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" \
   --region "${REGION}" \
+  --no-auto-asset-storage \
   --yes 2>&1)
 echo "${DEPLOY_OUT}" | tail -3
 

--- a/tests/integration/asset-bootstrap/verify.sh
+++ b/tests/integration/asset-bootstrap/verify.sh
@@ -17,11 +17,15 @@
 #            the re-bootstrap fix (never a silent legacy fallback).
 #   Cleanup: destroy the stack, delete marker + asset bucket + repo.
 #
-# NOTE: cleanup deletes the account's CANONICAL cdkd asset storage
-# (cdkd-assets-{account}-{region} + repo + marker) — safe on the dedicated
-# test account while PR 1 storage holds no objects, but once PR 2 publishes
-# real assets there, re-point this fixture at a dedicated marker/bucket or
-# gate the deletion on the bucket being empty.
+# SAFETY NOTE (issue #1052): this fixture exercises the region's CANONICAL
+# default-named cdkd asset storage (cdkd-assets-{account}-{region} + repo +
+# marker), so it must only run in a region whose marker does not exist yet.
+# A pre-run guard fails fast when the region already carries a bootstrap
+# marker (it belongs to live storage this fixture must not delete — pick a
+# marker-free region via AWS_REGION). The guard makes the EXIT-trap cleanup
+# safe: any marker/bucket/repo present at exit was created by THIS run.
+# The pre-run cleanup pass deletes only stack-scoped leftovers and never
+# touches asset storage.
 #
 # Required env vars:
 #   STATE_BUCKET - cdkd state bucket (e.g. cdkd-state-{accountId})
@@ -43,7 +47,12 @@ ASSET_BUCKET="cdkd-assets-${ACCOUNT_ID}-${REGION}"
 CONTAINER_REPO="cdkd-container-assets-${ACCOUNT_ID}-${REGION}"
 
 cleanup() {
-  echo "==> Cleanup: dropping stack state/resources + asset storage + marker"
+  # $1 = "prerun" skips the asset-storage deletion: a marker/bucket/repo
+  # that exists BEFORE this run is live storage we must not delete (the
+  # guard below fails fast on it instead). Without the arg (EXIT trap),
+  # asset storage is cleaned too — the guard guarantees anything present
+  # at exit was created by this run.
+  echo "==> Cleanup: dropping stack state/resources${1:+ (stack-scoped only)}"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
@@ -55,13 +64,17 @@ cleanup() {
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1 || true
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/" --recursive >/dev/null 2>&1 || true
-    aws s3 rm "s3://${STATE_BUCKET}/${MARKER_KEY}" >/dev/null 2>&1 || true
   fi
-  # The PR-1 asset bucket is never written to (redirection is PR 2), so a
-  # plain delete-bucket suffices; --force also clears any future objects.
-  aws s3 rb "s3://${ASSET_BUCKET}" --force >/dev/null 2>&1 || true
-  aws ecr delete-repository --repository-name "${CONTAINER_REPO}" \
-    --region "${REGION}" --force >/dev/null 2>&1 || true
+  if [ "${1:-}" != "prerun" ]; then
+    if [ -n "${STATE_BUCKET:-}" ]; then
+      aws s3 rm "s3://${STATE_BUCKET}/${MARKER_KEY}" >/dev/null 2>&1 || true
+    fi
+    # The PR-1 asset bucket is never written to (redirection is PR 2), so a
+    # plain delete-bucket suffices; --force also clears any future objects.
+    aws s3 rb "s3://${ASSET_BUCKET}" --force >/dev/null 2>&1 || true
+    aws ecr delete-repository --repository-name "${CONTAINER_REPO}" \
+      --region "${REGION}" --force >/dev/null 2>&1 || true
+  fi
   # Lambda deploys leave no log group here (the function is never invoked),
   # but sweep defensively per the fixture template.
   aws logs describe-log-groups --log-group-name-prefix "/aws/lambda/${STACK}" \
@@ -89,8 +102,22 @@ if [ ! -d node_modules ]; then
   pnpm install --ignore-workspace --prefer-offline
 fi
 
-echo "==> Pre-run cleanup"
-cleanup
+echo "==> Pre-run cleanup (stack-scoped only)"
+cleanup prerun
+
+# Own-marker guard (issue #1052): this fixture bootstraps and then DELETES
+# the region's default-named asset storage, so a pre-existing marker means
+# the region's storage is genuinely in use (real assets may live there since
+# #1002 PR 2) — never delete it. Fail fast and let the caller pick a
+# marker-free region.
+if aws s3 cp "s3://${STATE_BUCKET}/${MARKER_KEY}" - >/dev/null 2>&1; then
+  echo "FAIL: region ${REGION} already has a cdkd bootstrap marker (live asset storage)." >&2
+  echo "      This fixture creates AND deletes the region's default-named storage;" >&2
+  echo "      run it in a region without cdkd asset storage (e.g. AWS_REGION=us-west-2)." >&2
+  echo "      If this is a leftover from a previous crashed run of this fixture, clean it" >&2
+  echo "      up first: node dist/cli.js bootstrap --destroy --region ${REGION} --yes" >&2
+  exit 1
+fi
 
 GC_NOTICE="may garbage-collect"
 

--- a/tests/integration/asset-migration/verify.sh
+++ b/tests/integration/asset-migration/verify.sh
@@ -19,10 +19,15 @@
 #            pushes to cdkd-container-assets-* and Lambda pulls it from there.
 #   Phase 6: destroy everything, sweep log groups, delete marker + storage.
 #
-# NOTE: cleanup deletes the account's CANONICAL cdkd asset storage
-# (cdkd-assets-{account}-{region} + repo + marker) — fine on the dedicated
-# test account: assets are content-addressed and re-publishable, and no
-# deployed stack survives this run.
+# SAFETY NOTE (issue #1052): this fixture opts the region into cdkd asset
+# storage and DELETES the default-named storage on exit. A pre-run guard
+# fails fast when the region already carries a cdkd bootstrap marker —
+# that marker belongs to live storage (real assets may live there since
+# #1002 PR 2) that this fixture must not delete; pick a marker-free region
+# via AWS_REGION. The guard makes the EXIT-trap cleanup safe: any
+# marker/bucket/repo present at exit was created by THIS run (assets are
+# content-addressed and re-publishable, and no deployed stack survives the
+# run). The pre-run cleanup pass only deletes stack-scoped leftovers.
 #
 # Required env vars:
 #   STATE_BUCKET - cdkd state bucket (e.g. cdkd-state-{accountId})
@@ -45,7 +50,12 @@ CDKD_BUCKET="cdkd-assets-${ACCOUNT_ID}-${REGION}"
 CDKD_REPO="cdkd-container-assets-${ACCOUNT_ID}-${REGION}"
 
 cleanup() {
-  echo "==> Cleanup: dropping stacks + asset storage + marker"
+  # $1 = "prerun" skips the asset-storage deletion: a marker/bucket/repo
+  # that exists BEFORE this run is live storage we must not delete (the
+  # marker guard below fails fast on it instead). Without the arg (EXIT
+  # trap), asset storage is cleaned too — the guard guarantees anything
+  # present at exit was created by this run (issue #1052).
+  echo "==> Cleanup: dropping stacks${1:+ (stack-scoped only)}"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
     for s in "${IMAGE_STACK}" "${STACK}"; do
@@ -63,12 +73,16 @@ cleanup() {
       --query 'Contents[].Key' --output text 2>/dev/null | tr '\t' '\n' | while read -r key; do
       [ -n "${key}" ] && aws s3 rm "s3://${STATE_BUCKET}/${key}" >/dev/null 2>&1
     done
-    aws s3 rm "s3://${STATE_BUCKET}/${MARKER_KEY}" >/dev/null 2>&1 || true
   fi
-  # Canonical cdkd asset storage — content-addressed, re-publishable.
-  aws s3 rb "s3://${CDKD_BUCKET}" --force >/dev/null 2>&1 || true
-  aws ecr delete-repository --repository-name "${CDKD_REPO}" \
-    --region "${REGION}" --force >/dev/null 2>&1 || true
+  if [ "${1:-}" != "prerun" ]; then
+    if [ -n "${STATE_BUCKET:-}" ]; then
+      aws s3 rm "s3://${STATE_BUCKET}/${MARKER_KEY}" >/dev/null 2>&1 || true
+    fi
+    # Storage created by THIS run — content-addressed, re-publishable.
+    aws s3 rb "s3://${CDKD_BUCKET}" --force >/dev/null 2>&1 || true
+    aws ecr delete-repository --repository-name "${CDKD_REPO}" \
+      --region "${REGION}" --force >/dev/null 2>&1 || true
+  fi
   # Functional invokes create /aws/lambda/* log groups — sweep them.
   aws logs describe-log-groups --log-group-name-prefix "/aws/lambda/CdkdAssetMigration" \
     --region "${REGION}" --query 'logGroups[].logGroupName' --output text 2>/dev/null |
@@ -95,8 +109,20 @@ if [ ! -d node_modules ]; then
   pnpm install --ignore-workspace --prefer-offline
 fi
 
-echo "==> Pre-run cleanup"
-cleanup
+echo "==> Pre-run cleanup (stack-scoped only)"
+cleanup prerun
+
+# Own-marker guard (issue #1052): this fixture opts the region in and then
+# deletes the default-named asset storage — never proceed over a
+# pre-existing marker (it belongs to live storage).
+if aws s3 cp "s3://${STATE_BUCKET}/${MARKER_KEY}" - >/dev/null 2>&1; then
+  echo "FAIL: region ${REGION} already has a cdkd bootstrap marker (live asset storage)." >&2
+  echo "      This fixture bootstraps AND deletes the region's default-named storage;" >&2
+  echo "      run it in a CDK-bootstrapped region without a cdkd marker (via AWS_REGION)." >&2
+  echo "      If this is a leftover from a previous crashed run of this fixture, clean it" >&2
+  echo "      up first: node dist/cli.js bootstrap --destroy --region ${REGION} --yes" >&2
+  exit 1
+fi
 
 GC_NOTICE="may garbage-collect"
 

--- a/tests/integration/asset-migration/verify.sh
+++ b/tests/integration/asset-migration/verify.sh
@@ -149,8 +149,11 @@ handler_function_name() {
 
 # --- Phase 1: deploy WITHOUT marker (legacy destinations) -------------------
 echo "==> Phase 1: deploy without marker (legacy: CDK bootstrap destinations)"
+# --no-auto-asset-storage: since issue #1007 a --yes deploy into an
+# un-opted-in region AUTO-CREATES the asset storage instead of publishing
+# to the legacy CDK bootstrap destinations this phase asserts.
 DEPLOY_OUT=$(node "${LOCAL_DIST}" deploy "${STACK}" \
-  --state-bucket "${STATE_BUCKET}" --region "${REGION}" --yes 2>&1)
+  --state-bucket "${STATE_BUCKET}" --region "${REGION}" --no-auto-asset-storage --yes 2>&1)
 echo "${DEPLOY_OUT}" | tail -3
 echo "${DEPLOY_OUT}" | grep -qF "${GC_NOTICE}" ||
   { echo "FAIL: legacy-mode deploy did not print the gc-hazard notice" >&2; exit 1; }


### PR DESCRIPTION
## Summary

The `asset-bootstrap`, `asset-auto-create`, and `asset-migration` fixtures unconditionally deleted the region's default-named cdkd asset storage (bucket + container repo + bootstrap marker) in their pre-run and EXIT-trap cleanup. Since #1002 PR 2 that storage can hold real assets referenced by deployed stacks — running any of these fixtures in a region with live storage (e.g. us-east-1 on the test account today) would have force-destroyed it. The fixture's own header flagged this time bomb; the condition has arrived.

Per-fixture hardening (mirrors the `gc-custom-asset-names` reference pattern from PR #1030):

- **Pre-run cleanup is stack-scoped only** — `cleanup` takes a `prerun` arg that skips all asset-storage deletion.
- **Own-marker guard** — a pre-existing bootstrap marker at pre-run time means the region's storage is genuinely in use, so the fixture fails fast with region-picking guidance instead of deleting it. The guard makes the EXIT-trap full cleanup safe: anything present at exit was created by that run.
- **Staleness fix surfaced by the runs**: since #1007 a `--yes` deploy into an un-opted-in region AUTO-CREATES the asset storage, so the "legacy mode + gc notice" Phase 1 of `asset-bootstrap` / `asset-migration` had been silently broken on main (last green runs predate #1007). Both phases now pass `--no-auto-asset-storage`.

## Live runs (all three fixtures, real AWS, marker-free regions)

- `asset-auto-create` — PASS in ca-central-1 (all 3 phases incl. the expected legacy-publish failure legs; 0 orphans).
- `asset-migration` — PASS in us-west-2 (legacy deploy, migration diff, in-place repoint incl. nested child + ECR leg, opt-out round-trip, clean destroy; 0 orphans).
- `asset-bootstrap` — PASS in us-west-2 (legacy notice, bootstrap storage + marker, cdkd-assets detection, deleted-repo hard error, clean destroy; 0 orphans). The first attempt surfaced a REAL cdkd bug — `state info` dying with `PermanentRedirect` when AWS_REGION differs from the state bucket's region — fixed and merged separately as #1054 / PR #1055; this fixture's Phase 2 `state info --json` assertion now exercises that fix cross-region.

Ledger rows for all three runs are committed.

Closes #1052
