### PR TITLE
docs(rules): the *Once canary step asserts the detector's message, not just an exit

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -65,8 +65,13 @@ result — the vacuous pass this file forbids elsewhere.
 `tests/unit/scripts/once-leak-canary.test.ts` leaks deliberately (and is
 therefore allow-listed, automatically, by the generator), and the CI step
 `detector canary` re-runs that file alone with
-`CDKD_ONCE_LEAK_IGNORE_ALLOWLIST=1` and requires a NON-ZERO exit. Do not "fix"
-that suite's priming; it is not a defect.
+`CDKD_ONCE_LEAK_IGNORE_ALLOWLIST=1` and requires a failure carrying the
+detector's OWN wording (`primed by an EARLIER test`). Asserting only a non-zero
+exit is NOT equivalent and must not be "simplified" back to it: a deleted or
+renamed canary file makes `vp test run <path>` exit 1 with "No test files
+found", and so do a syntax error and a failed install — each of which would let
+the step pass while the detector is dead, which is the very hole it exists to
+close. Do not "fix" that suite's priming either; it is not a defect.
 
 Two more design points are decisions, not accidents:
 


### PR DESCRIPTION
## Summary

Fix-forward on a wording inaccuracy that landed with PR (#1661).

`.claude/rules/testing.md` describes the `detector canary` CI step as requiring
"a NON-ZERO exit". That was the step's FIRST version. The three-axis review on
that PR replaced it, because an exit-code-only assertion carries the same hole
the step exists to close:

- a deleted or renamed canary file makes `vp test run <path>` exit 1 with
  "No test files found";
- so does a syntax error in the file, and so does a failed install.

Each of those would let the step pass while the detector is dead — a vacuous
pass in the one check whose whole purpose is to prove the detector still
rejects. The shipped step greps for the detector's own wording
(`primed by an EARLIER test`), verified in both directions before merge.

The rules file is what a future contributor reads before touching that step, so
leaving the superseded sentence there is an active invitation to "simplify" the
grep away. This states the contract and why the cheaper form is not equivalent.

Docs only — no `src/**`, no test, no CI change.

## Test plan

- `vp check --fix`, `vp run check`, `vp run typecheck:test`, `vp run build`,
  `vp test run` (593 files / 11128 tests) all pass.
- Live-test not applicable: docs-only diff with no `src/**` change, which
  `/verify-pr` exempts explicitly.
