### PR TITLE
chore(skills): make the work-issues contention list CONTAIN the integ-broad gate scope, and write it once

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -165,18 +165,40 @@ touches:
 
 - `src/deployment/deploy-engine.ts` — the DAG executor, replacement-vs-in-place
   decision, event-driven ordering.
-- `src/deployment/intrinsic-function-resolver.ts` — `Ref` / `Fn::GetAtt` / `Fn::Sub`
-  / cross-stack resolution.
-- `src/analyzer/dag-builder.ts` / `src/analyzer/template-parser.ts` — dependency
-  graph + template parsing / implicit edges.
+- `src/deployment/intrinsic-function-resolver.ts` — `Ref` / `Fn::GetAtt` /
+  `Fn::Sub` / cross-stack resolution.
+- `src/deployment/retry.ts` — the retry loop every mutating AWS call runs through.
+- `src/deployment/retryable-errors.ts` — the terminal-vs-transient classifier the
+  retry loop consults.
+- `src/deployment/rollback-executor.ts` — the reverse walk a failed deploy runs.
+- `src/analyzer/dag-builder.ts` — the dependency graph plus its implicit edges.
+- `src/analyzer/template-parser.ts` — template parsing.
 - `src/provisioning/register-providers.ts` — the provider registry (every new
   provider touches it).
-- `src/cli/commands/deploy.ts` / `src/cli/commands/destroy.ts` — the command
-  entrypoints.
+- `src/cli/commands/deploy.ts` — the deploy command entrypoint.
+- `src/cli/commands/destroy.ts` — the destroy command entrypoint.
+- `src/cli/commands/destroy-runner.ts` — the destroy orchestration behind that
+  entrypoint.
+- `src/cli/commands/export.ts` — the CloudFormation export path.
 
 **At most one lane per cross-cutting file.** Everything else (a single provider, a
 new fixture, a state helper) is usually disjoint. Map each candidate to its target
 file before choosing.
+
+**This list is deliberately NOT the `integ-broad` merge gate's scope, and the two
+answer different questions.** The gate asks which changes need a broad real-AWS
+integ before merge — runtime blast radius. This asks which files admit only one
+lane at a time — edit contention. They overlap because a file sitting under every
+mutating AWS call is also one most fixes touch, so this list CONTAINS the gate's
+`CROSS_CUTTING_REGEX` scope and adds `src/cli/commands/export.ts`, which is
+contested without being gate-relevant. Containment rather than equality is what
+`tests/unit/scripts/cross-cutting-list-sync.test.ts` fences, because the two
+errors do not cost the same: over-inclusion here needlessly serializes one pair of
+lanes, while under-inclusion costs a lane its uncommitted work. So the list may
+grow past the gate but must never fall short of it — adding a file to the gate
+means adding it here too. That is the drift that actually happened:
+go-to-k/cdkd#2042 put `retry.ts`, `retryable-errors.ts` and `rollback-executor.ts`
+into both integ gates while this list kept none of the three.
 
 ## 3. Pick a FEW FILE-DISJOINT issues
 
@@ -405,9 +427,11 @@ gh issue view <n> --json body -q .body | grep -iE 'Session-fit:|Severity:|Effort
   when the scope is generic (`fix(provisioning)`), the files the body names.
   Judge by the command the user runs, not by which directory the code lives in:
   a provider bug that only manifests during `cdkd deploy` is a deploy issue.
-- **Cross-cutting**: the body names any of `deploy-engine.ts`,
-  `intrinsic-function-resolver.ts`, `dag-builder.ts`, `template-parser.ts`,
-  `register-providers.ts`, `destroy-runner.ts`, `export.ts` (the §2 list).
+- **Cross-cutting**: the body names any of the files §2 lists as contested. Do NOT
+  re-enumerate them here — this bullet used to carry its own copy, which named
+  `destroy-runner.ts` and `export.ts`, omitted `deploy.ts` and `destroy.ts`, and
+  still called itself "the §2 list" while being a different list
+  (go-to-k/cdkd#2076). §2 is the only place the list is written.
 - **Session-fit**: the body's own `Session-fit:` line (§3). `next` names a cycle
   this run has to be able to pay for before taking the issue. `now` is a
   COMMITMENT made by the session that filed it, so read it against §3-0: for an
@@ -2219,10 +2243,10 @@ the run evidence behind it — or "no skill change" plus what held.
   target repo because a sibling found it first. Resolve it against the file, open
   PRs and open issues before filing one (§10-c) or claiming one (§3). Which of the
   three finds it depends only on how long ago the other work landed.
-- **One lane per cross-cutting file.** `deploy-engine.ts` / `intrinsic-function-resolver.ts`
-  / `dag-builder.ts` / `register-providers.ts` absorb most non-trivial fixes; you
-  cannot parallelize two issues that both land there. Per-provider fixes ARE
-  disjoint — parallelize those freely.
+- **One lane per cross-cutting file.** The files §2 lists as contested absorb most
+  non-trivial fixes; you cannot parallelize two issues that both land there.
+  Per-provider fixes ARE disjoint — parallelize those freely. §2 holds the list;
+  this bullet does not restate it, for the reason go-to-k/cdkd#2076 records.
 - **Never merge a PR whose destroy path is unverified.** A green CI does not
   exercise real-AWS destroy. If the fix touches any `delete()` / DAG-destroy-order /
   state-cleanup path, the `integ-destroy` (+ `integ-broad`) gate blocks the merge

--- a/tests/unit/scripts/cross-cutting-list-sync.test.ts
+++ b/tests/unit/scripts/cross-cutting-list-sync.test.ts
@@ -40,22 +40,32 @@ import { dirname, join } from 'node:path';
  * added without being wired in here is likewise invisible; the extractor list
  * above is itself hand-maintained.
  *
- * TWO COPIES ARE DELIBERATELY EXCLUDED, both in
- * `.claude/skills/work-issues/SKILL.md`, which carries not one such list but
- * TWO, and they do not agree with each other:
- *   - lines ~165-176, the worktree-collision section's cross-cutting file list:
- *     `deploy-engine.ts`, `intrinsic-function-resolver.ts`, `dag-builder.ts`,
- *     `template-parser.ts`, `register-providers.ts`, `deploy.ts`, `destroy.ts`.
- *   - lines ~385-387, the triage heuristic, which calls itself "(the section-2
- *     list)" while naming `destroy-runner.ts` and `export.ts` and omitting
- *     `deploy.ts` / `destroy.ts` -- so it is not that list, and its own label
- *     is false.
- * Neither is the gate scope: both omit the three files this PR added, the
- * second names `export.ts`, which no gate scopes at all. They serve issue
- * TRIAGE (can two issues be worked as parallel lanes?), not merge gating, so
- * folding either in would assert an equality that was never true. Tracked
- * separately rather than fixed here; reconciling them is a decision about what
- * that heuristic should say.
+ * A SIXTH COPY IS FENCED DIFFERENTLY, and the difference is the point.
+ * `.claude/skills/work-issues/SKILL.md` section 2 carries a cross-cutting file
+ * list of its own, and it answers a DIFFERENT question: not "does this change
+ * need a broad real-AWS integ before merge" (runtime blast radius) but "does
+ * this file admit only one lane at a time" (edit contention). So it is compared
+ * by CONTAINMENT rather than by equality -- it must be a SUPERSET of the gate
+ * scope, and today it is the gate scope plus `src/cli/commands/export.ts`,
+ * which is contested without being gate-relevant.
+ *
+ * Containment is the right relation because the two errors do not cost the
+ * same. Over-inclusion there serializes one pair of lanes that could have run
+ * in parallel; under-inclusion lets two lanes edit one file and costs one of
+ * them its uncommitted work. Asserting EQUALITY would force a choice between
+ * dropping `export.ts` (losing real contention information) and pushing it into
+ * the merge gate (forcing a broad integ on export-only PRs) -- which is why an
+ * earlier revision of this comment excluded the copy outright rather than
+ * folding it in. go-to-k/cdkd#2076 settled it the other way: exclusion left the
+ * exact drift the gate scope's own history predicts, since go-to-k/cdkd#2042
+ * added `retry.ts` / `retryable-errors.ts` / `rollback-executor.ts` to both
+ * integ gates while that list kept none of them.
+ *
+ * That same file used to carry a SECOND, divergent copy in its triage heuristic
+ * -- one that named `destroy-runner.ts` and `export.ts`, omitted `deploy.ts` and
+ * `destroy.ts`, and still labelled itself "the section-2 list". It is gone: the
+ * triage bullet now points at section 2 instead of restating it, so there is
+ * one list in that file and a reference cannot drift from its referent.
  *
  * HOW the prose copies are read, stated as MEASURED rather than as intended.
  * Every extractor is a PREFIX SCAN from a fixed anchor: it consumes consecutive
@@ -87,6 +97,7 @@ const BROAD_HOOK = join(repoRoot, '.claude', 'hooks', 'integ-broad-gate.sh');
 const DESTROY_HOOK = join(repoRoot, '.claude', 'hooks', 'integ-destroy-gate.sh');
 const VERIFY_PR = join(repoRoot, '.claude', 'skills', 'verify-pr', 'SKILL.md');
 const PICK_INTEG = join(repoRoot, '.claude', 'skills', 'pick-integ', 'SKILL.md');
+const WORK_ISSUES = join(repoRoot, '.claude', 'skills', 'work-issues', 'SKILL.md');
 const RUN_INTEG = join(repoRoot, '.claude', 'skills', 'run-integ', 'SKILL.md');
 const MARKGATE_YML = join(repoRoot, '.markgate.yml');
 const CLAUDE_MD = join(repoRoot, 'CLAUDE.md');
@@ -165,6 +176,38 @@ const CROSS_CUTTING_PIN = [
   'src/deployment/rollback-executor.ts',
   'src/provisioning/register-providers.ts',
 ];
+
+/**
+ * The `/work-issues` section-2 CONTENTION list, pinned as literals.
+ *
+ * Deliberately NOT written as `[...CROSS_CUTTING_PIN, '<extra>']`. A table
+ * driven off the very constant it is validating against cannot see a DELETION:
+ * removing an entry from `CROSS_CUTTING_PIN` would silently remove it from the
+ * expected contention list too, and both assertions would stay green while the
+ * file lost an entry. The containment test below compares against the LIVE gate
+ * regex, so the two guards fail for different reasons -- this one on a shrink of
+ * the prose list, that one on the gate growing past it.
+ */
+const CONTENTION_PIN = [
+  'src/analyzer/dag-builder.ts',
+  'src/analyzer/template-parser.ts',
+  'src/cli/commands/deploy.ts',
+  'src/cli/commands/destroy-runner.ts',
+  'src/cli/commands/destroy.ts',
+  'src/cli/commands/export.ts',
+  'src/deployment/deploy-engine.ts',
+  'src/deployment/intrinsic-function-resolver.ts',
+  'src/deployment/retry.ts',
+  'src/deployment/retryable-errors.ts',
+  'src/deployment/rollback-executor.ts',
+  'src/provisioning/register-providers.ts',
+];
+
+const CONTENTION_RATIONALE =
+  'The `/work-issues` section-2 contested-file list decides whether two issues can be worked as ' +
+  'parallel lanes. It is PINNED: adding an entry is cheap and correct, but REMOVING one means ' +
+  'two lanes may now edit that file at once, so say in the PR body why it stopped being ' +
+  'contested.';
 
 const DESTROY_SCOPE_PIN = [
   'src/analyzer/dag-builder.ts',
@@ -337,6 +380,51 @@ function pathsFromPickInteg(): string[] {
     }
   }
   assertFloor(out, 'pick-integ/SKILL.md BROAD-set row', MIN_PATHS);
+  return out;
+}
+
+/**
+ * (f) the `/work-issues` section-2 CONTENTION list.
+ *
+ * Same prefix scan as the others, with one addition the other prose copies do
+ * not need: these bullets carry an explanatory clause after the path and are
+ * hard-wrapped, so a bullet spans several lines. The scan therefore accepts two
+ * line shapes and stops at the first BLANK line -- an entry line
+ * (`- \`<path>\` -- ...`) and a two-space-indented continuation. Anything else
+ * inside the span makes the parse FAIL rather than truncate, because unlike the
+ * gate copies this list's terminator is a blank line rather than a shape
+ * change, and a silently short list here would compare as a subset failure with
+ * a misleading name.
+ */
+function pathsFromWorkIssuesContested(): string[] {
+  const m =
+    /\*\*cross-cutting deploy\/destroy\*\* ones that almost every non-trivial fix\s+eventually\s+touches:\n\n((?:.+\n)+)/.exec(
+      read(WORK_ISSUES),
+    );
+  expect(
+    m,
+    'work-issues/SKILL.md: could not find the section-2 contested-file list. Its anchor ' +
+      'sentence ("...cross-cutting deploy/destroy ones that almost every non-trivial fix ' +
+      'eventually touches:") was reworded, or a blank line now separates it from the bullets. ' +
+      'The extractor asserts here rather than returning [], which would compare equal to ' +
+      'another [] and report green having compared nothing.',
+  ).not.toBeNull();
+  const out: string[] = [];
+  for (const line of m![1].split('\n')) {
+    if (line === '') break;
+    const entry = /^- `([^`]+)` /.exec(line);
+    if (entry !== null) {
+      out.push(entry[1]);
+      continue;
+    }
+    expect(
+      /^ {2}\S/.test(line),
+      `work-issues/SKILL.md: line ${JSON.stringify(line)} inside the contested-file list is ` +
+        'neither a "- `<path>` ..." entry nor a two-space-indented continuation of one. Keep ' +
+        'one path per bullet so the list stays machine-readable.',
+    ).toBe(true);
+  }
+  assertFloor(out, 'work-issues/SKILL.md section-2 contested list', MIN_PATHS);
   return out;
 }
 
@@ -639,6 +727,37 @@ describe('cross-cutting file list stays in sync across its five copies', () => {
 
   it('holds exactly the pinned scope', () => {
     expect(canonical(pathsFromHookRegex()), PIN_RATIONALE).toEqual(canonical(CROSS_CUTTING_PIN));
+  });
+});
+
+describe('work-issues contention list CONTAINS the integ-broad gate scope', () => {
+  it('names every file the live gate regex names', () => {
+    const contested = new Set(pathsFromWorkIssuesContested());
+    const missing = pathsFromHookRegex().filter((p) => !contested.has(p));
+    expect(
+      missing,
+      `these files are in integ-broad-gate.sh's CROSS_CUTTING_REGEX but not in ` +
+        `/work-issues section 2's contested-file list. A file with enough runtime blast radius ` +
+        `to force a broad real-AWS integ is also one most fixes touch, so it admits only one ` +
+        `lane at a time -- and a lane that does not know that will edit it alongside another. ` +
+        `This is a CONTAINMENT check, not an equality one: the contested list may name more ` +
+        `(it names src/cli/commands/export.ts, which no gate scopes), never fewer.`,
+    ).toEqual([]);
+  });
+
+  it('holds exactly the pinned contention list', () => {
+    expect(canonical(pathsFromWorkIssuesContested()), CONTENTION_RATIONALE).toEqual(
+      canonical(CONTENTION_PIN),
+    );
+  });
+
+  it('names only paths that exist', () => {
+    const missing = pathsFromWorkIssuesContested().filter((p) => !existsSync(join(repoRoot, p)));
+    expect(
+      missing,
+      `these contested-file entries name files that no longer exist, so a lane mapping its ` +
+        `issue to a target file can never match them and the entry silently protects nothing`,
+    ).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Closes #2076

## The problem

`.claude/skills/work-issues/SKILL.md` carried the cross-cutting file list THREE
times, all three disagreed, and one of them called itself another. The issue
reported two; the third turned up while fixing it.

| copy | contents | claimed to be |
| --- | --- | --- |
| section 2, "contested files" | 7 files | itself |
| the triage heuristic's Cross-cutting bullet | 7 files, a DIFFERENT 7 | "the section-2 list" |
| the Gotchas bullet (not in the issue) | 4 files | — |

Relative to the live gate scope (`CROSS_CUTTING_REGEX` in
`.claude/hooks/integ-broad-gate.sh`) all three omitted `retry.ts`,
`retryable-errors.ts` and `rollback-executor.ts`. That is not hypothetical drift:
go-to-k/cdkd#2042 put those three into both integ gates and none of the three
prose copies followed.

## The decision, and why neither option in the issue was taken as written

The issue offered (a) make it the gate scope and fence it as a sixth copy, or
(b) keep it deliberately different and delete the false label.

Pure (a) is wrong because the two lists answer different questions: the gate asks
**runtime blast radius** ("does this change need a broad real-AWS integ before
merge"), section 2 asks **edit contention** ("does this file admit only one lane
at a time"). Forcing equality would mean either dropping `src/cli/commands/export.ts`
(losing real contention information) or pushing it into the merge gate (forcing a
broad real-AWS integ on export-only PRs).

Pure (b) fixes the label and installs no mechanism — and the issue's own evidence
is that a comment does not hold two lists in sync.

So: **containment, not equality.** The contention list must CONTAIN the gate
scope and may exceed it. That relation is true, it is fenceable, and it is the
right asymmetry — over-inclusion needlessly serializes one pair of lanes, while
under-inclusion costs a lane its uncommitted work. The sync test's docblock
argument ("folding them in would assert an equality that was never true") is
correct about equality and is preserved; it was never an argument against
containment, and the exclusion is what let go-to-k/cdkd#2042's three files go
missing.

Section 2 is now the only place the list is written (12 entries = the 11 gate
files plus `export.ts`). The other two copies point at it instead of restating
it — a reference cannot drift from its referent.

## The fence

`tests/unit/scripts/cross-cutting-list-sync.test.ts` gains two guards that fail
for DIFFERENT reasons, which was measured rather than asserted:

- **containment** — compares section 2 against the LIVE regex, so it fires when
  the gate grows past the prose
- **the pin** — 12 literals, so it fires when the prose SHRINKS

The pin is deliberately NOT written as `[...CROSS_CUTTING_PIN, 'export.ts']`: a
table driven off the constant it validates cannot see a DELETION, since removing
an entry would silently remove it from the expected list too and both assertions
would stay green.

### Mutation probes

Every probe restored the file and `diff`-verified it afterwards.

| probe | mutation | rc | which guard fired |
| --- | --- | --- | --- |
| baseline | none | 0 | — |
| 1 | delete the `retry.ts` bullet | 1 | containment |
| 2 | delete the `export.ts` bullet | 1 | pin |
| 3 | reword the anchor sentence | 1 | asserts rather than returning an empty set |
| 4 | interleave prose mid-list | 1 | shape/floor refusal |
| independent | delete the `rollback-executor.ts` bullet | 1 | both, verified separately |

Independence confirmed by measurement: with only `export.ts` removed,
containment does NOT fire and the pin does.

## Verification

- containment re-checked by hand against the hook's actual regex: 11/11 gate
  files present, exactly one extra (`export.ts`), counts 12 and 11 as claimed
- `vp run test`: 777 files / 15999 tests, no type errors
- `vp run typecheck` / `lint` / `build` / `typecheck:test`: all rc=0
- `vp run gen:all-matrices` leaves the tree clean
- no `src/**` change, so the deploy / destroy live-test tiers do not apply; the
  arms that DO apply were both taken — the command arm (run the suite, drive the
  failure direction, add the cases) and the prose arm (every claim the new text
  makes resolved against this repo, including the go-to-k/cdkd#2042 citation and
  the "no gate scopes `export.ts`" claim)
