### PR TITLE
fix(dynamodb): refuse a malformed Table BillingMode instead of defaulting it

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -79,7 +79,7 @@ dsql	2026-07-30T18:11:24Z	PASS	540	verify.sh	4-phase incl. destroy --remove-prot
 dynamodb-autoscaling	2026-08-10T05:13:55Z	PASS	65	verify.sh	0810 sweep b5; table autoscaling re-verify post-#1451 GlobalTable work, 0 err 0 orph
 dynamodb-globaltable	2026-08-11T02:27:15Z	PASS	800	verify.sh	#1513 post-review run (blocker fix: unusable BillingMode keeps the previous mode); 2 earlier attempts died on a foreign-PID lock from a parallel session, not code; destroy 0 errors, 0 orphans both regions
 dynamodb-gsi-update	2026-08-10T05:13:55Z	PASS	1056	verify.sh	0810 sweep b5; GSI add is in-place UPDATE (no replacement), 3 phases, 1 del 0 err 0 orph
-dynamodb-ondemand	2026-08-01T10:07:21Z	PASS	81	verify.sh	0801 regression sweep; ondemand+policy+kinesis backfills ok, 0 orphans
+dynamodb-ondemand	2026-08-11T03:21:02Z	PASS	300	verify.sh	1545 lane: BillingMode guard; destroy 0 err 0 orph
 dynamodb-sse	2026-08-01T10:07:21Z	PASS	40	verify.sh	0801 regression sweep; SSE mapping ok, 0 orphans
 dynamodb-stream-filter	2026-08-10T05:13:55Z	PASS	57	verify.sh	0810 sweep b5; stream filter criteria, 0 err 0 orph
 dynamodb-streams	2026-08-10T05:13:55Z	PASS	81	verify.sh	0810 sweep b5; streams+ESM+StreamSpec UPDATE, 0 err 0 orph

--- a/src/provisioning/providers/dynamodb-table-provider.ts
+++ b/src/provisioning/providers/dynamodb-table-provider.ts
@@ -41,12 +41,14 @@ import { ProvisioningError } from '../../utils/error-handler.js';
 import { generateResourceName } from '../resource-name.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { normalizeAwsTagsToCfn, resolveExplicitPhysicalId } from '../import-helpers.js';
+import { replayWarn, requireConfigString } from '../config-shape.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
   ResourceUpdateResult,
   ResourceImportInput,
   ResourceImportResult,
+  CreateContext,
 } from '../../types/resource.js';
 
 /**
@@ -148,7 +150,8 @@ export class DynamoDBTableProvider implements ResourceProvider {
   async create(
     logicalId: string,
     resourceType: string,
-    properties: Record<string, unknown>
+    properties: Record<string, unknown>,
+    context?: CreateContext
   ): Promise<ResourceCreateResult> {
     this.logger.debug(`Creating DynamoDB table ${logicalId}`);
 
@@ -183,8 +186,25 @@ export class DynamoDBTableProvider implements ResourceProvider {
     let tableCreated = false;
 
     try {
-      // BillingMode (default: PROVISIONED)
-      const billingMode = (properties['BillingMode'] as string | undefined) || 'PROVISIONED';
+      // BillingMode (default: PROVISIONED). Guarded per issue #1545 — the
+      // `|| 'PROVISIONED'` spelling silently substituted the default for a
+      // present-but-unusable value (a `BillingMode: null`, an intrinsic the
+      // resolver could not resolve, a hand-authored L1 typo), so a template
+      // that says PAY_PER_REQUEST could create a continuously-billed
+      // PROVISIONED table with no error anywhere. `BillingMode` is
+      // ENUM-valued, so it does NOT take `coerceNumber`: a number here is a
+      // template bug, not the unquoted-YAML scalar CFn coerces. The refusal
+      // downgrades to a warning on a state replay (`replayWarn`) — the
+      // rollback executor's reverse-replacement arm revives the OLD resource
+      // from `previousState.properties`, which the user cannot edit from the
+      // template. The read sits inside `create()`'s try, so the catch below
+      // wraps the refusal into a ProvisioningError.
+      const billingMode = requireConfigString(
+        properties['BillingMode'],
+        'PROVISIONED',
+        'AWS::DynamoDB::Table BillingMode',
+        replayWarn(this.logger, context)
+      );
 
       const createParams: CreateTableCommandInput = {
         TableName: tableName,
@@ -439,16 +459,51 @@ export class DynamoDBTableProvider implements ResourceProvider {
       const tableClassChanged =
         normalizeTableClass(properties['TableClass']) !==
         normalizeTableClass(previousProperties['TableClass']);
+      // Shape-guard the DESIRED BillingMode before the change detection
+      // (issue #1545). WARN, never throw: `rollback-executor.ts` replays a
+      // rollback via `provider.update(..., previousState.properties, ...)`,
+      // so the desired bag here can itself be a historical state record — a
+      // hard refusal would make the table un-rollbackable with no
+      // template-side remedy. An UNUSABLE desired value falls back to the
+      // PREVIOUS billing mode, NOT the create-path default: defaulting would
+      // make the change detection see a real flip and silently re-price a
+      // live table, which is strictly worse than the pre-guard behavior (AWS
+      // rejecting the junk value loudly, billing unchanged). An ABSENT value
+      // keeps meaning "no flip requested" (no BillingMode sent). The PREVIOUS
+      // side stays unguarded on purpose: it comes from cdkd STATE, so
+      // refusing a malformed value an older binary recorded would make the
+      // stack permanently un-updatable.
+      const prevBillingMode = previousProperties['BillingMode'] as
+        | 'PROVISIONED'
+        | 'PAY_PER_REQUEST'
+        | undefined;
+      let billingModeUnusable = false;
+      const requestedBillingMode =
+        properties['BillingMode'] === undefined
+          ? undefined
+          : requireConfigString(
+              properties['BillingMode'],
+              'PROVISIONED',
+              'AWS::DynamoDB::Table BillingMode',
+              {
+                onUnusable: (message) => {
+                  billingModeUnusable = true;
+                  this.logger.warn(
+                    `${message} The table's current billing mode` +
+                      `${prevBillingMode ? ` (${prevBillingMode})` : ''} is kept for this ` +
+                      `update rather than flipped to the default.`
+                  );
+                },
+              }
+            );
+      const billingMode = billingModeUnusable
+        ? prevBillingMode
+        : (requestedBillingMode as 'PROVISIONED' | 'PAY_PER_REQUEST' | undefined);
       const billingOrThroughputChanged =
-        JSON.stringify(properties['BillingMode']) !==
-          JSON.stringify(previousProperties['BillingMode']) ||
+        JSON.stringify(billingMode) !== JSON.stringify(prevBillingMode) ||
         JSON.stringify(properties['ProvisionedThroughput']) !==
           JSON.stringify(previousProperties['ProvisionedThroughput']);
       if (billingOrThroughputChanged || tableClassChanged) {
-        const billingMode = properties['BillingMode'] as
-          | 'PROVISIONED'
-          | 'PAY_PER_REQUEST'
-          | undefined;
         const updateInput: UpdateTableCommandInput = { TableName: physicalId };
         if (billingOrThroughputChanged && billingMode) {
           updateInput.BillingMode = billingMode;

--- a/tests/unit/provisioning/dynamodb-table-provider-billing-mode-shape.test.ts
+++ b/tests/unit/provisioning/dynamodb-table-provider-billing-mode-shape.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { mockSend, childLogger } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+  childLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    dynamoDB: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  childLogger.child.mockReturnValue(childLogger);
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { DynamoDBTableProvider } from '../../../src/provisioning/providers/dynamodb-table-provider.js';
+import { ProvisioningError } from '../../../src/utils/error-handler.js';
+
+const RESOURCE_TYPE = 'AWS::DynamoDB::Table';
+const TABLE_NAME = 'my-test-table-xxx';
+const TABLE_ARN = 'arn:aws:dynamodb:us-east-1:123:table/my-test-table-xxx';
+
+/**
+ * The `||` spelling of the malformed-value defaulting class (issue #1545), on
+ * `AWS::DynamoDB::Table` — the sibling of the GlobalTable guard PR #1542
+ * shipped for the `??` spelling.
+ *
+ * `BillingMode || 'PROVISIONED'` reads correctly and is wrong for a
+ * present-but-unusable value: `BillingMode: null` (an `Fn::If` the resolver
+ * could not resolve, a hand-authored L1 typo) substitutes PROVISIONED on a
+ * template that says PAY_PER_REQUEST, silently creating a continuously-billed
+ * table with no error anywhere.
+ *
+ * Per-site decisions, following the PR #1542 precedent:
+ *
+ * - `BillingMode` is ENUM-valued, so it does NOT take `coerceNumber` — a
+ *   number here is a template bug, not the unquoted-YAML scalar CFn coerces.
+ * - THROW on a template-path create, WARN on a state replay (`replayWarn`) and
+ *   on the update path, which is a replay path unconditionally.
+ * - An UNUSABLE desired value on update falls back to the PREVIOUS billing
+ *   mode, never the create-path default — a malformed template must not
+ *   silently re-price a live table.
+ * - The `previousProperties` sibling stays unguarded: that side comes from
+ *   cdkd STATE, and refusing a value an older binary recorded would make the
+ *   stack permanently un-updatable with no template-side remedy.
+ */
+describe('DynamoDBTableProvider malformed BillingMode (issue #1545)', () => {
+  let provider: DynamoDBTableProvider;
+
+  beforeEach(() => {
+    mockSend.mockReset();
+    childLogger.warn.mockReset();
+    provider = new DynamoDBTableProvider();
+  });
+
+  const baseProps = {
+    TableName: TABLE_NAME,
+    KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
+    AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
+  };
+
+  const activeTable = () =>
+    mockSend.mockResolvedValue({
+      Table: {
+        TableName: TABLE_NAME,
+        TableArn: TABLE_ARN,
+        TableStatus: 'ACTIVE',
+      },
+    });
+
+  const commandNames = () => mockSend.mock.calls.map((c) => c[0].constructor.name);
+
+  const billingUpdateCalls = () =>
+    mockSend.mock.calls
+      .filter((c) => c[0].constructor.name === 'UpdateTableCommand')
+      .filter((c) => c[0].input.BillingMode !== undefined);
+
+  // ─── CREATE: refuse ────────────────────────────────────────────────────
+
+  it.each([
+    ['null', null, 'null'],
+    ['a blank string', '', 'a blank string'],
+    ['a number', 5, 'a number'],
+    ['an object', { Ref: 'Unresolved' }, 'an object'],
+    ['an array', ['PAY_PER_REQUEST'], 'an array'],
+  ])(
+    'refuses %s on create instead of silently deploying a PROVISIONED table',
+    async (_label, value, described) => {
+      activeTable();
+
+      await expect(
+        provider.create('MyTable', RESOURCE_TYPE, { ...baseProps, BillingMode: value })
+      ).rejects.toThrow(
+        new RegExp(
+          `AWS::DynamoDB::Table BillingMode must be a non-empty string \\(got ${described}\\)`
+        )
+      );
+
+      // The refusal must land BEFORE CreateTable, never after a real table
+      // exists — the whole point of a pre-flight refusal.
+      expect(commandNames()).not.toContain('CreateTableCommand');
+    }
+  );
+
+  it('surfaces the create refusal as a ProvisioningError, not a bare Error', async () => {
+    activeTable();
+    // The read sits inside `create()`'s try, so the existing catch wraps the
+    // refusal into the typed error the deploy engine expects.
+    const err = await provider
+      .create('MyTable', RESOURCE_TYPE, { ...baseProps, BillingMode: null })
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ProvisioningError);
+    expect(err).toMatchObject({ resourceType: RESOURCE_TYPE, logicalId: 'MyTable' });
+  });
+
+  it('names the field and the way out in the message', async () => {
+    activeTable();
+    await expect(
+      provider.create('MyTable', RESOURCE_TYPE, { ...baseProps, BillingMode: null })
+    ).rejects.toThrow(/Omit the field entirely to use the default \(PROVISIONED\)/);
+  });
+
+  // ─── CREATE: still default / pass through ──────────────────────────────
+
+  it('still defaults an ABSENT BillingMode to PROVISIONED', async () => {
+    activeTable();
+
+    await provider.create('MyTable', RESOURCE_TYPE, { ...baseProps });
+
+    const createCall = mockSend.mock.calls.find(
+      (c) => c[0].constructor.name === 'CreateTableCommand'
+    );
+    expect(createCall?.[0].input.BillingMode).toBe('PROVISIONED');
+    // The PROVISIONED default carries the default capacity block too.
+    expect(createCall?.[0].input.ProvisionedThroughput).toEqual({
+      ReadCapacityUnits: 5,
+      WriteCapacityUnits: 5,
+    });
+  });
+
+  it('passes an explicit PAY_PER_REQUEST through unchanged, with no capacity block', async () => {
+    activeTable();
+
+    await provider.create('MyTable', RESOURCE_TYPE, {
+      ...baseProps,
+      BillingMode: 'PAY_PER_REQUEST',
+    });
+
+    const createCall = mockSend.mock.calls.find(
+      (c) => c[0].constructor.name === 'CreateTableCommand'
+    );
+    expect(createCall?.[0].input.BillingMode).toBe('PAY_PER_REQUEST');
+    expect(createCall?.[0].input).not.toHaveProperty('ProvisionedThroughput');
+  });
+
+  // ─── CREATE: state replay downgrades to a warning ──────────────────────
+
+  it('WARNS instead of throwing when the create is a state replay', async () => {
+    activeTable();
+
+    // `rollback-executor.ts`'s reverse-replacement arm revives the OLD
+    // resource from `previousState.properties`. A record written by an older
+    // binary can carry the malformed value this guard refuses, and the user
+    // has no template-side remedy for a state record — so the refusal must
+    // downgrade, per the `CreateContext.replayingState` contract.
+    await expect(
+      provider.create(
+        'MyTable',
+        RESOURCE_TYPE,
+        { ...baseProps, BillingMode: null },
+        { replayingState: true }
+      )
+    ).resolves.toBeDefined();
+
+    const createCall = mockSend.mock.calls.find(
+      (c) => c[0].constructor.name === 'CreateTableCommand'
+    );
+    expect(createCall?.[0].input.BillingMode).toBe('PROVISIONED');
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('AWS::DynamoDB::Table BillingMode must be a non-empty string')
+    );
+  });
+
+  it('keeps the refusal when the context is present but carries no replay flag', async () => {
+    activeTable();
+
+    // `replayWarn` tests `=== true`, so an empty context bag is an ordinary
+    // create. Pinned so a future `!== false` refactor cannot silently turn
+    // every context-carrying create into a warn.
+    await expect(
+      provider.create('MyTable', RESOURCE_TYPE, { ...baseProps, BillingMode: null }, {})
+    ).rejects.toThrow(/AWS::DynamoDB::Table BillingMode must be a non-empty string/);
+  });
+
+  it('keeps the refusal on an ordinary template-path create that passes a context', async () => {
+    activeTable();
+
+    // An explicit `replayingState: false` is an ordinary deploy, not a replay
+    // — the downgrade is opt-in, so the guard must still fire.
+    await expect(
+      provider.create(
+        'MyTable',
+        RESOURCE_TYPE,
+        { ...baseProps, BillingMode: null },
+        { replayingState: false }
+      )
+    ).rejects.toThrow(/AWS::DynamoDB::Table BillingMode must be a non-empty string/);
+  });
+
+  // ─── UPDATE: warn, never throw; fall back to the PREVIOUS mode ─────────
+
+  it.each([
+    ['null', null],
+    ['a blank string', ''],
+    ['a number', 5],
+    ['an object', { Ref: 'Unresolved' }],
+    ['an array', ['PAY_PER_REQUEST']],
+  ])(
+    'an UNUSABLE desired value (%s) must NOT flip a live PROVISIONED table',
+    async (_label, value) => {
+      activeTable();
+
+      // The consequential arm: before the guard existed a truthy junk value
+      // flowed into `UpdateTable` and AWS REJECTED it (loud, billing
+      // unchanged) while a falsy one silently issued a bogus empty
+      // UpdateTable. Falling back to the create-path default instead would
+      // make the flip REAL — a malformed template silently re-pricing a
+      // production table with only a warn to show for it.
+      await expect(
+        provider.update(
+          'MyTable',
+          TABLE_NAME,
+          RESOURCE_TYPE,
+          { ...baseProps, BillingMode: value },
+          { ...baseProps, BillingMode: 'PROVISIONED' }
+        )
+      ).resolves.toBeDefined();
+
+      expect(billingUpdateCalls()).toHaveLength(0);
+      expect(childLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('AWS::DynamoDB::Table BillingMode must be a non-empty string')
+      );
+      expect(childLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("The table's current billing mode (PROVISIONED) is kept")
+      );
+    }
+  );
+
+  it('keeps the PREVIOUS mode (not the default) when an unusable value rides a capacity change', async () => {
+    activeTable();
+
+    // With a real ProvisionedThroughput change alongside the junk value, the
+    // UpdateTable DOES fire — and its BillingMode must be the previous
+    // PROVISIONED (the re-assert the well-formed path also sends), never a
+    // default-driven flip.
+    await provider.update(
+      'MyTable',
+      TABLE_NAME,
+      RESOURCE_TYPE,
+      {
+        ...baseProps,
+        BillingMode: null,
+        ProvisionedThroughput: { ReadCapacityUnits: 10, WriteCapacityUnits: 10 },
+      },
+      {
+        ...baseProps,
+        BillingMode: 'PROVISIONED',
+        ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+      }
+    );
+
+    const updates = billingUpdateCalls();
+    expect(updates).toHaveLength(1);
+    expect(updates[0][0].input.BillingMode).toBe('PROVISIONED');
+    expect(updates[0][0].input.ProvisionedThroughput).toEqual({
+      ReadCapacityUnits: 10,
+      WriteCapacityUnits: 10,
+    });
+  });
+
+  it('a well-formed flip still reaches AWS', async () => {
+    activeTable();
+
+    await provider.update(
+      'MyTable',
+      TABLE_NAME,
+      RESOURCE_TYPE,
+      { ...baseProps, BillingMode: 'PAY_PER_REQUEST' },
+      { ...baseProps, BillingMode: 'PROVISIONED' }
+    );
+
+    const updates = billingUpdateCalls();
+    expect(updates).toHaveLength(1);
+    expect(updates[0][0].input.BillingMode).toBe('PAY_PER_REQUEST');
+    expect(childLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('AWS::DynamoDB::Table BillingMode')
+    );
+  });
+
+  it('leaves the PREVIOUS side unguarded, so a malformed state record still deploys', async () => {
+    activeTable();
+
+    // The previous side comes from cdkd STATE, never from the template.
+    // Guarding it would make a stack whose state an older binary wrote
+    // permanently undeployable — editing the CDK code does not help, because
+    // the previous side stays malformed until a deploy succeeds.
+    await expect(
+      provider.update(
+        'MyTable',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        { ...baseProps, BillingMode: 'PROVISIONED' },
+        { ...baseProps, BillingMode: null }
+      )
+    ).resolves.toBeDefined();
+
+    expect(childLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('AWS::DynamoDB::Table BillingMode')
+    );
+    // The well-formed desired mode still goes out.
+    const updates = billingUpdateCalls();
+    expect(updates).toHaveLength(1);
+    expect(updates[0][0].input.BillingMode).toBe('PROVISIONED');
+  });
+
+  it('an ABSENT desired value is not treated as unusable', async () => {
+    activeTable();
+
+    // Absence means "no flip requested" in this provider (no BillingMode is
+    // sent), and it must keep meaning that — the suppression is scoped to
+    // present-but-unusable ONLY.
+    await provider.update(
+      'MyTable',
+      TABLE_NAME,
+      RESOURCE_TYPE,
+      { ...baseProps },
+      { ...baseProps, BillingMode: 'PROVISIONED' }
+    );
+
+    expect(billingUpdateCalls()).toHaveLength(0);
+    expect(childLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('AWS::DynamoDB::Table BillingMode')
+    );
+  });
+
+  it('does not warn on a no-op update', async () => {
+    activeTable();
+
+    await provider.update(
+      'MyTable',
+      TABLE_NAME,
+      RESOURCE_TYPE,
+      { ...baseProps, BillingMode: 'PROVISIONED' },
+      { ...baseProps, BillingMode: 'PROVISIONED' }
+    );
+
+    expect(childLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('AWS::DynamoDB::Table BillingMode')
+    );
+    expect(billingUpdateCalls()).toHaveLength(0);
+  });
+});

--- a/tests/unit/provisioning/dynamodb-table-provider-billing-mode-shape.test.ts
+++ b/tests/unit/provisioning/dynamodb-table-provider-billing-mode-shape.test.ts
@@ -263,6 +263,28 @@ describe('DynamoDBTableProvider malformed BillingMode (issue #1545)', () => {
     }
   );
 
+  it('handles an unusable desired value with NO previous mode on record', async () => {
+    activeTable();
+
+    // prevBillingMode === undefined + unusable desired: the fallback is
+    // undefined, the comparison reads "unchanged", and the warn renders
+    // without the parenthesized mode.
+    await expect(
+      provider.update(
+        'MyTable',
+        TABLE_NAME,
+        RESOURCE_TYPE,
+        { ...baseProps, BillingMode: '' },
+        { ...baseProps }
+      )
+    ).resolves.toBeDefined();
+
+    expect(billingUpdateCalls()).toHaveLength(0);
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("The table's current billing mode is kept")
+    );
+  });
+
   it('keeps the PREVIOUS mode (not the default) when an unusable value rides a capacity change', async () => {
     activeTable();
 
@@ -343,9 +365,12 @@ describe('DynamoDBTableProvider malformed BillingMode (issue #1545)', () => {
   it('an ABSENT desired value is not treated as unusable', async () => {
     activeTable();
 
-    // Absence means "no flip requested" in this provider (no BillingMode is
-    // sent), and it must keep meaning that — the suppression is scoped to
-    // present-but-unusable ONLY.
+    // Absence means "no flip requested" in this provider (no BillingMode
+    // FIELD is sent — the removal itself still emits an UpdateTable carrying
+    // no mutable field, the pre-existing #1160-class behavior this suite
+    // deliberately does not change; tracked in issue #1553), and it must
+    // keep meaning that — the suppression is scoped to present-but-unusable
+    // ONLY.
     await provider.update(
       'MyTable',
       TABLE_NAME,


### PR DESCRIPTION
## Summary

Closes #1545

`AWS::DynamoDB::Table` carried the malformed-value defaulting class in the `||` spelling, in the WORSE direction: a present-but-unusable `BillingMode` (empty string, `null`, a number, an unresolved intrinsic) silently created a continuously-billed PROVISIONED table on create, and the update path forwarded the raw value into `UpdateTable` with no shape check at all.

Per the per-site precedent issue 1524 recorded and PR (#1542) applied to the GlobalTable sibling:

- **Create**: `requireConfigString` (enum-valued, so no `coerceNumber`). Throws on a template-path create; downgrades to `replayWarn` under `CreateContext.replayingState` (the rollback executor's reverse-replacement arm revives the old resource from state the user cannot edit from the template). The guard sits inside `create()`'s existing try, so the refusal surfaces as a `ProvisioningError` before any `CreateTableCommand` is sent.
- **Update**: the same guard, warn-only (the desired bag can itself be a state record on rollback replay / `drift --revert`). An unusable desired value keeps the PREVIOUS billing mode rather than flipping a live table to the default; an absent value keeps meaning "no flip requested". The previous side stays deliberately unguarded (state-borne).

## The `||` sweep

The class-covering grep over `src/provisioning/providers/` found sibling desired-side hits outside this file's scope — firehose `DeliveryStreamType`, iam-managed-policy / iam-instance-profile / iam-role `Path`, ssm-parameter `Type` (kinesis's hit is a documented deliberate previous-side read). Those stay with the sweep item on (#1545); this PR fixes the DynamoDB Table instance the issue names.

## Test plan

- New `tests/unit/provisioning/dynamodb-table-provider-billing-mode-shape.test.ts` (23 tests — one added in review), mirroring the (#1542) GlobalTable suite: 5 malformed shapes refused on create before `CreateTable`; absent-default and explicit-value pass-throughs; both `replayingState` polarities; 5 malformed shapes on update with `old: 'PROVISIONED'` asserting zero `UpdateTable` calls carrying a `BillingMode`; the unusable-plus-capacity-change case asserting the PREVIOUS mode (not the default) in the emitted `UpdateTable`; well-formed flip still reaches AWS; previous-side-unguarded and absent-not-unusable pins.
- Binding proof: with the src change stashed, 16 of 22 tests fail (the 6 passing are pins that are correct either way).
- Full suite: 542 files / 9806 tests pass; typecheck / lint / build clean.
- Live verification: `/run-integ dynamodb-ondemand` (real-AWS deploy + destroy through the changed provider). The malformed-template refusal and replay-downgrade polarities are unit-verified (binding-proven above); a raw scratch-app deploy for the refusal path is blocked by the repo's run-integ-only policy.

## Review (1 reviewer — inline tier up-biased by the provider path)

- Fixed in this PR: the prev-undefined + unusable-desired arm is pinned by a dedicated test; the ABSENT-value test comment no longer implies no UpdateTable is emitted.
- TODO (#1552): the warn path records a junk desired value into state, and recovery can wedge on a same-mode re-assert (class follow-up incl. the GlobalTable precedent).
- TODO (#1553): BillingMode REMOVAL emits an empty UpdateTable (pre-existing (#1160)-class behavior, preserved byte-identically here; needs a live CFn A/B before choosing the reset-vs-retain semantics).
- Won't-do: the kept-mode warn interpolates the raw previous value, so a malformed truthy previous renders as `[object Object]` — cosmetic, same shape as the GlobalTable precedent's message; not worth diverging from it here.
