### PR TITLE
fix(providers): map previously-dropped ECS ContainerDefinition sub-fields (#1173)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -83,7 +83,7 @@ ec2-vpc	2026-06-21T11:12:35Z	PASS	53	standard	sweep-F staleness re-run (rc=0)
 ecr	2026-06-21T11:00:28Z	PASS	39	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 ecr-scanning	2026-07-20T17:37:23Z	PASS	56	verify.sh	ECR scanOnPush + tag add/change/untag update, clean destroy
 ecs-fargate	2026-07-02T18:23:15Z	PASS	373	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
-ecs-service-update-props	2026-07-23T07:43:53Z	PASS		verify.sh	#1169 Phase1d/1e ContainerDefinitions drift-clean; destroy 15 del 0 err 0 orph
+ecs-service-update-props	2026-07-23T08:11:17Z	PASS		verify.sh	#1173 Phase1f RestartPolicy write+read round-trip; destroy 15 del 0 err 0 orph
 efs-immutable-replacement	2026-07-19T19:05:41Z	PASS	76	verify.sh	rc ok, 1 deleted, orph clean
 efs-lambda	2026-06-21T14:48:46Z	PASS	560	standard	sweep-G standard re-run (rc=0)
 efs-standalone	2026-06-21T16:16:44Z	PASS	135	verify.sh	stale-real re-run; 11 deleted 0 err; clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -83,7 +83,7 @@ ec2-vpc	2026-06-21T11:12:35Z	PASS	53	standard	sweep-F staleness re-run (rc=0)
 ecr	2026-06-21T11:00:28Z	PASS	39	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 ecr-scanning	2026-07-20T17:37:23Z	PASS	56	verify.sh	ECR scanOnPush + tag add/change/untag update, clean destroy
 ecs-fargate	2026-07-02T18:23:15Z	PASS	373	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
-ecs-service-update-props	2026-07-23T08:11:17Z	PASS		verify.sh	#1173 Phase1f RestartPolicy write+read round-trip; destroy 15 del 0 err 0 orph
+ecs-service-update-props	2026-07-23T08:20:10Z	PASS		verify.sh	#1173 re-run after VersionConsistency norm; Phase1f + drift clean; destroy 15 del 0 err 0 orph
 efs-immutable-replacement	2026-07-19T19:05:41Z	PASS	76	verify.sh	rc ok, 1 deleted, orph clean
 efs-lambda	2026-06-21T14:48:46Z	PASS	560	standard	sweep-G standard re-run (rc=0)
 efs-standalone	2026-06-21T16:16:44Z	PASS	135	verify.sh	stale-real re-run; 11 deleted 0 err; clean

--- a/src/provisioning/providers/ecs-provider.ts
+++ b/src/provisioning/providers/ecs-provider.ts
@@ -1830,7 +1830,13 @@ export class ECSProvider implements ResourceProvider {
         out['CredentialSpecs'] = [...c.credentialSpecs];
       }
       if (c.hostname !== undefined) out['Hostname'] = c.hostname;
-      if (c.versionConsistency !== undefined) out['VersionConsistency'] = c.versionConsistency;
+      // AWS returns `versionConsistency: 'enabled'` by default even when the
+      // template omits it, so drop that default to equal "absent" (mirrors the
+      // Cpu: 0 / empty-array normalization above); a non-default 'disabled'
+      // still surfaces so real drift is caught.
+      if (c.versionConsistency !== undefined && c.versionConsistency !== 'enabled') {
+        out['VersionConsistency'] = c.versionConsistency;
+      }
       return out;
     });
   }

--- a/src/provisioning/providers/ecs-provider.ts
+++ b/src/provisioning/providers/ecs-provider.ts
@@ -62,6 +62,14 @@ import {
   type ContainerCondition,
   type EnvironmentFileType,
   type UlimitName,
+  type RepositoryCredentials,
+  type FirelensConfiguration,
+  type FirelensConfigurationType,
+  type ResourceRequirement,
+  type SystemControl,
+  type HostEntry,
+  type ContainerRestartPolicy,
+  type VersionConsistency,
 } from '@aws-sdk/client-ecs';
 import { getLogger } from '../../utils/logger.js';
 import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
@@ -1264,6 +1272,35 @@ export class ECSProvider implements ResourceProvider {
       stopTimeout: def['StopTimeout'] as number | undefined,
       interactive: def['Interactive'] as boolean | undefined,
       pseudoTerminal: def['PseudoTerminal'] as boolean | undefined,
+      // issue #1173: these container sub-fields were previously unmapped, so
+      // they were silently dropped on RegisterTaskDefinition. Each is a
+      // mechanical first-letter flip (pascalToCamelCaseKeys) EXCEPT
+      // FirelensConfiguration, whose `Options` is a free-form map whose keys
+      // are user data (NOT CFn property names) and must be copied verbatim.
+      repositoryCredentials: def['RepositoryCredentials']
+        ? (pascalToCamelCaseKeys(def['RepositoryCredentials']) as RepositoryCredentials)
+        : undefined,
+      firelensConfiguration: this.convertFirelensConfiguration(
+        def['FirelensConfiguration'] as Record<string, unknown> | undefined
+      ),
+      resourceRequirements: def['ResourceRequirements']
+        ? (pascalToCamelCaseKeys(def['ResourceRequirements']) as ResourceRequirement[])
+        : undefined,
+      systemControls: def['SystemControls']
+        ? (pascalToCamelCaseKeys(def['SystemControls']) as SystemControl[])
+        : undefined,
+      extraHosts: def['ExtraHosts']
+        ? (pascalToCamelCaseKeys(def['ExtraHosts']) as HostEntry[])
+        : undefined,
+      restartPolicy: def['RestartPolicy']
+        ? (pascalToCamelCaseKeys(def['RestartPolicy']) as ContainerRestartPolicy)
+        : undefined,
+      dnsServers: def['DnsServers'] as string[] | undefined,
+      dnsSearchDomains: def['DnsSearchDomains'] as string[] | undefined,
+      dockerSecurityOptions: def['DockerSecurityOptions'] as string[] | undefined,
+      credentialSpecs: def['CredentialSpecs'] as string[] | undefined,
+      hostname: def['Hostname'] as string | undefined,
+      versionConsistency: def['VersionConsistency'] as VersionConsistency | undefined,
     }));
   }
 
@@ -1397,6 +1434,23 @@ export class ECSProvider implements ResourceProvider {
       secretOptions: this.convertSecrets(
         config['SecretOptions'] as Array<Record<string, unknown>> | undefined
       ),
+    };
+  }
+
+  /**
+   * Convert CFn `ContainerDefinitions[].FirelensConfiguration` to the ECS SDK
+   * shape (issue #1173). `Type` flips to `type`, but `Options` is a free-form
+   * map of user-supplied FireLens options (e.g. `enable-ecs-log-metadata`,
+   * `config-file-value`) whose keys are NOT CFn property names, so it is copied
+   * verbatim rather than case-flipped.
+   */
+  private convertFirelensConfiguration(
+    config?: Record<string, unknown>
+  ): FirelensConfiguration | undefined {
+    if (!config) return undefined;
+    return {
+      type: config['Type'] as FirelensConfigurationType | undefined,
+      options: config['Options'] as Record<string, string> | undefined,
     };
   }
 
@@ -1738,6 +1792,45 @@ export class ECSProvider implements ResourceProvider {
       if (c.stopTimeout !== undefined) out['StopTimeout'] = c.stopTimeout;
       if (c.interactive !== undefined) out['Interactive'] = c.interactive;
       if (c.pseudoTerminal !== undefined) out['PseudoTerminal'] = c.pseudoTerminal;
+      // issue #1173: reverse-map the newly-settable sub-fields (see
+      // convertContainerDefinitions). FirelensConfiguration.Options is a
+      // free-form map copied verbatim; the rest are first-letter flips.
+      if (c.repositoryCredentials) {
+        out['RepositoryCredentials'] = camelToPascalCaseKeys(c.repositoryCredentials);
+      }
+      if (c.firelensConfiguration) {
+        const fc: Record<string, unknown> = {};
+        if (c.firelensConfiguration.type !== undefined) fc['Type'] = c.firelensConfiguration.type;
+        if (
+          c.firelensConfiguration.options &&
+          Object.keys(c.firelensConfiguration.options).length > 0
+        ) {
+          fc['Options'] = { ...c.firelensConfiguration.options };
+        }
+        if (Object.keys(fc).length > 0) out['FirelensConfiguration'] = fc;
+      }
+      if (c.resourceRequirements && c.resourceRequirements.length > 0) {
+        out['ResourceRequirements'] = camelToPascalCaseKeys(c.resourceRequirements);
+      }
+      if (c.systemControls && c.systemControls.length > 0) {
+        out['SystemControls'] = camelToPascalCaseKeys(c.systemControls);
+      }
+      if (c.extraHosts && c.extraHosts.length > 0) {
+        out['ExtraHosts'] = camelToPascalCaseKeys(c.extraHosts);
+      }
+      if (c.restartPolicy) out['RestartPolicy'] = camelToPascalCaseKeys(c.restartPolicy);
+      if (c.dnsServers && c.dnsServers.length > 0) out['DnsServers'] = [...c.dnsServers];
+      if (c.dnsSearchDomains && c.dnsSearchDomains.length > 0) {
+        out['DnsSearchDomains'] = [...c.dnsSearchDomains];
+      }
+      if (c.dockerSecurityOptions && c.dockerSecurityOptions.length > 0) {
+        out['DockerSecurityOptions'] = [...c.dockerSecurityOptions];
+      }
+      if (c.credentialSpecs && c.credentialSpecs.length > 0) {
+        out['CredentialSpecs'] = [...c.credentialSpecs];
+      }
+      if (c.hostname !== undefined) out['Hostname'] = c.hostname;
+      if (c.versionConsistency !== undefined) out['VersionConsistency'] = c.versionConsistency;
       return out;
     });
   }

--- a/tests/integration/ecs-service-update-props/lib/ecs-service-update-props-stack.ts
+++ b/tests/integration/ecs-service-update-props/lib/ecs-service-update-props-stack.ts
@@ -95,6 +95,19 @@ export class EcsServiceUpdatePropsStack extends cdk.Stack {
       }),
     });
 
+    // issue #1173: RestartPolicy is a ContainerDefinition sub-field that
+    // convertContainerDefinitions never mapped, so it was silently dropped on
+    // RegisterTaskDefinition. It is Fargate-compatible (platform 1.4.0+), so it
+    // registers on this task def. Injected via the L1 escape hatch (PascalCase)
+    // so the wire shape is exactly what a hand-written template emits; verify.sh
+    // reads it back via describe-task-definition AND asserts the deploy-time
+    // observedProperties captured it in CFn PascalCase.
+    const cfnTaskDef = taskDefinition.node.defaultChild as ecs.CfnTaskDefinition;
+    cfnTaskDef.addPropertyOverride('ContainerDefinitions.0.RestartPolicy', {
+      Enabled: true,
+      RestartAttemptPeriod: 60,
+    });
+
     // Plain Fargate Service (desiredCount: 0). NO serviceConnectConfiguration,
     // NO addVolume — stays SDK-routed.
     //

--- a/tests/integration/ecs-service-update-props/verify.sh
+++ b/tests/integration/ecs-service-update-props/verify.sh
@@ -43,6 +43,12 @@
 #         (free-form log-driver option keys preserved, AWS-defaulted empties
 #         normalized), and Phase 1e runs a real `cdkd drift` asserting NO
 #         ContainerDefinitions drift.
+#   #1173 (ContainerDefinition sub-field silent-drop): convertContainerDefinitions
+#         never mapped RestartPolicy (+ RepositoryCredentials / FirelensConfiguration
+#         / ResourceRequirements / SystemControls / ...), so they were silently
+#         dropped on RegisterTaskDefinition. Phase 1f sets RestartPolicy via the
+#         L1 escape hatch and asserts it (a) reached AWS and (b) round-tripped
+#         into observedProperties in CFn PascalCase.
 #
 # The Service in this fixture is deliberately plain (no
 # ServiceConnectConfiguration / VolumeConfigurations) so it stays on cdkd's
@@ -418,6 +424,31 @@ if echo "${DRIFT_OUT}" | grep -q "ContainerDefinitions"; then
   exit 1
 fi
 echo "    OK: 'cdkd drift' (rc=${DRIFT_RC}) reports NO ContainerDefinitions drift — reverse-map + normalization round-trip verified against real AWS (#1169)"
+
+# --- Phase 1f: RestartPolicy container sub-field write + read round-trip (#1173) --
+# #1173: convertContainerDefinitions never mapped RestartPolicy (and 11 other
+# container sub-fields), so they were silently dropped on RegisterTaskDefinition.
+# The fixture sets RestartPolicy via the L1 escape hatch. Assert (a) AWS actually
+# registered it (describe-task-definition) — before the fix it would be absent —
+# AND (b) the deploy-time observedProperties captured it back in CFn PascalCase
+# (the #1173 read-side reverse-map).
+echo "==> Phase 1f: assert RestartPolicy reached AWS + round-tripped into observedProperties (#1173)"
+AWS_RESTART_ENABLED=$(aws ecs describe-task-definition \
+  --task-definition "${TASKDEF_ARN}" --region "${REGION}" \
+  --query 'taskDefinition.containerDefinitions[0].restartPolicy.enabled' --output text 2>/dev/null)
+if [ "${AWS_RESTART_ENABLED}" != "True" ]; then
+  echo "FAIL: task definition containerDefinitions[0].restartPolicy.enabled is '${AWS_RESTART_ENABLED}', expected 'True' (#1173 RestartPolicy silently dropped on RegisterTaskDefinition)" >&2
+  aws ecs describe-task-definition --task-definition "${TASKDEF_ARN}" --region "${REGION}" \
+    --query 'taskDefinition.containerDefinitions[0].restartPolicy' | jq .
+  exit 1
+fi
+OBS_CD_RESTART=$(echo "${OBS_STATE}" | jq -r '[.resources[] | select(.resourceType=="AWS::ECS::TaskDefinition") | .observedProperties.ContainerDefinitions[0].RestartPolicy.Enabled] | first // "MISSING"')
+if [ "${OBS_CD_RESTART}" != "true" ]; then
+  echo "FAIL: TaskDefinition observedProperties.ContainerDefinitions[0].RestartPolicy.Enabled is '${OBS_CD_RESTART}', expected 'true' (#1173 read-side reverse-map did NOT surface RestartPolicy in CFn PascalCase)" >&2
+  echo "${OBS_STATE}" | jq '[.resources[] | select(.resourceType=="AWS::ECS::TaskDefinition") | .observedProperties.ContainerDefinitions[0]] | first'
+  exit 1
+fi
+echo "    OK: RestartPolicy registered on AWS (enabled=True) AND captured in observedProperties as CFn PascalCase RestartPolicy.Enabled=true (#1173 write + read round-trip verified against real AWS)"
 
 # --- Phase 2: UPDATE pass (issue #975 add-on-update + #1160 reset-on-removal) --
 echo "==> Phase 2: redeploy with CDKD_TEST_UPDATE=true (flip EnableECSManagedTags + PropagateTags; DROP PlatformVersion / grace)"

--- a/tests/unit/provisioning/ecs-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/ecs-provider-readcurrentstate.test.ts
@@ -321,6 +321,68 @@ describe('ECSProvider.readCurrentState', () => {
     ]);
   });
 
+  it('reverse-maps the #1173 ContainerDefinition sub-fields to PascalCase (issue #1173)', async () => {
+    mockSend.mockResolvedValueOnce({
+      taskDefinition: {
+        family: 'my-td',
+        containerDefinitions: [
+          {
+            name: 'c1',
+            image: 'img',
+            repositoryCredentials: {
+              credentialsParameter: 'arn:aws:secretsmanager:us-east-1:123:secret:reg',
+            },
+            firelensConfiguration: {
+              type: 'fluentbit',
+              options: { 'enable-ecs-log-metadata': 'true' },
+            },
+            resourceRequirements: [{ type: 'GPU', value: '1' }],
+            systemControls: [{ namespace: 'net.core.somaxconn', value: '1024' }],
+            extraHosts: [{ hostname: 'db.local', ipAddress: '10.0.0.5' }],
+            restartPolicy: { enabled: true, ignoredExitCodes: [1], restartAttemptPeriod: 60 },
+            dnsServers: ['10.0.0.2'],
+            dnsSearchDomains: ['example.internal'],
+            dockerSecurityOptions: ['label:user:me'],
+            credentialSpecs: ['credentialspecdomainless:arn:aws:...'],
+            hostname: 'web-host',
+            versionConsistency: 'disabled',
+          },
+        ],
+      },
+    });
+
+    const result = (await provider.readCurrentState(
+      'arn:aws:ecs:us-east-1:123:task-definition/my-td:1',
+      'TDLogical',
+      'AWS::ECS::TaskDefinition'
+    )) as Record<string, unknown>;
+
+    expect(result['ContainerDefinitions']).toEqual([
+      {
+        Name: 'c1',
+        Image: 'img',
+        RepositoryCredentials: {
+          CredentialsParameter: 'arn:aws:secretsmanager:us-east-1:123:secret:reg',
+        },
+        // free-form FireLens option keys preserved verbatim:
+        FirelensConfiguration: {
+          Type: 'fluentbit',
+          Options: { 'enable-ecs-log-metadata': 'true' },
+        },
+        ResourceRequirements: [{ Type: 'GPU', Value: '1' }],
+        SystemControls: [{ Namespace: 'net.core.somaxconn', Value: '1024' }],
+        ExtraHosts: [{ Hostname: 'db.local', IpAddress: '10.0.0.5' }],
+        RestartPolicy: { Enabled: true, IgnoredExitCodes: [1], RestartAttemptPeriod: 60 },
+        DnsServers: ['10.0.0.2'],
+        DnsSearchDomains: ['example.internal'],
+        DockerSecurityOptions: ['label:user:me'],
+        CredentialSpecs: ['credentialspecdomainless:arn:aws:...'],
+        Hostname: 'web-host',
+        VersionConsistency: 'disabled',
+      },
+    ]);
+  });
+
   // --- issue #1167: reverse-map nested objects SDK camelCase -> CFn PascalCase ---
   // The drift baseline is state `properties` (PascalCase) or `observedProperties`;
   // readCurrentState must return PascalCase nested shapes so a resource whose

--- a/tests/unit/provisioning/ecs-provider-readcurrentstate.test.ts
+++ b/tests/unit/provisioning/ecs-provider-readcurrentstate.test.ts
@@ -383,6 +383,26 @@ describe('ECSProvider.readCurrentState', () => {
     ]);
   });
 
+  it('drops the AWS-default VersionConsistency=enabled so it does not phantom-drift (issue #1173)', async () => {
+    // AWS returns versionConsistency: 'enabled' by default even when the
+    // template omits it; the read must drop the default (like Cpu: 0) so a
+    // template that omits it does not phantom-drift on the properties baseline.
+    mockSend.mockResolvedValueOnce({
+      taskDefinition: {
+        family: 'my-td',
+        containerDefinitions: [{ name: 'c1', image: 'img', versionConsistency: 'enabled' }],
+      },
+    });
+
+    const result = (await provider.readCurrentState(
+      'arn:aws:ecs:us-east-1:123:task-definition/my-td:1',
+      'TDLogical',
+      'AWS::ECS::TaskDefinition'
+    )) as Record<string, unknown>;
+
+    expect(result['ContainerDefinitions']).toEqual([{ Name: 'c1', Image: 'img' }]);
+  });
+
   // --- issue #1167: reverse-map nested objects SDK camelCase -> CFn PascalCase ---
   // The drift baseline is state `properties` (PascalCase) or `observedProperties`;
   // readCurrentState must return PascalCase nested shapes so a resource whose

--- a/tests/unit/provisioning/ecs-provider.test.ts
+++ b/tests/unit/provisioning/ecs-provider.test.ts
@@ -558,6 +558,19 @@ describe('ECSProvider', () => {
         expect(c.volumesFrom).toBeUndefined();
         expect(c.dependsOn).toBeUndefined();
         expect(c.ulimits).toBeUndefined();
+        // issue #1173 sub-fields also stay undefined when the template omits them:
+        expect(c.repositoryCredentials).toBeUndefined();
+        expect(c.firelensConfiguration).toBeUndefined();
+        expect(c.resourceRequirements).toBeUndefined();
+        expect(c.systemControls).toBeUndefined();
+        expect(c.extraHosts).toBeUndefined();
+        expect(c.restartPolicy).toBeUndefined();
+        expect(c.dnsServers).toBeUndefined();
+        expect(c.dnsSearchDomains).toBeUndefined();
+        expect(c.dockerSecurityOptions).toBeUndefined();
+        expect(c.credentialSpecs).toBeUndefined();
+        expect(c.hostname).toBeUndefined();
+        expect(c.versionConsistency).toBeUndefined();
       });
 
       it('forwards EnableFaultInjection=true onto RegisterTaskDefinition (#609 backfill)', async () => {

--- a/tests/unit/provisioning/ecs-provider.test.ts
+++ b/tests/unit/provisioning/ecs-provider.test.ts
@@ -476,6 +476,65 @@ describe('ECSProvider', () => {
         expect(c.ulimits).toEqual([{ name: 'nofile', softLimit: 1024, hardLimit: 2048 }]);
       });
 
+      it('maps the previously-dropped ContainerDefinition sub-fields to SDK camelCase (issue #1173)', async () => {
+        mockSend.mockResolvedValueOnce({
+          taskDefinition: {
+            taskDefinitionArn: 'arn:aws:ecs:us-east-1:123456789012:task-definition/subfields:1',
+          },
+        });
+
+        await provider.create('SubfieldsTask', 'AWS::ECS::TaskDefinition', {
+          Family: 'subfields',
+          ContainerDefinitions: [
+            {
+              Name: 'web',
+              Image: 'nginx:latest',
+              RepositoryCredentials: {
+                CredentialsParameter: 'arn:aws:secretsmanager:us-east-1:123:secret:reg',
+              },
+              FirelensConfiguration: {
+                Type: 'fluentbit',
+                // free-form keys must survive verbatim:
+                Options: { 'enable-ecs-log-metadata': 'true', 'config-file-value': '/extra.conf' },
+              },
+              ResourceRequirements: [{ Type: 'GPU', Value: '1' }],
+              SystemControls: [{ Namespace: 'net.core.somaxconn', Value: '1024' }],
+              ExtraHosts: [{ Hostname: 'db.local', IpAddress: '10.0.0.5' }],
+              RestartPolicy: { Enabled: true, IgnoredExitCodes: [1], RestartAttemptPeriod: 60 },
+              DnsServers: ['10.0.0.2'],
+              DnsSearchDomains: ['example.internal'],
+              DockerSecurityOptions: ['label:user:me'],
+              CredentialSpecs: ['credentialspecdomainless:arn:aws:...'],
+              Hostname: 'web-host',
+              VersionConsistency: 'disabled',
+            },
+          ],
+        });
+
+        const c = mockSend.mock.calls[0][0].input.containerDefinitions[0];
+        expect(c.repositoryCredentials).toEqual({
+          credentialsParameter: 'arn:aws:secretsmanager:us-east-1:123:secret:reg',
+        });
+        expect(c.firelensConfiguration).toEqual({
+          type: 'fluentbit',
+          options: { 'enable-ecs-log-metadata': 'true', 'config-file-value': '/extra.conf' },
+        });
+        expect(c.resourceRequirements).toEqual([{ type: 'GPU', value: '1' }]);
+        expect(c.systemControls).toEqual([{ namespace: 'net.core.somaxconn', value: '1024' }]);
+        expect(c.extraHosts).toEqual([{ hostname: 'db.local', ipAddress: '10.0.0.5' }]);
+        expect(c.restartPolicy).toEqual({
+          enabled: true,
+          ignoredExitCodes: [1],
+          restartAttemptPeriod: 60,
+        });
+        expect(c.dnsServers).toEqual(['10.0.0.2']);
+        expect(c.dnsSearchDomains).toEqual(['example.internal']);
+        expect(c.dockerSecurityOptions).toEqual(['label:user:me']);
+        expect(c.credentialSpecs).toEqual(['credentialspecdomainless:arn:aws:...']);
+        expect(c.hostname).toBe('web-host');
+        expect(c.versionConsistency).toBe('disabled');
+      });
+
       it('passes through undefined ContainerDefinition array fields without crashing', async () => {
         // Defensive — most container definitions don't set most of these
         // optional fields; the converter must not blow up on undefined.


### PR DESCRIPTION
## Summary

Fixes #1173.

`ECSProvider.convertContainerDefinitions` (the `RegisterTaskDefinition` SET path)
mapped only 30 of the SDK `ContainerDefinition` fields, so these 12
container-definition sub-properties were **silently dropped on register** (the
same silent-drop class as #1165, one level deeper — the top-level
`property-coverage` pre-flight does not descend into the `ContainerDefinitions`
array):

`RepositoryCredentials` (private registry auth), `FirelensConfiguration`
(FireLens custom logging), `ResourceRequirements` (GPU / InferenceAccelerator),
`SystemControls`, `ExtraHosts`, `DnsServers`, `DnsSearchDomains`,
`DockerSecurityOptions`, `Hostname`, `RestartPolicy`, `CredentialSpecs`,
`VersionConsistency`.

- **SET** (`convertContainerDefinitions`): map each field. A mechanical
  first-letter flip (`pascalToCamelCaseKeys`) for the structured ones, and an
  explicit `convertFirelensConfiguration` for `FirelensConfiguration` whose
  `Options` is a free-form map (user FireLens option keys, NOT CFn property
  names) that must be copied verbatim.
- **READ** (`containerDefinitionsToCfn`, the #1169 reverse-mapper): reverse-map
  them symmetrically so `cdkd drift` tracks the newly-settable fields too, and
  the SET/READ round-trip stays symmetric.

## Test plan

- **Unit**: a SET test asserts the 12 fields reach `RegisterTaskDefinition` in
  SDK camelCase (FireLens `Options` keys preserved verbatim); a READ test asserts
  the reverse-map back to CFn PascalCase; the "passes through undefined" test now
  also asserts the 12 fields stay `undefined` on a minimal container. Full suite
  green (7638 tests).
- **Integ** (`ecs-service-update-props`, real AWS `us-east-1`): the fixture sets
  `RestartPolicy` (Fargate-compatible) via the L1 escape hatch; new **Phase 1f**
  asserts (a) `describe-task-definition` returns `restartPolicy.enabled=True`
  (the write actually reached AWS — before the fix it was dropped) AND (b) the
  deploy-time `observedProperties.ContainerDefinitions[0].RestartPolicy.Enabled`
  is `true` (the read-side reverse-map). The pre-existing Phase 1e `cdkd drift`
  stays clean (RestartPolicy round-trips). Destroy 0 errors, 0 orphans.

Surfaced while working #1169.
