### PR TITLE
docs(import): list S3Tables Namespace / Table as override-only, not auto-resolved

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -434,8 +434,6 @@ Types with an `import()` that auto-resolves via the above:
 - AWS::ServiceDiscovery::PublicDnsNamespace
 - AWS::S3Express::DirectoryBucket
 - AWS::S3Tables::TableBucket
-- AWS::S3Tables::Namespace (composite: `--resource <logicalId>=<tableBucketARN>|<namespaceName>`)
-- AWS::S3Tables::Table (composite: `--resource <logicalId>=<tableBucketARN>|<namespace>|<name>`)
 - AWS::S3Vectors::VectorBucket
 - AWS::DLM::LifecyclePolicy
 - AWS::FSx::FileSystem
@@ -477,6 +475,8 @@ physical id via `--resource`.
 - AWS::AppSync::DataSource (composite: `--resource <logicalId>=<apiId>|<name>`)
 - AWS::AppSync::Resolver (composite: `--resource <logicalId>=<apiId>|<typeName>|<fieldName>`)
 - AWS::AppSync::ApiKey (composite: `--resource <logicalId>=<apiId>|<apiKeyId>`)
+- AWS::S3Tables::Namespace (composite: `--resource <logicalId>=<tableBucketARN>|<namespaceName>`; only the parent `AWS::S3Tables::TableBucket` auto-resolves)
+- AWS::S3Tables::Table (composite: `--resource <logicalId>=<tableBucketARN>|<namespace>|<name>`; only the parent `AWS::S3Tables::TableBucket` auto-resolves)
 - AWS::Route53::RecordSet (composite: `--resource <logicalId>=<hostedZoneId>|<name>|<type>`, where `<name>` is the record name exactly as the template spells it — CDK emits a trailing dot)
 - AWS::ElasticLoadBalancingV2::Listener
 - AWS::EFS::MountTarget


### PR DESCRIPTION
## Summary

`docs/import.md` listed `AWS::S3Tables::Namespace` and `AWS::S3Tables::Table` under **"Auto-resolved (no `--resource` flag needed)"**, but neither type auto-resolves: `S3TablesProvider.importNamespace` / `importTable` both `return null` whenever `knownPhysicalId` is absent (`src/provisioning/providers/s3-tables-provider.ts:800` / `:807`) — there is no name-based or list-based resolution for either, so in `auto` mode they are reported `skipped-not-found` and never adopted. Only `AWS::S3Tables::TableBucket` genuinely auto-resolves, matching `Properties.TableBucketName` against `ListTableBuckets`.

Both entries move to **"Override-only — sub-resources without a standalone identity"**, which is exactly what they are — child-of-parent resources whose identity is `<tableBucketARN>|<namespace>[|<name>]`, alongside `AWS::Route53::RecordSet` and the `AWS::ApiGateway::*` family. Each entry keeps its composite-format hint and now also names the parent type that does auto-resolve, so the contrast is readable without cross-checking the other list.

The mismatch is pre-existing. It is NOT changed by the in-flight S3Tables import-verify work for issue (#1668), open as PR (#1679), which makes a supplied override verified-and-canonicalized rather than trusted and keeps the no-override case declining exactly as before. It was left out of that PR because `docs/import.md` was held by a concurrent lane (#1666) at the time.

## Verification

- Claim checked against the provider source, not the issue text: `importTableBucket` reads `Properties.TableBucketName` and pages `ListTableBuckets`; `importNamespace` / `importTable` have no such path and fall through to `return null`.
- Swept the sibling docs for the same claim — `docs/supported-resources.md` (SDK-provider support, not import resolution), `docs/state-management.md` (composite format table) and `docs/cli-reference.md:1796` (physicalId format note) are all accurate and unchanged.
- Docs-only, no `src/**` change, so per the repo's live-test rule this PR is exempt; `check` + `docs` markers are set from a full local run (typecheck / lint / build / 594 files, 11181 tests) and `vp run gen:all-matrices` + `audit:coverage:check` report every generated artifact fresh.

Closes #1676
