### PR TITLE
test(integ): strict gone-probes distinguishing not-found from probe errors (#1097 pattern 2)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -47,6 +47,29 @@ both tear down correctly.
 Enforced by `tests/unit/scripts/integ-verify-signal-traps.test.ts` (issue #1097);
 the user-facing writeup is in [docs/testing.md](../../docs/testing.md).
 
+### `verify.sh` gone-probes (mandatory)
+
+A destroy/leak assertion must never be a silenced blind probe:
+`if aws <read-probe> ... >/dev/null 2>&1; then FAIL` (and the inverse
+`if ! aws ...; then <conclude gone>`) read ANY failure (throttle, auth,
+network) as "gone" and silently pass the leak check (issue #1097 pattern 2).
+Route probes through the canonical helper block every affected fixture carries
+verbatim (source of truth: `scripts/check-integ-probe-not-found.ts`):
+
+```bash
+assert_gone "<leak description>" aws <service> <read-verb> [args...]
+if ! gone_probe aws <service> <read-verb> [args...]; then ...still exists...; fi
+```
+
+`gone_probe` accepts ONLY the canonical not-found signature
+(`'not ?found|no ?such|does ?not ?exist|non ?existent|404'`) and hard-FAILs on
+anything else. Probe state files via `s3api head-object`, never `aws s3 ls`
+(which exits 1 with empty output for "no keys"). Out of scope: mutation probes,
+fail-closed existence checks, pre-flight "already exists" guards, best-effort
+cleanup guards. Enforced by
+`tests/unit/scripts/integ-verify-probe-not-found.test.ts`; user-facing writeup
+in [docs/testing.md](../../docs/testing.md).
+
 ## UPDATE Testing
 
 - Environment variable `CDKD_TEST_UPDATE=true` enables UPDATE test mode

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -62,7 +62,7 @@ if ! gone_probe aws <service> <read-verb> [args...]; then ...still exists...; fi
 ```
 
 `gone_probe` accepts ONLY the canonical not-found signature
-(`'not ?found|no ?such|does ?not ?exist|non ?existent|404'`) and hard-FAILs on
+(`'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'`) and hard-FAILs on
 anything else. Probe state files via `s3api head-object`, never `aws s3 ls`
 (which exits 1 with empty output for "no keys"). Out of scope: mutation probes,
 fail-closed existence checks, pre-flight "already exists" guards, best-effort

--- a/.claude/skills/new-integ/SKILL.md
+++ b/.claude/skills/new-integ/SKILL.md
@@ -165,7 +165,24 @@ The user provides a kebab-case test name (e.g., `ses-email-identity`,
      that it was in-place, not a replacement (e.g. an identity field like
      DynamoDB `CreationDateTime` is unchanged).
    - **Final phase — destroy** (`--force`), then assert the resource is gone, the
-     `state.json` is gone, and sweep the log groups again.
+     `state.json` is gone, and sweep the log groups again. Gone-assertions MUST
+     go through the canonical `gone_probe` / `assert_gone` helper block (copy it
+     verbatim from any swept fixture, e.g.
+     `tests/integration/dynamodb-gsi-update/verify.sh`; source of truth in
+     `scripts/check-integ-probe-not-found.ts`), inserted right after
+     `set -euo pipefail`:
+
+     ```bash
+     assert_gone "resource <name> still exists after destroy" aws <service> <read-verb> [args...]
+     assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
+     ```
+
+     Never write `if aws <read-probe> ... >/dev/null 2>&1; then FAIL` (or the
+     inverse `if ! aws ...; then <gone>`): a throttled probe would silently
+     pass the leak check (issue #1097 pattern 2). Use `s3api head-object` for
+     state files, never `aws s3 ls` (exit 1 + empty output for "no keys" is
+     indistinguishable from a silenced error). Enforced by
+     `tests/unit/scripts/integ-verify-probe-not-found.test.ts`.
    - End with a single `echo "[verify] PASS — ..."` line (the run-integ harness
      greps for it).
    - `chmod +x verify.sh`.

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -55,7 +55,6 @@ lambda-versioning	2026-06-21T11:00:28Z	PASS	48	standard	sweep-4..8 staleness re-
 legacy-bucket-name-fallback	2026-06-21T11:00:28Z	PASS	14	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 legacy-state-migration	2026-06-21T11:00:28Z	PASS	14	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 local-ecs-service-connect	2026-06-21T11:00:28Z	PASS	20	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-invoke	2026-06-21T11:00:28Z	PASS	32	verify.sh	sweep staleness re-run (re-verified PASS; ledger-restore)
 local-invoke-agentcore	2026-06-21T10:51:48Z	PASS	103	verify.sh	creds materialized (export-credentials); 21 tests; arm64-native container (no qemu); docker clean
 local-invoke-agentcore-from-state	2026-06-21T10:51:48Z	PASS	55	verify.sh	creds materialized; 8 del 0 err; --from-state intrinsic env-var substitution; docker clean
 local-invoke-buildkit	2026-06-21T11:00:28Z	PASS	32	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
@@ -146,7 +145,6 @@ custom-resource-provider	2026-06-27T16:56:19Z	PASS	293	standard	CR framework (on
 dynamodb-ttl-attr-change	2026-06-27T18:40:49Z	PASS		verify.sh	TTL attr-change rejected w/ actionable error; clean destroy (re-run post nit-fix)
 apigw-usage-plan-key	2026-06-27T19:25:47Z	PASS	74	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
 cognito-identity-pool	2026-06-27T19:25:47Z	PASS	44	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
-eventbridge-scheduler	2026-07-02T12:35:05Z	PASS	57	verify.sh	regression for new Scheduler SDK provider routing (default group)
 lambda-reserved-concurrency	2026-06-27T19:25:47Z	PASS	47	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
 lambda-alias-provisioned-concurrency	2026-06-27T19:25:47Z	PASS	251	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
 kinesis-esm-filter	2026-06-27T19:34:46Z	PASS	62	verify.sh	bughunt-clean regression fixture; FilterCriteria content asserted; clean destroy
@@ -253,3 +251,5 @@ fsx-windows	2026-07-20T02:35:13Z	PASS	5460	verify.sh	issue #1088 Windows AD-join
 cc-getatt-readback	2026-07-20T03:06:02Z	PASS	260	verify.sh	generic sparse read-back live-verified (#1105); destroy 8/8, 0 orphans
 lambda	2026-07-20T03:12:02Z	PASS	170	verify.sh	broad refresh for #1106 resolver guard; destroy 9/9, 0 orphans
 getatt-fallback-guard	2026-07-20T03:13:10Z	PASS	60	verify.sh	new error-path fixture: guard hard-fails BogusArn fallback live; rollback + destroy clean
+eventbridge-scheduler	2026-07-20T03:07:51Z	PASS	150	verify.sh	pattern-2 sweep sample: assert_gone/gone_probe/head-object idioms live-verified; 0 orphans
+local-invoke	2026-07-20T03:08:51Z	PASS	120	verify.sh	integ-local refresh for pattern-2 sweep (local-start-alb-from-state probe change); docker sweep clean

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -470,7 +470,7 @@ fi
 ```
 
 The helpers grep the probe's stderr for the ONE canonical not-found signature
-(`'not ?found|no ?such|does ?not ?exist|non ?existent|404'`, case-insensitive)
+(`'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'`, case-insensitive)
 and refuse to report PASS on any other failure. Notes:
 
 - Only READ-verb probes (`describe|get|head|list|batch-get`, `aws s3 ls`) used

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -433,6 +433,60 @@ re-runs `cleanup`.
 `tests/unit/scripts/integ-verify-signal-traps.test.ts` enforces this across the
 whole fixture tree (issue #1097).
 
+### Fixture convention: `verify.sh` gone-probes
+
+A "resource is gone after destroy" assertion must never be built on a silenced
+AWS CLI read probe. Both of these are the same bug (issue #1097 pattern 2):
+
+```bash
+# WRONG: ANY probe failure (throttle, expired credentials, network) lands in
+# the else-branch and reports "gone" -- a leaked resource passes silently.
+if aws lambda get-function --function-name "${FN}" >/dev/null 2>&1; then
+  echo "FAIL: function still exists after destroy" >&2; exit 1
+fi
+
+# WRONG (inverse spelling): any failure is read as "gone".
+if ! aws dynamodb describe-table --table-name "${TABLE}" >/dev/null 2>&1; then
+  TABLE_GONE=1
+fi
+```
+
+The list-operator spellings (`aws <probe> ... && { FAIL still exists; }` and
+`aws <probe> ... || { GONE=1; break; }`) are the same bug and equally banned.
+
+Instead, every fixture that asserts deletion carries the canonical helper block
+(verbatim; see `scripts/check-integ-probe-not-found.ts` for the source of
+truth) and routes probes through it:
+
+```bash
+# Simple leak assertion: fails on "still exists" AND on an undetermined probe.
+assert_gone "function ${FN} still exists after destroy" aws lambda get-function --function-name "${FN}" --region "${REGION}"
+
+# Branching form (orphan counters, wait-until-gone polls, status checks):
+# 0 = confirmed not-found, 1 = still exists, hard-FAIL on anything else.
+if ! gone_probe aws iam get-role --role-name "${ROLE}"; then
+  ORPHANS=$((ORPHANS + 1))
+fi
+```
+
+The helpers grep the probe's stderr for the ONE canonical not-found signature
+(`'not ?found|no ?such|does ?not ?exist|non ?existent|404'`, case-insensitive)
+and refuse to report PASS on any other failure. Notes:
+
+- Only READ-verb probes (`describe|get|head|list|batch-get`, `aws s3 ls`) used
+  as existence checks are in scope. A mutation such as
+  `if ! aws fsx delete-backup ...` legitimately treats non-zero as "the delete
+  failed" and stays as-is; so do fail-closed existence checks
+  (`if ! aws ...; then FAIL`), pre-flight "already exists, clean up first"
+  guards, and best-effort cleanup guards.
+- Probe state files with `aws s3api head-object --bucket ... --key ...`, not
+  `aws s3 ls`: `s3 ls` exits 1 with EMPTY output for "no keys", which is
+  indistinguishable from a silenced error.
+
+`tests/unit/scripts/integ-verify-probe-not-found.test.ts` enforces this across
+the whole fixture tree (issue #1097), including a bash-level behavioral test of
+the helpers against a stubbed `aws` (success, not-found, throttle).
+
 ## 3. Deploy Using cdkd
 
 ```bash

--- a/scripts/check-integ-probe-not-found.ts
+++ b/scripts/check-integ-probe-not-found.ts
@@ -23,7 +23,10 @@
  * Only READ-verb probes used as existence checks are in scope
  * (describe|get|head|list|batch-get, plus `aws s3 ls`): a mutation like
  * `if ! aws fsx delete-backup ...` legitimately treats non-zero as "the
- * delete failed" and must not be flagged.
+ * delete failed" and must not be flagged. The one exception: a silenced
+ * `aws <service> \${var}` in condition / list-operator position cannot be
+ * verb-classified at all and is flagged outright (variableVerbProbes) --
+ * route it through the helpers or use literal verbs.
  *
  * This module is separate from the test so the classifier can be table-tested
  * against synthetic script shapes rather than only against today's tree.
@@ -35,12 +38,15 @@
  * fixtures probe: `NotFound` / `Not Found` (generic, EC2 `*.NotFound`, S3 404
  * body), `NoSuch*` (S3, IAM NoSuchEntity, CloudFront, Route53), `does not
  * exist` / `*DoesNotExist*` (CloudFormation ValidationError, CodeDeploy,
- * Step Functions), `NonExistent*` (SQS NonExistentQueue), and bare `404`
- * (s3api head-object/head-bucket). Throttle / auth / network error texts match
- * none of these, so they surface as a hard FAIL instead of a silent pass.
+ * Step Functions), `NonExistent*` (SQS NonExistentQueue), and `\(404` (s3api
+ * head-object/head-bucket, whose error the AWS CLI spells "An error occurred
+ * (404)" -- the open paren anchors it so a bare `404` embedded in an ARN or
+ * request id inside a NON-not-found error text cannot match). Throttle / auth /
+ * network error texts match none of these, so they surface as a hard FAIL
+ * instead of a silent pass.
  */
 export const CANONICAL_NOT_FOUND_REGEX =
-  "'not ?found|no ?such|does ?not ?exist|non ?existent|404'";
+  "'not ?found|no ?such|does ?not ?exist|non ?existent|\\(404'";
 
 /**
  * The canonical helper block inserted into every fixture that asserts
@@ -55,7 +61,11 @@ export const CANONICAL_HELPER_BLOCK = `# --- issue #1097 pattern 2: strict gone-
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# \`assert_gone aws ...\` would exec \`lambda get-function ...\` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "\${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: \${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
@@ -101,6 +111,13 @@ export interface ProbeClassification {
    * through `gone_probe` (or capture + inspect the error text) instead.
    */
   blindProbeLoops: FlaggedProbe[];
+  /**
+   * A silenced `aws <service> \${var}` / `aws "$var" ...` in condition or
+   * list-operator position: the verb cannot be classified statically, so the
+   * probe must go through the helpers (or use literal verbs) regardless of
+   * what the branch concludes.
+   */
+  variableVerbProbes: FlaggedProbe[];
   /** Calls assert_gone or gone_probe somewhere. */
   usesHelpers: boolean;
   /** Contains CANONICAL_HELPER_BLOCK verbatim. */
@@ -136,17 +153,41 @@ export function joinContinuationLines(content: string): Array<{ line: number; te
 const READ_VERB = /^(describe|get|head|list|batch-get)/;
 
 /**
+ * The statement discards stderr (`2>&1` after `>/dev/null`, `2>/dev/null`, or
+ * `&>/dev/null`, each with optional space before `/dev/null`) -- the property
+ * that makes not-found indistinguishable from a throttle.
+ */
+function isSilenced(cmd: string): boolean {
+  return /(>\s*\/dev\/null\s+2>&1|2>\s*\/dev\/null|&>\s*\/dev\/null|2>&1\s*>\s*\/dev\/null)/.test(
+    cmd,
+  );
+}
+
+/**
  * Matches `aws <service> <verb> ...` where the verb is a read probe and the
- * statement discards stderr (`2>&1` after `>/dev/null`, `2>/dev/null`, or
- * `&>/dev/null`) -- the property that makes not-found indistinguishable from
- * a throttle.
+ * statement is silenced (see {@link isSilenced}).
  */
 function isSilencedReadProbe(cmd: string): boolean {
   const m = /^aws\s+([a-z0-9-]+)\s+([a-z0-9-]+)\b/.exec(cmd);
   if (!m) return false;
   const isRead = m[1] === 's3' ? m[2] === 'ls' : READ_VERB.test(m[2]!);
   if (!isRead) return false;
-  return /(>\/dev\/null\s+2>&1|2>\/dev\/null|&>\/dev\/null|2>&1\s*>\/dev\/null)/.test(cmd);
+  return isSilenced(cmd);
+}
+
+/**
+ * Matches a silenced `aws` invocation whose service or verb position is a
+ * shell VARIABLE (`aws glue \${chk} ...`, `aws "$svc" describe ...`): the
+ * probe cannot be verb-classified statically, so using it silenced in a
+ * condition / list-operator position is banned outright -- route it through
+ * gone_probe / assert_gone or restructure with literal verbs instead
+ * (glue-update-hardening's destroy loop evaded the classifier exactly this
+ * way).
+ */
+function isSilencedVariableVerbProbe(cmd: string): boolean {
+  if (!/^aws\s/.test(cmd)) return false;
+  if (!isSilenced(cmd)) return false;
+  return /^aws\s+(?:"?\$|[a-z0-9-]+\s+"?\$)/.test(cmd);
 }
 
 /** Wording that marks a then-branch as a leak/gone assertion. */
@@ -161,6 +202,7 @@ export function classifyVerifyScript(content: string): ProbeClassification {
   const blindLeakAsserts: FlaggedProbe[] = [];
   const blindGoneConcludes: FlaggedProbe[] = [];
   const blindProbeLoops: FlaggedProbe[] = [];
+  const variableVerbProbes: FlaggedProbe[] = [];
 
   for (let i = 0; i < joined.length; i++) {
     const { line, text } = joined[i]!;
@@ -170,9 +212,13 @@ export function classifyVerifyScript(content: string): ProbeClassification {
     // statement position (line starts with it), so probes inside an
     // `if [ ... ] && { aws ...; }` compound guard are not matched here.
     const sm =
-      /^\s*(aws\s.*?(?:>\/dev\/null 2>&1|2>\/dev\/null|&>\/dev\/null|2>&1\s*>\/dev\/null))\s*(&&|\|\|)\s*(.*)$/.exec(
+      /^\s*(aws\s.*?(?:>\s*\/dev\/null\s+2>&1|2>\s*\/dev\/null|&>\s*\/dev\/null|2>&1\s*>\s*\/dev\/null))\s*(&&|\|\|)\s*(.*)$/.exec(
         text,
       );
+    if (sm && isSilencedVariableVerbProbe(sm[1]!.trim())) {
+      variableVerbProbes.push({ line, text: text.trim() });
+      continue;
+    }
     if (sm && isSilencedReadProbe(sm[1]!.trim())) {
       // Branch text: the rest of the line, plus the `{ ... }` block when the
       // line opens one.
@@ -197,7 +243,12 @@ export function classifyVerifyScript(content: string): ProbeClassification {
     const m = /^\s*(if|elif|while|until)\s+(!\s+)?(aws\s.*?);?\s*(then|do)\s*$/.exec(text);
     if (!m) continue;
     const [, kw, neg, cmd] = m;
-    if (!isSilencedReadProbe(cmd!.trim())) continue;
+    if (!isSilencedReadProbe(cmd!.trim())) {
+      if (isSilencedVariableVerbProbe(cmd!.trim())) {
+        variableVerbProbes.push({ line, text: text.trim() });
+      }
+      continue;
+    }
 
     if (kw === 'while' || kw === 'until') {
       blindProbeLoops.push({ line, text: text.trim() });
@@ -241,6 +292,7 @@ export function classifyVerifyScript(content: string): ProbeClassification {
     blindLeakAsserts,
     blindGoneConcludes,
     blindProbeLoops,
+    variableVerbProbes,
     usesHelpers,
     hasCanonicalHelperBlock: content.includes(CANONICAL_HELPER_BLOCK),
     nonCanonicalNotFoundGreps,

--- a/scripts/check-integ-probe-not-found.ts
+++ b/scripts/check-integ-probe-not-found.ts
@@ -1,0 +1,248 @@
+/**
+ * Classifier for the integ-fixture `verify.sh` gone-probe convention (#1097
+ * pattern 2).
+ *
+ * A "resource is gone after destroy" assertion built on a silenced AWS CLI
+ * read probe cannot distinguish not-found from any other failure:
+ *
+ *   if aws lambda get-function ... >/dev/null 2>&1; then
+ *     echo "FAIL: ... still exists" >&2; exit 1
+ *   fi
+ *
+ * reads ANY probe failure (throttle, expired credentials, network) as "gone"
+ * and silently passes the leak assertion. The inverse spelling
+ * `if ! aws <probe> ...; then <conclude gone>` is the same bug, and so are the
+ * list-operator spellings `aws <probe> ... && { FAIL still exists; }` and
+ * `aws <probe> ... || { GONE=1; break; }`. The correct form routes the probe
+ * through the canonical helpers, which grep the error
+ * text for a not-found signature and hard-FAIL on anything else:
+ *
+ *   assert_gone "<leak description>" aws <service> <read-verb> [args...]
+ *   if ! gone_probe aws <service> <read-verb> [args...]; then ...; fi
+ *
+ * Only READ-verb probes used as existence checks are in scope
+ * (describe|get|head|list|batch-get, plus `aws s3 ls`): a mutation like
+ * `if ! aws fsx delete-backup ...` legitimately treats non-zero as "the
+ * delete failed" and must not be flagged.
+ *
+ * This module is separate from the test so the classifier can be table-tested
+ * against synthetic script shapes rather than only against today's tree.
+ */
+
+/**
+ * The ONE not-found signature every fixture must use verbatim (case-insensitive
+ * grep -qiE). It matches the not-found error families of the services the
+ * fixtures probe: `NotFound` / `Not Found` (generic, EC2 `*.NotFound`, S3 404
+ * body), `NoSuch*` (S3, IAM NoSuchEntity, CloudFront, Route53), `does not
+ * exist` / `*DoesNotExist*` (CloudFormation ValidationError, CodeDeploy,
+ * Step Functions), `NonExistent*` (SQS NonExistentQueue), and bare `404`
+ * (s3api head-object/head-bucket). Throttle / auth / network error texts match
+ * none of these, so they surface as a hard FAIL instead of a silent pass.
+ */
+export const CANONICAL_NOT_FOUND_REGEX =
+  "'not ?found|no ?such|does ?not ?exist|non ?existent|404'";
+
+/**
+ * The canonical helper block inserted into every fixture that asserts
+ * "gone after destroy". Byte-identical across the tree so this checker can
+ * verify it verbatim; edit it here and in every verify.sh together or the
+ * `usesCanonicalHelperBlock` assertion fails.
+ */
+export const CANONICAL_HELPER_BLOCK = `# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind \`if aws ...; then\` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "\${out}" | grep -qiE ${CANONICAL_NOT_FOUND_REGEX}; then
+    echo "FAIL: gone-probe undetermined ($*): \${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="\$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: \${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------`;
+
+/** A silenced blind probe the classifier flagged, with its 1-based line. */
+export interface FlaggedProbe {
+  line: number;
+  text: string;
+}
+
+export interface ProbeClassification {
+  /**
+   * Form B: `if/elif aws <read-probe> ... [stderr discarded]; then` whose
+   * then-branch is a leak assertion (matches leak wording). The probe's error
+   * path falls into the else-branch and reports "gone" on a throttle.
+   */
+  blindLeakAsserts: FlaggedProbe[];
+  /**
+   * Form A: `if/elif ! aws <read-probe> ... [stderr discarded]; then` whose
+   * then-branch concludes "gone" (no fail/exit/return-nonzero) -- ANY probe
+   * failure is read as success.
+   */
+  blindGoneConcludes: FlaggedProbe[];
+  /**
+   * A `while` / `until` loop driven directly by a silenced read probe -- a
+   * wait-until-gone poll that a throttle terminates as "gone". Loops must go
+   * through `gone_probe` (or capture + inspect the error text) instead.
+   */
+  blindProbeLoops: FlaggedProbe[];
+  /** Calls assert_gone or gone_probe somewhere. */
+  usesHelpers: boolean;
+  /** Contains CANONICAL_HELPER_BLOCK verbatim. */
+  hasCanonicalHelperBlock: boolean;
+  /**
+   * Occurrences of the `not ?found` grep alternation OUTSIDE the canonical
+   * regex string -- a drifted / partial copy of the not-found signature.
+   */
+  nonCanonicalNotFoundGreps: FlaggedProbe[];
+}
+
+/**
+ * Joins backslash-continuation lines so a multi-line probe condition cannot
+ * hide from a line-oriented scan (the pattern-1 sweep learned this the hard
+ * way with a multi-line `trap`). Line numbers reported for a joined statement
+ * are the number of its FIRST physical line.
+ */
+export function joinContinuationLines(content: string): Array<{ line: number; text: string }> {
+  const lines = content.split('\n');
+  const joined: Array<{ line: number; text: string }> = [];
+  for (let i = 0; i < lines.length; i++) {
+    const start = i;
+    let text = lines[i]!;
+    while (/\\$/.test(text) && i + 1 < lines.length) {
+      i++;
+      text = text.replace(/\\$/, ' ') + lines[i]!.trim();
+    }
+    joined.push({ line: start + 1, text });
+  }
+  return joined;
+}
+
+const READ_VERB = /^(describe|get|head|list|batch-get)/;
+
+/**
+ * Matches `aws <service> <verb> ...` where the verb is a read probe and the
+ * statement discards stderr (`2>&1` after `>/dev/null`, `2>/dev/null`, or
+ * `&>/dev/null`) -- the property that makes not-found indistinguishable from
+ * a throttle.
+ */
+function isSilencedReadProbe(cmd: string): boolean {
+  const m = /^aws\s+([a-z0-9-]+)\s+([a-z0-9-]+)\b/.exec(cmd);
+  if (!m) return false;
+  const isRead = m[1] === 's3' ? m[2] === 'ls' : READ_VERB.test(m[2]!);
+  if (!isRead) return false;
+  return /(>\/dev\/null\s+2>&1|2>\/dev\/null|&>\/dev\/null|2>&1\s*>\/dev\/null)/.test(cmd);
+}
+
+/** Wording that marks a then-branch as a leak/gone assertion. */
+const LEAK_WORDING =
+  /still (exists|present|remains|reachable|alive)|\bremains\b|orphan|leak(ed|s)?\b|appeared|survived|was created|should not (exist|happen)/i;
+
+/** Body signals that a branch fails loudly rather than concluding success. */
+const FAILS_LOUDLY = /\bexit 1\b|\bfail\b|\bFAIL\b|\breturn 1\b/;
+
+export function classifyVerifyScript(content: string): ProbeClassification {
+  const joined = joinContinuationLines(content);
+  const blindLeakAsserts: FlaggedProbe[] = [];
+  const blindGoneConcludes: FlaggedProbe[] = [];
+  const blindProbeLoops: FlaggedProbe[] = [];
+
+  for (let i = 0; i < joined.length; i++) {
+    const { line, text } = joined[i]!;
+
+    // Statement forms: `aws <probe> ... && <leak assert>` (Form B) and
+    // `aws <probe> ... || <conclude gone>` (Form A). The probe must be in
+    // statement position (line starts with it), so probes inside an
+    // `if [ ... ] && { aws ...; }` compound guard are not matched here.
+    const sm =
+      /^\s*(aws\s.*?(?:>\/dev\/null 2>&1|2>\/dev\/null|&>\/dev\/null|2>&1\s*>\/dev\/null))\s*(&&|\|\|)\s*(.*)$/.exec(
+        text,
+      );
+    if (sm && isSilencedReadProbe(sm[1]!.trim())) {
+      // Branch text: the rest of the line, plus the `{ ... }` block when the
+      // line opens one.
+      let branch = sm[3]!;
+      if (/\{\s*$/.test(branch)) {
+        for (let j = i + 1; j < joined.length; j++) {
+          branch += '\n' + joined[j]!.text;
+          if (/^\s*\}/.test(joined[j]!.text)) break;
+        }
+      }
+      if (sm[2] === '&&') {
+        if (LEAK_WORDING.test(branch)) blindLeakAsserts.push({ line, text: text.trim() });
+      } else {
+        const concludesGone = /\b[A-Za-z_]+=1\b|\bbreak\b|\bcontinue\b/.test(branch) || LEAK_WORDING.test(branch);
+        if (concludesGone && !FAILS_LOUDLY.test(branch)) {
+          blindGoneConcludes.push({ line, text: text.trim() });
+        }
+      }
+      continue;
+    }
+
+    const m = /^\s*(if|elif|while|until)\s+(!\s+)?(aws\s.*?);?\s*(then|do)\s*$/.exec(text);
+    if (!m) continue;
+    const [, kw, neg, cmd] = m;
+    if (!isSilencedReadProbe(cmd!.trim())) continue;
+
+    if (kw === 'while' || kw === 'until') {
+      blindProbeLoops.push({ line, text: text.trim() });
+      continue;
+    }
+
+    // Collect the then-branch: up to the matching `else` / `elif` / `fi`,
+    // tracking nested if/fi so an inner block cannot end the scan early.
+    const body: string[] = [];
+    let depth = 0;
+    for (let j = i + 1; j < joined.length; j++) {
+      const t = joined[j]!.text;
+      if (/^\s*if\b/.test(t)) depth++;
+      if (/^\s*fi\b/.test(t)) {
+        if (depth === 0) break;
+        depth--;
+      }
+      if (depth === 0 && /^\s*(else|elif)\b/.test(t)) break;
+      body.push(t);
+      if (body.length > 30) break;
+    }
+    const bodyStr = body.join('\n');
+
+    if (!neg) {
+      if (LEAK_WORDING.test(bodyStr)) blindLeakAsserts.push({ line, text: text.trim() });
+    } else {
+      if (!FAILS_LOUDLY.test(bodyStr)) blindGoneConcludes.push({ line, text: text.trim() });
+    }
+  }
+
+  // Any not-found grep alternation must be the one canonical string.
+  const nonCanonicalNotFoundGreps: FlaggedProbe[] = [];
+  for (const { line, text } of joined) {
+    if (/not \?found/.test(text) && !text.includes(CANONICAL_NOT_FOUND_REGEX)) {
+      nonCanonicalNotFoundGreps.push({ line, text: text.trim() });
+    }
+  }
+
+  const usesHelpers = /\b(assert_gone|gone_probe)\s/.test(content);
+  return {
+    blindLeakAsserts,
+    blindGoneConcludes,
+    blindProbeLoops,
+    usesHelpers,
+    hasCanonicalHelperBlock: content.includes(CANONICAL_HELPER_BLOCK),
+    nonCanonicalNotFoundGreps,
+  };
+}

--- a/tests/integration/agentcore-tools/verify.sh
+++ b/tests/integration/agentcore-tools/verify.sh
@@ -20,6 +20,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdAgentcoreToolsExample"
@@ -160,10 +188,7 @@ if [ "${BROWSER_STATUS}" != "READY" ] || [ "${CI_STATUS}" != "READY" ]; then
 fi
 echo "    AWS-managed defaults untouched (READY)"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — AgentCore Browser/CodeInterpreter adopt + Evaluator CREATE/UPDATE/destroy, all 3 phases passed"

--- a/tests/integration/agentcore-tools/verify.sh
+++ b/tests/integration/agentcore-tools/verify.sh
@@ -27,12 +27,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/alb/verify.sh
+++ b/tests/integration/alb/verify.sh
@@ -10,6 +10,34 @@
 #         or: bash tests/integration/alb/verify.sh
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 CDKD="node ../../../dist/cli.js"
@@ -77,10 +105,7 @@ ${CDKD} destroy ${STACK} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET
 
 echo ""
 echo "==> Final cleanup verification"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && {
-  echo "FAIL: state ${STATE_KEY} still exists after destroy"
-  exit 1
-} || true
+assert_gone "state ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    state file removed (✓)"
 
 echo ""

--- a/tests/integration/alb/verify.sh
+++ b/tests/integration/alb/verify.sh
@@ -18,12 +18,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/apigateway/verify.sh
+++ b/tests/integration/apigateway/verify.sh
@@ -23,12 +23,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/apigateway/verify.sh
+++ b/tests/integration/apigateway/verify.sh
@@ -16,6 +16,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="ApiGatewayStack"
@@ -209,10 +237,7 @@ if [ "${API_ID_AFTER}" != "None" ] && [ -n "${API_ID_AFTER}" ]; then
 fi
 echo "    OK: REST API is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/apigw-gateway-response/verify.sh
+++ b/tests/integration/apigw-gateway-response/verify.sh
@@ -30,12 +30,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/apigw-gateway-response/verify.sh
+++ b/tests/integration/apigw-gateway-response/verify.sh
@@ -22,6 +22,34 @@
 #   AWS_REGION   — defaults to us-east-1
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdApigwGatewayResponseExample"
@@ -160,10 +188,7 @@ if [ -n "${API_ID_P3}" ] && [ "${API_ID_P3}" != "None" ]; then
 fi
 echo "    REST API deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — API Gateway GatewayResponse deploy/update/destroy, all 3 phases passed"

--- a/tests/integration/apigw-stage-throttling/verify.sh
+++ b/tests/integration/apigw-stage-throttling/verify.sh
@@ -27,6 +27,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="ApigwStageThrottlingStack"
@@ -231,10 +259,7 @@ if [ "${API_ID_AFTER}" != "None" ] && [ -n "${API_ID_AFTER}" ]; then
 fi
 echo "    OK: REST API is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/apigw-stage-throttling/verify.sh
+++ b/tests/integration/apigw-stage-throttling/verify.sh
@@ -34,12 +34,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/apigw-usage-plan-key/verify.sh
+++ b/tests/integration/apigw-usage-plan-key/verify.sh
@@ -14,12 +14,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/apigw-usage-plan-key/verify.sh
+++ b/tests/integration/apigw-usage-plan-key/verify.sh
@@ -6,6 +6,34 @@
 # the regression guard for resolveRefValue compound-id handling.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdApigwUsagePlanKeyExample"
@@ -78,7 +106,7 @@ echo "    OK: rest api gone"
 PLAN_REMAIN=$(aws apigateway get-usage-plans --region "${REGION}" --query "items[?name=='${PLAN_NAME}'].id | [0]" --output text 2>/dev/null)
 [ -n "${PLAN_REMAIN}" ] && [ "${PLAN_REMAIN}" != "None" ] && { echo "FAIL: usage plan still exists after destroy" >&2; exit 1; }
 echo "    OK: usage plan gone"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && { echo "FAIL: state remains" >&2; exit 1; }
+assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 echo ""
 echo "==> apigw-usage-plan-key test passed"

--- a/tests/integration/appconfig/verify.sh
+++ b/tests/integration/appconfig/verify.sh
@@ -30,12 +30,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/appconfig/verify.sh
+++ b/tests/integration/appconfig/verify.sh
@@ -23,6 +23,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdAppConfigExample"
@@ -147,10 +175,7 @@ if [ -n "${LEFT_APP}" ] && [ "${LEFT_APP}" != "None" ]; then
 fi
 echo "    application deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — AppConfig chain deploys (compound-id Ref resolved), UPDATE bumps the hosted config, destroy clean"

--- a/tests/integration/asset-auto-create/verify.sh
+++ b/tests/integration/asset-auto-create/verify.sh
@@ -43,12 +43,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/asset-auto-create/verify.sh
+++ b/tests/integration/asset-auto-create/verify.sh
@@ -36,6 +36,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdAssetAutoCreateStack"
@@ -183,10 +211,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" \
   --region "${REGION}" \
   --yes
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file still present after destroy" >&2
-  exit 1
-fi
+assert_gone "state file still present after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: destroy clean"
 
 # --- Phase 2: --no-auto-asset-storage stays legacy ---------------------------
@@ -255,9 +280,6 @@ fi
 echo "    OK: --skip-assets stayed legacy (no auto-create line, no marker)"
 
 # --- Still no CDK bootstrap anywhere ----------------------------------------
-if aws ssm get-parameter --name "${CDK_SSM_PARAM}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: ${CDK_SSM_PARAM} appeared in ${REGION} during the test" >&2
-  exit 1
-fi
+assert_gone "${CDK_SSM_PARAM} appeared in ${REGION} during the test" aws ssm get-parameter --name "${CDK_SSM_PARAM}" --region "${REGION}"
 
 echo "PASS: asset-storage auto-create + opt-out verified in ${REGION}"

--- a/tests/integration/asset-bootstrap/verify.sh
+++ b/tests/integration/asset-bootstrap/verify.sh
@@ -40,12 +40,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/asset-bootstrap/verify.sh
+++ b/tests/integration/asset-bootstrap/verify.sh
@@ -33,6 +33,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdAssetBootstrapStack"
@@ -253,10 +281,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --yes
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/asset-migration/verify.sh
+++ b/tests/integration/asset-migration/verify.sh
@@ -42,12 +42,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/asset-migration/verify.sh
+++ b/tests/integration/asset-migration/verify.sh
@@ -35,6 +35,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdAssetMigrationStack"
@@ -309,10 +337,7 @@ echo "==> Phase 6: destroy (cascades into the nested child)"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --yes
 
-if aws s3 ls "s3://${STATE_BUCKET}/${parent_state_key}" >/dev/null 2>&1; then
-  echo "FAIL: parent state file still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "parent state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${parent_state_key}"
 CHILD_KEY=$(child_state_key)
 if [ -n "${CHILD_KEY}" ] && [ "${CHILD_KEY}" != "None" ]; then
   echo "FAIL: nested child state '${CHILD_KEY}' still exists after destroy" >&2

--- a/tests/integration/aws-custom-resource/verify.sh
+++ b/tests/integration/aws-custom-resource/verify.sh
@@ -19,6 +19,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdAwsCustomResourceExample"
@@ -107,16 +135,10 @@ echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws ssm get-parameter --name "${PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SSM parameter ${PARAM_NAME} still exists after destroy (onDelete did not run)" >&2
-  exit 1
-fi
+assert_gone "SSM parameter ${PARAM_NAME} still exists after destroy (onDelete did not run)" aws ssm get-parameter --name "${PARAM_NAME}" --region "${REGION}"
 echo "    OK: onDelete removed the parameter"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: cdkd state removed"
 
 sweep_log_groups

--- a/tests/integration/aws-custom-resource/verify.sh
+++ b/tests/integration/aws-custom-resource/verify.sh
@@ -26,12 +26,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/backup/verify.sh
+++ b/tests/integration/backup/verify.sh
@@ -20,6 +20,34 @@
 # Required env vars: STATE_BUCKET; AWS_REGION (defaults us-east-1).
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdBackupExample"
@@ -157,13 +185,9 @@ REMAINING_PLANS=$(aws backup list-backup-plans --region "${REGION}" \
 if [ "${REMAINING_PLANS}" != "0" ]; then
   echo "FAIL: backup plan ${PLAN} still exists after destroy" >&2; exit 1
 fi
-if aws backup describe-backup-vault --backup-vault-name "${VAULT}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: backup vault ${VAULT} still exists after destroy" >&2; exit 1
-fi
+assert_gone "backup vault ${VAULT} still exists after destroy" aws backup describe-backup-vault --backup-vault-name "${VAULT}" --region "${REGION}"
 echo "    Vault / Plan / Selection deleted"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file still exists after destroy" >&2; exit 1
-fi
+assert_gone "state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — BackupVaultArn Fn::GetAtt enrichment works end-to-end, 2 phases passed"

--- a/tests/integration/backup/verify.sh
+++ b/tests/integration/backup/verify.sh
@@ -28,12 +28,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi
@@ -180,12 +184,25 @@ echo "    SelectionRef resolved to the bare SelectionId (Ref segment fix #995 wo
 echo "==> Phase 2: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-REMAINING_PLANS=$(aws backup list-backup-plans --region "${REGION}" \
-  --query "length(BackupPlansList[?BackupPlanName=='${PLAN}'] || \`[]\`)" --output text 2>/dev/null || echo 0)
+# Strict capture (issue #1097 pattern 2): a silenced `|| echo 0` would read a
+# throttled list call as "0 remaining" and silently pass the leak check.
+if ! REMAINING_PLANS=$(aws backup list-backup-plans --region "${REGION}" \
+  --query "length(BackupPlansList[?BackupPlanName=='${PLAN}'] || \`[]\`)" --output text 2>&1); then
+  echo "FAIL: could not list backup plans after destroy: ${REMAINING_PLANS}" >&2; exit 1
+fi
 if [ "${REMAINING_PLANS}" != "0" ]; then
   echo "FAIL: backup plan ${PLAN} still exists after destroy" >&2; exit 1
 fi
-assert_gone "backup vault ${VAULT} still exists after destroy" aws backup describe-backup-vault --backup-vault-name "${VAULT}" --region "${REGION}"
+# AWS Backup masks a missing vault as AccessDeniedException ("Insufficient
+# privileges to perform this action"), NOT a not-found error, so gone_probe
+# cannot classify describe-backup-vault -- assert absence via a strict list.
+if ! REMAINING_VAULTS=$(aws backup list-backup-vaults --region "${REGION}" \
+  --query "length(BackupVaultList[?BackupVaultName=='${VAULT}'] || \`[]\`)" --output text 2>&1); then
+  echo "FAIL: could not list backup vaults after destroy: ${REMAINING_VAULTS}" >&2; exit 1
+fi
+if [ "${REMAINING_VAULTS}" != "0" ]; then
+  echo "FAIL: backup vault ${VAULT} still exists after destroy" >&2; exit 1
+fi
 echo "    Vault / Plan / Selection deleted"
 assert_gone "state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"

--- a/tests/integration/bootstrap-free-region/verify.sh
+++ b/tests/integration/bootstrap-free-region/verify.sh
@@ -37,12 +37,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/bootstrap-free-region/verify.sh
+++ b/tests/integration/bootstrap-free-region/verify.sh
@@ -30,6 +30,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdBootstrapFreeStack"
@@ -169,10 +197,7 @@ fi
 echo "    OK: Code.S3Bucket=${ASSET_BUCKET}, ${OBJ_COUNT} asset object(s) present"
 
 # --- Phase 3: still no CDK bootstrap anywhere -------------------------------
-if aws ssm get-parameter --name "${CDK_SSM_PARAM}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: ${CDK_SSM_PARAM} appeared in ${REGION} during the test" >&2
-  exit 1
-fi
+assert_gone "${CDK_SSM_PARAM} appeared in ${REGION} during the test" aws ssm get-parameter --name "${CDK_SSM_PARAM}" --region "${REGION}"
 echo "    OK: ${CDK_SSM_PARAM} still absent — no CDK bootstrap was needed"
 
 # --- Destroy -----------------------------------------------------------------
@@ -182,10 +207,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --yes
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file still present after destroy" >&2
-  exit 1
-fi
+assert_gone "state file still present after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 FN_COUNT=$(aws lambda list-functions --region "${REGION}" \
   --query "length(Functions[?starts_with(FunctionName, '${STACK}')] || \`[]\`)" --output text)
 if [ "${FN_COUNT}" != "0" ]; then

--- a/tests/integration/bucket-deployment/verify.sh
+++ b/tests/integration/bucket-deployment/verify.sh
@@ -18,6 +18,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdBucketDeploymentExample"
@@ -105,16 +133,10 @@ echo "==> Phase 2: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws s3api head-bucket --bucket "${SITE_BUCKET}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: bucket ${SITE_BUCKET} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "bucket ${SITE_BUCKET} still exists after destroy" aws s3api head-bucket --bucket "${SITE_BUCKET}" --region "${REGION}"
 echo "    OK: bucket is gone"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: cdkd state removed"
 
 # Lambda auto-creates /aws/lambda/* log groups on invoke; sweep so orphan-zero.

--- a/tests/integration/bucket-deployment/verify.sh
+++ b/tests/integration/bucket-deployment/verify.sh
@@ -25,12 +25,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/budgets/verify.sh
+++ b/tests/integration/budgets/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/budgets/verify.sh
+++ b/tests/integration/budgets/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdBudgetsExample"
@@ -159,16 +187,10 @@ echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws budgets describe-budget --account-id "${ACCOUNT_ID}" --budget-name "${BUDGET_NAME}" >/dev/null 2>&1; then
-  echo "FAIL: budget ${BUDGET_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "budget ${BUDGET_NAME} still exists after destroy" aws budgets describe-budget --account-id "${ACCOUNT_ID}" --budget-name "${BUDGET_NAME}"
 echo "    budget deleted from AWS"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    state file removed"
 
 trap - EXIT INT TERM

--- a/tests/integration/cc-api-fallback-transitions/verify.sh
+++ b/tests/integration/cc-api-fallback-transitions/verify.sh
@@ -39,12 +39,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/cc-api-fallback-transitions/verify.sh
+++ b/tests/integration/cc-api-fallback-transitions/verify.sh
@@ -32,6 +32,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 REGION="${AWS_REGION:-us-east-1}"
@@ -221,24 +249,12 @@ node "${LOCAL_DIST}" destroy "${TRANSITION_STACK}" \
   --region "${REGION}" \
   --force
 
-if aws lambda get-function --function-name "${OVERRIDE_FN}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: ${OVERRIDE_FN} still exists after destroy" >&2
-  exit 1
-fi
-if aws lambda get-function --function-name "${TRANSITION_FN}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: ${TRANSITION_FN} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "${OVERRIDE_FN} still exists after destroy" aws lambda get-function --function-name "${OVERRIDE_FN}" --region "${REGION}"
+assert_gone "${TRANSITION_FN} still exists after destroy" aws lambda get-function --function-name "${TRANSITION_FN}" --region "${REGION}"
 echo "    OK: both Lambda probes are gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${OVERRIDE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: OverrideStack state file still exists after destroy" >&2
-  exit 1
-fi
-if aws s3 ls "s3://${STATE_BUCKET}/${TRANSITION_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: TransitionStack state file still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "OverrideStack state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${OVERRIDE_KEY}"
+assert_gone "TransitionStack state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${TRANSITION_KEY}"
 echo "    OK: both state files are gone"
 
 echo ""

--- a/tests/integration/cc-api-fallback/verify.sh
+++ b/tests/integration/cc-api-fallback/verify.sh
@@ -14,6 +14,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdCcApiFallback"
@@ -120,16 +148,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Lambda function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "Lambda function ${FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
 echo "    OK: Lambda function is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/cc-api-fallback/verify.sh
+++ b/tests/integration/cc-api-fallback/verify.sh
@@ -21,12 +21,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/cc-getatt-readback/verify.sh
+++ b/tests/integration/cc-getatt-readback/verify.sh
@@ -19,6 +19,34 @@
 # Required env vars: STATE_BUCKET; AWS_REGION (defaults us-east-1).
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdCcGetattReadbackExample"
@@ -157,20 +185,11 @@ echo "    state pipe attribute Arn carries the real ARN"
 echo "==> Phase 2: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws pipes describe-pipe --name "${PIPE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: pipe ${PIPE_NAME} still exists after destroy" >&2; exit 1
-fi
-if aws s3control get-access-point --account-id "${ACCOUNT_ID}" --name "${AP_NAME}" \
-    --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: access point ${AP_NAME} still exists after destroy" >&2; exit 1
-fi
-if aws resource-groups get-group --group-name "${RG_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: resource group ${RG_NAME} still exists after destroy" >&2; exit 1
-fi
+assert_gone "pipe ${PIPE_NAME} still exists after destroy" aws pipes describe-pipe --name "${PIPE_NAME}" --region "${REGION}"
+assert_gone "access point ${AP_NAME} still exists after destroy" aws s3control get-access-point --account-id "${ACCOUNT_ID}" --name "${AP_NAME}" --region "${REGION}"
+assert_gone "resource group ${RG_NAME} still exists after destroy" aws resource-groups get-group --group-name "${RG_NAME}" --region "${REGION}"
 echo "    Pipe / AccessPoint / ResourceGroup deleted"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file still exists after destroy" >&2; exit 1
-fi
+assert_gone "state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — CC-routed Fn::GetAtt read-back enrichment works end-to-end, 2 phases passed"

--- a/tests/integration/cc-getatt-readback/verify.sh
+++ b/tests/integration/cc-getatt-readback/verify.sh
@@ -27,12 +27,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/ci-cd/verify.sh
+++ b/tests/integration/ci-cd/verify.sh
@@ -21,12 +21,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/ci-cd/verify.sh
+++ b/tests/integration/ci-cd/verify.sh
@@ -14,6 +14,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CiCdStack"
@@ -130,10 +158,7 @@ if [ "${NOT_FOUND}" != "${PROJECT_NAME}" ] || [ "${PROJECTS_LEN}" != "0" ]; then
 fi
 echo "    OK: CodeBuild project is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/cloudfront-function-url/verify.sh
+++ b/tests/integration/cloudfront-function-url/verify.sh
@@ -16,6 +16,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CloudFrontFunctionUrlStack"
@@ -139,7 +167,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
 # Function gone implies its resource policy is gone too.
 FUNCTION_GONE=""
 for _ in $(seq 1 24); do
-  if ! aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
+  if gone_probe aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}"; then
     FUNCTION_GONE=1
     break
   fi
@@ -151,10 +179,7 @@ if [ -z "${FUNCTION_GONE}" ]; then
 fi
 echo "    OK: Lambda function is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/cloudfront-function-url/verify.sh
+++ b/tests/integration/cloudfront-function-url/verify.sh
@@ -23,12 +23,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/codecommit/verify.sh
+++ b/tests/integration/codecommit/verify.sh
@@ -26,6 +26,34 @@
 # Required env vars: STATE_BUCKET; AWS_REGION (defaults us-east-1).
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdCodeCommitExample"
@@ -164,9 +192,7 @@ CDKD_TEST_UPDATE=true node "${LOCAL_DIST}" deploy "${STACK}" \
 
 # The OLD name must be gone; the NEW name must exist with the SAME repository
 # ID (in-place rename via UpdateRepositoryName, not delete+create).
-if aws codecommit get-repository --repository-name "${REPO}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: old repository name ${REPO} still exists after rename" >&2; exit 1
-fi
+assert_gone "old repository name ${REPO} still exists after rename" aws codecommit get-repository --repository-name "${REPO}" --region "${REGION}"
 REPO_ID2="$(repo_field "${REPO_RENAMED}" repositoryId)"
 echo "    repositoryId (Phase 2): ${REPO_ID2}"
 [ "${REPO_ID2}" = "${REPO_ID1}" ] || { echo "FAIL: repositoryId changed across rename ('${REPO_ID1}' -> '${REPO_ID2}') — repo was replaced, not renamed" >&2; exit 1; }
@@ -187,9 +213,7 @@ echo "    removed tag untagged + changed tag updated on AWS"
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws codecommit get-repository --repository-name "${REPO_RENAMED}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: repo ${REPO_RENAMED} still exists after destroy" >&2; exit 1
-fi
+assert_gone "repo ${REPO_RENAMED} still exists after destroy" aws codecommit get-repository --repository-name "${REPO_RENAMED}" --region "${REGION}"
 echo "    repo deleted"
 ACCT="$(aws sts get-caller-identity --query Account --output text 2>/dev/null)"
 if [ -n "${ACCT}" ] && aws sns get-topic-attributes \
@@ -197,9 +221,7 @@ if [ -n "${ACCT}" ] && aws sns get-topic-attributes \
   echo "FAIL: SNS topic ${TOPIC} still exists after destroy" >&2; exit 1
 fi
 echo "    SNS trigger topic deleted"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file still exists after destroy" >&2; exit 1
-fi
+assert_gone "state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — CodeCommit repository create (desc+tags+Ref id parity+Code seed+SNS trigger), in-place rename + tag untag on update, clean destroy, 3 phases passed"

--- a/tests/integration/codecommit/verify.sh
+++ b/tests/integration/codecommit/verify.sh
@@ -34,12 +34,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/codedeploy-lambda-deployment-group/verify.sh
+++ b/tests/integration/codedeploy-lambda-deployment-group/verify.sh
@@ -35,12 +35,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/codedeploy-lambda-deployment-group/verify.sh
+++ b/tests/integration/codedeploy-lambda-deployment-group/verify.sh
@@ -28,6 +28,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdCodedeployLambdaDeploymentGroupExample"
@@ -157,25 +185,12 @@ echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws deploy get-application --application-name "${APP_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: CodeDeploy application still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "CodeDeploy application still exists after destroy" aws deploy get-application --application-name "${APP_NAME}" --region "${REGION}"
 # Errors with ApplicationDoesNotExistException / DeploymentGroupDoesNotExist-
 # Exception once either level is gone — both count as "deployment group gone".
-if aws deploy get-deployment-group --application-name "${APP_NAME}" \
-  --deployment-group-name "${DG_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: CodeDeploy deployment group still exists after destroy" >&2
-  exit 1
-fi
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Lambda function still exists after destroy" >&2
-  exit 1
-fi
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "CodeDeploy deployment group still exists after destroy" aws deploy get-deployment-group --application-name "${APP_NAME}" --deployment-group-name "${DG_NAME}" --region "${REGION}"
+assert_gone "Lambda function still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
+assert_gone "state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    Application / function / state all gone"
 
 # The Phase 2 invoke auto-created /aws/lambda/<fn> — sweep it so the run

--- a/tests/integration/cognito-custom-attribute-add/verify.sh
+++ b/tests/integration/cognito-custom-attribute-add/verify.sh
@@ -21,6 +21,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdCognitoCustomAttributeAddExample"
@@ -136,10 +164,7 @@ if [ -n "$(pool_id)" ] && [ "$(pool_id)" != "None" ]; then
 fi
 echo "    pool deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — Cognito add-custom-attribute reaches AWS via AddCustomAttributes, all 3 phases passed"

--- a/tests/integration/cognito-custom-attribute-add/verify.sh
+++ b/tests/integration/cognito-custom-attribute-add/verify.sh
@@ -28,12 +28,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/cognito-identity-pool/verify.sh
+++ b/tests/integration/cognito-identity-pool/verify.sh
@@ -4,6 +4,34 @@
 # Confirmed-clean /hunt-bugs pattern; regression guard.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdCognitoIdentityPoolExample"
@@ -74,7 +102,7 @@ if [ -n "${UPREMAIN}" ] && [ "${UPREMAIN}" != "None" ]; then
   exit 1
 fi
 echo "    OK: user pool gone"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && { echo "FAIL: state remains" >&2; exit 1; }
+assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 echo ""
 echo "==> cognito-identity-pool test passed"

--- a/tests/integration/cognito-identity-pool/verify.sh
+++ b/tests/integration/cognito-identity-pool/verify.sh
@@ -12,12 +12,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/cognito-lambda-triggers/verify.sh
+++ b/tests/integration/cognito-lambda-triggers/verify.sh
@@ -18,6 +18,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdCognitoLambdaTriggersExample"
@@ -131,16 +159,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
 # Use describe-user-pool on the known id (strongly consistent) — list-user-pools
 # is eventually consistent and can still show a just-deleted pool for a few
 # seconds, which would be a false-positive failure.
-if aws cognito-idp describe-user-pool --user-pool-id "${POOL_ID}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: UserPool ${POOL_ID} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "UserPool ${POOL_ID} still exists after destroy" aws cognito-idp describe-user-pool --user-pool-id "${POOL_ID}" --region "${REGION}"
 echo "    OK: UserPool is gone"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: cdkd state removed"
 
 sweep_log_groups

--- a/tests/integration/cognito-lambda-triggers/verify.sh
+++ b/tests/integration/cognito-lambda-triggers/verify.sh
@@ -25,12 +25,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/cognito-resource-server/verify.sh
+++ b/tests/integration/cognito-resource-server/verify.sh
@@ -28,12 +28,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/cognito-resource-server/verify.sh
+++ b/tests/integration/cognito-resource-server/verify.sh
@@ -21,6 +21,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CognitoResourceServerStack"
@@ -134,16 +162,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws cognito-idp describe-user-pool --user-pool-id "${POOL_ID}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: UserPool ${POOL_ID} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "UserPool ${POOL_ID} still exists after destroy" aws cognito-idp describe-user-pool --user-pool-id "${POOL_ID}" --region "${REGION}"
 echo "    OK: UserPool is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/cognito-userpool-user-ref/verify.sh
+++ b/tests/integration/cognito-userpool-user-ref/verify.sh
@@ -16,12 +16,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/cognito-userpool-user-ref/verify.sh
+++ b/tests/integration/cognito-userpool-user-ref/verify.sh
@@ -8,6 +8,34 @@
 # username); with the fix the user lands in the group. Then destroys clean.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdCognitoUserPoolUserRefExample"
@@ -74,7 +102,7 @@ if [ -n "${REMAIN}" ] && [ "${REMAIN}" != "None" ]; then
   exit 1
 fi
 echo "    OK: user pool gone"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && { echo "FAIL: state remains" >&2; exit 1; }
+assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 echo ""
 echo "==> cognito-userpool-user-ref test passed (UserPoolUser Ref resolves to bare username; clean destroy)"

--- a/tests/integration/cognito/verify.sh
+++ b/tests/integration/cognito/verify.sh
@@ -27,12 +27,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/cognito/verify.sh
+++ b/tests/integration/cognito/verify.sh
@@ -20,6 +20,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CognitoStack"
@@ -157,16 +185,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws cognito-idp describe-user-pool --user-pool-id "${POOL_ID}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Backfill UserPool ${POOL_ID} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "Backfill UserPool ${POOL_ID} still exists after destroy" aws cognito-idp describe-user-pool --user-pool-id "${POOL_ID}" --region "${REGION}"
 echo "    OK: Backfill UserPool is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/conditions-and-if/verify.sh
+++ b/tests/integration/conditions-and-if/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdConditionsIfExample"
@@ -251,16 +279,10 @@ if ssm_exists "${TIER_LABEL_PARAM}"; then
   echo "FAIL: TierLabelParam still exists after destroy" >&2
   exit 1
 fi
-if aws sns get-topic-attributes --topic-arn "${TOPIC_ARN}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SNS topic '${TOPIC_ARN}' still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "SNS topic '${TOPIC_ARN}' still exists after destroy" aws sns get-topic-attributes --topic-arn "${TOPIC_ARN}" --region "${REGION}"
 echo "    OK: all AWS resources gone after destroy"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/conditions-and-if/verify.sh
+++ b/tests/integration/conditions-and-if/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi
@@ -127,9 +131,11 @@ ssm_value() {
   echo "${out}"
 }
 
-# Helper: does an SSM parameter exist? rc 0 = yes, 1 = no.
+# Helper: does an SSM parameter exist? rc 0 = yes, 1 = confirmed not-found.
+# Routed through gone_probe (issue #1097 pattern 2) so any other probe failure
+# (throttle, auth) hard-FAILs instead of reading as "absent".
 ssm_exists() {
-  aws ssm get-parameter --name "$1" --region "${REGION}" >/dev/null 2>&1
+  ! gone_probe aws ssm get-parameter --name "$1" --region "${REGION}"
 }
 
 # Helper: fetch a single tag value from the topic's SNS tags, or empty.

--- a/tests/integration/conditions-update-2/verify.sh
+++ b/tests/integration/conditions-update-2/verify.sh
@@ -48,12 +48,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi
@@ -148,9 +152,11 @@ fi
 echo "==> Pre-run cleanup"
 cleanup
 
-# Helper: does an SSM parameter exist? rc 0 = yes, 1 = no.
+# Helper: does an SSM parameter exist? rc 0 = yes, 1 = confirmed not-found.
+# Routed through gone_probe (issue #1097 pattern 2) so any other probe failure
+# (throttle, auth) hard-FAILs instead of reading as "absent".
 ssm_exists() {
-  aws ssm get-parameter --name "$1" --region "${REGION}" >/dev/null 2>&1
+  ! gone_probe aws ssm get-parameter --name "$1" --region "${REGION}"
 }
 
 # Helper: read an SSM parameter Value, or empty. Never aborts under set -e.
@@ -346,14 +352,12 @@ if ssm_exists "${APPEAR_PARAM}"; then
   echo "FAIL: AppearParam still exists after destroy" >&2
   exit 1
 fi
-if [ -n "$(queue_url "${WORK_QUEUE_NAME}")" ]; then
-  echo "FAIL: WorkQueue '${WORK_QUEUE_NAME}' still exists after destroy" >&2
-  exit 1
-fi
-if [ -n "$(queue_url "${DLQ_NAME}")" ]; then
-  echo "FAIL: DeadLetterQueue '${DLQ_NAME}' still exists after destroy" >&2
-  exit 1
-fi
+# Direct get-queue-url gone-probes (issue #1097 pattern 2): the silenced
+# queue_url helper reads a throttle as "" == gone, so it must not back a
+# leak assertion. SQS missing-queue is QueueDoesNotExist ("The specified
+# queue does not exist"), which matches the canonical signature.
+assert_gone "WorkQueue '${WORK_QUEUE_NAME}' still exists after destroy" aws sqs get-queue-url --queue-name "${WORK_QUEUE_NAME}" --region "${REGION}"
+assert_gone "DeadLetterQueue '${DLQ_NAME}' still exists after destroy" aws sqs get-queue-url --queue-name "${DLQ_NAME}" --region "${REGION}"
 echo "    OK: all AWS resources gone after destroy"
 
 assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"

--- a/tests/integration/conditions-update-2/verify.sh
+++ b/tests/integration/conditions-update-2/verify.sh
@@ -41,6 +41,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdConditionsUpdate2Example"
@@ -328,10 +356,7 @@ if [ -n "$(queue_url "${DLQ_NAME}")" ]; then
 fi
 echo "    OK: all AWS resources gone after destroy"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/cross-region-state-bucket/verify.sh
+++ b/tests/integration/cross-region-state-bucket/verify.sh
@@ -43,12 +43,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/cross-region-state-bucket/verify.sh
+++ b/tests/integration/cross-region-state-bucket/verify.sh
@@ -36,6 +36,34 @@
 # BSD/macOS-portable: no grep -P, no date -d.
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 BASE_REGION="${AWS_REGION:-us-east-1}"
 BUCKET_REGION="${BUCKET_REGION:-us-west-2}"
 if [ "${BASE_REGION}" = "${BUCKET_REGION}" ]; then
@@ -133,10 +161,7 @@ if ! aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" --reg
   echo "[verify] FAIL: state.json not found at s3://${STATE_BUCKET}/${STATE_KEY}"
   exit 1
 fi
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${LOCK_KEY}" --region "${BUCKET_REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: lock.json still present at s3://${STATE_BUCKET}/${LOCK_KEY} — lock was not released"
-  exit 1
-fi
+assert_gone "lock.json still present at s3://${STATE_BUCKET}/${LOCK_KEY} — lock was not released" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${LOCK_KEY}" --region "${BUCKET_REGION}"
 # Issue #819: the exports index file must have been written to the
 # cross-region bucket (pre-fix the write hit the 301 and was skipped).
 if ! aws s3api head-object --bucket "${STATE_BUCKET}" --key "${INDEX_KEY}" --region "${BUCKET_REGION}" >/dev/null 2>&1; then
@@ -171,14 +196,8 @@ DESTROY_OUT="$(${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --forc
 echo "${DESTROY_OUT}"
 
 echo "[verify] step 7: assert state gone + SSM parameter gone + no 301 warning"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" --region "${BUCKET_REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: state.json still present after destroy"
-  exit 1
-fi
-if aws ssm get-parameter --name "${SSM_PARAM_NAME}" --region "${BASE_REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: SSM parameter ${SSM_PARAM_NAME} still exists after destroy"
-  exit 1
-fi
+assert_gone "state.json still present after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" --region "${BUCKET_REGION}"
+assert_gone "SSM parameter ${SSM_PARAM_NAME} still exists after destroy" aws ssm get-parameter --name "${SSM_PARAM_NAME}" --region "${BASE_REGION}"
 # Issue #819: the destroy output must NOT carry the exports-index 301 warning.
 assert_no_exports_index_301 "destroy" "${DESTROY_OUT}"
 echo "[verify] step 7 ok"

--- a/tests/integration/custom-resource-getatt-data/verify.sh
+++ b/tests/integration/custom-resource-getatt-data/verify.sh
@@ -25,12 +25,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/custom-resource-getatt-data/verify.sh
+++ b/tests/integration/custom-resource-getatt-data/verify.sh
@@ -18,6 +18,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdCrGetAttDataExample"
@@ -151,26 +179,17 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # The CR + backing Lambda + the three SSM parameters must all be gone.
 for p in "${PARAM_COMPUTED}" "${PARAM_ANOTHER}" "${PARAM_NUMERIC}"; do
-  if aws ssm get-parameter --region "${REGION}" --name "${p}" >/dev/null 2>&1; then
-    echo "FAIL: SSM parameter ${p} still exists after destroy (orphan)" >&2
-    exit 1
-  fi
+  assert_gone "SSM parameter ${p} still exists after destroy (orphan)" aws ssm get-parameter --region "${REGION}" --name "${p}"
 done
 echo "    OK: all three SSM parameters are gone"
 
 if [ -n "${LAMBDA_ARN}" ]; then
-  if aws lambda get-function --region "${REGION}" --function-name "${LAMBDA_ARN}" >/dev/null 2>&1; then
-    echo "FAIL: backing Lambda ${LAMBDA_ARN} still exists after destroy (orphan)" >&2
-    exit 1
-  fi
+  assert_gone "backing Lambda ${LAMBDA_ARN} still exists after destroy (orphan)" aws lambda get-function --region "${REGION}" --function-name "${LAMBDA_ARN}"
   echo "    OK: backing Lambda is gone"
 fi
 

--- a/tests/integration/data-analytics/verify.sh
+++ b/tests/integration/data-analytics/verify.sh
@@ -24,12 +24,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/data-analytics/verify.sh
+++ b/tests/integration/data-analytics/verify.sh
@@ -17,6 +17,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="DataAnalyticsStack"
@@ -129,16 +157,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws glue get-table --database-name "${DB_NAME}" --name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Glue Iceberg table ${DB_NAME}.${TABLE_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "Glue Iceberg table ${DB_NAME}.${TABLE_NAME} still exists after destroy" aws glue get-table --database-name "${DB_NAME}" --name "${TABLE_NAME}" --region "${REGION}"
 echo "    OK: Glue Iceberg table is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/deep-getatt-chains/verify.sh
+++ b/tests/integration/deep-getatt-chains/verify.sh
@@ -44,12 +44,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/deep-getatt-chains/verify.sh
+++ b/tests/integration/deep-getatt-chains/verify.sh
@@ -37,6 +37,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdDeepGetAttChainsExample"
@@ -239,16 +267,11 @@ echo ""
 echo "==> Post-destroy: assert named resources are gone"
 
 # E: Lambda function gone.
-if aws lambda get-function-configuration --region "${REGION}" \
-  --function-name "${FUNCTION_NAME}" >/dev/null 2>&1; then
-  fail "Lambda ${FUNCTION_NAME} still exists after destroy"
-fi
+assert_gone "Lambda ${FUNCTION_NAME} still exists after destroy" aws lambda get-function-configuration --region "${REGION}" --function-name "${FUNCTION_NAME}"
 echo "    OK: Lambda E is gone"
 
 # D: SSM parameter gone.
-if aws ssm get-parameter --region "${REGION}" --name "${PARAM_NAME}" >/dev/null 2>&1; then
-  fail "SSM parameter ${PARAM_NAME} still exists after destroy"
-fi
+assert_gone "SSM parameter ${PARAM_NAME} still exists after destroy" aws ssm get-parameter --region "${REGION}" --name "${PARAM_NAME}"
 echo "    OK: SSM param D is gone"
 
 # C: composite alarm gone (and confirm it carried our OWN fixture tag while alive).
@@ -279,9 +302,7 @@ fi
 echo "    OK: SNS topic A is gone"
 
 # State file gone.
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  fail "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy"
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/deletion-policy-retain/verify.sh
+++ b/tests/integration/deletion-policy-retain/verify.sh
@@ -16,6 +16,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 CDKD="node ../../../dist/cli.js"
@@ -124,10 +152,7 @@ echo "    destroy param gone (ParameterNotFound) (✓)"
 
 echo ""
 echo "==> Step 3: Verify cdkd state cleared"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && {
-  echo "FAIL: cdkd state still exists at ${STATE_KEY} after destroy"
-  exit 1
-} || true
+assert_gone "cdkd state still exists at ${STATE_KEY} after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state cleared (✓)"
 
 echo ""

--- a/tests/integration/deletion-policy-retain/verify.sh
+++ b/tests/integration/deletion-policy-retain/verify.sh
@@ -23,12 +23,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/deployment-events/verify.sh
+++ b/tests/integration/deployment-events/verify.sh
@@ -26,6 +26,34 @@
 # the script prints an explicit "[verify] PASS" only at the very end.
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
 
@@ -178,14 +206,8 @@ echo "[verify] step 5: cdkd destroy ${STACK} --force"
 ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --force
 
 echo "[verify] step 6: assert state.json gone but events sidecar still readable + a destroy run appended"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: state.json still present after destroy"
-  exit 1
-fi
-if aws ssm get-parameter --name "${SSM_PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: SSM parameter ${SSM_PARAM_NAME} still exists after destroy"
-  exit 1
-fi
+assert_gone "state.json still present after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
+assert_gone "SSM parameter ${SSM_PARAM_NAME} still exists after destroy" aws ssm get-parameter --name "${SSM_PARAM_NAME}" --region "${REGION}"
 echo "[verify]   ok: SSM parameter ${SSM_PARAM_NAME} is gone"
 # Explicitly assert the named SNS topic is NOT-FOUND in AWS too — state-empty
 # alone would miss an orphaned topic that carries no stack name. SNS has no
@@ -197,10 +219,7 @@ if [ -z "${ACCOUNT_ID}" ] || [ "${ACCOUNT_ID}" = "None" ]; then
   exit 1
 fi
 TOPIC_ARN="arn:aws:sns:${REGION}:${ACCOUNT_ID}:${TOPIC_NAME}"
-if aws sns get-topic-attributes --topic-arn "${TOPIC_ARN}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: SNS topic ${TOPIC_ARN} still exists after destroy (orphan)"
-  exit 1
-fi
+assert_gone "SNS topic ${TOPIC_ARN} still exists after destroy (orphan)" aws sns get-topic-attributes --topic-arn "${TOPIC_ARN}" --region "${REGION}"
 echo "[verify]   ok: SNS topic ${TOPIC_NAME} is gone"
 # Events deliberately survive destroy — the deployments/ sidecar must still
 # exist and now also carry the destroy run's own {runId}.jsonl.

--- a/tests/integration/deployment-events/verify.sh
+++ b/tests/integration/deployment-events/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/destroy-interrupt/verify.sh
+++ b/tests/integration/destroy-interrupt/verify.sh
@@ -28,6 +28,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdDestroyInterruptExample"
@@ -359,20 +387,14 @@ echo "    OK: lock object is gone"
 
 # Backing Lambda gone.
 if [ -n "${FN_NAME}" ] && [ "${FN_NAME}" != "null" ]; then
-  if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-    echo "FAIL: backing Lambda ${FN_NAME} still exists after destroy" >&2
-    exit 1
-  fi
+  assert_gone "backing Lambda ${FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
   echo "    OK: backing Lambda is gone"
 fi
 
 # VPC gone (covers subnets / SG / ENI implicitly — a lingering ENI or SG
 # would keep the VPC alive and DescribeVpcs would still return it).
 if [ -n "${VPC_ID}" ] && [ "${VPC_ID}" != "null" ]; then
-  if aws ec2 describe-vpcs --vpc-ids "${VPC_ID}" --region "${REGION}" >/dev/null 2>&1; then
-    echo "FAIL: VPC ${VPC_ID} still exists after destroy" >&2
-    exit 1
-  fi
+  assert_gone "VPC ${VPC_ID} still exists after destroy" aws ec2 describe-vpcs --vpc-ids "${VPC_ID}" --region "${REGION}"
   echo "    OK: VPC is gone (subnets / SG / ENI implicitly cleared)"
 
   # Defensive explicit ENI / SG scan against the (now-deleted) VPC id —
@@ -394,10 +416,7 @@ fi
 # if the VPC delete path ever changes. describe-security-groups exits
 # non-zero (InvalidGroup.NotFound) once the SG is deleted.
 if [ -n "${SG_ID}" ] && [ "${SG_ID}" != "null" ]; then
-  if aws ec2 describe-security-groups --group-ids "${SG_ID}" --region "${REGION}" >/dev/null 2>&1; then
-    echo "FAIL: SecurityGroup ${SG_ID} still exists after destroy" >&2
-    exit 1
-  fi
+  assert_gone "SecurityGroup ${SG_ID} still exists after destroy" aws ec2 describe-security-groups --group-ids "${SG_ID}" --region "${REGION}"
   echo "    OK: SecurityGroup is gone"
 fi
 
@@ -406,10 +425,7 @@ fi
 # (the "state-empty misses a no-stack-name orphan" class). get-role exits
 # non-zero (NoSuchEntity) once the role is deleted.
 if [ -n "${ROLE_NAME}" ] && [ "${ROLE_NAME}" != "null" ]; then
-  if aws iam get-role --role-name "${ROLE_NAME}" >/dev/null 2>&1; then
-    echo "FAIL: IAM role ${ROLE_NAME} still exists after destroy" >&2
-    exit 1
-  fi
+  assert_gone "IAM role ${ROLE_NAME} still exists after destroy" aws iam get-role --role-name "${ROLE_NAME}"
   echo "    OK: IAM role is gone"
 fi
 
@@ -420,10 +436,7 @@ fi
 if [ -n "${PARAM_NAMES}" ]; then
   while IFS= read -r pname; do
     [ -z "${pname}" ] && continue
-    if aws ssm get-parameter --name "${pname}" --region "${REGION}" >/dev/null 2>&1; then
-      echo "FAIL: SSM parameter ${pname} still exists after destroy" >&2
-      exit 1
-    fi
+    assert_gone "SSM parameter ${pname} still exists after destroy" aws ssm get-parameter --name "${pname}" --region "${REGION}"
   done <<EOF
 ${PARAM_NAMES}
 EOF

--- a/tests/integration/destroy-interrupt/verify.sh
+++ b/tests/integration/destroy-interrupt/verify.sh
@@ -35,12 +35,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi
@@ -94,12 +98,17 @@ trap cleanup EXIT
 trap '(exit 130); cleanup; exit 130' INT
 trap '(exit 143); cleanup; exit 143' TERM
 
+# Strict existence probes (issue #1097 pattern 2): head-object through
+# gone_probe -- 0 = object present, 1 = confirmed 404-gone, hard-FAIL on any
+# other probe failure (a throttle must never read as "state/lock is gone").
+# `aws s3 ls` is unusable here: it exits 1 with EMPTY output for "no keys",
+# indistinguishable from a silenced error.
 state_exists() {
-  aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1
+  ! gone_probe aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 }
 
 lock_exists() {
-  aws s3 ls "s3://${STATE_BUCKET}/${LOCK_KEY}" >/dev/null 2>&1
+  ! gone_probe aws s3api head-object --bucket "${STATE_BUCKET}" --key "${LOCK_KEY}"
 }
 
 # Bounded poll: returns 0 (released) once the lock object is GONE, or 1
@@ -109,6 +118,8 @@ lock_exists() {
 # check can race the delete. Only call this AFTER `wait` has confirmed
 # the node process fully exited — while the process is alive the lock is
 # LEGITIMATELY held (it is released in the finally, not mid-drain).
+# lock_exists is strict (gone_probe): a throttled probe hard-FAILs the run
+# instead of reading as "released".
 wait_for_lock_release() {
   local tries=0
   while [ "${tries}" -lt 10 ]; do

--- a/tests/integration/dlm-lifecycle-policy/verify.sh
+++ b/tests/integration/dlm-lifecycle-policy/verify.sh
@@ -32,6 +32,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdDlmLifecyclePolicyExample"
@@ -193,22 +221,13 @@ echo "    update reached AWS (DISABLED, env=changed, dropme removed)"
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws dlm get-lifecycle-policy --policy-id "${POLICY_ID_P2}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: lifecycle policy ${POLICY_ID_P2} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "lifecycle policy ${POLICY_ID_P2} still exists after destroy" aws dlm get-lifecycle-policy --policy-id "${POLICY_ID_P2}" --region "${REGION}"
 echo "    lifecycle policy deleted"
 
-if aws iam get-role --role-name "${ROLE_NAME}" >/dev/null 2>&1; then
-  echo "FAIL: IAM role ${ROLE_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "IAM role ${ROLE_NAME} still exists after destroy" aws iam get-role --role-name "${ROLE_NAME}"
 echo "    execution role deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — AWS::DLM::LifecyclePolicy SDK provider: deploy + in-place update (incl. tag removal) + destroy all passed"

--- a/tests/integration/dlm-lifecycle-policy/verify.sh
+++ b/tests/integration/dlm-lifecycle-policy/verify.sh
@@ -39,12 +39,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/docker-image-asset/verify.sh
+++ b/tests/integration/docker-image-asset/verify.sh
@@ -32,6 +32,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdDockerImageAssetExample"
@@ -237,10 +265,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --yes
 
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Lambda function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "Lambda function ${FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
 echo "    OK: Lambda function is gone"
 
 # The Docker image asset is pushed into the SHARED CDK-managed container-assets
@@ -257,20 +282,13 @@ if [ -n "${IMAGE_TAG}" ]; then
       --image-ids "imageTag=${IMAGE_TAG}" --region "${REGION}" >/dev/null 2>&1 || true
   fi
   # Re-check: after the sweep, OUR image must be gone (0 orphans for our tag).
-  if aws ecr describe-images --repository-name "${ECR_REPO}" \
-      --image-ids "imageTag=${IMAGE_TAG}" --region "${REGION}" >/dev/null 2>&1; then
-    echo "FAIL: pushed ECR image (tag ${IMAGE_TAG}) still present after destroy + sweep" >&2
-    exit 1
-  fi
+  assert_gone "pushed ECR image (tag ${IMAGE_TAG}) still present after destroy + sweep" aws ecr describe-images --repository-name "${ECR_REPO}" --image-ids "imageTag=${IMAGE_TAG}" --region "${REGION}"
   echo "    OK: pushed ECR image (tag ${IMAGE_TAG}) is gone (0 ECR orphans)"
   # Clear so the EXIT-trap sweep does not run again.
   IMAGE_TAG=""
 fi
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/docker-image-asset/verify.sh
+++ b/tests/integration/docker-image-asset/verify.sh
@@ -39,12 +39,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/dynamodb-autoscaling/verify.sh
+++ b/tests/integration/dynamodb-autoscaling/verify.sh
@@ -30,12 +30,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/dynamodb-autoscaling/verify.sh
+++ b/tests/integration/dynamodb-autoscaling/verify.sh
@@ -23,6 +23,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdDynamodbAutoscalingExample"
@@ -159,10 +187,7 @@ if [ "${TARGETS_GONE}" != "0" ]; then
 fi
 echo "    all ScalableTargets deregistered"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — DynamoDB Application Auto Scaling CC-API create + in-place MaxCapacity UPDATE + destroy, all 3 phases passed"

--- a/tests/integration/dynamodb-globaltable/verify.sh
+++ b/tests/integration/dynamodb-globaltable/verify.sh
@@ -57,6 +57,34 @@
 # Auto-resolves AWS account ID + state bucket. Run from anywhere.
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
 STACK="CdkdDynamoDBGlobalTableExample"
@@ -352,17 +380,11 @@ echo "[verify] step 15: cdkd destroy --remove-protection --force"
 ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --remove-protection --force
 
 echo "[verify] step 16a: assert table is gone on AWS"
-if aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: table '${TABLE_NAME}' still exists after destroy"
-  exit 1
-fi
+assert_gone "table '${TABLE_NAME}' still exists after destroy" aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}"
 echo "[verify] step 16a ok: table deleted"
 
 echo "[verify] step 16b: assert cdkd state is empty"
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: cdkd state file still exists at s3://${STATE_BUCKET}/${STATE_KEY}"
-  exit 1
-fi
+assert_gone "cdkd state file still exists at s3://${STATE_BUCKET}/${STATE_KEY}" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "[verify] step 16b ok: cdkd state cleared"
 
 trap - EXIT INT TERM

--- a/tests/integration/dynamodb-globaltable/verify.sh
+++ b/tests/integration/dynamodb-globaltable/verify.sh
@@ -64,12 +64,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/dynamodb-gsi-update/verify.sh
+++ b/tests/integration/dynamodb-gsi-update/verify.sh
@@ -29,12 +29,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/dynamodb-gsi-update/verify.sh
+++ b/tests/integration/dynamodb-gsi-update/verify.sh
@@ -22,6 +22,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdDynamodbGsiUpdateExample"
@@ -138,10 +166,7 @@ if [ "${status}" != "GONE" ] && [ "${status}" != "DELETING" ]; then
 fi
 echo "    table deleted (status: ${status})"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — DynamoDB GSI add is an in-place UPDATE (no replacement), all 3 phases passed"

--- a/tests/integration/dynamodb-ondemand/verify.sh
+++ b/tests/integration/dynamodb-ondemand/verify.sh
@@ -34,12 +34,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/dynamodb-ondemand/verify.sh
+++ b/tests/integration/dynamodb-ondemand/verify.sh
@@ -27,6 +27,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdDynamodbOndemandExample"
@@ -279,7 +307,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
 # until it is truly gone rather than racing the async delete.
 TABLE_GONE=""
 for _ in $(seq 1 24); do
-  if ! aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
+  if gone_probe aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}"; then
     TABLE_GONE=1
     break
   fi
@@ -294,7 +322,7 @@ echo "    OK: DynamoDB table is gone"
 # The standalone PROVISIONED table is async-deleted too.
 PROV_TABLE_GONE=""
 for _ in $(seq 1 24); do
-  if ! aws dynamodb describe-table --table-name "${PROV_TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
+  if gone_probe aws dynamodb describe-table --table-name "${PROV_TABLE_NAME}" --region "${REGION}"; then
     PROV_TABLE_GONE=1
     break
   fi
@@ -309,7 +337,7 @@ echo "    OK: provisioned DynamoDB table is gone"
 # Kinesis DeleteStream is async too.
 STREAM_GONE=""
 for _ in $(seq 1 24); do
-  if ! aws kinesis describe-stream --stream-name "${STREAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
+  if gone_probe aws kinesis describe-stream --stream-name "${STREAM_NAME}" --region "${REGION}"; then
     STREAM_GONE=1
     break
   fi
@@ -321,10 +349,7 @@ if [ -z "${STREAM_GONE}" ]; then
 fi
 echo "    OK: Kinesis stream is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/dynamodb-sse/verify.sh
+++ b/tests/integration/dynamodb-sse/verify.sh
@@ -22,12 +22,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/dynamodb-sse/verify.sh
+++ b/tests/integration/dynamodb-sse/verify.sh
@@ -15,6 +15,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdDynamodbSseExample"
@@ -94,10 +122,7 @@ if [ "${status}" != "GONE" ] && [ "${status}" != "DELETING" ]; then
 fi
 echo "    table deleted (status: ${status})"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — DynamoDB AWS_MANAGED encryption (SSEEnabled->Enabled mapping) reaches AWS as SSEType=KMS, destroy clean"

--- a/tests/integration/dynamodb-stream-filter/verify.sh
+++ b/tests/integration/dynamodb-stream-filter/verify.sh
@@ -24,12 +24,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/dynamodb-stream-filter/verify.sh
+++ b/tests/integration/dynamodb-stream-filter/verify.sh
@@ -17,6 +17,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdDynamodbStreamFilterExample"
@@ -137,10 +165,7 @@ if [ "${TBL_STATUS}" != "GONE" ] && [ "${TBL_STATUS}" != "DELETING" ]; then
 fi
 echo "    OK: table deleted (status: ${TBL_STATUS})"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: cdkd state removed"
 
 sweep_log_groups

--- a/tests/integration/dynamodb-streams/verify.sh
+++ b/tests/integration/dynamodb-streams/verify.sh
@@ -22,6 +22,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="DynamodbStreamsStack"
@@ -257,7 +285,7 @@ CDKD_TEST_UPDATE=true node "${LOCAL_DIST}" destroy "${STACK}" \
 # until it is truly gone rather than racing the async delete.
 TABLE_GONE=""
 for _ in $(seq 1 24); do
-  if ! aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
+  if gone_probe aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}"; then
     TABLE_GONE=1
     break
   fi
@@ -269,10 +297,7 @@ if [ -z "${TABLE_GONE}" ]; then
 fi
 echo "    OK: DynamoDB table is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/dynamodb-streams/verify.sh
+++ b/tests/integration/dynamodb-streams/verify.sh
@@ -29,12 +29,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/dynamodb-tableclass-switch/verify.sh
+++ b/tests/integration/dynamodb-tableclass-switch/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdDynamodbTableclassSwitchExample"
@@ -156,10 +184,7 @@ if [ -z "${table_gone}" ]; then
 fi
 echo "    table deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — DynamoDB TableClass switch (STANDARD -> STANDARD_INFREQUENT_ACCESS) reaches AWS, all 3 phases passed"

--- a/tests/integration/dynamodb-tableclass-switch/verify.sh
+++ b/tests/integration/dynamodb-tableclass-switch/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/dynamodb-ttl-attr-change/verify.sh
+++ b/tests/integration/dynamodb-ttl-attr-change/verify.sh
@@ -20,6 +20,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdDynamodbTtlAttrChangeExample"
@@ -158,7 +186,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
 
 TABLE_GONE=""
 for _ in $(seq 1 24); do
-  if ! aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
+  if gone_probe aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}"; then
     TABLE_GONE=1
     break
   fi
@@ -170,10 +198,7 @@ if [ -z "${TABLE_GONE}" ]; then
 fi
 echo "    OK: DynamoDB table is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/dynamodb-ttl-attr-change/verify.sh
+++ b/tests/integration/dynamodb-ttl-attr-change/verify.sh
@@ -27,12 +27,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/ec2-instance/verify.sh
+++ b/tests/integration/ec2-instance/verify.sh
@@ -30,6 +30,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="Ec2InstanceStack"
@@ -200,10 +228,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --remove-protection \
   --force
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # Instance should be terminated (or shutting-down right after the call).

--- a/tests/integration/ec2-instance/verify.sh
+++ b/tests/integration/ec2-instance/verify.sh
@@ -37,12 +37,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/ecr-scanning/verify.sh
+++ b/tests/integration/ecr-scanning/verify.sh
@@ -23,6 +23,34 @@
 # Required env vars: STATE_BUCKET; AWS_REGION (defaults us-east-1).
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdEcrScanningExample"
@@ -141,13 +169,9 @@ echo "    removed tag untagged + changed tag updated on AWS"
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws ecr describe-repositories --repository-names "${REPO}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: repo ${REPO} still exists after destroy" >&2; exit 1
-fi
+assert_gone "repo ${REPO} still exists after destroy" aws ecr describe-repositories --repository-names "${REPO}" --region "${REGION}"
 echo "    repo deleted"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file still exists after destroy" >&2; exit 1
-fi
+assert_gone "state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — ECR scanOnPush (CFn->SDK casing) + tag add/change/untag on update reach AWS, 3 phases passed"

--- a/tests/integration/ecr-scanning/verify.sh
+++ b/tests/integration/ecr-scanning/verify.sh
@@ -31,12 +31,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/ecs-fargate/verify.sh
+++ b/tests/integration/ecs-fargate/verify.sh
@@ -27,12 +27,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/ecs-fargate/verify.sh
+++ b/tests/integration/ecs-fargate/verify.sh
@@ -20,6 +20,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="EcsFargateStack"
@@ -322,10 +350,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/ecs-service-update-props/verify.sh
+++ b/tests/integration/ecs-service-update-props/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="EcsServiceUpdatePropsStack"
@@ -171,10 +199,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/ecs-service-update-props/verify.sh
+++ b/tests/integration/ecs-service-update-props/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/efs-immutable-replacement/verify.sh
+++ b/tests/integration/efs-immutable-replacement/verify.sh
@@ -27,12 +27,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/efs-immutable-replacement/verify.sh
+++ b/tests/integration/efs-immutable-replacement/verify.sh
@@ -19,6 +19,34 @@
 # Required env vars: STATE_BUCKET, AWS_REGION (defaults us-east-1).
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdEfsImmutableReplacementExample"
@@ -140,9 +168,7 @@ if [ "$(fs_mode_by_id "${FS_ID_P4}")" != "generalPurpose" ]; then
   echo "FAIL: replacement filesystem is not generalPurpose" >&2; exit 1
 fi
 # old filesystem must be gone
-if aws efs describe-file-systems --region "${REGION}" --file-system-id "${FS_ID_P1}" >/dev/null 2>&1; then
-  echo "FAIL: old filesystem ${FS_ID_P1} still exists after replacement" >&2; exit 1
-fi
+assert_gone "old filesystem ${FS_ID_P1} still exists after replacement" aws efs describe-file-systems --region "${REGION}" --file-system-id "${FS_ID_P1}"
 echo "    replaced: ${FS_ID_P1} -> ${FS_ID_P4} (generalPurpose), old gone"
 
 # --- Phase 5: destroy --------------------------------------------------
@@ -152,9 +178,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --regio
 if [ -n "$(fs_id_by_tag)" ] && [ "$(fs_id_by_tag)" != "None" ]; then
   echo "FAIL: filesystem still present after destroy" >&2; exit 1
 fi
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2; exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    filesystem deleted, cdkd state removed"
 
 echo "[verify] PASS — createOnly replacement detection + stateful guard + forced replacement + destroy, all phases passed"

--- a/tests/integration/efs-standalone/verify.sh
+++ b/tests/integration/efs-standalone/verify.sh
@@ -25,12 +25,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/efs-standalone/verify.sh
+++ b/tests/integration/efs-standalone/verify.sh
@@ -18,6 +18,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="EfsStandaloneStack"
@@ -149,16 +177,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws efs describe-file-systems --file-system-id "${FS_ID}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: EFS FileSystem ${FS_ID} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "EFS FileSystem ${FS_ID} still exists after destroy" aws efs describe-file-systems --file-system-id "${FS_ID}" --region "${REGION}"
 echo "    OK: EFS FileSystem is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/elasticache-replicationgroup-getatt/verify.sh
+++ b/tests/integration/elasticache-replicationgroup-getatt/verify.sh
@@ -20,12 +20,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/elasticache-replicationgroup-getatt/verify.sh
+++ b/tests/integration/elasticache-replicationgroup-getatt/verify.sh
@@ -12,6 +12,34 @@
 # BSD/macOS-portable (no grep -P, no date -d). Real rc captured. Explicit PASS.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdElastiCacheRgExample"
@@ -119,12 +147,8 @@ fi
 echo "    OK: destroy exited 0"
 
 echo "==> Step 4: assert 0 orphans"
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file still exists after destroy" >&2; exit 1
-fi
-if aws ssm get-parameter --name "${ADDR_PARAM}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SSM parameter ${ADDR_PARAM} still exists after destroy" >&2; exit 1
-fi
+assert_gone "state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
+assert_gone "SSM parameter ${ADDR_PARAM} still exists after destroy" aws ssm get-parameter --name "${ADDR_PARAM}" --region "${REGION}"
 RG_LEFT=$(aws elasticache describe-replication-groups --region "${REGION}" \
   --query "ReplicationGroups[?contains(Description, 'cdkd elasticache-rg getatt fixture')] | length(@)" \
   --output text 2>/dev/null || echo 0)

--- a/tests/integration/emr-instance-configs/verify.sh
+++ b/tests/integration/emr-instance-configs/verify.sh
@@ -46,12 +46,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/emr-instance-configs/verify.sh
+++ b/tests/integration/emr-instance-configs/verify.sh
@@ -39,6 +39,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 # Disable the AWS CLI output pager everywhere — in a non-interactive shell an
 # invoked pager can hang or error (`[Errno 22] Invalid argument`).
 export AWS_PAGER=""
@@ -284,10 +312,7 @@ if [ -n "${LEFTOVERS}" ]; then
 fi
 echo "    no active cluster with the fixture tag remains"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — AWS::EMR::InstanceGroupConfig SDK provider: deploy + in-place resize + destroy (group released with cluster) all passed"

--- a/tests/integration/eventbridge-api-destination/verify.sh
+++ b/tests/integration/eventbridge-api-destination/verify.sh
@@ -27,12 +27,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/eventbridge-api-destination/verify.sh
+++ b/tests/integration/eventbridge-api-destination/verify.sh
@@ -19,6 +19,34 @@
 # Required env vars: STATE_BUCKET; AWS_REGION (defaults us-east-1).
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdEventbridgeApiDestinationExample"
@@ -92,19 +120,11 @@ echo "    Rule target Arn resolved to a real ARN (ApiDestination Arn enrichment 
 echo "==> Phase 2: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws events describe-api-destination --name "${DEST}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: ApiDestination ${DEST} still exists after destroy" >&2; exit 1
-fi
-if aws events describe-connection --name "${CONN}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Connection ${CONN} still exists after destroy" >&2; exit 1
-fi
-if aws events describe-rule --name "${RULE}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Rule ${RULE} still exists after destroy" >&2; exit 1
-fi
+assert_gone "ApiDestination ${DEST} still exists after destroy" aws events describe-api-destination --name "${DEST}" --region "${REGION}"
+assert_gone "Connection ${CONN} still exists after destroy" aws events describe-connection --name "${CONN}" --region "${REGION}"
+assert_gone "Rule ${RULE} still exists after destroy" aws events describe-rule --name "${RULE}" --region "${REGION}"
 echo "    Connection / ApiDestination / Rule deleted"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file still exists after destroy" >&2; exit 1
-fi
+assert_gone "state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — Connection Arn / ApiDestination Arn GetAtt enrichment works end-to-end, 2 phases passed"

--- a/tests/integration/eventbridge-archive/verify.sh
+++ b/tests/integration/eventbridge-archive/verify.sh
@@ -18,6 +18,34 @@
 #   AWS_REGION   — defaults to us-east-1
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdEventbridgeArchiveExample"
@@ -118,20 +146,11 @@ echo "    retention + pattern updated in place (CreationTime unchanged)"
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws events describe-archive --archive-name "${ARCHIVE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: archive ${ARCHIVE_NAME} still exists after destroy" >&2
-  exit 1
-fi
-if aws events describe-event-bus --name "${BUS_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: event bus ${BUS_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "archive ${ARCHIVE_NAME} still exists after destroy" aws events describe-archive --archive-name "${ARCHIVE_NAME}" --region "${REGION}"
+assert_gone "event bus ${BUS_NAME} still exists after destroy" aws events describe-event-bus --name "${BUS_NAME}" --region "${REGION}"
 echo "    archive + bus deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — EventBridge Archive deploy/update/destroy, all 3 phases passed"

--- a/tests/integration/eventbridge-archive/verify.sh
+++ b/tests/integration/eventbridge-archive/verify.sh
@@ -26,12 +26,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/eventbridge-input-transformer/verify.sh
+++ b/tests/integration/eventbridge-input-transformer/verify.sh
@@ -22,6 +22,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdEventbridgeInputTransformerExample"
@@ -149,16 +177,10 @@ echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws events describe-rule --name "${RULE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: rule ${RULE_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "rule ${RULE_NAME} still exists after destroy" aws events describe-rule --name "${RULE_NAME}" --region "${REGION}"
 echo "    rule deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — EventBridge target InputTransformer rewrites the payload, UPDATE applied in place, destroy clean, all 3 phases passed"

--- a/tests/integration/eventbridge-input-transformer/verify.sh
+++ b/tests/integration/eventbridge-input-transformer/verify.sh
@@ -29,12 +29,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/eventbridge-pipes/verify.sh
+++ b/tests/integration/eventbridge-pipes/verify.sh
@@ -12,12 +12,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/eventbridge-pipes/verify.sh
+++ b/tests/integration/eventbridge-pipes/verify.sh
@@ -4,6 +4,34 @@
 # clean. Confirmed-clean /hunt-bugs pattern; regression guard.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdEventbridgePipesExample"
@@ -109,12 +137,12 @@ node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --regio
 # Pipe delete is async (DELETING -> gone).
 PGONE=""
 for _ in $(seq 1 24); do
-  aws pipes describe-pipe --name "${PIPE}" --region "${REGION}" >/dev/null 2>&1 || { PGONE=1; break; }
+  if gone_probe aws pipes describe-pipe --name "${PIPE}" --region "${REGION}"; then PGONE=1; break; fi
   sleep 5
 done
 [ -z "${PGONE}" ] && { echo "FAIL: pipe ${PIPE} still exists after destroy" >&2; exit 1; }
 echo "    OK: pipe gone"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && { echo "FAIL: state remains" >&2; exit 1; }
+assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 echo ""
 echo "==> eventbridge-pipes test passed"

--- a/tests/integration/eventbridge-scheduler/verify.sh
+++ b/tests/integration/eventbridge-scheduler/verify.sh
@@ -4,6 +4,34 @@
 # Confirmed-clean /hunt-bugs pattern; regression guard.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdEventbridgeSchedulerExample"
@@ -52,16 +80,16 @@ echo "    OK: schedule reached AWS (ScheduleExpression: ${EXPR})"
 echo "==> Destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-aws scheduler get-schedule --name "${SCHED}" --region "${REGION}" >/dev/null 2>&1 && { echo "FAIL: schedule still exists after destroy" >&2; exit 1; }
+assert_gone "schedule still exists after destroy" aws scheduler get-schedule --name "${SCHED}" --region "${REGION}"
 echo "    OK: schedule gone"
 GONE=""
 for _ in $(seq 1 18); do
-  aws lambda get-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1 || { GONE=1; break; }
+  if gone_probe aws lambda get-function --function-name "${FN}" --region "${REGION}"; then GONE=1; break; fi
   sleep 5
 done
 [ -z "${GONE}" ] && { echo "FAIL: function ${FN} still exists after destroy" >&2; exit 1; }
 echo "    OK: function gone"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && { echo "FAIL: state remains" >&2; exit 1; }
+assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 echo ""
 echo "==> eventbridge-scheduler test passed"

--- a/tests/integration/eventbridge-scheduler/verify.sh
+++ b/tests/integration/eventbridge-scheduler/verify.sh
@@ -12,12 +12,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/eventbridge/verify.sh
+++ b/tests/integration/eventbridge/verify.sh
@@ -11,6 +11,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="EventBridgeStack"
@@ -132,16 +160,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --yes
 
-if aws events describe-event-bus --name "${BUS_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: EventBus '${BUS_NAME}' still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "EventBus '${BUS_NAME}' still exists after destroy" aws events describe-event-bus --name "${BUS_NAME}" --region "${REGION}"
 echo "    OK: EventBus is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/eventbridge/verify.sh
+++ b/tests/integration/eventbridge/verify.sh
@@ -18,12 +18,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/eventsourcemapping-race/verify.sh
+++ b/tests/integration/eventsourcemapping-race/verify.sh
@@ -28,6 +28,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdEsmRaceExample"
@@ -272,24 +300,15 @@ fi
 echo "    OK: no orphan EventSourceMapping remains"
 
 # Queue gone.
-if aws sqs get-queue-url --queue-name "$(basename "${QUEUE_URL}")" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SQS queue ${QUEUE_URL} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "SQS queue ${QUEUE_URL} still exists after destroy" aws sqs get-queue-url --queue-name "$(basename "${QUEUE_URL}")" --region "${REGION}"
 # get-queue-url by name above can lag; the direct URL check is the
 # authoritative one.
-if aws sqs get-queue-attributes --queue-url "${QUEUE_URL}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SQS queue ${QUEUE_URL} still reachable after destroy" >&2
-  exit 1
-fi
+assert_gone "SQS queue ${QUEUE_URL} still reachable after destroy" aws sqs get-queue-attributes --queue-url "${QUEUE_URL}" --region "${REGION}"
 QUEUE_URL=""
 echo "    OK: SQS queue is gone"
 
 # State gone.
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/eventsourcemapping-race/verify.sh
+++ b/tests/integration/eventsourcemapping-race/verify.sh
@@ -35,12 +35,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/export-nested-stack/verify.sh
+++ b/tests/integration/export-nested-stack/verify.sh
@@ -25,6 +25,34 @@
 # failure path so leftover orphans never persist.
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
 
@@ -245,14 +273,8 @@ aws ssm get-parameter --name "${CHILD_PARAM_NAME}" --region "${REGION}" >/dev/nu
 echo "[verify] step 10 ok: both SSM parameters still alive"
 
 echo "[verify] step 11: assert cdkd state files GONE (per-stack leaf-first cleanup)"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${PARENT_STATE_KEY}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: parent cdkd state still present at s3://${STATE_BUCKET}/${PARENT_STATE_KEY}"
-  exit 1
-fi
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${CHILD_STATE_KEY}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: child cdkd state still present at s3://${STATE_BUCKET}/${CHILD_STATE_KEY}"
-  exit 1
-fi
+assert_gone "parent cdkd state still present at s3://${STATE_BUCKET}/${PARENT_STATE_KEY}" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${PARENT_STATE_KEY}" --region "${REGION}"
+assert_gone "child cdkd state still present at s3://${STATE_BUCKET}/${CHILD_STATE_KEY}" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${CHILD_STATE_KEY}" --region "${REGION}"
 echo "[verify] step 11 ok: both cdkd state files cleared"
 
 echo "[verify] step 12: aws cloudformation delete-stack (leaf-first)"
@@ -272,14 +294,8 @@ aws cloudformation wait stack-delete-complete --stack-name "${PARENT_STACK}" --r
 echo "[verify] step 12 ok: CFn child + parent deleted (leaf-first)"
 
 echo "[verify] step 13: assert AWS resources are GONE post-delete"
-if aws ssm get-parameter --name "${PARENT_PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: parent SSM parameter ${PARENT_PARAM_NAME} still exists after CFn delete-stack"
-  exit 1
-fi
-if aws ssm get-parameter --name "${CHILD_PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: child SSM parameter ${CHILD_PARAM_NAME} still exists after CFn delete-stack"
-  exit 1
-fi
+assert_gone "parent SSM parameter ${PARENT_PARAM_NAME} still exists after CFn delete-stack" aws ssm get-parameter --name "${PARENT_PARAM_NAME}" --region "${REGION}"
+assert_gone "child SSM parameter ${CHILD_PARAM_NAME} still exists after CFn delete-stack" aws ssm get-parameter --name "${CHILD_PARAM_NAME}" --region "${REGION}"
 echo "[verify] step 13 ok: both SSM parameters gone"
 
 trap - EXIT INT TERM

--- a/tests/integration/export-nested-stack/verify.sh
+++ b/tests/integration/export-nested-stack/verify.sh
@@ -32,12 +32,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/export/verify.sh
+++ b/tests/integration/export/verify.sh
@@ -22,6 +22,34 @@
 # Auto-resolves AWS account ID + state bucket. Run from anywhere.
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 VARIANT="${VARIANT:-default}"
 
 REGION="${AWS_REGION:-us-east-1}"
@@ -173,10 +201,7 @@ case "${VARIANT}" in
     echo "[verify] step 3b ok: dry-run is permissive + emits the real-run hint"
 
     echo "[verify] step 4: verify CFn stack does NOT exist (dry-run)"
-    if aws cloudformation describe-stacks --stack-name "${CFN_STACK}" --region "${REGION}" >/dev/null 2>&1; then
-      echo "[verify] FAIL: dry-run created a CFn stack — should not happen"
-      exit 1
-    fi
+    assert_gone "dry-run created a CFn stack — should not happen" aws cloudformation describe-stacks --stack-name "${CFN_STACK}" --region "${REGION}"
     echo "[verify] step 4 ok: no CFn stack"
     echo "[verify] step 5: verify cdkd state still exists (dry-run preserves state)"
     if ! aws s3api head-object --bucket "${STATE_BUCKET}" --key "cdkd/${STACK}/${REGION}/state.json" --region "${REGION}" >/dev/null 2>&1; then
@@ -206,15 +231,9 @@ case "${VARIANT}" in
       *) echo "[verify] FAIL: expected UPDATE_COMPLETE / IMPORT_COMPLETE, got ${STATUS}"; exit 1 ;;
     esac
     # Default-name CFn stack must NOT exist (renamed-only assertion).
-    if aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}" >/dev/null 2>&1; then
-      echo "[verify] FAIL: default-name CFn stack '${STACK}' should not exist (--cfn-stack-name redirects)"
-      exit 1
-    fi
+    assert_gone "default-name CFn stack '${STACK}' should not exist (--cfn-stack-name redirects)" aws cloudformation describe-stacks --stack-name "${STACK}" --region "${REGION}"
     echo "[verify] step 4b: cdkd state cleared"
-    if aws s3api head-object --bucket "${STATE_BUCKET}" --key "cdkd/${STACK}/${REGION}/state.json" --region "${REGION}" >/dev/null 2>&1; then
-      echo "[verify] FAIL: cdkd state still present"
-      exit 1
-    fi
+    assert_gone "cdkd state still present" aws s3api head-object --bucket "${STATE_BUCKET}" --key "cdkd/${STACK}/${REGION}/state.json" --region "${REGION}"
     echo "[verify] step 4b ok"
     echo "[verify] step 5: delete-stack ${CFN_STACK}"
     aws cloudformation delete-stack --stack-name "${CFN_STACK}" --region "${REGION}"
@@ -355,10 +374,7 @@ for lid in sorted(deleted):
 
     echo "[verify] step 5: verify cdkd state is GONE"
     STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
-    if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" --region "${REGION}" >/dev/null 2>&1; then
-      echo "[verify] FAIL: cdkd state still present at s3://${STATE_BUCKET}/${STATE_KEY}"
-      exit 1
-    fi
+    assert_gone "cdkd state still present at s3://${STATE_BUCKET}/${STATE_KEY}" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" --region "${REGION}"
     echo "[verify] step 5 ok: cdkd state cleared"
 
     # Issue #319: post-export `cdk diff` must be clean against the

--- a/tests/integration/export/verify.sh
+++ b/tests/integration/export/verify.sh
@@ -29,12 +29,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/fifo-sqs-event-source/verify.sh
+++ b/tests/integration/fifo-sqs-event-source/verify.sh
@@ -27,12 +27,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/fifo-sqs-event-source/verify.sh
+++ b/tests/integration/fifo-sqs-event-source/verify.sh
@@ -20,6 +20,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdFifoSqsEventSourceExample"
@@ -141,10 +169,7 @@ echo "==> Phase 2: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "function ${FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
 LEFT_ESM="$(aws lambda list-event-source-mappings --region "${REGION}" \
   --query "length(EventSourceMappings[?contains(FunctionArn, '${FN_NAME}')])" --output text 2>/dev/null || echo 0)"
 if [ "${LEFT_ESM}" != "0" ]; then
@@ -153,10 +178,7 @@ if [ "${LEFT_ESM}" != "0" ]; then
 fi
 echo "    function + event source mapping deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 sweep_log_groups

--- a/tests/integration/fsx-lustre/verify.sh
+++ b/tests/integration/fsx-lustre/verify.sh
@@ -36,12 +36,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi
@@ -83,7 +87,7 @@ wait_fs_gone() {
       --region "${REGION}" 2>&1)"; then
       # Strict gone-check (#1097 pattern 2): only a not-found error means the
       # file system is gone; on any other failure (throttle) keep waiting.
-      if printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+      if printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
         return 0
       fi
     fi

--- a/tests/integration/fsx-lustre/verify.sh
+++ b/tests/integration/fsx-lustre/verify.sh
@@ -29,6 +29,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdFsxLustreExample"
@@ -48,11 +76,16 @@ tagged_fs_ids() {
 
 wait_fs_gone() {
   local fs_id="$1"
+  local out
   local deadline=$((SECONDS + 1800))
   while [ ${SECONDS} -lt ${deadline} ]; do
-    if ! aws fsx describe-file-systems --file-system-ids "${fs_id}" \
-      --region "${REGION}" >/dev/null 2>&1; then
-      return 0
+    if ! out="$(aws fsx describe-file-systems --file-system-ids "${fs_id}" \
+      --region "${REGION}" 2>&1)"; then
+      # Strict gone-check (#1097 pattern 2): only a not-found error means the
+      # file system is gone; on any other failure (throttle) keep waiting.
+      if printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+        return 0
+      fi
     fi
     sleep 15
   done
@@ -239,10 +272,7 @@ echo "    update reached AWS (compression LZ4, env=changed, dropme removed)"
 echo "==> Phase 3: destroy (FSx deletion takes a few minutes)"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws fsx describe-file-systems --file-system-ids "${FS_ID_P2}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: FSx file system ${FS_ID_P2} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "FSx file system ${FS_ID_P2} still exists after destroy" aws fsx describe-file-systems --file-system-ids "${FS_ID_P2}" --region "${REGION}"
 echo "    file system deleted (by id)"
 
 LEFTOVERS="$(tagged_fs_ids)"
@@ -252,10 +282,7 @@ if [ -n "${LEFTOVERS}" ]; then
 fi
 echo "    no file system with the fixture tag remains"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — AWS::FSx::FileSystem SDK provider: deploy + in-place update (incl. tag removal) + destroy all passed"

--- a/tests/integration/fsx-openzfs/verify.sh
+++ b/tests/integration/fsx-openzfs/verify.sh
@@ -45,12 +45,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi
@@ -92,7 +96,7 @@ wait_fs_gone() {
       --region "${REGION}" 2>&1)"; then
       # Strict gone-check (#1097 pattern 2): only a not-found error means the
       # file system is gone; on any other failure (throttle) keep waiting.
-      if printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+      if printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
         return 0
       fi
     fi

--- a/tests/integration/fsx-openzfs/verify.sh
+++ b/tests/integration/fsx-openzfs/verify.sh
@@ -38,6 +38,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdFsxOpenZfsExample"
@@ -57,11 +85,16 @@ tagged_fs_ids() {
 
 wait_fs_gone() {
   local fs_id="$1"
+  local out
   local deadline=$((SECONDS + 1800))
   while [ ${SECONDS} -lt ${deadline} ]; do
-    if ! aws fsx describe-file-systems --file-system-ids "${fs_id}" \
-      --region "${REGION}" >/dev/null 2>&1; then
-      return 0
+    if ! out="$(aws fsx describe-file-systems --file-system-ids "${fs_id}" \
+      --region "${REGION}" 2>&1)"; then
+      # Strict gone-check (#1097 pattern 2): only a not-found error means the
+      # file system is gone; on any other failure (throttle) keep waiting.
+      if printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+        return 0
+      fi
     fi
     sleep 15
   done
@@ -294,10 +327,7 @@ echo "    observedProperties carries the reverse-mapped OpenZFS block (readCurre
 echo "==> Phase 3: destroy (FSx deletion takes a few minutes)"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws fsx describe-file-systems --file-system-ids "${FS_ID_P2}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: FSx file system ${FS_ID_P2} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "FSx file system ${FS_ID_P2} still exists after destroy" aws fsx describe-file-systems --file-system-ids "${FS_ID_P2}" --region "${REGION}"
 echo "    file system deleted (by id)"
 
 LEFTOVERS="$(tagged_fs_ids)"
@@ -307,10 +337,7 @@ if [ -n "${LEFTOVERS}" ]; then
 fi
 echo "    no file system with the fixture tag remains"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — AWS::FSx::FileSystem OpenZFS variant: deploy + in-place update (incl. tag removal) + clean-drift + destroy all passed"

--- a/tests/integration/fsx-windows/verify.sh
+++ b/tests/integration/fsx-windows/verify.sh
@@ -450,10 +450,14 @@ cleanup() {
     # cleanup no longer blocks on the directory finishing its teardown, so
     # its ENIs may still be pinning these subnets. Say so rather than
     # leaving a silent survivor — a VPC is not chargeable, but it does need
-    # sweeping once the directory is gone.
-    if aws ec2 describe-vpcs --vpc-ids "${vpcid}" --region "${REGION}" >/dev/null 2>&1; then
+    # sweeping once the directory is gone. Strict probe (#1097 pattern 2):
+    # a throttle must not hide the survivor warning, so an undetermined
+    # probe warns too instead of silently passing.
+    if vpc_probe_out=$(aws ec2 describe-vpcs --vpc-ids "${vpcid}" --region "${REGION}" 2>&1); then
       echo "    WARNING: VPC ${vpcid} survived cleanup — most likely the Managed AD's ENIs are still attached while it finishes Deleting" >&2
       echo "    WARNING: not chargeable, but sweep it once 'aws ds describe-directories' is empty" >&2
+    elif ! printf '%s' "${vpc_probe_out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
+      echo "    WARNING: could not verify VPC ${vpcid} teardown: ${vpc_probe_out}" >&2
     fi
   done
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/gc-custom-asset-names/verify.sh
+++ b/tests/integration/gc-custom-asset-names/verify.sh
@@ -45,12 +45,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/gc-custom-asset-names/verify.sh
+++ b/tests/integration/gc-custom-asset-names/verify.sh
@@ -38,6 +38,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdGcCustomAssetNamesExample"
@@ -289,10 +317,7 @@ echo "==> Phase 3b: cdkd gc --yes (real deletion)"
 node "${LOCAL_DIST}" gc --state-bucket "${STATE_BUCKET}" --region "${REGION}" \
   --older-than 0.0002h --yes
 
-if aws s3api head-object --bucket "${ASSET_BUCKET}" --key "${GARBAGE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: seeded garbage object still exists after gc --yes" >&2
-  exit 1
-fi
+assert_gone "seeded garbage object still exists after gc --yes" aws s3api head-object --bucket "${ASSET_BUCKET}" --key "${GARBAGE_KEY}"
 if ! aws s3api head-object --bucket "${ASSET_BUCKET}" --key "${CODE_KEY}" >/dev/null 2>&1; then
   echo "FAIL: gc deleted the deploy-referenced asset s3://${ASSET_BUCKET}/${CODE_KEY}" >&2
   exit 1
@@ -306,14 +331,8 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --yes
 
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Lambda function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "Lambda function ${FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 # Content-addressed asset storage is never deleted on `cdkd destroy` (a
 # rollback or another stack may reference the same hash) — the object must
 # survive until `bootstrap --destroy` empties the bucket.
@@ -327,19 +346,9 @@ echo "==> Phase 4b: cdkd bootstrap --destroy (names read from the marker, no --f
 node "${LOCAL_DIST}" bootstrap --destroy --state-bucket "${STATE_BUCKET}" \
   --region "${REGION}" --yes
 
-if aws s3api head-bucket --bucket "${ASSET_BUCKET}" >/dev/null 2>&1; then
-  echo "FAIL: custom asset bucket ${ASSET_BUCKET} still exists after bootstrap --destroy" >&2
-  exit 1
-fi
-if aws ecr describe-repositories --repository-names "${CONTAINER_REPO}" \
-  --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: custom container repo ${CONTAINER_REPO} still exists after bootstrap --destroy" >&2
-  exit 1
-fi
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${MARKER_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: bootstrap marker ${MARKER_KEY} still exists after bootstrap --destroy" >&2
-  exit 1
-fi
+assert_gone "custom asset bucket ${ASSET_BUCKET} still exists after bootstrap --destroy" aws s3api head-bucket --bucket "${ASSET_BUCKET}"
+assert_gone "custom container repo ${CONTAINER_REPO} still exists after bootstrap --destroy" aws ecr describe-repositories --repository-names "${CONTAINER_REPO}" --region "${REGION}"
+assert_gone "bootstrap marker ${MARKER_KEY} still exists after bootstrap --destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${MARKER_KEY}"
 echo "    OK: custom bucket gone, custom repo gone, marker gone — zero residue"
 
 echo "[verify] PASS — custom-named asset storage bootstrap, publish-to-custom-bucket, gc dry-run/delete precision, and marker-driven teardown all verified"

--- a/tests/integration/getatt-fallback-guard/verify.sh
+++ b/tests/integration/getatt-fallback-guard/verify.sh
@@ -19,12 +19,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/getstackoutput-crossregion/verify.sh
+++ b/tests/integration/getstackoutput-crossregion/verify.sh
@@ -29,6 +29,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 PRODUCER_STACK="CdkdGsoProducer"
@@ -197,14 +225,8 @@ node "${LOCAL_DIST}" destroy "${CONSUMER_STACK}" \
   --region "${CONSUMER_REGION}" \
   --force
 
-if aws ssm get-parameter --name "${CONSUMER_PARAM_NAME}" --region "${CONSUMER_REGION}" >/dev/null 2>&1; then
-  echo "FAIL: consumer parameter still exists in ${CONSUMER_REGION} after destroy" >&2
-  exit 1
-fi
-if aws s3 ls "s3://${STATE_BUCKET}/${CONSUMER_STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: consumer state file still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "consumer parameter still exists in ${CONSUMER_REGION} after destroy" aws ssm get-parameter --name "${CONSUMER_PARAM_NAME}" --region "${CONSUMER_REGION}"
+assert_gone "consumer state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${CONSUMER_STATE_KEY}"
 echo "    OK: consumer is gone (AWS resource in ${CONSUMER_REGION} + state)"
 
 echo "==> Phase 4b: destroy PRODUCER ${PRODUCER_STACK} (${PRODUCER_REGION})"
@@ -213,14 +235,8 @@ node "${LOCAL_DIST}" destroy "${PRODUCER_STACK}" \
   --region "${PRODUCER_REGION}" \
   --force
 
-if aws ssm get-parameter --name "${PRODUCER_PARAM_NAME}" --region "${PRODUCER_REGION}" >/dev/null 2>&1; then
-  echo "FAIL: producer parameter still exists in ${PRODUCER_REGION} after destroy" >&2
-  exit 1
-fi
-if aws s3 ls "s3://${STATE_BUCKET}/${PRODUCER_STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: producer state file still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "producer parameter still exists in ${PRODUCER_REGION} after destroy" aws ssm get-parameter --name "${PRODUCER_PARAM_NAME}" --region "${PRODUCER_REGION}"
+assert_gone "producer state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${PRODUCER_STATE_KEY}"
 echo "    OK: producer is gone (AWS resource in ${PRODUCER_REGION} + state)"
 
 echo ""

--- a/tests/integration/getstackoutput-crossregion/verify.sh
+++ b/tests/integration/getstackoutput-crossregion/verify.sh
@@ -36,12 +36,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/glue-securityconfig-replace/verify.sh
+++ b/tests/integration/glue-securityconfig-replace/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdGlueSecurityConfigReplaceExample"
@@ -125,16 +153,10 @@ echo "    live config S3EncryptionMode=DISABLED — replacement (DELETE + CREATE
 echo "==> Phase 4: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws glue get-security-configuration --name "${SEC_CONFIG}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SecurityConfiguration ${SEC_CONFIG} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "SecurityConfiguration ${SEC_CONFIG} still exists after destroy" aws glue get-security-configuration --name "${SEC_CONFIG}" --region "${REGION}"
 echo "    SecurityConfiguration deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — --replace turns an immutable Glue SecurityConfiguration change into a clean DELETE + CREATE (and is required: the no-flag deploy fails), all 4 phases passed"

--- a/tests/integration/glue-securityconfig-replace/verify.sh
+++ b/tests/integration/glue-securityconfig-replace/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/glue-update-hardening/verify.sh
+++ b/tests/integration/glue-update-hardening/verify.sh
@@ -19,6 +19,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="GlueUpdateHardeningStack"
@@ -203,10 +231,7 @@ for chk in \
 done
 echo "    OK: all Glue resources are gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/glue-update-hardening/verify.sh
+++ b/tests/integration/glue-update-hardening/verify.sh
@@ -26,12 +26,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi
@@ -223,8 +227,11 @@ for chk in \
   "get-crawler --name ${CRAWLER_NAME}" \
   "get-trigger --name ${TRIGGER_NAME}" \
   "get-workflow --name ${WORKFLOW_NAME}"; do
+  # Route through gone_probe (issue #1097 pattern 2): Glue get-* not-found is
+  # EntityNotFoundException, which matches the canonical signature; any other
+  # probe failure (throttle, auth) hard-FAILs instead of reading as "gone".
   # shellcheck disable=SC2086
-  if aws glue ${chk} --region "${REGION}" >/dev/null 2>&1; then
+  if ! gone_probe aws glue ${chk} --region "${REGION}"; then
     echo "FAIL: Glue resource still exists after destroy: ${chk}" >&2
     exit 1
   fi

--- a/tests/integration/iam-oidc-provider/verify.sh
+++ b/tests/integration/iam-oidc-provider/verify.sh
@@ -23,6 +23,34 @@
 #   AWS_REGION   — defaults to us-east-1
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdIamOidcProviderExample"
@@ -129,16 +157,10 @@ echo "    clientId added in place (CreateDate unchanged) — custom resource UPD
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws iam get-open-id-connect-provider --open-id-connect-provider-arn "${PROVIDER_ARN}" >/dev/null 2>&1; then
-  echo "FAIL: OIDC provider still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "OIDC provider still exists after destroy" aws iam get-open-id-connect-provider --open-id-connect-provider-arn "${PROVIDER_ARN}"
 echo "    provider deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — IAM OIDC provider custom resource create/update/delete lifecycle, all 3 phases passed"

--- a/tests/integration/iam-oidc-provider/verify.sh
+++ b/tests/integration/iam-oidc-provider/verify.sh
@@ -31,12 +31,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/iam-propagation-stress/verify.sh
+++ b/tests/integration/iam-propagation-stress/verify.sh
@@ -45,12 +45,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/iam-propagation-stress/verify.sh
+++ b/tests/integration/iam-propagation-stress/verify.sh
@@ -38,6 +38,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdIamPropagationStressExample"
@@ -323,10 +351,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
 
 # Assert each NAMED resource is gone (state-empty alone can miss an orphan
 # carrying no stack name - per feedback_protection_integ_must_instantiate_resource).
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Lambda function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "Lambda function ${FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
 echo "    OK: Lambda function is gone"
 
 # StepFunctions DeleteStateMachine is ASYNC: the state machine enters
@@ -352,28 +377,16 @@ if [ "${SM_GONE}" != "yes" ]; then
 fi
 echo "    OK: state machine is gone"
 
-if aws events describe-rule --name "${RULE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: EventBridge rule ${RULE_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "EventBridge rule ${RULE_NAME} still exists after destroy" aws events describe-rule --name "${RULE_NAME}" --region "${REGION}"
 echo "    OK: EventBridge rule is gone"
 
-if aws sqs get-queue-attributes --queue-url "${QUEUE_URL}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SQS queue ${QUEUE_URL} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "SQS queue ${QUEUE_URL} still exists after destroy" aws sqs get-queue-attributes --queue-url "${QUEUE_URL}" --region "${REGION}"
 echo "    OK: SQS queue is gone"
 
-if aws sns get-topic-attributes --topic-arn "${TOPIC_ARN}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SNS topic ${TOPIC_ARN} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "SNS topic ${TOPIC_ARN} still exists after destroy" aws sns get-topic-attributes --topic-arn "${TOPIC_ARN}" --region "${REGION}"
 echo "    OK: SNS topic is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/iam-role-policies-drift-clean/verify.sh
+++ b/tests/integration/iam-role-policies-drift-clean/verify.sh
@@ -31,6 +31,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdIamRolePoliciesDriftCleanExample"
@@ -130,28 +158,16 @@ echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws lambda get-function-configuration --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "function ${FN_NAME} still exists after destroy" aws lambda get-function-configuration --function-name "${FN_NAME}" --region "${REGION}"
 echo "    function deleted"
 
-if aws iam get-role --role-name "${ROLE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: role ${ROLE_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "role ${ROLE_NAME} still exists after destroy" aws iam get-role --role-name "${ROLE_NAME}" --region "${REGION}"
 echo "    standalone role deleted"
 
-if aws sqs get-queue-url --queue-name "${QUEUE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: queue ${QUEUE_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "queue ${QUEUE_NAME} still exists after destroy" aws sqs get-queue-url --queue-name "${QUEUE_NAME}" --region "${REGION}"
 echo "    queue deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — IAM Role with a sibling Default Policy shows no phantom drift after deploy; all 3 phases passed"

--- a/tests/integration/iam-role-policies-drift-clean/verify.sh
+++ b/tests/integration/iam-role-policies-drift-clean/verify.sh
@@ -38,12 +38,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/iam-role-prefixed-name-update/verify.sh
+++ b/tests/integration/iam-role-prefixed-name-update/verify.sh
@@ -25,6 +25,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdIamRolePrefixedNameUpdateExample"
@@ -121,16 +149,10 @@ echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws iam get-role --role-name "${ROLE_NAME}" >/dev/null 2>&1; then
-  echo "FAIL: role ${ROLE_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "role ${ROLE_NAME} still exists after destroy" aws iam get-role --role-name "${ROLE_NAME}"
 echo "    role deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — in-place UPDATE of an IAM role whose name starts with the stack name is NOT blocked by a spurious prefix-migration replacement prompt"

--- a/tests/integration/iam-role-prefixed-name-update/verify.sh
+++ b/tests/integration/iam-role-prefixed-name-update/verify.sh
@@ -32,12 +32,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/import-nested-stack/verify.sh
+++ b/tests/integration/import-nested-stack/verify.sh
@@ -36,12 +36,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi
@@ -253,10 +257,19 @@ echo "[verify] step 9 ok: child state parent-link=${PARENT_LINK}"
 
 echo "[verify] step 10: assert source CFn stacks are retired (parent + child both gone)"
 if ! gone_probe aws cloudformation describe-stacks --stack-name "${PARENT_STACK}" --region "${REGION}"; then
-  STATUS=$(aws cloudformation describe-stacks --stack-name "${PARENT_STACK}" --region "${REGION}" \
-    --query 'Stacks[0].StackStatus' --output text)
-  if [ "${STATUS}" != "DELETE_COMPLETE" ]; then
-    echo "[verify] FAIL: parent CFn stack still alive with status ${STATUS}"
+  # Still present at the first probe -- but the stack can finish deleting
+  # between the two probes, so capture the follow-up describe instead of
+  # letting a raw not-found errexit-abort the script.
+  if STATUS=$(aws cloudformation describe-stacks --stack-name "${PARENT_STACK}" --region "${REGION}" \
+    --query 'Stacks[0].StackStatus' --output text 2>&1); then
+    if [ "${STATUS}" != "DELETE_COMPLETE" ]; then
+      echo "[verify] FAIL: parent CFn stack still alive with status ${STATUS}"
+      exit 1
+    fi
+  elif ! gone_probe aws cloudformation describe-stacks --stack-name "${PARENT_STACK}" --region "${REGION}"; then
+    # Describe failed but a re-probe says the stack still exists (or the
+    # failure was not a not-found, in which case gone_probe hard-FAILed).
+    echo "[verify] FAIL: parent CFn stack describe failed (${STATUS}) but the stack still exists"
     exit 1
   fi
 fi

--- a/tests/integration/import-nested-stack/verify.sh
+++ b/tests/integration/import-nested-stack/verify.sh
@@ -29,6 +29,34 @@
 # failure path so leftover orphans never persist.
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
 
@@ -224,7 +252,7 @@ fi
 echo "[verify] step 9 ok: child state parent-link=${PARENT_LINK}"
 
 echo "[verify] step 10: assert source CFn stacks are retired (parent + child both gone)"
-if aws cloudformation describe-stacks --stack-name "${PARENT_STACK}" --region "${REGION}" >/dev/null 2>&1; then
+if ! gone_probe aws cloudformation describe-stacks --stack-name "${PARENT_STACK}" --region "${REGION}"; then
   STATUS=$(aws cloudformation describe-stacks --stack-name "${PARENT_STACK}" --region "${REGION}" \
     --query 'Stacks[0].StackStatus' --output text)
   if [ "${STATUS}" != "DELETE_COMPLETE" ]; then
@@ -247,25 +275,13 @@ echo "[verify] step 12: cdkd destroy ${PARENT_STACK} --force"
 echo "[verify] step 12 ok: cdkd destroy exited 0"
 
 echo "[verify] step 13: assert AWS resources are GONE"
-if aws ssm get-parameter --name "${PARENT_PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: parent SSM parameter ${PARENT_PARAM_NAME} still exists after destroy"
-  exit 1
-fi
-if aws ssm get-parameter --name "${CHILD_PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: child SSM parameter ${CHILD_PARAM_NAME} still exists after destroy"
-  exit 1
-fi
+assert_gone "parent SSM parameter ${PARENT_PARAM_NAME} still exists after destroy" aws ssm get-parameter --name "${PARENT_PARAM_NAME}" --region "${REGION}"
+assert_gone "child SSM parameter ${CHILD_PARAM_NAME} still exists after destroy" aws ssm get-parameter --name "${CHILD_PARAM_NAME}" --region "${REGION}"
 echo "[verify] step 13 ok: both SSM parameters gone"
 
 echo "[verify] step 14: assert cdkd state files GONE (both parent and child)"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${PARENT_STATE_KEY}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: parent cdkd state still present at s3://${STATE_BUCKET}/${PARENT_STATE_KEY}"
-  exit 1
-fi
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${CHILD_STATE_KEY}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: child cdkd state still present at s3://${STATE_BUCKET}/${CHILD_STATE_KEY}"
-  exit 1
-fi
+assert_gone "parent cdkd state still present at s3://${STATE_BUCKET}/${PARENT_STATE_KEY}" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${PARENT_STATE_KEY}" --region "${REGION}"
+assert_gone "child cdkd state still present at s3://${STATE_BUCKET}/${CHILD_STATE_KEY}" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${CHILD_STATE_KEY}" --region "${REGION}"
 echo "[verify] step 14 ok: both cdkd state files cleared"
 
 trap - EXIT INT TERM

--- a/tests/integration/import-value-strong-ref/verify.sh
+++ b/tests/integration/import-value-strong-ref/verify.sh
@@ -19,6 +19,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 CDKD="node ../../../dist/cli.js"
@@ -220,14 +248,8 @@ echo ""
 echo "==> Step 5: Final cleanup verification"
 # NB: producer state may transiently exist if --force destroy is racing
 # AWS resource teardown; the verify trap handles the leftover case.
-aws s3 ls "s3://${STATE_BUCKET}/${PRODUCER_STATE_KEY}" >/dev/null 2>&1 && {
-  echo "FAIL: producer state still exists after destroy"
-  exit 1
-} || true
-aws s3 ls "s3://${STATE_BUCKET}/${CONSUMER_STATE_KEY}" >/dev/null 2>&1 && {
-  echo "FAIL: consumer state still exists after destroy"
-  exit 1
-} || true
+assert_gone "producer state still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${PRODUCER_STATE_KEY}"
+assert_gone "consumer state still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${CONSUMER_STATE_KEY}"
 echo "    all state files removed (✓)"
 
 echo ""

--- a/tests/integration/import-value-strong-ref/verify.sh
+++ b/tests/integration/import-value-strong-ref/verify.sh
@@ -26,12 +26,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/importvalue-chain/verify.sh
+++ b/tests/integration/importvalue-chain/verify.sh
@@ -49,12 +49,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/importvalue-chain/verify.sh
+++ b/tests/integration/importvalue-chain/verify.sh
@@ -42,6 +42,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 CDKD="node ../../../dist/cli.js"
@@ -342,36 +370,21 @@ echo ""
 echo "==> Step 4: Ordered teardown C -> B -> A (each succeeds once consumer gone)"
 echo "==> Step 4a: Destroy C (tail consumer) -> clean"
 ${CDKD} destroy ${STACK_C} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET}" --force
-if aws s3 ls "s3://${STATE_BUCKET}/${C_STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: C state still exists after destroy"
-  exit 1
-fi
-if aws ssm get-parameter --name "${C_PARAM_NAME}" --region "${AWS_REGION}" >/dev/null 2>&1; then
-  echo "FAIL: C's SSM Parameter ${C_PARAM_NAME} still exists after destroy (orphan)"
-  exit 1
-fi
+assert_gone "C state still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${C_STATE_KEY}"
+assert_gone "C's SSM Parameter ${C_PARAM_NAME} still exists after destroy (orphan)" aws ssm get-parameter --name "${C_PARAM_NAME}" --region "${AWS_REGION}"
 echo "    C destroyed, state + SSM Parameter gone (✓)"
 
 echo ""
 echo "==> Step 4b: Destroy B (now no consumer) -> clean"
 ${CDKD} destroy ${STACK_B} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET}" --force
-if aws s3 ls "s3://${STATE_BUCKET}/${B_STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: B state still exists after destroy"
-  exit 1
-fi
-if aws ssm get-parameter --name "${B_PARAM_NAME}" --region "${AWS_REGION}" >/dev/null 2>&1; then
-  echo "FAIL: B's SSM Parameter ${B_PARAM_NAME} still exists after destroy (orphan)"
-  exit 1
-fi
+assert_gone "B state still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${B_STATE_KEY}"
+assert_gone "B's SSM Parameter ${B_PARAM_NAME} still exists after destroy (orphan)" aws ssm get-parameter --name "${B_PARAM_NAME}" --region "${AWS_REGION}"
 echo "    B destroyed, state + SSM Parameter gone (✓)"
 
 echo ""
 echo "==> Step 4c: Destroy A (head, now no consumer) -> clean"
 ${CDKD} destroy ${STACK_A} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET}" --force
-if aws s3 ls "s3://${STATE_BUCKET}/${A_STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: A state still exists after destroy"
-  exit 1
-fi
+assert_gone "A state still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${A_STATE_KEY}"
 # Assert the SNS topic that Stack A created is gone (state-empty can miss an
 # orphan that carries no stack name; assert the real resource directly).
 LEFTOVER_TOPIC=$(aws sns list-topics --region "${AWS_REGION}" \

--- a/tests/integration/inplace-attr-propagation/verify.sh
+++ b/tests/integration/inplace-attr-propagation/verify.sh
@@ -27,12 +27,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/inplace-attr-propagation/verify.sh
+++ b/tests/integration/inplace-attr-propagation/verify.sh
@@ -20,6 +20,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdInplaceAttrPropagationExample"
@@ -100,17 +128,11 @@ echo "    Base = ${B2}, Derived = ${D2} (propagation confirmed)"
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws ssm get-parameter --name "${BASE}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: ${BASE} still exists after destroy" >&2; exit 1
-fi
-if aws ssm get-parameter --name "${DERIVED}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: ${DERIVED} still exists after destroy" >&2; exit 1
-fi
+assert_gone "${BASE} still exists after destroy" aws ssm get-parameter --name "${BASE}" --region "${REGION}"
+assert_gone "${DERIVED} still exists after destroy" aws ssm get-parameter --name "${DERIVED}" --region "${REGION}"
 echo "    both parameters deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2; exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — in-place upstream-attribute propagation, all 3 phases passed"

--- a/tests/integration/intrinsics-torture-2/verify.sh
+++ b/tests/integration/intrinsics-torture-2/verify.sh
@@ -27,12 +27,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/intrinsics-torture-2/verify.sh
+++ b/tests/integration/intrinsics-torture-2/verify.sh
@@ -20,6 +20,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 CDKD="node ../../../dist/cli.js"
@@ -204,10 +232,10 @@ ${CDKD} destroy ${STACK} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET
 
 echo ""
 echo "==> Step 3a: Verify cdkd state cleared"
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  fail "cdkd state still exists at ${STATE_KEY} after destroy"
-else
+if gone_probe aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"; then
   pass "cdkd state cleared"
+else
+  fail "cdkd state still exists at ${STATE_KEY} after destroy"
 fi
 
 echo ""
@@ -215,7 +243,7 @@ echo "==> Step 3b: Verify SSM parameters gone"
 STILL_THERE=0
 for n in select-getazs select-split findinmap-default getatt-refattr \
          sub-escape base64-intrinsic nested-if-sub-join cidr-ipv6 cidr-ipv4; do
-  if aws ssm get-parameter --region "${AWS_REGION}" --name "${NAME_PREFIX}/${n}" >/dev/null 2>&1; then
+  if ! gone_probe aws ssm get-parameter --region "${AWS_REGION}" --name "${NAME_PREFIX}/${n}"; then
     fail "SSM parameter ${n} survived destroy (orphan)"
     STILL_THERE=$((STILL_THERE + 1))
   fi

--- a/tests/integration/intrinsics-torture/verify.sh
+++ b/tests/integration/intrinsics-torture/verify.sh
@@ -26,6 +26,34 @@
 # failure; prints an explicit "[verify] PASS" only at the very end.
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
 
@@ -237,14 +265,11 @@ echo "[verify] step 4: cdkd destroy ${STACK} --force"
 ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --force
 
 echo "[verify] step 5: assert clean — state.json gone + all SSM parameters gone (0 orphans)"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: state.json still present after destroy"
-  exit 1
-fi
+assert_gone "state.json still present after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 ORPHANS=0
 for sfx in cidr-select cidr-join findinmap-default findinmap-region first-az \
            base64 split-select-join nested-sub pseudo topic-ref-sub; do
-  if aws ssm get-parameter --name "${PFX}/${sfx}" --region "${REGION}" >/dev/null 2>&1; then
+  if ! gone_probe aws ssm get-parameter --name "${PFX}/${sfx}" --region "${REGION}"; then
     echo "[verify] FAIL: SSM parameter ${PFX}/${sfx} still exists after destroy (orphan)"
     ORPHANS=$((ORPHANS + 1))
   fi

--- a/tests/integration/intrinsics-torture/verify.sh
+++ b/tests/integration/intrinsics-torture/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/kinesis-esm-filter/verify.sh
+++ b/tests/integration/kinesis-esm-filter/verify.sh
@@ -12,12 +12,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/kinesis-esm-filter/verify.sh
+++ b/tests/integration/kinesis-esm-filter/verify.sh
@@ -4,6 +4,34 @@
 # Confirmed-clean /hunt-bugs pattern; regression guard.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdKinesisEsmFilterExample"
@@ -65,7 +93,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --regio
 
 GONE=""
 for _ in $(seq 1 18); do
-  aws lambda get-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1 || { GONE=1; break; }
+  if gone_probe aws lambda get-function --function-name "${FN}" --region "${REGION}"; then GONE=1; break; fi
   sleep 5
 done
 [ -z "${GONE}" ] && { echo "FAIL: function ${FN} still exists after destroy" >&2; exit 1; }
@@ -73,12 +101,12 @@ echo "    OK: function gone"
 # Kinesis DeleteStream is async (DELETING -> gone).
 SGONE=""
 for _ in $(seq 1 18); do
-  aws kinesis describe-stream-summary --stream-name "${STREAM}" --region "${REGION}" >/dev/null 2>&1 || { SGONE=1; break; }
+  if gone_probe aws kinesis describe-stream-summary --stream-name "${STREAM}" --region "${REGION}"; then SGONE=1; break; fi
   sleep 5
 done
 [ -z "${SGONE}" ] && { echo "FAIL: kinesis stream ${STREAM} still exists after destroy" >&2; exit 1; }
 echo "    OK: kinesis stream gone"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && { echo "FAIL: state remains" >&2; exit 1; }
+assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 echo ""
 echo "==> kinesis-esm-filter test passed"

--- a/tests/integration/kinesis-stream-mode-switch/verify.sh
+++ b/tests/integration/kinesis-stream-mode-switch/verify.sh
@@ -22,6 +22,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdKinesisStreamModeSwitchExample"
@@ -139,10 +167,7 @@ if [ -z "${stream_gone}" ]; then
 fi
 echo "    stream deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — Kinesis StreamMode switch (PROVISIONED -> ON_DEMAND) reaches AWS, all 3 phases passed"

--- a/tests/integration/kinesis-stream-mode-switch/verify.sh
+++ b/tests/integration/kinesis-stream-mode-switch/verify.sh
@@ -29,12 +29,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/lambda-alias-provisioned-concurrency/verify.sh
+++ b/tests/integration/lambda-alias-provisioned-concurrency/verify.sh
@@ -12,12 +12,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/lambda-alias-provisioned-concurrency/verify.sh
+++ b/tests/integration/lambda-alias-provisioned-concurrency/verify.sh
@@ -4,6 +4,34 @@
 # clean. Confirmed-clean /hunt-bugs pattern; regression guard.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdLambdaAliasProvisionedConcurrencyExample"
@@ -56,12 +84,12 @@ node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --regio
 
 GONE=""
 for _ in $(seq 1 18); do
-  aws lambda get-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1 || { GONE=1; break; }
+  if gone_probe aws lambda get-function --function-name "${FN}" --region "${REGION}"; then GONE=1; break; fi
   sleep 5
 done
 [ -z "${GONE}" ] && { echo "FAIL: function ${FN} still exists after destroy" >&2; exit 1; }
 echo "    OK: function gone"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && { echo "FAIL: state remains" >&2; exit 1; }
+assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 echo ""
 echo "==> lambda-alias-provisioned-concurrency test passed"

--- a/tests/integration/lambda-arch-switch/verify.sh
+++ b/tests/integration/lambda-arch-switch/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdLambdaArchSwitchExample"
@@ -146,16 +174,10 @@ echo "    architecture switched (reached AWS config AND runtime, not just cdkd s
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws lambda get-function-configuration --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: function ${FN} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "function ${FN} still exists after destroy" aws lambda get-function-configuration --function-name "${FN}" --region "${REGION}"
 echo "    function deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — Lambda architecture switch (x86_64 -> arm64) reaches AWS, all 3 phases passed"

--- a/tests/integration/lambda-arch-switch/verify.sh
+++ b/tests/integration/lambda-arch-switch/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/lambda-destinations/verify.sh
+++ b/tests/integration/lambda-destinations/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdLambdaDestinationsExample"
@@ -192,16 +220,10 @@ echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "function ${FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
 echo "    function (and its EventInvokeConfig) deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 sweep_log_groups

--- a/tests/integration/lambda-destinations/verify.sh
+++ b/tests/integration/lambda-destinations/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/lambda-env-removal/verify.sh
+++ b/tests/integration/lambda-env-removal/verify.sh
@@ -19,6 +19,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdLambdaEnvRemovalExample"
@@ -98,14 +126,10 @@ echo "    TOREMOVE removed, KEEP retained"
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws lambda get-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: function ${FN} still exists after destroy" >&2; exit 1
-fi
+assert_gone "function ${FN} still exists after destroy" aws lambda get-function --function-name "${FN}" --region "${REGION}"
 echo "    function deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2; exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — nested-map-key removal (Lambda env var), all 3 phases passed"

--- a/tests/integration/lambda-env-removal/verify.sh
+++ b/tests/integration/lambda-env-removal/verify.sh
@@ -26,12 +26,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/lambda-event-invoke-config-update/verify.sh
+++ b/tests/integration/lambda-event-invoke-config-update/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdLambdaEventInvokeConfigUpdateExample"
@@ -145,16 +173,10 @@ echo "    Phase 2 UPDATE reached AWS (the change that was undeployable pre-fix)"
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws lambda get-function-configuration --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "function ${FN_NAME} still exists after destroy" aws lambda get-function-configuration --function-name "${FN_NAME}" --region "${REGION}"
 echo "    function deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — Lambda EventInvokeConfig deploy + UPDATE (maxEventAge/retryAttempts change) reach AWS via the SDK provider, all 3 phases passed"

--- a/tests/integration/lambda-event-invoke-config-update/verify.sh
+++ b/tests/integration/lambda-event-invoke-config-update/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/lambda-layer-version-update/verify.sh
+++ b/tests/integration/lambda-layer-version-update/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/lambda-layer-version-update/verify.sh
+++ b/tests/integration/lambda-layer-version-update/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdLambdaLayerVersionUpdateExample"
@@ -127,16 +155,10 @@ echo "    function re-pointed at layer version :2 (replacement propagated)"
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws lambda get-function-configuration --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "function ${FN_NAME} still exists after destroy" aws lambda get-function-configuration --function-name "${FN_NAME}" --region "${REGION}"
 echo "    function deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — Lambda LayerVersion content change auto-replaces (no --replace) and re-points the consuming function, all 3 phases passed"

--- a/tests/integration/lambda-log-retention/verify.sh
+++ b/tests/integration/lambda-log-retention/verify.sh
@@ -19,6 +19,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdLambdaLogRetentionExample"
@@ -120,16 +148,10 @@ echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: function ${FUNCTION_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "function ${FUNCTION_NAME} still exists after destroy" aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}"
 echo "    OK: function is gone"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: cdkd state removed"
 
 # The Custom::LogRetention CR does NOT delete the log group on stack delete

--- a/tests/integration/lambda-log-retention/verify.sh
+++ b/tests/integration/lambda-log-retention/verify.sh
@@ -26,12 +26,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/lambda-reserved-concurrency/verify.sh
+++ b/tests/integration/lambda-reserved-concurrency/verify.sh
@@ -12,12 +12,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/lambda-reserved-concurrency/verify.sh
+++ b/tests/integration/lambda-reserved-concurrency/verify.sh
@@ -4,6 +4,34 @@
 # then destroys clean. Confirmed-clean /hunt-bugs pattern; regression guard.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdLambdaReservedConcurrencyExample"
@@ -53,12 +81,12 @@ node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --regio
 
 GONE=""
 for _ in $(seq 1 18); do
-  aws lambda get-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1 || { GONE=1; break; }
+  if gone_probe aws lambda get-function --function-name "${FN}" --region "${REGION}"; then GONE=1; break; fi
   sleep 5
 done
 [ -z "${GONE}" ] && { echo "FAIL: function ${FN} still exists after destroy" >&2; exit 1; }
 echo "    OK: function gone"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && { echo "FAIL: state remains" >&2; exit 1; }
+assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 echo ""
 echo "==> lambda-reserved-concurrency test passed"

--- a/tests/integration/lambda-snapstart/verify.sh
+++ b/tests/integration/lambda-snapstart/verify.sh
@@ -25,6 +25,34 @@
 #   AWS_REGION   — defaults to us-east-1
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdLambdaSnapstartExample"
@@ -138,10 +166,7 @@ if [ "${ALIAS_V_P2}" != "2" ]; then
   echo "FAIL: expected alias live -> version 2 after update, got '${ALIAS_V_P2}'" >&2
   exit 1
 fi
-if aws lambda get-function-configuration --function-name "${FN}:1" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: old version 1 still exists after update (should be deleted)" >&2
-  exit 1
-fi
+assert_gone "old version 1 still exists after update (should be deleted)" aws lambda get-function-configuration --function-name "${FN}:1" --region "${REGION}"
 BODY_P2="$(invoke_alias)"
 if ! printf '%s' "${BODY_P2}" | grep -q 'hello-v2'; then
   echo "FAIL: alias invoke expected hello-v2 after update, got: ${BODY_P2}" >&2
@@ -153,20 +178,14 @@ echo "    version 2 optimized, alias retargeted, old version deleted, alias serv
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws lambda get-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: function ${FN} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "function ${FN} still exists after destroy" aws lambda get-function --function-name "${FN}" --region "${REGION}"
 echo "    function deleted"
 
 # The invoke auto-created the log group; neither CFn nor cdkd deletes it.
 aws logs delete-log-group --log-group-name "/aws/lambda/${FN}" --region "${REGION}" >/dev/null 2>&1 || true
 echo "    log group swept"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — Lambda SnapStart + Version/Alias rotation deploy/update/destroy, all 3 phases passed"

--- a/tests/integration/lambda-snapstart/verify.sh
+++ b/tests/integration/lambda-snapstart/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/lambda/verify.sh
+++ b/tests/integration/lambda/verify.sh
@@ -20,12 +20,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/lambda/verify.sh
+++ b/tests/integration/lambda/verify.sh
@@ -13,6 +13,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="LambdaStack"
@@ -124,16 +152,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --yes
 
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Lambda function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "Lambda function ${FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
 echo "    OK: Lambda function is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/launchtemplate-asg-inplace/verify.sh
+++ b/tests/integration/launchtemplate-asg-inplace/verify.sh
@@ -24,6 +24,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="LaunchTemplateAsgInplaceStack"
@@ -169,17 +197,10 @@ if [ "${REMAINING}" != "0" ]; then
 fi
 echo "    OK: AutoScalingGroup is gone"
 
-if aws ec2 describe-launch-templates --launch-template-names "${LT_NAME}" \
-  --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: LaunchTemplate ${LT_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "LaunchTemplate ${LT_NAME} still exists after destroy" aws ec2 describe-launch-templates --launch-template-names "${LT_NAME}" --region "${REGION}"
 echo "    OK: LaunchTemplate is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/launchtemplate-asg-inplace/verify.sh
+++ b/tests/integration/launchtemplate-asg-inplace/verify.sh
@@ -31,12 +31,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/local-start-alb-from-state/verify.sh
+++ b/tests/integration/local-start-alb-from-state/verify.sh
@@ -249,14 +249,17 @@ echo "==> Verifying state is empty post-destroy"
 # after teardown and would false-FAIL here. The destroy contract is that
 # `state.json` is gone; the informational events store is swept separately
 # (see /cleanup step 3.5).
-# `aws s3 ls --recursive` returns exit 1 when nothing matches (success but
-# empty). Under `set -o pipefail` that would terminate the script BEFORE the
-# final "test passed" echo; wrap the call in `|| true` so the pipeline
-# reports its own intent (number of matching lines == 0) cleanly.
-STATE_REMAINING=$(
-  (aws s3 ls "s3://${STATE_BUCKET}/cdkd/${STACK_NAME}/" --recursive --region "${REGION}" 2>/dev/null || true) \
-    | grep -c 'state\.json' || true
-)
+# `aws s3 ls --recursive` exits 1 BOTH when nothing matches (empty output)
+# and on a real error like a throttle (non-empty error text); only the
+# empty-output case means "no keys" (#1097 pattern 2 -- an API error must
+# not silently pass this leak check).
+STATE_LISTING="$(aws s3 ls "s3://${STATE_BUCKET}/cdkd/${STACK_NAME}/" --recursive --region "${REGION}" 2>&1)" || {
+  if [ -n "${STATE_LISTING}" ]; then
+    echo "FAIL: could not list s3://${STATE_BUCKET}/cdkd/${STACK_NAME}/ to verify state deletion: ${STATE_LISTING}"
+    exit 1
+  fi
+}
+STATE_REMAINING=$(printf '%s' "${STATE_LISTING}" | grep -c 'state\.json' || true)
 if [[ "${STATE_REMAINING}" -ne 0 ]]; then
   echo "FAIL: cdkd state.json for ${STACK_NAME} still present after destroy"
   exit 1

--- a/tests/integration/loggroup-class-guard/verify.sh
+++ b/tests/integration/loggroup-class-guard/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdLoggroupClassGuardExample"
@@ -172,10 +200,7 @@ if [ "${FOUND}" != "0" ]; then
 fi
 echo "    log group deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — LogGroupClass guard (actionable failure without --replace, recreate with --replace), all 4 phases passed"

--- a/tests/integration/loggroup-class-guard/verify.sh
+++ b/tests/integration/loggroup-class-guard/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/loggroup-kms-associate/verify.sh
+++ b/tests/integration/loggroup-kms-associate/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdLoggroupKmsAssociateExample"
@@ -169,10 +197,7 @@ if [ "${KEY_STATE}" != "PendingDeletion" ] && [ "${KEY_STATE}" != "GONE" ]; then
 fi
 echo "    KMS key state: ${KEY_STATE} (7-day pending window is AWS-mandated, not an orphan)"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — LogGroup KmsKeyId associate + disassociate both reach AWS, all 4 phases passed"

--- a/tests/integration/loggroup-kms-associate/verify.sh
+++ b/tests/integration/loggroup-kms-associate/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/macro-expansion/verify.sh
+++ b/tests/integration/macro-expansion/verify.sh
@@ -35,12 +35,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/macro-expansion/verify.sh
+++ b/tests/integration/macro-expansion/verify.sh
@@ -28,6 +28,34 @@
 # Auto-resolves AWS account ID + state bucket. Run from anywhere.
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
 STACK="CdkdMacroExpansionExample"
@@ -115,17 +143,11 @@ echo "[verify] step 6: cdkd destroy"
 ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --force
 
 echo "[verify] step 7: assert function is gone on AWS"
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" > /dev/null 2>&1; then
-  echo "[verify] FAIL: function ${FN_NAME} still exists post-destroy"
-  exit 1
-fi
+assert_gone "function ${FN_NAME} still exists post-destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
 echo "[verify]   ✓ function deleted"
 
 echo "[verify] step 7b: assert cdkd state is empty for ${STACK}"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" > /dev/null 2>&1; then
-  echo "[verify] FAIL: cdkd state still present at s3://${STATE_BUCKET}/${STATE_KEY}"
-  exit 1
-fi
+assert_gone "cdkd state still present at s3://${STATE_BUCKET}/${STATE_KEY}" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "[verify]   ✓ cdkd state cleared"
 
 echo "[verify] PASS"

--- a/tests/integration/migrate-from-bare-cfn/verify.sh
+++ b/tests/integration/migrate-from-bare-cfn/verify.sh
@@ -30,12 +30,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/migrate-from-bare-cfn/verify.sh
+++ b/tests/integration/migrate-from-bare-cfn/verify.sh
@@ -23,6 +23,34 @@
 # failure path so leftover orphans never persist.
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
 
@@ -175,9 +203,9 @@ done
 echo "[verify] step 6 ok: cdkd state has all 3 resource types"
 
 echo "[verify] step 7: assert source CFn stack is retired"
-if aws cloudformation describe-stacks \
+if ! gone_probe aws cloudformation describe-stacks \
     --stack-name "${SOURCE_STACK}" \
-    --region "${REGION}" >/dev/null 2>&1; then
+    --region "${REGION}"; then
   STATUS="$(aws cloudformation describe-stacks --stack-name "${SOURCE_STACK}" --region "${REGION}" \
     --query 'Stacks[0].StackStatus' --output text)"
   if [ "${STATUS}" != "DELETE_COMPLETE" ]; then
@@ -201,25 +229,13 @@ ${CLI} destroy "${SOURCE_STACK}" \
 echo "[verify] step 9 ok: cdkd destroy exited 0"
 
 echo "[verify] step 10: assert AWS resources are GONE"
-if aws s3api head-bucket --bucket "${BUCKET_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: ${BUCKET_NAME} still exists after destroy"
-  exit 1
-fi
-if aws ssm get-parameter --name "${PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: ${PARAM_NAME} still exists after destroy"
-  exit 1
-fi
-if aws sns get-topic-attributes --topic-arn "${TOPIC_ARN}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: ${TOPIC_NAME} still exists after destroy"
-  exit 1
-fi
+assert_gone "${BUCKET_NAME} still exists after destroy" aws s3api head-bucket --bucket "${BUCKET_NAME}" --region "${REGION}"
+assert_gone "${PARAM_NAME} still exists after destroy" aws ssm get-parameter --name "${PARAM_NAME}" --region "${REGION}"
+assert_gone "${TOPIC_NAME} still exists after destroy" aws sns get-topic-attributes --topic-arn "${TOPIC_ARN}" --region "${REGION}"
 echo "[verify] step 10 ok: bucket / parameter / topic all 404"
 
 echo "[verify] step 11: assert cdkd state is GONE"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: cdkd state still present at s3://${STATE_BUCKET}/${STATE_KEY}"
-  exit 1
-fi
+assert_gone "cdkd state still present at s3://${STATE_BUCKET}/${STATE_KEY}" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" --region "${REGION}"
 echo "[verify] step 11 ok: cdkd state cleared"
 
 trap - EXIT INT TERM

--- a/tests/integration/multi-asset/verify.sh
+++ b/tests/integration/multi-asset/verify.sh
@@ -49,6 +49,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdMultiAssetExample"
@@ -311,10 +339,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
 for pair in "docker:${DOCKER_FN}" "alpha:${ALPHA_FN}" "beta:${BETA_FN}" "gamma:${GAMMA_FN}"; do
   label="${pair%%:*}"
   name="${pair#*:}"
-  if aws lambda get-function --function-name "${name}" --region "${REGION}" >/dev/null 2>&1; then
-    echo "FAIL: ${label} Lambda function ${name} still exists after destroy" >&2
-    exit 1
-  fi
+  assert_gone "${label} Lambda function ${name} still exists after destroy" aws lambda get-function --function-name "${name}" --region "${REGION}"
   echo "    OK: ${label} Lambda function is gone"
 done
 
@@ -330,20 +355,13 @@ if [ -n "${IMAGE_TAG}" ]; then
     aws ecr batch-delete-image --repository-name "${ECR_REPO}" \
       --image-ids "imageTag=${IMAGE_TAG}" --region "${REGION}" >/dev/null 2>&1 || true
   fi
-  if aws ecr describe-images --repository-name "${ECR_REPO}" \
-      --image-ids "imageTag=${IMAGE_TAG}" --region "${REGION}" >/dev/null 2>&1; then
-    echo "FAIL: pushed ECR image (tag ${IMAGE_TAG}) still present after destroy + sweep" >&2
-    exit 1
-  fi
+  assert_gone "pushed ECR image (tag ${IMAGE_TAG}) still present after destroy + sweep" aws ecr describe-images --repository-name "${ECR_REPO}" --image-ids "imageTag=${IMAGE_TAG}" --region "${REGION}"
   echo "    OK: pushed ECR image (tag ${IMAGE_TAG}) is gone (0 ECR orphans)"
   # Clear so the EXIT-trap sweep does not run again.
   IMAGE_TAG=""
 fi
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # NOTE: the bootstrap asset bucket OBJECTS (the uploaded ZIPs) + the shared

--- a/tests/integration/multi-asset/verify.sh
+++ b/tests/integration/multi-asset/verify.sh
@@ -56,12 +56,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/nested-stack-3level/verify.sh
+++ b/tests/integration/nested-stack-3level/verify.sh
@@ -39,12 +39,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/nested-stack-3level/verify.sh
+++ b/tests/integration/nested-stack-3level/verify.sh
@@ -32,6 +32,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 CDKD="node ../../../dist/cli.js"
@@ -262,10 +290,7 @@ ${CDKD} destroy ${STACK} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET
 
 # 6a: no state file for ANY level remains.
 for lvl in "${STACK}" "${CHILD}" "${GRANDCHILD}" "${GREATGRANDCHILD}"; do
-  if aws s3 ls "$(state_key_uri "${lvl}")" >/dev/null 2>&1; then
-    echo "FAIL: state file for '${lvl}' still present after destroy"
-    exit 1
-  fi
+  assert_gone "state file for '${lvl}' still present after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "cdkd/${lvl}/${AWS_REGION}/state.json"
   echo "  OK: state gone: ${lvl}"
 done
 if ${CDKD} state list --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET}" 2>&1 | grep -q "${STACK}"; then
@@ -275,17 +300,11 @@ fi
 
 # 6b: every level's AWS resource is gone.
 for name in "${SSM_PARAM_NAMES[@]}"; do
-  if aws ssm get-parameter --name "${name}" --region "${AWS_REGION}" >/dev/null 2>&1; then
-    echo "FAIL: SSM parameter '${name}' still exists on AWS after destroy (cascade leak)"
-    exit 1
-  fi
+  assert_gone "SSM parameter '${name}' still exists on AWS after destroy (cascade leak)" aws ssm get-parameter --name "${name}" --region "${AWS_REGION}"
   echo "  OK: SSM parameter gone: ${name}"
 done
 for arn in "${SNS_TOPIC_ARNS[@]}"; do
-  if aws sns get-topic-attributes --topic-arn "${arn}" --region "${AWS_REGION}" >/dev/null 2>&1; then
-    echo "FAIL: SNS topic '${arn}' still exists on AWS after destroy (cascade leak)"
-    exit 1
-  fi
+  assert_gone "SNS topic '${arn}' still exists on AWS after destroy (cascade leak)" aws sns get-topic-attributes --topic-arn "${arn}" --region "${AWS_REGION}"
   echo "  OK: SNS topic gone: ${arn}"
 done
 

--- a/tests/integration/nodejs-function/verify.sh
+++ b/tests/integration/nodejs-function/verify.sh
@@ -18,6 +18,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdNodejsFunctionExample"
@@ -107,16 +135,10 @@ echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: function ${FUNCTION_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "function ${FUNCTION_NAME} still exists after destroy" aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}"
 echo "    OK: function is gone"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: cdkd state removed"
 
 sweep_log_groups

--- a/tests/integration/nodejs-function/verify.sh
+++ b/tests/integration/nodejs-function/verify.sh
@@ -25,12 +25,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/opensearch-domain-getatt/verify.sh
+++ b/tests/integration/opensearch-domain-getatt/verify.sh
@@ -13,6 +13,34 @@
 # NOTE: OpenSearch domain create + delete are SLOW (~15-20 min each).
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdOpenSearchDomainExample"
@@ -118,12 +146,8 @@ fi
 echo "    OK: destroy exited 0"
 
 echo "==> Step 4: assert 0 orphans"
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file still exists after destroy" >&2; exit 1
-fi
-if aws ssm get-parameter --name "${ENDPOINT_PARAM}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SSM parameter ${ENDPOINT_PARAM} still exists after destroy" >&2; exit 1
-fi
+assert_gone "state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
+assert_gone "SSM parameter ${ENDPOINT_PARAM} still exists after destroy" aws ssm get-parameter --name "${ENDPOINT_PARAM}" --region "${REGION}"
 DOM_LEFT=$(aws opensearch list-domain-names --region "${REGION}" \
   --query "DomainNames[?contains(DomainName, 'cdkd-opensearch')] | length(@)" \
   --output text 2>/dev/null || echo 0)

--- a/tests/integration/opensearch-domain-getatt/verify.sh
+++ b/tests/integration/opensearch-domain-getatt/verify.sh
@@ -21,12 +21,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/outputs-only-export/verify.sh
+++ b/tests/integration/outputs-only-export/verify.sh
@@ -20,6 +20,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 CDKD="node ../../../dist/cli.js"
@@ -173,10 +201,7 @@ CDKD_TEST_WITH_CONSUMER=true ${CDKD} destroy ${CONSUMER} --region "${AWS_REGION}
 CDKD_TEST_WITH_CONSUMER=true ${CDKD} destroy ${PRODUCER} --region "${AWS_REGION}" --state-bucket "${STATE_BUCKET}" --force
 
 for key in "${PRODUCER_STATE_KEY}" "${CONSUMER_STATE_KEY}"; do
-  aws s3 ls "s3://${STATE_BUCKET}/${key}" >/dev/null 2>&1 && {
-    echo "FAIL: state ${key} still exists after destroy"
-    exit 1
-  } || true
+  assert_gone "state ${key} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${key}"
 done
 pass "all state files removed"
 

--- a/tests/integration/outputs-only-export/verify.sh
+++ b/tests/integration/outputs-only-export/verify.sh
@@ -27,12 +27,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/propagation-races-2/verify.sh
+++ b/tests/integration/propagation-races-2/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdPropagationRaces2Example"
@@ -261,10 +289,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # --- Post-destroy: assert each NAMED resource is gone ------------------
@@ -279,25 +304,16 @@ case "${ST}" in
 esac
 
 # Instance profile gone.
-if aws iam get-instance-profile --instance-profile-name "${INSTANCE_PROFILE_NAME}" >/dev/null 2>&1; then
-  echo "FAIL: instance profile ${INSTANCE_PROFILE_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "instance profile ${INSTANCE_PROFILE_NAME} still exists after destroy" aws iam get-instance-profile --instance-profile-name "${INSTANCE_PROFILE_NAME}"
 echo "    OK: instance profile gone"
 
 # Lambda function gone.
-if aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Lambda ${FUNCTION_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "Lambda ${FUNCTION_NAME} still exists after destroy" aws lambda get-function --function-name "${FUNCTION_NAME}" --region "${REGION}"
 echo "    OK: Lambda function gone"
 
 # Both buckets gone.
 for b in "${NOTIFY_BUCKET}" "${POLICED_BUCKET}"; do
-  if aws s3api head-bucket --bucket "${b}" --region "${REGION}" >/dev/null 2>&1; then
-    echo "FAIL: bucket ${b} still exists after destroy" >&2
-    exit 1
-  fi
+  assert_gone "bucket ${b} still exists after destroy" aws s3api head-bucket --bucket "${b}" --region "${REGION}"
 done
 echo "    OK: both S3 buckets gone"
 

--- a/tests/integration/propagation-races-2/verify.sh
+++ b/tests/integration/propagation-races-2/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/raw-cfn-conditions-params/verify.sh
+++ b/tests/integration/raw-cfn-conditions-params/verify.sh
@@ -27,6 +27,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdRawCfnCondParamsExample"
@@ -109,10 +137,7 @@ if [ "${ENV_VALUE}" != "dev:${QUEUE_NAME}:${STACK}" ]; then
 fi
 echo "    OK: Fn::Sub over parameter + GetAtt resolved (${ENV_VALUE})"
 
-if aws ssm get-parameter --name "${PROD_PARAM}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: condition-false resource ${PROD_PARAM} was created" >&2
-  exit 1
-fi
+assert_gone "condition-false resource ${PROD_PARAM} was created" aws ssm get-parameter --name "${PROD_PARAM}" --region "${REGION}"
 echo "    OK: condition-false resource not created"
 
 if aws s3 cp "s3://${STATE_BUCKET}/${STATE_KEY}" - 2>/dev/null | jq -e '.outputs.ProdParamName' >/dev/null 2>&1; then
@@ -180,18 +205,9 @@ echo "==> Phase 5: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws sqs get-queue-url --queue-name "${QUEUE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: queue ${QUEUE_NAME} still exists after destroy" >&2
-  exit 1
-fi
-if aws ssm get-parameter --name "${ENV_PARAM}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: parameter ${ENV_PARAM} still exists after destroy" >&2
-  exit 1
-fi
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "queue ${QUEUE_NAME} still exists after destroy" aws sqs get-queue-url --queue-name "${QUEUE_NAME}" --region "${REGION}"
+assert_gone "parameter ${ENV_PARAM} still exists after destroy" aws ssm get-parameter --name "${ENV_PARAM}" --region "${REGION}"
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: queue, parameters, and cdkd state removed"
 
 echo "[verify] PASS — raw-CFn Parameters/Conditions diff-deploy parity (#1027) + condition-false output skip (#1028), all 5 phases passed"

--- a/tests/integration/raw-cfn-conditions-params/verify.sh
+++ b/tests/integration/raw-cfn-conditions-params/verify.sh
@@ -34,12 +34,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/rds-aurora/verify.sh
+++ b/tests/integration/rds-aurora/verify.sh
@@ -25,6 +25,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="RdsAuroraStack"
@@ -198,10 +226,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
 # before describe returns *NotFoundFault. cdkd's delete path waits for the
 # terminal NotFound, but the post-delete S3 state cleanup is the verifiable
 # signal here.
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # Spot-check the security cluster is gone or in 'deleting'.

--- a/tests/integration/rds-aurora/verify.sh
+++ b/tests/integration/rds-aurora/verify.sh
@@ -32,12 +32,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/rds-dbinstance-backfill/verify.sh
+++ b/tests/integration/rds-dbinstance-backfill/verify.sh
@@ -41,12 +41,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/rds-dbinstance-backfill/verify.sh
+++ b/tests/integration/rds-dbinstance-backfill/verify.sh
@@ -34,6 +34,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="RdsDbInstanceBackfillStack"
@@ -291,10 +319,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
 # a few minutes before describe returns DBInstanceNotFoundFault. cdkd's
 # delete path waits for the terminal NotFound, but the post-delete S3
 # state cleanup is the verifiable signal here.
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # Spot-check the DBInstance is also gone or in 'deleting'.

--- a/tests/integration/rds-full-stack/verify.sh
+++ b/tests/integration/rds-full-stack/verify.sh
@@ -47,12 +47,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/rds-full-stack/verify.sh
+++ b/tests/integration/rds-full-stack/verify.sh
@@ -40,6 +40,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdRdsFullStackExample"
@@ -255,10 +283,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --force
 
 # State file must be gone after a clean destroy.
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # DBInstance must be gone or in 'deleting'. RDS Delete* is async; cdkd's delete
@@ -275,30 +300,15 @@ else
 fi
 
 # DBSubnetGroup must be gone.
-if aws rds describe-db-subnet-groups \
-  --db-subnet-group-name "${DB_SUBNET_GROUP}" \
-  --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: DBSubnetGroup ${DB_SUBNET_GROUP} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "DBSubnetGroup ${DB_SUBNET_GROUP} still exists after destroy" aws rds describe-db-subnet-groups --db-subnet-group-name "${DB_SUBNET_GROUP}" --region "${REGION}"
 echo "    OK: DBSubnetGroup is gone"
 
 # DBParameterGroup must be gone.
-if aws rds describe-db-parameter-groups \
-  --db-parameter-group-name "${DB_PARAM_GROUP}" \
-  --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: DBParameterGroup ${DB_PARAM_GROUP} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "DBParameterGroup ${DB_PARAM_GROUP} still exists after destroy" aws rds describe-db-parameter-groups --db-parameter-group-name "${DB_PARAM_GROUP}" --region "${REGION}"
 echo "    OK: DBParameterGroup is gone"
 
 # SSM parameter must be gone.
-if aws ssm get-parameter \
-  --name "${SSM_PARAM_NAME}" \
-  --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SSM parameter ${SSM_PARAM_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "SSM parameter ${SSM_PARAM_NAME} still exists after destroy" aws ssm get-parameter --name "${SSM_PARAM_NAME}" --region "${REGION}"
 echo "    OK: SSM parameter is gone"
 
 echo ""

--- a/tests/integration/recreate-mixed-direction/verify.sh
+++ b/tests/integration/recreate-mixed-direction/verify.sh
@@ -22,12 +22,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/recreate-mixed-direction/verify.sh
+++ b/tests/integration/recreate-mixed-direction/verify.sh
@@ -15,6 +15,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 REGION="${AWS_REGION:-us-east-1}"
@@ -171,22 +199,13 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws lambda get-function --function-name "${FWD_FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: FwdProbe Lambda ${FWD_FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "FwdProbe Lambda ${FWD_FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FWD_FN_NAME}" --region "${REGION}"
 echo "    OK: FwdProbe Lambda is gone"
 
-if aws lambda get-function --function-name "${BACK_FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: BackProbe Lambda ${BACK_FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "BackProbe Lambda ${BACK_FN_NAME} still exists after destroy" aws lambda get-function --function-name "${BACK_FN_NAME}" --region "${REGION}"
 echo "    OK: BackProbe Lambda is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 LEFTOVER_ROLES=$(aws iam list-roles \

--- a/tests/integration/recreate-via-cc-api/verify.sh
+++ b/tests/integration/recreate-via-cc-api/verify.sh
@@ -19,6 +19,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 REGION="${AWS_REGION:-us-east-1}"
@@ -232,22 +260,13 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Lambda function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "Lambda function ${FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
 echo "    OK: Lambda function is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
-if aws s3api head-bucket --bucket "${BUCKET_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: S3 probe bucket ${BUCKET_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "S3 probe bucket ${BUCKET_NAME} still exists after destroy" aws s3api head-bucket --bucket "${BUCKET_NAME}" --region "${REGION}"
 echo "    OK: S3 probe bucket is gone"
 
 # Audit follow-up: assert the IAM role was destroyed too — not just

--- a/tests/integration/recreate-via-cc-api/verify.sh
+++ b/tests/integration/recreate-via-cc-api/verify.sh
@@ -26,12 +26,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/recreate-via-sdk-provider/verify.sh
+++ b/tests/integration/recreate-via-sdk-provider/verify.sh
@@ -28,12 +28,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/recreate-via-sdk-provider/verify.sh
+++ b/tests/integration/recreate-via-sdk-provider/verify.sh
@@ -21,6 +21,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 REGION="${AWS_REGION:-us-east-1}"
@@ -146,16 +174,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Lambda function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "Lambda function ${FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
 echo "    OK: Lambda function is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # Audit follow-up: assert the IAM role was destroyed too — not just

--- a/tests/integration/redshift-cluster-getatt/verify.sh
+++ b/tests/integration/redshift-cluster-getatt/verify.sh
@@ -11,6 +11,34 @@
 # BSD/macOS-portable (no grep -P, no date -d). Real rc captured. Explicit PASS.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdRedshiftClusterExample"
@@ -116,12 +144,8 @@ fi
 echo "    OK: destroy exited 0"
 
 echo "==> Step 4: assert 0 orphans"
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file still exists after destroy" >&2; exit 1
-fi
-if aws ssm get-parameter --name "${ADDR_PARAM}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SSM parameter ${ADDR_PARAM} still exists after destroy" >&2; exit 1
-fi
+assert_gone "state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
+assert_gone "SSM parameter ${ADDR_PARAM} still exists after destroy" aws ssm get-parameter --name "${ADDR_PARAM}" --region "${REGION}"
 CL_LEFT=$(aws redshift describe-clusters --region "${REGION}" \
   --query "Clusters[?DBName=='cdkddb' && contains(ClusterIdentifier, 'cdkdredshift')] | length(@)" \
   --output text 2>/dev/null || echo 0)

--- a/tests/integration/redshift-cluster-getatt/verify.sh
+++ b/tests/integration/redshift-cluster-getatt/verify.sh
@@ -19,12 +19,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/replacement-fanout/verify.sh
+++ b/tests/integration/replacement-fanout/verify.sh
@@ -45,12 +45,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/replacement-fanout/verify.sh
+++ b/tests/integration/replacement-fanout/verify.sh
@@ -38,6 +38,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdReplacementFanoutExample"
@@ -209,10 +237,7 @@ if ! aws sns get-topic-attributes --topic-arn "${TOPIC_ARN_B}" --region "${REGIO
   exit 1
 fi
 # ...and the old topic must be GONE (replacement deletes the original).
-if aws sns get-topic-attributes --topic-arn "${TOPIC_ARN_A}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: old base topic '${TOPIC_ARN_A}' still exists after replacement — old physical resource was not cleaned up" >&2
-  exit 1
-fi
+assert_gone "old base topic '${TOPIC_ARN_A}' still exists after replacement — old physical resource was not cleaned up" aws sns get-topic-attributes --topic-arn "${TOPIC_ARN_A}" --region "${REGION}"
 echo "    OK (replacement): base topic ARN CHANGED ${TOPIC_ARN_A} -> ${TOPIC_ARN_B}, old gone, new present"
 
 # --- FAN-OUT assertion: EVERY dependent picks up the NEW ARN ----------
@@ -284,17 +309,11 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # The (replaced) base topic must be gone.
-if aws sns get-topic-attributes --topic-arn "${TOPIC_ARN_B}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: base topic '${TOPIC_ARN_B}' still exists after destroy (orphan)" >&2
-  exit 1
-fi
+assert_gone "base topic '${TOPIC_ARN_B}' still exists after destroy (orphan)" aws sns get-topic-attributes --topic-arn "${TOPIC_ARN_B}" --region "${REGION}"
 echo "    OK: base topic is gone after destroy"
 
 # Every dependent parameter must be NOT-FOUND in AWS after destroy. The
@@ -303,7 +322,7 @@ echo "    OK: base topic is gone after destroy"
 ORPHAN_PARAMS=()
 for i in $(seq 0 $((DEP_COUNT - 1))); do
   pname="${DEP_NAMES[$i]}"
-  if aws ssm get-parameter --name "${pname}" --region "${REGION}" >/dev/null 2>&1; then
+  if ! gone_probe aws ssm get-parameter --name "${pname}" --region "${REGION}"; then
     echo "FAIL: dependent ${i} parameter '${pname}' still exists after destroy (orphan)" >&2
     ORPHAN_PARAMS+=("${i}")
   fi

--- a/tests/integration/replacement-immutable-name/verify.sh
+++ b/tests/integration/replacement-immutable-name/verify.sh
@@ -25,6 +25,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdReplacementImmutableNameExample"
@@ -165,9 +193,7 @@ param_exists "/${STACK}/param-v2" && { echo "FAIL: param-v2 still exists after d
 alarm_exists "${STACK}-alarm-v2"  && { echo "FAIL: alarm-v2 still exists after destroy" >&2; exit 1; }
 echo "    all 6 v2 resources deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2; exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — immutable-Name replacement across 6 types, all 3 phases passed"

--- a/tests/integration/replacement-immutable-name/verify.sh
+++ b/tests/integration/replacement-immutable-name/verify.sh
@@ -32,12 +32,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi
@@ -65,39 +69,65 @@ STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
 LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 # --- existence helpers (async-delete aware where needed) ---------------
+# All strict (issue #1097 pattern 2): rc 0 = exists/live, rc 1 = confirmed
+# gone; any OTHER probe failure (throttle, auth) hard-FAILs the run instead of
+# reading as "gone". ID-based error-on-missing probes go through gone_probe;
+# list/query forms capture the output and fail loudly on a probe error.
 stream_live() {
   # Kinesis DeleteStream is async (StreamStatus=DELETING) — treat that as gone.
   local s
-  s="$(aws kinesis describe-stream-summary --stream-name "$1" --region "${REGION}" \
-    --query 'StreamDescriptionSummary.StreamStatus' --output text 2>/dev/null)" || return 1
+  if ! s="$(aws kinesis describe-stream-summary --stream-name "$1" --region "${REGION}" \
+    --query 'StreamDescriptionSummary.StreamStatus' --output text 2>&1)"; then
+    if printf '%s' "${s}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
+      return 1
+    fi
+    echo "FAIL: stream_live probe undetermined ($1): ${s}" >&2; exit 1
+  fi
   [ -n "${s}" ] && [ "${s}" != "DELETING" ] && [ "${s}" != "None" ]
 }
 secret_active() {
-  local n; n="$(aws secretsmanager list-secrets --region "${REGION}" \
-    --query "SecretList[?Name=='$1'].Name | [0]" --output text 2>/dev/null)"
+  local n
+  if ! n="$(aws secretsmanager list-secrets --region "${REGION}" \
+    --query "SecretList[?Name=='$1'].Name | [0]" --output text 2>&1)"; then
+    echo "FAIL: secret_active probe undetermined ($1): ${n}" >&2; exit 1
+  fi
   [ "${n}" = "$1" ]
 }
 sm_live() {
   # DeleteStateMachine is async (status=DELETING) — treat that as gone. Match by name.
   local arn st
-  arn="$(aws stepfunctions list-state-machines --region "${REGION}" \
-    --query "stateMachines[?name=='$1'].stateMachineArn | [0]" --output text 2>/dev/null)"
+  if ! arn="$(aws stepfunctions list-state-machines --region "${REGION}" \
+    --query "stateMachines[?name=='$1'].stateMachineArn | [0]" --output text 2>&1)"; then
+    echo "FAIL: sm_live list probe undetermined ($1): ${arn}" >&2; exit 1
+  fi
   [ -n "${arn}" ] && [ "${arn}" != "None" ] || return 1
-  st="$(aws stepfunctions describe-state-machine --state-machine-arn "${arn}" --region "${REGION}" \
-    --query 'status' --output text 2>/dev/null)" || return 1
+  if ! st="$(aws stepfunctions describe-state-machine --state-machine-arn "${arn}" --region "${REGION}" \
+    --query 'status' --output text 2>&1)"; then
+    # Deleted between the list and the describe -> gone.
+    if printf '%s' "${st}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
+      return 1
+    fi
+    echo "FAIL: sm_live describe probe undetermined (${arn}): ${st}" >&2; exit 1
+  fi
   [ "${st}" != "DELETING" ]
 }
 rule_exists() {
-  local n; n="$(aws events list-rules --name-prefix "$1" --region "${REGION}" \
-    --query "Rules[?Name=='$1'].Name | [0]" --output text 2>/dev/null)"
+  local n
+  if ! n="$(aws events list-rules --name-prefix "$1" --region "${REGION}" \
+    --query "Rules[?Name=='$1'].Name | [0]" --output text 2>&1)"; then
+    echo "FAIL: rule_exists probe undetermined ($1): ${n}" >&2; exit 1
+  fi
   [ "${n}" = "$1" ]
 }
 param_exists() {
-  aws ssm get-parameter --name "$1" --region "${REGION}" >/dev/null 2>&1
+  ! gone_probe aws ssm get-parameter --name "$1" --region "${REGION}"
 }
 alarm_exists() {
-  local n; n="$(aws cloudwatch describe-alarms --alarm-names "$1" --region "${REGION}" \
-    --query 'MetricAlarms[0].AlarmName' --output text 2>/dev/null)"
+  local n
+  if ! n="$(aws cloudwatch describe-alarms --alarm-names "$1" --region "${REGION}" \
+    --query 'MetricAlarms[0].AlarmName' --output text 2>&1)"; then
+    echo "FAIL: alarm_exists probe undetermined ($1): ${n}" >&2; exit 1
+  fi
   [ "${n}" = "$1" ]
 }
 

--- a/tests/integration/rollback-failure-injection/verify.sh
+++ b/tests/integration/rollback-failure-injection/verify.sh
@@ -31,6 +31,34 @@
 # prints an explicit "[verify] PASS" only at the very end.
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 REGION="${AWS_REGION:-us-east-1}"
 export AWS_REGION="${REGION}"
 
@@ -227,10 +255,7 @@ echo "[verify] step 2 ok: failed deploy exited non-zero (rc=${DEPLOY_RC})"
 echo "[verify] step 3: assert completed siblings were ROLLED BACK (query AWS directly)"
 
 # 3a. SSM Parameter (a fast sibling guaranteed created before the failure).
-if aws ssm get-parameter --name "${SSM_PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: SSM parameter ${SSM_PARAM_NAME} still exists — rollback did NOT delete the completed sibling"
-  exit 1
-fi
+assert_gone "SSM parameter ${SSM_PARAM_NAME} still exists — rollback did NOT delete the completed sibling" aws ssm get-parameter --name "${SSM_PARAM_NAME}" --region "${REGION}"
 echo "[verify]   ok: SSM parameter ${SSM_PARAM_NAME} rolled back (gone)"
 
 # 3b. The failing queue itself must not linger (AWS rejected it; nothing to clean,
@@ -262,7 +287,7 @@ echo "[verify]   ok: no fixture SecurityGroup / leftover hyperplane ENI source l
 # 3e. cdkd state reflects rollback: state.json gone (rollback deleted everything,
 #     so the engine removes the now-empty state) OR present-but-empty resources.
 echo "[verify] step 3e: assert cdkd state reflects rollback (empty / no orphan)"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
+if ! gone_probe aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"; then
   STATE_JSON="$(aws s3 cp "s3://${STATE_BUCKET}/${STATE_KEY}" - 2>/dev/null || true)"
   N_RES="$(echo "${STATE_JSON}" | jq '(.resources // {}) | length' 2>/dev/null || echo "unknown")"
   if [ "${N_RES}" != "0" ]; then
@@ -362,14 +387,8 @@ echo "[verify] step 6: cdkd destroy ${STACK} --force"
 ${CLI} destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --force
 
 echo "[verify] step 7: assert destroy is clean (0 orphans, state gone)"
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: state.json still present after destroy"
-  exit 1
-fi
-if aws ssm get-parameter --name "${SSM_PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "[verify] FAIL: SSM parameter ${SSM_PARAM_NAME} still exists after destroy"
-  exit 1
-fi
+assert_gone "state.json still present after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
+assert_gone "SSM parameter ${SSM_PARAM_NAME} still exists after destroy" aws ssm get-parameter --name "${SSM_PARAM_NAME}" --region "${REGION}"
 POST_VPCS="$(find_fixture_vpcs)"
 if [ -n "${POST_VPCS}" ] && [ "${POST_VPCS}" != "None" ]; then
   echo "[verify] FAIL: VPC(s) still present after destroy: ${POST_VPCS}"

--- a/tests/integration/rollback-failure-injection/verify.sh
+++ b/tests/integration/rollback-failure-injection/verify.sh
@@ -38,12 +38,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/route53/verify.sh
+++ b/tests/integration/route53/verify.sh
@@ -25,6 +25,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="Route53Stack"
@@ -198,16 +226,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
 # record is gone — cdkd's destroy DAG handles that order. Route53 record /
 # zone deletes are effectively synchronous, so a single get-hosted-zone is
 # enough to confirm the zone is gone.
-if aws route53 get-hosted-zone --id "${ZONE_ID}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: hosted zone ${ZONE_ID} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "hosted zone ${ZONE_ID} still exists after destroy" aws route53 get-hosted-zone --id "${ZONE_ID}" --region "${REGION}"
 echo "    OK: hosted zone is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/route53/verify.sh
+++ b/tests/integration/route53/verify.sh
@@ -32,12 +32,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/s3-asset-deploy/verify.sh
+++ b/tests/integration/s3-asset-deploy/verify.sh
@@ -36,12 +36,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/s3-asset-deploy/verify.sh
+++ b/tests/integration/s3-asset-deploy/verify.sh
@@ -29,6 +29,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdS3AssetDeployExample"
@@ -170,16 +198,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --yes
 
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Lambda function ${FN_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "Lambda function ${FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
 echo "    OK: Lambda function is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # NOTE: the bootstrap asset bucket objects (the uploaded ZIPs) are NOT cleaned

--- a/tests/integration/s3-cloudfront/verify.sh
+++ b/tests/integration/s3-cloudfront/verify.sh
@@ -23,12 +23,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/s3-cloudfront/verify.sh
+++ b/tests/integration/s3-cloudfront/verify.sh
@@ -16,6 +16,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="S3CloudFrontStack"
@@ -240,7 +268,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
 # to ~20 minutes for the GetDistribution call to start returning NoSuch.
 DIST_GONE=""
 for _ in $(seq 1 80); do
-  if ! aws cloudfront get-distribution --id "${DIST_ID}" --region "${REGION}" >/dev/null 2>&1; then
+  if gone_probe aws cloudfront get-distribution --id "${DIST_ID}" --region "${REGION}"; then
     DIST_GONE=1
     break
   fi
@@ -252,10 +280,7 @@ if [ -z "${DIST_GONE}" ]; then
 fi
 echo "    OK: CloudFront distribution is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/s3-event-notification/verify.sh
+++ b/tests/integration/s3-event-notification/verify.sh
@@ -21,6 +21,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdS3EventNotificationExample"
@@ -130,10 +158,7 @@ echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws s3api head-bucket --bucket "${BUCKET_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: bucket ${BUCKET_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "bucket ${BUCKET_NAME} still exists after destroy" aws s3api head-bucket --bucket "${BUCKET_NAME}" --region "${REGION}"
 echo "    OK: bucket is gone"
 
 TBL_STATUS="$(aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" \
@@ -144,10 +169,7 @@ if [ "${TBL_STATUS}" != "GONE" ] && [ "${TBL_STATUS}" != "DELETING" ]; then
 fi
 echo "    OK: table deleted (status: ${TBL_STATUS})"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: cdkd state removed"
 
 # Lambda auto-creates /aws/lambda/* log groups on invoke; they are not

--- a/tests/integration/s3-event-notification/verify.sh
+++ b/tests/integration/s3-event-notification/verify.sh
@@ -28,12 +28,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/s3-lifecycle/verify.sh
+++ b/tests/integration/s3-lifecycle/verify.sh
@@ -24,6 +24,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdS3LifecycleExample"
@@ -137,16 +165,10 @@ echo "    bucket identity preserved (CreationDate unchanged) — no replacement"
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws s3api head-bucket --bucket "${BUCKET_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: bucket ${BUCKET_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "bucket ${BUCKET_NAME} still exists after destroy" aws s3api head-bucket --bucket "${BUCKET_NAME}" --region "${REGION}"
 echo "    bucket deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — S3 lifecycle V1/V2 normalization CREATE + in-place UPDATE + destroy, all 3 phases passed"

--- a/tests/integration/s3-lifecycle/verify.sh
+++ b/tests/integration/s3-lifecycle/verify.sh
@@ -31,12 +31,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/s3-object-lock/verify.sh
+++ b/tests/integration/s3-object-lock/verify.sh
@@ -19,6 +19,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdS3ObjectLockExample"
@@ -113,16 +141,10 @@ echo "    bucket identity preserved (CreationDate unchanged) — no replacement"
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws s3api head-bucket --bucket "${BUCKET_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: bucket ${BUCKET_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "bucket ${BUCKET_NAME} still exists after destroy" aws s3api head-bucket --bucket "${BUCKET_NAME}" --region "${REGION}"
 echo "    bucket deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — S3 Object Lock CREATE + in-place retention UPDATE + destroy, all 3 phases passed"

--- a/tests/integration/s3-object-lock/verify.sh
+++ b/tests/integration/s3-object-lock/verify.sh
@@ -26,12 +26,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/s3-replication-and-filter/verify.sh
+++ b/tests/integration/s3-replication-and-filter/verify.sh
@@ -30,12 +30,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/s3-replication-and-filter/verify.sh
+++ b/tests/integration/s3-replication-and-filter/verify.sh
@@ -23,6 +23,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdS3ReplicationAndFilterExample"
@@ -126,17 +154,11 @@ echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
 for b in "${SRC_BUCKET}" "${DST_BUCKET}"; do
-  if aws s3api head-bucket --bucket "${b}" --region "${REGION}" >/dev/null 2>&1; then
-    echo "FAIL: bucket ${b} still exists after destroy" >&2
-    exit 1
-  fi
+  assert_gone "bucket ${b} still exists after destroy" aws s3api head-bucket --bucket "${b}" --region "${REGION}"
 done
 echo "    both buckets deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — S3 replication combined And filter CREATE + in-place UPDATE + destroy, all 3 phases passed"

--- a/tests/integration/s3-tables/verify.sh
+++ b/tests/integration/s3-tables/verify.sh
@@ -18,6 +18,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="S3TablesStack"
@@ -274,19 +302,13 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # Sanity: the TableBucket cascade (Tables → Namespaces → Bucket) should
 # leave nothing behind. The bucket is the most visible orphan to spot-check.
 if [ -n "${TABLE_BUCKET_ARN}" ]; then
-  if aws s3tables get-table-bucket --region "${REGION}" --table-bucket-arn "${TABLE_BUCKET_ARN}" >/dev/null 2>&1; then
-    echo "FAIL: TableBucket ${TABLE_BUCKET_ARN} still exists after destroy" >&2
-    exit 1
-  fi
+  assert_gone "TableBucket ${TABLE_BUCKET_ARN} still exists after destroy" aws s3tables get-table-bucket --region "${REGION}" --table-bucket-arn "${TABLE_BUCKET_ARN}"
   echo "    OK: TableBucket cascade complete"
 fi
 

--- a/tests/integration/s3-tables/verify.sh
+++ b/tests/integration/s3-tables/verify.sh
@@ -25,12 +25,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/s3-vectors/verify.sh
+++ b/tests/integration/s3-vectors/verify.sh
@@ -19,12 +19,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/s3-vectors/verify.sh
+++ b/tests/integration/s3-vectors/verify.sh
@@ -12,6 +12,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="S3VectorsStack"
@@ -145,16 +173,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws s3vectors get-vector-bucket --vector-bucket-name "${BUCKET_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: VectorBucket '${BUCKET_NAME}' still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "VectorBucket '${BUCKET_NAME}' still exists after destroy" aws s3vectors get-vector-bucket --vector-bucket-name "${BUCKET_NAME}" --region "${REGION}"
 echo "    OK: VectorBucket is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/scheduler-custom-group/verify.sh
+++ b/tests/integration/scheduler-custom-group/verify.sh
@@ -14,12 +14,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/scheduler-custom-group/verify.sh
+++ b/tests/integration/scheduler-custom-group/verify.sh
@@ -6,6 +6,34 @@
 # removal (group kept; the schedule MUST actually leave AWS) -> destroy.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdSchedulerCustomGroupExample"
@@ -66,10 +94,7 @@ echo "==> Phase 3: schedule-only removal (group kept) — the #961 silent-orphan
 env -u CDKD_TEST_UPDATE CDKD_TEST_REMOVE_SCHED=true \
   node "${LOCAL_DIST}" deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --yes
 
-if aws scheduler get-schedule --name "${SCHED}" --group-name "${GROUP}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: schedule still LIVE in AWS after removal deploy (silent orphan — the #961 delete bug)" >&2
-  exit 1
-fi
+assert_gone "schedule still LIVE in AWS after removal deploy (silent orphan — the #961 delete bug)" aws scheduler get-schedule --name "${SCHED}" --group-name "${GROUP}" --region "${REGION}"
 echo "    OK: schedule actually left AWS"
 aws scheduler get-schedule-group --name "${GROUP}" --region "${REGION}" >/dev/null 2>&1 \
   || { echo "FAIL: schedule group disappeared during schedule-only removal" >&2; exit 1; }
@@ -78,9 +103,9 @@ echo "    OK: schedule group survived"
 echo "==> Phase 4: Destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-aws scheduler get-schedule-group --name "${GROUP}" --region "${REGION}" >/dev/null 2>&1 && { echo "FAIL: group still exists after destroy" >&2; exit 1; }
+assert_gone "group still exists after destroy" aws scheduler get-schedule-group --name "${GROUP}" --region "${REGION}"
 echo "    OK: group gone"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && { echo "FAIL: state remains" >&2; exit 1; }
+assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 echo ""
 echo "==> scheduler-custom-group test passed"

--- a/tests/integration/schema-v5-to-v6-migration/verify.sh
+++ b/tests/integration/schema-v5-to-v6-migration/verify.sh
@@ -22,6 +22,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdSchemaV5ToV6Migration"
@@ -187,16 +215,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws ssm get-parameter --name "${PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SSM parameter ${PARAM_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "SSM parameter ${PARAM_NAME} still exists after destroy" aws ssm get-parameter --name "${PARAM_NAME}" --region "${REGION}"
 echo "    OK: SSM parameter is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/schema-v5-to-v6-migration/verify.sh
+++ b/tests/integration/schema-v5-to-v6-migration/verify.sh
@@ -29,12 +29,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/schema-v6-to-v7-migration/verify.sh
+++ b/tests/integration/schema-v6-to-v7-migration/verify.sh
@@ -22,6 +22,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdSchemaV6ToV7Migration"
@@ -198,16 +226,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws ssm get-parameter --name "${PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SSM parameter ${PARAM_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "SSM parameter ${PARAM_NAME} still exists after destroy" aws ssm get-parameter --name "${PARAM_NAME}" --region "${REGION}"
 echo "    OK: SSM parameter is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/schema-v6-to-v7-migration/verify.sh
+++ b/tests/integration/schema-v6-to-v7-migration/verify.sh
@@ -29,12 +29,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/schema-v7-to-v8-migration/verify.sh
+++ b/tests/integration/schema-v7-to-v8-migration/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 PRODUCER_STACK="CdkdSchemaV7ToV8MigrationProducer"
@@ -236,14 +264,8 @@ node "${LOCAL_DIST}" destroy "${CONSUMER_STACK}" \
   --region "${REGION}" \
   --force
 
-if aws ssm get-parameter --name "${CONSUMER_PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: consumer parameter still exists after destroy" >&2
-  exit 1
-fi
-if aws s3 ls "s3://${STATE_BUCKET}/${CONSUMER_STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: consumer state file still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "consumer parameter still exists after destroy" aws ssm get-parameter --name "${CONSUMER_PARAM_NAME}" --region "${REGION}"
+assert_gone "consumer state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${CONSUMER_STATE_KEY}"
 echo "    OK: consumer is gone (AWS resource + state)"
 
 echo "==> Phase 4b: destroy Producer with v8 binary"
@@ -252,14 +274,8 @@ node "${LOCAL_DIST}" destroy "${PRODUCER_STACK}" \
   --region "${REGION}" \
   --force
 
-if aws ssm get-parameter --name "${PRODUCER_PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: producer parameter still exists after destroy" >&2
-  exit 1
-fi
-if aws s3 ls "s3://${STATE_BUCKET}/${PRODUCER_STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: producer state file still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "producer parameter still exists after destroy" aws ssm get-parameter --name "${PRODUCER_PARAM_NAME}" --region "${REGION}"
+assert_gone "producer state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${PRODUCER_STATE_KEY}"
 echo "    OK: producer is gone (AWS resource + state)"
 
 echo ""

--- a/tests/integration/schema-v7-to-v8-migration/verify.sh
+++ b/tests/integration/schema-v7-to-v8-migration/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/sdk-ccapi-crossref/verify.sh
+++ b/tests/integration/sdk-ccapi-crossref/verify.sh
@@ -42,12 +42,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/sdk-ccapi-crossref/verify.sh
+++ b/tests/integration/sdk-ccapi-crossref/verify.sh
@@ -35,6 +35,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdSdkCcApiCrossrefExample"
@@ -202,29 +230,19 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --force
 
 # --- Assertion 6: every named resource is gone from AWS ------------------
-if aws kinesis describe-stream-summary --stream-name "${STREAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  fail "Kinesis stream ${STREAM_NAME} still exists after destroy"
-fi
+assert_gone "Kinesis stream ${STREAM_NAME} still exists after destroy" aws kinesis describe-stream-summary --stream-name "${STREAM_NAME}" --region "${REGION}"
 echo "    OK: Kinesis stream is gone"
 
-if aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  fail "Lambda function ${FN_NAME} still exists after destroy"
-fi
+assert_gone "Lambda function ${FN_NAME} still exists after destroy" aws lambda get-function --function-name "${FN_NAME}" --region "${REGION}"
 echo "    OK: Lambda function is gone"
 
-if aws iam get-role --role-name "${ROLE_NAME}" >/dev/null 2>&1; then
-  fail "IAM role ${ROLE_NAME} still exists after destroy"
-fi
+assert_gone "IAM role ${ROLE_NAME} still exists after destroy" aws iam get-role --role-name "${ROLE_NAME}"
 echo "    OK: IAM role is gone"
 
-if aws ssm get-parameter --name "${PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  fail "SSM parameter ${PARAM_NAME} still exists after destroy"
-fi
+assert_gone "SSM parameter ${PARAM_NAME} still exists after destroy" aws ssm get-parameter --name "${PARAM_NAME}" --region "${REGION}"
 echo "    OK: SSM parameter is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  fail "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy"
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/secrets-dynamic-ref/verify.sh
+++ b/tests/integration/secrets-dynamic-ref/verify.sh
@@ -41,6 +41,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdSecretsDynamicRefExample"
@@ -204,10 +232,7 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --yes
 
-if aws lambda get-function-configuration --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: consumer Lambda '${FN_NAME}' still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "consumer Lambda '${FN_NAME}' still exists after destroy" aws lambda get-function-configuration --function-name "${FN_NAME}" --region "${REGION}"
 echo "    OK: consumer Lambda is gone"
 
 # SecretsManager DeleteSecret SCHEDULES deletion with a recovery window
@@ -229,16 +254,10 @@ else
   exit 1
 fi
 
-if aws ssm get-parameter --name "${PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SSM parameter '${PARAM_NAME}' still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "SSM parameter '${PARAM_NAME}' still exists after destroy" aws ssm get-parameter --name "${PARAM_NAME}" --region "${REGION}"
 echo "    OK: SSM parameter is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/secrets-dynamic-ref/verify.sh
+++ b/tests/integration/secrets-dynamic-ref/verify.sh
@@ -48,12 +48,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/secrets-rotation-schedule/verify.sh
+++ b/tests/integration/secrets-rotation-schedule/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/secrets-rotation-schedule/verify.sh
+++ b/tests/integration/secrets-rotation-schedule/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdSecretsRotationScheduleExample"
@@ -124,10 +152,7 @@ if [ "${DELETED_DATE}" = "None" ]; then
 fi
 echo "    secret deleted (state: ${DELETED_DATE})"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 sweep_log_groups

--- a/tests/integration/serverless-api/verify.sh
+++ b/tests/integration/serverless-api/verify.sh
@@ -26,6 +26,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="ServerlessApiStack"
@@ -244,16 +272,10 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws apigatewayv2 get-api --api-id "${API_ID}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: HTTP API ${API_ID} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "HTTP API ${API_ID} still exists after destroy" aws apigatewayv2 get-api --api-id "${API_ID}" --region "${REGION}"
 echo "    OK: HTTP API is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/serverless-api/verify.sh
+++ b/tests/integration/serverless-api/verify.sh
@@ -33,12 +33,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/servicediscovery-namespaces/verify.sh
+++ b/tests/integration/servicediscovery-namespaces/verify.sh
@@ -22,12 +22,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/servicediscovery-namespaces/verify.sh
+++ b/tests/integration/servicediscovery-namespaces/verify.sh
@@ -15,6 +15,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="ServiceDiscoveryNamespacesStack"
@@ -167,16 +195,10 @@ done
 echo "    OK: both namespaces are gone"
 
 # --- Assertion: the hosted zone was deleted with the namespace --------
-if aws route53 get-hosted-zone --id "${HOSTED_ZONE_ID}" >/dev/null 2>&1; then
-  echo "FAIL: Route 53 hosted zone ${HOSTED_ZONE_ID} still exists after destroy (orphan!)" >&2
-  exit 1
-fi
+assert_gone "Route 53 hosted zone ${HOSTED_ZONE_ID} still exists after destroy (orphan!)" aws route53 get-hosted-zone --id "${HOSTED_ZONE_ID}"
 echo "    OK: hosted zone ${HOSTED_ZONE_ID} is gone (no Route 53 orphan)"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/servicediscovery/verify.sh
+++ b/tests/integration/servicediscovery/verify.sh
@@ -14,6 +14,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="ServiceDiscoveryStack"
@@ -128,10 +156,7 @@ if [ -n "${STILL}" ] && [ "${STILL}" != "None" ]; then
 fi
 echo "    OK: Cloud Map service is gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/servicediscovery/verify.sh
+++ b/tests/integration/servicediscovery/verify.sh
@@ -21,12 +21,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/ses-identity/verify.sh
+++ b/tests/integration/ses-identity/verify.sh
@@ -27,12 +27,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/ses-identity/verify.sh
+++ b/tests/integration/ses-identity/verify.sh
@@ -19,6 +19,34 @@
 #   AWS_REGION   — defaults to us-east-1
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdSesIdentityExample"
@@ -111,20 +139,11 @@ echo "    reputation metrics on; Mail-From attached — both in-place updates OK
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws sesv2 get-email-identity --email-identity "${IDENTITY}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: email identity ${IDENTITY} still exists after destroy" >&2
-  exit 1
-fi
-if aws sesv2 get-configuration-set --configuration-set-name "${CONFIG_SET}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: configuration set ${CONFIG_SET} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "email identity ${IDENTITY} still exists after destroy" aws sesv2 get-email-identity --email-identity "${IDENTITY}" --region "${REGION}"
+assert_gone "configuration set ${CONFIG_SET} still exists after destroy" aws sesv2 get-configuration-set --configuration-set-name "${CONFIG_SET}" --region "${REGION}"
 echo "    identity + configuration set deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — SES EmailIdentity + ConfigurationSet deploy/update/destroy, all 3 phases passed"

--- a/tests/integration/sg-circular-dependency/verify.sh
+++ b/tests/integration/sg-circular-dependency/verify.sh
@@ -32,6 +32,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdSgCircularExample"
@@ -267,27 +295,18 @@ if ! node "${LOCAL_DIST}" destroy "${STACK}" \
   exit 1
 fi
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # Both SGs must be gone from AWS.
 for SG in "${SG_A_ID}" "${SG_B_ID}"; do
-  if aws ec2 describe-security-groups --group-ids "${SG}" --region "${REGION}" >/dev/null 2>&1; then
-    echo "FAIL: security group ${SG} still exists after destroy (orphan — destroy ordering likely deleted in the wrong order or skipped it)" >&2
-    exit 1
-  fi
+  assert_gone "security group ${SG} still exists after destroy (orphan — destroy ordering likely deleted in the wrong order or skipped it)" aws ec2 describe-security-groups --group-ids "${SG}" --region "${REGION}"
 done
 echo "    OK: both security groups are gone from AWS"
 
 # VPC must be gone.
 if [ -n "${VPC_ID}" ]; then
-  if aws ec2 describe-vpcs --vpc-ids "${VPC_ID}" --region "${REGION}" >/dev/null 2>&1; then
-    echo "FAIL: VPC ${VPC_ID} still exists after destroy (orphan)" >&2
-    exit 1
-  fi
+  assert_gone "VPC ${VPC_ID} still exists after destroy (orphan)" aws ec2 describe-vpcs --vpc-ids "${VPC_ID}" --region "${REGION}"
   echo "    OK: VPC ${VPC_ID} is gone from AWS"
 fi
 

--- a/tests/integration/sg-circular-dependency/verify.sh
+++ b/tests/integration/sg-circular-dependency/verify.sh
@@ -39,12 +39,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/sns-event-source/verify.sh
+++ b/tests/integration/sns-event-source/verify.sh
@@ -18,6 +18,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdSnsEventSourceExample"
@@ -127,8 +155,12 @@ echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws sns list-topics --region "${REGION}" \
-  --query "Topics[?ends_with(TopicArn, ':${TOPIC_NAME}')].TopicArn | [0]" --output text 2>/dev/null | grep -q "${TOPIC_NAME}"; then
+MATCHED_TOPIC="$(aws sns list-topics --region "${REGION}" \
+  --query "Topics[?ends_with(TopicArn, ':${TOPIC_NAME}')].TopicArn | [0]" --output text)" || {
+  echo "FAIL: could not list SNS topics to verify ${TOPIC_NAME} deletion" >&2
+  exit 1
+}
+if [ "${MATCHED_TOPIC}" != "None" ]; then
   echo "FAIL: topic ${TOPIC_NAME} still exists after destroy" >&2
   exit 1
 fi
@@ -142,10 +174,7 @@ if [ "${TBL_STATUS}" != "GONE" ] && [ "${TBL_STATUS}" != "DELETING" ]; then
 fi
 echo "    OK: table deleted (status: ${TBL_STATUS})"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: cdkd state removed"
 
 sweep_log_groups

--- a/tests/integration/sns-event-source/verify.sh
+++ b/tests/integration/sns-event-source/verify.sh
@@ -25,12 +25,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/sns-inline-subscription/verify.sh
+++ b/tests/integration/sns-inline-subscription/verify.sh
@@ -18,6 +18,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdSnsInlineSubscriptionExample"
@@ -164,9 +192,12 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws sns list-subscriptions-by-topic --topic-arn "${TOPIC_ARN}" --region "${REGION}" >/dev/null 2>&1; then
+if ! gone_probe aws sns list-subscriptions-by-topic --topic-arn "${TOPIC_ARN}" --region "${REGION}"; then
   REMAINING=$(aws sns list-subscriptions-by-topic --topic-arn "${TOPIC_ARN}" \
-    --region "${REGION}" --query 'length(Subscriptions || `[]`)' --output text 2>/dev/null || echo 0)
+    --region "${REGION}" --query 'length(Subscriptions || `[]`)' --output text) || {
+    echo "FAIL: could not count remaining subscriptions on ${TOPIC_ARN}" >&2
+    exit 1
+  }
   if [ "${REMAINING}" != "0" ]; then
     echo "FAIL: topic still has ${REMAINING} subscriptions after destroy" >&2
     exit 1
@@ -174,16 +205,10 @@ if aws sns list-subscriptions-by-topic --topic-arn "${TOPIC_ARN}" --region "${RE
 fi
 echo "    OK: topic + subscriptions are gone"
 
-if aws sqs get-queue-url --queue-name "${QUEUE_A_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: queue A ${QUEUE_A_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "queue A ${QUEUE_A_NAME} still exists after destroy" aws sqs get-queue-url --queue-name "${QUEUE_A_NAME}" --region "${REGION}"
 echo "    OK: queues are gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/sns-inline-subscription/verify.sh
+++ b/tests/integration/sns-inline-subscription/verify.sh
@@ -25,12 +25,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/sns-sqs-event/verify.sh
+++ b/tests/integration/sns-sqs-event/verify.sh
@@ -17,6 +17,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdSnsSqsEventExample"
@@ -173,23 +201,13 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws sqs get-queue-url --queue-name "${DLQ_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: DLQ ${DLQ_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "DLQ ${DLQ_NAME} still exists after destroy" aws sqs get-queue-url --queue-name "${DLQ_NAME}" --region "${REGION}"
 echo "    OK: DLQ is gone"
 
-if aws sns get-subscription-attributes --subscription-arn "${PRIMARY_SUB_ARN}" \
-  --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: primary subscription still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "primary subscription still exists after destroy" aws sns get-subscription-attributes --subscription-arn "${PRIMARY_SUB_ARN}" --region "${REGION}"
 echo "    OK: subscriptions are gone"
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/sns-sqs-event/verify.sh
+++ b/tests/integration/sns-sqs-event/verify.sh
@@ -24,12 +24,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/sns-subscription-filter/verify.sh
+++ b/tests/integration/sns-subscription-filter/verify.sh
@@ -17,6 +17,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdSnsSubscriptionFilterExample"
@@ -123,23 +151,21 @@ echo "==> Phase 2: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-if aws sns list-topics --region "${REGION}" \
-  --query "Topics[?ends_with(TopicArn, ':${TOPIC_NAME}')].TopicArn | [0]" --output text 2>/dev/null | grep -q "${TOPIC_NAME}"; then
+MATCHED_TOPIC="$(aws sns list-topics --region "${REGION}" \
+  --query "Topics[?ends_with(TopicArn, ':${TOPIC_NAME}')].TopicArn | [0]" --output text)" || {
+  echo "FAIL: could not list SNS topics to verify ${TOPIC_NAME} deletion" >&2
+  exit 1
+}
+if [ "${MATCHED_TOPIC}" != "None" ]; then
   echo "FAIL: topic ${TOPIC_NAME} still exists after destroy" >&2
   exit 1
 fi
 echo "    OK: topic is gone"
 
-if aws sqs get-queue-url --queue-name "${QUEUE_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: queue ${QUEUE_NAME} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "queue ${QUEUE_NAME} still exists after destroy" aws sqs get-queue-url --queue-name "${QUEUE_NAME}" --region "${REGION}"
 echo "    OK: queue is gone"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: cdkd state removed"
 
 echo "[verify] PASS — SNS subscription filterPolicy reached AWS intact, clean destroy"

--- a/tests/integration/sns-subscription-filter/verify.sh
+++ b/tests/integration/sns-subscription-filter/verify.sh
@@ -24,12 +24,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/sqs-esm-max-concurrency/verify.sh
+++ b/tests/integration/sqs-esm-max-concurrency/verify.sh
@@ -6,6 +6,34 @@
 # silent drop). Then destroys clean.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdSqsEsmMaxConcurrencyExample"
@@ -102,12 +130,12 @@ node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --regio
 
 GONE=""
 for _ in $(seq 1 18); do
-  aws lambda get-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1 || { GONE=1; break; }
+  if gone_probe aws lambda get-function --function-name "${FN}" --region "${REGION}"; then GONE=1; break; fi
   sleep 5
 done
 [ -z "${GONE}" ] && { echo "FAIL: function ${FN} still exists after destroy" >&2; exit 1; }
 echo "    OK: function gone"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && { echo "FAIL: state remains" >&2; exit 1; }
+assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 echo ""
 echo "==> sqs-esm-max-concurrency test passed"

--- a/tests/integration/sqs-esm-max-concurrency/verify.sh
+++ b/tests/integration/sqs-esm-max-concurrency/verify.sh
@@ -14,12 +14,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/stepfunctions-logging/verify.sh
+++ b/tests/integration/stepfunctions-logging/verify.sh
@@ -37,12 +37,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/stepfunctions-logging/verify.sh
+++ b/tests/integration/stepfunctions-logging/verify.sh
@@ -30,6 +30,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdStepfunctionsLoggingExample"
@@ -193,10 +221,7 @@ if [ -z "${sm_gone}" ]; then
 fi
 echo "    state machine deleted"
 
-if aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file ${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
 
 echo "[verify] PASS — SFN Express + Logging/Tracing deploy (assume-role retry), removal-clear update (#978), destroy: all 3 phases passed"

--- a/tests/integration/stepfunctions-s3-definition/verify.sh
+++ b/tests/integration/stepfunctions-s3-definition/verify.sh
@@ -34,12 +34,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/stepfunctions-s3-definition/verify.sh
+++ b/tests/integration/stepfunctions-s3-definition/verify.sh
@@ -27,6 +27,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="StepFunctionsS3Stack"
@@ -154,10 +182,7 @@ case "${SM_STATUS}" in
     ;;
 esac
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # NOTE: the bootstrap asset bucket object (the uploaded ASL) is NOT cleaned by

--- a/tests/integration/synthetics-canary/verify.sh
+++ b/tests/integration/synthetics-canary/verify.sh
@@ -8,6 +8,34 @@
 # Phases: deploy -> assert canary -> UPDATE (schedule) -> destroy -> orphan sweep.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdSyntheticsCanaryExample"
@@ -82,15 +110,15 @@ echo "    OK: in-place UPDATE reached AWS (Schedule: ${EXPR})"
 echo "==> Destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-aws synthetics get-canary --name "${CANARY}" --region "${REGION}" >/dev/null 2>&1 && { echo "FAIL: canary still exists after destroy" >&2; exit 1; }
+assert_gone "canary still exists after destroy" aws synthetics get-canary --name "${CANARY}" --region "${REGION}"
 echo "    OK: canary gone"
 LEFT=$(aws lambda list-functions --region "${REGION}" \
   --query "Functions[?starts_with(FunctionName,'cwsyn-${CANARY}')].FunctionName" --output text)
 [ -n "${LEFT}" ] && { echo "FAIL: backing lambda remains: ${LEFT}" >&2; exit 1; }
 echo "    OK: no cwsyn-* backing lambda remains"
-aws s3api head-bucket --bucket "${BUCKET}" >/dev/null 2>&1 && { echo "FAIL: artifacts bucket remains" >&2; exit 1; }
+assert_gone "artifacts bucket remains" aws s3api head-bucket --bucket "${BUCKET}"
 echo "    OK: artifacts bucket gone"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && { echo "FAIL: state remains" >&2; exit 1; }
+assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 echo ""
 echo "==> synthetics-canary test passed"

--- a/tests/integration/synthetics-canary/verify.sh
+++ b/tests/integration/synthetics-canary/verify.sh
@@ -16,12 +16,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/throttle-wide-dag/verify.sh
+++ b/tests/integration/throttle-wide-dag/verify.sh
@@ -25,6 +25,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 # This fixture DELIBERATELY induces an SSM Parameter Store rate-limit storm (80
@@ -284,17 +312,13 @@ echo "    OK: destroy exited 0"
 # the throttle-prone `describe-parameters` LIST API — the destroy fires a
 # 70-DeleteParameter burst that rate-limits a List call called moments later.
 for IDX in 0 "${MID_WIDE}" "${LAST_WIDE}"; do
-  if aws ssm get-parameter --region "${REGION}" --name "/${STACK}/wide/${IDX}" \
-    >/dev/null 2>&1; then
-    echo "FAIL: SSM parameter /${STACK}/wide/${IDX} still exists after destroy (orphan)" >&2
-    exit 1
-  fi
+  assert_gone "SSM parameter /${STACK}/wide/${IDX} still exists after destroy (orphan)" aws ssm get-parameter --region "${REGION}" --name "/${STACK}/wide/${IDX}"
 done
 echo "    OK: 0 SSM parameter orphans (spot-checked wide/0, wide/${MID_WIDE}, wide/${LAST_WIDE})"
 
 ROLE_LEFT=0
 for i in $(seq 0 $((ROLE_COUNT - 1))); do
-  if aws iam get-role --role-name "${ROLE_PREFIX}${i}" >/dev/null 2>&1; then
+  if ! gone_probe aws iam get-role --role-name "${ROLE_PREFIX}${i}"; then
     ROLE_LEFT=$((ROLE_LEFT + 1))
   fi
 done
@@ -306,9 +330,9 @@ echo "    OK: 0 IAM role orphans"
 
 TOPIC_LEFT=0
 for i in $(seq 0 $((TOPIC_COUNT - 1))); do
-  if aws sns get-topic-attributes \
+  if ! gone_probe aws sns get-topic-attributes \
     --topic-arn "arn:aws:sns:${REGION}:${ACCOUNT}:${TOPIC_PREFIX}${i}" \
-    --region "${REGION}" >/dev/null 2>&1; then
+    --region "${REGION}"; then
     TOPIC_LEFT=$((TOPIC_LEFT + 1))
   fi
 done
@@ -319,10 +343,7 @@ fi
 echo "    OK: 0 SNS topic orphans"
 
 # --- Assertion: state file gone --------------------------------------------
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 echo ""

--- a/tests/integration/throttle-wide-dag/verify.sh
+++ b/tests/integration/throttle-wide-dag/verify.sh
@@ -32,12 +32,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/update-policy-mutations/verify.sh
+++ b/tests/integration/update-policy-mutations/verify.sh
@@ -36,6 +36,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 CDKD="node ../../../dist/cli.js"
@@ -219,9 +247,7 @@ echo "    phase-b bucket survived destroy (✓) — Retain honored on destroy"
 
 echo ""
 echo "==> Step 5: cdkd state cleared after destroy"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && {
-  fail "cdkd state still exists at ${STATE_KEY} after destroy"
-} || true
+assert_gone "cdkd state still exists at ${STATE_KEY} after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state cleared (✓)"
 
 # =====================================================================

--- a/tests/integration/update-policy-mutations/verify.sh
+++ b/tests/integration/update-policy-mutations/verify.sh
@@ -43,12 +43,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi
@@ -110,15 +114,20 @@ trap '(exit 130); cleanup; exit 130' INT
 trap '(exit 143); cleanup; exit 143' TERM
 
 # --- helpers (BSD-portable) ------------------------------------------
+# All strict (issue #1097 pattern 2), routed through gone_probe: rc 0 =
+# exists, rc 1 = confirmed not-found; any other probe failure (throttle,
+# auth) hard-FAILs the run instead of reading as "gone".
 bucket_exists() {
-  # 0 if the bucket exists AND we can see it, non-zero otherwise.
-  aws s3api head-bucket --bucket "$1" --region "${AWS_REGION}" >/dev/null 2>&1
+  # head-bucket answers 404 for a missing bucket (matches the canonical
+  # signature); 403/AccessDenied on someone ELSE's bucket is undetermined
+  # and hard-FAILs -- these buckets are account-owned, so that is correct.
+  ! gone_probe aws s3api head-bucket --bucket "$1" --region "${AWS_REGION}"
 }
 ssm_exists() {
-  aws ssm get-parameter --region "${AWS_REGION}" --name "$1" >/dev/null 2>&1
+  ! gone_probe aws ssm get-parameter --region "${AWS_REGION}" --name "$1"
 }
 sns_exists() {
-  aws sns get-topic-attributes --region "${AWS_REGION}" --topic-arn "$1" >/dev/null 2>&1
+  ! gone_probe aws sns get-topic-attributes --region "${AWS_REGION}" --topic-arn "$1"
 }
 
 fail() {

--- a/tests/integration/update-replace/verify.sh
+++ b/tests/integration/update-replace/verify.sh
@@ -39,12 +39,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/update-replace/verify.sh
+++ b/tests/integration/update-replace/verify.sh
@@ -32,6 +32,34 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdUpdateReplaceExample"
@@ -279,10 +307,7 @@ if ! aws s3api head-bucket --bucket "${REPLACE_BUCKET_AFTER}" --region "${REGION
   exit 1
 fi
 # ...and the old bucket must be GONE (replacement deletes the original).
-if aws s3api head-bucket --bucket "${REPLACE_BUCKET_BEFORE}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: old ReplaceBucket '${REPLACE_BUCKET_BEFORE}' still exists after replacement — old physical resource was not cleaned up" >&2
-  exit 1
-fi
+assert_gone "old ReplaceBucket '${REPLACE_BUCKET_BEFORE}' still exists after replacement — old physical resource was not cleaned up" aws s3api head-bucket --bucket "${REPLACE_BUCKET_BEFORE}" --region "${REGION}"
 echo "    OK (replacement): ReplaceBucket id CHANGED ${REPLACE_BUCKET_BEFORE} -> ${REPLACE_BUCKET_AFTER}, old gone, new present"
 
 # --- Phase 2: destroy -------------------------------------------------
@@ -292,18 +317,12 @@ node "${LOCAL_DIST}" destroy "${STACK}" \
   --region "${REGION}" \
   --force
 
-if aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1; then
-  echo "FAIL: state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" >&2
-  exit 1
-fi
+assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
 # Both buckets must be gone after destroy.
 for b in "${IN_PLACE_BUCKET}" "${REPLACE_BUCKET_AFTER}"; do
-  if aws s3api head-bucket --bucket "${b}" --region "${REGION}" >/dev/null 2>&1; then
-    echo "FAIL: bucket '${b}' still exists after destroy (orphan)" >&2
-    exit 1
-  fi
+  assert_gone "bucket '${b}' still exists after destroy (orphan)" aws s3api head-bucket --bucket "${b}" --region "${REGION}"
 done
 echo "    OK: both S3 buckets are gone after destroy"
 
@@ -313,25 +332,16 @@ echo "    OK: both S3 buckets are gone after destroy"
 # no-stack-name orphan" class). We use the physical ids captured from state in
 # Phase 1 (they are stable across the in-place update — id unchanged asserts
 # above prove it). Each AWS call exits non-zero once the resource is deleted.
-if aws lambda get-function-configuration --function-name "${FUNCTION_NAME}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: Lambda '${FUNCTION_NAME}' still exists after destroy (orphan)" >&2
-  exit 1
-fi
+assert_gone "Lambda '${FUNCTION_NAME}' still exists after destroy (orphan)" aws lambda get-function-configuration --function-name "${FUNCTION_NAME}" --region "${REGION}"
 echo "    OK: Lambda '${FUNCTION_NAME}' is gone"
 
-if aws iam get-role --role-name "${ROLE_NAME}" >/dev/null 2>&1; then
-  echo "FAIL: IAM role '${ROLE_NAME}' still exists after destroy (orphan)" >&2
-  exit 1
-fi
+assert_gone "IAM role '${ROLE_NAME}' still exists after destroy (orphan)" aws iam get-role --role-name "${ROLE_NAME}"
 echo "    OK: IAM role '${ROLE_NAME}' is gone"
 
 # describe-security-groups exits non-zero (InvalidGroup.NotFound) once the SG
 # is deleted. The SG lives in the account's default VPC, so a lingering SG is
 # a true orphan that no VPC-gone check would surface here.
-if aws ec2 describe-security-groups --group-ids "${SG_ID}" --region "${REGION}" >/dev/null 2>&1; then
-  echo "FAIL: SecurityGroup '${SG_ID}' still exists after destroy (orphan)" >&2
-  exit 1
-fi
+assert_gone "SecurityGroup '${SG_ID}' still exists after destroy (orphan)" aws ec2 describe-security-groups --group-ids "${SG_ID}" --region "${REGION}"
 echo "    OK: SecurityGroup '${SG_ID}' is gone"
 echo "    OK: named Lambda / IAM role / SecurityGroup are all gone after destroy"
 

--- a/tests/integration/wait-condition-handle/verify.sh
+++ b/tests/integration/wait-condition-handle/verify.sh
@@ -16,12 +16,16 @@ set -euo pipefail
 # gone_probe returns 0 when the probe fails with a not-found error (resource
 # confirmed gone), 1 when the probe succeeds (resource still exists), and
 # hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
 gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
   local out
   if out="$("$@" 2>&1)"; then
     return 1
   fi
-  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
     echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
     exit 1
   fi

--- a/tests/integration/wait-condition-handle/verify.sh
+++ b/tests/integration/wait-condition-handle/verify.sh
@@ -8,6 +8,34 @@
 # (sibling SSM param changes; handle physical id must be stable) -> destroy.
 
 set -euo pipefail
+
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
 STACK="CdkdWaitConditionHandleExample"
@@ -97,10 +125,9 @@ echo "    OK: handle physical id stable across update"
 echo "==> Phase 3: Destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --region "${REGION}" --force
 
-aws ssm get-parameter --name "${PARAM}" --region "${REGION}" >/dev/null 2>&1 \
-  && { echo "FAIL: SSM param still exists after destroy" >&2; exit 1; }
+assert_gone "SSM param still exists after destroy" aws ssm get-parameter --name "${PARAM}" --region "${REGION}"
 echo "    OK: SSM param gone"
-aws s3 ls "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 && { echo "FAIL: state remains" >&2; exit 1; }
+assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 echo ""
 echo "==> wait-condition-handle test passed"

--- a/tests/unit/scripts/integ-verify-probe-not-found.test.ts
+++ b/tests/unit/scripts/integ-verify-probe-not-found.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  readFileSync,
+  readdirSync,
+  existsSync,
+  writeFileSync,
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import {
+  classifyVerifyScript,
+  joinContinuationLines,
+  CANONICAL_HELPER_BLOCK,
+  CANONICAL_NOT_FOUND_REGEX,
+} from '../../../scripts/check-integ-probe-not-found.js';
+
+/**
+ * Regression guard for issue #1097 pattern 2 (blind gone-probes in integ
+ * fixtures). See `scripts/check-integ-probe-not-found.ts` for why the correct
+ * form is what it is.
+ */
+
+const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
+
+/**
+ * Fixtures whose verify.sh is owned by an in-flight PR, so the sweep skips
+ * them to avoid a cross-lane collision. Mirrors the pattern-1 test's
+ * mechanism; entries are asserted stale-free below so the exception
+ * self-expires once the owning PR lands.
+ *
+ * Empty today. `fsx-windows` / `fsx-ontap` (PR #1094) do not exist in this
+ * tree yet; `emr-cluster` (PR #1101) already uses a strict output-capturing
+ * idiom that this classifier accepts without an exception.
+ */
+const PENDING_OTHER_PR: Record<string, string> = {};
+
+function readFixtures() {
+  return readdirSync(INTEG_ROOT, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(INTEG_ROOT, e.name, 'verify.sh')))
+    .map((e) => {
+      const content = readFileSync(join(INTEG_ROOT, e.name, 'verify.sh'), 'utf8');
+      return { name: e.name, content, ...classifyVerifyScript(content) };
+    });
+}
+
+describe('classifyVerifyScript (pattern 2)', () => {
+  const FORM_B = `if aws lambda get-function --function-name "x" >/dev/null 2>&1; then
+  echo "FAIL: function still exists after destroy" >&2
+  exit 1
+fi
+`;
+
+  it('flags Form B: blind probe backing a leak assertion', () => {
+    expect(classifyVerifyScript(FORM_B).blindLeakAsserts).toHaveLength(1);
+  });
+
+  it.each([
+    ['stderr-only silencing piped to grep', 'if aws sns list-topics --query "q" 2>/dev/null | grep -q x; then'],
+    ['&> silencing', 'if aws iam get-role --role-name x &>/dev/null; then'],
+    ['reversed redirect order', 'if aws ssm get-parameter --name x 2>&1 >/dev/null; then'],
+    ['elif arm', 'elif aws s3api head-object --bucket b --key k >/dev/null 2>&1; then'],
+    ['aws s3 ls', 'if aws s3 ls "s3://b/k" >/dev/null 2>&1; then'],
+  ])('flags Form B variant: %s', (_label, cond) => {
+    const script = `${cond}\n  echo "FAIL: still exists after destroy" >&2\n  exit 1\nfi\n`;
+    expect(classifyVerifyScript(script).blindLeakAsserts).toHaveLength(1);
+  });
+
+  it('flags a multi-line continuation condition', () => {
+    // The pattern-1 sweep learned that multi-line statements hide from
+    // line-oriented scans; the same applies to probe conditions.
+    const script = `if aws deploy get-deployment-group --application-name "a" \\
+  --deployment-group-name "d" --region "r" >/dev/null 2>&1; then
+  echo "FAIL: deployment group still exists after destroy" >&2
+  exit 1
+fi
+`;
+    expect(classifyVerifyScript(script).blindLeakAsserts).toHaveLength(1);
+    expect(joinContinuationLines(script)[0]!.text).toContain('--deployment-group-name');
+  });
+
+  it('flags Form A: negated blind probe concluding gone', () => {
+    const script = `if ! aws dynamodb describe-table --table-name x >/dev/null 2>&1; then
+  TABLE_GONE=1
+  break
+fi
+`;
+    expect(classifyVerifyScript(script).blindGoneConcludes).toHaveLength(1);
+  });
+
+  it('does not flag Form A that fails loudly (fail-closed existence check)', () => {
+    const script = `if ! aws codecommit get-file --repository-name r --file-path p >/dev/null 2>&1; then
+  echo "FAIL: seed file not found" >&2
+  exit 1
+fi
+`;
+    const c = classifyVerifyScript(script);
+    expect(c.blindGoneConcludes).toEqual([]);
+    expect(c.blindLeakAsserts).toEqual([]);
+  });
+
+  it('does not flag a mutation probe (read-verb restriction)', () => {
+    // `if ! aws fsx delete-backup ...` legitimately treats non-zero as "the
+    // delete failed" -- the naive-grep over-count the issue warns about.
+    const script = `if ! aws fsx delete-backup --backup-id b >/dev/null 2>&1; then
+  echo "delete failed, retrying"
+fi
+`;
+    expect(classifyVerifyScript(script).blindGoneConcludes).toEqual([]);
+  });
+
+  it('does not flag a cleanup guard whose body merely cleans up', () => {
+    const script = `if aws s3api head-object --bucket b --key k >/dev/null 2>&1; then
+  echo "[verify] cleanup: cdkd destroy stack"
+  cli destroy stack --force || true
+fi
+`;
+    expect(classifyVerifyScript(script).blindLeakAsserts).toEqual([]);
+  });
+
+  it('does not flag a pre-flight "already exists" guard', () => {
+    const script = `if aws cloudformation describe-stacks --stack-name s >/dev/null 2>&1; then
+  echo "FAIL: s already exists in CFn -- clean up first"
+  exit 1
+fi
+`;
+    expect(classifyVerifyScript(script).blindLeakAsserts).toEqual([]);
+  });
+
+  it('flags the &&-list Form B: `aws <probe> && { FAIL still exists }`', () => {
+    const single = `aws scheduler get-schedule --name s >/dev/null 2>&1 && { echo "FAIL: schedule still exists after destroy" >&2; exit 1; }\n`;
+    expect(classifyVerifyScript(single).blindLeakAsserts).toHaveLength(1);
+    const multi = `aws s3 ls "s3://b/k" >/dev/null 2>&1 && {
+  echo "FAIL: state remains" >&2
+  exit 1
+} || true
+`;
+    expect(classifyVerifyScript(multi).blindLeakAsserts).toHaveLength(1);
+  });
+
+  it('does not flag the &&-list pre-flight guard', () => {
+    const script = `aws s3 ls "s3://b/k" >/dev/null 2>&1 && {
+  echo "FAIL: state already exists -- clean up first."
+  exit 1
+} || true
+`;
+    expect(classifyVerifyScript(script).blindLeakAsserts).toEqual([]);
+  });
+
+  it('flags the ||-list Form A: `aws <probe> || { GONE=1; break; }`', () => {
+    const script = `aws lambda get-function --function-name f >/dev/null 2>&1 || { GONE=1; break; }\n`;
+    expect(classifyVerifyScript(script).blindGoneConcludes).toHaveLength(1);
+  });
+
+  it('does not flag a bare `|| true` tolerance suffix', () => {
+    const script = `aws s3 ls "s3://b/k" >/dev/null 2>&1 || true\n`;
+    const c = classifyVerifyScript(script);
+    expect(c.blindGoneConcludes).toEqual([]);
+    expect(c.blindLeakAsserts).toEqual([]);
+  });
+
+  it('flags a wait-until-gone while/until loop driven by a blind probe', () => {
+    for (const kw of ['while', 'until']) {
+      const script = `${kw} aws efs describe-file-systems --file-system-id f >/dev/null 2>&1; do
+  sleep 5
+done
+`;
+      expect(classifyVerifyScript(script).blindProbeLoops).toHaveLength(1);
+    }
+  });
+
+  it('does not flag calls routed through the helpers', () => {
+    const script = `${CANONICAL_HELPER_BLOCK}
+assert_gone "function still exists after destroy" aws lambda get-function --function-name x
+if ! gone_probe aws iam get-role --role-name r; then
+  ROLE_LEFT=$((ROLE_LEFT + 1))
+fi
+`;
+    const c = classifyVerifyScript(script);
+    expect(c.blindLeakAsserts).toEqual([]);
+    expect(c.blindGoneConcludes).toEqual([]);
+    expect(c.usesHelpers).toBe(true);
+    expect(c.hasCanonicalHelperBlock).toBe(true);
+    expect(c.nonCanonicalNotFoundGreps).toEqual([]);
+  });
+
+  it('scans past a nested if inside the then-branch', () => {
+    const script = `if aws sns list-subscriptions-by-topic --topic-arn t >/dev/null 2>&1; then
+  if [ "x" != "0" ]; then
+    echo "noise"
+  fi
+  echo "FAIL: topic still exists after destroy" >&2
+  exit 1
+fi
+`;
+    expect(classifyVerifyScript(script).blindLeakAsserts).toHaveLength(1);
+  });
+
+  it('flags a drifted copy of the not-found signature', () => {
+    const script = `if ! printf '%s' "\${out}" | grep -qiE 'not ?found|404'; then
+  exit 1
+fi
+`;
+    expect(classifyVerifyScript(script).nonCanonicalNotFoundGreps).toHaveLength(1);
+  });
+
+  it('accepts the canonical signature outside the helper block (inline poll)', () => {
+    const script = `if printf '%s' "\${out}" | grep -qiE ${CANONICAL_NOT_FOUND_REGEX}; then
+  return 0
+fi
+`;
+    expect(classifyVerifyScript(script).nonCanonicalNotFoundGreps).toEqual([]);
+  });
+});
+
+describe('bash behavior of the canonical helpers', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'cdkd-probe-'));
+  const binDir = join(dir, 'bin');
+  mkdirSync(binDir);
+
+  // PATH-shimmed `aws` whose behavior is chosen via AWS_STUB_MODE.
+  writeFileSync(
+    join(binDir, 'aws'),
+    `#!/usr/bin/env bash
+case "\${AWS_STUB_MODE}" in
+  exists) exit 0 ;;
+  notfound)
+    echo "An error occurred (ResourceNotFoundException) when calling the GetFunction operation: Function not found" >&2
+    exit 254 ;;
+  throttle)
+    echo "An error occurred (ThrottlingException) when calling the GetFunction operation: Rate exceeded" >&2
+    exit 254 ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+
+  const script = join(dir, 'probe.sh');
+  writeFileSync(
+    script,
+    `#!/usr/bin/env bash
+set -euo pipefail
+${CANONICAL_HELPER_BLOCK}
+assert_gone "widget still exists after destroy" aws lambda get-function --function-name w
+echo "LEAK-CHECK-PASSED"
+`,
+    { mode: 0o755 },
+  );
+
+  const run = (mode: string) =>
+    spawnSync('bash', [script], {
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${binDir}:${process.env['PATH']}`, AWS_STUB_MODE: mode },
+    });
+
+  it('probe success -> FAIL: still exists', () => {
+    const r = run('exists');
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('FAIL: widget still exists after destroy');
+    expect(r.stdout).not.toContain('LEAK-CHECK-PASSED');
+  });
+
+  it('not-found error -> the leak check passes', () => {
+    const r = run('notfound');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('LEAK-CHECK-PASSED');
+  });
+
+  it('throttle error -> FAIL: undetermined (never a silent pass)', () => {
+    const r = run('throttle');
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('gone-probe undetermined');
+    expect(r.stderr).toContain('ThrottlingException');
+    expect(r.stdout).not.toContain('LEAK-CHECK-PASSED');
+  });
+
+  it('cleans up the temp scripts', () => {
+    rmSync(dir, { recursive: true, force: true });
+    expect(existsSync(dir)).toBe(false);
+  });
+});
+
+describe('integ fixture verify.sh gone-probes (#1097 pattern 2)', () => {
+  const fixtures = readFixtures();
+  const inScope = fixtures.filter((f) => !(f.name in PENDING_OTHER_PR));
+
+  it('finds the fixture tree', () => {
+    expect(fixtures.length).toBeGreaterThan(100);
+  });
+
+  it('never backs a leak assertion with a blind probe (Form B)', () => {
+    const offenders = inScope
+      .filter((f) => f.blindLeakAsserts.length > 0)
+      .map((f) => `${f.name}: ${f.blindLeakAsserts.map((p) => p.line).join(',')}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('never concludes "gone" from a negated blind probe (Form A)', () => {
+    const offenders = inScope
+      .filter((f) => f.blindGoneConcludes.length > 0)
+      .map((f) => `${f.name}: ${f.blindGoneConcludes.map((p) => p.line).join(',')}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('never drives a wait loop directly off a blind probe', () => {
+    const offenders = inScope
+      .filter((f) => f.blindProbeLoops.length > 0)
+      .map((f) => `${f.name}: ${f.blindProbeLoops.map((p) => p.line).join(',')}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('every fixture that uses the helpers carries the canonical block verbatim', () => {
+    const offenders = inScope
+      .filter((f) => f.usesHelpers && !f.hasCanonicalHelperBlock)
+      .map((f) => f.name);
+    expect(offenders).toEqual([]);
+  });
+
+  it('uses the ONE canonical not-found signature everywhere', () => {
+    const offenders = inScope
+      .filter((f) => f.nonCanonicalNotFoundGreps.length > 0)
+      .map((f) => `${f.name}: ${f.nonCanonicalNotFoundGreps.map((p) => p.line).join(',')}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('the sweep actually landed: a majority of fixtures use the helpers', () => {
+    // Guards against a future refactor silently dropping the helper blocks.
+    expect(inScope.filter((f) => f.usesHelpers).length).toBeGreaterThan(100);
+  });
+
+  it('keeps the in-flight-PR exception list free of already-fixed fixtures', () => {
+    const stale = Object.keys(PENDING_OTHER_PR).filter((name) => {
+      const f = fixtures.find((x) => x.name === name);
+      if (!f) return true; // fixture gone entirely -> entry is stale
+      return (
+        f.blindLeakAsserts.length === 0 &&
+        f.blindGoneConcludes.length === 0 &&
+        f.blindProbeLoops.length === 0
+      );
+    });
+    expect(stale).toEqual([]);
+  });
+});

--- a/tests/unit/scripts/integ-verify-probe-not-found.test.ts
+++ b/tests/unit/scripts/integ-verify-probe-not-found.test.ts
@@ -64,6 +64,9 @@ fi
     ['reversed redirect order', 'if aws ssm get-parameter --name x 2>&1 >/dev/null; then'],
     ['elif arm', 'elif aws s3api head-object --bucket b --key k >/dev/null 2>&1; then'],
     ['aws s3 ls', 'if aws s3 ls "s3://b/k" >/dev/null 2>&1; then'],
+    ['spaced > /dev/null redirection', 'if aws lambda get-function --function-name x > /dev/null 2>&1; then'],
+    ['spaced 2> /dev/null silencing', 'if aws sqs get-queue-url --queue-name x 2> /dev/null | grep -q x; then'],
+    ['spaced reversed redirect order', 'if aws ssm get-parameter --name x 2>&1 > /dev/null; then'],
   ])('flags Form B variant: %s', (_label, cond) => {
     const script = `${cond}\n  echo "FAIL: still exists after destroy" >&2\n  exit 1\nfi\n`;
     expect(classifyVerifyScript(script).blindLeakAsserts).toHaveLength(1);
@@ -162,6 +165,25 @@ fi
     expect(c.blindLeakAsserts).toEqual([]);
   });
 
+  it.each([
+    ['if condition, variable verb', 'if aws glue ${chk} --region r >/dev/null 2>&1; then\n  echo "FAIL: still exists after destroy" >&2\n  exit 1\nfi\n'],
+    ['negated if condition', 'if ! aws glue ${chk} --region r >/dev/null 2>&1; then\n  GONE=1\nfi\n'],
+    ['quoted variable verb', 'if aws glue "$chk" --region r >/dev/null 2>&1; then\n  echo "FAIL: still exists" >&2\n  exit 1\nfi\n'],
+    ['variable service', 'if aws ${svc} describe-thing --id x >/dev/null 2>&1; then\n  echo "noise"\nfi\n'],
+    ['&&-list position', 'aws glue ${chk} --region r >/dev/null 2>&1 && { echo "FAIL: still exists" >&2; exit 1; }\n'],
+    ['||-list position', 'aws glue ${chk} --region r >/dev/null 2>&1 || { GONE=1; break; }\n'],
+  ])('flags a silenced variable-verb probe: %s', (_label, script) => {
+    expect(classifyVerifyScript(script).variableVerbProbes).toHaveLength(1);
+  });
+
+  it.each([
+    ['routed through gone_probe', 'if ! gone_probe aws glue ${chk} --region r; then\n  echo "FAIL: still exists" >&2\n  exit 1\nfi\n'],
+    ['unsilenced strict capture', 'if ! out=$(aws glue ${chk} --region r 2>&1); then\n  echo "probe failed: ${out}" >&2\nfi\n'],
+    ['literal-verb probe (handled by the read-probe categories)', 'if aws glue get-job --job-name x >/dev/null 2>&1; then\n  echo "noise"\nfi\n'],
+  ])('does not flag a variable-verb non-violation: %s', (_label, script) => {
+    expect(classifyVerifyScript(script).variableVerbProbes).toEqual([]);
+  });
+
   it('flags a wait-until-gone while/until loop driven by a blind probe', () => {
     for (const kw of ['while', 'until']) {
       const script = `${kw} aws efs describe-file-systems --file-system-id f >/dev/null 2>&1; do
@@ -233,6 +255,12 @@ case "\${AWS_STUB_MODE}" in
   throttle)
     echo "An error occurred (ThrottlingException) when calling the GetFunction operation: Rate exceeded" >&2
     exit 254 ;;
+  http404)
+    echo "An error occurred (404) when calling the HeadObject operation: Not Found" >&2
+    exit 254 ;;
+  arn404)
+    echo "An error occurred (AccessDenied) when calling the GetFunction operation: User arn:aws:iam::123404567890:role/x is not authorized" >&2
+    exit 254 ;;
 esac
 `,
     { mode: 0o755 },
@@ -277,6 +305,45 @@ echo "LEAK-CHECK-PASSED"
     expect(r.stdout).not.toContain('LEAK-CHECK-PASSED');
   });
 
+  it('"An error occurred (404)" -> the leak check passes (anchored 404)', () => {
+    const r = run('http404');
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('LEAK-CHECK-PASSED');
+  });
+
+  it('a bare 404 embedded in an ARN does NOT match -> FAIL: undetermined', () => {
+    // Before the \\(404 anchor, "123404567890" in an AccessDenied ARN would
+    // satisfy the alternation and silently pass the leak check.
+    const r = run('arn404');
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('gone-probe undetermined');
+    expect(r.stdout).not.toContain('LEAK-CHECK-PASSED');
+  });
+
+  it('a forgotten assert_gone description hard-FAILs instead of silently passing', () => {
+    // `assert_gone aws ...` (desc omitted) makes gone_probe exec
+    // `lambda get-function ...` -> "command not found" would match
+    // `not ?found` without the first-arg guard.
+    const noDescScript = join(dir, 'no-desc.sh');
+    writeFileSync(
+      noDescScript,
+      `#!/usr/bin/env bash
+set -euo pipefail
+${CANONICAL_HELPER_BLOCK}
+assert_gone aws lambda get-function --function-name w
+echo "LEAK-CHECK-PASSED"
+`,
+      { mode: 0o755 },
+    );
+    const r = spawnSync('bash', [noDescScript], {
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${binDir}:${process.env['PATH']}`, AWS_STUB_MODE: 'notfound' },
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain('gone_probe: probe must start with aws (got: lambda)');
+    expect(r.stdout).not.toContain('LEAK-CHECK-PASSED');
+  });
+
   it('cleans up the temp scripts', () => {
     rmSync(dir, { recursive: true, force: true });
     expect(existsSync(dir)).toBe(false);
@@ -309,6 +376,13 @@ describe('integ fixture verify.sh gone-probes (#1097 pattern 2)', () => {
     const offenders = inScope
       .filter((f) => f.blindProbeLoops.length > 0)
       .map((f) => `${f.name}: ${f.blindProbeLoops.map((p) => p.line).join(',')}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('never probes with a silenced variable verb in condition position', () => {
+    const offenders = inScope
+      .filter((f) => f.variableVerbProbes.length > 0)
+      .map((f) => `${f.name}: ${f.variableVerbProbes.map((p) => p.line).join(',')}`);
     expect(offenders).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

Pattern 2 of issue #1097 (the issue stays open for the remaining CLI-flag lint follow-up and two lint-coverage residuals noted below).

A destroy/leak assertion built on a silenced AWS CLI read probe cannot distinguish not-found from any other failure, so an API throttle silently passes the leak check and a run can report PASS while leaking billable resources. The issue's survey counted 119 affected fixtures across two spellings; this sweep also caught the `&&`/`||` list-operator spellings the survey missed.

- Every affected `verify.sh` now carries one canonical helper block (byte-identical across 149 files; source of truth exported from the lint): `gone_probe` returns 0 only on a confirmed not-found error signature (`'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'`, case-insensitive), returns 1 when the probe succeeds (resource still exists), and hard-FAILs the run on any other probe failure (undetermined). It also rejects a missing description argument (bash's "command not found" would otherwise match the signature and silently PASS). `assert_gone` wraps it for the simple leak-assert case, preserving each fixture's original FAIL message.
- 292 form-B rewrites, 29 list-operator-form rewrites, 7 wait-gone polls, ~15 branching/counter/status sites, plus strict-capture rewrites where the helper does not fit (piped `list-topics | grep`, prefix `s3 ls --recursive` captures, FSx cleanup wait loops, and AWS Backup, which masks not-found as AccessDeniedException so its vault gone-assert is a strict `list-backup-vaults` capture).
- `aws s3 ls <key>` probes converted to `aws s3api head-object`: `s3 ls` exits 1 with EMPTY output for "no keys", indistinguishable from a silenced error.
- Regression lint `scripts/check-integ-probe-not-found.ts` + `tests/unit/scripts/integ-verify-probe-not-found.test.ts` enforce the convention tree-wide (mirroring the #1102 pattern-1 lint), including spaced `> /dev/null` redirections, silenced variable-verb probes, drifted signature copies, and bash-level behavioral tests against a stubbed `aws` (success / not-found / throttle / missing-desc / 404-embedded-in-ARN). The lint caught 2 sites the mechanical sweep missed, plus `fsx-windows` when PR #1094 merged mid-flight.
- Convention documented in `docs/testing.md` / `.claude/rules/testing.md`; helper threaded into the `/new-integ` scaffold.
- Deliberately untouched: mutation probes, fail-closed existence checks, pre-flight "already exists" guards, best-effort cleanup guards; `emr-cluster` (already strict via #1101).

Trade-offs (deliberate, fail-closed): wait-gone polls now hard-FAIL on a mid-poll throttle instead of breaking early; an undetermined probe is never read as "gone".

## Review (3-axis) outcome

No blockers survived. Addressed in-PR: the AWS Backup AccessDenied-on-missing false-FAIL (live-verified by the test reviewer), the `REMAINING_PLANS` throttle-reads-as-zero capture, the `assert_gone` missing-desc foot-gun, the unanchored `404` alternation, six files with function-wrapped / variable-verb probes the lint could not see (all routed through the helpers), the `import-nested-stack` deleted-between-probes race, and classifier coverage for spaced redirections + variable-verb probes. Left as follow-ups on #1097: generic function-wrapper dataflow detection in the lint, and the `$(aws ... 2>/dev/null || echo 0)` capture-form fallback class (~9 sites, mostly live-phase checks).

## Test plan

- `bash -n` on all verify.sh clean; full unit suite 7331 green (incl. 49 lint tests and the existing pattern-1 tests); typecheck / lint / format clean.
- Live sample runs this session, both PASS with 0 orphans: `eventbridge-scheduler` (exercises `assert_gone`, a `gone_probe` poll loop, and an `s3 ls`-to-`head-object` conversion) and `local-invoke` (Docker clean; refreshes the `integ-local` gate for the `local-start-alb-from-state` strict-listing change).
