### PR TITLE
chore(docs): regenerate cli-flag-coverage for new annotation flags

### DIFF
--- a/docs/_generated/cli-flag-coverage.json
+++ b/docs/_generated/cli-flag-coverage.json
@@ -10,6 +10,7 @@
     "--exclusively",
     "--force",
     "--force-stateful-recreation",
+    "--ignore-errors",
     "--image-build-concurrency",
     "--no-aggressive-vpc-parallel",
     "--no-auto-asset-storage",
@@ -32,6 +33,7 @@
     "--stack-concurrency",
     "--state-bucket",
     "--state-prefix",
+    "--strict",
     "--strict-getatt",
     "--use-cdk-bootstrap-assets",
     "--verbose",
@@ -1104,13 +1106,15 @@
     "--allow-unsupported-types",
     "--asset-publish-concurrency",
     "--context",
+    "--ignore-errors",
     "--image-build-concurrency",
     "--no-aggressive-vpc-parallel",
     "--no-capture-observed-state",
     "--prefix-user-supplied-names",
     "--role-arn",
     "--stack",
-    "--stack-concurrency"
+    "--stack-concurrency",
+    "--strict"
   ],
   "unknownFlagsInIntegs": [
     "--Arn--",

--- a/docs/cli-flag-coverage.md
+++ b/docs/cli-flag-coverage.md
@@ -4,7 +4,7 @@
 
 Run `vp run cli-flag-coverage` to regenerate.
 
-**26 / 36 declared CLI flags** appear in at least one `tests/integration/<name>/verify.sh` script. 10 flags are not exercised by any integ verify.sh.
+**26 / 38 declared CLI flags** appear in at least one `tests/integration/<name>/verify.sh` script. 12 flags are not exercised by any integ verify.sh.
 
 ## Important: this is a VISIBILITY report, not a CI gate
 
@@ -12,13 +12,14 @@ Many cdkd flags are tested at the **unit-test level** rather than via an integ `
 
 See the script docstring for the design rationale; the *coverage numbers* here are intentionally not wired to a CI hard-fail (contrast with the provider-coverage matrix in [docs/integ-coverage.md](integ-coverage.md), where a coverage gate IS appropriate because every registered provider is expected to have real-AWS verification). CI does, however, run a *staleness* check on this generated file — `vp run cli-flag-coverage` followed by `git diff --exit-code` — so the matrix cannot silently drift; that guards freshness, not coverage %.
 
-## Flags with no integ verify.sh mention (10)
+## Flags with no integ verify.sh mention (12)
 
 Reviewer judgment required per flag — many of these are pure-logic flags adequately tested at the unit level.
 
 - `--allow-unsupported-types`
 - `--asset-publish-concurrency`
 - `--context`
+- `--ignore-errors`
 - `--image-build-concurrency`
 - `--no-aggressive-vpc-parallel`
 - `--no-capture-observed-state`
@@ -26,6 +27,7 @@ Reviewer judgment required per flag — many of these are pure-logic flags adequ
 - `--role-arn`
 - `--stack`
 - `--stack-concurrency`
+- `--strict`
 
 ## Flags exercised by integ verify.sh (26)
 


### PR DESCRIPTION
## Summary

Fix-forward for the CI staleness failure PR #1231 introduced: the two new annotation flags (`--strict` / `--ignore-errors`, issue #1230) changed the declared-flag count (36 -> 38), which staled the generated `docs/cli-flag-coverage.{md,json}`. CI's `cli-flag-coverage matrix is up-to-date` step hard-fails on that drift, so main's `check-build-test` is currently red. This PR is the `vp run cli-flag-coverage` regeneration only — no behavior change.

Root cause of the miss: the `/verify-pr` coverage-matrix step only regenerates when integ fixtures / providers change; a flag-only diff slips past that trigger, and the merge went through without re-confirming the final CI verdict.

## Test plan

- [x] `vp run cli-flag-coverage` output committed verbatim (26/38 exercised, 12 uncovered — the two new flags join the visibility list)
