### PR TITLE
test(integ): re-run rollback-failure-injection to completion (ledger PASS)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -220,7 +220,7 @@ replacement-fanout	2026-08-08T16:39:04Z	PASS	83	verify.sh	P1 post-#1360 replacem
 replacement-immutable-name	2026-08-01T09:51:12Z	PASS	113	verify.sh	0801 regression sweep; 6 types x 3 phases ok, 0 orphans
 rollback-command	2026-07-25T05:24:26Z	PASS	130	verify.sh	#1220 echo-before-assert on R2/F2 success-expected rollbacks, destroy clean
 rollback-deletion-policy-snapshot	2026-08-08T16:34:46Z	PASS	107	verify.sh	P0 first run post-#1361/#1365/#1367/#1369 rollback rework; rolled-back CREATE snapshot-then-deleted, state clean, 0 orphans
-rollback-failure-injection	2026-08-08T17:11:06Z	FAIL	600	verify.sh	run cut short by the 600s harness tool timeout (not a cdkd bug); SIGTERM graceful path worked; cleanup destroy 16 del/1 SG ENI-race err, AWS verified clean (SG+VPC NotFound), state orphaned. Needs a full re-run
+rollback-failure-injection	2026-08-08T17:42:23Z	PASS	389	verify.sh	issue #1375 re-run (background, dodging the 600s clamp); all 8 phases, 17 del/0 err, 0 orphans incl NAT/EIP/ENI
 rollback-sqs-cooldown	2026-07-25T05:24:26Z	PASS	180	verify.sh	#1220 echo-before-assert on steps 4/9/10, destroy clean
 route53	2026-07-22T07:59:10Z	PASS		verify.sh	TTL-refresh sweep; HostedZone/GeoProximity/CidrRouting backfills, 6 del 0 err, hosted zone + state gone
 s3-asset-deploy	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean


### PR DESCRIPTION
## Summary

Closes #1375.

Flips the `rollback-failure-injection` ledger row from FAIL back to PASS by
running the test to completion.

The 0809 sweep (#1374) recorded it as FAIL because the run was cut short by the
600s `Bash` tool timeout partway through its destroy phase — not by any cdkd
defect. `Bash` silently clamps its `timeout` parameter to 600000 ms, so asking
for more does nothing. This re-run went to the background, where the clamp
cannot fire.

## Result

**PASS in 389s** — all 8 `verify.sh` phases completed, destroy reported
**17 deleted / 0 errors**.

Post-run orphan scan, all clean:

| check | result |
|---|---|
| `state.json` / `lock.json` | 0 |
| VPC (`CdkdRollbackFailureExample/Vpc`) | none |
| NAT Gateway (incl. `deleting`) | none |
| Elastic IPs | none |
| Lambda hyperplane ENIs | none |
| IAM roles / Lambdas / SSM parameters | none |

## Why it mattered

The interrupted run never reached its own assertions, so the fixture's coverage
of the rollback-executor changes in #1361 / #1365 / #1367 / #1369 was unproven —
only the sibling `rollback-deletion-policy-snapshot` fixture had exercised that
code. This run closes that gap.

## Test plan

- `/run-integ rollback-failure-injection` against real AWS in `us-east-1`,
  run in the background, deploy + rollback-injection + destroy
- `vp run typecheck` / `lint` / `build` clean
- `vp run test` — 8625 passed (514 files)
- Marker set: `integ-destroy` (clean destroy, 0 orphans)
