### PR TITLE
docs: document the composite pipe-delimited physicalId format

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,10 @@ cdkd import MyStack --yes
 # Adopt only specific resources (CDK CLI parity).
 cdkd import MyStack --resource MyBucket=my-bucket-name
 
+# Some types use a composite, `|`-delimited physical id — quote it.
+# Full per-type table: docs/state-management.md#composite-pipe-delimited-physicalids
+cdkd import MyStack --resource 'MyGlueTable=my_database|my_table'
+
 # Migrate off CloudFormation in one shot — adopt + retire the source CFn stack.
 cdkd import MyStack --migrate-from-cloudformation --yes
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1793,6 +1793,18 @@ The following SDK Providers ship with first-class `readCurrentState`
   `OriginAccessControlConfig` field names are identical, so the reverse
   mapping is a straight per-field copy)
 
+> [!NOTE]
+> **physicalId formats.** Several types in the lists above
+> (`AWS::ApiGateway::Method`, `AWS::Route53::RecordSet`,
+> `AWS::AppSync::DataSource` / `Resolver` / `ApiKey`, `AWS::Glue::Table`,
+> `AWS::S3Tables::Namespace` / `Table`, and the EC2 sub-resources) are
+> identified by a **composite, `|`-delimited physical id** rather than a
+> single scalar. That composite is what `cdkd state show` /
+> `cdkd state resources` print and what
+> `cdkd import --resource <logicalId>=<physicalId>` expects — quote it on
+> a shell command line. The per-type format table is in
+> [state-management.md](state-management.md#composite-pipe-delimited-physicalids).
+
 Tag drift is supported across the SDK Providers listed above (and the CC
 API fallback). cdkd filters out CDK / AWS-internal `aws:`-prefixed entries
 (notably `aws:cdk:path` and `aws:cdk:metadata`) from the AWS-current

--- a/docs/import.md
+++ b/docs/import.md
@@ -65,6 +65,13 @@ cdkd import MyStack \
   --resource MyBucket=my-bucket-name \
   --resource MyFn=my-function-name
 
+# Composite physical ids: some types are identified by several segments
+# joined with a `|` pipe. QUOTE the argument — an unquoted `|` is the shell
+# pipe operator and would truncate the id.
+cdkd import MyStack \
+  --resource 'MyGlueTable=my_database|my_table' \
+  --resource 'MyGetMethod=a1b2c3d4e5|xy9z8w|GET'
+
 # CDK CLI compat: read overrides from a JSON file.
 cdkd import MyStack --resource-mapping mapping.json
 # mapping.json: { "MyBucket": "my-bucket-name", "MyFn": "my-function-name" }
@@ -290,6 +297,17 @@ explicit `--resource <id>=<physicalId>` override mode — selective mode
 handles exactly this case. Resource types whose provider does not
 implement import are reported as `unsupported` and skipped.
 
+> [!IMPORTANT]
+> **A cdkd physical id is not always the id CloudFormation shows you.**
+> Types annotated `composite:` below are identified by several segments
+> joined with a `|` pipe (`<databaseName>|<tableName>`,
+> `<restApiId>|<resourceId>|<httpMethod>`, ...) — that composite is the
+> value `--resource` expects and the value `cdkd state show` /
+> `cdkd state resources` print. Quote it on a shell command line
+> (`--resource 'Id=db|table'`); no escaping is needed inside a
+> `--resource-mapping` JSON file. The full per-type format table lives in
+> [state-management.md](state-management.md#composite-pipe-delimited-physicalids).
+
 ### Auto-resolved (no `--resource` flag needed)
 
 These types implement `import()` and can resolve a physical id under `auto`
@@ -339,7 +357,7 @@ Types with an `import()` that auto-resolves via the above:
 - AWS::EC2::Subnet
 - AWS::EC2::SecurityGroup
 - AWS::EC2::NatGateway
-- AWS::EC2::EIP (`--resource <logicalId>=<allocationId>`)
+- AWS::EC2::EIP (accepts an `eipalloc-...` allocation id, a public IP, or the composite `<publicIp>|<allocationId>`; cdkd normalizes and stores the composite)
 - AWS::RDS::DBInstance
 - AWS::RDS::DBCluster
 - AWS::RDS::DBProxy
@@ -352,7 +370,7 @@ Types with an `import()` that auto-resolves via the above:
 - AWS::Neptune::DBCluster
 - AWS::Neptune::DBSubnetGroup
 - AWS::ECS::Cluster
-- AWS::ECS::Service
+- AWS::ECS::Service (accepts the service ARN — the form cdkd stores — or the composite `<clusterArn>|<serviceName>`)
 - AWS::ECS::TaskDefinition
 - AWS::CloudFront::Distribution
 - AWS::Cognito::UserPool
@@ -368,7 +386,7 @@ Types with an `import()` that auto-resolves via the above:
 - AWS::Route53::HostedZone
 - AWS::StepFunctions::StateMachine
 - AWS::Glue::Database
-- AWS::Glue::Table
+- AWS::Glue::Table (stored and displayed as the composite `<databaseName>|<tableName>`; `--resource` also accepts CloudFormation's bare table name, paired with the template's `DatabaseName`)
 - AWS::Glue::Job
 - AWS::Glue::Crawler
 - AWS::Glue::Connection
@@ -390,8 +408,8 @@ Types with an `import()` that auto-resolves via the above:
 - AWS::ServiceDiscovery::PublicDnsNamespace
 - AWS::S3Express::DirectoryBucket
 - AWS::S3Tables::TableBucket
-- AWS::S3Tables::Namespace
-- AWS::S3Tables::Table
+- AWS::S3Tables::Namespace (composite: `--resource <logicalId>=<tableBucketARN>|<namespaceName>`)
+- AWS::S3Tables::Table (composite: `--resource <logicalId>=<tableBucketARN>|<namespace>|<name>`)
 - AWS::S3Vectors::VectorBucket
 - AWS::DLM::LifecyclePolicy
 - AWS::FSx::FileSystem
@@ -424,16 +442,16 @@ physical id via `--resource`.
 - AWS::ApiGateway::Resource
 - AWS::ApiGateway::Deployment
 - AWS::ApiGateway::Stage
-- AWS::ApiGateway::Method
+- AWS::ApiGateway::Method (composite: `--resource <logicalId>=<restApiId>|<resourceId>|<httpMethod>`)
 - AWS::ApiGatewayV2::Stage
 - AWS::ApiGatewayV2::Integration
 - AWS::ApiGatewayV2::Route
 - AWS::ApiGatewayV2::Authorizer
 - AWS::AppSync::GraphQLSchema
-- AWS::AppSync::DataSource
-- AWS::AppSync::Resolver
-- AWS::AppSync::ApiKey
-- AWS::Route53::RecordSet
+- AWS::AppSync::DataSource (composite: `--resource <logicalId>=<apiId>|<name>`)
+- AWS::AppSync::Resolver (composite: `--resource <logicalId>=<apiId>|<typeName>|<fieldName>`)
+- AWS::AppSync::ApiKey (composite: `--resource <logicalId>=<apiId>|<apiKeyId>`)
+- AWS::Route53::RecordSet (composite: `--resource <logicalId>=<hostedZoneId>|<name>|<type>`, where `<name>` is the record name exactly as templated, trailing dot included)
 - AWS::ElasticLoadBalancingV2::Listener
 - AWS::EFS::MountTarget
 - AWS::RDS::DBProxyTargetGroup
@@ -449,10 +467,10 @@ have no taggable identity either. Provide the physical id via
 - AWS::SNS::TopicPolicy
 - AWS::SQS::QueuePolicy
 - AWS::S3::BucketPolicy
-- AWS::Lambda::Permission
+- AWS::Lambda::Permission (pass the bare statement id — the form cdkd stores; the legacy Cloud-Control-produced composite `<functionArn>|<statementId>` is also read correctly)
 - AWS::Lambda::EventSourceMapping
 - AWS::Lambda::Url
-- AWS::Lambda::EventInvokeConfig
+- AWS::Lambda::EventInvokeConfig (composite: `--resource <logicalId>=<functionName>|<qualifier>`; a bare function name is read as qualifier `$LATEST`)
 - AWS::CloudFormation::CustomResource
 - AWS::CloudFront::CloudFrontOriginAccessIdentity
 - AWS::BedrockAgentCore::Runtime (adopt by ARN via `--resource`)

--- a/docs/import.md
+++ b/docs/import.md
@@ -299,7 +299,7 @@ implement import are reported as `unsupported` and skipped.
 
 > [!IMPORTANT]
 > **A cdkd physical id is not always the id CloudFormation shows you.**
-> Types annotated `composite:` below are identified by several segments
+> Types whose id shape is annotated below are identified by several segments
 > joined with a `|` pipe (`<databaseName>|<tableName>`,
 > `<restApiId>|<resourceId>|<httpMethod>`, ...) — that composite is the
 > value `--resource` expects and the value `cdkd state show` /
@@ -451,7 +451,7 @@ physical id via `--resource`.
 - AWS::AppSync::DataSource (composite: `--resource <logicalId>=<apiId>|<name>`)
 - AWS::AppSync::Resolver (composite: `--resource <logicalId>=<apiId>|<typeName>|<fieldName>`)
 - AWS::AppSync::ApiKey (composite: `--resource <logicalId>=<apiId>|<apiKeyId>`)
-- AWS::Route53::RecordSet (composite: `--resource <logicalId>=<hostedZoneId>|<name>|<type>`, where `<name>` is the record name exactly as templated, trailing dot included)
+- AWS::Route53::RecordSet (composite: `--resource <logicalId>=<hostedZoneId>|<name>|<type>`, where `<name>` is the record name exactly as the template spells it — CDK emits a trailing dot)
 - AWS::ElasticLoadBalancingV2::Listener
 - AWS::EFS::MountTarget
 - AWS::RDS::DBProxyTargetGroup

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -514,6 +514,84 @@ Varies by resource type. Examples:
 
 **Note**: cdkd supports **all resource types supported by Cloud Control API**. The table above shows only a few examples. For resources not supported by Cloud Control API, custom SDK Providers can be implemented (see [provider-development.md](./provider-development.md)).
 
+**The physicalId is provider-defined, and it may differ from the value
+CloudFormation records for the same resource.** cdkd stores whatever the
+provider that created the resource returned — the value that provider needs
+to address the resource again on update / delete / drift. For most types
+that is the same scalar CloudFormation's `Ref` returns (a bucket name, a
+function ARN), but it is not guaranteed to be: see the composite forms
+below. Always read the id you must reuse from cdkd itself
+(`cdkd state show <stack>` / `cdkd state resources <stack>`) rather than
+from the AWS console or CloudFormation's `DescribeStackResources`.
+
+#### Composite (pipe-delimited) physicalIds
+
+Some resources have no single AWS-side identifier — a Glue table is only
+addressable as (database, table); an API Gateway method as (restApi,
+resource, httpMethod). For those types cdkd stores a **composite physical
+id: the identifying segments joined with a `|` pipe**. That is deliberately
+the same convention Cloud Control API uses for a multi-part
+`primaryIdentifier`, so a type that moves between an SDK Provider and the
+Cloud Control fallback keeps a compatible id (`AWS::EC2::EIP` is the
+explicit case — its SDK Provider reproduces the id shape the Cloud Control
+path had produced).
+
+The composite value is what state records, what `cdkd state show` /
+`cdkd state resources` print, and what
+`cdkd import --resource <logicalId>=<physicalId>` expects. A few types also
+accept a looser form on import — see
+[import.md](./import.md#auto-resolved-no---resource-flag-needed) for the
+per-type notes.
+
+| Resource Type | physicalId format |
+|---------------|-------------------|
+| `AWS::ApiGateway::Method` | `<restApiId>\|<resourceId>\|<httpMethod>` |
+| `AWS::AppSync::ApiKey` | `<apiId>\|<apiKeyId>` |
+| `AWS::AppSync::DataSource` | `<apiId>\|<name>` |
+| `AWS::AppSync::Resolver` | `<apiId>\|<typeName>\|<fieldName>` |
+| `AWS::EC2::EIP` | `<publicIp>\|<allocationId>` |
+| `AWS::EC2::NetworkAclEntry` | `<networkAclId>\|<ruleNumber>\|<egress>` (`egress` is `true` / `false`) |
+| `AWS::EC2::Route` | `<routeTableId>\|<destination>` (`destination` is the `DestinationCidrBlock`, `DestinationIpv6CidrBlock`, or `DestinationPrefixListId` the route declares) |
+| `AWS::EC2::SecurityGroupIngress` | `<groupId>\|<ipProtocol>\|<fromPort>\|<toPort>` (an omitted port is recorded as `-1`) |
+| `AWS::EC2::VPCGatewayAttachment` | `<internetGatewayId>\|<vpcId>` (note the order — CloudFormation's own identifier is `VpcId` first) |
+| `AWS::Glue::Table` | `<databaseName>\|<tableName>` |
+| `AWS::Lambda::EventInvokeConfig` | `<functionName>\|<qualifier>` (a bare function name is read as qualifier `$LATEST`) |
+| `AWS::Route53::RecordSet` | `<hostedZoneId>\|<name>\|<type>` |
+| `AWS::S3Tables::Namespace` | `<tableBucketARN>\|<namespaceName>` |
+| `AWS::S3Tables::Table` | `<tableBucketARN>\|<namespace>\|<name>` |
+
+Examples as they appear in a real state file (`resources` map, abridged):
+
+```json
+{
+  "MyGlueTable":  { "physicalId": "my_database|my_table" },
+  "MyGetMethod":  { "physicalId": "a1b2c3d4e5|xy9z8w|GET" },
+  "MyARecord":    { "physicalId": "Z1D633PJN98FT9|www.example.com.|A" },
+  "MyEip":        { "physicalId": "52.1.2.3|eipalloc-0abc123def456789a" }
+}
+```
+
+Two more types **accept** a composite id without producing one:
+
+- `AWS::ECS::Service` — cdkd stores the service ARN, but
+  `<clusterArn>|<serviceName>` is also accepted on `--resource`.
+- `AWS::Lambda::Permission` — cdkd stores the bare statement id; state
+  written by the older Cloud Control path may instead hold
+  `<functionArn>|<statementId>`, and both are read correctly.
+
+> [!IMPORTANT]
+> `|` is the shell pipe character. Always **quote** a composite id when you
+> pass it on a command line:
+>
+> ```bash
+> cdkd import MyStack --resource 'MyGlueTable=my_database|my_table'
+> ```
+>
+> Unquoted, the shell splits the command at the `|` and the import runs
+> against a truncated id. JSON mapping files
+> (`--resource-mapping` / `--resource-mapping-inline`) need no escaping —
+> `|` is an ordinary character in JSON.
+
 #### Purpose of attributes
 
 Stored to resolve attribute references via `Fn::GetAtt`.


### PR DESCRIPTION
## Summary

cdkd stores a **composite, pipe-delimited physical id** for resource types
that have no single AWS-side identifier — a Glue table is only addressable
as `(database, table)`, an API Gateway method as `(restApi, resource,
httpMethod)`. That composite is the value state records, the value
`cdkd state show` / `cdkd state resources` print, and the value
`cdkd import --resource <logicalId>=<physicalId>` expects.

It was documented nowhere. This PR closes that gap. Docs-only — no `src/**`,
`tests/**`, or `scripts/**` changes.

## What changed

- **`docs/state-management.md`** — new `#### Composite (pipe-delimited)
  physicalIds` subsection under the existing "physicalId Format" table:
  the per-type format table, real state-file examples, the two types that
  *accept* a composite without producing one, and the shell-quoting rule.
  The preceding paragraph now states the general rule — a cdkd physicalId
  is **provider-defined** and may differ from what CloudFormation records
  for the same resource, so the id to reuse should be read from cdkd, not
  from the console / `DescribeStackResources`.
- **`docs/import.md`** — every composite type in the `--resource` coverage
  lists is annotated with its id shape, matching the convention the file
  already used for `AWS::EC2::EIP` and `AWS::EMR::Cluster`. Entries stay
  one-per-line per the file's own "Adding a new entry" note. Adds a
  composite `--resource` example next to the scalar ones, and an
  `> [!IMPORTANT]` note on quoting.
- **`docs/cli-reference.md`** — a short id-format note next to the
  `readCurrentState` coverage lists, cross-referencing the table rather
  than duplicating it.
- **`README.md`** — one extra example line in the existing `cdkd import`
  block, plus a pointer. No new prose sections.

## Verified affected-type table

Derived from the `physicalId = ` ... `|` ... construction sites and their
`split('|')` / `indexOf('|')` consumers under `src/provisioning/`, not from
the issue text. Every row was read at its source line.

| Resource type | Format | Produced at |
|---|---|---|
| `AWS::ApiGateway::Method` | `restApiId \| resourceId \| httpMethod` | `apigateway-provider.ts:1836` |
| `AWS::AppSync::ApiKey` | `apiId \| apiKeyId` | `appsync-provider.ts:2466` |
| `AWS::AppSync::DataSource` | `apiId \| name` | `appsync-provider.ts:2272` |
| `AWS::AppSync::Resolver` | `apiId \| typeName \| fieldName` | `appsync-provider.ts:2369` |
| `AWS::EC2::EIP` | `publicIp \| allocationId` | `ec2-provider.ts:1451` |
| `AWS::EC2::NetworkAclEntry` | `networkAclId \| ruleNumber \| egress` | `ec2-provider.ts:4326` |
| `AWS::EC2::Route` | `routeTableId \| destination` | `ec2-provider.ts:2221` |
| `AWS::EC2::SecurityGroupIngress` | `groupId \| ipProtocol \| fromPort \| toPort` | `ec2-provider.ts:2931` |
| `AWS::EC2::VPCGatewayAttachment` | `internetGatewayId \| vpcId` | `ec2-provider.ts:1718` |
| `AWS::Glue::Table` | `databaseName \| tableName` | `glue-provider.ts:455` |
| `AWS::Lambda::EventInvokeConfig` | `functionName \| qualifier` | `lambda-event-invoke-config-provider.ts:72` |
| `AWS::Route53::RecordSet` | `hostedZoneId \| name \| type` | `route53-provider.ts:729` / `:787` |
| `AWS::S3Tables::Namespace` | `tableBucketARN \| namespaceName` | `s3-tables-provider.ts:411` |
| `AWS::S3Tables::Table` | `tableBucketARN \| namespace \| name` | `s3-tables-provider.ts:552` |

Accept a composite without producing one:

| Resource type | Stored form | Also accepted |
|---|---|---|
| `AWS::ECS::Service` | service ARN | `clusterArn \| serviceName` (`ecs-provider.ts:2817`) |
| `AWS::Lambda::Permission` | bare statement id | legacy CC-produced `functionArn \| statementId` (`lambda-permission-provider.ts:163`) |

### Corrections to the issue's version of the table

1. **`AWS::Lambda::EventInvokeConfig` was missing.** It builds
   `functionName|qualifier` in `buildPhysicalId`
   (`lambda-event-invoke-config-provider.ts:72`) and parses it back with
   `indexOf('|')` rather than `split('|')`, which is why the issue's
   `split('|')` sweep did not surface it.
2. **`AWS::ECS::Service` was missing.** `ecs-provider.ts:2817` accepts
   `clusterArn|serviceName` (and `import()` honours it verbatim) even
   though `createService` stores the service ARN.
3. **`AWS::EC2::EIP` is produced by `ec2-provider.ts:1451**
   (`eipPhysicalId`), not `cloud-control-provider.ts:1155` — that site is
   the attribute-enrichment *consumer* that re-derives `AllocationId` /
   `PublicIp` from an already-composite id.
4. **`AWS::Route53::RecordSet` is built at `route53-provider.ts:729`
   (create) and `:787` (update).** `:817` is the delete-path consumer.
5. **`AWS::EC2::SecurityGroupIngress`'s ports use a `-1` placeholder**
   when absent (`${fromPort ?? '-1'}`) — worth stating, since a reader
   would otherwise expect an empty segment.

Also checked and deliberately **excluded**:

- `dynamodb-globaltable-provider.ts:2823` / `:4368` — `region|dimension|
  suffix` is an internal auto-scaling-target diff key, not a physicalId.
- `AWS::EC2::SecurityGroupEgress` — not a standalone provider type
  (egress rules are inline on `AWS::EC2::SecurityGroup`).
- `AWS::ApiGateway::Resource` — `export.ts`'s splitter and the provider's
  `import()` docstring both claim `restApiId|resourceId`, but
  `createResource()` returns a **bare** resource id. Filed separately as
  #1663 rather than documented as a composite here.

## Glue::Table wording

Coordinated with the parallel #1651 lane (`glue-provider.ts`): the
`AWS::Glue::Table` entry says the composite is what cdkd **stores and
displays**, while `--resource` **also** accepts CloudFormation's bare table
name paired with the template's `DatabaseName`. Phrased to stay true both
before and after #1651 merges. The leniency is deliberately NOT generalized
to the other composite types — #1651 is Glue-scoped.

## Verification

- `vp check --fix` / `vp run check` — 0 errors (6 pre-existing warnings).
- `vp run typecheck:test`, `vp run build` — pass.
- `vp run test` — 586 files, 11036 tests, all pass.
- `vp run gen:all-matrices` + `vp run audit:coverage:check` — no drift.
- Live-checked the documented CLI surfaces against `dist/cli.js`:
  `state resources <stack>` and `state show <stack>` both exist as
  documented, and the `--resource` parser splits on the FIRST `=`
  (`import.ts:1109`, `entry.slice(eq + 1)`), so a `|` in the physical id
  survives verbatim — the quoting caveat is shell-level, not cdkd-level.
- Anchors verified: `#composite-pipe-delimited-physicalids` and
  `#auto-resolved-no---resource-flag-needed` both resolve to real headings.

No integ run: docs-only diff, no deletion / local / cross-cutting /
schema code touched.

## Side findings filed

- #1663 — `AWS::ApiGateway::Resource`: `export.ts`'s splitter and the
  `import()` docstring claim a composite the SDK provider never produces.
- #1664 — `cdkd import --help` still describes the `aws:cdk:path` tag walk
  removed in #1134, contradicting `docs/import.md`.

Both are `src/**` changes and out of this lane's scope.

## Retrospective

A docs-only lane in a **fresh worktree** is still blocked by
`check-gate.sh`: markgate markers are per-worktree, so a new worktree has
`check` at `no marker`, which the gate treats as failing regardless of the
gate's `src/**` / `tests/**` / `scripts/**` scope. The documented
"a docs-only commit only needs `/check-docs`" shortcut therefore does not
hold on the first commit of a new worktree — you must run the full
`/check` (~2.5 min of tests) to produce a marker that scoping would
otherwise have made unnecessary. Worth considering whether
`check-gate.sh` should treat "no marker + no in-scope change vs the merge
base" as a pass, the way a scoped-and-fresh marker already does.

Closes #1656
