### PR TITLE
test(dynamodb): fence the local-replica-only GSI read-capacity derivation after a probe disproved #1452

### DIFF
--- a/tests/unit/provisioning/dynamodb-globaltable-provider-gsi-throughput.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-gsi-throughput.test.ts
@@ -361,6 +361,81 @@ describe('DynamoDBGlobalTable GSI throughput translation (issue #1387)', () => {
       expect(gsi!.OnDemandThroughput).toBeUndefined();
     });
 
+    // Issue #1452 FENCE. The CFn docs for CapacityAutoScalingSettings claim a
+    // CROSS-REGION max: "if your global secondary index myGSI has a
+    // SeedCapacity of 10 in us-east-1 and a fixed ReadCapacityUnits of 20 in
+    // eu-west-1, CloudFormation will initially set the read capacity for myGSI
+    // to 20." A live probe DISPROVED that sentence, so deriving read capacity
+    // from the LOCAL replica alone is CORRECT and must stay that way.
+    //
+    // Probe (stack Cdkd1452ProbeXRegionRead, us-east-1 + us-west-2, 2026-08-10):
+    // an AWS::DynamoDB::GlobalTable whose local (us-east-1) replica GSI carried
+    // ReadCapacityAutoScalingSettings{MinCapacity 1, MaxCapacity 100,
+    // SeedCapacity 10} and whose remote (us-west-2) replica GSI carried a fixed
+    // ReadCapacityUnits 20 reached CREATE_COMPLETE with:
+    //   us-east-1 myGSI ProvisionedThroughput.ReadCapacityUnits = 1
+    //   us-west-2 myGSI ProvisionedThroughputOverride.ReadCapacityUnits = 20
+    // So CloudFormation took the LOCAL replica's MinCapacity (1) and applied
+    // the remote's 20 only as that replica's own override. It took neither the
+    // remote's higher value NOR the local SeedCapacity — the latter
+    // independently re-confirming issue #1435's 'min'-on-create finding.
+    //
+    // Taking a max across replicas here would OVER-provision every such table
+    // and diverge from CloudFormation. This is the same failure mode as #1427,
+    // whose doc-derived premise the same probe family also disproved.
+    it('does NOT raise the local read capacity to a higher REMOTE replica value (issue #1452)', () => {
+      const [gsi] = toSdkGlobalSecondaryIndexes(
+        {
+          BillingMode: 'PROVISIONED',
+          GlobalSecondaryIndexes: [
+            {
+              IndexName: 'myGSI',
+              KeySchema: [{ AttributeName: 'gsipk', KeyType: 'HASH' }],
+              Projection: { ProjectionType: 'KEYS_ONLY' },
+              WriteProvisionedThroughputSettings: {
+                WriteCapacityAutoScalingSettings: { MinCapacity: 1, MaxCapacity: 10 },
+              },
+            },
+          ],
+          Replicas: [
+            {
+              Region: 'us-east-1',
+              GlobalSecondaryIndexes: [
+                {
+                  IndexName: 'myGSI',
+                  ReadProvisionedThroughputSettings: {
+                    ReadCapacityAutoScalingSettings: {
+                      MinCapacity: 1,
+                      MaxCapacity: 100,
+                      SeedCapacity: 10,
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              Region: 'us-west-2',
+              GlobalSecondaryIndexes: [
+                {
+                  IndexName: 'myGSI',
+                  ReadProvisionedThroughputSettings: { ReadCapacityUnits: 20 },
+                },
+              ],
+            },
+          ],
+        },
+        'us-east-1',
+        'PROVISIONED'
+      );
+      // 1 = the LOCAL replica's MinCapacity. NOT 20 (the remote replica's
+      // fixed value) and NOT 10 (the local SeedCapacity) — both were rejected
+      // by the live probe above.
+      expect(gsi!.ProvisionedThroughput).toEqual({
+        ReadCapacityUnits: 1,
+        WriteCapacityUnits: 1,
+      });
+    });
+
     it('maps the on-demand CDK shape to SDK OnDemandThroughput (both directions)', () => {
       const [gsi] = toSdkGlobalSecondaryIndexes(
         ON_DEMAND_TABLE_PROPS,


### PR DESCRIPTION
## Summary

Issue #1452 asked for a **live probe before implementing**, because its parent
#1427 had been filed on an AWS doc sentence that the probe disproved. The probe
has now run and the same thing happened again: the cross-region max does not
exist either.

**cdkd needs no source change** — deriving per-GSI read capacity from the LOCAL
replica entry alone is exactly what CloudFormation does. This PR ships the
disproof as a regression **fence** instead, so a future reader who finds the
same doc sentence cannot turn it into a bug fix.

## The probe

Stack `Cdkd1452ProbeXRegionRead`, us-east-1 + us-west-2, 2026-08-10, deployed
through CloudFormation (not cdkd) so the reference behavior is CloudFormation's
own. One `AWS::DynamoDB::GlobalTable`, `BillingMode: PROVISIONED`, one GSI
`myGSI`, shaped to make the three candidate answers distinguishable:

| replica | `myGSI` read setting | expected if... |
| --- | --- | --- |
| us-east-1 (local) | `ReadCapacityAutoScalingSettings { MinCapacity: 1, MaxCapacity: 100, SeedCapacity: 10 }` | `1` = MinCapacity, `10` = local SeedCapacity |
| us-west-2 (remote) | fixed `ReadCapacityUnits: 20` | `20` = the documented cross-region max |

`CREATE_COMPLETE`, then `describe-table` in both regions:

```
us-east-1  myGSI ProvisionedThroughput.ReadCapacityUnits         = 1
us-west-2  myGSI ProvisionedThroughput.ReadCapacityUnits         = 20
us-east-1  Replicas[us-west-2].GSI[myGSI]
             .ProvisionedThroughputOverride.ReadCapacityUnits    = 20
```

What that settles:

1. **No cross-region max.** The doc's own example shape produced `1` in
   us-east-1, not `20`. "CloudFormation will use the highest value found in
   either the `SeedCapacity` or `ReadCapacityUnits` properties" does not
   describe what the handler does.
2. **The remote value stays scoped to the remote replica**, landing as that
   replica's `ProvisionedThroughputOverride` — which `toSdkReplicaGlobalSecondaryIndexes`
   already maps correctly.
3. **Bonus re-confirmation of #1435**: CloudFormation took `MinCapacity: 1`, not
   `SeedCapacity: 10`, on create — a second independent confirmation of the
   `'min'`-on-create finding, on a different template shape from the one that
   established it.

Also worth noting: `MinCapacity` is `Required: Yes` in the registry schema, so
the shape the doc describes (a `SeedCapacity` with no `MinCapacity` for the max
to be taken against) is not even constructible.

## What this PR contains

One unit test in
`tests/unit/provisioning/dynamodb-globaltable-provider-gsi-throughput.test.ts`
pinning the local-replica-only derivation with the exact probe shape, and the
probe transcript inlined in its comment. A "fix" that takes the max across
replicas would over-provision every such table and diverge from CloudFormation;
this is what stops it being written.

Without the fence the disproof would live only in an issue comment, and the
misleading doc sentence stays published. It has now cost two issues.

## Test plan

- `vp run test` — 527 files / 9088 tests pass.
- `vp test --run -t "issue #1452"` — 1 passed, confirming the new test actually
  executes rather than being silently filtered out.
- Live test: the CloudFormation probe above IS the live test — the asserted
  numbers are read back from real AWS, not predicted.
- Teardown verified clean: stack gone, table gone in BOTH regions, no orphan
  (`DescribeStacks` / `DescribeTable` x2 all return not-found). The 24h
  source-region deletion lock recorded on #1434 / #1442 did not bite, because a
  `DeleteStack` of a CFn-owned global table removes all replicas as one
  operation rather than issuing a standalone replica-delete.

Closes #1452
