### PR TITLE
fix(drift): warn about KEYED-list entries a --revert would drop (#1626 item 1)

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -75,7 +75,7 @@ diff-intrinsic-target-change	2026-08-10T06:18:10Z	PASS	46	verify.sh	0810 P2 swee
 dlm-lifecycle-policy	2026-07-27T09:43:47Z	PASS	140	verify.sh	1160 removal phase 2b final-tree run, destroy 3/0, 0 orphans
 docdb-neptune	2026-07-27T06:16:35Z	PASS	1560	verify.sh	#1160 neptune+docdb removal steps 3b-3d verified; destroy w/o remove-protection 14/0 errors, 0 orphans
 docker-image-asset	2026-08-10T04:23:28Z	PASS	81	verify.sh	0810 sweep b2; post-#1406 ECR mutability filters, 2 del 0 err, 0 orph
-drift-revert	2026-08-10T16:43:31Z	PASS	540	verify.sh	post-review re-run: ARN round-trip + throttle no-cache; 6b/6c ok, 13 del/0 err
+drift-revert	2026-08-11T14:33:06Z	PASS	285	verify.sh	#1626 keyed-list revert-plan walk: revert path regression-clean, destroy 13/0, orphans clean
 drift-revert-arrays	2026-08-01T09:36:05Z	PASS	110	verify.sh	0801 regression sweep; 16 del/0 err, 0 orphans
 drift-revert-vpc	2026-08-10T11:50:46Z	PASS	310	verify.sh	0810 P0/P1 sweep b5 BROAD; 21 del/0 err incl EFS+PrivateDnsNamespace
 dsql	2026-07-30T18:11:24Z	PASS	540	verify.sh	4-phase incl. destroy --remove-protection CC flip (#1312); orph clean

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1648,7 +1648,31 @@ Flags:
   `LoadBalancerAttributes` — and it applies even when the recorded
   baseline list is EMPTY, since a declared-but-empty `Tags` still has an
   AWS side worth diffing. A tag list NESTED inside another property (an
-  EC2 launch template's `TagSpecifications`) still reverts wholesale. Requires a stack lock. Mutually exclusive with
+  EC2 launch template's `TagSpecifications`) still reverts wholesale.
+
+  The plan also **warns about AWS-authored values the revert would drop**
+  (issue [#1478](https://github.com/go-to-k/cdkd/issues/1478)). A revert
+  overwrites each drifted top-level subtree from
+  `observedProperties ?? properties`, so when a resource has NO
+  `observedProperties` (older state, or a deploy-time capture that failed)
+  the desired side is the raw template — and anything AWS wrote into that
+  subtree but the template never declared is about to be erased. cdkd lists
+  those paths before the confirmation prompt rather than refusing, since the
+  user did ask to push state over AWS. Both shapes are covered: nested object
+  keys report dotted (`Parameters.table_type`), and a KEYED
+  `[{Key, Value}]` list reports its missing entries in bracket form
+  (`LoadBalancerAttributes[deletion_protection.enabled]`) — the bracket
+  distinguishes a list entry from a nested path, since attribute keys contain
+  dots of their own. That keyed-list half was added by issue
+  [#1626](https://github.com/go-to-k/cdkd/issues/1626): the walk previously
+  skipped every array, which is exactly the shape with the most to drop, so
+  a revert against an ELBv2 resource could touch ~18 untemplated attributes
+  while the plan warned about none. A service-authored tag is NOT listed —
+  the carve-out above preserves it, so it is not dropped. A POSITIONAL array
+  is still compared wholesale, because its elements have positions rather
+  than identities.
+
+  Requires a stack lock. Mutually exclusive with
   `--accept`. See "Resolving drift" below.
 - `--dry-run` — for `--accept` / `--revert`: print the planned mutations
   and exit without acquiring a lock or hitting AWS / S3.

--- a/src/cli/commands/drift.ts
+++ b/src/cli/commands/drift.ts
@@ -1039,7 +1039,17 @@ export function findRevertDroppedAwsKeys(
     // `buildRevertNewProperties` only overwrites a key the desired side
     // actually has; otherwise the AWS-current value survives untouched.
     if (!(key in desiredProperties)) continue;
-    collectMissingPaths(awsProperties[key], desiredProperties[key], key, dropped);
+    // A top-level TAG LIST is reverted through `mergeTagListForRevert`, which
+    // PRESERVES service-authored entries (issue #1501) — so those are not
+    // dropped and must not be reported here, while an ordinary console-added
+    // tag still is stripped and still counts.
+    collectMissingPaths(
+      awsProperties[key],
+      desiredProperties[key],
+      key,
+      dropped,
+      isTagListKey(key) ? isServiceManagedTagKey : undefined
+    );
   }
 
   return [...dropped].sort();
@@ -1049,17 +1059,53 @@ export function findRevertDroppedAwsKeys(
  * Walk the AWS-side value against the desired-side value, recording every path
  * present on the AWS side and absent on the desired side.
  *
- * Only plain objects are descended into. An ARRAY is compared wholesale — the
- * drift comparator itself treats arrays as single values (its paths never
+ * Plain objects are descended into. A POSITIONAL array is compared wholesale —
+ * the drift comparator itself treats arrays as single values (its paths never
  * carry an index), so an element-wise walk here would report positions the
  * rest of the revert path cannot reason about.
+ *
+ * A KEYED list is the exception, and it is the shape with the most to drop
+ * (issue [#1626](https://github.com/go-to-k/cdkd/issues/1626)). An
+ * `[{Key, Value}]` list is semantically a MAP that CFn spells as an array —
+ * ELBv2 `LoadBalancerAttributes`, `ListenerAttributes`, `TargetGroupAttributes`
+ * and every `Tags` list are this shape — so its entries have stable identities,
+ * not positions, and `Key` is exactly what the user would act on. Skipping it
+ * left the pass blind precisely where `readCurrentState` returns AWS's FULL
+ * attribute set (~20 entries) against a template that declares one or two: the
+ * plan warned about nothing while the revert was about to touch eighteen keys.
+ *
+ * Keyed-list entries are reported in BRACKET form (`LoadBalancerAttributes
+ * [deletion_protection.enabled]`) rather than dotted, because attribute keys
+ * contain dots themselves and a dotted path would be ambiguous with a nested
+ * object.
+ *
+ * `isPreservedKey` exempts entries the revert does NOT actually drop — the
+ * caller passes {@link isServiceManagedTagKey} for a top-level TAG LIST, whose
+ * revert goes through {@link mergeTagListForRevert} and keeps `aws:`-prefixed /
+ * `AmazonECSManaged` entries (issue #1501). Reporting those would be a warning
+ * about a loss that cannot happen.
  */
 function collectMissingPaths(
   awsValue: unknown,
   desiredValue: unknown,
   path: string,
-  out: Set<string>
+  out: Set<string>,
+  isPreservedKey?: (key: string) => boolean
 ): void {
+  if (isKeyedList(awsValue)) {
+    if (!isKeyedList(desiredValue)) {
+      // A scalar / object / absent desired side replaces the whole list.
+      if (desiredValue === undefined) out.add(path);
+      return;
+    }
+    const desiredKeys = new Set(desiredValue.map((e) => e.Key));
+    for (const entry of awsValue) {
+      if (desiredKeys.has(entry.Key)) continue;
+      if (isPreservedKey?.(entry.Key)) continue;
+      out.add(`${path}[${entry.Key}]`);
+    }
+    return;
+  }
   if (!isPlainRecord(awsValue)) return;
   if (!isPlainRecord(desiredValue)) {
     // The desired side is a scalar / array / absent where AWS has an object:
@@ -1076,6 +1122,24 @@ function collectMissingPaths(
     }
     collectMissingPaths(value, desiredValue[key], childPath, out);
   }
+}
+
+/**
+ * A NON-EMPTY array whose every element is an object carrying a string `Key`.
+ *
+ * Emptiness is deliberately excluded: `[]` carries no identities, so treating
+ * it as keyed would report nothing on the AWS side and — as the DESIRED side —
+ * would claim every AWS entry is dropped, which is already what the
+ * whole-list arm reports more legibly.
+ */
+function isKeyedList(value: unknown): value is Array<{ Key: string }> {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(
+      (e) => typeof e === 'object' && e !== null && typeof (e as { Key?: unknown }).Key === 'string'
+    )
+  );
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/tests/unit/cli/drift.test.ts
+++ b/tests/unit/cli/drift.test.ts
@@ -1862,14 +1862,88 @@ describe('findRevertDroppedAwsKeys (pure helper, issue #1478)', () => {
     expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual(['Parameters.nested']);
   });
 
-  it('compares arrays wholesale, never element-wise', async () => {
+  it('compares a POSITIONAL array wholesale, never element-wise', async () => {
     const findRevertDroppedAwsKeys = await load();
     // The drift comparator's paths never carry an array index, so an
     // element-wise walk here would report positions the rest of the revert
-    // path cannot reason about.
+    // path cannot reason about. Only a KEYED list (below) is walked, because
+    // its entries have identities rather than positions.
+    const desired = { SubnetIds: ['subnet-a'] };
+    const aws = { SubnetIds: ['subnet-a', 'subnet-b'] };
+    const drifts = [{ path: 'SubnetIds', stateValue: [], awsValue: [] }];
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual([]);
+  });
+
+  it('does NOT report a SERVICE-authored tag the revert preserves', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    // `mergeTagListForRevert` (issue #1501) keeps `aws:`-prefixed /
+    // AmazonECSManaged entries, so they are not dropped and warning about
+    // them would be a false alarm. This case predates the keyed-list walk and
+    // must keep returning [] now that tag lists ARE walked.
     const desired = { Tags: [{ Key: 'a', Value: '1' }] };
-    const aws = { Tags: [{ Key: 'a', Value: '1' }, { Key: 'aws:authored', Value: 'x' }] };
+    const aws = {
+      Tags: [
+        { Key: 'a', Value: '1' },
+        { Key: 'aws:authored', Value: 'x' },
+        { Key: 'AmazonECSManaged', Value: 'true' },
+      ],
+    };
     const drifts = [{ path: 'Tags', stateValue: [], awsValue: [] }];
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual([]);
+  });
+
+  it('DOES report an ordinary console-added tag, which the revert strips', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    // The other half of #1501: a non-service tag IS stripped by the revert,
+    // so the plan should say so.
+    const desired = { Tags: [{ Key: 'a', Value: '1' }] };
+    const aws = { Tags: [{ Key: 'a', Value: '1' }, { Key: 'owner', Value: 'alice' }] };
+    const drifts = [{ path: 'Tags', stateValue: [], awsValue: [] }];
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual(['Tags[owner]']);
+  });
+
+  it('reports every AWS-only entry of a KEYED attribute list (issue #1626)', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    // The motivating case. `readCurrentState` returns ELBv2's FULL attribute
+    // set, so against a template declaring one key every other entry lands on
+    // the provider's removal path — and before this walk the plan warned about
+    // NONE of them, because the list is an array.
+    const desired = {
+      LoadBalancerAttributes: [{ Key: 'idle_timeout.timeout_seconds', Value: '120' }],
+    };
+    const aws = {
+      LoadBalancerAttributes: [
+        { Key: 'idle_timeout.timeout_seconds', Value: '60' },
+        { Key: 'deletion_protection.enabled', Value: 'false' },
+        { Key: 'routing.http2.enabled', Value: 'true' },
+      ],
+    };
+    const drifts = [
+      { path: 'LoadBalancerAttributes', stateValue: [], awsValue: [] },
+    ];
+    // Bracket form, because an attribute key contains dots of its own and a
+    // dotted path would be ambiguous with a nested object.
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual([
+      'LoadBalancerAttributes[deletion_protection.enabled]',
+      'LoadBalancerAttributes[routing.http2.enabled]',
+    ]);
+  });
+
+  it('treats an EMPTY desired list as the whole-list case, not a keyed compare', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    // `[]` carries no identities. Enumerating every AWS entry against it would
+    // be noisier than the existing whole-list report and says the same thing.
+    const desired = { LoadBalancerAttributes: [] };
+    const aws = { LoadBalancerAttributes: [{ Key: 'deletion_protection.enabled', Value: 'x' }] };
+    const drifts = [{ path: 'LoadBalancerAttributes', stateValue: [], awsValue: [] }];
+    expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual([]);
+  });
+
+  it('does not treat a list of plain objects without Key as keyed', async () => {
+    const findRevertDroppedAwsKeys = await load();
+    const desired = { Rules: [{ Name: 'a' }] };
+    const aws = { Rules: [{ Name: 'a' }, { Name: 'b' }] };
+    const drifts = [{ path: 'Rules', stateValue: [], awsValue: [] }];
     expect(findRevertDroppedAwsKeys(drifts, desired, aws)).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

Addresses item 1 of (#1626). The issue stays OPEN for items 2 and 3 — see
"Not addressed here" below.

`findRevertDroppedAwsKeys` exists to name the AWS-authored values a `--revert`
is about to erase. But `collectMissingPaths` returned early on **any** array,
and a `[{Key, Value}]` list is exactly the shape with the most to drop.

Those lists are semantically MAPS that CFn spells as arrays — ELBv2
`LoadBalancerAttributes` / `ListenerAttributes` / `TargetGroupAttributes`, and
every `Tags` list. Their entries have stable identities rather than positions,
and `Key` is precisely what a user would act on. Skipping them left the pass
blind exactly where `readCurrentState` returns AWS's FULL attribute set (~20
entries) against a template declaring one or two: a revert could touch eighteen
untemplated keys while the plan warned about **none**.

The `mergeTagListForRevert` docstring had already recorded the gap in passing —
"the tag list is an ARRAY, which `findRevertDroppedAwsKeys`'s walk [skips]".

## What changed

A keyed list is now walked by `Key`. A **positional** array is still compared
wholesale — its elements have positions the rest of the revert path cannot
reason about, which was the original rule and stays. Entries report in BRACKET
form (`LoadBalancerAttributes[deletion_protection.enabled]`) rather than
dotted, since attribute keys contain dots of their own and a dotted path would
be ambiguous with a nested object.

**The tag carve-out is honored, not re-litigated.** `mergeTagListForRevert`
(#1501) PRESERVES `aws:`-prefixed / `AmazonECSManaged` entries, so those are
not dropped and reporting them would be a warning about a loss that cannot
happen. The walk takes an `isPreservedKey` predicate seeded with the existing
`isServiceManagedTagKey` for a top-level tag list. An ordinary console-added
tag IS still stripped by the revert, so it IS reported — both halves pinned.

That interaction is also why the pre-existing "compares arrays wholesale" test
needed care rather than deletion: it used a `Tags` list with an `aws:`-prefixed
entry, so post-change it would have read as a stale assertion when it is
actually asserting the 1501 carve-out (#1501). It is split into a genuinely positional
case plus the two tag polarities, so the original intent survives explicitly.

An EMPTY desired list is deliberately NOT treated as keyed: `[]` carries no
identities, so enumerating every AWS entry against it would be noisier than the
existing whole-list report while saying the same thing.

## Scope note on the live test

The warning only fires when a resource has **no** `observedProperties`
(`drift.ts` gates on it), so the `drift-revert` integ — which always has them —
cannot reach the new branch. That run is the **regression proof for the revert
path**; the new branch's coverage is unit-level with a binding proof.

## Test plan

- `vp run check` / `typecheck:test` / `build` — pass
- `vp run test` — 572 files, 10721 tests, pass
- **Binding proof**: disabling the keyed-list walk fails exactly the two new
  reporting tests (the ELBv2 attribute case and the ordinary-tag case) while
  the preserved-tag / empty-list / non-keyed cases keep passing — so the new
  assertions bind on the change and the carve-out assertions are independent
  of it.
- `/run-integ drift-revert` — PASS, destroy 13/0 errors, orphans clean
  (state.json 404, no leftover bucket or role).
- `vp run gen:all-matrices` — no drift.

## Not addressed here

The issue stays open for its other two items, which are design rather than
mechanics:

- the residual write for a key the template never set that AWS reports at a
  NON-default value (genuine drift, but the user did not ask for it via the
  template);
- the general contract question — handing a provider a full observed bag as
  `previousProperties` makes "absent from desired" mean two different things
  depending on the caller, and that affects every provider that key-diffs a
  collection, not just ELBv2.
