### PR TITLE
fix(glue): send the Table members the allow-lists dropped (SkewedInfo / SchemaReference / TargetTable / ViewDefinition)

### DIFF
--- a/docs/_generated/integ-coverage.json
+++ b/docs/_generated/integ-coverage.json
@@ -3183,7 +3183,8 @@
       "resourceType": "AWS::Glue::Database",
       "integs": [
         "data-analytics",
-        "drift-revert"
+        "drift-revert",
+        "glue-update-hardening"
       ],
       "signals": {
         "data-analytics": [
@@ -3191,6 +3192,9 @@
           "literal"
         ],
         "drift-revert": [
+          "l1"
+        ],
+        "glue-update-hardening": [
           "l1"
         ]
       }
@@ -3221,12 +3225,16 @@
     {
       "resourceType": "AWS::Glue::Table",
       "integs": [
-        "data-analytics"
+        "data-analytics",
+        "glue-update-hardening"
       ],
       "signals": {
         "data-analytics": [
           "l1",
           "literal"
+        ],
+        "glue-update-hardening": [
+          "l1"
         ]
       }
     },

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -121,7 +121,7 @@ gc-custom-asset-names	2026-07-31T06:41:35Z	PASS	120	verify.sh	TTL-refresh sweep 
 getatt-fallback-guard	2026-08-01T10:07:21Z	PASS	84	verify.sh	0801 regression sweep; strict-getatt paths ok, 0 orphans
 getstackoutput-crossregion	2026-07-26T19:05:27Z	PASS	79	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 glue-securityconfig-replace	2026-07-26T18:20:27Z	PASS	59	verify.sh	0727b sweep-b3 staleness re-run (rc=0); account clean
-glue-update-hardening	2026-08-09T06:55:05Z	PASS	71	verify.sh	#1391 scanAll/scanRate create+update; 3 Glue IAM-propagation retry gaps found and patterned; clean destroy, 0 orphans
+glue-update-hardening	2026-08-10T12:31:38Z	PASS	86	verify.sh	#1505 SkewedInfo create+update reached AWS; 14 deleted 0 errors, 0 orphans
 iam-access-key	2026-07-31T07:18:11Z	PASS	210	verify.sh	new fixture #1323: create+status-flip+secret-preservation+destroy clean (1st run false-FAIL on async DeleteSecret probe, poll added)
 iam-managed-policy	2026-07-27T16:40:50Z	PASS	32	verify.sh	issue #1272 IAM pass-through guard; clean destroy 0 orphans
 iam-oidc-provider	2026-07-31T06:25:46Z	PASS	82	verify.sh	TTL-refresh sweep re-run; 3 phases clean, orph clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -121,7 +121,7 @@ gc-custom-asset-names	2026-07-31T06:41:35Z	PASS	120	verify.sh	TTL-refresh sweep 
 getatt-fallback-guard	2026-08-01T10:07:21Z	PASS	84	verify.sh	0801 regression sweep; strict-getatt paths ok, 0 orphans
 getstackoutput-crossregion	2026-07-26T19:05:27Z	PASS	79	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 glue-securityconfig-replace	2026-07-26T18:20:27Z	PASS	59	verify.sh	0727b sweep-b3 staleness re-run (rc=0); account clean
-glue-update-hardening	2026-08-10T12:31:38Z	PASS	86	verify.sh	#1505 SkewedInfo create+update reached AWS; 14 deleted 0 errors, 0 orphans
+glue-update-hardening	2026-08-10T12:46:49Z	PASS	80	verify.sh	#1505 re-run after review fixes (TargetTable/ViewDefinition); 14 deleted 0 errors, 0 orphans
 iam-access-key	2026-07-31T07:18:11Z	PASS	210	verify.sh	new fixture #1323: create+status-flip+secret-preservation+destroy clean (1st run false-FAIL on async DeleteSecret probe, poll added)
 iam-managed-policy	2026-07-27T16:40:50Z	PASS	32	verify.sh	issue #1272 IAM pass-through guard; clean destroy 0 orphans
 iam-oidc-provider	2026-07-31T06:25:46Z	PASS	82	verify.sh	TTL-refresh sweep re-run; 3 phases clean, orph clean

--- a/docs/integ-coverage.md
+++ b/docs/integ-coverage.md
@@ -109,10 +109,10 @@ Registered without an integ fixture, with an explicit `// allow-no-integ: <ratio
 | `AWS::Events::Rule` | [`ecs-schedule-targets`](../tests/integration/ecs-schedule-targets/) (l2,literal)<br>[`eventbridge`](../tests/integration/eventbridge/) (l2,literal)<br>[`eventbridge-api-destination`](../tests/integration/eventbridge-api-destination/) (l2)<br>[`eventbridge-input-transformer`](../tests/integration/eventbridge-input-transformer/) (l2,literal)<br>[`iam-propagation-stress`](../tests/integration/iam-propagation-stress/) (l2)<br>[`rename-refactor`](../tests/integration/rename-refactor/) (l2,literal)<br>[`replacement-immutable-name`](../tests/integration/replacement-immutable-name/) (l2,literal)<br>[`scheduled-task`](../tests/integration/scheduled-task/) (l2) |
 | `AWS::FSx::FileSystem` | [`fsx-lustre`](../tests/integration/fsx-lustre/) (literal)<br>[`fsx-ontap`](../tests/integration/fsx-ontap/) (literal)<br>[`fsx-openzfs`](../tests/integration/fsx-openzfs/) (literal)<br>[`fsx-windows`](../tests/integration/fsx-windows/) (literal) |
 | `AWS::Glue::Crawler` | [`glue-update-hardening`](../tests/integration/glue-update-hardening/) (l1) |
-| `AWS::Glue::Database` | [`data-analytics`](../tests/integration/data-analytics/) (l1,literal)<br>[`drift-revert`](../tests/integration/drift-revert/) (l1) |
+| `AWS::Glue::Database` | [`data-analytics`](../tests/integration/data-analytics/) (l1,literal)<br>[`drift-revert`](../tests/integration/drift-revert/) (l1)<br>[`glue-update-hardening`](../tests/integration/glue-update-hardening/) (l1) |
 | `AWS::Glue::Job` | [`glue-update-hardening`](../tests/integration/glue-update-hardening/) (l1) |
 | `AWS::Glue::SecurityConfiguration` | [`glue-securityconfig-replace`](../tests/integration/glue-securityconfig-replace/) (l1,literal) |
-| `AWS::Glue::Table` | [`data-analytics`](../tests/integration/data-analytics/) (l1,literal) |
+| `AWS::Glue::Table` | [`data-analytics`](../tests/integration/data-analytics/) (l1,literal)<br>[`glue-update-hardening`](../tests/integration/glue-update-hardening/) (l1) |
 | `AWS::Glue::Trigger` | [`glue-update-hardening`](../tests/integration/glue-update-hardening/) (l1) |
 | `AWS::Glue::Workflow` | [`glue-update-hardening`](../tests/integration/glue-update-hardening/) (l1) |
 | `AWS::IAM::AccessKey` | [`iam-access-key`](../tests/integration/iam-access-key/) (literal) |

--- a/src/provisioning/providers/glue-provider.ts
+++ b/src/provisioning/providers/glue-provider.ts
@@ -47,6 +47,8 @@ import {
   type Column,
   type Order,
   type SerDeInfo,
+  type SkewedInfo,
+  type SchemaReference,
   type EncryptionConfiguration,
   type S3Encryption,
   type CloudWatchEncryption,
@@ -1099,14 +1101,15 @@ export class GlueProvider implements ResourceProvider {
     if (sd['SerdeInfo'] !== undefined) {
       const serde = sd['SerdeInfo'] as Record<string, unknown>;
       if (serde['Parameters']) {
-        const params = serde['Parameters'] as Record<string, unknown>;
-        const converted: Record<string, string> = {};
-        for (const [k, v] of Object.entries(params)) {
-          converted[k] = String(v);
-        }
-        serde['Parameters'] = converted;
+        // Copy rather than mutate: `sd` is the caller's template object, and
+        // the same block is re-read by the #1479 merge's key-set walk.
+        result.SerdeInfo = {
+          ...serde,
+          Parameters: stringifyParameterValues(serde['Parameters']),
+        } as SerDeInfo;
+      } else {
+        result.SerdeInfo = serde as SerDeInfo;
       }
-      result.SerdeInfo = serde as SerDeInfo;
     }
 
     if (sd['BucketColumns'] !== undefined) {
@@ -1123,6 +1126,43 @@ export class GlueProvider implements ResourceProvider {
 
     if (sd['StoredAsSubDirectories'] !== undefined) {
       result.StoredAsSubDirectories = sd['StoredAsSubDirectories'] as boolean;
+    }
+
+    // `SkewedInfo` / `SchemaReference` complete the CFn `StorageDescriptor`
+    // member set (issue #1505). Before this they were dropped by the
+    // allow-list, and the #1479 merge made that WORSE than a plain drop: its
+    // key sets come from the RAW template, so DECLARING one suppressed the
+    // live carry-forward (the member counts as user-authored) while the
+    // builder never sent a value — erasing the live value with nothing
+    // replacing it. An UNDECLARED member was, and still is, preserved by the
+    // carry-forward.
+    //
+    // The issue also named `AdditionalLocations`, but the live CFn registry
+    // schema declares exactly the 13 members handled here with
+    // `additionalProperties: false` — that one exists only in the SDK model,
+    // so no template can reach it and forwarding it would be dead code.
+    if (sd['SkewedInfo'] !== undefined) {
+      const skewed = sd['SkewedInfo'] as Record<string, unknown>;
+      // CFn types `SkewedColumnValueLocationMaps` as a free-form object while
+      // the SDK member is `Record<string, string>` — the same CFn-delivers-
+      // non-strings case `Parameters` handles.
+      result.SkewedInfo =
+        skewed['SkewedColumnValueLocationMaps'] !== undefined
+          ? ({
+              ...skewed,
+              SkewedColumnValueLocationMaps: stringifyParameterValues(
+                skewed['SkewedColumnValueLocationMaps']
+              ),
+            } as SkewedInfo)
+          : (skewed as SkewedInfo);
+    }
+
+    if (sd['SchemaReference'] !== undefined) {
+      // Every member (`SchemaId.{RegistryName,SchemaName,SchemaArn}`,
+      // `SchemaVersionId`, `SchemaVersionNumber`) is same-spelled and
+      // same-shaped between the CFn schema and `@aws-sdk/client-glue`, so the
+      // block forwards verbatim.
+      result.SchemaReference = sd['SchemaReference'] as SchemaReference;
     }
 
     return result;

--- a/src/provisioning/providers/glue-provider.ts
+++ b/src/provisioning/providers/glue-provider.ts
@@ -49,6 +49,8 @@ import {
   type SerDeInfo,
   type SkewedInfo,
   type SchemaReference,
+  type TableIdentifier,
+  type ViewDefinitionInput,
   type EncryptionConfiguration,
   type S3Encryption,
   type CloudWatchEncryption,
@@ -1065,6 +1067,30 @@ export class GlueProvider implements ResourceProvider {
       result.PartitionKeys = tableInput['PartitionKeys'] as Column[];
     }
 
+    // `TargetTable` (resource-link tables) and `ViewDefinition` complete the CFn
+    // `TableInput` member set. Found by diffing the WHOLE blob against the live
+    // registry schema while fixing the StorageDescriptor allow-list (issue
+    // #1505) — the same silent-drop class one level up, and WORSE there: the
+    // #1479 read-merge-write only covers the `StorageDescriptor` subtree and
+    // `Parameters`, so nothing carries these forward and `UpdateTable`'s full
+    // replace erased a live value unconditionally. `readCurrentState` already
+    // reads `TargetTable` back, so drift surfaced a member deploy could never
+    // send.
+    //
+    // Both forward verbatim: all 12 CFn `TableInput` members were compared
+    // against `@aws-sdk/client-glue`, and `TableIdentifier`
+    // ({CatalogId, DatabaseName, Name, Region}) plus `ViewDefinition`
+    // ({Definer, SubObjects, Representations, IsProtected}, whose
+    // `ViewRepresentation` is {Dialect, DialectVersion, ValidationConnection,
+    // ViewExpandedText, ViewOriginalText}) are same-spelled and same-shaped.
+    if (tableInput['TargetTable'] !== undefined) {
+      result.TargetTable = tableInput['TargetTable'] as TableIdentifier;
+    }
+
+    if (tableInput['ViewDefinition'] !== undefined) {
+      result.ViewDefinition = tableInput['ViewDefinition'] as ViewDefinitionInput;
+    }
+
     return result;
   }
 
@@ -1142,7 +1168,11 @@ export class GlueProvider implements ResourceProvider {
     // `additionalProperties: false` — that one exists only in the SDK model,
     // so no template can reach it and forwarding it would be dead code.
     if (sd['SkewedInfo'] !== undefined) {
-      const skewed = sd['SkewedInfo'] as Record<string, unknown>;
+      // `asRecord` rather than a cast: a malformed / null block would otherwise
+      // throw a raw TypeError from the member read below, surfacing as
+      // "Cannot read properties of null" instead of AWS's real validation
+      // error. Same convention as `parameterKeySet` / the #1471 shape guards.
+      const skewed = asRecord(sd['SkewedInfo']) ?? {};
       // CFn types `SkewedColumnValueLocationMaps` as a free-form object while
       // the SDK member is `Record<string, string>` — the same CFn-delivers-
       // non-strings case `Parameters` handles.
@@ -1162,7 +1192,16 @@ export class GlueProvider implements ResourceProvider {
       // `SchemaVersionId`, `SchemaVersionNumber`) is same-spelled and
       // same-shaped between the CFn schema and `@aws-sdk/client-glue`, so the
       // block forwards verbatim.
-      result.SchemaReference = sd['SchemaReference'] as SchemaReference;
+      // `SchemaVersionNumber` is the one member needing coercion: CFn types it
+      // as an integer, but a hand-authored template (or a `Ref` to a Number
+      // parameter) can deliver "2", which the SDK's number field rejects with a
+      // SerializationException. Same treatment the Job numerics get.
+      const schemaRef = asRecord(sd['SchemaReference']) ?? {};
+      result.SchemaReference = (
+        schemaRef['SchemaVersionNumber'] !== undefined
+          ? { ...schemaRef, SchemaVersionNumber: coerceNumber(schemaRef['SchemaVersionNumber']) }
+          : schemaRef
+      ) as SchemaReference;
     }
 
     return result;
@@ -2695,7 +2734,13 @@ function buildJobCommonFields(p: Record<string, unknown>): Partial<JobUpdate> {
  */
 function stringifyParameterValues(raw: unknown): Record<string, string> {
   const params: Record<string, string> = {};
-  for (const [k, v] of Object.entries((raw ?? {}) as Record<string, unknown>)) {
+  // A non-object (a string / array / unresolved intrinsic) must contribute NO
+  // keys: `Object.entries('s3://x')` yields {'0':'s','1':'3',...}, which would
+  // be written to AWS as a real map. Same refusal as `parameterKeySet` /
+  // `asRecord` (the #1471 convention).
+  const source = asRecord(raw);
+  if (source === undefined) return params;
+  for (const [k, v] of Object.entries(source)) {
     params[k] = String(v);
   }
   return params;

--- a/tests/integration/glue-update-hardening/lib/glue-update-hardening-stack.ts
+++ b/tests/integration/glue-update-hardening/lib/glue-update-hardening-stack.ts
@@ -26,6 +26,12 @@ import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
  *     members, so the tuning silently never reached AWS while the target
  *     itself (matched by `Path`) survived. CDKD_TEST_UPDATE flips both values
  *     so the update path is covered too.
+ *  6. Glue Table `StorageDescriptor.SkewedInfo` (issue #1505). The provider's
+ *     `buildStorageDescriptor` was an explicit allow-list that dropped this
+ *     member outright, and the #1479 live-merge made a DECLARED one worse than
+ *     a plain drop (declaring it suppressed the carry-forward while the builder
+ *     sent nothing). CDKD_TEST_UPDATE flips the skewed value so the update path
+ *     is covered too.
  *
  * All resources are idle (no schedule, ON_DEMAND trigger), so deploy + destroy
  * is fast and clean — no quota, no running jobs.
@@ -133,6 +139,54 @@ export class GlueUpdateHardeningStack extends cdk.Stack {
       },
     });
 
+    // Glue Database + Table — `StorageDescriptor.SkewedInfo` (issue #1505).
+    //
+    // `buildStorageDescriptor` was an explicit allow-list of 11 members, so
+    // `SkewedInfo` (and its sibling `SchemaReference`) never reached AWS. The
+    // #1479 merge made a DECLARED one worse than a plain drop: its key sets
+    // come from the RAW template, so declaring the member suppressed the live
+    // carry-forward while the builder produced nothing — erasing it outright.
+    //
+    // `SkewedColumnValueLocationMaps` is deliberately populated: CFn types it
+    // as a free-form object while the SDK member is Record<string,string>, so
+    // it also covers the value coercion. CDKD_TEST_UPDATE flips the skewed
+    // value so the update path is exercised with a second distinct payload.
+    const tableDb = new glue.CfnDatabase(this, 'TableDatabase', {
+      catalogId: this.account,
+      databaseInput: { name: `${this.stackName}-table-db`.toLowerCase() },
+    });
+
+    const skewedValue = isUpdate ? 'CA' : 'US';
+    const skewedTable = new glue.CfnTable(this, 'SkewedTable', {
+      catalogId: this.account,
+      databaseName: `${this.stackName}-table-db`.toLowerCase(),
+      tableInput: {
+        name: `${this.stackName}-skewed-table`.toLowerCase(),
+        tableType: 'EXTERNAL_TABLE',
+        storageDescriptor: {
+          location: `s3://${scriptBucket.bucketName}/skewed/`,
+          inputFormat: 'org.apache.hadoop.mapred.TextInputFormat',
+          outputFormat: 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
+          columns: [
+            { name: 'id', type: 'bigint' },
+            { name: 'country', type: 'string' },
+          ],
+          serdeInfo: {
+            serializationLibrary: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
+            parameters: { 'field.delim': ',' },
+          },
+          skewedInfo: {
+            skewedColumnNames: ['country'],
+            skewedColumnValues: [skewedValue],
+            skewedColumnValueLocationMaps: {
+              [skewedValue]: `s3://${scriptBucket.bucketName}/skewed/${skewedValue}/`,
+            },
+          },
+        },
+      },
+    });
+    skewedTable.addDependency(tableDb);
+
     // Glue Trigger — ON_DEMAND (idle, will not auto-fire) running the Job.
     const trigger = new glue.CfnTrigger(this, 'EtlTrigger', {
       name: `${this.stackName}-trigger`.toLowerCase(),
@@ -147,5 +201,11 @@ export class GlueUpdateHardeningStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'CrawlerName', { value: `${this.stackName}-crawler`.toLowerCase() });
     new cdk.CfnOutput(this, 'CrawlerTableName', { value: crawlerTable.tableName });
     new cdk.CfnOutput(this, 'TriggerName', { value: `${this.stackName}-trigger`.toLowerCase() });
+    new cdk.CfnOutput(this, 'SkewedTableDbName', {
+      value: `${this.stackName}-table-db`.toLowerCase(),
+    });
+    new cdk.CfnOutput(this, 'SkewedTableName', {
+      value: `${this.stackName}-skewed-table`.toLowerCase(),
+    });
   }
 }

--- a/tests/integration/glue-update-hardening/verify.sh
+++ b/tests/integration/glue-update-hardening/verify.sh
@@ -18,6 +18,11 @@
 #      drops unknown members, so the scan tuning silently never reached AWS
 #      while the target itself (matched by `Path`) survived. Asserted via
 #      `aws glue get-crawler` on BOTH the base deploy and the UPDATE re-deploy.
+#   6. Table `StorageDescriptor.SkewedInfo` reaching AWS (issue #1505).
+#      `buildStorageDescriptor` was an explicit 11-member allow-list that
+#      dropped it, and the #1479 live-merge made a DECLARED one worse than a
+#      plain drop. Asserted via `aws glue get-table` on BOTH phases; the update
+#      phase flips the skewed value so a stale carry-forward cannot pass.
 #
 # Required env vars:
 #   STATE_BUCKET — cdkd state bucket (e.g. cdkd-state-{accountId})
@@ -145,6 +150,10 @@ if [ -z "${CRAWLER_TABLE_NAME}" ]; then
   echo "FAIL: state has no CrawlerTableName output after deploy" >&2
   exit 1
 fi
+SKEWED_DB_NAME=$(echo "${STATE}" | jq -r '.outputs.SkewedTableDbName // empty')
+[ -z "${SKEWED_DB_NAME}" ] && SKEWED_DB_NAME="${LOWER}-table-db"
+SKEWED_TABLE_NAME=$(echo "${STATE}" | jq -r '.outputs.SkewedTableName // empty')
+[ -z "${SKEWED_TABLE_NAME}" ] && SKEWED_TABLE_NAME="${LOWER}-skewed-table"
 
 echo "    Using job '${JOB_NAME}', workflow '${WORKFLOW_NAME}', crawler '${CRAWLER_NAME}', trigger '${TRIGGER_NAME}', crawler table '${CRAWLER_TABLE_NAME}'"
 
@@ -252,6 +261,44 @@ fi
 echo "    OK: DynamoDBTargets[0].Path == ${CRAWLER_TABLE_NAME}"
 assert_ddb_scan_tuning "${CRAWLER_JSON}" 'false' '0.9' 'create'
 
+# --- Assertion: Table StorageDescriptor.SkewedInfo reached AWS (issue #1505) --
+# `buildStorageDescriptor` was an explicit 11-member allow-list, so SkewedInfo
+# was dropped outright. There is no AWS-side default that can satisfy this:
+# an unset SkewedInfo reads back absent (or with empty member lists), so any
+# non-empty skewed column name proves the member was delivered.
+# `SkewedColumnValueLocationMaps` additionally proves the CFn free-form-object
+# -> SDK Record<string,string> coercion.
+assert_skewed_info() { # usage: assert_skewed_info <want skewed value> <phase label>
+  local want="$1" phase="$2" table_json sd got_names got_values got_map
+  # `|| return 1` on every capture (#1120): errexit is CLEARED inside `$( )`, so
+  # without it a failed probe would fall through to the comparisons below and
+  # report a misleading "SkewedInfo never reached AWS" instead of the real error.
+  table_json=$(aws glue get-table --database-name "${SKEWED_DB_NAME}" --name "${SKEWED_TABLE_NAME}" \
+    --region "${REGION}" --output json) || return 1
+  sd=$(printf '%s' "${table_json}" | jq -c '.Table.StorageDescriptor // {}') || return 1
+  # sort() both sides: AWS does not guarantee list order on readback.
+  got_names=$(printf '%s' "${sd}" | jq -r '(.SkewedInfo.SkewedColumnNames // []) | sort | join(",")') || return 1
+  if [ "${got_names}" != "country" ]; then
+    echo "FAIL: ${phase}: StorageDescriptor.SkewedInfo.SkewedColumnNames is '${got_names}', expected 'country' — SkewedInfo never reached AWS (issue #1505)" >&2
+    exit 1
+  fi
+  got_values=$(printf '%s' "${sd}" | jq -r '(.SkewedInfo.SkewedColumnValues // []) | sort | join(",")') || return 1
+  if [ "${got_values}" != "${want}" ]; then
+    echo "FAIL: ${phase}: SkewedInfo.SkewedColumnValues is '${got_values}', expected '${want}'" >&2
+    exit 1
+  fi
+  got_map=$(printf '%s' "${sd}" | jq -r --arg k "${want}" '.SkewedInfo.SkewedColumnValueLocationMaps[$k] // "<absent>"') || return 1
+  case "${got_map}" in
+    s3://*"/skewed/${want}/") ;;
+    *)
+      echo "FAIL: ${phase}: SkewedColumnValueLocationMaps['${want}'] is '${got_map}', expected an s3://.../skewed/${want}/ URI" >&2
+      exit 1
+      ;;
+  esac
+  echo "    OK: ${phase}: SkewedInfo reached AWS (names=${got_names} values=${got_values} map[${want}]=${got_map})"
+}
+assert_skewed_info 'US' 'create'
+
 # --- Sanity: trigger exists -------------------------------------------
 if aws glue get-trigger --name "${TRIGGER_NAME}" --region "${REGION}" >/dev/null 2>&1; then
   echo "    OK: trigger ${TRIGGER_NAME} exists"
@@ -289,6 +336,13 @@ CRAWLER_JSON=$(aws glue get-crawler --name "${CRAWLER_NAME}" --region "${REGION}
 # phase asserts the drop-proof pair, false/0.9, and fails first anyway.)
 assert_ddb_scan_tuning "${CRAWLER_JSON}" 'true' '1.2' 'update'
 
+# The UPDATE path is where the #1479 interaction bites: the merge's key sets
+# come from the RAW template, so DECLARING SkewedInfo suppresses the live
+# carry-forward — and before #1505 the builder sent nothing, so UpdateTable's
+# full replace ERASED the member. The flipped value ('CA') is what discriminates:
+# a carry-forward of the create-phase value would still read 'US'.
+assert_skewed_info 'CA' 'update'
+
 # --- Phase 3: destroy -------------------------------------------------
 echo "==> Phase 3: destroy"
 node "${LOCAL_DIST}" destroy "${STACK}" \
@@ -300,7 +354,9 @@ for chk in \
   "get-job --job-name ${JOB_NAME}" \
   "get-crawler --name ${CRAWLER_NAME}" \
   "get-trigger --name ${TRIGGER_NAME}" \
-  "get-workflow --name ${WORKFLOW_NAME}"; do
+  "get-workflow --name ${WORKFLOW_NAME}" \
+  "get-table --database-name ${SKEWED_DB_NAME} --name ${SKEWED_TABLE_NAME}" \
+  "get-database --name ${SKEWED_DB_NAME}"; do
   # Route through gone_probe (issue #1097 pattern 2): Glue get-* not-found is
   # EntityNotFoundException, which matches the canonical signature; any other
   # probe failure (throttle, auth) hard-FAILs instead of reading as "gone".
@@ -336,4 +392,4 @@ assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after des
 echo "    OK: state file is gone"
 
 echo ""
-echo "==> glue-update-hardening test passed (numeric coercion + MAP tags + DynamoDB scan tuning + clean destroy)"
+echo "==> glue-update-hardening test passed (numeric coercion + MAP tags + DynamoDB scan tuning + Table SkewedInfo + clean destroy)"

--- a/tests/unit/provisioning/glue-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/glue-provider-roundtrip.test.ts
@@ -2121,3 +2121,105 @@ describe('GlueProvider — StorageDescriptor declared-member coverage (#1505)', 
     expect(serdeInfo.Parameters).toStrictEqual({ 'skip.header.line.count': 1 });
   });
 });
+
+// ─── #1505 review: the same silent-drop class one level up + shape guards ────
+//
+// Diffing the WHOLE `TableInput` blob (not just the reported StorageDescriptor)
+// against the live CFn registry schema found two more dropped members. That is
+// WORSE than the StorageDescriptor case: the #1479 read-merge-write only covers
+// the `StorageDescriptor` subtree and `Parameters`, so nothing carries these
+// forward and UpdateTable's full replace erased a live value unconditionally.
+describe('GlueProvider — TableInput member coverage + shape guards (#1505 review)', () => {
+  let provider: GlueProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new GlueProvider();
+  });
+
+  const createdTableInput = (): Record<string, unknown> => {
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof CreateTableCommand);
+    expect(call).toBeDefined();
+    return (call![0].input as { TableInput: Record<string, unknown> }).TableInput;
+  };
+
+  const createWith = async (tableInput: Record<string, unknown>): Promise<void> => {
+    mockSend.mockResolvedValueOnce({});
+    await provider.create('L', 'AWS::Glue::Table', {
+      DatabaseName: 'mydb',
+      TableInput: { Name: 'mytbl', ...tableInput },
+    });
+  };
+
+  it('create() sends TargetTable (resource-link table) instead of dropping it', async () => {
+    const targetTable = {
+      CatalogId: '111122223333',
+      DatabaseName: 'shared-db',
+      Name: 'shared-table',
+      Region: 'us-west-2',
+    };
+    await createWith({ TargetTable: targetTable });
+    expect(createdTableInput().TargetTable).toStrictEqual(targetTable);
+  });
+
+  it('create() sends ViewDefinition instead of dropping it', async () => {
+    const viewDefinition = {
+      IsProtected: true,
+      Definer: 'arn:aws:iam::111122223333:role/definer',
+      SubObjects: ['arn:aws:glue:us-east-1:111122223333:table/mydb/base'],
+      Representations: [
+        {
+          Dialect: 'ATHENA',
+          DialectVersion: '3',
+          ViewOriginalText: 'SELECT 1',
+          ViewExpandedText: 'SELECT 1',
+          ValidationConnection: 'my-conn',
+        },
+      ],
+    };
+    await createWith({ ViewDefinition: viewDefinition });
+    expect(createdTableInput().ViewDefinition).toStrictEqual(viewDefinition);
+  });
+
+  it('coerces a stringly-typed SchemaReference.SchemaVersionNumber to a number', async () => {
+    // CFn types it as an integer, but a hand-authored template (or a Ref to a
+    // Number parameter) can deliver "2", which the SDK number field rejects.
+    await createWith({
+      StorageDescriptor: {
+        Location: 's3://b/t/',
+        SchemaReference: { SchemaVersionId: 'abc', SchemaVersionNumber: '2' },
+      },
+    });
+    const sd = createdTableInput().StorageDescriptor as Record<string, unknown>;
+    expect(sd.SchemaReference).toStrictEqual({ SchemaVersionId: 'abc', SchemaVersionNumber: 2 });
+  });
+
+  it('a malformed SkewedColumnValueLocationMaps contributes NO keys instead of index garbage', async () => {
+    // `Object.entries('s3://x')` yields {'0':'s','1':'3',...}; before the guard
+    // that index garbage was written to AWS as a real location map.
+    await createWith({
+      StorageDescriptor: {
+        Location: 's3://b/t/',
+        SkewedInfo: { SkewedColumnNames: ['c'], SkewedColumnValueLocationMaps: 's3://b/x/' },
+      },
+    });
+    const sd = createdTableInput().StorageDescriptor as Record<string, unknown>;
+    expect(sd.SkewedInfo).toStrictEqual({
+      SkewedColumnNames: ['c'],
+      SkewedColumnValueLocationMaps: {},
+    });
+  });
+
+  it('a malformed Parameters block contributes NO keys (same guard, shared helper)', async () => {
+    await createWith({ Parameters: 'not-an-object' });
+    expect(createdTableInput().Parameters).toStrictEqual({});
+  });
+
+  it('a null SkewedInfo does not throw a raw TypeError', async () => {
+    await expect(
+      createWith({ StorageDescriptor: { Location: 's3://b/t/', SkewedInfo: null } })
+    ).resolves.not.toThrow();
+    const sd = createdTableInput().StorageDescriptor as Record<string, unknown>;
+    expect(sd.SkewedInfo).toStrictEqual({});
+  });
+});

--- a/tests/unit/provisioning/glue-provider-roundtrip.test.ts
+++ b/tests/unit/provisioning/glue-provider-roundtrip.test.ts
@@ -1936,3 +1936,188 @@ describe('GlueProvider — out-of-band StorageDescriptor preservation (#1479)', 
     expect(sd.Location).toBe('s3://b/t/');
   });
 });
+
+// ─── #1505: the StorageDescriptor allow-list dropped declared members ───
+//
+// `buildStorageDescriptor` was an explicit allow-list of 11 members, so the
+// CFn `StorageDescriptor` members outside it were never sent. The live CFn
+// registry schema declares exactly 13 members with `additionalProperties:
+// false`, so the two missing ones are `SkewedInfo` and `SchemaReference`
+// (the issue also named `AdditionalLocations`, which the registry does NOT
+// declare — it exists only in the SDK model, so no template can carry it).
+//
+// The #1479 merge made the drop worse than a plain silent drop: its key sets
+// come from the RAW template, so a template DECLARING one of these suppressed
+// the live carry-forward (the member counts as user-authored) while the
+// builder never produced a value — erasing the live value with nothing
+// replacing it. That is the `erases the live value` case below.
+describe('GlueProvider — StorageDescriptor declared-member coverage (#1505)', () => {
+  let provider: GlueProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new GlueProvider();
+  });
+
+  const SKEWED_INFO = {
+    SkewedColumnNames: ['country'],
+    SkewedColumnValues: ['US'],
+    SkewedColumnValueLocationMaps: { US: 's3://b/skew/us/' },
+  };
+
+  const SCHEMA_REFERENCE = {
+    SchemaId: { RegistryName: 'my-registry', SchemaName: 'my-schema' },
+    SchemaVersionNumber: 2,
+  };
+
+  const createdTableInput = (): Record<string, unknown> => {
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof CreateTableCommand);
+    expect(call).toBeDefined();
+    return (call![0].input as { TableInput: Record<string, unknown> }).TableInput;
+  };
+
+  const sentTableInput = (): Record<string, unknown> => {
+    const call = mockSend.mock.calls.find((c) => c[0] instanceof UpdateTableCommand);
+    expect(call).toBeDefined();
+    return (call![0].input as { TableInput: Record<string, unknown> }).TableInput;
+  };
+
+  it('create() sends SkewedInfo and SchemaReference instead of dropping them', async () => {
+    mockSend.mockResolvedValueOnce({});
+
+    await provider.create('L', 'AWS::Glue::Table', {
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        StorageDescriptor: {
+          Location: 's3://b/t/',
+          SkewedInfo: SKEWED_INFO,
+          SchemaReference: SCHEMA_REFERENCE,
+        },
+      },
+    });
+
+    const sd = createdTableInput().StorageDescriptor as Record<string, unknown>;
+    // toStrictEqual, not toEqual: an `{ X: undefined }` forward would pass
+    // toEqual while the SDK v3 serializer treats undefined as absent — the
+    // silent-drop failure mode these assertions exist to fence.
+    expect(sd.SkewedInfo).toStrictEqual(SKEWED_INFO);
+    expect(sd.SchemaReference).toStrictEqual(SCHEMA_REFERENCE);
+  });
+
+  it('create() stringifies SkewedColumnValueLocationMaps values (CFn free-form object -> SDK Record<string,string>)', async () => {
+    mockSend.mockResolvedValueOnce({});
+
+    await provider.create('L', 'AWS::Glue::Table', {
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        StorageDescriptor: {
+          Location: 's3://b/t/',
+          SkewedInfo: {
+            SkewedColumnNames: ['n'],
+            SkewedColumnValueLocationMaps: { a: 1, b: true },
+          },
+        },
+      },
+    });
+
+    const sd = createdTableInput().StorageDescriptor as Record<string, unknown>;
+    expect(sd.SkewedInfo).toStrictEqual({
+      SkewedColumnNames: ['n'],
+      SkewedColumnValueLocationMaps: { a: '1', b: 'true' },
+    });
+  });
+
+  it('a DECLARED SkewedInfo no longer erases the live value (the #1479 interaction)', async () => {
+    // Live table carries a SkewedInfo; the template declares its own. Before
+    // the fix the declaration suppressed the carry-forward AND the builder
+    // sent nothing, so UpdateTable's full replace wiped the member entirely.
+    mockSend.mockResolvedValueOnce({
+      Table: {
+        Name: 'mytbl',
+        VersionId: '3',
+        StorageDescriptor: {
+          Location: 's3://b/t/',
+          SkewedInfo: { SkewedColumnNames: ['stale'] },
+        },
+      },
+    });
+    mockSend.mockResolvedValueOnce({});
+
+    const side = (names: string[]) => ({
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        StorageDescriptor: {
+          Location: 's3://b/t/',
+          SkewedInfo: { SkewedColumnNames: names },
+        },
+      },
+    });
+
+    await provider.update(
+      'L',
+      TABLE_PHYSICAL_ID,
+      'AWS::Glue::Table',
+      side(['country']),
+      side(['region'])
+    );
+
+    const sd = sentTableInput().StorageDescriptor as Record<string, unknown>;
+    expect(sd.SkewedInfo).toStrictEqual({ SkewedColumnNames: ['country'] });
+  });
+
+  it('an UNDECLARED SkewedInfo is still carried forward by the #1479 merge', async () => {
+    mockSend.mockResolvedValueOnce({
+      Table: {
+        Name: 'mytbl',
+        VersionId: '3',
+        StorageDescriptor: { Location: 's3://b/t/', SkewedInfo: SKEWED_INFO },
+      },
+    });
+    mockSend.mockResolvedValueOnce({});
+
+    const side = (description: string) => ({
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        Description: description,
+        StorageDescriptor: { Location: 's3://b/t/' },
+      },
+    });
+
+    await provider.update('L', TABLE_PHYSICAL_ID, 'AWS::Glue::Table', side('v2'), side('v1'));
+
+    const sd = sentTableInput().StorageDescriptor as Record<string, unknown>;
+    expect(sd.SkewedInfo).toStrictEqual(SKEWED_INFO);
+  });
+
+  it('SerdeInfo.Parameters stringification copies rather than mutating the caller template', async () => {
+    mockSend.mockResolvedValueOnce({});
+
+    const serdeInfo = {
+      SerializationLibrary: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
+      Parameters: { 'skip.header.line.count': 1 },
+    };
+    const properties = {
+      DatabaseName: 'mydb',
+      TableInput: {
+        Name: 'mytbl',
+        StorageDescriptor: { Location: 's3://b/t/', SerdeInfo: serdeInfo },
+      },
+    };
+
+    await provider.create('L', 'AWS::Glue::Table', properties);
+
+    const sd = createdTableInput().StorageDescriptor as Record<string, unknown>;
+    expect(sd.SerdeInfo).toStrictEqual({
+      SerializationLibrary: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
+      Parameters: { 'skip.header.line.count': '1' },
+    });
+    // The caller's object is untouched — the #1479 merge re-reads the RAW
+    // template for its key sets, so mutating it in place would leak the
+    // builder's coercion into that walk.
+    expect(serdeInfo.Parameters).toStrictEqual({ 'skip.header.line.count': 1 });
+  });
+});


### PR DESCRIPTION
## Summary

`GlueProvider.buildStorageDescriptor` was an explicit allow-list of 11 members, so a CFn `StorageDescriptor` member outside it was never sent.

The (#1479) merge made that **worse than a plain silent drop**: its key sets come from the RAW template, so a template *declaring* one of these suppressed the live carry-forward (the member counts as user-authored) while the builder never produced a value — erasing the live value with nothing replacing it. An UNDECLARED member was, and still is, preserved by the carry-forward.

## What changed

- `SkewedInfo` is forwarded, with `SkewedColumnValueLocationMaps` coerced to `Record<string, string>` — CFn types it as a free-form object, the SDK member is string-valued, so it needs the same coercion `Parameters` already gets.
- `SchemaReference` forwards verbatim: every member (`SchemaId.{RegistryName,SchemaName,SchemaArn}` / `SchemaVersionId` / `SchemaVersionNumber`) is same-spelled and same-shaped between the CFn schema and `@aws-sdk/client-glue`.
- Opportunistic fix in the same builder: the `SerdeInfo.Parameters` stringification **mutated the caller's template object** in place. The (#1479) merge re-reads that raw template for its key sets, so the coercion was leaking into that walk. It now copies.

`readCurrentState` already passes `Table.StorageDescriptor` through wholesale, so the read side needed no change.

## Found by review: the same class one level up

`.claude/rules/providers.md` says to diff the WHOLE blob, not the reported key. Doing that for `TableInput` against the live registry schema found two more dropped members: **`TargetTable`** (resource-link tables) and **`ViewDefinition`**. All 12 CFn `TableInput` members were compared against `@aws-sdk/client-glue`.

That drop is **worse** than the one it was found next to: the (#1479) merge covers only the `StorageDescriptor` subtree and `Parameters`, so nothing carried these forward and `UpdateTable`'s full replace erased a live value unconditionally — while `readCurrentState` already reads `TargetTable` back, so drift surfaced a member deploy could never send. Both forward verbatim (`TableIdentifier` and `ViewDefinition` / `ViewRepresentation` are same-spelled and same-shaped).

Three shape guards from the same review, all on the #1471 convention already used by `parameterKeySet` / `asRecord`:

- `stringifyParameterValues` refuses a non-object. Previously `SkewedColumnValueLocationMaps: 's3://x'` became `{'0':'s','1':'3',...}` and was written to AWS as a real location map. Covers the `Parameters` call sites too.
- `SkewedInfo` reads through `asRecord`, so a `null` block surfaces AWS's error instead of a raw `TypeError`.
- `SchemaReference.SchemaVersionNumber` is coerced with the file's own `coerceNumber` — CFn types it as an integer, but a hand-authored template or a `Ref` to a Number parameter delivers a string the SDK rejects.

## Correction to the issue

The issue also named `AdditionalLocations`. The **live CFn registry schema declares exactly the 13 members handled here, with `additionalProperties: false`** — that member exists only in the SDK model, so no template can reach it and forwarding it would be dead code. Recorded in a code comment rather than implemented. (`aws-cdk-lib`'s `CfnTable` renderer agrees: it emits the same 13 and no `AdditionalLocations`.)

## Test plan

**Unit** — 11 new cases in `glue-provider-roundtrip.test.ts`, each revert-probed against the real provider. The first 5 cover the allow-list fix: reverting to the pre-fix provider fails 4 of them (the 5th, undeclared member → carry-forward, passes both ways by design — it is a regression guard for (#1479), not a fix probe). The 6 review-fix cases all fail against the pre-review provider.

**Real AWS** (`/run-integ glue-update-hardening`, us-east-1) — the fixture had no Glue Table at all, so it satisfied the `integ-destroy` gate without exercising this fix. It now deploys a Glue Database + Table declaring `SkewedInfo`, asserted on both phases:

```
OK: create: SkewedInfo reached AWS (names=country values=US map[US]=s3://.../skewed/US/)
OK: update: SkewedInfo reached AWS (names=country values=CA map[CA]=s3://.../skewed/CA/)
Stack GlueUpdateHardeningStack destroyed (14 deleted, 0 errors)
```

The update phase is the load-bearing one: `CDKD_TEST_UPDATE` flips the skewed value `US` -> `CA`, so a stale carry-forward would still read `US` and fail. There is no AWS-side default that can satisfy these assertions — an unset `SkewedInfo` reads back absent.

The integ was re-run after the review fixes landed (the provider edit staled the `integ-destroy` marker) — both runs clean. Destroy clean, 0 orphans (`state.json` count 0, no IAM roles, database `EntityNotFoundException`, no buckets). Ledger row + regenerated `integ-coverage` matrices included.

`/check` green: typecheck + lint + format, test-project typecheck, build, 530 files / 9515 tests.

## Won't-do (recorded)

- The three fall-through branches in `buildStorageDescriptor` still hand out the live template reference rather than copying. Harmless today — `preserveAwsManagedParameters` / `preserveAwsManagedStorageDescriptor` build fresh objects and never mutate nested template values — so the copy is applied only where a coercion would otherwise write through to the caller's object.

## Out of scope

- **`SchemaReference` is unit-tested, not live-tested.** Covering it on real AWS needs a Glue Schema Registry + Schema, and both members flow through the identical allow-list extension, so the mechanism is proven live by `SkewedInfo`.
- **Adding `AWS::Glue::Table` to `NESTED_KEY_TARGETS`** stays with issue (#1393), which already tracks Glue critic-target expansion — it needs a `nestedPropertyPaths` fixture re-capture and a measured finding count first.

Closes #1505
