### PR TITLE
test(integ): resolve a fixture-local aws-cdk in every upstream-cdk fixture, and lint the class

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -238,6 +238,33 @@ Mechanically enforced since issue
 [#1402](https://github.com/go-to-k/cdkd/issues/1402) (see the lint named
 above). User-facing writeup in [docs/testing.md](../../docs/testing.md).
 
+### `verify.sh` upstream-cdk callers must pin AND resolve a fixture-local CLI (mandatory)
+
+A fixture whose `verify.sh` invokes the upstream `cdk` CLI (bare `cdk deploy`,
+`npx cdk ...`, or a `CDK_BIN`-style variable) must (1) pin `aws-cdk` in its
+package.json, (2) carry an install step so a gitignored `node_modules` cannot
+leave the pin inert, and (3) make every invocation resolve the fixture-local
+CLI — the canonical shape:
+
+```bash
+[ -x "${TEST_DIR}/node_modules/.bin/cdk" ] || (cd "${TEST_DIR}" && npm install)
+export PATH="${TEST_DIR}/node_modules/.bin:${PATH}"
+```
+
+(an explicit `CDK_BIN="${TEST_DIR}/node_modules/.bin/cdk"` used for every
+invocation is equally hermetic and needs no PATH prepend.) A pin without
+resolution is dead weight: the run silently takes whatever global `cdk` the
+machine has, and when that lags the fixture's `aws-cdk-lib` the synth dies
+with a cloud-assembly schema-version mismatch. `import-nested-stack` failed
+exactly this way on the 2026-08-10 staleness sweep — its package.json pinned
+`aws-cdk` while its verify.sh logged `using global cdk` — seven weeks after
+PR #1253 fixed the identical trap in three other fixtures individually
+(issue #1485 closed the class). Enforced by
+`tests/unit/scripts/integ-cdk-cli-pins.test.ts` (classifier:
+`scripts/check-integ-cdk-cli-pins.ts`, command-position matching so comments
+and echo prose don't count); user-facing writeup in
+[docs/testing.md](../../docs/testing.md).
+
 ### `verify.sh` list readbacks must be order-insensitive (mandatory)
 
 AWS does not preserve the submitted order of list-valued members on readback.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -241,10 +241,18 @@ above). User-facing writeup in [docs/testing.md](../../docs/testing.md).
 ### `verify.sh` upstream-cdk callers must pin AND resolve a fixture-local CLI (mandatory)
 
 A fixture whose `verify.sh` invokes the upstream `cdk` CLI (bare `cdk deploy`,
-`npx cdk ...`, or a `CDK_BIN`-style variable) must (1) pin `aws-cdk` in its
-package.json, (2) carry an install step so a gitignored `node_modules` cannot
-leave the pin inert, and (3) make every invocation resolve the fixture-local
-CLI — the canonical shape:
+`npx` / `pnpm exec` / `yarn cdk ...`, or a `CDK_BIN`-style variable) must:
+
+1. pin `aws-cdk` at a real version range — `*` / `latest` re-admit the very
+   skew this rule exists for;
+2. install the FIXTURE's own deps. The `(cd "${REPO_ROOT}" && pnpm install)`
+   nearly every verify.sh already carries installs the CLI's deps, not the
+   fixture's, and does not count;
+3. if that install is conditional, guard it on the cdk BIN, not on the
+   directory — a `node_modules` left over from before the pin exists but has
+   no `cdk` in it, so `[ -d node_modules ]` skips the install that would fix
+   it. An unconditional install needs no guard; and
+4. make every invocation resolve the fixture-local CLI. The canonical shape:
 
 ```bash
 [ -x "${TEST_DIR}/node_modules/.bin/cdk" ] || (cd "${TEST_DIR}" && npm install)
@@ -252,17 +260,22 @@ export PATH="${TEST_DIR}/node_modules/.bin:${PATH}"
 ```
 
 (an explicit `CDK_BIN="${TEST_DIR}/node_modules/.bin/cdk"` used for every
-invocation is equally hermetic and needs no PATH prepend.) A pin without
-resolution is dead weight: the run silently takes whatever global `cdk` the
-machine has, and when that lags the fixture's `aws-cdk-lib` the synth dies
-with a cloud-assembly schema-version mismatch. `import-nested-stack` failed
-exactly this way on the 2026-08-10 staleness sweep — its package.json pinned
-`aws-cdk` while its verify.sh logged `using global cdk` — seven weeks after
-PR #1253 fixed the identical trap in three other fixtures individually
-(issue #1485 closed the class). Enforced by
+invocation is equally hermetic and needs no PATH prepend — but a `CDK_BIN`
+holding an absolute path is resolved directly, so a prepended PATH never
+redeems one pointing outside the fixture.)
+
+A pin without resolution is dead weight: the run silently takes whatever
+global `cdk` the machine has, and when that lags the fixture's `aws-cdk-lib`
+the synth dies with a cloud-assembly schema-version mismatch.
+`import-nested-stack` failed exactly this way on the 2026-08-10 staleness
+sweep — its package.json pinned `aws-cdk` while its verify.sh logged
+`using global cdk` — seven weeks after PR #1253 fixed the identical trap in
+three other fixtures individually (issue #1485 closed the class). Enforced by
 `tests/unit/scripts/integ-cdk-cli-pins.test.ts` (classifier:
-`scripts/check-integ-cdk-cli-pins.ts`, command-position matching so comments
-and echo prose don't count); user-facing writeup in
+`scripts/check-integ-cdk-cli-pins.ts`). The classifier strips heredoc bodies
+and comments, then walks each line quote-aware, so neither an invocation nor
+an install/prepend/guard signal is ever read out of an `echo` argument, a
+`grep` pattern, or a trailing comment. User-facing writeup in
 [docs/testing.md](../../docs/testing.md).
 
 ### `verify.sh` list readbacks must be order-insensitive (mandatory)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -722,17 +722,22 @@ invariant — most existing fixtures do not set it and are fine.
 ### Fixture convention: pin and resolve a fixture-local `cdk` CLI
 
 A fixture whose `verify.sh` shells out to the upstream `cdk` CLI must be
-hermetic about which `cdk` it gets. Three requirements (enforced by
+hermetic about which `cdk` it gets. Four requirements (enforced by
 `tests/unit/scripts/integ-cdk-cli-pins.test.ts`, classifier
 `scripts/check-integ-cdk-cli-pins.ts`):
 
-1. Pin `aws-cdk` in the fixture's `package.json`, at a version whose
-   cloud-assembly schema support covers the fixture's `aws-cdk-lib`.
-2. Install the fixture's deps when absent — `node_modules` is gitignored and
-   the repo-root `pnpm install` does not populate fixture dirs, so without an
-   install step the pin is inert.
-3. Resolve the local CLI on every invocation, either by PATH prepend or by an
-   explicit bin path:
+1. Pin `aws-cdk` in the fixture's `package.json` at a real version range
+   whose cloud-assembly schema support covers the fixture's `aws-cdk-lib`
+   (`*` / `latest` are rejected — they re-admit the skew).
+2. Install the **fixture's own** deps. `node_modules` is gitignored and the
+   repo-root `pnpm install` does not populate fixture dirs, so a root install
+   alone leaves the pin inert.
+3. Guard a conditional install on the cdk **binary**, not on the directory: a
+   `node_modules` left from before the pin exists but contains no `cdk`, so
+   `[ -d node_modules ]` skips the very install that would fix it. An
+   unconditional install needs no guard.
+4. Resolve the local CLI on every invocation, by PATH prepend or an explicit
+   local bin path:
 
    ```bash
    [ -x "${TEST_DIR}/node_modules/.bin/cdk" ] || (cd "${TEST_DIR}" && npm install)
@@ -744,8 +749,12 @@ the machine's global CLI. When that CLI lags the fixture's `aws-cdk-lib`, the
 run fails with `Cloud assembly schema version mismatch` — which is how
 `import-nested-stack` failed on the 2026-08-10 staleness sweep even though its
 `package.json` pinned `aws-cdk` (the pin was never on the resolution path).
-The check matches invocations in command position only, so comments and
-`echo` prose mentioning `cdk deploy` don't count.
+
+The check reads code, never prose: heredoc bodies and comments (including
+trailing ones) are stripped, and each line is split quote-aware into
+command-position segments, so a `cdk deploy` inside an `echo` string or a
+`grep` pattern is not an invocation — and equally, an `npm install` mentioned
+in a comment does not satisfy requirement 2.
 
 ### Fixture convention: sort both sides of a list readback
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -719,6 +719,34 @@ as a recommendation for new and affected fixtures rather than a tree-wide
 invariant — most existing fixtures do not set it and are fine.
 `tests/integration/emr-instance-configs/verify.sh` is the reference.
 
+### Fixture convention: pin and resolve a fixture-local `cdk` CLI
+
+A fixture whose `verify.sh` shells out to the upstream `cdk` CLI must be
+hermetic about which `cdk` it gets. Three requirements (enforced by
+`tests/unit/scripts/integ-cdk-cli-pins.test.ts`, classifier
+`scripts/check-integ-cdk-cli-pins.ts`):
+
+1. Pin `aws-cdk` in the fixture's `package.json`, at a version whose
+   cloud-assembly schema support covers the fixture's `aws-cdk-lib`.
+2. Install the fixture's deps when absent — `node_modules` is gitignored and
+   the repo-root `pnpm install` does not populate fixture dirs, so without an
+   install step the pin is inert.
+3. Resolve the local CLI on every invocation, either by PATH prepend or by an
+   explicit bin path:
+
+   ```bash
+   [ -x "${TEST_DIR}/node_modules/.bin/cdk" ] || (cd "${TEST_DIR}" && npm install)
+   export PATH="${TEST_DIR}/node_modules/.bin:${PATH}"
+   ```
+
+Why: a bare `cdk deploy` (or `npx cdk` with no local install) silently takes
+the machine's global CLI. When that CLI lags the fixture's `aws-cdk-lib`, the
+run fails with `Cloud assembly schema version mismatch` — which is how
+`import-nested-stack` failed on the 2026-08-10 staleness sweep even though its
+`package.json` pinned `aws-cdk` (the pin was never on the resolution path).
+The check matches invocations in command position only, so comments and
+`echo` prose mentioning `cdk deploy` don't count.
+
 ### Fixture convention: sort both sides of a list readback
 
 AWS does not preserve the submitted order of list-valued members when you read

--- a/scripts/check-integ-cdk-cli-pins.ts
+++ b/scripts/check-integ-cdk-cli-pins.ts
@@ -26,7 +26,7 @@
  */
 
 const CDK_VERBS =
-  'deploy|synth|synthesize|bootstrap|destroy|diff|migrate|import|watch|ls|list|context|acknowledge|doctor|version|--version';
+  'deploy|synth|synthesize|bootstrap|destroy|diff|migrate|import|watch|ls|list|context|acknowledge|doctor|version|gc|rollback|init|drift|notices|metadata|--version';
 
 /** Segments of a line that sit in command position (after ; & | ( ` and $( ). */
 function commandSegments(line: string): string[] {
@@ -36,9 +36,22 @@ function commandSegments(line: string): string[] {
     .filter((s) => s.length > 0);
 }
 
-/** Strip leading inline env-var assignments (`FOO=bar BAZ=qux cmd ...`). */
-function stripEnvAssignments(segment: string): string {
-  return segment.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=[^\s]*\s+)+/, '');
+/**
+ * Strip leading tokens that keep the rest of the segment in command
+ * position: shell keywords (`if ! cdk deploy`, `then cdk deploy`, ...),
+ * negation, `time` / `timeout <n>` wrappers, and inline env-var assignments
+ * (quoted values included: `FOO="a b" cdk deploy`).
+ */
+function stripToCommandWord(segment: string): string {
+  let s = segment;
+  let prev;
+  do {
+    prev = s;
+    s = s.replace(/^(?:!|if|then|else|elif|do|while|until|time)\s+/, '');
+    s = s.replace(/^timeout\s+(?:-\S+\s+)*\d+\S*\s+/, '');
+    s = s.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)\s+)+/, '');
+  } while (s !== prev);
+  return s;
 }
 
 export interface CdkCliUsage {
@@ -48,10 +61,12 @@ export interface CdkCliUsage {
   npxInvocations: number;
   /** `"${...CDK_BIN...}" <verb>` invocations */
   explicitBinInvocations: number;
-  /** `export PATH="<...>/node_modules/.bin:${PATH}"` present */
+  /** `export PATH="<...>/node_modules/.bin:${PATH}"` present (non-comment) */
   hasPathPrepend: boolean;
-  /** an `npm install` / `pnpm install` / `vp install` step present */
+  /** an `npm install` / `pnpm install` / `vp install` step present (non-comment) */
   hasInstallStep: boolean;
+  /** an `-x .../node_modules/.bin/cdk` existence test present (non-comment) */
+  hasCdkBinGuard: boolean;
   /** every `*CDK_BIN*` variable used is defined to a node_modules/.bin/cdk */
   cdkBinPointsAtLocalBin: boolean;
 }
@@ -75,7 +90,7 @@ export function classifyCdkCliUsage(script: string): CdkCliUsage {
     if (defMatch) binVarsLocal.add(defMatch[1]);
 
     for (const rawSegment of commandSegments(line)) {
-      const segment = stripEnvAssignments(rawSegment);
+      const segment = stripToCommandWord(rawSegment);
       // echo/printf arguments are prose, not invocations
       if (/^(echo|printf)\b/.test(segment)) continue;
       if (npxRe.test(segment)) {
@@ -92,8 +107,21 @@ export function classifyCdkCliUsage(script: string): CdkCliUsage {
     }
   }
 
-  const hasPathPrepend = /export\s+PATH=["']?[^"'\n]*node_modules\/\.bin:/.test(joined);
-  const hasInstallStep = /\b(?:npm|pnpm|vp)\s+install\b/.test(joined);
+  // Match hermeticity signals against NON-COMMENT lines only: a comment like
+  // "# remember to npm install first" must not satisfy the install
+  // requirement (reviewer finding on the first version of this classifier —
+  // the canonical block's own explanatory comment mentions the install
+  // command, so comment-inclusive matching passed a fixture whose real guard
+  // had been deleted).
+  const code = lines.join('\n');
+  const hasPathPrepend = /export\s+PATH=["']?[^"'\n]*node_modules\/\.bin:/.test(code);
+  const hasInstallStep = /\b(?:npm|pnpm|vp)\s+install\b/.test(code);
+  // Directory-blindness bound (recorded, not solved): these regexes cannot
+  // statically track the cwd of the install or the prepended path's prefix, so
+  // an install in the wrong directory could still pass. The `-x` guard
+  // requirement narrows that: the guard names node_modules/.bin/cdk relative
+  // to the fixture in every canonical shape, and its absence fails the lint.
+  const hasCdkBinGuard = /-x\s+["']?[^"'\n]*node_modules\/\.bin\/cdk/.test(code);
   const cdkBinPointsAtLocalBin =
     binVarsUsed.size > 0 && [...binVarsUsed].every((v) => binVarsLocal.has(v));
 
@@ -103,6 +131,7 @@ export function classifyCdkCliUsage(script: string): CdkCliUsage {
     explicitBinInvocations: explicitBin,
     hasPathPrepend,
     hasInstallStep,
+    hasCdkBinGuard,
     cdkBinPointsAtLocalBin,
   };
 }
@@ -144,6 +173,11 @@ export function checkFixture(
     }
     if (!usage.hasInstallStep) {
       violations.push('no install step (npm/pnpm/vp install) — a gitignored node_modules leaves the pin inert');
+    }
+    if (!usage.hasCdkBinGuard) {
+      violations.push(
+        'no `-x .../node_modules/.bin/cdk` guard — a node_modules that pre-exists without the cdk bin (stale checkout from before the pin) silently skips the install',
+      );
     }
     const bareOrNpx = usage.bareInvocations + usage.npxInvocations > 0;
     if (bareOrNpx && !usage.hasPathPrepend) {

--- a/scripts/check-integ-cdk-cli-pins.ts
+++ b/scripts/check-integ-cdk-cli-pins.ts
@@ -1,0 +1,160 @@
+/**
+ * Classifier for issue 1485: integ fixtures that shell out to the upstream
+ * `cdk` CLI must be hermetic about WHICH cdk they get.
+ *
+ * The failure class: a fixture pins `aws-cdk` in its package.json but its
+ * verify.sh runs a bare `cdk deploy` (or an `npx cdk ...` with no local
+ * install), so the pin is dead weight and the run silently takes whatever
+ * global `cdk` the machine has. When the global CLI lags the fixture's
+ * aws-cdk-lib, synth dies with a cloud-assembly schema-version mismatch —
+ * `import-nested-stack` failed exactly this way on the 2026-08-10 staleness
+ * sweep, seven weeks after PR 1253 fixed the same trap in three other
+ * fixtures individually.
+ *
+ * A fixture that invokes the upstream cdk CLI is compliant when ALL of:
+ *   1. its package.json pins `aws-cdk` (dependencies or devDependencies);
+ *   2. its verify.sh has an install step (`npm install` / `pnpm install` /
+ *      `vp install`), so a gitignored node_modules cannot leave the pin
+ *      inert; and
+ *   3. every invocation resolves the fixture-local CLI: either the script
+ *      PATH-prepends `<fixture>/node_modules/.bin`, or every invocation goes
+ *      through an explicit `${...CDK_BIN...}` variable that is defined to
+ *      point at a `node_modules/.bin/cdk`.
+ *
+ * Out of scope (not upstream-cdk invocations): `cdkd`, `cdk-local`, prose in
+ * comments and echo/printf strings (matching is command-position only).
+ */
+
+const CDK_VERBS =
+  'deploy|synth|synthesize|bootstrap|destroy|diff|migrate|import|watch|ls|list|context|acknowledge|doctor|version|--version';
+
+/** Segments of a line that sit in command position (after ; & | ( ` and $( ). */
+function commandSegments(line: string): string[] {
+  return line
+    .split(/(?:\$\(|[;&|()`])+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** Strip leading inline env-var assignments (`FOO=bar BAZ=qux cmd ...`). */
+function stripEnvAssignments(segment: string): string {
+  return segment.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=[^\s]*\s+)+/, '');
+}
+
+export interface CdkCliUsage {
+  /** bare `cdk <verb>` invocations in command position */
+  bareInvocations: number;
+  /** `npx cdk <verb>` invocations */
+  npxInvocations: number;
+  /** `"${...CDK_BIN...}" <verb>` invocations */
+  explicitBinInvocations: number;
+  /** `export PATH="<...>/node_modules/.bin:${PATH}"` present */
+  hasPathPrepend: boolean;
+  /** an `npm install` / `pnpm install` / `vp install` step present */
+  hasInstallStep: boolean;
+  /** every `*CDK_BIN*` variable used is defined to a node_modules/.bin/cdk */
+  cdkBinPointsAtLocalBin: boolean;
+}
+
+export function classifyCdkCliUsage(script: string): CdkCliUsage {
+  const joined = script.replace(/\\\n\s*/g, ' ');
+  const lines = joined.split('\n').filter((l) => !/^\s*#/.test(l));
+
+  let bare = 0;
+  let npx = 0;
+  let explicitBin = 0;
+  const binVarsUsed = new Set<string>();
+  const binVarsLocal = new Set<string>();
+
+  const verbRe = new RegExp(`^cdk\\s+(?:${CDK_VERBS})\\b`);
+  const npxRe = new RegExp(`^npx\\s+cdk\\s+(?:${CDK_VERBS})\\b`);
+  const binRe = new RegExp(`^"?\\$\\{?(\\w*CDK_BIN\\w*)\\}?"?\\s+(?:${CDK_VERBS})\\b`);
+
+  for (const line of lines) {
+    const defMatch = line.match(/(\w*CDK_BIN\w*)=["']?[^"'\n]*node_modules\/\.bin\/cdk/);
+    if (defMatch) binVarsLocal.add(defMatch[1]);
+
+    for (const rawSegment of commandSegments(line)) {
+      const segment = stripEnvAssignments(rawSegment);
+      // echo/printf arguments are prose, not invocations
+      if (/^(echo|printf)\b/.test(segment)) continue;
+      if (npxRe.test(segment)) {
+        npx += 1;
+      } else if (verbRe.test(segment)) {
+        bare += 1;
+      } else {
+        const m = segment.match(binRe);
+        if (m) {
+          explicitBin += 1;
+          binVarsUsed.add(m[1]);
+        }
+      }
+    }
+  }
+
+  const hasPathPrepend = /export\s+PATH=["']?[^"'\n]*node_modules\/\.bin:/.test(joined);
+  const hasInstallStep = /\b(?:npm|pnpm|vp)\s+install\b/.test(joined);
+  const cdkBinPointsAtLocalBin =
+    binVarsUsed.size > 0 && [...binVarsUsed].every((v) => binVarsLocal.has(v));
+
+  return {
+    bareInvocations: bare,
+    npxInvocations: npx,
+    explicitBinInvocations: explicitBin,
+    hasPathPrepend,
+    hasInstallStep,
+    cdkBinPointsAtLocalBin,
+  };
+}
+
+export interface FixtureVerdict extends CdkCliUsage {
+  invokesUpstreamCdk: boolean;
+  hasAwsCdkPin: boolean;
+  /** empty when compliant (or when the fixture never invokes upstream cdk) */
+  violations: string[];
+}
+
+export function checkFixture(
+  verifySh: string,
+  packageJson: string | undefined,
+): FixtureVerdict {
+  const usage = classifyCdkCliUsage(verifySh);
+  const invokes =
+    usage.bareInvocations + usage.npxInvocations + usage.explicitBinInvocations > 0;
+
+  let hasAwsCdkPin = false;
+  if (packageJson !== undefined) {
+    try {
+      const pkg = JSON.parse(packageJson) as {
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+      };
+      hasAwsCdkPin =
+        typeof (pkg.dependencies?.['aws-cdk'] ?? pkg.devDependencies?.['aws-cdk']) ===
+        'string';
+    } catch {
+      hasAwsCdkPin = false;
+    }
+  }
+
+  const violations: string[] = [];
+  if (invokes) {
+    if (!hasAwsCdkPin) {
+      violations.push('invokes the upstream cdk CLI but package.json does not pin aws-cdk');
+    }
+    if (!usage.hasInstallStep) {
+      violations.push('no install step (npm/pnpm/vp install) — a gitignored node_modules leaves the pin inert');
+    }
+    const bareOrNpx = usage.bareInvocations + usage.npxInvocations > 0;
+    if (bareOrNpx && !usage.hasPathPrepend) {
+      violations.push(
+        'bare/npx cdk invocation without `export PATH="<fixture>/node_modules/.bin:${PATH}"` — resolution can fall through to a stale global cdk',
+      );
+    }
+    if (!bareOrNpx && usage.explicitBinInvocations > 0 && !usage.cdkBinPointsAtLocalBin && !usage.hasPathPrepend) {
+      violations.push('CDK_BIN-style invocation whose variable is not defined to a node_modules/.bin/cdk');
+    }
+  }
+
+  return { ...usage, invokesUpstreamCdk: invokes, hasAwsCdkPin, violations };
+}

--- a/scripts/check-integ-cdk-cli-pins.ts
+++ b/scripts/check-integ-cdk-cli-pins.ts
@@ -12,28 +12,125 @@
  * fixtures individually.
  *
  * A fixture that invokes the upstream cdk CLI is compliant when ALL of:
- *   1. its package.json pins `aws-cdk` (dependencies or devDependencies);
- *   2. its verify.sh has an install step (`npm install` / `pnpm install` /
- *      `vp install`), so a gitignored node_modules cannot leave the pin
- *      inert; and
- *   3. every invocation resolves the fixture-local CLI: either the script
+ *   1. its package.json pins `aws-cdk` at a real version range (`*` /
+ *      `latest` re-admit the very skew this lint exists for, so they are
+ *      rejected);
+ *   2. its verify.sh installs the FIXTURE's own deps — a repo-root
+ *      `(cd "${REPO_ROOT}" && pnpm install)`, which nearly every verify.sh
+ *      already has, does not count;
+ *   3. a conditional install carries a guard that tests for the cdk bin
+ *      itself, so a `node_modules` left over from before the pin (present,
+ *      but with no cdk) cannot skip the install. An UNCONDITIONAL install
+ *      needs no guard — it is strictly more hermetic; and
+ *   4. every invocation resolves the fixture-local CLI: either the script
  *      PATH-prepends `<fixture>/node_modules/.bin`, or every invocation goes
- *      through an explicit `${...CDK_BIN...}` variable that is defined to
- *      point at a `node_modules/.bin/cdk`.
+ *      through a `${...CDK_BIN...}` variable defined to a
+ *      `node_modules/.bin/cdk`.
  *
- * Out of scope (not upstream-cdk invocations): `cdkd`, `cdk-local`, prose in
- * comments and echo/printf strings (matching is command-position only).
+ * Everything is evaluated on CODE, never on prose. The scanner strips
+ * heredoc bodies and comments (including trailing ones), then splits each
+ * line into command-position segments with a quote-aware walk, so a
+ * `cdk deploy` inside an `echo "..."` / `grep "..."` argument — or a
+ * `; cdk deploy` inside such a string — is not an invocation, and an
+ * `npm install` mentioned in prose does not satisfy the install requirement.
+ * `cdkd` / `cdk-local` are different binaries and are out of scope.
  */
 
 const CDK_VERBS =
   'deploy|synth|synthesize|bootstrap|destroy|diff|migrate|import|watch|ls|list|context|acknowledge|doctor|version|gc|rollback|init|drift|notices|metadata|--version';
 
-/** Segments of a line that sit in command position (after ; & | ( ` and $( ). */
+/** Commands whose arguments are prose/data rather than nested commands. */
+const PROSE_COMMANDS =
+  /^(?:echo|printf|grep|egrep|fgrep|cat|sed|awk|jq|python3?|node|comm|diff|read)\b/;
+
+/** Join backslash continuations so one logical command is one line. */
+function joinContinuations(script: string): string {
+  return script.replace(/\\\n\s*/g, ' ');
+}
+
+/**
+ * Drop heredoc bodies. A body is data — a `cdk deploy` line inside one is
+ * not an invocation by this script, and an `npm install` inside one does not
+ * install anything now.
+ */
+function stripHeredocs(script: string): string {
+  const out: string[] = [];
+  const lines = script.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    out.push(line);
+    const m = line.match(/<<-?\s*['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?/);
+    if (!m) continue;
+    const terminator = m[1];
+    const endRe = new RegExp(`^\\s*${terminator}\\s*$`);
+    i += 1;
+    while (i < lines.length && !endRe.test(lines[i])) i += 1;
+    if (i < lines.length) out.push(lines[i]); // keep the terminator line
+  }
+  return out.join('\n');
+}
+
+/** Remove a `#` comment, honoring quote state (so `"a # b"` survives). */
+function stripComment(line: string): string {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === '\\' && inDouble) {
+      i += 1;
+      continue;
+    }
+    if (ch === "'" && !inDouble) inSingle = !inSingle;
+    else if (ch === '"' && !inSingle) inDouble = !inDouble;
+    else if (ch === '#' && !inSingle && !inDouble) {
+      // `#` starts a comment only at the start of a word.
+      if (i === 0 || /\s/.test(line[i - 1])) return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
+/**
+ * Split a line into segments that start in COMMAND position, honoring quote
+ * state so a separator inside a quoted argument does not open a new segment.
+ */
 function commandSegments(line: string): string[] {
-  return line
-    .split(/(?:\$\(|[;&|()`])+/)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+  const segments: string[] = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === '\\' && inDouble) {
+      current += ch + (line[i + 1] ?? '');
+      i += 1;
+      continue;
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      current += ch;
+      continue;
+    }
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      current += ch;
+      continue;
+    }
+    if (!inSingle && !inDouble && /[;&|()`]/.test(ch)) {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+    if (!inSingle && !inDouble && ch === '$' && line[i + 1] === '(') {
+      segments.push(current);
+      current = '';
+      i += 1;
+      continue;
+    }
+    current += ch;
+  }
+  segments.push(current);
+  return segments.map((s) => s.trim()).filter((s) => s.length > 0);
 }
 
 /**
@@ -47,6 +144,7 @@ function stripToCommandWord(segment: string): string {
   let prev;
   do {
     prev = s;
+    s = s.replace(/^\{\s+/, '');
     s = s.replace(/^(?:!|if|then|else|elif|do|while|until|time)\s+/, '');
     s = s.replace(/^timeout\s+(?:-\S+\s+)*\d+\S*\s+/, '');
     s = s.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)\s+)+/, '');
@@ -57,42 +155,93 @@ function stripToCommandWord(segment: string): string {
 export interface CdkCliUsage {
   /** bare `cdk <verb>` invocations in command position */
   bareInvocations: number;
-  /** `npx cdk <verb>` invocations */
+  /** `npx cdk <verb>` / `pnpm exec cdk <verb>` / `yarn cdk <verb>` invocations */
   npxInvocations: number;
   /** `"${...CDK_BIN...}" <verb>` invocations */
   explicitBinInvocations: number;
-  /** `export PATH="<...>/node_modules/.bin:${PATH}"` present (non-comment) */
+  /** `export PATH="<...>/node_modules/.bin:${PATH}"` in code (not prose) */
   hasPathPrepend: boolean;
-  /** an `npm install` / `pnpm install` / `vp install` step present (non-comment) */
-  hasInstallStep: boolean;
-  /** an `-x .../node_modules/.bin/cdk` existence test present (non-comment) */
+  /** an install of the FIXTURE's own deps (a repo-root install does not count) */
+  hasFixtureInstall: boolean;
+  /** the install is conditional (guarded / inside an `if`) rather than unconditional */
+  installIsConditional: boolean;
+  /** a guard testing for `<...>/node_modules/.bin/cdk` itself */
   hasCdkBinGuard: boolean;
   /** every `*CDK_BIN*` variable used is defined to a node_modules/.bin/cdk */
   cdkBinPointsAtLocalBin: boolean;
 }
 
 export function classifyCdkCliUsage(script: string): CdkCliUsage {
-  const joined = script.replace(/\\\n\s*/g, ' ');
-  const lines = joined.split('\n').filter((l) => !/^\s*#/.test(l));
+  const lines = stripHeredocs(joinContinuations(script))
+    .split('\n')
+    .map(stripComment)
+    .filter((l) => l.trim().length > 0);
 
   let bare = 0;
   let npx = 0;
   let explicitBin = 0;
+  let hasPathPrepend = false;
+  let hasFixtureInstall = false;
+  let installIsConditional = false;
+  let hasCdkBinGuard = false;
   const binVarsUsed = new Set<string>();
   const binVarsLocal = new Set<string>();
+  /** vars assigned a `<...>/node_modules/.bin` directory, e.g. BIN="${TEST_DIR}/node_modules/.bin" */
+  const binDirVars = new Set<string>();
 
-  const verbRe = new RegExp(`^cdk\\s+(?:${CDK_VERBS})\\b`);
-  const npxRe = new RegExp(`^npx\\s+cdk\\s+(?:${CDK_VERBS})\\b`);
+  // Global flags may sit between `cdk` and the verb, and their values may be
+  // quoted with spaces (`cdk --app "node bin/app.ts" synth`).
+  const verbRe = new RegExp(
+    `^cdk\\s+(?:[-\\w]+\\s+(?:"[^"]*"|'[^']*'|\\S+)\\s+)*?(?:${CDK_VERBS})\\b`,
+  );
+  const npxRe = new RegExp(
+    `^(?:npx(?:\\s+--\\S+)*|pnpm\\s+(?:exec|dlx)|npm\\s+exec|yarn(?:\\s+run)?)\\s+(?:aws-cdk@\\S+|cdk)\\s+(?:${CDK_VERBS})\\b`,
+  );
   const binRe = new RegExp(`^"?\\$\\{?(\\w*CDK_BIN\\w*)\\}?"?\\s+(?:${CDK_VERBS})\\b`);
 
-  for (const line of lines) {
-    const defMatch = line.match(/(\w*CDK_BIN\w*)=["']?[^"'\n]*node_modules\/\.bin\/cdk/);
-    if (defMatch) binVarsLocal.add(defMatch[1]);
+  /** Does this text reference a fixture-local node_modules/.bin[/cdk]? */
+  const namesLocalBin = (text: string, suffix: string): boolean => {
+    if (new RegExp(`node_modules/\\.bin${suffix}`).test(text)) return true;
+    return [...binDirVars].some((v) =>
+      new RegExp(`\\$\\{?${v}\\}?${suffix}`).test(text),
+    );
+  };
 
+  for (const line of lines) {
     for (const rawSegment of commandSegments(line)) {
       const segment = stripToCommandWord(rawSegment);
-      // echo/printf arguments are prose, not invocations
-      if (/^(echo|printf)\b/.test(segment)) continue;
+      if (PROSE_COMMANDS.test(segment)) continue;
+
+      // --- variable definitions -------------------------------------------
+      const binDef = segment.match(/^(\w*CDK_BIN\w*)=["']?[^"'\n]*node_modules\/\.bin\/cdk/);
+      if (binDef) binVarsLocal.add(binDef[1]);
+      const dirDef = segment.match(/^(\w+)=["']?[^"'\n]*node_modules\/\.bin["']?\s*$/);
+      if (dirDef) binDirVars.add(dirDef[1]);
+
+      // --- hermeticity signals (code only) --------------------------------
+      if (/^export\s+PATH=/.test(segment) && namesLocalBin(segment, ':')) {
+        hasPathPrepend = true;
+      }
+      if (/^(?:\[\[?|test)\s/.test(segment) && /-[xfe]\s/.test(segment) && namesLocalBin(segment, '/cdk')) {
+        hasCdkBinGuard = true;
+      }
+      if (/^command\s+-v\s+cdk\b/.test(segment)) hasCdkBinGuard = true;
+
+      if (/^(?:npm|pnpm|yarn|vp)\s+(?:install|i)\b/.test(segment)) {
+        // A repo-root install (the `(cd "${REPO_ROOT}" && pnpm install)` nearly
+        // every verify.sh carries) installs the CLI's deps, not the fixture's.
+        const rootScoped = /REPO_ROOT|ROOT_DIR/.test(rawSegment) || /REPO_ROOT|ROOT_DIR/.test(line);
+        if (!rootScoped) {
+          hasFixtureInstall = true;
+          // Conditional when the install is the RHS of a `||`/`&&` guard or sits
+          // inside an `if`/`while` block opener on the same logical line.
+          if (/\|\||&&|^\s*(?:if|while|until)\b|;\s*then\b/.test(line)) {
+            installIsConditional = true;
+          }
+        }
+      }
+
+      // --- invocations -----------------------------------------------------
       if (npxRe.test(segment)) {
         npx += 1;
       } else if (verbRe.test(segment)) {
@@ -107,21 +256,6 @@ export function classifyCdkCliUsage(script: string): CdkCliUsage {
     }
   }
 
-  // Match hermeticity signals against NON-COMMENT lines only: a comment like
-  // "# remember to npm install first" must not satisfy the install
-  // requirement (reviewer finding on the first version of this classifier —
-  // the canonical block's own explanatory comment mentions the install
-  // command, so comment-inclusive matching passed a fixture whose real guard
-  // had been deleted).
-  const code = lines.join('\n');
-  const hasPathPrepend = /export\s+PATH=["']?[^"'\n]*node_modules\/\.bin:/.test(code);
-  const hasInstallStep = /\b(?:npm|pnpm|vp)\s+install\b/.test(code);
-  // Directory-blindness bound (recorded, not solved): these regexes cannot
-  // statically track the cwd of the install or the prepended path's prefix, so
-  // an install in the wrong directory could still pass. The `-x` guard
-  // requirement narrows that: the guard names node_modules/.bin/cdk relative
-  // to the fixture in every canonical shape, and its absence fails the lint.
-  const hasCdkBinGuard = /-x\s+["']?[^"'\n]*node_modules\/\.bin\/cdk/.test(code);
   const cdkBinPointsAtLocalBin =
     binVarsUsed.size > 0 && [...binVarsUsed].every((v) => binVarsLocal.has(v));
 
@@ -130,7 +264,8 @@ export function classifyCdkCliUsage(script: string): CdkCliUsage {
     npxInvocations: npx,
     explicitBinInvocations: explicitBin,
     hasPathPrepend,
-    hasInstallStep,
+    hasFixtureInstall,
+    installIsConditional,
     hasCdkBinGuard,
     cdkBinPointsAtLocalBin,
   };
@@ -141,6 +276,14 @@ export interface FixtureVerdict extends CdkCliUsage {
   hasAwsCdkPin: boolean;
   /** empty when compliant (or when the fixture never invokes upstream cdk) */
   violations: string[];
+}
+
+/** `*` / `latest` / `x` re-admit the version skew this lint exists for. */
+function isRealVersionRange(spec: unknown): boolean {
+  if (typeof spec !== 'string') return false;
+  const s = spec.trim();
+  if (s === '' || s === '*' || s === 'latest' || /^x(\.x)*$/i.test(s)) return false;
+  return /\d/.test(s);
 }
 
 export function checkFixture(
@@ -158,9 +301,9 @@ export function checkFixture(
         dependencies?: Record<string, string>;
         devDependencies?: Record<string, string>;
       };
-      hasAwsCdkPin =
-        typeof (pkg.dependencies?.['aws-cdk'] ?? pkg.devDependencies?.['aws-cdk']) ===
-        'string';
+      hasAwsCdkPin = isRealVersionRange(
+        pkg.dependencies?.['aws-cdk'] ?? pkg.devDependencies?.['aws-cdk'],
+      );
     } catch {
       hasAwsCdkPin = false;
     }
@@ -169,24 +312,30 @@ export function checkFixture(
   const violations: string[] = [];
   if (invokes) {
     if (!hasAwsCdkPin) {
-      violations.push('invokes the upstream cdk CLI but package.json does not pin aws-cdk');
-    }
-    if (!usage.hasInstallStep) {
-      violations.push('no install step (npm/pnpm/vp install) — a gitignored node_modules leaves the pin inert');
-    }
-    if (!usage.hasCdkBinGuard) {
       violations.push(
-        'no `-x .../node_modules/.bin/cdk` guard — a node_modules that pre-exists without the cdk bin (stale checkout from before the pin) silently skips the install',
+        'invokes the upstream cdk CLI but package.json does not pin aws-cdk at a real version range',
       );
     }
-    const bareOrNpx = usage.bareInvocations + usage.npxInvocations > 0;
-    if (bareOrNpx && !usage.hasPathPrepend) {
+    if (!usage.hasFixtureInstall) {
+      violations.push(
+        "no install of the FIXTURE's own deps — node_modules is gitignored and a repo-root install does not populate fixture dirs, so the pin stays inert",
+      );
+    } else if (usage.installIsConditional && !usage.hasCdkBinGuard) {
+      violations.push(
+        'the fixture install is conditional but its guard does not test for node_modules/.bin/cdk — a node_modules left over from before the pin skips the install',
+      );
+    }
+    if (usage.bareInvocations + usage.npxInvocations > 0 && !usage.hasPathPrepend) {
       violations.push(
         'bare/npx cdk invocation without `export PATH="<fixture>/node_modules/.bin:${PATH}"` — resolution can fall through to a stale global cdk',
       );
     }
-    if (!bareOrNpx && usage.explicitBinInvocations > 0 && !usage.cdkBinPointsAtLocalBin && !usage.hasPathPrepend) {
-      violations.push('CDK_BIN-style invocation whose variable is not defined to a node_modules/.bin/cdk');
+    // No PATH-prepend escape here: a CDK_BIN holding an absolute path is
+    // resolved directly, so a prepended PATH does not redeem it.
+    if (usage.explicitBinInvocations > 0 && !usage.cdkBinPointsAtLocalBin) {
+      violations.push(
+        'CDK_BIN-style invocation whose variable is not defined to a node_modules/.bin/cdk',
+      );
     }
   }
 

--- a/tests/integration/export/package.json
+++ b/tests/integration/export/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "aws-cdk": "^2.1112.0",
+    "aws-cdk": "^2.1133.0",
     "typescript": "^5.0.0"
   },
   "dependencies": {

--- a/tests/integration/export/package.json
+++ b/tests/integration/export/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "aws-cdk": "^2.1133.0",
+    "aws-cdk": "^2.1135.1",
     "typescript": "^5.0.0"
   },
   "dependencies": {

--- a/tests/integration/export/pnpm-lock.yaml
+++ b/tests/integration/export/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^20.0.0
         version: 20.19.40
       aws-cdk:
-        specifier: ^2.1112.0
-        version: 2.1121.0
+        specifier: ^2.1135.1
+        version: 2.1135.1
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -62,8 +62,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.1121.0:
-    resolution: {integrity: sha512-cG7CHt/SytYTfwrK+BUNQpqmS1dwhjt8z6ExKL6GK4n+8/6ZCwFzxlZWA/jUd2+Y9xPc+Q8cLKfMqGmgxEXbkg==}
+  aws-cdk@2.1135.1:
+    resolution: {integrity: sha512-g1jcMfWlyYtGamFJ/kPBOCuchl3NfwTF2UwOLTIDN0nJbGm84EAO+c8DlYnaemM8UmKFkdoq4BGdmiNL5nHWwA==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
 
@@ -97,7 +97,7 @@ snapshots:
       '@aws-cdk/cloud-assembly-schema': 53.22.0
       constructs: 10.6.0
 
-  aws-cdk@2.1121.0: {}
+  aws-cdk@2.1135.1: {}
 
   constructs@10.6.0: {}
 

--- a/tests/integration/export/verify.sh
+++ b/tests/integration/export/verify.sh
@@ -87,6 +87,12 @@ cd "${TEST_DIR}"
 if [ ! -d node_modules ]; then
   vp install
 fi
+# Vendored cdk CLI (issue 1485): the guard re-runs the install when
+# node_modules pre-exists without the cdk bin (stale checkout from before
+# aws-cdk was pinned), and the PATH prepend guarantees `npx cdk` resolves
+# the fixture-local CLI rather than a possibly stale global one.
+[ -x "${TEST_DIR}/node_modules/.bin/cdk" ] || vp install
+export PATH="${TEST_DIR}/node_modules/.bin:${PATH}"
 
 cleanup() {
   rc=$?

--- a/tests/integration/export/verify.sh
+++ b/tests/integration/export/verify.sh
@@ -84,11 +84,8 @@ echo "[verify] step 1: install + build cdkd"
 (cd "${REPO_ROOT}" && vp run build)
 
 cd "${TEST_DIR}"
-if [ ! -d node_modules ]; then
-  vp install
-fi
-# Vendored cdk CLI (issue 1485): the guard re-runs the install when
-# node_modules pre-exists without the cdk bin (stale checkout from before
+# Vendored cdk CLI (issue 1485): the guard installs when node_modules is
+# absent OR pre-exists without the cdk bin (stale checkout from before
 # aws-cdk was pinned), and the PATH prepend guarantees `npx cdk` resolves
 # the fixture-local CLI rather than a possibly stale global one.
 [ -x "${TEST_DIR}/node_modules/.bin/cdk" ] || vp install

--- a/tests/integration/import-auto-mode/package.json
+++ b/tests/integration/import-auto-mode/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "aws-cdk": "^2.1133.0",
+    "aws-cdk": "^2.1135.1",
     "aws-cdk-lib": "^2.172.0",
     "constructs": "^10.0.0",
     "typescript": "^5.7.2"

--- a/tests/integration/import-auto-mode/verify.sh
+++ b/tests/integration/import-auto-mode/verify.sh
@@ -24,6 +24,14 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+# Vendored cdk CLI (issue 1485): install the fixture's deps when absent
+# (node_modules is gitignored, and the repo-root pnpm install does NOT
+# populate fixture dirs), otherwise the PATH prepend is inert and `npx cdk`
+# falls through to a possibly stale global CLI whose cloud-assembly schema
+# no longer matches the fixture's aws-cdk-lib.
+[ -x "${PWD}/node_modules/.bin/cdk" ] || npm install
+export PATH="${PWD}/node_modules/.bin:${PATH}"
+
 STACK="CdkdImportAutoModeExample"
 REGION="${AWS_REGION:-us-east-1}"
 LOCAL_DIST="${PWD}/../../../dist/cli.js"

--- a/tests/integration/import-nested-stack/package.json
+++ b/tests/integration/import-nested-stack/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "aws-cdk": "^2.1112.0",
+    "aws-cdk": "^2.1133.0",
     "typescript": "^5.0.0"
   },
   "dependencies": {

--- a/tests/integration/import-nested-stack/package.json
+++ b/tests/integration/import-nested-stack/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "aws-cdk": "^2.1133.0",
+    "aws-cdk": "^2.1135.1",
     "typescript": "^5.0.0"
   },
   "dependencies": {

--- a/tests/integration/import-nested-stack/verify.sh
+++ b/tests/integration/import-nested-stack/verify.sh
@@ -165,7 +165,12 @@ echo "[verify] step 2: install fixture deps (aws-cdk-lib + pinned aws-cdk CLI)"
 # the 2026-08-10 staleness sweep while its package.json pin sat unused).
 (cd "${TEST_DIR}" && { [ -x node_modules/.bin/cdk ] || npm install; })
 export PATH="${TEST_DIR}/node_modules/.bin:${PATH}"
-echo "[verify] step 2 ok: using $(command -v cdk) ($(cdk --version))"
+# Capture into variables first: a failing command substitution inside an echo
+# ARGUMENT does not trip `set -e`, so a missing cdk would print "using ()" and
+# let the run limp on to the deploy.
+CDK_RESOLVED="$(command -v cdk)"
+CDK_VERSION="$(cdk --version)"
+echo "[verify] step 2 ok: using ${CDK_RESOLVED} (${CDK_VERSION})"
 
 echo "[verify] step 3: pre-flight orphan scan"
 if aws cloudformation describe-stacks --stack-name "${PARENT_STACK}" --region "${REGION}" >/dev/null 2>&1; then

--- a/tests/integration/import-nested-stack/verify.sh
+++ b/tests/integration/import-nested-stack/verify.sh
@@ -156,14 +156,16 @@ echo "[verify] step 1: install + build cdkd"
 (cd "${REPO_ROOT}" && pnpm install)
 (cd "${REPO_ROOT}" && vp run build)
 
-echo "[verify] step 2: install fixture deps (aws-cdk-lib for synth)"
+echo "[verify] step 2: install fixture deps (aws-cdk-lib + pinned aws-cdk CLI)"
 # pnpm at this repo's root ignores per-fixture package.json under
-# tests/integration/* (no workspace registration), so the fixture's
-# aws-cdk-lib + aws-cdk deps come from the global vp-managed npm
-# environment instead. CDK CLI is `cdk` (global), and aws-cdk-lib is
-# resolved via Node's parent-directory lookup against the repo-root
-# install. No `pnpm install` round-trip needed.
-echo "[verify] step 2 ok: using global cdk (\$(which cdk))"
+# tests/integration/* (no workspace registration), so install the fixture's
+# own deps and PATH-prepend its bin dir. The pinned aws-cdk CLI must be the
+# one that runs: a stale global `cdk` fails the synth with a cloud-assembly
+# schema-version mismatch (issue 1485 — exactly how this fixture failed on
+# the 2026-08-10 staleness sweep while its package.json pin sat unused).
+(cd "${TEST_DIR}" && { [ -x node_modules/.bin/cdk ] || npm install; })
+export PATH="${TEST_DIR}/node_modules/.bin:${PATH}"
+echo "[verify] step 2 ok: using $(command -v cdk) ($(cdk --version))"
 
 echo "[verify] step 3: pre-flight orphan scan"
 if aws cloudformation describe-stacks --stack-name "${PARENT_STACK}" --region "${REGION}" >/dev/null 2>&1; then
@@ -178,10 +180,8 @@ fi
 echo "[verify] step 4: cdk deploy parent + nested child (simulating existing CFn stack)"
 # `--require-approval never` skips the IAM prompt; `--no-version-reporting`
 # and friends keep CDK quiet. The CDK toolkit handles asset publishing
-# (nested-stack child template upload) automatically. Uses the global
-# `cdk` binary supplied by vp (`/Users/goto/.vite-plus/bin/cdk` on dev
-# machines, vp-bin path in CI) — see step 2's note on why no per-fixture
-# install is needed.
+# (nested-stack child template upload) automatically. Uses the fixture's
+# pinned aws-cdk from node_modules/.bin (PATH-prepended in step 2).
 (cd "${TEST_DIR}" && cdk deploy "${PARENT_STACK}" \
   --require-approval never \
   --no-version-reporting \

--- a/tests/integration/intrinsics-torture-2/package.json
+++ b/tests/integration/intrinsics-torture-2/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "aws-cdk": "^2.1133.0",
     "typescript": "^5.0.0"
   },
   "dependencies": {

--- a/tests/integration/intrinsics-torture-2/package.json
+++ b/tests/integration/intrinsics-torture-2/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "aws-cdk": "^2.1133.0",
+    "aws-cdk": "^2.1135.1",
     "typescript": "^5.0.0"
   },
   "dependencies": {

--- a/tests/integration/intrinsics-torture-2/pnpm-lock.yaml
+++ b/tests/integration/intrinsics-torture-2/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.43
+      aws-cdk:
+        specifier: ^2.1135.1
+        version: 2.1135.1
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -59,6 +62,11 @@ packages:
       - yaml
       - mime-types
 
+  aws-cdk@2.1135.1:
+    resolution: {integrity: sha512-g1jcMfWlyYtGamFJ/kPBOCuchl3NfwTF2UwOLTIDN0nJbGm84EAO+c8DlYnaemM8UmKFkdoq4BGdmiNL5nHWwA==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+
   constructs@10.6.0:
     resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==}
 
@@ -88,6 +96,8 @@ snapshots:
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
       '@aws-cdk/cloud-assembly-schema': 54.2.0
       constructs: 10.6.0
+
+  aws-cdk@2.1135.1: {}
 
   constructs@10.6.0: {}
 

--- a/tests/integration/intrinsics-torture-2/verify.sh
+++ b/tests/integration/intrinsics-torture-2/verify.sh
@@ -103,13 +103,11 @@ triage() {
 }
 
 echo "==> Installing fixture deps"
-if [[ ! -d node_modules ]]; then
-  pnpm install --ignore-workspace --prefer-offline
-fi
-# Vendored cdk CLI (issue 1485): the guard re-runs the install when
-# node_modules pre-exists without the cdk bin (stale checkout from before
-# aws-cdk was pinned), and the PATH prepend guarantees `npx cdk` resolves
-# the fixture-local CLI rather than a possibly stale global one.
+# Vendored cdk CLI (issue 1485): guard on the cdk BIN, not on the directory —
+# a node_modules left over from before aws-cdk was pinned exists but has no
+# cdk in it, so a `[ ! -d node_modules ]` test would skip the very install
+# that fixes it. The PATH prepend then guarantees `npx cdk` resolves the
+# fixture-local CLI rather than a possibly stale global one.
 [ -x "node_modules/.bin/cdk" ] || pnpm install --ignore-workspace --prefer-offline
 export PATH="${PWD}/node_modules/.bin:${PATH}"
 

--- a/tests/integration/intrinsics-torture-2/verify.sh
+++ b/tests/integration/intrinsics-torture-2/verify.sh
@@ -106,6 +106,12 @@ echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then
   pnpm install --ignore-workspace --prefer-offline
 fi
+# Vendored cdk CLI (issue 1485): the guard re-runs the install when
+# node_modules pre-exists without the cdk bin (stale checkout from before
+# aws-cdk was pinned), and the PATH prepend guarantees `npx cdk` resolves
+# the fixture-local CLI rather than a possibly stale global one.
+[ -x "node_modules/.bin/cdk" ] || pnpm install --ignore-workspace --prefer-offline
+export PATH="${PWD}/node_modules/.bin:${PATH}"
 
 echo ""
 echo "==> Pre-flight: stale state check"

--- a/tests/unit/scripts/integ-cdk-cli-pins.test.ts
+++ b/tests/unit/scripts/integ-cdk-cli-pins.test.ts
@@ -72,37 +72,76 @@ describe('classifyCdkCliUsage (issue 1485)', () => {
     expect(c.bareInvocations + c.npxInvocations + c.explicitBinInvocations).toBe(0);
   });
 
-  it('detects the canonical PATH prepend and install guard', () => {
+  // Reviewer finding on v1: keyword/wrapper prefixes kept segments out of
+  // command position, so these shapes were silent false negatives.
+  it.each([
+    ['negated condition', 'if ! cdk deploy "${STACK}"; then exit 1; fi'],
+    ['then-branch', 'if true; then cdk deploy "${STACK}"; fi'],
+    ['loop body', 'for s in a b; do cdk deploy "$s"; done'],
+    ['timeout wrapper', 'timeout 600 npx cdk deploy "${STACK}"'],
+    ['quoted env value with space', 'FOO="a b" cdk deploy "${STACK}"'],
+  ])('counts keyword/wrapper-prefixed invocations: %s', (_label, line) => {
+    const c = classifyCdkCliUsage(`${line}\n`);
+    expect(c.bareInvocations + c.npxInvocations).toBe(1);
+  });
+
+  it('detects the canonical PATH prepend, install step, and cdk-bin guard', () => {
     const c = classifyCdkCliUsage(
       '[ -x "${TEST_DIR}/node_modules/.bin/cdk" ] || (cd "${TEST_DIR}" && npm install)\nexport PATH="${TEST_DIR}/node_modules/.bin:${PATH}"\n',
     );
     expect(c.hasPathPrepend).toBe(true);
     expect(c.hasInstallStep).toBe(true);
+    expect(c.hasCdkBinGuard).toBe(true);
+  });
+
+  // Reviewer finding on v1: these signals were matched against
+  // comment-INCLUSIVE text, so a comment mentioning "npm install" (which the
+  // canonical block's own explanation does) satisfied the requirement.
+  it('does not accept install / prepend / guard signals from comments', () => {
+    const c = classifyCdkCliUsage(
+      '# remember to npm install first\n# and export PATH="${TEST_DIR}/node_modules/.bin:${PATH}"\n# guard: [ -x "${TEST_DIR}/node_modules/.bin/cdk" ]\n',
+    );
+    expect(c.hasInstallStep).toBe(false);
+    expect(c.hasPathPrepend).toBe(false);
+    expect(c.hasCdkBinGuard).toBe(false);
   });
 });
 
 describe('checkFixture verdicts (issue 1485)', () => {
   const pinnedPkg = JSON.stringify({ devDependencies: { 'aws-cdk': '^2.1133.0' } });
+  const guardAndInstall = '[ -x "${PWD}/node_modules/.bin/cdk" ] || npm install\n';
 
   it('flags a bare invocation with a pin but no PATH prepend (the incident shape)', () => {
-    const v = checkFixture('npm install\ncdk deploy "${STACK}"\n', pinnedPkg);
+    const v = checkFixture(`${guardAndInstall}cdk deploy "\${STACK}"\n`, pinnedPkg);
     expect(v.violations).toHaveLength(1);
     expect(v.violations[0]).toContain('PATH');
   });
 
   it('flags an npx invocation with no pin at all', () => {
     const v = checkFixture(
-      'pnpm install --ignore-workspace\nexport PATH="${PWD}/node_modules/.bin:${PATH}"\nnpx cdk synth\n',
+      `if [[ ! -x "node_modules/.bin/cdk" ]]; then pnpm install --ignore-workspace; fi\nexport PATH="\${PWD}/node_modules/.bin:\${PATH}"\nnpx cdk synth\n`,
       JSON.stringify({ dependencies: { 'aws-cdk-lib': '^2.169.0' } }),
     );
     expect(v.violations).toHaveLength(1);
     expect(v.violations[0]).toContain('pin');
   });
 
-  it('flags a pinned + prepended fixture with no install step', () => {
-    const v = checkFixture('export PATH="${PWD}/node_modules/.bin:${PATH}"\nnpx cdk deploy X\n', pinnedPkg);
+  it('flags a pinned + prepended fixture with no install step (comment mentions do not count)', () => {
+    const v = checkFixture(
+      '# install deps via npm install before running\n[ -x "node_modules/.bin/cdk" ] || true\nexport PATH="${PWD}/node_modules/.bin:${PATH}"\nnpx cdk deploy X\n',
+      pinnedPkg,
+    );
     expect(v.violations).toHaveLength(1);
     expect(v.violations[0]).toContain('install');
+  });
+
+  it('flags a fixture whose install has no cdk-bin guard', () => {
+    const v = checkFixture(
+      'npm install\nexport PATH="${PWD}/node_modules/.bin:${PATH}"\nnpx cdk deploy X\n',
+      pinnedPkg,
+    );
+    expect(v.violations).toHaveLength(1);
+    expect(v.violations[0]).toContain('-x');
   });
 
   it('accepts the canonical hermetic shape', () => {

--- a/tests/unit/scripts/integ-cdk-cli-pins.test.ts
+++ b/tests/unit/scripts/integ-cdk-cli-pins.test.ts
@@ -30,7 +30,7 @@ function readFixtures() {
     });
 }
 
-describe('classifyCdkCliUsage (issue 1485)', () => {
+describe('classifyCdkCliUsage — invocation shapes (issue 1485)', () => {
   it('sees a bare cdk deploy inside a (cd ... && ...) subshell', () => {
     const c = classifyCdkCliUsage('(cd "${TEST_DIR}" && cdk deploy "${STACK}" --require-approval never)\n');
     expect(c.bareInvocations).toBe(1);
@@ -44,7 +44,7 @@ describe('classifyCdkCliUsage (issue 1485)', () => {
   });
 
   it('sees an env-prefixed npx cdk synth', () => {
-    const c = classifyCdkCliUsage('  CDK_DEBUG=true npx cdk synth --app "node bin/app.ts" 2>/dev/null | grep Fn:: || true\n');
+    const c = classifyCdkCliUsage('  CDK_DEBUG=true npx cdk synth --app "node bin/app.ts" 2>/dev/null || true\n');
     expect(c.npxInvocations).toBe(1);
   });
 
@@ -61,23 +61,13 @@ describe('classifyCdkCliUsage (issue 1485)', () => {
     expect(c.bareInvocations).toBe(1);
   });
 
-  it.each([
-    ['comment line', '# this fixture used to run cdk deploy against the global CLI'],
-    ['echo prose', 'echo "[verify] step 4: cdk deploy parent + nested child"'],
-    ['cdkd is not cdk', 'node "${LOCAL_DIST}" deploy --region us-east-1'],
-    ['string mention inside echo', "echo \"FAIL: this region has been 'cdk bootstrap'ed\" >&2"],
-    ['grep for the word', 'grep -q "cdk deploy" some.log'],
-  ])('does not count prose: %s', (_label, line) => {
-    const c = classifyCdkCliUsage(`${line}\n`);
-    expect(c.bareInvocations + c.npxInvocations + c.explicitBinInvocations).toBe(0);
-  });
-
-  // Reviewer finding on v1: keyword/wrapper prefixes kept segments out of
-  // command position, so these shapes were silent false negatives.
+  // Keyword / wrapper prefixes keep the rest of the segment in command
+  // position; before the round-1 review these were silent false negatives.
   it.each([
     ['negated condition', 'if ! cdk deploy "${STACK}"; then exit 1; fi'],
     ['then-branch', 'if true; then cdk deploy "${STACK}"; fi'],
     ['loop body', 'for s in a b; do cdk deploy "$s"; done'],
+    ['brace group', '(cd "${D}" && { cdk deploy X; })'],
     ['timeout wrapper', 'timeout 600 npx cdk deploy "${STACK}"'],
     ['quoted env value with space', 'FOO="a b" cdk deploy "${STACK}"'],
   ])('counts keyword/wrapper-prefixed invocations: %s', (_label, line) => {
@@ -85,79 +75,167 @@ describe('classifyCdkCliUsage (issue 1485)', () => {
     expect(c.bareInvocations + c.npxInvocations).toBe(1);
   });
 
-  it('detects the canonical PATH prepend, install step, and cdk-bin guard', () => {
+  // Package-runner spellings other than plain `npx`, and a global flag
+  // sitting between `cdk` and its verb.
+  it.each([
+    ['pnpm exec', 'pnpm exec cdk synth'],
+    ['npm exec', 'npm exec cdk deploy X'],
+    ['yarn', 'yarn cdk deploy X'],
+    ['npx with a pinned package', 'npx aws-cdk@2.1135.1 deploy X'],
+    ['npx flag before the package', 'npx --yes cdk deploy X'],
+  ])('counts runner spelling: %s', (_label, line) => {
+    expect(classifyCdkCliUsage(`${line}\n`).npxInvocations).toBe(1);
+  });
+
+  it('counts a global flag placed before the verb', () => {
+    expect(classifyCdkCliUsage('cdk --app "node bin/app.ts" synth\n').bareInvocations).toBe(1);
+  });
+});
+
+describe('classifyCdkCliUsage — prose must never count (issue 1485)', () => {
+  it.each([
+    ['whole-line comment', '# this fixture used to run cdk deploy against the global CLI'],
+    ['trailing comment', 'true # then cdk deploy "${STACK}" by hand'],
+    ['echo prose', 'echo "[verify] step 4: cdk deploy parent + nested child"'],
+    ['echo prose containing a separator', 'echo "[verify] FAIL (exit 1); cdk destroy attempted"'],
+    ['echo prose with backticks', 'echo "run \\`cdk deploy\\` yourself"'],
+    ['grep pattern with an alternation', 'grep -E "a|cdk deploy" out.log'],
+    ['grep pattern with a separator', 'grep -q "foo; cdk deploy" out.log'],
+    ['cdkd is a different binary', 'node "${LOCAL_DIST}" deploy --region us-east-1'],
+    ['cdk-local is a different binary', 'cdk-local invoke MyFn'],
+  ])('does not count: %s', (_label, line) => {
+    const c = classifyCdkCliUsage(`${line}\n`);
+    expect(c.bareInvocations + c.npxInvocations + c.explicitBinInvocations).toBe(0);
+  });
+
+  it('does not count a heredoc body', () => {
+    const c = classifyCdkCliUsage("cat > run.sh <<'EOF'\ncdk deploy MyStack\nnpm install\nEOF\n");
+    expect(c.bareInvocations).toBe(0);
+    expect(c.hasFixtureInstall).toBe(false);
+  });
+
+  // Hermeticity signals are the other half: prose must not SATISFY them
+  // either (the round-1 classifier matched them against comment-inclusive
+  // text, so the canonical block's own explanation passed a gutted fixture).
+  it.each([
+    ['whole-line comments', '# npm install first\n# export PATH="${D}/node_modules/.bin:${PATH}"\n# [ -x "${D}/node_modules/.bin/cdk" ]\n'],
+    ['echo prose', 'echo "run [ -x node_modules/.bin/cdk ], npm install, export PATH=x/node_modules/.bin:y"\n'],
+  ])('does not accept install / prepend / guard signals from %s', (_label, script) => {
+    const c = classifyCdkCliUsage(script);
+    expect(c.hasFixtureInstall).toBe(false);
+    expect(c.hasPathPrepend).toBe(false);
+    expect(c.hasCdkBinGuard).toBe(false);
+  });
+
+  it('does not accept an install named only in a trailing comment', () => {
+    // The guard on this line IS code and legitimately registers; the point is
+    // that the `npm install` after the `#` does not.
+    const c = classifyCdkCliUsage('[ -x node_modules/.bin/cdk ] || true # npm install\n');
+    expect(c.hasCdkBinGuard).toBe(true);
+    expect(c.hasFixtureInstall).toBe(false);
+  });
+});
+
+describe('classifyCdkCliUsage — hermeticity signals (issue 1485)', () => {
+  it('detects the canonical guard + install + prepend block', () => {
     const c = classifyCdkCliUsage(
       '[ -x "${TEST_DIR}/node_modules/.bin/cdk" ] || (cd "${TEST_DIR}" && npm install)\nexport PATH="${TEST_DIR}/node_modules/.bin:${PATH}"\n',
     );
     expect(c.hasPathPrepend).toBe(true);
-    expect(c.hasInstallStep).toBe(true);
+    expect(c.hasFixtureInstall).toBe(true);
+    expect(c.installIsConditional).toBe(true);
     expect(c.hasCdkBinGuard).toBe(true);
   });
 
-  // Reviewer finding on v1: these signals were matched against
-  // comment-INCLUSIVE text, so a comment mentioning "npm install" (which the
-  // canonical block's own explanation does) satisfied the requirement.
-  it('does not accept install / prepend / guard signals from comments', () => {
+  it('detects a nested-quote guard and a variable-held bin directory', () => {
     const c = classifyCdkCliUsage(
-      '# remember to npm install first\n# and export PATH="${TEST_DIR}/node_modules/.bin:${PATH}"\n# guard: [ -x "${TEST_DIR}/node_modules/.bin/cdk" ]\n',
+      'BIN="${TEST_DIR}/node_modules/.bin"\nif [ ! -x "${BIN}/cdk" ]; then npm install; fi\nexport PATH="${BIN}:${PATH}"\n',
     );
-    expect(c.hasInstallStep).toBe(false);
-    expect(c.hasPathPrepend).toBe(false);
-    expect(c.hasCdkBinGuard).toBe(false);
+    expect(c.hasCdkBinGuard).toBe(true);
+    expect(c.hasPathPrepend).toBe(true);
+    expect(c.hasFixtureInstall).toBe(true);
+  });
+
+  it('treats an unconditional install as unconditional', () => {
+    const c = classifyCdkCliUsage('npm install\nexport PATH="${PWD}/node_modules/.bin:${PATH}"\n');
+    expect(c.hasFixtureInstall).toBe(true);
+    expect(c.installIsConditional).toBe(false);
+  });
+
+  it('does not accept a repo-root install as the fixture install', () => {
+    const c = classifyCdkCliUsage('(cd "${REPO_ROOT}" && pnpm install)\n(cd "${REPO_ROOT}" && vp run build)\n');
+    expect(c.hasFixtureInstall).toBe(false);
   });
 });
 
 describe('checkFixture verdicts (issue 1485)', () => {
-  const pinnedPkg = JSON.stringify({ devDependencies: { 'aws-cdk': '^2.1133.0' } });
-  const guardAndInstall = '[ -x "${PWD}/node_modules/.bin/cdk" ] || npm install\n';
+  const pinnedPkg = JSON.stringify({ devDependencies: { 'aws-cdk': '^2.1135.1' } });
+  const guardedInstall = '[ -x "${PWD}/node_modules/.bin/cdk" ] || npm install\n';
+  const prepend = 'export PATH="${PWD}/node_modules/.bin:${PATH}"\n';
 
-  it('flags a bare invocation with a pin but no PATH prepend (the incident shape)', () => {
-    const v = checkFixture(`${guardAndInstall}cdk deploy "\${STACK}"\n`, pinnedPkg);
+  it('flags a guarded install + pin but no PATH prepend (the incident shape)', () => {
+    const v = checkFixture(`${guardedInstall}cdk deploy "\${STACK}"\n`, pinnedPkg);
     expect(v.violations).toHaveLength(1);
     expect(v.violations[0]).toContain('PATH');
   });
 
-  it('flags an npx invocation with no pin at all', () => {
+  it('flags an invocation with no pin at all', () => {
     const v = checkFixture(
-      `if [[ ! -x "node_modules/.bin/cdk" ]]; then pnpm install --ignore-workspace; fi\nexport PATH="\${PWD}/node_modules/.bin:\${PATH}"\nnpx cdk synth\n`,
+      `${guardedInstall}${prepend}npx cdk synth\n`,
       JSON.stringify({ dependencies: { 'aws-cdk-lib': '^2.169.0' } }),
     );
     expect(v.violations).toHaveLength(1);
     expect(v.violations[0]).toContain('pin');
   });
 
-  it('flags a pinned + prepended fixture with no install step (comment mentions do not count)', () => {
+  it.each([['*'], ['latest'], ['x']])('rejects the non-range pin %s', (spec) => {
     const v = checkFixture(
-      '# install deps via npm install before running\n[ -x "node_modules/.bin/cdk" ] || true\nexport PATH="${PWD}/node_modules/.bin:${PATH}"\nnpx cdk deploy X\n',
+      `${guardedInstall}${prepend}npx cdk synth\n`,
+      JSON.stringify({ devDependencies: { 'aws-cdk': spec } }),
+    );
+    expect(v.violations.some((x) => x.includes('pin'))).toBe(true);
+  });
+
+  it('flags a fixture whose only install is the repo-root one', () => {
+    const v = checkFixture(`(cd "\${REPO_ROOT}" && pnpm install)\n${prepend}npx cdk deploy X\n`, pinnedPkg);
+    expect(v.violations).toHaveLength(1);
+    expect(v.violations[0]).toContain('FIXTURE');
+  });
+
+  it('flags a conditional install whose guard does not test the cdk bin', () => {
+    const v = checkFixture(
+      `[ -d node_modules ] || npm install\n${prepend}npx cdk deploy X\n`,
       pinnedPkg,
     );
     expect(v.violations).toHaveLength(1);
-    expect(v.violations[0]).toContain('install');
+    expect(v.violations[0]).toContain('conditional');
   });
 
-  it('flags a fixture whose install has no cdk-bin guard', () => {
-    const v = checkFixture(
-      'npm install\nexport PATH="${PWD}/node_modules/.bin:${PATH}"\nnpx cdk deploy X\n',
-      pinnedPkg,
-    );
-    expect(v.violations).toHaveLength(1);
-    expect(v.violations[0]).toContain('-x');
+  it('accepts an UNCONDITIONAL install with no guard (strictly more hermetic)', () => {
+    const v = checkFixture(`npm install\n${prepend}npx cdk deploy X\n`, pinnedPkg);
+    expect(v.violations).toEqual([]);
   });
 
-  it('accepts the canonical hermetic shape', () => {
-    const v = checkFixture(
-      '[ -x "${PWD}/node_modules/.bin/cdk" ] || npm install\nexport PATH="${PWD}/node_modules/.bin:${PATH}"\nnpx cdk deploy X\n',
-      pinnedPkg,
-    );
+  it('accepts the canonical guarded shape', () => {
+    const v = checkFixture(`${guardedInstall}${prepend}npx cdk deploy X\n`, pinnedPkg);
     expect(v.violations).toEqual([]);
   });
 
   it('accepts an explicit local CDK_BIN without a PATH prepend', () => {
     const v = checkFixture(
       'if [[ ! -x "node_modules/.bin/cdk" ]]; then pnpm install --ignore-workspace; fi\nCDK_BIN="${TEST_DIR}/node_modules/.bin/cdk"\n"${CDK_BIN}" migrate --from-path x.json\n',
-      JSON.stringify({ dependencies: { 'aws-cdk': '2.1128.0' } }),
+      JSON.stringify({ dependencies: { 'aws-cdk': '2.1135.1' } }),
     );
     expect(v.violations).toEqual([]);
+  });
+
+  it('flags a non-local CDK_BIN even when bare/npx invocations are present', () => {
+    const v = checkFixture(
+      `${guardedInstall}${prepend}CDK_BIN="/usr/local/bin/cdk"\nnpx cdk deploy X\n"\${CDK_BIN}" synth\n`,
+      pinnedPkg,
+    );
+    expect(v.violations).toHaveLength(1);
+    expect(v.violations[0]).toContain('CDK_BIN');
   });
 
   it('ignores fixtures that never invoke upstream cdk', () => {
@@ -174,11 +252,15 @@ describe('integ fixture verify.sh cdk CLI pins (issue 1485)', () => {
     expect(fixtures.length).toBeGreaterThan(100);
   });
 
-  // Coverage floors, measured against the 2026-08-10 tree ("A checker must
-  // prove it sees its input", .claude/rules/testing.md). The upstream-cdk
-  // callers: import-nested-stack + the two local-invoke-from-cfn-stack
-  // fixtures (bare), export / import-auto-mode / intrinsics-torture-2 (npx),
-  // migrate-from-bare-cfn-codegen-only (CDK_BIN). If a legitimate refactor
+  // Coverage floors, measured EXACTLY against the 2026-08-10 tree
+  // ("A checker must prove it sees its input", .claude/rules/testing.md).
+  // The invoking set: import-nested-stack + the two local-invoke-from-cfn-stack
+  // fixtures (bare, 7 invocations), export / import-auto-mode /
+  // intrinsics-torture-2 (npx, 5), migrate-from-bare-cfn-codegen-only
+  // (CDK_BIN, 2). Both totals AND per-shape FIXTURE counts are pinned: a
+  // total-only floor lets a within-fixture regression (import-auto-mode's 3
+  // npx dropping to 1) hide, and a per-shape fixture floor stops a dead shape
+  // being masked by new fixtures of another shape. If a legitimate refactor
   // removes one, lower the floor in the same PR with a note — a silent drop
   // to zero is the failure mode this exists for.
   it('parses the known invocation shapes across the tree', () => {
@@ -187,9 +269,12 @@ describe('integ fixture verify.sh cdk CLI pins (issue 1485)', () => {
     const npx = fixtures.reduce((n, f) => n + f.npxInvocations, 0);
     const explicitBin = fixtures.reduce((n, f) => n + f.explicitBinInvocations, 0);
     expect(invokers.length).toBeGreaterThanOrEqual(7);
-    expect(bare).toBeGreaterThanOrEqual(3);
-    expect(npx).toBeGreaterThanOrEqual(3);
-    expect(explicitBin).toBeGreaterThanOrEqual(1);
+    expect(bare).toBeGreaterThanOrEqual(7);
+    expect(npx).toBeGreaterThanOrEqual(5);
+    expect(explicitBin).toBeGreaterThanOrEqual(2);
+    expect(fixtures.filter((f) => f.bareInvocations > 0).length).toBeGreaterThanOrEqual(3);
+    expect(fixtures.filter((f) => f.npxInvocations > 0).length).toBeGreaterThanOrEqual(3);
+    expect(fixtures.filter((f) => f.explicitBinInvocations > 0).length).toBeGreaterThanOrEqual(1);
   });
 
   it('every fixture that invokes the upstream cdk CLI is hermetic about which cdk it gets', () => {

--- a/tests/unit/scripts/integ-cdk-cli-pins.test.ts
+++ b/tests/unit/scripts/integ-cdk-cli-pins.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { classifyCdkCliUsage, checkFixture } from '../../../scripts/check-integ-cdk-cli-pins.js';
+
+/**
+ * Regression guard for issue 1485: fixtures that shell out to the upstream
+ * `cdk` CLI must pin a fixture-local aws-cdk AND make the invocation resolve
+ * it (PATH prepend or explicit node_modules/.bin path). See
+ * `scripts/check-integ-cdk-cli-pins.ts` for the failure class
+ * (schema-version mismatch against a stale global cdk — the
+ * import-nested-stack failure on the 2026-08-10 sweep, and PR 1253's three
+ * fixtures before it).
+ */
+
+const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
+
+function readFixtures() {
+  return readdirSync(INTEG_ROOT, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(INTEG_ROOT, e.name, 'verify.sh')))
+    .map((e) => {
+      const pkgPath = join(INTEG_ROOT, e.name, 'package.json');
+      return {
+        name: e.name,
+        ...checkFixture(
+          readFileSync(join(INTEG_ROOT, e.name, 'verify.sh'), 'utf8'),
+          existsSync(pkgPath) ? readFileSync(pkgPath, 'utf8') : undefined,
+        ),
+      };
+    });
+}
+
+describe('classifyCdkCliUsage (issue 1485)', () => {
+  it('sees a bare cdk deploy inside a (cd ... && ...) subshell', () => {
+    const c = classifyCdkCliUsage('(cd "${TEST_DIR}" && cdk deploy "${STACK}" --require-approval never)\n');
+    expect(c.bareInvocations).toBe(1);
+    expect(c.npxInvocations).toBe(0);
+  });
+
+  it('sees an npx cdk diff inside a command substitution capture', () => {
+    const c = classifyCdkCliUsage('CDK_DIFF_OUT=$(npx cdk diff "${STACK}" --region "${REGION}" 2>&1)\n');
+    expect(c.npxInvocations).toBe(1);
+    expect(c.bareInvocations).toBe(0);
+  });
+
+  it('sees an env-prefixed npx cdk synth', () => {
+    const c = classifyCdkCliUsage('  CDK_DEBUG=true npx cdk synth --app "node bin/app.ts" 2>/dev/null | grep Fn:: || true\n');
+    expect(c.npxInvocations).toBe(1);
+  });
+
+  it('sees a CDK_BIN-style invocation and resolves its local-bin definition', () => {
+    const c = classifyCdkCliUsage(
+      'CDK_BIN="${TEST_DIR}/node_modules/.bin/cdk"\n"${CDK_BIN}" migrate --from-path x.json\n',
+    );
+    expect(c.explicitBinInvocations).toBe(1);
+    expect(c.cdkBinPointsAtLocalBin).toBe(true);
+  });
+
+  it('sees a backslash-continued cdk deploy', () => {
+    const c = classifyCdkCliUsage('(cd "${TEST_DIR}" && cdk deploy "${STACK}" \\\n  --require-approval never)\n');
+    expect(c.bareInvocations).toBe(1);
+  });
+
+  it.each([
+    ['comment line', '# this fixture used to run cdk deploy against the global CLI'],
+    ['echo prose', 'echo "[verify] step 4: cdk deploy parent + nested child"'],
+    ['cdkd is not cdk', 'node "${LOCAL_DIST}" deploy --region us-east-1'],
+    ['string mention inside echo', "echo \"FAIL: this region has been 'cdk bootstrap'ed\" >&2"],
+    ['grep for the word', 'grep -q "cdk deploy" some.log'],
+  ])('does not count prose: %s', (_label, line) => {
+    const c = classifyCdkCliUsage(`${line}\n`);
+    expect(c.bareInvocations + c.npxInvocations + c.explicitBinInvocations).toBe(0);
+  });
+
+  it('detects the canonical PATH prepend and install guard', () => {
+    const c = classifyCdkCliUsage(
+      '[ -x "${TEST_DIR}/node_modules/.bin/cdk" ] || (cd "${TEST_DIR}" && npm install)\nexport PATH="${TEST_DIR}/node_modules/.bin:${PATH}"\n',
+    );
+    expect(c.hasPathPrepend).toBe(true);
+    expect(c.hasInstallStep).toBe(true);
+  });
+});
+
+describe('checkFixture verdicts (issue 1485)', () => {
+  const pinnedPkg = JSON.stringify({ devDependencies: { 'aws-cdk': '^2.1133.0' } });
+
+  it('flags a bare invocation with a pin but no PATH prepend (the incident shape)', () => {
+    const v = checkFixture('npm install\ncdk deploy "${STACK}"\n', pinnedPkg);
+    expect(v.violations).toHaveLength(1);
+    expect(v.violations[0]).toContain('PATH');
+  });
+
+  it('flags an npx invocation with no pin at all', () => {
+    const v = checkFixture(
+      'pnpm install --ignore-workspace\nexport PATH="${PWD}/node_modules/.bin:${PATH}"\nnpx cdk synth\n',
+      JSON.stringify({ dependencies: { 'aws-cdk-lib': '^2.169.0' } }),
+    );
+    expect(v.violations).toHaveLength(1);
+    expect(v.violations[0]).toContain('pin');
+  });
+
+  it('flags a pinned + prepended fixture with no install step', () => {
+    const v = checkFixture('export PATH="${PWD}/node_modules/.bin:${PATH}"\nnpx cdk deploy X\n', pinnedPkg);
+    expect(v.violations).toHaveLength(1);
+    expect(v.violations[0]).toContain('install');
+  });
+
+  it('accepts the canonical hermetic shape', () => {
+    const v = checkFixture(
+      '[ -x "${PWD}/node_modules/.bin/cdk" ] || npm install\nexport PATH="${PWD}/node_modules/.bin:${PATH}"\nnpx cdk deploy X\n',
+      pinnedPkg,
+    );
+    expect(v.violations).toEqual([]);
+  });
+
+  it('accepts an explicit local CDK_BIN without a PATH prepend', () => {
+    const v = checkFixture(
+      'if [[ ! -x "node_modules/.bin/cdk" ]]; then pnpm install --ignore-workspace; fi\nCDK_BIN="${TEST_DIR}/node_modules/.bin/cdk"\n"${CDK_BIN}" migrate --from-path x.json\n',
+      JSON.stringify({ dependencies: { 'aws-cdk': '2.1128.0' } }),
+    );
+    expect(v.violations).toEqual([]);
+  });
+
+  it('ignores fixtures that never invoke upstream cdk', () => {
+    const v = checkFixture('node "${LOCAL_DIST}" deploy --region us-east-1\n', undefined);
+    expect(v.invokesUpstreamCdk).toBe(false);
+    expect(v.violations).toEqual([]);
+  });
+});
+
+describe('integ fixture verify.sh cdk CLI pins (issue 1485)', () => {
+  const fixtures = readFixtures();
+
+  it('finds the fixture tree', () => {
+    expect(fixtures.length).toBeGreaterThan(100);
+  });
+
+  // Coverage floors, measured against the 2026-08-10 tree ("A checker must
+  // prove it sees its input", .claude/rules/testing.md). The upstream-cdk
+  // callers: import-nested-stack + the two local-invoke-from-cfn-stack
+  // fixtures (bare), export / import-auto-mode / intrinsics-torture-2 (npx),
+  // migrate-from-bare-cfn-codegen-only (CDK_BIN). If a legitimate refactor
+  // removes one, lower the floor in the same PR with a note — a silent drop
+  // to zero is the failure mode this exists for.
+  it('parses the known invocation shapes across the tree', () => {
+    const invokers = fixtures.filter((f) => f.invokesUpstreamCdk);
+    const bare = fixtures.reduce((n, f) => n + f.bareInvocations, 0);
+    const npx = fixtures.reduce((n, f) => n + f.npxInvocations, 0);
+    const explicitBin = fixtures.reduce((n, f) => n + f.explicitBinInvocations, 0);
+    expect(invokers.length).toBeGreaterThanOrEqual(7);
+    expect(bare).toBeGreaterThanOrEqual(3);
+    expect(npx).toBeGreaterThanOrEqual(3);
+    expect(explicitBin).toBeGreaterThanOrEqual(1);
+  });
+
+  it('every fixture that invokes the upstream cdk CLI is hermetic about which cdk it gets', () => {
+    const offenders = fixtures
+      .filter((f) => f.violations.length > 0)
+      .map((f) => ({ name: f.name, violations: f.violations }));
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixtures that shell out to the upstream `cdk` CLI were inconsistent about which `cdk` they got. `import-nested-stack` failed the 2026-08-10 staleness sweep with a cloud-assembly schema-version mismatch because its `aws-cdk` pin was dead weight — its verify.sh explicitly ran (and logged) the machine's global `cdk`. Same failure PR 1253 fixed for three fixtures individually; this PR fixes the class and adds the lint that stops it re-opening one fixture at a time.

## Scope correction vs the issue table

The issue's 15-row table was built with a comment-blind grep — the same trap the lint now avoids. Re-derived with command-position matching, only **7 fixtures actually execute** the upstream cdk CLI: the 3 already-hermetic ones (`local-invoke-from-cfn-stack`, `local-invoke-from-cfn-stack-multi-stack`, `migrate-from-bare-cfn-codegen-only` via explicit `CDK_BIN`) and 4 non-hermetic ones fixed here. The other table rows (`bootstrap-free-region`, `dynamodb-gsi-update`, `export-nested-stack`, `lambda-layer-version-update`, etc.) only mention `cdk` in comments or echo prose, or run `cdkd` — nothing to fix there.

## Changes

- `import-nested-stack`: replace the "using global cdk" step with the canonical install-guard + PATH-prepend block; bump `aws-cdk` `^2.1112.0` → `^2.1133.0`.
- `export`: add the guard + prepend after its existing `vp install` step (covers a stale node_modules from before the pin); bump `aws-cdk` to `^2.1133.0`.
- `import-auto-mode`: add the canonical block (its `npx cdk` had no local install at all, so npx fell through).
- `intrinsics-torture-2`: add the missing `aws-cdk` pin (`^2.1133.0`) + guard + prepend.
- New lint `tests/unit/scripts/integ-cdk-cli-pins.test.ts` (classifier `scripts/check-integ-cdk-cli-pins.ts`): any fixture invoking the upstream cdk CLI (bare / `npx` / `CDK_BIN`-style, command-position only) must pin `aws-cdk`, have an install step, and resolve the local CLI (PATH prepend or explicit local bin).
- Docs: new mandatory-convention sections in `.claude/rules/testing.md` and `docs/testing.md`.

## Checker discipline (per `.claude/rules/testing.md`)

- **Sees its input**: coverage floors pin ≥7 invoking fixtures, ≥3 bare, ≥3 npx, ≥1 explicit-bin; the detected set was reconciled against an independent non-comment grep (exactly the 7 named above).
- **Fails against real code**: deleting the PATH prepend from the real `import-auto-mode/verify.sh` makes the lint exit non-zero naming `import-auto-mode`; restored after the probe.
- Live-checked the canonical block: in `import-auto-mode/`, the guard `npm install`s and `command -v cdk` then resolves the fixture-local `node_modules/.bin/cdk` at 2.1135.1 — the exact version bar the sweep failure demanded.

## Verification

- `vp check --fix` + `vp run check` (CI parity): 0 errors.
- `vp run typecheck:test`, `vp run build`: pass.
- `vp run test`: 9380 passed (incl. the 20 new lint tests).
- `bash -n` on all four edited verify.sh files.

Closes #1485

## Update: reviewer-found gaps closed (second commit)

An independent code review of the first version found three ways a non-hermetic fixture could still pass the lint. All three are fixed here:

1. **Comment-blind signals.** `hasInstallStep` / `hasPathPrepend` matched comment-inclusive text, so the canonical block's own explanatory comment (which names the install command) satisfied the requirement even with the real guard deleted. Both now match non-comment lines only — demonstrated by a regression test.
2. **Keyword / wrapper prefixes were false negatives.** `if ! cdk deploy`, `then cdk deploy`, `do cdk deploy`, `timeout 600 npx cdk deploy`, and a quoted env value containing a space all classified as zero invocations. `stripToCommandWord` peels those before matching.
3. **Directory-blindness.** The install / prepend regexes cannot statically track a cwd, so an install in the wrong directory passed. The lint now also requires the `-x .../node_modules/.bin/cdk` guard, which names the fixture-relative path in every canonical shape; the residual bound is recorded as a code comment rather than silently accepted.

Also: `CDK_VERBS` gained `gc` / `rollback` / `init` / `drift` / `notices` / `metadata`, and `export/verify.sh`'s now-subsumed `! -d node_modules` branch is gone. Seven new tests (27 total), and the real-code rejection probe was re-run against the updated classifier — deleting the guard line from the real `import-auto-mode/verify.sh` fails the lint naming that fixture.

Two nits from the review were deliberately not taken: `echo "... && cdk deploy X"` counting as an invocation (a loud false positive, not a silent pass) and a `PATH` export placed after the last invocation (would need ordering analysis the regex layer cannot do). Both are recorded here rather than fixed.

## Update 2: 3-axis review round — the classifier now reads code, not prose

The spec / code / test reviewers independently confirmed the scope correction (both re-derived exactly the same 7 invoking fixtures, and neither found an invoking fixture left unfixed), and found real defects in the lint. All are addressed:

**Correctness of the scanner.** Round 1 matched textually over the whole script, which cut both ways: prose COUNTED as an invocation (`echo "FAIL (exit 1); cdk destroy attempted"`, a `grep -E "a|cdk deploy"` pattern, a heredoc body) and prose SATISFIED the hermeticity signals (a trailing `# npm install`, an echo naming the canonical block). The scanner now strips heredoc bodies and comments quote-aware, then splits each line into command-position segments with a quote-aware walk and skips prose-carrying command words.

**Verdict logic, where review showed it was wrong.**
- An unconditional `npm install` no longer requires the `-x` guard — it is strictly more hermetic than the guarded form, and requiring it would have failed a correct new fixture with red CI.
- The install requirement is anchored to the fixture. The repo-root `(cd "${REPO_ROOT}" && pnpm install)` that 222 of 224 verify.sh files carry used to satisfy it, making that verdict unfireable.
- A conditional install must guard on the cdk **bin**, not the directory (`[ -d node_modules ]` skips the install on a stale node_modules that predates the pin).
- A `CDK_BIN` pointing outside the fixture is flagged even when a PATH prepend exists — an absolute path is resolved directly, so the prepend does not redeem it.
- `"*"` / `"latest"` no longer count as a pin.

**Detection gaps closed:** nested-quote and variable-held bin dirs (`BIN="${TEST_DIR}/node_modules/.bin"`), brace groups, `pnpm exec` / `npm exec` / `yarn` / `npx aws-cdk@X` runners, and a global flag between `cdk` and its verb.

**Spec drift fixed:** pins were one release below what the incident demanded — bumped `^2.1133.0` → `^2.1135.1` (cloud-assembly schema 54, which intrinsics-torture-2's `aws-cdk-lib@2.259.0` already emits), and the two tracked fixture lockfiles were regenerated so a `CI=true` install cannot hit `ERR_PNPM_OUTDATED_LOCKFILE`. `import-nested-stack`'s version echo now captures into variables so a missing cdk trips `set -e` instead of printing `using ()`.

**Checker discipline, re-done for the rewrite:** 49 tests (from 27), with per-shape FIXTURE floors alongside the totals so a within-fixture regression cannot hide under an aggregate. All six verdicts were probed against the real tree by mutating each of the 7 invoking fixtures in memory — drop the pin (7/7 rejected), pin → `"*"` (7/7), neutralize the fixture install (7/7), delete the PATH prepend (6/6 that have one), weaken the guard to `-d node_modules` (7/7), point `CDK_BIN` at `/usr/local/bin/cdk` (1/1 that has one). No verdict is untested against real code.

**Won't-do (recorded):** `export-nested-stack` / `dynamodb-gsi-update` / `lambda-layer-version-update` still carry unused `aws-cdk` pins. They invoke `cdkd`, not upstream `cdk`, so the pins are inert and invisible to the lint; removing them is unrelated churn. Signal ordering (a PATH prepend placed after the last invocation) is also not checked — it would need flow analysis the regex layer cannot do, and no fixture has that shape.

## Live-test (the resolution switch, against the real machine)

With `node_modules` removed from `import-nested-stack`, the exact block from its verify.sh was run:

```
global cdk before: /Users/goto/.vite-plus/bin/cdk 2.1129.0
[verify] step 2 ok: using .../tests/integration/import-nested-stack/node_modules/.bin/cdk (2.1135.1)
```

The machine's global CLI is 2.1129.0 — below the 2.1135.1 the sweep failure demanded — and the block switches resolution to the pinned 2.1135.1. That is the defect and the fix, demonstrated end to end.

Honest note: the schema-mismatch FAILURE itself did not reproduce on demand — `cdk synth` under the 2.1129.0 global CLI exited 0 for `intrinsics-torture-2` (aws-cdk-lib 2.259.0, manifest schema 54.0.0), so the mismatch is evidently not triggered by every CLI/lib pair below the bar. The recorded reproduction remains the 2026-08-10 sweep's `import-nested-stack` failure quoted in the issue. What this PR changes — which CLI runs — is directly verified above.

## Residual reviewer items

Fixed in this PR: comment/prose matching in both directions, keyword and wrapper prefixes, runner spellings, global flag before the verb, nested-quote and variable-held bin dirs, unconditional-install false positive, repo-root-install vacuity, guard-on-bin vs guard-on-dir, non-local `CDK_BIN` with a PATH prepend, `"*"` / `"latest"` pins, coverage floors plus per-shape fixture floors, the `import-nested-stack` version echo (`set -e` now fires on a missing cdk), the pin bump to `^2.1135.1`, both stale fixture lockfiles, and `intrinsics-torture-2`'s now-subsumed `[ ! -d node_modules ]` branch.

Won't-do (recorded, no action needed):
- **Signal ordering is not checked** — a PATH prepend placed after the last invocation would pass. Needs flow analysis the regex layer cannot do; no fixture has that shape.
- **The guard detects absence, not staleness** — a pre-existing `node_modules` holding an older cdk skips the install, so the version bumps are inert on a machine that ran the fixture before. Detecting that means parsing installed versions in a shell guard; deleting `node_modules` is the documented recovery.
- **Unused `aws-cdk` pins in three non-invoking fixtures** (`export-nested-stack`, `dynamodb-gsi-update`, `lambda-layer-version-update`) — they invoke `cdkd`, not upstream `cdk`, so the pins are inert and invisible to the lint; removing them is unrelated churn.
- **`package-lock.json` from `npm install`** — verified already covered by `tests/integration/.gitignore`, so it cannot dirty the tree.

Retrospective rule recorded in memory: a checker that matches script text fails in BOTH directions — prose counting as an occurrence AND prose satisfying a required signal — and the second half survives coverage floors and rejection probes, because a compliant tree flags nothing either way.
