### PR TITLE
test(integ): make the wafv2 fixture re-runnable by dropping its retained CloudWatch role

### DIFF
--- a/docs/_generated/integ-coverage.json
+++ b/docs/_generated/integ-coverage.json
@@ -140,13 +140,17 @@
       "resourceType": "AWS::ApiGateway::Account",
       "integs": [
         "apigateway",
-        "apigw-stage-throttling"
+        "apigw-stage-throttling",
+        "wafv2"
       ],
       "signals": {
         "apigateway": [
           "literal"
         ],
         "apigw-stage-throttling": [
+          "literal"
+        ],
+        "wafv2": [
           "literal"
         ]
       }

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -268,5 +268,5 @@ vpc-lambda	2026-07-26T16:53:02Z	PASS	386	standard	0727 P0 sweep (ec2-provider ch
 vpc-lambda-cr-race	2026-07-24T11:03:24Z	PASS	432	standard	0724b sweep staleness; 9 del 0 err 0 orphans incl hyperplane ENI
 vpc-lookup	2026-07-24T10:55:09Z	PASS	20	standard	0724b sweep staleness; context-provider loop ok; 1 del 0 err 0 orphans
 vpc-nat-gateway	2026-07-22T08:08:02Z	PASS		standard	TTL-refresh sweep; standard flow (classifier-approved direct deploy/destroy); 21 created / 21 deleted 0 err; NAT GW + VPC + EIP + ENI all gone, state gone
-wafv2	2026-08-09T06:52:50Z	PASS	130	standard	#1389 SearchStringBase64 + reference-statement Arn->ARN asserted via GetWebACL at all 3 sites; 7 del/2 retained/0 err. NOT re-runnable: RETAIN ApiGateway CloudWatch role collides (#1407)
+wafv2	2026-08-09T08:03:56Z	PASS	150	standard	#1407 cloudWatchRole:false -> re-runnable; TWO consecutive cycles clean, 7 del/0 retained/0 err, no manual IAM cleanup
 wait-condition-handle	2026-07-31T06:19:56Z	PASS	44	verify.sh	TTL-refresh sweep re-run; rc ok, orph clean

--- a/docs/integ-coverage.md
+++ b/docs/integ-coverage.md
@@ -36,7 +36,7 @@ Registered without an integ fixture, with an explicit `// allow-no-integ: <ratio
 
 | Resource Type | Integ Fixture(s) |
 |---|---|
-| `AWS::ApiGateway::Account` | [`apigateway`](../tests/integration/apigateway/) (literal)<br>[`apigw-stage-throttling`](../tests/integration/apigw-stage-throttling/) (literal) |
+| `AWS::ApiGateway::Account` | [`apigateway`](../tests/integration/apigateway/) (literal)<br>[`apigw-stage-throttling`](../tests/integration/apigw-stage-throttling/) (literal)<br>[`wafv2`](../tests/integration/wafv2/) (literal) |
 | `AWS::ApiGateway::Authorizer` | [`api-cognito`](../tests/integration/api-cognito/) (l1)<br>[`apigateway`](../tests/integration/apigateway/) (l1)<br>[`local-start-api`](../tests/integration/local-start-api/) (l2) |
 | `AWS::ApiGateway::Deployment` | [`api-cognito`](../tests/integration/api-cognito/) (literal)<br>[`apigateway`](../tests/integration/apigateway/) (literal)<br>[`apigw-gateway-response`](../tests/integration/apigw-gateway-response/) (literal)<br>[`apigw-stage-throttling`](../tests/integration/apigw-stage-throttling/) (literal) |
 | `AWS::ApiGateway::Method` | [`api-cognito`](../tests/integration/api-cognito/) (literal)<br>[`apigateway`](../tests/integration/apigateway/) (literal)<br>[`apigw-gateway-response`](../tests/integration/apigw-gateway-response/) (literal)<br>[`apigw-stage-throttling`](../tests/integration/apigw-stage-throttling/) (literal) |

--- a/tests/integration/wafv2/lib/wafv2-stack.ts
+++ b/tests/integration/wafv2/lib/wafv2-stack.ts
@@ -142,6 +142,19 @@ export class Wafv2Stack extends cdk.Stack {
     const api = new apigateway.RestApi(this, 'TestApi', {
       restApiName: `cdkd-wafv2-test-api`,
       description: 'Minimal API for WAFv2 WebACL association test',
+      // Issue #1407: `cloudWatchRole` defaults to true, and CDK gives the
+      // generated role AND the account-level `AWS::ApiGateway::Account`
+      // singleton `DeletionPolicy: Retain`. cdkd honors that correctly
+      // (destroy reported "7 deleted, 2 retained, 0 errors"), so the role
+      // survived every run under the FIXED name
+      // `Wafv2Stack-TestApiCloudWatchRole3E85D09F` and the next CREATE failed
+      // with "Role with name ... already exists" — the fixture was single-use
+      // per account until someone cleaned up by hand.
+      //
+      // This fixture never exercises API Gateway access logging, so the role
+      // is dead weight. Disabling it removes both retained resources and makes
+      // the fixture re-runnable.
+      cloudWatchRole: false,
     });
     api.root.addMethod('GET', new apigateway.MockIntegration({
       integrationResponses: [{ statusCode: '200' }],


### PR DESCRIPTION
## Summary

`apigateway.RestApi` defaults `cloudWatchRole` to true, and CDK gives the generated role **and** the account-level `AWS::ApiGateway::Account` singleton `DeletionPolicy: Retain`. cdkd honors that correctly — destroy reported `7 deleted, 2 retained, 0 errors` — so the role survived every run under the fixed name `Wafv2Stack-TestApiCloudWatchRole3E85D09F`, and the next CREATE failed with `Role with name ... already exists`, rolling back the whole deploy.

The fixture was therefore **single-use per account**. Every green row in the ledger was a first run after someone had cleaned up by hand.

This fixture never exercises API Gateway access logging, so the role is dead weight.

## Why it was not caught earlier

The failure only appears on a back-to-back re-run, which nobody had done. It surfaced while verifying the #1389 fix: two failed deploys and two manual IAM sweeps before the pattern was clear.

## Test plan

Verified against real AWS (us-east-1) by running the full deploy + destroy cycle **twice back to back** — the second run is exactly what used to fail:

| | created | deleted | retained | errors |
| --- | --- | --- | --- | --- |
| Run 1 | 7 | 7 | 0 | 0 |
| Run 2 | 7 | 7 | 0 | 0 |

No manual cleanup between runs, and the post-run sweep (IAM roles / WebACLs / IPSets / REST APIs / cdkd state) came back empty. The synthesized template drops from 9 to 8 resources with zero `DeletionPolicy: Retain` entries and no `AWS::ApiGateway::Account`.

The `integ-coverage` matrix is regenerated accordingly — the fixture no longer covers `AWS::ApiGateway::Account`, which it only ever covered as a side effect of the retained singleton.

Closes #1407
