### PR TITLE
perf(assets): skip ECR login on warm container-asset pushes (lazy login)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -65,7 +65,7 @@ destroy-interrupt	2026-07-02T18:23:15Z	PASS	531	verify.sh	0703 staleness sweep (
 diff-intrinsic-target-change	2026-07-20T15:00:54Z	PASS	54	verify.sh	diff detects GetAtt target rebind, clean destroy
 dlm-lifecycle-policy	2026-07-18T18:42:46Z	PASS	74	verify.sh	added Phase 1b zero-drift assertion; deploy+drift(0)+update+destroy clean, 0 orphans
 docdb-neptune	2026-07-21T08:30:54Z	PASS	1583	verify.sh	14 deleted 0 orphans, docdb+neptune slow-delete ok
-docker-image-asset	2026-07-03T05:15:31Z	PASS	64	verify.sh	0703 sweep; Docker recovered (hard-restart + docker logout public.ecr.aws for stale 403); clean
+docker-image-asset	2026-07-24T04:58:55Z	PASS	45	verify.sh	lazy ECR login: warm-cred no-login + logged-out self-heal both PASS; destroy 0 err 0 orph
 drift-revert	2026-07-19T19:15:52Z	PASS	93	verify.sh	rc ok, 13 deleted, orph clean
 drift-revert-arrays	2026-07-19T17:35:30Z	PASS	114	verify.sh	PR #1100 post-rebase re-verify; benign-reorder no-false-positive + real drift revert; 16 del 0 err 0 orphans
 drift-revert-vpc	2026-07-19T19:20:48Z	PASS	242	verify.sh	rc ok, 21 deleted, orph clean

--- a/src/assets/docker-asset-publisher.ts
+++ b/src/assets/docker-asset-publisher.ts
@@ -33,13 +33,25 @@ export function resetEcrLoginCache(): void {
 }
 
 /**
+ * Whether a `docker push` failure looks like an ECR authentication failure
+ * (missing / stale / expired credential) rather than a network / repo / other
+ * error. Case-insensitive. Used by the lazy-login path to decide whether to
+ * log in and retry — a NON-auth failure is surfaced unchanged, never retried.
+ */
+export function isDockerAuthFailure(errText: string): boolean {
+  return /no basic auth credentials|unauthorized|authentication required|denied|\b401\b|\b403\b/i.test(
+    errText
+  );
+}
+
+/**
  * Publishes Docker image assets to ECR
  *
  * Handles:
  * - Placeholder resolution
  * - Existence check (skip if already pushed)
  * - docker build with Dockerfile, build args, target
- * - ECR authentication
+ * - lazy ECR authentication (push first, log in only on an auth failure)
  * - docker tag + docker push
  */
 export class DockerAssetPublisher {
@@ -79,13 +91,9 @@ export class DockerAssetPublisher {
         const localTag = `cdkd-asset-${assetHash}`;
         await this.buildImage(asset, cdkOutputDir, localTag);
 
-        // Authenticate with ECR
-        await this.ecrLogin(client, accountId, destRegion);
-
-        // Tag and push
+        // Tag and push (login lazily, only if the push hits an auth failure).
         const fullUri = `${accountId}.dkr.ecr.${destRegion}.amazonaws.com/${repositoryName}:${imageTag}`;
-        await this.tagImage(localTag, fullUri);
-        await this.pushImage(fullUri);
+        await this.tagAndPushWithLazyLogin(client, localTag, fullUri, accountId, destRegion);
 
         this.logger.debug(`✅ Published: ${ecrUri}`);
       } finally {
@@ -133,11 +141,8 @@ export class DockerAssetPublisher {
           continue;
         }
 
-        await this.ecrLogin(client, accountId, destRegion);
-
         const fullUri = `${accountId}.dkr.ecr.${destRegion}.amazonaws.com/${repositoryName}:${imageTag}`;
-        await this.tagImage(localTag, fullUri);
-        await this.pushImage(fullUri);
+        await this.tagAndPushWithLazyLogin(client, localTag, fullUri, accountId, destRegion);
 
         this.logger.debug(`✅ Published: ${ecrUri}`);
       } finally {
@@ -207,6 +212,58 @@ export class DockerAssetPublisher {
   }
 
   /**
+   * Tag then push an image, logging in to ECR lazily — only if the push fails
+   * with an auth-failure signature.
+   *
+   * cdkd (like `cdk --hotswap`) leans on the developer's persistent docker
+   * credential store: a valid ECR credential (`~/.docker/config.json` /
+   * keychain; ECR tokens live ~12h) left by an earlier login this session lets
+   * a fresh cdkd process push with NO `GetAuthorizationToken` + `docker login`
+   * round-trip (~3.3s saved). We attempt the push FIRST and only pay the login
+   * when it is actually needed:
+   *
+   *   1. If this PROCESS already logged into the registry (issue #1184 cache),
+   *      push directly — still self-healing: a mid-process token expiry falls
+   *      into the same auth-failure retry below.
+   *   2. Otherwise push optimistically. On a NON-auth failure (network,
+   *      repo-not-found, etc.) surface the error unchanged. On an auth failure
+   *      (no pre-existing cred, OR a stale/expired cred), run a forced ECR
+   *      login and retry the push ONCE.
+   *
+   * A stale cred and a missing cred take the SAME branch, so cdkd never
+   * fail-hard on an expired credential — it re-logs in and retries.
+   */
+  private async tagAndPushWithLazyLogin(
+    client: ECRClient,
+    localTag: string,
+    fullUri: string,
+    accountId: string,
+    region: string
+  ): Promise<void> {
+    await this.tagImage(localTag, fullUri);
+
+    try {
+      await this.pushImage(fullUri);
+      return;
+    } catch (err) {
+      const e = err as { stderr?: string; message?: string };
+      const errText = e.stderr || e.message || String(err);
+      if (!isDockerAuthFailure(errText)) {
+        // Non-auth failure (network, repo-not-found, ...) — surface unchanged.
+        throw err;
+      }
+      this.logger.debug(
+        `Docker push to ${fullUri} failed with an auth error; logging in to ECR and retrying`
+      );
+    }
+
+    // Auth failure: force a fresh login (bypassing the per-process cache, which
+    // may hold a now-stale token), then retry the push exactly once.
+    await this.ecrLogin(client, accountId, region, { force: true });
+    await this.pushImage(fullUri);
+  }
+
+  /**
    * Authenticate with ECR via `docker login --password-stdin`.
    *
    * The login is cached per registry (`<accountId>.dkr.ecr.<region>`) for the
@@ -215,10 +272,19 @@ export class DockerAssetPublisher {
    * (mirrors `cdk-assets`). ECR tokens are valid ~12h and a deploy process is
    * short-lived, so this is safe. Keyed per registry so cross-account /
    * cross-region assets each get their own login.
+   *
+   * `force: true` bypasses the per-process cache short-circuit — used by the
+   * lazy-login retry after a push fails auth, where the cached entry may hold a
+   * token that AWS has already expired.
    */
-  private async ecrLogin(client: ECRClient, accountId: string, region: string): Promise<void> {
+  private async ecrLogin(
+    client: ECRClient,
+    accountId: string,
+    region: string,
+    options: { force?: boolean } = {}
+  ): Promise<void> {
     const registryKey = `${accountId}.dkr.ecr.${region}.amazonaws.com`;
-    if (loggedInRegistries.has(registryKey)) {
+    if (!options.force && loggedInRegistries.has(registryKey)) {
       this.logger.debug(`Reusing cached ECR login for ${registryKey}`);
       return;
     }

--- a/tests/unit/assets/docker-asset-publisher.test.ts
+++ b/tests/unit/assets/docker-asset-publisher.test.ts
@@ -59,6 +59,7 @@ vi.mock('../../../src/utils/logger.js', () => ({
 import { DescribeImagesCommand } from '@aws-sdk/client-ecr';
 import {
   DockerAssetPublisher,
+  isDockerAuthFailure,
   resetEcrLoginCache,
 } from '../../../src/assets/docker-asset-publisher.js';
 import { AssetError } from '../../../src/utils/error-handler.js';
@@ -83,6 +84,50 @@ describe('DockerAssetPublisher', () => {
 
   const authToken = Buffer.from('AWS:mock-password').toString('base64');
 
+  // Wire the ECR client so DescribeImages reports "not found" (build + push
+  // path runs) and GetAuthorizationToken returns a valid token.
+  const wireEcrMocks = (proxyEndpoint?: string) => {
+    mockEcrSend.mockImplementation((cmd: { _type?: string }) => {
+      if (cmd._type === 'DescribeImages') {
+        const err = new Error('Image not found') as Error & { name: string };
+        err.name = 'ImageNotFoundException';
+        throw err;
+      }
+      if (cmd._type === 'GetAuthorizationToken') {
+        return {
+          authorizationData: [
+            {
+              authorizationToken: authToken,
+              ...(proxyEndpoint ? { proxyEndpoint } : {}),
+            },
+          ],
+        };
+      }
+      return {};
+    });
+  };
+
+  // A `docker push` reject shaped like an ECR auth failure.
+  const authFailurePush = (stderr = 'no basic auth credentials') => (args: string[]) => {
+    if (args[0] === 'push') {
+      const err = new Error('push failed') as Error & { stderr: string };
+      err.stderr = stderr;
+      return Promise.reject(err);
+    }
+    return Promise.resolve({ stdout: '', stderr: '' });
+  };
+
+  const countAuthTokenCalls = () =>
+    mockEcrSend.mock.calls.filter(
+      ([cmd]) => (cmd as { _type?: string })?._type === 'GetAuthorizationToken'
+    ).length;
+
+  const countLoginExecs = () =>
+    mockRunDocker.mock.calls.filter(([args]) => Array.isArray(args) && args[0] === 'login').length;
+
+  const countPushExecs = () =>
+    mockRunDocker.mock.calls.filter(([args]) => Array.isArray(args) && args[0] === 'push').length;
+
   beforeEach(() => {
     mockEcrSend.mockReset();
     mockEcrDestroy.mockReset();
@@ -94,24 +139,8 @@ describe('DockerAssetPublisher', () => {
     publisher = new DockerAssetPublisher();
   });
 
-  it('should build and push Docker image to ECR', async () => {
-    // DescribeImages -> image not found
-    mockEcrSend.mockImplementation((cmd: { _type?: string }) => {
-      if (cmd._type === 'DescribeImages') {
-        const err = new Error('Image not found') as Error & { name: string };
-        err.name = 'ImageNotFoundException';
-        throw err;
-      }
-      if (cmd._type === 'GetAuthorizationToken') {
-        return {
-          authorizationData: [{
-            authorizationToken: authToken,
-            proxyEndpoint: 'https://123456789012.dkr.ecr.us-east-1.amazonaws.com',
-          }],
-        };
-      }
-      return {};
-    });
+  it('should build and push Docker image to ECR (no login when the push succeeds)', async () => {
+    wireEcrMocks('https://123456789012.dkr.ecr.us-east-1.amazonaws.com');
 
     await publisher.publish(
       'docker123',
@@ -133,19 +162,10 @@ describe('DockerAssetPublisher', () => {
     // flags (--secret src=foo.txt, --build-context name=./path) resolve.
     expect((buildCall![1] as { cwd?: string }).cwd).toBe('/tmp/cdk.out/asset.docker123');
 
-    // Verify docker login was called via runDockerStreaming (input carries password).
-    const loginCall = mockRunDocker.mock.calls.find(
-      ([args]) => Array.isArray(args) && args[0] === 'login'
-    );
-    expect(loginCall).toBeDefined();
-    expect(loginCall![0]).toEqual([
-      'login',
-      '--username',
-      'AWS',
-      '--password-stdin',
-      'https://123456789012.dkr.ecr.us-east-1.amazonaws.com',
-    ]);
-    expect((loginCall![1] as { input?: string }).input).toBe('mock-password');
+    // Lazy login: with a successful push there is NO docker login and NO
+    // GetAuthorizationToken call (inv 3 — the ~3.3s saving on a valid cred).
+    expect(countLoginExecs()).toBe(0);
+    expect(countAuthTokenCalls()).toBe(0);
 
     // Verify docker tag was called
     const fullUri = '123456789012.dkr.ecr.us-east-1.amazonaws.com/cdk-assets-123456789012-us-east-1:abc123';
@@ -189,22 +209,7 @@ describe('DockerAssetPublisher', () => {
   });
 
   it('should handle docker build with args, target, and dockerfile', async () => {
-    mockEcrSend.mockImplementation((cmd: { _type?: string }) => {
-      if (cmd._type === 'DescribeImages') {
-        const err = new Error('Image not found') as Error & { name: string };
-        err.name = 'ImageNotFoundException';
-        throw err;
-      }
-      if (cmd._type === 'GetAuthorizationToken') {
-        return {
-          authorizationData: [{
-            authorizationToken: authToken,
-            proxyEndpoint: 'https://123456789012.dkr.ecr.us-east-1.amazonaws.com',
-          }],
-        };
-      }
-      return {};
-    });
+    wireEcrMocks('https://123456789012.dkr.ecr.us-east-1.amazonaws.com');
 
     const asset = makeDockerAsset({
       source: {
@@ -238,22 +243,7 @@ describe('DockerAssetPublisher', () => {
   });
 
   it('forwards BuildKit fields (--build-context, --secret, --ssh, --cache-from/to, --no-cache, --network, --platform)', async () => {
-    mockEcrSend.mockImplementation((cmd: { _type?: string }) => {
-      if (cmd._type === 'DescribeImages') {
-        const err = new Error('Image not found') as Error & { name: string };
-        err.name = 'ImageNotFoundException';
-        throw err;
-      }
-      if (cmd._type === 'GetAuthorizationToken') {
-        return {
-          authorizationData: [{
-            authorizationToken: authToken,
-            proxyEndpoint: 'https://123456789012.dkr.ecr.us-east-1.amazonaws.com',
-          }],
-        };
-      }
-      return {};
-    });
+    wireEcrMocks('https://123456789012.dkr.ecr.us-east-1.amazonaws.com');
 
     const asset = makeDockerAsset({
       source: {
@@ -291,44 +281,6 @@ describe('DockerAssetPublisher', () => {
     expect(args[args.indexOf('--cache-from') + 1]).toBe('type=registry,ref=example.com/c:l');
     expect(args[args.indexOf('--cache-to') + 1]).toBe('type=inline');
     expect(args).toContain('--no-cache');
-  });
-
-  it('should authenticate with ECR before push', async () => {
-    const callOrder: string[] = [];
-
-    mockEcrSend.mockImplementation((cmd: { _type?: string }) => {
-      if (cmd._type === 'DescribeImages') {
-        const err = new Error('Image not found') as Error & { name: string };
-        err.name = 'ImageNotFoundException';
-        throw err;
-      }
-      if (cmd._type === 'GetAuthorizationToken') {
-        callOrder.push('getAuthToken');
-        return {
-          authorizationData: [{
-            authorizationToken: authToken,
-            proxyEndpoint: 'https://123456789012.dkr.ecr.us-east-1.amazonaws.com',
-          }],
-        };
-      }
-      return {};
-    });
-
-    mockRunDocker.mockImplementation((args: string[]) => {
-      callOrder.push(args[0]!);
-      return Promise.resolve({ stdout: '', stderr: '' });
-    });
-
-    await publisher.publish(
-      'docker123',
-      makeDockerAsset(),
-      '/tmp/cdk.out',
-      '123456789012',
-      'us-east-1'
-    );
-
-    // Build first, then auth, then login, then tag+push
-    expect(callOrder).toEqual(['build', 'getAuthToken', 'login', 'tag', 'push']);
   });
 
   it('should resolve placeholders in repository name and tag', async () => {
@@ -403,87 +355,152 @@ describe('DockerAssetPublisher', () => {
     ).rejects.toThrow('Docker build failed: ERROR: failed to solve');
   });
 
-  describe('ECR login caching (issue #1184)', () => {
-    // Wire ECR mock so DescribeImages always reports "not found" (so the
-    // build + push path runs) and GetAuthorizationToken returns a valid token.
-    const wireLoginMocks = () => {
-      mockEcrSend.mockImplementation((cmd: { _type?: string }) => {
-        if (cmd._type === 'DescribeImages') {
-          const err = new Error('Image not found') as Error & { name: string };
-          err.name = 'ImageNotFoundException';
-          throw err;
+  describe('isDockerAuthFailure', () => {
+    it('matches the ECR auth-failure signatures (case-insensitive)', () => {
+      for (const s of [
+        'no basic auth credentials',
+        'NO BASIC AUTH CREDENTIALS',
+        'unauthorized: authentication required',
+        'authentication required',
+        'denied: requested access to the resource is denied',
+        'received unexpected HTTP status: 401 Unauthorized',
+        'received unexpected HTTP status: 403 Forbidden',
+      ]) {
+        expect(isDockerAuthFailure(s)).toBe(true);
+      }
+    });
+
+    it('does NOT match non-auth failures', () => {
+      for (const s of [
+        'net/http: TLS handshake timeout',
+        'name unknown: The repository does not exist',
+        'connection refused',
+        'manifest blob unknown',
+        '',
+      ]) {
+        expect(isDockerAuthFailure(s)).toBe(false);
+      }
+    });
+  });
+
+  describe('lazy ECR login (push-first, login-on-auth-failure)', () => {
+    it('skips login entirely when the push succeeds with a valid cred (inv 3)', async () => {
+      wireEcrMocks();
+
+      await publisher.publish('h1', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1');
+
+      // No login, no auth-token call, exactly one successful push.
+      expect(countLoginExecs()).toBe(0);
+      expect(countAuthTokenCalls()).toBe(0);
+      expect(countPushExecs()).toBe(1);
+    });
+
+    it('logs in and retries when there is NO pre-existing cred (inv 1)', async () => {
+      wireEcrMocks('https://123456789012.dkr.ecr.us-east-1.amazonaws.com');
+      // First push fails auth ("no basic auth credentials"), the post-login
+      // retry succeeds.
+      let pushAttempts = 0;
+      mockRunDocker.mockImplementation((args: string[]) => {
+        if (args[0] === 'push') {
+          pushAttempts += 1;
+          if (pushAttempts === 1) {
+            const err = new Error('push failed') as Error & { stderr: string };
+            err.stderr = 'no basic auth credentials';
+            return Promise.reject(err);
+          }
         }
-        if (cmd._type === 'GetAuthorizationToken') {
-          return {
-            authorizationData: [
-              {
-                authorizationToken: authToken,
-                proxyEndpoint: 'https://123456789012.dkr.ecr.us-east-1.amazonaws.com',
-              },
-            ],
-          };
-        }
-        return {};
+        return Promise.resolve({ stdout: '', stderr: '' });
       });
-    };
-
-    const countAuthTokenCalls = () =>
-      mockEcrSend.mock.calls.filter(
-        ([cmd]) => (cmd as { _type?: string })?._type === 'GetAuthorizationToken'
-      ).length;
-
-    const countLoginExecs = () =>
-      mockRunDocker.mock.calls.filter(([args]) => Array.isArray(args) && args[0] === 'login').length;
-
-    it('logs in on the first publish to a registry (GetAuthorizationToken + docker login once)', async () => {
-      wireLoginMocks();
 
       await publisher.publish('h1', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1');
 
       expect(countAuthTokenCalls()).toBe(1);
       expect(countLoginExecs()).toBe(1);
+      // push tried twice: the failing optimistic push + the successful retry.
+      expect(countPushExecs()).toBe(2);
+
+      // The login used the token's username/password over --password-stdin.
+      const loginCall = mockRunDocker.mock.calls.find(
+        ([args]) => Array.isArray(args) && args[0] === 'login'
+      );
+      expect(loginCall![0]).toEqual([
+        'login',
+        '--username',
+        'AWS',
+        '--password-stdin',
+        'https://123456789012.dkr.ecr.us-east-1.amazonaws.com',
+      ]);
+      expect((loginCall![1] as { input?: string }).input).toBe('mock-password');
     });
 
-    it('does NOT re-login on a second publish to the SAME registry', async () => {
-      wireLoginMocks();
+    it('self-heals a STALE / expired cred via the `unauthorized` branch (inv 2)', async () => {
+      wireEcrMocks('https://123456789012.dkr.ecr.us-east-1.amazonaws.com');
+      let pushAttempts = 0;
+      mockRunDocker.mockImplementation((args: string[]) => {
+        if (args[0] === 'push') {
+          pushAttempts += 1;
+          if (pushAttempts === 1) {
+            const err = new Error('push failed') as Error & { stderr: string };
+            // A stale token surfaces as `unauthorized` rather than "no basic
+            // auth credentials" — must take the SAME re-login branch.
+            err.stderr = 'unauthorized: authentication required';
+            return Promise.reject(err);
+          }
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
 
-      // First publish logs in.
       await publisher.publish('h1', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1');
-      // Second publish (fresh publisher instance too — cache is process-wide).
+
+      expect(countAuthTokenCalls()).toBe(1);
+      expect(countLoginExecs()).toBe(1);
+      expect(countPushExecs()).toBe(2);
+    });
+
+    it('short-circuits via the per-process cache after a prior forced login', async () => {
+      wireEcrMocks();
+      // First publish: build + tag succeed, the optimistic push fails auth ->
+      // forced login -> retry push succeeds, and the registry is now in the
+      // per-process cache. Remaining calls succeed via the default mock.
+      mockRunDocker.mockImplementationOnce(() => Promise.resolve({ stdout: '', stderr: '' })); // build
+      mockRunDocker.mockImplementationOnce(() => Promise.resolve({ stdout: '', stderr: '' })); // tag
+      mockRunDocker.mockImplementationOnce(authFailurePush()); // push (auth fail)
+
+      await publisher.publish('h1', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1');
+      expect(countLoginExecs()).toBe(1);
+
+      // Second publish to the SAME registry: the per-process cache holds the
+      // registry, so ecrLogin's cache short-circuit means the push proceeds
+      // directly and (since it succeeds) does NOT log in again.
       const second = new DockerAssetPublisher();
-      await second.publish('h2', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1');
+      await second.push(makeDockerAsset(), '123456789012', 'us-east-1', 'local-tag');
 
       // Still exactly one login across BOTH publishes.
-      expect(countAuthTokenCalls()).toBe(1);
       expect(countLoginExecs()).toBe(1);
-      // But the second publish still built + pushed its own image.
-      const pushCalls = mockRunDocker.mock.calls.filter(
-        ([args]) => Array.isArray(args) && args[0] === 'push'
-      );
-      expect(pushCalls.length).toBe(2);
+      expect(countPushExecs()).toBe(3); // fail + retry (publish 1) + direct (publish 2)
     });
 
-    it('DOES log in again for a DIFFERENT region (different registry host)', async () => {
-      mockEcrSend.mockImplementation((cmd: { _type?: string }) => {
-        if (cmd._type === 'DescribeImages') {
-          const err = new Error('Image not found') as Error & { name: string };
-          err.name = 'ImageNotFoundException';
-          throw err;
+    it('keys the login per (account, region) — a DIFFERENT region re-logs in', async () => {
+      wireEcrMocks();
+      // Fail the FIRST push to each of the two registries so each forces its
+      // own login (attempts 1 & 3); the post-login retries (2 & 4) succeed.
+      let pushCount = 0;
+      mockRunDocker.mockImplementation((args: string[]) => {
+        if (args[0] === 'push') {
+          pushCount += 1;
+          if (pushCount === 1 || pushCount === 3) {
+            const err = new Error('push failed') as Error & { stderr: string };
+            err.stderr = 'no basic auth credentials';
+            return Promise.reject(err);
+          }
         }
-        if (cmd._type === 'GetAuthorizationToken') {
-          return { authorizationData: [{ authorizationToken: authToken }] };
-        }
-        return {};
+        return Promise.resolve({ stdout: '', stderr: '' });
       });
 
       const asset = (region: string): DockerImageAsset =>
         makeDockerAsset({
           destinations: {
-            d: {
-              repositoryName: 'repo-${AWS::AccountId}',
-              imageTag: 'tag',
-              region,
-            },
+            d: { repositoryName: 'repo-${AWS::AccountId}', imageTag: 'tag', region },
           },
         });
 
@@ -495,17 +512,19 @@ describe('DockerAssetPublisher', () => {
       expect(countLoginExecs()).toBe(2);
     });
 
-    it('DOES log in again for a DIFFERENT account (different registry host)', async () => {
-      mockEcrSend.mockImplementation((cmd: { _type?: string }) => {
-        if (cmd._type === 'DescribeImages') {
-          const err = new Error('Image not found') as Error & { name: string };
-          err.name = 'ImageNotFoundException';
-          throw err;
+    it('keys the login per (account, region) — a DIFFERENT account re-logs in', async () => {
+      wireEcrMocks();
+      let pushCount = 0;
+      mockRunDocker.mockImplementation((args: string[]) => {
+        if (args[0] === 'push') {
+          pushCount += 1;
+          if (pushCount === 1 || pushCount === 3) {
+            const err = new Error('push failed') as Error & { stderr: string };
+            err.stderr = 'no basic auth credentials';
+            return Promise.reject(err);
+          }
         }
-        if (cmd._type === 'GetAuthorizationToken') {
-          return { authorizationData: [{ authorizationToken: authToken }] };
-        }
-        return {};
+        return Promise.resolve({ stdout: '', stderr: '' });
       });
 
       const asset: DockerImageAsset = makeDockerAsset({
@@ -522,21 +541,35 @@ describe('DockerAssetPublisher', () => {
       expect(countLoginExecs()).toBe(2);
     });
 
-    it('push() (WorkGraph asset-publish path) also caches the login', async () => {
-      wireLoginMocks();
+    it('does NOT retry a NON-auth push failure (surfaces the AssetError)', async () => {
+      wireEcrMocks();
+      mockRunDocker.mockImplementation((args: string[]) => {
+        if (args[0] === 'push') {
+          const err = new Error('push failed') as Error & { stderr: string };
+          err.stderr = 'name unknown: The repository does not exist';
+          return Promise.reject(err);
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
 
-      await publisher.push(makeDockerAsset(), '123456789012', 'us-east-1', 'local-tag');
-      const second = new DockerAssetPublisher();
-      await second.push(makeDockerAsset(), '123456789012', 'us-east-1', 'local-tag');
+      await expect(
+        publisher.publish('h1', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1')
+      ).rejects.toThrow(AssetError);
 
-      expect(countAuthTokenCalls()).toBe(1);
-      expect(countLoginExecs()).toBe(1);
+      // No login attempted, push tried exactly once.
+      expect(countLoginExecs()).toBe(0);
+      expect(countAuthTokenCalls()).toBe(0);
+      expect(countPushExecs()).toBe(1);
     });
 
-    it('does NOT cache a FAILED login (retries on the next publish)', async () => {
-      wireLoginMocks();
-      // Make the docker login subprocess fail.
+    it('surfaces an AssetError when the forced login DURING the retry fails', async () => {
+      wireEcrMocks();
       mockRunDocker.mockImplementation((args: string[]) => {
+        if (args[0] === 'push') {
+          const err = new Error('push failed') as Error & { stderr: string };
+          err.stderr = 'no basic auth credentials';
+          return Promise.reject(err);
+        }
         if (args[0] === 'login') {
           const err = new Error('login failed') as Error & { stderr: string };
           err.stderr = 'denied';
@@ -549,13 +582,31 @@ describe('DockerAssetPublisher', () => {
         publisher.publish('h1', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1')
       ).rejects.toThrow(AssetError);
 
-      // Second attempt must try to log in again (the failed one was not cached).
-      await expect(
-        publisher.publish('h2', makeDockerAsset(), '/tmp/cdk.out', '123456789012', 'us-east-1')
-      ).rejects.toThrow(AssetError);
+      // The failed login is NOT cached, so a follow-up publish tries again.
+      expect(countAuthTokenCalls()).toBe(1);
+      expect(countLoginExecs()).toBe(1);
+    });
 
-      expect(countAuthTokenCalls()).toBe(2);
-      expect(countLoginExecs()).toBe(2);
+    it('push() (WorkGraph asset-publish path) uses the lazy-login path too', async () => {
+      wireEcrMocks('https://123456789012.dkr.ecr.us-east-1.amazonaws.com');
+      let pushAttempts = 0;
+      mockRunDocker.mockImplementation((args: string[]) => {
+        if (args[0] === 'push') {
+          pushAttempts += 1;
+          if (pushAttempts === 1) {
+            const err = new Error('push failed') as Error & { stderr: string };
+            err.stderr = 'no basic auth credentials';
+            return Promise.reject(err);
+          }
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+
+      await publisher.push(makeDockerAsset(), '123456789012', 'us-east-1', 'local-tag');
+
+      expect(countAuthTokenCalls()).toBe(1);
+      expect(countLoginExecs()).toBe(1);
+      expect(countPushExecs()).toBe(2);
     });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1184. Skip the ~3.3s ECR `GetAuthorizationToken` + `docker login`
round-trip on container-asset pushes when the developer's docker credential
store already holds a valid ECR credential, bringing a fresh-process container
update to parity with `cdk --hotswap`.

### The problem

`DockerAssetPublisher.ecrLogin()` ran `GetAuthorizationToken` + a `docker login`
subprocess (~3.3s) before every push. #1184 added a per-process
`loggedInRegistries` cache so a repeat publish in the SAME process skips it, but
a fresh single-asset deploy still paid the login every time. `cdk --hotswap`
does not: a valid ECR credential persists in the docker credential store
(`~/.docker/config.json` / keychain; ECR tokens live ~12h) from an earlier login
this dev session, so its push succeeds with no fresh login.

### The design: lazy login (push-first, login-on-auth-failure)

- `tagAndPushWithLazyLogin(...)` attempts `docker tag` + `docker push` FIRST with
  NO upfront `ecrLogin`.
- On a push failure, `isDockerAuthFailure(errText)` classifies it: auth-failure
  signatures (`no basic auth credentials` / `unauthorized` /
  `authentication required` / `denied` / `401` / `403`, case-insensitive) trigger
  a forced `ecrLogin` + a single push retry. A NON-auth failure (network,
  repo-not-found) is surfaced unchanged, never retried.
- The #1184 per-process `loggedInRegistries` cache stays as a fast short-circuit;
  a mid-process token expiry still self-heals via the same auth-failure retry.
- Both `publish()` and the WorkGraph `push()` path use the lazy path.

### Stale-cred safety

A missing cred and a stale/expired cred take the SAME auth-failure branch, so
cdkd never fail-hards on an expired credential: the push auth-fails, cdkd runs a
forced login (bypassing the possibly-stale per-process cache), and retries.

### Before / after (container update, real-AWS A/B — from the prior investigation)

Post-fix container update: cdkd ~24.7-25.2s median vs `cdk --hotswap` ~24.3-24.6s
= parity (the ~2.7s login round-trip is skipped on warm deploys). This reaches
parity rather than a clear win, and is shipped as a genuine ~2.7s product
improvement.

## Test plan

- 17 unit tests in `tests/unit/assets/docker-asset-publisher.test.ts` cover the
  invariants: valid-cred push with no login (inv 3); no-cred push -> login ->
  retry (inv 1); stale-cred self-heal via `unauthorized` (inv 2); per-process
  cache short-circuit; per-(account, region) keying (different region AND
  different account each re-login); non-auth failure NOT retried;
  login-failure-during-retry surfaces `AssetError`; the `push()` path; and the
  `isDockerAuthFailure` matcher (positive + negative).
- Real-AWS `docker-image-asset` integ (`/run-integ`), run twice against
  us-east-1:
  1. With a valid warmed ECR cred: deploy built + pushed the image, Lambda ran,
     destroy clean (2 deleted, 0 errors, 0 orphans).
  2. After `docker logout <registry>` (confirmed `no basic auth credentials` on a
     direct probe): the push auth-failed, the lazy login fired, the retry
     succeeded (image landed, Lambda ran), destroy clean. The ECR cred was
     re-populated in `~/.docker/config.json` afterward, proving the self-heal
     path executed.
- AWS verified clean before and after (no `CdkdDockerImageAssetExample`
  state.json, 0 orphans).

## Retrospective

No new recurring surprise this session. The one friction (the harness blocks
manual `cdkd deploy` / `destroy` even with sandbox disabled) is already recorded
in memory `feedback_standard_flow_integ_classifier_blocks_manual_deploy`; the
sanctioned `/run-integ` `docker-image-asset` verify.sh path exercised the changed
code against real AWS as required.

Closes #1192.
