### PR TITLE
fix(cloud-control): mask the create-path DesiredState debug log (GHSA sibling)

### DIFF
--- a/src/provisioning/cloud-control-provider.ts
+++ b/src/provisioning/cloud-control-provider.ts
@@ -229,7 +229,15 @@ export class CloudControlProvider implements ResourceProvider {
       const cleanProperties = stripNullValues(properties) as Record<string, unknown>;
       const ccProperties = stringifyJsonProperties(resourceType, cleanProperties);
       const desiredState = JSON.stringify(ccProperties);
-      this.logger.debug(`DesiredState for ${logicalId}: ${desiredState}`);
+      // Log the top-level property KEYS only, never the values (GHSA fix, sibling
+      // of the update-path patch-log masking below): a CC-routed resource with no
+      // SDK provider may carry a resolved `{{resolve:secretsmanager:...}}` value
+      // in `ccProperties`, and this provider has no access to the resolver's
+      // recorded-secret map to mask it. Keys are enough to debug a CREATE; the
+      // full document still goes to AWS below.
+      this.logger.debug(
+        `DesiredState for ${logicalId}: keys=${JSON.stringify(Object.keys(ccProperties))}`
+      );
       const createResponse = await this.cloudControlClient.send(
         new CreateResourceCommand({
           TypeName: resourceType,

--- a/tests/unit/provisioning/cloud-control-provider-create-log-redaction.test.ts
+++ b/tests/unit/provisioning/cloud-control-provider-create-log-redaction.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+// Shared debug spy so we can assert on the CREATE-path `DesiredState` log line.
+// The provider builds its logger via getLogger().child(...), so the child's
+// debug must be the shared spy.
+const mockCcSend = vi.fn();
+const mockDebug = vi.fn();
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    cloudControl: { send: mockCcSend, config: { region: () => Promise.resolve('us-east-1') } },
+    cloudFormation: { send: vi.fn() },
+  }),
+}));
+
+vi.mock('../../../src/deployment/intrinsic-function-resolver.js', () => ({
+  getAccountInfo: () =>
+    Promise.resolve({ partition: 'aws', region: 'us-east-1', accountId: '123456789012' }),
+}));
+
+vi.mock('../../../src/utils/logger.js', () => ({
+  getLogger: () => {
+    const child = {
+      debug: mockDebug,
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(() => child),
+    };
+    return { child: () => child, debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  },
+}));
+
+import { CloudControlProvider } from '../../../src/provisioning/cloud-control-provider.js';
+
+describe('CloudControlProvider create-path DesiredState log redaction (GHSA sibling of the update-path masking)', () => {
+  beforeEach(() => {
+    mockCcSend.mockReset();
+    mockDebug.mockReset();
+  });
+
+  it('logs top-level property KEYS only on create, never a resolved secret value', async () => {
+    // A CC-routed resource with no SDK provider may carry a resolved
+    // {{resolve:secretsmanager:...}} value in its properties; the create-path
+    // DesiredState debug log must not echo it. The log fires (synchronously)
+    // BEFORE the CreateResourceCommand send, so a rejected send still exercises
+    // it — no need to mock the full success poll.
+    const secretValue = 'super-secret-resolved-pw-123';
+    mockCcSend.mockRejectedValue(new Error('CreateResource boom (log already fired)'));
+
+    const provider = new CloudControlProvider();
+    await provider
+      .create('MySecretRes', 'AWS::SomeCc::Type', {
+        ClientSecret: secretValue,
+        PublicId: 'public-value',
+      })
+      .catch(() => undefined);
+
+    const desiredLog = mockDebug.mock.calls
+      .map((c) => String(c[0]))
+      .find((m) => m.includes('DesiredState for MySecretRes'));
+
+    // The log exists, names the KEYS (so it is still useful for debugging)...
+    expect(desiredLog).toBeDefined();
+    expect(desiredLog).toContain('ClientSecret');
+    expect(desiredLog).toContain('PublicId');
+    // ...and NEVER contains the resolved secret value. Non-vacuous: without the
+    // keys-only masking the whole `desiredState` JSON (incl. the secret) was
+    // logged, so this line would fail.
+    expect(desiredLog).not.toContain(secretValue);
+    // Hard invariant: the secret appears in NO debug line at all.
+    expect(mockDebug.mock.calls.map((c) => String(c[0])).join('\n')).not.toContain(secretValue);
+  });
+});


### PR DESCRIPTION
## Summary

Masks the Cloud Control **create-path** `DesiredState` debug log so it no longer
prints a resolved secret value. Follow-up to the dynamic-reference
secret-redaction fix (advisory GHSA-p5qg-v9gv-hc7w, shipped in 0.283.20).

**How it was found.** The new `pr-security-reviewer` agent
(from the reviewer PR just merged), run against the merged GHSA PR as a live-test,
traced every reader of a resolved secret and flagged the ONE sibling the diff
never revisited: the fix masked the CC **update** patch log
(`cloud-control-provider.ts` ~line 478, "log the OPERATIONS + PATHS only") but
left the CC **create** log one method up still stringifying the whole resolved
`DesiredState`.

## The leak

`src/provisioning/cloud-control-provider.ts` create path:

```ts
const desiredState = JSON.stringify(ccProperties);
this.logger.debug(`DesiredState for ${logicalId}: ${desiredState}`);
```

For a Cloud-Control-routed resource (no SDK provider) carrying a
`{{resolve:secretsmanager:...}}` property, `ccProperties` holds the resolved
plaintext, so `cdkd deploy --verbose` echoed the secret to the terminal / CI
logs on CREATE. The CC provider has no access to the resolver's recorded-secret
map, so — exactly like the update path — it now logs the top-level property KEYS
only, never the values. The full document still goes to AWS unchanged.

## Scope

- `--verbose` / debug-gated, and only for a CC-routed secret-bearing resource, so
  narrower than the primary GHSA surface (which was every resource's state.json).
  Does not warrant amending the published advisory.
- Log-format change only; no behavior change to create / destroy, so no integ
  needed (cloud-control-provider.ts is not in the integ-destroy scope).

## Test plan

- New `tests/unit/provisioning/cloud-control-provider-create-log-redaction.test.ts`:
  asserts the create-path debug log names the property keys but NOT the resolved
  secret value. **Mutation-probe verified non-vacuous** — reverting the fix to the
  leaky form makes the test fail.
- Existing `cloud-control-provider.test.ts` (94 tests) still green; full suite green.
- Reviewed by `pr-security-reviewer` (whole-file sweep): **Clean**, no other
  unmasked full-bag value sink on the create/update/delete/enrichment/error paths.

## Follow-up

The same sweep flagged one pre-existing, out-of-scope readback-log surface —
`parseResourceModel`'s 500-char raw-model `warn` on a JSON parse failure — which
could in principle print a resolved NON-write-only secret. Filed as
[Issue 1908](https://github.com/go-to-k/cdkd/issues/1908) (Session-fit: next); not
part of the create/update leak class this PR fixes.
