### PR TITLE
chore(skills): document --from-state / --from-cfn-stack in the local section (v0.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Skill for using cdkd (CDK Direct) safely from AI coding agents",
-    "version": "0.2.1"
+    "version": "0.3.0"
   },
   "plugins": [
     {
       "name": "cdkd-skills",
       "source": "./plugins/cdkd-skills",
       "description": "Deploy AWS CDK apps safely with cdkd: install, bootstrap, preview, deploy, verify, and destroy dev/test stacks with explicit safety boundaries.",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "author": {
         "name": "go-to-k",
         "url": "https://github.com/go-to-k"

--- a/plugins/cdkd-skills/.claude-plugin/plugin.json
+++ b/plugins/cdkd-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "cdkd-skills",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Deploy AWS CDK apps safely with cdkd (CDK Direct). Guides AI coding agents through installing cdkd and bootstrapping, previewing, deploying, verifying, and destroying dev/test stacks with explicit safety boundaries.",
   "author": {
     "name": "go-to-k",

--- a/plugins/cdkd-skills/skills/cdkd/SKILL.md
+++ b/plugins/cdkd-skills/skills/cdkd/SKILL.md
@@ -186,11 +186,11 @@ cdkd local run-task <task>         # one-shot ECS task
 cdkd local start-service <service> # long-running ECS service emulator
 ```
 
-The most important choice is the environment source. A workload whose environment variables reference other resources (`Ref` / `Fn::GetAtt` table names, queue URLs — the common case) runs with those variables dropped unless one of these options resolves them from deployed values:
+The most important choice is the environment source: `--from-state` or `--from-cfn-stack`. A workload whose environment variables reference other resources (`Ref` / `Fn::GetAtt` table names, queue URLs — the common case) runs with those variables dropped unless one of the two fills them with the REAL values of the already-deployed resources — the physical IDs and attributes of the tables, queues, and buckets actually running in the AWS account:
 
 ```bash
-cdkd local invoke <function> --from-state       # resolve env vars from cdkd's S3 state (stack was deployed with cdkd deploy)
-cdkd local invoke <function> --from-cfn-stack   # resolve env vars from the deployed CloudFormation stack (cdk deploy)
+cdkd local invoke <function> --from-state       # env vars <- the deployed resources' real values, when the stack was deployed with cdkd deploy
+cdkd local invoke <function> --from-cfn-stack   # env vars <- the deployed resources' real values, when the stack was deployed with cdk deploy
 ```
 
 `--from-state` and `--from-cfn-stack` are mutually exclusive — pick the one matching how the stack was deployed. Both make read-only AWS calls, so they need credentials; a plain local run without them does not.

--- a/plugins/cdkd-skills/skills/cdkd/SKILL.md
+++ b/plugins/cdkd-skills/skills/cdkd/SKILL.md
@@ -195,6 +195,8 @@ cdkd local invoke <function> --from-cfn-stack   # resolve env vars from the depl
 
 `--from-state` and `--from-cfn-stack` are mutually exclusive — pick the one matching how the stack was deployed. Both make read-only AWS calls, so they need credentials; a plain local run without them does not.
 
+With the environment source resolved, a local run is a hybrid: the handler executes on the developer's machine (edit and re-invoke — no deploy round-trip), while talking to the real deployed dev resources. That removes the usual local-testing overhead — no hand-maintained `.env` files mirroring resource names, and no local emulators to install and seed with test data, because the code reads and writes the actual dev-environment tables, queues, and buckets.
+
 Most `cdkd local` commands require Docker, and the first run pulls base images (up to ~600 MB). See the [local execution guide](https://github.com/go-to-k/cdkd/blob/main/docs/local-emulation.md) for the full subcommand list (ALB, CloudFront, AgentCore) and flags.
 
 ## Command reference

--- a/plugins/cdkd-skills/skills/cdkd/SKILL.md
+++ b/plugins/cdkd-skills/skills/cdkd/SKILL.md
@@ -177,7 +177,7 @@ Do not use `--force`, `--yes`, `--purge-events`, or other confirmation-bypassing
 
 ## Run workloads locally (no AWS needed)
 
-`cdkd local *` runs Lambda functions, API Gateway APIs, ECS tasks and services, ALBs, CloudFront distributions, and Bedrock AgentCore runtimes on the developer's machine via Docker — no AWS deploy and no AWS credentials involved, so the deployment-boundary steps above do not apply to these commands:
+`cdkd local *` runs Lambda functions, API Gateway APIs, ECS tasks and services, ALBs, CloudFront distributions, and Bedrock AgentCore runtimes on the developer's machine via Docker — no AWS deploy involved, so the deployment-boundary steps above do not apply to these commands:
 
 ```bash
 cdkd local invoke <function>       # one-shot Lambda invoke
@@ -185,6 +185,15 @@ cdkd local start-api               # long-running local API Gateway
 cdkd local run-task <task>         # one-shot ECS task
 cdkd local start-service <service> # long-running ECS service emulator
 ```
+
+The most important choice is the environment source. A workload whose environment variables reference other resources (`Ref` / `Fn::GetAtt` table names, queue URLs — the common case) runs with those variables dropped unless one of these options resolves them from deployed values:
+
+```bash
+cdkd local invoke <function> --from-state       # resolve env vars from cdkd's S3 state (stack was deployed with cdkd deploy)
+cdkd local invoke <function> --from-cfn-stack   # resolve env vars from the deployed CloudFormation stack (cdk deploy)
+```
+
+`--from-state` and `--from-cfn-stack` are mutually exclusive — pick the one matching how the stack was deployed. Both make read-only AWS calls, so they need credentials; a plain local run without them does not.
 
 Most `cdkd local` commands require Docker, and the first run pulls base images (up to ~600 MB). See the [local execution guide](https://github.com/go-to-k/cdkd/blob/main/docs/local-emulation.md) for the full subcommand list (ALB, CloudFront, AgentCore) and flags.
 

--- a/plugins/cdkd-skills/skills/cdkd/SKILL.md
+++ b/plugins/cdkd-skills/skills/cdkd/SKILL.md
@@ -175,7 +175,7 @@ Before `destroy`, `state destroy`, `orphan`, `import`, `export`, `drift --accept
 
 Do not use `--force`, `--yes`, `--purge-events`, or other confirmation-bypassing flags unless the user approved that exact destructive scope.
 
-## Run workloads locally (no AWS needed)
+## Run workloads locally
 
 `cdkd local *` runs Lambda functions, API Gateway APIs, ECS tasks and services, ALBs, CloudFront distributions, and Bedrock AgentCore runtimes on the developer's machine via Docker — no AWS deploy involved, so the deployment-boundary steps above do not apply to these commands:
 


### PR DESCRIPTION
## Summary

Follow-up to #1564. The distributed skill's local-execution section listed the subcommands but not the environment-source options — the choice that decides whether a workload whose env vars reference other resources (`Ref` / `Fn::GetAtt` table names, queue URLs — the common case) runs with real deployed values or with those variables dropped:

```bash
cdkd local invoke <function> --from-state       # resolve env vars from cdkd's S3 state (stack was deployed with cdkd deploy)
cdkd local invoke <function> --from-cfn-stack   # resolve env vars from the deployed CloudFormation stack (cdk deploy)
```

- Documents the two options, why they matter, their mutual exclusivity, and picking by how the stack was deployed
- Corrects the previous blanket "no AWS credentials involved" claim: both `--from-*` options make read-only AWS calls and need credentials; only a plain local run needs none
- Manifests bumped 0.2.1 → 0.3.0 per the in-file sync-comment rule (content addition → minor)

Semantics checked against [docs/local-emulation.md](https://github.com/go-to-k/cdkd/blob/main/docs/local-emulation.md) (flag table + state-driven / CloudFormation-driven env recovery sections).

## Test plan

- [x] `/check` on latest main — typecheck, lint (0 errors), build, 10,145 unit tests passed
- [x] Real `claude --plugin-dir` load: plugin resolves as `cdkd-skills 0.3.0`
- [x] No Japanese characters; skill-only diff (plugins/ + manifests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011trUkZrAk6YishwMLrv6Kv

---
_Generated by [Claude Code](https://claude.ai/code/session_011trUkZrAk6YishwMLrv6Kv)_