### PR TITLE
chore(skills): move the local-execution section below the deploy lifecycle (v0.2.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Skill for using cdkd (CDK Direct) safely from AI coding agents",
-    "version": "0.2.0"
+    "version": "0.2.1"
   },
   "plugins": [
     {
       "name": "cdkd-skills",
       "source": "./plugins/cdkd-skills",
       "description": "Deploy AWS CDK apps safely with cdkd: install, bootstrap, preview, deploy, verify, and destroy dev/test stacks with explicit safety boundaries.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "go-to-k",
         "url": "https://github.com/go-to-k"

--- a/plugins/cdkd-skills/.claude-plugin/plugin.json
+++ b/plugins/cdkd-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "cdkd-skills",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Deploy AWS CDK apps safely with cdkd (CDK Direct). Guides AI coding agents through installing cdkd and bootstrapping, previewing, deploying, verifying, and destroying dev/test stacks with explicit safety boundaries.",
   "author": {
     "name": "go-to-k",

--- a/plugins/cdkd-skills/skills/cdkd/SKILL.md
+++ b/plugins/cdkd-skills/skills/cdkd/SKILL.md
@@ -34,19 +34,6 @@ cdkd --version
 
 Do not silently upgrade an existing installation during an unrelated deployment.
 
-## Run workloads locally (no AWS needed)
-
-`cdkd local *` runs Lambda functions, API Gateway APIs, ECS tasks and services, ALBs, CloudFront distributions, and Bedrock AgentCore runtimes on the developer's machine via Docker — no AWS deploy and no AWS credentials involved, so the deployment-boundary steps below do not apply to these commands:
-
-```bash
-cdkd local invoke <function>       # one-shot Lambda invoke
-cdkd local start-api               # long-running local API Gateway
-cdkd local run-task <task>         # one-shot ECS task
-cdkd local start-service <service> # long-running ECS service emulator
-```
-
-Most `cdkd local` commands require Docker, and the first run pulls base images (up to ~600 MB). See the [local execution guide](https://github.com/go-to-k/cdkd/blob/main/docs/local-emulation.md) for the full subcommand list (ALB, CloudFront, AgentCore) and flags.
-
 ## Establish the deployment boundary
 
 Before any AWS-changing command:
@@ -187,6 +174,19 @@ Before `destroy`, `state destroy`, `orphan`, `import`, `export`, `drift --accept
 4. Obtain explicit user confirmation immediately before execution.
 
 Do not use `--force`, `--yes`, `--purge-events`, or other confirmation-bypassing flags unless the user approved that exact destructive scope.
+
+## Run workloads locally (no AWS needed)
+
+`cdkd local *` runs Lambda functions, API Gateway APIs, ECS tasks and services, ALBs, CloudFront distributions, and Bedrock AgentCore runtimes on the developer's machine via Docker — no AWS deploy and no AWS credentials involved, so the deployment-boundary steps above do not apply to these commands:
+
+```bash
+cdkd local invoke <function>       # one-shot Lambda invoke
+cdkd local start-api               # long-running local API Gateway
+cdkd local run-task <task>         # one-shot ECS task
+cdkd local start-service <service> # long-running ECS service emulator
+```
+
+Most `cdkd local` commands require Docker, and the first run pulls base images (up to ~600 MB). See the [local execution guide](https://github.com/go-to-k/cdkd/blob/main/docs/local-emulation.md) for the full subcommand list (ALB, CloudFront, AgentCore) and flags.
 
 ## Command reference
 


### PR DESCRIPTION
## Summary

Follow-up to #1561. "Run workloads locally" is an auxiliary capability, not part of the deploy safety spine, so it no longer sits second in the distributed skill — it now follows the destructive-operation guards, just before the command reference. The deploy lifecycle (install → boundary → bootstrap → preview → deploy → verify → drift → gc → guards) reads uninterrupted.

- Section moved; content unchanged except the deployment-boundary cross-reference flips from "below" to "above" to match the new position
- Manifests bumped 0.2.0 → 0.2.1 per the in-file sync-comment rule

## Test plan

- [x] Section order verified (`grep "^## "`): the boundary section now directly follows Install; local sits between the guards and the command reference
- [x] Real `claude --plugin-dir` load: plugin resolves as `cdkd-skills 0.2.1`
- [x] Content-only move — no gate-scoped files touched; no Japanese characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011trUkZrAk6YishwMLrv6Kv

---
_Generated by [Claude Code](https://claude.ai/code/session_011trUkZrAk6YishwMLrv6Kv)_