### PR TITLE
chore(rules): name the decision not the mechanism, and define the report shape when a 'now' TODO exists

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -409,16 +409,24 @@ anything non-obvious you learned in memory.
   (the worktree, the deps and the markers are already paid for, and removing it
   and re-creating it later is most of the cost), while a residual in a lane you
   just merged and cleaned up has lost exactly those things and is `next`. Close
-  the run with the handoff line naming the literal next command, and say which
-  `next` items are file-disjoint enough for one fresh run to take together.
-  **This flow is where the handoff line is most likely to be written
-  ambiguously**, because lanes merge at different times: while one lane is still
-  in flight the report is simultaneously "waiting on lane C" and "handing off
-  three issues", and a handoff line phrased as "next session, after lane C
-  merges" collapses the two into "this run continues into them once C lands".
-  Write the start command with NO condition attached, mark it as outside this
-  run, and keep the `next` items off the State line entirely — that line is only
-  for lanes this run is still driving to merge.
+  the run with the **not-this-session line** — the decision first, then the
+  literal command (`Not this session — start a fresh session with: /work-issues`)
+  — and say which `next` items are file-disjoint enough for one fresh run to
+  take together. Do NOT label it "Handoff" or "Next steps": those name how the
+  work moves, not whether this run will do it, which is the one thing the reader
+  needs.
+  **This flow is where that line is most likely to be written ambiguously**,
+  because lanes merge at different times: while one lane is still in flight the
+  report is simultaneously "waiting on lane C" and "handing off three issues",
+  and a line phrased as "next session, after lane C merges" collapses the two
+  into "this run continues into them once C lands". Write the start command with
+  NO condition attached, and keep the `next` items off the State line entirely —
+  that line is only for lanes this run is still driving to merge.
+  Conversely, a `now` item found mid-run (a residual landing in a lane whose
+  worktree is still open) is a commitment this run finishes it: it goes in
+  Remaining work WITH what you are about to do about it, the State line is never
+  STOPPED while it is open, and the verdict is NOT CLOSEABLE naming it. A final
+  report can therefore only ever list `next` items and won't-dos.
 - **This flow parks a LOT, so the State line carries most of its weight.** A
   fan-out run spends most of its wall-clock parked on something: a lane subagent
   still implementing, `gh pr checks --watch` on a lane's CI, a `/run-integ`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,11 +257,25 @@ high.
 
   **Session close** — a one-line verdict: **CLOSEABLE** or **NOT CLOSEABLE (waiting on: ...)** naming the blocker. CLOSEABLE requires ALL of: working tree clean and not on a feature branch left dangling; no open PRs owned by this session; no running background tasks / integs / subagents; no AWS resources pending cleanup; every TODO filed as an issue; and **zero `Session-fit: now` TODOs left open**.
 
-  When `next` TODOs exist, close the report with a **handoff line** — the literal command that starts a fresh session, so resuming costs no thought: e.g. `Handoff (NOT this session): /work-issues` or `Handoff (NOT this session): fix issue #1791 (Effort: M)`. Group the `next` items by whether one fresh session could take them together (file-disjoint lanes) or whether they must be serialized, and say which.
+  When `next` TODOs exist, close the report with a **not-this-session line** — the decision first, then the literal command that starts a fresh session, so resuming costs no thought:
 
-  **The handoff line must be unmistakably OUTSIDE this session's plan, and that is easy to get wrong while the session is still running.** `next` means this session ends without those items — it is a decision, not a queue position, and it holds however long the session continues for other reasons. Two failure modes to avoid, both of which turn the handoff line back into the hesitation it exists to remove:
-  - **Never condition the handoff line on this session's pending work.** "Next session (after lane C merges): /work-issues" reads as *this* session continuing into those items once lane C lands. Write the start command standalone, with no "after X" clause; if the reader has to work out whether the condition is about this session or the next one, the line has failed.
+  ```text
+  Not this session — start a fresh session with: /work-issues
+  Not this session — start a fresh session with: fix issue #1791 (Effort: M)
+  ```
+
+  Group the `next` items by whether one fresh session could take them together (file-disjoint lanes) or whether they must be serialized, and say which. **Label it with the decision, not the mechanism.** Words like "Handoff" or "Next steps" name how the work moves, not whether THIS session will do it, so the reader is left making exactly the call this classification exists to have already made. Lead with "Not this session".
+
+  **The not-this-session line must be unmistakably OUTSIDE this session's plan, and that is easy to get wrong while the session is still running.** `next` means this session ends without those items — it is a decision, not a queue position, and it holds however long the session continues for other reasons. Two failure modes to avoid, both of which turn the line back into the hesitation it exists to remove:
+  - **Never condition it on this session's pending work.** "Next session (after lane C merges): /work-issues" reads as *this* session continuing into those items once lane C lands. Write the start command standalone, with no "after X" clause; if the reader has to work out whether the condition is about this session or the next one, the line has failed.
   - **Never let a `next` item appear on the State line.** WAITING enumerates only what THIS session will still do on its own (a CI run, an integ, a subagent, a merge). A `next` TODO is by definition not one of those. If a `next` item is in the WAITING list, either it was misclassified and belongs in `now`, or the list is wrong.
+
+  **What the report looks like when a `now` item exists.** A `now` TODO is a commitment that this session finishes it, so it changes all three parts of the report together — and the common failure is listing one while still writing CLOSEABLE:
+  - **Remaining work** — list it with its classification and, unlike a `next` item, **what you are about to do about it**: `TODO (issue #N) — <what>. Session-fit: now / Effort: S — <why now>. Doing this next.`
+  - **State** — never STOPPED. Either WAITING (something must finish first, and the line says the `now` item follows it) or you simply keep working and do not end the turn at all. Ending a turn STOPPED with an open `now` is the "stopped with work left undone" failure.
+  - **Session close** — always **NOT CLOSEABLE**, naming the `now` item as the blocker.
+
+  So in a genuinely final report, the Remaining-work section contains only `next` items and won't-dos: an open `now` and a CLOSEABLE verdict cannot both be true. If you reach the end of the work and discover a `now` item, the honest move is to **do it**, not to report it — or to re-classify it to `next` and say why the criteria that made it `now` no longer apply.
 
   Promoting a `next` to `now` mid-session is allowed — that is the "the session ended up touching those files anyway" case — but it is an explicit re-classification that must be stated as one ("promoting #N to `now`: this lane reopened that file"). It must never happen by drift, i.e. by the agent simply carrying on into a `next` item because the session happened to still be open.
 


### PR DESCRIPTION
Two gaps in the session-fit rules, both surfaced by a maintainer reading a
report produced under them.

## 1. "Handoff" named the mechanism, not the decision

The closing line was labelled `Handoff (NOT this session): /work-issues`.
"Handoff" says how the work moves; it does not say whether **this** session will
do it -- which is the single thing the reader needs, and precisely the call the
classification exists to have already made. Same for "Next steps".

The line now leads with the decision:

```text
Not this session - start a fresh session with: /work-issues
Not this session - start a fresh session with: fix issue <N> (Effort: M)
```

## 2. The report shape for a `now` TODO was never specified

Which left the obvious failure available: list a `now` item and still write
CLOSEABLE. A `now` is a commitment that this session finishes it, so it binds
all three parts of the report together:

- **Remaining work** -- states what you are about to **do** about it ("Doing
  this next"), unlike a `next` item which states only what it is.
- **State** -- never STOPPED while a `now` is open. Either WAITING (with the
  `now` named as what follows), or simply keep working and do not end the turn.
  Ending STOPPED over an open `now` is the "stopped with work left undone"
  failure the State line already forbids.
- **Session close** -- always NOT CLOSEABLE, naming the `now` item as the
  blocker.

The corollary is the actually useful rule: **a genuinely final report can only
ever contain `next` items and won't-dos.** An open `now` and a CLOSEABLE verdict
cannot both be true. So discovering a `now` at the end of the work means DOING
it, not reporting it -- or re-classifying it to `next` and saying why the
criteria that made it `now` no longer apply.

`.claude/skills/work-issues/SKILL.md` gets both, since its lanes merge at
staggered times and it is where the ambiguous phrasing is most likely to appear.

## Test plan

Agent-instruction only; no `src/` change. `CLAUDE.md` and the verification-depth
skills sit in the `check` gate scope because CI checkers pattern-scan them, so
the full suite was run: **636 files / 12522 tests / 0 type errors**, lint, format
and build clean, generated matrices fresh.
