### PR TITLE
docs: sharpen README tagline and intro bullets to focus on fast deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Drop-in CDK CLI for existing CDK apps: up to 15x faster deploys via AWS SDK inst
 
 - **Drop-in CDK compatible**: your existing CDK app code runs as-is.
 - **Up to 15x faster deploys than the AWS CDK CLI (CloudFormation)**
-- **Local execution**: run your functions and APIs locally, with env vars resolved from your deployed stack instead of hand-written `.env` files.
+- **Local execution**: run your functions and APIs locally, with env vars, secrets, and resource references resolved from your deployed stack instead of hand-written `.env` files.
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Drop-in CDK CLI for existing CDK apps: up to 15x faster deploys via AWS SDK instead of CloudFormation.
 
 - **Drop-in CDK compatible**: your existing CDK app code runs as-is.
-- **Up to 15x faster deploys**: direct SDK calls, no changesets, no stack-event polling.
+- **Up to 15x faster deploys**: direct SDK calls, aggressive parallelization, and `--no-wait` to skip slow stabilization waits.
 - **Local execution**: run your functions and APIs locally, with env vars, secrets, and resource references resolved from your deployed stack instead of hand-written `.env` files.
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Drop-in CDK CLI for existing CDK apps: up to 15x faster deploys via AWS SDK instead of CloudFormation.
 
 - **Drop-in CDK compatible**: your existing CDK app code runs as-is.
-- **Up to 15x faster deploys than the AWS CDK CLI (CloudFormation)**
+- **Up to 15x faster deploys**: direct SDK calls, no changesets, no stack-event polling.
 - **Local execution**: run your functions and APIs locally, with env vars, secrets, and resource references resolved from your deployed stack instead of hand-written `.env` files.
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![Downloads](https://img.shields.io/npm/dw/@go-to-k/cdkd.svg)](https://www.npmjs.com/package/@go-to-k/cdkd)
 [![License: Apache-2.0](https://img.shields.io/npm/l/@go-to-k/cdkd.svg)](./LICENSE)
 
-Drop-in CDK CLI for existing CDK apps — faster deploys via AWS SDK instead of CloudFormation, plus local emulation for Lambda, API Gateway, and ECS.
+Drop-in CDK CLI for existing CDK apps: up to 15x faster deploys via AWS SDK instead of CloudFormation.
 
-- **Drop-in CDK compatible** — your existing CDK app code runs as-is.
+- **Drop-in CDK compatible**: your existing CDK app code runs as-is.
 - **Up to 15x faster deploys than the AWS CDK CLI (CloudFormation)**
-- **Local dev for any CDK app** — invoke Lambdas, serve API Gateway routes, run ECS tasks/services directly from your CDK code. Works against both `cdkd deploy`-managed AND `cdk deploy`-managed (CloudFormation) stacks via `--from-state` / `--from-cfn-stack` — no migration, no `cdk synth → sam local` round-trip.
+- **Local execution**: run your functions and APIs locally, with env vars resolved from your deployed stack instead of hand-written `.env` files.
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)
 


### PR DESCRIPTION
## Summary

Refocus the README opening on the message the tool is actually known for: fast CDK deploys.

- **Tagline**: lead with the up-to-15x deploy speedup and drop the local emulation mention. When cdkd gets introduced or shared, it is described as "deploy CDK fast", so the tagline now matches how people actually talk about it. Local execution still has its own bullet and full section.
- **15x bullet**: reshape into the same `**label**: explanation` form as its siblings, and explain the mechanism (direct SDK calls, aggressive parallelization, `--no-wait`) instead of restating the comparison baseline that the benchmark section already covers.
- **Local execution bullet**: replace the service-name list (Lambda, API Gateway, ECS) with the benefit: env vars, secrets, and resource references are resolved from the deployed stack instead of hand-written `.env` files. Verified against `docs/local-emulation.md` — the `--from-state` / `--from-cfn-stack` substitution covers env vars, ECS secrets, container image URIs, IAM role ARNs, volumes, and CloudFront origin bindings, so the previous env-vars-only phrasing undersold it.
- Remove em dashes from the tagline and bullets.

The GitHub About description should be updated manually to match the new tagline:

> Drop-in CDK CLI for existing CDK apps: up to 15x faster deploys via AWS SDK instead of CloudFormation.

## Notes

- README-only change, no code touched.
- Consistency checked: the 15x figure matches the benchmark section (15.0x with `--no-wait`), and no other file quotes the old tagline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCQ5iSLUJjrLFBTZKnWCYM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCQ5iSLUJjrLFBTZKnWCYM)_