### PR TITLE
fix(lambda-url): wrap update() SDK errors in ProvisioningError

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -36,7 +36,7 @@ cc-api-fallback	2026-07-27T05:30:42Z	PASS	65	verify.sh	1252 fix live-verify (CC 
 cc-api-fallback-transitions	2026-07-20T02:19:31Z	PASS	140	verify.sh	CC transition/override #634 verified, 2 stacks destroy clean
 cc-getatt-readback	2026-07-20T03:06:02Z	PASS	260	verify.sh	generic sparse read-back live-verified (#1105); destroy 8/8, 0 orphans
 ci-cd	2026-07-21T18:23:00Z	PASS	55	verify.sh	rc ok, orph clean
-cloudfront-function-url	2026-07-27T09:57:55Z	PASS	430	verify.sh	1160 removal phase 1b final rebased-tree run, destroy 7/0, 0 orphans
+cloudfront-function-url	2026-07-27T10:27:57Z	PASS	384	verify.sh	issue #1263 lambda-url update error-wrap verify; destroy 7/0, 0 orphans
 cloudwatch	2026-07-26T20:00:52Z	PASS	55	standard	0727b sweep-b13 staleness re-run (rc=0); account clean
 codecommit	2026-07-18T19:54:34Z	PASS		verify.sh	Code seed+SNS trigger+rename+drift, destroy 0 err 0 orph (re-run post review-nits)
 codedeploy-lambda-deployment-group	2026-07-26T19:45:58Z	PASS	109	verify.sh	re-run after version-agnostic fixture fix; live-verified, account clean (remnant-warning follow-up: issue #1252)
@@ -129,7 +129,7 @@ intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 stale
 kinesis-esm-filter	2026-07-24T10:29:51Z	PASS	73	verify.sh	0724 P0 sweep: lambda-eventsource-provider #1194 coverage; FilterCriteria verified; 5 del 0 err
 kinesis-stream-mode-switch	2026-07-26T18:57:55Z	PASS	73	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda	2026-07-26T15:31:59Z	PASS	85	verify.sh	PR #1231 broad integ; destroy 0 errors 0 orphans
+lambda	2026-07-27T10:30:21Z	PASS	89	verify.sh	issue #1263 broad integ; destroy 9/0, 0 orphans
 lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-arch-switch	2026-07-26T19:25:15Z	PASS	63	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 lambda-config-field-removal	2026-07-22T08:19:38Z	PASS	140	verify.sh	issue #1158 post-rebase re-verify; 6-field removal reset + destroy clean

--- a/src/provisioning/providers/lambda-url-provider.ts
+++ b/src/provisioning/providers/lambda-url-provider.ts
@@ -112,7 +112,7 @@ export class LambdaUrlProvider implements ResourceProvider {
   async update(
     logicalId: string,
     physicalId: string,
-    _resourceType: string,
+    resourceType: string,
     properties: Record<string, unknown>,
     previousProperties: Record<string, unknown>
   ): Promise<ResourceUpdateResult> {
@@ -185,16 +185,29 @@ export class LambdaUrlProvider implements ResourceProvider {
     );
     if (corsParam !== undefined) updateParams.Cors = corsParam;
 
-    const response = await this.lambdaClient.send(new UpdateFunctionUrlConfigCommand(updateParams));
+    try {
+      const response = await this.lambdaClient.send(
+        new UpdateFunctionUrlConfigCommand(updateParams)
+      );
 
-    return {
-      physicalId,
-      wasReplaced: false,
-      attributes: {
-        FunctionUrl: response.FunctionUrl,
-        FunctionArn: response.FunctionArn,
-      },
-    };
+      return {
+        physicalId,
+        wasReplaced: false,
+        attributes: {
+          FunctionUrl: response.FunctionUrl,
+          FunctionArn: response.FunctionArn,
+        },
+      };
+    } catch (error) {
+      const cause = error instanceof Error ? error : undefined;
+      throw new ProvisioningError(
+        `Failed to update Lambda URL ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,
+        resourceType,
+        logicalId,
+        physicalId,
+        cause
+      );
+    }
   }
 
   /**

--- a/tests/unit/provisioning/lambda-url-provider.test.ts
+++ b/tests/unit/provisioning/lambda-url-provider.test.ts
@@ -30,6 +30,7 @@ vi.mock('../../../src/utils/logger.js', () => {
 });
 
 import { LambdaUrlProvider } from '../../../src/provisioning/providers/lambda-url-provider.js';
+import { ProvisioningError } from '../../../src/utils/error-handler.js';
 
 describe('LambdaUrlProvider', () => {
   let provider: LambdaUrlProvider;
@@ -108,6 +109,53 @@ describe('LambdaUrlProvider', () => {
 
       const result = await provider.getAttribute('missing-fn', 'AWS::Lambda::Url', 'FunctionUrl');
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('update error wrapping', () => {
+    // Issue #1263: the UpdateFunctionUrlConfig send was the one call in this
+    // provider not wrapped in ProvisioningError, so an AWS SDK error surfaced
+    // raw and bypassed cdkd's typed error formatting / exit-code handling.
+    it('wraps an UpdateFunctionUrlConfig failure in ProvisioningError', async () => {
+      const sdkError = new Error('The function URL config could not be updated');
+      mockSend.mockRejectedValueOnce(sdkError);
+
+      // AuthType differs from the previous side so the diff-based no-op gate
+      // opens and the AWS call is actually attempted.
+      const promise = provider.update(
+        'MyUrl',
+        'arn:aws:lambda:us-east-1:123456789012:function:my-fn',
+        'AWS::Lambda::Url',
+        { AuthType: 'AWS_IAM' },
+        { AuthType: 'NONE' }
+      );
+
+      await expect(promise).rejects.toThrow(ProvisioningError);
+      await expect(promise).rejects.toMatchObject({
+        resourceType: 'AWS::Lambda::Url',
+        logicalId: 'MyUrl',
+        physicalId: 'arn:aws:lambda:us-east-1:123456789012:function:my-fn',
+        cause: sdkError,
+      });
+      await expect(promise).rejects.toThrow(
+        'Failed to update Lambda URL MyUrl: The function URL config could not be updated'
+      );
+    });
+
+    it('does not wrap when the diff-based no-op gate skips the AWS call', async () => {
+      // No handled property changed, so update() returns without sending —
+      // the wrap must not turn a legitimate no-op into an error.
+      const props = { AuthType: 'NONE' };
+      const result = await provider.update(
+        'MyUrl',
+        'my-fn',
+        'AWS::Lambda::Url',
+        props,
+        { ...props }
+      );
+
+      expect(result).toEqual({ physicalId: 'my-fn', wasReplaced: false, attributes: {} });
+      expect(mockSend).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/provisioning/lambda-url-provider.test.ts
+++ b/tests/unit/provisioning/lambda-url-provider.test.ts
@@ -143,8 +143,10 @@ describe('LambdaUrlProvider', () => {
     });
 
     it('does not wrap when the diff-based no-op gate skips the AWS call', async () => {
-      // No handled property changed, so update() returns without sending —
-      // the wrap must not turn a legitimate no-op into an error.
+      // No handled property changed, so update() returns without sending.
+      // The early return sits OUTSIDE the try, so this pins the pre-existing
+      // no-op behavior rather than guarding the wrap itself — it is the
+      // regression fence for anyone later widening the try to enclose it.
       const props = { AuthType: 'NONE' };
       const result = await provider.update(
         'MyUrl',
@@ -156,6 +158,31 @@ describe('LambdaUrlProvider', () => {
 
       expect(result).toEqual({ physicalId: 'my-fn', wasReplaced: false, attributes: {} });
       expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('wraps a non-Error rejection with a stringified message and no cause', async () => {
+      // The `error instanceof Error` narrowing has two arms; the non-Error arm
+      // is reachable in principle (a middleware rejecting with a plain value)
+      // and must still produce a well-formed ProvisioningError.
+      mockSend.mockRejectedValueOnce('boom');
+
+      const promise = provider.update(
+        'MyUrl',
+        'my-fn',
+        'AWS::Lambda::Url',
+        { AuthType: 'AWS_IAM' },
+        { AuthType: 'NONE' }
+      );
+
+      await expect(promise).rejects.toThrow(ProvisioningError);
+      await expect(promise).rejects.toThrow('Failed to update Lambda URL MyUrl: boom');
+      await expect(promise).rejects.toMatchObject({
+        resourceType: 'AWS::Lambda::Url',
+        logicalId: 'MyUrl',
+        physicalId: 'my-fn',
+      });
+      const caught = await promise.catch((e: unknown) => e);
+      expect((caught as Error).cause).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

`LambdaUrlProvider.update()`'s `UpdateFunctionUrlConfig` send was the one AWS
call in this provider not wrapped in `ProvisioningError` the way `create()` and
`delete()` are. An AWS SDK error surfaced raw from that path, bypassing cdkd's
typed error formatting and exit-code handling.

Surfaced by the PR #1261 code review (pre-existing, not introduced there).

## Changes

- Wrap the `UpdateFunctionUrlConfigCommand` send in the same try/catch +
  `ProvisioningError` pattern as `create()`, carrying `resourceType` /
  `logicalId` / `physicalId` / `cause`.
- Drop the underscore prefix from the `resourceType` parameter, now that it is
  used.

The pure property-building above the call (the `clearOnUpdateRemoval` /
`buildCorsConfig` logic) is deliberately left outside the `try`: a throw there
would be a programming bug, not a provisioning failure, and should not be
misattributed as one. The diff-based no-op early return is likewise untouched.

## Verification

- Three unit tests: the wrap itself (error type, `resourceType` / `logicalId` /
  `physicalId`, message, preserved `cause`), the non-`Error` rejection arm, and
  a fence pinning that the diff-based no-op gate still short-circuits without an
  AWS call. The wrap test was confirmed to FAIL without the fix and pass with it.
- Live-tested against real AWS: a genuine `ResourceNotFoundException` from
  `UpdateFunctionUrlConfig` now surfaces as `ProvisioningError`
  (`code: PROVISIONING_ERROR`, message `Failed to update Lambda URL MyUrl:
  Function does not exist`, AWS error preserved as `cause`).
- Retry-classification regression checked (and independently re-verified in
  review): `retryable-errors.ts` walks the `.cause` chain, so wrapping does not
  hide a throttle from the deploy engine's transient-retry logic, and the
  original message is embedded so the message-pattern table still matches.
- Full suite: 481 files / 7969 tests pass.
- Real-AWS integs, both clean with 0 errors / 0 orphans:
  `cloudfront-function-url` (exercises this provider's create/update/destroy,
  7 deleted) and `lambda` (broad set, 9 deleted).

## Follow-up

The review flagged the same unwrapped-`update()` pattern in four sibling
providers (EventBridge bus, SNS topic, Lambda event-source, Logs log-group).
Tracked separately in #1267 — out of scope here.

Closes #1263
