### PR TITLE
fix(rollback): emit rollback event for --orphan CREATE + cover output-failure journal reason (#1183)

### DIFF
--- a/src/deployment/rollback-executor.ts
+++ b/src/deployment/rollback-executor.ts
@@ -350,6 +350,17 @@ async function replaySingle(
           delete stateResources[op.logicalId];
           logger.info(`  Rollback: Orphaning created resource ${op.logicalId} (--orphan)`);
           await afterOp?.(op.logicalId);
+          // Emit the same rollback event as the DeletionPolicy-orphan path
+          // (`orphan-retain`) so `cdkd events` surfaces the orphaned resource
+          // consistently regardless of which orphan trigger fired.
+          ctx.recordEvent?.({
+            eventType: 'ROLLBACK_RESOURCE_SUCCEEDED',
+            stackName,
+            operation: 'CREATE',
+            logicalId: op.logicalId,
+            resourceType: op.resourceType,
+            ...(op.provisionedBy && { provisionedBy: op.provisionedBy }),
+          });
         } else {
           // --orphan on an UPDATE: leave the resource at its new properties;
           // keep state as-is so it keeps describing AWS truth.

--- a/tests/unit/deployment/deploy-engine-rollback-journal.test.ts
+++ b/tests/unit/deployment/deploy-engine-rollback-journal.test.ts
@@ -202,4 +202,33 @@ describe('DeployEngine — rollback journal (issue #1183)', () => {
     // Clean rollback (A deletes fine) → journal deleted after the post-rollback save.
     expect(journal.deleteRollbackJournal).toHaveBeenCalled();
   });
+
+  it('writes a no-rollback-failure segment when provisioning succeeds but output resolution fails', async () => {
+    // Every resource op succeeds; resolveOutputs then throws (only reachable
+    // under --strict-getatt). The engine persists state then journals a
+    // `no-rollback-failure` segment so `cdkd rollback` can revert.
+    const changes = new Map([
+      ['A', makeChange('A')],
+      ['B', makeChange('B')],
+    ]);
+    const engine = buildEngine({ changes, deps: { A: [], B: [] }, currentEtag: 'e0' });
+    // Turn on strict-getatt + make the Output value resolution throw.
+    (engine as unknown as { options: { strictGetAtt: boolean } }).options.strictGetAtt = true;
+    const outputSentinel = { 'Fn::GetAtt': ['Missing', 'Arn'] };
+    const resolver = (engine as unknown as { resolver: { resolve: ReturnType<typeof vi.fn> } }).resolver;
+    resolver.resolve.mockImplementation((value: unknown) => {
+      if (value === outputSentinel) return Promise.reject(new Error('unresolvable output'));
+      return Promise.resolve(value);
+    });
+    const templateWithOutput: CloudFormationTemplate = {
+      Resources: template.Resources,
+      Outputs: { Bad: { Value: outputSentinel } },
+    };
+    await expect(engine.deploy(stackName, templateWithOutput)).rejects.toThrow(/unresolvable output|Missing/);
+    expect(journal.appendRollbackJournalSegment).toHaveBeenCalledOnce();
+    const seg = journal.appendRollbackJournalSegment.mock.calls[0]![2];
+    expect(seg.reason).toBe('no-rollback-failure');
+    // Both A and B completed before the output failure → both are journaled.
+    expect(seg.operations.map((o: { logicalId: string }) => o.logicalId).sort()).toEqual(['A', 'B']);
+  });
 });

--- a/tests/unit/deployment/rollback-executor.test.ts
+++ b/tests/unit/deployment/rollback-executor.test.ts
@@ -243,7 +243,7 @@ describe('replayRollback', () => {
 
   it('--orphan on a CREATE leaves the resource, drops it from state', async () => {
     const del = vi.fn();
-    const { ctx } = makeCtx({ delete: del });
+    const { ctx, events } = makeCtx({ delete: del });
     const ops: CompletedOperation[] = [
       { logicalId: 'B', changeType: 'CREATE', resourceType: 'AWS::S3::Bucket', physicalId: 'phys-B' },
     ];
@@ -251,11 +251,13 @@ describe('replayRollback', () => {
     await replayRollback(ops, state, 'S', ctx, { orphanLogicalIds: new Set(['B']) });
     expect(del).not.toHaveBeenCalled();
     expect(state.B).toBeUndefined();
+    // Parity with orphan-retain: the orphaned CREATE surfaces in events.
+    expect(events.map((e) => e.eventType)).toContain('ROLLBACK_RESOURCE_SUCCEEDED');
   });
 
-  it('--orphan on an UPDATE leaves state as-is (no provider.update)', async () => {
+  it('--orphan on an UPDATE leaves state as-is (no provider.update, no event)', async () => {
     const update = vi.fn();
-    const { ctx } = makeCtx({ update });
+    const { ctx, events } = makeCtx({ update });
     const cur = res({ physicalId: 'phys-B', properties: { a: 2 } });
     const ops: CompletedOperation[] = [
       { logicalId: 'B', changeType: 'UPDATE', resourceType: 'AWS::S3::Bucket', physicalId: 'phys-B', previousState: res({ properties: { a: 1 } }) },
@@ -264,6 +266,8 @@ describe('replayRollback', () => {
     await replayRollback(ops, state, 'S', ctx, { orphanLogicalIds: new Set(['B']) });
     expect(update).not.toHaveBeenCalled();
     expect(state.B).toBe(cur);
+    // An orphaned UPDATE changes nothing in state/AWS → no event.
+    expect(events.map((e) => e.eventType)).not.toContain('ROLLBACK_RESOURCE_SUCCEEDED');
   });
 
   it('per-op failure is caught, counted, and does not abort remaining ops', async () => {


### PR DESCRIPTION
## Summary

Two low-priority review nits from #1196 (standalone `cdkd rollback`, issue #1183):

1. **Event consistency** — a CREATE skipped via `--orphan` now emits the same `ROLLBACK_RESOURCE_SUCCEEDED` event as the `DeletionPolicy: Retain`/`Snapshot` orphan path (`orphan-retain`). Previously only the DeletionPolicy-driven orphan surfaced in `cdkd events`; the user-requested `--orphan` skip did not. An orphaned **UPDATE** still emits nothing (it changes neither state nor AWS).
2. **Test coverage** — adds the previously-missing unit test for the deploy engine's output-resolution-failure journal-write path (all resource ops succeed, `resolveOutputs` throws under `--strict-getatt` → a `no-rollback-failure` segment is journaled so `cdkd rollback` can revert).

No behavior change to what gets deleted/reverted — the event is the only observable delta (`rollback-executor.ts` is not in any integ-gate scope). `cdkd events` output is strictly a superset.

## Test plan

- `tests/unit/deployment/rollback-executor.test.ts`: `--orphan` CREATE asserts the event is emitted; `--orphan` UPDATE asserts no event.
- `tests/unit/deployment/deploy-engine-rollback-journal.test.ts`: output-resolution failure journals a `no-rollback-failure` segment with both completed resources.
- Full suite: 7748 pass.

Follow-up tracking issues from the same review: #1198 (revert the failed in-flight resource), #1199 (reverse-replacement for immutable reverts).
