### PR TITLE
test(integ): harden eventbridge-input-transformer P2 propagation race + record 0720b sweep runs

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -56,7 +56,7 @@ custom-resource-getatt-data	2026-06-21T18:25:10Z	PASS	61	verify.sh	first run (ne
 custom-resource-provider	2026-06-27T16:56:19Z	PASS	293	standard	CR framework (onEvent/isComplete/waiter SFN); destroy 17 del 0 err
 data-analytics	2026-06-21T11:00:28Z	PASS	43	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 data-pipeline	2026-06-21T04:36:15Z	PASS	42	standard	deploy 7 / destroy 7, 0 err
-deep-getatt-chains	2026-06-20T19:32:52Z	PASS		verify.sh	first run; deep GetAtt chain SDK+CC-API resolved; 6 deleted 0 errors; clean
+deep-getatt-chains	2026-07-20T08:10:49Z	PASS	66	verify.sh	rc ok, orph clean
 deletion-ordering-complex	2026-07-02T18:23:15Z	PASS	194	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 deletion-policy-retain	2026-06-21T11:00:28Z	PASS	24	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 deployment-events	2026-07-02T18:23:15Z	PASS	39	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
@@ -70,8 +70,8 @@ drift-revert-arrays	2026-07-19T17:35:30Z	PASS	114	verify.sh	PR #1100 post-rebase
 drift-revert-vpc	2026-07-19T19:20:48Z	PASS	242	verify.sh	rc ok, 21 deleted, orph clean
 dynamodb-autoscaling	2026-06-27T16:08:39Z	PASS	68	verify.sh	CC-API ScalableTarget/Policy create + maxCap 10->20 in-place UPDATE; 0 errors 0 orphans
 dynamodb-globaltable	2026-06-20T17:59:38Z	PASS		verify.sh	BillingMode/autoscaling UPDATE + clean destroy (#887 regression); 1 deleted 0 errors
-dynamodb-gsi-update	2026-06-20T18:10:27Z	PASS		verify.sh	#887 add-GSI in-place UPDATE (no replacement); 3 phases pass, clean destroy
-dynamodb-ondemand	2026-06-20T18:12:58Z	PASS		verify.sh	BillingMode/ProvisionedThroughput in-place UPDATE (#887 regression); 3 deleted 0 errors
+dynamodb-gsi-update	2026-07-20T08:09:23Z	PASS	579	verify.sh	rc ok, orph clean
+dynamodb-ondemand	2026-07-20T07:59:21Z	PASS	93	verify.sh	rc ok, orph clean
 dynamodb-sse	2026-07-20T07:04:47Z	PASS	150	verify.sh	capture-form sweep sample (#1120): strict captures + gone_probe branch live-verified; 0 orphans
 dynamodb-stream-filter	2026-06-21T06:31:35Z	PASS	58	verify.sh	FilterCriteria/bisect/responseTypes; 0 orph
 dynamodb-streams	2026-07-03T10:26:01Z	PASS	86	verify.sh	OnDemand/Warm wait follow-up; destroy clean
@@ -93,7 +93,7 @@ event-driven	2026-06-21T11:00:28Z	PASS	35	standard	sweep-4..8 staleness re-run (
 eventbridge	2026-07-02T06:09:46Z	PASS	210	verify.sh	new Phase 1.5 custom-bus rule-drop update (issue 955 fix), destroy 10/0 err
 eventbridge-api-destination	2026-06-21T18:24:53Z	PASS	90	verify.sh	ConnectionArn+ApiDest Arn enrichment verified, destroy clean 0 orphans
 eventbridge-archive	2026-07-16T15:54:15Z	PASS	53	verify.sh	new fixture, 3 phases clean, orph clean
-eventbridge-input-transformer	2026-06-21T07:34:45Z	PASS	53	verify.sh	InputTransformer rewrites payload; UPDATE version reached AWS; destroy clean
+eventbridge-input-transformer	2026-07-20T08:18:46Z	PASS	63	verify.sh	hardened P2 propagation race; passes
 eventbridge-pipes	2026-07-02T16:12:06Z	PASS	182	verify.sh	new phases (issue 960 follow-up): named-replacement collision refused + --replace delete-first OK
 eventbridge-scheduler	2026-07-20T03:07:51Z	PASS	150	verify.sh	pattern-2 sweep sample: assert_gone/gone_probe/head-object idioms live-verified; 0 orphans
 eventsourcemapping-race	2026-06-21T18:33:45Z	PASS	88	verify.sh	first run (never-run); fresh-source/role ESM create + message processing + no-orphan-ESM destroy
@@ -228,7 +228,7 @@ servicediscovery	2026-07-19T19:00:29Z	PASS	111	verify.sh	rc ok, 3 deleted, orph 
 servicediscovery-namespaces	2026-07-17T12:12:19Z	PASS	114	verify.sh	re-run post review fixes (import kind filter, PrivateDns tag sync, resolver HostedZoneId); clean, 0 orphans
 ses-identity	2026-07-16T15:54:15Z	PASS	182	verify.sh	new fixture, 3 phases clean, orph clean
 sg-circular-dependency	2026-06-21T18:54:29Z	PASS	180	verify.sh	first run (never-run); circular SG cross-ref via standalone ingress; revoke-before-delete destroy order; 11 deleted 0 err
-sns-event-source	2026-06-21T03:52:27Z	PASS		verify.sh	SnsEventSource: publish->Lambda->DynamoDB delivered; clean destroy 0 orphan
+sns-event-source	2026-07-20T08:12:14Z	PASS	68	verify.sh	rc ok, orph clean
 sns-inline-subscription	2026-07-03T09:04:10Z	PASS	47	verify.sh	inline sub create(in-try)+update+drift reach AWS; destroy clean
 sns-sqs-event	2026-06-21T16:16:44Z	PASS	56	verify.sh	stale-real re-run; 19 deleted 0 err; clean
 sns-subscription-filter	2026-06-21T06:31:35Z	PASS	38	verify.sh	FilterPolicy intact; 0 orph

--- a/tests/integration/eventbridge-input-transformer/verify.sh
+++ b/tests/integration/eventbridge-input-transformer/verify.sh
@@ -141,17 +141,28 @@ fi
 echo "==> Pre-run cleanup"
 cleanup
 
-# put one matching event, poll the queue until a message arrives, print its body,
-# and delete it (so phase 2 does not read a phase 1 message). Echoes the body.
+# put a matching event, poll the queue for the delivered (transformed) body,
+# delete it, and echo it. An optional 2nd arg is a substring the body MUST
+# contain before it is accepted; bodies lacking it are drained as stale and a
+# fresh event is re-put on the next iteration.
+#
+# Why re-put every iteration instead of once: an in-place Rule update does not
+# apply to the target's InputTransformer instantly -- EventBridge takes a few
+# seconds to propagate the new target config. A single event fired immediately
+# after the phase-2 update can be delivered under the OLD transform, and then
+# every poll reads that same stale message (observed as an intermittent P2
+# FAIL). Re-putting each iteration and requiring the expected marker drains the
+# stale delivery and keeps trying until the propagated transform is applied.
 put_and_read() {
   local order_id="$1"
+  local want="${2:-}"
   local url
   url="$(queue_url)"
-  aws events put-events --region "${REGION}" --entries \
-    "[{\"Source\":\"cdkd.bughunt\",\"DetailType\":\"order\",\"Detail\":\"{\\\"orderId\\\":\\\"${order_id}\\\"}\"}]" \
-    >/dev/null
   local i body rh
-  for i in 1 2 3 4 5 6 7 8; do
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    aws events put-events --region "${REGION}" --entries \
+      "[{\"Source\":\"cdkd.bughunt\",\"DetailType\":\"order\",\"Detail\":\"{\\\"orderId\\\":\\\"${order_id}\\\"}\"}]" \
+      >/dev/null
     local msg
     msg="$(aws sqs receive-message --queue-url "${url}" --wait-time-seconds 5 \
       --region "${REGION}" --output json 2>/dev/null || true)"
@@ -159,8 +170,12 @@ put_and_read() {
     if [ -n "${body}" ]; then
       rh="$(printf '%s' "${msg}" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const m=JSON.parse(s);process.stdout.write(m.Messages[0].ReceiptHandle)})')"
       aws sqs delete-message --queue-url "${url}" --receipt-handle "${rh}" --region "${REGION}" >/dev/null 2>&1 || true
-      printf '%s' "${body}"
-      return 0
+      # Accept once the required marker (if any) is present; otherwise this is a
+      # stale pre-propagation delivery -- drop it and re-put on the next loop.
+      if [ -z "${want}" ] || printf '%s' "${body}" | grep -qF "${want}"; then
+        printf '%s' "${body}"
+        return 0
+      fi
     fi
   done
   return 1
@@ -185,9 +200,9 @@ echo "==> Phase 2: re-deploy adding version:2 to the transform (in-place Rule up
 CDKD_TEST_UPDATE=true node "${LOCAL_DIST}" deploy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --yes
 
-BODY2="$(put_and_read ORD-222 || true)"
+BODY2="$(put_and_read ORD-222 '"version":2' || true)"
 if [ -z "${BODY2}" ]; then
-  echo "FAIL: no transformed message delivered to the SQS target in Phase 2" >&2
+  echo "FAIL: updated transform (version:2) never reached the SQS target in Phase 2 after propagation retries" >&2
   exit 1
 fi
 echo "    delivered body (P2): ${BODY2}"


### PR DESCRIPTION
## Summary

Integ sweep 0720b (coverage-hygiene continuation): ran 5 stale (>14d) `verify.sh`
integ tests against real AWS, all PASS with clean destroys and 0 orphans. One
flaky fixture was found and hardened.

Runs recorded in `docs/_generated/integ-last-run.tsv`:

| test | result | dur | note |
|------|--------|-----|------|
| dynamodb-ondemand | PASS | 93s | rc ok, orph clean |
| dynamodb-gsi-update | PASS | 579s | GSI backfill, rc ok |
| deep-getatt-chains | PASS | 66s | rc ok, orph clean |
| sns-event-source | PASS | 68s | rc ok, orph clean |
| eventbridge-input-transformer | PASS | 63s | hardened (see below) |

## Fixture hardening: `eventbridge-input-transformer`

Phase 2 verifies an in-place `Events::Rule` target `InputTransformer` UPDATE by
firing one event immediately after the update deploy and polling the SQS target.
EventBridge propagates the new target config with a few seconds of lag, so the
single event could be delivered under the OLD transform and every subsequent poll
then read that same stale message. This surfaced as an intermittent P2 FAIL that
mimics a product silent-drop bug.

It is NOT a cdkd bug: an immediate re-run passed, confirming cdkd applied the
InputTransformer update correctly. The classifier is determinism -- a real
silent-drop fails every run; a propagation race passes on re-run.

`put_and_read` now re-puts a fresh event on every poll iteration and accepts a
body only once an optional expected-marker substring is present, draining stale
pre-propagation deliveries. Phase 2 requires `"version":2`. The marker check also
naturally drains any leftover phase-1 event.

## Test plan

- `vp check --fix` / `vp run build` / `vp run test` -> 452 files, 7568 tests pass
  (incl. the three `verify.sh` lints: signal-traps, probe-not-found, cli-flags).
- Hardened fixture re-run end-to-end: all 3 phases PASS, destroy 0 errors, state gone.
- Coverage matrices (integ / scenario / cli-flag) regenerated -> no diff.
- Account post-sweep: 0 state.json, 0 locks; my stacks' `deployments/` keys swept.

## Retrospective

Left a memory rule (`feedback_integ_inplace_update_propagation_race`): fixtures
probing eventually-consistent UPDATE effects (EventBridge target config, IAM
propagation, DNS) must loop {re-trigger; read; accept only when the NEW-state
marker is present} rather than single-shot probe -- a single immediate probe of a
lagging resource is a latent flake that reads like a silent-drop bug.
