### PR TITLE
chore(audit): lint a fixture resource gated on a mode token a later deploy drops

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -374,11 +374,26 @@ that no step needs to transition.
   check passes vacuously when the resource was deleted mid-run, so it is not a
   guard; assert presence at the point the resource must still exist.
 
-NOT yet mechanically enforced — issue
-[#1543](https://github.com/go-to-k/cdkd/issues/1543) tracks the lint (the
-ordered mode lists and the token-gated declarations are both statically
-extractable, so unlike the order-insensitivity rule above this one is a
-checker, not a judgment call).
+Mechanically enforced since issue
+[#1543](https://github.com/go-to-k/cdkd/issues/1543): both halves are statically
+extractable, so unlike the order-insensitivity rule above this one is a checker
+rather than a judgment call. `scripts/check-integ-mode-gated-resources.ts`
+reads the ORDERED per-deploy mode lists out of `verify.sh` (including the
+monotonic-suffix `${VAR}` idiom prescribed above, which it resolves in source
+order) and the CONDITION behind each gated declaration in the fixture stack,
+then reports a declaration that is present at one step and absent at a later
+one. Enforced by `tests/unit/scripts/integ-mode-gated-resources.test.ts`.
+
+Two things about its verdicts are worth knowing before you hit one:
+
+- Only CREATE-shaped gates BLOCK — a construct, or an entry in a resource list
+  such as `replicas: [...]`. A scalar property gate (`deletionProtection: true`)
+  is reported for visibility only, because flipping a property back off is an
+  ordinary in-place update test and this fixture does exactly that at its
+  structural-teardown step.
+- A deliberate removal takes `// allow-mode-gated-drop: <reason>` on the
+  declaration. The reason is mandatory; a bare marker is rejected. The step-12d
+  replica removal here carries one.
 
 ### Fixture stateful L2s need an explicit removalPolicy (mandatory)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -683,11 +683,21 @@ it created. Finally, make sure some assertion would *notice* a drop — a
 post-destroy "it is gone" check passes vacuously when the resource was deleted
 mid-run, so it is not a guard.
 
-Not yet mechanically enforced; issue
-[#1543](https://github.com/go-to-k/cdkd/issues/1543) tracks the lint. Unlike the
+Mechanically enforced since issue
+[#1543](https://github.com/go-to-k/cdkd/issues/1543). Unlike the
 order-insensitivity convention above, this one is a genuine checker rather than
 a judgment call — the ordered mode lists and the token-gated declarations are
 both statically extractable.
+
+`scripts/check-integ-mode-gated-resources.ts` reads the ordered per-deploy mode
+lists out of `verify.sh` (resolving the monotonic-suffix `${VAR}` idiom above in
+source order) plus the condition behind each gated declaration in the fixture
+stack, and reports any declaration that is present at one step and absent at a
+later one. Only create-shaped gates block — a construct, or an entry in a
+resource list such as `replicas: [...]`; a scalar property gate is reported for
+visibility only, since flipping a property back off is an ordinary update test.
+A deliberate removal is marked on the declaration with
+`// allow-mode-gated-drop: <reason>`; the reason is mandatory.
 
 ### Fixture convention: stateful L2 constructs need an explicit removalPolicy
 

--- a/scripts/check-integ-mode-gated-resources.ts
+++ b/scripts/check-integ-mode-gated-resources.ts
@@ -111,12 +111,52 @@ export interface DeployStep {
   raw: string;
 }
 
-function parseModeValue(rhs: string): string[] | null {
-  const unquoted = /^(["'])([\s\S]*)\1$/.exec(rhs);
-  const value = unquoted ? unquoted[2]! : rhs;
-  // A variable reference or a command substitution cannot be resolved here.
-  if (/[$`]/.test(value)) return null;
-  return value
+/** Strip one layer of matching quotes from a shell RHS. */
+function unquote(rhs: string): string {
+  const m = /^(["'])([\s\S]*)\1$/.exec(rhs);
+  return m ? m[2]! : rhs;
+}
+
+/**
+ * Expand `${VAR}` / `$VAR` against the literal variables in scope at this line.
+ *
+ * The MONOTONIC SUFFIX idiom is why this exists rather than being a nicety:
+ * `.claude/rules/testing.md` prescribes carrying a token forward with
+ * `CDKD_TEST_UPDATE=ttl,tags${OD_MODE_SUFFIX}`, where the suffix is seeded
+ * empty and set once the resource exists. That is the CORRECT fix for the bug
+ * this lint checks, so a parser that gave up on `$` would report
+ * `unresolvable-mode-list` on precisely the fixtures that did the right thing —
+ * turning the lint into a blocker against its own recommended pattern.
+ *
+ * Assignments are applied in SOURCE ORDER (last one before the invocation
+ * wins), which models a linear script exactly and a conditional assignment
+ * conservatively — the same "assume the branch is taken" stance
+ * {@link parseDeploySteps} takes for a deploy inside an `if`.
+ *
+ * @returns the expanded string, or `null` when a reference cannot be resolved.
+ */
+function expandVars(value: string, vars: Map<string, string>): string | null {
+  // A command substitution is never resolvable here.
+  if (/`|\$\(/.test(value)) return null;
+
+  let unresolved = false;
+  const expanded = value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (_m, a, b) => {
+    const name = (a ?? b) as string;
+    const known = vars.get(name);
+    if (known === undefined) {
+      unresolved = true;
+      return '';
+    }
+    return known;
+  });
+
+  return unresolved ? null : expanded;
+}
+
+function parseModeValue(rhs: string, vars: Map<string, string>): string[] | null {
+  const expanded = expandVars(unquote(rhs), vars);
+  if (expanded === null) return null;
+  return expanded
     .split(',')
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
@@ -141,10 +181,18 @@ export function parseDeploySteps(content: string): DeployStep[] {
     .join('|');
   const steps: DeployStep[] = [];
   let ambient: string[] | null = [];
+  /** Literal shell variables in scope, updated in source order. */
+  const vars = new Map<string, string>();
 
   const assignment = new RegExp(
     String.raw`^\s*(?:export\s+)?${MODE_ENV}=(".*?"|'.*?'|\S*)\s*(?:#.*)?$`,
   );
+  // Any other simple `NAME=<literal>` assignment, so the monotonic-suffix
+  // idiom resolves. A non-literal RHS REMOVES the name from the table rather
+  // than being ignored, so a later expansion reports unresolvable instead of
+  // silently reusing a stale value.
+  const otherAssignment =
+    /^\s*(?:export\s+|readonly\s+|local\s+)?([A-Za-z_][A-Za-z0-9_]*)=("[^"]*"|'[^']*'|\S*)\s*(?:#.*)?$/;
   // The leading `\s*` is load-bearing, not tidiness: every deploy inside a
   // shell `if` block is INDENTED, and an anchor that demanded column 0 read
   // those invocations as unmoded. That silently emptied the mode list of
@@ -166,7 +214,14 @@ export function parseDeploySteps(content: string): DeployStep[] {
     }
     const bare = assignment.exec(stripped);
     if (bare) {
-      ambient = parseModeValue(bare[1]!);
+      ambient = parseModeValue(bare[1]!, vars);
+      continue;
+    }
+    const other = otherAssignment.exec(stripped);
+    if (other) {
+      const expanded = expandVars(unquote(other[2]!), vars);
+      if (expanded === null) vars.delete(other[1]!);
+      else vars.set(other[1]!, expanded);
       continue;
     }
 
@@ -175,7 +230,7 @@ export function parseDeploySteps(content: string): DeployStep[] {
       const inline = inlinePrefix.exec(segment);
       steps.push({
         line,
-        modes: inline ? parseModeValue(inline[1]!) : ambient,
+        modes: inline ? parseModeValue(inline[1]!, vars) : ambient,
         raw: segment.trim(),
       });
     }

--- a/scripts/check-integ-mode-gated-resources.ts
+++ b/scripts/check-integ-mode-gated-resources.ts
@@ -1,0 +1,655 @@
+/**
+ * Classifier for the integ-fixture mode-gating trap (issue #1543).
+ *
+ * Multi-step fixtures drive their phases with
+ * `CDKD_TEST_UPDATE=<comma,separated,modes>` and the stack reads
+ * `updateMode.includes('x')`. Gating a NEW resource on a NEW token is the
+ * natural spelling, and it is WRONG whenever a later deploy in the same
+ * `verify.sh` runs with a mode list that omits the token: the resource leaves
+ * the template and cdkd correctly DELETEs it.
+ *
+ * Found by hand during #1512, before the run reached it.
+ * `OnDemandReplicaTable` gated its `eu-west-1` replica on a `cross-region`-ish
+ * token; the fixture then deploys several more times with mode lists that omit
+ * it, so an earlier step would have removed the replica FROM A STILL-LIVE
+ * TABLE — the operation that arms DynamoDB's 24h source-region delete lock
+ * (#1442 wedged a table in `UPDATING` for 90+ minutes exactly that way). The
+ * fixture comments, the commit message and the issue comment had all already
+ * claimed the design "only ever ADDs". Nothing would have caught the
+ * contradiction.
+ *
+ * Unlike the order-insensitivity rule (which needs a human to decide whether a
+ * list is order-significant), both halves here are statically extractable:
+ *
+ *   - the ORDERED list of `CDKD_TEST_UPDATE=` mode lists per deploy invocation
+ *     in `verify.sh` (reusing the `check-integ-cli-flags` invocation parser,
+ *     which already handles the inline-env-prefix form and the `${CLI}`
+ *     variable spellings 135 of the fixtures use);
+ *   - the CONDITION each gated declaration in the fixture stack sits behind
+ *     (TS Compiler API, as the other classifiers do).
+ *
+ * The verdict is then per DECLARATION rather than per token, which the issue's
+ * framing does not make obvious but the real tree forces: `useProvisioned =
+ * useAutoScaling || updateMode.includes('billing-provisioned')` gates one
+ * declaration on TWO tokens, so "is token T absent later?" reports a drop at a
+ * step where `autoscaling` still holds the declaration in the template. Each
+ * gate therefore carries an evaluable condition tree, and a step's mode list is
+ * evaluated against it.
+ *
+ * Two deliberate widenings of the issue's stated rule:
+ *
+ *   - The issue asks about a deploy AFTER THE LAST one carrying the token. A
+ *     gap BETWEEN two carrying deploys is the same bug and strictly worse (the
+ *     resource is deleted and then re-created), so the rule is "present at some
+ *     step i, absent at some step j > i".
+ *   - A deploy inside a shell `if` is treated as always running. If the branch
+ *     is taken the drop happens, and a lint that assumed otherwise would go
+ *     quiet on exactly the opt-in blocks (`CDKD_INTEG_MULTI_REGION=1`) where
+ *     the expensive, stateful resources live.
+ *
+ * SEVERITY is encoded in the message, not in the verdict, per the issue:
+ * dropping a plain queue mid-run is free; dropping a DynamoDB replica / RDS
+ * instance / stateful store is the whole problem. The lint flags every dropped
+ * DECLARATION and lets the rationale comment carry the decision.
+ *
+ * Deliberate scope: only declarations that CREATE something (a construct
+ * instantiation, or an entry in a resource list such as `replicas: [...]`) are
+ * CI-blocking. A scalar property gate (`deletionProtection: true` behind
+ * `deletion-protection`) is reported as `property` and does NOT block —
+ * flipping a property back off is an ordinary in-place update test, and the
+ * dynamodb-globaltable fixture does it on purpose at its structural-teardown
+ * step. Blocking those would have made the lint's first real-tree run a wall
+ * of rationale comments on correct fixtures, which is how a checker gets
+ * disabled.
+ *
+ * ESCAPE HATCH: a fixture that WANTS to exercise the removal marks the
+ * declaration with `// allow-mode-gated-drop: <reason>` (the step-12d replica
+ * removal on the dynamodb-globaltable main table is exactly that). The reason
+ * is mandatory — a bare marker is rejected — so the decision is recorded
+ * rather than merely silenced.
+ *
+ * This module is separate from the test so the classifier can be table-tested
+ * against synthetic shapes rather than only against today's tree.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript-v6';
+import {
+  joinContinuedLines,
+  splitShellCommands,
+  stripTrailingComment,
+  findCliVariables,
+} from './check-integ-cli-flags.js';
+
+/** The env var whose comma-separated value drives a fixture's phases. */
+export const MODE_ENV = 'CDKD_TEST_UPDATE';
+
+/**
+ * `// allow-mode-gated-drop: <reason>` — the deliberate-removal opt-out.
+ *
+ * The reason group is deliberately allowed to match EMPTY. Requiring a
+ * non-space character here made a bare `// allow-mode-gated-drop:` fail to
+ * match the marker at all, so instead of being rejected as unreasoned it read
+ * as "no marker present" — the annotation silently did nothing.
+ */
+const ALLOW_MARKER = /allow-mode-gated-drop\s*:(.*)$/m;
+
+// ---------------------------------------------------------------------------
+// verify.sh side: the ORDERED mode list per deploy
+// ---------------------------------------------------------------------------
+
+export interface DeployStep {
+  /** 1-based line of the invocation. */
+  line: number;
+  /**
+   * The mode tokens in effect for this deploy, or `null` when the value could
+   * not be resolved statically (a shell variable / command substitution).
+   * `null` is NOT silently skipped — see {@link lintFixture}.
+   */
+  modes: string[] | null;
+  raw: string;
+}
+
+function parseModeValue(rhs: string): string[] | null {
+  const unquoted = /^(["'])([\s\S]*)\1$/.exec(rhs);
+  const value = unquoted ? unquoted[2]! : rhs;
+  // A variable reference or a command substitution cannot be resolved here.
+  if (/[$`]/.test(value)) return null;
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Pull the ordered `cdkd deploy` invocations out of a verify.sh, each with the
+ * mode list in effect for it.
+ *
+ * The value comes from the invocation's own inline env prefix
+ * (`CDKD_TEST_UPDATE=a,b ${CLI} deploy ...`) when it has one, else from the
+ * AMBIENT value a previous `export CDKD_TEST_UPDATE=` / bare assignment left
+ * set (and `unset CDKD_TEST_UPDATE` clears it back to empty). Missing the
+ * ambient form would read a whole fixture's deploys as unmoded and report
+ * nothing, so it is tracked rather than assumed absent.
+ */
+export function parseDeploySteps(content: string): DeployStep[] {
+  const cliVars = findCliVariables(content);
+  const cliRef = [...cliVars]
+    .map((v) => `\\$\\{${v}\\}|\\$${v}\\b`)
+    .concat(['cli\\.js'])
+    .join('|');
+  const steps: DeployStep[] = [];
+  let ambient: string[] | null = [];
+
+  const assignment = new RegExp(
+    String.raw`^\s*(?:export\s+)?${MODE_ENV}=(".*?"|'.*?'|\S*)\s*(?:#.*)?$`,
+  );
+  // The leading `\s*` is load-bearing, not tidiness: every deploy inside a
+  // shell `if` block is INDENTED, and an anchor that demanded column 0 read
+  // those invocations as unmoded. That silently emptied the mode list of
+  // exactly the opt-in `CDKD_INTEG_MULTI_REGION=1` block where the cross-region
+  // replica lives — i.e. it muted the one real finding this lint exists for,
+  // while still reporting the harmless property gates. Caught by measuring the
+  // classifier against the real fixture rather than only synthetic shapes.
+  const inlinePrefix = new RegExp(
+    String.raw`(?:^\s*|[;&|(]\s*|&&\s*|\|\|\s*)${MODE_ENV}=(".*?"|'.*?'|\S+)\s`,
+  );
+  const deployCall = new RegExp(String.raw`(?:${cliRef})[^;&|]*?\bdeploy\b`);
+
+  for (const { text, line } of joinContinuedLines(content)) {
+    const stripped = stripTrailingComment(text);
+
+    if (new RegExp(String.raw`^\s*unset\s+${MODE_ENV}\b`).test(stripped)) {
+      ambient = [];
+      continue;
+    }
+    const bare = assignment.exec(stripped);
+    if (bare) {
+      ambient = parseModeValue(bare[1]!);
+      continue;
+    }
+
+    for (const segment of splitShellCommands(stripped)) {
+      if (!deployCall.test(segment)) continue;
+      const inline = inlinePrefix.exec(segment);
+      steps.push({
+        line,
+        modes: inline ? parseModeValue(inline[1]!) : ambient,
+        raw: segment.trim(),
+      });
+    }
+  }
+
+  return steps;
+}
+
+// ---------------------------------------------------------------------------
+// Stack side: the CONDITION behind each gated declaration
+// ---------------------------------------------------------------------------
+
+export type Cond =
+  | { t: 'token'; token: string }
+  | { t: 'and'; l: Cond; r: Cond }
+  | { t: 'or'; l: Cond; r: Cond }
+  | { t: 'not'; e: Cond }
+  /**
+   * A leaf that IS a mode-list read but whose token could not be resolved —
+   * `updateMode.includes(SOME_CONST)`. Kept distinct from `unknown` because it
+   * still makes the gate mode-derived: collapsing the two dropped such a gate
+   * from the analysis entirely, which is the silent skip this lint exists to
+   * avoid.
+   */
+  | { t: 'unknown-token' }
+  /** A leaf that is not a mode-list read at all (e.g. another env var). */
+  | { t: 'unknown' };
+
+/** What the gated subtree brings into the template. */
+export type GateKind = 'construct' | 'resource-list' | 'property';
+
+export interface ModeGate {
+  /** 1-based line of the gate. */
+  line: number;
+  cond: Cond;
+  kind: GateKind;
+  /** The gated source text, truncated for the message. */
+  text: string;
+  /** `allow-mode-gated-drop:` reason attached to the gate, if any. */
+  allowReason: string | null;
+}
+
+/**
+ * Evaluate a gate condition against one step's mode list.
+ *
+ * @returns `null` when the condition contains a leaf this classifier cannot
+ *   resolve — the caller must treat that as INCONCLUSIVE, never as `false`.
+ */
+export function evaluateCond(cond: Cond, modes: string[]): boolean | null {
+  switch (cond.t) {
+    case 'token':
+      return modes.includes(cond.token);
+    case 'not': {
+      const e = evaluateCond(cond.e, modes);
+      return e === null ? null : !e;
+    }
+    case 'and': {
+      const l = evaluateCond(cond.l, modes);
+      const r = evaluateCond(cond.r, modes);
+      // A definite `false` on either side settles it even when the other leaf
+      // is unknown, which keeps an unrelated env var from muting the gate.
+      if (l === false || r === false) return false;
+      return l === null || r === null ? null : l && r;
+    }
+    case 'or': {
+      const l = evaluateCond(cond.l, modes);
+      const r = evaluateCond(cond.r, modes);
+      if (l === true || r === true) return true;
+      return l === null || r === null ? null : l || r;
+    }
+    case 'unknown-token':
+    case 'unknown':
+      return null;
+  }
+}
+
+/** Every token named anywhere in a condition. */
+export function tokensOf(cond: Cond): string[] {
+  switch (cond.t) {
+    case 'token':
+      return [cond.token];
+    case 'not':
+      return tokensOf(cond.e);
+    case 'and':
+    case 'or':
+      return [...new Set([...tokensOf(cond.l), ...tokensOf(cond.r)])];
+    case 'unknown-token':
+    case 'unknown':
+      return [];
+  }
+}
+
+/**
+ * Does this condition read the mode list at all?
+ *
+ * NOT the same question as "does it name a token": a gate whose token is a
+ * const reference is still mode-derived and must stay in the analysis (as an
+ * `inconclusive-gate`) rather than vanish from it.
+ */
+function isModeDerived(cond: Cond): boolean {
+  switch (cond.t) {
+    case 'token':
+    case 'unknown-token':
+      return true;
+    case 'not':
+      return isModeDerived(cond.e);
+    case 'and':
+    case 'or':
+      return isModeDerived(cond.l) || isModeDerived(cond.r);
+    case 'unknown':
+      return false;
+  }
+}
+
+/**
+ * Collect the mode gates in one fixture stack file.
+ *
+ * The `updateMode` binding is found by its INITIALIZER (anything reading
+ * `process.env.CDKD_TEST_UPDATE`) rather than by name, so a fixture that calls
+ * it something else is still analyzed. Only the LIST-shaped form is a gate
+ * source: the three fixtures using the boolean `=== 'true'` spelling have no
+ * token list and therefore no token to drop.
+ */
+export function collectModeGates(sourceText: string, fileName = 'stack.ts'): ModeGate[] {
+  const sf = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
+  const gates: ModeGate[] = [];
+
+  /** Names bound to the mode LIST (`(process.env.X ?? '').split(',')...`). */
+  const listBindings = new Set<string>();
+  /** Names bound to a condition over the mode list. */
+  const condBindings = new Map<string, Cond>();
+
+  const isModeEnvRead = (node: ts.Node): boolean =>
+    /process\s*\.\s*env\s*(\.|\[['"])/.test(node.getText()) && node.getText().includes(MODE_ENV);
+
+  // Pass 1: bindings, in source order so a later condition can reference an
+  // earlier one (`useProvisioned = useAutoScaling || ...`).
+  const collectBindings = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const name = node.name.text;
+      const init = node.initializer;
+      if (isModeEnvRead(init)) {
+        // A list binding only when the value is actually split into tokens;
+        // the `=== 'true'` boolean form is not a token list.
+        if (/\.split\s*\(/.test(init.getText())) listBindings.add(name);
+      } else {
+        const cond = toCond(init);
+        if (cond && isModeDerived(cond)) condBindings.set(name, cond);
+      }
+    }
+    ts.forEachChild(node, collectBindings);
+  };
+
+  /** `<listBinding>.includes('literal')` */
+  const asIncludes = (node: ts.Node): Cond | null => {
+    if (!ts.isCallExpression(node)) return null;
+    const callee = node.expression;
+    if (!ts.isPropertyAccessExpression(callee) || callee.name.text !== 'includes') return null;
+    if (!ts.isIdentifier(callee.expression) || !listBindings.has(callee.expression.text)) return null;
+    const arg = node.arguments[0];
+    if (!arg || !ts.isStringLiteralLike(arg)) return { t: 'unknown-token' };
+    return { t: 'token', token: arg.text };
+  };
+
+  function toCond(node: ts.Node): Cond | null {
+    if (ts.isParenthesizedExpression(node)) return toCond(node.expression);
+    const inc = asIncludes(node);
+    if (inc) return inc;
+    if (ts.isIdentifier(node)) return condBindings.get(node.text) ?? null;
+    if (ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.ExclamationToken) {
+      const e = toCond(node.operand);
+      return e ? { t: 'not', e } : null;
+    }
+    if (ts.isBinaryExpression(node)) {
+      const op = node.operatorToken.kind;
+      if (op === ts.SyntaxKind.AmpersandAmpersandToken || op === ts.SyntaxKind.BarBarToken) {
+        const l = toCond(node.left);
+        const r = toCond(node.right);
+        // One mode-derived side is enough; the other becomes an opaque leaf so
+        // an `updateMode.includes('x') && someOtherFlag` still registers.
+        if (!l && !r) return null;
+        return {
+          t: op === ts.SyntaxKind.AmpersandAmpersandToken ? 'and' : 'or',
+          l: l ?? { t: 'unknown' },
+          r: r ?? { t: 'unknown' },
+        };
+      }
+    }
+    return null;
+  }
+
+  collectBindings(sf);
+
+  const lineOf = (node: ts.Node): number =>
+    sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
+
+  const snippet = (node: ts.Node): string => {
+    const text = node.getText(sf).replace(/\s+/g, ' ').trim();
+    return text.length > 90 ? `${text.slice(0, 87)}...` : text;
+  };
+
+  /**
+   * The `allow-mode-gated-drop:` reason attached to a gate — read from the
+   * comments immediately preceding the gate's own line, or from a trailing
+   * comment on it. Ranges are taken from the whole enclosing statement so the
+   * marker can sit above the statement rather than glued to the expression.
+   */
+  const allowReasonFor = (node: ts.Node): string | null => {
+    // Walk OUTWARD from the gate to the enclosing statement, checking leading
+    // comments at every level. Checking only the statement's own leading
+    // comments missed the common real shape: a gate spread into a big object
+    // literal (`const tableProps = { ... ...(cond && { replicas }) ... }`) is
+    // many levels below the statement, so an annotation written directly above
+    // the spread — the only place a reader would put it — was invisible and
+    // the marker silently did nothing.
+    const ranges: ts.CommentRange[] = [];
+    let cursor: ts.Node | undefined = node;
+    while (cursor) {
+      ranges.push(...(ts.getLeadingCommentRanges(sourceText, cursor.getFullStart()) ?? []));
+      if (ts.isStatement(cursor)) break;
+      cursor = cursor.parent;
+    }
+    ranges.push(...(ts.getTrailingCommentRanges(sourceText, node.getEnd()) ?? []));
+
+    for (const range of ranges) {
+      const m = ALLOW_MARKER.exec(sourceText.slice(range.pos, range.end));
+      if (m) return m[1]!.replace(/\*\/\s*$/, '').trim();
+    }
+    return null;
+  };
+
+  /** `{}` / `[]` / an empty block — a gate that brings nothing into the template. */
+  const isEmptyValue = (node: ts.Node): boolean => {
+    if (ts.isObjectLiteralExpression(node)) return node.properties.length === 0;
+    if (ts.isArrayLiteralExpression(node)) return node.elements.length === 0;
+    if (ts.isBlock(node)) return node.statements.length === 0;
+    return false;
+  };
+
+  const kindOf = (node: ts.Node): GateKind => {
+    let hasNew = false;
+    let hasResourceList = false;
+    const walk = (n: ts.Node): void => {
+      if (ts.isNewExpression(n)) hasNew = true;
+      // An array of object literals under a property is an entry in a resource
+      // LIST — `replicas: [{ region: 'eu-west-1' }]`, the #1512 shape. A
+      // `new`-less scalar array (`['a','b']`) is not.
+      if (ts.isArrayLiteralExpression(n) && n.elements.some(ts.isObjectLiteralExpression)) {
+        hasResourceList = true;
+      }
+      ts.forEachChild(n, walk);
+    };
+    walk(node);
+    if (hasNew) return 'construct';
+    if (hasResourceList) return 'resource-list';
+    return 'property';
+  };
+
+  const record = (condNode: ts.Node, gated: ts.Node, anchor: ts.Node): void => {
+    const cond = toCond(condNode);
+    if (!cond || !isModeDerived(cond)) return;
+    // Only the TRUTHY arm is recorded (see `visit`), so the `drop-*` idiom
+    // `...(includes('drop-x') ? {} : { limit })` lands here with an EMPTY arm:
+    // the token ADDS nothing, it removes the else-arm. That is a deliberate
+    // removal test by construction — recording it would flag every `drop-*`
+    // fixture and demand a rationale comment for the thing the token is named
+    // after. An empty gated value gates nothing.
+    if (isEmptyValue(gated)) return;
+    gates.push({
+      line: lineOf(anchor),
+      cond,
+      kind: kindOf(gated),
+      text: snippet(gated),
+      allowReason: allowReasonFor(anchor),
+    });
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isIfStatement(node)) {
+      record(node.expression, node.thenStatement, node);
+    } else if (ts.isConditionalExpression(node)) {
+      // Both arms are gated — one by the condition, one by its negation. Only
+      // the truthy arm is recorded: a fixture spelling the DEFAULT in the false
+      // arm (`cond ? [] : [entry]`) is an add-on-absence, whose "drop" is the
+      // presence of the token, and reporting both arms doubled every finding.
+      record(node.condition, node.whenTrue, node);
+    } else if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken &&
+      // `...(cond && { prop })` — a gated VALUE, not a boolean sub-expression
+      // of a larger condition.
+      (ts.isObjectLiteralExpression(node.right) || ts.isArrayLiteralExpression(node.right))
+    ) {
+      record(node.left, node.right, node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+
+  return gates;
+}
+
+// ---------------------------------------------------------------------------
+// Verdict
+// ---------------------------------------------------------------------------
+
+export type ViolationKind =
+  /** Present at one step, absent at a later one — the #1543 bug. */
+  | 'dropped-mid-run'
+  /** A deploy whose mode list could not be resolved statically. */
+  | 'unresolvable-mode-list'
+  /** A gate whose condition carries a leaf this classifier cannot evaluate. */
+  | 'inconclusive-gate'
+  /** An `allow-mode-gated-drop:` marker with no reason after the colon. */
+  | 'unreasoned-allow';
+
+export interface Violation {
+  fixture: string;
+  file: string;
+  line: number;
+  kind: ViolationKind;
+  gateKind: GateKind;
+  /** CI-blocking. A `property` drop is reported for visibility only. */
+  blocking: boolean;
+  message: string;
+}
+
+/** Types whose mid-run removal is destructive far beyond the wasted step. */
+// The trailing `s?` is not cosmetic: the shape that motivated the issue is a
+// LIST property (`replicas: [...]`), so a `\bReplica\b` match misses the exact
+// case and downgrades its message to the generic one.
+const STATEFUL_HINT =
+  /\b(Tables?|Replicas?|Buckets?|Clusters?|Instances?|Databases?|Dbs?|Volumes?|FileSystems?|Domains?|Secrets?|Repositor(?:y|ies))\b/i;
+
+function severityHint(gate: ModeGate): string {
+  if (gate.kind === 'property') {
+    return 'a property, so the later step merely flips it back — visibility only';
+  }
+  return STATEFUL_HINT.test(gate.text)
+    ? 'this looks STATEFUL — a mid-run removal can destroy data or arm a long ' +
+        'AWS-side lock (a DynamoDB replica removal arms a 24h source-region delete lock)'
+    : 'the resource is deleted and (if the token returns) re-created mid-run';
+}
+
+export function lintFixture(
+  fixture: string,
+  file: string,
+  stackSource: string,
+  verifySource: string,
+): Violation[] {
+  const gates = collectModeGates(stackSource, file);
+  if (gates.length === 0) return [];
+
+  const steps = parseDeploySteps(verifySource);
+  const violations: Violation[] = [];
+
+  for (const gate of gates) {
+    if (gate.allowReason !== null && gate.allowReason === '') {
+      violations.push({
+        fixture,
+        file,
+        line: gate.line,
+        kind: 'unreasoned-allow',
+        gateKind: gate.kind,
+        blocking: true,
+        message: `allow-mode-gated-drop needs a reason after the colon (${gate.text})`,
+      });
+    }
+  }
+
+  // An unresolvable mode list makes EVERY gate's timeline unreliable, so it is
+  // reported once per fixture rather than swallowed. Reporting nothing here is
+  // the vacuous pass the repo's checker rules exist to forbid.
+  const unresolvable = steps.filter((s) => s.modes === null);
+  for (const step of unresolvable) {
+    violations.push({
+      fixture,
+      file: 'verify.sh',
+      line: step.line,
+      kind: 'unresolvable-mode-list',
+      gateKind: 'property',
+      blocking: true,
+      message:
+        `${MODE_ENV} is set from a shell variable or command substitution, so the ` +
+        `mode timeline cannot be checked: ${step.raw.slice(0, 80)}`,
+    });
+  }
+  if (unresolvable.length > 0) return violations;
+
+  for (const gate of gates) {
+    if (gate.allowReason) continue;
+
+    let seenPresent = false;
+    for (const step of steps) {
+      const present = evaluateCond(gate.cond, step.modes!);
+      if (present === null) {
+        // NOT a silent skip: a condition the classifier cannot evaluate is the
+        // shape in which this lint would go quiet on a real drop, so it is
+        // surfaced. Non-blocking, because an undecidable condition is a limit
+        // of the classifier rather than evidence of a fixture bug.
+        violations.push({
+          fixture,
+          file,
+          line: gate.line,
+          kind: 'inconclusive-gate',
+          gateKind: gate.kind,
+          blocking: false,
+          message:
+            `condition carries a leaf this classifier cannot evaluate, so the mode ` +
+            `timeline was not checked for it. Gate: ${gate.text}`,
+        });
+        break;
+      }
+      if (present) {
+        seenPresent = true;
+        continue;
+      }
+      if (!seenPresent) continue;
+
+      const tokens = tokensOf(gate.cond).join(', ');
+      violations.push({
+        fixture,
+        file,
+        line: gate.line,
+        kind: 'dropped-mid-run',
+        gateKind: gate.kind,
+        blocking: gate.kind !== 'property',
+        message:
+          `gated on [${tokens}] and DROPPED by the deploy at verify.sh:${step.line} ` +
+          `(modes: ${step.modes!.length > 0 ? step.modes!.join(',') : '<empty>'}) — ` +
+          `${severityHint(gate)}. If the removal is deliberate, mark the declaration ` +
+          `with \`// allow-mode-gated-drop: <reason>\`. Gate: ${gate.text}`,
+      });
+      break; // one finding per declaration; the first drop is the diagnosis
+    }
+  }
+
+  return violations;
+}
+
+/** Stack sources for one fixture: `lib/*.ts` plus `bin/*.ts`. */
+export function fixtureStackFiles(fixtureDir: string): string[] {
+  const out: string[] = [];
+  for (const sub of ['lib', 'bin']) {
+    const dir = join(fixtureDir, sub);
+    if (!existsSync(dir)) continue;
+    for (const entry of readdirSync(dir)) {
+      if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) out.push(join(sub, entry));
+    }
+  }
+  return out;
+}
+
+export function lintFixtureTree(integRoot: string): Violation[] {
+  const violations: Violation[] = [];
+
+  for (const entry of readdirSync(integRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const dir = join(integRoot, entry.name);
+    const verify = join(dir, 'verify.sh');
+    if (!existsSync(verify)) continue;
+    const verifySource = readFileSync(verify, 'utf8');
+
+    for (const rel of fixtureStackFiles(dir)) {
+      violations.push(
+        ...lintFixture(entry.name, rel, readFileSync(join(dir, rel), 'utf8'), verifySource),
+      );
+    }
+  }
+
+  return violations;
+}
+
+export function formatViolation(v: Violation): string {
+  const tag = v.blocking ? 'ERROR' : 'note';
+  return `[${tag}] ${v.fixture}/${v.file}:${v.line} [${v.kind}/${v.gateKind}] ${v.message}`;
+}

--- a/scripts/check-integ-mode-gated-resources.ts
+++ b/scripts/check-integ-mode-gated-resources.ts
@@ -68,6 +68,23 @@
  * is mandatory — a bare marker is rejected — so the decision is recorded
  * rather than merely silenced.
  *
+ * KNOWN BOUNDS, measured rather than predicted (a 3-axis review found each):
+ *
+ *   1. A gate whose condition is mode-derived but not reducible to a token set
+ *      (`onDemandReplicaMode !== 'none'`) reports `inconclusive-gate`, not a
+ *      verdict. That is deliberate — the alternative was dropping it silently,
+ *      which is what the first version did to the one declaration this lint was
+ *      written for. Widening the reducer (comparisons, `Set.has`, non-`split`
+ *      mode bindings) would convert those notes into real verdicts.
+ *   2. `resource-list` is a SHAPE test (an array of object literals), so a
+ *      gated `tags: [{ key, value }]` classifies as one and would BLOCK if a
+ *      later step dropped its token. No fixture does that today; the escape
+ *      hatch is the remedy if one ever does.
+ *   3. An `allow-mode-gated-drop:` marker attached to a STATEMENT silences
+ *      every gate inside that statement, not just the nearest one.
+ *   4. A deploy inside a shell FUNCTION is counted at the definition site; its
+ *      call sites are invisible.
+ *
  * This module is separate from the test so the classifier can be table-tested
  * against synthetic shapes rather than only against today's tree.
  */
@@ -93,7 +110,7 @@ export const MODE_ENV = 'CDKD_TEST_UPDATE';
  * match the marker at all, so instead of being rejected as unreasoned it read
  * as "no marker present" — the annotation silently did nothing.
  */
-const ALLOW_MARKER = /allow-mode-gated-drop\s*:(.*)$/m;
+const ALLOW_MARKER = /^\s*(?:\/\/|\/\*|\*)?\s*allow-mode-gated-drop\s*:(.*?)(?:\*\/)?\s*$/m;
 
 // ---------------------------------------------------------------------------
 // verify.sh side: the ORDERED mode list per deploy
@@ -109,6 +126,29 @@ export interface DeployStep {
    */
   modes: string[] | null;
   raw: string;
+}
+
+/**
+ * Drop heredoc BODIES before parsing. A body is data: a
+ * `CDKD_TEST_UPDATE=... deploy` line inside `<<EOF` sets nothing and deploys
+ * nothing, but read as live script it would set the ambient mode list for the
+ * whole rest of the file. Mirrors `check-integ-cdk-cli-pins.ts`'s private
+ * `stripHeredocs` (kept local rather than widening that module's export
+ * surface for one caller).
+ */
+function stripHeredocBodies(script: string): string {
+  const out: string[] = [];
+  const lines = script.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    out.push(lines[i]!);
+    const m = /<<-?\s*['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?/.exec(lines[i]!);
+    if (!m) continue;
+    const endRe = new RegExp(`^\\s*${m[1]!}\\s*$`);
+    i += 1;
+    while (i < lines.length && !endRe.test(lines[i]!)) i += 1;
+    if (i < lines.length) out.push(lines[i]!); // keep the terminator
+  }
+  return out.join('\n');
 }
 
 /** Strip one layer of matching quotes from a shell RHS. */
@@ -150,7 +190,13 @@ function expandVars(value: string, vars: Map<string, string>): string | null {
     return known;
   });
 
-  return unresolved ? null : expanded;
+  // Any surviving `$` means a form this expander does not model — `${VAR:-def}`,
+  // `${VAR#pat}`, `$1`. Returning the literal text would leave it glued to a
+  // token (`alpha${SUF:-}`), so the token reads ABSENT and a correct fixture
+  // gets a false `dropped-mid-run`. `${VAR:-}` is one keystroke from the
+  // monotonic-suffix idiom this expander exists for, so it is not hypothetical.
+  if (unresolved || expanded.includes('$')) return null;
+  return expanded;
 }
 
 function parseModeValue(rhs: string, vars: Map<string, string>): string[] | null {
@@ -191,21 +237,28 @@ export function parseDeploySteps(content: string): DeployStep[] {
   // idiom resolves. A non-literal RHS REMOVES the name from the table rather
   // than being ignored, so a later expansion reports unresolvable instead of
   // silently reusing a stale value.
+  // The RHS alternation carries an explicit `$( … )` / backtick arm so a
+  // command substitution (`SUF=$(echo ,beta)`, which contains SPACES) still
+  // MATCHES and therefore invalidates the name. A space-free-only RHS never
+  // matched it, so the variable silently kept its previous value and the step
+  // read a stale mode list instead of reporting unresolvable. The end-of-line
+  // anchor is what keeps this from swallowing an inline env PREFIX
+  // (`CDKD_TEST_UPDATE=a ${CLI} deploy …` is a command, not an assignment).
   const otherAssignment =
-    /^\s*(?:export\s+|readonly\s+|local\s+)?([A-Za-z_][A-Za-z0-9_]*)=("[^"]*"|'[^']*'|\S*)\s*(?:#.*)?$/;
-  // The leading `\s*` is load-bearing, not tidiness: every deploy inside a
-  // shell `if` block is INDENTED, and an anchor that demanded column 0 read
-  // those invocations as unmoded. That silently emptied the mode list of
-  // exactly the opt-in `CDKD_INTEG_MULTI_REGION=1` block where the cross-region
-  // replica lives — i.e. it muted the one real finding this lint exists for,
-  // while still reporting the harmless property gates. Caught by measuring the
-  // classifier against the real fixture rather than only synthetic shapes.
-  const inlinePrefix = new RegExp(
-    String.raw`(?:^\s*|[;&|(]\s*|&&\s*|\|\|\s*)${MODE_ENV}=(".*?"|'.*?'|\S+)\s`,
-  );
+    /^\s*(?:export\s+|readonly\s+|local\s+)?([A-Za-z_][A-Za-z0-9_]*)=("[^"]*"|'[^']*'|\$\([^)]*\)|`[^`]*`|\S*)\s*(?:#.*)?$/;
+  // Scan EVERY assignment in the invocation's env prefix, not just one anchored
+  // at the start of the segment. Two shapes that already exist in the tree read
+  // as UNMODED under an anchored match — `CDKD_TEST_REMOVAL=true
+  // CDKD_TEST_UPDATE=alpha ${CLI} deploy` and `env -u OTHER
+  // CDKD_TEST_UPDATE=alpha ${CLI} deploy` — and an unmoded read is a CI-BLOCKING
+  // false positive on a correct fixture, not a miss. (The leading `\s*` is
+  // equally load-bearing: every deploy inside a shell `if` block is INDENTED,
+  // and demanding column 0 muted the one real finding this lint exists for
+  // while still reporting the harmless property gates.)
+  const inlinePrefix = new RegExp(String.raw`(?:^|[\s;&|(])${MODE_ENV}=(".*?"|'.*?'|\S*)`, 'g');
   const deployCall = new RegExp(String.raw`(?:${cliRef})[^;&|]*?\bdeploy\b`);
 
-  for (const { text, line } of joinContinuedLines(content)) {
+  for (const { text, line } of joinContinuedLines(stripHeredocBodies(content))) {
     const stripped = stripTrailingComment(text);
 
     if (new RegExp(String.raw`^\s*unset\s+${MODE_ENV}\b`).test(stripped)) {
@@ -227,7 +280,12 @@ export function parseDeploySteps(content: string): DeployStep[] {
 
     for (const segment of splitShellCommands(stripped)) {
       if (!deployCall.test(segment)) continue;
-      const inline = inlinePrefix.exec(segment);
+      // Last assignment wins, matching the shell.
+      inlinePrefix.lastIndex = 0;
+      let inline: RegExpExecArray | null = null;
+      for (let m = inlinePrefix.exec(segment); m !== null; m = inlinePrefix.exec(segment)) {
+        inline = m;
+      }
       steps.push({
         line,
         modes: inline ? parseModeValue(inline[1]!, vars) : ambient,
@@ -362,6 +420,19 @@ export function collectModeGates(sourceText: string, fileName = 'stack.ts'): Mod
   const listBindings = new Set<string>();
   /** Names bound to a condition over the mode list. */
   const condBindings = new Map<string, Cond>();
+  /**
+   * Names whose VALUE derives from the mode list without being a condition this
+   * classifier can reduce — `const mode = updateMode.includes('x') ? 'a' : 'b'`.
+   *
+   * Without this the real #1512 declaration was invisible: its gate is
+   * `wantsOnDemandReplica = onDemandReplicaMode !== 'none'`, a `!==` over such a
+   * string, which `toCond` reduced to `null` — so `record` returned early and
+   * the `replicas: [...]` gate left the analysis ENTIRELY, with no
+   * `inconclusive-gate` either. That is the exact silent skip the
+   * `unknown-token` leaf exists to prevent, on the one declaration this lint
+   * was written for.
+   */
+  const modeDerivedNames = new Set<string>();
 
   const isModeEnvRead = (node: ts.Node): boolean =>
     /process\s*\.\s*env\s*(\.|\[['"])/.test(node.getText()) && node.getText().includes(MODE_ENV);
@@ -379,9 +450,30 @@ export function collectModeGates(sourceText: string, fileName = 'stack.ts'): Mod
       } else {
         const cond = toCond(init);
         if (cond && isModeDerived(cond)) condBindings.set(name, cond);
+        else if (readsModeList(init)) modeDerivedNames.add(name);
       }
     }
     ts.forEachChild(node, collectBindings);
+  };
+
+  /**
+   * Does this expression read the mode list, directly or through a name already
+   * known to derive from it? Deliberately SYNTACTIC and permissive — it only
+   * decides whether an unreducible gate is reported `inconclusive-gate` or
+   * dropped, and dropping is the failure mode that matters.
+   */
+  const readsModeList = (node: ts.Node): boolean => {
+    let found = false;
+    const walk = (n: ts.Node): void => {
+      if (found) return;
+      if (ts.isIdentifier(n) && (listBindings.has(n.text) || modeDerivedNames.has(n.text) || condBindings.has(n.text))) {
+        found = true;
+        return;
+      }
+      ts.forEachChild(n, walk);
+    };
+    walk(node);
+    return found;
   };
 
   /** `<listBinding>.includes('literal')` */
@@ -404,6 +496,9 @@ export function collectModeGates(sourceText: string, fileName = 'stack.ts'): Mod
       const e = toCond(node.operand);
       return e ? { t: 'not', e } : null;
     }
+    if (ts.isIdentifier(node) && modeDerivedNames.has(node.text)) {
+      return { t: 'unknown-token' };
+    }
     if (ts.isBinaryExpression(node)) {
       const op = node.operatorToken.kind;
       if (op === ts.SyntaxKind.AmpersandAmpersandToken || op === ts.SyntaxKind.BarBarToken) {
@@ -418,7 +513,12 @@ export function collectModeGates(sourceText: string, fileName = 'stack.ts'): Mod
           r: r ?? { t: 'unknown' },
         };
       }
+      // Any OTHER binary operator over a mode-derived value — `!==`, `===`,
+      // `>` — is not reducible to a token set, but the gate is still
+      // mode-derived and must stay VISIBLE as inconclusive.
+      if (readsModeList(node)) return { t: 'unknown-token' };
     }
+    if (readsModeList(node)) return { t: 'unknown-token' };
     return null;
   }
 
@@ -462,12 +562,25 @@ export function collectModeGates(sourceText: string, fileName = 'stack.ts'): Mod
     return null;
   };
 
-  /** `{}` / `[]` / an empty block — a gate that brings nothing into the template. */
-  const isEmptyValue = (node: ts.Node): boolean => {
+  /**
+   * A gate that DECLARES nothing: an empty `{}` / `[]` / block (the `drop-*`
+   * idiom's truthy arm), or a bare primitive (`cond ? 'dropped' : 'none'`,
+   * `cond ? 40 : 20`). A primitive arm chooses a VALUE that some declaration
+   * elsewhere consumes — the declaration itself is not gated, so reporting it
+   * as dropped is noise that trains readers to ignore the lint.
+   */
+  const isNonDeclarationValue = (node: ts.Node): boolean => {
     if (ts.isObjectLiteralExpression(node)) return node.properties.length === 0;
     if (ts.isArrayLiteralExpression(node)) return node.elements.length === 0;
     if (ts.isBlock(node)) return node.statements.length === 0;
-    return false;
+    return (
+      ts.isStringLiteralLike(node) ||
+      ts.isNumericLiteral(node) ||
+      node.kind === ts.SyntaxKind.TrueKeyword ||
+      node.kind === ts.SyntaxKind.FalseKeyword ||
+      node.kind === ts.SyntaxKind.NullKeyword ||
+      ts.isIdentifier(node)
+    );
   };
 
   const kindOf = (node: ts.Node): GateKind => {
@@ -498,7 +611,7 @@ export function collectModeGates(sourceText: string, fileName = 'stack.ts'): Mod
     // removal test by construction — recording it would flag every `drop-*`
     // fixture and demand a rationale comment for the thing the token is named
     // after. An empty gated value gates nothing.
-    if (isEmptyValue(gated)) return;
+    if (isNonDeclarationValue(gated)) return;
     gates.push({
       line: lineOf(anchor),
       cond,
@@ -580,6 +693,7 @@ export function lintFixture(
   file: string,
   stackSource: string,
   verifySource: string,
+  reportUnresolvable = true,
 ): Violation[] {
   const gates = collectModeGates(stackSource, file);
   if (gates.length === 0) return [];
@@ -588,7 +702,7 @@ export function lintFixture(
   const violations: Violation[] = [];
 
   for (const gate of gates) {
-    if (gate.allowReason !== null && gate.allowReason === '') {
+    if (gate.allowReason === '') {
       violations.push({
         fixture,
         file,
@@ -604,7 +718,10 @@ export function lintFixture(
   // An unresolvable mode list makes EVERY gate's timeline unreliable, so it is
   // reported once per fixture rather than swallowed. Reporting nothing here is
   // the vacuous pass the repo's checker rules exist to forbid.
-  const unresolvable = steps.filter((s) => s.modes === null);
+  // Reported against the FIRST stack file only: the mode timeline is a
+  // property of verify.sh, so emitting it per stack file produced duplicate
+  // rows for a multi-file fixture.
+  const unresolvable = reportUnresolvable ? steps.filter((s) => s.modes === null) : [];
   for (const step of unresolvable) {
     violations.push({
       fixture,
@@ -696,7 +813,13 @@ export function lintFixtureTree(integRoot: string): Violation[] {
 
     for (const rel of fixtureStackFiles(dir)) {
       violations.push(
-        ...lintFixture(entry.name, rel, readFileSync(join(dir, rel), 'utf8'), verifySource),
+        ...lintFixture(
+          entry.name,
+          rel,
+          readFileSync(join(dir, rel), 'utf8'),
+          verifySource,
+          rel === fixtureStackFiles(dir)[0],
+        ),
       );
     }
   }

--- a/tests/integration/dynamodb-globaltable/lib/dynamodb-globaltable-stack.ts
+++ b/tests/integration/dynamodb-globaltable/lib/dynamodb-globaltable-stack.ts
@@ -138,6 +138,11 @@ export class DynamoDBGlobalTableStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       ...(updateMode.includes('ttl') && { timeToLiveAttribute: 'expiresAt' }),
       ...(updateMode.includes('deletion-protection') && { deletionProtection: true }),
+      // allow-mode-gated-drop: step 12d removes this replica on purpose — the
+      // add-then-remove round-trip IS the test (verify.sh asserts the eu-west-1
+      // replica reaches ACTIVE, then that it is gone). The removal is safe here
+      // because it runs inside the opt-in CDKD_INTEG_MULTI_REGION block and is
+      // the last thing that touches this replica.
       ...(wantsCrossRegion && {
         // Issue #1512: the replica declares its OWN table-level read
         // capacity, which synthesizes to

--- a/tests/unit/scripts/integ-mode-gated-resources.test.ts
+++ b/tests/unit/scripts/integ-mode-gated-resources.test.ts
@@ -22,22 +22,6 @@ import {
 
 const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
 
-/**
- * Fixtures whose stack / verify.sh is owned by an in-flight PR, so the sweep
- * does not demand the `allow-mode-gated-drop:` annotation there yet — adding
- * one would collide on rebase. Each entry is asserted BELOW to still be
- * violating, so the exception self-expires: once the owning PR lands and the
- * annotation goes in, this test fails and forces the entry's deletion rather
- * than letting it linger. Same mechanism as `PENDING_OTHER_PR` in
- * `integ-verify-signal-traps.test.ts`.
- */
-const PENDING_OTHER_PR: Record<string, string> = {
-  'dynamodb-globaltable':
-    'PR #1550 (issue #1512) owns both dynamodb-globaltable-stack.ts and verify.sh. ' +
-    'The finding is the step-12d replica removal, which IS deliberate — it needs an ' +
-    '`allow-mode-gated-drop:` comment on the `replicas` gate, added once #1550 lands.',
-};
-
 // ---------------------------------------------------------------------------
 // verify.sh parsing
 // ---------------------------------------------------------------------------
@@ -381,17 +365,8 @@ describe('the real fixture tree', () => {
   const violations = lintFixtureTree(INTEG_ROOT);
 
   it('has no un-annotated mode-gated resource drop', () => {
-    const blocking = violations.filter((v) => v.blocking && !(v.fixture in PENDING_OTHER_PR));
-    expect(blocking.map(formatViolation)).toEqual([]);
+    expect(violations.filter((v) => v.blocking).map(formatViolation)).toEqual([]);
   });
-
-  for (const [fixture, why] of Object.entries(PENDING_OTHER_PR)) {
-    it(`self-expiring exception: ${fixture} still violates (${why.slice(0, 40)}...)`, () => {
-      // When the owning PR lands and the annotation goes in, this fails and
-      // forces the entry's deletion — the exception cannot linger silently.
-      expect(violations.some((v) => v.fixture === fixture && v.blocking)).toBe(true);
-    });
-  }
 
   it('parses at least one fixture that actually uses the token-list form', () => {
     // A coverage floor, not decoration: every classifier half can regress to
@@ -437,22 +412,27 @@ describe('real-code probes against the dynamodb-globaltable fixture', () => {
   const stack = readFileSync(join(FIXTURE, STACK_REL), 'utf8');
   const verify = readFileSync(join(FIXTURE, 'verify.sh'), 'utf8');
 
-  it('flags the real cross-region replica gate against the real verify.sh', () => {
-    const v = lintFixture('dynamodb-globaltable', STACK_REL, stack, verify);
-    const replica = v.find((x) => x.blocking && x.gateKind === 'resource-list');
+  it('is CLEAN as shipped — the real replica gate carries its annotation', () => {
+    expect(
+      lintFixture('dynamodb-globaltable', STACK_REL, stack, verify).filter((x) => x.blocking)
+    ).toEqual([]);
+  });
+
+  it('flags the real cross-region replica gate once the annotation is REMOVED', () => {
+    // The inverse of the test above, and the one that actually proves the lint
+    // works: strip the `allow-mode-gated-drop` line from the REAL fixture and
+    // the real verify.sh must produce the blocking finding. Without this, an
+    // annotation that silences everything would look identical to a lint that
+    // detects nothing.
+    const stripped = stack.replace(/^.*allow-mode-gated-drop.*\n/m, '');
+    expect(stripped, 'the strip probe did not apply').not.toBe(stack);
+
+    const replica = lintFixture('dynamodb-globaltable', STACK_REL, stripped, verify).find(
+      (x) => x.blocking && x.gateKind === 'resource-list'
+    );
     expect(replica, 'the real replica drop was not detected').toBeDefined();
     expect(replica!.message).toContain('cross-region');
     expect(replica!.message).toContain('24h source-region delete lock');
-  });
-
-  it('goes quiet once the real gate carries the annotation', () => {
-    const annotated = stack.replace(
-      /(\n\s*)(\.\.\.\(wantsCrossRegion && \{)/,
-      '$1// allow-mode-gated-drop: step 12d removes the replica on purpose$1$2',
-    );
-    expect(annotated, 'the annotation probe did not apply').not.toBe(stack);
-    const v = lintFixture('dynamodb-globaltable', STACK_REL, annotated, verify);
-    expect(v.filter((x) => x.blocking)).toEqual([]);
   });
 
   it('flags the real ttl property gate once a later real step drops it', () => {

--- a/tests/unit/scripts/integ-mode-gated-resources.test.ts
+++ b/tests/unit/scripts/integ-mode-gated-resources.test.ts
@@ -70,6 +70,58 @@ describe('parseDeploySteps', () => {
     expect(steps[0]?.modes).toBeNull();
   });
 
+  it('resolves the monotonic-suffix idiom in source order', () => {
+    // The idiom `.claude/rules/testing.md` prescribes: seeded empty, set once
+    // the resource exists, appended to every later mode list.
+    const steps = parseDeploySteps(
+      `${CLI_HEADER}SUF=""\n` +
+        `CDKD_TEST_UPDATE=ttl,tags\${SUF} \${CLI} deploy S\n` +
+        `SUF=",extra"\n` +
+        `CDKD_TEST_UPDATE=ttl,tags\${SUF} \${CLI} deploy S\n`,
+    );
+    expect(steps.map((x) => x.modes)).toEqual([
+      ['ttl', 'tags'],
+      ['ttl', 'tags', 'extra'],
+    ]);
+  });
+
+  it('reports a `${VAR:-default}` form as unresolvable, not as a literal token', () => {
+    // Leaving `alpha${SUF:-}` in the string makes token `alpha` read ABSENT and
+    // produces a FALSE blocking finding on a correct fixture — and `:-` is one
+    // keystroke from the prescribed suffix idiom.
+    expect(
+      parseDeploySteps(`${CLI_HEADER}CDKD_TEST_UPDATE=alpha\${SUF:-} \${CLI} deploy S\n`)[0]?.modes,
+    ).toBeNull();
+  });
+
+  it('invalidates a variable assigned from a command substitution', () => {
+    const steps = parseDeploySteps(
+      `${CLI_HEADER}SUF=",a"\nSUF=$(echo ,beta)\nCDKD_TEST_UPDATE=ttl\${SUF} \${CLI} deploy S\n`,
+    );
+    expect(steps[0]?.modes, 'a stale value must not survive an unresolvable RHS').toBeNull();
+  });
+
+  it('reads the mode list when it is NOT the first env assignment', () => {
+    // Both shapes already exist in the tree. An anchored match read them as
+    // unmoded, which is a CI-BLOCKING false positive, not a miss.
+    expect(
+      parseDeploySteps(
+        `${CLI_HEADER}CDKD_TEST_REMOVAL=true CDKD_TEST_UPDATE=alpha \${CLI} deploy S\n`,
+      )[0]?.modes,
+    ).toEqual(['alpha']);
+    expect(
+      parseDeploySteps(`${CLI_HEADER}env -u OTHER CDKD_TEST_UPDATE=alpha \${CLI} deploy S\n`)[0]
+        ?.modes,
+    ).toEqual(['alpha']);
+  });
+
+  it('ignores a mode assignment inside a heredoc body', () => {
+    const steps = parseDeploySteps(
+      `${CLI_HEADER}cat <<EOF\nCDKD_TEST_UPDATE=ghost\nEOF\n\${CLI} deploy S\n`,
+    );
+    expect(steps.map((x) => x.modes)).toEqual([[]]);
+  });
+
   it('ignores non-deploy invocations', () => {
     const steps = parseDeploySteps(
       `${CLI_HEADER}CDKD_TEST_UPDATE=a \${CLI} destroy S --force\nCDKD_TEST_UPDATE=b \${CLI} deploy S\n`,
@@ -386,6 +438,48 @@ describe('the real fixture tree', () => {
     expect(withGates.flat().length).toBeGreaterThanOrEqual(8);
   });
 
+  it('resolves a real, non-trivial number of mode lists — per SHAPE, not just a total', () => {
+    // The aggregate step count is NOT a floor for this: the column-0 anchor bug
+    // left all 353 steps parsed and only emptied their mode lists, so the total
+    // stayed green while the one real finding vanished. What has to be fenced
+    // is the number of steps whose mode list actually RESOLVED to something.
+    const resolved = readdirSync(INTEG_ROOT, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && existsSync(join(INTEG_ROOT, e.name, 'verify.sh')))
+      .flatMap((e) => parseDeploySteps(readFileSync(join(INTEG_ROOT, e.name, 'verify.sh'), 'utf8')));
+    const nonEmpty = resolved.filter((s) => s.modes !== null && s.modes.length > 0);
+    expect(nonEmpty.length, 'no deploy carries a resolved mode list — parser regression?')
+      .toBeGreaterThanOrEqual(60);
+    // And at least one must come from the monotonic-suffix idiom, the shape a
+    // `$`-give-up parser silently turns into `unresolvable`.
+    expect(nonEmpty.some((s) => s.modes!.includes('cross-region-ondemand-dropped'))).toBe(true);
+  });
+
+  it('collects every gate KIND the classifier claims to produce', () => {
+    const kinds = new Set(
+      readdirSync(INTEG_ROOT, { withFileTypes: true })
+        .filter((e) => e.isDirectory() && existsSync(join(INTEG_ROOT, e.name, 'verify.sh')))
+        .flatMap((e) =>
+          fixtureStackFiles(join(INTEG_ROOT, e.name)).flatMap((rel) =>
+            collectModeGates(readFileSync(join(INTEG_ROOT, e.name, rel), 'utf8'), rel),
+          ),
+        )
+        .map((g) => g.kind),
+    );
+    // An aggregate `>= 8` survives losing a whole shape; this does not.
+    expect([...kinds].sort()).toEqual(['construct', 'property', 'resource-list']);
+  });
+
+  it('pins the NON-blocking findings so the visibility-only bucket cannot rot', () => {
+    // Nothing prints these today, so without a pin they are unobservable — and
+    // an inconclusive gate silently becoming zero would look like progress.
+    const notes = violations.filter((v) => !v.blocking);
+    expect(notes.length).toBeGreaterThanOrEqual(5);
+    expect(
+      notes.some((v) => v.kind === 'inconclusive-gate' && v.gateKind === 'resource-list'),
+      'the #1512 replica gate must stay VISIBLE as inconclusive, never silently dropped',
+    ).toBe(true);
+  });
+
   it('parses a plausible number of deploy steps across the tree', () => {
     const total = readdirSync(INTEG_ROOT, { withFileTypes: true })
       .filter((e) => e.isDirectory() && existsSync(join(INTEG_ROOT, e.name, 'verify.sh')))
@@ -446,6 +540,37 @@ describe('real-code probes against the dynamodb-globaltable fixture', () => {
       `${verify}\nunset CDKD_TEST_UPDATE\n\${CLI} deploy "\${STACK}"\n`,
     );
     expect(v.some((x) => x.message.includes('ttl'))).toBe(true);
+  });
+});
+
+describe('real-code probes for the remaining blocking verdicts', () => {
+  const FIXTURE2 = join(INTEG_ROOT, 'dynamodb-globaltable');
+  const STACK_REL2 = 'lib/dynamodb-globaltable-stack.ts';
+  const stack2 = readFileSync(join(FIXTURE2, STACK_REL2), 'utf8');
+  const verify2 = readFileSync(join(FIXTURE2, 'verify.sh'), 'utf8');
+
+  it('unreasoned-allow: blanking the REAL annotation reason blocks', () => {
+    const blanked = stack2.replace(/allow-mode-gated-drop:.*$/m, 'allow-mode-gated-drop:');
+    expect(blanked).not.toBe(stack2);
+    const v = lintFixture('dynamodb-globaltable', STACK_REL2, blanked, verify2);
+    const found = v.find((x) => x.kind === 'unreasoned-allow');
+    expect(found, 'a reasonless marker must be refused').toBeDefined();
+    expect(found!.blocking).toBe(true);
+  });
+
+  it('unresolvable-mode-list: a command substitution in the REAL verify.sh blocks', () => {
+    // The LATER assignment, not the empty seed: the seed is re-set to a
+    // literal further down, so wrecking it leaves every USE resolvable and the
+    // probe proves nothing.
+    const wrecked = verify2.replace(
+      /OD_MODE_SUFFIX=",cross-region-ondemand-dropped"/,
+      'OD_MODE_SUFFIX=$(echo ,cross-region-ondemand-dropped)',
+    );
+    expect(wrecked).not.toBe(verify2);
+    const v = lintFixture('dynamodb-globaltable', STACK_REL2, stack2, wrecked);
+    const found = v.find((x) => x.kind === 'unresolvable-mode-list');
+    expect(found, 'an unresolvable mode list must fail loudly').toBeDefined();
+    expect(found!.blocking).toBe(true);
   });
 });
 

--- a/tests/unit/scripts/integ-mode-gated-resources.test.ts
+++ b/tests/unit/scripts/integ-mode-gated-resources.test.ts
@@ -1,0 +1,497 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync, readdirSync, existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  collectModeGates,
+  parseDeploySteps,
+  evaluateCond,
+  tokensOf,
+  lintFixture,
+  lintFixtureTree,
+  fixtureStackFiles,
+  formatViolation,
+  type Cond,
+} from '../../../scripts/check-integ-mode-gated-resources.js';
+
+/**
+ * Regression guard for issue #1543 — the integ-fixture mode-gating trap. See
+ * `scripts/check-integ-mode-gated-resources.ts` for why gating a NEW resource
+ * on a NEW token is wrong whenever a later deploy's mode list omits it.
+ */
+
+const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
+
+/**
+ * Fixtures whose stack / verify.sh is owned by an in-flight PR, so the sweep
+ * does not demand the `allow-mode-gated-drop:` annotation there yet — adding
+ * one would collide on rebase. Each entry is asserted BELOW to still be
+ * violating, so the exception self-expires: once the owning PR lands and the
+ * annotation goes in, this test fails and forces the entry's deletion rather
+ * than letting it linger. Same mechanism as `PENDING_OTHER_PR` in
+ * `integ-verify-signal-traps.test.ts`.
+ */
+const PENDING_OTHER_PR: Record<string, string> = {
+  'dynamodb-globaltable':
+    'PR #1550 (issue #1512) owns both dynamodb-globaltable-stack.ts and verify.sh. ' +
+    'The finding is the step-12d replica removal, which IS deliberate — it needs an ' +
+    '`allow-mode-gated-drop:` comment on the `replicas` gate, added once #1550 lands.',
+};
+
+// ---------------------------------------------------------------------------
+// verify.sh parsing
+// ---------------------------------------------------------------------------
+
+const CLI_HEADER = 'CLI="node ../../dist/cli.js"\n';
+
+describe('parseDeploySteps', () => {
+  it('reads the inline env prefix, in order', () => {
+    const steps = parseDeploySteps(
+      `${CLI_HEADER}` +
+        `CDKD_TEST_UPDATE=a \${CLI} deploy S\n` +
+        `CDKD_TEST_UPDATE=a,b \${CLI} deploy S\n`,
+    );
+    expect(steps.map((s) => s.modes)).toEqual([['a'], ['a', 'b']]);
+  });
+
+  it('reads an INDENTED invocation inside an if block', () => {
+    // The bug this pins was live in the first draft of the classifier: an
+    // anchor demanding column 0 read every `if`-nested deploy as unmoded, which
+    // muted the opt-in multi-region block where the real finding lives.
+    const steps = parseDeploySteps(
+      `${CLI_HEADER}if [ "\${X:-0}" = "1" ]; then\n` +
+        `  CDKD_TEST_UPDATE=cross-region \${CLI} deploy S\n` +
+        `  CDKD_TEST_UPDATE=base \${CLI} deploy S\n` +
+        `fi\n`,
+    );
+    expect(steps.map((s) => s.modes)).toEqual([['cross-region'], ['base']]);
+  });
+
+  it('treats an unprefixed deploy as carrying the AMBIENT value', () => {
+    const steps = parseDeploySteps(
+      `${CLI_HEADER}export CDKD_TEST_UPDATE=a,b\n\${CLI} deploy S\nunset CDKD_TEST_UPDATE\n\${CLI} deploy S\n`,
+    );
+    expect(steps.map((s) => s.modes)).toEqual([
+      ['a', 'b'],
+      [],
+    ]);
+  });
+
+  it('defaults to an empty mode list before any assignment', () => {
+    expect(parseDeploySteps(`${CLI_HEADER}\${CLI} deploy S\n`)[0]?.modes).toEqual([]);
+  });
+
+  it('reports a shell-variable mode list as unresolvable rather than empty', () => {
+    const steps = parseDeploySteps(`${CLI_HEADER}CDKD_TEST_UPDATE="\${MODES}" \${CLI} deploy S\n`);
+    expect(steps[0]?.modes).toBeNull();
+  });
+
+  it('ignores non-deploy invocations', () => {
+    const steps = parseDeploySteps(
+      `${CLI_HEADER}CDKD_TEST_UPDATE=a \${CLI} destroy S --force\nCDKD_TEST_UPDATE=b \${CLI} deploy S\n`,
+    );
+    expect(steps.map((s) => s.modes)).toEqual([['b']]);
+  });
+
+  it('does not read a mode list out of a comment', () => {
+    const steps = parseDeploySteps(
+      `${CLI_HEADER}# CDKD_TEST_UPDATE=ghost \${CLI} deploy S\nCDKD_TEST_UPDATE=real \${CLI} deploy S\n`,
+    );
+    expect(steps.map((s) => s.modes)).toEqual([['real']]);
+  });
+
+  it('handles a `\\`-continued invocation', () => {
+    const steps = parseDeploySteps(
+      `${CLI_HEADER}CDKD_TEST_UPDATE=a,b \${CLI} deploy S \\\n  --state-bucket B --verbose\n`,
+    );
+    expect(steps.map((s) => s.modes)).toEqual([['a', 'b']]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stack parsing
+// ---------------------------------------------------------------------------
+
+const STACK_HEADER = `const updateMode = (process.env.CDKD_TEST_UPDATE ?? '').split(',').map((s) => s.trim());\n`;
+
+const gatesOf = (body: string) => collectModeGates(STACK_HEADER + body, 'stack.ts');
+
+describe('collectModeGates', () => {
+  it('records a spread-gated property', () => {
+    const gates = gatesOf(`const p = { ...(updateMode.includes('ttl') && { ttl: 'x' }) };`);
+    expect(gates).toHaveLength(1);
+    expect(gates[0]!.kind).toBe('property');
+    expect(tokensOf(gates[0]!.cond)).toEqual(['ttl']);
+  });
+
+  it('records a spread-gated resource LIST as resource-list, not property', () => {
+    // The #1512 shape. It contains no `new`, so a construct-only heuristic
+    // would have classified the exact motivating case as a harmless property.
+    const gates = gatesOf(
+      `const p = { ...(updateMode.includes('cross-region') && { replicas: [{ region: 'eu-west-1' }] }) };`,
+    );
+    expect(gates[0]!.kind).toBe('resource-list');
+  });
+
+  it('records an if-gated construct', () => {
+    const gates = gatesOf(
+      `if (updateMode.includes('extra')) { const q = new sqs.Queue(this, 'Q'); }`,
+    );
+    expect(gates[0]!.kind).toBe('construct');
+  });
+
+  it('resolves a condition through an intermediate const binding', () => {
+    const gates = gatesOf(
+      `const wants = updateMode.includes('cross-region');\n` +
+        `const p = { ...(wants && { replicas: [{ region: 'eu-west-1' }] }) };`,
+    );
+    expect(tokensOf(gates[0]!.cond)).toEqual(['cross-region']);
+  });
+
+  it('unions an OR across bindings, so a sibling token still holds the gate', () => {
+    // `useProvisioned = useAutoScaling || includes('billing-provisioned')` is
+    // real code; a per-TOKEN rule reports a drop at a step where `autoscaling`
+    // still holds the declaration in the template.
+    const gates = gatesOf(
+      `const auto = updateMode.includes('autoscaling');\n` +
+        `const prov = auto || updateMode.includes('billing-provisioned');\n` +
+        `const p = { ...(prov && { billing: 'PROVISIONED' }) };`,
+    );
+    expect(tokensOf(gates[0]!.cond).sort()).toEqual(['autoscaling', 'billing-provisioned']);
+  });
+
+  it('records only the TRUTHY arm of a ternary', () => {
+    const gates = gatesOf(`const p = { r: updateMode.includes('x') ? [{ a: 1 }] : [] };`);
+    expect(gates).toHaveLength(1);
+    expect(gates[0]!.kind).toBe('resource-list');
+  });
+
+  it('skips a gate whose truthy arm is EMPTY (the `drop-*` idiom)', () => {
+    // `...(includes('drop-x') ? {} : { limit })` — the token removes rather
+    // than adds, which is a deliberate removal test by construction.
+    expect(gatesOf(`const p = { ...(updateMode.includes('drop-x') ? {} : { limit: 100 }) };`)).toEqual(
+      [],
+    );
+  });
+
+  it('ignores the BOOLEAN `=== true` spelling, which has no token list', () => {
+    const gates = collectModeGates(
+      `const updateMode = process.env.CDKD_TEST_UPDATE === 'true';\n` +
+        `const p = { ...(updateMode && { a: 1 }) };`,
+      'stack.ts',
+    );
+    expect(gates).toEqual([]);
+  });
+
+  it('finds the mode binding by its initializer, not by the name `updateMode`', () => {
+    const gates = collectModeGates(
+      `const phases = (process.env.CDKD_TEST_UPDATE ?? '').split(',');\n` +
+        `const p = { ...(phases.includes('x') && { a: 1 }) };`,
+      'stack.ts',
+    );
+    expect(tokensOf(gates[0]!.cond)).toEqual(['x']);
+  });
+
+  it('does not treat an unrelated array `.includes` as a gate', () => {
+    expect(gatesOf(`const p = { ...(['a'].includes('a') && { x: 1 }) };`)).toEqual([]);
+  });
+
+  it('reads the allow marker from a comment above the statement', () => {
+    const gates = gatesOf(
+      `// allow-mode-gated-drop: step 12d removes the replica on purpose\n` +
+        `const p = { ...(updateMode.includes('cross-region') && { replicas: [{ region: 'x' }] }) };`,
+    );
+    expect(gates[0]!.allowReason).toBe('step 12d removes the replica on purpose');
+  });
+
+  it('reports a bare marker with no reason as empty, not as absent', () => {
+    const gates = gatesOf(
+      `// allow-mode-gated-drop:\n` +
+        `const p = { ...(updateMode.includes('x') && { replicas: [{ region: 'y' }] }) };`,
+    );
+    expect(gates[0]!.allowReason).toBe('');
+  });
+
+  it('keeps a mode-derived gate whose TOKEN is unreadable, as unknown-token', () => {
+    // `unknown-token` must stay distinct from `unknown`: collapsing the two
+    // made `isModeDerived` false and the gate vanished from the analysis
+    // entirely — a silent skip rather than the `inconclusive-gate` note.
+    const gates = gatesOf(
+      `const p = { ...(updateMode.includes(SOME_CONST) && { replicas: [{ region: 'x' }] }) };`,
+    );
+    expect(gates).toHaveLength(1);
+    expect(gates[0]!.cond).toEqual<Cond>({ t: 'unknown-token' });
+  });
+
+  it('does NOT record a gate whose condition never reads the mode list', () => {
+    expect(gatesOf(`const p = { ...(process.env.OTHER === '1' && { replicas: [{ r: 1 }] }) };`)).toEqual(
+      [],
+    );
+  });
+});
+
+describe('evaluateCond', () => {
+  const token = (t: string): Cond => ({ t: 'token', token: t });
+
+  it('settles an AND on a definite false even beside an unknown leaf', () => {
+    expect(evaluateCond({ t: 'and', l: token('a'), r: { t: 'unknown' } }, [])).toBe(false);
+  });
+
+  it('settles an OR on a definite true even beside an unknown leaf', () => {
+    expect(evaluateCond({ t: 'or', l: token('a'), r: { t: 'unknown' } }, ['a'])).toBe(true);
+  });
+
+  it('returns null when nothing settles it', () => {
+    expect(evaluateCond({ t: 'and', l: token('a'), r: { t: 'unknown' } }, ['a'])).toBeNull();
+  });
+
+  it('handles negation', () => {
+    expect(evaluateCond({ t: 'not', e: token('a') }, [])).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Verdict
+// ---------------------------------------------------------------------------
+
+const REPLICA_GATE = `const p = { ...(updateMode.includes('cross-region') && { replicas: [{ region: 'eu-west-1' }] }) };`;
+
+describe('lintFixture', () => {
+  it('flags a resource gated on a token a LATER deploy omits', () => {
+    const v = lintFixture(
+      'f',
+      'lib/s.ts',
+      STACK_HEADER + REPLICA_GATE,
+      `${CLI_HEADER}CDKD_TEST_UPDATE=cross-region \${CLI} deploy S\nCDKD_TEST_UPDATE=base \${CLI} deploy S\n`,
+    );
+    expect(v).toHaveLength(1);
+    expect(v[0]!.kind).toBe('dropped-mid-run');
+    expect(v[0]!.blocking).toBe(true);
+    expect(v[0]!.message).toContain('24h source-region delete lock');
+  });
+
+  it('flags a GAP between two carrying deploys, not only a trailing drop', () => {
+    // The issue's stated rule ("a deploy after the LAST carrying one") misses
+    // this, and it is strictly worse: the resource is deleted and re-created.
+    const v = lintFixture(
+      'f',
+      'lib/s.ts',
+      STACK_HEADER + REPLICA_GATE,
+      `${CLI_HEADER}CDKD_TEST_UPDATE=cross-region \${CLI} deploy S\n` +
+        `CDKD_TEST_UPDATE=base \${CLI} deploy S\n` +
+        `CDKD_TEST_UPDATE=cross-region \${CLI} deploy S\n`,
+    );
+    expect(v).toHaveLength(1);
+  });
+
+  it('does NOT flag a token that is only ever added and carried forward', () => {
+    const v = lintFixture(
+      'f',
+      'lib/s.ts',
+      STACK_HEADER + REPLICA_GATE,
+      `${CLI_HEADER}\${CLI} deploy S\n` +
+        `CDKD_TEST_UPDATE=cross-region \${CLI} deploy S\n` +
+        `CDKD_TEST_UPDATE=cross-region,more \${CLI} deploy S\n`,
+    );
+    expect(v).toEqual([]);
+  });
+
+  it('does NOT flag a declaration a SIBLING token still enables', () => {
+    const v = lintFixture(
+      'f',
+      'lib/s.ts',
+      STACK_HEADER +
+        `const auto = updateMode.includes('autoscaling');\n` +
+        `const prov = auto || updateMode.includes('billing-provisioned');\n` +
+        `const p = { ...(prov && { replicas: [{ region: 'x' }] }) };`,
+      `${CLI_HEADER}CDKD_TEST_UPDATE=billing-provisioned \${CLI} deploy S\n` +
+        `CDKD_TEST_UPDATE=autoscaling \${CLI} deploy S\n`,
+    );
+    expect(v).toEqual([]);
+  });
+
+  it('reports a property drop as NON-blocking', () => {
+    const v = lintFixture(
+      'f',
+      'lib/s.ts',
+      STACK_HEADER + `const p = { ...(updateMode.includes('dp') && { deletionProtection: true }) };`,
+      `${CLI_HEADER}CDKD_TEST_UPDATE=dp \${CLI} deploy S\n\${CLI} deploy S\n`,
+    );
+    expect(v).toHaveLength(1);
+    expect(v[0]!.blocking).toBe(false);
+    expect(v[0]!.gateKind).toBe('property');
+  });
+
+  it('silences a drop carrying an allow-mode-gated-drop reason', () => {
+    const v = lintFixture(
+      'f',
+      'lib/s.ts',
+      `${STACK_HEADER}// allow-mode-gated-drop: the removal IS the test\n${REPLICA_GATE}`,
+      `${CLI_HEADER}CDKD_TEST_UPDATE=cross-region \${CLI} deploy S\n\${CLI} deploy S\n`,
+    );
+    expect(v).toEqual([]);
+  });
+
+  it('rejects an allow marker with no reason', () => {
+    const v = lintFixture(
+      'f',
+      'lib/s.ts',
+      `${STACK_HEADER}// allow-mode-gated-drop:\n${REPLICA_GATE}`,
+      `${CLI_HEADER}CDKD_TEST_UPDATE=cross-region \${CLI} deploy S\n\${CLI} deploy S\n`,
+    );
+    expect(v.map((x) => x.kind)).toContain('unreasoned-allow');
+    expect(v.find((x) => x.kind === 'unreasoned-allow')!.blocking).toBe(true);
+  });
+
+  it('fails LOUDLY on an unresolvable mode list instead of passing vacuously', () => {
+    const v = lintFixture(
+      'f',
+      'lib/s.ts',
+      STACK_HEADER + REPLICA_GATE,
+      `${CLI_HEADER}CDKD_TEST_UPDATE="\${MODES}" \${CLI} deploy S\n\${CLI} deploy S\n`,
+    );
+    expect(v).toHaveLength(1);
+    expect(v[0]!.kind).toBe('unresolvable-mode-list');
+    expect(v[0]!.blocking).toBe(true);
+  });
+
+  it('surfaces an inconclusive gate rather than skipping it silently', () => {
+    const v = lintFixture(
+      'f',
+      'lib/s.ts',
+      STACK_HEADER + `const p = { ...(updateMode.includes(K) && { replicas: [{ region: 'x' }] }) };`,
+      `${CLI_HEADER}\${CLI} deploy S\n`,
+    );
+    expect(v.map((x) => x.kind)).toEqual(['inconclusive-gate']);
+    expect(v[0]!.blocking).toBe(false);
+  });
+
+  it('says nothing about a fixture with no mode gates at all', () => {
+    expect(
+      lintFixture('f', 'lib/s.ts', `const q = new sqs.Queue(this, 'Q');`, `${CLI_HEADER}\${CLI} deploy S\n`),
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-tree sweep + parser floors
+// ---------------------------------------------------------------------------
+
+describe('the real fixture tree', () => {
+  const violations = lintFixtureTree(INTEG_ROOT);
+
+  it('has no un-annotated mode-gated resource drop', () => {
+    const blocking = violations.filter((v) => v.blocking && !(v.fixture in PENDING_OTHER_PR));
+    expect(blocking.map(formatViolation)).toEqual([]);
+  });
+
+  for (const [fixture, why] of Object.entries(PENDING_OTHER_PR)) {
+    it(`self-expiring exception: ${fixture} still violates (${why.slice(0, 40)}...)`, () => {
+      // When the owning PR lands and the annotation goes in, this fails and
+      // forces the entry's deletion — the exception cannot linger silently.
+      expect(violations.some((v) => v.fixture === fixture && v.blocking)).toBe(true);
+    });
+  }
+
+  it('parses at least one fixture that actually uses the token-list form', () => {
+    // A coverage floor, not decoration: every classifier half can regress to
+    // "found nothing", and a tree-wide green is indistinguishable from a
+    // silent parse failure without it. Only `dynamodb-globaltable` uses the
+    // token-list spelling today; the other three `CDKD_TEST_UPDATE` fixtures
+    // use the boolean `=== 'true'` form, which carries no token to drop.
+    const withGates = readdirSync(INTEG_ROOT, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && existsSync(join(INTEG_ROOT, e.name, 'verify.sh')))
+      .flatMap((e) =>
+        fixtureStackFiles(join(INTEG_ROOT, e.name)).map((rel) =>
+          collectModeGates(readFileSync(join(INTEG_ROOT, e.name, rel), 'utf8'), rel),
+        ),
+      )
+      .filter((g) => g.length > 0);
+    expect(withGates.length).toBeGreaterThanOrEqual(1);
+    expect(withGates.flat().length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('parses a plausible number of deploy steps across the tree', () => {
+    const total = readdirSync(INTEG_ROOT, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && existsSync(join(INTEG_ROOT, e.name, 'verify.sh')))
+      .reduce(
+        (n, e) => n + parseDeploySteps(readFileSync(join(INTEG_ROOT, e.name, 'verify.sh'), 'utf8')).length,
+        0,
+      );
+    expect(total).toBeGreaterThanOrEqual(200);
+  });
+
+  it('resolves every mode list in the tree (no unresolvable-mode-list today)', () => {
+    expect(violations.filter((v) => v.kind === 'unresolvable-mode-list')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REAL-CODE fail probes — the classifier must catch the bug in the real
+// fixture, not only in synthetic shapes it was written against.
+// ---------------------------------------------------------------------------
+
+describe('real-code probes against the dynamodb-globaltable fixture', () => {
+  const FIXTURE = join(INTEG_ROOT, 'dynamodb-globaltable');
+  const STACK_REL = 'lib/dynamodb-globaltable-stack.ts';
+  const stack = readFileSync(join(FIXTURE, STACK_REL), 'utf8');
+  const verify = readFileSync(join(FIXTURE, 'verify.sh'), 'utf8');
+
+  it('flags the real cross-region replica gate against the real verify.sh', () => {
+    const v = lintFixture('dynamodb-globaltable', STACK_REL, stack, verify);
+    const replica = v.find((x) => x.blocking && x.gateKind === 'resource-list');
+    expect(replica, 'the real replica drop was not detected').toBeDefined();
+    expect(replica!.message).toContain('cross-region');
+    expect(replica!.message).toContain('24h source-region delete lock');
+  });
+
+  it('goes quiet once the real gate carries the annotation', () => {
+    const annotated = stack.replace(
+      /(\n\s*)(\.\.\.\(wantsCrossRegion && \{)/,
+      '$1// allow-mode-gated-drop: step 12d removes the replica on purpose$1$2',
+    );
+    expect(annotated, 'the annotation probe did not apply').not.toBe(stack);
+    const v = lintFixture('dynamodb-globaltable', STACK_REL, annotated, verify);
+    expect(v.filter((x) => x.blocking)).toEqual([]);
+  });
+
+  it('flags the real ttl property gate once a later real step drops it', () => {
+    // `ttl` is carried forward to the end today, so it is clean. Truncating
+    // verify.sh after a `ttl`-carrying deploy and appending an unmoded one
+    // reproduces the drop against unmodified fixture SOURCE.
+    const v = lintFixture(
+      'dynamodb-globaltable',
+      STACK_REL,
+      stack,
+      `${verify}\nunset CDKD_TEST_UPDATE\n\${CLI} deploy "\${STACK}"\n`,
+    );
+    expect(v.some((x) => x.message.includes('ttl'))).toBe(true);
+  });
+});
+
+describe('lintFixtureTree over a scratch copy', () => {
+  it('detects an injected mode-gated resource drop in a real-shaped fixture', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'cdkd-1543-'));
+    try {
+      const fixture = join(dir, 'scratch-fixture');
+      mkdirSync(join(fixture, 'lib'), { recursive: true });
+      writeFileSync(
+        join(fixture, 'verify.sh'),
+        `${CLI_HEADER}CDKD_TEST_UPDATE=extra \${CLI} deploy S\n\${CLI} deploy S\n`,
+      );
+      writeFileSync(
+        join(fixture, 'lib', 'scratch-stack.ts'),
+        `${STACK_HEADER}if (updateMode.includes('extra')) { const t = new ddb.Table(this, 'T'); }`,
+      );
+
+      const v = lintFixtureTree(dir);
+      expect(v).toHaveLength(1);
+      expect(v[0]!.fixture).toBe('scratch-fixture');
+      expect(v[0]!.file).toBe(join('lib', 'scratch-stack.ts'));
+      expect(v[0]!.blocking).toBe(true);
+      expect(formatViolation(v[0]!)).toContain('[ERROR]');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1543. Mechanically enforces the mode-gating trap `.claude/rules/testing.md` documents: a fixture resource gated on a `CDKD_TEST_UPDATE` token DISAPPEARS in every later step whose mode list omits it, and cdkd correctly issues a DELETE for it. Found by hand during (#1512), before the run reached it — the fixture comments, the commit message and the issue comment had all already claimed the design "only ever ADDs".

`scripts/check-integ-mode-gated-resources.ts` extracts both halves statically: the ORDERED per-deploy mode lists from `verify.sh` (reusing the `check-integ-cli-flags` invocation primitives, plus the ambient `export` / `unset` forms and the monotonic-suffix `${VAR}` idiom the rules file prescribes), and the CONDITION behind each gated declaration in the fixture stack via the TS Compiler API.

## Three deviations from the issue, each deliberate

- **Per DECLARATION, not per token.** `useProvisioned = useAutoScaling || updateMode.includes('billing-provisioned')` gates one declaration on two tokens, so a per-token rule reports a drop at a step where the sibling token still holds it in the template. Each gate carries an evaluable condition tree instead.
- **Only CREATE-shaped gates block** (a construct, or an entry in a resource list such as `replicas: [...]`). A scalar property gate is reported non-blocking: flipping a property back off is an ordinary in-place update test, and `dynamodb-globaltable` does exactly that at its structural-teardown step.
- **Widened** from the issue's "a deploy after the LAST carrying one" to "present at step i, absent at step j > i" — a GAP between two carrying deploys is the same bug and strictly worse.

## What the reviews changed

A 3-axis review found three blockers, all reproduced against real fixtures:

1. The inline env prefix was only seen when `CDKD_TEST_UPDATE=` was the FIRST token of the segment. `CDKD_TEST_REMOVAL=true CDKD_TEST_UPDATE=alpha ${CLI} deploy` and `env -u OTHER CDKD_TEST_UPDATE=alpha ${CLI} deploy` both exist in the tree and parsed as UNMODED — a CI-BLOCKING false positive on a correct fixture, not a miss.
2. `${VAR:-default}` / `$1` were left in the string as literal text, so `alpha${SUF:-}` made token `alpha` read absent and produced a false `dropped-mid-run`.
3. **The #1512 declaration this lint was written for was invisible to it.** Its gate is `wantsOnDemandReplica = onDemandReplicaMode !== 'none'`, a `!==` over a mode-derived string, which the reducer turned into `null` — so the gate left the analysis entirely, with no `inconclusive-gate` either. It now reports as inconclusive rather than vanishing.

That is twice in one PR that measuring against the REAL fixture — rather than the synthetic shapes the classifier was written against — found the parser silently normalizing its input into a benign shape while still reporting the harmless findings. The earlier instance (a column-0 anchor that read every `if`-indented deploy as unmoded) is fixed here too.

## Real-tree result

0 blocking, 8 non-blocking notes. The deliberate step-12d replica removal in `dynamodb-globaltable` carries `// allow-mode-gated-drop: <reason>`; the reason is mandatory and a bare marker is rejected.

## Test plan

54 unit tests: table tests per parsed shape (inline prefix in any position, indented-in-`if`, ambient `export`/`unset`, `\`-continuation, heredoc bodies, comments, the monotonic-suffix idiom, `${VAR:-}`, command substitution), per gate shape, and per verdict.

Floors are **per SHAPE**, per the repo rule — the aggregate step count could not fence the column-0 bug (it left all 353 steps parsed and only emptied their mode lists), so the floor is on steps whose mode list actually RESOLVED, plus one on the gate-kind set, plus a pin on the non-blocking findings so the visibility-only bucket cannot rot.

All three CI-blocking verdicts have REAL-CODE probes against the real fixture: stripping the annotation must produce the blocking finding (and the fixture must be clean as shipped), blanking the annotation's reason must be refused, and wrecking the real `OD_MODE_SUFFIX` assignment must fail loudly.

Four measured bounds are recorded in the script header rather than left implicit.
