### PR TITLE
docs(readme): drop --full-wait example from Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@ cdkd deploy
 # Deploy at maximum speed: skip slow stabilization waits
 cdkd deploy --no-wait
 
-# Deploy with CloudFormation-parity completion waits
-cdkd deploy --full-wait
-
 # Check what would change
 cdkd diff
 


### PR DESCRIPTION
## Summary
- Remove the `cdkd deploy --full-wait` example from the README Quick Start (added in #1334).
- Quick Start doesn't need it, and showing `--no-wait` and `--full-wait` side by side raises the question "so which one is the default?" for first-time readers.
- `--full-wait` remains fully documented in Features, the CLI examples section, and the dedicated "`--no-wait` / `--full-wait`: choose what \"done\" means" section, where the default semantics are explained.

## Test plan
- [x] Unit tests pass (502 files, 8400 tests)
- [x] Integration test: n/a (docs-only)
- [x] Documentation updated (this PR is the docs change; README stays internally consistent)
