### PR TITLE
fix(wafv2): decode SearchStringBase64 and rename reference-statement Arn to the SDK ARN

### DIFF
--- a/.claude/rules/providers.md
+++ b/.claude/rules/providers.md
@@ -114,6 +114,37 @@ hand-fed inline `Tags` and so agreed with the bug.
 - Ask of any test: "would this still pass if the API returned nothing for this
   field?" If yes, it pins your assumption, not the behavior.
 
+## Fixing ONE nested-key divergence: diff the WHOLE blob, not the reported key
+
+A filed silent-drop bug names the key someone happened to notice. Fixing only
+that key leaves its siblings broken, and the sibling is often the WIDER
+breakage — the reported key may be the rarer shape.
+
+Issue #1389 reported `ByteMatchStatement.SearchStringBase64` (CFn-only, no SDK
+member) on `AWS::WAFv2::WebACL`. A reviewer extracted **all 154** CFn keys in the
+`CfnWebACL` tree from `aws-cdk-lib`'s `convertCfnWebACL*PropertyToCloudFormation`
+renderers and diffed them against the SDK schema member-name set. That found a
+second divergence the issue never mentioned: CFn spells the reference-statement
+ARN `Arn` while `IPSetReferenceStatement` / `RegexPatternSetReferenceStatement` /
+`RuleGroupReferenceStatement` all declare it `ARN` **and mark it required** — so
+every WebACL using a reference statement failed `CreateWebACL`, base64 or not.
+That is a far more common template shape than the base64 search string.
+
+**Before fixing a nested-key divergence:**
+
+- Enumerate the CFn side MECHANICALLY, from `aws-cdk-lib`'s generated
+  `convertCfn<Type><Prop>PropertyToCloudFormation` functions or the registry
+  schema's `nestedProperties` capture — not by reading the type by eye.
+- Enumerate the SDK side from the schema serde aliases
+  (`node_modules/@aws-sdk/client-*/dist-cjs/schemas/schemas_0.js`) as well as the
+  `.d.ts` members: the aliases are what the serializer actually iterates, so
+  "`_ARN = "ARN"` exists and `_Arn` does not" is the decisive evidence.
+- Diff the two sets and fix EVERY divergence in the same change. Report the
+  count you compared, so a reviewer can tell a full diff from a spot-check.
+- Prefer adding the type to `NESTED_KEY_TARGETS` (see step 4 below) over relying
+  on this being done by hand next time — the mechanical critic is the durable
+  form of this rule, and a type inside it cannot regress.
+
 ## Adding a New SDK Provider
 
 1. Create new file in `src/provisioning/providers/`

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -268,5 +268,5 @@ vpc-lambda	2026-07-26T16:53:02Z	PASS	386	standard	0727 P0 sweep (ec2-provider ch
 vpc-lambda-cr-race	2026-07-24T11:03:24Z	PASS	432	standard	0724b sweep staleness; 9 del 0 err 0 orphans incl hyperplane ENI
 vpc-lookup	2026-07-24T10:55:09Z	PASS	20	standard	0724b sweep staleness; context-provider loop ok; 1 del 0 err 0 orphans
 vpc-nat-gateway	2026-07-22T08:08:02Z	PASS		standard	TTL-refresh sweep; standard flow (classifier-approved direct deploy/destroy); 21 created / 21 deleted 0 err; NAT GW + VPC + EIP + ENI all gone, state gone
-wafv2	2026-07-26T19:36:49Z	PASS	58	standard	0727b sweep-b11 staleness re-run (rc=0); account clean
+wafv2	2026-08-09T06:52:50Z	PASS	130	standard	#1389 SearchStringBase64 + reference-statement Arn->ARN asserted via GetWebACL at all 3 sites; 7 del/2 retained/0 err. NOT re-runnable: RETAIN ApiGateway CloudWatch role collides (#1407)
 wait-condition-handle	2026-07-31T06:19:56Z	PASS	44	verify.sh	TTL-refresh sweep re-run; rc ok, orph clean

--- a/src/provisioning/providers/wafv2-provider.ts
+++ b/src/provisioning/providers/wafv2-provider.ts
@@ -52,6 +52,195 @@ function sanitizeDescription(value: unknown): string | undefined {
   return value as string;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * CFn `Rules` members that have NO counterpart in the installed
+ * `@aws-sdk/client-wafv2` model (verified: zero hits in
+ * `dist-types/models/models_0.d.ts`).
+ *
+ * The AWS SDK v3 serializer drops unknown members, so these silently do
+ * not reach AWS no matter what cdkd forwards. There is no mapping cdkd
+ * can invent — the fix is an SDK bump, after which the spellings already
+ * match and no code here has to change. Until then the drop is made LOUD
+ * (`warnOnSdkUnsupportedRuleKeys`) instead of silent.
+ *
+ * They cannot be declared in `unhandledByDesign` either: that map is
+ * TOP-LEVEL CFn property granularity, and all three are nested inside
+ * `Rules`, which the provider genuinely handles.
+ */
+const SDK_UNSUPPORTED_RULE_KEYS: readonly string[] = [
+  // TextTransformation.PreParseTextTransformations
+  'PreParseTextTransformations',
+  // Rule action Monetize / its PriceMultiplier
+  'Monetize',
+  'PriceMultiplier',
+];
+
+/**
+ * Convert a CFn `ByteMatchStatement` into the SDK shape.
+ *
+ * `SearchStringBase64` exists ONLY in CloudFormation — the SDK models
+ * carry a single `SearchString: Uint8Array | undefined` blob member
+ * (`@aws-sdk/client-wafv2/dist-types/models/models_0.d.ts:1034`).
+ * Forwarding the CFn blob raw made the serializer drop the unknown key
+ * and `CreateWebACL` then failed validation on the missing required
+ * `SearchString` (issue #1389).
+ *
+ * The decoded bytes are passed as a `Uint8Array`, matching the declared
+ * member type: the JSON serializer base64-encodes a blob member on the
+ * wire, so decoding here reproduces byte-for-byte what CloudFormation
+ * sends. Plain `SearchString` values are deliberately left untouched —
+ * the same serializer accepts a string at a blob member and UTF-8 +
+ * base64 encodes it, which is exactly the existing (working) behavior.
+ *
+ * Precedence when a template carries BOTH keys: `SearchStringBase64`
+ * wins. CloudFormation treats them as mutually exclusive and rejects
+ * such a template, so any choice is arbitrary; the explicit-encoding
+ * form is preferred because it is the only one that can express
+ * non-UTF-8 bytes, so honoring it never loses information.
+ */
+function toSdkByteMatchStatement(
+  byteMatchStatement: Record<string, unknown>
+): Record<string, unknown> {
+  const encoded = byteMatchStatement['SearchStringBase64'];
+  if (typeof encoded !== 'string') return byteMatchStatement;
+
+  const converted: Record<string, unknown> = { ...byteMatchStatement };
+  delete converted['SearchStringBase64'];
+  converted['SearchString'] = Uint8Array.from(Buffer.from(encoded, 'base64'));
+  return converted;
+}
+
+/**
+ * CFn `Statement` members that carry a reference ARN.
+ *
+ * CloudFormation spells the member `Arn`; every one of these SDK types
+ * declares it `ARN` (and marks it REQUIRED) — verified against
+ * `@aws-sdk/client-wafv2` `models_0.d.ts` (`IPSetReferenceStatement` /
+ * `RegexPatternSetReferenceStatement` / `RuleGroupReferenceStatement`),
+ * whose schema serde carries a single `_ARN = "ARN"` alias and no `Arn`.
+ * The serializer drops the CFn spelling, so `CreateWebACL` fails
+ * validation on the missing required `ARN` — the same silent-drop class
+ * as `SearchStringBase64`, and the only other one in the whole `Rules`
+ * tree (all 154 CFn keys were diffed against the SDK member set).
+ */
+const ARN_REFERENCE_STATEMENT_KEYS: readonly string[] = [
+  'IPSetReferenceStatement',
+  'RegexPatternSetReferenceStatement',
+  'RuleGroupReferenceStatement',
+];
+
+/**
+ * Recursively convert a CFn `Statement` tree into the SDK shape.
+ *
+ * Two conversions ride this walk: the `ByteMatchStatement`
+ * `SearchStringBase64` decode and the reference-statement `Arn` -> `ARN`
+ * rename (see {@link ARN_REFERENCE_STATEMENT_KEYS}). Both leaves are
+ * nestable, so the walk has to cover every recursion point the SDK
+ * `Statement` union declares:
+ *   - `NotStatement.Statement`            (single nested Statement)
+ *   - `AndStatement.Statements[]`         (Statement array)
+ *   - `OrStatement.Statements[]`          (Statement array)
+ *   - `RateBasedStatement.ScopeDownStatement`
+ *   - `ManagedRuleGroupStatement.ScopeDownStatement`
+ *
+ * That list mirrors the SDK model exactly — those are the only members
+ * typed `Statement` / `Statement[]`. `RuleGroupReferenceStatement` is
+ * NOT a recursion point (it declares no nested statement member, only
+ * `ARN` / `ExcludedRules` / `RuleActionOverrides`); it appears in the
+ * ARN list above for the rename alone. Extend either list if AWS adds a
+ * member.
+ *
+ * The caller's object is never mutated — every level is rebuilt.
+ */
+function toSdkStatement(statement: Record<string, unknown>): Record<string, unknown> {
+  const converted: Record<string, unknown> = { ...statement };
+
+  const byteMatchStatement = converted['ByteMatchStatement'];
+  if (isPlainObject(byteMatchStatement)) {
+    converted['ByteMatchStatement'] = toSdkByteMatchStatement(byteMatchStatement);
+  }
+
+  for (const key of ARN_REFERENCE_STATEMENT_KEYS) {
+    const reference = converted[key];
+    if (!isPlainObject(reference) || !('Arn' in reference)) continue;
+    const { Arn: arn, ...rest } = reference;
+    converted[key] = { ...rest, ARN: arn };
+  }
+
+  const notStatement = converted['NotStatement'];
+  if (isPlainObject(notStatement)) {
+    const nested = notStatement['Statement'];
+    if (isPlainObject(nested)) {
+      converted['NotStatement'] = { ...notStatement, Statement: toSdkStatement(nested) };
+    }
+  }
+
+  for (const key of ['AndStatement', 'OrStatement']) {
+    const combined = converted[key];
+    if (!isPlainObject(combined)) continue;
+    const nested = combined['Statements'];
+    if (!Array.isArray(nested)) continue;
+    converted[key] = {
+      ...combined,
+      Statements: nested.map((item) => (isPlainObject(item) ? toSdkStatement(item) : item)),
+    };
+  }
+
+  for (const key of ['RateBasedStatement', 'ManagedRuleGroupStatement']) {
+    const scoping = converted[key];
+    if (!isPlainObject(scoping)) continue;
+    const nested = scoping['ScopeDownStatement'];
+    if (!isPlainObject(nested)) continue;
+    converted[key] = { ...scoping, ScopeDownStatement: toSdkStatement(nested) };
+  }
+
+  return converted;
+}
+
+/**
+ * Convert the CFn `Rules` blob into the SDK `Rule[]` shape.
+ *
+ * Falsy input degrades to `[]`, matching the previous
+ * `(properties['Rules'] as Rule[]) || []` behavior exactly. A truthy NON-array
+ * (an unresolved intrinsic) is deliberately passed through instead:
+ * defaulting it to `[]` would make `update()` a silent `UpdateWebACL`
+ * that wipes every rule and still reports success, where the old code
+ * handed the value to the SDK and failed loudly.
+ */
+function toSdkRules(rules: unknown): Rule[] {
+  // Falsy (absent / null / '' / 0 / false) degrades to `[]` for EXACT parity
+  // with the previous `(properties['Rules'] as Rule[]) || []`. Only a TRUTHY
+  // non-array passes through.
+  if (!rules) return [];
+  if (!Array.isArray(rules)) return rules as unknown as Rule[];
+  return rules.map((rule) => {
+    if (!isPlainObject(rule)) return rule as unknown as Rule;
+    const statement = rule['Statement'];
+    if (!isPlainObject(statement)) return rule as unknown as Rule;
+    return { ...rule, Statement: toSdkStatement(statement) } as unknown as Rule;
+  });
+}
+
+/**
+ * Collect every {@link SDK_UNSUPPORTED_RULE_KEYS} member present anywhere
+ * in the CFn `Rules` blob, so the caller can report the silent drop.
+ */
+function collectSdkUnsupportedRuleKeys(value: unknown, found: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) collectSdkUnsupportedRuleKeys(item, found);
+    return;
+  }
+  if (!isPlainObject(value)) return;
+  for (const [key, nested] of Object.entries(value)) {
+    if (SDK_UNSUPPORTED_RULE_KEYS.includes(key)) found.add(key);
+    collectSdkUnsupportedRuleKeys(nested, found);
+  }
+}
+
 /**
  * Parse WAFv2 WebACL ARN to extract Id, Name, and Scope.
  *
@@ -140,6 +329,8 @@ export class WAFv2WebACLProvider implements ResourceProvider {
       generateResourceName(logicalId, { maxLength: 128 });
     const scope = ((properties['Scope'] as string) || 'REGIONAL') as Scope;
 
+    this.warnOnSdkUnsupportedRuleKeys(logicalId, properties['Rules']);
+
     try {
       // Build tags
       const tags: Tag[] = [];
@@ -156,7 +347,7 @@ export class WAFv2WebACLProvider implements ResourceProvider {
           Scope: scope,
           DefaultAction: properties['DefaultAction'] as DefaultAction,
           Description: sanitizeDescription(properties['Description']),
-          Rules: (properties['Rules'] as Rule[]) || [],
+          Rules: toSdkRules(properties['Rules']),
           VisibilityConfig: properties['VisibilityConfig'] as VisibilityConfig,
           ...(tags.length > 0 && { Tags: tags }),
           CustomResponseBodies: properties['CustomResponseBodies'] as
@@ -212,6 +403,8 @@ export class WAFv2WebACLProvider implements ResourceProvider {
   ): Promise<ResourceUpdateResult> {
     this.logger.debug(`Updating WAFv2 WebACL ${logicalId}: ${physicalId}`);
 
+    this.warnOnSdkUnsupportedRuleKeys(logicalId, properties['Rules']);
+
     try {
       const { id, name, scope } = parseWebACLArn(physicalId);
 
@@ -237,7 +430,7 @@ export class WAFv2WebACLProvider implements ResourceProvider {
           LockToken: lockToken,
           DefaultAction: properties['DefaultAction'] as DefaultAction,
           Description: sanitizeDescription(properties['Description']),
-          Rules: (properties['Rules'] as Rule[]) || [],
+          Rules: toSdkRules(properties['Rules']),
           VisibilityConfig: properties['VisibilityConfig'] as VisibilityConfig,
           CustomResponseBodies: properties['CustomResponseBodies'] as
             | Record<string, CustomResponseBody>
@@ -346,6 +539,26 @@ export class WAFv2WebACLProvider implements ResourceProvider {
         cause
       );
     }
+  }
+
+  /**
+   * Report every CFn `Rules` member the installed `@aws-sdk/client-wafv2`
+   * model has no counterpart for, so the drop is visible instead of
+   * silent. See {@link SDK_UNSUPPORTED_RULE_KEYS} for why cdkd cannot map
+   * them and what makes them work (an SDK bump).
+   */
+  private warnOnSdkUnsupportedRuleKeys(logicalId: string, rules: unknown): void {
+    const found = new Set<string>();
+    collectSdkUnsupportedRuleKeys(rules, found);
+    if (found.size === 0) return;
+
+    const sorted = [...found].sort();
+    const names = sorted.join(', ');
+    const subject = sorted.length === 1 ? 'property' : 'properties';
+    const verb = sorted.length === 1 ? 'has' : 'have';
+    this.logger.warn(
+      `WAFv2 WebACL ${logicalId}: rule ${subject} ${names} ${verb} no member in the installed AWS SDK WAFv2 model and will NOT be sent to AWS. Upgrade cdkd once its @aws-sdk/client-wafv2 dependency carries the ${subject}.`
+    );
   }
 
   /**

--- a/tests/integration/wafv2/lib/wafv2-stack.ts
+++ b/tests/integration/wafv2/lib/wafv2-stack.ts
@@ -11,6 +11,17 @@ import * as apigateway from 'aws-cdk-lib/aws-apigateway';
  * - AWS::WAFv2::WebACL
  * - AWS::WAFv2::WebACLAssociation
  * - AWS::ApiGateway::RestApi
+ *
+ * The WebACL also exercises both CFn-vs-SDK spelling divergences in the Rules
+ * tree (issue #1389), so the deploy itself is the regression signal -- pre-fix
+ * the SDK serializer dropped each unknown key and CreateWebACL failed
+ * validation on the missing required member:
+ *
+ * - Two ByteMatchStatements written with the CFn-only `SearchStringBase64`
+ *   key, one nested under the rate-based rule's ScopeDownStatement and one
+ *   under a NotStatement.
+ * - An IPSetReferenceStatement whose CFn `Arn` member the SDK spells `ARN`,
+ *   nested under an AndStatement.
  */
 export class Wafv2Stack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -50,6 +61,77 @@ export class Wafv2Stack extends cdk.Stack {
             rateBasedStatement: {
               limit: 2000,
               aggregateKeyType: 'IP',
+              // NESTED ByteMatchStatement (issue #1389): the scope-down of a
+              // RateBasedStatement is one of the statement-tree recursion
+              // points the base64 conversion has to walk. Base64 of
+              // 'cdkd-scoped'.
+              scopeDownStatement: {
+                byteMatchStatement: {
+                  searchStringBase64: 'Y2RrZC1zY29wZWQ=',
+                  fieldToMatch: { uriPath: {} },
+                  positionalConstraint: 'CONTAINS',
+                  textTransformations: [{ priority: 0, type: 'NONE' }],
+                },
+              },
+            },
+          },
+        },
+        {
+          // Issue #1389: SearchStringBase64 exists ONLY in CloudFormation --
+          // the SDK models carry a single SearchString blob member -- so the
+          // AWS SDK v3 serializer dropped the unknown key and CreateWebACL
+          // failed validation on the missing required SearchString. This rule
+          // therefore makes the whole deploy fail without the fix, which is
+          // exactly the regression signal we want from a standard-flow fixture.
+          // Base64 of 'cdkd-blocked'.
+          name: 'Base64ByteMatchRule',
+          priority: 2,
+          action: { block: {} },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'Base64ByteMatchRule',
+            sampledRequestsEnabled: true,
+          },
+          statement: {
+            notStatement: {
+              statement: {
+                byteMatchStatement: {
+                  searchStringBase64: 'Y2RrZC1ibG9ja2Vk',
+                  fieldToMatch: { singleHeader: { Name: 'user-agent' } },
+                  positionalConstraint: 'CONTAINS',
+                  textTransformations: [{ priority: 0, type: 'LOWERCASE' }],
+                },
+              },
+            },
+          },
+        },
+        {
+          // The other CFn-vs-SDK spelling divergence in the Rules tree: CFn
+          // spells the reference-statement member `Arn`, the SDK declares it
+          // `ARN` and marks it REQUIRED, so pre-fix the serializer dropped it
+          // and CreateWebACL rejected the stack. Exercised at a nested
+          // recursion point (under AndStatement) so the walk is covered too.
+          name: 'IPSetReferenceRule',
+          priority: 3,
+          action: { block: {} },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'IPSetReferenceRule',
+            sampledRequestsEnabled: true,
+          },
+          statement: {
+            andStatement: {
+              statements: [
+                { ipSetReferenceStatement: { arn: ipSet.attrArn } },
+                {
+                  byteMatchStatement: {
+                    searchString: 'cdkd-plain',
+                    fieldToMatch: { uriPath: {} },
+                    positionalConstraint: 'CONTAINS',
+                    textTransformations: [{ priority: 0, type: 'NONE' }],
+                  },
+                },
+              ],
             },
           },
         },

--- a/tests/unit/provisioning/wafv2-provider-search-string-base64.test.ts
+++ b/tests/unit/provisioning/wafv2-provider-search-string-base64.test.ts
@@ -1,0 +1,500 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const mockSend = vi.hoisted(() => vi.fn());
+// `vi.hoisted` runs before the hoisted `vi.mock` factory, so the spy exists
+// when the provider's module-level `getLogger().child(...)` call resolves.
+const mockWarn = vi.hoisted(() => vi.fn());
+
+vi.mock('@aws-sdk/client-wafv2', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-wafv2')>(
+    '@aws-sdk/client-wafv2'
+  );
+  return {
+    ...actual,
+    WAFV2Client: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: mockWarn,
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: mockWarn,
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { WAFv2WebACLProvider } from '../../../src/provisioning/providers/wafv2-provider.js';
+
+const TEST_ARN = 'arn:aws:wafv2:us-east-1:123456789012:regional/webacl/my-acl/abc-123-def';
+const TEST_ID = 'abc-123-def';
+const RESOURCE_TYPE = 'AWS::WAFv2::WebACL';
+
+const VISIBILITY_CONFIG = {
+  CloudWatchMetricsEnabled: true,
+  MetricName: 'my-acl-metric',
+  SampledRequestsEnabled: true,
+};
+
+// "BadBot" base64-encoded — the exact example AWS uses in the
+// SearchStringBase64 docs.
+const BAD_BOT_BASE64 = 'QmFkQm90';
+const BAD_BOT_BYTES = Uint8Array.from(Buffer.from('BadBot', 'utf8'));
+
+function byteMatchStatement(searchKey: 'SearchString' | 'SearchStringBase64', value: string) {
+  return {
+    ByteMatchStatement: {
+      [searchKey]: value,
+      FieldToMatch: { SingleHeader: { Name: 'user-agent' } },
+      PositionalConstraint: 'CONTAINS',
+      TextTransformations: [{ Priority: 0, Type: 'NONE' }],
+    },
+  };
+}
+
+function rule(statement: Record<string, unknown>) {
+  return {
+    Name: 'block-bad-bot',
+    Priority: 0,
+    Action: { Block: {} },
+    Statement: statement,
+    VisibilityConfig: VISIBILITY_CONFIG,
+  };
+}
+
+function baseProperties(rules: unknown[]) {
+  return {
+    Name: 'my-acl',
+    Scope: 'REGIONAL',
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: VISIBILITY_CONFIG,
+    Rules: rules,
+  };
+}
+
+/** Drive create() and return the `Rules` the CreateWebACL command carried. */
+async function createdRules(
+  provider: WAFv2WebACLProvider,
+  rules: unknown[]
+): Promise<Record<string, unknown>[]> {
+  mockSend.mockResolvedValueOnce({ Summary: { ARN: TEST_ARN, Id: TEST_ID } });
+  await provider.create('MyWebACL', RESOURCE_TYPE, baseProperties(rules));
+  return mockSend.mock.calls[0][0].input.Rules;
+}
+
+describe('WAFv2WebACLProvider ByteMatchStatement.SearchStringBase64 (issue #1389)', () => {
+  let provider: WAFv2WebACLProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new WAFv2WebACLProvider();
+  });
+
+  describe('create', () => {
+    it('decodes a top-level SearchStringBase64 into the SDK SearchString blob', async () => {
+      const rules = await createdRules(provider, [
+        rule(byteMatchStatement('SearchStringBase64', BAD_BOT_BASE64)),
+      ]);
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const byteMatch = statement['ByteMatchStatement'] as Record<string, unknown>;
+      expect(byteMatch['SearchString']).toEqual(BAD_BOT_BYTES);
+      expect(byteMatch).not.toHaveProperty('SearchStringBase64');
+      // Sibling members are preserved verbatim.
+      expect(byteMatch['PositionalConstraint']).toBe('CONTAINS');
+    });
+
+    it('decodes a SearchStringBase64 nested under AndStatement / NotStatement', async () => {
+      const rules = await createdRules(provider, [
+        rule({
+          AndStatement: {
+            Statements: [
+              { NotStatement: { Statement: byteMatchStatement('SearchStringBase64', 'QQ==') } },
+              byteMatchStatement('SearchStringBase64', BAD_BOT_BASE64),
+            ],
+          },
+        }),
+      ]);
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const and = statement['AndStatement'] as Record<string, unknown>;
+      const nested = and['Statements'] as Record<string, unknown>[];
+
+      const notInner = (nested[0]!['NotStatement'] as Record<string, unknown>)[
+        'Statement'
+      ] as Record<string, unknown>;
+      const notByteMatch = notInner['ByteMatchStatement'] as Record<string, unknown>;
+      expect(notByteMatch['SearchString']).toEqual(Uint8Array.from([0x41]));
+      expect(notByteMatch).not.toHaveProperty('SearchStringBase64');
+
+      const siblingByteMatch = nested[1]!['ByteMatchStatement'] as Record<string, unknown>;
+      expect(siblingByteMatch['SearchString']).toEqual(BAD_BOT_BYTES);
+      expect(siblingByteMatch).not.toHaveProperty('SearchStringBase64');
+    });
+
+    it('decodes a SearchStringBase64 nested under OrStatement', async () => {
+      const rules = await createdRules(provider, [
+        rule({
+          OrStatement: {
+            Statements: [byteMatchStatement('SearchStringBase64', BAD_BOT_BASE64)],
+          },
+        }),
+      ]);
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const or = statement['OrStatement'] as Record<string, unknown>;
+      const nested = (or['Statements'] as Record<string, unknown>[])[0]!;
+      const byteMatch = nested['ByteMatchStatement'] as Record<string, unknown>;
+      expect(byteMatch['SearchString']).toEqual(BAD_BOT_BYTES);
+      expect(byteMatch).not.toHaveProperty('SearchStringBase64');
+    });
+
+    it('decodes a SearchStringBase64 under RateBasedStatement.ScopeDownStatement', async () => {
+      const rules = await createdRules(provider, [
+        rule({
+          RateBasedStatement: {
+            Limit: 2000,
+            AggregateKeyType: 'IP',
+            ScopeDownStatement: byteMatchStatement('SearchStringBase64', BAD_BOT_BASE64),
+          },
+        }),
+      ]);
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const rateBased = statement['RateBasedStatement'] as Record<string, unknown>;
+      const scopeDown = rateBased['ScopeDownStatement'] as Record<string, unknown>;
+      const byteMatch = scopeDown['ByteMatchStatement'] as Record<string, unknown>;
+      expect(byteMatch['SearchString']).toEqual(BAD_BOT_BYTES);
+      expect(byteMatch).not.toHaveProperty('SearchStringBase64');
+      // Sibling members of the rate-based statement survive the rebuild.
+      expect(rateBased['Limit']).toBe(2000);
+    });
+
+    it('decodes a SearchStringBase64 under ManagedRuleGroupStatement.ScopeDownStatement', async () => {
+      const rules = await createdRules(provider, [
+        rule({
+          ManagedRuleGroupStatement: {
+            VendorName: 'AWS',
+            Name: 'AWSManagedRulesCommonRuleSet',
+            ScopeDownStatement: byteMatchStatement('SearchStringBase64', BAD_BOT_BASE64),
+          },
+        }),
+      ]);
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const managed = statement['ManagedRuleGroupStatement'] as Record<string, unknown>;
+      const scopeDown = managed['ScopeDownStatement'] as Record<string, unknown>;
+      const byteMatch = scopeDown['ByteMatchStatement'] as Record<string, unknown>;
+      expect(byteMatch['SearchString']).toEqual(BAD_BOT_BYTES);
+      expect(byteMatch).not.toHaveProperty('SearchStringBase64');
+    });
+
+    it('leaves a plain SearchString untouched', async () => {
+      const rules = await createdRules(provider, [
+        rule(byteMatchStatement('SearchString', 'BadBot')),
+      ]);
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const byteMatch = statement['ByteMatchStatement'] as Record<string, unknown>;
+      // The SDK's JSON serializer accepts a string at a blob member (UTF-8 +
+      // base64 on the wire), so the pre-existing behavior must not change.
+      expect(byteMatch['SearchString']).toBe('BadBot');
+    });
+
+    it('prefers SearchStringBase64 when a template carries both keys', async () => {
+      const rules = await createdRules(provider, [
+        rule({
+          ByteMatchStatement: {
+            SearchString: 'ignored',
+            SearchStringBase64: BAD_BOT_BASE64,
+            FieldToMatch: { SingleHeader: { Name: 'user-agent' } },
+            PositionalConstraint: 'CONTAINS',
+            TextTransformations: [{ Priority: 0, Type: 'NONE' }],
+          },
+        }),
+      ]);
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const byteMatch = statement['ByteMatchStatement'] as Record<string, unknown>;
+      expect(byteMatch['SearchString']).toEqual(BAD_BOT_BYTES);
+      expect(byteMatch).not.toHaveProperty('SearchStringBase64');
+    });
+
+    it('does not mutate the caller-supplied properties object', async () => {
+      const inputRules = [rule(byteMatchStatement('SearchStringBase64', BAD_BOT_BASE64))];
+      await createdRules(provider, inputRules);
+
+      const original = (inputRules[0]!.Statement as Record<string, unknown>)[
+        'ByteMatchStatement'
+      ] as Record<string, unknown>;
+      expect(original['SearchStringBase64']).toBe(BAD_BOT_BASE64);
+      expect(original).not.toHaveProperty('SearchString');
+    });
+
+    it('still sends an empty Rules array when the property is absent', async () => {
+      mockSend.mockResolvedValueOnce({ Summary: { ARN: TEST_ARN, Id: TEST_ID } });
+      await provider.create('MyWebACL', RESOURCE_TYPE, {
+        Name: 'my-acl',
+        Scope: 'REGIONAL',
+        DefaultAction: { Allow: {} },
+        VisibilityConfig: VISIBILITY_CONFIG,
+      });
+
+      expect(mockSend.mock.calls[0][0].input.Rules).toEqual([]);
+    });
+  });
+
+  describe('update', () => {
+    it('decodes SearchStringBase64 on the update path too', async () => {
+      // GetWebACL (LockToken), then UpdateWebACL.
+      mockSend.mockResolvedValueOnce({ LockToken: 'lock-token-123', WebACL: {} });
+      mockSend.mockResolvedValueOnce({});
+
+      await provider.update(
+        'MyWebACL',
+        TEST_ARN,
+        RESOURCE_TYPE,
+        baseProperties([
+          rule({
+            NotStatement: { Statement: byteMatchStatement('SearchStringBase64', BAD_BOT_BASE64) },
+          }),
+        ]),
+        baseProperties([])
+      );
+
+      const updateCall = mockSend.mock.calls[1][0];
+      expect(updateCall.constructor.name).toBe('UpdateWebACLCommand');
+      const statement = updateCall.input.Rules[0]['Statement'] as Record<string, unknown>;
+      const not = statement['NotStatement'] as Record<string, unknown>;
+      const inner = not['Statement'] as Record<string, unknown>;
+      const byteMatch = inner['ByteMatchStatement'] as Record<string, unknown>;
+      expect(byteMatch['SearchString']).toEqual(BAD_BOT_BYTES);
+      expect(byteMatch).not.toHaveProperty('SearchStringBase64');
+    });
+  });
+
+  describe('SDK-unsupported rule properties', () => {
+    it('warns loudly on create when a rule carries a property the SDK model lacks', async () => {
+      mockSend.mockResolvedValueOnce({ Summary: { ARN: TEST_ARN, Id: TEST_ID } });
+      await provider.create(
+        'MyWebACL',
+        RESOURCE_TYPE,
+        baseProperties([
+          {
+            Name: 'monetize-bots',
+            Priority: 0,
+            Action: { Monetize: { PriceMultiplier: 2 } },
+            Statement: {
+              ByteMatchStatement: {
+                SearchString: 'BadBot',
+                FieldToMatch: { SingleHeader: { Name: 'user-agent' } },
+                PositionalConstraint: 'CONTAINS',
+                TextTransformations: [
+                  { Priority: 0, Type: 'NONE', PreParseTextTransformations: [{ Type: 'JSON' }] },
+                ],
+              },
+            },
+            VisibilityConfig: VISIBILITY_CONFIG,
+          },
+        ])
+      );
+
+      expect(mockWarn).toHaveBeenCalledTimes(1);
+      const message = mockWarn.mock.calls[0][0] as string;
+      expect(message).toContain('MyWebACL');
+      expect(message).toContain('Monetize');
+      expect(message).toContain('PreParseTextTransformations');
+      expect(message).toContain('PriceMultiplier');
+      // Three names -> the plural branch of the message must be selected.
+      expect(message).toContain('rule properties');
+      expect(message).toContain('have no member');
+    });
+
+    it('warns on the update path too', async () => {
+      mockSend.mockResolvedValueOnce({ LockToken: 'lock-token-123', WebACL: {} });
+      mockSend.mockResolvedValueOnce({});
+
+      await provider.update(
+        'MyWebACL',
+        TEST_ARN,
+        RESOURCE_TYPE,
+        baseProperties([
+          {
+            Name: 'monetize-bots',
+            Priority: 0,
+            Action: { Monetize: {} },
+            Statement: byteMatchStatement('SearchString', 'BadBot'),
+            VisibilityConfig: VISIBILITY_CONFIG,
+          },
+        ]),
+        baseProperties([])
+      );
+
+      expect(mockWarn).toHaveBeenCalledTimes(1);
+      const updateMessage = mockWarn.mock.calls[0][0] as string;
+      expect(updateMessage).toContain('Monetize');
+      // One name -> the singular branch. Pinning both branches keeps the
+      // grammar swap from silently regressing.
+      expect(updateMessage).toContain('rule property Monetize has no member');
+    });
+
+    it('stays quiet for rules that use only SDK-supported properties', async () => {
+      await createdRules(provider, [rule(byteMatchStatement('SearchStringBase64', BAD_BOT_BASE64))]);
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  // The other CFn-vs-SDK spelling divergence in the whole Rules tree: CFn
+  // spells the reference-statement member `Arn`, every one of these SDK types
+  // declares it `ARN` and marks it REQUIRED, so the serializer dropped it and
+  // CreateWebACL failed validation the same way SearchStringBase64 did.
+  describe('reference-statement Arn -> ARN', () => {
+    const IPSET_ARN = 'arn:aws:wafv2:us-east-1:123456789012:regional/ipset/blocked/ip-1';
+    const REGEX_ARN = 'arn:aws:wafv2:us-east-1:123456789012:regional/regexpatternset/re/re-1';
+    const GROUP_ARN = 'arn:aws:wafv2:us-east-1:123456789012:regional/rulegroup/rg/rg-1';
+
+    it.each([
+      ['IPSetReferenceStatement', IPSET_ARN],
+      ['RegexPatternSetReferenceStatement', REGEX_ARN],
+      ['RuleGroupReferenceStatement', GROUP_ARN],
+    ])('renames Arn to ARN on a top-level %s', async (key, arn) => {
+      const rules = await createdRules(provider, [rule({ [key]: { Arn: arn } })]);
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const reference = statement[key] as Record<string, unknown>;
+      expect(reference['ARN']).toBe(arn);
+      expect(reference).not.toHaveProperty('Arn');
+    });
+
+    it('preserves the reference statement sibling members', async () => {
+      const rules = await createdRules(provider, [
+        rule({
+          RuleGroupReferenceStatement: {
+            Arn: GROUP_ARN,
+            ExcludedRules: [{ Name: 'noisy-rule' }],
+          },
+        }),
+      ]);
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const reference = statement['RuleGroupReferenceStatement'] as Record<string, unknown>;
+      expect(reference['ARN']).toBe(GROUP_ARN);
+      expect(reference['ExcludedRules']).toEqual([{ Name: 'noisy-rule' }]);
+    });
+
+    it('renames Arn nested under a RateBasedStatement ScopeDownStatement', async () => {
+      const rules = await createdRules(provider, [
+        rule({
+          RateBasedStatement: {
+            Limit: 2000,
+            AggregateKeyType: 'IP',
+            ScopeDownStatement: { IPSetReferenceStatement: { Arn: IPSET_ARN } },
+          },
+        }),
+      ]);
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const rateBased = statement['RateBasedStatement'] as Record<string, unknown>;
+      const scopeDown = rateBased['ScopeDownStatement'] as Record<string, unknown>;
+      const reference = scopeDown['IPSetReferenceStatement'] as Record<string, unknown>;
+      expect(reference['ARN']).toBe(IPSET_ARN);
+      expect(reference).not.toHaveProperty('Arn');
+    });
+
+    it('leaves an already-SDK-spelled ARN untouched', async () => {
+      const rules = await createdRules(provider, [
+        rule({ IPSetReferenceStatement: { ARN: IPSET_ARN } }),
+      ]);
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const reference = statement['IPSetReferenceStatement'] as Record<string, unknown>;
+      expect(reference['ARN']).toBe(IPSET_ARN);
+    });
+
+    it('renames Arn on the update path too', async () => {
+      mockSend.mockResolvedValueOnce({ LockToken: 'lock-1' });
+      mockSend.mockResolvedValueOnce({ NextLockToken: 'lock-2' });
+
+      await provider.update(
+        'MyWebACL',
+        TEST_ARN,
+        RESOURCE_TYPE,
+        baseProperties([rule({ IPSetReferenceStatement: { Arn: IPSET_ARN } })]),
+        baseProperties([])
+      );
+
+      const updateCall = mockSend.mock.calls.at(-1)!;
+      const rules = updateCall[0].input.Rules as Record<string, unknown>[];
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const reference = statement['IPSetReferenceStatement'] as Record<string, unknown>;
+      expect(reference['ARN']).toBe(IPSET_ARN);
+      expect(reference).not.toHaveProperty('Arn');
+    });
+  });
+
+  describe('non-array Rules', () => {
+    // A truthy non-array is an unresolved intrinsic. Defaulting it to [] would
+    // make update() a silent UpdateWebACL that wipes every rule and reports
+    // success; passing it through keeps the loud SDK validation failure.
+    it('passes a non-array Rules value through instead of wiping the rules', async () => {
+      mockSend.mockResolvedValueOnce({ Summary: { ARN: TEST_ARN, Id: TEST_ID } });
+      await provider.create('MyWebACL', RESOURCE_TYPE, {
+        ...baseProperties([]),
+        Rules: { Ref: 'SomeUnresolvedParameter' },
+      });
+
+      expect(mockSend.mock.calls[0][0].input.Rules).toEqual({
+        Ref: 'SomeUnresolvedParameter',
+      });
+    });
+
+    // The dangerous half: on update, defaulting an unresolved intrinsic to []
+    // would issue an UpdateWebACL that WIPES every rule and report success.
+    it('passes a non-array Rules value through on the update path too', async () => {
+      mockSend.mockResolvedValueOnce({ LockToken: 'lock-1' });
+      mockSend.mockResolvedValueOnce({ NextLockToken: 'lock-2' });
+
+      await provider.update('MyWebACL', TEST_ARN, RESOURCE_TYPE, {
+        ...baseProperties([]),
+        Rules: { Ref: 'SomeUnresolvedParameter' },
+      }, baseProperties([]));
+
+      const updateCall = mockSend.mock.calls.at(-1)!;
+      expect(updateCall[0].input.Rules).toEqual({ Ref: 'SomeUnresolvedParameter' });
+    });
+
+    it('degrades every FALSY Rules value to an empty array (parity with `|| []`)', async () => {
+      for (const falsy of [null, '', 0, false]) {
+        mockSend.mockReset();
+        mockSend.mockResolvedValueOnce({ Summary: { ARN: TEST_ARN, Id: TEST_ID } });
+        await provider.create('MyWebACL', RESOURCE_TYPE, {
+          ...baseProperties([]),
+          Rules: falsy,
+        });
+        expect(mockSend.mock.calls[0][0].input.Rules).toEqual([]);
+      }
+    });
+
+    it('still defaults absent Rules to an empty array', async () => {
+      mockSend.mockResolvedValueOnce({ Summary: { ARN: TEST_ARN, Id: TEST_ID } });
+      const properties: Record<string, unknown> = { ...baseProperties([]) };
+      delete properties['Rules'];
+      await provider.create('MyWebACL', RESOURCE_TYPE, properties);
+
+      expect(mockSend.mock.calls[0][0].input.Rules).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`WAFv2WebACLProvider` forwarded the CFn `Rules` blob raw. The AWS SDK v3 serializer drops unknown members, and the `Rules` tree carries exactly **two** spellings CFn uses that the SDK model does not — all 154 CFn keys in the `CfnWebACL` tree were diffed against the SDK schema member set, so this is the complete list:

| CFn key | SDK member | Effect |
| --- | --- | --- |
| `ByteMatchStatement.SearchStringBase64` | (none — CFn-only; the SDK has a single `SearchString` blob) | dropped, so `CreateWebACL` fails on the missing required `SearchString` |
| `Arn` on `IPSetReferenceStatement` / `RegexPatternSetReferenceStatement` / `RuleGroupReferenceStatement` | `ARN` (required) | dropped, so `CreateWebACL` fails on the missing required `ARN` |

The second row was **not** in the filed issue — a reviewer found it by diffing the whole tree, and it is the wider breakage: any WebACL using an IPSet / RegexPatternSet / RuleGroup reference statement failed today, base64 or not. Both are the same class and both leaves are nestable, so one walk fixes them together.

## What changed

- **One recursive statement walk** covering every member the SDK `Statement` union declares as nested: `NotStatement.Statement`, `AndStatement.Statements[]`, `OrStatement.Statements[]`, and the `ScopeDownStatement` of both `RateBasedStatement` and `ManagedRuleGroupStatement`. `RuleGroupReferenceStatement` is deliberately not a recursion point (it declares no nested statement member); it appears only in the ARN rename list. Applied on create and update; every level is rebuilt, so the caller's `properties` object is never mutated (pinned by a test).
- **`SearchStringBase64` decodes to a `Uint8Array`**, matching the declared member type. The issue flagged a latent string-vs-`Uint8Array` risk; it is resolved from the resolved serializer source rather than assumed — the blob member is schema code 21, and `@aws-sdk/core`'s JSON body serializer base64-encodes both a `Uint8Array` and a plain `string` at a blob member. Plain `SearchString` values are therefore correct as-is and left untouched.
- **Precedence** when a template carries both search keys: `SearchStringBase64` wins. CFn treats them as mutually exclusive and rejects such a template, so any choice is arbitrary; the explicit-encoding form is the only one that can express non-UTF-8 bytes, so honoring it never loses information.
- **Non-array `Rules` now passes through** instead of defaulting to `[]`. Defaulting a truthy non-array (an unresolved intrinsic) would make `update()` a silent `UpdateWebACL` that wipes every rule and reports success; the previous code handed the value to the SDK and failed loudly, and that is preserved. Absent `Rules` still defaults to `[]`.
- **`PreParseTextTransformations` / `Monetize` / `PriceMultiplier`** have no member in the installed SDK, so there is no mapping to write — the fix is an SDK bump, after which the spellings already match. They cannot go in `unhandledByDesign`, which is top-level property granularity, and all three nest inside the genuinely-handled `Rules`. Their drop is made loud with a warning naming them on create and update instead of staying silent.

## Test plan

- 25 unit tests, with fails-without-fix **measured** by a reviewer running surgical reverts rather than inferred: reverting the base64 decode turns **7** red, reverting the ARN rename **6**, reverting the non-array `Rules` handling **1**, and no-op'ing the warn helper **2**. The remaining tests are deliberate construction-green guards (plain `SearchString` untouched, absent / falsy `Rules`, no mutation of the caller's object, no spurious warning, an already-`ARN`-spelled value left alone).
- Full suite: 517 files / 8737 tests, no type errors.
- **Real AWS (`/run-integ wafv2`, us-east-1).** The fixture now exercises all three divergence sites — a base64 `ByteMatchStatement` under the rate-based rule's `ScopeDownStatement`, one under a `NotStatement`, and an `IPSetReferenceStatement` under an `AndStatement` — so the deploy itself is the regression signal: pre-fix `CreateWebACL` rejects the stack. Deploy 9/9 created; `GetWebACL` round-tripped all three (`Y2RrZC1zY29wZWQ=`, `Y2RrZC1ibG9ja2Vk`, and the IPSet ARN under `ARN`); destroy 7 deleted / 2 `DeletionPolicy: Retain` / 0 errors; account swept clean.

## Known gaps (reviewer-surfaced, deliberately not widened into this PR)

- **`readCurrentState` has no reverse mapping**, so `cdkd drift` reports permanent phantom `Rules` drift — AWS returns `ARN` and a decoded `Uint8Array` `SearchString`, while state holds `Arn` / `SearchStringBase64`. Tracked in (#1403), which this work widened: the reverse map must be BASELINE-driven (only the template knows whether it used `SearchString` or `SearchStringBase64`), and it now also has to un-rename `ARN`. Not folded in here because the cheaper alternative — a `getDriftUnknownPaths` entry for `Rules` — trades a false positive for never reporting real rule drift, and the repo argues that trade deserves an explicit decision.
- **The integ asserts the missing-key class, not decode correctness.** Deploy-success is a sound conjunctive assertion that all three divergence sites were accepted, but a hypothetical "renamed the key, forgot to decode" variant would send the base64 STRING at a blob member, which the SDK re-encodes and AWS accepts. Decode correctness is covered by unit tests instead (a `Buffer`-vs-`Uint8Array` mutation turns 7 red), and the exact bytes were confirmed by hand against `GetWebACL` on every verification run. Closing it mechanically means converting this standard-flow fixture to a `verify.sh`.
- **ARN-rename recursion coverage** is unit-tested at top level and under `RateBasedStatement.ScopeDownStatement`; the other three recursion points are covered for the base64 conversion only. Both conversions ride the same `toSdkStatement` frame, so they cannot regress independently.

## Follow-ups

- Pre-existing phantom drift on every `ByteMatchStatement` (#1403): `readCurrentState` returns the AWS `Rules` verbatim, where `GetWebACL` deserializes `SearchString` back into a `Uint8Array` while state holds the template shape. It already fires for the plain `SearchString` form; this PR makes the base64 form newly deployable and therefore newly able to hit it. A genuinely separate concern, so it is not widened into this diff.
- The `wafv2` fixture is not re-runnable (#1407): its `apigateway.RestApi` CloudWatch role is `DeletionPolicy: Retain` under a fixed name and collides with the next CREATE. Hit live during this verification and cleaned up by hand; pre-existing, not caused by this PR.
- `handledProperties` can lie (#1404) — proposed critic, from the sibling ECR work in the same session.
- `AWS::WAFv2::WebACL` is not in `NESTED_KEY_TARGETS`, so the nested-key critic would not have caught either divergence. That target expansion is tracked in (#1393), and the `Arn` case is a good argument for it — a mechanical critic would have found it without a reviewer.

Closes #1389
