### PR TITLE
test(integ): assert Glue actually wrote Iceberg metadata, not just tagged the table

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -58,7 +58,7 @@ cross-region-state-bucket	2026-08-01T09:42:37Z	PASS	29	verify.sh	0801 regression
 cross-stack-references	2026-08-08T17:48:34Z	PASS	25	standard	marker re-flip after review coercion fix; deploy+destroy clean
 custom-resource-getatt-data	2026-07-20T14:59:39Z	PASS	63	verify.sh	CR Data GetAtt->dependent prop, 6 res clean
 custom-resource-provider	2026-07-24T08:31:58Z	PASS	480	standard	cross-region us-west-2 vs us-east-1 bucket (issue #1195 fix + hardening live-verified); 17 res, destroy 0 err 0 orphan
-data-analytics	2026-07-21T18:30:46Z	PASS	50	verify.sh	rc ok, orph clean
+data-analytics	2026-08-09T19:29:29Z	PASS	51	verify.sh	rc ok, orph clean (swept 1 pre-existing autoDeleteObjects log group)
 data-pipeline	2026-07-24T10:53:59Z	PASS	47	standard	0724b sweep staleness; 7 del 0 err 0 orphans
 deep-getatt-chains	2026-08-01T10:07:21Z	PASS	53	verify.sh	0801 regression sweep; SDK+CC chain ok, 0 orphans
 deletion-ordering-complex	2026-07-26T20:00:52Z	PASS	187	verify.sh	0727b sweep-b13 staleness re-run (rc=0); account clean

--- a/tests/integration/data-analytics/verify.sh
+++ b/tests/integration/data-analytics/verify.sh
@@ -8,8 +8,15 @@
 # was a silent-drop before the #609 backfill. OpenTableFormatInput is a
 # create-time directive that GetTable does NOT echo back as an
 # OpenTableFormatInput field; an Iceberg table surfaces via
-# `Table.Parameters.table_type == 'ICEBERG'`, which is what we assert. Also
-# asserts the destroy path cleans up.
+# `Table.Parameters.table_type == 'ICEBERG'`, which is what we assert.
+#
+# Since issue #1408 it ALSO asserts `Table.Parameters.metadata_location` is an
+# s3:// URI, i.e. that `MetadataOperation: CREATE` made Glue write real Iceberg
+# metadata rather than merely tagging the catalog entry. See the comment at
+# that assertion for why the `IcebergTableInput` coverage #1408 originally asked
+# for is unreachable (CloudFormation itself cannot deploy that shape).
+#
+# Also asserts the destroy path cleans up.
 #
 # Required env vars:
 #   STATE_BUCKET — cdkd state bucket (e.g. cdkd-state-{accountId})
@@ -153,6 +160,40 @@ if [ "${TABLE_TYPE_UPPER}" != "ICEBERG" ]; then
   exit 1
 fi
 echo "    OK: Table.Parameters.table_type == ICEBERG on AWS (OpenTableFormatInput silent-drop CLOSED by #609)"
+
+# --- Assertion: Glue actually WROTE Iceberg metadata to S3 ------------
+# `table_type == ICEBERG` alone only proves the parameter was tagged onto the
+# table. `MetadataOperation: CREATE` is supposed to make Glue write a real
+# Iceberg metadata file under the StorageDescriptor location and record its
+# key in `Parameters.metadata_location`; a table tagged ICEBERG with an EMPTY
+# metadata_location would be a catalog entry no Iceberg reader can open.
+#
+# This is the achievable half of issue #1408. That issue asked for a fixture
+# asserting a column that exists ONLY in `IcebergInput.IcebergTableInput`, and
+# its live probe (2026-08-09, 5 raw glue:CreateTable shapes + 5 CloudFormation
+# stacks) proved that unreachable: CloudFormation itself cannot deploy
+# `IcebergTableInput` in ANY shape, every one failing with "Table metadata is
+# expected only via TableInput or via IcebergTableInputProperties inside
+# OpenTableFormatInput" — a third spelling present in neither the CFn registry
+# schema (`IcebergTableInput`) nor `@aws-sdk/client-glue`
+# (`CreateIcebergTableInput`). cdkd's compatibility target is CloudFormation,
+# so there is nothing to be compatible WITH there. What a CDK user can actually
+# deploy today is this shape, and this assertion is what pins it.
+METADATA_LOCATION=$(aws glue get-table \
+  --database-name "${DB_NAME}" --name "${TABLE_NAME}" --region "${REGION}" \
+  --query 'Table.Parameters.metadata_location' --output text)
+
+case "${METADATA_LOCATION}" in
+  s3://*)
+    ;;
+  *)
+    echo "FAIL: Table.Parameters.metadata_location is '${METADATA_LOCATION}', expected an s3:// URI (MetadataOperation: CREATE did not write Iceberg metadata)" >&2
+    aws glue get-table --database-name "${DB_NAME}" --name "${TABLE_NAME}" --region "${REGION}" \
+      --query 'Table.Parameters' --output json 2>/dev/null || true
+    exit 1
+    ;;
+esac
+echo "    OK: Table.Parameters.metadata_location == ${METADATA_LOCATION} (Glue wrote real Iceberg metadata)"
 
 # --- Phase 2: destroy -------------------------------------------------
 echo "==> Phase 2: destroy"


### PR DESCRIPTION
## Summary

Closes the **achievable** half of #1408 and records why the other half cannot be
built.

#1408 asked for an integ fixture asserting a column that exists ONLY in
`IcebergInput.IcebergTableInput`. Its live probe (5 raw `glue:CreateTable`
shapes + 5 CloudFormation stacks, us-east-1, all torn down) proved that
unreachable: **CloudFormation itself cannot deploy `IcebergTableInput` in any
shape**, every attempt failing with

```
Table metadata is expected only via TableInput or via
IcebergTableInputProperties inside OpenTableFormatInput
```

Note the spelling in that message — `IcebergTableInputProperties` appears in
**neither** the CFn registry schema (which declares
`IcebergInput.IcebergTableInput`) **nor** `@aws-sdk/client-glue` (which declares
`IcebergInput.CreateIcebergTableInput`). Three spellings, and the one the live
handler wants is offered by neither contract. cdkd's compatibility target is
CloudFormation, so there is nothing to be compatible *with* there, and no
fixture can be made green by fixing cdkd. The #1390 rename is still correct —
it is what let the request reach Glue at all — it just has no deployable shape
behind it.

## What this PR does

The probe DID establish that the shape the `data-analytics` fixture **already
deploys** — `TableType: EXTERNAL_TABLE` + `StorageDescriptor` +
`IcebergInput{MetadataOperation: CREATE}` — produces a real Iceberg table, with
Glue writing metadata to S3.

The fixture asserted only `Table.Parameters.table_type == 'ICEBERG'`. That proves
the parameter was tagged onto the catalog entry and nothing more: a table tagged
`ICEBERG` with an empty `metadata_location` is an entry no Iceberg reader can
open. So `verify.sh` now also requires `Table.Parameters.metadata_location` to be
an `s3://` URI.

The guard is a `case` matching `s3://*` with a hard-FAIL default that dumps the
full `Parameters` map — not a silenced probe (`.claude/rules/testing.md`
gone-probe rules).

## Verified against real AWS

`/run-integ data-analytics` on this branch:

```
OK: Table.Parameters.table_type == ICEBERG on AWS (OpenTableFormatInput silent-drop CLOSED by #609)
OK: Table.Parameters.metadata_location == s3://dataanalyticsstack-resultsbucketa95a2103/iceberg/metadata/00000-6438f364-cba1-42b0-9d93-877d200c57a4.metadata.json (Glue wrote real Iceberg metadata)
```

- 10 resources deployed and destroyed, **0 errors, 0 orphans**
- Post-run sweep removed one pre-existing
  `/aws/lambda/DataAnalyticsStack-CustomS3AutoDeleteObjects…` log group created
  by an earlier run at 06:17Z (the known `autoDeleteObjects` custom-resource
  leftover), then re-verified clean
- Ledger row recorded: `data-analytics  2026-08-09T19:29:29Z  PASS  51  verify.sh`

## Not included

**What cdkd should do when a template DOES carry `IcebergTableInput`** is a
separate question — forwarding it reproduces CloudFormation's own failure
(arguably correct parity), versus a pre-flight error naming the working shape.
That is a behavior decision, not test coverage, and belongs in its own issue
rather than folded into this one — filed as #1454.

## Test plan

- `vp run check` / `vp run typecheck:test` / `vp run build` — clean
- `vp test --run` — 526 files, 9059 tests, all pass (incl. the integ verify.sh
  lints: gone-probes, signal traps, CLI flags, aws-command availability,
  version literals)
- `vp run gen:all-matrices` — no drift
- `/run-integ data-analytics` — PASS, detailed above

Closes #1408
