### PR TITLE
chore(hooks,skills): stop advising a restore that destroys another session's work

### DIFF
--- a/.claude/hooks/main-tree-dirty-detector.sh
+++ b/.claude/hooks/main-tree-dirty-detector.sh
@@ -69,7 +69,9 @@ extra=$(printf '%s\n' "$dirty" | wc -l | tr -d ' ')
 msg="WARNING (main-tree-dirty-detector): the MAIN worktree ($main_tree) is on \`$branch\` and now has uncommitted changes to $extra tracked file(s): $files. "
 msg+="This is the gap the PreToolUse main-tree-edit-gate cannot catch (variable-indirected Bash writes like \`mv \\\"\$tmp\\\" \\\"\$LEDGER\\\"\`). "
 msg+="Tracked files must NOT be edited in the main tree on \`$branch\` — uncommitted edits there block \`git pull --ff-only\` and are a shared-resource hazard for parallel agents. "
-msg+="Fix NOW: move the change into a feature worktree (git worktree add .claude/worktrees/<b> -b <b> origin/main), copy the edited file(s) over, then \`git -C $main_tree checkout -- <file>\` to restore the main tree. For /run-integ specifically, point the ledger write at the worktree copy of docs/_generated/integ-last-run.tsv."
+msg+="FIRST establish whose edit this is: parallel agents share this tree, and restoring someone else's in-flight work destroys it irreversibly. "
+msg+="Run \`git -C $main_tree diff -- <file>\` and \`git -C $main_tree log -S<distinctive-string> --oneline\`; if the content references an issue, branch or feature you are not working on, it is NOT yours — leave it alone and tell the maintainer. "
+msg+="If it IS yours: move the change into a feature worktree (git worktree add .claude/worktrees/<b> -b <b> origin/main), copy the edited file(s) over, then \`git -C $main_tree checkout -- <file>\` to restore the main tree. For /run-integ specifically, point the ledger write at the worktree copy of docs/_generated/integ-last-run.tsv."
 
 # Emit non-blocking additionalContext (jq -Rs to JSON-encode safely).
 ctx=$(printf '%s' "$msg" | jq -Rs .)

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -384,5 +384,19 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
 - Always use `--region us-east-1` for integration tests
 - Always destroy after deploy to avoid leftover resources
 - If deploy fails, still attempt destroy to clean up partial state
+- **A run blocked BEFORE its assertions is not a test failure — say which it was.**
+  `cdkd gc` refuses while ANY stack in the state bucket holds a lock (an
+  account-wide guard, deliberate and documented at its site), so on an account
+  with parallel agent sessions a gc fixture can be stopped before it reaches a
+  single gc assertion. That happened twice in a row on 2026-08-19, from two
+  different foreign stacks in a different region than the one under test. Both
+  are recorded as `FAIL` rows because the bar is exit-code-based, and both notes
+  say plainly that the fix was not at fault.
+  When a run dies before its assertions, do all three: clean up as usual (an
+  aborted run still leaks — one of these left a state file, a Lambda and an IAM
+  role behind), write the ledger note so it names the blocker rather than
+  implying the change is broken, and WAIT for the blocker to clear rather than
+  forcing past it. Never `cdkd force-unlock` a lock you did not take: it belongs
+  to another session's in-flight deploy.
 - **Never report success based on a successful deploy alone** — destroy must complete and orphan check must pass
 - **Never bypass this skill** by calling `cdkd deploy` / `cdkd destroy` directly from a shell — the orphan-cleanup contract above is part of the integration test, not optional

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -507,6 +507,31 @@ if the fix needs a forbidden file" guardrail. Note: a subagent's Bash **bypasses
 the PreToolUse gate hooks**, so it can `gh pr create` past `verify-pr-gate` —
 enforce quality yourself; you (the orchestrator) still gate the MERGE.
 
+**Three guardrails every lane prompt must carry, all learned the hard way on
+2026-08-19:**
+
+- **Never force-push over a commit you did not author.** A lane agent resumed
+  with edits predating four commits the orchestrator had landed on its branch,
+  and force-pushed. Nothing was lost that time only because the rebase preserved
+  them — the same agent later caught the second occurrence itself, by noticing an
+  unfamiliar string in a file it thought it owned and running `git log -S`. Say
+  in the prompt: re-`git fetch` and inspect the branch before any force-push, and
+  if the branch carries work you did not write, STOP and report.
+- **A new fixture literal must not collide with an existing assertion needle.**
+  A `DB_URL` added to the secrets fixture hard-coded `cdkd-user` as its URL user
+  component — which is exactly `EXPECTED_USERNAME`, the needle grepped over the
+  whole persisted env to prove a whole-secret resolution did not land there. The
+  run reported a secret LEAK that had not happened. A false leak report is worse
+  than a missing assertion: it is indistinguishable from the real thing, and the
+  natural response is to go hunting in the redaction code.
+- **Execute every read expression you write.** Two integ runs were lost to
+  fixture code, not product defects: the literal collision above, and a `jq`
+  assignment written through `to_entries[]`, which builds a new array and is not
+  a path back into the document. The same file already had the correct shape one
+  phase away. jq / JMESPath / AWS CLI `--query` are untested code; run each
+  against real output shape before finishing, in both directions where the
+  expression carries a guard.
+
 ## 6. Gates + PR (per lane)
 
 From inside the worktree, run the local quality checks and record the markers:


### PR DESCRIPTION
## Summary

Retrospective from a `/work-issues` run that shipped (#2014) and (#2025). Three
lessons, each folded into the step where it fires rather than appended to a tail
section.

## 1. A hook told the reader to destroy another session's work

`main-tree-dirty-detector` fires when the shared main worktree goes dirty, and
its remedy was: move the change into a feature worktree, then restore the main
tree. That silently assumes the edit is the reader's own.

During this run it fired on a **foreign** session's in-flight work — the content
referenced an issue this session was not working on. Following the remedy
verbatim would have discarded it irreversibly, since a restore writes no reflog
entry and creates no stash. This is the same class as the 2026-08-09 incident
the multi-session guards exist for, arriving through the one place that tells
you what to do about it.

The hook now establishes ownership FIRST, names the two commands that settle it
(`git diff` on the path, `git log -S` on a distinctive string), and says to
leave a foreign edit alone and tell the maintainer.

## 2. `/run-integ` had nothing to say about a run that dies before its assertions

`cdkd gc` refuses while ANY stack in the state bucket holds a lock — an
account-wide guard, deliberate and documented at its site. On an account with
parallel agent sessions that means a gc fixture can be stopped before it reaches
a single gc assertion. It happened twice consecutively here, from two different
foreign stacks in a different region than the one under test.

Both are recorded `FAIL` in the ledger, because the bar is exit-code-based and
should stay that way. What was missing was the instruction to say so: to write
the note so it names the blocker rather than implying the change is broken, to
clean up anyway (one aborted run left a state file, a Lambda and an IAM role
behind), and never to `force-unlock` a lock belonging to someone else's deploy.

## 3. Three lane-prompt guardrails, each from a real loss

- **A lane agent force-pushed over commits it had not authored.** Nothing was
  lost only because the rebase preserved them. The same agent caught the second
  occurrence itself — by noticing an unfamiliar string in a file it thought it
  owned and running `git log -S` — which is the behaviour the guardrail asks for.
- **A new fixture literal collided with an assertion needle.** A `DB_URL` added
  to the secrets fixture hard-coded the same string as `EXPECTED_USERNAME`, the
  needle grepped over the whole persisted env, so the run reported a secret LEAK
  that had not happened. A false leak report is worse than a missing assertion:
  it is indistinguishable from the real thing, and the natural response is to go
  hunting in the redaction code.
- **A `jq` assignment written through `to_entries[]`** cost a real-AWS run — it
  builds a new array and is not a path back into the document. The same file
  already had the correct shape one phase away.

## Verification

This is a no-`src` diff, so it takes the two arms `/verify-pr` step 9 defines
for that shape:

- **Command arm** — the hook's own suite (`main-tree-dirty-detector.test.sh`)
  passes 8/8, and the full `.claude/hooks/run-tests.sh` is green across every
  suite.
- **Prose arm** — every gate, hook, path and command the new text names was
  resolved against this repo, and the commands it sends the next agent to run
  were executed.

`typecheck` / `typecheck:test` / `lint` / `fmt --check` clean; 701 files /
14313 tests pass.

## Not included, and why

Four other surprises from the run are recorded in the PR bodies of (#2014) and
(#2025) rather than here, because each is about a specific defect class rather
than about running this flow: an "equivalent mutant" claim that turned out to be
hiding a real defect, and predicates that read a store only some code paths
populate — the shape behind two separate empty-map divergences, one of which
only a real-AWS run caught.
