### PR TITLE
chore(hooks): let a foreign repo's own gate decide its own commands

### DIFF
--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -109,6 +109,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # Repo opt-in scope (issue #1259): this gate protects repos that follow
 # the feature-branch + PR + markgate convention. A session rooted in
 # such a repo can still run git against OTHER repos (a personal blog, a

--- a/.claude/hooks/bughunt-clean-gate.sh
+++ b/.claude/hooks/bughunt-clean-gate.sh
@@ -91,6 +91,21 @@ if [[ -n "$cd_target" ]]; then
   target_dir="$cd_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # Not a git repo (or git unavailable) → nothing to gate.
 git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1 || exit 0
 

--- a/.claude/hooks/check-gate.sh
+++ b/.claude/hooks/check-gate.sh
@@ -95,6 +95,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see (mirrors branch-gate.sh).
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/ci-green-gate.sh
+++ b/.claude/hooks/ci-green-gate.sh
@@ -99,6 +99,21 @@ if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi

--- a/.claude/hooks/cmd-parse-stub-gate.sh
+++ b/.claude/hooks/cmd-parse-stub-gate.sh
@@ -80,6 +80,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0

--- a/.claude/hooks/commit-prefix-scope-gate.sh
+++ b/.claude/hooks/commit-prefix-scope-gate.sh
@@ -79,6 +79,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0

--- a/.claude/hooks/integ-broad-gate.sh
+++ b/.claude/hooks/integ-broad-gate.sh
@@ -109,6 +109,21 @@ if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi

--- a/.claude/hooks/integ-coverage-matrix-gate.sh
+++ b/.claude/hooks/integ-coverage-matrix-gate.sh
@@ -84,6 +84,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0

--- a/.claude/hooks/integ-destroy-gate.sh
+++ b/.claude/hooks/integ-destroy-gate.sh
@@ -100,6 +100,21 @@ if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi

--- a/.claude/hooks/integ-local-gate.sh
+++ b/.claude/hooks/integ-local-gate.sh
@@ -134,6 +134,21 @@ if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see (mirrors branch-gate.sh).
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/integ-schema-migration-gate.sh
+++ b/.claude/hooks/integ-schema-migration-gate.sh
@@ -122,6 +122,21 @@ if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi

--- a/.claude/hooks/internal-pr-labels-gate.sh
+++ b/.claude/hooks/internal-pr-labels-gate.sh
@@ -81,6 +81,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see (mirrors branch-gate.sh).
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/lib/foreign-repo.sh
+++ b/.claude/hooks/lib/foreign-repo.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# lib/foreign-repo.sh — cross-repo gate delegation (issue #1961).
+#
+# A session's hooks come from ONE repo's .claude/settings.json (whichever
+# repo the session was started in), but they fire on EVERY Bash call —
+# including commands whose target is a different repository. The gates
+# already resolve the TARGET working tree correctly (issue #559, which is
+# why `markgate verify` consults the right per-worktree marker store), but
+# the hook SCRIPT is still the session's own copy, so the marker lookup is
+# target-correct while the policy around it is session-correct. Those two
+# disagree exactly when the repos' gate scripts have diverged, which they
+# have — each repo's gates evolved separately.
+#
+# Observed twice on 2026-08-18 while landing the markgate `hash: diff`
+# adoption across three repos: a `gh pr create` for cdk-real-drift was
+# refused by cdkd's copy of verify-pr-gate, because cdkd's copy has no
+# docs/tooling exemption while cdk-real-drift's own copy does and would
+# have exempted the diff. The agent correctly refused to route around the
+# block and hand-ran cdk-real-drift's checklist instead — right behavior,
+# pure waste.
+#
+# WHY DELEGATE RATHER THAN EARLY-EXIT. The obvious fix is "exit 0 when the
+# target is a foreign repo". It is wrong, and the reason is easy to miss:
+# the foreign repo's hooks are NOT registered in this session. Silencing
+# our copy therefore leaves the command with NO gate at all, which on the
+# two incidents above would have skipped the verify-pr requirement rather
+# than applying the wrong one — strictly weaker than the status quo. This
+# helper instead hands the decision to the target repo's own counterpart
+# when it has one, and otherwise keeps current behavior. On no path is it
+# weaker than not having this file.
+
+# hook_delegate_if_foreign <target_dir> <hook_basename> <payload>
+#
+# Returns 1 (caller proceeds with its own policy) when the target is this
+# same repo, when the target's repo cannot be determined, or when the
+# target has no counterpart for this hook. EXITS the calling script with
+# the counterpart's status when it does delegate.
+hook_delegate_if_foreign() {
+  target_dir="$1"
+  hook_name="$2"
+  payload="$3"
+
+  # Already one level deep: the counterpart we invoked is itself asking.
+  # Refuse to delegate again rather than risk a loop, and let it apply its
+  # own policy (it IS the target repo's hook, so that is correct).
+  if [ -n "${CDKD_HOOK_DELEGATED:-}" ]; then
+    return 1
+  fi
+
+  # Identify "this repo" from the library's own location rather than from
+  # the cwd, which is the thing under dispute.
+  __lib_dir="${BASH_SOURCE[0]%/*}"
+  [ "$__lib_dir" = "${BASH_SOURCE[0]}" ] && __lib_dir="."
+
+  # Compare by GIT COMMON DIR, not by toplevel: two worktrees of the same
+  # repo have different toplevels but one common dir, and a hook running
+  # from `.claude/worktrees/<branch>/` against the main tree (or the other
+  # way round) is ordinary same-repo work, not a foreign target.
+  own_common=$(git -C "$__lib_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+  tgt_common=$(git -C "$target_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+
+  # Unknown on either side -> not established as foreign. Fall through to
+  # our own policy; never silently pass.
+  if [ -z "$own_common" ] || [ -z "$tgt_common" ]; then
+    return 1
+  fi
+  if [ "$own_common" = "$tgt_common" ]; then
+    return 1
+  fi
+
+  tgt_top=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null)
+  if [ -z "$tgt_top" ]; then
+    return 1
+  fi
+
+  counterpart="$tgt_top/.claude/hooks/$hook_name"
+  if [ ! -x "$counterpart" ]; then
+    echo "[${hook_name%.sh}] target repo $tgt_top has no counterpart for this hook;" >&2
+    echo "  applying THIS repo's policy to a foreign target (see cdkd issue 1961)." >&2
+    return 1
+  fi
+
+  # Same file reached by another path (a symlinked checkout): not foreign
+  # in any meaningful sense, and exec'ing it would loop.
+  if [ "$counterpart" -ef "${BASH_SOURCE[1]:-}" ] 2>/dev/null; then
+    return 1
+  fi
+
+  echo "[${hook_name%.sh}] target is $tgt_top — delegating to that repo's own copy." >&2
+  printf '%s' "$payload" | CDKD_HOOK_DELEGATED=1 "$counterpart"
+  __rc=$?
+
+  # 126/127 mean we could not actually run it (not executable after all,
+  # bad interpreter). That is not a verdict, so do not report it as one —
+  # fall back to our own policy.
+  if [ "$__rc" -eq 126 ] || [ "$__rc" -eq 127 ]; then
+    echo "[${hook_name%.sh}] counterpart could not be executed (exit $__rc); applying this repo's policy." >&2
+    return 1
+  fi
+  exit "$__rc"
+}

--- a/.claude/hooks/lib/foreign-repo.test.sh
+++ b/.claude/hooks/lib/foreign-repo.test.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Smoke test for lib/foreign-repo.sh (issue 1961).
+#
+# Builds throwaway git repos rather than mocking git: the whole decision is
+# what `git rev-parse --git-common-dir` reports for two directories, so a
+# mock would be testing the mock. Worktrees are real ones too, because the
+# same-repo-across-worktrees case is exactly what a toplevel comparison
+# would have got wrong.
+#
+# Run from the repo root: `bash .claude/hooks/lib/foreign-repo.test.sh`.
+
+set -u
+
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pass=0
+fail=0
+fail_log=""
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+# --- fixtures -------------------------------------------------------------
+# `own` stands in for the repo whose session loaded the hooks; the library
+# under test is copied in so its BASH_SOURCE-derived identity is `own`.
+mk_repo() { # dir
+  mkdir -p "$1/.claude/hooks/lib"
+  git -C "$1" init -q -b main 2>/dev/null || { mkdir -p "$1" && git -C "$1" init -q; }
+  git -C "$1" config user.email t@t
+  git -C "$1" config user.name t
+  : > "$1/seed"
+  git -C "$1" add -A >/dev/null 2>&1
+  git -C "$1" commit -qm init >/dev/null 2>&1
+}
+
+mk_counterpart() { # repo_dir, hook_name, exit_code
+  cat > "$1/.claude/hooks/$2" <<EOF
+#!/usr/bin/env bash
+cat > "$TMP/received-payload"
+echo "counterpart-ran" > "$TMP/counterpart-ran"
+exit $3
+EOF
+  chmod +x "$1/.claude/hooks/$2"
+}
+
+OWN="$TMP/own"; mk_repo "$OWN"
+FOREIGN="$TMP/foreign"; mk_repo "$FOREIGN"
+cp "$LIB_DIR/foreign-repo.sh" "$OWN/.claude/hooks/lib/foreign-repo.sh"
+
+# A linked worktree of OWN: different toplevel, same common dir.
+OWN_WT="$TMP/own-wt"
+git -C "$OWN" worktree add -q "$OWN_WT" -b side >/dev/null 2>&1
+
+# A caller that sources the library exactly the way a real gate does.
+CALLER="$OWN/.claude/hooks/caller-gate.sh"
+cat > "$CALLER" <<'EOF'
+#!/usr/bin/env bash
+set -u
+input=$(cat 2>/dev/null || true)
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+. "$__fr_dir/lib/foreign-repo.sh"
+hook_delegate_if_foreign "$TARGET_DIR" "caller-gate.sh" "$input" || true
+echo "own-policy-ran"
+exit 7
+EOF
+chmod +x "$CALLER"
+
+run_caller() { # target_dir  -> prints "<exit>|<stdout>"; stderr to $TMP/err
+  local out rc
+  rm -f "$TMP/counterpart-ran" "$TMP/received-payload"
+  out=$(printf 'PAYLOAD-123' | TARGET_DIR="$1" "$CALLER" 2>"$TMP/err")
+  rc=$?
+  printf '%s|%s' "$rc" "$out"
+}
+
+check() { # name, want, got
+  if [ "$2" = "$3" ]; then
+    pass=$((pass + 1)); printf 'OK   %s\n' "$1"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (want %s, got %s)\n' "$1" "$2" "$3"
+    fail_log="${fail_log}FAIL $1: want '$2' got '$3'\n"
+  fi
+}
+
+# --- same repo: never delegate -------------------------------------------
+check "own repo -> own policy runs" "7|own-policy-ran" "$(run_caller "$OWN")"
+
+# The case a toplevel comparison gets wrong: a linked worktree IS the same
+# repo, and gate work legitimately runs from `.claude/worktrees/<branch>/`.
+check "own repo via a linked worktree -> own policy" "7|own-policy-ran" "$(run_caller "$OWN_WT")"
+
+# --- foreign repo WITHOUT a counterpart: fall back, never silently pass ---
+check "foreign, no counterpart -> own policy" "7|own-policy-ran" "$(run_caller "$FOREIGN")"
+if grep -q 'no counterpart' "$TMP/err"; then
+  pass=$((pass + 1)); printf 'OK   %s\n' "foreign, no counterpart -> says so on stderr"
+else
+  fail=$((fail + 1)); printf 'FAIL %s\n' "foreign, no counterpart -> says so on stderr"
+  fail_log="${fail_log}FAIL stderr note missing; got: $(cat "$TMP/err")\n"
+fi
+
+# --- foreign repo WITH a counterpart: delegate ---------------------------
+mk_counterpart "$FOREIGN" "caller-gate.sh" 0
+check "foreign + counterpart passes -> exit 0, own policy skipped" "0|" "$(run_caller "$FOREIGN")"
+check "  counterpart actually ran" "counterpart-ran" "$(cat "$TMP/counterpart-ran" 2>/dev/null)"
+check "  payload reached it intact" "PAYLOAD-123" "$(cat "$TMP/received-payload" 2>/dev/null)"
+
+# A blocking verdict must propagate, not be swallowed into our own exit 7.
+mk_counterpart "$FOREIGN" "caller-gate.sh" 2
+check "foreign + counterpart blocks -> exit 2 propagates" "2|" "$(run_caller "$FOREIGN")"
+
+# --- recursion guard ------------------------------------------------------
+out=$(printf 'x' | CDKD_HOOK_DELEGATED=1 TARGET_DIR="$FOREIGN" "$CALLER" 2>/dev/null); rc=$?
+check "already delegated -> no second hop, own policy" "7|own-policy-ran" "$rc|$out"
+
+# --- unrunnable counterpart is not a verdict -----------------------------
+# Non-executable: we must not read "cannot run" as "passed".
+chmod -x "$FOREIGN/.claude/hooks/caller-gate.sh"
+check "counterpart not executable -> own policy" "7|own-policy-ran" "$(run_caller "$FOREIGN")"
+chmod +x "$FOREIGN/.claude/hooks/caller-gate.sh"
+
+# Bad interpreter (exit 126/127) is likewise not a verdict.
+printf '#!/nonexistent/interpreter\n' > "$FOREIGN/.claude/hooks/caller-gate.sh"
+chmod +x "$FOREIGN/.claude/hooks/caller-gate.sh"
+check "counterpart unrunnable (bad interpreter) -> own policy" "7|own-policy-ran" "$(run_caller "$FOREIGN")"
+
+# --- target is not a git repo at all --------------------------------------
+mkdir -p "$TMP/plain"
+check "target not a repo -> own policy" "7|own-policy-ran" "$(run_caller "$TMP/plain")"
+check "target does not exist -> own policy" "7|own-policy-ran" "$(run_caller "$TMP/no-such-dir")"
+
+echo
+echo "Pass: $pass  Fail: $fail"
+if [ "$fail" -gt 0 ]; then
+  echo
+  printf '%b' "$fail_log"
+  exit 1
+fi

--- a/.claude/hooks/main-tree-branch-gate.sh
+++ b/.claude/hooks/main-tree-branch-gate.sh
@@ -105,6 +105,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # Is the target dir the main worktree (= the top-level of the
 # shared .git directory)? `git rev-parse --show-toplevel` returns
 # the current worktree's top — which differs between the main

--- a/.claude/hooks/non-english-text-gate.sh
+++ b/.claude/hooks/non-english-text-gate.sh
@@ -102,6 +102,21 @@ if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0

--- a/.claude/hooks/post-merge-orphan-push-gate.sh
+++ b/.claude/hooks/post-merge-orphan-push-gate.sh
@@ -111,6 +111,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # Parse `git push [...] <remote> <branch>` out of the command. We strip
 # the `git ... push` prefix (incl. any `-C <path>` between `git` and
 # `push`) and then walk the remaining tokens, skipping known flags that

--- a/.claude/hooks/pr-review-gate.sh
+++ b/.claude/hooks/pr-review-gate.sh
@@ -111,6 +111,21 @@ if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi

--- a/.claude/hooks/pr-title-prefix-scope-gate.sh
+++ b/.claude/hooks/pr-title-prefix-scope-gate.sh
@@ -133,6 +133,21 @@ if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0

--- a/.claude/hooks/provider-docs-gate.sh
+++ b/.claude/hooks/provider-docs-gate.sh
@@ -70,6 +70,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see (mirrors branch-gate.sh).
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/provider-integ-gate.sh
+++ b/.claude/hooks/provider-integ-gate.sh
@@ -93,6 +93,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see (mirrors branch-gate.sh).
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/ref-segment-audit-gate.sh
+++ b/.claude/hooks/ref-segment-audit-gate.sh
@@ -70,6 +70,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi

--- a/.claude/hooks/restore-backup.sh
+++ b/.claude/hooks/restore-backup.sh
@@ -124,6 +124,21 @@ while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
   target_dir="$c_target"
 done
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1 || exit 0
 
 # --------------------------------------------------------------- snapshot

--- a/.claude/hooks/roundtrip-test-gate.sh
+++ b/.claude/hooks/roundtrip-test-gate.sh
@@ -72,6 +72,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see (mirrors branch-gate.sh).
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/state-destroy-force-gate.sh
+++ b/.claude/hooks/state-destroy-force-gate.sh
@@ -80,6 +80,21 @@ if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/hooks/verify-pr-gate.sh
+++ b/.claude/hooks/verify-pr-gate.sh
@@ -100,6 +100,21 @@ if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
   target_dir="$c_target"
 fi
 
+# Cross-repo delegation (issue 1961). The hooks a session runs come from
+# ONE repo's settings, but they fire on every Bash call -- including
+# commands whose target is a different repository. When that target ships
+# its own copy of this gate, that copy decides; ours must not impose a
+# policy the target never adopted. Falls back to this repo's policy (with
+# a stderr note) when the target has no counterpart, and degrades to
+# exactly today's behaviour if the library is missing -- never weaker.
+__fr_dir="${BASH_SOURCE[0]%/*}"
+[ "$__fr_dir" = "${BASH_SOURCE[0]}" ] && __fr_dir="."
+# shellcheck source=lib/foreign-repo.sh
+if . "$__fr_dir/lib/foreign-repo.sh" 2>/dev/null \
+   && declare -F hook_delegate_if_foreign >/dev/null; then
+  hook_delegate_if_foreign "$target_dir" "${BASH_SOURCE[0]##*/}" "$input" || true
+fi
+
 # If the resolved target dir is not a git repo, silently pass — we
 # can't audit what we can't see.
 if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -187,6 +187,22 @@ One consequence of neutralising rather than deleting is that a pattern needing a
 
 See `feedback_cross_agent_main_tree_contention.md` for the full session history that motivated the cwd-awareness; cdkd#562 for the original line-start anchoring fix to `check-gate.sh`, and cdkd#1455 for its replacement.
 
+## Cross-repo delegation (issue 1961)
+
+Resolving the target working tree (the "cwd-aware" section above) fixed WHERE a gate looks. It did not fix WHOSE RULES apply. The hooks a session runs come from one repo's `.claude/settings.json` — whichever repo the session started in — and they fire on every Bash call, including commands whose target is a different repository. So the marker lookup ends up target-correct while the policy around it stays session-correct, and the two disagree exactly when the repos' gate scripts have diverged. They have: cdkd carries 35 gates, cdk-local 17, cdk-real-drift 10, each evolved separately.
+
+Seen twice on 2026-08-18 while landing the markgate `hash: diff` adoption across three repos. A `gh pr create` for cdk-real-drift was refused by **cdkd's** copy of `verify-pr-gate`; feeding the same payload to both copies settled it — cdk-real-drift's own hook answered `PR diff touches no src/** (docs/tooling-only) — exempt` and exited 0, while cdkd's copy, which has no such exemption, exited 2. Both times the agent correctly refused to route around the block and hand-ran the target repo's checklist instead: right behavior, pure waste, since the target's own policy had already exempted the change.
+
+`lib/foreign-repo.sh` provides `hook_delegate_if_foreign <target_dir> <hook_basename> <payload>`, called by all 24 gates that resolve a target dir, immediately after resolution completes. When the target is a different repo that ships its own copy of that gate, the payload is piped to it and its exit status becomes the gate's. Otherwise the caller proceeds with its own policy.
+
+**Why delegation and not an early exit.** "Exit 0 when the target is foreign" is the obvious fix and it is wrong, for a reason easy to miss: the foreign repo's hooks are NOT registered in this session. Silencing our copy leaves the command with no gate at all — on the two incidents above that would have skipped the `verify-pr` requirement rather than applying the wrong one, which is strictly weaker than the status quo. Delegation is the only shape that is never weaker than not having the file: correct policy when a counterpart exists, today's behavior (plus a stderr note) when it does not.
+
+Identity is compared by **git common dir**, not by toplevel. Two worktrees of one repo have different toplevels and a single common dir, and gate work legitimately runs from `.claude/worktrees/<branch>/` against the main tree — a toplevel comparison would have called that foreign and delegated to the same repo's own hook for no reason.
+
+Failure directions are all set to fall back rather than to pass: an unknown repo on either side, a missing counterpart, a non-executable counterpart, and an unrunnable one (exit 126/127, which is "could not run" and not a verdict) each return control to the caller's own policy. `CDKD_HOOK_DELEGATED=1` is set on the delegated call so a counterpart that also carries the helper cannot hop again. A missing or unloadable library degrades to exactly the pre-1961 behavior, so the gate never opens because the helper broke.
+
+Smoke test at `.claude/hooks/lib/foreign-repo.test.sh` (13 cases against real throwaway repos and a real `git worktree` — the decision is what `git rev-parse --git-common-dir` reports, so a git mock would only be testing the mock).
+
 ## Uncommitted-work safety (multi-session)
 
 Two hooks added after the 2026-08-09 two-sessions-one-worktree incident: two sessions both drove `.claude/worktrees/fix-1387-globaltable-gsi-throughput`, and the second one found ~228 lines of uncommitted changes it had not written, could not attribute them, and ran `git checkout --` on the two files. Those lines were the first session's finished, tested provider fix plus its regression tests. `git checkout --` writes no reflog entry and creates no stash, so nothing in git held a copy; the work survived only because the reverting session happened to save a diff by hand first. Both sessions then serialized their remaining lanes behind each other to avoid a repeat.


### PR DESCRIPTION
## Summary

A session's hooks come from one repo's `.claude/settings.json` and fire on **every** Bash call — including commands whose target is a different repository. Issue 559 made the gates resolve the target working tree, so the marker lookup is target-correct; the hook SCRIPT is still ours, so the policy around it is session-correct. Those disagree exactly when the repos' gates have diverged, and they have: 35 gates here, 17 in cdk-local, 10 in cdk-real-drift, each evolved separately.

`lib/foreign-repo.sh` adds `hook_delegate_if_foreign`, called by all 24 gates that resolve a target dir, right after resolution completes. A foreign target that ships its own copy of the gate gets the payload piped to it, and its exit status becomes ours.

Closes #1961.

## What went wrong twice

While landing the markgate `hash: diff` adoption across three repos on 2026-08-18, a `gh pr create` for cdk-real-drift was refused by **this repo's** copy of `verify-pr-gate`. Feeding one payload to both copies settled it:

| copy | verdict |
|---|---|
| cdk-real-drift's own | `PR diff touches no src/** (docs/tooling-only) — exempt`, exit 0 |
| ours (no such exemption) | exit 2 |

Both times the agent correctly refused to route around the block and hand-ran the target repo's checklist instead. Right behavior, pure waste: the target's own policy had already exempted the change.

## Why delegation and not an early exit

"Exit 0 when the target is foreign" is the obvious fix and it is wrong, for a reason that is easy to miss and that I got wrong in the issue body before checking: **the foreign repo's hooks are not registered in this session**. Silencing our copy leaves the command with no gate at all — on both incidents that would have skipped the `verify-pr` requirement rather than applying the wrong one. Strictly weaker than the status quo.

Delegation is the only shape that is never weaker on any path: the target's policy when a counterpart exists, today's behaviour plus a stderr note when it does not.

## Identity is the git common dir, not the toplevel

Two worktrees of one repo have different toplevels and one common dir, and gate work legitimately runs from `.claude/worktrees/<branch>/` against the main tree. A toplevel comparison would have called that foreign and delegated to the same repo's own hook for nothing. Pinned by a test using a real `git worktree`.

## Failure directions all fall back, never pass

| situation | result |
|---|---|
| target repo unknown (not a repo, missing dir) | caller's own policy |
| target has no counterpart for this gate | caller's own policy + stderr note |
| counterpart not executable | caller's own policy |
| counterpart unrunnable (exit 126/127 — "could not run", not a verdict) | caller's own policy |
| library missing or unloadable | exactly the pre-change behaviour |
| counterpart also carries the helper | `CDKD_HOOK_DELEGATED=1` stops a second hop |

The last two matter most: a gate must never open because the helper broke, and a delegation loop must not be reachable.

## Test plan

`.claude/hooks/lib/foreign-repo.test.sh` — 13 cases against real throwaway repos and a real `git worktree`. Git is not mocked: the whole decision is what `git rev-parse --git-common-dir` reports, so a mock would only be testing the mock. Covers the linked-worktree case, the payload arriving intact, a blocking verdict propagating rather than being swallowed, and each unrunnable-counterpart shape.

Full hook suite green under **both** bashes — `bash 5.3.9` and `/bin/bash 3.2.57` (the macOS system bash the gates actually run under on a bare machine), 33 suites including the new one. `vp run check` / `typecheck:test` / `build` clean; `vp run test` 685 files, 13931 tests, no type errors.

## Review note

24 safety gates change at once, so the diff is mechanical but the blast radius is not: a mistake here can make a gate silently not fire, which is the failure mode the whole gate family exists to prevent. The insertion is identical in every gate and sits immediately after target-dir resolution; the interesting file is `lib/foreign-repo.sh`.
