### PR TITLE
fix(s3tables): verify a supplied physicalId before adopting it on import

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -242,7 +242,7 @@ s3-lifecycle	2026-08-11T10:53:57Z	PASS	95	verify.sh	#1595 per-item Status replay
 s3-object-lock	2026-08-10T04:16:05Z	PASS	44	verify.sh	0810 staleness sweep b1; s3-bucket-provider re-verify, 0 err, 0 orph
 s3-replication-and-filter	2026-08-11T15:11:16Z	PASS	110	verify.sh	issue #1605 versioning+logging replay downgrade; 7 del/0 err, 0 orph
 s3-subconfig-removal	2026-08-12T06:25:37Z	PASS	70	verify.sh	issue #1612 final rebase; rc ok, orph clean
-s3-tables	2026-08-12T08:40:57Z	PASS	47	verify.sh	rc ok, 5 deleted 0 errors, orph clean
+s3-tables	2026-08-12T09:24:42Z	PASS	49	verify.sh	rc ok, 5 deleted 0 errors, orph clean
 s3-vectors	2026-08-09T03:50:21Z	PASS	230	verify.sh	#1385 CMK encryption asserted; destroy 0 errors, 0 orphans
 scheduled-task	2026-07-26T18:04:53Z	PASS	44	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 scheduler-custom-group	2026-07-26T19:25:15Z	PASS	103	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -242,8 +242,6 @@ s3-lifecycle	2026-08-11T10:53:57Z	PASS	95	verify.sh	#1595 per-item Status replay
 s3-object-lock	2026-08-10T04:16:05Z	PASS	44	verify.sh	0810 staleness sweep b1; s3-bucket-provider re-verify, 0 err, 0 orph
 s3-replication-and-filter	2026-08-11T15:11:16Z	PASS	110	verify.sh	issue #1605 versioning+logging replay downgrade; 7 del/0 err, 0 orph
 s3-subconfig-removal	2026-08-12T06:25:37Z	PASS	70	verify.sh	issue #1612 final rebase; rc ok, orph clean
-s3-tables	2026-07-27T16:53:47Z	PASS	45	verify.sh	issue #1270/#1272 post-review re-run; 5 del 0 err, 0 orphans
-s3-subconfig-removal	2026-08-10T07:17:25Z	PASS	63	verify.sh	issue #1466 final; 4 removal verdicts + drift-detect; rc ok, 0 orph
 s3-tables	2026-08-12T07:15:00Z	PASS	420	verify.sh	#1668 S3Tables import verify-before-adopt; deploy + Tags backfill + destroy clean, 0 errors, 0 orphans (import path itself not covered by this fixture - see PR body)
 s3-vectors	2026-08-09T03:50:21Z	PASS	230	verify.sh	#1385 CMK encryption asserted; destroy 0 errors, 0 orphans
 scheduled-task	2026-07-26T18:04:53Z	PASS	44	standard	0727b sweep-b1 staleness re-run (rc=0); account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -242,7 +242,7 @@ s3-lifecycle	2026-08-11T10:53:57Z	PASS	95	verify.sh	#1595 per-item Status replay
 s3-object-lock	2026-08-10T04:16:05Z	PASS	44	verify.sh	0810 staleness sweep b1; s3-bucket-provider re-verify, 0 err, 0 orph
 s3-replication-and-filter	2026-08-11T15:11:16Z	PASS	110	verify.sh	issue #1605 versioning+logging replay downgrade; 7 del/0 err, 0 orph
 s3-subconfig-removal	2026-08-12T06:25:37Z	PASS	70	verify.sh	issue #1612 final rebase; rc ok, orph clean
-s3-tables	2026-08-12T07:15:00Z	PASS	420	verify.sh	#1668 S3Tables import verify-before-adopt; deploy + Tags backfill + destroy clean, 0 errors, 0 orphans (import path itself not covered by this fixture - see PR body)
+s3-tables	2026-08-12T08:40:57Z	PASS	47	verify.sh	rc ok, 5 deleted 0 errors, orph clean
 s3-vectors	2026-08-09T03:50:21Z	PASS	230	verify.sh	#1385 CMK encryption asserted; destroy 0 errors, 0 orphans
 scheduled-task	2026-07-26T18:04:53Z	PASS	44	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 scheduler-custom-group	2026-07-26T19:25:15Z	PASS	103	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -243,6 +243,8 @@ s3-object-lock	2026-08-10T04:16:05Z	PASS	44	verify.sh	0810 staleness sweep b1; s
 s3-replication-and-filter	2026-08-11T15:11:16Z	PASS	110	verify.sh	issue #1605 versioning+logging replay downgrade; 7 del/0 err, 0 orph
 s3-subconfig-removal	2026-08-12T06:25:37Z	PASS	70	verify.sh	issue #1612 final rebase; rc ok, orph clean
 s3-tables	2026-07-27T16:53:47Z	PASS	45	verify.sh	issue #1270/#1272 post-review re-run; 5 del 0 err, 0 orphans
+s3-subconfig-removal	2026-08-10T07:17:25Z	PASS	63	verify.sh	issue #1466 final; 4 removal verdicts + drift-detect; rc ok, 0 orph
+s3-tables	2026-08-12T07:15:00Z	PASS	420	verify.sh	#1668 S3Tables import verify-before-adopt; deploy + Tags backfill + destroy clean, 0 errors, 0 orphans (import path itself not covered by this fixture - see PR body)
 s3-vectors	2026-08-09T03:50:21Z	PASS	230	verify.sh	#1385 CMK encryption asserted; destroy 0 errors, 0 orphans
 scheduled-task	2026-07-26T18:04:53Z	PASS	44	standard	0727b sweep-b1 staleness re-run (rc=0); account clean
 scheduler-custom-group	2026-07-26T19:25:15Z	PASS	103	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean

--- a/src/provisioning/providers/s3-tables-provider.ts
+++ b/src/provisioning/providers/s3-tables-provider.ts
@@ -20,6 +20,7 @@ import {
 import { getLogger } from '../../utils/logger.js';
 import { CdkdError, ProvisioningError } from '../../utils/error-handler.js';
 import { assertRegionMatch, type DeleteContext } from '../region-check.js';
+import { findSilentDropProperties } from '../property-coverage.js';
 import type {
   ResourceProvider,
   ResourceCreateResult,
@@ -1013,14 +1014,56 @@ export class S3TablesProvider implements ResourceProvider {
     // When the template carries a LITERAL bucket ARN, it must agree with the
     // one the ARN resolves to. (It is usually an unresolved intrinsic here, in
     // which case there is nothing to cross-check — see the note above.)
-    const templateBucketArn = readStringProperty(input.properties, 'TableBucketARN');
-    if (templateBucketArn && templateBucketArn !== identity.tableBucketARN) {
+    // Only compare a LITERAL that looks like the same kind of value: a
+    // name-shaped `--resource` override substituted into a `{Ref}` would
+    // otherwise produce a false refusal.
+    const mismatch = (
+      [
+        [
+          'TableBucketARN',
+          readStringProperty(input.properties, 'TableBucketARN'),
+          identity.tableBucketARN,
+        ],
+        ['Namespace', readStringProperty(input.properties, 'Namespace'), identity.namespace],
+        [
+          'TableName',
+          readStringProperty(input.properties, 'TableName') ??
+            readStringProperty(input.properties, 'Name'),
+          identity.name,
+        ],
+      ] as const
+    ).find(([key, declared, resolved]) => {
+      if (!declared) return false;
+      if (key === 'TableBucketARN' && !declared.startsWith('arn:')) return false;
+      return declared !== resolved;
+    });
+    if (mismatch) {
+      const [key, declared, resolved] = mismatch;
       this.logger.warn(
-        `S3 Tables Table ${input.logicalId}: the supplied physical id '${known}' resolves to table ` +
-          `bucket '${identity.tableBucketARN}', but the template declares '${templateBucketArn}'; ` +
-          `refusing to adopt a table from a different bucket.`
+        `S3 Tables Table ${input.logicalId}: the supplied physical id '${known}' resolves to ` +
+          `${key} '${resolved}', but the template declares '${declared}'; refusing to adopt a ` +
+          `different table than the one the template describes.`
       );
       return null;
+    }
+
+    // ROUTE-AWARE physicalId. A table whose template carries a silent-drop
+    // property (`IcebergMetadata` / `Compaction` / `SnapshotManagement` /
+    // `StorageClassConfiguration` / `WithoutMetadata`) is auto-routed to Cloud
+    // Control by the #614 rule, and CC's Identifier for this type is the bare
+    // `TableARN` — not cdkd's composite. `cdkd import` records
+    // `provisionedBy: 'sdk'`, but ONLY `'cc-api'` is sticky, so the next
+    // deploy / destroy re-derives the route from the template and such a table
+    // lands on CC. Canonicalizing unconditionally would therefore hand Cloud
+    // Control `arn|ns|name` and break exactly the tables the ARN form was
+    // (accidentally) correct for before this PR.
+    const ccRouted = findSilentDropProperties('AWS::S3Tables::Table', input.properties).length > 0;
+    if (ccRouted) {
+      this.logger.debug(
+        `S3 Tables Table ${input.logicalId}: template carries a Cloud-Control-routing property, ` +
+          `recording the bare TableARN (CC's identifier) rather than cdkd's composite.`
+      );
+      return { physicalId: tableARN, attributes: { TableARN: tableARN } };
     }
 
     return {

--- a/src/provisioning/providers/s3-tables-provider.ts
+++ b/src/provisioning/providers/s3-tables-provider.ts
@@ -6,6 +6,7 @@ import {
   DeleteNamespaceCommand,
   CreateTableCommand,
   DeleteTableCommand,
+  GetNamespaceCommand,
   GetTableBucketCommand,
   GetTableCommand,
   ListNamespacesCommand,
@@ -26,6 +27,82 @@ import type {
   ResourceImportInput,
   ResourceImportResult,
 } from '../../types/resource.js';
+
+/**
+ * Parse cdkd's composite namespace physicalId `<tableBucketARN>|<namespace>`.
+ *
+ * Returns `undefined` for any other shape. Exactly two non-empty segments are
+ * required: every other method on the provider splits the stored id on `|` and
+ * indexes segments 0 and 1, so a wrong-arity id recorded verbatim produces a
+ * state row that cannot be updated, deleted or read back (issue #1668).
+ */
+export function parseNamespaceCompositeId(
+  physicalId: string
+): { tableBucketARN: string; namespace: string } | undefined {
+  const parts = physicalId.split('|');
+  if (parts.length !== 2) return undefined;
+  const [tableBucketARN, namespace] = parts as [string, string];
+  if (!tableBucketARN || !namespace) return undefined;
+  return { tableBucketARN, namespace };
+}
+
+/** Parse cdkd's composite table physicalId `<tableBucketARN>|<namespace>|<name>`. */
+export function parseTableCompositeId(
+  physicalId: string
+): { tableBucketARN: string; namespace: string; name: string } | undefined {
+  const parts = physicalId.split('|');
+  if (parts.length !== 3) return undefined;
+  const [tableBucketARN, namespace, name] = parts as [string, string, string];
+  if (!tableBucketARN || !namespace || !name) return undefined;
+  return { tableBucketARN, namespace, name };
+}
+
+/** Read a non-blank string property, tolerating a malformed properties bag. */
+function readStringProperty(
+  properties: Record<string, unknown> | undefined,
+  key: string
+): string | undefined {
+  const value = properties?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Rebuild a namespace's identity from the template.
+ *
+ * `Namespace` is emitted as a plain string by CDK 2.x's `CfnNamespace` and as
+ * a singleton array by the CFn docs / SDK shape, so accept both — the same
+ * tolerance `createNamespace` already applies.
+ */
+function namespaceIdentityFromProperties(
+  properties: Record<string, unknown> | undefined
+): { tableBucketARN: string; namespace: string } | undefined {
+  const tableBucketARN = readStringProperty(properties, 'TableBucketARN');
+  const raw = properties?.['Namespace'];
+  const namespace =
+    Array.isArray(raw) && typeof raw[0] === 'string' && raw[0].length > 0
+      ? raw[0]
+      : readStringProperty(properties, 'Namespace');
+  if (!tableBucketARN || !namespace) return undefined;
+  return { tableBucketARN, namespace };
+}
+
+/**
+ * Rebuild a table's identity from the template.
+ *
+ * The name is read as `TableName ?? Name`, mirroring `createTable` exactly —
+ * if the two disagreed, a template using the legacy spelling would import
+ * under an identity the create path would never produce.
+ */
+function tableIdentityFromProperties(
+  properties: Record<string, unknown> | undefined
+): { tableBucketARN: string; namespace: string; name: string } | undefined {
+  const tableBucketARN = readStringProperty(properties, 'TableBucketARN');
+  const namespace = readStringProperty(properties, 'Namespace');
+  const name =
+    readStringProperty(properties, 'TableName') ?? readStringProperty(properties, 'Name');
+  if (!tableBucketARN || !namespace || !name) return undefined;
+  return { tableBucketARN, namespace, name };
+}
 
 /**
  * SDK Provider for AWS S3 Tables resources
@@ -796,41 +873,126 @@ export class S3TablesProvider implements ResourceProvider {
     return null;
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await -- explicit-override-only intentionally has no AWS calls
+  /**
+   * Adopt an existing namespace (issue #1668).
+   *
+   * cdkd's physicalId is `<tableBucketARN>|<namespaceName>` and so is
+   * CloudFormation's — the registry declares a two-field
+   * `primaryIdentifier` (`/properties/TableBucketARN` + `/properties/Namespace`,
+   * verified live us-east-1 2026-08-12) and Cloud Control joins a multi-part
+   * identifier with `|`. So the two agree and no foreign form has to be
+   * accepted; what was missing is that a WRONG-ARITY id was recorded verbatim,
+   * after which every other method on this provider — which all split the
+   * stored id on `|` — failed against a state row that looked adopted.
+   *
+   * A malformed override is therefore rebuilt from the template properties and
+   * VERIFIED, and an unverifiable namespace returns `null`
+   * (`skipped-not-found`), which is loud and leaves state clean.
+   */
   private async importNamespace(input: ResourceImportInput): Promise<ResourceImportResult | null> {
-    if (input.knownPhysicalId) {
-      return { physicalId: input.knownPhysicalId, attributes: {} };
+    if (!input.knownPhysicalId) return null;
+
+    const identity =
+      parseNamespaceCompositeId(input.knownPhysicalId) ??
+      namespaceIdentityFromProperties(input.properties);
+    if (!identity) {
+      this.logger.warn(
+        `S3 Tables Namespace ${input.logicalId}: physical id '${input.knownPhysicalId}' is not '<tableBucketARN>|<namespace>' and the template does not supply TableBucketARN + Namespace; skipping import.`
+      );
+      return null;
     }
-    return null;
+
+    try {
+      await this.getClient().send(
+        new GetNamespaceCommand({
+          tableBucketARN: identity.tableBucketARN,
+          namespace: identity.namespace,
+        })
+      );
+    } catch (err) {
+      if (err instanceof NotFoundException) return null;
+      throw err;
+    }
+
+    return {
+      physicalId: `${identity.tableBucketARN}|${identity.namespace}`,
+      attributes: {},
+    };
   }
 
+  /**
+   * Adopt an existing table (issue #1668).
+   *
+   * Unlike the namespace above, the two id shapes DISAGREE here: cdkd's
+   * physicalId is `<tableBucketARN>|<namespace>|<name>` while the registry
+   * declares a SINGLE-field `primaryIdentifier` of `/properties/TableARN`
+   * (verified live us-east-1 2026-08-12), so CloudFormation's physicalId is
+   * the table ARN. An auto-mode / `--migrate-from-cloudformation` import
+   * merges CFn-derived ids into the overrides, so that ARN was landing in
+   * state verbatim and every later update / delete / read then failed to parse
+   * it — the #1651 class on a second type.
+   *
+   * The table ARN is not decomposable into its parts (see `createTable`: the
+   * real ARN format is not inferrable), so the composite is rebuilt from the
+   * TEMPLATE properties and confirmed with `GetTable`. When the override was
+   * an ARN, the ARN AWS returns must equal it — otherwise the template and
+   * the override name DIFFERENT tables and adopting either would be a guess.
+   */
   private async importTable(input: ResourceImportInput): Promise<ResourceImportResult | null> {
-    if (input.knownPhysicalId) {
-      const parts = input.knownPhysicalId.split('|');
-      if (parts.length >= 3) {
-        try {
-          await this.getClient().send(
-            new GetTableCommand({
-              tableBucketARN: parts[0],
-              namespace: parts[1],
-              name: parts[2],
-            })
-          );
-          return { physicalId: input.knownPhysicalId, attributes: {} };
-        } catch (err) {
-          if (err instanceof NotFoundException) return null;
-          throw err;
-        }
-      }
-      return { physicalId: input.knownPhysicalId, attributes: {} };
+    if (!input.knownPhysicalId) {
+      // No `aws:cdk:path` tag walk: AWS rejects `aws:`-prefixed tag writes, so
+      // that tag never exists on a real resource and the walk could not match
+      // (issue #1134). Auto-mode import resolves ids from CloudFormation's
+      // `DescribeStackResources` or the template's physical-name property; a
+      // table reaching here needs an explicit `--resource` override.
+      return null;
     }
 
-    // No `aws:cdk:path` tag walk: AWS rejects `aws:`-prefixed tag writes, so
-    // that tag never exists on a real resource and the walk could not match
-    // (issue #1134). Auto-mode import resolves ids from CloudFormation's
-    // `DescribeStackResources` or the template's physical-name property; a
-    // table reaching here needs an explicit `--resource` override.
-    return null;
+    const identity =
+      parseTableCompositeId(input.knownPhysicalId) ?? tableIdentityFromProperties(input.properties);
+    if (!identity) {
+      this.logger.warn(
+        `S3 Tables Table ${input.logicalId}: physical id '${input.knownPhysicalId}' is not '<tableBucketARN>|<namespace>|<name>' and the template does not supply TableBucketARN + Namespace + TableName; skipping import.`
+      );
+      return null;
+    }
+
+    let response;
+    try {
+      response = await this.getClient().send(
+        new GetTableCommand({
+          tableBucketARN: identity.tableBucketARN,
+          namespace: identity.namespace,
+          name: identity.name,
+        })
+      );
+    } catch (err) {
+      if (err instanceof NotFoundException) return null;
+      throw err;
+    }
+
+    // The override was CloudFormation's TableARN: confirm it names the same
+    // table the template describes before adopting, rather than assuming it.
+    // The `|`-free test is load-bearing — cdkd's own composite STARTS with the
+    // bucket ARN, so an `arn:` prefix alone would refuse every composite id.
+    if (
+      !input.knownPhysicalId.includes('|') &&
+      input.knownPhysicalId.startsWith('arn:') &&
+      response.tableARN !== undefined &&
+      response.tableARN !== input.knownPhysicalId
+    ) {
+      this.logger.warn(
+        `S3 Tables Table ${input.logicalId}: the supplied physical id '${input.knownPhysicalId}' does not match the ARN of the table the template describes ('${response.tableARN}'); skipping import.`
+      );
+      return null;
+    }
+
+    return {
+      physicalId: `${identity.tableBucketARN}|${identity.namespace}|${identity.name}`,
+      // Cache the real ARN the same way `createTable` does, so a
+      // `Fn::GetAtt: [Table, TableARN]` resolves for an imported table too.
+      attributes: response.tableARN !== undefined ? { TableARN: response.tableARN } : {},
+    };
   }
 
   private async deleteTable(

--- a/src/provisioning/providers/s3-tables-provider.ts
+++ b/src/provisioning/providers/s3-tables-provider.ts
@@ -67,41 +67,30 @@ function readStringProperty(
 }
 
 /**
- * Rebuild a namespace's identity from the template.
+ * Rebuild a table's identity from what `GetTable` returned.
  *
- * `Namespace` is emitted as a plain string by CDK 2.x's `CfnNamespace` and as
- * a singleton array by the CFn docs / SDK shape, so accept both — the same
- * tolerance `createNamespace` already applies.
- */
-function namespaceIdentityFromProperties(
-  properties: Record<string, unknown> | undefined
-): { tableBucketARN: string; namespace: string } | undefined {
-  const tableBucketARN = readStringProperty(properties, 'TableBucketARN');
-  const raw = properties?.['Namespace'];
-  const namespace =
-    Array.isArray(raw) && typeof raw[0] === 'string' && raw[0].length > 0
-      ? raw[0]
-      : readStringProperty(properties, 'Namespace');
-  if (!tableBucketARN || !namespace) return undefined;
-  return { tableBucketARN, namespace };
-}
-
-/**
- * Rebuild a table's identity from the template.
+ * Deliberately NOT from the template: a CDK-synthesized `TableBucketARN` is an
+ * `Fn::GetAtt` object at import time (full intrinsic resolution runs after
+ * `provider.import()`), so a template-side read is `undefined` on exactly the
+ * `--migrate-from-cloudformation` path this exists to serve.
  *
- * The name is read as `TableName ?? Name`, mirroring `createTable` exactly —
- * if the two disagreed, a template using the legacy spelling would import
- * under an identity the create path would never produce.
+ * The bucket ARN is the table ARN's prefix — S3 Tables ARNs are
+ * `arn:<p>:s3tables:<region>:<acct>:bucket/<bucket>` and
+ * `…:bucket/<bucket>/table/<id>` — so it is recovered by trimming at the last
+ * `/table/` segment. `namespace` comes back as a single-element list.
  */
-function tableIdentityFromProperties(
-  properties: Record<string, unknown> | undefined
+function tableIdentityFromGetTable(
+  tableARN: string,
+  namespace: string[] | undefined,
+  name: string | undefined
 ): { tableBucketARN: string; namespace: string; name: string } | undefined {
-  const tableBucketARN = readStringProperty(properties, 'TableBucketARN');
-  const namespace = readStringProperty(properties, 'Namespace');
-  const name =
-    readStringProperty(properties, 'TableName') ?? readStringProperty(properties, 'Name');
-  if (!tableBucketARN || !namespace || !name) return undefined;
-  return { tableBucketARN, namespace, name };
+  const marker = '/table/';
+  const cut = tableARN.lastIndexOf(marker);
+  if (cut <= 0) return undefined;
+  const tableBucketARN = tableARN.slice(0, cut);
+  const ns = namespace?.[0];
+  if (!tableBucketARN || !ns || !name) return undefined;
+  return { tableBucketARN, namespace: ns, name };
 }
 
 /**
@@ -885,19 +874,26 @@ export class S3TablesProvider implements ResourceProvider {
    * after which every other method on this provider — which all split the
    * stored id on `|` — failed against a state row that looked adopted.
    *
-   * A malformed override is therefore rebuilt from the template properties and
-   * VERIFIED, and an unverifiable namespace returns `null`
-   * (`skipped-not-found`), which is loud and leaves state clean.
+   * A wrong-arity override is REFUSED rather than silently replaced with the
+   * template's identity: `knownPhysicalId` is documented as ground truth
+   * (`ResourceImportInput`), so quietly adopting a different resource than the
+   * one the user named would be worse than declining. An unverifiable
+   * namespace returns `null` (`skipped-not-found`), which is loud and leaves
+   * state clean.
+   *
+   * NOTE this now issues an AWS call where it previously made none, so
+   * `s3tables:GetNamespace` is newly required, and a path that could not fail
+   * before can now report `failed` on a non-`NotFound` error (throttle, IAM).
    */
   private async importNamespace(input: ResourceImportInput): Promise<ResourceImportResult | null> {
     if (!input.knownPhysicalId) return null;
 
-    const identity =
-      parseNamespaceCompositeId(input.knownPhysicalId) ??
-      namespaceIdentityFromProperties(input.properties);
+    const identity = parseNamespaceCompositeId(input.knownPhysicalId);
     if (!identity) {
       this.logger.warn(
-        `S3 Tables Namespace ${input.logicalId}: physical id '${input.knownPhysicalId}' is not '<tableBucketARN>|<namespace>' and the template does not supply TableBucketARN + Namespace; skipping import.`
+        `S3 Tables Namespace ${input.logicalId}: physical id '${input.knownPhysicalId}' is not ` +
+          `'<tableBucketARN>|<namespace>'. CloudFormation uses the same two-field composite for ` +
+          `this type, so this id names no namespace cdkd can verify; skipping import.`
       );
       return null;
     }
@@ -932,14 +928,26 @@ export class S3TablesProvider implements ResourceProvider {
    * state verbatim and every later update / delete / read then failed to parse
    * it — the #1651 class on a second type.
    *
-   * The table ARN is not decomposable into its parts (see `createTable`: the
-   * real ARN format is not inferrable), so the composite is rebuilt from the
-   * TEMPLATE properties and confirmed with `GetTable`. When the override was
-   * an ARN, the ARN AWS returns must equal it — otherwise the template and
-   * the override name DIFFERENT tables and adopting either would be a guess.
+   * **The identity is resolved from AWS, not from the template.** An earlier
+   * draft rebuilt the composite out of `Properties.TableBucketARN` /
+   * `Namespace` / `TableName`, and that is INERT for the case this exists to
+   * fix: in a CDK-synthesized template `TableBucketARN` is
+   * `{"Fn::GetAtt": ["TableBucket", "TableBucketARN"]}`, `import.ts`
+   * pre-substitutes only single-key `{Ref}` before calling a provider, and
+   * full intrinsic resolution runs AFTER every `provider.import()`. So the
+   * template read yielded `undefined` on exactly the
+   * `--migrate-from-cloudformation` path that supplies the bare ARN, turning a
+   * corrupt adoption into a non-adoption instead of canonicalizing it.
+   *
+   * `GetTable` accepts `tableArn` directly and returns `name` + `namespace`,
+   * so the ARN resolves its own identity with no template involvement. The
+   * bucket ARN is the table ARN's prefix (`<bucketArn>/table/<id>`); when the
+   * template DOES carry a literal `TableBucketARN` it is cross-checked, and a
+   * disagreement is refused rather than guessed at.
    */
   private async importTable(input: ResourceImportInput): Promise<ResourceImportResult | null> {
-    if (!input.knownPhysicalId) {
+    const known = input.knownPhysicalId;
+    if (!known) {
       // No `aws:cdk:path` tag walk: AWS rejects `aws:`-prefixed tag writes, so
       // that tag never exists on a real resource and the walk could not match
       // (issue #1134). Auto-mode import resolves ids from CloudFormation's
@@ -948,41 +956,69 @@ export class S3TablesProvider implements ResourceProvider {
       return null;
     }
 
-    const identity =
-      parseTableCompositeId(input.knownPhysicalId) ?? tableIdentityFromProperties(input.properties);
-    if (!identity) {
+    const composite = parseTableCompositeId(known);
+    const request = composite
+      ? {
+          tableBucketARN: composite.tableBucketARN,
+          namespace: composite.namespace,
+          name: composite.name,
+        }
+      : // The `|`-free test is load-bearing: cdkd's own composite STARTS with
+        // the bucket ARN, so an `arn:` prefix alone would route a MALFORMED
+        // composite (`<bucketArn>|ns`) into the by-ARN lookup and adopt the
+        // wrong thing. A real table ARN never contains `|`.
+        !known.includes('|') && known.startsWith('arn:')
+        ? { tableArn: known }
+        : undefined;
+
+    if (!request) {
       this.logger.warn(
-        `S3 Tables Table ${input.logicalId}: physical id '${input.knownPhysicalId}' is not '<tableBucketARN>|<namespace>|<name>' and the template does not supply TableBucketARN + Namespace + TableName; skipping import.`
+        `S3 Tables Table ${input.logicalId}: physical id '${known}' is neither cdkd's ` +
+          `'<tableBucketARN>|<namespace>|<name>' composite nor a table ARN (CloudFormation's ` +
+          `physicalId for this type), so it names no table cdkd can verify; skipping import.`
       );
       return null;
     }
 
     let response;
     try {
-      response = await this.getClient().send(
-        new GetTableCommand({
-          tableBucketARN: identity.tableBucketARN,
-          namespace: identity.namespace,
-          name: identity.name,
-        })
-      );
+      response = await this.getClient().send(new GetTableCommand(request));
     } catch (err) {
       if (err instanceof NotFoundException) return null;
       throw err;
     }
 
-    // The override was CloudFormation's TableARN: confirm it names the same
-    // table the template describes before adopting, rather than assuming it.
-    // The `|`-free test is load-bearing — cdkd's own composite STARTS with the
-    // bucket ARN, so an `arn:` prefix alone would refuse every composite id.
-    if (
-      !input.knownPhysicalId.includes('|') &&
-      input.knownPhysicalId.startsWith('arn:') &&
-      response.tableARN !== undefined &&
-      response.tableARN !== input.knownPhysicalId
-    ) {
+    // Treat a response without an ARN as UNVERIFIABLE rather than adopting it:
+    // `createTable` hard-errors on exactly this condition, and the ARN is what
+    // the bucket-ARN derivation and the attribute cache both depend on.
+    const tableARN = response.tableARN;
+    if (!tableARN) {
       this.logger.warn(
-        `S3 Tables Table ${input.logicalId}: the supplied physical id '${input.knownPhysicalId}' does not match the ARN of the table the template describes ('${response.tableARN}'); skipping import.`
+        `S3 Tables Table ${input.logicalId}: GetTable returned no tableARN for '${known}', ` +
+          `so the table's identity cannot be confirmed; skipping import.`
+      );
+      return null;
+    }
+
+    const identity =
+      composite ?? tableIdentityFromGetTable(tableARN, response.namespace, response.name);
+    if (!identity) {
+      this.logger.warn(
+        `S3 Tables Table ${input.logicalId}: GetTable('${known}') did not return a usable ` +
+          `namespace / name / bucket-ARN prefix; skipping import.`
+      );
+      return null;
+    }
+
+    // When the template carries a LITERAL bucket ARN, it must agree with the
+    // one the ARN resolves to. (It is usually an unresolved intrinsic here, in
+    // which case there is nothing to cross-check — see the note above.)
+    const templateBucketArn = readStringProperty(input.properties, 'TableBucketARN');
+    if (templateBucketArn && templateBucketArn !== identity.tableBucketARN) {
+      this.logger.warn(
+        `S3 Tables Table ${input.logicalId}: the supplied physical id '${known}' resolves to table ` +
+          `bucket '${identity.tableBucketARN}', but the template declares '${templateBucketArn}'; ` +
+          `refusing to adopt a table from a different bucket.`
       );
       return null;
     }
@@ -991,7 +1027,7 @@ export class S3TablesProvider implements ResourceProvider {
       physicalId: `${identity.tableBucketARN}|${identity.namespace}|${identity.name}`,
       // Cache the real ARN the same way `createTable` does, so a
       // `Fn::GetAtt: [Table, TableARN]` resolves for an imported table too.
-      attributes: response.tableARN !== undefined ? { TableARN: response.tableARN } : {},
+      attributes: { TableARN: tableARN },
     };
   }
 

--- a/src/provisioning/providers/s3-tables-provider.ts
+++ b/src/provisioning/providers/s3-tables-provider.ts
@@ -808,7 +808,20 @@ export class S3TablesProvider implements ResourceProvider {
   private async readTableCurrentState(
     physicalId: string
   ): Promise<Record<string, unknown> | undefined> {
-    const resolved = await this.resolveTableParts(physicalId);
+    // `cdkd drift` has no per-resource try/catch, so a throttle or an
+    // AccessDenied on ONE bare-ARN row would abort the whole stack's drift
+    // run. Report drift-unknown for this resource instead — the same answer
+    // the two sentinel resolutions below already produce.
+    let resolved: TablePartsResolution;
+    try {
+      resolved = await this.resolveTableParts(physicalId);
+    } catch (err) {
+      this.logger.warn(
+        `S3 Tables Table ${physicalId}: could not resolve its identity for drift ` +
+          `(${err instanceof Error ? err.message : String(err)}); reporting drift as unknown.`
+      );
+      return undefined;
+    }
     if (resolved === 'not-found' || resolved === 'unparseable') return undefined;
     const { tableBucketARN, namespace, name } = resolved;
 
@@ -1092,7 +1105,19 @@ export class S3TablesProvider implements ResourceProvider {
     ).find(([key, declared, resolved]) => {
       if (!declared) return false;
       if (key === 'TableBucketARN' && !declared.startsWith('arn:')) return false;
-      return declared !== resolved;
+      // A `{Ref}` to a SIBLING resource is substituted with that resource's
+      // PHYSICAL ID before `import()` runs, and for `AWS::S3Tables::Namespace`
+      // that id is the 2-field composite `<bucketArn>|<namespace>` — the very
+      // shape this PR documents. So the canonical CDK spelling
+      // (`namespace: ns.ref`) declares `arn:...|analytics` where the resolved
+      // field is `analytics`, and comparing them raw REFUSES the adoption on
+      // exactly the migration path this fix targets. Compare the field, not
+      // the id that carries it: neither a namespace nor a table name may
+      // contain `|`, so the last segment is unambiguous.
+      const declaredField = declared.includes('|')
+        ? (declared.split('|').pop() ?? declared)
+        : declared;
+      return declaredField !== resolved;
     });
     if (mismatch) {
       const [key, declared, resolved] = mismatch;

--- a/src/provisioning/providers/s3-tables-provider.ts
+++ b/src/provisioning/providers/s3-tables-provider.ts
@@ -47,6 +47,18 @@ export function parseNamespaceCompositeId(
   return { tableBucketARN, namespace };
 }
 
+/**
+ * What `resolveTableParts` could make of a stored physicalId.
+ *
+ * `'not-found'` and `'unparseable'` are deliberately DISTINCT: the first is a
+ * valid id whose table is gone (delete must no-op), the second is an id cdkd
+ * cannot interpret (delete must fail loudly).
+ */
+type TablePartsResolution =
+  | { tableBucketARN: string; namespace: string; name: string }
+  | 'not-found'
+  | 'unparseable';
+
 /** Parse cdkd's composite table physicalId `<tableBucketARN>|<namespace>|<name>`. */
 export function parseTableCompositeId(
   physicalId: string
@@ -766,9 +778,7 @@ export class S3TablesProvider implements ResourceProvider {
    * imprecision-proof: whichever shape is stored, every SDK path works.
    * `GetTable` accepts `tableArn` and returns the parts.
    */
-  private async resolveTableParts(
-    physicalId: string
-  ): Promise<{ tableBucketARN: string; namespace: string; name: string } | undefined> {
+  private async resolveTableParts(physicalId: string): Promise<TablePartsResolution> {
     const composite = parseTableCompositeId(physicalId);
     if (composite) return composite;
     // Legacy rows may carry MORE than 3 segments; keep accepting them.
@@ -777,14 +787,20 @@ export class S3TablesProvider implements ResourceProvider {
       const [tableBucketARN, namespace, name] = parts;
       if (tableBucketARN && namespace && name) return { tableBucketARN, namespace, name };
     }
-    if (physicalId.includes('|') || !physicalId.startsWith('arn:')) return undefined;
+    if (physicalId.includes('|') || !physicalId.startsWith('arn:')) return 'unparseable';
 
     try {
       const resp = await this.getClient().send(new GetTableCommand({ tableArn: physicalId }));
-      if (!resp.tableARN) return undefined;
-      return tableIdentityFromGetTable(resp.tableARN, resp.namespace, resp.name);
+      if (!resp.tableARN) return 'unparseable';
+      return tableIdentityFromGetTable(resp.tableARN, resp.namespace, resp.name) ?? 'unparseable';
     } catch (err) {
-      if (err instanceof NotFoundException) return undefined;
+      // 'not-found' is NOT the same answer as 'unparseable'. Collapsing them
+      // makes a delete of an already-gone ARN row report
+      // "Invalid physical ID format" for a perfectly valid id — which fails
+      // the destroy and leaves the stack un-destroyable, the same shape of
+      // breakage this PR exists to fix. Recovery paths must tolerate a stale
+      // read.
+      if (err instanceof NotFoundException) return 'not-found';
       throw err;
     }
   }
@@ -793,7 +809,7 @@ export class S3TablesProvider implements ResourceProvider {
     physicalId: string
   ): Promise<Record<string, unknown> | undefined> {
     const resolved = await this.resolveTableParts(physicalId);
-    if (!resolved) return undefined;
+    if (resolved === 'not-found' || resolved === 'unparseable') return undefined;
     const { tableBucketARN, namespace, name } = resolved;
 
     let resp;
@@ -1126,8 +1142,28 @@ export class S3TablesProvider implements ResourceProvider {
     // Accepts cdkd's composite AND CloudFormation's bare TableARN — see
     // `resolveTableParts`. Rejecting the ARN here is what made a migrated
     // stack undestroyable (issue #1668).
-    const resolved = await this.resolveTableParts(physicalId);
-    if (!resolved) {
+    let resolved: TablePartsResolution;
+    try {
+      resolved = await this.resolveTableParts(physicalId);
+    } catch (error) {
+      const cause = error instanceof Error ? error : undefined;
+      throw new ProvisioningError(
+        `Failed to resolve S3 Tables Table ${logicalId} (${physicalId}): ${error instanceof Error ? error.message : String(error)}`,
+        resourceType,
+        logicalId,
+        physicalId,
+        cause
+      );
+    }
+    if (resolved === 'not-found') {
+      // Already gone — delete is idempotent, same as the DeleteTable
+      // NotFoundException arm below.
+      const clientRegion = await this.getClient().config.region();
+      assertRegionMatch(clientRegion, context?.expectedRegion, resourceType, logicalId, physicalId);
+      this.logger.debug(`S3 Tables Table ${physicalId} does not exist, skipping deletion`);
+      return;
+    }
+    if (resolved === 'unparseable') {
       throw new ProvisioningError(
         `Invalid physical ID format for S3 Tables Table ${logicalId}: ${physicalId} ` +
           `(expected '<tableBucketARN>|<namespace>|<name>' or a table ARN)`,
@@ -1308,7 +1344,16 @@ export class S3TablesProvider implements ResourceProvider {
     // Accepts cdkd's composite AND CloudFormation's bare TableARN, like the
     // delete / read paths — an imported row can carry either.
     const resolvedParts = await this.resolveTableParts(physicalId);
-    if (!resolvedParts) {
+    if (resolvedParts === 'not-found') {
+      throw new ProvisioningError(
+        `applyTableTagsDiff: table '${physicalId}' no longer exists (state is out of sync) — ` +
+          `refusing to silently drop the tag update`,
+        resourceType,
+        logicalId,
+        physicalId
+      );
+    }
+    if (resolvedParts === 'unparseable') {
       throw new ProvisioningError(
         `applyTableTagsDiff: cannot derive table ARN from physicalId '${physicalId}' ` +
           `(expected '<bucketArn>|<namespace>|<name>' or a table ARN) — refusing to silently ` +

--- a/src/provisioning/providers/s3-tables-provider.ts
+++ b/src/provisioning/providers/s3-tables-provider.ts
@@ -747,13 +747,54 @@ export class S3TablesProvider implements ResourceProvider {
     };
   }
 
+  /**
+   * Recover a table's `(bucketARN, namespace, name)` from EITHER id shape.
+   *
+   * cdkd's composite carries all three. CloudFormation's physicalId for this
+   * type is the bare `TableARN` (single-field `primaryIdentifier`), and that
+   * form reaches the SDK path in two ways worth tolerating rather than
+   * rejecting:
+   *
+   * - every state row written by `cdkd import` before issue #1668, which
+   *   stored the CFn id verbatim; and
+   * - a CC-ROUTED table imported by this version, which deliberately records
+   *   the ARN because Cloud Control's Identifier is the ARN — while
+   *   `destroy` / `drift` route on `provisionedBy` ALONE (no properties), and
+   *   `cdkd import` records `'sdk'`, so those paths land HERE with an ARN.
+   *
+   * Tolerating both is what makes the route-detection at import time
+   * imprecision-proof: whichever shape is stored, every SDK path works.
+   * `GetTable` accepts `tableArn` and returns the parts.
+   */
+  private async resolveTableParts(
+    physicalId: string
+  ): Promise<{ tableBucketARN: string; namespace: string; name: string } | undefined> {
+    const composite = parseTableCompositeId(physicalId);
+    if (composite) return composite;
+    // Legacy rows may carry MORE than 3 segments; keep accepting them.
+    const parts = physicalId.split('|');
+    if (parts.length > 3) {
+      const [tableBucketARN, namespace, name] = parts;
+      if (tableBucketARN && namespace && name) return { tableBucketARN, namespace, name };
+    }
+    if (physicalId.includes('|') || !physicalId.startsWith('arn:')) return undefined;
+
+    try {
+      const resp = await this.getClient().send(new GetTableCommand({ tableArn: physicalId }));
+      if (!resp.tableARN) return undefined;
+      return tableIdentityFromGetTable(resp.tableARN, resp.namespace, resp.name);
+    } catch (err) {
+      if (err instanceof NotFoundException) return undefined;
+      throw err;
+    }
+  }
+
   private async readTableCurrentState(
     physicalId: string
   ): Promise<Record<string, unknown> | undefined> {
-    const parts = physicalId.split('|');
-    if (parts.length < 3) return undefined;
-    const [tableBucketARN, namespace, name] = parts;
-    if (!tableBucketARN || !namespace || !name) return undefined;
+    const resolved = await this.resolveTableParts(physicalId);
+    if (!resolved) return undefined;
+    const { tableBucketARN, namespace, name } = resolved;
 
     let resp;
     try {
@@ -1082,19 +1123,21 @@ export class S3TablesProvider implements ResourceProvider {
   ): Promise<void> {
     this.logger.debug(`Deleting S3 Tables Table ${logicalId}: ${physicalId}`);
 
-    const parts = physicalId.split('|');
-    if (parts.length < 3) {
+    // Accepts cdkd's composite AND CloudFormation's bare TableARN — see
+    // `resolveTableParts`. Rejecting the ARN here is what made a migrated
+    // stack undestroyable (issue #1668).
+    const resolved = await this.resolveTableParts(physicalId);
+    if (!resolved) {
       throw new ProvisioningError(
-        `Invalid physical ID format for S3 Tables Table ${logicalId}: ${physicalId}`,
+        `Invalid physical ID format for S3 Tables Table ${logicalId}: ${physicalId} ` +
+          `(expected '<tableBucketARN>|<namespace>|<name>' or a table ARN)`,
         resourceType,
         logicalId,
         physicalId
       );
     }
 
-    const tableBucketARN = parts[0];
-    const namespace = parts[1];
-    const name = parts[2];
+    const { tableBucketARN, namespace, name } = resolved;
 
     try {
       await this.getClient().send(
@@ -1262,24 +1305,20 @@ export class S3TablesProvider implements ResourceProvider {
     // No tag delta → no work, no error.
     if (removedKeys.length === 0 && Object.keys(upserts).length === 0) return;
 
-    const parts = physicalId.split('|');
-    if (parts.length < 3) {
+    // Accepts cdkd's composite AND CloudFormation's bare TableARN, like the
+    // delete / read paths — an imported row can carry either.
+    const resolvedParts = await this.resolveTableParts(physicalId);
+    if (!resolvedParts) {
       throw new ProvisioningError(
-        `applyTableTagsDiff: cannot derive table ARN from physicalId '${physicalId}' (expected '<bucketArn>|<namespace>|<name>') — refusing to silently drop the tag update`,
+        `applyTableTagsDiff: cannot derive table ARN from physicalId '${physicalId}' ` +
+          `(expected '<bucketArn>|<namespace>|<name>' or a table ARN) — refusing to silently ` +
+          `drop the tag update`,
         resourceType,
         logicalId,
         physicalId
       );
     }
-    const [tableBucketARN, namespace, name] = parts;
-    if (!tableBucketARN || !namespace || !name) {
-      throw new ProvisioningError(
-        `applyTableTagsDiff: cannot derive table ARN from malformed physicalId '${physicalId}' (empty part after split) — refusing to silently drop the tag update`,
-        resourceType,
-        logicalId,
-        physicalId
-      );
-    }
+    const { tableBucketARN, namespace, name } = resolvedParts;
 
     // Tag APIs need the REAL table ARN (not cdkd's compound physical id
     // and not a guessed derivation from the parts — AWS rejects every

--- a/tests/unit/provisioning/s3-tables-provider-import-verify.test.ts
+++ b/tests/unit/provisioning/s3-tables-provider-import-verify.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import {
+  DeleteTableCommand,
   GetNamespaceCommand,
   GetTableCommand,
   NotFoundException,
@@ -145,6 +146,53 @@ describe('S3Tables import: verify the composite before adopting (issue #1668)', 
     });
   });
 
+  // The route detection at import time is deliberately imprecise (the
+  // allow-set, unresolved `Fn::If` keys and coverage-table drift can all make
+  // it disagree with the deploy-time router). That is SAFE only because every
+  // SDK path accepts BOTH id shapes — these tests pin that tolerance, without
+  // which a CC-routed row would make `cdkd destroy` fail and orphan the table.
+  describe('SDK paths accept CloudFormation\'s bare TableARN', () => {
+    it('deletes a table recorded as a bare ARN', async () => {
+      mockSend
+        .mockResolvedValueOnce({ tableARN: TABLE_ARN, namespace: ['ns'], name: 'tbl' })
+        .mockResolvedValueOnce({});
+
+      await provider.delete('MyTable', TABLE_ARN, 'AWS::S3Tables::Table', {});
+
+      const del = mockSend.mock.calls[1]?.[0];
+      expect(del).toBeInstanceOf(DeleteTableCommand);
+      expect(del.input).toMatchObject({
+        tableBucketARN: BUCKET_ARN,
+        namespace: 'ns',
+        name: 'tbl',
+      });
+    });
+
+    it('reads drift for a table recorded as a bare ARN', async () => {
+      mockSend
+        .mockResolvedValueOnce({ tableARN: TABLE_ARN, namespace: ['ns'], name: 'tbl' })
+        .mockResolvedValueOnce({ tableARN: TABLE_ARN, name: 'tbl', namespace: ['ns'] })
+        .mockResolvedValueOnce({ tags: {} });
+
+      const result = await provider.readCurrentState(
+        TABLE_ARN,
+        'MyTable',
+        'AWS::S3Tables::Table'
+      );
+
+      expect(result).toBeDefined();
+    });
+
+    it('still deletes a table recorded as the composite (no extra lookup)', async () => {
+      mockSend.mockResolvedValueOnce({});
+
+      await provider.delete('MyTable', `${BUCKET_ARN}|ns|tbl`, 'AWS::S3Tables::Table', {});
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(mockSend.mock.calls[0]?.[0]).toBeInstanceOf(DeleteTableCommand);
+    });
+  });
+
   describe('AWS::S3Tables::Table', () => {
     const input = {
       logicalId: 'MyTable',
@@ -278,6 +326,18 @@ describe('S3Tables import: verify the composite before adopting (issue #1668)', 
       await expect(
         provider.import({ ...input, knownPhysicalId: TABLE_ARN })
       ).rejects.toThrow(/AccessDenied/);
+    });
+
+    it('refuses when the ARN resolves to a different NAMESPACE than the template', async () => {
+      mockSend.mockResolvedValueOnce({
+        tableARN: TABLE_ARN,
+        namespace: ['a-different-namespace'],
+        name: 'tbl',
+      });
+
+      const result = await provider.import({ ...input, knownPhysicalId: TABLE_ARN });
+
+      expect(result).toBeNull();
     });
 
     it('refuses an override that is neither a composite nor an ARN', async () => {

--- a/tests/unit/provisioning/s3-tables-provider-import-verify.test.ts
+++ b/tests/unit/provisioning/s3-tables-provider-import-verify.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import {
+  GetNamespaceCommand,
+  GetTableCommand,
+  NotFoundException,
+} from '@aws-sdk/client-s3tables';
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-s3tables', async () => {
+  const actual = await vi.importActual<typeof import('@aws-sdk/client-s3tables')>(
+    '@aws-sdk/client-s3tables'
+  );
+  class MockS3TablesClient {
+    config = { region: () => Promise.resolve('us-east-1') };
+    send = mockSend;
+  }
+  return { ...actual, S3TablesClient: MockS3TablesClient };
+});
+
+vi.mock('../../../src/utils/logger.js', () => {
+  const childLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    getLogger: () => ({
+      child: () => childLogger,
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import {
+  S3TablesProvider,
+  parseNamespaceCompositeId,
+  parseTableCompositeId,
+} from '../../../src/provisioning/providers/s3-tables-provider.js';
+
+const BUCKET_ARN = 'arn:aws:s3tables:us-east-1:111122223333:bucket/my-bucket';
+const TABLE_ARN = `${BUCKET_ARN}/table/abc-123`;
+
+function notFound(): NotFoundException {
+  return new NotFoundException({ message: 'not found', $metadata: {} });
+}
+
+describe('S3Tables import: verify the composite before adopting (issue #1668)', () => {
+  let provider: S3TablesProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new S3TablesProvider();
+  });
+
+  describe('composite id parsers', () => {
+    it('accepts the exact arity and rejects everything else', () => {
+      expect(parseNamespaceCompositeId(`${BUCKET_ARN}|ns`)).toEqual({
+        tableBucketARN: BUCKET_ARN,
+        namespace: 'ns',
+      });
+      expect(parseNamespaceCompositeId(BUCKET_ARN)).toBeUndefined();
+      expect(parseNamespaceCompositeId(`${BUCKET_ARN}|ns|extra`)).toBeUndefined();
+      expect(parseNamespaceCompositeId(`${BUCKET_ARN}|`)).toBeUndefined();
+
+      expect(parseTableCompositeId(`${BUCKET_ARN}|ns|tbl`)).toEqual({
+        tableBucketARN: BUCKET_ARN,
+        namespace: 'ns',
+        name: 'tbl',
+      });
+      expect(parseTableCompositeId(`${BUCKET_ARN}|ns`)).toBeUndefined();
+      expect(parseTableCompositeId(TABLE_ARN)).toBeUndefined();
+    });
+  });
+
+  describe('AWS::S3Tables::Namespace', () => {
+    const input = {
+      logicalId: 'MyNamespace',
+      resourceType: 'AWS::S3Tables::Namespace',
+      stackName: 'MyStack',
+      region: 'us-east-1',
+      properties: { TableBucketARN: BUCKET_ARN, Namespace: 'ns' },
+    };
+
+    it('verifies a well-formed composite against AWS before adopting', async () => {
+      mockSend.mockResolvedValueOnce({ namespace: ['ns'] });
+
+      const result = await provider.import({
+        ...input,
+        knownPhysicalId: `${BUCKET_ARN}|ns`,
+      });
+
+      expect(result).toEqual({ physicalId: `${BUCKET_ARN}|ns`, attributes: {} });
+      const call = mockSend.mock.calls[0]?.[0];
+      expect(call).toBeInstanceOf(GetNamespaceCommand);
+      expect(call.input).toMatchObject({ tableBucketARN: BUCKET_ARN, namespace: 'ns' });
+    });
+
+    it('rebuilds a wrong-arity override from the template instead of recording it verbatim', async () => {
+      mockSend.mockResolvedValueOnce({ namespace: ['ns'] });
+
+      // Pre-#1668 this bare id landed in state and broke every later op.
+      const result = await provider.import({ ...input, knownPhysicalId: 'ns' });
+
+      expect(result).toEqual({ physicalId: `${BUCKET_ARN}|ns`, attributes: {} });
+    });
+
+    it('accepts the CDK singleton-array Namespace shape', async () => {
+      mockSend.mockResolvedValueOnce({ namespace: ['ns'] });
+
+      const result = await provider.import({
+        ...input,
+        properties: { TableBucketARN: BUCKET_ARN, Namespace: ['ns'] },
+        knownPhysicalId: 'ns',
+      });
+
+      expect(result).toEqual({ physicalId: `${BUCKET_ARN}|ns`, attributes: {} });
+    });
+
+    it('returns null when the namespace does not exist', async () => {
+      mockSend.mockRejectedValueOnce(notFound());
+
+      const result = await provider.import({
+        ...input,
+        knownPhysicalId: `${BUCKET_ARN}|ns`,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when neither the id nor the template identifies a namespace', async () => {
+      const result = await provider.import({
+        ...input,
+        properties: {},
+        knownPhysicalId: 'ns',
+      });
+
+      expect(result).toBeNull();
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('declines with no override (override-only)', async () => {
+      const result = await provider.import(input);
+      expect(result).toBeNull();
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('AWS::S3Tables::Table', () => {
+    const input = {
+      logicalId: 'MyTable',
+      resourceType: 'AWS::S3Tables::Table',
+      stackName: 'MyStack',
+      region: 'us-east-1',
+      properties: { TableBucketARN: BUCKET_ARN, Namespace: 'ns', TableName: 'tbl' },
+    };
+
+    it("canonicalizes CloudFormation's TableARN physicalId into cdkd's composite", async () => {
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN });
+
+      // The registry declares a single-field primaryIdentifier of TableARN,
+      // so this is what --migrate-from-cloudformation supplies.
+      const result = await provider.import({ ...input, knownPhysicalId: TABLE_ARN });
+
+      expect(result).toEqual({
+        physicalId: `${BUCKET_ARN}|ns|tbl`,
+        attributes: { TableARN: TABLE_ARN },
+      });
+      const call = mockSend.mock.calls[0]?.[0];
+      expect(call).toBeInstanceOf(GetTableCommand);
+      expect(call.input).toMatchObject({
+        tableBucketARN: BUCKET_ARN,
+        namespace: 'ns',
+        name: 'tbl',
+      });
+    });
+
+    it('refuses when the supplied ARN names a different table than the template', async () => {
+      mockSend.mockResolvedValueOnce({ tableARN: `${BUCKET_ARN}/table/other-999` });
+
+      const result = await provider.import({ ...input, knownPhysicalId: TABLE_ARN });
+
+      expect(result).toBeNull();
+    });
+
+    it('verifies and adopts a well-formed composite, caching the real ARN', async () => {
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN });
+
+      const result = await provider.import({
+        ...input,
+        knownPhysicalId: `${BUCKET_ARN}|ns|tbl`,
+      });
+
+      expect(result).toEqual({
+        physicalId: `${BUCKET_ARN}|ns|tbl`,
+        attributes: { TableARN: TABLE_ARN },
+      });
+    });
+
+    it('rebuilds a wrong-arity override from the template instead of recording it verbatim', async () => {
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN });
+
+      // Pre-#1668 a 2-segment id fell through to verbatim adoption.
+      const result = await provider.import({
+        ...input,
+        knownPhysicalId: `${BUCKET_ARN}|ns`,
+      });
+
+      expect(result).toEqual({
+        physicalId: `${BUCKET_ARN}|ns|tbl`,
+        attributes: { TableARN: TABLE_ARN },
+      });
+    });
+
+    it("mirrors createTable's TableName ?? Name fallback", async () => {
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN });
+
+      const result = await provider.import({
+        ...input,
+        properties: { TableBucketARN: BUCKET_ARN, Namespace: 'ns', Name: 'tbl' },
+        knownPhysicalId: TABLE_ARN,
+      });
+
+      expect(result).toMatchObject({ physicalId: `${BUCKET_ARN}|ns|tbl` });
+    });
+
+    it('returns null when the table does not exist', async () => {
+      mockSend.mockRejectedValueOnce(notFound());
+
+      const result = await provider.import({ ...input, knownPhysicalId: TABLE_ARN });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when neither the id nor the template identifies a table', async () => {
+      const result = await provider.import({
+        ...input,
+        properties: {},
+        knownPhysicalId: TABLE_ARN,
+      });
+
+      expect(result).toBeNull();
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('declines with no override (override-only)', async () => {
+      const result = await provider.import(input);
+      expect(result).toBeNull();
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/provisioning/s3-tables-provider-import-verify.test.ts
+++ b/tests/unit/provisioning/s3-tables-provider-import-verify.test.ts
@@ -101,25 +101,16 @@ describe('S3Tables import: verify the composite before adopting (issue #1668)', 
       expect(call.input).toMatchObject({ tableBucketARN: BUCKET_ARN, namespace: 'ns' });
     });
 
-    it('rebuilds a wrong-arity override from the template instead of recording it verbatim', async () => {
-      mockSend.mockResolvedValueOnce({ namespace: ['ns'] });
-
+    it('REFUSES a wrong-arity override rather than recording it verbatim', async () => {
       // Pre-#1668 this bare id landed in state and broke every later op.
+      // CloudFormation uses the SAME two-field composite for this type, so a
+      // bare name names no namespace cdkd can verify — and silently
+      // substituting the template's identity would adopt a resource the user
+      // did not name (knownPhysicalId is documented ground truth).
       const result = await provider.import({ ...input, knownPhysicalId: 'ns' });
 
-      expect(result).toEqual({ physicalId: `${BUCKET_ARN}|ns`, attributes: {} });
-    });
-
-    it('accepts the CDK singleton-array Namespace shape', async () => {
-      mockSend.mockResolvedValueOnce({ namespace: ['ns'] });
-
-      const result = await provider.import({
-        ...input,
-        properties: { TableBucketARN: BUCKET_ARN, Namespace: ['ns'] },
-        knownPhysicalId: 'ns',
-      });
-
-      expect(result).toEqual({ physicalId: `${BUCKET_ARN}|ns`, attributes: {} });
+      expect(result).toBeNull();
+      expect(mockSend).not.toHaveBeenCalled();
     });
 
     it('returns null when the namespace does not exist', async () => {
@@ -133,15 +124,18 @@ describe('S3Tables import: verify the composite before adopting (issue #1668)', 
       expect(result).toBeNull();
     });
 
-    it('returns null when neither the id nor the template identifies a namespace', async () => {
+    it('adopts a composite id regardless of the template property shapes', async () => {
+      // The CDK shape: Namespace / TableBucketARN are unresolved intrinsics at
+      // import time. The composite alone must be sufficient.
+      mockSend.mockResolvedValueOnce({ namespace: ['ns'] });
+
       const result = await provider.import({
         ...input,
-        properties: {},
-        knownPhysicalId: 'ns',
+        properties: { TableBucketARN: { 'Fn::GetAtt': ['B', 'TableBucketARN'] } },
+        knownPhysicalId: `${BUCKET_ARN}|ns`,
       });
 
-      expect(result).toBeNull();
-      expect(mockSend).not.toHaveBeenCalled();
+      expect(result).toEqual({ physicalId: `${BUCKET_ARN}|ns`, attributes: {} });
     });
 
     it('declines with no override (override-only)', async () => {
@@ -160,8 +154,8 @@ describe('S3Tables import: verify the composite before adopting (issue #1668)', 
       properties: { TableBucketARN: BUCKET_ARN, Namespace: 'ns', TableName: 'tbl' },
     };
 
-    it("canonicalizes CloudFormation's TableARN physicalId into cdkd's composite", async () => {
-      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN });
+    it("canonicalizes CloudFormation's TableARN by resolving identity from AWS (#1668)", async () => {
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN, namespace: ['ns'], name: 'tbl' });
 
       // The registry declares a single-field primaryIdentifier of TableARN,
       // so this is what --migrate-from-cloudformation supplies.
@@ -173,23 +167,65 @@ describe('S3Tables import: verify the composite before adopting (issue #1668)', 
       });
       const call = mockSend.mock.calls[0]?.[0];
       expect(call).toBeInstanceOf(GetTableCommand);
-      expect(call.input).toMatchObject({
-        tableBucketARN: BUCKET_ARN,
-        namespace: 'ns',
-        name: 'tbl',
+      // Resolved BY ARN — not by template-derived parts.
+      expect(call.input).toEqual({ tableArn: TABLE_ARN });
+    });
+
+    it('canonicalizes the ARN when TableBucketARN is an unresolved Fn::GetAtt (the CDK shape)', async () => {
+      // The shape that actually occurs: import.ts substitutes only single-key
+      // {Ref}, and full intrinsic resolution runs AFTER provider.import().
+      // A template-derived fallback is `undefined` here, which is why the
+      // identity must come from AWS.
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN, namespace: ['ns'], name: 'tbl' });
+
+      const result = await provider.import({
+        ...input,
+        properties: {
+          TableBucketARN: { 'Fn::GetAtt': ['TableBucket', 'TableBucketARN'] },
+          Namespace: { Ref: 'MyNamespace' },
+          TableName: 'tbl',
+        },
+        knownPhysicalId: TABLE_ARN,
+      });
+
+      expect(result).toEqual({
+        physicalId: `${BUCKET_ARN}|ns|tbl`,
+        attributes: { TableARN: TABLE_ARN },
       });
     });
 
-    it('refuses when the supplied ARN names a different table than the template', async () => {
-      mockSend.mockResolvedValueOnce({ tableARN: `${BUCKET_ARN}/table/other-999` });
+    it('refuses when the resolved bucket disagrees with a LITERAL template bucket ARN', async () => {
+      const otherBucket = 'arn:aws:s3tables:us-east-1:111122223333:bucket/other-bucket';
+      mockSend.mockResolvedValueOnce({
+        tableARN: `${otherBucket}/table/abc-123`,
+        namespace: ['ns'],
+        name: 'tbl',
+      });
 
       const result = await provider.import({ ...input, knownPhysicalId: TABLE_ARN });
 
       expect(result).toBeNull();
     });
 
+    it('refuses when GetTable returns no tableARN (unverifiable)', async () => {
+      mockSend.mockResolvedValueOnce({ namespace: ['ns'], name: 'tbl' });
+
+      const result = await provider.import({ ...input, knownPhysicalId: TABLE_ARN });
+
+      expect(result).toBeNull();
+    });
+
+    it('refuses an override that is neither a composite nor an ARN', async () => {
+      // knownPhysicalId is documented ground truth, so silently substituting
+      // the template's identity would adopt a resource the user did not name.
+      const result = await provider.import({ ...input, knownPhysicalId: 'just_a_name' });
+
+      expect(result).toBeNull();
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
     it('verifies and adopts a well-formed composite, caching the real ARN', async () => {
-      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN });
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN, namespace: ['ns'], name: 'tbl' });
 
       const result = await provider.import({
         ...input,
@@ -202,31 +238,16 @@ describe('S3Tables import: verify the composite before adopting (issue #1668)', 
       });
     });
 
-    it('rebuilds a wrong-arity override from the template instead of recording it verbatim', async () => {
-      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN });
-
-      // Pre-#1668 a 2-segment id fell through to verbatim adoption.
+    it('refuses a wrong-arity override rather than recording it verbatim', async () => {
+      // Pre-#1668 a 2-segment id fell through to verbatim adoption. It is not
+      // a composite and not an ARN-only id, so it names nothing verifiable.
       const result = await provider.import({
         ...input,
         knownPhysicalId: `${BUCKET_ARN}|ns`,
       });
 
-      expect(result).toEqual({
-        physicalId: `${BUCKET_ARN}|ns|tbl`,
-        attributes: { TableARN: TABLE_ARN },
-      });
-    });
-
-    it("mirrors createTable's TableName ?? Name fallback", async () => {
-      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN });
-
-      const result = await provider.import({
-        ...input,
-        properties: { TableBucketARN: BUCKET_ARN, Namespace: 'ns', Name: 'tbl' },
-        knownPhysicalId: TABLE_ARN,
-      });
-
-      expect(result).toMatchObject({ physicalId: `${BUCKET_ARN}|ns|tbl` });
+      expect(result).toBeNull();
+      expect(mockSend).not.toHaveBeenCalled();
     });
 
     it('returns null when the table does not exist', async () => {
@@ -237,15 +258,16 @@ describe('S3Tables import: verify the composite before adopting (issue #1668)', 
       expect(result).toBeNull();
     });
 
-    it('returns null when neither the id nor the template identifies a table', async () => {
+    it('adopts by ARN even when the template carries no usable properties', async () => {
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN, namespace: ['ns'], name: 'tbl' });
+
       const result = await provider.import({
         ...input,
         properties: {},
         knownPhysicalId: TABLE_ARN,
       });
 
-      expect(result).toBeNull();
-      expect(mockSend).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ physicalId: `${BUCKET_ARN}|ns|tbl` });
     });
 
     it('declines with no override (override-only)', async () => {

--- a/tests/unit/provisioning/s3-tables-provider-import-verify.test.ts
+++ b/tests/unit/provisioning/s3-tables-provider-import-verify.test.ts
@@ -215,6 +215,71 @@ describe('S3Tables import: verify the composite before adopting (issue #1668)', 
       expect(result).toBeNull();
     });
 
+    it('keeps the bare TableARN for a Cloud-Control-routed table (#614 routing)', async () => {
+      // `IcebergMetadata` is a silent-drop property, so this table auto-routes
+      // to Cloud Control, whose Identifier is the bare TableARN. cdkd import
+      // records provisionedBy: 'sdk' but only 'cc-api' is STICKY, so the next
+      // deploy/destroy re-derives the route — canonicalizing here would hand
+      // CC 'arn|ns|name'.
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN, namespace: ['ns'], name: 'tbl' });
+
+      const result = await provider.import({
+        ...input,
+        properties: { ...input.properties, IcebergMetadata: { SchemaDefinition: {} } },
+        knownPhysicalId: TABLE_ARN,
+      });
+
+      expect(result).toEqual({ physicalId: TABLE_ARN, attributes: { TableARN: TABLE_ARN } });
+    });
+
+    it('pins the request shape for a composite id (must NOT go through tableArn)', async () => {
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN, namespace: ['ns'], name: 'tbl' });
+
+      await provider.import({ ...input, knownPhysicalId: `${BUCKET_ARN}|ns|tbl` });
+
+      expect(mockSend.mock.calls[0]?.[0].input).toEqual({
+        tableBucketARN: BUCKET_ARN,
+        namespace: 'ns',
+        name: 'tbl',
+      });
+    });
+
+    it('refuses when the ARN resolves to a different table NAME than the template', async () => {
+      mockSend.mockResolvedValueOnce({
+        tableARN: TABLE_ARN,
+        namespace: ['ns'],
+        name: 'a-different-table',
+      });
+
+      const result = await provider.import({ ...input, knownPhysicalId: TABLE_ARN });
+
+      expect(result).toBeNull();
+    });
+
+    it('refuses when GetTable returns an empty namespace list', async () => {
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN, namespace: [], name: 'tbl' });
+
+      const result = await provider.import({ ...input, knownPhysicalId: TABLE_ARN });
+
+      expect(result).toBeNull();
+    });
+
+    it('refuses when the returned ARN has no /table/ segment to split on', async () => {
+      mockSend.mockResolvedValueOnce({ tableARN: BUCKET_ARN, namespace: ['ns'], name: 'tbl' });
+
+      const result = await provider.import({ ...input, knownPhysicalId: TABLE_ARN });
+
+      expect(result).toBeNull();
+    });
+
+    it('propagates a non-NotFound error as a failure rather than a skip', async () => {
+      mockSend.mockRejectedValueOnce(new Error('AccessDeniedException'));
+
+      await expect(
+        provider.import({ ...input, knownPhysicalId: TABLE_ARN })
+      ).rejects.toThrow(/AccessDenied/);
+    });
+
     it('refuses an override that is neither a composite nor an ARN', async () => {
       // knownPhysicalId is documented ground truth, so silently substituting
       // the template's identity would adopt a resource the user did not name.

--- a/tests/unit/provisioning/s3-tables-provider-import-verify.test.ts
+++ b/tests/unit/provisioning/s3-tables-provider-import-verify.test.ts
@@ -263,6 +263,50 @@ describe('S3Tables import: verify the composite before adopting (issue #1668)', 
       });
     });
 
+    it('adopts when Namespace was SUBSTITUTED with the sibling composite id (#1668)', async () => {
+      // The migration path this fix targets. `import.ts` substitutes a
+      // single-key {Ref} with the referenced resource's PHYSICAL ID before
+      // provider.import() runs, and for AWS::S3Tables::Namespace that id is
+      // the 2-field composite `<bucketArn>|<namespace>`. Comparing it RAW
+      // against the resolved field refused the adoption on exactly the
+      // canonical CDK spelling (`namespace: ns.ref`) -- so the table was
+      // silently not adopted and the next deploy tried to CREATE it.
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN, namespace: ['ns'], name: 'tbl' });
+
+      const result = await provider.import({
+        ...input,
+        properties: {
+          TableBucketARN: { 'Fn::GetAtt': ['TableBucket', 'TableBucketARN'] },
+          Namespace: `${BUCKET_ARN}|ns`,
+          TableName: 'tbl',
+        },
+        knownPhysicalId: TABLE_ARN,
+      });
+
+      expect(result).toEqual({
+        physicalId: `${BUCKET_ARN}|ns|tbl`,
+        attributes: { TableARN: TABLE_ARN },
+      });
+    });
+
+    it('still refuses a substituted composite naming a DIFFERENT namespace (#1668)', async () => {
+      // The other polarity: relaxing the comparison must not disable it. The
+      // last segment is still compared, so a genuine disagreement is refused.
+      mockSend.mockResolvedValueOnce({ tableARN: TABLE_ARN, namespace: ['ns'], name: 'tbl' });
+
+      const result = await provider.import({
+        ...input,
+        properties: {
+          TableBucketARN: { 'Fn::GetAtt': ['TableBucket', 'TableBucketARN'] },
+          Namespace: `${BUCKET_ARN}|someone-elses-namespace`,
+          TableName: 'tbl',
+        },
+        knownPhysicalId: TABLE_ARN,
+      });
+
+      expect(result).toBeNull();
+    });
+
     it('refuses when the resolved bucket disagrees with a LITERAL template bucket ARN', async () => {
       const otherBucket = 'arn:aws:s3tables:us-east-1:111122223333:bucket/other-bucket';
       mockSend.mockResolvedValueOnce({

--- a/tests/unit/provisioning/s3-tables-provider-import-verify.test.ts
+++ b/tests/unit/provisioning/s3-tables-provider-import-verify.test.ts
@@ -183,6 +183,27 @@ describe('S3Tables import: verify the composite before adopting (issue #1668)', 
       expect(result).toBeDefined();
     });
 
+    it('treats an ALREADY-GONE bare-ARN row as deleted rather than unparseable', async () => {
+      // "already deleted" and "cannot parse" must not collapse: a re-run after
+      // an interrupted destroy, or an out-of-band console delete, otherwise
+      // fails with "Invalid physical ID format" for a perfectly valid id and
+      // leaves the stack un-destroyable.
+      mockSend.mockRejectedValueOnce(notFound());
+
+      await expect(
+        provider.delete('MyTable', TABLE_ARN, 'AWS::S3Tables::Table', {})
+      ).resolves.toBeUndefined();
+
+      // Only the resolution attempt ran — no DeleteTable was issued.
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+
+    it('still refuses a genuinely unparseable id', async () => {
+      await expect(
+        provider.delete('MyTable', 'not-an-id', 'AWS::S3Tables::Table', {})
+      ).rejects.toThrow(/Invalid physical ID format/);
+    });
+
     it('still deletes a table recorded as the composite (no extra lookup)', async () => {
       mockSend.mockResolvedValueOnce({});
 


### PR DESCRIPTION
Closes #1668

## The bug

`S3TablesProvider.import()` returned the caller-supplied `knownPhysicalId` as the
adopted physicalId **without verifying its shape**, for both `Namespace` and
`Table`. cdkd's own ids for these types are composites, and every other method on
the provider splits the stored id on `|` — so a bare or wrong-arity id produced a
state row that *looked* adopted and could not afterwards be updated, deleted or
read back.

## What the registry actually says (and why the two types differ)

The issue asked to settle what CloudFormation's physicalId is per type, and
warned not to assume the Glue answer transfers. It does not. Live
`DescribeType`, us-east-1, 2026-08-12:

| Type | `primaryIdentifier` | vs cdkd's id |
|---|---|---|
| `AWS::S3Tables::Namespace` | `[TableBucketARN, Namespace]` (2 fields) | **agrees** — Cloud Control joins a multi-part identifier with `\|`, which is exactly cdkd's composite |
| `AWS::S3Tables::Table` | `[TableARN]` (**1 field**) | **disagrees** — CFn's id is the table ARN, not `<bucketArn>\|<ns>\|<name>` |

So `Table` carries the same real, user-facing defect as https://github.com/go-to-k/cdkd/issues/1651 (Glue): an auto /
`--migrate-from-cloudformation` import merges CFn-derived ids into the overrides,
so that ARN was landing in state verbatim. `Namespace` only ever had the missing
arity check.

## The fix

Identity is resolved **from AWS, not from the template**.

- A cdkd composite verifies via `GetTable({tableBucketARN, namespace, name})`.
- A bare ARN — what `--migrate-from-cloudformation` supplies — verifies via
  `GetTable({tableArn})`, which returns `name` + `namespace` directly. The
  bucket ARN is the table ARN's prefix (`<bucketArn>/table/<id>`). When the
  template *does* carry a literal `TableBucketARN` it is cross-checked, and a
  disagreement is refused rather than guessed at.
- Anything else is refused: `knownPhysicalId` is documented ground truth, so
  silently substituting the template's identity would adopt a resource the user
  did not name. `Namespace` is the same — CloudFormation uses the same 2-field
  composite there, so there is no foreign form to accept.

**The first cut of this PR derived the identity from the template, and review
showed it was inert.** In a CDK-synthesized template `TableBucketARN` is
`{"Fn::GetAtt": [...]}`; `import.ts` pre-substitutes only single-key `Ref`, and
full intrinsic resolution runs *after* every `provider.import()`. So on exactly
the migration path this targets, the template read was `undefined` and the
import declined — converting a corrupt adoption into a non-adoption instead of
canonicalizing it. Every test passed a literal string, the one shape CDK never
emits, so the suite agreed with the defect.

The verified `GetTable` response also caches the real `TableARN` attribute, the
same one `createTable` records, so `Fn::GetAtt: [Table, TableARN]` now resolves
for an **imported** table too. A response without `tableARN` is treated as
unverifiable rather than adopted (`createTable` hard-errors on the same
condition).

**A later review round caught a second, worse case in the same helper.**
`resolveTableParts` collapsed `NotFoundException` and "cannot interpret this id"
into one `undefined`, so deleting a bare-ARN row whose table no longer exists
reported `Invalid physical ID format` for a perfectly VALID id — failing the
destroy and leaving the stack **un-destroyable**. That is the same shape of
breakage this issue exists to fix, one branch over, and it is reachable by an
ordinary destroy re-run after an interrupted run or an out-of-band console
delete. The resolution is now tri-state (`parts` / `'not-found'` /
`'unparseable'`):

- `deleteTable` treats `'not-found'` as already-deleted — asserting the region
  first, exactly like the `DeleteTable` `NotFoundException` arm below it — and
  still fails loudly on `'unparseable'`;
- `readTableCurrentState` reports nothing for either;
- `applyTableTagsDiff` reaches its existing "state is out of sync" message
  instead of the misleading "cannot derive table ARN".

A raw SDK error escaping the resolution is wrapped now too, matching every other
error on the delete path.

## Two corrections to the issue's premises

- The issue says the delete path "warns and SKIPS, which leaks the AWS resource
  while `cdkd destroy` reports success". It does not — both `deleteNamespace` and
  `deleteTable` **throw** `Invalid physical ID format`. The failure was loud, not
  silent. The real damage is the unusable state row, which this PR prevents.
- `Namespace` needed no foreign id shape accepted, per the table above.


## Review round: the cross-check refused the very path this targets

A final review pass found the identity cross-check comparing two different
**shapes of the same fact**. `import.ts` substitutes a single-key `{Ref}` with
the referenced resource's **physical id** before `provider.import()` runs, and
for `AWS::S3Tables::Namespace` that id is the 2-field composite
`<bucketArn>|<namespace>` — the shape documented in the table above. So the
canonical CDK spelling `namespace: ns.ref` declared `arn:…|analytics` where the
resolved field is `analytics`, the check read it as a disagreement, and the
table was refused adoption with only a warning; the next deploy then tried to
CREATE a table that already exists.

The guard already carried the "same kind of value" idea but applied it only to
`TableBucketARN`. It now compares the **field**, not the id carrying it —
neither a namespace nor a table name may contain `|`, so the last segment is
unambiguous and the check keeps its teeth. A substituted composite naming a
**different** namespace is still refused, and both polarities are pinned. The
pre-existing test passed the *unsubstituted* `{Ref}` — the one shape that reads
as absent and skips the comparison entirely — which is why the suite agreed
with the defect.

Also fixed in the same round: `readTableCurrentState` propagated a resolution
failure, and `cdkd drift` has no per-resource try/catch, so a single throttle or
`AccessDenied` on a bare-ARN row aborted the whole stack's drift run. It reports
drift-unknown for that resource now — the same answer the two sentinel
resolutions already give.

## Verification

- **Unit**: 30 new tests — the two parsers, both id shapes per type, the
  ARN-mismatch refusal, the `TableName ?? Name` fallback mirrored from
  `createTable`, not-found handling, and the still-declines-without-an-override
  contract. Both polarities of the tri-state are pinned (a gone ARN row deletes cleanly
  and issues no `DeleteTable`; a genuinely unparseable id still throws).
  Suite green (11,209 tests).
  One of these caught a real bug in my own first draft: the ARN cross-check was
  gated on `startsWith('arn:')`, which also matches cdkd's **own** composite
  (whose first segment is the bucket ARN), so it refused valid ids. It is now
  scoped to a `|`-free value, with the reason recorded in-code.
- **Live (real AWS, us-east-1)**: `s3-tables` integ — deploy + `https://github.com/go-to-k/cdkd/issues/609` Tags
  backfill assertions + destroy, **5 deleted, 0 errors, 0 orphans**, no leftover
  table buckets.
- **Live-test gap, stated explicitly**: that fixture drives `deploy` / `destroy`,
  not `cdkd import`, so it proves the create/delete paths are **regression-free**
  but does not exercise the `import()` branch this PR changes. That branch has
  unit binding proof plus the live `DescribeType` evidence above for the id
  shapes it depends on.

## Follow-up filed

https://github.com/go-to-k/cdkd/issues/1676 — `docs/import.md` lists both types under "Auto-resolved", but their
`import()` declines without an override (pre-existing; unchanged by this PR).
Not fixed here because that file is owned by a concurrent lane (PR https://github.com/go-to-k/cdkd/issues/1666).


