### PR TITLE
test(route53): make the NameServers list-shape fences discriminate, and stop the live probe from failing opaquely

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -238,7 +238,7 @@ rollback-deletion-policy-snapshot	2026-08-08T16:34:46Z	PASS	107	verify.sh	P0 fir
 rollback-failure-injection	2026-08-08T17:42:23Z	PASS	389	verify.sh	issue #1375 re-run (background, dodging the 600s clamp); all 8 phases, 17 del/0 err, 0 orphans incl NAT/EIP/ENI
 rollback-replay-effective-props	2026-08-13T05:57:36Z	PASS	191	verify.sh	1741 prune + 1742 ordering at 882fcef8; measured; 0 orphans
 rollback-sqs-cooldown	2026-08-10T04:45:42Z	PASS	152	verify.sh	0810 sweep b3; post-#1361 rollback-executor re-verify, destroy clean
-route53	2026-08-13T17:23:45Z	PASS	377	verify.sh	Issue #1873: adds the bare Fn::GetAtt NameServers Output arm; asserted array type + live element count + members; probe branches exercised; 8 created / 8 deleted, 0 errors, 0 orphans; duration measured from recorded start/end markers
+route53	2026-08-13T18:53:48Z	PASS	438	verify.sh	Issue #1873 re-run after the probe rework fix (stderr kept out of the payload, Route53-specific not-found signature); bare Fn::GetAtt list arm asserted a 4-element LIST against the live delegation set; 8 created / 8 deleted, 0 errors, 0 orphans
 s3-analytics-inventory	2026-08-13T00:49:56Z	PASS	135	verify.sh	1707/1717/1718 live after review round 3; 49 assertions, 0 orphans
 s3-asset-deploy	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 s3-cloudfront	2026-08-13T09:22:26Z	PASS	1150	verify.sh	PR 1745 re-run after review fixes (provider edit staled integ-destroy); 5 deleted 0 errors, 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -201,8 +201,6 @@ loggroup-class-guard	2026-08-13T13:37:55Z	PASS	62	verify.sh	4 phases ok, destroy
 loggroup-kms-associate	2026-08-10T11:50:46Z	PASS	45	verify.sh	0810 P0/P1 sweep b3; KMS associate+disassociate, 4 phases; key PendingDeletion is AWS-mandated
 macro-expansion	2026-08-10T05:24:30Z	PASS	54	verify.sh	0810 P2 sweep b7; diff-expands + destroy-no-expand asserts, 0 orph
 microservices	2026-08-13T18:47:41Z	PASS	44	standard	Issue #1874 broad integ at rebased head 133a9660 (merged PR #1884 region fold + PR #1885); 19 created / 19 deleted, 0 errors, 0 orphans
-microservices	2026-08-14T00:00:00Z	PASS	40	standard	PR #1868 broad integ (intrinsic-function-resolver.ts); 19 created / 19 deleted, 0 errors, 0 orphans
-microservices	2026-08-13T15:55:58Z	PASS	40	standard	PR #1868 broad integ (intrinsic-function-resolver.ts); 19 created / 19 deleted, 0 errors, 0 orphans; timestamp is the reporting comment's instant (maintainer supplied a date only) so it is an upper bound, not a measurement
 migrate-from-bare-cfn	2026-08-10T06:01:30Z	PASS	90	verify.sh	0810 P2 sweep b11; bare-CFn migrate + destroy clean
 migrate-from-bare-cfn-codegen-only	2026-07-26T18:57:55Z	PASS	17	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 migrate-from-cfn	2026-08-10T06:32:58Z	PASS	338	run.sh	0810 P2 sweep b11r; run.sh flow (NOT verify.sh) - import+migrate+destroy, 2 del 0 err, state cleaned

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -202,6 +202,7 @@ loggroup-kms-associate	2026-08-10T11:50:46Z	PASS	45	verify.sh	0810 P0/P1 sweep b
 macro-expansion	2026-08-10T05:24:30Z	PASS	54	verify.sh	0810 P2 sweep b7; diff-expands + destroy-no-expand asserts, 0 orph
 microservices	2026-08-13T18:47:41Z	PASS	44	standard	Issue #1874 broad integ at rebased head 133a9660 (merged PR #1884 region fold + PR #1885); 19 created / 19 deleted, 0 errors, 0 orphans
 microservices	2026-08-14T00:00:00Z	PASS	40	standard	PR #1868 broad integ (intrinsic-function-resolver.ts); 19 created / 19 deleted, 0 errors, 0 orphans
+microservices	2026-08-13T15:55:58Z	PASS	40	standard	PR #1868 broad integ (intrinsic-function-resolver.ts); 19 created / 19 deleted, 0 errors, 0 orphans; timestamp is the reporting comment's instant (maintainer supplied a date only) so it is an upper bound, not a measurement
 migrate-from-bare-cfn	2026-08-10T06:01:30Z	PASS	90	verify.sh	0810 P2 sweep b11; bare-CFn migrate + destroy clean
 migrate-from-bare-cfn-codegen-only	2026-07-26T18:57:55Z	PASS	17	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 migrate-from-cfn	2026-08-10T06:32:58Z	PASS	338	run.sh	0810 P2 sweep b11r; run.sh flow (NOT verify.sh) - import+migrate+destroy, 2 del 0 err, state cleaned
@@ -237,7 +238,7 @@ rollback-deletion-policy-snapshot	2026-08-08T16:34:46Z	PASS	107	verify.sh	P0 fir
 rollback-failure-injection	2026-08-08T17:42:23Z	PASS	389	verify.sh	issue #1375 re-run (background, dodging the 600s clamp); all 8 phases, 17 del/0 err, 0 orphans incl NAT/EIP/ENI
 rollback-replay-effective-props	2026-08-13T05:57:36Z	PASS	191	verify.sh	1741 prune + 1742 ordering at 882fcef8; measured; 0 orphans
 rollback-sqs-cooldown	2026-08-10T04:45:42Z	PASS	152	verify.sh	0810 sweep b3; post-#1361 rollback-executor re-verify, destroy clean
-route53	2026-08-14T00:00:00Z	PASS	349	verify.sh	PR #1868 maintainer re-run; Fn::Join over NameServers matched the live delegation set; 8 deleted, 0 errors, 0 orphans
+route53	2026-08-13T17:23:45Z	PASS	377	verify.sh	Issue #1873: adds the bare Fn::GetAtt NameServers Output arm; asserted array type + live element count + members; probe branches exercised; 8 created / 8 deleted, 0 errors, 0 orphans; duration measured from recorded start/end markers
 s3-analytics-inventory	2026-08-13T00:49:56Z	PASS	135	verify.sh	1707/1717/1718 live after review round 3; 49 assertions, 0 orphans
 s3-asset-deploy	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 s3-cloudfront	2026-08-13T09:22:26Z	PASS	1150	verify.sh	PR 1745 re-run after review fixes (provider edit staled integ-destroy); 5 deleted 0 errors, 0 orphans

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -201,6 +201,7 @@ loggroup-class-guard	2026-08-13T13:37:55Z	PASS	62	verify.sh	4 phases ok, destroy
 loggroup-kms-associate	2026-08-10T11:50:46Z	PASS	45	verify.sh	0810 P0/P1 sweep b3; KMS associate+disassociate, 4 phases; key PendingDeletion is AWS-mandated
 macro-expansion	2026-08-10T05:24:30Z	PASS	54	verify.sh	0810 P2 sweep b7; diff-expands + destroy-no-expand asserts, 0 orph
 microservices	2026-08-13T18:47:41Z	PASS	44	standard	Issue #1874 broad integ at rebased head 133a9660 (merged PR #1884 region fold + PR #1885); 19 created / 19 deleted, 0 errors, 0 orphans
+microservices	2026-08-14T00:00:00Z	PASS	40	standard	PR #1868 broad integ (intrinsic-function-resolver.ts); 19 created / 19 deleted, 0 errors, 0 orphans
 migrate-from-bare-cfn	2026-08-10T06:01:30Z	PASS	90	verify.sh	0810 P2 sweep b11; bare-CFn migrate + destroy clean
 migrate-from-bare-cfn-codegen-only	2026-07-26T18:57:55Z	PASS	17	verify.sh	0727b sweep-b7 staleness re-run (rc=0); account clean
 migrate-from-cfn	2026-08-10T06:32:58Z	PASS	338	run.sh	0810 P2 sweep b11r; run.sh flow (NOT verify.sh) - import+migrate+destroy, 2 del 0 err, state cleaned
@@ -236,7 +237,7 @@ rollback-deletion-policy-snapshot	2026-08-08T16:34:46Z	PASS	107	verify.sh	P0 fir
 rollback-failure-injection	2026-08-08T17:42:23Z	PASS	389	verify.sh	issue #1375 re-run (background, dodging the 600s clamp); all 8 phases, 17 del/0 err, 0 orphans incl NAT/EIP/ENI
 rollback-replay-effective-props	2026-08-13T05:57:36Z	PASS	191	verify.sh	1741 prune + 1742 ordering at 882fcef8; measured; 0 orphans
 rollback-sqs-cooldown	2026-08-10T04:45:42Z	PASS	152	verify.sh	0810 sweep b3; post-#1361 rollback-executor re-verify, destroy clean
-route53	2026-08-13T14:30:03Z	PASS	442	verify.sh	Post-rebase: NameServers Fn::Join matched the live delegation set; 8 created / 8 deleted, 0 errors, no AWS resource orphans
+route53	2026-08-14T00:00:00Z	PASS	349	verify.sh	PR #1868 maintainer re-run; Fn::Join over NameServers matched the live delegation set; 8 deleted, 0 errors, 0 orphans
 s3-analytics-inventory	2026-08-13T00:49:56Z	PASS	135	verify.sh	1707/1717/1718 live after review round 3; 49 assertions, 0 orphans
 s3-asset-deploy	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 s3-cloudfront	2026-08-13T09:22:26Z	PASS	1150	verify.sh	PR 1745 re-run after review fixes (provider edit staled integ-destroy); 5 deleted 0 errors, 0 orphans

--- a/tests/integration/route53/lib/route53-stack.ts
+++ b/tests/integration/route53/lib/route53-stack.ts
@@ -14,6 +14,8 @@ import * as logs from 'aws-cdk-lib/aws-logs';
  * - AWS::Route53::CidrCollection (CC-API) + RecordSet with CidrRoutingConfig (#609 backfill)
  * - Resource dependencies (RecordSet depends on HostedZone)
  * - Fn::GetAtt for outputs (HostedZoneId, HostedZone NameServers, HealthCheckId)
+ * - The NameServers list read BOTH ways: through Fn::Join, and bare so the
+ *   Output persists a JSON array whose element count is observable (#1873)
  * - HostedZoneTags + QueryLoggingConfig REMOVAL resets (#1160 route53 batch)
  *
  * The REMOVAL phase (gated on CDKD_TEST_REMOVAL, issue #1160 route53 batch)
@@ -170,6 +172,26 @@ export class Route53Stack extends cdk.Stack {
     // provider attribute capture -> Fn::GetAtt -> Fn::Join -> state output.
     new cdk.CfnOutput(this, 'HostedZoneNameServers', {
       value: cdk.Fn.join(',', zone.hostedZoneNameServers ?? []),
+    });
+
+    // Issue #1873: the SAME attribute with NO Fn::Join, so the Output value is
+    // the bare Fn::GetAtt over a list-valued attribute. This is the shape the
+    // joined Output above structurally cannot check: Fn::Join with ',' renders
+    // `['a','b']` and `['a,b']` to the identical string, so a single-element
+    // collapse is invisible to any post-join comparison. Here cdkd stores the
+    // resolved value verbatim, so `state.outputs` carries a JSON ARRAY and
+    // verify.sh can assert the element COUNT and the members directly.
+    //
+    // `CfnOutput.value` is typed `string` because CloudFormation Outputs must
+    // be strings; the cast is deliberate. cdkd resolves Outputs itself and
+    // persists whatever the resolver returned (`outputs` is
+    // `Record<string, unknown>`), which is exactly the user-visible shape
+    // under test. This Output is therefore cdkd-specific by construction and
+    // is not claimed to round-trip through real CloudFormation.
+    const cfnZone = zone.node.defaultChild as route53.CfnHostedZone;
+    new cdk.CfnOutput(this, 'HostedZoneNameServersList', {
+      value: cdk.Fn.getAtt(cfnZone.logicalId, 'NameServers') as unknown as string,
+      description: 'Bare Fn::GetAtt over the NameServers LIST (no Fn::Join) — issue #1873',
     });
 
     new cdk.CfnOutput(this, 'HealthCheckId', {

--- a/tests/integration/route53/verify.sh
+++ b/tests/integration/route53/verify.sh
@@ -86,6 +86,12 @@ LOCAL_DIST="${PWD}/../../../dist/cli.js"
 
 cleanup() {
   echo "==> Cleanup: dropping any leftover state + AWS resources"
+  # The NameServers probe's stderr scratch file is unlinked on every path
+  # the probe itself takes, but a SIGNAL between its `mktemp` and that
+  # unlink would strand it -- and `/run-integ` SIGTERMs this script on its
+  # time clamp, so that window is reachable rather than theoretical. This
+  # runs on EXIT / INT / TERM, so sweeping it here covers all three.
+  rm -f "${LIVE_NS_STDERR:-}" 2>/dev/null || true
   # `set +eu` so an early-exit (e.g. STATE_BUCKET unset) does not abort
   # cleanup on the first `"${STATE_BUCKET}"` expansion — best-effort
   # cleanup should run as much as it can with the env it has.

--- a/tests/integration/route53/verify.sh
+++ b/tests/integration/route53/verify.sh
@@ -170,27 +170,63 @@ JOINED_NAME_SERVERS_SORTED=$(printf '%s' "${JOINED_NAME_SERVERS}" \
   | jq -Rr 'split(",") | sort | join(",")')
 
 # The live read is a POSITIVE probe (the zone must exist here), so it follows
-# this file's header rule the same way the gone-probes do: capture combined
-# output, branch on the exit status, and report the canonical not-found case
-# separately from an undetermined failure (throttle / auth / network). The old
+# this file's header rule the same way the gone-probes do: branch on the exit
+# status, and report the canonical not-found case separately from an
+# undetermined failure (throttle / auth / network). The original
 # `$(aws ... 2>/dev/null)` form aborted the whole script at the assignment
 # under `set -euo pipefail` with the AWS error discarded, so an expired token
 # and a deleted zone were indistinguishable -- and both looked like the
 # NameServers assertion itself had blown up.
+#
+# stderr goes to a FILE, never `2>&1` into the captured value. The AWS CLI
+# writes to stderr on plenty of SUCCESSFUL calls (urllib3 / NotOpenSSLWarning,
+# python deprecation notices, SSO token refresh), and combining the streams
+# prepends those lines to the JSON payload we are about to parse. The
+# emptiness guard would pass (the string is neither empty nor `null`) and jq
+# would then die with `parse error: Invalid numeric literal` and rc=5, with no
+# FAIL: line naming the assertion -- reintroducing on the SUCCESS path exactly
+# the opacity this block removes from the failure path.
+LIVE_NS_STDERR=$(mktemp)
 if ! LIVE_NAME_SERVERS=$(aws route53 get-hosted-zone --id "${ZONE_ID}" --region "${REGION}" \
-  --query 'DelegationSet.NameServers' --output json 2>&1); then
-  if printf '%s' "${LIVE_NAME_SERVERS}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
+  --query 'DelegationSet.NameServers' --output json 2>"${LIVE_NS_STDERR}"); then
+  LIVE_NS_ERR=$(cat "${LIVE_NS_STDERR}")
+  rm -f "${LIVE_NS_STDERR}"
+  # Route 53-specific signature, deliberately NARROWER than `gone_probe`'s
+  # generic pattern above -- do NOT hoist the two into one shared variable.
+  # gone_probe is a cross-service NEGATIVE probe whose caller wants any
+  # not-found spelling; this is a POSITIVE probe whose whole job is telling a
+  # deleted zone apart from a broken credential, and the generic pattern
+  # cannot do that here. Two of its alternations match failures that are not
+  # about the zone at all: botocore's SSO-token load error ends in the same
+  # words as a missing resource ("Token for https://... does not exist"), and
+  # a shell reporting a missing `aws` binary ends in the same words as a
+  # missing lookup target. Both would be reported as "the hosted zone is
+  # gone", which is the confusion this block exists to end. The exit code is 1
+  # either way -- it is the DIAGNOSTIC that would lie. (Spelled out rather
+  # than quoted: a verbatim copy of the shared alternation here would read to
+  # scripts/check-integ-probe-not-found.ts as a drifted partial duplicate of
+  # the canonical signature, which is a rule worth keeping.)
+  ROUTE53_ZONE_NOT_FOUND_RE='NoSuchHostedZone|no hosted zone found'
+  if printf '%s' "${LIVE_NS_ERR}" | grep -qiE "${ROUTE53_ZONE_NOT_FOUND_RE}"; then
     echo "FAIL: hosted zone ${ZONE_ID} does not exist while asserting its NameServers" >&2
   else
     echo "FAIL: get-hosted-zone probe undetermined for ${ZONE_ID}" >&2
   fi
-  echo "  aws said: ${LIVE_NAME_SERVERS}" >&2
+  echo "  aws said: ${LIVE_NS_ERR}" >&2
   exit 1
 fi
-# An absent delegation set serializes as the JSON literal `null`, on which the
-# `sort` below exits 5 -- a jq error where an assertion failure is meant.
-if [ -z "${LIVE_NAME_SERVERS}" ] || [ "${LIVE_NAME_SERVERS}" = "null" ]; then
-  echo "FAIL: hosted zone ${ZONE_ID} reports no DelegationSet.NameServers on AWS" >&2
+rm -f "${LIVE_NS_STDERR}"
+
+# Validate the PAYLOAD before any jq that assumes an array. This subsumes the
+# empty / `null` guard (an absent delegation set serializes as the JSON literal
+# `null`, on which `sort` exits 5 -- a jq error where an assertion failure is
+# meant) AND covers a case the emptiness check missed: an empty `[]` used to
+# fall through and resurface as a confusing joined-output mismatch with an
+# empty `expected:`. It is also what catches a stderr line smuggled into the
+# payload, should any future edit reintroduce `2>&1` here.
+if ! printf '%s' "${LIVE_NAME_SERVERS}" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+  echo "FAIL: get-hosted-zone did not return a NameServers array for ${ZONE_ID}" >&2
+  echo "  aws said: ${LIVE_NAME_SERVERS}" >&2
   exit 1
 fi
 LIVE_NAME_SERVERS_SORTED=$(printf '%s' "${LIVE_NAME_SERVERS}" \
@@ -216,7 +252,7 @@ LIVE_NAME_SERVERS_SORTED=$(printf '%s' "${LIVE_NAME_SERVERS}" \
 # pre-#1868 single-element collapse. The Output under test is already
 # `Fn::Join`ed with ',', so `['a','b']` and `['a,b']` render the identical
 # string and no post-join check can tell them apart (measured with a stubbed
-# aws, 2026-08-14 -- it passes). Pre-#1868 that shape surfaced here only
+# aws, 2026-08-13 UTC -- it passes). Pre-#1868 that shape surfaced here only
 # because Fn::Join THREW on a string operand and the Output went missing from
 # state, which is what the `-z "${JOINED_NAME_SERVERS}"` guard above catches.
 # The element COUNT itself is fenced by the same two unit tests.

--- a/tests/integration/route53/verify.sh
+++ b/tests/integration/route53/verify.sh
@@ -231,6 +231,47 @@ if [ "${JOINED_NAME_SERVERS_SORTED}" != "${LIVE_NAME_SERVERS_SORTED}" ]; then
 fi
 echo "    OK: Fn::Join resolved the HostedZone NameServers list (${JOINED_NAME_SERVERS})"
 
+# --- Assertion: the BARE Fn::GetAtt Output round-trips as a real LIST -------
+# Issue #1873. This is the arm the joined Output above structurally cannot
+# provide: `Fn::Join` with ',' renders `['a','b']` and `['a,b']` identically,
+# so a single-element collapse survives every post-join comparison. cdkd
+# resolves Outputs itself and stores the resolved value verbatim
+# (`resolveOutputs` -> `state.outputs`, typed `Record<string, unknown>`), so
+# the bare Fn::GetAtt persists a JSON ARRAY and the element COUNT and members
+# become directly observable.
+NS_LIST_TYPE=$(echo "${STATE}" | jq -r '.outputs.HostedZoneNameServersList | type')
+if [ "${NS_LIST_TYPE}" != "array" ]; then
+  echo "FAIL: HostedZoneNameServersList is '${NS_LIST_TYPE}', expected 'array'" >&2
+  echo "  a bare Fn::GetAtt over a list-valued attribute must persist a JSON array" >&2
+  echo "${STATE}" | jq '.outputs.HostedZoneNameServersList'
+  exit 1
+fi
+
+# Count first, and compare it to the LIVE count rather than to a literal: the
+# delegation-set size is AWS's to choose, so a hardcoded 4 would be a fixture
+# assumption rather than a measurement. This is the check that catches the
+# pre-#1868 collapse -- one element holding the whole comma-joined string.
+NS_LIST_COUNT=$(echo "${STATE}" | jq -r '.outputs.HostedZoneNameServersList | length')
+LIVE_NAME_SERVERS_COUNT=$(printf '%s' "${LIVE_NAME_SERVERS}" | jq -r 'length')
+if [ "${NS_LIST_COUNT}" != "${LIVE_NAME_SERVERS_COUNT}" ]; then
+  echo "FAIL: HostedZoneNameServersList has ${NS_LIST_COUNT} element(s), Route 53 reports ${LIVE_NAME_SERVERS_COUNT}" >&2
+  echo "  (1 element vs several is the pre-#1868 comma-string collapse)" >&2
+  echo "${STATE}" | jq '.outputs.HostedZoneNameServersList'
+  exit 1
+fi
+
+# Then the members. Sorted for the same reason as the joined assertion above
+# (AWS does not guarantee a stable delegation-set order across calls); the
+# count check above is what the sort cannot give us.
+NS_LIST_SORTED=$(echo "${STATE}" | jq -r '.outputs.HostedZoneNameServersList | sort | join(",")')
+if [ "${NS_LIST_SORTED}" != "${LIVE_NAME_SERVERS_SORTED}" ]; then
+  echo "FAIL: HostedZoneNameServersList members do not match Route 53" >&2
+  echo "  got:      ${NS_LIST_SORTED}" >&2
+  echo "  expected: ${LIVE_NAME_SERVERS_SORTED}" >&2
+  exit 1
+fi
+echo "    OK: bare Fn::GetAtt persisted a ${NS_LIST_COUNT}-element LIST matching the live delegation set (#1873)"
+
 # --- Assertion: Ref to a RecordSet is the record NAME (issue #1681) ----
 # cdkd stores the composite physicalId `<hostedZoneId>|<name>|<type>`, while
 # CloudFormation's `Ref` returns "the name of the record" — the MIDDLE

--- a/tests/integration/route53/verify.sh
+++ b/tests/integration/route53/verify.sh
@@ -168,14 +168,65 @@ fi
 
 JOINED_NAME_SERVERS_SORTED=$(printf '%s' "${JOINED_NAME_SERVERS}" \
   | jq -Rr 'split(",") | sort | join(",")')
-LIVE_NAME_SERVERS=$(aws route53 get-hosted-zone --id "${ZONE_ID}" --region "${REGION}" \
-  --query 'DelegationSet.NameServers' --output json 2>/dev/null)
+
+# The live read is a POSITIVE probe (the zone must exist here), so it follows
+# this file's header rule the same way the gone-probes do: capture combined
+# output, branch on the exit status, and report the canonical not-found case
+# separately from an undetermined failure (throttle / auth / network). The old
+# `$(aws ... 2>/dev/null)` form aborted the whole script at the assignment
+# under `set -euo pipefail` with the AWS error discarded, so an expired token
+# and a deleted zone were indistinguishable -- and both looked like the
+# NameServers assertion itself had blown up.
+if ! LIVE_NAME_SERVERS=$(aws route53 get-hosted-zone --id "${ZONE_ID}" --region "${REGION}" \
+  --query 'DelegationSet.NameServers' --output json 2>&1); then
+  if printf '%s' "${LIVE_NAME_SERVERS}" | grep -qiE 'not ?found|no ?such|does ?not ?exist|non ?existent|\(404'; then
+    echo "FAIL: hosted zone ${ZONE_ID} does not exist while asserting its NameServers" >&2
+  else
+    echo "FAIL: get-hosted-zone probe undetermined for ${ZONE_ID}" >&2
+  fi
+  echo "  aws said: ${LIVE_NAME_SERVERS}" >&2
+  exit 1
+fi
+# An absent delegation set serializes as the JSON literal `null`, on which the
+# `sort` below exits 5 -- a jq error where an assertion failure is meant.
+if [ -z "${LIVE_NAME_SERVERS}" ] || [ "${LIVE_NAME_SERVERS}" = "null" ]; then
+  echo "FAIL: hosted zone ${ZONE_ID} reports no DelegationSet.NameServers on AWS" >&2
+  exit 1
+fi
 LIVE_NAME_SERVERS_SORTED=$(printf '%s' "${LIVE_NAME_SERVERS}" \
   | jq -r 'sort | join(",")')
+
+# Both sides are SORTED deliberately, and the trade-off is recorded here
+# because it is a judgement call (issue #1873): Route 53 does not guarantee
+# that GetHostedZone returns the delegation set in the same order that
+# CreateHostedZone did, and the two sides of this comparison come from those
+# two different calls (the Output was resolved from the create-time attribute
+# in state). An unsorted compare would therefore be flaky, and per the repo's
+# "list readbacks must be order-insensitive" rule its failure message would
+# accuse the very fix it is guarding.
+#
+# What sorting gives up is an order-SCRAMBLING regression inside cdkd. That
+# half is fenced deterministically at the unit level instead -- the bare
+# Fn::GetAtt assertions in tests/unit/deployment/intrinsic-functions.test.ts
+# and tests/unit/deployment/deploy-engine-outputs-nameservers-list.test.ts pin
+# the exact element ORDER the resolver produces from a fixed input, which a
+# live AWS readback cannot do.
+#
+# Note what this comparison can NOT see either way, sorted or not: the
+# pre-#1868 single-element collapse. The Output under test is already
+# `Fn::Join`ed with ',', so `['a','b']` and `['a,b']` render the identical
+# string and no post-join check can tell them apart (measured with a stubbed
+# aws, 2026-08-14 -- it passes). Pre-#1868 that shape surfaced here only
+# because Fn::Join THREW on a string operand and the Output went missing from
+# state, which is what the `-z "${JOINED_NAME_SERVERS}"` guard above catches.
+# The element COUNT itself is fenced by the same two unit tests.
 if [ "${JOINED_NAME_SERVERS_SORTED}" != "${LIVE_NAME_SERVERS_SORTED}" ]; then
   echo "FAIL: HostedZoneNameServers output does not match Route 53" >&2
-  echo "  got:      ${JOINED_NAME_SERVERS}" >&2
+  # Print the SORTED form on both lines -- printing the raw output against a
+  # sorted expectation made the two lines differ even on a spurious mismatch.
+  echo "  got:      ${JOINED_NAME_SERVERS_SORTED}" >&2
   echo "  expected: ${LIVE_NAME_SERVERS_SORTED}" >&2
+  echo "  (raw output value: ${JOINED_NAME_SERVERS})" >&2
   exit 1
 fi
 echo "    OK: Fn::Join resolved the HostedZone NameServers list (${JOINED_NAME_SERVERS})"

--- a/tests/unit/deployment/deploy-engine-outputs-nameservers-list.test.ts
+++ b/tests/unit/deployment/deploy-engine-outputs-nameservers-list.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { DeployEngine } from '../../../src/deployment/deploy-engine.js';
+import type { CloudFormationTemplate } from '../../../src/types/resource.js';
+import type { ResourceChange, StackState } from '../../../src/types/state.js';
+import { STATE_SCHEMA_VERSION_CURRENT } from '../../../src/types/state.js';
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  }),
+}));
+
+vi.mock('p-limit', () => ({
+  default: vi.fn(() => <T>(fn: () => T) => fn()),
+}));
+
+/**
+ * Issue #1873 item 5a: a BARE `Fn::GetAtt` over
+ * `AWS::Route53::HostedZone.NameServers` used directly as a stack Output.
+ *
+ * `resolveOutputs` stores whatever the resolver returned, verbatim — so since
+ * PR #1868 kept the attribute in its CloudFormation list shape, such an Output
+ * persists a JSON ARRAY into `state.outputs` where it used to persist a
+ * comma-delimited string. That is a user-visible shape change in the state
+ * file (and in the exports index) and had zero coverage: every existing test
+ * read the attribute through `Fn::Join`, which collapses both shapes back to
+ * one string.
+ *
+ * The resolver is deliberately NOT mocked here (unlike the sibling
+ * `deploy-engine-outputs-only-change.test.ts`, whose identity-resolver mock
+ * would make the assertion vacuous) — the point is to exercise the real
+ * `resolveGetAtt` normalization all the way through to what `saveState`
+ * receives.
+ */
+describe('DeployEngine - bare Fn::GetAtt over HostedZone NameServers as an Output (#1873)', () => {
+  const stackName = 'route53-stack';
+
+  let mockProvider: {
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    getAttribute: ReturnType<typeof vi.fn>;
+    readCurrentState: ReturnType<typeof vi.fn>;
+  };
+  let mockStateBackend: {
+    getState: ReturnType<typeof vi.fn>;
+    saveState: ReturnType<typeof vi.fn>;
+  };
+  let mockLockManager: {
+    acquireLockWithRetry: ReturnType<typeof vi.fn>;
+    releaseLock: ReturnType<typeof vi.fn>;
+  };
+  let mockDagBuilder: {
+    buildGraph: ReturnType<typeof vi.fn>;
+    getExecutionLevels: ReturnType<typeof vi.fn>;
+    getDirectDependencies: ReturnType<typeof vi.fn>;
+  };
+  let mockDiffCalculator: {
+    calculateDiff: ReturnType<typeof vi.fn>;
+    hasChanges: ReturnType<typeof vi.fn>;
+    filterByType: ReturnType<typeof vi.fn>;
+  };
+  let mockProviderRegistry: {
+    getProvider: ReturnType<typeof vi.fn>;
+    getProviderFor: ReturnType<typeof vi.fn>;
+    getRegisteredTypes: ReturnType<typeof vi.fn>;
+    validateResourceTypes: ReturnType<typeof vi.fn>;
+    validateResourceProperties: ReturnType<typeof vi.fn>;
+  };
+  let mockExportIndexStore: {
+    updateForStack: ReturnType<typeof vi.fn>;
+    lookup: ReturnType<typeof vi.fn>;
+    patchEntry: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockProvider = {
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      getAttribute: vi.fn(),
+      readCurrentState: vi.fn(),
+    };
+    mockLockManager = {
+      acquireLockWithRetry: vi.fn().mockResolvedValue(true),
+      releaseLock: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDagBuilder = {
+      buildGraph: vi.fn().mockReturnValue({}),
+      getExecutionLevels: vi.fn().mockReturnValue([]),
+      getDirectDependencies: vi.fn().mockReturnValue([]),
+    };
+    mockDiffCalculator = {
+      calculateDiff: vi.fn().mockResolvedValue(
+        new Map<string, ResourceChange>([
+          [
+            'HostedZone',
+            {
+              logicalId: 'HostedZone',
+              changeType: 'NO_CHANGE',
+              resourceType: 'AWS::Route53::HostedZone',
+            },
+          ],
+        ])
+      ),
+      hasChanges: vi.fn().mockReturnValue(false),
+      filterByType: vi
+        .fn()
+        .mockImplementation((changes: Map<string, ResourceChange>, type: string) =>
+          Array.from(changes.values()).filter((c) => c.changeType === type)
+        ),
+    };
+    mockProviderRegistry = {
+      getProvider: vi.fn().mockReturnValue(mockProvider),
+      getProviderFor: vi.fn().mockReturnValue({ provider: mockProvider, provisionedBy: 'sdk' }),
+      getRegisteredTypes: vi.fn().mockReturnValue([]),
+      validateResourceTypes: vi.fn(),
+      validateResourceProperties: vi.fn(),
+    };
+    mockStateBackend = {
+      getState: vi.fn(),
+      saveState: vi.fn().mockResolvedValue('etag-new'),
+    };
+    mockExportIndexStore = {
+      updateForStack: vi.fn().mockResolvedValue(undefined),
+      lookup: vi.fn().mockResolvedValue(null),
+      patchEntry: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  /**
+   * `observedProperties` present keeps the auto-refresh path dormant, so the
+   * only thing under test is what `resolveOutputs` persists.
+   */
+  function makeState(nameServers: unknown): StackState {
+    return {
+      version: STATE_SCHEMA_VERSION_CURRENT,
+      region: 'us-east-1',
+      stackName,
+      resources: {
+        HostedZone: {
+          physicalId: 'Z1234567890',
+          resourceType: 'AWS::Route53::HostedZone',
+          properties: { Name: 'example.com' },
+          observedProperties: { Name: 'example.com' },
+          attributes: { Id: 'Z1234567890', NameServers: nameServers },
+          dependencies: [],
+        },
+      },
+      outputs: {},
+      lastModified: 0,
+    };
+  }
+
+  const template: CloudFormationTemplate = {
+    Resources: {
+      HostedZone: { Type: 'AWS::Route53::HostedZone', Properties: { Name: 'example.com' } },
+    },
+    Outputs: {
+      // No Fn::Join — the raw attribute is the Output value.
+      NameServers: { Value: { 'Fn::GetAtt': ['HostedZone', 'NameServers'] } },
+    },
+  };
+
+  function makeEngine() {
+    return new DeployEngine(
+      mockStateBackend as never,
+      mockLockManager as never,
+      mockDagBuilder as never,
+      mockDiffCalculator as never,
+      mockProviderRegistry as never,
+      { dryRun: false },
+      'us-east-1',
+      mockExportIndexStore as never
+    );
+  }
+
+  function savedOutputs(): Record<string, unknown> {
+    expect(mockStateBackend.saveState).toHaveBeenCalledTimes(1);
+    return (mockStateBackend.saveState.mock.calls[0]![2] as StackState).outputs as unknown as Record<
+      string,
+      unknown
+    >;
+  }
+
+  it('persists the LIST verbatim into state.outputs (list-shaped state)', async () => {
+    mockStateBackend.getState.mockResolvedValue({
+      state: makeState(['ns-1.example.com', 'ns-2.example.com']),
+      etag: 'etag-old',
+    });
+
+    const result = await makeEngine().deploy(stackName, template);
+
+    // Element-wise equality, so a single-element collapse is RED.
+    expect(savedOutputs()['NameServers']).toEqual(['ns-1.example.com', 'ns-2.example.com']);
+    expect(result.outputs?.['NameServers']).toEqual(['ns-1.example.com', 'ns-2.example.com']);
+  });
+
+  it('persists a LIST for a LEGACY comma-delimited state value, not the string', async () => {
+    // The v1 state shape (pre-#1868): a comma-joined string. The read-boundary
+    // normalization must turn it into N elements before it lands in outputs.
+    mockStateBackend.getState.mockResolvedValue({
+      state: makeState('ns-1.example.com,ns-2.example.com'),
+      etag: 'etag-old',
+    });
+
+    await makeEngine().deploy(stackName, template);
+
+    const persisted = savedOutputs()['NameServers'];
+    expect(Array.isArray(persisted)).toBe(true);
+    expect(persisted).toEqual(['ns-1.example.com', 'ns-2.example.com']);
+  });
+
+  it('persists an EMPTY list for an empty legacy value', async () => {
+    mockStateBackend.getState.mockResolvedValue({
+      state: makeState(''),
+      etag: 'etag-old',
+    });
+
+    await makeEngine().deploy(stackName, template);
+
+    expect(savedOutputs()['NameServers']).toEqual([]);
+  });
+});

--- a/tests/unit/deployment/intrinsic-functions.test.ts
+++ b/tests/unit/deployment/intrinsic-functions.test.ts
@@ -2217,14 +2217,82 @@ describe('IntrinsicFunctionResolver - Fn::Join over a list-returning intrinsic',
     expect(result).toBe('ns-1.example.com,ns-2.example.com');
   });
 
-  it('normalizes the legacy comma-delimited HostedZone NameServers state before joining', async () => {
+  // --- Route 53 HostedZone.NameServers list-shape fences (issue #1873) ------
+  // The normalization block in `resolveGetAtt` is guarded THREE ways
+  // (resourceType === HostedZone, attributeName === NameServers, value is a
+  // string) and produces `[]` for the empty string. Each of the tests below
+  // is written so that removing exactly one of those pieces turns it RED —
+  // joining the result with the SAME `,` the block splits on cannot do that,
+  // because `['a,b'].join(',')` and `['a','b'].join(',')` are the same string.
+  const legacyHostedZoneContext = (nameServers: unknown): ResolverContext => ({
+    template: {} as CloudFormationTemplate,
+    resources: {
+      HostedZone: {
+        physicalId: 'Z1234567890',
+        resourceType: 'AWS::Route53::HostedZone',
+        properties: { Name: 'example.com' },
+        attributes: {
+          Id: 'Z1234567890',
+          NameServers: nameServers,
+        },
+        dependencies: [],
+      },
+    },
+  });
+
+  it('normalizes the legacy comma-delimited HostedZone NameServers state into a real list', async () => {
+    const context = legacyHostedZoneContext('ns-1.example.com,ns-2.example.com');
+
+    // Assert the BARE Fn::GetAtt result: this pins the element COUNT and the
+    // per-element values, so replacing `flatValue.split(',')` with
+    // `[flatValue]` fails here (a single element still "is not a string").
+    const bare = await resolver.resolve({ 'Fn::GetAtt': ['HostedZone', 'NameServers'] }, context);
+    expect(bare).toEqual(['ns-1.example.com', 'ns-2.example.com']);
+
+    // And the Fn::Join over it, joined with a delimiter that DIFFERS from the
+    // split delimiter so the join cannot reconstruct the un-split string.
+    const joined = await resolver.resolve(
+      { 'Fn::Join': [' | ', { 'Fn::GetAtt': ['HostedZone', 'NameServers'] }] },
+      context
+    );
+    expect(joined).toBe('ns-1.example.com | ns-2.example.com');
+  });
+
+  it('normalizes an EMPTY legacy NameServers string to an empty list, not a one-element list', async () => {
+    // The `flatValue === '' ? [] : flatValue.split(',')` ternary: an
+    // unconditional `''.split(',')` yields `['']`, i.e. one bogus empty name
+    // server that Fn::Join would render as an empty string.
+    const context = legacyHostedZoneContext('');
+
+    const bare = await resolver.resolve({ 'Fn::GetAtt': ['HostedZone', 'NameServers'] }, context);
+    expect(bare).toEqual([]);
+    expect(bare).toHaveLength(0);
+  });
+
+  it('leaves a HostedZone attribute OTHER than NameServers a string (attributeName guard)', async () => {
+    // Negative control for `attributeName === 'NameServers'`. Without that
+    // guard `.Id` would resolve to `['Z1234567890']` and every consumer that
+    // interpolates the zone id would silently receive an array.
+    const context = legacyHostedZoneContext('ns-1.example.com,ns-2.example.com');
+
+    const result = await resolver.resolve({ 'Fn::GetAtt': ['HostedZone', 'Id'] }, context);
+
+    expect(Array.isArray(result)).toBe(false);
+    expect(result).toBe('Z1234567890');
+  });
+
+  it('leaves a NON-Route 53 resource NameServers attribute a string (resourceType guard)', async () => {
+    // Negative control for `resource.resourceType === 'AWS::Route53::HostedZone'`.
+    // The attribute name matches, and the value happens to contain a comma —
+    // only the resource-type guard keeps it a string. A custom resource is the
+    // realistic carrier: its outputs are opaque strings cdkd must not reshape.
     const context: ResolverContext = {
       template: {} as CloudFormationTemplate,
       resources: {
-        HostedZone: {
-          physicalId: 'Z1234567890',
-          resourceType: 'AWS::Route53::HostedZone',
-          properties: { Name: 'example.com' },
+        Lookup: {
+          physicalId: 'lookup-1',
+          resourceType: 'Custom::DnsLookup',
+          properties: {},
           attributes: {
             NameServers: 'ns-1.example.com,ns-2.example.com',
           },
@@ -2233,12 +2301,32 @@ describe('IntrinsicFunctionResolver - Fn::Join over a list-returning intrinsic',
       },
     };
 
-    const result = await resolver.resolve(
-      { 'Fn::Join': [',', { 'Fn::GetAtt': ['HostedZone', 'NameServers'] }] },
-      context
-    );
+    const result = await resolver.resolve({ 'Fn::GetAtt': ['Lookup', 'NameServers'] }, context);
 
+    expect(Array.isArray(result)).toBe(false);
     expect(result).toBe('ns-1.example.com,ns-2.example.com');
+  });
+
+  it('resolves Fn::Select over the HostedZone NameServers list (both state shapes)', async () => {
+    // Fn::Select is the other common read shape over the list. On the legacy
+    // string state it is ONLY correct once the normalization has produced N
+    // elements — `[flatValue]` makes index 1 out of bounds.
+    const listState = legacyHostedZoneContext(['ns-1.example.com', 'ns-2.example.com']);
+    const stringState = legacyHostedZoneContext('ns-1.example.com,ns-2.example.com');
+
+    for (const context of [listState, stringState]) {
+      const first = await resolver.resolve(
+        { 'Fn::Select': [0, { 'Fn::GetAtt': ['HostedZone', 'NameServers'] }] },
+        context
+      );
+      const second = await resolver.resolve(
+        { 'Fn::Select': [1, { 'Fn::GetAtt': ['HostedZone', 'NameServers'] }] },
+        context
+      );
+
+      expect(first).toBe('ns-1.example.com');
+      expect(second).toBe('ns-2.example.com');
+    }
   });
 
   it('should still resolve Fn::Join whose second arg is a literal array (regression)', async () => {

--- a/tests/unit/provisioning/route53-provider.test.ts
+++ b/tests/unit/provisioning/route53-provider.test.ts
@@ -90,6 +90,20 @@ describe('Route53Provider', () => {
 
         expect(result).toEqual(['ns-1.example.com', 'ns-2.example.com']);
       });
+
+      it('returns an empty LIST when the zone has no delegation set (issue #1873)', async () => {
+        // The `?? []` fallback: GetHostedZone answers without a DelegationSet.
+        mockSend.mockResolvedValueOnce({});
+
+        const result = await provider.getAttribute(
+          'Z1234567890',
+          'AWS::Route53::HostedZone',
+          'NameServers'
+        );
+
+        expect(result).toEqual([]);
+        expect(Array.isArray(result)).toBe(true);
+      });
     });
 
     describe('update', () => {
@@ -113,6 +127,22 @@ describe('Route53Provider', () => {
           Id: 'Z1234567890',
           NameServers: ['ns-1.example.com', 'ns-2.example.com'],
         });
+      });
+
+      it('returns an empty LIST when the post-update read has no delegation set (issue #1873)', async () => {
+        mockSend.mockResolvedValueOnce({}); // UpdateHostedZoneComment
+        mockSend.mockResolvedValueOnce({}); // GetHostedZone, no DelegationSet
+
+        const result = await provider.update(
+          'MyZone',
+          'Z1234567890',
+          'AWS::Route53::HostedZone',
+          { Name: 'example.com' },
+          { Name: 'example.com' }
+        );
+
+        expect(result.attributes).toEqual({ Id: 'Z1234567890', NameServers: [] });
+        expect(Array.isArray(result.attributes?.['NameServers'])).toBe(true);
       });
     });
 
@@ -148,12 +178,34 @@ describe('Route53Provider', () => {
           DelegationSet: { NameServers: [] },
         });
 
-        await provider.create('MyZone', 'AWS::Route53::HostedZone', {
+        const result = await provider.create('MyZone', 'AWS::Route53::HostedZone', {
           Name: 'example.com',
         });
 
+        // An EMPTY delegation set stays an empty LIST (issue #1873). Pre-#1868
+        // the provider flattened NameServers to a comma-joined string, so this
+        // case produced `''`; a downstream Fn::Join / Fn::Select over the
+        // attribute needs the list shape even when there is nothing in it.
+        expect(result.attributes).toEqual({ Id: 'Z1234567890', NameServers: [] });
+
         expect(mockSend).toHaveBeenCalledTimes(1);
         expect(mockSend.mock.calls[0][0].constructor.name).toBe('CreateHostedZoneCommand');
+      });
+
+      it('create: an ABSENT DelegationSet still yields an empty NameServers LIST', async () => {
+        // Pins the `?? []` default itself: the response carries no
+        // DelegationSet at all, so the fallback — not the AWS payload — is
+        // what decides the attribute shape.
+        mockSend.mockResolvedValueOnce({
+          HostedZone: { Id: '/hostedzone/Z1234567890' },
+        });
+
+        const result = await provider.create('MyZone', 'AWS::Route53::HostedZone', {
+          Name: 'example.com',
+        });
+
+        expect(result.attributes).toEqual({ Id: 'Z1234567890', NameServers: [] });
+        expect(Array.isArray(result.attributes?.['NameServers'])).toBe(true);
       });
 
       it('create: omits UpdateHostedZoneFeatures when AcceleratedRecoveryStatus=DISABLED (matches AWS default)', async () => {
@@ -162,10 +214,12 @@ describe('Route53Provider', () => {
           DelegationSet: { NameServers: [] },
         });
 
-        await provider.create('MyZone', 'AWS::Route53::HostedZone', {
+        const result = await provider.create('MyZone', 'AWS::Route53::HostedZone', {
           Name: 'example.com',
           HostedZoneFeatures: { AcceleratedRecoveryStatus: 'DISABLED' },
         });
+
+        expect(result.attributes).toEqual({ Id: 'Z1234567890', NameServers: [] });
 
         // Only CreateHostedZone fires — DISABLED is the AWS default so we skip
         // the explicit toggle call.


### PR DESCRIPTION
## Summary

Follow-up to PR #1868 (Route 53 `HostedZone.NameServers` kept as a CFn list). The shipped behavior was correct and every source line was fenced by at least one test — but several of those fences passed **for the wrong reason**, so a future regression in the same lines would have gone unnoticed. This PR makes each one discriminate. **No `src/**` change: every fix is in a test or the integ fixture.**

Each item below is backed by a mutation probe applied to the REAL source (per line, not by text anchor — the provider's `?? []` occurs three times), and re-derived independently by a reviewer.

| # | Fence that passed for the wrong reason | Probe | Now |
|---|---|---|---|
| 1 | Legacy-split assertion joined with the SAME `,` it split on, so `split(',')` → `[flatValue]` stayed green | `resolver:1715` → `[flatValue]` | RED 3 tests |
| 2 | Neither guard on the normalization block had a negative control | delete `resourceType` guard | RED 1 (distinct) |
| 2 | " | delete `attributeName` guard | RED 1 (distinct) |
| 3 | The `'' -> []` empty-string edge was claimed in the changelog but untested | unconditional `split(',')` | RED 2 tests |
| 4 | The provider's `?? []` shape was unasserted | `?? ''` at each of the 3 sites | RED 1 each |

Items 2's two probes red **disjoint** tests, which is why the non-Route53 negative control deliberately names its attribute `NameServers` — otherwise deleting the `resourceType` guard would never reach it. Item 4 needed three NEW absent-`DelegationSet` tests: the pre-existing `NameServers: []` cases correctly stay green under a `?? ''` mutation, because `[]` is not nullish.

## The integ fixture could not see three whole failure modes

The existing check asserts a `Fn::Join`ed Output against the live delegation set. Anything already joined with `','` is blind to how the value was SHAPED, so this PR adds a bare `Fn::GetAtt` Output (no `Fn::Join`) and asserts it is a real array whose element count matches the LIVE count (not a hardcoded 4) and whose members match:

| `state.outputs` value | old joined check | new list arm |
|---|---|---|
| healthy 4-element array | pass | **pass** |
| collapse — `["ns-1,ns-2,ns-3,ns-4"]` | pass (blind) | **FAIL** — 1 element, live 4 |
| pre-#1868 comma string | pass (blind) | **FAIL** — type is `string` |
| output missing entirely | pass (blind) | **FAIL** — type is `null` |
| one wrong member | pass | **FAIL** — members differ |

A correction worth stating: an earlier version of the sorting rationale claimed the joined check still caught the single-element collapse. A stubbed `aws` disproved it — `['a','b']` and `['a,b']` render the identical string, so no post-join check can tell them apart. The comment now records that honestly, and the new arm is what actually closes it.

Both comparison sides stay sorted deliberately (Route 53 does not guarantee `GetHostedZone` returns the delegation set in `CreateHostedZone`'s order, and the two sides come from those two different calls). Element ORDER is pinned deterministically at the unit level instead, which a live readback cannot do.

## `verify.sh` probe robustness — including a defect this PR introduced and then fixed

The original `LIVE_NAME_SERVERS=$(aws route53 get-hosted-zone ... 2>/dev/null)` aborted the whole script at the assignment under `set -euo pipefail` with the AWS error discarded, so an expired token and a deleted zone were indistinguishable.

The first rework replaced it with `2>&1` + a status branch — and review caught that this moved the opacity rather than removing it: the AWS CLI writes to stderr on SUCCESSFUL calls (urllib3 / `NotOpenSSLWarning`, SSO refresh notices), so any such line was prepended to the JSON payload and `jq` died with rc=5 and no `FAIL:` line. Measured with a stub emitting one stderr line plus valid JSON on exit 0:

| | first rework | shipped |
|---|---|---|
| success + stderr warning | `jq: parse error`, **rc=5**, no `FAIL:` | **rc=0**, payload accepted |

stderr now goes to a temp file read only in the failure branch, and the payload is validated with `jq -e 'type == "array" and length > 0'` — which also subsumes the old `null`/empty guard and closes the previously unguarded `[]` case.

The not-found signature was also too broad: `does ?not ?exist` matched botocore's `Error loading SSO Token: ... does not exist` and `not ?found` matched `aws: command not found`, both reported as "hosted zone does not exist" — the exact confusion the rework claims to fix. This call site now uses `NoSuchHostedZone|no hosted zone found`; the generic `gone_probe` keeps its broad pattern, because a cross-service negative probe genuinely wants any not-found spelling while this positive probe's whole job is telling a deleted zone from a broken credential. That divergence is recorded in-code rather than hoisted.

Finally, the failure diagnostic printed the UNSORTED joined value against the SORTED live value, so the two lines differed even on a spurious mismatch. Both are sorted now, with the raw value on its own annotated line.

## Test plan

- `vp run typecheck` / `lint` / `build` — pass
- `vp run test` — 663 files, 13386 tests, all pass
- `bash -n` clean; all 29 shell-lint suites pass (1177 tests), including the probe-not-found / signal-trap / state-bucket checkers
- The behavioral harness EXTRACTS the real block from `verify.sh` rather than a retyped copy, so it cannot drift from what ships
- **Real AWS** (`route53`, twice — the second run validates the shipped probe logic, since the first validated the version review then changed): exit 0, 438s, 8 created / 8 deleted, 0 errors. The new arm fired on live data: `OK: bare Fn::GetAtt persisted a 4-element LIST matching the live delegation set (#1873)`. Post-run sweep: 0 hosted zones, 0 health checks, 0 CIDR collections, 0 query-logging log groups, 0 IAM roles, 0 `state.json` objects.

## Ledger note

`docs/_generated/integ-last-run.tsv` carries this run plus the maintainer's PR #1868 verification data from the issue. The maintainer supplied a DATE only, so that row's timestamp is the reporting comment's `created_at` — an upper bound derived from real data, stated in the note. An earlier attempt filled it with `00:00:00Z`, which for a JST-sourced date lands in the FUTURE and made the normalizer silently discard a real measured run; the last commit removes the copy the rebase replayed.

Closes #1873
