### PR TITLE
chore(work-issues): name the three fence-failure shapes the sibling repos found

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -691,9 +691,26 @@ REAL tree rather than by reasoning:
   accept the flag. Deriving it from what declares the option, and making the
   predicate per-READ rather than per-file, is what made both probes fail.
 
-The general shape: **a fence is not evidence until you have watched it go red.**
-Calibration tells you it is not noisy; only the deletion probe tells you it is
-load-bearing.
+  The worst population is one derived from the DEFECT itself, because deleting
+  the required thing then drops the subject OUT of the population instead of
+  failing. Running these probes across the sibling repos on 2026-08-20 found
+  four such fences in one tree (go-to-k/cdk-real-drift#1797): a gate-parity test
+  that selected its gates by `condition.includes('Bash(git commit*)')` stayed
+  green at 7/7 with two gates disarmed outright, and a hook-coverage test that
+  enumerated `*.test.sh` could never report the hook that had no harness — the
+  one every commit passes through. A STATEFUL scanner fails the same way with no
+  OR at all: go-to-k/cdk-local#537's reference scan flipped one `inFence` boolean
+  on any fence marker, so a single nested fence inverted it and muted every check
+  for the rest of the file, silently.
+
+And ask the dumbest question last: **is anything RUNNING it?** The nine hook
+harnesses in go-to-k/cdk-real-drift were shell, so the vitest task never saw
+them, and no CI step invoked them either — they had been exercised only by hand
+since the day each was written.
+
+The general shape: **a fence is not evidence until you have watched it go red on
+something you had not already counted.** Calibration tells you it is not noisy;
+only the spelling and deletion probes tell you it is load-bearing.
 
 You may fan out **one subagent per lane** (disjoint files) to run them
 concurrently — give each agent its worktree path, its allowed files, and an


### PR DESCRIPTION
## Summary

Back-ports what landing go-to-k/cdkd#2112's lesson in the two sibling repos
turned up. The mirror issues (go-to-k/cdk-real-drift#1797,
go-to-k/cdk-local#537) were both worked in one session, and adapting the section
meant running its two probes over each sibling's own fences — which produced
three failure shapes this repo's paragraph does not yet name.

## What the siblings found, and what it adds here

- **A population derived from the DEFECT is the worst kind.** This paragraph
  already says a wrong population breaks the deletion probe, with "mentions
  `options.region`" as the example. The sharper case is a fence that selects its
  subjects BY the pattern it is checking for: go-to-k/cdk-real-drift's gate-parity
  test used `condition.includes('Bash(git commit*)')`, so deleting the required
  form dropped the gate out of the population instead of failing, and two gates
  disarmed outright left it green at 7/7. Four fences of that family were dead in
  that one tree.
- **A STATEFUL scanner fails the same way with no OR at all.**
  go-to-k/cdk-local's reference scan flipped one `inFence` boolean on any fence
  marker, so a single nested fence inverted the state and muted every check for
  the rest of the file — silently, because a scanner that scans nothing reports
  nothing.
- **Ask whether anything RUNS it.** go-to-k/cdk-real-drift's nine hook harnesses
  were shell, so the vitest task never saw them, and no CI step invoked them
  either; they had been exercised by hand only, since the day each was written.

The closing line is amended with the same qualification the siblings carry: a
fence is evidence once it has gone red on something you had NOT already counted.

## Not done here, deliberately

The reference scanner's population is still the one mirrored doc. Widening it to
every skill doc would mean qualifying 46 references across nine skills; extending
it to `.claude/rules/**` — which is not mirrored — would mean 800 more, which the
existing comment correctly calls churn. The case for widening is weaker here than
in the siblings, and it is now covered from the other end: both sibling repos
landed scanners today that cover ALL of their own agent-instruction files, so a
bare reference arriving from a cdkd sentence fails in the repo it arrives in.

## Test plan

- [x] `vp run --no-cache check` — 0 errors
- [x] `vp run build`
- [x] `vp run test`
- [x] `vp test run tests/unit/scripts/work-issues-skill-refs.test.ts` — the fence
      on this file's own references (every added ref uses the qualified
      `owner/repo#N` form)
