### PR TITLE
chore(skills): regenerate cli-flag-coverage on flag-declaring diffs in verify-pr

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -63,10 +63,18 @@ Run each check and report pass/fail:
      ```bash
      fixtures_changed=$(git diff main...HEAD --name-only | grep -qE '^src/provisioning/register-providers\.ts$|^tests/integration/[^/]+/(lib|bin)/.+\.ts$|^tests/integration/[^/]+/\.scenarios\.json$|^tests/integration/[^/]+/verify\.sh$' && echo yes)
      providers_changed=$(git diff main...HEAD --name-only | grep -qE '^src/provisioning/register-providers\.ts$' && echo yes)
+     # cli-flag-coverage counts DECLARED flags, so a flag-only diff (options.ts
+     # or a command file adding/removing an Option) stales it with NO fixture
+     # change — PR #1231 (--strict/--ignore-errors) merged that way and turned
+     # main's check-build-test red until the regen landed (PR #1232).
+     cli_flags_changed=$(git diff main...HEAD --name-only | grep -qE '^src/cli/options\.ts$|^src/cli/commands/.+\.ts$' && echo yes)
 
      if [ "$fixtures_changed" = "yes" ]; then
        vp run integ-coverage
        vp run scenario-coverage
+     fi
+
+     if [ "$fixtures_changed" = "yes" ] || [ "$cli_flags_changed" = "yes" ]; then
        vp run cli-flag-coverage
      fi
 


### PR DESCRIPTION
## Summary

Process fix for the PR #1231 incident: `docs/cli-flag-coverage.{md,json}` counts DECLARED CLI flags, so a flag-only diff (adding an Option in `src/cli/options.ts` or a command file) stales the generated matrix with NO fixture change — but `/verify-pr` step 5 only regenerated it when integ fixtures changed. #1231 added `--strict` / `--ignore-errors`, slipped past the trigger, and turned main's `check-build-test` red on the CI staleness gate until the regen landed (#1232).

This adds a `cli_flags_changed` trigger (`src/cli/options.ts` or `src/cli/commands/**`) that runs `vp run cli-flag-coverage` independently of the fixture trigger, with an inline comment recording the incident.

Skills-only diff — no runtime behavior change.

## Test plan

- [x] Trigger regex verified against the #1231 diff shape (options.ts + command files fire it) and a docs-only diff (does not fire)
