### PR TITLE
perf(assets): cache ECR docker login per registry for the process lifetime (#1184)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,7 +188,12 @@ Publishes file assets (Lambda code packages, etc.) to S3:
 
 Publishes Docker image assets to ECR:
 
-- Authenticates with ECR via `GetAuthorizationToken`
+- Authenticates with ECR via `GetAuthorizationToken`, then `docker login`. The
+  login is cached per registry (`<accountId>.dkr.ecr.<region>.amazonaws.com`)
+  for the process lifetime, so a repeat publish to the same registry skips the
+  `GetAuthorizationToken` call and the `docker login` subprocess (mirrors
+  `cdk-assets`; ECR tokens are valid ~12h and a deploy process is short-lived).
+  Keyed per registry so cross-account / cross-region assets each log in once.
 - Builds Docker images from source
 - Tags and pushes images to the ECR repository
 

--- a/src/assets/docker-asset-publisher.ts
+++ b/src/assets/docker-asset-publisher.ts
@@ -10,6 +10,29 @@ import { AssetError } from '../utils/error-handler.js';
 import { buildDockerImage } from './docker-build.js';
 
 /**
+ * Registries this process has already logged in to, keyed by registry host
+ * (`<accountId>.dkr.ecr.<region>.amazonaws.com`, which uniquely encodes the
+ * account + region credential context). ECR authorization tokens are valid
+ * for ~12h and a deploy process is short-lived, so a successful login is
+ * reused for the process lifetime — mirroring `cdk-assets`, which skips
+ * re-login on repeat publishes. Keyed per registry (NOT globally) so that
+ * cross-account / cross-region assets each get their own login.
+ *
+ * Module-level (not an instance field) because the deploy pipeline may
+ * construct more than one `DockerAssetPublisher` per run (e.g. one per
+ * WorkGraph asset-publish node), and the login is genuinely process-wide.
+ */
+const loggedInRegistries = new Set<string>();
+
+/**
+ * Test-only: reset the process-lifetime ECR login cache so each test starts
+ * from a clean slate.
+ */
+export function resetEcrLoginCache(): void {
+  loggedInRegistries.clear();
+}
+
+/**
  * Publishes Docker image assets to ECR
  *
  * Handles:
@@ -185,8 +208,21 @@ export class DockerAssetPublisher {
 
   /**
    * Authenticate with ECR via `docker login --password-stdin`.
+   *
+   * The login is cached per registry (`<accountId>.dkr.ecr.<region>`) for the
+   * process lifetime: a repeat publish to the same registry returns early
+   * without the `GetAuthorizationToken` call or the `docker login` subprocess
+   * (mirrors `cdk-assets`). ECR tokens are valid ~12h and a deploy process is
+   * short-lived, so this is safe. Keyed per registry so cross-account /
+   * cross-region assets each get their own login.
    */
   private async ecrLogin(client: ECRClient, accountId: string, region: string): Promise<void> {
+    const registryKey = `${accountId}.dkr.ecr.${region}.amazonaws.com`;
+    if (loggedInRegistries.has(registryKey)) {
+      this.logger.debug(`Reusing cached ECR login for ${registryKey}`);
+      return;
+    }
+
     const response = await client.send(new GetAuthorizationTokenCommand({}));
     const authData = response.authorizationData?.[0];
 
@@ -208,6 +244,9 @@ export class DockerAssetPublisher {
       await runDockerStreaming(['login', '--username', username, '--password-stdin', endpoint], {
         input: password,
       });
+      // Only cache after a successful login so a failed attempt is retried on
+      // the next publish rather than silently skipped.
+      loggedInRegistries.add(registryKey);
     } catch (err) {
       const e = err as { stderr?: string; message?: string };
       throw new AssetError(

--- a/tests/unit/assets/docker-asset-publisher.test.ts
+++ b/tests/unit/assets/docker-asset-publisher.test.ts
@@ -57,7 +57,10 @@ vi.mock('../../../src/utils/logger.js', () => ({
 }));
 
 import { DescribeImagesCommand } from '@aws-sdk/client-ecr';
-import { DockerAssetPublisher } from '../../../src/assets/docker-asset-publisher.js';
+import {
+  DockerAssetPublisher,
+  resetEcrLoginCache,
+} from '../../../src/assets/docker-asset-publisher.js';
 import { AssetError } from '../../../src/utils/error-handler.js';
 import type { DockerImageAsset } from '../../../src/types/assets.js';
 
@@ -85,6 +88,9 @@ describe('DockerAssetPublisher', () => {
     mockEcrDestroy.mockReset();
     mockRunDocker.mockReset();
     mockRunDocker.mockResolvedValue({ stdout: '', stderr: '' });
+    // The ECR login cache is module-level (process-lifetime), so reset it
+    // between tests to keep them isolated.
+    resetEcrLoginCache();
     publisher = new DockerAssetPublisher();
   });
 
@@ -395,5 +401,161 @@ describe('DockerAssetPublisher', () => {
         'us-east-1'
       )
     ).rejects.toThrow('Docker build failed: ERROR: failed to solve');
+  });
+
+  describe('ECR login caching (issue #1184)', () => {
+    // Wire ECR mock so DescribeImages always reports "not found" (so the
+    // build + push path runs) and GetAuthorizationToken returns a valid token.
+    const wireLoginMocks = () => {
+      mockEcrSend.mockImplementation((cmd: { _type?: string }) => {
+        if (cmd._type === 'DescribeImages') {
+          const err = new Error('Image not found') as Error & { name: string };
+          err.name = 'ImageNotFoundException';
+          throw err;
+        }
+        if (cmd._type === 'GetAuthorizationToken') {
+          return {
+            authorizationData: [
+              {
+                authorizationToken: authToken,
+                proxyEndpoint: 'https://123456789012.dkr.ecr.us-east-1.amazonaws.com',
+              },
+            ],
+          };
+        }
+        return {};
+      });
+    };
+
+    const countAuthTokenCalls = () =>
+      mockEcrSend.mock.calls.filter(
+        ([cmd]) => (cmd as { _type?: string })?._type === 'GetAuthorizationToken'
+      ).length;
+
+    const countLoginExecs = () =>
+      mockRunDocker.mock.calls.filter(([args]) => Array.isArray(args) && args[0] === 'login').length;
+
+    it('logs in on the first publish to a registry (GetAuthorizationToken + docker login once)', async () => {
+      wireLoginMocks();
+
+      await publisher.publish('h1', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1');
+
+      expect(countAuthTokenCalls()).toBe(1);
+      expect(countLoginExecs()).toBe(1);
+    });
+
+    it('does NOT re-login on a second publish to the SAME registry', async () => {
+      wireLoginMocks();
+
+      // First publish logs in.
+      await publisher.publish('h1', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1');
+      // Second publish (fresh publisher instance too — cache is process-wide).
+      const second = new DockerAssetPublisher();
+      await second.publish('h2', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1');
+
+      // Still exactly one login across BOTH publishes.
+      expect(countAuthTokenCalls()).toBe(1);
+      expect(countLoginExecs()).toBe(1);
+      // But the second publish still built + pushed its own image.
+      const pushCalls = mockRunDocker.mock.calls.filter(
+        ([args]) => Array.isArray(args) && args[0] === 'push'
+      );
+      expect(pushCalls.length).toBe(2);
+    });
+
+    it('DOES log in again for a DIFFERENT region (different registry host)', async () => {
+      mockEcrSend.mockImplementation((cmd: { _type?: string }) => {
+        if (cmd._type === 'DescribeImages') {
+          const err = new Error('Image not found') as Error & { name: string };
+          err.name = 'ImageNotFoundException';
+          throw err;
+        }
+        if (cmd._type === 'GetAuthorizationToken') {
+          return { authorizationData: [{ authorizationToken: authToken }] };
+        }
+        return {};
+      });
+
+      const asset = (region: string): DockerImageAsset =>
+        makeDockerAsset({
+          destinations: {
+            d: {
+              repositoryName: 'repo-${AWS::AccountId}',
+              imageTag: 'tag',
+              region,
+            },
+          },
+        });
+
+      await publisher.publish('h1', asset('us-east-1'), '/tmp/cdk.out', '123456789012', 'us-east-1');
+      await publisher.publish('h2', asset('eu-west-1'), '/tmp/cdk.out', '123456789012', 'us-east-1');
+
+      // Two distinct registries -> two logins.
+      expect(countAuthTokenCalls()).toBe(2);
+      expect(countLoginExecs()).toBe(2);
+    });
+
+    it('DOES log in again for a DIFFERENT account (different registry host)', async () => {
+      mockEcrSend.mockImplementation((cmd: { _type?: string }) => {
+        if (cmd._type === 'DescribeImages') {
+          const err = new Error('Image not found') as Error & { name: string };
+          err.name = 'ImageNotFoundException';
+          throw err;
+        }
+        if (cmd._type === 'GetAuthorizationToken') {
+          return { authorizationData: [{ authorizationToken: authToken }] };
+        }
+        return {};
+      });
+
+      const asset: DockerImageAsset = makeDockerAsset({
+        destinations: {
+          d: { repositoryName: 'repo-${AWS::AccountId}', imageTag: 'tag' },
+        },
+      });
+
+      await publisher.publish('h1', asset, '/tmp/cdk.out', '111111111111', 'us-east-1');
+      await publisher.publish('h2', asset, '/tmp/cdk.out', '222222222222', 'us-east-1');
+
+      // Two distinct accounts -> two logins.
+      expect(countAuthTokenCalls()).toBe(2);
+      expect(countLoginExecs()).toBe(2);
+    });
+
+    it('push() (WorkGraph asset-publish path) also caches the login', async () => {
+      wireLoginMocks();
+
+      await publisher.push(makeDockerAsset(), '123456789012', 'us-east-1', 'local-tag');
+      const second = new DockerAssetPublisher();
+      await second.push(makeDockerAsset(), '123456789012', 'us-east-1', 'local-tag');
+
+      expect(countAuthTokenCalls()).toBe(1);
+      expect(countLoginExecs()).toBe(1);
+    });
+
+    it('does NOT cache a FAILED login (retries on the next publish)', async () => {
+      wireLoginMocks();
+      // Make the docker login subprocess fail.
+      mockRunDocker.mockImplementation((args: string[]) => {
+        if (args[0] === 'login') {
+          const err = new Error('login failed') as Error & { stderr: string };
+          err.stderr = 'denied';
+          return Promise.reject(err);
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+
+      await expect(
+        publisher.publish('h1', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1')
+      ).rejects.toThrow(AssetError);
+
+      // Second attempt must try to log in again (the failed one was not cached).
+      await expect(
+        publisher.publish('h2', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1')
+      ).rejects.toThrow(AssetError);
+
+      expect(countAuthTokenCalls()).toBe(2);
+      expect(countLoginExecs()).toBe(2);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`DockerAssetPublisher` ran a full ECR login (`GetAuthorizationToken` + a `docker login` subprocess) on **every** container asset publish, while `cdk-assets` skips re-login after the first. This caches successful logins per registry for the process lifetime.

Closes #1184

## Change

- Module-level `Set<string>` of registry hosts (`<accountId>.dkr.ecr.<region>.amazonaws.com`) this process has logged in to.
- `ecrLogin()` returns early on a cache hit — no `GetAuthorizationToken` call, no `docker login` subprocess.
- Keyed **per (account, region)** via the registry host string, so cross-account / cross-region assets each log in once (the key is built from the same `destRegion` both call sites already resolve).
- A **failed** login is NOT cached (retried on the next publish).
- Both call sites (`publish()` and `push()` — the WorkGraph asset-publish path) route through the same cached `ecrLogin()`.
- ECR tokens are valid ~12h and a deploy process is short-lived, so process-lifetime caching is safe.

## Tests

Added 6 unit tests (`tests/unit/assets/docker-asset-publisher.test.ts`):
- first publish to a registry logs in (`GetAuthorizationToken` + `docker login` exactly once);
- a **second** publish to the **same** registry does NOT re-login (still one login across both, but a second push happens);
- a **different region** and a **different account** each DO log in again;
- `push()` (WorkGraph path) also caches;
- a **failed** login is not cached (retries).

Full suite: 459 files / 7668 tests pass.

## Live-test (real AWS, us-east-1, `cdkd-bench-agentcore`)

Verified a real AgentCore container deploy + update + destroy end-to-end clean. `--verbose` shows exactly ONE `docker login` (`Login Succeeded` count == 1) per deploy process. Single-asset build->push gap ~3.14s (the one login) — unchanged from the pre-fix ~3.2s, since a single-asset deploy only logs in once regardless.

## Container-path A/B (N=3, warm cache, same session)

| tool | median | range |
|------|--------|-------|
| cdkd `deploy` (this branch) | 27.6s | 26.9-31.9s |
| cdk `deploy --hotswap` | 24.9s | 24.7-31.0s |

**Honest caveat:** this bench has a SINGLE container asset and each `cdkd deploy` is its own process, so the cache does not fire within one deploy (there is no second publish to skip, and a fresh process starts with an empty cache). The single-asset build->push gap is unchanged. The measured median move vs the issue's 33.2s baseline is dominated by run-to-run variance, not this fix. The real payoff of this change is **multi-asset deploys that publish >1 image to the same registry in one process**, plus straightforward `cdk-assets` parity. cdkd remains ~2-3s behind hotswap on the single-asset container path; closing that further needs work elsewhere (not the login).
