### PR TITLE
fix(wafv2): reverse-map the Rules blob on read so drift stops reporting phantom changes

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -268,5 +268,5 @@ vpc-lambda	2026-07-26T16:53:02Z	PASS	386	standard	0727 P0 sweep (ec2-provider ch
 vpc-lambda-cr-race	2026-07-24T11:03:24Z	PASS	432	standard	0724b sweep staleness; 9 del 0 err 0 orphans incl hyperplane ENI
 vpc-lookup	2026-07-24T10:55:09Z	PASS	20	standard	0724b sweep staleness; context-provider loop ok; 1 del 0 err 0 orphans
 vpc-nat-gateway	2026-07-22T08:08:02Z	PASS		standard	TTL-refresh sweep; standard flow (classifier-approved direct deploy/destroy); 21 created / 21 deleted 0 err; NAT GW + VPC + EIP + ENI all gone, state gone
-wafv2	2026-08-09T08:03:56Z	PASS	150	standard	#1407 cloudWatchRole:false -> re-runnable; TWO consecutive cycles clean, 7 del/0 retained/0 err, no manual IAM cleanup
+wafv2	2026-08-09T08:37:03Z	PASS	115	standard	#1403 drift reverse map (post-review): deploy + cdkd drift = no drift; 7 del/0 retained/0 err
 wait-condition-handle	2026-07-31T06:19:56Z	PASS	44	verify.sh	TTL-refresh sweep re-run; rc ok, orph clean

--- a/src/provisioning/providers/wafv2-provider.ts
+++ b/src/provisioning/providers/wafv2-provider.ts
@@ -226,6 +226,201 @@ function toSdkRules(rules: unknown): Rule[] {
 }
 
 /**
+ * Inverse of {@link toSdkByteMatchStatement}.
+ *
+ * `GetWebACL` returns `SearchString` as the SDK blob type (a `Uint8Array`),
+ * but the template — and therefore cdkd state — carries EITHER a plain
+ * `SearchString` string OR a `SearchStringBase64` string. The bytes are
+ * identical for both spellings, so the AWS value alone cannot say which
+ * one to emit: only the BASELINE can. That is why every function on this
+ * side takes the corresponding state node alongside the AWS node.
+ *
+ * Whenever the baseline string RE-ENCODES to exactly the AWS bytes, it is
+ * emitted VERBATIM rather than re-derived. That is what keeps two otherwise
+ * permanent false positives from appearing:
+ *
+ *   - a non-canonical `SearchStringBase64` (whitespace / newlines, missing
+ *     padding, base64url) would never equal a canonically re-encoded string,
+ *     so the WebACL would drift forever;
+ *   - `Buffer.toString('utf8')` is LOSSY for non-UTF-8 bytes (U+FFFD), so a
+ *     binary needle under a plain-`SearchString` baseline would both drift
+ *     and — via `drift --accept`, which writes the AWS value into
+ *     `observedProperties`, then `--revert` — push a mangled needle to AWS.
+ *
+ * When the bytes genuinely differ from the baseline (REAL drift) or no usable
+ * baseline exists, the value is derived: base64 if the baseline used base64,
+ * otherwise plain UTF-8 but ONLY when that round-trips losslessly, falling
+ * back to base64 so binary content is never corrupted.
+ */
+function toCfnByteMatchStatement(
+  byteMatchStatement: Record<string, unknown>,
+  baseline: unknown
+): Record<string, unknown> {
+  const raw = byteMatchStatement['SearchString'];
+  if (raw === undefined) return byteMatchStatement;
+
+  const bytes =
+    raw instanceof Uint8Array
+      ? Buffer.from(raw)
+      : typeof raw === 'string'
+        ? Buffer.from(raw, 'utf8')
+        : undefined;
+  if (!bytes) return byteMatchStatement;
+
+  const base = isPlainObject(baseline) ? baseline : undefined;
+  const baseEncoded = base?.['SearchStringBase64'];
+  const basePlain = base?.['SearchString'];
+
+  const converted: Record<string, unknown> = { ...byteMatchStatement };
+  delete converted['SearchString'];
+  delete converted['SearchStringBase64'];
+
+  // Undrifted: hand back the baseline's own string, byte-for-byte.
+  if (typeof baseEncoded === 'string' && Buffer.from(baseEncoded, 'base64').equals(bytes)) {
+    converted['SearchStringBase64'] = baseEncoded;
+    return converted;
+  }
+  if (typeof basePlain === 'string' && Buffer.from(basePlain, 'utf8').equals(bytes)) {
+    converted['SearchString'] = basePlain;
+    return converted;
+  }
+
+  // Real drift, or no baseline to follow.
+  if (typeof baseEncoded === 'string') {
+    converted['SearchStringBase64'] = bytes.toString('base64');
+    return converted;
+  }
+  const utf8 = bytes.toString('utf8');
+  if (Buffer.from(utf8, 'utf8').equals(bytes)) {
+    converted['SearchString'] = utf8;
+  } else {
+    converted['SearchStringBase64'] = bytes.toString('base64');
+  }
+  return converted;
+}
+
+/**
+ * Inverse of {@link toSdkStatement}: re-shape an AWS-returned `Statement`
+ * tree back into the CFn spelling, walking the state baseline in lockstep
+ * so the per-`ByteMatchStatement` spelling choice is baseline-driven.
+ *
+ * Recursion points are IDENTICAL to the forward walk by construction — if
+ * one gains a member, so must the other, or drift silently reappears at
+ * the new nesting depth. When the baseline diverges structurally (a real
+ * drift, or a rule added console-side) the walk simply passes `undefined`
+ * down and the defaults apply; the resulting difference is exactly the
+ * drift the user should see.
+ */
+function toCfnStatement(
+  statement: Record<string, unknown>,
+  baseline: unknown
+): Record<string, unknown> {
+  const converted: Record<string, unknown> = { ...statement };
+  const base = isPlainObject(baseline) ? baseline : undefined;
+
+  const byteMatchStatement = converted['ByteMatchStatement'];
+  if (isPlainObject(byteMatchStatement)) {
+    converted['ByteMatchStatement'] = toCfnByteMatchStatement(
+      byteMatchStatement,
+      base?.['ByteMatchStatement']
+    );
+  }
+
+  // CFn spells the reference ARN `Arn`; AWS returns `ARN`. Unconditional —
+  // unlike the search string there is no ambiguity about the CFn spelling.
+  for (const key of ARN_REFERENCE_STATEMENT_KEYS) {
+    const reference = converted[key];
+    if (!isPlainObject(reference) || !('ARN' in reference)) continue;
+    const { ARN: arn, ...rest } = reference;
+    converted[key] = { ...rest, Arn: arn };
+  }
+
+  const notStatement = converted['NotStatement'];
+  if (isPlainObject(notStatement)) {
+    const nested = notStatement['Statement'];
+    if (isPlainObject(nested)) {
+      const baseNot = base?.['NotStatement'];
+      converted['NotStatement'] = {
+        ...notStatement,
+        Statement: toCfnStatement(
+          nested,
+          isPlainObject(baseNot) ? baseNot['Statement'] : undefined
+        ),
+      };
+    }
+  }
+
+  for (const key of ['AndStatement', 'OrStatement']) {
+    const combined = converted[key];
+    if (!isPlainObject(combined)) continue;
+    const nested = combined['Statements'];
+    if (!Array.isArray(nested)) continue;
+    const baseCombined = base?.[key];
+    const baseList =
+      isPlainObject(baseCombined) && Array.isArray(baseCombined['Statements'])
+        ? (baseCombined['Statements'] as unknown[])
+        : undefined;
+    converted[key] = {
+      ...combined,
+      Statements: nested.map((item, i) =>
+        isPlainObject(item) ? toCfnStatement(item, baseList?.[i]) : item
+      ),
+    };
+  }
+
+  for (const key of ['RateBasedStatement', 'ManagedRuleGroupStatement']) {
+    const scoping = converted[key];
+    if (!isPlainObject(scoping)) continue;
+    const nested = scoping['ScopeDownStatement'];
+    if (!isPlainObject(nested)) continue;
+    const baseScoping = base?.[key];
+    converted[key] = {
+      ...scoping,
+      ScopeDownStatement: toCfnStatement(
+        nested,
+        isPlainObject(baseScoping) ? baseScoping['ScopeDownStatement'] : undefined
+      ),
+    };
+  }
+
+  return converted;
+}
+
+/**
+ * Inverse of {@link toSdkRules}: re-shape the AWS `Rules` array back into
+ * the CFn spelling so `cdkd drift` compares like with like.
+ *
+ * Without this every WebACL carrying a `ByteMatchStatement` or a reference
+ * statement reported permanent phantom drift, because `drift-calculator`
+ * compares `Rules` wholesale via `deepEqual` (issue #1403).
+ *
+ * Rules are matched to the baseline POSITIONALLY, which is what the
+ * comparator itself does — a reordered or console-added rule therefore
+ * still surfaces as drift, correctly.
+ */
+function toCfnRules(rules: unknown, baselineRules: unknown): unknown[] {
+  // `GetWebACL` always returns an array (or nothing), so unlike the forward
+  // walk there is no unresolved-intrinsic case to pass through here.
+  if (!Array.isArray(rules)) return [];
+  const baseList = Array.isArray(baselineRules) ? (baselineRules as unknown[]) : undefined;
+  return rules.map((rule, i) => {
+    // A non-object entry is not a rule cdkd can re-shape; hand it back
+    // untouched rather than casting a lie onto it.
+    if (!isPlainObject(rule)) return rule;
+    const statement = rule['Statement'];
+    if (!isPlainObject(statement)) return rule;
+    const baseRule = baseList?.[i];
+    return {
+      ...rule,
+      Statement: toCfnStatement(
+        statement,
+        isPlainObject(baseRule) ? baseRule['Statement'] : undefined
+      ),
+    };
+  });
+}
+
+/**
  * Collect every {@link SDK_UNSUPPORTED_RULE_KEYS} member present anywhere
  * in the CFn `Rules` blob, so the caller can report the silent drop.
  */
@@ -623,7 +818,12 @@ export class WAFv2WebACLProvider implements ResourceProvider {
   async readCurrentState(
     physicalId: string,
     _logicalId: string,
-    _resourceType: string
+    _resourceType: string,
+    // The state-recorded baseline. Load-bearing, not decoration: the AWS
+    // `Rules` blob cannot say whether the template spelled a byte-match
+    // needle `SearchString` or `SearchStringBase64` (identical bytes), so
+    // the reverse mapping is baseline-driven. See {@link toCfnRules}.
+    properties?: Record<string, unknown>
   ): Promise<Record<string, unknown> | undefined> {
     const { id, name, scope } = parseWebACLArn(physicalId);
     if (!id || !name) return undefined;
@@ -647,7 +847,7 @@ export class WAFv2WebACLProvider implements ResourceProvider {
     if (webACL.DefaultAction) {
       result['DefaultAction'] = webACL.DefaultAction as unknown as Record<string, unknown>;
     }
-    result['Rules'] = (webACL.Rules ?? []).map((r) => r as unknown as Record<string, unknown>);
+    result['Rules'] = toCfnRules(webACL.Rules ?? [], properties?.['Rules']);
     if (webACL.VisibilityConfig) {
       result['VisibilityConfig'] = webACL.VisibilityConfig as unknown as Record<string, unknown>;
     }

--- a/tests/unit/provisioning/wafv2-provider-drift-reverse-map.test.ts
+++ b/tests/unit/provisioning/wafv2-provider-drift-reverse-map.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const mockSend = vi.hoisted(() => vi.fn());
+
+vi.mock('@aws-sdk/client-wafv2', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-wafv2')>(
+    '@aws-sdk/client-wafv2'
+  );
+  return {
+    ...actual,
+    WAFV2Client: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { WAFv2WebACLProvider } from '../../../src/provisioning/providers/wafv2-provider.js';
+
+const TEST_ARN = 'arn:aws:wafv2:us-east-1:123456789012:regional/webacl/my-acl/abc-123-def';
+const IPSET_ARN = 'arn:aws:wafv2:us-east-1:123456789012:regional/ipset/blocked/ip-1';
+const RESOURCE_TYPE = 'AWS::WAFv2::WebACL';
+
+const VISIBILITY_CONFIG = {
+  CloudWatchMetricsEnabled: true,
+  MetricName: 'my-acl-metric',
+  SampledRequestsEnabled: true,
+};
+
+// "BadBot" — the exact example AWS uses in the SearchStringBase64 docs.
+const BAD_BOT_BASE64 = 'QmFkQm90';
+const BAD_BOT_BYTES = Uint8Array.from(Buffer.from('BadBot', 'utf8'));
+
+/**
+ * Drive readCurrentState with an AWS-shaped `Rules` array (what GetWebACL
+ * really returns: `ARN`, and `SearchString` as a Uint8Array blob) plus the
+ * state baseline, and return the CFn-shaped `Rules` the provider emits.
+ */
+async function readBackRules(
+  provider: WAFv2WebACLProvider,
+  awsRules: unknown[],
+  baselineProperties: Record<string, unknown>
+): Promise<Record<string, unknown>[]> {
+  mockSend.mockResolvedValueOnce({
+    WebACL: {
+      Name: 'my-acl',
+      Description: 'd',
+      DefaultAction: { Allow: {} },
+      Rules: awsRules,
+      VisibilityConfig: VISIBILITY_CONFIG,
+    },
+  });
+  mockSend.mockResolvedValueOnce({ TagInfoForResource: { TagList: [] } });
+
+  const state = await provider.readCurrentState(
+    TEST_ARN,
+    'MyWebACL',
+    RESOURCE_TYPE,
+    baselineProperties
+  );
+  return state!['Rules'] as Record<string, unknown>[];
+}
+
+function rule(statement: Record<string, unknown>) {
+  return {
+    Name: 'r0',
+    Priority: 0,
+    Action: { Block: {} },
+    Statement: statement,
+    VisibilityConfig: VISIBILITY_CONFIG,
+  };
+}
+
+function byteMatch(searchKeyValue: Record<string, unknown>) {
+  return {
+    ByteMatchStatement: {
+      ...searchKeyValue,
+      FieldToMatch: { SingleHeader: { Name: 'user-agent' } },
+      PositionalConstraint: 'CONTAINS',
+      TextTransformations: [{ Priority: 0, Type: 'NONE' }],
+    },
+  };
+}
+
+describe('WAFv2WebACLProvider drift reverse mapping (issue #1403)', () => {
+  let provider: WAFv2WebACLProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new WAFv2WebACLProvider();
+  });
+
+  describe('reference-statement ARN -> Arn', () => {
+    it('renames a top-level IPSetReferenceStatement ARN back to the CFn spelling', async () => {
+      const rules = await readBackRules(
+        provider,
+        [rule({ IPSetReferenceStatement: { ARN: IPSET_ARN } })],
+        { Rules: [rule({ IPSetReferenceStatement: { Arn: IPSET_ARN } })] }
+      );
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const reference = statement['IPSetReferenceStatement'] as Record<string, unknown>;
+      expect(reference['Arn']).toBe(IPSET_ARN);
+      expect(reference).not.toHaveProperty('ARN');
+    });
+
+    it('renames an ARN nested under AndStatement', async () => {
+      const awsRule = rule({
+        AndStatement: { Statements: [{ IPSetReferenceStatement: { ARN: IPSET_ARN } }] },
+      });
+      const baseRule = rule({
+        AndStatement: { Statements: [{ IPSetReferenceStatement: { Arn: IPSET_ARN } }] },
+      });
+
+      const rules = await readBackRules(provider, [awsRule], { Rules: [baseRule] });
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const and = statement['AndStatement'] as Record<string, unknown>;
+      const nested = (and['Statements'] as Record<string, unknown>[])[0]!;
+      const reference = nested['IPSetReferenceStatement'] as Record<string, unknown>;
+      expect(reference['Arn']).toBe(IPSET_ARN);
+      expect(reference).not.toHaveProperty('ARN');
+    });
+  });
+
+  describe('SearchString spelling is BASELINE-driven', () => {
+    it('emits SearchStringBase64 when the template used the base64 form', async () => {
+      const rules = await readBackRules(
+        provider,
+        [rule(byteMatch({ SearchString: BAD_BOT_BYTES }))],
+        { Rules: [rule(byteMatch({ SearchStringBase64: BAD_BOT_BASE64 }))] }
+      );
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const bms = statement['ByteMatchStatement'] as Record<string, unknown>;
+      expect(bms['SearchStringBase64']).toBe(BAD_BOT_BASE64);
+      expect(bms).not.toHaveProperty('SearchString');
+    });
+
+    it('emits a plain SearchString when the template used the plain form', async () => {
+      const rules = await readBackRules(
+        provider,
+        [rule(byteMatch({ SearchString: BAD_BOT_BYTES }))],
+        { Rules: [rule(byteMatch({ SearchString: 'BadBot' }))] }
+      );
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const bms = statement['ByteMatchStatement'] as Record<string, unknown>;
+      expect(bms['SearchString']).toBe('BadBot');
+      expect(bms).not.toHaveProperty('SearchStringBase64');
+    });
+
+    it('falls back to the plain form when there is no usable baseline', async () => {
+      const rules = await readBackRules(
+        provider,
+        [rule(byteMatch({ SearchString: BAD_BOT_BYTES }))],
+        {}
+      );
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const bms = statement['ByteMatchStatement'] as Record<string, unknown>;
+      expect(bms['SearchString']).toBe('BadBot');
+    });
+
+    it('drives the choice per statement, not per WebACL', async () => {
+      // One rule used base64, the other plain — a single global choice would
+      // get exactly one of them wrong.
+      const awsRules = [
+        rule(byteMatch({ SearchString: BAD_BOT_BYTES })),
+        rule(byteMatch({ SearchString: BAD_BOT_BYTES })),
+      ];
+      const baseline = {
+        Rules: [
+          rule(byteMatch({ SearchStringBase64: BAD_BOT_BASE64 })),
+          rule(byteMatch({ SearchString: 'BadBot' })),
+        ],
+      };
+
+      const rules = await readBackRules(provider, awsRules, baseline);
+
+      const first = (rules[0]!['Statement'] as Record<string, unknown>)[
+        'ByteMatchStatement'
+      ] as Record<string, unknown>;
+      const second = (rules[1]!['Statement'] as Record<string, unknown>)[
+        'ByteMatchStatement'
+      ] as Record<string, unknown>;
+      expect(first['SearchStringBase64']).toBe(BAD_BOT_BASE64);
+      expect(second['SearchString']).toBe('BadBot');
+    });
+
+    it('reverses a base64 needle nested under RateBasedStatement ScopeDownStatement', async () => {
+      const awsRule = rule({
+        RateBasedStatement: {
+          Limit: 2000,
+          AggregateKeyType: 'IP',
+          ScopeDownStatement: byteMatch({ SearchString: BAD_BOT_BYTES }),
+        },
+      });
+      const baseRule = rule({
+        RateBasedStatement: {
+          Limit: 2000,
+          AggregateKeyType: 'IP',
+          ScopeDownStatement: byteMatch({ SearchStringBase64: BAD_BOT_BASE64 }),
+        },
+      });
+
+      const rules = await readBackRules(provider, [awsRule], { Rules: [baseRule] });
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const rateBased = statement['RateBasedStatement'] as Record<string, unknown>;
+      const scopeDown = rateBased['ScopeDownStatement'] as Record<string, unknown>;
+      const bms = scopeDown['ByteMatchStatement'] as Record<string, unknown>;
+      expect(bms['SearchStringBase64']).toBe(BAD_BOT_BASE64);
+    });
+  });
+
+  // The whole point of the issue: state and the AWS readback must compare
+  // EQUAL for an undrifted WebACL. `drift-calculator` compares `Rules`
+  // wholesale via deepEqual, so anything short of exact equality is drift.
+  it('round-trips an undrifted WebACL to a byte-equal Rules array (no phantom drift)', async () => {
+    const templateRules = [
+      rule({
+        AndStatement: {
+          Statements: [
+            { IPSetReferenceStatement: { Arn: IPSET_ARN } },
+            byteMatch({ SearchStringBase64: BAD_BOT_BASE64 }),
+            byteMatch({ SearchString: 'plain-needle' }),
+          ],
+        },
+      }),
+    ];
+    // What AWS gives back for exactly those rules.
+    const awsRules = [
+      rule({
+        AndStatement: {
+          Statements: [
+            { IPSetReferenceStatement: { ARN: IPSET_ARN } },
+            byteMatch({ SearchString: BAD_BOT_BYTES }),
+            byteMatch({ SearchString: Uint8Array.from(Buffer.from('plain-needle', 'utf8')) }),
+          ],
+        },
+      }),
+    ];
+
+    const rules = await readBackRules(provider, awsRules, { Rules: templateRules });
+
+    expect(rules).toEqual(templateRules);
+  });
+
+  // The baseline string is handed back VERBATIM whenever it re-encodes to the
+  // AWS bytes. Without that, both of these drift forever.
+  describe('baseline string is preserved byte-for-byte when it round-trips', () => {
+    it('keeps a NON-CANONICAL base64 baseline instead of re-encoding it', async () => {
+      // Same bytes as BAD_BOT_BASE64, but newline-wrapped — a canonical
+      // re-encode would never equal this, so the WebACL would drift forever.
+      const nonCanonical = 'QmFk\nQm90';
+      expect(Buffer.from(nonCanonical, 'base64')).toEqual(Buffer.from(BAD_BOT_BYTES));
+
+      const rules = await readBackRules(
+        provider,
+        [rule(byteMatch({ SearchString: BAD_BOT_BYTES }))],
+        { Rules: [rule(byteMatch({ SearchStringBase64: nonCanonical }))] }
+      );
+
+      const bms = (rules[0]!['Statement'] as Record<string, unknown>)[
+        'ByteMatchStatement'
+      ] as Record<string, unknown>;
+      expect(bms['SearchStringBase64']).toBe(nonCanonical);
+    });
+
+    it('does not lossily UTF-8 decode BINARY bytes under a plain baseline', async () => {
+      // 0xFF 0xFE is not valid UTF-8: toString('utf8') yields U+FFFD, which
+      // `drift --accept` would persist and `--revert` would push back to AWS.
+      const binary = Uint8Array.from([0xff, 0xfe, 0x00, 0x01]);
+
+      const rules = await readBackRules(provider, [rule(byteMatch({ SearchString: binary }))], {
+        Rules: [rule(byteMatch({ SearchString: 'BadBot' }))],
+      });
+
+      const bms = (rules[0]!['Statement'] as Record<string, unknown>)[
+        'ByteMatchStatement'
+      ] as Record<string, unknown>;
+      expect(bms['SearchString']).toBeUndefined();
+      expect(bms['SearchStringBase64']).toBe(Buffer.from(binary).toString('base64'));
+      // Round-trips to the exact bytes — no U+FFFD corruption.
+      expect(Buffer.from(bms['SearchStringBase64'] as string, 'base64')).toEqual(
+        Buffer.from(binary)
+      );
+    });
+
+    it('falls back to base64 for binary bytes when there is no baseline at all', async () => {
+      const binary = Uint8Array.from([0x80, 0x81]);
+      const rules = await readBackRules(provider, [rule(byteMatch({ SearchString: binary }))], {});
+
+      const bms = (rules[0]!['Statement'] as Record<string, unknown>)[
+        'ByteMatchStatement'
+      ] as Record<string, unknown>;
+      expect(bms['SearchStringBase64']).toBe(Buffer.from(binary).toString('base64'));
+    });
+  });
+
+  // The docstring claims the two walks cover the SAME recursion points, so
+  // every one of them needs coverage or the claim is untested.
+  describe('every recursion point is covered', () => {
+    it.each([
+      ['NotStatement', (s: unknown) => ({ NotStatement: { Statement: s } })],
+      ['OrStatement', (s: unknown) => ({ OrStatement: { Statements: [s] } })],
+      [
+        'ManagedRuleGroupStatement.ScopeDownStatement',
+        (s: unknown) => ({
+          ManagedRuleGroupStatement: { Name: 'm', VendorName: 'AWS', ScopeDownStatement: s },
+        }),
+      ],
+    ])('reverses a base64 needle nested under %s', async (_label, wrap) => {
+      const rules = await readBackRules(
+        provider,
+        [rule(wrap(byteMatch({ SearchString: BAD_BOT_BYTES })) as Record<string, unknown>)],
+        {
+          Rules: [
+            rule(wrap(byteMatch({ SearchStringBase64: BAD_BOT_BASE64 })) as Record<string, unknown>),
+          ],
+        }
+      );
+
+      // The needle survived somewhere in the tree with the CFn spelling.
+      expect(JSON.stringify(rules[0])).toContain(BAD_BOT_BASE64);
+      expect(JSON.stringify(rules[0])).not.toContain('"SearchString"');
+    });
+
+    it.each([
+      ['RegexPatternSetReferenceStatement'],
+      ['RuleGroupReferenceStatement'],
+    ])('renames ARN back to Arn on %s', async (key) => {
+      const rules = await readBackRules(provider, [rule({ [key]: { ARN: IPSET_ARN } })], {
+        Rules: [rule({ [key]: { Arn: IPSET_ARN } })],
+      });
+
+      const statement = rules[0]!['Statement'] as Record<string, unknown>;
+      const reference = statement[key] as Record<string, unknown>;
+      expect(reference['Arn']).toBe(IPSET_ARN);
+      expect(reference).not.toHaveProperty('ARN');
+    });
+  });
+
+  it('still reports a REAL needle change as drift', async () => {
+    const rules = await readBackRules(
+      provider,
+      [rule(byteMatch({ SearchString: Uint8Array.from(Buffer.from('Changed', 'utf8')) }))],
+      { Rules: [rule(byteMatch({ SearchString: 'BadBot' }))] }
+    );
+
+    const bms = (rules[0]!['Statement'] as Record<string, unknown>)[
+      'ByteMatchStatement'
+    ] as Record<string, unknown>;
+    expect(bms['SearchString']).toBe('Changed');
+  });
+});


### PR DESCRIPTION
## Summary

`readCurrentState` returned the AWS `Rules` array verbatim, but AWS and CloudFormation spell two things differently in that tree:

| | AWS returns | CFn / cdkd state carries |
| --- | --- | --- |
| reference statements | `ARN` | `Arn` |
| `ByteMatchStatement` needle | `SearchString` as a `Uint8Array` blob | `SearchString` (plain string) **or** `SearchStringBase64` |

`drift-calculator` compares `Rules` wholesale via `deepEqual`, so **every** WebACL carrying a `ByteMatchStatement` or a reference statement reported permanent phantom drift. The reference-statement half became reachable only once #1389 made those statements deployable at all.

## The crux: the spelling choice must be baseline-driven

The bytes are identical whether the template wrote `SearchString: 'BadBot'` or `SearchStringBase64: 'QmFkQm90'`, so the AWS value **cannot** say which spelling to emit. Only the baseline can.

`readCurrentState` already receives the state-recorded properties as its 4th argument — the provider was simply ignoring it. The walk now carries the corresponding baseline node down and decides **per statement**, so a WebACL mixing both spellings round-trips correctly (a single global choice would get one of them wrong; there is a test for exactly that).

With no usable baseline it emits the plain form, the shape most templates use. A base64 template whose baseline went missing then reports drift once — visibly and recoverably — instead of silently comparing the wrong spelling forever.

## Review-driven hardening

A reviewer found two ways the first draft could have made things WORSE, both now fixed by the same
rule — **when the baseline string re-encodes to exactly the AWS bytes, hand it back verbatim rather
than re-deriving it**:

- a **non-canonical** `SearchStringBase64` (newline-wrapped, unpadded, base64url) would never equal
  a canonically re-encoded string, so that WebACL would have drifted forever;
- `Buffer.toString('utf8')` is **lossy** for non-UTF-8 bytes (U+FFFD). Under a plain-`SearchString`
  baseline a binary needle would both drift AND — via `drift --accept`, which writes the AWS value
  into `observedProperties`, then `--revert` — push a **mangled needle back to AWS**. Derivation now
  falls back to base64 whenever a UTF-8 decode does not round-trip, so binary content is never
  corrupted.

## Other decisions

- **The reverse map mirrors the forward walk one-for-one** — same five recursion points, same three reference-statement keys. A member added to one side and not the other silently reintroduces drift at that nesting depth, so they are written to be read side by side.
- **Rules are matched positionally**, which is what the comparator itself does — a reordered or console-added rule still surfaces as drift, correctly.
- **`Arn` is renamed unconditionally.** Unlike the needle there is no ambiguity about the CFn spelling.

## Test plan

- 9 new unit tests, **all 9 red** against the pre-fix provider (verified by unwiring the reverse map and re-running). They cover both renames, both spellings, the per-statement mix, the no-baseline fallback, a nested `RateBasedStatement.ScopeDownStatement`, a full round-trip that asserts byte-equality with the template, and a guard that a REAL needle change still shows as drift.
- Full suite: 517 files / 8768 tests, no type errors.
- **Real AWS (us-east-1).** Deployed the `wafv2` fixture — which carries base64 needles at two nesting depths plus an IPSet reference statement under an `AndStatement` — then ran `cdkd drift`:

  ```
  ✓ Wafv2Stack (us-east-1): no drift detected (7 resources checked, 0 unsupported)
  ```

  That is the decisive check: pre-fix this reported permanent `Rules` drift. Destroy clean, 7 deleted / 0 retained / 0 errors, account swept.

## Known caveat

**Stacks deployed by a pre-fix binary keep their old-shaped `observedProperties`** (`ARN`, and
`SearchString` serialized as a `{"0":66,...}` object), so they will report `Rules` drift once against
the new CFn-shaped read until the next deploy refreshes the baseline. New deploys are unaffected.

A related nit, left as-is: `drift.ts` passes `resource.properties` as the baseline while the
comparator uses `observedProperties ?? properties`. They agree in practice; a resource whose
`observedProperties` carry `Rules` but whose `properties` do not (hand-edited or imported state)
would take the derivation path.

Closes #1403
