### PR TITLE
fix(providers): accept ARN-form physicalId in ECS Service readCurrentState + getServiceAttribute (#1170)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -83,7 +83,7 @@ ec2-vpc	2026-06-21T11:12:35Z	PASS	53	standard	sweep-F staleness re-run (rc=0)
 ecr	2026-06-21T11:00:28Z	PASS	39	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 ecr-scanning	2026-07-20T17:37:23Z	PASS	56	verify.sh	ECR scanOnPush + tag add/change/untag update, clean destroy
 ecs-fargate	2026-07-02T18:23:15Z	PASS	373	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
-ecs-service-update-props	2026-07-23T07:03:42Z	PASS		verify.sh	#1170 Phase1c ARN-form observedProperties captured; destroy 15 del 0 err 0 orph
+ecs-service-update-props	2026-07-23T07:13:07Z	PASS		verify.sh	#1170 re-run after getServiceAttribute polish; destroy 15 del 0 err 0 orph
 efs-immutable-replacement	2026-07-19T19:05:41Z	PASS	76	verify.sh	rc ok, 1 deleted, orph clean
 efs-lambda	2026-06-21T14:48:46Z	PASS	560	standard	sweep-G standard re-run (rc=0)
 efs-standalone	2026-06-21T16:16:44Z	PASS	135	verify.sh	stale-real re-run; 11 deleted 0 err; clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -83,7 +83,7 @@ ec2-vpc	2026-06-21T11:12:35Z	PASS	53	standard	sweep-F staleness re-run (rc=0)
 ecr	2026-06-21T11:00:28Z	PASS	39	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 ecr-scanning	2026-07-20T17:37:23Z	PASS	56	verify.sh	ECR scanOnPush + tag add/change/untag update, clean destroy
 ecs-fargate	2026-07-02T18:23:15Z	PASS	373	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
-ecs-service-update-props	2026-07-23T06:34:52Z	PASS		verify.sh	#1167 read reverse-map (+NetworkConfig/LoadBalancers); rc ok, orph clean
+ecs-service-update-props	2026-07-23T07:03:42Z	PASS		verify.sh	#1170 Phase1c ARN-form observedProperties captured; destroy 15 del 0 err 0 orph
 efs-immutable-replacement	2026-07-19T19:05:41Z	PASS	76	verify.sh	rc ok, 1 deleted, orph clean
 efs-lambda	2026-06-21T14:48:46Z	PASS	560	standard	sweep-G standard re-run (rc=0)
 efs-standalone	2026-06-21T16:16:44Z	PASS	135	verify.sh	stale-real re-run; 11 deleted 0 err; clean

--- a/src/provisioning/providers/ecs-provider.ts
+++ b/src/provisioning/providers/ecs-provider.ts
@@ -1138,9 +1138,13 @@ export class ECSProvider implements ResourceProvider {
   private async getServiceAttribute(physicalId: string, attributeName: string): Promise<unknown> {
     const client = this.getClient();
 
-    // Extract cluster from service ARN if possible
+    // physicalId is the service ARN (what createService stores). DescribeServices
+    // scopes to the default cluster unless a cluster is given, so a Service in a
+    // non-default cluster would come back MISSING; derive the cluster from the
+    // ARN so the lookup is scoped correctly (issue #1170).
     const response = await client.send(
       new DescribeServicesCommand({
+        cluster: clusterNameFromServiceArn(physicalId),
         services: [physicalId],
       })
     );

--- a/src/provisioning/providers/ecs-provider.ts
+++ b/src/provisioning/providers/ecs-provider.ts
@@ -105,6 +105,25 @@ const DEPLOYMENT_CONFIG_PRESERVE_KEYS: ReadonlySet<string> = new Set(['HookDetai
 const DEPLOYMENT_CONFIG_PRESERVE_KEYS_CAMEL: ReadonlySet<string> = new Set(['hookDetails']);
 
 /**
+ * Derive the cluster name from a long-format ECS Service ARN
+ * (`arn:<partition>:ecs:<region>:<account>:service/<clusterName>/<serviceName>`)
+ * so `DescribeServices` can be scoped to the right cluster (issue #1170).
+ * Returns `undefined` for the legacy short-format ARN
+ * (`.../service/<serviceName>`, which does not encode a cluster) or any input
+ * that does not match the ARN shape — the caller then falls back to the default
+ * cluster, matching what the short-format ARN implies.
+ */
+function clusterNameFromServiceArn(arn: string): string | undefined {
+  // ARN = arn:<partition>:<service>:<region>:<account>:<resource>
+  const resource = arn.split(':')[5];
+  if (!resource) return undefined;
+  // resource = service/<clusterName>/<serviceName> (long) OR service/<serviceName> (short)
+  const segments = resource.split('/');
+  if (segments[0] !== 'service') return undefined;
+  return segments.length >= 3 ? segments[1] : undefined;
+}
+
+/**
  * AWS ECS Provider
  *
  * Implements resource provisioning for ECS resources:
@@ -1895,8 +1914,9 @@ export class ECSProvider implements ResourceProvider {
    *
    * Dispatches by resource type:
    *   - `AWS::ECS::Cluster` → `DescribeClusters`
-   *   - `AWS::ECS::Service` → `DescribeServices`. Service physicalIds use
-   *     the composite form `<clusterArn>|<serviceName>`; we split on `|`.
+   *   - `AWS::ECS::Service` → `DescribeServices`. Service physicalIds come in
+   *     two forms — the service ARN (what `createService` stores) and the
+   *     composite `<clusterArn>|<serviceName>` — and both are accepted (#1170).
    *   - `AWS::ECS::TaskDefinition` → `DescribeTaskDefinition`
    *
    * Each branch surfaces only the keys cdkd's `create()` accepts, mapping
@@ -1987,11 +2007,26 @@ export class ECSProvider implements ResourceProvider {
   private async readCurrentStateService(
     physicalId: string
   ): Promise<Record<string, unknown> | undefined> {
-    // Service physicalId is `<clusterArn>|<serviceName>` (composite form).
+    // Service physicalId can be either the composite form `<clusterArn>|<serviceName>`
+    // or the service ARN. `createService` stores the ARN (which has no `|`), so a
+    // clusterArn|name split alone made `cdkd drift` report every cdkd-created
+    // Service as drift-unknown (issue #1170). Accept BOTH: the composite form
+    // still splits on `|`, while the ARN form derives the cluster from the ARN
+    // (DescribeServices scopes to that cluster, falling back to the default
+    // cluster when the legacy short-format ARN does not encode one).
+    // `cluster` holds a cluster ARN (composite form) or a cluster name (derived
+    // from the service ARN); DescribeServices accepts either, or the default
+    // cluster when undefined.
+    let cluster: string | undefined;
+    let serviceName: string;
     const sep = physicalId.indexOf('|');
-    if (sep < 0) return undefined;
-    const clusterArn = physicalId.substring(0, sep);
-    const serviceName = physicalId.substring(sep + 1);
+    if (sep >= 0) {
+      cluster = physicalId.substring(0, sep);
+      serviceName = physicalId.substring(sep + 1);
+    } else {
+      serviceName = physicalId;
+      cluster = clusterNameFromServiceArn(physicalId);
+    }
 
     let resp: {
       services?: Array<{
@@ -2019,7 +2054,7 @@ export class ECSProvider implements ResourceProvider {
     try {
       resp = (await this.getClient().send(
         new DescribeServicesCommand({
-          cluster: clusterArn,
+          cluster,
           services: [serviceName],
           include: ['TAGS'],
         })
@@ -2185,10 +2220,11 @@ export class ECSProvider implements ResourceProvider {
    * `AWS::ECS::TaskDefinition` — all explicit-override only (see the
    * per-branch notes on why the `aws:cdk:path` tag walk was removed).
    *
-   * Service has a composite physical id of `<clusterArn>|<serviceName>`
-   * (the form ECSProvider uses internally for mutation operations),
-   * so the explicit-override path takes that composite form when
-   * supplied.
+   * `createService` stores the service ARN as the Service physical id (and
+   * the mutation ops pass it straight through as the `service` argument, with
+   * the cluster read from the template `Cluster` property). The explicit
+   * `--resource` override is honored verbatim, so a caller may also supply the
+   * composite `<clusterArn>|<serviceName>` form that `readCurrentState` accepts.
    */
   async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {
     switch (input.resourceType) {
@@ -2229,8 +2265,9 @@ export class ECSProvider implements ResourceProvider {
   }
 
   private async importService(input: ResourceImportInput): Promise<ResourceImportResult | null> {
-    // Service physical id is `<clusterArn>|<serviceName>` (cdkd internal
-    // composite form). Explicit override is honored as-is.
+    // `createService` stores the service ARN as the physical id; an explicit
+    // override is honored as-is (the composite `<clusterArn>|<serviceName>`
+    // form is also accepted by readCurrentState).
     if (input.knownPhysicalId) {
       return { physicalId: input.knownPhysicalId, attributes: {} };
     }

--- a/tests/integration/ecs-service-update-props/verify.sh
+++ b/tests/integration/ecs-service-update-props/verify.sh
@@ -25,6 +25,15 @@
 #         `properties` (PascalCase). Phase 1b asserts the deploy-time
 #         observedProperties baseline (captured FROM readCurrentState) carries
 #         the nested RuntimePlatform in CFn PascalCase.
+#   #1170 (Service readCurrentState accepts the ARN physicalId): the Service
+#         physicalId `createService` stores is the service ARN, but
+#         readCurrentStateService only understood the composite
+#         `<clusterArn>|<serviceName>` form and returned undefined for the ARN,
+#         so every cdkd-created Service read back as drift-unknown and NO
+#         observedProperties were captured for it. Phase 1c asserts the
+#         Service's deploy-time observedProperties ARE captured (proving the
+#         ARN-form read works) AND carry DeploymentConfiguration in CFn
+#         PascalCase.
 #
 # The Service in this fixture is deliberately plain (no
 # ServiceConnectConfiguration / VolumeConfigurations) so it stays on cdkd's
@@ -290,11 +299,11 @@ echo "    OK: base #1165 TaskDefinition on AWS is runtimePlatform.cpuArchitectur
 #
 # (A whole-stack `cdkd drift` assertion is deliberately NOT used: this fixture's
 # TaskDefinition also carries ContainerDefinitions, which readCurrentState still
-# surfaces as raw SDK camelCase — a larger structural gap out of #1167 scope —
-# and the ECS Service reads back drift-unknown because its physicalId is the ARN
-# rather than the composite `<clusterArn>|<serviceName>` form readCurrentState
-# expects; both would make a whole-stack drift assertion fail for reasons
-# unrelated to #1167.)
+# surfaces as raw SDK camelCase — a larger structural gap tracked by #1169 —
+# so a whole-stack drift assertion would still phantom-drift on the
+# TaskDefinition for reasons unrelated to the Service. The Service side is
+# proven directly by Phase 1c below: #1170 makes its ARN-form physicalId read
+# back, so its observedProperties are now captured.)
 echo "==> Phase 1b: assert deploy-time observedProperties captured RuntimePlatform in CFn PascalCase (#1167 readCurrentState reverse-map)"
 OBS_STATE=$(aws s3 cp "s3://${STATE_BUCKET}/${STATE_KEY}" -)
 OBS_CPU_ARCH=$(echo "${OBS_STATE}" | jq -r '[.resources[] | select(.resourceType=="AWS::ECS::TaskDefinition") | .observedProperties.RuntimePlatform.CpuArchitecture] | first // "MISSING"')
@@ -312,6 +321,26 @@ if [ "${OBS_EPHEMERAL}" != "30" ]; then
   exit 1
 fi
 echo "    OK: deploy-time observedProperties captured RuntimePlatform.CpuArchitecture=ARM64 + EphemeralStorage.SizeInGiB=30 in CFn PascalCase (#1167 readCurrentState reverse-map verified against real AWS)"
+
+# --- Phase 1c: Service observedProperties captured via ARN-form physicalId ----
+# #1170: `createService` stores the service ARN as the physicalId, but
+# `readCurrentStateService` only understood the composite
+# `<clusterArn>|<serviceName>` form and returned undefined for the ARN. That
+# made `cdkd drift` report every cdkd-created Service as drift-unknown AND meant
+# NO observedProperties were captured for the Service at deploy time. After the
+# fix the ARN-form read works, so the Service's observedProperties are present.
+# We assert a nested field (DeploymentConfiguration.MaximumPercent = 150, set in
+# phase 1) so the check also confirms the #1167 nested reverse-map ran on the
+# Service read path. Before #1170 the whole `observedProperties` object would be
+# absent for the Service, so this lookup would be MISSING.
+echo "==> Phase 1c: assert Service observedProperties captured via ARN-form physicalId (#1170)"
+OBS_SVC_MAXPCT=$(echo "${OBS_STATE}" | jq -r '[.resources[] | select(.resourceType=="AWS::ECS::Service") | .observedProperties.DeploymentConfiguration.MaximumPercent] | first // "MISSING"')
+if [ "${OBS_SVC_MAXPCT}" != "150" ]; then
+  echo "FAIL: Service observedProperties.DeploymentConfiguration.MaximumPercent is '${OBS_SVC_MAXPCT}', expected '150' (#1170 readCurrentStateService did NOT read back the ARN-form physicalId, so no observedProperties were captured for the Service)" >&2
+  echo "${OBS_STATE}" | jq '[.resources[] | select(.resourceType=="AWS::ECS::Service") | {physicalId, hasObserved: (.observedProperties != null)}] | first'
+  exit 1
+fi
+echo "    OK: Service observedProperties captured (DeploymentConfiguration.MaximumPercent=150) — ARN-form readCurrentState verified against real AWS (#1170)"
 
 # --- Phase 2: UPDATE pass (issue #975 add-on-update + #1160 reset-on-removal) --
 echo "==> Phase 2: redeploy with CDKD_TEST_UPDATE=true (flip EnableECSManagedTags + PropagateTags; DROP PlatformVersion / grace)"

--- a/tests/unit/provisioning/ecs-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/ecs-provider-readcurrentstate.test.ts
@@ -114,6 +114,61 @@ describe('ECSProvider.readCurrentState', () => {
     });
   });
 
+  it('accepts a bare service ARN physicalId and scopes DescribeServices to the ARN cluster (issue #1170)', async () => {
+    // `createService` stores the service ARN (no `|`), so `readCurrentState`
+    // must accept the ARN form or every cdkd-created Service reads back as
+    // drift-unknown. The cluster is derived from the long-format ARN.
+    mockSend.mockResolvedValueOnce({
+      services: [
+        {
+          serviceName: 'my-svc',
+          clusterArn: 'arn:aws:ecs:us-east-1:123:cluster/my-cluster',
+          taskDefinition: 'arn:aws:ecs:us-east-1:123:task-definition/td:1',
+          desiredCount: 2,
+          launchType: 'FARGATE',
+        },
+      ],
+    });
+
+    const result = await provider.readCurrentState(
+      'arn:aws:ecs:us-east-1:123:service/my-cluster/my-svc',
+      'SvcLogical',
+      'AWS::ECS::Service'
+    );
+
+    const cmd = mockSend.mock.calls[0]?.[0];
+    expect(cmd).toBeInstanceOf(DescribeServicesCommand);
+    // Cluster derived from the ARN, service name is the full ARN.
+    expect((cmd as DescribeServicesCommand).input).toMatchObject({
+      cluster: 'my-cluster',
+      services: ['arn:aws:ecs:us-east-1:123:service/my-cluster/my-svc'],
+    });
+    expect(result).not.toBeUndefined();
+    expect(result?.['ServiceName']).toBe('my-svc');
+  });
+
+  it('accepts a short-format service ARN physicalId and falls back to the default cluster (issue #1170)', async () => {
+    // Legacy short-format ARN does not encode a cluster; the reader must not
+    // return undefined — it passes an undefined cluster (AWS default cluster).
+    mockSend.mockResolvedValueOnce({
+      services: [{ serviceName: 'my-svc', desiredCount: 1, launchType: 'FARGATE' }],
+    });
+
+    const result = await provider.readCurrentState(
+      'arn:aws:ecs:us-east-1:123:service/my-svc',
+      'SvcLogical',
+      'AWS::ECS::Service'
+    );
+
+    const cmd = mockSend.mock.calls[0]?.[0];
+    expect(cmd).toBeInstanceOf(DescribeServicesCommand);
+    expect((cmd as DescribeServicesCommand).input.cluster).toBeUndefined();
+    expect((cmd as DescribeServicesCommand).input.services).toEqual([
+      'arn:aws:ecs:us-east-1:123:service/my-svc',
+    ]);
+    expect(result?.['ServiceName']).toBe('my-svc');
+  });
+
   it('returns CFn-shaped TaskDefinition fields from DescribeTaskDefinition', async () => {
     mockSend.mockResolvedValueOnce({
       taskDefinition: {

--- a/tests/unit/provisioning/ecs-provider.test.ts
+++ b/tests/unit/provisioning/ecs-provider.test.ts
@@ -1617,6 +1617,36 @@ describe('ECSProvider', () => {
         expect(mockSend).toHaveBeenCalledTimes(1);
       });
     });
+
+    describe('getAttribute', () => {
+      it('scopes DescribeServices to the cluster derived from the service ARN (issue #1170)', async () => {
+        // Without the cluster, DescribeServices defaults to the `default`
+        // cluster and a Service in a named cluster comes back MISSING. The
+        // cluster is derived from the long-format service ARN.
+        mockSend.mockResolvedValueOnce({
+          services: [
+            {
+              serviceArn: 'arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service',
+              serviceName: 'my-service',
+            },
+          ],
+        });
+
+        const arn = await provider.getAttribute(
+          'arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service',
+          'AWS::ECS::Service',
+          'ServiceArn'
+        );
+
+        const call = mockSend.mock.calls[0][0];
+        expect(call.constructor.name).toBe('DescribeServicesCommand');
+        expect(call.input.cluster).toBe('my-cluster');
+        expect(call.input.services).toEqual([
+          'arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service',
+        ]);
+        expect(arn).toBe('arn:aws:ecs:us-east-1:123456789012:service/my-cluster/my-service');
+      });
+    });
   });
 
   // ─── Unsupported resource type ──────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #1170.

`ECSProvider.readCurrentStateService` only understood the composite physicalId
form `<clusterArn>|<serviceName>` and returned `undefined` when there was no
`|`. But `createService` stores the service **ARN** (which has no `|`), so for
every cdkd-created ECS Service `readCurrentState` returned `undefined`: `cdkd
drift` reported the Service as **drift-unknown** and no `observedProperties`
were captured for it at deploy time.

The fix makes the **reader** accept both forms (the safer direction the issue
recommends — the mutation ops already pass the ARN straight through as the
`service` argument, with the cluster read from the template `Cluster` property,
so what `createService` stores is unchanged):

- Add `clusterNameFromServiceArn` to derive the cluster from a long-format
  service ARN (`arn:...:service/<clusterName>/<serviceName>`).
- `readCurrentStateService` splits on `|` (composite form) OR derives the
  cluster from the ARN, falling back to the default cluster for the legacy
  short-format ARN.
- Also fix the sibling `getServiceAttribute` gap surfaced in review: it issued
  `DescribeServices` with no cluster, so a Service in a named (non-default)
  cluster came back MISSING and `getAttribute` returned `undefined`. It now
  derives the cluster via the same helper.

## Test plan

- **Unit**: long- and short-format ARN physicalId round-trip in
  `readCurrentState`; `getAttribute` scopes `DescribeServices` to the ARN
  cluster. Full suite green (7634 tests).
- **Integ** (`ecs-service-update-props`, real AWS `us-east-1`): new Phase 1c
  asserts the Service's deploy-time `observedProperties` ARE now captured
  (`DeploymentConfiguration.MaximumPercent=150`) — this lookup was MISSING
  before the fix because `readCurrentState` returned `undefined` for the
  ARN-form physicalId. Deploy 15 / update 1 / destroy 15, **0 errors, 0
  orphans**; re-run after the `getServiceAttribute` polish also clean.

## Notes

- `#1169` (TaskDefinition `ContainerDefinitions` still surfaced as raw SDK
  camelCase) is the sibling follow-up and is intentionally out of scope here;
  the fixture's comment points a whole-stack `cdkd drift` assertion at that
  gap.
