### PR TITLE
chore(repo): add scripts/** to the check gate scope and pin eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,12 @@
+# Normalize line endings to LF on checkout for all text files (issue #1592).
+# check-source-control-bytes.ts (#1587) REJECTS a raw CR in tracked text
+# files, and CI runs on ubuntu-latest — without this rule a contributor on
+# Windows with core.autocrlf=true produces CRLF working files and hits a
+# tree-wide checker failure as the first signal. text=auto lets git keep
+# detecting binaries; the tree carried zero CR bytes when this landed, so
+# the rule changes no existing content.
+* text=auto eol=lf
+
 # The integ ledger is an append-ish, one-row-per-test TSV updated by every
 # /run-integ invocation. Parallel-agent PRs almost always touch DIFFERENT
 # test rows, so the union driver auto-resolves what was previously a

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -80,6 +80,14 @@ gates:
     include:
       - "src/**"
       - "tests/**"
+      # scripts/** holds load-bearing CI logic: the codegen'd-critic family
+      # (gen-nested-key-coverage.ts, gen-handled-property-wiring.ts, ...)
+      # plus every check-*.ts classifier. Before issue #1592 the enforcement
+      # logic sat OUTSIDE the gate that guards it — weakening a classifier
+      # did not stale the marker while editing its test (tests/**) did, so
+      # a change that narrows what a critic rejects could be committed
+      # against a fresh-looking marker.
+      - "scripts/**"
       - "package.json"
       - "pnpm-lock.yaml"
       - "tsconfig*.json"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ high.
 
   Surface findings out loud (in chat or todos) and fix them before invoking `/check`. The cost of one more pass is small compared to a follow-up PR or a missed regression.
 - **Before every commit**: Two markgate gates guard `git commit` via `.claude/hooks/check-gate.sh`. Both must be fresh:
-  - `check` — recorded by `/check` (typecheck, lint, build, tests). Scope: `src/**`, `tests/**`, build/test configs (see `.markgate.yml`). Only invalidated by changes in that scope.
+  - `check` — recorded by `/check` (typecheck, lint, build, tests). Scope: `src/**`, `tests/**`, `scripts/**` (the CI classifier / codegen logic — issue #1592), build/test configs (see `.markgate.yml`). Only invalidated by changes in that scope.
   - `docs` — recorded by `/check-docs` (README.md / CLAUDE.md / docs/ / .claude/rules/ consistency with src). Scope: `src/**`, `docs/**`, `README.md`, `CLAUDE.md`, `.claude/rules/**`. Only invalidated by changes in that scope.
 
   **Run the required skills proactively** before attempting the commit — look at `git status` / `git diff --cached --name-only` and match it against each gate's scope: a tests-only commit only needs `/check`; a docs-only commit only needs `/check-docs` (which now also includes `.claude/rules/**`); a src edit needs both; changes that fall outside both scopes (e.g. `.claude/hooks/**`, `.claude/skills/**`, `.markgate.yml`) need neither. The hook is a safety net, not the primary trigger — if you see "Blocked by check-gate", the message names exactly which skill to re-run, but getting there means you skipped the proactive step. `/verify-pr` refreshes both markers in one shot. Install `vp` and markgate via `mise install` at the repo root (see CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Two repo-wide config gaps found by the code review on PR #1589 and deferred there because three other worktrees were active at the time (staling shared markers across lanes is a cross-session side effect).

- **`.markgate.yml`**: add `scripts/**` to the `check` gate's `include`. That directory holds load-bearing CI logic — the codegen'd-critic family and every `check-*.ts` classifier — but the enforcement logic sat outside the gate that guards it: weakening a classifier did not stale the `check` marker, while editing its test did.
- **`.gitattributes`**: add `* text=auto eol=lf`. `check-source-control-bytes.ts` (#1587, PR #1589) rejects a raw CR and CI is `ubuntu-latest`, but nothing prevented a Windows contributor with `core.autocrlf=true` from producing CRLF working files and hitting a tree-wide checker failure as the first signal.
- **`CLAUDE.md`**: sync the `check` gate scope description with the new include list.

## Verification

- Full `/check` suite green under the new gate config (typecheck, lint, format, build, 10246 unit tests).
- Live-tested the gate scope change: appending to a `scripts/**` file flips the `check` marker to `mismatch`; reverting restores `match`; the `docs` marker is unaffected.
- Live-tested EOL normalization: a probe file staged with CRLF content lands in the index with LF only (git also emits the replacement warning).
- Renormalization is a no-op on the existing tree: `git grep -Il $'\r'` over tracked files finds nothing, and `git add --renormalize .` stages no file beyond this PR's three edits — the rule changes no existing content.

## Trade-off (from the issue)

Every `scripts/**` edit now requires a `/check` re-run, and this landing will stale the `check` marker in any active worktree once rebased. Accepted in the issue as the right direction — false marker freshness on classifier weakening is the worse failure.

Closes #1592
