### PR TITLE
docs(claude): scope the session-wrap Remaining-work section to this session's work

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -308,3 +308,9 @@ anything non-obvious you learned in memory.
 - **English-only** for all committed/public artifacts (source, docs, PR/commit
   messages, issue comments on this repo).
 - **Never download/run/install untrusted third-party content** (§0).
+- **Wrap with a Remaining-work section + Session-close verdict, scoped to the
+  issues this run actually worked.** This skill is the easiest place to get that
+  scope wrong: the backlog issues you triaged but did NOT pick up are not
+  follow-ups and do not belong in the report. List only residuals of the lanes
+  you shipped (gaps, deferred polish, issues filed because of this work).
+  (`CLAUDE.md` → Workflow Rules.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,8 @@ high.
 - **After fixing documentation or code**: Commit to a feature branch (not `main`) and push immediately. Do not leave uncommitted changes. Before reporting completion to the user, always run `git status` to verify nothing is uncommitted and that you are not on `main`.
 - **Every session-wrap / task-complete report MUST end with a "Remaining work" section AND a "Session close" verdict — unprompted**: the user should never have to ask "any follow-up tasks?" or "can I close this session?".
 
+  **Scope: only work this session created or touched.** The section reports residuals of THIS session's task: gaps in what was just shipped, polish deferred while doing it, and issues filed BECAUSE of this work. It is NOT a backlog dump. Do not list pre-existing open issues that merely happen to be unresolved, and once the session has moved on to an unrelated task, stop carrying forward items from earlier unrelated work in it. If the current work leaves nothing behind, the answer is "Nothing remaining" even when the repo has open issues elsewhere.
+
   **Remaining work** — exactly one of:
   - **TODO (issue #N)** — work that still needs doing later. This is the ONLY bucket that means "there are follow-up tasks"; every entry MUST have a GitHub issue number (file the issue BEFORE reporting, in the same turn the deferral is decided). A reader who wants to know "is anything left to do?" reads this bucket and nothing else.
   - **Won't-do (decided + recorded)** — things consciously decided AGAINST doing (cost/benefit call), with a one-line reason and where the decision is recorded (PR body, in-code comment, issue comment). These are NOT follow-up tasks and require no action; they are listed only so the decision is visible and challengeable.


### PR DESCRIPTION
## Summary

Scopes the session-wrap **Remaining work** section to the work of the session
that is reporting.

The rule (added in #1230, renamed in #1257) says every wrap report must end with
a Remaining-work section, but it never said whose work that section covers. In
practice it was being filled with pre-existing open issues that had nothing to
do with the task just finished, which buries the residuals that actually matter
and reads as a backlog dump.

The added clause states the scope explicitly: the section reports what THIS
session created or touched (gaps in what was just shipped, polish deferred while
doing it, issues filed because of this work), it is not a backlog dump, and when
the session moves on to an unrelated task it stops carrying forward items from
the earlier unrelated work. If the current work leaves nothing behind, the
answer is "Nothing remaining" even when the repo has open issues elsewhere.

## Test plan

Documentation only, one clause added to an existing CLAUDE.md workflow rule.
typecheck / lint / build / tests (7950) all pass.
