### PR TITLE
chore(work-issues): an integ arm owes the same discrimination proof a unit test does

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1057,6 +1057,48 @@ AWS:
   (deploy → the redeploy-with-a-change that reproduced the bug → destroy) with a
   fresh fixture, or via `/run-integ` against an existing one that covers it.
 
+**An integ ARM owes the same discrimination proof a unit test does, and it is
+easier to write a vacuous one — so MUTATION-PROBE THE ARM against real AWS.**
+The unit-test rules above stop at the suite; an arm is the one place this flow
+routinely ships a fence nobody has watched fail. Three ways it goes wrong, all
+measured on 2026-08-21 across go-to-k/cdkd#2108 / go-to-k/cdkd#2109, and none
+visible by reading the script:
+
+- **The host has the trigger but not the EVIDENCE, or the reverse.** A fix that
+  keys on recorded state needs the state AND the thing that state describes in
+  the SAME unit. `cdkd scrub` classifies only a literal `{{resolve:...}}` in the
+  TEMPLATE, so the producer stack (literal, no cross-stack read on record) and
+  the consumer (evidence, but an `Fn::GetStackOutput` leaf with no literal) each
+  had exactly half, and a third fixture had the two-region seeding with no
+  cross-stack machinery at all. All three would have passed with the fix
+  reverted. Adding one small resource to the stack that already carried the
+  evidence is what made the arm real — cheaper than a new fixture, so check for
+  it before concluding a live arm is `next`.
+- **The arm is INERT because the command returns early.** When the fix's
+  behaviour is to SKIP something, a fixture whose only difference is in the
+  skipped thing gives the command no work: it finds nothing to do and never
+  reaches the new code. A `drift --revert` arm tampered the secret-bearing
+  property, which is exactly the one now skipped, so the resource came back
+  clean and the revert returned "nothing to revert" — two live writes, zero
+  signal. Give the fixture a second, ORDINARY difference alongside the one under
+  test, and add a phase that proves the premise (the resource really is drifted,
+  on the ordinary property) before the phase that depends on it.
+- **The assertion is a negative, so it is a confluence point.** "The bad value
+  was not written" is satisfied by a correct refusal AND by any unrelated
+  failure that stopped short. Measured: with the fix mutated back to pre-fix
+  behaviour the arm stayed GREEN, because the revert had errored instead of
+  writing. Assert the POSITIVE marker only the fixed path emits — a specific
+  exit code, a string only the deep path prints, a field in the `--json`
+  payload — and demote the negative to a stated safety net, recording the
+  measurement so nobody re-promotes it.
+
+The probe is one extra run of a fixture you are already running: revert the fix,
+rebuild, run, confirm the arm goes RED, restore, rebuild. Both arms this run
+were probed; one passed the probe and one failed it, which is the whole argument
+for doing it rather than reasoning about it. Also add a NEGATIVE CONTROL inside
+the arm — a sibling case that must NOT trip the new behaviour — or a refusal
+that fires on everything satisfies every positive assertion you just wrote.
+
 **Never leave a real-AWS run unwatched, and do not reach for `timeout` to do
 it.** A hung integ and a legitimately slow one look identical from outside, so
 silence proves nothing: on 2026-08-20 a fixture wedged inside `docker push` and


### PR DESCRIPTION
## Summary

Section 8 of `/work-issues` tells the flow to live-test the changed behaviour. It said nothing about whether the ARM ITSELF can fail — and an arm is the one place this flow routinely ships a fence nobody has watched go red.

Three failures on 2026-08-21, all measured across the #2108 and #2109 lanes, none visible by reading the script:

1. **The host carried the trigger but not the evidence.** `cdkd scrub` classifies only a literal `{{resolve:...}}` in the TEMPLATE. The producer stack had the literal with no cross-stack read on record; the consumer had the foreign-region evidence but an `Fn::GetStackOutput` leaf with no literal; a third candidate fixture had two-region secret seeding and no cross-stack machinery at all. **All three would have passed with the fix reverted.** Adding one small resource to the stack that already held the evidence was cheaper than authoring a new fixture — worth checking before concluding a live arm is `next`.
2. **An arm was INERT.** When the fix's behaviour is to SKIP something, a fixture whose only difference is the skipped thing gives the command no work: a `drift --revert` arm tampered the secret-bearing property — exactly the one now skipped — so the resource came back `clean` and the revert returned "nothing to revert". Two live writes, zero signal.
3. **The assertion was a negative, so it was a confluence point.** "The bad value was not written" is satisfied by a correct refusal AND by any unrelated failure that stopped short. Re-running the fixture against real AWS with the fix mutated back to pre-fix behaviour left it **green**, because the revert had errored instead of writing.

The remedies are in the new text: put trigger and evidence in the same unit, give the fixture a second ordinary difference plus a phase proving the premise, assert the positive marker only the deep path emits, carry a negative control, and **mutation-probe the arm against real AWS** — one extra run of a fixture already being run.

Both arms this run were probed. One passed the probe; one failed it. That asymmetry is the whole argument for measuring rather than reasoning, and it is why this lands as a rule rather than a note.

## Verification

Prose-only change to a skill, so per section 8's own no-`src` tier the verification is the claims, not a command:

- Every incident cited is from this session, with the measurement stated inline rather than summarised.
- The commands the new text sends the next agent to run (revert the fix, rebuild, run the fixture, confirm RED, restore, rebuild) were run twice this session — once per lane — and are what produced findings 2 and 3.
- `tests/unit/scripts/work-issues-skill-refs.test.ts` passes (5/5): every new issue reference is fully qualified as `go-to-k/cdkd#N`, so the section survives being mirrored into a sibling repo.
- `vp run check` rc=0, `vp run test` rc=0 (760 files, 15270 tests).

Net growth is 42 lines. Section 8 had no line this run proved stale — the gap was silence, not a wrong claim.

## Not mirrored to the siblings

This lesson is about cdkd's real-AWS integ fixtures specifically (`verify.sh` arms, `/run-integ`, the state-bucket version sweep). `cdk-local`'s and `cdk-real-drift`'s equivalents differ enough that a copy would assert mechanics they do not have. The general half — mutation-probe the fence, prefer a positive discriminator — is already carried there under their own wording.
