### PR TITLE
chore(tooling): disable cache on the typecheck task (stale-green follow-up to #1141)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -199,6 +199,11 @@ export default defineConfig({
       },
       typecheck: {
         command: 'tsc --project tsconfig.json --noEmit',
+        // Same reason as `typecheck:test` below: Vite+'s task cache does not
+        // invalidate on a `src/**` change, so a stale green replays as a
+        // "cache hit" even after a real type error is introduced (verified).
+        // A type-check gate must never be skipped by the cache.
+        cache: false,
       },
       // `vp check` (and the `typecheck` task above) type-check only
       // tsconfig.json, whose `include` is `src/**` + `types/**` and whose


### PR DESCRIPTION
## Summary

Follow-up to #1141. That PR set `cache: false` on the new `typecheck:test`
task after finding Vite+'s task cache replayed a green **"cache hit"** over a
deliberately broken test file. The pre-existing `typecheck` task
(`tsc --project tsconfig.json --noEmit`) had the same latent hole for `src/**`
edits.

**Verified, not assumed:** with a real type error added to `src/utils/logger.ts`,
`vp run typecheck` returned rc=0 (`cache hit, replaying`) — a false green. With
`cache: false` it correctly returns rc=1 (`TS2322`). Reverted, it is green.

Not in the CI path today (CI runs the built-in `vp check`, a separate
mechanism), so it never bit — but `vp run typecheck` is a task a developer can
run directly, and a type-check gate must never be skipped by a stale cache.
**Every other correctness-gate task in `vite.config.ts`** (`integ-coverage` /
`scenario-coverage` / `cli-flag-coverage` / `audit:coverage:check` / `gen:*` /
`integ-ledger-normalize`) already sets `cache: false`; this brings `typecheck`
in line with that established convention.

## Test plan

- Break `src/utils/logger.ts` on purpose → `vp run typecheck` exits 1 (TS2322);
  revert → green. (The exact break→red→revert→green proof.)
- `vp check`, `vp run typecheck:test`, `vp run build`, `vp run test` (7547) all green.
- 1-line config change, no `src/**` behavior change, no real-AWS surface.
