### PR TITLE
test(deployment): pin the deploy engine's rollback-context threading of finalSnapshotClients / skipFinalSnapshot

### DIFF
--- a/tests/unit/deployment/deploy-engine-rollback-context.test.ts
+++ b/tests/unit/deployment/deploy-engine-rollback-context.test.ts
@@ -1,0 +1,186 @@
+/**
+ * DeployEngine -> rollback-executor context threading (issue #1363).
+ *
+ * `DeployEngine.rollbackExecutorContext()` hands the executor two fields the
+ * `DeletionPolicy: Snapshot` rollback path (issue #1358) depends on:
+ *
+ *   finalSnapshotClients: this.options.finalSnapshotClients,
+ *   skipFinalSnapshot: this.options.skipFinalSnapshot,
+ *
+ * Nothing pinned that wiring: deleting BOTH lines left the whole unit suite
+ * green, and the real-AWS integ cannot catch it either — dropping
+ * `finalSnapshotClients` falls back to `getAwsClients()`, which is correct in
+ * any single-region run, and dropping `skipFinalSnapshot` only means
+ * `--skip-final-snapshot` silently stops applying to the automatic rollback's
+ * delete (an extra snapshot, no fixture asserts its absence).
+ *
+ * These cases drive the engine's own `performRollback` through the REAL
+ * `replayRollback`, so each field is observed where it actually lands: the
+ * clients in the pre-delete snapshot call, the flag in the provider's
+ * DeleteContext. Both polarities of the flag are pinned — asserting only the
+ * `true` case would also pass with the line deleted if the default happened
+ * to match.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { DeployEngine } from '../../../src/deployment/deploy-engine.js';
+import type { CompletedOperation } from '../../../src/deployment/rollback-executor.js';
+import type { ResourceProvider } from '../../../src/types/resource.js';
+import type { ResourceState } from '../../../src/types/state.js';
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const fns = {
+    setLevel: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => fns,
+  };
+  return { getLogger: () => fns };
+});
+
+const mockCreatePreDeleteFinalSnapshot = vi.hoisted(() => vi.fn());
+
+// Only the AWS-touching dispatcher is stubbed; the type sets / identifier
+// builder stay REAL so these cases pin the actual routing matrix.
+vi.mock('../../../src/provisioning/final-snapshot.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../src/provisioning/final-snapshot.js')>();
+  return { ...actual, createPreDeleteFinalSnapshot: mockCreatePreDeleteFinalSnapshot };
+});
+
+// The process-global fallback the engine's `finalSnapshotClients` exists to
+// AVOID. Distinct object identity is what makes the assertion below fail if
+// the engine stops threading its own region-pinned clients.
+const processGlobalClients = { ec2: { send: vi.fn() }, tag: 'process-global' };
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => processGlobalClients,
+  setAwsClients: vi.fn(),
+  AwsClients: vi.fn(),
+}));
+
+/** The region-pinned set a stack's deploy builds and threads down. */
+const pinnedClients = { ec2: { send: vi.fn() }, tag: 'stack-region-pinned' };
+
+describe('DeployEngine rollback context threading (#1363)', () => {
+  let deleteProvider: ResourceProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreatePreDeleteFinalSnapshot.mockResolvedValue('snap-unit');
+    deleteProvider = {
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn().mockResolvedValue(undefined),
+      getAttribute: vi.fn(),
+    };
+  });
+
+  function makeEngine(options: Record<string, unknown> = {}): InstanceType<typeof DeployEngine> {
+    const mockProviderRegistry = {
+      getProvider: vi.fn().mockReturnValue(deleteProvider),
+      getProviderFor: vi.fn().mockReturnValue({ provider: deleteProvider, provisionedBy: 'sdk' }),
+      getRegisteredTypes: vi.fn().mockReturnValue([]),
+      validateResourceTypes: vi.fn(),
+      validateResourceProperties: vi.fn(),
+    };
+    return new DeployEngine(
+      { getState: vi.fn(), saveState: vi.fn() } as unknown as never,
+      { acquireLockWithRetry: vi.fn(), releaseLock: vi.fn() } as unknown as never,
+      { buildGraph: vi.fn(), getExecutionLevels: vi.fn(), getDirectDependencies: vi.fn() } as never,
+      { calculateDiff: vi.fn(), hasChanges: vi.fn(), filterByType: vi.fn() } as never,
+      mockProviderRegistry as unknown as never,
+      options,
+      'us-east-1'
+    );
+  }
+
+  /**
+   * Roll back one completed CREATE of `resourceType` carrying
+   * `DeletionPolicy: Snapshot`, through the engine's own private
+   * `performRollback` (the caller of `rollbackExecutorContext()`).
+   */
+  async function rollbackSnapshotCreate(
+    engine: InstanceType<typeof DeployEngine>,
+    resourceType: string
+  ): Promise<Record<string, ResourceState>> {
+    const op: CompletedOperation = {
+      logicalId: 'Target',
+      changeType: 'CREATE',
+      resourceType,
+      physicalId: 'phys-target',
+    };
+    const stateResources: Record<string, ResourceState> = {
+      Target: {
+        physicalId: 'phys-target',
+        resourceType,
+        properties: {},
+        attributes: {},
+        dependencies: [],
+        deletionPolicy: 'Snapshot',
+      },
+    };
+    type PerformRollbackFn = (
+      completedOperations: CompletedOperation[],
+      stateResources: Record<string, ResourceState>,
+      stackName: string
+    ) => Promise<{ failures: number; warnings: number }>;
+    const performRollback = (
+      engine as unknown as { performRollback: PerformRollbackFn }
+    ).performRollback.bind(engine);
+    const result = await performRollback([op], stateResources, 'MyStack');
+    expect(result.failures).toBe(0);
+    return stateResources;
+  }
+
+  function deleteContextArg(): Record<string, unknown> {
+    const deleteMock = deleteProvider.delete as ReturnType<typeof vi.fn>;
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    return deleteMock.mock.calls[0][4] as Record<string, unknown>;
+  }
+
+  it('threads finalSnapshotClients into the pre-delete snapshot call', async () => {
+    const state = await rollbackSnapshotCreate(
+      makeEngine({ finalSnapshotClients: pinnedClients }),
+      'AWS::EC2::Volume'
+    );
+    // The 4th argument is the clients object. It must be the engine's
+    // region-pinned set, NOT the `getAwsClients()` process-global a
+    // concurrent stack's deploy can repoint at another region.
+    expect(mockCreatePreDeleteFinalSnapshot).toHaveBeenCalledOnce();
+    expect(mockCreatePreDeleteFinalSnapshot.mock.calls[0][3]).toBe(pinnedClients);
+    expect(mockCreatePreDeleteFinalSnapshot.mock.calls[0][3]).not.toBe(processGlobalClients);
+    expect(state['Target']).toBeUndefined();
+  });
+
+  it('threads skipFinalSnapshot: true — the rollback delete takes no snapshot', async () => {
+    await rollbackSnapshotCreate(
+      makeEngine({ finalSnapshotClients: pinnedClients, skipFinalSnapshot: true }),
+      'AWS::RDS::DBInstance'
+    );
+    expect(deleteContextArg()['finalSnapshotIdentifier']).toBeUndefined();
+    expect(mockCreatePreDeleteFinalSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('threads skipFinalSnapshot: false — the rollback delete DOES snapshot (opposite polarity)', async () => {
+    await rollbackSnapshotCreate(
+      makeEngine({ finalSnapshotClients: pinnedClients, skipFinalSnapshot: false }),
+      'AWS::RDS::DBInstance'
+    );
+    expect(deleteContextArg()['finalSnapshotIdentifier']).toMatch(
+      /^phys-target-final-\d{8}-\d{6}$/
+    );
+  });
+
+  it('skipFinalSnapshot: true also reaches the pre-delete snapshot types', async () => {
+    // Same flag, the other mechanism arm: without the threading this would
+    // still take (and wait for) a real EBS snapshot the user opted out of.
+    await rollbackSnapshotCreate(
+      makeEngine({ finalSnapshotClients: pinnedClients, skipFinalSnapshot: true }),
+      'AWS::EC2::Volume'
+    );
+    expect(mockCreatePreDeleteFinalSnapshot).not.toHaveBeenCalled();
+    expect(deleteContextArg()['finalSnapshotIdentifier']).toBeUndefined();
+  });
+});

--- a/tests/unit/deployment/rollback-executor.test.ts
+++ b/tests/unit/deployment/rollback-executor.test.ts
@@ -38,6 +38,17 @@ vi.mock('../../../src/provisioning/final-snapshot.js', async (importOriginal) =>
   };
 });
 
+// The process-global the executor falls back to when the context pins no
+// clients (`ctx.finalSnapshotClients ?? getAwsClients()`). Distinct object
+// identity so the fallback and the pinned-clients cases cannot be confused
+// for one another (issue #1363).
+const processGlobalClients = { tag: 'process-global' };
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => processGlobalClients,
+  setAwsClients: vi.fn(),
+  AwsClients: vi.fn(),
+}));
+
 function res(overrides: Partial<ResourceState> = {}): ResourceState {
   return {
     physicalId: 'phys',
@@ -1309,6 +1320,51 @@ describe('replayRollback — DeletionPolicy: Snapshot on a rolled-back CREATE (#
     expect(
       vi.mocked(createPreDeleteFinalSnapshot).mock.invocationCallOrder[0]!
     ).toBeLessThan(del.mock.invocationCallOrder[0]!);
+    expect(state['Res']).toBeUndefined();
+  });
+
+  it('pre-delete type with NO context clients: falls back to the process-global set (#1363)', async () => {
+    // The `ctx.finalSnapshotClients ?? getAwsClients()` fallback arm — taken
+    // by any caller that does not pin a region-scoped set (a legacy embedder,
+    // or the engine before #1358 threaded its own). Untested until #1363, so
+    // a fallback that silently resolved to `undefined` would have gone
+    // unnoticed until it reached AWS.
+    const del = vi.fn().mockResolvedValue(undefined);
+    const { ctx } = makeCtx({ delete: del });
+    expect(ctx.finalSnapshotClients).toBeUndefined();
+    const state = snapshotState('AWS::EC2::Volume', 'cc-api');
+    const result = await replayRollback([snapshotOp('AWS::EC2::Volume')], state, 'S', ctx);
+    expect(result.failures).toBe(0);
+    expect(vi.mocked(createPreDeleteFinalSnapshot).mock.calls[0]![3]).toBe(processGlobalClients);
+    expect(del).toHaveBeenCalledOnce();
+    expect(state['Res']).toBeUndefined();
+  });
+
+  it('state record wins over the journaled op in BOTH directions (record sdk, op cc-api) (#1363)', async () => {
+    // The sibling case above pins record-absent -> op-wins. This is the
+    // inverse: the record says the resource is SDK-routed while a stale
+    // journal entry says cc-api. The record is what state says AWS holds
+    // right now, so the snapshot gate must NOT refuse and the delete must
+    // take the SDK route — one routing source for both.
+    const del = vi.fn().mockResolvedValue(undefined);
+    const getProviderFor = vi.fn().mockReturnValue({ provider: { delete: del } });
+    const { ctx } = makeCtx({ delete: del });
+    ctx.providerRegistry = {
+      getProviderFor,
+    } as unknown as RollbackExecutorContext['providerRegistry'];
+    ctx.finalSnapshotClients = fakeClients;
+    const state = snapshotState('AWS::RDS::DBInstance', 'sdk');
+    const result = await replayRollback(
+      [snapshotOp('AWS::RDS::DBInstance', 'cc-api')],
+      state,
+      'S',
+      ctx
+    );
+    expect(result.failures).toBe(0);
+    expect(getProviderFor).toHaveBeenCalledWith(expect.objectContaining({ provisionedBy: 'sdk' }));
+    expect(
+      (del.mock.calls[0]![4] as Record<string, unknown>)['finalSnapshotIdentifier']
+    ).toMatch(/^phys-res-final-\d{8}-\d{6}$/);
     expect(state['Res']).toBeUndefined();
   });
 


### PR DESCRIPTION
## Problem

`DeployEngine.rollbackExecutorContext()` threads two fields into the rollback executor (added by #1361 for issue #1358):

```typescript
finalSnapshotClients: this.options.finalSnapshotClients,
skipFinalSnapshot: this.options.skipFinalSnapshot,
```

Nothing pinned that wiring. Deleting BOTH lines left the whole unit suite green, and the real-AWS integ (`rollback-deletion-policy-snapshot`) cannot catch it either:

- dropping `finalSnapshotClients` falls back to `getAwsClients()`, which is correct in any single-region run — the field only matters under `--stack-concurrency > 1` with a multi-region app, which no fixture exercises;
- dropping `skipFinalSnapshot` means `cdkd deploy --skip-final-snapshot` silently stops applying to the automatic rollback's delete of a `DeletionPolicy: Snapshot` resource. Mild (an extra snapshot, not data loss), but a real flag regression with zero coverage.

The `cdkd rollback` side of the same plumbing IS pinned (`tests/unit/cli/commands/rollback.test.ts`, #1361). This PR closes the deploy-engine side.

## Changes

**New `tests/unit/deployment/deploy-engine-rollback-context.test.ts`** (4 cases). Behavioral, not source-level: it drives the engine's own private `performRollback` through the REAL `replayRollback`, so each field is observed where it actually lands.

- `finalSnapshotClients` is asserted by OBJECT IDENTITY as the 4th argument of the pre-delete snapshot call, against a deliberately distinct `getAwsClients()` double (`toBe(pinnedClients)` + `not.toBe(processGlobalClients)`). Identity is what makes the assertion fail on the fallback — a shape assertion would pass either way, which is exactly why the field was unpinned.
- `skipFinalSnapshot` is asserted in the provider's `DeleteContext`, in BOTH polarities (`true` -> no identifier and no pre-delete snapshot; `false` -> a generated identifier), and on BOTH mechanism arms (atomic `AWS::RDS::DBInstance` and pre-delete `AWS::EC2::Volume`). Pinning only the `true` case would still pass with the line deleted if the default happened to match.

**Two coverage nits from the same review**, in `tests/unit/deployment/rollback-executor.test.ts`:

- the `ctx.finalSnapshotClients ?? getAwsClients()` fallback arm (previously only the pinned-clients polarity was exercised);
- `effectiveProvisionedBy` with state record `sdk` + journaled op `cc-api` — the record-wins direction. Only the record-absent fallback was covered, so an inversion to op-wins was invisible.

## Binding proof

Sed-swap only, no `git checkout`; the source is restored and the diff is tests-only (`git diff --stat` shows 2 test files, 0 src).

| Reverted line | Failing cases |
|---|---|
| `finalSnapshotClients: this.options.finalSnapshotClients` | 1 of 4 |
| `skipFinalSnapshot: this.options.skipFinalSnapshot` | 2 of 4 |
| both | 3 of 4 |
| `ctx.finalSnapshotClients ?? getAwsClients()` -> `ctx.finalSnapshotClients as never` | the new fallback case |
| `effectiveProvisionedBy` inverted to `fallbackProvisionedBy ?? record?.provisionedBy` | the new record-wins case, and NOTHING else in the pre-existing 72 |

That last row is the direct evidence for the issue's claim: the record-wins direction genuinely had no coverage before.

## Tests

Full suite: 514 files / 8562 tests pass (was 513 / 8556).

No `src/` change, so no integ gate applies and no AWS resources were created. State bucket verified clean (0 `state.json` objects).

Closes #1363
