### PR TITLE
chore(hooks): fence gh-pr-edit-deprecation-gate's command-position scoping, which issue 2037 reported as still missing

### DIFF
--- a/.claude/hooks/gh-pr-edit-deprecation-gate.sh
+++ b/.claude/hooks/gh-pr-edit-deprecation-gate.sh
@@ -29,6 +29,19 @@ cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
 # matcher (.claude/hooks/lib/command-match.sh, issue #2129): the old unanchored
 # form blocked `echo "next step: gh pr edit 1 --body foo"` — a measured false
 # positive on a command that never called gh — while missing nothing it caught.
+# Issue #2037 re-reported the same class from the other end: a `grep` pattern,
+# a `python3 - <<'PY'` heredoc body, or a test-case label that merely QUOTES the
+# deprecated spelling is data, not an invocation, and a PreToolUse denial aborts
+# the WHOLE call, so those runs did nothing at all. The shared matcher already
+# neutralises quoted spans and heredoc bodies before looking for the verb in
+# command position, so all four reported shapes pass; the suite beside this file
+# now pins them so a future rewrite cannot quietly reintroduce them.
+#
+# DELIBERATELY NOT SOLVED HERE: deciding policy by regex-matching shell text
+# leaves the set of bypass spellings unbounded (an alias, a variable holding the
+# verb, an interpreter reading the command off stdin). That class is tracked in
+# go-to-k/cdkd#2156 and is out of scope for this gate — the choice was made, not
+# missed.
 # shellcheck source=lib/command-match.sh
 _gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/command-match.sh"
 # Fail CLOSED: a gate that cannot evaluate the command must not wave it through.

--- a/.claude/hooks/gh-pr-edit-deprecation-gate.test.sh
+++ b/.claude/hooks/gh-pr-edit-deprecation-gate.test.sh
@@ -5,7 +5,19 @@
 # "is this a `gh pr edit` that sets --title / --body / --body-file". This suite
 # exists because issue #2129 measured the gate BLOCKING a command that never
 # called gh (`echo "next step: gh pr edit 1 --body foo"`), so both directions of
-# the match are now pinned. Run from the repo root:
+# the match are now pinned.
+#
+# Issue #2037 then reported four more DATA-position shapes measured in the wild
+# while editing this repo's own hook fixtures: a `grep` pattern, a
+# `python3 - <<'PY'` heredoc body, a `-f body=` string, and a `run_case` label.
+# All four are quoted text that cannot invoke anything, and a PreToolUse denial
+# aborts the WHOLE call, so blocking them ran nothing at all. They pass under the
+# shared matcher and are pinned below, PAIRED with the invocation twin of each so
+# a fix that merely stops refusing things cannot look green: every ALLOW case has
+# a BLOCK case one quote-removal away. The unbounded-bypass class (an alias, a
+# variable holding the verb) is go-to-k/cdkd#2156, deliberately not fenced here.
+#
+# Run from the repo root:
 #   bash .claude/hooks/gh-pr-edit-deprecation-gate.test.sh
 
 set -u
@@ -40,12 +52,42 @@ run_case "compound: git push && gh pr edit --body blocked" 2 \
 run_case "compound with echo first" 2 'echo start && gh pr edit 123 --body x'
 run_case "gh -C <path> pr edit blocked" 2 'gh -C /w/t pr edit 123 --body x'
 run_case "leading env assignment blocked" 2 'GH_PAGER=cat gh pr edit 123 --body x'
+# Issue #2037's `cd <worktree> &&` twin: this repo runs nearly every gated command
+# from a worktree, so losing that shape would make the gate miss its commonest form.
+run_case "cd <worktree> && gh pr edit --body blocked" 2 \
+  'cd /w/t && gh pr edit 123 --body x'
+run_case "semicolon-chained gh pr edit --body blocked" 2 \
+  'echo start; gh pr edit 123 --body x'
+run_case "subshell gh pr edit --body blocked" 2 '( gh pr edit 123 --body x )'
+# An interpreter's `-c` payload is CODE, not data: the quote is the interpreter's
+# argument syntax, so stripping it as a data span would be a real bypass.
+run_case "bash -c payload blocked" 2 "bash -c 'gh pr edit 123 --body x'"
+# Flag order is not part of the match: the verb decides, the flag scan is separate.
+run_case "flags before the number blocked" 2 'gh pr edit --body x 123'
+run_case "pipe target gh pr edit --body-file blocked" 2 \
+  'cat /tmp/b.md | gh pr edit 123 --body-file -'
 
 # --- PASS --------------------------------------------------------------------
 run_case "quoted mention does not fire" 0 'echo "next step: gh pr edit 1 --body foo"'
 run_case "single-quoted mention does not fire" 0 "echo 'run gh pr edit 1 --title x'"
 run_case "gh pr edit without title/body passes" 0 'gh pr edit 123 --add-label bug'
 run_case "gh pr create is not gh pr edit" 0 'gh pr create --body x'
+# --- PASS: the four DATA-position shapes issue #2037 measured in the wild -------
+# 1. the `grep` used to locate those labels (reported repro 2).
+run_case "grep pattern mentioning the verb does not fire" 0 \
+  "grep -n 'gh pr edit ' pr-body-item-number-gate.test.sh"
+# 2. a heredoc body carrying the spelling as a replacement anchor (reported repro 1).
+run_case "python3 heredoc body does not fire" 0 \
+  $'python3 - <<\'PY\'\ns = "gh pr edit 1 --body t"\nPY'
+# 3. the spelling inside the body TEXT of the prescribed replacement call.
+run_case "api PATCH body text mentioning the verb does not fire" 0 \
+  'gh api -X PATCH repos/o/r/pulls/1 -f body="do not use gh pr edit --body"'
+# 4. a test-case label quoting the verb, which is what this very file is made of.
+run_case "test-case label quoting the verb does not fire" 0 \
+  'run_case "gh pr edit --body blocked" 2 '\''gh pr edit 123 --body x'\'''
+# The replacement the block message prescribes must never be gated by its own gate.
+run_case "prescribed api PATCH replacement passes" 0 \
+  'gh api -X PATCH repos/o/r/pulls/1 -f title=T -F body=@/tmp/b.md'
 run_case "unrelated command passes" 0 'git status --short'
 run_case "empty command passes" 0 ''
 


### PR DESCRIPTION
## The issue's premise no longer holds, so the predicate is NOT touched

go-to-k/cdkd#2037 reported that this gate fires on the deprecated invocation's SPELLING anywhere in a Bash command string, so a `grep`, an edit script or a heredoc that merely NAMES the command is refused -- and because a PreToolUse denial aborts the whole call, those runs do nothing at all.

The gate now routes through `lib/command-match.sh`'s `gate_matches`, which landed with the convergence in go-to-k/cdkd#2129: it neutralises heredoc bodies and quoted spans as DATA first, then requires the verb in COMMAND POSITION (line start, or after `&&` / `||` / `;` / `|`). All four reported shapes were measured against this tree and all four pass:

| shape reported in the issue | rc on this tree |
| --- | --- |
| `grep -n '<the spelling>' file.sh` | 0 (allowed) |
| a `python3 - <<'PY'` heredoc whose body contains it | 0 (allowed) |
| `-f body="... <the spelling> ..."` | 0 (allowed) |
| a `run_case "<the spelling> ..."` test label | 0 (allowed) |

Changing the predicate now could only make it worse. What was genuinely missing is the FENCE.

## What this ships

The hook's own suite goes from 13 to 24 cases: the four reported shapes plus the recommended `gh api -X PATCH` replacement on the ALLOW side, and on the BLOCK side their **twins with exactly one quote removed** (`cd <worktree> &&`, a `;` chain, a subshell, `bash -c`, reordered flags, after a pipe). Pairing them is the point -- the ALLOW cases alone stay green under a gate that refuses nothing.

The hook itself gains comments only.

## Probes

Three, each written as a change a future contributor would plausibly make rather than as a re-plant of a removed line:

| mutation | red |
| --- | --- |
| a "belt and braces" raw grep added ABOVE the matcher | 7, including all four reported shapes |
| `gate_matches` replaced by a prefix `case` on the raw command -- the "just anchor it properly" change | 9 |
| the body-carrying flags dropped from the flag list | 12, with `--title` surviving, which proves the second stage is reached and discriminating |

The first run of the third probe was **discarded rather than reported**: the marker went in as a trailing comment and swallowed a `; then`, so every case failed on a syntax error and the result read as a single red. Caught by `bash -n` and re-run with the marker inside an identifier. A probe must prove not only that the mutation landed but that the path is still executable.

24/24 rc=0 under bash 5.3.9 and `/bin/bash` 3.2.57. Full `run-tests.sh`: 86 ok across 43 suites x 2 shells, 0 failures.

## Deliberately not solved here

The unbounded set of bypass spellings that follows from deciding policy by regex over shell text at all -- an alias, a variable-indirected verb, an interpreter reading a command from stdin. That is go-to-k/cdkd#2156, and it is now named in a comment in the hook so the scope decision is visible rather than looking like an oversight.

Closes go-to-k/cdkd#2037
