### PR TITLE
test(integ): assert zero drift on freshly-deployed DLM lifecycle policy

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -232,7 +232,6 @@ gc-custom-asset-names	2026-07-16T18:11:36Z	PASS	169	verify.sh	us-west-2; re-run 
 asset-auto-create	2026-07-17T06:52:34Z	PASS	150	verify.sh	ca-central-1; own-marker guard + prerun-scoped cleanup (issue-1052); 0 orphans
 asset-migration	2026-07-17T06:59:52Z	PASS	780	verify.sh	us-west-2; own-marker guard + no-auto-asset-storage phase-1 fix (issue-1052); nested+ECR legs; 0 orphans
 asset-bootstrap	2026-07-17T07:11:51Z	PASS	120	verify.sh	us-west-2; own-marker guard + no-auto-asset-storage phase-1 + state-info cross-region fix (1054); 0 orphans
-dlm-lifecycle-policy	2026-07-17T07:27:24Z	PASS	72	verify.sh	re-run post review fixes; deploy+update+destroy clean, 0 orphans
 codecommit	2026-07-17T10:28:12Z	PASS	59	verify.sh	re-run on final code post-review fixes (null-id delete + retry-safe rename); 3 phases clean 0 orphans
 budgets	2026-07-17T11:58:00Z	PASS	60	verify.sh	new fixture #1041 re-run post-rebase (idempotent reconciler, verbatim name); 3 phases clean, 0 orphans
 servicediscovery-namespaces	2026-07-17T12:12:19Z	PASS	114	verify.sh	re-run post review fixes (import kind filter, PrivateDns tag sync, resolver HostedZoneId); clean, 0 orphans
@@ -242,3 +241,4 @@ fsx-lustre	2026-07-17T16:22:08Z	PASS	1100	verify.sh	deploy+update(LZ4,tags)+dest
 fsx-lustre	2026-07-18T00:50:49Z	PASS	900	verify.sh	deploy+update(incl tag removal)+destroy clean, 0 orphans (4th run, covers de7494ba observe-confirmed-action fix)
 bench-cdk-sample	2026-07-18T03:53:42Z	PASS		standard	deploy 0-err + destroy 37 deleted/2 retained(by-design LogGroups)/0 errors, 0 orphans
 emr-cluster	2026-07-18T04:17:17Z	PASS		verify.sh	post-review-fixes: deploy+update+destroy clean, 12 deleted 0 errors, TERMINATED, 0 orphans
+dlm-lifecycle-policy	2026-07-18T18:42:46Z	PASS	74	verify.sh	added Phase 1b zero-drift assertion; deploy+drift(0)+update+destroy clean, 0 orphans

--- a/tests/integration/dlm-lifecycle-policy/README.md
+++ b/tests/integration/dlm-lifecycle-policy/README.md
@@ -19,6 +19,12 @@ the SDK provider.
    `aws dlm get-lifecycle-policy` that the configuration reached AWS and
    that state routes the resource via the SDK provider
    (`provisionedBy=sdk`).
+1b. **Drift (zero)**: assert `cdkd drift` exits 0 on the freshly-deployed
+   policy. `GetLifecyclePolicy` returns `PolicyDetails` with server-injected
+   defaults (e.g. `PolicyLanguage: SIMPLIFIED`) the template never set; the
+   provider's `readCurrentState` + `getDriftUnknownPaths` exclude those so
+   they never register as phantom drift (issue #1067). A no-op deploy must
+   be drift-free.
 2. **Update** (`CDKD_TEST_UPDATE=true`): description change + State
    `ENABLED -> DISABLED` (UpdateLifecyclePolicy), tag value change AND
    tag removal (TagResource / UntagResource — the #981 regression

--- a/tests/integration/dlm-lifecycle-policy/verify.sh
+++ b/tests/integration/dlm-lifecycle-policy/verify.sh
@@ -9,6 +9,12 @@
 #      role). Assert via `aws dlm get-lifecycle-policy` that the policy is
 #      ENABLED with the baseline description and carries the templated tags,
 #      and that state routes it via the SDK provider (provisionedBy=sdk).
+#   1b. Assert `cdkd drift` reports ZERO drift on the freshly-deployed policy
+#      (exit 0). GetLifecyclePolicy returns PolicyDetails with server-injected
+#      defaults (e.g. PolicyLanguage: SIMPLIFIED) the template never set; the
+#      provider's readCurrentState + getDriftUnknownPaths must exclude those so
+#      they never surface as phantom drift (issue #1067). This is the whole
+#      point of the drift caveat — a no-op deploy MUST be drift-free.
 #   2. Re-deploy with CDKD_TEST_UPDATE=true: description change + State
 #      ENABLED -> DISABLED (UpdateLifecyclePolicy), tag value change AND tag
 #      removal (TagResource / UntagResource — the #981 regression class).
@@ -128,6 +134,24 @@ if [ "${PROVISIONED_BY}" != "sdk" ]; then
   exit 1
 fi
 echo "    policy routed via SDK provider (provisionedBy=sdk)"
+
+# --- Phase 1b: zero-drift assertion (server-default guard, issue #1067) --
+echo "==> Phase 1b: assert cdkd drift reports NO drift on the freshly-deployed policy"
+# `cdkd drift` exits 0 when in sync, 1 when drift is detected. GetLifecyclePolicy
+# returns PolicyDetails with server-injected defaults (e.g. PolicyLanguage:
+# SIMPLIFIED, PolicyType/ResourceTypes/per-schedule defaults) that the template
+# never set. The provider's readCurrentState surfaces only
+# Description/State/ExecutionRoleArn/Tags and lists PolicyDetails + the
+# default-policy shorthand fields in getDriftUnknownPaths, so those server
+# defaults must NOT register as phantom drift. A freshly-deployed, unmodified
+# policy MUST be drift-free — that is the whole point of issue #1067.
+if node "${LOCAL_DIST}" drift "${STACK}" \
+  --state-bucket "${STATE_BUCKET}" --region "${REGION}"; then
+  echo "    cdkd drift reports zero drift (server-injected PolicyDetails defaults handled)"
+else
+  echo "FAIL: cdkd drift reported drift on a freshly-deployed DLM policy (expected none) — server-injected PolicyDetails defaults are leaking as phantom drift" >&2
+  exit 1
+fi
 
 # --- Phase 2: in-place update (state/description/tags) ------------------
 echo "==> Phase 2: re-deploy with CDKD_TEST_UPDATE=true (DISABLED, tag change + removal)"


### PR DESCRIPTION
## Summary

Adds a **Phase 1b zero-drift assertion** to the `dlm-lifecycle-policy`
integration fixture. This closes the one genuine remaining gap in issue
#1067: the provider-side drift work (`readCurrentState` +
`getDriftUnknownPaths` with the `PolicyDetails` server-default handling +
unit tests) already shipped in PR #1056 itself (commit 78959c3e), but the
fixture had no end-to-end `cdkd drift` check.

`GetLifecyclePolicy` returns `PolicyDetails` with server-injected defaults
(e.g. `PolicyLanguage: SIMPLIFIED`, `PolicyType` / `ResourceTypes` /
per-schedule defaults) that the template never set. The provider's
`readCurrentState` surfaces only `Description` / `State` /
`ExecutionRoleArn` / `Tags` and lists `PolicyDetails` + the default-policy
shorthand fields in `getDriftUnknownPaths`, so those server defaults must
not register as phantom drift. This PR proves that holds end-to-end
against real AWS: `cdkd drift` on a freshly-deployed, unmodified policy
must exit 0.

Provider code is **unchanged** — this is a fixture-only addition.

Changes:
- `tests/integration/dlm-lifecycle-policy/verify.sh`: new Phase 1b that
  runs `cdkd drift <stack>` after the baseline deploy and fails if it
  reports drift (exit 1). Placed before the update phase so the server
  defaults are freshly present.
- `tests/integration/dlm-lifecycle-policy/README.md`: document the new
  drift phase.
- `docs/_generated/integ-last-run.tsv`: record the integ run.

## Test plan

- [x] Unit tests pass (442 files, 7023 tests)
- [x] `vp check --fix` (typecheck + lint + format): 0 errors
- [x] Integration test: `/run-integ dlm-lifecycle-policy` — deploy +
      drift(0) + in-place update + destroy all clean; 74s; destroy 2
      deleted, 0 errors, 0 orphans. Phase 1b reported
      "no drift detected (2 resources checked, 0 unsupported)" against a
      real policy with server-injected `PolicyDetails` defaults present.
- [x] Documentation updated (fixture README)

Closes #1067
