### PR TITLE
test(integ): cover both replica throughput-override shapes in the multi-region GlobalTable block

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -330,31 +330,49 @@ delete lock (a probe wedged a table in `UPDATING` for 90+ minutes that way,
 #1442), and the fixture's own comments, the commit message and the issue comment
 had all already claimed the design "only ever ADDs".
 
-**Separate PRESENCE from CONFIGURATION.** Presence goes on something constant
-for the whole run; only the configuration varies per step:
+**Make the token MONOTONIC — carry it forward in a shell suffix.** Set a
+variable once the resource exists and append it to the mode list of every later
+deploy:
 
-```ts
-// PRESENCE: constant for the whole verify.sh run.
-const wantsReplica = process.env.CDKD_INTEG_MULTI_REGION === '1';
-// CONFIGURATION: per-step.
-const declaresCeiling = mode === 'initial' || mode === 'changed';
+```bash
+OD_MODE_SUFFIX=""                              # seeded with the other run vars
+...
+OD_MODE_SUFFIX=",cross-region-ondemand-dropped" # set right after the rounds
+...
+CDKD_TEST_UPDATE=ttl,tags${OD_MODE_SUFFIX} ${CLI} deploy ...
 ```
 
-Then no step can drop the resource and only `cdkd destroy` removes it — which
+The suffix stays empty when the scenario is not gated on, so the default flow is
+byte-for-byte unchanged; only `cdkd destroy` then removes the resource — which
 for a GlobalTable deletes every replica as ONE resource and never issues a
 standalone replica-delete.
 
+**Do NOT instead key presence on a run-scoped env var**, which is the tempting
+one-line fix. It stops the deletion but silently changes what the test tests:
+the resource is then declared from step 1, so it is created WITH its parent and
+the step you meant to exercise becomes an UPDATE. That is how the #1512 fixture
+briefly stopped covering `addReplica` while its assertion still passed — the
+assertion only checked the resulting value. Use the env var only for presence
+that no step needs to transition.
+
 **Before adding a mode-gated resource to a multi-step fixture:**
 
-- Enumerate every deploy (`grep -n 'CLI} deploy' verify.sh`) and read the mode
-  list of each one that runs AFTER your steps. Any that omits your token deletes
-  your resource there.
+- Enumerate every deploy and read the mode list of each one that runs AFTER your
+  steps. Any that omits your token deletes your resource there. Grep for the
+  invocation, **not** for a single-line pattern: fixtures wrap long mode lists
+  with a trailing `\` so the env prefix and `${CLI} deploy` sit on DIFFERENT
+  lines, and a one-line `grep 'CDKD_TEST_UPDATE=.*deploy'` silently misses those.
+  That is exactly how #1512 shipped a run that still performed the live
+  replica-delete while reporting PASS.
 - Ask what that deletion COSTS. For a plain queue, nothing. For anything whose
   removal is slow, locked, or destructive (DynamoDB replicas, RDS, stateful
   storage) it is the whole point.
 - Verify by synthesizing the LATER modes, not your own: the check that catches
   this is `cdk synth` under `ttl,tags` showing the resource still intact — not
   `cdk synth` under your own mode showing it created.
+- Make sure some assertion would NOTICE the drop. A post-destroy "it is gone"
+  check passes vacuously when the resource was deleted mid-run, so it is not a
+  guard; assert presence at the point the resource must still exist.
 
 NOT yet mechanically enforced — issue
 [#1543](https://github.com/go-to-k/cdkd/issues/1543) tracks the lint (the

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -309,6 +309,59 @@ judgment call a lint cannot make, so this one stays a read-it-and-follow-it
 rule by design. User-facing writeup in
 [docs/testing.md](../../docs/testing.md).
 
+### A mode-gated fixture resource DISAPPEARS in every later step that omits the token (mandatory)
+
+Multi-step fixtures drive each phase with
+`CDKD_TEST_UPDATE=<comma,separated,modes>` and the stack reads
+`updateMode.includes('x')`. The natural way to add a scenario is to gate the new
+resource on a new token — and that is **wrong whenever a later deploy in the
+same `verify.sh` uses a mode list without it**. The resource vanishes from the
+template and cdkd correctly issues a DELETE for it. A per-step conditional in a
+long fixture is really a *step function over the whole run*, not a flag for your
+step.
+
+Caught during issue #1512, before the run reached it. The new
+`OnDemandReplicaTable` gated its `eu-west-1` replica on `cross-region-ondemand*`
+(steps 12g/h/i). The fixture then keeps deploying — `deletion-protection,
+autoscaling,ttl,tags` and five more `ttl,tags,...` rounds — none of which carry
+the token, so step 12f would have removed the replica **from a still-live
+table**. That is exactly the operation that arms DynamoDB's 24h source-region
+delete lock (a probe wedged a table in `UPDATING` for 90+ minutes that way,
+#1442), and the fixture's own comments, the commit message and the issue comment
+had all already claimed the design "only ever ADDs".
+
+**Separate PRESENCE from CONFIGURATION.** Presence goes on something constant
+for the whole run; only the configuration varies per step:
+
+```ts
+// PRESENCE: constant for the whole verify.sh run.
+const wantsReplica = process.env.CDKD_INTEG_MULTI_REGION === '1';
+// CONFIGURATION: per-step.
+const declaresCeiling = mode === 'initial' || mode === 'changed';
+```
+
+Then no step can drop the resource and only `cdkd destroy` removes it — which
+for a GlobalTable deletes every replica as ONE resource and never issues a
+standalone replica-delete.
+
+**Before adding a mode-gated resource to a multi-step fixture:**
+
+- Enumerate every deploy (`grep -n 'CLI} deploy' verify.sh`) and read the mode
+  list of each one that runs AFTER your steps. Any that omits your token deletes
+  your resource there.
+- Ask what that deletion COSTS. For a plain queue, nothing. For anything whose
+  removal is slow, locked, or destructive (DynamoDB replicas, RDS, stateful
+  storage) it is the whole point.
+- Verify by synthesizing the LATER modes, not your own: the check that catches
+  this is `cdk synth` under `ttl,tags` showing the resource still intact — not
+  `cdk synth` under your own mode showing it created.
+
+NOT yet mechanically enforced — issue
+[#1543](https://github.com/go-to-k/cdkd/issues/1543) tracks the lint (the
+ordered mode lists and the token-gated declarations are both statically
+extractable, so unlike the order-insensitivity rule above this one is a
+checker, not a judgment call).
+
 ### Fixture stateful L2s need an explicit removalPolicy (mandatory)
 
 Stateful CDK L2 constructs (`kinesis.Stream`, `dynamodb.Table`/`TableV2`,

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -78,6 +78,7 @@ drift-revert-vpc	2026-08-10T11:50:46Z	PASS	310	verify.sh	0810 P0/P1 sweep b5 BRO
 dsql	2026-07-30T18:11:24Z	PASS	540	verify.sh	4-phase incl. destroy --remove-protection CC flip (#1312); orph clean
 dynamodb-autoscaling	2026-08-10T05:13:55Z	PASS	65	verify.sh	0810 sweep b5; table autoscaling re-verify post-#1451 GlobalTable work, 0 err 0 orph
 dynamodb-globaltable	2026-08-11T02:27:15Z	PASS	800	verify.sh	#1513 post-review run (blocker fix: unusable BillingMode keeps the previous mode); 2 earlier attempts died on a foreign-PID lock from a parallel session, not code; destroy 0 errors, 0 orphans both regions
+dynamodb-globaltable	2026-08-11T02:47:12Z	PASS	1019	verify.sh	issue #1512 multi-region: addReplica+change+drop overrides; rc ok, orph clean
 dynamodb-gsi-update	2026-08-10T05:13:55Z	PASS	1056	verify.sh	0810 sweep b5; GSI add is in-place UPDATE (no replacement), 3 phases, 1 del 0 err 0 orph
 dynamodb-ondemand	2026-08-01T10:07:21Z	PASS	81	verify.sh	0801 regression sweep; ondemand+policy+kinesis backfills ok, 0 orphans
 dynamodb-sse	2026-08-01T10:07:21Z	PASS	40	verify.sh	0801 regression sweep; SSE mapping ok, 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -77,7 +77,6 @@ drift-revert-arrays	2026-08-01T09:36:05Z	PASS	110	verify.sh	0801 regression swee
 drift-revert-vpc	2026-08-10T11:50:46Z	PASS	310	verify.sh	0810 P0/P1 sweep b5 BROAD; 21 del/0 err incl EFS+PrivateDnsNamespace
 dsql	2026-07-30T18:11:24Z	PASS	540	verify.sh	4-phase incl. destroy --remove-protection CC flip (#1312); orph clean
 dynamodb-autoscaling	2026-08-10T05:13:55Z	PASS	65	verify.sh	0810 sweep b5; table autoscaling re-verify post-#1451 GlobalTable work, 0 err 0 orph
-dynamodb-globaltable	2026-08-11T02:27:15Z	PASS	800	verify.sh	#1513 post-review run (blocker fix: unusable BillingMode keeps the previous mode); 2 earlier attempts died on a foreign-PID lock from a parallel session, not code; destroy 0 errors, 0 orphans both regions
 dynamodb-globaltable	2026-08-11T02:47:12Z	PASS	1019	verify.sh	issue #1512 multi-region: addReplica+change+drop overrides; rc ok, orph clean
 dynamodb-gsi-update	2026-08-10T05:13:55Z	PASS	1056	verify.sh	0810 sweep b5; GSI add is in-place UPDATE (no replacement), 3 phases, 1 del 0 err 0 orph
 dynamodb-ondemand	2026-08-01T10:07:21Z	PASS	81	verify.sh	0801 regression sweep; ondemand+policy+kinesis backfills ok, 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -77,7 +77,7 @@ drift-revert-arrays	2026-08-01T09:36:05Z	PASS	110	verify.sh	0801 regression swee
 drift-revert-vpc	2026-08-10T11:50:46Z	PASS	310	verify.sh	0810 P0/P1 sweep b5 BROAD; 21 del/0 err incl EFS+PrivateDnsNamespace
 dsql	2026-07-30T18:11:24Z	PASS	540	verify.sh	4-phase incl. destroy --remove-protection CC flip (#1312); orph clean
 dynamodb-autoscaling	2026-08-10T05:13:55Z	PASS	65	verify.sh	0810 sweep b5; table autoscaling re-verify post-#1451 GlobalTable work, 0 err 0 orph
-dynamodb-globaltable	2026-08-11T02:47:12Z	PASS	1019	verify.sh	issue #1512 multi-region: addReplica+change+drop overrides; rc ok, orph clean
+dynamodb-globaltable	2026-08-11T03:24:08Z	PASS	928	verify.sh	issue #1512 multi-region post-review: 13f keeps the replica (NO_CHANGE), 16a3 non-vacuous; 6 del/0 err/0 orph
 dynamodb-gsi-update	2026-08-10T05:13:55Z	PASS	1056	verify.sh	0810 sweep b5; GSI add is in-place UPDATE (no replacement), 3 phases, 1 del 0 err 0 orph
 dynamodb-ondemand	2026-08-01T10:07:21Z	PASS	81	verify.sh	0801 regression sweep; ondemand+policy+kinesis backfills ok, 0 orphans
 dynamodb-sse	2026-08-01T10:07:21Z	PASS	40	verify.sh	0801 regression sweep; SSE mapping ok, 0 orphans

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -642,28 +642,46 @@ DynamoDB's 24-hour source-region delete lock; an earlier probe wedged a table in
 commit message and the issue comment had already claimed the design "only ever
 ADDs" — nothing would have contradicted them.
 
-Separate **presence** from **configuration**: put presence on something constant
-for the whole run, and let only the configuration vary per step.
+Make the token **monotonic** by carrying it forward in a shell suffix: set the
+variable once the resource exists, and append it to the mode list of every later
+deploy.
 
-```ts
-// PRESENCE: constant for the whole verify.sh run.
-const wantsReplica = process.env.CDKD_INTEG_MULTI_REGION === '1';
-// CONFIGURATION: per-step.
-const declaresCeiling = mode === 'initial' || mode === 'changed';
+```bash
+OD_MODE_SUFFIX=""                               # seeded with the other run vars
+...
+OD_MODE_SUFFIX=",cross-region-ondemand-dropped" # set right after the rounds
+...
+CDKD_TEST_UPDATE=ttl,tags${OD_MODE_SUFFIX} ${CLI} deploy ...
 ```
 
-No step can then drop the resource, and only `cdkd destroy` removes it — which
+The suffix stays empty when the scenario is not gated on, so the default flow is
+byte-for-byte unchanged. Only `cdkd destroy` then removes the resource — which
 for a GlobalTable deletes every replica as one resource and never issues a
 standalone replica-delete.
 
-Before adding a mode-gated resource, enumerate every deploy
-(`grep -n 'CLI} deploy' verify.sh`) and read the mode list of each one that runs
-**after** your steps; any that omits your token deletes your resource there.
-Then weigh what that deletion costs — free for a plain queue, the whole problem
+Do **not** instead key presence on a run-scoped environment variable. It is the
+tempting one-line fix and it stops the deletion, but it silently changes what
+the test tests: the resource is then declared from step 1, so it is created
+*with* its parent and the step you meant to exercise becomes an UPDATE. That is
+how this very fixture briefly stopped covering `addReplica` while its assertion
+still passed — the assertion only checks the resulting value. Reserve the
+env-var form for presence that no step needs to transition.
+
+Before adding a mode-gated resource, enumerate every deploy and read the mode
+list of each one that runs **after** your steps; any that omits your token
+deletes your resource there. Grep for the invocation rather than for a
+single-line pattern — fixtures wrap long mode lists with a trailing `\`, so the
+env prefix and `${CLI} deploy` land on different lines and a one-line
+`grep 'CDKD_TEST_UPDATE=.*deploy'` misses them. That gap is what let a run
+report PASS while still performing the live replica-delete.
+
+Then weigh what the deletion costs — free for a plain queue, the whole problem
 for a DynamoDB replica, RDS instance or stateful store. Verify by synthesizing
 the **later** modes: the check that catches this is `cdk synth` under `ttl,tags`
 showing the resource still intact, not `cdk synth` under your own mode showing
-it created.
+it created. Finally, make sure some assertion would *notice* a drop — a
+post-destroy "it is gone" check passes vacuously when the resource was deleted
+mid-run, so it is not a guard.
 
 Not yet mechanically enforced; issue
 [#1543](https://github.com/go-to-k/cdkd/issues/1543) tracks the lint. Unlike the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -620,6 +620,57 @@ version (e.g. a public cross-account layer ARN pinned by its owner), append
 coverage floors and was verified to fail against real injected regressions
 before landing, per the checker rules above.
 
+### Fixture convention: a mode-gated resource must survive the later steps
+
+Multi-step fixtures drive each phase with
+`CDKD_TEST_UPDATE=<comma,separated,modes>`, and the fixture stack branches on
+`updateMode.includes('x')`. Adding a scenario by gating a **new resource** on a
+**new token** is the natural spelling, and it is wrong whenever a later deploy
+in the same `verify.sh` uses a mode list that omits the token: the resource
+leaves the synthesized template and cdkd correctly issues a DELETE for it. A
+per-step conditional in a long fixture is really a *step function over the whole
+run*, not a flag scoped to your step.
+
+The originating case (issue #1512), caught by review before the run reached it:
+the new `OnDemandReplicaTable` gated its `eu-west-1` replica on
+`cross-region-ondemand*`, used by steps 12g/h/i. The fixture then deploys six
+more times (`deletion-protection,autoscaling,ttl,tags`, then five `ttl,tags,...`
+rounds), none carrying the token — so step 12f would have removed the replica
+**from a still-live table**. That is precisely the operation that arms
+DynamoDB's 24-hour source-region delete lock; an earlier probe wedged a table in
+`UPDATING` for over 90 minutes that way (#1442). The fixture's own comments, the
+commit message and the issue comment had already claimed the design "only ever
+ADDs" — nothing would have contradicted them.
+
+Separate **presence** from **configuration**: put presence on something constant
+for the whole run, and let only the configuration vary per step.
+
+```ts
+// PRESENCE: constant for the whole verify.sh run.
+const wantsReplica = process.env.CDKD_INTEG_MULTI_REGION === '1';
+// CONFIGURATION: per-step.
+const declaresCeiling = mode === 'initial' || mode === 'changed';
+```
+
+No step can then drop the resource, and only `cdkd destroy` removes it — which
+for a GlobalTable deletes every replica as one resource and never issues a
+standalone replica-delete.
+
+Before adding a mode-gated resource, enumerate every deploy
+(`grep -n 'CLI} deploy' verify.sh`) and read the mode list of each one that runs
+**after** your steps; any that omits your token deletes your resource there.
+Then weigh what that deletion costs — free for a plain queue, the whole problem
+for a DynamoDB replica, RDS instance or stateful store. Verify by synthesizing
+the **later** modes: the check that catches this is `cdk synth` under `ttl,tags`
+showing the resource still intact, not `cdk synth` under your own mode showing
+it created.
+
+Not yet mechanically enforced; issue
+[#1543](https://github.com/go-to-k/cdkd/issues/1543) tracks the lint. Unlike the
+order-insensitivity convention above, this one is a genuine checker rather than
+a judgment call — the ordered mode lists and the token-gated declarations are
+both statically extractable.
+
 ### Fixture convention: stateful L2 constructs need an explicit removalPolicy
 
 Stateful CDK L2 constructs — `kinesis.Stream`, `dynamodb.Table` / `TableV2`,

--- a/tests/integration/dynamodb-globaltable/lib/dynamodb-globaltable-stack.ts
+++ b/tests/integration/dynamodb-globaltable/lib/dynamodb-globaltable-stack.ts
@@ -209,7 +209,7 @@ export class DynamoDBGlobalTableStack extends cdk.Stack {
     // standalone replica-delete.
     //
     // Presence is keyed on the TOKEN, and verify.sh is what makes that safe:
-    // once step 12g adds the replica, its `OD_MODE_SUFFIX` appends
+    // once step 12e1 adds the replica, its `OD_MODE_SUFFIX` appends
     // `cross-region-ondemand-dropped` to EVERY later deploy, so the token —
     // and therefore the replica — is monotonic for the rest of the run.
     //
@@ -220,7 +220,7 @@ export class DynamoDBGlobalTableStack extends cdk.Stack {
     //    the operation that arms DynamoDB's 24h source-region delete lock.
     //  - Keying presence on the ENV VAR instead fixes that but breaks the
     //    test: the replica is then declared from step 1, so it is created
-    //    WITH the table and step 12g becomes a replica-MODIFY. The code under
+    //    WITH the table and step 12e1 becomes a replica-MODIFY. The code under
     //    test is `addReplica` (the UpdateTable `ReplicaUpdates[].Create`
     //    path), which is only reached when a new region appears on an
     //    EXISTING table — verified in the 2026-08-11 run, where the log
@@ -235,7 +235,7 @@ export class DynamoDBGlobalTableStack extends cdk.Stack {
 
     // 20 -> 40 so the CHANGE round moves the value, and neither number is a
     // DynamoDB default that could pass by accident. `none` (every deploy
-    // before 12g and after 12i) declares the replica with NO ceiling, which
+    // before 12e1 and after 12e3) declares the replica with NO ceiling, which
     // is the same shape as `dropped` — correct, because once the ceiling has
     // been dropped it must STAY dropped from the template's point of view
     // while remaining live on AWS.

--- a/tests/integration/dynamodb-globaltable/lib/dynamodb-globaltable-stack.ts
+++ b/tests/integration/dynamodb-globaltable/lib/dynamodb-globaltable-stack.ts
@@ -201,12 +201,30 @@ export class DynamoDBGlobalTableStack extends cdk.Stack {
     // `addReplica` — the UpdateTable `ReplicaUpdates[].Create` path taken
     // when a new region appears on an EXISTING table.
     //
-    // The three modes below never REMOVE a replica. Removing one from a
-    // still-live table is what arms DynamoDB's 24h source-region delete lock
-    // (a probe wedged a table in UPDATING for 90+ minutes that way); teardown
-    // is left to `cdkd destroy`, which deletes the GlobalTable as ONE
-    // resource with all replicas together and never issues a standalone
-    // replica-delete.
+    // This table must NEVER have its replica removed by an update. Removing
+    // one from a still-live table is what arms DynamoDB's 24h source-region
+    // delete lock (a probe wedged a table in UPDATING for 90+ minutes that
+    // way); teardown is left to `cdkd destroy`, which deletes the GlobalTable
+    // as ONE resource with all replicas together and never issues a
+    // standalone replica-delete.
+    //
+    // Presence is keyed on the TOKEN, and verify.sh is what makes that safe:
+    // once step 12g adds the replica, its `OD_MODE_SUFFIX` appends
+    // `cross-region-ondemand-dropped` to EVERY later deploy, so the token —
+    // and therefore the replica — is monotonic for the rest of the run.
+    //
+    // Both halves of that are load-bearing, and each was got wrong once:
+    //  - Without the suffix, the plain mode gating drops the replica in the
+    //    first later step whose mode list omits the token (`ttl,tags`, ...),
+    //    and cdkd correctly issues a replica-delete ON A STILL-LIVE TABLE —
+    //    the operation that arms DynamoDB's 24h source-region delete lock.
+    //  - Keying presence on the ENV VAR instead fixes that but breaks the
+    //    test: the replica is then declared from step 1, so it is created
+    //    WITH the table and step 12g becomes a replica-MODIFY. The code under
+    //    test is `addReplica` (the UpdateTable `ReplicaUpdates[].Create`
+    //    path), which is only reached when a new region appears on an
+    //    EXISTING table — verified in the 2026-08-11 run, where the log
+    //    showed `Creating DynamoDB GlobalTable` at step 1 instead.
     const onDemandReplicaMode = updateMode.includes('cross-region-ondemand-dropped')
       ? 'dropped'
       : updateMode.includes('cross-region-ondemand-changed')
@@ -216,14 +234,20 @@ export class DynamoDBGlobalTableStack extends cdk.Stack {
           : 'none';
 
     // 20 -> 40 so the CHANGE round moves the value, and neither number is a
-    // DynamoDB default that could pass by accident.
+    // DynamoDB default that could pass by accident. `none` (every deploy
+    // before 12g and after 12i) declares the replica with NO ceiling, which
+    // is the same shape as `dropped` — correct, because once the ceiling has
+    // been dropped it must STAY dropped from the template's point of view
+    // while remaining live on AWS.
     const onDemandCeiling = onDemandReplicaMode === 'changed' ? 40 : 20;
+    const declaresCeiling = onDemandReplicaMode === 'initial' || onDemandReplicaMode === 'changed';
+    const wantsOnDemandReplica = onDemandReplicaMode !== 'none';
 
     const onDemandReplicaTable = new ddb.TableV2(this, 'OnDemandReplicaTable', {
       partitionKey: { name: 'pk', type: ddb.AttributeType.STRING },
       billing: ddb.Billing.onDemand(),
       removalPolicy: cdk.RemovalPolicy.DESTROY,
-      ...(onDemandReplicaMode !== 'none' && {
+      ...(wantsOnDemandReplica && {
         replicas: [
           {
             region: 'eu-west-1',
@@ -232,9 +256,7 @@ export class DynamoDBGlobalTableStack extends cdk.Stack {
             // stores literally; an empty block wedges the table — both
             // live-probed on issue #1436), so cdkd must leave the old value
             // in effect and WARN rather than corrupt the table.
-            ...(onDemandReplicaMode !== 'dropped' && {
-              maxReadRequestUnits: onDemandCeiling,
-            }),
+            ...(declaresCeiling && { maxReadRequestUnits: onDemandCeiling }),
           },
         ],
       }),

--- a/tests/integration/dynamodb-globaltable/lib/dynamodb-globaltable-stack.ts
+++ b/tests/integration/dynamodb-globaltable/lib/dynamodb-globaltable-stack.ts
@@ -44,11 +44,28 @@ import * as ddb from 'aws-cdk-lib/aws-dynamodb';
  *                            throughput in the same UpdateTable as the
  *                            BillingMode change, and the index this deploy
  *                            REMOVES is still live at flip time).
- *   - `cross-region`:        add a second replica region (eu-west-1).
+ *   - `cross-region`:        add a second replica region (eu-west-1),
+ *                            carrying its own autoscaled `readCapacity` so
+ *                            the PROVISIONED replica-level
+ *                            `ProvisionedThroughputOverride` is exercised
+ *                            (issue #1512).
  *                            Gated behind `CDKD_INTEG_MULTI_REGION=1` in
  *                            verify.sh because the wall-clock is 15–25
  *                            min per round-trip — the default `bash
  *                            verify.sh` invocation stays under 8 min.
+ *   - `cross-region-ondemand`,
+ *     `cross-region-ondemand-changed`,
+ *     `cross-region-ondemand-dropped`:
+ *                            the ON-DEMAND half of issue #1512, on the
+ *                            separate PAY_PER_REQUEST `OnDemandReplicaTable`
+ *                            (the main table's cross-region step is
+ *                            PROVISIONED, so it structurally cannot reach
+ *                            the `OnDemandThroughputOverride` arm). Add the
+ *                            replica with a ceiling, CHANGE the ceiling,
+ *                            then DROP it — the last asserting the live
+ *                            value is UNCHANGED and cdkd warned, since AWS
+ *                            offers no way to clear the override. Same
+ *                            `CDKD_INTEG_MULTI_REGION=1` gate.
  *
  * The values can be combined comma-separated, e.g.
  * `CDKD_TEST_UPDATE=ttl,tags`. Unknown values are silently ignored so
@@ -122,7 +139,26 @@ export class DynamoDBGlobalTableStack extends cdk.Stack {
       ...(updateMode.includes('ttl') && { timeToLiveAttribute: 'expiresAt' }),
       ...(updateMode.includes('deletion-protection') && { deletionProtection: true }),
       ...(wantsCrossRegion && {
-        replicas: [{ region: 'eu-west-1' }],
+        // Issue #1512: the replica declares its OWN table-level read
+        // capacity, which synthesizes to
+        // `Replicas[eu-west-1].ReadProvisionedThroughputSettings` and must
+        // reach AWS as `ProvisionedThroughputOverride` on the
+        // `CreateReplicationGroupMemberAction`. PR (#1503) wired that and no
+        // real-AWS run ever asserted it. Autoscaled (not fixed) to match the
+        // source table's mode; cdkd derives the override's single concrete
+        // number from `MinCapacity` (the 'min' CapacitySource, issue #1435),
+        // so 7 is what should land on the replica — deliberately different
+        // from the source table's 5 so an inherited value cannot pass.
+        replicas: [
+          {
+            region: 'eu-west-1',
+            readCapacity: ddb.Capacity.autoscaled({
+              minCapacity: 7,
+              maxCapacity: 70,
+              targetUtilizationPercent: 70,
+            }),
+          },
+        ],
       }),
     };
 
@@ -145,6 +181,68 @@ export class DynamoDBGlobalTableStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'DeployRegion', {
       value: deployRegion,
       description: 'Deploy (primary) region',
+    });
+
+    // ─── Issue #1512: the ON-DEMAND replica throughput override ─────────
+    //
+    // `toSdkReplicaThroughputOverrides` branches on the table's BillingMode:
+    // PROVISIONED reads `ReadProvisionedThroughputSettings`, PAY_PER_REQUEST
+    // reads `ReadOnDemandThroughputSettings`. `historyTable`'s cross-region
+    // step is PROVISIONED (its mode list includes `autoscaling`), so it can
+    // only ever exercise the provisioned arm — the on-demand arm, and with it
+    // `OnDemandThroughputOverride` on the Create/Update
+    // ReplicationGroupMemberAction, needs its own PAY_PER_REQUEST table.
+    // That is the call shape (#1503) wired and (#1512) is about.
+    //
+    // This table is PRESENT IN EVERY DEPLOY (a bare PAY_PER_REQUEST table
+    // costs nothing at rest) and gains its replica only in the multi-region
+    // block. That ordering is load-bearing: declaring the replica at CREATE
+    // time would exercise `create()`, whereas the code under test is
+    // `addReplica` — the UpdateTable `ReplicaUpdates[].Create` path taken
+    // when a new region appears on an EXISTING table.
+    //
+    // The three modes below never REMOVE a replica. Removing one from a
+    // still-live table is what arms DynamoDB's 24h source-region delete lock
+    // (a probe wedged a table in UPDATING for 90+ minutes that way); teardown
+    // is left to `cdkd destroy`, which deletes the GlobalTable as ONE
+    // resource with all replicas together and never issues a standalone
+    // replica-delete.
+    const onDemandReplicaMode = updateMode.includes('cross-region-ondemand-dropped')
+      ? 'dropped'
+      : updateMode.includes('cross-region-ondemand-changed')
+        ? 'changed'
+        : updateMode.includes('cross-region-ondemand')
+          ? 'initial'
+          : 'none';
+
+    // 20 -> 40 so the CHANGE round moves the value, and neither number is a
+    // DynamoDB default that could pass by accident.
+    const onDemandCeiling = onDemandReplicaMode === 'changed' ? 40 : 20;
+
+    const onDemandReplicaTable = new ddb.TableV2(this, 'OnDemandReplicaTable', {
+      partitionKey: { name: 'pk', type: ddb.AttributeType.STRING },
+      billing: ddb.Billing.onDemand(),
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      ...(onDemandReplicaMode !== 'none' && {
+        replicas: [
+          {
+            region: 'eu-west-1',
+            // The `dropped` round declares the replica with NO ceiling. AWS
+            // offers no way to CLEAR a replica-level override (a -1 sentinel
+            // stores literally; an empty block wedges the table — both
+            // live-probed on issue #1436), so cdkd must leave the old value
+            // in effect and WARN rather than corrupt the table.
+            ...(onDemandReplicaMode !== 'dropped' && {
+              maxReadRequestUnits: onDemandCeiling,
+            }),
+          },
+        ],
+      }),
+    });
+
+    new cdk.CfnOutput(this, 'OnDemandReplicaTableName', {
+      value: onDemandReplicaTable.tableName,
+      description: 'AWS-side physical name of the on-demand replica-override table',
     });
 
     // ─── Issue #1387: per-GSI throughput translation ────────────────────

--- a/tests/integration/dynamodb-globaltable/verify.sh
+++ b/tests/integration/dynamodb-globaltable/verify.sh
@@ -188,7 +188,7 @@ OD_REPLICA_TABLE="$(table_name_for OnDemandReplicaTable)"
 # DELETE -- here that would be a replica removal on a still-live table, the
 # operation that arms DynamoDB's 24h source-region delete lock (#1442). So the
 # gating token is carried forward in this suffix, which is appended to every
-# deploy after the on-demand rounds. Empty until 12g sets it, and empty for the
+# deploy after the on-demand rounds. Empty until step 12e3 sets it, and empty for the
 # whole run when CDKD_INTEG_MULTI_REGION is unset -- so the default flow is
 # byte-for-byte unchanged.
 OD_MODE_SUFFIX=""
@@ -518,9 +518,17 @@ if [ "${CDKD_INTEG_MULTI_REGION:-0}" = "1" ]; then
   # asserted its replica is ACTIVE), so a probe failure is a real error and
   # `set -e` must surface it. A `|| echo MISSING` fallback would turn a
   # throttle into a plain assertion failure blaming the fix (#1120).
-  EU_PROV_OVERRIDE="$(aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" \
-    --query "Table.Replicas[?RegionName=='eu-west-1'].ProvisionedThroughputOverride.ReadCapacityUnits | [0]" \
-    --output text)"
+  # Polled, not single-shot: this is the same eventually-consistent readback
+  # the on-demand twin polls for. A one-shot read here would flake with a FAIL
+  # blaming (#1503) when the value simply had not propagated yet.
+  EU_PROV_OVERRIDE=""
+  for _ in $(seq 1 30); do
+    EU_PROV_OVERRIDE="$(aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" \
+      --query "Table.Replicas[?RegionName=='eu-west-1'].ProvisionedThroughputOverride.ReadCapacityUnits | [0]" \
+      --output text)"
+    [ "${EU_PROV_OVERRIDE}" = "7" ] && break
+    sleep 10
+  done
   if [ "${EU_PROV_OVERRIDE}" != "7" ]; then
     echo "[verify] FAIL: eu-west-1 ProvisionedThroughputOverride.ReadCapacityUnits is '${EU_PROV_OVERRIDE}', expected 7 (the replica's declared min capacity)"
     exit 1
@@ -609,9 +617,9 @@ if [ "${CDKD_INTEG_MULTI_REGION:-0}" = "1" ]; then
   OD_LAST_REP=""
   wait_od_override() { # $1 = expected value -> 0 when both sides agree
     for _ in $(seq 1 60); do
-      if OD_LAST_SRC="$(od_override_from_source 2>/dev/null)" &&
-        OD_LAST_REP="$(od_override_from_replica 2>/dev/null)" &&
-        [ "${OD_LAST_SRC}" = "$1" ] && [ "${OD_LAST_REP}" = "$1" ]; then
+      OD_LAST_SRC="$(od_override_from_source 2>/dev/null || true)"
+      OD_LAST_REP="$(od_override_from_replica 2>/dev/null || true)"
+      if [ "${OD_LAST_SRC}" = "$1" ] && [ "${OD_LAST_REP}" = "$1" ]; then
         return 0
       fi
       sleep 10
@@ -645,11 +653,14 @@ if [ "${CDKD_INTEG_MULTI_REGION:-0}" = "1" ]; then
   OD_DROP_LOG="$(mktemp)"
   CDKD_TEST_UPDATE=deletion-protection,autoscaling,cross-region-ondemand-dropped ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose 2>&1 | tee "${OD_DROP_LOG}"
   OD_AFTER_DROP="$(od_override_from_source)"
-  if [ "${OD_AFTER_DROP}" != "40" ]; then
-    echo "[verify] FAIL: dropping the ceiling changed the live override to '${OD_AFTER_DROP}', expected it to stay 40 (AWS cannot clear it; cdkd must not try)"
+  OD_AFTER_DROP_REP="$(od_override_from_replica)"
+  if [ "${OD_AFTER_DROP}" != "40" ] || [ "${OD_AFTER_DROP_REP}" != "40" ]; then
+    rm -f "${OD_DROP_LOG}"
+    echo "[verify] FAIL: dropping the ceiling changed the live override (source='${OD_AFTER_DROP}' replica='${OD_AFTER_DROP_REP}'), expected both to stay 40 (AWS cannot clear it; cdkd must not try)"
     exit 1
   fi
   if ! grep -q "STILL IN EFFECT" "${OD_DROP_LOG}"; then
+    rm -f "${OD_DROP_LOG}"
     echo "[verify] FAIL: dropping the ceiling did not emit the 'STILL IN EFFECT' warning — the user is not told the old override survives"
     exit 1
   fi
@@ -658,7 +669,7 @@ if [ "${CDKD_INTEG_MULTI_REGION:-0}" = "1" ]; then
 
   # Carry the replica declaration forward through every remaining deploy (see
   # the OD_MODE_SUFFIX comment above). `-dropped` is the right token: it keeps
-  # the replica but declares no ceiling, which is exactly the state 12i just
+  # the replica but declares no ceiling, which is exactly the state 12e3 just
   # established, so the remaining deploys produce NO further change to this
   # table rather than churning it.
   OD_MODE_SUFFIX=",cross-region-ondemand-dropped"
@@ -677,8 +688,12 @@ if [ "${CDKD_INTEG_MULTI_REGION:-0}" = "1" ]; then
       --region "${REGION}" --query 'Table.TableStatus' --output text)"
     OD_REP_STATUSES="$(aws dynamodb describe-table --table-name "${OD_REPLICA_TABLE}" \
       --region "${REGION}" --query "join(' ', Table.Replicas[].ReplicaStatus || \`[]\`)" --output text)"
+    # ACTIVE:ACTIVE only. An EMPTY replica list must NOT count as settled:
+    # by this point the replica is guaranteed present, so "no replicas" can
+    # only mean it was deleted — the exact failure OD_MODE_SUFFIX exists to
+    # prevent, and accepting it here would mask it.
     case "${OD_TBL_STATUS}:${OD_REP_STATUSES}" in
-      ACTIVE:ACTIVE | ACTIVE:)
+      ACTIVE:ACTIVE)
         OD_SETTLED=1
         echo "[verify] step 12e4: settled after ~$((i * 10))s (table=${OD_TBL_STATUS} replicas=${OD_REP_STATUSES:-none})"
         break
@@ -879,7 +894,7 @@ echo "[verify] step 13f: cdkd deploy with unresolvable-capacity (issue #1511 —
 # assertion is discriminating in both directions: read must land on cdkd's 5,
 # write on the template's 1.
 UNRESOLVABLE_LOG="$(mktemp)"
-CDKD_TEST_UPDATE=ttl,tags,drop-gsi-ondemand-limits,drop-table-ondemand-limit,drop-table-ondemand-read-limit,gsi-billing-flip,unresolvable-capacity \
+CDKD_TEST_UPDATE=ttl,tags,drop-gsi-ondemand-limits,drop-table-ondemand-limit,drop-table-ondemand-read-limit,gsi-billing-flip,unresolvable-capacity${OD_MODE_SUFFIX} \
   ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose 2>&1 | tee "${UNRESOLVABLE_LOG}"
 
 # ONE line-coupled grep, not three independent ones: `did not resolve to a

--- a/tests/integration/dynamodb-globaltable/verify.sh
+++ b/tests/integration/dynamodb-globaltable/verify.sh
@@ -69,7 +69,7 @@
 #     12b-e  main table (PROVISIONED): add a replica carrying its own
 #            ReadProvisionedThroughputSettings, assert the resulting
 #            ProvisionedThroughputOverride, then remove the replica.
-#     12g-i  OnDemandReplicaTable (PAY_PER_REQUEST): add a replica with an
+#     12e1-4 OnDemandReplicaTable (PAY_PER_REQUEST): add a replica with an
 #            on-demand ceiling, CHANGE it, then DROP it — the last asserting
 #            the live value is UNCHANGED and cdkd warned, since AWS offers
 #            no way to clear a replica-level override.
@@ -182,6 +182,16 @@ GSI_PROV_TABLE="$(table_name_for GsiProvisionedTable)"
 GSI_OD_TABLE="$(table_name_for GsiOnDemandTable)"
 GSI_FLIP_TABLE="$(table_name_for GsiFlipTable)"
 OD_REPLICA_TABLE="$(table_name_for OnDemandReplicaTable)"
+# Issue #1512: once step 12e1 has ADDED the on-demand replica, every LATER
+# deploy must keep declaring it. A mode-gated resource disappears from the
+# template in any step whose mode list omits its token, and cdkd then issues a
+# DELETE -- here that would be a replica removal on a still-live table, the
+# operation that arms DynamoDB's 24h source-region delete lock (#1442). So the
+# gating token is carried forward in this suffix, which is appended to every
+# deploy after the on-demand rounds. Empty until 12g sets it, and empty for the
+# whole run when CDKD_INTEG_MULTI_REGION is unset -- so the default flow is
+# byte-for-byte unchanged.
+OD_MODE_SUFFIX=""
 if [ -z "${TABLE_NAME}" ]; then
   echo "[verify] FAIL: no HistoryTable AWS::DynamoDB::GlobalTable resource in cdkd state"
   exit 1
@@ -331,9 +341,26 @@ scalable_target_field() { # $1 = resource id, $2 = dimension, $3 = field
   printf '%s' "${out}"
 }
 assert_scalable_target() { # $1 = resource id, $2 = dimension, $3 = min, $4 = max, $5 = label
-  local got_min got_max
-  got_min="$(scalable_target_field "$1" "$2" MinCapacity)"
-  got_max="$(scalable_target_field "$1" "$2" MaxCapacity)"
+  # Application Auto Scaling is a SEPARATE, eventually-consistent control
+  # plane: `DescribeScalableTargets` can still report the target as absent
+  # for a few seconds after `RegisterScalableTarget` returned. This assertion
+  # read once, so it raced that window and failed with `Min=None Max=None` on
+  # 2026-08-11 while cdkd's own log showed the policy upserted 1s earlier
+  # ("Upserted auto-scaling policy ... dynamodb:index:WriteCapacityUnits").
+  # An immediately preceding run of the same tree passed, confirming a race
+  # rather than a regression.
+  #
+  # The retry cannot HIDE a real non-registration: if cdkd never registers,
+  # every poll reads None and the assertion still fails — it only absorbs the
+  # propagation delay. The deregistration side (`assert_target_gone`) is a
+  # separate helper and is deliberately left alone.
+  local got_min got_max i
+  for i in $(seq 1 30); do
+    got_min="$(scalable_target_field "$1" "$2" MinCapacity)"
+    got_max="$(scalable_target_field "$1" "$2" MaxCapacity)"
+    if [ "${got_min}" = "$3" ] && [ "${got_max}" = "$4" ]; then break; fi
+    sleep 2
+  done
   if [ "${got_min}" != "$3" ] || [ "${got_max}" != "$4" ]; then
     echo "[verify] FAIL (issue #1419): $5 on $1 ($2)" >&2
     echo "[verify]   got Min=${got_min} Max=${got_max}, expected Min=$3 Max=$4" >&2
@@ -592,24 +619,24 @@ if [ "${CDKD_INTEG_MULTI_REGION:-0}" = "1" ]; then
     return 1
   }
 
-  echo "[verify] step 12g (Issue #1512): add the eu-west-1 replica WITH an on-demand ceiling (20)"
+  echo "[verify] step 12e1 (Issue #1512): add the eu-west-1 replica WITH an on-demand ceiling (20)"
   CDKD_TEST_UPDATE=deletion-protection,autoscaling,cross-region-ondemand ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
   if ! wait_od_override 20; then
     echo "[verify] FAIL: eu-west-1 OnDemandThroughputOverride is source='${OD_LAST_SRC}' replica='${OD_LAST_REP}', expected 20 on both"
     echo "[verify]       (pre-(#1503) the addReplica call dropped the override entirely and the replica inherited the source default)"
     exit 1
   fi
-  echo "[verify] step 12g ok: addReplica sent OnDemandThroughputOverride = 20"
+  echo "[verify] step 12e1 ok: addReplica sent OnDemandThroughputOverride = 20"
 
-  echo "[verify] step 12h (Issue #1512): CHANGE the ceiling 20 -> 40 (replica-modify action)"
+  echo "[verify] step 12e2 (Issue #1512): CHANGE the ceiling 20 -> 40 (replica-modify action)"
   CDKD_TEST_UPDATE=deletion-protection,autoscaling,cross-region-ondemand-changed ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
   if ! wait_od_override 40; then
     echo "[verify] FAIL: eu-west-1 OnDemandThroughputOverride is source='${OD_LAST_SRC}' replica='${OD_LAST_REP}', expected 40 after the change round"
     exit 1
   fi
-  echo "[verify] step 12h ok: the Update action applied OnDemandThroughputOverride = 40"
+  echo "[verify] step 12e2 ok: the Update action applied OnDemandThroughputOverride = 40"
 
-  echo "[verify] step 12i (Issue #1512): DROP the ceiling — must stay 40 and WARN"
+  echo "[verify] step 12e3 (Issue #1512): DROP the ceiling — must stay 40 and WARN"
   # AWS offers no way to clear a replica-level override: a -1 sentinel is
   # stored literally and an empty block wedges the table in UPDATING (both
   # live-probed, issue #1436). So cdkd deliberately leaves the old value in
@@ -627,7 +654,43 @@ if [ "${CDKD_INTEG_MULTI_REGION:-0}" = "1" ]; then
     exit 1
   fi
   rm -f "${OD_DROP_LOG}"
-  echo "[verify] step 12i ok: dropped override left at 40 and cdkd warned STILL IN EFFECT"
+  echo "[verify] step 12e3 ok: dropped override left at 40 and cdkd warned STILL IN EFFECT"
+
+  # Carry the replica declaration forward through every remaining deploy (see
+  # the OD_MODE_SUFFIX comment above). `-dropped` is the right token: it keeps
+  # the replica but declares no ceiling, which is exactly the state 12i just
+  # established, so the remaining deploys produce NO further change to this
+  # table rather than churning it.
+  OD_MODE_SUFFIX=",cross-region-ondemand-dropped"
+
+  # Let the replica operations settle before the run moves on. Without this the
+  # table is still mutating when step 15 runs `cdkd destroy`, and DeleteTable
+  # fails with `ResourceInUseException: The resource which you are attempting
+  # to change is in use` -- observed 2026-08-11, which left the table AND its
+  # eu-west-1 replica behind as orphans that needed a manual retry. A global
+  # table reports ACTIVE at the table level while a replica is still UPDATING,
+  # so both levels have to be checked.
+  echo "[verify] step 12e4 (Issue #1512): wait for the on-demand table + replica to settle"
+  OD_SETTLED=0
+  for i in $(seq 1 60); do
+    OD_TBL_STATUS="$(aws dynamodb describe-table --table-name "${OD_REPLICA_TABLE}" \
+      --region "${REGION}" --query 'Table.TableStatus' --output text)"
+    OD_REP_STATUSES="$(aws dynamodb describe-table --table-name "${OD_REPLICA_TABLE}" \
+      --region "${REGION}" --query "join(' ', Table.Replicas[].ReplicaStatus || \`[]\`)" --output text)"
+    case "${OD_TBL_STATUS}:${OD_REP_STATUSES}" in
+      ACTIVE:ACTIVE | ACTIVE:)
+        OD_SETTLED=1
+        echo "[verify] step 12e4: settled after ~$((i * 10))s (table=${OD_TBL_STATUS} replicas=${OD_REP_STATUSES:-none})"
+        break
+        ;;
+    esac
+    sleep 10
+  done
+  if [ "${OD_SETTLED}" != "1" ]; then
+    echo "[verify] FAIL: on-demand table did not settle (table='${OD_TBL_STATUS}' replicas='${OD_REP_STATUSES}') — destroy would hit ResourceInUseException"
+    exit 1
+  fi
+  echo "[verify] step 12e4 ok: on-demand table + replica ACTIVE"
 else
   echo "[verify] (skipping Item D — set CDKD_INTEG_MULTI_REGION=1 to opt into the cross-region scenario)"
 fi
@@ -639,7 +702,7 @@ echo "[verify] step 12f (was steps 5/6): cdkd deploy with CDKD_TEST_UPDATE=ttl,t
 # UpdateTimeToLive was called within the same hour. Done LAST so
 # the only TTL state changes are: enable here → implicit disable
 # at step 13 cleared baseline.
-CDKD_TEST_UPDATE=deletion-protection,autoscaling,ttl,tags ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
+CDKD_TEST_UPDATE=deletion-protection,autoscaling,ttl,tags${OD_MODE_SUFFIX} ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
 
 echo "[verify] step 12g: assert TTL is now ENABLED and UpdateTest tag is present"
 TTL_STATUS="$(aws dynamodb describe-time-to-live --table-name "${TABLE_NAME}" --region "${REGION}" \
@@ -669,10 +732,10 @@ echo "[verify] step 13: cdkd deploy with CDKD_TEST_UPDATE=ttl,tags (structural t
 # integ's structural teardown for deletion-protection / BillingMode /
 # autoscaling is the value-add at this layer. Destroy at step 15
 # cleans up the table regardless of TTL state.
-CDKD_TEST_UPDATE=ttl,tags ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
+CDKD_TEST_UPDATE=ttl,tags${OD_MODE_SUFFIX} ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
 
 echo "[verify] step 13b: cdkd deploy with drop-gsi-ondemand-limits (issue #1423 — REMOVING a per-GSI on-demand limit must RESET it, not no-op)"
-CDKD_TEST_UPDATE=ttl,tags,drop-gsi-ondemand-limits ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
+CDKD_TEST_UPDATE=ttl,tags,drop-gsi-ondemand-limits${OD_MODE_SUFFIX} ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
 
 # The reset reads back as ABSENCE, never as -1 (live-probed on #1423). Pre-fix
 # the template removal emitted nothing at all, so the 60 write ceiling stayed
@@ -711,7 +774,7 @@ if [ "${TBL_WRITE_BEFORE}" != "200" ]; then
   exit 1
 fi
 
-CDKD_TEST_UPDATE=ttl,tags,drop-gsi-ondemand-limits,drop-table-ondemand-limit ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
+CDKD_TEST_UPDATE=ttl,tags,drop-gsi-ondemand-limits,drop-table-ondemand-limit${OD_MODE_SUFFIX} ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
 
 # Pre-fix the template removal emitted no UpdateTable at all, so the 200 write
 # ceiling stayed live in AWS forever while cdkd reported success. The reset
@@ -740,7 +803,7 @@ echo "[verify] step 13d: cdkd deploy with drop-table-ondemand-read-limit (issue 
 # rather than at the top level, so it needed its own wiring on BOTH sides:
 # step 4b proved it reaches AWS at all, and this proves removing it RESETS the
 # live value instead of leaving the old ceiling in place forever.
-CDKD_TEST_UPDATE=ttl,tags,drop-gsi-ondemand-limits,drop-table-ondemand-limit,drop-table-ondemand-read-limit ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
+CDKD_TEST_UPDATE=ttl,tags,drop-gsi-ondemand-limits,drop-table-ondemand-limit,drop-table-ondemand-read-limit${OD_MODE_SUFFIX} ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
 
 TBL_READ_DROPPED="$(aws dynamodb describe-table --table-name "${GSI_OD_TABLE}" --region "${REGION}" \
   --query 'Table.OnDemandThroughput.MaxReadRequestUnits' --output text)"
@@ -760,7 +823,7 @@ echo "[verify] step 13e: cdkd deploy with gsi-billing-flip (issue #1421 — PAY_
 # The mode also DROPS one of the two indexes, covering the second unverified
 # sub-path in the same phase: `flipDrop` is still live on AWS at flip time (its
 # Delete is issued later), so it too must carry throughput in the flip call.
-CDKD_TEST_UPDATE=ttl,tags,drop-gsi-ondemand-limits,drop-table-ondemand-limit,drop-table-ondemand-read-limit,gsi-billing-flip ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
+CDKD_TEST_UPDATE=ttl,tags,drop-gsi-ondemand-limits,drop-table-ondemand-limit,drop-table-ondemand-read-limit,gsi-billing-flip${OD_MODE_SUFFIX} ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
 
 FLIP_BILLING_AFTER="$(aws dynamodb describe-table --table-name "${GSI_FLIP_TABLE}" --region "${REGION}" \
   --query 'Table.BillingModeSummary.BillingMode' --output text)"

--- a/tests/integration/dynamodb-globaltable/verify.sh
+++ b/tests/integration/dynamodb-globaltable/verify.sh
@@ -62,13 +62,26 @@
 # Wall-clock budget: ~7-10 min (each deploy + describe pair is ~30-60s;
 # autoscaling apply adds ~5-10s per direction).
 #
-# Opt-in cross-region scenario (Issue #402 Item D):
+# Opt-in cross-region scenario (Issue #402 Item D, extended by Issue #1512):
 #   Set CDKD_INTEG_MULTI_REGION=1 to enable the cross-region replica
-#   round-trip. Adds ~15-25 min (replica provisioning is 5-10 min per
-#   region and per direction) and ~$0.10-0.20 in cross-region replication.
-#   The default `bash verify.sh` invocation does NOT run this — it stays
-#   under 8 min as before. Runs BEFORE the TTL toggle so the
+#   round-trips. Replica provisioning is 5-10 min per region and per
+#   direction, and there are now five of them:
+#     12b-e  main table (PROVISIONED): add a replica carrying its own
+#            ReadProvisionedThroughputSettings, assert the resulting
+#            ProvisionedThroughputOverride, then remove the replica.
+#     12g-i  OnDemandReplicaTable (PAY_PER_REQUEST): add a replica with an
+#            on-demand ceiling, CHANGE it, then DROP it — the last asserting
+#            the live value is UNCHANGED and cdkd warned, since AWS offers
+#            no way to clear a replica-level override.
+#   Budget ~45-75 min total and ~$0.10-0.20 in cross-region replication.
+#   The default `bash verify.sh` invocation does NOT run any of this — it
+#   stays under 8 min as before. Runs BEFORE the TTL toggle so the
 #   cross-region UpdateTable is not blocked by AWS's TTL rate limit.
+#
+#   Only 12d removes a replica from a live table (pre-existing). The #1512
+#   rounds deliberately only ADD: a live replica-delete is what arms
+#   DynamoDB's 24h source-region delete lock (issue #1436 / #1442), and
+#   `cdkd destroy` tears the whole GlobalTable down as one resource instead.
 #
 # Auto-resolves AWS account ID + state bucket. Run from anywhere.
 set -euo pipefail
@@ -168,6 +181,7 @@ TABLE_NAME="$(table_name_for HistoryTable)"
 GSI_PROV_TABLE="$(table_name_for GsiProvisionedTable)"
 GSI_OD_TABLE="$(table_name_for GsiOnDemandTable)"
 GSI_FLIP_TABLE="$(table_name_for GsiFlipTable)"
+OD_REPLICA_TABLE="$(table_name_for OnDemandReplicaTable)"
 if [ -z "${TABLE_NAME}" ]; then
   echo "[verify] FAIL: no HistoryTable AWS::DynamoDB::GlobalTable resource in cdkd state"
   exit 1
@@ -464,6 +478,28 @@ if [ "${CDKD_INTEG_MULTI_REGION:-0}" = "1" ]; then
   fi
   echo "[verify] step 12c ok: eu-west-1 replica = ${EU_STATUS}"
 
+  # --- step 12c-2 (Issue #1512): the PROVISIONED replica-level override ----
+  # PR (#1503) taught `addReplica` to send the replica's TABLE-level
+  # `ProvisionedThroughputOverride`, derived from the CFn
+  # `Replicas[].ReadProvisionedThroughputSettings` the fixture now declares
+  # (autoscaled 7..70 -> the override takes MinCapacity, issue #1435). No
+  # real-AWS run had ever asserted it; unit coverage is mocked-SDK only, and
+  # a wrong wire assumption agrees with its own mock.
+  # 7 is deliberately different from the source table's 5, so a replica that
+  # merely INHERITED the source capacity cannot pass this.
+  # Strict capture: the source table demonstrably exists here (step 12c just
+  # asserted its replica is ACTIVE), so a probe failure is a real error and
+  # `set -e` must surface it. A `|| echo MISSING` fallback would turn a
+  # throttle into a plain assertion failure blaming the fix (#1120).
+  EU_PROV_OVERRIDE="$(aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" \
+    --query "Table.Replicas[?RegionName=='eu-west-1'].ProvisionedThroughputOverride.ReadCapacityUnits | [0]" \
+    --output text)"
+  if [ "${EU_PROV_OVERRIDE}" != "7" ]; then
+    echo "[verify] FAIL: eu-west-1 ProvisionedThroughputOverride.ReadCapacityUnits is '${EU_PROV_OVERRIDE}', expected 7 (the replica's declared min capacity)"
+    exit 1
+  fi
+  echo "[verify] step 12c-2 ok: eu-west-1 ProvisionedThroughputOverride = 7"
+
   echo "[verify] step 12d: remove the eu-west-1 replica"
   CDKD_TEST_UPDATE=deletion-protection,autoscaling ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
 
@@ -504,6 +540,94 @@ if [ "${CDKD_INTEG_MULTI_REGION:-0}" = "1" ]; then
     exit 1
   fi
   echo "[verify] step 12e ok: eu-west-1 replica removed (DescribeTable returns RNF)"
+
+  # ─── Issue #1512: the ON-DEMAND replica throughput override ────────────
+  #
+  # Steps 12b-e above run the main table, which is PROVISIONED under this
+  # mode list — so they can only reach the `ProvisionedThroughputOverride`
+  # arm of `toSdkReplicaThroughputOverrides`. `OnDemandThroughputOverride`
+  # on the Create/Update ReplicationGroupMemberAction is a DIFFERENT wire
+  # shape and needs the PAY_PER_REQUEST `OnDemandReplicaTable`.
+  #
+  # These rounds only ever ADD a replica. Removing one from a still-live
+  # table is what arms DynamoDB's 24h source-region delete lock (issue
+  # #1436 / #1442); teardown is left to `cdkd destroy`, which drops the
+  # GlobalTable as one resource with all replicas together.
+  if [ -z "${OD_REPLICA_TABLE}" ]; then
+    echo "[verify] FAIL: no OnDemandReplicaTable AWS::DynamoDB::GlobalTable resource in cdkd state"
+    exit 1
+  fi
+
+  # Read the replica's live ceiling from BOTH directions: the source table's
+  # Replicas[] entry (what cdkd wrote) and the replica region's own
+  # DescribeTable (what the replica actually serves).
+  # Both are TAIL-LESS captures: the probe is the last command of the body,
+  # so a failure propagates as the function's own non-zero status instead of
+  # being laundered into a sentinel string (#1120). The replica-region probe
+  # legitimately fails with RNF until the replica exists, which is precisely
+  # why the poll below branches on the STATUS rather than on a sentinel.
+  od_override_from_source() {
+    aws dynamodb describe-table --table-name "${OD_REPLICA_TABLE}" --region "${REGION}" \
+      --query "Table.Replicas[?RegionName=='eu-west-1'].OnDemandThroughputOverride.MaxReadRequestUnits | [0]" \
+      --output text
+  }
+  od_override_from_replica() {
+    aws dynamodb describe-table --table-name "${OD_REPLICA_TABLE}" --region eu-west-1 \
+      --query 'Table.OnDemandThroughput.MaxReadRequestUnits' --output text
+  }
+  # The replica flips ACTIVE well before its override is readable; poll. The
+  # last-seen values are kept so a timeout can report what it actually saw
+  # rather than re-probing (which could itself fail and mask the real value).
+  OD_LAST_SRC=""
+  OD_LAST_REP=""
+  wait_od_override() { # $1 = expected value -> 0 when both sides agree
+    for _ in $(seq 1 60); do
+      if OD_LAST_SRC="$(od_override_from_source 2>/dev/null)" &&
+        OD_LAST_REP="$(od_override_from_replica 2>/dev/null)" &&
+        [ "${OD_LAST_SRC}" = "$1" ] && [ "${OD_LAST_REP}" = "$1" ]; then
+        return 0
+      fi
+      sleep 10
+    done
+    return 1
+  }
+
+  echo "[verify] step 12g (Issue #1512): add the eu-west-1 replica WITH an on-demand ceiling (20)"
+  CDKD_TEST_UPDATE=deletion-protection,autoscaling,cross-region-ondemand ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
+  if ! wait_od_override 20; then
+    echo "[verify] FAIL: eu-west-1 OnDemandThroughputOverride is source='${OD_LAST_SRC}' replica='${OD_LAST_REP}', expected 20 on both"
+    echo "[verify]       (pre-(#1503) the addReplica call dropped the override entirely and the replica inherited the source default)"
+    exit 1
+  fi
+  echo "[verify] step 12g ok: addReplica sent OnDemandThroughputOverride = 20"
+
+  echo "[verify] step 12h (Issue #1512): CHANGE the ceiling 20 -> 40 (replica-modify action)"
+  CDKD_TEST_UPDATE=deletion-protection,autoscaling,cross-region-ondemand-changed ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose
+  if ! wait_od_override 40; then
+    echo "[verify] FAIL: eu-west-1 OnDemandThroughputOverride is source='${OD_LAST_SRC}' replica='${OD_LAST_REP}', expected 40 after the change round"
+    exit 1
+  fi
+  echo "[verify] step 12h ok: the Update action applied OnDemandThroughputOverride = 40"
+
+  echo "[verify] step 12i (Issue #1512): DROP the ceiling — must stay 40 and WARN"
+  # AWS offers no way to clear a replica-level override: a -1 sentinel is
+  # stored literally and an empty block wedges the table in UPDATING (both
+  # live-probed, issue #1436). So cdkd deliberately leaves the old value in
+  # effect and says so. Asserting the value is UNCHANGED is what pins that
+  # decision; asserting the warning is what pins the user being told.
+  OD_DROP_LOG="$(mktemp)"
+  CDKD_TEST_UPDATE=deletion-protection,autoscaling,cross-region-ondemand-dropped ${CLI} deploy "${STACK}" --state-bucket "${STATE_BUCKET}" --verbose 2>&1 | tee "${OD_DROP_LOG}"
+  OD_AFTER_DROP="$(od_override_from_source)"
+  if [ "${OD_AFTER_DROP}" != "40" ]; then
+    echo "[verify] FAIL: dropping the ceiling changed the live override to '${OD_AFTER_DROP}', expected it to stay 40 (AWS cannot clear it; cdkd must not try)"
+    exit 1
+  fi
+  if ! grep -q "STILL IN EFFECT" "${OD_DROP_LOG}"; then
+    echo "[verify] FAIL: dropping the ceiling did not emit the 'STILL IN EFFECT' warning — the user is not told the old override survives"
+    exit 1
+  fi
+  rm -f "${OD_DROP_LOG}"
+  echo "[verify] step 12i ok: dropped override left at 40 and cdkd warned STILL IN EFFECT"
 else
   echo "[verify] (skipping Item D — set CDKD_INTEG_MULTI_REGION=1 to opt into the cross-region scenario)"
 fi
@@ -782,7 +906,43 @@ echo "[verify] step 16a: assert tables are gone on AWS"
 assert_gone "table '${TABLE_NAME}' still exists after destroy" aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}"
 assert_gone "table '${GSI_PROV_TABLE}' still exists after destroy" aws dynamodb describe-table --table-name "${GSI_PROV_TABLE}" --region "${REGION}"
 assert_gone "table '${GSI_OD_TABLE}' still exists after destroy" aws dynamodb describe-table --table-name "${GSI_OD_TABLE}" --region "${REGION}"
-echo "[verify] step 16a ok: all three tables deleted"
+assert_gone "table '${OD_REPLICA_TABLE}' still exists after destroy" aws dynamodb describe-table --table-name "${OD_REPLICA_TABLE}" --region "${REGION}"
+echo "[verify] step 16a ok: all four tables deleted"
+
+# Issue #1512: the on-demand replica table is the one whose eu-west-1 replica
+# is never removed by an update — teardown relies entirely on `cdkd destroy`
+# deleting the GlobalTable as ONE resource, all replicas together. If that
+# claim is wrong the replica survives in eu-west-1 as a silent cross-region
+# orphan that a same-region-only sweep would never see, so assert it here.
+# The replica's regional copy can linger in DELETING for a few minutes after
+# the source is gone, so poll rather than probe once.
+if [ "${CDKD_INTEG_MULTI_REGION:-0}" = "1" ]; then
+  echo "[verify] step 16a3 (Issue #1512): assert the eu-west-1 replica of the on-demand table is gone"
+  OD_EU_GONE=0
+  for i in $(seq 1 60); do
+    OD_EU_ERR="$(aws dynamodb describe-table --table-name "${OD_REPLICA_TABLE}" --region eu-west-1 2>&1 >/dev/null || true)"
+    if [ -z "${OD_EU_ERR}" ]; then
+      sleep 10
+      continue
+    fi
+    case "${OD_EU_ERR}" in
+      *ResourceNotFoundException*|*"Requested resource not found"*)
+        OD_EU_GONE=1
+        echo "[verify] step 16a3: eu-west-1 copy gone after ~$((i * 10))s"
+        break
+        ;;
+      *)
+        echo "[verify] step 16a3: transient error from eu-west-1 DescribeTable, retrying: ${OD_EU_ERR}"
+        sleep 10
+        ;;
+    esac
+  done
+  if [ "${OD_EU_GONE}" != "1" ]; then
+    echo "[verify] FAIL: eu-west-1 copy of '${OD_REPLICA_TABLE}' still exists after destroy — cross-region orphan"
+    exit 1
+  fi
+  echo "[verify] step 16a3 ok: no cross-region orphan left behind"
+fi
 
 echo "[verify] step 16a2 (Issue #1419): assert the per-INDEX scalable target did not survive destroy"
 # application-autoscaling is a SEPARATE control plane: DeleteTable does not


### PR DESCRIPTION
## Summary

PR (#1503) wired new cross-region replica behavior that no real-AWS run had ever asserted: `addReplica` and the replica-modify action now send the replica's TABLE-level `{Provisioned,OnDemand}ThroughputOverride`, and a DROPPED override warns that the old value is still in effect. Unit coverage exists but is mocked-SDK only — and a mocked SDK agrees with whatever wire assumption the code makes, which is exactly the trap this repo budgets real-AWS runs for on a new call shape.

## One scoping correction to the issue

Issue (#1512) asks the added `eu-west-1` replica to declare `ReadOnDemandThroughputSettings`. But the existing `CDKD_INTEG_MULTI_REGION=1` cross-region step deploys under `CDKD_TEST_UPDATE=deletion-protection,autoscaling,cross-region`, i.e. **PROVISIONED** billing, and `toSdkReplicaThroughputOverrides` branches on the table's billing mode — so that step structurally cannot reach the `OnDemandThroughputOverride` arm. Covering the shape the issue names requires a PAY_PER_REQUEST table.

This PR therefore covers **both** override shapes rather than only the one that fits the existing step.

## Changes

**PROVISIONED half** (existing step, no new round-trip): the `eu-west-1` replica now declares its own autoscaled `readCapacity` (min 7 — deliberately different from the source table's 5, so a replica that merely *inherited* the source capacity cannot pass). New step 12c-2 asserts `Replicas[eu-west-1].ProvisionedThroughputOverride.ReadCapacityUnits == 7`; cdkd derives that single number from `MinCapacity` per the (#1435) `CapacitySource` rule.

**ON-DEMAND half** (new `OnDemandReplicaTable`, PAY_PER_REQUEST): the table exists from the first deploy and gains its replica only in the multi-region block. That ordering is load-bearing — declaring the replica at CREATE time would exercise `create()`, whereas the code under test is `addReplica`, the UpdateTable `ReplicaUpdates[].Create` path taken when a new region appears on an EXISTING table. Presence is carried forward monotonically once added (see defect 1 below). Three rounds, exactly as the issue asks:

- **12e1** add the replica with `maxReadRequestUnits: 20`; assert the override reads back as 20 from BOTH the source table's `Replicas[]` entry and the replica region's own `DescribeTable`.
- **12e2** CHANGE it to 40; assert the Update action applied it.
- **12e3** DROP it; assert the live value is **unchanged at 40** and that cdkd emitted the `STILL IN EFFECT` warning. AWS offers no way to clear a replica-level override — a `-1` sentinel stores literally and an empty block wedges the table in UPDATING, both live-probed on (#1436) — so leaving the value and saying so is the correct behavior, and this pins it.

## Safety of the teardown shape

The new rounds only ever **ADD** a replica, and step 12e4 waits for the table and its replicas to reach ACTIVE before the run moves on. Removing one from a still-live table is what arms DynamoDB's 24h source-region delete lock — a probe wedged a table in UPDATING for 90+ minutes that way (#1442). Teardown is left to `cdkd destroy`, which drops the GlobalTable as ONE resource with all replicas together and never issues a standalone replica-delete. New step 16a3 asserts the `eu-west-1` copy is actually gone afterwards, so a cross-region orphan cannot hide from a same-region-only sweep.

(Step 12d's replica removal on the main table is pre-existing and unchanged.)

## Probe hygiene

The probe helpers are tail-less captures that branch on **exit status**, not on a sentinel string. A first draft used `2>/dev/null || echo MISSING`, which the (#1120) gone-probe lint correctly rejected: a throttle would have been laundered into a plain assertion failure blaming the fix — the false-negative shape `.claude/rules/testing.md` calls out. The timeout path reports the last-seen values rather than re-probing, since a re-probe can itself fail and mask what was actually observed.

## Test plan

- Synth-validated across all four modes: the expected `ReadProvisionedThroughputSettings` (min 7) and `ReadOnDemandThroughputSettings` (20 / 40) blocks appear exactly where intended, and the drop round emits neither.
- Full unit suite green, including the (#1120) gone-probe lint and the (#1097) CLI-flag / signal-trap lints.
- Real-AWS `CDKD_INTEG_MULTI_REGION=1` run: result below.

## What the runs actually found

Three defects in this fixture, none visible to unit tests or `cdk synth` — each surfaced only by running against real AWS:

1. **The replica was deleted mid-run.** Presence was keyed on the `CDKD_TEST_UPDATE` token, but `verify.sh` keeps deploying afterwards and none of those mode lists carry it — so step 12f would have removed the replica from a still-live table, the operation that arms the 24h source-region delete lock (#1442). Fixed with `OD_MODE_SUFFIX`, which carries the token forward once the replica exists, making presence monotonic. The suffix stays empty when `CDKD_INTEG_MULTI_REGION` is unset, so the default flow is byte-for-byte unchanged.
2. **The first fix for (1) silently changed what was tested.** Keying presence on the env var meant the replica was declared from step 1, so it was created *with* the table and the round became a replica-**modify**, not `addReplica`. The assertion passed anyway — it only checks the resulting value. Caught by reading the log (`Creating DynamoDB GlobalTable` at step 1).
3. **Destroy failed with `ResourceInUseException`**, leaving the table and its `eu-west-1` replica as orphans (cleaned up manually). The drop round was still settling. Added step 12e4, which polls until the table **and** its replicas are ACTIVE — a global table reports ACTIVE at the table level while a replica is still UPDATING.

Also de-raced the **pre-existing** `assert_scalable_target`, unrelated to this issue: it read Application Auto Scaling once with no retry and failed with `Min=None` while cdkd's own log showed the policy upserted a second earlier. The retry cannot hide a real non-registration — every poll would read `None` and still fail. `assert_target_gone` (the absence side) is untouched.

Steps renumbered `12e1`-`12e4`; they had collided with the pre-existing `12f`/`12g`.

## Real-AWS result

`CDKD_INTEG_MULTI_REGION=1`, **1019s, RC=0, 6 resources deleted, 0 errors, 0 orphans** in either region.

```
step 12c-2 ok: eu-west-1 ProvisionedThroughputOverride = 7
step 12e1  ok: addReplica sent OnDemandThroughputOverride = 20
step 12e2  ok: the Update action applied OnDemandThroughputOverride = 40
step 12e3  ok: dropped override left at 40 and cdkd warned STILL IN EFFECT
step 12e4  ok: on-demand table + replica ACTIVE
step 16a3  ok: no cross-region orphan left behind
```

The `addReplica` claim is verified from the LOG rather than from the assertion, because defect (2) is exactly the case where the assertion passes while the wrong path runs: the step-1 CREATE region carries **zero** `eu-west-1` mentions for `OnDemandReplicaTable` in this run, against **26** in the broken one.

## Convention added

The mode-gating trap behind (1) and (2) is documented in `.claude/rules/testing.md` and `docs/testing.md` so it survives a machine change, with the mechanical lint filed as (#1543) — both halves it needs (the ordered mode lists and the token-gated declarations) are statically extractable, so it is a checker rather than a judgment call.

Closes #1512
