### PR TITLE
fix(providers): wrap update() SDK errors in ProvisioningError

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -91,13 +91,13 @@ elasticache-replicationgroup-getatt	2026-07-20T14:51:32Z	PASS	596	verify.sh	CC G
 emr-cluster	2026-07-19T18:32:52Z	PASS	1560	verify.sh	issue #1090 import round-trip w/ discriminating assertions (attributes from #1099, observed-vs-template divergence); 12 deleted 0 errors 0 orphans
 emr-instance-configs	2026-07-19T12:15:47Z	PASS	1680	verify.sh	post-review re-run (fleet scale-down fix); deploy+resize+destroy clean, 0 orphans
 event-driven	2026-07-26T18:36:31Z	PASS	42	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
-eventbridge	2026-07-20T17:32:58Z	PASS	82	verify.sh	EventBus+Pipes+Scheduler, 10 res clean destroy
+eventbridge	2026-07-27T11:04:52Z	PASS	87	verify.sh	issue #1267 post-review re-run; 10 del 0 err, 0 orphans
 eventbridge-api-destination	2026-07-21T14:48:06Z	PASS	70	verify.sh	rc ok, orph clean
 eventbridge-archive	2026-07-16T15:54:15Z	PASS	53	verify.sh	new fixture, 3 phases clean, orph clean
 eventbridge-input-transformer	2026-07-20T08:18:46Z	PASS	63	verify.sh	hardened P2 propagation race; passes
 eventbridge-pipes	2026-07-26T19:36:49Z	PASS	177	verify.sh	0727b sweep-b11 staleness re-run (rc=0); account clean
 eventbridge-scheduler	2026-07-20T03:07:51Z	PASS	150	verify.sh	pattern-2 sweep sample: assert_gone/gone_probe/head-object idioms live-verified; 0 orphans
-eventsourcemapping-race	2026-07-24T05:12:28Z	PASS	180	verify.sh	#1190 fix: EsmArn GetAtt now resolves (EsmArn output = real ARN); 5 del 0 err; no orphan ESM
+eventsourcemapping-race	2026-07-27T11:04:52Z	PASS	80	verify.sh	issue #1267 Lambda ESM update wrap; 5 del 0 err; swept 1 auto-created log group
 export	2026-07-26T17:37:08Z	PASS	249	verify.sh	live-test for export.ts DescribeType throttle-retry follow-up; CFn round-trip + clean delete
 export-nested-stack	2026-07-21T08:39:22Z	PASS	327	verify.sh	export->CFn nested adopt, CFn delete clean, 0 orphans
 fifo-sqs-event-source	2026-07-27T06:44:00Z	PASS	111	verify.sh	final-tree gate refresh for #1256; destroy 6/0 errors, 0 orphans
@@ -176,7 +176,7 @@ local-start-cloudfront	2026-07-26T20:40:20Z	PASS	7	verify.sh	0727b sweep-L6 stal
 local-start-service	2026-07-26T20:18:09Z	PASS	20	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
 local-start-service-watch-fast	2026-07-26T20:18:09Z	PASS	186	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
 log-pipeline	2026-07-26T18:10:48Z	PASS	72	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
-loggroup-class-guard	2026-07-26T19:25:15Z	PASS	53	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
+loggroup-class-guard	2026-07-27T11:04:52Z	PASS	49	verify.sh	issue #1267 post-review re-run; typed-error pass-through verified vs real AWS; 1 del 0 err
 loggroup-kms-associate	2026-07-26T19:25:15Z	PASS	57	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 macro-expansion	2026-07-21T19:45:50Z	PASS	107	verify.sh	re-run w/ new diff-expands + destroy-no-expand asserts (1150)
 microservices	2026-07-19T19:50:37Z	PASS	54	standard	rc ok, 19 res, all destroyed, orph clean
@@ -236,7 +236,7 @@ servicediscovery-namespaces	2026-07-17T12:12:19Z	PASS	114	verify.sh	re-run post 
 ses-identity	2026-07-21T14:41:07Z	PASS	199	verify.sh	PASS on re-run; 1st attempt hit transient 403 token-expiry (not a cdkd bug), cleaned orphan config-set
 sg-circular-dependency	2026-07-26T18:49:34Z	PASS	51	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
 sns-event-source	2026-07-20T08:12:14Z	PASS	68	verify.sh	rc ok, orph clean
-sns-inline-subscription	2026-07-20T17:38:28Z	PASS	53	verify.sh	SNS inline subscription create+update, clean destroy
+sns-inline-subscription	2026-07-27T11:04:52Z	PASS	53	verify.sh	issue #1267 SNS topic update wrap; 3 del 0 err
 sns-sqs-event	2026-07-26T17:01:09Z	PASS	78	verify.sh	#1160 sqs SSE removal phase 2 verified; destroy 20/0 errors, 0 orphans
 sns-subscription-filter	2026-07-21T18:09:46Z	PASS	46	verify.sh	rc ok, orph clean
 sqs-cloudwatch	2026-07-26T18:04:53Z	PASS	56	standard	0727b sweep-b1 staleness re-run (rc=0); account clean

--- a/src/provisioning/providers/eventbridge-bus-provider.ts
+++ b/src/provisioning/providers/eventbridge-bus-provider.ts
@@ -16,7 +16,7 @@ import {
 } from '@aws-sdk/client-eventbridge';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
-import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
+import { CdkdError, ProvisioningError } from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { normalizeAwsTagsToCfn, resolveExplicitPhysicalId } from '../import-helpers.js';
 import type {
@@ -177,7 +177,10 @@ export class EventBridgeBusProvider implements ResourceProvider {
     try {
       return await this.applyUpdate(logicalId, physicalId, properties, previousProperties);
     } catch (error) {
-      if (error instanceof ResourceUpdateNotSupportedError) throw error;
+      // Pass through every cdkd-typed error untouched: ResourceUpdateNotSupportedError
+      // is control flow the deploy engine matches BY CLASS, and a ProvisioningError
+      // raised deeper in the body already carries better context than a re-wrap.
+      if (error instanceof CdkdError) throw error;
       const cause = error instanceof Error ? error : undefined;
       throw new ProvisioningError(
         `Failed to update EventBus ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/provisioning/providers/eventbridge-bus-provider.ts
+++ b/src/provisioning/providers/eventbridge-bus-provider.ts
@@ -16,7 +16,7 @@ import {
 } from '@aws-sdk/client-eventbridge';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
-import { ProvisioningError } from '../../utils/error-handler.js';
+import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { normalizeAwsTagsToCfn, resolveExplicitPhysicalId } from '../import-helpers.js';
 import type {
@@ -154,14 +154,48 @@ export class EventBridgeBusProvider implements ResourceProvider {
     }
   }
 
+  /**
+   * Update an EventBus.
+   *
+   * Thin wrapper that maps any AWS SDK failure onto {@link ProvisioningError}
+   * the same way {@link create} and {@link delete} do, so an update failure
+   * carries cdkd's typed error formatting and exit-code handling instead of
+   * surfacing raw (issue #1267). The body lives in {@link applyUpdate} so the
+   * wrap is a boundary concern rather than a 70-line indentation change.
+   *
+   * A typed control-flow error is re-thrown untouched: the deploy engine
+   * matches those by class to decide its fallback, so swallowing one into a
+   * ProvisioningError would silently disable that path.
+   */
   async update(
-    _logicalId: string,
+    logicalId: string,
     physicalId: string,
-    _resourceType: string,
+    resourceType: string,
     properties: Record<string, unknown>,
     previousProperties: Record<string, unknown>
   ): Promise<ResourceUpdateResult> {
-    this.logger.debug(`Updating EventBus ${_logicalId}: ${physicalId}`);
+    try {
+      return await this.applyUpdate(logicalId, physicalId, properties, previousProperties);
+    } catch (error) {
+      if (error instanceof ResourceUpdateNotSupportedError) throw error;
+      const cause = error instanceof Error ? error : undefined;
+      throw new ProvisioningError(
+        `Failed to update EventBus ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,
+        resourceType,
+        logicalId,
+        physicalId,
+        cause
+      );
+    }
+  }
+
+  private async applyUpdate(
+    logicalId: string,
+    physicalId: string,
+    properties: Record<string, unknown>,
+    previousProperties: Record<string, unknown>
+  ): Promise<ResourceUpdateResult> {
+    this.logger.debug(`Updating EventBus ${logicalId}: ${physicalId}`);
 
     // Update mutable properties (Description, KmsKeyIdentifier, DeadLetterConfig, LogConfig)
     const descChanged = properties['Description'] !== previousProperties['Description'];

--- a/src/provisioning/providers/lambda-eventsource-provider.ts
+++ b/src/provisioning/providers/lambda-eventsource-provider.ts
@@ -12,7 +12,7 @@ import {
 } from '@aws-sdk/client-lambda';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
-import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
+import { CdkdError, ProvisioningError } from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
@@ -373,7 +373,10 @@ export class LambdaEventSourceMappingProvider implements ResourceProvider {
     try {
       return await this.applyUpdate(logicalId, physicalId, properties, previousProperties);
     } catch (error) {
-      if (error instanceof ResourceUpdateNotSupportedError) throw error;
+      // Pass through every cdkd-typed error untouched: ResourceUpdateNotSupportedError
+      // is control flow the deploy engine matches BY CLASS, and a ProvisioningError
+      // raised deeper in the body already carries better context than a re-wrap.
+      if (error instanceof CdkdError) throw error;
       const cause = error instanceof Error ? error : undefined;
       throw new ProvisioningError(
         `Failed to update event source mapping ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/provisioning/providers/lambda-eventsource-provider.ts
+++ b/src/provisioning/providers/lambda-eventsource-provider.ts
@@ -12,7 +12,7 @@ import {
 } from '@aws-sdk/client-lambda';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
-import { ProvisioningError } from '../../utils/error-handler.js';
+import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import type {
   ResourceProvider,
@@ -352,11 +352,42 @@ export class LambdaEventSourceMappingProvider implements ResourceProvider {
 
   /**
    * Update a Lambda Event Source Mapping
+   *
+   * Thin wrapper that maps any AWS SDK failure onto {@link ProvisioningError}
+   * the same way {@link create} and {@link delete} do, so an update failure
+   * carries cdkd's typed error formatting and exit-code handling instead of
+   * surfacing raw (issue #1267). The body lives in {@link applyUpdate} so the
+   * wrap is a boundary concern rather than a large indentation change.
+   *
+   * A typed control-flow error is re-thrown untouched: the deploy engine
+   * matches those by class to decide its fallback, so swallowing one into a
+   * ProvisioningError would silently disable that path.
    */
   async update(
     logicalId: string,
     physicalId: string,
-    _resourceType: string,
+    resourceType: string,
+    properties: Record<string, unknown>,
+    previousProperties: Record<string, unknown>
+  ): Promise<ResourceUpdateResult> {
+    try {
+      return await this.applyUpdate(logicalId, physicalId, properties, previousProperties);
+    } catch (error) {
+      if (error instanceof ResourceUpdateNotSupportedError) throw error;
+      const cause = error instanceof Error ? error : undefined;
+      throw new ProvisioningError(
+        `Failed to update event source mapping ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,
+        resourceType,
+        logicalId,
+        physicalId,
+        cause
+      );
+    }
+  }
+
+  private async applyUpdate(
+    logicalId: string,
+    physicalId: string,
     properties: Record<string, unknown>,
     previousProperties: Record<string, unknown>
   ): Promise<ResourceUpdateResult> {

--- a/src/provisioning/providers/logs-loggroup-provider.ts
+++ b/src/provisioning/providers/logs-loggroup-provider.ts
@@ -252,11 +252,43 @@ export class LogsLogGroupProvider implements ResourceProvider {
    * class after creation), so a class change throws
    * {@link ResourceUpdateNotSupportedError} instead of being silently
    * dropped; `--replace` recreates the log group under the new class.
+   *
+   * Thin wrapper that maps any AWS SDK failure onto {@link ProvisioningError}
+   * the same way {@link create} and {@link delete} do, so an update failure
+   * carries cdkd's typed error formatting and exit-code handling instead of
+   * surfacing raw (issue #1267). The body lives in {@link applyUpdate} so the
+   * wrap is a boundary concern rather than a large indentation change.
+   *
+   * The {@link ResourceUpdateNotSupportedError} thrown by the LogGroupClass
+   * guard is re-thrown untouched: the deploy engine matches it by class to
+   * fall back to replacement, so swallowing it into a ProvisioningError would
+   * turn a recoverable class change into a hard failure.
    */
   async update(
     logicalId: string,
     physicalId: string,
-    _resourceType: string,
+    resourceType: string,
+    properties: Record<string, unknown>,
+    previousProperties: Record<string, unknown>
+  ): Promise<ResourceUpdateResult> {
+    try {
+      return await this.applyUpdate(logicalId, physicalId, properties, previousProperties);
+    } catch (error) {
+      if (error instanceof ResourceUpdateNotSupportedError) throw error;
+      const cause = error instanceof Error ? error : undefined;
+      throw new ProvisioningError(
+        `Failed to update log group ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,
+        resourceType,
+        logicalId,
+        physicalId,
+        cause
+      );
+    }
+  }
+
+  private async applyUpdate(
+    logicalId: string,
+    physicalId: string,
     properties: Record<string, unknown>,
     previousProperties: Record<string, unknown>
   ): Promise<ResourceUpdateResult> {

--- a/src/provisioning/providers/logs-loggroup-provider.ts
+++ b/src/provisioning/providers/logs-loggroup-provider.ts
@@ -24,7 +24,11 @@ import {
 import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
-import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
+import {
+  CdkdError,
+  ProvisioningError,
+  ResourceUpdateNotSupportedError,
+} from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
 import { normalizeAwsTagsToCfn, resolveExplicitPhysicalId } from '../import-helpers.js';
@@ -274,7 +278,10 @@ export class LogsLogGroupProvider implements ResourceProvider {
     try {
       return await this.applyUpdate(logicalId, physicalId, properties, previousProperties);
     } catch (error) {
-      if (error instanceof ResourceUpdateNotSupportedError) throw error;
+      // Pass through every cdkd-typed error untouched: ResourceUpdateNotSupportedError
+      // is control flow the deploy engine matches BY CLASS, and a ProvisioningError
+      // raised deeper in the body already carries better context than a re-wrap.
+      if (error instanceof CdkdError) throw error;
       const cause = error instanceof Error ? error : undefined;
       throw new ProvisioningError(
         `Failed to update log group ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/provisioning/providers/sns-topic-provider.ts
+++ b/src/provisioning/providers/sns-topic-provider.ts
@@ -18,7 +18,7 @@ import {
 } from '@aws-sdk/client-sns';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
-import { ProvisioningError } from '../../utils/error-handler.js';
+import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
 import { stringifyValue } from '../../utils/stringify.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
@@ -287,11 +287,43 @@ export class SNSTopicProvider implements ResourceProvider {
    *
    * SNS topics have limited mutable properties (DisplayName, KmsMasterKeyId, etc.).
    * TopicName is immutable and requires replacement (handled by deployment layer).
+   *
+   * Thin wrapper that maps any AWS SDK failure onto {@link ProvisioningError}
+   * the same way {@link create} and {@link delete} do, so an update failure
+   * carries cdkd's typed error formatting and exit-code handling instead of
+   * surfacing raw (issue #1267). This provider issues many separate `send`
+   * calls across attributes / policies / subscriptions, so the wrap lives at
+   * the boundary and the body stays in {@link applyUpdate}.
+   *
+   * A typed control-flow error is re-thrown untouched: the deploy engine
+   * matches those by class to decide its fallback, so swallowing one into a
+   * ProvisioningError would silently disable that path.
    */
   async update(
     logicalId: string,
     physicalId: string,
-    _resourceType: string,
+    resourceType: string,
+    properties: Record<string, unknown>,
+    previousProperties: Record<string, unknown>
+  ): Promise<ResourceUpdateResult> {
+    try {
+      return await this.applyUpdate(logicalId, physicalId, properties, previousProperties);
+    } catch (error) {
+      if (error instanceof ResourceUpdateNotSupportedError) throw error;
+      const cause = error instanceof Error ? error : undefined;
+      throw new ProvisioningError(
+        `Failed to update SNS topic ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,
+        resourceType,
+        logicalId,
+        physicalId,
+        cause
+      );
+    }
+  }
+
+  private async applyUpdate(
+    logicalId: string,
+    physicalId: string,
     properties: Record<string, unknown>,
     previousProperties: Record<string, unknown>
   ): Promise<ResourceUpdateResult> {

--- a/src/provisioning/providers/sns-topic-provider.ts
+++ b/src/provisioning/providers/sns-topic-provider.ts
@@ -18,7 +18,7 @@ import {
 } from '@aws-sdk/client-sns';
 import { getLogger } from '../../utils/logger.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
-import { ProvisioningError, ResourceUpdateNotSupportedError } from '../../utils/error-handler.js';
+import { CdkdError, ProvisioningError } from '../../utils/error-handler.js';
 import { stringifyValue } from '../../utils/stringify.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
@@ -309,7 +309,10 @@ export class SNSTopicProvider implements ResourceProvider {
     try {
       return await this.applyUpdate(logicalId, physicalId, properties, previousProperties);
     } catch (error) {
-      if (error instanceof ResourceUpdateNotSupportedError) throw error;
+      // Pass through every cdkd-typed error untouched: ResourceUpdateNotSupportedError
+      // is control flow the deploy engine matches BY CLASS, and a ProvisioningError
+      // raised deeper in the body already carries better context than a re-wrap.
+      if (error instanceof CdkdError) throw error;
       const cause = error instanceof Error ? error : undefined;
       throw new ProvisioningError(
         `Failed to update SNS topic ${logicalId}: ${error instanceof Error ? error.message : String(error)}`,

--- a/tests/unit/provisioning/provider-update-error-wrapping.test.ts
+++ b/tests/unit/provisioning/provider-update-error-wrapping.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+// Issue #1267: these four providers wrapped their create()/delete() SDK errors
+// in ProvisioningError but left update() unwrapped, so an AWS SDK error from an
+// update surfaced raw and bypassed cdkd's typed error formatting / exit-code
+// handling. Each provider now wraps at the update() boundary.
+//
+// One shared client mock per service — every provider reads its client off
+// getAwsClients() in the constructor.
+const mockEventBridgeSend = vi.fn();
+const mockSnsSend = vi.fn();
+const mockLambdaSend = vi.fn();
+const mockLogsSend = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    eventBridge: {
+      send: mockEventBridgeSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    },
+    sns: { send: mockSnsSend, config: { region: () => Promise.resolve('us-east-1') } },
+    lambda: { send: mockLambdaSend, config: { region: () => Promise.resolve('us-east-1') } },
+    cloudWatchLogs: { send: mockLogsSend, config: { region: () => Promise.resolve('us-east-1') } },
+    sts: {
+      send: vi.fn(() => Promise.resolve({ Account: '123456789012' })),
+      config: { region: () => Promise.resolve('us-east-1') },
+    },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { EventBridgeBusProvider } from '../../../src/provisioning/providers/eventbridge-bus-provider.js';
+import { SNSTopicProvider } from '../../../src/provisioning/providers/sns-topic-provider.js';
+import { LambdaEventSourceMappingProvider } from '../../../src/provisioning/providers/lambda-eventsource-provider.js';
+import { LogsLogGroupProvider } from '../../../src/provisioning/providers/logs-loggroup-provider.js';
+import {
+  ProvisioningError,
+  ResourceUpdateNotSupportedError,
+} from '../../../src/utils/error-handler.js';
+
+/**
+ * Each case drives its provider's update() into at least one AWS `send` by
+ * changing a mutable property, with the mocked client rejecting.
+ */
+const CASES = [
+  {
+    name: 'EventBridgeBusProvider',
+    resourceType: 'AWS::Events::EventBus',
+    logicalId: 'MyBus',
+    physicalId: 'my-bus',
+    expectedPrefix: 'Failed to update EventBus MyBus',
+    mock: () => mockEventBridgeSend,
+    make: () => new EventBridgeBusProvider(),
+    next: { Name: 'my-bus', Description: 'after' },
+    prev: { Name: 'my-bus', Description: 'before' },
+  },
+  {
+    name: 'SNSTopicProvider',
+    resourceType: 'AWS::SNS::Topic',
+    logicalId: 'MyTopic',
+    physicalId: 'arn:aws:sns:us-east-1:123456789012:my-topic',
+    expectedPrefix: 'Failed to update SNS topic MyTopic',
+    mock: () => mockSnsSend,
+    make: () => new SNSTopicProvider(),
+    next: { TopicName: 'my-topic', DisplayName: 'after' },
+    prev: { TopicName: 'my-topic', DisplayName: 'before' },
+  },
+  {
+    name: 'LambdaEventSourceMappingProvider',
+    resourceType: 'AWS::Lambda::EventSourceMapping',
+    logicalId: 'MyEsm',
+    physicalId: '00000000-1111-2222-3333-444444444444',
+    expectedPrefix: 'Failed to update event source mapping MyEsm',
+    mock: () => mockLambdaSend,
+    make: () => new LambdaEventSourceMappingProvider(),
+    next: { FunctionName: 'fn', BatchSize: 20 },
+    prev: { FunctionName: 'fn', BatchSize: 10 },
+  },
+  {
+    name: 'LogsLogGroupProvider',
+    resourceType: 'AWS::Logs::LogGroup',
+    logicalId: 'MyLg',
+    physicalId: '/cdkd/my-lg',
+    expectedPrefix: 'Failed to update log group MyLg',
+    mock: () => mockLogsSend,
+    make: () => new LogsLogGroupProvider(),
+    next: { LogGroupName: '/cdkd/my-lg', RetentionInDays: 30 },
+    prev: { LogGroupName: '/cdkd/my-lg', RetentionInDays: 7 },
+  },
+] as const;
+
+describe('SDK provider update() error wrapping (issue #1267)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  for (const c of CASES) {
+    describe(c.name, () => {
+      it('wraps an AWS SDK update failure in ProvisioningError', async () => {
+        const sdkError = new Error('AWS said no');
+        c.mock().mockRejectedValue(sdkError);
+
+        const provider = c.make();
+        const promise = provider.update(
+          c.logicalId,
+          c.physicalId,
+          c.resourceType,
+          { ...c.next },
+          { ...c.prev }
+        );
+
+        await expect(promise).rejects.toThrow(ProvisioningError);
+        await expect(promise).rejects.toThrow(`${c.expectedPrefix}: AWS said no`);
+        await expect(promise).rejects.toMatchObject({
+          resourceType: c.resourceType,
+          logicalId: c.logicalId,
+          physicalId: c.physicalId,
+          cause: sdkError,
+        });
+        // Sanity: the case actually reached an AWS call, so the assertion above
+        // is not passing vacuously on some earlier throw.
+        expect(c.mock()).toHaveBeenCalled();
+      });
+
+      it('wraps a non-Error rejection with a stringified message and no cause', async () => {
+        c.mock().mockRejectedValue('boom');
+
+        const provider = c.make();
+        const promise = provider.update(
+          c.logicalId,
+          c.physicalId,
+          c.resourceType,
+          { ...c.next },
+          { ...c.prev }
+        );
+
+        await expect(promise).rejects.toThrow(ProvisioningError);
+        await expect(promise).rejects.toThrow(`${c.expectedPrefix}: boom`);
+        const caught = await promise.catch((e: unknown) => e);
+        expect((caught as Error).cause).toBeUndefined();
+      });
+    });
+  }
+
+  // The load-bearing case: LogsLogGroupProvider.update() throws the typed
+  // ResourceUpdateNotSupportedError on a LogGroupClass change, and the deploy
+  // engine matches it BY CLASS to fall back to replacement. If the new wrap
+  // swallowed it into a ProvisioningError, a recoverable class change would
+  // become a hard failure. (logs-loggroup-provider-class-guard.test.ts covers
+  // the guard itself; this pins that the wrap does not re-classify it.)
+  it('does not re-wrap ResourceUpdateNotSupportedError from the LogGroupClass guard', async () => {
+    mockLogsSend.mockResolvedValue({});
+    const provider = new LogsLogGroupProvider();
+
+    const promise = provider.update(
+      'ClassLg',
+      '/cdkd/class-lg',
+      'AWS::Logs::LogGroup',
+      { LogGroupName: '/cdkd/class-lg', LogGroupClass: 'INFREQUENT_ACCESS' },
+      { LogGroupName: '/cdkd/class-lg', LogGroupClass: 'STANDARD' }
+    );
+
+    await expect(promise).rejects.toThrow(ResourceUpdateNotSupportedError);
+    await expect(promise).rejects.not.toThrow(ProvisioningError);
+    // The guard runs before any mutation.
+    expect(mockLogsSend).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/provisioning/provider-update-error-wrapping.test.ts
+++ b/tests/unit/provisioning/provider-update-error-wrapping.test.ts
@@ -55,6 +55,10 @@ import {
   ProvisioningError,
   ResourceUpdateNotSupportedError,
 } from '../../../src/utils/error-handler.js';
+import {
+  isRetryableTransientError,
+  isThrottlingError,
+} from '../../../src/deployment/retryable-errors.js';
 
 /**
  * Each case drives its provider's update() into at least one AWS `send` by
@@ -159,6 +163,71 @@ describe('SDK provider update() error wrapping (issue #1267)', () => {
       });
     });
   }
+
+  // Wrapping is exactly the change that historically breaks throttle
+  // classification: the deploy engine's withRetry decides whether to back off
+  // by inspecting the error, and a wrapper that hid the SDK error would turn a
+  // retryable throttle into a hard failure. `isThrottlingError` walks the
+  // `.cause` chain, and the wrapper message embeds the original message, so
+  // both detection routes must still fire through the wrap.
+  it('keeps a wrapped throttle classifiable as a retryable transient error', async () => {
+    const throttle = Object.assign(new Error('Rate exceeded'), {
+      name: 'ThrottlingException',
+      $metadata: { httpStatusCode: 400 },
+    });
+    mockEventBridgeSend.mockRejectedValue(throttle);
+
+    const provider = new EventBridgeBusProvider();
+    const caught = await provider
+      .update(
+        'MyBus',
+        'my-bus',
+        'AWS::Events::EventBus',
+        { Name: 'my-bus', Description: 'after' },
+        { Name: 'my-bus', Description: 'before' }
+      )
+      .catch((e: unknown) => e);
+
+    expect(caught).toBeInstanceOf(ProvisioningError);
+    expect(isThrottlingError(caught)).toBe(true);
+    expect(isRetryableTransientError(caught, (caught as Error).message)).toBe(true);
+  });
+
+  // Every case above fails on the FIRST send. This one fails on a LATER send
+  // (the tags diff, after UpdateEventBus and DescribeEventBus both succeed) so
+  // the wrap is proven to cover non-first calls and the otherwise-untouched
+  // tags-diff sub-path.
+  it('wraps a mid-sequence failure after earlier sends succeeded', async () => {
+    const tagFailure = new Error('Tagging blew up');
+    mockEventBridgeSend.mockImplementation((command: unknown) => {
+      const name = (command as object).constructor.name;
+      if (name === 'UpdateEventBusCommand') return Promise.resolve({});
+      if (name === 'DescribeEventBusCommand') {
+        return Promise.resolve({ Arn: 'arn:aws:events:us-east-1:123456789012:event-bus/my-bus' });
+      }
+      if (name === 'TagResourceCommand' || name === 'UntagResourceCommand') {
+        return Promise.reject(tagFailure);
+      }
+      return Promise.resolve({});
+    });
+
+    const provider = new EventBridgeBusProvider();
+    const promise = provider.update(
+      'MyBus',
+      'my-bus',
+      'AWS::Events::EventBus',
+      { Name: 'my-bus', Description: 'after', Tags: [{ Key: 'a', Value: '2' }] },
+      { Name: 'my-bus', Description: 'before', Tags: [{ Key: 'a', Value: '1' }] }
+    );
+
+    await expect(promise).rejects.toThrow(ProvisioningError);
+    await expect(promise).rejects.toThrow('Failed to update EventBus MyBus: Tagging blew up');
+    await expect(promise).rejects.toMatchObject({ cause: tagFailure });
+    // Prove the earlier sends really did run before the failing one.
+    const sent = mockEventBridgeSend.mock.calls.map((c) => (c[0] as object).constructor.name);
+    expect(sent).toContain('UpdateEventBusCommand');
+    expect(sent.length).toBeGreaterThan(1);
+  });
 
   // The load-bearing case: LogsLogGroupProvider.update() throws the typed
   // ResourceUpdateNotSupportedError on a LogGroupClass change, and the deploy


### PR DESCRIPTION
## Summary

Four SDK providers wrapped their `create()` and `delete()` AWS SDK errors in
`ProvisioningError` but left `update()` unwrapped, so an SDK error from an
update surfaced raw and bypassed cdkd's typed error formatting and exit-code
handling:

- `eventbridge-bus-provider.ts`
- `sns-topic-provider.ts`
- `lambda-eventsource-provider.ts`
- `logs-loggroup-provider.ts`

Surfaced by the PR #1265 code review, which found the same class of defect the
#1263 fix closed for `LambdaUrlProvider`.

## Approach

Each `update()` becomes a thin wrapper that maps SDK failures onto
`ProvisioningError` (`resourceType` / `logicalId` / `physicalId` / `cause`) and
delegates the body to a private `applyUpdate()`.

The wrap lives at the boundary rather than as a large in-place indentation
change because these bodies interleave pure computation with many separate
`send` calls, so the "pure logic outside the try" split used in #1263 is not
achievable here. Keeping the body untouched also makes the diff reviewable.

**A typed control-flow error is re-thrown untouched.** This is the load-bearing
part: `LogsLogGroupProvider`'s LogGroupClass guard throws
`ResourceUpdateNotSupportedError`, which the deploy engine matches BY CLASS to
fall back to replacement. Swallowing it into a `ProvisioningError` would turn a
recoverable class change into a hard failure. The explicit `instanceof`
re-throw is more robust than relying on the guard's position in the body.

## Verification

- New `provider-update-error-wrapping.test.ts`: 9 tests — per provider, the
  wrap (type, `resourceType` / `logicalId` / `physicalId`, message, preserved
  `cause`) plus the non-`Error` rejection arm, and one test pinning that
  `ResourceUpdateNotSupportedError` is NOT re-wrapped. Confirmed the 8 wrap
  tests FAIL without the fix; the pass-through test passes both ways (it is a
  fence for behavior that must not change).
- The pre-existing `logs-loggroup-provider-class-guard.test.ts` independently
  exercises the typed-error path through the public `update()` and still passes.
- Live-tested against real AWS — all four providers, real AWS error responses:
  - EventBridge -> `Failed to update EventBus MyRes: Event bus ... does not exist.` (cause `ResourceNotFoundException`)
  - SNS -> `Failed to update SNS topic MyRes: Topic does not exist` (cause `NotFoundException`)
  - Lambda ESM -> `Failed to update event source mapping MyRes: The resource you requested does not exist.` (cause `ResourceNotFoundException`)
  - Logs -> `Failed to update log group MyRes: The specified log group does not exist.` (cause `ResourceNotFoundException`)

  All four with `code: PROVISIONING_ERROR`.
- Retry-classification unaffected: `retryable-errors.ts` walks the `.cause`
  chain and the wrapper message embeds the original SDK message, so throttles
  are still classified (same reasoning verified in review for #1263).
- Full suite: 482 files / 7978 tests pass.

Closes #1267
