### PR TITLE
test(integ): 0801 regression sweep — 30 tests re-run, all PASS (ledger update)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -60,7 +60,7 @@ custom-resource-getatt-data	2026-07-20T14:59:39Z	PASS	63	verify.sh	CR Data GetAt
 custom-resource-provider	2026-07-24T08:31:58Z	PASS	480	standard	cross-region us-west-2 vs us-east-1 bucket (issue #1195 fix + hardening live-verified); 17 res, destroy 0 err 0 orphan
 data-analytics	2026-07-21T18:30:46Z	PASS	50	verify.sh	rc ok, orph clean
 data-pipeline	2026-07-24T10:53:59Z	PASS	47	standard	0724b sweep staleness; 7 del 0 err 0 orphans
-deep-getatt-chains	2026-07-20T08:10:49Z	PASS	66	verify.sh	rc ok, orph clean
+deep-getatt-chains	2026-08-01T10:07:21Z	PASS	53	verify.sh	0801 regression sweep; SDK+CC chain ok, 0 orphans
 deletion-ordering-complex	2026-07-26T20:00:52Z	PASS	187	verify.sh	0727b sweep-b13 staleness re-run (rc=0); account clean
 deletion-policy-retain	2026-07-21T07:21:45Z	PASS	29	verify.sh	retain honored, manual cleanup ok, 0 orphans
 deployment-events	2026-07-26T20:00:52Z	PASS	45	verify.sh	0727b sweep-b13 staleness re-run (rc=0); account clean
@@ -76,8 +76,8 @@ dsql	2026-07-30T18:11:24Z	PASS	540	verify.sh	4-phase incl. destroy --remove-prot
 dynamodb-autoscaling	2026-07-21T14:33:57Z	PASS	77	verify.sh	rc ok, orph clean
 dynamodb-globaltable	2026-07-21T05:21:32Z	PASS	237	verify.sh	rc ok, orph clean
 dynamodb-gsi-update	2026-07-20T08:09:23Z	PASS	579	verify.sh	rc ok, orph clean
-dynamodb-ondemand	2026-07-20T07:59:21Z	PASS	93	verify.sh	rc ok, orph clean
-dynamodb-sse	2026-07-20T07:04:47Z	PASS	150	verify.sh	capture-form sweep sample (#1120): strict captures + gone_probe branch live-verified; 0 orphans
+dynamodb-ondemand	2026-08-01T10:07:21Z	PASS	81	verify.sh	0801 regression sweep; ondemand+policy+kinesis backfills ok, 0 orphans
+dynamodb-sse	2026-08-01T10:07:21Z	PASS	40	verify.sh	0801 regression sweep; SSE mapping ok, 0 orphans
 dynamodb-stream-filter	2026-07-21T18:08:16Z	PASS	62	verify.sh	rc ok, orph clean
 dynamodb-streams	2026-07-20T17:40:13Z	PASS	86	verify.sh	DDB streams WarmThroughput+ESM+StreamSpec UPDATE, 10 res clean
 dynamodb-tableclass-switch	2026-07-26T19:36:49Z	PASS	62	verify.sh	0727b sweep-b11 staleness re-run (rc=0); account clean
@@ -112,7 +112,7 @@ fsx-openzfs	2026-07-19T16:00:39Z	PASS	1380	verify.sh	re-run after review fixes; 
 fsx-windows	2026-07-20T02:35:13Z	PASS	5460	verify.sh	issue #1088 Windows AD-joined: 7 phases, DiskIopsConfiguration read back, ENIs released 192s; 11 deleted 0 errors 0 orphans
 full-stack-demo	2026-07-26T18:36:31Z	PASS	41	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 gc-custom-asset-names	2026-07-31T06:41:35Z	PASS	120	verify.sh	TTL-refresh sweep re-run in ca-central-1 (us-west-2 now marker-owned); zero residue
-getatt-fallback-guard	2026-07-20T05:59:44Z	PASS	300	verify.sh	4-phase incl. strict-output state-persistence guarantee (#1111 blocker fix); 0 orphans
+getatt-fallback-guard	2026-08-01T10:07:21Z	PASS	84	verify.sh	0801 regression sweep; strict-getatt paths ok, 0 orphans
 getstackoutput-crossregion	2026-07-26T19:05:27Z	PASS	79	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 glue-securityconfig-replace	2026-07-26T18:20:27Z	PASS	59	verify.sh	0727b sweep-b3 staleness re-run (rc=0); account clean
 glue-update-hardening	2026-07-26T20:00:52Z	PASS	75	verify.sh	0727b sweep-b13 staleness re-run (rc=0); account clean
@@ -241,7 +241,7 @@ servicediscovery	2026-08-01T09:42:37Z	PASS	106	verify.sh	0801 regression sweep; 
 servicediscovery-namespaces	2026-08-01T09:36:05Z	PASS	108	verify.sh	0801 regression sweep; Http+PublicDns namespaces ok, 0 orphans
 ses-identity	2026-07-21T14:41:07Z	PASS	199	verify.sh	PASS on re-run; 1st attempt hit transient 403 token-expiry (not a cdkd bug), cleaned orphan config-set
 sg-circular-dependency	2026-07-26T18:49:34Z	PASS	51	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
-sns-event-source	2026-07-20T08:12:14Z	PASS	68	verify.sh	rc ok, orph clean
+sns-event-source	2026-08-01T10:07:21Z	PASS	59	verify.sh	0801 regression sweep; e2e delivery ok, log groups swept, 0 orphans
 sns-inline-subscription	2026-07-27T11:04:52Z	PASS	53	verify.sh	issue #1267 SNS topic update wrap; 3 del 0 err
 sns-pending-subscription	2026-07-30T12:40:16Z	PASS	22	verify.sh	issue #1301 re-run after review fixes, clean
 sns-sqs-event	2026-07-26T17:01:09Z	PASS	78	verify.sh	#1160 sqs SSE removal phase 2 verified; destroy 20/0 errors, 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -22,7 +22,7 @@ asset-bootstrap	2026-08-01T09:21:06Z	PASS	99	verify.sh	0801 regression sweep; us
 asset-migration	2026-08-01T09:26:36Z	PASS	292	verify.sh	0801 regression sweep; eu-west-1 (marker-free pick); nested+ECR legs ok, 0 orphans
 aws-custom-resource	2026-07-21T05:26:32Z	PASS	82	verify.sh	rc ok, orph clean
 backup	2026-07-26T20:07:41Z	PASS	67	verify.sh	0727b sweep-b14 staleness re-run (rc=0); account clean
-basic	2026-07-20T04:38:04Z	PASS	83	standard	rc 0/0, 0 orphans; validates buildProgram entry-point refactor (#1097)
+basic	2026-08-01T10:00:06Z	PASS	81	standard	0801 regression sweep; 2 del/0 err, 0 orphans
 batch	2026-07-26T18:43:33Z	PASS	89	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 bedrock-agentcore	2026-07-24T04:22:29Z	PASS	42	standard	import() attr enrich (#1188); GetAgentRuntime live-probe confirms field shape; 6 del 0 err
 bench-ccapi	2026-07-26T18:43:33Z	PASS	89	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
@@ -33,8 +33,8 @@ bucket-deployment	2026-07-21T18:02:21Z	PASS	125	verify.sh	rc ok, orph clean
 budgets	2026-08-01T09:36:05Z	PASS	42	verify.sh	0801 regression sweep; create/update/destroy ok, 0 orphans
 cache-streaming	2026-07-21T10:54:20Z	PASS	497	verify.sh	converted to verify.sh; GetAtt redis endpoint ok, 0 orphans
 cc-api-fallback	2026-07-27T05:30:42Z	PASS	65	verify.sh	1252 fix live-verify (CC delete path incl. new integ-destroy scope); 0 errors 0 orphans
-cc-api-fallback-transitions	2026-07-20T02:19:31Z	PASS	140	verify.sh	CC transition/override #634 verified, 2 stacks destroy clean
-cc-getatt-readback	2026-07-20T03:06:02Z	PASS	260	verify.sh	generic sparse read-back live-verified (#1105); destroy 8/8, 0 orphans
+cc-api-fallback-transitions	2026-08-01T10:00:06Z	PASS	123	verify.sh	0801 regression sweep; #634 items 3+4 ok, 0 orphans
+cc-getatt-readback	2026-08-01T10:00:06Z	PASS	90	verify.sh	0801 regression sweep; CC GetAtt read-back ok, 0 orphans
 cc-protection-flip	2026-07-31T03:56:21Z	PASS	1250	verify.sh	5 CC types incl. RDS/DocDB GlobalCluster shells (#1315); orph clean
 cc-protection-flip-eks	2026-07-31T04:30:02Z	PASS	2300	verify.sh	EKS blocked-destroy + --remove-protection flip (#1315); orph clean
 ci-cd	2026-07-21T18:23:00Z	PASS	55	verify.sh	rc ok, orph clean
@@ -101,7 +101,7 @@ eventbridge-api-destination	2026-07-21T14:48:06Z	PASS	70	verify.sh	rc ok, orph c
 eventbridge-archive	2026-07-31T06:21:38Z	PASS	54	verify.sh	TTL-refresh sweep re-run; 3 phases clean, orph clean
 eventbridge-input-transformer	2026-07-20T08:18:46Z	PASS	63	verify.sh	hardened P2 propagation race; passes
 eventbridge-pipes	2026-07-26T19:36:49Z	PASS	177	verify.sh	0727b sweep-b11 staleness re-run (rc=0); account clean
-eventbridge-scheduler	2026-07-20T03:07:51Z	PASS	150	verify.sh	pattern-2 sweep sample: assert_gone/gone_probe/head-object idioms live-verified; 0 orphans
+eventbridge-scheduler	2026-08-01T10:00:06Z	PASS	46	verify.sh	0801 regression sweep; ok, 0 orphans
 eventsourcemapping-race	2026-07-27T11:04:52Z	PASS	80	verify.sh	issue #1267 Lambda ESM update wrap; 5 del 0 err; swept 1 auto-created log group
 export	2026-07-30T12:24:41Z	PASS	480	verify.sh	regression sweep post-#1289/#1294; full CFn IMPORT round-trip clean
 export-nested-stack	2026-07-21T08:39:22Z	PASS	327	verify.sh	export->CFn nested adopt, CFn delete clean, 0 orphans
@@ -208,7 +208,7 @@ rds-aurora	2026-07-25T06:38:38Z	PASS	2085	verify.sh	1160 removal reset: cluster 
 rds-dbinstance-backfill	2026-07-25T07:01:56Z	PASS	725	verify.sh	re-run after 1222 review fixes; destroy 11/0
 rds-full-stack	2026-07-21T08:03:48Z	PASS	2346	verify.sh	15 deleted 0 orphans, RDS slow-delete floor ok
 recreate-mixed-direction	2026-07-21T05:15:35Z	PASS	100	verify.sh	rc ok, orph clean
-recreate-via-cc-api	2026-07-20T02:21:54Z	PASS	106	verify.sh	SDK->CC mid-life migration + S3 probe, destroy clean
+recreate-via-cc-api	2026-08-01T10:00:06Z	PASS	93	verify.sh	0801 regression sweep; SDK->CC mid-life migration ok, 0 orphans
 recreate-via-sdk-provider	2026-07-21T05:13:38Z	PASS	86	verify.sh	rc ok, orph clean
 redshift-cluster-getatt	2026-07-20T14:58:06Z	PASS	330	verify.sh	CC GetAtt Endpoint real hostname, 0 orphans
 remove-protection	2026-07-30T18:35:25Z	PASS	1300	verify.sh	broad run for #1312 destroy-runner touch; 12 del/0 err, orph clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -6,7 +6,7 @@
 #   vp run integ-ledger-normalize
 # CI enforces this; a non-normalized file fails check-build-test.
 acm-certificate	2026-07-27T16:40:50Z	PASS	23	verify.sh	issue #1272 ACM pass-through guard; 1 del 0 err
-agentcore-tools	2026-07-17T12:05:03Z	PASS	180	verify.sh	3 phases clean; adopt-only singletons + evaluator CRUD; name regex fix (no hyphens)
+agentcore-tools	2026-08-01T09:36:05Z	PASS	58	verify.sh	0801 regression sweep; 3 phases ok, 0 orphans
 alb	2026-07-27T16:40:50Z	PASS	64	verify.sh	issue #1270 ELBv2 + EC2 update wrap; 16 del 0 err
 alb-advanced	2026-07-28T02:54:42Z	PASS	206	standard	ALB active wait 156s (#1274), destroy 17/0 errors
 api-cognito	2026-07-26T18:49:34Z	PASS	75	standard	0727b sweep-b6 staleness re-run (rc=0); account clean
@@ -30,7 +30,7 @@ bench-cdk-sample	2026-07-31T06:06:20Z	PASS	373	standard	regression run post-#131
 bench-sdk	2026-07-26T18:43:33Z	PASS	33	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 bootstrap-free-region	2026-07-31T06:23:42Z	PASS	78	verify.sh	TTL-refresh sweep re-run in ca-central-1; marker+bucket swept, orph clean
 bucket-deployment	2026-07-21T18:02:21Z	PASS	125	verify.sh	rc ok, orph clean
-budgets	2026-07-17T11:58:00Z	PASS	60	verify.sh	new fixture #1041 re-run post-rebase (idempotent reconciler, verbatim name); 3 phases clean, 0 orphans
+budgets	2026-08-01T09:36:05Z	PASS	42	verify.sh	0801 regression sweep; create/update/destroy ok, 0 orphans
 cache-streaming	2026-07-21T10:54:20Z	PASS	497	verify.sh	converted to verify.sh; GetAtt redis endpoint ok, 0 orphans
 cc-api-fallback	2026-07-27T05:30:42Z	PASS	65	verify.sh	1252 fix live-verify (CC delete path incl. new integ-destroy scope); 0 errors 0 orphans
 cc-api-fallback-transitions	2026-07-20T02:19:31Z	PASS	140	verify.sh	CC transition/override #634 verified, 2 stacks destroy clean
@@ -41,7 +41,7 @@ ci-cd	2026-07-21T18:23:00Z	PASS	55	verify.sh	rc ok, orph clean
 cloudfront-function-url	2026-07-31T06:11:38Z	PASS	209	verify.sh	regression run post-#1311/#1318; fire-and-forget create + delete-wait path clean; 7 del/0 err, 0 orphans
 cloudwatch	2026-07-26T20:00:52Z	PASS	55	standard	0727b sweep-b13 staleness re-run (rc=0); account clean
 cloudwatch-anomaly-detector	2026-07-30T16:41:15Z	PASS	35	verify.sh	final run post review fixes: GetAtt Id + phys-id stability asserted; clean
-codecommit	2026-07-18T19:54:34Z	PASS		verify.sh	Code seed+SNS trigger+rename+drift, destroy 0 err 0 orph (re-run post review-nits)
+codecommit	2026-08-01T09:36:05Z	PASS	83	verify.sh	0801 regression sweep; 3 phases ok, 0 orphans
 codedeploy-lambda-deployment-group	2026-07-26T19:45:58Z	PASS	109	verify.sh	re-run after version-agnostic fixture fix; live-verified, account clean (remnant-warning follow-up: issue #1252)
 cognito	2026-07-21T14:27:28Z	PASS	60	verify.sh	rc ok, orph clean
 cognito-custom-attribute-add	2026-07-26T19:05:27Z	PASS	57	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
@@ -70,7 +70,7 @@ dlm-lifecycle-policy	2026-07-27T09:43:47Z	PASS	140	verify.sh	1160 removal phase 
 docdb-neptune	2026-07-27T06:16:35Z	PASS	1560	verify.sh	#1160 neptune+docdb removal steps 3b-3d verified; destroy w/o remove-protection 14/0 errors, 0 orphans
 docker-image-asset	2026-07-24T04:58:55Z	PASS	45	verify.sh	lazy ECR login: warm-cred no-login + logged-out self-heal both PASS; destroy 0 err 0 orph
 drift-revert	2026-07-31T06:15:02Z	PASS	90	verify.sh	regression run post-#1313/#1317/#1321 destroy-runner touches; drift inject+revert ok, 13 del/0 err, CR log group swept
-drift-revert-arrays	2026-07-19T17:35:30Z	PASS	114	verify.sh	PR #1100 post-rebase re-verify; benign-reorder no-false-positive + real drift revert; 16 del 0 err 0 orphans
+drift-revert-arrays	2026-08-01T09:36:05Z	PASS	110	verify.sh	0801 regression sweep; 16 del/0 err, 0 orphans
 drift-revert-vpc	2026-07-30T16:18:56Z	PASS	480	verify.sh	post-rebase final for PR #1307 (#1299/#1300): 6/6 reverted, 21 del 0 err 0 orphans
 dsql	2026-07-30T18:11:24Z	PASS	540	verify.sh	4-phase incl. destroy --remove-protection CC flip (#1312); orph clean
 dynamodb-autoscaling	2026-07-21T14:33:57Z	PASS	77	verify.sh	rc ok, orph clean
@@ -238,7 +238,7 @@ secrets-dynamic-ref	2026-07-26T17:14:50Z	PASS	72	verify.sh	#1160 secretsmanager 
 secrets-rotation-schedule	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 serverless-api	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 servicediscovery	2026-07-19T19:00:29Z	PASS	111	verify.sh	rc ok, 3 deleted, orph clean
-servicediscovery-namespaces	2026-07-17T12:12:19Z	PASS	114	verify.sh	re-run post review fixes (import kind filter, PrivateDns tag sync, resolver HostedZoneId); clean, 0 orphans
+servicediscovery-namespaces	2026-08-01T09:36:05Z	PASS	108	verify.sh	0801 regression sweep; Http+PublicDns namespaces ok, 0 orphans
 ses-identity	2026-07-21T14:41:07Z	PASS	199	verify.sh	PASS on re-run; 1st attempt hit transient 403 token-expiry (not a cdkd bug), cleaned orphan config-set
 sg-circular-dependency	2026-07-26T18:49:34Z	PASS	51	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
 sns-event-source	2026-07-20T08:12:14Z	PASS	68	verify.sh	rc ok, orph clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -17,9 +17,9 @@ apigw-stage-throttling	2026-07-26T19:36:49Z	PASS	79	verify.sh	0727b sweep-b11 st
 apigw-usage-plan-key	2026-07-26T19:16:39Z	PASS	84	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 appconfig	2026-07-21T18:18:22Z	PASS	75	verify.sh	rc ok, orph clean
 appsync	2026-07-26T18:43:33Z	PASS	33	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
-asset-auto-create	2026-07-17T06:52:34Z	PASS	150	verify.sh	ca-central-1; own-marker guard + prerun-scoped cleanup (issue-1052); 0 orphans
-asset-bootstrap	2026-07-17T07:11:51Z	PASS	120	verify.sh	us-west-2; own-marker guard + no-auto-asset-storage phase-1 + state-info cross-region fix (1054); 0 orphans
-asset-migration	2026-07-17T06:59:52Z	PASS	780	verify.sh	us-west-2; own-marker guard + no-auto-asset-storage phase-1 fix (issue-1052); nested+ECR legs; 0 orphans
+asset-auto-create	2026-08-01T09:18:54Z	PASS	143	verify.sh	0801 regression sweep; ca-central-1 auto-create+opt-out ok, 0 orphans
+asset-bootstrap	2026-08-01T09:21:06Z	PASS	99	verify.sh	0801 regression sweep; us-east-2 (us-west-2 now carries a foreign marker); 4 phases ok, 0 orphans
+asset-migration	2026-08-01T09:26:36Z	PASS	292	verify.sh	0801 regression sweep; eu-west-1 (marker-free pick); nested+ECR legs ok, 0 orphans
 aws-custom-resource	2026-07-21T05:26:32Z	PASS	82	verify.sh	rc ok, orph clean
 backup	2026-07-26T20:07:41Z	PASS	67	verify.sh	0727b sweep-b14 staleness re-run (rc=0); account clean
 basic	2026-07-20T04:38:04Z	PASS	83	standard	rc 0/0, 0 orphans; validates buildProgram entry-point refactor (#1097)
@@ -135,7 +135,7 @@ intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 stale
 kinesis-esm-filter	2026-07-24T10:29:51Z	PASS	73	verify.sh	0724 P0 sweep: lambda-eventsource-provider #1194 coverage; FilterCriteria verified; 5 del 0 err
 kinesis-stream-mode-switch	2026-07-26T18:57:55Z	PASS	73	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda	2026-07-31T07:44:44Z	PASS	170	verify.sh	broad run for #1329 resolver touch; 9 del/0 err, orph clean
+lambda	2026-08-01T09:14:31Z	PASS	75	verify.sh	0801 regression sweep post-#1331 resolver touch; 9 del/0 err, orph clean
 lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-arch-switch	2026-07-26T19:25:15Z	PASS	63	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 lambda-config-field-removal	2026-07-22T08:19:38Z	PASS	140	verify.sh	issue #1158 post-rebase re-verify; 6-field removal reset + destroy clean
@@ -203,7 +203,7 @@ orphan-resource	2026-07-26T18:04:53Z	PASS	38	standard	0727b sweep-b1 staleness r
 outputs-only-export	2026-07-26T20:00:52Z	PASS	80	verify.sh	0727b sweep-b13 staleness re-run (rc=0); account clean
 parameters	2026-07-26T18:04:53Z	PASS	24	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 propagation-races-2	2026-07-26T18:57:55Z	PASS	169	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
-raw-cfn-conditions-params	2026-07-17T05:02:58Z	PASS	76	verify.sh	re-run with #1032 fix: PASS + destroy param-dep warn gone (live verify)
+raw-cfn-conditions-params	2026-08-01T09:11:18Z	PASS	64	verify.sh	0801 regression sweep; 5 phases ok, 2 del/0 err, orph clean (foreign Bughunt state left untouched)
 rds-aurora	2026-07-25T06:38:38Z	PASS	2085	verify.sh	1160 removal reset: cluster DeletionProtection+IAMAuth reset live-verified, destroy 23/0
 rds-dbinstance-backfill	2026-07-25T07:01:56Z	PASS	725	verify.sh	re-run after 1222 review fixes; destroy 11/0
 rds-full-stack	2026-07-21T08:03:48Z	PASS	2346	verify.sh	15 deleted 0 orphans, RDS slow-delete floor ok

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -54,7 +54,7 @@ conditions	2026-07-21T13:08:15Z	PASS	25	verify.sh	converted; Fn::If suppressed p
 conditions-and-if	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 conditions-update-2	2026-07-26T19:05:27Z	PASS	83	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 context-test	2026-07-26T18:43:33Z	PASS	24	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
-cross-region-state-bucket	2026-07-19T18:57:34Z	PASS	33	verify.sh	rc ok, temp bucket removed, orph clean
+cross-region-state-bucket	2026-08-01T09:42:37Z	PASS	29	verify.sh	0801 regression sweep; cross-region bucket round-trip ok, temp bucket removed
 cross-stack-references	2026-07-19T19:57:33Z	PASS	27	standard	rc ok, 2 stacks, orph clean
 custom-resource-getatt-data	2026-07-20T14:59:39Z	PASS	63	verify.sh	CR Data GetAtt->dependent prop, 6 res clean
 custom-resource-provider	2026-07-24T08:31:58Z	PASS	480	standard	cross-region us-west-2 vs us-east-1 bucket (issue #1195 fix + hardening live-verified); 17 res, destroy 0 err 0 orphan
@@ -152,7 +152,7 @@ launchtemplate-asg-inplace	2026-07-26T13:03:26Z	PASS	90	verify.sh	1225 classific
 legacy-bucket-name-fallback	2026-07-26T18:10:48Z	PASS	22	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
 legacy-state-migration	2026-07-26T18:10:48Z	PASS	23	standard	0727b sweep-b2 staleness re-run (rc=0); account clean
 local-ecs-service-connect	2026-07-26T20:40:20Z	PASS	23	verify.sh	0727b sweep-L6 staleness re-run (rc=0); docker + account clean
-local-invoke	2026-07-20T03:08:51Z	PASS	120	verify.sh	integ-local refresh for pattern-2 sweep (local-start-alb-from-state probe change); docker sweep clean
+local-invoke	2026-08-01T09:42:37Z	PASS	22	verify.sh	0801 regression sweep; 5 tests ok, docker clean
 local-invoke-agentcore	2026-07-26T20:40:20Z	PASS	97	verify.sh	0727b sweep-L6 staleness re-run (rc=0); docker + account clean
 local-invoke-agentcore-from-state	2026-07-26T20:40:20Z	PASS	86	verify.sh	0727b sweep-L6 staleness re-run (rc=0); docker + account clean
 local-invoke-buildkit	2026-07-26T20:35:19Z	PASS	18	verify.sh	0727b sweep-L5 staleness re-run (rc=0); docker + account clean
@@ -174,10 +174,10 @@ local-run-task-multi-container	2026-07-26T20:18:09Z	PASS	12	verify.sh	0727b swee
 local-start-agentcore	2026-07-26T20:40:20Z	PASS	13	verify.sh	0727b sweep-L6 staleness re-run (rc=0); docker + account clean
 local-start-alb	2026-07-26T20:18:09Z	PASS	22	verify.sh	0727b sweep-L2 staleness re-run (rc=0); docker + account clean
 local-start-alb-from-state	2026-07-26T20:18:09Z	PASS	98	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
-local-start-api	2026-07-19T18:27:53Z	PASS	22	verify.sh	rc ok, 0 docker orphans; swept verify.sh (#1097 pattern 1)
+local-start-api	2026-08-01T09:42:37Z	PASS	17	verify.sh	0801 regression sweep; smoke ok, docker clean
 local-start-api-container	2026-07-26T20:11:51Z	PASS	11	verify.sh	0727b sweep-L1 staleness re-run (rc=0); docker + account clean
 local-start-api-rest-v1-non-proxy	2026-07-26T20:11:51Z	PASS	13	verify.sh	0727b sweep-L1 staleness re-run (rc=0); docker + account clean
-local-start-api-websocket	2026-07-19T18:46:28Z	PASS	103	verify.sh	rc ok, 0 docker orphans; validates restructured multi-line trap (#1097)
+local-start-api-websocket	2026-08-01T09:42:37Z	PASS	102	verify.sh	0801 regression sweep; ws stages + sigterm-fast ok, docker clean
 local-start-cloudfront	2026-07-26T20:40:20Z	PASS	7	verify.sh	0727b sweep-L6 staleness re-run (rc=0); docker + account clean
 local-start-service	2026-07-26T20:18:09Z	PASS	20	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
 local-start-service-watch-fast	2026-07-26T20:18:09Z	PASS	186	verify.sh	re-run after removing stale cdkl-svc network (pool overlap); docker + account clean
@@ -237,7 +237,7 @@ sdk-ccapi-crossref	2026-07-22T07:07:07Z	PASS		verify.sh	P0: CC-provider changes 
 secrets-dynamic-ref	2026-07-26T17:14:50Z	PASS	72	verify.sh	#1160 secretsmanager removal phase 2 verified; destroy 4/0 errors, 0 orphans
 secrets-rotation-schedule	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 serverless-api	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
-servicediscovery	2026-07-19T19:00:29Z	PASS	111	verify.sh	rc ok, 3 deleted, orph clean
+servicediscovery	2026-08-01T09:42:37Z	PASS	106	verify.sh	0801 regression sweep; ServiceAttributes coverage ok, 0 orphans
 servicediscovery-namespaces	2026-08-01T09:36:05Z	PASS	108	verify.sh	0801 regression sweep; Http+PublicDns namespaces ok, 0 orphans
 ses-identity	2026-07-21T14:41:07Z	PASS	199	verify.sh	PASS on re-run; 1st attempt hit transient 403 token-expiry (not a cdkd bug), cleaned orphan config-set
 sg-circular-dependency	2026-07-26T18:49:34Z	PASS	51	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -55,7 +55,7 @@ conditions-and-if	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 stalenes
 conditions-update-2	2026-07-26T19:05:27Z	PASS	83	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 context-test	2026-07-26T18:43:33Z	PASS	24	standard	0727b sweep-b5 staleness re-run (rc=0); account clean
 cross-region-state-bucket	2026-08-01T09:42:37Z	PASS	29	verify.sh	0801 regression sweep; cross-region bucket round-trip ok, temp bucket removed
-cross-stack-references	2026-07-19T19:57:33Z	PASS	27	standard	rc ok, 2 stacks, orph clean
+cross-stack-references	2026-08-01T09:51:12Z	PASS	23	standard	0801 regression sweep; 2-stack exporter/consumer deploy+destroy clean
 custom-resource-getatt-data	2026-07-20T14:59:39Z	PASS	63	verify.sh	CR Data GetAtt->dependent prop, 6 res clean
 custom-resource-provider	2026-07-24T08:31:58Z	PASS	480	standard	cross-region us-west-2 vs us-east-1 bucket (issue #1195 fix + hardening live-verified); 17 res, destroy 0 err 0 orphan
 data-analytics	2026-07-21T18:30:46Z	PASS	50	verify.sh	rc ok, orph clean
@@ -89,7 +89,7 @@ ecr	2026-07-26T18:36:31Z	PASS	85	standard	0727b sweep-b4 staleness re-run (rc=0)
 ecr-scanning	2026-07-20T17:37:23Z	PASS	56	verify.sh	ECR scanOnPush + tag add/change/untag update, clean destroy
 ecs-fargate	2026-07-30T11:54:49Z	PASS	420	verify.sh	#1280 live-test: --full-wait waiter w/ new max(600,resolved) cap ran on create+update; 23 del/0 err, orph clean
 ecs-service-update-props	2026-07-23T08:20:10Z	PASS		verify.sh	#1173 re-run after VersionConsistency norm; Phase1f + drift clean; destroy 15 del 0 err 0 orph
-efs-immutable-replacement	2026-07-19T19:05:41Z	PASS	76	verify.sh	rc ok, 1 deleted, orph clean
+efs-immutable-replacement	2026-08-01T09:51:12Z	PASS	63	verify.sh	0801 regression sweep; createOnly+stateful guard ok, 0 orphans
 efs-lambda	2026-07-26T18:36:31Z	PASS	499	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 efs-standalone	2026-07-26T18:36:31Z	PASS	148	verify.sh	0727b sweep-b4 staleness re-run (rc=0); account clean
 elasticache-replicationgroup-getatt	2026-07-20T14:51:32Z	PASS	596	verify.sh	CC GetAtt PrimaryEndPoint real hostname, 0 orphans
@@ -214,7 +214,7 @@ redshift-cluster-getatt	2026-07-20T14:58:06Z	PASS	330	verify.sh	CC GetAtt Endpoi
 remove-protection	2026-07-30T18:35:25Z	PASS	1300	verify.sh	broad run for #1312 destroy-runner touch; 12 del/0 err, orph clean
 rename-refactor	2026-07-21T14:37:30Z	PASS	107	verify.sh	new fixture; review-fix re-run; destroy 0 err 0 orph
 replacement-fanout	2026-07-21T05:17:15Z	PASS	82	verify.sh	rc ok, orph clean
-replacement-immutable-name	2026-07-19T19:03:36Z	PASS	120	verify.sh	rc ok, 7 deleted, orph clean
+replacement-immutable-name	2026-08-01T09:51:12Z	PASS	113	verify.sh	0801 regression sweep; 6 types x 3 phases ok, 0 orphans
 rollback-command	2026-07-25T05:24:26Z	PASS	130	verify.sh	#1220 echo-before-assert on R2/F2 success-expected rollbacks, destroy clean
 rollback-failure-injection	2026-07-24T10:50:16Z	PASS	368	verify.sh	0724b sweep P1: #1212 journal-after-clean-rollback coverage; 17 del 0 err 0 orphans
 rollback-sqs-cooldown	2026-07-25T05:24:26Z	PASS	180	verify.sh	#1220 echo-before-assert on steps 4/9/10, destroy clean
@@ -232,7 +232,7 @@ scheduled-task	2026-07-26T18:04:53Z	PASS	44	standard	0727b sweep-b1 staleness re
 scheduler-custom-group	2026-07-26T19:25:15Z	PASS	103	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 schema-v5-to-v6-migration	2026-07-24T10:27:22Z	PASS	61	verify.sh	0724 P0 sweep: v5->v8 transparent upgrade verified; 1 del 0 err
 schema-v6-to-v7-migration	2026-07-24T10:25:01Z	PASS	66	verify.sh	0724 P0 sweep: s3-state-backend #1196/#1203 coverage; v6->v8 transparent upgrade; 1 del 0 err
-schema-v7-to-v8-migration	2026-07-19T19:56:03Z	PASS	100	verify.sh	rc ok, transparent auto-migration, orph clean
+schema-v7-to-v8-migration	2026-08-01T09:51:12Z	PASS	92	verify.sh	0801 regression sweep; transparent auto-migration + outputReads ok, 0 orphans
 sdk-ccapi-crossref	2026-07-22T07:07:07Z	PASS		verify.sh	P0: CC-provider changes (#1135/#1109) covered; heterogeneous SDK/CC routing + bidirectional cross-ref, 4 del 0 err, state.json gone (deployments/ logs retained)
 secrets-dynamic-ref	2026-07-26T17:14:50Z	PASS	72	verify.sh	#1160 secretsmanager removal phase 2 verified; destroy 4/0 errors, 0 orphans
 secrets-rotation-schedule	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
@@ -249,7 +249,7 @@ sns-subscription-filter	2026-07-21T18:09:46Z	PASS	46	verify.sh	rc ok, orph clean
 sqs-cloudwatch	2026-07-31T07:00:20Z	PASS	75	standard	removalPolicy DESTROY fix verified: stream deleted on destroy, 0 orphans
 sqs-esm-max-concurrency	2026-07-21T14:49:55Z	PASS	85	verify.sh	rc ok, orph clean
 state-destroy	2026-07-26T18:04:53Z	PASS	25	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
-state-info-command	2026-07-19T20:01:06Z	PASS	21	standard	rc ok, state info #1055 GetBucketLocation exercised, orph clean
+state-info-command	2026-08-01T09:51:12Z	PASS	18	standard	0801 regression sweep; deploy+destroy clean, state info --json verified via CDKD_STATE_BUCKET
 stepfunctions	2026-07-21T13:08:15Z	PASS	97	verify.sh	converted; SM ACTIVE w/ auto role, async-delete poll, 0 orphans
 stepfunctions-logging	2026-07-20T17:36:15Z	PASS	117	verify.sh	SFN Express logging/tracing removal-clear, clean destroy
 stepfunctions-s3-definition	2026-07-26T19:45:58Z	PASS	43	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean


### PR DESCRIPTION
## Summary

Ledger update for a 30-test regression sweep run on 2026-08-01 against real AWS (account 531991745243), motivated by the recent merge burst (#1317, #1318, #1321, #1328, #1330, #1331). All 30 tests PASS with 0 destroy errors and 0 orphan resources.

- P0/P1 (recent-change coverage): `raw-cfn-conditions-params` (15d stale + #1331 touched parameter handling in the intrinsic resolver), `lambda` (first broad integ after the #1331 resolver change merged 6 min after the previous broad run)
- Staleness (>14d TTL): `asset-auto-create` (ca-central-1), `asset-bootstrap` (us-east-2), `asset-migration` (eu-west-1)
- Coverage hygiene (oldest-first, 12-14d): budgets, agentcore-tools, servicediscovery-namespaces, codecommit, drift-revert-arrays, local-start-api, local-start-api-websocket, local-invoke, cross-region-state-bucket, servicediscovery, replacement-immutable-name, efs-immutable-replacement, schema-v7-to-v8-migration, cross-stack-references, state-info-command, cc-api-fallback-transitions, recreate-via-cc-api, cc-getatt-readback, eventbridge-scheduler, basic, getatt-fallback-guard, dynamodb-sse, dynamodb-ondemand, deep-getatt-chains, sns-event-source

Markers refreshed by the sweep: `integ-destroy`, `integ-broad` (via `lambda`), `integ-local` (via the local trio, Docker-side sweep clean), `integ-schema-migration` (via `schema-v7-to-v8-migration`).

## Notes

- `asset-bootstrap` moved from us-west-2 (previous run region) to us-east-2 because us-west-2 now carries a cdkd bootstrap marker (dated 2026-07-24) that does not belong to this sweep; marker-free-region rule applied, the foreign marker was left untouched. `asset-migration` similarly ran in eu-west-1.
- The `state-info-command` fixture's standard flow never runs `cdkd state info` itself; verified manually this sweep (works via `CDKD_STATE_BUCKET`). Follow-up in (#1335).
- Not run (heavy, 20-90 min each, all still inside the 14d TTL): `fsx-*` x4, `emr-*` x2, plus `fsx-windows`-class long tails — candidates for a dedicated session before their TTL expires around 2026-08-03.

## Test plan

- The 30 runs themselves (deploy + verify + destroy against real AWS, per-batch orphan scans all clean)
- `vp check` / `vp run typecheck:test` / `vp run build` / `vp run test` (502 files, 8400 tests) all pass
- `vp run integ-ledger-normalize -- --check`: 259 rows, one per test, normalized
