### PR TITLE
fix(skill): regenerate every CI-guarded artifact via one aggregate task

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -59,43 +59,49 @@ Run each check and report pass/fail:
 5. **Documentation consistency**
    - Invoke `/check-docs` skill logic: verify docs match code changes
    - Check for stale references to removed code
-   - **Coverage matrix freshness**: CI runs four independent matrix checks (`integ-coverage`, `scenario-coverage`, `cli-flag-coverage`, `audit:coverage:check`) and hard-fails on staleness. PR #548 hit two of these in succession because `/verify-pr` only regenerated `integ-coverage` locally — the contributor pushed, CI failed on `audit:coverage:check`, the contributor regenerated provider-coverage and pushed again, CI failed on `scenario-coverage matrix is up-to-date`. PR #1104 then hit the SAME round-trip on `cli-flag-coverage` (added to CI by #1072 without updating this step): a new fixture's `verify.sh` joined the per-flag user lists, CI failed, one more regen+push cycle. The block below covers all four so the round-trip can't happen again:
+   - **Generated-artifact freshness**: CI carries a staleness guard per generated
+     artifact — it runs the generator and fails if the working tree changes.
+     There are NINE of them, and this step used to name only four, so the list
+     drifted every time one was added. Do NOT re-list them here; regenerate
+     everything in one shot:
      ```bash
-     fixtures_changed=$(git diff main...HEAD --name-only | grep -qE '^src/provisioning/register-providers\.ts$|^tests/integration/[^/]+/(lib|bin)/.+\.ts$|^tests/integration/[^/]+/\.scenarios\.json$|^tests/integration/[^/]+/verify\.sh$' && echo yes)
-     providers_changed=$(git diff main...HEAD --name-only | grep -qE '^src/provisioning/register-providers\.ts$' && echo yes)
-     # cli-flag-coverage counts DECLARED flags, so a flag-only diff (options.ts
-     # or a command file adding/removing an Option) stales it with NO fixture
-     # change — PR #1231 (--strict/--ignore-errors) merged that way and turned
-     # main's check-build-test red until the regen landed (PR #1232).
-     cli_flags_changed=$(git diff main...HEAD --name-only | grep -qE '^src/cli/options\.ts$|^src/cli/commands/.+\.ts$' && echo yes)
+     # Regenerates every artifact CI guards (offline static analysis, seconds
+     # each). Unconditional on purpose: the old per-matrix `git diff` triggers
+     # were themselves the drift, since each new matrix needed a new trigger.
+     vp run gen:all-matrices
 
-     if [ "$fixtures_changed" = "yes" ]; then
-       vp run integ-coverage
-       vp run scenario-coverage
-     fi
+     # `--check` is offline (~0.5s) and verifies the cached
+     # docs/_generated/provider-coverage.json matches register-providers.ts
+     # under the current Tier classification. It is a CRITIC, not a generator,
+     # so it is not part of the aggregate. If it fails, run
+     # `vp run audit:coverage:regenerate` (heavy: ~15 min, needs AWS creds with
+     # cloudformation:ListTypes + DescribeType) and commit the regenerated
+     # cache. /verify-pr does NOT auto-run :regenerate — too costly, and the
+     # creds may not be present locally.
+     vp run audit:coverage:check
 
-     if [ "$fixtures_changed" = "yes" ] || [ "$cli_flags_changed" = "yes" ]; then
-       vp run cli-flag-coverage
-     fi
-
-     if [ "$providers_changed" = "yes" ]; then
-       # `--check` is offline (~0.5s) and verifies the cached
-       # docs/_generated/provider-coverage.json matches register-providers.ts
-       # under the current Tier classification. If it fails, the contributor
-       # must run `vp run audit:coverage:regenerate` (heavy: ~15 min, requires
-       # AWS creds with cloudformation:ListTypes + DescribeType) and commit
-       # the regenerated cache. /verify-pr does NOT auto-run :regenerate
-       # because the cost is too high and AWS creds may not be present in
-       # the local dev environment.
-       vp run audit:coverage:check
-     fi
-
-     git status --short docs/integ-coverage.md docs/_generated/integ-coverage.json \
-                        docs/scenario-coverage.md docs/_generated/scenario-coverage.json \
-                        docs/cli-flag-coverage.md docs/_generated/cli-flag-coverage.json \
-                        docs/_generated/provider-coverage.json docs/_generated/provider-coverage.md
+     # Anything dirty here was stale before you ran the above.
+     git status --short docs/ src/provisioning/property-coverage.generated.ts \
+                        src/provisioning/unsupported-types.generated.ts
      ```
-     If `git status` reports any of these files as dirty, the contributor forgot to regenerate after their code change. Stage the regenerated output, amend / new-commit it onto the PR, and re-run `/check-docs` to refresh the docs marker. If `vp run audit:coverage:check` exits non-zero, run `vp run audit:coverage:regenerate` (heavy — see above) and commit the regenerated `docs/_generated/provider-coverage.{json,md}`.
+     If `git status` reports anything dirty, the contributor forgot to
+     regenerate after their code change. Stage it, add it to the PR, and re-run
+     `/check-docs` to refresh the docs marker.
+
+     `tests/unit/scripts/matrix-regen-coverage.test.ts` pins `gen:all-matrices`
+     against the guards actually present in `.github/workflows/ci.yml` in BOTH
+     directions, so a new CI guard cannot be added without landing in the
+     aggregate, and a removed one cannot linger. That test is what makes this
+     step non-drifting; keep pointing at the aggregate rather than re-listing.
+
+     History, because the same round-trip has now happened four times: PR #548
+     hit two matrices in succession; PR #1104 hit `cli-flag-coverage` (added to
+     CI by #1072 without updating this step); PR #1231 merged a flag-only diff
+     that staled `cli-flag-coverage` with no fixture change and turned main's
+     `check-build-test` red until #1232; and PR #1416 hit
+     `handled-property-wiring` (added by #1414), which is staled by an ordinary
+     private-method rename inside a provider — a refactor nobody associates with
+     a generated file (issue #1417).
      The `provider-integ-gate.sh` PreToolUse hook blocks `git commit` when a new `registry.register('AWS::Foo::Bar', ...)` is added without integ coverage (literal type id, `Cfn<Type>(` L1 class, or `// allow-no-integ: <rationale>` carve-out) — but it does not enforce that the matrix snapshots themselves are regenerated. This step closes that gap.
 
 6. **Leftover resources**

--- a/tests/unit/scripts/matrix-regen-coverage.test.ts
+++ b/tests/unit/scripts/matrix-regen-coverage.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Regression guard for issue #1417: a CI-enforced generated matrix that no
+ * documented pre-push step regenerates.
+ *
+ * CI carries a staleness guard per generated matrix — it runs the generator and
+ * fails if the working tree changes. The list of generators a contributor is
+ * told to run before pushing lived ONLY in prose, in
+ * `.claude/skills/verify-pr/SKILL.md`, and it drifted: CI grew to nine guards
+ * while the skill still named four. The failure mode is a CI round-trip, and it
+ * is worst for the matrices staled by changes nobody associates with a
+ * generated file — `handled-property-wiring` records the METHOD NAMES that seed
+ * each handled property, so an ordinary private-method rename inside a provider
+ * stales it.
+ *
+ * This test makes the drift impossible: whatever CI enforces, the
+ * `gen:all-matrices` aggregate task must regenerate.
+ */
+
+const REPO_ROOT = join(import.meta.dirname, '../../..');
+const CI_YML = join(REPO_ROOT, '.github/workflows/ci.yml');
+const VITE_CONFIG = join(REPO_ROOT, 'vite.config.ts');
+
+/**
+ * The generator tasks CI runs inside a staleness guard.
+ *
+ * A guard is a step that runs a generator and then `git diff --quiet`s its
+ * output. Matching on that PAIR is what keeps the check honest: a plain
+ * `- run: vp run audit:*:check` is a critic, not a staleness guard, and running
+ * it would not regenerate anything.
+ */
+function ciStalenessGuardTasks(): Set<string> {
+  const yml = readFileSync(CI_YML, 'utf8');
+  const tasks = new Set<string>();
+
+  // Steps are `- name: … \n run: | \n <lines>`; split on the step boundary and
+  // keep the blocks that both run a generator and diff its output.
+  for (const block of yml.split(/^ {6}- /m)) {
+    if (!/git diff --quiet/.test(block)) continue;
+    for (const rawLine of block.split('\n')) {
+      const line = rawLine.trim();
+      // Only actual command lines count. A `#` comment and the
+      // `echo "::error::… run \`vp run X\`"` remediation both name tasks that
+      // the step does NOT run — including them would drag
+      // `audit:coverage:regenerate` (10-30 min, needs AWS creds) into the
+      // aggregate.
+      if (!line.startsWith('vp run ')) continue;
+      const task = line.slice('vp run '.length).trim();
+      // `--check` critics validate; they regenerate nothing.
+      if (task.endsWith(':check')) continue;
+      tasks.add(task);
+    }
+  }
+  return tasks;
+}
+
+/** The tasks `gen:all-matrices` chains together. */
+function aggregateTasks(): Set<string> {
+  const config = readFileSync(VITE_CONFIG, 'utf8');
+  const block = /'gen:all-matrices':\s*\{[\s\S]*?\n {6}\},/.exec(config);
+  expect(block, 'gen:all-matrices task not found in vite.config.ts').not.toBeNull();
+  return new Set([...block![0].matchAll(/'vp run ([a-z][a-z0-9:-]*)'/g)].map((m) => m[1]!));
+}
+
+describe('gen:all-matrices covers every CI staleness guard (#1417)', () => {
+  // Parser floor: "found nothing" and "everything matches" look identical
+  // otherwise, which is the vacuous pass `.claude/rules/testing.md` forbids.
+  it('parses a plausible number of guards out of ci.yml', () => {
+    const ci = ciStalenessGuardTasks();
+    expect(ci.size).toBeGreaterThanOrEqual(9);
+    // Spot-check both ends: the oldest guard and the one whose absence from the
+    // skill's list caused #1417.
+    expect(ci.has('integ-coverage')).toBe(true);
+    expect(ci.has('gen:handled-property-wiring')).toBe(true);
+  });
+
+  it('regenerates every matrix CI checks for staleness', () => {
+    const missing = [...ciStalenessGuardTasks()].filter((t) => !aggregateTasks().has(t)).sort();
+    expect(
+      missing,
+      `CI runs a staleness guard for these, but \`gen:all-matrices\` does not regenerate them — ` +
+        `add them to the task in vite.config.ts:\n  ${missing.join('\n  ')}`
+    ).toEqual([]);
+  });
+
+  // The inverse direction: an entry that no longer corresponds to a CI guard is
+  // dead weight that slows every /verify-pr run, and usually means the guard was
+  // renamed rather than removed.
+  it('does not chain a task CI no longer guards', () => {
+    const stale = [...aggregateTasks()].filter((t) => !ciStalenessGuardTasks().has(t)).sort();
+    expect(
+      stale,
+      `\`gen:all-matrices\` regenerates these, but CI has no staleness guard for them — ` +
+        `remove them or restore the guard:\n  ${stale.join('\n  ')}`
+    ).toEqual([]);
+  });
+
+  // The skill is what a human actually follows; keep it pointing at the
+  // aggregate rather than re-listing (and re-drifting from) the set.
+  it('the verify-pr skill regenerates via the aggregate task', () => {
+    const skill = readFileSync(join(REPO_ROOT, '.claude/skills/verify-pr/SKILL.md'), 'utf8');
+    expect(skill).toContain('vp run gen:all-matrices');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -320,6 +320,45 @@ export default defineConfig({
         command: 'node --experimental-strip-types scripts/gen-handled-property-wiring.ts --check',
         cache: false,
       },
+      // Regenerates EVERY CI-enforced matrix in one shot, so `/verify-pr` (and
+      // anyone about to push) can check freshness without knowing the list.
+      //
+      // The list used to live only in `.claude/skills/verify-pr/SKILL.md`, and
+      // it drifted: CI grew to NINE staleness guards while the skill still
+      // named four. Issue #1417 — a private method rename staled
+      // `handled-property-wiring`, `/verify-pr` reported clean, and CI failed.
+      // `tests/unit/scripts/matrix-regen-coverage.test.ts` pins this task
+      // against the guards actually present in `.github/workflows/ci.yml`, so a
+      // NEW matrix cannot be added to CI without also landing here.
+      //
+      // Deliberately excludes `audit:coverage:regenerate` (needs AWS creds,
+      // 10-30 min) and `gen:aws-cli-removals` (needs a local AWS CLI); neither
+      // is a CI staleness guard.
+      'gen:all-matrices': {
+        command: [
+          'vp run integ-coverage',
+          'vp run scenario-coverage',
+          'vp run cli-flag-coverage',
+          'vp run gen:unsupported-types',
+          'vp run gen:property-coverage',
+          // The property-coverage codegen writes a raw multi-line shape while
+          // the committed module is Prettier-formatted, so CI's guard runs
+          // `format` before diffing. Regenerating WITHOUT it produces a
+          // formatting-only diff that looks like real drift (hit live while
+          // preparing #1416).
+          'vp run format',
+          'vp run gen:enrichment-coverage',
+          'vp run gen:sdk-attr-coverage',
+          'vp run gen:update-wrap-coverage',
+          'vp run gen:nested-key-coverage',
+          'vp run gen:handled-property-wiring',
+          // Not a matrix, but the same class of CI guard: a rebase can
+          // denormalize the committed integ ledger, and the failure looks
+          // identical (regenerate-and-commit).
+          'vp run integ-ledger-normalize',
+        ].join(' && '),
+        cache: false,
+      },
       'compat-corpus': {
         command: 'node --experimental-strip-types scripts/compat-corpus.ts',
         cache: false,


### PR DESCRIPTION
## Summary

`/verify-pr`'s matrix-freshness step named **four** generators while CI had grown
to **nine** staleness guards, so the list drifted every time one was added.

Issue #1417: PR #1416 renamed a private provider method, which staled
`handled-property-wiring` (that matrix records the METHOD NAMES seeding each
handled property). `/verify-pr` ran its documented block and reported clean; CI
then failed. That is the same round-trip as #548, #1104 and #1231 before it —
the step's own comment already says it exists to prevent exactly this.

## Approach

Adding the seven missing names would drift again. Instead:

- **`vp run gen:all-matrices`** — one aggregate task, run **unconditionally**.
  The old per-matrix `git diff` triggers were themselves the drift: each new
  matrix needed a new trigger. The generators are offline static analysis,
  seconds each, so conditioning them buys nothing.
- **`tests/unit/scripts/matrix-regen-coverage.test.ts`** — parses the staleness
  guards out of `.github/workflows/ci.yml` and pins them against the aggregate
  in **both** directions: a new CI guard cannot be added without landing in the
  task, and a removed one cannot linger. This is what makes the step
  non-drifting; the skill now points at the aggregate instead of re-listing.

The parser matches only steps that run a generator **and** diff its output, so a
`--check` critic, or a task named inside an `echo "::error::"` remediation line,
is not mistaken for a generator. That distinction is load-bearing: it keeps
`audit:coverage:regenerate` (10-30 min, needs AWS creds) out of the aggregate.

## Two things the parse surfaced that the issue did not mention

- **`vp run format` is part of CI's property-coverage guard.** The codegen writes
  a raw multi-line shape while the committed module is Prettier-formatted, so
  regenerating *without* `format` produces a formatting-only diff that reads as
  real drift. Hit live while preparing #1416 (I reverted it as noise at the
  time — this explains why it appeared).
- **`integ-ledger-normalize` is the same class of guard** — a rebase can
  denormalize the committed integ ledger, and the failure looks identical
  (regenerate-and-commit). It joins the aggregate.

## Verification

- **Real-code fail probe** (per `.claude/rules/testing.md`): removed
  `gen:handled-property-wiring` from the aggregate — the exact #1417 regression —
  and the test exited non-zero naming that task; restored after.
- **Parser floor**: asserts at least 9 guards parsed, plus spot-checks the oldest
  guard and the one whose absence caused #1417, so "parsed nothing" cannot pass
  as "everything matches".
- **Live-tested the aggregate end to end**: 12/12 tasks succeed, no generated
  drift. Its first run failed on a missing SDK typings dir — my worktree had no
  `node_modules`, the pre-flight both skills carry a step 0 for. A real finding
  about my process rather than about the task.
- `check` / `typecheck:test` / `build` / `test` all verified by captured exit
  code, not by piping to `tail` — the trap that let a TS2741 through earlier in
  this session.

Closes #1417
