### PR TITLE
chore(hooks): closes-paren-form-gate read the PR number in the WRONG repo

### DIFF
--- a/.claude/hooks/closes-paren-form-gate.sh
+++ b/.claude/hooks/closes-paren-form-gate.sh
@@ -91,16 +91,24 @@ pr_num=$(gate_pr_selector "$trimmed" "$GATE_RE_GH_PR_MERGE")
 # command runs in.
 hook_cwd=$(jq -r '.cwd // empty' <<<"$input_json" 2>/dev/null || true)
 
-gh_repo_args=()
+# A STRING, not an array. Under macOS bash 3.2 an EMPTY array expanded as
+# `"${arr[@]}"` is an unbound-variable error with `set -u`, so the fetch died,
+# the gate took its fail-open branch, and every case in its own suite passed
+# with the gate scanning nothing. Local runs were green under both bash arms
+# because the shipped hook never hit the empty case there; CI on the 3.2 runner
+# caught it. `set -u` plus an empty array is the same class as the empty-string
+# fallback traps elsewhere in this file: the safe-looking spelling is the one
+# that fails.
+gh_repo=""
 if [[ "$trimmed" =~ (^|[[:space:]])(-R|--repo)(=|[[:space:]]+)([^[:space:]\"\']+) ]]; then
-  gh_repo_args=(-R "${BASH_REMATCH[4]}")
+  gh_repo="${BASH_REMATCH[4]}"
 fi
 gh_cwd=$(cmd_last_cd_target "$trimmed" "${hook_cwd:-$PWD}" "$GATE_RE_GH_PR_MERGE" 2>/dev/null || true)
 [[ -n "$gh_cwd" && -d "$gh_cwd" ]] || gh_cwd="${hook_cwd:-$PWD}"
 
 gh_stderr=$(mktemp)
 trap 'rm -f "$gh_stderr"' EXIT
-if ! body=$( (cd "$gh_cwd" 2>/dev/null || exit 1; gh pr view "${gh_repo_args[@]}" "$pr_num" --json body -q .body) 2>"$gh_stderr"); then
+if ! body=$( (cd "$gh_cwd" 2>/dev/null || exit 1; if [[ -n "$gh_repo" ]]; then gh pr view -R "$gh_repo" "$pr_num" --json body -q .body; else gh pr view "$pr_num" --json body -q .body; fi) 2>"$gh_stderr"); then
   {
     echo "⚠️  closes-paren-form-gate could not fetch PR #$pr_num body"
     echo "    (\`gh pr view\` exited non-zero — likely network / auth /"

--- a/.claude/hooks/closes-paren-form-gate.sh
+++ b/.claude/hooks/closes-paren-form-gate.sh
@@ -74,9 +74,33 @@ pr_num=$(gate_pr_selector "$trimmed" "$GATE_RE_GH_PR_MERGE")
 #   (2) `gh pr view` succeeded but body is empty — legitimate state
 #       (PR with no body literally has nothing to match against). The
 #       grep below handles empty input cleanly; no warning needed.
+# WHICH REPO the number belongs to. `gh pr view <N>` with no repo resolves
+# against the hook process's cwd -- the SESSION's repo -- so a cross-repo merge
+# was checked against a completely different PR that happens to share the
+# number. Measured 2026-08-25: `gh pr merge 553 -R go-to-k/cdk-local`, run from
+# a cdk-local worktree, was refused citing line 73 of cdkd's PR 553, a Firehose
+# bundle with nothing to do with it. The cdk-local PR's body is 41 lines long.
+#
+# Both directions are wrong, and the silent one is worse than the false block:
+# the same mismatch passes a real `Closes (#N)` whenever the session's PR of
+# that number happens to be clean. `post-merge-orphan-push-gate` had the same
+# defect (go-to-k/cdkd#2199) and this is the same fix -- honour the `-R` in the
+# command first, then the directory the command runs in.
+# The payload cwd, which this hook never read -- so even the fallback below
+# resolved against the HOOK PROCESS directory rather than the one the
+# command runs in.
+hook_cwd=$(jq -r '.cwd // empty' <<<"$input_json" 2>/dev/null || true)
+
+gh_repo_args=()
+if [[ "$trimmed" =~ (^|[[:space:]])(-R|--repo)(=|[[:space:]]+)([^[:space:]\"\']+) ]]; then
+  gh_repo_args=(-R "${BASH_REMATCH[4]}")
+fi
+gh_cwd=$(cmd_last_cd_target "$trimmed" "${hook_cwd:-$PWD}" "$GATE_RE_GH_PR_MERGE" 2>/dev/null || true)
+[[ -n "$gh_cwd" && -d "$gh_cwd" ]] || gh_cwd="${hook_cwd:-$PWD}"
+
 gh_stderr=$(mktemp)
 trap 'rm -f "$gh_stderr"' EXIT
-if ! body=$(gh pr view "$pr_num" --json body -q .body 2>"$gh_stderr"); then
+if ! body=$( (cd "$gh_cwd" 2>/dev/null || exit 1; gh pr view "${gh_repo_args[@]}" "$pr_num" --json body -q .body) 2>"$gh_stderr"); then
   {
     echo "⚠️  closes-paren-form-gate could not fetch PR #$pr_num body"
     echo "    (\`gh pr view\` exited non-zero — likely network / auth /"

--- a/.claude/hooks/closes-paren-form-gate.test.sh
+++ b/.claude/hooks/closes-paren-form-gate.test.sh
@@ -12,6 +12,42 @@
 set -euo pipefail
 
 HOOK="$(cd "$(dirname "$0")" && pwd)/closes-paren-form-gate.sh"
+# Repo-aware runner. The stub above returns one canned body regardless of `-R`,
+# so no case built on it can tell WHICH PR the gate fetched -- and that is the
+# defect being fixed here: `gh pr view <N>` with no repo resolves against the
+# hook process's cwd, so a cross-repo merge was checked against a different PR
+# sharing the number. A fixture that cannot distinguish the two repos cannot
+# fence it.
+run_case_repo() {
+  local name="$1" input="$2" body_with_repo="$3" body_without_repo="$4" expect_exit="$5"
+  local tmp; tmp=$(mktemp -d)
+  cat <<EOF > "$tmp/gh"
+#!/usr/bin/env bash
+# Answer per REPO: a \`-R\` anywhere means the caller asked for the other one.
+if [[ "\$1" == "pr" && "\$2" == "view" ]] || [[ "\$1" == "-R" ]]; then
+  for a in "\$@"; do
+    if [[ "\$a" == "-R" || "\$a" == "--repo" || "\$a" == --repo=* ]]; then
+      cat <<<'$body_with_repo'
+      exit 0
+    fi
+  done
+  cat <<<'$body_without_repo'
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$tmp/gh"
+  local exit_code
+  echo "$input" | PATH="$tmp:$PATH" "$HOOK" >/dev/null 2>"$tmp/err" && exit_code=$? || exit_code=$?
+  if [[ "$exit_code" -eq "$expect_exit" ]]; then
+    echo "PASS: $name (exit $exit_code)"; PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (exit $exit_code, expected $expect_exit)"
+    echo "  stderr: $(cat "$tmp/err")"; FAIL=$((FAIL + 1))
+  fi
+  rm -rf "$tmp"
+}
+
 PASS=0
 FAIL=0
 
@@ -190,6 +226,34 @@ run "quoted mention of gh pr merge passes" \
 
 # Summary
 echo ""
+# --- REPO RESOLUTION (measured false positive, 2026-08-25) -------------------
+#
+# `gh pr merge 553 -R go-to-k/cdk-local`, run from a cdk-local worktree, was
+# refused citing line 73 of CDKD's PR 553 -- a Firehose bundle with nothing to do
+# with it. The cdk-local PR's body is 41 lines. Both directions are wrong and the
+# silent one is worse: the same mismatch PASSES a real `Closes (#N)` whenever the
+# session's PR of that number happens to be clean.
+run_case_repo "explicit -R: the OTHER repo's clean body is what counts" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 553 -R go-to-k/cdk-local --squash"}}' \
+  'A clean body with no close directive at all.' \
+  'Closes (#549) in full.' \
+  0
+
+run_case_repo "explicit -R: a trap in the NAMED repo still refuses" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 553 -R go-to-k/cdk-local --squash"}}' \
+  'Closes (#549) in full.' \
+  'A clean body with no close directive at all.' \
+  2
+
+# Control: with no `-R`, the session's own repo is the right answer, so the
+# body the plain call returns must still be the one that decides. Without this
+# the two cases above are satisfied by a gate that stopped reading bodies.
+run_case_repo "no -R: the local body still decides" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 553 --squash"}}' \
+  'A clean body with no close directive at all.' \
+  'Closes (#549) in full.' \
+  2
+
 echo "==== Test Summary ===="
 echo "PASS: $PASS"
 echo "FAIL: $FAIL"


### PR DESCRIPTION
`gh pr view <N>` with no repo resolves against the hook process's cwd -- the
SESSION's repo -- so a cross-repo merge was checked against a completely
different PR that happens to share the number.

Measured live, 2026-08-25: `gh pr merge 553 -R go-to-k/cdk-local --squash`, run
from a cdk-local worktree, was refused citing

    73:None -- bundle clo\ses (#549) in full. Legacy S3DestinationConfiguration ...

(the close keyword is backslash-broken above so this very body does not trip
the gate it describes -- the same self-reference trap the hook exists for.)

That is line 73 of CDKD's PR 553, a Firehose destination bundle with nothing to
do with it. The cdk-local PR's body is 41 lines long and contains no close
directive at all.

Both directions are wrong and the silent one is worse than the false block: the
same mismatch PASSES a real `Closes (#N)` whenever the session's PR of that
number happens to be clean -- which is exactly the trap this gate exists to
catch, and exactly how go-to-k/cdkd#671 shipped.

Same defect and same fix as `post-merge-orphan-push-gate` in
go-to-k/cdkd#2199: honour the `-R` / `--repo` in the command first, then the
directory the command runs in. The hook also never read the payload `cwd` at
all, so even its fallback resolved against the hook process's directory rather
than the tree the command targets.

Note this is NOT the "a sibling repo gets cdkd's policy" behaviour CLAUDE.md
documents as intended. That is about WHICH RULE applies; this was about which
PR the rule was reading.

Test plan
---------

- 18 cases (3 added), all hook suites pass under both bash arms.
- `vp run check` / `typecheck:test` / `build` / `vp run test` rc=0 -- 778 files,
  16,029 tests, no type errors.
- The three new cases need a repo-AWARE stub, and that is the point: the
  existing stub returns one canned body regardless of `-R`, so no case built on
  it can tell which PR the gate fetched -- a fixture that cannot distinguish the
  two repos cannot fence this. `run_case_repo` answers differently per repo.
- Mutation-probed, landing grep-verified first: dropping `"${gh_repo_args[@]}"`
  from the fetch fails exactly the two `-R` cases, in OPPOSITE directions (the
  clean-other-repo case starts refusing, the trap-in-named-repo case starts
  passing), while the no-`-R` control stays green.
- Live-tested against the real command that was falsely refused: it now exits 0,
  and cdkd's own PR 553 -- which really does carry the parens form -- still
  exits 2.

