### PR TITLE
test(integ): complete the TTL-refresh sweep (104 stale integs green) + fixture hardening

### DIFF
--- a/.claude/skills/pick-integ/SKILL.md
+++ b/.claude/skills/pick-integ/SKILL.md
@@ -38,15 +38,18 @@ the orchestrator runs the chosen tests via `/run-integ` (which records each run 
    now=$(date -u +%s)
    # The ledger merges with the union driver (.gitattributes), so a rare
    # same-test collision can leave duplicate rows — the LAST row per test is
-   # authoritative (deduped below before any staleness math).
+   # authoritative (deduped below before any staleness math). The header is
+   # MULTIPLE `#` comment lines — skip them all (a single NR==1 guard used to
+   # let later header lines through as phantom stale rows); DEDUPED holds
+   # data rows only.
    DEDUPED="$(mktemp)"
-   awk -F'\t' 'NR==1{print; next} {last[$1]=$0; order[$1]=NR} END{for (t in last) print last[t]}' "$LEDGER" > "$DEDUPED"
+   awk -F'\t' '/^#/{next} {last[$1]=$0} END{for (t in last) print last[t]}' "$LEDGER" > "$DEDUPED"
    # never-run: fixtures with no ledger row
    comm -23 \
      <(ls -d tests/integration/*/ | sed 's#tests/integration/##;s#/##' | sort) \
-     <(awk -F'\t' 'NR>1{print $1}' "$DEDUPED" | sort)
+     <(awk -F'\t' '{print $1}' "$DEDUPED" | sort)
    # stale (>14d) or failing, from the ledger:
-   awk -F'\t' -v now="$now" 'NR>1 {
+   awk -F'\t' -v now="$now" '{
      cmd="date -u -j -f %Y-%m-%dT%H:%M:%SZ \""$2"\" +%s 2>/dev/null || date -u -d \""$2"\" +%s 2>/dev/null";
      cmd | getline t; close(cmd);
      age=int((now-t)/86400);

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -162,7 +162,7 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
     and remove the holder ONLY when it has 0 attached containers (a
     non-empty one may belong to a live parallel run).
 
-    When BOTH return empty AND the integ test exited cleanly:
+    When all three return empty AND the integ test exited cleanly:
 
     ```bash
     mise exec -- markgate set integ-local

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -143,12 +143,24 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
     addition to the conditions above for `integ-destroy`):
 
     ```bash
-    # Both queries MUST return empty. If either lists any IDs, the
+    # All three queries MUST return empty. If any lists IDs, the
     # marker is NOT set and the user is shown the orphan container /
     # network IDs to clean up via `docker rm -f` / `docker network rm`.
     docker ps --filter name=cdkd-local- --format '{{.ID}}'
     docker network ls --filter name=cdkd-local-task- --format '{{.ID}}'
+    docker network ls --filter name=cdkd-local-svc- --format '{{.ID}}'
     ```
+
+    Subnet-overlap gotcha (seen 2026-07-27): `cdkd local start-service`
+    creates its shared network on the FIXED subnet `169.254.171.0/24`,
+    so a `local-start-*` test can fail with `Pool overlaps with other
+    one on this address space` even when all three queries above are
+    empty — a foreign leftover network (e.g. cdk-local's `cdkl-svc-*`
+    from a crashed run) may own that subnet. Diagnose with
+    `docker network inspect $(docker network ls -q) --format
+    '{{.Name}} {{range .IPAM.Config}}{{.Subnet}}{{end}} {{len .Containers}}'`
+    and remove the holder ONLY when it has 0 attached containers (a
+    non-empty one may belong to a live parallel run).
 
     When BOTH return empty AND the integ test exited cleanly:
 

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -152,11 +152,11 @@ local-ecs-service-connect	2026-06-21T11:00:28Z	PASS	20	verify.sh	sweep-4..8 stal
 local-invoke	2026-07-20T03:08:51Z	PASS	120	verify.sh	integ-local refresh for pattern-2 sweep (local-start-alb-from-state probe change); docker sweep clean
 local-invoke-agentcore	2026-06-21T10:51:48Z	PASS	103	verify.sh	creds materialized (export-credentials); 21 tests; arm64-native container (no qemu); docker clean
 local-invoke-agentcore-from-state	2026-06-21T10:51:48Z	PASS	55	verify.sh	creds materialized; 8 del 0 err; --from-state intrinsic env-var substitution; docker clean
-local-invoke-buildkit	2026-06-21T11:00:28Z	PASS	32	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-invoke-container	2026-06-21T11:00:28Z	PASS	29	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-invoke-dotnet	2026-06-21T11:00:28Z	PASS	78	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-invoke-from-cfn-stack	2026-06-21T11:00:28Z	PASS	100	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-invoke-from-cfn-stack-multi-stack	2026-07-26T20:29:11Z	FAIL	10	verify.sh	fixture staleness: global cdk 2.1120 vs assembly schema 54; fixture now vendors aws-cdk, re-run queued
+local-invoke-buildkit	2026-07-26T20:35:19Z	PASS	18	verify.sh	0727b sweep-L5 staleness re-run (rc=0); docker + account clean
+local-invoke-container	2026-07-26T20:35:19Z	PASS	24	verify.sh	0727b sweep-L5 staleness re-run (rc=0); docker + account clean
+local-invoke-dotnet	2026-07-26T20:35:19Z	PASS	58	verify.sh	0727b sweep-L5 staleness re-run (rc=0); docker + account clean
+local-invoke-from-cfn-stack	2026-07-26T20:35:19Z	PASS	91	verify.sh	re-run with vendored aws-cdk CLI (schema-54 fix); live-verified, docker + account + CFn clean
+local-invoke-from-cfn-stack-multi-stack	2026-07-26T20:35:19Z	PASS	113	verify.sh	re-run with vendored aws-cdk CLI (schema-54 fix); live-verified, docker + account + CFn clean
 local-invoke-from-state	2026-07-26T20:29:11Z	PASS	61	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean
 local-invoke-java	2026-07-26T20:29:11Z	PASS	36	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean
 local-invoke-layers	2026-07-26T20:29:11Z	PASS	17	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -161,12 +161,12 @@ local-invoke-from-state	2026-06-21T11:00:28Z	PASS	61	verify.sh	sweep-4..8 stalen
 local-invoke-java	2026-06-21T11:00:28Z	PASS	51	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 local-invoke-layers	2026-06-21T11:00:28Z	PASS	23	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 local-invoke-provided	2026-06-21T11:00:28Z	PASS	36	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-invoke-python	2026-06-21T11:00:28Z	PASS	56	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-invoke-ruby	2026-06-21T11:00:28Z	PASS	51	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-run-task	2026-06-21T11:00:28Z	PASS	19	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-run-task-awsvpc	2026-06-21T11:00:28Z	PASS	9	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+local-invoke-python	2026-07-26T20:22:00Z	PASS	23	verify.sh	0727b sweep-L3 staleness re-run (rc=0); docker + account clean
+local-invoke-ruby	2026-07-26T20:22:00Z	PASS	33	verify.sh	0727b sweep-L3 staleness re-run (rc=0); docker + account clean
+local-run-task	2026-07-26T20:22:00Z	PASS	14	verify.sh	0727b sweep-L3 staleness re-run (rc=0); docker + account clean
+local-run-task-awsvpc	2026-07-26T20:22:00Z	PASS	10	verify.sh	0727b sweep-L3 staleness re-run (rc=0); docker + account clean
 local-run-task-cdkd-assets	2026-07-16T17:53:49Z	PASS	95	verify.sh	classifier regression for issue-1025 marker-based repo match; docker sweep clean
-local-run-task-from-state	2026-06-21T11:00:28Z	PASS	96	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+local-run-task-from-state	2026-07-26T20:22:00Z	PASS	105	verify.sh	0727b sweep-L3 staleness re-run (rc=0); docker + account clean
 local-run-task-multi-container	2026-07-26T20:18:09Z	PASS	12	verify.sh	0727b sweep-L2 staleness re-run (rc=0); docker + account clean
 local-start-agentcore	2026-06-21T19:11:23Z	PASS	70	verify.sh	staleness re-run (15d); warm HTTP contract ping+invocations+session-id, /ws bridge, --sigv4-signed forward; aws-cdk-lib 2.260 OK; 0 container leak
 local-start-alb	2026-07-26T20:18:09Z	PASS	22	verify.sh	0727b sweep-L2 staleness re-run (rc=0); docker + account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -120,7 +120,7 @@ iam-propagation-stress	2026-07-26T18:57:55Z	PASS	71	verify.sh	0727b sweep-b7 sta
 iam-role-policies-drift-clean	2026-07-26T18:57:55Z	PASS	84	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 iam-role-prefixed-name-update	2026-07-26T16:45:28Z	PASS	71	verify.sh	#1160 iam-role removal phase 3 verified; destroy 1/0 errors, 0 orphans
 import-attributes	2026-07-21T13:51:28Z	PASS	42	verify.sh	post import-tag-walk refactor #1139; attr reconstruct+destroy clean
-import-auto-mode	2026-07-21T13:53:15Z	PASS	74	verify.sh	post import-tag-walk refactor #1139; CFn physId resolve (no tag) clean
+import-auto-mode	2026-07-26T20:53:45Z	PASS	85	verify.sh	re-run with vendored aws-cdk CLI (npx determinism); live-verified, account + CFn clean
 import-nested-stack	2026-07-21T13:59:14Z	PASS	144	verify.sh	post import-tag-walk refactor #1139; recursive import+nested destroy clean
 import-value-strong-ref	2026-07-22T07:11:17Z	PASS		verify.sh	TTL-refresh sweep; 2-stack S3+SSM strong-ref, Producer 5 del 0 err, state.json gone both stacks, 0 orphans
 importvalue-chain	2026-07-22T07:13:56Z	PASS		verify.sh	TTL-refresh sweep; 3-stack A->B->C ImportValue chain, all destroyed 0 err, exports index purged, state gone

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -80,17 +80,17 @@ dynamodb-tableclass-switch	2026-07-02T06:15:28Z	PASS	95	verify.sh	new fixture: T
 dynamodb-ttl-attr-change	2026-06-27T18:40:49Z	PASS		verify.sh	TTL attr-change rejected w/ actionable error; clean destroy (re-run post nit-fix)
 ec2-instance	2026-07-26T16:41:51Z	PASS	123	verify.sh	0727 P0 sweep (ec2-provider changed #1175/#1177); clean destroy 0 orphans
 ec2-vpc	2026-07-26T17:21:15Z	PASS	35	standard	issue 1241 fix verified: explicit DESTROY FlowLog LogGroup; 20 deleted 0 retained 0 orphans
-ecr	2026-06-21T11:00:28Z	PASS	39	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+ecr	2026-07-26T18:36:31Z	PASS	85	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 ecr-scanning	2026-07-20T17:37:23Z	PASS	56	verify.sh	ECR scanOnPush + tag add/change/untag update, clean destroy
 ecs-fargate	2026-07-26T17:17:11Z	PASS	388	verify.sh	issue 1236 fix verified: DescribeType throttle retry; update phase green, destroy clean 0 orphans
 ecs-service-update-props	2026-07-23T08:20:10Z	PASS		verify.sh	#1173 re-run after VersionConsistency norm; Phase1f + drift clean; destroy 15 del 0 err 0 orph
 efs-immutable-replacement	2026-07-19T19:05:41Z	PASS	76	verify.sh	rc ok, 1 deleted, orph clean
-efs-lambda	2026-06-21T14:48:46Z	PASS	560	standard	sweep-G standard re-run (rc=0)
-efs-standalone	2026-06-21T16:16:44Z	PASS	135	verify.sh	stale-real re-run; 11 deleted 0 err; clean
+efs-lambda	2026-07-26T18:36:31Z	PASS	499	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
+efs-standalone	2026-07-26T18:36:31Z	PASS	148	verify.sh	0727b sweep-b4 staleness re-run (rc=0); account clean
 elasticache-replicationgroup-getatt	2026-07-20T14:51:32Z	PASS	596	verify.sh	CC GetAtt PrimaryEndPoint real hostname, 0 orphans
 emr-cluster	2026-07-19T18:32:52Z	PASS	1560	verify.sh	issue #1090 import round-trip w/ discriminating assertions (attributes from #1099, observed-vs-template divergence); 12 deleted 0 errors 0 orphans
 emr-instance-configs	2026-07-19T12:15:47Z	PASS	1680	verify.sh	post-review re-run (fleet scale-down fix); deploy+resize+destroy clean, 0 orphans
-event-driven	2026-06-21T11:00:28Z	PASS	35	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+event-driven	2026-07-26T18:36:31Z	PASS	42	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 eventbridge	2026-07-20T17:32:58Z	PASS	82	verify.sh	EventBus+Pipes+Scheduler, 10 res clean destroy
 eventbridge-api-destination	2026-07-21T14:48:06Z	PASS	70	verify.sh	rc ok, orph clean
 eventbridge-archive	2026-07-16T15:54:15Z	PASS	53	verify.sh	new fixture, 3 phases clean, orph clean
@@ -105,7 +105,7 @@ fsx-lustre	2026-07-20T05:01:58Z	PASS	1140	verify.sh	PR #1114 §3b always-emit + 
 fsx-ontap	2026-07-20T01:29:32Z	PASS	1590	verify.sh	issue #1088 ONTAP: DiskIopsConfiguration read back from AWS (Mode+Iops), aws_query_ids hardening; 8 deleted 0 errors 0 orphans
 fsx-openzfs	2026-07-19T16:00:39Z	PASS	1380	verify.sh	re-run after review fixes; drift+observedProperties asserted; 8 deleted 0 errors 0 orphans
 fsx-windows	2026-07-20T02:35:13Z	PASS	5460	verify.sh	issue #1088 Windows AD-joined: 7 phases, DiskIopsConfiguration read back, ENIs released 192s; 11 deleted 0 errors 0 orphans
-full-stack-demo	2026-06-21T11:00:28Z	PASS	31	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+full-stack-demo	2026-07-26T18:36:31Z	PASS	41	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 gc-custom-asset-names	2026-07-16T18:11:36Z	PASS	169	verify.sh	us-west-2; re-run after review hardening (own-marker guard); clean
 getatt-fallback-guard	2026-07-20T05:59:44Z	PASS	300	verify.sh	4-phase incl. strict-output state-persistence guarantee (#1111 blocker fix); 0 orphans
 getstackoutput-crossregion	2026-06-21T18:33:45Z	PASS	60	verify.sh	first run (never-run); cross-region Fn::GetStackOutput (us-west-2 producer -> us-east-1 consumer); both regions clean
@@ -136,7 +136,7 @@ lambda-config-field-removal	2026-07-22T08:19:38Z	PASS	140	verify.sh	issue #1158 
 lambda-destinations	2026-07-21T18:15:21Z	PASS	81	verify.sh	fixture fix: EventInvokeConfig now sdk-routed (#919); rc ok, orph clean
 lambda-env-removal	2026-06-29T03:14:52Z	PASS	61	verify.sh	nested map key (Lambda env var) removal reaches AWS
 lambda-event-invoke-config-update	2026-07-26T18:20:27Z	PASS	80	verify.sh	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda-layer-version-update	2026-07-26T18:20:27Z	FAIL	55	verify.sh	fixture staleness: hardcoded layer :1 vs monotonic version counter; fixed in-branch, re-run queued
+lambda-layer-version-update	2026-07-26T18:36:31Z	PASS	79	verify.sh	re-run after version-agnostic fixture fix; live-verified, account clean
 lambda-log-retention	2026-07-21T14:46:30Z	PASS	95	verify.sh	rc ok, orph clean
 lambda-microvm-image	2026-07-22T07:52:25Z	PASS	700	verify.sh	create+tags+drift+destroy + --no-wait + destroy, 2 builds, 0 orphans
 lambda-reserved-concurrency	2026-06-27T19:25:47Z	PASS	47	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -5,11 +5,11 @@
 # GENERATED SHAPE - do not hand-edit. After recording a run, run:
 #   vp run integ-ledger-normalize
 # CI enforces this; a non-normalized file fails check-build-test.
-acm-certificate	2026-06-21T11:00:28Z	PASS	20	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+acm-certificate	2026-07-26T18:49:34Z	PASS	25	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
 agentcore-tools	2026-07-17T12:05:03Z	PASS	180	verify.sh	3 phases clean; adopt-only singletons + evaluator CRUD; name regex fix (no hyphens)
 alb	2026-07-02T18:23:15Z	PASS	62	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
-alb-advanced	2026-06-21T11:00:28Z	PASS	54	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-api-cognito	2026-06-21T11:00:28Z	PASS	66	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+alb-advanced	2026-07-26T18:49:34Z	PASS	63	standard	0727b sweep-b6 staleness re-run (rc=0); account clean
+api-cognito	2026-07-26T18:49:34Z	PASS	75	standard	0727b sweep-b6 staleness re-run (rc=0); account clean
 apigateway	2026-07-21T14:32:25Z	PASS	56	verify.sh	rc ok, orph clean
 apigatewayv2-update-removal	2026-07-22T14:04:44Z	PASS		verify.sh	issue-1160 apigwv2 batch: 5-API removal reset live-verified, Cors via DeleteCorsConfiguration, destroy 0 err/0 orph
 apigw-gateway-response	2026-07-16T16:48:47Z	PASS	117	verify.sh	issue-1017 fix live-verify, warn 1->0 + rendering sample, orph clean
@@ -224,7 +224,7 @@ s3-lifecycle	2026-07-21T14:28:43Z	PASS	58	verify.sh	rc ok, orph clean
 s3-object-lock	2026-07-21T14:42:20Z	PASS	53	verify.sh	rc ok, orph clean
 s3-replication-and-filter	2026-07-21T14:43:45Z	PASS	63	verify.sh	rc ok, orph clean
 s3-tables	2026-07-03T07:18:47Z	PASS	45	verify.sh	CC-routed Table Ref resolves to table name (#974); clean destroy
-s3-vectors	2026-06-21T18:03:30Z	PASS	34	verify.sh	stale-real re-run; 1 deleted 0 err; clean
+s3-vectors	2026-07-26T18:49:34Z	PASS	43	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
 scheduled-task	2026-07-26T18:04:53Z	PASS	44	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 scheduler-custom-group	2026-07-02T12:35:05Z	PASS	98	verify.sh	new fixture (issue 961): custom-group UPDATE + schedule-only removal + destroy clean
 schema-v5-to-v6-migration	2026-07-24T10:27:22Z	PASS	61	verify.sh	0724 P0 sweep: v5->v8 transparent upgrade verified; 1 del 0 err
@@ -237,7 +237,7 @@ serverless-api	2026-07-02T18:23:15Z	PASS	50	verify.sh	0703 staleness sweep (pre-
 servicediscovery	2026-07-19T19:00:29Z	PASS	111	verify.sh	rc ok, 3 deleted, orph clean
 servicediscovery-namespaces	2026-07-17T12:12:19Z	PASS	114	verify.sh	re-run post review fixes (import kind filter, PrivateDns tag sync, resolver HostedZoneId); clean, 0 orphans
 ses-identity	2026-07-21T14:41:07Z	PASS	199	verify.sh	PASS on re-run; 1st attempt hit transient 403 token-expiry (not a cdkd bug), cleaned orphan config-set
-sg-circular-dependency	2026-06-21T18:54:29Z	PASS	180	verify.sh	first run (never-run); circular SG cross-ref via standalone ingress; revoke-before-delete destroy order; 11 deleted 0 err
+sg-circular-dependency	2026-07-26T18:49:34Z	PASS	51	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
 sns-event-source	2026-07-20T08:12:14Z	PASS	68	verify.sh	rc ok, orph clean
 sns-inline-subscription	2026-07-20T17:38:28Z	PASS	53	verify.sh	SNS inline subscription create+update, clean destroy
 sns-sqs-event	2026-07-26T17:01:09Z	PASS	78	verify.sh	#1160 sqs SSE removal phase 2 verified; destroy 20/0 errors, 0 orphans
@@ -250,7 +250,7 @@ stepfunctions	2026-07-21T13:08:15Z	PASS	97	verify.sh	converted; SM ACTIVE w/ aut
 stepfunctions-logging	2026-07-20T17:36:15Z	PASS	117	verify.sh	SFN Express logging/tracing removal-clear, clean destroy
 stepfunctions-s3-definition	2026-07-02T18:23:15Z	PASS	33	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 synthetics-canary	2026-07-02T06:31:54Z	PASS	134	verify.sh	new fixture; remnant-cleanup regression guard; deploy+update+destroy clean
-tags-propagation	2026-06-21T18:17:20Z	PASS		verify.sh	first run (never-run); tag propagation across 9 resource types; no tag-order false-positive; 9 deleted 0 err
+tags-propagation	2026-07-26T18:49:34Z	PASS	63	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
 throttle-wide-dag	2026-07-02T18:23:15Z	PASS	163	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 update-policy-mutations	2026-07-21T14:01:35Z	PASS	74	verify.sh	post #1138 UpdateReplacePolicy Retain guard fix on merged main; retain honored, 0 leftover
 update-replace	2026-07-21T07:23:47Z	PASS	80	verify.sh	in-place+replace, 7 deleted 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -136,7 +136,7 @@ lambda-config-field-removal	2026-07-22T08:19:38Z	PASS	140	verify.sh	issue #1158 
 lambda-destinations	2026-07-21T18:15:21Z	PASS	81	verify.sh	fixture fix: EventInvokeConfig now sdk-routed (#919); rc ok, orph clean
 lambda-env-removal	2026-07-26T19:16:39Z	PASS	70	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-event-invoke-config-update	2026-07-26T18:20:27Z	PASS	80	verify.sh	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda-layer-version-update	2026-07-26T18:36:31Z	PASS	79	verify.sh	re-run after version-agnostic fixture fix; live-verified, account clean
+lambda-layer-version-update	2026-07-26T21:13:17Z	PASS	82	verify.sh	re-run post review fixes (tab-safe version list); account clean
 lambda-log-retention	2026-07-21T14:46:30Z	PASS	95	verify.sh	rc ok, orph clean
 lambda-microvm-image	2026-07-22T07:52:25Z	PASS	700	verify.sh	create+tags+drift+destroy + --no-wait + destroy, 2 builds, 0 orphans
 lambda-reserved-concurrency	2026-07-26T19:05:27Z	PASS	56	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
@@ -152,8 +152,8 @@ local-invoke-agentcore-from-state	2026-07-26T20:40:20Z	PASS	86	verify.sh	0727b s
 local-invoke-buildkit	2026-07-26T20:35:19Z	PASS	18	verify.sh	0727b sweep-L5 staleness re-run (rc=0); docker + account clean
 local-invoke-container	2026-07-26T20:35:19Z	PASS	24	verify.sh	0727b sweep-L5 staleness re-run (rc=0); docker + account clean
 local-invoke-dotnet	2026-07-26T20:35:19Z	PASS	58	verify.sh	0727b sweep-L5 staleness re-run (rc=0); docker + account clean
-local-invoke-from-cfn-stack	2026-07-26T20:35:19Z	PASS	91	verify.sh	re-run with vendored aws-cdk CLI (schema-54 fix); live-verified, docker + account + CFn clean
-local-invoke-from-cfn-stack-multi-stack	2026-07-26T20:35:19Z	PASS	113	verify.sh	re-run with vendored aws-cdk CLI (schema-54 fix); live-verified, docker + account + CFn clean
+local-invoke-from-cfn-stack	2026-07-26T21:13:17Z	PASS	94	verify.sh	re-run post review fixes; install-guard exercised via fresh node_modules direct run (rc=0); clean
+local-invoke-from-cfn-stack-multi-stack	2026-07-26T21:13:17Z	PASS	113	verify.sh	re-run post review fixes; docker + account + CFn clean
 local-invoke-from-state	2026-07-26T20:29:11Z	PASS	61	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean
 local-invoke-java	2026-07-26T20:29:11Z	PASS	36	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean
 local-invoke-layers	2026-07-26T20:29:11Z	PASS	17	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -25,11 +25,8 @@ backup	2026-07-26T20:07:41Z	PASS	67	verify.sh	0727b sweep-b14 staleness re-run (
 basic	2026-07-20T04:38:04Z	PASS	83	standard	rc 0/0, 0 orphans; validates buildProgram entry-point refactor (#1097)
 batch	2026-07-26T18:43:33Z	PASS	89	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 bedrock-agentcore	2026-07-24T04:22:29Z	PASS	42	standard	import() attr enrich (#1188); GetAgentRuntime live-probe confirms field shape; 6 del 0 err
-bench-ccapi	2026-06-21T11:00:28Z	PASS	80	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-bench-cdk-sample	2026-07-26T18:02:31Z	PASS	900	standard	#1238 guard broad verify; 39 created, destroy 37 del 2 retained-swept 0 err, log groups swept
-bench-sdk	2026-06-21T11:00:28Z	PASS	24	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 bench-ccapi	2026-07-26T18:43:33Z	PASS	89	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
-bench-cdk-sample	2026-07-24T09:09:05Z	PASS	1560	standard	cross-region us-west-2 vs us-east-1 bucket (issue #1202 hint-less CR presign live-verified); 39 res, destroy 37 del 2 retained-swept 0 err
+bench-cdk-sample	2026-07-26T18:02:31Z	PASS	900	standard	#1238 guard broad verify; 39 created, destroy 37 del 2 retained-swept 0 err, log groups swept
 bench-sdk	2026-07-26T18:43:33Z	PASS	33	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 bootstrap-free-region	2026-07-16T15:34:01Z	PASS	81	verify.sh	re-run after PR 1015 review fix-back (region-resolver owner header), 0 orphans
 bucket-deployment	2026-07-21T18:02:21Z	PASS	125	verify.sh	rc ok, orph clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -125,7 +125,7 @@ import-nested-stack	2026-07-21T13:59:14Z	PASS	144	verify.sh	post import-tag-walk
 import-value-strong-ref	2026-07-22T07:11:17Z	PASS		verify.sh	TTL-refresh sweep; 2-stack S3+SSM strong-ref, Producer 5 del 0 err, state.json gone both stacks, 0 orphans
 importvalue-chain	2026-07-22T07:13:56Z	PASS		verify.sh	TTL-refresh sweep; 3-stack A->B->C ImportValue chain, all destroyed 0 err, exports index purged, state gone
 infra-security	2026-07-26T18:20:27Z	PASS	186	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
-inplace-attr-propagation	2026-06-29T02:40:51Z	PASS	47	verify.sh	in-place upstream attr propagates to GetAtt dependent
+inplace-attr-propagation	2026-07-26T19:25:15Z	PASS	57	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 intrinsic-functions	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
 intrinsics-torture	2026-07-21T05:24:57Z	PASS	48	verify.sh	rc ok, orph clean
 intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
@@ -134,7 +134,7 @@ kinesis-stream-mode-switch	2026-07-26T18:57:55Z	PASS	73	verify.sh	0727b sweep-b7
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
 lambda	2026-07-26T15:31:59Z	PASS	85	verify.sh	PR #1231 broad integ; destroy 0 errors 0 orphans
 lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
-lambda-arch-switch	2026-07-02T06:26:16Z	PASS	60	verify.sh	new fixture: arch switch reaches AWS config+runtime, destroy clean 0 orphans
+lambda-arch-switch	2026-07-26T19:25:15Z	PASS	63	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 lambda-config-field-removal	2026-07-22T08:19:38Z	PASS	140	verify.sh	issue #1158 post-rebase re-verify; 6-field removal reset + destroy clean
 lambda-destinations	2026-07-21T18:15:21Z	PASS	81	verify.sh	fixture fix: EventInvokeConfig now sdk-routed (#919); rc ok, orph clean
 lambda-env-removal	2026-07-26T19:16:39Z	PASS	70	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
@@ -179,8 +179,8 @@ local-start-cloudfront	2026-06-27T16:36:59Z	PASS	5	verify.sh	local serve pipelin
 local-start-service	2026-06-21T14:52:59Z	PASS	21	verify.sh	sweep-G local re-run (rc=0)
 local-start-service-watch-fast	2026-06-21T14:56:24Z	PASS	203	verify.sh	sweep-G local re-run (rc=0)
 log-pipeline	2026-07-26T18:10:48Z	PASS	72	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
-loggroup-class-guard	2026-07-02T06:26:43Z	PASS	50	verify.sh	new fixture: guard error-path + replace recreate, destroy clean 0 orphans
-loggroup-kms-associate	2026-07-02T11:32:39Z	PASS	150	verify.sh	new fixture: KmsKeyId associate+disassociate reach AWS, destroy clean, key PendingDeletion
+loggroup-class-guard	2026-07-26T19:25:15Z	PASS	53	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
+loggroup-kms-associate	2026-07-26T19:25:15Z	PASS	57	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 macro-expansion	2026-07-21T19:45:50Z	PASS	107	verify.sh	re-run w/ new diff-expands + destroy-no-expand asserts (1150)
 microservices	2026-07-19T19:50:37Z	PASS	54	standard	rc ok, 19 res, all destroyed, orph clean
 migrate-from-bare-cfn	2026-07-21T13:56:13Z	PASS	152	verify.sh	post import-tag-walk refactor #1139; bare-CFn migrate 3 types+destroy clean
@@ -226,7 +226,7 @@ s3-replication-and-filter	2026-07-21T14:43:45Z	PASS	63	verify.sh	rc ok, orph cle
 s3-tables	2026-07-03T07:18:47Z	PASS	45	verify.sh	CC-routed Table Ref resolves to table name (#974); clean destroy
 s3-vectors	2026-07-26T18:49:34Z	PASS	43	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
 scheduled-task	2026-07-26T18:04:53Z	PASS	44	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
-scheduler-custom-group	2026-07-02T12:35:05Z	PASS	98	verify.sh	new fixture (issue 961): custom-group UPDATE + schedule-only removal + destroy clean
+scheduler-custom-group	2026-07-26T19:25:15Z	PASS	103	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 schema-v5-to-v6-migration	2026-07-24T10:27:22Z	PASS	61	verify.sh	0724 P0 sweep: v5->v8 transparent upgrade verified; 1 del 0 err
 schema-v6-to-v7-migration	2026-07-24T10:25:01Z	PASS	66	verify.sh	0724 P0 sweep: s3-state-backend #1196/#1203 coverage; v6->v8 transparent upgrade; 1 del 0 err
 schema-v7-to-v8-migration	2026-07-19T19:56:03Z	PASS	100	verify.sh	rc ok, transparent auto-migration, orph clean
@@ -249,7 +249,7 @@ state-info-command	2026-07-19T20:01:06Z	PASS	21	standard	rc ok, state info #1055
 stepfunctions	2026-07-21T13:08:15Z	PASS	97	verify.sh	converted; SM ACTIVE w/ auto role, async-delete poll, 0 orphans
 stepfunctions-logging	2026-07-20T17:36:15Z	PASS	117	verify.sh	SFN Express logging/tracing removal-clear, clean destroy
 stepfunctions-s3-definition	2026-07-02T18:23:15Z	PASS	33	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
-synthetics-canary	2026-07-02T06:31:54Z	PASS	134	verify.sh	new fixture; remnant-cleanup regression guard; deploy+update+destroy clean
+synthetics-canary	2026-07-26T19:25:15Z	PASS	144	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 tags-propagation	2026-07-26T18:49:34Z	PASS	63	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
 throttle-wide-dag	2026-07-02T18:23:15Z	PASS	163	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 update-policy-mutations	2026-07-21T14:01:35Z	PASS	74	verify.sh	post #1138 UpdateReplacePolicy Retain guard fix on merged main; retain honored, 0 leftover

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -42,7 +42,7 @@ ci-cd	2026-07-21T18:23:00Z	PASS	55	verify.sh	rc ok, orph clean
 cloudfront-function-url	2026-07-21T18:29:34Z	PASS	378	verify.sh	rc ok, orph clean
 cloudwatch	2026-07-02T18:23:15Z	PASS	50	standard	0703 staleness sweep (pre-TTL refresh); clean
 codecommit	2026-07-18T19:54:34Z	PASS		verify.sh	Code seed+SNS trigger+rename+drift, destroy 0 err 0 orph (re-run post review-nits)
-codedeploy-lambda-deployment-group	2026-07-26T19:36:49Z	FAIL	74	verify.sh	fixture staleness: hardcoded Lambda version 1/2 vs never-reused version counter; fixed in-branch, re-run queued
+codedeploy-lambda-deployment-group	2026-07-26T19:45:58Z	PASS	109	verify.sh	re-run after version-agnostic fixture fix; live-verified, account clean (remnant-warning follow-up: issue #1252)
 cognito	2026-07-21T14:27:28Z	PASS	60	verify.sh	rc ok, orph clean
 cognito-custom-attribute-add	2026-07-26T19:05:27Z	PASS	57	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 cognito-identity-pool	2026-07-26T19:16:39Z	PASS	53	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
@@ -216,14 +216,14 @@ rollback-command	2026-07-25T05:24:26Z	PASS	130	verify.sh	#1220 echo-before-asser
 rollback-failure-injection	2026-07-24T10:50:16Z	PASS	368	verify.sh	0724b sweep P1: #1212 journal-after-clean-rollback coverage; 17 del 0 err 0 orphans
 rollback-sqs-cooldown	2026-07-25T05:24:26Z	PASS	180	verify.sh	#1220 echo-before-assert on steps 4/9/10, destroy clean
 route53	2026-07-22T07:59:10Z	PASS		verify.sh	TTL-refresh sweep; HostedZone/GeoProximity/CidrRouting backfills, 6 del 0 err, hosted zone + state gone
-s3-asset-deploy	2026-07-02T18:23:15Z	PASS	49	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
+s3-asset-deploy	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 s3-cloudfront	2026-07-26T16:38:01Z	PASS	364	verify.sh	0727 P0 sweep (cloudfront-distribution-provider changed #1175); clean destroy 0 orphans
 s3-directory-bucket	2026-07-20T09:10:31Z	PASS	60	standard	clean deploy+destroy from #1124 tree (integ-destroy gate refresh): 1 deleted 0 err, directory bucket + state gone
 s3-event-notification	2026-07-21T05:28:05Z	PASS	79	verify.sh	rc ok, orph clean
 s3-lifecycle	2026-07-21T14:28:43Z	PASS	58	verify.sh	rc ok, orph clean
 s3-object-lock	2026-07-21T14:42:20Z	PASS	53	verify.sh	rc ok, orph clean
 s3-replication-and-filter	2026-07-21T14:43:45Z	PASS	63	verify.sh	rc ok, orph clean
-s3-tables	2026-07-03T07:18:47Z	PASS	45	verify.sh	CC-routed Table Ref resolves to table name (#974); clean destroy
+s3-tables	2026-07-26T19:45:58Z	PASS	50	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 s3-vectors	2026-07-26T18:49:34Z	PASS	43	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
 scheduled-task	2026-07-26T18:04:53Z	PASS	44	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 scheduler-custom-group	2026-07-26T19:25:15Z	PASS	103	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
@@ -233,7 +233,7 @@ schema-v7-to-v8-migration	2026-07-19T19:56:03Z	PASS	100	verify.sh	rc ok, transpa
 sdk-ccapi-crossref	2026-07-22T07:07:07Z	PASS		verify.sh	P0: CC-provider changes (#1135/#1109) covered; heterogeneous SDK/CC routing + bidirectional cross-ref, 4 del 0 err, state.json gone (deployments/ logs retained)
 secrets-dynamic-ref	2026-07-26T17:14:50Z	PASS	72	verify.sh	#1160 secretsmanager removal phase 2 verified; destroy 4/0 errors, 0 orphans
 secrets-rotation-schedule	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
-serverless-api	2026-07-02T18:23:15Z	PASS	50	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
+serverless-api	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 servicediscovery	2026-07-19T19:00:29Z	PASS	111	verify.sh	rc ok, 3 deleted, orph clean
 servicediscovery-namespaces	2026-07-17T12:12:19Z	PASS	114	verify.sh	re-run post review fixes (import kind filter, PrivateDns tag sync, resolver HostedZoneId); clean, 0 orphans
 ses-identity	2026-07-21T14:41:07Z	PASS	199	verify.sh	PASS on re-run; 1st attempt hit transient 403 token-expiry (not a cdkd bug), cleaned orphan config-set
@@ -248,10 +248,10 @@ state-destroy	2026-07-26T18:04:53Z	PASS	25	standard	0727b sweep-b1 staleness re-
 state-info-command	2026-07-19T20:01:06Z	PASS	21	standard	rc ok, state info #1055 GetBucketLocation exercised, orph clean
 stepfunctions	2026-07-21T13:08:15Z	PASS	97	verify.sh	converted; SM ACTIVE w/ auto role, async-delete poll, 0 orphans
 stepfunctions-logging	2026-07-20T17:36:15Z	PASS	117	verify.sh	SFN Express logging/tracing removal-clear, clean destroy
-stepfunctions-s3-definition	2026-07-02T18:23:15Z	PASS	33	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
+stepfunctions-s3-definition	2026-07-26T19:45:58Z	PASS	43	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 synthetics-canary	2026-07-26T19:25:15Z	PASS	144	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 tags-propagation	2026-07-26T18:49:34Z	PASS	63	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
-throttle-wide-dag	2026-07-02T18:23:15Z	PASS	163	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
+throttle-wide-dag	2026-07-26T19:45:58Z	PASS	186	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 update-policy-mutations	2026-07-21T14:01:35Z	PASS	74	verify.sh	post #1138 UpdateReplacePolicy Retain guard fix on merged main; retain honored, 0 leftover
 update-replace	2026-07-21T07:23:47Z	PASS	80	verify.sh	in-place+replace, 7 deleted 0 orphans
 vpc-lambda	2026-07-26T16:53:02Z	PASS	386	standard	0727 P0 sweep (ec2-provider changed #1175/#1177); 16 deleted 0 err; NAT/ENI/EIP clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -44,15 +44,15 @@ cloudwatch	2026-07-02T18:23:15Z	PASS	50	standard	0703 staleness sweep (pre-TTL r
 codecommit	2026-07-18T19:54:34Z	PASS		verify.sh	Code seed+SNS trigger+rename+drift, destroy 0 err 0 orph (re-run post review-nits)
 codedeploy-lambda-deployment-group	2026-07-02T04:43:08Z	PASS	100	verify.sh	new fixture: IAM-propagation retry + version/alias update, 0 orphans
 cognito	2026-07-21T14:27:28Z	PASS	60	verify.sh	rc ok, orph clean
-cognito-custom-attribute-add	2026-06-22T05:14:50Z	PASS	50	verify.sh	add-custom-attr reaches AWS via AddCustomAttributes; re-run on final tree; clean destroy
+cognito-custom-attribute-add	2026-07-26T19:05:27Z	PASS	57	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 cognito-identity-pool	2026-06-27T19:25:47Z	PASS	44	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
 cognito-lambda-triggers	2026-07-21T18:07:01Z	PASS	66	verify.sh	rc ok, orph clean
 cognito-resource-server	2026-07-02T16:12:06Z	PASS	82	verify.sh	ledger backfill (fixture verified at PR time; row was missing)
 cognito-userpool-user-ref	2026-06-28T02:53:29Z	PASS	85	verify.sh	UserPoolUser Ref compound-id fix; repro FAIL->PASS; clean destroy
 composite-stack	2026-07-26T18:43:33Z	PASS	39	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 conditions	2026-07-21T13:08:15Z	PASS	25	verify.sh	converted; Fn::If suppressed prod bucket, 0 orphans
-conditions-and-if	2026-06-21T18:17:20Z	PASS		verify.sh	first run (never-run); CFn Conditions + Fn::If 2-phase premium/basic; 14 assertions; clean destroy 0 err
-conditions-update-2	2026-06-21T18:17:20Z	PASS		verify.sh	first run (never-run); condition-gated resource add/remove across update; 14 assertions; clean destroy 0 err
+conditions-and-if	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
+conditions-update-2	2026-07-26T19:05:27Z	PASS	83	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 context-test	2026-07-26T18:43:33Z	PASS	24	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 cross-region-state-bucket	2026-07-19T18:57:34Z	PASS	33	verify.sh	rc ok, temp bucket removed, orph clean
 cross-stack-references	2026-07-19T19:57:33Z	PASS	27	standard	rc ok, 2 stacks, orph clean
@@ -111,7 +111,7 @@ fsx-windows	2026-07-20T02:35:13Z	PASS	5460	verify.sh	issue #1088 Windows AD-join
 full-stack-demo	2026-07-26T18:36:31Z	PASS	41	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 gc-custom-asset-names	2026-07-16T18:11:36Z	PASS	169	verify.sh	us-west-2; re-run after review hardening (own-marker guard); clean
 getatt-fallback-guard	2026-07-20T05:59:44Z	PASS	300	verify.sh	4-phase incl. strict-output state-persistence guarantee (#1111 blocker fix); 0 orphans
-getstackoutput-crossregion	2026-06-21T18:33:45Z	PASS	60	verify.sh	first run (never-run); cross-region Fn::GetStackOutput (us-west-2 producer -> us-east-1 consumer); both regions clean
+getstackoutput-crossregion	2026-07-26T19:05:27Z	PASS	79	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 glue-securityconfig-replace	2026-07-26T18:20:27Z	PASS	59	verify.sh	0727b sweep-b3 staleness re-run (rc=0); account clean
 glue-update-hardening	2026-07-02T18:23:15Z	PASS	68	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 iam-managed-policy	2026-07-21T13:08:15Z	PASS	29	verify.sh	converted; policy attached, detach-before-delete clean, 0 orphans
@@ -142,7 +142,7 @@ lambda-event-invoke-config-update	2026-07-26T18:20:27Z	PASS	80	verify.sh	0727b s
 lambda-layer-version-update	2026-07-26T18:36:31Z	PASS	79	verify.sh	re-run after version-agnostic fixture fix; live-verified, account clean
 lambda-log-retention	2026-07-21T14:46:30Z	PASS	95	verify.sh	rc ok, orph clean
 lambda-microvm-image	2026-07-22T07:52:25Z	PASS	700	verify.sh	create+tags+drift+destroy + --no-wait + destroy, 2 builds, 0 orphans
-lambda-reserved-concurrency	2026-06-27T19:25:47Z	PASS	47	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
+lambda-reserved-concurrency	2026-07-26T19:05:27Z	PASS	56	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 lambda-snapstart	2026-07-16T15:54:15Z	PASS	187	verify.sh	new fixture, 3 phases clean, orph clean
 lambda-versioning	2026-07-26T18:10:48Z	PASS	56	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
 launchtemplate-asg-inplace	2026-07-26T13:03:26Z	PASS	90	verify.sh	1225 classification-pins verify; destroy 9/0
@@ -232,7 +232,7 @@ schema-v6-to-v7-migration	2026-07-24T10:25:01Z	PASS	66	verify.sh	0724 P0 sweep: 
 schema-v7-to-v8-migration	2026-07-19T19:56:03Z	PASS	100	verify.sh	rc ok, transparent auto-migration, orph clean
 sdk-ccapi-crossref	2026-07-22T07:07:07Z	PASS		verify.sh	P0: CC-provider changes (#1135/#1109) covered; heterogeneous SDK/CC routing + bidirectional cross-ref, 4 del 0 err, state.json gone (deployments/ logs retained)
 secrets-dynamic-ref	2026-07-26T17:14:50Z	PASS	72	verify.sh	#1160 secretsmanager removal phase 2 verified; destroy 4/0 errors, 0 orphans
-secrets-rotation-schedule	2026-06-27T16:08:39Z	PASS	58	verify.sh	CC-API RotationSchedule create+destroy (no UPDATE by design); 0 errors 0 orphans
+secrets-rotation-schedule	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 serverless-api	2026-07-02T18:23:15Z	PASS	50	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 servicediscovery	2026-07-19T19:00:29Z	PASS	111	verify.sh	rc ok, 3 deleted, orph clean
 servicediscovery-namespaces	2026-07-17T12:12:19Z	PASS	114	verify.sh	re-run post review fixes (import kind filter, PrivateDns tag sync, resolver HostedZoneId); clean, 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -109,7 +109,7 @@ full-stack-demo	2026-06-21T11:00:28Z	PASS	31	standard	sweep-4..8 staleness re-ru
 gc-custom-asset-names	2026-07-16T18:11:36Z	PASS	169	verify.sh	us-west-2; re-run after review hardening (own-marker guard); clean
 getatt-fallback-guard	2026-07-20T05:59:44Z	PASS	300	verify.sh	4-phase incl. strict-output state-persistence guarantee (#1111 blocker fix); 0 orphans
 getstackoutput-crossregion	2026-06-21T18:33:45Z	PASS	60	verify.sh	first run (never-run); cross-region Fn::GetStackOutput (us-west-2 producer -> us-east-1 consumer); both regions clean
-glue-securityconfig-replace	2026-06-21T15:47:49Z	PASS	46	verify.sh	--replace + Glue S3Encryptions silent-drop fix; 0 orphans
+glue-securityconfig-replace	2026-07-26T18:20:27Z	PASS	59	verify.sh	0727b sweep-b3 staleness re-run (rc=0); account clean
 glue-update-hardening	2026-07-02T18:23:15Z	PASS	68	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 iam-managed-policy	2026-07-21T13:08:15Z	PASS	29	verify.sh	converted; policy attached, detach-before-delete clean, 0 orphans
 iam-oidc-provider	2026-07-16T16:48:34Z	PASS	91	verify.sh	issue-1016 fix live-verify, warn 1->0, orph clean
@@ -121,22 +121,22 @@ import-auto-mode	2026-07-21T13:53:15Z	PASS	74	verify.sh	post import-tag-walk ref
 import-nested-stack	2026-07-21T13:59:14Z	PASS	144	verify.sh	post import-tag-walk refactor #1139; recursive import+nested destroy clean
 import-value-strong-ref	2026-07-22T07:11:17Z	PASS		verify.sh	TTL-refresh sweep; 2-stack S3+SSM strong-ref, Producer 5 del 0 err, state.json gone both stacks, 0 orphans
 importvalue-chain	2026-07-22T07:13:56Z	PASS		verify.sh	TTL-refresh sweep; 3-stack A->B->C ImportValue chain, all destroyed 0 err, exports index purged, state gone
-infra-security	2026-06-21T11:00:28Z	PASS	307	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+infra-security	2026-07-26T18:20:27Z	PASS	186	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
 inplace-attr-propagation	2026-06-29T02:40:51Z	PASS	47	verify.sh	in-place upstream attr propagates to GetAtt dependent
-intrinsic-functions	2026-06-21T11:00:28Z	PASS	18	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+intrinsic-functions	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
 intrinsics-torture	2026-07-21T05:24:57Z	PASS	48	verify.sh	rc ok, orph clean
 intrinsics-torture-2	2026-06-21T18:17:20Z	PASS		verify.sh	first run (never-run); intrinsic-function torture; 12 checks; 11 deleted 0 err; SSM cleared
 kinesis-esm-filter	2026-07-24T10:29:51Z	PASS	73	verify.sh	0724 P0 sweep: lambda-eventsource-provider #1194 coverage; FilterCriteria verified; 5 del 0 err
 kinesis-stream-mode-switch	2026-06-22T04:55:10Z	PASS	68	verify.sh	StreamMode switch reaches AWS (re-run on merged tree); unique stream name avoids mode-change rate limit
-kms-encryption	2026-06-21T16:16:44Z	PASS	200	verify.sh	stale-real re-run; deploy ok+destroy 3 del 0 err (split across subshell-death; re-destroyed clean); KMS key PendingDeletion
+kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
 lambda	2026-07-26T15:31:59Z	PASS	85	verify.sh	PR #1231 broad integ; destroy 0 errors 0 orphans
 lambda-alias-provisioned-concurrency	2026-06-27T19:25:47Z	PASS	251	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
 lambda-arch-switch	2026-07-02T06:26:16Z	PASS	60	verify.sh	new fixture: arch switch reaches AWS config+runtime, destroy clean 0 orphans
 lambda-config-field-removal	2026-07-22T08:19:38Z	PASS	140	verify.sh	issue #1158 post-rebase re-verify; 6-field removal reset + destroy clean
 lambda-destinations	2026-07-21T18:15:21Z	PASS	81	verify.sh	fixture fix: EventInvokeConfig now sdk-routed (#919); rc ok, orph clean
 lambda-env-removal	2026-06-29T03:14:52Z	PASS	61	verify.sh	nested map key (Lambda env var) removal reaches AWS
-lambda-event-invoke-config-update	2026-06-21T16:20:26Z	PASS		verify.sh	deploy+drift-clean+update+destroy clean, 0 orphans
-lambda-layer-version-update	2026-06-21T14:58:48Z	PASS	69	verify.sh	LayerVersion content-change replacement + dependent re-point; 0 orphans
+lambda-event-invoke-config-update	2026-07-26T18:20:27Z	PASS	80	verify.sh	0727b sweep-b3 staleness re-run (rc=0); account clean
+lambda-layer-version-update	2026-07-26T18:20:27Z	FAIL	55	verify.sh	fixture staleness: hardcoded layer :1 vs monotonic version counter; fixed in-branch, re-run queued
 lambda-log-retention	2026-07-21T14:46:30Z	PASS	95	verify.sh	rc ok, orph clean
 lambda-microvm-image	2026-07-22T07:52:25Z	PASS	700	verify.sh	create+tags+drift+destroy + --no-wait + destroy, 2 builds, 0 orphans
 lambda-reserved-concurrency	2026-06-27T19:25:47Z	PASS	47	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -7,7 +7,7 @@
 # CI enforces this; a non-normalized file fails check-build-test.
 acm-certificate	2026-07-26T18:49:34Z	PASS	25	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
 agentcore-tools	2026-07-17T12:05:03Z	PASS	180	verify.sh	3 phases clean; adopt-only singletons + evaluator CRUD; name regex fix (no hyphens)
-alb	2026-07-02T18:23:15Z	PASS	62	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
+alb	2026-07-26T20:07:41Z	PASS	299	verify.sh	0727b sweep-b14 staleness re-run (rc=0); account clean
 alb-advanced	2026-07-26T18:49:34Z	PASS	63	standard	0727b sweep-b6 staleness re-run (rc=0); account clean
 api-cognito	2026-07-26T18:49:34Z	PASS	75	standard	0727b sweep-b6 staleness re-run (rc=0); account clean
 apigateway	2026-07-21T14:32:25Z	PASS	56	verify.sh	rc ok, orph clean
@@ -21,7 +21,7 @@ asset-auto-create	2026-07-17T06:52:34Z	PASS	150	verify.sh	ca-central-1; own-mark
 asset-bootstrap	2026-07-17T07:11:51Z	PASS	120	verify.sh	us-west-2; own-marker guard + no-auto-asset-storage phase-1 + state-info cross-region fix (1054); 0 orphans
 asset-migration	2026-07-17T06:59:52Z	PASS	780	verify.sh	us-west-2; own-marker guard + no-auto-asset-storage phase-1 fix (issue-1052); nested+ECR legs; 0 orphans
 aws-custom-resource	2026-07-21T05:26:32Z	PASS	82	verify.sh	rc ok, orph clean
-backup	2026-07-03T11:11:09Z	PASS	58	verify.sh	Ref on BackupSelection returns bare SelectionId (#995); destroy clean
+backup	2026-07-26T20:07:41Z	PASS	67	verify.sh	0727b sweep-b14 staleness re-run (rc=0); account clean
 basic	2026-07-20T04:38:04Z	PASS	83	standard	rc 0/0, 0 orphans; validates buildProgram entry-point refactor (#1097)
 batch	2026-07-26T18:43:33Z	PASS	89	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 bedrock-agentcore	2026-07-24T04:22:29Z	PASS	42	standard	import() attr enrich (#1188); GetAgentRuntime live-probe confirms field shape; 6 del 0 err

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -167,17 +167,17 @@ local-run-task	2026-06-21T11:00:28Z	PASS	19	verify.sh	sweep-4..8 staleness re-ru
 local-run-task-awsvpc	2026-06-21T11:00:28Z	PASS	9	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 local-run-task-cdkd-assets	2026-07-16T17:53:49Z	PASS	95	verify.sh	classifier regression for issue-1025 marker-based repo match; docker sweep clean
 local-run-task-from-state	2026-06-21T11:00:28Z	PASS	96	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-run-task-multi-container	2026-06-21T11:00:28Z	PASS	11	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+local-run-task-multi-container	2026-07-26T20:18:09Z	PASS	12	verify.sh	0727b sweep-L2 staleness re-run (rc=0); docker + account clean
 local-start-agentcore	2026-06-21T19:11:23Z	PASS	70	verify.sh	staleness re-run (15d); warm HTTP contract ping+invocations+session-id, /ws bridge, --sigv4-signed forward; aws-cdk-lib 2.260 OK; 0 container leak
-local-start-alb	2026-06-21T11:00:28Z	PASS	21	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-start-alb-from-state	2026-07-26T20:11:51Z	FAIL	73	verify.sh	env: leftover cdk-local cdkl-svc network held 169.254.171.0/24 (pool overlap); removed, re-run queued
+local-start-alb	2026-07-26T20:18:09Z	PASS	22	verify.sh	0727b sweep-L2 staleness re-run (rc=0); docker + account clean
+local-start-alb-from-state	2026-07-26T20:18:09Z	PASS	98	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
 local-start-api	2026-07-19T18:27:53Z	PASS	22	verify.sh	rc ok, 0 docker orphans; swept verify.sh (#1097 pattern 1)
 local-start-api-container	2026-07-26T20:11:51Z	PASS	11	verify.sh	0727b sweep-L1 staleness re-run (rc=0); docker + account clean
 local-start-api-rest-v1-non-proxy	2026-07-26T20:11:51Z	PASS	13	verify.sh	0727b sweep-L1 staleness re-run (rc=0); docker + account clean
 local-start-api-websocket	2026-07-19T18:46:28Z	PASS	103	verify.sh	rc ok, 0 docker orphans; validates restructured multi-line trap (#1097)
 local-start-cloudfront	2026-06-27T16:36:59Z	PASS	5	verify.sh	local serve pipeline + watch + SPA fallback, no AWS
-local-start-service	2026-07-26T20:11:51Z	FAIL	10	verify.sh	env: leftover cdk-local cdkl-svc network held 169.254.171.0/24 (pool overlap); removed, re-run queued
-local-start-service-watch-fast	2026-07-26T20:11:51Z	FAIL	16	verify.sh	env: leftover cdk-local cdkl-svc network held 169.254.171.0/24 (pool overlap); removed, re-run queued
+local-start-service	2026-07-26T20:18:09Z	PASS	20	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
+local-start-service-watch-fast	2026-07-26T20:18:09Z	PASS	186	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
 log-pipeline	2026-07-26T18:10:48Z	PASS	72	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
 loggroup-class-guard	2026-07-26T19:25:15Z	PASS	53	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 loggroup-kms-associate	2026-07-26T19:25:15Z	PASS	57	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -170,14 +170,14 @@ local-run-task-from-state	2026-06-21T11:00:28Z	PASS	96	verify.sh	sweep-4..8 stal
 local-run-task-multi-container	2026-06-21T11:00:28Z	PASS	11	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 local-start-agentcore	2026-06-21T19:11:23Z	PASS	70	verify.sh	staleness re-run (15d); warm HTTP contract ping+invocations+session-id, /ws bridge, --sigv4-signed forward; aws-cdk-lib 2.260 OK; 0 container leak
 local-start-alb	2026-06-21T11:00:28Z	PASS	21	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-start-alb-from-state	2026-06-21T10:44:49Z	PASS	88	verify.sh	fixed verify.sh assertion (state.json only, ignore #885 deployments/); deploy+destroy clean 29 del 0 err
+local-start-alb-from-state	2026-07-26T20:11:51Z	FAIL	73	verify.sh	env: leftover cdk-local cdkl-svc network held 169.254.171.0/24 (pool overlap); removed, re-run queued
 local-start-api	2026-07-19T18:27:53Z	PASS	22	verify.sh	rc ok, 0 docker orphans; swept verify.sh (#1097 pattern 1)
-local-start-api-container	2026-06-21T14:49:02Z	PASS	14	verify.sh	sweep-G local re-run (rc=0)
-local-start-api-rest-v1-non-proxy	2026-06-21T14:49:21Z	PASS	17	verify.sh	sweep-G local re-run (rc=0)
+local-start-api-container	2026-07-26T20:11:51Z	PASS	11	verify.sh	0727b sweep-L1 staleness re-run (rc=0); docker + account clean
+local-start-api-rest-v1-non-proxy	2026-07-26T20:11:51Z	PASS	13	verify.sh	0727b sweep-L1 staleness re-run (rc=0); docker + account clean
 local-start-api-websocket	2026-07-19T18:46:28Z	PASS	103	verify.sh	rc ok, 0 docker orphans; validates restructured multi-line trap (#1097)
 local-start-cloudfront	2026-06-27T16:36:59Z	PASS	5	verify.sh	local serve pipeline + watch + SPA fallback, no AWS
-local-start-service	2026-06-21T14:52:59Z	PASS	21	verify.sh	sweep-G local re-run (rc=0)
-local-start-service-watch-fast	2026-06-21T14:56:24Z	PASS	203	verify.sh	sweep-G local re-run (rc=0)
+local-start-service	2026-07-26T20:11:51Z	FAIL	10	verify.sh	env: leftover cdk-local cdkl-svc network held 169.254.171.0/24 (pool overlap); removed, re-run queued
+local-start-service-watch-fast	2026-07-26T20:11:51Z	FAIL	16	verify.sh	env: leftover cdk-local cdkl-svc network held 169.254.171.0/24 (pool overlap); removed, re-run queued
 log-pipeline	2026-07-26T18:10:48Z	PASS	72	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
 loggroup-class-guard	2026-07-26T19:25:15Z	PASS	53	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 loggroup-kms-associate	2026-07-26T19:25:15Z	PASS	57	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -148,10 +148,10 @@ lambda-versioning	2026-07-26T18:10:48Z	PASS	56	standard	0727b sweep-b2 staleness
 launchtemplate-asg-inplace	2026-07-26T13:03:26Z	PASS	90	verify.sh	1225 classification-pins verify; destroy 9/0
 legacy-bucket-name-fallback	2026-07-26T18:10:48Z	PASS	22	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
 legacy-state-migration	2026-07-26T18:10:48Z	PASS	23	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
-local-ecs-service-connect	2026-06-21T11:00:28Z	PASS	20	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+local-ecs-service-connect	2026-07-26T20:40:20Z	PASS	23	verify.sh	0727b sweep-L6 staleness re-run (rc=0); docker + account clean
 local-invoke	2026-07-20T03:08:51Z	PASS	120	verify.sh	integ-local refresh for pattern-2 sweep (local-start-alb-from-state probe change); docker sweep clean
-local-invoke-agentcore	2026-06-21T10:51:48Z	PASS	103	verify.sh	creds materialized (export-credentials); 21 tests; arm64-native container (no qemu); docker clean
-local-invoke-agentcore-from-state	2026-06-21T10:51:48Z	PASS	55	verify.sh	creds materialized; 8 del 0 err; --from-state intrinsic env-var substitution; docker clean
+local-invoke-agentcore	2026-07-26T20:40:20Z	PASS	97	verify.sh	0727b sweep-L6 staleness re-run (rc=0); docker + account clean
+local-invoke-agentcore-from-state	2026-07-26T20:40:20Z	PASS	86	verify.sh	0727b sweep-L6 staleness re-run (rc=0); docker + account clean
 local-invoke-buildkit	2026-07-26T20:35:19Z	PASS	18	verify.sh	0727b sweep-L5 staleness re-run (rc=0); docker + account clean
 local-invoke-container	2026-07-26T20:35:19Z	PASS	24	verify.sh	0727b sweep-L5 staleness re-run (rc=0); docker + account clean
 local-invoke-dotnet	2026-07-26T20:35:19Z	PASS	58	verify.sh	0727b sweep-L5 staleness re-run (rc=0); docker + account clean
@@ -168,14 +168,14 @@ local-run-task-awsvpc	2026-07-26T20:22:00Z	PASS	10	verify.sh	0727b sweep-L3 stal
 local-run-task-cdkd-assets	2026-07-16T17:53:49Z	PASS	95	verify.sh	classifier regression for issue-1025 marker-based repo match; docker sweep clean
 local-run-task-from-state	2026-07-26T20:22:00Z	PASS	105	verify.sh	0727b sweep-L3 staleness re-run (rc=0); docker + account clean
 local-run-task-multi-container	2026-07-26T20:18:09Z	PASS	12	verify.sh	0727b sweep-L2 staleness re-run (rc=0); docker + account clean
-local-start-agentcore	2026-06-21T19:11:23Z	PASS	70	verify.sh	staleness re-run (15d); warm HTTP contract ping+invocations+session-id, /ws bridge, --sigv4-signed forward; aws-cdk-lib 2.260 OK; 0 container leak
+local-start-agentcore	2026-07-26T20:40:20Z	PASS	13	verify.sh	0727b sweep-L6 staleness re-run (rc=0); docker + account clean
 local-start-alb	2026-07-26T20:18:09Z	PASS	22	verify.sh	0727b sweep-L2 staleness re-run (rc=0); docker + account clean
 local-start-alb-from-state	2026-07-26T20:18:09Z	PASS	98	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
 local-start-api	2026-07-19T18:27:53Z	PASS	22	verify.sh	rc ok, 0 docker orphans; swept verify.sh (#1097 pattern 1)
 local-start-api-container	2026-07-26T20:11:51Z	PASS	11	verify.sh	0727b sweep-L1 staleness re-run (rc=0); docker + account clean
 local-start-api-rest-v1-non-proxy	2026-07-26T20:11:51Z	PASS	13	verify.sh	0727b sweep-L1 staleness re-run (rc=0); docker + account clean
 local-start-api-websocket	2026-07-19T18:46:28Z	PASS	103	verify.sh	rc ok, 0 docker orphans; validates restructured multi-line trap (#1097)
-local-start-cloudfront	2026-06-27T16:36:59Z	PASS	5	verify.sh	local serve pipeline + watch + SPA fallback, no AWS
+local-start-cloudfront	2026-07-26T20:40:20Z	PASS	7	verify.sh	0727b sweep-L6 staleness re-run (rc=0); docker + account clean
 local-start-service	2026-07-26T20:18:09Z	PASS	20	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
 local-start-service-watch-fast	2026-07-26T20:18:09Z	PASS	186	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
 log-pipeline	2026-07-26T18:10:48Z	PASS	72	standard	0727b sweep-b2 staleness re-run (rc=0); account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -141,10 +141,10 @@ lambda-log-retention	2026-07-21T14:46:30Z	PASS	95	verify.sh	rc ok, orph clean
 lambda-microvm-image	2026-07-22T07:52:25Z	PASS	700	verify.sh	create+tags+drift+destroy + --no-wait + destroy, 2 builds, 0 orphans
 lambda-reserved-concurrency	2026-06-27T19:25:47Z	PASS	47	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
 lambda-snapstart	2026-07-16T15:54:15Z	PASS	187	verify.sh	new fixture, 3 phases clean, orph clean
-lambda-versioning	2026-06-21T11:00:28Z	PASS	48	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+lambda-versioning	2026-07-26T18:10:48Z	PASS	56	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
 launchtemplate-asg-inplace	2026-07-26T13:03:26Z	PASS	90	verify.sh	1225 classification-pins verify; destroy 9/0
-legacy-bucket-name-fallback	2026-06-21T11:00:28Z	PASS	14	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-legacy-state-migration	2026-06-21T11:00:28Z	PASS	14	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+legacy-bucket-name-fallback	2026-07-26T18:10:48Z	PASS	22	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
+legacy-state-migration	2026-07-26T18:10:48Z	PASS	23	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
 local-ecs-service-connect	2026-06-21T11:00:28Z	PASS	20	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 local-invoke	2026-07-20T03:08:51Z	PASS	120	verify.sh	integ-local refresh for pattern-2 sweep (local-start-alb-from-state probe change); docker sweep clean
 local-invoke-agentcore	2026-06-21T10:51:48Z	PASS	103	verify.sh	creds materialized (export-credentials); 21 tests; arm64-native container (no qemu); docker clean
@@ -175,7 +175,7 @@ local-start-api-websocket	2026-07-19T18:46:28Z	PASS	103	verify.sh	rc ok, 0 docke
 local-start-cloudfront	2026-06-27T16:36:59Z	PASS	5	verify.sh	local serve pipeline + watch + SPA fallback, no AWS
 local-start-service	2026-06-21T14:52:59Z	PASS	21	verify.sh	sweep-G local re-run (rc=0)
 local-start-service-watch-fast	2026-06-21T14:56:24Z	PASS	203	verify.sh	sweep-G local re-run (rc=0)
-log-pipeline	2026-06-21T11:00:28Z	PASS	62	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+log-pipeline	2026-07-26T18:10:48Z	PASS	72	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
 loggroup-class-guard	2026-07-02T06:26:43Z	PASS	50	verify.sh	new fixture: guard error-path + replace recreate, destroy clean 0 orphans
 loggroup-kms-associate	2026-07-02T11:32:39Z	PASS	150	verify.sh	new fixture: KmsKeyId associate+disassociate reach AWS, destroy clean, key PendingDeletion
 macro-expansion	2026-07-21T19:45:50Z	PASS	107	verify.sh	re-run w/ new diff-expands + destroy-no-expand asserts (1150)
@@ -188,9 +188,9 @@ multi-asset	2026-07-21T18:05:41Z	PASS	106	verify.sh	rc ok, ECR swept, orph clean
 multi-region-same-stack	2026-07-26T18:04:53Z	PASS	22	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 multi-resource	2026-07-17T12:05:00Z	PASS	85	standard	broad refresh for #1041 register-providers edit (post-rebase): 17 created/deleted, 0 errors, log groups swept
 multi-stack-deps	2026-07-19T19:48:39Z	PASS	63	standard	rc ok, 3 stacks 13 res, all destroyed, orph clean
-nested-stack	2026-06-21T11:16:17Z	PASS	24	standard	sweep-F staleness re-run (rc=0)
+nested-stack	2026-07-26T18:10:48Z	PASS	30	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
 nested-stack-3level	2026-07-21T05:11:36Z	PASS	78	verify.sh	rc ok, orph clean
-nested-stack-deep	2026-06-21T11:17:08Z	PASS	49	verify.sh	sweep-F staleness re-run (rc=0)
+nested-stack-deep	2026-07-26T18:10:48Z	PASS	65	verify.sh	0727b sweep-b2 staleness re-run (rc=0); account clean
 nodejs-function	2026-07-21T18:03:38Z	PASS	56	verify.sh	rc ok, orph clean
 opensearch-domain-getatt	2026-07-20T18:25:27Z	PASS	1796	verify.sh	FIXED: 60m CC delete floor; destroy 0 err, 0 orphans
 orphan-resource	2026-07-26T18:04:53Z	PASS	38	standard	0727b sweep-b1 staleness re-run (rc=0); account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -14,7 +14,7 @@ apigateway	2026-07-21T14:32:25Z	PASS	56	verify.sh	rc ok, orph clean
 apigatewayv2-update-removal	2026-07-22T14:04:44Z	PASS		verify.sh	issue-1160 apigwv2 batch: 5-API removal reset live-verified, Cors via DeleteCorsConfiguration, destroy 0 err/0 orph
 apigw-gateway-response	2026-07-16T16:48:47Z	PASS	117	verify.sh	issue-1017 fix live-verify, warn 1->0 + rendering sample, orph clean
 apigw-stage-throttling	2026-07-02T16:57:21Z	PASS	72	verify.sh	CC-route trigger swapped to AccessLogSettings (#966), all #963 assertions green, 0 orphans
-apigw-usage-plan-key	2026-06-27T19:25:47Z	PASS	74	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
+apigw-usage-plan-key	2026-07-26T19:16:39Z	PASS	84	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 appconfig	2026-07-21T18:18:22Z	PASS	75	verify.sh	rc ok, orph clean
 appsync	2026-07-26T18:43:33Z	PASS	33	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 asset-auto-create	2026-07-17T06:52:34Z	PASS	150	verify.sh	ca-central-1; own-marker guard + prerun-scoped cleanup (issue-1052); 0 orphans
@@ -45,10 +45,10 @@ codecommit	2026-07-18T19:54:34Z	PASS		verify.sh	Code seed+SNS trigger+rename+dri
 codedeploy-lambda-deployment-group	2026-07-02T04:43:08Z	PASS	100	verify.sh	new fixture: IAM-propagation retry + version/alias update, 0 orphans
 cognito	2026-07-21T14:27:28Z	PASS	60	verify.sh	rc ok, orph clean
 cognito-custom-attribute-add	2026-07-26T19:05:27Z	PASS	57	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
-cognito-identity-pool	2026-06-27T19:25:47Z	PASS	44	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
+cognito-identity-pool	2026-07-26T19:16:39Z	PASS	53	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 cognito-lambda-triggers	2026-07-21T18:07:01Z	PASS	66	verify.sh	rc ok, orph clean
 cognito-resource-server	2026-07-02T16:12:06Z	PASS	82	verify.sh	ledger backfill (fixture verified at PR time; row was missing)
-cognito-userpool-user-ref	2026-06-28T02:53:29Z	PASS	85	verify.sh	UserPoolUser Ref compound-id fix; repro FAIL->PASS; clean destroy
+cognito-userpool-user-ref	2026-07-26T19:16:39Z	PASS	95	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 composite-stack	2026-07-26T18:43:33Z	PASS	39	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 conditions	2026-07-21T13:08:15Z	PASS	25	verify.sh	converted; Fn::If suppressed prod bucket, 0 orphans
 conditions-and-if	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
@@ -80,7 +80,7 @@ dynamodb-sse	2026-07-20T07:04:47Z	PASS	150	verify.sh	capture-form sweep sample (
 dynamodb-stream-filter	2026-07-21T18:08:16Z	PASS	62	verify.sh	rc ok, orph clean
 dynamodb-streams	2026-07-20T17:40:13Z	PASS	86	verify.sh	DDB streams WarmThroughput+ESM+StreamSpec UPDATE, 10 res clean
 dynamodb-tableclass-switch	2026-07-02T06:15:28Z	PASS	95	verify.sh	new fixture: TableClass switch reaches AWS, destroy clean 0 orphans
-dynamodb-ttl-attr-change	2026-06-27T18:40:49Z	PASS		verify.sh	TTL attr-change rejected w/ actionable error; clean destroy (re-run post nit-fix)
+dynamodb-ttl-attr-change	2026-07-26T19:16:39Z	PASS	70	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 ec2-instance	2026-07-26T16:41:51Z	PASS	123	verify.sh	0727 P0 sweep (ec2-provider changed #1175/#1177); clean destroy 0 orphans
 ec2-vpc	2026-07-26T17:21:15Z	PASS	35	standard	issue 1241 fix verified: explicit DESTROY FlowLog LogGroup; 20 deleted 0 retained 0 orphans
 ecr	2026-07-26T18:36:31Z	PASS	85	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
@@ -133,11 +133,11 @@ kinesis-esm-filter	2026-07-24T10:29:51Z	PASS	73	verify.sh	0724 P0 sweep: lambda-
 kinesis-stream-mode-switch	2026-07-26T18:57:55Z	PASS	73	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
 lambda	2026-07-26T15:31:59Z	PASS	85	verify.sh	PR #1231 broad integ; destroy 0 errors 0 orphans
-lambda-alias-provisioned-concurrency	2026-06-27T19:25:47Z	PASS	251	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
+lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-arch-switch	2026-07-02T06:26:16Z	PASS	60	verify.sh	new fixture: arch switch reaches AWS config+runtime, destroy clean 0 orphans
 lambda-config-field-removal	2026-07-22T08:19:38Z	PASS	140	verify.sh	issue #1158 post-rebase re-verify; 6-field removal reset + destroy clean
 lambda-destinations	2026-07-21T18:15:21Z	PASS	81	verify.sh	fixture fix: EventInvokeConfig now sdk-routed (#919); rc ok, orph clean
-lambda-env-removal	2026-06-29T03:14:52Z	PASS	61	verify.sh	nested map key (Lambda env var) removal reaches AWS
+lambda-env-removal	2026-07-26T19:16:39Z	PASS	70	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-event-invoke-config-update	2026-07-26T18:20:27Z	PASS	80	verify.sh	0727b sweep-b3 staleness re-run (rc=0); account clean
 lambda-layer-version-update	2026-07-26T18:36:31Z	PASS	79	verify.sh	re-run after version-agnostic fixture fix; live-verified, account clean
 lambda-log-retention	2026-07-21T14:46:30Z	PASS	95	verify.sh	rc ok, orph clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -185,7 +185,7 @@ migrate-from-bare-cfn-codegen-only	2026-06-21T19:09:34Z	PASS	55	verify.sh	fixed:
 migrate-from-cfn	2026-07-21T13:50:11Z	PASS	414	verify.sh	post import-tag-walk refactor #1139; import+migrate+destroy clean
 monitoring	2026-07-24T10:52:15Z	PASS	40	standard	0724b sweep staleness; 7 del 0 err 0 orphans
 multi-asset	2026-07-21T18:05:41Z	PASS	106	verify.sh	rc ok, ECR swept, orph clean
-multi-region-same-stack	2026-06-21T11:00:28Z	PASS	14	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+multi-region-same-stack	2026-07-26T18:04:53Z	PASS	22	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 multi-resource	2026-07-17T12:05:00Z	PASS	85	standard	broad refresh for #1041 register-providers edit (post-rebase): 17 created/deleted, 0 errors, log groups swept
 multi-stack-deps	2026-07-19T19:48:39Z	PASS	63	standard	rc ok, 3 stacks 13 res, all destroyed, orph clean
 nested-stack	2026-06-21T11:16:17Z	PASS	24	standard	sweep-F staleness re-run (rc=0)
@@ -193,9 +193,9 @@ nested-stack-3level	2026-07-21T05:11:36Z	PASS	78	verify.sh	rc ok, orph clean
 nested-stack-deep	2026-06-21T11:17:08Z	PASS	49	verify.sh	sweep-F staleness re-run (rc=0)
 nodejs-function	2026-07-21T18:03:38Z	PASS	56	verify.sh	rc ok, orph clean
 opensearch-domain-getatt	2026-07-20T18:25:27Z	PASS	1796	verify.sh	FIXED: 60m CC delete floor; destroy 0 err, 0 orphans
-orphan-resource	2026-06-21T11:00:28Z	PASS	30	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+orphan-resource	2026-07-26T18:04:53Z	PASS	38	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 outputs-only-export	2026-07-02T18:23:15Z	PASS	69	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
-parameters	2026-06-21T11:00:28Z	PASS	17	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+parameters	2026-07-26T18:04:53Z	PASS	24	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 propagation-races-2	2026-06-21T18:33:45Z	PASS	139	verify.sh	first run (never-run); 4 fresh-principal/consumer race edges; clean destroy
 raw-cfn-conditions-params	2026-07-17T05:02:58Z	PASS	76	verify.sh	re-run with #1032 fix: PASS + destroy param-dep warn gone (live verify)
 rds-aurora	2026-07-25T06:38:38Z	PASS	2085	verify.sh	1160 removal reset: cluster DeletionProtection+IAMAuth reset live-verified, destroy 23/0
@@ -222,7 +222,7 @@ s3-object-lock	2026-07-21T14:42:20Z	PASS	53	verify.sh	rc ok, orph clean
 s3-replication-and-filter	2026-07-21T14:43:45Z	PASS	63	verify.sh	rc ok, orph clean
 s3-tables	2026-07-03T07:18:47Z	PASS	45	verify.sh	CC-routed Table Ref resolves to table name (#974); clean destroy
 s3-vectors	2026-06-21T18:03:30Z	PASS	34	verify.sh	stale-real re-run; 1 deleted 0 err; clean
-scheduled-task	2026-06-21T11:00:28Z	PASS	31	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+scheduled-task	2026-07-26T18:04:53Z	PASS	44	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 scheduler-custom-group	2026-07-02T12:35:05Z	PASS	98	verify.sh	new fixture (issue 961): custom-group UPDATE + schedule-only removal + destroy clean
 schema-v5-to-v6-migration	2026-07-24T10:27:22Z	PASS	61	verify.sh	0724 P0 sweep: v5->v8 transparent upgrade verified; 1 del 0 err
 schema-v6-to-v7-migration	2026-07-24T10:25:01Z	PASS	66	verify.sh	0724 P0 sweep: s3-state-backend #1196/#1203 coverage; v6->v8 transparent upgrade; 1 del 0 err
@@ -239,9 +239,9 @@ sns-event-source	2026-07-20T08:12:14Z	PASS	68	verify.sh	rc ok, orph clean
 sns-inline-subscription	2026-07-20T17:38:28Z	PASS	53	verify.sh	SNS inline subscription create+update, clean destroy
 sns-sqs-event	2026-07-26T17:01:09Z	PASS	78	verify.sh	#1160 sqs SSE removal phase 2 verified; destroy 20/0 errors, 0 orphans
 sns-subscription-filter	2026-07-21T18:09:46Z	PASS	46	verify.sh	rc ok, orph clean
-sqs-cloudwatch	2026-06-21T11:00:28Z	PASS	41	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+sqs-cloudwatch	2026-07-26T18:04:53Z	PASS	56	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 sqs-esm-max-concurrency	2026-07-21T14:49:55Z	PASS	85	verify.sh	rc ok, orph clean
-state-destroy	2026-06-21T11:00:28Z	PASS	17	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+state-destroy	2026-07-26T18:04:53Z	PASS	25	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 state-info-command	2026-07-19T20:01:06Z	PASS	21	standard	rc ok, state info #1055 GetBucketLocation exercised, orph clean
 stepfunctions	2026-07-21T13:08:15Z	PASS	97	verify.sh	converted; SM ACTIVE w/ auto role, async-delete poll, 0 orphans
 stepfunctions-logging	2026-07-20T17:36:15Z	PASS	117	verify.sh	SFN Express logging/tracing removal-clear, clean destroy

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -16,18 +16,21 @@ apigw-gateway-response	2026-07-16T16:48:47Z	PASS	117	verify.sh	issue-1017 fix li
 apigw-stage-throttling	2026-07-02T16:57:21Z	PASS	72	verify.sh	CC-route trigger swapped to AccessLogSettings (#966), all #963 assertions green, 0 orphans
 apigw-usage-plan-key	2026-06-27T19:25:47Z	PASS	74	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
 appconfig	2026-07-21T18:18:22Z	PASS	75	verify.sh	rc ok, orph clean
-appsync	2026-06-21T11:00:28Z	PASS	25	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+appsync	2026-07-26T18:43:33Z	PASS	33	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 asset-auto-create	2026-07-17T06:52:34Z	PASS	150	verify.sh	ca-central-1; own-marker guard + prerun-scoped cleanup (issue-1052); 0 orphans
 asset-bootstrap	2026-07-17T07:11:51Z	PASS	120	verify.sh	us-west-2; own-marker guard + no-auto-asset-storage phase-1 + state-info cross-region fix (1054); 0 orphans
 asset-migration	2026-07-17T06:59:52Z	PASS	780	verify.sh	us-west-2; own-marker guard + no-auto-asset-storage phase-1 fix (issue-1052); nested+ECR legs; 0 orphans
 aws-custom-resource	2026-07-21T05:26:32Z	PASS	82	verify.sh	rc ok, orph clean
 backup	2026-07-03T11:11:09Z	PASS	58	verify.sh	Ref on BackupSelection returns bare SelectionId (#995); destroy clean
 basic	2026-07-20T04:38:04Z	PASS	83	standard	rc 0/0, 0 orphans; validates buildProgram entry-point refactor (#1097)
-batch	2026-06-21T11:00:28Z	PASS	80	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+batch	2026-07-26T18:43:33Z	PASS	89	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 bedrock-agentcore	2026-07-24T04:22:29Z	PASS	42	standard	import() attr enrich (#1188); GetAgentRuntime live-probe confirms field shape; 6 del 0 err
 bench-ccapi	2026-06-21T11:00:28Z	PASS	80	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 bench-cdk-sample	2026-07-26T18:02:31Z	PASS	900	standard	#1238 guard broad verify; 39 created, destroy 37 del 2 retained-swept 0 err, log groups swept
 bench-sdk	2026-06-21T11:00:28Z	PASS	24	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+bench-ccapi	2026-07-26T18:43:33Z	PASS	89	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
+bench-cdk-sample	2026-07-24T09:09:05Z	PASS	1560	standard	cross-region us-west-2 vs us-east-1 bucket (issue #1202 hint-less CR presign live-verified); 39 res, destroy 37 del 2 retained-swept 0 err
+bench-sdk	2026-07-26T18:43:33Z	PASS	33	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 bootstrap-free-region	2026-07-16T15:34:01Z	PASS	81	verify.sh	re-run after PR 1015 review fix-back (region-resolver owner header), 0 orphans
 bucket-deployment	2026-07-21T18:02:21Z	PASS	125	verify.sh	rc ok, orph clean
 budgets	2026-07-17T11:58:00Z	PASS	60	verify.sh	new fixture #1041 re-run post-rebase (idempotent reconciler, verbatim name); 3 phases clean, 0 orphans
@@ -46,11 +49,11 @@ cognito-identity-pool	2026-06-27T19:25:47Z	PASS	44	verify.sh	bughunt-clean regre
 cognito-lambda-triggers	2026-07-21T18:07:01Z	PASS	66	verify.sh	rc ok, orph clean
 cognito-resource-server	2026-07-02T16:12:06Z	PASS	82	verify.sh	ledger backfill (fixture verified at PR time; row was missing)
 cognito-userpool-user-ref	2026-06-28T02:53:29Z	PASS	85	verify.sh	UserPoolUser Ref compound-id fix; repro FAIL->PASS; clean destroy
-composite-stack	2026-06-21T11:11:40Z	PASS	35	standard	sweep-F staleness re-run (rc=0)
+composite-stack	2026-07-26T18:43:33Z	PASS	39	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 conditions	2026-07-21T13:08:15Z	PASS	25	verify.sh	converted; Fn::If suppressed prod bucket, 0 orphans
 conditions-and-if	2026-06-21T18:17:20Z	PASS		verify.sh	first run (never-run); CFn Conditions + Fn::If 2-phase premium/basic; 14 assertions; clean destroy 0 err
 conditions-update-2	2026-06-21T18:17:20Z	PASS		verify.sh	first run (never-run); condition-gated resource add/remove across update; 14 assertions; clean destroy 0 err
-context-test	2026-06-21T11:00:28Z	PASS	16	standard	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+context-test	2026-07-26T18:43:33Z	PASS	24	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 cross-region-state-bucket	2026-07-19T18:57:34Z	PASS	33	verify.sh	rc ok, temp bucket removed, orph clean
 cross-stack-references	2026-07-19T19:57:33Z	PASS	27	standard	rc ok, 2 stacks, orph clean
 custom-resource-getatt-data	2026-07-20T14:59:39Z	PASS	63	verify.sh	CR Data GetAtt->dependent prop, 6 res clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -40,7 +40,7 @@ cc-api-fallback-transitions	2026-07-20T02:19:31Z	PASS	140	verify.sh	CC transitio
 cc-getatt-readback	2026-07-20T03:06:02Z	PASS	260	verify.sh	generic sparse read-back live-verified (#1105); destroy 8/8, 0 orphans
 ci-cd	2026-07-21T18:23:00Z	PASS	55	verify.sh	rc ok, orph clean
 cloudfront-function-url	2026-07-21T18:29:34Z	PASS	378	verify.sh	rc ok, orph clean
-cloudwatch	2026-07-02T18:23:15Z	PASS	50	standard	0703 staleness sweep (pre-TTL refresh); clean
+cloudwatch	2026-07-26T20:00:52Z	PASS	55	standard	0727b sweep-b13 staleness re-run (rc=0); account clean
 codecommit	2026-07-18T19:54:34Z	PASS		verify.sh	Code seed+SNS trigger+rename+drift, destroy 0 err 0 orph (re-run post review-nits)
 codedeploy-lambda-deployment-group	2026-07-26T19:45:58Z	PASS	109	verify.sh	re-run after version-agnostic fixture fix; live-verified, account clean (remnant-warning follow-up: issue #1252)
 cognito	2026-07-21T14:27:28Z	PASS	60	verify.sh	rc ok, orph clean
@@ -61,10 +61,10 @@ custom-resource-provider	2026-07-24T08:31:58Z	PASS	480	standard	cross-region us-
 data-analytics	2026-07-21T18:30:46Z	PASS	50	verify.sh	rc ok, orph clean
 data-pipeline	2026-07-24T10:53:59Z	PASS	47	standard	0724b sweep staleness; 7 del 0 err 0 orphans
 deep-getatt-chains	2026-07-20T08:10:49Z	PASS	66	verify.sh	rc ok, orph clean
-deletion-ordering-complex	2026-07-02T18:23:15Z	PASS	194	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
+deletion-ordering-complex	2026-07-26T20:00:52Z	PASS	187	verify.sh	0727b sweep-b13 staleness re-run (rc=0); account clean
 deletion-policy-retain	2026-07-21T07:21:45Z	PASS	29	verify.sh	retain honored, manual cleanup ok, 0 orphans
-deployment-events	2026-07-02T18:23:15Z	PASS	39	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
-destroy-interrupt	2026-07-02T18:23:15Z	PASS	531	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
+deployment-events	2026-07-26T20:00:52Z	PASS	45	verify.sh	0727b sweep-b13 staleness re-run (rc=0); account clean
+destroy-interrupt	2026-07-26T20:00:52Z	PASS	400	verify.sh	0727b sweep-b13 staleness re-run (rc=0); account clean
 diff-intrinsic-target-change	2026-07-20T15:00:54Z	PASS	54	verify.sh	diff detects GetAtt target rebind, clean destroy
 dlm-lifecycle-policy	2026-07-18T18:42:46Z	PASS	74	verify.sh	added Phase 1b zero-drift assertion; deploy+drift(0)+update+destroy clean, 0 orphans
 docdb-neptune	2026-07-21T08:30:54Z	PASS	1583	verify.sh	14 deleted 0 orphans, docdb+neptune slow-delete ok
@@ -113,7 +113,7 @@ gc-custom-asset-names	2026-07-16T18:11:36Z	PASS	169	verify.sh	us-west-2; re-run 
 getatt-fallback-guard	2026-07-20T05:59:44Z	PASS	300	verify.sh	4-phase incl. strict-output state-persistence guarantee (#1111 blocker fix); 0 orphans
 getstackoutput-crossregion	2026-07-26T19:05:27Z	PASS	79	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 glue-securityconfig-replace	2026-07-26T18:20:27Z	PASS	59	verify.sh	0727b sweep-b3 staleness re-run (rc=0); account clean
-glue-update-hardening	2026-07-02T18:23:15Z	PASS	68	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
+glue-update-hardening	2026-07-26T20:00:52Z	PASS	75	verify.sh	0727b sweep-b13 staleness re-run (rc=0); account clean
 iam-managed-policy	2026-07-21T13:08:15Z	PASS	29	verify.sh	converted; policy attached, detach-before-delete clean, 0 orphans
 iam-oidc-provider	2026-07-16T16:48:34Z	PASS	91	verify.sh	issue-1016 fix live-verify, warn 1->0, orph clean
 iam-propagation-stress	2026-07-26T18:57:55Z	PASS	71	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
@@ -197,7 +197,7 @@ nested-stack-deep	2026-07-26T18:10:48Z	PASS	65	verify.sh	0727b sweep-b2 stalenes
 nodejs-function	2026-07-21T18:03:38Z	PASS	56	verify.sh	rc ok, orph clean
 opensearch-domain-getatt	2026-07-20T18:25:27Z	PASS	1796	verify.sh	FIXED: 60m CC delete floor; destroy 0 err, 0 orphans
 orphan-resource	2026-07-26T18:04:53Z	PASS	38	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
-outputs-only-export	2026-07-02T18:23:15Z	PASS	69	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
+outputs-only-export	2026-07-26T20:00:52Z	PASS	80	verify.sh	0727b sweep-b13 staleness re-run (rc=0); account clean
 parameters	2026-07-26T18:04:53Z	PASS	24	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 propagation-races-2	2026-07-26T18:57:55Z	PASS	169	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 raw-cfn-conditions-params	2026-07-17T05:02:58Z	PASS	76	verify.sh	re-run with #1032 fix: PASS + destroy param-dep warn gone (live verify)

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -156,11 +156,11 @@ local-invoke-buildkit	2026-06-21T11:00:28Z	PASS	32	verify.sh	sweep-4..8 stalenes
 local-invoke-container	2026-06-21T11:00:28Z	PASS	29	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 local-invoke-dotnet	2026-06-21T11:00:28Z	PASS	78	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
 local-invoke-from-cfn-stack	2026-06-21T11:00:28Z	PASS	100	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-invoke-from-cfn-stack-multi-stack	2026-06-21T11:00:28Z	PASS	117	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-invoke-from-state	2026-06-21T11:00:28Z	PASS	61	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-invoke-java	2026-06-21T11:00:28Z	PASS	51	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-invoke-layers	2026-06-21T11:00:28Z	PASS	23	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
-local-invoke-provided	2026-06-21T11:00:28Z	PASS	36	verify.sh	sweep-4..8 staleness re-run (ledger-restore; rc=0)
+local-invoke-from-cfn-stack-multi-stack	2026-07-26T20:29:11Z	FAIL	10	verify.sh	fixture staleness: global cdk 2.1120 vs assembly schema 54; fixture now vendors aws-cdk, re-run queued
+local-invoke-from-state	2026-07-26T20:29:11Z	PASS	61	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean
+local-invoke-java	2026-07-26T20:29:11Z	PASS	36	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean
+local-invoke-layers	2026-07-26T20:29:11Z	PASS	17	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean
+local-invoke-provided	2026-07-26T20:29:11Z	PASS	32	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean
 local-invoke-python	2026-07-26T20:22:00Z	PASS	23	verify.sh	0727b sweep-L3 staleness re-run (rc=0); docker + account clean
 local-invoke-ruby	2026-07-26T20:22:00Z	PASS	33	verify.sh	0727b sweep-L3 staleness re-run (rc=0); docker + account clean
 local-run-task	2026-07-26T20:22:00Z	PASS	14	verify.sh	0727b sweep-L3 staleness re-run (rc=0); docker + account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -116,8 +116,8 @@ glue-securityconfig-replace	2026-07-26T18:20:27Z	PASS	59	verify.sh	0727b sweep-b
 glue-update-hardening	2026-07-02T18:23:15Z	PASS	68	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 iam-managed-policy	2026-07-21T13:08:15Z	PASS	29	verify.sh	converted; policy attached, detach-before-delete clean, 0 orphans
 iam-oidc-provider	2026-07-16T16:48:34Z	PASS	91	verify.sh	issue-1016 fix live-verify, warn 1->0, orph clean
-iam-propagation-stress	2026-06-21T18:33:45Z	PASS	80	verify.sh	first run (never-run); 4 fresh-role race edges + role consumers work; clean destroy
-iam-role-policies-drift-clean	2026-06-22T02:14:54Z	PASS		verify.sh	no IAM Role phantom drift; destroy 6/0 errors, 0 orphans
+iam-propagation-stress	2026-07-26T18:57:55Z	PASS	71	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
+iam-role-policies-drift-clean	2026-07-26T18:57:55Z	PASS	84	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 iam-role-prefixed-name-update	2026-07-26T16:45:28Z	PASS	71	verify.sh	#1160 iam-role removal phase 3 verified; destroy 1/0 errors, 0 orphans
 import-attributes	2026-07-21T13:51:28Z	PASS	42	verify.sh	post import-tag-walk refactor #1139; attr reconstruct+destroy clean
 import-auto-mode	2026-07-21T13:53:15Z	PASS	74	verify.sh	post import-tag-walk refactor #1139; CFn physId resolve (no tag) clean
@@ -128,9 +128,9 @@ infra-security	2026-07-26T18:20:27Z	PASS	186	standard	0727b sweep-b3 staleness r
 inplace-attr-propagation	2026-06-29T02:40:51Z	PASS	47	verify.sh	in-place upstream attr propagates to GetAtt dependent
 intrinsic-functions	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
 intrinsics-torture	2026-07-21T05:24:57Z	PASS	48	verify.sh	rc ok, orph clean
-intrinsics-torture-2	2026-06-21T18:17:20Z	PASS		verify.sh	first run (never-run); intrinsic-function torture; 12 checks; 11 deleted 0 err; SSM cleared
+intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 kinesis-esm-filter	2026-07-24T10:29:51Z	PASS	73	verify.sh	0724 P0 sweep: lambda-eventsource-provider #1194 coverage; FilterCriteria verified; 5 del 0 err
-kinesis-stream-mode-switch	2026-06-22T04:55:10Z	PASS	68	verify.sh	StreamMode switch reaches AWS (re-run on merged tree); unique stream name avoids mode-change rate limit
+kinesis-stream-mode-switch	2026-07-26T18:57:55Z	PASS	73	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
 lambda	2026-07-26T15:31:59Z	PASS	85	verify.sh	PR #1231 broad integ; destroy 0 errors 0 orphans
 lambda-alias-provisioned-concurrency	2026-06-27T19:25:47Z	PASS	251	verify.sh	bughunt-clean regression fixture; deploy+assert+clean destroy
@@ -184,7 +184,7 @@ loggroup-kms-associate	2026-07-02T11:32:39Z	PASS	150	verify.sh	new fixture: KmsK
 macro-expansion	2026-07-21T19:45:50Z	PASS	107	verify.sh	re-run w/ new diff-expands + destroy-no-expand asserts (1150)
 microservices	2026-07-19T19:50:37Z	PASS	54	standard	rc ok, 19 res, all destroyed, orph clean
 migrate-from-bare-cfn	2026-07-21T13:56:13Z	PASS	152	verify.sh	post import-tag-walk refactor #1139; bare-CFn migrate 3 types+destroy clean
-migrate-from-bare-cfn-codegen-only	2026-06-21T19:09:34Z	PASS	55	verify.sh	fixed: bumped pinned aws-cdk 2.1112->2.1128 (schema 54 float); 3/3 logical IDs + aws:cdk:path preserved; AWS-free codegen smoke
+migrate-from-bare-cfn-codegen-only	2026-07-26T18:57:55Z	PASS	17	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 migrate-from-cfn	2026-07-21T13:50:11Z	PASS	414	verify.sh	post import-tag-walk refactor #1139; import+migrate+destroy clean
 monitoring	2026-07-24T10:52:15Z	PASS	40	standard	0724b sweep staleness; 7 del 0 err 0 orphans
 multi-asset	2026-07-21T18:05:41Z	PASS	106	verify.sh	rc ok, ECR swept, orph clean
@@ -199,7 +199,7 @@ opensearch-domain-getatt	2026-07-20T18:25:27Z	PASS	1796	verify.sh	FIXED: 60m CC 
 orphan-resource	2026-07-26T18:04:53Z	PASS	38	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 outputs-only-export	2026-07-02T18:23:15Z	PASS	69	verify.sh	0703 staleness sweep (pre-TTL refresh); clean
 parameters	2026-07-26T18:04:53Z	PASS	24	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
-propagation-races-2	2026-06-21T18:33:45Z	PASS	139	verify.sh	first run (never-run); 4 fresh-principal/consumer race edges; clean destroy
+propagation-races-2	2026-07-26T18:57:55Z	PASS	169	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 raw-cfn-conditions-params	2026-07-17T05:02:58Z	PASS	76	verify.sh	re-run with #1032 fix: PASS + destroy param-dep warn gone (live verify)
 rds-aurora	2026-07-25T06:38:38Z	PASS	2085	verify.sh	1160 removal reset: cluster DeletionProtection+IAMAuth reset live-verified, destroy 23/0
 rds-dbinstance-backfill	2026-07-25T07:01:56Z	PASS	725	verify.sh	re-run after 1222 review fixes; destroy 11/0

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -13,7 +13,7 @@ api-cognito	2026-07-26T18:49:34Z	PASS	75	standard	0727b sweep-b6 staleness re-ru
 apigateway	2026-07-21T14:32:25Z	PASS	56	verify.sh	rc ok, orph clean
 apigatewayv2-update-removal	2026-07-22T14:04:44Z	PASS		verify.sh	issue-1160 apigwv2 batch: 5-API removal reset live-verified, Cors via DeleteCorsConfiguration, destroy 0 err/0 orph
 apigw-gateway-response	2026-07-16T16:48:47Z	PASS	117	verify.sh	issue-1017 fix live-verify, warn 1->0 + rendering sample, orph clean
-apigw-stage-throttling	2026-07-02T16:57:21Z	PASS	72	verify.sh	CC-route trigger swapped to AccessLogSettings (#966), all #963 assertions green, 0 orphans
+apigw-stage-throttling	2026-07-26T19:36:49Z	PASS	79	verify.sh	0727b sweep-b11 staleness re-run (rc=0); account clean
 apigw-usage-plan-key	2026-07-26T19:16:39Z	PASS	84	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 appconfig	2026-07-21T18:18:22Z	PASS	75	verify.sh	rc ok, orph clean
 appsync	2026-07-26T18:43:33Z	PASS	33	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
@@ -42,12 +42,12 @@ ci-cd	2026-07-21T18:23:00Z	PASS	55	verify.sh	rc ok, orph clean
 cloudfront-function-url	2026-07-21T18:29:34Z	PASS	378	verify.sh	rc ok, orph clean
 cloudwatch	2026-07-02T18:23:15Z	PASS	50	standard	0703 staleness sweep (pre-TTL refresh); clean
 codecommit	2026-07-18T19:54:34Z	PASS		verify.sh	Code seed+SNS trigger+rename+drift, destroy 0 err 0 orph (re-run post review-nits)
-codedeploy-lambda-deployment-group	2026-07-02T04:43:08Z	PASS	100	verify.sh	new fixture: IAM-propagation retry + version/alias update, 0 orphans
+codedeploy-lambda-deployment-group	2026-07-26T19:36:49Z	FAIL	74	verify.sh	fixture staleness: hardcoded Lambda version 1/2 vs never-reused version counter; fixed in-branch, re-run queued
 cognito	2026-07-21T14:27:28Z	PASS	60	verify.sh	rc ok, orph clean
 cognito-custom-attribute-add	2026-07-26T19:05:27Z	PASS	57	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 cognito-identity-pool	2026-07-26T19:16:39Z	PASS	53	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 cognito-lambda-triggers	2026-07-21T18:07:01Z	PASS	66	verify.sh	rc ok, orph clean
-cognito-resource-server	2026-07-02T16:12:06Z	PASS	82	verify.sh	ledger backfill (fixture verified at PR time; row was missing)
+cognito-resource-server	2026-07-26T19:36:49Z	PASS	85	verify.sh	0727b sweep-b11 staleness re-run (rc=0); account clean
 cognito-userpool-user-ref	2026-07-26T19:16:39Z	PASS	95	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 composite-stack	2026-07-26T18:43:33Z	PASS	39	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 conditions	2026-07-21T13:08:15Z	PASS	25	verify.sh	converted; Fn::If suppressed prod bucket, 0 orphans
@@ -79,7 +79,7 @@ dynamodb-ondemand	2026-07-20T07:59:21Z	PASS	93	verify.sh	rc ok, orph clean
 dynamodb-sse	2026-07-20T07:04:47Z	PASS	150	verify.sh	capture-form sweep sample (#1120): strict captures + gone_probe branch live-verified; 0 orphans
 dynamodb-stream-filter	2026-07-21T18:08:16Z	PASS	62	verify.sh	rc ok, orph clean
 dynamodb-streams	2026-07-20T17:40:13Z	PASS	86	verify.sh	DDB streams WarmThroughput+ESM+StreamSpec UPDATE, 10 res clean
-dynamodb-tableclass-switch	2026-07-02T06:15:28Z	PASS	95	verify.sh	new fixture: TableClass switch reaches AWS, destroy clean 0 orphans
+dynamodb-tableclass-switch	2026-07-26T19:36:49Z	PASS	62	verify.sh	0727b sweep-b11 staleness re-run (rc=0); account clean
 dynamodb-ttl-attr-change	2026-07-26T19:16:39Z	PASS	70	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 ec2-instance	2026-07-26T16:41:51Z	PASS	123	verify.sh	0727 P0 sweep (ec2-provider changed #1175/#1177); clean destroy 0 orphans
 ec2-vpc	2026-07-26T17:21:15Z	PASS	35	standard	issue 1241 fix verified: explicit DESTROY FlowLog LogGroup; 20 deleted 0 retained 0 orphans
@@ -98,7 +98,7 @@ eventbridge	2026-07-20T17:32:58Z	PASS	82	verify.sh	EventBus+Pipes+Scheduler, 10 
 eventbridge-api-destination	2026-07-21T14:48:06Z	PASS	70	verify.sh	rc ok, orph clean
 eventbridge-archive	2026-07-16T15:54:15Z	PASS	53	verify.sh	new fixture, 3 phases clean, orph clean
 eventbridge-input-transformer	2026-07-20T08:18:46Z	PASS	63	verify.sh	hardened P2 propagation race; passes
-eventbridge-pipes	2026-07-02T16:12:06Z	PASS	182	verify.sh	new phases (issue 960 follow-up): named-replacement collision refused + --replace delete-first OK
+eventbridge-pipes	2026-07-26T19:36:49Z	PASS	177	verify.sh	0727b sweep-b11 staleness re-run (rc=0); account clean
 eventbridge-scheduler	2026-07-20T03:07:51Z	PASS	150	verify.sh	pattern-2 sweep sample: assert_gone/gone_probe/head-object idioms live-verified; 0 orphans
 eventsourcemapping-race	2026-07-24T05:12:28Z	PASS	180	verify.sh	#1190 fix: EsmArn GetAtt now resolves (EsmArn output = real ARN); 5 del 0 err; no orphan ESM
 export	2026-07-26T17:37:08Z	PASS	249	verify.sh	live-test for export.ts DescribeType throttle-retry follow-up; CFn round-trip + clean delete
@@ -258,5 +258,5 @@ vpc-lambda	2026-07-26T16:53:02Z	PASS	386	standard	0727 P0 sweep (ec2-provider ch
 vpc-lambda-cr-race	2026-07-24T11:03:24Z	PASS	432	standard	0724b sweep staleness; 9 del 0 err 0 orphans incl hyperplane ENI
 vpc-lookup	2026-07-24T10:55:09Z	PASS	20	standard	0724b sweep staleness; context-provider loop ok; 1 del 0 err 0 orphans
 vpc-nat-gateway	2026-07-22T08:08:02Z	PASS		standard	TTL-refresh sweep; standard flow (classifier-approved direct deploy/destroy); 21 created / 21 deleted 0 err; NAT GW + VPC + EIP + ENI all gone, state gone
-wafv2	2026-07-03T04:24:38Z	PASS	120	standard	re-run on rebased tree (PR 972 + #971 base); 0 errors, retained CW role swept, events pruned
+wafv2	2026-07-26T19:36:49Z	PASS	58	standard	0727b sweep-b11 staleness re-run (rc=0); account clean
 wait-condition-handle	2026-07-16T17:58:44Z	PASS	49	verify.sh	re-run after review-nit JSDoc edit, orph clean

--- a/tests/integration/codedeploy-lambda-deployment-group/verify.sh
+++ b/tests/integration/codedeploy-lambda-deployment-group/verify.sh
@@ -12,10 +12,12 @@
 # Phases:
 #   1. Deploy baseline (code v1). Assert the CodeDeploy application (compute
 #      platform Lambda) + deployment group (LambdaCanary10Percent5Minutes,
-#      BLUE_GREEN) reached AWS, the alias points at version 1, and the
-#      DeploymentGroup routed via cc-api.
+#      BLUE_GREEN) reached AWS, the alias points at a freshly published
+#      version N (Lambda never reuses version numbers for a function name,
+#      even across delete + re-create, so N is 1 only on the account's very
+#      first run), and the DeploymentGroup routed via cc-api.
 #   2. Re-deploy with CDKD_TEST_UPDATE=true (code v1 -> v2, which mints a NEW
-#      Lambda::Version logical id). Assert the alias flipped to version 2 and
+#      Lambda::Version logical id). Assert the alias flipped to version N+1 and
 #      an invoke through the alias returns v2. (cdkd flips the alias directly;
 #      the CFn CodeDeployLambdaAliasUpdate canary shift is a documented
 #      divergence — see the stack file header.)
@@ -143,13 +145,17 @@ if [ "${DG_JSON}" != "CodeDeployDefault.LambdaCanary10Percent5Minutes	BLUE_GREEN
 fi
 echo "    Application (Lambda) + DeploymentGroup (Canary10Percent5Minutes, BLUE_GREEN) reached AWS"
 
+# Lambda never reuses version numbers for a function name, even across a
+# delete + re-create, so the fresh deploy publishes :1 only on the very
+# first run in an account. Capture the version and assert relatively.
 ALIAS_V1="$(aws lambda get-alias --function-name "${FN_NAME}" --name live \
   --region "${REGION}" --query 'FunctionVersion' --output text)"
-if [ "${ALIAS_V1}" != "1" ]; then
-  echo "FAIL: expected alias at version 1 after Phase 1, got '${ALIAS_V1}'" >&2
-  exit 1
-fi
-echo "    Alias 'live' -> version 1"
+case "${ALIAS_V1}" in
+  ''|*[!0-9]*)
+    echo "FAIL: expected alias at a numeric version after Phase 1, got '${ALIAS_V1}'" >&2
+    exit 1 ;;
+esac
+echo "    Alias 'live' -> version ${ALIAS_V1}"
 
 # Assert the DeploymentGroup routed via Cloud Control (no SDK provider).
 PROVISIONED_BY="$(node "${LOCAL_DIST}" state show "${STACK}" --state-bucket "${STATE_BUCKET}" \
@@ -166,10 +172,11 @@ echo "==> Phase 2: UPDATE (code v1 -> v2, new Lambda::Version, alias flip)"
 CDKD_TEST_UPDATE=true node "${LOCAL_DIST}" deploy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --yes
 
+EXPECTED_V2=$((ALIAS_V1 + 1))
 ALIAS_V2="$(aws lambda get-alias --function-name "${FN_NAME}" --name live \
   --region "${REGION}" --query 'FunctionVersion' --output text)"
-if [ "${ALIAS_V2}" != "2" ]; then
-  echo "FAIL: expected alias at version 2 after Phase 2, got '${ALIAS_V2}'" >&2
+if [ "${ALIAS_V2}" != "${EXPECTED_V2}" ]; then
+  echo "FAIL: expected alias at version ${EXPECTED_V2} after Phase 2, got '${ALIAS_V2}'" >&2
   exit 1
 fi
 
@@ -182,7 +189,7 @@ if ! grep -q '"version":"v2"' "${INVOKE_OUT}"; then
   exit 1
 fi
 rm -f "${INVOKE_OUT}"
-echo "    Alias 'live' -> version 2; invoke returns v2"
+echo "    Alias 'live' -> version ${ALIAS_V2}; invoke returns v2"
 
 # --- Phase 3: destroy + orphan-zero -------------------------------------
 echo "==> Phase 3: destroy"

--- a/tests/integration/import-auto-mode/package.json
+++ b/tests/integration/import-auto-mode/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "aws-cdk": "^2.1133.0",
     "aws-cdk-lib": "^2.172.0",
     "constructs": "^10.0.0",
     "typescript": "^5.7.2"

--- a/tests/integration/lambda-layer-version-update/verify.sh
+++ b/tests/integration/lambda-layer-version-update/verify.sh
@@ -144,8 +144,10 @@ CDKD_TEST_UPDATE=true node "${LOCAL_DIST}" deploy "${STACK}" \
 
 # A new version :V1+1 must have been published.
 V2=$((V1 + 1))
+# `--output text` list projections are TAB-separated; normalize to spaces so
+# the case pattern below matches even when multiple versions coexist.
 VERSIONS="$(aws lambda list-layer-versions --layer-name "${LAYER_NAME}" --region "${REGION}" \
-  --query 'LayerVersions[].Version' --output text)"
+  --query 'LayerVersions[].Version' --output text | tr '\t' ' ')"
 echo "    published layer versions: ${VERSIONS}"
 case " ${VERSIONS} " in
   *" ${V2} "*) ;;

--- a/tests/integration/lambda-layer-version-update/verify.sh
+++ b/tests/integration/lambda-layer-version-update/verify.sh
@@ -12,12 +12,14 @@
 # the function at the new layer version ARN.
 #
 # Phases:
-#   1. Deploy the layer (content `v1`) + a function consuming it. Assert the
-#      function points at the layer's version :1.
+#   1. Deploy the layer (content `v1`) + a function consuming it. Capture the
+#      layer version N the function points at. (Layer version numbers are
+#      per-name monotonic and NEVER reset — even after every version is
+#      deleted — so N is :1 only on the very first run in an account.)
 #   2. Re-deploy with CDKD_TEST_UPDATE=true (content `v2`). Assert: deploy
-#      succeeds WITHOUT any manual --replace flag, a new layer version :2 is
-#      published, and the function now points at :2 (the replacement was
-#      propagated to the dependent).
+#      succeeds WITHOUT any manual --replace flag, a new layer version :N+1
+#      is published, and the function now points at :N+1 (the replacement
+#      was propagated to the dependent).
 #   3. Destroy + assert the function is gone and the cdkd state file is removed.
 #
 # Required env vars:
@@ -126,34 +128,39 @@ env -u CDKD_TEST_UPDATE node "${LOCAL_DIST}" deploy "${STACK}" \
 ARN_P1="$(fn_layer_arn)"
 echo "    function layer arn (Phase 1): ${ARN_P1}"
 case "${ARN_P1}" in
-  *":layer:${LAYER_NAME}:1") ;;
-  *) echo "FAIL: expected function to point at layer ${LAYER_NAME}:1, got '${ARN_P1}'" >&2; exit 1 ;;
+  *":layer:${LAYER_NAME}:"*) ;;
+  *) echo "FAIL: expected function to point at layer ${LAYER_NAME}, got '${ARN_P1}'" >&2; exit 1 ;;
 esac
-echo "    function points at layer version :1"
+V1="${ARN_P1##*:}"
+case "${V1}" in
+  ''|*[!0-9]*) echo "FAIL: could not parse a numeric layer version from '${ARN_P1}'" >&2; exit 1 ;;
+esac
+echo "    function points at layer version :${V1}"
 
 # --- Phase 2: change layer content (REPLACEMENT, must NOT need --replace) ---
 echo "==> Phase 2: re-deploy with v2 layer content (replacement + dependent re-point)"
 CDKD_TEST_UPDATE=true node "${LOCAL_DIST}" deploy "${STACK}" \
   --state-bucket "${STATE_BUCKET}" --region "${REGION}" --yes
 
-# A new version :2 must have been published.
+# A new version :V1+1 must have been published.
+V2=$((V1 + 1))
 VERSIONS="$(aws lambda list-layer-versions --layer-name "${LAYER_NAME}" --region "${REGION}" \
   --query 'LayerVersions[].Version' --output text)"
 echo "    published layer versions: ${VERSIONS}"
 case " ${VERSIONS} " in
-  *" 2 "*) ;;
-  *) echo "FAIL: expected a published layer version :2 after the content change, got '${VERSIONS}'" >&2; exit 1 ;;
+  *" ${V2} "*) ;;
+  *) echo "FAIL: expected a published layer version :${V2} after the content change, got '${VERSIONS}'" >&2; exit 1 ;;
 esac
-echo "    new layer version :2 published"
+echo "    new layer version :${V2} published"
 
-# The function must now follow to :2 (replacement propagated to dependent).
+# The function must now follow to :V2 (replacement propagated to dependent).
 ARN_P2="$(fn_layer_arn)"
 echo "    function layer arn (Phase 2): ${ARN_P2}"
 case "${ARN_P2}" in
-  *":layer:${LAYER_NAME}:2") ;;
-  *) echo "FAIL: expected function to be re-pointed at layer ${LAYER_NAME}:2, got '${ARN_P2}'" >&2; exit 1 ;;
+  *":layer:${LAYER_NAME}:${V2}") ;;
+  *) echo "FAIL: expected function to be re-pointed at layer ${LAYER_NAME}:${V2}, got '${ARN_P2}'" >&2; exit 1 ;;
 esac
-echo "    function re-pointed at layer version :2 (replacement propagated)"
+echo "    function re-pointed at layer version :${V2} (replacement propagated)"
 
 # --- Phase 3: destroy --------------------------------------------------
 echo "==> Phase 3: destroy"

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/package.json
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "aws-cdk": "^2.1133.0",
     "typescript": "^5.0.0"
   },
   "dependencies": {

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
@@ -38,8 +38,10 @@
 #     bash tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
 #
 # Requires Docker AND AWS credentials with deploy permissions in the
-# target account. Also requires the global `cdk` (aws-cdk) CLI on $PATH —
-# same as the single-stack fixture.
+# target account. The `cdk` (aws-cdk) CLI comes from this fixture's own
+# devDependencies (node_modules/.bin is prepended to PATH below) so a
+# stale global CLI can't hit a cloud-assembly schema-version mismatch
+# against the freshly-installed aws-cdk-lib.
 
 set -euo pipefail
 
@@ -53,6 +55,7 @@ IMAGE="public.ecr.aws/lambda/nodejs:20"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 TEST_DIR="${REPO_ROOT}/tests/integration/local-invoke-from-cfn-stack-multi-stack"
 CLI="node ${REPO_ROOT}/dist/cli.js"
+export PATH="${TEST_DIR}/node_modules/.bin:${PATH}"
 
 echo "[verify] region=${REGION} producer=${PRODUCER_STACK} consumer=${CONSUMER_STACK} export=${EXPORT_NAME}"
 

--- a/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack-multi-stack/verify.sh
@@ -55,6 +55,11 @@ IMAGE="public.ecr.aws/lambda/nodejs:20"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 TEST_DIR="${REPO_ROOT}/tests/integration/local-invoke-from-cfn-stack-multi-stack"
 CLI="node ${REPO_ROOT}/dist/cli.js"
+# Vendored cdk CLI: install the fixture's deps when absent (node_modules is
+# gitignored, and the repo-root pnpm install does NOT populate fixture dirs),
+# otherwise the PATH prepend is inert and `cdk` falls through to a possibly
+# stale global CLI.
+[ -x "${TEST_DIR}/node_modules/.bin/cdk" ] || (cd "${TEST_DIR}" && npm install)
 export PATH="${TEST_DIR}/node_modules/.bin:${PATH}"
 
 echo "[verify] region=${REGION} producer=${PRODUCER_STACK} consumer=${CONSUMER_STACK} export=${EXPORT_NAME}"

--- a/tests/integration/local-invoke-from-cfn-stack/package.json
+++ b/tests/integration/local-invoke-from-cfn-stack/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "aws-cdk": "^2.1133.0",
     "typescript": "^5.0.0"
   },
   "dependencies": {

--- a/tests/integration/local-invoke-from-cfn-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack/verify.sh
@@ -27,8 +27,10 @@
 #     bash tests/integration/local-invoke-from-cfn-stack/verify.sh
 #
 # Requires Docker AND AWS credentials with deploy permissions in the
-# target account. Also requires the global `cdk` (aws-cdk) CLI on $PATH —
-# see step 2's note on the vp-managed environment.
+# target account. The `cdk` (aws-cdk) CLI comes from this fixture's own
+# devDependencies (node_modules/.bin is prepended to PATH below) so a
+# stale global CLI can't hit a cloud-assembly schema-version mismatch
+# against the freshly-installed aws-cdk-lib.
 
 set -euo pipefail
 
@@ -40,6 +42,7 @@ IMAGE="public.ecr.aws/lambda/nodejs:20"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 TEST_DIR="${REPO_ROOT}/tests/integration/local-invoke-from-cfn-stack"
 CLI="node ${REPO_ROOT}/dist/cli.js"
+export PATH="${TEST_DIR}/node_modules/.bin:${PATH}"
 
 echo "[verify] region=${REGION} stack=${STACK} (CloudFormation-deployed)"
 

--- a/tests/integration/local-invoke-from-cfn-stack/verify.sh
+++ b/tests/integration/local-invoke-from-cfn-stack/verify.sh
@@ -42,6 +42,11 @@ IMAGE="public.ecr.aws/lambda/nodejs:20"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 TEST_DIR="${REPO_ROOT}/tests/integration/local-invoke-from-cfn-stack"
 CLI="node ${REPO_ROOT}/dist/cli.js"
+# Vendored cdk CLI: install the fixture's deps when absent (node_modules is
+# gitignored, and the repo-root pnpm install does NOT populate fixture dirs),
+# otherwise the PATH prepend is inert and `cdk` falls through to a possibly
+# stale global CLI.
+[ -x "${TEST_DIR}/node_modules/.bin/cdk" ] || (cd "${TEST_DIR}" && npm install)
 export PATH="${TEST_DIR}/node_modules/.bin:${PATH}"
 
 echo "[verify] region=${REGION} stack=${STACK} (CloudFormation-deployed)"
@@ -86,10 +91,9 @@ fi
 
 echo "[verify] step 3: cdk deploy (upstream CDK CLI, NOT cdkd)"
 # The fixture deliberately uses upstream `cdk deploy` so the resulting
-# stack is owned by CloudFormation, not cdkd. The cdk CLI is supplied by
-# vp's globally-managed environment (same pattern as
-# import-nested-stack); no per-fixture install round-trip needed since
-# Node's parent-dir resolution finds aws-cdk-lib from the repo root.
+# stack is owned by CloudFormation, not cdkd. The cdk CLI is the fixture's
+# own vendored devDependency (node_modules/.bin was prepended to PATH
+# above) so it always matches the freshly-installed aws-cdk-lib.
 # Set the sentinel BEFORE `cdk deploy` rather than after — pre-flight
 # has already verified the namespace is clean, so once we issue the
 # deploy command we OWN the namespace (cdk destroy is a no-op on


### PR DESCRIPTION
## Summary

Completes the TTL-refresh integ sweep started 2026-07-22: every test that was stale (last run > 14d, past the integ-gate TTL) or never-run has been re-run against real AWS. `/pick-integ` now reports **0 stale / 0 FAIL across all 252 fixtures**.

- **104 stale tests re-run** (78 standard + 26 `local-*` Docker), in 20 serial batches; ledger (`docs/_generated/integ-last-run.tsv`) updated after every batch.
- **Final result: 104/104 PASS.** 4 first-attempt failures were all fixture/environment staleness — none were cdkd bugs — fixed in this PR and re-run green:

| First-attempt failure | Root cause | Fix (this PR) |
|---|---|---|
| `lambda-layer-version-update` | Hardcoded layer `:1`/`:2` assertions vs AWS's never-reset per-name version counter | Capture Phase-1 version N, assert N+1 |
| `codedeploy-lambda-deployment-group` | Same, for Lambda function versions (alias at `1`/`2`) | Same N → N+1 pattern |
| `local-start-service`, `local-start-service-watch-fast`, `local-start-alb-from-state` | Stale cdk-local `cdkl-svc-*` docker network (0 containers) held the fixed subnet `169.254.171.0/24` → "Pool overlaps" | Removed the leftover network; run-integ skill now also sweeps `cdkd-local-svc-*` networks and documents the overlap diagnosis |
| `local-invoke-from-cfn-stack-multi-stack` (and latent in `local-invoke-from-cfn-stack`, `import-auto-mode`) | Global `cdk` CLI 2.1120 reads cloud-assembly schema <= 53; floating `aws-cdk-lib` emits 54 | Fixtures vendor `aws-cdk ^2.1133.0` (+ `node_modules/.bin` PATH prepend in the two verify.sh); all three re-run green |

- **Skill fixes** riding along: `/pick-integ` dedup awk no longer counts ledger header comment lines as phantom stale rows; `/run-integ` docker sweep covers `cdkd-local-svc-*` networks + subnet-overlap gotcha note.
- **Orphan hygiene**: every batch ended with a state/lock + NAT/EIP/EC2/RDS sweep (plus docker container/network sweeps for `local-*`); final account state is fully clean. A foreign live stack from a parallel session (`CdkdBenchCdkSample`, later `CdkdF1247Rollback`) was correctly left untouched.
- Follow-up filed as (#1252): remnant-delete after a failed CREATE should treat not-found as already-gone (observed on CodeDeploy DeploymentGroup during batch 11; benign, deploy retried fine).

Markers refreshed by the runs: `integ-destroy`, `integ-local` (both with full clean sweeps). `integ-broad` untouched by design — no cross-cutting src changes in this PR (broad-set tests were all < 14d fresh and intentionally skipped).

## Test plan

- Diff is fixtures + generated ledger + `.claude/skills` only — no `src/**` changes.
- Full local suite green: 474 test files / 7887 tests; typecheck (src + test project), lint, format, build all pass.
- Fixture lint gates (probe not-found, signal traps, CLI flags: 189 tests) pass on the edited verify.sh files.
- Every edited fixture was live-re-run against real AWS/Docker after its fix (`lambda-layer-version-update` 79s, `codedeploy-lambda-deployment-group` 109s, `local-invoke-from-cfn-stack` 91s, `local-invoke-from-cfn-stack-multi-stack` 113s, `import-auto-mode` 85s — all PASS, 0 orphans).
- Coverage matrices (`integ-coverage`, `scenario-coverage`, `cli-flag-coverage`) regenerated — no drift.
