### PR TITLE
test(integ): echo captured CLI output before asserting success in verify.sh

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -209,9 +209,9 @@ remove-protection	2026-07-23T15:56:48Z	PASS		verify.sh	1176 poll-cap follow-up; 
 rename-refactor	2026-07-21T14:37:30Z	PASS	107	verify.sh	new fixture; review-fix re-run; destroy 0 err 0 orph
 replacement-fanout	2026-07-21T05:17:15Z	PASS	82	verify.sh	rc ok, orph clean
 replacement-immutable-name	2026-07-19T19:03:36Z	PASS	120	verify.sh	rc ok, 7 deleted, orph clean
-rollback-command	2026-07-24T09:05:25Z	PASS	620	verify.sh	post-rebase (main #1201) re-run; rc ok, orph clean
+rollback-command	2026-07-25T05:24:26Z	PASS	130	verify.sh	#1220 echo-before-assert on R2/F2 success-expected rollbacks, destroy clean
 rollback-failure-injection	2026-07-24T10:50:16Z	PASS	368	verify.sh	0724b sweep P1: #1212 journal-after-clean-rollback coverage; 17 del 0 err 0 orphans
-rollback-sqs-cooldown	2026-07-24T14:00:01Z	PASS	175	verify.sh	new fixture #1218: #1206 cooldown reverse-replacement + #1208/#1216 failed-only journal cycle, destroy clean
+rollback-sqs-cooldown	2026-07-25T05:24:26Z	PASS	180	verify.sh	#1220 echo-before-assert on steps 4/9/10, destroy clean
 route53	2026-07-22T07:59:10Z	PASS		verify.sh	TTL-refresh sweep; HostedZone/GeoProximity/CidrRouting backfills, 6 del 0 err, hosted zone + state gone
 s3-asset-deploy	2026-07-02T18:23:15Z	PASS	49	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 s3-cloudfront	2026-07-02T18:23:15Z	PASS	396	verify.sh	0703 staleness sweep (pre-TTL refresh); clean

--- a/tests/integration/rollback-command/verify.sh
+++ b/tests/integration/rollback-command/verify.sh
@@ -302,8 +302,18 @@ assert_gone "old ${REPLACE_A_NAME} still exists — the replacement did not dele
 echo "[verify] step R1 ok: replacement landed (b created, a deleted), journal present"
 
 echo "[verify] step R2: cdkd rollback ${STACK} --force (expect reverse-replacement, exit 0)"
+# Success-expected, but echo the captured output BEFORE asserting the exit
+# code — a bare invocation under `set -e` would abort before the sed echo,
+# losing the failing rollback's output from the harness log (issue #1220).
+set +e
 ${CLI} rollback "${STACK}" --state-bucket "${STATE_BUCKET}" --force > /tmp/rollback-cmd-replace-rb.log 2>&1
+R2_RC=$?
+set -e
 sed 's/^/  /' /tmp/rollback-cmd-replace-rb.log || true
+if [ "${R2_RC}" -ne 0 ]; then
+  echo "[verify] FAIL: reverse-replacement rollback exited ${R2_RC} (output above)"
+  exit 1
+fi
 if ! grep -qi 'reverse-replace\|Reversing replacement' /tmp/rollback-cmd-replace-rb.log; then
   echo "[verify] FAIL: rollback output does not mention the reverse-replacement"
   exit 1
@@ -361,8 +371,16 @@ fi
 echo "[verify] step F1 ok: deploy failed on the UPDATE, journal carries the failed op (prev=3600, attempted=9999999)"
 
 echo "[verify] step F2: cdkd rollback ${STACK} --force --revert-failed (expect exit 0)"
+# Same echo-before-assert pattern as step R2 (issue #1220).
+set +e
 ${CLI} rollback "${STACK}" --state-bucket "${STATE_BUCKET}" --force --revert-failed > /tmp/rollback-cmd-updfail-rb.log 2>&1
+F2_RC=$?
+set -e
 sed 's/^/  /' /tmp/rollback-cmd-updfail-rb.log || true
+if [ "${F2_RC}" -ne 0 ]; then
+  echo "[verify] FAIL: --revert-failed rollback exited ${F2_RC} (output above)"
+  exit 1
+fi
 if ! grep -qi 'force-reverting failed UPDATE' /tmp/rollback-cmd-updfail-rb.log; then
   echo "[verify] FAIL: rollback output does not mention the failed-op force-revert"
   exit 1

--- a/tests/integration/rollback-sqs-cooldown/verify.sh
+++ b/tests/integration/rollback-sqs-cooldown/verify.sh
@@ -210,8 +210,18 @@ fi
 echo "[verify] step 3 ok: replacement landed (y created, x deleted — cooldown running), journal present"
 
 echo "[verify] step 4: cdkd rollback ${STACK} --force --verbose immediately (expect the re-create to retry through QueueDeletedRecently, exit 0)"
+# Success-expected, but echo the captured output BEFORE asserting the exit
+# code — a bare invocation under `set -e` would abort before the sed echo,
+# losing the failing rollback's output from the harness log (issue #1220).
+set +e
 ${CLI} rollback "${STACK}" --state-bucket "${STATE_BUCKET}" --force --verbose > /tmp/rollback-sqs-rb.log 2>&1
+RB_RC=$?
+set -e
 sed 's/^/  /' /tmp/rollback-sqs-rb.log || true
+if [ "${RB_RC}" -ne 0 ]; then
+  echo "[verify] FAIL: cooldown reverse-replacement rollback exited ${RB_RC} (output above)"
+  exit 1
+fi
 if ! grep -qi 'reverse-replace\|Reversing replacement' /tmp/rollback-sqs-rb.log; then
   echo "[verify] FAIL: rollback output does not mention the reverse-replacement"
   exit 1
@@ -346,8 +356,16 @@ fi
 echo "[verify] step 8 ok: failing state re-created, journal retained"
 
 echo "[verify] step 9: NO-CHANGE fix-forward deploy (bad resource removed) must clear the journal (PR #1212 regression)"
+# Same echo-before-assert pattern as step 4 (issue #1220).
+set +e
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" > /tmp/rollback-sqs-fixforward.log 2>&1
+FF_RC=$?
+set -e
 sed 's/^/  /' /tmp/rollback-sqs-fixforward.log || true
+if [ "${FF_RC}" -ne 0 ]; then
+  echo "[verify] FAIL: fix-forward deploy exited ${FF_RC} (output above)"
+  exit 1
+fi
 if ! grep -qi 'No changes detected' /tmp/rollback-sqs-fixforward.log; then
   echo "[verify] FAIL: fix-forward deploy was not the no-change path — the #1212 regression is not being exercised"
   exit 1
@@ -359,8 +377,16 @@ fi
 echo "[verify] step 9 ok: no-change deploy cleared the journal"
 
 echo "[verify] step 10: one more clean deploy must NOT print the journal note"
+# Same echo-before-assert pattern as step 4 (issue #1220).
+set +e
 ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" > /tmp/rollback-sqs-clean.log 2>&1
+CLEAN_RC=$?
+set -e
 sed 's/^/  /' /tmp/rollback-sqs-clean.log || true
+if [ "${CLEAN_RC}" -ne 0 ]; then
+  echo "[verify] FAIL: final clean deploy exited ${CLEAN_RC} (output above)"
+  exit 1
+fi
 if grep -qi 'automatically rolled back\|revert-failed' /tmp/rollback-sqs-clean.log; then
   echo "[verify] FAIL: the journal note survived the fix-forward deploy"
   exit 1


### PR DESCRIPTION
## Summary

Surfaced by the 3-axis review on PR #1219: five **success-expected** CLI invocations captured their output to a `/tmp` log while running directly under `set -e`, so a non-zero exit aborted the script BEFORE the `sed` echo — the failing step's CLI output never reached the harness log (it survived only in the machine-local `/tmp` file). Convert all five to the canonical `set +e` / `RC=$?` / `set -e` idiom the failure-expected sites already use, echoing the captured log before asserting the exit code:

- `tests/integration/rollback-command/verify.sh` — steps R2 and F2 (the two success-expected rollbacks).
- `tests/integration/rollback-sqs-cooldown/verify.sh` — step 4 (cooldown rollback), step 9 (NO-CHANGE fix-forward deploy), step 10 (final clean deploy).

A repo-wide sweep found no other affected sites — every other capture is already `set +e`-wrapped (`rollback-failure-injection`, `recreate-via-cc-api`, `eventbridge-pipes` checked). The direct `${CLI} ...` invocation line shape is preserved, so the CLI-flag lint coverage is unchanged (matrix regen produced no diff).

## Test plan

- **Both integs re-run clean against real AWS with the edited scripts** (shipped == verified): `rollback-command` PASS (130s) and `rollback-sqs-cooldown` PASS (180s), destroy clean, 0 orphans, sidecars swept; ledger rows recorded. The success paths of all five converted sites executed live. The new failure branches (echo + FAIL message) were not induced live — they reuse the idiom the same scripts' failure-expected sites already exercise.
- Fixture lints green (signal-traps / probe-not-found / cli-flags, 189 tests), `bash -n` clean, full suite 467 files / 7820 tests, `cli-flag-coverage` regen no-diff.
- A lint distinguishing success-expected captures from `set +e` blocks is deliberately deferred (see the issue) — the surface was 5 sites and the existing lints don't model control flow.

Closes #1220
