### PR TITLE
fix(route53): accept CloudFormation's record-name physicalId for AWS::Route53::RecordSet

### DIFF
--- a/docs/_generated/handled-property-wiring.json
+++ b/docs/_generated/handled-property-wiring.json
@@ -16288,7 +16288,12 @@
           "seededBy": [
             "create",
             "createRecordSet",
+            "delete",
+            "deleteRecordSet",
+            "readCurrentState",
+            "readRecordSet",
             "resolveHostedZoneId",
+            "resolveRecordSetIdentity",
             "update",
             "updateRecordSet"
           ]
@@ -16306,7 +16311,12 @@
           "seededBy": [
             "create",
             "createRecordSet",
+            "delete",
+            "deleteRecordSet",
+            "readCurrentState",
+            "readRecordSet",
             "resolveHostedZoneId",
+            "resolveRecordSetIdentity",
             "update",
             "updateRecordSet"
           ]
@@ -16368,6 +16378,9 @@
             "createRecordSet",
             "delete",
             "deleteRecordSet",
+            "readCurrentState",
+            "readRecordSet",
+            "resolveRecordSetIdentity",
             "update",
             "updateRecordSet"
           ]
@@ -16487,6 +16500,9 @@
             "createRecordSet",
             "delete",
             "deleteRecordSet",
+            "readCurrentState",
+            "readRecordSet",
+            "resolveRecordSetIdentity",
             "update",
             "updateRecordSet"
           ]

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -232,7 +232,7 @@ rollback-command	2026-08-10T04:45:42Z	PASS	117	verify.sh	0810 sweep b3; post-#13
 rollback-deletion-policy-snapshot	2026-08-08T16:34:46Z	PASS	107	verify.sh	P0 first run post-#1361/#1365/#1367/#1369 rollback rework; rolled-back CREATE snapshot-then-deleted, state clean, 0 orphans
 rollback-failure-injection	2026-08-08T17:42:23Z	PASS	389	verify.sh	issue #1375 re-run (background, dodging the 600s clamp); all 8 phases, 17 del/0 err, 0 orphans incl NAT/EIP/ENI
 rollback-sqs-cooldown	2026-08-10T04:45:42Z	PASS	152	verify.sh	0810 sweep b3; post-#1361 rollback-executor re-verify, destroy clean
-route53	2026-08-12T08:39:07Z	PASS	333	verify.sh	rc ok, 8 deleted 0 errors, orph clean
+route53	2026-08-12T09:23:23Z	PASS	317	verify.sh	rc ok, 8 deleted 0 errors, orph clean
 s3-analytics-inventory	2026-08-11T15:41:43Z	PASS	95	verify.sh	issue #1605 re-run after review fixes; 3 del/0 err, 0 orph
 s3-asset-deploy	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 s3-cloudfront	2026-08-08T17:42:05Z	PASS	228	verify.sh	1373 OriginCustomHeaders create+update-survive asserts green; destroy 0 errors 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -232,7 +232,7 @@ rollback-command	2026-08-10T04:45:42Z	PASS	117	verify.sh	0810 sweep b3; post-#13
 rollback-deletion-policy-snapshot	2026-08-08T16:34:46Z	PASS	107	verify.sh	P0 first run post-#1361/#1365/#1367/#1369 rollback rework; rolled-back CREATE snapshot-then-deleted, state clean, 0 orphans
 rollback-failure-injection	2026-08-08T17:42:23Z	PASS	389	verify.sh	issue #1375 re-run (background, dodging the 600s clamp); all 8 phases, 17 del/0 err, 0 orphans incl NAT/EIP/ENI
 rollback-sqs-cooldown	2026-08-10T04:45:42Z	PASS	152	verify.sh	0810 sweep b3; post-#1361 rollback-executor re-verify, destroy clean
-route53	2026-08-11T02:45:10Z	PASS	405	verify.sh	#1160 route53 batch on the post-rebase MERGE PRODUCT (main incl. #1542 + this branch); both removal resets live-verified, destroy clean, 0 orphans
+route53	2026-08-12T06:55:00Z	PASS	900	verify.sh	#1658 route53 RecordSet CFn-scalar physicalId fix; deploy + removal-redeploy + destroy clean, 0 errors, 0 orphans (import path itself not covered by this fixture - see PR body)
 s3-analytics-inventory	2026-08-11T15:41:43Z	PASS	95	verify.sh	issue #1605 re-run after review fixes; 3 del/0 err, 0 orph
 s3-asset-deploy	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 s3-cloudfront	2026-08-08T17:42:05Z	PASS	228	verify.sh	1373 OriginCustomHeaders create+update-survive asserts green; destroy 0 errors 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -232,7 +232,7 @@ rollback-command	2026-08-10T04:45:42Z	PASS	117	verify.sh	0810 sweep b3; post-#13
 rollback-deletion-policy-snapshot	2026-08-08T16:34:46Z	PASS	107	verify.sh	P0 first run post-#1361/#1365/#1367/#1369 rollback rework; rolled-back CREATE snapshot-then-deleted, state clean, 0 orphans
 rollback-failure-injection	2026-08-08T17:42:23Z	PASS	389	verify.sh	issue #1375 re-run (background, dodging the 600s clamp); all 8 phases, 17 del/0 err, 0 orphans incl NAT/EIP/ENI
 rollback-sqs-cooldown	2026-08-10T04:45:42Z	PASS	152	verify.sh	0810 sweep b3; post-#1361 rollback-executor re-verify, destroy clean
-route53	2026-08-12T06:55:00Z	PASS	900	verify.sh	#1658 route53 RecordSet CFn-scalar physicalId fix; deploy + removal-redeploy + destroy clean, 0 errors, 0 orphans (import path itself not covered by this fixture - see PR body)
+route53	2026-08-12T08:39:07Z	PASS	333	verify.sh	rc ok, 8 deleted 0 errors, orph clean
 s3-analytics-inventory	2026-08-11T15:41:43Z	PASS	95	verify.sh	issue #1605 re-run after review fixes; 3 del/0 err, 0 orph
 s3-asset-deploy	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 s3-cloudfront	2026-08-08T17:42:05Z	PASS	228	verify.sh	1373 OriginCustomHeaders create+update-survive asserts green; destroy 0 errors 0 orphans

--- a/src/provisioning/providers/route53-provider.ts
+++ b/src/provisioning/providers/route53-provider.ts
@@ -60,6 +60,7 @@ class HostedZoneNameNotFoundError extends ProvisioningError {
     cause?: Error
   ) {
     super(message, resourceType, logicalId, physicalId, cause);
+    this.name = 'HostedZoneNameNotFoundError';
     // REQUIRED: `CdkdError`'s constructor chain ends with
     // `Object.setPrototypeOf(this, ProvisioningError.prototype)`, which erases
     // the subclass identity — without re-setting it here, `instanceof
@@ -93,6 +94,22 @@ export function parseRecordSetCompositeId(
 }
 
 /**
+ * Octal escapes that must NOT be decoded, because decoding them is not
+ * injective — two genuinely different names would compare EQUAL:
+ *
+ * - `056` is a period INSIDE a label. Route 53 reports the single-label
+ *   record `a.b` (period escaped) as `a\\056b.example.com.`, which decodes to
+ *   `a.b.example.com.` — identical to the different, two-label record
+ *   `a.b.example.com`.
+ * - `134` is a literal backslash, which would re-introduce escape ambiguity.
+ *
+ * A false MATCH is far worse than a false miss here: the compare drives which
+ * record `readCurrentState` reports and which hosted zone `create` picks, so
+ * collapsing two records would target the wrong one.
+ */
+const UNDECODABLE_OCTAL_ESCAPES = new Set(['056', '134']);
+
+/**
  * Canonicalize a record name for comparison.
  *
  * Two AWS-side spellings have to be absorbed, and missing either one makes
@@ -101,15 +118,21 @@ export function parseRecordSetCompositeId(
  *
  * - Route 53 reports every name fully qualified with a TRAILING DOT, while a
  *   template may declare it either way.
- * - Non-ASCII and special characters come back OCTAL-ESCAPED: `*.example.com`
- *   is reported as `\\052.example.com.`. That affects every wildcard record,
- *   including ones cdkd created itself, so decoding it here fixes drift for
- *   the whole population rather than only the imported ones.
+ * - Special characters come back OCTAL-ESCAPED: `*.example.com` is reported as
+ *   `\\052.example.com.`. That affects every wildcard record, including ones
+ *   cdkd created itself, so decoding it here fixes drift for the whole
+ *   population rather than only the imported ones.
+ *
+ * Known bound: Route 53 escapes per BYTE, so a non-ASCII name decodes to
+ * latin-1 mojibake and will not match its template spelling. That is a false
+ * MISS (drift unknown), never a false match, and CDK emits punycode for
+ * internationalized names in practice.
  */
 function normalizeRecordName(name: string): string {
-  // `\\ddd` -> the character it encodes (Route 53 uses 3-digit octal).
-  const decoded = name.replace(/\\(\d{3})/g, (_m, oct: string) =>
-    String.fromCharCode(parseInt(oct, 8))
+  // `\\ddd` -> the character it encodes. Strictly octal digits, and never the
+  // structure-significant escapes above.
+  const decoded = name.replace(/\\([0-7]{3})/g, (match, oct: string) =>
+    UNDECODABLE_OCTAL_ESCAPES.has(oct) ? match : String.fromCharCode(parseInt(oct, 8))
   );
   return decoded.endsWith('.') ? decoded : `${decoded}.`;
 }
@@ -1927,7 +1950,14 @@ export class Route53Provider implements ResourceProvider {
           HostedZoneId: hostedZoneId,
           StartRecordName: name,
           StartRecordType: type as RRType,
-          MaxItems: 1,
+          // NOT 1: AWS orders records on the ESCAPED name, so for a wildcard
+          // (`*` 0x2A, reported as `\\052…` and ordered by `\` 0x5C) a
+          // single-record page can skip straight past the record we asked
+          // for. Decoding the escape on the COMPARE side alone would not fix
+          // wildcards — the query has to return the record first. Take a few
+          // and let the exact-match filter below pick, the same shape the
+          // hosted-zone lookup uses.
+          MaxItems: 5,
         })
       );
     } catch (err) {
@@ -2085,11 +2115,12 @@ export class Route53Provider implements ResourceProvider {
    * Adopting verbatim is safe now precisely because `deleteRecordSet` and
    * `readRecordSet` both accept the scalar form (the other half of this fix).
    *
-   * Two shapes make verification legitimately fail, and both are ordinary
-   * rather than exotic: a `HostedZoneId` still carrying an unresolved
-   * intrinsic (`import.ts` substitutes only single-key `{Ref}` before calling
-   * a provider), and a wildcard record, which AWS reports octal-escaped as
-   * `\\052.example.com.` so the exact-name match misses.
+   * The ordinary shape that makes verification legitimately fail is a
+   * `HostedZoneId` still carrying an unresolved intrinsic (`import.ts`
+   * substitutes only single-key `{Ref}` before calling a provider). A
+   * split-horizon zone name is refused for safety and lands here too.
+   * (Wildcard records used to fail here as well; `normalizeRecordName` now
+   * decodes Route 53's octal escapes, so they canonicalize normally.)
    *
    * This stays OVERRIDE-ONLY (see the "sub-resources without a standalone
    * identity" list in docs/import.md): the id is now derived from the template

--- a/src/provisioning/providers/route53-provider.ts
+++ b/src/provisioning/providers/route53-provider.ts
@@ -134,7 +134,13 @@ function normalizeRecordName(name: string): string {
   const decoded = name.replace(/\\([0-7]{3})/g, (match, oct: string) =>
     UNDECODABLE_OCTAL_ESCAPES.has(oct) ? match : String.fromCharCode(parseInt(oct, 8))
   );
-  return decoded.endsWith('.') ? decoded : `${decoded}.`;
+  // DNS is case-insensitive and AWS lowercases what it returns, so compare
+  // lowercased. Without this a template spelling `Example.com` fails to match
+  // the zone AWS reports as `example.com.` — which, on the delete path, now
+  // resolves to "zone is gone" and would DROP the state row while leaving the
+  // record live in AWS.
+  const lowered = decoded.toLowerCase();
+  return lowered.endsWith('.') ? lowered : `${lowered}.`;
 }
 
 /**
@@ -952,8 +958,11 @@ export class Route53Provider implements ResourceProvider {
             logicalId,
             physicalId
           );
-          this.logger.debug(
-            `Hosted zone for record set ${logicalId} no longer exists, skipping deletion`
+          // WARN, not debug: this drops the state row, so if the diagnosis is
+          // ever wrong the record is silently orphaned in AWS.
+          this.logger.warn(
+            `Hosted zone for record set ${logicalId} no longer exists; treating the record as ` +
+              `already deleted and dropping it from state.`
           );
           return;
         }

--- a/src/provisioning/providers/route53-provider.ts
+++ b/src/provisioning/providers/route53-provider.ts
@@ -864,7 +864,12 @@ export class Route53Provider implements ResourceProvider {
     const composite = parseRecordSetCompositeId(physicalId);
     const hostedZoneId =
       composite?.hostedZoneId ??
-      (await this.resolveHostedZoneId(properties, logicalId, resourceType, physicalId));
+      (await this.resolveHostedZoneId(properties, logicalId, resourceType, physicalId, {
+        // A DELETE resolved from a name must not guess between a public and a
+        // private zone of the same name — deleting from the wrong one is
+        // unrecoverable, and this fallback is what newly routes delete here.
+        requireUnambiguousZoneName: true,
+      }));
 
     try {
       const resourceRecordSet = this.buildResourceRecordSet(properties);
@@ -1581,31 +1586,60 @@ export class Route53Provider implements ResourceProvider {
     properties: Record<string, unknown>,
     logicalId: string,
     resourceType: string,
-    physicalId?: string
+    physicalId?: string,
+    options?: { requireUnambiguousZoneName?: boolean }
   ): Promise<string> {
-    const hostedZoneId = properties['HostedZoneId'] as string | undefined;
-    if (hostedZoneId) return hostedZoneId;
+    // Guard the TYPE, not just presence: an unresolved intrinsic
+    // (`Fn::ImportValue` / `Fn::GetAtt` / a Parameter `Ref`) is an OBJECT and
+    // therefore truthy, so an unguarded read stringifies it to
+    // `[object Object]` and sends that to AWS as a zone id.
+    const hostedZoneId = properties['HostedZoneId'];
+    if (typeof hostedZoneId === 'string' && hostedZoneId) return hostedZoneId;
 
-    const hostedZoneName = properties['HostedZoneName'] as string | undefined;
-    if (hostedZoneName) {
+    const hostedZoneName = properties['HostedZoneName'];
+    if (typeof hostedZoneName === 'string' && hostedZoneName) {
+      // The lookup keeps its ORIGINAL warn-and-continue catch — a transient
+      // failure here must still fall through to the "specify one of these"
+      // error below rather than surfacing raw. The ambiguity decision is made
+      // AFTER the try deliberately: raising inside it would make this catch a
+      // conditional re-throw rather than a swallow, which un-protects the
+      // `.send()` for the `update-wrap-coverage` critic (and would be a real
+      // hazard if a later edit widened what the try covers).
+      let matched: { Id?: string | undefined }[] = [];
       try {
         const response = await this.getClient().send(
           new ListHostedZonesByNameCommand({
             DNSName: hostedZoneName,
-            MaxItems: 1,
+            // Deliberately > 1: split-horizon DNS lets a public and a private
+            // zone share one name, and `MaxItems: 1` silently picks whichever
+            // AWS lists first. Callers that DELETE through this resolution ask
+            // for the ambiguity to be refused instead.
+            MaxItems: 5,
           })
         );
         const zones = response.HostedZones ?? [];
         // Match the zone name (Route53 returns names with trailing dot)
-        const normalizedName = hostedZoneName.endsWith('.') ? hostedZoneName : `${hostedZoneName}.`;
-        const matchedZone = zones.find((z) => z.Name === normalizedName);
-        if (matchedZone?.Id) {
-          return matchedZone.Id.replace('/hostedzone/', '');
-        }
+        const normalizedName = normalizeRecordName(hostedZoneName);
+        matched = zones.filter((z) => z.Name === normalizedName);
       } catch (error) {
         this.logger.warn(
           `Failed to resolve HostedZoneName "${hostedZoneName}" for ${logicalId}: ${error instanceof Error ? error.message : String(error)}`
         );
+      }
+
+      if (matched.length > 1 && options?.requireUnambiguousZoneName) {
+        throw new ProvisioningError(
+          `HostedZoneName "${hostedZoneName}" matches ${matched.length} hosted zones for ${logicalId} ` +
+            `(split-horizon public/private DNS). Refusing to guess which one this record belongs to — ` +
+            `set HostedZoneId explicitly, or pass the '<zoneId>|<name>|<type>' composite via --resource.`,
+          resourceType,
+          logicalId,
+          physicalId
+        );
+      }
+      const matchedZone = matched[0];
+      if (matchedZone?.Id) {
+        return matchedZone.Id.replace('/hostedzone/', '');
       }
     }
 
@@ -1649,7 +1683,14 @@ export class Route53Provider implements ResourceProvider {
         physicalId
       );
       return { hostedZoneId, name, type };
-    } catch {
+    } catch (err) {
+      // Both callers treat "cannot determine" as "nothing to report" rather
+      // than as a failure, but say WHY at debug level — a swallowed throttle
+      // or credential error is otherwise indistinguishable from a template
+      // that simply does not name a zone.
+      this.logger.debug(
+        `Cannot resolve record-set identity for '${physicalId}': ${err instanceof Error ? err.message : String(err)}`
+      );
       return undefined;
     }
   }
@@ -1946,9 +1987,24 @@ export class Route53Provider implements ResourceProvider {
    * So re-canonicalize instead, the way `AWS::EC2::EIP` already does: an
    * already-composite override passes through (the documented
    * `--resource 'Id=zone|name|type'` form), anything else is rebuilt from the
-   * template properties and VERIFIED against AWS before adoption. A record we
-   * cannot verify returns `null`, which the import command reports as
-   * `skipped-not-found` — loud, and it leaves state clean.
+   * template properties and VERIFIED against AWS.
+   *
+   * **Canonicalization is BEST-EFFORT and never drops the row.** When the
+   * identity cannot be resolved or verified, the supplied id is adopted
+   * VERBATIM with a warning rather than returning `null`. Returning `null`
+   * there would be strictly worse than the bug this fixes: `import.ts` only
+   * aborts when ZERO resources import, so under
+   * `--migrate-from-cloudformation` the run proceeds to `UpdateStack(Retain)`
+   * + `DeleteStack` and the record ends up in NEITHER CloudFormation nor cdkd
+   * state — after which the next deploy CREATEs over a live RRSet and fails.
+   * Adopting verbatim is safe now precisely because `deleteRecordSet` and
+   * `readRecordSet` both accept the scalar form (the other half of this fix).
+   *
+   * Two shapes make verification legitimately fail, and both are ordinary
+   * rather than exotic: a `HostedZoneId` still carrying an unresolved
+   * intrinsic (`import.ts` substitutes only single-key `{Ref}` before calling
+   * a provider), and a wildcard record, which AWS reports octal-escaped as
+   * `\\052.example.com.` so the exact-name match misses.
    *
    * This stays OVERRIDE-ONLY (see the "sub-resources without a standalone
    * identity" list in docs/import.md): the id is now derived from the template
@@ -1956,25 +2012,41 @@ export class Route53Provider implements ResourceProvider {
    * because a RecordSet has no standalone identity for auto mode to key on.
    */
   private async importRecordSet(input: ResourceImportInput): Promise<ResourceImportResult | null> {
-    if (!input.knownPhysicalId) return null;
-    if (parseRecordSetCompositeId(input.knownPhysicalId)) {
-      return { physicalId: input.knownPhysicalId, attributes: {} };
+    const known = input.knownPhysicalId;
+    if (!known) return null;
+    if (parseRecordSetCompositeId(known)) {
+      return { physicalId: known, attributes: {} };
     }
+
+    const adoptVerbatim = (reason: string): ResourceImportResult => {
+      this.logger.warn(
+        `Record set ${input.logicalId}: could not canonicalize physical id '${known}' (${reason}). ` +
+          `Adopting it as-is — delete and drift both accept this form, but a later deploy that ` +
+          `UPDATEs the record will rewrite it to cdkd's '<zoneId>|<name>|<type>' composite.`
+      );
+      return { physicalId: known, attributes: {} };
+    };
 
     // A non-composite override IS CloudFormation's physicalId, i.e. the record
     // name; the template properties carry the same name plus the zone, so they
     // are the authoritative source either way.
-    const identity = await this.resolveRecordSetIdentity(input.knownPhysicalId, input.properties);
+    const identity = await this.resolveRecordSetIdentity(known, input.properties);
     if (!identity) {
-      this.logger.warn(
-        `Cannot resolve the hosted zone / name / type of record set ${input.logicalId} from its template properties; skipping import.`
-      );
-      return null;
+      return adoptVerbatim('the template does not resolve to a hosted zone + Name + Type');
     }
 
     const compositeId = `${identity.hostedZoneId}|${identity.name}|${identity.type}`;
-    const observed = await this.readRecordSet(compositeId);
-    if (!observed) return null;
+    let observed: Record<string, unknown> | undefined;
+    try {
+      observed = await this.readRecordSet(compositeId);
+    } catch (err) {
+      return adoptVerbatim(
+        `verification failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+    if (!observed) {
+      return adoptVerbatim('the record was not found under the resolved hosted zone');
+    }
 
     return { physicalId: compositeId, attributes: {} };
   }

--- a/src/provisioning/providers/route53-provider.ts
+++ b/src/provisioning/providers/route53-provider.ts
@@ -44,6 +44,31 @@ export function isZoneDisabledForMutationError(error: unknown): boolean {
   return error instanceof Error && error.message.includes('is marked disabled for mutation');
 }
 
+/**
+ * A `HostedZoneName` that resolved cleanly but matches no zone.
+ *
+ * Distinct from "no zone was specified": the DELETE path treats a vanished
+ * zone as already-gone (the zone's records went with it) rather than surfacing
+ * a misconfiguration error that would block `cdkd destroy`.
+ */
+class HostedZoneNameNotFoundError extends ProvisioningError {
+  constructor(
+    message: string,
+    resourceType: string,
+    logicalId: string,
+    physicalId?: string,
+    cause?: Error
+  ) {
+    super(message, resourceType, logicalId, physicalId, cause);
+    // REQUIRED: `CdkdError`'s constructor chain ends with
+    // `Object.setPrototypeOf(this, ProvisioningError.prototype)`, which erases
+    // the subclass identity — without re-setting it here, `instanceof
+    // HostedZoneNameNotFoundError` is FALSE for an instance of this class and
+    // the delete path's skip-as-gone arm silently never fires.
+    Object.setPrototypeOf(this, HostedZoneNameNotFoundError.prototype);
+  }
+}
+
 /** Segment count of cdkd's `AWS::Route53::RecordSet` composite physicalId. */
 const RECORD_SET_COMPOSITE_SEGMENTS = 3;
 
@@ -68,12 +93,25 @@ export function parseRecordSetCompositeId(
 }
 
 /**
- * Route 53 stores and reports every record name fully qualified with a
- * trailing dot, while a template may declare it either way — so compare on
- * the normalized form rather than the raw string.
+ * Canonicalize a record name for comparison.
+ *
+ * Two AWS-side spellings have to be absorbed, and missing either one makes
+ * `readCurrentState` return `undefined` — which reads as "drift unknown"
+ * rather than as an error:
+ *
+ * - Route 53 reports every name fully qualified with a TRAILING DOT, while a
+ *   template may declare it either way.
+ * - Non-ASCII and special characters come back OCTAL-ESCAPED: `*.example.com`
+ *   is reported as `\\052.example.com.`. That affects every wildcard record,
+ *   including ones cdkd created itself, so decoding it here fixes drift for
+ *   the whole population rather than only the imported ones.
  */
 function normalizeRecordName(name: string): string {
-  return name.endsWith('.') ? name : `${name}.`;
+  // `\\ddd` -> the character it encodes (Route 53 uses 3-digit octal).
+  const decoded = name.replace(/\\(\d{3})/g, (_m, oct: string) =>
+    String.fromCharCode(parseInt(oct, 8))
+  );
+  return decoded.endsWith('.') ? decoded : `${decoded}.`;
 }
 
 /**
@@ -862,14 +900,43 @@ export class Route53Provider implements ResourceProvider {
     // back to resolving the zone from the recorded properties — the delete
     // only needs segment 1; `Name` / `Type` come from `properties` anyway.
     const composite = parseRecordSetCompositeId(physicalId);
-    const hostedZoneId =
-      composite?.hostedZoneId ??
-      (await this.resolveHostedZoneId(properties, logicalId, resourceType, physicalId, {
-        // A DELETE resolved from a name must not guess between a public and a
-        // private zone of the same name — deleting from the wrong one is
-        // unrecoverable, and this fallback is what newly routes delete here.
-        requireUnambiguousZoneName: true,
-      }));
+    let hostedZoneId: string;
+    if (composite) {
+      hostedZoneId = composite.hostedZoneId;
+    } else {
+      try {
+        hostedZoneId = await this.resolveHostedZoneId(
+          properties,
+          logicalId,
+          resourceType,
+          physicalId,
+          {
+            // A DELETE resolved from a name must not guess between a public
+            // and a private zone of the same name — deleting from the wrong
+            // one is unrecoverable, and this fallback is what newly routes
+            // delete here.
+            requireUnambiguousZoneName: true,
+          }
+        );
+      } catch (error) {
+        if (error instanceof HostedZoneNameNotFoundError) {
+          // The zone is gone, so its records are too. Delete is idempotent.
+          const clientRegion = await this.getClient().config.region();
+          assertRegionMatch(
+            clientRegion,
+            context?.expectedRegion,
+            resourceType,
+            logicalId,
+            physicalId
+          );
+          this.logger.debug(
+            `Hosted zone for record set ${logicalId} no longer exists, skipping deletion`
+          );
+          return;
+        }
+        throw error;
+      }
+    }
 
     try {
       const resourceRecordSet = this.buildResourceRecordSet(properties);
@@ -1605,7 +1672,8 @@ export class Route53Provider implements ResourceProvider {
       // conditional re-throw rather than a swallow, which un-protects the
       // `.send()` for the `update-wrap-coverage` critic (and would be a real
       // hazard if a later edit widened what the try covers).
-      let matched: { Id?: string | undefined }[] = [];
+      let matched: { Id?: string | undefined; Name?: string | undefined }[] = [];
+      let lookupRan = false;
       try {
         const response = await this.getClient().send(
           new ListHostedZonesByNameCommand({
@@ -1618,9 +1686,11 @@ export class Route53Provider implements ResourceProvider {
           })
         );
         const zones = response.HostedZones ?? [];
-        // Match the zone name (Route53 returns names with trailing dot)
+        // Normalize BOTH sides — AWS returns the trailing dot and escapes
+        // special characters, the template may do neither.
         const normalizedName = normalizeRecordName(hostedZoneName);
-        matched = zones.filter((z) => z.Name === normalizedName);
+        matched = zones.filter((z) => normalizeRecordName(z.Name ?? '') === normalizedName);
+        lookupRan = true;
       } catch (error) {
         this.logger.warn(
           `Failed to resolve HostedZoneName "${hostedZoneName}" for ${logicalId}: ${error instanceof Error ? error.message : String(error)}`
@@ -1640,6 +1710,19 @@ export class Route53Provider implements ResourceProvider {
       const matchedZone = matched[0];
       if (matchedZone?.Id) {
         return matchedZone.Id.replace('/hostedzone/', '');
+      }
+
+      // A name WAS specified and the lookup SUCCEEDED but matched no zone —
+      // materially different from "no zone was specified", and the delete path
+      // treats it as already-gone rather than as a misconfiguration.
+      if (lookupRan) {
+        throw new HostedZoneNameNotFoundError(
+          `HostedZoneName "${hostedZoneName}" matches no hosted zone in this account/region ` +
+            `for ${logicalId}`,
+          resourceType,
+          logicalId,
+          physicalId
+        );
       }
     }
 
@@ -1665,7 +1748,8 @@ export class Route53Provider implements ResourceProvider {
    */
   private async resolveRecordSetIdentity(
     physicalId: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
+    options?: { requireUnambiguousZoneName?: boolean }
   ): Promise<{ hostedZoneId: string; name: string; type: string } | undefined> {
     const composite = parseRecordSetCompositeId(physicalId);
     if (composite) return composite;
@@ -1680,7 +1764,8 @@ export class Route53Provider implements ResourceProvider {
         properties,
         'RecordSet',
         'AWS::Route53::RecordSet',
-        physicalId
+        physicalId,
+        options
       );
       return { hostedZoneId, name, type };
     } catch (err) {
@@ -1955,11 +2040,11 @@ export class Route53Provider implements ResourceProvider {
    * Adopt an existing Route 53 resource into cdkd state.
    *
    * Supported types: `AWS::Route53::HostedZone` (override-only);
-   * `AWS::Route53::RecordSet` (resolved from the template's
+   * `AWS::Route53::RecordSet` (override-only too — the supplied id is
+   * CANONICALIZED rather than trusted, using the template's
    * `HostedZoneId` / `HostedZoneName` + `Name` + `Type` and verified
-   * against AWS — RecordSets are not taggable, but their identity is
-   * fully derivable from the template, so an explicit override is not
-   * required).
+   * against AWS, but an import with no override still declines because
+   * a RecordSet has no standalone identity for auto mode to key on).
    */
   async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {
     switch (input.resourceType) {
@@ -2030,9 +2115,19 @@ export class Route53Provider implements ResourceProvider {
     // A non-composite override IS CloudFormation's physicalId, i.e. the record
     // name; the template properties carry the same name plus the zone, so they
     // are the authoritative source either way.
-    const identity = await this.resolveRecordSetIdentity(known, input.properties);
+    // The ambiguity guard matters MORE here than on delete: canonicalizing to
+    // the wrong split-horizon zone FREEZES it into state, after which delete
+    // parses the composite and never re-resolves — so the delete-time guard
+    // can never fire. Verification cannot catch it either, because both zones
+    // hold a record of that name. `resolveRecordSetIdentity` swallows the
+    // refusal into `undefined`, which lands on the safe verbatim fallback.
+    const identity = await this.resolveRecordSetIdentity(known, input.properties, {
+      requireUnambiguousZoneName: true,
+    });
     if (!identity) {
-      return adoptVerbatim('the template does not resolve to a hosted zone + Name + Type');
+      return adoptVerbatim(
+        'the template does not unambiguously resolve to a hosted zone + Name + Type'
+      );
     }
 
     const compositeId = `${identity.hostedZoneId}|${identity.name}|${identity.type}`;

--- a/src/provisioning/providers/route53-provider.ts
+++ b/src/provisioning/providers/route53-provider.ts
@@ -44,6 +44,38 @@ export function isZoneDisabledForMutationError(error: unknown): boolean {
   return error instanceof Error && error.message.includes('is marked disabled for mutation');
 }
 
+/** Segment count of cdkd's `AWS::Route53::RecordSet` composite physicalId. */
+const RECORD_SET_COMPOSITE_SEGMENTS = 3;
+
+/**
+ * Parse cdkd's composite record-set physicalId `<hostedZoneId>|<Name>|<Type>`.
+ *
+ * Returns `undefined` for anything else — most importantly CloudFormation's
+ * OWN physicalId for this type, which is the record name alone (`Ref` on an
+ * `AWS::Route53::RecordSet` returns the domain name, and a DNS name can never
+ * contain `|`). `cdkd import` stored that scalar verbatim before issue #1658,
+ * so state files in the wild carry BOTH shapes and every consumer has to know
+ * which one it is holding.
+ */
+export function parseRecordSetCompositeId(
+  physicalId: string
+): { hostedZoneId: string; name: string; type: string } | undefined {
+  const parts = physicalId.split('|');
+  if (parts.length !== RECORD_SET_COMPOSITE_SEGMENTS) return undefined;
+  const [hostedZoneId, name, type] = parts as [string, string, string];
+  if (!hostedZoneId || !name || !type) return undefined;
+  return { hostedZoneId, name, type };
+}
+
+/**
+ * Route 53 stores and reports every record name fully qualified with a
+ * trailing dot, while a template may declare it either way — so compare on
+ * the normalized form rather than the raw string.
+ */
+function normalizeRecordName(name: string): string {
+  return name.endsWith('.') ? name : `${name}.`;
+}
+
 /**
  * AWS Route 53 Provider
  *
@@ -813,20 +845,6 @@ export class Route53Provider implements ResourceProvider {
   ): Promise<void> {
     this.logger.debug(`Deleting Route 53 record set ${logicalId}: ${physicalId}`);
 
-    // Parse composite ID: hostedZoneId|name|type
-    const parts = physicalId.split('|');
-    if (parts.length !== 3) {
-      throw new ProvisioningError(
-        `Invalid record set physical ID format: ${physicalId}`,
-        resourceType,
-        logicalId,
-        physicalId
-      );
-    }
-
-    // Safe: the length-3 check above guarantees all three segments exist.
-    const [hostedZoneId] = parts as [string, string, string];
-
     // We need the full record details for DELETE action
     if (!properties) {
       throw new ProvisioningError(
@@ -836,6 +854,17 @@ export class Route53Provider implements ResourceProvider {
         physicalId
       );
     }
+
+    // Parse composite ID: hostedZoneId|name|type. A physicalId that is NOT
+    // the composite is CloudFormation's own form (the record name alone —
+    // what `Ref` returns), written into state by `cdkd import` before issue
+    // #1658. Throwing there left every migrated stack undestroyable, so fall
+    // back to resolving the zone from the recorded properties — the delete
+    // only needs segment 1; `Name` / `Type` come from `properties` anyway.
+    const composite = parseRecordSetCompositeId(physicalId);
+    const hostedZoneId =
+      composite?.hostedZoneId ??
+      (await this.resolveHostedZoneId(properties, logicalId, resourceType, physicalId));
 
     try {
       const resourceRecordSet = this.buildResourceRecordSet(properties);
@@ -1589,6 +1618,43 @@ export class Route53Provider implements ResourceProvider {
   }
 
   /**
+   * Recover `(hostedZoneId, name, type)` for a record set from EITHER shape of
+   * physicalId (issue #1658).
+   *
+   * cdkd's own composite carries all three. CloudFormation's physicalId is the
+   * record name alone, so the zone has to be resolved from the recorded
+   * properties — which is exactly what `createRecordSet` does, so the answer is
+   * the same triple the composite would have held. Returns `undefined` (rather
+   * than throwing) when the zone cannot be resolved, because both callers of
+   * this helper treat "cannot determine" as "nothing to report" rather than as
+   * a failure.
+   */
+  private async resolveRecordSetIdentity(
+    physicalId: string,
+    properties?: Record<string, unknown>
+  ): Promise<{ hostedZoneId: string; name: string; type: string } | undefined> {
+    const composite = parseRecordSetCompositeId(physicalId);
+    if (composite) return composite;
+    if (!properties) return undefined;
+
+    const name = typeof properties['Name'] === 'string' ? properties['Name'] : physicalId;
+    const type = properties['Type'];
+    if (!name || typeof type !== 'string' || !type) return undefined;
+
+    try {
+      const hostedZoneId = await this.resolveHostedZoneId(
+        properties,
+        'RecordSet',
+        'AWS::Route53::RecordSet',
+        physicalId
+      );
+      return { hostedZoneId, name, type };
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
    * Read the AWS-current Route 53 resource configuration in CFn-property shape.
    *
    * Dispatch per resource type:
@@ -1602,7 +1668,11 @@ export class Route53Provider implements ResourceProvider {
    *    `CloudWatchLogsLogGroupArn` to match cdkd state).
    *  - `RecordSet` → `ListResourceRecordSets` filtered to the exact
    *    `(name, type)` pair from the composite physicalId
-   *    (`{zoneId}|{name}|{type}`). Surfaces TTL, ResourceRecords (with
+   *    (`{zoneId}|{name}|{type}`), or — for a state record carrying
+   *    CloudFormation's scalar physicalId, written by `cdkd import`
+   *    before issue #1658 — from the recorded properties, so drift is
+   *    reported for those records instead of silently skipped.
+   *    Surfaces TTL, ResourceRecords (with
    *    `[{Value}]` -> string[] re-shape to match cdkd state), AliasTarget,
    *    Weight, Region, Failover, MultiValueAnswer, HealthCheckId,
    *    GeoLocation, GeoProximityLocation, CidrRoutingConfig, SetIdentifier.
@@ -1612,13 +1682,14 @@ export class Route53Provider implements ResourceProvider {
   async readCurrentState(
     physicalId: string,
     _logicalId: string,
-    resourceType: string
+    resourceType: string,
+    properties?: Record<string, unknown>
   ): Promise<Record<string, unknown> | undefined> {
     switch (resourceType) {
       case 'AWS::Route53::HostedZone':
         return this.readHostedZone(physicalId);
       case 'AWS::Route53::RecordSet':
-        return this.readRecordSet(physicalId);
+        return this.readRecordSet(physicalId, properties);
       default:
         return undefined;
     }
@@ -1715,11 +1786,13 @@ export class Route53Provider implements ResourceProvider {
     return result;
   }
 
-  private async readRecordSet(physicalId: string): Promise<Record<string, unknown> | undefined> {
-    const parts = physicalId.split('|');
-    if (parts.length < 3) return undefined;
-    const [hostedZoneId, name, type] = parts;
-    if (!hostedZoneId || !name || !type) return undefined;
+  private async readRecordSet(
+    physicalId: string,
+    properties?: Record<string, unknown>
+  ): Promise<Record<string, unknown> | undefined> {
+    const identity = await this.resolveRecordSetIdentity(physicalId, properties);
+    if (!identity) return undefined;
+    const { hostedZoneId, name, type } = identity;
 
     let resp;
     try {
@@ -1738,8 +1811,13 @@ export class Route53Provider implements ResourceProvider {
 
     // ListResourceRecordSets returns records in lexicographic order starting
     // at StartRecordName/Type; the first match is exact only when both name
-    // and type match what we asked for.
-    const recordSet = resp.ResourceRecordSets?.find((r) => r.Name === name && r.Type === type);
+    // and type match what we asked for. Compare on the fully-qualified name:
+    // AWS always reports the trailing dot, a template may declare it either
+    // way, and the composite physicalId carries whatever the template wrote.
+    const wantedName = normalizeRecordName(name);
+    const recordSet = resp.ResourceRecordSets?.find(
+      (r) => r.Name !== undefined && normalizeRecordName(r.Name) === wantedName && r.Type === type
+    );
     if (!recordSet) return undefined;
 
     const result: Record<string, unknown> = {
@@ -1835,24 +1913,70 @@ export class Route53Provider implements ResourceProvider {
   /**
    * Adopt an existing Route 53 resource into cdkd state.
    *
-   * Supported types: `AWS::Route53::HostedZone` (full tag-based
-   * lookup); `AWS::Route53::RecordSet` (override-only — RecordSets are
-   * not taggable, and the composite child-of-zone identity makes auto
-   * lookup impractical).
+   * Supported types: `AWS::Route53::HostedZone` (override-only);
+   * `AWS::Route53::RecordSet` (resolved from the template's
+   * `HostedZoneId` / `HostedZoneName` + `Name` + `Type` and verified
+   * against AWS — RecordSets are not taggable, but their identity is
+   * fully derivable from the template, so an explicit override is not
+   * required).
    */
   async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {
     switch (input.resourceType) {
       case 'AWS::Route53::HostedZone':
         return this.importHostedZone(input);
       case 'AWS::Route53::RecordSet':
-        // RecordSets aren't taggable; only honor explicit overrides.
-        if (input.knownPhysicalId) {
-          return { physicalId: input.knownPhysicalId, attributes: {} };
-        }
-        return null;
+        return this.importRecordSet(input);
       default:
         return null;
     }
+  }
+
+  /**
+   * Adopt an existing record set (issue #1658).
+   *
+   * cdkd's physicalId is the composite `<hostedZoneId>|<Name>|<Type>` that
+   * `createRecordSet` returns, but CloudFormation's is the record NAME alone.
+   * In auto / `--migrate-from-cloudformation` mode `knownPhysicalId` is NOT a
+   * user choice — the overrides are pre-populated from the CFn stack's
+   * `DescribeStackResources` — so storing it verbatim wrote an id this
+   * provider's own `delete` could not parse, and the migrated stack became
+   * undestroyable with the defect only surfacing after the CFn stack had
+   * already been retired.
+   *
+   * So re-canonicalize instead, the way `AWS::EC2::EIP` already does: an
+   * already-composite override passes through (the documented
+   * `--resource 'Id=zone|name|type'` form), anything else is rebuilt from the
+   * template properties and VERIFIED against AWS before adoption. A record we
+   * cannot verify returns `null`, which the import command reports as
+   * `skipped-not-found` — loud, and it leaves state clean.
+   *
+   * This stays OVERRIDE-ONLY (see the "sub-resources without a standalone
+   * identity" list in docs/import.md): the id is now derived from the template
+   * rather than trusted, but an import with no override at all still declines,
+   * because a RecordSet has no standalone identity for auto mode to key on.
+   */
+  private async importRecordSet(input: ResourceImportInput): Promise<ResourceImportResult | null> {
+    if (!input.knownPhysicalId) return null;
+    if (parseRecordSetCompositeId(input.knownPhysicalId)) {
+      return { physicalId: input.knownPhysicalId, attributes: {} };
+    }
+
+    // A non-composite override IS CloudFormation's physicalId, i.e. the record
+    // name; the template properties carry the same name plus the zone, so they
+    // are the authoritative source either way.
+    const identity = await this.resolveRecordSetIdentity(input.knownPhysicalId, input.properties);
+    if (!identity) {
+      this.logger.warn(
+        `Cannot resolve the hosted zone / name / type of record set ${input.logicalId} from its template properties; skipping import.`
+      );
+      return null;
+    }
+
+    const compositeId = `${identity.hostedZoneId}|${identity.name}|${identity.type}`;
+    const observed = await this.readRecordSet(compositeId);
+    if (!observed) return null;
+
+    return { physicalId: compositeId, attributes: {} };
   }
 
   private async importHostedZone(input: ResourceImportInput): Promise<ResourceImportResult | null> {

--- a/src/provisioning/providers/route53-provider.ts
+++ b/src/provisioning/providers/route53-provider.ts
@@ -144,6 +144,28 @@ function normalizeRecordName(name: string): string {
 }
 
 /**
+ * Canonicalize a name for the QUERY side of a Route 53 list call.
+ *
+ * `normalizeRecordName` above is the COMPARE-side canonicalizer, and the two
+ * are deliberately NOT the same function. Route 53 orders both hosted zones
+ * and record sets by reversed labels of the name it STORES — lower-cased and
+ * escape-ENCODED — and a `DNSName` / `StartRecordName` start key in any other
+ * spelling positions the window somewhere else entirely. So the query side
+ * must move TOWARD AWS's spelling (lower-case, encode `*`), where the compare
+ * side moves AWS's answer toward the template's (decode escapes).
+ *
+ * Decoding here would be actively wrong: `*.example.com` sorts at `*` (0x2A)
+ * while AWS stores `\052.example.com` and sorts it at `\` (0x5C), so every
+ * name whose first label begins with `-` / `+` / a digit / an upper-case
+ * letter falls BETWEEN them — with a bounded page, the wildcard record we
+ * asked for is skipped straight past.
+ */
+function canonicalizeQueryName(name: string): string {
+  const lowered = name.toLowerCase().replaceAll('*', '\\052');
+  return lowered.endsWith('.') ? lowered : `${lowered}.`;
+}
+
+/**
  * AWS Route 53 Provider
  *
  * Implements resource provisioning for Route 53 resources:
@@ -961,8 +983,9 @@ export class Route53Provider implements ResourceProvider {
           // WARN, not debug: this drops the state row, so if the diagnosis is
           // ever wrong the record is silently orphaned in AWS.
           this.logger.warn(
-            `Hosted zone for record set ${logicalId} no longer exists; treating the record as ` +
-              `already deleted and dropping it from state.`
+            `Hosted zone "${String(properties?.['HostedZoneName'])}" for record set ${logicalId} ` +
+              `(${physicalId}) no longer exists; treating the record as already deleted and ` +
+              `dropping it from state.`
           );
           return;
         }
@@ -1695,6 +1718,12 @@ export class Route53Provider implements ResourceProvider {
     const hostedZoneId = properties['HostedZoneId'];
     if (typeof hostedZoneId === 'string' && hostedZoneId) return hostedZoneId;
 
+    // Declared out here because the terminal throw below is outside the
+    // branch: a lookup that FAILED must surface its cause rather than the
+    // misleading "specify one of these" message.
+    let lookupErrorMessage: string | undefined;
+    let lookupErrorCause: Error | undefined;
+
     const hostedZoneName = properties['HostedZoneName'];
     if (typeof hostedZoneName === 'string' && hostedZoneName) {
       // The lookup keeps its ORIGINAL warn-and-continue catch — a transient
@@ -1705,11 +1734,22 @@ export class Route53Provider implements ResourceProvider {
       // `.send()` for the `update-wrap-coverage` critic (and would be a real
       // hazard if a later edit widened what the try covers).
       let matched: { Id?: string | undefined; Name?: string | undefined }[] = [];
-      let lookupRan = false;
+      // NOT "the lookup returned" — "an empty result PROVES the zone is gone".
+      // Only this flag authorizes the delete path's already-deleted arm, which
+      // drops a state row, so it stays false for every answer we cannot read
+      // as a sound negative.
+      let absenceIsSound = false;
       try {
         const response = await this.getClient().send(
           new ListHostedZonesByNameCommand({
-            DNSName: hostedZoneName,
+            // Case-folded + encoded: this is the START KEY of AWS's ordering,
+            // not a filter. Sending the template's spelling verbatim
+            // positions the window by `Example.com` while AWS orders by
+            // `example.com.`, so an existing zone can fall outside a bounded
+            // page and read as ABSENT — which on the delete path drops the
+            // state row and orphans the record. That is the failure the
+            // compare-side case fold alone does NOT close.
+            DNSName: canonicalizeQueryName(hostedZoneName),
             // Deliberately > 1: split-horizon DNS lets a public and a private
             // zone share one name, and `MaxItems: 1` silently picks whichever
             // AWS lists first. Callers that DELETE through this resolution ask
@@ -1722,10 +1762,19 @@ export class Route53Provider implements ResourceProvider {
         // special characters, the template may do neither.
         const normalizedName = normalizeRecordName(hostedZoneName);
         matched = zones.filter((z) => normalizeRecordName(z.Name ?? '') === normalizedName);
-        lookupRan = true;
+        // AWS starts the page AT the requested key, so same-named zones are
+        // the first entries and a page that shows a LATER zone has already
+        // proven ours is not there. An EMPTY truncated page proves nothing —
+        // and neither does a name we could not position confidently, so a
+        // template spelling that already carries a backslash escape is
+        // refused the negative rather than guessed at.
+        absenceIsSound =
+          !hostedZoneName.includes('\\') && (zones.length > 0 || response.IsTruncated !== true);
       } catch (error) {
+        lookupErrorMessage = error instanceof Error ? error.message : String(error);
+        lookupErrorCause = error instanceof Error ? error : undefined;
         this.logger.warn(
-          `Failed to resolve HostedZoneName "${hostedZoneName}" for ${logicalId}: ${error instanceof Error ? error.message : String(error)}`
+          `Failed to resolve HostedZoneName "${hostedZoneName}" for ${logicalId}: ${lookupErrorMessage}`
         );
       }
 
@@ -1744,10 +1793,10 @@ export class Route53Provider implements ResourceProvider {
         return matchedZone.Id.replace('/hostedzone/', '');
       }
 
-      // A name WAS specified and the lookup SUCCEEDED but matched no zone —
+      // A name WAS specified and the lookup returned a SOUND NEGATIVE —
       // materially different from "no zone was specified", and the delete path
       // treats it as already-gone rather than as a misconfiguration.
-      if (lookupRan) {
+      if (absenceIsSound) {
         throw new HostedZoneNameNotFoundError(
           `HostedZoneName "${hostedZoneName}" matches no hosted zone in this account/region ` +
             `for ${logicalId}`,
@@ -1759,10 +1808,14 @@ export class Route53Provider implements ResourceProvider {
     }
 
     throw new ProvisioningError(
-      `Either HostedZoneId or HostedZoneName is required for record set ${logicalId}`,
+      lookupErrorMessage
+        ? `Could not resolve HostedZoneName "${String(hostedZoneName)}" for record set ` +
+            `${logicalId}: ${lookupErrorMessage}`
+        : `Either HostedZoneId or HostedZoneName is required for record set ${logicalId}`,
       resourceType,
       logicalId,
-      physicalId
+      physicalId,
+      lookupErrorCause
     );
   }
 
@@ -1957,15 +2010,18 @@ export class Route53Provider implements ResourceProvider {
       resp = await this.getClient().send(
         new ListResourceRecordSetsCommand({
           HostedZoneId: hostedZoneId,
-          StartRecordName: name,
+          // Encoded start key, for the reason `canonicalizeQueryName`
+          // records: AWS orders records on the name it STORES, so a template
+          // spelling `*.example.com` positions at `*` (0x2A) while the record
+          // sits at `\\052…` (0x5C) — every sibling whose first label starts
+          // with `-` / `+` / a digit / an upper-case letter falls between
+          // them, and a bounded page skips the record we asked for. Decoding
+          // on the COMPARE side alone cannot fix that; the query has to
+          // return the record first.
+          StartRecordName: canonicalizeQueryName(name),
           StartRecordType: type as RRType,
-          // NOT 1: AWS orders records on the ESCAPED name, so for a wildcard
-          // (`*` 0x2A, reported as `\\052…` and ordered by `\` 0x5C) a
-          // single-record page can skip straight past the record we asked
-          // for. Decoding the escape on the COMPARE side alone would not fix
-          // wildcards — the query has to return the record first. Take a few
-          // and let the exact-match filter below pick, the same shape the
-          // hosted-zone lookup uses.
+          // Still > 1 after the encoding fix: a name can also carry escapes
+          // this helper does not encode, and a few extra rows are free.
           MaxItems: 5,
         })
       );

--- a/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
+++ b/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
@@ -442,11 +442,60 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
         })
       ).rejects.toThrow(/HostedZoneId or HostedZoneName is required/);
 
+      // The message is the SAME one a "no zone specified at all" template
+      // gets, so assert the lookup actually RAN -- otherwise a regression
+      // that stopped reading HostedZoneName passes this test while never
+      // reaching the truncation logic at all.
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(ListHostedZonesByNameCommand);
+
       expect(
         mockSend.mock.calls.some(
           (c: unknown[]) => c[0] instanceof ChangeResourceRecordSetsCommand
         )
       ).toBe(false);
+    });
+
+    it('checks the REGION before treating a vanished zone as already-deleted (#1658)', async () => {
+      // The skip arm drops a state row, so it must not fire when the client
+      // is pointed somewhere other than where the resource was recorded --
+      // a foreign region lists zero zones, which would otherwise read as
+      // "the zone is gone" and orphan a record that is alive elsewhere.
+      // Without the assertRegionMatch call this resolves instead of throwing.
+      mockSend.mockResolvedValueOnce({ HostedZones: [] });
+
+      await expect(
+        provider.delete(
+          'WebsiteRecord',
+          'record.example.com',
+          'AWS::Route53::RecordSet',
+          { ...RECORD_PROPS, HostedZoneId: undefined, HostedZoneName: 'example.com' },
+          { expectedRegion: 'eu-west-1' }
+        )
+      ).rejects.toThrow(/region/i);
+
+      expect(
+        mockSend.mock.calls.some(
+          (c: unknown[]) => c[0] instanceof ChangeResourceRecordSetsCommand
+        )
+      ).toBe(false);
+    });
+
+    it('refuses the already-gone conclusion for an ESCAPED zone name (#1658)', async () => {
+      // AWS orders on the ESCAPED name, so a template spelling that already
+      // carries a backslash cannot be positioned confidently -- and an
+      // unconfident negative must not authorize dropping the state row.
+      mockSend.mockResolvedValueOnce({ HostedZones: [] });
+
+      await expect(
+        provider.delete('WebsiteRecord', 'record.example.com', 'AWS::Route53::RecordSet', {
+          ...RECORD_PROPS,
+          HostedZoneId: undefined,
+          HostedZoneName: String.raw`ex\344mple.com`,
+        })
+      ).rejects.toThrow(/HostedZoneId or HostedZoneName is required/);
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
     });
 
     it('still errors when neither the id nor the properties identify a zone', async () => {
@@ -600,6 +649,54 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
       );
 
       expect(result).toBeUndefined();
+    });
+
+    it('sends the ENCODED wildcard name as the list START KEY (#1658)', async () => {
+      // The pin that makes the query-side fix testable at all. AWS orders
+      // records on the name it STORES, so `*.example.com` (`*` = 0x2A) sits
+      // far from the stored `\052.example.com.` (`\` = 0x5C) -- every
+      // sibling whose first label starts with `-` / `+` / a digit / an
+      // upper-case letter falls between them, and a bounded page skips the
+      // record we asked for. Mocking AWS's ANSWER cannot catch that
+      // regression; only asserting the REQUEST can.
+      mockSend.mockResolvedValueOnce({
+        ResourceRecordSets: [
+          { Name: String.raw`\052.example.com.`, Type: 'A', TTL: 300, ResourceRecords: [] },
+        ],
+      });
+
+      await provider.readCurrentState(
+        'Z0123456789ABCDEFGHIJ|*.example.com|A',
+        'WildcardRecord',
+        'AWS::Route53::RecordSet'
+      );
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const list = mockSend.mock.calls[0]?.[0];
+      expect(list).toBeInstanceOf(ListResourceRecordSetsCommand);
+      expect(list.input.StartRecordName).toBe(String.raw`\052.example.com.`);
+      expect(list.input.StartRecordType).toBe('A');
+    });
+
+    it('sends the ENCODED wildcard name as the ZONE lookup start key too (#1658)', async () => {
+      // Same helper, other call site: a wildcard-named zone is as
+      // mis-positionable as a wildcard record, and here the miss drops a
+      // state row rather than merely hiding drift.
+      mockSend
+        .mockResolvedValueOnce({
+          HostedZones: [{ Id: '/hostedzone/Z0123456789ABCDEFGHIJ', Name: String.raw`\052.example.com.` }],
+        })
+        .mockResolvedValueOnce({});
+
+      await provider.delete('WildcardRecord', 'record.example.com', 'AWS::Route53::RecordSet', {
+        ...RECORD_PROPS,
+        HostedZoneId: undefined,
+        HostedZoneName: '*.example.com',
+      });
+
+      const list = mockSend.mock.calls[0]?.[0];
+      expect(list).toBeInstanceOf(ListHostedZonesByNameCommand);
+      expect(list.input.DNSName).toBe(String.raw`\052.example.com.`);
     });
 
     it('returns undefined when the id is unparsable and no properties are available', async () => {

--- a/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
+++ b/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import {
+  ChangeResourceRecordSetsCommand,
+  ListHostedZonesByNameCommand,
+  ListResourceRecordSetsCommand,
+} from '@aws-sdk/client-route-53';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-route-53', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-route-53')>(
+    '@aws-sdk/client-route-53'
+  );
+  return {
+    ...actual,
+    Route53Client: vi.fn().mockImplementation(() => ({
+      send: mockSend,
+      config: { region: () => Promise.resolve('us-east-1') },
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import {
+  Route53Provider,
+  parseRecordSetCompositeId,
+} from '../../../src/provisioning/providers/route53-provider.js';
+
+const RECORD_PROPS = {
+  HostedZoneId: 'Z0123456789ABCDEFGHIJ',
+  Name: 'record.example.com.',
+  Type: 'A',
+  TTL: 300,
+  ResourceRecords: ['1.2.3.4'],
+};
+
+/** The shape `ListResourceRecordSets` returns for RECORD_PROPS. */
+const AWS_RECORD = {
+  ResourceRecordSets: [
+    {
+      Name: 'record.example.com.',
+      Type: 'A',
+      TTL: 300,
+      ResourceRecords: [{ Value: '1.2.3.4' }],
+    },
+  ],
+};
+
+describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (issue #1658)', () => {
+  let provider: Route53Provider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new Route53Provider();
+  });
+
+  describe('parseRecordSetCompositeId', () => {
+    it('parses cdkd composite ids', () => {
+      expect(parseRecordSetCompositeId('Z1|record.example.com.|A')).toEqual({
+        hostedZoneId: 'Z1',
+        name: 'record.example.com.',
+        type: 'A',
+      });
+    });
+
+    it("rejects CloudFormation's scalar physicalId (the record name)", () => {
+      expect(parseRecordSetCompositeId('record.example.com')).toBeUndefined();
+    });
+
+    it('rejects wrong-arity and blank-segment ids', () => {
+      expect(parseRecordSetCompositeId('Z1|record.example.com.')).toBeUndefined();
+      expect(parseRecordSetCompositeId('Z1|record.example.com.|A|extra')).toBeUndefined();
+      expect(parseRecordSetCompositeId('Z1||A')).toBeUndefined();
+    });
+  });
+
+  describe('import()', () => {
+    it("canonicalizes CloudFormation's record-name physicalId into cdkd's composite", async () => {
+      mockSend.mockResolvedValueOnce(AWS_RECORD);
+
+      const result = await provider.import({
+        logicalId: 'WebsiteRecord',
+        resourceType: 'AWS::Route53::RecordSet',
+        stackName: 'MyStack',
+        region: 'us-east-1',
+        properties: RECORD_PROPS,
+        // What `--migrate-from-cloudformation` pre-populates from
+        // DescribeStackResources: CFn's physicalId, not cdkd's composite.
+        knownPhysicalId: 'record.example.com',
+      });
+
+      expect(result).toEqual({
+        physicalId: 'Z0123456789ABCDEFGHIJ|record.example.com.|A',
+        attributes: {},
+      });
+      const verify = mockSend.mock.calls[0]?.[0];
+      expect(verify).toBeInstanceOf(ListResourceRecordSetsCommand);
+      expect(verify.input).toMatchObject({ HostedZoneId: 'Z0123456789ABCDEFGHIJ' });
+    });
+
+    it('passes an already-composite override through without an AWS call', async () => {
+      const result = await provider.import({
+        logicalId: 'WebsiteRecord',
+        resourceType: 'AWS::Route53::RecordSet',
+        stackName: 'MyStack',
+        region: 'us-east-1',
+        properties: RECORD_PROPS,
+        knownPhysicalId: 'Z9|record.example.com.|A',
+      });
+
+      expect(result).toEqual({ physicalId: 'Z9|record.example.com.|A', attributes: {} });
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('resolves the zone via HostedZoneName when the template has no HostedZoneId', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          HostedZones: [{ Id: '/hostedzone/Z0123456789ABCDEFGHIJ', Name: 'example.com.' }],
+        })
+        .mockResolvedValueOnce(AWS_RECORD);
+
+      const result = await provider.import({
+        logicalId: 'WebsiteRecord',
+        resourceType: 'AWS::Route53::RecordSet',
+        stackName: 'MyStack',
+        region: 'us-east-1',
+        properties: { ...RECORD_PROPS, HostedZoneId: undefined, HostedZoneName: 'example.com' },
+        knownPhysicalId: 'record.example.com',
+      });
+
+      expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(ListHostedZonesByNameCommand);
+      expect(result).toEqual({
+        physicalId: 'Z0123456789ABCDEFGHIJ|record.example.com.|A',
+        attributes: {},
+      });
+    });
+
+    it('stays override-only: declines with no override, per docs/import.md', async () => {
+      const result = await provider.import({
+        logicalId: 'WebsiteRecord',
+        resourceType: 'AWS::Route53::RecordSet',
+        stackName: 'MyStack',
+        region: 'us-east-1',
+        properties: RECORD_PROPS,
+      });
+
+      expect(result).toBeNull();
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('returns null (skipped-not-found) when the record does not exist in AWS', async () => {
+      mockSend.mockResolvedValueOnce({ ResourceRecordSets: [] });
+
+      const result = await provider.import({
+        logicalId: 'WebsiteRecord',
+        resourceType: 'AWS::Route53::RecordSet',
+        stackName: 'MyStack',
+        region: 'us-east-1',
+        properties: RECORD_PROPS,
+        knownPhysicalId: 'record.example.com',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the zone cannot be resolved from the template', async () => {
+      const result = await provider.import({
+        logicalId: 'WebsiteRecord',
+        resourceType: 'AWS::Route53::RecordSet',
+        stackName: 'MyStack',
+        region: 'us-east-1',
+        properties: { Name: 'record.example.com.', Type: 'A' },
+        knownPhysicalId: 'record.example.com',
+      });
+
+      expect(result).toBeNull();
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete()', () => {
+    it('deletes a record whose state carries the cdkd composite id', async () => {
+      mockSend.mockResolvedValueOnce({});
+
+      await provider.delete(
+        'WebsiteRecord',
+        'Z0123456789ABCDEFGHIJ|record.example.com.|A',
+        'AWS::Route53::RecordSet',
+        RECORD_PROPS
+      );
+
+      const call = mockSend.mock.calls[0]?.[0];
+      expect(call).toBeInstanceOf(ChangeResourceRecordSetsCommand);
+      expect(call.input.HostedZoneId).toBe('Z0123456789ABCDEFGHIJ');
+    });
+
+    it("deletes a record whose state carries CloudFormation's scalar id, by resolving the zone from properties", async () => {
+      mockSend.mockResolvedValueOnce({});
+
+      // Pre-#1658 state written by `cdkd import --migrate-from-cloudformation`.
+      await provider.delete(
+        'WebsiteRecord',
+        'record.example.com',
+        'AWS::Route53::RecordSet',
+        RECORD_PROPS
+      );
+
+      const call = mockSend.mock.calls[0]?.[0];
+      expect(call).toBeInstanceOf(ChangeResourceRecordSetsCommand);
+      expect(call.input.HostedZoneId).toBe('Z0123456789ABCDEFGHIJ');
+      expect(call.input.ChangeBatch.Changes[0].Action).toBe('DELETE');
+    });
+
+    it('resolves the zone via HostedZoneName when state carries the scalar id and no HostedZoneId', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          HostedZones: [{ Id: '/hostedzone/Z0123456789ABCDEFGHIJ', Name: 'example.com.' }],
+        })
+        .mockResolvedValueOnce({});
+
+      await provider.delete('WebsiteRecord', 'record.example.com', 'AWS::Route53::RecordSet', {
+        ...RECORD_PROPS,
+        HostedZoneId: undefined,
+        HostedZoneName: 'example.com',
+      });
+
+      expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(ListHostedZonesByNameCommand);
+      const del = mockSend.mock.calls[1]?.[0];
+      expect(del).toBeInstanceOf(ChangeResourceRecordSetsCommand);
+      expect(del.input.HostedZoneId).toBe('Z0123456789ABCDEFGHIJ');
+    });
+
+    it('still errors when neither the id nor the properties identify a zone', async () => {
+      await expect(
+        provider.delete('WebsiteRecord', 'record.example.com', 'AWS::Route53::RecordSet', {
+          Name: 'record.example.com.',
+          Type: 'A',
+        })
+      ).rejects.toThrow(/HostedZoneId or HostedZoneName is required/);
+    });
+  });
+
+  describe('readCurrentState()', () => {
+    it("reports drift for a record whose state carries CloudFormation's scalar id", async () => {
+      mockSend.mockResolvedValueOnce(AWS_RECORD);
+
+      const result = await provider.readCurrentState(
+        'record.example.com',
+        'WebsiteRecord',
+        'AWS::Route53::RecordSet',
+        RECORD_PROPS
+      );
+
+      expect(result).toMatchObject({
+        HostedZoneId: 'Z0123456789ABCDEFGHIJ',
+        Name: 'record.example.com.',
+        Type: 'A',
+        TTL: 300,
+        ResourceRecords: ['1.2.3.4'],
+      });
+    });
+
+    it('reads back a composite-id record without consulting properties', async () => {
+      mockSend.mockResolvedValueOnce(AWS_RECORD);
+
+      const result = await provider.readCurrentState(
+        'Z0123456789ABCDEFGHIJ|record.example.com.|A',
+        'WebsiteRecord',
+        'AWS::Route53::RecordSet'
+      );
+
+      expect(result).toMatchObject({ Name: 'record.example.com.', Type: 'A' });
+    });
+
+    it('matches a composite whose Name lacks the trailing dot AWS reports', async () => {
+      mockSend.mockResolvedValueOnce(AWS_RECORD);
+
+      const result = await provider.readCurrentState(
+        'Z0123456789ABCDEFGHIJ|record.example.com|A',
+        'WebsiteRecord',
+        'AWS::Route53::RecordSet'
+      );
+
+      expect(result).toMatchObject({ Type: 'A', TTL: 300 });
+    });
+
+    it('returns undefined when the id is unparsable and no properties are available', async () => {
+      const result = await provider.readCurrentState(
+        'record.example.com',
+        'WebsiteRecord',
+        'AWS::Route53::RecordSet'
+      );
+
+      expect(result).toBeUndefined();
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
+++ b/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
@@ -166,7 +166,11 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
       expect(mockSend).not.toHaveBeenCalled();
     });
 
-    it('returns null (skipped-not-found) when the record does not exist in AWS', async () => {
+    // The import command aborts only when ZERO resources import, so a `null`
+    // here lets --migrate-from-cloudformation retire the CFn stack while the
+    // record is in NEITHER system. Adopting verbatim is safe because delete
+    // and drift both accept the scalar form.
+    it('adopts VERBATIM (never null) when the record cannot be found in AWS', async () => {
       mockSend.mockResolvedValueOnce({ ResourceRecordSets: [] });
 
       const result = await provider.import({
@@ -178,10 +182,10 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
         knownPhysicalId: 'record.example.com',
       });
 
-      expect(result).toBeNull();
+      expect(result).toEqual({ physicalId: 'record.example.com', attributes: {} });
     });
 
-    it('returns null when the zone cannot be resolved from the template', async () => {
+    it('adopts VERBATIM when the zone cannot be resolved from the template', async () => {
       const result = await provider.import({
         logicalId: 'WebsiteRecord',
         resourceType: 'AWS::Route53::RecordSet',
@@ -191,8 +195,62 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
         knownPhysicalId: 'record.example.com',
       });
 
-      expect(result).toBeNull();
+      expect(result).toEqual({ physicalId: 'record.example.com', attributes: {} });
       expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('adopts VERBATIM when HostedZoneId is still an unresolved intrinsic', async () => {
+      // `import.ts` substitutes only single-key {Ref}; Fn::ImportValue / GetAtt
+      // reach the provider as objects. An unguarded read would stringify this
+      // to '[object Object]' and send it to AWS as a zone id.
+      const result = await provider.import({
+        logicalId: 'WebsiteRecord',
+        resourceType: 'AWS::Route53::RecordSet',
+        stackName: 'MyStack',
+        region: 'us-east-1',
+        properties: {
+          ...RECORD_PROPS,
+          HostedZoneId: { 'Fn::ImportValue': 'SharedZoneId' },
+        },
+        knownPhysicalId: 'record.example.com',
+      });
+
+      expect(result).toEqual({ physicalId: 'record.example.com', attributes: {} });
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('adopts VERBATIM when verification throws (e.g. a throttle)', async () => {
+      mockSend.mockRejectedValueOnce(new Error('Throttling: Rate exceeded'));
+
+      const result = await provider.import({
+        logicalId: 'WebsiteRecord',
+        resourceType: 'AWS::Route53::RecordSet',
+        stackName: 'MyStack',
+        region: 'us-east-1',
+        properties: RECORD_PROPS,
+        knownPhysicalId: 'record.example.com',
+      });
+
+      expect(result).toEqual({ physicalId: 'record.example.com', attributes: {} });
+    });
+
+    it('adopts VERBATIM for a wildcard record AWS reports octal-escaped', async () => {
+      // Route 53 renders `*.example.com` as `\052.example.com.`, so the exact
+      // name match legitimately misses and must not drop the row.
+      mockSend.mockResolvedValueOnce({
+        ResourceRecordSets: [{ Name: '\\052.example.com.', Type: 'A', TTL: 300 }],
+      });
+
+      const result = await provider.import({
+        logicalId: 'WildcardRecord',
+        resourceType: 'AWS::Route53::RecordSet',
+        stackName: 'MyStack',
+        region: 'us-east-1',
+        properties: { ...RECORD_PROPS, Name: '*.example.com.' },
+        knownPhysicalId: '*.example.com',
+      });
+
+      expect(result).toEqual({ physicalId: '*.example.com', attributes: {} });
     });
   });
 
@@ -246,6 +304,53 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
       const del = mockSend.mock.calls[1]?.[0];
       expect(del).toBeInstanceOf(ChangeResourceRecordSetsCommand);
       expect(del.input.HostedZoneId).toBe('Z0123456789ABCDEFGHIJ');
+    });
+
+    it('refuses to guess between split-horizon zones of the same name', async () => {
+      // A public and a private zone can share one name. Deleting from the
+      // wrong one is unrecoverable, and this fallback is what newly routes
+      // delete through name resolution.
+      mockSend.mockResolvedValueOnce({
+        HostedZones: [
+          { Id: '/hostedzone/ZPUBLIC000000000000', Name: 'example.com.' },
+          { Id: '/hostedzone/ZPRIVATE00000000000', Name: 'example.com.' },
+        ],
+      });
+
+      await expect(
+        provider.delete('WebsiteRecord', 'record.example.com', 'AWS::Route53::RecordSet', {
+          ...RECORD_PROPS,
+          HostedZoneId: undefined,
+          HostedZoneName: 'example.com',
+        })
+      ).rejects.toThrow(/matches 2 hosted zones/);
+    });
+
+    it('deletes with a COMPOSITE id and no HostedZoneName lookup', async () => {
+      // Pins the reordered guard: the composite short-circuits zone
+      // resolution entirely, so no ListHostedZonesByName is issued.
+      mockSend.mockResolvedValueOnce({});
+
+      await provider.delete(
+        'WebsiteRecord',
+        'Z0123456789ABCDEFGHIJ|record.example.com.|A',
+        'AWS::Route53::RecordSet',
+        { ...RECORD_PROPS, HostedZoneId: undefined, HostedZoneName: 'example.com' }
+      );
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(ChangeResourceRecordSetsCommand);
+    });
+
+    it('rejects a composite id with no properties at all', async () => {
+      await expect(
+        provider.delete(
+          'WebsiteRecord',
+          'Z0123456789ABCDEFGHIJ|record.example.com.|A',
+          'AWS::Route53::RecordSet',
+          undefined
+        )
+      ).rejects.toThrow(/Properties required/);
     });
 
     it('still errors when neither the id nor the properties identify a zone', async () => {

--- a/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
+++ b/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
@@ -234,27 +234,6 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
       expect(result).toEqual({ physicalId: 'record.example.com', attributes: {} });
     });
 
-    it('adopts VERBATIM for a wildcard record AWS reports octal-escaped', async () => {
-      // Route 53 renders `*.example.com` as `\052.example.com.`, so the exact
-      // name match legitimately misses and must not drop the row.
-      mockSend.mockResolvedValueOnce({
-        ResourceRecordSets: [{ Name: '\\052.example.com.', Type: 'A', TTL: 300 }],
-      });
-
-      const result = await provider.import({
-        logicalId: 'WildcardRecord',
-        resourceType: 'AWS::Route53::RecordSet',
-        stackName: 'MyStack',
-        region: 'us-east-1',
-        properties: { ...RECORD_PROPS, Name: '*.example.com.' },
-        knownPhysicalId: '*.example.com',
-      });
-
-      expect(result).toEqual({ physicalId: '*.example.com', attributes: {} });
-    });
-  });
-
-  describe('delete()', () => {
     it('deletes a record whose state carries the cdkd composite id', async () => {
       mockSend.mockResolvedValueOnce({});
 
@@ -353,6 +332,25 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
       ).rejects.toThrow(/Properties required/);
     });
 
+    it('treats a vanished hosted zone as already-gone rather than erroring', async () => {
+      // A name that resolves cleanly to ZERO zones means the zone (and its
+      // records) are gone. Surfacing "HostedZoneId or HostedZoneName is
+      // required" there would be the wrong description AND would block
+      // `cdkd destroy`.
+      mockSend.mockResolvedValueOnce({ HostedZones: [] });
+
+      await expect(
+        provider.delete('WebsiteRecord', 'record.example.com', 'AWS::Route53::RecordSet', {
+          ...RECORD_PROPS,
+          HostedZoneId: undefined,
+          HostedZoneName: 'example.com',
+        })
+      ).resolves.toBeUndefined();
+
+      // Only the lookup ran — no ChangeResourceRecordSets was attempted.
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+
     it('still errors when neither the id nor the properties identify a zone', async () => {
       await expect(
         provider.delete('WebsiteRecord', 'record.example.com', 'AWS::Route53::RecordSet', {
@@ -360,6 +358,56 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
           Type: 'A',
         })
       ).rejects.toThrow(/HostedZoneId or HostedZoneName is required/);
+    });
+  });
+
+  describe('create / update paths (the guard is not import-only)', () => {
+    // Pin BOTH polarities of the typeof guard: the fix's stated create/update
+    // benefit is otherwise unpinned, and a regression there sends AWS the
+    // string '[object Object]' as a hosted zone id.
+    it('refuses an object HostedZoneId on create instead of sending [object Object]', async () => {
+      await expect(
+        provider.create('WebsiteRecord', 'AWS::Route53::RecordSet', {
+          ...RECORD_PROPS,
+          HostedZoneId: { 'Fn::ImportValue': 'SharedZoneId' },
+        })
+      ).rejects.toThrow(/HostedZoneId or HostedZoneName is required/);
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('still accepts a plain-string HostedZoneId on create', async () => {
+      mockSend.mockResolvedValueOnce({});
+
+      const result = await provider.create(
+        'WebsiteRecord',
+        'AWS::Route53::RecordSet',
+        RECORD_PROPS
+      );
+
+      expect(result.physicalId).toBe('Z0123456789ABCDEFGHIJ|record.example.com.|A');
+      expect(mockSend.mock.calls[0]?.[0].input.HostedZoneId).toBe('Z0123456789ABCDEFGHIJ');
+    });
+
+    it('does NOT refuse split-horizon on create (first-match preserved)', async () => {
+      // Deliberate asymmetry: refusing here would break deploys that work
+      // today. Only the destructive / state-freezing paths require an
+      // unambiguous zone.
+      mockSend
+        .mockResolvedValueOnce({
+          HostedZones: [
+            { Id: '/hostedzone/ZPUBLIC000000000000', Name: 'example.com.' },
+            { Id: '/hostedzone/ZPRIVATE00000000000', Name: 'example.com.' },
+          ],
+        })
+        .mockResolvedValueOnce({});
+
+      const result = await provider.create('WebsiteRecord', 'AWS::Route53::RecordSet', {
+        ...RECORD_PROPS,
+        HostedZoneId: undefined,
+        HostedZoneName: 'example.com',
+      });
+
+      expect(result.physicalId).toBe('ZPUBLIC000000000000|record.example.com.|A');
     });
   });
 

--- a/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
+++ b/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
@@ -234,6 +234,9 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
       expect(result).toEqual({ physicalId: 'record.example.com', attributes: {} });
     });
 
+  });
+
+  describe('delete()', () => {
     it('deletes a record whose state carries the cdkd composite id', async () => {
       mockSend.mockResolvedValueOnce({});
 
@@ -303,6 +306,11 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
           HostedZoneName: 'example.com',
         })
       ).rejects.toThrow(/matches 2 hosted zones/);
+
+      // Reverting to MaxItems: 1 would make the guard UNREACHABLE in
+      // production (AWS would only ever return one zone) while this mock
+      // still returned two — the assertion exists so that cannot pass.
+      expect(mockSend.mock.calls[0]?.[0].input.MaxItems).toBeGreaterThan(1);
     });
 
     it('deletes with a COMPOSITE id and no HostedZoneName lookup', async () => {
@@ -453,6 +461,55 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
       );
 
       expect(result).toMatchObject({ Type: 'A', TTL: 300 });
+    });
+
+    it('reads back a WILDCARD record AWS reports octal-escaped (#1658)', async () => {
+      // Deleting the octal decode leaves every wildcard record reporting
+      // "drift unknown" — silently, because `undefined` is not an error.
+      mockSend.mockResolvedValueOnce({
+        ResourceRecordSets: [
+          { Name: '\\052.example.com.', Type: 'A', TTL: 300, ResourceRecords: [{ Value: '1.2.3.4' }] },
+        ],
+      });
+
+      const result = await provider.readCurrentState(
+        'Z0123456789ABCDEFGHIJ|*.example.com.|A',
+        'WildcardRecord',
+        'AWS::Route53::RecordSet'
+      );
+
+      expect(result).toMatchObject({ Name: '*.example.com.', Type: 'A', TTL: 300 });
+    });
+
+    it('does NOT ask for a single record (AWS orders on the ESCAPED form)', async () => {
+      // With MaxItems: 1 the page can skip past `\\052…` entirely, so the
+      // compare-side decode alone would not fix wildcards.
+      mockSend.mockResolvedValueOnce({ ResourceRecordSets: [] });
+
+      await provider.readCurrentState(
+        'Z0123456789ABCDEFGHIJ|*.example.com.|A',
+        'WildcardRecord',
+        'AWS::Route53::RecordSet'
+      );
+
+      expect(mockSend.mock.calls[0]?.[0].input.MaxItems).toBeGreaterThan(1);
+    });
+
+    it('does NOT collapse an escaped period into a label separator', async () => {
+      // `a\\056b.example.com.` is the SINGLE-label record `a.b`; decoding it
+      // would make it equal the different two-label `a.b.example.com`.
+      // A false match here targets the wrong record.
+      mockSend.mockResolvedValueOnce({
+        ResourceRecordSets: [{ Name: 'a\\056b.example.com.', Type: 'A', TTL: 60 }],
+      });
+
+      const result = await provider.readCurrentState(
+        'Z0123456789ABCDEFGHIJ|a.b.example.com.|A',
+        'AmbiguousRecord',
+        'AWS::Route53::RecordSet'
+      );
+
+      expect(result).toBeUndefined();
     });
 
     it('returns undefined when the id is unparsable and no properties are available', async () => {

--- a/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
+++ b/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
@@ -380,6 +380,75 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
       expect(del.input.HostedZoneId).toBe('Z0123456789ABCDEFGHIJ');
     });
 
+    it('sends the CASE-FOLDED, ENCODED name as the list START KEY (#1658)', async () => {
+      // The compare-side fold is only half the fix. AWS positions the window
+      // by the name it STORES, so a verbatim `Example.COM` start key can put
+      // an existing zone outside a bounded page -- and this arm reads an
+      // empty page as "zone is gone" and DROPS the state row. Pin the query
+      // side, not just the answer.
+      mockSend
+        .mockResolvedValueOnce({
+          HostedZones: [{ Id: '/hostedzone/Z0123456789ABCDEFGHIJ', Name: 'example.com.' }],
+        })
+        .mockResolvedValueOnce({});
+
+      await provider.delete('WebsiteRecord', 'record.example.com', 'AWS::Route53::RecordSet', {
+        ...RECORD_PROPS,
+        HostedZoneId: undefined,
+        HostedZoneName: 'Example.COM',
+      });
+
+      const list = mockSend.mock.calls[0]?.[0];
+      expect(list).toBeInstanceOf(ListHostedZonesByNameCommand);
+      expect(list.input.DNSName).toBe('example.com.');
+    });
+
+    it('does NOT treat a FAILED zone lookup as already-deleted (#1658)', async () => {
+      // The dangerous polarity of the skip-as-gone arm. A throttle / creds /
+      // network failure must never authorize dropping the state row -- if it
+      // did, a transient error would silently orphan a live record. The
+      // original error has to reach the user, too: the pre-fix message named
+      // neither the zone nor the cause.
+      const throttle = new Error('Rate exceeded');
+      throttle.name = 'Throttling';
+      mockSend.mockRejectedValueOnce(throttle);
+
+      await expect(
+        provider.delete('WebsiteRecord', 'record.example.com', 'AWS::Route53::RecordSet', {
+          ...RECORD_PROPS,
+          HostedZoneId: undefined,
+          HostedZoneName: 'example.com',
+        })
+      ).rejects.toThrow(/Rate exceeded/);
+
+      // and it must NOT have issued the delete, nor silently resolved
+      expect(
+        mockSend.mock.calls.some(
+          (c: unknown[]) => c[0] instanceof ChangeResourceRecordSetsCommand
+        )
+      ).toBe(false);
+    });
+
+    it('does NOT conclude "gone" from an EMPTY TRUNCATED page (#1658)', async () => {
+      // An empty page that AWS says is truncated proves nothing about whether
+      // the zone exists, so it must not authorize the state-row drop.
+      mockSend.mockResolvedValueOnce({ HostedZones: [], IsTruncated: true });
+
+      await expect(
+        provider.delete('WebsiteRecord', 'record.example.com', 'AWS::Route53::RecordSet', {
+          ...RECORD_PROPS,
+          HostedZoneId: undefined,
+          HostedZoneName: 'example.com',
+        })
+      ).rejects.toThrow(/HostedZoneId or HostedZoneName is required/);
+
+      expect(
+        mockSend.mock.calls.some(
+          (c: unknown[]) => c[0] instanceof ChangeResourceRecordSetsCommand
+        )
+      ).toBe(false);
+    });
+
     it('still errors when neither the id nor the properties identify a zone', async () => {
       await expect(
         provider.delete('WebsiteRecord', 'record.example.com', 'AWS::Route53::RecordSet', {

--- a/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
+++ b/tests/unit/provisioning/route53-provider-cfn-physical-id.test.ts
@@ -359,6 +359,27 @@ describe('Route53 RecordSet physicalId: CloudFormation form vs cdkd composite (i
       expect(mockSend).toHaveBeenCalledTimes(1);
     });
 
+    it('matches a zone whose template spelling differs only in CASE', async () => {
+      // DNS is case-insensitive and AWS lowercases what it returns. Without
+      // the lowercase fold this resolved to "zone is gone" and would DROP the
+      // state row while leaving the record live in AWS.
+      mockSend
+        .mockResolvedValueOnce({
+          HostedZones: [{ Id: '/hostedzone/Z0123456789ABCDEFGHIJ', Name: 'example.com.' }],
+        })
+        .mockResolvedValueOnce({});
+
+      await provider.delete('WebsiteRecord', 'record.example.com', 'AWS::Route53::RecordSet', {
+        ...RECORD_PROPS,
+        HostedZoneId: undefined,
+        HostedZoneName: 'Example.COM',
+      });
+
+      const del = mockSend.mock.calls[1]?.[0];
+      expect(del).toBeInstanceOf(ChangeResourceRecordSetsCommand);
+      expect(del.input.HostedZoneId).toBe('Z0123456789ABCDEFGHIJ');
+    });
+
     it('still errors when neither the id nor the properties identify a zone', async () => {
       await expect(
         provider.delete('WebsiteRecord', 'record.example.com', 'AWS::Route53::RecordSet', {


### PR DESCRIPTION
Closes #1658

## The bug

cdkd's physicalId for an `AWS::Route53::RecordSet` is the composite
`<hostedZoneId>|<Name>|<Type>`. CloudFormation's is the record **name alone** —
`Ref` on that type returns the domain name and never contains `|`.

`import()` stored whatever it was handed, verbatim. In auto /
`--migrate-from-cloudformation` mode `knownPhysicalId` is **not** a user choice:
the overrides map is pre-populated from the CFn stack's `DescribeStackResources`,
so **every** migrated record set landed in state with an id cdkd itself cannot
parse.

The import reported success. The failure surfaced only at destroy time —
*after* the same command had already retired the CloudFormation stack, so there
was no CFn stack left to fall back on:

```
Failed to delete WebsiteHostingDomainConfigARecord2F914E47:
  "ProvisioningError: Invalid record set physical ID format: record.example.com"
```

`readCurrentState` applied the same parse and returned `undefined`, so
`cdkd drift` silently reported nothing for those records — the one command a
user would run to notice.

## The fix

Three parts, and the second is the one that matters most for already-broken
stacks:

1. **`import()` re-canonicalizes instead of trusting.** An already-composite
   override passes through (the documented `--resource 'Id=zone|name|type'`
   form); anything else is rebuilt from the template's `HostedZoneId` /
   `HostedZoneName` + `Name` + `Type` and **verified against AWS** before
   adoption.

   When that verification cannot be completed, the id is **adopted verbatim**
   with a warning rather than returning `null`. A review round caught that the
   obvious `null` (`skipped-not-found`) answer is the more dangerous one here:
   `import.ts` aborts only when *zero* resources import, so a single skipped
   record leaves it in **neither** CloudFormation (the `--migrate-from-cloudformation`
   run has already retired the stack) **nor** cdkd state — an untracked, live
   record. Verbatim adoption keeps it tracked, and part (2) below makes that id
   destroyable.
2. **`deleteRecordSet` falls back** to resolving the zone from the recorded
   properties when the id is not composite, instead of throwing. Required
   *independently* of (1): state files written by every cdkd version to date
   already carry the bad shape, so an import-only fix leaves those stacks
   undestroyable forever.
3. **`readRecordSet` takes the same fallback**, so drift is reported for those
   records instead of being invisible.

Also fixes two latent name-matching mismatches in the same read path. AWS always
reports a record name fully qualified and **lower-cased**, while a template may
declare it either way, so the exact-string match could miss the record it had
just asked for. DNS is case-insensitive, so `normalizeRecordName` now folds case
as well as the trailing dot — and it decodes AWS's octal escapes except `\056`
/ `\134` (an escaped `.` / `\`), which are not injective under decoding and
would make two different names compare equal.

The case fold is load-bearing for part (2), not cosmetic: with the new
"hosted zone is gone, treat the delete as idempotent" arm, a template spelling
`HostedZoneName: 'Example.com'` that failed to match AWS's `example.com.` would
have concluded the zone was gone, dropped the state row, and left the record
**live in AWS** — a silent orphan. That arm therefore also logs at `warn`, since
it drops a state row and the user should see why.

## Scope decision

Kept **override-only** — an import with no override still declines. Widening it
to auto-resolution would have made the `docs/import.md` "Override-only —
sub-resources without a standalone identity" classification stale, and that file
is owned by a concurrent lane (PR https://github.com/go-to-k/cdkd/pull/1666). A unit test pins the declining
behavior so the docs stay true.


## Review round: the query side, not just the compare side

A final review pass found the case fold above was only half the fix, and the
half it left open reaches the same orphan by a different route.
`ListHostedZonesByName`'s `DNSName` is a **start key** into AWS's
reversed-label ordering, and that ordering is over the name AWS **stores** —
lower-cased and escape-encoded. Sending the template's spelling verbatim
positions the window by `Example.com` while AWS orders by `example.com.`, so
with a bounded page an **existing** zone can fall outside it, read as absent,
and take the "zone is gone" arm — dropping the state row and leaving the record
live in AWS.

So the query side gets its own canonicalizer, deliberately **not** the same
function as the compare side: `canonicalizeQueryName` moves toward AWS's
spelling (lower-case, encode `*`) where `normalizeRecordName` moves AWS's
answer toward the template's (decode escapes). Decoding on the query side would
be actively wrong — `*.example.com` sorts at `*` (0x2A) while the stored
`\052…` sorts at `\` (0x5C), so every sibling whose first label starts with
`-` / `+` / a digit / an upper-case letter falls between them.
`readRecordSet`'s `StartRecordName` had exactly that defect, so wildcard drift
was unreadable for the same reason; it takes the same helper.

The absence conclusion is gated rather than assumed: `absenceIsSound` replaces
`lookupRan` and refuses an empty **truncated** page, and any name already
carrying a backslash escape — neither can be positioned confidently, and this
arm drops a state row. A lookup that **threw** no longer falls through to the
misleading "specify one of these" error either; the cause is carried into the
message and the `cause` chain.

Three previously-unpinned polarities are now tested: the encoded start key
itself, a failing lookup **not** being read as already-deleted, and an empty
truncated page **not** being read as gone.


## 3-axis review round: four guards that were deletable

At 1107 LOC this PR is `3-axis` tier, so spec and test reviewers ran alongside
the code one. The spec pass came back clean — all four items of #1658 are
implemented, and the one deviation (verbatim adoption instead of `null`) is the
deliberate change described above. The **test** pass found the real problem:
four of this PR's own guards could be **deleted with the whole suite still
green**.

Each is now pinned, and each pin was proven by reverting the fix and watching
the named test fail — not by assuming:

| Guard | Reverted → |
|---|---|
| `StartRecordName` encoding in `readRecordSet` | 1 failure |
| `DNSName` encoding in the zone lookup | 2 failures |
| `assertRegionMatch` inside the skip-as-gone arm | 1 failure |
| truncation + backslash guard on `absenceIsSound` | 2 failures |

The first is the instructive one: the pre-existing wildcard test mocked AWS's
**answer**, so it passed with the start key un-encoded — it could never have
caught the mis-positioning the encoding exists to prevent. Only asserting the
**request** can. And no route53 test passed `context.expectedRegion` at all, so
the region check in the arm that drops a state row was entirely unprotected.

The truncated-page test was strengthened too: it asserted a message the
"no zone specified at all" path emits verbatim, so a regression that stopped
reading `HostedZoneName` would have passed it without ever reaching the
truncation logic.

Those additions are tests only, so the real-AWS integ result above still stands
for this HEAD.

## Verification

- **Unit**: 37 new tests covering both id shapes across `import()` / `delete()` /
  `readCurrentState()`, the parser, the trailing-dot match, and the
  still-declines-without-an-override contract. The whole suite is green
  (11,216 tests).
- **Live (real AWS, us-east-1)**: `route53` integ — deploy + removal-redeploy +
  destroy, **8 deleted, 0 errors, 0 orphans**, state file gone, hosted zone gone.
- **Live-test gap, stated explicitly**: that fixture drives `deploy` / `destroy`,
  not `cdkd import`, so it proves the composite path is **regression-free** but
  does not exercise the CFn-scalar branch this PR adds. That branch is covered by
  unit binding proof only. The premise behind it is verified from source
  (`createRecordSet` builds the composite; `retire-cfn-stack.ts` seeds the
  overrides from `DescribeStackResources`) rather than from a live import.



