### PR TITLE
chore(work-issues): fence the trap-clobber near-miss, and close the claim-race gap the rule leaves open

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -526,6 +526,31 @@ go-to-k/cdkd#1419 / go-to-k/cdkd#1435 twenty seconds apart (2026-08-09), both
 having followed every other rule in this skill, and it took the maintainer
 arbitrating to resolve. See go-to-k/cdkd#1446.
 
+**The tie-break only works if the LOSER re-reads. Nothing makes it, so the
+window is not seconds — it is the whole lane.** The compare-and-swap above is
+written as a one-shot check performed right after posting, which catches only a
+rival who posted BEFORE you. A rival who posts LATER never appears in it, and
+since neither session re-reads the issue again, both run to completion. On
+2026-08-25 go-to-k/cdkd#2200 was claimed at 14:34:26Z and again at 15:00:22Z --
+26 minutes apart, so the first claim was plainly visible to the second session,
+which had the losing timestamp and worked it anyway. Both lanes built the same
+fix. The merged one (go-to-k/cdkd#2206) turned out to be a strict superset, so
+nothing was lost but the duplicated hours; that is luck, not the rule working.
+
+Two cheap habits close it, and they are cheap precisely because a claim comment
+is one API call:
+
+- **Re-read the claims before you PUSH, not only after you post.** By then your
+  lane has a branch name to offer and a rival has had its whole triage window to
+  appear. If a later claim exists and yours is earlier, say so on the issue
+  rather than assuming they saw it; if yours is later, stand down even though
+  you have already written code -- discarding a branch is cheaper than two
+  reviews and two merges of the same change.
+- **When you find yourself the loser, record the timestamps in the stand-down
+  comment.** The rule is unenforced by construction (nothing can block another
+  session's `gh issue comment`), so the only thing keeping it alive is that
+  violations stay visible instead of being quietly absorbed.
+
 **Claim what you FILE, too — filing is not claiming.** An issue this run files as
 its own deferral is invisible to every ownership probe: no branch, no PR, no comment,
 and only §3-0's hour covers it. So when the issue is one THIS run means to pick up
@@ -791,6 +816,21 @@ this family: its `stripComments` stripped block comments before line ones, so a
 `//` comment containing the glob `src/provisioning/**` opened a block comment and
 swallowed 235 lines of `deploy-engine.ts`, dropping 2 writers and 2 helper calls
 into silence.
+
+**Adding a HANDLER to a slot that already has one REPLACES it.** Bash `trap`
+does not chain: a second `trap ... EXIT` anywhere in a script silently disarms
+the first, and in an integ fixture the first is the AWS teardown. Nearly shipped
+2026-08-25 on the go-to-k/cdkd#2213 lane, acting on a correct reviewer nit -- a
+`mktemp` scratch file leaked on five `exit 1` paths, and the obvious fix
+(`trap 'rm -f "${OUT}"' EXIT`) would have traded that temp file for a live SQS
+queue, an anomaly detector and a state record left behind on every failure path.
+The happy path still passes, so a green run proves nothing. Put the extra work
+inside the EXISTING handler (unset-guarded -- it can run before the variable is
+assigned, under `set +eu`), or re-install a handler that still CALLS the
+original, which is the form 16 fixtures already use. Fenced by
+`tests/unit/scripts/integ-single-exit-trap.test.ts`. The general shape is worth
+carrying past `trap`: before adding to any single-slot registration -- a signal
+handler, a callback field, an `EXIT` hook -- count what is already there.
 
 **A mutation probe proves a test discriminates only if it changes the value the
 test READS.** Four vacuous tests shipped across three lanes on 2026-08-19, and

--- a/tests/unit/scripts/integ-single-exit-trap.test.ts
+++ b/tests/unit/scripts/integ-single-exit-trap.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Every integ `verify.sh` may install AT MOST ONE `trap ... EXIT`.
+ *
+ * WHY THIS IS A TEST AND NOT A SENTENCE. Bash REPLACES a signal's handler on
+ * each `trap`; it does not chain them. So a second `trap ... EXIT` anywhere in
+ * a script silently disarms the first — and in these fixtures the first one is
+ * always the AWS teardown (`trap cleanup EXIT`, where `cleanup` runs
+ * `cdkd state destroy` and sweeps leftover resources).
+ *
+ * Nearly shipped on 2026-08-25 in PR go-to-k/cdkd#2213. A code reviewer raised a
+ * correct nit — a `DRIFT_OUT="$(mktemp)"` leaked on five `exit 1` paths — and
+ * the obvious fix is `trap 'rm -f "${DRIFT_OUT}"' EXIT` right next to it.
+ * `cloudwatch-anomaly-detector/verify.sh` already had `trap cleanup EXIT` at
+ * line 103. The new trap would have won, and the fixture would have stopped
+ * tearing down AWS on every failure path — trading a scratch file in `/tmp` for
+ * a live SQS queue, an anomaly detector and a state record, on exactly the runs
+ * where cleanup matters most. It was caught only by counting the traps by hand.
+ *
+ * The failure is invisible to every other signal we have: the happy path still
+ * passes (its explicit teardown runs before the trap would), CI never runs these
+ * fixtures, and the orphans appear in an AWS account rather than in any log. So
+ * the check has to be static, and it has to be a test rather than a review
+ * habit — the review is where the bug came FROM.
+ *
+ * Scoped to EXIT deliberately. `INT` / `TERM` handlers are installed
+ * per-fixture alongside it and replacing one of those is the same hazard, so
+ * they are counted too.
+ */
+
+const REPO_ROOT = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+  encoding: 'utf-8',
+}).trim();
+
+/** Every committed integ `verify.sh`, from git rather than a directory walk. */
+function verifyScripts(): string[] {
+  return execFileSync('git', ['ls-files', 'tests/integration/*/verify.sh'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf-8',
+  })
+    .split('\n')
+    .filter(Boolean);
+}
+
+/**
+ * Collect the ACTIONS of every `trap <action> <signals...>` INSTALLATION for one
+ * signal, in source order.
+ *
+ * Four things the naive rule gets wrong, every one of them found by running it
+ * over the real tree and reading the hits — the repo's calibrate-against-the-
+ * broken-tree rule, which is the only reason this fence discriminates:
+ *
+ *  1. `trap - EXIT INT TERM` is a DISARM, not an installation. Six fixtures use
+ *     it to drop handlers before a deliberate exit.
+ *  2. Signals are not line-final: one `trap` can name several, so anchoring the
+ *     signal to end-of-line counted TERM in 65 files and EXIT in 16 purely from
+ *     where each name happened to sit.
+ *  3. The action is quoted and routinely CONTAINS a signal name
+ *     (`trap '(exit 143); cleanup; exit 143' TERM`), so the signal must be read
+ *     from the trailing signal LIST only.
+ *  4. **A second installation is not automatically a bug.** Sixteen fixtures
+ *     legitimately re-install with `trap 'rm -f "${OUT_FILE}"; cleanup' EXIT` —
+ *     a handler that adds a scratch-file removal and STILL calls the teardown.
+ *     Flagging those would have made this fence noise, and noise gets deleted.
+ *
+ * So the rule is not "at most one trap". It is: **a later installation must
+ * still invoke what the first one invoked.** That is exactly the near-miss this
+ * file exists for, and exactly what the idiomatic form satisfies.
+ */
+function trapActions(body: string, signal: string): string[] {
+  const actions: string[] = [];
+  for (const raw of body.split('\n')) {
+    const line = raw.replace(/#.*$/, '').trim();
+    const m = /^trap\s+(.*)$/.exec(line);
+    if (!m) continue;
+    const rest = m[1]!;
+    const quoted = /^(?:'([^']*)'|"([^"]*)")\s*(.*)$/.exec(rest);
+    const action = quoted ? (quoted[1] ?? quoted[2] ?? '') : (/^(\S+)/.exec(rest)?.[1] ?? '');
+    const signals = quoted ? quoted[3]! : rest.slice(action.length);
+    if (!quoted && action === '-') continue; // a disarm, not an installation
+    if (signals.trim().split(/\s+/).includes(signal)) actions.push(action);
+  }
+  return actions;
+}
+
+/**
+ * The identifiers a trap action invokes, RESOLVED one level through the script's
+ * own function definitions.
+ *
+ * The resolution step is not polish. `local-start-api-websocket/verify.sh`
+ * legitimately replaces `trap cleanup EXIT` with
+ * `trap cleanup_and_assert_sigterm_fast EXIT`, and that wrapper calls `cleanup`
+ * on its first line — a name-only comparison called it a dropped teardown and
+ * made this fence's ONLY hit a false positive. A fence whose single finding is
+ * wrong is worse than no fence: it gets muted, and then it is not there for the
+ * real one.
+ *
+ * One level only, deliberately. It is what the observed idiom needs, and a
+ * transitive walk would need cycle handling to avoid hanging the suite — the
+ * same bound the drift guard's cause-chain walk carries, for the same reason.
+ */
+function invoked(action: string, body: string): Set<string> {
+  const BUILTINS = ['rm', 'f', 'exit', 'echo', 'true', 'false', 'set', 'e', 'u', 'then', 'fi'];
+  const words = (text: string): string[] =>
+    (text.match(/[A-Za-z_][A-Za-z0-9_]*/g) ?? []).filter((w) => !BUILTINS.includes(w));
+
+  const out = new Set<string>();
+  for (const name of words(action)) {
+    out.add(name);
+    // If the script defines `name() { ... }`, add what IT calls.
+    const def = new RegExp(String.raw`^${name}\s*\(\)\s*\{([\s\S]*?)^\}`, 'm').exec(body);
+    if (def) for (const inner of words(def[1]!)) out.add(inner);
+  }
+  return out;
+}
+
+describe('an integ verify.sh never drops its teardown handler', () => {
+  const scripts = verifyScripts();
+
+  /**
+   * PARSER FLOOR. Without it every assertion below passes vacuously the moment
+   * the regex stops matching — the "found nothing, therefore nothing is wrong"
+   * shape this repo has shipped more than once. Every fixture that tears down
+   * AWS installs an EXIT trap, so a total of zero means the parser broke, not
+   * that the fixtures changed.
+   */
+  it('finds the EXIT traps that certainly exist, including the re-installing form', () => {
+    expect(scripts.length).toBeGreaterThan(50);
+    const counts = scripts.map((p) => trapActions(readFileSync(join(REPO_ROOT, p), 'utf-8'), 'EXIT'));
+    expect(counts.filter((a) => a.length > 0).length).toBeGreaterThan(20);
+    // ...and the legitimate re-installers are SEEN rather than parsed away. If
+    // this hits zero the rule below has nothing left to be lenient about, which
+    // is how a tightened fence quietly becomes a vacuous one.
+    expect(counts.filter((a) => a.length > 1).length).toBeGreaterThan(5);
+  });
+
+  for (const signal of ['EXIT', 'INT', 'TERM']) {
+    it(`a re-installed ${signal} handler still invokes the first one's work`, () => {
+      const offenders: string[] = [];
+      for (const rel of scripts) {
+        const actions = trapActions(readFileSync(join(REPO_ROOT, rel), 'utf-8'), signal);
+        if (actions.length < 2) continue;
+        const body = readFileSync(join(REPO_ROOT, rel), 'utf-8');
+        // The FIRST handler's own top-level names, UNRESOLVED. Expanding it too
+        // was the bug in the first cut of this fence: it turned `cleanup` into
+        // every word in `cleanup`'s body and then demanded the replacement
+        // mention all of them, which no wrapper does. What must survive is the
+        // CALL, not the callee's contents.
+        const first = invoked(actions[0]!, '');
+        for (const later of actions.slice(1)) {
+          // The later handler's REACH, resolved one level, so a wrapper that
+          // calls the original counts as keeping it.
+          const kept = invoked(later, body);
+          const dropped = [...first].filter((fn) => !kept.has(fn));
+          if (dropped.length > 0) {
+            offenders.push(`${rel}: 'trap ${later} ${signal}' drops ${dropped.join(', ')}`);
+          }
+        }
+      }
+
+      expect(
+        offenders,
+        `bash REPLACES a signal handler rather than chaining it, so the LAST ` +
+          `trap ... ${signal} wins and every earlier one is dead. In these fixtures ` +
+          `the first is the AWS teardown, so a replacement that does not call it ` +
+          `leaks live resources on every failure path — trading a scratch file for ` +
+          `billable orphans, on exactly the runs where cleanup matters most. ` +
+          `Either call the original handler from the new one (the idiomatic ` +
+          `'trap \'rm -f "\${TMP}"; cleanup\' ${signal}' form, which 16 fixtures ` +
+          `already use) or put the extra work INSIDE the existing handler, ` +
+          `unset-guarded since it may run before the variable is assigned.`
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
Retrospective for the `/work-issues` run that shipped go-to-k/cdkd#2213
(closing go-to-k/cdkd#2151 / go-to-k/cdkd#1945 / go-to-k/cdkd#2154). Two
lessons, both with evidence from that run, and neither a restatement of
something the skill already says.

## 1. A trap-clobber fence — a TEST, not a sentence

Bash `trap` REPLACES a signal's handler; it does not chain. So a second
`trap ... EXIT` anywhere in a script silently disarms the first, and in an integ
fixture the first is always the AWS teardown.

This nearly shipped. A code reviewer raised a correct nit on the
go-to-k/cdkd#2213 lane — a `DRIFT_OUT="$(mktemp)"` leaked on five `exit 1`
paths — and the obvious fix is `trap 'rm -f "${DRIFT_OUT}"' EXIT` right beside
it. `cloudwatch-anomaly-detector/verify.sh` already had `trap cleanup EXIT` at
line 103. The new trap would have won, trading a scratch file in `/tmp` for a
live SQS queue, an anomaly detector and a state record left behind **on every
failure path** — precisely the runs where cleanup matters. It was caught by
counting traps by hand.

It is a test rather than a rule because **the bug came from a review**. Nothing
else we have can see it: the happy path still passes (explicit teardown runs
before the trap would), CI never executes these fixtures, and the orphans appear
in an AWS account rather than in any log.

### The rule took four calibration rounds, and they are in the file

Each round is a rule that looked right and was wrong on the real tree:

| round | what the naive rule did | reality |
| --- | --- | --- |
| 1 | counted `trap - EXIT INT TERM` | that is a DISARM, not an install — 6 fixtures |
| 2 | anchored the signal to end-of-line | signals are not line-final; swung the count 16 → 65 purely by position |
| 3 | searched the whole line for the signal | a quoted action CONTAINS one: `trap '(exit 143); cleanup; exit 143' TERM` |
| 4 | flagged any second installation | 16 fixtures legitimately re-install as `trap 'rm -f "${OUT}"; cleanup' EXIT` |

So the shipped rule is not "at most one trap". It is **a later installation must
still invoke what the first one invoked**, resolved one level through the
script's own function definitions — without that resolution the fence's ONLY hit
was a false positive (`local-start-api-websocket` replaces `cleanup` with a
wrapper whose first line calls `cleanup`), and a fence whose single finding is
wrong gets muted before it ever catches a real one.

**Probed** by injecting the exact near-miss back into the fixture:

```text
tests/integration/cloudwatch-anomaly-detector/verify.sh:
  'trap rm -f "${DRIFT_OUT}" EXIT' drops cleanup
```

Red with the injection, green without, and it names the dropped handler. The
parser floor asserts both that EXIT traps are found at all AND that the
legitimate re-installers are still seen — otherwise a tightened fence quietly
becomes a vacuous one.

## 2. The claim tie-break only works if the loser re-reads, and nothing makes it

Section 4's compare-and-swap is written as a one-shot check performed right
after posting, so it catches only a rival who posted **before** you. A rival who
posts **later** never appears in it, and since neither session re-reads the
issue again, both run to completion. The window is not seconds — it is the whole
lane.

Measured this run on go-to-k/cdkd#2200: claimed at `14:34:26Z`, and again at
`15:00:22Z`. Twenty-six minutes apart, so the first claim was plainly visible to
the second session, which held the losing timestamp and worked the issue anyway.
Both lanes built the same fix. The merged one (go-to-k/cdkd#2206) turned out to
be a **strict superset** — it had the same length-strip helper under another
name, one more differential baseline case, and an extra chained-command
regression fix — so nothing was lost but the duplicated hours. That is luck, not
the rule working.

The section now adds two habits, both cheap because a claim comment is one API
call: **re-read the claims before you PUSH** (by then a rival has had its whole
triage window to appear, and discarding a branch is cheaper than two reviews and
two merges of the same change), and **record the timestamps when you stand
down** — the rule is unenforced by construction, since nothing can block another
session's `gh issue comment`, so visibility is the only thing keeping it alive.

## Verification

No `src/**` change, so this takes the prose + command arms of `/verify-pr` step
9 rather than a deploy tier: every claim about a gate, path or fixture count was
resolved against this repo's own files, and the new test was run in both
directions (injected failure, then clean). `vp run --no-cache check`,
`typecheck:test`, `build` all rc=0; full suite **779 files / 16033 tests**, rc=0.

Also written to agent memory this run (local, outside this PR):
`second-exit-trap-disarms-the-first`, `mocked-logger-hides-a-real-crash`,
`assertion-is-a-substring-of-what-it-rejects`,
`inserting-a-function-orphans-the-jsdoc-above`.
