### PR TITLE
chore(audit): fence AWS::Lambda::EventSourceMapping's forwarded blobs with the nested-key critic

### DIFF
--- a/docs/_generated/enrichment-coverage.json
+++ b/docs/_generated/enrichment-coverage.json
@@ -6,7 +6,7 @@
     "noComputedAttr": 15,
     "unenrichedGap": 0,
     "sdkFallbackGap": 102,
-    "allowListedTypes": 29
+    "allowListedTypes": 30
   },
   "types": [
     {
@@ -2242,12 +2242,12 @@
         },
         {
           "name": "Id",
-          "status": "gap"
+          "status": "allow-listed",
+          "rationale": "primaryIdentifier == physicalId; resolves via the resolver physicalId fallback"
         }
       ],
       "gaps": [
-        "EventSourceMappingArn",
-        "Id"
+        "EventSourceMappingArn"
       ]
     },
     {

--- a/docs/_generated/enrichment-coverage.md
+++ b/docs/_generated/enrichment-coverage.md
@@ -16,7 +16,7 @@ Gap severity depends on the tier. A gap on an **SDK-backed** type (`sdk-fallback
 - No computed attribute (Ref == physicalId is correct): **15**
 - **Pure-CC latent gaps (unenriched-computed, blocks CI): 0**
 - SDK-fallback gaps (informational, #614 path only): **102**
-- Types with allow-listed (not-a-gap) attributes: **29**
+- Types with allow-listed (not-a-gap) attributes: **30**
 
 ## Pure-CC latent gaps
 
@@ -97,7 +97,7 @@ SDK-backed types whose computed attribute is unenriched: only exposed on the #61
 | `AWS::Kinesis::Stream` | `WarmThroughputObject` |
 | `AWS::Kinesis::StreamConsumer` | `ConsumerARN`, `ConsumerCreationTimestamp`, `ConsumerStatus` |
 | `AWS::KinesisFirehose::DeliveryStream` | `Arn` |
-| `AWS::Lambda::EventSourceMapping` | `EventSourceMappingArn`, `Id` |
+| `AWS::Lambda::EventSourceMapping` | `EventSourceMappingArn` |
 | `AWS::Lambda::Function` | `Arn`, `SnapStartResponse` |
 | `AWS::Lambda::LayerVersion` | `LayerVersionArn` |
 | `AWS::Lambda::MicrovmImage` | `CreatedAt`, `LatestActiveImageVersion`, `LatestFailedImageVersion`, `State`, `UpdatedAt` |
@@ -230,7 +230,7 @@ SDK-backed types whose computed attribute is unenriched: only exposed on the #61
 | `AWS::KMS::Alias` | yes | no-computed-attr | _(none)_ |
 | `AWS::KMS::Key` | yes | enriched | `Arn` (OK), `KeyId` (OK) |
 | `AWS::Lambda::EventInvokeConfig` | yes | no-computed-attr | _(none)_ |
-| `AWS::Lambda::EventSourceMapping` | yes | sdk-fallback-gap | `EventSourceMappingArn` (GAP), `Id` (GAP) |
+| `AWS::Lambda::EventSourceMapping` | yes | sdk-fallback-gap | `EventSourceMappingArn` (GAP), `Id` (allow) |
 | `AWS::Lambda::Function` | yes | sdk-fallback-gap | `Arn` (GAP), `SnapStartResponse` (GAP) |
 | `AWS::Lambda::LayerVersion` | yes | sdk-fallback-gap | `LayerVersionArn` (GAP) |
 | `AWS::Lambda::MicrovmImage` | yes | sdk-fallback-gap | `CreatedAt` (GAP), `ImageArn` (allow), `LatestActiveImageVersion` (GAP), `LatestFailedImageVersion` (GAP), `State` (GAP), `UpdatedAt` (GAP) |

--- a/docs/_generated/nested-key-coverage.json
+++ b/docs/_generated/nested-key-coverage.json
@@ -1,16 +1,16 @@
 {
   "summary": {
-    "targetCount": 14,
-    "nestedKeyCount": 837,
-    "sameSpelling": 767,
-    "providerHandled": 50,
-    "allowListed": 20,
+    "targetCount": 15,
+    "nestedKeyCount": 874,
+    "sameSpelling": 801,
+    "providerHandled": 51,
+    "allowListed": 22,
     "caseDivergence": 0,
     "noSdkMember": 0,
     "noWriteEvidence": 0,
     "freshObjectTargets": 14,
-    "shapeClean": 90,
-    "shapeHandled": 35,
+    "shapeClean": 98,
+    "shapeHandled": 36,
     "shapeAllowListed": 7,
     "arrayVsWrapper": 0,
     "definitionMemberMissing": 0,
@@ -4998,6 +4998,301 @@
       "usedTerminalRenames": [
         "ProxyConfiguration.ProxyConfigurationProperties"
       ]
+    },
+    {
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "providerFile": "lambda-eventsource-provider.ts",
+      "sdkClientPackage": "@aws-sdk/client-lambda",
+      "keyStyle": "exact",
+      "freshObjectMapper": false,
+      "nestedKeyCount": 37,
+      "entries": [
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "AmazonManagedKafkaEventSourceConfig.ConsumerGroupId",
+          "topLevelProperty": "AmazonManagedKafkaEventSourceConfig",
+          "terminalKey": "ConsumerGroupId",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "AmazonManagedKafkaEventSourceConfig.SchemaRegistryConfig",
+          "topLevelProperty": "AmazonManagedKafkaEventSourceConfig",
+          "terminalKey": "SchemaRegistryConfig",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "AmazonManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs",
+          "topLevelProperty": "AmazonManagedKafkaEventSourceConfig",
+          "terminalKey": "AccessConfigs",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "AmazonManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.Type",
+          "topLevelProperty": "AmazonManagedKafkaEventSourceConfig",
+          "terminalKey": "Type",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "AmazonManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URI",
+          "topLevelProperty": "AmazonManagedKafkaEventSourceConfig",
+          "terminalKey": "URI",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "AmazonManagedKafkaEventSourceConfig.SchemaRegistryConfig.EventRecordFormat",
+          "topLevelProperty": "AmazonManagedKafkaEventSourceConfig",
+          "terminalKey": "EventRecordFormat",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "AmazonManagedKafkaEventSourceConfig.SchemaRegistryConfig.SchemaRegistryURI",
+          "topLevelProperty": "AmazonManagedKafkaEventSourceConfig",
+          "terminalKey": "SchemaRegistryURI",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "AmazonManagedKafkaEventSourceConfig.SchemaRegistryConfig.SchemaValidationConfigs",
+          "topLevelProperty": "AmazonManagedKafkaEventSourceConfig",
+          "terminalKey": "SchemaValidationConfigs",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "AmazonManagedKafkaEventSourceConfig.SchemaRegistryConfig.SchemaValidationConfigs.Attribute",
+          "topLevelProperty": "AmazonManagedKafkaEventSourceConfig",
+          "terminalKey": "Attribute",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "DestinationConfig.OnFailure",
+          "topLevelProperty": "DestinationConfig",
+          "terminalKey": "OnFailure",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "DestinationConfig.OnFailure.Destination",
+          "topLevelProperty": "DestinationConfig",
+          "terminalKey": "Destination",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "DocumentDBEventSourceConfig.CollectionName",
+          "topLevelProperty": "DocumentDBEventSourceConfig",
+          "terminalKey": "CollectionName",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "DocumentDBEventSourceConfig.DatabaseName",
+          "topLevelProperty": "DocumentDBEventSourceConfig",
+          "terminalKey": "DatabaseName",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "DocumentDBEventSourceConfig.FullDocument",
+          "topLevelProperty": "DocumentDBEventSourceConfig",
+          "terminalKey": "FullDocument",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "FilterCriteria.Filters",
+          "topLevelProperty": "FilterCriteria",
+          "terminalKey": "Filters",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "FilterCriteria.Filters.Pattern",
+          "topLevelProperty": "FilterCriteria",
+          "terminalKey": "Pattern",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "LoggingConfig.SystemLogLevel",
+          "topLevelProperty": "LoggingConfig",
+          "terminalKey": "SystemLogLevel",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "MetricsConfig.Metrics",
+          "topLevelProperty": "MetricsConfig",
+          "terminalKey": "Metrics",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "ProvisionedPollerConfig.MaximumPollers",
+          "topLevelProperty": "ProvisionedPollerConfig",
+          "terminalKey": "MaximumPollers",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "ProvisionedPollerConfig.MinimumPollers",
+          "topLevelProperty": "ProvisionedPollerConfig",
+          "terminalKey": "MinimumPollers",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "ProvisionedPollerConfig.PollerGroupName",
+          "topLevelProperty": "ProvisionedPollerConfig",
+          "terminalKey": "PollerGroupName",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "ScalingConfig.MaximumConcurrency",
+          "topLevelProperty": "ScalingConfig",
+          "terminalKey": "MaximumConcurrency",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SelfManagedEventSource.Endpoints",
+          "topLevelProperty": "SelfManagedEventSource",
+          "terminalKey": "Endpoints",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SelfManagedEventSource.Endpoints.KafkaBootstrapServers",
+          "topLevelProperty": "SelfManagedEventSource",
+          "terminalKey": "KafkaBootstrapServers",
+          "bucket": "provider-handled"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SelfManagedKafkaEventSourceConfig.ConsumerGroupId",
+          "topLevelProperty": "SelfManagedKafkaEventSourceConfig",
+          "terminalKey": "ConsumerGroupId",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig",
+          "topLevelProperty": "SelfManagedKafkaEventSourceConfig",
+          "terminalKey": "SchemaRegistryConfig",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs",
+          "topLevelProperty": "SelfManagedKafkaEventSourceConfig",
+          "terminalKey": "AccessConfigs",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.Type",
+          "topLevelProperty": "SelfManagedKafkaEventSourceConfig",
+          "terminalKey": "Type",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.AccessConfigs.URI",
+          "topLevelProperty": "SelfManagedKafkaEventSourceConfig",
+          "terminalKey": "URI",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.EventRecordFormat",
+          "topLevelProperty": "SelfManagedKafkaEventSourceConfig",
+          "terminalKey": "EventRecordFormat",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.SchemaRegistryURI",
+          "topLevelProperty": "SelfManagedKafkaEventSourceConfig",
+          "terminalKey": "SchemaRegistryURI",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.SchemaValidationConfigs",
+          "topLevelProperty": "SelfManagedKafkaEventSourceConfig",
+          "terminalKey": "SchemaValidationConfigs",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SelfManagedKafkaEventSourceConfig.SchemaRegistryConfig.SchemaValidationConfigs.Attribute",
+          "topLevelProperty": "SelfManagedKafkaEventSourceConfig",
+          "terminalKey": "Attribute",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SourceAccessConfigurations.Type",
+          "topLevelProperty": "SourceAccessConfigurations",
+          "terminalKey": "Type",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "SourceAccessConfigurations.URI",
+          "topLevelProperty": "SourceAccessConfigurations",
+          "terminalKey": "URI",
+          "bucket": "same-spelling"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "Tags.Key",
+          "topLevelProperty": "Tags",
+          "terminalKey": "Key",
+          "bucket": "allow-listed",
+          "sdkNearMiss": "KEY",
+          "rationale": "Same list-to-map fold as the AppSync entries: Lambda models an event source mapping's tags as a flat Record<string, string> (`Tags`), not as CFn's [{Key, Value}] list, and the provider folds the list into that map on create (`Object.fromEntries(cfnTags.map((t) => [t.Key, t.Value]))`). No `Key` member exists anywhere in the SDK model to spell-match. READ THE VERDICT WITH CARE: the key pass reports this as `case-divergence` (\"SDK has KEY\") rather than `no-sdk-member`, because the member index also carries enum const-object keys and `@aws-sdk/client-lambda`'s `KafkaSchemaValidationAttribute` declares `KEY` / `VALUE` — a Kafka schema-validation attribute with nothing to do with tagging. A case fold would NOT fix this key; there is no member to fold onto.",
+          "allowMatchKey": "AWS::Lambda::EventSourceMapping#Tags.Key"
+        },
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "Tags.Value",
+          "topLevelProperty": "Tags",
+          "terminalKey": "Value",
+          "bucket": "allow-listed",
+          "sdkNearMiss": "VALUE",
+          "rationale": "Same list-to-map fold as Tags.Key, and the same spurious enum near-miss — `VALUE` is the other `KafkaSchemaValidationAttribute` member, not a tag member the provider could write.",
+          "allowMatchKey": "AWS::Lambda::EventSourceMapping#Tags.Value"
+        }
+      ],
+      "shapeEntries": [
+        {
+          "resourceType": "AWS::Lambda::EventSourceMapping",
+          "nestedKey": "Tags",
+          "definition": "#top",
+          "pass": "wrapper",
+          "bucket": "provider-handled"
+        }
+      ],
+      "shapeCleanCount": 8,
+      "unmatchedDefinitions": [
+        "Endpoints",
+        "MetricsConfig",
+        "SchemaRegistryAccessConfig",
+        "SchemaRegistryConfig",
+        "SchemaValidationConfig",
+        "Tag"
+      ],
+      "usedSegmentRenames": [],
+      "usedTerminalRenames": []
     },
     {
       "resourceType": "AWS::S3::Bucket",

--- a/docs/_generated/nested-key-coverage.md
+++ b/docs/_generated/nested-key-coverage.md
@@ -7,17 +7,17 @@ For every SDK provider that forwards a nested CFn config blob, diffs the blob's 
 
 ## Summary
 
-- Audited targets: **14**
-- Nested CFn key paths audited: **837**
-- Same spelling in SDK model: **767**
-- Explicitly handled in provider: **50**
-- Allow-listed pass-throughs (does NOT block CI): **20**
+- Audited targets: **15**
+- Nested CFn key paths audited: **874**
+- Same spelling in SDK model: **801**
+- Explicitly handled in provider: **51**
+- Allow-listed pass-throughs (does NOT block CI): **22**
 - **Case divergences (blocks CI): 0**
 - **No SDK member (blocks CI): 0**
 - Write-evidence pass — fresh-object targets audited: **14**
 - **No write evidence (blocks CI): 0**
-- Shape pass — bare-array pairs clean: **90**
-- Shape pass — explicitly handled in provider: **35**
+- Shape pass — bare-array pairs clean: **98**
+- Shape pass — explicitly handled in provider: **36**
 - Shape pass — allow-listed (does NOT block CI): **7**
 - **Array-vs-wrapper divergences (blocks CI): 0**
 - **Definition-member-missing divergences (blocks CI): 0**
@@ -45,6 +45,8 @@ None. Every audited nested CFn key either matches an SDK member spelling or is e
 | `AWS::CodeBuild::Project` | `Environment.HostKernel` | Declared in the CFn registry schema but has NO member anywhere in the installed @aws-sdk/client-codebuild dist-types tree, so there is nothing to map it onto until an SDK bump adds one (issue #1386). Naming it in the provider would be a false claim of support. Remove this entry once the SDK ships the member, at which point the key becomes genuinely mappable. |
 | `AWS::ECS::Service` | `ForceNewDeployment.EnableForceNewDeployment` | CFn-only rollout-trigger member with NO per-member SDK counterpart: the ECS SDK models the whole ForceNewDeployment block as the single top-level boolean `forceNewDeployment` on UpdateService. ECSProvider.resolveForceNewDeployment translates {EnableForceNewDeployment: true} OR a ForceNewDeploymentNonce change into `forceNewDeployment: true` (issue #609) — a shape collapse neither the key pass (no same-spelled member exists) nor the write pass (the write is a different, top-level member) can express. |
 | `AWS::ECS::Service` | `ForceNewDeployment.ForceNewDeploymentNonce` | Same single-boolean collapse as ForceNewDeployment.EnableForceNewDeployment: the nonce has no SDK member of its own — a nonce CHANGE is what resolveForceNewDeployment turns into `forceNewDeployment: true` (issue #609). |
+| `AWS::Lambda::EventSourceMapping` | `Tags.Key` | Same list-to-map fold as the AppSync entries: Lambda models an event source mapping's tags as a flat Record<string, string> (`Tags`), not as CFn's [{Key, Value}] list, and the provider folds the list into that map on create (`Object.fromEntries(cfnTags.map((t) => [t.Key, t.Value]))`). No `Key` member exists anywhere in the SDK model to spell-match. READ THE VERDICT WITH CARE: the key pass reports this as `case-divergence` ("SDK has KEY") rather than `no-sdk-member`, because the member index also carries enum const-object keys and `@aws-sdk/client-lambda`'s `KafkaSchemaValidationAttribute` declares `KEY` / `VALUE` — a Kafka schema-validation attribute with nothing to do with tagging. A case fold would NOT fix this key; there is no member to fold onto. |
+| `AWS::Lambda::EventSourceMapping` | `Tags.Value` | Same list-to-map fold as Tags.Key, and the same spurious enum near-miss — `VALUE` is the other `KafkaSchemaValidationAttribute` member, not a tag member the provider could write. |
 | `AWS::S3::Bucket` | `CorsConfiguration.CorsRules` | Delivered by applyCorsConfiguration, which reads the CFn key via typed property access (`corsConfig.CorsRules.map(...)`) and writes the SDK spelling `CORSRules` — the literal walk deliberately counts neither a property ACCESS nor a type-literal member, and the only literal mention of the CFn spelling is `readCors`, excluded as a reverse map by the #1520 widening. Key pass only; the members BENEATH it need no entry — the per-level case fold resolves `CorsConfiguration.CorsRules` onto the written `CORSConfiguration.CORSRules` scope, so they stay write-audited (issue #1520). |
 | `AWS::S3::Bucket` | `LifecycleConfiguration.Rules.TagFilters` | Forwarded verbatim into `Filter{,.And}.Tags` by applyLifecycleConfiguration through the destructured-gatherScope shape the hand-off taint walk deliberately does not cross — same class as the `LifecycleConfiguration.Rules.TagFilters.Key` / `.Value` write-pass entries, here for the ARRAY itself on the key pass (issue #1393). The per-item config families (Analytics / Metrics / IntelligentTiering) resolve via declared terminal renames and need no entry. |
 | `AWS::S3::Bucket` | `LifecycleConfiguration.Rules.TagFilters.Key` | Forwarded verbatim into `Filter{,.And}.Tags` by applyLifecycleConfiguration, but through a chain the hand-off taint walk deliberately does not cross: the array reaches the write as a DESTRUCTURED member of the in-method `gatherScope` helper's returned literal, and member-level taint through a returned literal is a materially bigger analysis (issue #1540; same wrapper-level class as the CloudFront `Tags.Key` / `Tags.Value` entries). The equivalent per-item-config forwards (Analytics / Metrics / IntelligentTiering) ARE wildcard-credited via the for-of taint hop. |
@@ -80,6 +82,7 @@ Keys with no same-spelling SDK member that the provider explicitly names (conver
 | `AWS::ECS::TaskDefinition` | `Volumes.EFSVolumeConfiguration.FilesystemId` |
 | `AWS::ECS::TaskDefinition` | `Volumes.FSxWindowsFileServerVolumeConfiguration` |
 | `AWS::ECS::TaskDefinition` | `Volumes.S3FilesVolumeConfiguration` |
+| `AWS::Lambda::EventSourceMapping` | `SelfManagedEventSource.Endpoints.KafkaBootstrapServers` |
 | `AWS::S3::Bucket` | `AccelerateConfiguration.AccelerationStatus` |
 | `AWS::S3::Bucket` | `AnalyticsConfigurations.TagFilters` |
 | `AWS::S3::Bucket` | `BucketEncryption.ServerSideEncryptionConfiguration.ServerSideEncryptionByDefault` |
@@ -143,6 +146,7 @@ CFn members whose SHAPE diverges from the same-spelled SDK member (bare array vs
 | `AWS::CloudFront::Distribution` | `ForwardedValues` | `QueryStringCacheKeys` | wrapper | SDK wraps it as `QueryStringCacheKeys` ({ Quantity, Items }) |
 | `AWS::CloudFront::Distribution` | `GeoRestriction` | `Locations` | definition | SDK interface `GeoRestriction` has no `Locations` member |
 | `AWS::ECS::Service` | `DeploymentLifecycleHook` | `HookDetails` | wrapper | — |
+| `AWS::Lambda::EventSourceMapping` | `#top` | `Tags` | wrapper | — |
 | `AWS::S3::Bucket` | `Destination` | `BucketArn` | definition | SDK interface `Destination` has no `BucketArn` member |
 | `AWS::S3::Bucket` | `Destination` | `BucketAccountId` | definition | SDK interface `Destination` has no `BucketAccountId` member |
 | `AWS::S3::Bucket` | `Destination` | `Format` | definition | SDK interface `Destination` has no `Format` member |
@@ -175,5 +179,6 @@ CFn members whose SHAPE diverges from the same-spelled SDK member (bare array vs
 | `AWS::CodeBuild::Project` | `codebuild-provider.ts` | `@aws-sdk/client-codebuild` | lower-first | yes | 98 | 4 |
 | `AWS::ECS::Service` | `ecs-provider.ts` | `@aws-sdk/client-ecs` | lower-first | yes | 114 | 4 |
 | `AWS::ECS::TaskDefinition` | `ecs-provider.ts` | `@aws-sdk/client-ecs` | lower-first | yes | 142 | 3 |
+| `AWS::Lambda::EventSourceMapping` | `lambda-eventsource-provider.ts` | `@aws-sdk/client-lambda` | exact | no | 37 | 6 |
 | `AWS::S3::Bucket` | `s3-bucket-provider.ts` | `@aws-sdk/client-s3` | exact | yes | 190 | 15 |
 

--- a/scripts/gen-nested-key-coverage.ts
+++ b/scripts/gen-nested-key-coverage.ts
@@ -344,8 +344,19 @@
  *   AWS::AppSync::GraphQLApi            0 /  33   0 /  33    0 /  33    0 /  33  OPTED IN (#609)
  *   AWS::AppSync::DataSource           10 /  27  10 /  27   10 /  27   10 /  27  OPTED IN (#1597) [all 10 FIXED in the provider, now 0/27]
  *   AWS::AppSync::Resolver              0 /   9   0 /   9    0 /   9    0 /   9  OPTED IN (#1597)
+ *   AWS::Lambda::EventSourceMapping     0 /  37   0 /  37    0 /  37    0 /  37  key pass only (#1393 item 3)
  *                                     -------   -------    -------    -------
  *                                        410       290        260         81
+ *
+ * The `AWS::Lambda::EventSourceMapping` row (issue #1393 item 3) is flat for a
+ * different reason, and it is NOT opted into the write-evidence pass: the
+ * provider forwards each config blob VERBATIM (`params.X = properties['X'] as
+ * <SdkType>`) rather than hand-building an SDK object, so the top-level member
+ * write already vouches for every path beneath it and the pass has nothing to
+ * find — 0/37 even when forced on, which is the measurement the calibration
+ * test pins. For a verbatim forwarder the KEY pass is the whole audit: a
+ * CFn-side member the SDK spells differently rides the cast to AWS as an
+ * unknown key with no code change to notice it.
  *
  * The three AppSync rows joined AFTER the four recognizer stages, so their
  * columns are flat (no stage moves them) and they are excluded from the stage
@@ -1655,6 +1666,42 @@ export const NESTED_KEY_TARGETS: readonly NestedKeyTarget[] = [
     segmentRenames: S3_BUCKET_SEGMENT_RENAMES,
     terminalRenames: S3_BUCKET_TERMINAL_RENAMES,
   },
+  {
+    // Opted in by issue #1393 item 3, after
+    // `node scripts/refresh-cfn-schemas.mjs AWS::Lambda::EventSourceMapping`
+    // re-captured the fixture with the `definitionShapes` /
+    // `nestedPropertyPaths` sections the generator requires (the old capture
+    // pre-dated both, the same blocker the AppSync opt-ins hit).
+    //
+    // This target is a FENCE, not a bug hunt, and #1393's own first comment
+    // says so: the #1384 defect it grew out of (`Endpoints` is a map keyed by
+    // an ENUM value, so there is no `KafkaBootstrapServers` member to miss)
+    // is structurally invisible to a critic that compares model member NAMES,
+    // and opting in does not close that class. What the opt-in DOES fence is
+    // the provider's seven other forwarded blobs —
+    // `SelfManagedKafkaEventSourceConfig`, `AmazonManagedKafkaEventSourceConfig`,
+    // `DocumentDBEventSourceConfig`, `ScalingConfig`, `DestinationConfig`,
+    // `LoggingConfig`, `MetricsConfig`, `ProvisionedPollerConfig` — every one
+    // of which the provider forwards VERBATIM (`params.X = properties['X'] as
+    // <SdkType>`), so a CFn-side member the SDK spells differently reaches AWS
+    // as an unknown key with no code change to notice it.
+    //
+    // Measured at opt-in: 37 audited paths, 34 same-spelling, 1 explicitly
+    // handled (`SelfManagedEventSource.Endpoints.KafkaBootstrapServers`), 2
+    // allow-listed (`Tags.Key` / `Tags.Value` — see their entries), 0 blocking
+    // findings.
+    //
+    // NOT a `freshObjectMapper`: the write-evidence pass asks "does the
+    // provider WRITE the SDK member", which only means something where the
+    // provider hand-builds the SDK object. Here the blobs are cast
+    // pass-throughs, so the key pass IS the audit and a write floor would
+    // fence nothing.
+    resourceType: 'AWS::Lambda::EventSourceMapping',
+    providerFile: 'lambda-eventsource-provider.ts',
+    sdkClientPackage: '@aws-sdk/client-lambda',
+    keyStyle: 'exact',
+    minNestedKeys: 30,
+  },
 ];
 
 /**
@@ -1825,6 +1872,34 @@ export const NESTED_KEY_ALLOW_LIST: ReadonlyMap<string, AllowListEntry> = new Ma
       rationale:
         'Same list-to-map fold as Tags.Key: the CFn tag list becomes the SDK `tags` ' +
         'Record<string, string>, so no `Value` member exists on the SDK side.',
+      passes: ['key', 'shape', 'write'],
+    },
+  ],
+  [
+    allowKey('AWS::Lambda::EventSourceMapping', 'Tags.Key'),
+    {
+      rationale:
+        "Same list-to-map fold as the AppSync entries: Lambda models an event source " +
+        "mapping's tags as a flat Record<string, string> (`Tags`), not as CFn's " +
+        '[{Key, Value}] list, and the provider folds the list into that map on create ' +
+        '(`Object.fromEntries(cfnTags.map((t) => [t.Key, t.Value]))`). No `Key` member ' +
+        'exists anywhere in the SDK model to spell-match. ' +
+        'READ THE VERDICT WITH CARE: the key pass reports this as `case-divergence` ' +
+        '("SDK has KEY") rather than `no-sdk-member`, because the member index also ' +
+        "carries enum const-object keys and `@aws-sdk/client-lambda`'s " +
+        '`KafkaSchemaValidationAttribute` declares `KEY` / `VALUE` — a Kafka ' +
+        'schema-validation attribute with nothing to do with tagging. A case fold ' +
+        'would NOT fix this key; there is no member to fold onto.',
+      passes: ['key', 'shape', 'write'],
+    },
+  ],
+  [
+    allowKey('AWS::Lambda::EventSourceMapping', 'Tags.Value'),
+    {
+      rationale:
+        'Same list-to-map fold as Tags.Key, and the same spurious enum near-miss — ' +
+        '`VALUE` is the other `KafkaSchemaValidationAttribute` member, not a tag ' +
+        'member the provider could write.',
       passes: ['key', 'shape', 'write'],
     },
   ],

--- a/scripts/gen-nested-key-coverage.ts
+++ b/scripts/gen-nested-key-coverage.ts
@@ -349,7 +349,10 @@
  *                                        410       290        260         81
  *
  * The `AWS::Lambda::EventSourceMapping` row (issue #1393 item 3) is flat for a
- * different reason, and it is NOT opted into the write-evidence pass: the
+ * different reason, and it is NOT opted into the write-evidence pass — so its
+ * denominator is the TOTAL audited path count (37), not the write-audited
+ * subset the opted-in rows use. It is excluded from the stage totals for the
+ * same reason the AppSync rows are: no stage moves it. The
  * provider forwards each config blob VERBATIM (`params.X = properties['X'] as
  * <SdkType>`) rather than hand-building an SDK object, so the top-level member
  * write already vouches for every path beneath it and the pass has nothing to
@@ -359,8 +362,9 @@
  * unknown key with no code change to notice it.
  *
  * The three AppSync rows joined AFTER the four recognizer stages, so their
- * columns are flat (no stage moves them) and they are excluded from the stage
- * totals above. Flat does NOT mean zero, and the split is the point:
+ * columns are flat (no stage moves them) and they — like the EventSourceMapping
+ * row above, four excluded rows in total — are excluded from the stage totals
+ * above. Flat does NOT mean zero, and the split is the point:
  * `GraphQLApi` and `Resolver` measured 0 on their first run because the #609
  * backfill had already wired every member (31 of GraphQLApi's 33 paths are
  * same-spelling WITH scoped write evidence; its 2 `Tags.*` paths are
@@ -5129,8 +5133,22 @@ export function classifyTarget(
       // A target WITHOUT the write-evidence opt-in keeps the file-global
       // rescue: there is no scope index to check against, and inventing one
       // from nothing would flag every key of a legitimately blob-forwarding
-      // provider. All current targets have opted in, so the loose path is
-      // future-target fallback only.
+      // provider.
+      //
+      // This path is LIVE, not a future-target fallback: since issue #1393
+      // item 3, `AWS::Lambda::EventSourceMapping` is a target that
+      // deliberately does not opt in (its blobs are verbatim casts, so the
+      // write pass measures 0/37 — see its entry in NESTED_KEY_TARGETS), and
+      // its ONE `provider-handled` verdict
+      // (`SelfManagedEventSource.Endpoints.KafkaBootstrapServers`) rests on
+      // exactly this rescue — under a FORCED opt-in the same key reports
+      // `no-sdk-member`. That is the intended reading for a #1384-class key
+      // (a map keyed by an enum value has no member to write), but it means
+      // the loose path's known weakness applies to that target: a future
+      // nested member sharing the name of any PascalCase literal already in
+      // the provider file would be rescued without per-key evidence. Scope it
+      // by opting the target in, or by a path-scoped allow-list entry, if
+      // that ever stops being acceptable.
       const near = sdkLower.get(key.toLowerCase());
       const allowed = lookupAllowEntry(allowList, target.resourceType, path, key, 'key');
       let literalRescued: boolean;

--- a/scripts/gen-nested-key-coverage.ts
+++ b/scripts/gen-nested-key-coverage.ts
@@ -1682,7 +1682,7 @@ export const NESTED_KEY_TARGETS: readonly NestedKeyTarget[] = [
     // an ENUM value, so there is no `KafkaBootstrapServers` member to miss)
     // is structurally invisible to a critic that compares model member NAMES,
     // and opting in does not close that class. What the opt-in DOES fence is
-    // the provider's seven other forwarded blobs —
+    // the provider's eight other forwarded blobs —
     // `SelfManagedKafkaEventSourceConfig`, `AmazonManagedKafkaEventSourceConfig`,
     // `DocumentDBEventSourceConfig`, `ScalingConfig`, `DestinationConfig`,
     // `LoggingConfig`, `MetricsConfig`, `ProvisionedPollerConfig` — every one

--- a/tests/fixtures/cfn-schemas/AWS-Lambda-EventSourceMapping.json
+++ b/tests/fixtures/cfn-schemas/AWS-Lambda-EventSourceMapping.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "AWS::Lambda::EventSourceMapping",
-  "generatedAt": "2026-05-16",
+  "generatedAt": "2026-08-12",
   "properties": [
     "AmazonManagedKafkaEventSourceConfig",
     "BatchSize",
@@ -42,5 +42,234 @@
     "SelfManagedEventSource",
     "StartingPosition",
     "StartingPositionTimestamp"
-  ]
+  ],
+  "primaryIdentifier": [
+    "Id"
+  ],
+  "nestedProperties": {
+    "SelfManagedEventSource": [
+      "Endpoints",
+      "KafkaBootstrapServers"
+    ],
+    "FilterCriteria": [
+      "Filters",
+      "Pattern"
+    ],
+    "ProvisionedPollerConfig": [
+      "MaximumPollers",
+      "MinimumPollers",
+      "PollerGroupName"
+    ],
+    "MetricsConfig": [
+      "Metrics"
+    ],
+    "DestinationConfig": [
+      "Destination",
+      "OnFailure"
+    ],
+    "AmazonManagedKafkaEventSourceConfig": [
+      "AccessConfigs",
+      "Attribute",
+      "ConsumerGroupId",
+      "EventRecordFormat",
+      "SchemaRegistryConfig",
+      "SchemaRegistryURI",
+      "SchemaValidationConfigs",
+      "Type",
+      "URI"
+    ],
+    "SourceAccessConfigurations": [
+      "Type",
+      "URI"
+    ],
+    "Tags": [
+      "Key",
+      "Value"
+    ],
+    "ScalingConfig": [
+      "MaximumConcurrency"
+    ],
+    "SelfManagedKafkaEventSourceConfig": [
+      "AccessConfigs",
+      "Attribute",
+      "ConsumerGroupId",
+      "EventRecordFormat",
+      "SchemaRegistryConfig",
+      "SchemaRegistryURI",
+      "SchemaValidationConfigs",
+      "Type",
+      "URI"
+    ],
+    "DocumentDBEventSourceConfig": [
+      "CollectionName",
+      "DatabaseName",
+      "FullDocument"
+    ],
+    "LoggingConfig": [
+      "SystemLogLevel"
+    ]
+  },
+  "nestedPropertyPaths": {
+    "SelfManagedEventSource": [
+      "Endpoints",
+      "Endpoints.KafkaBootstrapServers"
+    ],
+    "FilterCriteria": [
+      "Filters",
+      "Filters.Pattern"
+    ],
+    "ProvisionedPollerConfig": [
+      "MaximumPollers",
+      "MinimumPollers",
+      "PollerGroupName"
+    ],
+    "MetricsConfig": [
+      "Metrics"
+    ],
+    "DestinationConfig": [
+      "OnFailure",
+      "OnFailure.Destination"
+    ],
+    "AmazonManagedKafkaEventSourceConfig": [
+      "ConsumerGroupId",
+      "SchemaRegistryConfig",
+      "SchemaRegistryConfig.AccessConfigs",
+      "SchemaRegistryConfig.AccessConfigs.Type",
+      "SchemaRegistryConfig.AccessConfigs.URI",
+      "SchemaRegistryConfig.EventRecordFormat",
+      "SchemaRegistryConfig.SchemaRegistryURI",
+      "SchemaRegistryConfig.SchemaValidationConfigs",
+      "SchemaRegistryConfig.SchemaValidationConfigs.Attribute"
+    ],
+    "SourceAccessConfigurations": [
+      "Type",
+      "URI"
+    ],
+    "Tags": [
+      "Key",
+      "Value"
+    ],
+    "ScalingConfig": [
+      "MaximumConcurrency"
+    ],
+    "SelfManagedKafkaEventSourceConfig": [
+      "ConsumerGroupId",
+      "SchemaRegistryConfig",
+      "SchemaRegistryConfig.AccessConfigs",
+      "SchemaRegistryConfig.AccessConfigs.Type",
+      "SchemaRegistryConfig.AccessConfigs.URI",
+      "SchemaRegistryConfig.EventRecordFormat",
+      "SchemaRegistryConfig.SchemaRegistryURI",
+      "SchemaRegistryConfig.SchemaValidationConfigs",
+      "SchemaRegistryConfig.SchemaValidationConfigs.Attribute"
+    ],
+    "DocumentDBEventSourceConfig": [
+      "CollectionName",
+      "DatabaseName",
+      "FullDocument"
+    ],
+    "LoggingConfig": [
+      "SystemLogLevel"
+    ]
+  },
+  "definitionShapes": {
+    "#top": {
+      "StartingPosition": "scalar",
+      "SelfManagedEventSource": "object",
+      "ParallelizationFactor": "scalar",
+      "FilterCriteria": "object",
+      "ProvisionedPollerConfig": "object",
+      "MetricsConfig": "object",
+      "FunctionName": "scalar",
+      "DestinationConfig": "object",
+      "KmsKeyArn": "scalar",
+      "AmazonManagedKafkaEventSourceConfig": "object",
+      "SourceAccessConfigurations": "array",
+      "Tags": "array",
+      "MaximumBatchingWindowInSeconds": "scalar",
+      "BatchSize": "scalar",
+      "MaximumRetryAttempts": "scalar",
+      "Topics": "array",
+      "ScalingConfig": "object",
+      "Enabled": "scalar",
+      "EventSourceArn": "scalar",
+      "SelfManagedKafkaEventSourceConfig": "object",
+      "DocumentDBEventSourceConfig": "object",
+      "TumblingWindowInSeconds": "scalar",
+      "BisectBatchOnFunctionError": "scalar",
+      "EventSourceMappingArn": "scalar",
+      "MaximumRecordAgeInSeconds": "scalar",
+      "StartingPositionTimestamp": "scalar",
+      "LoggingConfig": "object",
+      "Queues": "array",
+      "Id": "scalar",
+      "FunctionResponseTypes": "array"
+    },
+    "ScalingConfig": {
+      "MaximumConcurrency": "scalar"
+    },
+    "SchemaRegistryConfig": {
+      "SchemaValidationConfigs": "array",
+      "SchemaRegistryURI": "scalar",
+      "EventRecordFormat": "scalar",
+      "AccessConfigs": "array"
+    },
+    "SelfManagedEventSource": {
+      "Endpoints": "object"
+    },
+    "SourceAccessConfiguration": {
+      "Type": "scalar",
+      "URI": "scalar"
+    },
+    "FilterCriteria": {
+      "Filters": "array"
+    },
+    "ProvisionedPollerConfig": {
+      "PollerGroupName": "scalar",
+      "MinimumPollers": "scalar",
+      "MaximumPollers": "scalar"
+    },
+    "SelfManagedKafkaEventSourceConfig": {
+      "ConsumerGroupId": "scalar",
+      "SchemaRegistryConfig": "object"
+    },
+    "MetricsConfig": {
+      "Metrics": "array"
+    },
+    "DocumentDBEventSourceConfig": {
+      "FullDocument": "scalar",
+      "CollectionName": "scalar",
+      "DatabaseName": "scalar"
+    },
+    "Endpoints": {
+      "KafkaBootstrapServers": "array"
+    },
+    "DestinationConfig": {
+      "OnFailure": "object"
+    },
+    "Filter": {
+      "Pattern": "scalar"
+    },
+    "AmazonManagedKafkaEventSourceConfig": {
+      "ConsumerGroupId": "scalar",
+      "SchemaRegistryConfig": "object"
+    },
+    "LoggingConfig": {
+      "SystemLogLevel": "scalar"
+    },
+    "Tag": {
+      "Value": "scalar",
+      "Key": "scalar"
+    },
+    "SchemaValidationConfig": {
+      "Attribute": "scalar"
+    },
+    "SchemaRegistryAccessConfig": {
+      "Type": "scalar",
+      "URI": "scalar"
+    },
+    "OnFailure": {
+      "Destination": "scalar"
+    }
+  }
 }

--- a/tests/unit/scripts/gen-nested-key-coverage.test.ts
+++ b/tests/unit/scripts/gen-nested-key-coverage.test.ts
@@ -3600,12 +3600,17 @@ describe('real-repo audit (regression floors)', () => {
     );
     expect(esm).toBeDefined();
     // Read the floor off the target table rather than restating it, so a
-    // recalibration cannot leave this assertion pinning the old number.
+    // recalibration cannot leave this assertion pinning the old number, and
+    // assert HEADROOM rather than `>=`: `loadReport` already throws below the
+    // floor, so a `>=` here is satisfied by construction. Strict `>` is the
+    // part the generator does not already enforce — it fails if the yield ever
+    // collapses to exactly the floor, which is the shape a partial capture or
+    // a `handledProperties` parse regression would produce.
     const declared = NESTED_KEY_TARGETS.find(
       (t) => t.resourceType === 'AWS::Lambda::EventSourceMapping'
     )!;
-    expect(esm!.nestedKeyCount).toBeGreaterThanOrEqual(declared.minNestedKeys);
-    // The seven verbatim-forwarded blobs the opt-in exists to fence are all
+    expect(esm!.nestedKeyCount).toBeGreaterThan(declared.minNestedKeys);
+    // The eight verbatim-forwarded blobs the opt-in exists to fence are all
     // actually reached — a `handledProperties` parse that lost them would
     // leave this target vacuously clean rather than failing.
     const tops = new Set(esm!.entries.map((e) => e.topLevelProperty));

--- a/tests/unit/scripts/gen-nested-key-coverage.test.ts
+++ b/tests/unit/scripts/gen-nested-key-coverage.test.ts
@@ -3599,7 +3599,12 @@ describe('real-repo audit (regression floors)', () => {
       (t) => t.resourceType === 'AWS::Lambda::EventSourceMapping'
     );
     expect(esm).toBeDefined();
-    expect(esm!.nestedKeyCount).toBeGreaterThanOrEqual(30);
+    // Read the floor off the target table rather than restating it, so a
+    // recalibration cannot leave this assertion pinning the old number.
+    const declared = NESTED_KEY_TARGETS.find(
+      (t) => t.resourceType === 'AWS::Lambda::EventSourceMapping'
+    )!;
+    expect(esm!.nestedKeyCount).toBeGreaterThanOrEqual(declared.minNestedKeys);
     // The seven verbatim-forwarded blobs the opt-in exists to fence are all
     // actually reached — a `handledProperties` parse that lost them would
     // leave this target vacuously clean rather than failing.

--- a/tests/unit/scripts/gen-nested-key-coverage.test.ts
+++ b/tests/unit/scripts/gen-nested-key-coverage.test.ts
@@ -3594,6 +3594,58 @@ describe('real-repo audit (regression floors)', () => {
     expect(bucketOf(s3.entries, 'EventBridgeEnabled')).toBe('allow-listed');
   });
 
+  it('audits the Lambda EventSourceMapping target with a healthy nested-key count (#1393 item 3)', () => {
+    const esm = report.targets.find(
+      (t) => t.resourceType === 'AWS::Lambda::EventSourceMapping'
+    );
+    expect(esm).toBeDefined();
+    expect(esm!.nestedKeyCount).toBeGreaterThanOrEqual(30);
+    // The seven verbatim-forwarded blobs the opt-in exists to fence are all
+    // actually reached — a `handledProperties` parse that lost them would
+    // leave this target vacuously clean rather than failing.
+    const tops = new Set(esm!.entries.map((e) => e.topLevelProperty));
+    for (const blob of [
+      'SelfManagedKafkaEventSourceConfig',
+      'AmazonManagedKafkaEventSourceConfig',
+      'DocumentDBEventSourceConfig',
+      'ScalingConfig',
+      'DestinationConfig',
+      'LoggingConfig',
+      'MetricsConfig',
+      'ProvisionedPollerConfig',
+    ]) {
+      expect(tops.has(blob), blob).toBe(true);
+    }
+  });
+
+  it('keeps the EventSourceMapping target OUT of the write-evidence pass (verbatim forwards)', () => {
+    // The decision the target comment records: the blobs are cast
+    // pass-throughs, so the key pass IS the audit. If a future change makes
+    // the provider hand-build SDK objects, this expectation is the prompt to
+    // re-measure and opt in rather than leave the write pass silently unused.
+    const esm = NESTED_KEY_TARGETS.find(
+      (t) => t.resourceType === 'AWS::Lambda::EventSourceMapping'
+    )!;
+    expect(esm.freshObjectMapper).toBeUndefined();
+    expect(esm.minWrittenMembers).toBeUndefined();
+  });
+
+  it('allow-lists only the two EventSourceMapping Tags paths, for the list-to-map fold', () => {
+    const esm = report.targets.find(
+      (t) => t.resourceType === 'AWS::Lambda::EventSourceMapping'
+    )!;
+    expect(
+      esm.entries.filter((e) => e.bucket === 'allow-listed').map((e) => e.nestedKey).sort()
+    ).toEqual(['Tags.Key', 'Tags.Value']);
+    // The #1384 key stays visible as provider-handled: the provider names the
+    // literal, which is the only evidence available for a map keyed by an
+    // enum value (the class this target deliberately does NOT close).
+    const byPath = new Map(esm.entries.map((e) => [e.nestedKey, e.bucket]));
+    expect(byPath.get('SelfManagedEventSource.Endpoints.KafkaBootstrapServers')).toBe(
+      'provider-handled'
+    );
+  });
+
   it('fences the #1304-fixed AnomalyDetector MetricTimeZone as provider-handled', () => {
     const ad = report.targets.find((t) => t.resourceType === 'AWS::CloudWatch::AnomalyDetector')!;
     expect(bucketOf(ad.entries, 'MetricTimeZone')).toBe('provider-handled');
@@ -3813,6 +3865,13 @@ describe('whole-blob hand-off walk (real repo, issue #1445)', () => {
       'AWS::CloudWatch::AnomalyDetector': 0,
       'AWS::ECS::Service': 0,
       'AWS::ECS::TaskDefinition': 0,
+      // 0 at opt-in (issue #1393 item 3) even under the FORCED fresh-object
+      // pass, which is the measurement that says the real target does not
+      // need it: the provider forwards each blob verbatim
+      // (`params.X = properties['X'] as <SdkType>`), so the top-level member
+      // write vouches for every path beneath it and the write pass has
+      // nothing left to find.
+      'AWS::Lambda::EventSourceMapping': 0,
       // 81 before issue #1520 (segment renames + widened reverse-map
       // exclusion, -> 50), 0 since issue #1540 (builder-behind-binding hop,
       // for-of taint hop, scoped + terminal renames) opted the target in —
@@ -4147,6 +4206,55 @@ describe('whole-blob hand-off walk (real repo, issue #1445)', () => {
           source.replace("        EndTime: toDate(r['EndTime']),\n", '')
         )
       ).toEqual(['Configuration.ExcludedTimeRanges.EndTime']);
+    });
+  });
+
+  describe('the EventSourceMapping opt-in fires on a real divergence (#1393 item 3)', () => {
+    // The target measures 0 findings today, which is exactly the state in
+    // which a fence can be vacuous — so prove the RED direction. The realistic
+    // regression for a VERBATIM forwarder is CFn-side: AWS publishes a nested
+    // member under one of the forwarded blobs whose SDK spelling differs (or
+    // does not exist), and the cast carries it to AWS as an unknown key with
+    // no code change to notice. Injected into a scratch COPY of the fixture
+    // tree via loadReport's fixtureDir seam, with the committed fixture
+    // untouched.
+    const scratch = mkdtempSync(join(tmpdir(), 'cdkd-nkc-esm-'));
+    afterAll(() => rmSync(scratch, { recursive: true, force: true }));
+
+    const withInjectedPath = (name: string, blob: string, path: string): string[] => {
+      const dir = join(scratch, name);
+      cpSync(resolve(repoRoot, 'tests/fixtures/cfn-schemas'), dir, { recursive: true });
+      const file = join(dir, 'AWS-Lambda-EventSourceMapping.json');
+      const fixture = JSON.parse(readFileSync(file, 'utf8')) as {
+        nestedPropertyPaths: Record<string, string[]>;
+      };
+      const before = fixture.nestedPropertyPaths[blob];
+      expect(before, `${blob} missing from the capture — anchor drifted?`).toBeDefined();
+      fixture.nestedPropertyPaths[blob] = [...before!, path];
+      writeFileSync(file, JSON.stringify(fixture, null, 2));
+      const target = NESTED_KEY_TARGETS.find(
+        (t) => t.resourceType === 'AWS::Lambda::EventSourceMapping'
+      )!;
+      return loadReport([target], undefined, undefined, dir)
+        .targets[0]!.entries.filter(
+          (e) => e.bucket === 'case-divergence' || e.bucket === 'no-sdk-member'
+        )
+        .map((e) => `${e.bucket}:${e.nestedKey}`)
+        .sort();
+    };
+
+    it('flags a nested member with NO SDK counterpart under a forwarded blob', () => {
+      expect(withInjectedPath('nomember', 'ScalingConfig', 'MaximumConcurrencyLimit')).toEqual([
+        'no-sdk-member:ScalingConfig.MaximumConcurrencyLimit',
+      ]);
+    });
+
+    it('flags a nested member the SDK spells with different CASE', () => {
+      // `MaximumPollers` exists on the SDK's ProvisionedPollerConfig; a
+      // CFn-side `Maximumpollers` would ride the cast unrecognized.
+      expect(
+        withInjectedPath('casediverge', 'ProvisionedPollerConfig', 'Maximumpollers')
+      ).toEqual(['case-divergence:ProvisionedPollerConfig.Maximumpollers']);
     });
   });
 });


### PR DESCRIPTION
## Summary

Issue (#1393) item 3, one type. `LambdaEventSourceMappingProvider` forwards eight nested config blobs **verbatim** — `params.X = properties['X'] as <SdkType>` for `SelfManagedKafkaEventSourceConfig`, `AmazonManagedKafkaEventSourceConfig`, `DocumentDBEventSourceConfig`, `ScalingConfig`, `DestinationConfig`, `LoggingConfig`, `MetricsConfig`, `ProvisionedPollerConfig` — so a CFn-side member the SDK spells differently rides the cast to AWS as an unknown key, with no code change anywhere for a reviewer to notice. The type was not audited by the nested-key critic at all; now it is.

This is a **fence, not a bug hunt**, and the issue's own first comment says so: the defect it grew out of (#1384) is a map keyed by an enum value, so there is no `KafkaBootstrapServers` member to miss and a critic comparing member NAMES structurally cannot close that class. What the opt-in closes is the next silent drop under any of the eight blobs.

## What landed

- **Re-captured the schema fixture** via `node scripts/refresh-cfn-schemas.mjs AWS::Lambda::EventSourceMapping`. The committed capture pre-dated the `definitionShapes` / `nestedPropertyPaths` sections the generator requires — the same blocker the AppSync opt-ins hit, and the reason only 14 of 134 fixtures are target-eligible today. Purely additive: the top-level `properties` array is unchanged, so there is no `property-coverage` impact.
- **Registered the target** (`keyStyle: 'exact'`, `minNestedKeys: 30`). Measured at opt-in: 37 audited paths — 34 same-spelling, 1 provider-handled, 2 allow-listed, **0 blocking findings**.
- **Deliberately NOT opted into the write-evidence pass.** That pass asks "does the provider WRITE the SDK member", which only means something where the provider hand-builds the object; here the blobs are cast pass-throughs, so the top-level write vouches for everything beneath it. Measured 0/37 even when forced on, and the calibration test pins that number so the decision is re-measured rather than inherited.
- **Two allow-list entries** for `Tags.Key` / `Tags.Value`: Lambda models tags as a flat `Record<string, string>`, so neither member exists on the SDK side (same list-to-map fold as the AppSync entries). Their rationale records something a future reader would otherwise chase: the reported verdict is `case-divergence` ("SDK has KEY"), but `KEY` / `VALUE` are members of the unrelated `KafkaSchemaValidationAttribute` **enum**, not a tag member — no case fold can fix that key because there is nothing to fold onto.
- **A false enrichment gap disappeared as a side effect.** The re-captured fixture carries `primaryIdentifier`, which `gen-enrichment-coverage` auto-classifies as not-a-gap: `Id` IS the primaryIdentifier == physicalId and resolves through the resolver's physicalId fallback. The stale capture lacked the field, so `Id` had been reported as an SDK-fallback gap it never was.

## Test plan

- Three real-repo assertions: healthy audited-path count with all eight forwarded blobs actually reached (a `handledProperties` parse regression would otherwise leave the target vacuously clean), the write-pass opt-out, and exactly two allow-listed paths with the (#1384) key still visible as provider-handled.
- **Two RED probes** through `loadReport`'s `fixtureDir` seam, per the repo's checker rule that a fence measuring zero must be proven to fire: a nested member with no SDK counterpart (`ScalingConfig.MaximumConcurrencyLimit`) surfaces as `no-sdk-member`, and one the SDK spells with different case (`ProvisionedPollerConfig.Maximumpollers`) surfaces as `case-divergence`. Both run against a scratch copy; the committed fixture is untouched.
- `vp run test`: 594 files / 11186 tests pass. `vp run gen:all-matrices` + `vp run audit:coverage:check` clean (the enrichment regen above is committed). Tooling-only change, no `src/**` diff, so no live-AWS test applies — the tool itself was exercised in both write and `--check` mode.

## Follow-ups

- Item 4 of (#1393) is a **strict subset of item 3** and stays open: its only currently-auditable key (`AWS::CodeBuild::Project` `Environment.HostKernel`) is already allow-listed, and the other three need their types brought under the critic first — an entry for an unaudited type silences nothing and would be flagged by the unused-entry staleness fence. Recorded on the issue.
- The fixture re-capture prerequisite for opting an EXISTING type in is currently only discoverable from a code comment; `.claude/rules/providers.md` documents the new-provider path only. Filed as a follow-up rather than edited here, because that file is held by two concurrent lanes.

Refs #1393
