### PR TITLE
chore(import): dedupe the CFn override filter and document the substituteOverrideRefs side effect

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -116,7 +116,7 @@ iam-propagation-stress	2026-06-21T18:33:45Z	PASS	80	verify.sh	first run (never-r
 iam-role-policies-drift-clean	2026-06-22T02:14:54Z	PASS		verify.sh	no IAM Role phantom drift; destroy 6/0 errors, 0 orphans
 iam-role-prefixed-name-update	2026-06-21T08:38:12Z	PASS	45	verify.sh	prefix-migration false-positive fix (generator-based); in-place UPDATE w/o -y, RoleId unchanged, destroy clean
 import-attributes	2026-07-20T15:36:18Z	PASS	41	verify.sh	rc 0, 0 orphans; #1091 batch 4 final
-import-auto-mode	2026-07-20T16:48:19Z	PASS	77	verify.sh	#1128 final; verified red without the fix
+import-auto-mode	2026-07-20T17:16:39Z	PASS	108	verify.sh	rc 0, destroy 1 deleted 0 errors, orph clean
 import-nested-stack	2026-06-21T11:00:28Z	PASS	146	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 import-value-strong-ref	2026-07-02T18:23:15Z	PASS	115	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 importvalue-chain	2026-07-02T18:23:15Z	PASS	75	verify.sh	0703 staleness sweep (pre-TTL refresh); clean

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -336,43 +336,17 @@ async function importCommand(stackArg: string | undefined, options: ImportOption
         migrationCfnStackName,
         awsClients.cloudFormation
       );
-      const cfnMapping = migrationTree.resources;
-      let derived = 0;
-      let skippedNonImportable = 0;
-      let skippedNestedStackRow = 0;
-      for (const [logicalId, physicalId] of cfnMapping) {
-        if (!templateLogicalIds.has(logicalId)) {
-          skippedNonImportable++;
-          continue;
-        }
-        // Nested-stack rows: the AWS-side physical ID is the child stack
-        // ARN, which is NOT what we want as an import override. The root
-        // parent's state entry for the nested-stack resource carries the
-        // synthesized cdkd-local ARN (matching what `NestedStackProvider.create`
-        // would write at deploy time — design §6), populated by `importOne`'s
-        // short-circuit below. Filter the AWS ARN out here so it doesn't
-        // overwrite the synth-ARN entry.
-        const tmplResource = template.Resources[logicalId];
-        if (tmplResource?.Type === NESTED_STACK_RESOURCE_TYPE) {
-          skippedNestedStackRow++;
-          continue;
-        }
-        if (!overrides.has(logicalId)) {
-          overrides.set(logicalId, physicalId);
-          derived++;
-        }
-      }
-      const overriddenByUser =
-        cfnMapping.size - derived - skippedNonImportable - skippedNestedStackRow;
-      const detail: string[] = [];
-      if (overriddenByUser > 0) detail.push(`${overriddenByUser} already overridden by --resource`);
-      if (skippedNonImportable > 0)
-        detail.push(`${skippedNonImportable} non-importable (e.g. CDKMetadata)`);
-      if (skippedNestedStackRow > 0)
-        detail.push(`${skippedNestedStackRow} nested-stack row(s) handled separately`);
+      // Shared filter (see `mergeCfnDerivedOverrides`): non-importable rows,
+      // nested-stack rows, and ids the user already supplied are all dropped.
+      const mergeStats = mergeCfnDerivedOverrides({
+        cfnMapping: migrationTree.resources,
+        template,
+        templateLogicalIds,
+        overrides,
+      });
       logger.info(
-        `Resolved ${derived} physical ID(s) from CloudFormation` +
-          (detail.length > 0 ? ` (${detail.join(', ')})` : '')
+        `Resolved ${mergeStats.derived} physical ID(s) from CloudFormation` +
+          formatCfnOverrideMergeDetail(mergeStats)
       );
       // Validate template ↔ AWS shape: every nested-stack row in the synth
       // template MUST have a matching child in the AWS tree, and vice
@@ -473,17 +447,24 @@ async function importCommand(stackArg: string | undefined, options: ImportOption
         awsClients.cloudFormation
       );
       if (cfnResources) {
-        let derived = 0;
-        for (const [logicalId, physicalId] of cfnResources) {
-          if (!templateLogicalIds.has(logicalId)) continue;
-          if (template.Resources[logicalId]?.Type === NESTED_STACK_RESOURCE_TYPE) continue;
-          if (overrides.has(logicalId)) continue;
-          overrides.set(logicalId, physicalId);
-          derived++;
-        }
-        if (derived > 0) {
+        // Same three filters as the migration path — shared so a change to
+        // any of them lands once (issue #1131). Note the second-order effect
+        // documented on the helper: seeding `overrides` ALSO pre-resolves
+        // `{Ref: <X>}` in a resource's Properties via `substituteOverrideRefs`
+        // before `provider.import()` runs, which auto mode did not do before
+        // #1128. That is intended — it is the same resolution
+        // `--migrate-from-cloudformation` has always produced, and it is what
+        // makes sub-resource providers (e.g. `SQSQueuePolicyProvider`)
+        // importable — but it is broader than "resolve physical IDs" alone.
+        const mergeStats = mergeCfnDerivedOverrides({
+          cfnMapping: cfnResources,
+          template,
+          templateLogicalIds,
+          overrides,
+        });
+        if (mergeStats.derived > 0) {
           logger.info(
-            `Resolved ${derived} physical ID(s) from CloudFormation stack '${stackInfo.stackName}'. ` +
+            `Resolved ${mergeStats.derived} physical ID(s) from CloudFormation stack '${stackInfo.stackName}'. ` +
               `To adopt AND retire that stack, use --migrate-from-cloudformation.`
           );
         } else {
@@ -841,6 +822,101 @@ interface ImportTask {
    * `--migrate-from-cloudformation`).
    */
   overrides: Map<string, string>;
+}
+
+/** Per-filter counts from {@link mergeCfnDerivedOverrides}. */
+export interface CfnOverrideMergeStats {
+  /** Entries actually seeded into `overrides` by this merge. */
+  derived: number;
+  /** CFn rows whose logical ID is not an importable template resource (e.g. `AWS::CDK::Metadata`). */
+  skippedNonImportable: number;
+  /** CFn rows for `AWS::CloudFormation::Stack` resources (handled separately). */
+  skippedNestedStackRow: number;
+  /** CFn rows that survived both filters but were already in `overrides` (user-supplied wins). */
+  overriddenByUser: number;
+}
+
+/**
+ * Merge a CloudFormation-derived `logicalId -> physicalId` map into the run's
+ * `overrides`, applying the three filters every CFn-derived seed needs, and
+ * report what each filter dropped.
+ *
+ * The filters, in order:
+ *   1. **Not an importable template resource** — CFn knows about sentinel rows
+ *      like `AWS::CDK::Metadata` that cdkd silently skips on import. Merging
+ *      those would make the typo-validation step reject them.
+ *   2. **Nested-stack row** — the AWS-side physical ID of an
+ *      `AWS::CloudFormation::Stack` row is the child stack ARN, which is NOT
+ *      what we want as an import override. The parent's state entry carries
+ *      the synthesized cdkd-local ARN (matching what `NestedStackProvider.create`
+ *      writes at deploy time — design §6), populated by `importOne`'s
+ *      short-circuit. Filtering here keeps the AWS ARN from overwriting it.
+ *   3. **Already overridden** — user-supplied `--resource` /
+ *      `--resource-mapping` entries are inserted before any CFn lookup and
+ *      always win.
+ *
+ * Shared by all three CFn-derived seeding sites so a change to any filter
+ * lands once: the `--migrate-from-cloudformation` root walk, the auto-mode
+ * best-effort lookup (issue #1128), and the recursive nested-child walk.
+ * The three differ only in their LOGGING, which stays at the call sites.
+ *
+ * **Second-order effect worth naming:** `overrides` is also consumed by
+ * {@link substituteOverrideRefs}, so seeding it from CloudFormation means a
+ * `{Ref: <X>}` in a resource's Properties pre-resolves to the CFn physical ID
+ * before `provider.import()` sees it. That is intended — it is what makes
+ * sub-resource providers (e.g. `SQSQueuePolicyProvider`, which reads
+ * `properties.Queues[0]` as a literal queue URL) importable — but it is a
+ * behavior beyond "resolve physical IDs", and it applies to every caller of
+ * this helper, not just the migration path. See issue #1131.
+ *
+ * Mutates `overrides` in place; does not mutate `cfnMapping` or `template`.
+ */
+export function mergeCfnDerivedOverrides(params: {
+  cfnMapping: ReadonlyMap<string, string>;
+  template: CloudFormationTemplate;
+  templateLogicalIds: ReadonlySet<string>;
+  overrides: Map<string, string>;
+}): CfnOverrideMergeStats {
+  const { cfnMapping, template, templateLogicalIds, overrides } = params;
+  const stats: CfnOverrideMergeStats = {
+    derived: 0,
+    skippedNonImportable: 0,
+    skippedNestedStackRow: 0,
+    overriddenByUser: 0,
+  };
+  for (const [logicalId, physicalId] of cfnMapping) {
+    if (!templateLogicalIds.has(logicalId)) {
+      stats.skippedNonImportable++;
+      continue;
+    }
+    if (template.Resources[logicalId]?.Type === NESTED_STACK_RESOURCE_TYPE) {
+      stats.skippedNestedStackRow++;
+      continue;
+    }
+    if (overrides.has(logicalId)) {
+      stats.overriddenByUser++;
+      continue;
+    }
+    overrides.set(logicalId, physicalId);
+    stats.derived++;
+  }
+  return stats;
+}
+
+/**
+ * Render the human-readable breakdown of a {@link mergeCfnDerivedOverrides}
+ * result — the parenthesized suffix of the `Resolved N physical ID(s)` line.
+ * Returns `''` when nothing was dropped (no breakdown worth reporting).
+ */
+export function formatCfnOverrideMergeDetail(stats: CfnOverrideMergeStats): string {
+  const detail: string[] = [];
+  if (stats.overriddenByUser > 0)
+    detail.push(`${stats.overriddenByUser} already overridden by --resource`);
+  if (stats.skippedNonImportable > 0)
+    detail.push(`${stats.skippedNonImportable} non-importable (e.g. CDKMetadata)`);
+  if (stats.skippedNestedStackRow > 0)
+    detail.push(`${stats.skippedNestedStackRow} nested-stack row(s) handled separately`);
+  return detail.length > 0 ? ` (${detail.join(', ')})` : '';
 }
 
 /**
@@ -1742,19 +1818,18 @@ async function importNestedStackChildrenRecursive(args: {
     await lockManager.acquireLock(childStackName, childRegion, lockOwner, 'import');
     try {
       // Compose the child's import overrides from the child tree's flat
-      // resource map. Filter out nested-stack rows (those are
-      // short-circuited to synth ARNs below — same as the root's
-      // dispatch loop) and any logical id not in the child template
-      // (e.g. AWS::CDK::Metadata).
+      // resource map, through the same shared filter as the root walk
+      // (issue #1131). The "already overridden" filter is inert here — the
+      // child map starts empty, since `--resource` overrides are root-scoped.
       const childResources = collectImportableResources(childTemplate);
       const childTemplateLogicalIds = new Set(childResources.map((r) => r.logicalId));
       const childOverrides = new Map<string, string>();
-      for (const [logicalId, physicalId] of childTreeNode.resources) {
-        if (!childTemplateLogicalIds.has(logicalId)) continue;
-        const tmplResource = childTemplate.Resources[logicalId];
-        if (tmplResource?.Type === NESTED_STACK_RESOURCE_TYPE) continue;
-        childOverrides.set(logicalId, physicalId);
-      }
+      mergeCfnDerivedOverrides({
+        cfnMapping: childTreeNode.resources,
+        template: childTemplate,
+        templateLogicalIds: childTemplateLogicalIds,
+        overrides: childOverrides,
+      });
 
       // Dispatch + collect rows (same shape as the root's dispatch loop).
       const rows: ImportRow[] = [];

--- a/tests/unit/cli/import-cfn-override-merge.test.ts
+++ b/tests/unit/cli/import-cfn-override-merge.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vite-plus/test';
+
+/**
+ * Issue #1131: the CloudFormation-derived override filter used to be written
+ * out twice (the `--migrate-from-cloudformation` root walk and the #1128
+ * auto-mode lookup) and a third time in a reduced form for the recursive
+ * nested-child walk. All three now route through `mergeCfnDerivedOverrides`.
+ *
+ * These tests pin the three filters and the user-precedence rule so a future
+ * change to any one of them cannot silently regress a call site, plus the
+ * documented second-order effect: seeding `overrides` from CloudFormation
+ * makes `substituteOverrideRefs` pre-resolve `{Ref: <X>}` in a resource's
+ * Properties. That effect is INTENDED (it is what makes sub-resource
+ * providers like `SQSQueuePolicyProvider` importable under auto mode), so it
+ * is pinned by a test rather than left as an undocumented side effect.
+ */
+
+import {
+  mergeCfnDerivedOverrides,
+  formatCfnOverrideMergeDetail,
+  substituteOverrideRefs,
+} from '../../../src/cli/commands/import.js';
+import type { CloudFormationTemplate } from '../../../src/types/resource.js';
+
+function template(resources: Record<string, { Type: string }>): CloudFormationTemplate {
+  return { Resources: resources } as unknown as CloudFormationTemplate;
+}
+
+describe('mergeCfnDerivedOverrides', () => {
+  it('seeds every importable non-nested row not already overridden', () => {
+    const overrides = new Map<string, string>();
+    const stats = mergeCfnDerivedOverrides({
+      cfnMapping: new Map([
+        ['Bucket', 'my-bucket'],
+        ['Queue', 'https://sqs/my-queue'],
+      ]),
+      template: template({
+        Bucket: { Type: 'AWS::S3::Bucket' },
+        Queue: { Type: 'AWS::SQS::Queue' },
+      }),
+      templateLogicalIds: new Set(['Bucket', 'Queue']),
+      overrides,
+    });
+
+    expect(overrides).toEqual(
+      new Map([
+        ['Bucket', 'my-bucket'],
+        ['Queue', 'https://sqs/my-queue'],
+      ])
+    );
+    expect(stats).toEqual({
+      derived: 2,
+      skippedNonImportable: 0,
+      skippedNestedStackRow: 0,
+      overriddenByUser: 0,
+    });
+  });
+
+  it('drops rows that are not importable template resources (e.g. CDKMetadata)', () => {
+    const overrides = new Map<string, string>();
+    const stats = mergeCfnDerivedOverrides({
+      cfnMapping: new Map([
+        ['Bucket', 'my-bucket'],
+        ['CDKMetadata', 'AWS::CDK::Metadata'],
+      ]),
+      template: template({
+        Bucket: { Type: 'AWS::S3::Bucket' },
+        CDKMetadata: { Type: 'AWS::CDK::Metadata' },
+      }),
+      // `collectImportableResources` excludes the metadata sentinel.
+      templateLogicalIds: new Set(['Bucket']),
+      overrides,
+    });
+
+    expect(overrides.has('CDKMetadata')).toBe(false);
+    expect(stats.derived).toBe(1);
+    expect(stats.skippedNonImportable).toBe(1);
+  });
+
+  it('drops nested-stack rows so the AWS child ARN never overwrites the synth ARN', () => {
+    const overrides = new Map<string, string>();
+    const stats = mergeCfnDerivedOverrides({
+      cfnMapping: new Map([
+        ['Child', 'arn:aws:cloudformation:us-east-1:111122223333:stack/Parent-Child/abc'],
+        ['Bucket', 'my-bucket'],
+      ]),
+      template: template({
+        Child: { Type: 'AWS::CloudFormation::Stack' },
+        Bucket: { Type: 'AWS::S3::Bucket' },
+      }),
+      templateLogicalIds: new Set(['Child', 'Bucket']),
+      overrides,
+    });
+
+    expect(overrides.has('Child')).toBe(false);
+    expect(stats.derived).toBe(1);
+    expect(stats.skippedNestedStackRow).toBe(1);
+  });
+
+  it('never overwrites a user-supplied override', () => {
+    const overrides = new Map([['Bucket', 'user-supplied-bucket']]);
+    const stats = mergeCfnDerivedOverrides({
+      cfnMapping: new Map([['Bucket', 'cfn-derived-bucket']]),
+      template: template({ Bucket: { Type: 'AWS::S3::Bucket' } }),
+      templateLogicalIds: new Set(['Bucket']),
+      overrides,
+    });
+
+    expect(overrides.get('Bucket')).toBe('user-supplied-bucket');
+    expect(stats).toEqual({
+      derived: 0,
+      skippedNonImportable: 0,
+      skippedNestedStackRow: 0,
+      overriddenByUser: 1,
+    });
+  });
+
+  it('does not mutate the source mapping', () => {
+    const cfnMapping = new Map([['Bucket', 'my-bucket']]);
+    mergeCfnDerivedOverrides({
+      cfnMapping,
+      template: template({ Bucket: { Type: 'AWS::S3::Bucket' } }),
+      templateLogicalIds: new Set(['Bucket']),
+      overrides: new Map(),
+    });
+    expect(cfnMapping).toEqual(new Map([['Bucket', 'my-bucket']]));
+  });
+});
+
+describe('formatCfnOverrideMergeDetail', () => {
+  it('is empty when nothing was dropped', () => {
+    expect(
+      formatCfnOverrideMergeDetail({
+        derived: 3,
+        skippedNonImportable: 0,
+        skippedNestedStackRow: 0,
+        overriddenByUser: 0,
+      })
+    ).toBe('');
+  });
+
+  it('lists each non-zero filter in a stable order', () => {
+    expect(
+      formatCfnOverrideMergeDetail({
+        derived: 1,
+        skippedNonImportable: 2,
+        skippedNestedStackRow: 3,
+        overriddenByUser: 4,
+      })
+    ).toBe(
+      ' (4 already overridden by --resource, 2 non-importable (e.g. CDKMetadata), ' +
+        '3 nested-stack row(s) handled separately)'
+    );
+  });
+});
+
+describe('CFn-seeded overrides feed substituteOverrideRefs (issue #1131 item 2)', () => {
+  it('pre-resolves {Ref: X} in Properties to the CFn-derived physical ID', () => {
+    // This is the documented second-order effect of seeding `overrides` from
+    // CloudFormation: it is what lets a sub-resource provider read
+    // `properties.Queues[0]` as a literal queue URL instead of an intrinsic.
+    const overrides = new Map<string, string>();
+    mergeCfnDerivedOverrides({
+      cfnMapping: new Map([['Queue', 'https://sqs.us-east-1.amazonaws.com/111122223333/q']]),
+      template: template({
+        Queue: { Type: 'AWS::SQS::Queue' },
+        QueuePolicy: { Type: 'AWS::SQS::QueuePolicy' },
+      }),
+      templateLogicalIds: new Set(['Queue', 'QueuePolicy']),
+      overrides,
+    });
+
+    const properties = substituteOverrideRefs({ Queues: [{ Ref: 'Queue' }] }, overrides);
+
+    expect(properties).toEqual({
+      Queues: ['https://sqs.us-east-1.amazonaws.com/111122223333/q'],
+    });
+  });
+
+  it('leaves a Ref to a filtered-out row untouched for the post-import resolver', () => {
+    // A nested-stack row is deliberately NOT seeded, so a Ref to it must
+    // survive as an intrinsic rather than silently resolving to the AWS ARN.
+    const overrides = new Map<string, string>();
+    mergeCfnDerivedOverrides({
+      cfnMapping: new Map([['Child', 'arn:aws:cloudformation:us-east-1:111122223333:stack/C/x']]),
+      template: template({ Child: { Type: 'AWS::CloudFormation::Stack' } }),
+      templateLogicalIds: new Set(['Child']),
+      overrides,
+    });
+
+    expect(substituteOverrideRefs({ Target: { Ref: 'Child' } }, overrides)).toEqual({
+      Target: { Ref: 'Child' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Both maintainability findings from the #1130 code review, neither of which is a
correctness bug.

**1. The CFn-derived override filter was duplicated.** The three filters every
CloudFormation-derived override seed needs — not an importable template
resource, nested-stack row, already supplied by the user — were written out in
full twice and a third time in reduced form:

- the `--migrate-from-cloudformation` root walk (which also counted what it
  skipped and logged a breakdown),
- the auto-mode lookup added in #1128 (which did not), and
- the recursive nested-child walk (which had no "already overridden" arm,
  correctly — its map starts empty).

All three now route through `mergeCfnDerivedOverrides`, so a change to any
filter lands once. Per-call-site **logging is unchanged**: the migration path
keeps its breakdown via the extracted `formatCfnOverrideMergeDetail`, and the
auto-mode path keeps its own `derived > 0` info line / debug fallback.

Behavior is otherwise identical. The one arithmetic change worth naming: the
migration path previously derived `overriddenByUser` by subtraction
(`cfnMapping.size - derived - skippedNonImportable - skippedNestedStackRow`);
the helper counts the already-present branch directly. Equivalent, since a
`Map` cannot carry duplicate keys.

**2. The `substituteOverrideRefs` side effect is now documented.** `overrides`
is consumed by `substituteOverrideRefs`, so seeding it from CloudFormation makes
a `{Ref: <X>}` in a resource's Properties pre-resolve to the CFn physical ID
before `provider.import()` sees it — something auto mode did not do before
#1128. That is intended (it is the same resolution
`--migrate-from-cloudformation` has always produced, and it is what makes
sub-resource providers such as `SQSQueuePolicyProvider` importable), but it is
broader than "resolve physical IDs" alone. It is now stated on the helper, at
the auto-mode call site, and — per the issue's "confirm with a test that pins
the intent" — pinned by two tests.

## Test plan

- New `tests/unit/cli/import-cfn-override-merge.test.ts` (9 cases): each of the
  three filters in isolation, user-precedence, non-mutation of the source map,
  the log-breakdown formatter (empty + all-filters-firing), and the two
  `substituteOverrideRefs` interaction cases (a seeded `Ref` resolves; a `Ref`
  to a filtered-out nested-stack row stays an intrinsic for the post-import
  resolver).
- Full suite: 456 files / 7667 tests pass; typecheck + lint + format + build
  clean.
- **Live-tested against real AWS** via `/run-integ import-auto-mode`, the
  fixture that covers the refactored auto-mode call site end to end: `cdk deploy`
  a stack with a CFn-generated physical name and no `aws:cdk:path` tag → `cdkd
  import` in AUTO mode with no override flags → `1 imported, 0 not found` →
  destroy `1 deleted, 0 errors`, 0 orphans. (Pre-#1128 this fixture reported
  `0 imported, 1 not found`, so it fails red if the CFn seeding regresses.)

## Note for reviewers

While adding the new test I hit an unrelated repo-level gap worth flagging
separately: a wrong `import type` path in a `.test.ts` file passes both
`vp run typecheck` (its tsconfig excludes `**/*.test.ts`) and `vp test` (whose
`Type Errors  no errors` line only covers `*.test-d.ts`). Nothing local
typechecks test files. Not fixed here — happy to file it as its own issue.

Closes #1131
