### PR TITLE
chore(work-issues): catch the duplicates the three-repo mirror rule generates

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -167,6 +167,20 @@ parallelized — bundle them into ONE lane (one worktree, one PR) or defer one.
   exactly the re-litigation the classification exists to prevent (CLAUDE.md →
   "Session-fit classification") — the call was made when the evidence for it was
   still in hand, and that evidence is gone by the time you are triaging.
+- **A MIRROR issue may already be done — resolve it against the repo before you
+  claim it.** A body saying it is mirroring a lesson from a sibling repo comes from
+  the duplicate generator §10-c describes, so run that section's three-window check
+  from the reading side — but at triage the order INVERTS: read the FILE first.
+  Filing happens minutes after a rival hop, while its issue and PR are still open;
+  triage happens after they have merged and closed, so the backlog search that would
+  have served the filer surfaces no rival while the work sits done on `main`. On
+  2026-08-19 go-to-k/cdkd#1986 was shortlisted here, and a grep of
+  `.claude/skills/work-issues/SKILL.md` found both halves of it already on `main` —
+  merged by go-to-k/cdkd#1984 four minutes after go-to-k/cdkd#1986 was filed — while
+  an open-issue search at that moment surfaced no rival holding the lesson, the one
+  that had (go-to-k/cdkd#1980) having closed four minutes earlier. That grep costs
+  one command at triage; the same discovery after claiming costs a worktree, a
+  `pnpm install` and a gate round.
 
 Scale the count to the backlog and to how many cross-cutting files are free. 2–3
 clean lanes is typical; do not force a lane into a contested file just to raise the
@@ -221,8 +235,11 @@ gate and §4's claim-then-verify still apply unchanged:
   comment on it is the proof — which is also why the exemption stops at `now`: §4
   gives a `next` issue no claim, and taking one back minutes after classifying it
   `next` contradicts the classification rather than being exempted by it.
-- **The maintainer named the issue in the invocation** (`/work-issues #<n>`) — an
-  explicit instruction outranks a heuristic about who else might want it.
+- **The maintainer named the issue in the invocation** — an explicit instruction
+  outranks a heuristic about who else might want it. Read the whole invoking
+  message, not just the command line: an issue number anywhere in it names the
+  issue, whether it trails the command, leads it, or sits on its own line above it.
+  On 2026-08-19 a run arrived with the number alone on the preceding line.
 - **A security issue** (rule 1 of §3-a) — an extra hour of a shipped vulnerability
   costs more than a duplicated context. Take it, and say in the claim (§4) that you
   took it inside the window and why.
@@ -238,10 +255,10 @@ What the gate accepts in exchange: an issue filed by a session that has since en
 waits up to an hour. That is the cheap side — the backlog is not going anywhere,
 while the expensive side is two agents deriving one fix from scratch. Added
 2026-08-19 at the maintainer's request, and the window was watched live the same
-morning: #1973 was filed at 03:14Z, claimed by its filing lane at 03:30Z, and that
-lane's branch reached `origin` only at 04:06Z. For 16 minutes the issue had no
-branch, no PR and no comment, so every probe in §2 reported it free; for 52 minutes
-nothing but a time-based gate could have kept a second run off it.
+morning: go-to-k/cdkd#1973 was filed at 03:14Z, claimed by its filing lane at
+03:30Z, and that lane's branch reached `origin` only at 04:06Z. For 16 minutes the
+issue had no branch, no PR and no comment, so every probe in §2 reported it free;
+for 52 minutes nothing but a time-based gate could have kept a second run off it.
 
 ### 3-a. Ranking the eligible issues
 
@@ -693,6 +710,51 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   them in this session when it can pay for two more gate runs; otherwise file one
   issue per repo carrying the `Session-fit` line. What is not an option is landing
   the fix in only one of the three — that is how the three drift apart.
+  **Before filing into a target repo, resolve the lesson against that repo's
+  CURRENT state — the merged FILE, then open PRs, then open issues — and file only
+  what none of the three already carries.** This mirror rule is a duplicate
+  GENERATOR, structurally rather than by bad luck: the chain runs A -> B -> C, so
+  two hops file into the same target repo independently and neither can see the
+  other. All three windows are needed because a lesson MOVES between them while it
+  is being worked — an hour after a rival hop files, its issue is closed and its PR
+  is merged, and the file is the only place left that shows the work was done. Each
+  hit takes a different action: already in the file, do not file at all; in an open
+  PR, comment on the PR; in an open issue, comment there with what this hop adds.
+  Two ways these searches miss what is really there: **match on the CONCEPT, not on
+  a phrase** — the bullet above tells each hop to adapt the wording per repo, so a
+  literal phrase lifted from your own copy will not find the sibling's rewrite — and
+  **judge a candidate PR by its BODY and DIFF, never its title**, since a mirror
+  lesson often rides along in a PR named for a different one. A mirror body saying
+  "landed in N of them" is the signal that other hops exist.
+
+  ```bash
+  T=/Users/goto/github/<target>
+  # the landed window — fetch first: a stale clone false-negatives the one window
+  # that no later check can recover
+  git -C "$T" fetch -q origin
+  git -C "$T" grep -n -i -e '<concept-keyword-1>' -e '<concept-keyword-2>' \
+    origin/main -- .claude/skills/work-issues/SKILL.md
+  # the in-flight window — then read each hit, since the title alone decides nothing
+  gh -R go-to-k/<target> pr list --state open --search '<keyword>' --json number,title
+  gh -R go-to-k/<target> pr view <hit> --json body -q .body
+  gh -R go-to-k/<target> pr diff <hit>
+  # the not-started window
+  gh -R go-to-k/<target> issue list --state open --search '<keyword>' --json number,title
+  ```
+
+  On 2026-08-19 this chain filed THREE issues into cdkd for two lessons inside 70
+  minutes, and the SAME lesson was reachable through a different window at each
+  moment someone looked. go-to-k/cdkd#1973 (03:14Z) and go-to-k/cdkd#1980 (03:50Z)
+  duplicate each other on the same §8 change: at 03:50Z the open-ISSUE check reaches
+  it, go-to-k/cdkd#1973 being still open. go-to-k/cdkd#1986 (04:23Z) then asked for
+  a §10-c sentence that by then sat in TWO open places — go-to-k/cdkd#1980's body,
+  and go-to-k/cdkd#1984, open since 04:18:12Z carrying the sentence in both its body
+  and its diff while its title named only the §8 lesson. Ten minutes later every one
+  of those had evaporated: go-to-k/cdkd#1984 merged at 04:27:29Z, go-to-k/cdkd#1980
+  closed at 04:28:51Z, and at 04:33Z triage neither an issue nor a PR search still
+  surfaced a rival holding the lesson, while the FILE now carried it outright (§3).
+  No single window was sufficient across that hour; which one pays depends only on
+  when you look.
   **Verify the copy against the TARGET repo, claim by claim, before shipping it.**
   Their gates, hooks and ship steps differ, so a sentence that is true here reads as
   authoritative there while being false, and nothing lints instruction prose — the
@@ -789,6 +851,10 @@ the run evidence behind it — or "no skill change" plus what held.
   lanes — was claimed, and had to be retracted after the deep read showed the
   legacy-state fixture arm plus export integ its body had already named. The line
   was in the body the whole time; nothing but a grep stood between the run and it.
+- **A mirror issue is a duplicate more often than it looks.** §10-c's three-repo
+  rule files one lesson into one repo from two hops, so resolve it against the file,
+  open PRs and open issues before filing one (§10-c) or claiming one (§3). Which of
+  the three finds it depends only on how long ago the rival hop ran.
 - **One lane per cross-cutting file.** `deploy-engine.ts` / `intrinsic-function-resolver.ts`
   / `dag-builder.ts` / `register-providers.ts` absorb most non-trivial fixes; you
   cannot parallelize two issues that both land there. Per-provider fixes ARE


### PR DESCRIPTION
## Summary

`/work-issues` section 10-c requires a flow lesson to land in all three repos, so
the chain runs A -> B -> C and two hops file into the same target repo
independently, neither able to see the other. It is a duplicate GENERATOR, and
neither the filing side (10-c) nor the triage side (sections 1-3) had a step that
caught what it produces.

**Filing side (section 10-c)** — before filing into a target repo, resolve the
lesson against that repo's current state: the merged FILE, then open PRs, then
open issues. File only what none of the three already carries.

**Triage side (section 3)** — the same three-window check, but the order
**inverts**. Filing happens minutes after a rival hop, while its issue and PR are
still open. Triage happens after they have merged and closed, so the backlog
search that would have served the filer surfaces no rival, and only the file
still shows the work was done.

Two search failure modes are called out because both were hit live: match on the
CONCEPT rather than a phrase (section 10-c itself tells each hop to reword per
repo), and judge a candidate PR by its BODY and DIFF, never its title.

## Evidence

All on 2026-08-19. The chain filed three issues into cdkd for two lessons inside
70 minutes, and the same lesson was reachable through a **different window at
each moment someone looked** — which is why all three checks are needed:

| time | event | which window reaches it |
|---|---|---|
| 03:14:04Z | issue 1973 filed | — |
| 03:50:28Z | issue 1980 filed, duplicating 1973's section 8 change | open ISSUE (1973 still open) |
| 04:18:12Z | PR 1984 opened — carries a section 10-c sentence in body AND diff, title names only section 8 | — |
| 04:23:07Z | issue 1986 filed for that sentence | open ISSUE (1980's body) **and** open PR (1984) |
| 04:27:29Z | PR 1984 merged | — |
| 04:28:51Z | issue 1980 closed | — |
| 04:33:05Z | triage of 1986 | FILE only — no rival left in issues or PRs |

## Two corrections made during review

Both were caught by re-reading the cited records rather than trusting a plausible
story — the same failure mode section 10-c's "read the BODY of every incident the
copy cites" rule exists to prevent. Recording them because this PR is about
exactly that class of error:

- A first draft claimed **only** the open-PR check could reach issue 1986, and
  that at 04:23Z no open issue held it. False — issue 1980 was open until
  04:28:51Z and its body carries the rule verbatim.
- A first draft claimed PR 1984's **diff** was the sole place the sentence was
  visible. False — its body quotes the sentence, and the body is what `--search`
  indexes.

## Verification

No `src/**` change, so section 8's **prose arm** applies: the claims are the
artifact. Every command the new text will send the next agent to run was executed
against a real sibling repo, not just read:

- `git -C <target> fetch -q origin` then
  `git -C <target> grep -n -i -e '<k1>' -e '<k2>' origin/main -- .claude/skills/work-issues/SKILL.md`
  — rc=0 against both `cdk-local` and `cdk-real-drift`, and it does find the
  lesson in `cdk-local`'s main
- `gh pr list --state open --search ... --json number,title`, `gh pr view --json body`,
  `gh pr diff`, `gh issue list --state open --search ...` — all rc=0
- every path, section cross-reference, and cited issue/PR resolved against the
  live GitHub API; every timestamp checked to the second
- `/check`: 690 test files, 14054 tests, 0 type errors; `gen:all-matrices` and
  `audit:coverage:check` clean

Two independent read-only reviewers were dispatched despite the size heuristic
giving `inline` (66 LOC, 1 file). Agent-instruction files are deliberately
excluded from the review down-bias because a wrong rule here propagates into
every future session, and the tier is a floor rather than a cap. They found four
false claims, all fixed above; a second adversarial round confirmed the rewrite
introduced no new ones.

## Not done here

- Roughly 14 unqualified issue/PR refs elsewhere in this file — (#1991).
  Section 10-c's qualify rule is scoped to "every reference the copy carries", so
  a whole-file pass is a deliberate widening rather than a consistency fix.
- `pr-body-item-number-gate` rejects the qualified `owner/repo` ref form that
  section 10-c mandates — (#1992). Hit live while filing 1991.
- Nothing was cut to offset the addition. Section 10-c accepts net growth when
  the lesson is genuinely new, and there was no prior duplicate check to amend.

Closes #1987
Closes #1986
