### PR TITLE
fix(providers): reverse-map ECS ContainerDefinitions to CFn PascalCase on readCurrentState (#1169)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -83,7 +83,7 @@ ec2-vpc	2026-06-21T11:12:35Z	PASS	53	standard	sweep-F staleness re-run (rc=0)
 ecr	2026-06-21T11:00:28Z	PASS	39	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 ecr-scanning	2026-07-20T17:37:23Z	PASS	56	verify.sh	ECR scanOnPush + tag add/change/untag update, clean destroy
 ecs-fargate	2026-07-02T18:23:15Z	PASS	373	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
-ecs-service-update-props	2026-07-23T07:13:07Z	PASS		verify.sh	#1170 re-run after getServiceAttribute polish; destroy 15 del 0 err 0 orph
+ecs-service-update-props	2026-07-23T07:43:53Z	PASS		verify.sh	#1169 Phase1d/1e ContainerDefinitions drift-clean; destroy 15 del 0 err 0 orph
 efs-immutable-replacement	2026-07-19T19:05:41Z	PASS	76	verify.sh	rc ok, 1 deleted, orph clean
 efs-lambda	2026-06-21T14:48:46Z	PASS	560	standard	sweep-G standard re-run (rc=0)
 efs-standalone	2026-06-21T16:16:44Z	PASS	135	verify.sh	stale-real re-run; 11 deleted 0 err; clean

--- a/src/provisioning/providers/ecs-provider.ts
+++ b/src/provisioning/providers/ecs-provider.ts
@@ -1666,8 +1666,14 @@ export class ECSProvider implements ResourceProvider {
    *   2. AWS-defaulted-empty divergences are normalized away — `Cpu: 0`, empty
    *      arrays (`PortMappings` / `Environment` / ...), and an empty
    *      `LinuxParameters.Capabilities: {Add:[],Drop:[]}` are dropped so they
-   *      equal "absent" (what the template has). This keeps the `properties`
-   *      fallback baseline (pre-observedProperties state) drift-clean too.
+   *      equal "absent" (what the template has). AWS returns these defaults on
+   *      EVERY read, so without this the `properties` fallback baseline
+   *      (pre-observedProperties state) would phantom-drift on every run; the
+   *      normalization trades that for a rare edge — a template that EXPLICITLY
+   *      sets one of these to its empty/zero default AND has no observed baseline
+   *      (CDK L2 never emits e.g. an explicit `Cpu: 0`). On the normal
+   *      `observedProperties` path both sides run through this reader, so the
+   *      snapshot is self-consistent regardless.
    *
    * Free-form maps (`DockerLabels`, `LogConfiguration.Options`) are copied
    * verbatim — their keys are user data (log-driver options / container labels),

--- a/src/provisioning/providers/ecs-provider.ts
+++ b/src/provisioning/providers/ecs-provider.ts
@@ -1651,6 +1651,137 @@ export class ECSProvider implements ResourceProvider {
   }
 
   /**
+   * Reverse of `convertContainerDefinitions` for `readCurrentState` (issue
+   * #1169). Emits CFn PascalCase so the drift baseline (state `properties`
+   * PascalCase, or `observedProperties` captured via this same reader) compares
+   * apples-to-apples instead of phantom-drifting on the whole array — the drift
+   * comparator compares arrays wholesale via `deepEqual`, so the previous raw
+   * SDK camelCase read (`result['ContainerDefinitions'] = td.containerDefinitions`)
+   * never matched a PascalCase baseline.
+   *
+   * Two rules keep the read side matching a template that omits AWS's defaults:
+   *   1. Only the fields `convertContainerDefinitions` can SET are emitted, so
+   *      the round-trip is symmetric — a field cdkd cannot set is never surfaced
+   *      as drift against a template that lacks it.
+   *   2. AWS-defaulted-empty divergences are normalized away — `Cpu: 0`, empty
+   *      arrays (`PortMappings` / `Environment` / ...), and an empty
+   *      `LinuxParameters.Capabilities: {Add:[],Drop:[]}` are dropped so they
+   *      equal "absent" (what the template has). This keeps the `properties`
+   *      fallback baseline (pre-observedProperties state) drift-clean too.
+   *
+   * Free-form maps (`DockerLabels`, `LogConfiguration.Options`) are copied
+   * verbatim — their keys are user data (log-driver options / container labels),
+   * NOT CFn property names, so they must not be case-flipped.
+   */
+  private containerDefinitionsToCfn(defs?: ContainerDefinition[]): Array<Record<string, unknown>> {
+    if (!defs) return [];
+    return defs.map((c) => {
+      const out: Record<string, unknown> = {};
+      if (c.name !== undefined) out['Name'] = c.name;
+      if (c.image !== undefined) out['Image'] = c.image;
+      // Cpu 0 is the AWS default for a container that omits it; drop so it
+      // matches a template without an explicit Cpu.
+      if (c.cpu !== undefined && c.cpu !== 0) out['Cpu'] = c.cpu;
+      if (c.memory !== undefined) out['Memory'] = c.memory;
+      if (c.memoryReservation !== undefined) out['MemoryReservation'] = c.memoryReservation;
+      if (c.essential !== undefined) out['Essential'] = c.essential;
+      if (c.command && c.command.length > 0) out['Command'] = [...c.command];
+      if (c.entryPoint && c.entryPoint.length > 0) out['EntryPoint'] = [...c.entryPoint];
+      if (c.environment && c.environment.length > 0) {
+        out['Environment'] = c.environment.map((e) => ({ Name: e.name, Value: e.value }));
+      }
+      if (c.environmentFiles && c.environmentFiles.length > 0) {
+        out['EnvironmentFiles'] = c.environmentFiles.map((e) => ({ Type: e.type, Value: e.value }));
+      }
+      if (c.secrets && c.secrets.length > 0) {
+        out['Secrets'] = c.secrets.map((s) => ({ Name: s.name, ValueFrom: s.valueFrom }));
+      }
+      if (c.portMappings && c.portMappings.length > 0) {
+        out['PortMappings'] = camelToPascalCaseKeys(c.portMappings);
+      }
+      if (c.mountPoints && c.mountPoints.length > 0) {
+        out['MountPoints'] = camelToPascalCaseKeys(c.mountPoints);
+      }
+      if (c.volumesFrom && c.volumesFrom.length > 0) {
+        out['VolumesFrom'] = camelToPascalCaseKeys(c.volumesFrom);
+      }
+      if (c.dependsOn && c.dependsOn.length > 0) {
+        out['DependsOn'] = camelToPascalCaseKeys(c.dependsOn);
+      }
+      if (c.links && c.links.length > 0) out['Links'] = [...c.links];
+      if (c.workingDirectory !== undefined) out['WorkingDirectory'] = c.workingDirectory;
+      if (c.disableNetworking !== undefined) out['DisableNetworking'] = c.disableNetworking;
+      if (c.privileged !== undefined) out['Privileged'] = c.privileged;
+      if (c.readonlyRootFilesystem !== undefined) {
+        out['ReadonlyRootFilesystem'] = c.readonlyRootFilesystem;
+      }
+      if (c.user !== undefined) out['User'] = c.user;
+      if (c.ulimits && c.ulimits.length > 0) out['Ulimits'] = camelToPascalCaseKeys(c.ulimits);
+      if (c.logConfiguration) {
+        out['LogConfiguration'] = this.logConfigurationToCfn(c.logConfiguration);
+      }
+      if (c.healthCheck) out['HealthCheck'] = camelToPascalCaseKeys(c.healthCheck);
+      if (c.linuxParameters) {
+        const lp = this.linuxParametersToCfn(c.linuxParameters);
+        if (Object.keys(lp).length > 0) out['LinuxParameters'] = lp;
+      }
+      if (c.dockerLabels && Object.keys(c.dockerLabels).length > 0) {
+        out['DockerLabels'] = { ...c.dockerLabels };
+      }
+      if (c.startTimeout !== undefined) out['StartTimeout'] = c.startTimeout;
+      if (c.stopTimeout !== undefined) out['StopTimeout'] = c.stopTimeout;
+      if (c.interactive !== undefined) out['Interactive'] = c.interactive;
+      if (c.pseudoTerminal !== undefined) out['PseudoTerminal'] = c.pseudoTerminal;
+      return out;
+    });
+  }
+
+  /**
+   * Reverse of `convertLogConfiguration` for `containerDefinitionsToCfn`.
+   * `LogDriver` flips; `Options` is a free-form log-driver option map copied
+   * verbatim (its keys, e.g. `awslogs-group`, are NOT CFn property names);
+   * `SecretOptions` is a `{Name, ValueFrom}[]` list. Emit-when-present so an
+   * absent / empty sub-field does not phantom-drift.
+   */
+  private logConfigurationToCfn(lc: LogConfiguration): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    if (lc.logDriver !== undefined) out['LogDriver'] = lc.logDriver;
+    if (lc.options && Object.keys(lc.options).length > 0) out['Options'] = { ...lc.options };
+    if (lc.secretOptions && lc.secretOptions.length > 0) {
+      out['SecretOptions'] = lc.secretOptions.map((s) => ({
+        Name: s.name,
+        ValueFrom: s.valueFrom,
+      }));
+    }
+    return out;
+  }
+
+  /**
+   * Reverse of `convertLinuxParameters` for `containerDefinitionsToCfn`. The
+   * SET side is a mechanical first-letter flip (`pascalToCamelCaseKeys`), so the
+   * read side is the inverse `camelToPascalCaseKeys` — plus normalization of the
+   * AWS-defaulted-empty `Capabilities` / `Devices` / `Tmpfs`: AWS returns
+   * `capabilities: {add:[], drop:[]}` even when the template set neither, so the
+   * empty `Add` / `Drop` (and an otherwise-empty `Capabilities`) and empty
+   * `Devices` / `Tmpfs` arrays are dropped to equal a template that omits them.
+   */
+  private linuxParametersToCfn(lp: LinuxParameters): Record<string, unknown> {
+    const out = camelToPascalCaseKeys(lp) as Record<string, unknown>;
+    const caps = out['Capabilities'] as Record<string, unknown> | undefined;
+    if (caps) {
+      const normalized: Record<string, unknown> = {};
+      if (Array.isArray(caps['Add']) && caps['Add'].length > 0) normalized['Add'] = caps['Add'];
+      if (Array.isArray(caps['Drop']) && caps['Drop'].length > 0) normalized['Drop'] = caps['Drop'];
+      if (Object.keys(normalized).length > 0) out['Capabilities'] = normalized;
+      else delete out['Capabilities'];
+    }
+    for (const key of ['Devices', 'Tmpfs']) {
+      if (Array.isArray(out[key]) && (out[key] as unknown[]).length === 0) delete out[key];
+    }
+    return out;
+  }
+
+  /**
    * Coerce a CFn boolean property to a real boolean at the wire boundary.
    * CFn templates can carry booleans as the strings "true" / "false"
    * (e.g. via Fn::Sub / parameter plumbing), so the SDK input must
@@ -2211,7 +2342,12 @@ export class ECSProvider implements ResourceProvider {
     if (td.enableFaultInjection !== undefined) {
       result['EnableFaultInjection'] = td.enableFaultInjection;
     }
-    result['ContainerDefinitions'] = td.containerDefinitions ?? [];
+    // Reverse-map the container definitions from SDK camelCase to CFn
+    // PascalCase (issue #1169). The previous raw `td.containerDefinitions`
+    // surfaced camelCase, so the drift comparator (which compares this array
+    // wholesale via deepEqual) phantom-drifted the whole block against the
+    // PascalCase baseline.
+    result['ContainerDefinitions'] = this.containerDefinitionsToCfn(td.containerDefinitions);
     const tags = normalizeAwsTagsToCfn(resp.tags);
     result['Tags'] = tags;
     return result;

--- a/tests/integration/ecs-service-update-props/verify.sh
+++ b/tests/integration/ecs-service-update-props/verify.sh
@@ -34,6 +34,15 @@
 #         Service's deploy-time observedProperties ARE captured (proving the
 #         ARN-form read works) AND carry DeploymentConfiguration in CFn
 #         PascalCase.
+#   #1169 (ContainerDefinitions reverse-map): readCurrentStateTaskDefinition
+#         surfaced the whole ContainerDefinitions array as raw SDK camelCase,
+#         while the drift baseline is CFn PascalCase, so `cdkd drift`
+#         phantom-drifted the TaskDefinition on ContainerDefinitions (the drift
+#         comparator compares arrays wholesale via deepEqual). Phase 1d asserts
+#         the deploy-time observedProperties.ContainerDefinitions is PascalCase
+#         (free-form log-driver option keys preserved, AWS-defaulted empties
+#         normalized), and Phase 1e runs a real `cdkd drift` asserting NO
+#         ContainerDefinitions drift.
 #
 # The Service in this fixture is deliberately plain (no
 # ServiceConnectConfiguration / VolumeConfigurations) so it stays on cdkd's
@@ -297,13 +306,12 @@ echo "    OK: base #1165 TaskDefinition on AWS is runtimePlatform.cpuArchitectur
 # lookup below would be MISSING — a robust, whole-stack-drift-free check that
 # readCurrentState round-trips the nested casing against real AWS.
 #
-# (A whole-stack `cdkd drift` assertion is deliberately NOT used: this fixture's
-# TaskDefinition also carries ContainerDefinitions, which readCurrentState still
-# surfaces as raw SDK camelCase — a larger structural gap tracked by #1169 —
-# so a whole-stack drift assertion would still phantom-drift on the
-# TaskDefinition for reasons unrelated to the Service. The Service side is
-# proven directly by Phase 1c below: #1170 makes its ARN-form physicalId read
-# back, so its observedProperties are now captured.)
+# (Phase 1c proves the Service side reads back (#1170); Phase 1d + 1e prove the
+# TaskDefinition ContainerDefinitions reverse-map (#1169). Phase 1e runs a real
+# `cdkd drift` and asserts it reports NO ContainerDefinitions drift — before
+# #1169 readCurrentState surfaced ContainerDefinitions as raw SDK camelCase,
+# which the drift comparator (wholesale array deepEqual) phantom-drifted against
+# the PascalCase baseline.)
 echo "==> Phase 1b: assert deploy-time observedProperties captured RuntimePlatform in CFn PascalCase (#1167 readCurrentState reverse-map)"
 OBS_STATE=$(aws s3 cp "s3://${STATE_BUCKET}/${STATE_KEY}" -)
 OBS_CPU_ARCH=$(echo "${OBS_STATE}" | jq -r '[.resources[] | select(.resourceType=="AWS::ECS::TaskDefinition") | .observedProperties.RuntimePlatform.CpuArchitecture] | first // "MISSING"')
@@ -341,6 +349,75 @@ if [ "${OBS_SVC_MAXPCT}" != "150" ]; then
   exit 1
 fi
 echo "    OK: Service observedProperties captured (DeploymentConfiguration.MaximumPercent=150) — ARN-form readCurrentState verified against real AWS (#1170)"
+
+# --- Phase 1d: TaskDefinition observedProperties.ContainerDefinitions PascalCase (#1169) --
+# #1169: readCurrentStateTaskDefinition surfaced the whole ContainerDefinitions
+# array as RAW SDK camelCase (`result['ContainerDefinitions'] =
+# td.containerDefinitions`), while the drift baseline is CFn PascalCase. Since
+# observedProperties is captured FROM readCurrentState, the deploy-time snapshot
+# must now carry PascalCase container keys (`Name` / `Image` /
+# `LogConfiguration.LogDriver` / `LinuxParameters.InitProcessEnabled`). Before
+# the fix these PascalCase lookups would be MISSING (the keys were camelCase).
+echo "==> Phase 1d: assert deploy-time observedProperties.ContainerDefinitions in CFn PascalCase (#1169 reverse-map)"
+CD_JQ='[.resources[] | select(.resourceType=="AWS::ECS::TaskDefinition") | .observedProperties.ContainerDefinitions[0]] | first'
+OBS_CD_NAME=$(echo "${OBS_STATE}" | jq -r "${CD_JQ}.Name // \"MISSING\"")
+OBS_CD_LOGDRIVER=$(echo "${OBS_STATE}" | jq -r "${CD_JQ}.LogConfiguration.LogDriver // \"MISSING\"")
+OBS_CD_INITPROC=$(echo "${OBS_STATE}" | jq -r "${CD_JQ}.LinuxParameters.InitProcessEnabled // \"MISSING\"")
+# The free-form awslogs option keys must be preserved verbatim (NOT case-flipped).
+OBS_CD_AWSLOGS_GROUP=$(echo "${OBS_STATE}" | jq -r "${CD_JQ}.LogConfiguration.Options.\"awslogs-group\" // \"MISSING\"")
+# camelCase leak guard: the lowercase `name` key must NOT be present.
+OBS_CD_CAMEL_NAME=$(echo "${OBS_STATE}" | jq -r "${CD_JQ} | has(\"name\")")
+
+if [ "${OBS_CD_NAME}" != "AppContainer" ]; then
+  echo "FAIL: TaskDefinition observedProperties.ContainerDefinitions[0].Name is '${OBS_CD_NAME}', expected 'AppContainer' (#1169 readCurrentState did NOT reverse-map ContainerDefinitions to CFn PascalCase)" >&2
+  echo "${OBS_STATE}" | jq "${CD_JQ}"
+  exit 1
+fi
+if [ "${OBS_CD_LOGDRIVER}" != "awslogs" ]; then
+  echo "FAIL: TaskDefinition observedProperties.ContainerDefinitions[0].LogConfiguration.LogDriver is '${OBS_CD_LOGDRIVER}', expected 'awslogs' (#1169 reverse-map)" >&2
+  exit 1
+fi
+if [ "${OBS_CD_INITPROC}" != "true" ]; then
+  echo "FAIL: TaskDefinition observedProperties.ContainerDefinitions[0].LinuxParameters.InitProcessEnabled is '${OBS_CD_INITPROC}', expected 'true' (#1169 reverse-map of nested LinuxParameters)" >&2
+  exit 1
+fi
+if [ "${OBS_CD_AWSLOGS_GROUP}" = "MISSING" ]; then
+  echo "FAIL: TaskDefinition observedProperties.ContainerDefinitions[0].LogConfiguration.Options.awslogs-group is MISSING (#1169 must preserve free-form log-driver option keys verbatim)" >&2
+  echo "${OBS_STATE}" | jq "${CD_JQ}.LogConfiguration"
+  exit 1
+fi
+if [ "${OBS_CD_CAMEL_NAME}" = "true" ]; then
+  echo "FAIL: TaskDefinition observedProperties.ContainerDefinitions[0] carries a camelCase 'name' key (#1169 reverse-map leaked SDK camelCase)" >&2
+  exit 1
+fi
+echo "    OK: observedProperties.ContainerDefinitions[0] captured in CFn PascalCase (Name/LogDriver/InitProcessEnabled), free-form awslogs option keys preserved, no camelCase leak (#1169)"
+
+# --- Phase 1e: `cdkd drift` reports NO ContainerDefinitions drift (#1169) --
+# End-to-end proof against real AWS: with the reverse-map + AWS-defaulted-empty
+# normalization, a `cdkd drift` right after deploy must not phantom-drift the
+# TaskDefinition on ContainerDefinitions. drift is state-driven (no synth) and
+# exits 1 if ANY resource drifts, so we capture the exit code and grep the
+# report for the specific symptom rather than gating on the whole-stack result
+# (unrelated CC-API drift on other resources must not fail this check).
+echo "==> Phase 1e: assert 'cdkd drift' reports NO ContainerDefinitions drift on the TaskDefinition (#1169)"
+set +e
+DRIFT_OUT=$(node "${LOCAL_DIST}" drift "${STACK}" \
+  --state-bucket "${STATE_BUCKET}" \
+  --region "${REGION}" 2>&1)
+DRIFT_RC=$?
+set -e
+# rc 0 = no drift, 1 = drift detected; rc 2 = command error (must not pass vacuously).
+if [ "${DRIFT_RC}" != "0" ] && [ "${DRIFT_RC}" != "1" ]; then
+  echo "FAIL: 'cdkd drift' exited ${DRIFT_RC} (command error, not a drift result) — cannot conclude anything about ContainerDefinitions" >&2
+  echo "${DRIFT_OUT}" | tail -20
+  exit 1
+fi
+if echo "${DRIFT_OUT}" | grep -q "ContainerDefinitions"; then
+  echo "FAIL: 'cdkd drift' reported ContainerDefinitions drift on the TaskDefinition (#1169 reverse-map did NOT round-trip against real AWS)" >&2
+  echo "${DRIFT_OUT}" | grep -B2 -A8 "ContainerDefinitions" | head -40
+  exit 1
+fi
+echo "    OK: 'cdkd drift' (rc=${DRIFT_RC}) reports NO ContainerDefinitions drift — reverse-map + normalization round-trip verified against real AWS (#1169)"
 
 # --- Phase 2: UPDATE pass (issue #975 add-on-update + #1160 reset-on-removal) --
 echo "==> Phase 2: redeploy with CDKD_TEST_UPDATE=true (flip EnableECSManagedTags + PropagateTags; DROP PlatformVersion / grace)"

--- a/tests/unit/provisioning/ecs-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/ecs-provider-readcurrentstate.test.ts
@@ -204,6 +204,123 @@ describe('ECSProvider.readCurrentState', () => {
     });
   });
 
+  // --- issue #1169: reverse-map ContainerDefinitions SDK camelCase -> CFn PascalCase ---
+  it('reverse-maps ContainerDefinitions to CFn PascalCase and normalizes AWS-defaulted empties (issue #1169)', async () => {
+    mockSend.mockResolvedValueOnce({
+      taskDefinition: {
+        family: 'my-td',
+        containerDefinitions: [
+          {
+            name: 'AppContainer',
+            image: 'public.ecr.aws/amazonlinux/amazonlinux:latest',
+            memory: 512,
+            essential: true,
+            command: ['echo', 'hello'],
+            // AWS-defaulted empties that must be dropped so they equal a
+            // template that omits them:
+            cpu: 0,
+            portMappings: [],
+            environment: [],
+            mountPoints: [],
+            volumesFrom: [],
+            systemControls: [],
+            logConfiguration: {
+              logDriver: 'awslogs',
+              // free-form option keys must be preserved verbatim (NOT flipped):
+              options: {
+                'awslogs-group': '/ecs/app',
+                'awslogs-region': 'us-east-1',
+                'awslogs-stream-prefix': 'cdkd',
+              },
+            },
+            linuxParameters: {
+              initProcessEnabled: true,
+              // AWS always returns the capability pair even when empty:
+              capabilities: { add: [], drop: [] },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = (await provider.readCurrentState(
+      'arn:aws:ecs:us-east-1:123:task-definition/my-td:1',
+      'TDLogical',
+      'AWS::ECS::TaskDefinition'
+    )) as Record<string, unknown>;
+
+    expect(result['ContainerDefinitions']).toEqual([
+      {
+        Name: 'AppContainer',
+        Image: 'public.ecr.aws/amazonlinux/amazonlinux:latest',
+        Memory: 512,
+        Essential: true,
+        Command: ['echo', 'hello'],
+        LogConfiguration: {
+          LogDriver: 'awslogs',
+          Options: {
+            'awslogs-group': '/ecs/app',
+            'awslogs-region': 'us-east-1',
+            'awslogs-stream-prefix': 'cdkd',
+          },
+        },
+        LinuxParameters: {
+          InitProcessEnabled: true,
+        },
+      },
+    ]);
+  });
+
+  it('reverse-maps populated ContainerDefinitions sub-lists to PascalCase (issue #1169)', async () => {
+    mockSend.mockResolvedValueOnce({
+      taskDefinition: {
+        family: 'my-td',
+        containerDefinitions: [
+          {
+            name: 'c1',
+            image: 'img',
+            cpu: 256,
+            environment: [{ name: 'FOO', value: 'bar' }],
+            secrets: [{ name: 'SEC', valueFrom: 'arn:aws:ssm:...:parameter/x' }],
+            portMappings: [{ containerPort: 8080, hostPort: 8080, protocol: 'tcp' }],
+            mountPoints: [{ sourceVolume: 'v', containerPath: '/data', readOnly: true }],
+            dependsOn: [{ containerName: 'c0', condition: 'START' }],
+            ulimits: [{ name: 'nofile', softLimit: 1024, hardLimit: 2048 }],
+            linuxParameters: {
+              initProcessEnabled: false,
+              capabilities: { add: ['NET_ADMIN'], drop: [] },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = (await provider.readCurrentState(
+      'arn:aws:ecs:us-east-1:123:task-definition/my-td:1',
+      'TDLogical',
+      'AWS::ECS::TaskDefinition'
+    )) as Record<string, unknown>;
+
+    expect(result['ContainerDefinitions']).toEqual([
+      {
+        Name: 'c1',
+        Image: 'img',
+        Cpu: 256,
+        Environment: [{ Name: 'FOO', Value: 'bar' }],
+        Secrets: [{ Name: 'SEC', ValueFrom: 'arn:aws:ssm:...:parameter/x' }],
+        PortMappings: [{ ContainerPort: 8080, HostPort: 8080, Protocol: 'tcp' }],
+        MountPoints: [{ SourceVolume: 'v', ContainerPath: '/data', ReadOnly: true }],
+        DependsOn: [{ ContainerName: 'c0', Condition: 'START' }],
+        Ulimits: [{ Name: 'nofile', SoftLimit: 1024, HardLimit: 2048 }],
+        LinuxParameters: {
+          InitProcessEnabled: false,
+          // non-empty Add survives; empty Drop is dropped:
+          Capabilities: { Add: ['NET_ADMIN'] },
+        },
+      },
+    ]);
+  });
+
   // --- issue #1167: reverse-map nested objects SDK camelCase -> CFn PascalCase ---
   // The drift baseline is state `properties` (PascalCase) or `observedProperties`;
   // readCurrentState must return PascalCase nested shapes so a resource whose


### PR DESCRIPTION
## Summary

Fixes #1169 (follow-up to #1167).

`ECSProvider.readCurrentStateTaskDefinition` surfaced the whole
`ContainerDefinitions` array as **raw SDK camelCase**
(`result['ContainerDefinitions'] = td.containerDefinitions`), while cdkd's drift
baseline (state `properties` PascalCase, or `observedProperties` captured via
`readCurrentState`) is CFn PascalCase. The drift comparator compares arrays
**wholesale via `deepEqual`**, so `cdkd drift` phantom-drifted the TaskDefinition
on `ContainerDefinitions`.

Add a `containerDefinitionsToCfn` reverse-mapper (inverse of
`convertContainerDefinitions`, analogous to the existing `volumesToCfn`):

- **Symmetric field set** — emits CFn PascalCase for exactly the fields
  `convertContainerDefinitions` can SET, so a field cdkd cannot set is never
  surfaced as drift against a template that lacks it.
- **AWS-defaulted-empty normalization** — `Cpu: 0`, empty sub-arrays
  (`PortMappings` / `Environment` / ...), and an empty
  `LinuxParameters.Capabilities: {Add:[],Drop:[]}` are dropped so they equal
  "absent". AWS returns these defaults on every read, so without this the
  `properties` fallback baseline would phantom-drift on every run; the
  normalization trades that common phantom-drift for a rare edge (a template
  that explicitly sets one of these to its empty/zero default AND has no observed
  baseline; CDK L2 never emits e.g. an explicit `Cpu: 0`).
- **Free-form maps preserved verbatim** — `DockerLabels` and
  `LogConfiguration.Options` keys are user data (container labels / log-driver
  options), NOT CFn property names, so they are copied without case-flipping.
- Sub-helpers `logConfigurationToCfn` / `linuxParametersToCfn`.

On the normal `observedProperties` path both sides run through this same reader,
so the snapshot is self-consistent regardless of the normalization.

## Test plan

- **Unit**: two tests assert the PascalCase output, the AWS-defaulted-empty
  normalization, free-form option-key preservation, the no-camelCase-leak guard,
  and populated sub-list reverse-mapping. Full suite green (7636 tests).
- **Integ** (`ecs-service-update-props`, real AWS `us-east-1`): new **Phase 1d**
  asserts the deploy-time `observedProperties.ContainerDefinitions[0]` is CFn
  PascalCase (`Name` / `LogConfiguration.LogDriver` / `LinuxParameters.InitProcessEnabled`,
  free-form `awslogs-group` option key preserved, no camelCase leak). New
  **Phase 1e** runs a real `cdkd drift` and asserts it reports **no
  `ContainerDefinitions` drift** — the end-to-end proof that the reverse-map +
  normalization round-trips against real AWS. Destroy 0 errors, 0 orphans.
