### PR TITLE
docs: drop local execution from the README intro to prevent a speed misreading

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ Drop-in CDK CLI for existing CDK apps: up to 15x faster deploys via AWS SDK inst
 
 - **Drop-in CDK compatible**: your existing CDK app code runs as-is.
 - **Up to 15x faster deploys**: direct SDK calls, aggressive parallelization, and `--no-wait` to skip slow stabilization waits.
-- **Local execution**: run your functions and APIs locally, with env vars, secrets, and resource references resolved from your deployed stack instead of hand-written `.env` files.
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)
 
-**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration and SAM-style local execution; use the AWS CDK CLI in production for full CloudFormation tooling. Install cdkd alongside an existing `cdk deploy` workflow — no migration needed, `cdkd local *` reads deployed state directly via `--from-cfn-stack`. Bidirectional migration is also supported — [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation when ready.
+**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration and local execution; use the AWS CDK CLI in production for full CloudFormation tooling. Install cdkd alongside an existing `cdk deploy` workflow: no migration needed, `cdkd local *` reads deployed state directly via `--from-cfn-stack`, resolving env vars, secrets, and resource references with no hand-written `.env` files. Bidirectional migration is also supported: [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation when ready.
 
 **A natural fit for AI-driven development.** AI coding agents iterate in tight spin-up / tear-down loops — and cdkd keeps each turn short, with fast deploys and an equally fast `cdkd destroy` that deletes via direct SDK calls instead of polling a CloudFormation stack-delete.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Drop-in CDK CLI for existing CDK apps: up to 15x faster deploys via AWS SDK inst
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)
 
-**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration and local execution; use the AWS CDK CLI in production for full CloudFormation tooling. Install cdkd alongside an existing `cdk deploy` workflow: no migration needed, `cdkd local *` reads deployed state directly via `--from-cfn-stack`, resolving env vars, secrets, and resource references with no hand-written `.env` files. Bidirectional migration is also supported: [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation when ready.
+**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration and local execution; use the AWS CDK CLI in production for full CloudFormation tooling. Install cdkd alongside an existing `cdk deploy` workflow: no migration needed. Bidirectional migration is also supported: [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation when ready.
 
 **A natural fit for AI-driven development.** AI coding agents iterate in tight spin-up / tear-down loops — and cdkd keeps each turn short, with fast deploys and an equally fast `cdkd destroy` that deletes via direct SDK calls instead of polling a CloudFormation stack-delete.
 


### PR DESCRIPTION
## Summary

Follow-up to #1076. With the **Local execution** bullet sitting right under the **Up to 15x faster deploys** bullet, a skimmer can attribute the speedup to local emulation (LocalStack-style) and conclude cdkd does not really deploy. Fixing the bullet text would not help, since the misreading happens at the bold-label level, so the bullet is removed instead.

- **Remove the Local execution bullet** from the intro list. The first screen is now purely the fast-real-deploy story: tagline, two bullets (drop-in compatible / 15x faster), and the benchmark gif.
- **Keep the complements paragraph to positioning only**: drop the `cdkd local *` / `--from-cfn-stack` / `.env` resolution details that had been folded into it, along with the "SAM-style" phrasing. Local execution keeps a passing mention in the dev/test sentence, and its first substantial appearance is now inside the real-deploy context, where "reads deployed state" makes the misreading impossible.
- No information is lost: the state-source flags and env var / secret resolution details remain in the Features list and the Local execution section.

## Notes

- README-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCQ5iSLUJjrLFBTZKnWCYM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCQ5iSLUJjrLFBTZKnWCYM)_