### PR TITLE
chore(skills): make the work-issues claim protocol race-safe

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -139,8 +139,39 @@ Claiming to avoid collision with parallel agents."
 (English only — committed/public artifacts are English.) This is mandatory and
 comes BEFORE the first edit. It is the issue-level twin of the worktree
 DISJOINT-FILE rule (see the "Claim a filed issue before working it" rule in
-`CLAUDE.md`). Re-check for a competing claim/PR right before you start; if one
-appeared, pick a different issue.
+`CLAUDE.md`).
+
+**Claim at SHORTLIST time, not after the analysis.** Claim the moment an issue
+enters your candidate set — before the deep read of its body, before mapping
+which files it lands in. Retracting a claim you then decided against costs one
+comment; a collision costs a whole lane. The window this closes is the one that
+actually bites: two sessions can each spend minutes triaging in total mutual
+invisibility, because neither has posted anything yet.
+
+**Then VERIFY the claim stuck (compare-and-swap).** Posting is not winning —
+another session may have posted seconds earlier. Immediately re-read the issue
+and check for a competing claim:
+
+```bash
+gh issue view <n> --json comments \
+  --jq '.comments[] | select(.body | test("Working on this")) | "\(.createdAt)\t\(.body[0:80])"'
+```
+
+**Tie-break: the EARLIEST `createdAt` wins.** If someone else's claim predates
+yours, you are the loser of the race — post a short stand-down comment naming
+the winning branch, drop the lane, and pick a different issue. Do this without
+asking; the whole point is that both sessions independently reach the same
+answer from the same timestamps. Escalate to the maintainer only when the
+timestamps cannot settle it.
+
+This exists because it has already failed once: two sessions claimed #1419 /
+#1435 twenty seconds apart (2026-08-09), both having followed every other rule
+in this skill, and it took the maintainer arbitrating to resolve. See #1446.
+
+**Do not trust a handoff table — verify it live.** A "these issues are taken"
+note you were handed is a snapshot of the moment it was written; PRs merge and
+worktrees disappear. Re-derive occupancy from `gh pr list --state open`,
+`git worktree list`, and the issues' own comments before believing any of it.
 
 ## 5. One worktree per lane, then implement
 
@@ -277,6 +308,9 @@ anything non-obvious you learned in memory.
 
 - **Claim before editing, always** — the whole point. An unclaimed lane races a
   parallel agent onto the same cross-cutting file.
+- **Claiming is not winning.** Posting the comment does not end the race — read
+  it back and yield to an earlier `createdAt` (§4). Claiming late, after the
+  triage, is what makes the race winnable in the first place.
 - **One lane per cross-cutting file.** `deploy-engine.ts` / `intrinsic-function-resolver.ts`
   / `dag-builder.ts` / `register-providers.ts` absorb most non-trivial fixes; you
   cannot parallelize two issues that both land there. Per-provider fixes ARE


### PR DESCRIPTION
## Problem

Two parallel sessions claimed #1419 and #1435 **20 seconds apart** (18:17:05Z vs 18:17:25Z). Both had followed every existing rule in `/work-issues` — screened the backlog, mapped the collision landscape, picked file-disjoint lanes, claimed before editing. Resolving it still took the maintainer arbitrating between the two sessions.

## Root cause

The claim comment is posted **after** the triage work, not before it. Both sessions spent minutes reading issue bodies and working out which files each candidate lands in, and during that whole window neither was visible to the other. The 20-second gap is just the tail of that invisible window.

A second factor: one session was working from a handoff table that had gone stale — it listed #1440 / #1444 as owned by a live session, but PR #1443 had already merged and both the worktree and the session-owner sentinel were gone.

## Change

Three additions to section 4 of `.claude/skills/work-issues/SKILL.md`, plus a matching Gotchas entry:

1. **Claim at shortlist time, not after the analysis.** Retracting a claim costs one comment; a collision costs a lane. Shrinks the race window from minutes to seconds.
2. **Read the claim back (compare-and-swap).** Posting is not winning — re-read the issue and check for a competing claim with an earlier `createdAt`.
3. **An explicit tie-break: earliest claim wins.** The loser posts a stand-down comment and moves on, without asking. This is what lets two sessions independently reach the same answer from the same timestamps instead of escalating to the maintainer.

Plus: a handoff table naming "taken" issues must be re-derived live (`gh pr list`, `git worktree list`, the issues' own comments) rather than trusted.

## Why not a hook

A PreToolUse gate could enforce this physically, but it needs a `gh` round-trip per invocation — too heavy for a path that fires on every edit. The read-back check in (2) gets most of the value at no per-edit cost.

## Verification

Docs-only change under `.claude/skills/**` — outside the `check` and `docs` markgate scopes, no `src/**` change, so no live test applies.

Closes #1446
