### PR TITLE
chore(work-issues): rank security issues first, and require a per-repo claim check when mirroring

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -179,11 +179,12 @@ next only to break a tie:
 
 | # | Rule | Why |
 |---|---|---|
-| 1 | **Umbrella issues sort LAST**, whatever else they score | They cannot be finished in one lane, so a lane leaves the issue open with ambiguous residue, and their many sites collide with everything |
-| 2 | **`fix:` outranks everything else** (`feat:` / `test:` / `docs:` / `audit:` / `chore:`) | A `fix:` is a defect in shipped behavior a user can hit today; the rest are improvements to behavior that is not wrong |
-| 3 | **Area: `deploy` > `diff` = `destroy` > everything else** | Deploy is the tool's primary function — it is what cdkd exists to do, so a deploy defect costs more than an equally-sized defect elsewhere. `diff` and `destroy` rank equally behind it |
-| 4 | **Prefer issues landing in ONE isolated file** over cross-cutting ones | Not just collision-avoidance for this run: a cross-cutting file admits only one lane at a time, so taking it blocks the widest set of future parallel work. Among equals, spend the contested files last |
-| 5 | **Newer first** (higher issue number / `created_at`) | Not novelty — **accuracy**. A freshly filed issue was written against current code, so its file:line tables and reproduction still hold. Older ones rot: on 2026-08-13 two of the enumerated sites in a one-day-old issue were already fixed or deleted. An older issue is likelier to be partly done, superseded, or wrong |
+| 1 | **Security issues come FIRST**, ahead of every other rule below | A security defect is the one class where the cost keeps growing while it sits: the vulnerable behavior is already shipped, already running in users' accounts, and the report may be public. Every other rule orders work by how much value a fix adds; this one orders it by how much a delay costs |
+| 2 | **Umbrella issues sort LAST**, whatever else they score | They cannot be finished in one lane, so a lane leaves the issue open with ambiguous residue, and their many sites collide with everything |
+| 3 | **`fix:` outranks everything else** (`feat:` / `test:` / `docs:` / `audit:` / `chore:`) | A `fix:` is a defect in shipped behavior a user can hit today; the rest are improvements to behavior that is not wrong |
+| 4 | **Area: `deploy` > `diff` = `destroy` > everything else** | Deploy is the tool's primary function — it is what cdkd exists to do, so a deploy defect costs more than an equally-sized defect elsewhere. `diff` and `destroy` rank equally behind it |
+| 5 | **Prefer issues landing in ONE isolated file** over cross-cutting ones | Not just collision-avoidance for this run: a cross-cutting file admits only one lane at a time, so taking it blocks the widest set of future parallel work. Among equals, spend the contested files last |
+| 6 | **Newer first** (higher issue number / `created_at`) | Not novelty — **accuracy**. A freshly filed issue was written against current code, so its file:line tables and reproduction still hold. Older ones rot: on 2026-08-13 two of the enumerated sites in a one-day-old issue were already fixed or deleted. An older issue is likelier to be partly done, superseded, or wrong |
 
 **Detecting each signal** — from the same REST listing §1 already fetched, plus
 the body when needed:
@@ -200,6 +201,22 @@ gh api 'repos/{owner}/{repo}/issues?state=open&per_page=60' \
 gh issue view <n> --json body -q .body | grep -i 'Session-fit:'
 ```
 
+- **Security**: the issue reports a vulnerability in shipped behavior rather than a
+  bug — credential / secret handling, redaction or masking, a sensitive value
+  persisted or logged, IAM / role-assumption scope, auth or token verification,
+  command injection or arbitrary execution, or anything tied to a GHSA advisory.
+  Signals: a `security` label, a GHSA link, a private-report reference, or a title /
+  body naming `secret`, `credential`, `token`, `redact`, `leak`, `privilege`,
+  `injection`. Path signal: the issue names any surface the security add-on reviewer
+  covers (`src/utils/role-arn.ts`, `src/local/{cognito-jwt,lambda-authorizer,`
+  `docker-runner,docker-image-builder,ecr-puller}.ts`,
+  `src/provisioning/providers/**` when the defect is about what gets stored or
+  exposed). When in doubt, treat it as security — the cost of ranking a normal bug
+  first is one position in a queue.
+  Two consequences that follow from rule 1 sitting above rule 2: a security issue
+  that is ALSO an umbrella is not deferred by the umbrella rule — split it, take the
+  concrete sites this lane can close now, and file the remainder. And a security
+  issue does not lose its place for being older; rule 6 never applies to it.
 - **Umbrella**: title or body says `umbrella`, `audit:`, `Backfill`, `N entries
   across M types`, or the body carries a TABLE of sites rather than one defect.
   A "residual of #N" issue naming two or three concrete sites is NOT an umbrella —
@@ -218,20 +235,23 @@ gh issue view <n> --json body -q .body | grep -i 'Session-fit:'
   reason to skip.
 
 **These are tiebreakers, not a scoring formula — do not average them.** Apply
-rule 1, then 2, then 3, and stop at the first that separates the candidates. And
-they rank *what to take first*; they never justify taking an issue that fails the
-disjointness gate, nor skipping the §0 safety screen.
+rule 1, then 2, then 3, and so on, stopping at the first that separates the
+candidates. And they rank *what to take first*; they never justify taking an issue
+that fails the disjointness gate, nor skipping the §0 safety screen.
 
 Two overrides worth stating, because both have been talked into by a ranking
 before:
 
-- **A user-reported breakage outranks the table.** If an issue reports a
-  currently-broken user-facing path, take it first regardless of type, area or
-  age. The ranking exists to order a backlog of self-filed findings, not to make
+- **A user-reported breakage outranks the rest of the table** (but not rule 1 —
+  nothing outranks a security issue). If an issue reports a currently-broken
+  user-facing path, take it first regardless of type, area or age. The ranking exists to order a backlog of self-filed findings, not to make
   someone wait behind a `fix(deploy)` because their bug is filed as `fix(state)`.
 - **Ranking never lowers verification depth.** A rank-1 issue and a rank-9 issue
   get the same review tier, the same integs and the same live test — priority
-  decides ORDER, never rigor (see CLAUDE.md → "Cost is not a tiebreaker").
+  decides ORDER, never rigor (see CLAUDE.md → "Cost is not a tiebreaker"). A
+  security issue moves the other way: dispatch `pr-security-reviewer` in addition
+  to whatever tier its size gives (`CLAUDE.md` → "PR review pattern"), since urgency
+  is a reason to start it sooner, never to check it less.
 
 ## 4. CLAIM the chosen issues BEFORE editing
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -498,6 +498,18 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   them in this session when it can pay for two more gate runs; otherwise file one
   issue per repo carrying the `Session-fit` line. What is not an option is landing
   the fix in only one of the three — that is how the three drift apart.
+  **Verify the copy against the TARGET repo, claim by claim, before shipping it.**
+  Their gates, hooks and ship steps differ, so a sentence that is true here reads as
+  authoritative there while being false, and nothing lints instruction prose — the
+  next agent simply acts on it. On 2026-08-18 the first mirror of this section
+  carried four such claims: a `verify-pr` gate that exempts a non-`src/**` diff, a
+  review heuristic that still down-biases `.claude/**`, a `CLAUDE.md` rule the
+  sibling does not carry, and a hook it does not ship. A read-only reviewer per
+  target repo — its only job being to check each gate name, hook behavior, skill
+  name, path convention and cross-reference against that repo's own files — is what
+  caught them. Checking in the rule here rather than in agent memory is deliberate:
+  memory is per-project-path and per-machine, so it would not load in the very repos
+  this bullet sends you to.
 
 ### 10-d. Ship it like any other change
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -180,7 +180,7 @@ next only to break a tie:
 | # | Rule | Why |
 |---|---|---|
 | 1 | **Security issues come FIRST**, ahead of every other rule below | A security defect is the one class where the cost keeps growing while it sits: the vulnerable behavior is already shipped, already running in users' accounts, and the report may be public. Every other rule orders work by how much value a fix adds; this one orders it by how much a delay costs |
-| 2 | **Umbrella issues sort LAST**, whatever else they score | They cannot be finished in one lane, so a lane leaves the issue open with ambiguous residue, and their many sites collide with everything |
+| 2 | **Umbrella issues sort LAST**, whatever else they score (except rule 1) | They cannot be finished in one lane, so a lane leaves the issue open with ambiguous residue, and their many sites collide with everything |
 | 3 | **`fix:` outranks everything else** (`feat:` / `test:` / `docs:` / `audit:` / `chore:`) | A `fix:` is a defect in shipped behavior a user can hit today; the rest are improvements to behavior that is not wrong |
 | 4 | **Area: `deploy` > `diff` = `destroy` > everything else** | Deploy is the tool's primary function — it is what cdkd exists to do, so a deploy defect costs more than an equally-sized defect elsewhere. `diff` and `destroy` rank equally behind it |
 | 5 | **Prefer issues landing in ONE isolated file** over cross-cutting ones | Not just collision-avoidance for this run: a cross-cutting file admits only one lane at a time, so taking it blocks the widest set of future parallel work. Among equals, spend the contested files last |
@@ -208,11 +208,14 @@ gh issue view <n> --json body -q .body | grep -i 'Session-fit:'
   Signals: a `security` label, a GHSA link, a private-report reference, or a title /
   body naming `secret`, `credential`, `token`, `redact`, `leak`, `privilege`,
   `injection`. Path signal: the issue names any surface the security add-on reviewer
-  covers (`src/utils/role-arn.ts`, `src/local/{cognito-jwt,lambda-authorizer,`
-  `docker-runner,docker-image-builder,ecr-puller}.ts`,
-  `src/provisioning/providers/**` when the defect is about what gets stored or
-  exposed). When in doubt, treat it as security — the cost of ranking a normal bug
-  first is one position in a queue.
+  covers — `src/utils/role-arn.ts`, `src/local/cognito-jwt.ts`,
+  `src/local/docker-runner.ts`, `src/local/docker-image-builder.ts`,
+  `src/local/ecr-puller.ts`, and `src/provisioning/providers/**` when the defect is
+  about what gets stored or exposed. (`CLAUDE.md`'s copy of that list still names
+  `src/local/lambda-authorizer.ts`, which moved to cdk-local in PR #691 — the
+  surviving files here are `authorizer-resolver.ts` / `authorizer-cache.ts`.)
+  When in doubt, treat it as security — the cost of ranking a normal bug first is
+  one position in a queue.
   Two consequences that follow from rule 1 sitting above rule 2: a security issue
   that is ALSO an umbrella is not deferred by the umbrella rule — split it, take the
   concrete sites this lane can close now, and file the remainder. And a security
@@ -244,8 +247,9 @@ before:
 
 - **A user-reported breakage outranks the rest of the table** (but not rule 1 —
   nothing outranks a security issue). If an issue reports a currently-broken
-  user-facing path, take it first regardless of type, area or age. The ranking exists to order a backlog of self-filed findings, not to make
-  someone wait behind a `fix(deploy)` because their bug is filed as `fix(state)`.
+  user-facing path, take it first regardless of type, area or age. The ranking
+  exists to order a backlog of self-filed findings, not to make someone wait behind
+  a `fix(deploy)` because their bug is filed as `fix(state)`.
 - **Ranking never lowers verification depth.** A rank-1 issue and a rank-9 issue
   get the same review tier, the same integs and the same live test — priority
   decides ORDER, never rigor (see CLAUDE.md → "Cost is not a tiebreaker"). A


### PR DESCRIPTION
## Summary

The section-10 mirror bullet told the next agent to "adapt the wording per repo",
which reads as an editing note. What actually happened when this section was first
mirrored across the three repos is stronger than that: four claims travelled as
authoritative statements that are FALSE in the target repo —

- a `verify-pr` gate that exempts a diff with no `src/**` path (true in one repo, not the others),
- a review-tier heuristic that still down-biases `.claude/**`,
- a `CLAUDE.md` rule the sibling repo does not carry (a dangling pointer),
- a hook named as the reason for a step that the sibling does not ship.

Nothing type-checks instruction prose and the markdown lints clean, so the failure
is silent: the next agent reads the claim and acts on it.

## What changes

One clause in 10-c's mirror bullet: verify the copy against the TARGET repo claim
by claim before shipping it, with the check that actually caught these — a
read-only reviewer per target repo whose only job is to walk each gate name, hook
behavior, skill name, path convention and cross-reference against that repo's own
files.

It also records WHY the rule is checked in rather than kept in agent memory: memory
is per-project-path and per-machine, so a note written in one repo's memory does not
load in the repos this bullet sends you to. Git is the only carrier that crosses
both.

## Test plan

- Tooling-only change, no `src/**`.
- Local quality checks green in the worktree.
- Review: inline read (1 file, 12 added lines).

Landing the same clause in all three repos (cdkd, cdk-local, cdk-real-drift), per
the bullet it amends.


## Also in this PR: security issues rank first

The pick step ordered candidates by how much value a fix adds (type, then area,
then file isolation, then age). A security defect does not sit on that axis — the
vulnerable behavior is already shipped and running in users' accounts and the
report may be public, so its cost grows while it waits instead of staying flat. It
now sorts ahead of every other rule, with its own detection list (credential /
secret handling, redaction or masking, a sensitive value persisted or logged, IAM /
role-assumption scope, auth or token verification, command injection, GHSA-tied
reports, plus the paths the security reviewer covers) and an instruction to treat
ambiguous cases as security.

Two interactions are spelled out because they read the other way otherwise: a
security issue that is ALSO an umbrella gets split and started, not deferred by the
umbrella-last rule; and urgency never buys a shortcut — the lane keeps the review
tier its size gives, adds the security reviewer, and runs the same verification as
any other lane.

The same change lands in all three repos' copies of this skill.
