### PR TITLE
fix(provisioning): re-frame a Cloud Control FAILED 403 originating inside the AWS-managed resource handler

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -247,7 +247,7 @@ secrets-rotation-schedule	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 
 serverless-api	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 servicediscovery	2026-08-01T09:42:37Z	PASS	106	verify.sh	0801 regression sweep; ServiceAttributes coverage ok, 0 orphans
 servicediscovery-namespaces	2026-08-01T09:36:05Z	PASS	108	verify.sh	0801 regression sweep; Http+PublicDns namespaces ok, 0 orphans
-ses-identity	2026-08-10T05:50:57Z	FAIL	171	verify.sh	0810 P2 sweep b9; FAILED twice: Cloud Control AWS::SES::EmailIdentity UPDATE returns SesV2 403 invalid-token on Phase2 (MailFrom+reputation). NOT a cdkd bug - direct sesv2 put-email-identity-mail-from-attributes with the same creds succeeds. Upstream CC handler issue; 0 orphans
+ses-identity	2026-08-10T10:50:49Z	PASS	180	verify.sh	upstream SES CC 403 resolved; all 3 phases clean (issue #1468)
 sg-circular-dependency	2026-07-26T18:49:34Z	PASS	51	verify.sh	0727b sweep-b6 staleness re-run (rc=0); account clean
 sns-event-source	2026-08-01T10:07:21Z	PASS	59	verify.sh	0801 regression sweep; e2e delivery ok, log groups swept, 0 orphans
 sns-inline-subscription	2026-07-27T11:04:52Z	PASS	53	verify.sh	issue #1267 SNS topic update wrap; 3 del 0 err

--- a/src/provisioning/cloud-control-provider.ts
+++ b/src/provisioning/cloud-control-provider.ts
@@ -155,6 +155,46 @@ export function isNotFoundMessage(message: string): boolean {
   );
 }
 
+/**
+ * When a Cloud Control operation FAILS with an authorization error whose
+ * Java-SDK trailer names a service OTHER than Cloud Control itself
+ * ("... (Service: SesV2, Status Code: 403, Request ID: ...)"), the rejection
+ * happened inside the AWS-managed resource handler's own downstream call —
+ * cdkd's credentials already authenticated to Cloud Control to start the
+ * operation, so the caller's local credential setup is not the culprit. The
+ * raw StatusMessage reads like a local credential problem and sends users off
+ * to debug their own keys (issue #1468: the AWS::SES::EmailIdentity UPDATE
+ * handler's SesV2 call 403'd reproducibly while the exact same SesV2
+ * operations succeeded when invoked directly with the same credentials).
+ * Returns a re-framing hint to append to the failure message, or '' when the
+ * shape does not match.
+ *
+ * Wording constraint: the hint is appended to an error message that
+ * downstream matchers test against (isNotFoundMessage above, the
+ * retryable-error message table in src/deployment/retryable-errors.ts), so it
+ * must not introduce a "not found" / "does not exist" / "no such" match nor
+ * any retryable-pattern substring. Pinned by a unit test.
+ */
+export function handlerAuthFailureHint(statusMessage: string): string {
+  const match = /\(Service:\s*([A-Za-z0-9._-]+)[,;]\s*Status Code:\s*403[,;)]/i.exec(statusMessage);
+  if (!match) {
+    return '';
+  }
+  const service = match[1] ?? '';
+  // A 403 from Cloud Control itself IS a caller-credential problem — only a
+  // downstream service's refusal gets re-framed.
+  if (/cloudcontrol/i.test(service)) {
+    return '';
+  }
+  return (
+    ` [hint: this 403 was returned by ${service} to the AWS-managed resource handler running the ` +
+    `operation, not to cdkd directly — these credentials already passed Cloud Control's own auth ` +
+    `to start it. If the equivalent ${service} API call succeeds with the same credentials, the ` +
+    `resource handler itself is failing (an upstream AWS issue worth retrying later), not your ` +
+    `local credential setup.]`
+  );
+}
+
 export class CloudControlProvider implements ResourceProvider {
   private cloudControlClient: CloudControlClient;
   private logger = getLogger().child('CloudControlProvider');
@@ -784,15 +824,17 @@ export class CloudControlProvider implements ResourceProvider {
         case 'SUCCESS':
           return progressEvent;
 
-        case 'FAILED':
+        case 'FAILED': {
+          const failureMessage = progressEvent.StatusMessage || 'Unknown error';
           throw new CloudControlOperationFailedError(
-            `${operation} failed for ${logicalId}: ${progressEvent.StatusMessage || 'Unknown error'}`,
+            `${operation} failed for ${logicalId}: ${failureMessage}${handlerAuthFailureHint(failureMessage)}`,
             progressEvent.TypeName || 'Unknown',
             logicalId,
             progressEvent.Identifier,
             progressEvent.ErrorCode,
             operation
           );
+        }
 
         case 'CANCEL_COMPLETE':
           // NOTE: a CREATE cancelled after materialization (external

--- a/tests/unit/provisioning/cloud-control-provider.test.ts
+++ b/tests/unit/provisioning/cloud-control-provider.test.ts
@@ -102,6 +102,7 @@ import {
   CloudControlProvider,
   CloudControlOperationFailedError,
   isNotFoundMessage,
+  handlerAuthFailureHint,
 } from '../../../src/provisioning/cloud-control-provider.js';
 import { clearWriteOnlyPropertiesCache } from '../../../src/provisioning/write-only-properties.js';
 import { isRetryableTransientError } from '../../../src/deployment/retryable-errors.js';
@@ -259,6 +260,105 @@ describe('isNotFoundMessage (issue #1252)', () => {
     'no permission to delete; resource found in another account',
   ])('does not match %s', (message) => {
     expect(isNotFoundMessage(message)).toBe(false);
+  });
+});
+
+describe('handlerAuthFailureHint (issue #1468)', () => {
+  // The exact wire shape observed on the AWS::SES::EmailIdentity UPDATE
+  // regression: the handler's own SesV2 call 403s while the caller's
+  // credentials are fine.
+  const SES_403 =
+    'The security token included in the request is invalid ' +
+    '(Service: SesV2, Status Code: 403, Request ID: af4fdbec-78b3-4700-ae43-00b28e51c5ae)';
+
+  it('re-frames a downstream-service 403 naming the service', () => {
+    const hint = handlerAuthFailureHint(SES_403);
+    expect(hint).toContain('SesV2');
+    expect(hint).toContain('AWS-managed resource handler');
+    expect(hint).toContain('upstream AWS issue');
+  });
+
+  it('is silent for a non-403 status in the trailer', () => {
+    expect(
+      handlerAuthFailureHint('No Deployment Group found for name: x (Service: CodeDeploy, Status Code: 400)')
+    ).toBe('');
+  });
+
+  it('is silent for a 403 from Cloud Control itself (a real caller-credential problem)', () => {
+    expect(
+      handlerAuthFailureHint(
+        'User is not authorized (Service: CloudControlApi, Status Code: 403, Request ID: abc)'
+      )
+    ).toBe('');
+  });
+
+  it('is silent for a message with no Java-SDK service trailer (JS-SDK local credential failure)', () => {
+    expect(handlerAuthFailureHint('The security token included in the request is invalid.')).toBe(
+      ''
+    );
+  });
+
+  it('the appended hint does not trip the isNotFoundMessage matcher', () => {
+    const full = `UPDATE failed for Identity2D60E2CC: ${SES_403}${handlerAuthFailureHint(SES_403)}`;
+    expect(isNotFoundMessage(full)).toBe(false);
+  });
+
+  it('the appended hint does not make the message retryable when the base message was not', () => {
+    // The SES wire shape lacks the period before "(Service:" that the IAM
+    // propagation pattern anchors on, so it is not retryable — and the hint
+    // must not change that.
+    const baseMessage = `UPDATE failed for Id: ${SES_403}`;
+    const hintedMessage = `${baseMessage}${handlerAuthFailureHint(SES_403)}`;
+    expect(isRetryableTransientError(new Error(hintedMessage), hintedMessage)).toBe(
+      isRetryableTransientError(new Error(baseMessage), baseMessage)
+    );
+  });
+});
+
+describe('CloudControlProvider UPDATE FAILED with a downstream 403 (issue #1468)', () => {
+  let provider: CloudControlProvider;
+
+  beforeEach(() => {
+    mockCloudControlSend.mockReset();
+    mockCloudFormationSend.mockReset();
+    mockCloudControlConfigRegion.mockReset();
+    mockCloudControlConfigRegion.mockResolvedValue('us-east-1');
+    clearWriteOnlyPropertiesCache();
+    // DescribeType unavailable -> write-only resolution degrades to empty set.
+    mockCloudFormationSend.mockRejectedValue(new Error('AccessDenied'));
+    provider = new CloudControlProvider();
+  });
+
+  it('appends the handler-origin hint to the thrown failure message', async () => {
+    mockCloudControlSend.mockImplementation((cmd: { constructor: { name: string } }) => {
+      const name = cmd.constructor.name;
+      if (name === 'UpdateResourceCommand') {
+        return Promise.resolve({ ProgressEvent: { RequestToken: 'tok-upd' } });
+      }
+      if (name === 'GetResourceRequestStatusCommand') {
+        return Promise.resolve({
+          ProgressEvent: {
+            OperationStatus: 'FAILED',
+            TypeName: 'AWS::SES::EmailIdentity',
+            ErrorCode: 'AccessDenied',
+            StatusMessage:
+              'The security token included in the request is invalid ' +
+              '(Service: SesV2, Status Code: 403, Request ID: af4fdbec)',
+          },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    await expect(
+      provider.update(
+        'Identity2D60E2CC',
+        'cdkd-ses.example.com',
+        'AWS::SES::EmailIdentity',
+        { EmailIdentity: 'cdkd-ses.example.com', MailFromAttributes: { MailFromDomain: 'mail.x' } },
+        { EmailIdentity: 'cdkd-ses.example.com' }
+      )
+    ).rejects.toThrow(/AWS-managed resource handler.*SesV2|SesV2.*AWS-managed resource handler/s);
   });
 });
 


### PR DESCRIPTION
## Summary

Item 2 of #1468: when a Cloud Control operation FAILs with a Java-SDK auth
trailer naming a downstream service (`... (Service: SesV2, Status Code: 403,
Request ID: ...)`), the raw StatusMessage reads like a local credential
problem. But cdkd's credentials already authenticated to Cloud Control to
start the operation — the 403 came from the AWS-managed resource handler's
own downstream call. `waitForOperation`'s FAILED arm now appends a re-framing
hint via the new `handlerAuthFailureHint()`:

- fires only on a `(Service: <X>, Status Code: 403, ...)` trailer where `<X>`
  is not Cloud Control itself (a CC-origin 403 IS a caller-credential problem
  and stays un-hinted);
- hint wording is pinned by tests to not trip `isNotFoundMessage` (the
  delete-idempotency matcher) nor the retryable-error message table.

## Upstream status (items 1 & 3 of the issue)

Re-probed 2026-08-10 ~10:45 UTC: the `AWS::SES::EmailIdentity` UPDATE 403 has
**resolved upstream**. A direct `cloudcontrol update-resource` on a scratch
identity returned SUCCESS, and the full `ses-identity` integ then passed
end-to-end (create + both Phase-2 UPDATEs + destroy, 0 errors / 0 orphans) —
the committed ledger row flips FAIL -> PASS in this PR.

## Test plan

- 7 new unit tests (`handlerAuthFailureHint` shapes + an end-to-end UPDATE
  FAILED throw assertion + matcher-interaction fences); full suite 528 files /
  9367 tests green.
- Live: `/run-integ ses-identity` PASS (180s), exercising the touched
  `waitForOperation` path against real AWS; hint string verified present in
  the built `dist/` chunk.

## Retrospective

No new rule proposals: the two frictions hit this lane (markgate-set chained
with the gated commit; `mise exec` shell-snapshot 127) are both covered by
existing memory rules.

Closes #1468
