### PR TITLE
chore(work-issues): a proxy for a question only another component can answer is wrong in BOTH directions

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1200,6 +1200,34 @@ Two things follow, and the second is the one that is easy to get backwards:
   character for character ended it. So when you name the shape, also name the
   SITE THAT OWNS the question, and make every other site call or copy it exactly;
   a paraphrase is a fourth round waiting to happen.
+- **When the shape is "A PROXY FOR A QUESTION ONLY ANOTHER COMPONENT CAN
+  ANSWER", the fix is to make that component REPORT — and the tell is that each
+  proxy is wrong in BOTH directions at once.** The sibling of the bullet above,
+  and it is diagnosable one round earlier: two spellings DISAGREE at an edge,
+  while a proxy has no access to the fact at all, so every candidate both misses
+  real cases and fires on unreal ones. When a round's fix lands on a new
+  observable rather than a new spelling — "it threw", "the text survived", "a
+  needle exists" — ask whether the thing you want to know is even derivable from
+  outside the component that decides it. If it is not, the rounds are unbounded.
+  Measured on issues go-to-k/cdkd#2157 / go-to-k/cdkd#2166, three rounds asking
+  "did this reference go unresolved?" from outside the resolver: keying on "the
+  resolution THREW" missed the shape where `resolveSub` warn-and-KEEPS an
+  unevaluable placeholder (nothing throws) and over-reported an unrelated `Ref`
+  failure that merely shared the bag; keying on "the raw leaf text SURVIVED"
+  missed a leaf a downstream intrinsic rewrote without resolving, broke on JSON
+  escaping, and fired PERMANENTLY on prose that merely mentions the syntax —
+  re-opening, one level out, an unactionable-refusal class the same file had
+  already closed once.
+- **WITHDRAWING the half that cannot be made right is a legitimate outcome, and
+  the residual issue must carry the MEASUREMENTS, not just the diagnosis.**
+  §8's "do NOT take the structural fix late in the cascade" says where the fix
+  goes; this says what to do with the code already written for the wrong one.
+  Cut it, ship the part the issues actually scoped, and file the rest — the
+  filing is cheap only if it carries what the session PAID for: each proxy tried,
+  the input that broke it, and the number it produced. A diagnosis alone makes
+  the next session re-run the probes. The go-to-k/cdkd#2166 filing carries all
+  three rounds plus a live arm that was written, passed, mutation-probed and then
+  reverted, so none of it is rebuilt.
 
 Run `/verify-pr`. It layers CI status, docs consistency, AWS-resource cleanup, code
 review, and a **live-test of the changed behavior** on top of `/check`. Unit tests


### PR DESCRIPTION
Retrospective from the go-to-k/cdkd#2157 / go-to-k/cdkd#2150 run (PR go-to-k/cdkd#2164), which spent **four** review rounds on one relaxation and withdrew half of it.

## What the rule adds

§8 already says to question the SHAPE when a fix round produces the next round's blocker, and it names one shape: **two spellings of one question**. This run hit a second, adjacent one it did not cover — and the distinction is diagnosable a round *earlier*:

| shape | how it fails | tell |
| --- | --- | --- |
| two spellings of one question | the two DISAGREE at an edge | a round's fix is a *better spelling* of the same test |
| a proxy for a question only another component can answer | the proxy has no access to the fact, so every candidate misses real cases **and** fires on unreal ones at once | a round's fix lands on a new **observable** — "it threw", "the text survived", "a needle exists" |

When the second one is what you have, the rounds are unbounded until the component that owns the fact is made to REPORT.

## The measurements behind it

Three rounds asking *"did this reference go unresolved?"* from outside the resolver that decides it:

- **"the resolution THREW"** — missed the shape where `resolveSub` warn-and-KEEPS an unevaluable placeholder (nothing throws); over-reported an unrelated `Ref` failure that merely shared the bag.
- **"the raw leaf text SURVIVED"** — missed a leaf a downstream intrinsic rewrote without resolving (measured: an `ssm-secure:` reference assembled from a *resolvable* placeholder reports zero findings while logging `Unsupported dynamic reference service`); broke on JSON escaping; and fired **permanently** on prose that merely mentions the syntax, re-opening one level out an unactionable-refusal class the same file had already closed once.

## The second bullet

Withdrawing the half that cannot be made right is a legitimate outcome, and it had no rule. §8 says where the structural fix goes; this says what to do with the code already written for the wrong one — cut it, ship what the issues scoped, and file the rest with the **measurements**, not just the diagnosis. A filing is cheap only if it carries what the session paid for; otherwise the next session re-runs every probe. go-to-k/cdkd#2166 is the worked example: three rounds plus a live arm that was written, passed, mutation-probed and then reverted.

## Verification

Prose-only change to a skill, so §8's own "no `src/**` change" arm applies: the claims are the artifact. Every issue and PR number resolves, both named shapes are checked against the run they came from, and `tests/unit/scripts/work-issues-skill-refs.test.ts` (which fences fully-qualified refs in this file) passes. Full suite green: 766 files / 15505 tests.
