### PR TITLE
chore(work-issues): a hand-picked suite cannot fence a classifier

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -670,6 +670,54 @@ occurring in the finished line. Both probes ran the same mutation; only one coul
 see it. Before trusting a green, ask what property of the INPUT the defect
 depends on.
 
+**When the change alters a CLASSIFIER, hand-picked cases cannot fence it —
+measure the DELTA against the old implementation.** A classifier is any function
+deciding which of several shapes an input is: a region-vs-stack-name predicate,
+a route selector, an error categoriser. Its defects live in the shapes nobody
+thought to write down, so a suite of chosen values goes green on exactly the
+regressions that matter. On 2026-08-21 issue go-to-k/cdkd#2001 shipped THREE
+green revisions that way. Each fixed the case the previous review named and
+broke a neighbouring one: widening a region pattern's length bound fixed the
+`eusc-` partition and started reading five idiomatic stack names (`api-prod-1`,
+`demo-app-1`) as regions; an exact segment-depth rule fixed those under the
+default prefix and mis-split legacy keys under a NESTED one; narrowing that rule
+fixed the nested spelling and still left six shapes regressed under FOREIGN
+prefixes, where the rule cannot reach at all. Every revision passed a suite that
+grew a case per round.
+
+The fence that ends it is a differential walk: enumerate the input space, run
+BOTH the new implementation and a transcription of the old one, and fail on any
+difference outside an explicitly enumerated set of intended classes. That
+inverts the burden — a shape nobody imagined is a failure by default rather than
+a silent pass — and it is what finally showed the delta was three classes when
+the code comments said two. Two ways it goes inert, both measured on that lane:
+
+- **Classify by the resulting VALUE, not by the input's shape.** The first cut
+  bucketed a differing cell by which key it was, so mutating the fix to return
+  the prefix outright — a total regression of the thing the PR added — left
+  every cell inside the "intended repair" bucket and the fence stayed GREEN
+  while nine ordinary cases caught it. Each arm must assert what the function
+  now returns.
+- **Carry a floor per class.** The walk reaches a class only if the input pool
+  contains it; one class was real, intended and never reached, so a pool that
+  quietly stops covering one would pass as "no regressions".
+
+The transcription is the only real cost, and it is cheap for a predicate. Get it
+from `git show origin/main:<path>` rather than from memory, and confirm the two
+agree on the cells where they SHOULD agree before trusting the cells where they
+differ.
+
+**A VALUE import from a module other suites `vi.mock` reds those suites.** The
+`type`-only import that module already had is invisible to the mock; adding a
+runtime one is not, and the failure names the EXPORT rather than the
+mock (`[vitest] No "<CONST>" export ...`), so it reads as a missing symbol in
+the module you just edited rather than as a mocking problem in a suite you did
+not touch. Measured on the same lane: importing one constant into
+`state-file-keys.ts` reddened `gc.test.ts` and `bootstrap-destroy.test.ts`,
+neither of which imports it. When two modules must agree on a constant and one
+of them is widely mocked, spell it in both and fence the pair with a test that
+imports both — the sync is what matters, not the single definition.
+
 **Run probes with `vp test run <path>`, never `vp run test <path>`.** The
 latter goes through the Vite+ task runner, where `test` is CACHED: a repeat
 invocation prints `◉ cache hit, replaying` and re-reports the previous run's
@@ -892,6 +940,16 @@ retry with `>>` then appends to nothing and ships a fragment: go-to-k/cdk-local#
 opened carrying only its review section, with no `Closes` line, and silently lost
 the issue auto-close. Write the body file in one call, run the gated command in the
 next, and re-create rather than append after any refusal.
+
+**Its worst signature is not an absent file but a STALE one from an earlier
+session**, since these paths are conventional (`/tmp/pr-body.md`) and shared.
+The gate then inspects that file and reports violations from content this
+session never wrote — measured 2026-08-21, when a `gh pr create` whose heredoc
+had not run was refused for four bare `#N` refs belonging to a lane from days
+earlier, none of which were in the draft on screen. If a gate names text you do
+not recognise, check the file's mtime before hunting for the text. Give body
+files a per-session name (the scratchpad directory, plus a suffix) for the same
+reason §5 gives probe files one.
 
 **"All green" is the EXIT CODE, not the summary.** A run can report every test
 passing and still exit non-zero, and this repo's runner prints the two facts on
@@ -1318,6 +1376,20 @@ marker correctly went stale, buying a second real-AWS run at merge time. Push
 first so CI starts, then re-run the integ alongside it; the two are independent
 and serializing them wastes the CI wall-clock.
 
+**Check a reviewer's PREMISE before acting on the finding, and say so when you
+decline.** Reviewers are read-only and reason from what they can see, so a
+suggestion can be correct in form and rest on a reachability claim that is
+false — and acting is not free, since a "just add a sentence" edit to a gated
+file buys a real-AWS cycle. On 2026-08-21 a reviewer asked that
+`deploy-engine.ts`'s call-site comment name a second guarantor, because the
+engine is also constructed from `NestedStackProvider.update`. Tracing it took two
+greps: `rollback.ts` builds a DESTROY-mode nested-stack context, so
+`requireDeployContext` throws before a child engine exists, and the only
+deploy-mode context is `deploy.ts`'s own — the guarantor is identical on every
+reachable path and the comment was already complete. Record the trace in the PR
+body and the commit: a declined finding with evidence is a decision the next
+reader can re-judge, while a silently dropped one looks like an oversight.
+
 **When two reviewers CONTRADICT each other, settle it in the code yourself
 before forwarding either.** On 2026-08-20 the spec reviewer explicitly CLEARED
 the evidence-persistence issue the security reviewer called a blocker, both
@@ -1367,8 +1439,16 @@ are looking at two additions or one contested sentence.
 gh pr merge <n> --squash --delete-branch     # squash is the repo's only method
 ```
 
-(`--delete-branch` removes the REMOTE branch but fails on the local one while its
-worktree exists — expected. The worktree removal below does NOT then clear it:
+(**`--delete-branch` prints a bare `fatal:` line and the merge SUCCEEDED anyway —
+read it as the expected artifact, not a failed merge.** Run from the PR's own
+worktree, as this flow requires, `gh` deletes the remote branch, then tries to
+check out the default branch to delete the local one and cannot:
+`failed to run git: fatal: 'main' is already used by worktree at '<main tree>'`.
+Measured twice on 2026-08-21 (PRs go-to-k/cdkd#2144 and go-to-k/cdkd#2145): both
+merged, and NOTHING in the output says so. Confirm with
+`gh pr view <N> --json state` before reacting; the natural reaction — re-running
+the merge — then blocks on a gate for an already-merged PR and reads as a second
+failure. The worktree removal below does NOT then clear it:
 `git worktree remove` deletes the worktree, never the branch, so the local ref
 survives both steps and you must finish with an explicit `git branch -D <branch>`.
 It has to be `-D`: this repo squash-merges, so the branch tip is never an ancestor of
@@ -1723,9 +1803,13 @@ Every worktree THIS run added is gone by §9 and you are back on `main`, where
 worktree:
 
 ```bash
-# Date-suffix the branch: a merged branch is deleted, and re-pushing that same
-# name is refused by post-merge-orphan-push-gate on the next run.
-B=chore/work-issues-retro-$(date +%Y%m%d)
+# Suffix the branch to UTC MINUTE, not day. A merged branch is deleted, and
+# re-pushing that name is refused by post-merge-orphan-push-gate — which a bare
+# date suffix does not avoid, because more than one run lands per day. Measured
+# 2026-08-21: this step's own `$(date +%Y%m%d)` name collided with PR
+# go-to-k/cdkd#2139, merged 02:35Z the same morning, and the push was blocked
+# after the retro was already written and committed.
+B=chore/work-issues-retro-$(date -u +%Y%m%d-%H%M)
 git worktree add ".claude/worktrees/${B##*/}" -b "$B" origin/main
 cd ".claude/worktrees/${B##*/}"
 mise trust && mise install    # untrusted .mise.toml: vp / markgate will not resolve


### PR DESCRIPTION
## Summary

Retrospective (§10) from a `/work-issues` run that shipped go-to-k/cdkd#2118 and go-to-k/cdkd#2001. Six amendments, each carrying the run's own evidence.

## The main lesson: a hand-picked suite cannot fence a classifier

go-to-k/cdkd#2001 shipped **three green revisions** of a region-vs-stack-name predicate. Each fixed the case the previous review named and broke a neighbouring one:

1. Widening the pattern's length bound fixed the `eusc-` partition and started reading five idiomatic stack names (`api-prod-1`, `demo-app-1`) as regions.
2. An exact segment-depth rule fixed those under the default prefix and mis-split legacy keys under a **nested** one.
3. Narrowing that rule fixed the nested spelling and **still left six shapes regressed** under foreign prefixes, where the rule cannot reach at all.

Every revision passed a suite that grew a case per round — because a suite of hand-picked values goes green on exactly the shapes nobody thought to write down, and that is where a classifier's defects live.

What ended it was a **differential walk**: enumerate the input space, run both the new implementation and a transcription of the old one, and fail on any difference outside an explicitly enumerated set of intended classes. That inverts the burden — an unimagined shape becomes a failure by default rather than a silent pass.

§5 now says to reach for that whenever a change alters a classifier, plus the two ways it goes inert, both measured on that lane:

- **Classify by the resulting VALUE, not the input's shape.** The first cut bucketed a differing cell by which key it was, so mutating the fix to return the prefix outright — a total regression of what the PR added — left every cell in the "intended repair" bucket and the fence stayed **green**, while nine ordinary cases caught it.
- **Carry a floor per class.** One real, intended class was never reached by the input pool, so a pool that quietly stops covering one would pass as "no regressions".

## The other five

- **§5** — a VALUE import from a module other suites `vi.mock` reds those suites, and the error names the *export* rather than the mock, so it reads as a missing symbol in the file you just edited rather than a mocking problem in a suite you never touched. Cost a cycle on the same lane.
- **§8** — check a reviewer's PREMISE before acting, and record the trace when you decline. A suggestion can be correct in form and rest on a false reachability claim, and acting is not free: a one-sentence edit to a gated file buys a real-AWS cycle.
- **§9** — the `--delete-branch` note said the local delete "fails". What actually happens is a bare `fatal: 'main' is already used by worktree` line with **nothing** saying the merge landed, twice in this run. The natural reaction — re-running the merge — then blocks on a gate for an already-merged PR and reads as a second failure.
- **§10-d**, found BY this step: it told the retro branch to carry a **date** suffix, and that name collided with go-to-k/cdkd#2139 — another retro merged 02:35Z the same morning — so `post-merge-orphan-push-gate` blocked the push after the retro was already written and committed. More than one run lands per day; the suffix is now UTC minute.
- **§6**, also found by this step: writing a `--body-file` in the same Bash call as the gated `gh` command is already forbidden there, but the failure signature was not. When a file of that name survives from an EARLIER session, the gate inspects *that* file and reports violations from content this session never wrote — here, four `#N` refs belonging to a lane from days ago. The rule gains the symptom, so the next reader recognises it instead of hunting for text that is not in their draft.

## Test plan

Prose-only diff with no `src/**` change, so §8's **prose arm** applies rather than a live test: every command, path, gate name and symbol the new text names was resolved against this repo's own files, and each command a future reader is sent to run was executed (`gh pr view <N> --json state`, `git show origin/main:<path>`, `vp test run <path>`, the corrected `date -u +%Y%m%d-%H%M` branch form).

One claim was **softened after checking**: the vitest error wording had only ever been seen truncated in this session, so the text no longer asserts the full sentence — it quotes the fragment actually observed.

`tests/unit/scripts/work-issues-skill-refs.test.ts` passes (every new issue/PR reference uses the qualified `go-to-k/cdkd#N` form). Full suite 763 files / 15343 tests, rc=0.
