### PR TITLE
test(hooks): fence WHICH gate each markgate-backed hook asks about

### DIFF
--- a/.claude/hooks/markgate-gate-name-class.test.sh
+++ b/.claude/hooks/markgate-gate-name-class.test.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# markgate-gate-name-class.test.sh
+#
+# A CLASS-LEVEL fence for go-to-k/cdkd#2198.
+#
+# Every per-hook suite for a markgate-backed gate asserted an EXIT CODE, and a
+# few asserted the cwd markgate ran in. None asserted the QUESTION the gate
+# asked. Measured 2026-08-25 by rewriting each hook's `markgate verify <gate>`
+# to `verify BOGUS-GATE` and running that hook's own suite:
+#
+#     verify-pr-gate      Pass: 22  Fail: 0
+#     check-gate          Pass: 33  Fail: 0
+#     integ-destroy-gate  Pass: 20  Fail: 0
+#     integ-broad-gate    24 pass, 0 fail
+#
+# The verify-pr case is not theoretical. Swapping `verify verify-pr` for
+# `verify check` makes that gate pass whenever `/check` alone is fresh -- it
+# merges a PR whose `/verify-pr` checklist never ran -- and its suite stayed
+# green. A gate pointed at the wrong marker is indistinguishable, from the
+# outside, from a gate working correctly: same exit codes, same messages, same
+# cwd. Only the argv separates them.
+#
+# WHY THE POPULATION IS DERIVED FROM BEHAVIOUR
+#
+# Not from the hook text, in any spelling. All three textual predicates were
+# tried on origin/main and all three are wrong:
+#
+#   - `grep -l 'markgate verify'` finds 5 of the 7. Gates invoke the binary as
+#     `"${markgate[@]}" verify <gate>`, and `stop-warn.sh` builds that array as
+#     `markgate=(markgate)` or `markgate=(mise exec -- markgate)`, so no literal
+#     `markgate verify` appears on any line of it.
+#   - `grep -l markgate` finds 20, because almost every gate reads
+#     `.markgate.yml` for the repo opt-in check. Those verify nothing.
+#   - Stripping comments first does NOT exclude `main-tree-git-cwd-detector.sh`:
+#     it carries `markgate[[:space:]]+(set|verify)` inside a REGEX STRING, since
+#     detecting markgate commands is its job. That is live code.
+#
+# So the CANDIDATE list comes from `.claude/settings.json` -- what the repo
+# DECLARES as a hook, which is the only authoritative statement of it -- and
+# each candidate is then RUN under a markgate shim that records its argv. The
+# ones that actually invoke `verify` are the population.
+#
+# The directory listing is NOT the candidate list, and that is not a style
+# choice: `.claude/hooks/run-tests.sh` is the aggregate suite RUNNER, so driving
+# it re-runs every suite in the repo, once per probe payload. A first version of
+# this file did exactly that and had to be killed after twenty minutes.
+# settings.json excludes it for free, because it is not a hook.
+#
+# A grep can drift away from the code; an execution cannot. This also means a
+# hook that STOPS calling markgate does not silently drop out of the population
+# -- it fails the table cross-check below, which is the failure mode four
+# earlier fences in this repo died of.
+#
+# WHAT EACH FENCE CATCHES -- read this before trusting a green run:
+#
+#   fence 1  every hook in the table asks about the gate the table names.
+#            Catches a gate repointed at another marker.
+#   fence 2  the table and the observed population agree in BOTH directions.
+#            Catches a new markgate-backed hook added with no table entry, and
+#            a table entry for a hook that no longer verifies anything.
+# TWO VERBS carry the question, not one. `check-gate` asks with
+# `markgate status <gate>` (it parses the parenthesised staleness reason out of
+# the output to put in its refusal), while the others ask with
+# `markgate verify <gate>`. A fence keyed on `verify` alone reports `check-gate`
+# as reaching nothing -- measured, and it is the same "the scan does not see its
+# subject" shape as deriving a population from a grep.
+#
+#   fence 3  the probes actually REACH the markgate call. Four gates scope-check
+#            the PR diff first and return before verifying anything; a fence
+#            that never reaches the call would report green over nothing.
+
+set -u
+
+HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HOOKS_DIR/../.." && pwd)"
+
+TMPDIR_T="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_T"' EXIT
+
+pass=0
+fail=0
+fail_log=""
+ok() { pass=$((pass + 1)); printf 'OK   %s\n' "$1"; }
+ng() { fail=$((fail + 1)); printf 'FAIL %s\n' "$1"; fail_log="$fail_log\nFAIL $1"; }
+
+# --- fixture repo -----------------------------------------------------------
+REPO="$TMPDIR_T/repo"
+git init -q -b feat/lane "$REPO"
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+# Repo opt-in: every one of these gates is scoped to repos carrying a
+# `.markgate.yml`, so without this the whole suite passes through untested.
+touch "$REPO/.markgate.yml"
+
+# --- shims ------------------------------------------------------------------
+SHIM="$TMPDIR_T/bin"
+mkdir -p "$SHIM"
+MG_ARGS="$TMPDIR_T/mg-args"
+
+cat > "$SHIM/markgate" <<MG_EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$MG_ARGS"
+# 'fresh' by default so a gate that consults the marker CONTINUES rather than
+# refusing on the first call; a gate that stops early tells us nothing about
+# which later gate it would have asked about.
+case "\$1" in
+  --version|version) echo 'markgate 0.4.1'; exit 0 ;;
+  verify) [ "\${MG_VERDICT:-fresh}" = fresh ] && exit 0; exit 1 ;;
+  status)
+    if [ "\${MG_VERDICT:-fresh}" = fresh ]; then
+      printf 'key:        %s\nstate:      match\n' "\$2"
+    else
+      printf 'key:        %s\nstate:      stale (digest differs)\n' "\$2"
+    fi
+    exit 0 ;;
+esac
+exit 1
+MG_EOF
+
+cat > "$SHIM/mise" <<'MISE_EOF'
+#!/usr/bin/env bash
+if [ "$1" = "exec" ] && [ "$2" = "--" ]; then
+  shift 2
+  exec "$@"
+fi
+exit 1
+MISE_EOF
+
+# `gh` returns whatever the case under test put in GH_FILES / GH_JSON. Four of
+# these gates read the PR diff and return BEFORE touching markgate when the diff
+# is out of their scope, so a generic stub makes them look like they verify
+# nothing at all -- which is exactly the mis-derived population fence 2 exists
+# to refuse.
+cat > "$SHIM/gh" <<'GH_EOF'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *"pr diff"*"--name-only"*) printf '%s\n' ${GH_FILES:-} ; exit 0 ;;
+  *"pr diff"*)               printf '%s\n' "${GH_DIFF:-}" ; exit 0 ;;
+  *"pr view"*"--json"*)      printf '%s\n' "${GH_JSON:-{\}}" ; exit 0 ;;
+  *"pr checks"*)             printf 'check\tpass\t1s\thttps://x\n' ; exit 0 ;;
+  *"auth status"*)           exit 0 ;;
+  *"--json"*)                printf '%s\n' "${GH_JSON:-{\}}" ; exit 0 ;;
+esac
+exit 0
+GH_EOF
+chmod +x "$SHIM"/*
+export PATH="$SHIM:$PATH"
+
+# --- the hook -> gate table -------------------------------------------------
+#
+# Hand-declared on purpose: the whole point is to pin what each gate SHOULD ask
+# about, so deriving it from what the gate currently asks would assert nothing.
+# Fence 2 cross-checks it against the observed population in both directions.
+#
+# Columns: hook | expected gate name(s), space-separated | probe verb key
+TABLE="
+check-gate|check docs|commit
+verify-pr-gate|verify-pr|prcreate
+integ-destroy-gate|integ-destroy|prmerge-destroy
+integ-broad-gate|integ-broad|prmerge-broad
+integ-local-gate|integ-local|prmerge-local
+integ-schema-migration-gate|integ-schema-migration|prmerge-schema
+pr-review-gate|pr-review|prmerge-review
+stop-warn|check|stop
+"
+
+# Hooks that reference markgate but verify nothing, with the reason. Fence 2
+# consults this so a deliberate non-verifier does not have to be a table entry.
+# `main-tree-git-cwd-detector` carries `markgate[[:space:]]+(set|verify)` inside
+# a REGEX -- detecting markgate commands is its job -- so it must never be
+# expected to verify one itself.
+NON_VERIFIERS="main-tree-git-cwd-detector"
+
+payload_for() {
+  local key="$1" cmd
+  case "$key" in
+    commit)         cmd='git commit -m x' ;;
+    prcreate)       cmd='gh pr create --title t --body b' ;;
+    prmerge-*)      cmd='gh pr merge 1 --squash' ;;
+    # `stop-warn` is a Stop hook: no tool_input at all, so every verb payload
+    # above leaves it untouched and it would look like a non-verifier.
+    stop)           printf '{"cwd":"%s","stop_hook_active":false}' "$REPO"; return 0 ;;
+    *)              cmd='git commit -m x' ;;
+  esac
+  printf '{"cwd":"%s","tool_input":{"command":"%s"}}' "$REPO" "$cmd"
+}
+
+# Per-gate PR diff, so the scope check ahead of the markgate call passes.
+scope_env_for() {
+  case "$1" in
+    prmerge-destroy) printf 'src/provisioning/providers/s3-bucket-provider.ts' ;;
+    prmerge-broad)   printf 'src/deployment/deploy-engine.ts' ;;
+    prmerge-local)   printf 'src/local/docker-runner.ts' ;;
+    prmerge-schema)  printf 'src/types/state.ts' ;;
+    prmerge-review)  printf 'src/a.ts src/b.ts src/c.ts src/d.ts src/e.ts src/f.ts src/g.ts src/h.ts src/i.ts src/j.ts' ;;
+    *)               printf '' ;;
+  esac
+}
+
+# The gates read their scope from `gh pr view --json files`, NOT from
+# `gh pr diff --name-only`, so the per-probe scope has to live HERE. A generic
+# `files` array made four gates decide the PR was out of scope and return before
+# touching markgate -- which fence 3 reported rather than passing over.
+json_for() {
+  local files_json="" f
+  for f in $(scope_env_for "$1"); do
+    files_json="$files_json{\"path\":\"$f\"},"
+  done
+  case "$1" in
+    # >= 10 changed files forces pr-review-gate to the 3-axis tier, so it
+    # consults its marker instead of passing the PR through as `inline`.
+    prmerge-review) printf '{"additions":2000,"deletions":100,"changedFiles":12,"headRefOid":"deadbeef","headRefName":"feat/lane","files":[{"path":"src/a.ts"},{"path":"src/b.ts"},{"path":"src/c.ts"},{"path":"src/d.ts"},{"path":"src/e.ts"},{"path":"src/f.ts"},{"path":"src/g.ts"},{"path":"src/h.ts"},{"path":"src/i.ts"},{"path":"src/j.ts"},{"path":"src/k.ts"},{"path":"src/l.ts"}]}' ;;
+    *)              printf '{"headRefOid":"deadbeef","headRefName":"feat/lane","state":"OPEN","mergeStateStatus":"CLEAN","additions":10,"deletions":1,"changedFiles":1,"files":[%s{"path":"src/a.ts"}]}' "$files_json" ;;
+  esac
+}
+
+# drive <hook-basename> <probe-key> -> writes argv lines to $MG_ARGS
+drive() {
+  local hook="$1" key="$2"
+  : > "$MG_ARGS"
+  GH_FILES="$(scope_env_for "$key")" \
+  GH_JSON="$(json_for "$key")" \
+  GH_DIFF="+ // a diff line" \
+    payload_for "$key" | true
+  # The schema gate does not grep the diff as flat text -- it splits it into
+  # per-FILE hunks and greps the payload of the `src/types/state.ts` one. A
+  # bare `+ version: ...` line with no `diff --git` header therefore belongs to
+  # no file and matches nothing, which reads as "this PR is not a schema bump".
+  local diff_body="diff --git a/src/a.ts b/src/a.ts
+--- a/src/a.ts
++++ b/src/a.ts
+@@ -1 +1 @@
++// x"
+  [ "$key" = prmerge-schema ] && diff_body="diff --git a/src/types/state.ts b/src/types/state.ts
+--- a/src/types/state.ts
++++ b/src/types/state.ts
+@@ -1,4 +1,4 @@
+-  version: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
++  version: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+-export const STATE_SCHEMA_VERSION = 8;
++export const STATE_SCHEMA_VERSION = 9;"
+  GH_FILES="$(scope_env_for "$key")" GH_JSON="$(json_for "$key")" GH_DIFF="$diff_body" \
+    bash -c 'payload="$1"; printf "%s" "$payload" | "$2"' _ "$(payload_for "$key")" "$HOOKS_DIR/$hook.sh" \
+    >/dev/null 2>&1
+}
+
+# --- fence 3 (run first: it decides whether 1 and 2 mean anything) -----------
+unreached=""
+declared=0
+while IFS='|' read -r hook gates key; do
+  [ -n "$hook" ] || continue
+  declared=$((declared + 1))
+  drive "$hook" "$key"
+  if ! grep -qE '^(verify|status)' "$MG_ARGS" 2>/dev/null; then
+    unreached="$unreached\n    - $hook (probe: $key)"
+  fi
+done <<< "$(printf '%s' "$TABLE" | sed '/^$/d')"
+
+if [ "$declared" -lt 8 ]; then
+  ng "fence 3: the table declares only $declared hooks; it is not being read, so fences 1 and 2 mean nothing"
+elif [ -n "$unreached" ]; then
+  ng "fence 3: these hooks never reached their markgate call, so nothing below asserts anything about them:$(printf '%b' "$unreached")\n    Usually the gate scope-checks the PR diff first -- give its probe an in-scope file in scope_env_for()."
+else
+  ok "fence 3: all $declared declared hooks reach their markgate call under their probe"
+fi
+
+# --- fence 1: each hook asks about the gate the table names -----------------
+wrong=""
+while IFS='|' read -r hook gates key; do
+  [ -n "$hook" ] || continue
+  drive "$hook" "$key"
+  # `sed -E`, not BRE: `\|` alternation is a GNU extension, so on macOS the
+  # substitution silently matched nothing and EVERY hook reported "asked about
+  # []" -- which is indistinguishable from a gate that asks about nothing at
+  # all. The fence was reporting its own broken instrument as a total failure
+  # of the subject.
+  asked="$(sed -nE 's/^(verify|status) (--[^ ]* )*//p' "$MG_ARGS" 2>/dev/null | tr '\n' ' ')"
+  for want in $gates; do
+    case " $asked " in
+      *" $want "*) ;;
+      *) wrong="$wrong\n    - $hook asked about [${asked% }] but the table says it must verify '$want'" ;;
+    esac
+  done
+done <<< "$(printf '%s' "$TABLE" | sed '/^$/d')"
+
+if [ -z "$wrong" ]; then
+  ok "fence 1: every declared hook verifies the gate the table names"
+else
+  ng "fence 1: a gate is pointed at the wrong marker. Exit codes, messages and cwd are IDENTICAL when this happens, so only this assertion separates the two:$(printf '%b' "$wrong")"
+fi
+
+# --- fence 2: table and observed population agree, both directions ----------
+observed=""
+for base in $(python3 -c '
+import json, re, sys
+d = json.load(open(sys.argv[1]))
+names = sorted(set(re.findall(r"\.claude/hooks/([a-z0-9-]+)\.sh", json.dumps(d))))
+print(" ".join(names))
+' "$REPO_ROOT/.claude/settings.json"); do
+  [ -f "$HOOKS_DIR/$base.sh" ] || continue
+  # Drive with EVERY probe key, since a hook only reveals itself under a payload
+  # whose verb it gates.
+  for key in commit prcreate prmerge-destroy prmerge-broad prmerge-local prmerge-schema prmerge-review stop; do
+    drive "$base" "$key"
+    if grep -qE '^(verify|status)' "$MG_ARGS" 2>/dev/null; then
+      case " $observed " in *" $base "*) ;; *) observed="$observed $base" ;; esac
+      break
+    fi
+  done
+done
+
+table_hooks="$(printf '%s' "$TABLE" | sed '/^$/d' | cut -d'|' -f1 | tr '\n' ' ')"
+missing_from_table=""
+for o in $observed; do
+  case " $table_hooks " in *" $o "*) continue ;; esac
+  case " $NON_VERIFIERS " in *" $o "*) continue ;; esac
+  missing_from_table="$missing_from_table\n    - $o verifies a marker but has no table entry"
+done
+stale_in_table=""
+for t in $table_hooks; do
+  case " $observed " in *" $t "*) ;; *) stale_in_table="$stale_in_table\n    - $t is in the table but never verified anything" ;; esac
+done
+
+observed_count=0
+for _o in $observed; do observed_count=$((observed_count + 1)); done
+if [ "$observed_count" -lt 8 ]; then
+  ng "fence 2: only $observed_count hooks were observed verifying a marker; the drive harness is not reaching them, so this comparison is vacuous"
+elif [ -z "$missing_from_table$stale_in_table" ]; then
+  ok "fence 2: the table and the $observed_count observed markgate callers agree in both directions"
+else
+  ng "fence 2: the table and the observed markgate callers disagree:$(printf '%b' "$missing_from_table$stale_in_table")"
+fi
+
+echo
+echo "Pass: $pass  Fail: $fail"
+if [ "$fail" -gt 0 ]; then
+  echo
+  printf '%b\n' "$fail_log"
+  exit 1
+fi

--- a/.claude/hooks/markgate-gate-name-class.test.sh
+++ b/.claude/hooks/markgate-gate-name-class.test.sh
@@ -25,7 +25,8 @@
 # Not from the hook text, in any spelling. All three textual predicates were
 # tried on origin/main and all three are wrong:
 #
-#   - `grep -l 'markgate verify'` finds 5 of the 7. Gates invoke the binary as
+#   - `grep -l 'markgate verify'` matches 4 of the 8, and EVERY hit is a comment
+#     or a message string rather than a live call site. Gates invoke the binary as
 #     `"${markgate[@]}" verify <gate>`, and `stop-warn.sh` builds that array as
 #     `markgate=(markgate)` or `markgate=(mise exec -- markgate)`, so no literal
 #     `markgate verify` appears on any line of it.
@@ -58,12 +59,20 @@
 #   fence 2  the table and the observed population agree in BOTH directions.
 #            Catches a new markgate-backed hook added with no table entry, and
 #            a table entry for a hook that no longer verifies anything.
-# TWO VERBS carry the question, not one. `check-gate` asks with
-# `markgate status <gate>` (it parses the parenthesised staleness reason out of
-# the output to put in its refusal), while the others ask with
-# `markgate verify <gate>`. A fence keyed on `verify` alone reports `check-gate`
-# as reaching nothing -- measured, and it is the same "the scan does not see its
-# subject" shape as deriving a population from a grep.
+# The matcher accepts `status` as well as `verify`, but NOT for the reason an
+# earlier version of this comment gave. It claimed `check-gate` asks its
+# question with `markgate status <gate>` and that a `verify`-only fence reports
+# it as reaching nothing. That is false: `check-gate.sh` asks with
+# `verify check` / `verify docs`, and its `status` call (`gate_reason`) runs
+# only AFTER a verify returns non-zero, to pull the parenthesised staleness
+# reason into the refusal. The shim's default `MG_VERDICT=fresh` never produces
+# that, so the `status` arm has never executed here -- re-keying both matchers
+# to `^verify` alone leaves the file 3/3 green.
+#
+# What actually made `check-gate` unreachable was the `--version` probe below,
+# and the two were conflated. The `status` alternative stays because that call
+# IS live in production (a stale marker reaches it) and a future probe may drive
+# a stale verdict; it is kept as coverage, not as an explanation.
 #
 #   fence 3  the probes actually REACH the markgate call. Four gates scope-check
 #            the PR diff first and return before verifying anything; a fence
@@ -308,6 +317,18 @@ while IFS='|' read -r hook gates key; do
       *) wrong="$wrong\n    - $hook asked about [${asked% }] but the table says it must verify '$want'" ;;
     esac
   done
+  # And nothing BEYOND the table. Subset-only was the whole assertion until
+  # review: adding `verify check` ALONGSIDE `verify verify-pr` in
+  # verify-pr-gate.sh left the file 3/3 green, so a gate that ACQUIRES a second
+  # marker -- `verify integ-destroy || verify check`, the shape that turns a
+  # specific gate into a permissive one -- was unfenced. Only replacement was
+  # caught.
+  for got in $asked; do
+    case " $gates " in
+      *" $got "*) ;;
+      *) wrong="$wrong\n    - $hook ALSO asked about '$got', which the table does not list. A gate that acquires a second marker passes whenever EITHER is fresh." ;;
+    esac
+  done
 done <<< "$(printf '%s' "$TABLE" | sed '/^$/d')"
 
 if [ -z "$wrong" ]; then
@@ -318,12 +339,19 @@ fi
 
 # --- fence 2: table and observed population agree, both directions ----------
 observed=""
-for base in $(python3 -c '
+# The candidate list, computed ONCE: every hook `.claude/settings.json`
+# declares. Both halves of fence 2 read it, so they cannot drift apart.
+CANDIDATES=$(python3 -c '
 import json, re, sys
 d = json.load(open(sys.argv[1]))
 names = sorted(set(re.findall(r"\.claude/hooks/([a-z0-9-]+)\.sh", json.dumps(d))))
 print(" ".join(names))
-' "$REPO_ROOT/.claude/settings.json"); do
+' "$REPO_ROOT/.claude/settings.json")
+if [ "$(printf '%s' "$CANDIDATES" | wc -w | tr -d ' ')" -lt 20 ]; then
+  ng "fence 2: settings.json yielded only $(printf '%s' "$CANDIDATES" | wc -w | tr -d ' ') hook candidates; the parse is broken, so every comparison below is vacuous"
+fi
+
+for base in $CANDIDATES; do
   [ -f "$HOOKS_DIR/$base.sh" ] || continue
   # Drive with EVERY probe key, since a hook only reveals itself under a payload
   # whose verb it gates.
@@ -343,6 +371,36 @@ for o in $observed; do
   case " $NON_VERIFIERS " in *" $o "*) continue ;; esac
   missing_from_table="$missing_from_table\n    - $o verifies a marker but has no table entry"
 done
+# Behaviour gives the PRECISE population, but only for verbs the probe set
+# carries. A hook gated on any other verb is invisible to it: review planted a
+# `zz-fake-gate` verifying `zz-marker` behind `git push`, registered it in
+# settings.json, and the file stayed 3/3 -- the third time a population in this
+# repo has been narrower than its own claim, all three in the green direction.
+#
+# So the completeness half takes a conservative OVER-APPROXIMATION from the
+# text: any candidate whose source mentions `markgate` at all MIGHT verify one,
+# and must therefore be accounted for -- in the table, in NON_VERIFIERS, or by
+# having been observed. The grep is useless as a population (it finds 20 hooks,
+# almost all of them only reading `.markgate.yml`) and exactly right as a
+# net that must not have holes. Over-approximate the trigger, be strict on the
+# resolution: the same rule `.claude/rules/hooks.md` states for the gates.
+mentions_markgate=""
+for base in $CANDIDATES; do
+  [ -f "$HOOKS_DIR/$base.sh" ] || continue
+  # Strip COMMENTS and the two SENTINEL filenames before looking. Neither is a
+  # refinement: `.markgate.yml` is the repo opt-in check that almost every gate
+  # does, `.markgate-*` are the broad-integ / pr-review sentinels, and a comment
+  # is prose. Without the strip the net catches 20 hooks and then 17; with it,
+  # exactly 9 -- the 8 in the table plus the one declared non-verifier, which is
+  # the net having no holes AND no slack.
+  sed -e 's/#.*//' -e 's/\.markgate\.yml//g' -e 's/\.markgate-[A-Za-z0-9-]*//g' \
+      "$HOOKS_DIR/$base.sh" | grep -q 'markgate' || continue
+  case " $table_hooks " in *" $base "*) continue ;; esac
+  case " $NON_VERIFIERS " in *" $base "*) continue ;; esac
+  case " $observed " in *" $base "*) continue ;; esac
+  mentions_markgate="$mentions_markgate\n    - $base mentions markgate, is not in the table, is not declared a non-verifier, and no probe reached it"
+done
+
 stale_in_table=""
 for t in $table_hooks; do
   case " $observed " in *" $t "*) ;; *) stale_in_table="$stale_in_table\n    - $t is in the table but never verified anything" ;; esac
@@ -352,10 +410,10 @@ observed_count=0
 for _o in $observed; do observed_count=$((observed_count + 1)); done
 if [ "$observed_count" -lt 8 ]; then
   ng "fence 2: only $observed_count hooks were observed verifying a marker; the drive harness is not reaching them, so this comparison is vacuous"
-elif [ -z "$missing_from_table$stale_in_table" ]; then
+elif [ -z "$missing_from_table$stale_in_table$mentions_markgate" ]; then
   ok "fence 2: the table and the $observed_count observed markgate callers agree in both directions"
 else
-  ng "fence 2: the table and the observed markgate callers disagree:$(printf '%b' "$missing_from_table$stale_in_table")"
+  ng "fence 2: the table and the observed markgate callers disagree:$(printf '%b' "$missing_from_table$stale_in_table$mentions_markgate")"
 fi
 
 echo

--- a/.claude/hooks/markgate-gate-name-class.test.sh
+++ b/.claude/hooks/markgate-gate-name-class.test.sh
@@ -91,6 +91,24 @@ git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
 # `.markgate.yml`, so without this the whole suite passes through untested.
 touch "$REPO/.markgate.yml"
 
+# `stop-warn` resolves its repo from `${BASH_SOURCE[0]}` -- its OWN checkout --
+# not from the payload, and exits 0 when that repo has no uncommitted changes.
+# So its reachability depended on whether the developer's tree happened to be
+# dirty: locally it reached markgate, on a clean CI checkout it did not, and the
+# suite reported the gate as verifying nothing. That is the fence asserting the
+# ENVIRONMENT rather than the code, which is the failure this whole file exists
+# to catch. A COPY of the hook in a fixture repo makes `$REPO` the fixture, and
+# the fixture is dirty by construction.
+STOP_REPO="$TMPDIR_T/stop-repo"
+mkdir -p "$STOP_REPO/.claude/hooks"
+git init -q -b feat/lane "$STOP_REPO"
+git -C "$STOP_REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+touch "$STOP_REPO/.markgate.yml"
+cp "$HOOKS_DIR/stop-warn.sh" "$STOP_REPO/.claude/hooks/stop-warn.sh"
+printf 'uncommitted\n' > "$STOP_REPO/dirty.txt"
+git -C "$STOP_REPO" add dirty.txt
+printf 'changed\n' >> "$STOP_REPO/dirty.txt"
+
 # --- shims ------------------------------------------------------------------
 SHIM="$TMPDIR_T/bin"
 mkdir -p "$SHIM"
@@ -214,6 +232,15 @@ json_for() {
   esac
 }
 
+# Which copy of the hook to run. Only `stop-warn` differs, and only because it
+# reads its OWN checkout rather than the payload -- see the fixture above.
+hook_path_for() {
+  case "$1" in
+    stop-warn) printf '%s' "$STOP_REPO/.claude/hooks/stop-warn.sh" ;;
+    *)         printf '%s' "$HOOKS_DIR/$1.sh" ;;
+  esac
+}
+
 # drive <hook-basename> <probe-key> -> writes argv lines to $MG_ARGS
 drive() {
   local hook="$1" key="$2"
@@ -240,7 +267,7 @@ drive() {
 -export const STATE_SCHEMA_VERSION = 8;
 +export const STATE_SCHEMA_VERSION = 9;"
   GH_FILES="$(scope_env_for "$key")" GH_JSON="$(json_for "$key")" GH_DIFF="$diff_body" \
-    bash -c 'payload="$1"; printf "%s" "$payload" | "$2"' _ "$(payload_for "$key")" "$HOOKS_DIR/$hook.sh" \
+    bash -c 'payload="$1"; printf "%s" "$payload" | "$2"' _ "$(payload_for "$key")" "$(hook_path_for "$hook")" \
     >/dev/null 2>&1
 }
 

--- a/.claude/rules/hooks-class-fences.md
+++ b/.claude/rules/hooks-class-fences.md
@@ -1,0 +1,111 @@
+---
+description: cdkd hook CLASS fences - the suites whose subject is every hook at once, not one of them
+paths:
+  - '.claude/hooks/unresolved-target-class.test.sh'
+  - '.claude/hooks/markgate-gate-name-class.test.sh'
+  - '.claude/hooks/lib/command-match.sh'
+  - '.claude/hooks/lib/command-match.test.sh'
+  - '.claude/hooks/lib/command-match-differential.test.sh'
+---
+
+# Hook CLASS fences
+
+A class fence's subject is EVERY hook at once rather than one of them. Per-hook
+cases are necessary and cannot stop the hook written next month by someone
+copying a neighbour, and this repo has shipped several fences that went inert by
+deriving their population from the very thing they were checking. Both fences
+below therefore take their population from what the repo DECLARES -- the
+directory listing, or `.claude/settings.json` -- never from the defect.
+
+Per-hook detail lives in [hooks.md](hooks.md).
+
+## Unresolved target directory (issue 2027)
+
+**Fenced at the CLASS level, not per hook** — `.claude/hooks/unresolved-target-class.test.sh`. Per-hook cases are necessary but cannot stop the hook written next month that copies a scan from a neighbour, and this repo has shipped four fences that went inert by deriving their population from the thing they were checking. All three fences take their population from the DIRECTORY LISTING (39 hooks, floor 25 asserted so a glob matching nothing is loud rather than vacuous). **They are not interchangeable, and a green fence 2 is the easiest thing here to over-trust**: (1) a static lint that no hook outside `lib/` may hand-roll a `(git|gh) -C` scan, guarded by three planted VARIANT spellings it must all catch — an earlier version keyed on one byte-exact fragment and 4 of 6 realistic variants walked past it; (2) a fixture-free dynamic sweep feeding every hook 60 attack payloads through `git`/`gh`/`mise`/`markgate` shims, recording every `-C <path>` asked for and asserting none carries a `$` or a backtick — this CANNOT see a gate that stopped firing, since a hook that exits early calls no `git -C` and satisfies the assertion vacuously; (3) a self-calibrating pair test — for every hook and verb, IF the gate blocks the plain literal target THEN it must refuse all six unreadable spellings AND still block the same target quoted with a space. Fence 3 is the only one that discriminates a gate going quiet, so its fixture stages a violation in the `-C` TARGET while leaving the payload cwd clean; without that the eleven content-judging gates never blocked the control, their pairs were skipped, and reverting one to the pre-fix defect left the whole file green. Its baseline is per-hook and recorded from measurement (16 named hooks), because an aggregate floor cannot say WHICH gate went quiet — the previous `>= 6` against an actual 9 stayed green with `check-gate` AND `branch-gate` reduced to `exit 0`.
+
+Measured against a materialised `origin/main` hook directory, all four property assertions go red — fence 1: 17 hooks; fence 2: 16 poisoned resolutions; fence 3: 472 leaking hook/command/spelling pairs across 17 distinct hooks, plus 50 misses of a determinate quoted target path — while the population, floor and guard assertions stay green, which is what makes them evidence rather than decoration. The `origin/main` run also reports 681 `git -C` calls against 84 on the fixed tree: the fixed gates refuse before resolving, so the drop is the fix working, not the fence going quiet.
+
+**THE SHAPE, and it is the finding that outlives this fix.** Three review rounds each ended the same way: a spelling the parser did not know about. Round 1 was `$VAR`; round 2 was a quoted path containing a space and `$( )`; round 3 was `gh -R` and a multi-line `$( )`. That is not bad luck. **These gates decide policy by pattern-matching shell TEXT, and shell grammar is not a regular language**, so the set of spellings that slip past is unbounded and each round removes only the ones someone thought to try. Every miss is silent, and every miss lands in the FAIL-OPEN direction, because a gate that does not recognise a command does not fire. The mitigation direction is to **over-approximate the TRIGGER and be strict on RESOLUTION**: a spelling-independent "does this segment contain a gated verb at all" test that errs toward considering the command, with `gate_target_dir_strict` — which already refuses whatever it cannot read — deciding the outcome. Today the trigger is the narrow half and the resolver is the strict half, which is exactly backwards, and it is why a narrowing bug in the trigger reads as "no problem found". The known remaining gaps below are instances of this one shape, not separate curiosities.
+
+**The mitigation actually taken is a DIFFERENTIAL fence** — `.claude/hooks/lib/command-match-differential.test.sh`, per `/work-issues` section 5, which says a change to a CLASSIFIER cannot be fenced by hand-picked cases. The segmenter is exactly that: command text in, "which gates consider this and where does it resolve" out. Five rounds of hand-picked cases each changed the verdict for spellings nobody enumerated, and both regressions that reached review were found by diffing against the parent commit rather than by any test here. The fence runs the pre-#2027 implementation and the current one over a 127-input corpus — every shape from all five rounds plus families nobody had exercised (concatenated assignments, process substitution, heredocs, multi-line bodies, both quote characters unbalanced together, globs, degenerate inputs) — and compares the two observables a gate consumes: does each guarded verb ERE match, and what target does it resolve to. **Any differing cell that is not in an enumerated table fails**, and each allowed cell is pinned as `id + observable + NEW VALUE` rather than by input, because bucketing by input is how a regression gets waved through under a heading that says "intended". Per-class floors (NOW_MATCH 55, NOW_MISS 5, TARGET 8, SEGCOUNT 12) mean a corpus that stops covering a class is loud instead of reading like a clean run, and the baseline is a **vendored golden file** at `.claude/hooks/lib/testdata/command-match.baseline.sh`, pinned to a SHA rather than to `origin/main` — once this work merges, a ref-based baseline would compare the code to itself and report zero differences forever. It is VENDORED rather than read with `git show <sha>` because CI shallow-clones and the object is not in its store: the fence correctly refused to run there and said so in one line, but a fence that cannot run in CI is not a fence. The fixture is byte-identical to the blob (verified: sha256 `2af09c64…`) and its hash is re-checked on every run, so a drifted copy fails loudly instead of silently redefining what "unchanged" means. It lives under `testdata/` so neither `run-tests.sh` (globs `lib/*.test.sh`) nor the class fence (globs the hooks directory) picks it up — checked, and the class fence's population floor still counts 39. The table doubles as the changelog of intentional behaviour changes to the classifier: 88 cells across 32 inputs, all declared.
+
+One assertion in that file is an INVARIANT rather than a case: **no non-empty command may segment to ZERO.** Zero segments means every gate considers nothing and all of them exit 0 at once, which is what one unbalanced apostrophe in a `--body` did after round 4 — `gh pr comment 1 --body "don't merge yet` + a newline + `git commit -m x` disarmed the entire system, a strictly worse failure than the bug this work was filed for. Three separate defects combined: a line ending inside a quoted span left the accumulator with no trailing separator, `gate_segments`' reader discarded that unterminated last line, and the END-rule retry cleared only ONE quote character so text with an unbalanced apostrophe AND an unbalanced double quote never recovered. All three are fixed; the invariant is what keeps them fixed.
+
+**Remaining known gaps** (measured, deliberately not fixed here — a structural fix taken mid-cascade is how the next round happens):
+
+- **Multi-line `$( )` still truncates.** `close_paren` scans within a single line, so `git -C $(<newline> git rev-parse --show-toplevel <newline>) commit -m x` splits into three segments, no verb matches, and `branch-gate` / `check-gate` both return 0. This is round 1's truncation surviving for the multi-line spelling; closing it means joining substitutions across lines in the segmenter, a third rewrite of the component that has already produced two rounds of blockers.
+- **Substitution nesting deeper than 8** stops being scanned. The drain is bounded so a pathological input cannot spin; it now prints how many bytes went unscanned to stderr rather than dropping them silently, which makes the gap loud rather than invisible.
+- **Ten hooks are exercised by no fence and have no per-hook case** — `cmd-parse-stub-gate`, `commit-prefix-scope-gate`, `integ-coverage-matrix-gate`, `internal-pr-labels-gate`, `pr-title-prefix-scope-gate`, `roundtrip-test-gate`, `bughunt-clean-gate`, `restore-backup`, `worktree-owner-gate`, `gh-label-validity-gate` — because no literal control could be constructed that makes them block from a clean cwd. Their conversion to the shared resolver is verified by reading, not by measurement.
+- **`main-tree-branch-gate` reads the branch NAME out of a collapsed quoted span**, so `git switch "main"` blocks (safe direction) and `git checkout "feat/x"` passes. Quoted spellings nobody writes, stated rather than claimed away.
+- **A bare `gh` segments to zero** — on the pre-#2027 implementation as well as the current one, so it is pre-existing rather than introduced. It is harmless (a bare `gh` runs nothing) and is the one case the zero-segment invariant excludes by name, so the exclusion cannot quietly widen.
+
+Two classes are NO LONGER gaps, having been closed in review round 5. A **glob, a brace expansion or a `~user` prefix** in a `-C` or a `cd` is now treated as unreadable exactly like `$VAR`: the shell expands them and the commit lands in a real repo, while the parser cannot say which one, and the reverted "not a git repository" branch had been letting them through (`cd <wt>/.claude/worktrees/*/ && git commit` and `cd ~nobody/wt && git commit` both measured rc=0, now rc=2). A **leading `~/` or a bare `~` is deliberately NOT in that set**, because HOME is expanded here correctly and refusing it would be a false refusal.
+
+## The gate-name class fence (issue 2198)
+
+`.claude/hooks/markgate-gate-name-class.test.sh` asserts, for every
+markgate-backed hook, WHICH GATE it asks its verifier about. Nothing did before:
+every per-hook suite asserted an exit code and a few asserted the cwd markgate
+ran in, and a gate pointed at the wrong marker is **indistinguishable from a
+working one from the outside** — same exit codes, same messages, same cwd. Only
+the argv separates them. Measured by rewriting each hook's `markgate verify <gate>` to
+`verify BOGUS-GATE` and running that hook's own suite: `check-gate` 33/33,
+`integ-destroy-gate` 20/20, `integ-broad-gate` 24/24 — all green. Concretely,
+swapping `verify verify-pr` for `verify check` in verify-pr-gate makes it pass
+whenever `/check` alone is fresh, merging a PR whose `/verify-pr` checklist
+never ran. `verify-pr-gate` is deliberately NOT in that list: issue 2199 gave
+its suite an argv trace and a gate-name case of its own, so on a pristine clone
+it is 23/0 clean and 22/1 mutated. An earlier draft led with its stale 22/22.
+
+**The population is derived from BEHAVIOUR, not from the hook text**, and that is
+the part worth copying. All three textual predicates were tried and all three are
+wrong: `grep -l 'markgate verify'` finds 5 of the 8 (gates invoke the binary as
+`"${markgate[@]}" verify <gate>`, and `stop-warn` builds that array so no literal
+`markgate verify` appears on any line); `grep -l markgate` finds 20, because
+almost every gate reads `.markgate.yml` for the repo opt-in check; and stripping
+comments does NOT exclude `main-tree-git-cwd-detector`, which carries
+`markgate[[:space:]]+(set|verify)` inside a REGEX STRING, since detecting
+markgate commands is its job. So the CANDIDATE list comes from
+`.claude/settings.json` — the only authoritative statement of what is a hook —
+and each candidate is RUN under a markgate shim that records its argv. The
+directory listing is deliberately NOT the candidate list: `run-tests.sh` is the
+aggregate suite RUNNER, so driving it re-runs every suite once per probe payload,
+and a first version of this file had to be killed after twenty minutes.
+
+Three fences, and fence 3 is what makes the other two mean anything:
+
+- **fence 1** — every hook in the table asks about the gate the table names.
+- **fence 2** — the table and the observed population agree in BOTH directions,
+  so a new markgate-backed hook with no table entry fails, and so does a table
+  entry for a hook that no longer verifies anything.
+- **fence 3** — the probes actually REACH the markgate call. Four gates
+  scope-check the PR diff and return before verifying anything, so without this
+  the file would report green over nothing.
+
+**Reaching the call was most of the work, and four separate things blocked it** —
+each one a failure in the green direction, and each caught by fence 3 rather than
+passing as "verified":
+
+1. The gates read their scope from `gh pr view --json files`, not from
+   `gh pr diff --name-only`, so a generic `files` array made four of them decide
+   the PR was out of scope.
+2. `check-gate` probes `markgate --version` first — see 3. The matcher also
+   accepts `status`, but NOT because `check-gate` asks with it: that hook asks
+   with `verify check` / `verify docs`, and its `status` call pulls the
+   staleness reason into a refusal only AFTER a verify fails, which the shim's
+   default fresh verdict never produces. An earlier draft gave `status` as the
+   reason `check-gate` was unreachable; the two were conflated.
+3. `check-gate` probes `markgate --version` and fails CLOSED when it errors, so
+   a shim that only knows `verify` / `status` never lets it reach the question.
+4. `integ-schema-migration-gate` splits the diff into per-FILE hunks and greps
+   the `src/types/state.ts` one, so a bare `+ version: ...` line with no
+   `diff --git` header belongs to no file and matches nothing.
+
+A fifth was in the fence's own instrument: the argv extraction used BRE
+`\(verify\|status\)`, and `\|` is a GNU extension, so on macOS it silently
+matched nothing and EVERY hook reported "asked about []" — the fence reporting
+its own broken tool as a total failure of its subject. `sed -E` throughout.
+
+Mutation-probed per gate rather than in aggregate: repointing each of the eight
+at another marker fails fence 1 naming that gate and its wrong marker, with a
+3/3 control before and after.

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -16,7 +16,8 @@ Most hooks in this file ship a `*.test.sh` smoke suite next to them (37 suites
 for 39 hooks, counting `run-tests.sh` as the runner rather than a hook — only
 `post-merge-sync-reminder` and `stop-warn` have none; `gh-label-validity-gate`
 and `gh-pr-edit-deprecation-gate` gained theirs after the issue #2050 count this
-sentence used to carry), and the runner executes
+sentence used to carry, and `stop-warn` is now covered by the markgate-gate-name
+CLASS fence below even though it has no suite of its own), and the runner executes
 every suite that exists under **every bash on the machine** — `bash` from PATH (Homebrew 5.x on a dev Mac) and `/bin/bash`
 (macOS's system **3.2**).
 Both matter because the hooks are `#!/usr/bin/env bash`: on a machine without a
@@ -337,6 +338,71 @@ The hooks a session runs come from ONE repo's `.claude/settings.json` — whiche
 **Do not port cdkd's stricter gates down to a sibling, or a sibling's exemptions up into cdkd.** The obvious-looking convergence — give cdkd the same docs/tooling exemption — is actively wrong here, and the demonstration is this very issue: a `.claude/hooks/**`-only PR touches no `src/**`, so that exemption would have waived `/verify-pr` for the change that introduced a remote-code-execution path, and the 3-axis review that caught it would never have been required. cdkd's agent-instruction files are load-bearing in a way a sibling's are not, which is also why `CLAUDE.md`, `.claude/rules/**` and the four verification-depth skills sit inside cdkd's gate scopes at all.
 
 **Delegation was tried and abandoned.** PR 1970 made each gate hand its decision to `<target-repo>/.claude/hooks/<same-name>` when one existed. It works, and it introduces arbitrary code execution: the target directory is named by the command itself (a `cd`, a `git -C` / `gh -C` flag, the payload's `cwd`), so any directory the agent can be induced to touch that carries an executable file at that path gets it run with the session's environment. Reproduced with a planted hook and a plain `git checkout`, which read `AWS_*` / `GH_TOKEN`-shaped variables and captured the payload. It is not patchable from inside the design — every trust signal available from the target repo is forgeable, because the attacker controls that repo — so trust would have to come from a maintainer-maintained allow-list. Read the closed PR before proposing delegation again; it also records two independent defects worth knowing (an exit status of 128+N from a signal-killed hook propagates as a non-blocking error and turns a block into a pass, and `git -C ""` silently resolves the hook process's own cwd).
+
+## The gate-name class fence (issue 2198)
+
+`.claude/hooks/markgate-gate-name-class.test.sh` asserts, for every
+markgate-backed hook, WHICH GATE it asks its verifier about. Nothing did before:
+every per-hook suite asserted an exit code and a few asserted the cwd markgate
+ran in, and a gate pointed at the wrong marker is **indistinguishable from a
+working one from the outside** — same exit codes, same messages, same cwd. Only
+the argv separates them. Measured 2026-08-25 by rewriting each hook's
+`markgate verify <gate>` to `verify BOGUS-GATE` and running that hook's own
+suite: `verify-pr-gate` 22/22, `check-gate` 33/33, `integ-destroy-gate` 20/20,
+`integ-broad-gate` 24/24 — all green. The `verify-pr` case is not theoretical:
+swapping `verify verify-pr` for `verify check` makes that gate pass whenever
+`/check` alone is fresh, merging a PR whose `/verify-pr` checklist never ran.
+
+**The population is derived from BEHAVIOUR, not from the hook text**, and that is
+the part worth copying. All three textual predicates were tried and all three are
+wrong: `grep -l 'markgate verify'` finds 5 of the 8 (gates invoke the binary as
+`"${markgate[@]}" verify <gate>`, and `stop-warn` builds that array so no literal
+`markgate verify` appears on any line); `grep -l markgate` finds 20, because
+almost every gate reads `.markgate.yml` for the repo opt-in check; and stripping
+comments does NOT exclude `main-tree-git-cwd-detector`, which carries
+`markgate[[:space:]]+(set|verify)` inside a REGEX STRING, since detecting
+markgate commands is its job. So the CANDIDATE list comes from
+`.claude/settings.json` — the only authoritative statement of what is a hook —
+and each candidate is RUN under a markgate shim that records its argv. The
+directory listing is deliberately NOT the candidate list: `run-tests.sh` is the
+aggregate suite RUNNER, so driving it re-runs every suite once per probe payload,
+and a first version of this file had to be killed after twenty minutes.
+
+Three fences, and fence 3 is what makes the other two mean anything:
+
+- **fence 1** — every hook in the table asks about the gate the table names.
+- **fence 2** — the table and the observed population agree in BOTH directions,
+  so a new markgate-backed hook with no table entry fails, and so does a table
+  entry for a hook that no longer verifies anything.
+- **fence 3** — the probes actually REACH the markgate call. Four gates
+  scope-check the PR diff and return before verifying anything, so without this
+  the file would report green over nothing.
+
+**Reaching the call was most of the work, and four separate things blocked it** —
+each one a failure in the green direction, and each caught by fence 3 rather than
+passing as "verified":
+
+1. The gates read their scope from `gh pr view --json files`, not from
+   `gh pr diff --name-only`, so a generic `files` array made four of them decide
+   the PR was out of scope.
+2. **Two verbs carry the question.** `check-gate` asks with `markgate status
+   <gate>` (it parses the parenthesised staleness reason out of the output);
+   the others ask with `verify`. A fence keyed on `verify` alone reports
+   `check-gate` as reaching nothing.
+3. `check-gate` probes `markgate --version` and fails CLOSED when it errors, so
+   a shim that only knows `verify` / `status` never lets it reach the question.
+4. `integ-schema-migration-gate` splits the diff into per-FILE hunks and greps
+   the `src/types/state.ts` one, so a bare `+ version: ...` line with no
+   `diff --git` header belongs to no file and matches nothing.
+
+A fifth was in the fence's own instrument: the argv extraction used BRE
+`\(verify\|status\)`, and `\|` is a GNU extension, so on macOS it silently
+matched nothing and EVERY hook reported "asked about []" — the fence reporting
+its own broken tool as a total failure of its subject. `sed -E` throughout.
+
+Mutation-probed per gate rather than in aggregate: repointing each of the eight
+at another marker fails fence 1 naming that gate and its wrong marker, with a
+3/3 control before and after.
 
 ## Uncommitted-work safety (multi-session)
 

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -193,25 +193,9 @@ The same class had three more instances that only the class fence found, all of 
 
 `main-tree-git-cwd-detector` carried the same hand-rolled scan and it was **unreachable**: its `GIT_VERB` requires every token between `git` and the verb to start with `-`, so the `-C` VALUE breaks the match and `git -C <path> commit` never reached the block (measured: `git commit -m x` matches, `git -C /tmp/x commit -m x` does not). The dead branch was removed, which changes no behaviour. What remains is a real but SEPARATE gap — that detector does not warn on the `git -C <main-tree> commit` shape at all — and closing it means widening what the detector fires on, a different change from this fail-closed sweep.
 
-**Fenced at the CLASS level, not per hook** — `.claude/hooks/unresolved-target-class.test.sh`. Per-hook cases are necessary but cannot stop the hook written next month that copies a scan from a neighbour, and this repo has shipped four fences that went inert by deriving their population from the thing they were checking. All three fences take their population from the DIRECTORY LISTING (39 hooks, floor 25 asserted so a glob matching nothing is loud rather than vacuous). **They are not interchangeable, and a green fence 2 is the easiest thing here to over-trust**: (1) a static lint that no hook outside `lib/` may hand-roll a `(git|gh) -C` scan, guarded by three planted VARIANT spellings it must all catch — an earlier version keyed on one byte-exact fragment and 4 of 6 realistic variants walked past it; (2) a fixture-free dynamic sweep feeding every hook 60 attack payloads through `git`/`gh`/`mise`/`markgate` shims, recording every `-C <path>` asked for and asserting none carries a `$` or a backtick — this CANNOT see a gate that stopped firing, since a hook that exits early calls no `git -C` and satisfies the assertion vacuously; (3) a self-calibrating pair test — for every hook and verb, IF the gate blocks the plain literal target THEN it must refuse all six unreadable spellings AND still block the same target quoted with a space. Fence 3 is the only one that discriminates a gate going quiet, so its fixture stages a violation in the `-C` TARGET while leaving the payload cwd clean; without that the eleven content-judging gates never blocked the control, their pairs were skipped, and reverting one to the pre-fix defect left the whole file green. Its baseline is per-hook and recorded from measurement (16 named hooks), because an aggregate floor cannot say WHICH gate went quiet — the previous `>= 6` against an actual 9 stayed green with `check-gate` AND `branch-gate` reduced to `exit 0`.
-
-Measured against a materialised `origin/main` hook directory, all four property assertions go red — fence 1: 17 hooks; fence 2: 16 poisoned resolutions; fence 3: 472 leaking hook/command/spelling pairs across 17 distinct hooks, plus 50 misses of a determinate quoted target path — while the population, floor and guard assertions stay green, which is what makes them evidence rather than decoration. The `origin/main` run also reports 681 `git -C` calls against 84 on the fixed tree: the fixed gates refuse before resolving, so the drop is the fix working, not the fence going quiet.
-
-**THE SHAPE, and it is the finding that outlives this fix.** Three review rounds each ended the same way: a spelling the parser did not know about. Round 1 was `$VAR`; round 2 was a quoted path containing a space and `$( )`; round 3 was `gh -R` and a multi-line `$( )`. That is not bad luck. **These gates decide policy by pattern-matching shell TEXT, and shell grammar is not a regular language**, so the set of spellings that slip past is unbounded and each round removes only the ones someone thought to try. Every miss is silent, and every miss lands in the FAIL-OPEN direction, because a gate that does not recognise a command does not fire. The mitigation direction is to **over-approximate the TRIGGER and be strict on RESOLUTION**: a spelling-independent "does this segment contain a gated verb at all" test that errs toward considering the command, with `gate_target_dir_strict` — which already refuses whatever it cannot read — deciding the outcome. Today the trigger is the narrow half and the resolver is the strict half, which is exactly backwards, and it is why a narrowing bug in the trigger reads as "no problem found". The known remaining gaps below are instances of this one shape, not separate curiosities.
-
-**The mitigation actually taken is a DIFFERENTIAL fence** — `.claude/hooks/lib/command-match-differential.test.sh`, per `/work-issues` section 5, which says a change to a CLASSIFIER cannot be fenced by hand-picked cases. The segmenter is exactly that: command text in, "which gates consider this and where does it resolve" out. Five rounds of hand-picked cases each changed the verdict for spellings nobody enumerated, and both regressions that reached review were found by diffing against the parent commit rather than by any test here. The fence runs the pre-#2027 implementation and the current one over a 127-input corpus — every shape from all five rounds plus families nobody had exercised (concatenated assignments, process substitution, heredocs, multi-line bodies, both quote characters unbalanced together, globs, degenerate inputs) — and compares the two observables a gate consumes: does each guarded verb ERE match, and what target does it resolve to. **Any differing cell that is not in an enumerated table fails**, and each allowed cell is pinned as `id + observable + NEW VALUE` rather than by input, because bucketing by input is how a regression gets waved through under a heading that says "intended". Per-class floors (NOW_MATCH 55, NOW_MISS 5, TARGET 8, SEGCOUNT 12) mean a corpus that stops covering a class is loud instead of reading like a clean run, and the baseline is a **vendored golden file** at `.claude/hooks/lib/testdata/command-match.baseline.sh`, pinned to a SHA rather than to `origin/main` — once this work merges, a ref-based baseline would compare the code to itself and report zero differences forever. It is VENDORED rather than read with `git show <sha>` because CI shallow-clones and the object is not in its store: the fence correctly refused to run there and said so in one line, but a fence that cannot run in CI is not a fence. The fixture is byte-identical to the blob (verified: sha256 `2af09c64…`) and its hash is re-checked on every run, so a drifted copy fails loudly instead of silently redefining what "unchanged" means. It lives under `testdata/` so neither `run-tests.sh` (globs `lib/*.test.sh`) nor the class fence (globs the hooks directory) picks it up — checked, and the class fence's population floor still counts 39. The table doubles as the changelog of intentional behaviour changes to the classifier: 88 cells across 32 inputs, all declared.
-
-One assertion in that file is an INVARIANT rather than a case: **no non-empty command may segment to ZERO.** Zero segments means every gate considers nothing and all of them exit 0 at once, which is what one unbalanced apostrophe in a `--body` did after round 4 — `gh pr comment 1 --body "don't merge yet` + a newline + `git commit -m x` disarmed the entire system, a strictly worse failure than the bug this work was filed for. Three separate defects combined: a line ending inside a quoted span left the accumulator with no trailing separator, `gate_segments`' reader discarded that unterminated last line, and the END-rule retry cleared only ONE quote character so text with an unbalanced apostrophe AND an unbalanced double quote never recovered. All three are fixed; the invariant is what keeps them fixed.
-
-**Remaining known gaps** (measured, deliberately not fixed here — a structural fix taken mid-cascade is how the next round happens):
-
-- **Multi-line `$( )` still truncates.** `close_paren` scans within a single line, so `git -C $(<newline> git rev-parse --show-toplevel <newline>) commit -m x` splits into three segments, no verb matches, and `branch-gate` / `check-gate` both return 0. This is round 1's truncation surviving for the multi-line spelling; closing it means joining substitutions across lines in the segmenter, a third rewrite of the component that has already produced two rounds of blockers.
-- **Substitution nesting deeper than 8** stops being scanned. The drain is bounded so a pathological input cannot spin; it now prints how many bytes went unscanned to stderr rather than dropping them silently, which makes the gap loud rather than invisible.
-- **Ten hooks are exercised by no fence and have no per-hook case** — `cmd-parse-stub-gate`, `commit-prefix-scope-gate`, `integ-coverage-matrix-gate`, `internal-pr-labels-gate`, `pr-title-prefix-scope-gate`, `roundtrip-test-gate`, `bughunt-clean-gate`, `restore-backup`, `worktree-owner-gate`, `gh-label-validity-gate` — because no literal control could be constructed that makes them block from a clean cwd. Their conversion to the shared resolver is verified by reading, not by measurement.
-- **`main-tree-branch-gate` reads the branch NAME out of a collapsed quoted span**, so `git switch "main"` blocks (safe direction) and `git checkout "feat/x"` passes. Quoted spellings nobody writes, stated rather than claimed away.
-- **A bare `gh` segments to zero** — on the pre-#2027 implementation as well as the current one, so it is pre-existing rather than introduced. It is harmless (a bare `gh` runs nothing) and is the one case the zero-segment invariant excludes by name, so the exclusion cannot quietly widen.
-
-Two classes are NO LONGER gaps, having been closed in review round 5. A **glob, a brace expansion or a `~user` prefix** in a `-C` or a `cd` is now treated as unreadable exactly like `$VAR`: the shell expands them and the commit lands in a real repo, while the parser cannot say which one, and the reverted "not a git repository" branch had been letting them through (`cd <wt>/.claude/worktrees/*/ && git commit` and `cd ~nobody/wt && git commit` both measured rc=0, now rc=2). A **leading `~/` or a bare `~` is deliberately NOT in that set**, because HOME is expanded here correctly and refusing it would be a false refusal.
+**Fenced at the CLASS level, not per hook** -- see
+[hooks-class-fences.md](hooks-class-fences.md) for the three fences, their
+populations and their floors.
 
 **"Scope" is TWO lists per gate, and they can disagree silently** (issue [#2042](https://github.com/go-to-k/cdkd/issues/2042)). `.markgate.yml`'s `include` decides what makes the MARKER stale; the hook's own activation patterns decide whether `gh pr merge` consults that marker at all. A file named by only the include yields an invalidated marker no hook ever reads; a file named by only the hook is a **FAIL-OPEN** — the gate activates, `markgate verify` runs, the digest never saw the file, so it returns 0 and the merge proceeds with no verification. The second is the dangerous direction because it is indistinguishable from a working gate. `destroy-runner.ts` / `region-check.ts` sat in that state, and the retry pair plus `rollback-executor.ts` were in neither list, until #2042's audit. Both directions are now fenced by `tests/unit/scripts/cross-cutting-list-sync.test.ts`; the full per-gate file lists live in the `integ-destroy` / `integ-broad` entries in CLAUDE.md rather than being copied here.
 
@@ -339,70 +323,12 @@ The hooks a session runs come from ONE repo's `.claude/settings.json` — whiche
 
 **Delegation was tried and abandoned.** PR 1970 made each gate hand its decision to `<target-repo>/.claude/hooks/<same-name>` when one existed. It works, and it introduces arbitrary code execution: the target directory is named by the command itself (a `cd`, a `git -C` / `gh -C` flag, the payload's `cwd`), so any directory the agent can be induced to touch that carries an executable file at that path gets it run with the session's environment. Reproduced with a planted hook and a plain `git checkout`, which read `AWS_*` / `GH_TOKEN`-shaped variables and captured the payload. It is not patchable from inside the design — every trust signal available from the target repo is forgeable, because the attacker controls that repo — so trust would have to come from a maintainer-maintained allow-list. Read the closed PR before proposing delegation again; it also records two independent defects worth knowing (an exit status of 128+N from a signal-killed hook propagates as a non-blocking error and turns a block into a pass, and `git -C ""` silently resolves the hook process's own cwd).
 
-## The gate-name class fence (issue 2198)
+## Class fences
 
-`.claude/hooks/markgate-gate-name-class.test.sh` asserts, for every
-markgate-backed hook, WHICH GATE it asks its verifier about. Nothing did before:
-every per-hook suite asserted an exit code and a few asserted the cwd markgate
-ran in, and a gate pointed at the wrong marker is **indistinguishable from a
-working one from the outside** — same exit codes, same messages, same cwd. Only
-the argv separates them. Measured 2026-08-25 by rewriting each hook's
-`markgate verify <gate>` to `verify BOGUS-GATE` and running that hook's own
-suite: `verify-pr-gate` 22/22, `check-gate` 33/33, `integ-destroy-gate` 20/20,
-`integ-broad-gate` 24/24 — all green. The `verify-pr` case is not theoretical:
-swapping `verify verify-pr` for `verify check` makes that gate pass whenever
-`/check` alone is fresh, merging a PR whose `/verify-pr` checklist never ran.
-
-**The population is derived from BEHAVIOUR, not from the hook text**, and that is
-the part worth copying. All three textual predicates were tried and all three are
-wrong: `grep -l 'markgate verify'` finds 5 of the 8 (gates invoke the binary as
-`"${markgate[@]}" verify <gate>`, and `stop-warn` builds that array so no literal
-`markgate verify` appears on any line); `grep -l markgate` finds 20, because
-almost every gate reads `.markgate.yml` for the repo opt-in check; and stripping
-comments does NOT exclude `main-tree-git-cwd-detector`, which carries
-`markgate[[:space:]]+(set|verify)` inside a REGEX STRING, since detecting
-markgate commands is its job. So the CANDIDATE list comes from
-`.claude/settings.json` — the only authoritative statement of what is a hook —
-and each candidate is RUN under a markgate shim that records its argv. The
-directory listing is deliberately NOT the candidate list: `run-tests.sh` is the
-aggregate suite RUNNER, so driving it re-runs every suite once per probe payload,
-and a first version of this file had to be killed after twenty minutes.
-
-Three fences, and fence 3 is what makes the other two mean anything:
-
-- **fence 1** — every hook in the table asks about the gate the table names.
-- **fence 2** — the table and the observed population agree in BOTH directions,
-  so a new markgate-backed hook with no table entry fails, and so does a table
-  entry for a hook that no longer verifies anything.
-- **fence 3** — the probes actually REACH the markgate call. Four gates
-  scope-check the PR diff and return before verifying anything, so without this
-  the file would report green over nothing.
-
-**Reaching the call was most of the work, and four separate things blocked it** —
-each one a failure in the green direction, and each caught by fence 3 rather than
-passing as "verified":
-
-1. The gates read their scope from `gh pr view --json files`, not from
-   `gh pr diff --name-only`, so a generic `files` array made four of them decide
-   the PR was out of scope.
-2. **Two verbs carry the question.** `check-gate` asks with `markgate status
-   <gate>` (it parses the parenthesised staleness reason out of the output);
-   the others ask with `verify`. A fence keyed on `verify` alone reports
-   `check-gate` as reaching nothing.
-3. `check-gate` probes `markgate --version` and fails CLOSED when it errors, so
-   a shim that only knows `verify` / `status` never lets it reach the question.
-4. `integ-schema-migration-gate` splits the diff into per-FILE hunks and greps
-   the `src/types/state.ts` one, so a bare `+ version: ...` line with no
-   `diff --git` header belongs to no file and matches nothing.
-
-A fifth was in the fence's own instrument: the argv extraction used BRE
-`\(verify\|status\)`, and `\|` is a GNU extension, so on macOS it silently
-matched nothing and EVERY hook reported "asked about []" — the fence reporting
-its own broken tool as a total failure of its subject. `sed -E` throughout.
-
-Mutation-probed per gate rather than in aggregate: repointing each of the eight
-at another marker fails fence 1 naming that gate and its wrong marker, with a
-3/3 control before and after.
+Two suites whose subject is EVERY hook at once -- the unresolved-target-directory
+sweep (issue 2027) and the gate-name fence (issue 2198) -- live in
+[hooks-class-fences.md](hooks-class-fences.md), loaded when you touch one of
+them or the shared matcher.
 
 ## Uncommitted-work safety (multi-session)
 

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -189,7 +189,8 @@ const REACH_FLOORS: ReadonlyMap<string, number> = new Map([
   ['assets.md', 51],
   ['cli-internals.md', 48],
   ['code-layout.md', 261],
-  ['hooks.md', 67],
+  ['hooks.md', 68],
+  ['hooks-class-fences.md', 5], // literal list: EXACT, see below
   ['layout-analyzer.md', 12],
   ['layout-cli-import-export.md', 3], // literal list: EXACT, see below
   ['layout-cli.md', 48],
@@ -257,7 +258,12 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // fire at all; anywhere under it, the two fire together. The row is here for
   // its FLOOR, which nothing else provides, so the cap simply tracks the
   // per-file cap rather than pretending to add a signal.
-  ['.claude/hooks/branch-gate.sh', 101_000, MAX_RULE_FILE_BYTES], // measured 115,520
+  ['.claude/hooks/branch-gate.sh', 95_000, MAX_RULE_FILE_BYTES], // measured 106,568 -- hooks.md alone
+  // The shared matcher pulls hooks.md AND the class-fence satellite, which is
+  // the only path that loads both. hooks.md outgrew the 120,000 per-file cap on
+  // its own, so the two CLASS fences moved to a satellite of their own rather
+  // than the cap being raised -- a cap that moves when it fires is not a cap.
+  ['.claude/hooks/lib/command-match.sh', 108_000, 140_000], // measured 121,407
   // Second review round, 2026-08-25: three heavy paths still carried no budget
   // at all. `masked-retry-logger.ts` is the 2nd-heaviest path in the repo and
   // was covered only by prose, in the `region-check.ts` row's claim to speak
@@ -379,8 +385,8 @@ const ruleFiles: RuleFile[] = readdirSync(RULES_DIR, { recursive: true })
 //   - the UPPER bound catches growth that spreads thinly enough to stay under
 //     every per-file cap.
 // Update these deliberately, with the reason, when the corpus genuinely moves.
-const CORPUS_FILE_COUNT = 28;
-const CORPUS_BYTES_MIN = 790_000;   // measured 799,693 B -- 9,693 B of slack
+const CORPUS_FILE_COUNT = 29;
+const CORPUS_BYTES_MIN = 795_000;   // measured 808,384 B -- 13,384 B of slack
 const CORPUS_BYTES_MAX = 900_000;   // growth is the norm here; this catches bulk growth that stays under every per-file cap
 
 /**


### PR DESCRIPTION
Every per-hook suite for a markgate-backed gate asserted an exit code, and a
few asserted the cwd markgate ran in. None asserted the QUESTION the gate
asked. A gate pointed at the wrong marker is indistinguishable from a working
one from the outside -- same exit codes, same messages, same cwd. Only the
argv separates them.

Measured by rewriting each hook's `markgate verify <gate>` to
`verify BOGUS-GATE` and running that hook's own suite:

    verify-pr-gate      Pass: 22  Fail: 0
    check-gate          Pass: 33  Fail: 0
    integ-destroy-gate  Pass: 20  Fail: 0
    integ-broad-gate    24 pass, 0 fail

The verify-pr case is not theoretical: swapping `verify verify-pr` for
`verify check` makes that gate pass whenever `/check` alone is fresh, merging
a PR whose `/verify-pr` checklist never ran.

Closes #2198.

The population comes from BEHAVIOUR
-----------------------------------

Not from the hook text, in any spelling -- all three predicates were tried
and all three are wrong:

  - `grep -l 'markgate verify'` finds 5 of the 8. Gates invoke the binary as
    `"${markgate[@]}" verify <gate>`, and `stop-warn` builds that array as
    `markgate=(markgate)` / `markgate=(mise exec -- markgate)`, so no literal
    `markgate verify` appears on any of its lines.
  - `grep -l markgate` finds 20, because almost every gate reads
    `.markgate.yml` for the repo opt-in check. Those verify nothing.
  - Stripping comments does NOT exclude `main-tree-git-cwd-detector`: it
    carries `markgate[[:space:]]+(set|verify)` inside a REGEX STRING, since
    detecting markgate commands is its job. That is live code.

So the CANDIDATE list is `.claude/settings.json` -- the authoritative
statement of what is a hook -- and each candidate is RUN under a markgate
shim that records its argv. The directory listing is deliberately not the
candidate list: `run-tests.sh` is the aggregate suite RUNNER, so driving it
re-runs every suite once per probe payload, and the first version of this
file had to be killed after twenty minutes.

Reaching the markgate call was most of the work
-----------------------------------------------

Four things blocked it, each a failure in the GREEN direction, each caught by
fence 3 rather than passing as "verified":

  1. The gates read their scope from `gh pr view --json files`, not from
     `gh pr diff --name-only`, so a generic `files` array made four of them
     decide the PR was out of scope and return before touching markgate.
  2. TWO VERBS carry the question. `check-gate` asks with
     `markgate status <gate>` (it parses the parenthesised staleness reason
     out of the output); the others ask with `verify`.
  3. `check-gate` probes `markgate --version` and fails CLOSED when it
     errors, so a shim knowing only verify/status never lets it reach the
     question.
  4. `integ-schema-migration-gate` splits the diff into per-FILE hunks and
     greps the `src/types/state.ts` one, so a bare `+ version: ...` line with
     no `diff --git` header belongs to no file and matches nothing.

A fifth was in the fence's own instrument: the argv extraction used BRE
`\(verify\|status\)`, and `\|` is a GNU extension, so on macOS it silently
matched nothing and EVERY hook reported "asked about []" -- the fence
reporting its own broken tool as a total failure of its subject. `sed -E`
throughout.

Test plan
---------

- 3 fences, 8 hooks in the table (`check-gate` verifying BOTH `check` and
  `docs`), green under bash 5.3.9 and macOS system bash 3.2.
- Mutation-probed PER GATE, not in aggregate: repointing each of the eight at
  another marker fails fence 1 naming that gate and its wrong marker, with a
  3/3 control before and after. Every one of the eight discriminates.
- All hook suites pass under both arms (`run-tests.sh` rc=0), and
  `vp check --fix` / `vp run check` / `typecheck:test` / `build` /
  `vp run test` rc=0 -- 777 files, 15,996 tests, no type errors.
