### PR TITLE
chore(hooks): make the Stop hook see the lane it is running inside

### DIFF
--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -22,18 +22,28 @@
 # alone separates "there is unmerged work here" from "there is not".
 set -u
 
+# BASH_SOURCE resolves to whichever checkout this copy of the hook lives in --
+# in a linked worktree that is the LANE, not the main tree. That is fine as a
+# place to run `git` from (every worktree shares one object store and one
+# `origin/main`), but it must NOT be used to decide which worktree to skip: the
+# session ending inside its own lane is the case this hook exists for, and an
+# earlier revision skipped exactly that one. Measured from a lane 5 commits
+# ahead: the hook printed nothing. The main tree is excluded by BRANCH below
+# (`main`/`master`), which is the property that actually identifies it.
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO" 2>/dev/null || exit 0
 
-# Cheap: no fetch. A stale `origin/main` can only UNDER-report (a branch whose
-# work already merged still looks ahead until the next fetch), and the failure
-# direction that matters is missing a real lane, not naming a merged one.
+# Cheap: no fetch. A stale `origin/main` can only OVER-report: `rev-list --count
+# origin/main..$br` only grows as `origin/main` ages, so a branch whose work has
+# already merged keeps reading as ahead. That is the safe direction -- the
+# failure that matters is MISSING a real lane, and staleness cannot cause it.
+# (An earlier revision of this comment said UNDER-report while its own
+# parenthetical described over-reporting; the parenthetical was the true half.)
 git rev-parse --verify origin/main >/dev/null 2>&1 || exit 0
 
 lanes=""
 while IFS= read -r wt; do
   [ -n "$wt" ] || continue
-  [ "$wt" = "$REPO" ] && continue
   br=$(git -C "$wt" branch --show-current 2>/dev/null) || continue
   [ -n "$br" ] || continue
   case "$br" in main | master) continue ;; esac
@@ -49,7 +59,10 @@ msg="WARNING: unmerged lane(s) still open -- a NOT-CLOSEABLE verdict is a TO-DO 
 Each branch below is committed but not on origin/main. If any is YOURS, you are not done: rebase, run the
 gates, open the PR, merge. If one belongs to another session, say which and why, rather than leaving it
 unexplained. And if you are ending the turn with nothing that will re-invoke you, the honest label is
-STOPPED, not WAITING."
+STOPPED, not WAITING.
+One false positive is expected and is cheap to clear: this repo SQUASH-merges, so a merged branch never
+becomes an ancestor of origin/main and keeps reading as ahead. If a lane below is already merged, the
+remaining work is to remove its worktree and delete the branch -- not to open another PR."
 
 payload=$(printf '%s\n%s' "$msg" "$lanes" |
   python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -42,7 +42,17 @@ print(sum(1 for line in msg.splitlines() if line.startswith("  ")))
 '
 }
 
-SANDBOX="$(mktemp -d)"
+# `pwd -P` is load-bearing, not tidiness. On macOS `mktemp -d` hands back a
+# path under `/var/folders/...` whose real location is `/private/var/...`, and
+# the hook derives its own root with `cd ... && pwd`, which canonicalises. Git,
+# meanwhile, records a worktree under whatever path it was CREATED with. So an
+# uncanonicalised sandbox makes the hook's root and git's listing two spellings
+# of one directory that never compare equal -- and any case whose subject is an
+# equality between those two paths passes no matter what the hook does. That is
+# how the self-lane case below was measured VACUOUS on its first attempt: the
+# defect it was written for (a skip keyed on the hook's own checkout) could be
+# reintroduced and the suite stayed green.
+SANDBOX="$(cd "$(mktemp -d)" && pwd -P)"
 trap 'rm -rf "$SANDBOX"' EXIT
 
 REPO="$SANDBOX/repo"
@@ -79,6 +89,44 @@ git -C "$REPO" worktree add -q "$REPO/wt-two" -b feat/two HEAD
 git -C "$REPO/wt-two" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
 out=$(cd "$REPO" && bash "$RUN")
 check "names both lanes, not the detached worktree" "2" "$(lanes_in "$out")"
+
+# --- FIRES: run from INSIDE a lane worktree, that lane must still be named. ---
+# The case the hook exists for, and the one every case above misses: they all
+# `cd "$REPO"` (the main tree), so a skip keyed on the hook's OWN checkout was
+# invisible to all seven of them. An earlier revision derived the skip from
+# `BASH_SOURCE` and went silent for exactly this run. The main tree is excluded
+# by BRANCH, so removing that skip costs nothing here -- which this case pins
+# from the other side, by asserting the count is 2 rather than 3.
+mkdir -p "$REPO/wt-two/.claude/hooks"
+cp "$HOOK" "$REPO/wt-two/.claude/hooks/"
+out=$(cd "$REPO/wt-two" && bash "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")")
+check "names its OWN lane when run from inside it" "2" "$(lanes_in "$out")"
+if printf '%s' "$out" | grep -q 'feat/two'; then
+  pass=$((pass + 1)); printf 'OK   the self-lane is the one named\n'
+else
+  fail=$((fail + 1)); fail_log+="FAIL the self-lane is not named\n"; printf 'FAIL the self-lane is named\n'
+fi
+
+# --- SILENT: the main tree ON `main`, ahead of origin/main, is NOT a lane.
+# Without this the `main`/`master` filter is unfenced: everywhere else in this
+# sandbox the main tree is LEVEL with origin/main, so the ahead-count check
+# already excludes it and deleting the branch filter changes nothing. Measured:
+# with this case absent, dropping `case "$br" in main|master) continue` left the
+# suite green. Direct commits on `main` are a different problem with its own
+# gate; this hook reports unmerged LANES.
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 'on main'
+out=$(cd "$REPO" && bash "$RUN")
+check "the main tree on main is not a lane even when ahead" "2" "$(lanes_in "$out")"
+
+# --- The BRANCH filter, not the path, is what excludes the main tree. Put the
+# main tree on a feature branch that is ahead and it must be named like any
+# other lane; otherwise the two filters mask each other and neither is fenced.
+git -C "$REPO" checkout -q -b feat/main-tree-lane
+git -C "$REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+out=$(cd "$REPO" && bash "$RUN")
+check "the main tree on a feature branch is a lane too" "3" "$(lanes_in "$out")"
+git -C "$REPO" checkout -q -
+git -C "$REPO" branch -q -D feat/main-tree-lane
 
 # --- The payload has to be valid JSON, or the harness swallows it silently. ---
 if printf '%s' "$out" | python3 -c 'import json,sys; json.loads(sys.stdin.read())' 2>/dev/null; then

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -12,12 +12,17 @@ paths:
 vp run test:hooks     # or: bash .claude/hooks/run-tests.sh
 ```
 
-Most hooks in this file ship a `*.test.sh` smoke suite next to them (39 suites
-for 41 hooks, counting `run-tests.sh` as the runner rather than a hook — only
-`post-merge-sync-reminder` and `stop-warn` have none; `gh-label-validity-gate`
-and `gh-pr-edit-deprecation-gate` gained theirs after the issue #2050 count this
-sentence used to carry, and `stop-warn` is now covered by the markgate-gate-name
-CLASS fence below even though it has no suite of its own), and the runner executes
+Most hooks in this file ship a `*.test.sh` smoke suite next to them (**40 of the
+42** hooks do, counting `run-tests.sh` as the runner rather than a hook — only
+`post-merge-sync-reminder` and `stop-warn` have none, and `stop-warn` is covered
+by the markgate-gate-name CLASS fence below despite having no suite of its own).
+`.claude/hooks/` holds 42 `*.test.sh` files rather than 40, because two of them
+— `markgate-gate-name-class` and `unresolved-target-class` — are CLASS fences
+whose subject is every hook at once rather than one named hook, so they pair
+with no `.sh` of the same name. Recount rather than trusting this sentence:
+`ls .claude/hooks/*.sh | grep -v '\.test\.sh$'`. It has now been stale twice —
+at 39/41 while the tree held 42 hooks, because a PR that ADDS a hook and its
+suite has no reason to look here. The runner executes
 every suite that exists under **every bash on the machine** — `bash` from PATH (Homebrew 5.x on a dev Mac) and `/bin/bash`
 (macOS's system **3.2**).
 Both matter because the hooks are `#!/usr/bin/env bash`: on a machine without a
@@ -346,6 +351,55 @@ Two suites whose subject is EVERY hook at once -- the unresolved-target-director
 sweep (issue 2027) and the gate-name fence (issue 2198) -- live in
 [hooks-class-fences.md](hooks-class-fences.md), loaded when you touch one of
 them or the shared matcher.
+
+## Stop hooks
+
+Two hooks fire on `Stop` rather than on a tool call, and they split the same
+question -- "is there work here that is not finished?" -- along the axis of
+whether it has been committed.
+
+- **`.claude/hooks/stop-warn.sh`** covers the UNCOMMITTED half in the main tree.
+- **`.claude/hooks/stop-unmerged-lane-warn.sh`** covers the quieter half: a
+  linked worktree whose branch is COMMITTED but still ahead of `origin/main` --
+  a lane that is finished as far as the editor is concerned and unfinished as
+  far as the repo is. Non-blocking; it emits a `systemMessage` naming each such
+  branch, its commit count and its worktree.
+
+  Why a hook rather than another sentence: `CLAUDE.md` already says a
+  NOT-CLOSEABLE verdict is a to-do list and not a stopping point, and already
+  says that a turn with no signal that will re-invoke you is STOPPED and not
+  WAITING. Both were violated repeatedly in one session on 2026-08-26 -- turns
+  ended with `Mode: WAITING` next to `Waiting on: none`, and with
+  `Verdict: NOT CLOSEABLE` in the same report as the stop. Per the escalation
+  rule, a rule already in the text that gets violated anyway is not made
+  load-bearing by a third spelling of it, so this computes the verdict from the
+  REPO instead of from the agent's own self-report -- which is the part that was
+  wrong. Deliberately does NOT call `gh` and does NOT fetch: it runs every turn,
+  and a stale `origin/main` can only UNDER-report, which is the safe direction.
+
+  **It shipped INERT for its own primary case** (go-to-k/cdkd#2279, fixed in the
+  follow-up). It derived its root from `BASH_SOURCE` and skipped the worktree
+  that matched -- intended to skip the main tree, but in a linked worktree
+  `BASH_SOURCE` IS the lane, so the session ending inside its own unmerged lane
+  got nothing. Measured in the sibling cdk-local from a lane five commits ahead:
+  EMPTY. The main tree is identified by BRANCH (`main` / `master`), which the
+  loop already checks, so the path skip was redundant AND the entire defect. All
+  seven original cases ran the hook from the sandbox's MAIN tree, which is why
+  none of them could see it.
+
+  Its suite carries one trap worth knowing before editing it. On macOS
+  `mktemp -d` returns a `/var/folders/...` path whose real location is
+  `/private/var/...`; the hook canonicalises its own root with `cd && pwd` while
+  git records a worktree under the path it was CREATED with, so the two
+  spellings never compare equal and any case whose subject IS that equality
+  passes no matter what the hook does. The self-lane case was measured VACUOUS
+  on its first attempt for exactly that reason. The sandbox root is therefore
+  `cd "$(mktemp -d)" && pwd -P`.
+
+  One false positive is expected and is named in the warning text itself: this
+  repo squash-merges, so a merged branch never becomes an ancestor of
+  `origin/main` and keeps reading as ahead until its worktree is removed. The
+  remedy there is `git worktree remove` plus `git branch -D`, not another PR.
 
 ## Uncommitted-work safety (multi-session)
 


### PR DESCRIPTION
Follow-up to go-to-k/cdkd#2279, which shipped this hook with a defect that made it inert for its own primary case. The same fix went to go-to-k/cdk-real-drift#1823 (merged) and go-to-k/cdk-local#573, whose copies carry the identical line.

## The defect

`stop-unmerged-lane-warn.sh` derived `REPO` from `BASH_SOURCE` and skipped the worktree it matched. The intent was to skip the main tree. The effect was the opposite: in a linked worktree `BASH_SOURCE` IS the lane, so the session ending inside its own unmerged lane -- exactly what the hook exists to catch -- got nothing.

Measured in the sibling cdk-local, whose copy is the same code, from a lane worktree five commits ahead: the hook printed EMPTY.

The main tree is identified by BRANCH (`main` / `master`), which the loop already checks, so the path skip was both redundant and the entire defect.

## Why no case caught it

All seven cases ran the hook from the sandbox's MAIN tree, so a skip keyed on the hook's own checkout was invisible to every one of them. Three cases now cover it:

- the hook run from INSIDE a lane worktree, which must still name that lane;
- a main tree ON `main` and ahead of `origin/main`, which must stay SILENT (direct commits to main are a different problem with their own gate);
- a main tree put on a FEATURE branch, which must be named like any other lane -- pinning that the filter is by branch and not by path.

## The first attempt at that case passed while proving nothing

On macOS `mktemp -d` returns a `/var/folders/...` path whose real location is `/private/var/...`. The hook canonicalises its own root with `cd && pwd`; git records a worktree under whatever path it was CREATED with. The two spellings never compare equal, so a case whose subject IS that equality cannot fail. Reintroducing the skip left the suite green. The sandbox root is now `cd "$(mktemp -d)" && pwd -P`.

The branch filter was unfenced for a second, independent reason: everywhere else in the sandbox the main tree is LEVEL with `origin/main`, so the ahead-count check already excluded it and deleting the filter changed nothing.

## Two more corrections

- **A backwards comment.** The hook said a stale `origin/main` "can only UNDER-report" while its own parenthetical described over-reporting. `rev-list --count origin/main..$br` only GROWS as `origin/main` ages, so staleness over-reports. That is still the safe direction -- staleness cannot cause a real lane to be missed -- and the comment now says so rather than the opposite.
- **The squash false positive is now named in the warning itself.** This repo squash-merges, so a merged branch never becomes an ancestor of `origin/main` and keeps reading as ahead until its worktree is removed. Without that line the hook tells the reader to open a PR for work already on main.

## Docs

The hook was never documented in `.claude/rules/hooks.md` at all, so it now has an entry there covering the split with `stop-warn.sh`, the defect above, the sandbox canonicalisation trap and the squash false positive.

That file's suite count was also wrong: it read "39 suites for 41 hooks" while the tree holds **42 hooks and 42 `*.test.sh` files** -- 40 of the hooks have one, and two of the suites (`markgate-gate-name-class`, `unresolved-target-class`) are CLASS fences pairing with no hook of the same name. It has now been stale twice, because a PR that ADDS a hook plus its suite has no reason to look there, so the sentence carries the one-line recount instead of asking to be trusted.

## Verification

Probed rather than asserted, each probe restoring first and the restore verified:

| mutation | measured |
|---|---|
| reintroduce the `BASH_SOURCE` skip | 3 fail |
| drop the `main` / `master` filter | 1 fail |
| revert the sandbox to a bare `mktemp -d` AND reintroduce the skip | **11/0 -- vacuous**, which is why `pwd -P` is load-bearing |

11 pass / 0 fail under bash 5.x and macOS system bash 3.2. Full `run-tests.sh` green under both. `vp run check` rc 0, `vp run build` rc 0, full suite **807 files / 16624 tests** green.
