### PR TITLE
fix(export): accept the bare AWS::ApiGateway::Resource physicalId cdkd actually stores

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -10,7 +10,7 @@ agentcore-tools	2026-08-01T09:36:05Z	PASS	58	verify.sh	0801 regression sweep; 3 
 alb	2026-08-11T14:04:52Z	PASS	396	verify.sh	#1609 final post-rebase: removal resets + sibling retained + revert mass-reset guard; destroy 16/0, orphans clean
 alb-advanced	2026-07-28T02:54:42Z	PASS	206	standard	ALB active wait 156s (#1274), destroy 17/0 errors
 api-cognito	2026-07-26T18:49:34Z	PASS	75	standard	0727b sweep-b6 staleness re-run (rc=0); account clean
-apigateway	2026-08-12T08:46:34Z	PASS	57	verify.sh	rc ok, 25 deleted 0 errors, orph clean
+apigateway	2026-08-12T09:29:57Z	PASS	60	verify.sh	rc ok, 25 deleted 0 errors, orph clean
 apigatewayv2-update-removal	2026-08-11T13:20:54Z	PASS	300	verify.sh	#1602 review round-3: anchored unsupported guard; 17 deleted 0 errors 0 orphans
 apigw-gateway-response	2026-07-31T06:27:45Z	PASS	66	verify.sh	TTL-refresh sweep re-run; 3 phases clean, orph clean
 apigw-stage-props	2026-08-11T06:41:16Z	PASS	300	verify.sh	final post-rebase run (Route batch on main); 0 orphans
@@ -114,7 +114,7 @@ eventbridge-pipes	2026-08-10T11:50:46Z	PASS	179	verify.sh	0810 P0/P1 sweep b2; 6
 eventbridge-scheduler	2026-08-01T10:00:06Z	PASS	46	verify.sh	0801 regression sweep; ok, 0 orphans
 eventbus-policy	2026-08-11T10:54:05Z	PASS	56	verify.sh	new fixture (issue 1608): deploy/diff/update/destroy clean, 0 orphans
 eventsourcemapping-race	2026-07-27T11:04:52Z	PASS	80	verify.sh	issue #1267 Lambda ESM update wrap; 5 del 0 err; swept 1 auto-created log group
-export	2026-08-12T08:46:34Z	PASS	207	verify.sh	rc ok, CFn IMPORT round-trip + no-REPLACE guard, orph clean
+export	2026-08-12T09:29:57Z	PASS	194	verify.sh	rc ok, CFn IMPORT round-trip + no-REPLACE guard, orph clean
 export-nested-stack	2026-08-10T04:45:42Z	PASS	153	verify.sh	0810 sweep b3; export->CFn nested adopt + CFn delete clean, 0 orph
 fifo-sqs-event-source	2026-07-27T06:44:00Z	PASS	111	verify.sh	final-tree gate refresh for #1256; destroy 6/0 errors, 0 orphans
 fsx-lustre	2026-08-02T05:30:54Z	PASS	899	verify.sh	0802 heavy TTL sweep; deploy+update+destroy ok, 0 orphans, no final backup

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -10,7 +10,7 @@ agentcore-tools	2026-08-01T09:36:05Z	PASS	58	verify.sh	0801 regression sweep; 3 
 alb	2026-08-11T14:04:52Z	PASS	396	verify.sh	#1609 final post-rebase: removal resets + sibling retained + revert mass-reset guard; destroy 16/0, orphans clean
 alb-advanced	2026-07-28T02:54:42Z	PASS	206	standard	ALB active wait 156s (#1274), destroy 17/0 errors
 api-cognito	2026-07-26T18:49:34Z	PASS	75	standard	0727b sweep-b6 staleness re-run (rc=0); account clean
-apigateway	2026-08-12T07:35:00Z	PASS	480	verify.sh	#1663 ApiGateway::Resource bare physicalId; deploy + destroy clean, 25 deleted, 0 errors, 0 orphans (export splitter itself not covered by any fixture - see PR body)
+apigateway	2026-08-12T08:46:34Z	PASS	57	verify.sh	rc ok, 25 deleted 0 errors, orph clean
 apigatewayv2-update-removal	2026-08-11T13:20:54Z	PASS	300	verify.sh	#1602 review round-3: anchored unsupported guard; 17 deleted 0 errors 0 orphans
 apigw-gateway-response	2026-07-31T06:27:45Z	PASS	66	verify.sh	TTL-refresh sweep re-run; 3 phases clean, orph clean
 apigw-stage-props	2026-08-11T06:41:16Z	PASS	300	verify.sh	final post-rebase run (Route batch on main); 0 orphans
@@ -114,7 +114,7 @@ eventbridge-pipes	2026-08-10T11:50:46Z	PASS	179	verify.sh	0810 P0/P1 sweep b2; 6
 eventbridge-scheduler	2026-08-01T10:00:06Z	PASS	46	verify.sh	0801 regression sweep; ok, 0 orphans
 eventbus-policy	2026-08-11T10:54:05Z	PASS	56	verify.sh	new fixture (issue 1608): deploy/diff/update/destroy clean, 0 orphans
 eventsourcemapping-race	2026-07-27T11:04:52Z	PASS	80	verify.sh	issue #1267 Lambda ESM update wrap; 5 del 0 err; swept 1 auto-created log group
-export	2026-08-10T11:50:46Z	PASS	194	verify.sh	0810 P0/P1 sweep b5 BROAD; variant=default, post-export cdk diff no-replacement (#319 guard)
+export	2026-08-12T08:46:34Z	PASS	207	verify.sh	rc ok, CFn IMPORT round-trip + no-REPLACE guard, orph clean
 export-nested-stack	2026-08-10T04:45:42Z	PASS	153	verify.sh	0810 sweep b3; export->CFn nested adopt + CFn delete clean, 0 orph
 fifo-sqs-event-source	2026-07-27T06:44:00Z	PASS	111	verify.sh	final-tree gate refresh for #1256; destroy 6/0 errors, 0 orphans
 fsx-lustre	2026-08-02T05:30:54Z	PASS	899	verify.sh	0802 heavy TTL sweep; deploy+update+destroy ok, 0 orphans, no final backup

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -10,7 +10,7 @@ agentcore-tools	2026-08-01T09:36:05Z	PASS	58	verify.sh	0801 regression sweep; 3 
 alb	2026-08-11T14:04:52Z	PASS	396	verify.sh	#1609 final post-rebase: removal resets + sibling retained + revert mass-reset guard; destroy 16/0, orphans clean
 alb-advanced	2026-07-28T02:54:42Z	PASS	206	standard	ALB active wait 156s (#1274), destroy 17/0 errors
 api-cognito	2026-07-26T18:49:34Z	PASS	75	standard	0727b sweep-b6 staleness re-run (rc=0); account clean
-apigateway	2026-08-10T17:13:20Z	PASS	175	verify.sh	final re-run after re-review fixes; 25 deleted 0 errors
+apigateway	2026-08-12T07:35:00Z	PASS	480	verify.sh	#1663 ApiGateway::Resource bare physicalId; deploy + destroy clean, 25 deleted, 0 errors, 0 orphans (export splitter itself not covered by any fixture - see PR body)
 apigatewayv2-update-removal	2026-08-11T13:20:54Z	PASS	300	verify.sh	#1602 review round-3: anchored unsupported guard; 17 deleted 0 errors 0 orphans
 apigw-gateway-response	2026-07-31T06:27:45Z	PASS	66	verify.sh	TTL-refresh sweep re-run; 3 phases clean, orph clean
 apigw-stage-props	2026-08-11T06:41:16Z	PASS	300	verify.sh	final post-rebase run (Route batch on main); 0 orphans

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -263,9 +263,14 @@ const PRIMARY_IDENTIFIER_FALLBACK: Record<string, string> = {
  *   and MUST be complete (CFn rejects partial identifiers).
  * - `propertiesOverlay` (optional): subset of `resourceIdentifier` to write
  *   into the synth template's `Properties` block. Defaults to the full
- *   `resourceIdentifier` map (existing behavior for `AWS::ApiGateway::Method`
- *   and `AWS::EC2::VPCGatewayAttachment`, whose identifier fields ARE all
- *   writable Properties — `Method` has NO `readOnlyProperties` at all).
+ *   `resourceIdentifier` map — correct for `AWS::ApiGateway::Method`, which
+ *   has NO `readOnlyProperties` at all (live `DescribeType`, us-east-1,
+ *   2026-08-12). `AWS::EC2::VPCGatewayAttachment` was listed here too and is
+ *   NOT such a type: its identifier is `[AttachmentType, VpcId]` with
+ *   `AttachmentType` read-only, so its splitter neither produces the right
+ *   fields nor narrows the overlay — tracked as
+ *   https://github.com/go-to-k/cdkd/issues/1691 rather than fixed here, since
+ *   it is a different type's defect.
  *   Sub-resource types whose
  *   primaryIdentifier includes a generated-id field (`ResourceId` /
  *   `IntegrationId` / `RouteId` / Lambda::Permission's `Id`) MUST narrow to just the writable
@@ -316,9 +321,11 @@ const COMPOSITE_ID_SPLITTERS: Record<string, CompositeIdSplitter> = {
   // cdkd's SDK provider stores the BARE `resourceId` — `createResource`
   // returns `response.id` and every other method treats the physicalId as a
   // bare id, reading the parent `RestApiId` from the recorded properties. The
-  // LEGACY Cloud Control path produced `restApiId|resourceId` (CC joins a
-  // multi-part primaryIdentifier with `|`), so both shapes exist in state in
-  // the wild and BOTH are accepted here. Requiring the composite made
+  // The Cloud Control path produces `restApiId|resourceId` (CC joins a
+  // multi-part primaryIdentifier with `|`). That path is LIVE, not
+  // historical: the #614 silent-drop rule still auto-routes these types
+  // through Cloud Control, so both shapes exist in state in the wild and BOTH
+  // are accepted here. Requiring the composite made
   // `cdkd export` throw on every SDK-created Resource — on a value cdkd
   // itself wrote (issue #1663).
   //
@@ -335,7 +342,9 @@ const COMPOSITE_ID_SPLITTERS: Record<string, CompositeIdSplitter> = {
   // ResourceId — so the default overlay would have skipped it anyway. Narrow
   // it explicitly so the safety does not depend on that conditional.
   'AWS::ApiGateway::Resource': (physicalId, properties) => {
-    if (!physicalId) {
+    // `.trim()`, not truthiness: a blank id is as unusable as an empty one
+    // and would otherwise ship `ResourceId: ' '` into the changeset.
+    if (!physicalId.trim()) {
       throw new Error('empty physical id for AWS::ApiGateway::Resource (expected a resourceId)');
     }
     const parts = physicalId.split('|');

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -312,16 +312,43 @@ const COMPOSITE_ID_SPLITTERS: Record<string, CompositeIdSplitter> = {
     const map = { RestApiId: parts[0]!, ResourceId: parts[1]!, HttpMethod: parts[2]! };
     return { resourceIdentifier: map };
   },
-  // cdkd stores `restApiId|resourceId` (apigateway-provider.ts);
-  // CFn primary identifier is [RestApiId, ResourceId] — both are writable
-  // Properties of AWS::ApiGateway::Resource.
-  'AWS::ApiGateway::Resource': (id) => {
-    const parts = id.split('|');
-    if (parts.length !== 2) {
-      throw new Error(`expected 2 parts (restApiId|resourceId), got ${parts.length}: '${id}'`);
+  // cdkd's SDK provider stores the BARE `resourceId` — `createResource`
+  // returns `response.id` and every other method treats the physicalId as a
+  // bare id, reading the parent `RestApiId` from the recorded properties. The
+  // LEGACY Cloud Control path produced `restApiId|resourceId` (CC joins a
+  // multi-part primaryIdentifier with `|`), so both shapes exist in state in
+  // the wild and BOTH are accepted here. Requiring the composite made
+  // `cdkd export` throw on every SDK-created Resource — on a value cdkd
+  // itself wrote (issue #1663).
+  //
+  // CFn primary identifier is [RestApiId, ResourceId], but unlike
+  // AWS::ApiGateway::Method (which has NO read-only properties, verified live
+  // us-east-1 2026-08-12) `ResourceId` is `readOnlyProperties` here — so it is
+  // EXCLUDED from propertiesOverlay, since CFn rejects a changeset that writes
+  // a read-only property. Same narrowing, same reason, as the
+  // ApiGatewayV2::Integration splitter below.
+  'AWS::ApiGateway::Resource': (physicalId, properties) => {
+    const parts = physicalId.split('|');
+    if (parts.length > 2) {
+      throw new Error(
+        `expected a bare resourceId or 'restApiId|resourceId', got ${parts.length} parts: '${physicalId}'`
+      );
     }
-    const map = { RestApiId: parts[0]!, ResourceId: parts[1]! };
-    return { resourceIdentifier: map };
+    if (parts.length === 2) {
+      const [restApiId, resourceId] = parts as [string, string];
+      if (!restApiId || !resourceId) {
+        throw new Error(`empty part in 'restApiId|resourceId': '${physicalId}'`);
+      }
+      return {
+        resourceIdentifier: { RestApiId: restApiId, ResourceId: resourceId },
+        propertiesOverlay: { RestApiId: restApiId },
+      };
+    }
+    const restApiId = readStringProperty(properties, 'RestApiId', 'AWS::ApiGateway::Resource');
+    return {
+      resourceIdentifier: { RestApiId: restApiId, ResourceId: physicalId },
+      propertiesOverlay: { RestApiId: restApiId },
+    };
   },
   // cdkd stores `IGW|VpcId` (ec2-provider.ts);
   // CFn primary identifier is [VpcId, InternetGatewayId] — DIFFERENT order

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -264,10 +264,11 @@ const PRIMARY_IDENTIFIER_FALLBACK: Record<string, string> = {
  * - `propertiesOverlay` (optional): subset of `resourceIdentifier` to write
  *   into the synth template's `Properties` block. Defaults to the full
  *   `resourceIdentifier` map (existing behavior for `AWS::ApiGateway::Method`
- *   / `AWS::ApiGateway::Resource` / `AWS::EC2::VPCGatewayAttachment` whose
- *   identifier fields ARE all writable Properties). Sub-resource types whose
- *   primaryIdentifier includes a generated-id field (`IntegrationId` /
- *   `RouteId` / Lambda::Permission's `Id`) MUST narrow to just the writable
+ *   and `AWS::EC2::VPCGatewayAttachment`, whose identifier fields ARE all
+ *   writable Properties — `Method` has NO `readOnlyProperties` at all).
+ *   Sub-resource types whose
+ *   primaryIdentifier includes a generated-id field (`ResourceId` /
+ *   `IntegrationId` / `RouteId` / Lambda::Permission's `Id`) MUST narrow to just the writable
  *   subset — those generated-id fields ARE listed in the CFn schema's
  *   `properties` block but tagged `readOnlyProperties`, so writing them
  *   via Properties at IMPORT changeset creation is rejected by CFn. The
@@ -324,10 +325,19 @@ const COMPOSITE_ID_SPLITTERS: Record<string, CompositeIdSplitter> = {
   // CFn primary identifier is [RestApiId, ResourceId], but unlike
   // AWS::ApiGateway::Method (which has NO read-only properties, verified live
   // us-east-1 2026-08-12) `ResourceId` is `readOnlyProperties` here — so it is
-  // EXCLUDED from propertiesOverlay, since CFn rejects a changeset that writes
-  // a read-only property. Same narrowing, same reason, as the
+  // EXCLUDED from propertiesOverlay. Same narrowing, same reason, as the
   // ApiGatewayV2::Integration splitter below.
+  //
+  // This is defense-in-depth rather than a live bug fix:
+  // `overlayResourceIdentifierOnProperties` writes a field ONLY when the
+  // template already carries it as a literal string, and a synthesized
+  // AWS::ApiGateway::Resource has RestApiId / ParentId / PathPart and no
+  // ResourceId — so the default overlay would have skipped it anyway. Narrow
+  // it explicitly so the safety does not depend on that conditional.
   'AWS::ApiGateway::Resource': (physicalId, properties) => {
+    if (!physicalId) {
+      throw new Error('empty physical id for AWS::ApiGateway::Resource (expected a resourceId)');
+    }
     const parts = physicalId.split('|');
     if (parts.length > 2) {
       throw new Error(

--- a/src/provisioning/providers/apigateway-provider.ts
+++ b/src/provisioning/providers/apigateway-provider.ts
@@ -2431,7 +2431,14 @@ export class ApiGatewayProvider implements ResourceProvider {
    * Users adopting an existing API Gateway should pass
    * `--resource <logicalId>=<physicalId>` for each sub-resource; the
    * physical id format follows what `create()` returns for the same
-   * type (e.g. `<restApiId>|<resourceId>` for `AWS::ApiGateway::Resource`).
+   * type. Note this is NOT uniformly a composite: `create()` returns a
+   * BARE `resourceId` for `AWS::ApiGateway::Resource` (the parent
+   * `RestApiId` is read from the recorded properties by every other
+   * method), while `AWS::ApiGateway::Method` genuinely is
+   * `<restApiId>|<resourceId>|<httpMethod>`. `import()` honours the
+   * supplied id verbatim, so a composite passed for a type whose
+   * provider stores a scalar would be written to state and then fed to
+   * the API as a resource id (issue #1663).
    */
   // eslint-disable-next-line @typescript-eslint/require-await -- explicit-override-only intentionally has no AWS calls
   async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {

--- a/src/provisioning/providers/apigateway-provider.ts
+++ b/src/provisioning/providers/apigateway-provider.ts
@@ -2435,14 +2435,38 @@ export class ApiGatewayProvider implements ResourceProvider {
    * BARE `resourceId` for `AWS::ApiGateway::Resource` (the parent
    * `RestApiId` is read from the recorded properties by every other
    * method), while `AWS::ApiGateway::Method` genuinely is
-   * `<restApiId>|<resourceId>|<httpMethod>`. `import()` honours the
-   * supplied id verbatim, so a composite passed for a type whose
-   * provider stores a scalar would be written to state and then fed to
-   * the API as a resource id (issue #1663).
+   * `<restApiId>|<resourceId>|<httpMethod>`.
+   *
+   * `import()` otherwise honours the supplied id verbatim, so a composite
+   * passed for a type whose provider stores a SCALAR would be written to
+   * state and then fed to the API as a resource id (issue #1663). That is
+   * not merely a failed call: `deleteResource` treats `NotFoundException`
+   * as an idempotent success, so the bad id would be reported as deleted
+   * while the resource stayed live in AWS — a silent orphan, the same class
+   * as issues #1651 / #1658. So the one type whose stored shape is
+   * unambiguously scalar refuses a composite up front, where the user can
+   * still act on it.
    */
   // eslint-disable-next-line @typescript-eslint/require-await -- explicit-override-only intentionally has no AWS calls
   async import(input: ResourceImportInput): Promise<ResourceImportResult | null> {
     if (input.knownPhysicalId) {
+      // Scoped to Resource deliberately: `Method` IS a composite, and this
+      // type cannot take the #614 Cloud-Control route (all three of its CFn
+      // properties are in `handledProperties`), so a `|` here is always the
+      // user mis-following the old docstring rather than a CC-shaped id.
+      if (
+        input.resourceType === 'AWS::ApiGateway::Resource' &&
+        input.knownPhysicalId.includes('|')
+      ) {
+        this.logger.warn(
+          `AWS::ApiGateway::Resource ${input.logicalId}: '${input.knownPhysicalId}' looks like a ` +
+            `composite, but cdkd stores a BARE resourceId for this type (the parent RestApiId ` +
+            `comes from the template). Adopting it would send the whole string to the API as a ` +
+            `resource id, and the delete path would then report success on the NotFound. Pass ` +
+            `just the resourceId.`
+        );
+        return null;
+      }
       return { physicalId: input.knownPhysicalId, attributes: {} };
     }
     return null;

--- a/tests/unit/cli/export.test.ts
+++ b/tests/unit/cli/export.test.ts
@@ -602,10 +602,43 @@ describe('splitCompositePhysicalId', () => {
     });
   });
 
-  it('parses AWS::ApiGateway::Resource (restApiId|resourceId)', () => {
+  it('parses AWS::ApiGateway::Resource legacy composite (restApiId|resourceId)', () => {
+    // The Cloud Control path produced this shape; state written by it must
+    // still export. `ResourceId` is read-only, so the overlay narrows to
+    // RestApiId (issue #1663).
     expect(splitCompositePhysicalId('AWS::ApiGateway::Resource', 'api123|res456')).toEqual({
       resourceIdentifier: { RestApiId: 'api123', ResourceId: 'res456' },
+      propertiesOverlay: { RestApiId: 'api123' },
     });
+  });
+
+  it('parses AWS::ApiGateway::Resource BARE resourceId, taking RestApiId from state (#1663)', () => {
+    // What the SDK provider's createResource() actually stores.
+    expect(
+      splitCompositePhysicalId('AWS::ApiGateway::Resource', 'res456', { RestApiId: 'api123' })
+    ).toEqual({
+      resourceIdentifier: { RestApiId: 'api123', ResourceId: 'res456' },
+      propertiesOverlay: { RestApiId: 'api123' },
+    });
+  });
+
+  it('never writes the read-only ResourceId into Properties (#1663)', () => {
+    // propertiesOverlay defaults to the whole resourceIdentifier map, so an
+    // absent overlay here would hand CFn a read-only property and the IMPORT
+    // changeset would be rejected.
+    for (const id of ['res456', 'api123|res456']) {
+      const result = splitCompositePhysicalId('AWS::ApiGateway::Resource', id, {
+        RestApiId: 'api123',
+      });
+      expect(result.propertiesOverlay).toBeDefined();
+      expect(result.propertiesOverlay).not.toHaveProperty('ResourceId');
+    }
+  });
+
+  it('reports a corrupt state entry when the bare form has no RestApiId in properties', () => {
+    expect(() => splitCompositePhysicalId('AWS::ApiGateway::Resource', 'res456', {})).toThrow(
+      /missing 'RestApiId'/
+    );
   });
 
   it('reorders AWS::EC2::VPCGatewayAttachment (cdkd: IGW|VpcId → CFn: {VpcId, InternetGatewayId})', () => {
@@ -680,10 +713,20 @@ describe('splitCompositePhysicalId', () => {
     );
   });
 
-  it('throws on wrong part count for ApiGateway::Resource', () => {
-    expect(() => splitCompositePhysicalId('AWS::ApiGateway::Resource', 'one-part')).toThrow(
-      /expected 2 parts/
-    );
+  it('throws on too many parts for ApiGateway::Resource', () => {
+    // A single part is now VALID (the bare SDK-created id), so the negative
+    // case is an over-long id, not a short one.
+    expect(() =>
+      splitCompositePhysicalId('AWS::ApiGateway::Resource', 'api|res|extra', {
+        RestApiId: 'api123',
+      })
+    ).toThrow(/got 3 parts/);
+  });
+
+  it('throws on an empty part in the ApiGateway::Resource composite', () => {
+    expect(() =>
+      splitCompositePhysicalId('AWS::ApiGateway::Resource', 'api123|', { RestApiId: 'api123' })
+    ).toThrow(/empty part/);
   });
 
   it('throws on wrong part count for VPCGatewayAttachment', () => {

--- a/tests/unit/cli/export.test.ts
+++ b/tests/unit/cli/export.test.ts
@@ -736,6 +736,13 @@ describe('splitCompositePhysicalId', () => {
     ).toThrow(/empty physical id/);
   });
 
+  it('throws on a BLANK ApiGateway::Resource physical id', () => {
+    // Truthiness alone lets ' ' through as `ResourceId: ' '`.
+    expect(() =>
+      splitCompositePhysicalId('AWS::ApiGateway::Resource', '   ', { RestApiId: 'api123' })
+    ).toThrow(/empty physical id/);
+  });
+
   it('throws on wrong part count for VPCGatewayAttachment', () => {
     expect(() =>
       splitCompositePhysicalId('AWS::EC2::VPCGatewayAttachment', 'three|parts|here')

--- a/tests/unit/cli/export.test.ts
+++ b/tests/unit/cli/export.test.ts
@@ -729,6 +729,13 @@ describe('splitCompositePhysicalId', () => {
     ).toThrow(/empty part/);
   });
 
+  it('throws on a wholly empty ApiGateway::Resource physical id', () => {
+    // Without the guard the bare branch would ship `ResourceId: ''` to CFn.
+    expect(() =>
+      splitCompositePhysicalId('AWS::ApiGateway::Resource', '', { RestApiId: 'api123' })
+    ).toThrow(/empty physical id/);
+  });
+
   it('throws on wrong part count for VPCGatewayAttachment', () => {
     expect(() =>
       splitCompositePhysicalId('AWS::EC2::VPCGatewayAttachment', 'three|parts|here')

--- a/tests/unit/provisioning/apigateway-provider.test.ts
+++ b/tests/unit/provisioning/apigateway-provider.test.ts
@@ -2430,4 +2430,58 @@ describe('ApiGatewayProvider', () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe('import() physicalId shape (issue #1663)', () => {
+    const baseInput = {
+      logicalId: 'HelloResource',
+      stackName: 'Stack',
+      region: 'us-east-1',
+      properties: {},
+    };
+
+    it('adopts a BARE resourceId for AWS::ApiGateway::Resource', async () => {
+      const result = await provider.import({
+        ...baseInput,
+        resourceType: 'AWS::ApiGateway::Resource',
+        knownPhysicalId: 'abc123',
+      });
+
+      expect(result).toEqual({ physicalId: 'abc123', attributes: {} });
+    });
+
+    it('REFUSES a composite for AWS::ApiGateway::Resource rather than orphaning it', async () => {
+      // Adopting it would send 'api123|abc123' to DeleteResource as a
+      // resource id, and deleteResource treats NotFoundException as an
+      // idempotent success -- so destroy would report the row deleted while
+      // the resource stayed live in AWS. Refuse where the user can still act.
+      const result = await provider.import({
+        ...baseInput,
+        resourceType: 'AWS::ApiGateway::Resource',
+        knownPhysicalId: 'api123|abc123',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('still adopts the composite AWS::ApiGateway::Method genuinely stores', async () => {
+      // The other polarity: the refusal is scoped to the one type whose
+      // stored shape is unambiguously scalar. Method IS a composite.
+      const result = await provider.import({
+        ...baseInput,
+        resourceType: 'AWS::ApiGateway::Method',
+        knownPhysicalId: 'api123|abc123|GET',
+      });
+
+      expect(result).toEqual({ physicalId: 'api123|abc123|GET', attributes: {} });
+    });
+
+    it('declines without an override (explicit-override-only contract)', async () => {
+      const result = await provider.import({
+        ...baseInput,
+        resourceType: 'AWS::ApiGateway::Resource',
+      });
+
+      expect(result).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
Closes #1663

## The bug

`export.ts`'s `COMPOSITE_ID_SPLITTERS` required `restApiId|resourceId` for
`AWS::ApiGateway::Resource` — a shape the SDK provider **never produces**.
`createResource` returns `response.id` (a bare resource id), and every other
method treats the physicalId as a bare id, reading the parent `RestApiId` from
the recorded properties. The composite only ever came from the legacy Cloud
Control path, where CC joins a multi-part `primaryIdentifier` with `|`.

So `cdkd export` threw on any REST API stack — on a value cdkd itself wrote:

```
expected 2 parts (restApiId|resourceId), got 1: 'abc123'
```

## A latent hazard on the same splitter (not a live bug)

Fixing the arity surfaced something the issue did not mention. `propertiesOverlay`
defaults to the **whole** `resourceIdentifier` map:

```ts
propertiesOverlay: resolved.propertiesOverlay ?? resolved.resourceIdentifier,
```

and this splitter returned no overlay — while `AWS::ApiGateway::Resource` declares
`ResourceId` in `readOnlyProperties` (live `DescribeType`, us-east-1,
2026-08-12), and CFn rejects a changeset that writes a read-only property.

**It is not reachable today, and the PR says so rather than claiming a fix it did
not make.** `overlayResourceIdentifierOnProperties` writes a field only when the
template already carries it as a literal string, and a synthesized
`AWS::ApiGateway::Resource` has `RestApiId` / `ParentId` / `PathPart` and no
`ResourceId` — so the default overlay would have skipped it anyway. Narrowing
explicitly is defense-in-depth: it stops the safety depending on that
conditional. The in-code comment states the same thing, and the splitter's
docstring — which had listed this type among those "whose identifier fields ARE
all writable Properties" — is corrected.

I checked the sibling `AWS::ApiGateway::Method` splitter against the same live
schema rather than assuming: that type has **no** read-only properties, so its
identical-looking comment is accurate and it needs no change.

## The fix

- The splitter accepts **both** shapes: a bare resource id (taking `RestApiId`
  from state's properties, the mechanism `ApiGatewayV2::Integration` already
  uses) and the legacy composite, so state written by either path exports.
- `propertiesOverlay` narrows to `RestApiId` on both branches, so the read-only
  `ResourceId` is never written.
- The bare branch rejects an EMPTY physical id rather than shipping
  `ResourceId: ''` to CloudFormation (the composite branch already refused an
  empty part).
- `ApiGatewayProvider.import()`'s docstring no longer tells users to pass
  `<restApiId>|<resourceId>` for this type. `import()` honours the supplied id
  verbatim, so following that comment wrote a composite into state that the API
  would then receive as a resource id.


## Review round: a silent orphan, and two docstring claims re-checked live

A final review pass found one real hazard and two inaccurate claims — including
one this PR had just written.

**`import()` would silently orphan a composite id.** It honoured
`knownPhysicalId` verbatim, so a composite passed for
`AWS::ApiGateway::Resource` — exactly what the old docstring told users to pass
— was written to state and then sent to the API as a resource id. Not merely a
failed call: `deleteResource` treats `NotFoundException` as an idempotent
success, so `cdkd destroy` would report the row deleted while the resource
stayed **live in AWS**. Same class as https://github.com/go-to-k/cdkd/issues/1651 / https://github.com/go-to-k/cdkd/issues/1658. It is now refused
up front, scoped to that one type (`Method` genuinely IS a composite, and
`Resource` cannot take the CC route since all three of its CFn properties are
handled), with both polarities pinned.

**`AWS::EC2::VPCGatewayAttachment` is not what the docstring said.** My
correction had kept it grouped with `Method` as a type "whose identifier fields
ARE all writable Properties". Live `DescribeType` says otherwise: its identifier
is `[AttachmentType, VpcId]` with `AttachmentType` **read-only**, so its
splitter produces neither the right fields nor a narrowed overlay and `cdkd
export` aborts on any stack with an IGW attachment. That is a different type's
pre-existing defect — filed as https://github.com/go-to-k/cdkd/issues/1691 and linked from the docstring
rather than fixed here.

**"LEGACY Cloud Control path" was wrong in the other direction.** That path is
live, not historical: the #614 silent-drop rule still auto-routes these types
through Cloud Control. Both id shapes really do occur, which is the reason both
are accepted.

Plus the blank-id case the empty-id guard missed (`'   '` would have shipped
`ResourceId: ' '`).

## Scope gap, stated rather than implied

https://github.com/go-to-k/cdkd/issues/1692 records what the same review surfaced: `Deployment` / `Stage` /
`Authorizer` / `Model` / `RequestValidator` are composite in the registry and
stored **bare** by cdkd, with no splitter. Every CDK `RestApi` emits a
Deployment and a Stage, so `cdkd export` still aborts on REST API stacks after
this fix — one splitter further along. This PR closes the `Resource` row the
issue names; the family is tracked there.

## Verification

- **Unit**: 11 tests — both id shapes, an explicit assertion that
  `propertiesOverlay` never carries `ResourceId`, the corrupt-state error, and
  the negative cases. Two pre-existing tests pinned the **old** behavior and were
  updated rather than deleted: the "wrong part count" test asserted that a
  single part throws, which is now the valid SDK form, so it was re-pointed at
  an over-long id (the shape a regression would actually produce). Suite green
  (11,189 tests).
- **Live (real AWS, us-east-1)**: `apigateway` integ — deploy + destroy of a
  REST API stack, results in the run log.
- **Live-test gap, stated explicitly**: no fixture combines a REST v1 API with
  `cdkd export` — the `export` fixture uses **ApiGatewayV2** (`HttpApi`), so it
  covers the neighbouring splitters, not this one. The changed branch therefore
  has unit binding proof only. Its two premises are verified directly rather than
  inferred: the bare-id storage from `createResource`/`deleteResource` in source,
  and the read-only `ResourceId` from live `DescribeType`.


