### PR TITLE
chore(work-issues): an inherited integ arm is somebody else's regression net

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1154,11 +1154,32 @@ visible by reading the script:
   exit code, a string only the deep path prints, a field in the `--json`
   payload — and demote the negative to a stated safety net, recording the
   measurement so nobody re-promotes it.
+- **Every assertion in the arm PREDATES your change, so the run is somebody
+  else's regression net.** The cheapest arm to reach for is a fixture that
+  already asserts something near your subject — and if you changed none of those
+  assertions, a green run says only that you broke nothing. On 2026-08-21 a lane
+  ran `rollback-cross-region-secret` for a `cdkd drift` outcome-type change and
+  recorded it as the live evidence; a review found every drift assertion in that
+  `verify.sh` byte-identical to `origin/main` (the PR had touched three comment
+  lines there) and all of them passing under the PRE-change shape, because an
+  earlier issue already emitted the roll-up and the same exit code. The one
+  user-visible delta — a refused resource leaving `clean[]` — was asserted
+  nowhere: `grep '\.clean' verify.sh` returned zero hits. So before believing an
+  inherited arm, run `git diff origin/main -- <the fixture>` and ask which
+  assertion could only pass AFTER your change. If none, the arm is a regression
+  net for a different issue; add the discriminating one. And guard it against
+  vacuity in the same breath — the added assertion there was an ABSENCE from an
+  array, which a run that died before writing that array would also satisfy, so
+  it first requires the array to have been emitted at all.
 
 The probe is one extra run of a fixture you are already running: revert the fix,
-rebuild, run, confirm the arm goes RED, restore, rebuild. Both arms this run
-were probed; one passed the probe and one failed it, which is the whole argument
-for doing it rather than reasoning about it. Also add a NEGATIVE CONTROL inside
+rebuild, run, confirm the arm goes RED, restore, rebuild. **Probe each HALF of a
+multi-part fix separately, not just the whole.** On 2026-08-21 a scrub lane's
+three probes were the whole argument: reverting everything reproduced the bug,
+reverting only the wiring red one assertion, and reverting only the pre-pass left
+that assertion PASSING while a different one red — which is what proved the two
+halves were independently fenced rather than one arm covering both. A single
+all-or-nothing revert cannot tell those apart. Also add a NEGATIVE CONTROL inside
 the arm — a sibling case that must NOT trip the new behaviour — or a refusal
 that fires on everything satisfies every positive assertion you just wrote.
 


### PR DESCRIPTION
## Summary

Retrospective from the run that shipped go-to-k/cdkd#2133 and go-to-k/cdkd#2135. Two lessons, both about integ arms, both measured during the run rather than reasoned about afterwards.

## An inherited arm is somebody else's regression net

The cheapest live arm available is a fixture that already asserts something near your subject. If you change none of its assertions, a green run says only that you broke nothing.

This run recorded `rollback-cross-region-secret` as the live evidence for a `cdkd drift` outcome-type change. A round-2 review found every drift assertion in that `verify.sh` byte-identical to `origin/main` — the PR had touched three comment lines there — and all of them passing under the PRE-change shape, because go-to-k/cdkd#2108 already emitted the same `notCompared` roll-up and the same exit code. The one user-visible delta this change introduced, a refused resource leaving `clean[]`, was asserted nowhere: `grep '\.clean' verify.sh` returned zero hits.

The check costs one command — `git diff origin/main -- <the fixture>`, then ask which assertion could only pass AFTER the change. It goes next to the existing confluence-point bullet because it is the same failure arrived at from the fixture's history rather than from the assertion's shape.

The vacuity guard is recorded alongside it, because the fix for this one walked into the adjacent trap: the discriminating assertion added was an ABSENCE from an array, which a run that died before writing that array satisfies just as well. It now requires the array to have been emitted before reading its membership.

## Probe each HALF, not just the whole

The instruction was "revert the fix and confirm the arm goes RED". That is not enough for a multi-part fix.

The scrub lane's three probes are the argument:

| Probe | Reverts | Result |
|---|---|---|
| M1 | everything | reproduced the bug verbatim |
| M2 | the wiring only | red one assertion |
| M3 | the pre-pass only | that assertion **passed**, a different one red |

M3 is what proved the two halves were independently fenced rather than one arm covering both. A single all-or-nothing revert cannot distinguish those cases, and the difference is exactly whether half the fix could later be removed with the suite still green.

## What this cost

Folded the older "both arms this run were probed; one passed the probe and one failed it" sentence into the sharper version — it made the same point with weaker evidence, so the section grows by less than the two additions.

## Verification

Prose-only change to a skill, so per the no-`src`-diff arm of `/verify-pr` step 9 the verification is resolving the CLAIMS. Both incidents are from this run and their measurements are quoted above; the commands the new text sends the next agent to run (`git diff origin/main -- <fixture>`, the fixture grep) are the ones actually used to find the defect. `vp run check` / `typecheck:test` / `build` / full suite all green.
