### PR TITLE
test(dynamodb): close the review nits on the GlobalTable autoscaling tests

### DIFF
--- a/tests/integration/dynamodb-globaltable/verify.sh
+++ b/tests/integration/dynamodb-globaltable/verify.sh
@@ -256,19 +256,37 @@ echo "[verify] step 4c (Issue #1419): assert the per-INDEX auto-scaling target +
 # `create()` additionally registered NOTHING, so this assertion runs against
 # the BASELINE deploy: no update deploy has happened yet at this point in the
 # flow. That is deliberate — it pins the create-side half of the fix.
+# Read ONE scalable-target field. Per-value queries rather than a joined
+# multi-field `--output text` row: the joined form compares against a literal
+# embedded TAB, which is invisible in review and breaks if the AWS CLI ever
+# changes its text-output separator. `|| return 1` propagates a probe failure
+# to the caller's `set -e` (errexit is cleared inside `$( )`).
+scalable_target_field() { # $1 = resource id, $2 = dimension, $3 = field
+  local out
+  out="$(aws application-autoscaling describe-scalable-targets \
+    --service-namespace dynamodb \
+    --resource-ids "$1" \
+    --scalable-dimension "$2" \
+    --region "${REGION}" \
+    --query "ScalableTargets[0].$3" --output text)" || return 1
+  printf '%s' "${out}"
+}
+assert_scalable_target() { # $1 = resource id, $2 = dimension, $3 = min, $4 = max, $5 = label
+  local got_min got_max
+  got_min="$(scalable_target_field "$1" "$2" MinCapacity)"
+  got_max="$(scalable_target_field "$1" "$2" MaxCapacity)"
+  if [ "${got_min}" != "$3" ] || [ "${got_max}" != "$4" ]; then
+    echo "[verify] FAIL (issue #1419): $5 on $1 ($2)" >&2
+    echo "[verify]   got Min=${got_min} Max=${got_max}, expected Min=$3 Max=$4" >&2
+    echo "[verify]   pre-fix cdkd never registered this scalable dimension" >&2
+    exit 1
+  fi
+  echo "[verify] $5 ok: Min=${got_min} Max=${got_max}"
+}
+
 INDEX_RESOURCE_ID="table/${GSI_PROV_TABLE}/index/byStatus"
-INDEX_TARGET_JSON="$(aws application-autoscaling describe-scalable-targets \
-  --service-namespace dynamodb \
-  --resource-ids "${INDEX_RESOURCE_ID}" \
-  --scalable-dimension dynamodb:index:WriteCapacityUnits \
-  --region "${REGION}" \
-  --query 'ScalableTargets[0].[MinCapacity,MaxCapacity]' --output text)"
-if [ "${INDEX_TARGET_JSON}" != "2	20" ]; then
-  echo "[verify] FAIL (issue #1419): no dynamodb:index:WriteCapacityUnits target on ${INDEX_RESOURCE_ID}" >&2
-  echo "[verify]   got Min/Max '${INDEX_TARGET_JSON}', expected tab-separated '2' and '20' from Capacity.autoscaled" >&2
-  echo "[verify]   pre-fix cdkd never registered ANY index-level scalable target" >&2
-  exit 1
-fi
+assert_scalable_target "${INDEX_RESOURCE_ID}" dynamodb:index:WriteCapacityUnits 2 20 \
+  "step 4c index write autoscaling"
 INDEX_POLICY_TARGET="$(aws application-autoscaling describe-scaling-policies \
   --service-namespace dynamodb \
   --resource-id "${INDEX_RESOURCE_ID}" \
@@ -289,18 +307,8 @@ esac
 # The READ half of the same index. Registered from a DIFFERENT CFn location
 # than the write half (`Replicas[local].GlobalSecondaryIndexes[]` rather than
 # the top-level GSI), so it is a genuinely separate path, not a mirror.
-INDEX_READ_MINMAX="$(aws application-autoscaling describe-scalable-targets \
-  --service-namespace dynamodb \
-  --resource-ids "${INDEX_RESOURCE_ID}" \
-  --scalable-dimension dynamodb:index:ReadCapacityUnits \
-  --region "${REGION}" \
-  --query 'ScalableTargets[0].[MinCapacity,MaxCapacity]' --output text)"
-if [ "${INDEX_READ_MINMAX}" != "7	70" ]; then
-  echo "[verify] FAIL (issue #1419): no dynamodb:index:ReadCapacityUnits target on ${INDEX_RESOURCE_ID}" >&2
-  echo "[verify]   got Min/Max '${INDEX_READ_MINMAX}', expected tab-separated '7' and '70'" >&2
-  exit 1
-fi
-echo "[verify] step 4c ok: index read autoscaling registered (${INDEX_READ_MINMAX})"
+assert_scalable_target "${INDEX_RESOURCE_ID}" dynamodb:index:ReadCapacityUnits 7 70 \
+  "step 4c index read autoscaling"
 
 # Issue #1435 at TABLE level: the fixture declares minCapacity 1 / seedCapacity 8,
 # and CloudFormation creates at MinCapacity. Pre-fix cdkd sent the seed (8).
@@ -391,17 +399,8 @@ echo "[verify] step 12a (Issue #1419): assert the LOCAL replica's read dimension
 # local region, so only CROSS-REGION replicas got a read target, and create()
 # registered nothing at all. The read half of a single-region autoscaled
 # table was therefore silently unscaled.
-LOCAL_READ_MINMAX="$(aws application-autoscaling describe-scalable-targets \
-  --service-namespace dynamodb \
-  --resource-ids "table/${TABLE_NAME}" \
-  --scalable-dimension dynamodb:table:ReadCapacityUnits \
-  --region "${REGION}" \
-  --query 'ScalableTargets[0].[MinCapacity,MaxCapacity]' --output text)"
-if [ "${LOCAL_READ_MINMAX}" != "5	50" ]; then
-  echo "[verify] FAIL (issue #1419): local read target on table/${TABLE_NAME} is '${LOCAL_READ_MINMAX}' (expected Min 5 / Max 50)" >&2
-  exit 1
-fi
-echo "[verify] step 12a ok: local replica read autoscaling registered (${LOCAL_READ_MINMAX})"
+assert_scalable_target "table/${TABLE_NAME}" dynamodb:table:ReadCapacityUnits 5 50 \
+  "step 12a local replica read autoscaling"
 
 # Item D — opt-in cross-region replica round-trip. Guarded behind
 # CDKD_INTEG_MULTI_REGION=1 because the wall-clock + cost is large.

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-index-autoscaling.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-index-autoscaling.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import {
+  CreateTableCommand,
   DescribeTableCommand,
   DeleteTableCommand,
+  UpdateTableCommand,
   UpdateTimeToLiveCommand,
   ResourceNotFoundException,
 } from '@aws-sdk/client-dynamodb';
@@ -420,6 +422,22 @@ describe('DynamoDBGlobalTable per-index auto-scaling (issue #1419)', () => {
         ReadProvisionedThroughputSettings: { ReadCapacityAutoScalingSettings: TABLE_READ_AS },
       });
       await provider.create('Prov', RESOURCE_TYPE, props);
+
+      // Asserting only that a client was built for eu-west-1 would pass even
+      // if the register carried the wrong ResourceId, dimension or Min/Max —
+      // the local-region registrations alone already construct clients. Pin
+      // the actual input the way the local-region tests do.
+      const register = registerInputs().find(
+        (i) =>
+          i['ScalableDimension'] === 'dynamodb:table:ReadCapacityUnits' &&
+          i['ResourceId'] === `table/${TABLE_NAME}` &&
+          i['MinCapacity'] === TABLE_READ_AS.MinCapacity
+      );
+      expect(register).toBeDefined();
+      expect(register).toMatchObject({
+        ServiceNamespace: 'dynamodb',
+        MaxCapacity: TABLE_READ_AS.MaxCapacity,
+      });
       expect(autoScalingRegionSpy).toHaveBeenCalledWith('eu-west-1');
     });
   });
@@ -499,6 +517,68 @@ describe('DynamoDBGlobalTable per-index auto-scaling (issue #1419)', () => {
     });
   });
 
+  describe('ordering', () => {
+    // Two ordering claims are load-bearing and were documented only in code
+    // comments: registration must follow the table AND replicas going ACTIVE,
+    // and step 6b must follow step 6 so an index added by the same deploy
+    // exists. The DynamoDB and application-autoscaling mocks are separate
+    // `vi.fn()`s, so per-mock assertions cannot see the interleaving —
+    // `mock.invocationCallOrder` spans mocks and can.
+    it('registers only AFTER the table is created and observed ACTIVE', async () => {
+      await provider.create('Prov', RESOURCE_TYPE, AUTOSCALED_PROPS);
+
+      const createOrder = mockSend.mock.calls
+        .map((c, i) => ({ c: c[0], i }))
+        .filter(({ c }) => c instanceof CreateTableCommand)
+        .map(({ i }) => mockSend.mock.invocationCallOrder[i]!);
+      const describeOrder = mockSend.mock.calls
+        .map((c, i) => ({ c: c[0], i }))
+        .filter(({ c }) => c instanceof DescribeTableCommand)
+        .map(({ i }) => mockSend.mock.invocationCallOrder[i]!);
+      const firstRegister = mockAutoScalingSend.mock.calls
+        .map((c, i) => ({ c: c[0], i }))
+        .filter(({ c }) => c instanceof RegisterScalableTargetCommand)
+        .map(({ i }) => mockAutoScalingSend.mock.invocationCallOrder[i]!)[0];
+
+      expect(firstRegister).toBeDefined();
+      expect(createOrder[0]).toBeLessThan(firstRegister!);
+      // At least one ACTIVE-observing DescribeTable precedes registration.
+      expect(describeOrder.some((o) => o < firstRegister!)).toBe(true);
+    });
+
+    it('registers an index target only AFTER the GSI-create UpdateTable', async () => {
+      // A GSI added by this deploy: step 6 creates it, step 6b registers it.
+      // Reversed, application-autoscaling would reject a target whose index
+      // does not exist yet.
+      const previous = structuredClone(AUTOSCALED_PROPS) as Record<string, unknown>;
+      previous['GlobalSecondaryIndexes'] = [];
+      (previous['Replicas'] as Array<Record<string, unknown>>)[0]!['GlobalSecondaryIndexes'] = [];
+
+      await provider.update('Prov', TABLE_NAME, RESOURCE_TYPE, AUTOSCALED_PROPS, previous);
+
+      const gsiCreateOrder = mockSend.mock.calls
+        .map((c, i) => ({ c: c[0], i }))
+        .filter(
+          ({ c }) =>
+            c instanceof UpdateTableCommand &&
+            (c.input.GlobalSecondaryIndexUpdates ?? []).some((u) => u.Create !== undefined)
+        )
+        .map(({ i }) => mockSend.mock.invocationCallOrder[i]!);
+      const indexRegisterOrder = mockAutoScalingSend.mock.calls
+        .map((c, i) => ({ c: c[0], i }))
+        .filter(
+          ({ c }) =>
+            c instanceof RegisterScalableTargetCommand &&
+            String(c.input.ScalableDimension).startsWith('dynamodb:index:')
+        )
+        .map(({ i }) => mockAutoScalingSend.mock.invocationCallOrder[i]!);
+
+      expect(gsiCreateOrder.length).toBeGreaterThan(0);
+      expect(indexRegisterOrder.length).toBeGreaterThan(0);
+      expect(gsiCreateOrder[0]).toBeLessThan(indexRegisterOrder[0]!);
+    });
+  });
+
   describe('throttle retry', () => {
     it('RETRIES a throttled RegisterScalableTarget instead of silently giving up', async () => {
       // Regression guard for a fix that TYPECHECKED while doing nothing:
@@ -565,17 +645,24 @@ describe('DynamoDBGlobalTable per-index auto-scaling (issue #1419)', () => {
      * would poll forever, so serve the table once (the pre-delete describe
      * the teardown reads index names from) and RNF after that.
      */
-    function describeOnceThenGone(table: Record<string, unknown>): void {
-      let served = false;
+    // `serves` controls how many DescribeTable calls return the table before
+    // RNF. The default of 1 covers the pre-delete describe only, which means
+    // `waitForTableGone` sees RNF on its very first poll and its loop never
+    // iterates — fine for the teardown assertions, but it leaves the polling
+    // itself unexercised, so a regression that broke the loop would not show
+    // up here. The `serves > 1` form below closes that.
+    function describeNTimesThenGone(table: Record<string, unknown>, serves = 1): void {
+      let served = 0;
       mockSend.mockImplementation((command: unknown) => {
         if (command instanceof DescribeTableCommand) {
-          if (served) return Promise.reject(newRnf());
-          served = true;
+          if (served >= serves) return Promise.reject(newRnf());
+          served += 1;
           return Promise.resolve({ Table: table });
         }
         return Promise.resolve({});
       });
     }
+    const describeOnceThenGone = (t: Record<string, unknown>): void => describeNTimesThenGone(t, 1);
 
     it('deregisters the per-index targets so they are not inherited by a future table of the same name', async () => {
       describeOnceThenGone({
@@ -660,6 +747,35 @@ describe('DynamoDBGlobalTable per-index auto-scaling (issue #1419)', () => {
       await provider.delete('Prov', TABLE_NAME, RESOURCE_TYPE, AUTOSCALED_PROPS);
 
       expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('polls DescribeTable until the table is really gone, then finishes cleanly', async () => {
+      // Two extra serves after the pre-delete describe, so waitForTableGone
+      // actually loops before observing RNF. Without this every delete test
+      // proves only the one-shot path.
+      describeNTimesThenGone(
+        {
+          TableName: TABLE_NAME,
+          TableArn: TABLE_ARN,
+          TableStatus: 'ACTIVE',
+          GlobalSecondaryIndexes: [{ IndexName: 'gsi1' }],
+          Replicas: [{ RegionName: 'us-east-1' }],
+        },
+        3
+      );
+
+      await provider.delete('Prov', TABLE_NAME, RESOURCE_TYPE, AUTOSCALED_PROPS);
+
+      const describeCalls = mockSend.mock.calls
+        .map((c) => c[0])
+        .filter((c) => c instanceof DescribeTableCommand);
+      // 1 pre-delete + at least 2 poll iterations + the RNF that ends the wait.
+      expect(describeCalls.length).toBeGreaterThanOrEqual(4);
+      // And the teardown still ran to completion.
+      expect(deregistered()).toContainEqual([
+        `table/${TABLE_NAME}/index/gsi1`,
+        'dynamodb:index:WriteCapacityUnits',
+      ]);
     });
 
     it('takes index names from the live DescribeTable, not from the (possibly stale) template', async () => {


### PR DESCRIPTION
Four test-quality items the #1451 review raised, which that PR deliberately deferred: each strengthens an already-green test rather than closing a correctness gap, so none justified restarting its CI + real-AWS integ cycle.

## 1. The cross-region create test asserted almost nothing

It checked only that an `ApplicationAutoScalingClient` had been constructed for `eu-west-1`. The local-region registrations already construct clients, so it would have passed with the wrong `ResourceId`, the wrong dimension, or the wrong Min/Max. It now pins the `RegisterScalableTarget` input the way the local-region tests do.

## 2. No test pinned the two ordering claims

Both were documented only in code comments:

- registration must follow the table **and** replicas going ACTIVE;
- step 6b must follow step 6, so an index added by the same deploy exists (application-autoscaling rejects a target whose resource is not ready).

The DynamoDB and application-autoscaling mocks are separate `vi.fn()`s, so per-mock assertions cannot see the interleaving. `mock.invocationCallOrder` spans mocks and now pins both.

## 3. The delete-path helper hid the poll loop

`describeOnceThenGone` served one `DescribeTable` and then RNF — so `waitForTableGone` observed RNF on its very first poll and its loop never iterated. Fine for the teardown assertions, but it left the polling itself unexercised, so a regression that broke the loop would not have shown up. The helper now takes a serve count, and a new case makes the loop actually run before the table disappears.

## 4. `verify.sh` compared against embedded literal tabs

Three assertions joined multi-field `--output text` rows and compared them to literals containing a real TAB character — invisible in review, and dependent on the AWS CLI's text-output separator staying what it is today.

Replaced by a `scalable_target_field` / `assert_scalable_target` helper pair doing per-value queries. `scalable_target_field` carries `|| return 1` so a probe failure propagates to the caller's `set -e` instead of being swallowed by the command substitution (errexit is cleared inside `$( )` — the repo's gone-probe rule). **No literal tabs remain in the file.**

## Verification

Tests-only change: 527 files / 9091 tests green, typecheck + lint + build clean, and the `integ-verify-*` fixture lints (signal traps, gone-probes, CLI flags, aws-verb availability) all pass against the rewritten `verify.sh`.

No `src/**` change, so no live test or integ applies — the changed `verify.sh` assertions run on this fixture's next integ, and the shape they assert was already proven against real AWS in #1451's run.

Closes #1456
