### PR TITLE
chore(hooks): make provider-integ-gate.test.sh bash 3.2-safe and run every hook suite under both shells

### DIFF
--- a/.claude/hooks/provider-integ-gate.test.sh
+++ b/.claude/hooks/provider-integ-gate.test.sh
@@ -85,12 +85,18 @@ add_register() {
 # that pass a single line don't need to worry.
 add_integ_fixture() {
   local dir="$1" name="$2" body="$3"
+  # `${name^}` (uppercase-first) is a bash 4+ expansion and expands to
+  # `bad substitution` under macOS's system bash 3.2, which silently
+  # truncated the heredoc and made three cases fail there (issue #1477).
+  # `${name:0:1}` / `${name:1}` + `tr` is the 3.2-compatible equivalent.
+  local class_name
+  class_name="$(printf '%s' "${name:0:1}" | tr '[:lower:]' '[:upper:]')${name:1}"
   mkdir -p "$dir/tests/integration/$name/lib"
   cat > "$dir/tests/integration/$name/lib/${name}-stack.ts" <<EOF
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
-export class ${name^}Stack extends cdk.Stack {
+export class ${class_name}Stack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 ${body}
@@ -281,7 +287,7 @@ if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
 # `$schema-doc` / `$why-sidecar` keys in the real sidecar must NEVER
 # exempt the type. A regex regression that drops the `$` filter would
 # silently allow every entry — this case catches that.
-case_label "sidecar with only `$`-prefixed keys (no real entry) -> block"
+case_label 'sidecar with only `$`-prefixed keys (no real entry) -> block'
 D="$TMPDIR/case14"; init_repo "$D"
 cat > "$D/.claude/integ-coverage-allowlist.json" <<'EOF'
 {

--- a/.claude/hooks/run-tests.sh
+++ b/.claude/hooks/run-tests.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Runs every hook smoke test under EVERY bash on this machine.
+#
+# Why more than one shell: the hooks are `#!/usr/bin/env bash`, so which
+# bash they get depends on PATH. On a machine without Homebrew bash first
+# on PATH they run under macOS's system bash 3.2, where bash 4+ syntax
+# (`mapfile`, `declare -A`, `${var^}`, `${var,,}`) is a runtime error.
+# Issue #1458 shipped a `mapfile` in the shared helper that would have
+# silently left quoted `cd` paths unresolved under 3.2, and issue #1477
+# found `provider-integ-gate.test.sh` itself failing there — both found
+# only by running the suites under `/bin/bash` explicitly.
+#
+# Usage (from the repo root):
+#   bash .claude/hooks/run-tests.sh
+#   vp run test:hooks
+#
+# Exits 0 only when every suite passes under every shell.
+
+set -u
+
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)" || exit 1
+
+# Every bash worth testing against, de-duplicated by resolved version.
+# `bash` is whatever PATH gives (Homebrew 5.x on a dev Mac, the distro
+# bash in CI); `/bin/bash` is macOS's system 3.2. On Linux both usually
+# resolve to the same binary, in which case the second is skipped.
+shells=()
+seen=""
+for candidate in bash /bin/bash; do
+  command -v "$candidate" >/dev/null 2>&1 || continue
+  resolved="$(command -v "$candidate")"
+  case " $seen " in
+    *" $resolved "*) continue ;;
+  esac
+  seen="$seen $resolved"
+  shells+=("$candidate")
+done
+
+if [ ${#shells[@]} -eq 0 ]; then
+  echo "no bash found on PATH" >&2
+  exit 1
+fi
+
+failures=0
+for shell in "${shells[@]}"; do
+  version="$("$shell" -c 'echo "${BASH_VERSION}"')"
+  echo "===== $shell (bash $version) ====="
+  for suite in .claude/hooks/*.test.sh .claude/hooks/lib/*.test.sh; do
+    [ -f "$suite" ] || continue
+    if output="$("$shell" "$suite" 2>&1)"; then
+      # A suite can exit 0 while individual cases failed (the runners
+      # print a `fail: N` tally rather than propagating the count), so
+      # the tally is checked too — this is exactly how the bash 3.2
+      # breakage in issue #1477 stayed invisible.
+      if printf '%s\n' "$output" | grep -qE '^[[:space:]]*total:.*fail: [1-9]'; then
+        echo "FAIL $suite"
+        printf '%s\n' "$output"
+        failures=$((failures + 1))
+      else
+        echo "  ok  $suite"
+      fi
+    else
+      echo "FAIL $suite (exit $?)"
+      printf '%s\n' "$output"
+      failures=$((failures + 1))
+    fi
+  done
+done
+
+if [ "$failures" -ne 0 ]; then
+  echo ""
+  echo "$failures hook suite run(s) failed" >&2
+  exit 1
+fi
+
+echo ""
+echo "all hook suites pass under: ${shells[*]}"

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -6,6 +6,34 @@ paths:
   - '.markgate.yml'
 ---
 
+# Running the hook suites
+
+```bash
+vp run test:hooks     # or: bash .claude/hooks/run-tests.sh
+```
+
+Most hooks in this file ship a `*.test.sh` smoke suite next to them (31 suites
+for 35 hooks as of issue #1477 — `gh-label-validity-gate`,
+`gh-pr-edit-deprecation-gate`, `post-merge-sync-reminder`, and `stop-warn` have
+none), and the runner executes every suite that exists under **every bash on
+the machine** — `bash` from PATH (Homebrew 5.x on a dev Mac) and `/bin/bash`
+(macOS's system **3.2**).
+Both matter because the hooks are `#!/usr/bin/env bash`: on a machine without a
+newer bash first on PATH they execute under 3.2, where bash 4+ syntax
+(`mapfile`, `declare -A`, `${var^}`, `${var,,}`) is a runtime error. Issue
+#1458 shipped exactly that into `lib/command-match.sh`, and issue #1477 found
+`provider-integ-gate.test.sh` failing 3 of its 17 cases there — neither
+detectable from a bash-5-only run.
+
+The runner also treats a suite that exits 0 while printing a non-zero `fail: N`
+tally as a failure; the runners report their tally rather than propagating a
+count, which is how the 3.2 breakage stayed invisible.
+
+Deliberately NOT part of `vp run check` / `vp run verify`: the suites build
+throwaway git repos and take ~6 minutes, which is the wrong cost for the inner
+dev loop. `.github/workflows/hooks.yml` runs it on `macos-latest` (the only
+runner image carrying bash 3.2) whenever a PR touches `.claude/hooks/**`.
+
 # Other PreToolUse safety hooks
 
 Thirteen additional one-shot hooks block known foot-guns at the source.

--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -1,0 +1,40 @@
+name: Hook suites
+
+# The `.claude/hooks/**` smoke tests. Kept out of `ci.yml` on purpose:
+# they build throwaway git repos and take several minutes, and they are
+# only interesting when a hook or its test changes — so this workflow is
+# path-filtered instead of running on every push.
+#
+# Runs on macOS because that is the only runner image carrying bash 3.2
+# (`/bin/bash`). The hooks are `#!/usr/bin/env bash`, so on a machine
+# without a newer bash first on PATH they execute under 3.2, where bash 4+
+# syntax (`mapfile`, `declare -A`, `${var^}`) is a runtime error. Issue
+# #1458 shipped exactly that into the shared matcher, and issue #1477
+# found `provider-integ-gate.test.sh` failing 3 of 17 cases there. A Linux
+# runner would resolve both `bash` and `/bin/bash` to the same 5.x binary
+# and prove nothing about that path.
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.claude/hooks/**'
+      - '.github/workflows/hooks.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.claude/hooks/**'
+      - '.github/workflows/hooks.yml'
+
+jobs:
+  hook-suites:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Report available shells
+        run: |
+          echo "bash on PATH: $(command -v bash) -> $(bash -c 'echo $BASH_VERSION')"
+          echo "/bin/bash:    $(/bin/bash -c 'echo $BASH_VERSION')"
+
+      - run: bash .claude/hooks/run-tests.sh

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -225,6 +225,22 @@ export default defineConfig({
       verify: {
         command: 'vp run check && vp run typecheck:test && vp run test && vp run build',
       },
+      // The `.claude/hooks/**` smoke tests, run under every bash on the
+      // machine. Before issue #1477 no task and no CI job ran them at all,
+      // so a suite could rot unnoticed — `provider-integ-gate.test.sh` was
+      // failing 3 of its 17 cases under macOS's system bash 3.2, and
+      // #1458 shipped a bash-4-only `mapfile` into the shared matcher that
+      // only an explicit `/bin/bash` run would have caught. NOT part of
+      // `vp run check` / `verify`: the suites build throwaway git repos and
+      // take ~6 minutes, which is the wrong cost for the inner dev loop.
+      // `.github/workflows/hooks.yml` runs this on any `.claude/hooks/**`
+      // change.
+      'test:hooks': {
+        command: 'bash .claude/hooks/run-tests.sh',
+        // A correctness gate must never replay a cached green: the task's
+        // inputs are shell scripts outside any source glob Vite+ tracks.
+        cache: false,
+      },
       'runtime:smoke': {
         command: 'node dist/cli.js --version',
         dependsOn: ['build'],


### PR DESCRIPTION
## Summary

`.claude/hooks/provider-integ-gate.test.sh` failed 3 of its 17 cases under
macOS's system bash 3.2 while passing under Homebrew bash 5.x. The hooks are
`#!/usr/bin/env bash`, so on a machine without a newer bash first on PATH they
execute under 3.2 — a suite that cannot run there is not exercising the shell
the hook may actually run under.

## The two causes

Both in the test file, neither in the hook itself:

- `${name^}` (uppercase-first) is a bash 4+ expansion. Under 3.2 it is a
  `bad substitution` that truncated the generated fixture heredoc, so the hook
  saw a fixture with no resource type in it and blocked. Replaced with the
  3.2-compatible `${name:0:1}` + `tr` form.
- A `case_label "... \`$\`-prefixed keys ..."` label used backticks inside
  double quotes, so the shell tried to execute `$` as a command
  (`line 284: $: command not found`). Switched to single quotes.

## The reason it stayed invisible

Nothing ran these suites — no `vp` task, no CI job. That is also how issue
#1458 shipped a bash-4-only `mapfile` into the shared `lib/command-match.sh`
matcher, which would have silently left quoted `cd` paths unresolved under 3.2.

- **`.claude/hooks/run-tests.sh`** runs every `*.test.sh` under every distinct
  bash on the machine, de-duplicated by resolved path (on Linux both names are
  the same binary, so the second run is skipped).
- It also fails a suite that **exits 0 while printing a non-zero `fail: N`
  tally**. The runners report a tally rather than propagating a count, which is
  exactly how the 3.2 failures read as green — an exit-code-only wrapper would
  have inherited the blind spot it exists to remove.
- **`vp run test:hooks`** registers it, with `cache: false` so a correctness
  gate never replays a cached green.
- **`.github/workflows/hooks.yml`** runs it on `macos-latest`, the only runner
  image carrying bash 3.2. Path-filtered to `.claude/hooks/**` because the
  suites build throwaway git repos and take ~6 minutes; for the same reason the
  task is deliberately kept out of `vp run check` / `vp run verify`.

## Test plan

- All 31 suites pass under both bash 5.3.9 and bash 3.2.57 (`vp run test:hooks`).
  Before this change, `/bin/bash .claude/hooks/provider-integ-gate.test.sh`
  reported `total: 17  pass: 14  fail: 3`; it now reports `17/17` under both.
- Both of the runner's failure branches were break-tested with throwaway
  suites, since a wrapper that has never been shown to fail is not known to
  work:
  - a suite that exits 0 with a `fail: 3` tally -> reported under both shells,
    runner exits 1
  - a suite that exits 3 -> reported as `(exit 3)` under both shells, runner
    exits 1
- `vp run check` / `typecheck:test` / `build` / `test` (527 files, 9192 tests)
  all pass; `gen:all-matrices` + `audit:coverage:check` leave nothing dirty.

## Follow-up

`.markgate.yml`'s `check` gate scopes a `vitest.config.ts` that does not exist,
while `vite.config.ts` — which defines every task, including the one added here
— is in no gate's scope at all, so editing it does not invalidate a recorded
`check` marker. Filed as (#1487) rather than fixed here: widening a gate's scope
invalidates the marker for every in-flight lane, which other sessions should see
coming rather than inherit from an unrelated PR.

Closes #1477
