### PR TITLE
chore(work-issues,run-integ): name the discriminator, read the merge state, and count what the bucket still holds

### DIFF
--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -77,6 +77,27 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
 
 6. **Verify cleanup**:
    - Check `aws s3 ls s3://<bucket>/cdkd/ --region us-east-1` to confirm no leftover state
+   - **The state bucket is VERSIONED** (`cdkd bootstrap` enables it), so that
+     listing shows nothing while every prior version is still readable: `aws s3
+     rm` writes a DELETE MARKER, it does not remove content. For any fixture that
+     WRITES a secret into state — the redaction / scrub / drift fixtures do it
+     deliberately, to simulate a pre-GHSA binary — "the object is gone" is not
+     "the content is gone", and the difference is a disclosure. Check versions,
+     not just the current object:
+     ```bash
+     # Per state/lock key the fixture touched. Non-empty = content still readable.
+     aws s3api list-object-versions --bucket <bucket> --prefix "cdkd/<Stack>/<region>/state.json" \
+       --query "([Versions, DeleteMarkers][])[?Key=='cdkd/<Stack>/<region>/state.json'].VersionId" \
+       --output text
+     ```
+     Two bugs of this shape shipped on 2026-08-19 and BOTH survived a green run:
+     a fixture's version sweep lived only in `cleanup`, which runs from the trap
+     the success path DISARMS (so on the normal path it never ran — one key had
+     accumulated 30 versions), and the sweep itself iterated with `printf '%s' |
+     tr | while read`, which drops the LAST field because there is no trailing
+     newline. Neither is visible from reading the script; both are obvious the
+     moment you COUNT what S3 holds afterwards. If a fixture seeded a secret,
+     grep the surviving versions for it rather than assuming the sweep worked.
    - Also verify actual AWS resources are gone by checking with stack name prefix filters. Get stack names from the synth output, then for each stack name query AWS APIs filtered by that prefix:
      - `aws iam list-roles --query 'Roles[?contains(RoleName, \`{StackName}\`)].RoleName'`
      - `aws lambda list-functions --region us-east-1 --query 'Functions[?contains(FunctionName, \`{StackName}\`)].FunctionName'`

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -454,6 +454,25 @@ over-claimed. Then ask what makes the recurrence mechanical: if the issue says
 a list must stay in sync with the repo, that is a test, not a sentence asking
 the next reader to remember.
 
+**A mutation probe proves a test discriminates only if it changes the value the
+test READS.** Four vacuous tests shipped across three lanes on 2026-08-19, and
+every one had the same shape: the assertion targeted an observable that the
+BROKEN code also produces — a confluence point of the fixed and the broken path,
+not a discriminator. Two "released the allowance" cases asserted a poll count
+that a second `delete()` never reached, so `.at(-1)` re-read the FIRST call's
+value and the test passed with the release deleted. A "canonicalizes case" test
+asserted "the ambient client was reused", which is also what the reject-unsafe
+arm produces, so deleting the canonicalization left it green. A fourth asserted
+`ambient.ssm !== instances.at(-1)` while `ambient.ssm` is a LAZY getter that
+constructs at assertion time — it was measuring its own side effect.
+
+So when you write the probe, name the discriminator first and assert THAT:
+which client was constructed and with what region, which call the stub actually
+received, what the second invocation saw. "The happy path still happens" is
+almost never it. And run the probe: a test added because a reviewer asked, which
+still passes under the mutation that motivated it, converts an open gap into a
+false assurance and is worse than no test.
+
 You may fan out **one subagent per lane** (disjoint files) to run them
 concurrently — give each agent its worktree path, its allowed files, and an
 explicit "do NOT touch <the other lanes' / other agents' files>; STOP and report
@@ -635,6 +654,25 @@ direct AWS API call before doing anything else.
 the `integ-*` markers — together they unblock `gh pr merge`.
 
 ## 9. Ship: merge → pull → release → rebuild → cleanup
+
+**Before you watch CI, read the PR's merge state** — `/verify-pr` step 3 already
+says why, and the failure mode is silent, so it is worth the pointer here: a PR
+at `mergeable=CONFLICTING state=DIRTY` never fires CI at all, and
+`gh pr checks --watch` on one blocks forever reporting "no checks reported". In a
+fan-out run this is the likeliest PR state you will meet, because peer lanes keep
+merging while yours sits open — on 2026-08-19 both remaining lanes went
+CONFLICTING on `docs/changelog-cdkd.md` between `gh pr create` and the first
+check. Rebase, force-push, and CI fires within ~30s.
+
+The changelog conflicts on nearly every parallel-lane rebase, and a
+commit-by-commit rebase re-conflicts on each one. Since the repo squash-merges,
+flattening first is cheaper and loses nothing: `git reset --soft $(git merge-base
+origin/main HEAD)`, one commit, then rebase — at most one conflict to resolve.
+Resolve `docs/changelog-cdkd.md` by keeping BOTH entries, but never reflexively
+keep-both a SHARED paragraph: `.claude/rules/code-layout.md` conflicted on one
+bullet that both sides had edited, where main's version described this lane's own
+issue as still open. A word-level diff of the two sides is what shows whether you
+are looking at two additions or one contested sentence.
 
 ```bash
 gh pr merge <n> --squash --delete-branch     # squash is the repo's only method


### PR DESCRIPTION
## Summary

Retrospective of a four-lane `/work-issues` run — (#1968), (#1955), (#1957) and
(#1932) item 3, all merged as (#1982) / (#2013) / (#2022) / (#2024). Three
edits, each carrying the instances that produced it. A fourth lesson went to
memory instead, because it refines a rule that already lives there.

Nothing here is a "would be nice": every item cost this run something concrete.

## `work-issues` section 5 — name the discriminator

**A mutation probe proves a test discriminates only if it changes the value the
test READS.** Four vacuous tests shipped across three lanes, and every one had
the same shape: the assertion targeted an observable the BROKEN code also
produces — a confluence point of the fixed and broken paths.

- Two "released the allowance" cases asserted a poll count that the second
  `delete()` never reached (the stub left the table gone, so it took the
  already-gone arm), so `.at(-1)` re-read the FIRST call's value and the test
  passed with the release deleted.
- A "canonicalizes case" test asserted "the ambient client was reused" — which
  is also what the reject-unsafe arm produces, so deleting the canonicalization
  left it green.
- A fourth asserted `ambient.ssm !== instances.at(-1)` while `ambient.ssm` is a
  LAZY getter that constructs at assertion time: it was measuring its own side
  effect.

Three of the four were caught by reviewers running the mutation; one was caught
by the lane itself. The rule now says to name the discriminator first, and that
a test added because a reviewer asked which still passes under the motivating
mutation is worse than no test.

## `work-issues` section 9 — read the merge state before watching CI

A pointer rather than a restatement: `/verify-pr` step 3 already says a
CONFLICTING PR never fires CI. I skipped it and watched CI directly, and both
remaining lanes had gone `mergeable=CONFLICTING state=DIRTY` on
`docs/changelog-cdkd.md` between `gh pr create` and the first check — so
`gh pr checks --watch` sat there reporting "no checks reported". In a fan-out
run this is the LIKELY state, because peer lanes keep merging while yours is
open, which is why the pointer belongs at the ship step.

Two conflict-resolution notes earned the same round:

- **Flatten before rebasing.** The repo squash-merges, so a commit-by-commit
  rebase just re-conflicts on the same changelog for each commit. One
  `git reset --soft $(git merge-base ...)` leaves at most one conflict.
- **Do not reflexively keep-both a SHARED paragraph.**
  `.claude/rules/code-layout.md` conflicted on a single bullet both sides had
  edited, where main's version described this lane's own issue as still OPEN.
  Keep-both would have shipped a contradiction; taking one side blindly would
  have dropped main's unrelated edit in the same bullet. A word-level diff is
  what distinguishes two additions from one contested sentence.

## `run-integ` step 6 — the state bucket is VERSIONED

`aws s3 ls` showing nothing does not mean the content is gone: `aws s3 rm`
writes a delete marker. For the fixtures that deliberately seed a secret into
state (redaction / scrub / drift), "the object is gone" versus "the content is
gone" is the difference between a clean teardown and a disclosure.

Two bugs of exactly this shape both survived a GREEN run:

- a fixture's version sweep lived only in `cleanup`, which runs from the trap
  the success path DISARMS — so on the normal path it never ran, and one key had
  accumulated 30 versions;
- the sweep itself iterated with `printf '%s' | tr | while read`, which drops
  the LAST field because there is no trailing newline (seen from outside as
  repeated passes taking a key from 30 to 1 and then stopping).

Neither is visible from reading the script. Both are obvious the moment you
COUNT what S3 holds afterwards, which is why the step now says to.

## The fourth lesson went to memory

`execute-fixture-read-expressions` already says a JMESPath in a `verify.sh` is
untested code. This run adds the dimension that rule was missing: that fixture's
expression WAS executed, against five hand-built responses, and the
flatten-projection bug it was hunting was correctly found — and it shipped
anyway with a second bug that deleted the CURRENT version, because all five
payloads varied WHICH KEYS came back and not one varied `IsLatest`. Executing it
is necessary, not sufficient; the question is which DIMENSION the payloads vary.

## Test plan

- typecheck / lint / format / build — pass. `vp run test` — 700 files /
  14205 tests, no type errors.
- Documentation-only diff (`.claude/skills/**`), so no live test applies. Per
  the repo's own tier rule agent-instruction files are deliberately NOT
  down-biased, so this took the tier the heuristic gives rather than arguing it
  down.

## One thing this PR does not fix

While committing it I hit something worth a separate look: in a freshly created
worktree where `mise trust` had not taken effect, every `markgate set` failed
and **no marker was written — yet `git commit` succeeded**. Reading
`check-gate.sh`, the obvious fail-open theory does not hold, so I filed the
evidence rather than a guess: (#2027). A fresh worktree is the normal state for
this flow, so if a gate stops enforcing there, it is weakest exactly when a lane
is newest.
