### PR TITLE
docs(readme): refresh VPC+Lambda+SQS+CloudFront cdkd benchmark 197 -> 168 (#1178)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ CloudFormation's [Express mode](https://aws.amazon.com/about-aws/whats-new/2026/
 
 | Stack | Normal (CFn) | Express | cdkd | cdkd `--no-wait` |
 | --- | ---: | ---: | ---: | ---: |
-| VPC + Lambda + SQS + CloudFront | 562 | 366 | 197 | **40** |
+| VPC + Lambda + SQS + CloudFront | 562 | 366 | 168 | **40** |
 | DynamoDB | 34 | 34 | 19 | 15 |
 | DynamoDB + KMS | 71 | 55 | 27 | 27 |
 | EC2 | 44 | 31 | 27 | 26 |


### PR DESCRIPTION
## Summary

Re-measures the README `VPC + Lambda + SQS + CloudFront` benchmark row (cdkd column) on current cdkd (v0.262.x, after the poll-cap fixes #1175 / #1176), per issue #1178, and refreshes the permanent number **197 -> 168**.

## Measurement

- Best-of-3, deploy-phase only (DeployEngine `Duration`, synth excluded), `us-west-2` (matches the README methodology).
- Three deploy-phase runs: **168.33s / 173.26s / 240.53s** (CloudFront propagation is the dominant, high-variance term; best-of-3 min discards the slow draws).
- **min = 168s**, clearly under the prior 197s and the 192s update threshold, so the number is refreshed.

## Note on methodology

The issue's literal default (`--state-bucket cdkd-state-<acct>`, region-free us-east-1, + `--region us-west-2`) hits a cross-region S3 301 on the `VpcRestrictDefaultSG` custom resource. This run used a us-west-2-co-located state bucket to avoid it. That cross-region 301 is a genuine cdkd bug (the custom-resource response-bucket presign is not `GetBucketLocation`-corrected, unlike the state backend / lock manager / exports store) tracked separately as #1195.

Scope: only the main benchmark table (line 33) is updated per the issue. The detail section further down carries a separately-measured 197 against a different (599s) baseline and was left untouched to avoid cascading ratio edits.

## Test plan

- Doc-only change (one number). typecheck / lint / build / tests (7698) all green.
- Live-verified: the benchmark itself (3x deploy + destroy of bench-cdk-sample in us-west-2) produced the new number; all destroys clean (37 deleted, 0 errors), 0 AWS orphans, temp bucket removed.

Closes #1178
