### PR TITLE
test(integ): stop sqs-cloudwatch fixture leaking retained Kinesis streams

### DIFF
--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -26,7 +26,7 @@ Detect and optionally delete AWS resources left behind by cdkd integration tests
    - If a prefix is given, use that
    - Otherwise, discover all integration test stack names by running synth or reading `bin/app.ts` in each `tests/integration/*/` directory. Look for the CDK construct ID (second argument to `new *Stack(app, '<id>')`)
 
-2. **Resolve region and account**: Scan both `us-east-1` and `ap-northeast-1`. Resolve account ID via `aws sts get-caller-identity`. IAM is global so only needs one query.
+2. **Resolve region and account**: Scan `us-east-1`, `ap-northeast-1`, AND `us-west-2` — the benchmark suite (docs/benchmarks.md) runs its CFn/cdkd variant stacks in `us-west-2`, and its leftovers (billed PROVISIONED Kinesis streams, ~130 Lambda log groups) went unnoticed for a month because this skill only scanned the first two regions (2026-07-31 sweep). Additionally, derive extra regions dynamically from the state-bucket key layout (`aws s3 ls` the bucket recursively and collect the distinct `{region}` path segments) so a fixture pinned to an unusual region is not missed. Resolve account ID via `aws sts get-caller-identity`. IAM is global so only needs one query.
 
 3. **Check S3 state**: `aws s3 ls s3://cdkd-state-{accountId}-us-east-1/stacks/ --region us-east-1`
 

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -245,7 +245,7 @@ sns-inline-subscription	2026-07-27T11:04:52Z	PASS	53	verify.sh	issue #1267 SNS t
 sns-pending-subscription	2026-07-30T12:40:16Z	PASS	22	verify.sh	issue #1301 re-run after review fixes, clean
 sns-sqs-event	2026-07-26T17:01:09Z	PASS	78	verify.sh	#1160 sqs SSE removal phase 2 verified; destroy 20/0 errors, 0 orphans
 sns-subscription-filter	2026-07-21T18:09:46Z	PASS	46	verify.sh	rc ok, orph clean
-sqs-cloudwatch	2026-07-26T18:04:53Z	PASS	56	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
+sqs-cloudwatch	2026-07-31T07:00:20Z	PASS	75	standard	removalPolicy DESTROY fix verified: stream deleted on destroy, 0 orphans
 sqs-esm-max-concurrency	2026-07-21T14:49:55Z	PASS	85	verify.sh	rc ok, orph clean
 state-destroy	2026-07-26T18:04:53Z	PASS	25	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 state-info-command	2026-07-19T20:01:06Z	PASS	21	standard	rc ok, state info #1055 GetBucketLocation exercised, orph clean

--- a/tests/integration/sqs-cloudwatch/lib/sqs-cloudwatch-stack.ts
+++ b/tests/integration/sqs-cloudwatch/lib/sqs-cloudwatch-stack.ts
@@ -67,6 +67,10 @@ export class SqsCloudwatchStack extends cdk.Stack {
 
     const logStream = new Stream(this, 'LogStream', {
       shardCount: 1,
+      // Stream is a stateful L2 whose default removalPolicy is RETAIN; without
+      // DESTROY every deploy/destroy cycle (and every benchmark variant synthing
+      // this stack) leaks a billed PROVISIONED stream.
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
     const subscriptionFilterRole = new Role(this, 'SubscriptionFilterRole', {


### PR DESCRIPTION
## Summary

The 2026-07-31 `/cleanup` sweep found 14 leftover PROVISIONED Kinesis streams in `us-west-2` (billed continuously, created 2026-07-01/02 by the benchmark campaign). Root cause: the `sqs-cloudwatch` fixture's `new Stream(...)` carried no `removalPolicy`, and stateful CDK L2 constructs default to `RemovalPolicy.RETAIN` — so both CloudFormation (benchmark variants: `Normal-` / `Express-` / `Enhanced-` / `AwsCliExpress-`) and cdkd (`Cdkd-` / `CdkdNoWait-`) *correctly* retained the stream on every destroy. The leak went unnoticed because the `/cleanup` skill only scanned `us-east-1` / `ap-northeast-1`, not the benchmark region.

- `tests/integration/sqs-cloudwatch/lib/sqs-cloudwatch-stack.ts`: set `removalPolicy: RemovalPolicy.DESTROY` on the fixture's Kinesis Stream (template now emits `DeletionPolicy: Delete`).
- `.claude/skills/cleanup/SKILL.md`: scan `us-west-2` too, and derive additional regions dynamically from the state-bucket key layout so region-pinned fixtures are never missed again.
- `docs/_generated/integ-last-run.tsv`: ledger row for the verification run.

All 14 leaked streams (plus 130 benchmark Lambda log groups in `us-west-2` and 16 in `us-east-1`) were deleted during the sweep; this PR is the recurrence prevention.

## Test plan

- `/check`: typecheck + lint + build + 8311 unit tests pass; integ/scenario/cli-flag coverage matrices regenerated with no drift.
- Live-verified via `/run-integ sqs-cloudwatch` against real AWS: synth shows `DeletionPolicy: Delete` on the stream, deploy created 8 resources, destroy deleted 8 with 0 errors **including the Kinesis stream**, post-run orphan scan clean (state 404, no streams/roles/queues/log groups left).

## Remaining work

- TODO (#1326): unit-level lint flagging stateful L2 constructs in integ fixtures that lack an explicit `removalPolicy`, so the whole class of this bug is caught at commit time.
