### PR TITLE
docs: say direct AWS SDK calls in the README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Downloads](https://img.shields.io/npm/dw/@go-to-k/cdkd.svg)](https://www.npmjs.com/package/@go-to-k/cdkd)
 [![License: Apache-2.0](https://img.shields.io/npm/l/@go-to-k/cdkd.svg)](./LICENSE)
 
-Drop-in CDK CLI for existing CDK apps: up to 15x faster deploys via AWS SDK instead of CloudFormation.
+Drop-in CDK CLI for existing CDK apps: up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation.
 
 - **Drop-in CDK compatible**: your existing CDK app code runs as-is.
 - **Up to 15x faster deploys**: direct SDK calls, aggressive parallelization, and `--no-wait` to skip slow stabilization waits.


### PR DESCRIPTION
## Summary

Follow-up to #1076 / #1077. Change the tagline from "via AWS SDK" to "via direct AWS SDK calls":

> Drop-in CDK CLI for existing CDK apps: up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation.

- The differentiator is not using the SDK (CloudFormation also calls service APIs internally) but skipping the CloudFormation middleman, which "direct" states precisely.
- It also reads more naturally and echoes the product name (cdkd = CDK Direct).
- The GitHub About description should be updated manually to the same sentence.

## Notes

- README-only change, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCQ5iSLUJjrLFBTZKnWCYM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCQ5iSLUJjrLFBTZKnWCYM)_