### PR TITLE
chore(audit): close the 50-path S3 nested-key residual and opt AWS::S3::Bucket into the write-evidence pass

### DIFF
--- a/docs/_generated/nested-key-coverage.json
+++ b/docs/_generated/nested-key-coverage.json
@@ -2,13 +2,13 @@
   "summary": {
     "targetCount": 11,
     "nestedKeyCount": 703,
-    "sameSpelling": 642,
+    "sameSpelling": 639,
     "providerHandled": 53,
-    "allowListed": 8,
+    "allowListed": 11,
     "caseDivergence": 0,
     "noSdkMember": 0,
     "noWriteEvidence": 0,
-    "freshObjectTargets": 10,
+    "freshObjectTargets": 11,
     "shapeClean": 87,
     "shapeHandled": 32,
     "shapeAllowListed": 7,
@@ -73,7 +73,8 @@
       "unmatchedDefinitions": [
         "BodyS3Location"
       ],
-      "usedSegmentRenames": []
+      "usedSegmentRenames": [],
+      "usedTerminalRenames": []
     },
     {
       "resourceType": "AWS::ApiGatewayV2::Authorizer",
@@ -101,7 +102,8 @@
       "shapeEntries": [],
       "shapeCleanCount": 2,
       "unmatchedDefinitions": [],
-      "usedSegmentRenames": []
+      "usedSegmentRenames": [],
+      "usedTerminalRenames": []
     },
     {
       "resourceType": "AWS::ApiGatewayV2::Integration",
@@ -126,7 +128,8 @@
         "ResponseParameterMap",
         "Tag"
       ],
-      "usedSegmentRenames": []
+      "usedSegmentRenames": [],
+      "usedTerminalRenames": []
     },
     {
       "resourceType": "AWS::ApiGatewayV2::Route",
@@ -139,7 +142,8 @@
       "shapeEntries": [],
       "shapeCleanCount": 1,
       "unmatchedDefinitions": [],
-      "usedSegmentRenames": []
+      "usedSegmentRenames": [],
+      "usedTerminalRenames": []
     },
     {
       "resourceType": "AWS::ApiGatewayV2::Stage",
@@ -188,7 +192,8 @@
       "shapeEntries": [],
       "shapeCleanCount": 0,
       "unmatchedDefinitions": [],
-      "usedSegmentRenames": []
+      "usedSegmentRenames": [],
+      "usedTerminalRenames": []
     },
     {
       "resourceType": "AWS::CloudFront::Distribution",
@@ -1578,7 +1583,8 @@
         "LegacyS3Origin",
         "Logging"
       ],
-      "usedSegmentRenames": []
+      "usedSegmentRenames": [],
+      "usedTerminalRenames": []
     },
     {
       "resourceType": "AWS::CloudWatch::AnomalyDetector",
@@ -1811,7 +1817,8 @@
       "unmatchedDefinitions": [
         "Configuration"
       ],
-      "usedSegmentRenames": []
+      "usedSegmentRenames": [],
+      "usedTerminalRenames": []
     },
     {
       "resourceType": "AWS::CodeBuild::Project",
@@ -2518,7 +2525,8 @@
         "ProjectTriggers",
         "Source"
       ],
-      "usedSegmentRenames": []
+      "usedSegmentRenames": [],
+      "usedTerminalRenames": []
     },
     {
       "resourceType": "AWS::ECS::Service",
@@ -2937,7 +2945,8 @@
         "ServiceConnectTestTrafficRulesHeader",
         "ServiceConnectTestTrafficRulesHeaderValue"
       ],
-      "usedSegmentRenames": []
+      "usedSegmentRenames": [],
+      "usedTerminalRenames": []
     },
     {
       "resourceType": "AWS::ECS::TaskDefinition",
@@ -3951,14 +3960,15 @@
       ],
       "usedSegmentRenames": [
         "ProxyConfigurationProperties"
-      ]
+      ],
+      "usedTerminalRenames": []
     },
     {
       "resourceType": "AWS::S3::Bucket",
       "providerFile": "s3-bucket-provider.ts",
       "sdkClientPackage": "@aws-sdk/client-s3",
       "keyStyle": "exact",
-      "freshObjectMapper": false,
+      "freshObjectMapper": true,
       "nestedKeyCount": 190,
       "entries": [
         {
@@ -4473,14 +4483,20 @@
           "nestedKey": "LifecycleConfiguration.Rules.TagFilters.Key",
           "topLevelProperty": "LifecycleConfiguration",
           "terminalKey": "Key",
-          "bucket": "same-spelling"
+          "bucket": "allow-listed",
+          "sdkNearMiss": "Key",
+          "rationale": "Forwarded verbatim into `Filter{,.And}.Tags` by applyLifecycleConfiguration, but through a chain the hand-off taint walk deliberately does not cross: the array reaches the write as a DESTRUCTURED member of the in-method `gatherScope` helper's returned literal, and member-level taint through a returned literal is a materially bigger analysis (issue #1540; same wrapper-level class as the CloudFront `Tags.Key` / `Tags.Value` entries). The equivalent per-item-config forwards (Analytics / Metrics / IntelligentTiering) ARE wildcard-credited via the for-of taint hop.",
+          "allowMatchKey": "AWS::S3::Bucket#LifecycleConfiguration.Rules.TagFilters.Key"
         },
         {
           "resourceType": "AWS::S3::Bucket",
           "nestedKey": "LifecycleConfiguration.Rules.TagFilters.Value",
           "topLevelProperty": "LifecycleConfiguration",
           "terminalKey": "Value",
-          "bucket": "same-spelling"
+          "bucket": "allow-listed",
+          "sdkNearMiss": "Value",
+          "rationale": "Same destructured-gatherScope forward as the sibling `LifecycleConfiguration.Rules.TagFilters.Key` entry (issue #1540).",
+          "allowMatchKey": "AWS::S3::Bucket#LifecycleConfiguration.Rules.TagFilters.Value"
         },
         {
           "resourceType": "AWS::S3::Bucket",
@@ -4543,7 +4559,10 @@
           "nestedKey": "LifecycleConfiguration.TransitionDefaultMinimumObjectSize",
           "topLevelProperty": "LifecycleConfiguration",
           "terminalKey": "TransitionDefaultMinimumObjectSize",
-          "bucket": "same-spelling"
+          "bucket": "allow-listed",
+          "sdkNearMiss": "TransitionDefaultMinimumObjectSize",
+          "rationale": "Written by applyLifecycleConfiguration DIRECTLY on the PutBucketLifecycleConfigurationRequest (the SDK hoists it out of `LifecycleConfiguration`, where CFn nests it), so the audited chain can never resolve: a terminal rename redirects WITHIN the config object and cannot express a request-level hoist. Delivery is proven by the s3-replication-and-filter integ read-back (issue #1495) and the write is pinned by name in the #1495 write-evidence unit test (issues #1520 / #1540).",
+          "allowMatchKey": "AWS::S3::Bucket#LifecycleConfiguration.TransitionDefaultMinimumObjectSize"
         },
         {
           "resourceType": "AWS::S3::Bucket",
@@ -5488,15 +5507,41 @@
       ],
       "usedSegmentRenames": [
         "AnalyticsConfigurations",
+        "AnalyticsConfigurations.TagFilters",
         "BucketEncryption",
+        "DataExport.Destination",
         "IntelligentTieringConfigurations",
+        "IntelligentTieringConfigurations.TagFilters",
         "InventoryConfigurations",
+        "InventoryConfigurations.Destination",
+        "LambdaConfigurations",
         "LoggingConfiguration",
         "MetricsConfigurations",
+        "MetricsConfigurations.TagFilters",
         "RedirectRule",
         "RoutingRuleCondition",
+        "Rules.NoncurrentVersionTransition",
+        "Rules.TagFilters",
+        "Rules.Transition",
+        "S3Key",
+        "S3Key.Rules",
         "ServerSideEncryptionByDefault",
         "ServerSideEncryptionConfiguration"
+      ],
+      "usedTerminalRenames": [
+        "AnalyticsConfigurations.Prefix",
+        "BucketEncryption.ServerSideEncryptionConfiguration",
+        "IntelligentTieringConfigurations.Prefix",
+        "InventoryConfigurations.Enabled",
+        "InventoryConfigurations.Prefix",
+        "LifecycleConfiguration.Rules.ExpiredObjectDeleteMarker",
+        "LifecycleConfiguration.Rules.ObjectSizeGreaterThan",
+        "LifecycleConfiguration.Rules.ObjectSizeLessThan",
+        "MetricsConfigurations.AccessPointArn",
+        "MetricsConfigurations.Prefix",
+        "NotificationConfiguration.LambdaConfigurations.Filter.S3Key.Rules",
+        "NotificationConfiguration.QueueConfigurations.Filter.S3Key.Rules",
+        "NotificationConfiguration.TopicConfigurations.Filter.S3Key.Rules"
       ]
     }
   ]

--- a/docs/_generated/nested-key-coverage.md
+++ b/docs/_generated/nested-key-coverage.md
@@ -9,12 +9,12 @@ For every SDK provider that forwards a nested CFn config blob, diffs the blob's 
 
 - Audited targets: **11**
 - Nested CFn key paths audited: **703**
-- Same spelling in SDK model: **642**
+- Same spelling in SDK model: **639**
 - Explicitly handled in provider: **53**
-- Allow-listed pass-throughs (does NOT block CI): **8**
+- Allow-listed pass-throughs (does NOT block CI): **11**
 - **Case divergences (blocks CI): 0**
 - **No SDK member (blocks CI): 0**
-- Write-evidence pass — fresh-object targets audited: **10**
+- Write-evidence pass — fresh-object targets audited: **11**
 - **No write evidence (blocks CI): 0**
 - Shape pass — bare-array pairs clean: **87**
 - Shape pass — explicitly handled in provider: **32**
@@ -39,6 +39,9 @@ None. Every audited nested CFn key either matches an SDK member spelling or is e
 | `AWS::CloudFront::Distribution` | `Tags.Value` | Same wrapper-level insertion as Tags.Key: written by toSdkTags beneath the SDK { Items: Tag[] } wrapper (scope Tags.Items), one level below the CFn chain. |
 | `AWS::CodeBuild::Project` | `Environment.HostKernel` | Declared in the CFn registry schema but has NO member anywhere in the installed @aws-sdk/client-codebuild dist-types tree, so there is nothing to map it onto until an SDK bump adds one (issue #1386). Naming it in the provider would be a false claim of support. Remove this entry once the SDK ships the member, at which point the key becomes genuinely mappable. |
 | `AWS::S3::Bucket` | `CorsConfiguration.CorsRules` | Delivered by applyCorsConfiguration, which reads the CFn key via typed property access (`corsConfig.CorsRules.map(...)`) and writes the SDK spelling `CORSRules` — the literal walk deliberately counts neither a property ACCESS nor a type-literal member, and the only literal mention of the CFn spelling is `readCors`, excluded as a reverse map by the #1520 widening. Key pass only; the members BENEATH it need no entry — the per-level case fold resolves `CorsConfiguration.CorsRules` onto the written `CORSConfiguration.CORSRules` scope, so they stay write-audited (issue #1520). |
+| `AWS::S3::Bucket` | `LifecycleConfiguration.Rules.TagFilters.Key` | Forwarded verbatim into `Filter{,.And}.Tags` by applyLifecycleConfiguration, but through a chain the hand-off taint walk deliberately does not cross: the array reaches the write as a DESTRUCTURED member of the in-method `gatherScope` helper's returned literal, and member-level taint through a returned literal is a materially bigger analysis (issue #1540; same wrapper-level class as the CloudFront `Tags.Key` / `Tags.Value` entries). The equivalent per-item-config forwards (Analytics / Metrics / IntelligentTiering) ARE wildcard-credited via the for-of taint hop. |
+| `AWS::S3::Bucket` | `LifecycleConfiguration.Rules.TagFilters.Value` | Same destructured-gatherScope forward as the sibling `LifecycleConfiguration.Rules.TagFilters.Key` entry (issue #1540). |
+| `AWS::S3::Bucket` | `LifecycleConfiguration.TransitionDefaultMinimumObjectSize` | Written by applyLifecycleConfiguration DIRECTLY on the PutBucketLifecycleConfigurationRequest (the SDK hoists it out of `LifecycleConfiguration`, where CFn nests it), so the audited chain can never resolve: a terminal rename redirects WITHIN the config object and cannot express a request-level hoist. Delivery is proven by the s3-replication-and-filter integ read-back (issue #1495) and the write is pinned by name in the #1495 write-evidence unit test (issues #1520 / #1540). |
 | `AWS::CloudFront::Distribution` | `S3Origin` | Legacy pre-2012 single-origin form (LegacyS3Origin definition), sibling of CustomOrigin; superseded by Origins[]. Invisible to the KEY pass because the StreamingDistribution API still has a same-spelled S3Origin member — the definition pass (issue #1378) is what catches it. |
 | `AWS::S3::Bucket` | `TableNamespace` | Member of the S3TablesDestination definition, reachable only from the MetadataTableConfiguration top-level the provider declares as silent-drop (Cloud-Control-routed), so no SDK forwarding path exists to drop it (issue #1430). |
 | `AWS::S3::Bucket` | `TableArn` | Member of the S3TablesDestination / JournalTableConfiguration / InventoryTableConfiguration definitions, reachable only from the MetadataConfiguration / MetadataTableConfiguration top-levels the provider declares as silent-drop (Cloud-Control-routed), so no SDK forwarding path exists to drop it (issue #1430). |
@@ -166,5 +169,5 @@ CFn members whose SHAPE diverges from the same-spelled SDK member (bare array vs
 | `AWS::CodeBuild::Project` | `codebuild-provider.ts` | `@aws-sdk/client-codebuild` | lower-first | yes | 98 | 4 |
 | `AWS::ECS::Service` | `ecs-provider.ts` | `@aws-sdk/client-ecs` | lower-first | yes | 56 | 4 |
 | `AWS::ECS::TaskDefinition` | `ecs-provider.ts` | `@aws-sdk/client-ecs` | lower-first | yes | 142 | 3 |
-| `AWS::S3::Bucket` | `s3-bucket-provider.ts` | `@aws-sdk/client-s3` | exact | no | 190 | 15 |
+| `AWS::S3::Bucket` | `s3-bucket-provider.ts` | `@aws-sdk/client-s3` | exact | yes | 190 | 15 |
 

--- a/scripts/gen-nested-key-coverage.ts
+++ b/scripts/gen-nested-key-coverage.ts
@@ -332,8 +332,9 @@
  * CloudFront's 162 -> 0 is 160 spread/scope-covered plus 2 allow-listed with
  * `passes: ['write']` (`Tags.Key` / `Tags.Value` — genuinely written by
  * `toSdkTags`, but one SDK wrapper level below the CFn transparent-array
- * chain; see their entries). S3 is deliberately unmoved: its residual is
- * segment renames + never-written drops (#1495), not an unrecognized shape.
+ * chain; see their entries). S3's column values are the HISTORICAL stage
+ * measurements; its road from 81 to the #1540 opt-in at 0 is the bracket
+ * note and reason (C).
  *
  * The RECORDED, MEASURED reasons the remaining targets cannot opt in — none
  * of them "add an allow-list entry", which is what the issue forbids:
@@ -4582,8 +4583,8 @@ export function classifyTarget(
         return renames[segments[i]!] !== undefined ? segments[i]! : undefined;
       };
       const parentChain = segments.slice(0, -1).flatMap((seg, i) => {
-        const key = renameKeyAt(i);
-        return (key === undefined ? styled(seg) : renames[key]!).split('.');
+        const renameKey = renameKeyAt(i);
+        return (renameKey === undefined ? styled(seg) : renames[renameKey]!).split('.');
       });
       const parentPaths = resolveWritePaths(parentChain);
       const coveredPlain =
@@ -4624,10 +4625,10 @@ export function classifyTarget(
       // divergence rather than a stale-map error on top of it.
       if (usedSegmentRenames !== undefined) {
         for (let i = 0; i < segments.length - 1; i++) {
-          const key = renameKeyAt(i);
-          if (key === undefined) continue;
+          const renameKey = renameKeyAt(i);
+          if (renameKey === undefined) continue;
           const plain = segments.slice(0, i + 1).map((seg) => styled(seg));
-          if (!chainResolves(plain)) usedSegmentRenames.add(key);
+          if (!chainResolves(plain)) usedSegmentRenames.add(renameKey);
         }
       }
       // Same negation for terminal entries: unused only when the PLAIN
@@ -5524,8 +5525,8 @@ function main(argv: readonly string[] = process.argv.slice(2)): void {
   if (staleTerminals.length > 0) {
     process.stderr.write(
       'nested-key-coverage: FAIL — stale terminalRenames entr(ies): the un-renamed terminal ' +
-        'already resolves, so the entry is dead weight. Remove them from ' +
-        'scripts/gen-nested-key-coverage.ts:\n' +
+        'already resolves (or the path is no longer write-audited), so the entry is dead ' +
+        'weight. Remove them from scripts/gen-nested-key-coverage.ts:\n' +
         staleTerminals.map((k) => `  ${k}\n`).join('')
     );
     process.exit(1);

--- a/scripts/gen-nested-key-coverage.ts
+++ b/scripts/gen-nested-key-coverage.ts
@@ -324,7 +324,7 @@
  *   AWS::ECS::TaskDefinition           30 / 136   0 / 136    0 / 136    0 / 136  OPTED IN (#1472)   [25/115 -> 1/115]
  *   AWS::ECS::Service                  45 /  56   0 /  56    0 /  56    0 /  56  OPTED IN (#1473)   [44/54 -> 5/54]
  *   AWS::CloudWatch::AnomalyDetector   30 /  30   3 /  30    0 /  30    0 /  30  OPTED IN (#1474)   [29/29 -> 3/29]
- *   AWS::S3::Bucket                   130 / 152 125 / 152   98 / 152   81 / 152  out — see (C)      [106/125 -> 104/125; #1520 renames: 81 -> 50]
+ *   AWS::S3::Bucket                   130 / 152 125 / 152   98 / 152   81 / 152  OPTED IN (#1540)   [#1520 renames: 81 -> 50; #1540 hops + scoped/terminal renames: 50 -> 0]
  *   AWS::CloudFront::Distribution     162 / 162 162 / 162  162 / 162    0 / 162  OPTED IN (#1475)   [110/112 -> 110/112]
  *                                     -------   -------    -------    -------
  *                                        410       290        260         81
@@ -413,43 +413,41 @@
  *     plural->singular per-item PUT tops) and widened the reverse-map
  *     exclusion, which moved the OPT-IN-FORCED residual 81 -> 50.
  *
- *     The remaining 50, RE-MEASURED for #1520, are all shapes a segment
- *     rename cannot express — each a recorded bound, none a known drop:
- *       - RELOCATION under the SDK's `Filter`: CFn puts `Prefix` /
- *         `TagFilters` / `AccessPointArn` (and lifecycle's rule-level
- *         `ObjectSizeGreaterThan` / `LessThan`) at the config/rule level,
- *         the SDK nests them under `Filter{,.And}` with `TagFilters` becoming
- *         `Tag`/`Tags` — Analytics (7) / IntelligentTiering (3) /
- *         Metrics (4) / part of Lifecycle;
- *       - TERMINAL renames (out of a rename's reach by design):
- *         `Destination.BucketArn` -> `Bucket`, `BucketAccountId` ->
- *         `AccountId`, `Enabled` -> `IsEnabled` (Inventory, 6), and
- *         `BucketEncryption.ServerSideEncryptionConfiguration` itself (the
- *         CFn LIST is the SDK's `Rules` wrapper member, 1);
- *       - RENAME-NAME COLLISIONS: the map is keyed by segment name per
- *         TARGET, so Notification's `Rules` -> `FilterRules` / `S3Key` ->
- *         `Key` would corrupt `LifecycleConfiguration.Rules`, and
- *         `Destination` -> `Destination.S3BucketDestination` (Analytics /
- *         Inventory) would corrupt `ReplicationConfiguration.Rules.
- *         Destination` (Notification, 10);
- *       - BUILDER FLOW BOUNDS (bound (8)): lifecycle's `sdkRule` builder
- *         populates members through merge helpers (`mergeLegacySingular` /
- *         `toSdkTransition` / `toSdkNvt`) and forwarded CFn blobs the
- *         seed-literal-only recognizer refuses (rest of Lifecycle's 19);
- *       - a REQUEST-LEVEL HOIST: `TransitionDefaultMinimumObjectSize` sits on
- *         `PutBucketLifecycleConfigurationRequest`, not inside
- *         `LifecycleConfiguration` — a rename cannot express a hoist, the
- *         terminal is out of a rename's reach by design, and a
- *         `passes: ['write']` allow-list entry cannot be added TODAY because
- *         the write pass does not run on a non-opted-in target and the
- *         staleness fence (correctly) rejects a workless entry. The eventual
- *         opt-in change adds it, rationale'd against the write at the
- *         PutBucketLifecycleConfigurationCommand call site (1).
- *     S3 therefore stays out — still for STRUCTURAL reasons, with no known
- *     silent drop behind the number, and the number itself is pinned by the
- *     header-table test so it cannot drift silently. Closing the remaining
- *     50 needs per-path rename scoping and/or a relocation form — a
- *     materially bigger analysis, recorded here rather than half-built.
+ *     [RESOLVED by issue #1540] The remaining 50 fell to 0 through four
+ *     measured mechanisms, each closing one recorded family:
+ *       - the BUILDER-BEHIND-BINDING hop in {@link resolveBuilders}: a
+ *         builder returned from a `.map()` callback held in a plain binding
+ *         (`const rules = cfg.Rules.map((r) => { const sdkRule = {…}; … })`)
+ *         now credits its mutations — lifecycle 19 -> 4 on that alone;
+ *       - the FOR-OF taint hop: the element of a bag-derived array is bag
+ *         data, so the per-item config loops' verbatim `Tags: tagFilters`
+ *         forwards register as whole-blob hand-offs and wildcard-credit
+ *         `TagFilters.Key` / `.Value` (Analytics / Metrics /
+ *         IntelligentTiering);
+ *       - SCOPED segment-rename keys (`'Parent.Segment'`): Notification's
+ *         `S3Key.Rules` -> `FilterRules` and the destination wrappers
+ *         (`DataExport.Destination` / `InventoryConfigurations.Destination`
+ *         -> `Destination.S3BucketDestination`) without corrupting
+ *         `LifecycleConfiguration.Rules` / `ReplicationConfiguration.Rules.
+ *         Destination` — the collision class that blocked bare-name entries;
+ *       - TERMINAL renames / relocations ({@link
+ *         NestedKeyTarget.terminalRenames}, full-path-keyed,
+ *         staleness-fenced): `Enabled` -> `IsEnabled`, the config-level
+ *         `Prefix` / `AccessPointArn` -> `Filter.*` relocations, the
+ *         encryption LIST -> `Rules`, and lifecycle's rule-level
+ *         `ExpiredObjectDeleteMarker` / size constraints.
+ *     Three shapes remain inexpressible BY DESIGN and carry reviewed
+ *     `passes: ['write']` allow-list entries: the request-level
+ *     `TransitionDefaultMinimumObjectSize` hoist and the two lifecycle
+ *     `TagFilters` members forwarded through a destructured member of the
+ *     in-method `gatherScope` helper's returned literal (member-level taint
+ *     through a returned literal is a materially bigger analysis — the same
+ *     wrapper-level class as CloudFront's `Tags.Key` / `Tags.Value`).
+ *     The `Destination.BucketArn` / `BucketAccountId` terminals needed NO
+ *     entry — the bag-derived member forwards register seed-key ALIASES
+ *     (`registerSeedKeyHandoffs`) that cover the CFn spellings, and the
+ *     staleness fence rejected the hand-authored entries as dead weight
+ *     (measured, the fence's first live catch).
  *
  * (D) [RESOLVED by issue #1475] `CloudFrontDistributionProvider.convertToSdkFormat`
  *     is a SPREAD-AND-PATCH forwarder: `const result = { ...config }` delivers
@@ -946,6 +944,32 @@ export interface NestedKeyTarget {
    * divergence it is.
    */
   readonly segmentRenames?: Readonly<Record<string, string>>;
+  /**
+   * TERMINAL renames for audited paths (issue #1540), keyed by the FULL CFn
+   * path. The value's LAST dotted part is the SDK member spelling the provider
+   * actually writes; any earlier parts are scope insertions appended to the
+   * (already renamed) parent chain. Three shapes, all measured on
+   * `s3-bucket-provider.ts`:
+   *   - a pure terminal rename: CFn `InventoryConfigurations.Enabled` is the
+   *     SDK's `IsEnabled`;
+   *   - a relocation: CFn puts `Prefix` at the config level, the SDK nests it
+   *     under `Filter` (`'MetricsConfigurations.Prefix': 'Filter.Prefix'`);
+   *   - both at once: CFn `…Destination.BucketArn` is the SDK's `Bucket`.
+   *
+   * {@link NestedKeyTarget.segmentRenames} deliberately never touches the
+   * terminal ("the terminal IS the audited key"), and that stays true — this
+   * map does not weaken the judgment, it REDIRECTS it: the renamed member is
+   * still required to be scope-written verbatim at the (extended) chain, so a
+   * provider that stops writing `IsEnabled` still fails by name. What the map
+   * adds is the DECLARED CFn->SDK correspondence the case fold cannot express,
+   * per path so one entry can never leak onto a same-named sibling.
+   *
+   * STALENESS-FENCED exactly like segmentRenames ({@link
+   * findStaleTerminalRenames}): an entry whose UN-renamed terminal resolves is
+   * dead weight and fails `--check`; an entry whose renamed terminal ALSO
+   * fails to resolve keeps reporting the divergence rather than masking it.
+   */
+  readonly terminalRenames?: Readonly<Record<string, string>>;
 }
 
 /**
@@ -1045,6 +1069,80 @@ const S3_BUCKET_SEGMENT_RENAMES = {
   InventoryConfigurations: 'InventoryConfiguration',
   MetricsConfigurations: 'MetricsConfiguration',
   IntelligentTieringConfigurations: 'IntelligentTieringConfiguration',
+  // --- issue #1540: SCOPED entries ('Parent.Segment', matched on the ORIGINAL
+  // CFn spellings) for segments whose bare name would leak onto an unrelated
+  // family. ---
+  // Notification: CFn `LambdaConfigurations` is the SDK's
+  // `LambdaFunctionConfigurations` (bare — the name is unique to
+  // notification); `Filter.S3Key` is `Key` (bare, unique); the `Rules` list
+  // under S3Key is the SDK's `FilterRules` — scoped, because bare `Rules`
+  // would corrupt `LifecycleConfiguration.Rules` and
+  // `ReplicationConfiguration.Rules`.
+  LambdaConfigurations: 'LambdaFunctionConfigurations',
+  S3Key: 'Key',
+  'S3Key.Rules': 'FilterRules',
+  // Lifecycle: the legacy SINGULAR forms the CFn schema still accepts are
+  // written through the plural SDK members (`mergeLegacySingular`). Scoped so
+  // the entries can never leak beyond the lifecycle rule.
+  'Rules.Transition': 'Transitions',
+  'Rules.NoncurrentVersionTransition': 'NoncurrentVersionTransitions',
+  // Per-item config families + lifecycle rules: CFn `TagFilters` at the
+  // config/rule level is the SDK's `Tags` under `Filter.And` (the provider
+  // forwards the array verbatim there — the write registers as a whole-blob
+  // hand-off, so the members beneath are wildcard-credited). Scoped per
+  // family; replication's tag filter lives under an explicit CFn `Filter`
+  // and resolves without an entry.
+  'AnalyticsConfigurations.TagFilters': 'Filter.And.Tags',
+  'IntelligentTieringConfigurations.TagFilters': 'Filter.And.Tags',
+  'MetricsConfigurations.TagFilters': 'Filter.And.Tags',
+  'Rules.TagFilters': 'Filter.And.Tags',
+  // Analytics / Inventory destinations: CFn flattens the SDK's
+  // `S3BucketDestination` wrapper level. Scoped because bare `Destination`
+  // would corrupt `ReplicationConfiguration.Rules.Destination`.
+  'DataExport.Destination': 'Destination.S3BucketDestination',
+  'InventoryConfigurations.Destination': 'Destination.S3BucketDestination',
+} as const;
+
+/**
+ * The S3 terminal renames / relocations (issue #1540) — see
+ * {@link NestedKeyTarget.terminalRenames} for the mechanism and its fences.
+ * Every value is verified against the provider's actual write site.
+ */
+const S3_BUCKET_TERMINAL_RENAMES = {
+  // PutBucketInventoryConfiguration: `IsEnabled: (config['Enabled'] …)` and
+  // `Filter: config['Prefix'] ? { Prefix … } : undefined`. The destination's
+  // `BucketArn` -> `Bucket` / `BucketAccountId` -> `AccountId` terminals need
+  // NO entry: the provider forwards them as bag-derived member accesses
+  // (`Bucket: (s3Dest['BucketArn'] ?? …)`), which register a whole-blob
+  // hand-off whose SEED-KEY ALIAS (`registerSeedKeyHandoffs`) already covers
+  // the CFn spelling at the renamed chain — an entry there is dead weight the
+  // staleness fence rejects, measured, not assumed.
+  'InventoryConfigurations.Enabled': 'IsEnabled',
+  'InventoryConfigurations.Prefix': 'Filter.Prefix',
+  // PutBucketAnalyticsConfiguration: the config-level Prefix lands under
+  // `Filter{,.And}` (single-condition branch writes `Filter = { Prefix }`);
+  // the destination's `BucketArn` is alias-covered as above.
+  'AnalyticsConfigurations.Prefix': 'Filter.Prefix',
+  // PutBucketMetricsConfiguration / PutBucketIntelligentTieringConfiguration:
+  // same Filter relocation for the config-level scope members.
+  'MetricsConfigurations.Prefix': 'Filter.Prefix',
+  'MetricsConfigurations.AccessPointArn': 'Filter.AccessPointArn',
+  'IntelligentTieringConfigurations.Prefix': 'Filter.Prefix',
+  // PutBucketEncryption: CFn's `ServerSideEncryptionConfiguration` LIST is the
+  // SDK's `Rules` member of the same-named wrapper (the parent chain already
+  // renames `BucketEncryption` onto that wrapper).
+  'BucketEncryption.ServerSideEncryptionConfiguration': 'Rules',
+  // Lifecycle rule-level members the SDK nests: the rule-level delete-marker
+  // flag is written into `Expiration` (both branches), and the rule-level
+  // size constraints land under `Filter{,.And}`.
+  'LifecycleConfiguration.Rules.ExpiredObjectDeleteMarker': 'Expiration.ExpiredObjectDeleteMarker',
+  'LifecycleConfiguration.Rules.ObjectSizeGreaterThan': 'Filter.ObjectSizeGreaterThan',
+  'LifecycleConfiguration.Rules.ObjectSizeLessThan': 'Filter.ObjectSizeLessThan',
+  // Notification: the `Rules` LIST itself (members are covered via the
+  // scoped segment rename above).
+  'NotificationConfiguration.LambdaConfigurations.Filter.S3Key.Rules': 'FilterRules',
+  'NotificationConfiguration.QueueConfigurations.Filter.S3Key.Rules': 'FilterRules',
+  'NotificationConfiguration.TopicConfigurations.Filter.S3Key.Rules': 'FilterRules',
 } as const;
 
 /**
@@ -1277,15 +1375,28 @@ export const NESTED_KEY_TARGETS: readonly NestedKeyTarget[] = [
     sdkClientPackage: '@aws-sdk/client-s3',
     keyStyle: 'exact',
     minNestedKeys: 170,
-    // Still NOT opted into the write-evidence pass. Issue #1520 declared the
-    // structural renames (see S3_BUCKET_SEGMENT_RENAMES) and widened the
-    // reverse-map exclusion, which moved the opt-in-forced residual 81 -> 50 —
-    // but 50 is not 0, and every remaining path has a RECORDED cause in reason
-    // (C) that a segment rename cannot express (relocation under the SDK's
-    // Filter, terminal renames, rename-name collisions, builder-recognizer
-    // flow bounds). The renames stay declared so they are staleness-fenced
-    // and the header-table pin measures the honest number.
+    // OPTED IN by issue #1540, which closed the 50-path residual #1520
+    // recorded: the builder-behind-binding hop in `resolveBuilders` (lifecycle
+    // 19 -> 4), the for-of taint hop (the per-item config loops' verbatim
+    // `Tags` forwards register as hand-offs), SCOPED segment-rename keys
+    // (notification / legacy-singular / per-family TagFilters / destination
+    // wrappers), and TERMINAL renames ({@link S3_BUCKET_TERMINAL_RENAMES}).
+    // Measured at 0 findings; the three shapes no mechanism can express carry
+    // reviewed `passes: ['write']` allow-list entries (the request-level
+    // `TransitionDefaultMinimumObjectSize` hoist and the two
+    // destructured-gatherScope lifecycle `TagFilters` members).
+    freshObjectMapper: true,
+    // Measured at opt-in (#1540): 157 written member names, 156 non-empty
+    // write scopes, rounded down generously per the field docs.
+    minWrittenMembers: 120,
+    minWriteScopes: 110,
+    // Deliberately 1, not the measured raw count — see the API GW v2 floors
+    // note for why a floor AT the measurement is the wrong fence. S3's opt-in
+    // DEPENDS on the walk (the TagFilters wildcard credits and the
+    // destination seed-key aliases), so the floor is declared.
+    minHandoffPoints: 1,
     segmentRenames: S3_BUCKET_SEGMENT_RENAMES,
+    terminalRenames: S3_BUCKET_TERMINAL_RENAMES,
   },
 ];
 
@@ -1479,6 +1590,46 @@ export const NESTED_KEY_ALLOW_LIST: ReadonlyMap<string, AllowListEntry> = new Ma
     },
   ],
   [
+    allowKey('AWS::S3::Bucket', 'LifecycleConfiguration.TransitionDefaultMinimumObjectSize'),
+    {
+      rationale:
+        'Written by applyLifecycleConfiguration DIRECTLY on the ' +
+        'PutBucketLifecycleConfigurationRequest (the SDK hoists it out of ' +
+        '`LifecycleConfiguration`, where CFn nests it), so the audited chain ' +
+        'can never resolve: a terminal rename redirects WITHIN the config ' +
+        'object and cannot express a request-level hoist. Delivery is proven ' +
+        'by the s3-replication-and-filter integ read-back (issue #1495) and ' +
+        'the write is pinned by name in the #1495 write-evidence unit test ' +
+        '(issues #1520 / #1540).',
+      passes: ['write'],
+    },
+  ],
+  [
+    allowKey('AWS::S3::Bucket', 'LifecycleConfiguration.Rules.TagFilters.Key'),
+    {
+      rationale:
+        'Forwarded verbatim into `Filter{,.And}.Tags` by ' +
+        'applyLifecycleConfiguration, but through a chain the hand-off taint ' +
+        'walk deliberately does not cross: the array reaches the write as a ' +
+        "DESTRUCTURED member of the in-method `gatherScope` helper's returned " +
+        'literal, and member-level taint through a returned literal is a ' +
+        'materially bigger analysis (issue #1540; same wrapper-level class as ' +
+        'the CloudFront `Tags.Key` / `Tags.Value` entries). The equivalent ' +
+        'per-item-config forwards (Analytics / Metrics / IntelligentTiering) ' +
+        'ARE wildcard-credited via the for-of taint hop.',
+      passes: ['write'],
+    },
+  ],
+  [
+    allowKey('AWS::S3::Bucket', 'LifecycleConfiguration.Rules.TagFilters.Value'),
+    {
+      rationale:
+        'Same destructured-gatherScope forward as the sibling ' +
+        '`LifecycleConfiguration.Rules.TagFilters.Key` entry (issue #1540).',
+      passes: ['write'],
+    },
+  ],
+  [
     allowKey('AWS::S3::Bucket', 'CorsConfiguration.CorsRules'),
     {
       rationale:
@@ -1596,6 +1747,8 @@ export interface TargetReport {
    * needed must be removed, the same discipline the allow-list carries.
    */
   readonly usedSegmentRenames: readonly string[];
+  /** Same contract for {@link NestedKeyTarget.terminalRenames} (issue #1540). */
+  readonly usedTerminalRenames: readonly string[];
 }
 
 export interface NestedKeyCoverageReport {
@@ -2824,8 +2977,10 @@ export function collectWriteEvidence(
   /**
    * Taint the property-bag parameters, then propagate to fixpoint: a binding
    * initialized (or assigned) from bag data, a callee parameter handed bag data
-   * at a resolvable call site, and an array-callback parameter iterating bag
-   * data. Three iterations settle the real tree; the loop is bounded anyway.
+   * at a resolvable call site, an array-callback parameter iterating bag
+   * data, and a `for (const x of bag)` loop variable (issue #1540 — the
+   * statement-form twin of the callback hop). Three iterations settle the
+   * real tree; the loop is bounded anyway.
    */
   const seedTaint = (): void => {
     const collectRoots = (n: ts.Node): void => {
@@ -2869,6 +3024,24 @@ export function collectWriteEvidence(
           if (declaration !== undefined && !tainted.has(declaration)) {
             tainted.add(declaration);
             changed = true;
+          }
+        } else if (
+          ts.isForOfStatement(n) &&
+          ts.isVariableDeclarationList(n.initializer) &&
+          isBagDerived(n.expression, new Set())
+        ) {
+          // `for (const config of configs)` — the element of a bag-derived
+          // array is bag data, the statement-form twin of the `.map((element)
+          // => …)` callback hop below (issue #1540). Without it every
+          // per-item S3 config loop (`applyMetricsConfigurations` etc.) broke
+          // the taint chain at the loop variable, so a verbatim
+          // `Tags: tagFilters` forward inside the loop never registered as a
+          // whole-blob hand-off.
+          for (const d of n.initializer.declarations) {
+            if (!tainted.has(d)) {
+              tainted.add(d);
+              changed = true;
+            }
           }
         } else if (ts.isCallExpression(n)) {
           const callee = unwrapExpression(n.expression);
@@ -3350,7 +3523,29 @@ export function collectWriteEvidence(
     seen.add(e);
     if (ts.isIdentifier(e)) {
       const declaration = builderDeclarationOf(e);
-      return declaration === undefined ? [] : [declaration];
+      if (declaration !== undefined) return [declaration];
+      // Issue #1540: a builder can sit BEHIND a plain binding — `const rules =
+      // cfg.Rules.map((r) => { const sdkRule = { … }; sdkRule.X = …; return
+      // sdkRule; })` delivered as `Rules: rules`. The identifier itself is not
+      // a builder (its initializer is no literal seed), but the value it HOLDS
+      // may resolve to one, and {@link resolveLiterals} already makes exactly
+      // this hop for the seed's members — so refusing it here split one value
+      // into "seed credited, mutations lost" (measured on the real
+      // `s3-bucket-provider.ts` lifecycle mapper: `LifecycleConfiguration.Rules`
+      // carried only the seed's `ID`/`Status`/`Prefix`). The hop keeps the
+      // recognizer's strictness: declaration IDENTITY via `declarationOf`
+      // (never bare-name), and a wholly-reassigned binding stays refused for
+      // the same false-CLEAR reason `builderDeclarationOf` refuses it.
+      const plain = declarationOf(e);
+      if (
+        plain !== undefined &&
+        ts.isVariableDeclaration(plain) &&
+        plain.initializer !== undefined &&
+        !isWhollyReassigned(plain)
+      ) {
+        return resolveBuilders(plain.initializer, seen);
+      }
+      return [];
     }
     if (ts.isConditionalExpression(e)) {
       return [...resolveBuilders(e.whenTrue, seen), ...resolveBuilders(e.whenFalse, seen)];
@@ -4302,7 +4497,9 @@ export function classifyTarget(
   // did work on this run, so `findStaleSegmentRenames` can force the removal of
   // one that stopped. An out-param rather than a second return value because
   // every existing caller (and every unit probe) wants only the verdicts.
-  usedSegmentRenames?: Set<string>
+  usedSegmentRenames?: Set<string>,
+  // Same contract for {@link NestedKeyTarget.terminalRenames} (issue #1540).
+  usedTerminalRenames?: Set<string>
 ): NestedKeyClassification[] {
   const sdkLower = new Map<string, string>();
   for (const m of sdkMembers) {
@@ -4367,16 +4564,29 @@ export function classifyTarget(
       // appearing somewhere in the file is the loose heuristic this pass exists
       // to stop trusting.
       // Non-terminal segments carry the target's declared RENAMES; the terminal
-      // never does (it IS the audited key — see `segmentRenames`). A rename
-      // value may be DOTTED (`LoggingConfiguration` ->
+      // never does (it IS the audited key — see `segmentRenames`; a DECLARED
+      // terminal correspondence is `terminalRenames`' separate, path-keyed
+      // job). A rename value may be DOTTED (`LoggingConfiguration` ->
       // `BucketLoggingStatus.LoggingEnabled` — an SDK-only wrapper level the
       // CFn shape flattens), so the chain is flattened one write-index level
-      // per dotted part (issue #1520).
-      const parentChain = segments
-        .slice(0, -1)
-        .flatMap((seg) => (renames[seg] ?? styled(seg)).split('.'));
+      // per dotted part (issue #1520). A key may be SCOPED by the segment's
+      // immediate CFn parent (`'S3Key.Rules': 'FilterRules'`, issue #1540) —
+      // matched on the ORIGINAL CFn spellings, winning over a bare-name entry
+      // — so one rename can never leak onto a same-named segment elsewhere
+      // (`LifecycleConfiguration.Rules` stays untouched by the notification
+      // entry above).
+      const renameKeyAt = (i: number): string | undefined => {
+        if (i > 0 && renames[`${segments[i - 1]}.${segments[i]}`] !== undefined) {
+          return `${segments[i - 1]}.${segments[i]}`;
+        }
+        return renames[segments[i]!] !== undefined ? segments[i]! : undefined;
+      };
+      const parentChain = segments.slice(0, -1).flatMap((seg, i) => {
+        const key = renameKeyAt(i);
+        return (key === undefined ? styled(seg) : renames[key]!).split('.');
+      });
       const parentPaths = resolveWritePaths(parentChain);
-      const covered =
+      const coveredPlain =
         parentPaths.some((p) => writeEvidence.scopes.get(p)?.has(expected) ?? false) ||
         isHandoffCovered(
           writeEvidence.handoffScopes,
@@ -4384,6 +4594,27 @@ export function classifyTarget(
           expected,
           writeEvidence.handoffExclusions
         );
+      // TERMINAL rename / relocation (issue #1540): redirect the judgment to
+      // the declared SDK spelling — still verbatim, still scope-checked, at
+      // the parent chain extended by the entry's scope-insertion parts.
+      const terminalEntry = (target.terminalRenames ?? {})[path];
+      let coveredRenamed = false;
+      if (terminalEntry !== undefined && !coveredPlain) {
+        const parts = terminalEntry.split('.');
+        const renamedTerminal = parts[parts.length - 1]!;
+        const extendedChain = [...parentChain, ...parts.slice(0, -1)];
+        coveredRenamed =
+          resolveWritePaths(extendedChain).some(
+            (p) => writeEvidence.scopes.get(p)?.has(renamedTerminal) ?? false
+          ) ||
+          isHandoffCovered(
+            writeEvidence.handoffScopes,
+            extendedChain.join('.'),
+            renamedTerminal,
+            writeEvidence.handoffExclusions
+          );
+      }
+      const covered = coveredPlain || coveredRenamed;
       // Record which renames still EARN their place. The test is stated as its
       // negation so it cannot MASK a real finding: an entry goes unused only
       // when the UN-RENAMED chain resolves — i.e. the SDK (or the provider)
@@ -4393,10 +4624,17 @@ export function classifyTarget(
       // divergence rather than a stale-map error on top of it.
       if (usedSegmentRenames !== undefined) {
         for (let i = 0; i < segments.length - 1; i++) {
-          if (renames[segments[i]!] === undefined) continue;
+          const key = renameKeyAt(i);
+          if (key === undefined) continue;
           const plain = segments.slice(0, i + 1).map((seg) => styled(seg));
-          if (!chainResolves(plain)) usedSegmentRenames.add(segments[i]!);
+          if (!chainResolves(plain)) usedSegmentRenames.add(key);
         }
+      }
+      // Same negation for terminal entries: unused only when the PLAIN
+      // terminal already resolves (the map is redundant); a still-unresolved
+      // renamed terminal keeps both the entry and the reported divergence.
+      if (usedTerminalRenames !== undefined && terminalEntry !== undefined && !coveredPlain) {
+        usedTerminalRenames.add(path);
       }
       if (target.freshObjectMapper === true && !covered) {
         sdkNearMiss = expected;
@@ -4784,6 +5022,31 @@ export function findStaleSegmentRenames(
   return stale.sort();
 }
 
+/**
+ * {@link NestedKeyTarget.terminalRenames} entries that no longer do any work —
+ * the terminal twin of {@link findStaleSegmentRenames}, same semantics: an
+ * entry is stale when the UN-renamed terminal already resolves (redundant) or
+ * its path is no longer audited; a still-unresolved RENAMED terminal is NOT
+ * stale, because the run must keep reporting that divergence (issue #1540).
+ */
+export function findStaleTerminalRenames(
+  report: NestedKeyCoverageReport,
+  targetList: readonly NestedKeyTarget[] = NESTED_KEY_TARGETS
+): string[] {
+  const usedByType = new Map(
+    report.targets.map((t) => [t.resourceType, new Set(t.usedTerminalRenames)])
+  );
+  const stale: string[] = [];
+  for (const target of targetList) {
+    const used = usedByType.get(target.resourceType);
+    if (used === undefined) continue; // not in this report
+    for (const path of Object.keys(target.terminalRenames ?? {})) {
+      if (!used.has(path)) stale.push(`${target.resourceType}#${path}`);
+    }
+  }
+  return stale.sort();
+}
+
 function renderMarkdown(report: NestedKeyCoverageReport): string {
   const lines: string[] = [];
   lines.push('# Nested CFn->SDK key-divergence coverage matrix');
@@ -5158,6 +5421,7 @@ export function loadReport(
     );
 
     const usedSegmentRenames = new Set<string>();
+    const usedTerminalRenames = new Set<string>();
     const entries = classifyTarget(
       target,
       nestedKeys,
@@ -5165,7 +5429,8 @@ export function loadReport(
       literals,
       NESTED_KEY_ALLOW_LIST,
       written,
-      usedSegmentRenames
+      usedSegmentRenames,
+      usedTerminalRenames
     );
 
     targets.push({
@@ -5180,6 +5445,7 @@ export function loadReport(
       shapeCleanCount: shapeResult.cleanCount,
       unmatchedDefinitions: shapeResult.unmatchedDefinitions,
       usedSegmentRenames: [...usedSegmentRenames].sort(),
+      usedTerminalRenames: [...usedTerminalRenames].sort(),
     });
   }
   return buildReport(targets);
@@ -5250,6 +5516,17 @@ function main(argv: readonly string[] = process.argv.slice(2)): void {
       'nested-key-coverage: FAIL — stale segmentRenames entr(ies) no longer resolve anything ' +
         'the un-renamed chain does not. Remove them from scripts/gen-nested-key-coverage.ts:\n' +
         staleRenames.map((k) => `  ${k}\n`).join('')
+    );
+    process.exit(1);
+  }
+
+  const staleTerminals = findStaleTerminalRenames(report);
+  if (staleTerminals.length > 0) {
+    process.stderr.write(
+      'nested-key-coverage: FAIL — stale terminalRenames entr(ies): the un-renamed terminal ' +
+        'already resolves, so the entry is dead weight. Remove them from ' +
+        'scripts/gen-nested-key-coverage.ts:\n' +
+        staleTerminals.map((k) => `  ${k}\n`).join('')
     );
     process.exit(1);
   }

--- a/tests/unit/scripts/gen-nested-key-coverage.test.ts
+++ b/tests/unit/scripts/gen-nested-key-coverage.test.ts
@@ -29,6 +29,7 @@ import {
   findDivergences,
   findStaleAllowListEntries,
   findStaleSegmentRenames,
+  findStaleTerminalRenames,
   isHandoffCovered,
   loadReport,
   lowerFirst,
@@ -763,11 +764,13 @@ describe('the BUILDER idiom (synthetic, issue #1474)', () => {
     // borrowed from the arrow's same-named binding, which is both halves of
     // the inversion.
     expect(scopeAt(source, 'Root.Cfg')).toEqual(['Outer']);
-    // `Root.Inner` is empty for an UNRELATED reason, noted so the assertion
-    // above is not misread as covering it: `inner` binds to a `.map(…)` call,
-    // not to an object literal, so it is not a builder seed — the
-    // seed-literal-only half of bound (8), in its under-crediting direction.
-    expect(scopeAt(source, 'Root.Inner')).toEqual([]);
+    // `Root.Inner` used to be empty because `inner` binds to a `.map(…)` call
+    // rather than a literal seed — the under-crediting gap issue #1540's
+    // BUILDER-BEHIND-BINDING hop closed: `resolveBuilders` now follows the
+    // plain binding's initializer (same declaration-identity strictness), so
+    // the callback's builder credits its members here. The assertion above
+    // still proves the arrow's same-named `cfg` did NOT leak into `Root.Cfg`.
+    expect(scopeAt(source, 'Root.Inner')).toEqual(['Inner']);
   });
 
   it('skips a REVERSE-MAP helper nested inside the builder scope', () => {
@@ -2287,9 +2290,196 @@ describe('classifyTarget (synthetic)', () => {
         shapeCleanCount: 0,
         unmatchedDefinitions: [],
         usedSegmentRenames: ['Middle'],
+        usedTerminalRenames: [],
       },
     ]);
     expect(findStaleSegmentRenames(report, [target])).toEqual(['AWS::Fake::Thing#Gone']);
+  });
+
+  it('a SCOPED segmentRenames key applies only under its declared parent (#1540)', () => {
+    // Two families share a segment NAME (`Rules`); only the one under `S3Key`
+    // is renamed. A bare-name entry would corrupt the lifecycle chain — the
+    // collision class that blocked the notification renames until scoping.
+    const target: NestedKeyTarget = {
+      ...exactTarget,
+      freshObjectMapper: true,
+      segmentRenames: { 'S3Key.Rules': 'FilterRules' },
+    };
+    const evidence = writeEvidence({
+      Top: ['S3Key', 'Lifecycle'],
+      'Top.S3Key': ['FilterRules'],
+      'Top.S3Key.FilterRules': ['Name'],
+      'Top.Lifecycle': ['Rules'],
+      'Top.Lifecycle.Rules': ['Name'],
+    });
+    const used = new Set<string>();
+    const [notif] = classifyTarget(
+      target,
+      keyPaths('Top', 'S3Key.Rules.Name'),
+      new Set(['Name']),
+      new Set(),
+      new Map(),
+      evidence,
+      used
+    );
+    expect(notif?.bucket).toBe('same-spelling');
+    expect([...used]).toEqual(['S3Key.Rules']);
+    // The same-named `Rules` under a DIFFERENT parent is untouched: its plain
+    // chain resolves, so the entry neither applies nor reads as used there.
+    const [lifecycle] = classifyTarget(
+      target,
+      keyPaths('Top', 'Lifecycle.Rules.Name'),
+      new Set(['Name']),
+      new Set(),
+      new Map(),
+      evidence
+    );
+    expect(lifecycle?.bucket).toBe('same-spelling');
+  });
+
+  it('a SCOPED segmentRenames key WINS over a bare-name entry for the same segment (#1540)', () => {
+    const target: NestedKeyTarget = {
+      ...exactTarget,
+      freshObjectMapper: true,
+      segmentRenames: { Middle: 'bareTarget', 'Top.Middle': 'scopedTarget' },
+    };
+    const used = new Set<string>();
+    const [entry] = classifyTarget(
+      target,
+      keyPaths('Top', 'Middle.Leaf'),
+      new Set(['Leaf']),
+      new Set(),
+      new Map(),
+      writeEvidence({ Top: ['scopedTarget'], 'Top.scopedTarget': ['Leaf'] }),
+      used
+    );
+    expect(entry?.bucket).toBe('same-spelling');
+    expect([...used]).toEqual(['Top.Middle']);
+  });
+
+  it('terminalRenames redirects the terminal judgment to the declared SDK spelling (#1540)', () => {
+    // Pure rename: CFn `Enabled` is the SDK's `IsEnabled`. The check stays
+    // strict — the RENAMED member must be scope-written verbatim.
+    const paths = keyPaths('Top', 'Enabled');
+    const evidence = writeEvidence({ Top: ['IsEnabled'] });
+    const [without] = classifyTarget(
+      { ...exactTarget, freshObjectMapper: true },
+      paths,
+      new Set(['Enabled']),
+      new Set(),
+      new Map(),
+      evidence
+    );
+    expect(without?.bucket).toBe('no-write-evidence');
+    const target: NestedKeyTarget = {
+      ...exactTarget,
+      freshObjectMapper: true,
+      terminalRenames: { 'Top.Enabled': 'IsEnabled' },
+    };
+    const usedTerminals = new Set<string>();
+    const [with_] = classifyTarget(
+      target,
+      paths,
+      new Set(['Enabled']),
+      new Set(),
+      new Map(),
+      evidence,
+      undefined,
+      usedTerminals
+    );
+    expect(with_?.bucket).toBe('same-spelling');
+    expect([...usedTerminals]).toEqual(['Top.Enabled']);
+  });
+
+  it('a DOTTED terminalRenames value relocates the terminal under an inserted scope (#1540)', () => {
+    // Relocation: CFn puts `Prefix` at the config level, the SDK nests it
+    // under `Filter` — the value's non-last parts extend the parent chain.
+    const target: NestedKeyTarget = {
+      ...exactTarget,
+      freshObjectMapper: true,
+      terminalRenames: { 'Top.Prefix': 'Filter.Prefix' },
+    };
+    const [entry] = classifyTarget(
+      target,
+      keyPaths('Top', 'Prefix'),
+      new Set(['Prefix']),
+      new Set(),
+      new Map(),
+      writeEvidence({ Top: ['Filter'], 'Top.Filter': ['Prefix'] })
+    );
+    expect(entry?.bucket).toBe('same-spelling');
+  });
+
+  it('a terminalRenames entry whose PLAIN terminal resolves is reported unused (#1540)', () => {
+    // The staleness fence's input, mirroring segmentRenames: a redundant
+    // entry must be removed, and this is what caught the three hand-authored
+    // `BucketArn` / `BucketAccountId` entries the seed-key hand-off aliases
+    // already covered.
+    const target: NestedKeyTarget = {
+      ...exactTarget,
+      freshObjectMapper: true,
+      terminalRenames: { 'Top.Leaf': 'RenamedLeaf' },
+    };
+    const usedTerminals = new Set<string>();
+    classifyTarget(
+      target,
+      keyPaths('Top', 'Leaf'),
+      new Set(['Leaf']),
+      new Set(),
+      new Map(),
+      writeEvidence({ Top: ['Leaf'] }),
+      undefined,
+      usedTerminals
+    );
+    expect([...usedTerminals]).toEqual([]);
+  });
+
+  it('a terminalRenames entry stays USED when neither spelling resolves (#1540)', () => {
+    // Same negation as segmentRenames: the entry is still the right bridge,
+    // and the divergence — not a stale-map error — is what must surface.
+    const target: NestedKeyTarget = {
+      ...exactTarget,
+      freshObjectMapper: true,
+      terminalRenames: { 'Top.Leaf': 'RenamedLeaf' },
+    };
+    const usedTerminals = new Set<string>();
+    const [entry] = classifyTarget(
+      target,
+      keyPaths('Top', 'Leaf'),
+      new Set(['Leaf']),
+      new Set(),
+      new Map(),
+      writeEvidence({ Top: [] }),
+      undefined,
+      usedTerminals
+    );
+    expect(entry?.bucket).toBe('no-write-evidence');
+    expect([...usedTerminals]).toEqual(['Top.Leaf']);
+  });
+
+  it('findStaleTerminalRenames reports the entry the classifier never needed (#1540)', () => {
+    const target: NestedKeyTarget = {
+      ...exactTarget,
+      resourceType: 'AWS::Fake::Thing',
+      terminalRenames: { 'Top.Used': 'X', 'Top.Gone': 'Y' },
+    };
+    const report = buildReport([
+      {
+        resourceType: target.resourceType,
+        providerFile: target.providerFile,
+        sdkClientPackage: target.sdkClientPackage,
+        keyStyle: target.keyStyle,
+        freshObjectMapper: true,
+        nestedKeyCount: 0,
+        entries: [],
+        shapeEntries: [],
+        shapeCleanCount: 0,
+        unmatchedDefinitions: [],
+        usedSegmentRenames: [],
+        usedTerminalRenames: ['Top.Used'],
+      },
+    ]);
+    expect(findStaleTerminalRenames(report, [target])).toEqual(['AWS::Fake::Thing#Top.Gone']);
   });
 
   it('a no-write-evidence key is a CI-blocking divergence', () => {
@@ -2307,6 +2497,7 @@ describe('classifyTarget (synthetic)', () => {
         shapeCleanCount: 0,
         unmatchedDefinitions: [],
         usedSegmentRenames: [],
+        usedTerminalRenames: [],
       },
     ]);
     expect(report.summary.noWriteEvidence).toBe(1);
@@ -2717,6 +2908,7 @@ describe('report plumbing (positive direction)', () => {
         shapeCleanCount: 0,
         unmatchedDefinitions: [],
         usedSegmentRenames: [],
+        usedTerminalRenames: [],
       },
     ]);
     const divergences = findDivergences(report);
@@ -2753,6 +2945,7 @@ describe('report plumbing (positive direction)', () => {
         shapeCleanCount: 0,
         unmatchedDefinitions: [],
         usedSegmentRenames: [],
+        usedTerminalRenames: [],
       },
     ]);
     expect(findStaleAllowListEntries(report, allow)).toEqual(['AWS::Fake::Thing#GoneKey']);
@@ -2785,6 +2978,7 @@ describe('report plumbing (positive direction)', () => {
         shapeCleanCount: 0,
         unmatchedDefinitions: [],
         usedSegmentRenames: [],
+        usedTerminalRenames: [],
       },
     ]);
     expect(findStaleAllowListEntries(report, allow)).toEqual([]);
@@ -2820,6 +3014,7 @@ describe('report plumbing (positive direction)', () => {
         shapeCleanCount: 0,
         unmatchedDefinitions: [],
         usedSegmentRenames: [],
+        usedTerminalRenames: [],
       },
     ]);
     expect(findDivergences(report).map((d) => [d.nestedKey, d.bucket])).toEqual([
@@ -3473,11 +3668,11 @@ describe('whole-blob hand-off walk (real repo, issue #1445)', () => {
       'AWS::CloudWatch::AnomalyDetector': 0,
       'AWS::ECS::Service': 0,
       'AWS::ECS::TaskDefinition': 0,
-      // 81 before issue #1520 declared the S3 segment renames and widened the
-      // reverse-map exclusion; the 50 that remain are the recorded structural
-      // bounds in header reason (C) (Filter relocation, terminal renames,
-      // rename-name collisions, builder flow bounds, the request-level hoist).
-      'AWS::S3::Bucket': 50,
+      // 81 before issue #1520 (segment renames + widened reverse-map
+      // exclusion, -> 50), 0 since issue #1540 (builder-behind-binding hop,
+      // for-of taint hop, scoped + terminal renames) opted the target in —
+      // the trajectory is recorded in header reason (C).
+      'AWS::S3::Bucket': 0,
     });
   });
 
@@ -3491,43 +3686,37 @@ describe('whole-blob hand-off walk (real repo, issue #1445)', () => {
   // `*ToCfn` reverse families, which makes the empty-never-written assertion a
   // REAL by-name re-drop fence; the RED-direction probe further below proves
   // that direction against the real provider source.
-  it('keeps S3 reason (C) CLOSED: only the recorded terminal renames are never-written (#1495/#1520)', () => {
-    // Reason (C) in the header, RESOLVED. This test used to pin the 20 paths
-    // whose terminal member appeared NOWHERE in `s3-bucket-provider.ts` — the
-    // confirmed write-side silent drops (the `TargetObjectKeyFormat` family,
-    // the four `Destination` blocks, `SourceSelectionCriteria`,
-    // `TransitionDefaultMinimumObjectSize`, `BlockedEncryptionTypes`). Issue
-    // #1495 wired every one of them, so the probe is INVERTED into a fence:
-    // an EMPTY never-written set is now the assertion, and a future provider
-    // change that drops a member back out fails here by name.
-    //
-    // The remaining `no-write-evidence` paths (50 after #1520's segment
-    // renames; 81 before) ARE written somewhere in the file and fail only to
-    // resolve at the audited CHAIN, for the recorded structural bounds in
-    // header reason (C) — shapes a segment rename cannot express, not drops.
-    const forced = NESTED_KEY_TARGETS.map((t) => ({ ...t, freshObjectMapper: true }));
-    const s3 = loadReport(forced).targets.find((t) => t.resourceType === 'AWS::S3::Bucket')!;
-    const evidence = collectWriteEvidence(
-      readFileSync(join(PROVIDERS_DIR, 's3-bucket-provider.ts'), 'utf8'),
-      's3-bucket-provider.ts'
-    );
-    const neverWritten = s3.entries
+  it('keeps S3 reason (C) CLOSED: the opted-in target audits at ZERO, with the once-never-written spellings covered by their declared bridges (#1495/#1520/#1540)', () => {
+    // Reason (C) in the header, RESOLVED in three steps this test's history
+    // mirrors: #1495 wired the 20 confirmed silent drops (the original pin),
+    // #1520 made the never-written set a real by-name fence (widened
+    // reverse-map exclusion), and #1540 closed the structural residual and
+    // opted the target in. The fence is now the OPT-IN itself — any provider
+    // re-drop or bridge regression surfaces as a `no-write-evidence` entry,
+    // which this asserts is empty on the REAL tree (and which `--check`
+    // blocks CI with, by member name).
+    const s3 = loadReport().targets.find((t) => t.resourceType === 'AWS::S3::Bucket')!;
+    expect(s3.freshObjectMapper).toBe(true);
+    const flagged = s3.entries
       .filter((e) => e.bucket === 'no-write-evidence')
-      .filter((e) => !evidence.written.has(e.nestedKey.split('.').pop()!))
       .map((e) => e.nestedKey)
       .sort();
-    // The three CFn spellings below are never written BY DESIGN, not drops:
-    // the provider delivers them under the SDK's TERMINAL RENAME —
-    // `Bucket: (s3Dest['BucketArn'] ?? …)` for both destination blocks and
-    // `IsEnabled: (config['Enabled'] …)` for inventory — and #1520's widened
-    // reverse-map exclusion withdrew the reverse-map mentions that used to
-    // mask them. Pinned EXACTLY so any NEW never-written member (a real
-    // re-drop of a #1495 write) still fails here by name.
-    expect(neverWritten).toEqual([
+    expect(flagged).toEqual([]);
+    // The three CFn spellings the #1520-era fence pinned as "never written by
+    // design" are now COVERED, each through its declared bridge rather than a
+    // loose literal: `Enabled` via the `IsEnabled` terminal rename, the two
+    // `BucketArn`s via the hand-off seed-key alias of the bag-derived
+    // `Bucket: (s3Dest['BucketArn'] ?? …)` forwards. Asserted as
+    // `same-spelling` (the covered verdict) so a bridge regression re-flags
+    // them by name here as well as in `--check`.
+    for (const path of [
       'AnalyticsConfigurations.StorageClassAnalysis.DataExport.Destination.BucketArn',
       'InventoryConfigurations.Destination.BucketArn',
       'InventoryConfigurations.Enabled',
-    ]);
+    ]) {
+      const entry = s3.entries.find((e) => e.nestedKey === path);
+      expect(entry?.bucket, `${path} must be covered`).toBe('same-spelling');
+    }
   });
 
   it('pins the #1495 members as present in the write-evidence name set', () => {
@@ -3599,6 +3788,60 @@ describe('whole-blob hand-off walk (real repo, issue #1445)', () => {
     // so this probe cannot pass vacuously.
     const clean = collectWriteEvidence(source, 's3-bucket-provider.ts');
     expect(clean.written.has('SseKmsEncryptedObjects')).toBe(true);
+  });
+
+  it('RED probe (#1540): dropping a lifecycle BUILDER mutation is caught at its scope', () => {
+    // Real-code proof of the builder-behind-binding hop: the lifecycle rules
+    // are built by mutating `sdkRule` inside a `.map()` callback held in a
+    // plain binding — the exact shape the hop credits. Stripping the
+    // `AbortIncompleteMultipartUpload` mutation must remove the member from
+    // the `LifecycleConfiguration.Rules` scope (which the opted-in write pass
+    // then flags by name), and the unregressed source must carry it — the
+    // credit comes from the real mutation write, not from anywhere looser.
+    const source = readFileSync(join(PROVIDERS_DIR, 's3-bucket-provider.ts'), 'utf8');
+    const regressed = source.replace(
+      /^\s*sdkRule\.AbortIncompleteMultipartUpload = \{\n[^}]*\};\n/m,
+      ''
+    );
+    expect(regressed).not.toBe(source);
+    const stripped = collectWriteEvidence(regressed, 's3-bucket-provider.ts');
+    expect(
+      stripped.scopes.get('LifecycleConfiguration.Rules')?.has('AbortIncompleteMultipartUpload')
+    ).toBe(false);
+    const clean = collectWriteEvidence(source, 's3-bucket-provider.ts');
+    expect(
+      clean.scopes.get('LifecycleConfiguration.Rules')?.has('AbortIncompleteMultipartUpload')
+    ).toBe(true);
+    expect(
+      clean.scopes.get('LifecycleConfiguration.Rules.AbortIncompleteMultipartUpload')?.has(
+        'DaysAfterInitiation'
+      )
+    ).toBe(true);
+  });
+
+  it('the for-of taint hop registers a verbatim forward inside a config loop as a hand-off (#1540)', () => {
+    // The statement-form twin of the `.map((element) => …)` callback hop: the
+    // element of a bag-derived array is bag data. Without it, every per-item
+    // S3 config loop broke the taint chain at the loop variable and the
+    // `Tags: tagFilters` forward never registered.
+    const src = `
+      class P {
+        apply(properties) {
+          const configs = properties['MetricsConfigurations'];
+          for (const config of configs) {
+            const tagFilters = config['TagFilters'];
+            this.client.send(
+              new Cmd({ MetricsConfiguration: { Filter: { And: { Tags: tagFilters } } } })
+            );
+          }
+        }
+      }
+    `;
+    const ev = collectWriteEvidence(src, 'p.ts');
+    expect(ev.handoffScopes.has('MetricsConfiguration.Filter.And.Tags')).toBe(true);
+    // The seed-key ALIAS carries the CFn spelling too, which is what the
+    // scoped `TagFilters` rename resolves against on the real tree.
+    expect(ev.handoffScopes.has('MetricsConfiguration.Filter.And.TagFilters')).toBe(true);
   });
 
   it('keeps the six #1472/#1473 ECS silent drops CLOSED (fixed, both targets opted in)', () => {
@@ -4091,6 +4334,7 @@ describe('real-code regression probes (per the repo checker rules)', () => {
         shapeCleanCount: 0,
         unmatchedDefinitions: [],
         usedSegmentRenames: [],
+        usedTerminalRenames: [],
       },
     ]))).toHaveLength(0);
   });
@@ -4624,7 +4868,7 @@ describe('the shipped --check command', { timeout: 30_000 }, () => {
     // a target silently dropping out of the table cannot satisfy this probe.
     expect(stderr).toContain('nested-key-coverage: OK');
     expect(stderr).toContain('0 divergences');
-    expect(stderr).toContain('10 fresh-object target(s)');
+    expect(stderr).toContain('11 fresh-object target(s)');
   });
 
   it('exits 1 naming ONLY the members a partial hand-mapping leaves out', () => {

--- a/tests/unit/scripts/gen-nested-key-coverage.test.ts
+++ b/tests/unit/scripts/gen-nested-key-coverage.test.ts
@@ -773,6 +773,33 @@ describe('the BUILDER idiom (synthetic, issue #1474)', () => {
     expect(scopeAt(source, 'Root.Inner')).toEqual(['Inner']);
   });
 
+  it('the builder-behind-binding hop refuses a wholly-reassigned binding (#1540)', () => {
+    // The false-CLEAR guard on the new hop itself, asserted on the shape the
+    // REGRESSION would credit: the binding holds a builder-producing `.map()`
+    // at declaration, then is reassigned to an opaque value before delivery.
+    // Crediting the callback's builder MUTATIONS for a value that is no longer
+    // that value is exactly what `isWhollyReassigned` refuses — same reason
+    // `builderDeclarationOf` refuses it for a directly-held builder. The SEED
+    // member still appears via `resolveLiterals`, which resolves reassigned
+    // bindings by design (the recorded bound (8) note) — the hop's own
+    // contract is only that `Mutated` is not borrowed.
+    const source = `
+      class P {
+        build(props) {
+          let rules = props['Rules'].map(() => { const sdkRule = { Seed: 1 }; sdkRule.Mutated = 2; return sdkRule; });
+          rules = opaque(props);
+          return { Rules: rules };
+        }
+        put(props) { return { Cfg: this.build(props) }; }
+      }
+    `;
+    expect(scopeAt(source, 'Cfg.Rules')).toEqual(['Seed']);
+    // The control: without the reassignment the SAME source credits the
+    // mutation, proving the refusal above is the guard and not a dead branch.
+    const withoutReassignment = source.replace('rules = opaque(props);', '');
+    expect(scopeAt(withoutReassignment, 'Cfg.Rules').sort()).toEqual(['Mutated', 'Seed']);
+  });
+
   it('skips a REVERSE-MAP helper nested inside the builder scope', () => {
     // The only builder refusal in the OVER-crediting direction, and it had no
     // test (#1474 review). `builderMembers` re-applies the
@@ -2324,17 +2351,21 @@ describe('classifyTarget (synthetic)', () => {
     );
     expect(notif?.bucket).toBe('same-spelling');
     expect([...used]).toEqual(['S3Key.Rules']);
-    // The same-named `Rules` under a DIFFERENT parent is untouched: its plain
-    // chain resolves, so the entry neither applies nor reads as used there.
+    // The same-named `Rules` under a DIFFERENT parent is untouched: the
+    // scoped key does not match there, so the plain chain resolves and the
+    // used set stays empty.
+    const usedElsewhere = new Set<string>();
     const [lifecycle] = classifyTarget(
       target,
       keyPaths('Top', 'Lifecycle.Rules.Name'),
       new Set(['Name']),
       new Set(),
       new Map(),
-      evidence
+      evidence,
+      usedElsewhere
     );
     expect(lifecycle?.bucket).toBe('same-spelling');
+    expect([...usedElsewhere]).toEqual([]);
   });
 
   it('a SCOPED segmentRenames key WINS over a bare-name entry for the same segment (#1540)', () => {


### PR DESCRIPTION
## Summary

Closes the 50-path S3 `no-write-evidence` residual that #1520 recorded and **opts `AWS::S3::Bucket` into the write-evidence pass** — the audit now runs at 0 divergences across all 11 fresh-object targets. All numbers measured on the real tree; every mechanism carries a synthetic test AND a real-code probe.

Four mechanisms, one per recorded family:

1. **Builder-behind-binding hop** (`resolveBuilders`): a builder returned from a `.map()` callback held in a plain binding (`const rules = cfg.Rules.map((r) => { const sdkRule = {…}; sdkRule.X = …; return sdkRule; })`) now credits its mutations — the seed members were credited while the mutations were lost, splitting one value in two. Lifecycle went 19 -> 4 on this alone. Declaration-identity strict; wholly-reassigned bindings stay refused (negative test with a control included).
2. **for-of taint hop**: the element of a bag-derived array is bag data — the statement-form twin of the existing `.map((element) => …)` callback hop. The per-item S3 config loops' verbatim `Tags: tagFilters` forwards now register as whole-blob hand-offs and wildcard-credit `TagFilters.Key/.Value` (Analytics / Metrics / IntelligentTiering).
3. **Scoped segment-rename keys** (`'Parent.Segment'`, matched on original CFn spellings, winning over bare keys): Notification's `S3Key.Rules` -> `FilterRules` and the destination wrappers -> `Destination.S3BucketDestination` without corrupting `LifecycleConfiguration.Rules` / `ReplicationConfiguration.Rules.Destination` — the collision class that blocked bare-name entries.
4. **`terminalRenames`** (new per-target map, full-path-keyed, staleness-fenced by `findStaleTerminalRenames`): pure renames (`Enabled` -> `IsEnabled`), relocations (config-level `Prefix`/`AccessPointArn` -> `Filter.*`, lifecycle rule-level `ExpiredObjectDeleteMarker`/size constraints), and the encryption LIST -> `Rules`. The judgment stays strict — the renamed member must be scope-written verbatim at the extended chain.

Three shapes remain inexpressible by design and carry reviewed `passes: ['write']` allow-list entries: the request-level `TransitionDefaultMinimumObjectSize` hoist and the two lifecycle `TagFilters` members forwarded through a destructured member of the in-method `gatherScope` helper's returned literal (the CloudFront `Tags.Key/.Value` wrapper-level class).

Notably, the new staleness fence caught its first live prey during development: three hand-authored `BucketArn`/`BucketAccountId` terminal entries were rejected as dead weight because the bag-derived member forwards' seed-key aliases already covered those CFn spellings.

S3 opts in with measured floors (`minWrittenMembers: 120` / `minWriteScopes: 110` of measured 157/156; `minHandoffPoints: 1` per the deliberate not-at-the-measurement convention).

A single `pr-code-reviewer` pass ran on the diff; all findings (2 Minor, 3 Nit — stale header prose, missing reassignment-guard negative test, narrow fence message, shadowed variable name, over-claiming test comment) are fixed in the second commit.

Closes #1540

## Test plan

- `vp run audit:nested-key-coverage:check`: OK — 703 paths, 11 targets, 0 divergences, no stale segment/terminal renames or allow entries.
- Full suite: 9793 tests pass (262 in the coverage suite; 11 new: scoped-key scoping/precedence, terminal rename/relocation/staleness trio, `findStaleTerminalRenames`, for-of hand-off registration, builder-hop positive + reassignment-refusal negative, and two real-code RED probes — stripping the real lifecycle `AbortIncompleteMultipartUpload` mutation and the real `SseKmsEncryptedObjects` forward write are both caught by name).
- `vp run gen:all-matrices` + `audit:coverage:check`: clean; regenerated `nested-key-coverage.{md,json}` committed.
