### PR TITLE
test(integ): gate the emr-cluster cleanup warning on an actual state.json probe

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -93,7 +93,7 @@ efs-immutable-replacement	2026-08-01T09:51:12Z	PASS	63	verify.sh	0801 regression
 efs-lambda	2026-07-26T18:36:31Z	PASS	499	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 efs-standalone	2026-07-26T18:36:31Z	PASS	148	verify.sh	0727b sweep-b4 staleness re-run (rc=0); account clean
 elasticache-replicationgroup-getatt	2026-07-20T14:51:32Z	PASS	596	verify.sh	CC GetAtt PrimaryEndPoint real hostname, 0 orphans
-emr-cluster	2026-08-02T06:04:41Z	PASS	595	verify.sh	0802 heavy TTL sweep; 12 del/0 err, TERMINATED, 0 orphans; cleanup warning is a false alarm (#1339)
+emr-cluster	2026-08-02T14:15:43Z	PASS	605	verify.sh	#1339 fix verified: cleanup warning gone on clean run (gone_probe-gated); 12 del/0 err, 0 orphans
 emr-instance-configs	2026-08-02T06:50:46Z	PASS	997	verify.sh	0802 heavy TTL sweep; deploy+resize+destroy ok, 0 orphans
 event-driven	2026-07-26T18:36:31Z	PASS	42	standard	0727b sweep-b4 staleness re-run (rc=0); account clean
 eventbridge	2026-07-27T11:04:52Z	PASS	87	verify.sh	issue #1267 post-review re-run; 10 del 0 err, 0 orphans

--- a/tests/integration/emr-cluster/verify.sh
+++ b/tests/integration/emr-cluster/verify.sh
@@ -50,6 +50,38 @@
 
 set -euo pipefail
 
+# --- issue #1097 pattern 2: strict gone-probe helpers -----------------------
+# A destroy/leak assertion must distinguish "not found" from any other probe
+# failure (throttle, auth, network); a blind `if aws ...; then` reads ANY
+# failure as "gone" and silently passes the leak check.
+# gone_probe returns 0 when the probe fails with a not-found error (resource
+# confirmed gone), 1 when the probe succeeds (resource still exists), and
+# hard-FAILs the run on any other probe failure (undetermined result).
+# The first-arg guard catches a forgotten assert_gone description: without it,
+# `assert_gone aws ...` would exec `lambda get-function ...` and the shell's
+# "command not found" error would match the signature -- a silent pass.
+gone_probe() { # usage: gone_probe aws <service> <read-verb> [args...]
+  [ "${1:-}" = "aws" ] || { echo "FAIL: gone_probe: probe must start with aws (got: ${1:-<empty>})" >&2; exit 1; }
+  local out
+  if out="$("$@" 2>&1)"; then
+    return 1
+  fi
+  if ! printf '%s' "${out}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
+    echo "FAIL: gone-probe undetermined ($*): ${out}" >&2
+    exit 1
+  fi
+  return 0
+}
+assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-verb> [args...]
+  local desc="$1"
+  shift
+  if ! gone_probe "$@"; then
+    echo "FAIL: ${desc}" >&2
+    exit 1
+  fi
+}
+# ---------------------------------------------------------------------------
+
 cd "$(dirname "$0")"
 
 STACK="CdkdEmrClusterExample"
@@ -240,7 +272,13 @@ cleanup() {
   if [ -n "${STATE_BUCKET:-}" ]; then
     if [ "${state_destroy_ok}" = "true" ] && [ "${cluster_wait_failed}" != "true" ]; then
       aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true
-    else
+    elif ! gone_probe aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"; then
+      # Only warn when state.json actually EXISTS. This cleanup also runs at
+      # pre-run (nothing deployed yet) and after a clean PASS (the main flow
+      # already destroyed the stack and confirmed the 404), and warning on
+      # those paths reads like a leak report on a clean run (issue #1339).
+      # An undetermined probe (throttle / auth) hard-fails via gone_probe
+      # rather than silently skipping or fabricating the warning.
       echo "    WARNING: leaving ${STATE_KEY} in place — teardown was not confirmed clean." >&2
       echo "             It is the only record of what may have leaked. Inspect with:" >&2
       echo "             aws s3 cp s3://${STATE_BUCKET}/${STATE_KEY} -" >&2


### PR DESCRIPTION
## Summary

Closes #1339

The emr-cluster fixture's cleanup helper runs at pre-run AND at exit, and its "leaving state.json in place — teardown was not confirmed clean" warning fired whenever the helper's own `state_destroy_ok` flag was unset — WITHOUT checking whether state.json actually exists. On a fully clean run the warning printed twice (pre-run: nothing deployed yet; exit: the main flow had already destroyed the stack and confirmed the 404), reading like a leak report and costing an investigation pass during the 0802 heavy TTL sweep.

- The warning branch is now gated on `! gone_probe aws s3api head-object ...` — it prints ONLY when state.json actually exists (a genuinely dirty teardown). A not-found probe (the clean paths) skips it; an undetermined probe (throttle / auth / network) hard-fails loudly via `gone_probe` instead of silently skipping or fabricating the warning.
- The fixture gains the canonical issue-#1097 strict gone-probe helper block (byte-identical to the tree-wide copy). The first cut of this fix used a bare silenced `elif aws s3api head-object ...` and the probe lint correctly rejected it as a blind leak assert — the canonical form is the sanctioned spelling.
- Integ ledger row updated from the verification run.

## Test plan

- Real-AWS re-run of the full emr-cluster integ with the fix: PASS in 605s (deploy + update + import round-trip + destroy, 12 deleted / 0 errors, post-run orphan scan clean) and the warning appears **0 times** in the log — previously twice per clean run.
- Fixture lint suites (signal traps / gone-probes / CLI flags / version literals): 211 tests pass — including the gone-probe lint that rejected the first, non-canonical version of this fix.
- `vp check` + `vp run typecheck:test` + `vp run build` + `vp run test` (502 files / 8400 tests) all pass.
