### PR TITLE
test(integ): probe state.json key in migrate-from-cfn instead of sweeping the cdkd/ prefix (retained deployments/ logs)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -178,7 +178,7 @@ macro-expansion	2026-06-21T11:15:51Z	PASS	105	verify.sh	sweep-F staleness re-run
 microservices	2026-07-19T19:50:37Z	PASS	54	standard	rc ok, 19 res, all destroyed, orph clean
 migrate-from-bare-cfn	2026-06-21T11:00:28Z	PASS	146	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 migrate-from-bare-cfn-codegen-only	2026-06-21T19:09:34Z	PASS	55	verify.sh	fixed: bumped pinned aws-cdk 2.1112->2.1128 (schema 54 float); 3/3 logical IDs + aws:cdk:path preserved; AWS-free codegen smoke
-migrate-from-cfn	2026-06-21T11:00:28Z	PASS	89	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+migrate-from-cfn	2026-07-20T09:10:31Z	PASS	330	verify.sh	run.sh preflight+assert_state_absent fixed to head-object state.json probe (deployments/ #808 no longer false-positives); full small-flow clean: 24 imported/24 destroyed 0 err, state+resources gone
 monitoring	2026-06-21T04:34:50Z	PASS	40	standard	CW alarms/dashboard deploy 7 / destroy 7, 0 err
 multi-asset	2026-06-21T04:31:39Z	PASS	74	verify.sh	1 ECR + 4 S3 assets, each Lambda correct marker, destroy 0 err; swept 4 log groups
 multi-region-same-stack	2026-06-21T11:00:28Z	PASS	14	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
@@ -208,7 +208,7 @@ rollback-failure-injection	2026-07-02T16:12:06Z	PASS	436	verify.sh	post-merge va
 route53	2026-06-21T16:16:44Z	PASS	384	verify.sh	stale-real re-run; 6 deleted 0 err; clean
 s3-asset-deploy	2026-07-02T18:23:15Z	PASS	49	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 s3-cloudfront	2026-07-02T18:23:15Z	PASS	396	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
-s3-directory-bucket	2026-06-21T11:00:28Z	PASS	18	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+s3-directory-bucket	2026-07-20T09:10:31Z	PASS	60	standard	clean deploy+destroy from #1124 tree (integ-destroy gate refresh): 1 deleted 0 err, directory bucket + state gone
 s3-event-notification	2026-06-20T18:40:52Z	PASS		verify.sh	S3->Lambda notification fired (DynamoDB record); 3 phases pass, clean destroy, 0 orphan
 s3-lifecycle	2026-06-28T17:58:35Z	PASS	51	verify.sh	V1/V2 mix + top-level ObjectSize fold; deploy+update+destroy clean
 s3-object-lock	2026-06-27T16:08:39Z	PASS	46	verify.sh	Object Lock GOVERNANCE create + retention 1->5d in-place UPDATE; 0 errors 0 orphans

--- a/tests/integration/migrate-from-cfn/run.sh
+++ b/tests/integration/migrate-from-cfn/run.sh
@@ -38,13 +38,34 @@ fi
 
 log() { printf '\n=== %s ===\n' "$*"; }
 
+# True (rc 0) iff the cdkd state.json key exists for a stack. Probes the exact
+# key via head-object, NOT `aws s3 ls` on the prefix: the deployment-events
+# layer at cdkd/<stack>/<region>/deployments/ (issue #808) is intentionally
+# retained after destroy, so a whole-prefix sweep false-positives the moment a
+# run has emitted any deployment event. A canonical not-found/404 means gone;
+# any other error (throttle, auth, network) hard-fails rather than being read
+# as "clean" (per .claude/rules/testing.md gone-probe rule).
+state_json_exists() {
+  local stack="$1" err
+  err="$(aws s3api head-object --bucket "${STATE_BUCKET}" \
+    --key "cdkd/${stack}/${REGION}/state.json" --region us-east-1 2>&1 >/dev/null || true)"
+  if [ -z "${err}" ]; then
+    return 0
+  fi
+  if printf '%s' "${err}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|404'; then
+    return 1
+  fi
+  echo "ERROR: unexpected error probing state.json for ${stack}: ${err}" >&2
+  exit 1
+}
+
 # Hard-fail early if a previous run left cdkd state OR a CFn stack with the
 # same name. Resuming on top of either masks real bugs (the import would
 # refuse, or the cdk deploy would attempt UPDATE on a stale stack).
 preflight_clean() {
   local stack="$1"
   log "[${stack}] pre-flight orphan scan"
-  if aws s3 ls "s3://${STATE_BUCKET}/cdkd/${stack}/" --region us-east-1 2>/dev/null | grep -q .; then
+  if state_json_exists "${stack}"; then
     echo "ERROR: cdkd state already exists for ${stack}. Run 'cdkd state orphan ${stack} --yes' first." >&2
     exit 1
   fi
@@ -56,7 +77,7 @@ preflight_clean() {
 
 assert_state_present() {
   local stack="$1"
-  if ! aws s3 ls "s3://${STATE_BUCKET}/cdkd/${stack}/${REGION}/state.json" --region us-east-1 >/dev/null 2>&1; then
+  if ! state_json_exists "${stack}"; then
     echo "ASSERTION FAILED: cdkd state not written for ${stack}" >&2
     exit 1
   fi
@@ -65,11 +86,11 @@ assert_state_present() {
 
 assert_state_absent() {
   local stack="$1"
-  if aws s3 ls "s3://${STATE_BUCKET}/cdkd/${stack}/" --region us-east-1 2>/dev/null | grep -q .; then
+  if state_json_exists "${stack}"; then
     echo "ASSERTION FAILED: cdkd state still present for ${stack} after destroy" >&2
     exit 1
   fi
-  echo "  ok: cdkd state cleaned"
+  echo "  ok: cdkd state cleaned (deployments/ event log retained by design)"
 }
 
 assert_cfn_gone() {


### PR DESCRIPTION
## Summary

The `migrate-from-cfn` integ fixture's pre-flight guard and post-destroy
assertion swept the whole `cdkd/<stack>/` S3 prefix via
`aws s3 ls ... | grep -q .`. That false-positives once the deployment-events
layer (`cdkd/<stack>/<region>/deployments/` = `index.json` + `*.jsonl`, issue
(#808)) has emitted any event: that layer is intentionally retained after
destroy, so a perfectly clean run still leaves objects under the prefix and the
script reports `cdkd state still present` and exits 1.

Observed live 2026-07-20: a `migrate-from-cfn` run destroyed cleanly (24
imported / 24 destroyed, 0 errors, state.json + all resources gone) yet the
`assert_state_absent` check failed on the retained `deployments/` logs.

## Fix

Add a shared `state_json_exists` helper that probes the exact `state.json` key
via `aws s3api head-object` instead of `aws s3 ls` on the prefix:

- canonical not-found / 404 stderr => gone (rc 1)
- empty stderr => present (rc 0)
- any other error (throttle / auth / network) => hard-fail, never read as "clean"

This mirrors the `.claude/rules/testing.md` gone-probe rule (head-object over
`aws s3 ls`, canonical not-found signature, non-not-found errors hard-fail).
`preflight_clean`, `assert_state_present`, and `assert_state_absent` all route
through it, so the retained `deployments/` logs are ignored by design.

## Test plan

- `vp check` green (0 errors); full unit suite 452 files / 7568 tests pass.
- End-to-end re-run of `migrate-from-cfn small` with the fix: pre-flight passed
  despite prior-run `deployments/` logs present (exercising the pre-flight fix
  against real leftover state), then 24 imported / 24 destroyed / 0 errors,
  state.json + resources gone, `ALL CHECKS PASSED`.
- Account orphan-clean after the run.
- Ledger updated: `migrate-from-cfn` and `s3-directory-bucket` recorded PASS.

## Retrospective

Latent-sibling sweep: other integ fixtures using `aws s3 ls "s3://.../cdkd/<stack>/"`
prefix checks would false-positive the same way once they emit deployment
events. Recorded as a memory rule (state-gone assertions must probe the
`state.json` key via head-object, never sweep the prefix).
