### PR TITLE
docs(state): say the state bucket is created by cdkd bootstrap, not by the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,12 @@ State is stored in S3 with optimistic locking via S3 Conditional Writes
 (no DynamoDB required). Keys are scoped by `(stackName, region)` so the
 same stack deployed to two regions has two independent state files.
 
+**You do not create this bucket yourself** — `cdkd bootstrap` creates it once
+per account (see [Prerequisites](#prerequisites)), with versioning, AES-256
+encryption, and a deny-external-access bucket policy. The settings below are
+only for pointing cdkd at a non-default name; pass that same name to
+`cdkd bootstrap --state-bucket` so bootstrap creates it for you there too.
+
 | Setting | CLI | cdk.json | Env var | Default |
 |---------|-----|----------|---------|---------|
 | Bucket | `--state-bucket` | `context.cdkd.stateBucket` | `CDKD_STATE_BUCKET` | `cdkd-state-{accountId}` (legacy `cdkd-state-{accountId}-{region}` is still read with a deprecation warning — run `cdkd state migrate` to consolidate) |

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -4,6 +4,12 @@
 
 cdkd adopts a state management system with S3 as the backend. Unlike CloudFormation's server-side state management, state is explicitly managed on the client side.
 
+The state bucket is **created by `cdkd bootstrap`** (once per account), not by
+the user: bootstrap creates it with versioning, AES-256 encryption, and a
+deny-external-access bucket policy. A `cdkd deploy` that finds no state bucket
+fails with a "run cdkd bootstrap" error rather than creating one implicitly —
+see [Default Bucket Name](#default-bucket-name) below.
+
 ## Design Principles
 
 ### 1. Use S3 as Single Source of Truth (SSOT)


### PR DESCRIPTION
## Problem

README's `## State Management` section opens straight into the bucket-name /
prefix settings table and never says **who creates the state bucket**. That
fact is stated only under `## Prerequisites` (~580 lines above) and in a Quick
Start comment.

Most readers do not arrive at the top of the file: `docs/state-management.md`,
the README's own cross-links, and external links all point at the
`#state-management` anchor. Landing there, a reader sees
`Bucket ... cdkd-state-{accountId}` in a table of things they can configure and
reasonably concludes creating the bucket is their job.

`docs/state-management.md` has the same gap: its Overview never mentions
`cdkd bootstrap`, and the only reference is buried in the backwards-compat
fallback chain ("if neither exists, fail with a run cdkd bootstrap error").

## Change

One short paragraph added to each, before the configuration details:

- **README.md** — `cdkd bootstrap` creates it once per account, with versioning,
  AES-256 encryption and a deny-external-access bucket policy; the settings
  table is only for pointing cdkd at a non-default name, which should be passed
  to `cdkd bootstrap --state-bucket` too.
- **docs/state-management.md** — same ownership statement in the Overview, plus
  the fact that a run finding no state bucket **fails** with a "run cdkd
  bootstrap" error rather than creating one implicitly.

Docs only. No source change.

## Verification

Every claim checked against source, and the refusal checked against the real
CLI:

- versioning + AES-256 + deny-external-access policy —
  `src/cli/commands/bootstrap.ts` (`PutBucketVersioningCommand`,
  `SSEAlgorithm: 'AES256'`, `buildDenyExternalAccessPolicy`).
- custom name is created by bootstrap too — `bootstrap.ts` `options.stateBucket`
  path feeds the same `CreateBucketCommand`.
- no implicit creation — `src/state/s3-state-backend.ts` throws
  `State bucket '<name>' does not exist. Run 'cdkd bootstrap' to create it...`,
  and `src/cli/config-loader.ts` throws
  `No cdkd state bucket found for account <id>. ... Run 'cdkd bootstrap' ...`
  when neither default name resolves.
- live: `node dist/cli.js state list --state-bucket <nonexistent>` printed that
  exact `StateError`, confirming the "fails rather than creates" wording.

`vp run check`, `vp run typecheck:test`, `vp run build`, `vp run test`
(754 files / 15205 tests) all pass; `vp run gen:all-matrices` and
`vp run audit:coverage:check` leave the tree clean.
