### PR TITLE
docs: document stack-lock behavior on cancelled CI jobs and fix stale lock-TTL value

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ cdkd drift MyStack --revert --yes   # AWS ← state
 cdkd publish-assets                 # synth + upload only (typical CI split)
 cdkd destroy MyStack
 cdkd orphan MyStack/MyBucket        # drop one resource from state (AWS resource stays)
-cdkd force-unlock MyStack           # clear stale lock from an interrupted deploy
+cdkd force-unlock MyStack           # clear stale lock from an interrupted deploy / cancelled CI job
 cdkd gc --dry-run                   # reclaim unreferenced cdkd-owned assets (S3 + ECR)
 
 # Migrate between cdkd and CloudFormation

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -656,7 +656,7 @@ async acquireLockWithRetry(
 
     // Force release if lock is old
     const age = Date.now() - lockInfo.timestamp;
-    if (age >= this.lockTTL) {  // Default 15 minutes
+    if (age >= this.lockTTL) {  // Default 30 minutes
       await this.forceReleaseLock(stackName);
       continue;
     }
@@ -674,9 +674,23 @@ async acquireLockWithRetry(
 
 ### Lock TTL (Time To Live)
 
-Default: **15 minutes**
+Default: **30 minutes**
 
-Even if a process crashes, after 15 minutes the old lock is considered stale and can be force released.
+Even if a process crashes, after 30 minutes the old lock is considered stale and can be force released.
+
+### Deploy interruption (Ctrl-C)
+
+`cdkd deploy` handles the first `Ctrl-C` (SIGINT) gracefully:
+
+- **First Ctrl-C** stops dispatching new resource operations. Any provider
+  call already in flight is allowed to finish, partial state is saved (state
+  is also saved incrementally after each completed resource), a rollback
+  journal is recorded for `cdkd rollback`, and the stack lock is **released**
+  before the command exits non-zero. A re-run resumes without waiting out the
+  lock TTL.
+- **Second Ctrl-C** force-quits immediately (`process.exit(130)`) without
+  waiting for in-flight operations. The lock may be left behind and is
+  reclaimed after the TTL above (or cleared with `cdkd force-unlock`).
 
 ### Destroy interruption (Ctrl-C)
 
@@ -699,6 +713,17 @@ mirroring Terraform:
 This is why an interrupted destroy no longer strands the lock for its full
 TTL: only an ungraceful kill (`SIGKILL`, a second Ctrl-C, or a crash) leaves a
 stale lock.
+
+### CI job cancellation
+
+A cancelled CI job (e.g. GitHub Actions `cancel-in-progress: true`) can kill
+the process ungracefully and strand the lock: cdkd currently handles `SIGINT`
+but not `SIGTERM` in the deploy/destroy path, and CI runners escalate to
+`SIGTERM`/`SIGKILL` on cancellation. The lock is then reclaimed after the TTL
+above, or cleared immediately with `cdkd force-unlock <stack>`. See
+["Stale lock after a cancelled CI job" in the troubleshooting
+guide](./troubleshooting.md#issue-stale-lock-after-a-cancelled-ci-job) for the
+full CI story and recommended workflow patterns.
 
 ## State Saving and Updating
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,7 +36,9 @@ Locked by: user@hostname:12345, operation: deploy
 > [#816](https://github.com/go-to-k/cdkd/issues/816)) finishes any in-flight
 > delete, flushes the incremental state, and **releases the lock** before
 > exiting non-zero. A re-run resumes immediately without waiting out the lock
-> TTL.
+> TTL. `cdkd deploy` behaves the same way on a first `Ctrl-C`: in-flight
+> operations finish, partial state is saved, a rollback journal is recorded,
+> and the lock is released before the non-zero exit.
 >
 > A **second** `Ctrl-C` force-quits immediately (`exit 130`) without waiting
 > for the in-flight delete. Because the force-quit path cannot run the normal
@@ -94,6 +96,74 @@ await lockManager.acquireLockWithRetry(
   10000   // retryDelay (default: 5000ms)
 );
 ```
+
+### Issue: Stale lock after a cancelled CI job
+
+#### Symptoms
+
+A CI job running `cdkd deploy` was cancelled (manually, or automatically by a
+newer run), and the next run fails with `Failed to acquire lock` even though
+no deploy is in progress.
+
+A very common GitHub Actions setup for per-PR environments hits this:
+
+```yaml
+concurrency:
+  group: pr-env-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+```
+
+Consecutive pushes to the same PR target the **same stack**, so the cancelled
+run's stale lock blocks the run that replaced it.
+
+#### Causes
+
+Cancellation is not a clean `Ctrl-C`. GitHub Actions escalates
+`SIGINT` → `SIGTERM` (~7.5 s later) → `SIGKILL` (~2.5 s after that); other CI
+systems (GitLab CI, `docker stop`, Kubernetes) typically send `SIGTERM`
+directly. cdkd's deploy/destroy path currently handles `SIGINT` gracefully
+(finish in-flight operations, save state, release the lock) but has **no
+`SIGTERM` handler**, and `SIGKILL` cannot be handled by any process. So a
+cancelled job usually dies before the lock-release cleanup runs, stranding
+the lock.
+
+#### Solutions
+
+**1. Wait out the TTL** — a stale lock is reclaimed automatically after the
+lock TTL (**30 minutes** by default). The next run after that succeeds
+without intervention.
+
+**2. Clear it immediately** with:
+
+```bash
+cdkd force-unlock MyStack
+```
+
+**3. Recommended CI pattern** — when your workflow serializes runs per stack
+(as the `concurrency` group above does), it is safe to clear any stale lock
+at the start of the job, because no other run of the same group can be
+holding it legitimately:
+
+```yaml
+- run: npm i -g @go-to-k/cdkd
+- run: cdkd force-unlock MyStack || true  # only safe when runs are serialized per stack
+- run: cdkd deploy MyStack --yes
+```
+
+Do **not** add an unconditional `force-unlock` to workflows where two jobs
+can legitimately operate on the same stack concurrently — it would break the
+lock that protects the running deploy.
+
+#### Note on partially-applied deploys
+
+A killed deploy is usually not a correctness problem beyond the lock: cdkd
+saves state incrementally after each completed resource, so a re-run resumes
+from the last saved state, and a rollback journal (when present) lets
+`cdkd rollback` revert the interrupted deploy instead. The remaining exposure
+is a resource whose create was in flight at the moment of the kill: it may
+have been created on AWS without reaching state, in which case the next run
+can surface an "already exists" conflict that needs manual reconciliation
+(delete the resource, or adopt it with `cdkd import`).
 
 ---
 


### PR DESCRIPTION
## Summary

Docs half of #1342 (the SIGTERM-handler code half follows in a separate PR).

- **New troubleshooting section: "Stale lock after a cancelled CI job"** (`docs/troubleshooting.md`) — the common GitHub Actions `concurrency` + `cancel-in-progress: true` per-PR-environment setup, why cancellation strands the stack lock (Actions escalates SIGINT → SIGTERM → SIGKILL and the deploy/destroy path currently has no SIGTERM handler), the 30-minute TTL auto-release, `cdkd force-unlock` for immediate recovery, a recommended CI pattern (`force-unlock || true` at job start — explicitly scoped to workflows that serialize runs per stack), and a note on what a killed deploy leaves behind (incremental per-resource state saves + rollback journal; in-flight creates may need `cdkd import` reconciliation).
- **Documented `cdkd deploy`'s own interrupt behavior explicitly** (`docs/state-management.md` "Deploy interruption (Ctrl-C)" + a sentence in the troubleshooting lock note) — first Ctrl-C finishes in-flight ops, saves partial state, records a rollback journal, and releases the lock (verified against `deploy-engine.ts`'s `finally`); second Ctrl-C force-quits and may strand the lock. Previously only destroy's behavior was documented (issue #816).
- **Fixed a stale lock-TTL value**: `docs/state-management.md` claimed the lock TTL default is **15 minutes**; the actual default in `src/state/lock-manager.ts` is **30 minutes** (`ttlMinutes ?? 30`). Fixed in 3 places. (The issue text's "15-minute TTL" repeats this stale doc value.)
- README `force-unlock` one-liner now mentions the cancelled-CI-job case.

Part of #1342 — does NOT close it; the optional SIGTERM-handler code change lands separately.

## Verification

- Lock TTL default verified in `src/state/lock-manager.ts` (`ttlMinutes ?? 30`).
- Deploy lock-release-on-interrupt verified in `src/deployment/deploy-engine.ts` (`finally` always releases the lock; graceful SIGINT reaches it, force-exit/SIGKILL does not).
- Cross-doc anchor (`troubleshooting.md#issue-stale-lock-after-a-cancelled-ci-job`) matches the new heading.
- `vp run typecheck` / `lint` / `build` pass; unit tests 505 files / 8415 tests pass (docs-only change).

## Retrospective note

The stale "15 minutes" TTL is a numeric constant quoted in docs drifting from code. Won't-do on new tooling for this class: too low-frequency to justify a doc-constants lint; `/check-docs` remains the line of defense (recorded here).
