### PR TITLE
test(integ): pass --state-bucket on every fixture state destroy, and lint it

### DIFF
--- a/.claude/hooks/state-destroy-force-gate.sh
+++ b/.claude/hooks/state-destroy-force-gate.sh
@@ -132,10 +132,17 @@ for rel in $staged_files; do
     # comment is documenting the bug, not exercising it.
     [[ "$trimmed" == \#* ]] && continue
 
-    # Anchor on `state destroy` (cdkd subcommand) AND `--force`.
-    # Use grep with extended regex to be tolerant of varying whitespace.
+    # Anchor on `state destroy` (cdkd subcommand) and require the flag to
+    # come AFTER it — testing both halves against the WHOLE line matches a
+    # bash file test that merely precedes the invocation, e.g.
+    #   [ -f "${LOCAL_DIST}" ] && node ... state destroy ... --yes
+    # which is correct code (14 fixtures use the `-x` spelling of it). That
+    # false positive blocked the #1567 sweep the moment it touched such a
+    # line. The header comment already described the intended semantics as
+    # "`state destroy` FOLLOWED BY `--force`"; only the check lagged.
+    tail_after_destroy=$(printf '%s' "$line" | sed -E 's/^.*state[[:space:]]+destroy//')
     if printf '%s' "$line" | grep -qE 'state[[:space:]]+destroy\b' \
-       && printf '%s' "$line" | grep -qE '(\-\-force\b|[[:space:]]\-f\b)'; then
+       && printf '%s' "$tail_after_destroy" | grep -qE '(\-\-force\b|[[:space:]]\-f\b)'; then
       OFFENDERS+=("$rel: $trimmed")
       [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]] && break 2
     fi

--- a/.claude/hooks/state-destroy-force-gate.sh
+++ b/.claude/hooks/state-destroy-force-gate.sh
@@ -132,17 +132,21 @@ for rel in $staged_files; do
     # comment is documenting the bug, not exercising it.
     [[ "$trimmed" == \#* ]] && continue
 
-    # Anchor on `state destroy` (cdkd subcommand) and require the flag to
-    # come AFTER it — testing both halves against the WHOLE line matches a
-    # bash file test that merely precedes the invocation, e.g.
+    # ONE regex, ordered: `state destroy` FOLLOWED BY the flag. Testing the
+    # two halves independently against the whole line matched a bash file
+    # test that merely PRECEDES the invocation, e.g.
     #   [ -f "${LOCAL_DIST}" ] && node ... state destroy ... --yes
-    # which is correct code (14 fixtures use the `-x` spelling of it). That
-    # false positive blocked the #1567 sweep the moment it touched such a
-    # line. The header comment already described the intended semantics as
-    # "`state destroy` FOLLOWED BY `--force`"; only the check lagged.
-    tail_after_destroy=$(printf '%s' "$line" | sed -E 's/^.*state[[:space:]]+destroy//')
-    if printf '%s' "$line" | grep -qE 'state[[:space:]]+destroy\b' \
-       && printf '%s' "$tail_after_destroy" | grep -qE '(\-\-force\b|[[:space:]]\-f\b)'; then
+    # which is correct code; that false positive blocked the #1567 sweep the
+    # moment it touched such a line. (Only the single `[ -f` site tripped it;
+    # the `-x` spelling its 14 siblings use never did.)
+    #
+    # Ordering must be expressed IN the regex, not by pre-slicing the line
+    # with `sed 's/^.*state destroy//'` — `.*` is greedy, so a line carrying
+    # TWO invocations would slice past the first and miss a `--force` on it.
+    # The header comment already described the intent as "`state destroy`
+    # FOLLOWED BY `--force`"; only the check lagged.
+    if printf '%s' "$line" \
+       | grep -qE 'state[[:space:]]+destroy\b.*(\-\-force\b|[[:space:]]\-f\b)'; then
       OFFENDERS+=("$rel: $trimmed")
       [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]] && break 2
     fi

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -282,11 +282,21 @@ an install/prepend/guard signal is ever read out of an `echo` argument, a
 
 The harness exports `STATE_BUCKET`; the CLI's env fallback is
 `CDKD_STATE_BUCKET` — a DIFFERENT name. A cleanup sweep that omits
-`--state-bucket` therefore never reads the harness bucket at all: it falls
-through to the STS-derived default `cdkd-state-{accountId}` and only appears to
-work because that default is usually the same bucket. Against a non-default
-`STATE_BUCKET` the state sweep silently no-ops — destroys nothing, reports
-success, leaves a state record that wedges the fixture's next run.
+`--state-bucket` therefore never reads the harness bucket at all. Resolution is
+CLI flag > `CDKD_STATE_BUCKET` > `cdk.json` `context.cdkd.stateBucket` > STS
+default (`resolveStateBucketWithSource`), so the omission lands in one of two
+wrong places:
+
+- **109 fixture `cdk.json` files declare `context.cdkd.stateBucket`** and
+  `verify.sh` runs the CLI from the fixture directory, so the sweep resolved
+  that name (`your-cdkd-state-bucket` / `cdkd-state-test`) and died with
+  `StateError: State bucket '...' does not exist` — swallowed by the call's own
+  `>/dev/null 2>&1`. Those cleanups had been failing on EVERY run, invisibly.
+- **The rest** fell through to the STS default `cdkd-state-{accountId}`, which
+  IS the harness bucket on a default setup — working by coincidence, and
+  silently no-opping the moment `STATE_BUCKET` points anywhere else.
+
+Either way the state record survives and wedges the fixture's next run.
 
 ```bash
 node "${LOCAL_DIST}" state destroy "${STACK}" \
@@ -307,7 +317,7 @@ bucket. Do not "normalize" the deploy sites to `:-`.
 
 The measured asymmetry is what made this a lint rather than a one-time sweep
 (issue [#1567](https://github.com/go-to-k/cdkd/issues/1567), 2026-08-11):
-`deploy` passed the flag at all 335 call sites and `destroy` at all 227, while
+`deploy` passed the flag at all 335 call sites and `destroy` at all 228, while
 `state destroy` had drifted at **96 of 171** call sites across 94 fixtures —
 because nothing enforced it. Enforced by
 `tests/unit/scripts/integ-state-bucket.test.ts` (classifier:

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -278,6 +278,43 @@ an install/prepend/guard signal is ever read out of an `echo` argument, a
 `grep` pattern, or a trailing comment. User-facing writeup in
 [docs/testing.md](../../docs/testing.md).
 
+### `verify.sh` `state destroy` must pass `--state-bucket` (mandatory)
+
+The harness exports `STATE_BUCKET`; the CLI's env fallback is
+`CDKD_STATE_BUCKET` — a DIFFERENT name. A cleanup sweep that omits
+`--state-bucket` therefore never reads the harness bucket at all: it falls
+through to the STS-derived default `cdkd-state-{accountId}` and only appears to
+work because that default is usually the same bucket. Against a non-default
+`STATE_BUCKET` the state sweep silently no-ops — destroys nothing, reports
+success, leaves a state record that wedges the fixture's next run.
+
+```bash
+node "${LOCAL_DIST}" state destroy "${STACK}" \
+  --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes
+```
+
+`"${STATE_BUCKET:-}"` not `"${STATE_BUCKET}"`: `cleanup` is trap-installed and
+can run BEFORE the script's own `[ -z "${STATE_BUCKET:-}" ]` guard rejects an
+unset variable, and a cleanup that only does `set +e` (not `set +eu`) aborts
+teardown mid-sweep on the unguarded form. Empty is safe — `resolveStateBucket()`
+treats `''` as not-supplied and falls back exactly as omitting the flag does.
+
+**`deploy` / `destroy` deliberately keep the strict `"${STATE_BUCKET}"` form.**
+The two cases are not the same: in cleanup the guard prevents an abort that
+would skip teardown, whereas on a deploy an unset bucket is a harness
+misconfiguration that must fail loudly rather than silently target the default
+bucket. Do not "normalize" the deploy sites to `:-`.
+
+The measured asymmetry is what made this a lint rather than a one-time sweep
+(issue [#1567](https://github.com/go-to-k/cdkd/issues/1567), 2026-08-11):
+`deploy` passed the flag at all 335 call sites and `destroy` at all 227, while
+`state destroy` had drifted at **96 of 171** call sites across 94 fixtures —
+because nothing enforced it. Enforced by
+`tests/unit/scripts/integ-state-bucket.test.ts` (classifier:
+`scripts/check-integ-state-bucket.ts`), which strips heredocs, comments and
+`echo` arguments so a remediation hint that PRINTS the command is not read as an
+invocation. User-facing writeup in [docs/testing.md](../../docs/testing.md).
+
 ### `verify.sh` list readbacks must be order-insensitive (mandatory)
 
 AWS does not preserve the submitted order of list-valued members on readback.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -857,6 +857,50 @@ sides for the same reason. The same caveat applies too: a list whose order
 carries meaning (DNS resolver lists, preference orders) must NOT be sorted,
 because sorting would hide a real regression rather than reveal one.
 
+### Fixture convention: `state destroy` must pass `--state-bucket`
+
+The harness exports the state bucket as `STATE_BUCKET`, but the CLI's own
+environment fallback is `CDKD_STATE_BUCKET` — a **different** name. So a
+`cleanup()` sweep spelled
+
+```bash
+node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes
+```
+
+never reads the harness's bucket at all. It falls through to the STS-derived
+default `cdkd-state-{accountId}` and only appears to work because that default
+is usually the same bucket. Point `STATE_BUCKET` anywhere else — a per-run
+isolated bucket, a second-account run, the legacy region-suffixed bucket — and
+the state sweep silently no-ops: it destroys nothing, reports success, and only
+the fixture's own tag-based AWS sweeps clean up. The leaked state record then
+wedges the next run of that fixture.
+
+Pass the bucket explicitly, in the `set -u`-safe form:
+
+```bash
+node "${LOCAL_DIST}" state destroy "${STACK}" \
+  --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes
+```
+
+`"${STATE_BUCKET:-}"` rather than `"${STATE_BUCKET}"` is load-bearing: `cleanup`
+is trap-installed, so it can run **before** the script's own
+`if [ -z "${STATE_BUCKET:-}" ]` guard has rejected an unset variable, and a
+cleanup that only does `set +e` (not `set +eu`) would abort teardown mid-sweep
+on the unguarded form. An empty value is safe — the resolver treats `''` as "not
+supplied" and falls back exactly as omitting the flag does, so the guarded form
+is never worse than the status quo.
+
+Note the asymmetry this convention corrects: `deploy` (335 call sites) and
+`destroy` (227) already passed the flag everywhere; only `state destroy` had
+drifted, at 96 of 171 call sites across 94 fixtures. `deploy` deliberately keeps
+the strict `"${STATE_BUCKET}"` form — there an unset bucket is a harness
+misconfiguration that should fail loudly rather than silently target the default.
+
+Enforced by `tests/unit/scripts/integ-state-bucket.test.ts` (classifier:
+`scripts/check-integ-state-bucket.ts`), which evaluates code only — heredoc
+bodies, comments and `echo` arguments are stripped, so a remediation hint that
+prints the command is not treated as an invocation.
+
 ## 3. Deploy Using cdkd
 
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -867,13 +867,24 @@ environment fallback is `CDKD_STATE_BUCKET` — a **different** name. So a
 node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes
 ```
 
-never reads the harness's bucket at all. It falls through to the STS-derived
-default `cdkd-state-{accountId}` and only appears to work because that default
-is usually the same bucket. Point `STATE_BUCKET` anywhere else — a per-run
-isolated bucket, a second-account run, the legacy region-suffixed bucket — and
-the state sweep silently no-ops: it destroys nothing, reports success, and only
-the fixture's own tag-based AWS sweeps clean up. The leaked state record then
-wedges the next run of that fixture.
+never reads the harness's bucket at all. Resolution is CLI flag >
+`CDKD_STATE_BUCKET` > `cdk.json` `context.cdkd.stateBucket` > STS-derived
+default, so the omission lands in one of two wrong places:
+
+- **109 fixture `cdk.json` files declare `context.cdkd.stateBucket`**, and
+  `verify.sh` runs the CLI from the fixture directory — so the sweep resolved
+  that name (`your-cdkd-state-bucket`, `cdkd-state-test`) and died with
+  `StateError: State bucket '...' does not exist`, swallowed by the call's own
+  `>/dev/null 2>&1`. Those cleanups had been failing on **every run**,
+  invisibly.
+- **The rest** fell through to the STS default `cdkd-state-{accountId}`, which
+  is the harness bucket on a default setup — so they worked by coincidence.
+  Point `STATE_BUCKET` anywhere else (a per-run isolated bucket, a
+  second-account run, the legacy region-suffixed bucket) and the sweep silently
+  no-ops: destroys nothing, reports success, and only the fixture's own
+  tag-based AWS sweeps clean up.
+
+Either way the state record survives and wedges the next run of that fixture.
 
 Pass the bucket explicitly, in the `set -u`-safe form:
 
@@ -891,7 +902,7 @@ supplied" and falls back exactly as omitting the flag does, so the guarded form
 is never worse than the status quo.
 
 Note the asymmetry this convention corrects: `deploy` (335 call sites) and
-`destroy` (227) already passed the flag everywhere; only `state destroy` had
+`destroy` (228) already passed the flag everywhere; only `state destroy` had
 drifted, at 96 of 171 call sites across 94 fixtures. `deploy` deliberately keeps
 the strict `"${STATE_BUCKET}"` form — there an unset bucket is a harness
 misconfiguration that should fail loudly rather than silently target the default.

--- a/scripts/check-integ-state-bucket.ts
+++ b/scripts/check-integ-state-bucket.ts
@@ -1,0 +1,220 @@
+/**
+ * Classifier for the integ-fixture `cdkd state destroy` state-bucket
+ * convention (issue #1567).
+ *
+ * A fixture's `cleanup()` sweeps cdkd state with
+ * `node "${LOCAL_DIST}" state destroy "${STACK}" --region ... --yes`. The
+ * harness exports the bucket as `STATE_BUCKET`, but the CLI's env fallback is
+ * `CDKD_STATE_BUCKET` — a DIFFERENT name — so a `state destroy` that omits
+ * `--state-bucket` does not read the harness's bucket at all. It falls through
+ * to the STS-derived default `cdkd-state-{accountId}`, and the sweep only
+ * appears to work because that default usually IS the harness bucket.
+ *
+ * Point `STATE_BUCKET` at anything else (a per-run isolated bucket, a
+ * second-account run, a legacy region-suffixed bucket) and the state sweep
+ * silently no-ops: it destroys nothing, reports success, and only the fixture's
+ * own tag-based AWS sweeps clean up. The leaked state record then wedges the
+ * NEXT run of that fixture.
+ *
+ * The convention is therefore: EVERY `state destroy` invocation passes the
+ * bucket explicitly.
+ *
+ *   node "${LOCAL_DIST}" state destroy "${STACK}" \
+ *     --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes
+ *
+ * `"${STATE_BUCKET:-}"` rather than `"${STATE_BUCKET}"` is load-bearing: the
+ * trap-installed `cleanup` can run BEFORE the script's own
+ * `if [ -z "${STATE_BUCKET:-}" ]` guard has rejected an unset variable, and
+ * under `set -u` the unguarded form would abort the teardown mid-sweep. An
+ * empty value is safe — `resolveStateBucket()` treats `''` as "not supplied"
+ * and falls back exactly as omitting the flag does today, so the guarded form
+ * is a strict improvement over the status quo in every case.
+ *
+ * Why this is a checker and not a one-time sweep: 94 of the 166 fixtures that
+ * call `state destroy` had drifted off the convention (96 of 171 call sites)
+ * precisely because nothing enforced it, while `deploy` (335 invocations) and
+ * `destroy` (227) pass the flag at every single site. Measured 2026-08-11.
+ * The asymmetry is what a lint is for.
+ *
+ * Everything is evaluated on CODE, never on prose: heredoc bodies and comments
+ * are stripped and each line is split into command-position segments with a
+ * quote-aware walk, so a `state destroy` inside an `echo "..."` remediation
+ * hint is not an invocation. The stripper mirrors
+ * `scripts/check-integ-cdk-cli-pins.ts`, which established the shape.
+ */
+
+/** Commands whose arguments are prose/data rather than nested commands. */
+const PROSE_COMMANDS = /^(?:echo|printf|grep|egrep|fgrep|cat|sed|awk|jq|comm|read)\b/;
+
+/**
+ * The cdkd CLI as fixtures spell it: `node "${LOCAL_DIST}"`, a bare `${CLI}`
+ * variable, or `node "${CLI}"`. Anchored at the segment's command word so a
+ * mention inside an argument cannot match.
+ */
+const CDKD_CLI = /^(?:node\s+)?["']?\$\{(?:LOCAL_DIST|CLI|CDKD_BIN)(?::-[^}]*)?\}["']?\s+/;
+
+export interface StateDestroyInvocation {
+  /** The full logical command, continuations joined. */
+  command: string;
+  /** Passes `--state-bucket` explicitly. */
+  passesStateBucket: boolean;
+  /**
+   * Shape the invocation was parsed from, so coverage floors can be asserted
+   * per shape rather than only in aggregate.
+   */
+  shape: 'plain' | 'guarded' | 'env-prefixed';
+}
+
+/** Join backslash continuations so one logical command is one line. */
+function joinContinuations(script: string): string {
+  return script.replace(/\\\n\s*/g, ' ');
+}
+
+/**
+ * Drop heredoc bodies. A body is data — a `state destroy` line inside one is
+ * documentation, not an invocation.
+ */
+function stripHeredocs(script: string): string {
+  const out: string[] = [];
+  const lines = script.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    out.push(lines[i]!);
+    const m = lines[i]!.match(/<<-?\s*['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?/);
+    if (!m) continue;
+    const endRe = new RegExp(`^\\s*${m[1]!}\\s*$`);
+    i += 1;
+    while (i < lines.length && !endRe.test(lines[i]!)) i += 1;
+    if (i < lines.length) out.push(lines[i]!); // keep the terminator line
+  }
+  return out.join('\n');
+}
+
+/** Remove a `#` comment, honoring quote state (so `"a # b"` survives). */
+function stripComment(line: string): string {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i]!;
+    if (ch === '\\' && inDouble) {
+      i += 1;
+      continue;
+    }
+    if (ch === "'" && !inDouble) inSingle = !inSingle;
+    else if (ch === '"' && !inSingle) inDouble = !inDouble;
+    else if (ch === '#' && !inSingle && !inDouble) {
+      if (i === 0 || /\s/.test(line[i - 1]!)) return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
+/**
+ * Split a line into segments that start in COMMAND position, honoring quote
+ * state so a separator inside a quoted argument does not open a new segment.
+ */
+function commandSegments(line: string): string[] {
+  const segments: string[] = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i]!;
+    if (ch === '\\' && inDouble) {
+      current += ch + (line[i + 1] ?? '');
+      i += 1;
+      continue;
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      current += ch;
+      continue;
+    }
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      current += ch;
+      continue;
+    }
+    if (!inSingle && !inDouble && ch === '$' && line[i + 1] === '(') {
+      segments.push(current);
+      current = '';
+      i += 1;
+      continue;
+    }
+    if (!inSingle && !inDouble && /[;&|()`]/.test(ch)) {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  segments.push(current);
+  return segments.map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+/**
+ * Strip leading tokens that keep the rest of the segment in command position,
+ * reporting which shape was peeled so the caller can assert per-shape floors.
+ */
+function stripToCommandWord(segment: string): { command: string; shape: StateDestroyInvocation['shape'] } {
+  let s = segment;
+  let shape: StateDestroyInvocation['shape'] = 'plain';
+  let prev;
+  do {
+    prev = s;
+    s = s.replace(/^\{\s+/, '');
+    // `[ -x "${LOCAL_DIST}" ] &&` / `if`-guarded invocations. The `&&` itself
+    // already opened a new segment, so only a bare keyword remains here.
+    const guard = s.replace(/^(?:!|if|then|else|elif|do|while|until|time)\s+/, '');
+    if (guard !== s) {
+      shape = 'guarded';
+      s = guard;
+    }
+    s = s.replace(/^timeout\s+(?:-\S+\s+)*\d+\S*\s+/, '');
+    const env = s.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)\s+)+/, '');
+    if (env !== s) {
+      shape = 'env-prefixed';
+      s = env;
+    }
+  } while (s !== prev);
+  return { command: s, shape };
+}
+
+/**
+ * Every `cdkd state destroy` invocation the script actually runs, in source
+ * order. Prose mentions (comments, heredocs, `echo` arguments) are excluded.
+ */
+export function collectStateDestroyInvocations(script: string): StateDestroyInvocation[] {
+  const normalized = joinContinuations(stripHeredocs(script));
+  const found: StateDestroyInvocation[] = [];
+
+  for (const rawLine of normalized.split('\n')) {
+    const line = stripComment(rawLine);
+    if (!line.includes('state destroy')) continue;
+
+    for (const segment of commandSegments(line)) {
+      const { command, shape } = stripToCommandWord(segment);
+      if (PROSE_COMMANDS.test(command)) continue;
+      if (!CDKD_CLI.test(command)) continue;
+      // `state destroy` must be the SUBCOMMAND, i.e. directly after the binary.
+      if (!/^\S+\s+(?:\S+\s+)?state\s+destroy\b/.test(command)) continue;
+      found.push({
+        command,
+        passesStateBucket: /(?:^|\s)--state-bucket(?:=|\s)/.test(command),
+        shape,
+      });
+    }
+  }
+
+  return found;
+}
+
+export interface FixtureVerdict {
+  invocations: StateDestroyInvocation[];
+  /** Invocations that omit `--state-bucket` — the CI-blocking verdict. */
+  offenders: StateDestroyInvocation[];
+}
+
+export function checkFixture(script: string): FixtureVerdict {
+  const invocations = collectStateDestroyInvocations(script);
+  return { invocations, offenders: invocations.filter((i) => !i.passesStateBucket) };
+}

--- a/scripts/check-integ-state-bucket.ts
+++ b/scripts/check-integ-state-bucket.ts
@@ -6,15 +6,26 @@
  * `node "${LOCAL_DIST}" state destroy "${STACK}" --region ... --yes`. The
  * harness exports the bucket as `STATE_BUCKET`, but the CLI's env fallback is
  * `CDKD_STATE_BUCKET` — a DIFFERENT name — so a `state destroy` that omits
- * `--state-bucket` does not read the harness's bucket at all. It falls through
- * to the STS-derived default `cdkd-state-{accountId}`, and the sweep only
- * appears to work because that default usually IS the harness bucket.
+ * `--state-bucket` never reads the harness's bucket at all.
  *
- * Point `STATE_BUCKET` at anything else (a per-run isolated bucket, a
- * second-account run, a legacy region-suffixed bucket) and the state sweep
- * silently no-ops: it destroys nothing, reports success, and only the fixture's
- * own tag-based AWS sweeps clean up. The leaked state record then wedges the
- * NEXT run of that fixture.
+ * What it reads instead depends on the fixture, and BOTH outcomes are wrong
+ * (`resolveStateBucketWithSource`, src/cli/config-loader.ts: CLI flag >
+ * `CDKD_STATE_BUCKET` > `cdk.json` `context.cdkd.stateBucket` > STS default):
+ *
+ *  - 109 fixture `cdk.json` files declare `context.cdkd.stateBucket`
+ *    (`your-cdkd-state-bucket`, `cdkd-state-test`, ...). `verify.sh` runs the
+ *    CLI from the fixture directory, so the sweep resolved THAT name and died
+ *    with `StateError: State bucket '...' does not exist` — swallowed by the
+ *    call's own `>/dev/null 2>&1`. Those cleanups had been failing on EVERY
+ *    run, invisibly. 48 of the fixtures swept here are in this bucket.
+ *  - The rest fell through to the STS-derived default
+ *    `cdkd-state-{accountId}`, which happens to be the harness bucket on a
+ *    default setup — so they worked, but by coincidence rather than by
+ *    intent, and break the moment `STATE_BUCKET` points anywhere else (a
+ *    per-run isolated bucket, a second-account run, the legacy
+ *    region-suffixed bucket). There the sweep silently no-ops: destroys
+ *    nothing, reports success, and only the fixture's own tag-based AWS
+ *    sweeps clean up. The leaked state record then wedges the NEXT run.
  *
  * The convention is therefore: EVERY `state destroy` invocation passes the
  * bucket explicitly.
@@ -33,7 +44,7 @@
  * Why this is a checker and not a one-time sweep: 94 of the 166 fixtures that
  * call `state destroy` had drifted off the convention (96 of 171 call sites)
  * precisely because nothing enforced it, while `deploy` (335 invocations) and
- * `destroy` (227) pass the flag at every single site. Measured 2026-08-11.
+ * `destroy` (228) pass the flag at every single site. Measured 2026-08-11.
  * The asymmetry is what a lint is for.
  *
  * Everything is evaluated on CODE, never on prose: heredoc bodies and comments
@@ -47,11 +58,18 @@
 const PROSE_COMMANDS = /^(?:echo|printf|grep|egrep|fgrep|cat|sed|awk|jq|comm|read)\b/;
 
 /**
- * The cdkd CLI as fixtures spell it: `node "${LOCAL_DIST}"`, a bare `${CLI}`
- * variable, or `node "${CLI}"`. Anchored at the segment's command word so a
- * mention inside an argument cannot match.
+ * The cdkd CLI as fixtures spell it: `node "${LOCAL_DIST}"`, a bare `${CLI}` /
+ * `${CDKD}` variable, or `node "${CDKD}"`. Anchored at the segment's command
+ * word so a mention inside an argument cannot match.
+ *
+ * This list is NOT the safety net — an unrecognized spelling would silently
+ * exempt a fixture, which is the #1097 lint's failure mode. `collect*` reports
+ * every UNRECOGNIZED `state destroy` segment instead, and the test fails on a
+ * non-empty report, so a new binary spelling surfaces loudly rather than as a
+ * quiet zero. (`CDKD=` is used by 36 fixtures; none call `state destroy` yet,
+ * which is exactly why the whitelist alone could not be trusted.)
  */
-const CDKD_CLI = /^(?:node\s+)?["']?\$\{(?:LOCAL_DIST|CLI|CDKD_BIN)(?::-[^}]*)?\}["']?\s+/;
+const CDKD_CLI = /^(?:node\s+)?["']?\$\{(?:LOCAL_DIST|CLI|CDKD)(?::-[^}]*)?\}["']?\s+/;
 
 export interface StateDestroyInvocation {
   /** The full logical command, continuations joined. */
@@ -73,13 +91,22 @@ function joinContinuations(script: string): string {
 /**
  * Drop heredoc bodies. A body is data — a `state destroy` line inside one is
  * documentation, not an invocation.
+ *
+ * `(?<!<)…(?!<)` excludes the `<<< bareword` herestring, which is NOT a
+ * heredoc: treating `grep x <<< bar` as one swallowed the entire rest of the
+ * file. BOTH guards are needed — with only the lookahead the engine shifts one
+ * character and matches `<<` starting at the second `<` of `<<<`, taking
+ * `bar` as the terminator.
+ * Run this on comment-stripped text, or a `# ... <<EOF` in prose opens a
+ * heredoc that never terminates and hides every invocation below it
+ * (`local-invoke-buildkit/verify.sh` has exactly that comment).
  */
 function stripHeredocs(script: string): string {
   const out: string[] = [];
   const lines = script.split('\n');
   for (let i = 0; i < lines.length; i += 1) {
     out.push(lines[i]!);
-    const m = lines[i]!.match(/<<-?\s*['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?/);
+    const m = lines[i]!.match(/(?<!<)<<-?(?!<)\s*['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?/);
     if (!m) continue;
     const endRe = new RegExp(`^\\s*${m[1]!}\\s*$`);
     i += 1;
@@ -87,6 +114,21 @@ function stripHeredocs(script: string): string {
     if (i < lines.length) out.push(lines[i]!); // keep the terminator line
   }
   return out.join('\n');
+}
+
+/**
+ * Comments first (per PHYSICAL line), then heredocs, then continuations.
+ *
+ * The order is load-bearing in both places. Bash does NOT continue a comment
+ * across a trailing backslash, so joining first lets a `# ... \` comment glue
+ * the following REAL invocation into itself and strip it — a silent false
+ * negative, and `local-start-alb-from-state/verify.sh` carries that comment
+ * shape. And heredoc openers must be looked for on comment-stripped text (see
+ * `stripHeredocs`).
+ */
+function normalizeScript(script: string): string {
+  const commentStripped = script.split('\n').map(stripComment).join('\n');
+  return joinContinuations(stripHeredocs(commentStripped));
 }
 
 /** Remove a `#` comment, honoring quote state (so `"a # b"` survives). */
@@ -170,7 +212,11 @@ function stripToCommandWord(segment: string): { command: string; shape: StateDes
       s = guard;
     }
     s = s.replace(/^timeout\s+(?:-\S+\s+)*\d+\S*\s+/, '');
-    const env = s.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)\s+)+/, '');
+    // `env -u VAR` / `env -i` wrappers (a real tree shape — see
+    // agentcore-tools/verify.sh) as well as bare `VAR=value` prefixes.
+    const env = s
+      .replace(/^env\s+(?:-[iu]\s+[A-Za-z_][A-Za-z0-9_]*\s+|-[iu]\s+)+/, '')
+      .replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)\s+)+/, '');
     if (env !== s) {
       shape = 'env-prefixed';
       s = env;
@@ -183,20 +229,28 @@ function stripToCommandWord(segment: string): { command: string; shape: StateDes
  * Every `cdkd state destroy` invocation the script actually runs, in source
  * order. Prose mentions (comments, heredocs, `echo` arguments) are excluded.
  */
-export function collectStateDestroyInvocations(script: string): StateDestroyInvocation[] {
-  const normalized = joinContinuations(stripHeredocs(script));
+export function collectStateDestroyInvocations(script: string): StateDestroyScan {
   const found: StateDestroyInvocation[] = [];
+  const unrecognized: string[] = [];
 
-  for (const rawLine of normalized.split('\n')) {
-    const line = stripComment(rawLine);
+  for (const line of normalizeScript(script).split('\n')) {
     if (!line.includes('state destroy')) continue;
 
     for (const segment of commandSegments(line)) {
+      if (!segment.includes('state destroy')) continue;
       const { command, shape } = stripToCommandWord(segment);
+      // Prose: `echo "... state destroy ..."` is a printed hint, not a run.
       if (PROSE_COMMANDS.test(command)) continue;
-      if (!CDKD_CLI.test(command)) continue;
-      // `state destroy` must be the SUBCOMMAND, i.e. directly after the binary.
-      if (!/^\S+\s+(?:\S+\s+)?state\s+destroy\b/.test(command)) continue;
+      // `state destroy` must be the SUBCOMMAND, i.e. right after the binary.
+      const isSubcommand = /^\S+\s+(?:\S+\s+)?state\s+destroy\b/.test(command);
+      if (!CDKD_CLI.test(command) || !isSubcommand) {
+        // Do NOT silently skip: an unknown binary spelling would exempt the
+        // fixture. Report it so the test fails loudly instead.
+        if (isSubcommand || /(?:^|\s)state\s+destroy\b/.test(command)) {
+          unrecognized.push(command);
+        }
+        continue;
+      }
       found.push({
         command,
         passesStateBucket: /(?:^|\s)--state-bucket(?:=|\s)/.test(command),
@@ -205,16 +259,26 @@ export function collectStateDestroyInvocations(script: string): StateDestroyInvo
     }
   }
 
-  return found;
+  return { invocations: found, unrecognized };
 }
 
-export interface FixtureVerdict {
+export interface StateDestroyScan {
   invocations: StateDestroyInvocation[];
+  /**
+   * Segments that run a `state destroy` through a binary spelling this
+   * classifier does not recognize. Always expected to be empty; a non-empty
+   * report means the whitelist needs the new spelling, NOT that the fixture is
+   * exempt.
+   */
+  unrecognized: string[];
+}
+
+export interface FixtureVerdict extends StateDestroyScan {
   /** Invocations that omit `--state-bucket` — the CI-blocking verdict. */
   offenders: StateDestroyInvocation[];
 }
 
 export function checkFixture(script: string): FixtureVerdict {
-  const invocations = collectStateDestroyInvocations(script);
-  return { invocations, offenders: invocations.filter((i) => !i.passesStateBucket) };
+  const scan = collectStateDestroyInvocations(script);
+  return { ...scan, offenders: scan.invocations.filter((i) => !i.passesStateBucket) };
 }

--- a/tests/integration/agentcore-tools/verify.sh
+++ b/tests/integration/agentcore-tools/verify.sh
@@ -80,7 +80,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   LEFTOVER_ID="$(find_evaluator_id)"
   if [ -n "${LEFTOVER_ID}" ]; then

--- a/tests/integration/apigateway/verify.sh
+++ b/tests/integration/apigateway/verify.sh
@@ -69,7 +69,7 @@ cleanup() {
   # should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # The {proxy+} ANY curl in Assertion 4 invokes the Lambda, which auto-creates a
   # /aws/lambda/${STACK}* log group that is not stack-managed (CFn leaves it too).

--- a/tests/integration/apigatewayv2-update-removal/verify.sh
+++ b/tests/integration/apigatewayv2-update-removal/verify.sh
@@ -104,7 +104,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   local aid
   aid="$(api_id)"

--- a/tests/integration/apigw-gateway-response/verify.sh
+++ b/tests/integration/apigw-gateway-response/verify.sh
@@ -78,7 +78,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   local id
   id="$(api_id)"

--- a/tests/integration/apigw-stage-throttling/verify.sh
+++ b/tests/integration/apigw-stage-throttling/verify.sh
@@ -77,7 +77,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # The functional curls invoke the Lambda, which auto-creates a
   # /aws/lambda/${STACK}* log group that is not stack-managed. Sweep it so the

--- a/tests/integration/apigw-usage-plan-key/verify.sh
+++ b/tests/integration/apigw-usage-plan-key/verify.sh
@@ -59,7 +59,7 @@ api_id() {
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   for pid in $(aws apigateway get-usage-plans --region "${REGION}" --query "items[?name=='${PLAN_NAME}'].id" --output text 2>/dev/null); do
     aws apigateway delete-usage-plan --usage-plan-id "${pid}" --region "${REGION}" >/dev/null 2>&1 || true
   done

--- a/tests/integration/appconfig/verify.sh
+++ b/tests/integration/appconfig/verify.sh
@@ -100,7 +100,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   delete_app
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/appsync/verify.sh
+++ b/tests/integration/appsync/verify.sh
@@ -70,7 +70,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1

--- a/tests/integration/aws-custom-resource/verify.sh
+++ b/tests/integration/aws-custom-resource/verify.sh
@@ -75,7 +75,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws ssm delete-parameter --name "${PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   sweep_log_groups

--- a/tests/integration/backup/verify.sh
+++ b/tests/integration/backup/verify.sh
@@ -68,7 +68,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Delete every backup plan matching our plan name, then the empty vault.
   for PLAN_ID in $(aws backup list-backup-plans --region "${REGION}" \

--- a/tests/integration/bucket-deployment/verify.sh
+++ b/tests/integration/bucket-deployment/verify.sh
@@ -77,7 +77,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${SITE_BUCKET}" ]; then
     aws s3 rb "s3://${SITE_BUCKET}" --force >/dev/null 2>&1 || true

--- a/tests/integration/budgets/verify.sh
+++ b/tests/integration/budgets/verify.sh
@@ -75,7 +75,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws budgets delete-budget --account-id "${ACCOUNT_ID}" --budget-name "${BUDGET_NAME}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/cache-streaming/verify.sh
+++ b/tests/integration/cache-streaming/verify.sh
@@ -73,7 +73,7 @@ cleanup() {
     # Best-effort real teardown first (removes AWS resources if the run died
     # mid-flight), then drop any residual state record.
     node "${LOCAL_DIST}" destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET}" --force >/dev/null 2>&1
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET:-}" --yes >/dev/null 2>&1
   fi
   rm -f "${DEPLOY_LOG}" 2>/dev/null || true
   set -e

--- a/tests/integration/cc-api-fallback-transitions/verify.sh
+++ b/tests/integration/cc-api-fallback-transitions/verify.sh
@@ -96,8 +96,8 @@ cleanup() {
   # cleanup should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${OVERRIDE_STACK}" --region "${REGION}" --yes >/dev/null 2>&1
-    node "${LOCAL_DIST}" state destroy "${TRANSITION_STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${OVERRIDE_STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${TRANSITION_STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${OVERRIDE_FN}" --region "${REGION}" >/dev/null 2>&1 || true
   aws lambda delete-function --function-name "${TRANSITION_FN}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/cc-api-fallback/verify.sh
+++ b/tests/integration/cc-api-fallback/verify.sh
@@ -65,7 +65,7 @@ cleanup() {
   # cleanup should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/cc-getatt-readback/verify.sh
+++ b/tests/integration/cc-getatt-readback/verify.sh
@@ -69,7 +69,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws pipes delete-pipe --name "${PIPE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   aws s3control delete-access-point --account-id "${ACCOUNT_ID}" \

--- a/tests/integration/cc-protection-flip-eks/verify.sh
+++ b/tests/integration/cc-protection-flip-eks/verify.sh
@@ -74,7 +74,7 @@ cleanup() {
     # state destroy --remove-protection tears down the whole stack (cluster
     # flip included) when state still exists; the per-resource sweeps below
     # cover the no-state case.
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --remove-protection --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --remove-protection --yes >/dev/null 2>&1
   fi
   ( set +eu
     if aws eks describe-cluster --name "${CLUSTER_NAME}" --region "${REGION}" >/dev/null 2>&1; then

--- a/tests/integration/cc-protection-flip/verify.sh
+++ b/tests/integration/cc-protection-flip/verify.sh
@@ -77,7 +77,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --remove-protection --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --remove-protection --yes >/dev/null 2>&1
   fi
   # NeptuneGraph: deterministic name discovery.
   ( set +eu

--- a/tests/integration/ci-cd/verify.sh
+++ b/tests/integration/ci-cd/verify.sh
@@ -71,7 +71,7 @@ cleanup() {
   set +eu
   local destroy_rc=0
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --yes --state-bucket "${STATE_BUCKET}" --region "${REGION}"
+    node "${LOCAL_DIST}" state destroy "${STACK}" --yes --state-bucket "${STATE_BUCKET:-}" --region "${REGION}"
     destroy_rc=$?
   fi
   # Only remove the state key when the destroy succeeded (rc 0). A failed

--- a/tests/integration/cloudfront-function-url/verify.sh
+++ b/tests/integration/cloudfront-function-url/verify.sh
@@ -64,7 +64,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true

--- a/tests/integration/cloudwatch-anomaly-detector/verify.sh
+++ b/tests/integration/cloudwatch-anomaly-detector/verify.sh
@@ -80,7 +80,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true

--- a/tests/integration/codecommit/verify.sh
+++ b/tests/integration/codecommit/verify.sh
@@ -72,7 +72,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws codecommit delete-repository --repository-name "${REPO}" --region "${REGION}" >/dev/null 2>&1 || true
   aws codecommit delete-repository --repository-name "${REPO_RENAMED}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/codedeploy-lambda-deployment-group/verify.sh
+++ b/tests/integration/codedeploy-lambda-deployment-group/verify.sh
@@ -88,7 +88,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Deleting the application cascades to its deployment groups.
   aws deploy delete-application --application-name "${APP_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/cognito-custom-attribute-add/verify.sh
+++ b/tests/integration/cognito-custom-attribute-add/verify.sh
@@ -74,7 +74,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   local pid
   pid="$(pool_id)"

--- a/tests/integration/cognito-identity-pool/verify.sh
+++ b/tests/integration/cognito-identity-pool/verify.sh
@@ -61,7 +61,7 @@ up_id() {
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   local id; id=$(idp_id)
   [ -n "${id}" ] && [ "${id}" != "None" ] && aws cognito-identity delete-identity-pool --identity-pool-id "${id}" --region "${REGION}" >/dev/null 2>&1 || true
   local up; up=$(up_id)

--- a/tests/integration/cognito-lambda-triggers/verify.sh
+++ b/tests/integration/cognito-lambda-triggers/verify.sh
@@ -89,7 +89,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   delete_pool_by_name
   sweep_log_groups

--- a/tests/integration/cognito-resource-server/verify.sh
+++ b/tests/integration/cognito-resource-server/verify.sh
@@ -71,7 +71,7 @@ cleanup() {
   if [ -x "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" \
       --yes \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi

--- a/tests/integration/cognito-userpool-user-ref/verify.sh
+++ b/tests/integration/cognito-userpool-user-ref/verify.sh
@@ -61,7 +61,7 @@ pool_id() {
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   local pid; pid=$(pool_id)
   [ -n "${pid}" ] && [ "${pid}" != "None" ] && aws cognito-idp delete-user-pool --user-pool-id "${pid}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/cognito/verify.sh
+++ b/tests/integration/cognito/verify.sh
@@ -73,7 +73,7 @@ cleanup() {
     # `state destroy` rejects `--force`; the confirmation skip flag is `--yes`.
     node "${LOCAL_DIST}" state destroy "${STACK}" \
       --yes \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi

--- a/tests/integration/conditions/verify.sh
+++ b/tests/integration/conditions/verify.sh
@@ -67,7 +67,7 @@ cleanup() {
   set +e
   if [ -x "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET}" --force >/dev/null 2>&1
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET:-}" --yes >/dev/null 2>&1
   fi
   rm -f "${DEPLOY_LOG}" 2>/dev/null || true
   set -e

--- a/tests/integration/custom-resource-getatt-data/verify.sh
+++ b/tests/integration/custom-resource-getatt-data/verify.sh
@@ -80,7 +80,7 @@ cleanup() {
   set +eu
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" \
       --yes
   fi

--- a/tests/integration/data-analytics/verify.sh
+++ b/tests/integration/data-analytics/verify.sh
@@ -155,7 +155,7 @@ cleanup() {
     # `state destroy` rejects `--force`; the confirmation skip flag is `--yes`.
     node "${LOCAL_DIST}" state destroy "${STACK}" \
       --yes \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi

--- a/tests/integration/deep-getatt-chains/verify.sh
+++ b/tests/integration/deep-getatt-chains/verify.sh
@@ -99,7 +99,7 @@ cleanup() {
   echo "==> Cleanup (errors during this block are tolerated)"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true

--- a/tests/integration/deletion-ordering-complex/verify.sh
+++ b/tests/integration/deletion-ordering-complex/verify.sh
@@ -187,7 +187,7 @@ cleanup() {
   done
 
   # Best-effort cdkd state cleanup so a re-run is not blocked.
-  ${CLI} state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --yes 2>/dev/null || true
+  ${CLI} state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --yes 2>/dev/null || true
   ${CLI} state orphan "${STACK}" --state-bucket "${STATE_BUCKET}" 2>/dev/null || true
 
   echo "[verify] cleanup attempt complete (exit ${rc})"

--- a/tests/integration/deletion-policy-snapshot-heavy/verify.sh
+++ b/tests/integration/deletion-policy-snapshot-heavy/verify.sh
@@ -150,7 +150,7 @@ cleanup() {
     done < "${IDS_FILE}"
   fi
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" --skip-final-snapshot --yes >/dev/null 2>&1
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/deletion-policy-snapshot/verify.sh
+++ b/tests/integration/deletion-policy-snapshot/verify.sh
@@ -106,7 +106,7 @@ cleanup() {
     done
   done
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" --skip-final-snapshot --yes >/dev/null 2>&1
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/destroy-interrupt/verify.sh
+++ b/tests/integration/destroy-interrupt/verify.sh
@@ -81,7 +81,7 @@ cleanup() {
   set +eu
   destroy_rc=0
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" --yes >/dev/null 2>&1
     destroy_rc=$?
   fi

--- a/tests/integration/dlm-lifecycle-policy/verify.sh
+++ b/tests/integration/dlm-lifecycle-policy/verify.sh
@@ -87,7 +87,7 @@ cleanup() {
   set +eu
   if [ -x "${LOCAL_DIST}" ] || [ -f "${LOCAL_DIST}" ]; then
     if [ -n "${STATE_BUCKET:-}" ]; then
-      node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --stack-region "${REGION}" --yes >/dev/null 2>&1
+      node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --stack-region "${REGION}" --yes >/dev/null 2>&1
     fi
   fi
   # Delete any leftover lifecycle policy carrying the fixture's constant tag

--- a/tests/integration/docker-image-asset/verify.sh
+++ b/tests/integration/docker-image-asset/verify.sh
@@ -147,7 +147,7 @@ fi
 echo "==> Pre-run cleanup"
 # Pre-run cleanup must not exit the script (it runs before deploy). Inline a
 # minimal state drop here; the EXIT trap handles the full teardown.
-node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
   --region "${REGION}" --yes >/dev/null 2>&1 || true
 
 # --- Phase 1: deploy (forces docker build + ECR push) -----------------------

--- a/tests/integration/dsql/verify.sh
+++ b/tests/integration/dsql/verify.sh
@@ -84,7 +84,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # DSQL clusters have no deterministic name: discover leftovers by the integ
   # tag and best-effort delete them (dropping deletion protection first).

--- a/tests/integration/dynamodb-autoscaling/verify.sh
+++ b/tests/integration/dynamodb-autoscaling/verify.sh
@@ -80,7 +80,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   deregister_targets
   aws dynamodb delete-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/dynamodb-gsi-update/verify.sh
+++ b/tests/integration/dynamodb-gsi-update/verify.sh
@@ -71,7 +71,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws dynamodb delete-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/dynamodb-ondemand/verify.sh
+++ b/tests/integration/dynamodb-ondemand/verify.sh
@@ -89,7 +89,7 @@ cleanup() {
   # cleanup should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws dynamodb delete-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   aws dynamodb delete-table --table-name "${PROV_TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/dynamodb-sse/verify.sh
+++ b/tests/integration/dynamodb-sse/verify.sh
@@ -63,7 +63,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws dynamodb delete-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/dynamodb-stream-filter/verify.sh
+++ b/tests/integration/dynamodb-stream-filter/verify.sh
@@ -73,7 +73,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws dynamodb delete-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   sweep_log_groups

--- a/tests/integration/dynamodb-streams/verify.sh
+++ b/tests/integration/dynamodb-streams/verify.sh
@@ -82,7 +82,7 @@ cleanup() {
     # Destroy under CDKD_TEST_UPDATE=true so the synthesized template matches
     # whatever phase the state was last written in (the stream-consumer subtree
     # only exists in the UPDATE phase).
-    CDKD_TEST_UPDATE=true node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    CDKD_TEST_UPDATE=true node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${TABLE_NAME}" ]; then
     aws dynamodb delete-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/dynamodb-tableclass-switch/verify.sh
+++ b/tests/integration/dynamodb-tableclass-switch/verify.sh
@@ -79,7 +79,7 @@ cleanup() {
   if [ -n "${STATE_BUCKET:-}" ] && [ -f "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" \
       --yes \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi

--- a/tests/integration/dynamodb-ttl-attr-change/verify.sh
+++ b/tests/integration/dynamodb-ttl-attr-change/verify.sh
@@ -68,7 +68,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws dynamodb delete-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/ec2-instance-fanout/verify.sh
+++ b/tests/integration/ec2-instance-fanout/verify.sh
@@ -71,7 +71,7 @@ cleanup() {
     # Do NOT silence stderr — a partial failure must be visible so we never
     # leak ten billing instances.
     node "${LOCAL_DIST}" state destroy "${STACK}" \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" \
       --yes
   fi

--- a/tests/integration/ec2-instance/verify.sh
+++ b/tests/integration/ec2-instance/verify.sh
@@ -88,7 +88,7 @@ cleanup() {
     # is still terminated. Do NOT silence stderr — a partial failure must be
     # visible so we never leak a billing instance.
     node "${LOCAL_DIST}" state destroy "${STACK}" \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" \
       --remove-protection \
       --yes

--- a/tests/integration/ecr-scanning/verify.sh
+++ b/tests/integration/ecr-scanning/verify.sh
@@ -81,7 +81,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws ecr delete-repository --repository-name "${REPO}" --force --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/ecs-bluegreen/verify.sh
+++ b/tests/integration/ecs-bluegreen/verify.sh
@@ -70,7 +70,7 @@ cleanup() {
   ( set +eu
     if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
       node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" \
-        --state-bucket "${STATE_BUCKET}" --yes >/dev/null 2>&1
+        --state-bucket "${STATE_BUCKET:-}" --yes >/dev/null 2>&1
     fi
     # Out-of-band sweep of the fixed-name ECS pieces so a crashed run cannot
     # poison the next one even if state destroy failed. Deliberately does NOT

--- a/tests/integration/ecs-fargate/verify.sh
+++ b/tests/integration/ecs-fargate/verify.sh
@@ -77,7 +77,7 @@ cleanup() {
   # cleanup should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --yes --state-bucket "${STATE_BUCKET}" --region "${REGION}"
+    node "${LOCAL_DIST}" state destroy "${STACK}" --yes --state-bucket "${STATE_BUCKET:-}" --region "${REGION}"
     rc=$?
   else
     rc=0

--- a/tests/integration/ecs-schedule-targets/verify.sh
+++ b/tests/integration/ecs-schedule-targets/verify.sh
@@ -59,7 +59,7 @@ LOCAL_DIST="${PWD}/../../../dist/cli.js"
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1 || true

--- a/tests/integration/ecs-service-update-props/verify.sh
+++ b/tests/integration/ecs-service-update-props/verify.sh
@@ -113,7 +113,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --yes --state-bucket "${STATE_BUCKET}" --region "${REGION}"
+    node "${LOCAL_DIST}" state destroy "${STACK}" --yes --state-bucket "${STATE_BUCKET:-}" --region "${REGION}"
     rc=$?
   else
     rc=0

--- a/tests/integration/efs-immutable-replacement/verify.sh
+++ b/tests/integration/efs-immutable-replacement/verify.sh
@@ -76,7 +76,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Sweep any filesystem(s) carrying our tag (an interrupted run may leave one).
   for fsid in $(aws efs describe-file-systems --region "${REGION}" \

--- a/tests/integration/efs-standalone/verify.sh
+++ b/tests/integration/efs-standalone/verify.sh
@@ -68,7 +68,7 @@ cleanup() {
   if [ -x "${LOCAL_DIST}" ] || [ -f "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" \
       --yes \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi

--- a/tests/integration/elasticache-replicationgroup-getatt/verify.sh
+++ b/tests/integration/elasticache-replicationgroup-getatt/verify.sh
@@ -67,7 +67,7 @@ cleanup() {
   echo "==> Cleanup (errors tolerated)"
   set +e
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET:-}" --yes >/dev/null 2>&1
   fi
   aws ssm delete-parameter --name "${ADDR_PARAM}" --region "${REGION}" >/dev/null 2>&1 || true
   aws ssm delete-parameter --name "${PORT_PARAM}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/emr-cluster/verify.sh
+++ b/tests/integration/emr-cluster/verify.sh
@@ -228,7 +228,7 @@ cleanup() {
 
   state_destroy_ok=true
   if [ -f "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
       --stack-region "${REGION}" --yes >/dev/null 2>&1 || state_destroy_ok=false
   fi
 

--- a/tests/integration/emr-instance-configs/verify.sh
+++ b/tests/integration/emr-instance-configs/verify.sh
@@ -172,7 +172,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -f "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
       --stack-region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Terminate any leftover active cluster (disable termination protection

--- a/tests/integration/emr-instance-fleets/verify.sh
+++ b/tests/integration/emr-instance-fleets/verify.sh
@@ -198,7 +198,7 @@ cleanup() {
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1
   fi
   if [ -f "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
       --stack-region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Terminate any leftover active cluster (disable termination protection

--- a/tests/integration/eventbridge-api-destination/verify.sh
+++ b/tests/integration/eventbridge-api-destination/verify.sh
@@ -68,7 +68,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Rule must lose its targets before it can be deleted.
   aws events remove-targets --rule "${RULE}" --ids Target0 --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/eventbridge-archive/verify.sh
+++ b/tests/integration/eventbridge-archive/verify.sh
@@ -67,7 +67,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws events delete-archive --archive-name "${ARCHIVE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   aws events delete-event-bus --name "${BUS_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/eventbridge-input-transformer/verify.sh
+++ b/tests/integration/eventbridge-input-transformer/verify.sh
@@ -105,7 +105,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   delete_rule
   local url

--- a/tests/integration/eventbridge-pipes/verify.sh
+++ b/tests/integration/eventbridge-pipes/verify.sh
@@ -52,7 +52,7 @@ LOCAL_DIST="${PWD}/../../../dist/cli.js"
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   aws pipes delete-pipe --name "${PIPE}" --region "${REGION}" >/dev/null 2>&1 || true
   Q=$(aws sqs get-queue-url --queue-name "${SRC}" --region "${REGION}" --query QueueUrl --output text 2>/dev/null)
   [ -n "${Q}" ] && [ "${Q}" != "None" ] && aws sqs delete-queue --queue-url "${Q}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/eventbridge-scheduler/verify.sh
+++ b/tests/integration/eventbridge-scheduler/verify.sh
@@ -51,7 +51,7 @@ LOCAL_DIST="${PWD}/../../../dist/cli.js"
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   aws scheduler delete-schedule --name "${SCHED}" --region "${REGION}" >/dev/null 2>&1 || true
   aws lambda delete-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1 || true
   aws logs delete-log-group --log-group-name "/aws/lambda/${FN}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/eventsourcemapping-race/verify.sh
+++ b/tests/integration/eventsourcemapping-race/verify.sh
@@ -106,7 +106,7 @@ cleanup() {
     done
   fi
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${QUEUE_URL}" ]; then
     aws sqs delete-queue --queue-url "${QUEUE_URL}" --region "${REGION}" >/dev/null 2>&1 || true
@@ -154,7 +154,7 @@ if [ -n "${PREFLIGHT_ESMS}" ]; then
   for uuid in ${PREFLIGHT_ESMS}; do
     echo "    aws lambda delete-event-source-mapping --uuid ${uuid} --region ${REGION}" >&2
   done
-  echo "    node ${LOCAL_DIST} state destroy ${STACK} --region ${REGION} --yes" >&2
+  echo "    node ${LOCAL_DIST} state destroy ${STACK} --state-bucket ${STATE_BUCKET} --region ${REGION} --yes" >&2
   exit 1
 fi
 echo "    OK: no orphan EventSourceMapping bound to '${STACK}'"

--- a/tests/integration/fifo-sqs-event-source/verify.sh
+++ b/tests/integration/fifo-sqs-event-source/verify.sh
@@ -104,7 +104,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   for uuid in $(aws lambda list-event-source-mappings --function-name "${FN_NAME}" \
     --region "${REGION}" --query 'EventSourceMappings[].UUID' --output text 2>/dev/null); do

--- a/tests/integration/fsx-lustre/verify.sh
+++ b/tests/integration/fsx-lustre/verify.sh
@@ -100,7 +100,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -f "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
       --stack-region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Delete any leftover file system carrying the fixture's constant tag and

--- a/tests/integration/fsx-ontap/verify.sh
+++ b/tests/integration/fsx-ontap/verify.sh
@@ -178,7 +178,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -f "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
       --stack-region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Delete any leftover file system carrying the fixture's constant tag and

--- a/tests/integration/fsx-openzfs/verify.sh
+++ b/tests/integration/fsx-openzfs/verify.sh
@@ -109,7 +109,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -f "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
       --stack-region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Delete any leftover file system carrying the fixture's constant tag and

--- a/tests/integration/fsx-windows/verify.sh
+++ b/tests/integration/fsx-windows/verify.sh
@@ -401,7 +401,7 @@ cleanup() {
   # every exit path (may be unset if we never reached Phase 2).
   rm -f "${AD_INPUT_FILE:-}"
   if [ -f "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
       --stack-region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Order matters: the file system leaves the domain first, then the

--- a/tests/integration/gc-custom-asset-names/verify.sh
+++ b/tests/integration/gc-custom-asset-names/verify.sh
@@ -97,7 +97,7 @@ cleanup() {
   echo "==> Cleanup: dropping stack state/resources + asset storage + marker"
   set +eu
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" --yes >/dev/null 2>&1
     node "${LOCAL_DIST}" events prune "${STACK}" --all --state-bucket "${STATE_BUCKET}" \
       --region "${REGION}" --yes >/dev/null 2>&1

--- a/tests/integration/getatt-fallback-guard/verify.sh
+++ b/tests/integration/getatt-fallback-guard/verify.sh
@@ -74,7 +74,7 @@ LOCAL_DIST="${PWD}/../../../dist/cli.js"
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -f "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -f "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   aws ssm delete-parameter --name "${PARAM}" --region "${REGION}" >/dev/null 2>&1 || true
   aws ssm delete-parameter --name "${CONSUMER_PARAM}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/getstackoutput-crossregion/verify.sh
+++ b/tests/integration/getstackoutput-crossregion/verify.sh
@@ -88,8 +88,8 @@ cleanup() {
   # doesn't strictly matter, but mirrors real-world recommended order.
   # Each stack is destroyed against its OWN region.
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${CONSUMER_STACK}" --state-bucket "${STATE_BUCKET}" --region "${CONSUMER_REGION}" --yes >/dev/null 2>&1
-    node "${LOCAL_DIST}" state destroy "${PRODUCER_STACK}" --state-bucket "${STATE_BUCKET}" --region "${PRODUCER_REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${CONSUMER_STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${CONSUMER_REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${PRODUCER_STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${PRODUCER_REGION}" --yes >/dev/null 2>&1
   fi
   # Direct API fallback so a half-deployed AWS resource doesn't leak —
   # delete the SSM parameter from the region it was created in.

--- a/tests/integration/glue-securityconfig-replace/verify.sh
+++ b/tests/integration/glue-securityconfig-replace/verify.sh
@@ -74,7 +74,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws glue delete-security-configuration --name "${SEC_CONFIG}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/glue-update-hardening/verify.sh
+++ b/tests/integration/glue-update-hardening/verify.sh
@@ -86,7 +86,7 @@ cleanup() {
   if [ -x "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" \
       --yes \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi

--- a/tests/integration/iam-access-key/verify.sh
+++ b/tests/integration/iam-access-key/verify.sh
@@ -81,7 +81,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true

--- a/tests/integration/iam-managed-policy/verify.sh
+++ b/tests/integration/iam-managed-policy/verify.sh
@@ -67,7 +67,7 @@ cleanup() {
   set +e
   if [ -x "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET}" --force >/dev/null 2>&1
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET:-}" --yes >/dev/null 2>&1
   fi
   rm -f "${DEPLOY_LOG}" 2>/dev/null || true
   set -e

--- a/tests/integration/iam-oidc-provider/verify.sh
+++ b/tests/integration/iam-oidc-provider/verify.sh
@@ -72,7 +72,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws iam delete-open-id-connect-provider --open-id-connect-provider-arn "${PROVIDER_ARN}" >/dev/null 2>&1 || true
   # Sweep stack-prefixed roles (deploy role + custom resource provider role).

--- a/tests/integration/iam-role-policies-drift-clean/verify.sh
+++ b/tests/integration/iam-role-policies-drift-clean/verify.sh
@@ -81,7 +81,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   QUEUE_URL="$(aws sqs get-queue-url --queue-name "${QUEUE_NAME}" --region "${REGION}" \

--- a/tests/integration/iam-role-prefixed-name-update/verify.sh
+++ b/tests/integration/iam-role-prefixed-name-update/verify.sh
@@ -86,7 +86,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   delete_role
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/import-attributes/verify.sh
+++ b/tests/integration/import-attributes/verify.sh
@@ -151,7 +151,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -f "${LOCAL_DIST}" ]; then
-    ${CLI} state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" --yes >/dev/null 2>&1
+    ${CLI} state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --yes >/dev/null 2>&1
   fi
   # Unconditional: covers the orphaned window and any state-teardown failure.
   aws iam delete-policy --policy-arn "${POLICY_ARN}" >/dev/null 2>&1

--- a/tests/integration/inplace-attr-propagation/verify.sh
+++ b/tests/integration/inplace-attr-propagation/verify.sh
@@ -73,7 +73,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws ssm delete-parameter --name "${BASE}" --region "${REGION}" >/dev/null 2>&1
   aws ssm delete-parameter --name "${DERIVED}" --region "${REGION}" >/dev/null 2>&1

--- a/tests/integration/kinesis-esm-filter/verify.sh
+++ b/tests/integration/kinesis-esm-filter/verify.sh
@@ -51,7 +51,7 @@ LOCAL_DIST="${PWD}/../../../dist/cli.js"
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   for uuid in $(aws lambda list-event-source-mappings --function-name "${FN}" --region "${REGION}" --query 'EventSourceMappings[].UUID' --output text 2>/dev/null); do
     aws lambda delete-event-source-mapping --uuid "${uuid}" --region "${REGION}" >/dev/null 2>&1 || true
   done

--- a/tests/integration/kinesis-stream-mode-switch/verify.sh
+++ b/tests/integration/kinesis-stream-mode-switch/verify.sh
@@ -75,7 +75,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws kinesis delete-stream --stream-name "${STREAM_NAME}" --enforce-consumer-deletion \
     --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/lambda-alias-provisioned-concurrency/verify.sh
+++ b/tests/integration/lambda-alias-provisioned-concurrency/verify.sh
@@ -51,7 +51,7 @@ LOCAL_DIST="${PWD}/../../../dist/cli.js"
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   aws lambda delete-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1 || true
   aws logs delete-log-group --log-group-name "/aws/lambda/${FN}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/lambda-arch-switch/verify.sh
+++ b/tests/integration/lambda-arch-switch/verify.sh
@@ -81,7 +81,7 @@ cleanup() {
   if [ -n "${STATE_BUCKET:-}" ] && [ -f "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" \
       --yes \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi

--- a/tests/integration/lambda-config-field-removal/verify.sh
+++ b/tests/integration/lambda-config-field-removal/verify.sh
@@ -76,7 +76,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1
   aws logs delete-log-group --log-group-name "/aws/lambda/${FN}" --region "${REGION}" >/dev/null 2>&1

--- a/tests/integration/lambda-destinations/verify.sh
+++ b/tests/integration/lambda-destinations/verify.sh
@@ -106,7 +106,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   delete_queue_by_name "${SUCCESS_Q}"

--- a/tests/integration/lambda-env-removal/verify.sh
+++ b/tests/integration/lambda-env-removal/verify.sh
@@ -73,7 +73,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1
   aws logs delete-log-group --log-group-name "/aws/lambda/${FN}" --region "${REGION}" >/dev/null 2>&1

--- a/tests/integration/lambda-esm-self-managed-kafka/verify.sh
+++ b/tests/integration/lambda-esm-self-managed-kafka/verify.sh
@@ -76,7 +76,7 @@ LOCAL_DIST="${PWD}/../../../dist/cli.js"
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   for uuid in $(aws lambda list-event-source-mappings --function-name "${FN}" --region "${REGION}" --query 'EventSourceMappings[].UUID' --output text 2>/dev/null); do
     aws lambda delete-event-source-mapping --uuid "${uuid}" --region "${REGION}" >/dev/null 2>&1 || true
   done

--- a/tests/integration/lambda-event-invoke-config-update/verify.sh
+++ b/tests/integration/lambda-event-invoke-config-update/verify.sh
@@ -75,7 +75,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # The EventInvokeConfig is deleted with the function; delete the function +
   # DLQ explicitly in case a partial run left them.

--- a/tests/integration/lambda-layer-version-update/verify.sh
+++ b/tests/integration/lambda-layer-version-update/verify.sh
@@ -77,7 +77,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   # Delete every published version of the test layer.

--- a/tests/integration/lambda-log-retention/verify.sh
+++ b/tests/integration/lambda-log-retention/verify.sh
@@ -78,7 +78,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   sweep_log_groups
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/lambda-microvm-image/verify.sh
+++ b/tests/integration/lambda-microvm-image/verify.sh
@@ -77,7 +77,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ] || [ -f "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # GetMicrovmImage / DeleteMicrovmImage require the image ARN (a bare Name is
   # rejected with "Invalid ARN format"); resolve the ARN by name first.

--- a/tests/integration/lambda-reserved-concurrency/verify.sh
+++ b/tests/integration/lambda-reserved-concurrency/verify.sh
@@ -51,7 +51,7 @@ LOCAL_DIST="${PWD}/../../../dist/cli.js"
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   aws lambda delete-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1 || true
   aws logs delete-log-group --log-group-name "/aws/lambda/${FN}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/lambda-snapstart/verify.sh
+++ b/tests/integration/lambda-snapstart/verify.sh
@@ -77,7 +77,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FN}" --region "${REGION}" >/dev/null 2>&1 || true
   aws logs delete-log-group --log-group-name "/aws/lambda/${FN}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/loggroup-class-guard/verify.sh
+++ b/tests/integration/loggroup-class-guard/verify.sh
@@ -79,7 +79,7 @@ cleanup() {
   if [ -n "${STATE_BUCKET:-}" ] && [ -f "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" \
       --yes \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi

--- a/tests/integration/loggroup-kms-associate/verify.sh
+++ b/tests/integration/loggroup-kms-associate/verify.sh
@@ -79,7 +79,7 @@ cleanup() {
   if [ -n "${STATE_BUCKET:-}" ] && [ -f "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" \
       --yes \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi

--- a/tests/integration/multi-asset/verify.sh
+++ b/tests/integration/multi-asset/verify.sh
@@ -163,7 +163,7 @@ fi
 echo "==> Pre-run cleanup"
 # Pre-run cleanup must not exit the script (it runs before deploy). Inline a
 # minimal state drop here; the EXIT trap handles the full teardown.
-node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
   --region "${REGION}" --yes >/dev/null 2>&1 || true
 
 # --- Phase 1: deploy (publishes 1 ECR image + 4 S3 assets concurrently) -----

--- a/tests/integration/nodejs-function/verify.sh
+++ b/tests/integration/nodejs-function/verify.sh
@@ -75,7 +75,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   sweep_log_groups
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/opensearch-domain-getatt/verify.sh
+++ b/tests/integration/opensearch-domain-getatt/verify.sh
@@ -66,7 +66,7 @@ cleanup() {
   echo "==> Cleanup (errors tolerated)"
   set +e
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET:-}" --yes >/dev/null 2>&1
   fi
   aws ssm delete-parameter --name "${ENDPOINT_PARAM}" --region "${REGION}" >/dev/null 2>&1 || true
   aws ssm delete-parameter --name "${ARN_PARAM}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/propagation-races-2/verify.sh
+++ b/tests/integration/propagation-races-2/verify.sh
@@ -85,7 +85,7 @@ cleanup() {
   # cdkd-owned teardown first (deletes resources AND state in dependency order).
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" \
       --yes
   fi

--- a/tests/integration/raw-cfn-conditions-params/verify.sh
+++ b/tests/integration/raw-cfn-conditions-params/verify.sh
@@ -74,7 +74,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   QURL="$(aws sqs get-queue-url --queue-name "${QUEUE_NAME}" --region "${REGION}" --query QueueUrl --output text 2>/dev/null)"
   if [ -n "${QURL}" ] && [ "${QURL}" != "None" ]; then

--- a/tests/integration/rds-aurora/verify.sh
+++ b/tests/integration/rds-aurora/verify.sh
@@ -98,7 +98,7 @@ cleanup() {
     # DeletionProtection=true live on the SecurityCluster (#1160 fixture
     # shape); idempotent when protection is already off.
     node "${LOCAL_DIST}" state destroy "${STACK}" \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" \
       --remove-protection \
       --yes

--- a/tests/integration/rds-dbinstance-backfill/verify.sh
+++ b/tests/integration/rds-dbinstance-backfill/verify.sh
@@ -119,7 +119,7 @@ cleanup() {
     # DeletionProtection=true live on the DBInstance (#1160 fixture
     # shape); idempotent when protection is already off.
     node "${LOCAL_DIST}" state destroy "${STACK}" \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" \
       --remove-protection \
       --yes

--- a/tests/integration/rds-full-stack/verify.sh
+++ b/tests/integration/rds-full-stack/verify.sh
@@ -103,7 +103,7 @@ cleanup() {
   set +eu
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" \
       --yes
   fi

--- a/tests/integration/recreate-mixed-direction/verify.sh
+++ b/tests/integration/recreate-mixed-direction/verify.sh
@@ -64,7 +64,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probes"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FWD_FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   aws lambda delete-function --function-name "${BACK_FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/recreate-via-cc-api/verify.sh
+++ b/tests/integration/recreate-via-cc-api/verify.sh
@@ -72,7 +72,7 @@ cleanup() {
   # cleanup should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   # Empty + delete the S3 probe bucket if it leaked from a prior run.

--- a/tests/integration/recreate-via-sdk-provider/verify.sh
+++ b/tests/integration/recreate-via-sdk-provider/verify.sh
@@ -69,7 +69,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS probe"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws lambda delete-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/redshift-cluster-getatt/verify.sh
+++ b/tests/integration/redshift-cluster-getatt/verify.sh
@@ -64,7 +64,7 @@ cleanup() {
   echo "==> Cleanup (errors tolerated)"
   set +e
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET:-}" --yes >/dev/null 2>&1
   fi
   aws ssm delete-parameter --name "${ADDR_PARAM}" --region "${REGION}" >/dev/null 2>&1 || true
   aws ssm delete-parameter --name "${PORT_PARAM}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/rename-refactor/verify.sh
+++ b/tests/integration/rename-refactor/verify.sh
@@ -107,7 +107,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   for gen in a b; do
     aws lambda delete-function --function-name "${PFX}-handler-${gen}" --region "${REGION}" >/dev/null 2>&1

--- a/tests/integration/replacement-fanout/verify.sh
+++ b/tests/integration/replacement-fanout/verify.sh
@@ -85,7 +85,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --yes --state-bucket "${STATE_BUCKET}" --region "${REGION}"
+    node "${LOCAL_DIST}" state destroy "${STACK}" --yes --state-bucket "${STATE_BUCKET:-}" --region "${REGION}"
     rc=$?
   else
     rc=0

--- a/tests/integration/replacement-immutable-name/verify.sh
+++ b/tests/integration/replacement-immutable-name/verify.sh
@@ -135,7 +135,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   for s in v1 v2; do
     aws kinesis delete-stream --stream-name "${STACK}-stream-${s}" --enforce-consumer-deletion --region "${REGION}" >/dev/null 2>&1

--- a/tests/integration/rollback-deletion-policy-snapshot/verify.sh
+++ b/tests/integration/rollback-deletion-policy-snapshot/verify.sh
@@ -110,7 +110,7 @@ cleanup() {
     aws ec2 delete-volume --volume-id "${vol_id}" --region "${REGION}" >/dev/null 2>&1
   done
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET}" \
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" --skip-final-snapshot --yes >/dev/null 2>&1
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/route53/verify.sh
+++ b/tests/integration/route53/verify.sh
@@ -97,7 +97,7 @@ cleanup() {
     # exited 0 — a failed destroy must LEAVE state so AWS resources are
     # not orphaned (the next run / a human can retry against the state).
     node "${LOCAL_DIST}" state destroy "${STACK}" --yes \
-      --state-bucket "${STATE_BUCKET}" --region "${REGION}" >/dev/null 2>&1
+      --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi
   if [ -n "${STATE_BUCKET:-}" ] && [ "${destroy_rc}" -eq 0 ]; then

--- a/tests/integration/s3-analytics-inventory/verify.sh
+++ b/tests/integration/s3-analytics-inventory/verify.sh
@@ -116,7 +116,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws s3api delete-bucket --bucket "${SOURCE_BUCKET}" --region "${REGION}" >/dev/null 2>&1 || true
   aws s3api delete-bucket --bucket "${REPORT_BUCKET}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/s3-cloudfront/verify.sh
+++ b/tests/integration/s3-cloudfront/verify.sh
@@ -64,7 +64,7 @@ cleanup() {
   set +eu
   local state_destroy_ok=1
   if [ -x "${LOCAL_DIST}" ]; then
-    if node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1; then
+    if node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1; then
       state_destroy_ok=0
     fi
   fi

--- a/tests/integration/s3-event-notification/verify.sh
+++ b/tests/integration/s3-event-notification/verify.sh
@@ -80,7 +80,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws dynamodb delete-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${BUCKET_NAME}" ]; then

--- a/tests/integration/s3-lifecycle/verify.sh
+++ b/tests/integration/s3-lifecycle/verify.sh
@@ -101,7 +101,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws s3api delete-bucket --bucket "${BUCKET_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   aws s3api delete-bucket --bucket "${LEGACY_BUCKET}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/s3-object-lock/verify.sh
+++ b/tests/integration/s3-object-lock/verify.sh
@@ -68,7 +68,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws s3api delete-bucket --bucket "${BUCKET_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/s3-replication-and-filter/verify.sh
+++ b/tests/integration/s3-replication-and-filter/verify.sh
@@ -122,7 +122,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Replication config must go before the source bucket can be deleted cleanly.
   aws s3api delete-bucket-replication --bucket "${SRC_BUCKET}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/s3-subconfig-removal/verify.sh
+++ b/tests/integration/s3-subconfig-removal/verify.sh
@@ -103,7 +103,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws s3api delete-bucket --bucket "${BUCKET_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then

--- a/tests/integration/s3-tables/verify.sh
+++ b/tests/integration/s3-tables/verify.sh
@@ -81,7 +81,7 @@ cleanup() {
   set +eu
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" \
       --yes
   fi

--- a/tests/integration/s3-vectors/verify.sh
+++ b/tests/integration/s3-vectors/verify.sh
@@ -60,7 +60,7 @@ cleanup() {
   set +eu
   destroy_rc=0
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --yes --state-bucket "${STATE_BUCKET}" --region "${REGION}" >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --yes --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi
   if [ -n "${STATE_BUCKET:-}" ] && [ "${destroy_rc}" = "0" ]; then

--- a/tests/integration/scheduler-custom-group/verify.sh
+++ b/tests/integration/scheduler-custom-group/verify.sh
@@ -53,7 +53,7 @@ LOCAL_DIST="${PWD}/../../../dist/cli.js"
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   aws scheduler delete-schedule --name "${SCHED}" --group-name "${GROUP}" --region "${REGION}" >/dev/null 2>&1 || true
   aws scheduler delete-schedule-group --name "${GROUP}" --region "${REGION}" >/dev/null 2>&1 || true
   ACCT=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)

--- a/tests/integration/schema-v5-to-v6-migration/verify.sh
+++ b/tests/integration/schema-v5-to-v6-migration/verify.sh
@@ -78,7 +78,7 @@ cleanup() {
   set +e
   # Try the v6 binary's destroy first (cleanest path).
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Direct API fallback so a half-deployed AWS resource doesn't leak.
   aws ssm delete-parameter --name "${PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/schema-v6-to-v7-migration/verify.sh
+++ b/tests/integration/schema-v6-to-v7-migration/verify.sh
@@ -78,7 +78,7 @@ cleanup() {
   set +e
   # Try the v7 binary's destroy first (cleanest path).
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Direct API fallback so a half-deployed AWS resource doesn't leak.
   aws ssm delete-parameter --name "${PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/schema-v7-to-v8-migration/verify.sh
+++ b/tests/integration/schema-v7-to-v8-migration/verify.sh
@@ -87,8 +87,8 @@ cleanup() {
   # producer last — Fn::GetStackOutput is a weak reference so order
   # doesn't strictly matter, but mirrors real-world recommended order.
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${CONSUMER_STACK}" --region "${REGION}" --yes >/dev/null 2>&1
-    node "${LOCAL_DIST}" state destroy "${PRODUCER_STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${CONSUMER_STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${PRODUCER_STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Direct API fallback so a half-deployed AWS resource doesn't leak.
   aws ssm delete-parameter --name "${CONSUMER_PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/sdk-ccapi-crossref/verify.sh
+++ b/tests/integration/sdk-ccapi-crossref/verify.sh
@@ -90,7 +90,7 @@ cleanup() {
   # it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws ssm delete-parameter --name "${PARAM_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   aws lambda delete-function --function-name "${FN_NAME}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/secrets-rotation-schedule/verify.sh
+++ b/tests/integration/secrets-rotation-schedule/verify.sh
@@ -82,7 +82,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws secretsmanager delete-secret --secret-id "${SECRET_NAME}" \
     --force-delete-without-recovery --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/ses-identity/verify.sh
+++ b/tests/integration/ses-identity/verify.sh
@@ -68,7 +68,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws sesv2 delete-email-identity --email-identity "${IDENTITY}" --region "${REGION}" >/dev/null 2>&1 || true
   aws sesv2 delete-configuration-set --configuration-set-name "${CONFIG_SET}" --region "${REGION}" >/dev/null 2>&1 || true

--- a/tests/integration/sg-circular-dependency/verify.sh
+++ b/tests/integration/sg-circular-dependency/verify.sh
@@ -125,7 +125,7 @@ cleanup() {
     # state destroy first — exercises cdkd's own teardown ordering. Do NOT
     # silence stderr so a partial failure is visible.
     node "${LOCAL_DIST}" state destroy "${STACK}" \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" \
       --yes
   fi

--- a/tests/integration/sns-event-source/verify.sh
+++ b/tests/integration/sns-event-source/verify.sh
@@ -77,7 +77,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   aws dynamodb delete-table --table-name "${TABLE_NAME}" --region "${REGION}" >/dev/null 2>&1 || true
   ARN="$(aws sns list-topics --region "${REGION}" \

--- a/tests/integration/sns-inline-subscription/verify.sh
+++ b/tests/integration/sns-inline-subscription/verify.sh
@@ -69,7 +69,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true

--- a/tests/integration/sns-pending-subscription/verify.sh
+++ b/tests/integration/sns-pending-subscription/verify.sh
@@ -71,7 +71,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # The pending email subscription is undeletable by design (SNS rejects
   # Unsubscribe until it expires), so state destroy above may report a

--- a/tests/integration/sns-sqs-event/verify.sh
+++ b/tests/integration/sns-sqs-event/verify.sh
@@ -80,7 +80,7 @@ cleanup() {
   # should run as much as it can with the env it has.
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true

--- a/tests/integration/sns-subscription-filter/verify.sh
+++ b/tests/integration/sns-subscription-filter/verify.sh
@@ -66,7 +66,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   ARN="$(aws sns list-topics --region "${REGION}" \
     --query "Topics[?ends_with(TopicArn, ':${TOPIC_NAME}')].TopicArn | [0]" --output text 2>/dev/null)"

--- a/tests/integration/sqs-esm-max-concurrency/verify.sh
+++ b/tests/integration/sqs-esm-max-concurrency/verify.sh
@@ -54,7 +54,7 @@ LOCAL_DIST="${PWD}/../../../dist/cli.js"
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   for uuid in $(aws lambda list-event-source-mappings --function-name "${FN}" --region "${REGION}" --query 'EventSourceMappings[].UUID' --output text 2>/dev/null); do
     aws lambda delete-event-source-mapping --uuid "${uuid}" --region "${REGION}" >/dev/null 2>&1 || true
   done

--- a/tests/integration/stepfunctions-logging/verify.sh
+++ b/tests/integration/stepfunctions-logging/verify.sh
@@ -83,7 +83,7 @@ cleanup() {
   if [ -n "${STATE_BUCKET:-}" ] && [ -f "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" state destroy "${STACK}" \
       --yes \
-      --state-bucket "${STATE_BUCKET}" \
+      --state-bucket "${STATE_BUCKET:-}" \
       --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi

--- a/tests/integration/stepfunctions/verify.sh
+++ b/tests/integration/stepfunctions/verify.sh
@@ -66,7 +66,7 @@ cleanup() {
   set +e
   if [ -x "${LOCAL_DIST}" ]; then
     node "${LOCAL_DIST}" destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET}" --force >/dev/null 2>&1
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --state-bucket "${STATE_BUCKET:-}" --yes >/dev/null 2>&1
   fi
   rm -f "${DEPLOY_LOG}" 2>/dev/null || true
   set -e

--- a/tests/integration/synthetics-canary/verify.sh
+++ b/tests/integration/synthetics-canary/verify.sh
@@ -70,7 +70,7 @@ sweep_canary_backend() {
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   aws synthetics delete-canary --name "${CANARY}" --region "${REGION}" >/dev/null 2>&1 || true
   aws s3 rb "s3://${BUCKET}" --force >/dev/null 2>&1 || true
   sweep_canary_backend

--- a/tests/integration/throttle-wide-dag/verify.sh
+++ b/tests/integration/throttle-wide-dag/verify.sh
@@ -100,7 +100,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   fi
   # Best-effort sweep of any fixture-named resources left behind.
   for i in $(seq 0 $((ROLE_COUNT - 1))); do

--- a/tests/integration/update-replace/verify.sh
+++ b/tests/integration/update-replace/verify.sh
@@ -79,7 +79,7 @@ cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
   set +eu
   if [ -x "${LOCAL_DIST}" ] && [ -n "${STATE_BUCKET:-}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --yes --state-bucket "${STATE_BUCKET}" --region "${REGION}"
+    node "${LOCAL_DIST}" state destroy "${STACK}" --yes --state-bucket "${STATE_BUCKET:-}" --region "${REGION}"
     rc=$?
   else
     rc=0

--- a/tests/integration/vpc-nat-gateway/verify.sh
+++ b/tests/integration/vpc-nat-gateway/verify.sh
@@ -79,7 +79,7 @@ cleanup() {
   set +eu
   destroy_rc=0
   if [ -f "${LOCAL_DIST}" ]; then
-    node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+    node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
     destroy_rc=$?
   fi
   # Only drop the state file when the destroy actually succeeded. A classic NAT

--- a/tests/integration/wait-condition-handle/verify.sh
+++ b/tests/integration/wait-condition-handle/verify.sh
@@ -54,7 +54,7 @@ LOCAL_DIST="${PWD}/../../../dist/cli.js"
 cleanup() {
   echo "==> Cleanup"
   set +eu
-  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --region "${REGION}" --yes >/dev/null 2>&1
+  [ -x "${LOCAL_DIST}" ] && node "${LOCAL_DIST}" state destroy "${STACK}" --state-bucket "${STATE_BUCKET:-}" --region "${REGION}" --yes >/dev/null 2>&1
   aws ssm delete-parameter --name "${PARAM}" --region "${REGION}" >/dev/null 2>&1 || true
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true

--- a/tests/unit/scripts/integ-state-bucket.test.ts
+++ b/tests/unit/scripts/integ-state-bucket.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  collectStateDestroyInvocations,
+  checkFixture,
+} from '../../../scripts/check-integ-state-bucket.js';
+
+/**
+ * Regression guard for issue #1567: a fixture's `state destroy` sweep that
+ * omits `--state-bucket` reads the STS-derived default bucket, not the
+ * harness's `STATE_BUCKET`, and silently no-ops against any non-default bucket.
+ * See `scripts/check-integ-state-bucket.ts` for the full rationale.
+ */
+
+const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
+const CLI = 'node "${LOCAL_DIST}"';
+
+function readFixtures() {
+  return readdirSync(INTEG_ROOT, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(INTEG_ROOT, e.name, 'verify.sh')))
+    .map((e) => ({
+      name: e.name,
+      path: join(INTEG_ROOT, e.name, 'verify.sh'),
+      ...checkFixture(readFileSync(join(INTEG_ROOT, e.name, 'verify.sh'), 'utf8')),
+    }));
+}
+
+describe('collectStateDestroyInvocations', () => {
+  it('accepts the canonical form', () => {
+    const inv = collectStateDestroyInvocations(
+      `${CLI} state destroy "\${STACK}" --state-bucket "\${STATE_BUCKET:-}" --region "\${REGION}" --yes\n`,
+    );
+    expect(inv).toHaveLength(1);
+    expect(inv[0]!.passesStateBucket).toBe(true);
+  });
+
+  it('flags an invocation that omits the flag', () => {
+    const inv = collectStateDestroyInvocations(
+      `${CLI} state destroy "\${STACK}" --region "\${REGION}" --yes\n`,
+    );
+    expect(inv).toHaveLength(1);
+    expect(inv[0]!.passesStateBucket).toBe(false);
+  });
+
+  // Each shape below is a real spelling from the tree. A parser that misses one
+  // silently exempts every fixture using it -- the #1097 lint shipped exactly
+  // that defect twice, so every supported shape gets its own case.
+  it.each([
+    ['plain', `${CLI} state destroy "\${STACK}" --region "\${R}" --yes`],
+    ['&&-guarded', `[ -x "\${LOCAL_DIST}" ] && ${CLI} state destroy "\${STACK}" --region "\${R}" --yes`],
+    ['if-guarded', `if ${CLI} state destroy "\${STACK}" --region "\${R}" --yes; then :; fi`],
+    ['env-prefixed', `CDKD_TEST_UPDATE=true ${CLI} state destroy "\${STACK}" --region "\${R}" --yes`],
+    ['bare \${CLI} var', `\${CLI} state destroy "\${STACK}" --region "\${R}" --yes`],
+    [
+      'continuation-joined',
+      `${CLI} state destroy "\${STACK}" \\\n  --region "\${R}" --yes`,
+    ],
+    ['indented in a function', `cleanup() {\n  ${CLI} state destroy "\${S}" --region "\${R}" --yes\n}`],
+  ])('sees the %s shape', (_label, script) => {
+    const inv = collectStateDestroyInvocations(`${script}\n`);
+    expect(inv).toHaveLength(1);
+    expect(inv[0]!.passesStateBucket).toBe(false);
+  });
+
+  it('credits the flag when it lands on a continuation line', () => {
+    // The 23 fixtures already on the reference multi-line shape carry the flag
+    // on the SECOND physical line; a line-oriented scan would report them all.
+    const inv = collectStateDestroyInvocations(
+      `${CLI} state destroy "\${STACK}" --state-bucket "\${STATE_BUCKET:-}" \\\n  --region "\${R}" --yes\n`,
+    );
+    expect(inv[0]!.passesStateBucket).toBe(true);
+  });
+
+  it('accepts the --state-bucket=value spelling', () => {
+    const inv = collectStateDestroyInvocations(
+      `${CLI} state destroy "\${STACK}" --state-bucket="\${STATE_BUCKET:-}" --yes\n`,
+    );
+    expect(inv[0]!.passesStateBucket).toBe(true);
+  });
+
+  // Prose is not an invocation. Each of these exists verbatim in the tree and
+  // was a false positive of the first hand-rolled grep.
+  it.each([
+    ['a comment', `# ${CLI} state destroy "\${STACK}" --yes`],
+    ['a trailing comment', `echo hi  # then ${CLI} state destroy "\${S}" --yes`],
+    ['an echo hint', `echo "    node \${LOCAL_DIST} state destroy \${STACK} --yes" >&2`],
+    ['a heredoc body', `cat <<'EOF'\n${CLI} state destroy "\${S}" --yes\nEOF`],
+    ['prose naming the command', `echo "destroying stack via cdkd state destroy"`],
+  ])('ignores %s', (_label, script) => {
+    expect(collectStateDestroyInvocations(`${script}\n`)).toEqual([]);
+  });
+
+  it('does not match a different subcommand', () => {
+    expect(
+      collectStateDestroyInvocations(`${CLI} state show "\${STACK}" --yes\n`),
+    ).toEqual([]);
+    // `destroy` is a DIFFERENT command from `state destroy` and already passes
+    // the flag at all 227 call sites; matching it here would be a false report.
+    expect(collectStateDestroyInvocations(`${CLI} destroy "\${STACK}" --yes\n`)).toEqual([]);
+  });
+
+  it('does not match a non-cdkd binary', () => {
+    expect(
+      collectStateDestroyInvocations(`terraform state destroy "\${STACK}" --yes\n`),
+    ).toEqual([]);
+  });
+
+  it('finds both invocations when a line runs two', () => {
+    const inv = collectStateDestroyInvocations(
+      `${CLI} state destroy "\${A}" --yes; ${CLI} state destroy "\${B}" --state-bucket "\${SB}" --yes\n`,
+    );
+    expect(inv.map((i) => i.passesStateBucket)).toEqual([false, true]);
+  });
+});
+
+describe('integ fixture state-bucket convention (#1567)', () => {
+  const fixtures = readFixtures();
+  const all = fixtures.flatMap((f) => f.invocations);
+
+  it('finds the fixture tree', () => {
+    expect(fixtures.length).toBeGreaterThan(100);
+  });
+
+  // Coverage floors: "0 offenders" and "parsed nothing" are the same green.
+  // Measured 2026-08-11 at 171 invocations across 166 of 228 fixtures; floors
+  // sit just under so a parser regression fails loudly rather than vacuously.
+  it('parses the invocations it claims to', () => {
+    expect(all.length).toBeGreaterThanOrEqual(165);
+    expect(fixtures.filter((f) => f.invocations.length > 0).length).toBeGreaterThanOrEqual(160);
+  });
+
+  it('still parses each shape it claims to handle', () => {
+    // An aggregate floor hides a dead shape: `plain` is 169 of 171, so the
+    // env-prefixed and guarded parsers could both regress to zero and the
+    // total above would barely move. Real-tree counts 2026-08-11: 169/1/1.
+    const perShape = (shape: string) => all.filter((i) => i.shape === shape).length;
+    expect(perShape('plain')).toBeGreaterThanOrEqual(160);
+    expect(perShape('env-prefixed')).toBeGreaterThanOrEqual(1);
+    expect(perShape('guarded')).toBeGreaterThanOrEqual(1);
+  });
+
+  it('every state destroy passes --state-bucket explicitly', () => {
+    const offenders = fixtures
+      .filter((f) => f.offenders.length > 0)
+      .map((f) => `${f.name}: ${f.offenders[0]!.command.slice(0, 90)}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('uses the set -u-safe ${STATE_BUCKET:-} form', () => {
+    // `cleanup` is trap-installed and can run BEFORE the script's own
+    // `[ -z "${STATE_BUCKET:-}" ]` guard rejects an unset variable, so the
+    // unguarded `"${STATE_BUCKET}"` would abort teardown mid-sweep under set -u.
+    const bad = fixtures
+      .flatMap((f) => f.invocations.map((i) => ({ name: f.name, ...i })))
+      .filter((i) => /--state-bucket[= ]"?\$\{STATE_BUCKET\}/.test(i.command))
+      .map((i) => i.name);
+    expect(bad).toEqual([]);
+  });
+});
+
+describe('real-code fail probe', () => {
+  // Coverage floors prove the checker SEES its input; they do not prove it
+  // still REJECTS a violation. Re-introduce the real defect into a real
+  // fixture's real text and require the checker to name it.
+  it('reports a real fixture whose flag is removed again', () => {
+    const path = join(INTEG_ROOT, 'apigateway/verify.sh');
+    const original = readFileSync(path, 'utf8');
+    expect(original).toContain('--state-bucket "${STATE_BUCKET:-}"');
+
+    const regressed = original.replace(' --state-bucket "${STATE_BUCKET:-}"', '');
+    expect(regressed).not.toEqual(original);
+
+    const verdict = checkFixture(regressed);
+    expect(verdict.offenders).toHaveLength(1);
+    expect(verdict.offenders[0]!.command).toContain('state destroy');
+    // The clean text must still pass, or the probe proves nothing.
+    expect(checkFixture(original).offenders).toEqual([]);
+  });
+
+  it('leaves the real fixture untouched', () => {
+    expect(readFileSync(join(INTEG_ROOT, 'apigateway/verify.sh'), 'utf8')).toContain(
+      '--state-bucket "${STATE_BUCKET:-}"',
+    );
+  });
+});

--- a/tests/unit/scripts/integ-state-bucket.test.ts
+++ b/tests/unit/scripts/integ-state-bucket.test.ts
@@ -16,6 +16,23 @@ import {
 const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
 const CLI = 'node "${LOCAL_DIST}"';
 
+/**
+ * A deliberately CRUDE, independent prose stripper for the completeness audit
+ * below — comment lines and `echo` lines only.
+ *
+ * It must NOT reuse the classifier's own normalizer: if that over-stripped,
+ * both sides would agree and the audit would pass vacuously. Being cruder than
+ * the classifier is the safe direction — it leaves MORE text in, so the audit
+ * errs toward reporting a fixture rather than excusing one.
+ */
+function stripProseForAudit(script: string): string {
+  return script
+    .split('\n')
+    .filter((l) => !/^\s*#/.test(l) && !/^\s*echo\b/.test(l))
+    .map((l) => l.replace(/\s#.*$/, ''))
+    .join('\n');
+}
+
 function readFixtures() {
   return readdirSync(INTEG_ROOT, { withFileTypes: true })
     .filter((e) => e.isDirectory() && existsSync(join(INTEG_ROOT, e.name, 'verify.sh')))
@@ -26,9 +43,12 @@ function readFixtures() {
     }));
 }
 
+/** Synthetic-shape helper: the parsed invocations only. */
+const parse = (script: string) => collectStateDestroyInvocations(script).invocations;
+
 describe('collectStateDestroyInvocations', () => {
   it('accepts the canonical form', () => {
-    const inv = collectStateDestroyInvocations(
+    const inv = parse(
       `${CLI} state destroy "\${STACK}" --state-bucket "\${STATE_BUCKET:-}" --region "\${REGION}" --yes\n`,
     );
     expect(inv).toHaveLength(1);
@@ -36,7 +56,7 @@ describe('collectStateDestroyInvocations', () => {
   });
 
   it('flags an invocation that omits the flag', () => {
-    const inv = collectStateDestroyInvocations(
+    const inv = parse(
       `${CLI} state destroy "\${STACK}" --region "\${REGION}" --yes\n`,
     );
     expect(inv).toHaveLength(1);
@@ -58,7 +78,7 @@ describe('collectStateDestroyInvocations', () => {
     ],
     ['indented in a function', `cleanup() {\n  ${CLI} state destroy "\${S}" --region "\${R}" --yes\n}`],
   ])('sees the %s shape', (_label, script) => {
-    const inv = collectStateDestroyInvocations(`${script}\n`);
+    const inv = parse(`${script}\n`);
     expect(inv).toHaveLength(1);
     expect(inv[0]!.passesStateBucket).toBe(false);
   });
@@ -66,14 +86,14 @@ describe('collectStateDestroyInvocations', () => {
   it('credits the flag when it lands on a continuation line', () => {
     // The 23 fixtures already on the reference multi-line shape carry the flag
     // on the SECOND physical line; a line-oriented scan would report them all.
-    const inv = collectStateDestroyInvocations(
+    const inv = parse(
       `${CLI} state destroy "\${STACK}" --state-bucket "\${STATE_BUCKET:-}" \\\n  --region "\${R}" --yes\n`,
     );
     expect(inv[0]!.passesStateBucket).toBe(true);
   });
 
   it('accepts the --state-bucket=value spelling', () => {
-    const inv = collectStateDestroyInvocations(
+    const inv = parse(
       `${CLI} state destroy "\${STACK}" --state-bucket="\${STATE_BUCKET:-}" --yes\n`,
     );
     expect(inv[0]!.passesStateBucket).toBe(true);
@@ -88,26 +108,26 @@ describe('collectStateDestroyInvocations', () => {
     ['a heredoc body', `cat <<'EOF'\n${CLI} state destroy "\${S}" --yes\nEOF`],
     ['prose naming the command', `echo "destroying stack via cdkd state destroy"`],
   ])('ignores %s', (_label, script) => {
-    expect(collectStateDestroyInvocations(`${script}\n`)).toEqual([]);
+    expect(parse(`${script}\n`)).toEqual([]);
   });
 
   it('does not match a different subcommand', () => {
     expect(
-      collectStateDestroyInvocations(`${CLI} state show "\${STACK}" --yes\n`),
+      parse(`${CLI} state show "\${STACK}" --yes\n`),
     ).toEqual([]);
     // `destroy` is a DIFFERENT command from `state destroy` and already passes
-    // the flag at all 227 call sites; matching it here would be a false report.
-    expect(collectStateDestroyInvocations(`${CLI} destroy "\${STACK}" --yes\n`)).toEqual([]);
+    // the flag at all 228 call sites; matching it here would be a false report.
+    expect(parse(`${CLI} destroy "\${STACK}" --yes\n`)).toEqual([]);
   });
 
   it('does not match a non-cdkd binary', () => {
     expect(
-      collectStateDestroyInvocations(`terraform state destroy "\${STACK}" --yes\n`),
+      parse(`terraform state destroy "\${STACK}" --yes\n`),
     ).toEqual([]);
   });
 
   it('finds both invocations when a line runs two', () => {
-    const inv = collectStateDestroyInvocations(
+    const inv = parse(
       `${CLI} state destroy "\${A}" --yes; ${CLI} state destroy "\${B}" --state-bucket "\${SB}" --yes\n`,
     );
     expect(inv.map((i) => i.passesStateBucket)).toEqual([false, true]);
@@ -130,14 +150,32 @@ describe('integ fixture state-bucket convention (#1567)', () => {
     expect(fixtures.filter((f) => f.invocations.length > 0).length).toBeGreaterThanOrEqual(160);
   });
 
-  it('still parses each shape it claims to handle', () => {
-    // An aggregate floor hides a dead shape: `plain` is 169 of 171, so the
-    // env-prefixed and guarded parsers could both regress to zero and the
-    // total above would barely move. Real-tree counts 2026-08-11: 169/1/1.
-    const perShape = (shape: string) => all.filter((i) => i.shape === shape).length;
-    expect(perShape('plain')).toBeGreaterThanOrEqual(160);
-    expect(perShape('env-prefixed')).toBeGreaterThanOrEqual(1);
-    expect(perShape('guarded')).toBeGreaterThanOrEqual(1);
+  // This is the real completeness net, and it is stronger than a per-shape
+  // floor: it needs no calibration, it cannot be satisfied vacuously, and it
+  // catches an invocation SHAPE the parser has never seen rather than only a
+  // regression in one it has. A per-shape floor was tried first and was both
+  // brittle (`env-prefixed` and `guarded` ride on ONE fixture each, so an
+  // unrelated edit reds the suite and invites deleting the floor) and blind to
+  // exactly the case that matters — a NEW binary spelling, which produces zero
+  // invocations in every shape at once.
+  it('parses a state destroy out of every fixture whose code contains one', () => {
+    const missed = fixtures
+      .filter((f) => {
+        // Same normalization the classifier uses, so prose does not count.
+        const code = stripProseForAudit(readFileSync(f.path, 'utf8'));
+        return code.includes('state destroy') && f.invocations.length === 0;
+      })
+      .map((f) => f.name);
+    expect(missed).toEqual([]);
+  });
+
+  it('recognizes the binary in every state destroy it finds', () => {
+    // An unknown spelling (`${CDKD}`, a literal `node dist/cli.js`, ...) would
+    // otherwise exempt the fixture silently — the #1097 lint's failure mode.
+    const unrecognized = fixtures
+      .filter((f) => f.unrecognized.length > 0)
+      .map((f) => `${f.name}: ${f.unrecognized[0]!.slice(0, 90)}`);
+    expect(unrecognized).toEqual([]);
   });
 
   it('every state destroy passes --state-bucket explicitly', () => {
@@ -153,9 +191,31 @@ describe('integ fixture state-bucket convention (#1567)', () => {
     // unguarded `"${STATE_BUCKET}"` would abort teardown mid-sweep under set -u.
     const bad = fixtures
       .flatMap((f) => f.invocations.map((i) => ({ name: f.name, ...i })))
-      .filter((i) => /--state-bucket[= ]"?\$\{STATE_BUCKET\}/.test(i.command))
+      .filter((i) => isUnguardedStateBucket(i.command))
       .map((i) => i.name);
     expect(bad).toEqual([]);
+  });
+});
+
+// This predicate is a second CI-blocking verdict whose pattern currently
+// matches NOTHING in the tree, so a typo in it would be permanently green.
+// These cases are what keep it honest.
+function isUnguardedStateBucket(command: string): boolean {
+  return /--state-bucket[= ]"?\$(?:\{STATE_BUCKET\}|STATE_BUCKET\b)/.test(command);
+}
+
+describe('isUnguardedStateBucket', () => {
+  it.each([
+    ['braced unguarded', '--state-bucket "${STATE_BUCKET}" --yes', true],
+    ['unbraced unguarded', '--state-bucket "$STATE_BUCKET" --yes', true],
+    ['unquoted unguarded', '--state-bucket ${STATE_BUCKET} --yes', true],
+    ['equals form unguarded', '--state-bucket="${STATE_BUCKET}" --yes', true],
+    ['guarded', '--state-bucket "${STATE_BUCKET:-}" --yes', false],
+    ['guarded equals form', '--state-bucket="${STATE_BUCKET:-}" --yes', false],
+    ['guarded with default', '--state-bucket "${STATE_BUCKET:-fallback}" --yes', false],
+    ['a different variable', '--state-bucket "${OTHER_BUCKET}" --yes', false],
+  ])('%s', (_label, command, expected) => {
+    expect(isUnguardedStateBucket(command)).toBe(expected);
   });
 });
 
@@ -178,9 +238,37 @@ describe('real-code fail probe', () => {
     expect(checkFixture(original).offenders).toEqual([]);
   });
 
-  it('leaves the real fixture untouched', () => {
-    expect(readFileSync(join(INTEG_ROOT, 'apigateway/verify.sh'), 'utf8')).toContain(
-      '--state-bucket "${STATE_BUCKET:-}"',
-    );
+  it('reports a real fixture whose binary spelling is unrecognized', () => {
+    // The other half of the net: an unknown binary must be REPORTED, never
+    // silently dropped. Swapping in a spelling the whitelist lacks must not
+    // reduce the fixture to "0 invocations, all clean".
+    const original = readFileSync(join(INTEG_ROOT, 'apigateway/verify.sh'), 'utf8');
+    const regressed = original.replaceAll('node "${LOCAL_DIST}"', 'node dist/cli.js');
+
+    const verdict = checkFixture(regressed);
+    expect(verdict.invocations).toEqual([]);
+    expect(verdict.unrecognized.length).toBeGreaterThanOrEqual(1);
+    expect(verdict.unrecognized[0]).toContain('state destroy');
+  });
+});
+
+describe('the premise that makes the ${STATE_BUCKET:-} form safe', () => {
+  // All 171 swept sites can pass an EMPTY value when the variable is unset.
+  // That is only acceptable because the resolver treats '' as "not supplied"
+  // and falls back exactly as omitting the flag does. Pin it here: if this
+  // ever changes, the whole sweep silently starts targeting the wrong bucket.
+  it('treats an empty --state-bucket as not-supplied', async () => {
+    const { resolveStateBucketWithSource } = await import('../../../src/cli/config-loader.js');
+    const saved = process.env['CDKD_STATE_BUCKET'];
+    process.env['CDKD_STATE_BUCKET'] = 'env-bucket';
+    try {
+      // A real value wins; an empty string must fall through to the env var.
+      expect(resolveStateBucketWithSource('real-bucket')?.bucket).toBe('real-bucket');
+      expect(resolveStateBucketWithSource('')?.bucket).toBe('env-bucket');
+      expect(resolveStateBucketWithSource(undefined)?.bucket).toBe('env-bucket');
+    } finally {
+      if (saved === undefined) delete process.env['CDKD_STATE_BUCKET'];
+      else process.env['CDKD_STATE_BUCKET'] = saved;
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixture `cleanup()` sweeps call `cdkd state destroy` to drop cdkd state. The harness exports the bucket as `STATE_BUCKET`, but the CLI's env fallback is **`CDKD_STATE_BUCKET`** — a different name — so a `state destroy` that omits `--state-bucket` never reads the harness's bucket at all.

Resolution is CLI flag > `CDKD_STATE_BUCKET` > `cdk.json` `context.cdkd.stateBucket` > STS default, so the omission landed in one of two wrong places:

- **109 fixture `cdk.json` files declare `context.cdkd.stateBucket`** (`your-cdkd-state-bucket`, `cdkd-state-test`), and `verify.sh` runs the CLI from the fixture directory — so the sweep resolved *that* name and died with `StateError: State bucket '...' does not exist`, swallowed by the call's own `>/dev/null 2>&1`. **48 of the fixtures swept here are in this group: their cleanups had been failing on every run, invisibly.**
- **The rest** fell through to the STS default `cdkd-state-{accountId}`, which is the harness bucket on a default setup — working by coincidence, and silently no-opping the moment `STATE_BUCKET` points anywhere else.

Either way the state record survives and wedges the fixture's next run.

*(The first revision of this PR described only the second mechanism. The `cdk.json` path was found in review and is the more common one; verified live.)*

## What made this a lint rather than a one-time sweep

| invocation | call sites | missing `--state-bucket` |
|---|---:|---:|
| `deploy` | 335 | **0** |
| `destroy` | 228 | **0** |
| `state destroy` | 171 | **96** (across 94 of the 166 fixtures that call it) |

`deploy` and `destroy` were already correct at every site; only `state destroy` had drifted — because nothing enforced it.

## Changes

- **Sweep**: `--state-bucket "${STATE_BUCKET:-}"` added to all 96 offending invocations.
- **Normalization**: all 171 sites now use the `set -u`-safe `"${STATE_BUCKET:-}"` form (53 were unguarded). `cleanup` is trap-installed and can run *before* the script's own `[ -z "${STATE_BUCKET:-}" ]` guard rejects an unset variable; a cleanup that only does `set +e` would then abort teardown mid-sweep. Empty is safe — the resolver treats `''` as not-supplied, now pinned by a unit test against the real resolver.
- **`deploy` / `destroy` deliberately keep the strict `"${STATE_BUCKET}"` form** (88 sites). There an unset bucket is a harness misconfiguration that must fail loudly rather than silently target the default.
- **New lint**: `scripts/check-integ-state-bucket.ts` + `tests/unit/scripts/integ-state-bucket.test.ts` (36 cases). Evaluates code only — heredocs, comments, `echo` arguments stripped.
- **Docs**: new fixture-convention section in `.claude/rules/testing.md` + `docs/testing.md`, matching the 9 siblings.
- **Hook fix**: `state-destroy-force-gate.sh` tested for `state destroy` and `-f` *independently on the whole line*, so `[ -f "${LOCAL_DIST}" ] && ... state destroy ... --yes` false-positived and blocked the sweep. Now one ordered regex.

## Review round (3-axis) — what it caught

All findings addressed in `3199cd6f`:

**Classifier false negatives** — each silently exempted a fixture, the #1097 failure mode:
1. Comments were stripped *after* continuations were joined, so a `# ... \` comment glued the following real invocation into itself and stripped it (live precedent in-tree).
2. Heredoc openers were detected on raw text, so a `# ... <<EOF` in prose opened a heredoc that never terminated, hiding every invocation below it.
3. `<<<` herestrings parsed as heredocs — and the first `(?!<)` guard alone was insufficient, since the engine shifts one char and matches `<<` from the second `<`.
4. The binary whitelist missed `${CDKD}` (used by **36** fixtures) and `env -u` prefixes.

**Structural fix, not just a wider whitelist**: the classifier now *reports* unrecognized `state destroy` segments and the test fails on a non-empty report, so a new binary spelling surfaces loudly instead of as a quiet zero.

**Hook**: expressing the ordering by pre-slicing with `sed 's/^.*state destroy//'` was greedy — a line with two invocations sliced past the first and missed a `--force` on it. Replaced with one ordered regex.

**Test quality**: replaced the brittle per-shape floors (`env-prefixed` / `guarded` each rode on one fixture) with a **structural completeness audit** — every fixture whose prose-stripped code contains `state destroy` must yield ≥1 parsed invocation, using an *independent* crude stripper so the audit cannot agree with a broken normalizer. Added shape cases for the unguarded-`${STATE_BUCKET}` predicate (which matched nothing in-tree, so a typo would have been permanently green), pinned the empty-string fallback premise, dropped a no-op assertion.

**Counts**: `destroy` corrected 227 → 228 (one line carries two via `||`).

## The lint immediately caught a real regression

While this PR was in review, #1569 merged and added `tests/integration/appsync/` — whose `cleanup()` `state destroy` omits `--state-bucket`. CI (which builds the merge commit) went red on this branch's own lint, naming the fixture. Swept on the rebase in `86cc8fd6`.

So the convention drifted again within hours of a new fixture landing, and the lint caught it before merge rather than in a sweep months later. Invocation count 171 -> 172; still 0 offenders.

## Verification

**Live-test against the built CLI** (no AWS resources created):

| case | result |
|---|---|
| no flag, fixture with `cdk.json` stateBucket | `StateError: State bucket 'your-cdkd-state-bucket' does not exist` — the silenced failure |
| no flag, no `cdk.json` entry | resolves default `cdkd-state-<acct>` |
| `STATE_BUCKET` env set, no flag | **still** the default — proves the env name is ignored |
| exported `STATE_BUCKET` + flag | targets the harness bucket — the fix works |
| flag with empty value | falls back to default — the `:-` guard is safe |

**Real-code fail probes**, both on disk against the real tree, restored after:
- removing the flag from `apigateway/verify.sh` → suite fails naming that invocation;
- swapping its binary for `node dist/cli.js` → suite fails naming the fixture as *unrecognized* (not as a silent zero).

No `src/**` changes, so the `integ-*` gates are n/a. `gen:all-matrices` + `audit:coverage:check` clean. 10,032 tests pass.

Closes #1567

