### PR TITLE
chore(work-issues): make the next-to-now promotion a query, and warn on Stop when a lane is still unmerged

### DIFF
--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# stop-unmerged-lane-warn.sh
+#
+# Stop hook. `stop-warn.sh` next to it catches UNCOMMITTED work in the main
+# tree. This catches the other, quieter half: a feature worktree whose branch
+# is COMMITTED but still ahead of `origin/main` -- a lane that is finished as
+# far as the editor is concerned and unfinished as far as the repo is.
+#
+# Why this is a hook rather than another sentence. CLAUDE.md already says a
+# NOT-CLOSEABLE verdict is a to-do list and not a stopping point, and already
+# says that if you cannot name a signal that will re-invoke you then you are
+# STOPPED rather than WAITING. Both were violated repeatedly in one session on
+# 2026-08-26: turns ended with `Mode: WAITING` next to `Waiting on: none`, and
+# with `Verdict: NOT CLOSEABLE` in the same report as the stop. A rule that is
+# already in the text and gets violated anyway is not made load-bearing by a
+# third spelling of it (`/work-issues` section 10-b says to escalate rather
+# than restate), so this computes the verdict from the REPO instead of from the
+# agent's own self-report -- which is the part that was wrong.
+#
+# Deliberately does NOT call `gh`: a Stop hook runs on every turn, and a network
+# round-trip per turn is a cost this warning does not justify. Branch state
+# alone separates "there is unmerged work here" from "there is not".
+set -u
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO" 2>/dev/null || exit 0
+
+# Cheap: no fetch. A stale `origin/main` can only UNDER-report (a branch whose
+# work already merged still looks ahead until the next fetch), and the failure
+# direction that matters is missing a real lane, not naming a merged one.
+git rev-parse --verify origin/main >/dev/null 2>&1 || exit 0
+
+lanes=""
+while IFS= read -r wt; do
+  [ -n "$wt" ] || continue
+  [ "$wt" = "$REPO" ] && continue
+  br=$(git -C "$wt" branch --show-current 2>/dev/null) || continue
+  [ -n "$br" ] || continue
+  case "$br" in main | master) continue ;; esac
+  ahead=$(git -C "$wt" rev-list --count "origin/main..$br" 2>/dev/null) || continue
+  [ "${ahead:-0}" -gt 0 ] || continue
+  lanes="${lanes}  ${br}  (${ahead} commit(s) ahead, worktree ${wt##*/})
+"
+done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+
+[ -n "$lanes" ] || exit 0
+
+msg="WARNING: unmerged lane(s) still open -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.
+Each branch below is committed but not on origin/main. If any is YOURS, you are not done: rebase, run the
+gates, open the PR, merge. If one belongs to another session, say which and why, rather than leaving it
+unexplained. And if you are ending the turn with nothing that will re-invoke you, the honest label is
+STOPPED, not WAITING."
+
+payload=$(printf '%s\n%s' "$msg" "$lanes" |
+  python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+printf '{"systemMessage": %s}' "$payload"

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Smoke test for stop-unmerged-lane-warn.sh.
+#
+# Run from BESIDE the hook (`bash .claude/hooks/stop-unmerged-lane-warn.test.sh`):
+# the path below is `${BASH_SOURCE[0]}`-relative, so a copy run from a scratch
+# directory resolves a hook that is not there and every case fails with 127.
+#
+# Both polarities are exercised. A Stop hook that only ever proves it FIRES
+# cannot notice itself starting to fire on every turn, and a warning that cries
+# wolf on a clean tree is one people learn to scroll past -- which is the same
+# outcome as not having it.
+
+set -u
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/stop-unmerged-lane-warn.sh"
+
+pass=0
+fail=0
+fail_log=""
+
+check() {
+  local name="$1" want="$2" got="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    printf 'OK   %s\n' "$name"
+  else
+    fail=$((fail + 1))
+    fail_log+="FAIL $name: want '$want', got '$got'\n"
+    printf 'FAIL %s (want %s, got %s)\n' "$name" "$want" "$got"
+  fi
+}
+
+# `lanes_in <output>` -> how many branch lines the payload named.
+lanes_in() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+raw = sys.stdin.read()
+if not raw.strip():
+    print(0); raise SystemExit
+msg = json.loads(raw)["systemMessage"]
+print(sum(1 for line in msg.splitlines() if line.startswith("  ")))
+'
+}
+
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+REPO="$SANDBOX/repo"
+mkdir -p "$REPO/.claude/hooks"
+cp "$HOOK" "$REPO/.claude/hooks/"
+RUN="$REPO/.claude/hooks/$(basename "$HOOK")"
+
+git -C "$REPO" init -q .
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+# --- SILENT: nothing unmerged. The expensive half to get right, because a
+# false alarm every turn is indistinguishable from noise. ---
+out=$(cd "$REPO" && bash "$RUN")
+check "silent when no worktree exists" "" "$out"
+
+# --- SILENT: a worktree that is level with origin/main is not a lane. ---
+git -C "$REPO" worktree add -q "$REPO/wt-level" -b feat/level HEAD
+out=$(cd "$REPO" && bash "$RUN")
+check "silent for a worktree with no commits of its own" "" "$out"
+
+# --- SILENT: a DETACHED worktree has no branch to report. ---
+git -C "$REPO" worktree add -q "$REPO/wt-detached" --detach HEAD
+out=$(cd "$REPO" && bash "$RUN")
+check "silent for a detached worktree" "" "$out"
+
+# --- FIRES: one lane with a commit of its own. ---
+git -C "$REPO/wt-level" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+out=$(cd "$REPO" && bash "$RUN")
+check "names the one lane that is ahead" "1" "$(lanes_in "$out")"
+
+# --- FIRES: counts each lane separately, and still ignores the detached one. ---
+git -C "$REPO" worktree add -q "$REPO/wt-two" -b feat/two HEAD
+git -C "$REPO/wt-two" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+out=$(cd "$REPO" && bash "$RUN")
+check "names both lanes, not the detached worktree" "2" "$(lanes_in "$out")"
+
+# --- The payload has to be valid JSON, or the harness swallows it silently. ---
+if printf '%s' "$out" | python3 -c 'import json,sys; json.loads(sys.stdin.read())' 2>/dev/null; then
+  pass=$((pass + 1)); printf 'OK   payload is valid JSON\n'
+else
+  fail=$((fail + 1)); fail_log+="FAIL payload is not valid JSON\n"; printf 'FAIL payload is valid JSON\n'
+fi
+
+# --- SILENT: no `origin/main` at all (a fresh clone before the first fetch)
+# must not error or spam. ---
+BARE="$SANDBOX/norem"
+mkdir -p "$BARE/.claude/hooks"
+cp "$HOOK" "$BARE/.claude/hooks/"
+git -C "$BARE" init -q .
+git -C "$BARE" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+out=$(cd "$BARE" && bash "$BARE/.claude/hooks/$(basename "$HOOK")")
+check "silent when origin/main is unresolvable" "" "$out"
+
+printf '\nPass: %d  Fail: %d\n' "$pass" "$fail"
+if [ "$fail" -gt 0 ]; then
+  printf '%b' "$fail_log" >&2
+  exit 1
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -283,6 +283,10 @@
             "command": ".claude/hooks/stop-warn.sh",
             "timeout": 10,
             "statusMessage": "Checking working tree and /check marker..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/stop-unmerged-lane-warn.sh"
           }
         ]
       }

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -2456,6 +2456,71 @@ gh issue list --state all --limit 100 --json number,createdAt,title \
   --jq '.[] | select(.createdAt > "<this run start ISO>") | "\(.number)\t\(.title)"'
 ```
 
+**Then run the PROMOTION check on every `next` this run filed, because a
+deferral is judged against the run that has now happened, not the run that was
+predicted when it was written.** `CLAUDE.md` already requires promoting a `next`
+to `now` when the session ends up touching those files anyway, and the `next`
+criterion "an independent subsystem with no file overlap" already carries the
+conjunct "AND none of the `now` criteria fire". Both are correctly written and
+both get skipped, because at wrap time nobody re-opens a decision they remember
+making deliberately. So make it a QUERY rather than a thing to remember:
+
+```bash
+# For each issue this run filed, does the run's OWN merged diff touch a file
+# that issue names? A hit means the reverse move in CLAUDE.md fires.
+RANGE="<the sha main was at when this run started>..origin/main"
+git diff --name-only "$RANGE" | sort -u > /tmp/run-touched.$$
+# The population is the issues this run FILED and left OPEN -- not the folded
+# list above, and not the ones it filed and then fixed in the same lane, which
+# section 3-a makes routine.
+for n in <the numbers this run filed that are still open>; do
+  b=$(gh issue view "$n" --json body -q .body)
+  # The prose says every `next`; without this the loop also reports items
+  # already classified `now`, which are not deferrals at all. `Session-fit`
+  # carries no GitHub label, so it has to be grepped out of the body.
+  printf '%s' "$b" | grep -q 'Session-fit: *next' || continue
+  printf '%s' "$b" \
+    | grep -oE '[A-Za-z0-9_][A-Za-z0-9_./-]*\.[a-z]+' | sort -u \
+    | while read -r f; do
+        # Suffix match, not equality: an issue body names a file by BASENAME far
+        # more often than by full path (`destroy-runner.ts`, not
+        # `src/cli/commands/destroy-runner.ts`), and an exact-line compare misses
+        # every one of those. Measured: the exact form fired on 1 of this run's 2
+        # deferrals and missed the one whose body used the basename.
+        grep -E "(^|/)$(printf '%s' "$f" | sed 's/[.[\*^$]/\\&/g')\$" \
+          /tmp/run-touched.$$ | while read -r hit; do
+            echo "PROMOTE #$n -- this run touched $hit"
+          done
+      done
+done
+rm -f /tmp/run-touched.$$
+```
+
+Pipe the whole loop through `sort -u`: a body naming the same file twice prints
+twice, and the duplicate reads as two findings.
+
+**A hit is a prompt for judgement, not a verdict** -- measured on this run's own
+two deferrals, one hit on the single file its fix touches and the other hit on
+FOUR, three of which its body cited as precedent rather than as files to change.
+The check cannot tell a citation from a target, and should not try: its job is to
+put the issue back in front of you at the moment the answer has changed.
+
+A hit is still not something to skim past. Either do the item, or re-classify it in the issue
+with the reason the criterion no longer applies.
+
+**And re-read the REASON, not just the files, because a deferral reason can
+name a state that has since resolved.** The classify-once rule exists to stop
+the post-merge moment being re-litigated, and it is right — but it freezes the
+DECISION, not the PREMISE. A reason phrased in terms of the run's own transient
+state ("taking this at review round four is how a fifth round happens", "the PR
+carrying it is still open", "the lane holding that file is mid-flight") is true
+when written and FALSE the moment that state resolves. On 2026-08-26 exactly
+that shipped: an issue was deferred because its fix would have been a fifth
+round on a PR still in review, and the reason survived unchanged into the wrap
+report after that PR merged, where it read as a considered judgement. Re-reading
+a premise that has expired is not re-litigation; keeping a `next` alive on a
+reason that has stopped being true is.
+
 Then split the filed count by what the section 5 window did with each finding,
 because the aggregate cannot tell the two apart and they mean opposite things:
 


### PR DESCRIPTION
Two changes from one run's retrospective, both replacing an instruction that already
existed and was violated anyway with something that does not depend on the agent
remembering it.

## 1. The `next` -> `now` promotion becomes a QUERY

Section 10-0 already stops to run `gh issue list`. It now also intersects the paths each
issue this run FILED names against the run's own merged diff, and prints `PROMOTE #N` on a
hit.

Two rules already covered the case that went wrong. The `next` criterion "an independent
subsystem with no file overlap" carries the conjunct "AND none of the `now` criteria
fire", and CLAUDE.md requires promoting a `next` to `now` when the session ends up touching
those files anyway. Both were skipped, because at wrap time nobody re-opens a decision they
remember making deliberately. Section 10-b is explicit that another sentence does not fix
that — escalate rather than restate.

**Two defects were found by running the query against this run's own two deferrals**, and
both would have shipped from the first draft:

- the path regex allow-listed `(src|tests|docs|scripts)/`, which excludes `.claude/**` —
  and section 10 files INTO `.claude/skills/**`, so the run most likely to have a hit was
  exactly the one the grep could not see. In cdk-local `scripts/` does not exist at all.
  The directory allow-list is gone: the intersection with `git diff --name-only` already
  restricts matches to real tracked paths, so enumerating roots bought nothing and could
  only go stale per repo.
- the comparison was `grep -qxF`, an exact whole-line match against full paths, while issue
  bodies name files by BASENAME far more often. Measured: the exact form fired on one of
  the two deferrals and missed the other for precisely that reason. It is a suffix match
  now, and both fire.

The honest limit is stated rather than asserted: one of those two hit on FOUR files, three
of which its body cited as precedent rather than as files to change. The check cannot tell
a citation from a target and should not try — its job is to put the issue back in front of
you at the moment the answer has changed.

## 2. A deferral REASON can expire

Classifying once, when the item is created, is right — it is what stops the post-merge
moment being re-litigated. But it freezes the DECISION, and a reason phrased in terms of
the run's own transient state ("the PR carrying it is still open", "taking this now would
be a fifth review round") is true when written and FALSE the moment that state resolves.
This run shipped exactly that. Re-reading an expired premise is not re-litigation; keeping
a `next` alive on a reason that has stopped being true is.

## 3. `stop-unmerged-lane-warn.sh` — a NOT-CLOSEABLE verdict is not a stopping point

Same escalation, applied to the wrap report itself. Two rules already say it: a
NOT-CLOSEABLE verdict is a to-do list, and an agent that cannot name a signal which will
re-invoke it is STOPPED rather than WAITING. Both were violated repeatedly in one session —
turns ended with `Mode: WAITING` next to `Waiting on: none`, and with `Verdict: NOT
CLOSEABLE` in the same report as the stop. The maintainer had to ask twice.

So the verdict is computed from the REPO rather than from the agent's self-report, which is
the part that was wrong. On Stop, any linked worktree whose branch is ahead of
`origin/main` is named. The existing `stop-warn.sh` catches UNCOMMITTED work in the main
tree; this is the quieter half — a lane finished as far as the editor is concerned and
unfinished as far as the repo is.

Deliberately cheap: no `gh`, no `git fetch`. A Stop hook runs every turn, and a stale
`origin/main` can only UNDER-report, which is the safe direction.

## Verification

No `src/**` change, so this takes section 8's no-src tier — and BOTH arms of it, because
the diff does both:

- **prose arm** (SKILL.md): every claim resolved against this repo's own files. The two
  citations that exist only in cdkd were verified present here / absent in the siblings
  before being kept / dropped per repo.
- **command arm** (the hook): its own suite, run from beside the hook, fences both
  polarities — silent with no worktrees, silent for a worktree level with main, silent for
  a detached one, silent when `origin/main` is unresolvable, and naming each lane genuinely
  ahead. **Probed rather than asserted**: disabling the detection reds 3 of the 7 cases.

Full suite green. The `work-issues-skill-refs` fence (which validates the qualified
`go-to-k/cdkd#N` citation form) passes.
