### PR TITLE
fix(cognito): replace the blanket UpdateUserPool reset rationale with measured per-field results, and correct a warning that promised a deploy AWS rejects

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -46,7 +46,7 @@ cloudwatch-anomaly-detector	2026-07-30T16:41:15Z	PASS	35	verify.sh	final run pos
 codebuild-project	2026-08-11T03:08:37Z	PASS	63	verify.sh	#1160 codebuild batch final: reset + 7 CFn retentions live-verified; destroy 3/0
 codecommit	2026-08-01T09:36:05Z	PASS	83	verify.sh	0801 regression sweep; 3 phases ok, 0 orphans
 codedeploy-lambda-deployment-group	2026-07-26T19:45:58Z	PASS	109	verify.sh	re-run after version-agnostic fixture fix; live-verified, account clean (remnant-warning follow-up: issue #1252)
-cognito	2026-08-18T15:53:50Z	PASS	150	verify.sh	#1925/#1932 post-review re-run: both MFA update transitions, downgrade announcement now bound to the pool id; 7 deleted 0 errors 0 orphans
+cognito	2026-08-19T03:51:50Z	PASS	92	verify.sh	#1968 pinned-OFF warn correction; 7 deleted 0 errors 0 orphans, no user pools remain
 cognito-custom-attribute-add	2026-08-10T11:50:46Z	PASS	47	verify.sh	0810 P0/P1 sweep b2; AddCustomAttributes reaches AWS, 3 phases
 cognito-identity-pool	2026-08-10T11:50:46Z	PASS	45	verify.sh	0810 P0/P1 sweep b1; identity+user pool gone, orph clean
 cognito-lambda-triggers	2026-08-10T04:23:28Z	PASS	58	verify.sh	0810 sweep b2; post-#1395 SignInPolicy, triggers fired, 8 del 0 err, 0 orph

--- a/src/provisioning/providers/cognito-provider.ts
+++ b/src/provisioning/providers/cognito-provider.ts
@@ -280,8 +280,10 @@ function hasMfaConfigProps(properties: Record<string, unknown>): boolean {
  * `MfaConfiguration` (ON/OFF/OPTIONAL) MUST be threaded into this request:
  * `SetUserPoolMfaConfig` is a full-replace of the pool's MFA state, and an
  * omitted `MfaConfiguration` defaults to OFF on the wire — which resets the
- * pool to MFA-disabled and makes AWS reject (or silently drop) the per-factor
- * sub-blocks we are trying to enable. Use the template's `MfaConfiguration`
+ * pool to MFA-disabled, and makes AWS reject the per-factor sub-blocks we are
+ * trying to enable. That reset is MEASURED against THIS API — it is not read
+ * off `UpdateUserPool`'s blanket reset sentence, which holds only field by
+ * field. Use the template's `MfaConfiguration`
  * when present; when the template omitted it, default by whether this call
  * enables an MFA FACTOR — `OPTIONAL` if it does, `OFF` (CloudFormation's own
  * default) if it does not. The body comment on that decision explains why both
@@ -374,8 +376,22 @@ function buildMfaConfigRequest(
   }
 
   // SetUserPoolMfaConfig is a full-replace: an omitted MfaConfiguration resets
-  // the pool to OFF, which would disable the very factors we are enabling. So
-  // thread the template's value, and when the template omitted it, default by
+  // the pool to OFF, which would disable the very factors we are enabling.
+  //
+  // That is a property of THIS API, MEASURED (us-east-1, 2026-08-19, issue
+  // #1968) — it is NOT the `UpdateUserPool` blanket "unspecified parameters are
+  // set to their default value" sentence, which holds only field by field (the
+  // ledger is in `readLiveMfaConfiguration`). On a pool sitting at
+  // MfaConfiguration ON with software-token enabled: a bare
+  // SetUserPoolMfaConfig carrying only the pool id reset it to OFF and dropped
+  // SoftwareTokenMfaConfiguration, while the same omission WITH a factor
+  // sub-block was rejected outright — `InvalidParameterException: Invalid MFA
+  // configuration given, can't turn off MFA and configure an MFA together`,
+  // whose wording is AWS itself confirming it read the absent field as "turn
+  // off". The sub-block case therefore fails loudly rather than shipping a
+  // silently MFA-disabled pool; threading the value is what avoids both.
+  //
+  // So thread the template's value, and when the template omitted it, default by
   // whether this call enables an MFA FACTOR at all. OFF is CloudFormation's own
   // default, and it is REQUIRED for a passkey-only pool: WebAuthn is not an MFA
   // factor, so AWS rejects OPTIONAL there with "Invalid MFA Configuration given.
@@ -738,9 +754,35 @@ export class CognitoUserPoolProvider implements ResourceProvider {
   /**
    * Build the SDK `Policies` input from the CFn `Policies` blob. Both
    * sub-keys must be forwarded: `SignInPolicy` (passwordless first-auth
-   * factors) was silently dropped before issue #1380, and UpdateUserPool
-   * resets omitted attributes to their defaults, so leaving it out also
-   * wipes an existing sign-in policy on every update.
+   * factors) was silently dropped before issue #1380, so a template that
+   * declared -- or later CHANGED -- the allowed first-auth factors never
+   * reached AWS at all.
+   *
+   * **Forwarding is what APPLIES a declared value; it is NOT what keeps an
+   * existing one alive.** The original rationale here was AWS's blanket "if
+   * you don't provide a value for an attribute, Amazon Cognito sets it to its
+   * default value", i.e. that omitting `SignInPolicy` would WIPE it. MEASURED
+   * us-east-1 2026-08-19 (issue #1968), on a pool created with
+   * `SignInPolicy.AllowedFirstAuthFactors = [PASSWORD, EMAIL_OTP]` on the
+   * default `ESSENTIALS` tier -- no explicit `UserPoolTier` was needed for the
+   * field to be settable:
+   *
+   * - `UpdateUserPool` sending `Policies` with ONLY `PasswordPolicy` left
+   *   `SignInPolicy` at `[PASSWORD, EMAIL_OTP]`. Control: that same call's
+   *   `--auto-verified-attributes email` applied, so the update really ran.
+   * - `UpdateUserPool` omitting `Policies` entirely left BOTH sub-keys intact
+   *   (a non-default `RequireSymbols: false` survived too), while
+   *   `AutoVerifiedAttributes` reset from `[email]` to none in that very call
+   *   -- the control proving the omission was processed, not ignored.
+   * - An explicit `SignInPolicy` write landed in both directions
+   *   (`[PASSWORD]`, then back to `[PASSWORD, EMAIL_OTP]`), so the field is
+   *   reachable and writable here rather than silently dropped.
+   *
+   * So the forwarding stays -- it is the only way a CHANGED sign-in policy is
+   * applied -- but on the measured reason, not the blanket sentence. Do not
+   * generalise that sentence to another field from this site: see
+   * `readLiveMfaConfiguration`'s docstring, which carries the one ledger of
+   * which fields were measured to reset and which were not.
    */
   private toSdkUserPoolPolicies(policies: Record<string, unknown>): UserPoolPolicyType | undefined {
     const result: UserPoolPolicyType = {};
@@ -1134,9 +1176,20 @@ export class CognitoUserPoolProvider implements ResourceProvider {
    * `--auto-verified-attributes` change in the same request applied) and that
    * the field is writable here rather than ignored (an explicit
    * `--mfa-configuration OFF` did reset it). So AWS's blanket "unspecified
-   * parameters are set to their default value" holds field by field —
-   * `AutoVerifiedAttributes` DOES reset, `MfaConfiguration` does not — and
+   * parameters are set to their default value" holds field by field — and
    * there is no MFA-OFF window to design around.
+   *
+   * **This paragraph is the single ledger of that field-by-field result; a
+   * per-field verdict belongs at that field's own site, pointing here.**
+   * Measured so far, all `UpdateUserPool` with a control proving the call ran:
+   *
+   * - `AutoVerifiedAttributes` — DOES reset when omitted (2026-08-18).
+   * - `MfaConfiguration` — does NOT reset when omitted (2026-08-18, above).
+   * - `Policies` — neither sub-key resets, whether the container is sent
+   *   without `SignInPolicy` or omitted outright (2026-08-19, issue #1968;
+   *   details at `toSdkUserPoolPolicies`).
+   *
+   * Nothing here licenses a claim about a field NOT on that list. Measure it.
    *
    * The earlier ordering was reached from that doc sentence alone and is kept
    * only because it is strictly safer and already tested: reading first cannot

--- a/src/provisioning/providers/cognito-provider.ts
+++ b/src/provisioning/providers/cognito-provider.ts
@@ -278,12 +278,17 @@ function hasMfaConfigProps(properties: Record<string, unknown>): boolean {
  * - `WebAuthnRelyingPartyID`/`WebAuthnUserVerification` -> `WebAuthnConfiguration`
  *
  * `MfaConfiguration` (ON/OFF/OPTIONAL) MUST be threaded into this request:
- * `SetUserPoolMfaConfig` is a full-replace of the pool's MFA state, and an
- * omitted `MfaConfiguration` defaults to OFF on the wire — which resets the
- * pool to MFA-disabled, and makes AWS reject the per-factor sub-blocks we are
- * trying to enable. That reset is MEASURED against THIS API — it is not read
- * off `UpdateUserPool`'s blanket reset sentence, which holds only field by
- * field. Use the template's `MfaConfiguration`
+ * `SetUserPoolMfaConfig` is a full-replace of the pool's MFA state, and AWS
+ * reads an omitted `MfaConfiguration` as OFF. That splits into two MUTUALLY
+ * EXCLUSIVE arms — both MEASURED against THIS API, not read off
+ * `UpdateUserPool`'s blanket reset sentence, which holds only field by field:
+ *
+ * - WITH a per-factor sub-block in the request, AWS REJECTS the call: nothing
+ *   is reset, and the deploy FAILS.
+ * - WITHOUT one, AWS accepts the call and the pool is silently reset to
+ *   MFA-disabled.
+ *
+ * Use the template's `MfaConfiguration`
  * when present; when the template omitted it, default by whether this call
  * enables an MFA FACTOR — `OPTIONAL` if it does, `OFF` (CloudFormation's own
  * default) if it does not. The body comment on that decision explains why both
@@ -391,6 +396,14 @@ function buildMfaConfigRequest(
   // off". The sub-block case therefore fails loudly rather than shipping a
   // silently MFA-disabled pool; threading the value is what avoids both.
   //
+  // Reproduced 2026-08-19 with an EXPLICIT `MfaConfiguration: OFF` instead of
+  // an omitted one -- same rejection, same message, for every member of
+  // `anyFactorBlock`. That transcript lives at the pinned-OFF warning below,
+  // which is the site it decides. `readLiveMfaConfiguration`'s ledger carries
+  // this API in a SECTION OF ITS OWN: `SetUserPoolMfaConfig` and
+  // `UpdateUserPool` are different APIs with different rules, and neither
+  // list licenses a claim about the other.
+  //
   // So thread the template's value, and when the template omitted it, default by
   // whether this call enables an MFA FACTOR at all. OFF is CloudFormation's own
   // default, and it is REQUIRED for a passkey-only pool: WebAuthn is not an MFA
@@ -410,13 +423,16 @@ function buildMfaConfigRequest(
   //  - The EmailMfaConfiguration half keeps the email-OTP message/subject shape
   //    on its existing OPTIONAL default: that block is emitted for a bare
   //    EmailAuthenticationMessage/Subject customization with NO EnabledMfas, so
-  //    it is the one sub-block the first half does not already imply. Whether
-  //    AWS accepts it under OFF is UNVERIFIED — the integ cannot reach it
-  //    (email-OTP needs a verified SES sender; see the fixture note) — so that
-  //    shape is deliberately left unchanged rather than flipped on an untested
-  //    wire assumption. Issue #1920 proposed keying on EnabledMfas alone, which
-  //    WOULD have flipped it; issue #1923 tracks the SES-account verification
-  //    that would settle it.
+  //    it is the one sub-block the first half does not already imply. Keeping
+  //    it on OPTIONAL is now MEASURED-correct rather than merely untested:
+  //    `{MfaConfiguration: OFF, EmailMfaConfiguration: {...}}` is REJECTED by
+  //    AWS (2026-08-19, issue #1968 — the same exclusion message every other
+  //    factor block draws under OFF), so flipping this shape to OFF would turn
+  //    a deploy that works into one that fails. Issue #1920 proposed keying on
+  //    EnabledMfas alone, which WOULD have flipped it. Only the under-OFF
+  //    ACCEPTANCE question is settled; what issue #1923 still tracks is the
+  //    SES-account verification the INTEG needs to exercise email-OTP end to
+  //    end, which is unchanged.
   //
   // Note SmsMfaConfiguration / SoftwareTokenMfaConfiguration are deliberately
   // NOT tested here: both are only ever set inside a `factors.has(...)` guard,
@@ -476,18 +492,48 @@ function buildMfaConfigRequest(
   // OFF here can only have come from the template. No explicit "was it
   // declared" test is needed and adding one could not change any outcome.
   //
-  // WARNING ONLY, never a refusal: sending OFF alongside a factor block is
-  // CloudFormation's own behavior for this template (the template asked for
-  // OFF and CFn sends OFF), and whether AWS accepts the pairing at all is
-  // UNVERIFIED — issue #1923 tracks the EmailMfaConfiguration-under-OFF
-  // question. The guard is correct under either answer precisely because it
-  // changes nothing about the request.
+  // MEASURED us-east-1 2026-08-19 (issue #1968): AWS REJECTS every request in
+  // which a factor block rides alongside `MfaConfiguration: OFF`, with
+  // `InvalidParameterException: Invalid MFA configuration given, can't turn off
+  // MFA and configure an MFA together`:
+  //
+  //   {ON,  SoftwareTokenMfaConfiguration: {Enabled: true}}   -> ACCEPTED (control)
+  //   {OFF, SoftwareTokenMfaConfiguration: {Enabled: true}}   -> rejected
+  //   {OFF, SoftwareTokenMfaConfiguration: {Enabled: false}}  -> rejected
+  //   {OFF, EmailMfaConfiguration: {Message, Subject}}        -> rejected
+  //
+  // The `Enabled: false` arm is what settles the KEY: a block that enables
+  // nothing is still refused, so the rule is about the block's PRESENCE, which
+  // is exactly what `anyFactorBlock` tests. `anyFactorBlock` is precisely
+  // {Sms, SoftwareToken, Email}MfaConfiguration, so no accepted case survives.
+  //
+  // Qualifier, stated because it bounds the EmailMfaConfiguration arm: an
+  // OPTIONAL control with that block on the same pool failed with a DIFFERENT
+  // error ("Cannot set EmailMfaConfiguration when user pool EmailConfiguration
+  // contains an EmailSendingAccount of COGNITO_DEFAULT"), so there was no clean
+  // isolated control for it. That divergence is itself informative -- the
+  // exclusion rule is evaluated BEFORE the email-sending-account check, which
+  // is why the OFF rejection is the exclusion and not an email-config artifact
+  // -- but the arm rests on the shared message, not on a control of its own.
+  //
+  // So the outcome is a DEPLOY FAILURE, not a silently MFA-disabled pool. The
+  // earlier message claimed the latter; it was wrong, and issue #1968 replaced
+  // it with the line below.
+  //
+  // STILL A WARNING, never a refusal -- but no longer because it is "correct
+  // under either answer", since there is only one answer now. It earns its
+  // place by firing BEFORE the call and naming the one-line fix, which the raw
+  // AWS error does not, while leaving the request untouched so cdkd is not the
+  // thing deciding a template is invalid. Promoting it to a pre-flight refusal
+  // is a behavior change needing its own integ and review round, and is filed
+  // separately rather than done here.
   if (request.MfaConfiguration === 'OFF' && anyFactorBlock) {
     logger?.warn(
       `UserPool ${physicalId}: MfaConfiguration is pinned to OFF while an MFA factor block is ` +
-        `configured. The factor configuration is still sent, but the pool deploys with MFA ` +
-        `DISABLED. Remove MfaConfiguration (or set it to ON / OPTIONAL) to enable the ` +
-        `declared factor.`
+        `configured. AWS REJECTS that combination ("Invalid MFA configuration given, can't ` +
+        `turn off MFA and configure an MFA together"), so this deploy FAILS rather than ` +
+        `producing a pool with MFA disabled. Remove MfaConfiguration (or set it to ON / ` +
+        `OPTIONAL) to enable the declared factor.`
     );
   }
 
@@ -519,25 +565,36 @@ function buildMfaConfigRequest(
     dropped.push(`${JSON.stringify(properties['EnabledMfas'])} (not a list)`);
   }
   if (dropped.length > 0) {
-    // Three outcomes, not two. Splitting only on OFF made the second arm claim
+    // FOUR outcomes, not three. Splitting only on OFF made the second arm claim
     // a rejection that does not happen whenever a RECOGNIZED factor rides
     // alongside the dropped entry: the request carries that factor's block, so
     // the dropped entry is not what fails the call. That is the silent-drop
     // case this warning exists to surface, so telling the user to expect a hard
-    // failure there is the worst of the three things it could say. The arm says
+    // failure there is the worst thing it could say. The arm says
     // a block IS SENT rather than that a factor IS ENABLED, because that is all
     // this code knows -- e.g. SMS_MFA without SmsConfiguration sends a block
     // AWS then rejects. (`anyFactorBlock` is hoisted above, shared with the
     // pinned-OFF warning -- one definition of "a factor block IS sent" so the
     // two messages cannot disagree about the same request.)
+    // The OFF case splits again on that same flag, because its two halves have
+    // OPPOSITE outcomes and the measurement (2026-08-19, issue #1968) covers
+    // only one of them: OFF WITH a block is REJECTED by AWS, while OFF with no
+    // block is accepted and really does deploy an MFA-disabled pool. Unsplit,
+    // the OFF arm contradicted the pinned-OFF warning -- which fires on exactly
+    // the OFF-plus-block request and now says "rejected" -- and that
+    // disagreement is what sharing `anyFactorBlock` exists to prevent.
     const consequence =
-      request.MfaConfiguration === 'OFF'
-        ? `MfaConfiguration is OFF, so this pool deploys with MFA DISABLED`
-        : anyFactorBlock
-          ? `MfaConfiguration is ${request.MfaConfiguration} and another factor block IS sent, ` +
-            `so these entries are silently ignored rather than failing the call on their own`
-          : `MfaConfiguration is ${request.MfaConfiguration} with no factor enabled, so AWS ` +
-            `rejects this call rather than deploying the pool with MFA disabled`;
+      request.MfaConfiguration === 'OFF' && anyFactorBlock
+        ? `MfaConfiguration is OFF while another factor block IS sent, so AWS REJECTS this ` +
+          `call outright and the deploy fails`
+        : request.MfaConfiguration === 'OFF'
+          ? `MfaConfiguration is OFF, so this pool deploys with MFA DISABLED`
+          : anyFactorBlock
+            ? `MfaConfiguration is ${request.MfaConfiguration} and another factor block IS ` +
+              `sent, so these entries are silently ignored rather than failing the call on ` +
+              `their own`
+            : `MfaConfiguration is ${request.MfaConfiguration} with no factor enabled, so AWS ` +
+              `rejects this call rather than deploying the pool with MFA disabled`;
     logger?.warn(
       `UserPool ${physicalId}: EnabledMfas entries ${dropped.join(', ')} do not map to an MFA ` +
         `factor block (known: ${MFA_FACTOR_SMS}, ${MFA_FACTOR_SOFTWARE_TOKEN}, ` +
@@ -777,12 +834,29 @@ export class CognitoUserPoolProvider implements ResourceProvider {
    * - An explicit `SignInPolicy` write landed in both directions
    *   (`[PASSWORD]`, then back to `[PASSWORD, EMAIL_OTP]`), so the field is
    *   reachable and writable here rather than silently dropped.
+   * - The MIRROR image holds too, so the ledger entry is measured rather than
+   *   generalised from one sub-key: a container carrying ONLY `SignInPolicy`
+   *   updated it to `[PASSWORD, WEB_AUTHN]` while leaving a non-default
+   *   `PasswordPolicy` (`MinimumLength: 12`, `RequireSymbols: false`) intact,
+   *   with the same `--auto-verified-attributes` control.
    *
    * So the forwarding stays -- it is the only way a CHANGED sign-in policy is
    * applied -- but on the measured reason, not the blanket sentence. Do not
    * generalise that sentence to another field from this site: see
    * `readLiveMfaConfiguration`'s docstring, which carries the one ledger of
    * which fields were measured to reset and which were not.
+   *
+   * **Consequence of that measurement, NOT fixed here: there is no removal
+   * path.** This builder forwards only what the template DECLARES, so deleting
+   * `SignInPolicy` from a template sends nothing for it -- and nothing sent
+   * means nothing changed. A user tightening their auth by removing a
+   * passwordless first-auth factor therefore leaves it live on the pool
+   * indefinitely, and `readCurrentState` keeps reporting a drift that
+   * `cdkd drift --revert` cannot clear, since the revert routes through this
+   * same builder. Clearing it needs an explicit reset value on the wire, which
+   * is a behavior change with its own integ and is out of this lane's scope.
+   * Whether CloudFormation removes it on the same template edit is UNMEASURED
+   * -- do not assume parity in either direction.
    */
   private toSdkUserPoolPolicies(policies: Record<string, unknown>): UserPoolPolicyType | undefined {
     const result: UserPoolPolicyType = {};
@@ -1180,16 +1254,32 @@ export class CognitoUserPoolProvider implements ResourceProvider {
    * there is no MFA-OFF window to design around.
    *
    * **This paragraph is the single ledger of that field-by-field result; a
-   * per-field verdict belongs at that field's own site, pointing here.**
-   * Measured so far, all `UpdateUserPool` with a control proving the call ran:
+   * per-field verdict belongs at that field's own site, pointing here.** Every
+   * line below was taken with a control proving the omitting call really ran.
+   *
+   * `UpdateUserPool`, on omission:
    *
    * - `AutoVerifiedAttributes` — DOES reset when omitted (2026-08-18).
    * - `MfaConfiguration` — does NOT reset when omitted (2026-08-18, above).
-   * - `Policies` — neither sub-key resets, whether the container is sent
-   *   without `SignInPolicy` or omitted outright (2026-08-19, issue #1968;
-   *   details at `toSdkUserPoolPolicies`).
+   * - `Policies` — neither sub-key resets, measured in BOTH directions
+   *   (2026-08-19, issue #1968; details at `toSdkUserPoolPolicies`): a
+   *   container sent without `SignInPolicy` left `SignInPolicy` intact, a
+   *   container sent without `PasswordPolicy` left `PasswordPolicy` intact,
+   *   and omitting the container outright left both. Forwarding is still
+   *   REQUIRED to APPLY a changed sub-key — preservation is not application —
+   *   and no omission can express a REMOVAL.
    *
-   * Nothing here licenses a claim about a field NOT on that list. Measure it.
+   * `SetUserPoolMfaConfig` — a DIFFERENT API with a DIFFERENT rule, kept in
+   * its own section so neither list is read as evidence for the other:
+   *
+   * - `MfaConfiguration` — an omitted value is read as OFF. With a factor
+   *   sub-block in the request AWS REJECTS the call; with none it accepts and
+   *   resets the pool to MFA-disabled. An EXPLICIT OFF beside a block is
+   *   rejected the same way (2026-08-19, issue #1968; the transcript lives at
+   *   the pinned-OFF warning in `buildMfaConfigRequest`).
+   *
+   * Nothing here licenses a claim about a field on neither list, or about one
+   * API from the other's section. Measure it.
    *
    * The earlier ordering was reached from that doc sentence alone and is kept
    * only because it is strictly safer and already tested: reading first cannot
@@ -1331,6 +1421,10 @@ export class CognitoUserPoolProvider implements ResourceProvider {
       if (properties['LambdaConfig']) {
         updateParams.LambdaConfig = properties['LambdaConfig'] as LambdaConfigType;
       }
+      // The one field measured to RESET when omitted -- see the ledger in
+      // `readLiveMfaConfiguration`. So a template that drops this property
+      // really does clear it at AWS, unlike `Policies` above, whose sub-keys
+      // survive their own omission.
       if (properties['AutoVerifiedAttributes']) {
         updateParams.AutoVerifiedAttributes = properties[
           'AutoVerifiedAttributes'

--- a/tests/integration/cognito/README.md
+++ b/tests/integration/cognito/README.md
@@ -7,7 +7,7 @@ UserPool deployment example for cdkd with email sign-in and password policy.
 - **UserPool** - Cognito User Pool with email sign-in, auto-verification, and custom password policy
 - **BackfillUserPool** - L1 `CfnUserPool` exercising the issue #609 backfill properties (`UserPoolTier` / `EnabledMfas` / `WebAuthn*`) with an explicit `MfaConfiguration: ON` (ON, not OPTIONAL, so the assertion can tell a threaded explicit value from a fired default)
 - **PasskeyOnlyUserPool** - L1 `CfnUserPool` with WebAuthn and NO `MfaConfiguration` (issue #1920) -> must land as `OFF`; the absence is the input under test, so do not add one
-- **FactorDefaultUserPool** - L1 `CfnUserPool` with an MFA factor and NO `MfaConfiguration` (issue #1920) -> must land as `OPTIONAL`; the inverse regression, where a declared factor deploys with MFA disabled
+- **FactorDefaultUserPool** - L1 `CfnUserPool` with an MFA factor and NO `MfaConfiguration` (issue #1920) -> must land as `OPTIONAL`; the inverse regression sends the declared factor under `MfaConfiguration: OFF`, which AWS REJECTS outright (measured 2026-08-19, issue #1968), so it surfaces as a FAILED deploy rather than as a silently MFA-disabled pool
 
 ## Demonstrates
 

--- a/tests/unit/provisioning/cognito-provider.test.ts
+++ b/tests/unit/provisioning/cognito-provider.test.ts
@@ -225,8 +225,12 @@ describe('CognitoUserPoolProvider', () => {
     });
 
     it('should forward Policies.SignInPolicy on update (#1380)', async () => {
-      // UpdateUserPool resets omitted attributes to defaults, so dropping
-      // SignInPolicy here wipes an existing passwordless configuration.
+      // Forwarding is what APPLIES a declared change: this case CHANGES the
+      // allowed first-auth factors, and dropping SignInPolicy from the request
+      // would leave the pool on its previous value. It is NOT about omission
+      // resetting the field -- measured us-east-1 2026-08-19 (issue #1968), an
+      // UpdateUserPool omitting SignInPolicy leaves it intact; see
+      // `toSdkUserPoolPolicies` in the provider.
       mockSend.mockResolvedValueOnce({});
       mockSend.mockResolvedValueOnce({
         UserPool: {
@@ -714,8 +718,9 @@ describe('CognitoUserPoolProvider', () => {
 
       it('defaults to OFF for a WebAuthn-only pool on update too', async () => {
         // GetUserPoolMfaConfig: the undeclared-OFF announcement probe (#1925
-        // item 3) reads the live value BEFORE UpdateUserPool can reset it. OFF
-        // here, so nothing is being downgraded and no warning is emitted.
+        // item 3) reads the live value BEFORE UpdateUserPool, defensively --
+        // measured, that update does NOT reset MfaConfiguration. OFF here, so
+        // nothing is being downgraded and no warning is emitted.
         mockSend.mockResolvedValueOnce({ MfaConfiguration: 'OFF' });
         mockSend.mockResolvedValueOnce({}); // UpdateUserPool
         mockSend.mockResolvedValueOnce({}); // SetUserPoolMfaConfig
@@ -1342,9 +1347,13 @@ describe('CognitoUserPoolProvider', () => {
           {}
         );
 
-        // The read must come FIRST: AWS documents UpdateUserPool as resetting
-        // omitted parameters, so probing after it could read a value this same
-        // call already clobbered and the announcement would go silent.
+        // The read must come FIRST -- defensively, NOT because AWS resets the
+        // field. Measured us-east-1 2026-08-18: MfaConfiguration survives an
+        // UpdateUserPool that omits it (see `readLiveMfaConfiguration`, which
+        // carries the ledger of which fields were measured to reset). Reading
+        // first is kept because it cannot report a value this same call
+        // clobbered, whatever AWS does later; do not re-derive the ordering
+        // from the blanket "omitted parameters are reset" doc sentence.
         const getCall = mockSend.mock.calls[0][0];
         expect(getCall.constructor.name).toBe('GetUserPoolMfaConfigCommand');
         expect(getCall.input.UserPoolId).toBe('us-east-1_abc123');

--- a/tests/unit/provisioning/cognito-provider.test.ts
+++ b/tests/unit/provisioning/cognito-provider.test.ts
@@ -225,12 +225,12 @@ describe('CognitoUserPoolProvider', () => {
     });
 
     it('should forward Policies.SignInPolicy on update (#1380)', async () => {
-      // Forwarding is what APPLIES a declared change: this case CHANGES the
-      // allowed first-auth factors, and dropping SignInPolicy from the request
-      // would leave the pool on its previous value. It is NOT about omission
-      // resetting the field -- measured us-east-1 2026-08-19 (issue #1968), an
-      // UpdateUserPool omitting SignInPolicy leaves it intact; see
-      // `toSdkUserPoolPolicies` in the provider.
+      // Forwarding is what APPLIES a declared value. `previousProperties` here
+      // declares no SignInPolicy, so this case ADDS one; dropping it from the
+      // request would leave the pool with no sign-in policy at all. It is NOT
+      // about omission resetting the field -- measured us-east-1 2026-08-19
+      // (issue #1968), an UpdateUserPool omitting SignInPolicy leaves it
+      // intact; see `toSdkUserPoolPolicies` in the provider.
       mockSend.mockResolvedValueOnce({});
       mockSend.mockResolvedValueOnce({
         UserPool: {
@@ -539,9 +539,13 @@ describe('CognitoUserPoolProvider', () => {
         const mfaCall = mockSend.mock.calls[1][0];
         expect(mfaCall.constructor.name).toBe('SetUserPoolMfaConfigCommand');
         expect(mfaCall.input.UserPoolId).toBe('us-east-1_abc123');
-        // SetUserPoolMfaConfig is a full-replace: MfaConfiguration MUST be set
-        // (an omitted value resets the pool to OFF and drops the factors below).
-        // Defaults to OPTIONAL when the template omits it but enables factors.
+        // SetUserPoolMfaConfig is a full-replace: MfaConfiguration MUST be set.
+        // Measured 2026-08-19 (issue #1968), the two arms differ: omitting it
+        // WITH factor blocks in the request makes AWS REJECT the call, and
+        // omitting it with none resets the pool to OFF. See the
+        // SetUserPoolMfaConfig section of the ledger in
+        // `readLiveMfaConfiguration`. Defaults to OPTIONAL when the template
+        // omits it but enables factors.
         expect(mfaCall.input.MfaConfiguration).toBe('OPTIONAL');
         expect(mfaCall.input.SoftwareTokenMfaConfiguration).toEqual({ Enabled: true });
         expect(mfaCall.input.SmsMfaConfiguration).toEqual({
@@ -1042,6 +1046,35 @@ describe('CognitoUserPoolProvider', () => {
           expect(warned).not.toContain('AWS rejects');
         }
       );
+
+      // The OFF arm of the consequence, split on `anyFactorBlock` by issue
+      // #1968. A dropped entry NEXT TO a recognized factor under an explicit
+      // OFF is the one shape where both warnings fire on the same request, and
+      // before the split they contradicted each other: this one promised a
+      // deployed-but-MFA-disabled pool while the pinned-OFF warning promised a
+      // rejection. Measured 2026-08-19, the rejection is what happens.
+      it('says the call is REJECTED when a dropped entry rides beside a factor block under OFF', async () => {
+        mockSend.mockResolvedValueOnce({
+          UserPool: { Id: 'us-east-1_abc123', Arn: 'arn:dropped-off-with-block' },
+        });
+        mockSend.mockResolvedValueOnce({});
+
+        await provider.create('MyUserPool', 'AWS::Cognito::UserPool', {
+          EnabledMfas: ['SOFTWARE_TOKEN_MFA', 'NOT_A_FACTOR'],
+          MfaConfiguration: 'OFF',
+        });
+
+        const mfaCall = mockSend.mock.calls[1][0];
+        expect(mfaCall.input.MfaConfiguration).toBe('OFF');
+        expect(mfaCall.input.SoftwareTokenMfaConfiguration).toEqual({ Enabled: true });
+
+        const warned = childLogger.warn.mock.calls.map((c) => String(c[0])).join('\n');
+        expect(warned).toContain('"NOT_A_FACTOR"');
+        expect(warned).toContain('AWS REJECTS this call outright');
+        // The two warnings must now AGREE about this one request.
+        expect(warned).toContain('MfaConfiguration is pinned to OFF');
+        expect(warned).not.toContain('deploys with MFA DISABLED');
+      });
 
       // Pins the `?? String(f)` fallback. A template cannot produce an
       // undefined member, but JSON.stringify(undefined) returns undefined and
@@ -1807,10 +1840,13 @@ describe('CognitoUserPoolProvider', () => {
       });
     });
 
-    // Issue #1932 item 2. WARNING ONLY: sending OFF alongside a factor block is
-    // what CloudFormation does for this template, and whether AWS accepts the
-    // pairing is unverified (#1923) — so the guard must be correct under either
-    // answer, which it is precisely because it changes nothing on the wire.
+    // Issue #1932 item 2, with the open question settled by issue #1968.
+    // MEASURED 2026-08-19: AWS REJECTS OFF alongside a factor block, so the
+    // deploy FAILS -- it never produces a pool with MFA disabled, which is what
+    // the message used to promise. Still WARNING ONLY: it fires before the call
+    // and names the one-line fix, and leaves the request untouched. Promoting
+    // it to a pre-flight refusal is a separate behavior change, filed on its
+    // own rather than made here.
     describe('a declared factor pinned to MfaConfiguration OFF (#1932)', () => {
       it('warns, and still sends the factor block plus OFF', async () => {
         mockSend.mockResolvedValueOnce({
@@ -1826,7 +1862,16 @@ describe('CognitoUserPoolProvider', () => {
         const warned = childLogger.warn.mock.calls.map((c) => String(c[0])).join('\n');
         expect(warned).toContain('MfaConfiguration is pinned to OFF');
         expect(warned).toContain('an MFA factor block is configured');
+        // The measured outcome (issue #1968): AWS refuses the pairing, so the
+        // deploy fails. The old message promised a deployed-but-MFA-disabled
+        // pool, an outcome this branch never reaches -- pinned as a negative so
+        // reintroducing that claim fails here rather than shipping again.
+        expect(warned).toContain('AWS REJECTS that combination');
+        expect(warned).toContain('this deploy FAILS');
+        expect(warned).not.toContain('deploys with MFA');
 
+        // The request is still sent unchanged: this is an announcement, not a
+        // pre-flight refusal.
         const mfaCall = mockSend.mock.calls[1][0];
         expect(mfaCall.input.MfaConfiguration).toBe('OFF');
         expect(mfaCall.input.SoftwareTokenMfaConfiguration).toEqual({ Enabled: true });


### PR DESCRIPTION
## Summary

`CognitoUserPoolProvider` justified forwarding `Policies.SignInPolicy` on the
update path with AWS's blanket sentence *"if you don't provide a value for an
attribute, Amazon Cognito sets it to its default value."* PR #1965 had already
measured that sentence to hold **field by field**, not API-wide. This PR
measures the fields this provider actually depends on, replaces every rationale
resting on the blanket sentence with the measurement, and — because one of those
measurements falsified a user-facing warning — corrects that warning too.

Closes #1968
Closes #1923

## What was measured

All arms us-east-1, 2026-08-19, throwaway pools, deleted afterwards. Every arm
carries a control proving the call actually applied, because a silently
no-opped update is indistinguishable from "preserved" without one.

`UpdateUserPool`:

| arm | result |
|---|---|
| `Policies` sent with only `PasswordPolicy` | `SignInPolicy` **preserved** |
| `Policies` omitted entirely | **both** sub-keys preserved (a non-default `RequireSymbols: false` survived) |
| `Policies` sent with only `SignInPolicy` | `PasswordPolicy` **preserved** |
| explicit `SignInPolicy` write, both directions | landed — the field is reachable and writable |
| control, every arm | `AutoVerifiedAttributes` moved as expected, so the calls ran |

`SetUserPoolMfaConfig` — a different API with a different rule, so it is
recorded as a separate ledger section rather than inferred from the above:

| arm | result |
|---|---|
| `MfaConfiguration: OFF` + `SoftwareTokenMfaConfiguration {Enabled: true}` | **REJECTED** — `Invalid MFA configuration given, can't turn off MFA and configure an MFA together` |
| `MfaConfiguration: OFF` + `SoftwareTokenMfaConfiguration {Enabled: false}` | **REJECTED**, same message — a block that enables nothing still counts |
| `MfaConfiguration: OFF` + `EmailMfaConfiguration {Message, Subject}` | **REJECTED**, same message |
| control | `ON` + the same factor block is **accepted** |

## The user-facing correction

`anyFactorBlock` is exactly `{SmsMfaConfiguration, SoftwareTokenMfaConfiguration,
EmailMfaConfiguration}`, so **every** combination the pinned-OFF warning fires on
is rejected by AWS. The warning nevertheless told the user:

> The factor configuration is still sent, but the pool deploys with MFA DISABLED.

That is false — the deploy FAILS. It now states the rejection, quotes AWS's
message, and keeps the same one-line remedy. It stays a **warning, not a
refusal**: firing before the call and naming the fix is worth keeping, but
promoting it to a pre-flight refusal is a behavior change with its own integ and
review cost, split out as #1977.

The other warning containing the phrase "deploys with MFA DISABLED" — the
dropped-entry consequence arm, which fires when NO factor sub-block is emitted —
is **unchanged and still true**: a bare `SetUserPoolMfaConfig` carrying only the
pool id is accepted and does set the pool to OFF. The two are different
predicates and were kept apart deliberately.

While splitting them, one further defect surfaced: the dropped-entry arm picked
its OFF consequence regardless of `anyFactorBlock`, so on a request carrying both
a dropped entry and a recognized factor under OFF the two warnings would have
flatly contradicted each other once the first was corrected. That arm is now
split too, with a test.

## Why #1923 closes

#1923 asked whether AWS accepts `EmailMfaConfiguration` under `MfaConfiguration:
OFF`, and recorded that a portable integ could not settle it because
`EmailMfaConfiguration` needs `EmailSendingAccount=DEVELOPER` with a verified SES
identity. The MFA-exclusion check turns out to be evaluated **before** the
email-sending-account check — an `OPTIONAL` control on the same pool failed with
the SES error while the `OFF` arm failed with the MFA one — so the question is
answerable on any account. By that issue's own decision rule the outcome is: keep
today's `OPTIONAL` default for a bare message/subject customization. It is not
merely the safe choice, it is the only working one.

## Scope discipline

Rationale sites are consolidated: `readLiveMfaConfiguration`'s docstring is the
single ledger of measured per-field results, and every other site points at it
rather than restating it. Nothing there licenses a claim about a field not on the
list.

Three consequences of the measurement are recorded in-code but deliberately NOT
implemented here, each with its own issue and `Session-fit` line:

- **#1979** — because omission preserves, REMOVING `SignInPolicy` from a template
  is a silent no-op at AWS. A tightening edit never lands and leaves drift that
  `--revert` cannot clear. Needs a CloudFormation A/B to decide between an
  explicit reset and a warn.
- **#1977** — promote the corrected warning to a pre-flight refusal, since the
  rejection rate for the warned condition is 100%.
- **#1975** — an `EMAIL_OTP` first-auth factor with `MfaConfiguration: ON` is
  refused by AWS, and on the update path `UpdateUserPool` has already landed when
  `SetUserPoolMfaConfig` fails, leaving a partial apply.

No CloudFormation parity claim is made anywhere in this PR; every parity question
is named as unmeasured and deferred to the issue that owns it.

## Test plan

- `vp run typecheck`, `typecheck:test`, `lint` (0 errors), `format:check`,
  `build` — all pass.
- `vp run test` — 685 files / 14016 tests pass, no type errors.
- New tests pin the corrected warning (including a `not.toContain` on the old
  claim so it cannot come back) and the newly-split dropped-entry arm. Both were
  verified to FAIL without their fix by in-place source mutation, then restored.
- Live: `/run-integ cognito` against real AWS — 7 resources deleted, 0 errors,
  0 orphans, no user pool and no `state.json` left behind. The fixture covers the
  two arms the corrected warning sits between (`MfaConfiguration` defaulting on
  both OFF and OPTIONAL, #1920; the MFA update transitions, #1925). Recorded in
  `docs/_generated/integ-last-run.tsv`.
- Reviewed by `pr-code-reviewer` and `pr-security-reviewer`. Every blocker and
  should-fix is either fixed here or filed above; no reviewer item is unhandled.
