### PR TITLE
test(integ): lint verify.sh fixtures against hardcoded Lambda version literals

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -126,6 +126,23 @@ of this lint were green while skipping most of the tree. The
 specific `state destroy --force` case; this lint generalizes it to every
 subcommand and also catches pre-existing occurrences the hook cannot see.
 
+### `verify.sh` version literals (mandatory)
+
+Never hardcode a Lambda published-version literal in a fixture: version
+counters are monotonic per function/layer NAME and never reset, so a
+`"${FN}:1"` probe or a `[ "${V}" != "2" ]` assert passes only on the very
+first run in the account and fails every re-run with
+`ResourceNotFoundException` (issue #1324; third recurrence of the trap). Read
+version N from the live alias (`--query 'FunctionVersion'`), guard it numeric
+with a `case` pattern, and assert rotation as `EXPECTED=$((N + 1))` — see
+`codedeploy-lambda-deployment-group/verify.sh` for the reference shape. Alias
+qualifiers (`:live`, `:$LATEST`), variable qualifiers, relative compares, and
+`length(...)` count queries stay legal; genuinely fixed versions (public
+cross-account layer ARNs) take `# allow-version-literal: <reason>`. Enforced
+by `tests/unit/scripts/integ-verify-version-literals.test.ts` (classifier:
+`scripts/check-integ-version-literals.ts`); user-facing writeup in
+[docs/testing.md](../../docs/testing.md).
+
 ### A checker must prove it sees its input
 
 When writing a lint or codegen that SCANS files (verify.sh scripts, templates,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -583,6 +583,43 @@ env-prefixed `CDKD_TEST_UPDATE=true ...` deploy, then every
 `node "${LOCAL_DIST}" ...` call site — 135 of 195 fixtures). Current coverage:
 195 fixtures, ~830 invocations, ~2,160 flags, 25 command paths.
 
+### Fixture convention: no Lambda published-version literals
+
+Lambda version counters are monotonic per function name (and per layer name)
+and never reset — not even across a delete + re-create. A fixture with a fixed
+function name that probes `"${FN}:1"` or asserts an alias's `FunctionVersion`
+equals `"2"` therefore passes exactly once (the first run ever in the account)
+and fails every re-run with `ResourceNotFoundException` while the deploy itself
+is clean. Three fixtures shipped this trap before it was made mechanical
+(issue #1324).
+
+The correct shape reads the published version from the live alias and asserts
+the rotation relatively:
+
+```bash
+V1="$(aws lambda get-alias --function-name "${FN}" --name live \
+  --query 'FunctionVersion' --output text)"
+case "${V1}" in ''|*[!0-9]*) echo "FAIL: non-numeric version" >&2; exit 1 ;; esac
+# ... update deploy ...
+EXPECTED=$((V1 + 1))
+V2="$(aws lambda get-alias --function-name "${FN}" --name live \
+  --query 'FunctionVersion' --output text)"
+[ "${V2}" = "${EXPECTED}" ] || { echo "FAIL: expected ${EXPECTED}" >&2; exit 1; }
+```
+
+`tests/unit/scripts/integ-verify-version-literals.test.ts` enforces this across
+the fixture tree (classifier: `scripts/check-integ-version-literals.ts`). It
+flags digits-literal qualifiers on `aws lambda` commands (`--function-name
+"${FN}:1"`, ARN `...:function:fn:3`, `--qualifier 5`), digits-literal
+`--version-number` args, and integer-literal comparisons of variables captured
+from a version-ish `--query` (`FunctionVersion`, `.Version`). Alias qualifiers
+(`:live`, `:$LATEST`), variable qualifiers, relative compares, count queries
+(`length(...)`), and non-Lambda commands stay legal. For a genuinely fixed
+version (e.g. a public cross-account layer ARN pinned by its owner), append
+`# allow-version-literal: <reason>` to the line. The check carries per-shape
+coverage floors and was verified to fail against real injected regressions
+before landing, per the checker rules above.
+
 ## 3. Deploy Using cdkd
 
 ```bash

--- a/scripts/check-integ-version-literals.ts
+++ b/scripts/check-integ-version-literals.ts
@@ -1,0 +1,209 @@
+/**
+ * Classifier for hardcoded Lambda published-version literals in integ-fixture
+ * `verify.sh` scripts (issue #1324).
+ *
+ * Lambda version counters are monotonic per function NAME (and per layer
+ * name) and never reset — not even across a delete + re-create. A fixture
+ * with a fixed function name that probes `"${FN}:1"` or asserts an alias's
+ * `FunctionVersion` equals `"2"` therefore passes exactly once (the first run
+ * ever in the account) and fails on every re-run with
+ * ResourceNotFoundException while the deploy itself is clean. Three fixtures
+ * shipped this trap (`lambda-versioning`, `lambda-layer-version-update`,
+ * `lambda-snapstart`); the convention lived only in session memory, which
+ * does not protect new fixtures — hence this lint.
+ *
+ * The correct shapes (see `codedeploy-lambda-deployment-group/verify.sh` and
+ * `lambda-snapstart/verify.sh` for reference implementations):
+ *
+ *   - read the published version N from the live alias
+ *     (`--query 'FunctionVersion'`), guard it is numeric, and qualify probes
+ *     with `"${FN}:${N}"`;
+ *   - assert rotation relatively: `EXPECTED=$((N + 1))`, compare against
+ *     `"${EXPECTED}"` — never against a numeric literal.
+ *
+ * What this classifier flags (violations):
+ *   1. `literal-qualifier` — an `aws lambda` invocation whose
+ *      `--function-name` / `--qualifier` value carries an all-digits literal
+ *      qualifier (`"${FN}:1"`, `arn:...:function:fn:3`, `--qualifier 5`).
+ *   2. `literal-version-number` — an `aws lambda` invocation passing a
+ *      digits-literal `--version-number` (layer versions are monotonic per
+ *      layer name the same way).
+ *   3. `literal-compare` — a test-bracket comparison of a variable captured
+ *      from a version-ish `aws lambda --query` (e.g. `FunctionVersion`)
+ *      against an integer literal (`[ "${V}" != "2" ]`, `[ "$V" -eq 1 ]`).
+ *
+ * What stays legal:
+ *   - variable qualifiers (`"${FN}:${V}"`) and alias-name qualifiers
+ *     (`"${FN}:live"`, `"${FN}:$LATEST"`) — alias names are stable;
+ *   - relative compares (`!= "${EXPECTED_V2}"`) and numeric-format guards
+ *     (`case "${V}" in ''|*[!0-9]*)`);
+ *   - non-lambda commands (`aws appconfig ... --version-number "${v}"` uses
+ *     an API whose version ids the fixture itself enumerated);
+ *   - a line carrying `# allow-version-literal: <reason>` — the escape hatch
+ *     for genuinely fixed versions (e.g. a public cross-account layer ARN
+ *     whose version is pinned by its owner, not by this account's counter).
+ *
+ * This module is separate from the test so the classifier can be table-tested
+ * against synthetic script shapes rather than only against today's tree, per
+ * the checker rules in `.claude/rules/testing.md`.
+ */
+
+const ALLOW_COMMENT = 'allow-version-literal';
+
+export type VersionLiteralKind =
+  | 'literal-qualifier'
+  | 'literal-version-number'
+  | 'literal-compare';
+
+export interface VersionLiteralFinding {
+  kind: VersionLiteralKind;
+  /** The joined statement the finding was made on (for the failure report). */
+  text: string;
+}
+
+export interface VersionLiteralClassification {
+  findings: VersionLiteralFinding[];
+  /**
+   * Coverage counters — "0 violations" and "parsed nothing" are
+   * indistinguishable without them (see `.claude/rules/testing.md`,
+   * "A checker must prove it sees its input").
+   */
+  /** `aws lambda` args carrying ANY qualifier (`--function-name "x:q"` / `--qualifier q`). */
+  lambdaQualifierArgs: number;
+  /** ...of which the qualifier is variable-driven (`:${V}`, `:$LATEST`). */
+  variableQualifierArgs: number;
+  /** ...of which the qualifier is a non-numeric literal (alias names like `:live`). */
+  aliasLiteralQualifierArgs: number;
+  /** `aws lambda ... --version-number` args seen (variable or literal). */
+  versionNumberArgs: number;
+  /** Variables captured from a version-ish `aws lambda --query`. */
+  versionCaptureVars: string[];
+  /** Test-bracket comparisons involving a captured version variable. */
+  versionCaptureCompares: number;
+}
+
+/**
+ * Joins backslash-continued lines into single statements so a line-oriented
+ * scan cannot miss a qualifier or `--query` that lands on a continuation
+ * line (the dominant multi-line shape in the fixture tree).
+ */
+export function joinContinuedLines(content: string): string[] {
+  const lines = content.split('\n');
+  const joined: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i]!;
+    while (line.endsWith('\\') && i + 1 < lines.length) {
+      line = `${line.slice(0, -1).trimEnd()} ${lines[++i]!.trim()}`;
+    }
+    joined.push(line);
+  }
+  return joined;
+}
+
+/** The value token following a long option: `--opt value` or `--opt "value"`. */
+function optionValue(statement: string, option: string): string | null {
+  const m = new RegExp(`${option}[= ]+("([^"]*)"|'([^']*)'|([^\\s'"]+))`).exec(statement);
+  if (!m) return null;
+  return m[2] ?? m[3] ?? m[4] ?? null;
+}
+
+const ALL_DIGITS = /^[0-9]+$/;
+const HAS_VARIABLE = /\$/;
+
+/**
+ * Version-ish `--query` expressions. `FunctionVersion` (get-alias /
+ * get-function-configuration), a trailing `Version` field (publish-version,
+ * get-layer-version), or `LatestMatchingVersion.Version`-style paths. A
+ * `length(...)` query is a COUNT, not a version — excluded so asserting
+ * "exactly 2 versions exist" stays legal.
+ */
+function isVersionishQuery(query: string): boolean {
+  if (/length\s*\(/.test(query)) return false;
+  return /(^|\.|\[)FunctionVersion($|\W)|(^|\.)Version($|\W)/.test(query);
+}
+
+export function classifyVerifyScript(content: string): VersionLiteralClassification {
+  const statements = joinContinuedLines(content);
+  const findings: VersionLiteralFinding[] = [];
+
+  let lambdaQualifierArgs = 0;
+  let variableQualifierArgs = 0;
+  let aliasLiteralQualifierArgs = 0;
+  let versionNumberArgs = 0;
+  const versionCaptureVars: string[] = [];
+  let versionCaptureCompares = 0;
+
+  const classifyQualifier = (statement: string, qualifier: string) => {
+    lambdaQualifierArgs++;
+    if (ALL_DIGITS.test(qualifier)) {
+      if (!statement.includes(ALLOW_COMMENT)) {
+        findings.push({ kind: 'literal-qualifier', text: statement.trim() });
+      }
+    } else if (HAS_VARIABLE.test(qualifier)) {
+      variableQualifierArgs++;
+    } else {
+      aliasLiteralQualifierArgs++;
+    }
+  };
+
+  for (const statement of statements) {
+    if (!/\baws\s+lambda\s/.test(statement)) continue;
+
+    const functionName = optionValue(statement, '--function-name');
+    if (functionName && functionName.includes(':')) {
+      // The qualifier is the segment after the LAST colon — this reads both
+      // `"${FN}:1"` and a full ARN `arn:...:function:name:1` correctly. A
+      // colon inside a variable expansion (`"${FN:-x}"`) is not a qualifier.
+      const qualifier = functionName.slice(functionName.lastIndexOf(':') + 1);
+      const beforeQualifier = functionName.slice(0, functionName.lastIndexOf(':'));
+      const insideExpansion = /\$\{[^}]*$/.test(beforeQualifier);
+      if (qualifier.length > 0 && !insideExpansion) classifyQualifier(statement, qualifier);
+    }
+
+    const qualifierOpt = optionValue(statement, '--qualifier');
+    if (qualifierOpt) classifyQualifier(statement, qualifierOpt);
+
+    const versionNumber = optionValue(statement, '--version-number');
+    if (versionNumber) {
+      versionNumberArgs++;
+      if (ALL_DIGITS.test(versionNumber) && !statement.includes(ALLOW_COMMENT)) {
+        findings.push({ kind: 'literal-version-number', text: statement.trim() });
+      }
+    }
+
+    // Track variables captured from version-ish queries:
+    //   VAR="$(aws lambda get-alias ... --query 'FunctionVersion' ...)"
+    const capture = /^\s*(?:local\s+)?([A-Za-z_][A-Za-z0-9_]*)=["']?\$\(\s*aws\s+lambda\s/.exec(
+      statement,
+    );
+    if (capture) {
+      const query = optionValue(statement, '--query');
+      if (query && isVersionishQuery(query)) versionCaptureVars.push(capture[1]!);
+    }
+  }
+
+  // Second pass: comparisons of captured version variables.
+  for (const statement of statements) {
+    for (const varName of versionCaptureVars) {
+      const varRef = `"?\\$\\{?${varName}\\}?"?`;
+      const compare = new RegExp(
+        `\\[\\[?\\s+${varRef}\\s+(!=|==|=|-eq|-ne|-gt|-ge|-lt|-le)\\s+("?)([^\\s\\]]+)\\2\\s+\\]?\\]`,
+      ).exec(statement);
+      if (!compare) continue;
+      versionCaptureCompares++;
+      if (ALL_DIGITS.test(compare[3]!) && !statement.includes(ALLOW_COMMENT)) {
+        findings.push({ kind: 'literal-compare', text: statement.trim() });
+      }
+    }
+  }
+
+  return {
+    findings,
+    lambdaQualifierArgs,
+    variableQualifierArgs,
+    aliasLiteralQualifierArgs,
+    versionNumberArgs,
+    versionCaptureVars,
+    versionCaptureCompares,
+  };
+}

--- a/tests/unit/scripts/integ-verify-version-literals.test.ts
+++ b/tests/unit/scripts/integ-verify-version-literals.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  classifyVerifyScript,
+  joinContinuedLines,
+} from '../../../scripts/check-integ-version-literals.js';
+
+/**
+ * Regression guard for issue #1324: hardcoded Lambda published-version
+ * literals in integ fixtures. See `scripts/check-integ-version-literals.ts`
+ * for why the monotonic version counter makes any `":1"` probe a
+ * first-run-only assert.
+ */
+
+const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
+
+function readFixtures() {
+  return readdirSync(INTEG_ROOT, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(INTEG_ROOT, e.name, 'verify.sh')))
+    .map((e) => ({
+      name: e.name,
+      ...classifyVerifyScript(readFileSync(join(INTEG_ROOT, e.name, 'verify.sh'), 'utf8')),
+    }));
+}
+
+describe('classifyVerifyScript (version literals)', () => {
+  it('flags a digits-literal --function-name qualifier', () => {
+    const c = classifyVerifyScript(
+      'aws lambda get-function-configuration --function-name "${FN}:1" --region us-east-1\n',
+    );
+    expect(c.findings.map((f) => f.kind)).toEqual(['literal-qualifier']);
+  });
+
+  it('flags a digits-literal qualifier on a full function ARN', () => {
+    const c = classifyVerifyScript(
+      'aws lambda invoke --function-name arn:aws:lambda:us-east-1:123456789012:function:my-fn:3 out.json\n',
+    );
+    expect(c.findings.map((f) => f.kind)).toEqual(['literal-qualifier']);
+  });
+
+  it('flags a digits-literal --qualifier', () => {
+    const c = classifyVerifyScript(
+      'aws lambda get-provisioned-concurrency-config --function-name "${FN}" --qualifier 5\n',
+    );
+    expect(c.findings.map((f) => f.kind)).toEqual(['literal-qualifier']);
+  });
+
+  it('flags a digits-literal --version-number on an aws lambda command', () => {
+    const c = classifyVerifyScript(
+      'aws lambda delete-layer-version --layer-name "${LAYER}" --version-number 1\n',
+    );
+    expect(c.findings.map((f) => f.kind)).toEqual(['literal-version-number']);
+  });
+
+  it('flags a literal integer compare of a version capture', () => {
+    const c = classifyVerifyScript(
+      `V="$(aws lambda get-alias --function-name "\${FN}" --name live --query 'FunctionVersion' --output text)"
+if [ "\${V}" != "2" ]; then exit 1; fi
+`,
+    );
+    expect(c.versionCaptureVars).toEqual(['V']);
+    expect(c.findings.map((f) => f.kind)).toEqual(['literal-compare']);
+  });
+
+  it('flags the -eq form of a literal compare', () => {
+    const c = classifyVerifyScript(
+      `V="$(aws lambda publish-version --function-name "\${FN}" --query 'Version' --output text)"
+if [ "\${V}" -eq 1 ]; then exit 1; fi
+`,
+    );
+    expect(c.findings.map((f) => f.kind)).toEqual(['literal-compare']);
+  });
+
+  it('sees a qualifier that lands on a backslash-continuation line', () => {
+    const script = `OPT="$(aws lambda get-function-configuration \\
+  --function-name "\${FN}:1" --region "\${REGION}" \\
+  --query 'SnapStart.OptimizationStatus' --output text)"
+`;
+    expect(joinContinuedLines(script).some((l) => l.includes('--function-name "${FN}:1"'))).toBe(
+      true,
+    );
+    expect(classifyVerifyScript(script).findings.map((f) => f.kind)).toEqual([
+      'literal-qualifier',
+    ]);
+  });
+
+  it.each([
+    ['variable qualifier', 'aws lambda invoke --function-name "${FN}:${V}" out.json'],
+    ['alias qualifier', 'aws lambda invoke --function-name "${FN}:live" out.json'],
+    ['$LATEST qualifier', 'aws lambda invoke --function-name "${FN}:$LATEST" out.json'],
+    ['no qualifier', 'aws lambda get-function --function-name "${FN}"'],
+    ['variable --qualifier', 'aws lambda get-policy --function-name "${FN}" --qualifier "${ALIAS}"'],
+    ['variable --version-number', 'aws lambda delete-layer-version --layer-name "${L}" --version-number "${v}"'],
+    ['default-expansion colon is not a qualifier', 'aws lambda get-function --function-name "${FN:-fallback}"'],
+  ])('does not flag the legal shape: %s', (_label, line) => {
+    expect(classifyVerifyScript(`${line}\n`).findings).toEqual([]);
+  });
+
+  it('does not flag non-lambda --version-number literals', () => {
+    // appconfig hosted-configuration versions are ids the fixture itself
+    // enumerated — a different API with different semantics.
+    const c = classifyVerifyScript(
+      'aws appconfig delete-hosted-configuration-version --application-id "${id}" --version-number 3\n',
+    );
+    expect(c.findings).toEqual([]);
+    expect(c.versionNumberArgs).toBe(0);
+  });
+
+  it('does not flag relative compares or numeric-format case guards', () => {
+    const c = classifyVerifyScript(
+      `V="$(aws lambda get-alias --function-name "\${FN}" --name live --query 'FunctionVersion' --output text)"
+case "\${V}" in ''|*[!0-9]*) exit 1 ;; esac
+EXPECTED=$((V + 1))
+if [ "\${V2}" != "\${EXPECTED}" ]; then exit 1; fi
+if [ "\${V}" != "\${EXPECTED}" ]; then exit 1; fi
+`,
+    );
+    expect(c.findings).toEqual([]);
+    expect(c.versionCaptureCompares).toBe(1);
+  });
+
+  it('does not treat a count query as a version capture', () => {
+    const c = classifyVerifyScript(
+      `N="$(aws lambda list-versions-by-function --function-name "\${FN}" --query 'length(Versions)' --output text)"
+if [ "\${N}" -ne 2 ]; then exit 1; fi
+`,
+    );
+    expect(c.versionCaptureVars).toEqual([]);
+    expect(c.findings).toEqual([]);
+  });
+
+  it('honors the allow-version-literal escape hatch (still counted, not flagged)', () => {
+    const c = classifyVerifyScript(
+      'aws lambda invoke --function-name "arn:aws:lambda:us-east-1:017000801446:function:shared:7" out.json # allow-version-literal: pinned by the layer owner, not this account\n',
+    );
+    expect(c.findings).toEqual([]);
+    expect(c.lambdaQualifierArgs).toBe(1);
+  });
+});
+
+describe('integ fixture verify.sh version literals (#1324)', () => {
+  const fixtures = readFixtures();
+
+  it('finds the fixture tree', () => {
+    expect(fixtures.length).toBeGreaterThan(100);
+  });
+
+  // Coverage floors, measured against the 2026-07-31 tree (see
+  // `.claude/rules/testing.md`, "A checker must prove it sees its input"):
+  // qualifier args come from `lambda-snapstart` (3 variable + 1 alias) and
+  // `codedeploy-lambda-deployment-group` (1 alias); version captures from the
+  // same two fixtures (2 each); the relative compares and the variable
+  // `--version-number` from those plus `lambda-layer-version-update`. If a
+  // legitimate refactor removes one of these, lower the floor in the same PR
+  // with a note — a silent drop to zero is the failure mode this exists for.
+  it('parses the known qualifier shapes across the tree', () => {
+    const total = fixtures.reduce((n, f) => n + f.lambdaQualifierArgs, 0);
+    const variable = fixtures.reduce((n, f) => n + f.variableQualifierArgs, 0);
+    const alias = fixtures.reduce((n, f) => n + f.aliasLiteralQualifierArgs, 0);
+    expect(total).toBeGreaterThanOrEqual(5);
+    expect(variable).toBeGreaterThanOrEqual(3);
+    expect(alias).toBeGreaterThanOrEqual(2);
+  });
+
+  it('parses the known version-capture and compare shapes across the tree', () => {
+    const captures = fixtures.reduce((n, f) => n + f.versionCaptureVars.length, 0);
+    const compares = fixtures.reduce((n, f) => n + f.versionCaptureCompares, 0);
+    const versionNumberArgs = fixtures.reduce((n, f) => n + f.versionNumberArgs, 0);
+    expect(captures).toBeGreaterThanOrEqual(4);
+    expect(compares).toBeGreaterThanOrEqual(2);
+    expect(versionNumberArgs).toBeGreaterThanOrEqual(1);
+  });
+
+  it('never hardcodes a Lambda published-version literal', () => {
+    const offenders = fixtures
+      .filter((f) => f.findings.length > 0)
+      .map((f) => ({ name: f.name, findings: f.findings }));
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1324.

Adds a mechanical lint banning hardcoded Lambda published-version literals in integ-fixture `verify.sh` scripts. Version counters are monotonic per function/layer NAME and never reset, so a `"${FN}:1"` probe or a `FunctionVersion == "2"` assert passes only on the first-ever run in the account and fails every re-run with `ResourceNotFoundException` — the trap shipped three times (`lambda-versioning`, `lambda-layer-version-update`, and `lambda-snapstart`, the last fixed in #1325) while the convention lived only in session memory.

## What it flags

- `literal-qualifier` — digits-literal qualifier on `aws lambda` commands: `--function-name "${FN}:1"`, ARN `...:function:fn:3`, `--qualifier 5`
- `literal-version-number` — digits-literal `--version-number` on `aws lambda` commands (layer counters behave the same way)
- `literal-compare` — integer-literal test-bracket compares of variables captured from version-ish `--query` expressions (`FunctionVersion`, `.Version`)

Legal shapes stay legal: alias qualifiers (`:live`, `:$LATEST`), variable qualifiers, relative `N -> N+1` compares, `length(...)` count queries, non-Lambda commands (e.g. appconfig `--version-number`), and the `# allow-version-literal: <reason>` escape hatch for versions pinned by an external owner.

## Checker-rules compliance (`.claude/rules/testing.md`)

- **Proves it sees its input**: per-shape coverage floors measured against today's tree — 5 qualifier args (3 variable / 2 alias), 4 version captures, 2 relative compares, 1 variable `--version-number`, >100 fixtures scanned. A parser regression that stops matching fails loudly instead of passing vacuously.
- **Proves it FAILS against real code**: before landing, the removed `":1"` qualifier was re-injected into the real `lambda-snapstart/verify.sh` and a literal `"2"` compare into the real `codedeploy-lambda-deployment-group/verify.sh`; the sweep exited non-zero naming the right fixture and finding kind in both probes, then the injections were reverted. Both probe shapes are also encoded as synthetic regression tests.

## Files

- `scripts/check-integ-version-literals.ts` — classifier (table-testable, separate from the test per family convention)
- `tests/unit/scripts/integ-verify-version-literals.test.ts` — 22 tests: synthetic shapes + tree sweep + coverage floors
- `docs/testing.md`, `.claude/rules/testing.md` — new fixture-convention sections with the canonical alias-derived `N -> N+1` pattern

## Test plan

- New lint: 22/22 pass; tree sweep reports 0 violations.
- Full unit suite: 500 files / 8372 tests pass.
- Real-code failure probes: rc=1 with correct attribution (see above), fixtures restored byte-identical (`git status` clean).
