### PR TITLE
chore(work-issues): a green fixture is not a working fix, and three fixture mechanics that each cost a real-AWS cycle

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1119,6 +1119,68 @@ conclude the fix is broken.
     its output matches what the text promises. That is §10-c's claim-by-claim pass,
     owed whether or not the text came from a sibling repo.
 
+**A fixture that establishes its precondition on the HAPPY path cannot test the
+arm where the FAILING path creates it — and it stays green while the fix is
+inert.** This is the most expensive shape this flow produces, because every
+signal says pass. On 2026-08-20 the go-to-k/cdkd#2057 lane shipped a refusal that
+could not fire on the deploy that matters: the evidence it keys on
+(`state.imports[]` / `outputReads[]`) was persisted only by the SUCCESS path, so
+a deploy that both INTRODUCES a cross-region read and fails recorded none of it.
+The fixture passed anyway, because its phases established the read with a
+successful deploy first and only then failed one. Unit tests passed, the integ
+passed, four reviewers had read the diff; a fifth found it by tracing the
+evidence rather than the code.
+
+So when a fix keys on state that some earlier step wrote, ask **which step wrote
+it in the fixture, and which step writes it in the reachable case**. If the
+fixture's answer is "an earlier, successful one", add the arm where one operation
+does both — and prove the arm discriminates by mutating the fix and confirming
+the ORIGINAL arm still passes while the new one fails. That asymmetry is the
+whole point: an arm that fails alongside the old one has not shown it reaches
+anything new.
+
+**Three fixture mechanics that each cost a real-AWS cycle on 2026-08-20.** None
+is visible by reading the script, and all three are caught by a stubbed dry run
+in seconds:
+
+- **A `cleanup` that ALSO runs pre-run must not destroy anything the run then
+  needs.** AWS resources are safe because creating them IS a phase; a scratch
+  directory computed at variable-definition time is not. A `WORKDIR="$(mktemp -d
+  …)"` at load time plus an `rm -rf "$WORKDIR"` in `cleanup` plus the usual
+  explicit pre-run `cleanup` call means the directory is gone before its first
+  write, 200 lines from the cause.
+- **Before you wait for a resource to disappear, verify the probe reports
+  "still present" DURING deletion.** `DescribeStateMachine` on a deleting Step
+  Functions machine returns success with `status: DELETING`, so the poll really
+  waits; had it 404'd, the wait would have been vacuous and the fixture would
+  have raced exactly as before. Measure the window too — 23s there — so the
+  budget is a number rather than a guess.
+- **A fixture whose only `cdkd destroy` exits non-zero BY DESIGN cannot honestly
+  flip `integ-destroy`.** A refusal arm is a destroy that reports failure, and
+  out-of-band teardown is not a cdkd destroy at all, so the marker would attest
+  to a clean teardown that never happened. Add a final phase that disables the
+  injection, redeploys, and runs a genuinely clean destroy — that run is the one
+  the gate reads.
+
+**Run the integ AFTER the final rebase, and expect the marker to go stale if you
+do it before.** `integ-destroy` uses markgate's `hash: diff` mode, so it
+invalidates when main merges a change to a file YOUR branch also touches. On
+2026-08-20 the go-to-k/cdkd#2057 lane ran three integs, then rebased onto a peer
+PR that had edited `deploy-engine.ts` — which that lane also edited — and the
+marker correctly went stale, buying a second real-AWS run at merge time. Push
+first so CI starts, then re-run the integ alongside it; the two are independent
+and serializing them wastes the CI wall-clock.
+
+**When two reviewers CONTRADICT each other, settle it in the code yourself
+before forwarding either.** On 2026-08-20 the spec reviewer explicitly CLEARED
+the evidence-persistence issue the security reviewer called a blocker, both
+having read the same lines. The code's own comment settled it in one read
+("persisted only on the final success path"). Forwarding both verdicts to the
+implementing agent would have handed it a contradiction to adjudicate with less
+context than you have — and forwarding only the reassuring one is how a blocker
+ships. Say in the fix message which reviewer was right and why, so the agent
+does not re-derive it.
+
 **Fresh deploys: UNIQUE stack names only** (e.g. `Cdkd<Issue>Verify`), never a
 shared fixed name and never a real prod stack — the account may hold the
 maintainer's production stacks. Tear down with `cdkd destroy … --force`, then SWEEP


### PR DESCRIPTION
## Summary

Section-8 retrospective from the run that shipped #2121 and #2123 (five issues: #2057 / #2054 / #1866 / #1967 / #2079). Five lessons, each with its incident attached. Prose-only, in the step where each fires.

### A green fixture is not a working fix

The expensive one, because every signal said pass. #2121's refusal **could not fire on the deploy that matters**: the evidence it keys on (`state.imports[]` / `outputReads[]`) was persisted only by the SUCCESS path, so a deploy that both INTRODUCES a cross-region read and fails recorded none of it. Unit tests passed, the integ passed, and four reviewers had read the diff — a fifth found it by tracing the evidence rather than the code. The fixture was green because its phases established the read with a successful deploy first.

The rule is stated as the question to ask (which step writes the keyed-on state in the fixture, versus in the reachable case?) plus the asymmetry that proves a new arm reaches something: **mutate the fix and confirm the ORIGINAL arm still passes while the new one fails.** An arm that fails alongside the old one has shown nothing.

### Three fixture mechanics, each of which cost a real-AWS cycle

None is visible by reading the script; all three fall out of a stubbed dry run in seconds.

| mechanic | what happened |
| --- | --- |
| a `cleanup` that also runs pre-run must not destroy what the run needs | a load-time `WORKDIR="$(mktemp -d …)"` + `rm -rf "$WORKDIR"` in `cleanup` + the usual explicit pre-run `cleanup` call = the directory is gone before its first write, 200 lines from the cause |
| verify the wait's probe reports "still present" DURING deletion | `DescribeStateMachine` returns `status: DELETING`, not 404 — which is what makes the poll non-vacuous. Window measured at 23s rather than guessed |
| a fixture whose only `cdkd destroy` exits non-zero BY DESIGN cannot honestly flip `integ-destroy` | a refusal arm is a destroy that reports failure, and out-of-band teardown is not a cdkd destroy at all; the marker would attest to a clean teardown that never happened |

### Two process lessons

- **Run the integ AFTER the final rebase.** `integ-destroy` is `hash: diff`, so it invalidates when main merges a change to a file your branch also touches. This run ran three integs, rebased onto a peer PR that had edited `deploy-engine.ts` — which the lane also edited — and correctly paid for a second real-AWS cycle. Push first so CI starts, then re-run alongside it.
- **When two reviewers contradict each other, settle it in the code yourself before forwarding either.** The spec reviewer explicitly CLEARED what the security reviewer called a blocker, both having read the same lines; the code's own comment settled it in one read. Forwarding both hands the implementing agent a contradiction to adjudicate with less context than the orchestrator has, and forwarding only the reassuring one is how a blocker ships.

## Test plan

- `tests/unit/scripts/work-issues-skill-refs.test.ts` — 5 passed (every added reference is `go-to-k/cdkd#N`-qualified, as the mirror rule requires).
- Full suite: **744 files / 15082 tests**, typecheck + `typecheck:test` + lint + format:check + build clean.
- Per §8's prose arm, every claim in the new text was resolved against this repo during the run that produced it: the `DescribeStateMachine` status and the 23s window were measured against real AWS; the `hash: diff` staleness was observed live on the marker; the contradiction is in two reviewer reports from this session.

## Not mirrored to the sibling repos in this PR

Three of these five are repo-agnostic flow lessons (the happy-path precondition, the pre-run `cleanup` collision, the reviewer contradiction) and belong in `../cdk-local` and `../cdk-real-drift` too. The other two name cdkd-specific gates (`integ-destroy`, markgate `hash: diff`) and would need adapting rather than copying. Filed as a follow-up rather than landed here — see the issue linked below for why, and for the full set so a later hop can see it is complete rather than re-deriving it.

- Mirror filed into BOTH siblings in one turn, so the set is visibly complete rather than re-derived by a later hop: go-to-k/cdk-local#539 and go-to-k/cdk-real-drift#1799. Each names the other and names this PR as where the lesson landed. The three windows were checked against each target first: neither merged `SKILL.md` carries any of the three (the only grep hit is an unrelated use of "contradicts"), and no open PR or issue does.
