### PR TITLE
docs: move the bootstrap note out of the Prerequisites bullets

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,13 @@ parsing → synthesis → asset publishing → per-stack deploy), see
 ## Prerequisites
 
 - **Node.js** >= 20.0.0
-- **AWS CDK Bootstrap: not required.** `cdkd bootstrap` (once per account) creates
-  everything cdkd needs, and per-region asset storage is added automatically on the
-  first `cdkd deploy` into each region. Existing setups, legacy-mode opt-outs, and
-  how this relates to `cdk bootstrap`: see
-  [Upgrading from an earlier cdkd version](#upgrading-from-an-earlier-cdkd-version).
 - **AWS credentials with admin-equivalent permissions** for the resources being deployed. cdkd does NOT route through CloudFormation, so CDK CLI's `cdk-hnb659fds-deploy-role-*` is NOT sufficient — see [`--role-arn`](docs/cli-reference.md).
+
+AWS CDK's `cdk bootstrap` is not required. Instead, run `cdkd bootstrap` once per
+account: it creates everything cdkd needs, and per-region asset storage is added
+automatically on the first `cdkd deploy` into each region. Existing setups,
+legacy-mode opt-outs, and how this relates to `cdk bootstrap`: see
+[Upgrading from an earlier cdkd version](#upgrading-from-an-earlier-cdkd-version).
 
 ## Installation
 


### PR DESCRIPTION
## Summary

A bold **AWS CDK Bootstrap: not required.** item inside the Prerequisites list invites the misreading that no bootstrap is needed at all, when `cdkd bootstrap` IS required (once per account).

- Remove the item from the bullet list, leaving Node.js and AWS credentials as the actual prerequisites.
- Restate it as a paragraph below the list: the subject is explicitly AWS CDK's `cdk bootstrap`, and "Instead, run `cdkd bootstrap` once per account" leads so the required action is stated up front. The per-region asset storage note and the link to the upgrade section are unchanged.

## Notes

- README-only change, no code touched.
- Consistent with the Quick Start section, which already shows `cdkd bootstrap` as the first step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCQ5iSLUJjrLFBTZKnWCYM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCQ5iSLUJjrLFBTZKnWCYM)_