### PR TITLE
perf(deploy): prefetch create-only DescribeType schemas off the critical path (#1180)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -129,7 +129,7 @@ intrinsics-torture-2	2026-06-21T18:17:20Z	PASS		verify.sh	first run (never-run);
 kinesis-esm-filter	2026-06-27T19:34:46Z	PASS	62	verify.sh	bughunt-clean regression fixture; FilterCriteria content asserted; clean destroy
 kinesis-stream-mode-switch	2026-06-22T04:55:10Z	PASS	68	verify.sh	StreamMode switch reaches AWS (re-run on merged tree); unique stream name avoids mode-change rate limit
 kms-encryption	2026-06-21T16:16:44Z	PASS	200	verify.sh	stale-real re-run; deploy ok+destroy 3 del 0 err (split across subshell-death; re-destroyed clean); KMS key PendingDeletion
-lambda	2026-07-23T17:23:55Z	PASS		verify.sh	deploy-flow bucket-resolve||synth optimization (perf/deploy-overhead); clean destroy 0 orphans
+lambda	2026-07-23T19:24:13Z	PASS		verify.sh	C prefetch broad integ; 9 res, destroy 0 err 0 orph
 lambda-alias-provisioned-concurrency	2026-06-27T19:25:47Z	PASS	251	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
 lambda-arch-switch	2026-07-02T06:26:16Z	PASS	60	verify.sh	new fixture: arch switch reaches AWS config+runtime, destroy clean 0 orphans
 lambda-config-field-removal	2026-07-22T08:19:38Z	PASS	140	verify.sh	issue #1158 post-rebase re-verify; 6-field removal reset + destroy clean

--- a/src/deployment/deploy-engine.ts
+++ b/src/deployment/deploy-engine.ts
@@ -37,6 +37,7 @@ import type { DagBuilder } from '../analyzer/dag-builder.js';
 import type { DiffCalculator } from '../analyzer/diff-calculator.js';
 import { ProviderRegistry } from '../provisioning/provider-registry.js';
 import { slowCcOperationTimeoutMs } from '../provisioning/slow-cc-operation-timeouts.js';
+import { getCreateOnlyPropertyPaths } from '../provisioning/create-only-properties.js';
 import { TemplateParser } from '../analyzer/template-parser.js';
 import {
   IMPLICIT_DELETE_DEPENDENCIES,
@@ -872,6 +873,26 @@ export class DeployEngine {
   ): Promise<DeployResult> {
     const startTime = Date.now();
     this.logger.debug(`Starting deployment for stack: ${stackName}`);
+
+    // Warm the create-only DescribeType cache in parallel with the lock + state
+    // read below. calculateDiff (further down) resolves each UPDATE resource's
+    // create-only property paths via cloudformation:DescribeType (~0.8s cold per
+    // type, cached per-type for the deploy lifetime). Kicking those lookups off
+    // here for the template's distinct resource types — fire-and-forget — lets
+    // the diff's awaits hit a warm cache instead of paying the round-trip inline
+    // on the critical path. getCreateOnlyPropertyPaths is idempotent (per-type
+    // module cache) and never throws (it swallows DescribeType errors), so this
+    // is pure latency-hiding with no correctness impact. Custom types short-
+    // circuit without an API call; on a pure-CREATE (first) deploy the diff makes
+    // no create-only lookups at all, so the prefetched entries simply go unused
+    // that run — bounded, deduped, non-blocking waste, never a correctness issue.
+    // Part of #1180.
+    for (const type of new Set(Object.values(template.Resources).map((r) => r.Type))) {
+      // getCreateOnlyPropertyPaths already swallows DescribeType errors, but a
+      // .catch here defends against any unexpected rejection so a fire-and-forget
+      // prefetch never surfaces as an unhandled promise rejection.
+      void getCreateOnlyPropertyPaths(type).catch(() => {});
+    }
 
     // Acquire lock with retry (retries up to 3 times with 2s delay for transient lock conflicts)
     await this.lockManager.acquireLockWithRetry(stackName, this.stackRegion, undefined, 'deploy');

--- a/tests/unit/deployment/deploy-engine-create-only-prefetch.test.ts
+++ b/tests/unit/deployment/deploy-engine-create-only-prefetch.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Part of #1180 (deploy-overhead reduction). doDeploy fires a fire-and-forget
+ * prefetch of each distinct template resource type's create-only property paths
+ * (`getCreateOnlyPropertyPaths`, backed by cloudformation:DescribeType, ~0.8s
+ * cold per type, module-cached for the deploy lifetime) at the very start of the
+ * deploy — in parallel with the lock acquisition + state read — so that the
+ * later diff's per-resource create-only lookups hit a warm cache instead of
+ * paying the round-trip inline on the critical path.
+ *
+ * These tests pin two properties of that prefetch:
+ *  1. it warms the cache for EACH distinct resource type exactly once (dedup);
+ *  2. a rejecting lookup never surfaces as an unhandled promise rejection
+ *     (the fire-and-forget call carries its own `.catch`).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const getCreateOnlyPropertyPaths = vi.fn<(type: string) => Promise<ReadonlyArray<readonly string[]>>>();
+
+vi.mock('../../../src/provisioning/create-only-properties.js', () => ({
+  getCreateOnlyPropertyPaths: (type: string) => getCreateOnlyPropertyPaths(type),
+  createOnlyChangeRequiresReplacement: vi.fn().mockReturnValue(false),
+}));
+
+import { DeployEngine } from '../../../src/deployment/deploy-engine.js';
+import type { CloudFormationTemplate } from '../../../src/types/resource.js';
+import type { ResourceChange } from '../../../src/types/state.js';
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const fns = {
+    setLevel: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => fns,
+  };
+  return { getLogger: () => fns };
+});
+
+vi.mock('../../../src/deployment/intrinsic-function-resolver.js', () => ({
+  IntrinsicFunctionResolver: vi.fn().mockImplementation(() => ({
+    getPhysicalIdFallbackCount: vi.fn().mockReturnValue(0),
+    resetPhysicalIdFallbackCount: vi.fn(),
+    resolve: vi.fn().mockImplementation((props: unknown) => Promise.resolve(props)),
+    resolveParameters: vi.fn().mockResolvedValue({}),
+    evaluateConditions: vi.fn().mockResolvedValue({}),
+  })),
+}));
+
+vi.mock('p-limit', () => ({
+  default: vi.fn(() => <T>(fn: () => T) => fn()),
+}));
+
+describe('DeployEngine - create-only DescribeType prefetch (#1180)', () => {
+  const stackName = 'prefetch-stack';
+
+  let mockProvider: {
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    getAttribute: ReturnType<typeof vi.fn>;
+    readCurrentState: ReturnType<typeof vi.fn>;
+  };
+  let mockStateBackend: { getState: ReturnType<typeof vi.fn>; saveState: ReturnType<typeof vi.fn> };
+  let mockLockManager: {
+    acquireLockWithRetry: ReturnType<typeof vi.fn>;
+    releaseLock: ReturnType<typeof vi.fn>;
+  };
+  let mockDagBuilder: {
+    buildGraph: ReturnType<typeof vi.fn>;
+    getExecutionLevels: ReturnType<typeof vi.fn>;
+    getDirectDependencies: ReturnType<typeof vi.fn>;
+  };
+  let mockDiffCalculator: {
+    calculateDiff: ReturnType<typeof vi.fn>;
+    hasChanges: ReturnType<typeof vi.fn>;
+    filterByType: ReturnType<typeof vi.fn>;
+  };
+  let mockProviderRegistry: {
+    getProvider: ReturnType<typeof vi.fn>;
+    getProviderFor: ReturnType<typeof vi.fn>;
+    getRegisteredTypes: ReturnType<typeof vi.fn>;
+    validateResourceTypes: ReturnType<typeof vi.fn>;
+    validateResourceProperties: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCreateOnlyPropertyPaths.mockResolvedValue([]);
+
+    mockProvider = {
+      create: vi
+        .fn()
+        .mockImplementation((logicalId: string) =>
+          Promise.resolve({ physicalId: `phys-${logicalId}`, attributes: {} })
+        ),
+      update: vi.fn(),
+      delete: vi.fn().mockResolvedValue(undefined),
+      getAttribute: vi.fn(),
+      readCurrentState: vi.fn().mockResolvedValue({}),
+    };
+    mockLockManager = {
+      acquireLockWithRetry: vi.fn().mockResolvedValue(true),
+      releaseLock: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDagBuilder = {
+      buildGraph: vi.fn().mockReturnValue({}),
+      getExecutionLevels: vi.fn().mockReturnValue([['A', 'B', 'C']]),
+      getDirectDependencies: vi.fn().mockReturnValue([]),
+    };
+    mockDiffCalculator = {
+      calculateDiff: vi.fn(),
+      hasChanges: vi.fn().mockReturnValue(true),
+      filterByType: vi
+        .fn()
+        .mockImplementation((changes: Map<string, ResourceChange>, type: string) =>
+          Array.from(changes.values()).filter((c) => c.changeType === type)
+        ),
+    };
+    mockProviderRegistry = {
+      getProvider: vi.fn().mockReturnValue(mockProvider),
+      getProviderFor: vi.fn().mockReturnValue({ provider: mockProvider, provisionedBy: 'sdk' }),
+      getRegisteredTypes: vi.fn().mockReturnValue([]),
+      validateResourceTypes: vi.fn(),
+      validateResourceProperties: vi.fn(),
+    };
+    mockStateBackend = {
+      getState: vi.fn().mockResolvedValue({ state: null, etag: undefined }),
+      saveState: vi.fn().mockResolvedValue('etag-new'),
+    };
+  });
+
+  function makeEngine() {
+    return new DeployEngine(
+      mockStateBackend as never,
+      mockLockManager as never,
+      mockDagBuilder as never,
+      mockDiffCalculator as never,
+      mockProviderRegistry as never,
+      { dryRun: false },
+      'us-east-1'
+    );
+  }
+
+  const template: CloudFormationTemplate = {
+    Resources: {
+      A: { Type: 'AWS::SSM::Parameter', Properties: { Value: 'a' } },
+      B: { Type: 'AWS::SQS::Queue', Properties: {} },
+      // Duplicate type — must NOT trigger a second prefetch for AWS::SSM::Parameter.
+      C: { Type: 'AWS::SSM::Parameter', Properties: { Value: 'c' } },
+    },
+  };
+
+  function makeCreateDiff(): Map<string, ResourceChange> {
+    return new Map<string, ResourceChange>(
+      Object.entries(template.Resources).map(([id, res]) => [
+        id,
+        {
+          logicalId: id,
+          changeType: 'CREATE',
+          resourceType: res.Type,
+          desiredProperties: res.Properties,
+        },
+      ])
+    );
+  }
+
+  it('warms the create-only cache once per DISTINCT resource type', async () => {
+    mockDiffCalculator.calculateDiff.mockResolvedValue(makeCreateDiff());
+
+    const engine = makeEngine();
+    await engine.deploy(stackName, template);
+
+    // Two distinct types (AWS::SSM::Parameter appears twice) → two prefetch calls.
+    const prefetched = getCreateOnlyPropertyPaths.mock.calls.map((c) => c[0]);
+    expect(new Set(prefetched)).toEqual(new Set(['AWS::SSM::Parameter', 'AWS::SQS::Queue']));
+    expect(prefetched.filter((t) => t === 'AWS::SSM::Parameter')).toHaveLength(1);
+  });
+
+  it('does not surface an unhandled rejection when a prefetch lookup rejects', async () => {
+    // getCreateOnlyPropertyPaths is documented never-throw, but if it ever
+    // rejects the fire-and-forget prefetch must swallow it — otherwise the
+    // process logs an unhandledRejection (and the test worker dies).
+    getCreateOnlyPropertyPaths.mockRejectedValue(new Error('DescribeType boom'));
+    mockDiffCalculator.calculateDiff.mockResolvedValue(makeCreateDiff());
+
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    try {
+      const engine = makeEngine();
+      // The deploy itself must still succeed — the prefetch is pure latency-hiding.
+      await expect(engine.deploy(stackName, template)).resolves.toBeDefined();
+      // Let any leaked rejection reach the handler.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandled);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Part of #1180 (cdkd deploy pre/post-deploy fixed-overhead reduction).

`doDeploy` now fires a **fire-and-forget prefetch** of each distinct template
resource type's create-only property paths (`getCreateOnlyPropertyPaths`,
backed by `cloudformation:DescribeType`) at the very start of the deploy, in
parallel with the lock acquisition + state read. The later diff's per-resource
create-only lookups then hit the warm per-type module cache instead of paying
the ~0.8s cold `DescribeType` round-trip inline on the critical path.

`getCreateOnlyPropertyPaths` is idempotent (per-type module cache) and never
throws (it swallows `DescribeType` errors), so the prefetch is pure
latency-hiding with no correctness impact. The `.catch` on the fire-and-forget
call defends against any unexpected rejection surfacing as an unhandled promise
rejection. Custom types short-circuit without an API call; on a pure-CREATE
(first) deploy the diff makes no create-only lookups, so the prefetched entries
simply go unused that run (bounded, deduped, non-blocking).

## Benchmark (real AWS, AgentCore Runtime S3 `fromCodeAsset` update)

Same-session, same-AWS-window, back-to-back A/B (isolates the optimization from
AWS latency drift), N=3, sequential/alone:

| binary | median | all runs |
|---|---|---|
| v0.260.10 (this change's parent) | 15.4s | 15.4 / 15.4 / 15.5 |
| **+ this prefetch** | **14.2s** | 13.8 / 14.2 / 14.5 |

~1.2s win, distributions non-overlapping (baseline min 15.4 > new max 14.5).
For reference `cdk deploy --hotswap` on the same stack is 14.2s, so this closes
the single-resource AgentCore update gap to a dead tie. (The deploy engine
itself was already faster: `UpdateAgentRuntime` 0.93s vs hotswap 3.56s; the
wall-clock gap was orchestration overhead, of which the inline `DescribeType`
was one component.)

The remaining #1180 items (events-prune true-async ~0.3s, redundant final
state-save) stay backlog: low yield with real risk, and there is no gap left to
close on this path.

## Test plan

- New unit test `tests/unit/deployment/deploy-engine-create-only-prefetch.test.ts`:
  warms the cache once per DISTINCT type (dedup), and a rejecting prefetch never
  surfaces an unhandled rejection.
- `vp check` / `vp run typecheck:test` / `vp run build` / `vp run test`
  (459 files, 7662 tests) all green.
- Broad integ `lambda` (cross-cutting `deploy-engine.ts` change): LambdaStack
  deploy (9 resources) + RecursiveLoop / ReservedConcurrentExecutions backfill
  assertions + clean destroy (9 deleted, 0 errors, 0 orphans).
