### PR TITLE
chore(markgate): scope the check gate to vite.config.ts, drop vestigial entries

### DIFF
--- a/.markgate.yml
+++ b/.markgate.yml
@@ -83,10 +83,14 @@ gates:
       - "package.json"
       - "pnpm-lock.yaml"
       - "tsconfig*.json"
-      - "vitest.config.ts"
-      - "build.mjs"
-      - ".eslintrc*"
-      - ".prettierrc*"
+      # vite.config.ts holds the build / test / lint / codegen task
+      # definitions (Vite+), so it defines what "green" means for this
+      # gate — editing it must invalidate a previously-recorded marker.
+      # Issue 1487: the old list scoped a non-existent vitest.config.ts
+      # (plus vestigial build.mjs / .eslintrc* / .prettierrc* — this
+      # repo builds via vp/tsdown and lints/formats via Oxlint/Oxfmt,
+      # all configured in vite.config.ts).
+      - "vite.config.ts"
 
   docs:
     hash: files


### PR DESCRIPTION
## Summary

The `check` gate in `.markgate.yml` scoped a non-existent `vitest.config.ts` and missed `vite.config.ts` entirely — the file that actually holds the build / test / lint / codegen task definitions `vp run` executes. Editing `vite.config.ts` therefore did not invalidate a previously-recorded `check` marker: a stale green replayed as fresh for exactly the file that defines what "green" means.

## Changes

- `check.include`: replace `vitest.config.ts` with `vite.config.ts` (with a comment recording why).
- Drop the vestigial `build.mjs` / `.eslintrc*` / `.prettierrc*` entries — none of these files exist; this repo builds via vp/tsdown and lints/formats via Oxlint/Oxfmt, all configured in `vite.config.ts`. Verified: `.markgate.yml`, the hooks, the skills, CLAUDE.md, and `.claude/rules/` contain no other references to any of these names.

## Notes for in-flight lanes

Widening the gate's scope changes the include-set digest, so previously-recorded `check` markers go stale in any worktree once this lands there — re-run /check once after rebasing. That is by design (and why this is its own PR rather than a rider on an unrelated one, per the issue's own suggestion).

## Verification

- `mise exec -- markgate status` in the branch worktree parses the new config and lists all 8 gates as configured.
- Deliberately NO change to gate semantics or hooks — a one-list scope fix.

Closes #1487
