### PR TITLE
chore(work-issues): section 9 claimed the worktree removal deletes the local branch, and it never did

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -640,9 +640,20 @@ the `integ-*` markers — together they unblock `gh pr merge`.
 gh pr merge <n> --squash --delete-branch     # squash is the repo's only method
 ```
 
-(Local branch delete fails while its worktree exists — expected; the worktree
-removal below clears it.) Merge each verified PR. If a later PR is behind, GitHub
-still merges it when the files are disjoint.
+(`--delete-branch` removes the REMOTE branch but fails on the local one while its
+worktree exists — expected. The worktree removal below does NOT then clear it:
+`git worktree remove` deletes the worktree, never the branch, so the local ref
+survives both steps and you must finish with an explicit `git branch -D <branch>`.
+It has to be `-D`: this repo squash-merges, so the branch tip is never an ancestor of
+`main` and `-d` refuses it as "not fully merged" (verified 2026-08-19 — git's own hint
+is to use `-D`). Read that refusal as the expected squash artifact, not as a warning
+that the work is unmerged; confirm the PR is MERGED first, and the `-D` is safe.
+Measured 2026-08-19, after this sentence had claimed otherwise for months: the repo
+held a dozen stale local branches — `chore/1987-mirror-duplicate-detection`,
+`chore/1973-work-issues-no-src-tier`, `chore/1593-work-issues-author-association`
+and more — every one merged, every worktree long gone, every branch left behind by
+believing this line.) Merge each verified PR. If a later PR is behind, GitHub still
+merges it when the files are disjoint.
 
 ```bash
 git checkout main && git pull origin main    # bring the merges local
@@ -676,7 +687,9 @@ the silent residue of this flow):
 ```bash
 git worktree remove .claude/worktrees/<branch>   # --force if it refuses on artifacts
 git worktree prune
+git branch -D <branch>                           # -D, not -d (squash) - see §9 above
 git worktree list                                # every worktree THIS run added is gone
+git branch --list '<your prefix>*'               # ...and so is every branch it added
 ```
 
 The closing check is "every worktree THIS run added is gone", **never "only the


### PR DESCRIPTION
Section 10 retrospective for the run that shipped https://github.com/go-to-k/cdkd/pull/2009.

## The defect

Section 9 said, of the local branch left over after `gh pr merge --delete-branch`:

> (Local branch delete fails while its worktree exists — expected; the worktree
> removal below clears it.)

`git worktree remove` deletes the worktree and never the branch, so the second half
was simply false. Every lane that followed it left its local ref behind.

**Evidence, measured on this repo the same day.** A dozen stale local branches, every
one merged and every worktree long gone — `chore/1987-mirror-duplicate-detection`
(merged as https://github.com/go-to-k/cdkd/pull/2000),
`chore/1973-work-issues-no-src-tier`, `chore/1593-work-issues-author-association` and
more. This is not a single slip; it is months of accumulation caused by one sentence.

## The fix

The cleanup block now deletes the branch explicitly and the closing check verifies
branches as well as worktrees:

```bash
git worktree remove .claude/worktrees/<branch>
git worktree prune
git branch -D <branch>                           # -D, not -d (squash) - see §9 above
git worktree list
git branch --list '<your prefix>*'
```

`-D` is load-bearing and was verified rather than assumed. This repo squash-merges, so
a branch tip is never an ancestor of `main`; `git branch -d chore/1973-work-issues-no-src-tier`
returns `error: the branch ... is not fully merged` and git's own hint is to use `-D`.
That refusal is the expected squash artifact, not a warning that the work is unmerged
— which is exactly why a run that hits it might otherwise back off and leave the branch.
The text now says so, and says to confirm the PR is MERGED before forcing.

## Why this is section 10 rather than a follow-up issue

Section 10-d classifies this as `Session-fit: now`: leaving it makes `main`
self-inconsistent, because the skill would keep telling the next run something the
previous run just proved false, and the evidence dies with the session's context.

## Verification

No `src/**` in the diff, so section 8's prose arm applies: the claims are the artifact,
and the one command the new text adds was executed rather than reasoned about (the `-d`
refusal above; the branch was left intact by that refusal, so the probe had no side
effect).

`vp check --fix` rc=0 · `vp run check` rc=0 (0 errors) · `vp run typecheck:test` rc=0 ·
`vp run build` rc=0 · `vp run test` 690 files / 14054 tests rc=0.

One note on the test run: the first full-suite pass had `tests/unit/cli/version.test.ts`
time out at 5s while spawning the built CLI. It passed twice in isolation and the
re-run of the full suite was 690/690 green. It is load-induced (several lanes were
building concurrently) and cannot be caused by a prose-only diff, so the marker was set
against the green run, not the red one.
