### PR TITLE
fix(local): derive the layer-ARN partition from its region instead of listing three of eight

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -179,7 +179,7 @@ local-invoke-from-cfn-stack	2026-07-26T21:13:17Z	PASS	94	verify.sh	re-run post r
 local-invoke-from-cfn-stack-multi-stack	2026-07-26T21:13:17Z	PASS	113	verify.sh	re-run post review fixes; docker + account + CFn clean
 local-invoke-from-state	2026-08-26T03:18:49Z	PASS	79	verify.sh	PR #2194 integ-local gate (local-state-loader in scope); Docker + real-AWS from-state, 0 err 0 orphans
 local-invoke-java	2026-07-26T20:29:11Z	PASS	36	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean
-local-invoke-layers	2026-07-26T20:29:11Z	PASS	17	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean
+local-invoke-layers	2026-08-27T05:00:40Z	PASS	18	verify.sh	issue 2143 lane, 4th run. Re-run not because this lane changed: origin PR 2296 edited tests/integration/local-run-task-from-state/verify.sh, which is inside integ-local's include, and that gate is hash:files so a peer's already-gated change invalidates it. This lane's three in-scope files are byte-identical across the round. 4/4; docker sweep (ps -a + both network filters) empty.
 local-invoke-provided	2026-07-26T20:29:11Z	PASS	32	verify.sh	0727b sweep-L4 staleness re-run (rc=0); docker + account clean
 local-invoke-python	2026-07-26T20:22:00Z	PASS	23	verify.sh	0727b sweep-L3 staleness re-run (rc=0); docker + account clean
 local-invoke-ruby	2026-07-26T20:22:00Z	PASS	33	verify.sh	0727b sweep-L3 staleness re-run (rc=0); docker + account clean

--- a/docs/changelog-cdkd.md
+++ b/docs/changelog-cdkd.md
@@ -22,6 +22,174 @@ The CLAUDE.md `## Known Limitations` section retains the load-bearing summary
   **The probe has three outcomes and all three are distinct.** Answered-and-matching proceeds silently; answered-and-differing refuses non-retryably -- the marker is honoured by BOTH loops that wrap a `delete()`, the destroy path's own loop at `destroy-runner.ts:1328` (FOUR attempts -- `attempt` runs 0..`maxAttempts` and `maxAttempts` is 3 at `:1326` -- with the marker gating both retryable arms at `:1372`) and the deploy engine's `withRetry` (`retry.ts:332`) on the replacement-delete path; a probe that CANNOT answer proceeds but warns at default verbosity, because refusing would strand destroys for least-privilege roles while proceeding silently would let a bucket policy denying `s3:GetBucketLocation` -- settable by anyone holding `s3:PutBucketPolicy` on the target -- disable the guard with output identical to a normal destroy. An unresolvable SDK region chain gets that same treatment (the resolution is inside the `try`), so the guard cannot fail CLOSED on one undeterminable input while failing open on every other. An ABSENT bucket is a fourth case and is deliberately not the warning one: it falls through to the existing `NotFound` / `assertRegionMatch` handling, so an ordinary re-run of a finished destroy stays quiet. Absence is read from the wire CODE alone, never a message, so a bare 404 from a proxy or an S3-compatible gateway cannot be mistaken for a positive statement about a bucket's region. The probe deliberately omits `ExpectedBucketOwner`, unlike `state.ts` and `utils/aws-region-resolver.ts` which both pass it: those ask "is this MY bucket", while this one has to HEAR the foreign answer to refuse, so restoring the convention would turn every cross-account collision from a refusal into a 403 and thence into warn-and-proceed. The refusal's remedy names correcting the state record rather than re-running with `--region`, because the comparand is the region stored in state and the flag does not change it.
   31 unit cases. Both polarities of the routing decision are asserted, and the split is exact rather than uniform: `AWS::S3::Bucket` plus TWO control types (`AWS::SQS::Queue`, `AWS::DynamoDB::Table`) are driven through `delete()` end to end and must issue `DeleteResource` with no probe and no new IAM dependency, while FIVE further control types (`AWS::Lambda::Function`, `AWS::EC2::Instance`, `AWS::AutoScaling::AutoScalingGroup`, `AWS::S3::BucketPolicy`, `AWS::S3Express::DirectoryBucket`) are asserted against the exported predicate only. The us-east-1 fold is pinned across all THREE wire spellings -- an ABSENT field, `''`, and `null` -- because AWS's own API documentation calls a us-east-1 bucket's constraint `null` (verbatim in `@aws-sdk/client-s3`'s `models_0.d.ts:6806`, and what the CLI renders) -- but that sentence is the doc comment ON the field, and the DECLARED type four lines BELOW it, at `models_0.d.ts:6810`, is `GetBucketLocationOutput.LocationConstraint?: BucketLocationConstraint | undefined`. `null` is not in that union, so a v3 client can present the same fact as an absent field. (An earlier revision of this entry cited `:1581`, which is `CreateBucketConfiguration` -- the CreateBucket INPUT -- and placed it "above" rather than below.) A fixture that can only express `null` shares its premise with the production code, which is the one thing a mutation probe cannot falsify. Every fold gets both polarities, so an OVERfold is caught as well as an underfold (`eu-central-1` must not read as the legacy `EU` alias). **Twenty-three** mutations, applied one at a time and restored between, and the counts below were re-measured in one batch on the exact tree this entry ships with -- the two files as committed here, `shasum` (SHA-1) `c3f449d5b323...` for `cloud-control-provider.ts` and `ef6f2822692d...` for the test -- rather than patched from an earlier round -- every count in an earlier revision of this sentence had drifted low, because four cases were added after it was written. Every mutation reds at least one case, none is a no-op, and all 31 cases are reddened by at least one mutation (computed as a set difference over the run logs, not by inspection). Emptying the type set reds 24, removing the guard call 23, inverting the comparison 22, moving the guard AFTER the delete is issued 8, dropping the us-east-1 fold 6, preferring the client region over the state's 5, widening the type set to two control types 3, gating the guard on `removeProtection !== true` 3, downgrading the indeterminate warn to `debug` 2, treating a `null` constraint as the only absent spelling 2, and 1 each for: moving the guard BELOW all three `--remove-protection` blocks, making the injected protection entry inert, dropping `markNonRetryable`, collapsing absent into indeterminate, matching absence by message instead of wire code, dropping the `EU` fold, overfolding `eu` by prefix, dropping the region canonicalization, dropping the empty-region normalization, hoisting the client-region `await` out of its `try`, dropping either `.trim()` (one each), and reverting the remedy wording. **One ordering claim was asserted, probed, and found FALSE before shipping.** An earlier revision said the guard's placement ahead of the `--remove-protection` flips was "fenced by a unit case"; moving the call below all three protection blocks left the suite fully green -- as it still does on any tree without the injected case described next. With the production tables the order is unobservable -- `AWS::S3::Bucket` has no `cc-protection-properties.ts` entry and is neither SDK-delegating type, so nothing mutating precedes the probe and "zero Cloud Control traffic on a refusal" fences only a mutation that SKIPS the guard. The test now injects a `ccProtectionProperty` entry for the bucket type (test-side only, no production routing changed) so the delete has a real `UpdateResourceCommand` to issue first, plus a guard-the-guard case proving the injection reaches the provider; the ordering mutation now reds. The two SDK delegations remain unfenced, deliberately -- fencing them would mean putting a delegating type into the checked set, which is a routing change rather than a test. **Live arm:** `tests/integration/s3-lifecycle` phase 0c plants two hand-written single-resource state records -- the defect's actual premise, a record written before the guards existed -- one naming a bucket really in this region (the negative control, which must still delete through the Cloud Control route, and without which the other arm would pass on any malformed-state failure) and one naming a per-run unique bucket in another region, asserted on the refusal text AND on the bucket still standing afterwards. Both bucket names are per-run unique because a name that has existed in one region answers `OperationAborted` for well over ten minutes if re-created in another. **The arm has RUN against real AWS** and its result is on record in `docs/_generated/integ-last-run.tsv` (`s3-lifecycle`, 2026-08-26T19:01:39Z, PASS, 226s), the run taken AFTER the phase-0c-XR premise read gained its rc capture and dropped its `2>&1` fold: the XR arm refused with rc=2 naming both regions and the us-west-2 bucket survived, while the OK control arm still deleted through the Cloud Control route, so the guard is not a blanket refusal -- 7 deleted, 0 errors, an account-wide `state.json` count of 0 and no leftover buckets in either region. **Accepted residual, with its mechanism CORRECTED:** `CloudControlProvider.update()` is NOT guarded. An earlier revision of this entry said `ResourceProvider.update` "carries no `DeleteContext`, so the state's region is not available there at all" -- the conclusion holds but the reason was false, and it overstated the cost of ever fixing it. `src/types/resource.ts:793-800` DOES give `update()` a sixth `context?: UpdateContext` parameter (this provider's own `update` merely does not declare it); what is missing is the FIELD, since `UpdateContext` (`resource.ts:502`, which also extends `SecretMaskingContext`) carries no region field at all while `expectedRegion` is declared on `DeleteContext` alone (`region-check.ts:27`). The remedy is therefore one optional field plus threading it from callers that already hold `state.region`, not a signature change across every provider -- a separate change with its own review, filed as issue [#2301](https://github.com/go-to-k/cdkd/issues/2301) together with the non-S3 CC delete types. The delete path is taken first because its consequence is unrecoverable where a misapplied configuration is not.
 
+- **A literal layer-version ARN now PARSES in all eight partitions instead of three, and its partition must agree with its region (issue [#2143](https://github.com/go-to-k/cdkd/issues/2143))** --
+  `src/local/lambda-resolver.ts`, `tests/unit/local/lambda-layer-arn-partitions.test.ts` (new),
+  `tests/integration/local-invoke-layers/{lib/local-invoke-layers-stack.ts,verify.sh}`,
+  `docs/local-emulation.md`.
+  `parseLayerVersionArn` matched
+  `/^arn:(aws|aws-cn|aws-us-gov):lambda:([a-z]{2}-(?:[a-z]+-){1,2}\d+):(\d{12}):layer:([A-Za-z0-9_-]+):(\d+)$/`,
+  which carried TWO independent defects. (1) The partition alternation listed
+  three of eight, so a layer ARN in `aws-iso`, `aws-iso-b`, `aws-iso-e`,
+  `aws-iso-f` or `aws-eusc` did not parse -- and the caller HARD-THROWS on an
+  unparsed ARN, so `cdkd local invoke` / `local start-api` on any function
+  with a literal-ARN layer failed AT RESOLUTION in five partitions. (2) The
+  region group required a first token of exactly two letters, the same
+  `^[a-z]{2}` shape issue [#2001](https://github.com/go-to-k/cdkd/issues/2001)
+  fixed in `state-file-keys.ts`, which rejects the European Sovereign Cloud
+  partition's four-letter `eusc-de-east-1`; it also capped the interior
+  `<word>-` chunks at two, an independent bound. Neither defect subsumes the
+  other: fixing the partition list alone still rejects `eusc-de-east-1`, and
+  fixing the region shape alone still rejects
+  `arn:aws-iso:lambda:us-iso-east-1:...`.
+  **The partition is now DERIVED from the region** through
+  `derivePartitionAndUrlSuffix` (`src/utils/aws-partition.ts`) rather than
+  hand-listed a fourth time, so the list cannot go stale here independently --
+  and that also makes the pair SELF-CONSISTENT, which no alternation can:
+  `arn:aws-cn:lambda:us-east-1:...` used to parse, pairing China's partition
+  with a commercial region. The region group stays SHAPE-based
+  (`[a-z]{2,}(?:-[a-z]+)+-\d+`) rather than becoming a charset, because
+  `derivePartitionAndUrlSuffix` answers `aws` for a region it does not
+  recognise: a charset would make `arn:aws:lambda:notaregion:...` parse. It is
+  still much wider than the set of real regions -- `garbage-junk-1` matches
+  where the old pattern refused it (measured) -- and that is deliberate, since
+  the segment's POSITION inside an `arn:` string already establishes it is the
+  region field, so unlike a state-key segment there is no second
+  interpretation for a loose match to steal. The commercial fallback is
+  otherwise the direction that must keep working -- a brand-new COMMERCIAL
+  region still resolves before the table hears about it, while a region in a
+  future partition is refused rather than mis-attributed to commercial, the
+  same trade every other consumer of that table makes. Deliberately NOT
+  `isClientSafeRegion` from `src/deployment/intrinsic-function-resolver.ts`:
+  that predicate is charset-based because its job is keeping a value inside a
+  hostname label, and the note it carries already says so.
+  **SCOPE: this fixes the PARSE, and the download behind it is still
+  commercial-only -- so "eight partitions" is a claim about resolution, not
+  about end-to-end support.** `materializeLayerFromArn`
+  (`src/local/layer-arn-materializer.ts`) is a one-line shim re-exporting
+  cdk-local's implementation, and that implementation rebuilds the ARN with a
+  hardcoded `aws` before the SDK call --
+  `node_modules/cdk-local/dist/local-studio-BBtUAVNy.js:15214`,
+  `` const command = await buildGetLayerVersionCommand(`arn:aws:lambda:${layer.region}:${layer.accountId}:layer:${layer.name}`, Number(layer.version)) ``.
+  So a layer in ANY of the seven non-commercial partitions still fails at
+  `lambda:GetLayerVersion` -- `aws-cn` and `aws-us-gov` included, and those two
+  are no better off than before, since they already parsed under the old
+  alternation. What this change moves is confined to the FIVE that previously
+  did not parse (`aws-iso`, `aws-iso-b`, `aws-iso-e`, `aws-iso-f`, `aws-eusc`):
+  for them the failure shifts from cdkd refusing to read a perfectly valid ARN
+  to an AWS-side error naming the real blocker. Nothing in this repo can close
+  the rest: it is filed as
+  [go-to-k/cdk-local#575](https://github.com/go-to-k/cdk-local/issues/575),
+  which also records that cdk-local's own `derivePartitionAndUrlSuffix` knows
+  only four of the eight prefixes.
+  **UPGRADE NOTE -- one shape that used to work now hard-throws.** A literal
+  layer ARN whose partition disagrees with its region --
+  `arn:aws-cn:lambda:us-east-1:...`, `arn:aws:lambda:cn-north-1:...`,
+  `arn:aws-us-gov:lambda:us-east-1:...` -- parsed before and is now refused
+  with `cdkd cannot resolve locally`. This is deliberate and was asked for by
+  the issue's own direction ("which also makes the pair self-consistent"). It
+  costs nothing real: because of the commercial-ARN rebuild above, such a
+  layer could never have been fetched from the partition its ARN named, so the
+  refusal only moves an inevitable failure earlier and gives it a message that
+  says what is wrong. A correctly-paired ARN in any partition is unaffected.
+  The refusal message gained one sentence for exactly this class, and only for
+  it -- every other rejection is visible in the ARN a user is looking at
+  (a missing version, a 13-digit account, `function` where `layer` belongs)
+  whereas a mismatch looks ordinary. The sentence has TWO arms, because
+  `derivePartitionAndUrlSuffix` answers `aws` both for a genuinely commercial
+  region and for one no `PARTITION_TABLE` prefix matches: on a table HIT it
+  states membership as fact (`...which is in partition 'aws-eusc'.`), and on a
+  MISS it states the RESOLUTION instead (`...no partition prefix matches that
+  region, so cdkd resolves it to the commercial partition 'aws'.`). A single
+  assertive arm would tell a user that
+  `arn:aws-iso-g:lambda:us-isog-east-1:...` "is in partition 'aws'", which is
+  a guess asserted as fact. **Which arm is which is easy to get backwards, and
+  the first cut of this split did**: `PARTITION_TABLE` holds seven rows and
+  none of them is `aws` -- the commercial partition is the fallback `return`,
+  not a row -- so the MISS arm is the arm every genuinely commercial region
+  takes, and the HIT arm can never render `aws` at all. Its first wording,
+  "no partition prefix **cdkd knows** matches that region", was true of the
+  mechanism and read as cdkd failing to recognise `us-east-1`, which is both
+  the commonest AWS region and the canonical example this entry, the docs and
+  the integ fixture all use. Review caught it; the wording now leads with the
+  prefix test and ends on the resolution, and a unit negative pins the old
+  phrasing out.
+  **Tests treat this as the CLASSIFIER it is.** Hand-picked cases cannot fence
+  an accept/reject function -- a pattern widened until it accepts everything
+  satisfies every positive assertion ever written -- so the new suite runs a
+  DIFFERENTIAL fence: the pre-fix regex, transcribed from `origin/main` rather
+  than from memory, is run against the shipped code over 352 generated inputs
+  (10 partition strings x 28 region shapes, plus 72 structural malformations of
+  four self-consistent bases), and every difference must fall in an enumerated
+  intended class. Cells are classified by the value the NEW code returns, not
+  by the input's shape, so a total regression lands wholly in one bucket and
+  fails that bucket's predicate instead of being sorted into "expected" ones;
+  the predicate itself is an INDEPENDENT oracle built from `split(':')` /
+  `split('-')` plus a hand-written prefix table (pinned against
+  `PARTITION_TABLE`), so it cannot agree with the implementation by
+  construction. Each class carries a floor -- all five previously-missing
+  partitions present among the newly accepted, at least one `eusc-` region, at
+  least one region past the old `{1,2}` cap, at least 10 newly-rejected
+  mismatches (measured: 11 newly accepted, 40 newly rejected, 0 parsed-field
+  drift, 13 unchanged accepts, 288 unchanged rejects) -- so a pool that stops
+  covering a class cannot pass as "no regressions". On top of it: one case per
+  partition plus `eusc-de-east-1`, all driven through the REAL CALLER
+  (`resolveLambdaLayers`) so what is asserted is the hard-throw, and 16
+  negative controls that must still be REJECTED. Mutation-probed in three
+  directions, each half separately, because a single all-or-nothing revert
+  cannot show the two are independently fenced: reverting the PARTITION half
+  alone reds 10 (the five per-partition cases, the eusc pair, all three
+  mismatch controls, and the fence's newly-accepted predicate); reverting the
+  REGION half alone reds 4 (the eusc pair, the three-hyphen-group case, and the
+  fence's partition floor); widening the region to `[^:]+` with no derivation
+  check -- the "accepts everything" direction -- reds 10, nine of them negative
+  controls. Three more probe the message: collapsing the two arms into the
+  assertive one reds 2, emitting a hint for a shape rejection reds 1, and
+  unwiring the hint reds 3.
+  Structurally, ONE exported `classifyLayerVersionArn` now returns either the
+  segments or a TYPED rejection, and both the resolved layer's fields and the
+  error message read that one verdict -- so the message cannot describe a
+  different verdict than the parse reached. The first cut had the message
+  re-run the pattern in a separate helper, which left an arm -- "the partitions
+  agree" -- that the sole call site could never reach, since it only asked
+  after the parse had already refused; one classifier removes the arm rather
+  than justifying it, and runs the regex once. The old `parseLayerVersionArn`
+  export is GONE rather than kept as a wrapper, and the reason is worth
+  recording because the repo's own critic found it: once the resolver moved to
+  the classifier that wrapper had no `src/` caller left, and
+  `scripts/check-local-reachability.ts` (shipped days earlier by
+  [#2293](https://github.com/go-to-k/cdkd/pull/2293)) reported it as an
+  orphaned export -- 7 of its 39 cases red. Its opt-out tag would have been a
+  FALSE statement here, since it asserts cdk-local owns the live
+  implementation and cdkd owns this one, so the wrapper was deleted and the
+  `T | undefined` shape its cases were written against became a three-line
+  adapter inside `tests/unit/local/lambda-resolver.test.ts`. Naming that tag in
+  a JSDoc comment while explaining the decision then reported a STALE
+  annotation on a live symbol, which is the same critic working correctly from
+  the other side; the comment now describes the tag instead of spelling it.
+  The `local-invoke-layers` integ fixture gains a `MismatchedArnLayerHandler`
+  carrying `arn:aws-cn:lambda:us-east-1:...` and a fourth `verify.sh` test
+  asserting cdkd refuses it. That is the half of #2143 an integ CAN exercise --
+  the five previously-unsupported partitions have no endpoint reachable from a
+  normal dev account, whereas a mismatch is a purely local verdict with no
+  network call -- and what it adds over the unit matrix is that it runs the
+  SHIPPED `dist/` bundle, where a broken `src/local` -> `src/utils` import
+  would show up. It is discriminating rather than decorative: pre-#2143 that
+  ARN parsed and cdkd went on to attempt a `lambda:GetLayerVersion` download,
+  and the test asserts the refusal names the DERIVATION rather than merely
+  refusing -- a bundle whose layer parse broke wholesale would also refuse.
+  **`docs/local-emulation.md` is corrected as part of this, and the correction
+  predates this issue**: its "Lambda Layers" section still listed literal-ARN
+  entries under "Out of scope (v1) -- hard-errors", and its v1-scope table
+  still deferred them to a "Future PR", both of which stopped being true when
+  issue [#448](https://github.com/go-to-k/cdkd/issues/448) shipped literal-ARN
+  resolution. They now describe what ships -- the download-and-merge flow, the
+  partition rules with the commercial-only download limitation called out
+  beside them, and `--layer-role-arn`, which existed as a flag but appeared in
+  no documentation at all and is now in both the `local invoke` and the
+  `local start-api` flag tables.
+
+---
+
 **Recently Implemented** (2026-08-26):
 - **The custom-resource poll no longer debug-logs the first 200 bytes of the response body, so a generated secret in `Data` never reaches `--verbose` output (issue [#2250](https://github.com/go-to-k/cdkd/issues/2250))** -- `src/provisioning/providers/custom-resource-provider.ts`, plus `tests/unit/provisioning/custom-resource-provider-response-body-log.test.ts`. Each poll of the pre-signed S3 response key used to log `body.substring(0, 200)` of the CloudFormation custom-resource response document. `Data` is the documented place a handler returns a GENERATED VALUE -- including a generated secret -- so behind a short `PhysicalResourceId` those values landed inside the 200-character window and reached the terminal and, in CI, the retained build log. It fired for EVERY custom-resource response, gated only by `--verbose`. The line now renders the non-sensitive ENVELOPE instead: `Status`, `PhysicalResourceId` (already persisted to `state.json`, so not a new channel) and `Object.keys(Data)` -- never a `Data` value, and never `Reason`, which is free-form handler text that can quote them. Every one of those fields is HANDLER-CONTROLLED, so each goes through `displaySafe` (issue [#2170](https://github.com/go-to-k/cdkd/issues/2170)) and a 200-character cap before it is rendered -- both regressions this change introduced and a review caught. The line it replaced printed raw WIRE json, where the encoder had already escaped control characters and where `substring(0, 200)` bounded the output by construction; parsing first UNDOES the escaping, so an ESC and a newline reach the terminal as real bytes and anyone holding the pre-signed response URL could clear the screen and print a forged `ERROR [cdkd]` line into a CI transcript. Dropping the substring removed the bound as well: a 5000-character id with 300 `Data` keys rendered a 19,714-character line, re-emitted on EVERY poll of a resource that can run for an hour. The body stays UNTRUSTED input: the parse is hoisted above the log so one result feeds both the summary and the terminal-status check, but the log still fires for a body that does not parse -- reporting the body's LENGTH only -- because a malformed response is exactly when the diagnostic is worth most; a body that parses to a JSON scalar / array / `null` gets its own summary rather than an envelope-shaped read of it. An earlier write-to-every-reader trace concluded this log line was the ONLY reader emitting the payload and that the body is never written to `state.json`; the second half is FALSE and was relayed here without being re-derived. `cfnResponse.Data` becomes `attributes` (`custom-resource-provider.ts:1128` / `:1208`) and is persisted into `ResourceState.attributes`, so a generated secret ALSO sits in plaintext in the state record -- a durable channel strictly worse than this transient one, filed as [#2274](https://github.com/go-to-k/cdkd/issues/2274). What this entry closes is the `--verbose` channel, not the exposure as a whole. gc's placeholder sweep really is metadata-only. The four new cases assert the RENDERED line (captured at the `console.debug` boundary of a REAL `ConsoleLogger` at debug level, not a `vi.fn()` that would record any argument handed to it), covering the envelope, an unparseable body, a non-object JSON body and an object missing the protocol fields.
 - **`cdkd drift --json` now puts the payload and nothing else on stdout, so `--accept` / `--revert` output parses (issue [#2230](https://github.com/go-to-k/cdkd/issues/2230))** -- `src/utils/logger.ts`, `src/cli/commands/drift.ts`, `docs/cli-reference.md`, plus `tests/unit/cli/drift-json-stream.test.ts` and `tests/unit/utils/logger-stdout-reservation.test.ts`. `logger.info` / `logger.debug` resolve to `console.info` / `console.debug`, which write to STDOUT -- the stream `writeJsonReport` prints the payload on -- so every human-facing line of the remediation path interleaved with the document. Measured against the real binary before the fix: `cdkd drift <stack> --json --accept` over a stack with one unreadable resource emitted 692 bytes on stdout and `JSON.parse` rejected it with `Unexpected non-whitespace character after JSON at position 331`; after, stdout is 331 bytes and parses, with the prose on stderr. The failure is silent in the worst direction, because the terminal shows exactly the same text either way. **Two mechanisms, because ONE could not cover both populations.** `reserveStdoutForPayload()` (new, opt-in, module-level in `logger.ts`) routes `info` / `debug` to `console.error` for the rest of the process; `drift.ts` calls it once when `options.json`, BEFORE `applyRoleArnIfSet`. It is module-level rather than an instance field because `child()` hands out fresh `ChildLogger` instances, and the lines a per-call-site fix in `drift.ts` structurally CANNOT reach live in exactly those: `applyRoleArnIfSet`'s `Assumed role ...` (`src/utils/role-arn.ts:286`, unconditional on any `--role-arn` run) and `S3StateBackend.saveState`'s legacy-migration notice (`src/state/s3-state-backend.ts:448`, reachable on `--accept` over a pre-v2 record). The plan printers and the confirmation prompt call `process.stdout.write` / `readline` directly, which no logger flag reaches, so they take a per-call-site `HumanTextSink` instead -- 13 `process.stdout.write` calls in `printAcceptPlan` / `printRevertPlan` plus `confirmPrompt`'s readline `output`. The lines are MOVED, never suppressed: an operator still sees the plan, the prompt, the `--dry-run` notice, `No drift detected -- nothing to accept.`, the `Comparison INCOMPLETE` block (issue [#2208](https://github.com/go-to-k/cdkd/issues/2208)), `State updated` and `Revert summary`, and `--verbose` debug output. Dropping them would satisfy a "stdout parses" assertion while losing what the confirmation is asking about, so every case asserts the line ARRIVED on stderr rather than merely left stdout. The reservation is OPT-IN and only `drift` opts in, so no other command's output contract moves -- `cdkd diff` already solved its own instance differently (`diff.ts:89-101` demotes the logger to `warn` under `--json`, which SUPPRESSES rather than moves). The new `drift` suite deliberately does NOT mock the logger, unlike the four sibling `drift` suites: a `vi.fn()` standing in for `getLogger()` answers the stream question by construction, which is why `drift.test.ts`'s two existing `--json` cases pass over the defect. Vitest also intercepts `console`, so its output reaches neither `process.stdout.write` nor `process.stderr.write` (probed); the suite therefore spies the console methods and funnels them into an ordered fd-1 / fd-2 transcript. Mutation-probed in both halves separately: disabling the logger route reddens 8 of 10 drift cases (the headline one with the issue's own `SyntaxError`) while both no-`--json` controls stay green, and forcing the sink to stdout reddens the 5 plan-bearing cases while the 3 logger-only ones stay green. **An audit of the other `--json` commands found the same mixing on six more subcommands, left unfixed here** as a cross-command output-contract change, and filed as issue [go-to-k/cdkd#2280](https://github.com/go-to-k/cdkd/issues/2280): `cdkd state list` / `state resources` / `state show` / `state info` (`--verbose` un-gates helper debug onto stdout, and `role-arn.ts:286` fires unconditionally), `cdkd list` (worst -- `src/synthesis/app-executor.ts:165` re-emits the CDK app's stderr at info level on a DEFAULT run), and `cdkd events` (`--json -v` only). `cdkd diff` is clean.

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -149,6 +149,7 @@ in the resolved stack so the user can copy/paste a valid one.
 | `--no-pull` | off | Skip `docker pull`. Semantics differ by code path: **ZIP Lambdas** — skip pulling the public Lambda base image. **Container Lambdas, local-build path** — no-op (docker build's default does not refresh the FROM cache). **Container Lambdas, ECR-pull fallback** — skip `docker pull` AND error if the image is not in the local cache (re-run without `--no-pull` or pre-pull manually). |
 | `--no-build` | off | Skip `docker build` on the **Container Lambdas, local-build path** (`Code.ImageUri`). Requires the deterministic `cdkd-local-invoke-<hash>` tag to already be in the local docker registry from a prior `cdkd local invoke` (or manual `docker build`); errors clearly when missing. **No-op for ZIP Lambdas** (no docker build runs there) AND for the **Container Lambdas, ECR-pull fallback** (use `--no-pull` to control that path). Compatible with `--no-pull`. |
 | `--ecr-role-arn <arn>` | — | Role ARN to assume before authenticating against ECR on the **Container Lambdas, ECR-pull fallback** path. Issues `sts:AssumeRole` via the default credential chain and uses the resulting temp creds for `ecr:GetAuthorizationToken` + `docker pull`. Required for cross-account pulls when the caller's identity does not already have direct cross-account access. Same-account / same-region pulls do not need this flag; cross-account without the flag falls back to the caller's credentials (succeeds when an IAM resource policy on the ECR repo grants the caller directly, else AWS surfaces `AccessDenied`). No-op when `--no-pull` is set. |
+| `--layer-role-arn <arn>` | — | Role to `sts:AssumeRole` before calling `lambda:GetLayerVersion` on every literal-ARN entry in `Properties.Layers` (issue [#448](https://github.com/go-to-k/cdkd/issues/448)). Use only when the developer's own credentials cannot read the layer — typically a cross-account layer. AWS-published public layers (e.g. Lambda Powertools) are readable from every account and need no role. No-op for stacks whose layers are all same-stack `AWS::Lambda::LayerVersion` references. |
 | `--debug-port <port>` | off | Set `NODE_OPTIONS=--inspect-brk=0.0.0.0:<port>` and publish the port; attach a Node debugger to step through the handler. |
 | `--container-host <host>` | `127.0.0.1` | Host to bind the RIE port to. |
 | `--assume-role [arn]` | off | STS-assume the deployed function's execution role and forward the resulting temp credentials to the container, so the handler runs under the deployed role's narrow permissions instead of the developer's typically-admin shell credentials. Three forms: (1) `--assume-role <arn>` assumes the explicit ARN (precedence wins); (2) `--assume-role` (bare) auto-resolves the function's `Properties.Role` from cdkd state (requires `--from-state`); (3) `--no-assume-role` explicitly opts out (forces dev creds even with `--from-state`). Off by default — when omitted, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` / `AWS_REGION` are passed through unchanged (SAM-compatible default). STS failures degrade to a warn + dev-creds fallback. |
@@ -378,12 +379,52 @@ Same-stack `AWS::Lambda::LayerVersion` references in
    `/opt/nodejs/...`, `/opt/lib/...`, etc.) is the user's
    responsibility — cdkd does NOT inspect the contents.
 
+**Literal-ARN layer entries** (issue
+[#448](https://github.com/go-to-k/cdkd/issues/448)): a `Layers` entry
+that is the string
+`arn:<partition>:lambda:<region>:<account>:layer:<name>:<version>` is
+resolved by downloading that layer version's ZIP and unzipping it into a
+host tmpdir, which then joins the same `/opt` merge as same-stack layers
+— so "last layer wins" holds across both kinds. This covers
+AWS-published public layers (Lambda Powertools, the Datadog extension)
+and cross-account / cross-region shared layers. Pass
+`--layer-role-arn <arn>` to `sts:AssumeRole` before
+`lambda:GetLayerVersion` when the developer's own credentials cannot
+read the layer — typically a cross-account one; AWS-published public
+layers are readable from every account and need no role.
+
+The ARN's **partition is derived from its region** rather than matched
+against a hardcoded list, so the ARN in any of the eight partitions —
+commercial, `aws-cn`, `aws-us-gov`, `aws-iso`, `aws-iso-b`, `aws-iso-e`,
+`aws-iso-f`, `aws-eusc` — now PARSES; before issue
+[#2143](https://github.com/go-to-k/cdkd/issues/2143) only three did, and
+the other five were refused outright at resolution. The two segments must
+also AGREE: `arn:aws-cn:lambda:us-east-1:...` is refused, naming the
+disagreement, because `us-east-1` does not belong to `aws-cn`. A region
+cdkd's partition table does not recognise resolves to the commercial
+partition, so a brand-new commercial region keeps working with `arn:aws:`.
+
+> **Parsing is not the whole path, and the rest is still commercial-only.**
+> The download itself runs through cdk-local, which rebuilds the ARN with a
+> hardcoded `aws` partition before calling `lambda:GetLayerVersion`
+> (`node_modules/cdk-local/dist/local-studio-BBtUAVNy.js:15214` —
+> `` `arn:aws:lambda:${layer.region}:${layer.accountId}:layer:${layer.name}` ``).
+> So a layer ARN in any of the seven non-commercial partitions gets past
+> cdkd's parse and then fails at the AWS call instead. `aws-cn` and
+> `aws-us-gov` already parsed before this change and gain nothing from it;
+> for the five that did not (`aws-iso`, `aws-iso-b`, `aws-iso-e`,
+> `aws-iso-f`, `aws-eusc`) what changed is WHICH failure you get — an
+> AWS-side error naming the real blocker, rather than cdkd refusing to read
+> the ARN at all. End-to-end support for those partitions needs the fix
+> tracked in
+> [go-to-k/cdk-local#575](https://github.com/go-to-k/cdk-local/issues/575).
+
 **Out of scope (v1)** — hard-errors with a clear pointer at the
 offending entry:
 
-- Literal-ARN layer entries (`arn:aws:lambda:...`) — these are external
-  / pre-existing layers including cross-account / cross-region. No
-  asset on disk to mount; deferred to a follow-up PR.
+- Layer entries that are neither a same-stack reference nor a
+  well-formed layer-version ARN (a malformed ARN, a function ARN, an
+  unversioned layer ARN, or a partition that disagrees with the region).
 - Same-stack refs that don't point at an `AWS::Lambda::LayerVersion`
   (typo'd logical ID).
 - Same-stack refs to a `LayerVersion` whose `Metadata['aws:asset:path']`
@@ -474,7 +515,7 @@ to `cdkd local start-service` / `cdkd local start-alb`.
 | Out of scope | Deferred to |
 | --- | --- |
 | Java / Go / Ruby / .NET runtimes | Future PRs |
-| Cross-account / cross-region / pre-existing-ARN Lambda Layers | Future PR (same-stack `AWS::Lambda::LayerVersion` refs are supported in v1; literal ARNs hard-error — see "Lambda Layers" section above) |
+| Cross-account / cross-region / pre-existing-ARN Lambda Layers | Shipped — same-stack `AWS::Lambda::LayerVersion` refs and literal layer-version ARNs are both resolved, the latter by downloading the layer version; see the "Lambda Layers" section above |
 | Cross-stack `Fn::ImportValue` / `Fn::GetStackOutput` in `--from-state` | Future PR |
 | `Fn::Select` / `Fn::Split` / `Fn::If` etc. in `--from-state` | Future PR (warn + drop today) |
 | SQS / S3 event source emulation | Future PR |
@@ -655,6 +696,7 @@ the same tier; cdkd uses literal-segment count as a heuristic).
 | `--env-vars <file>` | unset | SAM-shape JSON: `{"LogicalId":{"KEY":"VALUE"}, "Parameters":{...}}`. Same format as `cdkd local invoke` — the function-specific key may also be a **CDK display path** (`MyStack/MyHandler`). |
 | `--assume-role <arn-or-pair>` | unset | Repeatable. Bare `<arn>` = global default; `<LogicalId>=<arn>` = per-Lambda override. Per-Lambda > global > (`--assume-role-auto` OR global default) > unset (developer creds passed through). |
 | `--assume-role-auto` | off | Auto-resolve EACH routed Lambda's OWN execution role per-Lambda instead of a single global default: tries the synthesized template's literal-ARN `Properties.Role`, then a deployed-state lookup (pair with `--from-state` / `--from-cfn-stack`), then warns-and-passes-through dev creds on a miss. Slower boot (one STS call per Lambda) but the right shape when each Lambda's deployed role differs. **Mutually exclusive** with the global-default `--assume-role <arn>` form (errors at boot); **compatible** with per-Lambda `--assume-role <LogicalId>=<arn>` overrides (the map wins for named Lambdas, auto-resolve handles the rest). |
+| `--layer-role-arn <arn>` | — | Role to `sts:AssumeRole` before calling `lambda:GetLayerVersion` on every literal-ARN entry in `Properties.Layers` (issue [#448](https://github.com/go-to-k/cdkd/issues/448)). Use only when the developer's own credentials cannot read the layer — typically a cross-account layer. AWS-published public layers (e.g. Lambda Powertools) are readable from every account and need no role. No-op for stacks whose layers are all same-stack `AWS::Lambda::LayerVersion` references. |
 | `--watch` | off | Hot reload: watch the CDK app **source tree** (the synth working directory, where `cdk.json` lives) and re-synth + re-discover routes on a source edit, mirroring `cdk watch`. `cdk.out` / `node_modules` / `.git` are excluded and `cdk.json`'s `watch.include` / `watch.exclude` are honored. 500ms debounce. Synth failures keep the previous version serving (warn-and-continue, never crashes the server). |
 | `--stage <name>` | first attached | Select an API Gateway Stage by `StageName`. Drives `event.stageVariables` (REST v1 + HTTP API v2). When the override doesn't match any Stage on a given API, that API's routes get `stageVariables: null` and the CLI emits a warn line up front. |
 | `--from-state` | off | Read cdkd S3 state for every routed stack and substitute `Ref` / `Fn::GetAtt` / `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters (`${AWS::AccountId}` / `${AWS::Region}` / `${AWS::Partition}` / `${AWS::URLSuffix}`) in Lambda env vars with the deployed physical IDs / attributes. Off by default — keeps the pre-PR literal-only / warn-and-drop behavior. Mirrors `cdkd local invoke --from-state` and `cdkd local run-task --from-state`. Re-runs against fresh state on every hot-reload firing (`--watch`). State load failures degrade per-stack to warn-and-fall-back so a missing or unreadable state file never aborts the server. |

--- a/src/local/lambda-resolver.ts
+++ b/src/local/lambda-resolver.ts
@@ -6,6 +6,7 @@ import { buildCdkPathIndex, resolveCdkPathToLogicalIds } from '../cli/cdk-path.j
 import { matchStacks } from '../cli/stack-matcher.js';
 import { derivePseudoParametersFromRegion, tryResolveImageFnJoin } from './intrinsic-image.js';
 import { stringifyValue } from '../utils/stringify.js';
+import { derivePartitionAndUrlSuffix } from '../utils/aws-partition.js';
 
 /**
  * Result of resolving a `cdkd local invoke <target>` argument back to a
@@ -813,16 +814,17 @@ export function resolveLambdaLayers(
     // (Lambda Powertools etc.) or cross-account / cross-region shared
     // layers bypass the same-stack resource scan.
     if (typeof entry === 'string') {
-      const parsed = parseLayerVersionArn(entry);
-      if (!parsed) {
+      const parsed = classifyLayerVersionArn(entry);
+      if (!parsed.ok) {
         throw new LocalInvokeResolutionError(
           `Lambda '${logicalId}' has a Layers entry [${i}] cdkd cannot resolve locally: literal string '${entry}'. ` +
             'Expected a same-stack Ref / Fn::GetAtt to an AWS::Lambda::LayerVersion ' +
             'OR a literal layer-version ARN of the form ' +
-            'arn:aws:lambda:<region>:<account>:layer:<name>:<version>.'
+            'arn:aws:lambda:<region>:<account>:layer:<name>:<version>.' +
+            describeLayerArnRejection(parsed.rejection)
         );
       }
-      out.push({ kind: 'arn', logicalId: parsed.arn, ...parsed });
+      out.push({ kind: 'arn', logicalId: parsed.value.arn, ...parsed.value });
       continue;
     }
 
@@ -857,35 +859,224 @@ export function resolveLambdaLayers(
 }
 
 /**
- * Parse a Lambda layer-version ARN string into its segments.
+ * The region segment of a layer-version ARN.
  *
- * Returns `undefined` for anything that does not match the strict
- * `arn:aws:lambda:<region>:<account>:layer:<name>:<version>` shape so
- * the caller can produce a clearer error than a silent
- * misinterpretation of hand-edited templates. The partition segment
- * accepts `aws` / `aws-cn` / `aws-us-gov` so GovCloud / China-region
- * ARNs work without code changes.
+ * Position, not shape, is what makes a segment a region here: it sits between
+ * the literal `lambda` and a 12-digit account id inside an `arn:` string, so —
+ * unlike `state-file-keys.ts`'s `REGION_SEGMENT`, which has to tell a region
+ * apart from a STACK NAME occupying the same key position — this pattern has
+ * nothing to disambiguate against and can take the region loosely. Both
+ * bounds the pre-#2143 spelling carried are therefore gone:
  *
- * Exported for unit testing.
+ * - the `^[a-z]{2}` first token, which rejected the European Sovereign Cloud
+ *   partition's four-letter `eusc-de-east-1` (the same defect issue #2001
+ *   fixed in `state-file-keys.ts`); and
+ * - the `{1,2}` cap on interior `<word>-` chunks, an independent bound that
+ *   happens to fit today's regions and would silently reject a longer one.
+ *
+ * **What it admits is therefore much wider than the set of real regions, and
+ * that is deliberate rather than an oversight.** The first token is any run of
+ * two or more lower-case letters and the interior chunks are unbounded, so
+ * `garbage-junk-1` matches where the pre-#2143 pattern rejected it (measured).
+ * Widening in that direction costs nothing HERE: the segment's position
+ * already establishes it is the region field, so unlike a state-key segment
+ * there is no second interpretation for a loose match to steal. What the shape
+ * still buys, and why it is not simply `[a-z0-9-]+`, is a floor under what
+ * reaches {@link derivePartitionAndUrlSuffix} — that helper answers `aws` for
+ * anything it does not recognise, so a pure charset would let
+ * `arn:aws:lambda:notaregion:...` through as a commercial layer ARN. Requiring
+ * `<letters>(-<letters>)+-<digits>` keeps single-token and digit-free junk out
+ * without pretending to enumerate AWS's region list.
+ *
+ * Lower-case only, matching the pre-#2143 spelling: AWS emits region ids
+ * lower-case inside ARNs, and this parses an ARN AWS produced, not a
+ * `--region` flag a human typed.
  */
-export function parseLayerVersionArn(
-  input: string
-): { arn: string; region: string; accountId: string; name: string; version: string } | undefined {
-  // Region segment accepts up to two interior `<word>-` chunks before
-  // the numeric suffix so GovCloud (`us-gov-west-1`) / China
-  // (`cn-north-1`) / standard (`us-east-1`) regions all match.
-  const m =
-    /^arn:(aws|aws-cn|aws-us-gov):lambda:([a-z]{2}-(?:[a-z]+-){1,2}\d+):(\d{12}):layer:([A-Za-z0-9_-]+):(\d+)$/.exec(
-      input
-    );
-  if (!m) return undefined;
+const LAYER_ARN_REGION = '[a-z]{2,}(?:-[a-z]+)+-\\d+';
+
+/**
+ * `arn:<partition>:lambda:<region>:<account>:layer:<name>:<version>`.
+ *
+ * The PARTITION group is deliberately loose. It is not validated by the
+ * pattern at all — {@link classifyLayerVersionArn} checks it against the one
+ * the REGION derives, which is a stronger check than any alternation.
+ */
+const LAYER_ARN_PATTERN = new RegExp(
+  `^arn:([a-z][a-z0-9-]*):lambda:(${LAYER_ARN_REGION}):(\\d{12}):layer:([A-Za-z0-9_-]+):(\\d+)$`
+);
+
+/** The segments a well-formed layer-version ARN yields. */
+export interface ParsedLayerVersionArn {
+  arn: string;
+  region: string;
+  accountId: string;
+  name: string;
+  version: string;
+}
+
+/**
+ * Why an ARN was refused — the input to the error message, so the message
+ * cannot describe a different verdict than the one the parse reached.
+ *
+ * `'shape'` needs no words: a missing version, a 13-digit account or
+ * `function` where `layer` belongs is visible in the string the user is
+ * already looking at. `'partition'` is the opposite — the ARN looks perfectly
+ * ordinary — so it carries what the message needs.
+ *
+ * `derivedFromTable` is the distinction that keeps the message HONEST.
+ * {@link derivePartitionAndUrlSuffix} answers `aws` in two very different
+ * situations: the region genuinely is commercial, or `PARTITION_TABLE` simply
+ * has no prefix rule matching it. Both come back `aws`, and only the first
+ * licenses saying "which is in partition 'aws'" — for
+ * `arn:aws-iso-g:lambda:us-isog-east-1:...` that sentence would be a guess
+ * asserted as fact.
+ */
+export type LayerArnRejection =
+  | { kind: 'shape' }
+  | {
+      kind: 'partition';
+      partition: string;
+      region: string;
+      derived: string;
+      derivedFromTable: boolean;
+    };
+
+export type LayerArnClassification =
+  | { ok: true; value: ParsedLayerVersionArn }
+  | { ok: false; rejection: LayerArnRejection };
+
+/**
+ * Classify a Lambda layer-version ARN: its segments, or why it was refused.
+ *
+ * The single decision point behind both the resolved layer's fields and the
+ * caller's error message, so the message cannot describe a different verdict
+ * than the parse reached. An earlier revision had the message re-run the
+ * pattern in a separate helper, which left an arm — "the partitions agree" —
+ * that the sole call site could never reach, because it only asked after the
+ * parse had already refused. One classifier with one return value removes the
+ * arm rather than justifying it, and runs the regex once.
+ *
+ * **The partition is DERIVED from the region, not enumerated** (issue #2143).
+ * The pre-#2143 spelling hard-listed `aws` / `aws-cn` / `aws-us-gov` and so
+ * failed to parse a layer ARN in any of the other five partitions
+ * (`aws-iso`, `aws-iso-b`, `aws-iso-e`, `aws-iso-f`, `aws-eusc`) — and the
+ * caller HARD-THROWS on an unparsed ARN, so `cdkd local invoke` on a function
+ * with a literal-ARN layer failed at RESOLUTION in each of them. Running the
+ * region through `derivePartitionAndUrlSuffix` (`src/utils/aws-partition.ts`)
+ * is what the repo already does everywhere else it needs a partition, so the
+ * list is not spelled a fourth time and cannot go stale here independently.
+ *
+ * **This fixes the PARSE only, and the download behind it is still commercial-
+ * only.** `materializeLayerFromArn` (`src/local/layer-arn-materializer.ts`) is
+ * a one-line shim over cdk-local, whose implementation rebuilds the ARN with a
+ * hardcoded `aws`:
+ *
+ * ```js
+ * // node_modules/cdk-local/dist/local-studio-BBtUAVNy.js:15214
+ * const command = await buildGetLayerVersionCommand(
+ *   `arn:aws:lambda:${layer.region}:${layer.accountId}:layer:${layer.name}`, Number(layer.version));
+ * ```
+ *
+ * So a layer in ANY of the seven non-commercial partitions still fails at
+ * `lambda:GetLayerVersion`. That includes `aws-cn` and `aws-us-gov`, which the
+ * old alternation ALREADY parsed and which therefore gain nothing here. What
+ * this change moves is confined to the five that previously did not parse
+ * (`aws-iso`, `aws-iso-b`, `aws-iso-e`, `aws-iso-f`, `aws-eusc`): for them the
+ * failure shifts from "cdkd cannot resolve locally" to an AWS-side error, so
+ * the parse stops being the blocker and the message names the true one. That
+ * is a real improvement and it is NOT end-to-end support; nothing in this repo
+ * can make it so, and the remaining half is filed as go-to-k/cdk-local#575.
+ *
+ * Deriving also makes the pair SELF-CONSISTENT, which the alternation could
+ * not: `arn:aws-cn:lambda:us-east-1:...` used to parse, pairing China's
+ * partition with a commercial region. It is now REFUSED — a deliberate
+ * behaviour break, asked for by issue #2143's own direction. Nothing is lost
+ * by refusing early, since the commercial-ARN rebuild above means such a layer
+ * could never have been fetched from the partition its ARN named.
+ *
+ * The fallback direction is worth stating, since `derivePartitionAndUrlSuffix`
+ * answers `aws` for a region it does not recognise. A brand-new COMMERCIAL
+ * region therefore still parses with `arn:aws:` — the direction that must keep
+ * working before the table hears about it — while a brand-new region in a
+ * future partition is rejected rather than mis-attributed to commercial, which
+ * is the same trade every other consumer of that table makes.
+ *
+ * Deliberately NOT `isClientSafeRegion` (`intrinsic-function-resolver.ts`):
+ * that predicate is charset-based because its job is to keep a value inside a
+ * hostname label, so it accepts anything lower-case alphanumeric — including
+ * strings no region grammar would admit. See the note it carries.
+ *
+ * THIS is the exported symbol, and a `parseLayerVersionArn` wrapper returning
+ * `T | undefined` is deliberately not kept beside it. Once the caller moved to
+ * the classifier, that wrapper had no `src/` reference left and existed only
+ * for the tests — which `scripts/check-local-reachability.ts` reports as an
+ * orphaned export, correctly. That critic's opt-out tag would have been a
+ * false statement here — it means "cdk-local owns the live implementation",
+ * and cdkd owns this one — so the wrapper is gone rather than tagged. Tests
+ * drive this classifier or the real caller instead. (The tag is deliberately
+ * not spelled out in this comment: the critic reads tags from JSDoc, so
+ * naming it here registers an annotation on a LIVE symbol and is reported as
+ * stale. Measured.)
+ */
+export function classifyLayerVersionArn(input: string): LayerArnClassification {
+  const m = LAYER_ARN_PATTERN.exec(input);
+  if (!m) return { ok: false, rejection: { kind: 'shape' } };
+  const partition = m[1]!;
+  const region = m[2]!;
+  const derived = derivePartitionAndUrlSuffix(region).partition;
+  if (derived !== partition) {
+    return {
+      ok: false,
+      rejection: {
+        kind: 'partition',
+        partition,
+        region,
+        derived,
+        derivedFromTable: derived !== 'aws',
+      },
+    };
+  }
   return {
-    arn: input,
-    region: m[2]!,
-    accountId: m[3]!,
-    name: m[4]!,
-    version: m[5]!,
+    ok: true,
+    value: { arn: input, region, accountId: m[3]!, name: m[4]!, version: m[5]! },
   };
+}
+
+/**
+ * The one sentence a reader cannot derive from the ARN in front of them.
+ *
+ * A `'shape'` rejection gets nothing appended, so the message is
+ * byte-identical to what it has always been for every pre-#2143 refusal. A
+ * `'partition'` rejection is the class this change newly refuses AND the one
+ * that looks perfectly well formed, so it says what disagrees.
+ *
+ * The two `'partition'` arms differ in what cdkd actually KNOWS. On a
+ * `PARTITION_TABLE` hit the derived partition is a fact and is stated as one.
+ * On a miss it is a FALLBACK, so the sentence states the RESOLUTION instead of
+ * asserting membership: `us-east-1` and a hypothetical `us-isog-east-1` both
+ * derive `aws`, but only the first is really commercial, and a message that
+ * cannot tell them apart teaches the reader something false about the second.
+ *
+ * **The miss arm is the COMMERCIAL arm, and that is not obvious from its
+ * name.** `PARTITION_TABLE` (`src/utils/aws-partition.ts`) holds seven rows
+ * and none of them is `aws` — the commercial partition is the fallback
+ * `return` at the bottom of `derivePartitionAndUrlSuffix`, not a row. So
+ * `derivedFromTable` is FALSE for every genuinely commercial region, the fact
+ * arm can never render `derived === 'aws'`, and the miss arm always does. Its
+ * wording therefore has to read correctly for `us-east-1` — the commonest
+ * region there is, and the one the docs, the integ fixture and the changelog
+ * all use as the canonical example. An earlier revision said "no partition
+ * prefix **cdkd knows** matches that region", which is true of the mechanism
+ * and reads as cdkd failing to recognise `us-east-1`; it now leads with the
+ * prefix test and ends on the resolution, which is the fact the reader needs.
+ */
+function describeLayerArnRejection(rejection: LayerArnRejection): string {
+  if (rejection.kind === 'shape') return '';
+  const { partition, region, derived, derivedFromTable } = rejection;
+  const head = ` The partition '${partition}' does not match region '${region}'`;
+  return derivedFromTable
+    ? `${head}, which is in partition '${derived}'.`
+    : `${head}: no partition prefix matches that region, so cdkd resolves it to the commercial partition '${derived}'.`;
 }
 
 /**

--- a/tests/integration/local-invoke-layers/lib/local-invoke-layers-stack.ts
+++ b/tests/integration/local-invoke-layers/lib/local-invoke-layers-stack.ts
@@ -60,5 +60,36 @@ export class LocalInvokeLayersStack extends cdk.Stack {
       layers: [greetingsA, greetingsB, counters],
       timeout: cdk.Duration.seconds(10),
     });
+
+    // Issue #2143 — a LITERAL-ARN layer whose partition and region DISAGREE.
+    //
+    // `resolveLambdaLayers` derives the partition from the region
+    // (`derivePartitionAndUrlSuffix`) instead of matching it against a
+    // hand-written alternation, so `aws-cn` paired with a commercial region is
+    // refused before anything touches the network. That refusal is what
+    // verify.sh's test 4 asserts, and it is the one half of #2143 an integ can
+    // exercise at all: the five previously-unsupported partitions have no
+    // reachable endpoints from a normal dev account, while a MISMATCH is a
+    // pure local verdict.
+    //
+    // What it buys over the unit matrix: the unit tests import the resolver
+    // from source, so they cannot see whether the shipped `dist/` bundle still
+    // wires the new `src/local` -> `src/utils/aws-partition` import. Pre-#2143
+    // this ARN PARSED, and `cdkd local invoke` went on to attempt a
+    // `lambda:GetLayerVersion` download; post-#2143 it must stop at
+    // resolution.
+    new lambda.Function(this, 'MismatchedArnLayerHandler', {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda')),
+      layers: [
+        lambda.LayerVersion.fromLayerVersionArn(
+          this,
+          'MismatchedArnLayer',
+          'arn:aws-cn:lambda:us-east-1:111122223333:layer:Mismatched:1'
+        ),
+      ],
+      timeout: cdk.Duration.seconds(10),
+    });
   }
 }

--- a/tests/integration/local-invoke-layers/verify.sh
+++ b/tests/integration/local-invoke-layers/verify.sh
@@ -38,7 +38,7 @@ ${CDKD} synth >/dev/null
 # Test 1 — multi-layer mounting works: handler can require() modules
 # from BOTH the greetings layers AND the counters layer at the same
 # /opt mount point.
-echo "==> [1/3] Invoking EchoHandler (default empty event)"
+echo "==> [1/4] Invoking EchoHandler (default empty event)"
 EVENT_FILE=$(mktemp)
 trap 'rm -f "${EVENT_FILE}"' EXIT
 echo '{"name":"alice","n":7}' > "${EVENT_FILE}"
@@ -73,7 +73,7 @@ echo "${RESULT_1}" | grep -q '"greeting":"from-layer-B:hello-alice"' || {
 
 # Test 2 — different event payload exercises the same warm code path
 # end-to-end (sanity check that nothing was cached as constants).
-echo "==> [2/3] Invoking with a different event payload"
+echo "==> [2/4] Invoking with a different event payload"
 EVENT2=$(mktemp)
 trap 'rm -f "${EVENT_FILE}" "${EVENT2}"' EXIT
 echo '{"name":"bob","n":42}' > "${EVENT2}"
@@ -92,7 +92,7 @@ echo "${RESULT_2}" | grep -q '"counter":"count=42"' || {
 # stdout + stderr (cdkd's `logger.info` writes to stdout via
 # `console.info`; we just want to verify the layer-count line appears
 # somewhere in the cdkd output) so users know the layer wiring fired.
-echo "==> [3/3] Verifying cdkd logs the layer count"
+echo "==> [3/4] Verifying cdkd logs the layer count"
 LOG_OUTPUT=$(${CDKD} local invoke CdkdLocalInvokeLayersFixture/EchoHandler --event "${EVENT_FILE}" --no-pull 2>&1)
 echo "${LOG_OUTPUT}" | grep -q 'Mounting 3 Lambda layers at /opt' || {
   echo "FAIL: expected 'Mounting 3 Lambda layers' message in cdkd output, got:"
@@ -100,5 +100,49 @@ echo "${LOG_OUTPUT}" | grep -q 'Mounting 3 Lambda layers at /opt' || {
   exit 1
 }
 
+# Test 4 (issue #2143) — the layer-version ARN parse derives the partition
+# from the region rather than matching a hand-written alternation, so a
+# literal-ARN layer whose partition and region DISAGREE is refused at
+# resolution time. `MismatchedArnLayerHandler` carries
+# `arn:aws-cn:lambda:us-east-1:...`; pre-#2143 that ARN parsed and cdkd went
+# on to attempt a `lambda:GetLayerVersion` download, so this assertion is
+# discriminating rather than decorative.
+#
+# It is the half of #2143 an integ CAN exercise: the five partitions the old
+# alternation omitted (`aws-iso*`, `aws-eusc`) have no endpoint reachable from
+# a normal dev account, whereas a mismatch is decided locally with no network
+# call at all. What it adds over the unit matrix is that this runs the SHIPPED
+# `dist/` bundle, which is where a broken `src/local` -> `src/utils` import
+# would show up.
+echo "==> [4/4] Verifying a partition/region-mismatched layer ARN is refused"
+set +e
+MISMATCH_OUTPUT=$(${CDKD} local invoke CdkdLocalInvokeLayersFixture/MismatchedArnLayerHandler --event "${EVENT_FILE}" --no-pull 2>&1)
+MISMATCH_RC=$?
+set -e
+if [[ ${MISMATCH_RC} -eq 0 ]]; then
+  echo "FAIL: expected a non-zero exit for the mismatched layer ARN, got 0. Output:"
+  echo "${MISMATCH_OUTPUT}"
+  exit 1
+fi
+echo "${MISMATCH_OUTPUT}" | grep -q 'cdkd cannot resolve locally' || {
+  echo "FAIL: expected the layer-resolution refusal for the mismatched ARN, got:"
+  echo "${MISMATCH_OUTPUT}"
+  exit 1
+}
+echo "${MISMATCH_OUTPUT}" | grep -q 'arn:aws-cn:lambda:us-east-1:111122223333:layer:Mismatched:1' || {
+  echo "FAIL: expected the refusal to name the offending ARN, got:"
+  echo "${MISMATCH_OUTPUT}"
+  exit 1
+}
+# The refusal must name the DERIVATION, not merely refuse: a bundle whose
+# layer parse broke wholesale would also refuse, and would satisfy the two
+# greps above. This sentence only exists on the partition-mismatch arm.
+echo "${MISMATCH_OUTPUT}" | grep -qF "The partition 'aws-cn' does not match region 'us-east-1': no partition prefix matches that region, so cdkd resolves it to the commercial partition 'aws'." || {
+  echo "FAIL: expected the refusal to name the partition/region disagreement, got:"
+  echo "${MISMATCH_OUTPUT}"
+  exit 1
+}
+echo "    refused as expected (exit ${MISMATCH_RC})"
+
 echo ""
-echo "==> All 3 local-invoke-layers tests passed"
+echo "==> All 4 local-invoke-layers tests passed"

--- a/tests/unit/local/lambda-layer-arn-partitions.test.ts
+++ b/tests/unit/local/lambda-layer-arn-partitions.test.ts
@@ -1,0 +1,526 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  LocalInvokeResolutionError,
+  resolveLambdaLayers,
+} from '../../../src/local/lambda-resolver.js';
+import {
+  PARTITION_TABLE,
+  derivePartitionAndUrlSuffix,
+} from '../../../src/utils/aws-partition.js';
+import type { StackInfo } from '../../../src/synthesis/assembly-reader.js';
+
+/**
+ * Issue #2143 — the layer-version ARN parse rejected five of eight partitions
+ * and carried the issue #2001 two-letter region prefix.
+ *
+ * This is a CLASSIFIER change (an ARN in, accept/reject plus parsed fields
+ * out), so hand-picked cases cannot fence it: a pattern widened until it
+ * accepts everything satisfies every positive assertion ever written. The file
+ * therefore has three layers:
+ *
+ * 1. a DIFFERENTIAL fence (`describe('differential fence')`) that runs the
+ *    pre-fix regex and the shipped code over a generated input space and fails
+ *    on any difference outside an enumerated set of intended classes, with a
+ *    FLOOR per class so a pool that stops covering one cannot pass as "no
+ *    regressions";
+ * 2. per-partition cases driven through the REAL CALLER, so what is asserted
+ *    is the hard-throw at `resolveLambdaLayers` rather than the regex in
+ *    isolation; and
+ * 3. negative controls that must still be REJECTED after the fix.
+ */
+
+const ACCOUNT = '111122223333';
+
+/** The caller needs no resources: a string Layers entry is handled first. */
+const STACK: StackInfo = {
+  stackName: 'ArnLayerStack',
+  displayName: 'ArnLayerStack',
+  artifactId: 'ArnLayerStack',
+  template: { Resources: {} },
+  dependencyNames: [],
+};
+
+type Verdict =
+  | { accepted: true; region: string; accountId: string; name: string; version: string }
+  | { accepted: false; message: string };
+
+/**
+ * Drive one literal ARN through `resolveLambdaLayers` — the real caller, which
+ * HARD-THROWS on an unparsed ARN (`lambda-resolver.ts`, the `!parsed` arm).
+ * Every assertion below reads this verdict, so the throw path is what is
+ * fenced, not `parseLayerVersionArn` in isolation.
+ */
+function callerVerdict(arn: string): Verdict {
+  try {
+    const layers = resolveLambdaLayers(STACK, 'Fn', { Layers: [arn] });
+    const layer = layers[0]!;
+    if (layer.kind !== 'arn') return { accepted: false, message: `resolved as ${layer.kind}` };
+    return {
+      accepted: true,
+      region: layer.region,
+      accountId: layer.accountId,
+      name: layer.name,
+      version: layer.version,
+    };
+  } catch (e) {
+    if (e instanceof LocalInvokeResolutionError) return { accepted: false, message: e.message };
+    throw e;
+  }
+}
+
+/**
+ * The pre-fix pattern, transcribed from
+ * `git show origin/main:src/local/lambda-resolver.ts` line 878 — NOT from
+ * memory. Its two defects are the point of the exercise: a three-of-eight
+ * partition alternation, and a region group whose first token is exactly two
+ * letters with interior `<word>-` chunks capped at two.
+ */
+const OLD_PATTERN =
+  /^arn:(aws|aws-cn|aws-us-gov):lambda:([a-z]{2}-(?:[a-z]+-){1,2}\d+):(\d{12}):layer:([A-Za-z0-9_-]+):(\d+)$/;
+
+/** The pre-fix `parseLayerVersionArn`, field for field. */
+function oldVerdict(arn: string): Verdict {
+  const m = OLD_PATTERN.exec(arn);
+  if (!m) return { accepted: false, message: 'old: no match' };
+  return { accepted: true, region: m[2]!, accountId: m[3]!, name: m[4]!, version: m[5]! };
+}
+
+/**
+ * INDEPENDENT oracle for "this ARN should be accepted after the fix".
+ *
+ * Deliberately built from `split(':')` / `split('-')` plus per-token tests
+ * rather than from a regex, and using a hand-written prefix table rather than
+ * calling `derivePartitionAndUrlSuffix`, so it cannot agree with the
+ * implementation by construction. The hand-written table is pinned against
+ * `PARTITION_TABLE` by a test below, so a stale copy here fails loudly instead
+ * of quietly weakening the oracle.
+ */
+const EXPECTED_PARTITION_PREFIXES: ReadonlyArray<readonly [string, string]> = [
+  ['cn-', 'aws-cn'],
+  ['us-gov-', 'aws-us-gov'],
+  ['us-iso-', 'aws-iso'],
+  ['us-isob-', 'aws-iso-b'],
+  ['us-isof-', 'aws-iso-f'],
+  ['eu-isoe-', 'aws-iso-e'],
+  ['eusc-', 'aws-eusc'],
+];
+
+function expectedPartition(region: string): string {
+  for (const [prefix, partition] of EXPECTED_PARTITION_PREFIXES) {
+    if (region.startsWith(prefix)) return partition;
+  }
+  return 'aws';
+}
+
+/** Token-wise region grammar: `<2+ letters>(-<letters>)+-<digits>`. */
+function isRegionShaped(region: string): boolean {
+  const tokens = region.split('-');
+  if (tokens.length < 3) return false;
+  const first = tokens[0]!;
+  const last = tokens[tokens.length - 1]!;
+  if (!/^[a-z]{2,}$/.test(first)) return false;
+  if (!/^[0-9]+$/.test(last)) return false;
+  return tokens.slice(1, -1).every((t) => /^[a-z]+$/.test(t));
+}
+
+function intendedAccept(arn: string): boolean {
+  const parts = arn.split(':');
+  if (parts.length !== 8) return false;
+  const [literal, partition, service, region, account, keyword, name, version] = parts as string[];
+  if (literal !== 'arn' || service !== 'lambda' || keyword !== 'layer') return false;
+  if (!/^[a-z][a-z0-9-]*$/.test(partition!)) return false;
+  if (!isRegionShaped(region!)) return false;
+  if (expectedPartition(region!) !== partition) return false;
+  if (!/^\d{12}$/.test(account!)) return false;
+  if (!/^[A-Za-z0-9_-]+$/.test(name!)) return false;
+  if (!/^\d+$/.test(version!)) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// The generated input space.
+// ---------------------------------------------------------------------------
+
+/** Every partition string cdkd knows, plus two that are not partitions. */
+const PARTITIONS = [
+  'aws',
+  'aws-cn',
+  'aws-us-gov',
+  'aws-iso',
+  'aws-iso-b',
+  'aws-iso-e',
+  'aws-iso-f',
+  'aws-eusc',
+  'aws-bogus',
+  'notaws',
+];
+
+const REGIONS = [
+  // real regions, at least one per partition prefix
+  'us-east-1',
+  'eu-west-1',
+  'ap-southeast-7',
+  'mx-central-1',
+  'il-central-1',
+  'ca-west-1',
+  'cn-north-1',
+  'cn-northwest-1',
+  'us-gov-west-1',
+  'us-gov-east-1',
+  'us-iso-east-1',
+  'us-iso-west-1',
+  'us-isob-east-1',
+  'eu-isoe-west-1',
+  'us-isof-south-1',
+  'us-isof-east-1',
+  'eusc-de-east-1',
+  // region-shaped but unknown to the partition table
+  'zz-nowhere-9',
+  'abcd-ef-gh-1',
+  // more interior hyphen groups than the pre-fix `{1,2}` cap allowed
+  'us-central-north-east-1',
+  // malformed region shapes
+  'us-east',
+  'useast1',
+  'u-east-1',
+  'US-EAST-1',
+  'us-east-1-1',
+  'us--east-1',
+  '',
+  'evil.example.com#',
+];
+
+/** Structural mutations applied to a well-formed, self-consistent base ARN. */
+function malformedVariants(): string[] {
+  const bases = [
+    ['aws', 'us-east-1'],
+    ['aws-cn', 'cn-north-1'],
+    ['aws-eusc', 'eusc-de-east-1'],
+    ['aws-iso-b', 'us-isob-east-1'],
+  ] as const;
+  const out: string[] = [];
+  for (const [p, r] of bases) {
+    out.push(
+      `arn:${p}:lambda:${r}:${ACCOUNT}:layer:MyLayer:1`, // control: well formed
+      `arn:${p}:lambda:${r}:${ACCOUNT}:function:MyLayer:1`, // wrong keyword
+      `arn:${p}:s3:${r}:${ACCOUNT}:layer:MyLayer:1`, // wrong service
+      `arn:${p}:lambda:${r}:${ACCOUNT}:layer:MyLayer`, // unversioned
+      `arn:${p}:lambda:${r}:${ACCOUNT}:layer:MyLayer:latest`, // non-numeric version
+      `arn:${p}:lambda:${r}:${ACCOUNT}:layer:MyLayer:`, // empty version
+      `arn:${p}:lambda:${r}:${ACCOUNT}:layer:MyLayer:1:2`, // extra segment
+      `arn:${p}:lambda:${r}:11112222333:layer:MyLayer:1`, // 11-digit account
+      `arn:${p}:lambda:${r}:1111222233334:layer:MyLayer:1`, // 13-digit account
+      `arn:${p}:lambda:${r}:not-an-account:layer:MyLayer:1`, // non-numeric account
+      `arn:${p}:lambda:${r}:${ACCOUNT}:layer::1`, // empty name
+      `arn:${p}:lambda:${r}:${ACCOUNT}:layer:My.Layer:1`, // dot in name
+      `ARN:${p}:lambda:${r}:${ACCOUNT}:layer:MyLayer:1`, // upper-case literal
+      `${p}:lambda:${r}:${ACCOUNT}:layer:MyLayer:1`, // no `arn:`
+      ` arn:${p}:lambda:${r}:${ACCOUNT}:layer:MyLayer:1`, // leading space
+      `arn:${p}:lambda:${r}:${ACCOUNT}:layer:MyLayer:1 `, // trailing space
+      `arn:${p}:lambda:${r}:${ACCOUNT}:layer:MyLayer:1\n`, // trailing newline
+      `arn::lambda:${r}:${ACCOUNT}:layer:MyLayer:1` // empty partition
+    );
+  }
+  return out;
+}
+
+function inputSpace(): string[] {
+  const out: string[] = [];
+  for (const p of PARTITIONS) {
+    for (const r of REGIONS) {
+      out.push(`arn:${p}:lambda:${r}:${ACCOUNT}:layer:MyLayer:1`);
+    }
+  }
+  out.push(...malformedVariants());
+  return out;
+}
+
+describe('layer-ARN classifier: differential fence vs the pre-#2143 pattern', () => {
+  // `classifyLayerVersionArn` reports `derivedFromTable` as `derived !== 'aws'`
+  // rather than re-walking `PARTITION_TABLE`, because a second walk is a second
+  // DECISION and can drift from the one `derivePartitionAndUrlSuffix` made: that
+  // helper walks `canonicalizeRegion(region)`, so the moment the ARN's region
+  // group admits upper case, a re-walk over the RAW region misses while `derived`
+  // still says `aws-cn`, and the miss arm renders the self-contradiction
+  // "resolves it to the commercial partition 'aws-cn'".
+  //
+  // The two are equivalent only because no `PARTITION_TABLE` row carries `aws` --
+  // commercial is the fallback `return`, not a row. Both halves are pinned here,
+  // over the whole region pool, so the substitution cannot silently stop holding.
+  it('no PARTITION_TABLE row carries the commercial partition', () => {
+    expect(PARTITION_TABLE.filter((row) => row.partition === 'aws')).toEqual([]);
+    expect(PARTITION_TABLE.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it("`derived !== 'aws'` equals a PARTITION_TABLE walk, for every region in the pool", () => {
+    const disagreements: string[] = [];
+    for (const region of REGIONS) {
+      const walk = PARTITION_TABLE.some((row) => region.startsWith(row.prefix));
+      const viaDerived = derivePartitionAndUrlSuffix(region).partition !== 'aws';
+      if (walk !== viaDerived) disagreements.push(`${region}: walk=${walk} derived=${viaDerived}`);
+    }
+    expect(disagreements).toEqual([]);
+    // Both verdicts must actually OCCUR in the pool, or the equality is vacuous.
+    const hits = REGIONS.filter((r) => derivePartitionAndUrlSuffix(r).partition !== 'aws');
+    expect(hits.length).toBeGreaterThanOrEqual(8);
+    expect(REGIONS.length - hits.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('the oracle prefix table still matches PARTITION_TABLE', () => {
+    expect([...EXPECTED_PARTITION_PREFIXES].sort()).toEqual(
+      PARTITION_TABLE.map((r) => [r.prefix, r.partition] as const)
+        .map((r) => [...r])
+        .sort()
+    );
+  });
+
+  it('every difference falls in an enumerated intended class, and each class has coverage', () => {
+    const inputs = inputSpace();
+    expect(inputs.length).toBeGreaterThanOrEqual(150);
+
+    const newlyAccepted: string[] = [];
+    const newlyRejected: string[] = [];
+    const fieldDrift: string[] = [];
+    const bothAccepted: string[] = [];
+    const bothRejected: string[] = [];
+
+    for (const arn of inputs) {
+      const oldV = oldVerdict(arn);
+      const newV = callerVerdict(arn);
+
+      if (oldV.accepted && newV.accepted) {
+        bothAccepted.push(arn);
+        // Nothing about the parsed FIELDS was meant to change. Compare them
+        // for every cell both implementations accept.
+        if (
+          oldV.region !== newV.region ||
+          oldV.accountId !== newV.accountId ||
+          oldV.name !== newV.name ||
+          oldV.version !== newV.version
+        ) {
+          fieldDrift.push(arn);
+        }
+        continue;
+      }
+      if (!oldV.accepted && !newV.accepted) {
+        bothRejected.push(arn);
+        continue;
+      }
+      // Classified by the value the NEW code returns, not by the input's
+      // shape — so a total regression (everything rejected) lands wholly in
+      // `newlyRejected` and fails that bucket's predicate, instead of being
+      // silently sorted into "expected" buckets by input shape.
+      if (newV.accepted) newlyAccepted.push(arn);
+      else newlyRejected.push(arn);
+    }
+
+    // ---- no unintended differences -------------------------------------
+    expect(fieldDrift).toEqual([]);
+
+    // Class A — newly ACCEPTED. Intended iff the independent oracle says the
+    // ARN is well formed AND its partition agrees with its region.
+    expect(newlyAccepted.filter((a) => !intendedAccept(a))).toEqual([]);
+
+    // Class B — newly REJECTED. Intended iff the pair is INCONSISTENT: the
+    // pre-fix pattern accepted `arn:aws-cn:...` in a commercial region.
+    expect(newlyRejected.filter((a) => intendedAccept(a))).toEqual([]);
+
+    // ---- and the pool still covers each class ---------------------------
+    // The floors below read the OUTCOME, which is not enough on its own: several
+    // cells are reachable from BOTH the partition x region cross-product AND the
+    // `malformedVariants` control bases, and for `eusc-de-east-1` / `us-isob-east-1`
+    // the two sources produce the IDENTICAL string. So an outcome floor of ">= 1"
+    // survives deleting that member from `REGIONS`, and A1's set match survives
+    // deleting `aws-iso-b` from `PARTITIONS` -- redundant coverage, not a false
+    // pass, but exactly the "floor names only the central member" mode. Assert the
+    // POOL directly as well, so removing a member from either source list reds
+    // here even when the control base still supplies the cell.
+    //
+    // All three are CONTAINMENT or a floor, never an exact match, and that is a
+    // deliberate choice rather than laziness. What they owe the floors below is
+    // only "REGIONS / PARTITIONS still SOURCE a cell of this class". A second
+    // legitimate `eusc-` region -- `eusc-fr-west-2`, say -- would be added
+    // coverage, not a regression, and it moves NO floor below it: every one is a
+    // `>=`, and A1's exact set is unmoved because such a region lands in the
+    // `aws-eusc` partition that set already names. So pinning the list exactly
+    // would red on an improvement while catching nothing a `>= 1` misses --
+    // DELETION, the only real regression here, reds under both forms (probed).
+    expect(REGIONS.filter((r) => r.startsWith('eusc-')).length).toBeGreaterThanOrEqual(1);
+    expect(REGIONS.filter((r) => r.split('-').length > 4).length).toBeGreaterThanOrEqual(1);
+    for (const p of ['aws-iso', 'aws-iso-b', 'aws-iso-e', 'aws-iso-f', 'aws-eusc']) {
+      expect(PARTITIONS).toContain(p);
+    }
+
+    // A1: the five partitions the alternation omitted.
+    const a1 = new Set(
+      newlyAccepted.map((a) => a.split(':')[1]!).filter((p) => p !== 'aws' && p !== 'aws-cn' && p !== 'aws-us-gov')
+    );
+    expect([...a1].sort()).toEqual(['aws-eusc', 'aws-iso', 'aws-iso-b', 'aws-iso-e', 'aws-iso-f']);
+
+    // A2: the four-letter region first token (issue #2001's defect).
+    expect(newlyAccepted.filter((a) => a.split(':')[3]!.startsWith('eusc-')).length).toBeGreaterThanOrEqual(1);
+
+    // A3: more interior hyphen groups than the pre-fix `{1,2}` cap.
+    expect(
+      newlyAccepted.filter((a) => a.split(':')[3]!.split('-').length > 4).length
+    ).toBeGreaterThanOrEqual(1);
+
+    // B: partition/region mismatches the pre-fix pattern let through.
+    expect(newlyRejected.length).toBeGreaterThanOrEqual(10);
+    expect(
+      newlyRejected.filter((a) => {
+        const parts = a.split(':');
+        return expectedPartition(parts[3]!) !== parts[1]!;
+      }).length
+    ).toBe(newlyRejected.length);
+
+    // Unchanged cells: the commercial-partition happy path and the malformed
+    // pool must both still be represented, or "no regressions" is vacuous.
+    expect(bothAccepted.length).toBeGreaterThanOrEqual(10);
+    expect(bothRejected.length).toBeGreaterThanOrEqual(60);
+  });
+});
+
+describe('layer-ARN parse through the real caller (issue #2143)', () => {
+  const CASES: ReadonlyArray<readonly [string, string]> = [
+    ['aws', 'us-east-1'],
+    ['aws-cn', 'cn-north-1'],
+    ['aws-us-gov', 'us-gov-west-1'],
+    ['aws-iso', 'us-iso-east-1'],
+    ['aws-iso-b', 'us-isob-east-1'],
+    ['aws-iso-e', 'eu-isoe-west-1'],
+    ['aws-iso-f', 'us-isof-south-1'],
+    ['aws-eusc', 'eusc-de-east-1'],
+  ];
+
+  it('covers all eight partitions', () => {
+    expect(CASES.length).toBe(PARTITION_TABLE.length + 1);
+  });
+
+  for (const [partition, region] of CASES) {
+    it(`resolves a layer ARN in ${partition} (${region})`, () => {
+      const arn = `arn:${partition}:lambda:${region}:${ACCOUNT}:layer:MyLayer:7`;
+      expect(callerVerdict(arn)).toEqual({
+        accepted: true,
+        region,
+        accountId: ACCOUNT,
+        name: 'MyLayer',
+        version: '7',
+      });
+    });
+  }
+
+  it('resolves the European Sovereign Cloud region (four-letter first token)', () => {
+    const arn = `arn:aws-eusc:lambda:eusc-de-east-1:${ACCOUNT}:layer:Sovereign:1`;
+    const v = callerVerdict(arn);
+    expect(v.accepted).toBe(true);
+    expect(v.accepted && v.region).toBe('eusc-de-east-1');
+  });
+
+  it('resolves a region with three interior hyphen groups (past the old {1,2} cap)', () => {
+    const arn = `arn:aws:lambda:us-central-north-east-1:${ACCOUNT}:layer:MyLayer:1`;
+    const v = callerVerdict(arn);
+    expect(v.accepted).toBe(true);
+    expect(v.accepted && v.region).toBe('us-central-north-east-1');
+  });
+
+  it('resolves an unknown-prefix region to the commercial partition', () => {
+    // `derivePartitionAndUrlSuffix` answers `aws` for a region it does not
+    // know, so a brand-new COMMERCIAL region keeps working before the table
+    // hears about it.
+    const v = callerVerdict(`arn:aws:lambda:zz-nowhere-9:${ACCOUNT}:layer:MyLayer:1`);
+    expect(v.accepted).toBe(true);
+  });
+});
+
+describe('layer-ARN negative controls (must still be REJECTED)', () => {
+  const REJECTED: ReadonlyArray<readonly [string, string]> = [
+    ['partition/region mismatch (China partition, commercial region)', `arn:aws-cn:lambda:us-east-1:${ACCOUNT}:layer:MyLayer:1`],
+    ['partition/region mismatch (commercial partition, China region)', `arn:aws:lambda:cn-north-1:${ACCOUNT}:layer:MyLayer:1`],
+    ['partition/region mismatch (GovCloud partition, commercial region)', `arn:aws-us-gov:lambda:us-east-1:${ACCOUNT}:layer:MyLayer:1`],
+    ['unknown-prefix region claiming a non-commercial partition', `arn:aws-eusc:lambda:zz-nowhere-9:${ACCOUNT}:layer:MyLayer:1`],
+    ['a partition string that is not a partition', `arn:aws-bogus:lambda:us-east-1:${ACCOUNT}:layer:MyLayer:1`],
+    ['wrong service', `arn:aws:s3:us-east-1:${ACCOUNT}:layer:MyLayer:1`],
+    ['wrong keyword (function, not layer)', `arn:aws:lambda:us-east-1:${ACCOUNT}:function:MyFn:1`],
+    ['unversioned', `arn:aws:lambda:us-east-1:${ACCOUNT}:layer:MyLayer`],
+    ['non-numeric version', `arn:aws:lambda:us-east-1:${ACCOUNT}:layer:MyLayer:latest`],
+    ['13-digit account id', `arn:aws:lambda:us-east-1:1111222233334:layer:MyLayer:1`],
+    ['upper-case region', `arn:aws:lambda:US-EAST-1:${ACCOUNT}:layer:MyLayer:1`],
+    ['region carrying a host delimiter', `arn:aws:lambda:evil.example.com#:${ACCOUNT}:layer:MyLayer:1`],
+    ['region with no numeric suffix', `arn:aws:lambda:us-east:${ACCOUNT}:layer:MyLayer:1`],
+    ['one-letter region first token', `arn:aws:lambda:u-east-1:${ACCOUNT}:layer:MyLayer:1`],
+    ['empty partition', `arn::lambda:us-east-1:${ACCOUNT}:layer:MyLayer:1`],
+    ['trailing newline', `arn:aws:lambda:us-east-1:${ACCOUNT}:layer:MyLayer:1\n`],
+  ];
+
+  for (const [label, arn] of REJECTED) {
+    it(`rejects ${label}`, () => {
+      const v = callerVerdict(arn);
+      expect(v.accepted).toBe(false);
+      expect(v.accepted === false && v.message).toContain('cdkd cannot resolve locally');
+    });
+  }
+
+  // The refusal message (issue #2143). A mismatch is the one rejection a
+  // reader cannot see in the ARN's own shape AND the one class this change
+  // newly refuses, so it is the only one that earns a hint.
+  // The message has TWO partition arms, and the split is about what cdkd
+  // actually knows rather than about the input's shape.
+  // `derivePartitionAndUrlSuffix` answers `aws` both for a real commercial
+  // region and for one no `PARTITION_TABLE` prefix matches, so only a table
+  // HIT licenses stating membership as fact.
+  it('states membership as fact when PARTITION_TABLE matches the region', () => {
+    const v = callerVerdict(`arn:aws:lambda:eusc-de-east-1:${ACCOUNT}:layer:MyLayer:1`);
+    expect(v.accepted).toBe(false);
+    expect(v.accepted === false && v.message).toContain(
+      "The partition 'aws' does not match region 'eusc-de-east-1', which is in partition 'aws-eusc'."
+    );
+  });
+
+  // `PARTITION_TABLE` has no commercial ROW -- `aws` is the fallback `return`
+  // in `derivePartitionAndUrlSuffix` -- so this MISS arm is the arm every
+  // genuinely commercial region takes, and `us-east-1` is the canonical
+  // example the docs, the integ fixture and the changelog all use. Its wording
+  // therefore has to read correctly for a region cdkd recognises perfectly
+  // well, which an earlier revision ("no partition prefix CDKD KNOWS matches
+  // that region") did not: true of the mechanism, and readable as cdkd not
+  // recognising the commonest AWS region. The negative pins that regression.
+  it('names the FALLBACK, not a membership claim, when no table prefix matches', () => {
+    const v = callerVerdict(`arn:aws-cn:lambda:us-east-1:${ACCOUNT}:layer:MyLayer:1`);
+    expect(v.accepted).toBe(false);
+    const message = v.accepted === false ? v.message : '';
+    expect(message).toContain(
+      "The partition 'aws-cn' does not match region 'us-east-1': no partition prefix matches " +
+        "that region, so cdkd resolves it to the commercial partition 'aws'."
+    );
+    expect(message).not.toContain('cdkd knows');
+  });
+
+  // The case the fact-arm would get WRONG. `us-isog-east-1` matches no
+  // `PARTITION_TABLE` prefix (`us-iso-` does not cover `us-isog-`), so it
+  // derives `aws` by fallback -- and it is plainly not a commercial region.
+  // A single assertive arm would tell the reader it "is in partition 'aws'".
+  it('does not claim a hypothetical future partition region is commercial', () => {
+    const v = callerVerdict(`arn:aws-iso-g:lambda:us-isog-east-1:${ACCOUNT}:layer:MyLayer:1`);
+    expect(v.accepted).toBe(false);
+    const message = v.accepted === false ? v.message : '';
+    expect(message).toContain(
+      "The partition 'aws-iso-g' does not match region 'us-isog-east-1': no partition prefix " +
+        "matches that region, so cdkd resolves it to the commercial partition 'aws'."
+    );
+    expect(message).not.toContain("which is in partition 'aws'");
+  });
+
+  it('adds NO hint to a rejection whose reason is visible in the ARN itself', () => {
+    for (const arn of [
+      `arn:aws:lambda:us-east-1:${ACCOUNT}:layer:MyLayer`,
+      `arn:aws:lambda:us-east-1:${ACCOUNT}:layer:MyLayer:latest`,
+      `arn:aws:lambda:US-EAST-1:${ACCOUNT}:layer:MyLayer:1`,
+      `arn:aws:s3:us-east-1:${ACCOUNT}:layer:MyLayer:1`,
+    ]) {
+      const v = callerVerdict(arn);
+      expect(v.accepted).toBe(false);
+      expect(v.accepted === false && v.message).not.toContain('does not match region');
+    }
+  });
+});

--- a/tests/unit/local/lambda-resolver.test.ts
+++ b/tests/unit/local/lambda-resolver.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
 import {
   LocalInvokeResolutionError,
-  parseLayerVersionArn,
+  classifyLayerVersionArn,
   parseTarget,
   resolveLambdaTarget,
 } from '../../../src/local/lambda-resolver.js';
@@ -1299,6 +1299,21 @@ describe('resolveLambdaTarget', () => {
     expect(result.ephemeralStorageMb).toBeUndefined();
   });
 });
+
+/**
+ * The `T | undefined` shape these cases were written against. It used to be a
+ * `parseLayerVersionArn` export, which issue #2143 removed: once the resolver
+ * moved to `classifyLayerVersionArn`, that wrapper had no `src/` caller left
+ * and `scripts/check-local-reachability.ts` reported it as an orphaned export.
+ * Keeping the adapter HERE — three lines over the real classifier — preserves
+ * every assertion below without a production symbol that only tests reach.
+ */
+function parseLayerVersionArn(
+  input: string
+): { arn: string; region: string; accountId: string; name: string; version: string } | undefined {
+  const result = classifyLayerVersionArn(input);
+  return result.ok ? result.value : undefined;
+}
 
 describe('parseLayerVersionArn (issue #448)', () => {
   it('parses a canonical commercial-partition layer ARN', () => {


### PR DESCRIPTION
## Summary

The Lambda layer-version ARN parse in `src/local/lambda-resolver.ts` matched

```
/^arn:(aws|aws-cn|aws-us-gov):lambda:([a-z]{2}-(?:[a-z]+-){1,2}\d+):(\d{12}):layer:([A-Za-z0-9_-]+):(\d+)$/
```

which carried two independent defects, neither subsuming the other:

1. The partition alternation listed **three of eight**, so a layer ARN in `aws-iso`, `aws-iso-b`, `aws-iso-e`, `aws-iso-f` or `aws-eusc` failed to parse.
2. The region group required a two-letter prefix -- the same shape issue go-to-k/cdkd#2001 fixed in `state-file-keys.ts` -- so `eusc-de-east-1` was rejected, and its `{1,2}` hyphen-group cap was a second independent bound.

The caller hard-throws, so `cdkd local invoke` / `cdkd local start-api` failed outright for any function with a layer in an affected partition.

Both halves are now **derived** rather than hand-listed a fourth time: the regex takes the partition loosely and the region shape-based, then validates `derivePartitionAndUrlSuffix(region).partition === partition`. That also makes the pair self-consistent, which the issue asked for.

## Upgrade note -- this refuses input it used to accept

A partition/region **mismatch** now hard-throws: `arn:aws-cn:...:us-east-1`, `arn:aws:...:cn-north-1`, `arn:aws-us-gov:...:us-east-1`. This was requested by the issue's own Direction section.

It costs nothing real. `src/local/layer-arn-materializer.ts` is a shim re-exporting cdk-local, whose bundle rebuilds the ARN with a hardcoded commercial partition (`node_modules/cdk-local/dist/local-studio-BBtUAVNy.js:15214`), so such a layer could never have been fetched from the partition its ARN named -- the refusal only moves an inevitable failure earlier, with a message that names the real problem.

## Scope -- what this does NOT fix

Only the **parse** covers eight partitions. Materialization still issues a commercial ARN via that shim, so an `aws-iso*` / `aws-eusc` layer now fails later at `lambda:GetLayerVersion` instead of at parse. For those five partitions what changed is *which* failure you get. Filed upstream as go-to-k/cdk-local#575, which also records that cdk-local's own `derivePartitionAndUrlSuffix` knows four of eight.

## Test plan

- **Differential fence** (`tests/unit/local/lambda-layer-arn-partitions.test.ts`): the old regex is transcribed from `origin/main` and run beside the new implementation over 352 inputs (10 partitions x 28 region shapes + 72 structural malformations). Differences are bucketed by the **value the new code returns**, so a total regression cannot land in an "intended" bucket, and each class carries a floor. Measured: 11 newly accepted, 40 newly rejected (100% partition/region mismatches), 0 parsed-field drift, 13 unchanged accepts, 288 unchanged rejects. Every cell runs through the real caller, not the regex.
- **Mutation probes**, applied one at a time: reverting only the partition half reds 10 cases; only the region half reds 4; a total widening reds 10, nine of them negative controls. The two halves are separately fenced.
- **Real Docker integ**: `/run-integ local-invoke-layers`, 4/4, run twice -- the second time after the round-3 message reword, with the assertion string re-derived from real rebuilt-CLI output rather than hand-written. Docker sweep (`ps -a` plus both network filters) empty both times.
- Full suite: 812 files / 16733 tests, exit 0.

## Review notes

Three review rounds. Round 2 raised a blocker whose factual half held -- the parsed partition is discarded downstream -- but whose remedy (downgrade the refusal to a warning) was **declined**, because the issue explicitly asks for the self-consistency check and a mismatched layer fails downstream either way. What the finding did establish is that the published claim was unearned, so "all eight partitions" is now stated as a claim about the parse with the limitation beside it.

Round 3 caught that the two-arm hint message read as ignorance of `us-east-1`: `PARTITION_TABLE` has seven rows and **none for the commercial partition** (`aws` is the fallback return), so the "table miss" arm *is* the commercial arm. Reworded; the source docstring now records the inversion so the next editor does not reintroduce it.

Also fixed here: the item-6 refactor left `parseLayerVersionArn` exported with zero `src/` references, which correctly reddened the go-to-k/cdkd#2293 reachability critic. The cause was fixed (wrapper deleted) rather than annotated -- its opt-out tag asserts cdk-local owns the implementation, which is false here.

Closes #2143
