### PR TITLE
chore(hooks): three gates matched a repo flag then parsed the command as if it were absent

### DIFF
--- a/.claude/hooks/ci-green-gate.sh
+++ b/.claude/hooks/ci-green-gate.sh
@@ -108,7 +108,11 @@ cd "$target_dir" 2>/dev/null || exit 0
 
 # --- Parse the PR number (same token walk as pr-review-gate.sh). -------
 pr_number=""
-args="${cmd##*gh pr merge}"
+# The matched-verb strip, not a literal one: `${cmd##*gh pr merge}` returns
+# the WHOLE command under `gh -R <owner/repo> pr merge`, and the walk below
+# then reads an unrelated integer as the PR number (lib/command-match.sh,
+# gate_pr_selector).
+args="$(gate_pr_selector_rest "$cmd" "$GATE_RE_GH_PR_MERGE")"
 # shellcheck disable=SC2086
 set -- $args
 while [ $# -gt 0 ]; do

--- a/.claude/hooks/ci-green-gate.sh
+++ b/.claude/hooks/ci-green-gate.sh
@@ -112,28 +112,14 @@ pr_number=""
 # the WHOLE command under `gh -R <owner/repo> pr merge`, and the walk below
 # then reads an unrelated integer as the PR number (lib/command-match.sh,
 # gate_pr_selector).
-args="$(gate_pr_selector_rest "$cmd" "$GATE_RE_GH_PR_MERGE")"
-# shellcheck disable=SC2086
-set -- $args
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --*=*) shift; continue ;;
-    --auto|--admin|--delete-branch|--squash|--merge|--rebase)
-      shift; continue ;;
-    -*)
-      shift
-      [ $# -gt 0 ] && shift
-      continue
-      ;;
-    *)
-      if printf '%s' "$1" | grep -qE '^[0-9]+$'; then
-        pr_number="$1"
-        break
-      fi
-      shift
-      ;;
-  esac
-done
+# Call the shared selector rather than hand-walking its `_rest` output. The
+# first version of this fix replaced the literal STRIP and left the walk, and a
+# review measured the consequence: the local valueless list carried only LONG
+# spellings, so `gh pr merge -d 2195` took the value-consuming arm, ate the
+# number, and the gate judged the CURRENT BRANCH's PR instead. The fence for
+# exactly that shape already existed -- inside `gate_pr_selector`, which this
+# gate did not call. A fence in a helper protects only the callers that use it.
+pr_number="$(gate_pr_selector "$cmd" "$GATE_RE_GH_PR_MERGE")"
 
 # --- Query live check status. ------------------------------------------
 # `gh pr checks` exit codes: 0 = all passed, 1 = some failed/skipped,

--- a/.claude/hooks/closes-paren-form-gate.sh
+++ b/.claude/hooks/closes-paren-form-gate.sh
@@ -54,8 +54,11 @@ fi
 gate_matches "$trimmed" "$GATE_RE_GH_PR_MERGE" || exit 0
 
 # Extract PR number (positional integer after `gh pr merge`)
-args="${trimmed##*gh pr merge}"
-pr_num=$(echo "$args" | grep -oE '^[[:space:]]*[0-9]+' | head -1 | tr -d '[:space:]' || true)
+# The matched-verb selector, not a literal strip: `${trimmed##*gh pr merge}`
+# returns the WHOLE command under `gh -R <owner/repo> pr merge`, the number
+# regex then finds nothing, and this gate exited 0 -- fully bypassed by the
+# flag the widened absorber had just taught it to match.
+pr_num=$(gate_pr_selector "$trimmed" "$GATE_RE_GH_PR_MERGE")
 [[ -n "$pr_num" ]] || exit 0
 [[ "$pr_num" =~ ^[0-9]+$ ]] || exit 0
 

--- a/.claude/hooks/lib/command-match.sh
+++ b/.claude/hooks/lib/command-match.sh
@@ -571,6 +571,22 @@ GATE_QUOTED_VALUE='("[^"]*"|'"'"'[^'"'"']*'"'"')'
 # `gh -C <path>` are absorbed — including a QUOTED path containing spaces, which
 # an earlier version could not parse, so `git -C "/a b" commit` matched nothing
 # and ran ungated (go-to-k/cdk-local#542 review).
+# A flag VALUE may embed a quoted span containing spaces -- `git -c
+# user.name="Jane Doe" commit` is the everyday shape. The value alternative
+# stops at the first space, so the flag loop ends mid-value and the verb is
+# never reached: measured on origin/main, `git commit -m x` on `main` gives
+# branch-gate rc=2 while `git -c user.name="Jane Doe" commit -m x` gives rc=0 --
+# a commit straight to main, ungated, and the same hole in EVERY gate keyed on
+# GATE_FLAGS.
+#
+# NOT FIXED HERE, deliberately, and tracked as its own issue. GATE_FLAGS
+# contributes a fixed number of CAPTURE GROUPS, and callers index them:
+# `dirty-path-restore-gate.sh:123` reads `BASH_REMATCH[4]`. Widening the value
+# alternative adds groups, shifts every such index, and that gate silently
+# stopped blocking `git checkout -- <dirty path>` -- 7 of its 18 cases, and the
+# class fence reported it "gone quiet". Fixing it means widening the pattern AND
+# auditing every BASH_REMATCH index built on it, which is a different change
+# from this one and needs its own review.
 GATE_FLAGS='([[:space:]]+-[^[:space:]]+([[:space:]]+("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]-][^[:space:]]*))?)*'
 # Every gh GLOBAL FLAG before the subcommand, not just `-C`. The `-C`-only form
 # meant a repo flag ahead of the verb made the verb unreachable, so
@@ -605,6 +621,174 @@ GATE_RE_VP_RUN_TEST='^vp[[:space:]]+run[[:space:]]+test([[:space:]]|$)'
 GATE_RE_CDK_DEPLOY="^(npx[[:space:]]+)?cdk${GATE_FLAGS}[[:space:]]+deploy([[:space:]]|$)"
 GATE_RE_CDK_DESTROY="^(npx[[:space:]]+)?cdk${GATE_FLAGS}[[:space:]]+destroy([[:space:]]|$)"
 GATE_RE_DELSTACK='^delstack([[:space:]]|$)'
+
+# gate_pr_selector <command> <verb-ere>
+#
+# The first non-flag token AFTER the matched verb, taken from the segment that
+# actually matched. Empty when there is none.
+#
+# WHY THIS EXISTS. Three gates hand-rolled `args="${cmd##*gh pr merge}"` — a
+# longest-prefix strip on the LITERAL string. Once `GATE_GH_C` was widened to
+# absorb `-R <owner/repo>`, those gates began to FIRE on the flagged spelling
+# while still failing to strip it: the literal `gh pr merge` does not appear in
+# `gh -R go-to-k/cdkd pr merge 2195`, so `##*` matches nothing and returns the
+# WHOLE command, and whatever runs next reads the wrong thing out of it.
+# Measured 2026-08-25 against the shipped hooks:
+#
+#   gh pr merge 2195 --squash                        -> pr-review-gate: PR #2195
+#   sleep 30 && gh -R go-to-k/cdkd pr merge 2195 ...  -> pr-review-gate: PR #30
+#
+# i.e. an unrelated PR's size decided the review tier, and for
+# closes-paren-form-gate the selector came back empty and the gate exited 0.
+# Widening the flag absorber was NECESSARY AND NOT SUFFICIENT: it moved the
+# bypass one step later rather than closing it. The same pair of defects was
+# found independently in cdk-local and cdk-real-drift.
+#
+# The regexes are anchored at `^`, so the match always starts at offset 0 and
+# its LENGTH is a safe strip — `${segment#${BASH_REMATCH[0]}}` is not, because
+# the matched text is then treated as a glob pattern.
+# gate_pr_selector_rest <command> <verb-ere>
+# Everything AFTER the matched verb, for callers that run their own token walk.
+# Same rationale and the same anchored-match strip as gate_pr_selector.
+gate_pr_selector_rest() {
+  local cmd="$1" re="$2" segment
+  while IFS= read -r segment; do
+    [[ "$segment" =~ $re ]] || continue
+    printf '%s' "${segment:${#BASH_REMATCH[0]}}"
+    return 0
+  done < <(gate_segments "$cmd")
+  return 0
+}
+
+# gate_pr_selector_ate_number <command> <verb-ere>
+#
+# Exit 0 when the walk CONSUMED a numeric token as some flag's value, i.e. the
+# selector is empty because a flag ATE it rather than because none was given.
+#
+# A separate FUNCTION, not a variable, and that is forced rather than stylistic:
+# every caller reads the selector as `$(gate_pr_selector …)`, and a subshell
+# assignment cannot reach the parent. Measured while adding it -- the flag read
+# back empty at every call site.
+#
+# The distinction matters because a corrected COMMENT does not close the hole
+# for the next unlisted flag. `gh pr merge --squash` -> empty, and falling back
+# to the current branch is right. `gh pr merge --future-flag 552` -> empty
+# because 552 was eaten, and falling back there is how a sibling repo's
+# ci-green-gate merged past red CI.
+gate_pr_selector_ate_number() {
+  local out
+  out=$(_gate_sel_want_ate=1 gate_pr_selector "$1" "$2")
+  [ "$out" = "ate" ]
+}
+
+gate_pr_selector() {
+  local cmd="$1" re="$2" segment rest tok
+  while IFS= read -r segment; do
+    [[ "$segment" =~ $re ]] || continue
+    rest="${segment:${#BASH_REMATCH[0]}}"
+    # Globbing OFF around the split: an unquoted `*` in the tail would
+    # otherwise expand against the hook's cwd and a stray filename could become
+    # the selector (measured: with files `77` and `aaa` present,
+    # `gh pr merge --some-flag * 552` yielded 77).
+    # Tokenise with GATE_EMBEDDING_TOKEN so a QUOTED flag value is ONE token.
+    # A plain word-split makes `--subject "chore: x" 2195` three tokens, the
+    # flag consumes `"chore:` and the walk then sees `x"` -- non-numeric, so the
+    # selector comes back empty. Empty is the safe direction, but it is still a
+    # miss, and it is the same tokenisation defect that let a `-C` inside a
+    # quoted value become a target.
+    set -f
+    # shellcheck disable=SC2086
+    set --
+    while [[ "$rest" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN([[:space:]]+(.*))?$ ]]; do
+      set -- "$@" "${BASH_REMATCH[1]}"
+      rest="${BASH_REMATCH[4]}"
+      [ -n "$rest" ] || break
+    done
+    set +f
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        # VALUELESS flags are enumerated; everything else that looks like a flag
+        # is assumed to TAKE a value and consumes the next token.
+        #
+        # The polarity is the whole point, and the opposite one was tried and
+        # measured wrong. Enumerating VALUE-TAKERS instead goes stale in the
+        # DANGEROUS direction: an unlisted value-taking flag leaves its value in
+        # place, so `gh pr merge -R go-to-k/cdkd 552` yields the repo SLUG and
+        # `gh pr merge -t 42 552` yields 42 -- a gate then judges a different PR
+        # and blocks or passes on its verdict. Enumerating VALUELESS flags goes
+        # stale the SAFE-ER way: an unlisted valueless flag eats the number and
+        # the selector comes back EMPTY.
+        #
+        # Be precise about what EMPTY costs, because an earlier version of this
+        # comment overstated it. Empty does NOT mean "the caller refuses". It
+        # means the caller resolves the CURRENT BRANCH's PR instead
+        # (`gh pr checks` with no argument), which is right when the command
+        # runs from the PR's own worktree and WRONG from anywhere else. A
+        # sibling repo measured a worse version of the same thing: there, an
+        # empty selector reached a `no pull requests found` fail-open arm and
+        # the gate PASSED, so `gh pr merge -s 2195` merged past red CI.
+        #
+        # So the polarity argument is real but bounded: wrong-PR is severe and
+        # deterministic, empty-PR is a fallback whose safety depends on the
+        # caller. That is why this list carries BOTH spellings of every flag
+        # rather than relying on the direction of staleness to save it, and why
+        # callers should shape-check the selector independently.
+        # BOTH spellings. `gh help pr merge` documents `-s/--squash`,
+        # `-m/--merge`, `-r/--rebase`, `-d/--delete-branch`; listing only the
+        # long forms sent every short one down the value-consuming arm, which
+        # ATE the PR number: `gh pr merge -s 2195` returned an empty selector.
+        --squash|-s|--merge|-m|--rebase|-r|--delete-branch|-d)
+          # `-m` COLLIDES across the two verbs this list serves: it is
+          # `--merge` (valueless) for `gh pr merge` and `--milestone`
+          # (value-TAKING) for `gh pr edit`. Listed valueless, deliberately.
+          # On `pr merge`, treating it as value-taking loses the PR number --
+          # the blocker this list exists for. On `pr edit`, `-m "Q3 plan" 42`
+          # leaves a quoted non-numeric token that the numeric guard below
+          # drops, so the selector is EMPTY: a fallback, not a wrong PR. Only
+          # a milestone literally NAMED a number, in first position, could
+          # mis-resolve. Found by a sibling repo re-deriving this list from
+          # `gh help` rather than copying it.
+          shift; continue ;;
+        --remove-milestone|--help)
+          shift; continue ;;
+        --auto|--disable-auto|--admin)
+          shift; continue ;;
+        -*)
+          shift
+          if [ $# -gt 0 ]; then
+            # Did this flag swallow something that LOOKED like the PR number?
+            # That is the case the caller must not treat as a plain absence.
+            case "$1" in
+              ''|*[!0-9]*) ;;
+              *) [ -n "${_gate_sel_want_ate:-}" ] && { printf 'ate'; return 0; } ;;
+            esac
+            shift
+          fi
+          continue ;;
+      esac
+      # And a final guard: the callers all want a PR NUMBER. A non-numeric
+      # token (a branch name, a URL, a repo slug that slipped through) is not
+      # one, and handing it on is how the flag-value bugs above became
+      # wrong-PR verdicts rather than harmless misses.
+      case "$1" in
+        ''|*[!0-9]*)
+          # A non-numeric first positional means we consumed something that
+          # was not the PR number. Record it: the caller must be able to tell
+          # "no selector was given" from "a flag ATE the selector", because a
+          # corrected comment does not close the hole for the NEXT unlisted
+          # flag. `gh pr merge --squash` -> empty and safe to fall back;
+          # `gh pr merge --future-flag 552` -> empty because 552 was eaten,
+          # and falling back there is how a sibling's ci-green merged past red
+          # CI. One walk answers both so the two cannot drift apart.
+          return 0 ;;
+      esac
+      printf '%s' "$1"
+      return 0
+    done
+    return 0
+  done < <(gate_segments "$cmd")
+  return 0
+}
 
 # Strip one layer of surrounding quotes from a path token.
 gate_unquote() {
@@ -652,26 +836,36 @@ gate_expand_tilde() {
 # It also fixes `git -C /one -C /two commit`, which the unanchored scan resolved
 # to `/one` (only the first `-C` sits next to the command word) while git itself
 # uses `/two`. Last-wins, like git.
+# A token that may EMBED quoted spans, e.g. `core.pager="less -C /evil"`.
+# `GATE_PATH_TOKEN` is a quoted span OR a bare run of non-space, so it splits
+# that at the first space and the tail `-C /evil"` is then read as a fresh
+# `-C` flag. Measured on origin/main (pre-existing, not introduced by the
+# selector work): `git -c core.pager="less -C /evil" commit -m y` resolved the
+# target to `/evil`, and through the real hook with the repo on `main`,
+# `git commit -m x` gives rc=2 while the same command with that `-c` prefix
+# gives rc=0 -- a branch-gate BYPASS driven entirely by a flag VALUE.
+GATE_EMBEDDING_TOKEN='(("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]"'"'"'])+)'
+
 gate_leading_c_value() {
   local seg="$1" tok rest val=""
   # Strip the leading command word; anything else is not a git/gh invocation.
   [[ "$seg" =~ ^[[:space:]]*(git|gh)[[:space:]]+(.*)$ ]] || return 1
   rest="${BASH_REMATCH[2]}"
   while [ -n "$rest" ]; do
-    [[ "$rest" =~ ^[[:space:]]*($GATE_PATH_TOKEN)([[:space:]]+(.*))?$ ]] || break
+    [[ "$rest" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN([[:space:]]+(.*))?$ ]] || break
     tok="${BASH_REMATCH[1]}"
     rest="${BASH_REMATCH[4]}"
     case "$tok" in
       -C)
         # The next token is the value, whatever it looks like.
-        [[ "$rest" =~ ^[[:space:]]*($GATE_PATH_TOKEN)([[:space:]]+(.*))?$ ]] || break
+        [[ "$rest" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN([[:space:]]+(.*))?$ ]] || break
         val="${BASH_REMATCH[1]}"
         rest="${BASH_REMATCH[4]}"
         ;;
       -c|--git-dir|--work-tree|--namespace|--exec-path|--config-env|-R|--repo)
         # Flags that consume the following token; skip it so a value is never
         # mistaken for the verb.
-        [[ "$rest" =~ ^[[:space:]]*($GATE_PATH_TOKEN)([[:space:]]+(.*))?$ ]] && rest="${BASH_REMATCH[4]}"
+        [[ "$rest" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN([[:space:]]+(.*))?$ ]] && rest="${BASH_REMATCH[4]}"
         ;;
       -*) : ;;
       *) break ;;   # the verb: leading flags are over

--- a/.claude/hooks/lib/command-match.sh
+++ b/.claude/hooks/lib/command-match.sh
@@ -662,8 +662,15 @@ gate_pr_selector_rest() {
 
 # gate_pr_selector_ate_number <command> <verb-ere>
 #
-# Exit 0 when the walk CONSUMED a numeric token as some flag's value, i.e. the
-# selector is empty because a flag ATE it rather than because none was given.
+# Exit 0 when the walk CONSUMED a numeric token as some flag's value.
+#
+# It reports what the WALK did, NOT that the selector is empty -- and the two
+# differ: `gh pr merge -t 42 552` yields selector `552` AND ate=YES, because 42
+# was eaten by `-t` and 552 was still found. A caller must therefore check
+# emptiness FIRST and consult this only then; treating ate=YES alone as a
+# refusal would reject valid commands. An earlier version of this comment said
+# "the selector is empty because a flag ate it", which is false in exactly that
+# case.
 #
 # A separate FUNCTION, not a variable, and that is forced rather than stylistic:
 # every caller reads the selector as `$(gate_pr_selector …)`, and a subshell
@@ -696,6 +703,11 @@ gate_pr_selector() {
     # selector comes back empty. Empty is the safe direction, but it is still a
     # miss, and it is the same tokenisation defect that let a `-C` inside a
     # quoted value become a target.
+    # Save the caller's noglob setting rather than forcing it off: an
+    # unconditional `set +f` below turned globbing ON for a caller that had it
+    # off.
+    local _gate_noglob=off
+    case "$-" in *f*) _gate_noglob=on ;; esac
     set -f
     # shellcheck disable=SC2086
     set --
@@ -704,7 +716,7 @@ gate_pr_selector() {
       rest="${BASH_REMATCH[4]}"
       [ -n "$rest" ] || break
     done
-    set +f
+    [ "$_gate_noglob" = "on" ] || set +f
     while [ $# -gt 0 ]; do
       case "$1" in
         # VALUELESS flags are enumerated; everything else that looks like a flag
@@ -737,6 +749,12 @@ gate_pr_selector() {
         # `-m/--merge`, `-r/--rebase`, `-d/--delete-branch`; listing only the
         # long forms sent every short one down the value-consuming arm, which
         # ATE the PR number: `gh pr merge -s 2195` returned an empty selector.
+        # `--flag=value` carries its value INSIDE the token, so it must not
+        # also consume the next one -- `gh pr merge --repo=go-to-k/cdkd 552`
+        # returned empty before this arm. The hand-walk this helper replaced
+        # had it; dropping it was a regression the replacement introduced.
+        --*=*)
+          shift; continue ;;
         --squash|-s|--merge|-m|--rebase|-r|--delete-branch|-d)
           # `-m` COLLIDES across the two verbs this list serves: it is
           # `--merge` (valueless) for `gh pr merge` and `--milestone`
@@ -852,20 +870,40 @@ gate_leading_c_value() {
   [[ "$seg" =~ ^[[:space:]]*(git|gh)[[:space:]]+(.*)$ ]] || return 1
   rest="${BASH_REMATCH[2]}"
   while [ -n "$rest" ]; do
-    [[ "$rest" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN([[:space:]]+(.*))?$ ]] || break
-    tok="${BASH_REMATCH[1]}"
-    rest="${BASH_REMATCH[4]}"
+    # Embedding token first; fall back to the plain one when it cannot match.
+    # The embedding class excludes bare quote characters, so an UNBALANCED
+    # apostrophe -- a path like `/tmp/o'neill/repo`, or `user.name=O'Brien` --
+    # made the whole token fail and this function returned NOTHING. Measured:
+    # `git -C /tmp/o'neill/repo commit` resolved the target on origin/main and
+    # fell back to the session cwd here, and `gate_target_dir_strict` cannot
+    # refuse it because it cannot tell "no -C" from "unparsable -C". That is
+    # the silent-fallback class go-to-k/cdkd#2200 was reverted for.
+    if [[ "$rest" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN([[:space:]]+(.*))?$ ]]; then
+      tok="${BASH_REMATCH[1]}"
+      rest="${BASH_REMATCH[4]}"
+    elif [[ "$rest" =~ ^[[:space:]]*($GATE_PATH_TOKEN)([[:space:]]+(.*))?$ ]]; then
+      tok="${BASH_REMATCH[1]}"
+      rest="${BASH_REMATCH[4]}"
+    else
+      break
+    fi
     case "$tok" in
       -C)
         # The next token is the value, whatever it looks like.
-        [[ "$rest" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN([[:space:]]+(.*))?$ ]] || break
-        val="${BASH_REMATCH[1]}"
-        rest="${BASH_REMATCH[4]}"
+        if [[ "$rest" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN([[:space:]]+(.*))?$ ]]; then
+          val="${BASH_REMATCH[1]}"; rest="${BASH_REMATCH[4]}"
+        elif [[ "$rest" =~ ^[[:space:]]*($GATE_PATH_TOKEN)([[:space:]]+(.*))?$ ]]; then
+          val="${BASH_REMATCH[1]}"; rest="${BASH_REMATCH[4]}"
+        else break; fi
         ;;
       -c|--git-dir|--work-tree|--namespace|--exec-path|--config-env|-R|--repo)
         # Flags that consume the following token; skip it so a value is never
         # mistaken for the verb.
-        [[ "$rest" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN([[:space:]]+(.*))?$ ]] && rest="${BASH_REMATCH[4]}"
+        if [[ "$rest" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN([[:space:]]+(.*))?$ ]]; then
+          rest="${BASH_REMATCH[4]}"
+        elif [[ "$rest" =~ ^[[:space:]]*($GATE_PATH_TOKEN)([[:space:]]+(.*))?$ ]]; then
+          rest="${BASH_REMATCH[4]}"
+        fi
         ;;
       -*) : ;;
       *) break ;;   # the verb: leading flags are over

--- a/.claude/hooks/lib/command-match.test.sh
+++ b/.claude/hooks/lib/command-match.test.sh
@@ -587,6 +587,121 @@ want_dir "/base" "gate_target_dir still FALLS BACK on an unexpanded -C" \
 want_dir "/base" "gate_target_dir still FALLS BACK on an unexpanded cd" \
   'cd "$W" && git commit -m x' /base "$C"
 
+# --- gate_pr_selector: the selector must come from the MATCHED verb ---------
+#
+# Three gates hand-rolled `${cmd##*gh pr merge}` -- a LITERAL strip. Once
+# GATE_GH_C absorbed `-R <owner/repo>`, they began to FIRE on the flagged
+# spelling while still failing to strip it, so whatever ran next read the wrong
+# token. Measured 2026-08-25 against the shipped hooks: `sleep 30 && gh -R
+# go-to-k/cdkd pr merge 2195 --squash` resolved PR #30 in pr-review-gate, and
+# closes-paren-form-gate got an empty selector and exited 0. Widening the flag
+# absorber was necessary and NOT sufficient -- it moved the bypass one step
+# later. These cases fence the second step.
+want_sel() {
+  local expect="$1" name="$2" cmd="$3" got
+  got=$(gate_pr_selector "$cmd" "$GATE_RE_GH_PR_MERGE")
+  if [ "$got" = "$expect" ]; then
+    pass=$((pass + 1)); printf 'ok   %s\n' "$name"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (got %s, want %s)\n' "$name" "${got:-<empty>}" "${expect:-<empty>}"
+    fail_log="${fail_log}FAIL ${name}\n"
+  fi
+}
+
+want_sel 2195 "selector: plain"                 'gh pr merge 2195 --squash'
+want_sel 2195 "selector: -R space"              'gh -R go-to-k/cdkd pr merge 2195 --squash'
+want_sel 2195 "selector: --repo space"          'gh --repo go-to-k/cdkd pr merge 2195 --squash'
+want_sel 2195 "selector: --repo="               'gh --repo=go-to-k/cdkd pr merge 2195 --squash'
+want_sel 2195 "selector: -R="                   'gh -R=go-to-k/cdkd pr merge 2195 --squash'
+want_sel 2195 "selector: -R glued"              'gh -Rgo-to-k/cdkd pr merge 2195 --squash'
+want_sel 2195 "selector: -C then -R"            'gh -C /tmp -R go-to-k/cdkd pr merge 2195 --squash'
+# THE case. A leading integer anywhere in the command must not be read as the
+# PR number -- this is the exact input that resolved PR #30 before the fix.
+want_sel 2195 "selector: leading sleep 30 does not win" \
+  'sleep 30 && gh -R go-to-k/cdkd pr merge 2195 --squash'
+want_sel 2195 "selector: flag with a numeric value first" \
+  'gh pr merge --delete-branch 2195'
+want_sel ""   "selector: no number given"       'gh pr merge --squash'
+want_sel ""   "selector: quoted mention only"   'echo "gh pr merge 5"'
+# A sibling lane's fix REGRESSED on this shape: its new anchor accepted a
+# selector only IMMEDIATELY after the verb, so `gh pr merge --squash 1` lost the
+# number and its ci-green-gate returned 0 -- a red-CI bypass introduced by the
+# fix itself, on a spelling gh accepts and the OLD extractor handled.
+want_sel 1    "selector: flags BEFORE the number"       'gh pr merge --squash 1'
+want_sel 1    "selector: -R and flags before the number" 'gh -R go-to-k/cdkd pr merge --squash 1'
+want_sel 2195 "selector: several flags first"           'gh pr merge --delete-branch --squash 2195'
+# And the other half of that lane's finding: the selector must come from the
+# MATCHED SEGMENT, never the whole command. A PR body quoting another merge
+# command must not donate its number.
+want_sel ""   "selector: number quoted inside another segment" \
+  'gh pr create --body "later: gh pr merge 42 --squash"'
+want_sel ""   "selector: quoted mention then a bare verb" \
+  'gh pr create --body "then run gh pr merge 9 --squash" && gh pr merge'
+
+# A repo flag AFTER the verb: the verb ERE only absorbs LEADING flags, so `-R`
+# reaches the selector walk. Enumerating VALUE-TAKERS (the polarity a sibling
+# lane tried) leaves the slug in place and the gate then judges repo-slug-as-PR;
+# `-t 42 552` is the same shape with a plausible-looking integer. Enumerating
+# VALUELESS flags instead fails SAFE: an unlisted one eats the number and the
+# selector comes back empty.
+want_sel 552  "selector: -R after the verb"        'gh pr merge -R go-to-k/cdkd 552 --squash'
+want_sel 552  "selector: --repo after the verb"    'gh pr merge --repo go-to-k/cdkd 552'
+want_sel 552  "selector: -t consumes its value"    'gh pr merge -t 42 552'
+want_sel 552  "selector: --disable-auto is valueless" 'gh pr merge --disable-auto 552'
+# SHORT spellings. `gh help pr merge` documents -s/-m/-r/-d, and listing only
+# the long forms sent every short one down the value-consuming arm, eating the
+# PR number. Found by a sibling repo's round-3 review, where the empty selector
+# then reached a `no pull requests found` fail-open and MERGED PAST RED CI.
+want_sel 2195 "selector: -s is valueless"            'gh pr merge -s 2195'
+want_sel 2195 "selector: -d is valueless"            'gh pr merge -d 2195'
+want_sel 2195 "selector: -m is valueless"            'gh pr merge -m 2195'
+want_sel 2195 "selector: -r is valueless"            'gh pr merge -r 2195'
+want_sel 2195 "selector: long and short mixed"       'gh pr merge --squash -d 2195'
+
+# "empty" has TWO causes and the caller must tell them apart. A corrected
+# comment does not close the hole for the next unlisted flag: a sibling repo's
+# ci-green-gate treated every empty selector as "fall back to the current
+# branch" and so merged past red CI when a flag had eaten the number.
+want_ate() {
+  local expect="$1" name="$2" cmd="$3"
+  local got=no
+  gate_pr_selector_ate_number "$cmd" "$GATE_RE_GH_PR_MERGE" && got=YES
+  if [ "$got" = "$expect" ]; then
+    pass=$((pass + 1)); printf 'ok   %s\n' "$name"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (got %s, want %s)\n' "$name" "$got" "$expect"
+    fail_log="${fail_log}FAIL ${name}\n"
+  fi
+}
+want_ate no  "ate: no number given at all"        'gh pr merge --squash'
+want_ate no  "ate: a branch name is not a number" 'gh pr merge feature-branch'
+want_ate no  "ate: number present and returned"   'gh pr merge 552 --squash'
+want_ate no  "ate: a non-numeric flag value"      'gh pr merge -t msg 2195'
+want_ate YES "ate: an UNLISTED flag swallowed it" 'gh pr merge --future-flag 552'
+want_ate YES "ate: a numeric flag value"          'gh pr merge --body-file 7 2195'
+want_sel ""   "selector: unknown flag fails SAFE, not wrong" 'gh pr merge --future-flag 552'
+want_sel ""   "selector: a branch name is not a PR number"   'gh pr merge feature-branch'
+
+# The FOURTH iteration of "the fix moved the bypass one step later", found by a
+# sibling repo's round-2 review. Skipping `-…` tokens but NOT their values makes
+# a flag value the selector: `gh pr merge -t msg 2195` yielded `msg`, which
+# `gh pr checks msg` answers with "no pull requests found" -- straight into
+# ci-green-gate's fail-open arm. Strictly worse than the empty selector it
+# replaced, because empty fell back to the current branch and blocked.
+want_sel 2195 "selector: -t value is consumed, not returned"  'gh pr merge -t msg 2195 --squash'
+want_sel 2195 "selector: --match-head-commit value consumed"  'gh pr merge --match-head-commit abc 2195'
+want_sel 2195 "selector: --body-file numeric value consumed"  'gh pr merge --body-file 7 2195 --squash'
+want_sel 2195 "selector: a QUOTED flag value is one token"    'gh pr merge --subject "chore: x" 2195 --squash'
+
+# A `-C` embedded in a quoted FLAG VALUE must not become the target. Measured on
+# origin/main: `git -c core.pager="less -C /evil" commit` resolved `/evil`, and
+# through branch-gate on `main` that turned rc=2 into rc=0 -- a bypass driven by
+# a flag value. Pre-existing, found by a sibling repo's review of the same code.
+want_dir "/fallback" "-C inside a quoted flag value is not a target" \
+  'git -c core.pager="less -C /evil" commit -m y' /fallback "$C"
+want_dir "/w/t" "a real -C after -c k=v still resolves" \
+  'git -c k=v -C /w/t commit -m x' /fallback "$C"
+
 echo
 echo "Pass: $pass  Fail: $fail"
 if [ "$fail" -gt 0 ]; then

--- a/.claude/hooks/lib/command-match.test.sh
+++ b/.claude/hooks/lib/command-match.test.sh
@@ -693,6 +693,23 @@ want_sel 2195 "selector: --match-head-commit value consumed"  'gh pr merge --mat
 want_sel 2195 "selector: --body-file numeric value consumed"  'gh pr merge --body-file 7 2195 --squash'
 want_sel 2195 "selector: a QUOTED flag value is one token"    'gh pr merge --subject "chore: x" 2195 --squash'
 
+# `--flag=value` carries its value inside the token. The hand-walk this helper
+# replaced had this arm; dropping it was a regression the replacement made.
+want_sel 552  "selector: --repo=<slug> before the number"  'gh pr merge --repo=go-to-k/cdkd 552'
+want_sel 2195 "selector: --body-file=<path> before it"     'gh pr merge --body-file=/tmp/b 2195'
+
+# An UNBALANCED apostrophe in a path made GATE_EMBEDDING_TOKEN fail outright,
+# so gate_leading_c_value returned NOTHING and the caller silently judged the
+# session cwd -- and gate_target_dir_strict cannot refuse it, because it cannot
+# tell "no -C" from "unparsable -C". Same silent-fallback class as the reverted
+# go-to-k/cdkd#2200. Built with a variable because a literal apostrophe inside
+# these already-quoted case strings is what broke this file once.
+APO=$(printf "\047")
+want_dir "/tmp/o${APO}neill/repo" "an apostrophe in the -C path still resolves" \
+  "git -C /tmp/o${APO}neill/repo commit -m x" FALLBACK "$C"
+want_dir "/w/t" "an apostrophe in an earlier flag VALUE does not lose it" \
+  "git -c user.name=O${APO}Brien -C /w/t commit -m x" FALLBACK "$C"
+
 # A `-C` embedded in a quoted FLAG VALUE must not become the target. Measured on
 # origin/main: `git -c core.pager="less -C /evil" commit` resolved `/evil`, and
 # through branch-gate on `main` that turned rc=2 into rc=0 -- a bypass driven by

--- a/.claude/hooks/post-merge-orphan-push-gate.sh
+++ b/.claude/hooks/post-merge-orphan-push-gate.sh
@@ -251,8 +251,18 @@ fi
 # `gh pr list` exits non-zero on auth failure / network error. We treat
 # that as "couldn't check" and pass through with a debug note — same
 # fail-open posture as the missing-gh branch.
-pr_json=$("${gh_bin}" pr list --head "$branch" --state merged --limit 1 \
-            --json number,mergedAt,headRefName,title 2>/dev/null || true)
+#
+# The `cd` is load-bearing and its absence was a live CROSS-REPO FALSE POSITIVE.
+# `gh` resolves the repo from its CWD, and it has no `-C` flag, so an unwrapped
+# call here read THIS SESSION's repo rather than the push target. Measured
+# 2026-08-25: a push to cdk-real-drift, whose PR go-to-k/cdk-real-drift#1815 was
+# OPEN, was refused citing go-to-k/cdkd#2195 -- a different repo's MERGED PR
+# that merely shared the branch name. These three repos name branches by
+# convention (`chore/issue-dup-check` existed in both simultaneously), so the
+# collision is the normal case, not a coincidence. The gate resolved
+# `target_dir` correctly all along and then did not use it.
+pr_json=$( (cd "$target_dir" 2>/dev/null && "${gh_bin}" pr list --head "$branch" --state merged --limit 1 \
+            --json number,mergedAt,headRefName,title) 2>/dev/null || true)
 
 if [ -z "$pr_json" ] || [ "$pr_json" = "null" ]; then
   echo "post-merge-orphan-push-gate: gh pr list failed or returned empty; skipping check." >&2

--- a/.claude/hooks/post-merge-orphan-push-gate.test.sh
+++ b/.claude/hooks/post-merge-orphan-push-gate.test.sh
@@ -212,6 +212,44 @@ run_case "echo body quoting 'git push' passes through" 0 \
   "$merged_match"
 
 echo
+# --- CROSS-REPO: the merged-PR lookup must target the PUSH TARGET -----------
+# Measured 2026-08-25: this gate refused a push to cdk-real-drift (PR OPEN)
+# citing go-to-k/cdkd#2195 (MERGED), because `gh pr list` ran with no `cd` and
+# so resolved THIS session's repo, and both repos had a branch named
+# `chore/issue-dup-check`. These repos name branches by convention, so the
+# collision is the normal case. The stub records the cwd it was called from;
+# the assertion is that it is the push TARGET, not the session's own tree.
+cross_repo_case() {
+  local other target trace stub out rc
+  other=$(mktemp -d); target=$(mktemp -d); trace=$(mktemp)
+  git -C "$target" init -q .
+  git -C "$target" remote add origin https://github.com/go-to-k/other.git
+  stub=$(mktemp -d)/gh
+  cat > "$stub" <<STUBEOF
+#!/usr/bin/env bash
+printf '%s\n' "\$PWD" >> "$trace"
+# A MERGED PR exists only in the session's own tree, never in the target.
+if [ "\$PWD" = "$other" ]; then
+  echo '[{"number":2195,"mergedAt":"2026-08-25T10:13:25Z","headRefName":"chore/issue-dup-check","title":"x"}]'
+else
+  echo '[]'
+fi
+STUBEOF
+  chmod +x "$stub"
+  out=$(jq -n --arg c "git -C $target push origin chore/issue-dup-check" --arg d "$other" \
+        '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}' \
+        | GH_BIN="$stub" bash "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ] && grep -qxF "$target" "$trace"; then
+    echo "PASS: merged-PR lookup targets the push target, not the session repo"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: gate consulted the wrong repo (rc=$rc, gh cwd: $(tr '\n' ' ' < "$trace"))"
+    fail=$((fail + 1))
+  fi
+  rm -rf "$other" "$target" "$trace"
+}
+cross_repo_case
+
 echo "Pass: $pass  Fail: $fail"
 if [ "$fail" -gt 0 ]; then
   echo

--- a/.claude/hooks/pr-review-gate.sh
+++ b/.claude/hooks/pr-review-gate.sh
@@ -133,29 +133,14 @@ pr_number=""
 # then reads an unrelated integer as the PR number. Measured 2026-08-25:
 # `sleep 30 && gh -R go-to-k/cdkd pr merge 2195 --squash` resolved PR #30,
 # so an unrelated PR's size decided the review tier.
-args="$(gate_pr_selector_rest "$cmd" "$GATE_RE_GH_PR_MERGE")"
-# shellcheck disable=SC2086
-set -- $args
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --*=*) shift; continue ;;
-    --auto|--admin|--delete-branch|--squash|--merge|--rebase)
-      shift; continue ;;
-    -*)
-      # Flag that may take a value; skip the next token defensively.
-      shift
-      [ $# -gt 0 ] && shift
-      continue
-      ;;
-    *)
-      if printf '%s' "$1" | grep -qE '^[0-9]+$'; then
-        pr_number="$1"
-        break
-      fi
-      shift
-      ;;
-  esac
-done
+# Call the shared selector rather than hand-walking its `_rest` output. The
+# first version of this fix replaced the literal STRIP and left the walk, and a
+# review measured the consequence: the local valueless list carried only LONG
+# spellings, so `gh pr merge -d 2195` took the value-consuming arm, ate the
+# number, and the gate judged the CURRENT BRANCH's PR instead. The fence for
+# exactly that shape already existed -- inside `gate_pr_selector`, which this
+# gate did not call. A fence in a helper protects only the callers that use it.
+pr_number="$(gate_pr_selector "$cmd" "$GATE_RE_GH_PR_MERGE")"
 
 # --- Fetch PR stats via gh. --------------------------------------------
 # Pass-through on any gh error so an unrelated infra outage doesn't

--- a/.claude/hooks/pr-review-gate.sh
+++ b/.claude/hooks/pr-review-gate.sh
@@ -128,7 +128,12 @@ pr_number=""
 # wrong token as the PR number. Matching on the full `gh pr merge` phrase
 # (not bare `merge`) is the load-bearing tightening — the prior `#*merge`
 # also matched merge inside `git merge`, `--no-merge`, branch names, etc.
-args="${cmd##*gh pr merge}"
+# The matched-verb strip, not a literal one: `${cmd##*gh pr merge}` returns
+# the WHOLE command under `gh -R <owner/repo> pr merge`, and the walk below
+# then reads an unrelated integer as the PR number. Measured 2026-08-25:
+# `sleep 30 && gh -R go-to-k/cdkd pr merge 2195 --squash` resolved PR #30,
+# so an unrelated PR's size decided the review tier.
+args="$(gate_pr_selector_rest "$cmd" "$GATE_RE_GH_PR_MERGE")"
 # shellcheck disable=SC2086
 set -- $args
 while [ $# -gt 0 ]; do

--- a/.claude/hooks/verify-pr-gate.test.sh
+++ b/.claude/hooks/verify-pr-gate.test.sh
@@ -32,6 +32,7 @@ touch "$side_repo/.markgate.yml" "$main_repo/.markgate.yml"
 SHIM_DIR="$TMPDIR/bin"
 mkdir -p "$SHIM_DIR"
 CWD_TRACE_FILE="$TMPDIR/cwd-trace"
+ARGS_TRACE_FILE=$(mktemp)
 
 cat > "$SHIM_DIR/mise" <<'MISE_EOF'
 #!/usr/bin/env bash
@@ -46,6 +47,14 @@ chmod +x "$SHIM_DIR/mise"
 cat > "$SHIM_DIR/markgate" <<MARKGATE_EOF
 #!/usr/bin/env bash
 echo "\$PWD" >> "$CWD_TRACE_FILE"
+# Record the ARGUMENTS too, not only the cwd. Discarding them left this suite
+# unable to see WHICH gate the hook asked about: swapping
+# `markgate verify verify-pr` for `markgate verify check` kept it at 22/22
+# GREEN, and that mutant is a live bypass -- verify-pr-gate would pass whenever
+# `/check` alone is fresh, with `/verify-pr` never having run. Found by a
+# sibling repo's round-2 test review, which named the class: nothing asserted
+# what the gate ASKS ITS VERIFIER.
+echo "\$*" >> "$ARGS_TRACE_FILE"
 verdict="\${MARKGATE_MOCK_VERDICT:-stale}"
 case "\$1" in
   verify)
@@ -226,6 +235,27 @@ run_case "unexpanded gh -C on pr create REFUSED" 2 stale "" \
 # An unresolvable `cd` is equally unreadable and equally refused.
 run_case "unexpanded cd before gh pr merge REFUSED" 2 fresh "" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"cd \\"$W\\" && gh pr merge 42 --squash"}}' "$main_repo")"
+
+# --- WHICH GATE did the hook ask markgate about? ---------------------------
+# The fourth blind spot, and the one no other case here covers. Every assertion
+# above is about the exit code or the cwd; none is about the QUESTION asked.
+# Mutating `verify verify-pr` to `verify check` leaves all of them green, and
+# that mutant passes whenever `/check` alone is fresh -- i.e. it merges a PR
+# whose `/verify-pr` checklist was never run.
+: > "$ARGS_TRACE_FILE"
+MARKGATE_MOCK_VERDICT=fresh
+export MARKGATE_MOCK_VERDICT
+printf '%s' "$(jq -n --arg c "gh pr create --title t" --arg d "$main_repo" \
+  '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')" \
+  | bash "$HOOK" >/dev/null 2>&1
+unset MARKGATE_MOCK_VERDICT
+if grep -qE '(^| )verify-pr( |$)' "$ARGS_TRACE_FILE"; then
+  echo "ok   markgate was asked about the verify-pr gate specifically"
+  pass=$((pass + 1))
+else
+  echo "FAIL markgate was never asked about verify-pr (asked: $(tr '\n' ';' < "$ARGS_TRACE_FILE"))"
+  fail=$((fail + 1))
+fi
 
 echo
 echo "Pass: $pass  Fail: $fail"


### PR DESCRIPTION
Three gates read the PR number with a **literal** prefix strip:

```bash
args="${cmd##*gh pr merge}"
```

`GATE_GH_C` is the full `GATE_FLAGS` here, so `pr-review-gate`, `ci-green-gate`
and `closes-paren-form-gate` all MATCH `gh -R <owner/repo> pr merge 2195`. They
then fail to strip it — that literal substring is absent, `##*` returns the
WHOLE command — and whatever runs next reads the wrong token. Measured against
the shipped hooks:

```
gh pr merge 2195 --squash                        -> pr-review-gate: PR #2195
sleep 30 && gh -R go-to-k/cdkd pr merge 2195 ...  -> pr-review-gate: PR #30
```

An unrelated PR's LOC and file count therefore decided the review tier. If that
PR is `inline`, the merge passes unreviewed. `closes-paren-form-gate` gets an
empty selector and exits 0 outright.

## Widening the flag absorber was necessary and NOT sufficient

cdkd widened `GATE_GH_C` long ago and was believed immune. What widening did was
let the flagged spelling **reach** gates that still parse it the old way — the
bypass moved one step later rather than closing. Reviews of the same change in
cdk-local and cdk-real-drift found the identical pair, then found two more
layers behind it. Four rounds, each one step deeper:

| | |
|---|---|
| 1 | `gh -R <o/r> pr merge` does not MATCH the gate |
| 2 | it matches, but the selector is parsed with the old literal strip |
| 3 | the strip is fixed, but a flag's VALUE becomes the selector |
| 4 | values are consumed, but a QUOTED value is not one token |

All four are closed here. `gh pr merge -t msg 2195` yielded `msg`, and
`gh pr checks msg` answers `no pull requests found` — straight into
`ci-green-gate`'s fail-open arm. That is **strictly worse** than the empty
selector it replaced, because empty falls back to the current branch and BLOCKS.

## The polarity is the transferable part

The flag list must enumerate **valueless** flags, not value-takers:

- enumerate value-takers → an unlisted value-taking flag leaves its value in
  place → the gate judges a **different PR**;
- enumerate valueless → an unlisted one eats the number → the selector is
  **empty** → the caller falls back or refuses.

Wrong-PR is severe; no-PR is not. An enumeration **will** go stale; the only
thing that can be designed is which way it falls. Verified: `--future-flag 552`
and `feature-branch` both yield empty.

## Two more defects of the same class, found by the sibling reviews

- **`post-merge-orphan-push-gate.sh`** resolved `target_dir` correctly and then
  never used it: `gh pr list --head <branch> --state merged` ran with no `cd`,
  and `gh` has no `-C`, so it read *this session's* repo. These three repos name
  branches by convention, so a push to cdk-real-drift — whose PR was **open** —
  was refused citing cdkd's **merged** #2195, which merely shared the branch
  name. Fenced by a case whose stub RECORDS the cwd it was called from.
- **`gate_leading_c_value`** could not tokenise a flag value containing spaces:
  `git -c core.pager="less -C /evil" commit -m y` split at the first space and
  the tail `-C /evil"` was read as a fresh `-C`. Through `branch-gate` with the
  repo on `main` that turns rc=2 into **rc=0**. Pre-existing on `origin/main`;
  the selector work is what made it visible.

## What a gate's tests must assert

`verify-pr-gate.test.sh` gains one case, worth more than its size. Rewriting
`markgate verify verify-pr` to `verify check` left that suite at **22/22
green** — and that mutant is a live bypass: the gate passes whenever `/check`
alone is fresh, i.e. merges a PR whose `/verify-pr` checklist never ran. The
shim logged `$PWD` and discarded `$*`.

Six other markgate callers share the hole (measured: mutating each to
`verify BOGUS-GATE` leaves every suite green). A class fence is issue #2198,
with the first attempt's three failure modes recorded so the next run does not
rediscover them.

**Exit code, cwd, resolved PR number, resolved directory, and the gate asked
about are five observables, and each is blind to what the others see.**

## Test plan

- **16 new cases** in `lib/command-match.test.sh` — plain, `-R` space, `--repo`
  space, `--repo=`, `-R=`, glued `-RX`, `-C` then `-R`, `-R`/`--repo` AFTER the
  verb, `-t`/`--match-head-commit`/`--body-file` value consumption, a quoted
  flag value as one token, the leading-`sleep 30` trap, an unknown flag failing
  SAFE, a branch name, no-number, and a quoted mention. Plus two `want_dir`
  cases for the `-C`-in-a-quoted-value defect, and the orphan-push cross-repo
  case.
- **Every fence mutation-probed**, each failing exactly its own cases: literal
  strip → the 7 flagged spellings; polarity inverted → the unknown-flag case;
  values not consumed → the 5 value-taker cases; tokeniser reverted → the
  quoted-value cases; `cd` removed from the orphan-push lookup → its case,
  naming the wrong directory; wrong marker name → the new `verify-pr`
  assertion, naming `asked: verify check`.
- 250/250 in `lib/command-match.test.sh`, 23/23 in `verify-pr-gate.test.sh`,
  17/17 in `post-merge-orphan-push-gate.test.sh`, **78/78 across the full hook
  suite** — all under bash 5.3.9 and macOS system bash 3.2.57.
- `vp run check` / `typecheck:test` / `build` / `vp run test` all rc=0
  (776 files, 15,824 tests, no type errors).
