### PR TITLE
chore(work-issues): fence the bash-4-ism that bash -n cannot see, and stop mutation probes from testing one use of two

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -109,6 +109,42 @@ Two more design points are decisions, not accidents:
   a drained suite can never be flagged by the detector again, which re-creates
   the grandfathering the ratchet exists to remove.
 
+## Mutation probes: mutate every site the value reaches, not the first one
+
+A probe that flips one use of a value proves that ONE use is pinned. When the
+same value appears in a guard AND in the thing the guard produces, a probe on
+the guard passes while the produced value stays unfenced — and the test looks
+alive, which is worse than an obviously missing one.
+
+Found 2026-08-19 on PR #2010. A banner read `stackUnaddressed` twice: once in
+`} else if (stackUnaddressed > 0)` and once interpolated into the message. The
+probe flipped the GUARD to the run-level total and the test failed, so the case
+was recorded as discriminating. Swapping the INTERPOLATION instead passed all
+18 tests. The fixture could not have caught it: it paired one dirty stack with a
+clean one, and a clean stack never enters the warn arm at all, so nothing is
+printed over it under either version — the `not.toContain('0 resource(s)')`
+assertion was unfalsifiable by construction.
+
+Two rules follow, and the second is the one that is easy to skip:
+
+- **Enumerate the value's uses before probing** (`grep` the identifier in the
+  changed hunk). One probe per use.
+- **A negative assertion needs a case where the wrong value would actually be
+  EMITTED.** "Assert the bad string is absent" is worth nothing if no arm can
+  produce it. Here the fix was two DIRTY stacks with different counts (1 and 2),
+  asserting the total 3 appears in neither banner — now the wrong value has a
+  place to show up.
+
+The same shape hides behind mocks. `recordRunOutcome`'s `result` parameter was
+asserted only in tests that `vi.mock` the module, so they pinned what the caller
+PASSES and never what the store WRITES; hard-coding `'SUCCEEDED'` inside the
+function passed all 2261 unit tests. When a value crosses a module boundary,
+one case must exercise the far side unmocked.
+
+**Do not report a mutation result you did not run.** Every claim in that PR's
+mutation table was executed against a scratch copy of the worktree by the
+reviewer, which is how the false one surfaced.
+
 ## Integration Tests
 
 - `tests/integration/**`

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -980,7 +980,18 @@ the run evidence behind it — or "no skill change" plus what held.
   `git diff main` appears to have removed; rebase instead.
 - **`bash cwd silent reset`** — a persistent Bash cwd can drift back to the main
   tree between calls; use `git -C .claude/worktrees/<branch>` for git ops and
-  re-`cd` before relative-path commands.
+  re-`cd` before relative-path commands. **When it has already happened, the two
+  obvious repairs are both refused**: `git checkout -- <path>` trips
+  `dirty-path-restore-gate` (the stray edit IS uncommitted work, and the gate
+  cannot know you have a copy elsewhere) and writing the file back trips
+  `main-tree-edit-gate`. Re-apply the edit in the worktree with an ABSOLUTE
+  path first, then `git -C <main> stash push -m <label> -- <path>` — that clears
+  the main tree without discarding anything, so neither gate has cause to
+  object. Drop the stash only after confirming `stash@{0}`'s message is yours;
+  parallel lanes stash too, and the indices shift (2026-08-19). Note also that a
+  blocked call runs NOTHING, so a `cat > /tmp/x <<EOF ... && git commit -F /tmp/x`
+  that the gate refuses leaves no file behind either — recreate it, do not
+  assume it is there.
 
 ## Important existing rules this skill leans on
 

--- a/tests/unit/scripts/integ-verify-bash-compat.test.ts
+++ b/tests/unit/scripts/integ-verify-bash-compat.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Integ `verify.sh` scripts must run under the bash a contributor actually has.
+ *
+ * macOS still ships **bash 3.2** as `/bin/bash`, and these scripts are run by
+ * hand far more often than in CI. A bash-4-only expansion does NOT fail a
+ * syntax check -- `bash -n` accepts `${VAR,,}` and only the RUNTIME errors with
+ * `bad substitution` -- so nothing in the existing lint suite or in a reviewer's
+ * `bash -n` pass can see it.
+ *
+ * Found 2026-08-19 in `acm-certificate/verify.sh` (PR #2010): a `${STACK,,}`
+ * inside the EXIT trap's leak sweep. Under 3.2 it would abort the trap's tail
+ * and make the script exit on the substitution error instead of the run's real
+ * status -- a passing integ reported as failed, or a failing one losing its
+ * reason, in the one code path whose whole job is cleaning up after a real-AWS
+ * run. It was the only such expansion in the tree, so nothing else established
+ * a bash-4 floor for these scripts and no contributor had reason to expect one.
+ *
+ * Portable replacements: `$(printf '%s' "$V" | tr '[:upper:]' '[:lower:]')` for
+ * case conversion; a plain indexed array or a `case` for an associative array;
+ * a `while read` loop for `mapfile` / `readarray`.
+ */
+
+const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
+
+interface Bash4ism {
+  /** What to look for. */
+  readonly pattern: RegExp;
+  /** Named in the failure so the fix is obvious without opening bash's manual. */
+  readonly what: string;
+  readonly instead: string;
+}
+
+const BASH4_ISMS: readonly Bash4ism[] = [
+  {
+    // ${V,,} ${V^^} ${V,} ${V^} -- case modification, bash 4.0+.
+    pattern: /\$\{[A-Za-z_][A-Za-z0-9_]*(\[[^\]]*\])?(\^\^?|,,?)\}/,
+    what: 'case-modifying parameter expansion (${VAR,,} / ${VAR^^})',
+    instead: `\$(printf '%s' "\$VAR" | tr '[:upper:]' '[:lower:]')`,
+  },
+  {
+    pattern: /\bdeclare\s+-A\b|\blocal\s+-A\b/,
+    what: 'associative array (declare -A)',
+    instead: 'an indexed array, or a `case` statement',
+  },
+  {
+    pattern: /\b(mapfile|readarray)\b/,
+    what: 'mapfile / readarray',
+    instead: 'a `while IFS= read -r` loop',
+  },
+];
+
+/** Every `tests/integration/<name>/verify.sh`, with its source. */
+function readVerifyScripts(): { name: string; lines: string[] }[] {
+  return readdirSync(INTEG_ROOT, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => ({ name: e.name, path: join(INTEG_ROOT, e.name, 'verify.sh') }))
+    .filter((f) => existsSync(f.path))
+    .map((f) => ({ name: f.name, lines: readFileSync(f.path, 'utf8').split('\n') }));
+}
+
+/**
+ * Comment-stripped scan. A bash-4-ism QUOTED in a comment is exactly what the
+ * fix for one leaves behind ("`tr`, not `${STACK,,}`, because..."), and
+ * flagging that would make the rule un-followable: you could not explain the
+ * trap in the file where it happened.
+ */
+function findIsms(lines: string[]): string[] {
+  const hits: string[] = [];
+  lines.forEach((line, i) => {
+    const code = line.replace(/(^|\s)#.*$/, '');
+    for (const ism of BASH4_ISMS) {
+      if (ism.pattern.test(code)) hits.push(`line ${i + 1}: ${ism.what} -- use ${ism.instead}`);
+    }
+  });
+  return hits;
+}
+
+describe('integ verify.sh scripts stay bash 3.2 compatible', () => {
+  const scripts = readVerifyScripts();
+
+  it('finds the fixture tree', () => {
+    // Guards the whole suite from passing by scanning nothing -- a wrong
+    // INTEG_ROOT would otherwise report every fixture clean.
+    expect(scripts.length).toBeGreaterThan(50);
+  });
+
+  it('detects each bash-4-ism it claims to (positive control)', () => {
+    // The lint must prove it can SEE its input. Without this, a regex that
+    // silently stopped matching would report the tree clean forever.
+    expect(findIsms(['S=Foo', 'echo "${S,,}"'])).toHaveLength(1);
+    expect(findIsms(['echo "${S^^}"'])).toHaveLength(1);
+    expect(findIsms(['declare -A map'])).toHaveLength(1);
+    expect(findIsms(['mapfile -t arr < f'])).toHaveLength(1);
+  });
+
+  it('does not flag a bash-4-ism quoted inside a comment', () => {
+    expect(findIsms(['  # `tr`, not `${STACK,,}`: needs bash >= 4'])).toEqual([]);
+  });
+
+  it('does not flag the portable replacements', () => {
+    expect(
+      findIsms([`  x=$(printf '%s' "\${STACK}" | tr '[:upper:]' '[:lower:]')`])
+    ).toEqual([]);
+    expect(findIsms(['  while IFS= read -r l; do :; done < f'])).toEqual([]);
+  });
+
+  it('no fixture uses a bash-4-only construct', () => {
+    const offenders = scripts
+      .flatMap((s) => findIsms(s.lines).map((h) => `${s.name}/verify.sh ${h}`))
+      .sort();
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Retrospective from the issue (#1960) run — PR (#2010). Three lessons, each with the incident that produced it.

## 1. A lint for bash-4-isms in integ `verify.sh` (new)

`tests/unit/scripts/integ-verify-bash-compat.test.ts`.

macOS still ships **bash 3.2** as `/bin/bash`, and integ scripts are run by hand far more often than in CI. A bash-4-only expansion was invisible to every check we had: **`bash -n` ACCEPTS the case-modifying expansion** — only the runtime says `bad substitution`. So neither the existing `verify.sh` lint suite nor a reviewer's syntax pass could see it.

The instance sat inside an EXIT trap's leak sweep, where under 3.2 it would abort the trap's tail and make the script exit on the substitution error instead of the run's real status — a passing integ reported as failed, or a failing one losing its reason, in the one code path whose whole job is cleaning up after a real-AWS run. It was the **only** such expansion in the tree, so nothing established a bash-4 floor for these scripts and no contributor had reason to expect one.

The lint carries the three things that keep a lint honest:

- a **positive control** — it must prove it can see its input, so a regex that silently stopped matching cannot report the tree clean forever;
- a **comment carve-out** — the fix for one of these leaves it *quoted* in the file where it happened, and flagging that would make the rule un-followable;
- a **fixture-count floor**, so a wrong root cannot pass by scanning nothing.

Break-tested: reintroducing the original expansion fails it with the file, line, and replacement named.

## 2. Mutation probes must cover every use of the value

`.claude/rules/testing.md`.

A probe that flips ONE use proves that one use is pinned. The banner read the per-stack counter in a guard **and** in the message it produces. The probe flipped the guard, the test failed, and the case was recorded as discriminating — while swapping the *interpolation* passed all 18 tests.

Worse, the paired assertion was **unfalsifiable by construction**: it asserted the absence of a wrong count in a run with one dirty stack and one clean one, but a clean stack never enters the warn arm at all, so nothing is printed over it under either version.

The rule states what follows — enumerate the value's uses before probing; a negative assertion needs a case where the wrong value would actually be *emitted* — plus the same shape hiding behind `vi.mock` across a module boundary (hard-coding a return inside the mocked module passed all 2261 unit tests), and that a mutation result must be **run**, not reasoned about.

## 3. Recovering from cwd drift, not just avoiding it

`.claude/skills/work-issues/SKILL.md` gotchas.

The existing entry named the cause. When it actually happens, **both obvious repairs are refused by design**: `dirty-path-restore-gate` blocks the checkout (the stray edit IS uncommitted work, and the gate cannot know a copy exists elsewhere), and `main-tree-edit-gate` blocks writing the file back.

The route that works: re-apply the edit in the worktree with an **absolute** path, then stash the path in the main tree — that clears it while discarding nothing, so neither gate has cause to object. With the caveat to drop only your own stash, since parallel lanes stash too and indices shift.

Also folded in: a blocked Bash call runs **nothing**, so a heredoc chained to a refused command leaves no file behind — recreate it rather than assuming it is there. (This PR hit exactly that while being opened.)

## Test plan

- 694 files / 14144 tests pass.
- New lint break-tested against the real bug (5 cases, incl. positive control and both carve-outs).
- Tooling-only PR, no `src/**` change → live-test exemption applies.
