### PR TITLE
fix(glue): preserve out-of-band-authored StorageDescriptor members across unrelated table updates

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -58,7 +58,7 @@ cross-region-state-bucket	2026-08-01T09:42:37Z	PASS	29	verify.sh	0801 regression
 cross-stack-references	2026-08-08T17:48:34Z	PASS	25	standard	marker re-flip after review coercion fix; deploy+destroy clean
 custom-resource-getatt-data	2026-08-10T06:18:10Z	PASS	59	verify.sh	0810 P2 sweep b12; CR Data GetAtt -> dependent prop, 0 orph
 custom-resource-provider	2026-08-10T06:18:10Z	PASS	256	standard	0810 P2 sweep b12; 0 err 0 orph
-data-analytics	2026-08-10T09:11:46Z	PASS	88	verify.sh	#1463 CreateContext (glue-provider pre-flight now context-aware); 10 deleted 0 errors, VersionId precondition re-proved
+data-analytics	2026-08-10T11:12:36Z	PASS	87	verify.sh	#1479 SD-subtree merge verified (out-of-band members survive; template members intact)
 data-pipeline	2026-08-10T05:19:05Z	PASS	48	standard	0810 P2 sweep b6; 7 del 0 err, 0 orph
 deep-getatt-chains	2026-08-01T10:07:21Z	PASS	53	verify.sh	0801 regression sweep; SDK+CC chain ok, 0 orphans
 deletion-ordering-complex	2026-07-26T20:00:52Z	PASS	187	verify.sh	0727b sweep-b13 staleness re-run (rc=0); account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -58,7 +58,7 @@ cross-region-state-bucket	2026-08-01T09:42:37Z	PASS	29	verify.sh	0801 regression
 cross-stack-references	2026-08-08T17:48:34Z	PASS	25	standard	marker re-flip after review coercion fix; deploy+destroy clean
 custom-resource-getatt-data	2026-08-10T06:18:10Z	PASS	59	verify.sh	0810 P2 sweep b12; CR Data GetAtt -> dependent prop, 0 orph
 custom-resource-provider	2026-08-10T06:18:10Z	PASS	256	standard	0810 P2 sweep b12; 0 err 0 orph
-data-analytics	2026-08-10T11:12:36Z	PASS	87	verify.sh	#1479 SD-subtree merge verified (out-of-band members survive; template members intact)
+data-analytics	2026-08-10T11:31:18Z	PASS	87	verify.sh	#1479 SD-subtree merge re-verified after review fixes (OR-gate bag semantics)
 data-pipeline	2026-08-10T05:19:05Z	PASS	48	standard	0810 P2 sweep b6; 7 del 0 err, 0 orph
 deep-getatt-chains	2026-08-01T10:07:21Z	PASS	53	verify.sh	0801 regression sweep; SDK+CC chain ok, 0 orphans
 deletion-ordering-complex	2026-07-26T20:00:52Z	PASS	187	verify.sh	0727b sweep-b13 staleness re-run (rc=0); account clean

--- a/docs/supported-resources.md
+++ b/docs/supported-resources.md
@@ -365,8 +365,13 @@ an Iceberg table's catalog `Columns` from table metadata — all of which an
 unrelated update used to wipe (`Columns` -> `[]`, `SerdeInfo` gone; probed
 live 2026-08-10, recorded on the issue). The preservation rule is the same
 "present in neither template side" test, applied per SD *member* (with the
-two nested `Parameters` bags merged per key). A template that never declared
-`StorageDescriptor` at all carries the whole live block forward. Scope is
+two nested `Parameters` bags merged per key — including when a whole bag is
+removed from the template, which keeps the top-level #1461 semantics: your
+keys are removed, AWS-authored keys survive). `SerdeInfo` is structural, not
+a bag: removing the whole block from the template removes it on AWS, since a
+partial serde carrying only crawler-authored entries would be incoherent. A
+template that never declared `StorageDescriptor` at all carries the whole
+live block forward. Scope is
 deliberately the `StorageDescriptor` subtree only — the crawler also authors
 `PartitionKeys` / `Owner`, which remain template-authoritative for now.
 

--- a/docs/supported-resources.md
+++ b/docs/supported-resources.md
@@ -357,9 +357,23 @@ external table pointing at Iceberg data files, with the deploy reporting
 success. The same exposure covered a crawler's `classification`, `EXTERNAL`,
 `comment`, and Lake Formation markers.
 
+Since issue [#1479](https://github.com/go-to-k/cdkd/issues/1479) the same
+exposure is closed one level down, for the `StorageDescriptor` subtree: a Glue
+crawler authors `Columns`, `InputFormat` / `OutputFormat`, `SerdeInfo` (and
+its `Parameters` bag) and `StorageDescriptor.Parameters`, and Glue re-derives
+an Iceberg table's catalog `Columns` from table metadata — all of which an
+unrelated update used to wipe (`Columns` -> `[]`, `SerdeInfo` gone; probed
+live 2026-08-10, recorded on the issue). The preservation rule is the same
+"present in neither template side" test, applied per SD *member* (with the
+two nested `Parameters` bags merged per key). A template that never declared
+`StorageDescriptor` at all carries the whole live block forward. Scope is
+deliberately the `StorageDescriptor` subtree only — the crawler also authors
+`PartitionKeys` / `Owner`, which remain template-authoritative for now.
+
 cdkd now reads the live table / database (`glue:GetTable` /
 `glue:GetDatabase`) immediately before the update and merges those
-AWS-authored entries back into the payload. Four consequences worth knowing:
+AWS-authored entries back into the payload. Four consequences worth knowing
+(they apply to the `StorageDescriptor` members the same way):
 
 - **Your removals still work.** A parameter you delete from your template is
   still deleted on AWS. The merge only restores keys present in *neither* the
@@ -404,7 +418,11 @@ fixture's UPDATE phase re-asserts both Iceberg markers after an unrelated
 `Description` edit (having first pinned that the update was in-place, via an
 unchanged `Table.CreateTime`), asserts a user-removed parameter on the sibling
 plain table is still gone, and runs the same removal-plus-preservation pair
-against the database. It also pins the concurrency guard's *premise*: AWS
+against the database. For the #1479 subtree it injects crawler-equivalent
+out-of-band members (`StorageDescriptor.Parameters` and
+`SerdeInfo.Parameters` entries) via a raw `UpdateTable`, asserts they survive
+the unrelated Phase-2 deploy, and that template-declared SD members
+(`SerializationLibrary`, `Columns`) stay template-authored. It also pins the concurrency guard's *premise*: AWS
 documents `VersionId` only as "the version ID at which to update the table
 contents", so the fixture advances a table's version out of band and requires
 AWS to refuse a replay of the stale one. If AWS ever starts ignoring it, that

--- a/src/provisioning/providers/glue-provider.ts
+++ b/src/provisioning/providers/glue-provider.ts
@@ -592,9 +592,10 @@ export class GlueProvider implements ResourceProvider {
         message +=
           live.versionId !== undefined
             ? ` cdkd sent the version it read (${live.versionId}) as a precondition and AWS ` +
-              `rejected the write, rather than let it put back the AWS-managed Parameters read ` +
-              `a moment earlier — which for an Apache Iceberg table would have pinned it to an ` +
-              `older metadata_location (an effective snapshot rollback).`
+              `rejected the write, rather than let it put back the AWS-managed Parameters and ` +
+              `StorageDescriptor members read a moment earlier — which for an Apache Iceberg ` +
+              `table would have pinned it to an older metadata_location (an effective snapshot ` +
+              `rollback).`
             : ` AWS returned no VersionId on the pre-update read, so cdkd could not attach a ` +
               `precondition; AWS rejected the write on its own.`;
         message += ` Re-run the deploy to pick up the current values.`;
@@ -800,12 +801,17 @@ export class GlueProvider implements ResourceProvider {
       sdOut[member] = liveValue;
     }
 
-    // The two nested BAGS get the per-KEY rule when the template DECLARES the
-    // containing member — when it does not, the member loop above already
-    // decided the whole bag (carried forward or user-removed).
+    // The two nested BAGS get the per-KEY rule whenever EITHER template side
+    // declares the containing member — when neither does, the member loop
+    // above already carried the whole bag forward. Gating on the desired side
+    // alone would make removing the whole bag wipe its AWS-authored keys, the
+    // exact action the top-level #1461 helper handles per key (desired absent
+    // + previous declared -> user keys removed, AWS-authored keys survive);
+    // the OR keeps the two levels on one semantic. SerdeInfo is deliberately
+    // different — see its gate below.
     const desiredSd = asRecord(desiredSdRaw);
     const previousSd = asRecord(previousSdRaw);
-    if (desiredKeys.has('Parameters')) {
+    if (desiredKeys.has('Parameters') || previousKeys.has('Parameters')) {
       this.preserveAwsManagedParameters(
         sdOut as { Parameters?: Record<string, string> | undefined },
         desiredSd?.['Parameters'],
@@ -813,6 +819,12 @@ export class GlueProvider implements ResourceProvider {
         liveSd.Parameters
       );
     }
+    // SerdeInfo is STRUCTURAL, not a bag: its members (SerializationLibrary,
+    // Name) are user-authored in every template shape, so removing the whole
+    // block from the template is a whole-member removal the member loop above
+    // honors — resurrecting a partial SerdeInfo carrying only the crawler's
+    // Parameters would leave an incoherent serde. Hence the desired-only gate
+    // here, unlike the Parameters bags.
     if (desiredKeys.has('SerdeInfo') && liveSd.SerdeInfo) {
       const desiredSerde = asRecord(desiredSd?.['SerdeInfo']);
       const previousSerde = asRecord(previousSd?.['SerdeInfo']);
@@ -828,7 +840,9 @@ export class GlueProvider implements ResourceProvider {
         if (desiredSerdeKeys.has(member) || previousSerdeKeys.has(member)) continue;
         serdeOut[member] = liveValue;
       }
-      if (desiredSerdeKeys.has('Parameters')) {
+      // Same OR gate as StorageDescriptor.Parameters — the inner bag keeps
+      // per-key semantics even when the user removes the whole bag.
+      if (desiredSerdeKeys.has('Parameters') || previousSerdeKeys.has('Parameters')) {
         this.preserveAwsManagedParameters(
           serdeOut as { Parameters?: Record<string, string> | undefined },
           desiredSerde?.['Parameters'],
@@ -847,8 +861,10 @@ export class GlueProvider implements ResourceProvider {
   }
 
   /**
-   * The live table state {@link preserveAwsManagedParameters} needs: its
-   * current `Parameters` plus the `VersionId` that pins them.
+   * The live table state the two merges need: its current `Parameters` (for
+   * {@link preserveAwsManagedParameters}), its `StorageDescriptor` (for
+   * {@link preserveAwsManagedStorageDescriptor}, issue #1479), plus the
+   * `VersionId` that pins both.
    *
    * A missing table returns empty rather than throwing: `UpdateTable` is about
    * to surface the real, more actionable error. Any OTHER failure is fatal by
@@ -2662,9 +2678,12 @@ function parameterKeySet(value: unknown): Set<string> {
 
 /**
  * Narrow an unknown template / state value to a plain object, or `undefined`.
- * A malformed side (string / array / unresolved intrinsic) yields `undefined`
- * and therefore an empty key set — the tolerant treatment `parameterKeySet`
- * already gives bags, extended to the StorageDescriptor merge's containers.
+ * A malformed side (string / array / null) yields `undefined` and therefore
+ * an empty key set — the tolerant treatment `parameterKeySet` already gives
+ * bags, extended to the StorageDescriptor merge's containers. (An unresolved
+ * intrinsic is itself a plain object, so it passes through and contributes
+ * its `Fn::*`/`Ref` key — harmless here, since providers only ever see
+ * resolved values.)
  */
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {

--- a/src/provisioning/providers/glue-provider.ts
+++ b/src/provisioning/providers/glue-provider.ts
@@ -548,6 +548,12 @@ export class GlueProvider implements ResourceProvider {
         (previousProperties?.['TableInput'] as Record<string, unknown> | undefined)?.['Parameters'],
         live.parameters
       );
+      this.preserveAwsManagedStorageDescriptor(
+        builtTableInput,
+        tableInput,
+        previousProperties?.['TableInput'],
+        live.storageDescriptor
+      );
 
       await this.getClient().send(
         new UpdateTableCommand({
@@ -717,6 +723,130 @@ export class GlueProvider implements ResourceProvider {
   }
 
   /**
+   * Read-merge-write for out-of-band-authored `TableInput.StorageDescriptor`
+   * members (issue #1479) — the subtree sibling of
+   * {@link preserveAwsManagedParameters}, applied per SD MEMBER, with the two
+   * nested bags (`StorageDescriptor.Parameters`, `SerdeInfo.Parameters`)
+   * getting the same per-KEY rule one level down.
+   *
+   * Live probes (2026-08-10, us-east-1 — recorded on issue #1479) established
+   * WHO authors what, which is why this is per-member rather than a blanket
+   * merge:
+   *
+   * - A USER-authored `EXTERNAL_TABLE`: re-sending the template verbatim
+   *   reads back identical — the service itself authors only scalar defaults
+   *   (`Compressed: false`, `NumberOfBuckets: 0`, ...). Full-replace is
+   *   CORRECT for template-declared members, and `drift --revert` depends on
+   *   it to clear console-side edits.
+   * - A CRAWLER-populated table: the crawler authors `Columns`,
+   *   `InputFormat` / `OutputFormat`, `SerdeInfo` (incl. its `Parameters`
+   *   bag), and `StorageDescriptor.Parameters`; an UpdateTable restating only
+   *   a minimal template wiped ALL of them (`Columns` -> `[]`, `SerdeInfo`
+   *   gone) while reporting success.
+   * - An ICEBERG table: an UpdateTable omitting `Columns` was ACCEPTED and
+   *   wiped the catalog schema to `[]` (Glue re-derives Iceberg columns from
+   *   table metadata, so the catalog copy is metadata-authored between
+   *   engine commits).
+   *
+   * The preservation key is the SAME "present in NEITHER template side" test
+   * as {@link preserveAwsManagedParameters}, per member:
+   *
+   * | member in desired | member in previous | outcome                            |
+   * | ----------------- | ------------------ | ---------------------------------- |
+   * | yes               | (either)           | template wins                      |
+   * | no                | yes                | the USER REMOVED it -> stays removed |
+   * | no                | no                 | out-of-band authored -> carried forward from live |
+   *
+   * A template that never declared `StorageDescriptor` on EITHER side (a
+   * crawler-managed table adopted into a minimal template) carries the whole
+   * live block forward. Deliberately scoped to the `StorageDescriptor`
+   * subtree per issue #1479 — the crawler also authors `PartitionKeys` /
+   * `Owner`, but widening beyond the issue's member set is a separate
+   * decision (recorded there).
+   *
+   * TOCTOU: the write rides the same unconditional `VersionId` precondition
+   * as the Parameters merge (see {@link readLiveTableState}), so a concurrent
+   * out-of-band write fails the update loudly instead of being clobbered.
+   */
+  private preserveAwsManagedStorageDescriptor(
+    built: TableInput,
+    desiredTableInput: Record<string, unknown>,
+    previousTableInput: unknown,
+    liveSd: StorageDescriptor | undefined
+  ): void {
+    if (!liveSd || Object.keys(liveSd).length === 0) return;
+
+    const desiredSdRaw = desiredTableInput['StorageDescriptor'];
+    const previousSdRaw = asRecord(previousTableInput)?.['StorageDescriptor'];
+
+    // Neither template side ever declared the block -> it is entirely
+    // out-of-band authored (crawler / Iceberg metadata); carry it forward
+    // whole. `undefined` (not key-set emptiness) is the declaration test, so
+    // a declared-but-empty `StorageDescriptor: {}` takes the per-member path.
+    if (desiredSdRaw === undefined && previousSdRaw === undefined) {
+      built.StorageDescriptor = liveSd;
+      return;
+    }
+
+    const desiredKeys = parameterKeySet(desiredSdRaw);
+    const previousKeys = parameterKeySet(previousSdRaw);
+    const sdOut: Record<string, unknown> = {
+      ...((built.StorageDescriptor as Record<string, unknown> | undefined) ?? {}),
+    };
+
+    for (const [member, liveValue] of Object.entries(liveSd as Record<string, unknown>)) {
+      if (liveValue === undefined) continue;
+      if (desiredKeys.has(member) || previousKeys.has(member)) continue;
+      sdOut[member] = liveValue;
+    }
+
+    // The two nested BAGS get the per-KEY rule when the template DECLARES the
+    // containing member — when it does not, the member loop above already
+    // decided the whole bag (carried forward or user-removed).
+    const desiredSd = asRecord(desiredSdRaw);
+    const previousSd = asRecord(previousSdRaw);
+    if (desiredKeys.has('Parameters')) {
+      this.preserveAwsManagedParameters(
+        sdOut as { Parameters?: Record<string, string> | undefined },
+        desiredSd?.['Parameters'],
+        previousSd?.['Parameters'],
+        liveSd.Parameters
+      );
+    }
+    if (desiredKeys.has('SerdeInfo') && liveSd.SerdeInfo) {
+      const desiredSerde = asRecord(desiredSd?.['SerdeInfo']);
+      const previousSerde = asRecord(previousSd?.['SerdeInfo']);
+      const desiredSerdeKeys = parameterKeySet(desiredSerde);
+      const previousSerdeKeys = parameterKeySet(previousSerde);
+      const serdeOut: Record<string, unknown> = {
+        ...((sdOut['SerdeInfo'] as Record<string, unknown> | undefined) ?? {}),
+      };
+      for (const [member, liveValue] of Object.entries(
+        liveSd.SerdeInfo as Record<string, unknown>
+      )) {
+        if (liveValue === undefined) continue;
+        if (desiredSerdeKeys.has(member) || previousSerdeKeys.has(member)) continue;
+        serdeOut[member] = liveValue;
+      }
+      if (desiredSerdeKeys.has('Parameters')) {
+        this.preserveAwsManagedParameters(
+          serdeOut as { Parameters?: Record<string, string> | undefined },
+          desiredSerde?.['Parameters'],
+          previousSerde?.['Parameters'],
+          liveSd.SerdeInfo.Parameters
+        );
+      }
+      if (Object.keys(serdeOut).length > 0) {
+        sdOut['SerdeInfo'] = serdeOut;
+      }
+    }
+
+    if (Object.keys(sdOut).length > 0) {
+      built.StorageDescriptor = sdOut as StorageDescriptor;
+    }
+  }
+
+  /**
    * The live table state {@link preserveAwsManagedParameters} needs: its
    * current `Parameters` plus the `VersionId` that pins them.
    *
@@ -765,7 +895,11 @@ export class GlueProvider implements ResourceProvider {
     databaseName: string,
     tableName: string,
     catalogId: string | undefined
-  ): Promise<{ parameters: Record<string, string> | undefined; versionId: string | undefined }> {
+  ): Promise<{
+    parameters: Record<string, string> | undefined;
+    storageDescriptor: StorageDescriptor | undefined;
+    versionId: string | undefined;
+  }> {
     try {
       const resp = await this.getClient().send(
         new GetTableCommand({
@@ -774,10 +908,14 @@ export class GlueProvider implements ResourceProvider {
           Name: tableName,
         })
       );
-      return { parameters: resp.Table?.Parameters, versionId: resp.Table?.VersionId };
+      return {
+        parameters: resp.Table?.Parameters,
+        storageDescriptor: resp.Table?.StorageDescriptor,
+        versionId: resp.Table?.VersionId,
+      };
     } catch (error) {
       if (error instanceof EntityNotFoundException) {
-        return { parameters: undefined, versionId: undefined };
+        return { parameters: undefined, storageDescriptor: undefined, versionId: undefined };
       }
       throw new ProvisioningError(
         preUpdateReadFailureMessage('Table', 'glue:GetTable', logicalId, error),
@@ -2520,6 +2658,19 @@ function parameterKeySet(value: unknown): Set<string> {
     return new Set<string>();
   }
   return new Set(Object.keys(value as Record<string, unknown>));
+}
+
+/**
+ * Narrow an unknown template / state value to a plain object, or `undefined`.
+ * A malformed side (string / array / unresolved intrinsic) yields `undefined`
+ * and therefore an empty key set — the tolerant treatment `parameterKeySet`
+ * already gives bags, extended to the StorageDescriptor merge's containers.
+ */
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
 }
 
 /**

--- a/tests/integration/data-analytics/verify.sh
+++ b/tests/integration/data-analytics/verify.sh
@@ -29,6 +29,13 @@
 # template DROPPED is still removed -- the mirror-image regression a naive
 # "restore anything absent from the desired side" merge would introduce.
 #
+# Since issue #1479 it ALSO covers the StorageDescriptor subtree one level
+# down: out-of-band SD members (a crawler's `StorageDescriptor.Parameters`
+# bag, a `SerdeInfo.Parameters` entry -- injected via a raw UpdateTable, which
+# is indistinguishable to cdkd from a crawler write) must survive the same
+# unrelated Phase-2 update, while template-declared SD members (SerdeInfo's
+# SerializationLibrary, Columns) stay template-authored.
+#
 # Also asserts the destroy path cleans up.
 #
 # Required env vars:
@@ -288,6 +295,36 @@ if [ "$(db_query 'Database.Parameters.out_of_band_marker')" != "must-survive" ];
 fi
 echo "    OK: out_of_band_marker injected"
 
+# --- Simulate crawler-authored StorageDescriptor members (#1479) -------
+# A Glue crawler writes `StorageDescriptor.Parameters` (sizeKey / recordCount
+# / UPDATED_BY_CRAWLER ...) and `SerdeInfo.Parameters` entries the template
+# never declares. Injecting them via a raw UpdateTable is indistinguishable to
+# cdkd from a crawler write: present in NEITHER the desired nor the previous
+# template side, which is the exact merge branch #1479 adds for the SD
+# subtree. Same jq keep-everything rebuild as the database injection above --
+# whitelisting members would itself cause the wholesale-replace data loss
+# under test.
+echo "==> Injecting out-of-band (crawler-equivalent) StorageDescriptor members onto '${EVENTS_TABLE_NAME}' (#1479)"
+EVENTS_LIVE_JSON="$(aws glue get-table --database-name "${DB_NAME}" --name "${EVENTS_TABLE_NAME}" --region "${REGION}" --query 'Table' --output json)"
+EVENTS_INJECT_INPUT="$(printf '%s' "${EVENTS_LIVE_JSON}" | jq -c '
+  del(.DatabaseName, .CreateTime, .UpdateTime, .LastAccessTime, .CreatedBy,
+      .IsRegisteredWithLakeFormation, .CatalogId, .VersionId,
+      .IsMultiDialectView, .IsMaterializedView)
+  | .StorageDescriptor.Parameters = ((.StorageDescriptor.Parameters // {}) + {"UPDATED_BY_CRAWLER": "cdkd-1479-sim"})
+  | .StorageDescriptor.SerdeInfo.Parameters = ((.StorageDescriptor.SerdeInfo.Parameters // {}) + {"crawler.added": "yes"})
+  | with_entries(select(.value != null))')"
+aws glue update-table --database-name "${DB_NAME}" --region "${REGION}" \
+  --table-input "${EVENTS_INJECT_INPUT}" >/dev/null
+if [ "$(table_query "${EVENTS_TABLE_NAME}" 'Table.StorageDescriptor.Parameters.UPDATED_BY_CRAWLER')" != "cdkd-1479-sim" ]; then
+  echo "FAIL: the out-of-band StorageDescriptor.Parameters injection did not take" >&2
+  exit 1
+fi
+if [ "$(table_query "${EVENTS_TABLE_NAME}" 'Table.StorageDescriptor.SerdeInfo.Parameters."crawler.added"')" != "yes" ]; then
+  echo "FAIL: the out-of-band SerdeInfo.Parameters injection did not take" >&2
+  exit 1
+fi
+echo "    OK: crawler-equivalent SD members injected"
+
 # --- Capture the pre-update identity of the Iceberg table -------------
 # Asserted unchanged after phase 2. Without it the phase-2 assertions would
 # also pass on a REPLACEMENT (delete + create), which would legitimately carry
@@ -350,6 +387,34 @@ if [ "${EVENTS_CLASSIFICATION}" != "json" ]; then
   exit 1
 fi
 echo "    OK: user-removed events parameter is gone, kept one passed through"
+
+# --- The #1479 assertions: SD-subtree out-of-band members survived ------
+# Phase 2 restated the events table's template SD (Location / Columns /
+# formats / SerdeInfo.SerializationLibrary) with NO mention of the injected
+# members. Pre-#1479, UpdateTable's wholesale TableInput replace erased both.
+SD_CRAWLER_MARKER="$(table_query "${EVENTS_TABLE_NAME}" 'Table.StorageDescriptor.Parameters.UPDATED_BY_CRAWLER')"
+if [ "${SD_CRAWLER_MARKER}" != "cdkd-1479-sim" ]; then
+  echo "FAIL: after UPDATE: StorageDescriptor.Parameters.UPDATED_BY_CRAWLER is '${SD_CRAWLER_MARKER}', expected 'cdkd-1479-sim' (the #1479 SD-subtree merge is NOT closed)" >&2
+  exit 1
+fi
+SERDE_CRAWLER_MARKER="$(table_query "${EVENTS_TABLE_NAME}" 'Table.StorageDescriptor.SerdeInfo.Parameters."crawler.added"')"
+if [ "${SERDE_CRAWLER_MARKER}" != "yes" ]; then
+  echo "FAIL: after UPDATE: SerdeInfo.Parameters.\"crawler.added\" is '${SERDE_CRAWLER_MARKER}', expected 'yes' (the #1479 SerdeInfo bag merge is NOT closed)" >&2
+  exit 1
+fi
+# Template-declared SD members must stay TEMPLATE-authored -- the merge is
+# per-member, not a blanket restore (drift --revert depends on this).
+EVENTS_SERDE_LIB="$(table_query "${EVENTS_TABLE_NAME}" 'Table.StorageDescriptor.SerdeInfo.SerializationLibrary')"
+if [ "${EVENTS_SERDE_LIB}" != "org.openx.data.jsonserde.JsonSerDe" ]; then
+  echo "FAIL: after UPDATE: SerdeInfo.SerializationLibrary is '${EVENTS_SERDE_LIB}', expected the template value (the merge must not clobber template-declared members)" >&2
+  exit 1
+fi
+EVENTS_COLUMN_COUNT="$(table_query "${EVENTS_TABLE_NAME}" 'length(Table.StorageDescriptor.Columns)')"
+if [ "${EVENTS_COLUMN_COUNT}" != "3" ]; then
+  echo "FAIL: after UPDATE: events Columns count is '${EVENTS_COLUMN_COUNT}', expected 3 (template-declared Columns must round-trip)" >&2
+  exit 1
+fi
+echo "    OK: crawler-equivalent SD members survived the unrelated update; template-declared SD members intact (#1479)"
 
 # --- The DATABASE half of #1461 (UpdateDatabase, same full-replace bag) ---
 DB_MARKER="$(db_query 'Database.Parameters.out_of_band_marker')"
@@ -468,4 +533,4 @@ assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after des
 echo "    OK: state file is gone"
 
 echo ""
-echo "==> data-analytics test passed (Iceberg backfill #609 + AWS-managed Parameters survive UPDATE #1461 + clean destroy)"
+echo "==> data-analytics test passed (Iceberg backfill #609 + AWS-managed Parameters survive UPDATE #1461 + out-of-band SD members survive UPDATE #1479 + clean destroy)"

--- a/tests/unit/provisioning/glue-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/glue-provider-roundtrip.test.ts
@@ -1455,3 +1455,293 @@ describe('GlueProvider — AWS-managed Parameters preservation (#1461)', () => {
     expect('CatalogId' in input).toBe(false);
   });
 });
+
+// ─── #1479: out-of-band-authored StorageDescriptor members must survive ──
+//
+// Live probes (2026-08-10, recorded on the issue) showed a Glue crawler
+// authors Columns / InputFormat / OutputFormat / SerdeInfo (incl. its
+// Parameters bag) / StorageDescriptor.Parameters, and Glue re-derives an
+// Iceberg table's catalog Columns from table metadata — while UpdateTable is
+// a full replace, so an update restating only the template wiped all of them
+// (Columns -> [], SerdeInfo gone) and reported success. The merge applies the
+// #1461 "present in NEITHER template side" rule per SD member, with the two
+// nested bags getting the per-key rule.
+describe('GlueProvider — out-of-band StorageDescriptor preservation (#1479)', () => {
+  let provider: GlueProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new GlueProvider();
+  });
+
+  /** Queue the pre-update `GetTable` readback (full Table), then the UpdateTable reply. */
+  const mockLiveTableFull = (table: Record<string, unknown>): void => {
+    mockSend.mockResolvedValueOnce({ Table: { Name: 'mytbl', VersionId: '3', ...table } });
+    mockSend.mockResolvedValueOnce({});
+  };
+
+  const sentTableInput = (): Record<string, unknown> => {
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof UpdateTableCommand);
+    expect(call).toBeDefined();
+    return (call![0].input as { TableInput: Record<string, unknown> }).TableInput;
+  };
+
+  const CRAWLER_SD = {
+    Columns: [
+      { Name: 'id', Type: 'bigint' },
+      { Name: 'name', Type: 'string' },
+    ],
+    Location: 's3://b/crawl/',
+    InputFormat: 'org.apache.hadoop.mapred.TextInputFormat',
+    OutputFormat: 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
+    SerdeInfo: {
+      SerializationLibrary: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
+      Parameters: { 'field.delim': ',' },
+    },
+    Parameters: { UPDATED_BY_CRAWLER: 'my-crawler', recordCount: '3' },
+  };
+
+  it('crawler-authored SD members survive an unrelated update that declares only Location', async () => {
+    mockLiveTableFull({ StorageDescriptor: CRAWLER_SD });
+
+    const templateSide = (description: string) => ({
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        Description: description,
+        StorageDescriptor: { Location: 's3://b/crawl/' },
+      },
+    });
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      templateSide('v2'),
+      templateSide('v1')
+    );
+
+    const sd = sentTableInput().StorageDescriptor as Record<string, unknown>;
+    expect(sd.Location).toBe('s3://b/crawl/');
+    expect(sd.Columns).toStrictEqual(CRAWLER_SD.Columns);
+    expect(sd.InputFormat).toBe(CRAWLER_SD.InputFormat);
+    expect(sd.OutputFormat).toBe(CRAWLER_SD.OutputFormat);
+    expect(sd.SerdeInfo).toStrictEqual(CRAWLER_SD.SerdeInfo);
+    expect(sd.Parameters).toStrictEqual(CRAWLER_SD.Parameters);
+  });
+
+  it('a template that never declared StorageDescriptor carries the WHOLE live block forward', async () => {
+    mockLiveTableFull({ StorageDescriptor: CRAWLER_SD });
+
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      { DatabaseName: 'mydb', TableInput: { Name: 'mytbl', Description: 'v2' } },
+      { DatabaseName: 'mydb', TableInput: { Name: 'mytbl', Description: 'v1' } }
+    );
+
+    expect(sentTableInput().StorageDescriptor).toStrictEqual(CRAWLER_SD);
+  });
+
+  it('the Iceberg headline case: catalog Columns the template never declared survive', async () => {
+    // Glue derives an Iceberg table's catalog Columns from table metadata;
+    // the raw full-replace wiped them to [] (probed live on the issue).
+    mockLiveTableFull({
+      StorageDescriptor: {
+        Columns: [{ Name: 'id', Type: 'int' }],
+        Location: 's3://b/iceberg_t/',
+      },
+      Parameters: { table_type: 'ICEBERG', metadata_location: 's3://b/iceberg_t/metadata/0.json' },
+    });
+
+    const templateSide = (description: string) => ({
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        Description: description,
+        TableType: 'EXTERNAL_TABLE',
+        StorageDescriptor: { Location: 's3://b/iceberg_t/' },
+      },
+    });
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      templateSide('v2'),
+      templateSide('v1')
+    );
+
+    const sent = sentTableInput();
+    const sd = sent.StorageDescriptor as Record<string, unknown>;
+    expect(sd.Columns).toStrictEqual([{ Name: 'id', Type: 'int' }]);
+    // The #1461 half still holds alongside the SD merge.
+    expect(sent.Parameters).toStrictEqual({
+      table_type: 'ICEBERG',
+      metadata_location: 's3://b/iceberg_t/metadata/0.json',
+    });
+  });
+
+  it('an SD member the USER removed stays removed (previous declared it, desired does not)', async () => {
+    mockLiveTableFull({
+      StorageDescriptor: {
+        Columns: [{ Name: 'id', Type: 'int' }],
+        Location: 's3://b/t/',
+      },
+    });
+
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      {
+        DatabaseName: 'mydb',
+        TableInput: { Name: 'mytbl', StorageDescriptor: { Location: 's3://b/t/' } },
+      },
+      {
+        DatabaseName: 'mydb',
+        TableInput: {
+          Name: 'mytbl',
+          StorageDescriptor: {
+            Location: 's3://b/t/',
+            Columns: [{ Name: 'id', Type: 'int' }],
+          },
+        },
+      }
+    );
+
+    expect('Columns' in (sentTableInput().StorageDescriptor as Record<string, unknown>)).toBe(
+      false
+    );
+  });
+
+  it('drift --revert still clears a console-side change to a template-declared member', async () => {
+    // Live Columns diverge from the template (console edit); the template
+    // DECLARES Columns, so the template value must win — a blanket merge here
+    // would make drift --revert a no-op, the exact trap the issue warns about.
+    mockLiveTableFull({
+      StorageDescriptor: {
+        Columns: [{ Name: 'added_in_console', Type: 'string' }],
+        Location: 's3://b/t/',
+      },
+    });
+
+    const templateSide = () => ({
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        StorageDescriptor: {
+          Location: 's3://b/t/',
+          Columns: [{ Name: 'id', Type: 'int' }],
+        },
+      },
+    });
+    await provider.update('L', TABLE_PHYSICAL_ID, 'AWS::Glue::Table', templateSide(), templateSide());
+
+    expect((sentTableInput().StorageDescriptor as Record<string, unknown>).Columns).toStrictEqual([
+      { Name: 'id', Type: 'int' },
+    ]);
+  });
+
+  it('SD.Parameters gets the per-KEY bag rule when the template declares the bag', async () => {
+    mockLiveTableFull({
+      StorageDescriptor: {
+        Location: 's3://b/t/',
+        Parameters: { UPDATED_BY_CRAWLER: 'my-crawler', user_key: 'v1', removed_key: 'x' },
+      },
+    });
+
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      {
+        DatabaseName: 'mydb',
+        TableInput: {
+          Name: 'mytbl',
+          StorageDescriptor: { Location: 's3://b/t/', Parameters: { user_key: 'v2' } },
+        },
+      },
+      {
+        DatabaseName: 'mydb',
+        TableInput: {
+          Name: 'mytbl',
+          StorageDescriptor: {
+            Location: 's3://b/t/',
+            Parameters: { user_key: 'v1', removed_key: 'x' },
+          },
+        },
+      }
+    );
+
+    expect((sentTableInput().StorageDescriptor as Record<string, unknown>).Parameters).toStrictEqual(
+      {
+        UPDATED_BY_CRAWLER: 'my-crawler', // authored by neither side -> preserved
+        user_key: 'v2', // template wins
+        // removed_key: user removed it -> stays removed
+      }
+    );
+  });
+
+  it('SerdeInfo merges per member, with its Parameters bag per key', async () => {
+    mockLiveTableFull({
+      StorageDescriptor: {
+        Location: 's3://b/t/',
+        SerdeInfo: {
+          SerializationLibrary: 'org.live.Serde',
+          Parameters: { 'field.delim': ',', 'crawler.added': 'yes' },
+        },
+      },
+    });
+
+    const templateSide = (lib: string) => ({
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        StorageDescriptor: {
+          Location: 's3://b/t/',
+          SerdeInfo: {
+            SerializationLibrary: lib,
+            Parameters: { 'field.delim': ',' },
+          },
+        },
+      },
+    });
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      templateSide('org.user.SerdeV2'),
+      templateSide('org.user.SerdeV1')
+    );
+
+    const serde = (sentTableInput().StorageDescriptor as Record<string, unknown>)
+      .SerdeInfo as Record<string, unknown>;
+    expect(serde.SerializationLibrary).toBe('org.user.SerdeV2'); // template wins
+    expect(serde.Parameters).toStrictEqual({
+      'field.delim': ',', // template-declared key, template value
+      'crawler.added': 'yes', // authored by neither side -> preserved
+    });
+  });
+
+  it('a live table with no StorageDescriptor leaves the payload untouched', async () => {
+    mockLiveTableFull({});
+
+    const templateSide = (description: string) => ({
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        Description: description,
+        StorageDescriptor: { Location: 's3://b/t/' },
+      },
+    });
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      templateSide('v2'),
+      templateSide('v1')
+    );
+
+    expect(sentTableInput().StorageDescriptor).toStrictEqual({ Location: 's3://b/t/' });
+  });
+});

--- a/tests/unit/provisioning/glue-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/glue-provider-roundtrip.test.ts
@@ -1744,4 +1744,195 @@ describe('GlueProvider — out-of-band StorageDescriptor preservation (#1479)', 
 
     expect(sentTableInput().StorageDescriptor).toStrictEqual({ Location: 's3://b/t/' });
   });
+
+  it('a whole SD.Parameters bag the user removed keeps its AWS-authored keys (per-key, like #1461)', async () => {
+    // Removing the whole bag while keeping StorageDescriptor is the same user
+    // action the top-level #1461 helper handles per key: user keys removed,
+    // AWS-authored keys survive. A desired-side-only gate would wipe the
+    // crawler keys here — the review-caught divergence this test pins.
+    mockLiveTableFull({
+      StorageDescriptor: {
+        Location: 's3://b/t/',
+        Parameters: { UPDATED_BY_CRAWLER: 'my-crawler', user_key: 'v1' },
+      },
+    });
+
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      {
+        DatabaseName: 'mydb',
+        TableInput: { Name: 'mytbl', StorageDescriptor: { Location: 's3://b/t/' } },
+      },
+      {
+        DatabaseName: 'mydb',
+        TableInput: {
+          Name: 'mytbl',
+          StorageDescriptor: { Location: 's3://b/t/', Parameters: { user_key: 'v1' } },
+        },
+      }
+    );
+
+    expect((sentTableInput().StorageDescriptor as Record<string, unknown>).Parameters).toStrictEqual(
+      { UPDATED_BY_CRAWLER: 'my-crawler' }
+    );
+  });
+
+  it('a whole SerdeInfo.Parameters bag the user removed keeps its AWS-authored keys', async () => {
+    mockLiveTableFull({
+      StorageDescriptor: {
+        Location: 's3://b/t/',
+        SerdeInfo: {
+          SerializationLibrary: 'org.user.Serde',
+          Parameters: { 'crawler.added': 'yes', 'user.key': 'v1' },
+        },
+      },
+    });
+
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      {
+        DatabaseName: 'mydb',
+        TableInput: {
+          Name: 'mytbl',
+          StorageDescriptor: {
+            Location: 's3://b/t/',
+            SerdeInfo: { SerializationLibrary: 'org.user.Serde' },
+          },
+        },
+      },
+      {
+        DatabaseName: 'mydb',
+        TableInput: {
+          Name: 'mytbl',
+          StorageDescriptor: {
+            Location: 's3://b/t/',
+            SerdeInfo: {
+              SerializationLibrary: 'org.user.Serde',
+              Parameters: { 'user.key': 'v1' },
+            },
+          },
+        },
+      }
+    );
+
+    const serde = (sentTableInput().StorageDescriptor as Record<string, unknown>)
+      .SerdeInfo as Record<string, unknown>;
+    expect(serde.Parameters).toStrictEqual({ 'crawler.added': 'yes' });
+  });
+
+  it('a whole SerdeInfo block the user removed stays removed (structural member, not a bag)', async () => {
+    // Unlike the Parameters bags, SerdeInfo's members are user-authored in
+    // every template shape — resurrecting a partial SerdeInfo carrying only
+    // crawler keys would leave an incoherent serde, so whole-member removal
+    // is honored.
+    mockLiveTableFull({
+      StorageDescriptor: {
+        Location: 's3://b/t/',
+        SerdeInfo: {
+          SerializationLibrary: 'org.user.Serde',
+          Parameters: { 'crawler.added': 'yes' },
+        },
+      },
+    });
+
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      {
+        DatabaseName: 'mydb',
+        TableInput: { Name: 'mytbl', StorageDescriptor: { Location: 's3://b/t/' } },
+      },
+      {
+        DatabaseName: 'mydb',
+        TableInput: {
+          Name: 'mytbl',
+          StorageDescriptor: {
+            Location: 's3://b/t/',
+            SerdeInfo: { SerializationLibrary: 'org.user.Serde' },
+          },
+        },
+      }
+    );
+
+    expect(
+      'SerdeInfo' in (sentTableInput().StorageDescriptor as Record<string, unknown>)
+    ).toBe(false);
+  });
+
+  it('a whole StorageDescriptor the user removed: authored members go, out-of-band members survive', async () => {
+    // The per-member rule extends to the block's own removal: members the
+    // user declared before are removed; members no template side ever
+    // authored (a crawler's SD.Parameters bag) are still carried.
+    mockLiveTableFull({
+      StorageDescriptor: {
+        Location: 's3://b/t/',
+        Columns: [{ Name: 'id', Type: 'int' }],
+        Parameters: { UPDATED_BY_CRAWLER: 'my-crawler' },
+      },
+    });
+
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      { DatabaseName: 'mydb', TableInput: { Name: 'mytbl' } },
+      {
+        DatabaseName: 'mydb',
+        TableInput: {
+          Name: 'mytbl',
+          StorageDescriptor: {
+            Location: 's3://b/t/',
+            Columns: [{ Name: 'id', Type: 'int' }],
+          },
+        },
+      }
+    );
+
+    expect(sentTableInput().StorageDescriptor).toStrictEqual({
+      Parameters: { UPDATED_BY_CRAWLER: 'my-crawler' },
+    });
+  });
+
+  it('a declared-but-empty StorageDescriptor {} on both sides still carries live members', async () => {
+    // Pins the declaration test: `undefined`, not key-set emptiness. An empty
+    // declared block means "I author nothing here", so every live member is
+    // out-of-band and carried.
+    mockLiveTableFull({ StorageDescriptor: CRAWLER_SD });
+
+    const templateSide = () => ({
+      DatabaseName: 'mydb',
+      TableInput: { Name: 'mytbl', StorageDescriptor: {} },
+    });
+    await provider.update('L', TABLE_PHYSICAL_ID, 'AWS::Glue::Table', templateSide(), templateSide());
+
+    expect(sentTableInput().StorageDescriptor).toStrictEqual(CRAWLER_SD);
+  });
+
+  it('a malformed (string-valued) desired StorageDescriptor does not crash the merge', async () => {
+    // asRecord tolerance: a malformed container contributes no keys, so live
+    // members are carried and AWS surfaces the real validation error.
+    mockLiveTableFull({
+      StorageDescriptor: { Location: 's3://b/t/', Columns: [{ Name: 'id', Type: 'int' }] },
+    });
+
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      {
+        DatabaseName: 'mydb',
+        TableInput: { Name: 'mytbl', StorageDescriptor: 'not-an-object' },
+      },
+      { DatabaseName: 'mydb', TableInput: { Name: 'mytbl' } }
+    );
+
+    const sd = sentTableInput().StorageDescriptor as Record<string, unknown>;
+    expect(sd.Columns).toStrictEqual([{ Name: 'id', Type: 'int' }]);
+    expect(sd.Location).toBe('s3://b/t/');
+  });
 });


### PR DESCRIPTION
## Summary

Closes the #1479 half of the Glue full-replace wipe class: `UpdateTable`
replaces `TableInput` wholesale, and #1461 protected only the top-level
`Parameters` bag. Live probes (recorded on the issue) established that a
crawler authors `Columns` / `InputFormat` / `OutputFormat` / `SerdeInfo`
(incl. its `Parameters` bag) / `StorageDescriptor.Parameters`, and Glue
re-derives an Iceberg table's catalog `Columns` from table metadata — all
wiped by an unrelated update (`Columns` -> `[]`, `SerdeInfo` gone) while a
user-authored EXTERNAL_TABLE round-trips byte-identical (so full-replace
stays correct for template-declared members).

`preserveAwsManagedStorageDescriptor` applies the #1461 "present in NEITHER
template side" rule per SD **member** (whole-block carry-forward when no side
ever declared `StorageDescriptor`), with the two nested bags
(`StorageDescriptor.Parameters`, `SerdeInfo.Parameters`) merged per **key**
via the existing helper — including on whole-bag removal (review catch: a
desired-side-only gate wiped AWS-authored keys there). `SerdeInfo` itself is
treated as structural: whole-block removal is honored. Template-declared
members stay template-authored, so user removals and `drift --revert` are
unaffected (verified against the actual revert call path). The write rides
the existing unconditional `VersionId` TOCTOU precondition.

## Review

3-axis (spec / code / test) dispatched per the providers/** up-bias; all
findings addressed in the second commit: OR-gate bag semantics + 6 edge
tests + JSDoc/message accuracy. Pre-existing `buildStorageDescriptor`
allow-list gap filed as #1505 (declared-but-unbuildable members). Won't-do
(recorded here): SD-member removal round-trip stays unit-tested only — the
removal path is the pre-existing skip branch, and the integ covers survival +
template-authority live.

## Test plan

- 14 unit tests in the new #1479 describe block (65 -> 71 -> exact-payload
  asserts; OR-gate fix bound by 2 tests that fail without it); full suite 528
  files / 9374 tests green.
- Live: data-analytics integ extended to inject crawler-equivalent
  out-of-band SD members via raw `UpdateTable` and assert they survive an
  unrelated Phase-2 deploy while template-declared members stay intact. Run
  clean twice (before + after review fixes): deploy + update + destroy,
  0 errors / 0 orphans, 87s.

Closes #1479
