### PR TITLE
test(integ): lint stateful L2 fixtures for explicit removalPolicy

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -147,7 +147,8 @@ by `tests/unit/scripts/integ-verify-version-literals.test.ts` (classifier:
 
 Stateful CDK L2 constructs (`kinesis.Stream`, `dynamodb.Table`/`TableV2`,
 `s3.Bucket`, `logs.LogGroup`, `kms.Key`, `rds.DatabaseInstance`/`Cluster`,
-`efs.FileSystem`, `opensearchservice.Domain`) default to
+`efs.FileSystem`, `opensearchservice.Domain`, `ecr.Repository`,
+`cognito.UserPool`, `backup.BackupVault`) default to
 `RemovalPolicy.RETAIN` -> `DeletionPolicy: Retain` in the template. Both
 CloudFormation and cdkd honor it, so a fixture that omits the policy leaks the
 resource on EVERY deploy/destroy cycle while destroy still reports success.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -143,6 +143,33 @@ by `tests/unit/scripts/integ-verify-version-literals.test.ts` (classifier:
 `scripts/check-integ-version-literals.ts`); user-facing writeup in
 [docs/testing.md](../../docs/testing.md).
 
+### Fixture stateful L2s need an explicit removalPolicy (mandatory)
+
+Stateful CDK L2 constructs (`kinesis.Stream`, `dynamodb.Table`/`TableV2`,
+`s3.Bucket`, `logs.LogGroup`, `kms.Key`, `rds.DatabaseInstance`/`Cluster`,
+`efs.FileSystem`, `opensearchservice.Domain`) default to
+`RemovalPolicy.RETAIN` -> `DeletionPolicy: Retain` in the template. Both
+CloudFormation and cdkd honor it, so a fixture that omits the policy leaks the
+resource on EVERY deploy/destroy cycle while destroy still reports success.
+Originating incident (issue #1326): the `sqs-cloudwatch` fixture's Kinesis
+Stream leaked 14 billed PROVISIONED streams across a month of us-west-2
+benchmark runs; the lint then immediately found a second live case
+(`log-pipeline`).
+
+Every instantiation of those constructs in `tests/integration/*/{lib,bin}`
+must do ONE of: pass an explicit `removalPolicy` (RETAIN included -- it has to
+be a decision, not a default), call `applyRemovalPolicy(...)` on the assigned
+variable/property in the same file, or carry an
+`// allow-default-removal-policy: <reason>` comment (for fixtures that
+intentionally exercise the default; the count is capped by the test). A props
+object passed as a same-file variable is resolved; a spread does NOT count --
+restate the policy visibly.
+
+Enforced by `tests/unit/scripts/integ-fixture-removal-policy.test.ts`
+(classifier: `scripts/check-fixture-removal-policy.ts`); user-facing writeup
+in [docs/testing.md](../../docs/testing.md). L1 `Cfn*` constructs are out of
+scope (their template default is `Delete`).
+
 ### A checker must prove it sees its input
 
 When writing a lint or codegen that SCANS files (verify.sh scripts, templates,

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -181,7 +181,7 @@ local-start-api-websocket	2026-07-19T18:46:28Z	PASS	103	verify.sh	rc ok, 0 docke
 local-start-cloudfront	2026-07-26T20:40:20Z	PASS	7	verify.sh	0727b sweep-L6 staleness re-run (rc=0); docker + account clean
 local-start-service	2026-07-26T20:18:09Z	PASS	20	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
 local-start-service-watch-fast	2026-07-26T20:18:09Z	PASS	186	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
-log-pipeline	2026-07-26T18:10:48Z	PASS	72	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
+log-pipeline	2026-07-31T07:44:41Z	PASS	95	standard	issue #1326 removalPolicy fix verified: stream deleted on destroy, 0 orphans
 loggroup-class-guard	2026-07-27T11:04:52Z	PASS	49	verify.sh	issue #1267 post-review re-run; typed-error pass-through verified vs real AWS; 1 del 0 err
 loggroup-kms-associate	2026-07-26T19:25:15Z	PASS	57	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 macro-expansion	2026-07-21T19:45:50Z	PASS	107	verify.sh	re-run w/ new diff-expands + destroy-no-expand asserts (1150)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -620,6 +620,41 @@ version (e.g. a public cross-account layer ARN pinned by its owner), append
 coverage floors and was verified to fail against real injected regressions
 before landing, per the checker rules above.
 
+### Fixture convention: stateful L2 constructs need an explicit removalPolicy
+
+Stateful CDK L2 constructs — `kinesis.Stream`, `dynamodb.Table` / `TableV2`,
+`s3.Bucket`, `logs.LogGroup`, `kms.Key`, `rds.DatabaseInstance` /
+`DatabaseCluster`, `efs.FileSystem`, `opensearchservice.Domain` — default to
+`RemovalPolicy.RETAIN`, which synthesizes `DeletionPolicy: Retain`. Both
+CloudFormation and cdkd honor it, so a fixture that omits the policy leaks the
+resource on **every** deploy/destroy cycle while the destroy still reports
+success. The originating incident (issue #1326): the `sqs-cloudwatch` fixture's
+Kinesis Stream carried no `removalPolicy`, and a month of benchmark runs in
+`us-west-2` accumulated 14 billed PROVISIONED streams before a cleanup sweep
+caught them. The lint then immediately found a second live case — the
+`log-pipeline` fixture's Stream, present since the initial commit.
+
+Every instantiation of those constructs under `tests/integration/*/{lib,bin}`
+must do one of:
+
+- pass an explicit `removalPolicy` in its props (an intentional `RETAIN` is
+  fine — it has to be a visible decision, not a silent default);
+- call `applyRemovalPolicy(...)` on the assigned variable / property elsewhere
+  in the same file;
+- carry an `// allow-default-removal-policy: <reason>` comment on the
+  statement, for fixtures that intentionally exercise the default (the test
+  caps how many of these may exist, so the escape hatch stays rare).
+
+A props object passed as a same-file variable is resolved through the variable;
+a spread (`{ ...base }`) does **not** count — restate the policy visibly. L1
+`Cfn*` constructs are out of scope because their template default is `Delete`.
+
+`tests/unit/scripts/integ-fixture-removal-policy.test.ts` enforces this across
+the fixture tree (classifier: `scripts/check-fixture-removal-policy.ts`), with
+coverage floors per constructor-reference shape and per construct kind so a
+parser regression fails loudly rather than passing vacuously. Baseline
+2026-07-31: 523 fixture files scanned, 107 stateful-L2 instantiations.
+
 ## 3. Deploy Using cdkd
 
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -624,7 +624,8 @@ before landing, per the checker rules above.
 
 Stateful CDK L2 constructs — `kinesis.Stream`, `dynamodb.Table` / `TableV2`,
 `s3.Bucket`, `logs.LogGroup`, `kms.Key`, `rds.DatabaseInstance` /
-`DatabaseCluster`, `efs.FileSystem`, `opensearchservice.Domain` — default to
+`DatabaseCluster`, `efs.FileSystem`, `opensearchservice.Domain`,
+`ecr.Repository`, `cognito.UserPool`, `backup.BackupVault` — default to
 `RemovalPolicy.RETAIN`, which synthesizes `DeletionPolicy: Retain`. Both
 CloudFormation and cdkd honor it, so a fixture that omits the policy leaks the
 resource on **every** deploy/destroy cycle while the destroy still reports
@@ -653,7 +654,7 @@ a spread (`{ ...base }`) does **not** count — restate the policy visibly. L1
 the fixture tree (classifier: `scripts/check-fixture-removal-policy.ts`), with
 coverage floors per constructor-reference shape and per construct kind so a
 parser regression fails loudly rather than passing vacuously. Baseline
-2026-07-31: 523 fixture files scanned, 107 stateful-L2 instantiations.
+2026-07-31: 523 fixture files scanned, 120 stateful-L2 instantiations.
 
 ## 3. Deploy Using cdkd
 

--- a/scripts/check-fixture-removal-policy.ts
+++ b/scripts/check-fixture-removal-policy.ts
@@ -41,9 +41,14 @@ export const STATEFUL_CONSTRUCTS: Record<string, readonly string[]> = {
   'aws-rds': ['DatabaseInstance', 'DatabaseCluster'],
   'aws-efs': ['FileSystem'],
   'aws-opensearchservice': ['Domain'],
+  'aws-ecr': ['Repository'],
+  'aws-cognito': ['UserPool'],
+  'aws-backup': ['BackupVault'],
 };
 
 export const ALLOW_COMMENT = 'allow-default-removal-policy:';
+/** The comment must carry a non-empty rationale after the marker. */
+const ALLOW_COMMENT_RE = /allow-default-removal-policy:\s*\S/;
 
 export interface ConstructHit {
   /** e.g. `aws-kinesis.Stream` */
@@ -211,24 +216,48 @@ export function scanFixtureSource(fileName: string, source: string): ScanStats {
     return null;
   };
 
-  const callsApplyRemovalPolicy = (target: string): boolean => {
-    // Escape regex metacharacters that can appear in a member LHS (`this.x`).
-    const escaped = target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp(`(?:^|[^\\w.])${escaped}\\.applyRemovalPolicy\\s*\\(`).test(source);
+  // AST-collected `<lhs>.applyRemovalPolicy(...)` call targets. Resolving via
+  // the AST (rather than a raw-source regex) means a commented-out or
+  // string-embedded call can never credit compliance.
+  const applyTargets = new Set<string>();
+  const collectApplyCalls = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'applyRemovalPolicy'
+    ) {
+      applyTargets.add(node.expression.expression.getText(sf));
+    }
+    ts.forEachChild(node, collectApplyCalls);
   };
+  collectApplyCalls(sf);
+
+  const callsApplyRemovalPolicy = (target: string): boolean => applyTargets.has(target);
 
   const hasAllowComment = (node: ts.NewExpression): boolean => {
-    // Leading comments attach to the enclosing STATEMENT, not the new-expr.
+    // Leading comments attach to the enclosing STATEMENT (or class-property
+    // declaration), not the new-expr. Stop at a class body too so a comment
+    // above the whole class can never credit every initializer inside it.
     let stmt: ts.Node = node;
-    while (stmt.parent && !ts.isSourceFile(stmt.parent) && !ts.isBlock(stmt.parent)) {
+    while (
+      stmt.parent &&
+      !ts.isSourceFile(stmt.parent) &&
+      !ts.isBlock(stmt.parent) &&
+      !ts.isClassLike(stmt.parent)
+    ) {
       stmt = stmt.parent;
     }
     const ranges = ts.getLeadingCommentRanges(source, stmt.getFullStart()) ?? [];
-    if (ranges.some((r) => source.slice(r.pos, r.end).includes(ALLOW_COMMENT))) return true;
-    // Same-line trailing comment.
-    const lineEnd = source.indexOf('\n', node.getStart(sf));
-    const lineText = source.slice(node.getStart(sf), lineEnd === -1 ? undefined : lineEnd);
-    return lineText.includes(ALLOW_COMMENT);
+    if (ranges.some((r) => ALLOW_COMMENT_RE.test(source.slice(r.pos, r.end)))) return true;
+    // Trailing comment on the first or last line of the (possibly multi-line)
+    // instantiation, e.g. `}); // allow-default-removal-policy: ...`.
+    for (const pos of [node.getStart(sf), node.getEnd()]) {
+      const lineStart = source.lastIndexOf('\n', pos) + 1;
+      const lineEnd = source.indexOf('\n', pos);
+      const lineText = source.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
+      if (ALLOW_COMMENT_RE.test(lineText)) return true;
+    }
+    return false;
   };
 
   // Walk ------------------------------------------------------------------

--- a/scripts/check-fixture-removal-policy.ts
+++ b/scripts/check-fixture-removal-policy.ts
@@ -1,0 +1,272 @@
+/**
+ * Classifier for the integ-fixture "stateful L2 needs an explicit
+ * removalPolicy" convention (issue #1326).
+ *
+ * Stateful CDK L2 constructs default to `RemovalPolicy.RETAIN`, which emits
+ * `DeletionPolicy: Retain` into the synthesized template. Both CloudFormation
+ * and cdkd honor it, so a fixture that omits the policy leaks the resource on
+ * EVERY deploy/destroy cycle -- silently, because the destroy still reports
+ * success. The originating incident: the `sqs-cloudwatch` fixture's Kinesis
+ * `Stream` had no `removalPolicy`, and every benchmark variant synthing that
+ * stack in us-west-2 leaked a billed PROVISIONED stream for a month (14
+ * streams found by the 2026-07-31 /cleanup sweep; fixed in PR #1327).
+ *
+ * The lint requires each instantiation of a construct in STATEFUL_CONSTRUCTS
+ * to do ONE of:
+ *   - pass an explicit `removalPolicy` in its props object (any value --
+ *     intentional RETAIN is fine, it just has to be a decision, not a default);
+ *   - call `<target>.applyRemovalPolicy(...)` on the assigned variable /
+ *     property elsewhere in the same file;
+ *   - carry an `allow-default-removal-policy: <reason>` comment on the
+ *     statement, for fixtures that intentionally exercise the default.
+ *
+ * L1 (`Cfn*`) constructs are out of scope: their template default is
+ * `Delete`, so omitting the policy does not leak.
+ *
+ * This module is separate from the test so the classifier can be table-tested
+ * against synthetic source shapes rather than only against today's tree.
+ */
+
+// `typescript-v6` is an npm alias of typescript@6: TypeScript 7's package no
+// longer exports the stable compiler API from its root (see package.json).
+import ts from 'typescript-v6';
+
+/** module suffix (after `aws-cdk-lib/`) -> stateful L2 construct class names. */
+export const STATEFUL_CONSTRUCTS: Record<string, readonly string[]> = {
+  'aws-kinesis': ['Stream'],
+  'aws-dynamodb': ['Table', 'TableV2'],
+  'aws-s3': ['Bucket'],
+  'aws-logs': ['LogGroup'],
+  'aws-kms': ['Key'],
+  'aws-rds': ['DatabaseInstance', 'DatabaseCluster'],
+  'aws-efs': ['FileSystem'],
+  'aws-opensearchservice': ['Domain'],
+};
+
+export const ALLOW_COMMENT = 'allow-default-removal-policy:';
+
+export interface ConstructHit {
+  /** e.g. `aws-kinesis.Stream` */
+  construct: string;
+  /** 1-based line of the `new` expression */
+  line: number;
+  compliant: boolean;
+  via: 'removalPolicy-prop' | 'applyRemovalPolicy' | 'allow-comment' | null;
+}
+
+/** How a hit's constructor reference was written -- used for coverage floors. */
+export interface ScanStats {
+  hits: ConstructHit[];
+  /** count of hits reached via `ns.Ctor` (namespace import) */
+  viaNamespace: number;
+  /** count of hits reached via bare `Ctor` (named import) */
+  viaNamed: number;
+  /** count of hits reached via `cdk.aws_x.Ctor` / `aws_x.Ctor` (barrel) */
+  viaBarrel: number;
+  /**
+   * count of hits whose props argument was an identifier resolved to a
+   * same-file variable (e.g. `new TableV2(this, 'T', tableProps)`) rather
+   * than an inline object literal. The dynamodb-globaltable fixture uses this
+   * shape; the first cut of this classifier flagged it as a false positive.
+   */
+  propsViaVariable: number;
+}
+
+const CDK_LIB = 'aws-cdk-lib';
+
+export function scanFixtureSource(fileName: string, source: string): ScanStats {
+  const sf = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true);
+
+  // Import bindings ------------------------------------------------------
+  const nsAliases = new Map<string, string>(); // local ns -> module suffix
+  const namedCtors = new Map<string, { module: string; name: string }>();
+  const barrelNs = new Set<string>(); // `import * as cdk from 'aws-cdk-lib'`
+  const barrelNamed = new Map<string, string>(); // local -> module suffix (aws_s3 etc.)
+
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt) || !ts.isStringLiteral(stmt.moduleSpecifier)) continue;
+    const spec = stmt.moduleSpecifier.text;
+    const clause = stmt.importClause;
+    if (!clause?.namedBindings) continue;
+
+    if (spec === CDK_LIB) {
+      if (ts.isNamespaceImport(clause.namedBindings)) {
+        barrelNs.add(clause.namedBindings.name.text);
+      } else {
+        for (const el of clause.namedBindings.elements) {
+          const exported = (el.propertyName ?? el.name).text;
+          if (exported.startsWith('aws_')) {
+            barrelNamed.set(el.name.text, exported.replace(/^aws_/, 'aws-'));
+          }
+        }
+      }
+      continue;
+    }
+
+    if (!spec.startsWith(`${CDK_LIB}/`)) continue;
+    const module = spec.slice(CDK_LIB.length + 1);
+    if (!(module in STATEFUL_CONSTRUCTS)) continue;
+
+    if (ts.isNamespaceImport(clause.namedBindings)) {
+      nsAliases.set(clause.namedBindings.name.text, module);
+    } else {
+      for (const el of clause.namedBindings.elements) {
+        const exported = (el.propertyName ?? el.name).text;
+        if (STATEFUL_CONSTRUCTS[module].includes(exported)) {
+          namedCtors.set(el.name.text, { module, name: exported });
+        }
+      }
+    }
+  }
+
+  // Constructor-reference resolution ------------------------------------
+  type Resolved = { construct: string; shape: 'namespace' | 'named' | 'barrel' };
+  const resolveCtor = (expr: ts.Expression): Resolved | null => {
+    if (ts.isIdentifier(expr)) {
+      const named = namedCtors.get(expr.text);
+      return named ? { construct: `${named.module}.${named.name}`, shape: 'named' } : null;
+    }
+    if (!ts.isPropertyAccessExpression(expr)) return null;
+    const ctor = expr.name.text;
+    const qualifier = expr.expression;
+    if (ts.isIdentifier(qualifier)) {
+      const module = nsAliases.get(qualifier.text) ?? barrelNamed.get(qualifier.text);
+      if (module && STATEFUL_CONSTRUCTS[module]?.includes(ctor)) {
+        const shape = nsAliases.has(qualifier.text) ? 'namespace' : 'barrel';
+        return { construct: `${module}.${ctor}`, shape };
+      }
+      return null;
+    }
+    // `cdk.aws_s3.Bucket`
+    if (
+      ts.isPropertyAccessExpression(qualifier) &&
+      ts.isIdentifier(qualifier.expression) &&
+      barrelNs.has(qualifier.expression.text) &&
+      qualifier.name.text.startsWith('aws_')
+    ) {
+      const module = qualifier.name.text.replace(/^aws_/, 'aws-');
+      if (STATEFUL_CONSTRUCTS[module]?.includes(ctor)) {
+        return { construct: `${module}.${ctor}`, shape: 'barrel' };
+      }
+    }
+    return null;
+  };
+
+  // Compliance helpers ---------------------------------------------------
+  const objectHasRemovalPolicy = (obj: ts.ObjectLiteralExpression): boolean =>
+    obj.properties.some(
+      (p) =>
+        (ts.isPropertyAssignment(p) || ts.isShorthandPropertyAssignment(p)) &&
+        ts.isIdentifier(p.name) &&
+        p.name.text === 'removalPolicy',
+    );
+
+  /** Resolve `const tableProps = { ... }` for a props-identifier argument. */
+  const resolvePropsVariable = (name: string): ts.ObjectLiteralExpression | null => {
+    let found: ts.ObjectLiteralExpression | null = null;
+    const walk = (node: ts.Node): void => {
+      if (found) return;
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.name.text === name &&
+        node.initializer &&
+        ts.isObjectLiteralExpression(node.initializer)
+      ) {
+        found = node.initializer;
+        return;
+      }
+      ts.forEachChild(node, walk);
+    };
+    walk(sf);
+    return found;
+  };
+
+  const hasRemovalPolicyProp = (node: ts.NewExpression): { ok: boolean; viaVariable: boolean } => {
+    const props = node.arguments?.[2];
+    if (!props) return { ok: false, viaVariable: false };
+    if (ts.isObjectLiteralExpression(props)) {
+      return { ok: objectHasRemovalPolicy(props), viaVariable: false };
+    }
+    if (ts.isIdentifier(props)) {
+      const obj = resolvePropsVariable(props.text);
+      if (obj) return { ok: objectHasRemovalPolicy(obj), viaVariable: true };
+    }
+    return { ok: false, viaVariable: false };
+  };
+
+  /** LHS text (`fileSystem`, `this.bucket`, ...) the new-expression is assigned to. */
+  const assignmentTarget = (node: ts.NewExpression): string | null => {
+    const parent = node.parent;
+    if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
+      return parent.name.text;
+    }
+    if (
+      ts.isBinaryExpression(parent) &&
+      parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      parent.right === node
+    ) {
+      return parent.left.getText(sf);
+    }
+    return null;
+  };
+
+  const callsApplyRemovalPolicy = (target: string): boolean => {
+    // Escape regex metacharacters that can appear in a member LHS (`this.x`).
+    const escaped = target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`(?:^|[^\\w.])${escaped}\\.applyRemovalPolicy\\s*\\(`).test(source);
+  };
+
+  const hasAllowComment = (node: ts.NewExpression): boolean => {
+    // Leading comments attach to the enclosing STATEMENT, not the new-expr.
+    let stmt: ts.Node = node;
+    while (stmt.parent && !ts.isSourceFile(stmt.parent) && !ts.isBlock(stmt.parent)) {
+      stmt = stmt.parent;
+    }
+    const ranges = ts.getLeadingCommentRanges(source, stmt.getFullStart()) ?? [];
+    if (ranges.some((r) => source.slice(r.pos, r.end).includes(ALLOW_COMMENT))) return true;
+    // Same-line trailing comment.
+    const lineEnd = source.indexOf('\n', node.getStart(sf));
+    const lineText = source.slice(node.getStart(sf), lineEnd === -1 ? undefined : lineEnd);
+    return lineText.includes(ALLOW_COMMENT);
+  };
+
+  // Walk ------------------------------------------------------------------
+  const stats: ScanStats = {
+    hits: [],
+    viaNamespace: 0,
+    viaNamed: 0,
+    viaBarrel: 0,
+    propsViaVariable: 0,
+  };
+  const visit = (node: ts.Node): void => {
+    if (ts.isNewExpression(node)) {
+      const resolved = resolveCtor(node.expression);
+      if (resolved) {
+        if (resolved.shape === 'namespace') stats.viaNamespace++;
+        else if (resolved.shape === 'named') stats.viaNamed++;
+        else stats.viaBarrel++;
+
+        const propCheck = hasRemovalPolicyProp(node);
+        if (propCheck.viaVariable) stats.propsViaVariable++;
+        let via: ConstructHit['via'] = null;
+        if (propCheck.ok) {
+          via = 'removalPolicy-prop';
+        } else {
+          const target = assignmentTarget(node);
+          if (target && callsApplyRemovalPolicy(target)) via = 'applyRemovalPolicy';
+          else if (hasAllowComment(node)) via = 'allow-comment';
+        }
+        stats.hits.push({
+          construct: resolved.construct,
+          line: sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1,
+          compliant: via !== null,
+          via,
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return stats;
+}

--- a/tests/integration/log-pipeline/lib/log-pipeline-stack.ts
+++ b/tests/integration/log-pipeline/lib/log-pipeline-stack.ts
@@ -68,6 +68,10 @@ def handler(event, context):
       streamName: `cdkd-log-pipeline-${this.stackName}`,
       shardCount: 1,
       retentionPeriod: cdk.Duration.hours(24),
+      // Stream is a stateful L2 whose default removalPolicy is RETAIN; without
+      // DESTROY every deploy/destroy cycle leaks a billed PROVISIONED stream
+      // (issue #1326, same class as the sqs-cloudwatch leak fixed in #1327).
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
     // MetricFilter on the LogGroup

--- a/tests/unit/scripts/integ-fixture-removal-policy.test.ts
+++ b/tests/unit/scripts/integ-fixture-removal-policy.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  scanFixtureSource,
+  STATEFUL_CONSTRUCTS,
+  type ScanStats,
+} from '../../../scripts/check-fixture-removal-policy.js';
+
+/**
+ * Regression guard for issue #1326: stateful CDK L2 constructs in integ
+ * fixtures must carry an EXPLICIT removalPolicy. The L2 default is RETAIN,
+ * which both CloudFormation and cdkd honor, so an omitted policy leaks the
+ * resource on every deploy/destroy cycle while the destroy still reports
+ * success. Originating incident: the sqs-cloudwatch fixture's Kinesis Stream
+ * leaked 14 billed PROVISIONED streams across a month of benchmark runs
+ * (fixed in PR #1327); this lint then immediately found a second live case
+ * (log-pipeline's Stream, fixed in the PR that added this file).
+ *
+ * See `scripts/check-fixture-removal-policy.ts` for the classifier and the
+ * compliance escapes (explicit prop / applyRemovalPolicy / allow-comment).
+ */
+
+const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
+
+function scanTree() {
+  const perFile: { fixture: string; file: string; stats: ScanStats }[] = [];
+  for (const dir of readdirSync(INTEG_ROOT, { withFileTypes: true })) {
+    if (!dir.isDirectory()) continue;
+    for (const sub of ['lib', 'bin']) {
+      const p = join(INTEG_ROOT, dir.name, sub);
+      if (!existsSync(p)) continue;
+      for (const f of readdirSync(p).filter((f) => f.endsWith('.ts'))) {
+        perFile.push({
+          fixture: dir.name,
+          file: `${dir.name}/${sub}/${f}`,
+          stats: scanFixtureSource(f, readFileSync(join(p, f), 'utf8')),
+        });
+      }
+    }
+  }
+  return perFile;
+}
+
+describe('scanFixtureSource', () => {
+  const HEADER = `import * as cdk from 'aws-cdk-lib';\nimport * as kinesis from 'aws-cdk-lib/aws-kinesis';\n`;
+
+  it('flags a namespace-import construct with no props argument', () => {
+    const { hits } = scanFixtureSource('t.ts', `${HEADER}new kinesis.Stream(this, 'S');\n`);
+    expect(hits).toEqual([
+      { construct: 'aws-kinesis.Stream', line: 3, compliant: false, via: null },
+    ]);
+  });
+
+  it('flags props that lack removalPolicy even when other keys exist', () => {
+    const src = `${HEADER}new kinesis.Stream(this, 'S', { shardCount: 1 });\n`;
+    expect(scanFixtureSource('t.ts', src).hits[0].compliant).toBe(false);
+  });
+
+  it('accepts an explicit removalPolicy prop (any value, RETAIN included)', () => {
+    for (const v of ['cdk.RemovalPolicy.DESTROY', 'cdk.RemovalPolicy.RETAIN']) {
+      const src = `${HEADER}new kinesis.Stream(this, 'S', { removalPolicy: ${v} });\n`;
+      expect(scanFixtureSource('t.ts', src).hits[0]).toMatchObject({
+        compliant: true,
+        via: 'removalPolicy-prop',
+      });
+    }
+  });
+
+  it('resolves a named import, including a rename', () => {
+    const src = `import { Stream as KStream } from 'aws-cdk-lib/aws-kinesis';\nnew KStream(this, 'S', { removalPolicy: x });\n`;
+    const stats = scanFixtureSource('t.ts', src);
+    expect(stats.hits[0]).toMatchObject({ construct: 'aws-kinesis.Stream', compliant: true });
+    expect(stats.viaNamed).toBe(1);
+  });
+
+  it('resolves barrel access in both spellings', () => {
+    // `cdk.aws_s3.Bucket` and `import { aws_s3 as s3l }` are rare but legal;
+    // the parameters fixture already uses the chain form for an L1.
+    const src =
+      `import * as cdk from 'aws-cdk-lib';\nimport { aws_s3 as s3l } from 'aws-cdk-lib';\n` +
+      `new cdk.aws_s3.Bucket(this, 'A');\nnew s3l.Bucket(this, 'B');\n`;
+    const stats = scanFixtureSource('t.ts', src);
+    expect(stats.hits.map((h) => h.construct)).toEqual(['aws-s3.Bucket', 'aws-s3.Bucket']);
+    expect(stats.viaBarrel).toBe(2);
+    expect(stats.hits.every((h) => !h.compliant)).toBe(true);
+  });
+
+  it('resolves a props argument passed as a same-file variable', () => {
+    // The dynamodb-globaltable fixture passes `tableProps`; the first cut of
+    // this classifier false-positived on exactly this shape.
+    const src = `${HEADER}const p = { shardCount: 1, removalPolicy: cdk.RemovalPolicy.DESTROY };\nnew kinesis.Stream(this, 'S', p);\n`;
+    const stats = scanFixtureSource('t.ts', src);
+    expect(stats.hits[0]).toMatchObject({ compliant: true, via: 'removalPolicy-prop' });
+    expect(stats.propsViaVariable).toBe(1);
+  });
+
+  it('still flags a props variable that lacks removalPolicy', () => {
+    const src = `${HEADER}const p = { shardCount: 1 };\nnew kinesis.Stream(this, 'S', p);\n`;
+    expect(scanFixtureSource('t.ts', src).hits[0].compliant).toBe(false);
+  });
+
+  it('does not credit a spread for an explicit removalPolicy', () => {
+    // `{ ...base }` may or may not carry the policy -- treat as absent so the
+    // author is forced to restate it visibly (or use the allow-comment).
+    const src = `${HEADER}const base = { removalPolicy: cdk.RemovalPolicy.DESTROY };\nnew kinesis.Stream(this, 'S', { ...base });\n`;
+    expect(scanFixtureSource('t.ts', src).hits[0].compliant).toBe(false);
+  });
+
+  it('accepts applyRemovalPolicy on a const target', () => {
+    const src = `${HEADER}const s = new kinesis.Stream(this, 'S');\ns.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);\n`;
+    expect(scanFixtureSource('t.ts', src).hits[0]).toMatchObject({
+      compliant: true,
+      via: 'applyRemovalPolicy',
+    });
+  });
+
+  it('accepts applyRemovalPolicy on a member target (this.x)', () => {
+    const src = `${HEADER}this.stream = new kinesis.Stream(this, 'S');\nthis.stream.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);\n`;
+    expect(scanFixtureSource('t.ts', src).hits[0].compliant).toBe(true);
+  });
+
+  it('does not let one variable name substring-match another', () => {
+    // `s.applyRemovalPolicy` must not satisfy `logs` (suffix) or `sx` (prefix).
+    const src = `${HEADER}const logs = new kinesis.Stream(this, 'A');\nconst s = new kinesis.Stream(this, 'B');\ns.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);\n`;
+    const [a, b] = scanFixtureSource('t.ts', src).hits;
+    expect(a.compliant).toBe(false);
+    expect(b.compliant).toBe(true);
+  });
+
+  it('accepts an allow-default-removal-policy comment with rationale', () => {
+    const src = `${HEADER}// allow-default-removal-policy: exercises the RETAIN default on purpose\nnew kinesis.Stream(this, 'S');\n`;
+    expect(scanFixtureSource('t.ts', src).hits[0]).toMatchObject({
+      compliant: true,
+      via: 'allow-comment',
+    });
+  });
+
+  it('ignores non-stateful constructs and L1 Cfn classes', () => {
+    const src =
+      `import * as sqs from 'aws-cdk-lib/aws-sqs';\nimport * as kinesis from 'aws-cdk-lib/aws-kinesis';\n` +
+      `new sqs.Queue(this, 'Q');\nnew kinesis.CfnStream(this, 'S');\n`;
+    expect(scanFixtureSource('t.ts', src).hits).toEqual([]);
+  });
+
+  it('ignores a same-name class from an unrelated module', () => {
+    const src = `import { Stream } from 'node:stream';\nnew Stream();\n`;
+    expect(scanFixtureSource('t.ts', src).hits).toEqual([]);
+  });
+});
+
+describe('integ fixture stateful-L2 removalPolicy sweep (issue #1326)', () => {
+  const perFile = scanTree();
+  const allHits = perFile.flatMap((f) => f.stats.hits.map((h) => ({ ...h, file: f.file })));
+
+  it('finds the fixture tree', () => {
+    expect(perFile.length).toBeGreaterThan(400);
+  });
+
+  // Coverage floors: "0 violations" and "parsed nothing" are the same green.
+  // Floors are per input SHAPE the parser claims to handle (see
+  // .claude/rules/testing.md "A checker must prove it sees its input").
+  // Baseline 2026-07-31: 107 hits -- namespace 104 / named 3 / props-variable 1.
+  it('sees each constructor-reference shape the tree actually uses', () => {
+    const total = (k: 'viaNamespace' | 'viaNamed' | 'propsViaVariable') =>
+      perFile.reduce((n, f) => n + f.stats[k], 0);
+    expect(total('viaNamespace')).toBeGreaterThanOrEqual(90);
+    expect(total('viaNamed')).toBeGreaterThanOrEqual(2);
+    expect(total('propsViaVariable')).toBeGreaterThanOrEqual(1);
+    // No barrel-form stateful L2 exists in the tree today; the shape is
+    // covered by the synthetic tests above. If one appears, raise a floor.
+  });
+
+  it('sees every construct kind the tree actually uses', () => {
+    const byConstruct = new Map<string, number>();
+    for (const h of allHits) byConstruct.set(h.construct, (byConstruct.get(h.construct) ?? 0) + 1);
+    // Baseline counts 2026-07-31, floored with slack for fixture churn.
+    const floors: Record<string, number> = {
+      'aws-s3.Bucket': 35,
+      'aws-dynamodb.Table': 20,
+      'aws-logs.LogGroup': 12,
+      'aws-kinesis.Stream': 5,
+      'aws-kms.Key': 5,
+      'aws-efs.FileSystem': 2,
+      'aws-dynamodb.TableV2': 1,
+      'aws-opensearchservice.Domain': 1,
+      'aws-rds.DatabaseInstance': 1,
+      'aws-rds.DatabaseCluster': 1,
+    };
+    for (const [construct, floor] of Object.entries(floors)) {
+      expect(byConstruct.get(construct) ?? 0, construct).toBeGreaterThanOrEqual(floor);
+    }
+    // Every floored kind must be declared, and vice versa nothing outside the
+    // registry can appear (hit constructs come FROM the registry by design).
+    for (const construct of Object.keys(floors)) {
+      const [module, name] = construct.split('.');
+      expect(STATEFUL_CONSTRUCTS[module]).toContain(name);
+    }
+  });
+
+  it('every stateful L2 instantiation carries an explicit removal policy', () => {
+    const violations = allHits
+      .filter((h) => !h.compliant)
+      .map((h) => `${h.file}:${h.line} ${h.construct}`);
+    expect(violations, 'add removalPolicy (or applyRemovalPolicy / allow-comment)').toEqual([]);
+  });
+
+  it('keeps allow-comments rare and intentional', () => {
+    // The escape hatch is for fixtures that TEST the default. If this grows,
+    // someone is using it to silence the lint -- review each addition.
+    const allowed = allHits.filter((h) => h.via === 'allow-comment');
+    expect(allowed.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/tests/unit/scripts/integ-fixture-removal-policy.test.ts
+++ b/tests/unit/scripts/integ-fixture-removal-policy.test.ts
@@ -120,6 +120,15 @@ describe('scanFixtureSource', () => {
     expect(scanFixtureSource('t.ts', src).hits[0].compliant).toBe(true);
   });
 
+  it('does not credit a commented-out or string-embedded applyRemovalPolicy', () => {
+    // The first cut resolved this with a raw-source regex, so commenting the
+    // call out during a refactor kept the lint green while the leak returned.
+    const commented = `${HEADER}const s = new kinesis.Stream(this, 'S');\n// s.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);\n`;
+    expect(scanFixtureSource('t.ts', commented).hits[0].compliant).toBe(false);
+    const inString = `${HEADER}const s = new kinesis.Stream(this, 'S');\nconst note = 's.applyRemovalPolicy(x)';\n`;
+    expect(scanFixtureSource('t.ts', inString).hits[0].compliant).toBe(false);
+  });
+
   it('does not let one variable name substring-match another', () => {
     // `s.applyRemovalPolicy` must not satisfy `logs` (suffix) or `sx` (prefix).
     const src = `${HEADER}const logs = new kinesis.Stream(this, 'A');\nconst s = new kinesis.Stream(this, 'B');\ns.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);\n`;
@@ -134,6 +143,37 @@ describe('scanFixtureSource', () => {
       compliant: true,
       via: 'allow-comment',
     });
+  });
+
+  it('accepts a trailing allow-comment on the closing line of a multi-line call', () => {
+    const src = `${HEADER}new kinesis.Stream(this, 'S', {\n  shardCount: 1,\n}); // allow-default-removal-policy: exercises the default\n`;
+    expect(scanFixtureSource('t.ts', src).hits[0]).toMatchObject({ via: 'allow-comment' });
+  });
+
+  it('rejects an allow-comment with no rationale', () => {
+    const src = `${HEADER}// allow-default-removal-policy:\nnew kinesis.Stream(this, 'S');\n`;
+    expect(scanFixtureSource('t.ts', src).hits[0].compliant).toBe(false);
+  });
+
+  it('scopes allow-comments to a class-property initializer, not the class', () => {
+    // A comment above the CLASS must not credit every initializer inside it.
+    const aboveClass = `${HEADER}// allow-default-removal-policy: nope\nclass X { s = new kinesis.Stream(this, 'S'); }\n`;
+    expect(scanFixtureSource('t.ts', aboveClass).hits[0].compliant).toBe(false);
+    const aboveProp = `${HEADER}class X {\n  // allow-default-removal-policy: exercises the default\n  s = new kinesis.Stream(this, 'S');\n}\n`;
+    expect(scanFixtureSource('t.ts', aboveProp).hits[0]).toMatchObject({ via: 'allow-comment' });
+  });
+
+  it('recognizes the ECR / Cognito / Backup registry additions', () => {
+    const src =
+      `import * as ecr from 'aws-cdk-lib/aws-ecr';\nimport * as cognito from 'aws-cdk-lib/aws-cognito';\nimport * as backup from 'aws-cdk-lib/aws-backup';\n` +
+      `new ecr.Repository(this, 'R');\nnew cognito.UserPool(this, 'P');\nnew backup.BackupVault(this, 'V');\n`;
+    const { hits } = scanFixtureSource('t.ts', src);
+    expect(hits.map((h) => h.construct)).toEqual([
+      'aws-ecr.Repository',
+      'aws-cognito.UserPool',
+      'aws-backup.BackupVault',
+    ]);
+    expect(hits.every((h) => !h.compliant)).toBe(true);
   });
 
   it('ignores non-stateful constructs and L1 Cfn classes', () => {
@@ -160,7 +200,7 @@ describe('integ fixture stateful-L2 removalPolicy sweep (issue #1326)', () => {
   // Coverage floors: "0 violations" and "parsed nothing" are the same green.
   // Floors are per input SHAPE the parser claims to handle (see
   // .claude/rules/testing.md "A checker must prove it sees its input").
-  // Baseline 2026-07-31: 107 hits -- namespace 104 / named 3 / props-variable 1.
+  // Baseline 2026-07-31: 120 hits -- namespace 117 / named 3 / props-variable 1.
   it('sees each constructor-reference shape the tree actually uses', () => {
     const total = (k: 'viaNamespace' | 'viaNamed' | 'propsViaVariable') =>
       perFile.reduce((n, f) => n + f.stats[k], 0);
@@ -181,11 +221,15 @@ describe('integ fixture stateful-L2 removalPolicy sweep (issue #1326)', () => {
       'aws-logs.LogGroup': 12,
       'aws-kinesis.Stream': 5,
       'aws-kms.Key': 5,
+      'aws-cognito.UserPool': 4,
+      'aws-ecr.Repository': 2,
       'aws-efs.FileSystem': 2,
       'aws-dynamodb.TableV2': 1,
       'aws-opensearchservice.Domain': 1,
       'aws-rds.DatabaseInstance': 1,
       'aws-rds.DatabaseCluster': 1,
+      // aws-backup.BackupVault: registered but unused in the tree today --
+      // covered by the synthetic test above; add a floor when a fixture lands.
     };
     for (const [construct, floor] of Object.entries(floors)) {
       expect(byConstruct.get(construct) ?? 0, construct).toBeGreaterThanOrEqual(floor);


### PR DESCRIPTION
## Summary

Closes #1326.

Stateful CDK L2 constructs default to `RemovalPolicy.RETAIN` (`DeletionPolicy: Retain` in the template), which both CloudFormation and cdkd honor — so an integ fixture that omits the policy leaks the resource on every deploy/destroy cycle while the destroy still reports success. The originating incident was the `sqs-cloudwatch` fixture's Kinesis Stream (14 billed PROVISIONED streams accumulated over a month of us-west-2 benchmark runs; fixed in #1327). This PR adds the lint that catches the whole class:

- `scripts/check-fixture-removal-policy.ts` — AST classifier (typescript-v6) over `tests/integration/*/{lib,bin}/*.ts`. Target set: `kinesis.Stream`, `dynamodb.Table`/`TableV2`, `s3.Bucket`, `logs.LogGroup`, `kms.Key`, `rds.DatabaseInstance`/`DatabaseCluster`, `efs.FileSystem`, `opensearchservice.Domain`, `ecr.Repository`, `cognito.UserPool`, `backup.BackupVault`. Compliance = explicit `removalPolicy` prop (any value; intentional RETAIN is fine), `applyRemovalPolicy(...)` on the assigned variable/property, or an `// allow-default-removal-policy: <reason>` comment (count capped at 2 by the test). Resolves namespace / named / barrel constructor references and props passed as a same-file variable; spreads do not count.
- `tests/unit/scripts/integ-fixture-removal-policy.test.ts` — synthetic table tests for every claimed shape + real-tree sweep with coverage floors per constructor-reference shape and per construct kind (baseline 2026-07-31: 523 files scanned, 120 stateful-L2 instantiations; namespace 117 / named 3 / props-variable 1).
- **Second live case found and fixed**: `log-pipeline`'s Stream had no `removalPolicy` since the initial commit — every run of that integ leaked a named PROVISIONED stream.
- Docs: fixture-convention sections in `.claude/rules/testing.md` and `docs/testing.md`.

## Prove-it-fails record (per `.claude/rules/testing.md`)

Both CI-blocking verdicts were proven against REAL repo code before trusting the checker, then restored:

- Reverting the `log-pipeline` fix → suite exits 1 naming `log-pipeline/lib/log-pipeline-stack.ts:67 aws-kinesis.Stream`.
- Removing `removalPolicy` from `dynamodb-globaltable`'s `tableProps` (the props-variable shape the first cut of the classifier false-positived on) → suite exits 1 naming `dynamodb-globaltable/lib/dynamodb-globaltable-stack.ts:112 aws-dynamodb.TableV2`.

## Test plan

- `/check`: typecheck + lint + build + full unit suite (500 files, 8369 tests) pass; integ/scenario/cli-flag matrices regenerated (no drift).
- `/run-integ log-pipeline` against real AWS: synth now emits `DeletionPolicy: Delete` on the stream; deploy 12 resources, destroy 12 deleted / 0 errors **including the Kinesis stream**; post-run orphan scan clean (state 404, Kinesis/Firehose/IAM/Lambda/S3/log groups all empty; Firehose deletion confirmed async-complete).

## Review (1-reviewer tier, pr-code-reviewer)

No blockers. Applied in this PR: ECR/Cognito/BackupVault registry additions (+floors), AST-resolved `applyRemovalPolicy` call sites (a commented-out or string-embedded call no longer credits compliance), allow-comment scoping stops at class bodies, trailing allow-comment recognized on the closing line of multi-line calls, and the allow-comment now requires a non-empty rationale.

Won't-do (recorded here): `resolvePropsVariable` is scope-blind (first same-named declaration in the file wins). Shadowed props-variable names within one fixture stack file are improbable, and the failure direction only matters if the shadowing pair also splits the policy; not worth the scope-tracking complexity in a fixture lint.
