### PR TITLE
perf(providers): tighten remaining sparse poll-loop caps to 10s (#1176)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -205,7 +205,7 @@ recreate-mixed-direction	2026-07-21T05:15:35Z	PASS	100	verify.sh	rc ok, orph cle
 recreate-via-cc-api	2026-07-20T02:21:54Z	PASS	106	verify.sh	SDK->CC mid-life migration + S3 probe, destroy clean
 recreate-via-sdk-provider	2026-07-21T05:13:38Z	PASS	86	verify.sh	rc ok, orph clean
 redshift-cluster-getatt	2026-07-20T14:58:06Z	PASS	330	verify.sh	CC GetAtt Endpoint real hostname, 0 orphans
-remove-protection	2026-07-19T19:44:06Z	PASS	1351	verify.sh	rc ok, 11 deleted, ASG orphan terminated, orph clean
+remove-protection	2026-07-23T15:56:48Z	PASS		verify.sh	1176 poll-cap follow-up; ASG force-delete + VPC teardown clean, 0 orphans
 rename-refactor	2026-07-21T14:37:30Z	PASS	107	verify.sh	new fixture; review-fix re-run; destroy 0 err 0 orph
 replacement-fanout	2026-07-21T05:17:15Z	PASS	82	verify.sh	rc ok, orph clean
 replacement-immutable-name	2026-07-19T19:03:36Z	PASS	120	verify.sh	rc ok, 7 deleted, orph clean

--- a/src/provisioning/providers/asg-provider.ts
+++ b/src/provisioning/providers/asg-provider.ts
@@ -955,7 +955,7 @@ export class ASGProvider implements ResourceProvider {
       }
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(

--- a/src/provisioning/providers/docdb-provider.ts
+++ b/src/provisioning/providers/docdb-provider.ts
@@ -846,7 +846,7 @@ export class DocDBProvider implements ResourceProvider {
       if (status === 'available') return;
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(
@@ -880,7 +880,7 @@ export class DocDBProvider implements ResourceProvider {
       }
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(`Timed out waiting for DocDB DBCluster ${dbClusterIdentifier} to be deleted`);
@@ -905,7 +905,7 @@ export class DocDBProvider implements ResourceProvider {
       if (status === 'available') return;
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(
@@ -936,7 +936,7 @@ export class DocDBProvider implements ResourceProvider {
       }
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(`Timed out waiting for DocDB DBInstance ${dbInstanceIdentifier} to be deleted`);

--- a/src/provisioning/providers/ec2-provider.ts
+++ b/src/provisioning/providers/ec2-provider.ts
@@ -3831,7 +3831,7 @@ export class EC2Provider implements ResourceProvider {
   ): Promise<T> {
     const totalBudgetMs = opts.totalBudgetMs ?? 600_000; // 10 min default
     const initialDelayMs = 5_000;
-    const maxDelayMs = 60_000;
+    const maxDelayMs = 10_000;
     const startedAt = Date.now();
 
     let attempt = 0;

--- a/src/provisioning/providers/elasticache-provider.ts
+++ b/src/provisioning/providers/elasticache-provider.ts
@@ -635,7 +635,7 @@ export class ElastiCacheProvider implements ResourceProvider {
       if (status === 'available') return;
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(`Timed out waiting for CacheCluster ${cacheClusterId} to become available`);
@@ -664,7 +664,7 @@ export class ElastiCacheProvider implements ResourceProvider {
       }
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(`Timed out waiting for CacheCluster ${cacheClusterId} to be deleted`);

--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -118,7 +118,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
   // (LastUpdateStatus -> Successful) after pre-delete VPC detach.
   private readonly eniWaitTimeoutMs: number = 10 * 60 * 1000;
   private readonly eniWaitInitialDelayMs: number = 10_000;
-  private readonly eniWaitMaxDelayMs: number = 30_000;
+  private readonly eniWaitMaxDelayMs: number = 10_000;
 
   // Budget for the post-Update wait that blocks until LastUpdateStatus
   // === 'Successful'. Required to prevent the SECOND in-flight call (e.g.
@@ -886,7 +886,7 @@ export class LambdaFunctionProvider implements ResourceProvider {
    * "myfn" matching for function "fn".
    *
    * Polling: starts at eniWaitInitialDelayMs (10s), exponential backoff up
-   * to eniWaitMaxDelayMs (30s), bounded by eniWaitTimeoutMs (10min).
+   * to eniWaitMaxDelayMs (10s), bounded by eniWaitTimeoutMs (10min).
    * Timeout is a soft warning — downstream Subnet/SG deletion has its own
    * retries.
    */

--- a/src/provisioning/providers/neptune-provider.ts
+++ b/src/provisioning/providers/neptune-provider.ts
@@ -874,7 +874,7 @@ export class NeptuneProvider implements ResourceProvider {
       if (status === 'available') return;
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(
@@ -908,7 +908,7 @@ export class NeptuneProvider implements ResourceProvider {
       }
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(`Timed out waiting for Neptune DBCluster ${dbClusterIdentifier} to be deleted`);
@@ -933,7 +933,7 @@ export class NeptuneProvider implements ResourceProvider {
       if (status === 'available') return;
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(
@@ -964,7 +964,7 @@ export class NeptuneProvider implements ResourceProvider {
       }
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(

--- a/src/provisioning/providers/rds-provider.ts
+++ b/src/provisioning/providers/rds-provider.ts
@@ -1180,7 +1180,7 @@ export class RDSProvider implements ResourceProvider {
       if (status === 'available') return;
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(`Timed out waiting for DBCluster ${dbClusterIdentifier} to become available`);
@@ -1212,7 +1212,7 @@ export class RDSProvider implements ResourceProvider {
       }
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(`Timed out waiting for DBCluster ${dbClusterIdentifier} to be deleted`);
@@ -1237,7 +1237,7 @@ export class RDSProvider implements ResourceProvider {
       if (status === 'available') return;
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(`Timed out waiting for DBInstance ${dbInstanceIdentifier} to become available`);
@@ -1269,7 +1269,7 @@ export class RDSProvider implements ResourceProvider {
       }
 
       await this.sleep(delay);
-      delay = Math.min(delay * 2, 30_000);
+      delay = Math.min(delay * 2, 10_000);
     }
 
     throw new Error(`Timed out waiting for DBInstance ${dbInstanceIdentifier} to be deleted`);

--- a/tests/unit/provisioning/poll-cap-tightness.test.ts
+++ b/tests/unit/provisioning/poll-cap-tightness.test.ts
@@ -79,11 +79,15 @@ describe('provider poll-loop cap tightness (#1175 / #1176)', () => {
 
     // Prove the scanner actually saw its inputs — a green result must mean
     // "all caps tight", never "parsed nothing" (see .claude/rules/testing.md
-    // "A checker must prove it sees its input"). The tightened set is asg(1) +
-    // docdb(4) + neptune(4) + rds(4) + elasticache(2) = 15 inline sites, plus
-    // the two named caps (ec2 maxDelayMs, lambda eniWaitMaxDelayMs).
+    // "A checker must prove it sees its input"). The #1176-tightened set is
+    // asg(1) + docdb(4) + neptune(4) + rds(4) + elasticache(2) = 15 inline
+    // sites, plus 2 named caps (ec2 maxDelayMs, lambda eniWaitMaxDelayMs). The
+    // scanner ALSO picks up already-tight sites not touched by #1176
+    // (servicediscovery's inline 10s loop; cloudfront's named `maxDelay` 10s),
+    // so live counts are >= 16 inline / >= 3 named — the floors keep margin and
+    // are the "saw nothing = fail" backstop, not an exact-count assertion.
     expect(inlineSites, 'expected the inline `Math.min(delay * N, cap)` poll loops to be found').toBeGreaterThanOrEqual(15);
-    expect(namedSites, 'expected the named maxDelay cap constants (ec2, lambda) to be found').toBeGreaterThanOrEqual(2);
+    expect(namedSites, 'expected the named maxDelay cap constants to be found').toBeGreaterThanOrEqual(2);
 
     expect(violations, `sparse poll-loop caps found (tighten to <= ${MAX_ALLOWED_CAP_MS}ms):\n${violations.join('\n')}`).toEqual([]);
   });

--- a/tests/unit/provisioning/poll-cap-tightness.test.ts
+++ b/tests/unit/provisioning/poll-cap-tightness.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+/**
+ * Mechanical non-regression backstop for the "sparse poll-loop backoff" latency
+ * class (PR #1175 / follow-up #1176, memory rule
+ * `feedback_sdk_waiter_sparse_default_poll`).
+ *
+ * Every hand-rolled terminal-state poll loop in a provider uses the shape
+ * `delay = Math.min(delay * N, <cap>)` with a wall-clock deadline as the loop
+ * guard (`while (Date.now() - start < maxWaitMs)`). Because the guard is a
+ * deadline (not a fixed attempt count), the cap only controls how DENSE the
+ * polling is — a sparse cap (30_000 / 60_000) means a resource that reaches its
+ * terminal state just after a poll is detected up to a full cap-interval late,
+ * which is exactly what made cdkd trail Terraform on NAT / CloudFront stacks
+ * until #1175. The whole class is kept tight by capping every such loop at
+ * <= 15s (the fixes land on 10s).
+ *
+ * Two cap spellings are enforced:
+ *   1. inline literal: `Math.min(delay * N, <literal>)`
+ *   2. named constant:  `...maxDelay... = <literal>` (e.g. `maxDelayMs = 10_000`,
+ *      `eniWaitMaxDelayMs: number = 10_000`) consumed by a `Math.min(delay * N,
+ *      <name>)` loop.
+ *
+ * Deliberately scoped to loops whose delay variable is named exactly `delay`.
+ * The DynamoDB `retryOnTransientControlPlane` loop uses `delayMs` and is
+ * ATTEMPT-based (`for (attempt; attempt < maxAttempts)`), not a deadline-guarded
+ * terminal-state poll — its cap is part of a deliberately-tuned fixed ~2min
+ * retry budget, so lowering it would SHRINK that budget rather than just
+ * densify polling. It is intentionally out of this rule's scope.
+ */
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const providersDir = join(repoRoot, 'src', 'provisioning', 'providers');
+
+const MAX_ALLOWED_CAP_MS = 15_000;
+
+function providerFiles(): string[] {
+  return readdirSync(providersDir)
+    .filter((f) => f.endsWith('-provider.ts'))
+    .map((f) => join(providersDir, f));
+}
+
+function parseCap(literal: string): number {
+  return Number.parseInt(literal.replace(/_/g, ''), 10);
+}
+
+describe('provider poll-loop cap tightness (#1175 / #1176)', () => {
+  // 1. inline `Math.min(delay * N, <literal>)`
+  const inlineCap = /Math\.min\(\s*delay\s*\*\s*[\d.]+\s*,\s*(\d[\d_]*)\s*\)/g;
+  // 2. named cap constant `...[Mm]axDelay... = <literal>` (excludes initialDelay)
+  const namedCap = /\b\w*[Mm]axDelay\w*(?:\s*:\s*number)?\s*=\s*(\d[\d_]*)/g;
+
+  it('every terminal-state poll loop caps its backoff at <= 15s', () => {
+    const violations: string[] = [];
+    let inlineSites = 0;
+    let namedSites = 0;
+
+    for (const file of providerFiles()) {
+      const src = readFileSync(file, 'utf8');
+      const name = file.slice(providersDir.length + 1);
+
+      for (const m of src.matchAll(inlineCap)) {
+        inlineSites++;
+        const cap = parseCap(m[1]);
+        if (cap > MAX_ALLOWED_CAP_MS) {
+          violations.push(`${name}: Math.min(delay * .., ${m[1]}) cap ${cap}ms > ${MAX_ALLOWED_CAP_MS}ms`);
+        }
+      }
+      for (const m of src.matchAll(namedCap)) {
+        namedSites++;
+        const cap = parseCap(m[1]);
+        if (cap > MAX_ALLOWED_CAP_MS) {
+          violations.push(`${name}: ${m[0].trim()} cap ${cap}ms > ${MAX_ALLOWED_CAP_MS}ms`);
+        }
+      }
+    }
+
+    // Prove the scanner actually saw its inputs — a green result must mean
+    // "all caps tight", never "parsed nothing" (see .claude/rules/testing.md
+    // "A checker must prove it sees its input"). The tightened set is asg(1) +
+    // docdb(4) + neptune(4) + rds(4) + elasticache(2) = 15 inline sites, plus
+    // the two named caps (ec2 maxDelayMs, lambda eniWaitMaxDelayMs).
+    expect(inlineSites, 'expected the inline `Math.min(delay * N, cap)` poll loops to be found').toBeGreaterThanOrEqual(15);
+    expect(namedSites, 'expected the named maxDelay cap constants (ec2, lambda) to be found').toBeGreaterThanOrEqual(2);
+
+    expect(violations, `sparse poll-loop caps found (tighten to <= ${MAX_ALLOWED_CAP_MS}ms):\n${violations.join('\n')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #1175. That PR fixed the "sparse poll-loop backoff" latency class in the EC2 waiters + `CloudFrontDistributionProvider`. A whole-repo grep found the **same** hand-rolled `delay = Math.min(delay * N, <cap>)` pattern (cap 30s/60s) in several other delete/create waiters that #1175 did not touch. This tightens every one of them to **10s**, matching the #1175 EC2/CloudFront fix.

Tightened (all guarded by a wall-clock deadline, so a smaller cap only **densifies** polling — the total wall-clock budget is unchanged):

| Provider | Site(s) | old cap | new cap |
| --- | --- | ---: | ---: |
| `asg-provider` | `waitForGroupDeleted` | 30s | 10s |
| `docdb-provider` | 4 cluster/instance waiters | 30s | 10s |
| `neptune-provider` | 4 cluster/instance waiters | 30s | 10s |
| `rds-provider` | 4 cluster/instance waiters | 30s | 10s |
| `elasticache-provider` | 2 waiters | 30s | 10s |
| `ec2-provider` | `withDependencyViolationRetry` (`maxDelayMs`) | 60s | 10s |
| `lambda-function-provider` | ENI-detach wait (`eniWaitMaxDelayMs`) + JSDoc | 30s | 10s |

## Deliberately excluded

`dynamodb-table-provider.retryOnTransientControlPlane` keeps its 30s cap. It is **attempt-based** (`for attempt < maxAttempts=8`), not a deadline-guarded terminal-state poll, and it is a transient-error retry (back-to-back control-plane ops), not a sparse readiness poll. Lowering its cap would shrink a deliberately-tuned ~2min retry budget rather than densify polling.

## Non-regression backstop

`tests/unit/provisioning/poll-cap-tightness.test.ts` scans every provider for `Math.min(delay * N, <cap>)` loops + named `maxDelay` constants and fails if any cap exceeds 15s. Scoped to loops whose delay variable is named exactly `delay` (the DynamoDB `delayMs` transient-retry is out of scope by design). Carries per-shape coverage floors so a parser regression fails loudly instead of passing vacuously.

## Verification

- Full unit suite green (7660 tests); typecheck / lint / format / build clean.
- Real-AWS integ: `remove-protection` (verify.sh) PASSED — the positive `destroy --remove-protection` phase cleanly deleted all 12 resources (0 errors, 0 orphans), directly exercising the changed **ASG force-delete** (`waitForGroupDeleted`) and **EC2 VPC-teardown** (`withDependencyViolationRetry`) waiters against real AWS. `integ-destroy` + `integ-broad` markers refreshed.

## Retrospective note

Session lesson recorded to memory: a worktree's `node_modules` symlinked to the main repo passes `[ -d node_modules ]` but breaks an integ `verify.sh`'s own `pnpm install` (no-TTY purge abort); and a fixture must be confirmed to actually exercise the changed path (`lambda` has no VPC, so it can't test a Lambda-ENI change) before using it as the verification integ.

Closes #1176
