### PR TITLE
fix(drift): warn before --revert drops AWS-authored values on state with no observed baseline

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1832,6 +1832,26 @@ matches the intent:
   `--revert` — once `provider.update` succeeds, AWS values match state
   by definition, so a subsequent `cdkd drift` reports `clean`.
 
+  **Resources with no observed-capture baseline.** The revert baseline is
+  `observedProperties ?? properties`. A resource deployed BEFORE
+  observed-capture shipped has no `observedProperties`, so the desired side
+  is the raw **template** while the previous side is the AWS-current
+  snapshot — and because a drifted top-level subtree is overlaid wholesale,
+  every AWS-authored key inside it that the template does not declare is
+  DROPPED. For a Glue Iceberg table that means `table_type` /
+  `metadata_location` are wiped by a `--revert`.
+
+  This is not silent: the plan prints, per affected resource, a
+  `! this resource has no observed-capture baseline ... will DROP N
+  AWS-authored values` line listing each path, before the confirmation
+  prompt and under `--dry-run`. The revert then proceeds — you did ask to
+  push state over AWS, and refusing outright would strand legacy state with
+  no path forward. **Re-deploy the stack first** if you want those values
+  preserved; the deploy records `observedProperties`, after which the
+  revert's desired side already carries the AWS-authored fields and the
+  warning stops firing. Only DRIFTED top-level keys are ever at risk —
+  non-drifted keys keep their AWS-current values.
+
   **Update-not-supported resources.** Some resource types are immutable
   in AWS (e.g. `AWS::Lambda::LayerVersion`, sub-resource attachments
   like `AWS::Lambda::Permission`, `AWS::ApiGateway::Deployment`) or do

--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -1267,6 +1267,28 @@ One semantic divergence from `getDriftUnknownPaths()`, required for this pass to
 
 **Do NOT sort inside the reverse-mapper instead.** It looks like a one-liner, but it breaks the `properties` fallback baseline: `runDriftForStack` uses `observedProperties` as the baseline only when present and falls back to the template `properties` otherwise, so for a resource deployed before observed-capture the baseline would be the user's TEMPLATE order while the read side is sorted — manufacturing drift instead of removing it. The normalizer runs on both comparison sides, which is exactly the property needed.
 
+#### When there is NO observed baseline at all
+
+The paragraph above describes the round-trip when `observedProperties` exists.
+When it does NOT — a resource deployed before observed-capture shipped —
+`--revert` falls back to the raw TEMPLATE as its desired side while the
+previous side is still the AWS-current snapshot. Because the revert overlays a
+drifted top-level subtree wholesale, every AWS-authored key inside that subtree
+which the template does not declare is DROPPED (issue #1478). Glue
+`Table.Parameters` is the discovered case — `table_type` / `metadata_location`
+are written by AWS, not by the template, so a `--revert` de-Icebergs the table —
+but the exposure is general to any resource where AWS writes into a bag the
+template does not fully declare.
+
+The chosen semantic is **warn and proceed**: `cdkd drift --revert` lists the
+paths it will drop as part of the plan (before the confirmation prompt, and
+under `--dry-run`) and then reverts. This is a `drift` concern, NOT a provider
+one — the baseline choice affects every provider that implements
+`readCurrentState`, so fixing it inside one provider would make that provider
+diverge from its siblings. Nothing is required of a provider here; the note
+exists so that reading only the round-trip paragraph above does not leave you
+believing the desired side is always an observed snapshot.
+
 #### Two failure modes when an always-emit placeholder round-trips through `update()`
 
 `cdkd drift --revert` round-trips `observedProperties` (the snapshot `readCurrentState` produced) back through `provider.update`. That code path is what surfaces every shape-mismatch bug between the read side (`readCurrentState` output) and the write side (AWS create/update API input). Two failure classes have been observed; both must be designed around BEFORE adding a new `readCurrentState`.

--- a/src/cli/commands/drift.ts
+++ b/src/cli/commands/drift.ts
@@ -726,6 +726,101 @@ async function runAccept(
  * parent path — so `path.split('.', 1)` is always safe to extract the
  * top-level key.
  */
+/**
+ * The AWS-authored property paths a `--revert` is about to DROP, for a
+ * resource whose state predates observed-capture (issue #1478).
+ *
+ * The mechanism, and why this is not a Glue fix: `runRevert` picks the revert
+ * baseline as `observedProperties ?? properties`. When `observedProperties` is
+ * absent, the desired side is the raw TEMPLATE while the previous side is the
+ * AWS-CURRENT snapshot — so {@link buildRevertNewProperties}, which overwrites
+ * each drifted top-level key with the desired sub-shape wholesale, replaces
+ * every AWS-authored key inside that subtree with the template's version. For
+ * a Glue Iceberg table that silently wipes `table_type` /
+ * `metadata_location`, the same outcome as issue #1461 reached by a different
+ * trigger. The exposure is general: ANY resource where AWS writes into a bag
+ * the template does not fully declare, on state written before
+ * observed-capture.
+ *
+ * The user DID ask to push state over AWS, so this is not silent-wrong the way
+ * #1461 was — but it is almost certainly not what they meant, and nothing told
+ * them. So the chosen semantic is **warn and proceed**: it is the cheapest
+ * honest step, preserves today's behavior, and does not foreclose the stricter
+ * options (refuse outright, or treat "no observedProperties" as "previous is
+ * unknown" so the merge preserves).
+ *
+ * Scoped deliberately:
+ *
+ * - **Only drifted top-level keys.** Non-drifted keys keep their AWS-current
+ *   value in `buildRevertNewProperties`, so nothing under them is dropped.
+ * - **Only when `observedProperties` is absent.** With it present the desired
+ *   side is the deploy-time AWS snapshot, which already carries AWS-authored
+ *   fields — dropping one there is a legitimate revert of a real console
+ *   change, and warning about it would be noise on every run.
+ * - **Only keys that vanish.** A key present on both sides with a different
+ *   VALUE is the drift the user asked to revert, not a silent loss.
+ *
+ * @returns dotted paths, sorted, e.g. `['Parameters.metadata_location']`.
+ */
+export function findRevertDroppedAwsKeys(
+  drifts: readonly PropertyDrift[],
+  desiredProperties: Record<string, unknown>,
+  awsProperties: Record<string, unknown>
+): string[] {
+  const dropped = new Set<string>();
+  const driftedTopLevelKeys = new Set<string>();
+  for (const d of drifts) {
+    const topLevelKey = d.path.split('.', 1)[0];
+    if (topLevelKey) driftedTopLevelKeys.add(topLevelKey);
+  }
+
+  for (const key of driftedTopLevelKeys) {
+    // `buildRevertNewProperties` only overwrites a key the desired side
+    // actually has; otherwise the AWS-current value survives untouched.
+    if (!(key in desiredProperties)) continue;
+    collectMissingPaths(awsProperties[key], desiredProperties[key], key, dropped);
+  }
+
+  return [...dropped].sort();
+}
+
+/**
+ * Walk the AWS-side value against the desired-side value, recording every path
+ * present on the AWS side and absent on the desired side.
+ *
+ * Only plain objects are descended into. An ARRAY is compared wholesale — the
+ * drift comparator itself treats arrays as single values (its paths never
+ * carry an index), so an element-wise walk here would report positions the
+ * rest of the revert path cannot reason about.
+ */
+function collectMissingPaths(
+  awsValue: unknown,
+  desiredValue: unknown,
+  path: string,
+  out: Set<string>
+): void {
+  if (!isPlainRecord(awsValue)) return;
+  if (!isPlainRecord(desiredValue)) {
+    // The desired side is a scalar / array / absent where AWS has an object:
+    // the whole AWS subtree goes. Report the containing path rather than
+    // enumerating leaves the user cannot act on individually.
+    if (desiredValue === undefined) out.add(path);
+    return;
+  }
+  for (const [key, value] of Object.entries(awsValue)) {
+    const childPath = `${path}.${key}`;
+    if (!(key in desiredValue)) {
+      out.add(childPath);
+      continue;
+    }
+    collectMissingPaths(value, desiredValue[key], childPath, out);
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export function buildRevertNewProperties(
   drifts: readonly PropertyDrift[],
   desiredProperties: Record<string, unknown>,
@@ -966,6 +1061,32 @@ function printRevertPlan(reports: StackDriftReport[]): void {
         process.stdout.write(
           `    ${change.path}: ${formatScalar(change.awsValue)} -> ${formatScalar(change.stateValue)}\n`
         );
+      }
+      // Issue #1478. Printed as part of the PLAN, not at update time, so it
+      // is visible before the confirmation prompt AND under `--dry-run` —
+      // a warning the user only sees after the writes have happened is not
+      // a warning.
+      const stateResource = report.state.resources[o.logicalId];
+      if (stateResource && stateResource.observedProperties === undefined) {
+        const dropped = findRevertDroppedAwsKeys(
+          o.changes,
+          stateResource.properties ?? {},
+          o.awsProperties
+        );
+        if (dropped.length > 0) {
+          const word = dropped.length === 1 ? 'value' : 'values';
+          process.stdout.write(
+            `    ! this resource has no observed-capture baseline, so the revert ` +
+              `pushes the raw TEMPLATE and will DROP ${dropped.length} AWS-authored ${word}:\n`
+          );
+          for (const path of dropped) {
+            process.stdout.write(`        ${path}\n`);
+          }
+          process.stdout.write(
+            `      Re-deploy the stack first to populate observedProperties if you want ` +
+              `these preserved.\n`
+          );
+        }
       }
     }
   }

--- a/tests/unit/cli/drift.test.ts
+++ b/tests/unit/cli/drift.test.ts
@@ -901,6 +901,74 @@ describe('cdkd drift', () => {
       expect(output).toContain('Plan (--revert)');
     });
 
+    it('--revert WARNS about AWS-authored values it will drop when state has no observedProperties (issue #1478)', async () => {
+      // End-to-end wiring, not just the pure helper: the warning has to reach
+      // the PLAN, which is what the user sees before confirming and what
+      // --dry-run prints.
+      mockListStacks.mockResolvedValueOnce([{ stackName: 'TestStack', region: 'us-east-1' }]);
+      mockGetState.mockResolvedValueOnce(
+        makeState({
+          Table1: makeResource({
+            physicalId: 't',
+            resourceType: 'AWS::Glue::Table',
+            // No observedProperties -> the baseline is the raw template.
+            properties: { Parameters: { classification: 'parquet' } },
+          }),
+        })
+      );
+      mockRegistryGetProvider.mockReturnValue({
+        readCurrentState: async () => ({
+          Parameters: {
+            classification: 'json',
+            table_type: 'ICEBERG',
+            metadata_location: 's3://b/metadata/00000.json',
+          },
+        }),
+        update: vi.fn(),
+      });
+
+      const { output, error } = await runDrift(['TestStack', '--revert', '--dry-run', '--yes']);
+
+      expect(error).toBeUndefined();
+      expect(output).toContain('DROP 2 AWS-authored values');
+      expect(output).toContain('Parameters.table_type');
+      expect(output).toContain('Parameters.metadata_location');
+      expect(output).toContain('Re-deploy the stack first');
+    });
+
+    it('--revert does NOT warn when state HAS observedProperties (issue #1478)', async () => {
+      // The negative half, matching the shape the regression would take: with
+      // an observed baseline the desired side already carries AWS-authored
+      // fields, so dropping one is a legitimate revert of a real console
+      // change. Warning there would fire on essentially every revert and
+      // train the user to ignore it.
+      mockListStacks.mockResolvedValueOnce([{ stackName: 'TestStack', region: 'us-east-1' }]);
+      mockGetState.mockResolvedValueOnce(
+        makeState({
+          Table1: makeResource({
+            physicalId: 't',
+            resourceType: 'AWS::Glue::Table',
+            properties: { Parameters: { classification: 'parquet' } },
+            observedProperties: {
+              Parameters: { classification: 'parquet', table_type: 'ICEBERG' },
+            },
+          }),
+        })
+      );
+      mockRegistryGetProvider.mockReturnValue({
+        readCurrentState: async () => ({
+          Parameters: { classification: 'json', table_type: 'ICEBERG' },
+        }),
+        update: vi.fn(),
+      });
+
+      const { output, error } = await runDrift(['TestStack', '--revert', '--dry-run', '--yes']);
+
+      expect(error).toBeUndefined();
+      expect(output).toContain('Plan (--revert)');
+      expect(output).not.toContain('AWS-authored');
+    });
+
     it('--revert on a clean stack is a no-op', async () => {
       mockListStacks.mockResolvedValueOnce([{ stackName: 'TestStack', region: 'us-east-1' }]);
       mockGetState.mockResolvedValueOnce(
@@ -1294,5 +1362,116 @@ describe('cdkd drift --revert (placeholder isolation regression)', () => {
       KmsMasterKeyId: 'alias/aws/sns',
       ContentBasedDeduplication: false,
     });
+  });
+});
+
+describe('findRevertDroppedAwsKeys (pure helper, issue #1478)', () => {
+  const load = async () =>
+    (await import('../../../src/cli/commands/drift.js')).findRevertDroppedAwsKeys;
+
+  it('reports an AWS-authored sub-key the raw template does not declare', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    // The motivating case: a Glue Iceberg table. AWS writes `table_type` /
+    // `metadata_location` into Parameters; the template declares neither, so
+    // reverting the drifted `Parameters` subtree wholesale wipes them.
+    const desired = { Parameters: { classification: 'parquet' } };
+    const aws = {
+      Parameters: {
+        classification: 'json',
+        table_type: 'ICEBERG',
+        metadata_location: 's3://bucket/metadata/00000.json',
+      },
+    };
+    const drifts = [
+      { path: 'Parameters.classification', stateValue: 'parquet', awsValue: 'json' },
+    ];
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual([
+      'Parameters.metadata_location',
+      'Parameters.table_type',
+    ]);
+  });
+
+  it('does NOT report a key present on both sides with a different value', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    // That is the drift the user explicitly asked to revert, not a silent
+    // loss — warning about it would make the warning meaningless.
+    const desired = { Parameters: { classification: 'parquet' } };
+    const aws = { Parameters: { classification: 'json' } };
+    const drifts = [
+      { path: 'Parameters.classification', stateValue: 'parquet', awsValue: 'json' },
+    ];
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual([]);
+  });
+
+  it('ignores AWS-authored keys under a NON-drifted top-level key', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    // `buildRevertNewProperties` only overwrites drifted top-level keys, so
+    // nothing under an undrifted one is at risk. Reporting it would be a
+    // false alarm on essentially every revert.
+    const desired = { Parameters: { classification: 'parquet' }, Description: 'd' };
+    const aws = {
+      Parameters: { classification: 'json' },
+      Description: 'd',
+      StorageDescriptor: { SerdeInfo: { aws_authored: 'x' } },
+    };
+    const drifts = [
+      { path: 'Parameters.classification', stateValue: 'parquet', awsValue: 'json' },
+    ];
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual([]);
+  });
+
+  it('ignores a drifted top-level key the desired side does not declare at all', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    // `buildRevertNewProperties` leaves the AWS-current value in place when
+    // the key is absent from desired, so nothing is dropped.
+    const desired = { Description: 'd' };
+    const aws = { Description: 'd', Parameters: { table_type: 'ICEBERG' } };
+    const drifts = [{ path: 'Parameters', stateValue: undefined, awsValue: {} }];
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual([]);
+  });
+
+  it('recurses through nested objects', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    const desired = { StorageDescriptor: { SerdeInfo: { Name: 'n' } } };
+    const aws = {
+      StorageDescriptor: {
+        SerdeInfo: { Name: 'n2', SerializationLibrary: 'org.apache.iceberg' },
+        Compressed: false,
+      },
+    };
+    const drifts = [
+      { path: 'StorageDescriptor.SerdeInfo.Name', stateValue: 'n', awsValue: 'n2' },
+    ];
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual([
+      'StorageDescriptor.Compressed',
+      'StorageDescriptor.SerdeInfo.SerializationLibrary',
+    ]);
+  });
+
+  it('reports the containing path when desired has no object where AWS does', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    const desired = { Parameters: { nested: undefined } } as Record<string, unknown>;
+    const aws = { Parameters: { nested: { table_type: 'ICEBERG' } } };
+    const drifts = [{ path: 'Parameters.nested', stateValue: undefined, awsValue: {} }];
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual(['Parameters.nested']);
+  });
+
+  it('compares arrays wholesale, never element-wise', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    // The drift comparator's paths never carry an array index, so an
+    // element-wise walk here would report positions the rest of the revert
+    // path cannot reason about.
+    const desired = { Tags: [{ Key: 'a', Value: '1' }] };
+    const aws = { Tags: [{ Key: 'a', Value: '1' }, { Key: 'aws:authored', Value: 'x' }] };
+    const drifts = [{ path: 'Tags', stateValue: [], awsValue: [] }];
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual([]);
+  });
+
+  it('returns nothing when AWS authored nothing extra', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    const desired = { Parameters: { a: '1', b: '2' } };
+    const aws = { Parameters: { a: '9', b: '2' } };
+    const drifts = [{ path: 'Parameters.a', stateValue: '1', awsValue: '9' }];
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

`cdkd drift --revert` picks its baseline as `observedProperties ?? properties`.
For a resource deployed BEFORE observed-capture shipped, `observedProperties` is
absent, so the desired side is the raw **template** while the previous side is
the AWS-CURRENT snapshot. `buildRevertNewProperties` overlays a drifted
top-level key with the desired sub-shape **wholesale**, so every AWS-authored
key inside that subtree which the template does not declare is dropped — for a
Glue Iceberg table, `table_type` / `metadata_location`, the same de-Icebergs
outcome as (#1461) reached by a different trigger, and not covered by that fix.

The user DID ask to push state over AWS, so unlike (#1461) this is not
silent-wrong — but it is almost certainly not what they meant, and nothing told
them.

## The semantic chosen

Of the three directions the issue lays out — refuse outright / warn and proceed /
treat "no observedProperties" as "previous is unknown" — this takes **warn and
proceed**. It is the cheapest honest step, preserves today's behavior, and does
not foreclose either stricter option. Refusing outright would strand legacy
state with no path forward.

`findRevertDroppedAwsKeys` computes the paths, and the warning is printed as
part of the **PLAN** rather than at update time — so it is visible BEFORE the
confirmation prompt and under `--dry-run`. A warning the user only sees after
the writes have happened is not a warning.

```text
  → provider.update on Table1 (AWS::Glue::Table): revert 1 property path
    Parameters.classification: json -> parquet
    ! this resource has no observed-capture baseline, so the revert pushes the
      raw TEMPLATE and will DROP 2 AWS-authored values:
        Parameters.metadata_location
        Parameters.table_type
      Re-deploy the stack first to populate observedProperties if you want
      these preserved.
```

## Scope, each pinned by a test

- only **drifted** top-level keys — non-drifted keys keep their AWS-current
  value in `buildRevertNewProperties`, so nothing under them is at risk;
- only when `observedProperties` is **absent** — with it present the desired
  side is the deploy-time AWS snapshot, so a drop there is a legitimate revert
  of a real console change; warning would fire on essentially every revert and
  train the user to ignore it;
- only keys that **vanish** — a key present on both sides with a different value
  is the drift the user asked to revert;
- arrays compared **wholesale**, never element-wise, matching the drift
  comparator's own paths (which never carry an index).

This is a `drift` concern, not a Glue one: the baseline choice affects every
provider implementing `readCurrentState`, so fixing it inside `glue-provider.ts`
would make Glue diverge from its siblings.

## Test plan

- 8 unit tests for the pure helper, plus **2 end-to-end** through the real
  command tree — the helper alone does not prove the warning reaches the user.
- The positive case was **break-tested**: disabling the plan-side branch makes
  exactly that test fail and nothing else, so it is not vacuously green.
- The negative case asserts the observed-baseline path stays quiet.
- Full suite green (528 files / 9280 tests).

## Documented

`docs/cli-reference.md`'s `--revert` section and
`docs/provider-development.md`'s round-trip section, which previously described
only the deploy-path merge and left a reader believing the desired side is
always an observed snapshot.

## Deliberately not done

The issue's acceptance also asks for a real-AWS fixture whose state has
`observedProperties` stripped. Not built here: this change adds **no AWS
mutation** — only a plan line — and a permanent fixture for a warning is a poor
cost/benefit trade. The revert path itself is covered by the existing
`drift-revert` integ (which includes the motivating `AWS::Glue::Database` type)
and was run clean against real AWS while preparing this stack of PRs. Calling it
out rather than letting the acceptance list look silently satisfied.

Closes #1478
