### PR TITLE
fix(cognito): forward Policies.SignInPolicy on user pool create and update

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -43,7 +43,7 @@ cloudwatch	2026-07-26T20:00:52Z	PASS	55	standard	0727b sweep-b13 staleness re-ru
 cloudwatch-anomaly-detector	2026-07-30T16:41:15Z	PASS	35	verify.sh	final run post review fixes: GetAtt Id + phys-id stability asserted; clean
 codecommit	2026-08-01T09:36:05Z	PASS	83	verify.sh	0801 regression sweep; 3 phases ok, 0 orphans
 codedeploy-lambda-deployment-group	2026-07-26T19:45:58Z	PASS	109	verify.sh	re-run after version-agnostic fixture fix; live-verified, account clean (remnant-warning follow-up: issue #1252)
-cognito	2026-07-21T14:27:28Z	PASS	60	verify.sh	rc ok, orph clean
+cognito	2026-08-08T18:49:35Z	PASS	63	verify.sh	SignInPolicy #1380 assertion added; clean destroy
 cognito-custom-attribute-add	2026-07-26T19:05:27Z	PASS	57	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 cognito-identity-pool	2026-07-26T19:16:39Z	PASS	53	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 cognito-lambda-triggers	2026-07-21T18:07:01Z	PASS	66	verify.sh	rc ok, orph clean

--- a/src/provisioning/providers/cognito-provider.ts
+++ b/src/provisioning/providers/cognito-provider.ts
@@ -17,6 +17,8 @@ import {
   type SchemaAttributeType,
   type LambdaConfigType,
   type PasswordPolicyType,
+  type SignInPolicyType,
+  type UserPoolPolicyType,
   type AdminCreateUserConfigType,
   type AccountRecoverySettingType,
   type UserAttributeUpdateSettingsType,
@@ -324,6 +326,26 @@ export class CognitoUserPoolProvider implements ResourceProvider {
   }
 
   /**
+   * Build the SDK `Policies` input from the CFn `Policies` blob. Both
+   * sub-keys must be forwarded: `SignInPolicy` (passwordless first-auth
+   * factors) was silently dropped before issue #1380, and UpdateUserPool
+   * resets omitted attributes to their defaults, so leaving it out also
+   * wipes an existing sign-in policy on every update.
+   */
+  private toSdkUserPoolPolicies(
+    policies: Record<string, unknown>
+  ): UserPoolPolicyType | undefined {
+    const result: UserPoolPolicyType = {};
+    if (policies['PasswordPolicy']) {
+      result.PasswordPolicy = policies['PasswordPolicy'] as PasswordPolicyType;
+    }
+    if (policies['SignInPolicy']) {
+      result.SignInPolicy = policies['SignInPolicy'] as SignInPolicyType;
+    }
+    return Object.keys(result).length > 0 ? result : undefined;
+  }
+
+  /**
    * Create a Cognito User Pool
    */
   async create(
@@ -360,11 +382,11 @@ export class CognitoUserPoolProvider implements ResourceProvider {
         ] as UsernameAttributeType[];
       }
       if (properties['Policies']) {
-        const policies = properties['Policies'] as Record<string, unknown>;
-        if (policies['PasswordPolicy']) {
-          createParams.Policies = {
-            PasswordPolicy: policies['PasswordPolicy'] as PasswordPolicyType,
-          };
+        const sdkPolicies = this.toSdkUserPoolPolicies(
+          properties['Policies'] as Record<string, unknown>
+        );
+        if (sdkPolicies) {
+          createParams.Policies = sdkPolicies;
         }
       }
       if (properties['Schema']) {
@@ -581,11 +603,11 @@ export class CognitoUserPoolProvider implements ResourceProvider {
       };
 
       if (properties['Policies']) {
-        const policies = properties['Policies'] as Record<string, unknown>;
-        if (policies['PasswordPolicy']) {
-          updateParams.Policies = {
-            PasswordPolicy: policies['PasswordPolicy'] as PasswordPolicyType,
-          };
+        const sdkPolicies = this.toSdkUserPoolPolicies(
+          properties['Policies'] as Record<string, unknown>
+        );
+        if (sdkPolicies) {
+          updateParams.Policies = sdkPolicies;
         }
       }
       if (properties['LambdaConfig']) {

--- a/src/provisioning/providers/cognito-provider.ts
+++ b/src/provisioning/providers/cognito-provider.ts
@@ -332,9 +332,7 @@ export class CognitoUserPoolProvider implements ResourceProvider {
    * resets omitted attributes to their defaults, so leaving it out also
    * wipes an existing sign-in policy on every update.
    */
-  private toSdkUserPoolPolicies(
-    policies: Record<string, unknown>
-  ): UserPoolPolicyType | undefined {
+  private toSdkUserPoolPolicies(policies: Record<string, unknown>): UserPoolPolicyType | undefined {
     const result: UserPoolPolicyType = {};
     if (policies['PasswordPolicy']) {
       result.PasswordPolicy = policies['PasswordPolicy'] as PasswordPolicyType;

--- a/tests/integration/cognito/lib/cognito-stack.ts
+++ b/tests/integration/cognito/lib/cognito-stack.ts
@@ -32,6 +32,16 @@ export class CognitoStack extends cdk.Stack {
         requireDigits: true,
         requireSymbols: false,
       },
+      // Passwordless sign-in policy (issue #1380): synthesizes
+      // Policies.SignInPolicy.AllowedFirstAuthFactors, which the provider
+      // silently dropped on create/update before the fix. EMAIL_OTP as a
+      // FIRST auth factor works with the default Cognito email sender
+      // (unlike EMAIL_OTP as MFA, which needs SES — see the BackfillUserPool
+      // note below). Requires the ESSENTIALS tier, so it is set explicitly.
+      featurePlan: cognito.FeaturePlan.ESSENTIALS,
+      signInPolicy: {
+        allowedFirstAuthFactors: { password: true, emailOtp: true },
+      },
       accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });

--- a/tests/integration/cognito/verify.sh
+++ b/tests/integration/cognito/verify.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # verify.sh — cdkd Cognito::UserPool #609 backfill integ test.
 #
-# Asserts that the BackfillUserPool (an L1 CfnUserPool) lands the issue #609
-# backfill properties on AWS after `cdkd deploy`:
+# Asserts that the L2 TestUserPool's Policies.SignInPolicy (passwordless
+# first-auth factors, issue #1380) lands on AWS after `cdkd deploy`, and that
+# the BackfillUserPool (an L1 CfnUserPool) lands the issue #609
+# backfill properties:
 #   - UserPoolTier                  -> DescribeUserPool.UserPool.UserPoolTier
 #   - EnabledMfas (SOFTWARE_TOKEN_MFA)
 #                                   -> GetUserPoolMfaConfig (per-factor blocks)
@@ -124,6 +126,24 @@ if [ -z "${POOL_ID}" ]; then
 fi
 echo "    Backfill UserPool id: ${POOL_ID}"
 
+# --- Assertion 0: SignInPolicy on the L2 pool (issue #1380) -----------
+# The L2 TestUserPool sets signInPolicy (PASSWORD + EMAIL_OTP). Before the
+# #1380 fix the provider forwarded only Policies.PasswordPolicy, so the
+# deployed pool silently fell back to the PASSWORD-only default.
+L2_POOL_ID=$(echo "${STATE}" | jq -r '.outputs.UserPoolId // empty')
+if [ -z "${L2_POOL_ID}" ]; then
+  echo "FAIL: UserPoolId output missing from state" >&2
+  exit 1
+fi
+FACTORS=$(aws cognito-idp describe-user-pool \
+  --user-pool-id "${L2_POOL_ID}" --region "${REGION}" \
+  --query 'UserPool.Policies.SignInPolicy.AllowedFirstAuthFactors' --output json)
+if ! echo "${FACTORS}" | jq -e 'index("EMAIL_OTP") != null and index("PASSWORD") != null' >/dev/null; then
+  echo "FAIL: SignInPolicy.AllowedFirstAuthFactors is ${FACTORS}, expected to contain PASSWORD and EMAIL_OTP (SignInPolicy dropped — issue #1380)" >&2
+  exit 1
+fi
+echo "    OK: SignInPolicy.AllowedFirstAuthFactors == ${FACTORS}"
+
 # --- Assertion 1: UserPoolTier (DescribeUserPool) ---------------------
 TIER=$(aws cognito-idp describe-user-pool \
   --user-pool-id "${POOL_ID}" --region "${REGION}" \
@@ -196,4 +216,4 @@ assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after des
 echo "    OK: state file is gone"
 
 echo ""
-echo "==> cognito test passed (UserPoolTier / EnabledMfas(SOFTWARE_TOKEN) / WebAuthn* backfill (EMAIL_OTP unit-only) closed + clean destroy)"
+echo "==> cognito test passed (SignInPolicy #1380 / UserPoolTier / EnabledMfas(SOFTWARE_TOKEN) / WebAuthn* backfill (EMAIL_OTP-as-MFA unit-only) closed + clean destroy)"

--- a/tests/unit/provisioning/cognito-provider.test.ts
+++ b/tests/unit/provisioning/cognito-provider.test.ts
@@ -109,6 +109,50 @@ describe('CognitoUserPoolProvider', () => {
         })
       ).rejects.toThrow('Failed to create Cognito User Pool MyUserPool');
     });
+
+    it('should forward Policies.SignInPolicy alongside PasswordPolicy (#1380)', async () => {
+      mockSend.mockResolvedValueOnce({
+        UserPool: {
+          Id: 'us-east-1_abc123',
+          Arn: 'arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_abc123',
+        },
+      });
+
+      await provider.create('MyUserPool', 'AWS::Cognito::UserPool', {
+        Policies: {
+          PasswordPolicy: { MinimumLength: 12 },
+          SignInPolicy: { AllowedFirstAuthFactors: ['PASSWORD', 'EMAIL_OTP'] },
+        },
+      });
+
+      const createCall = mockSend.mock.calls[0][0];
+      expect(createCall.input.Policies).toEqual({
+        PasswordPolicy: { MinimumLength: 12 },
+        SignInPolicy: { AllowedFirstAuthFactors: ['PASSWORD', 'EMAIL_OTP'] },
+      });
+    });
+
+    it('should forward Policies when only SignInPolicy is present (#1380)', async () => {
+      // CDK synthesizes Policies with ONLY SignInPolicy when the user sets
+      // signInPolicy but not passwordPolicy — Policies must still be sent.
+      mockSend.mockResolvedValueOnce({
+        UserPool: {
+          Id: 'us-east-1_abc123',
+          Arn: 'arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_abc123',
+        },
+      });
+
+      await provider.create('MyUserPool', 'AWS::Cognito::UserPool', {
+        Policies: {
+          SignInPolicy: { AllowedFirstAuthFactors: ['PASSWORD', 'WEB_AUTHN'] },
+        },
+      });
+
+      const createCall = mockSend.mock.calls[0][0];
+      expect(createCall.input.Policies).toEqual({
+        SignInPolicy: { AllowedFirstAuthFactors: ['PASSWORD', 'WEB_AUTHN'] },
+      });
+    });
   });
 
   describe('update', () => {
@@ -169,6 +213,40 @@ describe('CognitoUserPoolProvider', () => {
 
       const describeCall = mockSend.mock.calls[1][0];
       expect(describeCall.constructor.name).toBe('DescribeUserPoolCommand');
+    });
+
+    it('should forward Policies.SignInPolicy on update (#1380)', async () => {
+      // UpdateUserPool resets omitted attributes to defaults, so dropping
+      // SignInPolicy here wipes an existing passwordless configuration.
+      mockSend.mockResolvedValueOnce({});
+      mockSend.mockResolvedValueOnce({
+        UserPool: {
+          Arn: 'arn:aws:cognito-idp:us-east-1:123456789012:userpool/us-east-1_abc123',
+        },
+      });
+
+      await provider.update(
+        'MyUserPool',
+        'us-east-1_abc123',
+        'AWS::Cognito::UserPool',
+        {
+          Policies: {
+            PasswordPolicy: { MinimumLength: 12 },
+            SignInPolicy: { AllowedFirstAuthFactors: ['PASSWORD', 'EMAIL_OTP'] },
+          },
+        },
+        {
+          Policies: {
+            PasswordPolicy: { MinimumLength: 8 },
+          },
+        }
+      );
+
+      const updateCall = mockSend.mock.calls[0][0];
+      expect(updateCall.input.Policies).toEqual({
+        PasswordPolicy: { MinimumLength: 12 },
+        SignInPolicy: { AllowedFirstAuthFactors: ['PASSWORD', 'EMAIL_OTP'] },
+      });
     });
 
     it('adds a new custom attribute via AddCustomAttributes (Schema in-place add)', async () => {


### PR DESCRIPTION
## Summary

Closes #1380.

`CognitoUserPoolProvider` forwarded only `PasswordPolicy` out of the CFn `Policies` blob, in BOTH `create()` and `update()`. A CDK `UserPool` with `signInPolicy` (passwordless first-auth factors) therefore deployed "successfully" while the policy never reached AWS — live-confirmed before the fix: template requested `AllowedFirstAuthFactors: [PASSWORD, EMAIL_OTP]`, deployed pool showed the `[PASSWORD]` default. Because `UpdateUserPool` resets omitted attributes to their defaults (per the SDK model JSDoc), the update path also wiped an existing sign-in policy — e.g. on pools adopted via `cdkd import --migrate-from-cloudformation`.

This is the *selective sub-key forward* variant of the #1370 class: the key spelling matches the SDK member, so the #1373 nested-key critic structurally cannot flag it (recorded in #1393 item 5).

## Changes

- `src/provisioning/providers/cognito-provider.ts`: new `toSdkUserPoolPolicies()` helper builds `Policies` from BOTH `PasswordPolicy` and `SignInPolicy`; used by `create()` and `update()`. `Policies` is now also sent when the template carries only `SignInPolicy` (CDK synthesizes that shape when `signInPolicy` is set without `passwordPolicy`).
- `tests/unit/provisioning/cognito-provider.test.ts`: 3 new tests (create with both sub-keys, create with SignInPolicy only, update forwards SignInPolicy) — verified to FAIL without the fix (revert probe: 3 failed).
- `tests/integration/cognito/`: the L2 `TestUserPool` gains `signInPolicy` (PASSWORD + EMAIL_OTP; ESSENTIALS tier set explicitly) and `verify.sh` asserts the factors land on AWS via `DescribeUserPool`. EMAIL_OTP as a FIRST auth factor works with the default Cognito email sender (unlike EMAIL_OTP-as-MFA, which needs SES — the existing fixture note).

## Verification

- Unit: 8682 tests pass (full suite); the 3 new tests fail without the fix.
- Live: redeployed the repro pool with the fixed binary — `DescribeUserPool` now shows `AllowedFirstAuthFactors: [PASSWORD, EMAIL_OTP]`.
- Integ: `/run-integ cognito` PASS (63s), destroy 0 errors / 0 orphans (ledger updated).
- `readCurrentState` already returns the full `Policies` from AWS, so drift works with no read-side change.

## Notes

- Found by the 2026-08-09 `/hunt-bugs` sweep (the #1370/#1371 horizontal audit). Critic-side follow-up so this sub-class gets mechanical coverage is tracked in #1393.
