### PR TITLE
chore(hooks): remove dead if: fields so the 29 Bash PreToolUse gates fire again

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -102,22 +102,45 @@ The seven markgate-backed gate hooks (`check-gate.sh`, `verify-pr-gate.sh`, `int
 
 Smoke tests at `.claude/hooks/<gate>.test.sh` cover the cwd-aware resolution against fixture git worktrees (markgate is mocked via a PATH shim with a $CWD_TRACE_FILE so the tests assert the hook cd'd to the correct target dir before consulting markgate). Every gate test file also carries 2 quoted-body false-positive cases per cdkd#563 (`gh issue create --body "...<trigger>..."` / `echo "...<trigger>..."` shapes), which must keep passing: they are what proves the matcher does not fire when the trigger keyword sits inside an argument body of an unrelated command.
 
-**Two layers decide whether a gate fires, and both had to change (issue #1455).**
+**The `if:` layer is GONE (issue #1455, reopened): project-settings hooks carrying `if:` never fired at all.**
 
-1. The `if:` condition in `.claude/settings.json` decides whether the hook is
+The gate family briefly ran as two layers:
+
+1. The `if:` condition in `.claude/settings.json` decided whether the hook is
    INVOKED at all.
-2. The hook's own matcher then decides whether the command is really the one it
+2. The hook's own matcher then decided whether the command is really the one it
    guards.
 
-The `if:` patterns were prefix globs (`Bash(gh pr merge*)`), which is why
-several hooks had hand-enumerated chained variants (`Bash(cd * && gh pr merge*)`).
-They are now CONTAINS patterns (`Bash(*gh pr merge*)`), and the enumerated
-`cd * && ` variants are gone because a contains pattern subsumes them. The
-`-C` forms stay as separate alternatives, since `git -C <path> commit` does not
-contain the literal `git commit`.
+The verification pass filed as issue #1476 measured that in a real session,
+EVERY hook in the Bash PreToolUse entry that carried an `if:` field was never
+invoked — `git commit` / `gh pr merge` shapes ran with no gate consulted —
+while the no-`if:` entries in the SAME file (main-tree-edit-gate,
+worktree-owner-gate, the PostToolUse detectors) fired normally, and the same
+`if:` strings DID work when registered through the `settings.local.json`
+hot-reload path (which is where the original #1455 measurement was made — the
+measurement environment differed from the runtime environment in exactly the
+dimension that mattered). The poisoning variable inside the project-settings
+load path was never pinned (permission-classifier limits stopped the bisection);
+see the #1476 close-out comment for the full evidence chain.
 
-Measured rather than assumed, with temporary probe hooks in a gitignored
-`settings.local.json` (hook config hot-reloads, so this is testable without a
+Consequence: the `if:` fields were REMOVED from all 29 hooks in the Bash entry.
+Every hook is now invoked on every Bash call and the in-script matcher
+(`lib/command-match.sh`, below) is the SOLE filter. All 29 scripts were
+verified to exit 0 fast on non-matching commands, so the cost is ~29 quick
+spawns per Bash call, not spurious blocks. Do NOT reintroduce `if:` (on any
+hook in project settings) without the restart-verified protocol: change the
+setting → start a FRESH session → run the #1476 probe shapes → only then trust
+it. A hot-reload measurement via `settings.local.json` does NOT transfer to
+project settings.
+
+Historical context for the (now-removed) `if:` patterns: they were prefix globs
+(`Bash(gh pr merge*)`), which is why several hooks had hand-enumerated chained
+variants (`Bash(cd * && gh pr merge*)`); #1455's first pass widened them to
+CONTAINS patterns (`Bash(*gh pr merge*)`) with separate `-C` alternatives,
+since `git -C <path> commit` does not contain the literal `git commit`.
+
+That first pass was measured with temporary probe hooks in a gitignored
+`settings.local.json` (hook config hot-reloads, so this was testable without a
 restart):
 
 | probe `if:` | fired on `true && echo "... gh pr merge 999 ..."` |
@@ -125,13 +148,12 @@ restart):
 | `Bash(*gh pr merge*)` | **yes** |
 | `Bash(gh pr merge*)` | no |
 
-The same run established that matching there is purely TEXTUAL and quote-blind:
-a contains pattern fired on an occurrence that existed only inside a quoted
-`echo` string. That is exactly why the two layers must change together —
-widening `if:` alone would invoke hooks on prose, and the hook's matcher becomes
-the sole precision filter. Widening it BEFORE the matcher fix would have been
-pointless (the anchored matcher rejects chained invocations anyway); doing it
-after is what makes the pair correct.
+The same run established that `if:` matching was purely TEXTUAL and
+quote-blind: a contains pattern fired on an occurrence that existed only inside
+a quoted `echo` string. Both findings still matter after the removal of `if:`:
+they document the hot-reload path's semantics (should `if:` ever be
+re-evaluated under the restart-verified protocol above), and they are why the
+in-script matcher was made the precision filter — a role it now plays alone.
 
 **Command-position matching (issue #1455 — supersedes the line-start anchoring).** Those false-positive cases were originally handled by anchoring the matcher at LINE START, tolerating exactly one chained shape (an optional leading `cd <path> &&`). That dodged the false positive by POSITION, and the cost was a false NEGATIVE of the same shape: any other command in front — `git push && gh pr create`, `echo done; gh pr merge` — and the gate never fired at all. That is not a hypothetical: PR #1451's own `gh pr create` slipped past `verify-pr-gate` exactly that way, and the same hole existed in all six merge-time gates, which is strictly worse (they are what stand between an unverified destroy path and `main`).
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,203 +7,174 @@
           {
             "type": "command",
             "command": ".claude/hooks/branch-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git push*) or Bash(*git -C * commit*) or Bash(*git -C * push*)",
             "timeout": 10,
             "statusMessage": "Checking current branch..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/main-tree-branch-gate.sh",
-            "if": "Bash(*git switch*) or Bash(*git checkout*) or Bash(*git -C * switch*) or Bash(*git -C * checkout*)",
             "timeout": 10,
             "statusMessage": "Checking main-tree branch-switch policy..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/post-merge-orphan-push-gate.sh",
-            "if": "Bash(*git push*) or Bash(*git -C * push*)",
             "timeout": 10,
             "statusMessage": "Checking for already-merged PR on this branch..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/check-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking /check marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-destroy-gate.sh",
-            "if": "Bash(*gh pr merge*)",
             "timeout": 10,
             "statusMessage": "Checking integ-destroy marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-local-gate.sh",
-            "if": "Bash(*gh pr merge*) or Bash(*git merge*) or Bash(*git -C * merge*)",
             "timeout": 10,
             "statusMessage": "Checking integ-local marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-broad-gate.sh",
-            "if": "Bash(*gh pr merge*)",
             "timeout": 10,
             "statusMessage": "Checking integ-broad marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-schema-migration-gate.sh",
-            "if": "Bash(*gh pr merge*)",
             "timeout": 10,
             "statusMessage": "Checking integ-schema-migration marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-review-gate.sh",
-            "if": "Bash(*gh pr merge*)",
             "timeout": 15,
             "statusMessage": "Checking pr-review marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/ci-green-gate.sh",
-            "if": "Bash(*gh pr merge*) or Bash(*gh -C * pr merge*)",
             "timeout": 20,
             "statusMessage": "Checking PR CI status is green..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/closes-paren-form-gate.sh",
-            "if": "Bash(*gh pr merge*) or Bash(*gh -C * pr merge*)",
             "timeout": 10,
             "statusMessage": "Checking PR body for Closes (#N) auto-close trap..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/non-english-text-gate.sh",
-            "if": "Bash(*gh pr create*) or Bash(*gh pr edit*) or Bash(*gh pr merge*) or Bash(*gh -C * pr create*) or Bash(*gh -C * pr edit*) or Bash(*gh -C * pr merge*)",
             "timeout": 15,
             "statusMessage": "Checking PR diff for non-English text..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/verify-pr-gate.sh",
-            "if": "Bash(*gh pr create*) or Bash(*gh pr merge*)",
             "timeout": 10,
             "statusMessage": "Checking verify-pr marker..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/bughunt-clean-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git -C * commit*) or Bash(*gh pr create*) or Bash(*gh pr merge*) or Bash(*gh -C * pr create*) or Bash(*gh -C * pr merge*)",
             "timeout": 10,
             "statusMessage": "Checking for un-destroyed bug-hunt resources..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/commit-msg-heredoc-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking commit message format..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/gh-pr-edit-deprecation-gate.sh",
-            "if": "Bash(*gh pr edit*)",
             "timeout": 10,
             "statusMessage": "Checking gh pr edit usage..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-body-item-number-gate.sh",
-            "if": "Bash(*gh pr create*) or Bash(*gh pr edit*) or Bash(*gh issue create*) or Bash(*gh issue comment*) or Bash(*gh api*)",
             "timeout": 10,
             "statusMessage": "Checking PR body for #N auto-link traps..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/gh-label-validity-gate.sh",
-            "if": "Bash(*--label*) or Bash(*--add-label*)",
             "timeout": 10,
             "statusMessage": "Checking gh label validity..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/roundtrip-test-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking new SDK provider has round-trip test..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/provider-docs-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking new provider registration has docs entries..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/provider-integ-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking new provider registration has integ coverage..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/ref-segment-audit-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking new REF_RETURNS_SEGMENT_AFTER_PIPE entries have unit tests..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/integ-coverage-matrix-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 15,
             "statusMessage": "Checking integ-coverage matrix is in sync..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/internal-pr-labels-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking user-facing docs for internal PR labels..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/cmd-parse-stub-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking test files for cmd.parse without action stub..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/commit-prefix-scope-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking commit prefix matches user-visible scope..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/pr-title-prefix-scope-gate.sh",
-            "if": "Bash(*gh pr create*) or Bash(*gh -C * pr create*) or Bash(*gh api*pulls*) or Bash(*gh -C * api*pulls*)",
             "timeout": 10,
             "statusMessage": "Checking PR title prefix matches user-visible scope..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/state-destroy-force-gate.sh",
-            "if": "Bash(*git commit*) or Bash(*git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking staged verify.sh for state destroy --force..."
           },
           {
             "type": "command",
             "command": ".claude/hooks/restore-backup.sh",
-            "if": "Bash(*git checkout*) or Bash(*git restore*) or Bash(*git reset*) or Bash(*git clean*) or Bash(*git stash*) or Bash(*git -C * checkout*) or Bash(*git -C * restore*) or Bash(*git -C * reset*) or Bash(*git -C * clean*) or Bash(*git -C * stash*)",
             "timeout": 20,
             "statusMessage": "Snapshotting the working tree before a destructive restore..."
           }


### PR DESCRIPTION
## Summary

The #1476 verification found that **every PreToolUse hook carrying an `if:` field never fires in a real session** — `git commit`, `git push`, `gh pr create`, and `gh pr merge` all run with no gate consulted. That is all 29 hooks in the Bash entry: branch-gate, check-gate, verify-pr-gate, ci-green-gate, the integ gates, pr-review-gate, and the rest. The no-`if:` entries in the same file (main-tree-edit-gate, worktree-owner-gate, the PostToolUse detectors) fire normally.

This PR removes the `if:` field from all 29 hooks so each hook is invoked on every Bash call and its in-script matcher (`lib/command-match.sh`, the #1458 half of the original fix) is the sole filter — the pre-`if:` status quo. It also rewrites the "two layers" section of `.claude/rules/hooks.md` to record the incident and forbid reintroducing `if:` without a restart-verified protocol.

## Evidence (measured in the #1476 pass; full chain in that issue's close-out comment)

- The scripts are correct: piping the probe JSON into `branch-gate.sh` directly blocks with exit 2.
- Project settings load fine: the no-`if:` hooks registered in the same file fire (one blocked a probe write to a tracked file).
- `if:` semantics work via the `settings.local.json` hot-reload path: single-clause fires on match, non-matching is not invoked, and even the 4-clause `or` chain fires (quote-blind).
- Yet the project-settings entry is dead — including its **single-clause** `if:` hooks (the `gh pr merge` probe sailed past integ-destroy-gate / pr-review-gate, whose `if:` is a lone `Bash(*gh pr merge*)`), which points at the whole entry being dropped by the stricter session-start load path rather than one bad pattern failing to match. Claude Code's docs document `if:` with single permission-rule patterns only; the `or`-chained form is undocumented, and one undocumented condition in the entry dropping all 29 hooks fits every observation.

## Why this fix shape

Removing `if:` is mechanism-independent: whichever variable poisons the load path (`or` chains, the 29-hook entry, field validation), hooks without `if:` demonstrably fire from project settings today. Cost: ~29 fast script spawns per Bash call — all 29 scripts were verified to exit 0 quickly on a non-matching command, so there are no spurious blocks.

## Verification

- Pre-fix session measurements as above (the bug is reproduced and understood at the behavioral level).
- Post-fix verification **requires a restarted session** (project settings do not hot-reload): run the #1476 probe shapes and confirm both are blocked. Tracked on the reopened #1455, which stays open until that passes.

Refs #1455
