### PR TITLE
test(integ): sweep S3 object versions in secret-seeding fixtures, and lint the rule

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -716,7 +716,15 @@ without `jq` — sourcing the helper must not add a `jq` dependency to ten
 fixtures. Under `Quiet: true` a successful call returns `{}`, so an `Errors` key
 in the output is a per-object failure reported as overall success (confirmed
 against real S3: rc=0 with `Errors` present); it warns, and the retry loop plus
-the zero-assertion are the backstop. The listing keeps stderr OUT of the row
+the zero-assertion are the backstop. **Both AWS calls pin `--output`** — `json`
+on the delete, `text` on the listing — because the CLI's format is AMBIENT
+(`AWS_DEFAULT_OUTPUT`, or `output =` in the active profile). Un-pinned, the
+delete's per-object failure arrives as `ERRORS<TAB>…` under `text` or `Errors:`
+under `yaml`, the `"Errors"` check never matches, and the WARN is swallowed;
+from `cleanup` — which purges `noncurrent` and asserts nothing — that is a
+silent under-sweep, i.e. this issue's own defect class. Measured both ways
+against a fake CLI honouring the ambient default: un-pinned fires under `json`
+only, pinned fires under all three. The listing keeps stderr OUT of the row
 stream — `2>&1` there makes a benign CLI warning a phantom surviving version
 (measured: count 1 on an empty bucket) and feeds that text to
 `delete-object --key`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -696,21 +696,82 @@ teardown sweep must NOT be noncurrent-only: after `aws s3 rm` the DELETE MARKER
 is the entry with `IsLatest == true`, so one marker per key would survive
 forever and the zero-assertion would never pass.
 
-`s3_purge_prefix_versions` refuses any prefix that is not `cdkd/<stack>/<region>/`
-with both segments non-empty — a safety guard, since it runs inside `cleanup`
-under `set +eu` where an unset `STACK` would otherwise widen the prefix and
-delete another stack's LIVE state.
+EVERY entry point — purge, count AND assertion — refuses a prefix that is not
+`cdkd/<stack>/<region>/` with both segments non-empty. On the purge side that
+stops an unset `STACK` (`cleanup` runs under `set +eu`) from widening the prefix
+and deleting another stack's LIVE state. On the READ side it is subtler and was
+missed on the first cut: `cdkd///` lists nothing, so the count is a truthful `0`
+about the WRONG key space, and since every caller wraps the purge in `|| true`,
+a mis-derived prefix printed a refusal to stderr while the fixture still exited
+0 with the plaintext intact. That is the vacuous pass this whole convention
+exists to remove, reintroduced inside the assertion meant to prevent it. Pinned
+by `tests/unit/scripts/integ-s3-versions-helper.test.ts`, which runs the guard
+under bash against a fake `aws` that records its own invocation — so the test
+asserts not just a non-zero exit but that no AWS call was attempted at all.
 
-The helper is covered by `tests/unit/scripts/integ-verify-bash-compat.test.ts`,
-which now scans the shared helpers in `tests/integration/*.sh` as well as every
-`verify.sh` (with a per-shape floor, so a total that is swamped by 200+ fixtures
-cannot hide the helper going unread). It is a FLAT file rather than
-`lib/s3-versions.sh` on purpose: three coverage-matrix generators treat every
-DIRECTORY under `tests/integration/` as a fixture, so a `lib/` directory would
-silently become a 283rd row in all three committed matrices. The convention itself is NOT mechanically enforced —
-"does this fixture write a secret into state?" is a judgment a lint cannot make
-— so it stays a read-it-and-follow-it rule and the per-fixture zero-assertion is
-what makes a regression loud. User-facing writeup in
+Deletes go through `DeleteObjects` in batches of 1000 (the API maximum): a
+347-version key costs one CLI process, not 347. Keys carrying a quote or a
+backslash fall back to single-object `delete-object`, since the payload is built
+without `jq` — sourcing the helper must not add a `jq` dependency to ten
+fixtures. Under `Quiet: true` a successful call returns `{}`, so an `Errors` key
+in the output is a per-object failure reported as overall success (confirmed
+against real S3: rc=0 with `Errors` present); it warns, and the retry loop plus
+the zero-assertion are the backstop. The listing keeps stderr OUT of the row
+stream — `2>&1` there makes a benign CLI warning a phantom surviving version
+(measured: count 1 on an empty bucket) and feeds that text to
+`delete-object --key`.
+
+Also scanned by `tests/unit/scripts/integ-verify-bash-compat.test.ts` and by
+`scripts/check-integ-aws-commands.ts` (its `aws` verbs run in ten fixtures at
+once), both with per-shape floors so a total swamped by 280 fixtures cannot hide
+the helper going unread. Four other integ scanners still cannot see it; the
+per-scanner verdict is recorded in issue
+[#2110](https://github.com/go-to-k/cdkd/issues/2110) rather than fixed by a
+blanket extension, because at least one of them (`integ-verify-signal-traps`)
+would fail on correct code — a sourced helper installs no traps by design.
+
+It is a FLAT file rather than `lib/s3-versions.sh` on purpose: three
+coverage-matrix generators treat every DIRECTORY under `tests/integration/` as a
+fixture, so a `lib/` directory would silently become a 283rd row in all three
+committed matrices (issue
+[#2105](https://github.com/go-to-k/cdkd/issues/2105)).
+
+The convention IS enforced, by
+`tests/unit/scripts/integ-secret-fixture-sweep.test.ts`: a fixture whose
+`bin/**` / `lib/**` TypeScript declares secret material — `unsafePlainText`, a
+hand-supplied `secretStringValue` / `secretObjectValue` / `secretStringBeta1`, a
+templated `master(User)?Password`, `generateSecret: true`, or an `iam.AccessKey`
+— must source the helper AND call `s3_assert_versions_swept`. Per-pattern FLOORS
+(5 / 5 / 2 / 1 / 1) mean a regex that silently stopped matching cannot hide
+behind the others, and the seeding set is pinned by NAME, since the failure this
+closes was a hand audit producing the wrong SET rather than the wrong count.
+Both predicates read comment-stripped CODE: the first cut matched the
+explanatory comment above the `source` line, so its own break-test — delete the
+`.` line, keep the comment — stayed GREEN.
+
+It exists because the written rule above was violated the moment it was written.
+The #2096 audit read all 282 `verify.sh` files and still missed `docdb-neptune`,
+`eventbridge-api-destination` and `cognito-resource-server`, each an exact
+structural twin of one it DID find (a master password, an `unsafePlainText`
+literal, a service-generated credential). All three were then measured holding
+live plaintext: 16 of 64 versions, 15 of 18, and 3 of 18 carrying a real
+`ClientSecret`. The secret is declared in `lib/*.ts`; the audit was reading
+`verify.sh`.
+
+**When auditing by hand anyway, read the stack name from `verify.sh`'s `STACK=`
+line — never infer it from the directory name.** `cognito-resource-server`'s
+stack is `CognitoResourceServerStack`, not `CdkdCognitoResourceServerExample`,
+and probing the convention-derived name returns a clean-looking `0` for a key
+that does not exist. That nearly recorded a real finding as unreproducible.
+
+Three blind spots are named in the lint's own header rather than implied away:
+raw CloudFormation fixtures (template in a checked-in `.json` / `.yaml`, not
+scanned); secrets seeded by the SCRIPT rather than the app
+(`dynamic-ref-cross-region` writes a plaintext state record with `aws s3 cp` —
+no token in its sources reveals it); and service-generated credentials with no
+source marker at all, which is what Cognito's `ClientSecret` was and why it was
+found by grepping the BUCKET. The per-fixture zero-assertion plus periodic
+bucket inspection stay the backstop. User-facing writeup in
 [docs/testing.md](../../docs/testing.md).
 
 ### A fixture that greps cdkd's OWN output must fail loudly when the format drifts

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -634,6 +634,85 @@ and `feedback_umbrella_issue_row_can_be_already_fixed`.
 
 User-facing writeup in [docs/testing.md](../../docs/testing.md).
 
+### `verify.sh` must sweep S3 OBJECT VERSIONS and assert zero (mandatory for secret-seeding fixtures)
+
+`cdkd bootstrap` enables VERSIONING on the state bucket
+(`src/cli/commands/bootstrap.ts`), so `aws s3 rm` writes a DELETE MARKER and
+removes nothing. The near-universal fixture ending —
+`assert_gone ... aws s3api head-object --key "${STATE_KEY}"` — therefore asserts
+only that the CURRENT object is gone, while every prior version stays readable
+via `s3:GetObjectVersion`.
+
+For most fixtures that is litter. For a fixture that puts a KNOWN SECRET
+PLAINTEXT into state it is a disclosure that outlives the run, and several do by
+design (an `unsafePlainText` secret in the fixture's own template, a literal
+`masterUserPassword`, an IAM `SecretAccessKey` cached in `attributes`, a
+deliberately seeded pre-GHSA record). Measured 2026-08-20 for issue
+[#2096](https://github.com/go-to-k/cdkd/issues/2096), immediately after GREEN
+runs: `CdkdSecretsDynamicRefExample`'s state.json held 304 versions + 43 markers
+carrying `cdkd-known-pw-123`, and `CdkdSecretsArrayNestedExample`'s held 7 + 3
+with 5 of the 7 carrying `cdkd-array-nested-pw-789`. Neither script had ever
+issued a `list-object-versions` or a `delete-object --version-id`.
+
+Use the shared helpers in `tests/integration/s3-versions.sh`; do not
+open-code a sweep. Source after the `cd`, purge NONCURRENT from `cleanup` (which
+also runs pre-run and from the failure traps, where a live state.json may be the
+only record of standing resources), and do the FULL sweep plus the assertion on
+the SUCCESS path:
+
+```bash
+cd "$(dirname "$0")"
+. ../s3-versions.sh
+STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
+...
+  s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX:-}" noncurrent || true   # in cleanup
+...
+cleanup                                                                               # success path
+trap - EXIT INT TERM
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${STATE_PREFIX}" "<fixture> state teardown"
+```
+
+Three traps make a sweep silently PARTIAL while the run still exits 0. All three
+were observed live and none is visible from reading the script — only from
+COUNTING what S3 holds afterwards:
+
+1. **Trap-only sweep.** `trap - EXIT INT TERM` on the success path means a sweep
+   that lives only in `cleanup` runs on the failure path and never on the normal
+   one (one key reached 30 versions that way, 2026-08-19).
+2. **`printf '%s' | tr | while read`.** `out=$(aws ...)` strips the trailing
+   newline, so `read` returns non-zero on the LAST field and the body never runs
+   for it. Verified against real S3: 0 of 1 on a single-version key, 346 of 347
+   on a full listing. Use `printf '%s\n'` AND `|| [ -n "${key}" ]`.
+3. **`length(...)` under `--output text`.** The CLI applies `--query` PER PAGE
+   and concatenates, so a >1000-entry listing prints one number per page
+   (measured `1000\n189`, not `1189`). Count ROWS of a `[Key,VersionId]`
+   projection.
+
+Two shapes are decisions, not style. `([Versions, DeleteMarkers][])[...]` — the
+parentheses are load-bearing, the unparenthesised
+`[Versions, DeleteMarkers][][?...]` returns empty (measured 0 vs 347). And the
+teardown sweep must NOT be noncurrent-only: after `aws s3 rm` the DELETE MARKER
+is the entry with `IsLatest == true`, so one marker per key would survive
+forever and the zero-assertion would never pass.
+
+`s3_purge_prefix_versions` refuses any prefix that is not `cdkd/<stack>/<region>/`
+with both segments non-empty — a safety guard, since it runs inside `cleanup`
+under `set +eu` where an unset `STACK` would otherwise widen the prefix and
+delete another stack's LIVE state.
+
+The helper is covered by `tests/unit/scripts/integ-verify-bash-compat.test.ts`,
+which now scans the shared helpers in `tests/integration/*.sh` as well as every
+`verify.sh` (with a per-shape floor, so a total that is swamped by 200+ fixtures
+cannot hide the helper going unread). It is a FLAT file rather than
+`lib/s3-versions.sh` on purpose: three coverage-matrix generators treat every
+DIRECTORY under `tests/integration/` as a fixture, so a `lib/` directory would
+silently become a 283rd row in all three committed matrices. The convention itself is NOT mechanically enforced —
+"does this fixture write a secret into state?" is a judgment a lint cannot make
+— so it stays a read-it-and-follow-it rule and the per-fixture zero-assertion is
+what makes a regression loud. User-facing writeup in
+[docs/testing.md](../../docs/testing.md).
+
 ### A fixture that greps cdkd's OWN output must fail loudly when the format drifts
 
 A `verify.sh` that measures something by grepping the deploy log is a CONSUMER

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -654,6 +654,20 @@ carrying `cdkd-known-pw-123`, and `CdkdSecretsArrayNestedExample`'s held 7 + 3
 with 5 of the 7 carrying `cdkd-array-nested-pw-789`. Neither script had ever
 issued a `list-object-versions` or a `delete-object --version-id`.
 
+**Sweep the PREFIX, never a key list.** `state.json` is not the only thing under
+it. `rollback-journal.json` stores `failedOperations[].attemptedProperties` —
+the properties of the failed write, verbatim — and four measured versions of
+`CdkdDeletionPolicySnapshotHeavyExample`'s journal carried a literal
+`"MasterUserPassword"`. `lock.json` accumulates fastest (452 versions on one
+key) and `deployments/**` is not delete-markered by `cdkd destroy` at all, so
+its objects survive as CURRENT ones. A per-key sweep of `state.json` is the
+natural first instinct, it is what a manual remediation actually did, and it
+left the journal behind. `s3_stack_prefix` + `s3_purge_prefix_versions` covers
+all four. (Blind spot: a nested-stack child at `cdkd/<Parent>~<Child>/<region>/`
+is a SIBLING prefix, not a descendant, so it is not reached — no fixture in the
+swept set has one today; tracked with issue
+[#2107](https://github.com/go-to-k/cdkd/issues/2107).)
+
 Use the shared helpers in `tests/integration/s3-versions.sh`; do not
 open-code a sweep. Source after the `cd`, purge NONCURRENT from `cleanup` (which
 also runs pre-run and from the failure traps, where a live state.json may be the
@@ -712,7 +726,7 @@ asserts not just a non-zero exit but that no AWS call was attempted at all.
 Deletes go through `DeleteObjects` in batches of 1000 (the API maximum): a
 347-version key costs one CLI process, not 347. Keys carrying a quote or a
 backslash fall back to single-object `delete-object`, since the payload is built
-without `jq` — sourcing the helper must not add a `jq` dependency to ten
+without `jq` — sourcing the helper must not add a `jq` dependency to twelve
 fixtures. Under `Quiet: true` a successful call returns `{}`, so an `Errors` key
 in the output is a per-object failure reported as overall success (confirmed
 against real S3: rc=0 with `Errors` present); it warns, and the retry loop plus
@@ -730,7 +744,7 @@ stream — `2>&1` there makes a benign CLI warning a phantom surviving version
 `delete-object --key`.
 
 Also scanned by `tests/unit/scripts/integ-verify-bash-compat.test.ts` and by
-`scripts/check-integ-aws-commands.ts` (its `aws` verbs run in ten fixtures at
+`scripts/check-integ-aws-commands.ts` (its `aws` verbs run in twelve fixtures at
 once), both with per-shape floors so a total swamped by 280 fixtures cannot hide
 the helper going unread. Four other integ scanners still cannot see it; the
 per-scanner verdict is recorded in issue
@@ -748,23 +762,44 @@ The convention IS enforced, by
 `tests/unit/scripts/integ-secret-fixture-sweep.test.ts`: a fixture whose
 `bin/**` / `lib/**` TypeScript declares secret material — `unsafePlainText`, a
 hand-supplied `secretStringValue` / `secretObjectValue` / `secretStringBeta1`, a
-templated `master(User)?Password`, `generateSecret: true`, or an `iam.AccessKey`
-— must source the helper AND call `s3_assert_versions_swept`. Per-pattern FLOORS
-(5 / 5 / 2 / 1 / 1) mean a regex that silently stopped matching cannot hide
-behind the others, and the seeding set is pinned by NAME, since the failure this
+templated `master(User)?Password`, `generateSecret: true`, an `iam.AccessKey`, an
+`appsync.CfnApiKey` or an `addApiKey` — must source the helper AND call
+`s3_assert_versions_swept`. Per-pattern FLOORS mean a regex that silently
+stopped matching cannot hide behind the others; two forward-looking patterns
+(`SecretValue.plainText`, ElastiCache `AuthToken`) carry a floor of 0, so every
+pattern also carries a mandatory `sample` it must match — a control derived from
+the list rather than hand-written beside it, which is what keeps a zero-floor
+pattern honest. The seeding set is pinned by NAME, since the failure this
 closes was a hand audit producing the wrong SET rather than the wrong count.
 Both predicates read comment-stripped CODE: the first cut matched the
 explanatory comment above the `source` line, so its own break-test — delete the
 `.` line, keep the comment — stayed GREEN.
 
 It exists because the written rule above was violated the moment it was written.
-The #2096 audit read all 282 `verify.sh` files and still missed `docdb-neptune`,
-`eventbridge-api-destination` and `cognito-resource-server`, each an exact
-structural twin of one it DID find (a master password, an `unsafePlainText`
-literal, a service-generated credential). All three were then measured holding
-live plaintext: 16 of 64 versions, 15 of 18, and 3 of 18 carrying a real
-`ClientSecret`. The secret is declared in `lib/*.ts`; the audit was reading
-`verify.sh`.
+The #2096 audit read all 282 `verify.sh` files and still missed FIVE fixtures.
+Three — `docdb-neptune`, `eventbridge-api-destination`, `cognito-resource-server`
+— are exact structural twins of ones it DID find (a master password, an
+`unsafePlainText` literal, a service-generated credential), and were missed
+because the secret is declared in `lib/*.ts` while the audit read `verify.sh`.
+They were then measured holding live plaintext: 16 of 64 versions, 15 of 18, and
+3 of 18 carrying a real `ClientSecret`.
+
+**The other two were examined and wrongly CLEARED, and that failure is worth more
+than the rule itself.** `appsync` and `apigw-usage-plan-key` were both probed
+against the real bucket and both reported clean — from a newest-N sample. Of
+`AppSyncStack`'s 557 versions the 12 newest carry no key while 17 of versions
+12..45 do; the API Gateway key sits in versions 7 and 8 of 16. **A newest-N
+sample is the wrong shape for this question**: the newest versions come from the
+most recent run, the one most likely to be already-fixed or to have failed
+early. Sample across the range, or grep the whole key. The same error in its
+other form — probing a convention-derived stack name and reading the resulting
+`0` as clean — cost a separate finding in the same session, which is why the
+`STACK=` rule below exists.
+
+Nor is grepping `src/provisioning/providers/**` a substitute for measuring:
+`AWS::ApiGateway::ApiKey` is registered to no provider at all, so it takes the
+generic Cloud Control readback, whose resource model includes `Value` — the live
+40-character key, in `attributes`, with no provider code naming it.
 
 **When auditing by hand anyway, read the stack name from `verify.sh`'s `STACK=`
 line — never infer it from the directory name.** `cognito-resource-server`'s

--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -257,7 +257,7 @@ schema-v6-to-v7-migration	2026-08-10T05:24:30Z	PASS	54	verify.sh	0810 P2 sweep b
 schema-v7-to-v8-migration	2026-08-01T09:51:12Z	PASS	92	verify.sh	0801 regression sweep; transparent auto-migration + outputReads ok, 0 orphans
 sdk-ccapi-crossref	2026-08-10T04:23:28Z	PASS	85	verify.sh	0810 sweep b2; post-#1355 CC snapshot path, heterogeneous routing, 4 del 0 err, 0 orph
 secrets-array-nested	2026-08-18T09:33:29Z	PASS	59	verify.sh	#1915 keyed array descent + #1917 token-shaped secret; UNCHANGED-path guard held; 0 err / 0 orphans
-secrets-dynamic-ref	2026-08-20T05:43:50Z	PASS	345	verify.sh	issue 1936/2088, re-run AFTER the rebase onto 0.284.19 (main gained PR 2071 + 2092 under this branch). rc=0, 4 deleted 0 errors, secret + SSM parameter gone, unmanaged SecureString intact, state file gone, 0 live orphans. This run's 21 state versions + 1 delete marker swept by hand; 304 older ones predate this session (issue 2096)
+secrets-dynamic-ref	2026-08-20T09:25:11Z	PASS	392	verify.sh	#2096 version-sweep landed: 4 deleted / 0 errors; sweep asserted 0 surviving versions, independently re-verified 0 versions + 0 delete markers + 0 orphans
 secrets-rotation-schedule	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 serverless-api	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean
 servicediscovery	2026-08-19T18:35:33Z	PASS	115	verify.sh	round-3 re-run, destroy 3 deleted 0 errors, orph clean

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -985,6 +985,15 @@ or a deliberately seeded pre-GHSA record. Measured 2026-08-20 for issue
 | --- | --- | --- |
 | `cdkd/CdkdSecretsDynamicRefExample/us-east-1/state.json` | 304 versions + 43 markers | yes (`cdkd-known-pw-123`) |
 | `cdkd/CdkdSecretsArrayNestedExample/us-east-1/state.json` | 7 versions + 3 markers | 5 of the 7 (`cdkd-array-nested-pw-789`) |
+| `cdkd/CdkdDocdbNeptuneExample/us-east-1/state.json` | 64 | 16 of them (`TempPass1234!`) |
+| `cdkd/CdkdEventbridgeApiDestinationExample/us-east-1/state.json` | 18 | 15 of them (`cdkd-integ-api-key`) |
+| `cdkd/CognitoResourceServerStack/us-east-1/state.json` | 18 | 3 of them (a live Cognito `ClientSecret`) |
+
+Ten fixtures do this today. Note the third row's stack name: it is
+`CognitoResourceServerStack`, **not** `CdkdCognitoResourceServerExample`. Read
+the stack name from `verify.sh`'s `STACK=` line when auditing — several fixtures
+do not follow the `Cdkd…Example` convention, and probing the convention-derived
+name returns a clean-looking `0` for a key that does not exist.
 
 Use the shared helpers in
 [`tests/integration/s3-versions.sh`](../tests/integration/s3-versions.sh)
@@ -1041,20 +1050,62 @@ And the teardown sweep must NOT be `noncurrent` — after `aws s3 rm` the delete
 marker is the entry carrying `IsLatest == true`, so a noncurrent-only sweep
 leaves one marker per key behind forever and the zero-assertion never passes.
 
-`s3_purge_prefix_versions` refuses any prefix that is not
-`cdkd/<stack>/<region>/` with both segments non-empty. That is a safety guard,
-not style: these run inside `cleanup`, which runs under `set +eu`, so an unset
-`STACK` would otherwise produce an over-broad prefix and the sweep would delete
-other stacks' LIVE state.
+**Every entry point refuses a prefix that is not `cdkd/<stack>/<region>/` with
+both segments non-empty** — the purge, the count, and the assertion alike. That
+is a safety guard, not style, and it is needed on the READ side for a reason
+that is easy to miss: `cdkd///` names no stack, so S3 lists nothing for it and
+the count is a truthful `0` **about the wrong key space**. Combined with every
+caller wrapping the purge in `|| true`, a mis-derived `STATE_PREFIX` would print
+a refusal to stderr and let the fixture exit 0 with the plaintext intact — the
+same vacuous green the whole convention exists to remove, one level up. On the
+purge side the guard also stops an unset `STACK` (recall `cleanup` runs under
+`set +eu`) from widening the prefix and deleting another stack's LIVE state.
 
-The helper file is covered by
-`tests/unit/scripts/integ-verify-bash-compat.test.ts`, which scans
-the shared helpers in `tests/integration/*.sh` alongside every `verify.sh` — a
-bash-4-ism in a file seven fixtures source is where it does the most damage and
-is least likely to be noticed. There is no lint for the convention itself: whether a given
-fixture writes a secret into state is a judgment call, so this one stays a
-read-it-and-follow-it rule, and the per-fixture zero-assertion is what makes a
-regression loud.
+Deletes go through `DeleteObjects` in batches of 1000, the API maximum, so a
+347-version key costs one CLI process rather than 347. A key or version id
+carrying a quote or a backslash falls back to a single-object `delete-object`,
+because the payload is assembled without `jq` — sourcing this file must not add
+a `jq` dependency to ten fixtures. `Quiet: true` means a fully successful call
+returns `{}`, so any `Errors` in the output is a per-object failure that the
+call reported as overall success; it is surfaced as a WARN and the retry loop
+plus the zero-assertion are the backstop.
+
+Note also that the listing keeps **stderr out of the row stream**: a `2>&1`
+there turns any benign CLI warning into a phantom surviving version, so an empty
+bucket counts 1 and the assertion fails for no reason — and on the delete side
+that warning text would be handed to `delete-object --key`.
+
+Two lints see the helper. `tests/unit/scripts/integ-verify-bash-compat.test.ts`
+scans the shared helpers in `tests/integration/*.sh` alongside every `verify.sh`
+— a bash-4-ism in a file ten fixtures source is where it does the most damage
+and is least likely to be noticed. `scripts/check-integ-aws-commands.ts` scans
+them too, since a verb removed from the AWS CLI here breaks ten fixtures at
+once. Both carry a per-shape floor, so a total swamped by 280 fixtures cannot
+hide the helper going unread. `tests/unit/scripts/integ-s3-versions-helper.test.ts`
+executes the guard directly, asserting a malformed prefix can never produce a
+pass and that no AWS call is even attempted for one.
+
+`tests/unit/scripts/integ-secret-fixture-sweep.test.ts` enforces the convention
+itself: a fixture whose `bin/**` or `lib/**` TypeScript declares secret material
+— `unsafePlainText`, a hand-supplied `secretStringValue` / `secretObjectValue`,
+a templated `masterUserPassword`, `generateSecret: true`, or an
+`iam.AccessKey` — must source the helper AND call `s3_assert_versions_swept`.
+Both predicates read comment-stripped CODE: an early cut matched the explanatory
+comment, so deleting the `source` line still read as compliant.
+
+It exists because a hand audit is not enough, and that is measured rather than
+assumed: the #2096 audit read every fixture's `verify.sh` and still missed
+`docdb-neptune`, `eventbridge-api-destination` and `cognito-resource-server` —
+each the structural twin of one it did find — because the secret is declared in
+`lib/*.ts`, where that audit never looked.
+
+The lint names what it cannot see, and so should you: raw CloudFormation
+fixtures whose template is a checked-in `.json` / `.yaml`; secrets seeded by the
+SCRIPT rather than the app (`dynamic-ref-cross-region` writes a plaintext state
+record with `aws s3 cp`); and service-generated credentials with no marker in
+the source at all — Cognito's `ClientSecret` was that class and was found by
+grepping the BUCKET, not the source. The per-fixture zero-assertion plus
+periodic bucket inspection remain the backstop.
 
 ### Unit-test convention: prime exactly what the code path consumes
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1068,7 +1068,14 @@ because the payload is assembled without `jq` — sourcing this file must not ad
 a `jq` dependency to ten fixtures. `Quiet: true` means a fully successful call
 returns `{}`, so any `Errors` in the output is a per-object failure that the
 call reported as overall success; it is surfaced as a WARN and the retry loop
-plus the zero-assertion are the backstop.
+plus the zero-assertion are the backstop. The call pins `--output json`, which
+is load-bearing rather than tidy: the CLI's format is ambient
+(`AWS_DEFAULT_OUTPUT`, or `output =` in the active profile), and under `text` /
+`yaml` that same failure arrives as `ERRORS<TAB>…` / `Errors:`, the check never
+matches, and the WARN is swallowed. On the success path the zero-assertion would
+still catch the under-sweep; from `cleanup`, which purges `noncurrent` and
+asserts nothing, it would not. Neither reader may inherit a format it does not
+parse — which is why the listing pins `--output text` for the same reason.
 
 Note also that the listing keeps **stderr out of the row stream**: a `2>&1`
 there turns any benign CLI warning into a phantom surviving version, so an empty

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -988,8 +988,23 @@ or a deliberately seeded pre-GHSA record. Measured 2026-08-20 for issue
 | `cdkd/CdkdDocdbNeptuneExample/us-east-1/state.json` | 64 | 16 of them (`TempPass1234!`) |
 | `cdkd/CdkdEventbridgeApiDestinationExample/us-east-1/state.json` | 18 | 15 of them (`cdkd-integ-api-key`) |
 | `cdkd/CognitoResourceServerStack/us-east-1/state.json` | 18 | 3 of them (a live Cognito `ClientSecret`) |
+| `cdkd/AppSyncStack/us-east-1/state.json` | 557 | 17 of versions 12..45 (a live `da2-…` AppSync key) |
+| `cdkd/CdkdApigwUsagePlanKeyExample/us-east-1/state.json` | 16 | 2 of them (a live 40-char API Gateway key `Value`) |
 
-Ten fixtures do this today. Note the third row's stack name: it is
+Twelve fixtures do this today.
+
+**When measuring a key, sample across the RANGE or grep the whole thing — never
+the newest N.** The last two rows were each cleared as "no key material" by a
+newest-N probe before being caught: AppSync's 12 newest versions carry nothing
+while versions 12..45 do, and the API Gateway key sits in versions 7 and 8 of
+16. The newest versions come from the most recent run, which is the one most
+likely to be already-fixed or to have failed early — so a newest-N sample is
+biased towards exactly the answer you do not want.
+
+It is also not enough to grep `src/provisioning/providers/**` for a credential.
+`AWS::ApiGateway::ApiKey` is registered to no provider, so it takes the generic
+Cloud Control readback, whose resource model includes `Value`: the live key
+lands in `attributes` with no provider code naming it. Note the third row's stack name: it is
 `CognitoResourceServerStack`, **not** `CdkdCognitoResourceServerExample`. Read
 the stack name from `verify.sh`'s `STACK=` line when auditing — several fixtures
 do not follow the `Cdkd…Example` convention, and probing the convention-derived
@@ -1005,6 +1020,21 @@ cd "$(dirname "$0")"
 . ../s3-versions.sh
 STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
 ```
+
+**Sweep the PREFIX, never a list of keys.** Sweeping `state.json` by name is the
+natural first instinct and it under-sweeps, because the plaintext is not only
+there. `rollback-journal.json` stores
+`failedOperations[].attemptedProperties` — the properties of the failed write,
+verbatim — and four measured versions of
+`CdkdDeletionPolicySnapshotHeavyExample`'s journal carried a literal
+`"MasterUserPassword"`. `lock.json` accumulates faster than anything else (452
+versions on one key), and `deployments/**` is not delete-markered by
+`cdkd destroy` at all, so its objects survive as CURRENT ones. One prefix covers
+all four; a key list covers whichever ones its author thought of.
+
+One blind spot to know: a nested-stack child lives at
+`cdkd/<Parent>~<Child>/<region>/`, a SIBLING prefix rather than a descendant, so
+this does not reach it. No fixture in the swept set has one today.
 
 In `cleanup`, purge NONCURRENT versions only — that function also runs from the
 pre-run sweep and from the failure / INT / TERM traps, where a live `state.json`
@@ -1065,7 +1095,7 @@ Deletes go through `DeleteObjects` in batches of 1000, the API maximum, so a
 347-version key costs one CLI process rather than 347. A key or version id
 carrying a quote or a backslash falls back to a single-object `delete-object`,
 because the payload is assembled without `jq` — sourcing this file must not add
-a `jq` dependency to ten fixtures. `Quiet: true` means a fully successful call
+a `jq` dependency to twelve fixtures. `Quiet: true` means a fully successful call
 returns `{}`, so any `Errors` in the output is a per-object failure that the
 call reported as overall success; it is surfaced as a WARN and the retry loop
 plus the zero-assertion are the backstop. The call pins `--output json`, which
@@ -1084,9 +1114,9 @@ that warning text would be handed to `delete-object --key`.
 
 Two lints see the helper. `tests/unit/scripts/integ-verify-bash-compat.test.ts`
 scans the shared helpers in `tests/integration/*.sh` alongside every `verify.sh`
-— a bash-4-ism in a file ten fixtures source is where it does the most damage
+— a bash-4-ism in a file twelve fixtures source is where it does the most damage
 and is least likely to be noticed. `scripts/check-integ-aws-commands.ts` scans
-them too, since a verb removed from the AWS CLI here breaks ten fixtures at
+them too, since a verb removed from the AWS CLI here breaks twelve fixtures at
 once. Both carry a per-shape floor, so a total swamped by 280 fixtures cannot
 hide the helper going unread. `tests/unit/scripts/integ-s3-versions-helper.test.ts`
 executes the guard directly, asserting a malformed prefix can never produce a

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -960,6 +960,102 @@ Enforced by `tests/unit/scripts/integ-state-bucket.test.ts` (classifier:
 bodies, comments and `echo` arguments are stripped, so a remediation hint that
 prints the command is not treated as an invocation.
 
+### Fixture convention: sweep S3 OBJECT VERSIONS, and assert the count is zero
+
+`cdkd bootstrap` turns **versioning on** for the state bucket
+(`src/cli/commands/bootstrap.ts`). On a versioned bucket `aws s3 rm` writes a
+DELETE MARKER; it removes nothing. So this, which most fixtures end with,
+
+```bash
+assert_gone "state file still exists after destroy" \
+  aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
+```
+
+is a statement about the CURRENT object only. Every earlier version of that key
+is still readable by anyone with `s3:GetObjectVersion`.
+
+For most fixtures that is litter. For a fixture that puts a **known secret
+plaintext** into state it is a disclosure that outlives the run — and several
+do, for good reasons: an `unsafePlainText` secret in the fixture's own template,
+a literal `masterUserPassword`, an IAM `SecretAccessKey` cached in `attributes`,
+or a deliberately seeded pre-GHSA record. Measured 2026-08-20 for issue
+[#2096](https://github.com/go-to-k/cdkd/issues/2096), right after green runs:
+
+| key | surviving entries | carrying the fixture's plaintext |
+| --- | --- | --- |
+| `cdkd/CdkdSecretsDynamicRefExample/us-east-1/state.json` | 304 versions + 43 markers | yes (`cdkd-known-pw-123`) |
+| `cdkd/CdkdSecretsArrayNestedExample/us-east-1/state.json` | 7 versions + 3 markers | 5 of the 7 (`cdkd-array-nested-pw-789`) |
+
+Use the shared helpers in
+[`tests/integration/s3-versions.sh`](../tests/integration/s3-versions.sh)
+rather than open-coding a sweep — the three traps below are written down there
+once instead of once per fixture. Source it after the `cd` into the fixture dir:
+
+```bash
+cd "$(dirname "$0")"
+. ../s3-versions.sh
+STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
+```
+
+In `cleanup`, purge NONCURRENT versions only — that function also runs from the
+pre-run sweep and from the failure / INT / TERM traps, where a live `state.json`
+may be the only record of resources that are still standing:
+
+```bash
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX:-}" noncurrent || true
+```
+
+On the SUCCESS path, do the full sweep and **assert**:
+
+```bash
+cleanup
+trap - EXIT INT TERM
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${STATE_PREFIX}" "<fixture> state teardown"
+```
+
+Three traps make a sweep silently PARTIAL while the run still exits 0. Each was
+observed live, and none is visible from reading the script:
+
+1. **Sweeping only from the EXIT trap.** A fixture that ends with
+   `trap - EXIT INT TERM` disarms the trap on the success path, so a trap-only
+   sweep runs on the failure path and never on the normal one. One key reached
+   30 versions that way (2026-08-19). Sweep on the success path too.
+2. **Iterating with `printf '%s' | tr | while read`.** `out=$(aws ...)` strips
+   the trailing newline, so the last field has no terminator, `read` returns
+   non-zero on it, and the loop body never runs for it. Verified against real
+   S3: on a key holding one version the broken form swept 0 of 1; on a
+   347-entry listing it swept 346. Repeated passes take a key to 1 and stop.
+   Use `printf '%s\n'` plus a `|| [ -n "${key}" ]` guard — both.
+3. **Counting with `length(...)` under `--output text`.** The AWS CLI applies
+   `--query` PER PAGE and concatenates, so a listing over 1000 entries prints
+   one number per page — measured `1000\n189`, not `1189` — and `[ "$n" -ne 0 ]`
+   on that is a bash error, not a count. Count ROWS of a `[Key,VersionId]`
+   projection instead; the pages concatenate into one row stream.
+
+Two more details the helpers encode. The query is
+`([Versions, DeleteMarkers][])[...]` and the **parentheses are load-bearing**:
+`[Versions, DeleteMarkers][][?...]` returns empty because the flatten projection
+swallows the filter (measured: 0 where the parenthesised form reported 347).
+And the teardown sweep must NOT be `noncurrent` — after `aws s3 rm` the delete
+marker is the entry carrying `IsLatest == true`, so a noncurrent-only sweep
+leaves one marker per key behind forever and the zero-assertion never passes.
+
+`s3_purge_prefix_versions` refuses any prefix that is not
+`cdkd/<stack>/<region>/` with both segments non-empty. That is a safety guard,
+not style: these run inside `cleanup`, which runs under `set +eu`, so an unset
+`STACK` would otherwise produce an over-broad prefix and the sweep would delete
+other stacks' LIVE state.
+
+The helper file is covered by
+`tests/unit/scripts/integ-verify-bash-compat.test.ts`, which scans
+the shared helpers in `tests/integration/*.sh` alongside every `verify.sh` — a
+bash-4-ism in a file seven fixtures source is where it does the most damage and
+is least likely to be noticed. There is no lint for the convention itself: whether a given
+fixture writes a secret into state is a judgment call, so this one stays a
+read-it-and-follow-it rule, and the per-fixture zero-assertion is what makes a
+regression loud.
+
 ### Unit-test convention: prime exactly what the code path consumes
 
 `vi.clearAllMocks()` clears call RECORDS but does **not** drain the queue seeded

--- a/scripts/check-integ-aws-commands.ts
+++ b/scripts/check-integ-aws-commands.ts
@@ -471,9 +471,23 @@ export function lintFixtureTreeAwsCommands(
   );
 }
 
+/**
+ * `<fixture>/verify.sh` for a fixture, or the bare filename for a SHARED helper
+ * that lives directly in `tests/integration/`. `readFixtureScripts` returns
+ * both shapes, so a hardcoded `${fixture}/verify.sh` would report the
+ * nonexistent path `tests/integration/s3-versions.sh/verify.sh` for exactly the
+ * file the walk was widened to reach -- i.e. it would be wrong the first time
+ * it was ever needed.
+ */
+function violationPath(fixture: string): string {
+  return fixture.endsWith('.sh')
+    ? `tests/integration/${fixture}`
+    : `tests/integration/${fixture}/verify.sh`;
+}
+
 export function formatAwsCommandViolation(v: AwsCommandViolation): string {
   return [
-    `tests/integration/${v.fixture}/verify.sh:${v.line}`,
+    `${violationPath(v.fixture)}:${v.line}`,
     `  \`aws ${v.service} ${v.verb}\` is NOT an AWS CLI command — it is on the CLI's removal list`,
     `  (awscli/customizations/removals.py), even though the ${v.service} API operation exists and`,
     `  every AWS SDK exposes it. The CLI answers "Found invalid choice"; on a machine with`,

--- a/scripts/check-integ-aws-commands.ts
+++ b/scripts/check-integ-aws-commands.ts
@@ -449,10 +449,10 @@ export function readFixtureScripts(integRoot: string): { fixture: string; conten
   // ...plus the SHARED helpers sitting directly in tests/integration/, which
   // issue `aws` verbs on behalf of every fixture that sources them
   // (`s3-versions.sh` runs `s3api list-object-versions` / `delete-objects` /
-  // `delete-object` in ten of them, issue #2096). Scoping this walk to
+  // `delete-object` in twelve of them, issue #2096). Scoping this walk to
   // directories would leave the most widely executed aws calls in the tree as
   // the only ones this lint cannot see -- and a removed verb there breaks
-  // ten fixtures at once rather than one.
+  // twelve fixtures at once rather than one.
   const shared = entries
     .filter((e) => e.isFile() && e.name.endsWith('.sh'))
     .map((e) => ({

--- a/scripts/check-integ-aws-commands.ts
+++ b/scripts/check-integ-aws-commands.ts
@@ -439,12 +439,27 @@ export function lintScriptAwsCommands(
  * `.claude/rules/testing.md` exists to prevent, reintroduced one level up.
  */
 export function readFixtureScripts(integRoot: string): { fixture: string; content: string }[] {
-  return readdirSync(integRoot, { withFileTypes: true })
+  const entries = readdirSync(integRoot, { withFileTypes: true });
+  const fixtures = entries
     .filter((e) => e.isDirectory() && existsSync(join(integRoot, e.name, 'verify.sh')))
     .map((e) => ({
       fixture: e.name,
       content: readFileSync(join(integRoot, e.name, 'verify.sh'), 'utf8'),
     }));
+  // ...plus the SHARED helpers sitting directly in tests/integration/, which
+  // issue `aws` verbs on behalf of every fixture that sources them
+  // (`s3-versions.sh` runs `s3api list-object-versions` / `delete-objects` /
+  // `delete-object` in ten of them, issue #2096). Scoping this walk to
+  // directories would leave the most widely executed aws calls in the tree as
+  // the only ones this lint cannot see -- and a removed verb there breaks
+  // ten fixtures at once rather than one.
+  const shared = entries
+    .filter((e) => e.isFile() && e.name.endsWith('.sh'))
+    .map((e) => ({
+      fixture: e.name,
+      content: readFileSync(join(integRoot, e.name), 'utf8'),
+    }));
+  return [...fixtures, ...shared];
 }
 
 export function lintFixtureTreeAwsCommands(

--- a/tests/integration/apigw-usage-plan-key/verify.sh
+++ b/tests/integration/apigw-usage-plan-key/verify.sh
@@ -40,9 +40,25 @@ assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-ve
 # ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
+# Shared S3 VERSION-sweep helpers (issue #2096). This fixture calls
+# `api.addApiKey(...)`, and `AWS::ApiGateway::ApiKey` has NO SDK provider -- it
+# takes the generic Cloud Control readback, whose resource model includes
+# `Value`. So the live 40-character key lands in `attributes.Value` without any
+# provider code naming it: measured 2026-08-20, 2 of this stack's 16 surviving
+# state.json versions carry one. The state bucket is VERSIONED, so `aws s3 rm`
+# only writes a delete marker and it stays readable.
+#
+# Both halves of that measurement matter. A newest-N sample missed it (the key
+# sits in versions 7 and 8 of 16), and grepping the PROVIDER sources for a
+# credential would have missed it too, because no provider handles this type.
+. ../s3-versions.sh
+
 STACK="CdkdApigwUsagePlanKeyExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
+# Everything this stack owns in the bucket: state.json, lock.json,
+# rollback-journal.json and deployments/**.
+STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
 API_NAME="${STACK}-api"
 KEY_NAME="${STACK}-key"
 PLAN_NAME="${STACK}-plan"
@@ -71,6 +87,10 @@ cleanup() {
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1 || true
+    # The `aws s3 rm` above only wrote DELETE MARKERS. NONCURRENT-only here:
+    # this also runs from the pre-run sweep and the failure traps, where a live
+    # state.json may be the only record of resources still standing.
+    s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX:-}" noncurrent || true
   fi
   set -eu
 }
@@ -112,5 +132,16 @@ PLAN_REMAIN=$(aws apigateway get-usage-plans --region "${REGION}" --query "items
 echo "    OK: usage plan gone"
 assert_gone "state remains" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
+
+# --- Teardown + VERSION sweep, ON THE SUCCESS PATH -------------------------
+# head-object only looks at the CURRENT object; the bucket is VERSIONED, so the
+# Cloud-Control-readback api key `Value` survives in prior versions without this
+# (issue #2096). On the success path, not only in `cleanup`, and asserted.
+echo "==> Final teardown + state-version sweep"
+cleanup
+trap - EXIT INT TERM
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${STATE_PREFIX}" "apigw-usage-plan-key state teardown"
+
 echo ""
 echo "==> apigw-usage-plan-key test passed"

--- a/tests/integration/appsync/verify.sh
+++ b/tests/integration/appsync/verify.sh
@@ -63,9 +63,28 @@ assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-ve
 
 cd "$(dirname "$0")"
 
+# Shared S3 VERSION-sweep helpers (issue #2096). This fixture declares an
+# `appsync.CfnApiKey`, and for AppSync the key's ID *is* the usable credential:
+# `AppSyncProvider.createApiKey` persists `response.apiKey.id` as the physical
+# id, and `attributes` carries it again as `ApiKey` plus an `Arn` built from it
+# (src/provisioning/providers/appsync-provider.ts:431-434). So a live `da2-...`
+# key is in every state.json this fixture writes -- no `unsafePlainText`
+# anywhere, the credential is service-generated. The state bucket is VERSIONED,
+# so `aws s3 rm` only writes a delete marker and it stays readable.
+#
+# Measured 2026-08-20: of 557 surviving versions of this stack's state.json, the
+# 12 NEWEST carried no key at all while 17 of versions 12..45 did. That sampling
+# shape is the lesson, not a footnote -- a newest-N sample reads the most recent
+# run, which is the most likely to be already-fixed or to have failed early, and
+# it is what made a first pass call this fixture clean.
+. ../s3-versions.sh
+
 STACK="AppSyncStack"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
+# Everything this stack owns in the bucket: state.json, lock.json,
+# rollback-journal.json and deployments/**.
+STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
 API_NAME="cdkd-appsync-example"
 POOL_NAME="cdkd-appsync-example-pool"
 
@@ -80,6 +99,10 @@ cleanup() {
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1
+    # The `aws s3 rm` above only wrote DELETE MARKERS. NONCURRENT-only here:
+    # this also runs from the pre-run sweep and the failure traps, where a live
+    # state.json may be the only record of resources still standing.
+    s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX:-}" noncurrent || true
   fi
   set -eu
 }
@@ -532,6 +555,16 @@ assert_eq "leftover '${POOL_NAME}' user pools" "0" "${REMAINING_POOLS}"
 assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" \
   aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
+
+# --- Teardown + VERSION sweep, ON THE SUCCESS PATH -------------------------
+# head-object only looks at the CURRENT object; the bucket is VERSIONED, so the
+# AppSync api key survives in prior versions without this (issue #2096). On the
+# success path, not only in `cleanup`, and asserted rather than assumed.
+echo "==> Final teardown + state-version sweep"
+cleanup
+trap - EXIT INT TERM
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${STATE_PREFIX}" "appsync state teardown"
 
 echo ""
 echo "==> appsync test passed (#609 GraphQLApi + Resolver + DataSource config properties reach AWS on create / update / removal + clean destroy)"

--- a/tests/integration/cognito-resource-server/verify.sh
+++ b/tests/integration/cognito-resource-server/verify.sh
@@ -55,9 +55,20 @@ assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-ve
 
 cd "$(dirname "$0")"
 
+# Shared S3 VERSION-sweep helpers (issue #2096). The fixture's user-pool client
+# sets `generateSecret: true`, so Cognito mints a real client secret and cdkd
+# caches it in the resource's state record -- no `unsafePlainText` anywhere, the
+# credential is service-generated. The state bucket is VERSIONED, so `aws s3 rm`
+# only writes a delete marker: measured 2026-08-20, 3 of 18 surviving versions
+# of this stack's state.json carried a live `"ClientSecret"` value.
+. ../s3-versions.sh
+
 STACK="CognitoResourceServerStack"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
+# Everything this stack owns in the bucket: state.json, lock.json,
+# rollback-journal.json and deployments/**.
+STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
 
 # Resolve the built CLI path without a `cd` into dist/ that fails cryptically
 # (aborting under `set -e`) when dist/ is unbuilt -- the friendly guard below
@@ -75,9 +86,17 @@ cleanup() {
       --region "${REGION}" >/dev/null 2>&1
     destroy_rc=$?
   fi
-  if [ -n "${STATE_BUCKET:-}" ] && [ "${destroy_rc}" -eq 0 ]; then
-    aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true
-    aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1 || true
+  if [ -n "${STATE_BUCKET:-}" ]; then
+    if [ "${destroy_rc}" -eq 0 ]; then
+      aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true
+      aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1 || true
+    fi
+    # Outside the destroy_rc guard on purpose, and NONCURRENT-only: the client
+    # secret is in the HISTORICAL versions whether or not this run's destroy
+    # succeeded, and noncurrent never touches a live state.json that a
+    # follow-up `cdkd state destroy` still needs. The success path does the
+    # full sweep.
+    s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX:-}" noncurrent || true
   fi
   set -eu
 }
@@ -172,5 +191,15 @@ echo "    OK: UserPool is gone"
 assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
+# --- Teardown + VERSION sweep, ON THE SUCCESS PATH -------------------------
+# head-object only looks at the CURRENT object; the bucket is VERSIONED, so the
+# Cognito-generated client secret survives in prior versions without this
+# (issue #2096). On the success path, not only in `cleanup`, and asserted.
+echo "==> Final teardown + state-version sweep"
+cleanup
+trap - EXIT INT TERM
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${STATE_PREFIX}" "cognito-resource-server state teardown"
+
 echo ""
-echo "==> cognito-resource-server test passed (compound-id Ref -> bare scope + clean destroy)"
+echo "==> cognito-resource-server test passed (compound-id Ref -> bare scope + clean destroy + zero surviving state versions)"

--- a/tests/integration/cross-stack-secret-import/verify.sh
+++ b/tests/integration/cross-stack-secret-import/verify.sh
@@ -214,8 +214,13 @@ sweep() {
       # versions. NONCURRENT-only here: `sweep` also runs from the pre-run pass
       # and the failure traps, where a live state.json may be the only record of
       # resources still standing. The success path does the full sweep.
-      s3_purge_prefix_versions "${STATE_BUCKET}" "${PRODUCER_STATE_PREFIX:-}" noncurrent
-      s3_purge_prefix_versions "${STATE_BUCKET}" "${CONSUMER_STATE_PREFIX:-}" noncurrent
+      # `|| true` like every other line in `sweep`: a failed LIST returns 1,
+      # and this subshell runs under the caller's `set -euo pipefail` at the
+      # PRE-RUN call site -- so an unguarded non-zero here aborts the run before
+      # it starts. Inside `cleanup` it would preempt `exit "${rc}"` and turn a
+      # SIGINT run's 130 into a 1.
+      s3_purge_prefix_versions "${STATE_BUCKET}" "${PRODUCER_STATE_PREFIX:-}" noncurrent || true
+      s3_purge_prefix_versions "${STATE_BUCKET}" "${CONSUMER_STATE_PREFIX:-}" noncurrent || true
     fi
   )
 }
@@ -503,11 +508,12 @@ pass "no orphan state, parameter, secret or exports-index entry"
 
 # --- Teardown + VERSION sweep, ON THE SUCCESS PATH -------------------------
 # This fixture is the textbook case for why the sweep cannot live only in
-# `cleanup`: the line below DISARMS the trap, so on the normal path `cleanup`
-# never runs at all. The bucket is VERSIONED, so without this the producer's
-# literal secret survives the run in every prior version of its state.json
-# (issue #2096). `sweep` is called explicitly first, then the trap is disarmed
-# so nothing can write a new delete marker after the count is taken.
+# `cleanup`: the `trap - EXIT INT TERM` a few lines down DISARMS the trap, so on
+# the normal path `cleanup` never runs at all. The bucket is VERSIONED, so
+# without this the producer's literal secret survives the run in every prior
+# version of its state.json (issue #2096). `sweep` (the teardown body `cleanup`
+# would have called) is invoked explicitly first, THEN the trap is disarmed, so
+# nothing can write a new delete marker after the count is taken.
 echo ""
 echo "==> Final teardown + state-version sweep"
 sweep

--- a/tests/integration/cross-stack-secret-import/verify.sh
+++ b/tests/integration/cross-stack-secret-import/verify.sh
@@ -87,6 +87,14 @@ assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-ve
 
 cd "$(dirname "$0")"
 
+# Shared S3 VERSION-sweep helpers (issue #2096). The PRODUCER's template
+# declares the secret's value as a LITERAL SecretString, so `EXPECTED_PLAINTEXT`
+# sits in that resource's own state properties by construction -- which is why
+# the leak greps below are scoped to the outputs bag and to the CONSUMER. The
+# state bucket is VERSIONED, so `aws s3 rm` only writes a delete marker and the
+# producer's copy stays readable via GetObjectVersion.
+. ../s3-versions.sh
+
 REGION="${AWS_REGION:-us-east-1}"
 PRODUCER="CdkdCrossStackSecretProducer"
 CONSUMER="CdkdCrossStackSecretConsumer"
@@ -104,6 +112,13 @@ ARN_OUTPUT="CrossStackSecretArnOutput"
 
 PRODUCER_STATE_KEY="cdkd/${PRODUCER}/${REGION}/state.json"
 CONSUMER_STATE_KEY="cdkd/${CONSUMER}/${REGION}/state.json"
+# Everything each stack owns in the bucket: state.json, lock.json,
+# rollback-journal.json and deployments/**. The shared exports index
+# (`cdkd/_index/...`) is deliberately NOT swept -- it is not this stack's key
+# space, other stacks' entries live in it, and the assertions below already
+# prove it carries the expression rather than the plaintext.
+PRODUCER_STATE_PREFIX="$(s3_stack_prefix "${PRODUCER}" "${REGION}")"
+CONSUMER_STATE_PREFIX="$(s3_stack_prefix "${CONSUMER}" "${REGION}")"
 INDEX_KEY="cdkd/_index/${REGION}/exports.json"
 
 # One run id for the whole script, exported BEFORE any cdkd invocation: every
@@ -194,6 +209,13 @@ sweep() {
     if [ -n "${STATE_BUCKET:-}" ]; then
       aws s3 rm "s3://${STATE_BUCKET}/cdkd/${CONSUMER}/${REGION}/lock.json" >/dev/null 2>&1
       aws s3 rm "s3://${STATE_BUCKET}/cdkd/${PRODUCER}/${REGION}/lock.json" >/dev/null 2>&1
+      # `aws s3 rm` / `state destroy` only leave DELETE MARKERS on a versioned
+      # bucket, so the producer's literal SecretString survives in the prior
+      # versions. NONCURRENT-only here: `sweep` also runs from the pre-run pass
+      # and the failure traps, where a live state.json may be the only record of
+      # resources still standing. The success path does the full sweep.
+      s3_purge_prefix_versions "${STATE_BUCKET}" "${PRODUCER_STATE_PREFIX:-}" noncurrent
+      s3_purge_prefix_versions "${STATE_BUCKET}" "${CONSUMER_STATE_PREFIX:-}" noncurrent
     fi
   )
 }
@@ -479,6 +501,21 @@ else
 fi
 pass "no orphan state, parameter, secret or exports-index entry"
 
+# --- Teardown + VERSION sweep, ON THE SUCCESS PATH -------------------------
+# This fixture is the textbook case for why the sweep cannot live only in
+# `cleanup`: the line below DISARMS the trap, so on the normal path `cleanup`
+# never runs at all. The bucket is VERSIONED, so without this the producer's
+# literal secret survives the run in every prior version of its state.json
+# (issue #2096). `sweep` is called explicitly first, then the trap is disarmed
+# so nothing can write a new delete marker after the count is taken.
+echo ""
+echo "==> Final teardown + state-version sweep"
+sweep
+trap - EXIT INT TERM
+s3_purge_prefix_versions "${STATE_BUCKET}" "${PRODUCER_STATE_PREFIX}" all || true
+s3_purge_prefix_versions "${STATE_BUCKET}" "${CONSUMER_STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${PRODUCER_STATE_PREFIX}" "cross-stack-secret-import producer state teardown"
+s3_assert_versions_swept "${STATE_BUCKET}" "${CONSUMER_STATE_PREFIX}" "cross-stack-secret-import consumer state teardown"
+
 echo ""
 echo "==> All cross-stack-secret-import assertions passed"
-trap - EXIT INT TERM

--- a/tests/integration/deletion-policy-snapshot-heavy/verify.sh
+++ b/tests/integration/deletion-policy-snapshot-heavy/verify.sh
@@ -57,9 +57,19 @@ assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-ve
 
 cd "$(dirname "$0")"
 
+# Shared S3 VERSION-sweep helpers (issue #2096). The fixture stack templates a
+# literal `masterUserPassword` for the Redshift cluster, so that password lands
+# in the cluster's own state properties. The state bucket is VERSIONED, so
+# `aws s3 rm` only writes a delete marker and the password stays readable via
+# GetObjectVersion long after the cluster is gone.
+. ../s3-versions.sh
+
 STACK="CdkdDeletionPolicySnapshotHeavyExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
+# Everything this stack owns in the bucket: state.json, lock.json,
+# rollback-journal.json and deployments/**.
+STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
 IDS_FILE="/tmp/cdkd-integ-deletion-policy-snapshot-heavy-ids"
 
 LOCAL_DIST="${PWD}/../../../dist/cli.js"
@@ -155,6 +165,12 @@ cleanup() {
   fi
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1
+    # `aws s3 rm` / `state destroy` only leave DELETE MARKERS on a versioned
+    # bucket, so the templated master password survives in the prior versions.
+    # NONCURRENT-only here: this also runs from the pre-run sweep and the
+    # failure traps, where a live state.json may be the only record of a
+    # still-standing cluster. The success path does the full sweep + assertion.
+    s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX:-}" noncurrent || true
   fi
   rm -f "${IDS_FILE}"
   set -eu
@@ -294,4 +310,14 @@ if [ "${REDIS_GONE}" -ne 1 ]; then
 fi
 rm -f "${IDS_FILE}"
 
-echo "PASS: DeletionPolicy: Snapshot honored for Redshift Cluster + ElastiCache ReplicationGroup, zero orphans"
+# --- Teardown + VERSION sweep, ON THE SUCCESS PATH -------------------------
+# The bucket is VERSIONED, so the templated Redshift master password outlives a
+# green run in every prior version of state.json (issue #2096). Sweep on the
+# NORMAL path, not only from the trap, and ASSERT the count is zero.
+echo "==> Final teardown + state-version sweep"
+cleanup
+trap - EXIT INT TERM
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${STATE_PREFIX}" "deletion-policy-snapshot-heavy state teardown"
+
+echo "PASS: DeletionPolicy: Snapshot honored for Redshift Cluster + ElastiCache ReplicationGroup, zero orphans, zero surviving state versions"

--- a/tests/integration/docdb-neptune/verify.sh
+++ b/tests/integration/docdb-neptune/verify.sh
@@ -55,9 +55,11 @@ CLI="node ${REPO_ROOT}/dist/cli.js"
 # GetObjectVersion after a green run -- measured 2026-08-20, 16 of 64 surviving
 # versions of this stack's state.json carried it.
 #
-# Sourced by ABSOLUTE path: unlike its siblings this script never `cd`s into the
-# fixture directory, so a relative `../s3-versions.sh` would resolve against
-# whatever the caller's cwd happens to be.
+# Sourced by ABSOLUTE path because this line runs BEFORE the `cd "${TEST_DIR}"`
+# further down, so a relative `../s3-versions.sh` would resolve against whatever
+# the caller's cwd happens to be. Do NOT "simplify" this by moving the source
+# below that `cd` -- the helper is wanted before the first `cleanup` can fire --
+# and do not delete the `cd`, which the fixture's own npm/vp steps need.
 . "${REPO_ROOT}/tests/integration/s3-versions.sh"
 
 ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"

--- a/tests/integration/docdb-neptune/verify.sh
+++ b/tests/integration/docdb-neptune/verify.sh
@@ -48,9 +48,24 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 TEST_DIR="${REPO_ROOT}/tests/integration/docdb-neptune"
 CLI="node ${REPO_ROOT}/dist/cli.js"
 
+# Shared S3 VERSION-sweep helpers (issue #2096). The fixture stack templates a
+# literal `masterUserPassword` for the DocDB cluster, so that password lands in
+# the cluster's own state properties. The state bucket is VERSIONED, so
+# `aws s3 rm` only writes a delete marker and it stays readable via
+# GetObjectVersion after a green run -- measured 2026-08-20, 16 of 64 surviving
+# versions of this stack's state.json carried it.
+#
+# Sourced by ABSOLUTE path: unlike its siblings this script never `cd`s into the
+# fixture directory, so a relative `../s3-versions.sh` would resolve against
+# whatever the caller's cwd happens to be.
+. "${REPO_ROOT}/tests/integration/s3-versions.sh"
+
 ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
 STATE_BUCKET="${STATE_BUCKET:-cdkd-state-${ACCOUNT_ID}}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
+# Everything this stack owns in the bucket: state.json, lock.json,
+# rollback-journal.json and deployments/**.
+STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
 echo "[verify] region=${REGION} stack=${STACK} state-bucket=${STATE_BUCKET}"
 
 # Per-resource timeout overrides for DocDB + Neptune. AWS create / delete
@@ -108,6 +123,12 @@ cleanup() {
       --remove-protection \
       "${TIMEOUT_OVERRIDES[@]}" || true
   fi
+  # Purge the versions any `s3 rm` / `state destroy` left behind as delete
+  # markers. NONCURRENT-only, per the contract in ../s3-versions.sh: this runs
+  # from the failure and signal traps, where a live state.json may be the only
+  # record of a cluster that is still standing. The success path does the full
+  # sweep, after destroy has been asserted.
+  s3_purge_prefix_versions "${STATE_BUCKET:-}" "${STATE_PREFIX:-}" noncurrent || true
   exit "${rc}"
 }
 trap cleanup EXIT
@@ -224,5 +245,13 @@ echo "[verify] step 5 ok: state cleared"
 
 # AWS-side orphan auditing is delegated to /run-integ's /cleanup pass.
 
+# --- Teardown VERSION sweep, ON THE SUCCESS PATH ---------------------------
+# `state list` above only proves the CURRENT object is gone; the bucket is
+# VERSIONED, so the templated master password survived in every prior version
+# (issue #2096). The sweep must run HERE and not only in `cleanup`, because
+# `cleanup` does nothing on rc=0 and the line below disarms it anyway.
 trap - EXIT INT TERM
+echo "[verify] step 6: state-version sweep"
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${STATE_PREFIX}" "docdb-neptune state teardown"
 echo "[verify] PASS"

--- a/tests/integration/dynamic-ref-cross-region/verify.sh
+++ b/tests/integration/dynamic-ref-cross-region/verify.sh
@@ -172,72 +172,19 @@ assert_state_lacks() { # usage: assert_state_lacks <stack> <region> <plaintext> 
     exit 1
   fi
 }
-purge_s3_versions() { # usage: purge_s3_versions <key> [noncurrent]
-  # `cdkd bootstrap` enables bucket VERSIONING (src/cli/commands/bootstrap.ts),
-  # so `aws s3 rm` writes a DELETE MARKER and leaves every prior version
-  # readable. Phase 3d deliberately writes a SecureString plaintext into a
-  # state.json, so a run that only `s3 rm`s it leaves a real secret recoverable
-  # in the bucket after a "clean" teardown — the exact class this fixture
-  # exists to test.
-  #
-  # TWO MODES, and picking the wrong one is a live foot-gun rather than a
-  # nicety — the two callers care about DIFFERENT DIMENSIONS of the response:
-  #
-  #   noncurrent  MID-RUN, while the stack is still deployed. Removes the
-  #               historical versions (including the seeded plaintext) and
-  #               MUST leave the current one, which is StackB's LIVE state.
-  #               Delete it and `cdkd destroy` reports "No state found for
-  #               stack ..., skipping", StackB's parameters are never deleted,
-  #               and the teardown assertions fail ~30 minutes in.
-  #   (default)   TEARDOWN, from `cleanup`, when nothing needs the state any
-  #               more. Removes EVERY version and EVERY delete marker. The
-  #               filter must NOT be applied here: after `aws s3 rm` the
-  #               DELETE MARKER is the one carrying `IsLatest: true`, so a
-  #               noncurrent-only sweep would leave it behind forever.
-  #
-  # Two independent query bugs have already been caught here, and each was
-  # invisible to the other's test, which is why both dimensions are now
-  # spelled out. (1) The parenthesisation: `[Versions, DeleteMarkers][][?...]`
-  # returns EMPTY because the flatten projection swallows the filter. (2) The
-  # `IsLatest` axis: the first round validated five responses that all varied
-  # WHICH KEYS came back and none of which varied `IsLatest`, so a query that
-  # deleted the live object passed every one of them. Verified with the AWS
-  # CLI's own jmespath against a post-scrub shape (v3 current / v2 seeded /
-  # v1 original) and a post-`s3 rm` shape (delete marker current).
-  #
-  # `--prefix` matches by prefix, so the `?Key==` filter is what keeps a
-  # sibling key (`state.json.bak`) from being swept too.
-  local key="$1" mode="${2:-all}" filter="" vid versions
-  if [ "${mode}" = "noncurrent" ]; then
-    filter=" && IsLatest==\`false\`"
-  fi
-  # Captured rather than piped so a listing FAILURE is visible: piping into
-  # `while` hides the exit status, and with stderr discarded a transient
-  # throttle would silently purge nothing while the run continued.
-  if ! versions="$(aws s3api list-object-versions --bucket "${STATE_BUCKET}" \
-    --prefix "${key}" \
-    --query "([Versions, DeleteMarkers][])[?Key=='${key}'${filter}].VersionId" \
-    --output text 2>&1)"; then
-    echo "WARN: could not list versions of ${key}: ${versions}" >&2
-    return 0
-  fi
-  # `printf '%s\n'`, NOT `printf '%s'`. Without the trailing newline the final
-  # field has no line terminator, `read` returns non-zero on it, and the `while`
-  # body never runs for the LAST version — so exactly one version survived every
-  # sweep. Measured against real S3: repeated passes took a key from 30 to 1 and
-  # then stopped, which is what a silent off-by-one looks like from outside.
-  # `|| [ -n "${vid}" ]` is the belt to that braces, so a future edit that drops
-  # the newline again cannot reintroduce it.
-  printf '%s\n' "${versions}" | tr '\t' '\n' | while read -r vid || [ -n "${vid}" ]; do
-    [ -n "${vid}" ] || continue
-    [ "${vid}" = "None" ] && continue
-    aws s3api delete-object --bucket "${STATE_BUCKET}" --key "${key}" \
-      --version-id "${vid}" >/dev/null 2>&1 || true
-  done
-}
 # ---------------------------------------------------------------------------
 
 cd "$(dirname "$0")"
+
+# The version-sweep helpers moved to ../s3-versions.sh (issue #2096), where
+# the two traps this fixture's own copy documented -- a trap-only sweep, and the
+# `printf '%s' | tr | while read` that drops the last field -- are written down
+# once instead of once per fixture. The two MODES this file needs are both
+# preserved there: `noncurrent` for the mid-run purge in phase 3d (which must
+# leave StackB's LIVE state alone), and the default full sweep for teardown
+# (which must NOT be noncurrent-only, because after `aws s3 rm` the delete
+# marker is the entry carrying IsLatest==true).
+. ../s3-versions.sh
 
 REGION_A="${AWS_REGION:-us-east-1}"
 REGION_B="${SECOND_REGION:-us-west-2}"
@@ -366,12 +313,12 @@ cleanup() {
     for stack in "${STACK_A}" "${STACK_B}"; do
       aws s3 rm "s3://${STATE_BUCKET}/cdkd/${stack}/${region}/state.json" >/dev/null 2>&1 || true
       aws s3 rm "s3://${STATE_BUCKET}/cdkd/${stack}/${region}/lock.json" >/dev/null 2>&1 || true
-      # ...and purge the NON-CURRENT versions the delete markers above leave
-      # behind. Unconditional rather than only for the seeded key: a destroy
-      # that ran normally still leaves earlier versions, and one of this
-      # fixture's states held a plaintext for part of the run.
-      purge_s3_versions "cdkd/${stack}/${region}/state.json" || true
-      purge_s3_versions "cdkd/${stack}/${region}/lock.json" || true
+      # ...and purge the versions the delete markers above leave behind.
+      # Unconditional rather than only for the seeded key: a destroy that ran
+      # normally still leaves earlier versions, and one of this fixture's states
+      # held a plaintext for part of the run. By PREFIX, so lock.json,
+      # rollback-journal.json and deployments/** go with state.json.
+      s3_purge_prefix_versions "${STATE_BUCKET}" "$(s3_stack_prefix "${stack}" "${region}")" || true
     done
   done
   exit "${rc}"
@@ -632,7 +579,7 @@ assert_state_redacted "${STACK_B}" "${REGION_B}" "${EXPECTED_SECURE_B}"
 # `noncurrent` is load-bearing here — StackB is still DEPLOYED and the current
 # version is its live state.json. Sweeping that too makes Phase 4's destroy
 # skip the stack entirely and Phase 5's leak assertions fail.
-purge_s3_versions "${STATE_KEY_B}" noncurrent || true
+s3_purge_key_versions "${STATE_BUCKET}" "${STATE_KEY_B}" noncurrent || true
 echo "    OK: scrub classified region B's SecureString against region B (issue #1957)"
 
 echo "==> Phase 4: destroy both stacks"
@@ -681,21 +628,26 @@ assert_gone "mixed-type source parameter still exists in ${REGION_A}" \
 assert_gone "mixed-type source parameter still exists in ${REGION_B}" \
   aws ssm get-parameter --name "${MIXED_PARAM}" --region "${REGION_B}"
 
-# The version sweep lives in `cleanup`, and `cleanup` runs from the TRAP — which
-# the line below disarms. So on the SUCCESS path, the normal one, it never ran:
-# every run left its state/lock versions behind (measured: 30 accumulated on one
-# key before this was noticed, and a fresh run added 6 more). The seeded
-# plaintext itself was never among them — phase 3d's `noncurrent` purge runs
-# inline and was verified to leave zero versions containing it — so this is
-# litter rather than a disclosure. It is still worth sweeping: a fixture that
-# claims a clean teardown should have one, and a bucket that accumulates a
-# stack's history makes the next run's leak assertions harder to read.
+# --- Teardown VERSION sweep, ON THE SUCCESS PATH ---------------------------
+# `cleanup` also sweeps, but `cleanup` runs from the TRAP — which the line below
+# disarms — so on the SUCCESS path, the normal one, it never runs at all. Every
+# run therefore used to leave its state/lock versions behind (measured: 30
+# accumulated on one key before this was noticed, and a fresh run added 6 more).
+# The seeded plaintext itself was never among them — phase 3d's `noncurrent`
+# purge runs inline and was verified to leave zero versions containing it — so
+# for THIS fixture the residue is litter rather than a disclosure. It is the
+# same defect either way, and on the sibling fixtures issue #2096 covers it WAS
+# a disclosure, so the shape is identical: sweep here, then assert.
+trap - EXIT INT TERM
 for region in "${REGION_A}" "${REGION_B}"; do
   for stack in "${STACK_A}" "${STACK_B}"; do
-    purge_s3_versions "cdkd/${stack}/${region}/state.json" || true
-    purge_s3_versions "cdkd/${stack}/${region}/lock.json" || true
+    prefix="$(s3_stack_prefix "${stack}" "${region}")"
+    s3_purge_prefix_versions "${STATE_BUCKET}" "${prefix}" all || true
+    # ASSERT rather than assume. The sweep above used to run with nothing
+    # checking it, which is how issue #2096's sibling fixtures kept hundreds of
+    # versions while every run reported a clean teardown.
+    s3_assert_versions_swept "${STATE_BUCKET}" "${prefix}" "dynamic-ref-cross-region ${stack} (${region}) state teardown"
   done
 done
 
-trap - EXIT INT TERM
 echo "PASS: dynamic-ref-cross-region"

--- a/tests/integration/dynamic-ref-cross-region/verify.sh
+++ b/tests/integration/dynamic-ref-cross-region/verify.sh
@@ -314,11 +314,20 @@ cleanup() {
       aws s3 rm "s3://${STATE_BUCKET}/cdkd/${stack}/${region}/state.json" >/dev/null 2>&1 || true
       aws s3 rm "s3://${STATE_BUCKET}/cdkd/${stack}/${region}/lock.json" >/dev/null 2>&1 || true
       # ...and purge the versions the delete markers above leave behind.
-      # Unconditional rather than only for the seeded key: a destroy that ran
-      # normally still leaves earlier versions, and one of this fixture's states
-      # held a plaintext for part of the run. By PREFIX, so lock.json,
-      # rollback-journal.json and deployments/** go with state.json.
-      s3_purge_prefix_versions "${STATE_BUCKET}" "$(s3_stack_prefix "${stack}" "${region}")" || true
+      # Unconditional across KEYS rather than only the seeded one: a destroy
+      # that ran normally still leaves earlier versions, and one of this
+      # fixture's states held a plaintext for part of the run. By PREFIX, so
+      # lock.json, rollback-journal.json and deployments/** go with state.json.
+      #
+      # NONCURRENT, per the contract in ../s3-versions.sh. `cleanup` runs from
+      # the failure and signal traps too, and this fixture's `destroy` above is
+      # `|| true` -- so when it failed, StackA/StackB resources are still
+      # standing and the CURRENT state.json is the only thing a follow-up
+      # `cdkd state destroy` can work from. The pre-fix code defaulted to `all`
+      # here (inherited from this file's own helper, which is where the shared
+      # one came from) and would have erased it. The full sweep happens on the
+      # success path below, where destroy has been asserted.
+      s3_purge_prefix_versions "${STATE_BUCKET}" "$(s3_stack_prefix "${stack}" "${region}")" noncurrent || true
     done
   done
   exit "${rc}"

--- a/tests/integration/eventbridge-api-destination/verify.sh
+++ b/tests/integration/eventbridge-api-destination/verify.sh
@@ -53,9 +53,19 @@ assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-ve
 # ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
+# Shared S3 VERSION-sweep helpers (issue #2096). The fixture stack declares the
+# Connection's API key with `unsafePlainText`, so that value lands in the
+# Connection's own state properties. The state bucket is VERSIONED, so
+# `aws s3 rm` only writes a delete marker -- measured 2026-08-20, 15 of 18
+# surviving versions of this stack's state.json carried `cdkd-integ-api-key`.
+. ../s3-versions.sh
+
 STACK="CdkdEventbridgeApiDestinationExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
+# Everything this stack owns in the bucket: state.json, lock.json,
+# rollback-journal.json and deployments/**.
+STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
 CONN="cdkdeventbridgeapidestinationexample-conn"
 DEST="cdkdeventbridgeapidestinationexample-dest"
 RULE="cdkdeventbridgeapidestinationexample-rule"
@@ -78,6 +88,10 @@ cleanup() {
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1 || true
+    # The `aws s3 rm` above only wrote DELETE MARKERS. NONCURRENT-only here:
+    # this also runs from the pre-run sweep and the failure traps, where a live
+    # state.json may be the only record of resources still standing.
+    s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX:-}" noncurrent || true
   fi
   set -eu
 }
@@ -130,5 +144,15 @@ assert_gone "Rule ${RULE} still exists after destroy" aws events describe-rule -
 echo "    Connection / ApiDestination / Rule deleted"
 assert_gone "state file still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    cdkd state removed"
+
+# --- Teardown + VERSION sweep, ON THE SUCCESS PATH -------------------------
+# head-object only looks at the CURRENT object; the bucket is VERSIONED, so the
+# templated API key survives in prior versions without this (issue #2096). On
+# the success path, not only in `cleanup`, and asserted rather than assumed.
+echo "==> Final teardown + state-version sweep"
+cleanup
+trap - EXIT INT TERM
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${STATE_PREFIX}" "eventbridge-api-destination state teardown"
 
 echo "[verify] PASS — Connection Arn / ApiDestination Arn GetAtt enrichment works end-to-end, 2 phases passed"

--- a/tests/integration/iam-access-key/verify.sh
+++ b/tests/integration/iam-access-key/verify.sh
@@ -58,9 +58,20 @@ assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-ve
 
 cd "$(dirname "$0")"
 
+# Shared S3 VERSION-sweep helpers (issue #2096). This fixture asserts that the
+# create-time IAM SecretAccessKey is CACHED in state `attributes` -- so a real,
+# usable AWS credential is in every state.json this fixture writes, by design.
+# The state bucket is VERSIONED, so `aws s3 rm` only writes a delete marker and
+# each of those credentials stays readable via GetObjectVersion long after the
+# IAM user that owned it was deleted.
+. ../s3-versions.sh
+
 STACK="CdkdIamAccessKeyExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
+# Everything this stack owns in the bucket: state.json, lock.json,
+# rollback-journal.json and deployments/**.
+STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
 
 USER_NAME="cdkd-iam-access-key-user"
 SECRET_NAME="cdkd-iam-access-key-secret"
@@ -86,6 +97,13 @@ cleanup() {
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1 || true
+    # The `aws s3 rm` above only wrote DELETE MARKERS, leaving the cached
+    # SecretAccessKey readable in every prior version. Purge them
+    # NONCURRENT-only here: this function also runs from the pre-run sweep and
+    # from the failure/INT/TERM traps, where a live state.json may still be the
+    # only record of resources that are standing. The success path does the
+    # full sweep and asserts the count is zero.
+    s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX:-}" noncurrent || true
   fi
   # Direct sweep in case state-based teardown could not run: every access key
   # on the fixture user, then the user, then the secret (force, no recovery
@@ -238,5 +256,17 @@ assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after des
   aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
+# --- Teardown + VERSION sweep, ON THE SUCCESS PATH -------------------------
+# head-object above only looks at the CURRENT object. The bucket is VERSIONED
+# (issue #2096), so without this the cached SecretAccessKey survives the run in
+# every prior version. The sweep runs HERE, on the normal path, and not only in
+# `cleanup` -- a trap-only sweep never runs on a fixture that disarms its trap
+# -- and it ASSERTS zero rather than assuming it worked.
+echo "==> Final teardown + state-version sweep"
+cleanup
+trap - EXIT INT TERM
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${STATE_PREFIX}" "iam-access-key state teardown"
+
 echo ""
-echo "==> iam-access-key test passed (create + in-place Status update + secret preservation + clean destroy)"
+echo "==> iam-access-key test passed (create + in-place Status update + secret preservation + clean destroy + zero surviving state versions)"

--- a/tests/integration/lambda-esm-self-managed-kafka/verify.sh
+++ b/tests/integration/lambda-esm-self-managed-kafka/verify.sh
@@ -61,9 +61,18 @@ assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-ve
 # ---------------------------------------------------------------------------
 cd "$(dirname "$0")"
 
+# Shared S3 VERSION-sweep helpers (issue #2096). The fixture stack declares its
+# SASL/SCRAM secret with `unsafePlainText`, so those placeholder credentials sit
+# in that resource's own state properties by construction. The state bucket is
+# VERSIONED, so `aws s3 rm` only writes a delete marker and they stay readable.
+. ../s3-versions.sh
+
 STACK="CdkdLambdaEsmSelfManagedKafkaExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
+# Everything this stack owns in the bucket: state.json, lock.json,
+# rollback-journal.json and deployments/**.
+STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
 FN="${STACK}-fn"
 SECRET="${STACK}-kafka-auth"
 EXPECTED_BROKERS="b-1.cdkd-integ.example.com:9092 b-2.cdkd-integ.example.com:9092"
@@ -87,6 +96,10 @@ cleanup() {
   if [ -n "${STATE_BUCKET:-}" ]; then
     aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1 || true
+    # The `aws s3 rm` above only wrote DELETE MARKERS. NONCURRENT-only here:
+    # this runs from the pre-run sweep and the failure traps too, where a live
+    # state.json may be the only record of resources still standing.
+    s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX:-}" noncurrent || true
   fi
   set -eu
 }
@@ -254,5 +267,16 @@ echo "    OK: secret gone"
 assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state gone"
 
+# --- Teardown + VERSION sweep, ON THE SUCCESS PATH -------------------------
+# head-object only looks at the CURRENT object; the bucket is VERSIONED, so the
+# placeholder SASL credentials survive in prior versions without this (issue
+# #2096). On the success path, not only in `cleanup`, and asserted rather than
+# assumed.
+echo "==> Final teardown + state-version sweep"
+cleanup
+trap - EXIT INT TERM
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${STATE_PREFIX}" "lambda-esm-self-managed-kafka state teardown"
+
 echo ""
-echo "==> lambda-esm-self-managed-kafka test passed (issue #1384 closed + clean destroy)"
+echo "==> lambda-esm-self-managed-kafka test passed (issue #1384 closed + clean destroy + zero surviving state versions)"

--- a/tests/integration/s3-versions.sh
+++ b/tests/integration/s3-versions.sh
@@ -175,9 +175,20 @@ _s3v_key_query() {
 # failures, so any non-empty `Errors` in the output is a per-object failure the
 # call itself reported as overall success. Surfaced as a WARN rather than
 # swallowed: the caller retries, and the zero-assertion is the backstop.
+#
+# `--output json` is PINNED, and that is load-bearing rather than tidy. This
+# function greps the response for `"Errors"`, which is a JSON spelling. The AWS
+# CLI's output format is ambient - `AWS_DEFAULT_OUTPUT=text`, or `output = text`
+# / `output = yaml` in the active profile - so without the flag the same failure
+# arrives as `ERRORS<TAB>...` or `Errors:`, the case never matches, and a
+# per-object delete failure is swallowed with no WARN at all. On the success
+# path the zero-assertion would still catch the under-sweep; from `cleanup` it
+# would not, because that purges `noncurrent` and asserts nothing. `_s3v_rows`
+# pins `--output text` for the same reason: neither reader may inherit a format
+# it does not parse.
 _s3v_flush_batch() {
   local bucket="$1" objects="$2" out
-  if ! out="$(aws s3api delete-objects --bucket "${bucket}" \
+  if ! out="$(aws s3api delete-objects --bucket "${bucket}" --output json \
       --delete "{\"Objects\":[${objects}],\"Quiet\":true}" 2>&1)"; then
     echo "WARN: s3-versions: delete-objects batch failed on s3://${bucket}: ${out}" >&2
     return 1

--- a/tests/integration/s3-versions.sh
+++ b/tests/integration/s3-versions.sh
@@ -1,0 +1,267 @@
+# s3-versions.sh - shared S3 VERSION-sweep helpers for cdkd integ fixtures.
+#
+# Source it from a verify.sh, after the `cd "$(dirname "$0")"` that puts the
+# shell in the fixture directory:
+#
+#     . ../s3-versions.sh
+#
+# IT IS A FLAT FILE, NOT `lib/s3-versions.sh`, AND THAT IS DELIBERATE. Three
+# generators enumerate `tests/integration/*` and treat every DIRECTORY there as
+# a fixture (`listFixtures` in scripts/build-{integ,cli-flag,scenario}-coverage-
+# matrix.ts skips only dot-prefixed names), so a `lib/` directory silently
+# becomes a 283rd "fixture" in all three committed coverage matrices. A plain
+# file is ignored by all of them with no exclusion list to keep in sync. If a
+# second shared helper ever justifies a directory, teach those three
+# `listFixtures` to require a fixture marker (cdk.json / bin) first.
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# `cdkd bootstrap` turns VERSIONING ON for the state bucket
+# (src/cli/commands/bootstrap.ts). On a versioned bucket `aws s3 rm` writes a
+# DELETE MARKER; it does not remove content. So a fixture can destroy its
+# stack, assert `head-object` reports the state file gone, exit 0 - and leave
+# every byte it ever wrote into state.json readable forever to anyone with
+# `s3:GetObjectVersion`.
+#
+# For most fixtures that is litter. For a fixture that puts a KNOWN SECRET
+# PLAINTEXT into state - `unsafePlainText` in its own template, a literal
+# `masterUserPassword`, an IAM `SecretAccessKey` cached in `attributes`, or a
+# deliberately seeded pre-GHSA record - it is a disclosure that outlives the
+# run. Measured on 2026-08-20 for issue #2096, immediately after two GREEN
+# runs that both asserted "state file is gone":
+#
+#   cdkd/CdkdSecretsDynamicRefExample/us-east-1/state.json  304 versions + 43 markers
+#                                                           carrying cdkd-known-pw-123
+#   cdkd/CdkdSecretsArrayNestedExample/us-east-1/state.json   7 versions + 3 markers,
+#                                                           5 of the 7 carrying
+#                                                           cdkd-array-nested-pw-789
+#
+# Both fixtures "passed" every time. Nothing in either script had ever issued
+# a `list-object-versions` or a `delete-object --version-id`.
+#
+# THE THREE TRAPS THIS FILE EXISTS TO MAKE UNREPEATABLE
+# ----------------------------------------------------
+# Each one produces a SILENT PARTIAL sweep - the run still exits 0, and the
+# script still reads as if it cleaned up. All three were observed live.
+#
+#   1. Sweeping only from the EXIT trap. A fixture that ends with
+#      `trap - EXIT INT TERM` disarms the trap on the success path, so a
+#      trap-only sweep runs on the FAILURE path and never on the normal one.
+#      One key had reached 30 versions that way (2026-08-19).
+#      => Callers must sweep on the SUCCESS path too, and ASSERT.
+#
+#   2. Iterating with `printf '%s' | tr | while read`. `out=$(aws ...)` strips
+#      the trailing newline, so the final field has no terminator, `read`
+#      returns non-zero on it, and the loop body never runs for the LAST
+#      version. Verified against real S3 on 2026-08-20: on a key holding one
+#      version, the broken form saw 0 of 1; on a 347-entry listing it swept
+#      346. Repeated passes take a key to 1 and then stop - which is what a
+#      silent off-by-one looks like from outside.
+#      => `printf '%s\n'` plus `|| [ -n "${key}" ]`, both, below.
+#
+#   3. Counting with `length(...)` under `--output text`. The AWS CLI applies
+#      `--query` PER PAGE and concatenates, so a >1000-entry listing prints
+#      one number per page: measured `1000\n189`, not `1189`. `[ "$n" -ne 0 ]`
+#      on that is a bash syntax error, not a count.
+#      => Count ROWS of a `[Key,VersionId]` projection instead (page-safe:
+#      the pages concatenate into one row stream). Never use `length()` here.
+#
+# Auto-pagination itself is fine and is relied upon: with `--page-size 50`
+# forced over the same 347-entry key the row stream still carried all 347
+# ids, all unique. Do NOT add `--max-items` (it truncates).
+#
+# QUERY SHAPE
+# -----------
+# `([Versions, DeleteMarkers][])[...]` - the parentheses are load-bearing.
+# `[Versions, DeleteMarkers][][?...]` returns EMPTY, because the flatten
+# projection swallows the filter. Both forms were run against the real
+# bucket; the unparenthesised one reported 0 where the parenthesised one
+# reported 347.
+#
+# All four query variants below were executed against real S3 on 2026-08-20
+# over a 1189-entry (multi-page) prefix:
+#   all         1189
+#   noncurrent  1064
+#   latest-only  125   (1064 + 125 == 1189: the IsLatest axis really does
+#                       partition the response, so `noncurrent` is not a no-op)
+
+# --- internals --------------------------------------------------------------
+
+# _s3v_check_prefix <prefix> - refuse anything that is not a single stack's
+# own key space. This is a SAFETY guard, not a style check: these helpers are
+# called from `cleanup`, which runs under `set +eu`, so an unset `STACK` would
+# otherwise expand to an over-broad prefix and the sweep would delete other
+# stacks' LIVE state - including a concurrent lane's. `""` (whole bucket) is
+# the worst case and is the one this makes impossible.
+_s3v_check_prefix() {
+  local prefix="$1" rest stack region
+  case "${prefix}" in
+    */) ;;
+    *) echo "FAIL: s3-versions: prefix must end in '/' (got '${prefix}')" >&2; return 1 ;;
+  esac
+  rest="${prefix#cdkd/}"
+  if [ "${rest}" = "${prefix}" ]; then
+    echo "FAIL: s3-versions: prefix must start with 'cdkd/' (got '${prefix}')" >&2
+    return 1
+  fi
+  stack="${rest%%/*}"
+  rest="${rest#*/}"
+  region="${rest%%/*}"
+  if [ -z "${stack}" ] || [ -z "${region}" ]; then
+    echo "FAIL: s3-versions: refusing to sweep '${prefix}' - stack and region segments must both be non-empty" >&2
+    return 1
+  fi
+  return 0
+}
+
+# _s3v_rows <bucket> <prefix|key> <query> - echo "<key><TAB><versionId>" rows.
+# Returns 1 (with a WARN) when the LIST ITSELF failed. Captured rather than
+# piped on purpose: piping into `while` hides the exit status, so a transient
+# throttle would look exactly like "there is nothing here" and the sweep would
+# purge nothing while the run carried on.
+_s3v_rows() {
+  local bucket="$1" scope="$2" query="$3" rows
+  if ! rows="$(aws s3api list-object-versions --bucket "${bucket}" \
+      --prefix "${scope}" --query "${query}" --output text 2>&1)"; then
+    echo "WARN: s3-versions: could not list versions under s3://${bucket}/${scope}: ${rows}" >&2
+    return 1
+  fi
+  [ -n "${rows}" ] || return 0
+  printf '%s\n' "${rows}"
+  return 0
+}
+
+# _s3v_prefix_query [noncurrent] - JMESPath for the prefix-scoped listing.
+_s3v_prefix_query() {
+  if [ "${1:-all}" = "noncurrent" ]; then
+    printf '%s' '([Versions, DeleteMarkers][])[?IsLatest==`false`][].[Key,VersionId]'
+  else
+    printf '%s' '([Versions, DeleteMarkers][])[].[Key,VersionId]'
+  fi
+}
+
+# _s3v_key_query <key> [noncurrent] - JMESPath for an EXACT-key listing.
+# `--prefix` matches by prefix, so the `?Key==` term is what stops a sibling
+# key (`state.json.bak`, `state.json.tmp`) from being swept along with it.
+_s3v_key_query() {
+  if [ "${2:-all}" = "noncurrent" ]; then
+    printf '%s' "([Versions, DeleteMarkers][])[?Key=='$1' && IsLatest==\`false\`][].[Key,VersionId]"
+  else
+    printf '%s' "([Versions, DeleteMarkers][])[?Key=='$1'][].[Key,VersionId]"
+  fi
+}
+
+# _s3v_delete_rows <bucket> - read "<key><TAB><versionId>" rows on stdin and
+# delete each. See trap 2 above for why the caller must feed this with
+# `printf '%s\n'` and why the `|| [ -n "${key}" ]` guard is here as well.
+_s3v_delete_rows() {
+  local bucket="$1" key vid
+  while IFS=$'\t' read -r key vid || [ -n "${key}" ]; do
+    if [ -z "${key}" ] || [ -z "${vid}" ]; then continue; fi
+    if [ "${vid}" = "None" ]; then continue; fi
+    aws s3api delete-object --bucket "${bucket}" --key "${key}" \
+      --version-id "${vid}" >/dev/null 2>&1 || true
+  done
+}
+
+# --- public API -------------------------------------------------------------
+
+# s3_stack_prefix <stack> <region> - the key space one cdkd stack owns.
+# Covers state.json, lock.json, rollback-journal.json and deployments/**; the
+# trailing '/' is what keeps `CdkdFoo` from matching `CdkdFooBar`.
+s3_stack_prefix() {
+  printf 'cdkd/%s/%s/\n' "${1:-}" "${2:-}"
+}
+
+# s3_purge_prefix_versions <bucket> <prefix> [noncurrent]
+#
+# Best-effort: never aborts its caller, because it runs inside `cleanup`.
+# Proof that it worked is `s3_assert_versions_swept`, not this function's
+# exit code.
+#
+# MODE matters, and picking the wrong one is a live foot-gun:
+#   noncurrent  Safe on ANY path, including a FAILED run: it leaves whatever
+#               is CURRENT alone, so a live state.json that a later
+#               `cdkd state destroy` still needs survives, while the
+#               historical versions (where a seeded plaintext lives) go.
+#               Use this from `cleanup`, which cannot know whether the run
+#               failed with resources still standing.
+#   all         Removes every version AND every delete marker. Only correct
+#               once nothing needs the state any more - i.e. on the SUCCESS
+#               path, after destroy has been asserted. It must NOT be
+#               filtered to noncurrent there: after `aws s3 rm` the DELETE
+#               MARKER is the entry carrying IsLatest==true, so a
+#               noncurrent-only sweep would leave one marker per key behind
+#               forever and the zero-assertion would never pass.
+#
+# The retry loop is insurance against any future truncation of the listing:
+# a sweep that is only ever measured by its own listing cannot tell "I am
+# done" from "I was handed a short page". It exits as soon as a pass sees
+# nothing, so the normal cost is one extra LIST.
+s3_purge_prefix_versions() {
+  local bucket="$1" prefix="$2" mode="${3:-all}" query pass rows
+  [ -n "${bucket}" ] || return 0
+  _s3v_check_prefix "${prefix}" || return 1
+  query="$(_s3v_prefix_query "${mode}")"
+  for pass in 1 2 3 4 5; do
+    rows="$(_s3v_rows "${bucket}" "${prefix}" "${query}")" || return 1
+    [ -n "${rows}" ] || return 0
+    printf '%s\n' "${rows}" | _s3v_delete_rows "${bucket}"
+  done
+  return 0
+}
+
+# s3_purge_key_versions <bucket> <key> [noncurrent] - same, scoped to ONE key.
+# Use when the sweep runs MID-RUN and a sibling key under the same prefix must
+# survive.
+s3_purge_key_versions() {
+  local bucket="$1" key="$2" mode="${3:-all}" query pass rows
+  [ -n "${bucket}" ] || return 0
+  if [ -z "${key}" ]; then
+    echo "FAIL: s3-versions: s3_purge_key_versions needs a key" >&2
+    return 1
+  fi
+  query="$(_s3v_key_query "${key}" "${mode}")"
+  for pass in 1 2 3 4 5; do
+    rows="$(_s3v_rows "${bucket}" "${key}" "${query}")" || return 1
+    [ -n "${rows}" ] || return 0
+    printf '%s\n' "${rows}" | _s3v_delete_rows "${bucket}"
+  done
+  return 0
+}
+
+# s3_count_versions <bucket> <prefix> [noncurrent] - print the number of
+# surviving versions + delete markers. Returns 1 if the LIST failed, so a
+# caller can tell "zero" from "could not tell" (the same tri-state the
+# gone_probe helpers use). Counts ROWS, never `length()` - see trap 3.
+s3_count_versions() {
+  local bucket="$1" prefix="$2" mode="${3:-all}" rows
+  rows="$(_s3v_rows "${bucket}" "${prefix}" "$(_s3v_prefix_query "${mode}")")" || return 1
+  printf '%s\n' "${rows}" | awk 'NF{n++} END{print n+0}'
+  return 0
+}
+
+# s3_assert_versions_swept <bucket> <prefix> [description]
+#
+# HARD-FAILS the run when anything survives. This is the point of the file:
+# issue #2096 regressed silently precisely because the fixtures asserted on
+# the CURRENT object ("state file is gone") and never on what the bucket
+# still held. A sweep with no assertion is indistinguishable from no sweep.
+# Call it on the SUCCESS path, as the LAST thing that looks at the bucket.
+s3_assert_versions_swept() {
+  local bucket="$1" prefix="$2" desc="${3:-state teardown}" n
+  if ! n="$(s3_count_versions "${bucket}" "${prefix}")"; then
+    echo "FAIL: ${desc}: could not list object versions under s3://${bucket}/${prefix}." >&2
+    echo "      An unverified sweep is not a clean teardown - failing rather than assuming." >&2
+    exit 1
+  fi
+  if [ "${n}" -ne 0 ]; then
+    echo "FAIL: ${desc}: ${n} object version(s)/delete marker(s) survive under s3://${bucket}/${prefix}." >&2
+    echo "      The state bucket is VERSIONED, so 'aws s3 rm' only wrote a delete marker: everything" >&2
+    echo "      this fixture ever put in state - including any seeded secret plaintext - is still" >&2
+    echo "      readable via GetObjectVersion. Inspect with:" >&2
+    echo "        aws s3api list-object-versions --bucket ${bucket} --prefix ${prefix}" >&2
+    exit 1
+  fi
+  echo "    OK: ${desc}: 0 surviving object versions under s3://${bucket}/${prefix}"
+}

--- a/tests/integration/s3-versions.sh
+++ b/tests/integration/s3-versions.sh
@@ -119,11 +119,30 @@ _s3v_check_prefix() {
 # piped on purpose: piping into `while` hides the exit status, so a transient
 # throttle would look exactly like "there is nothing here" and the sweep would
 # purge nothing while the run carried on.
+#
+# stderr goes to its own file, NOT `2>&1`. Merging them puts any benign CLI
+# warning INTO THE ROW STREAM, where it becomes a phantom row: the count then
+# reports a surviving version on an empty bucket (assertion fails for no
+# reason), and the delete path hands that warning text to
+# `delete-object --key`. The message is still wanted for the WARN, hence the
+# temp file rather than `2>/dev/null`.
 _s3v_rows() {
-  local bucket="$1" scope="$2" query="$3" rows
-  if ! rows="$(aws s3api list-object-versions --bucket "${bucket}" \
-      --prefix "${scope}" --query "${query}" --output text 2>&1)"; then
-    echo "WARN: s3-versions: could not list versions under s3://${bucket}/${scope}: ${rows}" >&2
+  local bucket="$1" scope="$2" query="$3" rows err errfile rc
+  errfile="$(mktemp 2>/dev/null)" || errfile=""
+  if [ -n "${errfile}" ]; then
+    rows="$(aws s3api list-object-versions --bucket "${bucket}" \
+      --prefix "${scope}" --query "${query}" --output text 2>"${errfile}")"
+    rc=$?
+    err="$(cat "${errfile}" 2>/dev/null)"
+    rm -f "${errfile}"
+  else
+    rows="$(aws s3api list-object-versions --bucket "${bucket}" \
+      --prefix "${scope}" --query "${query}" --output text 2>/dev/null)"
+    rc=$?
+    err="<stderr unavailable: mktemp failed>"
+  fi
+  if [ "${rc}" -ne 0 ]; then
+    echo "WARN: s3-versions: could not list versions under s3://${bucket}/${scope}: ${err}" >&2
     return 1
   fi
   [ -n "${rows}" ] || return 0
@@ -151,17 +170,67 @@ _s3v_key_query() {
   fi
 }
 
+# _s3v_flush_batch <bucket> <objects-json-body> - one DeleteObjects call.
+# `Quiet: true` makes a fully successful call return `{}` and list ONLY the
+# failures, so any non-empty `Errors` in the output is a per-object failure the
+# call itself reported as overall success. Surfaced as a WARN rather than
+# swallowed: the caller retries, and the zero-assertion is the backstop.
+_s3v_flush_batch() {
+  local bucket="$1" objects="$2" out
+  if ! out="$(aws s3api delete-objects --bucket "${bucket}" \
+      --delete "{\"Objects\":[${objects}],\"Quiet\":true}" 2>&1)"; then
+    echo "WARN: s3-versions: delete-objects batch failed on s3://${bucket}: ${out}" >&2
+    return 1
+  fi
+  case "${out}" in
+    *'"Errors"'*)
+      echo "WARN: s3-versions: delete-objects reported per-object errors: ${out}" >&2
+      return 1
+      ;;
+  esac
+  return 0
+}
+
 # _s3v_delete_rows <bucket> - read "<key><TAB><versionId>" rows on stdin and
-# delete each. See trap 2 above for why the caller must feed this with
+# delete them in DeleteObjects batches of 1000 (the API maximum). Batched
+# rather than one `delete-object` per version because a single 347-version key
+# then costs 1 CLI process instead of 347; a real sweep of 455 objects went
+# from 455 calls to 7.
+#
+# See trap 2 in the header for why the caller must feed this with
 # `printf '%s\n'` and why the `|| [ -n "${key}" ]` guard is here as well.
+#
+# The payload is assembled by hand rather than through `jq`, so that sourcing
+# this file does not add a `jq` dependency to ten fixtures. That is safe for
+# cdkd's key space (stack names, regions, ISO timestamps, hashes) but not for
+# arbitrary text, so a key or version id carrying a quote or a backslash is
+# routed to a single-object `delete-object` instead of being interpolated into
+# JSON. A TAB or a NEWLINE cannot reach here at all - either would have split
+# the row before this point.
 _s3v_delete_rows() {
-  local bucket="$1" key vid
+  local bucket="$1" key vid objects="" n=0
   while IFS=$'\t' read -r key vid || [ -n "${key}" ]; do
     if [ -z "${key}" ] || [ -z "${vid}" ]; then continue; fi
     if [ "${vid}" = "None" ]; then continue; fi
-    aws s3api delete-object --bucket "${bucket}" --key "${key}" \
-      --version-id "${vid}" >/dev/null 2>&1 || true
+    case "${key}${vid}" in
+      *'"'* | *'\'*)
+        aws s3api delete-object --bucket "${bucket}" --key "${key}" \
+          --version-id "${vid}" >/dev/null 2>&1 || true
+        continue
+        ;;
+    esac
+    objects="${objects}${objects:+,}{\"Key\":\"${key}\",\"VersionId\":\"${vid}\"}"
+    n=$((n + 1))
+    if [ "${n}" -ge 1000 ]; then
+      _s3v_flush_batch "${bucket}" "${objects}" || true
+      objects=""
+      n=0
+    fi
   done
+  if [ "${n}" -gt 0 ]; then
+    _s3v_flush_batch "${bucket}" "${objects}" || true
+  fi
+  return 0
 }
 
 # --- public API -------------------------------------------------------------
@@ -231,11 +300,20 @@ s3_purge_key_versions() {
 }
 
 # s3_count_versions <bucket> <prefix> [noncurrent] - print the number of
-# surviving versions + delete markers. Returns 1 if the LIST failed, so a
-# caller can tell "zero" from "could not tell" (the same tri-state the
-# gone_probe helpers use). Counts ROWS, never `length()` - see trap 3.
+# surviving versions + delete markers. Returns 1 if the prefix is malformed OR
+# the LIST failed, so a caller can tell "zero" from "could not tell" (the same
+# tri-state the gone_probe helpers use). Counts ROWS, never `length()` - trap 3.
+#
+# The prefix check is NOT only a purge-path concern, even though nothing here
+# deletes. `cdkd///` lists nothing, so without it this returns a truthful 0 for
+# a prefix that names no stack, and `s3_assert_versions_swept` below then
+# announces a clean teardown for a bucket it never really looked at. Every
+# caller wraps the PURGE in `|| true`, so a mis-derived prefix would print the
+# purge's refusal to stderr and still let the run PASS - which is precisely the
+# vacuous green this file exists to remove.
 s3_count_versions() {
   local bucket="$1" prefix="$2" mode="${3:-all}" rows
+  _s3v_check_prefix "${prefix}" || return 1
   rows="$(_s3v_rows "${bucket}" "${prefix}" "$(_s3v_prefix_query "${mode}")")" || return 1
   printf '%s\n' "${rows}" | awk 'NF{n++} END{print n+0}'
   return 0
@@ -250,6 +328,14 @@ s3_count_versions() {
 # Call it on the SUCCESS path, as the LAST thing that looks at the bucket.
 s3_assert_versions_swept() {
   local bucket="$1" prefix="$2" desc="${3:-state teardown}" n
+  # Checked HERE as well as inside s3_count_versions, so the failure names the
+  # assertion's own description rather than surfacing as a bare helper WARN.
+  if ! _s3v_check_prefix "${prefix}"; then
+    echo "FAIL: ${desc}: refusing to certify a teardown against the malformed prefix '${prefix}'." >&2
+    echo "      A prefix that names no stack lists nothing, so the count would be a truthful 0" >&2
+    echo "      about the wrong key space - a vacuous pass, which is the failure this assertion exists to catch." >&2
+    exit 1
+  fi
   if ! n="$(s3_count_versions "${bucket}" "${prefix}")"; then
     echo "FAIL: ${desc}: could not list object versions under s3://${bucket}/${prefix}." >&2
     echo "      An unverified sweep is not a clean teardown - failing rather than assuming." >&2

--- a/tests/integration/s3-versions.sh
+++ b/tests/integration/s3-versions.sh
@@ -212,21 +212,27 @@ _s3v_flush_batch() {
 # `printf '%s\n'` and why the `|| [ -n "${key}" ]` guard is here as well.
 #
 # The payload is assembled by hand rather than through `jq`, so that sourcing
-# this file does not add a `jq` dependency to ten fixtures. That is safe for
+# this file does not add a `jq` dependency to twelve fixtures. That is safe for
 # cdkd's key space (stack names, regions, ISO timestamps, hashes) but not for
 # arbitrary text, so a key or version id carrying a quote or a backslash is
 # routed to a single-object `delete-object` instead of being interpolated into
 # JSON. A TAB or a NEWLINE cannot reach here at all - either would have split
 # the row before this point.
 _s3v_delete_rows() {
-  local bucket="$1" key vid objects="" n=0
+  local bucket="$1" key vid objects="" n=0 _s3v_out
   while IFS=$'\t' read -r key vid || [ -n "${key}" ]; do
     if [ -z "${key}" ] || [ -z "${vid}" ]; then continue; fi
     if [ "${vid}" = "None" ]; then continue; fi
     case "${key}${vid}" in
       *'"'* | *'\'*)
-        aws s3api delete-object --bucket "${bucket}" --key "${key}" \
-          --version-id "${vid}" >/dev/null 2>&1 || true
+        # WARN on failure rather than `|| true`. This is the only single-object
+        # call left, it is unreachable for cdkd's key shapes, and that is
+        # exactly why it would stay silent forever if it ever did fire -- in a
+        # file whose whole premise is that a quiet sweep is the bug.
+        if ! _s3v_out="$(aws s3api delete-object --bucket "${bucket}" --key "${key}" \
+            --version-id "${vid}" --output json 2>&1)"; then
+          echo "WARN: s3-versions: single-object delete failed for a quoted key under s3://${bucket}: ${_s3v_out}" >&2
+        fi
         continue
         ;;
     esac
@@ -247,8 +253,36 @@ _s3v_delete_rows() {
 # --- public API -------------------------------------------------------------
 
 # s3_stack_prefix <stack> <region> - the key space one cdkd stack owns.
-# Covers state.json, lock.json, rollback-journal.json and deployments/**; the
-# trailing '/' is what keeps `CdkdFoo` from matching `CdkdFooBar`.
+#
+# WHY A PREFIX AND NOT A LIST OF KEYS. Sweeping `state.json` by name is the
+# obvious first instinct and it UNDER-SWEEPS, because the plaintext is not only
+# there. Under one prefix cdkd writes at least four things:
+#
+#   state.json             the record everyone thinks of
+#   rollback-journal.json  failedOperations[].attemptedProperties - the
+#                          PROPERTIES OF THE FAILED WRITE, verbatim. Measured
+#                          2026-08-20 on CdkdDeletionPolicySnapshotHeavyExample:
+#                          four versions carrying a literal
+#                          `"MasterUserPassword": "Cdkdcf2f..."`. A per-key
+#                          sweep of state.json leaves every one of them.
+#   lock.json              no secret, but it accumulates faster than anything
+#                          else (452 versions on one key)
+#   deployments/**         the event store; sampled clean of plaintext, and its
+#                          objects are NOT delete-markered by `cdkd destroy`,
+#                          so they survive as CURRENT objects
+#
+# So the prefix form is the whole point of this helper, not a convenience: a
+# reviewer's manual remediation swept state.json by name and left the journal
+# behind, which is the mistake this comment exists to stop repeating.
+#
+# The trailing '/' is what keeps `CdkdFoo` from matching `CdkdFooBar`.
+#
+# BLIND SPOT, stated because it is invisible from here: a NESTED STACK child
+# lives at `cdkd/<Parent>~<Child>/<region>/`, which is a SIBLING prefix, not a
+# descendant of the parent's. This sweep does not reach it. No fixture in the
+# swept set creates one today (verified), so it is not a live gap - but a
+# fixture that gains a nested stack must sweep the child prefix too. Tracked
+# with the wider fixture-tree work in issue #2107.
 s3_stack_prefix() {
   printf 'cdkd/%s/%s/\n' "${1:-}" "${2:-}"
 }

--- a/tests/integration/secrets-array-nested/verify.sh
+++ b/tests/integration/secrets-array-nested/verify.sh
@@ -75,9 +75,22 @@ assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-ve
 
 cd "$(dirname "$0")"
 
+# Shared S3 VERSION-sweep helpers (issue #2096). This fixture's own template
+# declares the secret with `unsafePlainText`, so EXPECTED_PASSWORD lands in
+# that resource's own state properties by construction -- the no-plaintext
+# assertions below are deliberately scoped to the CONSUMER record for exactly
+# that reason. The state bucket is VERSIONED, so `aws s3 rm` only writes a
+# delete marker and that plaintext stays readable via GetObjectVersion.
+# Measured 2026-08-20: 5 of the 7 surviving versions of this stack's state.json
+# carried cdkd-array-nested-pw-789, after runs that all exited 0.
+. ../s3-versions.sh
+
 STACK="CdkdSecretsArrayNestedExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
+# Everything this stack owns in the bucket: state.json, lock.json,
+# rollback-journal.json and deployments/**.
+STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
 SECRET_NAME="cdkd-test-array-secret-${ACCOUNT_ID}"
@@ -172,6 +185,11 @@ cleanup() {
       aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1
     fi
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1
+    # The `aws s3 rm` above only wrote DELETE MARKERS. Purge the versions they
+    # hide, NONCURRENT-only: this function also runs from the pre-run sweep and
+    # from the failure/INT/TERM traps, where a live state.json may be the only
+    # record of resources still standing. The success path does the full sweep.
+    s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX:-}" noncurrent || true
   fi
   set -eu
 }
@@ -609,5 +627,17 @@ echo "    OK: out-of-band token-shaped secret is gone"
 
 assert_gone "state file ${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
+
+# --- Teardown + VERSION sweep, ON THE SUCCESS PATH -------------------------
+# head-object only looks at the CURRENT object; the bucket is VERSIONED, so
+# this fixture was green for months while its seeded password stayed readable
+# in every prior version (issue #2096). The sweep runs HERE, on the normal
+# path, not only in `cleanup` -- a trap-only sweep never runs on a run that
+# disarms its trap, and asserting nothing is how this regressed silently.
+echo "==> Final teardown + state-version sweep"
+cleanup
+trap - EXIT INT TERM
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${STATE_PREFIX}" "secrets-array-nested state teardown"
 
 echo "[verify] PASS — an array-nested secret is redacted in observedProperties on the UNCHANGED-resource path (issue #1915), a token-shaped secret plaintext is redacted on both the template-sourced and same-generation rows (issue #1917), non-secret siblings untouched, clean destroy"

--- a/tests/integration/secrets-dynamic-ref/verify.sh
+++ b/tests/integration/secrets-dynamic-ref/verify.sh
@@ -96,9 +96,22 @@ assert_gone() { # usage: assert_gone "<leak description>" aws <service> <read-ve
 
 cd "$(dirname "$0")"
 
+# Shared S3 VERSION-sweep helpers (issue #2096). The state bucket is
+# VERSIONED, so `aws s3 rm` only writes a delete marker and every state.json
+# this fixture wrote -- including the pre-GHSA records it SEEDS with the
+# plaintext password on purpose -- stays readable via GetObjectVersion after a
+# green run. See the file header for the three traps that make a sweep
+# silently partial.
+. ../s3-versions.sh
+
 STACK="CdkdSecretsDynamicRefExample"
 REGION="${AWS_REGION:-us-east-1}"
 STATE_KEY="cdkd/${STACK}/${REGION}/state.json"
+# Everything this stack owns in the bucket: state.json, lock.json,
+# rollback-journal.json and deployments/**. Swept as one prefix so a key added
+# later cannot be forgotten; the trailing '/' is what keeps a sibling stack
+# whose name merely starts the same out of it.
+STATE_PREFIX="$(s3_stack_prefix "${STACK}" "${REGION}")"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
 SECRET_NAME="cdkd-test-dynref-secret-${ACCOUNT_ID}"
@@ -185,6 +198,13 @@ cleanup() {
       aws s3 rm "s3://${STATE_BUCKET}/${STATE_KEY}" >/dev/null 2>&1 || true
     fi
     aws s3 rm "s3://${STATE_BUCKET}/cdkd/${STACK}/${REGION}/lock.json" >/dev/null 2>&1 || true
+    # The `aws s3 rm` above only wrote DELETE MARKERS. Purge the versions they
+    # hide, NONCURRENT-only: this same function runs from the pre-run sweep and
+    # from the failure/INT/TERM traps, where a live state.json may still be the
+    # only record of resources that are still standing -- deleting it would
+    # strand them. The success path below does the full sweep, once destroy has
+    # been asserted, and that is where the zero-assertion lives.
+    s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX:-}" noncurrent || true
   fi
   set -eu
 }
@@ -1513,5 +1533,21 @@ echo "    OK: out-of-band SecureString parameter is gone"
 assert_gone "state file s3://${STATE_BUCKET}/${STATE_KEY} still exists after destroy" aws s3api head-object --bucket "${STATE_BUCKET}" --key "${STATE_KEY}"
 echo "    OK: state file is gone"
 
+# --- Teardown + VERSION sweep, ON THE SUCCESS PATH -------------------------
+# "state file is gone" above is a head-object on the CURRENT object, and that
+# is exactly the assertion that let issue #2096 stand: the bucket is VERSIONED,
+# so it was green while 304 versions of this key still carried
+# cdkd-known-pw-123. The sweep therefore runs HERE, on the normal path, and not
+# only in `cleanup` -- a fixture that disarms its trap on success never runs a
+# trap-only cleanup, which is how a sibling key reached 30 versions on
+# 2026-08-19. `cleanup` is invoked explicitly first (it force-deletes the
+# secret and drops the state/lock objects), then the trap is disarmed so
+# nothing can write a new delete marker after the count is taken.
+echo "==> Final teardown + state-version sweep"
+cleanup
+trap - EXIT INT TERM
+s3_purge_prefix_versions "${STATE_BUCKET}" "${STATE_PREFIX}" all || true
+s3_assert_versions_swept "${STATE_BUCKET}" "${STATE_PREFIX}" "secrets-dynamic-ref state teardown"
+
 echo ""
-echo "==> secrets-dynamic-ref test passed (dynamic references resolved correctly + clean destroy)"
+echo "==> secrets-dynamic-ref test passed (dynamic references resolved correctly + clean destroy + zero surviving state versions)"

--- a/tests/unit/scripts/integ-aws-commands.test.ts
+++ b/tests/unit/scripts/integ-aws-commands.test.ts
@@ -391,6 +391,14 @@ describe('integ fixture aws invocations (#1402)', () => {
   it('parses a substantial share of the fixture tree', () => {
     const stats = collectStats();
     expect(stats.fixtures).toBeGreaterThan(150);
+    // Per-SHAPE floor for the shared helpers: an aggregate over 280 fixtures
+    // cannot tell "the helper is clean" from "the helper was never read", and
+    // it is the one script whose aws verbs run in seven fixtures at once.
+    const scanned = readFixtureScripts(INTEG_ROOT);
+    const helper = scanned.find((f) => f.fixture === 's3-versions.sh');
+    expect(helper, 'tests/integration/s3-versions.sh is not being scanned').toBeDefined();
+    expect(helper?.content).toContain('aws s3api list-object-versions');
+    expect(helper?.content).toContain('aws s3api delete-objects');
     // Current: 3022 invocations (3002 before the `nlb-source-nat` fixture of
     // issue #1619 added 20; 2635 when these floors were written — the comment
     // had not been refreshed as the tree grew, which is how the ceiling below

--- a/tests/unit/scripts/integ-aws-commands.test.ts
+++ b/tests/unit/scripts/integ-aws-commands.test.ts
@@ -414,7 +414,7 @@ describe('integ fixture aws invocations (#1402)', () => {
     expect(stats.fixtures).toBeGreaterThan(150);
     // Per-SHAPE floor for the shared helpers: an aggregate over 280 fixtures
     // cannot tell "the helper is clean" from "the helper was never read", and
-    // it is the one script whose aws verbs run in ten fixtures at once.
+    // it is the one script whose aws verbs run in twelve fixtures at once.
     const scanned = readFixtureScripts(INTEG_ROOT);
     const helper = scanned.find((f) => f.fixture === 's3-versions.sh');
     expect(helper, 'tests/integration/s3-versions.sh is not being scanned').toBeDefined();

--- a/tests/unit/scripts/integ-aws-commands.test.ts
+++ b/tests/unit/scripts/integ-aws-commands.test.ts
@@ -378,6 +378,27 @@ describe('lintScriptAwsCommands', () => {
 });
 
 describe('integ fixture aws invocations (#1402)', () => {
+  it('the violation path is right for BOTH shapes the walk now returns', () => {
+    // The walk was widened to include shared helpers that sit directly in
+    // tests/integration/ (issue #2096), which arrive with `fixture` set to a
+    // FILE name. A hardcoded `${fixture}/verify.sh` therefore reported the
+    // nonexistent path `tests/integration/s3-versions.sh/verify.sh` — wrong for
+    // exactly the file the walk was widened to reach, i.e. guaranteed wrong the
+    // first time it was ever needed. Nothing violates today, so only a direct
+    // assertion on the formatter can hold this.
+    const at = (fixture: string): string =>
+      formatAwsCommandViolation({
+        fixture,
+        line: 42,
+        service: 'emr',
+        verb: 'list-instance-groups',
+        raw: 'aws emr list-instance-groups --cluster-id j-X',
+      });
+    expect(at('lambda')).toContain('tests/integration/lambda/verify.sh:42');
+    expect(at('s3-versions.sh')).toContain('tests/integration/s3-versions.sh:42');
+    expect(at('s3-versions.sh')).not.toContain('s3-versions.sh/verify.sh');
+  });
+
   it('no fixture calls a command the AWS CLI removed', () => {
     const violations = lintFixtureTreeAwsCommands(INTEG_ROOT, TABLE);
     expect(violations.map(formatAwsCommandViolation).join('\n\n')).toBe('');
@@ -393,7 +414,7 @@ describe('integ fixture aws invocations (#1402)', () => {
     expect(stats.fixtures).toBeGreaterThan(150);
     // Per-SHAPE floor for the shared helpers: an aggregate over 280 fixtures
     // cannot tell "the helper is clean" from "the helper was never read", and
-    // it is the one script whose aws verbs run in seven fixtures at once.
+    // it is the one script whose aws verbs run in ten fixtures at once.
     const scanned = readFixtureScripts(INTEG_ROOT);
     const helper = scanned.find((f) => f.fixture === 's3-versions.sh');
     expect(helper, 'tests/integration/s3-versions.sh is not being scanned').toBeDefined();

--- a/tests/unit/scripts/integ-s3-versions-helper.test.ts
+++ b/tests/unit/scripts/integ-s3-versions-helper.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vite-plus/test';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/**
+ * Executable checks for `tests/integration/s3-versions.sh`, the shared version
+ * sweep every secret-seeding fixture now depends on (issue #2096).
+ *
+ * WHY THIS FILE EXISTS, narrowly. The helper's OTHER behaviours (paging, the
+ * trailing-newline iteration, the mode split) need a stand-in for the AWS CLI's
+ * `--query` / `--output text` semantics to exercise, which is its own piece of
+ * infrastructure and is tracked separately in issue #2106. What is pinned HERE
+ * is the one class that needs no AWS at all and is the most dangerous:
+ *
+ *   A MALFORMED PREFIX MUST NEVER PRODUCE A PASS.
+ *
+ * `cdkd///` names no stack, so S3 lists nothing for it and a count of 0 is
+ * TRUE — about the wrong key space. The assertion originally trusted that 0 and
+ * announced a clean teardown. Combined with every caller wrapping the purge in
+ * `|| true`, a mis-derived `STATE_PREFIX` printed a refusal to stderr and the
+ * fixture still exited 0 with the plaintext intact: the exact vacuous green the
+ * whole PR exists to remove, reintroduced inside the assertion meant to prevent
+ * it. Caught in review, 2026-08-20.
+ *
+ * Every case asserts the guard fired BEFORE any AWS call, by putting a fake
+ * `aws` on PATH that records its own invocation. "It returned non-zero" is not
+ * enough: a helper that called S3 and then failed for an unrelated reason would
+ * satisfy a bare exit-code check while still leaking a request per bad prefix.
+ */
+
+const HELPER = join(import.meta.dirname, '../../../tests/integration/s3-versions.sh');
+
+let sandbox: string;
+let fakeBin: string;
+let marker: string;
+
+beforeAll(() => {
+  sandbox = mkdtempSync(join(tmpdir(), 'cdkd-s3v-'));
+  fakeBin = join(sandbox, 'bin');
+  marker = join(sandbox, 'aws-was-called');
+  execFileSync('mkdir', ['-p', fakeBin]);
+  // A fake `aws` that RECORDS the call and then fails, so a helper that reaches
+  // it is both detectable and unable to fabricate a listing.
+  const fake = join(fakeBin, 'aws');
+  writeFileSync(
+    fake,
+    ['#!/bin/sh', `echo "$@" >> "${marker}"`, 'echo "fake aws: refusing" >&2', 'exit 255', ''].join(
+      '\n'
+    )
+  );
+  chmodSync(fake, 0o755);
+});
+
+afterAll(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+interface Run {
+  readonly status: number;
+  readonly stderr: string;
+  readonly stdout: string;
+  readonly awsCalled: boolean;
+}
+
+/**
+ * Source the helper under bash and run one snippet against the fake `aws`.
+ *
+ * `spawnSync`, not `execFileSync`: the latter THROWS on a non-zero exit, so the
+ * success and failure paths would be read differently and a snippet ending in
+ * `echo "rc=$?"` (exit 0, stderr non-empty) would lose its stderr entirely.
+ * Every case here cares about the exit code AND the message AND whether the AWS
+ * CLI was reached, so all three are always captured the same way.
+ */
+function run(snippet: string): Run {
+  if (existsSync(marker)) rmSync(marker);
+  const script = [
+    'set -uo pipefail',
+    `. ${JSON.stringify(HELPER)}`,
+    'BUCKET=cdkd-state-000000000000',
+    snippet,
+  ].join('\n');
+  // PATH puts the fake FIRST; the real directories stay so `mktemp` / `awk`
+  // remain available, which is what makes "aws was never called" meaningful
+  // rather than an artefact of a stripped environment.
+  const res = spawnSync('/bin/bash', ['-c', script], {
+    env: { ...process.env, PATH: `${fakeBin}:/usr/bin:/bin` },
+    encoding: 'utf8',
+  });
+  return {
+    status: res.status ?? -1,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+    awsCalled: existsSync(marker),
+  };
+}
+
+/**
+ * Prefixes that must never be certified. Each is a real way `STATE_PREFIX` can
+ * come out wrong: `cleanup` runs under `set +eu`, so an unset `STACK` or
+ * `REGION` expands to empty rather than aborting.
+ */
+const MALFORMED = [
+  ['', 'empty — would scope to the WHOLE bucket'],
+  ['cdkd/', 'bucket-wide cdkd prefix — every stack, including other lanes'],
+  ['cdkd///', 'both segments empty (unset STACK and REGION)'],
+  ['cdkd//us-east-1/', 'empty stack segment (unset STACK)'],
+  ['cdkd/CdkdFoo//', 'empty region segment (unset REGION)'],
+  ['cdkd/CdkdFoo/us-east-1', 'no trailing slash — would also match CdkdFooBar'],
+  ['/cdkd/CdkdFoo/us-east-1/', 'leading slash — not a cdkd key'],
+  ['other/CdkdFoo/us-east-1/', 'not under cdkd/'],
+] as const;
+
+describe('tests/integration/s3-versions.sh prefix guard', () => {
+  it('finds the helper it claims to test', () => {
+    // Without this the whole suite would pass by sourcing nothing.
+    expect(existsSync(HELPER)).toBe(true);
+    const body = readFileSync(HELPER, 'utf8');
+    expect(body).toContain('s3_assert_versions_swept()');
+    expect(body).toContain('_s3v_check_prefix()');
+  });
+
+  it('the fake aws records a call when it IS reached (positive control)', () => {
+    // Proves `awsCalled` can be true — otherwise every "aws was not called"
+    // assertion below would hold vacuously.
+    const r = run(
+      's3_assert_versions_swept "$BUCKET" "cdkd/CdkdFoo/us-east-1/" "well-formed"'
+    );
+    expect(r.awsCalled).toBe(true);
+    expect(r.status).toBe(1);
+    // A listing that could not be read must FAIL, never read as "zero".
+    expect(r.stderr).toContain('could not list object versions');
+    expect(r.stderr).not.toContain('0 surviving object versions');
+  });
+
+  for (const [prefix, why] of MALFORMED) {
+    it(`s3_assert_versions_swept REFUSES ${JSON.stringify(prefix)} (${why})`, () => {
+      const r = run(
+        `s3_assert_versions_swept "$BUCKET" ${JSON.stringify(prefix)} "probe"`
+      );
+      expect(r.status).toBe(1);
+      expect(r.stdout).not.toContain('OK:');
+      expect(r.stderr).toContain('malformed prefix');
+      expect(r.awsCalled).toBe(false);
+    });
+
+    it(`s3_count_versions REFUSES ${JSON.stringify(prefix)}`, () => {
+      const r = run(
+        `s3_count_versions "$BUCKET" ${JSON.stringify(prefix)}; echo "rc=$?"`
+      );
+      // A refusal must not print a count anyone could read as zero.
+      expect(r.stdout.trim()).toBe('rc=1');
+      expect(r.awsCalled).toBe(false);
+    });
+
+    it(`s3_purge_prefix_versions REFUSES ${JSON.stringify(prefix)}`, () => {
+      const r = run(
+        `s3_purge_prefix_versions "$BUCKET" ${JSON.stringify(prefix)} all; echo "rc=$?"`
+      );
+      expect(r.stdout.trim()).toBe('rc=1');
+      expect(r.awsCalled).toBe(false);
+    });
+  }
+
+  it('s3_stack_prefix produces a prefix the guard ACCEPTS (round trip)', () => {
+    // The negative cases above are only meaningful if the shipped constructor
+    // clears the same bar — a guard that rejected everything would pass them.
+    const r = run('s3_stack_prefix CdkdSecretsDynamicRefExample us-east-1');
+    expect(r.stdout.trim()).toBe('cdkd/CdkdSecretsDynamicRefExample/us-east-1/');
+    const accepted = run(
+      's3_count_versions "$BUCKET" "$(s3_stack_prefix CdkdFoo us-east-1)"; echo "rc=$?"'
+    );
+    // rc is still 1 — but from the FAKE AWS, not the guard, and the call happened.
+    expect(accepted.awsCalled).toBe(true);
+    expect(accepted.stderr).toContain('could not list versions');
+  });
+});

--- a/tests/unit/scripts/integ-secret-fixture-sweep.test.ts
+++ b/tests/unit/scripts/integ-secret-fixture-sweep.test.ts
@@ -13,7 +13,20 @@ import { join } from 'node:path';
  * since issue #2096, and `tests/integration/s3-versions.sh` implements it.
  *
  * WHY THIS IS A LINT AND NOT ANOTHER SENTENCE. The #2096 audit was done by
- * hand, against every fixture's `verify.sh`, and it still missed three:
+ * hand, against every fixture's `verify.sh`, and it still missed five. Three
+ * were found by a reviewer reading sources, and two more — `appsync` and
+ * `apigw-usage-plan-key` — had actually been EXAMINED by that audit and cleared
+ * on a bad measurement: a newest-N sample of their surviving state versions.
+ * That sampling shape is wrong for this question and the numbers say why. Of
+ * `AppSyncStack`'s 557 versions the 12 newest carried no key while 17 of
+ * versions 12..45 did; `apigw-usage-plan-key`'s key sits in versions 7 and 8 of
+ * 16. The newest versions come from the most recent run, which is the most
+ * likely to be already-fixed or to have failed early. **Sample across the
+ * range, or grep the whole key.** The same error, in its other form — probing a
+ * convention-derived stack name and reading the resulting `0` as clean — cost a
+ * separate finding in the same session; read `STACK=` out of `verify.sh`.
+ *
+ * The three found by reading sources were:
  * `docdb-neptune`, `eventbridge-api-destination` and `cognito-resource-server`
  * — each an exact structural twin of one the audit DID find (a master password,
  * an `unsafePlainText` literal, and a service-generated credential
@@ -43,11 +56,28 @@ import { join } from 'node:path';
  *     reveals that. It sources the helper anyway, so it is not a violation —
  *     but it would not have been CAUGHT.
  *  3. Service-generated credentials with no marker in the source at all.
- *     `generateSecret: true` and `iam.AccessKey` are the two shapes known to
- *     cache a credential cdkd never saw in the template; a future provider that
- *     caches some other credential attribute would be invisible here. Cognito's
- *     `ClientSecret` was exactly this class and was found by grepping the
- *     BUCKET, not the source.
+ *     `generateSecret: true`, `iam.AccessKey`, `appsync.CfnApiKey` and
+ *     `addApiKey` are the shapes known to cache a credential cdkd never saw in
+ *     the template; a future provider that caches some other credential
+ *     attribute would be invisible here. Cognito's `ClientSecret` was exactly
+ *     this class and was found by grepping the BUCKET, not the source.
+ *
+ *     Note that grepping `src/provisioning/providers/**` is NOT a substitute:
+ *     `AWS::ApiGateway::ApiKey` is registered to no provider at all, so it takes
+ *     the generic Cloud Control readback, whose resource model includes `Value`
+ *     — the live 40-character key, landing in `attributes` with no provider
+ *     code ever naming it.
+ *
+ *  4. Keys OTHER than `state.json` under the same prefix. The helper sweeps the
+ *     whole `cdkd/<stack>/<region>/` prefix precisely because
+ *     `rollback-journal.json` carries `failedOperations[].attemptedProperties`
+ *     — the properties of the failed write, verbatim, including a literal
+ *     `MasterUserPassword` in four measured versions. This lint only checks
+ *     that a fixture sweeps; the PREFIX form is what makes the sweep sufficient.
+ *
+ *  5. A NESTED-STACK child, at `cdkd/<Parent>~<Child>/<region>/`, which is a
+ *     sibling prefix rather than a descendant. No fixture in the swept set has
+ *     one today; tracked with issue #2107.
  *
  * So the honest backstop is still the per-fixture `s3_assert_versions_swept`
  * plus periodic bucket inspection. This lint closes the class that has actually
@@ -63,20 +93,43 @@ interface Pattern {
   readonly re: RegExp;
   /**
    * How many fixtures this must still match. A FLOOR per pattern, not one
-   * aggregate: five patterns summing to "at least 9" would let a regex that
-   * silently stopped matching hide behind the other four. Set to today's exact
+   * aggregate: patterns summing to "at least 11" would let a regex that
+   * silently stopped matching hide behind the others. Set to today's exact
    * count — raise it when a fixture is added, never lower it to make a red test
    * green.
+   *
+   * MAY be 0, for a shape no fixture uses yet. A zero floor proves nothing on
+   * its own, which is why `sample` below is mandatory rather than optional: the
+   * positive control is what keeps a forward-looking pattern honest.
    */
   readonly floor: number;
+  /**
+   * A snippet this pattern MUST match. Every pattern carries one and the suite
+   * checks all of them, so the positive control cannot drift out of step with
+   * the pattern list the way a hand-written list of probes does — and a pattern
+   * with `floor: 0` is still executed against real input.
+   */
+  readonly sample: string;
 }
 
 const SECRET_MATERIAL: readonly Pattern[] = [
-  { what: 'SecretValue.unsafePlainText(...) — a literal secret in the template', re: /unsafePlainText/, floor: 5 },
+  {
+    what: 'SecretValue.unsafePlainText(...) — a literal secret in the template',
+    re: /unsafePlainText/,
+    floor: 5,
+    sample: `secretStringValue: cdk.SecretValue.unsafePlainText('x')`,
+  },
+  {
+    what: 'SecretValue.plainText(...) — the deprecated alias, which /unsafePlainText/ does NOT match',
+    re: /SecretValue\.plainText\(/,
+    floor: 0,
+    sample: `value: cdk.SecretValue.plainText('x')`,
+  },
   {
     what: 'a hand-supplied Secret value (secretStringValue / secretObjectValue / secretStringBeta1)',
     re: /secretString(Value|Beta1)|secretObjectValue/,
     floor: 5,
+    sample: 'secretObjectValue: { username: x }',
   },
   {
     what: 'a templated database master password (masterPassword / masterUserPassword)',
@@ -85,11 +138,13 @@ const SECRET_MATERIAL: readonly Pattern[] = [
     // generated password lands in state exactly like a quoted one does.
     re: /master(User)?Password/,
     floor: 2,
+    sample: 'masterUserPassword: password,',
   },
   {
     what: 'generateSecret: true — Cognito mints a client secret that cdkd caches in state',
     re: /generateSecret:\s*true/,
     floor: 1,
+    sample: 'generateSecret: true,',
   },
   {
     what: 'an IAM AccessKey — the provider caches SecretAccessKey in state attributes',
@@ -98,6 +153,34 @@ const SECRET_MATERIAL: readonly Pattern[] = [
     // still cache the credential, and nothing else here would see it.
     re: /iam\.AccessKey\b|AWS::IAM::AccessKey/,
     floor: 1,
+    sample: `new iam.AccessKey(this, 'K', { user })`,
+  },
+  {
+    what: 'an AppSync ApiKey — for AppSync the key ID *is* the credential, and it is the physical id',
+    // `AppSyncProvider.createApiKey` persists `response.apiKey.id` as the
+    // physical id and repeats it in `attributes.ApiKey` plus an `Arn` built
+    // from it (appsync-provider.ts:431-434). Nothing in the fixture's source
+    // looks like a secret; the credential is service-generated.
+    re: /appsync\.CfnApiKey|AWS::AppSync::ApiKey/,
+    floor: 1,
+    sample: `new appsync.CfnApiKey(this, 'ApiKey', { apiId })`,
+  },
+  {
+    what: 'an API Gateway ApiKey — no SDK provider handles it, so the Cloud Control readback stores its Value',
+    // The sub-class that makes grepping `src/provisioning/providers/**` for a
+    // credential insufficient: `AWS::ApiGateway::ApiKey` is not registered to
+    // any provider, so it takes the generic Cloud Control path, whose resource
+    // model includes `Value` — the live 40-character key, in `attributes`, with
+    // no provider code ever naming it.
+    re: /addApiKey\(|AWS::ApiGateway::ApiKey/,
+    floor: 1,
+    sample: `const key = api.addApiKey('Key', { apiKeyName })`,
+  },
+  {
+    what: 'an ElastiCache AuthToken — a literal cache credential in the template',
+    re: /[Aa]uthToken/,
+    floor: 0,
+    sample: 'authToken: cdk.SecretValue.unsafePlainText(pw),',
   },
 ];
 
@@ -183,17 +266,28 @@ describe('a secret-seeding integ fixture must sweep S3 object versions', () => {
     ).toEqual([]);
   });
 
-  it('detects each shape it claims to (positive control)', () => {
-    const probe = (src: string): string[] =>
-      secretShapes({ name: 'probe', sources: src, verify: '' });
-    expect(probe(`secretStringValue: cdk.SecretValue.unsafePlainText('x')`)).toHaveLength(2);
-    expect(probe(`masterUserPassword: password,`)).toHaveLength(1);
-    expect(probe(`masterUserPassword: 'TempPass1234!',`)).toHaveLength(1);
-    expect(probe(`generateSecret: true,`)).toHaveLength(1);
-    expect(probe(`new iam.AccessKey(this, 'K', { user })`)).toHaveLength(1);
-    expect(probe(`secretObjectValue: { username: x }`)).toHaveLength(1);
-    // ...and does not fire on an ordinary stack.
-    expect(probe(`new s3.Bucket(this, 'B', { versioned: true });`)).toEqual([]);
+  it('every pattern matches its own sample, and none fires on an ordinary stack', () => {
+    // Derived from the list rather than hand-listed, so a pattern added later
+    // cannot arrive without a control — the failure mode of the previous
+    // hand-written version. This is also the ONLY thing standing behind a
+    // `floor: 0` pattern.
+    const dead = SECRET_MATERIAL.filter((p) => !p.re.test(p.sample)).map((p) => p.what);
+    expect(dead, 'pattern does not match its own sample').toEqual([]);
+    const benign = `
+      const b = new s3.Bucket(this, 'B', { versioned: true });
+      new lambda.Function(this, 'F', { environment: { TABLE: t.tableName } });
+      new sqs.Queue(this, 'Q', { fifo: true });
+    `;
+    const falsePositives = SECRET_MATERIAL.filter((p) => p.re.test(benign)).map((p) => p.what);
+    expect(falsePositives, 'pattern fires on an ordinary stack').toEqual([]);
+    // ...and the composite the fixtures actually use trips exactly two.
+    expect(
+      secretShapes({
+        name: 'p',
+        sources: `secretStringValue: cdk.SecretValue.unsafePlainText('x')`,
+        verify: '',
+      })
+    ).toHaveLength(2);
   });
 
   it('the source / assertion predicates read CODE, not comments (positive control)', () => {
@@ -216,6 +310,8 @@ describe('a secret-seeding integ fixture must sweep S3 object versions', () => {
     // dropped out while another appeared, and the whole point of #2096's
     // follow-up was that a hand audit produced the wrong SET.
     expect(seeding.map((f) => f.name).sort()).toEqual([
+      'apigw-usage-plan-key',
+      'appsync',
       'cognito-resource-server',
       'cross-stack-secret-import',
       'deletion-policy-snapshot-heavy',

--- a/tests/unit/scripts/integ-secret-fixture-sweep.test.ts
+++ b/tests/unit/scripts/integ-secret-fixture-sweep.test.ts
@@ -26,10 +26,17 @@ import { join } from 'node:path';
  * WHAT THIS CANNOT SEE — stated because a lint that implies completeness is
  * worse than one that names its edges:
  *
- *  1. RAW CloudFormation fixtures. The patterns read `bin/**` and `lib/**`
- *     TypeScript. A fixture whose template is a checked-in `.json` / `.yaml`
- *     (today: `migrate-from-bare-cfn-codegen-only/template-fixture.json`,
- *     verified secret-free) declares its resources somewhere this never looks.
+ *  1. A secret declared as a RAW CloudFormation property, wherever it lives.
+ *     The obvious case is a fixture whose template is a checked-in `.json` /
+ *     `.yaml` (today: `migrate-from-bare-cfn-codegen-only/template-fixture.json`,
+ *     verified secret-free), which these patterns never read. But being written
+ *     in TypeScript is NOT the same as being covered: every pattern below keys
+ *     on an L2 construct prop, so an L1 or an escape hatch slips straight
+ *     through -- `new CfnSecret({ secretString: 'x' })` (the pattern requires
+ *     the `Value` / `Beta1` suffix), `addPropertyOverride('MasterUserPassword',
+ *     ...)`, or a plain literal in a Lambda `environment`. Zero fixtures do this
+ *     today, so nothing here is quietly load-bearing -- but do not read "it is
+ *     .ts" as "it is scanned".
  *  2. Secrets seeded by the SCRIPT rather than the app. `dynamic-ref-cross-region`
  *     writes a SecureString plaintext straight into a state.json with
  *     `aws s3 cp` to simulate a pre-GHSA record. No token in its `lib/*.ts`

--- a/tests/unit/scripts/integ-secret-fixture-sweep.test.ts
+++ b/tests/unit/scripts/integ-secret-fixture-sweep.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * A fixture whose CDK app puts SECRET MATERIAL into state must sweep S3 object
+ * versions on teardown.
+ *
+ * The state bucket is versioned, so `aws s3 rm` writes a delete marker and
+ * removes nothing: every state.json a fixture ever wrote stays readable via
+ * `GetObjectVersion`. For a fixture carrying a real credential that is a
+ * disclosure outliving the run. `.claude/rules/testing.md` has stated the rule
+ * since issue #2096, and `tests/integration/s3-versions.sh` implements it.
+ *
+ * WHY THIS IS A LINT AND NOT ANOTHER SENTENCE. The #2096 audit was done by
+ * hand, against every fixture's `verify.sh`, and it still missed three:
+ * `docdb-neptune`, `eventbridge-api-destination` and `cognito-resource-server`
+ * — each an exact structural twin of one the audit DID find (a master password,
+ * an `unsafePlainText` literal, and a service-generated credential
+ * respectively). All three were then measured holding live plaintext in the
+ * bucket: 16 of 64 versions, 15 of 18, and 3 of 18 carrying a real
+ * `"ClientSecret"`. The audit read `verify.sh`, where the secret is invisible;
+ * the secret is declared in `lib/*.ts`. A human sweep found one of each pair
+ * and missed the other, which is what a mechanism is for.
+ *
+ * WHAT THIS CANNOT SEE — stated because a lint that implies completeness is
+ * worse than one that names its edges:
+ *
+ *  1. RAW CloudFormation fixtures. The patterns read `bin/**` and `lib/**`
+ *     TypeScript. A fixture whose template is a checked-in `.json` / `.yaml`
+ *     (today: `migrate-from-bare-cfn-codegen-only/template-fixture.json`,
+ *     verified secret-free) declares its resources somewhere this never looks.
+ *  2. Secrets seeded by the SCRIPT rather than the app. `dynamic-ref-cross-region`
+ *     writes a SecureString plaintext straight into a state.json with
+ *     `aws s3 cp` to simulate a pre-GHSA record. No token in its `lib/*.ts`
+ *     reveals that. It sources the helper anyway, so it is not a violation —
+ *     but it would not have been CAUGHT.
+ *  3. Service-generated credentials with no marker in the source at all.
+ *     `generateSecret: true` and `iam.AccessKey` are the two shapes known to
+ *     cache a credential cdkd never saw in the template; a future provider that
+ *     caches some other credential attribute would be invisible here. Cognito's
+ *     `ClientSecret` was exactly this class and was found by grepping the
+ *     BUCKET, not the source.
+ *
+ * So the honest backstop is still the per-fixture `s3_assert_versions_swept`
+ * plus periodic bucket inspection. This lint closes the class that has actually
+ * bitten twice: a declared secret in a fixture that forgot to sweep.
+ */
+
+const INTEG_ROOT = join(import.meta.dirname, '../../../tests/integration');
+const HELPER = 's3-versions.sh';
+
+interface Pattern {
+  /** Named in the failure so the fix is obvious without opening this file. */
+  readonly what: string;
+  readonly re: RegExp;
+  /**
+   * How many fixtures this must still match. A FLOOR per pattern, not one
+   * aggregate: five patterns summing to "at least 9" would let a regex that
+   * silently stopped matching hide behind the other four. Set to today's exact
+   * count — raise it when a fixture is added, never lower it to make a red test
+   * green.
+   */
+  readonly floor: number;
+}
+
+const SECRET_MATERIAL: readonly Pattern[] = [
+  { what: 'SecretValue.unsafePlainText(...) — a literal secret in the template', re: /unsafePlainText/, floor: 5 },
+  {
+    what: 'a hand-supplied Secret value (secretStringValue / secretObjectValue / secretStringBeta1)',
+    re: /secretString(Value|Beta1)|secretObjectValue/,
+    floor: 5,
+  },
+  {
+    what: 'a templated database master password (masterPassword / masterUserPassword)',
+    // Deliberately NOT `masterUserPassword:\s*'`: deletion-policy-snapshot-heavy
+    // passes a VARIABLE (`masterUserPassword: password`), and a randomly
+    // generated password lands in state exactly like a quoted one does.
+    re: /master(User)?Password/,
+    floor: 2,
+  },
+  {
+    what: 'generateSecret: true — Cognito mints a client secret that cdkd caches in state',
+    re: /generateSecret:\s*true/,
+    floor: 1,
+  },
+  {
+    what: 'an IAM AccessKey — the provider caches SecretAccessKey in state attributes',
+    // Forward-looking: today's only match also trips `secretStringValue`, but a
+    // fixture that creates an AccessKey WITHOUT wrapping it in a Secret would
+    // still cache the credential, and nothing else here would see it.
+    re: /iam\.AccessKey\b|AWS::IAM::AccessKey/,
+    floor: 1,
+  },
+];
+
+interface Fixture {
+  readonly name: string;
+  readonly sources: string;
+  readonly verify: string | undefined;
+}
+
+function readFixtures(): Fixture[] {
+  return readdirSync(INTEG_ROOT, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => {
+      const dir = join(INTEG_ROOT, e.name);
+      const verifyPath = join(dir, 'verify.sh');
+      return {
+        name: e.name,
+        sources: ['bin', 'lib']
+          .map((sub) => join(dir, sub))
+          .filter((d) => existsSync(d) && statSync(d).isDirectory())
+          .flatMap((d) => readTsRecursive(d))
+          .join('\n'),
+        verify: existsSync(verifyPath) ? readFileSync(verifyPath, 'utf8') : undefined,
+      };
+    });
+}
+
+function readTsRecursive(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) return readTsRecursive(full);
+    return e.isFile() && e.name.endsWith('.ts') ? [readFileSync(full, 'utf8')] : [];
+  });
+}
+
+/** The patterns a fixture's CDK sources trip, if any. */
+function secretShapes(f: Fixture): string[] {
+  return SECRET_MATERIAL.filter((p) => p.re.test(f.sources)).map((p) => p.what);
+}
+
+/**
+ * `verify.sh` with comments stripped.
+ *
+ * A plain `includes('s3-versions.sh')` passes on the COMMENT that explains why
+ * the helper is sourced — which is exactly what every one of these fixtures has
+ * directly above the source line. Deleting the source line and leaving the
+ * comment then reads as compliant. Found by the break-test for this very lint:
+ * removing the `.` line from `docdb-neptune` left the suite GREEN.
+ */
+function codeOf(script: string): string {
+  return script
+    .split('\n')
+    .map((line) => line.replace(/(^|\s)#.*$/, ''))
+    .join('\n');
+}
+
+/** `. ../s3-versions.sh` or `source "${REPO_ROOT}/tests/integration/s3-versions.sh"`. */
+const SOURCES_HELPER = /^[ \t]*(\.|source)[ \t]+.*s3-versions\.sh/m;
+/** The assertion, as a CALL rather than a mention. */
+const CALLS_ASSERTION = /^[^\n]*\bs3_assert_versions_swept[ \t]+\S/m;
+
+describe('a secret-seeding integ fixture must sweep S3 object versions', () => {
+  const fixtures = readFixtures();
+  const seeding = fixtures.filter((f) => secretShapes(f).length > 0);
+
+  it('finds the fixture tree', () => {
+    // Guards the whole suite from passing by scanning nothing.
+    expect(fixtures.length).toBeGreaterThan(250);
+    expect(fixtures.filter((f) => f.sources.length > 0).length).toBeGreaterThan(200);
+  });
+
+  it('each pattern still matches the fixtures it was calibrated against (per-shape floors)', () => {
+    // "found nothing" must not be able to pass as "everything complies".
+    const counts = SECRET_MATERIAL.map((p) => ({
+      what: p.what,
+      floor: p.floor,
+      matched: fixtures.filter((f) => p.re.test(f.sources)).length,
+    }));
+    const starved = counts.filter((c) => c.matched < c.floor);
+    expect(
+      starved.map((c) => `${c.what}: matched ${c.matched}, floor ${c.floor}`),
+      'a pattern stopped matching — it was probably narrowed, not obsoleted'
+    ).toEqual([]);
+  });
+
+  it('detects each shape it claims to (positive control)', () => {
+    const probe = (src: string): string[] =>
+      secretShapes({ name: 'probe', sources: src, verify: '' });
+    expect(probe(`secretStringValue: cdk.SecretValue.unsafePlainText('x')`)).toHaveLength(2);
+    expect(probe(`masterUserPassword: password,`)).toHaveLength(1);
+    expect(probe(`masterUserPassword: 'TempPass1234!',`)).toHaveLength(1);
+    expect(probe(`generateSecret: true,`)).toHaveLength(1);
+    expect(probe(`new iam.AccessKey(this, 'K', { user })`)).toHaveLength(1);
+    expect(probe(`secretObjectValue: { username: x }`)).toHaveLength(1);
+    // ...and does not fire on an ordinary stack.
+    expect(probe(`new s3.Bucket(this, 'B', { versioned: true });`)).toEqual([]);
+  });
+
+  it('the source / assertion predicates read CODE, not comments (positive control)', () => {
+    // The break-test that produced this: deleting the `.` line from a fixture
+    // left the explanatory comment behind, and a substring check stayed green.
+    expect(SOURCES_HELPER.test(codeOf('. ../s3-versions.sh'))).toBe(true);
+    expect(SOURCES_HELPER.test(codeOf('  source "${REPO_ROOT}/tests/integration/s3-versions.sh"'))).toBe(
+      true
+    );
+    expect(SOURCES_HELPER.test(codeOf('# Shared helpers live in ../s3-versions.sh (issue #2096).'))).toBe(
+      false
+    );
+    expect(SOURCES_HELPER.test(codeOf('echo "see ../s3-versions.sh"'))).toBe(false);
+    expect(CALLS_ASSERTION.test(codeOf('s3_assert_versions_swept "$B" "$P" "x"'))).toBe(true);
+    expect(CALLS_ASSERTION.test(codeOf('# then s3_assert_versions_swept runs'))).toBe(false);
+  });
+
+  it('the calibrated seeding set is the one that was audited by hand', () => {
+    // Pinned by NAME, not by count. A count would go on passing if one fixture
+    // dropped out while another appeared, and the whole point of #2096's
+    // follow-up was that a hand audit produced the wrong SET.
+    expect(seeding.map((f) => f.name).sort()).toEqual([
+      'cognito-resource-server',
+      'cross-stack-secret-import',
+      'deletion-policy-snapshot-heavy',
+      'docdb-neptune',
+      'eventbridge-api-destination',
+      'iam-access-key',
+      'lambda-esm-self-managed-kafka',
+      'secrets-array-nested',
+      'secrets-dynamic-ref',
+    ]);
+  });
+
+  it('every secret-seeding fixture has a verify.sh that sources the sweep helper', () => {
+    const violations = seeding.flatMap((f) => {
+      if (f.verify === undefined) {
+        return [
+          `${f.name}: declares secret material (${secretShapes(f).join('; ')}) but has NO verify.sh, ` +
+            `so nothing can sweep its state versions — add one, or move the secret out of the fixture`,
+        ];
+      }
+      if (!SOURCES_HELPER.test(codeOf(f.verify))) {
+        return [
+          `${f.name}/verify.sh: declares secret material (${secretShapes(f).join('; ')}) but never sources ` +
+            `${HELPER}. The state bucket is VERSIONED: 'aws s3 rm' only writes a delete marker, so that ` +
+            `secret stays readable via GetObjectVersion after a green run. See ".claude/rules/testing.md" ` +
+            `-> "verify.sh must sweep S3 OBJECT VERSIONS"`,
+        ];
+      }
+      return [];
+    });
+    expect(violations.sort()).toEqual([]);
+  });
+
+  it('and actually calls the assertion, not just the purge', () => {
+    // Sourcing the helper and purging without asserting is the exact shape that
+    // regressed silently before #2096: a sweep nothing checks.
+    const violations = seeding
+      .filter((f) => f.verify !== undefined && !CALLS_ASSERTION.test(codeOf(f.verify)))
+      .map(
+        (f) =>
+          `${f.name}/verify.sh: sources ${HELPER} but never calls s3_assert_versions_swept — ` +
+          `an unverified sweep is indistinguishable from no sweep`
+      );
+    expect(violations.sort()).toEqual([]);
+  });
+});

--- a/tests/unit/scripts/integ-verify-bash-compat.test.ts
+++ b/tests/unit/scripts/integ-verify-bash-compat.test.ts
@@ -53,11 +53,25 @@ const BASH4_ISMS: readonly Bash4ism[] = [
   },
 ];
 
-/** Every `tests/integration/<name>/verify.sh`, with its source. */
+/**
+ * Every fixture `verify.sh`, plus every SHARED helper sitting directly in
+ * `tests/integration/` (e.g. `s3-versions.sh`, issue #2096, sourced by seven
+ * fixtures).
+ *
+ * The shared helpers are scanned because that is where a bash-4-ism does the
+ * MOST damage while being the least likely to be noticed: the file belongs to
+ * no single fixture, and nobody debugging the fixture that broke would think to
+ * open it.
+ */
 function readVerifyScripts(): { name: string; lines: string[] }[] {
-  return readdirSync(INTEG_ROOT, { withFileTypes: true })
+  const entries = readdirSync(INTEG_ROOT, { withFileTypes: true });
+  const fixtures = entries
     .filter((e) => e.isDirectory())
-    .map((e) => ({ name: e.name, path: join(INTEG_ROOT, e.name, 'verify.sh') }))
+    .map((e) => ({ name: `${e.name}/verify.sh`, path: join(INTEG_ROOT, e.name, 'verify.sh') }));
+  const shared = entries
+    .filter((e) => e.isFile() && e.name.endsWith('.sh'))
+    .map((e) => ({ name: e.name, path: join(INTEG_ROOT, e.name) }));
+  return [...fixtures, ...shared]
     .filter((f) => existsSync(f.path))
     .map((f) => ({ name: f.name, lines: readFileSync(f.path, 'utf8').split('\n') }));
 }
@@ -88,6 +102,14 @@ describe('integ verify.sh scripts stay bash 3.2 compatible', () => {
     expect(scripts.length).toBeGreaterThan(50);
   });
 
+  it('also scans the shared helpers (per-SHAPE floor, not just a total)', () => {
+    // An aggregate floor cannot tell "the shared helper is clean" from "it was
+    // never read": 200+ fixtures swamp one file. Assert the shape separately.
+    const shared = scripts.filter((s) => !s.name.includes('/'));
+    expect(shared.length).toBeGreaterThanOrEqual(1);
+    expect(shared.some((s) => s.name === 's3-versions.sh')).toBe(true);
+  });
+
   it('detects each bash-4-ism it claims to (positive control)', () => {
     // The lint must prove it can SEE its input. Without this, a regex that
     // silently stopped matching would report the tree clean forever.
@@ -108,10 +130,8 @@ describe('integ verify.sh scripts stay bash 3.2 compatible', () => {
     expect(findIsms(['  while IFS= read -r l; do :; done < f'])).toEqual([]);
   });
 
-  it('no fixture uses a bash-4-only construct', () => {
-    const offenders = scripts
-      .flatMap((s) => findIsms(s.lines).map((h) => `${s.name}/verify.sh ${h}`))
-      .sort();
+  it('no fixture or shared helper uses a bash-4-only construct', () => {
+    const offenders = scripts.flatMap((s) => findIsms(s.lines).map((h) => `${s.name} ${h}`)).sort();
     expect(offenders).toEqual([]);
   });
 });

--- a/tests/unit/scripts/integ-verify-bash-compat.test.ts
+++ b/tests/unit/scripts/integ-verify-bash-compat.test.ts
@@ -55,7 +55,7 @@ const BASH4_ISMS: readonly Bash4ism[] = [
 
 /**
  * Every fixture `verify.sh`, plus every SHARED helper sitting directly in
- * `tests/integration/` (e.g. `s3-versions.sh`, issue #2096, sourced by seven
+ * `tests/integration/` (e.g. `s3-versions.sh`, issue #2096, sourced by ten
  * fixtures).
  *
  * The shared helpers are scanned because that is where a bash-4-ism does the
@@ -107,7 +107,13 @@ describe('integ verify.sh scripts stay bash 3.2 compatible', () => {
     // never read": 200+ fixtures swamp one file. Assert the shape separately.
     const shared = scripts.filter((s) => !s.name.includes('/'));
     expect(shared.length).toBeGreaterThanOrEqual(1);
-    expect(shared.some((s) => s.name === 's3-versions.sh')).toBe(true);
+    const helper = shared.find((s) => s.name === 's3-versions.sh');
+    expect(helper).toBeDefined();
+    // ...and that it was READ, not merely LISTED. A path that resolves to an
+    // empty or truncated read scans clean, which is the same vacuous-pass shape
+    // this suite exists to prevent elsewhere.
+    expect(helper?.lines.length ?? 0).toBeGreaterThan(50);
+    expect(helper?.lines.join('\n')).toContain('s3_assert_versions_swept()');
   });
 
   it('detects each bash-4-ism it claims to (positive control)', () => {

--- a/tests/unit/scripts/integ-verify-bash-compat.test.ts
+++ b/tests/unit/scripts/integ-verify-bash-compat.test.ts
@@ -55,7 +55,7 @@ const BASH4_ISMS: readonly Bash4ism[] = [
 
 /**
  * Every fixture `verify.sh`, plus every SHARED helper sitting directly in
- * `tests/integration/` (e.g. `s3-versions.sh`, issue #2096, sourced by ten
+ * `tests/integration/` (e.g. `s3-versions.sh`, issue #2096, sourced by twelve
  * fixtures).
  *
  * The shared helpers are scanned because that is where a bash-4-ism does the


### PR DESCRIPTION
## Summary

The state bucket is VERSIONED, so a fixture's `aws s3 rm` only writes a DELETE MARKER. Every intermediate `state.json` an integ fixture ever wrote stays readable via `GetObjectVersion` — including plaintext a fixture seeds deliberately to simulate a pre-GHSA binary. `verify.sh` asserted "state file is gone" and exited 0 over content that was still there.

Closes #2096

## Measured, not theorised

Twelve fixtures had the gap. The issue named one; an audit of all 282 found six; a review of that audit found three more. Live exposure at the time of measurement:

| fixture | seeded material | surviving versions carrying it |
| --- | --- | --- |
| `iam-access-key` | a live 40-char IAM `SecretAccessKey` + its `AKIA…` id | 8 |
| `docdb-neptune` | `masterUserPassword: 'TempPass1234!'` | 16 of 64 |
| `eventbridge-api-destination` | `unsafePlainText('cdkd-integ-api-key')` | 15 of 18 |
| `secrets-array-nested` | `cdkd-array-nested-pw-789` | 5 of 7 |
| `cognito-resource-server` | a service-generated `ClientSecret` | 3 of 18 |
| `secrets-dynamic-ref` | `cdkd-known-pw-123` | the 304 the issue counted |
| `deletion-policy-snapshot-heavy` | a Redshift master password | had no leak assertion at all |
| `cross-stack-secret-import` | the producer's literal `SecretString` | — |
| `lambda-esm-self-managed-kafka` | `unsafePlainText` | — |
| `dynamic-ref-cross-region` | swept already, but asserted nothing | — |

Two more fixtures were found by review after the table above was written. `appsync`: 17 of 33 versions sampled across the middle of its history carried a literal `da2-` AppSync API key at `resources.ApiKey.attributes.ApiKey`. It was missed on the first pass because the probe sampled only the 6 NEWEST versions, which are clean — a newest-N sample is the wrong shape for this question, since the newest versions come from the most recent run. A range re-check prompted by that miss then found a twelfth, `apigw-usage-plan-key`: 4 of 16 versions carry a 40-character API key at `attributes.Value`.

`apigw-usage-plan-key` carries the more general lesson. `AWS::ApiGateway::ApiKey` is registered to NO provider, so it takes the generic Cloud Control readback — whose resource model includes `Value`. Grepping `src/provisioning/providers/**` for credential handling, the obvious cross-check, would have missed it. For AppSync likewise the key ID *is* the credential, persisted as the physical id by construction.

And the security review named a reader the audit never did: **`rollback-journal.json` is a SIBLING key under the same prefix**, and four of its versions carried a literal `MasterUserPassword`. An initial remediation that swept only `state.json` left those readable.

Every leaked credential was verified dead before being treated as cleanup rather than an incident: the IAM keys belong to deleted users (the only active key in the account is unrelated), the AppSync API is gone, and the Cognito user pool is deleted. All of it has now been swept by PREFIX rather than by key — **2603 objects across 14 stack prefixes**, each re-verified at 0 versions / 0 delete markers, including `state.json`, `lock.json`, `rollback-journal.json` and `deployments/**`.

## What ships

- `tests/integration/s3-versions.sh` — a shared helper: `s3_stack_prefix`, `s3_purge_prefix_versions`, `s3_purge_key_versions`, `s3_count_versions`, `s3_assert_versions_swept`.
- Ten fixtures wired to it: a **noncurrent-only** purge in `cleanup` (a failed run's CURRENT `state.json` may be the only thing a recovery `cdkd state destroy` can use), and a full purge plus a **hard zero-assertion** on the success path, after the trap is disarmed so nothing writes a new delete marker after the count is taken.
- `tests/unit/scripts/integ-secret-fixture-sweep.test.ts` — a lint asserting that any fixture whose `lib/*.ts` declares secret material sources the helper AND calls the assertion. `.claude/rules/testing.md` stated this rule with nothing enforcing it, and the hand audit missing three fixtures is what proves a sentence was not enough.
- `docs/testing.md` and `.claude/rules/testing.md` document the convention.

## Traps this had to survive, each measured on real data

- **`--query` is applied PER PAGE and concatenated.** `length(Versions)` over a 1189-entry prefix prints `1000\n189`, not `1189` — so a `length()`-based count is broken above 1000 and `[ "$n" -ne 0 ]` on it is a bash error, not a count. The helper counts ROWS of a `[Key,VersionId]` projection instead.
- **`printf '%s' | tr | while read` drops the LAST field** for want of a trailing newline. On a real single-version key it saw 0 of 1; on the 1189-entry listing, 1188 of 1189.
- **`--max-items` truncates** (50 → 93 entries) while auto-pagination does not. Only the latter is relied on.
- **`delete-objects` returns rc=0 with `Errors` populated even under `Quiet: true`** — the WARN branch exists for exactly that.
- **A single-needle audit under-reports.** Each fixture spells its own plaintext; a global `cdkd-known-*` grep reported `secrets-array-nested` clean while 5 of its 7 versions carried `cdkd-array-nested-pw-789`. The assertion is therefore on VERSION COUNT ZERO, which is needle-independent.
- **A fixture's stack name is not its directory name.** `cognito-resource-server`'s stack is `CognitoResourceServerStack`; probing the `Cdkd…Example` convention returns a wrong count. Recorded in `.claude/rules/testing.md`.

## Review findings fixed in this PR

Three blockers, all found by review rather than by the lane:

1. `s3_count_versions` / `s3_assert_versions_swept` had **no prefix guard**, so `cdkd///` returned `OK: 0 surviving object versions`, rc=0 — the vacuous pass this PR exists to delete, reintroduced in the assertion meant to prevent it. Guarded, and pinned by 27 tests that assert the CLI is never even reached (a bare exit-code check would pass for a helper that called S3 and then failed for an unrelated reason).
2. `dynamic-ref-cross-region` purged `all` inside `cleanup`, contradicting the contract in three files.
3. The audit missed three fixtures — which is what motivated the lint.

The lint's own first cut shipped broken and its break-test caught it: `includes('s3-versions.sh')` matched the explanatory COMMENT above the `source` line, so deleting the source line left the suite green. Both predicates now read comment-stripped code.

## Test plan

- `vp run test` — 730 files, 14807 tests, no type errors.
- `/run-integ secrets-dynamic-ref` — PASS: 4 deleted / 0 errors, the new assertion reported 0 surviving versions, and that was independently re-verified afterwards (0 versions, 0 delete markers, 0 AWS orphans).
- Break-tests, each driven RED then restored: drop the `source` line keeping the comment; keep the source but drop the assertion; add a new fixture declaring a master password.
- The helper was exercised under macOS `/bin/bash` 3.2 against zero / one / many / page-boundary / throttled-listing / delete-marker-latest cases.

## Follow-ups

- go-to-k/cdkd#2105 — coverage-matrix `listFixtures` counts any directory under `tests/integration/` as a fixture, which is what forced the helper to be a flat file rather than `lib/`.
- go-to-k/cdkd#2106 — the offline harness that verified the helper is not shipped as a repo test.
- go-to-k/cdkd#2107 — the other 272 fixtures still never sweep (litter, not disclosure).
- go-to-k/cdkd#2110 — six scanners each walk the fixture tree privately; two were extended here, four carry a recorded verdict.

Won't-do: adding an `authToken` pattern to the lint — no fixture uses one. The `ApiKey` half of that call was WRONG and is retracted: `appsync` does put key material in state, and it is now a wired fixture with its own lint pattern. The retraction is kept here rather than deleted, because the reason it was wrong (a 6-version newest-N sample) is the reusable lesson.
