### PR TITLE
chore(work-issues): do not restart Docker to fix a hung pull -- on Docker Desktop the restart is the likelier cause

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -901,6 +901,32 @@ registry FIRST — `docker pull hello-world` under a 120s cap — because
 `docker version` answering says nothing about registry networking, and that is
 the half that fails.
 
+**Do NOT restart Docker to fix a hang — on Docker Desktop the restart IS the
+likelier cause.** The daemon routes registry traffic through
+`http.docker.internal:3128`, a proxy the Docker Desktop **application** serves.
+`osascript -e 'quit app "Docker"'` followed by `open -a Docker` can leave the
+self-respawning `com.docker.backend` watchdog up while the app itself never
+finishes launching — and then every pull waits forever on a proxy that is not
+there, while `docker version` keeps answering over the local socket. Measured
+2026-08-20: after that sequence, four consecutive `docker pull hello-world`
+attempts hung past a 90-120s cap, `pkill` could not clear the watchdog, and only
+a maintainer restarting the app by hand restored it. Diagnose in this order and
+STOP at the first one that explains the symptom, rather than restarting anything:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' --max-time 15 https://registry-1.docker.io/v2/  # 401 = HOST networking is fine
+docker info 2>/dev/null | grep -i proxy         # names the proxy the daemon depends on
+pgrep -f 'Docker Desktop' >/dev/null && echo app-running || echo APP-NOT-RUNNING
+```
+
+A host that reaches the registry, a daemon configured with a proxy, and no app
+process is the whole diagnosis: the app must come up, and nothing else will fix
+it. Ask the maintainer rather than escalating — the remaining moves (factory
+reset, deleting Docker's data, rewriting the daemon proxy config) destroy local
+images and volumes, which is never yours to spend. Also clean up after your own
+probes: `kill`ing the wrapper of a `docker pull` leaves the `com.docker.cli`
+child running, and five of them had accumulated before anyone looked.
+
 **A run blocked before its assertions is not a failing fix, and the ledger note
 is where that distinction survives.** Record such a run as `FAIL` (the bar is
 exit-code-based) with a note naming the blocker, saying the change was not at


### PR DESCRIPTION
Follow-up to (#2074), correcting a diagnosis that section 8 got only half right.

That PR said to verify docker can reach a REGISTRY before trusting it, because `docker version` answering says nothing about registry networking. True — but it stopped one step short of the actual mechanism, and the missing step is the one that decides what to DO.

## The mechanism

The daemon routes registry traffic through `http.docker.internal:3128`, a proxy served by the Docker Desktop **application**. Quitting the app and relaunching it can leave the self-respawning `com.docker.backend` watchdog up while the app itself never finishes launching — and then every pull waits forever on a proxy that is not there, while `docker version` keeps answering over the local socket.

**So the obvious remedy for a hung pull is also its likeliest cause.**

Measured 2026-08-20 during the (#2071) lane: after `osascript -e 'quit app "Docker"'` + `open -a Docker`, four consecutive `docker pull hello-world` attempts hung past a 90-120s cap, `pkill` could not clear the watchdog (it respawns by design), and only the maintainer restarting the app by hand restored it. That cost the lane its `integ-local` gate for hours and ended with the session reporting an "environment blocker" that was self-inflicted.

## What the section now says

Three commands, and stop at the first one that explains the symptom rather than restarting anything:

```bash
curl -s -o /dev/null -w '%{http_code}\n' --max-time 15 https://registry-1.docker.io/v2/  # 401 = HOST networking is fine
docker info 2>/dev/null | grep -i proxy         # names the proxy the daemon depends on
pgrep -f 'Docker Desktop' >/dev/null && echo app-running || echo APP-NOT-RUNNING
```

Host reachable + proxy configured + no app process **is** the whole diagnosis, and nothing except the app coming up will fix it.

Two more clauses:

- **Ask the maintainer rather than escalating.** The remaining moves — factory reset, deleting Docker's data, rewriting the daemon proxy config — destroy local images and volumes, which is never the agent's to spend.
- **Clean up after your own probes.** `kill`ing the wrapper of a `docker pull` leaves the `com.docker.cli` child running; five had accumulated before anyone looked.

## Verification

Prose-only diff, no `src/**` change, so section 8's prose arm applies: all three prescribed commands were executed against this machine before being written down, and returned `401`, the two `http.docker.internal:3128` proxy lines, and `app-running`.
