### PR TITLE
perf(deploy): overlap state-bucket resolution + preflight with CDK synth

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -129,7 +129,7 @@ intrinsics-torture-2	2026-06-21T18:17:20Z	PASS		verify.sh	first run (never-run);
 kinesis-esm-filter	2026-06-27T19:34:46Z	PASS	62	verify.sh	bughunt-clean regression fixture; FilterCriteria content asserted; clean destroy
 kinesis-stream-mode-switch	2026-06-22T04:55:10Z	PASS	68	verify.sh	StreamMode switch reaches AWS (re-run on merged tree); unique stream name avoids mode-change rate limit
 kms-encryption	2026-06-21T16:16:44Z	PASS	200	verify.sh	stale-real re-run; deploy ok+destroy 3 del 0 err (split across subshell-death; re-destroyed clean); KMS key PendingDeletion
-lambda	2026-07-22T05:14:50Z	PASS	180	verify.sh	broad integ for register-providers.ts change (microvm provider PR), 9 deleted 0 orphans
+lambda	2026-07-23T17:23:55Z	PASS		verify.sh	deploy-flow bucket-resolve||synth optimization (perf/deploy-overhead); clean destroy 0 orphans
 lambda-alias-provisioned-concurrency	2026-06-27T19:25:47Z	PASS	251	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
 lambda-arch-switch	2026-07-02T06:26:16Z	PASS	60	verify.sh	new fixture: arch switch reaches AWS config+runtime, destroy clean 0 orphans
 lambda-config-field-removal	2026-07-22T08:19:38Z	PASS	140	verify.sh	issue #1158 post-rebase re-verify; 6-field removal reset + destroy clean

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -822,6 +822,14 @@ complementary to the per-flow diagrams above:
    └── synth does NOT publish assets or deploy (deploy only)
 ```
 
+> Note: the top-to-bottom order above is the logical flow, not a strict serial
+> schedule. As a latency optimization, `cdkd deploy` resolves the default state
+> bucket (STS `GetCallerIdentity` + `GetBucketLocation`) and runs the fail-fast
+> bucket-exists preflight **concurrently with CDK synthesis** — synth needs
+> neither the state bucket (only the deferred macro-expander consumes it) nor
+> the provisioning clients, so the two independent I/O phases overlap instead of
+> running back-to-back.
+
 ## Design Principles
 
 ### 1. Single Responsibility Principle (SRP)

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -180,16 +180,14 @@ async function deployCommand(
   }
   options.app = app;
 
-  // Resolve --state-bucket from CLI, env, cdk.json, or default (cdkd-state-{accountId};
-  // legacy cdkd-state-{accountId}-{region} is consulted only as a fallback)
   const region = options.region || process.env['AWS_REGION'] || 'us-east-1';
-  const stateBucket = await resolveStateBucketWithDefault(options.stateBucket, region);
 
   logger.debug('Starting deployment...');
   logger.debug('Options:', options);
 
-  // Initialize AWS clients with region/profile
-  // Also set AWS_REGION env for providers using local SDK clients
+  // Initialize AWS clients with region/profile (synchronous — client
+  // construction only, no network). Also set AWS_REGION env for providers
+  // using local SDK clients.
   if (options.region) {
     process.env['AWS_REGION'] = options.region;
     process.env['AWS_DEFAULT_REGION'] = options.region;
@@ -200,35 +198,51 @@ async function deployCommand(
   });
   setAwsClients(awsClients);
 
-  // Fail fast if the state bucket is missing, before running synth / docker builds / asset uploads.
-  // Passing region/profile lets the backend rebuild its S3 client when the
-  // state bucket lives in a region different from the CLI's profile region.
-  const preflightStateBackend = new S3StateBackend(
-    awsClients.s3,
-    {
-      bucket: stateBucket,
-      prefix: options.statePrefix,
-    },
-    {
-      region,
-      ...(options.profile && { profile: options.profile }),
-    }
-  );
-  await preflightStateBackend.verifyBucketExists();
+  // Overlap the slow state-infra I/O with CDK synth (both ~2s and independent).
+  // Resolving the default state bucket (STS GetCallerIdentity + GetBucketLocation)
+  // and the fail-fast bucket-exists preflight do NOT need the synthesized
+  // template, and synth needs neither the state bucket (only the DEFERRED
+  // macro-expander consumes it) nor these clients (context providers build
+  // their own). Started here, awaited alongside synth in the Promise.all below.
+  // Fail-fast on a missing bucket is preserved — the preflight rejects the
+  // Promise.all; the only cost of overlap is a wasted ~2s synth on the rare
+  // misconfigured-bucket path.
+  const statePrepPromise = (async () => {
+    // Resolve --state-bucket from CLI, env, cdk.json, or default (cdkd-state-{accountId};
+    // legacy cdkd-state-{accountId}-{region} is consulted only as a fallback).
+    const stateBucket = await resolveStateBucketWithDefault(options.stateBucket, region);
 
-  // Shared exports index store for this deploy session. Lifecycle: created
-  // here once and threaded through every per-stack DeployEngine so its
-  // in-memory cache survives across all stacks in a `cdkd deploy --all`
-  // run. Lazy-loaded — the first Fn::ImportValue resolution triggers the
-  // rebuild from state.json (when index file is absent post-upgrade) or
-  // a single GET (when index file already exists).
-  const exportIndexStore = new ExportIndexStore(
-    awsClients.s3,
-    stateBucket,
-    options.statePrefix,
-    region,
-    preflightStateBackend
-  );
+    // Fail fast if the state bucket is missing, before docker builds / asset uploads.
+    // Passing region/profile lets the backend rebuild its S3 client when the
+    // state bucket lives in a region different from the CLI's profile region.
+    const preflightStateBackend = new S3StateBackend(
+      awsClients.s3,
+      {
+        bucket: stateBucket,
+        prefix: options.statePrefix,
+      },
+      {
+        region,
+        ...(options.profile && { profile: options.profile }),
+      }
+    );
+    await preflightStateBackend.verifyBucketExists();
+
+    // Shared exports index store for this deploy session. Lifecycle: created
+    // here once and threaded through every per-stack DeployEngine so its
+    // in-memory cache survives across all stacks in a `cdkd deploy --all`
+    // run. Lazy-loaded — the first Fn::ImportValue resolution triggers the
+    // rebuild from state.json (when index file is absent post-upgrade) or
+    // a single GET (when index file already exists).
+    const exportIndexStore = new ExportIndexStore(
+      awsClients.s3,
+      stateBucket,
+      options.statePrefix,
+      region,
+      preflightStateBackend
+    );
+    return { stateBucket, preflightStateBackend, exportIndexStore };
+  })();
 
   let deployInterrupted = false;
   const topLevelSigintHandler = () => {
@@ -244,6 +258,8 @@ async function deployCommand(
   try {
     // 1. Synthesize CDK app (or read a pre-synthesized assembly when --app
     // points at an existing directory — synthesis is skipped in that case).
+    // Run synth CONCURRENTLY with the state-infra prep started above (bucket
+    // resolution + preflight) — two independent ~2s I/O phases overlap.
     logger.info(cyan(synthesisStatusMessage(app, 'Synthesizing CDK app...')));
     const synthesizer = new Synthesizer();
     const context = parseContextOptions(options.context);
@@ -253,16 +269,23 @@ async function deployCommand(
       ...(options.region && { region: options.region }),
       ...(options.profile && { profile: options.profile }),
       ...(Object.keys(context).length > 0 && { context }),
-      // Threaded so the macro-expander has a real state bucket for
-      // the > 51,200-byte template upload path (Issue #463).
-      stateBucket,
+      // stateBucket is set below once statePrepPromise resolves — only the
+      // DEFERRED macro-expander (post-synth, for the > 51,200-byte template
+      // upload path, Issue #463) consumes it, so synthesize() does not need it.
       ...(options.profile && { macroExpandS3ClientOpts: { profile: options.profile } }),
       // Issue #1150: expand macros AFTER stack selection (below), so a
       // macro-carrying stack outside the deploy set can never block or
       // slow this deploy with a CFn round-trip.
       deferMacroExpansion: true,
     };
-    const result = await synthesizer.synthesize(synthOptions);
+    const [result, statePrep] = await Promise.all([
+      synthesizer.synthesize(synthOptions),
+      statePrepPromise,
+    ]);
+    const { stateBucket, preflightStateBackend, exportIndexStore } = statePrep;
+    // The deferred macro-expander (expandMacrosForStacks, below) needs the
+    // resolved state bucket for its > 51,200-byte template upload path (#463).
+    synthOptions.stateBucket = stateBucket;
 
     const { stacks: allStacks } = result;
 


### PR DESCRIPTION
## Summary

Overlap the default state-bucket resolution + fail-fast preflight with CDK synth in `cdkd deploy`. These two independent ~2s I/O phases previously ran **serially before** synth:

1. `resolveStateBucketWithDefault` (STS `GetCallerIdentity` + `GetBucketLocation`)
2. `preflightStateBackend.verifyBucketExists()` (fail-fast on a missing bucket)

Synth needs neither the state bucket (only the DEFERRED macro-expander consumes it, post-synth) nor the provisioning clients (context providers build their own), so they now run **concurrently** with synth via `Promise.all`.

## Why

Profiling a single-resource AgentCore update (S3 code artifact, no Docker/ECR) showed cdkd's actual deploy engine is only **0.93s** (faster than `cdk --hotswap`'s 3.56s), but the wall time was dominated by **size-independent per-deploy orchestration** — the biggest chunk being ~4.65s of CLI-startup + state-bucket resolution before synth even began (see #1180 for the full phase breakdown).

## Measured effect

Single-resource AgentCore update (fair, real code change, N=3, no Docker):

| | before | after |
| --- | ---: | ---: |
| profile wall | 17.4s | 15.8s |
| fair-bench median | 16.7s | **15.4s** |

`resolving default from account...` and `Synthesizing CDK app...` now start at the same timestamp (+0.00s) in `--verbose`. This is a fixed-cost reduction that helps **every** deploy — most visibly the fast, small stacks where the fixed overhead is a larger fraction of wall time.

## Safety

- `awsClients` stays a synchronous outer `const` (used in the `finally` for `.destroy()`); only the network I/O moves into the concurrent promise.
- Fail-fast on a missing bucket is preserved — the preflight rejects the `Promise.all`; the outer `try/finally` (no `catch`) propagates the error unchanged after a benign cleanup.
- `synthesize()` is called with `deferMacroExpansion: true`, so it never reads `synthOptions.stateBucket` (set after the `Promise.all`, before `expandMacrosForStacks`).
- The synthesis layer does not use the global `AwsClients` (`grep getAwsClients src/synthesis/` is empty; context providers build their own clients).

## Test plan

- Full unit suite green (7660 tests); typecheck / lint / format / build clean.
- Existing 577 deploy-flow unit tests pass (the `deploy()` CLI orchestration is integ-tested, not unit-tested — no direct unit harness).
- Independent code review confirmed all 6 correctness claims (synth/stateBucket independence, awsClients scope, fail-fast, no use-before-assignment, no unhandled-rejection window).
- Real-AWS broad integ: `lambda` (VPC + Lambda + DDB + SQS) deployed via the changed flow and destroyed clean (9 deleted, 0 errors, 0 orphans). `integ-destroy` + `integ-broad` refreshed.

Part of #1180 (further per-deploy overhead reductions — events-prune, create-only DescribeType prefetch — tracked there).
