### PR TITLE
chore(hooks): post-merge-orphan-push-gate refused the deletion it documented

### DIFF
--- a/.claude/hooks/post-merge-orphan-push-gate.sh
+++ b/.claude/hooks/post-merge-orphan-push-gate.sh
@@ -79,8 +79,9 @@ hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 # `cd <side> && git push` chain shape, mirroring check-gate.sh
 # (PR #562 fix pattern). `[^|;&]*` matches any flag/value pairs
 # between `git` and the subcommand without crossing pipeline
-# separators. We intentionally do NOT match `git push origin :branch`
-# (delete push) — see explicit deletion check below.
+# separators. We intentionally do NOT gate deletion pushes — both the
+# `git push origin :branch` refspec form and the `--delete` / `-d` flag
+# form — see the explicit deletion check below.
 if ! gate_matches "$cmd" "$GATE_RE_GIT_PUSH"; then
   exit 0
 fi
@@ -136,6 +137,7 @@ tokens=($push_args)
 
 remote=""
 branch=""
+delete_push=0
 i=0
 while [ "$i" -lt "${#tokens[@]}" ]; do
   tok="${tokens[$i]}"
@@ -145,9 +147,22 @@ while [ "$i" -lt "${#tokens[@]}" ]; do
     # Flags that take NO value — skip just this token.
     -u|--set-upstream|-f|--force|--force-with-lease|--force-if-includes|\
     -n|--dry-run|-v|--verbose|-q|--quiet|--all|--tags|--follow-tags|\
-    --mirror|--prune|--delete|--atomic|--no-verify|--verify|--progress|\
+    --mirror|--prune|--atomic|--no-verify|--verify|--progress|\
     --no-progress|--ipv4|--ipv6|-4|-6|--thin|--no-thin|--signed|\
     --no-signed|--porcelain|--no-recurse-submodules)
+      ;;
+    # DELETION, not a content push. Valueless like the group above, but it
+    # inverts what the command MEANS, so it is recorded rather than skipped.
+    # It sat in that group until 2026-08-25, which made the deletion check
+    # below a claim the code did not implement: its comment already said
+    # `git push origin --delete branch` passes through, while the code tested
+    # only the `:branch` refspec form. So the gate refused the routine
+    # post-merge `git push origin --delete <merged-branch>` -- naming the very
+    # PR whose merge is the reason the branch should go -- and the advice it
+    # printed (cherry-pick onto a new branch, open a new PR) was the opposite
+    # of what the user wanted.
+    -d|--delete)
+      delete_push=1
       ;;
     # Flags that DO take a value — skip this token AND the next.
     # `--foo=bar` (single token, captured by *=*) — no extra skip.
@@ -201,12 +216,12 @@ if [ "$remote" != "origin" ]; then
   exit 0
 fi
 
-# `git push origin :branch` (or `git push origin --delete branch`) is an
-# explicit deletion request, not a content push — let it through.
+# `git push origin :branch` and `git push origin --delete branch` are
+# explicit deletion requests, not content pushes — let them through.
 # Likewise `git push origin <sha>:<branch>` (force-push from a specific
 # sha) — we can't safely reason about whether the destination ref is
 # the merged-PR's old head without parsing refspecs, so we pass through.
-if [[ "$branch" == :* ]] || [[ "$branch" == *:* ]]; then
+if [ "$delete_push" -eq 1 ] || [[ "$branch" == :* ]] || [[ "$branch" == *:* ]]; then
   exit 0
 fi
 

--- a/.claude/hooks/post-merge-orphan-push-gate.test.sh
+++ b/.claude/hooks/post-merge-orphan-push-gate.test.sh
@@ -187,6 +187,32 @@ run_case "git push origin :branch (deletion) → pass through" 0 \
   "$del_payload" \
   "$merged_match"
 
+# The FLAG spellings of the same deletion. `--delete` used to sit in the
+# valueless-flag group of the token walk, so it was skipped and the branch
+# name after it was read as a positional -- making the command parse
+# identically to a content push and get refused, while the deletion check's
+# own comment claimed this form passed through. Deleting a merged branch is
+# the routine post-merge cleanup, so the false positive fired on exactly the
+# workflow the gate exists to support.
+del_flag_payload=$(printf '{"cwd":"%s","tool_input":{"command":"git push origin --delete %s"}}' "$feature_repo" "$branch")
+run_case "git push origin --delete branch → pass through" 0 \
+  "$del_flag_payload" \
+  "$merged_match"
+
+del_short_payload=$(printf '{"cwd":"%s","tool_input":{"command":"git push origin -d %s"}}' "$feature_repo" "$branch")
+run_case "git push origin -d branch → pass through" 0 \
+  "$del_short_payload" \
+  "$merged_match"
+
+# Polarity control: the same branch, same mocked merged-PR response, WITHOUT
+# a deletion flag, must still be refused. Without this the two cases above
+# are satisfied by a gate that stopped firing for any reason at all -- the
+# failure mode this session hit four separate times.
+del_control_payload=$(printf '{"cwd":"%s","tool_input":{"command":"git push origin %s"}}' "$feature_repo" "$branch")
+run_case "git push origin branch (no deletion flag) → still blocks" 2 \
+  "$del_control_payload" \
+  "$merged_match"
+
 # --- LINE-START ANCHORING cases (issue #563) ---
 #
 # The matcher MUST NOT fire when the literal substring `git push`


### PR DESCRIPTION
## What

`git push origin --delete <merged-branch>` — the routine post-merge cleanup —
was refused by `post-merge-orphan-push-gate`, which cited the very PR whose
merge is the reason the branch should go, and printed advice (cherry-pick onto
a new branch, open a new PR) that is the opposite of what the caller wanted.

Hit live in this session, immediately after merging #2201.

## Why it happened

The deletion check's own comment already claimed this form passed through:

```sh
# `git push origin :branch` (or `git push origin --delete branch`) is an
# explicit deletion request, not a content push -- let it through.
if [[ "$branch" == :* ]] || [[ "$branch" == *:* ]]; then
```

The code tested only the `:branch` refspec form. `--delete` sat in the
valueless-flag group of the token walk, so it was skipped and the branch name
after it was read as a positional — making a deletion parse **identically** to a
content push. `-d` was not modelled at all and fell to the unknown-flag
catch-all, with the same result.

This is the "a fence must watch the field it claims" shape: the comment
described behaviour the code did not have, so reading the file confirmed the
wrong thing.

## Fix

`--delete` / `-d` are recorded rather than skipped. Unlike every other flag in
that group they invert what the command MEANS, so they belong to the deletion
check rather than to the skip list, and the check now consults the flag.

## Test plan

- **Three cases added**: both flag spellings pass through, plus a **polarity
  control** — the same branch and the same mocked merged-PR response WITHOUT a
  deletion flag must still be refused. Without the control, the two new cases
  are satisfied by a gate that stopped firing for any reason at all, which is a
  failure mode this session hit four separate times.
- **Mutation probe**: reverting only the deletion check (flag still recorded,
  never consulted) fails exactly the two new pass-through cases and leaves the
  control green. The first attempt at this probe used `sed` and died on `bad
  flag in substitute command`, reporting 20/20 on unmutated code — re-run under
  `python3` with an anchor assertion.
- 20/20 in this suite; **all hook suites pass under both bash arms**
  (`run-tests.sh`, rc=0).
- `vp check --fix` / `vp run check` / `typecheck:test` / `build` / `vp run test`
  rc=0 — 777 files, 15,996 tests, no type errors.
- **Live test against the real repro**: `git push origin --delete
  chore/rule-payload-split` (merged PR #2201, branch auto-deleted) now reaches
  git, which reports `remote ref does not exist`. Before this change the same
  command was refused by the hook.
