### PR TITLE
chore(skill): make /work-issues read the issue body's own Session-fit line before claiming

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -154,6 +154,16 @@ parallelized — bundle them into ONE lane (one worktree, one PR) or defer one.
 - Prefer surgical, deterministic, live-proven issues (a provider tweak + a
   regression test) for auto-merge; hold complex redesigns (new DAG mechanism,
   new intrinsic, schema bump) for a focused solo pass.
+- **Read the body's own `Session-fit:` line before shortlisting it.** The filer
+  may already have classified the issue, and a `Session-fit: next` line names the
+  cycle it needs — its own fixture arm, an integ run, a higher review tier, an
+  upstream answer. Such an issue is not off-limits forever, but taking one means
+  the claim comment (§4) states why the recorded classification no longer
+  applies: typically that THIS run was started for it, or that the lane it would
+  have been bundled into is already merged. Silently re-deciding from scratch is
+  exactly the re-litigation the classification exists to prevent (CLAUDE.md →
+  "Session-fit classification") — the call was made when the evidence for it was
+  still in hand, and that evidence is gone by the time you are triaging.
 
 Scale the count to the backlog and to how many cross-cutting files are free. 2–3
 clean lanes is typical; do not force a lane into a contested file just to raise the
@@ -183,6 +193,10 @@ gh api 'repos/{owner}/{repo}/issues?state=open&per_page=60' \
   --jq '.[] | select(.pull_request | not)
         | [.number, (.title | capture("^(?<type>[a-z]+)(\\((?<area>[^)]+)\\))?") | .type + "/" + (.area // "-")), .title]
         | @tsv'
+
+# the filer may already have classified it (§3) — this is a body read, so do it
+# on the shortlist rather than on all 60
+gh issue view <n> --json body -q .body | grep -i 'Session-fit:'
 ```
 
 - **Umbrella**: title or body says `umbrella`, `audit:`, `Backfill`, `N entries
@@ -196,6 +210,11 @@ gh api 'repos/{owner}/{repo}/issues?state=open&per_page=60' \
 - **Cross-cutting**: the body names any of `deploy-engine.ts`,
   `intrinsic-function-resolver.ts`, `dag-builder.ts`, `template-parser.ts`,
   `register-providers.ts`, `destroy-runner.ts`, `export.ts` (the §2 list).
+- **Session-fit**: the body's own `Session-fit:` line (§3). `next` names a cycle
+  this run has to be able to pay for before taking the issue. `now` on a still-OPEN
+  issue is the rarer signal and points the other way — some earlier session ended
+  with a commitment unfinished, so it is a candidate to take EARLY rather than a
+  reason to skip.
 
 **These are tiebreakers, not a scoring formula — do not average them.** Apply
 rule 1, then 2, then 3, and stop at the first that separates the candidates. And
@@ -402,6 +421,13 @@ anything non-obvious you learned in memory.
   its `gh pr create` — which is when it is writing hardest. `git for-each-ref
   --sort=-committerdate refs/remotes/origin` after a `git fetch` is the only probe
   that sees it (§2).
+- **The filer may already have classified the issue.** A body carrying
+  `Session-fit: next` names the cycle the issue needs; take it only if this run
+  can pay for that, and say why in the claim (§3). On 2026-08-13 #1791 passed
+  every §2 / §3 gate — `fix(export)`, unclaimed, disjoint from all eight live
+  lanes — was claimed, and had to be retracted after the deep read showed the
+  legacy-state fixture arm plus export integ its body had already named. The line
+  was in the body the whole time; nothing but a grep stood between the run and it.
 - **One lane per cross-cutting file.** `deploy-engine.ts` / `intrinsic-function-resolver.ts`
   / `dag-builder.ts` / `register-providers.ts` absorb most non-trivial fixes; you
   cannot parallelize two issues that both land there. Per-provider fixes ARE


### PR DESCRIPTION
## Summary

`/work-issues` triage ranked candidates by type / area / file-disjointness / age and never looked at the `Session-fit:` line the issue's own filer may have written into the body. So a run could shortlist and CLAIM an issue whose filer had already recorded that it needs its own fixture arm, integ run or review tier — re-deciding the classification at the moment the evidence for the original call is gone, which is the re-litigation CLAUDE.md's "Session-fit classification" section exists to prevent.

Three additions to `.claude/skills/work-issues/SKILL.md`, all of them body reads on the shortlist rather than on the whole backlog:

- **§3** gains the rule: read the body's `Session-fit:` line before shortlisting. A `next` issue is not off-limits forever, but taking one means the claim comment states why the recorded classification no longer applies.
- **§3-a** gains the detection grep and a `Session-fit` signal bullet. The bullet also names the rarer `now`-on-a-still-open-issue case, which points the other way: an earlier session ended with a commitment unfinished, so it is a candidate to take EARLY rather than a reason to skip.
- **Gotchas** gains the measured case — (#1791) passed every §2 / §3 gate, was claimed, and had to be retracted after the deep read found the legacy-state fixture arm plus export integ its body had already named.

## Test plan

No `src/**` change, so this is docs/tooling-only and exempt from the live-AWS test. The command the skill now prescribes was exercised in both directions instead:

```
$ gh issue view 1867 --json body -q .body | grep -i 'Session-fit:'
Session-fit: next (not this session) - needs a new `tests/unit/cli/` deploy-command harness ...

$ gh issue view 1859 --json body -q .body | grep -i 'Session-fit:'   # no such line
[exit=1]
```

It prints the line when there is one and exits 1 silently when there is not, so it never blocks a run on a false positive.

Full suite green (647 files / 12835 tests); `vp run gen:all-matrices` leaves the tree clean.

## Note on this PR's own provenance

(#1858)'s body carries `Session-fit: next (not this session)`, so by the rule this PR adds, taking it required stating why that classification no longer applies. That is [recorded on the issue](https://github.com/go-to-k/cdkd/issues/1858#issuecomment-5281976212): the recorded reason was that a skill edit carried none of the deploy-engine lane's hot context, and this run was started fresh for (#1858) and (#1862) specifically.

Closes #1858
