### PR TITLE
chore(import): name the nested-stack ARN's region segment for the reader that parses it

### DIFF
--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -1747,14 +1747,34 @@ async function captureObservedForImportedResources(
  * than silently using a non-ARN string. The format MUST match
  * `NestedStackProvider.synthesizeArn` so an import-then-deploy cycle does
  * not surface phantom property changes on the nested-stack row.
+ *
+ * THE REGION SEGMENT IS READ BACK, so it must be the CHILD's region and must
+ * not be collapsed with the parent's (issue
+ * [#2055](https://github.com/go-to-k/cdkd/issues/2055)).
+ * `nestedStackChildRegionFromLocalArn` in
+ * [src/deployment/intrinsic-function-resolver.ts](../../deployment/intrinsic-function-resolver.ts)
+ * parses this segment to learn which region to resolve a child's persisted
+ * `{{resolve:...}}` output in — a secret NAME is regional, so resolving it in
+ * the wrong region can answer with a DIFFERENT secret. Reading the child's own
+ * state record instead is not an option: the region is part of that record's S3
+ * key, so the lookup would be circular. That reader's doc block carries the
+ * full rationale; this note exists because the value is produced HERE and the
+ * next edit to the import walk would otherwise have nothing in front of it.
+ *
+ * Both call sites already pass a child-scoped value — the top-level walk passes
+ * `targetRegion` (the stack being imported) and the recursive nested walk
+ * passes `childRegion` — and parent and child region are necessarily equal
+ * until cross-region nested stacks ship. The parameter is named `childRegion`
+ * anyway, matching `NestedStackProvider.synthesizeArn`, so the requirement is
+ * visible at the signature rather than only in prose.
  */
 function synthesizeNestedStackArn(
-  region: string,
+  childRegion: string,
   accountId: string,
   parentStackName: string,
   logicalId: string
 ): string {
-  return `arn:cdkd-local:${region}:${accountId}:nested-stack/${parentStackName}/${logicalId}`;
+  return `arn:cdkd-local:${childRegion}:${accountId}:nested-stack/${parentStackName}/${logicalId}`;
 }
 
 /**


### PR DESCRIPTION
Closes #2246

## What

`synthesizeNestedStackArn` in `src/cli/commands/import.ts` is the second producer of `arn:cdkd-local:<region>:<account>:nested-stack/<parent>/<logicalId>`. Its parameter is renamed `region` -> `childRegion`, and its doc block now records that the region segment is read back, and by whom.

No behaviour change. No test change.

## Why

The first producer, `NestedStackProvider.synthesizeArn`, had its parameter renamed to `childRegion` when `nestedStackChildRegionFromLocalArn` started PARSING that segment back (go-to-k/cdkd#2055). This one kept `region`, and a doc block saying only that the format must match the provider's — not why the segment matters, nor that anything reads it.

The segment is load-bearing now: the resolver takes it to decide which region to resolve a child's persisted `{{resolve:...}}` output in. A secret NAME is regional, so resolving it in the wrong region can answer with a **different secret**. Reading the child's own state record instead is circular — the region is part of that record's S3 key.

## Not a live bug

Both call sites already pass a child-scoped value: the top-level walk passes `targetRegion`, the recursive nested walk passes `childRegion`. Parent and child region are necessarily equal until cross-region nested stacks ship. What was missing is that the next edit to the import walk had nothing in front of it saying the segment is read back — which is exactly how the go-to-k/cdkd#2055 half would silently regress.

## Two corrections to the issue body, both verified against the tree

1. **The premise was not yet true when the issue was filed.** `nestedStackChildRegionFromLocalArn` did not exist on `main` when this lane started — it landed minutes earlier in go-to-k/cdkd#2266. The worktree was rebased and the reader confirmed present at `src/deployment/intrinsic-function-resolver.ts` before the note was written. Had the lane trusted the issue body, the new comment would have named a function that was not there.
2. **The provider's doc does not record the segment as load-bearing.** The issue says it does; only the parameter NAME changed there, and its comment still covers the `cdkd-local` partition alone. So the note points at the READER's own doc block, which does carry the full rationale, rather than at the provider's.

## Won't-do, recorded here

The provider's doc block is not given the same note. It sits in `src/provisioning/providers/**`, which is `integ-destroy` gate scope, so a comment-only edit there would stale that marker and drag a real-AWS integ run this lane is not otherwise paying for. The gap it would close is small: the provider's parameter is already named `childRegion`, and the reader's own doc block is thorough. Fold it into the next PR that touches that file for a real reason.

## Verification

`vp check --fix` / `vp run check` / `vp run typecheck:test` / `vp run build` / `vp run test` all green — 805 test files, 16578 tests.

## This lane also settles go-to-k/cdkd#2267

`.github/workflows/pr-inherit-issue-labels.yml` shipped in go-to-k/cdkd#2264, and its WRITE leg had never run against real GitHub: every PR since had closed no issue, so the job took its `No closing reference` early exit. The issue this PR closes carries `severity:low` + `effort:small`, so this is the first real exercise of the label copy — if those labels appear on this PR, the POST and its `pull-requests: write` permission are proven for all three repos running the byte-identical workflow. That is a side effect of doing the work rather than a reason it was worth doing.
