### PR TITLE
chore(work-issues): calibration proves a scanner is not noisy, not that it is load-bearing

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -664,6 +664,37 @@ per-line pass then pairs one span's closing backtick with the next span's openin
 one and invents findings; and report the HIT's own line, not the start of the
 region you stripped, or the failure message points at the wrong place.
 
+**Calibrating against the broken tree is only HALF the measurement, and the half
+it leaves out is the one that lets a fence ship inert.** Running the rule over
+the pre-fix tree measures its PRECISION (are the hits real?) and its recall on
+the instances that HAPPEN TO EXIST. It says nothing about the SHAPE — the
+spellings the tree does not currently use, and the contexts that defeat your
+exemption logic. So follow the calibration with two probes, both against the
+REAL tree rather than by reasoning:
+
+- **Write the defect in every spelling the language allows** and confirm each is
+  flagged. On 2026-08-20 (go-to-k/cdkd#2111) a scanner for
+  `options.region || process.env['AWS_REGION']` calibrated perfectly — 19
+  violations, zero false positives — and matched `||` only. The tree already used
+  `??` at four sites, so the obvious way to reintroduce the bug passed clean, and
+  the same rule was blind to the `opts.` / `args.` bag names two other files
+  resolve regions from. Widening it immediately surfaced a real pre-existing bug
+  nobody had filed.
+- **Delete the thing the fence REQUIRES, and watch it fail.** A fence whose
+  predicate is several whole-file substrings OR'd together is satisfied by any
+  one of them, and files routinely contain more than one. The same run's
+  coverage fence — "every region-taking handler folds" — passed 130/130 while a
+  probe deleted the ONLY fold from four handlers at once, because each still
+  contained a different accepted substring elsewhere. Its POPULATION was wrong
+  too: derived from "mentions `options.region`", it pulled in helper modules that
+  merely RECEIVE an already-folded value while missing the files that actually
+  accept the flag. Deriving it from what declares the option, and making the
+  predicate per-READ rather than per-file, is what made both probes fail.
+
+The general shape: **a fence is not evidence until you have watched it go red.**
+Calibration tells you it is not noisy; only the deletion probe tells you it is
+load-bearing.
+
 You may fan out **one subagent per lane** (disjoint files) to run them
 concurrently — give each agent its worktree path, its allowed files, and an
 explicit "do NOT touch <the other lanes' / other agents' files>; STOP and report


### PR DESCRIPTION
## Summary

Retrospective from the go-to-k/cdkd#2111 lane (`/work-issues` section 10). Amends section 5's scanner-calibration rule, which I **followed** and which was still insufficient — that is the whole argument for changing it rather than restating it.

## What the existing rule buys, and what it does not

> Run the candidate rule over the still-broken tree FIRST, read every hit, and tighten until the hits are all genuine.

That measures **precision** (are the hits real?) and **recall on the instances that happen to exist**. It says nothing about the **shape**: the spellings the tree does not currently use, and the contexts that defeat the exemption logic.

## The two failures it did not prevent

**A scanner that calibrated perfectly and was blind.** The go-to-k/cdkd#2111 rule for `options.region || process.env['AWS_REGION']` reported 19 violations over the pre-fix tree with zero false positives — and matched `||` only. The tree already used `??` at four sites, so the obvious way to reintroduce the bug passed clean, and the rule was blind to the `opts.` / `args.` bag names two other files resolve regions from. Widening it immediately surfaced a real pre-existing bug nobody had filed (go-to-k/cdkd#2103: `cdkd local start-api` ships a raw region into every Lambda container).

Its exemption walk had the same character: it sliced back to the last `;`/`{`/`}` and so included the preceding **comment** — and this repo routinely puts ten-line comments naming `canonicalizeRegion(` directly above these lines, so a genuinely unfolded resolution under one was exempted.

**A coverage fence that passed 130/130 with its subject deleted.** "Every region-taking handler folds" used three whole-file substrings OR'd together. 16 of the fenced files contain more than one, so a review probe deleted the **only** `foldRegionOption` call from `orphan.ts`, `drift.ts`, `force-unlock.ts` and `scrub.ts` at once and every case still passed — while `cdkd orphan --region US-EAST-1` then handed a raw spelling to `applyRoleArnIfSet`. Its population was wrong too: derived from "mentions `options.region`", it pulled in helper modules that merely *receive* an already-folded value while missing files using other bag names.

## The amendment

Two probes, both against the real tree rather than by reasoning:

1. **Write the defect in every spelling the language allows** and confirm each is flagged.
2. **Delete the thing the fence requires, and watch it fail.**

Plus the general shape: *a fence is not evidence until you have watched it go red. Calibration tells you it is not noisy; only the deletion probe tells you it is load-bearing.*

## Mirroring

This is a flow lesson, so section 10-c wants it in all three repos. Both siblings carry scanner guidance under different wording, so adapting it is real per-repo work rather than a copy; it is filed into each rather than landed here, and each issue names the other filing and this PR. See the "Not this session" note in the session wrap.

## Test plan

- [x] `vp test run tests/unit/scripts/work-issues-skill-refs.test.ts` — the fence on this file's own references (added refs use the qualified `owner/repo#N` form)
- [x] `vp run --no-cache check` — 0 errors
- [x] `vp run typecheck:test`, `vp run build`
- [x] `vp run test` — 731 files / 14925 tests
