### PR TITLE
docs(readme): merge speed bullets, move local execution to intro text

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AW
 
 **A natural fit for AI-driven development.** AI coding agents iterate in tight spin-up / tear-down loops — and cdkd keeps each turn short, with fast deploys and an equally fast `cdkd destroy` that deletes via direct SDK calls instead of polling a CloudFormation stack-delete.
 
-**Local execution from your deployed stack.** `cdkd local` runs your functions, APIs, and ECS tasks on your machine, and can resolve env vars, secrets, and resource references from your real deployed stack: no hand-written `.env` files, no hand-seeded test data (see [Local execution](#local-execution)).
+**Local execution from your deployed stack.** `cdkd local` runs your functions, APIs, and ECS tasks on your machine. It can resolve env vars, secrets, and resource references from your real deployed stack: no hand-written `.env` files, no hand-seeded test data (see [Local execution](#local-execution)).
 
 > [!IMPORTANT]
 > cdkd is for dev/test workflows only — early in development, not yet production-ready.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation.
 
 - **Drop-in CDK compatible**: your existing CDK app code runs as-is; just replace `cdk deploy` with `cdkd deploy`.
-- **Up to 15x faster deploys**: direct SDK calls, aggressive parallelization, and `--no-wait` to skip slow stabilization waits; faster than Terraform and CloudFormation Express mode too (see [Benchmark](#benchmark)).
+- **Up to 15x faster deploys**: direct SDK calls, aggressive parallelization, and `--no-wait` to skip slow stabilization waits; **faster than Terraform and CloudFormation Express mode** too (see [Benchmark](#benchmark)).
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AW
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)
 
-**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration and local execution; use the AWS CDK CLI in production for full CloudFormation tooling. Install cdkd alongside an existing `cdk deploy` workflow: no migration needed. Bidirectional migration is also supported: [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation when ready.
+**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration; use the AWS CDK CLI in production for full CloudFormation tooling. Install cdkd alongside an existing `cdk deploy` workflow: no migration needed. Bidirectional migration is also supported: [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation when ready.
 
 **A natural fit for AI-driven development.** AI coding agents iterate in tight spin-up / tear-down loops — and cdkd keeps each turn short, with fast deploys and an equally fast `cdkd destroy` that deletes via direct SDK calls instead of polling a CloudFormation stack-delete.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AW
 
 **A natural fit for AI-driven development.** AI coding agents iterate in tight spin-up / tear-down loops — and cdkd keeps each turn short, with fast deploys and an equally fast `cdkd destroy` that deletes via direct SDK calls instead of polling a CloudFormation stack-delete.
 
-**Local execution from your deployed stack.** `cdkd local` runs your functions, APIs, and ECS tasks on your machine, with env vars, secrets, and resource references resolved from real deployed state instead of hand-written `.env` files (see [Local execution](#local-execution)).
+**Local execution from your deployed stack.** `cdkd local` runs your functions, APIs, and ECS tasks on your machine, with env vars, secrets, and resource references resolved from real deployed state: no hand-written `.env` files, no hand-seeded test data (see [Local execution](#local-execution)).
 
 > [!IMPORTANT]
 > cdkd is for dev/test workflows only — early in development, not yet production-ready.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation.
 
 - **Drop-in CDK compatible**: your existing CDK app code runs as-is; just replace `cdk deploy` with `cdkd deploy`.
-- **Up to 15x faster deploys**: direct SDK calls, aggressive parallelization, and `--no-wait` to skip slow stabilization waits.
-- **Faster than Terraform and CloudFormation Express mode**: wins or ties every benchmarked scenario against Terraform, and beats CloudFormation's own fast-deploy option on nearly every stack, by up to 9x (see [Benchmark](#benchmark)).
+- **Up to 15x faster deploys**: direct SDK calls, aggressive parallelization, and `--no-wait` to skip slow stabilization waits; faster than Terraform and CloudFormation Express mode too (see [Benchmark](#benchmark)).
+- **Local execution from your deployed stack**: run your Lambdas, APIs, and ECS tasks on your machine, with env vars, secrets, and resource references resolved from real deployed state instead of hand-written `.env` files (see [Local execution](#local-execution)).
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AW
 
 **A natural fit for AI-driven development.** AI coding agents iterate in tight spin-up / tear-down loops — and cdkd keeps each turn short, with fast deploys and an equally fast `cdkd destroy` that deletes via direct SDK calls instead of polling a CloudFormation stack-delete.
 
-**Local execution from your deployed stack.** `cdkd local` runs your functions, APIs, and ECS tasks on your machine, with env vars, secrets, and resource references resolved from real deployed state: no hand-written `.env` files, no hand-seeded test data (see [Local execution](#local-execution)).
+**Local execution from your deployed stack.** `cdkd local` runs your functions, APIs, and ECS tasks on your machine, and can resolve env vars, secrets, and resource references from your real deployed stack: no hand-written `.env` files, no hand-seeded test data (see [Local execution](#local-execution)).
 
 > [!IMPORTANT]
 > cdkd is for dev/test workflows only — early in development, not yet production-ready.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AW
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)
 
-**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration; use the AWS CDK CLI in production for full CloudFormation tooling. Install cdkd alongside an existing `cdk deploy` workflow (no migration needed), and [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation anytime.
+**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration; use the AWS CDK CLI in production for full CloudFormation tooling. Install cdkd alongside an existing `cdk deploy` workflow: no migration needed. You can also [import](#importing-existing-resources) existing stacks into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation anytime.
 
 **A natural fit for AI-driven development.** AI coding agents iterate in tight spin-up / tear-down loops — and cdkd keeps each turn short, with fast deploys and an equally fast `cdkd destroy` that deletes via direct SDK calls instead of polling a CloudFormation stack-delete.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cdkd diff
 cdkd destroy
 ```
 
-That's it. cdkd reads `--app` from `cdk.json` and auto-resolves the state bucket from your AWS account ID (`cdkd-state-{accountId}`). If you bootstrapped under a previous cdkd version, the legacy region-suffixed name (`cdkd-state-{accountId}-{region}`) is still picked up automatically with a deprecation warning.
+That's it. cdkd reads `--app` from `cdk.json` and auto-resolves the state bucket from your AWS account ID: no per-project configuration needed.
 
 ## Benchmark
 
@@ -129,7 +129,10 @@ Existing setups, legacy-mode opt-outs, and how this relates to `cdk bootstrap`: 
 each region auto-creates the cdkd-owned asset storage (interactive runs are asked
 once per region, `--yes` / CI runs create it automatically) and shows a one-time
 in-place UPDATE repointing asset references — content identical, no replacement.
-Downgrading is safe too (older binaries ignore the marker). Explicit pre-provisioning
+Downgrading is safe too (older binaries ignore the marker). If you bootstrapped
+under a previous cdkd version, the legacy region-suffixed state bucket name
+(`cdkd-state-{accountId}-{region}`) is still picked up automatically with a
+deprecation warning. Explicit pre-provisioning
 (`cdkd bootstrap --region <r>`), legacy-mode opt-outs, and how this relates to
 `cdk bootstrap`: see [`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap).
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ cdkd diff
 cdkd destroy
 ```
 
-That's it. cdkd reads `--app` from `cdk.json` and auto-resolves the state bucket from your AWS account ID: no per-project configuration needed.
-
 ## Benchmark
 
 **cdkd deploys up to 15x faster than AWS CDK (CloudFormation)** on SDK-Provider-handled stacks; the per-stack speedup widens with size and parallelism.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,47 @@ Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AW
 > [!IMPORTANT]
 > cdkd is for dev/test workflows only — early in development, not yet production-ready.
 
+## Installation
+
+```bash
+npm i -g @go-to-k/cdkd          # latest release
+npm i -g @go-to-k/cdkd@0.0.2    # pin to a specific version
+```
+
+The installed binary is `cdkd`.
+
+## Quick Start
+
+> **First-time setup**: cdkd requires a one-time `cdkd bootstrap` per AWS
+> account before any other command will work — it creates the S3 state
+> bucket (`cdkd-state-{accountId}`) that cdkd uses to track deployed
+> resources, plus cdkd-owned asset storage for the region
+> (by default a `cdkd-assets-{accountId}-{region}` bucket +
+> `cdkd-container-assets-{accountId}-{region}` ECR repo — custom names via
+> `--asset-bucket` / `--container-repo`, skip with `--no-assets`; see
+> [`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap)).
+> This replaces `cdk bootstrap`, which cdkd does not require — see
+> [Prerequisites](#prerequisites).
+
+```bash
+# Bootstrap (creates S3 state bucket + asset storage — one-time setup per AWS account)
+cdkd bootstrap
+
+# List stacks in the CDK app
+cdkd list
+
+# Deploy your CDK app
+cdkd deploy
+
+# Check what would change
+cdkd diff
+
+# Tear down
+cdkd destroy
+```
+
+That's it. cdkd reads `--app` from `cdk.json` and auto-resolves the state bucket from your AWS account ID (`cdkd-state-{accountId}`). If you bootstrapped under a previous cdkd version, the legacy region-suffixed name (`cdkd-state-{accountId}-{region}`) is still picked up automatically with a deprecation warning.
+
 ## Benchmark
 
 **cdkd deploys up to 15x faster than AWS CDK (CloudFormation)** on SDK-Provider-handled stacks; the per-stack speedup widens with size and parallelism.
@@ -83,47 +124,6 @@ account: it creates everything cdkd needs, and per-region asset storage is added
 automatically on the first `cdkd deploy` into each region. Existing setups,
 legacy-mode opt-outs, and how this relates to `cdk bootstrap`: see
 [Upgrading from an earlier cdkd version](#upgrading-from-an-earlier-cdkd-version).
-
-## Installation
-
-```bash
-npm i -g @go-to-k/cdkd          # latest release
-npm i -g @go-to-k/cdkd@0.0.2    # pin to a specific version
-```
-
-The installed binary is `cdkd`.
-
-## Quick Start
-
-> **First-time setup**: cdkd requires a one-time `cdkd bootstrap` per AWS
-> account before any other command will work — it creates the S3 state
-> bucket (`cdkd-state-{accountId}`) that cdkd uses to track deployed
-> resources, plus cdkd-owned asset storage for the region
-> (by default a `cdkd-assets-{accountId}-{region}` bucket +
-> `cdkd-container-assets-{accountId}-{region}` ECR repo — custom names via
-> `--asset-bucket` / `--container-repo`, skip with `--no-assets`; see
-> [`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap)).
-> This replaces `cdk bootstrap`, which cdkd does not require — see
-> [Prerequisites](#prerequisites).
-
-```bash
-# Bootstrap (creates S3 state bucket + asset storage — one-time setup per AWS account)
-cdkd bootstrap
-
-# List stacks in the CDK app
-cdkd list
-
-# Deploy your CDK app
-cdkd deploy
-
-# Check what would change
-cdkd diff
-
-# Tear down
-cdkd destroy
-```
-
-That's it. cdkd reads `--app` from `cdk.json` and auto-resolves the state bucket from your AWS account ID (`cdkd-state-{accountId}`). If you bootstrapped under a previous cdkd version, the legacy region-suffixed name (`cdkd-state-{accountId}-{region}`) is still picked up automatically with a deprecation warning.
 
 ### Upgrading from an earlier cdkd version
 

--- a/README.md
+++ b/README.md
@@ -105,35 +105,6 @@ Distribution analysis, wait-skipping comparability (Terraform has no global `--n
 
 The full benchmark suite lives in [docs/benchmarks.md](docs/benchmarks.md): the SDK Provider path (**5.5x**, 17.0s vs 94.4s), the VPC + CloudFront + Lambda stack behind the headline **15x** (40s vs 599s with `--no-wait`), the Cloud Control API fallback path (**1.6x**), and the Terraform comparison in full detail. Reproduction scripts: [tests/benchmark](tests/benchmark/README.md).
 
-## Prerequisites
-
-- **Node.js** >= 20.0.0
-- **AWS credentials with admin-equivalent permissions** for the resources being deployed. cdkd does NOT route through CloudFormation, so CDK CLI's `cdk-hnb659fds-deploy-role-*` is NOT sufficient — see [`--role-arn`](docs/cli-reference.md).
-
-AWS CDK's `cdk bootstrap` is not required. Instead, run `cdkd bootstrap` once per
-account: it creates the S3 state bucket (`cdkd-state-{accountId}`) that cdkd uses
-to track deployed resources, plus cdkd-owned asset storage (by default a
-`cdkd-assets-{accountId}-{region}` bucket + a
-`cdkd-container-assets-{accountId}-{region}` ECR repo; custom names via
-`--asset-bucket` / `--container-repo`, skip with `--no-assets`; see
-[`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap)). Per-region asset
-storage is added automatically on the first `cdkd deploy` into each region.
-Existing setups, legacy-mode opt-outs, and how this relates to `cdk bootstrap`: see
-[Upgrading from an earlier cdkd version](#upgrading-from-an-earlier-cdkd-version).
-
-### Upgrading from an earlier cdkd version
-
-**No breaking change, no manual step: just deploy.** The first `cdkd deploy` into
-each region auto-creates the cdkd-owned asset storage (interactive runs are asked
-once per region, `--yes` / CI runs create it automatically) and shows a one-time
-in-place UPDATE repointing asset references — content identical, no replacement.
-Downgrading is safe too (older binaries ignore the marker). If you bootstrapped
-under a previous cdkd version, the legacy region-suffixed state bucket name
-(`cdkd-state-{accountId}-{region}`) is still picked up automatically with a
-deprecation warning. Explicit pre-provisioning
-(`cdkd bootstrap --region <r>`), legacy-mode opt-outs, and how this relates to
-`cdk bootstrap`: see [`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap).
-
 ## Features
 
 - **Synthesis orchestration**: CDK app subprocess execution, Cloud Assembly parsing, context provider loop
@@ -195,6 +166,35 @@ deprecation warning. Explicit pre-provisioning
 For a step-by-step walkthrough of the full `cdkd deploy` pipeline (CLI
 parsing → synthesis → asset publishing → per-stack deploy), see
 [docs/architecture.md](docs/architecture.md#5-end-to-end-pipeline-walkthrough-cdkd-deploy).
+
+## Prerequisites
+
+- **Node.js** >= 20.0.0
+- **AWS credentials with admin-equivalent permissions** for the resources being deployed. cdkd does NOT route through CloudFormation, so CDK CLI's `cdk-hnb659fds-deploy-role-*` is NOT sufficient — see [`--role-arn`](docs/cli-reference.md).
+
+AWS CDK's `cdk bootstrap` is not required. Instead, run `cdkd bootstrap` once per
+account: it creates the S3 state bucket (`cdkd-state-{accountId}`) that cdkd uses
+to track deployed resources, plus cdkd-owned asset storage (by default a
+`cdkd-assets-{accountId}-{region}` bucket + a
+`cdkd-container-assets-{accountId}-{region}` ECR repo; custom names via
+`--asset-bucket` / `--container-repo`, skip with `--no-assets`; see
+[`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap)). Per-region asset
+storage is added automatically on the first `cdkd deploy` into each region.
+Existing setups, legacy-mode opt-outs, and how this relates to `cdk bootstrap`: see
+[Upgrading from an earlier cdkd version](#upgrading-from-an-earlier-cdkd-version).
+
+### Upgrading from an earlier cdkd version
+
+**No breaking change, no manual step: just deploy.** The first `cdkd deploy` into
+each region auto-creates the cdkd-owned asset storage (interactive runs are asked
+once per region, `--yes` / CI runs create it automatically) and shows a one-time
+in-place UPDATE repointing asset references — content identical, no replacement.
+Downgrading is safe too (older binaries ignore the marker). If you bootstrapped
+under a previous cdkd version, the legacy region-suffixed state bucket name
+(`cdkd-state-{accountId}-{region}`) is still picked up automatically with a
+deprecation warning. Explicit pre-provisioning
+(`cdkd bootstrap --region <r>`), legacy-mode opt-outs, and how this relates to
+`cdk bootstrap`: see [`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -31,16 +31,9 @@ The installed binary is `cdkd`.
 
 ## Quick Start
 
-> **First-time setup**: cdkd requires a one-time `cdkd bootstrap` per AWS
-> account before any other command will work — it creates the S3 state
-> bucket (`cdkd-state-{accountId}`) that cdkd uses to track deployed
-> resources, plus cdkd-owned asset storage for the region
-> (by default a `cdkd-assets-{accountId}-{region}` bucket +
-> `cdkd-container-assets-{accountId}-{region}` ECR repo — custom names via
-> `--asset-bucket` / `--container-repo`, skip with `--no-assets`; see
-> [`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap)).
-> This replaces `cdk bootstrap`, which cdkd does not require — see
-> [Prerequisites](#prerequisites).
+> **First-time setup**: run `cdkd bootstrap` once per AWS account before any
+> other command; it replaces `cdk bootstrap`, which cdkd does not require
+> (details in [Prerequisites](#prerequisites)).
 
 ```bash
 # Bootstrap (creates S3 state bucket + asset storage — one-time setup per AWS account)
@@ -120,9 +113,14 @@ The full benchmark suite lives in [docs/benchmarks.md](docs/benchmarks.md): the 
 - **AWS credentials with admin-equivalent permissions** for the resources being deployed. cdkd does NOT route through CloudFormation, so CDK CLI's `cdk-hnb659fds-deploy-role-*` is NOT sufficient — see [`--role-arn`](docs/cli-reference.md).
 
 AWS CDK's `cdk bootstrap` is not required. Instead, run `cdkd bootstrap` once per
-account: it creates everything cdkd needs, and per-region asset storage is added
-automatically on the first `cdkd deploy` into each region. Existing setups,
-legacy-mode opt-outs, and how this relates to `cdk bootstrap`: see
+account: it creates the S3 state bucket (`cdkd-state-{accountId}`) that cdkd uses
+to track deployed resources, plus cdkd-owned asset storage (by default a
+`cdkd-assets-{accountId}-{region}` bucket + a
+`cdkd-container-assets-{accountId}-{region}` ECR repo; custom names via
+`--asset-bucket` / `--container-repo`, skip with `--no-assets`; see
+[`cdkd bootstrap`](docs/cli-reference.md#cdkd-bootstrap)). Per-region asset
+storage is added automatically on the first `cdkd deploy` into each region.
+Existing setups, legacy-mode opt-outs, and how this relates to `cdk bootstrap`: see
 [Upgrading from an earlier cdkd version](#upgrading-from-an-earlier-cdkd-version).
 
 ### Upgrading from an earlier cdkd version

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AW
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)
 
-**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration and local execution; use the AWS CDK CLI in production for full CloudFormation tooling. `cdkd local` runs your functions, APIs, and ECS tasks on your machine, with env vars, secrets, and resource references resolved from your deployed stack instead of hand-written `.env` files (see [Local execution](#local-execution)). Install cdkd alongside an existing `cdk deploy` workflow: no migration needed. Bidirectional migration is also supported: [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation when ready.
+**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration and local execution; use the AWS CDK CLI in production for full CloudFormation tooling. Install cdkd alongside an existing `cdk deploy` workflow: no migration needed. Bidirectional migration is also supported: [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation when ready.
 
 **A natural fit for AI-driven development.** AI coding agents iterate in tight spin-up / tear-down loops — and cdkd keeps each turn short, with fast deploys and an equally fast `cdkd destroy` that deletes via direct SDK calls instead of polling a CloudFormation stack-delete.
+
+**Local execution from your deployed stack.** `cdkd local` runs your functions, APIs, and ECS tasks on your machine, with env vars, secrets, and resource references resolved from real deployed state instead of hand-written `.env` files (see [Local execution](#local-execution)).
 
 > [!IMPORTANT]
 > cdkd is for dev/test workflows only — early in development, not yet production-ready.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AW
 
 - **Drop-in CDK compatible**: your existing CDK app code runs as-is; just replace `cdk deploy` with `cdkd deploy`.
 - **Up to 15x faster deploys**: direct SDK calls, aggressive parallelization, and `--no-wait` to skip slow stabilization waits; faster than Terraform and CloudFormation Express mode too (see [Benchmark](#benchmark)).
-- **Local execution from your deployed stack**: run your Lambdas, APIs, and ECS tasks on your machine, with env vars, secrets, and resource references resolved from real deployed state instead of hand-written `.env` files (see [Local execution](#local-execution)).
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)
 
-**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration and local execution; use the AWS CDK CLI in production for full CloudFormation tooling. Install cdkd alongside an existing `cdk deploy` workflow: no migration needed. Bidirectional migration is also supported: [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation when ready.
+**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration and local execution; use the AWS CDK CLI in production for full CloudFormation tooling. `cdkd local` runs your functions, APIs, and ECS tasks on your machine, with env vars, secrets, and resource references resolved from your deployed stack instead of hand-written `.env` files (see [Local execution](#local-execution)). Install cdkd alongside an existing `cdk deploy` workflow: no migration needed. Bidirectional migration is also supported: [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation when ready.
 
 **A natural fit for AI-driven development.** AI coding agents iterate in tight spin-up / tear-down loops — and cdkd keeps each turn short, with fast deploys and an equally fast `cdkd destroy` that deletes via direct SDK calls instead of polling a CloudFormation stack-delete.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Drop-in CDK CLI for existing CDK apps — up to 15x faster deploys via direct AW
 
 ![cdk deploy vs cdkd deploy — side-by-side, 35s recording, real AWS deploy. cdkd finishes while cdk is still creating its CloudFormation changeset.](assets/cdk-vs-cdkd.gif)
 
-**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration; use the AWS CDK CLI in production for full CloudFormation tooling. Install cdkd alongside an existing `cdk deploy` workflow: no migration needed. Bidirectional migration is also supported: [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation when ready.
+**cdkd complements the AWS CDK CLI rather than replacing it.** Use cdkd in dev/test for rapid iteration; use the AWS CDK CLI in production for full CloudFormation tooling. Install cdkd alongside an existing `cdk deploy` workflow (no migration needed), and [import](#importing-existing-resources) into cdkd or [export](#exporting-a-stack-back-to-cloudformation) back to CloudFormation anytime.
 
 **A natural fit for AI-driven development.** AI coding agents iterate in tight spin-up / tear-down loops — and cdkd keeps each turn short, with fast deploys and an equally fast `cdkd destroy` that deletes via direct SDK calls instead of polling a CloudFormation stack-delete.
 


### PR DESCRIPTION
## Summary

- Fold the standalone "Faster than Terraform and CloudFormation Express mode" tagline bullet into the "Up to 15x faster deploys" bullet as a trailing clause, bolded (`**faster than Terraform and CloudFormation Express mode**`) so the claim survives bold-only skimming. The two bullets overlapped (both are speed claims); the full tables with the tie framing remain in the Benchmark section.
- The intro bullet list is now two bullets (drop-in compatible + 15x faster), keeping the first screen a single-story speed pitch: tagline sentence, two bullets, benchmark gif. An intermediate revision tried a third "Local execution from your deployed stack" bullet; it was dropped because even with a deployed-anchored label (which fixes the #1077 LocalStack-style misreading), a local-execution bullet dilutes the speed pitch with an off-theme value prop.
- Local execution instead gets its own bold-lead intro paragraph ("**Local execution from your deployed stack.**") after the "A natural fit for AI-driven development" paragraph, matching the style of the surrounding paragraphs (one value prop each: positioning / AI fit / local execution). It carries the concrete hook: `cdkd local` runs functions, APIs, and ECS tasks locally and "can resolve" env vars, secrets, and resource references from the real deployed stack: no hand-written `.env` files, no hand-seeded test data. The capability framing ("can resolve") is deliberate: deployed-state resolution is opt-in via `--from-state` / `--from-cfn-stack` (bare commands drop intrinsic values with a per-key warning), so the intro must not present it as default behavior; the flag detail stays in the Local execution section. Below the gif the real-deploy context is already established, so neither the misreading nor the dilution concern applies.
- The complements paragraph drops its now-redundant "and local execution" mention ("Use cdkd in dev/test for rapid iteration"); the dedicated paragraph below is local execution's single intro home.
- The complements paragraph's install/migration tail is tightened: "Install cdkd alongside an existing `cdk deploy` workflow: no migration needed. You can also import existing stacks into cdkd or export back to CloudFormation anytime." This removes the "no migration needed. Bidirectional migration is also supported" back-to-back repetition of "migration", and the "You can also" framing keeps import/export clearly optional so it cannot be read as part of the install flow (which would contradict "no migration needed"). Both links and the reversibility message are kept.

- Section reorder: Installation and Quick Start move above Benchmark. The intro now carries the speed claims (bolded 15x + Terraform/Express clauses) and the gif, so the "numbers above the fold" goal that put Benchmark first in #622 is satisfied by the intro itself; a convinced reader's next question is "how do I try it", and the bullet's Benchmark link serves skeptics. Prerequisites (Node/credentials notes do not earn top placement) moves further down to sit directly above Usage, opening the reference part of the doc, and the "Upgrading from an earlier cdkd version" subsection moves out of Quick Start into Prerequisites as lower-importance reference material. Final order: intro / Installation / Quick Start / Benchmark / Features / How it works / Prerequisites / Usage. Pure moves, all anchors intact (the Quick Start callout's Prerequisites link is position-independent).
- The Quick Start "First-time setup" callout shrinks to one sentence (run `cdkd bootstrap` once per account; replaces `cdk bootstrap`; details in Prerequisites). The bucket/ECR names and `--asset-bucket` / `--container-repo` / `--no-assets` detail move into the existing Prerequisites bootstrap paragraph, which previously said only "creates everything cdkd needs". Quick Start stays a bare command sequence; Prerequisites is the reference home for bootstrap internals.
- The Quick Start closer paragraph ("That's it. cdkd reads `--app` from `cdk.json`...") is removed entirely: the drop-in bullet already promises zero extra configuration, the flag-less command list demonstrates it, and the state-bucket details live in Prerequisites / State Management. Its legacy region-suffixed state-bucket fallback sentence moves into the "Upgrading from an earlier cdkd version" subsection, where the rest of the old-version compatibility notes live. Quick Start is now just the one-line bootstrap callout plus the command sequence.

## Test plan

- [x] Unit tests pass (502 files, 8400 tests)
- [x] Typecheck / lint / build pass
- [x] Link anchors verified: `#benchmark` and `#local-execution` headings exist
- [x] Claims cross-checked against the Local execution section (`--from-state` / `--from-cfn-stack` deployed-state resolution) and the Benchmark section (Express "up to 9x" heading, Terraform tables + tie framing retained)
- [x] Documentation-only change, no code touched
