### PR TITLE
docs(readme): add --no-wait / --full-wait examples to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ cdkd list
 # Deploy your CDK app
 cdkd deploy
 
+# Deploy at maximum speed: skip slow stabilization waits
+cdkd deploy --no-wait
+
+# Deploy with CloudFormation-parity completion waits
+cdkd deploy --full-wait
+
 # Check what would change
 cdkd diff
 


### PR DESCRIPTION
## Summary

- Add `cdkd deploy --no-wait` and `cdkd deploy --full-wait` entries to the Quick Start command sequence, right after the plain `cdkd deploy`. `--no-wait` is cdkd's signature flag (the tagline bullet and the benchmark tables both lead with it), so the first-run command list should show it; `--full-wait` completes the picture as the opposite end of the wait spectrum.
- Comment wording mirrors the "`--no-wait` / `--full-wait`: choose what \"done\" means" section ("skip slow stabilization waits" / "CloudFormation-parity completion waits"), which remains the reference for the semantics.
- Deliberately NOT added: `cdkd drift` / `cdkd orphan` examples. Quick Start stays the minimal first-run loop (bootstrap, list, deploy, diff, destroy); drift and orphan are situational operations whose home is the Usage section and their own dedicated sections. The wait flags earn Quick Start placement because they are the product's core speed/"done" trade-off, not merely popular commands.

## Test plan

- [x] Documentation-only change (6 added lines in one code block), no code touched
- [x] Comment wording cross-checked against the wait-semantics section in this README and docs/cli-reference.md
