### PR TITLE
fix(sns): warn-and-skip malformed DeliveryStatusLogging on update instead of throwing

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -253,7 +253,7 @@ sg-circular-dependency	2026-07-26T18:49:34Z	PASS	51	verify.sh	0727b sweep-b6 sta
 sns-event-source	2026-08-01T10:07:21Z	PASS	59	verify.sh	0801 regression sweep; e2e delivery ok, log groups swept, 0 orphans
 sns-inline-subscription	2026-07-27T11:04:52Z	PASS	53	verify.sh	issue #1267 SNS topic update wrap; 3 del 0 err
 sns-pending-subscription	2026-07-30T12:40:16Z	PASS	22	verify.sh	issue #1301 re-run after review fixes, clean
-sns-sqs-event	2026-08-10T19:02:06Z	PASS	81	verify.sh	issue #1529 http/s assertions; rc ok, orph clean
+sns-sqs-event	2026-08-11T03:25:52Z	PASS	420	verify.sh	1538 lane: delivery-status warn mode; destroy 0 err 0 orph
 sns-subscription-filter	2026-08-10T05:38:11Z	PASS	39	verify.sh	0810 P2 sweep b9; rc ok, 0 orph
 sqs-cloudwatch	2026-07-31T07:00:20Z	PASS	75	standard	removalPolicy DESTROY fix verified: stream deleted on destroy, 0 orphans
 sqs-esm-max-concurrency	2026-08-10T04:23:28Z	PASS	76	verify.sh	0810 sweep b2; lambda-eventsource re-verify, 5 del 0 err, 0 orph

--- a/src/provisioning/providers/sns-topic-provider.ts
+++ b/src/provisioning/providers/sns-topic-provider.ts
@@ -353,10 +353,14 @@ export class SNSTopicProvider implements ResourceProvider {
     // Removal semantics (issue #1160): SetTopicAttributes is per-attribute
     // merge — an attribute we never send keeps its live value, so both a
     // whole `DeliveryStatusLogging` removal and a dropped sub-field /
-    // protocol entry must be reset EXPLICITLY. The desired side throws on
-    // a malformed container (template error, fail fast); the previous side
-    // comes from cdkd state, so it is walked in 'skip' mode — a state
-    // record an older binary wrote must never make the stack permanently
+    // protocol entry must be reset EXPLICITLY. The desired side is walked
+    // in 'warn' mode (issue #1538): it is NOT always template-borne — the
+    // rollback executor's revert arm and `cdkd drift --revert` both put a
+    // state-derived bag here, so a malformed value warns-and-skips instead
+    // of failing the update permanently (create() still throws, where the
+    // value is always template-borne). The previous side comes from cdkd
+    // state too, so it is walked in silent 'skip' mode — a state record an
+    // older binary wrote must never make the stack permanently
     // undeployable (guard-the-desired-side-only rule).
     if (
       JSON.stringify(properties['DeliveryStatusLogging']) !==
@@ -365,7 +369,7 @@ export class SNSTopicProvider implements ResourceProvider {
       const desiredAttributes = buildDeliveryStatusAttributeMap(
         properties['DeliveryStatusLogging'],
         logicalId,
-        'throw'
+        'warn'
       );
       const previousAttributes = buildDeliveryStatusAttributeMap(
         previousProperties['DeliveryStatusLogging'],
@@ -971,11 +975,24 @@ const SNS_DELIVERY_STATUS_ATTRIBUTE_SUFFIXES = [
  * rate on create and update alike).
  *
  * `onMalformed` picks the failure mode for a malformed container / entry
- * / unknown protocol: `'throw'` for the DESIRED side (a template error
- * must fail fast, naming the offending value), `'skip'` for the PREVIOUS
- * side (cdkd state — refusing a value an older binary recorded would make
- * the stack permanently undeployable, and an entry whose protocol cannot
- * be canonicalized maps to no attribute names anyway).
+ * / unknown protocol, and encodes the create-vs-update distinction
+ * (issue #1538):
+ *
+ * - `'throw'` — the CREATE desired side, which is always template-borne:
+ *   a template error must fail fast, naming the offending value.
+ * - `'warn'` — the UPDATE desired side, which is NOT always template-borne:
+ *   the rollback executor's revert arm and `cdkd drift --revert` both call
+ *   `update()` with a state-derived bag as the DESIRED properties, so a
+ *   state record carrying an unsupported protocol / malformed shape (a
+ *   hand-written imported template, or a record an older binary wrote)
+ *   must warn-and-skip rather than fail the update permanently — there is
+ *   no template-side remedy. Skip semantics are well-defined: an entry
+ *   whose protocol cannot be canonicalized maps to no attribute names, a
+ *   non-array container yields an empty map, and a non-object entry is
+ *   skipped. Each warning names the logicalId and the offending value.
+ * - `'skip'` — the PREVIOUS side (cdkd state): same tolerance, silently —
+ *   warning on every update about a value the user cannot act on from the
+ *   template would be pure noise (guard-the-desired-side-only rule).
  *
  * Two entries whose `Protocol` values canonicalize to the SAME prefix
  * (`http/s` + `https`, say) collapse onto one set of attribute names. The
@@ -989,38 +1006,60 @@ const SNS_DELIVERY_STATUS_ATTRIBUTE_SUFFIXES = [
  * produced `HTTPS*` names AWS rejected outright, so no such template ever
  * deployed.
  *
- * The collision WARNS rather than throws because this function's `'throw'`
- * side is also fed by the rollback executor's `update()` replay of a cdkd
- * STATE record, where the user has no template-side remedy. NOTE the three
- * pre-existing throws below (unsupported protocol, non-array container,
- * non-object entry) sit on that same side and are NOT covered by that
- * reasoning — a state record carrying one of those is permanently
- * unreplayable. That is a real but latent gap, tracked as issue #1538;
- * #1529 deliberately did not widen its scope to change the create path's
- * validation contract.
+ * The collision WARNS rather than throws for the same reason `'warn'` mode
+ * exists: the update desired side is also fed by the rollback executor's
+ * `update()` replay of a cdkd STATE record, where the user has no
+ * template-side remedy. The three malformed-value sites below (unsupported
+ * protocol, non-array container, non-object entry) used to throw on that
+ * side too, which made such a state record permanently unreplayable —
+ * fixed by issue #1538, which moved `update()`'s desired side to `'warn'`
+ * while `create()` keeps `'throw'` (a template create must still fail
+ * fast; #1529 / #1536 deliberately left that contract unchanged).
  */
 export function buildDeliveryStatusAttributeMap(
   logging: unknown,
   logicalId: string,
-  onMalformed: 'throw' | 'skip'
+  onMalformed: 'throw' | 'warn' | 'skip'
 ): Map<string, string> {
   const map = new Map<string, string>();
   if (logging == null) return map;
+  const warn = (message: string): void => {
+    getLogger().child('SNSTopicProvider').warn(message);
+  };
   const seenProtocols = new Set<SnsDeliveryStatusProtocol>();
   if (!Array.isArray(logging)) {
-    if (onMalformed === 'skip') return map;
-    throw new Error(
-      `SNS topic ${logicalId}: DeliveryStatusLogging must be an array of ` +
-        `{Protocol, ...} objects, got ${JSON.stringify(logging)}`
-    );
+    if (onMalformed === 'throw') {
+      throw new Error(
+        `SNS topic ${logicalId}: DeliveryStatusLogging must be an array of ` +
+          `{Protocol, ...} objects, got ${JSON.stringify(logging)}`
+      );
+    }
+    if (onMalformed === 'warn') {
+      warn(
+        `SNS topic ${logicalId}: DeliveryStatusLogging must be an array of ` +
+          `{Protocol, ...} objects, got ${JSON.stringify(logging)} — treating it ` +
+          `as empty for this update. The desired properties can come from a cdkd ` +
+          `state record (rollback replay / drift --revert), so this does not fail ` +
+          `the update; fix the state record or re-import to clear this warning.`
+      );
+    }
+    return map;
   }
   for (const entry of logging) {
     if (entry == null || typeof entry !== 'object' || Array.isArray(entry)) {
-      if (onMalformed === 'skip') continue;
-      throw new Error(
-        `SNS topic ${logicalId}: DeliveryStatusLogging entries must be ` +
-          `{Protocol, ...} objects, got ${JSON.stringify(entry)}`
-      );
+      if (onMalformed === 'throw') {
+        throw new Error(
+          `SNS topic ${logicalId}: DeliveryStatusLogging entries must be ` +
+            `{Protocol, ...} objects, got ${JSON.stringify(entry)}`
+        );
+      }
+      if (onMalformed === 'warn') {
+        warn(
+          `SNS topic ${logicalId}: skipping DeliveryStatusLogging entry ` +
+            `${JSON.stringify(entry)} — entries must be {Protocol, ...} objects.`
+        );
+      }
+      continue;
     }
     const config = entry as Record<string, unknown>;
     let protocol: SnsDeliveryStatusProtocol;
@@ -1028,23 +1067,32 @@ export function buildDeliveryStatusAttributeMap(
       protocol = normalizeDeliveryStatusProtocolOrThrow(config['Protocol'], logicalId);
     } else {
       const normalized = normalizeDeliveryStatusProtocol(config['Protocol']);
-      if (normalized === undefined) continue;
+      if (normalized === undefined) {
+        if (onMalformed === 'warn') {
+          warn(
+            `SNS topic ${logicalId}: skipping DeliveryStatusLogging entry with ` +
+              `unsupported protocol ${JSON.stringify(config['Protocol'])}. Expected ` +
+              `one of ${SNS_DELIVERY_STATUS_PROTOCOL_SPELLINGS.join(', ')} ` +
+              `(case-insensitive).`
+          );
+        }
+        continue;
+      }
       protocol = normalized;
     }
-    // Desired side only, per this function's guard-the-desired-side rule:
-    // on the PREVIOUS side the entries come from a cdkd state record, where
-    // "declare a single entry per protocol" is advice the user cannot act on.
-    if (onMalformed === 'throw' && seenProtocols.has(protocol)) {
-      getLogger()
-        .child('SNSTopicProvider')
-        .warn(
-          `SNS topic ${logicalId}: DeliveryStatusLogging declares more than one entry ` +
-            `for the "${protocol}" attribute prefix (${JSON.stringify(config['Protocol'])} ` +
-            `canonicalizes to it). AWS has one attribute set per prefix, so these are ` +
-            `merged per field — a later entry overwrites only the sub-fields it ` +
-            `declares, and a field it omits keeps the earlier entry's value. ` +
-            `Declare a single entry per protocol.`
-        );
+    // Desired side only ('throw' = create, 'warn' = update), per this
+    // function's guard-the-desired-side rule: on the PREVIOUS side the
+    // entries come from a cdkd state record, where "declare a single entry
+    // per protocol" is advice the user cannot act on.
+    if (onMalformed !== 'skip' && seenProtocols.has(protocol)) {
+      warn(
+        `SNS topic ${logicalId}: DeliveryStatusLogging declares more than one entry ` +
+          `for the "${protocol}" attribute prefix (${JSON.stringify(config['Protocol'])} ` +
+          `canonicalizes to it). AWS has one attribute set per prefix, so these are ` +
+          `merged per field — a later entry overwrites only the sub-fields it ` +
+          `declares, and a field it omits keeps the earlier entry's value. ` +
+          `Declare a single entry per protocol.`
+      );
     }
     seenProtocols.add(protocol);
     for (const suffix of SNS_DELIVERY_STATUS_ATTRIBUTE_SUFFIXES) {
@@ -1133,10 +1181,13 @@ export function normalizeDeliveryStatusProtocol(
 }
 
 /**
- * Variant used by `create()` / `update()` to fail fast when a template
- * carries an unknown protocol. Throws a clear error naming the offending
- * value so the user sees what to fix instead of AWS's generic
- * `InvalidParameter` rejection.
+ * Variant used by `create()` (the `'throw'` mode of
+ * `buildDeliveryStatusAttributeMap`) to fail fast when a template carries
+ * an unknown protocol. Throws a clear error naming the offending value so
+ * the user sees what to fix instead of AWS's generic `InvalidParameter`
+ * rejection. `update()`'s desired side warns-and-skips instead (issue
+ * #1538) because its bag can be a cdkd state record on a rollback replay
+ * or `drift --revert`.
  */
 function normalizeDeliveryStatusProtocolOrThrow(
   input: unknown,

--- a/src/provisioning/providers/sns-topic-provider.ts
+++ b/src/provisioning/providers/sns-topic-provider.ts
@@ -1038,9 +1038,10 @@ export function buildDeliveryStatusAttributeMap(
       warn(
         `SNS topic ${logicalId}: DeliveryStatusLogging must be an array of ` +
           `{Protocol, ...} objects, got ${JSON.stringify(logging)} — treating it ` +
-          `as empty for this update. The desired properties can come from a cdkd ` +
-          `state record (rollback replay / drift --revert), so this does not fail ` +
-          `the update; fix the state record or re-import to clear this warning.`
+          `as empty for this update, so previously set delivery-status attributes ` +
+          `are reset. The desired properties can come from a cdkd state record ` +
+          `(rollback replay / drift --revert), so this does not fail the update; ` +
+          `fix the template (or the state record on a replay) to clear this warning.`
       );
     }
     return map;
@@ -1056,7 +1057,9 @@ export function buildDeliveryStatusAttributeMap(
       if (onMalformed === 'warn') {
         warn(
           `SNS topic ${logicalId}: skipping DeliveryStatusLogging entry ` +
-            `${JSON.stringify(entry)} — entries must be {Protocol, ...} objects.`
+            `${JSON.stringify(entry)} — entries must be {Protocol, ...} objects. ` +
+            `Attributes previously set for the skipped entry's protocol are reset, ` +
+            `as if the entry had been removed.`
         );
       }
       continue;
@@ -1073,7 +1076,8 @@ export function buildDeliveryStatusAttributeMap(
             `SNS topic ${logicalId}: skipping DeliveryStatusLogging entry with ` +
               `unsupported protocol ${JSON.stringify(config['Protocol'])}. Expected ` +
               `one of ${SNS_DELIVERY_STATUS_PROTOCOL_SPELLINGS.join(', ')} ` +
-              `(case-insensitive).`
+              `(case-insensitive). Attributes previously set for the skipped ` +
+              `entry's protocol are reset, as if the entry had been removed.`
           );
         }
         continue;

--- a/tests/unit/provisioning/sns-topic-provider-delivery-status-removal.test.ts
+++ b/tests/unit/provisioning/sns-topic-provider-delivery-status-removal.test.ts
@@ -179,17 +179,28 @@ describe('SNSTopicProvider DeliveryStatusLogging removal resets (issue #1160)', 
     expect(setAttributeCalls()).toHaveLength(0);
   });
 
-  it('malformed DESIRED container (string) throws a clear error instead of silently resetting', async () => {
+  it('malformed DESIRED container (string) warns and is treated as empty — the update proceeds (issue #1538)', async () => {
+    // Pre-#1538 this threw. The desired bag on update is not always
+    // template-borne (rollback replay / drift --revert put a state-derived
+    // bag here), so a malformed container warns and yields an EMPTY desired
+    // map; the previously-set attributes are then reset like a removal.
+    // The warn-content assertions live in
+    // sns-topic-provider-delivery-status-replay.test.ts.
     const previous = {
       TopicName: 'topic',
       DeliveryStatusLogging: [{ Protocol: 'lambda', SuccessFeedbackRoleArn: ROLE_A }],
     };
     const desired = { TopicName: 'topic', DeliveryStatusLogging: 'enabled' };
 
-    await expect(
-      provider.update('L', TOPIC_ARN, 'AWS::SNS::Topic', desired, previous)
-    ).rejects.toThrow(/DeliveryStatusLogging must be an array/);
-    expect(setAttributeCalls()).toHaveLength(0);
+    await provider.update('L', TOPIC_ARN, 'AWS::SNS::Topic', desired, previous);
+
+    expect(setAttributeCalls()).toEqual([
+      {
+        TopicArn: TOPIC_ARN,
+        AttributeName: 'LambdaSuccessFeedbackRoleArn',
+        AttributeValue: '',
+      },
+    ]);
   });
 
   it('malformed PREVIOUS side (state record) is tolerated: treated as no previous attributes', async () => {

--- a/tests/unit/provisioning/sns-topic-provider-delivery-status-replay.test.ts
+++ b/tests/unit/provisioning/sns-topic-provider-delivery-status-replay.test.ts
@@ -258,3 +258,66 @@ describe('buildDeliveryStatusAttributeMap warn mode (issue #1538)', () => {
     ).not.toThrow();
   });
 });
+
+describe('per-entry skip interacting with the removal-reset arm (issue #1538 review)', () => {
+  let provider: SNSTopicProvider;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockSend.mockResolvedValue({});
+    provider = new SNSTopicProvider();
+  });
+
+  it('an unsupported-protocol DESIRED entry resets the attributes its previous twin had set', async () => {
+    // The most realistic breakage: the previous side carries a valid lambda
+    // entry; the desired (state-derived) side carries a typo'd protocol for
+    // the same intent. The typo'd entry maps to no attribute names, so the
+    // removal-reset arm treats the lambda attributes as removed — pinned
+    // here as the intended, well-defined semantic (and the warn says so).
+    const previous = {
+      TopicName: 'topic',
+      DeliveryStatusLogging: [{ Protocol: 'lambda', SuccessFeedbackRoleArn: ROLE_A }],
+    };
+    const desired = {
+      TopicName: 'topic',
+      DeliveryStatusLogging: [{ Protocol: 'lamda', SuccessFeedbackRoleArn: ROLE_A }],
+    };
+
+    await provider.update('L', TOPIC_ARN, 'AWS::SNS::Topic', desired, previous);
+
+    expect(setAttributeCalls()).toEqual([
+      {
+        TopicArn: TOPIC_ARN,
+        AttributeName: 'LambdaSuccessFeedbackRoleArn',
+        AttributeValue: '',
+      },
+    ]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0]?.[0] as string;
+    expect(message).toContain('"lamda"');
+    expect(message).toMatch(/previously set for the skipped entry's protocol are reset/);
+  });
+});
+
+describe('duplicate-protocol collision gate polarity (issue #1538 review)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("stays SILENT on a duplicate protocol in 'skip' mode (previous side)", () => {
+    // The gate flipped from `onMalformed === 'throw'` to `!== 'skip'`; pin
+    // the skip side so the previous-side walk never starts warning about
+    // entries the user cannot act on.
+    const map = buildDeliveryStatusAttributeMap(
+      [
+        { Protocol: 'lambda', SuccessFeedbackRoleArn: ROLE_A },
+        { Protocol: 'lambda', SuccessFeedbackRoleArn: ROLE_B },
+      ],
+      'MyTopic',
+      'skip'
+    );
+
+    expect([...map.entries()]).toEqual([['LambdaSuccessFeedbackRoleArn', ROLE_B]]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/provisioning/sns-topic-provider-delivery-status-replay.test.ts
+++ b/tests/unit/provisioning/sns-topic-provider-delivery-status-replay.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { CreateTopicCommand, SetTopicAttributesCommand } from '@aws-sdk/client-sns';
+
+const mockSend = vi.fn();
+// `vi.mock` factories are hoisted above these declarations, and the logger
+// factory builds its child logger EAGERLY (unlike the aws-clients factory,
+// which only closes over `mockSend`), so `warn` must be hoisted with it.
+const { warn } = vi.hoisted(() => ({ warn: vi.fn() }));
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    sns: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn,
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn,
+      error: vi.fn(),
+    }),
+  };
+});
+
+import {
+  SNSTopicProvider,
+  buildDeliveryStatusAttributeMap,
+} from '../../../src/provisioning/providers/sns-topic-provider.js';
+
+const TOPIC_ARN = 'arn:aws:sns:us-east-1:0:topic';
+const ROLE_A = 'arn:aws:iam::0:role/feedback-a';
+const ROLE_B = 'arn:aws:iam::0:role/feedback-b';
+
+/** Collect the {AttributeName, AttributeValue} pairs of every SetTopicAttributes call. */
+function setAttributeCalls(): Array<{ AttributeName: string; AttributeValue: string }> {
+  return mockSend.mock.calls
+    .filter((c) => c[0] instanceof SetTopicAttributesCommand)
+    .map((c) => c[0].input as { AttributeName: string; AttributeValue: string });
+}
+
+/**
+ * Issue #1538: `buildDeliveryStatusAttributeMap`'s DESIRED side is not always
+ * template-borne. The rollback executor's revert arm calls
+ * `provider.update(..., previousState.properties, ...)` and
+ * `cdkd drift --revert` likewise puts a state-derived bag on the desired
+ * side, so a state record carrying an unsupported protocol / malformed shape
+ * (a hand-written imported template, or a record an older binary wrote) used
+ * to hit the throw sites and fail PERMANENTLY — no template-side remedy
+ * exists. The fix: the UPDATE desired side warns-and-skips ('warn' mode)
+ * while the CREATE path — always template-borne — still throws ('throw').
+ */
+describe('SNSTopicProvider update() replay tolerance (issue #1538)', () => {
+  let provider: SNSTopicProvider;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockSend.mockResolvedValue({});
+    provider = new SNSTopicProvider();
+  });
+
+  it('unsupported protocol in the DESIRED bag warns, skips that entry, and still applies the valid siblings', async () => {
+    const previous = { TopicName: 'topic' };
+    // A state-derived desired bag (e.g. rollback replay of a record written
+    // by an older binary / imported hand-written template).
+    const desired = {
+      TopicName: 'topic',
+      DeliveryStatusLogging: [
+        { Protocol: 'smtp', SuccessFeedbackRoleArn: ROLE_A },
+        { Protocol: 'lambda', SuccessFeedbackRoleArn: ROLE_B },
+      ],
+    };
+
+    await provider.update('L', TOPIC_ARN, 'AWS::SNS::Topic', desired, previous);
+
+    // Well-defined result: the unsupported entry maps to no attribute names,
+    // the valid entry is applied verbatim.
+    expect(setAttributeCalls()).toEqual([
+      {
+        TopicArn: TOPIC_ARN,
+        AttributeName: 'LambdaSuccessFeedbackRoleArn',
+        AttributeValue: ROLE_B,
+      },
+    ]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0]?.[0] as string;
+    expect(message).toContain('L');
+    expect(message).toContain('"smtp"');
+    expect(message).toContain('unsupported protocol');
+    // Actionable: the accepted spellings are named.
+    expect(message).toMatch(/application, firehose, http\/s, lambda, sqs/);
+  });
+
+  it('non-array DESIRED container warns and yields an empty map — no throw', async () => {
+    const previous = {
+      TopicName: 'topic',
+      DeliveryStatusLogging: [{ Protocol: 'lambda', SuccessFeedbackRoleArn: ROLE_A }],
+    };
+    const desired = { TopicName: 'topic', DeliveryStatusLogging: { Protocol: 'lambda' } };
+
+    await provider.update('L', TOPIC_ARN, 'AWS::SNS::Topic', desired, previous);
+
+    // Empty desired map + populated previous map = the removal-reset arm.
+    expect(setAttributeCalls()).toEqual([
+      {
+        TopicArn: TOPIC_ARN,
+        AttributeName: 'LambdaSuccessFeedbackRoleArn',
+        AttributeValue: '',
+      },
+    ]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0]?.[0] as string;
+    expect(message).toContain('L');
+    expect(message).toContain('must be an array');
+    expect(message).toContain('{"Protocol":"lambda"}');
+  });
+
+  it('non-object DESIRED entry warns, is skipped, and the valid siblings still apply', async () => {
+    const previous = { TopicName: 'topic' };
+    const desired = {
+      TopicName: 'topic',
+      DeliveryStatusLogging: ['garbage', { Protocol: 'sqs', FailureFeedbackRoleArn: ROLE_A }],
+    };
+
+    await provider.update('L', TOPIC_ARN, 'AWS::SNS::Topic', desired, previous);
+
+    expect(setAttributeCalls()).toEqual([
+      {
+        TopicArn: TOPIC_ARN,
+        AttributeName: 'SQSFailureFeedbackRoleArn',
+        AttributeValue: ROLE_A,
+      },
+    ]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0]?.[0] as string;
+    expect(message).toContain('L');
+    expect(message).toContain('"garbage"');
+    expect(message).toContain('{Protocol, ...} objects');
+  });
+
+  it('a fully-unreplayable-before-#1538 state bag (all three malformed shapes across entries) completes the update', async () => {
+    const previous = { TopicName: 'topic' };
+    const desired = {
+      TopicName: 'topic',
+      DeliveryStatusLogging: [
+        { Protocol: 'smtp', SuccessFeedbackRoleArn: ROLE_A },
+        42,
+        { Protocol: 'lambda', SuccessFeedbackSampleRate: 0 },
+      ],
+    };
+
+    await provider.update('L', TOPIC_ARN, 'AWS::SNS::Topic', desired, previous);
+
+    // The `!= null` presence gate still holds in warn mode: SampleRate 0 is sent.
+    expect(setAttributeCalls()).toEqual([
+      {
+        TopicArn: TOPIC_ARN,
+        AttributeName: 'LambdaSuccessFeedbackSampleRate',
+        AttributeValue: '0',
+      },
+    ]);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  // ─── The create contract is UNCHANGED: template-borne, fail fast ──────
+
+  it('create() still throws on an unsupported protocol', async () => {
+    mockSend.mockImplementation((cmd) =>
+      cmd instanceof CreateTopicCommand
+        ? Promise.resolve({ TopicArn: TOPIC_ARN })
+        : Promise.resolve({})
+    );
+
+    await expect(
+      provider.create('L', 'AWS::SNS::Topic', {
+        TopicName: 'topic',
+        DeliveryStatusLogging: [{ Protocol: 'smtp', SuccessFeedbackRoleArn: ROLE_A }],
+      })
+    ).rejects.toThrow(/unsupported DeliveryStatusLogging protocol "smtp"/);
+  });
+
+  it('create() still throws on a non-array container', async () => {
+    mockSend.mockImplementation((cmd) =>
+      cmd instanceof CreateTopicCommand
+        ? Promise.resolve({ TopicArn: TOPIC_ARN })
+        : Promise.resolve({})
+    );
+
+    await expect(
+      provider.create('L', 'AWS::SNS::Topic', {
+        TopicName: 'topic',
+        DeliveryStatusLogging: 'enabled',
+      })
+    ).rejects.toThrow(/DeliveryStatusLogging must be an array/);
+  });
+
+  it('create() still throws on a non-object entry', async () => {
+    mockSend.mockImplementation((cmd) =>
+      cmd instanceof CreateTopicCommand
+        ? Promise.resolve({ TopicArn: TOPIC_ARN })
+        : Promise.resolve({})
+    );
+
+    await expect(
+      provider.create('L', 'AWS::SNS::Topic', {
+        TopicName: 'topic',
+        DeliveryStatusLogging: ['garbage'],
+      })
+    ).rejects.toThrow(/entries must be[\s\S]*\{Protocol, \.\.\.\} objects/);
+  });
+});
+
+describe('buildDeliveryStatusAttributeMap warn mode (issue #1538)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('non-array container: warn mode returns an empty map with one warning; skip mode stays silent', () => {
+    expect(buildDeliveryStatusAttributeMap('enabled', 'L', 'warn').size).toBe(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    warn.mockClear();
+    expect(buildDeliveryStatusAttributeMap('enabled', 'L', 'skip').size).toBe(0);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warn mode still warns on a duplicate-protocol collision (desired-side advice)', () => {
+    // The collision warning is gated on the DESIRED side, which since #1538
+    // is 'throw' (create) OR 'warn' (update) — not 'throw' alone.
+    const map = buildDeliveryStatusAttributeMap(
+      [
+        { Protocol: 'http/s', SuccessFeedbackRoleArn: ROLE_A },
+        { Protocol: 'https', SuccessFeedbackRoleArn: ROLE_B },
+      ],
+      'MyTopic',
+      'warn'
+    );
+
+    expect([...map.entries()]).toEqual([['HTTPSuccessFeedbackRoleArn', ROLE_B]]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('more than one entry');
+  });
+
+  it('warn mode never throws on any malformed shape', () => {
+    expect(() => buildDeliveryStatusAttributeMap('enabled', 'L', 'warn')).not.toThrow();
+    expect(() => buildDeliveryStatusAttributeMap([null, 42, []], 'L', 'warn')).not.toThrow();
+    expect(() =>
+      buildDeliveryStatusAttributeMap([{ Protocol: 'smtp' }], 'L', 'warn')
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1538

`buildDeliveryStatusAttributeMap(logging, logicalId, onMalformed)` took `'throw'` for the DESIRED side and `'skip'` for the PREVIOUS side — but the desired side of `update()` is not always template-borne: the rollback executor's revert arm and `cdkd drift --revert` both call `update()` with a state-derived bag as the desired properties. A state record carrying an unsupported `DeliveryStatusLogging` protocol (an import of a hand-written template, or a record written by an older binary) hit the three throw sites (unsupported protocol, non-array container, non-object entry) and failed permanently, with no template-side remedy.

This implements **option 1** from the issue (the create-vs-update distinction): `onMalformed` generalizes to `'throw' | 'warn' | 'skip'`:

- `'throw'` — create() desired side, unchanged (a template create still fails fast).
- `'warn'` — update() desired side (the change): all three sites warn-and-skip with well-defined semantics — an unsupported protocol maps to no attribute names, a non-array container yields an empty map, a non-object entry is skipped. Each warning names the logicalId and the offending value.
- `'skip'` — previous side, unchanged (silent tolerance; guard-the-desired-side-only rule).

The duplicate-protocol collision warning now fires on both desired modes (`onMalformed !== 'skip'`). The PR-1536-era JSDoc constraint note recording this as a latent gap is rewritten to record the fix.

Note the deliberate consequence: a malformed `DeliveryStatusLogging` in a plain TEMPLATE update now warns-and-skips instead of failing the deploy — that is the issue's chosen trade-off, since `update()` cannot distinguish a template bag from a state-derived one.

A sibling gap found during this work — `SNSTopicProvider.create()` declares no `context` parameter, so a state replay through CREATE still hits the `'throw'` mode — is out of scope here and tracked in (#1551).

## Test plan

- New `tests/unit/provisioning/sns-topic-provider-delivery-status-replay.test.ts` (12 tests — two added in review): update-path warn/skip for all three malformed shapes with SetTopicAttributes-map assertions (valid sibling entries still applied), create-path unchanged-contract pins, function-level `'warn'`-mode tests.
- One existing removal test re-pinned from the old throw contract to the new warn-and-reset behavior.
- Binding proof: with the src file stashed, 7 of the original 10 fail (the 3 passing are the create-contract pins, correctly unchanged).
- Full suite: 542 files / 9795 tests pass; typecheck / lint / build clean.
- Live verification: `/run-integ sns-sqs-event` (real-AWS deploy + destroy through a fixture that carries `DeliveryStatusLogging`). The malformed-desired-bag polarity is unit-verified (binding-proven above).

## Review (1 reviewer — inline tier up-biased by the provider path)

- Fixed in this PR: a test pinning the most realistic breakage (previous valid lambda entry + desired typo'd protocol → the lambda attributes reset, warn names the consequence); a test pinning silent 'skip'-mode duplicate-protocol handling (the gate flipped from `=== 'throw'` to `!== 'skip'`); the three warn messages now state the reset consequence and point at the template OR the state record.
- Won't-do (recorded above): a malformed DeliveryStatusLogging in a plain TEMPLATE update now warns-and-resets instead of failing fast — `update()` cannot distinguish a template bag from a state-derived one without a context parameter; raw-CFn users are the only exposure (CDK L1/L2 enum-validate at synth), and CFn itself schema-rejects. The create-side context-threading that would refine this is (#1551).
