### PR TITLE
test(integ): arm seeded, exiting INT/TERM traps across the fixture tree (#1097 pattern 1)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -19,6 +19,26 @@ paths:
 - Environment variables: `STATE_BUCKET`, `AWS_REGION`
 - Examples verified with real AWS deployments (see `tests/integration/` for full list)
 
+### `verify.sh` signal traps (mandatory)
+
+A fixture that provisions real AWS resources must arm its `cleanup` trap on the
+signal paths too, in the **exiting** form:
+
+```bash
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+```
+
+`trap cleanup EXIT INT TERM` is NOT equivalent and must never be used: a bash
+signal handler returns to the interrupted point, so the script resumes the
+interrupted phase after cleanup and can `exit 0` — reporting PASS while
+`cleanup` raced a still-live deploy. Omitting `INT` / `TERM` entirely leaks the
+stack on Ctrl-C or a harness timeout. Disarm with `trap - EXIT INT TERM`.
+
+Enforced by `tests/unit/scripts/integ-verify-signal-traps.test.ts` (issue #1097);
+the user-facing writeup is in [docs/testing.md](../../docs/testing.md).
+
 ## UPDATE Testing
 
 - Environment variable `CDKD_TEST_UPDATE=true` enables UPDATE test mode

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -26,8 +26,8 @@ signal paths too, in the **exiting** form:
 
 ```bash
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 ```
 
 `trap cleanup EXIT INT TERM` is NOT equivalent and must never be used: a bash
@@ -35,6 +35,14 @@ signal handler returns to the interrupted point, so the script resumes the
 interrupted phase after cleanup and can `exit 0` — reporting PASS while
 `cleanup` raced a still-live deploy. Omitting `INT` / `TERM` entirely leaks the
 stack on Ctrl-C or a harness timeout. Disarm with `trap - EXIT INT TERM`.
+
+The `(exit N)` seed is load-bearing, not decoration. Many fixtures' `cleanup`
+opens with `rc=$?` and gates the whole teardown on it (`if [ "${rc}" -eq 0 ];
+then exit 0; fi`). Inside a handler `$?` is the **interrupted command's** status,
+not the signal, so without the seed an interrupted run can see rc=0, skip the
+teardown entirely and exit 0 — the exact bug this convention exists to prevent.
+`(exit N)` sets `$?` to the signal's code, so `rc=$?` and `${1:-$?}` cleanups
+both tear down correctly.
 
 Enforced by `tests/unit/scripts/integ-verify-signal-traps.test.ts` (issue #1097);
 the user-facing writeup is in [docs/testing.md](../../docs/testing.md).

--- a/.claude/skills/new-integ/SKILL.md
+++ b/.claude/skills/new-integ/SKILL.md
@@ -131,8 +131,24 @@ The user provides a kebab-case test name (e.g., `ses-email-identity`,
      (`${AWS_REGION:-us-east-1}`), `STATE_KEY`, and
      `LOCAL_DIST="$(cd ../../../dist && pwd)/cli.js"`.
    - Require `STATE_BUCKET` (fail fast if unset) and the built `dist/cli.js`.
-   - Define a `cleanup()` and `trap cleanup EXIT`; run it once up-front as a
-     pre-run cleanup. cleanup must `node "${LOCAL_DIST}" state destroy`, delete
+   - Define a `cleanup()` and arm it on EXIT **and both signals**; run it once
+     up-front as a pre-run cleanup:
+
+     ```bash
+     trap cleanup EXIT
+     trap '(exit 130); cleanup; exit 130' INT
+     trap '(exit 143); cleanup; exit 143' TERM
+     ```
+
+     `trap cleanup EXIT INT TERM` is NOT equivalent and must never be used — a
+     bash signal handler returns to the interrupted point, so the script resumes
+     the interrupted phase and can `exit 0`, reporting PASS while resources leak.
+     The `(exit N)` seed is also load-bearing: inside a handler `$?` is the
+     interrupted command's status, so a `cleanup` opening with `rc=$?` would
+     otherwise see 0 and skip teardown. Disarm with `trap - EXIT INT TERM`.
+     Enforced by `tests/unit/scripts/integ-verify-signal-traps.test.ts` (#1097).
+
+     cleanup must `node "${LOCAL_DIST}" state destroy`, delete
      the AWS resources by deterministic name, remove the `state.json` + `lock.json`,
      and **sweep `/aws/lambda/${STACK}*` log groups** (Lambda auto-creates them on
      invoke and neither CFn nor cdkd deletes them — leaving them counts as an

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -79,7 +79,6 @@ local-start-alb	2026-06-21T11:00:28Z	PASS	21	verify.sh	sweep-4..8 staleness re-r
 local-start-alb-from-state	2026-06-21T10:44:49Z	PASS	88	verify.sh	fixed verify.sh assertion (state.json only, ignore #885 deployments/); deploy+destroy clean 29 del 0 err
 local-start-api-container	2026-06-21T14:49:02Z	PASS	14	verify.sh	sweep-G local re-run (rc=0)
 local-start-api-rest-v1-non-proxy	2026-06-21T14:49:21Z	PASS	17	verify.sh	sweep-G local re-run (rc=0)
-local-start-api-websocket	2026-06-21T14:52:36Z	PASS	193	verify.sh	sweep-G; retry rc=0 (arm64 qemu multi-container RIE; env-limited not cdkd bug if FAIL)
 local-start-service	2026-06-21T14:52:59Z	PASS	21	verify.sh	sweep-G local re-run (rc=0)
 local-start-service-watch-fast	2026-06-21T14:56:24Z	PASS	203	verify.sh	sweep-G local re-run (rc=0)
 log-pipeline	2026-06-21T11:00:28Z	PASS	62	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
@@ -250,3 +249,4 @@ emr-instance-configs	2026-07-19T12:15:47Z	PASS	1680	verify.sh	post-review re-run
 lambda	2026-07-19T15:42:32Z	PASS	83	verify.sh	broad integ for import-tag-walk retry widening; 9 deleted 0 errors 0 orphans
 emr-cluster	2026-07-19T18:32:52Z	PASS	1560	verify.sh	issue #1090 import round-trip w/ discriminating assertions (attributes from #1099, observed-vs-template divergence); 12 deleted 0 errors 0 orphans
 local-start-api	2026-07-19T18:27:53Z	PASS	22	verify.sh	rc ok, 0 docker orphans; swept verify.sh (#1097 pattern 1)
+local-start-api-websocket	2026-07-19T18:46:28Z	PASS	103	verify.sh	rc ok, 0 docker orphans; validates restructured multi-line trap (#1097)

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -77,7 +77,6 @@ local-run-task-multi-container	2026-06-21T11:00:28Z	PASS	11	verify.sh	sweep-4..8
 local-start-agentcore	2026-06-21T19:11:23Z	PASS	70	verify.sh	staleness re-run (15d); warm HTTP contract ping+invocations+session-id, /ws bridge, --sigv4-signed forward; aws-cdk-lib 2.260 OK; 0 container leak
 local-start-alb	2026-06-21T11:00:28Z	PASS	21	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 local-start-alb-from-state	2026-06-21T10:44:49Z	PASS	88	verify.sh	fixed verify.sh assertion (state.json only, ignore #885 deployments/); deploy+destroy clean 29 del 0 err
-local-start-api	2026-06-21T19:10:37Z	PASS	29	verify.sh	fresh re-run with Docker up (prior env-FAIL); HTTP/REST/FunctionURL routes + JWT authz + --watch source reload; 0 container leak
 local-start-api-container	2026-06-21T14:49:02Z	PASS	14	verify.sh	sweep-G local re-run (rc=0)
 local-start-api-rest-v1-non-proxy	2026-06-21T14:49:21Z	PASS	17	verify.sh	sweep-G local re-run (rc=0)
 local-start-api-websocket	2026-06-21T14:52:36Z	PASS	193	verify.sh	sweep-G; retry rc=0 (arm64 qemu multi-container RIE; env-limited not cdkd bug if FAIL)
@@ -250,3 +249,4 @@ bench-cdk-sample	2026-07-19T11:38:56Z	PASS	540	standard	deploy+destroy clean (37
 emr-instance-configs	2026-07-19T12:15:47Z	PASS	1680	verify.sh	post-review re-run (fleet scale-down fix); deploy+resize+destroy clean, 0 orphans
 lambda	2026-07-19T15:42:32Z	PASS	83	verify.sh	broad integ for import-tag-walk retry widening; 9 deleted 0 errors 0 orphans
 emr-cluster	2026-07-19T18:32:52Z	PASS	1560	verify.sh	issue #1090 import round-trip w/ discriminating assertions (attributes from #1099, observed-vs-template divergence); 12 deleted 0 errors 0 orphans
+local-start-api	2026-07-19T18:27:53Z	PASS	22	verify.sh	rc ok, 0 docker orphans; swept verify.sh (#1097 pattern 1)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -398,8 +398,8 @@ paths as well, in the exiting form:
 ```bash
 cleanup() { ... }             # destroy + state/orphan sweep
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 ```
 
 Two forms are wrong and both let a run leak billable resources:
@@ -412,6 +412,19 @@ Two forms are wrong and both let a run leak billable resources:
   next one and can `exit 0` — reporting PASS. Worse, when only the script PID
   is signalled the `node deploy` child survives, so `cleanup` deletes resources
   concurrently with a live deploy.
+
+The `(exit N)` seed is load-bearing, not decoration. Many fixtures' `cleanup`
+opens with `rc=$?` and gates the whole teardown on it:
+
+```bash
+cleanup() { rc=$?; if [ "${rc}" -eq 0 ]; then exit 0; fi; ...destroy...; }
+```
+
+Inside a signal handler `$?` is the **interrupted command's** status, not the
+signal. Without the seed, an interrupted run can see `rc=0`, skip the teardown
+entirely and exit 0 — reintroducing the very bug the signal trap was added to
+prevent. `(exit N)` sets `$?` to the signal's code, so both `rc=$?` and
+`${1:-$?}` cleanups tear down correctly.
 
 A disarm must release the signal traps too — `trap - EXIT INT TERM`, not
 `trap - EXIT` — otherwise a Ctrl-C after the fixture's own successful teardown

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -389,6 +389,37 @@ EOF
 vp run build
 ```
 
+### Fixture convention: `verify.sh` signal traps
+
+Every fixture that provisions real AWS resources arms a `cleanup` trap so a
+failed run tears its resources down. That trap MUST be armed for the signal
+paths as well, in the exiting form:
+
+```bash
+cleanup() { ... }             # destroy + state/orphan sweep
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+```
+
+Two forms are wrong and both let a run leak billable resources:
+
+- **No `INT` / `TERM` handler.** Ctrl-C or a harness timeout terminates the
+  script without running the `EXIT` trap, so the stack survives.
+- **`trap cleanup EXIT INT TERM`** (the bare-function form). A bash signal
+  handler *returns to the interrupted point* instead of exiting, so `cleanup`
+  runs and the script then **resumes the interrupted phase**, walks into the
+  next one and can `exit 0` — reporting PASS. Worse, when only the script PID
+  is signalled the `node deploy` child survives, so `cleanup` deletes resources
+  concurrently with a live deploy.
+
+A disarm must release the signal traps too — `trap - EXIT INT TERM`, not
+`trap - EXIT` — otherwise a Ctrl-C after the fixture's own successful teardown
+re-runs `cleanup`.
+
+`tests/unit/scripts/integ-verify-signal-traps.test.ts` enforces this across the
+whole fixture tree (issue #1097).
+
 ## 3. Deploy Using cdkd
 
 ```bash

--- a/scripts/check-integ-signal-traps.ts
+++ b/scripts/check-integ-signal-traps.ts
@@ -9,8 +9,8 @@
  * `trap cleanup EXIT` with no signal handler skips cleanup entirely on Ctrl-C
  * or a harness timeout, leaking billable AWS resources.
  *
- * The only correct form seeds `$?` with the signal's exit code before calling
- * the handler, then exits:
+ * The only correct form seeds `$?` with the signal's exit code immediately
+ * before calling the handler, then exits:
  *
  *   trap cleanup EXIT
  *   trap '(exit 130); cleanup; exit 130' INT
@@ -20,36 +20,47 @@
  * opens with `rc=$?` and gates the whole teardown on it. Inside a handler `$?`
  * is the interrupted command's status, so without the seed an interrupted run
  * can see rc=0, SKIP the teardown entirely and exit 0 -- the exact bug #1097
- * is about.
+ * is about. "Immediately before" is also load-bearing: any command between the
+ * seed and the handler call (e.g. a temp-file `rm`) clobbers `$?` again.
  *
  * This module is separate from the test so the classifier can be table-tested
  * against synthetic script shapes rather than only against today's tree.
  */
 
-/** A bash function name, optionally wrapped in single or double quotes. */
-const FN = `(['"]?)([A-Za-z_][A-Za-z0-9_]*)\\1`;
+/** A bash function name, bare or wrapped in single/double quotes. */
+const NAME = `[A-Za-z_][A-Za-z0-9_]*`;
 
 export interface TrapClassification {
-  /** Arms an EXIT trap that reaches a cleanup-ish function. */
+  /** Arms an EXIT trap that reaches one of the script's own functions. */
   hasCleanupExitTrap: boolean;
-  /** Arms `INT` with a handler that seeds `$?` and exits. */
+  /** Arms `INT`, and EVERY `INT` arm seeds `$?` and exits. */
   hasCorrectIntTrap: boolean;
-  /** Arms `TERM` with a handler that seeds `$?` and exits. */
+  /** Arms `TERM`, and EVERY `TERM` arm seeds `$?` and exits. */
   hasCorrectTermTrap: boolean;
   /**
    * Arms `INT` / `TERM` with a handler that can return to the interrupted
-   * point -- either the bare-function form or a body with no `exit`.
+   * point -- the bare-function form, or a body that never exits.
    */
   hasResumingSignalTrap: boolean;
   /** Function names this script defines, used to recognize handler traps. */
   definedFunctions: string[];
 }
 
+interface TrapStatement {
+  /** The handler: a bare function name, or the quoted body's contents. */
+  body: string;
+  /** True when the handler was given as a bare name rather than a body. */
+  bare: boolean;
+  signals: string[];
+  /** `trap - EXIT INT TERM` -- releases rather than arms. */
+  disarm: boolean;
+}
+
 /**
- * Collapses multi-line `trap '<body>' SIG` statements onto one line so a
- * line-oriented scan cannot miss them. `local-start-api-websocket` shipped a
- * multi-line `trap ' ... ' EXIT INT TERM` that a per-line regex read as two
- * unrelated fragments.
+ * Collapses multi-line `trap '<body>' SIG` / `trap "<body>" SIG` statements onto
+ * one line so a line-oriented scan cannot miss them. `local-start-api-websocket`
+ * shipped a multi-line `trap ' ... ' EXIT INT TERM` that a per-line regex read
+ * as two unrelated fragments and greenlit.
  */
 export function joinMultilineTraps(content: string): string[] {
   const lines = content.split('\n');
@@ -57,12 +68,14 @@ export function joinMultilineTraps(content: string): string[] {
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
-    // An opening `trap '` whose quote does not close on the same line.
-    if (/^\s*trap\s+'/.test(line) && (line.match(/'/g) ?? []).length === 1) {
+    const opener = /^\s*trap\s+(['"])/.exec(line);
+    // An opening quote that does not close on the same line.
+    if (opener && (line.match(new RegExp(opener[1]!, 'g')) ?? []).length === 1) {
+      const quote = opener[1]!;
       const parts = [line.trim()];
       while (++i < lines.length) {
         parts.push(lines[i]!.trim());
-        if (lines[i]!.includes("'")) break;
+        if (lines[i]!.includes(quote)) break;
       }
       joined.push(parts.join(' '));
       continue;
@@ -73,52 +86,70 @@ export function joinMultilineTraps(content: string): string[] {
   return joined;
 }
 
+function parseTraps(content: string): TrapStatement[] {
+  return joinMultilineTraps(content)
+    .filter((l) => /^trap\s/.test(l))
+    .map((line): TrapStatement | null => {
+      const disarm = /^trap\s+-\s+/.exec(line);
+      if (disarm) {
+        return { body: '', bare: true, signals: line.slice(disarm[0].length).split(/\s+/), disarm: true };
+      }
+      // Quoted body: `trap '...' SIG...` or `trap "..." SIG...`
+      const quoted = /^trap\s+(['"])([\s\S]*)\1\s+(.*)$/.exec(line);
+      if (quoted) {
+        return { body: quoted[2]!, bare: false, signals: quoted[3]!.split(/\s+/), disarm: false };
+      }
+      // Bare handler: `trap name SIG...`
+      const bare = new RegExp(`^trap\\s+(${NAME})\\s+(.*)$`).exec(line);
+      if (bare) {
+        return { body: bare[1]!, bare: true, signals: bare[2]!.split(/\s+/), disarm: false };
+      }
+      return null;
+    })
+    .filter((t): t is TrapStatement => t !== null);
+}
+
 export function classifyVerifyScript(content: string): TrapClassification {
   const definedFunctions = [...content.matchAll(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(\)\s*\{/gm)].map(
     (m) => m[1]!,
   );
-  const trapLines = joinMultilineTraps(content).filter((l) => /^trap\s/.test(l));
+  const traps = parseTraps(content).filter((t) => !t.disarm);
 
-  /** Does this trap body invoke one of the script's own functions? */
   const callsOwnFunction = (body: string) =>
     definedFunctions.some((fn) => new RegExp(`\\b${fn}\\b`).test(body));
 
-  const armsHandlerFor = (line: string, sig: 'EXIT' | 'INT' | 'TERM') => {
-    if (/^trap\s+-\s/.test(line)) return false; // a disarm, not an arm
-    const m = new RegExp(`^trap\\s+(?:${FN}|'(.*)')\\s+(.*)$`).exec(line);
-    if (!m) return false;
-    const signals = m[4] ?? '';
-    if (!new RegExp(`\\b${sig}\\b`).test(signals)) return false;
-    const body = m[3] ?? m[2] ?? '';
-    return callsOwnFunction(body);
+  const armsFor = (sig: string) => traps.filter((t) => t.signals.includes(sig));
+
+  /**
+   * A correct signal handler seeds `$?`, calls one of the script's own
+   * functions DIRECTLY after the seed (nothing in between may clobber `$?`),
+   * and exits with the signal's code.
+   */
+  const isCorrectSignalHandler = (t: TrapStatement, code: number) => {
+    if (t.bare) return false;
+    const seed = new RegExp(`\\(exit ${code}\\);\\s*(${NAME})\\b`).exec(t.body);
+    if (!seed || !definedFunctions.includes(seed[1]!)) return false;
+    return new RegExp(`exit ${code}\\s*;?\\s*$`).test(t.body.trim());
   };
 
-  const correctFor = (sig: 'INT' | 'TERM', code: number) =>
-    trapLines.some((l) => {
-      const m = new RegExp(`^trap\\s+'(.*)'\\s+(.*)$`).exec(l);
-      if (!m || !new RegExp(`\\b${sig}\\b`).test(m[2]!)) return false;
-      const body = m[1]!;
-      // Seeds `$?` immediately before the handler call, and exits afterwards.
-      return (
-        new RegExp(`\\(exit ${code}\\);\\s*[A-Za-z_]`).test(body) &&
-        new RegExp(`exit ${code}\\s*$`).test(body)
-      );
-    });
+  // EVERY arm must be correct, not just one: 8 fixtures legitimately re-arm
+  // their traps at phase boundaries, so a `some()` check would greenlight a
+  // file whose later re-arm dropped back to the un-seeded form.
+  const correctFor = (sig: string, code: number) => {
+    const arms = armsFor(sig);
+    return arms.length > 0 && arms.every((t) => isCorrectSignalHandler(t, code));
+  };
 
-  const hasResumingSignalTrap = trapLines.some((l) => {
-    if (/^trap\s+-\s/.test(l)) return false;
-    if (!/\b(INT|TERM)\b/.test(l)) return false;
-    const quoted = new RegExp(`^trap\\s+'(.*)'\\s+(.*)$`).exec(l);
-    if (!quoted) {
-      // Bare-function form: `trap cleanup EXIT INT TERM` -- always resumes.
-      return new RegExp(`^trap\\s+${FN}\\s+.*\\b(INT|TERM)\\b`).test(l);
-    }
-    // A quoted body that never exits also returns to the interrupted point.
-    return !/\bexit\b/.test(quoted[3] ?? quoted[1]!);
+  const hasResumingSignalTrap = traps.some((t) => {
+    if (!t.signals.some((s) => s === 'INT' || s === 'TERM')) return false;
+    // Bare-function form always returns to the interrupted point.
+    if (t.bare) return true;
+    // A body that never exits does too.
+    return !/\bexit\b/.test(t.body);
   });
 
   return {
-    hasCleanupExitTrap: trapLines.some((l) => armsHandlerFor(l, 'EXIT')),
+    hasCleanupExitTrap: armsFor('EXIT').some((t) => callsOwnFunction(t.body)),
     hasCorrectIntTrap: correctFor('INT', 130),
     hasCorrectTermTrap: correctFor('TERM', 143),
     hasResumingSignalTrap,

--- a/scripts/check-integ-signal-traps.ts
+++ b/scripts/check-integ-signal-traps.ts
@@ -1,0 +1,127 @@
+/**
+ * Classifier for the integ-fixture `verify.sh` signal-trap convention (#1097
+ * pattern 1).
+ *
+ * A bash signal handler RETURNS to the interrupted point rather than exiting,
+ * so `trap cleanup EXIT INT TERM` runs `cleanup` and then RESUMES the
+ * interrupted phase -- the script can walk into the next phase and `exit 0`,
+ * reporting PASS while `cleanup` raced a still-live deploy. A bare
+ * `trap cleanup EXIT` with no signal handler skips cleanup entirely on Ctrl-C
+ * or a harness timeout, leaking billable AWS resources.
+ *
+ * The only correct form seeds `$?` with the signal's exit code before calling
+ * the handler, then exits:
+ *
+ *   trap cleanup EXIT
+ *   trap '(exit 130); cleanup; exit 130' INT
+ *   trap '(exit 143); cleanup; exit 143' TERM
+ *
+ * The `(exit N)` seed is load-bearing, not decoration: many fixtures' `cleanup`
+ * opens with `rc=$?` and gates the whole teardown on it. Inside a handler `$?`
+ * is the interrupted command's status, so without the seed an interrupted run
+ * can see rc=0, SKIP the teardown entirely and exit 0 -- the exact bug #1097
+ * is about.
+ *
+ * This module is separate from the test so the classifier can be table-tested
+ * against synthetic script shapes rather than only against today's tree.
+ */
+
+/** A bash function name, optionally wrapped in single or double quotes. */
+const FN = `(['"]?)([A-Za-z_][A-Za-z0-9_]*)\\1`;
+
+export interface TrapClassification {
+  /** Arms an EXIT trap that reaches a cleanup-ish function. */
+  hasCleanupExitTrap: boolean;
+  /** Arms `INT` with a handler that seeds `$?` and exits. */
+  hasCorrectIntTrap: boolean;
+  /** Arms `TERM` with a handler that seeds `$?` and exits. */
+  hasCorrectTermTrap: boolean;
+  /**
+   * Arms `INT` / `TERM` with a handler that can return to the interrupted
+   * point -- either the bare-function form or a body with no `exit`.
+   */
+  hasResumingSignalTrap: boolean;
+  /** Function names this script defines, used to recognize handler traps. */
+  definedFunctions: string[];
+}
+
+/**
+ * Collapses multi-line `trap '<body>' SIG` statements onto one line so a
+ * line-oriented scan cannot miss them. `local-start-api-websocket` shipped a
+ * multi-line `trap ' ... ' EXIT INT TERM` that a per-line regex read as two
+ * unrelated fragments.
+ */
+export function joinMultilineTraps(content: string): string[] {
+  const lines = content.split('\n');
+  const joined: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    // An opening `trap '` whose quote does not close on the same line.
+    if (/^\s*trap\s+'/.test(line) && (line.match(/'/g) ?? []).length === 1) {
+      const parts = [line.trim()];
+      while (++i < lines.length) {
+        parts.push(lines[i]!.trim());
+        if (lines[i]!.includes("'")) break;
+      }
+      joined.push(parts.join(' '));
+      continue;
+    }
+    joined.push(line.trim());
+  }
+
+  return joined;
+}
+
+export function classifyVerifyScript(content: string): TrapClassification {
+  const definedFunctions = [...content.matchAll(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(\)\s*\{/gm)].map(
+    (m) => m[1]!,
+  );
+  const trapLines = joinMultilineTraps(content).filter((l) => /^trap\s/.test(l));
+
+  /** Does this trap body invoke one of the script's own functions? */
+  const callsOwnFunction = (body: string) =>
+    definedFunctions.some((fn) => new RegExp(`\\b${fn}\\b`).test(body));
+
+  const armsHandlerFor = (line: string, sig: 'EXIT' | 'INT' | 'TERM') => {
+    if (/^trap\s+-\s/.test(line)) return false; // a disarm, not an arm
+    const m = new RegExp(`^trap\\s+(?:${FN}|'(.*)')\\s+(.*)$`).exec(line);
+    if (!m) return false;
+    const signals = m[4] ?? '';
+    if (!new RegExp(`\\b${sig}\\b`).test(signals)) return false;
+    const body = m[3] ?? m[2] ?? '';
+    return callsOwnFunction(body);
+  };
+
+  const correctFor = (sig: 'INT' | 'TERM', code: number) =>
+    trapLines.some((l) => {
+      const m = new RegExp(`^trap\\s+'(.*)'\\s+(.*)$`).exec(l);
+      if (!m || !new RegExp(`\\b${sig}\\b`).test(m[2]!)) return false;
+      const body = m[1]!;
+      // Seeds `$?` immediately before the handler call, and exits afterwards.
+      return (
+        new RegExp(`\\(exit ${code}\\);\\s*[A-Za-z_]`).test(body) &&
+        new RegExp(`exit ${code}\\s*$`).test(body)
+      );
+    });
+
+  const hasResumingSignalTrap = trapLines.some((l) => {
+    if (/^trap\s+-\s/.test(l)) return false;
+    if (!/\b(INT|TERM)\b/.test(l)) return false;
+    const quoted = new RegExp(`^trap\\s+'(.*)'\\s+(.*)$`).exec(l);
+    if (!quoted) {
+      // Bare-function form: `trap cleanup EXIT INT TERM` -- always resumes.
+      return new RegExp(`^trap\\s+${FN}\\s+.*\\b(INT|TERM)\\b`).test(l);
+    }
+    // A quoted body that never exits also returns to the interrupted point.
+    return !/\bexit\b/.test(quoted[3] ?? quoted[1]!);
+  });
+
+  return {
+    hasCleanupExitTrap: trapLines.some((l) => armsHandlerFor(l, 'EXIT')),
+    hasCorrectIntTrap: correctFor('INT', 130),
+    hasCorrectTermTrap: correctFor('TERM', 143),
+    hasResumingSignalTrap,
+    definedFunctions,
+  };
+}

--- a/tests/integration/acm-certificate/verify.sh
+++ b/tests/integration/acm-certificate/verify.sh
@@ -36,6 +36,8 @@ cleanup() {
   $CDKD destroy --region "${REGION}" --state-bucket "${BUCKET}" --force || true
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "=== Deploying stack ${STACK} (no-wait) ==="
 CDKD_NO_WAIT=true $CDKD deploy --region "${REGION}" --state-bucket "${BUCKET}"

--- a/tests/integration/acm-certificate/verify.sh
+++ b/tests/integration/acm-certificate/verify.sh
@@ -36,8 +36,8 @@ cleanup() {
   $CDKD destroy --region "${REGION}" --state-bucket "${BUCKET}" --force || true
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "=== Deploying stack ${STACK} (no-wait) ==="
 CDKD_NO_WAIT=true $CDKD deploy --region "${REGION}" --state-bucket "${BUCKET}"

--- a/tests/integration/agentcore-tools/verify.sh
+++ b/tests/integration/agentcore-tools/verify.sh
@@ -56,8 +56,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/agentcore-tools/verify.sh
+++ b/tests/integration/agentcore-tools/verify.sh
@@ -56,6 +56,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/alb/verify.sh
+++ b/tests/integration/alb/verify.sh
@@ -28,7 +28,9 @@ cleanup() {
   ${CDKD} destroy ${STACK} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET}" --force >/dev/null 2>&1 || true
   exit ${rc}
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Installing fixture deps"
 [ -d node_modules ] || vp install --prefer-offline
@@ -83,4 +85,4 @@ echo "    state file removed (✓)"
 
 echo ""
 echo "==> All alb checks passed (incl. #609 ListenerAttributes backfill assertion)"
-trap - EXIT
+trap - EXIT INT TERM

--- a/tests/integration/alb/verify.sh
+++ b/tests/integration/alb/verify.sh
@@ -29,8 +29,8 @@ cleanup() {
   exit ${rc}
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Installing fixture deps"
 [ -d node_modules ] || vp install --prefer-offline

--- a/tests/integration/apigateway/verify.sh
+++ b/tests/integration/apigateway/verify.sh
@@ -55,8 +55,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/apigateway/verify.sh
+++ b/tests/integration/apigateway/verify.sh
@@ -55,6 +55,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/apigw-gateway-response/verify.sh
+++ b/tests/integration/apigw-gateway-response/verify.sh
@@ -61,8 +61,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/apigw-gateway-response/verify.sh
+++ b/tests/integration/apigw-gateway-response/verify.sh
@@ -61,6 +61,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/apigw-stage-throttling/verify.sh
+++ b/tests/integration/apigw-stage-throttling/verify.sh
@@ -63,6 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/apigw-stage-throttling/verify.sh
+++ b/tests/integration/apigw-stage-throttling/verify.sh
@@ -63,8 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/apigw-usage-plan-key/verify.sh
+++ b/tests/integration/apigw-usage-plan-key/verify.sh
@@ -43,8 +43,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/apigw-usage-plan-key/verify.sh
+++ b/tests/integration/apigw-usage-plan-key/verify.sh
@@ -43,6 +43,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/appconfig/verify.sh
+++ b/tests/integration/appconfig/verify.sh
@@ -79,6 +79,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/appconfig/verify.sh
+++ b/tests/integration/appconfig/verify.sh
@@ -79,8 +79,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/asset-auto-create/verify.sh
+++ b/tests/integration/asset-auto-create/verify.sh
@@ -86,8 +86,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/asset-auto-create/verify.sh
+++ b/tests/integration/asset-auto-create/verify.sh
@@ -86,6 +86,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/asset-bootstrap/verify.sh
+++ b/tests/integration/asset-bootstrap/verify.sh
@@ -86,8 +86,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/asset-bootstrap/verify.sh
+++ b/tests/integration/asset-bootstrap/verify.sh
@@ -86,6 +86,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/asset-migration/verify.sh
+++ b/tests/integration/asset-migration/verify.sh
@@ -93,8 +93,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/asset-migration/verify.sh
+++ b/tests/integration/asset-migration/verify.sh
@@ -93,6 +93,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/aws-custom-resource/verify.sh
+++ b/tests/integration/aws-custom-resource/verify.sh
@@ -55,8 +55,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/aws-custom-resource/verify.sh
+++ b/tests/integration/aws-custom-resource/verify.sh
@@ -55,6 +55,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/backup/verify.sh
+++ b/tests/integration/backup/verify.sh
@@ -76,6 +76,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first" >&2; exit 1; fi

--- a/tests/integration/backup/verify.sh
+++ b/tests/integration/backup/verify.sh
@@ -76,8 +76,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first" >&2; exit 1; fi

--- a/tests/integration/bootstrap-free-region/verify.sh
+++ b/tests/integration/bootstrap-free-region/verify.sh
@@ -71,6 +71,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/bootstrap-free-region/verify.sh
+++ b/tests/integration/bootstrap-free-region/verify.sh
@@ -71,8 +71,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/bucket-deployment/verify.sh
+++ b/tests/integration/bucket-deployment/verify.sh
@@ -59,6 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/bucket-deployment/verify.sh
+++ b/tests/integration/bucket-deployment/verify.sh
@@ -59,8 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/budgets/verify.sh
+++ b/tests/integration/budgets/verify.sh
@@ -54,8 +54,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/budgets/verify.sh
+++ b/tests/integration/budgets/verify.sh
@@ -54,6 +54,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2
@@ -169,5 +171,5 @@ if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/n
 fi
 echo "    state file removed"
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS — AWS::Budgets::Budget create / in-place update (notification + subscriber reconcile) / destroy all verified"

--- a/tests/integration/cc-api-fallback-transitions/verify.sh
+++ b/tests/integration/cc-api-fallback-transitions/verify.sh
@@ -93,8 +93,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cc-api-fallback-transitions/verify.sh
+++ b/tests/integration/cc-api-fallback-transitions/verify.sh
@@ -93,6 +93,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cc-api-fallback/verify.sh
+++ b/tests/integration/cc-api-fallback/verify.sh
@@ -44,6 +44,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cc-api-fallback/verify.sh
+++ b/tests/integration/cc-api-fallback/verify.sh
@@ -44,8 +44,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/ci-cd/verify.sh
+++ b/tests/integration/ci-cd/verify.sh
@@ -47,6 +47,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/ci-cd/verify.sh
+++ b/tests/integration/ci-cd/verify.sh
@@ -47,8 +47,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cloudfront-function-url/verify.sh
+++ b/tests/integration/cloudfront-function-url/verify.sh
@@ -42,8 +42,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cloudfront-function-url/verify.sh
+++ b/tests/integration/cloudfront-function-url/verify.sh
@@ -42,6 +42,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/codecommit/verify.sh
+++ b/tests/integration/codecommit/verify.sh
@@ -56,6 +56,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first" >&2; exit 1; fi

--- a/tests/integration/codecommit/verify.sh
+++ b/tests/integration/codecommit/verify.sh
@@ -56,8 +56,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first" >&2; exit 1; fi

--- a/tests/integration/codedeploy-lambda-deployment-group/verify.sh
+++ b/tests/integration/codedeploy-lambda-deployment-group/verify.sh
@@ -68,6 +68,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/codedeploy-lambda-deployment-group/verify.sh
+++ b/tests/integration/codedeploy-lambda-deployment-group/verify.sh
@@ -68,8 +68,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cognito-custom-attribute-add/verify.sh
+++ b/tests/integration/cognito-custom-attribute-add/verify.sh
@@ -57,8 +57,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cognito-custom-attribute-add/verify.sh
+++ b/tests/integration/cognito-custom-attribute-add/verify.sh
@@ -57,6 +57,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cognito-identity-pool/verify.sh
+++ b/tests/integration/cognito-identity-pool/verify.sh
@@ -41,8 +41,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/cognito-identity-pool/verify.sh
+++ b/tests/integration/cognito-identity-pool/verify.sh
@@ -41,6 +41,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/cognito-lambda-triggers/verify.sh
+++ b/tests/integration/cognito-lambda-triggers/verify.sh
@@ -63,6 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cognito-lambda-triggers/verify.sh
+++ b/tests/integration/cognito-lambda-triggers/verify.sh
@@ -63,8 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cognito-resource-server/verify.sh
+++ b/tests/integration/cognito-resource-server/verify.sh
@@ -51,6 +51,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cognito-resource-server/verify.sh
+++ b/tests/integration/cognito-resource-server/verify.sh
@@ -51,8 +51,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cognito-userpool-user-ref/verify.sh
+++ b/tests/integration/cognito-userpool-user-ref/verify.sh
@@ -39,6 +39,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/cognito-userpool-user-ref/verify.sh
+++ b/tests/integration/cognito-userpool-user-ref/verify.sh
@@ -39,8 +39,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/cognito/verify.sh
+++ b/tests/integration/cognito/verify.sh
@@ -51,6 +51,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cognito/verify.sh
+++ b/tests/integration/cognito/verify.sh
@@ -51,8 +51,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/conditions-and-if/verify.sh
+++ b/tests/integration/conditions-and-if/verify.sh
@@ -68,6 +68,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/conditions-and-if/verify.sh
+++ b/tests/integration/conditions-and-if/verify.sh
@@ -68,8 +68,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/conditions-update-2/verify.sh
+++ b/tests/integration/conditions-update-2/verify.sh
@@ -99,6 +99,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/conditions-update-2/verify.sh
+++ b/tests/integration/conditions-update-2/verify.sh
@@ -99,8 +99,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/cross-region-state-bucket/verify.sh
+++ b/tests/integration/cross-region-state-bucket/verify.sh
@@ -107,8 +107,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: create temporary state bucket in ${BUCKET_REGION}"
 if [ "${BUCKET_REGION}" = "us-east-1" ]; then

--- a/tests/integration/cross-region-state-bucket/verify.sh
+++ b/tests/integration/cross-region-state-bucket/verify.sh
@@ -107,6 +107,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: create temporary state bucket in ${BUCKET_REGION}"
 if [ "${BUCKET_REGION}" = "us-east-1" ]; then
@@ -184,5 +186,5 @@ echo "[verify] step 7 ok"
 echo "[verify] step 8: remove temporary state bucket"
 aws s3 rb "s3://${STATE_BUCKET}" --region "${BUCKET_REGION}" --force
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS"

--- a/tests/integration/custom-resource-getatt-data/verify.sh
+++ b/tests/integration/custom-resource-getatt-data/verify.sh
@@ -64,6 +64,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/custom-resource-getatt-data/verify.sh
+++ b/tests/integration/custom-resource-getatt-data/verify.sh
@@ -64,8 +64,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/data-analytics/verify.sh
+++ b/tests/integration/data-analytics/verify.sh
@@ -56,8 +56,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/data-analytics/verify.sh
+++ b/tests/integration/data-analytics/verify.sh
@@ -56,6 +56,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/deep-getatt-chains/verify.sh
+++ b/tests/integration/deep-getatt-chains/verify.sh
@@ -76,8 +76,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ ! -f "${LOCAL_DIST}" ]; then
   fail "local binary not built at ${LOCAL_DIST} — run 'vp run build' from repo root first"

--- a/tests/integration/deep-getatt-chains/verify.sh
+++ b/tests/integration/deep-getatt-chains/verify.sh
@@ -75,7 +75,9 @@ cleanup() {
   fi
   set -eu
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ ! -f "${LOCAL_DIST}" ]; then
   fail "local binary not built at ${LOCAL_DIST} — run 'vp run build' from repo root first"

--- a/tests/integration/deletion-ordering-complex/verify.sh
+++ b/tests/integration/deletion-ordering-complex/verify.sh
@@ -180,8 +180,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 1: install + build cdkd"
 (cd "${REPO_ROOT}" && pnpm install)

--- a/tests/integration/deletion-ordering-complex/verify.sh
+++ b/tests/integration/deletion-ordering-complex/verify.sh
@@ -180,6 +180,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 1: install + build cdkd"
 (cd "${REPO_ROOT}" && pnpm install)
@@ -290,5 +292,5 @@ if [ "${ORPHANS}" -ne 0 ]; then
 fi
 echo "[verify] step 6 ok: no orphan AWS resources (LB / TG / SG / subnets / IGW / VPC / EC2 all gone)"
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS"

--- a/tests/integration/deletion-policy-retain/verify.sh
+++ b/tests/integration/deletion-policy-retain/verify.sh
@@ -41,8 +41,8 @@ cleanup() {
   exit ${rc}
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then

--- a/tests/integration/deletion-policy-retain/verify.sh
+++ b/tests/integration/deletion-policy-retain/verify.sh
@@ -40,7 +40,9 @@ cleanup() {
   aws ssm delete-parameter --region "${AWS_REGION}" --name "${DESTROY_PARAM}" >/dev/null 2>&1 || true
   exit ${rc}
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then
@@ -143,4 +145,4 @@ echo "    retain param manually deleted, AWS clean (✓)"
 
 echo ""
 echo "==> All deletion-policy-retain checks passed"
-trap - EXIT
+trap - EXIT INT TERM

--- a/tests/integration/deployment-events/verify.sh
+++ b/tests/integration/deployment-events/verify.sh
@@ -76,6 +76,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 1: install + build cdkd (root) + fixture deps"
 (cd "${REPO_ROOT}" && pnpm install)
@@ -231,5 +233,5 @@ if echo "${REMAINING}" | grep -E -q '\.(jsonl|json)$'; then
 fi
 echo "[verify] step 7 ok: events sidecar removed"
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS"

--- a/tests/integration/deployment-events/verify.sh
+++ b/tests/integration/deployment-events/verify.sh
@@ -76,8 +76,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 1: install + build cdkd (root) + fixture deps"
 (cd "${REPO_ROOT}" && pnpm install)

--- a/tests/integration/destroy-interrupt/verify.sh
+++ b/tests/integration/destroy-interrupt/verify.sh
@@ -63,8 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 state_exists() {
   aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1

--- a/tests/integration/destroy-interrupt/verify.sh
+++ b/tests/integration/destroy-interrupt/verify.sh
@@ -63,6 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 state_exists() {
   aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1

--- a/tests/integration/diff-intrinsic-target-change/verify.sh
+++ b/tests/integration/diff-intrinsic-target-change/verify.sh
@@ -38,8 +38,8 @@ cleanup() {
   exit ${rc}
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then

--- a/tests/integration/diff-intrinsic-target-change/verify.sh
+++ b/tests/integration/diff-intrinsic-target-change/verify.sh
@@ -37,7 +37,9 @@ cleanup() {
   ${CDKD} destroy ${STACK} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET}" --force >/dev/null 2>&1 || true
   exit ${rc}
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then

--- a/tests/integration/dlm-lifecycle-policy/verify.sh
+++ b/tests/integration/dlm-lifecycle-policy/verify.sh
@@ -70,8 +70,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dlm-lifecycle-policy/verify.sh
+++ b/tests/integration/dlm-lifecycle-policy/verify.sh
@@ -70,6 +70,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/docdb-neptune/verify.sh
+++ b/tests/integration/docdb-neptune/verify.sh
@@ -68,8 +68,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" \

--- a/tests/integration/docdb-neptune/verify.sh
+++ b/tests/integration/docdb-neptune/verify.sh
@@ -68,6 +68,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" \
@@ -97,5 +99,5 @@ echo "[verify] step 5 ok: state cleared"
 
 # AWS-side orphan auditing is delegated to /run-integ's /cleanup pass.
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS"

--- a/tests/integration/docker-image-asset/verify.sh
+++ b/tests/integration/docker-image-asset/verify.sh
@@ -83,6 +83,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/docker-image-asset/verify.sh
+++ b/tests/integration/docker-image-asset/verify.sh
@@ -83,8 +83,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2
@@ -102,7 +102,7 @@ fi
 echo "==> Checking Docker is available"
 if ! docker info >/dev/null 2>&1; then
   echo "[verify] SKIP: Docker daemon not available (docker info failed); the docker-image-asset integ requires a running Docker daemon to build + push the image."
-  trap - EXIT
+  trap - EXIT INT TERM
   exit 0
 fi
 echo "    OK: Docker daemon is reachable"

--- a/tests/integration/drift-revert-arrays/verify.sh
+++ b/tests/integration/drift-revert-arrays/verify.sh
@@ -62,8 +62,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose

--- a/tests/integration/drift-revert-arrays/verify.sh
+++ b/tests/integration/drift-revert-arrays/verify.sh
@@ -62,6 +62,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
@@ -118,5 +120,5 @@ echo "[verify] step 6 ok: AWS reverted to template, drift clean"
 echo "[verify] step 7: cdkd destroy --force"
 ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --force
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS"

--- a/tests/integration/drift-revert-vpc/verify.sh
+++ b/tests/integration/drift-revert-vpc/verify.sh
@@ -50,8 +50,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose

--- a/tests/integration/drift-revert-vpc/verify.sh
+++ b/tests/integration/drift-revert-vpc/verify.sh
@@ -50,6 +50,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
@@ -77,5 +79,5 @@ ${CLI} drift "${STACK}" --state-bucket "${STATE_BUCKET}"
 echo "[verify] step 7: cdkd destroy --force"
 ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --force
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS"

--- a/tests/integration/drift-revert/verify.sh
+++ b/tests/integration/drift-revert/verify.sh
@@ -44,8 +44,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose

--- a/tests/integration/drift-revert/verify.sh
+++ b/tests/integration/drift-revert/verify.sh
@@ -44,6 +44,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
@@ -71,5 +73,5 @@ ${CLI} drift "${STACK}" --state-bucket "${STATE_BUCKET}"
 echo "[verify] step 7: cdkd destroy --force"
 ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --force
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS"

--- a/tests/integration/dynamodb-autoscaling/verify.sh
+++ b/tests/integration/dynamodb-autoscaling/verify.sh
@@ -60,8 +60,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-autoscaling/verify.sh
+++ b/tests/integration/dynamodb-autoscaling/verify.sh
@@ -60,6 +60,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-globaltable/verify.sh
+++ b/tests/integration/dynamodb-globaltable/verify.sh
@@ -92,6 +92,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy (baseline — no UPDATE flags)"
 unset CDKD_TEST_UPDATE
@@ -363,5 +365,5 @@ if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
 fi
 echo "[verify] step 16b ok: cdkd state cleared"
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS"

--- a/tests/integration/dynamodb-globaltable/verify.sh
+++ b/tests/integration/dynamodb-globaltable/verify.sh
@@ -92,8 +92,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy (baseline — no UPDATE flags)"
 unset CDKD_TEST_UPDATE

--- a/tests/integration/dynamodb-gsi-update/verify.sh
+++ b/tests/integration/dynamodb-gsi-update/verify.sh
@@ -50,6 +50,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-gsi-update/verify.sh
+++ b/tests/integration/dynamodb-gsi-update/verify.sh
@@ -50,8 +50,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-ondemand/verify.sh
+++ b/tests/integration/dynamodb-ondemand/verify.sh
@@ -70,8 +70,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-ondemand/verify.sh
+++ b/tests/integration/dynamodb-ondemand/verify.sh
@@ -70,6 +70,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-sse/verify.sh
+++ b/tests/integration/dynamodb-sse/verify.sh
@@ -42,8 +42,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-sse/verify.sh
+++ b/tests/integration/dynamodb-sse/verify.sh
@@ -42,6 +42,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-stream-filter/verify.sh
+++ b/tests/integration/dynamodb-stream-filter/verify.sh
@@ -53,8 +53,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-stream-filter/verify.sh
+++ b/tests/integration/dynamodb-stream-filter/verify.sh
@@ -53,6 +53,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-streams/verify.sh
+++ b/tests/integration/dynamodb-streams/verify.sh
@@ -63,6 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-streams/verify.sh
+++ b/tests/integration/dynamodb-streams/verify.sh
@@ -63,8 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-tableclass-switch/verify.sh
+++ b/tests/integration/dynamodb-tableclass-switch/verify.sh
@@ -59,6 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-tableclass-switch/verify.sh
+++ b/tests/integration/dynamodb-tableclass-switch/verify.sh
@@ -59,8 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-ttl-attr-change/verify.sh
+++ b/tests/integration/dynamodb-ttl-attr-change/verify.sh
@@ -47,6 +47,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/dynamodb-ttl-attr-change/verify.sh
+++ b/tests/integration/dynamodb-ttl-attr-change/verify.sh
@@ -47,8 +47,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/ec2-instance/verify.sh
+++ b/tests/integration/ec2-instance/verify.sh
@@ -75,8 +75,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/ec2-instance/verify.sh
+++ b/tests/integration/ec2-instance/verify.sh
@@ -75,6 +75,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/ecr-scanning/verify.sh
+++ b/tests/integration/ecr-scanning/verify.sh
@@ -48,6 +48,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first" >&2; exit 1; fi

--- a/tests/integration/ecr-scanning/verify.sh
+++ b/tests/integration/ecr-scanning/verify.sh
@@ -48,8 +48,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first" >&2; exit 1; fi

--- a/tests/integration/ecs-fargate/verify.sh
+++ b/tests/integration/ecs-fargate/verify.sh
@@ -51,6 +51,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/ecs-fargate/verify.sh
+++ b/tests/integration/ecs-fargate/verify.sh
@@ -51,8 +51,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/ecs-service-update-props/verify.sh
+++ b/tests/integration/ecs-service-update-props/verify.sh
@@ -59,6 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/ecs-service-update-props/verify.sh
+++ b/tests/integration/ecs-service-update-props/verify.sh
@@ -59,8 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/efs-immutable-replacement/verify.sh
+++ b/tests/integration/efs-immutable-replacement/verify.sh
@@ -58,6 +58,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET env var is required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then

--- a/tests/integration/efs-immutable-replacement/verify.sh
+++ b/tests/integration/efs-immutable-replacement/verify.sh
@@ -58,8 +58,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET env var is required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then

--- a/tests/integration/efs-standalone/verify.sh
+++ b/tests/integration/efs-standalone/verify.sh
@@ -48,6 +48,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/efs-standalone/verify.sh
+++ b/tests/integration/efs-standalone/verify.sh
@@ -48,8 +48,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/elasticache-replicationgroup-getatt/verify.sh
+++ b/tests/integration/elasticache-replicationgroup-getatt/verify.sh
@@ -44,8 +44,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first (vp run build)" >&2; exit 1; fi

--- a/tests/integration/elasticache-replicationgroup-getatt/verify.sh
+++ b/tests/integration/elasticache-replicationgroup-getatt/verify.sh
@@ -43,7 +43,9 @@ cleanup() {
   set -e
   exit "${rc}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first (vp run build)" >&2; exit 1; fi
@@ -134,4 +136,4 @@ echo "    OK: 0 orphans (state + SSM params + ReplicationGroup all gone)"
 
 echo ""
 echo "==> elasticache-replicationgroup-getatt test passed: GetAtt PrimaryEndPoint resolved to the real endpoint, clean destroy 0 orphans"
-trap - EXIT
+trap - EXIT INT TERM

--- a/tests/integration/emr-cluster/verify.sh
+++ b/tests/integration/emr-cluster/verify.sh
@@ -257,8 +257,8 @@ cleanup() {
 # failure. Cleanup is idempotent, so the re-entry via the EXIT trap is a
 # fast no-op once the sweep above has already run.
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/emr-instance-configs/verify.sh
+++ b/tests/integration/emr-instance-configs/verify.sh
@@ -171,6 +171,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/emr-instance-configs/verify.sh
+++ b/tests/integration/emr-instance-configs/verify.sh
@@ -171,8 +171,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/eventbridge-api-destination/verify.sh
+++ b/tests/integration/eventbridge-api-destination/verify.sh
@@ -50,6 +50,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first" >&2; exit 1; fi

--- a/tests/integration/eventbridge-api-destination/verify.sh
+++ b/tests/integration/eventbridge-api-destination/verify.sh
@@ -50,8 +50,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first" >&2; exit 1; fi

--- a/tests/integration/eventbridge-archive/verify.sh
+++ b/tests/integration/eventbridge-archive/verify.sh
@@ -47,6 +47,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/eventbridge-archive/verify.sh
+++ b/tests/integration/eventbridge-archive/verify.sh
@@ -47,8 +47,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/eventbridge-input-transformer/verify.sh
+++ b/tests/integration/eventbridge-input-transformer/verify.sh
@@ -71,6 +71,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/eventbridge-input-transformer/verify.sh
+++ b/tests/integration/eventbridge-input-transformer/verify.sh
@@ -71,8 +71,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/eventbridge-pipes/verify.sh
+++ b/tests/integration/eventbridge-pipes/verify.sh
@@ -33,6 +33,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/eventbridge-pipes/verify.sh
+++ b/tests/integration/eventbridge-pipes/verify.sh
@@ -33,8 +33,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/eventbridge-scheduler/verify.sh
+++ b/tests/integration/eventbridge-scheduler/verify.sh
@@ -30,8 +30,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/eventbridge-scheduler/verify.sh
+++ b/tests/integration/eventbridge-scheduler/verify.sh
@@ -30,6 +30,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/eventbridge/verify.sh
+++ b/tests/integration/eventbridge/verify.sh
@@ -43,6 +43,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/eventbridge/verify.sh
+++ b/tests/integration/eventbridge/verify.sh
@@ -43,8 +43,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/eventsourcemapping-race/verify.sh
+++ b/tests/integration/eventsourcemapping-race/verify.sh
@@ -82,8 +82,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/eventsourcemapping-race/verify.sh
+++ b/tests/integration/eventsourcemapping-race/verify.sh
@@ -82,6 +82,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/export-nested-stack/verify.sh
+++ b/tests/integration/export-nested-stack/verify.sh
@@ -120,7 +120,9 @@ cleanup() {
   aws s3 rm "s3://${STATE_BUCKET}/${CHILD_STATE_KEY}" --region "${REGION}" 2>/dev/null || true
   exit "${rc}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 1: install + build cdkd"
 (cd "${REPO_ROOT}" && pnpm install)

--- a/tests/integration/export-nested-stack/verify.sh
+++ b/tests/integration/export-nested-stack/verify.sh
@@ -121,8 +121,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 1: install + build cdkd"
 (cd "${REPO_ROOT}" && pnpm install)

--- a/tests/integration/export/verify.sh
+++ b/tests/integration/export/verify.sh
@@ -77,6 +77,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
@@ -415,5 +417,5 @@ for lid in sorted(deleted):
     ;;
 esac
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS (variant=${VARIANT})"

--- a/tests/integration/export/verify.sh
+++ b/tests/integration/export/verify.sh
@@ -77,8 +77,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose

--- a/tests/integration/fifo-sqs-event-source/verify.sh
+++ b/tests/integration/fifo-sqs-event-source/verify.sh
@@ -73,6 +73,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/fifo-sqs-event-source/verify.sh
+++ b/tests/integration/fifo-sqs-event-source/verify.sh
@@ -73,8 +73,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/fsx-lustre/verify.sh
+++ b/tests/integration/fsx-lustre/verify.sh
@@ -109,8 +109,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/fsx-lustre/verify.sh
+++ b/tests/integration/fsx-lustre/verify.sh
@@ -109,6 +109,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/fsx-openzfs/verify.sh
+++ b/tests/integration/fsx-openzfs/verify.sh
@@ -118,8 +118,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/fsx-openzfs/verify.sh
+++ b/tests/integration/fsx-openzfs/verify.sh
@@ -118,6 +118,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/gc-custom-asset-names/verify.sh
+++ b/tests/integration/gc-custom-asset-names/verify.sh
@@ -127,6 +127,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2
@@ -224,6 +226,8 @@ echo "    OK: state Code points at s3://${ASSET_BUCKET}/${CODE_KEY} and the obje
 # Functional assertion: the deployed Lambda actually runs the uploaded asset.
 OUT_FILE="$(mktemp)"
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+trap 'rm -f "${OUT_FILE}"; cleanup; exit 130' INT
+trap 'rm -f "${OUT_FILE}"; cleanup; exit 143' TERM
 aws lambda invoke \
   --function-name "${FN_NAME}" --region "${REGION}" \
   --cli-binary-format raw-in-base64-out \

--- a/tests/integration/gc-custom-asset-names/verify.sh
+++ b/tests/integration/gc-custom-asset-names/verify.sh
@@ -127,8 +127,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2
@@ -226,8 +226,8 @@ echo "    OK: state Code points at s3://${ASSET_BUCKET}/${CODE_KEY} and the obje
 # Functional assertion: the deployed Lambda actually runs the uploaded asset.
 OUT_FILE="$(mktemp)"
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
-trap 'rm -f "${OUT_FILE}"; cleanup; exit 130' INT
-trap 'rm -f "${OUT_FILE}"; cleanup; exit 143' TERM
+trap 'rm -f "${OUT_FILE}"; (exit 130); cleanup; exit 130' INT
+trap 'rm -f "${OUT_FILE}"; (exit 143); cleanup; exit 143' TERM
 aws lambda invoke \
   --function-name "${FN_NAME}" --region "${REGION}" \
   --cli-binary-format raw-in-base64-out \

--- a/tests/integration/getstackoutput-crossregion/verify.sh
+++ b/tests/integration/getstackoutput-crossregion/verify.sh
@@ -73,6 +73,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/getstackoutput-crossregion/verify.sh
+++ b/tests/integration/getstackoutput-crossregion/verify.sh
@@ -73,8 +73,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/glue-securityconfig-replace/verify.sh
+++ b/tests/integration/glue-securityconfig-replace/verify.sh
@@ -53,8 +53,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/glue-securityconfig-replace/verify.sh
+++ b/tests/integration/glue-securityconfig-replace/verify.sh
@@ -53,6 +53,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/glue-update-hardening/verify.sh
+++ b/tests/integration/glue-update-hardening/verify.sh
@@ -55,8 +55,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/glue-update-hardening/verify.sh
+++ b/tests/integration/glue-update-hardening/verify.sh
@@ -55,6 +55,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/iam-oidc-provider/verify.sh
+++ b/tests/integration/iam-oidc-provider/verify.sh
@@ -70,8 +70,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/iam-oidc-provider/verify.sh
+++ b/tests/integration/iam-oidc-provider/verify.sh
@@ -70,6 +70,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/iam-propagation-stress/verify.sh
+++ b/tests/integration/iam-propagation-stress/verify.sh
@@ -108,8 +108,8 @@ report_deploy_failure() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2
@@ -133,8 +133,8 @@ cleanup
 echo "==> Phase 1: deploy with the local binary (race detector)"
 DEPLOY_LOG="$(mktemp)"
 trap 'rm -f "${DEPLOY_LOG}"; cleanup' EXIT
-trap 'rm -f "${DEPLOY_LOG}"; cleanup; exit 130' INT
-trap 'rm -f "${DEPLOY_LOG}"; cleanup; exit 143' TERM
+trap 'rm -f "${DEPLOY_LOG}"; (exit 130); cleanup; exit 130' INT
+trap 'rm -f "${DEPLOY_LOG}"; (exit 143); cleanup; exit 143' TERM
 
 deploy_rc=0
 node "${LOCAL_DIST}" deploy "${STACK}" \
@@ -191,8 +191,8 @@ echo "==> Phase 1b: assert role-consuming resources work"
 # Edge 1: invoke the Lambda on its fresh exec role.
 OUT_FILE="$(mktemp)"
 trap 'rm -f "${DEPLOY_LOG}" "${OUT_FILE}"; cleanup' EXIT
-trap 'rm -f "${DEPLOY_LOG}" "${OUT_FILE}"; cleanup; exit 130' INT
-trap 'rm -f "${DEPLOY_LOG}" "${OUT_FILE}"; cleanup; exit 143' TERM
+trap 'rm -f "${DEPLOY_LOG}" "${OUT_FILE}"; (exit 130); cleanup; exit 130' INT
+trap 'rm -f "${DEPLOY_LOG}" "${OUT_FILE}"; (exit 143); cleanup; exit 143' TERM
 aws lambda invoke \
   --function-name "${FN_NAME}" --region "${REGION}" \
   --cli-binary-format raw-in-base64-out \

--- a/tests/integration/iam-propagation-stress/verify.sh
+++ b/tests/integration/iam-propagation-stress/verify.sh
@@ -108,6 +108,8 @@ report_deploy_failure() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2
@@ -131,6 +133,8 @@ cleanup
 echo "==> Phase 1: deploy with the local binary (race detector)"
 DEPLOY_LOG="$(mktemp)"
 trap 'rm -f "${DEPLOY_LOG}"; cleanup' EXIT
+trap 'rm -f "${DEPLOY_LOG}"; cleanup; exit 130' INT
+trap 'rm -f "${DEPLOY_LOG}"; cleanup; exit 143' TERM
 
 deploy_rc=0
 node "${LOCAL_DIST}" deploy "${STACK}" \
@@ -187,6 +191,8 @@ echo "==> Phase 1b: assert role-consuming resources work"
 # Edge 1: invoke the Lambda on its fresh exec role.
 OUT_FILE="$(mktemp)"
 trap 'rm -f "${DEPLOY_LOG}" "${OUT_FILE}"; cleanup' EXIT
+trap 'rm -f "${DEPLOY_LOG}" "${OUT_FILE}"; cleanup; exit 130' INT
+trap 'rm -f "${DEPLOY_LOG}" "${OUT_FILE}"; cleanup; exit 143' TERM
 aws lambda invoke \
   --function-name "${FN_NAME}" --region "${REGION}" \
   --cli-binary-format raw-in-base64-out \

--- a/tests/integration/iam-role-policies-drift-clean/verify.sh
+++ b/tests/integration/iam-role-policies-drift-clean/verify.sh
@@ -76,6 +76,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/iam-role-policies-drift-clean/verify.sh
+++ b/tests/integration/iam-role-policies-drift-clean/verify.sh
@@ -76,8 +76,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/iam-role-prefixed-name-update/verify.sh
+++ b/tests/integration/iam-role-prefixed-name-update/verify.sh
@@ -60,8 +60,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/iam-role-prefixed-name-update/verify.sh
+++ b/tests/integration/iam-role-prefixed-name-update/verify.sh
@@ -60,6 +60,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/import-attributes/verify.sh
+++ b/tests/integration/import-attributes/verify.sh
@@ -187,8 +187,6 @@ echo "==> Pre-flight ok"
 trap cleanup EXIT
 trap '(exit 130); cleanup; exit 130' INT
 trap '(exit 143); cleanup; exit 143' TERM
-trap '(exit 130); cleanup; exit 130' INT
-trap '(exit 143); cleanup; exit 143' TERM
 
 # ---------------------------------------------------------------------------
 echo "==> Phase 1: cdkd deploy ${STACK}"

--- a/tests/integration/import-attributes/verify.sh
+++ b/tests/integration/import-attributes/verify.sh
@@ -187,6 +187,8 @@ echo "==> Pre-flight ok"
 trap cleanup EXIT
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 # ---------------------------------------------------------------------------
 echo "==> Phase 1: cdkd deploy ${STACK}"

--- a/tests/integration/import-attributes/verify.sh
+++ b/tests/integration/import-attributes/verify.sh
@@ -185,10 +185,10 @@ echo "==> Pre-flight ok"
 # exit 0 reporting PASS. Each signal handler therefore exits explicitly with
 # the conventional 128+signo code.
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 # ---------------------------------------------------------------------------
 echo "==> Phase 1: cdkd deploy ${STACK}"

--- a/tests/integration/import-nested-stack/verify.sh
+++ b/tests/integration/import-nested-stack/verify.sh
@@ -114,7 +114,9 @@ cleanup() {
   aws s3 rm "s3://${STATE_BUCKET}/${CHILD_STATE_KEY}" --region "${REGION}" 2>/dev/null || true
   exit "${rc}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 1: install + build cdkd"
 (cd "${REPO_ROOT}" && pnpm install)

--- a/tests/integration/import-nested-stack/verify.sh
+++ b/tests/integration/import-nested-stack/verify.sh
@@ -115,8 +115,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 1: install + build cdkd"
 (cd "${REPO_ROOT}" && pnpm install)

--- a/tests/integration/import-value-strong-ref/verify.sh
+++ b/tests/integration/import-value-strong-ref/verify.sh
@@ -41,8 +41,8 @@ cleanup() {
   exit ${rc}
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then

--- a/tests/integration/import-value-strong-ref/verify.sh
+++ b/tests/integration/import-value-strong-ref/verify.sh
@@ -40,7 +40,9 @@ cleanup() {
   ${CDKD} destroy ${PRODUCER} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET}" --force >/dev/null 2>&1 || true
   exit ${rc}
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then
@@ -230,4 +232,4 @@ echo "    all state files removed (✓)"
 
 echo ""
 echo "==> All import-value-strong-ref smoke tests passed"
-trap - EXIT
+trap - EXIT INT TERM

--- a/tests/integration/importvalue-chain/verify.sh
+++ b/tests/integration/importvalue-chain/verify.sh
@@ -87,8 +87,8 @@ cleanup() {
   exit ${rc}
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 # Resolve a single export entry's value from the exports index JSON on stdin.
 # Args: <export-name>. Prints the value or empty string.

--- a/tests/integration/importvalue-chain/verify.sh
+++ b/tests/integration/importvalue-chain/verify.sh
@@ -86,7 +86,9 @@ cleanup() {
   aws ssm delete-parameter --name "${C_PARAM_NAME}" --region "${AWS_REGION}" >/dev/null 2>&1 || true
   exit ${rc}
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 # Resolve a single export entry's value from the exports index JSON on stdin.
 # Args: <export-name>. Prints the value or empty string.
@@ -402,4 +404,4 @@ echo "    exports index purged of ChainTopicArn + ChainDerivedValue (✓)"
 
 echo ""
 echo "==> All importvalue-chain smoke tests passed"
-trap - EXIT
+trap - EXIT INT TERM

--- a/tests/integration/inplace-attr-propagation/verify.sh
+++ b/tests/integration/inplace-attr-propagation/verify.sh
@@ -53,8 +53,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2; exit 1

--- a/tests/integration/inplace-attr-propagation/verify.sh
+++ b/tests/integration/inplace-attr-propagation/verify.sh
@@ -53,6 +53,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2; exit 1

--- a/tests/integration/intrinsics-torture-2/verify.sh
+++ b/tests/integration/intrinsics-torture-2/verify.sh
@@ -56,8 +56,8 @@ cleanup() {
   exit ${rc}
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 # Triage helper: dump state + synth on a deploy failure so the failing
 # resource + error are visible for diagnosis.

--- a/tests/integration/intrinsics-torture-2/verify.sh
+++ b/tests/integration/intrinsics-torture-2/verify.sh
@@ -55,7 +55,9 @@ cleanup() {
   done
   exit ${rc}
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 # Triage helper: dump state + synth on a deploy failure so the failing
 # resource + error are visible for diagnosis.
@@ -231,4 +233,4 @@ if [[ ${FAIL_COUNT} -ne 0 ]]; then
 fi
 echo "==> All ${PASS_COUNT} checks passed"
 echo "==> intrinsics-torture-2 result: PASS"
-trap - EXIT
+trap - EXIT INT TERM

--- a/tests/integration/intrinsics-torture/verify.sh
+++ b/tests/integration/intrinsics-torture/verify.sh
@@ -72,6 +72,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 1: install + build cdkd (root) + fixture deps"
 (cd "${REPO_ROOT}" && pnpm install)
@@ -256,5 +258,5 @@ echo "[verify] step 5 ok: state gone, no orphan SSM parameters"
 # Sweep the events sidecar (deliberately survives destroy) so nothing lingers.
 aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/" --recursive >/dev/null 2>&1 || true
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS"

--- a/tests/integration/intrinsics-torture/verify.sh
+++ b/tests/integration/intrinsics-torture/verify.sh
@@ -72,8 +72,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 1: install + build cdkd (root) + fixture deps"
 (cd "${REPO_ROOT}" && pnpm install)

--- a/tests/integration/kinesis-esm-filter/verify.sh
+++ b/tests/integration/kinesis-esm-filter/verify.sh
@@ -33,6 +33,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/kinesis-esm-filter/verify.sh
+++ b/tests/integration/kinesis-esm-filter/verify.sh
@@ -33,8 +33,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/kinesis-stream-mode-switch/verify.sh
+++ b/tests/integration/kinesis-stream-mode-switch/verify.sh
@@ -55,8 +55,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/kinesis-stream-mode-switch/verify.sh
+++ b/tests/integration/kinesis-stream-mode-switch/verify.sh
@@ -55,6 +55,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda-alias-provisioned-concurrency/verify.sh
+++ b/tests/integration/lambda-alias-provisioned-concurrency/verify.sh
@@ -29,6 +29,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/lambda-alias-provisioned-concurrency/verify.sh
+++ b/tests/integration/lambda-alias-provisioned-concurrency/verify.sh
@@ -29,8 +29,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/lambda-arch-switch/verify.sh
+++ b/tests/integration/lambda-arch-switch/verify.sh
@@ -69,8 +69,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda-arch-switch/verify.sh
+++ b/tests/integration/lambda-arch-switch/verify.sh
@@ -69,6 +69,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda-destinations/verify.sh
+++ b/tests/integration/lambda-destinations/verify.sh
@@ -76,6 +76,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda-destinations/verify.sh
+++ b/tests/integration/lambda-destinations/verify.sh
@@ -76,8 +76,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda-env-removal/verify.sh
+++ b/tests/integration/lambda-env-removal/verify.sh
@@ -53,8 +53,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2; exit 1

--- a/tests/integration/lambda-env-removal/verify.sh
+++ b/tests/integration/lambda-env-removal/verify.sh
@@ -53,6 +53,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2; exit 1

--- a/tests/integration/lambda-event-invoke-config-update/verify.sh
+++ b/tests/integration/lambda-event-invoke-config-update/verify.sh
@@ -64,6 +64,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda-event-invoke-config-update/verify.sh
+++ b/tests/integration/lambda-event-invoke-config-update/verify.sh
@@ -64,8 +64,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda-layer-version-update/verify.sh
+++ b/tests/integration/lambda-layer-version-update/verify.sh
@@ -60,8 +60,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda-layer-version-update/verify.sh
+++ b/tests/integration/lambda-layer-version-update/verify.sh
@@ -60,6 +60,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda-log-retention/verify.sh
+++ b/tests/integration/lambda-log-retention/verify.sh
@@ -57,8 +57,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda-log-retention/verify.sh
+++ b/tests/integration/lambda-log-retention/verify.sh
@@ -57,6 +57,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda-reserved-concurrency/verify.sh
+++ b/tests/integration/lambda-reserved-concurrency/verify.sh
@@ -29,6 +29,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/lambda-reserved-concurrency/verify.sh
+++ b/tests/integration/lambda-reserved-concurrency/verify.sh
@@ -29,8 +29,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/lambda-snapstart/verify.sh
+++ b/tests/integration/lambda-snapstart/verify.sh
@@ -62,8 +62,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda-snapstart/verify.sh
+++ b/tests/integration/lambda-snapstart/verify.sh
@@ -62,6 +62,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda/verify.sh
+++ b/tests/integration/lambda/verify.sh
@@ -43,6 +43,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/lambda/verify.sh
+++ b/tests/integration/lambda/verify.sh
@@ -43,8 +43,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/launchtemplate-asg-inplace/verify.sh
+++ b/tests/integration/launchtemplate-asg-inplace/verify.sh
@@ -56,8 +56,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/launchtemplate-asg-inplace/verify.sh
+++ b/tests/integration/launchtemplate-asg-inplace/verify.sh
@@ -56,6 +56,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/local-ecs-service-connect/verify.sh
+++ b/tests/integration/local-ecs-service-connect/verify.sh
@@ -69,8 +69,8 @@ cleanup() {
     | xargs -r docker network rm >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Pre-test orphan sweep"
 cleanup
@@ -92,8 +92,8 @@ ${CDKD} synth >/dev/null
 
 OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
-trap 'rm -f "${OUT_FILE}"; cleanup; exit 130' INT
-trap 'rm -f "${OUT_FILE}"; cleanup; exit 143' TERM
+trap 'rm -f "${OUT_FILE}"; (exit 130); cleanup; exit 130' INT
+trap 'rm -f "${OUT_FILE}"; (exit 143); cleanup; exit 143' TERM
 
 echo "==> Booting both services (one cdkd invocation, shared Cloud Map registry)"
 ${CDKD} local start-service \

--- a/tests/integration/local-ecs-service-connect/verify.sh
+++ b/tests/integration/local-ecs-service-connect/verify.sh
@@ -69,6 +69,8 @@ cleanup() {
     | xargs -r docker network rm >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Pre-test orphan sweep"
 cleanup
@@ -90,6 +92,8 @@ ${CDKD} synth >/dev/null
 
 OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+trap 'rm -f "${OUT_FILE}"; cleanup; exit 130' INT
+trap 'rm -f "${OUT_FILE}"; cleanup; exit 143' TERM
 
 echo "==> Booting both services (one cdkd invocation, shared Cloud Map registry)"
 ${CDKD} local start-service \

--- a/tests/integration/local-invoke-agentcore-from-state/verify.sh
+++ b/tests/integration/local-invoke-agentcore-from-state/verify.sh
@@ -59,8 +59,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy ${STACK}"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose

--- a/tests/integration/local-invoke-agentcore-from-state/verify.sh
+++ b/tests/integration/local-invoke-agentcore-from-state/verify.sh
@@ -59,6 +59,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy ${STACK}"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -456,6 +456,8 @@ cleanup_watch() {
   rm -f "${AGENT_SRC_BAK}" "${WATCH_LOG}" "${WATCH_EVENT}"
 }
 trap 'cleanup_watch; rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${LOOP_EVENT_FILE}" "${A2A_EVENT}"' EXIT
+trap 'cleanup_watch; rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${LOOP_EVENT_FILE}" "${A2A_EVENT}"; exit 130' INT
+trap 'cleanup_watch; rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${LOOP_EVENT_FILE}" "${A2A_EVENT}"; exit 143' TERM
 
 echo '{"loop":true}' > "${WATCH_EVENT}"
 # Background the watch session with stdin pinned to /dev/null (non-TTY one-shot

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -456,8 +456,8 @@ cleanup_watch() {
   rm -f "${AGENT_SRC_BAK}" "${WATCH_LOG}" "${WATCH_EVENT}"
 }
 trap 'cleanup_watch; rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${LOOP_EVENT_FILE}" "${A2A_EVENT}"' EXIT
-trap 'cleanup_watch; rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${LOOP_EVENT_FILE}" "${A2A_EVENT}"; exit 130' INT
-trap 'cleanup_watch; rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${LOOP_EVENT_FILE}" "${A2A_EVENT}"; exit 143' TERM
+trap '(exit 130); cleanup_watch; rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${LOOP_EVENT_FILE}" "${A2A_EVENT}"; exit 130' INT
+trap '(exit 143); cleanup_watch; rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${LOOP_EVENT_FILE}" "${A2A_EVENT}"; exit 143' TERM
 
 echo '{"loop":true}' > "${WATCH_EVENT}"
 # Background the watch session with stdin pinned to /dev/null (non-TTY one-shot

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
@@ -89,8 +89,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: pre-flight orphan scan for BOTH stacks"
 for stack in "${PRODUCER_STACK}" "${CONSUMER_STACK}"; do

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
@@ -88,7 +88,9 @@ cleanup() {
   fi
   exit "${rc}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: pre-flight orphan scan for BOTH stacks"
 for stack in "${PRODUCER_STACK}" "${CONSUMER_STACK}"; do

--- a/tests/integration/local-invoke-from-cfn-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack/verify.sh
@@ -70,7 +70,9 @@ cleanup() {
   fi
   exit "${rc}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: pre-flight orphan scan"
 if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" >/dev/null 2>&1; then

--- a/tests/integration/local-invoke-from-cfn-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack/verify.sh
@@ -71,8 +71,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: pre-flight orphan scan"
 if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" >/dev/null 2>&1; then

--- a/tests/integration/local-invoke-from-state/verify.sh
+++ b/tests/integration/local-invoke-from-state/verify.sh
@@ -66,8 +66,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}"

--- a/tests/integration/local-invoke-from-state/verify.sh
+++ b/tests/integration/local-invoke-from-state/verify.sh
@@ -66,6 +66,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}"

--- a/tests/integration/local-run-task-awsvpc/verify.sh
+++ b/tests/integration/local-run-task-awsvpc/verify.sh
@@ -41,8 +41,8 @@ cleanup() {
     | xargs -r docker network rm >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Pre-test orphan sweep"
 cleanup
@@ -64,8 +64,8 @@ ${CDKD} synth >/dev/null
 
 OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
-trap 'rm -f "${OUT_FILE}"; cleanup; exit 130' INT
-trap 'rm -f "${OUT_FILE}"; cleanup; exit 143' TERM
+trap 'rm -f "${OUT_FILE}"; (exit 130); cleanup; exit 130' INT
+trap 'rm -f "${OUT_FILE}"; (exit 143); cleanup; exit 143' TERM
 
 echo "==> Starting awsvpc task via --detach (output captured)"
 ${CDKD} local run-task CdkdLocalRunTaskAwsvpcFixture/AwsvpcTask \

--- a/tests/integration/local-run-task-awsvpc/verify.sh
+++ b/tests/integration/local-run-task-awsvpc/verify.sh
@@ -41,6 +41,8 @@ cleanup() {
     | xargs -r docker network rm >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Pre-test orphan sweep"
 cleanup
@@ -62,6 +64,8 @@ ${CDKD} synth >/dev/null
 
 OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+trap 'rm -f "${OUT_FILE}"; cleanup; exit 130' INT
+trap 'rm -f "${OUT_FILE}"; cleanup; exit 143' TERM
 
 echo "==> Starting awsvpc task via --detach (output captured)"
 ${CDKD} local run-task CdkdLocalRunTaskAwsvpcFixture/AwsvpcTask \

--- a/tests/integration/local-run-task-cdkd-assets/verify.sh
+++ b/tests/integration/local-run-task-cdkd-assets/verify.sh
@@ -77,6 +77,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd local run-task ${TASK_PATH} (custom-qualifier fromAsset image)"
 # --detach so the one-shot container is left in place for a docker-logs read.

--- a/tests/integration/local-run-task-cdkd-assets/verify.sh
+++ b/tests/integration/local-run-task-cdkd-assets/verify.sh
@@ -77,8 +77,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd local run-task ${TASK_PATH} (custom-qualifier fromAsset image)"
 # --detach so the one-shot container is left in place for a docker-logs read.

--- a/tests/integration/local-run-task-from-state/verify.sh
+++ b/tests/integration/local-run-task-from-state/verify.sh
@@ -117,6 +117,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy ${STACK}"
 ${CDKD} deploy "${STACK}" --state-bucket "${STATE_BUCKET}"

--- a/tests/integration/local-run-task-from-state/verify.sh
+++ b/tests/integration/local-run-task-from-state/verify.sh
@@ -117,8 +117,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy ${STACK}"
 ${CDKD} deploy "${STACK}" --state-bucket "${STATE_BUCKET}"

--- a/tests/integration/local-run-task-multi-container/verify.sh
+++ b/tests/integration/local-run-task-multi-container/verify.sh
@@ -21,6 +21,8 @@ cleanup() {
   docker network ls --filter "name=cdkd-local-task-" --format '{{.ID}}' | xargs -r docker network rm >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null

--- a/tests/integration/local-run-task-multi-container/verify.sh
+++ b/tests/integration/local-run-task-multi-container/verify.sh
@@ -21,8 +21,8 @@ cleanup() {
   docker network ls --filter "name=cdkd-local-task-" --format '{{.ID}}' | xargs -r docker network rm >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null

--- a/tests/integration/local-run-task/verify.sh
+++ b/tests/integration/local-run-task/verify.sh
@@ -27,6 +27,8 @@ cleanup() {
   docker network ls --filter "name=cdkd-local-task-" --format '{{.ID}}' | xargs -r docker network rm >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null

--- a/tests/integration/local-run-task/verify.sh
+++ b/tests/integration/local-run-task/verify.sh
@@ -27,8 +27,8 @@ cleanup() {
   docker network ls --filter "name=cdkd-local-task-" --format '{{.ID}}' | xargs -r docker network rm >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null

--- a/tests/integration/local-start-agentcore/verify.sh
+++ b/tests/integration/local-start-agentcore/verify.sh
@@ -66,7 +66,9 @@ cleanup() {
   rm -f "${OUT_FILE}"
   exit "${rc}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 fail() {
   echo "[verify] FAIL: $*" >&2

--- a/tests/integration/local-start-agentcore/verify.sh
+++ b/tests/integration/local-start-agentcore/verify.sh
@@ -67,8 +67,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 fail() {
   echo "[verify] FAIL: $*" >&2

--- a/tests/integration/local-start-alb-from-state/verify.sh
+++ b/tests/integration/local-start-alb-from-state/verify.sh
@@ -90,6 +90,8 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Pre-test orphan sweep (Docker)"
 cleanup

--- a/tests/integration/local-start-alb-from-state/verify.sh
+++ b/tests/integration/local-start-alb-from-state/verify.sh
@@ -90,8 +90,8 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Pre-test orphan sweep (Docker)"
 cleanup

--- a/tests/integration/local-start-alb/verify.sh
+++ b/tests/integration/local-start-alb/verify.sh
@@ -44,8 +44,8 @@ cleanup() {
     | xargs -r docker network rm >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Pre-test orphan sweep"
 cleanup
@@ -68,8 +68,8 @@ ${CDKD} synth >/dev/null
 # Capture the service output so we can grep for boot banners.
 OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
-trap 'rm -f "${OUT_FILE}"; cleanup; exit 130' INT
-trap 'rm -f "${OUT_FILE}"; cleanup; exit 143' TERM
+trap 'rm -f "${OUT_FILE}"; (exit 130); cleanup; exit 130' INT
+trap 'rm -f "${OUT_FILE}"; (exit 143); cleanup; exit 143' TERM
 
 echo "==> Booting cdkd local start-alb (listener 80 -> host ${HOST_PORT})"
 ${CDKD} local start-alb "${TARGET}" \

--- a/tests/integration/local-start-alb/verify.sh
+++ b/tests/integration/local-start-alb/verify.sh
@@ -44,6 +44,8 @@ cleanup() {
     | xargs -r docker network rm >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Pre-test orphan sweep"
 cleanup
@@ -66,6 +68,8 @@ ${CDKD} synth >/dev/null
 # Capture the service output so we can grep for boot banners.
 OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+trap 'rm -f "${OUT_FILE}"; cleanup; exit 130' INT
+trap 'rm -f "${OUT_FILE}"; cleanup; exit 143' TERM
 
 echo "==> Booting cdkd local start-alb (listener 80 -> host ${HOST_PORT})"
 ${CDKD} local start-alb "${TARGET}" \

--- a/tests/integration/local-start-api-container/verify.sh
+++ b/tests/integration/local-start-api-container/verify.sh
@@ -68,7 +68,9 @@ cleanup() {
   fi
   rm -f "${LOG_FILE}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Starting cdkd local start-api on port ${PORT}"
 ${CDKD} local start-api \

--- a/tests/integration/local-start-api-container/verify.sh
+++ b/tests/integration/local-start-api-container/verify.sh
@@ -69,8 +69,8 @@ cleanup() {
   rm -f "${LOG_FILE}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Starting cdkd local start-api on port ${PORT}"
 ${CDKD} local start-api \

--- a/tests/integration/local-start-api-rest-v1-non-proxy/verify.sh
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/verify.sh
@@ -72,7 +72,9 @@ cleanup() {
     rm -f "${LOG_FILE}"
   fi
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Booting cdkd local start-api on ${CONTAINER_HOST}:${PORT}"
 ${CDKD} local start-api \

--- a/tests/integration/local-start-api-rest-v1-non-proxy/verify.sh
+++ b/tests/integration/local-start-api-rest-v1-non-proxy/verify.sh
@@ -73,8 +73,8 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Booting cdkd local start-api on ${CONTAINER_HOST}:${PORT}"
 ${CDKD} local start-api \

--- a/tests/integration/local-start-api-websocket/verify.sh
+++ b/tests/integration/local-start-api-websocket/verify.sh
@@ -78,8 +78,8 @@ cleanup() {
   rm -f "$(pwd)/.ws-client.mjs"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Starting cdkd local start-api on port ${PORT}"
 ${CDKD} local start-api \
@@ -400,14 +400,17 @@ echo "==> All WebSocket assertions passed"
 # round-trip + wss.close cleanup). A wedged shutdown that hits the
 # 120s SIGKILL would pass verify.sh silently pre-PR; this assertion
 # fires post-cleanup to catch that regression.
-trap '
-cleanup
-if [[ -n "${SIGTERM_ELAPSED}" ]]; then
-  echo "==> Stage: stage_sigterm_fast (elapsed=${SIGTERM_ELAPSED}s)"
-  if [[ "${SIGTERM_ELAPSED}" -ge 7 ]]; then
-    echo "FAIL: stage_sigterm_fast — server took ${SIGTERM_ELAPSED}s to exit (expected <7s, $(($SIGTERM_ELAPSED - 5))s past the 5s drain ceiling)."
-    exit 1
+cleanup_and_assert_sigterm_fast() {
+  cleanup
+  if [[ -n "${SIGTERM_ELAPSED}" ]]; then
+    echo "==> Stage: stage_sigterm_fast (elapsed=${SIGTERM_ELAPSED}s)"
+    if [[ "${SIGTERM_ELAPSED}" -ge 7 ]]; then
+      echo "FAIL: stage_sigterm_fast — server took ${SIGTERM_ELAPSED}s to exit (expected <7s, $(($SIGTERM_ELAPSED - 5))s past the 5s drain ceiling)."
+      exit 1
+    fi
+    echo "PASS: stage_sigterm_fast — server exited within ${SIGTERM_ELAPSED}s"
   fi
-  echo "PASS: stage_sigterm_fast — server exited within ${SIGTERM_ELAPSED}s"
-fi
-' EXIT INT TERM
+}
+trap cleanup_and_assert_sigterm_fast EXIT
+trap '(exit 130); cleanup_and_assert_sigterm_fast; exit 130' INT
+trap '(exit 143); cleanup_and_assert_sigterm_fast; exit 143' TERM

--- a/tests/integration/local-start-api-websocket/verify.sh
+++ b/tests/integration/local-start-api-websocket/verify.sh
@@ -77,7 +77,9 @@ cleanup() {
   rm -f "${LOG_FILE}"
   rm -f "$(pwd)/.ws-client.mjs"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Starting cdkd local start-api on port ${PORT}"
 ${CDKD} local start-api \

--- a/tests/integration/local-start-api/verify.sh
+++ b/tests/integration/local-start-api/verify.sh
@@ -76,7 +76,9 @@ cleanup() {
   fi
   rm -f "${LOG_FILE}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Starting cdkd local start-api on port ${PORT} (with --watch: watch-source model)"
 ${CDKD} local start-api \

--- a/tests/integration/local-start-api/verify.sh
+++ b/tests/integration/local-start-api/verify.sh
@@ -77,8 +77,8 @@ cleanup() {
   rm -f "${LOG_FILE}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Starting cdkd local start-api on port ${PORT} (with --watch: watch-source model)"
 ${CDKD} local start-api \

--- a/tests/integration/local-start-cloudfront/verify.sh
+++ b/tests/integration/local-start-cloudfront/verify.sh
@@ -48,6 +48,8 @@ cleanup() {
   rm -f "${OUT_FILE}" "${ROOT_BODY}" "${MISS_BODY}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 fail() {
   echo "FAIL: $*" >&2

--- a/tests/integration/local-start-cloudfront/verify.sh
+++ b/tests/integration/local-start-cloudfront/verify.sh
@@ -48,8 +48,8 @@ cleanup() {
   rm -f "${OUT_FILE}" "${ROOT_BODY}" "${MISS_BODY}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 fail() {
   echo "FAIL: $*" >&2

--- a/tests/integration/local-start-service-watch-fast/verify.sh
+++ b/tests/integration/local-start-service-watch-fast/verify.sh
@@ -93,8 +93,8 @@ cleanup() {
 # still triggers restore_source + cleanup. The trap body is null-safe for
 # the unset-backup case via the [[ -n ... ]] guards in restore_source / cleanup.
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 SERVER_CJS_BACKUP="$(mktemp)"
 DOCKERFILE_BACKUP="$(mktemp)"

--- a/tests/integration/local-start-service-watch-fast/verify.sh
+++ b/tests/integration/local-start-service-watch-fast/verify.sh
@@ -92,7 +92,9 @@ cleanup() {
 # Install the trap BEFORE any mktemp/cp so a SIGINT in the pre-boot window
 # still triggers restore_source + cleanup. The trap body is null-safe for
 # the unset-backup case via the [[ -n ... ]] guards in restore_source / cleanup.
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 SERVER_CJS_BACKUP="$(mktemp)"
 DOCKERFILE_BACKUP="$(mktemp)"

--- a/tests/integration/local-start-service/verify.sh
+++ b/tests/integration/local-start-service/verify.sh
@@ -33,6 +33,8 @@ cleanup() {
     | xargs -r docker network rm >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 # Pre-test orphan sweep — a failed previous run can leak cdkd-local-*
 # containers / networks, and the new per-replica subnet-isolation assertion
@@ -62,6 +64,8 @@ ${CDKD} synth >/dev/null
 # Capture the service output so we can grep for the boot banner.
 OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+trap 'rm -f "${OUT_FILE}"; cleanup; exit 130' INT
+trap 'rm -f "${OUT_FILE}"; cleanup; exit 143' TERM
 
 echo "==> Booting service (DesiredCount=2)"
 ${CDKD} local start-service CdkdLocalStartServiceFixture:WebService \

--- a/tests/integration/local-start-service/verify.sh
+++ b/tests/integration/local-start-service/verify.sh
@@ -33,8 +33,8 @@ cleanup() {
     | xargs -r docker network rm >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 # Pre-test orphan sweep — a failed previous run can leak cdkd-local-*
 # containers / networks, and the new per-replica subnet-isolation assertion
@@ -64,8 +64,8 @@ ${CDKD} synth >/dev/null
 # Capture the service output so we can grep for the boot banner.
 OUT_FILE=$(mktemp)
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
-trap 'rm -f "${OUT_FILE}"; cleanup; exit 130' INT
-trap 'rm -f "${OUT_FILE}"; cleanup; exit 143' TERM
+trap 'rm -f "${OUT_FILE}"; (exit 130); cleanup; exit 130' INT
+trap 'rm -f "${OUT_FILE}"; (exit 143); cleanup; exit 143' TERM
 
 echo "==> Booting service (DesiredCount=2)"
 ${CDKD} local start-service CdkdLocalStartServiceFixture:WebService \

--- a/tests/integration/loggroup-class-guard/verify.sh
+++ b/tests/integration/loggroup-class-guard/verify.sh
@@ -59,6 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/loggroup-class-guard/verify.sh
+++ b/tests/integration/loggroup-class-guard/verify.sh
@@ -59,8 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/loggroup-kms-associate/verify.sh
+++ b/tests/integration/loggroup-kms-associate/verify.sh
@@ -59,6 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/loggroup-kms-associate/verify.sh
+++ b/tests/integration/loggroup-kms-associate/verify.sh
@@ -59,8 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/macro-expansion/verify.sh
+++ b/tests/integration/macro-expansion/verify.sh
@@ -76,8 +76,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy ${STACK} (expect macro expansion log line)"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose 2>&1 | tee "${DEPLOY_LOG}"

--- a/tests/integration/macro-expansion/verify.sh
+++ b/tests/integration/macro-expansion/verify.sh
@@ -75,7 +75,9 @@ cleanup() {
   rm -f "${DEPLOY_LOG}" "${INVOKE_OUT}" "${INVOKE_META}" 2>/dev/null || true
   exit "${rc}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy ${STACK} (expect macro expansion log line)"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose 2>&1 | tee "${DEPLOY_LOG}"

--- a/tests/integration/migrate-from-bare-cfn-codegen-only/verify.sh
+++ b/tests/integration/migrate-from-bare-cfn-codegen-only/verify.sh
@@ -37,7 +37,9 @@ STACK_NAME="SmokeMigrated"
 cleanup() {
   rm -rf "${OUTPUT_PARENT}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[smoke] test dir:   ${TEST_DIR}"
 echo "[smoke] output dir: ${OUTPUT_DIR}"

--- a/tests/integration/migrate-from-bare-cfn-codegen-only/verify.sh
+++ b/tests/integration/migrate-from-bare-cfn-codegen-only/verify.sh
@@ -38,8 +38,8 @@ cleanup() {
   rm -rf "${OUTPUT_PARENT}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[smoke] test dir:   ${TEST_DIR}"
 echo "[smoke] output dir: ${OUTPUT_DIR}"

--- a/tests/integration/migrate-from-bare-cfn/verify.sh
+++ b/tests/integration/migrate-from-bare-cfn/verify.sh
@@ -110,8 +110,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: create source CFn stack from bare-cfn-template.json"
 aws cloudformation create-stack \

--- a/tests/integration/migrate-from-bare-cfn/verify.sh
+++ b/tests/integration/migrate-from-bare-cfn/verify.sh
@@ -109,7 +109,9 @@ cleanup() {
   fi
   exit "${rc}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: create source CFn stack from bare-cfn-template.json"
 aws cloudformation create-stack \

--- a/tests/integration/multi-asset/verify.sh
+++ b/tests/integration/multi-asset/verify.sh
@@ -98,6 +98,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2
@@ -243,6 +245,8 @@ assert_codesize "gamma" "${GAMMA_FN}"
 echo "==> Phase 1c: invoke each Lambda + assert its DISTINCT marker (proves correct asset->Lambda wiring)"
 INVOKE_OUT="$(mktemp)"
 trap 'rc=$?; rm -f "${INVOKE_OUT}"; cleanup $rc' EXIT
+trap 'rm -f "${INVOKE_OUT}"; cleanup 130; exit 130' INT
+trap 'rm -f "${INVOKE_OUT}"; cleanup 143; exit 143' TERM
 
 invoke_marker() {
   # $1=function name, returns the .marker field on stdout (empty on failure).
@@ -294,6 +298,8 @@ echo "    OK: generic s3_assets.Asset downloaded at runtime (configBytes=${CONFI
 
 rm -f "${INVOKE_OUT}"
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 # --- Phase 2: destroy (clean) -----------------------------------------------
 echo "==> Phase 2: destroy"

--- a/tests/integration/multi-asset/verify.sh
+++ b/tests/integration/multi-asset/verify.sh
@@ -98,8 +98,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2
@@ -118,7 +118,7 @@ fi
 echo "==> Checking Docker is available"
 if ! docker info >/dev/null 2>&1; then
   echo "[verify] SKIP: Docker daemon not available (docker info failed); the multi-asset integ requires a running Docker daemon to build + push the Docker image asset."
-  trap - EXIT
+  trap - EXIT INT TERM
   exit 0
 fi
 echo "    OK: Docker daemon is reachable"
@@ -245,8 +245,8 @@ assert_codesize "gamma" "${GAMMA_FN}"
 echo "==> Phase 1c: invoke each Lambda + assert its DISTINCT marker (proves correct asset->Lambda wiring)"
 INVOKE_OUT="$(mktemp)"
 trap 'rc=$?; rm -f "${INVOKE_OUT}"; cleanup $rc' EXIT
-trap 'rm -f "${INVOKE_OUT}"; cleanup 130; exit 130' INT
-trap 'rm -f "${INVOKE_OUT}"; cleanup 143; exit 143' TERM
+trap 'rm -f "${INVOKE_OUT}"; (exit 130); cleanup; exit 130' INT
+trap 'rm -f "${INVOKE_OUT}"; (exit 143); cleanup; exit 143' TERM
 
 invoke_marker() {
   # $1=function name, returns the .marker field on stdout (empty on failure).
@@ -298,8 +298,8 @@ echo "    OK: generic s3_assets.Asset downloaded at runtime (configBytes=${CONFI
 
 rm -f "${INVOKE_OUT}"
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 # --- Phase 2: destroy (clean) -----------------------------------------------
 echo "==> Phase 2: destroy"

--- a/tests/integration/nested-stack-3level/verify.sh
+++ b/tests/integration/nested-stack-3level/verify.sh
@@ -58,8 +58,8 @@ cleanup() {
   exit ${rc}
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 # state_key_uri <stackName> -> the s3 URI of that level's state.json
 state_key_uri() {

--- a/tests/integration/nested-stack-3level/verify.sh
+++ b/tests/integration/nested-stack-3level/verify.sh
@@ -57,7 +57,9 @@ cleanup() {
   ${CDKD} destroy ${STACK} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET}" --force >/dev/null 2>&1 || true
   exit ${rc}
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 # state_key_uri <stackName> -> the s3 URI of that level's state.json
 state_key_uri() {

--- a/tests/integration/nested-stack-deep/verify.sh
+++ b/tests/integration/nested-stack-deep/verify.sh
@@ -41,7 +41,9 @@ cleanup() {
   ${CDKD} destroy ${STACK} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET}" --force >/dev/null 2>&1 || true
   exit ${rc}
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then

--- a/tests/integration/nested-stack-deep/verify.sh
+++ b/tests/integration/nested-stack-deep/verify.sh
@@ -42,8 +42,8 @@ cleanup() {
   exit ${rc}
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then

--- a/tests/integration/nodejs-function/verify.sh
+++ b/tests/integration/nodejs-function/verify.sh
@@ -54,8 +54,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/nodejs-function/verify.sh
+++ b/tests/integration/nodejs-function/verify.sh
@@ -54,6 +54,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/opensearch-domain-getatt/verify.sh
+++ b/tests/integration/opensearch-domain-getatt/verify.sh
@@ -43,8 +43,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first (vp run build)" >&2; exit 1; fi

--- a/tests/integration/opensearch-domain-getatt/verify.sh
+++ b/tests/integration/opensearch-domain-getatt/verify.sh
@@ -42,7 +42,9 @@ cleanup() {
   set -e
   exit "${rc}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first (vp run build)" >&2; exit 1; fi
@@ -133,4 +135,4 @@ echo "    OK: 0 orphans (state + SSM params + domain all gone)"
 
 echo ""
 echo "==> opensearch-domain-getatt test passed: GetAtt DomainEndpoint/Arn resolved to the real values, clean destroy 0 orphans"
-trap - EXIT
+trap - EXIT INT TERM

--- a/tests/integration/outputs-only-export/verify.sh
+++ b/tests/integration/outputs-only-export/verify.sh
@@ -49,7 +49,9 @@ cleanup() {
   CDKD_TEST_WITH_CONSUMER=true ${CDKD} destroy ${PRODUCER} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET}" --force >/dev/null 2>&1 || true
   exit ${rc}
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then
@@ -180,4 +182,4 @@ pass "all state files removed"
 
 echo ""
 echo "==> All ${PASS_COUNT} outputs-only-export checks passed"
-trap - EXIT
+trap - EXIT INT TERM

--- a/tests/integration/outputs-only-export/verify.sh
+++ b/tests/integration/outputs-only-export/verify.sh
@@ -50,8 +50,8 @@ cleanup() {
   exit ${rc}
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then

--- a/tests/integration/propagation-races-2/verify.sh
+++ b/tests/integration/propagation-races-2/verify.sh
@@ -96,8 +96,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 # Triage helper: dump cdkd events RESOURCE_FAILED lines on a deploy failure so a
 # CI run shows exactly which race edge failed + the AWS error.

--- a/tests/integration/propagation-races-2/verify.sh
+++ b/tests/integration/propagation-races-2/verify.sh
@@ -96,6 +96,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 # Triage helper: dump cdkd events RESOURCE_FAILED lines on a deploy failure so a
 # CI run shows exactly which race edge failed + the AWS error.

--- a/tests/integration/raw-cfn-conditions-params/verify.sh
+++ b/tests/integration/raw-cfn-conditions-params/verify.sh
@@ -58,8 +58,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/raw-cfn-conditions-params/verify.sh
+++ b/tests/integration/raw-cfn-conditions-params/verify.sh
@@ -58,6 +58,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/rds-aurora/verify.sh
+++ b/tests/integration/rds-aurora/verify.sh
@@ -71,6 +71,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/rds-aurora/verify.sh
+++ b/tests/integration/rds-aurora/verify.sh
@@ -71,8 +71,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/rds-dbinstance-backfill/verify.sh
+++ b/tests/integration/rds-dbinstance-backfill/verify.sh
@@ -92,8 +92,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/rds-dbinstance-backfill/verify.sh
+++ b/tests/integration/rds-dbinstance-backfill/verify.sh
@@ -92,6 +92,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/rds-full-stack/verify.sh
+++ b/tests/integration/rds-full-stack/verify.sh
@@ -116,6 +116,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/rds-full-stack/verify.sh
+++ b/tests/integration/rds-full-stack/verify.sh
@@ -116,8 +116,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/recreate-mixed-direction/verify.sh
+++ b/tests/integration/recreate-mixed-direction/verify.sh
@@ -49,6 +49,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/recreate-mixed-direction/verify.sh
+++ b/tests/integration/recreate-mixed-direction/verify.sh
@@ -49,8 +49,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/recreate-via-cc-api/verify.sh
+++ b/tests/integration/recreate-via-cc-api/verify.sh
@@ -62,8 +62,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/recreate-via-cc-api/verify.sh
+++ b/tests/integration/recreate-via-cc-api/verify.sh
@@ -62,6 +62,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/recreate-via-sdk-provider/verify.sh
+++ b/tests/integration/recreate-via-sdk-provider/verify.sh
@@ -53,8 +53,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/recreate-via-sdk-provider/verify.sh
+++ b/tests/integration/recreate-via-sdk-provider/verify.sh
@@ -53,6 +53,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/redshift-cluster-getatt/verify.sh
+++ b/tests/integration/redshift-cluster-getatt/verify.sh
@@ -40,7 +40,9 @@ cleanup() {
   set -e
   exit "${rc}"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first (vp run build)" >&2; exit 1; fi
@@ -131,4 +133,4 @@ echo "    OK: 0 orphans (state + SSM params + cluster all gone)"
 
 echo ""
 echo "==> redshift-cluster-getatt test passed: GetAtt Endpoint resolved to the real endpoint, clean destroy 0 orphans"
-trap - EXIT
+trap - EXIT INT TERM

--- a/tests/integration/redshift-cluster-getatt/verify.sh
+++ b/tests/integration/redshift-cluster-getatt/verify.sh
@@ -41,8 +41,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then echo "FAIL: STATE_BUCKET required" >&2; exit 1; fi
 if [ ! -f "${LOCAL_DIST}" ]; then echo "FAIL: build dist first (vp run build)" >&2; exit 1; fi

--- a/tests/integration/remove-protection/verify.sh
+++ b/tests/integration/remove-protection/verify.sh
@@ -56,6 +56,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
@@ -219,5 +221,5 @@ echo "[verify] step 7 ok: no ASG-launched orphan instance"
 # the integ's own success signals; broad AWS-side orphan auditing belongs in
 # `/cleanup`.
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS"

--- a/tests/integration/remove-protection/verify.sh
+++ b/tests/integration/remove-protection/verify.sh
@@ -56,8 +56,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose

--- a/tests/integration/replacement-fanout/verify.sh
+++ b/tests/integration/replacement-fanout/verify.sh
@@ -80,8 +80,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/replacement-fanout/verify.sh
+++ b/tests/integration/replacement-fanout/verify.sh
@@ -80,6 +80,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/replacement-immutable-name/verify.sh
+++ b/tests/integration/replacement-immutable-name/verify.sh
@@ -97,6 +97,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2; exit 1

--- a/tests/integration/replacement-immutable-name/verify.sh
+++ b/tests/integration/replacement-immutable-name/verify.sh
@@ -97,8 +97,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2; exit 1

--- a/tests/integration/rollback-failure-injection/verify.sh
+++ b/tests/integration/rollback-failure-injection/verify.sh
@@ -198,6 +198,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 1: install + build cdkd (root) + fixture deps"
 (cd "${REPO_ROOT}" && pnpm install)
@@ -390,5 +392,5 @@ if echo "${REMAINING}" | grep -E -q '\.(jsonl|json)$'; then
 fi
 echo "[verify] step 8 ok: events sidecar removed"
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS"

--- a/tests/integration/rollback-failure-injection/verify.sh
+++ b/tests/integration/rollback-failure-injection/verify.sh
@@ -198,8 +198,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 1: install + build cdkd (root) + fixture deps"
 (cd "${REPO_ROOT}" && pnpm install)

--- a/tests/integration/route53/verify.sh
+++ b/tests/integration/route53/verify.sh
@@ -64,6 +64,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/route53/verify.sh
+++ b/tests/integration/route53/verify.sh
@@ -64,8 +64,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-asset-deploy/verify.sh
+++ b/tests/integration/s3-asset-deploy/verify.sh
@@ -59,6 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2
@@ -122,6 +124,8 @@ echo "    OK: Lambda CodeSize == ${CODE_SIZE} bytes (uploaded asset ZIP, not inl
 #     and the generic s3_assets.Asset was downloaded at runtime ---------------
 OUT_FILE="$(mktemp)"
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
+trap 'rm -f "${OUT_FILE}"; cleanup; exit 130' INT
+trap 'rm -f "${OUT_FILE}"; cleanup; exit 143' TERM
 aws lambda invoke \
   --function-name "${FN_NAME}" --region "${REGION}" \
   --cli-binary-format raw-in-base64-out \

--- a/tests/integration/s3-asset-deploy/verify.sh
+++ b/tests/integration/s3-asset-deploy/verify.sh
@@ -59,8 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2
@@ -124,8 +124,8 @@ echo "    OK: Lambda CodeSize == ${CODE_SIZE} bytes (uploaded asset ZIP, not inl
 #     and the generic s3_assets.Asset was downloaded at runtime ---------------
 OUT_FILE="$(mktemp)"
 trap 'rm -f "${OUT_FILE}"; cleanup' EXIT
-trap 'rm -f "${OUT_FILE}"; cleanup; exit 130' INT
-trap 'rm -f "${OUT_FILE}"; cleanup; exit 143' TERM
+trap 'rm -f "${OUT_FILE}"; (exit 130); cleanup; exit 130' INT
+trap 'rm -f "${OUT_FILE}"; (exit 143); cleanup; exit 143' TERM
 aws lambda invoke \
   --function-name "${FN_NAME}" --region "${REGION}" \
   --cli-binary-format raw-in-base64-out \

--- a/tests/integration/s3-cloudfront/verify.sh
+++ b/tests/integration/s3-cloudfront/verify.sh
@@ -59,6 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-cloudfront/verify.sh
+++ b/tests/integration/s3-cloudfront/verify.sh
@@ -59,8 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-event-notification/verify.sh
+++ b/tests/integration/s3-event-notification/verify.sh
@@ -63,6 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-event-notification/verify.sh
+++ b/tests/integration/s3-event-notification/verify.sh
@@ -63,8 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-lifecycle/verify.sh
+++ b/tests/integration/s3-lifecycle/verify.sh
@@ -52,8 +52,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-lifecycle/verify.sh
+++ b/tests/integration/s3-lifecycle/verify.sh
@@ -52,6 +52,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-object-lock/verify.sh
+++ b/tests/integration/s3-object-lock/verify.sh
@@ -47,6 +47,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-object-lock/verify.sh
+++ b/tests/integration/s3-object-lock/verify.sh
@@ -47,8 +47,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-replication-and-filter/verify.sh
+++ b/tests/integration/s3-replication-and-filter/verify.sh
@@ -55,8 +55,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-replication-and-filter/verify.sh
+++ b/tests/integration/s3-replication-and-filter/verify.sh
@@ -55,6 +55,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-tables/verify.sh
+++ b/tests/integration/s3-tables/verify.sh
@@ -64,6 +64,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-tables/verify.sh
+++ b/tests/integration/s3-tables/verify.sh
@@ -64,8 +64,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-vectors/verify.sh
+++ b/tests/integration/s3-vectors/verify.sh
@@ -39,6 +39,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/s3-vectors/verify.sh
+++ b/tests/integration/s3-vectors/verify.sh
@@ -39,8 +39,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/scheduler-custom-group/verify.sh
+++ b/tests/integration/scheduler-custom-group/verify.sh
@@ -36,6 +36,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/scheduler-custom-group/verify.sh
+++ b/tests/integration/scheduler-custom-group/verify.sh
@@ -36,8 +36,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/schema-v5-to-v6-migration/verify.sh
+++ b/tests/integration/schema-v5-to-v6-migration/verify.sh
@@ -60,8 +60,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/schema-v5-to-v6-migration/verify.sh
+++ b/tests/integration/schema-v5-to-v6-migration/verify.sh
@@ -60,6 +60,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/schema-v6-to-v7-migration/verify.sh
+++ b/tests/integration/schema-v6-to-v7-migration/verify.sh
@@ -59,6 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/schema-v6-to-v7-migration/verify.sh
+++ b/tests/integration/schema-v6-to-v7-migration/verify.sh
@@ -59,8 +59,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/schema-v7-to-v8-migration/verify.sh
+++ b/tests/integration/schema-v7-to-v8-migration/verify.sh
@@ -72,6 +72,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/schema-v7-to-v8-migration/verify.sh
+++ b/tests/integration/schema-v7-to-v8-migration/verify.sh
@@ -72,8 +72,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/sdk-ccapi-crossref/verify.sh
+++ b/tests/integration/sdk-ccapi-crossref/verify.sh
@@ -72,6 +72,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 fail() {
   echo "[verify] FAIL: $*" >&2

--- a/tests/integration/sdk-ccapi-crossref/verify.sh
+++ b/tests/integration/sdk-ccapi-crossref/verify.sh
@@ -72,8 +72,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 fail() {
   echo "[verify] FAIL: $*" >&2

--- a/tests/integration/secrets-dynamic-ref/verify.sh
+++ b/tests/integration/secrets-dynamic-ref/verify.sh
@@ -99,6 +99,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/secrets-dynamic-ref/verify.sh
+++ b/tests/integration/secrets-dynamic-ref/verify.sh
@@ -99,8 +99,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/secrets-rotation-schedule/verify.sh
+++ b/tests/integration/secrets-rotation-schedule/verify.sh
@@ -63,6 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/secrets-rotation-schedule/verify.sh
+++ b/tests/integration/secrets-rotation-schedule/verify.sh
@@ -63,8 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/serverless-api/verify.sh
+++ b/tests/integration/serverless-api/verify.sh
@@ -69,8 +69,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/serverless-api/verify.sh
+++ b/tests/integration/serverless-api/verify.sh
@@ -69,6 +69,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/servicediscovery-namespaces/verify.sh
+++ b/tests/integration/servicediscovery-namespaces/verify.sh
@@ -54,8 +54,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/servicediscovery-namespaces/verify.sh
+++ b/tests/integration/servicediscovery-namespaces/verify.sh
@@ -54,6 +54,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/servicediscovery/verify.sh
+++ b/tests/integration/servicediscovery/verify.sh
@@ -46,6 +46,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/servicediscovery/verify.sh
+++ b/tests/integration/servicediscovery/verify.sh
@@ -46,8 +46,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/ses-identity/verify.sh
+++ b/tests/integration/ses-identity/verify.sh
@@ -48,6 +48,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/ses-identity/verify.sh
+++ b/tests/integration/ses-identity/verify.sh
@@ -48,8 +48,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/sg-circular-dependency/verify.sh
+++ b/tests/integration/sg-circular-dependency/verify.sh
@@ -108,8 +108,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/sg-circular-dependency/verify.sh
+++ b/tests/integration/sg-circular-dependency/verify.sh
@@ -108,6 +108,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/sns-event-source/verify.sh
+++ b/tests/integration/sns-event-source/verify.sh
@@ -62,8 +62,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/sns-event-source/verify.sh
+++ b/tests/integration/sns-event-source/verify.sh
@@ -62,6 +62,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/sns-inline-subscription/verify.sh
+++ b/tests/integration/sns-inline-subscription/verify.sh
@@ -47,6 +47,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/sns-inline-subscription/verify.sh
+++ b/tests/integration/sns-inline-subscription/verify.sh
@@ -47,8 +47,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/sns-sqs-event/verify.sh
+++ b/tests/integration/sns-sqs-event/verify.sh
@@ -50,6 +50,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/sns-sqs-event/verify.sh
+++ b/tests/integration/sns-sqs-event/verify.sh
@@ -50,8 +50,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/sns-subscription-filter/verify.sh
+++ b/tests/integration/sns-subscription-filter/verify.sh
@@ -54,8 +54,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/sns-subscription-filter/verify.sh
+++ b/tests/integration/sns-subscription-filter/verify.sh
@@ -54,6 +54,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/sqs-esm-max-concurrency/verify.sh
+++ b/tests/integration/sqs-esm-max-concurrency/verify.sh
@@ -37,8 +37,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/sqs-esm-max-concurrency/verify.sh
+++ b/tests/integration/sqs-esm-max-concurrency/verify.sh
@@ -37,6 +37,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/stepfunctions-logging/verify.sh
+++ b/tests/integration/stepfunctions-logging/verify.sh
@@ -63,6 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/stepfunctions-logging/verify.sh
+++ b/tests/integration/stepfunctions-logging/verify.sh
@@ -63,8 +63,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/stepfunctions-s3-definition/verify.sh
+++ b/tests/integration/stepfunctions-s3-definition/verify.sh
@@ -57,8 +57,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/stepfunctions-s3-definition/verify.sh
+++ b/tests/integration/stepfunctions-s3-definition/verify.sh
@@ -57,6 +57,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/synthetics-canary/verify.sh
+++ b/tests/integration/synthetics-canary/verify.sh
@@ -49,6 +49,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/synthetics-canary/verify.sh
+++ b/tests/integration/synthetics-canary/verify.sh
@@ -49,8 +49,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/tags-propagation/verify.sh
+++ b/tests/integration/tags-propagation/verify.sh
@@ -77,8 +77,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy (a wrong-Tags-shape crash on any type fails here)"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose

--- a/tests/integration/tags-propagation/verify.sh
+++ b/tests/integration/tags-propagation/verify.sh
@@ -77,6 +77,8 @@ cleanup() {
   exit "${rc}"
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 echo "[verify] step 2: cdkd deploy (a wrong-Tags-shape crash on any type fails here)"
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
@@ -218,5 +220,5 @@ echo "[verify]   ok: clean deploy is drift-free (no tag-order false positive)"
 echo "[verify] step 6: cdkd destroy --force"
 ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --force
 
-trap - EXIT
+trap - EXIT INT TERM
 echo "[verify] PASS"

--- a/tests/integration/throttle-wide-dag/verify.sh
+++ b/tests/integration/throttle-wide-dag/verify.sh
@@ -91,8 +91,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/throttle-wide-dag/verify.sh
+++ b/tests/integration/throttle-wide-dag/verify.sh
@@ -91,6 +91,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/update-policy-mutations/verify.sh
+++ b/tests/integration/update-policy-mutations/verify.sh
@@ -77,7 +77,9 @@ cleanup() {
   aws ssm delete-parameter --region "${AWS_REGION}" --name "${STABLE_PARAM}" >/dev/null 2>&1 || true
   exit ${rc}
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 # --- helpers (BSD-portable) ------------------------------------------
 bucket_exists() {
@@ -247,4 +249,4 @@ echo "    0 leftover resources (✓)"
 
 echo ""
 echo "==> All update-policy-mutations checks passed"
-trap - EXIT
+trap - EXIT INT TERM

--- a/tests/integration/update-policy-mutations/verify.sh
+++ b/tests/integration/update-policy-mutations/verify.sh
@@ -78,8 +78,8 @@ cleanup() {
   exit ${rc}
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 # --- helpers (BSD-portable) ------------------------------------------
 bucket_exists() {

--- a/tests/integration/update-replace/verify.sh
+++ b/tests/integration/update-replace/verify.sh
@@ -75,8 +75,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/update-replace/verify.sh
+++ b/tests/integration/update-replace/verify.sh
@@ -75,6 +75,8 @@ cleanup() {
 }
 
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 if [ -z "${STATE_BUCKET:-}" ]; then
   echo "FAIL: STATE_BUCKET env var is required" >&2

--- a/tests/integration/wait-condition-handle/verify.sh
+++ b/tests/integration/wait-condition-handle/verify.sh
@@ -31,6 +31,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/integration/wait-condition-handle/verify.sh
+++ b/tests/integration/wait-condition-handle/verify.sh
@@ -31,8 +31,8 @@ cleanup() {
   set -eu
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
 
 [ -z "${STATE_BUCKET:-}" ] && { echo "FAIL: STATE_BUCKET required" >&2; exit 1; }
 [ ! -f "${LOCAL_DIST}" ] && { echo "FAIL: build dist first" >&2; exit 1; }

--- a/tests/unit/scripts/integ-verify-signal-traps.test.ts
+++ b/tests/unit/scripts/integ-verify-signal-traps.test.ts
@@ -17,15 +17,17 @@ import {
 const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
 
 /**
- * Fixtures whose verify.sh is owned by an in-flight PR at the time of the
- * #1097 sweep, so the sweep deliberately skipped them to avoid a cross-lane
- * collision. Each entry is asserted to still be NON-compliant below, so the
- * exception self-expires: once the owning PR lands the correct form, this test
- * fails and forces the entry to be deleted rather than silently lingering.
+ * Fixtures whose verify.sh is owned by an in-flight PR, so the sweep skips them
+ * to avoid a cross-lane collision. Each entry is asserted to still be
+ * NON-compliant below, so the exception self-expires: once the owning PR lands
+ * the correct form, this test fails and forces the entry to be deleted rather
+ * than silently lingering.
+ *
+ * Empty today. `emr-cluster` was the one entry; PR #1101 merged mid-review with
+ * the un-seeded `trap 'cleanup; exit 130' INT` form, so this PR rebased onto it
+ * and swept it like the rest.
  */
-const PENDING_OTHER_PR: Record<string, string> = {
-  'emr-cluster': 'PR #1101 (EMR import round-trip) rewrites this verify.sh',
-};
+const PENDING_OTHER_PR: Record<string, string> = {};
 
 function readFixtures() {
   return readdirSync(INTEG_ROOT, { withFileTypes: true })

--- a/tests/unit/scripts/integ-verify-signal-traps.test.ts
+++ b/tests/unit/scripts/integ-verify-signal-traps.test.ts
@@ -1,26 +1,17 @@
 import { describe, it, expect } from 'vite-plus/test';
-import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync, spawn } from 'node:child_process';
+import {
+  classifyVerifyScript,
+  joinMultilineTraps,
+} from '../../../scripts/check-integ-signal-traps.js';
 
 /**
- * Regression guard for issue #1097 pattern 1 (signal handling in integ fixtures).
- *
- * A bash signal handler RETURNS to the interrupted point rather than exiting, so
- * `trap cleanup EXIT INT TERM` runs `cleanup` and then RESUMES the interrupted
- * phase -- the script can walk into the next phase and `exit 0`, reporting PASS
- * while `cleanup` raced a still-live deploy. And a bare `trap cleanup EXIT` with
- * no signal handler at all skips cleanup entirely on Ctrl-C or a harness
- * timeout, leaking billable AWS resources.
- *
- * The only correct form is an explicitly exiting handler per signal:
- *
- *   trap cleanup EXIT
- *   trap 'cleanup; exit 130' INT
- *   trap 'cleanup; exit 143' TERM
- *
- * This test is the lint that keeps the #1097 sweep from rotting: any fixture
- * that arms a resource-cleanup EXIT trap must also arm exiting INT and TERM
- * traps.
+ * Regression guard for issue #1097 pattern 1 (signal handling in integ
+ * fixtures). See `scripts/check-integ-signal-traps.ts` for why the correct
+ * form is what it is.
  */
 
 const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
@@ -36,63 +27,187 @@ const PENDING_OTHER_PR: Record<string, string> = {
   'emr-cluster': 'PR #1101 (EMR import round-trip) rewrites this verify.sh',
 };
 
-interface FixtureTraps {
-  name: string;
-  /** Arms an EXIT trap that reaches a cleanup function (vs. a temp-file `rm`). */
-  hasCleanupExitTrap: boolean;
-  hasExitingIntTrap: boolean;
-  hasExitingTermTrap: boolean;
-  /** The dangerous bare-function form that resumes the interrupted phase. */
-  hasBareSignalTrap: boolean;
-}
-
-function readFixtures(): FixtureTraps[] {
+function readFixtures() {
   return readdirSync(INTEG_ROOT, { withFileTypes: true })
     .filter((e) => e.isDirectory() && existsSync(join(INTEG_ROOT, e.name, 'verify.sh')))
-    .map((e) => {
-      const lines = readFileSync(join(INTEG_ROOT, e.name, 'verify.sh'), 'utf8').split('\n');
-      const trapLines = lines.map((l) => l.trim()).filter((l) => l.startsWith('trap '));
+    .map((e) => ({
+      name: e.name,
+      ...classifyVerifyScript(readFileSync(join(INTEG_ROOT, e.name, 'verify.sh'), 'utf8')),
+    }));
+}
 
-      const isCleanupExit = (l: string) =>
-        /^trap (cleanup|'.*cleanup.*') EXIT$/.test(l) && !l.startsWith('trap - ');
+describe('classifyVerifyScript', () => {
+  const CLEANUP = 'cleanup() {\n  echo teardown\n}\n';
 
-      return {
-        name: e.name,
-        hasCleanupExitTrap: trapLines.some(isCleanupExit),
-        hasExitingIntTrap: trapLines.some((l) => /^trap '.*exit 130' INT$/.test(l)),
-        hasExitingTermTrap: trapLines.some((l) => /^trap '.*exit 143' TERM$/.test(l)),
-        hasBareSignalTrap: trapLines.some((l) => /^trap [a-z_]+ .*\b(INT|TERM)\b/.test(l)),
-      };
-    });
+  it('accepts the canonical three-trap form', () => {
+    const c = classifyVerifyScript(
+      `${CLEANUP}trap cleanup EXIT\ntrap '(exit 130); cleanup; exit 130' INT\ntrap '(exit 143); cleanup; exit 143' TERM\n`,
+    );
+    expect(c.hasCleanupExitTrap).toBe(true);
+    expect(c.hasCorrectIntTrap).toBe(true);
+    expect(c.hasCorrectTermTrap).toBe(true);
+    expect(c.hasResumingSignalTrap).toBe(false);
+  });
+
+  // The reviewer of PR #1102 showed the first-cut regex (`^trap [a-z_]+ `)
+  // matched only the single literal `trap cleanup EXIT INT TERM`. Every shape
+  // below is the same bug and must be caught.
+  it.each([
+    ['bare function', 'trap cleanup EXIT INT TERM'],
+    ['single-quoted', "trap 'cleanup' EXIT INT TERM"],
+    ['double-quoted', 'trap "cleanup" EXIT INT TERM'],
+    ['digit in name', 'trap cleanup2 EXIT INT TERM'],
+    ['capitalized', 'trap Cleanup EXIT INT TERM'],
+    ['INT only', 'trap cleanup INT'],
+    ['body without exit', "trap 'cleanup; echo done' INT"],
+  ])('flags the resuming form: %s', (_label, trapLine) => {
+    const fns = 'cleanup() { :; }\ncleanup2() { :; }\nCleanup() { :; }\n';
+    expect(classifyVerifyScript(`${fns}${trapLine}\n`).hasResumingSignalTrap).toBe(true);
+  });
+
+  it('recognizes a cleanup EXIT trap under any handler name', () => {
+    // The first cut keyed on the literal name `cleanup`, so a rename would
+    // have silently exempted the fixture from the INT/TERM requirement.
+    for (const name of ['cleanup', 'teardown', 'cleanup_stack']) {
+      const c = classifyVerifyScript(`${name}() {\n  :\n}\ntrap ${name} EXIT\n`);
+      expect(c.hasCleanupExitTrap).toBe(true);
+      expect(c.hasCorrectIntTrap).toBe(false);
+    }
+  });
+
+  it('requires the (exit N) seed, not just a trailing exit', () => {
+    // `trap 'cleanup; exit 130' INT` looks right but leaves `$?` as the
+    // interrupted command's status, so an `rc=$?` cleanup can skip teardown.
+    const c = classifyVerifyScript(`${CLEANUP}trap 'cleanup; exit 130' INT\n`);
+    expect(c.hasCorrectIntTrap).toBe(false);
+  });
+
+  it('does not treat a disarm as an arm', () => {
+    const c = classifyVerifyScript(`${CLEANUP}trap - EXIT INT TERM\n`);
+    expect(c.hasCleanupExitTrap).toBe(false);
+    expect(c.hasResumingSignalTrap).toBe(false);
+  });
+
+  it('joins a multi-line trap so it cannot hide from a line scan', () => {
+    // local-start-api-websocket shipped exactly this shape; the line-oriented
+    // first cut read it as two unrelated fragments and greenlit the fixture.
+    const script = `${CLEANUP}trap '\ncleanup\necho extra\n' EXIT INT TERM\n`;
+    expect(joinMultilineTraps(script).some((l) => /^trap '.*' EXIT INT TERM$/.test(l))).toBe(true);
+    expect(classifyVerifyScript(script).hasResumingSignalTrap).toBe(true);
+  });
+});
+
+describe('bash signal semantics the sweep relies on', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'cdkd-trap-'));
+
+  /** Gates teardown on `$?` and exits -- the shape ~21 fixtures use. */
+  const RC_GATED_CLEANUP =
+    'cleanup() { rc=$?; if [ "${rc}" -eq 0 ]; then echo SKIPPED; exit 0; fi; echo "TEARDOWN rc=${rc}"; exit "${rc}"; }';
+  /** Does not exit -- the shape that lets a handler return and resume. */
+  const PLAIN_CLEANUP = 'cleanup() { echo TEARDOWN; }';
+
+  const run = async (trapLines: string, cleanupFn = RC_GATED_CLEANUP) => {
+    const path = join(dir, `t-${Math.abs(hash(trapLines + cleanupFn))}.sh`);
+    writeFileSync(
+      path,
+      `#!/usr/bin/env bash
+set -euo pipefail
+${cleanupFn}
+${trapLines}
+echo phase1
+sleep 2
+echo RESUMED
+`,
+      { mode: 0o755 },
+    );
+    const child = spawn('bash', [path]);
+    const out: string[] = [];
+    child.stdout.on('data', (d) => out.push(String(d)));
+    await new Promise((r) => setTimeout(r, 400));
+    child.kill('SIGINT');
+    const code = await new Promise<number>((r) => child.on('exit', (c) => r(c ?? -1)));
+    return { code, out: out.join('') };
+  };
+
+  it('the bare form resumes the interrupted phase and reports success', async () => {
+    // A bash signal handler RETURNS to the interrupted point. With a cleanup
+    // that does not exit on its own, the script walks straight into the next
+    // phase and finishes 0 -- a leaked stack reported as PASS.
+    const { code, out } = await run('trap cleanup EXIT INT TERM', PLAIN_CLEANUP);
+    expect(out).toContain('RESUMED');
+    expect(code).toBe(0);
+  });
+
+  it('the un-seeded form skips teardown entirely when $? happens to be 0', async () => {
+    const { code, out } = await run("trap cleanup EXIT\ntrap 'cleanup; exit 130' INT");
+    expect(out).toContain('SKIPPED');
+    expect(out).not.toContain('TEARDOWN');
+    expect(code).toBe(0);
+  });
+
+  it('the canonical form tears down with the signal code and exits 130', async () => {
+    const { code, out } = await run(
+      "trap cleanup EXIT\ntrap '(exit 130); cleanup; exit 130' INT",
+    );
+    expect(out).toContain('TEARDOWN rc=130');
+    expect(out).not.toContain('RESUMED');
+    expect(code).toBe(130);
+  });
+
+  it('cleans up the temp scripts', () => {
+    rmSync(dir, { recursive: true, force: true });
+    expect(existsSync(dir)).toBe(false);
+  });
+});
+
+function hash(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return h;
 }
 
 describe('integ fixture verify.sh signal traps (#1097 pattern 1)', () => {
   const fixtures = readFixtures();
+  const inScope = fixtures.filter((f) => !(f.name in PENDING_OTHER_PR));
 
   it('finds the fixture tree', () => {
     expect(fixtures.length).toBeGreaterThan(100);
   });
 
-  it('never uses the bare-function signal trap that resumes the interrupted phase', () => {
-    const offenders = fixtures
-      .filter((f) => !(f.name in PENDING_OTHER_PR))
-      .filter((f) => f.hasBareSignalTrap)
-      .map((f) => f.name);
-    expect(offenders).toEqual([]);
+  it('every fixture verify.sh is syntactically valid bash', () => {
+    const bad = fixtures
+      .map((f) => ({
+        name: f.name,
+        rc: spawnSync('bash', ['-n', join(INTEG_ROOT, f.name, 'verify.sh')]).status,
+      }))
+      .filter((r) => r.rc !== 0)
+      .map((r) => r.name);
+    expect(bad).toEqual([]);
   });
 
-  it('arms an exiting INT trap wherever it arms a cleanup EXIT trap', () => {
-    const offenders = fixtures
-      .filter((f) => !(f.name in PENDING_OTHER_PR))
-      .filter((f) => f.hasCleanupExitTrap && !f.hasExitingIntTrap)
-      .map((f) => f.name);
-    expect(offenders).toEqual([]);
+  it('never arms a signal trap that can resume the interrupted phase', () => {
+    expect(inScope.filter((f) => f.hasResumingSignalTrap).map((f) => f.name)).toEqual([]);
   });
 
-  it('arms an exiting TERM trap wherever it arms a cleanup EXIT trap', () => {
-    const offenders = fixtures
-      .filter((f) => !(f.name in PENDING_OTHER_PR))
-      .filter((f) => f.hasCleanupExitTrap && !f.hasExitingTermTrap)
+  it('arms a seeded, exiting INT trap wherever it arms a cleanup EXIT trap', () => {
+    expect(
+      inScope.filter((f) => f.hasCleanupExitTrap && !f.hasCorrectIntTrap).map((f) => f.name),
+    ).toEqual([]);
+  });
+
+  it('arms a seeded, exiting TERM trap wherever it arms a cleanup EXIT trap', () => {
+    expect(
+      inScope.filter((f) => f.hasCleanupExitTrap && !f.hasCorrectTermTrap).map((f) => f.name),
+    ).toEqual([]);
+  });
+
+  it('never leaves a bare `trap - EXIT` disarm that keeps signal handlers armed', () => {
+    const offenders = inScope
+      .filter((f) =>
+        readFileSync(join(INTEG_ROOT, f.name, 'verify.sh'), 'utf8')
+          .split('\n')
+          .some((l) => /^\s*trap\s+-\s+EXIT\s*$/.test(l)),
+      )
       .map((f) => f.name);
     expect(offenders).toEqual([]);
   });
@@ -103,9 +218,9 @@ describe('integ fixture verify.sh signal traps (#1097 pattern 1)', () => {
     // regression in that same fixture.
     const stale = Object.keys(PENDING_OTHER_PR).filter((name) => {
       const f = fixtures.find((x) => x.name === name);
-      // A fixture that disappeared entirely is also a stale entry.
-      if (!f) return true;
-      return !f.hasBareSignalTrap && (!f.hasCleanupExitTrap || f.hasExitingIntTrap);
+      if (!f) return true; // fixture gone entirely -> entry is stale
+      if (f.hasResumingSignalTrap) return false; // still broken -> entry earns its keep
+      return !f.hasCleanupExitTrap || (f.hasCorrectIntTrap && f.hasCorrectTermTrap);
     });
     expect(stale).toEqual([]);
   });

--- a/tests/unit/scripts/integ-verify-signal-traps.test.ts
+++ b/tests/unit/scripts/integ-verify-signal-traps.test.ts
@@ -90,6 +90,50 @@ describe('classifyVerifyScript', () => {
     expect(c.hasResumingSignalTrap).toBe(false);
   });
 
+  // Every case below is a non-compliant shape that passed an earlier cut of
+  // the classifier. They come from the PR #1102 re-review, which built them by
+  // reading the regexes rather than the tree.
+  it('rejects a seed placed AFTER the handler call', () => {
+    // `[A-Za-z_]` after the seed used to match the literal `exit`, so the
+    // round-1 blocker's own shape passed with the tokens merely reordered.
+    const c = classifyVerifyScript(`${CLEANUP}trap 'cleanup; (exit 130); exit 130' INT\n`);
+    expect(c.hasCorrectIntTrap).toBe(false);
+  });
+
+  it('rejects a command between the seed and the handler', () => {
+    // The `rm` clobbers `$?` again, defeating the seed.
+    const c = classifyVerifyScript(
+      `${CLEANUP}trap '(exit 130); rm -f x; cleanup; exit 130' INT\n`,
+    );
+    expect(c.hasCorrectIntTrap).toBe(false);
+  });
+
+  it('sees double-quoted trap bodies', () => {
+    const c = classifyVerifyScript(`${CLEANUP}trap "cleanup; echo x" EXIT INT TERM\n`);
+    expect(c.hasCleanupExitTrap).toBe(true);
+    expect(c.hasResumingSignalTrap).toBe(true);
+  });
+
+  it('requires a correct INT arm even with no EXIT trap', () => {
+    const c = classifyVerifyScript(`${CLEANUP}trap 'cleanup; exit 130' INT\n`);
+    expect(c.hasCorrectIntTrap).toBe(false);
+  });
+
+  it('requires EVERY re-arm to be correct, not just one', () => {
+    // 8 fixtures legitimately re-arm at phase boundaries. A `some()` check
+    // would greenlight a file whose later re-arm dropped the seed -- the most
+    // likely future regression.
+    const c = classifyVerifyScript(
+      `${CLEANUP}trap cleanup EXIT
+trap '(exit 130); cleanup; exit 130' INT
+trap '(exit 143); cleanup; exit 143' TERM
+echo phase2
+trap 'cleanup; exit 130' INT
+`,
+    );
+    expect(c.hasCorrectIntTrap).toBe(false);
+  });
+
   it('joins a multi-line trap so it cannot hide from a line scan', () => {
     // local-start-api-websocket shipped exactly this shape; the line-oriented
     // first cut read it as two unrelated fragments and greenlit the fixture.

--- a/tests/unit/scripts/integ-verify-signal-traps.test.ts
+++ b/tests/unit/scripts/integ-verify-signal-traps.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Regression guard for issue #1097 pattern 1 (signal handling in integ fixtures).
+ *
+ * A bash signal handler RETURNS to the interrupted point rather than exiting, so
+ * `trap cleanup EXIT INT TERM` runs `cleanup` and then RESUMES the interrupted
+ * phase -- the script can walk into the next phase and `exit 0`, reporting PASS
+ * while `cleanup` raced a still-live deploy. And a bare `trap cleanup EXIT` with
+ * no signal handler at all skips cleanup entirely on Ctrl-C or a harness
+ * timeout, leaking billable AWS resources.
+ *
+ * The only correct form is an explicitly exiting handler per signal:
+ *
+ *   trap cleanup EXIT
+ *   trap 'cleanup; exit 130' INT
+ *   trap 'cleanup; exit 143' TERM
+ *
+ * This test is the lint that keeps the #1097 sweep from rotting: any fixture
+ * that arms a resource-cleanup EXIT trap must also arm exiting INT and TERM
+ * traps.
+ */
+
+const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
+
+/**
+ * Fixtures whose verify.sh is owned by an in-flight PR at the time of the
+ * #1097 sweep, so the sweep deliberately skipped them to avoid a cross-lane
+ * collision. Each entry is asserted to still be NON-compliant below, so the
+ * exception self-expires: once the owning PR lands the correct form, this test
+ * fails and forces the entry to be deleted rather than silently lingering.
+ */
+const PENDING_OTHER_PR: Record<string, string> = {
+  'emr-cluster': 'PR #1101 (EMR import round-trip) rewrites this verify.sh',
+};
+
+interface FixtureTraps {
+  name: string;
+  /** Arms an EXIT trap that reaches a cleanup function (vs. a temp-file `rm`). */
+  hasCleanupExitTrap: boolean;
+  hasExitingIntTrap: boolean;
+  hasExitingTermTrap: boolean;
+  /** The dangerous bare-function form that resumes the interrupted phase. */
+  hasBareSignalTrap: boolean;
+}
+
+function readFixtures(): FixtureTraps[] {
+  return readdirSync(INTEG_ROOT, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(INTEG_ROOT, e.name, 'verify.sh')))
+    .map((e) => {
+      const lines = readFileSync(join(INTEG_ROOT, e.name, 'verify.sh'), 'utf8').split('\n');
+      const trapLines = lines.map((l) => l.trim()).filter((l) => l.startsWith('trap '));
+
+      const isCleanupExit = (l: string) =>
+        /^trap (cleanup|'.*cleanup.*') EXIT$/.test(l) && !l.startsWith('trap - ');
+
+      return {
+        name: e.name,
+        hasCleanupExitTrap: trapLines.some(isCleanupExit),
+        hasExitingIntTrap: trapLines.some((l) => /^trap '.*exit 130' INT$/.test(l)),
+        hasExitingTermTrap: trapLines.some((l) => /^trap '.*exit 143' TERM$/.test(l)),
+        hasBareSignalTrap: trapLines.some((l) => /^trap [a-z_]+ .*\b(INT|TERM)\b/.test(l)),
+      };
+    });
+}
+
+describe('integ fixture verify.sh signal traps (#1097 pattern 1)', () => {
+  const fixtures = readFixtures();
+
+  it('finds the fixture tree', () => {
+    expect(fixtures.length).toBeGreaterThan(100);
+  });
+
+  it('never uses the bare-function signal trap that resumes the interrupted phase', () => {
+    const offenders = fixtures
+      .filter((f) => !(f.name in PENDING_OTHER_PR))
+      .filter((f) => f.hasBareSignalTrap)
+      .map((f) => f.name);
+    expect(offenders).toEqual([]);
+  });
+
+  it('arms an exiting INT trap wherever it arms a cleanup EXIT trap', () => {
+    const offenders = fixtures
+      .filter((f) => !(f.name in PENDING_OTHER_PR))
+      .filter((f) => f.hasCleanupExitTrap && !f.hasExitingIntTrap)
+      .map((f) => f.name);
+    expect(offenders).toEqual([]);
+  });
+
+  it('arms an exiting TERM trap wherever it arms a cleanup EXIT trap', () => {
+    const offenders = fixtures
+      .filter((f) => !(f.name in PENDING_OTHER_PR))
+      .filter((f) => f.hasCleanupExitTrap && !f.hasExitingTermTrap)
+      .map((f) => f.name);
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps the in-flight-PR exception list free of already-fixed fixtures', () => {
+    // Self-expiring guard: an entry that has become compliant (its PR merged)
+    // must be deleted from PENDING_OTHER_PR, not left to mask a future
+    // regression in that same fixture.
+    const stale = Object.keys(PENDING_OTHER_PR).filter((name) => {
+      const f = fixtures.find((x) => x.name === name);
+      // A fixture that disappeared entirely is also a stale entry.
+      if (!f) return true;
+      return !f.hasBareSignalTrap && (!f.hasCleanupExitTrap || f.hasExitingIntTrap);
+    });
+    expect(stale).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Pattern 1 of #1097: 190 of 192 integ fixtures had a `verify.sh` signal-trap defect
that lets a run **report PASS while leaking billable AWS resources**. One caused a
real leak on 2026-07-19 (an EMR cluster billed for ~25 minutes before it was
terminated by hand).

Two wrong forms were in the tree:

| Form | Count | Behavior |
|---|---|---|
| No `INT` / `TERM` handler at all | 163 | Ctrl-C or a harness timeout skips cleanup entirely, so resources leak |
| `trap cleanup EXIT INT TERM` (bare function) | 27 | **Worse** — a bash signal handler RETURNS to the interrupted point instead of exiting |

The 27-file form is the dangerous one: `cleanup` runs and the script then
**resumes the interrupted phase**, walks into the next one and can `exit 0` —
reporting PASS. And when only the script PID is signalled, the `node deploy`
child survives, so `cleanup` deletes resources concurrently with a live deploy.

This PR sweeps 182 fixtures to the correct form:

```bash
trap cleanup EXIT
trap '(exit 130); cleanup; exit 130' INT
trap '(exit 143); cleanup; exit 143' TERM
```

Disarm sites become `trap - EXIT INT TERM`, so a Ctrl-C after a fixture's own
successful teardown no longer re-runs `cleanup`.

## The `(exit N)` seed is load-bearing

The obvious form — `trap 'cleanup; exit 130' INT` — is **not** sufficient, and
review caught it before merge. ~21 fixtures' `cleanup` opens with `rc=$?` and
gates the entire teardown on it:

```bash
cleanup() { rc=$?; if [ "${rc}" -eq 0 ]; then exit 0; fi; ...destroy...; }
```

Inside a signal handler `$?` is the **interrupted command's** status, not the
signal. A harness SIGTERM during a `cdkd deploy` whose child reaps 0 makes
`cleanup` see rc=0, **skip the whole teardown** and exit 0 — reintroducing the
exact bug this PR exists to fix, on the very fixtures it claimed to protect.

`(exit N)` seeds `$?` with the signal's code before the call, so `rc=$?` and
`${1:-$?}` cleanups both tear down correctly. Verified empirically against all
three cleanup shapes in the tree (see the new tests). This also removes the
double-`cleanup` the naive form caused on exiting cleanups.

## Scope decisions

- **Composite EXIT traps** get `INT` / `TERM` twins of their own body, with the
  seed placed immediately before the handler call — any command in between
  (e.g. a temp-file `rm`) would clobber `$?` again.
- **`local-start-api-websocket`** armed a **multi-line** `trap ' ... ' EXIT INT
  TERM` that a line-oriented codemod cannot see. Its body is now a named
  function armed on all three signals.
- **Temp-file-only traps are deliberately left alone** — `trap 'rm -f
  "${EVENT_FILE}"' EXIT` in the `local-invoke*` fixtures leaks nothing billable,
  and those fixtures re-arm their trap up to 4 times, so twinning each one would
  be pure diff noise.
- **`emr-cluster` is excluded** — owned by in-flight PR #1101. (`fsx-ontap` /
  `fsx-windows` are added by #1094 and do not exist on `main` yet; they already
  carry the correct form there.)
- **Pattern 2 of #1097** (a probe error read as "resource is gone") is **not** in
  this PR. The issue itself recommends splitting the mechanical sweep from any
  behavior change; pattern 2 needs a shared not-found-vs-undetermined probe
  helper and per-call-site judgement across ~270 sites. #1097 stays open for it.

## Regression guard

`scripts/check-integ-signal-traps.ts` holds the classifier (exported so it can be
table-tested against synthetic shapes, not just today's tree);
`tests/unit/scripts/integ-verify-signal-traps.test.ts` applies it to every fixture
and adds:

- **Shell-semantics tests** that spawn real bash, send a real `SIGINT`, and assert
  each form's actual behavior — the bare form resumes and exits 0, the un-seeded
  form skips teardown and exits 0, the canonical form tears down with rc=130 and
  exits 130. Nothing else in the suite validates the premise the sweep rests on.
- **Detection-hole coverage**: the first-cut regex only matched the literal
  `trap cleanup EXIT INT TERM`. Quoted, capitalized, digit-suffixed and
  renamed-handler variants now all fail the lint, as do multi-line traps and
  handler bodies with no `exit`.
- A **`bash -n` syntax gate** over all 192 fixtures.

The in-flight-PR exception list **self-expires**: a test asserts every entry is
still non-compliant, so once #1101 lands the correct form in `emr-cluster` this
test fails until the entry is deleted.

Convention documented in `docs/testing.md` (user-facing), `.claude/rules/testing.md`
(agent-facing), and `.claude/skills/new-integ/SKILL.md` (the scaffold that would
otherwise keep minting non-compliant fixtures).

## Test plan

- `vp check --fix` / `vp run build` / `vp run test` — 446 files, 7267 tests pass.
- `bash -n` on all 192 fixtures — 0 syntax errors (now asserted by the suite).
- Diff audit: every changed line under `tests/integration/**` is a `trap` line,
  except the `local-start-api-websocket` function extraction.
- Post-sweep audit: 195 seeded `INT` traps, 195 seeded `TERM` traps, 0 un-seeded
  signal traps, 0 bare `trap - EXIT` disarms; only `emr-cluster` remains
  non-compliant, as intended.
- **Live integ**: `/run-integ local-start-api` and `/run-integ
  local-start-api-websocket` against real Docker — the latter specifically
  exercises the hand-restructured multi-line trap, including its SIGTERM
  shutdown-timing assertion. Both clean, 0 orphan containers / networks.

Refs #1097
