### PR TITLE
chore(work-issues): gate Session-fit: next on naming the next session's verification

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -484,6 +484,50 @@ before:
   to whatever tier its size gives (`CLAUDE.md` → "PR review pattern"), since urgency
   is a reason to start it sooner, never to check it less.
 
+### 3-b. Before writing `next`, NAME the next session's verification
+
+Every deferral is a prediction: *a later session can finish this*. The prediction is
+usually never stated, so it is never checked — and the classification degrades into
+naming the KIND of work ("a fixture change", "a different subsystem", "its own review
+round"), which is the classify-by-MEANS-not-by-PURPOSE error `CLAUDE.md` already
+forbids, and which no list of `now` triggers can catch, because the next miss arrives in a shape the list does
+not contain.
+
+So make the prediction explicit. **You may not write `Session-fit: next` until you can
+name, concretely, the command the NEXT session will run to verify the fix — and can
+say that a fresh session will be able to run it.** Not "run the integ"; the fixture
+name. Not "test it"; the assertion that will go from red to green.
+
+This is a GENERATIVE check, not a lookup, which is the whole point: it fires on
+conditions nobody enumerated. If naming it is hard, that difficulty IS the finding —
+usually one of:
+
+- **The verifier is bound to THIS host.** CPU architecture, OS version, an installed
+  toolchain, the Docker daemon's image or platform state.
+- **The verifier is bound to THIS account or region.** A bootstrapped region, a live
+  resource someone else's fixture created, a quota that took a support ticket.
+- **The verifier does not exist yet**, and writing it is most of the work — the one
+  case where `next` is genuinely right, and it is right BECAUSE you could name what
+  is missing.
+- **You cannot name it at all**, which means nobody can confirm the fix later either.
+  That is not a deferral, it is an unbounded one.
+
+Measured 2026-08-26: cdk-local go-to-k/cdk-local#560 was filed and classified
+`Session-fit: next` on the reasoning "a fixture / base-image change on a different
+axis" — a statement about the work's CATEGORY. The defect is a Go RIE segfault under
+`linux/amd64` emulation on an arm64 host, and `uname -m` on the machine that filed it
+was **arm64**. The next session's verification is "run the two start-api fixtures on
+an arm64 host", and nothing guarantees a fresh session HAS one. Deferring would have
+handed the work to a session that might be structurally unable to confirm it, and the
+maintainer caught the misclassification rather than the flow doing so. Had the
+question been asked, the answer names the host in one sentence.
+
+**Its converse is the honest use of `next`.** When you CAN name the verification and a
+fresh session will plainly have it — an existing fixture on any machine, a unit
+assertion, an ordinary `gh` query — the deferral is sound and the naming costs one
+line. Put that line in the issue body next to `Session-fit`, so the next session
+starts from the check rather than re-deriving it.
+
 ## 4. CLAIM the chosen issues BEFORE editing
 
 For EACH issue you will start:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,28 @@ high.
 
   **Session-fit** — the question it answers is always the same one, and it is the one that otherwise gets re-litigated after every merge: **do I keep going in THIS session, or hand this to a fresh session / another agent?** Answer it once, when the item is created, and the post-merge moment stops being a decision point at all.
   - **`now`** — finish it in this session. Any of: it lands in files this session already has open or changed (**re-acquiring the context costs more than the work**); skipping it leaves main self-inconsistent (docs contradicting shipped code, a stale rationale comment, a fixture that no longer discriminates, an unearned claim in a PR body); it blocks another lane in this session; **it rides an EXISTING integ fixture** (see the calibration below); or **its evidence exists only in this session** — a live repro, a real-AWS observation, a measurement you took. Understanding survives in an issue body; evidence does not.
+
+    **Before writing `next`, NAME the next session's verification.** A deferral is an
+    unstated PREDICTION that a later session can finish the work; unstated, it is
+    never checked, and the classification decays into naming the KIND of work ("a
+    fixture change", "a different subsystem") — classifying by MEANS rather than by
+    PURPOSE, which the calibration below already forbids and which no list of `now`
+    triggers can catch, because the next miss arrives in a shape the list does not
+    contain. So the gate is GENERATIVE rather than a lookup: you may not write
+    `Session-fit: next` until you can name the concrete command the next session will
+    run to verify the fix, and say a fresh session will be able to run it. Not "run
+    the integ" — the fixture name. If naming it is hard, that difficulty IS the
+    finding: the verifier may be bound to THIS host (CPU architecture, toolchain,
+    Docker image state), to THIS account or region (a bootstrapped region, a live
+    resource, a quota), may not exist yet (the one case where `next` is genuinely
+    right, and right BECAUSE you could name what is missing), or may be unnameable at
+    all — which is not a deferral but an unbounded one. Measured 2026-08-26:
+    go-to-k/cdk-local#560 was classified `next` on "a fixture / base-image change on a
+    different axis"; the defect is a Go RIE segfault under `linux/amd64` emulation on
+    an arm64 host and the filing machine WAS arm64, so the verification is "run those
+    fixtures on an arm64 host" and nothing guarantees a fresh session has one. The
+    maintainer caught it, not the flow. Put the named command in the issue body beside
+    `Session-fit`, so the next session starts from the check instead of re-deriving it.
   - **`next`** — hand off to a fresh session / another agent. Any of: a NEW integ fixture has to be WRITTEN for it; it is a schema bump or a behavior change that must not share a PR (if either half fails, both become unmergeable); bundling it would make the PR unreviewable; it waits on external input (an AWS quota, a maintainer decision, an upstream fix); or it is an independent subsystem with no file overlap AND none of the `now` criteria fire.
 
   **Calibration: RUNNING an existing integ is not a reason to defer, and this rule used to say it was.** Measured over the 268 rows of `docs/_generated/integ-last-run.tsv` on 2026-08-20: median run **85 s**, mean 4.6 min, p90 8.8 min, and the heaviest broad fixture (`multi-stack-deps`) 8.0 min. A passing run costs a few hundred tokens of output. If the session is running an integ for its current lane anyway, a fix riding the same fixture costs **zero** — the same run refreshes the same 14-day gate. What is genuinely expensive is *writing* a new fixture (a CDK app plus `verify.sh` plus a ledger row plus the coverage matrix), an integ that FAILS (unbounded, and you would pay it next session too), and above all **review of a larger diff, which grows superlinearly** because a reviewer reads the whole thing and cross-file interactions multiply. Defer on those, never on "it needs an integ".


### PR DESCRIPTION
## Summary

`Session-fit: next` is an unstated PREDICTION that a later session can finish the work. Because it is never stated, it is never checked — and the classification decays into naming the KIND of work ("a fixture change", "a different subsystem"), which is classifying by MEANS rather than by PURPOSE, something CLAUDE.md already forbids elsewhere.

Adding another entry to the `now` trigger list would not have caught the miss below, because the next one arrives in a shape the list does not contain. So this is a **generative** gate rather than a lookup:

> You may not write `Session-fit: next` until you can NAME the concrete command the next session will run to verify the fix, and say a fresh session will be able to run it. Not "run the integ" — the fixture name.

If naming it is hard, that difficulty IS the finding. The verifier may be bound to **this host** (CPU architecture, toolchain, Docker image state), to **this account or region** (a bootstrapped region, a live resource, a quota), may **not exist yet** — the one case where `next` is genuinely right, and right BECAUSE you could name what is missing — or may be **unnameable at all**, which is not a deferral but an unbounded one.

## The incident

go-to-k/cdk-local#560 was classified `Session-fit: next` on the reasoning "a fixture / base-image change on a different axis" — a statement about the work's category. The defect is a Go RIE segfault under `linux/amd64` emulation on an **arm64** host, and `uname -m` on the filing machine was arm64. So the next session's verification is "run those two fixtures on an arm64 host", and nothing guarantees a fresh session has one. The maintainer caught the misclassification; the flow did not.

Worked on that arm64 host instead, it merged as go-to-k/cdk-local#567: reproduced (both fixtures failing, at **different** arms than the issue recorded — the signature of emulation rather than a code defect), root-caused to the fixtures never declaring `architecture` so CDK defaulted all 15 functions to `X86_64`, fixed, and re-verified **three runs each** on the same host. A session on an x86 machine could have written that fix and been unable to confirm it.

## Placement

The rule sits in **CLAUDE.md** because `Session-fit` is written by every wrap report, not only by this flow — that is where the field is defined, so it is where a gate on writing it belongs. The **skill** carries the applied form, at the point a deferral stops being a chat line and becomes a filed issue, plus the instruction to put the named command in the issue body beside `Session-fit` so the next session starts from the check instead of re-deriving it.

## Mirrored, adapted rather than transplanted

Landed in all three repos this session, each verified against its own files:

- **cdk-real-drift** — go-to-k/cdk-real-drift#1821. Confirmed the arm64/Docker shape *cannot recur there* (no `docker` anywhere in its hooks, `.markgate.yml` or settings; its `integ` gate is read-only AWS), so the illustrative binding was rewritten to that repo's real one: a stack destroyed by `bughunt-clean-gate` before the run can ship, with harvesting to `tests/corpus/` as the counter-move.
- **cdk-local** — go-to-k/cdk-local#568. Found it has **no ranking section** — its `### 3-a` is the freshness quarantine — so a `3-b` would have transplanted a number rather than a function; placed at the end of §5's filing sequence instead. Also corrected two claims that are true in cdkd and false there.

Each mirror ran its own repo's checks and its own bare-`#N` reference fence where one exists.

## Verification

Prose-only change, so the claims are the artifact: every gate, path and command the new text names was resolved against this repo's files, and `tests/unit/scripts/work-issues-skill-refs.test.ts` (the bare-`#N` fence over this SKILL.md) passes 5/5.

`vp run check` rc=0; full suite **804 files / 16,575 tests**, no type errors.

One note on that run: the first attempt reported `check` rc=1 and a failing `gen-nested-key-coverage` suite. Both were the missing-`node_modules` artifact of a fresh worktree, not the diff — the pre-flight step this repo's own `/verify-pr` opens with. After `pnpm install`, `check` rc=0 and that suite is 298/298.
