### PR TITLE
fix(providers): close the #1291 wait-semantics follow-ups (items 1, 3-8)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -82,7 +82,7 @@ ec2-instance	2026-07-30T03:09:54Z	PASS	77	verify.sh	re-run after the SG allSettl
 ec2-vpc	2026-07-26T17:21:15Z	PASS	35	standard	issue 1241 fix verified: explicit DESTROY FlowLog LogGroup; 20 deleted 0 retained 0 orphans
 ecr	2026-07-26T18:36:31Z	PASS	85	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 ecr-scanning	2026-07-20T17:37:23Z	PASS	56	verify.sh	ECR scanOnPush + tag add/change/untag update, clean destroy
-ecs-fargate	2026-07-30T05:12:12Z	PASS	381	verify.sh	full-wait create+update settle path after #1291 item 2 evidence-trail fix; 23 del/0 err, orph clean
+ecs-fargate	2026-07-30T06:13:35Z	PASS	390	verify.sh	#1291 items 1+7: update-side full-wait COMPLETED assert fired live; 23 del/0 err, orph clean
 ecs-service-update-props	2026-07-23T08:20:10Z	PASS		verify.sh	#1173 re-run after VersionConsistency norm; Phase1f + drift clean; destroy 15 del 0 err 0 orph
 efs-immutable-replacement	2026-07-19T19:05:41Z	PASS	76	verify.sh	rc ok, 1 deleted, orph clean
 efs-lambda	2026-07-26T18:36:31Z	PASS	499	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
@@ -129,7 +129,7 @@ intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 stale
 kinesis-esm-filter	2026-07-24T10:29:51Z	PASS	73	verify.sh	0724 P0 sweep: lambda-eventsource-provider #1194 coverage; FilterCriteria verified; 5 del 0 err
 kinesis-stream-mode-switch	2026-07-26T18:57:55Z	PASS	73	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda	2026-07-27T10:30:21Z	PASS	89	verify.sh	issue #1263 broad integ; destroy 9/0, 0 orphans
+lambda	2026-07-30T06:13:35Z	PASS	95	verify.sh	broad run for #1291 follow-ups (waiter configs, wait-flag env); 9 del/0 err, orph clean
 lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-arch-switch	2026-07-26T19:25:15Z	PASS	63	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 lambda-config-field-removal	2026-07-22T08:19:38Z	PASS	140	verify.sh	issue #1158 post-rebase re-verify; 6-field removal reset + destroy clean

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -11,7 +11,7 @@ import {
   parseContextOptions,
   warnIfDeprecatedRegion,
   validateResourceTimeouts,
-  validateWaitFlags,
+  applyWaitFlagEnv,
   type ResourceTimeoutOption,
 } from '../options.js';
 import { getLogger } from '../../utils/logger.js';
@@ -138,26 +138,18 @@ async function deployCommand(
 
   // Wait-mode flags. `--no-wait` / default / `--full-wait` are three
   // points on one axis; the two flags are opposite ends of it, so
-  // combining them is rejected here. This sits BEFORE applyRoleArnIfSet
-  // because that call issues a real `sts:AssumeRole` when --role-arn is
-  // set, and the docs promise the pair is rejected before any AWS call.
-  validateWaitFlags(options);
+  // combining them is rejected inside the helper. This sits BEFORE
+  // applyRoleArnIfSet because that call issues a real `sts:AssumeRole`
+  // when --role-arn is set, and the docs promise the pair is rejected
+  // before any AWS call. The helper also projects the flags onto the
+  // CDKD_NO_WAIT / CDKD_FULL_WAIT / CDKD_WAIT_FLAGS_AVAILABLE envs the
+  // providers read (issue #1291 items 1 + 6).
+  applyWaitFlagEnv(options);
 
   // Resolve --role-arn / CDKD_ROLE_ARN before any AWS call. Writes the
   // assumed-role temp credentials into AWS_* env vars so every later
   // `new AwsClients(...)` picks them up via the SDK default chain.
   await applyRoleArnIfSet({ roleArn: options.roleArn, region: options.region });
-
-  // Skip waiting for async resources (CloudFront, RDS, ElastiCache, etc.)
-  if (!options.wait) {
-    process.env['CDKD_NO_WAIT'] = 'true';
-  }
-
-  // Additionally wait for stabilizations cdkd skips by default (ECS
-  // Service steady state) so "deploy returned" means "it is serving".
-  if (options.fullWait) {
-    process.env['CDKD_FULL_WAIT'] = 'true';
-  }
 
   // Resolve the prefix-user-supplied-names flag pair once at command
   // start. The resolved boolean is plumbed into a `withSkipPrefix(...)`

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -2974,7 +2974,9 @@ export async function submitImportChangeSet(
 
     try {
       await waitUntilChangeSetCreateComplete(
-        { client: cfnClient, maxWaitTime: 600 },
+        // Changeset creation settles in seconds; the SDK default cadence (30s
+        // first poll) would dominate the wait (issue #1291 item 5).
+        { client: cfnClient, maxWaitTime: 600, minDelay: 2, maxDelay: 5 },
         { StackName: stackName, ChangeSetName: changeSetName }
       );
     } catch (err) {
@@ -3012,7 +3014,9 @@ export async function submitImportChangeSet(
         new ExecuteChangeSetCommand({ StackName: stackName, ChangeSetName: changeSetName })
       );
       await waitUntilStackImportComplete(
-        { client: cfnClient, maxWaitTime: 3600 },
+        // Minutes-scale CFn operation: 10s polling is dense enough and stays
+        // within the repo-wide waiter cap (issue #1291 item 5).
+        { client: cfnClient, maxWaitTime: 3600, minDelay: 5, maxDelay: 10 },
         { StackName: stackName }
       );
     } catch (err) {
@@ -3143,7 +3147,9 @@ export async function flipStackToUpdateComplete(
     })
   );
   await waitUntilStackUpdateComplete(
-    { client: cfnClient, maxWaitTime: 1800 },
+    // Minutes-scale CFn operation: 10s polling is dense enough and stays
+    // within the repo-wide waiter cap (issue #1291 item 5).
+    { client: cfnClient, maxWaitTime: 1800, minDelay: 5, maxDelay: 10 },
     { StackName: cfnStackName }
   );
 }
@@ -4390,7 +4396,9 @@ export async function executeUpdateChangeSet(
 
     try {
       await waitUntilChangeSetCreateComplete(
-        { client: cfnClient, maxWaitTime: 600 },
+        // Changeset creation settles in seconds; the SDK default cadence (30s
+        // first poll) would dominate the wait (issue #1291 item 5).
+        { client: cfnClient, maxWaitTime: 600, minDelay: 2, maxDelay: 5 },
         { StackName: stackName, ChangeSetName: changeSetName }
       );
     } catch (err) {
@@ -4417,7 +4425,9 @@ export async function executeUpdateChangeSet(
         new ExecuteChangeSetCommand({ StackName: stackName, ChangeSetName: changeSetName })
       );
       await waitUntilStackUpdateComplete(
-        { client: cfnClient, maxWaitTime: 3600 },
+        // Minutes-scale CFn operation: 10s polling is dense enough and stays
+        // within the repo-wide waiter cap (issue #1291 item 5).
+        { client: cfnClient, maxWaitTime: 3600, minDelay: 5, maxDelay: 10 },
         { StackName: stackName }
       );
     } catch (err) {

--- a/src/cli/commands/retire-cfn-stack.ts
+++ b/src/cli/commands/retire-cfn-stack.ts
@@ -411,7 +411,9 @@ export async function retireCloudFormationStack(
       }
       if (updateRan) {
         await waitUntilStackUpdateComplete(
-          { client: cfnClient, maxWaitTime: 1800 },
+          // Minutes-scale CFn operation: 10s polling is dense enough and stays
+          // within the repo-wide waiter cap (issue #1291 item 5).
+          { client: cfnClient, maxWaitTime: 1800, minDelay: 5, maxDelay: 10 },
           { StackName: cfnStackName }
         );
       }
@@ -445,7 +447,9 @@ export async function retireCloudFormationStack(
   logger.info(`[4/4] Deleting CloudFormation stack '${cfnStackName}' (resources retained)...`);
   await cfnClient.send(new DeleteStackCommand({ StackName: cfnStackName }));
   await waitUntilStackDeleteComplete(
-    { client: cfnClient, maxWaitTime: 1800 },
+    // Minutes-scale CFn operation: 10s polling is dense enough and stays
+    // within the repo-wide waiter cap (issue #1291 item 5).
+    { client: cfnClient, maxWaitTime: 1800, minDelay: 5, maxDelay: 10 },
     { StackName: cfnStackName }
   );
   logger.info(

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -558,6 +558,33 @@ export function validateWaitFlags(opts: { wait?: boolean; fullWait?: boolean }):
 }
 
 /**
+ * Validate the wait-flag pair and project it onto the process env the
+ * providers read. One helper instead of three separate lines in deploy.ts
+ * so the validation, the two mode envs, and the availability marker cannot
+ * drift apart individually (issue #1291 item 6 — the wiring had no unit
+ * coverage because it lived inline in the deploy command's action).
+ *
+ * - `CDKD_NO_WAIT` — set when `--no-wait` was passed; providers skip
+ *   convenience stabilization waits.
+ * - `CDKD_FULL_WAIT` — set when `--full-wait` was passed; providers add
+ *   the CloudFormation-side waits cdkd skips by default.
+ * - `CDKD_WAIT_FLAGS_AVAILABLE` — set unconditionally by commands that
+ *   DECLARE the wait flags (today: deploy). Providers gate flag-mentioning
+ *   hints on it, so `cdkd drift --revert` reaching the same provider code
+ *   never advertises a flag drift does not accept (issue #1291 item 1).
+ */
+export function applyWaitFlagEnv(opts: { wait?: boolean; fullWait?: boolean }): void {
+  validateWaitFlags(opts);
+  process.env['CDKD_WAIT_FLAGS_AVAILABLE'] = 'true';
+  if (opts.wait === false) {
+    process.env['CDKD_NO_WAIT'] = 'true';
+  }
+  if (opts.fullWait === true) {
+    process.env['CDKD_FULL_WAIT'] = 'true';
+  }
+}
+
+/**
  * Drop the CDK-injected defensive `DependsOn` edges from VPC Lambdas (and
  * adjacent IAM Role / Policy / Lambda::Url / EventSourceMapping resources)
  * onto the private subnet's `DefaultRoute` / `RouteTableAssociation`. CDK

--- a/src/provisioning/providers/custom-resource-provider.ts
+++ b/src/provisioning/providers/custom-resource-provider.ts
@@ -765,7 +765,9 @@ export class CustomResourceProvider implements ResourceProvider {
         })
       );
       await waitUntilFunctionUpdatedV2(
-        { client: this.lambdaClient, maxWaitTime: 120 },
+        // Explicit cadence per the repo-wide waiter rule (#1291 item 5);
+        // matches the Lambda V2 waiters' own dense 1s default.
+        { client: this.lambdaClient, maxWaitTime: 120, minDelay: 1, maxDelay: 5 },
         { FunctionName: serviceToken }
       );
     } catch (error) {
@@ -840,11 +842,15 @@ export class CustomResourceProvider implements ResourceProvider {
   private async waitForBackingLambdaReady(serviceToken: string, logicalId: string): Promise<void> {
     try {
       await waitUntilFunctionActiveV2(
-        { client: this.lambdaClient, maxWaitTime: 600 },
+        // Explicit cadence per the repo-wide waiter rule (#1291 item 5);
+        // matches the Lambda V2 waiters' own dense 1s default.
+        { client: this.lambdaClient, maxWaitTime: 600, minDelay: 1, maxDelay: 5 },
         { FunctionName: serviceToken }
       );
       await waitUntilFunctionUpdatedV2(
-        { client: this.lambdaClient, maxWaitTime: 600 },
+        // Explicit cadence per the repo-wide waiter rule (#1291 item 5);
+        // matches the Lambda V2 waiters' own dense 1s default.
+        { client: this.lambdaClient, maxWaitTime: 600, minDelay: 1, maxDelay: 5 },
         { FunctionName: serviceToken }
       );
     } catch (error) {

--- a/src/provisioning/providers/ec2-provider.ts
+++ b/src/provisioning/providers/ec2-provider.ts
@@ -4657,6 +4657,28 @@ export class EC2Provider implements ResourceProvider {
     // same wire shape.
     if (instance.IamInstanceProfile?.Arn !== undefined) {
       result['IamInstanceProfile'] = instance.IamInstanceProfile.Arn;
+    } else if (process.env['CDKD_NO_WAIT'] === 'true' && instance.State?.Name === 'pending') {
+      // --no-wait deploy-time observed-capture runs against a `pending`
+      // instance whose launch-time profile association may still be
+      // `associating`, in which case DescribeInstances does not surface it
+      // yet. Recording the field as absent would leave a PERMANENT drift
+      // blind spot: the comparator walks the baseline's keys only, so a key
+      // missing from observedProperties is never compared again -- a later
+      // console-side profile detach would go unreported forever (issue
+      // #1291 item 3). One targeted association read closes it; the extra
+      // call happens ONLY in this narrow window (--no-wait capture of a
+      // still-pending instance), never on `cdkd drift` reads.
+      const assoc = await this.ec2Client.send(
+        new DescribeIamInstanceProfileAssociationsCommand({
+          Filters: [{ Name: 'instance-id', Values: [physicalId] }],
+        })
+      );
+      const live = assoc.IamInstanceProfileAssociations?.find(
+        (a) => a.State === 'associated' || a.State === 'associating'
+      );
+      if (live?.IamInstanceProfile?.Arn !== undefined) {
+        result['IamInstanceProfile'] = live.IamInstanceProfile.Arn;
+      }
     }
 
     // BlockDeviceMappings: AWS DescribeInstances returns (DeviceName, Ebs.{VolumeId,

--- a/src/provisioning/providers/ec2-provider.ts
+++ b/src/provisioning/providers/ec2-provider.ts
@@ -4668,16 +4668,25 @@ export class EC2Provider implements ResourceProvider {
       // #1291 item 3). One targeted association read closes it; the extra
       // call happens ONLY in this narrow window (--no-wait capture of a
       // still-pending instance), never on `cdkd drift` reads.
-      const assoc = await this.ec2Client.send(
-        new DescribeIamInstanceProfileAssociationsCommand({
-          Filters: [{ Name: 'instance-id', Values: [physicalId] }],
-        })
-      );
-      const live = assoc.IamInstanceProfileAssociations?.find(
-        (a) => a.State === 'associated' || a.State === 'associating'
-      );
-      if (live?.IamInstanceProfile?.Arn !== undefined) {
-        result['IamInstanceProfile'] = live.IamInstanceProfile.Arn;
+      // Best-effort: a transient throttle here must cost only THIS field,
+      // not the whole snapshot -- an uncaught throw would make the deploy
+      // engine discard the entire observed-properties capture.
+      try {
+        const assoc = await this.ec2Client.send(
+          new DescribeIamInstanceProfileAssociationsCommand({
+            Filters: [{ Name: 'instance-id', Values: [physicalId] }],
+          })
+        );
+        const live = assoc.IamInstanceProfileAssociations?.find(
+          (a) => a.State === 'associated' || a.State === 'associating'
+        );
+        if (live?.IamInstanceProfile?.Arn !== undefined) {
+          result['IamInstanceProfile'] = live.IamInstanceProfile.Arn;
+        }
+      } catch (error) {
+        this.logger.warn(
+          `Could not backfill IamInstanceProfile for ${physicalId} during the --no-wait capture (${error instanceof Error ? error.message : String(error)}); the field is omitted from the observed snapshot`
+        );
       }
     }
 

--- a/src/provisioning/providers/ecs-provider.ts
+++ b/src/provisioning/providers/ecs-provider.ts
@@ -810,6 +810,10 @@ export class ECSProvider implements ResourceProvider {
       // collide on the name. Clean up best-effort first, mirroring the
       // partial-create handling in the ELBv2 / EC2 Instance providers.
       // `force: true` deletes without a separate scale-to-0 round trip.
+      // The cleanup NARROWS the collision window rather than closing it:
+      // DeleteService returns with the service in DRAINING, which outlives
+      // the call, so an immediate retry can still hit a name conflict until
+      // draining completes (issue #1291 item 4).
       //
       // The UPDATE path deliberately does NOT delete on the same timeout,
       // and the asymmetry is about STATE OWNERSHIP, not about whether AWS
@@ -931,8 +935,15 @@ export class ECSProvider implements ResourceProvider {
     }
 
     const clusterArg = cluster ? ` --cluster ${cluster}` : '';
+    // Mention --full-wait only when the invoking COMMAND actually declares
+    // it (cdkd deploy sets CDKD_WAIT_FLAGS_AVAILABLE; `cdkd drift --revert`
+    // reaches this same code through provider.update and does NOT — the
+    // flag does not exist there, so advertising it would tell the user to
+    // pass an option the command rejects (issue #1291 item 1).
+    const fullWaitHint =
+      process.env['CDKD_WAIT_FLAGS_AVAILABLE'] === 'true' ? '; pass --full-wait to wait' : '';
     this.logger.info(
-      `ECS service ${logicalId} accepted (not waiting for steady state; pass --full-wait to wait). ` +
+      `ECS service ${logicalId} accepted (not waiting for steady state${fullWaitHint}). ` +
         `To wait manually: aws ecs wait services-stable${clusterArg} --services ${serviceRef}`
     );
   }

--- a/src/provisioning/providers/elbv2-provider.ts
+++ b/src/provisioning/providers/elbv2-provider.ts
@@ -326,7 +326,11 @@ export class ELBv2Provider implements ResourceProvider {
         // from cdkd state would make the next deploy fail with
         // DuplicateLoadBalancerName (LB names are unique per scheme per
         // region), so it has to route through the same best-effort
-        // DeleteLoadBalancer as an attributes-wiring failure.
+        // DeleteLoadBalancer as an attributes-wiring failure. The cleanup
+        // NARROWS that window rather than closing it — LB deletion is
+        // asynchronous and outlives the DeleteLoadBalancer call, so an
+        // immediate retry can still hit the duplicate-name error (issue
+        // #1291 item 4).
         //
         // Create only. SetSubnets / SetSecurityGroups / SetIpAddressType
         // on update act on an already-active LB and need no waiter.

--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -946,7 +946,16 @@ export class LambdaFunctionProvider implements ResourceProvider {
   ): Promise<void> {
     try {
       await waitUntilFunctionUpdatedV2(
-        { client: this.lambdaClient, maxWaitTime: this.functionUpdateMaxWaitSeconds },
+        // Explicit cadence per the repo-wide waiter rule (#1291 item 5). The
+        // Lambda V2 waiters' own default is already dense (1s first poll);
+        // pinning it here keeps that a recorded decision instead of an SDK
+        // default we happen to inherit.
+        {
+          client: this.lambdaClient,
+          maxWaitTime: this.functionUpdateMaxWaitSeconds,
+          minDelay: 1,
+          maxDelay: 5,
+        },
         { FunctionName: functionName }
       );
     } catch (error) {

--- a/src/synthesis/macro-expander.ts
+++ b/src/synthesis/macro-expander.ts
@@ -382,7 +382,16 @@ async function expandMacrosAttempt(
     let waiterError: unknown;
     try {
       await waitUntilChangeSetCreateComplete(
-        { client: cfn, maxWaitTime: waiterMaxWaitSeconds },
+        {
+          client: cfn,
+          maxWaitTime: waiterMaxWaitSeconds,
+          // Changeset creation for a macro expansion settles in seconds and
+          // this runs on the DEPLOY path -- the SDK default cadence (30s
+          // first poll) would add a flat half-minute to every macro deploy
+          // (issue #1291 item 5: unconfigured waiters run at SDK defaults).
+          minDelay: 2,
+          maxDelay: 5,
+        },
         { StackName: transientStackName, ChangeSetName: changeSetName }
       );
     } catch (waiterErr) {

--- a/tests/integration/ecs-fargate/verify.sh
+++ b/tests/integration/ecs-fargate/verify.sh
@@ -399,6 +399,31 @@ if [ "${SERVICE_TD_AFTER}" = "${SERVICE_TD_BEFORE}" ]; then
   exit 1
 fi
 
+# --- Assertion: the UPDATE-side --full-wait actually settled the rollout ---
+# SERVICE_TD_AFTER flips the instant UpdateService returns, so the check
+# above passes even when the update-side settleService is a silent no-op
+# (issue #1291 item 7). Repeating the COMPLETED / runningCount block here is
+# what pins the update-side waitUntilServicesStable call: right after a
+# --full-wait update deploy returns, the NEW rollout must already be
+# COMPLETED with a single deployment.
+UPD_SVC_JSON=$(aws ecs describe-services \
+  --cluster "${CLUSTER_NAME}" --services "${SERVICE_NAME}" --region "${REGION}" \
+  --output json)
+UPD_ROLLOUT=$(echo "${UPD_SVC_JSON}" | jq -r '.services[0].deployments | length as $n
+  | if $n == 1 then (.[0].rolloutState // "NONE") else "deployments=\($n)" end')
+UPD_RUNNING=$(echo "${UPD_SVC_JSON}" | jq -r '.services[0].runningCount')
+UPD_DESIRED=$(echo "${UPD_SVC_JSON}" | jq -r '.services[0].desiredCount')
+if [ "${UPD_ROLLOUT}" != "COMPLETED" ]; then
+  echo "FAIL: service rollout is '${UPD_ROLLOUT}' immediately after a --full-wait UPDATE deploy, expected COMPLETED (update-side settleService NOT effective — issue #1291 item 7)" >&2
+  echo "${UPD_SVC_JSON}" | jq '.services[0] | {status, runningCount, desiredCount, deployments}'
+  exit 1
+fi
+if [ "${UPD_RUNNING}" != "${UPD_DESIRED}" ]; then
+  echo "FAIL: runningCount ${UPD_RUNNING} != desiredCount ${UPD_DESIRED} immediately after a --full-wait UPDATE deploy (update-side settleService NOT effective — issue #1291 item 7)" >&2
+  exit 1
+fi
+echo "    OK: update-side --full-wait left the service at a COMPLETED rollout (running=${UPD_RUNNING}/desired=${UPD_DESIRED})"
+
 # The revision the service now points at must be the NEW one: ACTIVE and
 # carrying the updated container command.
 NEW_TD_STATUS=$(aws ecs describe-task-definition \

--- a/tests/unit/cli/options.test.ts
+++ b/tests/unit/cli/options.test.ts
@@ -818,6 +818,6 @@ describe('applyWaitFlagEnv (issue #1291 items 1 + 6)', () => {
       'utf8'
     );
     expect(deploySrc).toMatch(/applyWaitFlagEnv\(options\)/);
-    expect(deploySrc).not.toMatch(/process\.env\['CDKD_(NO|FULL)_WAIT'\]\s*=/);
+    expect(deploySrc).not.toMatch(/process\.env\['CDKD_(NO_WAIT|FULL_WAIT|WAIT_FLAGS_AVAILABLE)'\]\s*=/);
   });
 });

--- a/tests/unit/cli/options.test.ts
+++ b/tests/unit/cli/options.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
 import { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
 import {
   commonOptions,
@@ -748,5 +751,73 @@ describe('validateWaitFlags (issue #1275)', () => {
     const flags = cmd.options.map((o) => o.flags);
     expect(flags).toContain('--full-wait');
     expect(flags).toContain('--no-wait');
+  });
+});
+
+// Issue #1291 item 6: the env projection lived inline in deploy.ts's action
+// with no unit coverage -- deleting either `process.env` line kept every test
+// green. The projection now lives in applyWaitFlagEnv so validation, the two
+// mode envs, and the availability marker are covered together.
+describe('applyWaitFlagEnv (issue #1291 items 1 + 6)', () => {
+  const ENVS = ['CDKD_NO_WAIT', 'CDKD_FULL_WAIT', 'CDKD_WAIT_FLAGS_AVAILABLE'] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENVS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENVS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it('rejects --no-wait --full-wait before touching any env', async () => {
+    const { applyWaitFlagEnv } = await import('../../../src/cli/options.js');
+    expect(() => applyWaitFlagEnv({ wait: false, fullWait: true })).toThrow(
+      /--no-wait and --full-wait cannot be combined/
+    );
+    expect(process.env['CDKD_NO_WAIT']).toBeUndefined();
+    expect(process.env['CDKD_FULL_WAIT']).toBeUndefined();
+    expect(process.env['CDKD_WAIT_FLAGS_AVAILABLE']).toBeUndefined();
+  });
+
+  it('sets CDKD_NO_WAIT for --no-wait, plus the availability marker', async () => {
+    const { applyWaitFlagEnv } = await import('../../../src/cli/options.js');
+    applyWaitFlagEnv({ wait: false });
+    expect(process.env['CDKD_NO_WAIT']).toBe('true');
+    expect(process.env['CDKD_FULL_WAIT']).toBeUndefined();
+    expect(process.env['CDKD_WAIT_FLAGS_AVAILABLE']).toBe('true');
+  });
+
+  it('sets CDKD_FULL_WAIT for --full-wait, plus the availability marker', async () => {
+    const { applyWaitFlagEnv } = await import('../../../src/cli/options.js');
+    applyWaitFlagEnv({ wait: true, fullWait: true });
+    expect(process.env['CDKD_FULL_WAIT']).toBe('true');
+    expect(process.env['CDKD_NO_WAIT']).toBeUndefined();
+    expect(process.env['CDKD_WAIT_FLAGS_AVAILABLE']).toBe('true');
+  });
+
+  it('default mode sets ONLY the availability marker', async () => {
+    const { applyWaitFlagEnv } = await import('../../../src/cli/options.js');
+    applyWaitFlagEnv({ wait: true });
+    expect(process.env['CDKD_NO_WAIT']).toBeUndefined();
+    expect(process.env['CDKD_FULL_WAIT']).toBeUndefined();
+    expect(process.env['CDKD_WAIT_FLAGS_AVAILABLE']).toBe('true');
+  });
+
+  it('is the helper the deploy command actually calls (wiring pin)', () => {
+    // A source-level pin: deploy.ts must route through applyWaitFlagEnv (not
+    // hand-rolled env writes), so the projection cannot silently fork again.
+    const deploySrc = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '../../../src/cli/commands/deploy.ts'),
+      'utf8'
+    );
+    expect(deploySrc).toMatch(/applyWaitFlagEnv\(options\)/);
+    expect(deploySrc).not.toMatch(/process\.env\['CDKD_(NO|FULL)_WAIT'\]\s*=/);
   });
 });

--- a/tests/unit/provisioning/ec2-instance-no-wait-gate.test.ts
+++ b/tests/unit/provisioning/ec2-instance-no-wait-gate.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
-import { RunInstancesCommand } from '@aws-sdk/client-ec2';
+import {
+  DescribeIamInstanceProfileAssociationsCommand,
+  RunInstancesCommand,
+} from '@aws-sdk/client-ec2';
 
 // Issue #1277: the EC2 Instance `running` wait was unconditional, so
 // `cdkd deploy --no-wait` still blocked on it. The NAT Gateway wait in the
@@ -7,9 +10,15 @@ import { RunInstancesCommand } from '@aws-sdk/client-ec2';
 // wait now matches, and that the DEFAULT path is unchanged (which is what
 // keeps previously published default-mode measurements valid).
 
-const { mockSend, waitUntilInstanceRunningMock } = vi.hoisted(() => ({
+// warnMock is hoisted (not sealed inside the vi.mock factory) because the
+// #1279 skip warning's CONTENT is asserted below — under --no-wait it is the
+// user's entire remedy for a possibly profile-less instance, so a silently
+// emptied message would be as bad as no message (issue #1291 item 8; same
+// shape as the sibling ec2-eip-no-wait-gate suite).
+const { mockSend, waitUntilInstanceRunningMock, warnMock } = vi.hoisted(() => ({
   mockSend: vi.fn(),
   waitUntilInstanceRunningMock: vi.fn(() => Promise.resolve({})),
+  warnMock: vi.fn(),
 }));
 
 vi.mock('../../../src/utils/aws-clients.js', () => ({
@@ -22,7 +31,7 @@ vi.mock('../../../src/utils/logger.js', () => {
   const childLogger = {
     debug: vi.fn(),
     info: vi.fn(),
-    warn: vi.fn(),
+    warn: warnMock,
     error: vi.fn(),
     child: vi.fn().mockReturnThis(),
   };
@@ -31,7 +40,7 @@ vi.mock('../../../src/utils/logger.js', () => {
       child: () => childLogger,
       debug: vi.fn(),
       info: vi.fn(),
-      warn: vi.fn(),
+      warn: warnMock,
       error: vi.fn(),
     }),
   };
@@ -250,5 +259,176 @@ describe('AWS::EC2::Instance immutable-property replacement rules (issue #1276)'
       expect(registry.requiresReplacement('AWS::EC2::Instance', prop, 'old', 'new')).toBe(true);
       expect(registry.isClassified('AWS::EC2::Instance', prop)).toBe(true);
     }
+  });
+});
+
+// Issue #1291 item 8: the #1279 skip warning's CONTENT was unasserted -- a
+// reworded or emptied message would have kept every test green while removing
+// the user's only remedy. Both --iam-instance-profile forms (Arn= for an
+// ARN-shaped template value, Name= for a bare profile name) are pinned.
+describe('IAM instance profile skip warning content under --no-wait (issue #1279 / #1291 item 8)', () => {
+  const INSTANCE_ID = 'i-1234567890abcdef0';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env['CDKD_NO_WAIT'] = 'true';
+    mockRunInstancesOk('pending');
+  });
+
+  afterEach(() => {
+    delete process.env['CDKD_NO_WAIT'];
+  });
+
+  function skipWarning(): string | undefined {
+    return warnMock.mock.calls
+      .map((c) => String(c[0]))
+      .find((m) => m.includes('Skipped the IAM instance profile association check'));
+  }
+
+  it('names the instance and both repair commands, using Arn= for an ARN-shaped profile', async () => {
+    const arn = 'arn:aws:iam::123456789012:instance-profile/MyProfile';
+
+    await new EC2Provider().create('MyInstance', 'AWS::EC2::Instance', {
+      ...PROPS,
+      IamInstanceProfile: arn,
+    });
+
+    const warning = skipWarning();
+    expect(warning).toBeDefined();
+    expect(warning).toContain(INSTANCE_ID);
+    // The verification probe, copy-pasteable.
+    expect(warning).toContain(
+      `aws ec2 describe-iam-instance-profile-associations --filters Name=instance-id,Values=${INSTANCE_ID}`
+    );
+    // The repair itself, in the Arn= form AWS requires for ARN references.
+    expect(warning).toContain(
+      `aws ec2 associate-iam-instance-profile --instance-id ${INSTANCE_ID} --iam-instance-profile Arn=${arn}`
+    );
+  });
+
+  it('uses Name= for a bare profile name', async () => {
+    await new EC2Provider().create('MyInstance', 'AWS::EC2::Instance', {
+      ...PROPS,
+      IamInstanceProfile: 'MyProfile',
+    });
+
+    const warning = skipWarning();
+    expect(warning).toBeDefined();
+    expect(warning).toContain(
+      `aws ec2 associate-iam-instance-profile --instance-id ${INSTANCE_ID} --iam-instance-profile Name=MyProfile`
+    );
+  });
+
+  it('emits no skip warning when the template has no profile', async () => {
+    await new EC2Provider().create('MyInstance', 'AWS::EC2::Instance', PROPS);
+
+    expect(skipWarning()).toBeUndefined();
+  });
+});
+
+// Issue #1291 item 3: --no-wait deploy-time observed-capture ran against a
+// `pending` instance whose profile association was still `associating`, so
+// DescribeInstances did not surface IamInstanceProfile and the field was
+// recorded absent -- a PERMANENT drift blind spot, because the comparator
+// walks baseline keys only. The narrow backfill reads
+// DescribeIamInstanceProfileAssociations ONLY in that window.
+describe('readInstanceCurrentState IamInstanceProfile backfill under --no-wait (issue #1291 item 3)', () => {
+  const INSTANCE_ID = 'i-1234567890abcdef0';
+  const PROFILE_ARN = 'arn:aws:iam::123456789012:instance-profile/MyProfile';
+
+  function mockDescribe(opts: {
+    state: 'pending' | 'running';
+    instanceProfileArn?: string;
+    associations?: Array<{ state: string; arn: string }>;
+  }) {
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof DescribeIamInstanceProfileAssociationsCommand) {
+        return Promise.resolve({
+          IamInstanceProfileAssociations: (opts.associations ?? []).map((a) => ({
+            State: a.state,
+            IamInstanceProfile: { Arn: a.arn },
+          })),
+        });
+      }
+      // DescribeInstances
+      return Promise.resolve({
+        Reservations: [
+          {
+            Instances: [
+              {
+                InstanceId: INSTANCE_ID,
+                State: { Name: opts.state },
+                ImageId: 'ami-12345678',
+                InstanceType: 't3.micro',
+                ...(opts.instanceProfileArn
+                  ? { IamInstanceProfile: { Arn: opts.instanceProfileArn } }
+                  : {}),
+              },
+            ],
+          },
+        ],
+      });
+    });
+  }
+
+  const associationCalls = () =>
+    mockSend.mock.calls.filter((c) => c[0] instanceof DescribeIamInstanceProfileAssociationsCommand);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env['CDKD_NO_WAIT'];
+  });
+
+  afterEach(() => {
+    delete process.env['CDKD_NO_WAIT'];
+  });
+
+  it('backfills the profile from an in-flight association during a --no-wait capture', async () => {
+    process.env['CDKD_NO_WAIT'] = 'true';
+    mockDescribe({ state: 'pending', associations: [{ state: 'associating', arn: PROFILE_ARN }] });
+
+    const current = await new EC2Provider().readCurrentState!(
+      INSTANCE_ID,
+      'MyInstance',
+      'AWS::EC2::Instance'
+    );
+
+    expect(current?.['IamInstanceProfile']).toBe(PROFILE_ARN);
+    expect(associationCalls()).toHaveLength(1);
+  });
+
+  it('omits the field when the pending instance genuinely has no association', async () => {
+    process.env['CDKD_NO_WAIT'] = 'true';
+    mockDescribe({ state: 'pending', associations: [] });
+
+    const current = await new EC2Provider().readCurrentState!(
+      INSTANCE_ID,
+      'MyInstance',
+      'AWS::EC2::Instance'
+    );
+
+    expect(current && 'IamInstanceProfile' in current).toBe(false);
+  });
+
+  it('makes NO extra call on ordinary drift reads (env unset)', async () => {
+    mockDescribe({ state: 'pending' });
+
+    await new EC2Provider().readCurrentState!(INSTANCE_ID, 'MyInstance', 'AWS::EC2::Instance');
+
+    expect(associationCalls()).toHaveLength(0);
+  });
+
+  it('makes NO extra call when DescribeInstances already surfaces the profile', async () => {
+    process.env['CDKD_NO_WAIT'] = 'true';
+    mockDescribe({ state: 'pending', instanceProfileArn: PROFILE_ARN });
+
+    const current = await new EC2Provider().readCurrentState!(
+      INSTANCE_ID,
+      'MyInstance',
+      'AWS::EC2::Instance'
+    );
+
+    expect(current?.['IamInstanceProfile']).toBe(PROFILE_ARN);
+    expect(associationCalls()).toHaveLength(0);
   });
 });

--- a/tests/unit/provisioning/ec2-instance-no-wait-gate.test.ts
+++ b/tests/unit/provisioning/ec2-instance-no-wait-gate.test.ts
@@ -410,6 +410,70 @@ describe('readInstanceCurrentState IamInstanceProfile backfill under --no-wait (
     expect(current && 'IamInstanceProfile' in current).toBe(false);
   });
 
+  it('makes NO extra call when the instance is already running (the wait was not skipped short)', async () => {
+    // The `pending` half of the gate: a running instance with no profile is a
+    // settled answer (genuinely no profile), not an in-flight association --
+    // probing there would add a call to every --no-wait capture of
+    // profile-less instances.
+    process.env['CDKD_NO_WAIT'] = 'true';
+    mockDescribe({ state: 'running' });
+
+    const current = await new EC2Provider().readCurrentState!(
+      INSTANCE_ID,
+      'MyInstance',
+      'AWS::EC2::Instance'
+    );
+
+    expect(current && 'IamInstanceProfile' in current).toBe(false);
+    expect(associationCalls()).toHaveLength(0);
+  });
+
+  it('omits the field when only a disassociated association remains', async () => {
+    process.env['CDKD_NO_WAIT'] = 'true';
+    mockDescribe({
+      state: 'pending',
+      associations: [{ state: 'disassociated', arn: PROFILE_ARN }],
+    });
+
+    const current = await new EC2Provider().readCurrentState!(
+      INSTANCE_ID,
+      'MyInstance',
+      'AWS::EC2::Instance'
+    );
+
+    expect(current && 'IamInstanceProfile' in current).toBe(false);
+  });
+
+  it('degrades to omitting the field when the association read itself fails', async () => {
+    // A throttle on the backfill must cost only this field, never the whole
+    // observed snapshot.
+    process.env['CDKD_NO_WAIT'] = 'true';
+    mockSend.mockImplementation((command: unknown) => {
+      if (command instanceof DescribeIamInstanceProfileAssociationsCommand) {
+        return Promise.reject(new Error('Rate exceeded'));
+      }
+      return Promise.resolve({
+        Reservations: [
+          {
+            Instances: [
+              { InstanceId: INSTANCE_ID, State: { Name: 'pending' }, ImageId: 'ami-12345678' },
+            ],
+          },
+        ],
+      });
+    });
+
+    const current = await new EC2Provider().readCurrentState!(
+      INSTANCE_ID,
+      'MyInstance',
+      'AWS::EC2::Instance'
+    );
+
+    expect(current).toBeDefined();
+    expect(current?.['ImageId']).toBe('ami-12345678');
+    expect(current && 'IamInstanceProfile' in current).toBe(false);
+  });
+
   it('makes NO extra call on ordinary drift reads (env unset)', async () => {
     mockDescribe({ state: 'pending' });
 

--- a/tests/unit/provisioning/ecs-service-full-wait.test.ts
+++ b/tests/unit/provisioning/ecs-service-full-wait.test.ts
@@ -100,6 +100,32 @@ describe('ECS Service wait semantics (issue #1275)', () => {
       expect(waitUntilServicesStableMock).not.toHaveBeenCalled();
     });
 
+    it('mentions --full-wait only when the invoking command declares the flag (issue #1291 item 1)', async () => {
+      // `cdkd deploy` sets CDKD_WAIT_FLAGS_AVAILABLE; `cdkd drift --revert`
+      // reaches the same provider code through update() and does NOT -- the
+      // flag does not exist there, so the hint must not advertise it.
+      process.env['CDKD_WAIT_FLAGS_AVAILABLE'] = 'true';
+      try {
+        mockCreateOk();
+        await new ECSProvider().create('MySvc', 'AWS::ECS::Service', CREATE_PROPS);
+        const hint = infoSpy.mock.calls.map((c) => String(c[0])).find((m) => m.includes('aws ecs wait'));
+        expect(hint).toContain('pass --full-wait to wait');
+      } finally {
+        delete process.env['CDKD_WAIT_FLAGS_AVAILABLE'];
+      }
+    });
+
+    it('does NOT advertise --full-wait when the invoking command lacks the flag (drift --revert path)', async () => {
+      delete process.env['CDKD_WAIT_FLAGS_AVAILABLE'];
+      mockCreateOk();
+
+      await new ECSProvider().create('MySvc', 'AWS::ECS::Service', CREATE_PROPS);
+
+      const hint = infoSpy.mock.calls.map((c) => String(c[0])).find((m) => m.includes('aws ecs wait'));
+      expect(hint).toBeDefined();
+      expect(hint).not.toContain('--full-wait');
+    });
+
     it('prints the exact command to wait manually', async () => {
       mockCreateOk();
 

--- a/tests/unit/provisioning/poll-cap-tightness.test.ts
+++ b/tests/unit/provisioning/poll-cap-tightness.test.ts
@@ -110,42 +110,93 @@ describe('provider poll-loop cap tightness (#1175 / #1176)', () => {
   // operation is itself only ~30-60s (an EC2 instance) want tighter still, but
   // a blanket rule cannot know per-type speed, so 10s is the enforced ceiling
   // and individual sites may go lower.
-  const waiterCap = /minDelay:\s*(\d+)\s*,\s*maxDelay:\s*(\d+)/g;
   const MAX_ALLOWED_WAITER_MAXDELAY_S = 10;
 
-  it('every AWS SDK waiter config caps maxDelay at <= 10s', () => {
+  // Recursively list every .ts source file under src/ — the rule covers the
+  // WHOLE tree, not just providers. The #1291 item-5 finding: the previous
+  // version scanned provider files for `{ minDelay, maxDelay }` CONFIGS, so a
+  // `waitUntil*` call that passed no config at all (running at the SDK's
+  // 15s-120s defaults, or 30s for the CloudFormation waiters) was invisible —
+  // eight such calls existed in export.ts / retire-cfn-stack.ts /
+  // macro-expander.ts.
+  function srcFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...srcFiles(full));
+      else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) out.push(full);
+    }
+    return out;
+  }
+
+  it('every AWS SDK waiter CALL SITE carries an explicit tight { minDelay, maxDelay } config', () => {
+    const srcRoot = join(repoRoot, 'src');
     const violations: string[] = [];
-    let waiterSites = 0;
+    let callSites = 0;
+    let configuredSites = 0;
+    const filesWithCalls = new Set<string>();
 
-    for (const file of providerFiles()) {
+    // A call site is `waitUntilXxx(` (imports / re-exports don't parenthesize).
+    // Its first argument is the waiter config object literal; line comments may
+    // sit between the paren and the brace. Capture up to the closing brace
+    // non-greedily. minDelay / maxDelay may appear in EITHER order (the old
+    // `minDelay:\s*\d+,\s*maxDelay:` regex was key-order-evadable) and a
+    // spread/constant config that hides the keys is deliberately flagged as
+    // unconfigured — fail loud, then inline the keys.
+    const callSite = /waitUntil\w+\(\s*(?:\/\/[^\n]*\n\s*)*\{([\s\S]*?)\}\s*,/g;
+
+    for (const file of srcFiles(srcRoot)) {
       const src = readFileSync(file, 'utf8');
-      const name = file.slice(providersDir.length + 1);
+      const name = file.slice(srcRoot.length + 1);
 
-      for (const m of src.matchAll(waiterCap)) {
-        waiterSites++;
-        const minDelay = Number.parseInt(m[1]!, 10);
-        const maxDelay = Number.parseInt(m[2]!, 10);
+      for (const m of src.matchAll(callSite)) {
+        callSites++;
+        filesWithCalls.add(name);
+        const config = m[1]!;
+        const minM = config.match(/\bminDelay:\s*(\d[\d_]*)/);
+        const maxM = config.match(/\bmaxDelay:\s*(\d[\d_]*)/);
+        if (!minM || !maxM) {
+          violations.push(
+            `${name}: a waitUntil* call site has no inline { minDelay, maxDelay } — it runs at the SDK default cadence (15s-120s exp backoff; 30s flat for CloudFormation waiters)`
+          );
+          continue;
+        }
+        configuredSites++;
+        const minDelay = parseCap(minM[1]!);
+        const maxDelay = parseCap(maxM[1]!);
         if (maxDelay > MAX_ALLOWED_WAITER_MAXDELAY_S) {
           violations.push(
-            `${name}: { minDelay: ${minDelay}, maxDelay: ${maxDelay} } — maxDelay ${maxDelay}s > ${MAX_ALLOWED_WAITER_MAXDELAY_S}s ` +
-              `(mean detection lag ${maxDelay / 2}s)`
+            `${name}: { minDelay: ${minDelay}, maxDelay: ${maxDelay} } — maxDelay ${maxDelay}s > ${MAX_ALLOWED_WAITER_MAXDELAY_S}s (mean detection lag ${maxDelay / 2}s)`
           );
         }
         if (minDelay > maxDelay) {
-          violations.push(`${name}: { minDelay: ${minDelay}, maxDelay: ${maxDelay} } — minDelay exceeds maxDelay`);
+          violations.push(
+            `${name}: { minDelay: ${minDelay}, maxDelay: ${maxDelay} } — minDelay exceeds maxDelay`
+          );
         }
       }
     }
 
-    // Coverage floor: 6 waiter configs live in the tree today (4 in
-    // ec2-provider, 1 elbv2, 1 ecs). A green result must mean "all caps tight",
-    // never "the regex stopped matching" — the failure mode this very rule was
-    // added to catch.
-    expect(waiterSites, 'expected the SDK waiter { minDelay, maxDelay } configs to be found').toBeGreaterThanOrEqual(6);
+    // Coverage floors — "saw nothing = fail", per .claude/rules/testing.md.
+    // 14 call sites live in the tree today: 6 in providers (4 ec2, 1 elbv2,
+    // 1 ecs) + 5 export.ts + 2 retire-cfn-stack.ts + 1 macro-expander.ts.
+    // Per-file floors pin the shape the old scan missed (non-provider files),
+    // so a regression that stops seeing THOSE cannot hide under the total.
+    expect(callSites, 'expected the waitUntil* call sites to be found').toBeGreaterThanOrEqual(14);
+    expect(
+      [...filesWithCalls].filter((f) => !f.startsWith('provisioning/providers/')).length,
+      'expected waitUntil* call sites OUTSIDE provisioning/providers to be seen (export / retire-cfn-stack / macro-expander)'
+    ).toBeGreaterThanOrEqual(3);
+    // Every call site must have parsed into a config — the two counters
+    // diverging means an unconfigured call slipped in (also reported as a
+    // violation above, but this keeps the invariant explicit).
+    expect(configuredSites + violations.filter((v) => v.includes('no inline')).length).toBe(
+      callSites
+    );
 
     expect(
       violations,
-      `sparse SDK waiter caps found (tighten maxDelay to <= ${MAX_ALLOWED_WAITER_MAXDELAY_S}s):\n${violations.join('\n')}`
+      `sparse or missing SDK waiter configs found (inline { minDelay, maxDelay } with maxDelay <= ${MAX_ALLOWED_WAITER_MAXDELAY_S}s):\n${violations.join('\n')}`
     ).toEqual([]);
   });
 });

--- a/tests/unit/provisioning/poll-cap-tightness.test.ts
+++ b/tests/unit/provisioning/poll-cap-tightness.test.ts
@@ -139,16 +139,24 @@ describe('provider poll-loop cap tightness (#1175 / #1176)', () => {
     // A call site is `waitUntilXxx(` (imports / re-exports don't parenthesize).
     // Its first argument is the waiter config object literal; line comments may
     // sit between the paren and the brace. Capture up to the closing brace
-    // non-greedily. minDelay / maxDelay may appear in EITHER order (the old
-    // `minDelay:\s*\d+,\s*maxDelay:` regex was key-order-evadable) and a
-    // spread/constant config that hides the keys is deliberately flagged as
-    // unconfigured — fail loud, then inline the keys.
+    // non-greedily — a future config with a NESTED object literal before
+    // minDelay truncates early and reads as "no inline config", which fails
+    // LOUD (a spurious violation), never silently green. minDelay / maxDelay
+    // may appear in EITHER order (the old `minDelay:\s*\d+,\s*maxDelay:` regex
+    // was key-order-evadable). A spread literal (`{ ...cfg }`) is flagged as
+    // unconfigured; a bare IDENTIFIER config (`waitUntilX(cfg, input)`) does
+    // not match this regex at all — that evasion is closed by the raw-count
+    // reconciliation below, which counts every `waitUntil*(` occurrence and
+    // fails when the two counters diverge.
     const callSite = /waitUntil\w+\(\s*(?:\/\/[^\n]*\n\s*)*\{([\s\S]*?)\}\s*,/g;
+    const rawCallSite = /waitUntil\w+\(/g;
+    let rawCallSites = 0;
 
     for (const file of srcFiles(srcRoot)) {
       const src = readFileSync(file, 'utf8');
       const name = file.slice(srcRoot.length + 1);
 
+      rawCallSites += [...src.matchAll(rawCallSite)].length;
       for (const m of src.matchAll(callSite)) {
         callSites++;
         filesWithCalls.add(name);
@@ -178,21 +186,28 @@ describe('provider poll-loop cap tightness (#1175 / #1176)', () => {
     }
 
     // Coverage floors — "saw nothing = fail", per .claude/rules/testing.md.
-    // 14 call sites live in the tree today: 6 in providers (4 ec2, 1 elbv2,
-    // 1 ecs) + 5 export.ts + 2 retire-cfn-stack.ts + 1 macro-expander.ts.
-    // Per-file floors pin the shape the old scan missed (non-provider files),
-    // so a regression that stops seeing THOSE cannot hide under the total.
-    expect(callSites, 'expected the waitUntil* call sites to be found').toBeGreaterThanOrEqual(14);
+    // 18 call sites live in the tree today: 10 in providers (4 ec2, 1 elbv2,
+    // 1 ecs, 3 custom-resource, 1 lambda-function) + 5 export.ts +
+    // 2 retire-cfn-stack.ts + 1 macro-expander.ts. The non-provider category
+    // floor pins the shape the old scan missed, so a regression that stops
+    // seeing THOSE cannot hide under the total.
+    expect(callSites, 'expected the waitUntil* call sites to be found').toBeGreaterThanOrEqual(18);
     expect(
       [...filesWithCalls].filter((f) => !f.startsWith('provisioning/providers/')).length,
       'expected waitUntil* call sites OUTSIDE provisioning/providers to be seen (export / retire-cfn-stack / macro-expander)'
     ).toBeGreaterThanOrEqual(3);
-    // Every call site must have parsed into a config — the two counters
-    // diverging means an unconfigured call slipped in (also reported as a
-    // violation above, but this keeps the invariant explicit).
-    expect(configuredSites + violations.filter((v) => v.includes('no inline')).length).toBe(
-      callSites
-    );
+    // Raw-count reconciliation: every `waitUntil*(` occurrence must have been
+    // parsed by the config-literal regex. A bare identifier config
+    // (`waitUntilX(cfg, input)`), a block comment before the brace, or any
+    // other shape the literal regex cannot see makes the counters diverge and
+    // fails HERE instead of silently dropping out of the scan. (The literal
+    // regex's own matches split exactly into configured + no-inline-violation
+    // by construction, so comparing against the RAW count is what makes this
+    // a real invariant rather than a tautology.)
+    expect(
+      rawCallSites,
+      'every waitUntil*( occurrence must be parseable by the config-literal regex — a bare identifier config or block-comment shape evades the cap rule; inline the { minDelay, maxDelay } literal'
+    ).toBe(callSites);
 
     expect(
       violations,


### PR DESCRIPTION
## Summary

Closes out the remaining items (1, 3-8) of issue [#1291](https://github.com/go-to-k/cdkd/issues/1291), the follow-up list from the #1284 wait-semantics review (item 2 shipped in #1293).

## What changed

- **Item 1 — hint scoping**: `settleService`'s manual-wait INFO advertised `--full-wait` on the `drift --revert` path, where the flag does not exist. The hint is now gated on `CDKD_WAIT_FLAGS_AVAILABLE`, set only by commands that declare the wait flags (deploy).
- **Item 3 — `--no-wait` capture blind spot**: the issue predicted phantom drift, but the actual failure mode is the inverse -- the comparator walks baseline keys only, so an `IamInstanceProfile` missing from the `--no-wait` observed snapshot was never compared again (a PERMANENT drift blind spot for console-side detaches). A best-effort `DescribeIamInstanceProfileAssociations` backfill closes it. Speed: the extra call fires ONLY during a `--no-wait` capture of a still-pending instance with no surfaced profile; drift reads and default deploys make zero extra calls, and a throttle on the backfill costs only that field, never the whole snapshot.
- **Item 4 — comment overclaims**: the ELBv2 / ECS partial-create cleanup comments now say the cleanup narrows the collision window (deletion is async on both services) instead of claiming it prevents the next deploy's name conflict.
- **Item 5 — waiter rule generalized**: the poll-cap test now scans every `waitUntil*` CALL SITE under `src/` (not provider configs only), key-order-insensitive, with a raw-count reconciliation that fails loud on bare identifier configs / block-comment shapes (proven by injecting one into real code). 12 unconfigured sites were found -- the issue's 8 (export x5, retire-cfn-stack x2, macro-expander x1) PLUS 4 the issue's own scan missed (custom-resource x3, lambda-function x1) -- and all got explicit tight configs. Speedup: the macro-expander changeset waiter is on the DEPLOY path and ran at the CFn waiter's 30s-first-poll default; it now polls at 2/5s, removing a flat ~half-minute from every macro-carrying deploy. No config is slower than the SDK default it replaces.
- **Item 6 — wiring coverage**: the wait-flag env projection moved from inline deploy.ts lines into `applyWaitFlagEnv` (validation + both mode envs + the availability marker), unit-covered for all four flag combinations plus a source-level pin that deploy.ts routes through it and hand-rolls no env writes.
- **Item 7 — update-side wait assert**: `ecs-fargate/verify.sh` repeats the `COMPLETED` / `runningCount == desiredCount` block after the `--full-wait` UPDATE deploy, so an update-side `settleService` no-op can no longer pass. **Fired live in this PR's integ run.**
- **Item 8 — warning content pinned**: the #1279 instance-profile skip warning's content is asserted for both `Arn=` and `Name=` repair-command branches.

## Review

3-axis (spec vs issue #1291 / code / test). The test reviewer's blocker (tautological checker invariant) and every minor were fixed in the follow-up commit; both recorded deviations from the issue text (item 3's blind-spot-not-phantom analysis, item 5's tighten-all-instead-of-allow-list) were judged sound by the spec reviewer.

## Test plan

- 8205 unit tests green (490 files); all behavior fixes revert-proven; the generalized checker proven to FAIL against real code twice (stripped config -> red; identifier-config evasion -> red).
- Real AWS: `/run-integ lambda` (broad set; 9 deleted / 0 errors / 0 orphans) and `/run-integ ecs-fargate` (23 deleted / 0 errors / 0 orphans, update-side `--full-wait` assert fired). `integ-destroy` + `integ-broad` markers set.
- Won't-do (recorded): item 1's hint-gating negative arm (drift-revert INFO without the flag mention) is unit-pinned, not live-tested -- a live run would need a full deploy + out-of-band drift + revert cycle to observe one INFO line. Issue #1280 (--full-wait cap vs --resource-timeout) is deliberately NOT bundled: it needs a new engine-to-provider timeout seam, a genuinely different concern.

Addresses #1291 items 1 and 3-8 -- with #1293's item 2, every item is now closed, so this PR also: Closes #1291
