### PR TITLE
test(provisioning): stop the registry test racing its own module graph

### DIFF
--- a/tests/unit/provisioning/provider-registry.test.ts
+++ b/tests/unit/provisioning/provider-registry.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from 'vite-plus/test';
 import { ProviderRegistry } from '../../../src/provisioning/provider-registry.js';
+// STATIC, not `await import(...)` inside the test (issue #1450).
+//
+// `register-providers.js` pulls in all 80 provider modules and their AWS SDK
+// clients. Imported lazily inside a test, that whole graph is resolved against
+// the 5s PER-TEST timeout: ~260ms warm and single-file, but under a loaded
+// 12-worker full-suite run it could exceed the budget and fail as a timeout —
+// which reads like a real assertion failure, passes on re-run once the FS
+// cache is warm, and passes in isolation. A static import resolves at
+// file-evaluation time instead, outside any test's budget.
+//
+// Nothing here required the laziness: this file has no `vi.mock`, so there was
+// no mock-ordering reason to defer the import.
+import { registerAllProviders } from '../../../src/provisioning/register-providers.js';
+import { WaitConditionHandleProvider } from '../../../src/provisioning/providers/wait-condition-handle-provider.js';
 
 describe('ProviderRegistry pre-flight (validateResourceTypes)', () => {
   it('passes for SDK + Cloud-Control-supported types', () => {
@@ -9,11 +23,7 @@ describe('ProviderRegistry pre-flight (validateResourceTypes)', () => {
     ).not.toThrow();
   });
 
-  it('passes for AWS::CloudFormation::WaitConditionHandle via its no-op SDK provider (issue #1020)', async () => {
-    const { registerAllProviders } = await import('../../../src/provisioning/register-providers.js');
-    const { WaitConditionHandleProvider } = await import(
-      '../../../src/provisioning/providers/wait-condition-handle-provider.js'
-    );
+  it('passes for AWS::CloudFormation::WaitConditionHandle via its no-op SDK provider (issue #1020)', () => {
     const registry = new ProviderRegistry();
     registerAllProviders(registry);
     expect(() =>


### PR DESCRIPTION
## Root cause — not what the issue guessed

The issue reasoned toward `ProviderRegistry` singleton pollution between test files. That was wrong: the test constructs its own `new ProviderRegistry()`, and the file contains no `vi.mock` at all.

The actual cause is a **timeout**, not flaky state. The test did:

```ts
const { registerAllProviders } = await import('../../../src/provisioning/register-providers.js');
```

`register-providers.js` has 79 direct imports pulling in all **80 provider modules** and their AWS SDK clients. Imported lazily *inside the test body*, that whole graph is resolved against the **5s per-test timeout** rather than at file-evaluation time.

That explains every symptom, which is what made it look like state flakiness:

| symptom | explanation |
| --- | --- |
| fails only in the full suite | 12 workers contending; cold module resolution |
| passes in isolation | no contention |
| passes on immediate re-run | FS cache warm |
| no assertion diff in the output | it was `Test timed out`, not a failed expectation |

## Fix

Hoist both imports to module scope. Resolution then happens at file evaluation, outside any test's budget.

Nothing required the laziness — with no `vi.mock` in the file there was no mock-ordering reason to defer, it was just style.

## Demonstrated, not assumed

The rare full-suite failure was **not** reproduced directly (3 full runs stayed green), so I did not rely on "it stopped happening" as evidence. Instead the mechanism is shown deterministically by shrinking the budget:

```
# before — and it is the ONLY case in the file that takes measurable time
$ vp test run tests/unit/provisioning/provider-registry.test.ts --testTimeout=250
 × passes for AWS::CloudFormation::WaitConditionHandle ... 259ms
 Error: Test timed out in 250ms.
 Tests  1 failed | 5 passed (6)

# after
$ vp test run tests/unit/provisioning/provider-registry.test.ts --testTimeout=250
 Tests  6 passed (6)
```

## Sweep

Checked whether any sibling has the same shape: **none**. No other unit test dynamically imports `register-providers` or a provider module, and the remaining `await import(...)` sites target small modules (`aws-region-resolver`, `options`, node builtins) where the laziness is required by an accompanying `vi.mock`.

Full suite green (527 files / 9088 tests).

Closes #1450
