### PR TITLE
chore(work-issues,run-integ): fold back three lessons from the 2117/2052 run

### DIFF
--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -243,6 +243,25 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
     export
     ```
 
+    **Only FIVE of those nine carry a `verify.sh`, and from an agent session
+    the other four cannot be run at all.** Step 5's dispatch note explains why
+    (the standard flow needs a direct `cdkd deploy`, which the harness's
+    auto-approval classifier refuses), but it leaves the selection to be
+    discovered one dead-end at a time. Measured 2026-08-26 while gating a
+    `destroy.ts` change: `multi-stack-deps` is the obvious pick for an `--all`
+    loop change and is one of the four without one.
+
+    Runnable from a session: **`lambda`**, `drift-revert`, `drift-revert-vpc`,
+    `remove-protection`, `export`.
+    Human-driven shell only: `bench-cdk-sample`, `microservices`,
+    `multi-stack-deps`, `multi-resource`.
+
+    `lambda` is the cheap default — a ~100 s, 9-resource DAG across SQS / IAM /
+    Lambda / LayerVersion / DynamoDB Table + GlobalTable, which is what makes it
+    broad. Re-derive the split with
+    `ls tests/integration/<name>/verify.sh` rather than trusting this list if a
+    fixture has since gained one.
+
     (Keep this list in sync with `.claude/hooks/integ-broad-gate.sh`'s
     error message and the matching memory rule
     `feedback_cross_cutting_needs_broad_integ.md`. The sync is now

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -984,6 +984,20 @@ spellings the tree does not currently use, and the contexts that defeat your
 exemption logic. So follow the calibration with two probes, both against the
 REAL tree rather than by reasoning:
 
+- **Write the defect in the spelling a PERSON would write, not the one that is
+  easiest to inject.** This is the sub-case that keeps passing, because an
+  artificial probe and a natural one look equally like "I mutated it". Measured
+  2026-08-26 on the issue go-to-k/cdkd#2052 lane: a prefix-sync fence split on
+  `'custom-resource-responses'` *with both quote characters*, and the probe
+  used `` `${'custom-resource-responses'}/` ``, which reds it. The spelling
+  anybody would actually type -- `listRawObjects('custom-resource-responses/')`
+  -- puts the trailing slash before the closing quote and sailed straight
+  through, as did a copy in any file outside the fence's hand-written list. A
+  reviewer found both. Note what that fence was FOR: it is the mechanism this
+  section's own "grep for the SHAPE, not for a NAME" rule prescribes, written by
+  someone who had just read that rule, and it broke it anyway -- so when the
+  probe is of a fence, mutate it the way a future contributor would, and derive
+  the population rather than listing it.
 - **Write the defect in every spelling the language allows** and confirm each is
   flagged. On 2026-08-20 (go-to-k/cdkd#2111) a scanner for
   `options.region || process.env['AWS_REGION']` calibrated perfectly — 19
@@ -1807,6 +1821,24 @@ PR that had edited `deploy-engine.ts` — which that lane also edited — and th
 marker correctly went stale, buying a second real-AWS run at merge time. Push
 first so CI starts, then re-run the integ alongside it; the two are independent
 and serializing them wastes the CI wall-clock.
+
+**A reviewer's suggested FIX can be wrong even when its finding is right —
+re-derive the fix from the source rather than pasting the patch.** The premise
+check below asks whether the finding holds; this asks whether the remedy does,
+and the two fail independently. Measured 2026-08-26 on the issue
+go-to-k/cdkd#2052 lane: a security reviewer proved by probe that an age-only
+sweep would delete live `state.json` under a colliding `--state-prefix`, which
+was correct and a blocker, and offered
+`/^cdkd-\d+-[0-9a-z]+\.json$/` as the key-shape filter. Reading the producer
+showed the suffix is `Math.random().toString(36).substring(7)`, which returns
+the EMPTY string whenever the base-36 rendering is shorter than eight
+characters -- so `cdkd-<epoch>-.json` is a key cdkd really writes and the `+`
+would have skipped exactly those. Adopting it would have traded an
+over-collection bug for an under-collection one that is INVISIBLE, since a
+sweep that collects nothing looks identical to a clean bucket. The tell is
+generic: a reviewer reasons from the diff, so a suggested REGEX, bound, or
+constant is the part it is least able to verify. Derive those from the code
+that produces the value, and probe both directions.
 
 **Check a reviewer's PREMISE before acting on the finding, and say so when you
 decline.** Reviewers are read-only and reason from what they can see, so a


### PR DESCRIPTION
Retrospective for the `/work-issues` run that shipped https://github.com/go-to-k/cdkd/issues/2117 and https://github.com/go-to-k/cdkd/issues/2052 (PRs https://github.com/go-to-k/cdkd/pull/2237, https://github.com/go-to-k/cdkd/pull/2238).

Three amendments. **Each refines a rule that already existed and got violated anyway**, which is why none is a new sentence in a new place — per section 10-b, restating a rule that was already written is the response that has already been shown not to work.

## 1. `run-integ` — name which broad-set fixtures are actually runnable

Only **five of the nine** carry a `verify.sh`. From an agent session the other four cannot be run at all: the standard flow needs a direct `cdkd deploy`, which the harness's auto-approval classifier refuses. Step 5 already says to check before committing to a name, but left the selection to be discovered one dead-end at a time.

Concretely: `multi-stack-deps` is the obvious pick for an `--all` loop change — which is exactly what #2117 was — and is one of the four.

Runnable: `lambda`, `drift-revert`, `drift-revert-vpc`, `remove-protection`, `export`.

## 2. `work-issues` §5 — probe with the spelling a PERSON would write

The #2052 lane's prefix-sync fence split on the literal **with both quote characters**. My probe used `` `${'custom-resource-responses'}/` ``, which reds it. The spelling anybody would actually type —

```ts
listRawObjects('custom-resource-responses/')
```

— puts the trailing slash *before* the closing quote and sailed straight through, as did a copy in any file outside the fence's hand-written four-file population. A reviewer found both.

This is worth stating plainly because of what that fence was **for**: it is the mechanism §5's own "grep for the SHAPE, not for a NAME" rule prescribes, written by someone who had just read that rule. Another sentence restating it would not have helped. What the next run needs is the probe discipline that catches it — an artificial mutation and a natural one look equally like "I mutated it", and only one of them is evidence.

## 3. `work-issues` §8 — a reviewer's suggested FIX can be wrong even when its finding is right

The premise check already in §8 asks whether the **finding** holds. This asks whether the **remedy** does, and the two fail independently.

On the same lane a security reviewer proved by probe that an age-only sweep would delete live `state.json` under a colliding `--state-prefix` — correct, and a genuine blocker — and offered `/^cdkd-\d+-[0-9a-z]+\.json$/` as the key-shape filter. Reading the producer showed the suffix is `Math.random().toString(36).substring(7)`, which returns the **empty string** whenever the base-36 rendering is shorter than eight characters. So `cdkd-<epoch>-.json` is a key cdkd really writes, and `+` would have skipped exactly those — trading an over-collection bug for an **invisible** under-collection one, since a sweep that collects nothing looks identical to a clean bucket.

The tell generalises: a reviewer reasons from the diff, so a suggested regex, bound or constant is the part it is least able to verify. Derive those from the code that produces the value, and probe both directions.

## Also folded, not filed

The `destroy-interrupt` fixture **passes while leaking** an auto-created `/aws/lambda/CdkdDestroyInterruptExample-*` log group — observed twice in one session (once on a flaked run, once on a clean PASS), swept by hand both times. Added as a checklist row on the existing https://github.com/go-to-k/cdkd/issues/2126 rather than filed separately: same fixture, same root cause, and §5's rule is that N sites of one root cause is one issue.

## Verification

No `src/**` change, so this takes §8's prose arm: every gate name, path, fixture name and command the new text asserts was resolved against this repo's own files, and the claims that are measurements were measured in the run being written up rather than recalled.

- `ls tests/integration/<name>/verify.sh` across all nine broad-set fixtures — the 5/4 split is that command's output.
- `vp run check` / `typecheck:test` / `build` / full suite (787 files, 16216 tests) — all rc=0.
- `tests/unit/scripts/work-issues-skill-refs.test.ts` (5 passed) — the fence that rejects a bare `#N` in this file's prose; every reference above is fully qualified.
- `tests/unit/scripts/rule-file-payload.test.ts` (178 passed) — the per-area rule-payload cap, which the #2052 lane tripped earlier in this same run.
