### PR TITLE
chore(hooks): allow the qualified owner/repo ref form, and fence the if: field the cd-form bypass lives in

### DIFF
--- a/.claude/hooks/pr-body-item-number-gate.sh
+++ b/.claude/hooks/pr-body-item-number-gate.sh
@@ -107,11 +107,16 @@ find_offender() {
   # 1. Strip URLs that contain /issues/N, /pull/N, /commit/<sha>, or
   #    just any http(s)://... URL — those have no `#N` auto-link.
   local stripped
-  stripped=$(printf '%s' "$line" | perl -pe 's|https?://\S+||g')
+  stripped=$(printf '%s' "$line" | perl -pe 's|https?://\S+| |g')
 
   # 2. Strip backtick-quoted code spans: `...`. The content of code
-  #    spans isn't auto-linked by GitHub.
-  stripped=$(printf '%s' "$stripped" | perl -pe 's|`[^`]*`||g')
+  #    spans isn't auto-linked by GitHub. Replace with a SPACE rather
+  #    than deleting: a deleted span closes the gap between its
+  #    neighbours, so `analyzer/resolver` + `` `.ts` `` + `#2` collapses
+  #    into a slug-adjacent hit that the owner/repo arm below then
+  #    allows -- while GitHub still renders the raw text as a live link
+  #    to an unrelated PR. Same reason for the URL strip above.
+  stripped=$(printf '%s' "$stripped" | perl -pe 's|`[^`]*`| |g')
 
   # 3. Find the first `#N` that is NOT preceded by an allowed context.
   #    We use perl with a single pass that captures `#N` plus a few
@@ -133,15 +138,22 @@ find_offender() {
       #   refs:, ref:, references, see
       next if $left =~ /(?i)(?:^|\s)(refs?:?|references|see)\s*$/;
       # ALLOWED: a fully-qualified cross-repo reference whose left
-      # context ends in an owner/repo slug -- go-to-k/cdkd#1973. It
+      # context ends in an owner/repo slug -- go-to-k/cdkd#1992. It
       # names its repo explicitly, so it cannot auto-link to the wrong
-      # one, which is the exact opposite of the trap this gate exists
-      # for; and /work-issues section 10-c mandates this form for every
+      # REPO. (It can still name the wrong ITEM in the right repo --
+      # `review-fix go-to-k/cdkd#4` is allowed and does render a link --
+      # so this arm narrows the trap rather than eliminating it; and /work-issues section 10-c mandates this form for every
       # citation the mirrored skill files carry, so blocking it put the
       # hook and the skill in direct contradiction.
       # Both slug segments must contain a letter, so an item number
-      # written as a fraction ("step 1/2#3") stays blocked.
-      next if $left =~ m{(?:^|\s)[A-Za-z0-9._-]*[A-Za-z][A-Za-z0-9._-]*/[A-Za-z0-9._-]*[A-Za-z][A-Za-z0-9._-]*$};
+      # written as a fraction ("step 1/2#3") stays blocked. The leading
+      # boundary admits `(` and `[` as well as whitespace: a qualified ref
+      # is very often parenthesised or a markdown link label, and requiring
+      # whitespace rejected `(go-to-k/cdkd#1476)` -- found by writing the
+      # body of the very PR that ships this arm, against the patched hook.
+      # NOTE: no apostrophes in this block -- it sits inside a single-quoted
+      # shell string, so one would terminate the perl program.
+      next if $left =~ m{(?:^|[\s(\[])[A-Za-z0-9._-]*[A-Za-z][A-Za-z0-9._-]*/[A-Za-z0-9._-]*[A-Za-z][A-Za-z0-9._-]*$};
       # Otherwise: BLOCKED. Print the hit and the full line context.
       print "$hit\n";
       last;

--- a/.claude/hooks/pr-body-item-number-gate.sh
+++ b/.claude/hooks/pr-body-item-number-gate.sh
@@ -24,6 +24,9 @@
 #         close[s]? #N, closed #N, fix[es]? #N, resolve[s]? #N
 #       These are load-bearing for GitHub's auto-close behavior.
 #     - Soft references: refs: #N, ref: #N, references #N, see #N
+#     - Fully-qualified cross-repo refs: owner/repo#N. Unambiguous by
+#       construction, and the form /work-issues section 10-c mandates
+#       for every citation in the mirrored skill files.
 #     - Parenthetical: (#N)   — used by squash-merge commit messages
 #       like `feat(...): subject (#231)`.
 #     - Inside fenced code blocks (between matching ``` lines).
@@ -129,6 +132,16 @@ find_offender() {
       # ALLOWED: soft reference keywords.
       #   refs:, ref:, references, see
       next if $left =~ /(?i)(?:^|\s)(refs?:?|references|see)\s*$/;
+      # ALLOWED: a fully-qualified cross-repo reference whose left
+      # context ends in an owner/repo slug -- go-to-k/cdkd#1973. It
+      # names its repo explicitly, so it cannot auto-link to the wrong
+      # one, which is the exact opposite of the trap this gate exists
+      # for; and /work-issues section 10-c mandates this form for every
+      # citation the mirrored skill files carry, so blocking it put the
+      # hook and the skill in direct contradiction.
+      # Both slug segments must contain a letter, so an item number
+      # written as a fraction ("step 1/2#3") stays blocked.
+      next if $left =~ m{(?:^|\s)[A-Za-z0-9._-]*[A-Za-z][A-Za-z0-9._-]*/[A-Za-z0-9._-]*[A-Za-z][A-Za-z0-9._-]*$};
       # Otherwise: BLOCKED. Print the hit and the full line context.
       print "$hit\n";
       last;
@@ -179,6 +192,7 @@ fi
   echo "Fix:"
   echo "  - Item numbers: use bare numbers (e.g. 'Must-fix 1' not 'Must-fix #1')"
   echo "  - Real issue refs: keep 'closes #NNN' / '(#NNN)' / full URLs (allow-listed)"
+  echo "  - Cross-repo refs: use the qualified 'owner/repo#NNN' form (allow-listed)"
   echo
   echo "Memory: ~/.claude/projects/-Users-goto-pc-github-cdkd/memory/feedback_pr_body_no_hash_for_item_numbers.md"
 } >&2

--- a/.claude/hooks/pr-body-item-number-gate.test.sh
+++ b/.claude/hooks/pr-body-item-number-gate.test.sh
@@ -113,6 +113,22 @@ I=$(write_file I.md "# Title
 Use the literal token \`#1\` in your config.
 ")
 
+# J: fully-qualified cross-repo refs, this repo and both siblings
+# (allowed). This is the form /work-issues section 10-c mandates.
+J=$(write_file J.md "# Title
+
+Mirrored from go-to-k/cdk-local#533 and go-to-k/cdk-real-drift#1792.
+Landed here as go-to-k/cdkd#1992.
+")
+
+# K: an item number written as a fraction (blocked). Pins that the
+# owner/repo arm did not widen into the failure the gate exists for --
+# 1/2 has no letter in either segment, so it is not a repo slug.
+K=$(write_file K.md "# Title
+
+step 1/2#3: the second half
+")
+
 # --- ALLOW cases ---
 
 # 1. PR create with bare-number body (A) → exit 0.
@@ -184,6 +200,14 @@ run_case "gh pr create with bare #N in prose blocked" 2 \
   "$(printf '{"tool_input":{"command":"gh pr create --body-file %s"}}' "$H")"
 
 # Extra: gh pr edit --body-file (deprecated form, but still possible) → exit 2.
+# Qualified cross-repo refs (owner/repo#N) are allowed -- go-to-k/cdkd#1992.
+run_case "gh pr create with qualified owner/repo#N allowed" 0 \
+  "$(printf '{"tool_input":{"command":"gh pr create --body-file %s"}}' "$J")"
+
+# ...and the arm did not widen: a fraction-shaped item number stays blocked.
+run_case "gh pr create with fraction-shaped item number still blocked" 2 \
+  "$(printf '{"tool_input":{"command":"gh pr create --body-file %s"}}' "$K")"
+
 run_case "gh pr edit with #N body-file blocked" 2 \
   "$(printf '{"tool_input":{"command":"gh pr edit 123 --body-file %s"}}' "$B")"
 

--- a/.claude/hooks/pr-body-item-number-gate.test.sh
+++ b/.claude/hooks/pr-body-item-number-gate.test.sh
@@ -119,6 +119,8 @@ J=$(write_file J.md "# Title
 
 Mirrored from go-to-k/cdk-local#533 and go-to-k/cdk-real-drift#1792.
 Landed here as go-to-k/cdkd#1992.
+The gate went inert (go-to-k/cdkd#1476) for that reason.
+See [go-to-k/cdk-local#533] for the mirror.
 ")
 
 # K: an item number written as a fraction (blocked). Pins that the
@@ -127,6 +129,18 @@ Landed here as go-to-k/cdkd#1992.
 K=$(write_file K.md "# Title
 
 step 1/2#3: the second half
+")
+
+# L: a code span sitting BETWEEN a slug-shaped token and the hit (blocked).
+# Stripping the span must not close the gap and manufacture an adjacency the
+# raw text never had -- GitHub renders every one of these as a live link.
+# Found by the security review of go-to-k/cdkd#1992.
+L=$(write_file L.md "# Title
+
+Fixed the analyzer/resolver\`.ts\`#2 path.
+Both cdk-local/cdk-real-drift\`(mirrored)\`#3 need it.
+The lambda/vpc\`-deps\`#5 edge.
+Item x/y\`the code\`#7 remains open.
 ")
 
 # --- ALLOW cases ---
@@ -168,6 +182,10 @@ run_case "gh pr create with inline --body not inspected" 0 \
 run_case "gh pr view not gated" 0 \
   '{"tool_input":{"command":"gh pr view 123"}}'
 
+# Qualified cross-repo refs (owner/repo#N) are allowed -- go-to-k/cdkd#1992.
+run_case "gh pr create with qualified owner/repo#N allowed" 0 \
+  "$(printf '{"tool_input":{"command":"gh pr create --body-file %s"}}' "$J")"
+
 # --- BLOCK cases ---
 
 # 2. PR create with #N body (B) → exit 2.
@@ -200,11 +218,11 @@ run_case "gh pr create with bare #N in prose blocked" 2 \
   "$(printf '{"tool_input":{"command":"gh pr create --body-file %s"}}' "$H")"
 
 # Extra: gh pr edit --body-file (deprecated form, but still possible) → exit 2.
-# Qualified cross-repo refs (owner/repo#N) are allowed -- go-to-k/cdkd#1992.
-run_case "gh pr create with qualified owner/repo#N allowed" 0 \
-  "$(printf '{"tool_input":{"command":"gh pr create --body-file %s"}}' "$J")"
-
 # ...and the arm did not widen: a fraction-shaped item number stays blocked.
+# A code span between a slug and the hit must not become an allow gadget.
+run_case "gh pr create with code-span slug gadget still blocked" 2 \
+  "$(printf '{"tool_input":{"command":"gh pr create --body-file %s"}}' "$L")"
+
 run_case "gh pr create with fraction-shaped item number still blocked" 2 \
   "$(printf '{"tool_input":{"command":"gh pr create --body-file %s"}}' "$K")"
 

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -34,29 +34,39 @@ throwaway git repos and take ~6 minutes, which is the wrong cost for the inner
 dev loop. `.github/workflows/hooks.yml` runs it on `macos-latest` (the only
 runner image carrying bash 3.2) whenever a PR touches `.claude/hooks/**`.
 
-# Why the `Bash` matcher stays coarse
+# Why every Bash gate stays unconditional
 
 Every Bash-targeting `PreToolUse` entry in `.claude/settings.json` registers its
-gates under the bare `Bash` matcher, never a command-narrowed `Bash(git commit:*)`
-form. That is load-bearing rather than incidental: the coarse matcher hands every
-Bash call to every gate, and each gate parses the command itself -- which is why
-several of them below can advertise that they also catch the `cd <path> && ...`
-and `gh -C <path>` spellings.
+gates under the coarse `Bash` matcher AND with no per-hook `if:` condition. Both
+halves matter, and the second is the load-bearing one: the coarse matcher hands
+every Bash call to every gate, and the absent `if:` is what lets each gate then
+parse the command itself -- which is why several of them below can advertise that
+they also catch the `cd <path> && ...` and `gh -C <path>` spellings.
 
-Narrowing a matcher would silently reopen a real bypass. In go-to-k/cdk-real-drift
-four gates carried a `Bash(cd * && ...)` alternative while three did not, so
-`cd <wt> && git commit` ran UNGATED and `cd <wt> && gh pr create` skipped both the
-verify-pr and English-only gates (fixed in go-to-k/cdk-real-drift#1788). cdkd was
-audited for the same asymmetry under go-to-k/cdkd#2016 and does not carry it --
-both spellings reach `check-gate` and `verify-pr-gate` alike, measured rc=2 either
-way -- and this matters here because `/work-issues` instructs agents to write
-commands in exactly that `cd <worktree> && ...` form.
+The `if:` fields were removed for the reason documented under "The `if:` layer is
+GONE" below: they silently never fired (go-to-k/cdkd#1455 / go-to-k/cdkd#1476).
+That removal also, incidentally, makes cdkd immune to a SECOND failure of the same
+field. go-to-k/cdkd#2016 asked whether cdkd carries the gate bypass fixed in
+go-to-k/cdk-real-drift#1788, where `cd <wt> && git commit` ran ungated and
+`cd <wt> && gh pr create` skipped two gates. Measured 2026-08-19 against that
+repo's own pre-fix settings (`git show b6a4213^:.claude/settings.json`): its
+matcher is the coarse `"Bash"` too, identical to cdkd's, so the matcher was never
+the differentiator. The asymmetry was between per-hook `if:` conditions --
+`branch-gate` and `bughunt-clean-gate` spelled `Bash(cd * && git commit*)` while
+`check-gate` carried only `Bash(git commit*) or Bash(git -C * commit*)`. cdkd
+carries 0 `if:` fields across 32 Bash hooks, so it has no such condition to be
+asymmetric about, and both spellings reach every gate: measured by feeding them
+to the gates directly, `check-gate` and `verify-pr-gate` answer rc=2 for a bare
+`git commit` / `gh pr create` and rc=2 for the `cd <wt> && ...` twin alike.
 
-An ungated command is indistinguishable from one that passed, so the invariant is
-fenced by a test rather than by this paragraph:
-`tests/unit/scripts/settings-bash-matcher-coverage.test.ts` fails on any
-command-narrowed `Bash(...)` matcher, requires those gates to sit under a coarse
-one, and carries a parser floor so "found nothing" cannot pass as "everything
+This matters more here than it would elsewhere, because `/work-issues` instructs
+agents to write commands in exactly that `cd <worktree> && ...` form. An ungated
+command is indistinguishable from one that passed, so the invariant is fenced by a
+test rather than by this paragraph:
+`tests/unit/scripts/settings-bash-matcher-coverage.test.ts` fails on any per-hook
+`if:` (the primary arm), on any command-narrowed `Bash(...)` matcher, and on the
+removal of `check-gate` / `verify-pr-gate` / `non-english-text-gate` from the
+coarse entry, with a parser floor so "found nothing" cannot pass as "everything
 matches".
 
 # Other PreToolUse safety hooks

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -34,6 +34,31 @@ throwaway git repos and take ~6 minutes, which is the wrong cost for the inner
 dev loop. `.github/workflows/hooks.yml` runs it on `macos-latest` (the only
 runner image carrying bash 3.2) whenever a PR touches `.claude/hooks/**`.
 
+# Why the `Bash` matcher stays coarse
+
+Every Bash-targeting `PreToolUse` entry in `.claude/settings.json` registers its
+gates under the bare `Bash` matcher, never a command-narrowed `Bash(git commit:*)`
+form. That is load-bearing rather than incidental: the coarse matcher hands every
+Bash call to every gate, and each gate parses the command itself -- which is why
+several of them below can advertise that they also catch the `cd <path> && ...`
+and `gh -C <path>` spellings.
+
+Narrowing a matcher would silently reopen a real bypass. In go-to-k/cdk-real-drift
+four gates carried a `Bash(cd * && ...)` alternative while three did not, so
+`cd <wt> && git commit` ran UNGATED and `cd <wt> && gh pr create` skipped both the
+verify-pr and English-only gates (fixed in go-to-k/cdk-real-drift#1788). cdkd was
+audited for the same asymmetry under go-to-k/cdkd#2016 and does not carry it --
+both spellings reach `check-gate` and `verify-pr-gate` alike, measured rc=2 either
+way -- and this matters here because `/work-issues` instructs agents to write
+commands in exactly that `cd <worktree> && ...` form.
+
+An ungated command is indistinguishable from one that passed, so the invariant is
+fenced by a test rather than by this paragraph:
+`tests/unit/scripts/settings-bash-matcher-coverage.test.ts` fails on any
+command-narrowed `Bash(...)` matcher, requires those gates to sit under a coarse
+one, and carries a parser floor so "found nothing" cannot pass as "everything
+matches".
+
 # Other PreToolUse safety hooks
 
 Fourteen additional one-shot hooks block known foot-guns at the source.
@@ -46,7 +71,7 @@ Fourteen additional one-shot hooks block known foot-guns at the source.
 
 - **`.claude/hooks/provider-docs-gate.sh`** blocks `git commit` when staged `src/provisioning/register-providers.ts` introduces a new `registry.register('AWS::Service::Type', ...)` call but the resource type does NOT appear in **both** `docs/supported-resources.md` and `docs/import.md` — closes the docs gap that the v2 drift coverage push (PRs #210-#216) shipped 7 new types without docs entries until a post-merge audit caught it (#219).
 
-- **`.claude/hooks/pr-body-item-number-gate.sh`** blocks `gh pr create` / `gh pr edit` / `gh issue create` / `gh issue comment` / `gh api -X PATCH .../pulls|issues/...` invocations whose body file (`--body-file <FILE>` or `--field body=@<FILE>` / `-F body=@<FILE>`) contains `#N` patterns that GitHub auto-links to issue/PR `#N` — the "review-fix #4 → linked to unrelated PR #4" trap that hit PR #237. Allow-listed contexts (`closes #N` / `(#N)` / fenced code blocks / GitHub URLs / backtick code spans) pass through; bare `Must-fix #N` / `review-fix #N` / `step #N` / plain `#N` in prose are blocked with line-numbered offender output. Smoke test at `.claude/hooks/pr-body-item-number-gate.test.sh`.
+- **`.claude/hooks/pr-body-item-number-gate.sh`** blocks `gh pr create` / `gh pr edit` / `gh issue create` / `gh issue comment` / `gh api -X PATCH .../pulls|issues/...` invocations whose body file (`--body-file <FILE>` or `--field body=@<FILE>` / `-F body=@<FILE>`) contains `#N` patterns that GitHub auto-links to issue/PR `#N` — the "review-fix #4 → linked to unrelated PR #4" trap that hit PR #237. Allow-listed contexts (`closes #N` / `(#N)` / fenced code blocks / GitHub URLs / backtick code spans / the fully-qualified cross-repo form `owner/repo#N`) pass through; bare `Must-fix #N` / `review-fix #N` / `step #N` / plain `#N` in prose are blocked with line-numbered offender output. The `owner/repo#N` arm was added for go-to-k/cdkd#1992: that form names its repo explicitly so it cannot auto-link to the wrong one, and `/work-issues` section 10-c mandates it for every citation the mirrored skill files carry, so blocking it put the hook and the skill in direct contradiction. Both slug segments must contain a letter, so a fraction-shaped item number (`step 1/2#3`) stays blocked. Smoke test at `.claude/hooks/pr-body-item-number-gate.test.sh`.
 
 - **`.claude/hooks/internal-pr-labels-gate.sh`** is the complementary check for prose-style internal dev labels in user-facing source code — it blocks `git commit` when staged `README.md` or `docs/*.md` files contain `(PR 8b)` / `(PR 6 of #224)` / `(PR 6 of #224, issue #232)` patterns in added/modified diff lines. Closes the gap that PR #251 had to clean up after — agent dispatch prompts use "PR 8b" / "PR 6 of #224" internally and that prose can leak into user-facing doc bodies. `CLAUDE.md` (developer-facing) and `tests/integration/**/README.md` (integ fixture metadata) are excluded; fenced code blocks and backtick code spans are allow-listed. Smoke test at `.claude/hooks/internal-pr-labels-gate.test.sh`.
 

--- a/tests/unit/scripts/settings-bash-matcher-coverage.test.ts
+++ b/tests/unit/scripts/settings-bash-matcher-coverage.test.ts
@@ -4,40 +4,47 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 /**
- * Fences the shape that keeps cdkd's PreToolUse gates immune to the
- * `cd <worktree> && <command>` bypass.
+ * Fences the shape that keeps cdkd's PreToolUse gates reachable for EVERY
+ * spelling of a gated command, including the `cd <worktree> && ...` form a lane
+ * driving commands at its own worktree naturally writes.
  *
- * The bypass is real, and it was measured in a sibling repo. In
- * go-to-k/cdk-real-drift, PreToolUse entries matched narrowed command forms
- * (`Bash(git commit:*)`), and four gates carried a `Bash(cd * && ...)`
- * alternative while three did not -- so `cd <wt> && git commit` ran UNGATED
- * and `cd <wt> && gh pr create` skipped both the verify-pr and English-only
- * gates. That was fixed there in go-to-k/cdk-real-drift#1788, and
- * go-to-k/cdkd#2016 asked whether cdkd carries the same asymmetry, since the
- * hooks were ported between the repos and `/work-issues` now instructs agents
- * to write commands in exactly that `cd <worktree> && ...` form.
+ * The load-bearing field is `if:`, not `matcher:` -- and that correction is the
+ * whole reason this file says what it says. go-to-k/cdkd#2016 asked whether cdkd
+ * carries the gate BYPASS fixed in go-to-k/cdk-real-drift#1788, and described it
+ * as an asymmetry between gates. The first pass of this test attributed the
+ * sibling's immunity gap to narrowed `Bash(...)` MATCHERS and fenced that.
+ * Measured 2026-08-19 against the sibling's own pre-fix settings
+ * (`git show b6a4213^:.claude/settings.json` in cdk-real-drift), that was wrong:
+ * its matcher is the coarse `"Bash"`, identical to cdkd's. The `cd * && ...`
+ * alternatives lived in each hook's per-hook `if:` condition, and the asymmetry
+ * was between hooks that spelled the `cd` twin there and hooks that did not --
+ * `branch-gate` and `bughunt-clean-gate` carried `Bash(cd * && git commit*)`
+ * while `check-gate` carried only `Bash(git commit*) or Bash(git -C * commit*)`.
  *
- * cdkd does NOT carry it, and the reason is structural rather than lucky: its
- * Bash-targeting PreToolUse entries use the COARSE `Bash` matcher, so every
- * Bash call reaches every gate and each gate parses the command itself.
- * Measured 2026-08-19 by feeding both spellings to the gates directly:
+ * cdkd is immune for a different reason than "coarse matchers": it carries ZERO
+ * `if:` fields (0 of 32, measured the same day). They were removed under
+ * go-to-k/cdkd#1455 / go-to-k/cdkd#1476 after being measured to never fire at
+ * all from project settings -- so every gate in the Bash entry runs on every
+ * Bash call and parses the command itself, which is why several of them can
+ * advertise that they also catch the `cd <path> && ...` and `gh -C <path>`
+ * spellings.
  *
- *   check-gate.sh     bare `git commit -m ...`               -> rc=2
- *   check-gate.sh     `cd <wt> && git commit -m ...`         -> rc=2
- *   verify-pr-gate.sh bare `gh pr create ...`                -> rc=2
- *   verify-pr-gate.sh `cd <wt> && gh pr create ...`          -> rc=2
- *
- * The danger is therefore not a bug to fix but a regression to prevent:
- * narrowing any of these matchers to a command-specific form would silently
- * reopen the bypass, and an ungated command is indistinguishable from one that
- * passed. Hence a test rather than a comment.
+ * `.claude/rules/hooks.md` already says "Do NOT reintroduce `if:`". That is a
+ * sentence, and per the repo's own rule a sentence that can be violated silently
+ * should be a test: re-adding an `if:` would BOTH make those gates inert again
+ * (the go-to-k/cdkd#1476 defect) and reopen the sibling's `cd`-form bypass, and
+ * an ungated command is indistinguishable from one that passed.
  */
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const SETTINGS = join(repoRoot, '.claude', 'settings.json');
 
+interface HookSpec {
+  command?: string;
+  if?: unknown;
+}
 interface HookEntry {
   matcher?: string;
-  hooks?: { command?: string }[];
+  hooks?: HookSpec[];
 }
 
 function preToolUseEntries(): HookEntry[] {
@@ -62,28 +69,67 @@ function bashEntries(entries: HookEntry[]): HookEntry[] {
   );
 }
 
-describe('.claude/settings.json PreToolUse Bash matchers', () => {
-  it('parses the file and finds Bash-targeting entries (floor)', () => {
+function gateName(spec: HookSpec): string | undefined {
+  return /([a-z0-9-]+)\.sh/.exec(spec.command ?? '')?.[1];
+}
+
+describe('.claude/settings.json PreToolUse gate reachability', () => {
+  it('parses the file and finds the Bash-targeting gates (floor)', () => {
     // Floor for every assertion below. Without it a renamed key or a changed
     // file shape would make this suite pass by asserting over an empty list --
-    // the "a lint must prove it sees its input" trap.
+    // the "a lint must prove it sees its input" trap. These are FLOORS with
+    // headroom, not pins on today's exact numbers: entries are routinely added.
     const entries = preToolUseEntries();
-    expect(entries.length).toBeGreaterThanOrEqual(3);
+    expect(entries.length).toBeGreaterThanOrEqual(1);
 
     const bash = bashEntries(entries);
-    expect(bash.length).toBeGreaterThanOrEqual(2);
+    expect(bash.length).toBeGreaterThanOrEqual(1);
 
     const gateCount = bash.reduce((n, e) => n + (e.hooks?.length ?? 0), 0);
-    // 31 gates registered against Bash as of 2026-08-19. A floor, not a pin:
-    // adding gates is routine, losing most of them is the regression.
+    // 32 gates registered against Bash as of 2026-08-19.
     expect(gateCount).toBeGreaterThanOrEqual(20);
   });
 
+  it('never reintroduces a per-hook `if:` condition', () => {
+    // THE primary assertion. An `if:` in project settings was measured to make
+    // its hook never fire at all (go-to-k/cdkd#1476), and it is also where the
+    // sibling repo's `cd <wt> && ...` bypass lived (a gate whose `if:` spelled
+    // the bare command form but not its `cd` twin ran ungated for that form).
+    const offenders: string[] = [];
+    for (const entry of preToolUseEntries()) {
+      for (const spec of entry.hooks ?? []) {
+        if ('if' in spec) offenders.push(`${gateName(spec) ?? spec.command} -> ${String(spec.if)}`);
+      }
+    }
+
+    expect(
+      offenders,
+      offenders.length === 0
+        ? ''
+        : [
+            'A PreToolUse hook carries an `if:` condition:',
+            ...offenders.map((o) => `  ${o}`),
+            '',
+            'Two separate failures follow, both silent:',
+            '  1. Project-settings hooks carrying `if:` were measured never to fire',
+            '     at all (go-to-k/cdkd#1455 / go-to-k/cdkd#1476) -- the gate goes',
+            '     inert while still looking registered.',
+            '  2. An `if:` enumerating command forms is exactly where the sibling',
+            '     bypass lived (go-to-k/cdk-real-drift#1788): a condition naming',
+            '     `Bash(git commit*)` but not `Bash(cd * && git commit*)` lets the',
+            '     `cd`-prefixed spelling -- the form a lane driving commands at',
+            '     its own worktree naturally writes -- run UNGATED.',
+            '',
+            'See the "The `if:` layer is GONE" section of .claude/rules/hooks.md.',
+          ].join('\n'),
+    ).toEqual([]);
+  });
+
   it('never narrows a Bash matcher to a command-specific form', () => {
-    // This is the whole point. `Bash` reaches every gate for every command,
-    // including the `cd <worktree> && ...` form. `Bash(git commit:*)` does
-    // not, and its `cd` twin has to be spelled out separately -- which is the
-    // asymmetry that produced a live, silent gate bypass in the sibling repo.
+    // Secondary, defence in depth. cdkd has never had a narrowed matcher and the
+    // sibling's bypass did not come from one -- but a narrowed `Bash(git commit:*)`
+    // would reopen the same hole by a second route, since its `cd` twin would then
+    // have to be spelled out separately too.
     const narrowed: string[] = [];
     for (const entry of bashEntries(preToolUseEntries())) {
       for (const alt of alternatives(entry.matcher ?? '')) {
@@ -99,29 +145,23 @@ describe('.claude/settings.json PreToolUse Bash matchers', () => {
             'A PreToolUse matcher was narrowed to a command-specific Bash form:',
             ...narrowed.map((n) => `  ${n}`),
             '',
-            'That reopens the `cd <worktree> && <command>` bypass fixed in',
-            'go-to-k/cdk-real-drift#1788: the narrowed form matches only the bare',
-            'spelling, so the same command written with a `cd` prefix -- the form',
-            '/work-issues section 9 tells agents to use -- runs UNGATED, and an',
-            'ungated command is indistinguishable from one that passed.',
-            '',
-            'Either keep the coarse `Bash` matcher, or add a `Bash(cd * && ...)`',
-            'twin for every narrowed form and update this test to check the pairing.',
+            'Keep the coarse `Bash` matcher: it hands every Bash call to every gate,',
+            'so each gate parses the command itself and sees every spelling.',
           ].join('\n'),
     ).toEqual([]);
   });
 
   it('registers the gates that must see both command spellings', () => {
-    // These three are the ones go-to-k/cdkd#2016 named as lacking a `cd` twin
-    // in the sibling repo. Here they must be registered under a coarse `Bash`
-    // matcher, which is what makes both spellings reach them.
+    // Catches gate REMOVAL, which neither assertion above would notice.
+    // These three are the ones go-to-k/cdkd#2016 named as lacking a `cd` twin in
+    // the sibling repo.
     const mustBeCoarse = ['check-gate', 'verify-pr-gate', 'non-english-text-gate'];
 
     const coarseGates = new Set<string>();
     for (const entry of preToolUseEntries()) {
       if (!alternatives(entry.matcher ?? '').includes('Bash')) continue;
-      for (const hook of entry.hooks ?? []) {
-        const name = /([a-z0-9-]+)\.sh/.exec(hook.command ?? '')?.[1];
+      for (const spec of entry.hooks ?? []) {
+        const name = gateName(spec);
         if (name) coarseGates.add(name);
       }
     }

--- a/tests/unit/scripts/settings-bash-matcher-coverage.test.ts
+++ b/tests/unit/scripts/settings-bash-matcher-coverage.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+/**
+ * Fences the shape that keeps cdkd's PreToolUse gates immune to the
+ * `cd <worktree> && <command>` bypass.
+ *
+ * The bypass is real, and it was measured in a sibling repo. In
+ * go-to-k/cdk-real-drift, PreToolUse entries matched narrowed command forms
+ * (`Bash(git commit:*)`), and four gates carried a `Bash(cd * && ...)`
+ * alternative while three did not -- so `cd <wt> && git commit` ran UNGATED
+ * and `cd <wt> && gh pr create` skipped both the verify-pr and English-only
+ * gates. That was fixed there in go-to-k/cdk-real-drift#1788, and
+ * go-to-k/cdkd#2016 asked whether cdkd carries the same asymmetry, since the
+ * hooks were ported between the repos and `/work-issues` now instructs agents
+ * to write commands in exactly that `cd <worktree> && ...` form.
+ *
+ * cdkd does NOT carry it, and the reason is structural rather than lucky: its
+ * Bash-targeting PreToolUse entries use the COARSE `Bash` matcher, so every
+ * Bash call reaches every gate and each gate parses the command itself.
+ * Measured 2026-08-19 by feeding both spellings to the gates directly:
+ *
+ *   check-gate.sh     bare `git commit -m ...`               -> rc=2
+ *   check-gate.sh     `cd <wt> && git commit -m ...`         -> rc=2
+ *   verify-pr-gate.sh bare `gh pr create ...`                -> rc=2
+ *   verify-pr-gate.sh `cd <wt> && gh pr create ...`          -> rc=2
+ *
+ * The danger is therefore not a bug to fix but a regression to prevent:
+ * narrowing any of these matchers to a command-specific form would silently
+ * reopen the bypass, and an ungated command is indistinguishable from one that
+ * passed. Hence a test rather than a comment.
+ */
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const SETTINGS = join(repoRoot, '.claude', 'settings.json');
+
+interface HookEntry {
+  matcher?: string;
+  hooks?: { command?: string }[];
+}
+
+function preToolUseEntries(): HookEntry[] {
+  const raw = JSON.parse(readFileSync(SETTINGS, 'utf8')) as {
+    hooks?: { PreToolUse?: HookEntry[] };
+  };
+  return raw.hooks?.PreToolUse ?? [];
+}
+
+/** Alternatives of a `A|B|C` matcher, trimmed. */
+function alternatives(matcher: string): string[] {
+  return matcher
+    .split('|')
+    .map((a) => a.trim())
+    .filter(Boolean);
+}
+
+/** Entries whose matcher targets the Bash tool at all. */
+function bashEntries(entries: HookEntry[]): HookEntry[] {
+  return entries.filter((e) =>
+    alternatives(e.matcher ?? '').some((a) => a === 'Bash' || a.startsWith('Bash(')),
+  );
+}
+
+describe('.claude/settings.json PreToolUse Bash matchers', () => {
+  it('parses the file and finds Bash-targeting entries (floor)', () => {
+    // Floor for every assertion below. Without it a renamed key or a changed
+    // file shape would make this suite pass by asserting over an empty list --
+    // the "a lint must prove it sees its input" trap.
+    const entries = preToolUseEntries();
+    expect(entries.length).toBeGreaterThanOrEqual(3);
+
+    const bash = bashEntries(entries);
+    expect(bash.length).toBeGreaterThanOrEqual(2);
+
+    const gateCount = bash.reduce((n, e) => n + (e.hooks?.length ?? 0), 0);
+    // 31 gates registered against Bash as of 2026-08-19. A floor, not a pin:
+    // adding gates is routine, losing most of them is the regression.
+    expect(gateCount).toBeGreaterThanOrEqual(20);
+  });
+
+  it('never narrows a Bash matcher to a command-specific form', () => {
+    // This is the whole point. `Bash` reaches every gate for every command,
+    // including the `cd <worktree> && ...` form. `Bash(git commit:*)` does
+    // not, and its `cd` twin has to be spelled out separately -- which is the
+    // asymmetry that produced a live, silent gate bypass in the sibling repo.
+    const narrowed: string[] = [];
+    for (const entry of bashEntries(preToolUseEntries())) {
+      for (const alt of alternatives(entry.matcher ?? '')) {
+        if (alt.startsWith('Bash(')) narrowed.push(alt);
+      }
+    }
+
+    expect(
+      narrowed,
+      narrowed.length === 0
+        ? ''
+        : [
+            'A PreToolUse matcher was narrowed to a command-specific Bash form:',
+            ...narrowed.map((n) => `  ${n}`),
+            '',
+            'That reopens the `cd <worktree> && <command>` bypass fixed in',
+            'go-to-k/cdk-real-drift#1788: the narrowed form matches only the bare',
+            'spelling, so the same command written with a `cd` prefix -- the form',
+            '/work-issues section 9 tells agents to use -- runs UNGATED, and an',
+            'ungated command is indistinguishable from one that passed.',
+            '',
+            'Either keep the coarse `Bash` matcher, or add a `Bash(cd * && ...)`',
+            'twin for every narrowed form and update this test to check the pairing.',
+          ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('registers the gates that must see both command spellings', () => {
+    // These three are the ones go-to-k/cdkd#2016 named as lacking a `cd` twin
+    // in the sibling repo. Here they must be registered under a coarse `Bash`
+    // matcher, which is what makes both spellings reach them.
+    const mustBeCoarse = ['check-gate', 'verify-pr-gate', 'non-english-text-gate'];
+
+    const coarseGates = new Set<string>();
+    for (const entry of preToolUseEntries()) {
+      if (!alternatives(entry.matcher ?? '').includes('Bash')) continue;
+      for (const hook of entry.hooks ?? []) {
+        const name = /([a-z0-9-]+)\.sh/.exec(hook.command ?? '')?.[1];
+        if (name) coarseGates.add(name);
+      }
+    }
+
+    for (const gate of mustBeCoarse) {
+      expect(coarseGates, `${gate} must be registered under a coarse Bash matcher`).toContain(
+        gate,
+      );
+    }
+  });
+});


### PR DESCRIPTION
Closes https://github.com/go-to-k/cdkd/issues/1992

Part of a cross-repo batch run taking every open `work-issues`-skill item across
cdkd / cdk-local / cdk-real-drift in one session, at the maintainer's instruction.
This is the hooks lane; the prose lane is a separate PR.

## 1. Allow the fully-qualified cross-repo ref form

`pr-body-item-number-gate` blocked the one reference form that cannot bind to the
wrong repo, and the one `/work-issues` section 10-c mandates for every citation
the mirrored skill files carry. The hook and the skill contradicted each other.

Reproduced on the unpatched hook before touching it:

```text
Blocked by pr-body-item-number-gate:
  q.md:1: Mirrored from go-to-k/cdk-local#533 and go-to-k/cdk-real-drift#1792.
exit=2
```

One allow arm beside the existing three: a hit whose left context ends in an
`owner/repo` slug passes. Both segments must contain a letter, so a fraction-shaped
item number stays blocked — the issue's own proposed pattern would have admitted it.

## 2. A regression the security review caught

The first version of the arm was exploitable, found by running candidates through
**GitHub's own markdown renderer** rather than reasoning about autolink rules.

`find_offender` stripped code spans by DELETING them. A deletion closes the gap
between the span's neighbours, so a repo-slug never adjacent to the hit in the raw
text becomes adjacent after stripping — the arm then allowed it, while GitHub still
rendered the raw text as a live link to an unrelated PR. That is the trap this gate
exists for, and it was a regression: all four probes are blocked on `origin/main`
and were allowed here.

```text
body text                                        before -> after   GitHub renders
Fixed the analyzer/resolver`.ts`#2 path.         rc=0   -> rc=2    link to /pull/2
Both cdk-local/cdk-real-drift`(mirrored)`#3 ...  rc=0   -> rc=2    link to /pull/3
The lambda/vpc`-deps`#5 edge.                    rc=0   -> rc=2    link to /pull/5
Item x/y`the code`#7 remains open.               rc=0   -> rc=2    link to /pull/7
```

Fix: neutralize both the URL strip and the code-span strip to a SPACE instead of
deleting — the placeholder rule `.claude/rules/hooks.md` already records elsewhere.
All four are now a regression fixture, verified individually rather than as one
block so an early offender cannot mask the rest.

The review also corrected the arm's justification: a qualified ref cannot auto-link
to the wrong **repo**, but it can still name the wrong ITEM in the right one. The
comment says that now rather than overclaiming.

## 3. A second gap, found by dogfooding

Writing this PR body against the patched hook surfaced a false negative the tests
had not covered: the arm required whitespace-or-start before the slug, so a
**parenthesised** qualified ref was rejected — and that is the commonest way one
appears in prose. Bracketed link labels failed the same way. The boundary now admits
`(` and `[`. Both forms are in the fixture, and narrowing the boundary back to
whitespace-only fails the suite (19/1, rc=1).

### Verification

```text
suite before any change ........... Pass: 17  Fail: 0
suite after ....................... Pass: 20  Fail: 0
new arm deleted ................... rc=1, Pass: 19  Fail: 1  (only the qualified case)
letter requirement dropped ........ rc=1  (only the fraction case)
boundary narrowed to whitespace ... rc=1, Pass: 19  Fail: 1  (only the qualified case)
```

Every failure direction was driven, not assumed. Full hooks suite
(`run-tests.sh`, the `hooks.yml` job) green — 66 suite runs, 0 failures, under both
bash 5 and `/bin/bash` 3.2.

## 4. The gate cd-form audit asked for by https://github.com/go-to-k/cdkd/issues/2016

That issue asks whether cdkd carries the bypass fixed in
https://github.com/go-to-k/cdk-real-drift/pull/1788, where a `cd <wt> &&`-prefixed
command ran ungated. It matters because that issue's lesson 2 tells agents to write
commands in exactly that form, so landing the lesson over a live bypass would teach
the bypass.

**Audited: cdkd does not carry it — but this PR's first version got the REASON
wrong**, and the code review caught that. I had claimed immunity from coarse
matchers. Measured against the sibling's own pre-fix settings
(`git show b6a4213^:.claude/settings.json` in cdk-real-drift), that is false: its
matcher is the coarse `"Bash"` as well, identical to cdkd's.

The asymmetry lived in each hook's per-hook **`if:`** condition:

```text
check-gate          if: Bash(git commit*) or Bash(git -C * commit*)     <- no cd twin
branch-gate         if: ... or Bash(cd * && git commit*)                <- has one
bughunt-clean-gate  if: ... or Bash(cd * && git commit*)                <- has one
```

cdkd is immune because it carries **0 `if:` fields across 33 Bash hooks**, removed
earlier after being measured never to fire from project settings. Confirmed
behaviourally by feeding both spellings to the gates directly:

```text
gate                       bare form   cd <wt> && form
check-gate.sh              rc=2        rc=2
verify-pr-gate.sh          rc=2        rc=2
non-english-text-gate.sh   rc=0        rc=0
branch-gate.sh             rc=0        rc=0
```

(The rc=0 rows are symmetric non-hits — the probe worktree is on a feature branch
and the body file did not exist — not passes through a hole.)

So `settings.json` is unchanged: there was nothing to fix. What lands is a fence on
the field that actually matters.
`tests/unit/scripts/settings-bash-matcher-coverage.test.ts` fails on any per-hook
`if:` (primary), on a command-narrowed matcher (defence in depth), and on removal of
the three named gates, with a parser floor.

`.claude/rules/hooks.md` already said "Do NOT reintroduce `if:`" — a sentence with no
test behind it. It is now a test, covering both failures that field produces: the
gate going inert, and the cd-form bypass.

```text
mutation                                    result
re-add if: to check-gate (the real shape)   fails ONLY the if: assertion
remove the check-gate registration          fails ONLY the registration assertion
narrow a matcher to a command form          fails the matcher assertion
restored                                    4/4 pass
```

This closes only the audit half of that issue; its three prose lessons land in the
SKILL.md lane of the same batch, which is why this PR does not close it.

## Gates

`vp check --fix` 0 errors · `vp run check` rc=0 · `typecheck:test` clean · build ok ·
`vp run test` **702 files / 14261 tests passed**, no type errors · `gen:all-matrices`
regenerated nothing · `audit:coverage:check` clean · hooks suite green.

Rebased over the merge of PR 2019, which also touched `.claude/rules/hooks.md`; the
same-file marker check confirms both sides survived (their marker and mine each
grep 1 in the rebased file).

## Note on this body's own reference style

Cross-repo references here are full URLs rather than the compact qualified form this
PR allows, because hooks resolve from the invoking worktree and the exploit examples
above must stay quoted as data. That friction is what
https://github.com/go-to-k/cdkd/issues/1992 reports.
