### PR TITLE
chore(integ): record the docker-image-asset run from the PR #1890 review

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -75,7 +75,7 @@ destroy-interrupt	2026-07-26T20:00:52Z	PASS	400	verify.sh	0727b sweep-b13 stalen
 diff-intrinsic-target-change	2026-08-10T06:18:10Z	PASS	46	verify.sh	0810 P2 sweep b12; diff detects GetAtt target rebind, clean destroy
 dlm-lifecycle-policy	2026-07-27T09:43:47Z	PASS	140	verify.sh	1160 removal phase 2b final-tree run, destroy 3/0, 0 orphans
 docdb-neptune	2026-07-27T06:16:35Z	PASS	1560	verify.sh	#1160 neptune+docdb removal steps 3b-3d verified; destroy w/o remove-protection 14/0 errors, 0 orphans
-docker-image-asset	2026-08-10T04:23:28Z	PASS	81	verify.sh	0810 sweep b2; post-#1406 ECR mutability filters, 2 del 0 err, 0 orph
+docker-image-asset	2026-08-14T00:41:19Z	PASS	73	verify.sh	PR 1890 review (image-function readback skip); deploy+ECR push+invoke+destroy 2 del 0 err, 0 orph; live probe: both ZIP-only Lambda getters reject with InvalidParameterValueException on a PackageType=Image function
 drift-revert	2026-08-13T08:34:06Z	PASS	215	verify.sh	broad set; 13 deleted 0 errors 0 orphans
 drift-revert-arrays	2026-08-13T08:30:39Z	PASS	230	verify.sh	issue 1783/1784 seams; 19 deleted 0 errors 0 orphans
 drift-revert-vpc	2026-08-11T15:53:33Z	PASS	314	verify.sh	#1591 final: both-sides canonicalizer + cdkd diff wiring; 21 del/0 err, 0 orph


### PR DESCRIPTION
## Summary

Records the `docker-image-asset` integ run performed while reviewing external PR #1890, per the mandatory `/run-integ` ledger rule. One row, regenerated through `vp run integ-ledger-normalize`.

The run itself is what cleared #1890's `integ-destroy` gate; it is separated from that PR because pushing a ledger row onto a contributor's branch moves HEAD and invalidates the sha-bound `pr-review` marker, forcing another review round on someone else's contribution.

## The run

- deploy -> `docker build` -> ECR push -> `PackageType=Image` Lambda -> invoke -> destroy
- 2 deleted, 0 errors, 0 orphans, state file gone, pushed image swept from the shared asset repo
- 73s wall clock (measured, not estimated)

## Why the note mentions API behavior

A background probe ran against the live image function while it existed, because #1890's safety hinged on it. Both ZIP-only getters reject rather than resolve:

```
GetRuntimeManagementConfig   -> InvalidParameterValueException ("... is a container image function")
GetFunctionCodeSigningConfig -> InvalidParameterValueException ("Code signing is not supported for functions created with container images")
```

Neither is `ResourceNotFoundException`, so the pre-#1890 code warned and emitted nothing — meaning no persisted `observedProperties` baseline can carry those keys, and skipping the reads cannot manufacture a one-sided removal drift. That is the fact a future reader of this row will want, so it lives in the note.

## Test plan

- `vp run check` / `typecheck:test` / `build`: pass
- `vp test run`: 662 files / 13,377 tests pass
- `vp run integ-ledger-normalize`: 279 rows, one per test (CI enforces this shape)
