### PR TITLE
chore(hooks): widen the gate if: conditions to contains patterns

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -74,6 +74,37 @@ The seven markgate-backed gate hooks (`check-gate.sh`, `verify-pr-gate.sh`, `int
 
 Smoke tests at `.claude/hooks/<gate>.test.sh` cover the cwd-aware resolution against fixture git worktrees (markgate is mocked via a PATH shim with a $CWD_TRACE_FILE so the tests assert the hook cd'd to the correct target dir before consulting markgate). Every gate test file also carries 2 quoted-body false-positive cases per cdkd#563 (`gh issue create --body "...<trigger>..."` / `echo "...<trigger>..."` shapes), which must keep passing: they are what proves the matcher does not fire when the trigger keyword sits inside an argument body of an unrelated command.
 
+**Two layers decide whether a gate fires, and both had to change (issue #1455).**
+
+1. The `if:` condition in `.claude/settings.json` decides whether the hook is
+   INVOKED at all.
+2. The hook's own matcher then decides whether the command is really the one it
+   guards.
+
+The `if:` patterns were prefix globs (`Bash(gh pr merge*)`), which is why
+several hooks had hand-enumerated chained variants (`Bash(cd * && gh pr merge*)`).
+They are now CONTAINS patterns (`Bash(*gh pr merge*)`), and the enumerated
+`cd * && ` variants are gone because a contains pattern subsumes them. The
+`-C` forms stay as separate alternatives, since `git -C <path> commit` does not
+contain the literal `git commit`.
+
+Measured rather than assumed, with temporary probe hooks in a gitignored
+`settings.local.json` (hook config hot-reloads, so this is testable without a
+restart):
+
+| probe `if:` | fired on `true && echo "... gh pr merge 999 ..."` |
+| --- | --- |
+| `Bash(*gh pr merge*)` | **yes** |
+| `Bash(gh pr merge*)` | no |
+
+The same run established that matching there is purely TEXTUAL and quote-blind:
+a contains pattern fired on an occurrence that existed only inside a quoted
+`echo` string. That is exactly why the two layers must change together —
+widening `if:` alone would invoke hooks on prose, and the hook's matcher becomes
+the sole precision filter. Widening it BEFORE the matcher fix would have been
+pointless (the anchored matcher rejects chained invocations anyway); doing it
+after is what makes the pair correct.
+
 **Command-position matching (issue #1455 — supersedes the line-start anchoring).** Those false-positive cases were originally handled by anchoring the matcher at LINE START, tolerating exactly one chained shape (an optional leading `cd <path> &&`). That dodged the false positive by POSITION, and the cost was a false NEGATIVE of the same shape: any other command in front — `git push && gh pr create`, `echo done; gh pr merge` — and the gate never fired at all. That is not a hypothetical: PR #1451's own `gh pr create` slipped past `verify-pr-gate` exactly that way, and the same hole existed in all six merge-time gates, which is strictly worse (they are what stand between an unverified destroy path and `main`).
 
 The fix separates the two concerns instead of trading them off. `.claude/hooks/lib/command-match.sh` provides `cmd_matches_verb <command> <verb-ere>`, which (1) NEUTRALISES the spans that are DATA rather than code — heredoc bodies, then quoted spans — removing the false-positive source directly rather than dodging it, then (2) matches the verb in COMMAND POSITION — line start OR immediately after a `&&` / `||` / `;` / `|` control operator. `main-tree-git-cwd-detector.sh` already used command-position anchoring; this brings the gate family in line with it.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,119 +7,119 @@
           {
             "type": "command",
             "command": ".claude/hooks/branch-gate.sh",
-            "if": "Bash(git commit*) or Bash(git push*) or Bash(git -C * commit*) or Bash(git -C * push*)",
+            "if": "Bash(*git commit*) or Bash(*git push*) or Bash(*git -C * commit*) or Bash(*git -C * push*)",
             "timeout": 10,
             "statusMessage": "Checking current branch..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/main-tree-branch-gate.sh",
-            "if": "Bash(git switch*) or Bash(git checkout*) or Bash(cd * && git switch*) or Bash(cd * && git checkout*) or Bash(git -C * switch*) or Bash(git -C * checkout*)",
+            "if": "Bash(*git switch*) or Bash(*git checkout*) or Bash(*git -C * switch*) or Bash(*git -C * checkout*)",
             "timeout": 10,
             "statusMessage": "Checking main-tree branch-switch policy..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/post-merge-orphan-push-gate.sh",
-            "if": "Bash(git push*) or Bash(git -C * push*)",
+            "if": "Bash(*git push*) or Bash(*git -C * push*)",
             "timeout": 10,
             "statusMessage": "Checking for already-merged PR on this branch..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/check-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*)",
+            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking /check marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-destroy-gate.sh",
-            "if": "Bash(gh pr merge*)",
+            "if": "Bash(*gh pr merge*)",
             "timeout": 10,
             "statusMessage": "Checking integ-destroy marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-local-gate.sh",
-            "if": "Bash(gh pr merge*) or Bash(git merge*) or Bash(git -C * merge*)",
+            "if": "Bash(*gh pr merge*) or Bash(*git merge*) or Bash(*git -C * merge*)",
             "timeout": 10,
             "statusMessage": "Checking integ-local marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-broad-gate.sh",
-            "if": "Bash(gh pr merge*)",
+            "if": "Bash(*gh pr merge*)",
             "timeout": 10,
             "statusMessage": "Checking integ-broad marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-schema-migration-gate.sh",
-            "if": "Bash(gh pr merge*)",
+            "if": "Bash(*gh pr merge*)",
             "timeout": 10,
             "statusMessage": "Checking integ-schema-migration marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-review-gate.sh",
-            "if": "Bash(gh pr merge*)",
+            "if": "Bash(*gh pr merge*)",
             "timeout": 15,
             "statusMessage": "Checking pr-review marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/ci-green-gate.sh",
-            "if": "Bash(gh pr merge*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr merge*)",
+            "if": "Bash(*gh pr merge*) or Bash(*gh -C * pr merge*)",
             "timeout": 20,
             "statusMessage": "Checking PR CI status is green..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/closes-paren-form-gate.sh",
-            "if": "Bash(gh pr merge*) or Bash(gh -C * pr merge*)",
+            "if": "Bash(*gh pr merge*) or Bash(*gh -C * pr merge*)",
             "timeout": 10,
             "statusMessage": "Checking PR body for Closes (#N) auto-close trap..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/non-english-text-gate.sh",
-            "if": "Bash(gh pr create*) or Bash(gh pr edit*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr edit*) or Bash(gh -C * pr merge*)",
+            "if": "Bash(*gh pr create*) or Bash(*gh pr edit*) or Bash(*gh pr merge*) or Bash(*gh -C * pr create*) or Bash(*gh -C * pr edit*) or Bash(*gh -C * pr merge*)",
             "timeout": 15,
             "statusMessage": "Checking PR diff for non-English text..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/verify-pr-gate.sh",
-            "if": "Bash(gh pr create*) or Bash(gh pr merge*)",
+            "if": "Bash(*gh pr create*) or Bash(*gh pr merge*)",
             "timeout": 10,
             "statusMessage": "Checking verify-pr marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/bughunt-clean-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*) or Bash(cd * && git commit*) or Bash(gh pr create*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr create*) or Bash(cd * && gh pr merge*)",
+            "if": "Bash(*git commit*) or Bash(*git -C * commit*) or Bash(*gh pr create*) or Bash(*gh pr merge*) or Bash(*gh -C * pr create*) or Bash(*gh -C * pr merge*)",
             "timeout": 10,
             "statusMessage": "Checking for un-destroyed bug-hunt resources..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/commit-msg-heredoc-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*)",
+            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking commit message format..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/gh-pr-edit-deprecation-gate.sh",
-            "if": "Bash(gh pr edit*)",
+            "if": "Bash(*gh pr edit*)",
             "timeout": 10,
             "statusMessage": "Checking gh pr edit usage..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-body-item-number-gate.sh",
-            "if": "Bash(gh pr create*) or Bash(gh pr edit*) or Bash(gh issue create*) or Bash(gh issue comment*) or Bash(gh api*)",
+            "if": "Bash(*gh pr create*) or Bash(*gh pr edit*) or Bash(*gh issue create*) or Bash(*gh issue comment*) or Bash(*gh api*)",
             "timeout": 10,
             "statusMessage": "Checking PR body for #N auto-link traps..."
           },
@@ -133,77 +133,77 @@
           {
             "type": "command",
             "command": ".claude/hooks/roundtrip-test-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*)",
+            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking new SDK provider has round-trip test..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/provider-docs-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*)",
+            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking new provider registration has docs entries..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/provider-integ-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*)",
+            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking new provider registration has integ coverage..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/ref-segment-audit-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*)",
+            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking new REF_RETURNS_SEGMENT_AFTER_PIPE entries have unit tests..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-coverage-matrix-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*)",
+            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 15,
             "statusMessage": "Checking integ-coverage matrix is in sync..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/internal-pr-labels-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*)",
+            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking user-facing docs for internal PR labels..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/cmd-parse-stub-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*)",
+            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking test files for cmd.parse without action stub..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/commit-prefix-scope-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*)",
+            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking commit prefix matches user-visible scope..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-title-prefix-scope-gate.sh",
-            "if": "Bash(gh pr create*) or Bash(gh -C * pr create*) or Bash(gh api*pulls*) or Bash(gh -C * api*pulls*)",
+            "if": "Bash(*gh pr create*) or Bash(*gh -C * pr create*) or Bash(*gh api*pulls*) or Bash(*gh -C * api*pulls*)",
             "timeout": 10,
             "statusMessage": "Checking PR title prefix matches user-visible scope..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/state-destroy-force-gate.sh",
-            "if": "Bash(git commit*) or Bash(git -C * commit*)",
+            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking staged verify.sh for state destroy --force..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/restore-backup.sh",
-            "if": "Bash(git checkout*) or Bash(git restore*) or Bash(git reset*) or Bash(git clean*) or Bash(git stash*) or Bash(git -C * checkout*) or Bash(git -C * restore*) or Bash(git -C * reset*) or Bash(git -C * clean*) or Bash(git -C * stash*) or Bash(cd * && git checkout*) or Bash(cd * && git restore*) or Bash(cd * && git reset*) or Bash(cd * && git clean*) or Bash(cd * && git stash*)",
+            "if": "Bash(*git checkout*) or Bash(*git restore*) or Bash(*git reset*) or Bash(*git clean*) or Bash(*git stash*) or Bash(*git -C * checkout*) or Bash(*git -C * restore*) or Bash(*git -C * reset*) or Bash(*git -C * clean*) or Bash(*git -C * stash*)",
             "timeout": 20,
             "statusMessage": "Snapshotting the working tree before a destructive restore..."
           }


### PR DESCRIPTION
Second half of #1455. [#1458](https://github.com/go-to-k/cdkd/pull/1458) fixed the hooks' own matchers so a chained invocation is recognised; this makes the hooks actually get **invoked** for one.

## Two layers

| layer | decides | was |
|---|---|---|
| `if:` in `.claude/settings.json` | whether the hook is **invoked** | prefix glob — `git push && gh pr create` never reached the hook |
| the hook's own matcher | the **verdict** | line-start anchored — fixed in #1458 |

Because `if:` was a prefix glob, the matcher fix alone was unreachable for exactly the shape this issue is about. Several hooks had already worked around it by hand-enumerating `Bash(cd * && gh pr merge*)`; those variants are dropped here, since a contains pattern subsumes them.

## Measured, not assumed

Temporary probe hooks in a gitignored `settings.local.json` (hook config hot-reloads, so no restart is needed), removed again afterwards:

| probe `if:` | fired on `true && echo "... gh pr merge 999 ..."` |
|---|---|
| `Bash(*gh pr merge*)` | **yes** |
| `Bash(gh pr merge*)` | no |

The same run established that matching here is **purely textual and quote-blind** — the contains pattern fired on an occurrence that existed only inside a quoted `echo` string.

## Why this order

That quote-blindness is exactly why the two layers had to change in sequence:

- widening `if:` **first** would have added invocations with no behaviour change, since the anchored matcher rejects chained invocations anyway;
- widening it is only **safe** now, because the widened condition invokes hooks on prose, making the hook's matcher the sole precision filter — and #1458 is what makes it neutralise heredoc bodies and quoted spans before deciding.

## Scope

28 conditions widened; no other change to the file. The `-C` alternatives stay separate because `git -C <path> commit` does not contain the literal `git commit`.

No `src/**` change, so no live test or integ applies. The behaviour this changes is hook invocation, which is what the probe run above measured directly.

Closes #1455
