### PR TITLE
docs(state): correct StackState.outputs to Record<string, unknown> and close the surrounding schema drift

### DIFF
--- a/.claude/rules/state-schema.md
+++ b/.claude/rules/state-schema.md
@@ -44,7 +44,7 @@ interface ResourceState {
   metadata?: Record<string, unknown>;           // Additional metadata
   deletionPolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate'; // v5+: template attribute recorded at deploy time
   updateReplacePolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate'; // v5+: template attribute recorded at deploy time
-  provisionedBy?: 'sdk' | 'cc-api';         // v7+: which provisioning layer owns this resource (absent = SDK legacy default)
+  provisionedBy?: 'sdk' | 'cc-api';         // v7+: which provisioning layer owns this resource (absent = pre-v7 record, SDK-managed then; NOT pinned — routing re-decides)
 }
 ```
 
@@ -108,10 +108,15 @@ provisioning-layer label: `'sdk'` (cdkd's preferred fast path, direct
 synchronous AWS SDK calls per resource type) or `'cc-api'` (the Cloud
 Control API fallback path, async polling create/update/delete via the
 unified CloudControlClient). Pre-#614 every resource was implicitly
-SDK-managed; the absent / `undefined` field on v6-and-earlier state
-records is treated by the v7 binary as "legacy SDK" (matches pre-#614
-behavior). v7 writers always emit the field explicitly so the routing
-decision is durable across deploys.
+SDK-managed, and the absent / `undefined` field on v6-and-earlier state
+records carries exactly that provenance — but it does NOT pin routing:
+rule 2 below gates on a RECORDED `'cc-api'` alone, so an absent field
+re-enters the matrix and can still be auto-routed to Cloud Control by
+rule 4 (the pre-#614 outcome for that resource). v7 writers always emit
+the field explicitly so the routing decision is durable across deploys.
+Fuller treatment in
+[docs/state-management.md](../../docs/state-management.md)'s `version: 7`
+section.
 
 Routing decision matrix (`ProviderRegistry.getProviderFor`, called by
 the deploy / drift / destroy / state-show paths):
@@ -132,8 +137,13 @@ the deploy / drift / destroy / state-show paths):
 The field is **sticky**: once a resource is `'cc-api'`, subsequent SDK
 Provider backfills (issue #609) do NOT auto-migrate it back. Avoids
 physical-ID churn + destroy + recreate cycles on every backfill
-release. User-initiated CC → SDK migration lives under #615 (or a
-future counterpart). `cdkd destroy` consults the field to pick the
+release. Exception: types in `STICKY_CC_MIGRATION_EXEMPT`
+(`src/provisioning/provider-registry.ts` — consult the constant, its
+membership changes) re-route to their SDK provider anyway, admitted only
+when CC routing is BROKEN and the physicalId is unchanged; see
+docs/state-management.md's `version: 7` section. User-initiated CC → SDK
+migration lives under #615 (or a future counterpart). `cdkd destroy`
+consults the field to pick the
 delete path; `cdkd drift` consults it to pick `readCurrentState`;
 `cdkd state show` displays `ProvisionedBy: sdk | cc-api | (sdk, legacy default)`
 for the absent-field case so users can audit the routing.

--- a/.claude/rules/state-schema.md
+++ b/.claude/rules/state-schema.md
@@ -13,7 +13,7 @@ interface StackState {
   stackName: string;
   region?: string;      // Required on version >= 2 (load-bearing for the S3 key)
   resources: Record<string, ResourceState>;
-  outputs: Record<string, string>;
+  outputs: Record<string, unknown>; // Resolved Output values — NOT coerced to string (see below)
   imports?: StateImportEntry[]; // v4+: Fn::ImportValue refs recorded for strong-reference destroy refusal
   outputReads?: StateOutputReadEntry[]; // v8+: Fn::GetStackOutput refs (informational; NO destroy-time refusal — weak reference by design)
   parentStack?: string;        // v6+: populated on nested-stack child state records (undefined on top-level)
@@ -35,17 +35,35 @@ interface StateOutputReadEntry {
 }
 
 interface ResourceState {
-  physicalId: string;                       // AWS physical ID
-  resourceType: string;                     // e.g., "AWS::S3::Bucket"
-  properties: Record<string, any>;          // Resolved template intent (what cdkd was asked to deploy)
-  observedProperties?: Record<string, any>; // AWS-current snapshot at deploy time (drift baseline)
-  attributes: Record<string, any>;          // For Fn::GetAtt resolution
-  dependencies: string[];                   // For proper deletion order
+  physicalId: string;                           // AWS physical ID
+  resourceType: string;                         // e.g., "AWS::S3::Bucket"
+  properties: Record<string, unknown>;          // Resolved template intent (what cdkd was asked to deploy)
+  observedProperties?: Record<string, unknown>; // AWS-current snapshot at deploy time (drift baseline)
+  attributes?: Record<string, unknown>;         // For Fn::GetAtt resolution
+  dependencies?: string[];                      // For proper deletion order
+  metadata?: Record<string, unknown>;           // Additional metadata
   deletionPolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate'; // v5+: template attribute recorded at deploy time
   updateReplacePolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate'; // v5+: template attribute recorded at deploy time
   provisionedBy?: 'sdk' | 'cc-api';         // v7+: which provisioning layer owns this resource (absent = SDK legacy default)
 }
 ```
+
+**`outputs`** values are `unknown`, NOT `string`. `DeployEngine.resolveOutputs`
+returns `Record<string, unknown>` and persists whatever
+`IntrinsicFunctionResolver.resolve` produced for the Output's `Value` — there
+is no stringification step anywhere on that path. Most Outputs do resolve to a
+string, but an `Fn::GetAtt` that CloudFormation defines as a LIST persists a
+JSON **array** into `state.outputs` whenever it is used as the Output value
+directly instead of being wrapped in `Fn::Join` — `AWS::Route53::HostedZone`'s
+`NameServers` is the shipped case (PR #1868 made the provider preserve the SDK
+array through create / update / `getAttribute`, so the list shape now survives
+into state). Two consequences worth stating because both have been assumed
+otherwise: code reading a `state.outputs` value back must not assume `string`
+(narrow before use), and a doc or a type annotation spelling this field
+`Record<string, string>` is wrong (issue
+[#1876](https://github.com/go-to-k/cdkd/issues/1876)). An output the resolver
+could not resolve is stored as `undefined` and therefore drops out of the
+persisted JSON entirely — absence means "not resolved", not "empty string".
 
 **`deletionPolicy` / `updateReplacePolicy`** (schema v5+) are the CFn template
 attributes recorded at deploy time so the next `cdkd deploy` / `cdkd diff` can

--- a/.claude/rules/state-schema.md
+++ b/.claude/rules/state-schema.md
@@ -65,6 +65,17 @@ otherwise: code reading a `state.outputs` value back must not assume `string`
 could not resolve is stored as `undefined` and therefore drops out of the
 persisted JSON entirely — absence means "not resolved", not "empty string".
 
+**Do not verify any of this from the deploy summary.** `cdkd deploy`'s
+`Outputs:` block prints each value with `String(value)`
+(`src/cli/commands/deploy.ts`), so a persisted ARRAY renders comma-joined with
+no brackets — byte-identical to a genuine comma-separated string, which is
+exactly the observation that makes a reader conclude the value was coerced.
+(`buildDisplayOutputs` in `src/deployment/deploy-engine.ts` does NOT stringify;
+it only selects the template's declared Output keys and drops `undefined` ones,
+so an unresolved output is absent from the block rather than printed.) The
+persisted shape is visible in `state.json` itself, or via `cdkd state show`,
+whose `formatAttributeValue` passes non-scalars through `JSON.stringify`.
+
 **`deletionPolicy` / `updateReplacePolicy`** (schema v5+) are the CFn template
 attributes recorded at deploy time so the next `cdkd deploy` / `cdkd diff` can
 detect attribute-only flips that have no AWS API impact but still matter to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ interface StackState {
   stackName: string;
   region?: string;
   resources: Record<string, ResourceState>;
-  outputs: Record<string, string>;
+  outputs: Record<string, unknown>; // NOT coerced to string — a list-valued Fn::GetAtt persists a JSON array
   imports?: StateImportEntry[];
   outputReads?: StateOutputReadEntry[]; // v8+: Fn::GetStackOutput refs (informational, NOT destroy-blocking)
   parentStack?: string;        // v6+: populated on nested-stack child state records (undefined on top-level stacks)
@@ -64,10 +64,10 @@ interface StackState {
 interface ResourceState {
   physicalId: string;
   resourceType: string;
-  properties: Record<string, any>;
-  observedProperties?: Record<string, any>;
-  attributes: Record<string, any>;
-  dependencies: string[];
+  properties: Record<string, unknown>;
+  observedProperties?: Record<string, unknown>;
+  attributes?: Record<string, unknown>;
+  dependencies?: string[];
   deletionPolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate';
   updateReplacePolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate';
   provisionedBy?: 'sdk' | 'cc-api'; // v7+: routing layer (absent = SDK legacy default)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ interface ResourceState {
   dependencies?: string[];
   deletionPolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate';
   updateReplacePolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate';
-  provisionedBy?: 'sdk' | 'cc-api'; // v7+: routing layer (absent = SDK legacy default)
+  provisionedBy?: 'sdk' | 'cc-api'; // v7+: routing layer (absent = pre-v7 record, SDK-managed then; NOT pinned — routing re-decides)
 }
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -359,14 +359,16 @@ interface S3StateBackend {
 }
 ```
 
-**State Schema** (`types/state.ts`):
+**State Schema** (`types/state.ts`) — abbreviated; the full current-version
+shape (v8, incl. `region` / `imports` / `outputReads` / the nested-stack parent
+links) is in [state-management.md](state-management.md#state-schema):
 
 ```typescript
 interface StackState {
   version: number
   stackName: string
   resources: Record<string, ResourceState>
-  outputs: Record<string, string>
+  outputs: Record<string, unknown>  // resolved Output values, NOT coerced to string
   lastModified: number
 }
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -288,10 +288,10 @@ a clear error** if it sees a higher-versioned blob (e.g. `Unsupported
 state schema version 3. Upgrade cdkd.`) instead of silently mishandling
 unknown fields.
 
-### `version: 3` adds `observedProperties` (current writers)
+### `version: 3` adds `observedProperties` (v3+ writers)
 
 Schema `version: 3` adds an optional `observedProperties` field to each
-`ResourceState`. Writers always emit `version: 3`. The on-disk key layout
+`ResourceState`. Writers emit `version: 3` or later. The on-disk key layout
 (`cdkd/{stackName}/{region}/state.json`) is unchanged from `version: 2` —
 only the per-resource shape grew. v2 readers see a `version: 3` blob and
 fail clearly with the same "upgrade cdkd" error as above.
@@ -333,7 +333,7 @@ Schema `version: 5` adds two optional template-attribute fields to each
 `ResourceState`: `deletionPolicy` and `updateReplacePolicy`. They mirror the
 CloudFormation `DeletionPolicy` / `UpdateReplacePolicy` attributes that the
 synth template carried at the resource's last successful create / update.
-Writers always emit `version: 5`. The on-disk key layout is unchanged from
+Writers emit `version: 5` or later. The on-disk key layout is unchanged from
 `version: 2`; only the per-resource shape grew. v4 readers see a `version: 5`
 blob and fail clearly with the same "upgrade cdkd" error.
 
@@ -373,7 +373,7 @@ promises before deleting (see the "DeletionPolicy: Snapshot" section in
 > only surface `UPDATE` for resources whose template attribute actually
 > changed.
 
-### `version: 6` adds `parentStack` / `parentLogicalId` / `parentRegion` (current writers)
+### `version: 6` adds `parentStack` / `parentLogicalId` / `parentRegion` (v6+ writers)
 
 Schema `version: 6` adds three optional stack-level fields to `StackState`:
 `parentStack`, `parentLogicalId`, `parentRegion`. They are populated **only on
@@ -388,13 +388,13 @@ Child state files live at `cdkd/{parentStack}~{parentLogicalId}/{region}/state.j
 — the `~` separator avoids ambiguity with CDK Stage's `/`-separated
 display paths. The on-disk shape is otherwise identical to v5.
 
-Writers always emit `version: 6`. v5 readers see a `version: 6` blob
+Writers emit `version: 6` or later. v5 readers see a `version: 6` blob
 and fail with the same "upgrade cdkd" error. **v5 → v6 upgrade is
 fully transparent** — read a v5 state file with a v6 binary and the
 parser tolerates the missing fields (degrades to "top-level stack");
 the next write persists `version: 6` silently. No `cdkd state
 migrate-schema` command, no env flag, no manual JSON edit. The
-[`tests/integration/schema-v5-to-v6-migration/`](../../tests/integration/schema-v5-to-v6-migration/)
+[`tests/integration/schema-v5-to-v6-migration/`](../tests/integration/schema-v5-to-v6-migration/)
 integ test proves the round-trip against real AWS.
 
 The v6 prep PR added the type bump alone. The
@@ -422,17 +422,70 @@ state for every stack in the tree is deleted leaf-first after the
 CFn-side IMPORT loop completes. Fresh `cdkd deploy` of new nested
 stacks has been supported since #459.
 
+### `version: 7` adds `provisionedBy` (v7+ writers)
+
+Schema `version: 7` adds an optional `provisionedBy` field to each
+`ResourceState`: `'sdk'` (cdkd's preferred fast path — direct synchronous AWS
+SDK calls) or `'cc-api'` (the Cloud Control API fallback), i.e. which
+provisioning layer owns the resource
+([#614](https://github.com/go-to-k/cdkd/issues/614)). Pre-#614 every resource
+was implicitly SDK-managed, so a v7 reader treats the absent field on a
+v6-and-earlier record as "legacy SDK" — which is what those records mean.
+v7+ writers always emit the field explicitly so the routing decision is
+durable across deploys.
+
+The field is **sticky**: once a resource is `'cc-api'`, a later SDK-provider
+backfill does NOT migrate it back, because that would mean physical-ID churn
+(destroy + recreate) on every backfill release. `cdkd destroy` reads it to pick
+the delete path, `cdkd drift` to pick `readCurrentState`, and `cdkd state show`
+displays it (`ProvisionedBy: sdk | cc-api | (sdk, legacy default)`).
+
+**v6 → v7 upgrade is fully transparent** — a v6 state file read by a v7 binary
+parses with the field undefined, and the next write persists `version: 7`
+silently. No command, no flag, no manual JSON edit. The
+[`tests/integration/schema-v6-to-v7-migration/`](../tests/integration/schema-v6-to-v7-migration/)
+integ test proves the round-trip against real AWS.
+
+### `version: 8` adds `outputReads` (current writers)
+
+Schema `version: 8` adds an optional stack-level `outputReads` array — one
+`StateOutputReadEntry` per successful **same-account** `Fn::GetStackOutput`
+resolution during the consumer stack's deploy
+([#668](https://github.com/go-to-k/cdkd/issues/668)). It is the sibling of v4's
+`imports`, with one deliberate difference: `outputReads` is **informational
+only**. There is no destroy-time refusal for `Fn::GetStackOutput`, because that
+intrinsic is a weak reference by design — the producer stays deletable
+independently of its consumers. The entries are consumed by
+`findDownstreamConsumers` to name affected downstream stacks in the
+`--recreate-via-cc-api` / `--recreate-via-sdk-provider` warn block.
+
+The field is omitted from the JSON when the resolved set is empty, so the
+on-the-wire shape is byte-identical to v7 for stacks that use no
+`Fn::GetStackOutput`. Cross-account (`RoleArn`-based) reads are deliberately
+NOT recorded in v8 — an unambiguous match key would need a `sourceAccountId`
+field, deferred to a future bump. Same-account cross-region reads ARE recorded
+(`sourceRegion` carries the producer's region).
+
+**v7 → v8 upgrade is fully transparent** — `outputReads === undefined` on a
+pre-v8 record reads as "no `Fn::GetStackOutput` consumers known" and the
+enumeration degrades to imports-only (the v4-shipped behavior); the next deploy
+under a v8 binary repopulates the field and persists `version: 8` silently. The
+[`tests/integration/schema-v7-to-v8-migration/`](../tests/integration/schema-v7-to-v8-migration/)
+integ test proves the round-trip against real AWS.
+
 ## State Schema
 
 ### StackState (`state.json`)
 
 ```typescript
 interface StackState {
-  version: 1 | 2 | 3 | 4 | 5 | 6           // 1 = legacy, 2 = region-prefixed, 3 = +observedProperties, 4 = +imports[], 5 = +deletionPolicy/updateReplacePolicy, 6 = +parentStack/parentLogicalId/parentRegion (nested-stack adoption)
+  version: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8   // 1 = legacy, 2 = region-prefixed, 3 = +observedProperties, 4 = +imports[], 5 = +deletionPolicy/updateReplacePolicy, 6 = +parentStack/parentLogicalId/parentRegion (nested-stack adoption), 7 = +provisionedBy on ResourceState, 8 = +outputReads[]
   stackName: string                        // Stack name
   region?: string                          // Required on version >= 2
   resources: Record<string, ResourceState> // Logical ID → Resource state
-  outputs: Record<string, string>          // Output name → Resolved value
+  outputs: Record<string, unknown>         // Output name → Resolved value (NOT coerced to string)
+  imports?: StateImportEntry[]             // v4+: Fn::ImportValue refs (strong reference — blocks the producer's destroy)
+  outputReads?: StateOutputReadEntry[]     // v8+: Fn::GetStackOutput refs (informational — weak reference, never destroy-blocking)
   parentStack?: string                     // v6+: populated on nested-stack child state records (undefined on top-level)
   parentLogicalId?: string                 // v6+: child's AWS::CloudFormation::Stack logical id in the parent's template
   parentRegion?: string                    // v6+: parent's region (always equals `region` until cross-region nested stacks ship)
@@ -440,11 +493,21 @@ interface StackState {
 }
 ```
 
+**`outputs` values are `unknown`, not `string`** — cdkd persists whatever the
+intrinsic resolver produced for the Output's `Value`, with no stringification
+step. Most Outputs do resolve to a string, but an `Fn::GetAtt` that
+CloudFormation defines as a LIST persists a JSON **array** when it is used as
+the Output value directly (rather than wrapped in `Fn::Join`) — e.g.
+`AWS::Route53::HostedZone.NameServers`, whose list shape the Route 53 provider
+preserves end to end. Do not write code (or docs) that assumes a
+`state.outputs` value is a string; a consumer reading one back must handle the
+non-string shapes too.
+
 #### Example
 
 ```json
 {
-  "version": 3,
+  "version": 8,
   "stackName": "MyAppStack",
   "region": "us-east-1",
   "resources": {
@@ -462,7 +525,8 @@ interface StackState {
         "DomainName": "myappstack-mybucket-abc123xyz.s3.amazonaws.com",
         "RegionalDomainName": "myappstack-mybucket-abc123xyz.s3.us-east-1.amazonaws.com"
       },
-      "dependencies": []
+      "dependencies": [],
+      "provisionedBy": "sdk"
     },
     "MyFunction": {
       "physicalId": "arn:aws:lambda:us-east-1:123456789012:function:MyAppStack-MyFunction",
@@ -480,7 +544,8 @@ interface StackState {
       "attributes": {
         "Arn": "arn:aws:lambda:us-east-1:123456789012:function:MyAppStack-MyFunction"
       },
-      "dependencies": ["MyFunctionRole", "MyBucket"]
+      "dependencies": ["MyFunctionRole", "MyBucket"],
+      "provisionedBy": "sdk"
     }
   },
   "outputs": {
@@ -496,12 +561,16 @@ interface StackState {
 
 ```typescript
 interface ResourceState {
-  physicalId: string                       // AWS physical ID (ARN, name, etc.)
-  resourceType: string                     // CloudFormation resource type
-  properties: Record<string, any>          // Resolved template intent (what cdkd was asked to deploy)
-  observedProperties?: Record<string, any> // AWS-current snapshot at deploy time (drift baseline)
-  attributes: Record<string, any>          // Attributes for Fn::GetAtt
-  dependencies: string[]                   // List of dependent logical IDs
+  physicalId: string                           // AWS physical ID (ARN, name, etc.)
+  resourceType: string                         // CloudFormation resource type
+  properties: Record<string, unknown>          // Resolved template intent (what cdkd was asked to deploy)
+  observedProperties?: Record<string, unknown> // AWS-current snapshot at deploy time (drift baseline)
+  attributes?: Record<string, unknown>         // Attributes for Fn::GetAtt
+  dependencies?: string[]                      // List of dependent logical IDs
+  metadata?: Record<string, unknown>           // Additional metadata
+  deletionPolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate'      // v5+: template attribute recorded at deploy time
+  updateReplacePolicy?: 'Delete' | 'Retain' | 'Snapshot' | 'RetainExceptOnCreate' // v5+: template attribute recorded at deploy time
+  provisionedBy?: 'sdk' | 'cc-api'             // v7+: provisioning layer (absent = SDK legacy default)
 }
 ```
 
@@ -1471,13 +1540,16 @@ explicit on-demand answer.
 
 ### Schema Version
 
-Current writers emit **`version: 2`** (region-prefixed key layout —
-`cdkd/{stackName}/{region}/state.json`). Older `version: 1` blobs at the
-non-region key (`cdkd/{stackName}/state.json`) are still readable; the
-next save migrates them to v2 and deletes the legacy key.
+Current writers emit **`version: 8`** on the region-prefixed key layout
+(`cdkd/{stackName}/{region}/state.json`, introduced by `version: 2`). Older
+`version: 1` blobs at the non-region key (`cdkd/{stackName}/state.json`) are
+still readable; the next save migrates them to the region-prefixed key and
+deletes the legacy key. Every v1..v7 blob is read and auto-upgraded in memory
+by the current binary, and the next write persists the current version
+silently — no user action, no migration command.
 
-A `version: 1` writer encountering a `version: 2` blob fails closed
-rather than silently mishandling unknown fields.
+An older writer encountering a newer blob fails closed rather than silently
+mishandling unknown fields.
 
 ## Troubleshooting
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -531,6 +531,18 @@ preserves end to end. Do not write code (or docs) that assumes a
 `state.outputs` value is a string; a consumer reading one back must handle the
 non-string shapes too.
 
+**The `Outputs:` block `cdkd deploy` prints is not evidence of the stored
+shape.** That summary renders each value with JavaScript's `String(value)`, and
+for an array that is a comma join with no brackets or spaces — a persisted
+`["ns-1.awsdns-00.com", "ns-2.awsdns-01.net"]` prints as
+`ns-1.awsdns-00.com,ns-2.awsdns-01.net`, indistinguishable from a genuine
+comma-separated string. (An object prints as `[object Object]`, and an
+unresolved output is dropped from the block entirely rather than printed as
+`undefined`.) To see what was actually stored, read the state file —
+`aws s3 cp s3://<bucket>/cdkd/{stackName}/{region}/state.json -` — or run
+`cdkd state show <stack>`, which renders any non-scalar through
+`JSON.stringify` and so preserves the distinction.
+
 #### Example
 
 ```json

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -425,20 +425,42 @@ stacks has been supported since #459.
 ### `version: 7` adds `provisionedBy` (v7+ writers)
 
 Schema `version: 7` adds an optional `provisionedBy` field to each
-`ResourceState`: `'sdk'` (cdkd's preferred fast path — direct synchronous AWS
-SDK calls) or `'cc-api'` (the Cloud Control API fallback), i.e. which
-provisioning layer owns the resource
-([#614](https://github.com/go-to-k/cdkd/issues/614)). Pre-#614 every resource
-was implicitly SDK-managed, so a v7 reader treats the absent field on a
-v6-and-earlier record as "legacy SDK" — which is what those records mean.
-v7+ writers always emit the field explicitly so the routing decision is
-durable across deploys.
+`ResourceState` ([#614](https://github.com/go-to-k/cdkd/issues/614)): `'sdk'`
+(cdkd's preferred fast path — direct synchronous AWS SDK calls) or `'cc-api'`
+(the Cloud Control API fallback), i.e. which provisioning layer owns the
+resource. A Custom Resource is recorded `'sdk'` too, so the field is always
+populated on a v7+ write; it has no SDK-vs-Cloud-Control dichotomy of its own,
+so read the value there as "not Cloud Control" rather than as a literal claim
+about synchronous SDK calls.
+
+Pre-#614 every resource was implicitly SDK-managed, so a v7 reader treats the
+absent field on a
+v6-and-earlier record as the legacy SDK default. Precisely, an absent field
+means the record is not PINNED: routing re-decides from scratch, so such a
+resource can still be auto-routed to Cloud Control by the #614 silent-drop
+check — the same decision it got before v7 existed. Only a recorded
+`'cc-api'` pins. v7+ writers (`cdkd deploy` and `cdkd import` alike) emit the
+field explicitly so the decision is durable across deploys.
 
 The field is **sticky**: once a resource is `'cc-api'`, a later SDK-provider
 backfill does NOT migrate it back, because that would mean physical-ID churn
-(destroy + recreate) on every backfill release. `cdkd destroy` reads it to pick
-the delete path, `cdkd drift` to pick `readCurrentState`, and `cdkd state show`
-displays it (`ProvisionedBy: sdk | cc-api | (sdk, legacy default)`).
+(destroy + recreate) on every backfill release. **The stickiness has a narrow
+exemption**, `STICKY_CC_MIGRATION_EXEMPT` in
+[`src/provisioning/provider-registry.ts`](../src/provisioning/provider-registry.ts) —
+consult the constant rather than a list here, since its membership changes.
+A type is admitted only when its Cloud Control routing is **broken** (not merely
+slower) AND the SDK provider addresses the resource by the SAME physicalId the
+CC path stored, so the re-route costs no churn and the record flips to
+`'sdk'` transparently on its next write. Without the exemption, pinning such a
+record to `cc-api` would keep the bug alive for every pre-existing resource.
+`AWS::Scheduler::Schedule` ([#961](https://github.com/go-to-k/cdkd/issues/961) —
+a schedule in a custom `ScheduleGroup` is unaddressable via Cloud Control) is
+the member today. So a `provisionedBy: 'cc-api'` record is NOT proof the
+resource will keep being managed through Cloud Control.
+
+`cdkd destroy` reads the field to pick the delete path, `cdkd drift` to pick
+`readCurrentState`, and `cdkd state show` displays it
+(`ProvisionedBy: sdk | cc-api | (sdk, legacy default)`).
 
 **v6 → v7 upgrade is fully transparent** — a v6 state file read by a v7 binary
 parses with the field undefined, and the next write persists `version: 7`
@@ -449,9 +471,17 @@ integ test proves the round-trip against real AWS.
 ### `version: 8` adds `outputReads` (current writers)
 
 Schema `version: 8` adds an optional stack-level `outputReads` array — one
-`StateOutputReadEntry` per successful **same-account** `Fn::GetStackOutput`
-resolution during the consumer stack's deploy
-([#668](https://github.com/go-to-k/cdkd/issues/668)). It is the sibling of v4's
+`StateOutputReadEntry` per `Fn::GetStackOutput` resolution that was served from
+a **cdkd state record** during the consumer stack's deploy
+([#668](https://github.com/go-to-k/cdkd/issues/668)). Two resolutions are
+deliberately NOT recorded, so the array is a subset of the references a
+template carries rather than an inventory of them: a **cross-account**
+(`RoleArn`) read (deferred to a future bump alongside a `sourceAccountId`
+field), and one served by the **CloudFormation fallback**
+([#1697](https://github.com/go-to-k/cdkd/issues/1697) — the producer is not
+cdkd-managed, so cdkd never recreates it and there is no warning to attach the
+consumer to). Same-account cross-REGION reads ARE recorded (`sourceRegion`
+carries the producer's region). It is the sibling of v4's
 `imports`, with one deliberate difference: `outputReads` is **informational
 only**. There is no destroy-time refusal for `Fn::GetStackOutput`, because that
 intrinsic is a weak reference by design — the producer stays deletable
@@ -459,12 +489,10 @@ independently of its consumers. The entries are consumed by
 `findDownstreamConsumers` to name affected downstream stacks in the
 `--recreate-via-cc-api` / `--recreate-via-sdk-provider` warn block.
 
-The field is omitted from the JSON when the resolved set is empty, so the
-on-the-wire shape is byte-identical to v7 for stacks that use no
-`Fn::GetStackOutput`. Cross-account (`RoleArn`-based) reads are deliberately
-NOT recorded in v8 — an unambiguous match key would need a `sourceAccountId`
-field, deferred to a future bump. Same-account cross-region reads ARE recorded
-(`sourceRegion` carries the producer's region).
+The field is omitted from the JSON when the recorded set is empty, so the
+on-the-wire shape is byte-identical to v7 for a stack whose references were all
+of the two unrecorded kinds above — and for one that uses no
+`Fn::GetStackOutput` at all.
 
 **v7 → v8 upgrade is fully transparent** — `outputReads === undefined` on a
 pre-v8 record reads as "no `Fn::GetStackOutput` consumers known" and the


### PR DESCRIPTION
## Summary

`CLAUDE.md`'s `StackState` snippet declared `outputs: Record<string, string>`, but
`src/types/state.ts` says `Record<string, unknown>`. The distinction is load-bearing
rather than cosmetic: `DeployEngine.resolveOutputs` assigns the resolver's value
verbatim with no stringification step, so an `Fn::GetAtt` that CloudFormation defines
as a LIST persists a JSON **array** into `state.outputs` when it is used as the Output
value directly. `AWS::Route53::HostedZone.NameServers` is the shipped case, made
possible by PR #1868. Reasoning from the old snippet led to the wrong conclusion that
the value is coerced to a string.

Fixed in all four stale sites — `CLAUDE.md`, `docs/architecture.md`,
`docs/state-management.md`, `.claude/rules/state-schema.md`. A repo-wide sweep found
no fifth site and no prose asserting outputs are strings;
`docs/cross-stack-references.md` was already correct and is untouched (its snippet is
a historical v4 design record). The consequence note went only into the two natural
homes; `CLAUDE.md` gained one line and no net length.

## Additional schema drift fixed in the same pass

Checking the surrounding text against `src/types/state.ts` turned up more than the
one field, all in files this change already touches:

- `docs/state-management.md`'s `StackState` stopped at `version: 1|2|3|4|5|6` and
  omitted `imports` / `outputReads` entirely.
- All three `ResourceState` snippets declared `attributes` and `dependencies` as
  **required** — both are optional in source — and used `Record<string, any>` where
  the source says `unknown`. `state-management.md` also omitted `metadata` /
  `deletionPolicy` / `updateReplacePolicy` / `provisionedBy`.
- `docs/state-management.md` claimed "Current writers emit `version: 2`" against an
  actual `STATE_SCHEMA_VERSION_CURRENT = 8`. Fixing it exposed a self-contradiction in
  three history sections headed "(current writers)", and the **missing v7 and v8
  migration sections** were written in the existing per-version format, each with its
  transparent-auto-migration paragraph and integ-fixture pointer (both fixtures exist).
- One broken `../../` relative link that resolved outside the repo.
- The example state blob was `"version": 3`; bumped to 8 with `provisionedBy` on both
  resources so the canonical example matches the schema above it.

## Carve-outs the corrected prose initially dropped

Two review rounds caught the new prose stating rules more absolutely than the code.
Each is now qualified by pointing at the constant rather than enumerating members:

- **Stickiness has an exemption.** `STICKY_CC_MIGRATION_EXEMPT` re-routes types whose
  Cloud Control routing is BROKEN, admitted only when the SDK provider addresses the
  resource by the same physicalId. A `provisionedBy: 'cc-api'` record is not proof the
  resource stays on Cloud Control.
- **An absent `provisionedBy` does not pin routing.** `getProviderFor` rule 2 gates on
  a RECORDED `'cc-api'` alone, so an absent field re-enters the matrix and can still be
  auto-routed to Cloud Control by rule 4. The old `absent = SDK legacy default`
  shorthand was right about PROVENANCE and wrong about ROUTING; both readings now
  survive.
- **`outputReads` is a subset, not an inventory** — cross-account `RoleArn` reads and
  CloudFormation-fallback resolutions are both deliberately unrecorded.
- `provisionedBy: 'sdk'` on a Custom Resource is a populated-field convention, not a
  claim about synchronous SDK calls.

## Test plan

Docs-only: no `src/**` or `tests/**` change, so the live-test gate is not applicable.

- `vp run typecheck` / `lint` / `build` — pass
- `vp run test` — 653 files, 13004 tests, all pass
- `vp run gen:all-matrices` — no generated artifact went stale
- `/check` and `/check-docs` — pass
- Every factual claim was read out of source before being written: the field
  optionality and types in `src/types/state.ts`, `STATE_SCHEMA_VERSION_CURRENT`, the
  verbatim assignment in `DeployEngine.resolveOutputs`, the `outputReads.length > 0`
  emission gate, the routing gate and Custom Resource arm in `ProviderRegistry`, both
  non-recording arms of the resolver, and the existence of both migration fixtures.

Closes #1876
