### PR TITLE
docs(provisioning): record the no-race-retry decision at the directory-bucket auto-empty site

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -222,7 +222,7 @@ rollback-sqs-cooldown	2026-07-25T05:24:26Z	PASS	180	verify.sh	#1220 echo-before-
 route53	2026-07-22T07:59:10Z	PASS		verify.sh	TTL-refresh sweep; HostedZone/GeoProximity/CidrRouting backfills, 6 del 0 err, hosted zone + state gone
 s3-asset-deploy	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 s3-cloudfront	2026-07-30T23:04:11Z	PASS	225	verify.sh	1316 delete waits out propagating disable, 5 del/0 err
-s3-directory-bucket	2026-08-02T15:13:23Z	PASS	50	verify.sh	#1344 guard: refusal + data intact, clean 2nd destroy, 0 orphans
+s3-directory-bucket	2026-08-02T15:38:47Z	PASS	50	verify.sh	re-run for #1347 wontdo-comment PR; guard + clean destroy, 0 orphans
 s3-event-notification	2026-07-21T05:28:05Z	PASS	79	verify.sh	rc ok, orph clean
 s3-lifecycle	2026-07-21T14:28:43Z	PASS	58	verify.sh	rc ok, orph clean
 s3-object-lock	2026-07-21T14:42:20Z	PASS	53	verify.sh	rc ok, orph clean

--- a/src/provisioning/providers/s3-directory-bucket-provider.ts
+++ b/src/provisioning/providers/s3-directory-bucket-provider.ts
@@ -227,6 +227,13 @@ export class S3DirectoryBucketProvider implements ResourceProvider {
         this.logger.info(
           `Emptying directory bucket ${physicalId} before deletion (auto-delete opt-in present)`
         );
+        // Deliberately NO deleteBucketWithEmptyRetry-style race loop here
+        // (unlike the standard-bucket sibling): directory buckets cannot be
+        // ALB/CloudTrail log-delivery targets, so nothing else writes during
+        // a destroy; a lost app-write race surfaces as the generic not-empty
+        // ProvisioningError and a destroy re-run recovers. Revisit when Tags
+        // becomes a handled property for this type ((#609) makes the tag
+        // opt-in mainstream) — see PR #1347's review disposition.
         await this.emptyBucket(physicalId);
       }
 


### PR DESCRIPTION
Follow-up to PR #1347 (issue #1344), by maintainer request: the "deliberately no race-retry loop on the opted-in auto-empty path" decision was recorded only in the merged PR's review-disposition section, which is invisible to someone reading the provider and wondering why it diverges from the standard-bucket sibling's `deleteBucketWithEmptyRetry`. This records it at the code site, with the revisit trigger (Tags handling per (#609) making the tag opt-in mainstream). A matching revisit note was posted on (#609).

Comment-only change (no behavior); the `s3-directory-bucket` integ was re-run clean to refresh the digest-bound `integ-destroy` marker (guard refusal + clean second destroy, 0 orphans — ledger updated).
