### PR TITLE
chore(hooks): a quoted flag value with a space walked past every GATE_FLAGS gate

### DIFF
--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -178,6 +178,23 @@ run_case "single-line chained git -C status; git -C commit is now CAUGHT (#1455)
 run_case "git -c commit.gpgSign=false commit on main blocked" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git -c commit.gpgSign=false commit -m oops"}}' "$main_repo")"
 
+# The SPACED variant of the line above, and the reason go-to-k/cdkd#2200 exists.
+# `commit.gpgSign=false` has no space, so it never exercised the hole: the value
+# alternative stopped at the first space, which meant a value CONTAINING one
+# ended the flag loop mid-value and the verb was never reached. Measured on the
+# parent commit, this gate returned rc=0 -- a commit straight to `main`, with
+# every gate keyed on GATE_FLAGS equally blind. It was pinned only at the
+# pattern level until this case; the pattern is where the fix lives, but the
+# gate is where the damage was.
+run_case "git -c with a SPACED value, commit on main blocked" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git -c user.name=\\"Jane Doe\\" commit -m oops"}}' "$main_repo")"
+run_case "git --author with a spaced value, commit on main blocked" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git --author=\\"Jane Doe\\" commit -m oops"}}' "$main_repo")"
+# Polarity control at the GATE level: the same spelling on a non-commit verb
+# must still pass, or the widening has simply made this gate fire on everything.
+run_case "git -c with a spaced value, non-commit verb passes" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git -c user.name=\\"Jane Doe\\" status"}}' "$main_repo")"
+
 # 11c. `git push --force` on main — `--force` after the subcommand.
 run_case "git push --force on main blocked" 2 \
   "$(printf '{"cwd":"%s","tool_input":{"command":"git push origin --force"}}' "$main_repo")"

--- a/.claude/hooks/dirty-path-restore-gate.sh
+++ b/.claude/hooks/dirty-path-restore-gate.sh
@@ -161,10 +161,30 @@ while IFS= read -r seg; do
   # and `git restore -S -W f`, while `git restore -SW f` and
   # `git restore -W f` correctly blocked. Pre-existing, found reviewing the
   # rewrite of this arm.
-  case " $seg " in
-    *" --worktree "*|*" -W "*|*" -SW "*|*" -WS "*) ;;   # discards the worktree: do NOT skip
-    *" --staged "*|*" -S "*) continue ;;
-  esac
+  # NOT an enumeration of `-W` clusters. `" -W "|" -SW "|" -WS "` was one, and
+  # it was stale on arrival: `git restore -S -qW f` is legal, matches none of
+  # them, hits the `-S` arm and skipped -- reverting the file with the gate
+  # reporting rc=0. Short flags cluster in any order with any other flag, so
+  # the set of spellings is not enumerable. Ask each WORD instead.
+  seg_has_worktree=0
+  seg_has_staged=0
+  for w in $seg; do
+    case "$w" in
+      --worktree) seg_has_worktree=1 ;;
+      --staged)   seg_has_staged=1 ;;
+      --*)        ;;
+      -*)
+        [[ "${w#-}" == *W* ]] && seg_has_worktree=1
+        [[ "${w#-}" == *S* ]] && seg_has_staged=1
+        ;;
+    esac
+  done
+  # `--staged` alone rewrites the INDEX, so it is skipped. With `--worktree`
+  # alongside it the same command ALSO discards worktree content, so the skip
+  # has to be conditional on `--worktree` being absent.
+  if [ "$seg_has_staged" -eq 1 ] && [ "$seg_has_worktree" -eq 0 ]; then
+    continue
+  fi
   if [[ " $seg " == *" -- "* ]]; then
     paths="$paths ${seg#*-- }"
   else
@@ -192,6 +212,18 @@ split_paths() {
   n=${#text}
   for (( i = 0; i < n; i++ )); do
     ch="${text:i:1}"
+    # A backslash escapes the NEXT character, in a span or out of one. Without
+    # this, `git checkout -- O\'"'"'Brien.txt dirty.txt` opened a quoted span at
+    # the apostrophe that ran to end-of-input, merging every later path into one
+    # token git does not know -- so the gate passed on a dirty file. Same class
+    # as the `\"` hole the lib half of this change fixes, in the tokenizer
+    # written to fix a different one. It also makes the commonest CLI spelling
+    # of a spaced path, `sp\ ace.txt`, a single token.
+    if [[ "$ch" == '\' ]]; then
+      i=$((i + 1))
+      tok="$tok${text:i:1}"
+      continue
+    fi
     if [[ -n "$quote" ]]; then
       if [[ "$ch" == "$quote" ]]; then quote=""; else tok="$tok$ch"; fi
     elif [[ "$ch" == '"' || "$ch" == "'" ]]; then

--- a/.claude/hooks/dirty-path-restore-gate.sh
+++ b/.claude/hooks/dirty-path-restore-gate.sh
@@ -115,18 +115,25 @@ git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 #                                 so `git checkout <branch>` never matches
 #   git restore [flags] <path>... path-scoped by default
 paths=""
-# `$GATE_FLAGS` rather than a local `-C` pattern: the local one had no quoted
-# alternative, so `git -C "/a b" checkout -- f` matched nothing and the gate
-# passed a destructive discard (go-to-k/cdkd#2027 review, blocker 1). GATE_FLAGS
-# contributes 3 capture groups, so the argument tail is [4], not [2].
-if [[ "$command" =~ git${GATE_FLAGS}[[:space:]]+checkout[[:space:]]+(.*)$ ]]; then
-  rest="${BASH_REMATCH[4]}"
+# `gate_verb_rest` rather than a local `=~` with a positional BASH_REMATCH
+# index. Both halves of that old form were hazards. The hand-rolled `-C` pattern
+# it originally used had no quoted alternative, so `git -C "/a b" checkout -- f`
+# matched nothing and the gate passed a destructive discard (go-to-k/cdkd#2027
+# review, blocker 1). Switching to `$GATE_FLAGS` fixed that but made the tail
+# `BASH_REMATCH[4]` -- an index into a SHARED pattern, so widening GATE_FLAGS
+# for `git -c user.name="Jane Doe"` shifted it and this gate silently stopped
+# blocking `git checkout -- <dirty path>` in 7 of its 18 cases
+# (go-to-k/cdkd#2200). The helper strips the matched prefix by LENGTH, so the
+# group count is no longer part of the contract.
+rest="$(gate_verb_rest "$command" "$GATE_RE_GIT_CHECKOUT")"
+if [[ -n "$rest" ]]; then
   case " $rest " in
     *" -- "*) paths="${rest#*-- }" ;;
     *) exit 0 ;;
   esac
-elif [[ "$command" =~ git${GATE_FLAGS}[[:space:]]+restore[[:space:]]+(.*)$ ]]; then
-  rest="${BASH_REMATCH[4]}"
+else
+  rest="$(gate_verb_rest "$command" "$GATE_RE_GIT_RESTORE")"
+  [[ -n "$rest" ]] || exit 0
   # The subject is padded (`" $rest "`), so a trailing-space pattern covers the
   # end-of-string case too — the unpadded `*" --staged"` variants would be dead
   # patterns that can never match.
@@ -138,8 +145,6 @@ elif [[ "$command" =~ git${GATE_FLAGS}[[:space:]]+restore[[:space:]]+(.*)$ ]]; t
   else
     paths="$rest"
   fi
-else
-  exit 0
 fi
 
 # Stop at the first shell operator so a chained command's tokens are not

--- a/.claude/hooks/dirty-path-restore-gate.sh
+++ b/.claude/hooks/dirty-path-restore-gate.sh
@@ -109,6 +109,52 @@ fi
 
 git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 
+# Defined ABOVE every user, and a liveness check below, because this file has
+# already shipped the other way once: a helper defined after its first call
+# makes every call `command not found` (127), and in an `&&` chain that reads
+# as "no match" -- silently, at rc=0. The same shape took out fence 4 of
+# unresolved-target-class.test.sh in an earlier round of this PR.
+# Split QUOTE-AWARE, not on whitespace. `for raw in $paths` word-splits, so
+# `git checkout -- "sp ace.txt"` yielded `"sp` and `ace.txt"`, neither of which
+# is a path git knows, and the gate passed on a dirty file. A path with a space
+# is ordinary and the failure direction is the bad one -- a silent discard of
+# uncommitted work, which is this gate's entire subject.
+split_paths() {
+  local text="$1" tok="" ch quote="" i n
+  n=${#text}
+  for (( i = 0; i < n; i++ )); do
+    ch="${text:i:1}"
+    # A backslash escapes the NEXT character -- but NOT inside a SINGLE-quoted
+    # span, where the shell takes it literally: 'a\b' is a\b, not ab.
+    # The arm sat above the quote test and so applied everywhere. With a
+    # tracked file literally named a\b.txt and dirty, `git restore 'a\b.txt'`
+    # tokenized to ab.txt -- a path git does not know -- and the gate passed
+    # on a dirty file. The double-quoted spelling was already correct.
+    if [[ "$quote" != "'" && "$ch" == '\' ]]; then
+      i=$((i + 1))
+      tok="$tok${text:i:1}"
+      continue
+    fi
+    if [[ -n "$quote" ]]; then
+      if [[ "$ch" == "$quote" ]]; then quote=""; else tok="$tok$ch"; fi
+    elif [[ "$ch" == '"' || "$ch" == "'" ]]; then
+      quote="$ch"
+    elif [[ "$ch" == ' ' || "$ch" == $'\t' ]]; then
+      [[ -n "$tok" ]] && printf '%s\n' "$tok"
+      tok=""
+    else
+      tok="$tok$ch"
+    fi
+  done
+  [[ -n "$tok" ]] && printf '%s\n' "$tok"
+  return 0
+}
+
+if ! command -v split_paths >/dev/null 2>&1; then
+  echo "Blocked by dirty-path-restore-gate: split_paths is not defined at the point it is used, so every call returns 127 and the gate would pass silently." >&2
+  exit 2
+fi
+
 # Extract the path arguments of a PATH-SCOPED restore.
 #
 #   git checkout -- <path>...     the `--` is what makes it a path restore,
@@ -166,19 +212,43 @@ while IFS= read -r seg; do
   # them, hits the `-S` arm and skipped -- reverting the file with the gate
   # reporting rc=0. Short flags cluster in any order with any other flag, so
   # the set of spellings is not enumerable. Ask each WORD instead.
+  # QUOTE-AWARE, via the same splitter the path scan uses. `for w in $seg`
+  # word-split a quoted path, so a FRAGMENT of one could be read as a flag:
+  # `git restore "a -Sx.txt" tracked.txt` yielded a word `-Sx.txt`, set
+  # seg_has_staged, skipped the segment, and passed on a dirty tracked.txt.
+  # That is the word-splitting defect `split_paths` exists to fix, reintroduced
+  # forty lines above it. It also removes the unquoted-expansion glob: `$seg`
+  # containing `*` used to expand against this process's cwd.
   seg_has_worktree=0
   seg_has_staged=0
-  for w in $seg; do
+  while IFS= read -r w; do
     case "$w" in
-      --worktree) seg_has_worktree=1 ;;
-      --staged)   seg_has_staged=1 ;;
-      --*)        ;;
+      # Git accepts any UNAMBIGUOUS PREFIX of a long option, so an exact-match
+      # arm is an enumeration with the same problem the short-flag arm had, one
+      # level up: `git restore --staged --worktr f` set staged=1, worktree=0,
+      # skipped, and DISCARDED the file with the gate returning 0. All eight
+      # prefixes from `--w` to `--worktre` are accepted by git and all eight
+      # reverted the file. The asymmetry is what hides it -- abbreviating BOTH
+      # halves fails safe, because neither flag is recognised here and nothing
+      # is skipped.
+      #
+      # `--st*`, NOT `--s*`: `--source` and `--staged` share the `--s`
+      # prefix, so a `--s*` arm reads `--sou` as staged and skips a segment
+      # that stages nothing. An explicit `--so*) ;;` arm was written first and
+      # a probe showed it fences nothing -- with `--st*` in place, `--so...`
+      # already falls through to `--*` and is ignored. The two `--sou` cases
+      # in the suite guard the `--s*` WIDENING, which is the change that would
+      # actually break this. A bare `--s` is ambiguous and git rejects it, so
+      # leaving it unclassified costs nothing -- the command does not run.
+      --w*)  seg_has_worktree=1 ;;
+      --st*) seg_has_staged=1 ;;
+      --*)   ;;
       -*)
         [[ "${w#-}" == *W* ]] && seg_has_worktree=1
         [[ "${w#-}" == *S* ]] && seg_has_staged=1
         ;;
     esac
-  done
+  done < <(split_paths "$seg")
   # `--staged` alone rewrites the INDEX, so it is skipped. With `--worktree`
   # alongside it the same command ALSO discards worktree content, so the skip
   # has to be conditional on `--worktree` being absent.
@@ -202,42 +272,6 @@ done < <(gate_verb_rest_each "$command" "$GATE_RE_GIT_RESTORE")
 # operator left to strip -- and stripping anyway would silently drop a path
 # containing one of those characters.
 
-# Split QUOTE-AWARE, not on whitespace. `for raw in $paths` word-splits, so
-# `git checkout -- "sp ace.txt"` yielded `"sp` and `ace.txt"`, neither of which
-# is a path git knows, and the gate passed on a dirty file. A path with a space
-# is ordinary and the failure direction is the bad one -- a silent discard of
-# uncommitted work, which is this gate's entire subject.
-split_paths() {
-  local text="$1" tok="" ch quote="" i n
-  n=${#text}
-  for (( i = 0; i < n; i++ )); do
-    ch="${text:i:1}"
-    # A backslash escapes the NEXT character, in a span or out of one. Without
-    # this, `git checkout -- O\'"'"'Brien.txt dirty.txt` opened a quoted span at
-    # the apostrophe that ran to end-of-input, merging every later path into one
-    # token git does not know -- so the gate passed on a dirty file. Same class
-    # as the `\"` hole the lib half of this change fixes, in the tokenizer
-    # written to fix a different one. It also makes the commonest CLI spelling
-    # of a spaced path, `sp\ ace.txt`, a single token.
-    if [[ "$ch" == '\' ]]; then
-      i=$((i + 1))
-      tok="$tok${text:i:1}"
-      continue
-    fi
-    if [[ -n "$quote" ]]; then
-      if [[ "$ch" == "$quote" ]]; then quote=""; else tok="$tok$ch"; fi
-    elif [[ "$ch" == '"' || "$ch" == "'" ]]; then
-      quote="$ch"
-    elif [[ "$ch" == ' ' || "$ch" == $'\t' ]]; then
-      [[ -n "$tok" ]] && printf '%s\n' "$tok"
-      tok=""
-    else
-      tok="$tok$ch"
-    fi
-  done
-  [[ -n "$tok" ]] && printf '%s\n' "$tok"
-  return 0
-}
 
 dirty_paths=()
 while IFS= read -r p; do

--- a/.claude/hooks/dirty-path-restore-gate.sh
+++ b/.claude/hooks/dirty-path-restore-gate.sh
@@ -124,15 +124,29 @@ split_paths() {
   n=${#text}
   for (( i = 0; i < n; i++ )); do
     ch="${text:i:1}"
-    # A backslash escapes the NEXT character -- but NOT inside a SINGLE-quoted
-    # span, where the shell takes it literally: 'a\b' is a\b, not ab.
-    # The arm sat above the quote test and so applied everywhere. With a
-    # tracked file literally named a\b.txt and dirty, `git restore 'a\b.txt'`
-    # tokenized to ab.txt -- a path git does not know -- and the gate passed
-    # on a dirty file. The double-quoted spelling was already correct.
-    if [[ "$quote" != "'" && "$ch" == '\' ]]; then
-      i=$((i + 1))
-      tok="$tok${text:i:1}"
+    # Backslash handling follows the SHELL, which is different in each of the
+    # three contexts and was got wrong in two of them across two rounds:
+    #   - single-quoted span: never an escape. 'a\b' is a\b.
+    #   - double-quoted span: an escape ONLY before $ ` " \ or a newline.
+    #     Before anything else the backslash is RETAINED, so "a\b.txt" is the
+    #     path a\b.txt -- and emitting ab.txt made the gate pass on a dirty
+    #     file of that name. The round that fixed the single-quote case
+    #     asserted "the double-quoted spelling was already correct", which
+    #     held only for the "a\\b.txt" spelling its one test used.
+    #   - outside any span: always an escape.
+    if [[ "$ch" == '\' ]]; then
+      _nxt="${text:$((i + 1)):1}"
+      if [[ "$quote" == "'" ]]; then
+        tok="$tok$ch"
+      elif [[ "$quote" == '"' ]]; then
+        case "$_nxt" in
+          '$'|'`'|'"'|'\'|"")
+            i=$((i + 1)); tok="$tok$_nxt" ;;
+          *) tok="$tok$ch" ;;
+        esac
+      else
+        i=$((i + 1)); tok="$tok$_nxt"
+      fi
       continue
     fi
     if [[ -n "$quote" ]]; then
@@ -161,6 +175,7 @@ fi
 #                                 so `git checkout <branch>` never matches
 #   git restore [flags] <path>... path-scoped by default
 paths=""
+pathspec_file_seen=0
 # `gate_verb_rest` rather than a local `=~` with a positional BASH_REMATCH
 # index. Both halves of that old form were hazards. The hand-rolled `-C` pattern
 # it originally used had no quoted alternative, so `git -C "/a b" checkout -- f`
@@ -221,13 +236,14 @@ while IFS= read -r seg; do
   # containing `*` used to expand against this process's cwd.
   seg_has_worktree=0
   seg_has_staged=0
+  seg_has_pathspec_file=0
   while IFS= read -r w; do
     case "$w" in
       # Git accepts any UNAMBIGUOUS PREFIX of a long option, so an exact-match
       # arm is an enumeration with the same problem the short-flag arm had, one
       # level up: `git restore --staged --worktr f` set staged=1, worktree=0,
       # skipped, and DISCARDED the file with the gate returning 0. All eight
-      # prefixes from `--w` to `--worktre` are accepted by git and all eight
+      # spellings from `--w` to `--worktree` are accepted by git and all eight
       # reverted the file. The asymmetry is what hides it -- abbreviating BOTH
       # halves fails safe, because neither flag is recognised here and nothing
       # is skipped.
@@ -240,15 +256,40 @@ while IFS= read -r seg; do
       # in the suite guard the `--s*` WIDENING, which is the change that would
       # actually break this. A bare `--s` is ambiguous and git rejects it, so
       # leaving it unclassified costs nothing -- the command does not run.
+      --pathspec-from-file*|--pathspec-file-nul*) seg_has_pathspec_file=1 ;;
       --w*)  seg_has_worktree=1 ;;
       --st*) seg_has_staged=1 ;;
       --*)   ;;
       -*)
-        [[ "${w#-}" == *W* ]] && seg_has_worktree=1
-        [[ "${w#-}" == *S* ]] && seg_has_staged=1
+        # Scan the cluster CHARACTER BY CHARACTER and stop at the first
+        # value-taking letter, because everything after it is that flag's
+        # VALUE rather than more flags. `git restore -sSTABLE f` is
+        # `-s STABLE`, and a substring test on the whole token read the `S`
+        # of STABLE as `--staged`, skipped the segment, and discarded the
+        # worktree copy. `-s` is the only value-taking short option
+        # `git restore` has.
+        _cluster="${w#-}"
+        while [ -n "$_cluster" ]; do
+          case "${_cluster:0:1}" in
+            s) break ;;
+            S) seg_has_staged=1 ;;
+            W) seg_has_worktree=1 ;;
+          esac
+          _cluster="${_cluster:1}"
+        done
         ;;
     esac
   done < <(split_paths "$seg")
+  # `--pathspec-from-file` names its paths in a FILE, so the segment carries
+  # none of them and every check below finds nothing to object to -- the gate
+  # returned 0 while git discarded every path the file listed. A path set this
+  # parser cannot enumerate is exactly the case for refusing rather than
+  # passing, which is what the rest of this gate does with a target it cannot
+  # read.
+  if [ "$seg_has_pathspec_file" -eq 1 ]; then
+    pathspec_file_seen=1
+    break
+  fi
   # `--staged` alone rewrites the INDEX, so it is skipped. With `--worktree`
   # alongside it the same command ALSO discards worktree content, so the skip
   # has to be conditional on `--worktree` being absent.
@@ -261,6 +302,22 @@ while IFS= read -r seg; do
     paths="$paths $seg"
   fi
 done < <(gate_verb_rest_each "$command" "$GATE_RE_GIT_RESTORE")
+
+if [ "$pathspec_file_seen" -eq 1 ]; then
+  {
+    echo "Blocked by dirty-path-restore-gate: this discards UNCOMMITTED work."
+    echo
+    echo "The command names its paths with --pathspec-from-file, so they live in a"
+    echo "FILE this hook cannot reliably read at PreToolUse time. Every path in that"
+    echo "file would be reverted to HEAD, and a gate that cannot enumerate them"
+    echo "refuses rather than passing -- the same choice this hook makes for a target"
+    echo "directory it cannot resolve."
+    echo
+    echo "Name the paths on the command line, or set CDKD_ALLOW_DIRTY_RESTORE=1 if"
+    echo "discarding them is the intent."
+  } >&2
+  exit 2
+fi
 
 [[ -n "${paths// /}" ]] || exit 0
 

--- a/.claude/hooks/dirty-path-restore-gate.sh
+++ b/.claude/hooks/dirty-path-restore-gate.sh
@@ -138,7 +138,6 @@ paths=""
 #
 # A branch switch chained ahead of a discard is an everyday shape, so the arm
 # that finds nothing must FALL THROUGH, never exit.
-paths=""
 while IFS= read -r seg; do
   [ -n "$seg" ] || continue
   # `git checkout` is a path restore only when `--` is present; without it the
@@ -154,7 +153,16 @@ while IFS= read -r seg; do
   # end-of-string case too — the unpadded `*" --staged"` variants would be dead
   # patterns that can never match. `continue`, not `exit 0`: a staged restore in
   # one segment says nothing about a worktree restore in the next.
+  #
+  # `--staged` alone rewrites the INDEX only, which is why it is skipped. With
+  # `--worktree` alongside it, the same command ALSO discards worktree content
+  # -- so the skip has to be conditional on `--worktree` being absent. Both
+  # spellings were passing on a dirty file: `git restore --staged --worktree f`
+  # and `git restore -S -W f`, while `git restore -SW f` and
+  # `git restore -W f` correctly blocked. Pre-existing, found reviewing the
+  # rewrite of this arm.
   case " $seg " in
+    *" --worktree "*|*" -W "*|*" -SW "*|*" -WS "*) ;;   # discards the worktree: do NOT skip
     *" --staged "*|*" -S "*) continue ;;
   esac
   if [[ " $seg " == *" -- "* ]]; then
@@ -174,17 +182,41 @@ done < <(gate_verb_rest_each "$command" "$GATE_RE_GIT_RESTORE")
 # operator left to strip -- and stripping anyway would silently drop a path
 # containing one of those characters.
 
+# Split QUOTE-AWARE, not on whitespace. `for raw in $paths` word-splits, so
+# `git checkout -- "sp ace.txt"` yielded `"sp` and `ace.txt"`, neither of which
+# is a path git knows, and the gate passed on a dirty file. A path with a space
+# is ordinary and the failure direction is the bad one -- a silent discard of
+# uncommitted work, which is this gate's entire subject.
+split_paths() {
+  local text="$1" tok="" ch quote="" i n
+  n=${#text}
+  for (( i = 0; i < n; i++ )); do
+    ch="${text:i:1}"
+    if [[ -n "$quote" ]]; then
+      if [[ "$ch" == "$quote" ]]; then quote=""; else tok="$tok$ch"; fi
+    elif [[ "$ch" == '"' || "$ch" == "'" ]]; then
+      quote="$ch"
+    elif [[ "$ch" == ' ' || "$ch" == $'\t' ]]; then
+      [[ -n "$tok" ]] && printf '%s\n' "$tok"
+      tok=""
+    else
+      tok="$tok$ch"
+    fi
+  done
+  [[ -n "$tok" ]] && printf '%s\n' "$tok"
+  return 0
+}
+
 dirty_paths=()
-for raw in $paths; do
-  [[ "$raw" == -* ]] && continue
-  [[ "$raw" == "--" ]] && continue
-  p="${raw%\"}"; p="${p#\"}"; p="${p%\'}"; p="${p#\'}"
+while IFS= read -r p; do
+  [[ "$p" == -* ]] && continue
+  [[ "$p" == "--" ]] && continue
   [[ -n "$p" ]] || continue
   # `git status --porcelain <path>` prints nothing when the path is clean.
   if status_out=$(git -C "$cwd" status --porcelain -- "$p" 2>/dev/null); then
     [[ -n "$status_out" ]] && dirty_paths+=("$p")
   fi
-done
+done < <(split_paths "$paths")
 
 [[ ${#dirty_paths[@]} -gt 0 ]] || exit 0
 

--- a/.claude/hooks/dirty-path-restore-gate.sh
+++ b/.claude/hooks/dirty-path-restore-gate.sh
@@ -125,36 +125,54 @@ paths=""
 # blocking `git checkout -- <dirty path>` in 7 of its 18 cases
 # (go-to-k/cdkd#2200). The helper strips the matched prefix by LENGTH, so the
 # group count is no longer part of the contract.
-rest="$(gate_verb_rest "$command" "$GATE_RE_GIT_CHECKOUT")"
-if [[ -n "$rest" ]]; then
-  case " $rest " in
-    *" -- "*) paths="${rest#*-- }" ;;
-    *) exit 0 ;;
+# EVERY matching segment, and both verbs, rather than "probe checkout, else
+# probe restore". The first-match form this replaces had a live regression found
+# in review: `git checkout main && git checkout -- f.txt` returned segment 1,
+# which has no `--`, so the gate exited 0 and never saw the segment that
+# discards the file. Measured old-vs-new on a repo with a dirty `f.txt`, all
+# three of these went BLOCK -> pass:
+#
+#   git checkout main && git checkout -- f.txt
+#   git checkout -b wip && git restore -- f.txt
+#   git checkout main; git restore -- f.txt
+#
+# A branch switch chained ahead of a discard is an everyday shape, so the arm
+# that finds nothing must FALL THROUGH, never exit.
+paths=""
+while IFS= read -r seg; do
+  [ -n "$seg" ] || continue
+  # `git checkout` is a path restore only when `--` is present; without it the
+  # segment is a branch switch and simply contributes nothing.
+  case " $seg " in
+    *" -- "*) paths="$paths ${seg#*-- }" ;;
   esac
-else
-  rest="$(gate_verb_rest "$command" "$GATE_RE_GIT_RESTORE")"
-  [[ -n "$rest" ]] || exit 0
-  # The subject is padded (`" $rest "`), so a trailing-space pattern covers the
-  # end-of-string case too — the unpadded `*" --staged"` variants would be dead
-  # patterns that can never match.
-  case " $rest " in
-    *" --staged "*|*" -S "*) exit 0 ;;
-  esac
-  if [[ " $rest " == *" -- "* ]]; then
-    paths="${rest#*-- }"
-  else
-    paths="$rest"
-  fi
-fi
+done < <(gate_verb_rest_each "$command" "$GATE_RE_GIT_CHECKOUT")
 
-# Stop at the first shell operator so a chained command's tokens are not
-# mistaken for paths.
-paths="${paths%%&&*}"
-paths="${paths%%||*}"
-paths="${paths%%;*}"
-paths="${paths%%|*}"
+while IFS= read -r seg; do
+  [ -n "$seg" ] || continue
+  # The subject is padded (`" $seg "`), so a trailing-space pattern covers the
+  # end-of-string case too — the unpadded `*" --staged"` variants would be dead
+  # patterns that can never match. `continue`, not `exit 0`: a staged restore in
+  # one segment says nothing about a worktree restore in the next.
+  case " $seg " in
+    *" --staged "*|*" -S "*) continue ;;
+  esac
+  if [[ " $seg " == *" -- "* ]]; then
+    paths="$paths ${seg#*-- }"
+  else
+    paths="$paths $seg"
+  fi
+done < <(gate_verb_rest_each "$command" "$GATE_RE_GIT_RESTORE")
 
 [[ -n "${paths// /}" ]] || exit 0
+
+# NO operator-stripping here any more, and its absence is deliberate. The old
+# form matched the RAW command with a greedy `(.*)$`, so the tail ran past
+# `&&` / `;` and had to be truncated; that truncation is also what made a
+# chained discard look like one command. The tails now come from
+# `gate_verb_rest_each`, which yields already-split segments, so there is no
+# operator left to strip -- and stripping anyway would silently drop a path
+# containing one of those characters.
 
 dirty_paths=()
 for raw in $paths; do

--- a/.claude/hooks/dirty-path-restore-gate.test.sh
+++ b/.claude/hooks/dirty-path-restore-gate.test.sh
@@ -36,6 +36,12 @@ make_repo() {
   # non-paths and the gate passed on a dirty file -- a silent discard, which is
   # the failure direction this gate exists to prevent.
   echo "original" > "$dir/sp ace.txt"
+  # An apostrophe in a filename is ordinary; it opened a quoted span that ran to
+  # end-of-input in the hand-written tokenizer, swallowing every later path.
+  # The apostrophe goes through a variable: writing it inline needs the
+  # `'"'"'` dance, which is what broke this file once already.
+  apos="'"
+  echo "original" > "$dir/O${apos}Brien.txt"
   git -C "$dir" add -A
   git -C "$dir" commit -qm init
   echo "$dir"
@@ -91,6 +97,26 @@ run "staged AND worktree restore blocks"       "$R" "git restore --staged --work
 run "short -S -W restore blocks"               "$R" "git restore -S -W tracked.txt" 2
 run "combined -SW restore blocks"              "$R" "git restore -SW tracked.txt" 2
 run "worktree-only restore blocks"             "$R" "git restore -W tracked.txt" 2
+
+# The `-W` cluster spellings an ENUMERATION misses. `git restore -S -qW f` is
+# legal, matched none of `" -W "|" -SW "|" -WS "`, hit the `-S` arm, and was
+# skipped -- reverting the file while the gate reported rc=0. Short flags
+# cluster in any order with any other flag, so the set is not enumerable.
+run "clustered -qW after -S blocks"            "$R" "git restore -S -qW tracked.txt" 2
+run "clustered -Wq after -S blocks"            "$R" "git restore -S -Wq tracked.txt" 2
+run "long --worktree after --staged blocks"    "$R" "git restore --staged --worktree tracked.txt" 2
+# Control: a cluster with NO W must still be skipped, or the predicate has
+# simply stopped skipping anything.
+run "clustered -qS with no W passes"           "$R" "git restore -qS tracked.txt" 0
+
+# BACKSLASH escapes. Without them an escaped quote opens a span that runs to
+# end-of-input, so every later path merges into one token git does not know and
+# the gate passes on a dirty file.
+RBS=$(make_repo); echo "modified" > "$RBS/tracked.txt"
+run "escaped apostrophe then a dirty path blocks" "$RBS" "git checkout -- O\\'Brien.txt tracked.txt" 2
+run "escaped quote then a dirty path blocks"      "$RBS" "git checkout -- say\\\"hi.txt tracked.txt" 2
+RBS2=$(make_repo); echo "modified" > "$RBS2/sp ace.txt"
+run "backslash-escaped space is one path"         "$RBS2" "git restore sp\\ ace.txt" 2
 
 # QUOTED paths containing a space. `for raw in $paths` split these into `"sp`
 # and `ace.txt"`, neither of which git knows, so the gate passed.

--- a/.claude/hooks/dirty-path-restore-gate.test.sh
+++ b/.claude/hooks/dirty-path-restore-gate.test.sh
@@ -32,6 +32,10 @@ make_repo() {
   git -C "$dir" config user.name t
   echo "original" > "$dir/tracked.txt"
   echo "original" > "$dir/other.txt"
+  # A path with a SPACE, because `for raw in $paths` word-split it into two
+  # non-paths and the gate passed on a dirty file -- a silent discard, which is
+  # the failure direction this gate exists to prevent.
+  echo "original" > "$dir/sp ace.txt"
   git -C "$dir" add -A
   git -C "$dir" commit -qm init
   echo "$dir"
@@ -78,8 +82,26 @@ run "checkout -b alone passes"                 "$R" "git checkout -b wip" 0
 # `--staged` is per-SEGMENT, not per-command. The old form exited 0 for the
 # whole command on seeing `--staged`, so a staged restore chained ahead of a
 # worktree restore passed the worktree one through untested.
-run "staged restore alone passes"              "$R" "git restore --staged tracked.txt" 0
 run "staged THEN worktree restore blocks"      "$R" "git restore --staged tracked.txt && git restore tracked.txt" 2
+
+# `--staged` alone rewrites the index; WITH `--worktree` the same command also
+# discards worktree content, so the skip has to be conditional. Both spellings
+# passed on a dirty file until this was fenced.
+run "staged AND worktree restore blocks"       "$R" "git restore --staged --worktree tracked.txt" 2
+run "short -S -W restore blocks"               "$R" "git restore -S -W tracked.txt" 2
+run "combined -SW restore blocks"              "$R" "git restore -SW tracked.txt" 2
+run "worktree-only restore blocks"             "$R" "git restore -W tracked.txt" 2
+
+# QUOTED paths containing a space. `for raw in $paths` split these into `"sp`
+# and `ace.txt"`, neither of which git knows, so the gate passed.
+RSP=$(make_repo); echo "modified" > "$RSP/sp ace.txt"
+run "quoted path with a space, checkout blocks"  "$RSP" "git checkout -- \"sp ace.txt\"" 2
+run "quoted path with a space, restore blocks"   "$RSP" "git restore \"sp ace.txt\"" 2
+run "single-quoted path with a space blocks"     "$RSP" "git restore 'sp ace.txt'" 2
+# Control: the same repo with that file CLEAN must pass, or the three above are
+# satisfied by a gate that blocks whenever it sees a quote.
+RSPC=$(make_repo)
+run "quoted path with a space, clean, passes"    "$RSPC" "git checkout -- \"sp ace.txt\"" 0
 run "restore <dirty path> blocks" "$R" "git restore tracked.txt" 2
 run "restore -- <dirty path> blocks" "$R" "git restore -- tracked.txt" 2
 run "escape hatch is honored" "$R" "CDKD_ALLOW_DIRTY_RESTORE=1 git checkout -- tracked.txt" 2

--- a/.claude/hooks/dirty-path-restore-gate.test.sh
+++ b/.claude/hooks/dirty-path-restore-gate.test.sh
@@ -40,7 +40,12 @@ make_repo() {
   # end-of-input in the hand-written tokenizer, swallowing every later path.
   # The apostrophe goes through a variable: writing it inline needs the
   # `'"'"'` dance, which is what broke this file once already.
-  apos="'"
+  local apos="'"
+  # A literal BACKSLASH in a filename: inside a single-quoted span the
+  # shell takes it literally, so the tokenizer must not treat it as an
+  # escape there.
+  local bslash="\\"
+  echo "original" > "$dir/a${bslash}b.txt"
   echo "original" > "$dir/O${apos}Brien.txt"
   git -C "$dir" add -A
   git -C "$dir" commit -qm init
@@ -117,6 +122,45 @@ run "escaped apostrophe then a dirty path blocks" "$RBS" "git checkout -- O\\'Br
 run "escaped quote then a dirty path blocks"      "$RBS" "git checkout -- say\\\"hi.txt tracked.txt" 2
 RBS2=$(make_repo); echo "modified" > "$RBS2/sp ace.txt"
 run "backslash-escaped space is one path"         "$RBS2" "git restore sp\\ ace.txt" 2
+
+# Git accepts any UNAMBIGUOUS PREFIX of a long option, so an exact-match arm is
+# an enumeration one level up from the short-flag one. `--staged --worktr`
+# reverted the file with the gate returning 0. The asymmetry is what hides it:
+# abbreviating BOTH halves fails safe, because neither flag is recognised and
+# nothing is skipped.
+RPX=$(make_repo); echo "modified" > "$RPX/tracked.txt"
+run "abbreviated --worktr after --staged blocks"  "$RPX" "git restore --staged --worktr tracked.txt" 2
+run "abbreviated --work after --staged blocks"    "$RPX" "git restore --staged --work tracked.txt" 2
+run "abbreviated --worktr after -S blocks"        "$RPX" "git restore -S --worktr tracked.txt" 2
+# Controls: an abbreviated STAGED-only restore is index-only and must still be
+# skipped, and `--source` must not be read as an abbreviation of `--staged`.
+run "abbreviated --stag alone passes"             "$RPX" "git restore --stag tracked.txt" 0
+run "--source is not --staged"                    "$RPX" "git restore --source=HEAD tracked.txt" 2
+
+# A backslash inside a SINGLE-quoted span is literal, not an escape.
+RQ=$(make_repo); echo "modified" > "$RQ/a\\b.txt"
+run "backslash inside single quotes is literal"   "$RQ" "git restore 'a\\b.txt'" 2
+run "backslash inside double quotes escapes"      "$RQ" 'git restore "a\\b.txt"' 2
+
+# A QUOTED path whose text contains a flag-shaped fragment. `for w in $seg`
+# word-split it, so `-Sx.txt` was read as a staged flag, the segment was
+# skipped, and a dirty tracked.txt passed -- the word-splitting defect
+# `split_paths` exists to fix, reintroduced in the flag scan above it.
+RWS=$(make_repo); echo "modified" > "$RWS/tracked.txt"
+run "flag-shaped fragment in a quoted path blocks" "$RWS" 'git restore "a -Sx.txt" tracked.txt' 2
+run "W-shaped fragment in a quoted path blocks"    "$RWS" 'git restore "a -Wx.txt" tracked.txt' 2
+# Control: the same shape with no flag-like fragment must block for the ORDINARY
+# reason, so the two above cannot be satisfied by a gate that blocks on sight of
+# a quote.
+run "plain quoted path still blocks"               "$RWS" 'git restore "a x.txt" tracked.txt' 2
+
+# `--source` and `--staged` share the `--s` prefix. Matching only the literal
+# `--source` let `--sou` fall through to the staged arm and skip a segment that
+# stages nothing.
+run "abbreviated --sou is not --staged"            "$RWS" "git restore --sou HEAD~1 tracked.txt" 2
+run "abbreviated --sourc is not --staged"          "$RWS" "git restore --sourc HEAD~1 tracked.txt" 2
+# Control: an abbreviated STAGED restore is index-only and must still pass.
+run "abbreviated --stage alone passes"             "$RWS" "git restore --stage tracked.txt" 0
 
 # QUOTED paths containing a space. `for raw in $paths` split these into `"sp`
 # and `ace.txt"`, neither of which git knows, so the gate passed.

--- a/.claude/hooks/dirty-path-restore-gate.test.sh
+++ b/.claude/hooks/dirty-path-restore-gate.test.sh
@@ -162,6 +162,28 @@ run "abbreviated --sourc is not --staged"          "$RWS" "git restore --sourc H
 # Control: an abbreviated STAGED restore is index-only and must still pass.
 run "abbreviated --stage alone passes"             "$RWS" "git restore --stage tracked.txt" 0
 
+# In a DOUBLE-quoted span bash escapes only before $ ` " \ or a newline; before
+# anything else the backslash is RETAINED. So "a\b.txt" is the path a\b.txt,
+# and emitting ab.txt made the gate pass on a dirty file of that name. The
+# round that fixed the single-quote case asserted the double-quoted spelling
+# was already correct -- true only of the "a\\b.txt" form its one case used,
+# which is why that case fenced nothing.
+run "backslash before an ordinary char in dquotes is literal" "$RQ" 'git restore "a\b.txt"' 2
+run "backslash before a dquote in dquotes escapes"            "$RQ" 'git restore "a\\b.txt"' 2
+
+# An attached VALUE on a short option is not more flags. `git restore -sSTABLE f`
+# is `-s STABLE`, and a substring test on the whole token read the `S` of
+# STABLE as `--staged`, skipped the segment, and discarded the worktree copy.
+run "uppercase S inside a short option VALUE is not --staged" "$RWS" "git restore -sSTABLE tracked.txt" 2
+# Control: a real clustered -S with no value still skips.
+run "clustered -qS with a value-free cluster passes"          "$RWS" "git restore -qS tracked.txt" 0
+
+# `--pathspec-from-file` names its paths in a FILE, so the segment carries none
+# of them: every check found nothing to object to and the gate returned 0 while
+# git discarded every path the file listed.
+run "--pathspec-from-file is refused, not passed"             "$RWS" "git restore --pathspec-from-file=list.txt" 2
+run "--pathspec-file-nul is refused, not passed"              "$RWS" "git restore --pathspec-from-file=- --pathspec-file-nul" 2
+
 # QUOTED paths containing a space. `for raw in $paths` split these into `"sp`
 # and `ace.txt"`, neither of which git knows, so the gate passed.
 RSP=$(make_repo); echo "modified" > "$RSP/sp ace.txt"

--- a/.claude/hooks/dirty-path-restore-gate.test.sh
+++ b/.claude/hooks/dirty-path-restore-gate.test.sh
@@ -58,6 +58,28 @@ run() {
 # --- dirty path: must BLOCK ------------------------------------------------
 R=$(make_repo); echo "modified" > "$R/tracked.txt"
 run "checkout -- <dirty path> blocks" "$R" "git checkout -- tracked.txt" 2
+
+# CHAINED shapes. None of the cases below this file's original 18 was chained,
+# which is why a live regression stayed green through a full review round:
+# converting the gate from a raw-command match to a per-segment one made it
+# read only the FIRST segment matching each verb, so a branch switch ahead of a
+# discard ended the probe. Measured at the time, all three went BLOCK -> pass.
+# A branch switch chained ahead of a discard is an everyday shape.
+run "branch switch THEN discard blocks"        "$R" "git checkout main && git checkout -- tracked.txt" 2
+run "checkout -b THEN restore blocks"          "$R" "git checkout -b wip && git restore -- tracked.txt" 2
+run "semicolon-chained discard blocks"         "$R" "git checkout main; git restore -- tracked.txt" 2
+run "discard THEN branch switch blocks"        "$R" "git restore tracked.txt && git checkout main" 2
+
+# Polarity controls for those four. Without them "it blocks" is satisfied by a
+# gate that blocks everything, which is the shape this session hit four times.
+run "branch switch alone passes"               "$R" "git checkout main" 0
+run "checkout -b alone passes"                 "$R" "git checkout -b wip" 0
+
+# `--staged` is per-SEGMENT, not per-command. The old form exited 0 for the
+# whole command on seeing `--staged`, so a staged restore chained ahead of a
+# worktree restore passed the worktree one through untested.
+run "staged restore alone passes"              "$R" "git restore --staged tracked.txt" 0
+run "staged THEN worktree restore blocks"      "$R" "git restore --staged tracked.txt && git restore tracked.txt" 2
 run "restore <dirty path> blocks" "$R" "git restore tracked.txt" 2
 run "restore -- <dirty path> blocks" "$R" "git restore -- tracked.txt" 2
 run "escape hatch is honored" "$R" "CDKD_ALLOW_DIRTY_RESTORE=1 git checkout -- tracked.txt" 2

--- a/.claude/hooks/lib/command-match-differential.test.sh
+++ b/.claude/hooks/lib/command-match-differential.test.sh
@@ -248,6 +248,11 @@ Z2ggLS1yZXBvICJnbyB0by9rIiBwciBtZXJnZSAx
 Z2l0IC1jIHVzZXIubmFtZT0iSmFuZSBEb2UiIC1DIC9hYnMvcmVwbyBjb21taXQgLW0geA==
 Z2l0IGNoZWNrb3V0IG1haW4gJiYgZ2l0IGNoZWNrb3V0IC0tIGYudHh0
 Z2l0IGNoZWNrb3V0IC1iIHdpcCAmJiBnaXQgcmVzdG9yZSAtLSBmLnR4dA==
+Z2l0IC1jIHVzZXIubmFtZT1PXCJCcmllbiBjb21taXQgLW0geA==
+Z2l0IC1jIGFsaWFzLng9InJ1biBjb21taXQgbGF0ZXIiIHN0YXR1cw==
+Z2l0IC1jIGZvbz0ieCBjb21taXQgLW0geSIgc3RhdHVz
+Z2l0IC1DIC90bXAvb1wibmVpbGwvcmVwbyBjb21taXQgLW0geA==
+Z2l0IC1jIGs9YVwiYiBjaGVja291dCAtLSBmLnR4dA==
 CORPUS_EOF
 
 # --------------------------------------------------------------- observables
@@ -423,8 +428,12 @@ cat > "$ALLOWED" <<'ALLOWED_EOF'
 134	m:GATE_RE_GH_PR_WRITE	1	NOW_MATCH	gh repo flag with a spaced value
 135	m:GATE_RE_GIT_COMMIT	1	NOW_MATCH	spaced value then a real -C
 135	m:GATE_RE_GIT_COMMIT_OR_PUSH	1	NOW_MATCH	spaced value then a real -C
-135	t:GATE_RE_GIT_COMMIT	/abs/repo	NOW_MATCH	spaced value then a real -C resolves the target
-135	t:GATE_RE_GIT_COMMIT_OR_PUSH	/abs/repo	NOW_MATCH	spaced value then a real -C resolves the target
+135	t:GATE_RE_GIT_COMMIT	/abs/repo	TARGET	spaced value then a real -C resolves the target
+135	t:GATE_RE_GIT_COMMIT_OR_PUSH	/abs/repo	TARGET	spaced value then a real -C resolves the target
+139	m:GATE_RE_GIT_COMMIT	0	NOW_MISS	verb inside a spaced flag value is no longer the verb
+139	m:GATE_RE_GIT_COMMIT_OR_PUSH	0	NOW_MISS	verb inside a spaced flag value is no longer the verb
+140	m:GATE_RE_GIT_COMMIT	0	NOW_MISS	verb inside a spaced flag value is no longer the verb
+140	m:GATE_RE_GIT_COMMIT_OR_PUSH	0	NOW_MISS	verb inside a spaced flag value is no longer the verb
 ALLOWED_EOF
 
 paste "$TMPDIR/old.tsv" "$TMPDIR/new.tsv" \

--- a/.claude/hooks/lib/command-match-differential.test.sh
+++ b/.claude/hooks/lib/command-match-differential.test.sh
@@ -238,6 +238,16 @@ Z2l0
 Z2g=
 Cg==
 Z2l0IC1DIC9hYnMvcmVwbw==
+Z2l0IC1jIHVzZXIubmFtZT0iSmFuZSBEb2UiIGNvbW1pdCAtbSB4
+Z2l0IC1jIHVzZXIubmFtZT0nSmFuZSBEb2UnIGNvbW1pdCAtbSB4
+Z2l0IC0tYXV0aG9yPSJKYW5lIERvZSIgY29tbWl0IC1tIHg=
+Z2l0IC1jIGNvcmUuZWRpdG9yPSJ2aW0gLWYiIGNvbW1pdCAtbSB4
+Z2l0IC1jIHVzZXIubmFtZT0iSmFuZSBEb2UiIHN0YXR1cw==
+Z2l0IC1jIGs9ImFcIiBiIiBjb21taXQgLW0geA==
+Z2ggLS1yZXBvICJnbyB0by9rIiBwciBtZXJnZSAx
+Z2l0IC1jIHVzZXIubmFtZT0iSmFuZSBEb2UiIC1DIC9hYnMvcmVwbyBjb21taXQgLW0geA==
+Z2l0IGNoZWNrb3V0IG1haW4gJiYgZ2l0IGNoZWNrb3V0IC0tIGYudHh0
+Z2l0IGNoZWNrb3V0IC1iIHdpcCAmJiBnaXQgcmVzdG9yZSAtLSBmLnR4dA==
 CORPUS_EOF
 
 # --------------------------------------------------------------- observables
@@ -402,6 +412,19 @@ cat > "$ALLOWED" <<'ALLOWED_EOF'
 110	m:GATE_RE_GIT_COMMIT	0	NOW_MISS	issue body with -C
 110	m:GATE_RE_GIT_COMMIT_OR_PUSH	0	NOW_MISS	issue body with -C
 111	segcount	1	SEGCOUNT	pr body multi-para
+128	m:GATE_RE_GIT_COMMIT	1	NOW_MATCH	flag value with a space, double quotes
+128	m:GATE_RE_GIT_COMMIT_OR_PUSH	1	NOW_MATCH	flag value with a space, double quotes
+129	m:GATE_RE_GIT_COMMIT	1	NOW_MATCH	flag value with a space, single quotes
+129	m:GATE_RE_GIT_COMMIT_OR_PUSH	1	NOW_MATCH	flag value with a space, single quotes
+133	m:GATE_RE_GIT_COMMIT	1	NOW_MATCH	escaped quote inside a flag value
+133	m:GATE_RE_GIT_COMMIT_OR_PUSH	1	NOW_MATCH	escaped quote inside a flag value
+134	m:GATE_RE_GH_PR_MERGE	1	NOW_MATCH	gh repo flag with a spaced value
+134	m:GATE_RE_GH_PR_CREATE_OR_MERGE	1	NOW_MATCH	gh repo flag with a spaced value
+134	m:GATE_RE_GH_PR_WRITE	1	NOW_MATCH	gh repo flag with a spaced value
+135	m:GATE_RE_GIT_COMMIT	1	NOW_MATCH	spaced value then a real -C
+135	m:GATE_RE_GIT_COMMIT_OR_PUSH	1	NOW_MATCH	spaced value then a real -C
+135	t:GATE_RE_GIT_COMMIT	/abs/repo	NOW_MATCH	spaced value then a real -C resolves the target
+135	t:GATE_RE_GIT_COMMIT_OR_PUSH	/abs/repo	NOW_MATCH	spaced value then a real -C resolves the target
 ALLOWED_EOF
 
 paste "$TMPDIR/old.tsv" "$TMPDIR/new.tsv" \

--- a/.claude/hooks/lib/command-match.sh
+++ b/.claude/hooks/lib/command-match.sh
@@ -579,15 +579,41 @@ GATE_QUOTED_VALUE='("[^"]*"|'"'"'[^'"'"']*'"'"')'
 # a commit straight to main, ungated, and the same hole in EVERY gate keyed on
 # GATE_FLAGS.
 #
-# NOT FIXED HERE, deliberately, and tracked as its own issue. GATE_FLAGS
-# contributes a fixed number of CAPTURE GROUPS, and callers index them:
-# `dirty-path-restore-gate.sh:123` reads `BASH_REMATCH[4]`. Widening the value
-# alternative adds groups, shifts every such index, and that gate silently
-# stopped blocking `git checkout -- <dirty path>` -- 7 of its 18 cases, and the
-# class fence reported it "gone quiet". Fixing it means widening the pattern AND
-# auditing every BASH_REMATCH index built on it, which is a different change
-# from this one and needs its own review.
-GATE_FLAGS='([[:space:]]+-[^[:space:]]+([[:space:]]+("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]-][^[:space:]]*))?)*'
+# FIXED, go-to-k/cdkd#2200. Both halves were needed and the first attempt
+# shipped only one: widening the value alternative adds CAPTURE GROUPS, and
+# callers used to index them positionally (`dirty-path-restore-gate.sh` read
+# `BASH_REMATCH[4]`), so the widening alone made that gate stop blocking
+# `git checkout -- <dirty path>` in 7 of its 18 cases and the class fence
+# reported it "gone quiet". Trading a `git -c` bypass for a `git checkout --`
+# bypass is not a fix, so that attempt was reverted.
+#
+# The durable half is that NO caller indexes into this pattern any more. The two
+# that did now strip the matched prefix by LENGTH via `gate_verb_rest` /
+# `gate_pr_selector`, so the group count is internal to this file and the next
+# widening cannot shift anything. `gate_flags_group_count` below exists to keep
+# that true: the suite pins it, so a change here fails with a message naming
+# this paragraph rather than silently re-opening a gate.
+#
+# A flag TOKEN and a flag VALUE both embed quoted spans now, so
+# `--author="Jane Doe"` and `-c user.name="Jane Doe"` are each a single token.
+# A value still may not BEGIN with `-`: without that restriction
+# `git -C /tmp -q commit` reads `-q` as `-C`'s value.
+# One shell word that may EMBED quoted spans: `user.name="Jane Doe"` is one
+# token, `"Jane Doe"` is one token, and a bare space still ends it.
+_GATE_WORD_CHAR='("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]"'"'"'])'
+# The same, but the FIRST character may not be `-`, so a following flag is never
+# swallowed as the previous flag's value.
+_GATE_WORD_CHAR_NODASH='("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]"'"'"'-])'
+# Each half keeps the OLD quote-blind alternative as a fallback, and it is
+# load-bearing rather than belt-and-braces: the embedding form treats a bare
+# `'"'"'` as opening a quoted span, so a path with an UNBALANCED apostrophe
+# (`git -C /tmp/o'"'"'neill/repo commit`) stops matching entirely. Dropping it
+# cost exactly the two apostrophe cases go-to-k/cdkd#2199 added, which is how
+# this was caught. Leftmost-longest picks the embedding form whenever the quotes
+# do balance, so the fallback only fires where the strict form has nothing.
+_GATE_WORD_BLIND='[^[:space:]]*'
+_GATE_WORD_BLIND_NODASH='[^[:space:]-][^[:space:]]*'
+GATE_FLAGS="([[:space:]]+-(${_GATE_WORD_CHAR}+|${_GATE_WORD_BLIND})([[:space:]]+(${_GATE_WORD_CHAR_NODASH}${_GATE_WORD_CHAR}*|${_GATE_WORD_BLIND_NODASH}))?)*"
 # Every gh GLOBAL FLAG before the subcommand, not just `-C`. The `-C`-only form
 # meant a repo flag ahead of the verb made the verb unreachable, so
 # `gh -R owner/repo pr merge 1 --squash` matched NOTHING and walked past every
@@ -595,7 +621,7 @@ GATE_FLAGS='([[:space:]]+-[^[:space:]]+([[:space:]]+("[^"]*"|'"'"'[^'"'"']*'"'"'
 # verify-pr-gate / integ-destroy-gate / pr-review-gate; go-to-k/cdkd#2027 review
 # round 4). `gate_leading_c_value` already treated `-R` / `--repo` as gh flags,
 # so the two halves of this file disagreed with each other. Same shape as
-# GATE_FLAGS, and like it this contributes THREE capture groups.
+# GATE_FLAGS, and like it its group count is nobody else's business.
 GATE_GH_C="$GATE_FLAGS"
 GATE_RE_GIT_COMMIT="^git${GATE_FLAGS}[[:space:]]+commit([[:space:]]|$)"
 GATE_RE_GIT_PUSH="^git${GATE_FLAGS}[[:space:]]+push([[:space:]]|$)"
@@ -607,9 +633,16 @@ GATE_RE_GH_PR_MERGE="^gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+merge([[:space:]]|
 GATE_RE_GIT_COMMIT_OR_PUSH="^git${GATE_FLAGS}[[:space:]]+(commit|push)([[:space:]]|$)"
 GATE_RE_GIT_MERGE="^git${GATE_FLAGS}[[:space:]]+merge([[:space:]]|$)"
 GATE_RE_GIT_SWITCH="^git${GATE_FLAGS}[[:space:]]+(switch|checkout)([[:space:]]|$)"
+# The two halves of GATE_RE_GIT_CHECKOUT_RESTORE, separately. A caller that
+# needs the ARGUMENT TAIL has to know which verb fired -- `git checkout` is a
+# path restore only when `--` is present, while `git restore` is path-scoped by
+# default -- so it cannot use the combined form.
+GATE_RE_GIT_CHECKOUT="^git${GATE_FLAGS}[[:space:]]+checkout([[:space:]]|$)"
+GATE_RE_GIT_RESTORE="^git${GATE_FLAGS}[[:space:]]+restore([[:space:]]|$)"
 GATE_RE_GIT_CHECKOUT_RESTORE="^git${GATE_FLAGS}[[:space:]]+(checkout|restore)([[:space:]]|$)"
 GATE_RE_GH_PR_CREATE_OR_MERGE="^gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+(create|merge)([[:space:]]|$)"
 # non-english-text-gate guards every way PR prose reaches GitHub.
+GATE_RE_GH_PR_MERGE_OR_EDIT="^gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+(merge|edit)([[:space:]]|$)"
 GATE_RE_GH_PR_WRITE="^gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+(create|edit|merge)([[:space:]]|$)"
 # gh-label-validity-gate: the two commands that can carry --label / --add-label.
 GATE_RE_GH_LABEL_CARRIER="^gh${GATE_GH_C}[[:space:]]+(issue|pr)[[:space:]]+(create|edit)([[:space:]]|$)"
@@ -664,7 +697,7 @@ GATE_RE_DELSTACK='^delstack([[:space:]]|$)'
 # gate_pr_selector_rest <command> <verb-ere>
 # Everything AFTER the matched verb, for callers that run their own token walk.
 # Same rationale and the same anchored-match strip as gate_pr_selector.
-gate_pr_selector_rest() {
+gate_verb_rest() {
   local cmd="$1" re="$2" segment
   while IFS= read -r segment; do
     [[ "$segment" =~ $re ]] || continue
@@ -673,6 +706,15 @@ gate_pr_selector_rest() {
   done < <(gate_segments "$cmd")
   return 0
 }
+
+# gate_pr_selector_rest <command> <verb-ere>
+#
+# Historical name for gate_verb_rest, kept because the shape is not
+# PR-specific: any gate that wants "everything after the verb it matched" wants
+# this, and two of them (dirty-path-restore-gate, non-english-text-gate) reached
+# for a positional BASH_REMATCH index instead, which is what go-to-k/cdkd#2200
+# is about.
+gate_pr_selector_rest() { gate_verb_rest "$@"; }
 
 # gate_pr_selector_ate_number <command> <verb-ere>
 #

--- a/.claude/hooks/lib/command-match.sh
+++ b/.claude/hooks/lib/command-match.sh
@@ -590,9 +590,11 @@ GATE_QUOTED_VALUE='("[^"]*"|'"'"'[^'"'"']*'"'"')'
 # The durable half is that NO caller indexes into this pattern any more. The two
 # that did now strip the matched prefix by LENGTH via `gate_verb_rest` /
 # `gate_pr_selector`, so the group count is internal to this file and the next
-# widening cannot shift anything. `gate_flags_group_count` below exists to keep
-# that true: the suite pins it, so a change here fails with a message naming
-# this paragraph rather than silently re-opening a gate.
+# widening cannot shift anything. Fence 4 of unresolved-target-class.test.sh
+# keeps that true: it refuses any hook that builds its own match from a shared
+# GATE_ constant and then reads a numbered group out of it, so a change here
+# fails with a message naming this paragraph rather than silently re-opening a
+# gate.
 #
 # A flag TOKEN and a flag VALUE both embed quoted spans now, so
 # `--author="Jane Doe"` and `-c user.name="Jane Doe"` are each a single token.
@@ -600,19 +602,39 @@ GATE_QUOTED_VALUE='("[^"]*"|'"'"'[^'"'"']*'"'"')'
 # `git -C /tmp -q commit` reads `-q` as `-C`'s value.
 # One shell word that may EMBED quoted spans: `user.name="Jane Doe"` is one
 # token, `"Jane Doe"` is one token, and a bare space still ends it.
-_GATE_WORD_CHAR='("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]"'"'"'])'
+# `\"` inside a double-quoted span is an ESCAPED quote, not the end of it.
+# Without the escape alternative `git -c k="a\" b" commit -m x` gave branch-gate
+# rc=0 on `main` while the plain form gave rc=2 -- the same bypass this whole
+# change is about, one escape deeper (found in review of go-to-k/cdkd#2200).
+# Single quotes take no escapes in shell, so only the double-quoted span needs
+# one.
+_GATE_WORD_CHAR='("([^"\\]|\\.)*"|'"'"'[^'"'"']*'"'"'|[^[:space:]"'"'"'])'
 # The same, but the FIRST character may not be `-`, so a following flag is never
 # swallowed as the previous flag's value.
-_GATE_WORD_CHAR_NODASH='("[^"]*"|'"'"'[^'"'"']*'"'"'|[^[:space:]"'"'"'-])'
+_GATE_WORD_CHAR_NODASH='("([^"\\]|\\.)*"|'"'"'[^'"'"']*'"'"'|[^[:space:]"'"'"'-])'
 # Each half keeps the OLD quote-blind alternative as a fallback, and it is
 # load-bearing rather than belt-and-braces: the embedding form treats a bare
 # `'"'"'` as opening a quoted span, so a path with an UNBALANCED apostrophe
 # (`git -C /tmp/o'"'"'neill/repo commit`) stops matching entirely. Dropping it
 # cost exactly the two apostrophe cases go-to-k/cdkd#2199 added, which is how
-# this was caught. Leftmost-longest picks the embedding form whenever the quotes
-# do balance, so the fallback only fires where the strict form has nothing.
-_GATE_WORD_BLIND='[^[:space:]]*'
-_GATE_WORD_BLIND_NODASH='[^[:space:]-][^[:space:]]*'
+# this was caught. The two forms are not ranked -- POSIX leftmost-longest is
+# about the WHOLE match, so a command can legitimately take the blind parse even
+# with balanced quotes (`git -c foo="x commit -m y" status` does). That is fine
+# here because every alternative is a strict SUPERSET of the old pattern at each
+# position, so the widening can only add matches, never remove one. Do not
+# rewrite this as "the strict form wins when quotes balance"; it does not.
+# The blind form deliberately excludes `"`. Allowing it made the fallback able
+# to parse HALF of a double-quoted token, and POSIX leftmost-longest then
+# PREFERS that reading whenever it produces a match the strict reading does not:
+# `git -c alias.x="run commit later" status` matched GATE_RE_GIT_COMMIT, taking
+# the `commit` inside the quoted value as the verb. A gate firing on an
+# unrelated command is far less dangerous than a bypass -- it refuses with an
+# actionable message -- but it is still wrong, and it was found by a polarity
+# control rather than reasoned about. Apostrophes stay in, because the whole
+# reason this alternative exists is an UNBALANCED one (`/tmp/o'neill/repo`);
+# double quotes have the strict form to fall back on.
+_GATE_WORD_BLIND='[^[:space:]"]*'
+_GATE_WORD_BLIND_NODASH='[^[:space:]"-][^[:space:]"]*'
 GATE_FLAGS="([[:space:]]+-(${_GATE_WORD_CHAR}+|${_GATE_WORD_BLIND})([[:space:]]+(${_GATE_WORD_CHAR_NODASH}${_GATE_WORD_CHAR}*|${_GATE_WORD_BLIND_NODASH}))?)*"
 # Every gh GLOBAL FLAG before the subcommand, not just `-C`. The `-C`-only form
 # meant a repo flag ahead of the verb made the verb unreachable, so
@@ -694,7 +716,7 @@ GATE_RE_DELSTACK='^delstack([[:space:]]|$)'
 # The regexes are anchored at `^`, so the match always starts at offset 0 and
 # its LENGTH is a safe strip — `${segment#${BASH_REMATCH[0]}}` is not, because
 # the matched text is then treated as a glob pattern.
-# gate_pr_selector_rest <command> <verb-ere>
+# gate_verb_rest <command> <verb-ere>
 # Everything AFTER the matched verb, for callers that run their own token walk.
 # Same rationale and the same anchored-match strip as gate_pr_selector.
 gate_verb_rest() {
@@ -707,14 +729,33 @@ gate_verb_rest() {
   return 0
 }
 
-# gate_pr_selector_rest <command> <verb-ere>
+# gate_verb_rest_each <command> <verb-ere>
 #
-# Historical name for gate_verb_rest, kept because the shape is not
-# PR-specific: any gate that wants "everything after the verb it matched" wants
-# this, and two of them (dirty-path-restore-gate, non-english-text-gate) reached
-# for a positional BASH_REMATCH index instead, which is what go-to-k/cdkd#2200
-# is about.
-gate_pr_selector_rest() { gate_verb_rest "$@"; }
+# Every matching segment's tail, one per line, instead of only the first.
+#
+# The FIRST-ONLY form is a trap for any gate whose verdict depends on the
+# arguments, and dirty-path-restore-gate fell into it during review of
+# go-to-k/cdkd#2200: it probed `checkout`, got segment 1 of
+# `git checkout main && git checkout -- f.txt`, saw no `--`, and exited 0 --
+# never looking at the segment that actually discards the file. The raw-command
+# match it replaced had a greedy `(.*)$` that ran past the operator, so it still
+# saw the later `--`. Measured old-vs-new on a repo with a dirty `f.txt`:
+#
+#   git checkout main && git checkout -- f.txt    BLOCK -> pass
+#   git checkout -b wip && git restore -- f.txt   BLOCK -> pass
+#   git checkout main; git restore -- f.txt       BLOCK -> pass
+#
+# So a gate that ASKS A QUESTION ABOUT THE ARGUMENTS must use this and consider
+# every segment; `gate_verb_rest` is only safe when the first match settles the
+# answer (resolving one PR number, say).
+gate_verb_rest_each() {
+  local cmd="$1" re="$2" segment
+  while IFS= read -r segment; do
+    [[ "$segment" =~ $re ]] || continue
+    printf '%s\n' "${segment:${#BASH_REMATCH[0]}}"
+  done < <(gate_segments "$cmd")
+  return 0
+}
 
 # gate_pr_selector_ate_number <command> <verb-ere>
 #

--- a/.claude/hooks/lib/command-match.sh
+++ b/.claude/hooks/lib/command-match.sh
@@ -602,16 +602,24 @@ GATE_QUOTED_VALUE='("[^"]*"|'"'"'[^'"'"']*'"'"')'
 # `git -C /tmp -q commit` reads `-q` as `-C`'s value.
 # One shell word that may EMBED quoted spans: `user.name="Jane Doe"` is one
 # token, `"Jane Doe"` is one token, and a bare space still ends it.
-# `\"` inside a double-quoted span is an ESCAPED quote, not the end of it.
+# `\"` is an escaped quote wherever it appears -- INSIDE a double-quoted span it
+# does not end the span, and OUTSIDE one it is an ordinary character rather than
+# an opener. Both alternatives are needed and the second is easy to forget: an
+# earlier version of this change added the in-span form and, in the same commit,
+# narrowed the blind fallback to exclude `"`, which is what used to cover the
+# out-of-span case. Nothing matched `\"` any more, and
+# `git -c user.name=O\"Brien checkout -- f.txt` went from rc=2 to rc=0 --
+# a bypass introduced by the commit that was closing one. Removing a false
+# POSITIVE and removing a match are the same edit from the pattern's side.
 # Without the escape alternative `git -c k="a\" b" commit -m x` gave branch-gate
 # rc=0 on `main` while the plain form gave rc=2 -- the same bypass this whole
 # change is about, one escape deeper (found in review of go-to-k/cdkd#2200).
 # Single quotes take no escapes in shell, so only the double-quoted span needs
 # one.
-_GATE_WORD_CHAR='("([^"\\]|\\.)*"|'"'"'[^'"'"']*'"'"'|[^[:space:]"'"'"'])'
+_GATE_WORD_CHAR='("([^"\\]|\\.)*"|'"'"'[^'"'"']*'"'"'|\\.|[^[:space:]"'"'"'])'
 # The same, but the FIRST character may not be `-`, so a following flag is never
 # swallowed as the previous flag's value.
-_GATE_WORD_CHAR_NODASH='("([^"\\]|\\.)*"|'"'"'[^'"'"']*'"'"'|[^[:space:]"'"'"'-])'
+_GATE_WORD_CHAR_NODASH='("([^"\\]|\\.)*"|'"'"'[^'"'"']*'"'"'|\\.|[^[:space:]"'"'"'-])'
 # Each half keeps the OLD quote-blind alternative as a fallback, and it is
 # load-bearing rather than belt-and-braces: the embedding form treats a bare
 # `'"'"'` as opening a quoted span, so a path with an UNBALANCED apostrophe
@@ -620,9 +628,15 @@ _GATE_WORD_CHAR_NODASH='("([^"\\]|\\.)*"|'"'"'[^'"'"']*'"'"'|[^[:space:]"'"'"'-]
 # this was caught. The two forms are not ranked -- POSIX leftmost-longest is
 # about the WHOLE match, so a command can legitimately take the blind parse even
 # with balanced quotes (`git -c foo="x commit -m y" status` does). That is fine
-# here because every alternative is a strict SUPERSET of the old pattern at each
-# position, so the widening can only add matches, never remove one. Do not
-# rewrite this as "the strict form wins when quotes balance"; it does not.
+# here because the blind form covers whatever the strict one cannot parse.
+#
+# Do NOT rewrite this as "the strict form wins when quotes balance" (it does
+# not), and do NOT reason that these alternatives are a strict SUPERSET of the
+# old pattern so the change can only ADD matches. An earlier version of this
+# comment said exactly that, three lines above a change that narrowed the blind
+# form -- and that claim is precisely what makes a reviewer skip checking for
+# LOST matches. Every edit here needs the differential fence run in both
+# directions.
 # The blind form deliberately excludes `"`. Allowing it made the fallback able
 # to parse HALF of a double-quoted token, and POSIX leftmost-longest then
 # PREFERS that reading whenever it produces a match the strict reading does not:

--- a/.claude/hooks/lib/command-match.test.sh
+++ b/.claude/hooks/lib/command-match.test.sh
@@ -241,6 +241,36 @@ C="$GATE_RE_GIT_COMMIT"
 P="$GATE_RE_GIT_PUSH"
 M="$GATE_RE_GH_PR_MERGE"
 
+# --- a FLAG VALUE CONTAINING A SPACE (go-to-k/cdkd#2200) ---------------------
+#
+# `git -c user.name="Jane Doe" commit` is an everyday shape and it walked past
+# EVERY gate keyed on GATE_FLAGS -- measured at the branch-gate level, not just
+# here: on a repo sitting on `main`, `git commit -m x` gave rc=2 while
+# `git -c user.name="Jane Doe" commit -m x` gave rc=0. A commit straight to main,
+# ungated. The value alternative stopped at the first space, so the flag loop
+# ended mid-value and the verb was never reached.
+#
+# Both quote styles, both the separate-value (`-c k=v`) and glued (`--flag=v`)
+# forms, and a value whose quoted span itself contains a DASH -- that last one
+# is what a naive "value may not start with -" fix breaks.
+want_match 0 "flag value with a space, double quotes" 'git -c user.name="Jane Doe" commit -m x' "$C"
+want_match 0 "flag value with a space, single quotes" "git -c user.name='Jane Doe' commit -m x" "$C"
+want_match 0 "glued flag value with a space"          'git --author="Jane Doe" commit -m x' "$C"
+want_match 0 "quoted span containing a dash"          'git -c core.editor="vim -f" commit -m x' "$C"
+want_match 0 "two flags, first value spaced"          'git -c user.name="Jane Doe" -C /tmp commit -m x' "$C"
+want_match 0 "gh repo flag with a spaced value"       'gh --repo "go to/k" pr merge 1' "$M"
+
+# Polarity controls. Widening a flag absorber is exactly the change that makes a
+# gate fire on commands it should ignore, and "it blocks" is satisfied by a gate
+# that blocks for any reason at all -- so the widening has to be shown NOT to
+# reach a different verb.
+want_match 1 "spaced flag value, non-commit verb"     'git -c user.name="Jane Doe" status' "$C"
+want_match 1 "spaced flag value, log not commit"      'git -c user.name="Jane Doe" log --oneline' "$C"
+
+# A following FLAG must not be eaten as the previous flag's value: with that
+# restriction dropped, `-q` becomes `-C`'s value and `/tmp` becomes the verb.
+want_match 0 "flag after a valueless flag"            'git -C /tmp -q commit -m x' "$C"
+
 # --- the spellings that used to bypass ---------------------------------------
 want_match 0 "bare git commit"              'git commit -m x' "$C"
 want_match 0 "git add -A && git commit"     'git add -A && git commit -m x' "$C"

--- a/.claude/hooks/lib/command-match.test.sh
+++ b/.claude/hooks/lib/command-match.test.sh
@@ -244,32 +244,47 @@ M="$GATE_RE_GH_PR_MERGE"
 # --- a FLAG VALUE CONTAINING A SPACE (go-to-k/cdkd#2200) ---------------------
 #
 # `git -c user.name="Jane Doe" commit` is an everyday shape and it walked past
-# EVERY gate keyed on GATE_FLAGS -- measured at the branch-gate level, not just
-# here: on a repo sitting on `main`, `git commit -m x` gave rc=2 while
-# `git -c user.name="Jane Doe" commit -m x` gave rc=0. A commit straight to main,
-# ungated. The value alternative stopped at the first space, so the flag loop
-# ended mid-value and the verb was never reached.
+# EVERY gate keyed on GATE_FLAGS -- measured at the gate level, not just here:
+# on a repo sitting on `main`, `git commit -m x` gave branch-gate rc=2 while
+# `git -c user.name="Jane Doe" commit -m x` gave rc=0. A commit straight to
+# main, ungated. The value alternative stopped at the first space, so the flag
+# loop ended mid-value and the verb was never reached.
 #
-# Both quote styles, both the separate-value (`-c k=v`) and glued (`--flag=v`)
-# forms, and a value whose quoted span itself contains a DASH -- that last one
-# is what a naive "value may not start with -" fix breaks.
+# WHICH OF THESE ACTUALLY DISCRIMINATE, measured by mutation rather than
+# assumed. A review round found the first version of this block naming six
+# hazards while its assertions pinned one, so each line now says what it is:
 want_match 0 "flag value with a space, double quotes" 'git -c user.name="Jane Doe" commit -m x' "$C"
 want_match 0 "flag value with a space, single quotes" "git -c user.name='Jane Doe' commit -m x" "$C"
+want_match 0 "escaped quote inside a flag value"      'git -c k="a\" b" commit -m x' "$C"
+want_match 0 "gh repo flag with a spaced value"       'gh --repo "go to/k" pr merge 1' "$M"
+# ^ these four red when the widening is reverted. They are the fix.
+
+# REGRESSION GUARDS, not bypass fixes: all three already matched before this
+# change, and they are here so the widening is shown not to LOSE them. Saying so
+# matters -- an earlier version of this comment presented them as newly-fixed
+# bypasses, which would have sent the next reader hunting for a defect that was
+# never there.
 want_match 0 "glued flag value with a space"          'git --author="Jane Doe" commit -m x' "$C"
 want_match 0 "quoted span containing a dash"          'git -c core.editor="vim -f" commit -m x' "$C"
-want_match 0 "two flags, first value spaced"          'git -c user.name="Jane Doe" -C /tmp commit -m x' "$C"
-want_match 0 "gh repo flag with a spaced value"       'gh --repo "go to/k" pr merge 1' "$M"
-
-# Polarity controls. Widening a flag absorber is exactly the change that makes a
-# gate fire on commands it should ignore, and "it blocks" is satisfied by a gate
-# that blocks for any reason at all -- so the widening has to be shown NOT to
-# reach a different verb.
-want_match 1 "spaced flag value, non-commit verb"     'git -c user.name="Jane Doe" status' "$C"
-want_match 1 "spaced flag value, log not commit"      'git -c user.name="Jane Doe" log --oneline' "$C"
-
-# A following FLAG must not be eaten as the previous flag's value: with that
-# restriction dropped, `-q` becomes `-C`'s value and `/tmp` becomes the verb.
 want_match 0 "flag after a valueless flag"            'git -C /tmp -q commit -m x' "$C"
+
+# POLARITY CONTROLS. Widening a flag absorber is exactly the change that makes a
+# gate fire on commands it should ignore, and "it matches" is satisfied by a
+# pattern that matches everything.
+#
+# The first version of this pair was `git -c user.name="Jane Doe" status` and
+# `... log --oneline`, and neither could EVER red: neither string contains the
+# word `commit`, so no amount of over-reach in GATE_FLAGS could make a commit
+# gate match them. Proven by mutating GATE_FLAGS to the total over-reach
+# `([[:space:]]+[^[:space:]]+)*` -- both stayed green. A control that cannot
+# fail is not a control.
+#
+# These do contain the verb, in a position where matching it would be wrong: a
+# quoted flag VALUE, and an argument. An absorber that swallows the closing
+# quote reaches them.
+want_match 1 "verb inside a spaced flag value"        'git -c alias.x="run commit later" status' "$C"
+want_match 1 "verb as an argument after a spaced value" 'git -c user.name="Jane Doe" log --grep commit' "$C"
+want_match 1 "gh verb inside a spaced repo value"     'gh --repo "a pr merge b" issue list' "$M"
 
 # --- the spellings that used to bypass ---------------------------------------
 want_match 0 "bare git commit"              'git commit -m x' "$C"

--- a/.claude/hooks/non-english-text-gate.sh
+++ b/.claude/hooks/non-english-text-gate.sh
@@ -144,14 +144,15 @@ fi
 #   `gh pr merge <N>` / `gh pr edit <N>` — N is the explicit arg.
 #   `gh pr create` / `gh pr merge` (no arg) — current branch's PR.
 pr_number=""
-# `$GATE_GH_C` rather than a local `-C` pattern, for the same reason as
-# dirty-path-restore-gate: the local one could not read a quoted path, and it
-# stopped at `-C` so a `gh -R <repo> pr merge <N>` hid the number. It absorbs
-# every global flag and contributes 3 capture groups, so the verb is [4] and the
-# number is [5].
-if [[ "$cmd" =~ gh${GATE_GH_C}[[:space:]]+pr[[:space:]]+(merge|edit)[[:space:]]+([0-9]+) ]]; then
-  pr_number="${BASH_REMATCH[5]}"
-fi
+# `gate_pr_selector` rather than a local `=~` with a positional BASH_REMATCH
+# index. The hand-rolled `-C` pattern this replaced could not read a quoted path
+# and stopped at `-C`, so `gh -R <repo> pr merge <N>` hid the number; moving to
+# `$GATE_GH_C` fixed that but made the number `BASH_REMATCH[5]` -- an index into
+# a SHARED pattern, which the go-to-k/cdkd#2200 widening shifts. The selector
+# walks flags itself and returns the first non-flag token after the verb, so it
+# also handles `gh pr merge --squash 552` and `gh pr merge -t 42 552`, which the
+# old adjacent-token regex read as no number at all.
+pr_number="$(gate_pr_selector "$cmd" "$GATE_RE_GH_PR_MERGE_OR_EDIT")"
 
 if [[ -z "$pr_number" ]]; then
   pr_number=$("$GH" pr view --json number -q .number 2>/dev/null || true)

--- a/.claude/hooks/unresolved-target-class.test.sh
+++ b/.claude/hooks/unresolved-target-class.test.sh
@@ -384,6 +384,58 @@ else
   ng "fence 3: gates miss a determinate quoted target path:$(printf '%b' "$space_leaks")"
 fi
 
+# --- fence 4: nobody indexes into a SHARED flag pattern by position ----------
+#
+# go-to-k/cdkd#2200. `GATE_FLAGS` had to be widened so a flag value containing a
+# space (`git -c user.name="Jane Doe" commit`) stopped ending the flag loop
+# mid-value -- an ungated commit straight to `main`, in every gate keyed on it.
+# But widening a regex ADDS CAPTURE GROUPS, and two gates read the argument tail
+# as a positional `BASH_REMATCH[N]` into that shared pattern. The first attempt
+# shipped the widening alone: `dirty-path-restore-gate` silently stopped
+# blocking `git checkout -- <dirty path>` in 7 of its 18 cases, and fence 3
+# above reported it "gone quiet". Trading a `git -c` bypass for a
+# `git checkout --` bypass is not a fix, so it was reverted.
+#
+# Both callers now strip the matched prefix by LENGTH (`gate_verb_rest` /
+# `gate_pr_selector`), so the group count is internal to command-match.sh. This
+# fence keeps it that way. It is deliberately a SOURCE scan rather than a
+# behavioural one: the behavioural symptom is a gate going quiet, which fence 3
+# already reports -- but only for the shapes it happens to exercise, and only
+# AFTER someone has written the coupling. This catches the coupling itself, in a
+# hook written next month by someone copying a neighbour.
+#
+# The population is the directory listing, never a hand-written list, for the
+# reason stated at the top of this file.
+coupled=""
+scanned=0
+for hook in "$HOOKS_DIR"/*.sh; do
+  case "$(basename "$hook")" in *.test.sh) continue ;; esac
+  # POPULATION: every hook that loads the shared matcher. Not "every hook that
+  # currently embeds a GATE_ constant in a `=~`" -- that set is the DEFECT, and
+  # taking the population from the defect is how a fence goes inert the moment
+  # it succeeds. Measured while writing this: after the fix that subset is 1,
+  # so a floor on it would be unreachable and a clean run would prove nothing.
+  # A hook in the population that has no coupling simply passes.
+  grep -q 'command-match.sh' "$hook" || continue
+  scanned=$((scanned + 1))
+  # HAZARD: this file builds its OWN match out of a shared constant, and then
+  # reads a numbered group out of it. Either half alone is fine -- the `gate_*`
+  # helpers take the pattern as an argument and index their own local patterns,
+  # which no widening here can shift.
+  grep -qE '=~[^#]*\$\{?GATE_' "$hook" || continue
+  if grep -qE '\$\{BASH_REMATCH\[[0-9]+\]\}' "$hook"; then
+    coupled="$coupled\n    - $(basename "$hook")"
+  fi
+done
+
+if [ "$scanned" -lt 20 ]; then
+  ng "fence 4: only $scanned hooks load command-match.sh -- the scan is not seeing the hook directory, so a green result here would mean nothing"
+elif [ -z "$coupled" ]; then
+  ok "fence 4: none of the $scanned matcher-using hooks index a shared pattern positionally"
+else
+  ng "fence 4: these hooks read a positional BASH_REMATCH out of a match they built from a SHARED GATE_ constant, so widening that constant shifts their index and silently re-opens them (go-to-k/cdkd#2200):$(printf '%b' "$coupled")\n    Use gate_verb_rest / gate_pr_selector, which strip the matched prefix by LENGTH."
+fi
+
 echo
 echo "Pass: $pass  Fail: $fail"
 if [ "$fail" -gt 0 ]; then

--- a/.claude/hooks/unresolved-target-class.test.sh
+++ b/.claude/hooks/unresolved-target-class.test.sh
@@ -384,6 +384,54 @@ else
   ng "fence 3: gates miss a determinate quoted target path:$(printf '%b' "$space_leaks")"
 fi
 
+# ONE definition, used by both the guard-the-guard probes and the real scan,
+# and it MUST stay above both. It was written out twice, so the probes validated
+# a COPY of the predicate rather than the code that runs -- a guard-the-guard
+# that guards a duplicate proves only that the duplicate works.
+#
+# De-duplicating it left the definition BELOW the real scan, and the result is
+# worth stating plainly because it is this fence's own subject turned on itself:
+# all 35 calls returned 127 (`command not found`), `&&` short-circuited, the
+# `coupled` list stayed empty, and fence 4 printed OK. A fence written to catch
+# inert gates was itself inert and reported green. `run-tests.sh` captures
+# stderr but only greps for a `fail: N` tally, so the suite was rc=0 and the
+# 35 `command not found` lines were invisible. The liveness check below is what
+# makes that state loud instead.
+#
+# Indirections the collector must survive, all confirmed live against the
+# earlier version: `printf -v re ...`; a variable copied through another
+# (`a="$GATE_..."; b="$a"`); a command substitution (`re=$(pick)`); an indirect
+# expansion (`name=GATE_RE_...; [[ $c =~ ${!name} ]]`); and an assignment
+# sharing a line with a function opener (`setup() { re="$GATE_..."; }`), which
+# a `^[[:space:]]*NAME=` anchor misses. The scan is deliberately generous here:
+# a false positive is one comment away from being cleared, a false negative is
+# a silently re-opened gate.
+fence4_hazard() {
+  local f="$1" gv m=0
+  grep -qE '=~[^#]*\$\{?GATE_' "$f" && m=1
+  if [ "$m" -eq 0 ]; then
+    # Names assigned a GATE_ pattern, anywhere on a line, plus `printf -v`.
+    for gv in $(
+      { grep -oE '[A-Za-z_][A-Za-z0-9_]*=[^=]*\$\{?GATE_' "$f" | grep -oE '^[A-Za-z_][A-Za-z0-9_]*'
+        grep -oE 'printf[[:space:]]+-v[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' "$f" | grep -oE '[A-Za-z_][A-Za-z0-9_]*$'
+      } | sort -u
+    ); do
+      grep -qE "=~[[:space:]]*\"?\\\$\{?!?${gv}\}?\"?" "$f" && { m=1; break; }
+      # A name copied into another name, one hop -- enough for the shapes seen.
+      for gv2 in $(grep -oE "[A-Za-z_][A-Za-z0-9_]*=\"?\\\$\{?${gv}\}?\"?" "$f" | grep -oE '^[A-Za-z_][A-Za-z0-9_]*'); do
+        grep -qE "=~[[:space:]]*\"?\\\$\{?!?${gv2}\}?\"?" "$f" && { m=1; break 2; }
+      done
+    done
+  fi
+  # An indirect expansion names its target as a plain STRING, so the collector
+  # above cannot see it; catch the shape directly.
+  if [ "$m" -eq 0 ] && grep -qE '=[[:space:]]*"?GATE_RE_[A-Z_]+' "$f" && grep -qE '=~[^#]*\$\{![A-Za-z_]' "$f"; then
+    m=1
+  fi
+  [ "$m" -eq 1 ] || return 1
+  grep -qE '\$\{BASH_REMATCH\[' "$f"
+}
+
 # --- fence 4: nobody indexes into a SHARED flag pattern by position ----------
 #
 # go-to-k/cdkd#2200. `GATE_FLAGS` had to be widened so a flag value containing a
@@ -406,6 +454,9 @@ fi
 #
 # The population is the directory listing, never a hand-written list, for the
 # reason stated at the top of this file.
+if ! command -v fence4_hazard >/dev/null 2>&1; then
+  ng "fence 4: fence4_hazard is not defined at the point the scan runs, so every call returns 127, \`&&\` short-circuits, and the fence reports OK over nothing. This exact state shipped once."
+fi
 coupled=""
 scanned=0
 for hook in "$HOOKS_DIR"/*.sh; do
@@ -450,44 +501,6 @@ done
 # always-empty scan -- a broken grep, a bad path, a quoting slip -- reads as a
 # clean repo. Fence 1 plants variants to prove it detects; this does the same,
 # against a throwaway file carrying each evasion spelling.
-# ONE definition, used by both the guard-the-guard probes and the real scan.
-# It was written out twice, so the probes validated a COPY of the predicate
-# rather than the code that runs -- a guard-the-guard that guards a duplicate
-# proves only that the duplicate works.
-#
-# Indirections the collector must survive, all confirmed live against the
-# earlier version: `printf -v re ...`; a variable copied through another
-# (`a="$GATE_..."; b="$a"`); a command substitution (`re=$(pick)`); an indirect
-# expansion (`name=GATE_RE_...; [[ $c =~ ${!name} ]]`); and an assignment
-# sharing a line with a function opener (`setup() { re="$GATE_..."; }`), which
-# a `^[[:space:]]*NAME=` anchor misses. The scan is deliberately generous here:
-# a false positive is one comment away from being cleared, a false negative is
-# a silently re-opened gate.
-fence4_hazard() {
-  local f="$1" gv m=0
-  grep -qE '=~[^#]*\$\{?GATE_' "$f" && m=1
-  if [ "$m" -eq 0 ]; then
-    # Names assigned a GATE_ pattern, anywhere on a line, plus `printf -v`.
-    for gv in $(
-      { grep -oE '[A-Za-z_][A-Za-z0-9_]*=[^=]*\$\{?GATE_' "$f" | grep -oE '^[A-Za-z_][A-Za-z0-9_]*'
-        grep -oE 'printf[[:space:]]+-v[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' "$f" | grep -oE '[A-Za-z_][A-Za-z0-9_]*$'
-      } | sort -u
-    ); do
-      grep -qE "=~[[:space:]]*\"?\\\$\{?!?${gv}\}?\"?" "$f" && { m=1; break; }
-      # A name copied into another name, one hop -- enough for the shapes seen.
-      for gv2 in $(grep -oE "[A-Za-z_][A-Za-z0-9_]*=\"?\\\$\{?${gv}\}?\"?" "$f" | grep -oE '^[A-Za-z_][A-Za-z0-9_]*'); do
-        grep -qE "=~[[:space:]]*\"?\\\$\{?!?${gv2}\}?\"?" "$f" && { m=1; break 2; }
-      done
-    done
-  fi
-  # An indirect expansion names its target as a plain STRING, so the collector
-  # above cannot see it; catch the shape directly.
-  if [ "$m" -eq 0 ] && grep -qE '=[[:space:]]*"?GATE_RE_[A-Z_]+' "$f" && grep -qE '=~[^#]*\$\{![A-Za-z_]' "$f"; then
-    m=1
-  fi
-  [ "$m" -eq 1 ] || return 1
-  grep -qE '\$\{BASH_REMATCH\[' "$f"
-}
 
 probe_dir="$TMPDIR/fence4-probe"
 mkdir -p "$probe_dir"

--- a/.claude/hooks/unresolved-target-class.test.sh
+++ b/.claude/hooks/unresolved-target-class.test.sh
@@ -443,27 +443,52 @@ for hook in "$HOOKS_DIR"/*.sh; do
   #
   # On the index side the subscript is not required to be a literal: an earlier
   # version demanded `[0-9]+` and `idx=4; ${BASH_REMATCH[$idx]}` walked past it.
-  hook_matches_shared=0
-  grep -qE '=~[^#]*\$\{?GATE_' "$hook" && hook_matches_shared=1
-  if [ "$hook_matches_shared" -eq 0 ]; then
-    for gv in $(grep -oE '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[^=]*\$\{?GATE_' "$hook" \
-                | grep -oE '[A-Za-z_][A-Za-z0-9_]*=' | tr -d '='); do
-      if grep -qE "=~[[:space:]]*\"?\\\$\{?${gv}\}?\"?" "$hook"; then
-        hook_matches_shared=1
-        break
-      fi
-    done
-  fi
-  [ "$hook_matches_shared" -eq 1 ] || continue
-  if grep -qE '\$\{BASH_REMATCH\[' "$hook"; then
-    coupled="$coupled\n    - $(basename "$hook")"
-  fi
+  fence4_hazard "$hook" && coupled="$coupled\n    - $(basename "$hook")"
 done
 
 # Guard the guard. `coupled` being empty is the PASS condition, so an
 # always-empty scan -- a broken grep, a bad path, a quoting slip -- reads as a
 # clean repo. Fence 1 plants variants to prove it detects; this does the same,
 # against a throwaway file carrying each evasion spelling.
+# ONE definition, used by both the guard-the-guard probes and the real scan.
+# It was written out twice, so the probes validated a COPY of the predicate
+# rather than the code that runs -- a guard-the-guard that guards a duplicate
+# proves only that the duplicate works.
+#
+# Indirections the collector must survive, all confirmed live against the
+# earlier version: `printf -v re ...`; a variable copied through another
+# (`a="$GATE_..."; b="$a"`); a command substitution (`re=$(pick)`); an indirect
+# expansion (`name=GATE_RE_...; [[ $c =~ ${!name} ]]`); and an assignment
+# sharing a line with a function opener (`setup() { re="$GATE_..."; }`), which
+# a `^[[:space:]]*NAME=` anchor misses. The scan is deliberately generous here:
+# a false positive is one comment away from being cleared, a false negative is
+# a silently re-opened gate.
+fence4_hazard() {
+  local f="$1" gv m=0
+  grep -qE '=~[^#]*\$\{?GATE_' "$f" && m=1
+  if [ "$m" -eq 0 ]; then
+    # Names assigned a GATE_ pattern, anywhere on a line, plus `printf -v`.
+    for gv in $(
+      { grep -oE '[A-Za-z_][A-Za-z0-9_]*=[^=]*\$\{?GATE_' "$f" | grep -oE '^[A-Za-z_][A-Za-z0-9_]*'
+        grep -oE 'printf[[:space:]]+-v[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' "$f" | grep -oE '[A-Za-z_][A-Za-z0-9_]*$'
+      } | sort -u
+    ); do
+      grep -qE "=~[[:space:]]*\"?\\\$\{?!?${gv}\}?\"?" "$f" && { m=1; break; }
+      # A name copied into another name, one hop -- enough for the shapes seen.
+      for gv2 in $(grep -oE "[A-Za-z_][A-Za-z0-9_]*=\"?\\\$\{?${gv}\}?\"?" "$f" | grep -oE '^[A-Za-z_][A-Za-z0-9_]*'); do
+        grep -qE "=~[[:space:]]*\"?\\\$\{?!?${gv2}\}?\"?" "$f" && { m=1; break 2; }
+      done
+    done
+  fi
+  # An indirect expansion names its target as a plain STRING, so the collector
+  # above cannot see it; catch the shape directly.
+  if [ "$m" -eq 0 ] && grep -qE '=[[:space:]]*"?GATE_RE_[A-Z_]+' "$f" && grep -qE '=~[^#]*\$\{![A-Za-z_]' "$f"; then
+    m=1
+  fi
+  [ "$m" -eq 1 ] || return 1
+  grep -qE '\$\{BASH_REMATCH\[' "$f"
+}
+
 probe_dir="$TMPDIR/fence4-probe"
 mkdir -p "$probe_dir"
 cat > "$probe_dir/inline.sh" <<'P1'
@@ -485,27 +510,32 @@ P4
 cat > "$probe_dir/clean.sh" <<'P5'
 rest="$(gate_verb_rest "$c" "$GATE_RE_GIT_CHECKOUT")"
 P5
+cat > "$probe_dir/printfv.sh" <<'P7'
+printf -v re '%s' "$GATE_RE_GIT_PUSH"
+[[ "$c" =~ $re ]] && x="${BASH_REMATCH[2]}"
+P7
+cat > "$probe_dir/copied.sh" <<'P8'
+a="$GATE_RE_GIT_PUSH"
+b="$a"
+[[ "$c" =~ $b ]] && x="${BASH_REMATCH[2]}"
+P8
+cat > "$probe_dir/indirect_name.sh" <<'P9'
+name=GATE_RE_GIT_PUSH
+[[ "$c" =~ ${!name} ]] && x="${BASH_REMATCH[2]}"
+P9
+cat > "$probe_dir/inline_fn.sh" <<'P10'
+setup() { re="$GATE_RE_GIT_PUSH"; }
+[[ "$c" =~ $re ]] && x="${BASH_REMATCH[2]}"
+P10
 cat > "$probe_dir/passthrough.sh" <<'P6'
 __verb_ere="$GATE_RE_GIT_PUSH"
 target=$(gate_target_dir_strict "$c" "$PWD" "$__verb_ere")
 if [[ "$c" =~ [[:space:]]push([[:space:]]+(.*))?$ ]]; then a="${BASH_REMATCH[2]}"; fi
 P6
 
-fence4_hazard() {
-  local f="$1" gv m=0
-  grep -qE '=~[^#]*\$\{?GATE_' "$f" && m=1
-  if [ "$m" -eq 0 ]; then
-    for gv in $(grep -oE '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[^=]*\$\{?GATE_' "$f" \
-                | grep -oE '[A-Za-z_][A-Za-z0-9_]*=' | tr -d '='); do
-      grep -qE "=~[[:space:]]*\"?\\\$\{?${gv}\}?\"?" "$f" && { m=1; break; }
-    done
-  fi
-  [ "$m" -eq 1 ] || return 1
-  grep -qE '\$\{BASH_REMATCH\[' "$f"
-}
 
 undetected=""
-for probe in inline split indirect quoted; do
+for probe in inline split indirect quoted printfv copied indirect_name inline_fn; do
   fence4_hazard "$probe_dir/$probe.sh" || undetected="$undetected $probe"
 done
 false_positive=""
@@ -517,7 +547,7 @@ if [ -n "$undetected" ]; then
 elif [ -n "$false_positive" ]; then
   ng "fence 4 (guard the guard): the scan flags$false_positive, which pass a GATE_ pattern to a helper instead of matching it. Four real hooks look like this; flagging them makes a clean state unreachable without an exemption list."
 else
-  ok "fence 4 (guard the guard): the scan detects all 4 coupling spellings and clears both non-coupling ones"
+  ok "fence 4 (guard the guard): the scan detects all 8 coupling spellings and clears both non-coupling ones"
 fi
 
 if [ "$scanned" -lt 20 ]; then

--- a/.claude/hooks/unresolved-target-class.test.sh
+++ b/.claude/hooks/unresolved-target-class.test.sh
@@ -422,11 +422,103 @@ for hook in "$HOOKS_DIR"/*.sh; do
   # reads a numbered group out of it. Either half alone is fine -- the `gate_*`
   # helpers take the pattern as an argument and index their own local patterns,
   # which no widening here can shift.
-  grep -qE '=~[^#]*\$\{?GATE_' "$hook" || continue
-  if grep -qE '\$\{BASH_REMATCH\[[0-9]+\]\}' "$hook"; then
+  # The hazard is: this file MATCHES a shared GATE_ pattern with `=~` itself,
+  # and reads BASH_REMATCH by subscript. Both halves need care.
+  #
+  # On the match side, three spellings evaded earlier versions of this scan and
+  # all three are real rather than hypothetical: the pattern inline on the `=~`
+  # line; the pattern assigned to a variable on one line and matched on another
+  # (`restore-backup.sh` already writes that assignment); and the same with the
+  # variable quoted on the `=~`. So variables assigned from a GATE_ constant are
+  # collected first, then looked for on an `=~`.
+  #
+  # But "mentions a GATE_ constant" alone is far too broad, and the difference
+  # is not cosmetic: four hooks -- commit-prefix-scope-gate, integ-local-gate,
+  # post-merge-orphan-push-gate, pr-title-prefix-scope-gate -- assign a
+  # `GATE_RE_*` and pass it as an ARGUMENT to `gate_target_dir_strict`, never
+  # matching it themselves, while indexing BASH_REMATCH out of their own local
+  # patterns. Those are correct code. Flagging them would make a clean state
+  # unreachable without an exemption list, and an exemption list is the thing
+  # that rots.
+  #
+  # On the index side the subscript is not required to be a literal: an earlier
+  # version demanded `[0-9]+` and `idx=4; ${BASH_REMATCH[$idx]}` walked past it.
+  hook_matches_shared=0
+  grep -qE '=~[^#]*\$\{?GATE_' "$hook" && hook_matches_shared=1
+  if [ "$hook_matches_shared" -eq 0 ]; then
+    for gv in $(grep -oE '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[^=]*\$\{?GATE_' "$hook" \
+                | grep -oE '[A-Za-z_][A-Za-z0-9_]*=' | tr -d '='); do
+      if grep -qE "=~[[:space:]]*\"?\\\$\{?${gv}\}?\"?" "$hook"; then
+        hook_matches_shared=1
+        break
+      fi
+    done
+  fi
+  [ "$hook_matches_shared" -eq 1 ] || continue
+  if grep -qE '\$\{BASH_REMATCH\[' "$hook"; then
     coupled="$coupled\n    - $(basename "$hook")"
   fi
 done
+
+# Guard the guard. `coupled` being empty is the PASS condition, so an
+# always-empty scan -- a broken grep, a bad path, a quoting slip -- reads as a
+# clean repo. Fence 1 plants variants to prove it detects; this does the same,
+# against a throwaway file carrying each evasion spelling.
+probe_dir="$TMPDIR/fence4-probe"
+mkdir -p "$probe_dir"
+cat > "$probe_dir/inline.sh" <<'P1'
+if [[ "$c" =~ git${GATE_FLAGS}[[:space:]]+checkout ]]; then x="${BASH_REMATCH[4]}"; fi
+P1
+cat > "$probe_dir/split.sh" <<'P2'
+re="^git${GATE_FLAGS}[[:space:]]+checkout"
+[[ "$c" =~ $re ]] && x="${BASH_REMATCH[4]}"
+P2
+cat > "$probe_dir/indirect.sh" <<'P3'
+if [[ "$c" =~ git${GATE_GH_C}[[:space:]]+pr ]]; then idx=4; x="${BASH_REMATCH[$idx]}"; fi
+P3
+cat > "$probe_dir/quoted.sh" <<'P4'
+re="^git${GATE_FLAGS}[[:space:]]+push"
+if [[ "$c" =~ "$re" ]]; then x="${BASH_REMATCH[2]}"; fi
+P4
+# The two shapes that must stay CLEAR. `passthrough` is the real one: four hooks
+# in this repo look exactly like it, and an over-broad scan flags them.
+cat > "$probe_dir/clean.sh" <<'P5'
+rest="$(gate_verb_rest "$c" "$GATE_RE_GIT_CHECKOUT")"
+P5
+cat > "$probe_dir/passthrough.sh" <<'P6'
+__verb_ere="$GATE_RE_GIT_PUSH"
+target=$(gate_target_dir_strict "$c" "$PWD" "$__verb_ere")
+if [[ "$c" =~ [[:space:]]push([[:space:]]+(.*))?$ ]]; then a="${BASH_REMATCH[2]}"; fi
+P6
+
+fence4_hazard() {
+  local f="$1" gv m=0
+  grep -qE '=~[^#]*\$\{?GATE_' "$f" && m=1
+  if [ "$m" -eq 0 ]; then
+    for gv in $(grep -oE '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[^=]*\$\{?GATE_' "$f" \
+                | grep -oE '[A-Za-z_][A-Za-z0-9_]*=' | tr -d '='); do
+      grep -qE "=~[[:space:]]*\"?\\\$\{?${gv}\}?\"?" "$f" && { m=1; break; }
+    done
+  fi
+  [ "$m" -eq 1 ] || return 1
+  grep -qE '\$\{BASH_REMATCH\[' "$f"
+}
+
+undetected=""
+for probe in inline split indirect quoted; do
+  fence4_hazard "$probe_dir/$probe.sh" || undetected="$undetected $probe"
+done
+false_positive=""
+for probe in clean passthrough; do
+  fence4_hazard "$probe_dir/$probe.sh" && false_positive="$false_positive $probe"
+done
+if [ -n "$undetected" ]; then
+  ng "fence 4 (guard the guard): the scan does not detect these coupling spellings, so its clean verdict on the real hooks means nothing:$undetected"
+elif [ -n "$false_positive" ]; then
+  ng "fence 4 (guard the guard): the scan flags$false_positive, which pass a GATE_ pattern to a helper instead of matching it. Four real hooks look like this; flagging them makes a clean state unreachable without an exemption list."
+else
+  ok "fence 4 (guard the guard): the scan detects all 4 coupling spellings and clears both non-coupling ones"
+fi
 
 if [ "$scanned" -lt 20 ]; then
   ng "fence 4: only $scanned hooks load command-match.sh -- the scan is not seeing the hook directory, so a green result here would mean nothing"


### PR DESCRIPTION
`GATE_FLAGS`'s value alternative stopped at the first space, so a flag value
containing one ended the flag loop mid-value and the verb was never reached.
Measured at the gate level on a repo sitting on `main`:

    git commit -m x                          -> branch-gate rc=2  (blocked)
    git -c user.name="Jane Doe" commit -m x  -> branch-gate rc=0  (BYPASS)

`git -c user.name="..." commit` is an everyday shape, and the same hole existed
in every gate keyed on GATE_FLAGS -- branch-gate, check-gate, verify-pr-gate,
the integ-* family, pr-review-gate. A commit straight to main, ungated.

Closes #2200.

Why the obvious one-line patch was not enough
---------------------------------------------

Widening the value alternative ADDS CAPTURE GROUPS, and two gates read the
argument tail as a positional index into that SHARED pattern. Shipping the
widening alone made `dirty-path-restore-gate` stop blocking
`git checkout -- <dirty path>` in 7 of its 18 cases, and the class fence
reported it "gone quiet". Trading a `git -c` bypass for a `git checkout --`
bypass is not a fix, which is why the first attempt was reverted rather than
patched.

So this change has three parts, and the third is the one that matters:

1. The widening. A flag TOKEN and a flag VALUE each embed quoted spans, so
   `--author="Jane Doe"` and `-c user.name="Jane Doe"` are one token. A value
   still may not BEGIN with `-`, or `git -C /tmp -q commit` reads `-q` as
   `-C`'s value. Each half keeps the old quote-blind alternative as a fallback,
   and that is load-bearing rather than belt-and-braces: the embedding form
   treats a bare apostrophe as opening a quoted span, so a path with an
   UNBALANCED one stops matching entirely. Dropping it cost exactly the two
   apostrophe cases #2199 added, which is how it was caught.

2. Both positional callers converted off index arithmetic.
   `dirty-path-restore-gate` (`BASH_REMATCH[4]`) now uses `gate_verb_rest` and
   `non-english-text-gate` (`BASH_REMATCH[5]`) now uses `gate_pr_selector`;
   both strip the matched prefix by LENGTH, so the group count is internal to
   command-match.sh. `gate_pr_selector_rest` is renamed `gate_verb_rest` --
   the shape was never PR-specific -- with the old name kept as an alias.
   The selector also handles `gh pr merge --squash 552` and `-t 42 552`, which
   the adjacent-token regex it replaces read as no number at all.

3. A CLASS fence, fence 4 in unresolved-target-class.test.sh: no hook may build
   its own match from a shared GATE_ constant AND read a numbered group out of
   it. That is what stops this recurring in a hook written next month by
   someone copying a neighbour.

Test plan
---------

- 9 fences in the class suite, 274 in command-match, 18 in
  dirty-path-restore-gate, 17 in non-english-text-gate; all hook suites pass
  under both bash arms (`run-tests.sh` rc=0, bash 5.x and macOS 3.2).
- `vp check --fix` / `vp run check` / `typecheck:test` / `build` / `vp run test`
  rc=0 -- 777 files, 15,996 tests, no type errors.
- Live test at the gate, not just the matcher: against a real repo on `main`
  with a `.markgate.yml`, all five spellings now give branch-gate rc=2 with
  "target git working tree is on branch 'main'" -- the RIGHT reason, checked
  rather than assumed -- while `git -c user.name="Jane Doe" status` gives rc=0,
  so the widening does not reach a different verb.
- Mutation probe on the widening: restoring the old GATE_FLAGS brings the
  bypass back (`rc=0` for the `-c` spellings, `rc=2` for the baseline), which is
  the issue's original measurement reproduced.
- Mutation probe on fence 4: restoring the positional coupling in
  dirty-path-restore-gate fails fence 4 AND fence 3, so the source-level
  coupling and its behavioural symptom are both covered.
- The fixture had to be fixed before it discriminated: without `.markgate.yml`
  the repo is outside branch-gate's opt-in scope and every case returned rc=0,
  including the baseline that should block.
- Fence 4's own guard-the-guard floor fired during development and was right to:
  the first population predicate grepped for `GATE_FLAGS`, which most gates
  reach only through the `GATE_RE_*` constants, so it saw 4 hooks. The
  population is now the 35 hooks that load the matcher -- never the set that
  currently has the defect, which after a fix is 1 and would make the floor
  unreachable.
