### PR TITLE
chore(work-issues): a fence's population can be dodged by omitting an optional language feature, and a probe count goes stale across rounds

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -869,6 +869,17 @@ arm produces, so deleting the canonicalization left it green. A fourth asserted
 `ambient.ssm !== instances.at(-1)` while `ambient.ssm` is a LAZY getter that
 constructs at assertion time — it was measuring its own side effect.
 
+**A probe COUNT goes stale across review rounds, so a matrix carried forward is
+wrong even when every row was true when written.** Later rounds add cases that
+depend on the same line, so the row that measured "exactly 1 RED" in round 1
+measures 4 by round 3 — and the number is the part a reader uses to judge how
+load-bearing the line is. Measured 2026-08-26 on one PR: two published rows said
+1 RED each; re-run on the final tree they were 4 and 6. Nothing had regressed,
+the matrix had simply been PATCHED (new rows appended) rather than RE-MEASURED.
+So when a body or changelog publishes a matrix, re-run the whole thing on the
+tree you are about to merge, and say which tree the counts are from — a count
+with no subject is not a measurement.
+
 So when you write the probe, name the discriminator first and assert THAT:
 which client was constructed and with what region, which call the stub actually
 received, what the second invocation saw. "The happy path still happens" is
@@ -1053,6 +1064,36 @@ REAL tree rather than by reasoning:
   OR at all: go-to-k/cdk-local#537's reference scan flipped one `inFence` boolean
   on any fence marker, so a single nested fence inverted it and muted every check
   for the rest of the file, silently.
+
+  **A population derived from an OPTIONAL language feature is derivable-around
+  for free, and a type annotation is the commonest one.** This is the same class
+  arriving through a spelling that looks rigorous rather than lazy. On
+  2026-08-26 a fence written to END a four-round cascade — every round's blocker
+  being "another site writes this field without the gate" — derived its
+  population as "files annotating `: DestroyRunnerResult`". TypeScript infers,
+  so the two files that hold the object as plain locals were never scanned, and
+  planting the write in one of them (the site of round 1's own blocker) left the
+  fence 4/4 GREEN. The fix is to derive from a relation the write CANNOT omit —
+  here, that a file either constructs the result or receives it from the one
+  function that returns it. Ask of any population: *what would this look like if
+  the author simply did not write the optional part?* Annotations, explicit
+  return types, `export` markers, and interface `implements` clauses all answer
+  "identical, and invisible to you".
+
+  **Probe the fence with the evasions the DEFECT would use, not with the one you
+  just fixed.** Re-planting the exact line you removed is the cheapest probe and
+  the least informative — it is the one spelling you have already proved you can
+  see. The same 2026-08-26 fence caught its own removed line and missed four
+  ordinary alternatives to it: a computed member (`x['field'] =`),
+  `Object.assign`, an object literal, and a spread rebuild. The last is the one
+  to reach for first when the cascade has been about early returns, because a
+  new early return is written as a new object, not as a new assignment.
+
+  **And watch the FLOOR for the same collapse.** A floor naming only the file
+  the defect lives in is satisfied BY the collapse it exists to catch: narrowing
+  that fence's pathspec to the owner file alone still passed 4/4, because the
+  floor asked for exactly the file that survived. Name the members a collapse
+  drops FIRST — the peripheral ones — not the central one.
 
 And ask the dumbest question last: **is anything RUNNING it?** The nine hook
 harnesses in go-to-k/cdk-real-drift were shell, so the vitest task never saw


### PR DESCRIPTION
`/work-issues` section 10 retrospective. Three lessons from a run that took **four review
rounds** to land one PR (go-to-k/cdkd#2247), each measured on this repo rather than reasoned
about. All three are amended in place next to the guidance they extend, not appended as new
sections.

## 1. A population derived from an OPTIONAL language feature is dodged for free

The skill already warns against a fence whose population is derived from the DEFECT itself.
This is the same class arriving through a spelling that looks rigorous rather than lazy, which
is why it survived being written *specifically* to end a cascade.

Every one of that PR's four rounds had the same blocker: another site writing the same field
without the gate. Round 3 replaced the human enumeration with a fence — and derived its
population as "files annotating `: DestroyRunnerResult`". TypeScript **infers**, so the two
files holding the object as plain locals were never scanned. Planting the write in one of them
— the site of round 1's own blocker — left the fence **4/4 GREEN**.

The question that catches it is recorded with it: *what would this population look like if the
author simply did not write the optional part?* Annotations, explicit return types, `export`
markers and `implements` clauses all answer "identical, and invisible to you". The fix is to
derive from a relation the write cannot omit — there, that the file either constructs the
result or receives it from the one function returning it.

## 2. Probe a fence with the evasions the DEFECT would use, not the line you removed

Re-planting the line you just deleted is the cheapest probe and the least informative: it is
the one spelling already proven visible. The same fence caught its own removed line and missed
four ordinary alternatives — a computed member, `Object.assign`, an object literal, and a
spread rebuild. The last is the one to reach for first when the cascade has been about early
returns, because a new early return is written as a new object rather than a new assignment.

The FLOOR collapses the same way and for the same reason: a floor naming only the file the
defect lives in is satisfied **by** the collapse it exists to catch. Narrowing that fence's
pathspec to the owner file alone still passed 4/4. Name the members a collapse drops first —
the peripheral ones — not the central one.

## 3. A probe COUNT goes stale across review rounds

Later rounds add cases that depend on the same line, so a row measuring "exactly 1 RED" in
round 1 measures 4 by round 3 — and the number is precisely what a reader uses to judge how
load-bearing that line is. Two rows published in that PR's body said 1 RED each; re-run on the
final tree they were **4 and 6**. Nothing had regressed. The matrix had been PATCHED (new rows
appended) rather than RE-MEASURED.

Added beside the existing vacuous-probe guidance, with the rule that a published matrix is
re-run on the tree being merged and states which tree its counts came from — a count with no
subject is not a measurement.

## Verification

No `src/**` change, so this takes section 8's no-src tier, PROSE arm: the artifact is the
CLAIMS. Every incident cited is one this run measured directly, and every command the new text
sends a future agent to run was run here.

`vp check --fix` / `vp run check` / `vp run typecheck:test` / `vp run build` all rc 0. Full
suite **789 files / 16348 tests**, 0 failures, no type errors —
`.claude/skills/work-issues/**` is in the `check` gate's scope, so this is required rather than
incidental. `tests/unit/scripts/work-issues-skill-refs.test.ts` (5 passed) is the fence that
validates the `go-to-k/cdkd#N` qualified form every citation added here uses.
