### PR TITLE
chore(work-issues): run a hook harness beside its subject, and gate its own SKILL.md

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -495,6 +495,27 @@ effect. **Always add a unit test that fails without the fix and passes with it**
 carries per-hook `*.test.sh` suites run by `run-tests.sh` under its own
 `hooks.yml` workflow, which is not where you would look from `tests/unit/**`.
 
+**Run such a harness from BESIDE its subject, never from a scratch copy.** Every
+suite resolves the hook under test from its own script path, so a copy runs
+against a sibling that is not there and every case fails with exit 127 —
+reporting a regression your change did not cause. Measured here 2026-08-19:
+`branch-gate.test.sh` scores `Pass: 27  Fail: 0` from `.claude/hooks/`, and from a
+scratch directory exits 1 with `branch-gate.sh: No such file or directory`. Say
+`$0` / `${BASH_SOURCE[0]}`-relative rather than naming one spelling — 27 of the 33
+suites use `${BASH_SOURCE[0]}` and 6 use `$0`, so a rule naming only one is false
+for most of them. Two things here double the damage: `pr-review-gate.test.sh`
+derives the REPO ROOT the same way, so a copy misresolves twice; and
+`run-tests.sh` is itself `${BASH_SOURCE[0]}`-relative before it globs the suite
+directory, so a copied RUNNER cds to the wrong repo entirely.
+
+The trap is invited by the before/after comparison a hook change wants: to check
+the OLD suite against the NEW hook, the obvious move is
+`git show origin/main:<suite> > /tmp/x.sh && bash /tmp/x.sh`. Write the old copy
+next to the real one under a temporary name (`.claude/hooks/_old-<name>.test.sh`)
+and delete it after — otherwise the probe measures its own path resolution rather
+than the hook. This is the one place the scratch-copy idiom §8 recommends does NOT
+transfer: it is right for a data file and wrong for a runnable harness.
+
 **When the issue reports a stale ENTRY in an enumerated list, audit the whole
 list, in both directions, before fixing the named entry.** The defect class is
 "this list drifted from the repo", and drift almost never produces exactly the

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -107,6 +107,17 @@ gates:
       - ".claude/skills/pick-integ/**"
       - ".claude/skills/run-integ/**"
       - ".claude/skills/verify-pr/**"
+      # work-issues joins them for the same reason, from the other direction:
+      # it is not a checker, it is a checker's INPUT. tests/unit/scripts/
+      # work-issues-skill-refs.test.ts reads its SKILL.md and fails on any
+      # issue reference in plain prose that is not go-to-k/<repo>#N. Without
+      # this entry a lane could introduce a bare reference there and commit
+      # against a marker that still verifies fresh, because nothing in the
+      # digest changed -- #1592's shape again, with the enforcement input
+      # rather than the enforcement logic sitting outside the gate. CI still
+      # catches it; what this restores is the LOCAL signal, before the commit
+      # rather than minutes later (issue #2041).
+      - ".claude/skills/work-issues/**"
       # CLAUDE.md is a pattern-scanned target of the same checker, so
       # reintroducing banned wording there must stale `check` as well.
       - "CLAUDE.md"


### PR DESCRIPTION
Closes https://github.com/go-to-k/cdkd/issues/1993
Closes https://github.com/go-to-k/cdkd/issues/2041

The tail of the cross-repo `work-issues` batch. Two small, independent cdkd edits
sharing one gate cycle.

## 1. Run a hook harness from beside its subject (issue 1993, lesson 2)

That issue carried two lessons. Lesson 1 shipped as
https://github.com/go-to-k/cdkd/pull/2019, but that PR had no closing reference,
so the issue stayed open with lesson 2 unlanded — worth noting as its own small
trap: a merged PR is not evidence its issue is done.

Every hook suite resolves the hook under test from its own script path, so a
scratch copy runs against a sibling that is not there and every case fails with
exit 127 — reporting a regression the change did not cause. The reflex comes from
this same file, which recommends the scratch-copy idiom for data files.

Measured here rather than inherited from the sibling that reported it:

```text
bash .claude/hooks/branch-gate.test.sh          Pass: 27  Fail: 0   rc=0
same file copied to a scratch dir, run there    rc=1
  branch-gate.sh: No such file or directory
```

Counts refreshed as well. The issue said 26 of 32 suites use `${BASH_SOURCE[0]}`;
after PR 2019 added one it is **27 of 33**, with 6 using `$0`. A sentence naming
only one spelling would be false for most of them. Two amplifiers specific to this
repo are stated because they double the damage: `pr-review-gate.test.sh` derives
the REPO ROOT the same way, and `run-tests.sh` is itself `${BASH_SOURCE[0]}`-relative
before it globs the suite directory, so a copied RUNNER cds to the wrong repo.

**Not mirrored, and that was checked rather than assumed.** Section 10-c's new
same-session clause asks whether a flow lesson needs all three repos. Both siblings
already carry this one — cdk-local is where it was found, cdk-real-drift states it
in its own words — so landing it here alone completes the set.

## 2. Scope `work-issues/**` into the `check` gate (issue 2041)

https://github.com/go-to-k/cdkd/pull/2045 made `.claude/skills/work-issues/SKILL.md`
the INPUT of a check-scope test (`work-issues-skill-refs.test.ts` fails on any
issue reference in plain prose that is not `go-to-k/<repo>#N`). `.markgate.yml`
did not scope that path, so a lane could introduce a bare reference and commit
against a marker that still verified fresh.

This is the shape issue 1592 closed for `scripts/**`, one step further out: there
the enforcement LOGIC sat outside its gate, here the enforcement INPUT does. The
comment added to `.markgate.yml` says so, matching the reasoning already written
beside the four verification-depth skills.

Verified in both directions rather than reasoned about — set the marker, append a
line to SKILL.md, re-verify:

```text
with this PR's .markgate.yml      markgate verify check -> rc=1   (correctly staled)
with origin/main's .markgate.yml  markgate verify check -> rc=0   (the reported gap)
```

Blast radius was always bounded — CI runs the full suite, so a bare reference
could not reach `main` silently. What this restores is the LOCAL signal, at the
commit rather than minutes later from CI.

## Gates

`vp check --fix` 0 errors · `vp run --no-cache check` rc=0 (uncached, per the
invocation section 8 now prescribes) · `typecheck:test` clean · build ok ·
`work-issues-skill-refs.test.ts` 5/5 against the new prose · full suite green.

No `src/**` change, so the integ gates are out of scope and no AWS resource was
created or touched.
