### PR TITLE
fix(provisioning): downgrade create-path config-shape refusals on a state replay

### DIFF
--- a/.claude/rules/providers.md
+++ b/.claude/rules/providers.md
@@ -37,18 +37,22 @@ helper exists to stop:
   spread into a create-path `requireConfigString` options bag — API Gateway
   `AuthorizationType`, EC2 `InstanceType` / `Domain`, IAM access-key `Status`,
   Lambda event-invoke `Qualifier`, RDS DB-proxy `TargetGroupName`, DynamoDB
-  GlobalTable `BillingMode`. Prefer this.
+  GlobalTable `BillingMode`, WAFv2 `Scope`, Lambda URL create-path `AuthType`,
+  S3 directory-bucket `DataRedundancy`, DynamoDB Table `BillingMode` (issues
+  #1544 / #1545). `readConfigString` accepts the same options bag for nested
+  containers (GlobalTable `StreamSpecification`), and
+  `toSdkGlobalSecondaryIndexes` takes the callback as `onUnusableIndexes`
+  wired from its `create()` call site only. Prefer this.
 - **A hand-threaded callback** — `EC2Provider.buildIpPermission` takes an
   `onUnusableProtocol` parameter and forwards it as `onUnusable`, because the
   helper is shared with state-borne callers that must NOT downgrade.
 - **A hand-written refusal** — `GlueProvider`'s
   `enforceIcebergTableInputAbsent`.
 
-Note the gap this list makes visible: `wafv2-provider.ts`,
-`lambda-url-provider.ts` and `s3-directory-bucket-provider.ts` call
-`requireConfigString` on a create path with NO options bag and no `context`
-parameter, so they still hard-throw on a state replay. That is pre-existing,
-not licensed. The full contract
+Update-path refusals that stay strict on purpose (a downgrade there needs a
+keep-the-previous-value design, not the create default — issue #1551):
+Lambda URL update-path `AuthType`, GlobalTable update-path nested guards.
+The full contract
 is on `CreateContext` in `src/types/resource.ts` (NOT in `region-check.ts`
 where `DeleteContext` lives — that type belongs there because its
 `expectedRegion` feeds `assertRegionMatch`; a one-line pointer sits next to

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -271,5 +271,5 @@ vpc-lambda	2026-08-10T11:50:46Z	PASS	317	standard	0810 P0/P1 sweep b1; 16 del/0 
 vpc-lambda-cr-race	2026-08-10T06:18:10Z	PASS	302	standard	0810 P2 sweep b12; 0 err 0 orph incl hyperplane ENI
 vpc-lookup	2026-08-10T06:01:30Z	PASS	20	standard	0810 P2 sweep b11; context-provider loop ok, 0 err 0 orph
 vpc-nat-gateway	2026-08-09T14:30:04Z	PASS	254	verify.sh	issues #1411/#1412 CC routing asserted live; rc ok, orph clean
-wafv2	2026-08-09T08:37:03Z	PASS	115	standard	#1403 drift reverse map (post-review): deploy + cdkd drift = no drift; 7 del/0 retained/0 err
+wafv2	2026-08-11T03:29:45Z	PASS	240	standard	1544 lane: Scope guard replay-downgrade wiring; destroy 0 err 0 orph
 wait-condition-handle	2026-07-31T06:19:56Z	PASS	44	verify.sh	TTL-refresh sweep re-run; rc ok, orph clean

--- a/src/provisioning/config-shape.ts
+++ b/src/provisioning/config-shape.ts
@@ -150,25 +150,47 @@
  * @param containerPath CFn path of the CONTAINER, used to build both error
  *   messages, e.g. `AWS::S3::Bucket VersioningConfiguration` (the field is
  *   reported as `<containerPath>.<key>`).
+ * @param options Per-site relaxations — see {@link ConfigStringOptions}. They
+ *   apply to BOTH refusals this helper can raise: a malformed CONTAINER under
+ *   `onUnusable` warns and behaves as `{}` (field absent, so the fallback is
+ *   returned — the same thing an empty block already means), and the FIELD
+ *   half threads the options into {@link requireConfigString} unchanged. The
+ *   downgrade exists for the same state-replay reason as
+ *   {@link replayWarn}: a nested block recorded malformed by an older binary
+ *   (`StreamSpecification: ''`) would otherwise make a reverse-replacement
+ *   create un-rollbackable (issue #1544).
  * @throws Error when the container is present but not a plain object, or the
- *   key is present but not a non-blank string.
+ *   key is present but not a non-blank string, unless `onUnusable` is
+ *   supplied.
  */
 export function readConfigString(
   container: unknown,
   key: string,
   fallback: string,
-  containerPath: string
+  containerPath: string,
+  options?: ConfigStringOptions
 ): string {
   if (container === undefined || container === null) return fallback;
 
   if (!isPlainObject(container)) {
-    throw new Error(
-      `${containerPath} must be an object (got ${describe(container)}) — check for ` +
-        `an unresolved intrinsic or a mis-nested template value`
-    );
+    const detail =
+      `(got ${describe(container)}) — check for an unresolved intrinsic or a ` +
+      `mis-nested template value`;
+
+    if (options?.onUnusable) {
+      const named = fallback === '' ? '' : ` (${fallback})`;
+      options.onUnusable(
+        `${containerPath} must be an object ${detail}. Treating the block as empty, ` +
+          `so ${containerPath}.${key} takes its default${named} here; the same ` +
+          `value is REFUSED on a template-path create`
+      );
+      return fallback;
+    }
+
+    throw new Error(`${containerPath} must be an object ${detail}`);
   }
 
-  return requireConfigString(container[key], fallback, `${containerPath}.${key}`);
+  return requireConfigString(container[key], fallback, `${containerPath}.${key}`, options);
 }
 
 /**

--- a/src/provisioning/providers/dynamodb-globaltable-provider.ts
+++ b/src/provisioning/providers/dynamodb-globaltable-provider.ts
@@ -395,11 +395,19 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
     if (streamSpecInput != null) {
       let streamViewType: string;
       try {
+        // `replayWarn` (issue #1544): a state record written by an older
+        // binary can carry `StreamSpecification: ''`, and on the rollback
+        // executor's reverse-replacement replay the user cannot edit that
+        // record — a hard refusal would leave the old table unrestorable. The
+        // downgrade treats the malformed block as `{}` (stream enabled with
+        // the NEW_AND_OLD_IMAGES default, exactly what an empty block means),
+        // warns, and proceeds; template-path creates keep the refusal.
         streamViewType = readConfigString(
           streamSpecInput,
           'StreamViewType',
           'NEW_AND_OLD_IMAGES',
-          'AWS::DynamoDB::GlobalTable StreamSpecification'
+          'AWS::DynamoDB::GlobalTable StreamSpecification',
+          replayWarn(this.logger, context)
         );
       } catch (error) {
         throw new ProvisioningError(
@@ -437,12 +445,18 @@ export class DynamoDBGlobalTableProvider implements ResourceProvider {
     // untyped into the deploy engine's retry loop.
     let sdkIndexes: GlobalSecondaryIndex[];
     try {
+      // The trailing `onUnusableIndexes` hook is the GSI guard's replay
+      // downgrade (issue #1544): on a reverse-replacement replay a non-array
+      // `GlobalSecondaryIndexes` recorded in state warns and the block is
+      // OMITTED (zero indexes) instead of stranding the rollback; on a
+      // template-path create the hook is `undefined` and the refusal stands.
       sdkIndexes = toSdkGlobalSecondaryIndexes(
         properties,
         currentRegion,
         billingMode,
         'min',
-        diagnostics
+        diagnostics,
+        replayWarn(this.logger, context).onUnusable
       );
     } catch (error) {
       throw new ProvisioningError(
@@ -4644,7 +4658,8 @@ export function toSdkGlobalSecondaryIndexes(
   region: string,
   billingMode: string,
   source: CapacitySource = 'min',
-  diagnostics?: ThroughputDiagnostic[]
+  diagnostics?: ThroughputDiagnostic[],
+  onUnusableIndexes?: (message: string) => void
 ): GlobalSecondaryIndex[] {
   const rawIndexes = properties['GlobalSecondaryIndexes'];
   // A NON-ARRAY value (an unresolved `Fn::If`, a malformed template) must not
@@ -4653,17 +4668,32 @@ export function toSdkGlobalSecondaryIndexes(
   // to close, one level up. Absent is legitimately empty; present-but-wrong
   // is an error, and naming it here beats AWS's opaque 400. Matches the
   // per-ENTRY policy below, which also refuses to swallow a bad entry.
+  //
+  // `onUnusableIndexes` (issue #1544) is the create-path STATE-REPLAY
+  // downgrade, wired from `replayWarn` at the `create()` call site only: on
+  // the rollback executor's reverse-replacement replay the properties are a
+  // cdkd state record the user cannot edit, so the refusal would leave the
+  // old table unrestorable. The downgrade warns and OMITS the malformed
+  // block (zero indexes) — a well-defined skip, never a fabricated value.
+  // Every other call site leaves the hook undefined and keeps the refusal.
   if (rawIndexes !== undefined && !Array.isArray(rawIndexes)) {
+    const message =
+      `AWS::DynamoDB::GlobalTable GlobalSecondaryIndexes must be an array, got ` +
+      `${typeof rawIndexes} (${JSON.stringify(rawIndexes)?.slice(0, 200)}). ` +
+      `An unresolved intrinsic here would otherwise deploy a table with no indexes.`;
+    if (onUnusableIndexes) {
+      onUnusableIndexes(
+        `${message} Ignoring the block and proceeding with NO indexes here; the ` +
+          `same value is REFUSED on a template-path create`
+      );
+      return [];
+    }
     // A plain Error on purpose: this is a module-level pure helper with no
     // logicalId to build a ProvisioningError from. `update()` runs inside a
     // wrapping catch that converts it; `create()` does NOT, so its call site
     // converts it explicitly. Both paths therefore surface a ProvisioningError
     // carrying the resource context.
-    throw new Error(
-      `AWS::DynamoDB::GlobalTable GlobalSecondaryIndexes must be an array, got ` +
-        `${typeof rawIndexes} (${JSON.stringify(rawIndexes)?.slice(0, 200)}). ` +
-        `An unresolved intrinsic here would otherwise deploy a table with no indexes.`
-    );
+    throw new Error(message);
   }
   const cfnIndexes = (rawIndexes ?? []) as unknown[];
   if (cfnIndexes.length === 0) return [];

--- a/src/provisioning/providers/dynamodb-globaltable-provider.ts
+++ b/src/provisioning/providers/dynamodb-globaltable-provider.ts
@@ -4677,14 +4677,13 @@ export function toSdkGlobalSecondaryIndexes(
   // block (zero indexes) — a well-defined skip, never a fabricated value.
   // Every other call site leaves the hook undefined and keeps the refusal.
   if (rawIndexes !== undefined && !Array.isArray(rawIndexes)) {
-    const message =
+    const shapeDetail =
       `AWS::DynamoDB::GlobalTable GlobalSecondaryIndexes must be an array, got ` +
-      `${typeof rawIndexes} (${JSON.stringify(rawIndexes)?.slice(0, 200)}). ` +
-      `An unresolved intrinsic here would otherwise deploy a table with no indexes.`;
+      `${typeof rawIndexes} (${JSON.stringify(rawIndexes)?.slice(0, 200)}).`;
     if (onUnusableIndexes) {
       onUnusableIndexes(
-        `${message} Ignoring the block and proceeding with NO indexes here; the ` +
-          `same value is REFUSED on a template-path create`
+        `${shapeDetail} Omitting the malformed block, so this create carries NO ` +
+          `indexes; the same value is REFUSED on a template-path create`
       );
       return [];
     }
@@ -4693,7 +4692,9 @@ export function toSdkGlobalSecondaryIndexes(
     // wrapping catch that converts it; `create()` does NOT, so its call site
     // converts it explicitly. Both paths therefore surface a ProvisioningError
     // carrying the resource context.
-    throw new Error(message);
+    throw new Error(
+      `${shapeDetail} An unresolved intrinsic here would otherwise deploy a table with no indexes.`
+    );
   }
   const cfnIndexes = (rawIndexes ?? []) as unknown[];
   if (cfnIndexes.length === 0) return [];

--- a/src/provisioning/providers/lambda-url-provider.ts
+++ b/src/provisioning/providers/lambda-url-provider.ts
@@ -13,13 +13,14 @@ import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { clearOnUpdateRemoval } from '../update-removal.js';
-import { requireConfigString } from '../config-shape.js';
+import { replayWarn, requireConfigString } from '../config-shape.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
   ResourceUpdateResult,
   ResourceImportInput,
   ResourceImportResult,
+  CreateContext,
 } from '../../types/resource.js';
 
 /**
@@ -50,7 +51,8 @@ export class LambdaUrlProvider implements ResourceProvider {
   async create(
     logicalId: string,
     resourceType: string,
-    properties: Record<string, unknown>
+    properties: Record<string, unknown>,
+    context?: CreateContext
   ): Promise<ResourceCreateResult> {
     this.logger.debug(`Creating Lambda URL ${logicalId}`);
 
@@ -66,10 +68,16 @@ export class LambdaUrlProvider implements ResourceProvider {
     // `|| 'NONE'` turned a blank / null AuthType into a PUBLIC function URL
     // (issue #1493). The #1490 sweep of this idiom keyed on the `as string`
     // cast and so missed this typed-cast spelling.
+    //
+    // `replayWarn`: on a rollback's reverse-replacement replay the properties
+    // are a cdkd STATE record the user cannot edit, so the refusal downgrades
+    // to a warning there (issue #1544) — the resource would otherwise be
+    // unrestorable. Template-path creates keep the refusal.
     const authType = requireConfigString(
       properties['AuthType'],
       'NONE',
-      'AWS::Lambda::Url AuthType'
+      'AWS::Lambda::Url AuthType',
+      replayWarn(this.logger, context)
     ) as FunctionUrlAuthType;
 
     try {

--- a/src/provisioning/providers/s3-directory-bucket-provider.ts
+++ b/src/provisioning/providers/s3-directory-bucket-provider.ts
@@ -16,7 +16,7 @@ import {
 import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { EC2Client, DescribeAvailabilityZonesCommand } from '@aws-sdk/client-ec2';
 import { getLogger } from '../../utils/logger.js';
-import { requireConfigString } from '../config-shape.js';
+import { replayWarn, requireConfigString } from '../config-shape.js';
 import { getAwsClients } from '../../utils/aws-clients.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
@@ -29,6 +29,7 @@ import type {
   ResourceUpdateResult,
   ResourceImportInput,
   ResourceImportResult,
+  CreateContext,
 } from '../../types/resource.js';
 
 /**
@@ -150,14 +151,20 @@ export class S3DirectoryBucketProvider implements ResourceProvider {
   async create(
     logicalId: string,
     resourceType: string,
-    properties: Record<string, unknown>
+    properties: Record<string, unknown>,
+    context?: CreateContext
   ): Promise<ResourceCreateResult> {
     this.logger.debug(`Creating S3 Express Directory Bucket ${logicalId}`);
 
+    // `replayWarn`: the rollback executor's reverse-replacement arm revives
+    // the OLD bucket from `previousState.properties`, which the user cannot
+    // edit from the template — a hard refusal there would leave the resource
+    // unrestorable (issue #1544). Template-path creates keep the refusal.
     const dataRedundancy = requireConfigString(
       properties['DataRedundancy'],
       'SingleAvailabilityZone',
-      'AWS::S3Express::DirectoryBucket DataRedundancy'
+      'AWS::S3Express::DirectoryBucket DataRedundancy',
+      replayWarn(this.logger, context)
     );
     // CFn LocationName: "us-east-1a--x-s3" → extract AZ name: "us-east-1a"
     const cfnLocationName = properties['LocationName'] as string | undefined;

--- a/src/provisioning/providers/wafv2-provider.ts
+++ b/src/provisioning/providers/wafv2-provider.ts
@@ -19,7 +19,7 @@ import {
   type AssociationConfig,
 } from '@aws-sdk/client-wafv2';
 import { getLogger } from '../../utils/logger.js';
-import { requireConfigString } from '../config-shape.js';
+import { replayWarn, requireConfigString } from '../config-shape.js';
 import { ProvisioningError } from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
 import { generateResourceName } from '../resource-name.js';
@@ -30,6 +30,7 @@ import type {
   ResourceUpdateResult,
   ResourceImportInput,
   ResourceImportResult,
+  CreateContext,
 } from '../../types/resource.js';
 
 /**
@@ -516,17 +517,23 @@ export class WAFv2WebACLProvider implements ResourceProvider {
   async create(
     logicalId: string,
     resourceType: string,
-    properties: Record<string, unknown>
+    properties: Record<string, unknown>,
+    context?: CreateContext
   ): Promise<ResourceCreateResult> {
     this.logger.debug(`Creating WAFv2 WebACL ${logicalId}`);
 
     const name =
       (properties['Name'] as string | undefined) ||
       generateResourceName(logicalId, { maxLength: 128 });
+    // `replayWarn`: the rollback executor's reverse-replacement arm revives
+    // the OLD resource from `previousState.properties`, which the user cannot
+    // edit from the template — a hard refusal there would leave the resource
+    // unrestorable (issue #1544). Template-path creates keep the refusal.
     const scope = requireConfigString(
       properties['Scope'],
       'REGIONAL',
-      'AWS::WAFv2::WebACL Scope'
+      'AWS::WAFv2::WebACL Scope',
+      replayWarn(this.logger, context)
     ) as Scope;
 
     this.warnOnSdkUnsupportedRuleKeys(logicalId, properties['Rules']);

--- a/tests/unit/provisioning/config-shape.test.ts
+++ b/tests/unit/provisioning/config-shape.test.ts
@@ -271,3 +271,46 @@ describe('onUnusable (issue #1513)', () => {
     expect(warn).not.toHaveBeenCalled();
   });
 });
+
+describe('readConfigString container downgrade under onUnusable (issue #1544)', () => {
+  // The nested-container form of the same replay downgrade: a malformed
+  // CONTAINER (`StreamSpecification: ''`) under onUnusable warns and behaves
+  // as `{}` — the key is then absent, so the fallback is returned, which is
+  // exactly what an empty block already means.
+  const PATH = 'AWS::DynamoDB::GlobalTable StreamSpecification';
+
+  it('warns and returns the fallback for a malformed container', () => {
+    const warn = vi.fn();
+    expect(readConfigString('', 'StreamViewType', 'NEW_AND_OLD_IMAGES', PATH, { onUnusable: warn })).toBe(
+      'NEW_AND_OLD_IMAGES'
+    );
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0][0] as string;
+    expect(message).toMatch(/must be an object/);
+    expect(message).toMatch(/Treating the block as empty/);
+    expect(message).toMatch(/default \(NEW_AND_OLD_IMAGES\)/);
+    expect(message).toMatch(/REFUSED on a template-path create/);
+  });
+
+  it('omits the parenthesized default when the fallback is the empty string', () => {
+    const warn = vi.fn();
+    expect(readConfigString(42, 'LogFilePrefix', '', 'AWS::S3::Bucket LoggingConfiguration', { onUnusable: warn })).toBe('');
+    const message = warn.mock.calls[0][0] as string;
+    expect(message).toMatch(/takes its default here/);
+    expect(message).not.toMatch(/default \(\)/);
+  });
+
+  it('still throws on a malformed container when no onUnusable is supplied', () => {
+    expect(() => readConfigString('', 'StreamViewType', 'NEW_AND_OLD_IMAGES', PATH)).toThrow(/must be an object/);
+    expect(() => readConfigString('', 'StreamViewType', 'NEW_AND_OLD_IMAGES', PATH, {})).toThrow(/must be an object/);
+  });
+
+  it('threads the options into the FIELD half unchanged', () => {
+    const warn = vi.fn();
+    expect(
+      readConfigString({ StreamViewType: null }, 'StreamViewType', 'NEW_AND_OLD_IMAGES', PATH, { onUnusable: warn })
+    ).toBe('NEW_AND_OLD_IMAGES');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0] as string).toMatch(/StreamSpecification\.StreamViewType/);
+  });
+});

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-replay-nested-guards.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-replay-nested-guards.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { mockSend, childLogger } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+  childLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    dynamoDB: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  childLogger.child.mockReturnValue(childLogger);
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { DynamoDBGlobalTableProvider } from '../../../src/provisioning/providers/dynamodb-globaltable-provider.js';
+import { ProvisioningError } from '../../../src/utils/error-handler.js';
+
+const RESOURCE_TYPE = 'AWS::DynamoDB::GlobalTable';
+const TABLE_NAME = 'my-test-table-xxx';
+
+/**
+ * `CreateContext.replayingState` downgrade for the two NESTED-container
+ * guards in `create()` (issue #1544), completing what #1542 did for the
+ * top-level `BillingMode` read:
+ *
+ * - the `StreamSpecification` guard (`readConfigString`, which had no options
+ *   parameter at all before this fix), and
+ * - the `GlobalSecondaryIndexes` non-array guard inside
+ *   `toSdkGlobalSecondaryIndexes` (an inline throw with no downgrade hook).
+ *
+ * A state record carrying `StreamSpecification: ''` (or a non-array GSI blob)
+ * previously made the rollback executor's reverse-replacement create hard-
+ * throw — the resource became un-rollbackable with only a hand-edit of
+ * state.json as a remedy, exactly the hazard the replay downgrade exists to
+ * prevent. Downgrade semantics are well-defined, never fabricated: a
+ * malformed StreamSpecification behaves as `{}` (stream enabled with the
+ * NEW_AND_OLD_IMAGES default an empty block already means), and a malformed
+ * GSI blob is OMITTED (zero indexes).
+ */
+describe('DynamoDBGlobalTableProvider nested guards on a state replay (issue #1544)', () => {
+  let provider: DynamoDBGlobalTableProvider;
+
+  beforeEach(() => {
+    mockSend.mockReset();
+    childLogger.warn.mockReset();
+    provider = new DynamoDBGlobalTableProvider();
+  });
+
+  const baseProps = {
+    TableName: TABLE_NAME,
+    KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
+    AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
+    BillingMode: 'PAY_PER_REQUEST',
+    Replicas: [{ Region: 'us-east-1' }],
+  };
+
+  const activeTable = () =>
+    mockSend.mockResolvedValue({ Table: { TableName: TABLE_NAME, TableStatus: 'ACTIVE' } });
+
+  const createCall = () =>
+    mockSend.mock.calls.find((c) => c[0].constructor.name === 'CreateTableCommand');
+
+  // ─── StreamSpecification: replay → warn + treat as {} ──────────────────
+
+  it('WARNS on a malformed StreamSpecification CONTAINER and proceeds as {}', async () => {
+    activeTable();
+
+    await expect(
+      provider.create(
+        'MyTable',
+        RESOURCE_TYPE,
+        { ...baseProps, StreamSpecification: '' },
+        { replayingState: true }
+      )
+    ).resolves.toBeDefined();
+
+    // `{}` means "stream enabled, default view type" — the same thing an
+    // empty block already means, so nothing is fabricated.
+    expect(createCall()?.[0].input.StreamSpecification).toEqual({
+      StreamEnabled: true,
+      StreamViewType: 'NEW_AND_OLD_IMAGES',
+    });
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('AWS::DynamoDB::GlobalTable StreamSpecification must be an object')
+    );
+  });
+
+  it('WARNS on a malformed StreamViewType FIELD and proceeds with the default', async () => {
+    activeTable();
+
+    await expect(
+      provider.create(
+        'MyTable',
+        RESOURCE_TYPE,
+        { ...baseProps, StreamSpecification: { StreamViewType: null } },
+        { replayingState: true }
+      )
+    ).resolves.toBeDefined();
+
+    expect(createCall()?.[0].input.StreamSpecification).toEqual({
+      StreamEnabled: true,
+      StreamViewType: 'NEW_AND_OLD_IMAGES',
+    });
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'AWS::DynamoDB::GlobalTable StreamSpecification.StreamViewType must be a non-empty string'
+      )
+    );
+  });
+
+  it('leaves a VALID StreamSpecification untouched on a state replay', async () => {
+    activeTable();
+
+    await provider.create(
+      'MyTable',
+      RESOURCE_TYPE,
+      { ...baseProps, StreamSpecification: { StreamViewType: 'KEYS_ONLY' } },
+      { replayingState: true }
+    );
+
+    expect(createCall()?.[0].input.StreamSpecification).toEqual({
+      StreamEnabled: true,
+      StreamViewType: 'KEYS_ONLY',
+    });
+    expect(childLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('StreamSpecification')
+    );
+  });
+
+  // ─── StreamSpecification: template path → refusal stands ───────────────
+
+  it('keeps the StreamSpecification refusal on an ordinary create (no context)', async () => {
+    activeTable();
+
+    await expect(
+      provider.create('MyTable', RESOURCE_TYPE, { ...baseProps, StreamSpecification: '' })
+    ).rejects.toThrow(
+      /AWS::DynamoDB::GlobalTable StreamSpecification must be an object \(got a blank string\)/
+    );
+    expect(createCall()).toBeUndefined();
+  });
+
+  it('keeps the StreamSpecification refusal under replayingState: false, as a ProvisioningError', async () => {
+    activeTable();
+
+    const err = await provider
+      .create(
+        'MyTable',
+        RESOURCE_TYPE,
+        { ...baseProps, StreamSpecification: 'NEW_IMAGE' },
+        { replayingState: false }
+      )
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ProvisioningError);
+    expect(err).toMatchObject({ resourceType: RESOURCE_TYPE, logicalId: 'MyTable' });
+    expect(createCall()).toBeUndefined();
+  });
+
+  // ─── GlobalSecondaryIndexes: replay → warn + omit the block ────────────
+
+  it('WARNS on a non-array GlobalSecondaryIndexes and proceeds with NO indexes', async () => {
+    activeTable();
+
+    await expect(
+      provider.create(
+        'MyTable',
+        RESOURCE_TYPE,
+        { ...baseProps, GlobalSecondaryIndexes: 'bad' },
+        { replayingState: true }
+      )
+    ).resolves.toBeDefined();
+
+    // OMITTED, not fabricated: the malformed block yields zero indexes.
+    expect(createCall()?.[0].input.GlobalSecondaryIndexes).toBeUndefined();
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('AWS::DynamoDB::GlobalTable GlobalSecondaryIndexes must be an array')
+    );
+  });
+
+  it('leaves a VALID GlobalSecondaryIndexes blob untouched on a state replay', async () => {
+    activeTable();
+
+    await provider.create(
+      'MyTable',
+      RESOURCE_TYPE,
+      {
+        ...baseProps,
+        AttributeDefinitions: [
+          { AttributeName: 'pk', AttributeType: 'S' },
+          { AttributeName: 'gsiPk', AttributeType: 'S' },
+        ],
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: 'my-index',
+            KeySchema: [{ AttributeName: 'gsiPk', KeyType: 'HASH' }],
+            Projection: { ProjectionType: 'ALL' },
+          },
+        ],
+      },
+      { replayingState: true }
+    );
+
+    const gsis = createCall()?.[0].input.GlobalSecondaryIndexes;
+    expect(gsis).toHaveLength(1);
+    expect(gsis[0].IndexName).toBe('my-index');
+    expect(childLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('GlobalSecondaryIndexes')
+    );
+  });
+
+  // ─── GlobalSecondaryIndexes: template path → refusal stands ────────────
+
+  it('keeps the GSI refusal on an ordinary create (no context)', async () => {
+    activeTable();
+
+    await expect(
+      provider.create('MyTable', RESOURCE_TYPE, { ...baseProps, GlobalSecondaryIndexes: 'bad' })
+    ).rejects.toThrow(/GlobalSecondaryIndexes must be an array/);
+    expect(createCall()).toBeUndefined();
+  });
+
+  it('keeps the GSI refusal when the context is present but carries no replay flag', async () => {
+    activeTable();
+
+    // `replayWarn` tests `=== true`, so an empty context bag is an ordinary
+    // create — pinned so a future `!== false` refactor cannot silently turn
+    // every context-carrying create into a warn.
+    const err = await provider
+      .create('MyTable', RESOURCE_TYPE, { ...baseProps, GlobalSecondaryIndexes: 'bad' }, {})
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ProvisioningError);
+    expect(err).toMatchObject({ resourceType: RESOURCE_TYPE, logicalId: 'MyTable' });
+    expect(createCall()).toBeUndefined();
+  });
+});

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-replay-nested-guards.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-replay-nested-guards.test.ts
@@ -250,4 +250,18 @@ describe('DynamoDBGlobalTableProvider nested guards on a state replay (issue #15
     expect(err).toMatchObject({ resourceType: RESOURCE_TYPE, logicalId: 'MyTable' });
     expect(createCall()).toBeUndefined();
   });
+
+  it('keeps the GSI refusal under replayingState: false', async () => {
+    activeTable();
+
+    await expect(
+      provider.create(
+        'MyTable',
+        RESOURCE_TYPE,
+        { ...baseProps, GlobalSecondaryIndexes: 'bad' },
+        { replayingState: false }
+      )
+    ).rejects.toThrow(/GlobalSecondaryIndexes must be an array/);
+    expect(createCall()).toBeUndefined();
+  });
 });

--- a/tests/unit/provisioning/lambda-url-provider-authtype-replay.test.ts
+++ b/tests/unit/provisioning/lambda-url-provider-authtype-replay.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { mockSend, childLogger } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+  childLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    lambda: { send: mockSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => {
+  childLogger.child.mockReturnValue(childLogger);
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { LambdaUrlProvider } from '../../../src/provisioning/providers/lambda-url-provider.js';
+
+const RESOURCE_TYPE = 'AWS::Lambda::Url';
+const FN_ARN = 'arn:aws:lambda:us-east-1:123456789012:function:my-fn';
+const URL = 'https://abc123.lambda-url.us-east-1.on.aws/';
+
+/**
+ * `CreateContext.replayingState` downgrade for the create-path `AuthType`
+ * pre-flight refusal (issue #1544).
+ *
+ * Before this fix `create()` did not declare the optional `context`
+ * parameter, so a state record carrying a malformed `AuthType` (written by an
+ * older binary) hard-threw on the rollback executor's reverse-replacement
+ * replay — leaving the old function URL unrestorable with only a hand-edit of
+ * state.json as a remedy. Modeled on the #1542 BillingMode suite.
+ */
+describe('LambdaUrlProvider malformed AuthType on a state replay (issue #1544)', () => {
+  let provider: LambdaUrlProvider;
+
+  beforeEach(() => {
+    mockSend.mockReset();
+    childLogger.warn.mockReset();
+    provider = new LambdaUrlProvider();
+  });
+
+  const baseProps = { TargetFunctionArn: FN_ARN };
+
+  const createSucceeds = () =>
+    mockSend.mockResolvedValue({ FunctionUrl: URL, FunctionArn: FN_ARN });
+
+  const commandNames = () => mockSend.mock.calls.map((c) => c[0].constructor.name);
+
+  // ─── replayingState: true → warn, proceed with the default ─────────────
+
+  it('WARNS instead of throwing when the create is a state replay', async () => {
+    createSucceeds();
+
+    const result = await provider.create(
+      'MyUrl',
+      RESOURCE_TYPE,
+      { ...baseProps, AuthType: null },
+      { replayingState: true }
+    );
+
+    expect(result.physicalId).toBe(FN_ARN);
+    const createCall = mockSend.mock.calls.find(
+      (c) => c[0].constructor.name === 'CreateFunctionUrlConfigCommand'
+    );
+    expect(createCall?.[0].input.AuthType).toBe('NONE');
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('AWS::Lambda::Url AuthType must be a non-empty string')
+    );
+  });
+
+  it('leaves a VALID AuthType untouched on a state replay', async () => {
+    createSucceeds();
+
+    await provider.create(
+      'MyUrl',
+      RESOURCE_TYPE,
+      { ...baseProps, AuthType: 'AWS_IAM' },
+      { replayingState: true }
+    );
+
+    const createCall = mockSend.mock.calls.find(
+      (c) => c[0].constructor.name === 'CreateFunctionUrlConfigCommand'
+    );
+    expect(createCall?.[0].input.AuthType).toBe('AWS_IAM');
+    expect(childLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('AWS::Lambda::Url AuthType')
+    );
+  });
+
+  // ─── replayingState absent / false / empty context → refusal stands ────
+
+  it('keeps the refusal on an ordinary template-path create (no context)', async () => {
+    createSucceeds();
+
+    // A blank AuthType silently defaulting to NONE is a PUBLIC function URL —
+    // the very reason this site was guarded in #1493. The refusal must stay
+    // on every template-path create.
+    await expect(
+      provider.create('MyUrl', RESOURCE_TYPE, { ...baseProps, AuthType: '' })
+    ).rejects.toThrow(/AWS::Lambda::Url AuthType must be a non-empty string \(got a blank string\)/);
+
+    expect(commandNames()).not.toContain('CreateFunctionUrlConfigCommand');
+  });
+
+  it('keeps the refusal when the context carries replayingState: false', async () => {
+    createSucceeds();
+
+    await expect(
+      provider.create(
+        'MyUrl',
+        RESOURCE_TYPE,
+        { ...baseProps, AuthType: null },
+        { replayingState: false }
+      )
+    ).rejects.toThrow(/AWS::Lambda::Url AuthType must be a non-empty string/);
+    expect(commandNames()).not.toContain('CreateFunctionUrlConfigCommand');
+  });
+
+  it('keeps the refusal when the context is present but carries no replay flag', async () => {
+    createSucceeds();
+
+    // `replayWarn` tests `=== true`; an empty context bag is an ordinary
+    // create.
+    await expect(
+      provider.create('MyUrl', RESOURCE_TYPE, { ...baseProps, AuthType: null }, {})
+    ).rejects.toThrow(/AWS::Lambda::Url AuthType must be a non-empty string/);
+  });
+
+  it('still defaults an ABSENT AuthType to NONE on a plain create', async () => {
+    createSucceeds();
+
+    await provider.create('MyUrl', RESOURCE_TYPE, { ...baseProps });
+
+    const createCall = mockSend.mock.calls.find(
+      (c) => c[0].constructor.name === 'CreateFunctionUrlConfigCommand'
+    );
+    expect(createCall?.[0].input.AuthType).toBe('NONE');
+    expect(childLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('AWS::Lambda::Url AuthType')
+    );
+  });
+});

--- a/tests/unit/provisioning/s3-directory-bucket-provider-data-redundancy-replay.test.ts
+++ b/tests/unit/provisioning/s3-directory-bucket-provider-data-redundancy-replay.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { mockS3Send, mockStsSend, mockEc2Send, childLogger } = vi.hoisted(() => ({
+  mockS3Send: vi.fn(),
+  mockStsSend: vi.fn(),
+  mockEc2Send: vi.fn(),
+  childLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    s3: { send: mockS3Send, config: { region: () => Promise.resolve('us-east-1') } },
+    sts: { send: mockStsSend, config: { region: () => Promise.resolve('us-east-1') } },
+  }),
+}));
+
+vi.mock('@aws-sdk/client-ec2', async () => {
+  const actual = await vi.importActual('@aws-sdk/client-ec2');
+  return {
+    ...actual,
+    EC2Client: vi.fn().mockImplementation(() => ({
+      send: mockEc2Send,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  childLogger.child.mockReturnValue(childLogger);
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { S3DirectoryBucketProvider } from '../../../src/provisioning/providers/s3-directory-bucket-provider.js';
+
+const RESOURCE_TYPE = 'AWS::S3Express::DirectoryBucket';
+const BUCKET_NAME = 'my-bucket--use1-az1--x-s3';
+
+/**
+ * `CreateContext.replayingState` downgrade for the create-path
+ * `DataRedundancy` pre-flight refusal (issue #1544).
+ *
+ * Before this fix `create()` did not declare the optional `context`
+ * parameter, so a state record carrying a malformed `DataRedundancy` hard-
+ * threw on the rollback executor's reverse-replacement replay — leaving the
+ * old directory bucket unrestorable. Modeled on the #1542 BillingMode suite.
+ */
+describe('S3DirectoryBucketProvider malformed DataRedundancy on a state replay (issue #1544)', () => {
+  let provider: S3DirectoryBucketProvider;
+
+  beforeEach(() => {
+    mockS3Send.mockReset();
+    mockStsSend.mockReset();
+    mockEc2Send.mockReset();
+    childLogger.warn.mockReset();
+    provider = new S3DirectoryBucketProvider();
+
+    mockEc2Send.mockResolvedValue({ AvailabilityZones: [{ ZoneId: 'use1-az1' }] });
+    mockStsSend.mockResolvedValue({ Account: '123456789012' });
+    mockS3Send.mockResolvedValue({});
+  });
+
+  const baseProps = { BucketName: BUCKET_NAME, LocationName: 'us-east-1a--x-s3' };
+
+  const createCall = () =>
+    mockS3Send.mock.calls.find((c) => c[0].constructor.name === 'CreateBucketCommand');
+
+  // ─── replayingState: true → warn, proceed with the default ─────────────
+
+  it('WARNS instead of throwing when the create is a state replay', async () => {
+    const result = await provider.create(
+      'MyBucket',
+      RESOURCE_TYPE,
+      { ...baseProps, DataRedundancy: null },
+      { replayingState: true }
+    );
+
+    expect(result.physicalId).toBe(BUCKET_NAME);
+    expect(createCall()?.[0].input.CreateBucketConfiguration.Bucket.DataRedundancy).toBe(
+      'SingleAvailabilityZone'
+    );
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'AWS::S3Express::DirectoryBucket DataRedundancy must be a non-empty string'
+      )
+    );
+  });
+
+  it('leaves a VALID DataRedundancy untouched on a state replay', async () => {
+    await provider.create(
+      'MyBucket',
+      RESOURCE_TYPE,
+      { ...baseProps, DataRedundancy: 'SingleAvailabilityZone' },
+      { replayingState: true }
+    );
+
+    expect(createCall()?.[0].input.CreateBucketConfiguration.Bucket.DataRedundancy).toBe(
+      'SingleAvailabilityZone'
+    );
+    expect(childLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('AWS::S3Express::DirectoryBucket DataRedundancy')
+    );
+  });
+
+  // ─── replayingState absent / false / empty context → refusal stands ────
+
+  it('keeps the refusal on an ordinary template-path create (no context)', async () => {
+    await expect(
+      provider.create('MyBucket', RESOURCE_TYPE, { ...baseProps, DataRedundancy: null })
+    ).rejects.toThrow(
+      /AWS::S3Express::DirectoryBucket DataRedundancy must be a non-empty string \(got null\)/
+    );
+
+    // The refusal must land BEFORE CreateBucket — a pre-flight refusal.
+    expect(createCall()).toBeUndefined();
+  });
+
+  it('keeps the refusal when the context carries replayingState: false', async () => {
+    await expect(
+      provider.create(
+        'MyBucket',
+        RESOURCE_TYPE,
+        { ...baseProps, DataRedundancy: '' },
+        { replayingState: false }
+      )
+    ).rejects.toThrow(/AWS::S3Express::DirectoryBucket DataRedundancy must be a non-empty string/);
+    expect(createCall()).toBeUndefined();
+  });
+
+  it('keeps the refusal when the context is present but carries no replay flag', async () => {
+    // `replayWarn` tests `=== true`; an empty context bag is an ordinary
+    // create.
+    await expect(
+      provider.create(
+        'MyBucket',
+        RESOURCE_TYPE,
+        { ...baseProps, DataRedundancy: { Ref: 'Unresolved' } },
+        {}
+      )
+    ).rejects.toThrow(
+      /AWS::S3Express::DirectoryBucket DataRedundancy must be a non-empty string \(got an object\)/
+    );
+  });
+
+  it('still defaults an ABSENT DataRedundancy on a plain create', async () => {
+    await provider.create('MyBucket', RESOURCE_TYPE, { ...baseProps });
+
+    expect(createCall()?.[0].input.CreateBucketConfiguration.Bucket.DataRedundancy).toBe(
+      'SingleAvailabilityZone'
+    );
+    expect(childLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('AWS::S3Express::DirectoryBucket DataRedundancy')
+    );
+  });
+});

--- a/tests/unit/provisioning/wafv2-provider-scope-replay.test.ts
+++ b/tests/unit/provisioning/wafv2-provider-scope-replay.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+const { mockSend, childLogger } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+  childLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  },
+}));
+
+vi.mock('@aws-sdk/client-wafv2', async () => {
+  const actual = await vi.importActual('@aws-sdk/client-wafv2');
+  return {
+    ...actual,
+    WAFV2Client: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  childLogger.child.mockReturnValue(childLogger);
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { WAFv2WebACLProvider } from '../../../src/provisioning/providers/wafv2-provider.js';
+
+const RESOURCE_TYPE = 'AWS::WAFv2::WebACL';
+const TEST_ARN = 'arn:aws:wafv2:us-east-1:123456789012:regional/webacl/my-acl/abc-123-def';
+
+/**
+ * `CreateContext.replayingState` downgrade for the create-path `Scope`
+ * pre-flight refusal (issue #1544).
+ *
+ * The rollback executor's reverse-replacement arm revives the OLD WebACL from
+ * `previousState.properties` — a cdkd STATE record the user cannot edit from
+ * CDK code. Before this fix `create()` did not declare the optional `context`
+ * parameter, so the `requireConfigString` refusal fired even on that replay
+ * and left the resource unrestorable. Modeled on the #1542 BillingMode suite.
+ */
+describe('WAFv2WebACLProvider malformed Scope on a state replay (issue #1544)', () => {
+  let provider: WAFv2WebACLProvider;
+
+  beforeEach(() => {
+    mockSend.mockReset();
+    childLogger.warn.mockReset();
+    provider = new WAFv2WebACLProvider();
+  });
+
+  const baseProps = {
+    Name: 'my-acl',
+    DefaultAction: { Allow: {} },
+    VisibilityConfig: {
+      SampledRequestsEnabled: true,
+      CloudWatchMetricsEnabled: true,
+      MetricName: 'my-acl',
+    },
+  };
+
+  const createSucceeds = () =>
+    mockSend.mockResolvedValue({
+      Summary: { ARN: TEST_ARN, Id: 'abc-123-def', LabelNamespace: 'awswaf:...:' },
+    });
+
+  const commandNames = () => mockSend.mock.calls.map((c) => c[0].constructor.name);
+
+  // ─── replayingState: true → warn, proceed with the default ─────────────
+
+  it('WARNS instead of throwing when the create is a state replay', async () => {
+    createSucceeds();
+
+    const result = await provider.create(
+      'MyWebACL',
+      RESOURCE_TYPE,
+      { ...baseProps, Scope: null },
+      { replayingState: true }
+    );
+
+    expect(result.physicalId).toBe(TEST_ARN);
+    const createCall = mockSend.mock.calls.find(
+      (c) => c[0].constructor.name === 'CreateWebACLCommand'
+    );
+    expect(createCall?.[0].input.Scope).toBe('REGIONAL');
+    expect(childLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('AWS::WAFv2::WebACL Scope must be a non-empty string')
+    );
+  });
+
+  it('leaves a VALID Scope untouched on a state replay', async () => {
+    createSucceeds();
+
+    await provider.create(
+      'MyWebACL',
+      RESOURCE_TYPE,
+      { ...baseProps, Scope: 'CLOUDFRONT' },
+      { replayingState: true }
+    );
+
+    const createCall = mockSend.mock.calls.find(
+      (c) => c[0].constructor.name === 'CreateWebACLCommand'
+    );
+    expect(createCall?.[0].input.Scope).toBe('CLOUDFRONT');
+    expect(childLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('AWS::WAFv2::WebACL Scope')
+    );
+  });
+
+  // ─── replayingState absent / false / empty context → refusal stands ────
+
+  it('keeps the refusal on an ordinary template-path create (no context)', async () => {
+    createSucceeds();
+
+    await expect(
+      provider.create('MyWebACL', RESOURCE_TYPE, { ...baseProps, Scope: null })
+    ).rejects.toThrow(/AWS::WAFv2::WebACL Scope must be a non-empty string \(got null\)/);
+
+    // The refusal must land BEFORE CreateWebACL — a pre-flight refusal.
+    expect(commandNames()).not.toContain('CreateWebACLCommand');
+  });
+
+  it('keeps the refusal when the context carries replayingState: false', async () => {
+    createSucceeds();
+
+    await expect(
+      provider.create(
+        'MyWebACL',
+        RESOURCE_TYPE,
+        { ...baseProps, Scope: '' },
+        { replayingState: false }
+      )
+    ).rejects.toThrow(/AWS::WAFv2::WebACL Scope must be a non-empty string/);
+    expect(commandNames()).not.toContain('CreateWebACLCommand');
+  });
+
+  it('keeps the refusal when the context is present but carries no replay flag', async () => {
+    createSucceeds();
+
+    // `replayWarn` tests `=== true`, so an empty context bag is an ordinary
+    // create. Pinned so a future `!== false` refactor cannot silently turn
+    // every context-carrying create into a warn.
+    await expect(
+      provider.create('MyWebACL', RESOURCE_TYPE, { ...baseProps, Scope: 5 }, {})
+    ).rejects.toThrow(/AWS::WAFv2::WebACL Scope must be a non-empty string \(got a number\)/);
+  });
+
+  it('still defaults an ABSENT Scope to REGIONAL on a plain create', async () => {
+    createSucceeds();
+
+    await provider.create('MyWebACL', RESOURCE_TYPE, { ...baseProps });
+
+    const createCall = mockSend.mock.calls.find(
+      (c) => c[0].constructor.name === 'CreateWebACLCommand'
+    );
+    expect(createCall?.[0].input.Scope).toBe('REGIONAL');
+    expect(childLogger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('AWS::WAFv2::WebACL Scope')
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1544

`CreateContext.replayingState` exists so a provider's create-path pre-flight refusal downgrades to a warning when the properties come from a cdkd STATE record — the rollback executor's reverse-replacement arm revives the old resource from `previousState.properties`, which the user cannot edit from the template. A refusal there leaves the old resource unrestorable with only a hand-edit of `state.json` as a remedy.

Three create-path refusals never downgraded because their providers did not declare the optional `context` parameter; they now thread it and pass `replayWarn`, with valid-path behavior unchanged (fallbacks preserved: `REGIONAL` / `NONE` / `SingleAvailabilityZone`):

- `wafv2-provider.ts` `Scope`
- `lambda-url-provider.ts` create-path `AuthType`
- `s3-directory-bucket-provider.ts` `DataRedundancy`

The GlobalTable provider's nested create-path guards downgrade too:

- `readConfigString` grew an optional trailing `ConfigStringOptions` parameter (backward compatible — untouched callers compile and behave identically). Under `onUnusable` a malformed CONTAINER warns and behaves as `{}` — the fallback an empty block already means — and the field half threads the options into `requireConfigString` unchanged. The `StreamSpecification` guard passes `replayWarn`, so a state record carrying `StreamSpecification: ''` no longer strands a reverse-replacement create.
- `toSdkGlobalSecondaryIndexes` grew an optional `onUnusableIndexes` hook, wired from `replayWarn` at the `create()` call site only: under replay a non-array GSI blob warns and is OMITTED (zero indexes — a well-defined skip, never a fabricated value). Every other call site leaves the hook undefined and keeps the refusal, message byte-identical (existing tests still pin it).

## Deviation from the issue text

The issue's step 2 asked whether `readConfigString` / `requireConfigArray` should grow options. `requireConfigArray` was deliberately NOT grown: its only callers are CodeBuild sites — the GSI guard does not use it (the issue's premise was inaccurate) — so growing it would have added a zero-caller API surface. The downgrade hook went into the GSI function itself instead.

## Left strict, deliberately (tracked in (#1551))

- `lambda-url-provider.ts` UPDATE-path `AuthType`: downgrading with the current `'NONE'` fallback would silently flip a live function URL to PUBLIC; it needs the keep-the-previous-value design.
- GlobalTable UPDATE-path nested guards: same per-site-decision requirement.

## Test plan

- Four new suites (28 tests — one added in review) plus direct config-shape helper tests, modeled on the (#1542) precedent: both `replayingState` polarities per site (true → warns via the child logger, proceeds, AWS create invoked with the well-defined value; false/absent → throws before the create command), valid-value-under-replay passthrough, absent-value defaulting.
- Binding proof: with `src/` stashed, exactly the 6 replay-downgrade assertions fail.
- Full suite: 545 files / 9815 tests pass; typecheck / lint / build clean.
- Live verification: `/run-integ wafv2` (real-AWS deploy + destroy through a changed provider — the Scope guard now runs through `replayWarn` wiring on every template-path create; destroy finished 0 errors / 0 orphans). The originally planned `dynamodb-globaltable` fixture was occupied by a parallel session's live run (lock.json present), so the wafv2 fixture was substituted; the GlobalTable template-path wiring is pinned by the 110-test provider suites, and the replay polarity requires a reverse-replacement rollback over a corrupted historical state record and is unit-verified only (binding-proven above).

## Review (3-axis: spec / code / tests)

- Spec review: clean — every issue site addressed or deferred with recorded rationale; the `requireConfigArray` deviation verified factually correct in code (its only callers are CodeBuild sites).
- Fixed in this PR: `.claude/rules/providers.md`'s "gap this list makes visible" note rewritten (it described exactly the gap this PR closes); the GSI downgrade warn no longer carries the contradictory refusal-rationale sentence; direct unit tests for `readConfigString`'s container-downgrade arm (incl. the empty-fallback message branch); a GSI `replayingState: false` polarity pin.
- TODO (#1551): lambda-url UPDATE-path AuthType and GlobalTable UPDATE-path nested guards stay strict (need the keep-the-previous-value design, not the create default).
