### PR TITLE
fix: honor --profile for AWS SDK credentials

### DIFF
--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -51,6 +51,13 @@ export function buildProgram(): Command {
     // appear in dist/).
     .version(typeof __CDKD_VERSION__ === 'string' ? __CDKD_VERSION__ : '0.0.0-dev');
 
+  program.hook('preAction', (_thisCommand, actionCommand) => {
+    const { profile } = actionCommand.opts<{ profile?: string }>();
+    if (profile !== undefined) {
+      process.env['AWS_PROFILE'] = profile;
+    }
+  });
+
   program.addCommand(createBootstrapCommand());
   program.addCommand(createSynthCommand());
   program.addCommand(createListCommand());

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -52,7 +52,7 @@ export function buildProgram(): Command {
     .version(typeof __CDKD_VERSION__ === 'string' ? __CDKD_VERSION__ : '0.0.0-dev');
 
   program.hook('preAction', (_thisCommand, actionCommand) => {
-    const { profile } = actionCommand.opts<{ profile?: string }>();
+    const { profile } = actionCommand.optsWithGlobals<{ profile?: string }>();
     if (profile !== undefined) {
       process.env['AWS_PROFILE'] = profile;
     }

--- a/src/utils/aws-clients.ts
+++ b/src/utils/aws-clients.ts
@@ -406,8 +406,7 @@ export class AwsClients {
   getLambdaMicrovmsClient(): LambdaMicrovmsClient {
     if (!this.lambdaMicrovmsClient) {
       this.lambdaMicrovmsClient = new LambdaMicrovmsClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.lambdaMicrovmsClient;

--- a/src/utils/aws-clients.ts
+++ b/src/utils/aws-clients.ts
@@ -62,6 +62,14 @@ export class AwsClients {
     this.config = config;
   }
 
+  private get clientOptions(): Pick<AwsClientConfig, 'region' | 'profile' | 'credentials'> {
+    return {
+      ...(this.config.region && { region: this.config.region }),
+      ...(this.config.profile && { profile: this.config.profile }),
+      ...(this.config.credentials && { credentials: this.config.credentials }),
+    };
+  }
+
   /**
    * Get S3 client
    *
@@ -73,8 +81,7 @@ export class AwsClients {
   getS3Client(): S3Client {
     if (!this.s3Client) {
       this.s3Client = new S3Client({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
         // Suppress "Are you using a Stream of unknown length" warning
         logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
       });
@@ -93,8 +100,7 @@ export class AwsClients {
   getCloudControlClient(): CloudControlClient {
     if (!this.cloudControlClient) {
       this.cloudControlClient = new CloudControlClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.cloudControlClient;
@@ -109,8 +115,8 @@ export class AwsClients {
   getIAMClient(): IAMClient {
     if (!this.iamClient) {
       this.iamClient = new IAMClient({
+        ...this.clientOptions,
         region: this.config.region || 'us-east-1',
-        ...(this.config.credentials && { credentials: this.config.credentials }),
       });
     }
     return this.iamClient;
@@ -143,8 +149,7 @@ export class AwsClients {
   getSQSClient(): SQSClient {
     if (!this.sqsClient) {
       this.sqsClient = new SQSClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.sqsClient;
@@ -163,8 +168,7 @@ export class AwsClients {
   getSNSClient(): SNSClient {
     if (!this.snsClient) {
       this.snsClient = new SNSClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.snsClient;
@@ -183,8 +187,7 @@ export class AwsClients {
   getLambdaClient(): LambdaClient {
     if (!this.lambdaClient) {
       this.lambdaClient = new LambdaClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.lambdaClient;
@@ -203,8 +206,7 @@ export class AwsClients {
   getEC2Client(): EC2Client {
     if (!this.ec2Client) {
       this.ec2Client = new EC2Client({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.ec2Client;
@@ -223,8 +225,7 @@ export class AwsClients {
   getSTSClient(): STSClient {
     if (!this.stsClient) {
       this.stsClient = new STSClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.stsClient;
@@ -243,8 +244,7 @@ export class AwsClients {
   getDynamoDBClient(): DynamoDBClient {
     if (!this.dynamoDBClient) {
       this.dynamoDBClient = new DynamoDBClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.dynamoDBClient;
@@ -263,8 +263,7 @@ export class AwsClients {
   getCloudFormationClient(): CloudFormationClient {
     if (!this.cloudFormationClient) {
       this.cloudFormationClient = new CloudFormationClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.cloudFormationClient;
@@ -283,8 +282,7 @@ export class AwsClients {
   getAPIGatewayClient(): APIGatewayClient {
     if (!this.apiGatewayClient) {
       this.apiGatewayClient = new APIGatewayClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.apiGatewayClient;
@@ -303,8 +301,7 @@ export class AwsClients {
   getEventBridgeClient(): EventBridgeClient {
     if (!this.eventBridgeClient) {
       this.eventBridgeClient = new EventBridgeClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.eventBridgeClient;
@@ -323,8 +320,7 @@ export class AwsClients {
   getSecretsManagerClient(): SecretsManagerClient {
     if (!this.secretsManagerClient) {
       this.secretsManagerClient = new SecretsManagerClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.secretsManagerClient;
@@ -343,8 +339,7 @@ export class AwsClients {
   getSSMClient(): SSMClient {
     if (!this.ssmClient) {
       this.ssmClient = new SSMClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.ssmClient;
@@ -363,8 +358,7 @@ export class AwsClients {
   getCloudFrontClient(): CloudFrontClient {
     if (!this.cloudFrontClient) {
       this.cloudFrontClient = new CloudFrontClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.cloudFrontClient;
@@ -387,8 +381,7 @@ export class AwsClients {
   getACMClient(): ACMClient {
     if (!this.acmClient) {
       this.acmClient = new ACMClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.acmClient;
@@ -433,8 +426,7 @@ export class AwsClients {
   getCloudWatchClient(): CloudWatchClient {
     if (!this.cloudWatchClient) {
       this.cloudWatchClient = new CloudWatchClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.cloudWatchClient;
@@ -453,8 +445,7 @@ export class AwsClients {
   getCloudWatchLogsClient(): CloudWatchLogsClient {
     if (!this.cloudWatchLogsClient) {
       this.cloudWatchLogsClient = new CloudWatchLogsClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.cloudWatchLogsClient;
@@ -473,8 +464,7 @@ export class AwsClients {
   getBedrockAgentCoreControlClient(): BedrockAgentCoreControlClient {
     if (!this.bedrockAgentCoreControlClient) {
       this.bedrockAgentCoreControlClient = new BedrockAgentCoreControlClient({
-        ...(this.config.region && { region: this.config.region }),
-        ...(this.config.credentials && { credentials: this.config.credentials }),
+        ...this.clientOptions,
       });
     }
     return this.bedrockAgentCoreControlClient;

--- a/tests/unit/cli/program.test.ts
+++ b/tests/unit/cli/program.test.ts
@@ -28,4 +28,26 @@ describe('CLI profile propagation', () => {
 
     expect(observedProfile).toBe('haruki-default');
   });
+
+  it('sets AWS_PROFILE when --profile belongs to the parent command', async () => {
+    delete process.env['AWS_PROFILE'];
+    const program = buildProgram();
+    let observedProfile: string | undefined;
+    const parent = program.command('profile-parent').option('--profile <profile>');
+
+    parent.command('profile-child').action(() => {
+      observedProfile = process.env['AWS_PROFILE'];
+    });
+
+    await program.parseAsync([
+      'node',
+      'cdkd',
+      'profile-parent',
+      '--profile',
+      'haruki-default',
+      'profile-child',
+    ]);
+
+    expect(observedProfile).toBe('haruki-default');
+  });
 });

--- a/tests/unit/cli/program.test.ts
+++ b/tests/unit/cli/program.test.ts
@@ -24,9 +24,9 @@ describe('CLI profile propagation', () => {
         observedProfile = process.env['AWS_PROFILE'];
       });
 
-    await program.parseAsync(['node', 'cdkd', 'profile-test', '--profile', 'haruki-default']);
+    await program.parseAsync(['node', 'cdkd', 'profile-test', '--profile', 'test-profile']);
 
-    expect(observedProfile).toBe('haruki-default');
+    expect(observedProfile).toBe('test-profile');
   });
 
   it('sets AWS_PROFILE when --profile belongs to the parent command', async () => {
@@ -44,10 +44,44 @@ describe('CLI profile propagation', () => {
       'cdkd',
       'profile-parent',
       '--profile',
-      'haruki-default',
+      'test-profile',
       'profile-child',
     ]);
 
-    expect(observedProfile).toBe('haruki-default');
+    expect(observedProfile).toBe('test-profile');
+  });
+
+  it('leaves an existing AWS_PROFILE untouched when --profile is not passed', async () => {
+    process.env['AWS_PROFILE'] = 'preset-profile';
+    const program = buildProgram();
+    let observedProfile: string | undefined;
+
+    program
+      .command('profile-test')
+      .option('--profile <profile>')
+      .action(() => {
+        observedProfile = process.env['AWS_PROFILE'];
+      });
+
+    await program.parseAsync(['node', 'cdkd', 'profile-test']);
+
+    expect(observedProfile).toBe('preset-profile');
+  });
+
+  it('overrides an existing AWS_PROFILE with the --profile flag', async () => {
+    process.env['AWS_PROFILE'] = 'preset-profile';
+    const program = buildProgram();
+    let observedProfile: string | undefined;
+
+    program
+      .command('profile-test')
+      .option('--profile <profile>')
+      .action(() => {
+        observedProfile = process.env['AWS_PROFILE'];
+      });
+
+    await program.parseAsync(['node', 'cdkd', 'profile-test', '--profile', 'flag-profile']);
+
+    expect(observedProfile).toBe('flag-profile');
   });
 });

--- a/tests/unit/cli/program.test.ts
+++ b/tests/unit/cli/program.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { buildProgram } from '../../../src/cli/program.js';
+
+describe('CLI profile propagation', () => {
+  const originalProfile = process.env['AWS_PROFILE'];
+
+  afterEach(() => {
+    if (originalProfile === undefined) {
+      delete process.env['AWS_PROFILE'];
+    } else {
+      process.env['AWS_PROFILE'] = originalProfile;
+    }
+  });
+
+  it('sets AWS_PROFILE before a nested command action runs', async () => {
+    delete process.env['AWS_PROFILE'];
+    const program = buildProgram();
+    let observedProfile: string | undefined;
+
+    program
+      .command('profile-test')
+      .option('--profile <profile>')
+      .action(() => {
+        observedProfile = process.env['AWS_PROFILE'];
+      });
+
+    await program.parseAsync(['node', 'cdkd', 'profile-test', '--profile', 'haruki-default']);
+
+    expect(observedProfile).toBe('haruki-default');
+  });
+});

--- a/tests/unit/utils/aws-clients.test.ts
+++ b/tests/unit/utils/aws-clients.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { AwsClients } from '../../../src/utils/aws-clients.js';
+
+describe('AwsClients', () => {
+  it('passes the configured profile to every AWS SDK client', () => {
+    const profile = 'haruki-default';
+    const clients = new AwsClients({ region: 'ap-northeast-1', profile });
+
+    try {
+      expect(clients.s3.config.profile).toBe(profile);
+      expect(clients.cloudControl.config.profile).toBe(profile);
+      expect(clients.iam.config.profile).toBe(profile);
+      expect(clients.sqs.config.profile).toBe(profile);
+      expect(clients.sns.config.profile).toBe(profile);
+      expect(clients.lambda.config.profile).toBe(profile);
+      expect(clients.ec2.config.profile).toBe(profile);
+      expect(clients.sts.config.profile).toBe(profile);
+      expect(clients.dynamoDB.config.profile).toBe(profile);
+      expect(clients.cloudFormation.config.profile).toBe(profile);
+      expect(clients.apiGateway.config.profile).toBe(profile);
+      expect(clients.eventBridge.config.profile).toBe(profile);
+      expect(clients.secretsManager.config.profile).toBe(profile);
+      expect(clients.ssm.config.profile).toBe(profile);
+      expect(clients.cloudFront.config.profile).toBe(profile);
+      expect(clients.acm.config.profile).toBe(profile);
+      expect(clients.cloudWatch.config.profile).toBe(profile);
+      expect(clients.cloudWatchLogs.config.profile).toBe(profile);
+      expect(clients.bedrockAgentCoreControl.config.profile).toBe(profile);
+    } finally {
+      clients.destroy();
+    }
+  });
+});

--- a/tests/unit/utils/aws-clients.test.ts
+++ b/tests/unit/utils/aws-clients.test.ts
@@ -3,29 +3,21 @@ import { AwsClients } from '../../../src/utils/aws-clients.js';
 
 describe('AwsClients', () => {
   it('passes the configured profile to every AWS SDK client', () => {
-    const profile = 'haruki-default';
+    const profile = 'test-profile';
     const clients = new AwsClients({ region: 'ap-northeast-1', profile });
+    const factoryNames = Object.getOwnPropertyNames(AwsClients.prototype).filter((name) =>
+      /^get[A-Z].*Client$/.test(name)
+    );
 
     try {
-      expect(clients.s3.config.profile).toBe(profile);
-      expect(clients.cloudControl.config.profile).toBe(profile);
-      expect(clients.iam.config.profile).toBe(profile);
-      expect(clients.sqs.config.profile).toBe(profile);
-      expect(clients.sns.config.profile).toBe(profile);
-      expect(clients.lambda.config.profile).toBe(profile);
-      expect(clients.ec2.config.profile).toBe(profile);
-      expect(clients.sts.config.profile).toBe(profile);
-      expect(clients.dynamoDB.config.profile).toBe(profile);
-      expect(clients.cloudFormation.config.profile).toBe(profile);
-      expect(clients.apiGateway.config.profile).toBe(profile);
-      expect(clients.eventBridge.config.profile).toBe(profile);
-      expect(clients.secretsManager.config.profile).toBe(profile);
-      expect(clients.ssm.config.profile).toBe(profile);
-      expect(clients.cloudFront.config.profile).toBe(profile);
-      expect(clients.acm.config.profile).toBe(profile);
-      expect(clients.cloudWatch.config.profile).toBe(profile);
-      expect(clients.cloudWatchLogs.config.profile).toBe(profile);
-      expect(clients.bedrockAgentCoreControl.config.profile).toBe(profile);
+      expect(factoryNames.length).toBeGreaterThanOrEqual(20);
+
+      for (const name of factoryNames) {
+        const client = (
+          clients as unknown as Record<string, () => { config: { profile?: string } }>
+        )[name]();
+        expect(client.config.profile, `client factory "${name}"`).toBe(profile);
+      }
     } finally {
       clients.destroy();
     }


### PR DESCRIPTION
## 概要

CLIコマンドで `--profile` を指定した際、AWS SDKが指定profileの認証情報を解決できるようにします。

従来のcdkdは `--profile` を受け付け、一部の内部設定へ渡していました。しかし共通のAWS SDKクライアント設定にはprofileが含まれていなかったため、`AWS_PROFILE` も同時に設定しないとprofileの解決に失敗する場合がありました。

今回の変更内容:

- Commanderのroot `preAction` hookで、`--profile` の値を `AWS_PROFILE` に設定します。親コマンドから継承されるprofileにも対応しています。
- `AwsClients` が生成するすべてのAWS SDKクライアントへ、設定されたprofileを渡します。最新mainで追加された `getLambdaMicrovmsClient` も対象です。
- `get*Client` factoryを動的に列挙し、今後クライアントが追加されてもprofileの渡し忘れを検出できる回帰テストにします。
- leaf commandのoption、親コマンドから継承されるoption、既存の `AWS_PROFILE` の維持・上書きをテストします。
- 最新の `main`（v0.262.2）へリベースしています。

## 検証結果

- `vp test run --testTimeout 20000`: 462ファイル、7,698テスト成功、型エラーなし
- `vp check`: エラー0件で成功（既存warning 4件）
- `vp run build`: 成功
- `AWS_PROFILE` を未設定にした状態で、`node dist/cli.js state info --profile haruki-default --json` を実行し、指定profileでのAWSアクセスに成功

サブエージェントレビューも実施し、最終レビューでは対応が必要な指摘はありませんでした。
