### PR TITLE
test(audit): prove the SDK-parse floors fire and pin the CLI-guard log string

### DIFF
--- a/scripts/gen-nested-key-coverage.ts
+++ b/scripts/gen-nested-key-coverage.ts
@@ -1012,8 +1012,17 @@ function atomicWrite(path: string, content: string): void {
 const isMainModule = (): boolean =>
   Boolean(process.argv[1]) && resolve(process.argv[1]!) === __filename;
 
+/** Default SDK-model directory for a client package. Overridable in tests. */
+export const defaultModelsDir = (sdkClientPackage: string): string =>
+  resolve(repoRoot, 'node_modules', sdkClientPackage, 'dist-types/models');
+
 export function loadReport(
-  targetList: readonly NestedKeyTarget[] = NESTED_KEY_TARGETS
+  targetList: readonly NestedKeyTarget[] = NESTED_KEY_TARGETS,
+  // Injection point so the two SDK-parse floors below are provable in the
+  // RED direction (the repo's checker rules: a CI-blocking fence must be
+  // shown to fire) — the member and interface parses are SEPARATE visitors
+  // over the same files, so either can regress alone.
+  resolveModelsDir: (sdkClientPackage: string) => string = defaultModelsDir
 ): NestedKeyCoverageReport {
   const sdkMembersByPackage = new Map<string, Set<string>>();
   const sdkInterfacesByPackage = new Map<string, Map<string, Map<string, SdkMemberType>>>();
@@ -1055,12 +1064,7 @@ export function loadReport(
     let sdkMembers = sdkMembersByPackage.get(target.sdkClientPackage);
     let sdkInterfaces = sdkInterfacesByPackage.get(target.sdkClientPackage);
     if (!sdkMembers || !sdkInterfaces) {
-      const modelsDir = resolve(
-        repoRoot,
-        'node_modules',
-        target.sdkClientPackage,
-        'dist-types/models'
-      );
+      const modelsDir = resolveModelsDir(target.sdkClientPackage);
       if (!existsSync(modelsDir)) {
         throw new Error(`missing SDK model typings dir: ${modelsDir}`);
       }

--- a/tests/unit/scripts/gen-nested-key-coverage.test.ts
+++ b/tests/unit/scripts/gen-nested-key-coverage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vite-plus/test';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import {
   NESTED_KEY_ALLOW_LIST,
   NESTED_KEY_TARGETS,
@@ -286,6 +287,38 @@ describe('loadReport loud-failure fences', () => {
     expect(() =>
       loadReport([{ ...realTarget, resourceType: 'AWS::S3::Bucket', minNestedKeys: 0 }])
     ).toThrow(/definitionShapes/);
+  });
+
+  it('fires the SDK MEMBER-parse floor on a collapsed model dir (red direction)', () => {
+    // A models dir whose lone .d.ts declares almost nothing: both parses
+    // collapse; the member floor (checked first) must fire.
+    const dir = mkdtempSync(join(tmpdir(), 'cdkd-nkc-members-'));
+    writeFileSync(join(dir, 'models_0.d.ts'), 'export interface A { M1?: string; }\n');
+    try {
+      expect(() => loadReport([realTarget], () => dir)).toThrow(
+        /SDK member parse .* collapsed/
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fires the SDK INTERFACE-parse floor when only the interface visitor collapses (red direction)', () => {
+    // PropertySignatures inside a TYPE LITERAL are counted by
+    // collectSdkMemberNames but NOT by collectSdkInterfaces — the two are
+    // separate visitors, so this shape passes the member floor while the
+    // interface floor must fire (a regression in the interface visitor
+    // alone would otherwise leave the shape pass vacuously green).
+    const members = Array.from({ length: 60 }, (_, i) => `M${i}?: string;`).join(' ');
+    const dir = mkdtempSync(join(tmpdir(), 'cdkd-nkc-ifaces-'));
+    writeFileSync(join(dir, 'models_0.d.ts'), `export type Blob = { ${members} };\n`);
+    try {
+      expect(() => loadReport([realTarget], () => dir)).toThrow(
+        /SDK interface parse .* collapsed/
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('throws when the provider declares no handledProperties for the target type', () => {
@@ -753,6 +786,11 @@ describe('refresh-cfn-schemas CLI guard (#1378 rider)', () => {
     });
     expect(stdout).toContain('Usage:');
     expect(stdout).not.toContain('Refreshing CFn schemas');
+    // Pin the guarded log string to the script SOURCE: if the fetch-start
+    // message is ever reworded, this fails and forces the negative
+    // assertion above to be updated — without it, that assertion would go
+    // silently vacuous.
+    expect(readFileSync(script, 'utf8')).toContain('Refreshing CFn schemas');
   });
 
   it('an unknown flag exits 1 with usage on stderr instead of silently full-refetching', async () => {


### PR DESCRIPTION
Follow-up polish to #1379 (issue #1378), promoting two of its recorded won't-do items after re-assessment:

- **Prove the SDK-parse floors fire (red direction).** The member and interface parses are SEPARATE visitors over the same model files, so either can regress alone; with both a visitor regression AND a broken floor, the shape pass would go vacuously green. `loadReport` gains a test-only `resolveModelsDir` injection point (default behavior unchanged), and two new tests drive each floor to its throw against synthetic model dirs — a type-literal-only `.d.ts` passes the member floor while collapsing the interface parse, isolating the interface floor.
- **Pin the CLI-guard log string to the script source.** The `--help` spawn test's `not.toContain('Refreshing CFn schemas')` assertion went silently vacuous if that log line was ever reworded; the test now also asserts the string still exists in `refresh-cfn-schemas.mjs`, forcing a paired update.

No `src/**` changes; matrix regenerates byte-identical; full suite green (8680 passed).
