### PR TITLE
fix(cloud-control): log a malformed readback model's shape, not its body

### DIFF
--- a/src/provisioning/cloud-control-provider.ts
+++ b/src/provisioning/cloud-control-provider.ts
@@ -197,6 +197,38 @@ export function handlerAuthFailureHint(statusMessage: string): string {
   );
 }
 
+/** How many key names a malformed-model log line may carry. */
+const MAX_LOGGED_MODEL_KEYS = 12;
+
+/**
+ * Summarize a JSON document by its KEY NAMES, for a log line that must not
+ * carry the document's values (issue #1908).
+ *
+ * The document failed to parse, so the keys cannot be read structurally; this
+ * matches the `"name":` lexical form instead. That is a deliberate trade: the
+ * pattern requires the colon, so a bare string VALUE is never reported, and the
+ * only way a value reaches the line is if the document contains a string that
+ * is itself followed by a colon -- which for an AWS readback means a nested
+ * key. Values are what must not leak, and a key-shaped token is not one.
+ */
+function describeJsonKeys(document: string): string {
+  const keys: string[] = [];
+  const seen = new Set<string>();
+  const pattern = /"([^"\\]{1,64})"\s*:/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(document)) !== null) {
+    const key = match[1]!;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    keys.push(key);
+    if (keys.length >= MAX_LOGGED_MODEL_KEYS) break;
+  }
+  if (keys.length === 0) return 'no readable key names';
+  const suffix =
+    pattern.lastIndex < document.length && keys.length >= MAX_LOGGED_MODEL_KEYS ? ', ...' : '';
+  return `keys: ${keys.join(', ')}${suffix}`;
+}
+
 export class CloudControlProvider implements ResourceProvider {
   private cloudControlClient: CloudControlClient;
   private logger = getLogger().child('CloudControlProvider');
@@ -942,7 +974,21 @@ export class CloudControlProvider implements ResourceProvider {
   }
 
   /**
-   * Parse resource model JSON string
+   * Parse resource model JSON string.
+   *
+   * On a parse failure this logs the error plus the model's SHAPE — never its
+   * body (issue #1908, a GHSA-p5qg-v9gv-hc7w residual). The model is an AWS
+   * readback, and a read handler cannot return write-only properties (the #809
+   * premise), so the common secret shapes are absent — but a `{{resolve:...}}`
+   * secret resolved into a NON-write-only property can round-trip back here,
+   * and the previous `Raw model: <first 500 chars>` line would have printed it.
+   * Truncation is not a mitigation: 500 characters is precisely where a
+   * document's leading values sit.
+   *
+   * KEY NAMES are logged and values are not, which is the whole distinction —
+   * a key is a property name from the type's schema, a value is the data. That
+   * keeps the line diagnostic (it says WHICH document failed to parse) without
+   * carrying anything sensitive.
    */
   private parseResourceModel(resourceModel: string): Record<string, unknown> {
     try {
@@ -951,7 +997,7 @@ export class CloudControlProvider implements ResourceProvider {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.warn(
         `Failed to parse resource model: ${errorMessage}\n` +
-          `Raw model: ${resourceModel.substring(0, 500)}${resourceModel.length > 500 ? '...' : ''}`
+          `Model shape: ${resourceModel.length} chars, ${describeJsonKeys(resourceModel)}`
       );
       return {};
     }

--- a/tests/unit/provisioning/cloud-control-provider.test.ts
+++ b/tests/unit/provisioning/cloud-control-provider.test.ts
@@ -1910,3 +1910,47 @@ describe('CloudControlProvider waitForOperation timeout cap (slow-type floor)', 
     expect(message).toMatch(/after 3600s/);
   });
 });
+
+describe('CloudControlProvider - malformed model log hygiene (issue #1908)', () => {
+  // The raw readback model used to be logged verbatim (truncated to 500 chars).
+  // A `{{resolve:...}}` secret resolved into a NON-write-only property can
+  // round-trip into that readback, so the log line could print it -- and
+  // truncation is not a mitigation, since 500 chars is exactly where a
+  // document's leading values sit.
+  it('logs the parse error and KEY NAMES, never the values', () => {
+    const provider = new CloudControlProvider();
+    const SECRET = 'hunter2-super-secret-value';
+    const malformed = `{"BucketName":"my-bucket","DbPassword":"${SECRET}",`;
+
+    const parsed = (
+      provider as unknown as {
+        parseResourceModel(model: string): Record<string, unknown>;
+      }
+    ).parseResourceModel(malformed);
+
+    expect(parsed).toEqual({});
+
+    const warned = mockLoggerWarn.mock.calls.map((c) => String(c[0])).join('\n');
+    // The VALUE must not appear anywhere in the log...
+    expect(warned).not.toContain(SECRET);
+    expect(warned).not.toContain('my-bucket');
+    // ...while the line stays diagnostic: it says which document failed.
+    expect(warned).toContain('Failed to parse resource model');
+    expect(warned).toContain('BucketName');
+    expect(warned).toContain('DbPassword');
+    expect(warned).toContain(`${malformed.length} chars`);
+  });
+
+  it('reports no readable key names rather than echoing an unparseable blob', () => {
+    const provider = new CloudControlProvider();
+    const SECRET = 'plain-secret-blob-no-json-at-all';
+
+    (
+      provider as unknown as { parseResourceModel(model: string): Record<string, unknown> }
+    ).parseResourceModel(SECRET);
+
+    const warned = mockLoggerWarn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warned).not.toContain(SECRET);
+    expect(warned).toContain('no readable key names');
+  });
+});


### PR DESCRIPTION
Closes #1908

## The residual

A GHSA-p5qg-v9gv-hc7w residual, found by the security review of the CC create-path log fix. On a JSON parse failure of an AWS readback model, `parseResourceModel` logged `Raw model: <first 500 chars>`.

Cloud Control read handlers cannot return write-only properties (the (#809) premise), so the common secret shapes are absent — but a `{{resolve:...}}` secret resolved into a NON-write-only property can round-trip into that readback, and the line would have printed it.

**Truncation is not a mitigation**, and that is the point worth keeping: 500 characters is precisely where a document's leading values sit, so the cap bounded the VOLUME of what leaked rather than whether anything did.

## The fix

The line now carries the parse error, the model's length, and its KEY NAMES.

Keys and values are the load-bearing distinction: a key is a property name from the type's schema, a value is the data. So the line still says WHICH document failed to parse — which is what made it worth logging at all — while carrying nothing sensitive. Masking was not an option here: the read path holds no recorded-secret map, so there is nothing to match against.

The document failed to parse, so the keys cannot be read structurally; the helper matches the `"name":` lexical form instead. That is a deliberate trade rather than an oversight — requiring the colon means a bare string VALUE is never reported, and the only way one reaches the line is a string followed by a colon, which in an AWS readback is a nested key.

## Verification

- Two unit cases: one asserts the resolved secret and the bucket name are absent from the log while `BucketName` / `DbPassword` / the length are present; the other covers a non-JSON blob, which must report `no readable key names` rather than echoing itself.
- **Mutation probe** on the real source: restoring the old `Raw model:` line fails exactly those two cases and nothing else, so the tests discriminate rather than passing blind. Probe reverted (`git diff` clean before the commit).
- 13470 unit tests pass; typecheck / lint / build green.

No integ: log-format only, outside every integ gate's scope.
