### PR TITLE
test(integ): 0802 heavy-fixture TTL sweep — fsx x4 + emr x2, all PASS (ledger update)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -106,7 +106,7 @@ eventsourcemapping-race	2026-07-27T11:04:52Z	PASS	80	verify.sh	issue #1267 Lambd
 export	2026-07-30T12:24:41Z	PASS	480	verify.sh	regression sweep post-#1289/#1294; full CFn IMPORT round-trip clean
 export-nested-stack	2026-07-21T08:39:22Z	PASS	327	verify.sh	export->CFn nested adopt, CFn delete clean, 0 orphans
 fifo-sqs-event-source	2026-07-27T06:44:00Z	PASS	111	verify.sh	final-tree gate refresh for #1256; destroy 6/0 errors, 0 orphans
-fsx-lustre	2026-07-20T05:01:58Z	PASS	1140	verify.sh	PR #1114 §3b always-emit + Class 1 discriminator carve-out; deploy+update(LZ4,tags)+destroy 10 del 0 err 0 orphans
+fsx-lustre	2026-08-02T05:30:54Z	PASS	899	verify.sh	0802 heavy TTL sweep; deploy+update+destroy ok, 0 orphans, no final backup
 fsx-ontap	2026-07-20T01:29:32Z	PASS	1590	verify.sh	issue #1088 ONTAP: DiskIopsConfiguration read back from AWS (Mode+Iops), aws_query_ids hardening; 8 deleted 0 errors 0 orphans
 fsx-openzfs	2026-07-19T16:00:39Z	PASS	1380	verify.sh	re-run after review fixes; drift+observedProperties asserted; 8 deleted 0 errors 0 orphans
 fsx-windows	2026-07-20T02:35:13Z	PASS	5460	verify.sh	issue #1088 Windows AD-joined: 7 phases, DiskIopsConfiguration read back, ENIs released 192s; 11 deleted 0 errors 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -108,7 +108,7 @@ export-nested-stack	2026-07-21T08:39:22Z	PASS	327	verify.sh	export->CFn nested a
 fifo-sqs-event-source	2026-07-27T06:44:00Z	PASS	111	verify.sh	final-tree gate refresh for #1256; destroy 6/0 errors, 0 orphans
 fsx-lustre	2026-08-02T05:30:54Z	PASS	899	verify.sh	0802 heavy TTL sweep; deploy+update+destroy ok, 0 orphans, no final backup
 fsx-ontap	2026-07-20T01:29:32Z	PASS	1590	verify.sh	issue #1088 ONTAP: DiskIopsConfiguration read back from AWS (Mode+Iops), aws_query_ids hardening; 8 deleted 0 errors 0 orphans
-fsx-openzfs	2026-07-19T16:00:39Z	PASS	1380	verify.sh	re-run after review fixes; drift+observedProperties asserted; 8 deleted 0 errors 0 orphans
+fsx-openzfs	2026-08-02T05:53:30Z	PASS	1287	verify.sh	0802 heavy TTL sweep; deploy+update+drift+destroy ok; untagged OpenZFS final backup swept (#1113)
 fsx-windows	2026-07-20T02:35:13Z	PASS	5460	verify.sh	issue #1088 Windows AD-joined: 7 phases, DiskIopsConfiguration read back, ENIs released 192s; 11 deleted 0 errors 0 orphans
 full-stack-demo	2026-07-26T18:36:31Z	PASS	41	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 gc-custom-asset-names	2026-07-31T06:41:35Z	PASS	120	verify.sh	TTL-refresh sweep re-run in ca-central-1 (us-west-2 now marker-owned); zero residue

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -107,7 +107,7 @@ export	2026-07-30T12:24:41Z	PASS	480	verify.sh	regression sweep post-#1289/#1294
 export-nested-stack	2026-07-21T08:39:22Z	PASS	327	verify.sh	export->CFn nested adopt, CFn delete clean, 0 orphans
 fifo-sqs-event-source	2026-07-27T06:44:00Z	PASS	111	verify.sh	final-tree gate refresh for #1256; destroy 6/0 errors, 0 orphans
 fsx-lustre	2026-08-02T05:30:54Z	PASS	899	verify.sh	0802 heavy TTL sweep; deploy+update+destroy ok, 0 orphans, no final backup
-fsx-ontap	2026-07-20T01:29:32Z	PASS	1590	verify.sh	issue #1088 ONTAP: DiskIopsConfiguration read back from AWS (Mode+Iops), aws_query_ids hardening; 8 deleted 0 errors 0 orphans
+fsx-ontap	2026-08-02T06:33:37Z	PASS	1704	verify.sh	0802 heavy TTL sweep; deploy+update+destroy ok, 0 orphans, no final backup
 fsx-openzfs	2026-08-02T05:53:30Z	PASS	1287	verify.sh	0802 heavy TTL sweep; deploy+update+drift+destroy ok; untagged OpenZFS final backup swept (#1113)
 fsx-windows	2026-07-20T02:35:13Z	PASS	5460	verify.sh	issue #1088 Windows AD-joined: 7 phases, DiskIopsConfiguration read back, ENIs released 192s; 11 deleted 0 errors 0 orphans
 full-stack-demo	2026-07-26T18:36:31Z	PASS	41	standard	0727b sweep-b4 staleness re-run (rc=0); account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -94,7 +94,7 @@ efs-lambda	2026-07-26T18:36:31Z	PASS	499	standard	0727b sweep-b4 staleness re-ru
 efs-standalone	2026-07-26T18:36:31Z	PASS	148	verify.sh	0727b sweep-b4 staleness re-run (rc=0); account clean
 elasticache-replicationgroup-getatt	2026-07-20T14:51:32Z	PASS	596	verify.sh	CC GetAtt PrimaryEndPoint real hostname, 0 orphans
 emr-cluster	2026-08-02T06:04:41Z	PASS	595	verify.sh	0802 heavy TTL sweep; 12 del/0 err, TERMINATED, 0 orphans; cleanup warning is a false alarm (#1339)
-emr-instance-configs	2026-07-19T12:15:47Z	PASS	1680	verify.sh	post-review re-run (fleet scale-down fix); deploy+resize+destroy clean, 0 orphans
+emr-instance-configs	2026-08-02T06:50:46Z	PASS	997	verify.sh	0802 heavy TTL sweep; deploy+resize+destroy ok, 0 orphans
 event-driven	2026-07-26T18:36:31Z	PASS	42	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 eventbridge	2026-07-27T11:04:52Z	PASS	87	verify.sh	issue #1267 post-review re-run; 10 del 0 err, 0 orphans
 eventbridge-api-destination	2026-07-21T14:48:06Z	PASS	70	verify.sh	rc ok, orph clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -109,7 +109,7 @@ fifo-sqs-event-source	2026-07-27T06:44:00Z	PASS	111	verify.sh	final-tree gate re
 fsx-lustre	2026-08-02T05:30:54Z	PASS	899	verify.sh	0802 heavy TTL sweep; deploy+update+destroy ok, 0 orphans, no final backup
 fsx-ontap	2026-08-02T06:33:37Z	PASS	1704	verify.sh	0802 heavy TTL sweep; deploy+update+destroy ok, 0 orphans, no final backup
 fsx-openzfs	2026-08-02T05:53:30Z	PASS	1287	verify.sh	0802 heavy TTL sweep; deploy+update+drift+destroy ok; untagged OpenZFS final backup swept (#1113)
-fsx-windows	2026-07-20T02:35:13Z	PASS	5460	verify.sh	issue #1088 Windows AD-joined: 7 phases, DiskIopsConfiguration read back, ENIs released 192s; 11 deleted 0 errors 0 orphans
+fsx-windows	2026-08-02T07:56:26Z	PASS	3895	verify.sh	0802 heavy TTL sweep; AD-joined create+update+delete ok, 0 orphans, no final backup left
 full-stack-demo	2026-07-26T18:36:31Z	PASS	41	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 gc-custom-asset-names	2026-07-31T06:41:35Z	PASS	120	verify.sh	TTL-refresh sweep re-run in ca-central-1 (us-west-2 now marker-owned); zero residue
 getatt-fallback-guard	2026-08-01T10:07:21Z	PASS	84	verify.sh	0801 regression sweep; strict-getatt paths ok, 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -93,7 +93,7 @@ efs-immutable-replacement	2026-08-01T09:51:12Z	PASS	63	verify.sh	0801 regression
 efs-lambda	2026-07-26T18:36:31Z	PASS	499	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 efs-standalone	2026-07-26T18:36:31Z	PASS	148	verify.sh	0727b sweep-b4 staleness re-run (rc=0); account clean
 elasticache-replicationgroup-getatt	2026-07-20T14:51:32Z	PASS	596	verify.sh	CC GetAtt PrimaryEndPoint real hostname, 0 orphans
-emr-cluster	2026-07-19T18:32:52Z	PASS	1560	verify.sh	issue #1090 import round-trip w/ discriminating assertions (attributes from #1099, observed-vs-template divergence); 12 deleted 0 errors 0 orphans
+emr-cluster	2026-08-02T06:04:41Z	PASS	595	verify.sh	0802 heavy TTL sweep; 12 del/0 err, TERMINATED, 0 orphans; cleanup warning is a false alarm (#1339)
 emr-instance-configs	2026-07-19T12:15:47Z	PASS	1680	verify.sh	post-review re-run (fleet scale-down fix); deploy+resize+destroy clean, 0 orphans
 event-driven	2026-07-26T18:36:31Z	PASS	42	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 eventbridge	2026-07-27T11:04:52Z	PASS	87	verify.sh	issue #1267 post-review re-run; 10 del 0 err, 0 orphans


### PR DESCRIPTION
## Summary

Ledger update for the dedicated heavy-fixture TTL sweep run on 2026-08-02 against real AWS — the six 20-90 min tests deliberately excluded from the 2026-08-01 30-test regression sweep (PR #1336), all about to cross the 14-day integ-gate TTL (last runs 07-19/07-20). All 6 PASS with 0 destroy errors and 0 orphan resources.

| test | duration | note |
|---|---|---|
| fsx-lustre | 899s | deploy + in-place update + destroy |
| fsx-openzfs | 1287s | deploy + update + clean-drift + destroy; untagged OpenZFS final backup swept post-run (known #1113 behavior) |
| emr-cluster | 595s | deploy + update + import round-trip + destroy (TERMINATED); cleanup prints a false "teardown not confirmed" warning on clean runs — filed as (#1339) |
| fsx-ontap | 1704s | deploy + update + destroy; no final backup left |
| emr-instance-configs | 997s | deploy + in-place resize + destroy |
| fsx-windows | 3895s | AD-joined create + update + delete + destroy; no final backup left |

Post-sweep account state: no `state.json` anywhere in the state bucket, no FSx file systems, no FSx backups, no active EMR clusters, no fixture-named IAM roles / security groups. `integ-destroy` marker refreshed after each test.

## Test plan

- The 6 real-AWS runs themselves (each: deploy + verify + destroy + per-test orphan scan including FSx `describe-backups` per issue #1113)
- `vp run integ-ledger-normalize -- --check`: normalized, one row per test (CI re-enforces)
