### PR TITLE
fix(provisioning): skip ZIP-only Lambda reads for image functions

### DIFF
--- a/src/provisioning/providers/lambda-function-provider.ts
+++ b/src/provisioning/providers/lambda-function-provider.ts
@@ -1829,54 +1829,62 @@ export class LambdaFunctionProvider implements ResourceProvider {
         }
       }
 
-      // RuntimeManagementConfig: a SEPARATE control-plane read
-      // (GetRuntimeManagementConfig), emit-when-present. AWS returns the
-      // default `UpdateRuntimeOn: 'Auto'` for functions that never set it;
-      // the comparator's state-keys-only walk ignores the field unless state
-      // carries it, so the always-emit shape produces no phantom drift.
-      try {
-        const rmResp = await this.lambdaClient.send(
-          new GetRuntimeManagementConfigCommand({ FunctionName: physicalId })
-        );
-        if (rmResp.UpdateRuntimeOn !== undefined) {
-          const rm: Record<string, unknown> = { UpdateRuntimeOn: rmResp.UpdateRuntimeOn };
-          // Only meaningful under Manual; AWS omits it otherwise.
-          if (rmResp.RuntimeVersionArn !== undefined) {
-            rm['RuntimeVersionArn'] = rmResp.RuntimeVersionArn;
+      // Runtime-management controls and code signing apply to managed-runtime
+      // ZIP functions only. Container-image functions own their runtime in the
+      // image and do not support Lambda code signing, so AWS rejects both
+      // secondary reads. Skip them when GetFunction already identified the
+      // package as Image; otherwise those expected rejections become warnings
+      // and can make drift look like a property removal.
+      if (cfg.PackageType !== 'Image') {
+        // RuntimeManagementConfig: a SEPARATE control-plane read
+        // (GetRuntimeManagementConfig), emit-when-present. AWS returns the
+        // default `UpdateRuntimeOn: 'Auto'` for functions that never set it;
+        // the comparator's state-keys-only walk ignores the field unless state
+        // carries it, so the always-emit shape produces no phantom drift.
+        try {
+          const rmResp = await this.lambdaClient.send(
+            new GetRuntimeManagementConfigCommand({ FunctionName: physicalId })
+          );
+          if (rmResp.UpdateRuntimeOn !== undefined) {
+            const rm: Record<string, unknown> = { UpdateRuntimeOn: rmResp.UpdateRuntimeOn };
+            // Only meaningful under Manual; AWS omits it otherwise.
+            if (rmResp.RuntimeVersionArn !== undefined) {
+              rm['RuntimeVersionArn'] = rmResp.RuntimeVersionArn;
+            }
+            result['RuntimeManagementConfig'] = rm;
           }
-          result['RuntimeManagementConfig'] = rm;
+        } catch (rmErr) {
+          if (!(rmErr instanceof ResourceNotFoundException)) {
+            // WARN, not debug: this read backs a drift-compared key, so a
+            // permission / throttle failure omits RuntimeManagementConfig from
+            // the snapshot and `cdkd drift` then reports it as a REMOVAL against
+            // state. The warning is what makes that false drift explainable.
+            this.logger.warn(
+              `GetRuntimeManagementConfig failed for ${physicalId} — RuntimeManagementConfig omitted from the drift snapshot (may surface as a false removal): ${rmErr instanceof Error ? rmErr.message : String(rmErr)}`
+            );
+          }
         }
-      } catch (rmErr) {
-        if (!(rmErr instanceof ResourceNotFoundException)) {
-          // WARN, not debug: this read backs a drift-compared key, so a
-          // permission / throttle failure omits RuntimeManagementConfig from
-          // the snapshot and `cdkd drift` then reports it as a REMOVAL against
-          // state. The warning is what makes that false drift explainable.
-          this.logger.warn(
-            `GetRuntimeManagementConfig failed for ${physicalId} — RuntimeManagementConfig omitted from the drift snapshot (may surface as a false removal): ${rmErr instanceof Error ? rmErr.message : String(rmErr)}`
-          );
-        }
-      }
 
-      // CodeSigningConfigArn: a SEPARATE control-plane read
-      // (GetFunctionCodeSigningConfig), emit-when-present. AWS raises
-      // ResourceNotFoundException for a function with no code-signing config
-      // attached, which the shared catch below maps to omit-from-readback —
-      // no phantom drift on the typical function.
-      try {
-        const csResp = await this.lambdaClient.send(
-          new GetFunctionCodeSigningConfigCommand({ FunctionName: physicalId })
-        );
-        if (csResp.CodeSigningConfigArn !== undefined) {
-          result['CodeSigningConfigArn'] = csResp.CodeSigningConfigArn;
-        }
-      } catch (csErr) {
-        if (!(csErr instanceof ResourceNotFoundException)) {
-          // WARN for the same reason as the read above — an omitted
-          // CodeSigningConfigArn reads as a removed security control.
-          this.logger.warn(
-            `GetFunctionCodeSigningConfig failed for ${physicalId} — CodeSigningConfigArn omitted from the drift snapshot (may surface as a false removal): ${csErr instanceof Error ? csErr.message : String(csErr)}`
+        // CodeSigningConfigArn: a SEPARATE control-plane read
+        // (GetFunctionCodeSigningConfig), emit-when-present. AWS raises
+        // ResourceNotFoundException for a function with no code-signing config
+        // attached, which the shared catch below maps to omit-from-readback —
+        // no phantom drift on the typical function.
+        try {
+          const csResp = await this.lambdaClient.send(
+            new GetFunctionCodeSigningConfigCommand({ FunctionName: physicalId })
           );
+          if (csResp.CodeSigningConfigArn !== undefined) {
+            result['CodeSigningConfigArn'] = csResp.CodeSigningConfigArn;
+          }
+        } catch (csErr) {
+          if (!(csErr instanceof ResourceNotFoundException)) {
+            // WARN for the same reason as the read above — an omitted
+            // CodeSigningConfigArn reads as a removed security control.
+            this.logger.warn(
+              `GetFunctionCodeSigningConfig failed for ${physicalId} — CodeSigningConfigArn omitted from the drift snapshot (may surface as a false removal): ${csErr instanceof Error ? csErr.message : String(csErr)}`
+            );
+          }
         }
       }
 

--- a/tests/unit/provisioning/lambda-function-props-609.test.ts
+++ b/tests/unit/provisioning/lambda-function-props-609.test.ts
@@ -646,6 +646,27 @@ describe('AWS::Lambda::Function #609 property backfill', () => {
       expect(state?.['CodeSigningConfigArn']).toBe('arn:csc:1');
     });
 
+    it('skips ZIP-only runtime-management and code-signing reads for image functions', async () => {
+      mockSend.mockResolvedValueOnce({
+        Configuration: { FunctionName: 'fn', PackageType: 'Image' },
+        Code: { ImageUri: '123456789012.dkr.ecr.us-east-1.amazonaws.com/fn:latest' },
+        Tags: {},
+      });
+      mockSend.mockResolvedValueOnce({}); // GetFunctionRecursionConfig
+      mockSend.mockResolvedValueOnce({}); // GetFunctionConcurrency
+
+      const state = await provider.readCurrentState('fn', 'Fn', 'AWS::Lambda::Function');
+
+      expect(sentOfType(GetRuntimeManagementConfigCommand)).toHaveLength(0);
+      expect(sentOfType(GetFunctionCodeSigningConfigCommand)).toHaveLength(0);
+      expect(state?.['PackageType']).toBe('Image');
+      expect(state?.['Code']).toEqual({
+        ImageUri: '123456789012.dkr.ecr.us-east-1.amazonaws.com/fn:latest',
+      });
+      expect(state).not.toHaveProperty('RuntimeManagementConfig');
+      expect(state).not.toHaveProperty('CodeSigningConfigArn');
+    });
+
     it('omits the keys when AWS reports no value (no phantom drift)', async () => {
       mockReadback({ configuration: { FunctionName: 'fn' } });
 


### PR DESCRIPTION
## Summary

- skip `GetRuntimeManagementConfig` and `GetFunctionCodeSigningConfig` when `GetFunction` reports `PackageType: Image`
- keep the existing readback behavior unchanged for ZIP functions
- add regression coverage verifying both unsupported API calls are omitted while image code metadata is preserved

## Why

AWS Lambda container-image functions manage their runtime in the image and do not support Lambda code signing. Calling these ZIP-only getter APIs during drift readback produces warnings and can make missing values look like removals.

## Verification

- post-rebase `vp run check` passed with 0 errors and 6 pre-existing warnings
- post-rebase test typecheck and build passed
- targeted Lambda property-backfill suite: 32 passed
- full suite before the final upstream rebase: 659 test files / 13,274 tests passed
- generated coverage matrices and provider coverage audit passed
- live `docker-image-asset` integration was attempted but could not reach Lambda creation because the existing sandbox CDK image-publishing role lacks `ecr:GetDownloadUrlForLayer`; cleanup confirmed 0 state, IAM, Lambda, and ECR orphans


---

## Maintainer verification (2026-08-14)

The live run the contributor could not complete was run here, and it settles the premise this change rests on. Against a real `PackageType: Image` function deployed by the `docker-image-asset` fixture (us-east-1):

```
GetRuntimeManagementConfig   -> InvalidParameterValueException:
  "Lambda couldn't get a runtime management configuration because <fn> is a container image function."
GetFunctionCodeSigningConfig -> InvalidParameterValueException:
  "Code signing is not supported for functions created with container images."
```

Both rejections are non-`ResourceNotFoundException`, so the pre-PR code took the `logger.warn` arm and emitted NEITHER key for an image function. That matters beyond the warning noise: a change that stops `readCurrentState` emitting a key normally manufactures a one-sided REMOVAL drift against every `observedProperties` baseline the old binary wrote, and would need a `getDriftUnknownPaths` companion. Because AWS always rejected here, no baseline can carry either key, and this skip is invisible to drift — no companion needed.

- `/run-integ docker-image-asset`: PASS, 73s — deploy + ECR push + invoke + destroy (2 deleted, 0 errors), 0 orphans, state gone.
- Deploy-time `readCurrentState` capture logged zero `GetRuntimeManagementConfig failed` / `GetFunctionCodeSigningConfig failed` warnings on the new binary (the branch under test ran).
- Full suite 659 files / 13,274 tests; `handled-property-wiring` audit still reports read evidence for both properties (1136/1138, 0 gaps) — the conditional wrap did not sever the evidence walk.
- Code review: 1-reviewer tier (`src/provisioning/providers/**` up-bias). Mutation probe confirms the new test is RED without the guard.

Minor follow-ups are tracked in #1894 (write-side asymmetry, comment rationale, two vacuous assertions, missing integ coverage of the branch, changelog entry) rather than being pushed onto this branch.
