### PR TITLE
test(integ): assert cdkd drift clean on the newly-read S3 nested blocks (#1495 read side)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -233,7 +233,7 @@ s3-directory-bucket	2026-08-10T16:45:07Z	PASS	300	verify.sh	final post-rebase+re
 s3-event-notification	2026-08-10T04:16:05Z	PASS	73	verify.sh	0810 staleness sweep b1; #1437 EventBridgeEnabled/NESTED_KEY_TARGETS live-verified, 14 del 0 err, 0 orph
 s3-lifecycle	2026-08-09T16:51:31Z	PASS	81	verify.sh	#1430 EventBridge pair asserted both phases with the booleans SWAPPED (real UPDATE path); destroy 0 err, 0 orph
 s3-object-lock	2026-08-10T04:16:05Z	PASS	44	verify.sh	0810 staleness sweep b1; s3-bucket-provider re-verify, 0 err, 0 orph
-s3-replication-and-filter	2026-08-10T17:12:34Z	PASS	205	verify.sh	final re-run after re-review fixes; 6 deleted 0 errors
+s3-replication-and-filter	2026-08-10T18:11:48Z	PASS	110	verify.sh	issue #1530 drift-clean asserts added; rc ok, orph clean
 s3-subconfig-removal	2026-08-10T07:17:25Z	PASS	63	verify.sh	issue #1466 final; 4 removal verdicts + drift-detect; rc ok, 0 orph
 s3-tables	2026-07-27T16:53:47Z	PASS	45	verify.sh	issue #1270/#1272 post-review re-run; 5 del 0 err, 0 orphans
 s3-vectors	2026-08-09T03:50:21Z	PASS	230	verify.sh	#1385 CMK encryption asserted; destroy 0 errors, 0 orphans

--- a/tests/integration/s3-replication-and-filter/README.md
+++ b/tests/integration/s3-replication-and-filter/README.md
@@ -28,11 +28,19 @@ bug-hunt sweep.
    replication role. The source rule uses `Filter.And { Prefix: 'logs/', TagFilters:
    [replicate=yes] }`. Assert `GetBucketReplication` returns the rule with
    `Filter.And.Prefix='logs/'` **and** `Filter.And.Tags` carrying `replicate=yes`
-   (NOT an empty filter / replicate-all).
+   (NOT an empty filter / replicate-all), plus the five issue #1495 read-backs
+   (`TargetObjectKeyFormat`, `Destination.ReplicationTime` + `Metrics`,
+   `SourceSelectionCriteria.ReplicaModifications`,
+   `TransitionDefaultMinimumObjectSize`), plus a `cdkd drift` clean assertion
+   (issue #1530) — the READ side of those blocks must reassemble what AWS
+   returns without phantom drift, and the source bucket must be reported
+   **checked + clean** by name (exit 0 alone would also pass on a
+   skipped/unsupported resource).
 2. **Re-deploy** with `CDKD_TEST_UPDATE=true` — changes the `And` prefix
    `logs/` → `data/` (tag unchanged). Assert the new prefix reached AWS via an
    in-place `PutBucketReplication` (the source bucket was **not** replaced — same
-   `CreationDate`) and the tag filter is still present.
+   `CreationDate`) and the tag filter is still present, then `cdkd drift` clean
+   again on the updated state (issue #1530).
 3. **Destroy** — assert both buckets are gone and the cdkd state file is removed.
 
 ## Run

--- a/tests/integration/s3-replication-and-filter/verify.sh
+++ b/tests/integration/s3-replication-and-filter/verify.sh
@@ -23,10 +23,13 @@
 # Phases:
 #   1. Deploy; assert GetBucketReplication returns the rule with
 #      Filter.And.Prefix='logs/' AND Filter.And.Tags carrying replicate=yes
-#      (NOT an empty filter / replicate-all), plus the five #1495 read-backs.
+#      (NOT an empty filter / replicate-all), plus the five #1495 read-backs,
+#      plus `cdkd drift` clean (issue #1530 — the READ side of the #1495
+#      blocks must reassemble what AWS returns, not report phantom drift).
 #   2. Re-deploy with CDKD_TEST_UPDATE=true (And prefix logs/ -> data/); assert
 #      the new prefix reached AWS via an in-place PutBucketReplication (the
-#      source bucket was NOT replaced) and the tag filter is still present.
+#      source bucket was NOT replaced) and the tag filter is still present,
+#      then `cdkd drift` clean again on the updated state.
 #   3. Destroy; assert both buckets are gone and the state file is removed.
 #
 # Required env vars:
@@ -64,6 +67,39 @@ assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-ve
     echo "FAIL: ${desc}" >&2
     exit 1
   fi
+}
+# ---------------------------------------------------------------------------
+
+# --- issue #1530: read-side drift proof --------------------------------------
+# The #1495 read-backs prove the WRITE side delivered each nested block. This
+# proves the READ side: `readCurrentState` must reassemble the live config into
+# the same shape the deploy captured, so `cdkd drift` reports the stack clean
+# immediately after a deploy. The concrete phantom-drift candidate is a
+# sub-block AWS returns that the template never declared (e.g.
+# `SourceSelectionCriteria.SseKmsEncryptedObjects` next to the declared
+# `ReplicaModifications`): drift-calculator.ts compares arrays WHOLESALE, so
+# one extra observed member would flag the entire Rules array as drifted.
+# Exit 0 alone is NOT sufficient — an unsupported/skipped SourceBucket also
+# exits 0 — so the by-name check asserts the bucket was CHECKED and clean.
+assert_drift_clean() { # usage: assert_drift_clean "<phase label>"
+  local phase="$1" rc=0 json
+  set +e
+  json="$(node "${LOCAL_DIST}" drift "${STACK}" --state-bucket "${STATE_BUCKET}" --json)"
+  rc=$?
+  set -e
+  if [ "${rc}" -ne 0 ]; then
+    echo "FAIL: expected no drift ${phase}, cdkd drift exited ${rc} — phantom drift on the newly-read S3 nested blocks (issue #1530):" >&2
+    printf '%s\n' "${json}" >&2
+    exit 1
+  fi
+  local clean_count
+  clean_count="$(printf '%s' "${json}" | jq -r '[.[].clean[] | select(.logicalId | startswith("SourceBucket"))] | length')"
+  if [ "${clean_count}" != "1" ]; then
+    echo "FAIL: SourceBucket not reported CLEAN by cdkd drift ${phase} (an unsupported/skipped bucket would mask a read-side gap):" >&2
+    printf '%s\n' "${json}" >&2
+    exit 1
+  fi
+  echo "    cdkd drift clean ${phase} — SourceBucket checked + clean (issue #1530)"
 }
 # ---------------------------------------------------------------------------
 
@@ -193,6 +229,8 @@ if [ "${MIN_SIZE}" != "varies_by_storage_class" ]; then
 fi
 echo "    LifecycleConfiguration.TransitionDefaultMinimumObjectSize reached AWS (issue #1495)"
 
+assert_drift_clean "after the phase-1 deploy"
+
 CREATION_P1="$(aws s3api list-buckets \
   --query "Buckets[?Name=='${SRC_BUCKET}'].CreationDate | [0]" --output text)"
 echo "    baseline source-bucket CreationDate=${CREATION_P1}"
@@ -219,6 +257,8 @@ if [ "${CREATION_P1}" != "${CREATION_P2}" ]; then
   exit 1
 fi
 echo "    source bucket identity preserved (CreationDate unchanged) — no replacement"
+
+assert_drift_clean "after the phase-2 update"
 
 # --- Phase 3: destroy ----------------------------------------------------
 echo "==> Phase 3: destroy"


### PR DESCRIPTION
## Summary

Adds the READ-side real-AWS proof for the issue #1495 nested S3 blocks: the `s3-replication-and-filter` integ fixture now runs `cdkd drift --json` after the phase-1 deploy AND after the phase-2 update, asserting

- exit 0 (no drift anywhere in the stack), and
- the source bucket is reported **checked + clean by name** (`.[].clean[]` contains `SourceBucket*`) — exit 0 alone would also pass on an `unsupported`/`skipped` resource, which is exactly the masking the issue calls out.

The WRITE side of the twenty #1495 keys was already proven by this fixture's read-backs; the read side (`readCurrentState` reassembly) was mock-only until now. The concrete phantom-drift candidate (`SourceSelectionCriteria.SseKmsEncryptedObjects` appearing in the observed `Rules` array next to the declared `ReplicaModifications`) did NOT materialize — the run is clean against real AWS.

Closes #1530

## Test plan

- `/run-integ s3-replication-and-filter`: PASS — all 3 phases (deploy + drift-clean, update + drift-clean, destroy), 0 errors / 0 orphans; ledger row committed.
- Full local suite: 9728 tests pass; fixture lints (probe/signal-trap/cli-flag/version-literal/aws-verb) pass.
