### PR TITLE
test: refuse and REPORT a real AWS call from a unit test

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -17,6 +17,38 @@ paths:
   `tests/unit/scripts/test-import-convention.test.ts` (fails the local test
   run, naming the offending file).
 - Mocking: Mock AWS SDK with vi.mock()
+- **Mocking `src/utils/aws-clients.js` does NOT isolate a provider that builds
+  its OWN client.** `new Route53Client({ region })` inside a provider ignores
+  that mock entirely, so the test transacts with whatever AWS account the
+  runner is authenticated to. The dangerous direction is silent: a call that
+  FAILS looks like an ordinary red, while one that SUCCEEDS creates a real,
+  billable resource and still reports green. A network fence in
+  `tests/setup.ts` refuses any outbound AWS call from a vitest run and names
+  the refused host plus the remedy (issue
+  [#2081](https://github.com/go-to-k/cdkd/issues/2081)); it also FAILS the test
+  from an `afterEach`, because a bare `rejects.toThrow()` is satisfied by the
+  refusal itself and would otherwise hide the escape. It is a RUNTIME control,
+  so it catches a leaked client only when a test EXERCISES it -- a file that
+  constructs one and never calls it stays green, and only a static scan would
+  see that.
+- **When the fence fires, find the CONSTRUCTION SITE before choosing the mock
+  -- and never an opt-out.** Which mock is correct depends on where the
+  escaping client is built, and both answers occur in this repo. Of the nine
+  files the fence caught, SIX construct the client inside the provider and are
+  fixed by mocking the SDK PACKAGE -- `vi.mock('@aws-sdk/client-<svc>', ...)`,
+  the shape `tests/unit/provisioning/route53-provider.test.ts` uses. The other
+  THREE (`tests/unit/analyzer/diff-calculator.test.ts`,
+  `tests/unit/deployment/deploy-engine-interrupt-cause.test.ts`,
+  `tests/unit/deployment/strict-getatt-output-refusal-cause.test.ts`) reach
+  `cloudformation:DescribeType` through `getAwsClients().cloudFormation` and
+  nothing self-constructs, so mocking `src/utils/aws-clients.js` is the right
+  fix there and a package mock would be the wrong one. Watch the package name:
+  the application-auto-scaling client hyphenates it
+  (`@aws-sdk/client-application-auto-scaling`) where the endpoint host does
+  not, and a mis-named `vi.mock` is silently INERT. The fence's message derives
+  the package from the refused host where it has a mapping and says plainly
+  that it cannot rather than guessing where it does not, so copy the name out
+  of the message instead of spelling it from the host.
 
 ### A `*Once` primer must be consumed by the test that primed it (mandatory)
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,10 @@
 /// <reference types="node" />
 
-import { vi } from 'vite-plus/test';
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+
+import { afterAll, afterEach, beforeEach, expect, vi } from 'vite-plus/test';
 
 import {
   isConstructable,
@@ -113,3 +117,703 @@ const originalExit = process.exit;
 
 // Keep a reference to the real exit in case anything downstream wants it.
 (globalThis as Record<string, unknown>).__cdkd_test_original_exit__ = originalExit;
+
+
+/* ------------------------------------------------------------------------ *
+ * Real-AWS network fence (issue #2081)
+ *
+ * A provider that constructs its OWN SDK client — `new Route53Client({...})`
+ * inside the provider — is not isolated by a test that only mocks
+ * `src/utils/aws-clients.js`. The provider ignores the mock, the client is
+ * real, and the test transacts with whatever AWS account the runner is
+ * authenticated to. The dangerous direction is the SILENT one: a call that
+ * FAILS looks like an ordinary red, while a call that SUCCEEDS creates a real,
+ * billable resource and still reports green.
+ *
+ * The fence is at the NETWORK layer rather than the credential-provider layer
+ * on purpose: a client built with explicit dummy credentials skips credential
+ * resolution entirely but still transacts, so a credential-level fence would
+ * miss exactly the shape that is easiest to write by accident.
+ *
+ * Two layers, because one of them is defeatable:
+ *
+ *   1. `http` / `https` `request` + `get`, replaced on the module's exports
+ *      object. A consumer only sees the replacement if it reads the property at
+ *      CALL time, and whether it does depends on which build of the package Node
+ *      loads. Measured against the installed tree: `@aws-sdk/client-route-53`
+ *      3.1018.0 resolves `@smithy/node-http-handler` 4.5.0, whose `dist-es`
+ *      build uses a NAMED import (`import { Agent as hsAgent, request as
+ *      hsRequest } from 'node:https'`) — a snapshot that would escape this
+ *      layer. That build is not the one that loads: 4.5.0 ships NO `exports`
+ *      field, so Node falls back to `main` (`dist-cjs/index.js`), which does
+ *      `var node_https = require('node:https')` and evaluates
+ *      `node_https.request` at request time. That live property read is what
+ *      layer 1 depends on. (@smithy/node-http-handler 4.9.x, also present in the
+ *      tree for other clients, moved its ESM build to a DEFAULT import,
+ *      `import node_https from 'node:https'`, which is live as well.) The
+ *      fragile part is the ABSENT `exports` field: if upstream adds one, the
+ *      ESM build starts loading, and for a named-import version every AWS call
+ *      would silently demote to layer 2 — still fenced, but with the less
+ *      specific message. This layer produces the actionable message.
+ *   2. `net.Socket.prototype.connect`, as a backstop. Node snapshots a builtin's
+ *      ESM NAMED exports, so a module written as `import { request } from
+ *      'node:http'` — which is exactly what `@smithy/credential-provider-imds`
+ *      does — keeps the pre-patch function and escapes layer 1. Every outbound
+ *      TCP connection opened through Node's own networking stack bottoms out
+ *      here, including `node:http2.connect`, `node:tls.connect` and undici
+ *      (global `fetch`).
+ *
+ * The boundary is IN-PROCESS Node networking APIs, and ONLY those. Three routes
+ * escape both layers, so the fence is not a claim about the whole process: a
+ * child process (`node:child_process`), a worker thread
+ * (`node:worker_threads`), and a hostname resolved out-of-band to a bare IP
+ * that is then connected to numerically. `src/synthesis/app-executor.ts` spawns
+ * the CDK app and is isolated today only because its tests mock
+ * `node:child_process` — not because of anything here. The REPORTING half has
+ * one gap of its own behind those three: a violation recorded after the file's
+ * `afterAll` drain — a floating async teardown that resolves past file end —
+ * dies with the worker and leaves the run green, so the refusal still holds and
+ * only the report is lost.
+ *
+ * Only AWS endpoints and the link-local credential addresses are refused. Tests
+ * that talk to a local HTTP server (tests/unit/local/**, the asset-manifest
+ * loader, ...) are deliberately unaffected — a fence that refused everything
+ * would pass its own positive test while telling us nothing.
+ *
+ * There is deliberately NO env-var kill switch. Other gates in this repo bypass
+ * through one (`CDKD_SKIP_CI_GREEN_GATE=1`, `CDKD_ALLOW_DIRTY_RESTORE=1`, ...),
+ * but those gate the AGENT's own commands, where an inherited value shows up in
+ * the transcript of the very command it disarms. This one gates a whole test
+ * run, where an inherited environment is precisely how a safety control goes
+ * quietly inert — and what it protects against is a GREEN run that created
+ * billable resources. Code that genuinely needs the network belongs in the
+ * shell-driven integration suite under `tests/integration/`, which vitest does
+ * not execute: `vite.config.ts` collects only `.test.ts` files, and there are
+ * none under `tests/integration/` (nor under `src/`) today.
+ * `expectAwsFenceViolation()` below opts out of REPORTING only — it never lets
+ * a call through.
+ * ------------------------------------------------------------------------ */
+
+const AWS_FENCE_MARKER = '[cdkd unit-test AWS fence]';
+
+/**
+ * Endpoint suffixes, matched anchored (`host === suffix` or `host` ends with
+ * `.${suffix}`) so `notamazonaws.com` and `amazonaws.com.evil.example` do not
+ * match.
+ *
+ * The partition suffixes are the ones in `src/utils/aws-partition.ts`'s
+ * `PARTITION_TABLE`, which is the repo's own source of truth for them.
+ * Best-effort: cdkd has no ISO / EUSC coverage today, so these are here to keep
+ * a future non-commercial endpoint from being the one hole in the fence, not
+ * because any current test approaches one.
+ */
+const AWS_ENDPOINT_SUFFIXES = [
+  'amazonaws.com', // commercial + GovCloud
+  'amazonaws.com.cn', // aws-cn
+  'c2s.ic.gov', // aws-iso
+  'sc2s.sgov.gov', // aws-iso-b
+  'csp.hci.ic.gov', // aws-iso-f
+  'cloud.adc-e.uk', // aws-iso-e
+  'amazonaws.eu', // aws-eusc
+  'api.aws', // dual-stack service endpoints
+  'on.aws', // Lambda Function URLs
+] as const;
+
+/**
+ * Link-local credential endpoints reached by the default credential chain.
+ * Every constant below was read out of the INSTALLED SDK, not from memory:
+ *
+ * - `169.254.169.254` / `fd00:ec2::254` — IMDSv2. `Endpoint.IPv4` /
+ *   `Endpoint.IPv6` in `@smithy/credential-provider-imds`.
+ * - `169.254.170.2` — ECS task role. `CMDS_IP` in
+ *   `@smithy/credential-provider-imds`, `ECS_CONTAINER_HOST` in
+ *   `@aws-sdk/credential-provider-http`.
+ * - `169.254.170.23` / `fd00:ec2::23` — EKS Pod Identity.
+ *   `EKS_CONTAINER_HOST_IPv4` / `EKS_CONTAINER_HOST_IPv6` in
+ *   `@aws-sdk/credential-provider-http`.
+ *
+ * The last three matter on a containerized runner specifically: there the chain
+ * does not fail, it MINTS a real credential set into the worker, which is the
+ * state this fence exists to make impossible.
+ */
+const AWS_METADATA_HOSTS = [
+  '169.254.169.254',
+  'fd00:ec2::254',
+  '169.254.170.2',
+  '169.254.170.23',
+  'fd00:ec2::23',
+] as const;
+
+const normalizeHost = (raw: string): string => {
+  let host = raw.trim().toLowerCase();
+  if (host.startsWith('[')) {
+    const close = host.indexOf(']');
+    if (close !== -1) {
+      return host.slice(1, close);
+    }
+  }
+  // Strip a `:port` suffix, but only when the single colon cannot be part of a
+  // bare IPv6 literal.
+  const colon = host.indexOf(':');
+  if (colon !== -1 && host.indexOf(':', colon + 1) === -1) {
+    host = host.slice(0, colon);
+  }
+  return host.endsWith('.') ? host.slice(0, -1) : host;
+};
+
+const isAwsHost = (raw: string): boolean => {
+  const host = normalizeHost(raw);
+  if (host.length === 0) {
+    return false;
+  }
+  if ((AWS_METADATA_HOSTS as readonly string[]).includes(host)) {
+    return true;
+  }
+  return AWS_ENDPOINT_SUFFIXES.some((suffix) => host === suffix || host.endsWith(`.${suffix}`));
+};
+
+/**
+ * The SDK package (and its client class) behind a refused endpoint, keyed by the
+ * host's FIRST label — the service label the SDK's own endpoint resolver emits.
+ *
+ * An explicit map rather than a host -> package transform, because there is no
+ * such transform. The SDK re-hyphenates several service names, and the two this
+ * fence has already caught disagree with their endpoints in OPPOSITE directions:
+ * `application-autoscaling.<region>.amazonaws.com` is served by
+ * `@aws-sdk/client-application-auto-scaling` (the package splits a word the host
+ * runs together), while `route53.amazonaws.com` is served by
+ * `@aws-sdk/client-route-53` (the package splits digits off a name the host runs
+ * together). A name derived from the host would be plausible and WRONG, which is
+ * worse than no name: `.claude/rules/testing.md` records that a mis-spelled
+ * `vi.mock` target is silently INERT, so the fence would be handing the reader a
+ * mock that changes nothing and a rerun that still transacts with AWS.
+ *
+ * Deliberately small — only the services a cdkd unit test has actually been
+ * caught reaching (`cloudformation`, `sts` and `application-autoscaling`, the
+ * three behind the nine files this fence found) plus `route53`, which the
+ * fence's own test drives. Every row was read out of the INSTALLED SDK rather
+ * than from memory: the host from `client.config.endpointProvider(...)`, the
+ * class from the package's own exports. Any other host takes the generic arm
+ * below, which names the host and refuses to guess.
+ */
+const AWS_SDK_PACKAGE_BY_SERVICE_LABEL: Readonly<
+  Record<string, { readonly package: string; readonly client: string } | undefined>
+> = {
+  'application-autoscaling': {
+    package: '@aws-sdk/client-application-auto-scaling',
+    client: 'ApplicationAutoScalingClient',
+  },
+  cloudformation: {
+    package: '@aws-sdk/client-cloudformation',
+    client: 'CloudFormationClient',
+  },
+  route53: { package: '@aws-sdk/client-route-53', client: 'Route53Client' },
+  sts: { package: '@aws-sdk/client-sts', client: 'STSClient' },
+};
+
+const sdkPackageForHost = (
+  host: string
+): { readonly package: string; readonly client: string } | undefined => {
+  const label = normalizeHost(host).split('.')[0];
+  return label === undefined ? undefined : AWS_SDK_PACKAGE_BY_SERVICE_LABEL[label];
+};
+
+/**
+ * The ledger entry format, minted and read back in one place so the reader half
+ * cannot drift from the writer half.
+ */
+const AWS_FENCE_VIA_SEPARATOR = ' (via ';
+
+const formatAwsFenceViolation = (host: string, via: string, origin: string): string =>
+  `${host}${AWS_FENCE_VIA_SEPARATOR}${via}) — from ${origin}`;
+
+/**
+ * The host back out of a ledger entry. Not a parse of foreign input: the string
+ * is produced by `formatAwsFenceViolation` directly above, and a hostname can
+ * never contain the separator. `auditAwsFenceViolations` is an exported seam
+ * that a test may drive with an arbitrary string, so an entry without the
+ * separator yields `undefined` and routes the remedy to its generic arm rather
+ * than reporting a host that was never refused.
+ */
+const hostFromAwsFenceViolation = (entry: string): string | undefined => {
+  const cut = entry.indexOf(AWS_FENCE_VIA_SEPARATOR);
+  return cut > 0 ? entry.slice(0, cut) : undefined;
+};
+
+/**
+ * The remedy half of the message, DERIVED from the host(s) that were refused.
+ * Shared by the thrown error and by the `afterEach` report, so an escape that is
+ * swallowed by a bare `rejects.toThrow()` still surfaces the same actionable
+ * text.
+ *
+ * Why it takes the hosts at all: a fixed template naming one package tells a
+ * reader whose test reached `application-autoscaling...` to mock
+ * `@aws-sdk/client-route-53`, i.e. to add a mock that isolates nothing. The
+ * message is the whole discovery half of this control, so it has to name the
+ * package for the endpoint actually refused, or say plainly that it cannot.
+ */
+const awsFenceRemedyLines = (hosts: readonly string[]): readonly string[] => {
+  const distinct = [...new Set(hosts.map((host) => normalizeHost(host)))].filter(
+    (host) => host.length > 0
+  );
+  const [first] = distinct;
+  // A concrete package only when exactly ONE endpoint was refused and it is a
+  // row of the map above. Several endpoints at once, or an unmapped one, both
+  // take the generic arm — printing one package beside a list of hosts would
+  // re-create the mis-direction this exists to remove.
+  const mapped =
+    distinct.length === 1 && first !== undefined ? sdkPackageForHost(first) : undefined;
+
+  const remedy =
+    mapped !== undefined && first !== undefined
+      ? [
+          'Remedy: mock the SDK PACKAGE the escaping client is constructed from, not',
+          'only the shared client factory. The refused endpoint',
+          `  ${first}`,
+          `is served by ${mapped.package}:`,
+          '',
+          `  vi.mock('${mapped.package}', () => ({`,
+          `    ${mapped.client}: vi.fn(() => ({ send: sendMock })),`,
+          '    // ...plus every Command the code under test constructs, e.g.',
+          '    // SomeCommand: vi.fn((input) => ({ input })),',
+          '  }));',
+        ]
+      : [
+          'Remedy: mock the SDK PACKAGE the escaping client is constructed from, not',
+          // Why the generic arm was reached decides the sentence. Saying "no
+          // mapping" for a MULTI-host report would be false whenever the fence
+          // does map those hosts — it declined to print one package beside two
+          // endpoints, which is a different thing.
+          ...(distinct.length > 1
+            ? [
+                'only the shared client factory. Several endpoints were refused, so this',
+                'message names no single package:',
+                ...distinct.map((host) => `  ${host}`),
+              ]
+            : distinct.length === 1
+              ? [
+                  'only the shared client factory. This fence has no package mapping for',
+                  ...distinct.map((host) => `  ${host}`),
+                ]
+              : ['only the shared client factory. This report names no endpoint,']),
+          'so read the specifier off the `new <Service>Client(...)` call the stack',
+          'trace points at and mock THAT string verbatim. Do NOT spell it from the',
+          'host: the SDK re-hyphenates several service names, so a derived name may',
+          'name no package at all — and a mis-spelled vi.mock target is silently',
+          'INERT, which leaves the run green and still transacting.',
+          ...(distinct.some((host) => (AWS_METADATA_HOSTS as readonly string[]).includes(host))
+            ? [
+                '',
+                'A link-local address here is the default credential chain, which only',
+                'runs because a real client was constructed; the same remedy applies.',
+              ]
+            : []),
+          '',
+          "  vi.mock('<the specifier the provider imports>', () => ({",
+          '    <Service>Client: vi.fn(() => ({ send: sendMock })),',
+          '  }));',
+        ];
+
+  return [
+    'Tests run under vitest must never transact with AWS. A call that succeeds',
+    'creates real, billable resources in whatever account the runner is',
+    'authenticated to, and the test still reports green (issue #2081).',
+    '',
+    'This almost always means an SDK client escaped its mock. Mocking',
+    "'src/utils/aws-clients.js' does NOT isolate a provider that builds its own",
+    'client — `new Route53Client({ region })` inside the provider ignores that mock',
+    'entirely. The converse is just as true: when the escaping client comes FROM',
+    "that factory, mocking 'src/utils/aws-clients.js' is the fix and a package mock",
+    'is not. Find the construction site before choosing which one to add.',
+    '',
+    ...remedy,
+    '',
+    'tests/unit/provisioning/route53-provider.test.ts shows the established shape',
+    'for a package mock.',
+    '',
+    'If the code under test genuinely needs real AWS, it does not belong in the',
+    'vitest suite at all: cdkd covers real AWS with the shell-driven integration',
+    'tests under tests/integration/, run via `/run-integ`. There is no env-var',
+    'bypass for this fence.',
+    '',
+    'A test that asserts ON the fence calls `expectAwsFenceViolation()` from',
+    'tests/setup.ts, once per test, BEFORE the call it expects to be refused.',
+  ];
+};
+
+class UnitTestAwsNetworkError extends Error {
+  constructor(host: string, via: string) {
+    super(
+      [
+        `${AWS_FENCE_MARKER} a test tried to reach real AWS at "${host}" (via ${via}).`,
+        '',
+        ...awsFenceRemedyLines([host]),
+      ].join('\n')
+    );
+    this.name = 'UnitTestAwsNetworkError';
+    // Repo convention (`src/utils/error-handler.ts` does the same on every
+    // CdkdError subclass): re-pin the prototype so `instanceof` holds no matter
+    // how the class is downlevelled. Under this repo's `target: "ESNext"` the
+    // native `extends` already preserves it, so today the call is belt-and-
+    // braces rather than load-bearing — it is kept so every error class in the
+    // codebase reads the same way.
+    Object.setPrototypeOf(this, UnitTestAwsNetworkError.prototype);
+  }
+}
+
+/**
+ * Pull the target host out of `http.request` / `https.request` style arguments.
+ *
+ * Node does NOT pick a single winner across the argument list. It merges the
+ * two forms into ONE options object — `{ ...urlToHttpOptions(url), ...options }`
+ * — and then resolves `options.hostname || options.host` in `_http_client`,
+ * defaulting to `localhost`. The URL argument only ever contributes `hostname`
+ * (`urlToHttpOptions()` returns no `host` key at all), so the two fields have to
+ * be tracked SEPARATELY and combined at the end. Measured on Node 24.15.0 by
+ * recording the host handed to `net.Socket.prototype.connect`:
+ *
+ *   request('http://127.0.0.1:9/', { host: 'x.example' })      -> 127.0.0.1
+ *   request('http://127.0.0.1:9/', { hostname: 'x.example' })  -> x.example
+ *   request('http://x.example/',   { host: '127.0.0.1' })      -> x.example
+ *   request({ host: 'a.example', hostname: 'b.example' })      -> b.example
+ *   request({ host: 'a.example' })                             -> a.example
+ *
+ * A last-writer-wins walk — which this used to be — gets rows 1 and 3 wrong in
+ * BOTH directions: it reports `x.example` for a request Node sends to
+ * 127.0.0.1 (a false positive), and `127.0.0.1` for one Node sends to
+ * `x.example` (layer 1 misses; layer 2 still refuses it, only with a less
+ * specific message).
+ *
+ * The subtlety is that an options object OWNING a `hostname` key overrides the
+ * URL's even when the value is empty or `undefined` — that is plain object
+ * spread, not a truthiness test — after which `|| options.host` takes over.
+ * Also measured:
+ *
+ *   request('http://url.example/', { hostname: undefined })              -> localhost
+ *   request('http://url.example/', { hostname: '', host: 'h.example' })  -> h.example
+ *
+ * which is why the `hostname` branch below keys on `hasOwnKey` and then
+ * normalizes an unusable value back to `undefined`.
+ */
+const hasOwnKey = (target: object, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(target, key);
+
+const hostFromRequestArgs = (args: readonly unknown[]): string | undefined => {
+  // Node's merged view of the call: the URL seeds `hostname`; an options object
+  // may override `hostname` and may supply `host`, independently.
+  let hostname: string | undefined;
+  let host: string | undefined;
+  for (const arg of args.slice(0, 2)) {
+    if (typeof arg === 'string') {
+      try {
+        hostname = new URL(arg).hostname;
+      } catch {
+        // Not a URL — Node would reject it too; leave the seed alone.
+      }
+      continue;
+    }
+    if (arg instanceof URL) {
+      hostname = arg.hostname;
+      continue;
+    }
+    if (arg !== null && typeof arg === 'object') {
+      const options = arg as { hostname?: unknown; host?: unknown };
+      if (hasOwnKey(options, 'hostname')) {
+        hostname =
+          typeof options.hostname === 'string' && options.hostname.length > 0
+            ? options.hostname
+            : undefined;
+      }
+      if (typeof options.host === 'string' && options.host.length > 0) {
+        host = options.host;
+      }
+    }
+  }
+  // `options.hostname || options.host`, as `_http_client` spells it.
+  return hostname ?? host;
+};
+
+/** Pull the target host out of `net.Socket.prototype.connect` arguments. */
+const hostFromSocketConnectArgs = (args: readonly unknown[]): string | undefined => {
+  // `net.createConnection()` normalizes its arguments and then calls
+  // `socket.connect(normalizedArray)`, so the real options object arrives
+  // nested one array level deep. Missing this unwrap is what made an earlier
+  // draft of layer 2 silently pass `net.connect({ host: 'sts...' })` through.
+  const flattened = Array.isArray(args[0]) ? (args[0] as unknown[]) : args;
+  const [first, second] = flattened;
+  // connect(port, host?, listener?) — reachable only by calling
+  // `net.Socket.prototype.connect` directly; `net.connect(...)` normalizes to
+  // the options form first.
+  if (typeof first === 'number' || (typeof first === 'string' && /^\d+$/.test(first))) {
+    return typeof second === 'string' ? second : undefined;
+  }
+  // connect(options, listener?). Only `host` — deliberately NOT `hostname`.
+  // `net` has no `hostname` option: a socket given one connects to localhost,
+  // so reading it here would report an AWS host for a connection that never
+  // went to AWS. (`http`/`https` DO honour `hostname`, which is why layer 1
+  // reads it and layer 2 does not.)
+  if (first !== null && typeof first === 'object') {
+    const options = first as { host?: unknown };
+    if (typeof options.host === 'string' && options.host.length > 0) {
+      return options.host;
+    }
+  }
+  return undefined;
+};
+
+type AnyFn = (...args: never[]) => unknown;
+
+const fenceModuleRequestFn = (
+  moduleExports: object,
+  key: 'request' | 'get',
+  label: string
+): void => {
+  const target = moduleExports as Record<string, unknown>;
+  const original = target[key] as AnyFn;
+  if (typeof original !== 'function') {
+    return;
+  }
+  const fenced = function fencedAwsRequest(this: unknown, ...args: unknown[]): unknown {
+    const host = hostFromRequestArgs(args);
+    if (host !== undefined && isAwsHost(host)) {
+      // No socket exists yet on this path — `http.ClientRequest` is what would
+      // create one — so there is nothing to destroy before throwing.
+      throw recordAwsFenceViolation(normalizeHost(host), `${label}.${key}()`);
+    }
+    return (original as (...a: unknown[]) => unknown).apply(this, args);
+  };
+  target[key] = fenced;
+};
+
+// `setupFiles` is re-evaluated for EVERY test file, but `node:http` /
+// `node:https` / `node:net` are external to vite's module graph and so are
+// cached per WORKER. Without this guard the wrappers would stack one level
+// deeper per test file the worker runs. The violation ledger and the
+// expectation flag live on the same object for the same reason: the fenced
+// functions are installed once per worker, while the `afterEach` that reads
+// them is registered once per test FILE.
+const FENCE_INSTALLED_KEY = '__cdkd_aws_network_fence_installed__';
+const FENCE_VIOLATIONS_KEY = '__cdkd_aws_network_fence_violations__';
+const FENCE_EXPECTED_KEY = '__cdkd_aws_network_fence_violation_expected__';
+// Whether a TEST body (as opposed to module top level / `beforeAll` /
+// `afterAll`) is currently executing. vitest's `expect.getState()
+// .currentTestName` is NOT cleared when a test ends, so on its own it would
+// blame the file's last test for a violation raised from an `afterAll`.
+const FENCE_IN_TEST_KEY = '__cdkd_aws_network_fence_in_test__';
+const fenceHost = globalThis as Record<string, unknown>;
+
+const fenceViolations = (): string[] => {
+  const existing = fenceHost[FENCE_VIOLATIONS_KEY];
+  if (Array.isArray(existing)) {
+    return existing as string[];
+  }
+  const created: string[] = [];
+  fenceHost[FENCE_VIOLATIONS_KEY] = created;
+  return created;
+};
+
+/**
+ * Build the refusal AND record it, then hand the error back to the caller to
+ * throw.
+ *
+ * Recording is the half that makes the fence VISIBLE. Throwing alone is not
+ * enough: `tests/unit/**` holds 142 assertions written as a bare
+ * `await expect(...).rejects.toThrow()` with no matcher, and every one of them
+ * is SATISFIED by this error. Without the ledger + the `afterEach` / `afterAll`
+ * audit below, a client that escaped its mock would keep the suite green and
+ * say nothing —
+ * the billable-resource half of the control would hold while the discovery half
+ * (issue #2081's acceptance item 1, "fails, and says so in those terms") would
+ * not.
+ */
+const recordAwsFenceViolation = (host: string, via: string): UnitTestAwsNetworkError => {
+  fenceViolations().push(formatAwsFenceViolation(host, via, currentTestOrigin()));
+  return new UnitTestAwsNetworkError(host, via);
+};
+
+/**
+ * Where the refusal happened, captured AT RECORD TIME.
+ *
+ * The ledger hangs off `globalThis`, i.e. it is shared by every test FILE the
+ * worker runs. That is harmless today only because vitest's `isolate` is on and
+ * each file gets its own process. Under `--no-isolate`, or a future
+ * single-threaded pool, a violation recorded late in file A would redden file
+ * B's first test with a message naming nothing that leads back to A. Stamping
+ * the origin at record time removes the whole class instead of resting on the
+ * pool configuration.
+ */
+const currentTestOrigin = (): string => {
+  try {
+    const state = expect.getState() as { testPath?: unknown; currentTestName?: unknown };
+    const rawPath = typeof state.testPath === 'string' ? state.testPath : undefined;
+    const cwd = `${process.cwd()}/`;
+    const file =
+      rawPath !== undefined && rawPath.startsWith(cwd) ? rawPath.slice(cwd.length) : rawPath;
+    const name =
+      fenceHost[FENCE_IN_TEST_KEY] === true &&
+      typeof state.currentTestName === 'string' &&
+      state.currentTestName.length > 0
+        ? state.currentTestName
+        : undefined;
+    if (file !== undefined && name !== undefined) {
+      return `${file} > ${name}`;
+    }
+    if (file !== undefined) {
+      // No current test: module top level, a `beforeAll`, or an `afterAll`.
+      return `${file} (outside any test — module top level or a beforeAll/afterAll hook)`;
+    }
+    if (name !== undefined) {
+      return name;
+    }
+  } catch {
+    // `expect.getState()` is unavailable outside a vitest run; fall through.
+  }
+  return 'an unidentified test (vitest expect state unavailable)';
+};
+
+/**
+ * The audit both fence hooks run, expressed as a PURE function of the drained
+ * ledger and the drained opt-out flag: it returns the failure message, or
+ * `undefined` when the test is clean.
+ *
+ * Pure on purpose. Two arms of this mechanism can only demonstrate themselves by
+ * FAILING a test — "armed but never tripped" and "an unarmed violation" — so a
+ * nested `describe` cannot cover them. Exporting the decision lets
+ * `tests/unit/aws-network-fence.test.ts` drive both arms with synthetic input
+ * and assert on the answer.
+ */
+export const auditAwsFenceViolations = (
+  violations: readonly string[],
+  expected: boolean
+): string | undefined => {
+  if (expected) {
+    if (violations.length === 0) {
+      return (
+        `${AWS_FENCE_MARKER} expectAwsFenceViolation() was armed for this test, but the ` +
+        'fence never fired. Either the call under test no longer reaches AWS, or the ' +
+        'arming call belongs in a different test.'
+      );
+    }
+    return undefined;
+  }
+
+  if (violations.length === 0) {
+    return undefined;
+  }
+
+  // The remedy is keyed on the endpoints actually refused, so a violation on
+  // `application-autoscaling...` is never answered with the route-53 package.
+  const refusedHosts = violations
+    .map((violation) => hostFromAwsFenceViolation(violation))
+    .filter((host): host is string => host !== undefined);
+
+  return [
+    `${AWS_FENCE_MARKER} this test file reached real AWS. The call was REFUSED, but the`,
+    'assertion around it did not notice — a bare `rejects.toThrow()` is satisfied by',
+    'the refusal itself, so the escape would otherwise have stayed invisible.',
+    '',
+    `Refused ${violations.length === 1 ? 'call' : `calls (${violations.length})`}:`,
+    ...violations.map((violation) => `  - ${violation}`),
+    '',
+    ...awsFenceRemedyLines(refusedHosts),
+  ].join('\n');
+};
+
+/** Read-and-clear the violation ledger. Exported as the seam the audit tests drive. */
+export const drainAwsFenceViolations = (): string[] => fenceViolations().splice(0);
+
+/** Read-and-clear the per-test opt-out flag. Exported for the same reason. */
+export const drainAwsFenceExpectation = (): boolean => {
+  const expected = fenceHost[FENCE_EXPECTED_KEY] === true;
+  fenceHost[FENCE_EXPECTED_KEY] = false;
+  return expected;
+};
+
+/**
+ * Opt out of the post-test report (`afterEach`, and the `afterAll` sweep behind
+ * it) for the CURRENT test, for a test that is deliberately asserting on the
+ * fence itself.
+ *
+ * Deliberately narrow, three ways over a "fence off" flag:
+ *
+ * - it is armed per TEST and consumed by the very next `afterEach`, so it
+ *   cannot leak past the test that called it;
+ * - it is SELF-VERIFYING — arming it without then tripping the fence fails the
+ *   test, so it cannot be sprinkled around defensively "just in case"; and
+ * - it silences REPORTING only. The call is still refused, so no opt-out
+ *   anywhere can put a real AWS request on the wire.
+ */
+export const expectAwsFenceViolation = (): void => {
+  fenceHost[FENCE_EXPECTED_KEY] = true;
+};
+
+beforeEach(() => {
+  fenceHost[FENCE_IN_TEST_KEY] = true;
+});
+
+const runAwsFenceAudit = (): void => {
+  fenceHost[FENCE_IN_TEST_KEY] = false;
+  // Drain FIRST, unconditionally. If a violation survived into the next test,
+  // one escape would redden every test after it in the file and the real
+  // culprit would be unfindable.
+  const violations = drainAwsFenceViolations();
+  const message = auditAwsFenceViolations(violations, drainAwsFenceExpectation());
+  if (message !== undefined) {
+    throw new Error(message);
+  }
+};
+
+afterEach(runAwsFenceAudit);
+
+// A violation planted AFTER the last `afterEach` — from a file-level
+// `afterAll`, or from a teardown a test scheduled and did not await — used to
+// leave the run GREEN: the ledger simply died with the worker. "Refused but
+// unreported" is exactly the half of this control the reporter exists to close,
+// so drain once more at file end.
+//
+// It cannot double-report: `afterEach` SPLICES the ledger, so this pass only
+// ever sees entries recorded after the last test finished.
+//
+// Ordering is what makes it work, and it was MEASURED rather than assumed: a
+// throwaway file whose own top-level `afterAll` planted a violation went GREEN
+// with this line commented out and RED with it restored. The setup file is
+// evaluated before the test file, so this hook is registered first and runs
+// last under vitest's reverse ordering for `after*` hooks.
+afterAll(runAwsFenceAudit);
+
+if (fenceHost[FENCE_INSTALLED_KEY] !== true) {
+  fenceHost[FENCE_INSTALLED_KEY] = true;
+
+  // Layer 1 — the path `@smithy/node-http-handler` actually takes for every
+  // AWS service call in the installed tree (see the header comment for the
+  // build-resolution detail this depends on).
+  fenceModuleRequestFn(https, 'request', 'node:https');
+  fenceModuleRequestFn(https, 'get', 'node:https');
+  fenceModuleRequestFn(http, 'request', 'node:http');
+  fenceModuleRequestFn(http, 'get', 'node:http');
+
+  // Layer 2 — the backstop for in-process Node networking. Covers builtin
+  // NAMED-import escapes (IMDS), `node:http2.connect`, `node:tls.connect`, and
+  // undici / global `fetch`.
+  const originalSocketConnect = net.Socket.prototype.connect;
+  net.Socket.prototype.connect = function fencedAwsSocketConnect(
+    this: net.Socket,
+    ...args: unknown[]
+  ): net.Socket {
+    const host = hostFromSocketConnectArgs(args);
+    if (host !== undefined && isAwsHost(host)) {
+      const error = recordAwsFenceViolation(
+        normalizeHost(host),
+        'net.Socket.prototype.connect()'
+      );
+      // The socket already exists by the time `connect` is called (`tls.connect`
+      // builds a TLSSocket, then connects it), so throwing without this leaves
+      // one live handle per refusal. `destroy()` on a not-yet-connected socket
+      // is a no-op-and-mark, emits no 'error', and is what keeps a run that
+      // trips the fence N times from ending with N dangling handles.
+      this.destroy();
+      throw error;
+    }
+    return (originalSocketConnect as (...a: unknown[]) => net.Socket).apply(this, args);
+  } as typeof net.Socket.prototype.connect;
+}

--- a/tests/unit/analyzer/diff-calculator.test.ts
+++ b/tests/unit/analyzer/diff-calculator.test.ts
@@ -1,4 +1,48 @@
 import { describe, it, expect, vi } from 'vite-plus/test';
+
+/**
+ * `DiffCalculator` consults the CloudFormation registry schema for create-only
+ * properties (`src/provisioning/create-only-properties.ts` ->
+ * `describe-type.ts` -> `getAwsClients().cloudFormation`), so without a mock
+ * this file issues a REAL `cloudformation:DescribeType` against whatever
+ * account the runner is authenticated to (issue #2081).
+ *
+ * The lookup is mocked to FAIL, not to succeed, and the choice is load-bearing:
+ * every assertion in this file is about the REGISTRY-ONLY classification
+ * (`ReplacementRulesRegistry` plus the reference-propagation rules), which is
+ * exactly the fallback `getCreateOnlyPropertyPaths` takes when DescribeType
+ * fails. That is also the path these tests took in CI before the fence existed,
+ * where no credentials resolve and the call errors out. Feeding a SUCCESSFUL
+ * schema instead would route every case through the schema-driven replacement
+ * branch and silently change what this file covers.
+ *
+ * The error carries the shape the production code actually reads: `withRetry`'s
+ * `isRetryable` is `isThrottlingError`, which inspects `name` and
+ * `$metadata.httpStatusCode`. `AccessDeniedException` / 403 is neither a
+ * throttling name nor a retryable status, so it surfaces on the FIRST attempt
+ * with no backoff sleep — the same fast warn-and-fall-back path a caller
+ * without the `cloudformation:DescribeType` permission gets in production.
+ */
+const mockCloudFormationSend = vi.fn(() => {
+  const error = Object.assign(
+    new Error(
+      'User: arn:aws:iam::123456789012:user/test is not authorized to perform: ' +
+        'cloudformation:DescribeType'
+    ),
+    {
+      name: 'AccessDeniedException',
+      $metadata: { httpStatusCode: 403, requestId: 'test-request-id' },
+    }
+  );
+  return Promise.reject(error);
+});
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    cloudFormation: { send: mockCloudFormationSend },
+  }),
+}));
+
 import { DiffCalculator } from '../../../src/analyzer/diff-calculator.js';
 import { ReplacementRulesRegistry } from '../../../src/analyzer/replacement-rules.js';
 import type { CloudFormationTemplate } from '../../../src/types/resource.js';

--- a/tests/unit/aws-network-fence.test.ts
+++ b/tests/unit/aws-network-fence.test.ts
@@ -1,0 +1,602 @@
+/**
+ * Discrimination tests for the real-AWS network fence installed by
+ * `tests/setup.ts` (issue #2081).
+ *
+ * The fence exists because a provider that constructs its own SDK client
+ * escapes a `getAwsClients` mock and transacts with real AWS from a unit test.
+ * These tests must prove BOTH directions:
+ *
+ *   - it fires on a real SDK client's outbound call, on a provider that
+ *     self-constructs its client, on a raw AWS-bound socket, and on every
+ *     link-local credential endpoint; and
+ *   - it does NOT fire on ordinary local traffic, so a fence that refused every
+ *     outbound connection could not pass this file.
+ *
+ * It must also pin WHICH LAYER refuses. Layer 2 (`net.Socket.prototype.connect`)
+ * is reached synchronously from inside the `http.ClientRequest` constructor, so
+ * every layer-1 case throws the same marker and the same host with layer 1
+ * deleted. The `(via node:https.request())` / `(via node:http.request())`
+ * assertions below are the only thing that reddens when layer 1 goes missing.
+ *
+ * Every test that expects a refusal calls `expectAwsFenceViolation()` first.
+ * That is the setup file's per-test opt-out from its own `afterEach` reporter,
+ * which otherwise fails any test that reached AWS — the reporter is what makes
+ * an escape visible to the 142 `tests/unit/**` assertions written as a bare
+ * `rejects.toThrow()`, all of which the refusal itself would satisfy.
+ *
+ * The one deliberate exception is the "REPORTER itself" block near the bottom.
+ * Its two arms are the ones the reporter cannot show in-band — "armed but never
+ * tripped" and "an unarmed violation" — since each would fail the very test
+ * asserting on it. They drive the setup file's exported audit seams instead
+ * (`drainAwsFenceViolations` / `drainAwsFenceExpectation` /
+ * `auditAwsFenceViolations`), so the ledger is emptied before the `afterEach`
+ * that would otherwise redden them.
+ */
+
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+import type { AddressInfo, LookupFunction } from 'node:net';
+
+import { ListHostedZonesCommand, Route53Client } from '@aws-sdk/client-route-53';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
+
+import {
+  auditAwsFenceViolations,
+  drainAwsFenceExpectation,
+  drainAwsFenceViolations,
+  expectAwsFenceViolation,
+} from '../setup.js';
+
+const FENCE_MARKER = '[cdkd unit-test AWS fence]';
+
+/** Explicit dummy credentials: proves the fence is at the NETWORK layer, not the credential layer. */
+const DUMMY_CREDENTIALS = {
+  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+};
+
+/**
+ * The hole issue #2081 reported, reproduced against a REAL provider:
+ * `BudgetsBudgetProvider` resolves the account id through
+ * `getAwsClients().sts` — which this mock does isolate — and then sends
+ * `DescribeBudget` through a `BudgetsClient` it constructs ITSELF, which the
+ * mock cannot reach.
+ */
+const mockStsSend = vi.hoisted(() => vi.fn());
+vi.mock('../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({ sts: { send: mockStsSend } }),
+}));
+
+import { BudgetsBudgetProvider } from '../../src/provisioning/providers/budgets-budget-provider.js';
+
+/** Collect `message` down an error's `cause` chain (undici and the SDK both wrap). */
+const messageChain = (error: unknown): string => {
+  const messages: string[] = [];
+  for (let e: unknown = error; e instanceof Error; e = (e as { cause?: unknown }).cause) {
+    messages.push(e.message);
+  }
+  return messages.join('\n');
+};
+
+/**
+ * Run a request the fence must LET THROUGH, and dispose of the live
+ * `ClientRequest` it returns.
+ *
+ * Every non-refused row points at 127.0.0.1 / localhost on port 1, where
+ * nothing listens: the connection fails asynchronously, so without an 'error'
+ * listener the rejection surfaces against whichever test happens to be running.
+ */
+const expectNoFence = (call: () => http.ClientRequest, why?: string): void => {
+  let request: http.ClientRequest | undefined;
+  expect(() => {
+    request = call();
+  }, why).not.toThrow();
+  request?.on('error', () => {});
+  request?.destroy();
+};
+
+describe('AWS network fence — fires on real AWS traffic', () => {
+  it('refuses an outbound call from a genuinely-constructed AWS SDK client', async () => {
+    expectAwsFenceViolation();
+    const client = new Route53Client({
+      region: 'us-east-1',
+      credentials: DUMMY_CREDENTIALS,
+      maxAttempts: 1,
+    });
+
+    await expect(client.send(new ListHostedZonesCommand({}))).rejects.toThrow(
+      /\[cdkd unit-test AWS fence\]/
+    );
+
+    await expect(client.send(new ListHostedZonesCommand({}))).rejects.toThrow(/amazonaws\.com/);
+  });
+
+  it('names the host and the concrete vi.mock remedy in the message', async () => {
+    expectAwsFenceViolation();
+    const client = new Route53Client({
+      region: 'us-east-1',
+      credentials: DUMMY_CREDENTIALS,
+      maxAttempts: 1,
+    });
+
+    const error = await client.send(new ListHostedZonesCommand({})).catch((e: unknown) => e);
+    const message = (error as Error).message;
+
+    expect(message).toContain(FENCE_MARKER);
+    expect(message).toContain('route53.amazonaws.com');
+    expect(message).toContain("vi.mock('@aws-sdk/client-route-53'");
+    expect(message).toContain("'src/utils/aws-clients.js' does NOT isolate");
+  });
+
+  it('fires through a provider that self-constructs its client while only getAwsClients is mocked', async () => {
+    expectAwsFenceViolation();
+    mockStsSend.mockResolvedValue({ Account: '123456789012' });
+
+    const saved = {
+      region: process.env['AWS_REGION'],
+      accessKeyId: process.env['AWS_ACCESS_KEY_ID'],
+      secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY'],
+      sessionToken: process.env['AWS_SESSION_TOKEN'],
+    };
+    // Pin credential + region resolution to dummies so the case measures the
+    // FENCE and not the runner's ambient AWS config. It still reaches the wire:
+    // an env credential resolves without any network of its own.
+    process.env['AWS_REGION'] = 'us-east-1';
+    process.env['AWS_ACCESS_KEY_ID'] = DUMMY_CREDENTIALS.accessKeyId;
+    process.env['AWS_SECRET_ACCESS_KEY'] = DUMMY_CREDENTIALS.secretAccessKey;
+    delete process.env['AWS_SESSION_TOKEN'];
+
+    try {
+      const provider = new BudgetsBudgetProvider();
+      const error = await provider
+        .getAttribute('cdkd-fence-probe-budget', 'AWS::Budgets::Budget', 'Arn')
+        .catch((e: unknown) => e);
+
+      // The `getAwsClients` half WAS isolated — that is exactly why the hole is
+      // invisible without this fence.
+      expect(mockStsSend).toHaveBeenCalledTimes(1);
+
+      const chain = messageChain(error);
+      expect(chain).toContain(FENCE_MARKER);
+      expect(chain).toContain('budgets.amazonaws.com');
+    } finally {
+      for (const [key, value] of [
+        ['AWS_REGION', saved.region],
+        ['AWS_ACCESS_KEY_ID', saved.accessKeyId],
+        ['AWS_SECRET_ACCESS_KEY', saved.secretAccessKey],
+        ['AWS_SESSION_TOKEN', saved.sessionToken],
+      ] as const) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
+
+  it('refuses a direct https.request to an AWS endpoint (layer 1)', () => {
+    expectAwsFenceViolation();
+    expect(() => https.request('https://sqs.us-east-1.amazonaws.com/')).toThrow(
+      /sqs\.us-east-1\.amazonaws\.com/
+    );
+    expect(() => https.request({ hostname: 'cloudcontrolapi.us-east-1.amazonaws.com' })).toThrow(
+      FENCE_MARKER
+    );
+    // China partition + the newer *.api.aws suffix.
+    expect(() => https.request({ host: 's3.cn-north-1.amazonaws.com.cn' })).toThrow(FENCE_MARKER);
+    expect(() => https.request({ host: 'bedrock.us-east-1.api.aws' })).toThrow(FENCE_MARKER);
+  });
+
+  it('names LAYER 1 as the refusing layer, so deleting layer 1 cannot stay green', () => {
+    expectAwsFenceViolation();
+    // Layer 2 is reached synchronously from the `http.ClientRequest`
+    // constructor and produces the same marker and the same host, so the LABEL
+    // is the only discriminator between the two layers.
+    expect(() => https.request({ hostname: 'sqs.us-east-1.amazonaws.com' })).toThrow(
+      '(via node:https.request())'
+    );
+    expect(() => https.get({ hostname: 'sqs.us-east-1.amazonaws.com' })).toThrow(
+      '(via node:https.get())'
+    );
+    expect(() => http.request({ host: 'sqs.us-east-1.amazonaws.com' })).toThrow(
+      '(via node:http.request())'
+    );
+    expect(() => http.get({ host: 'sqs.us-east-1.amazonaws.com' })).toThrow(
+      '(via node:http.get())'
+    );
+  });
+
+  it('reads the host the way Node does when request(url, options) disagree', () => {
+    expectAwsFenceViolation();
+    // Node merges the two arguments into one options object and resolves
+    // `options.hostname || options.host`. The URL contributes `hostname`, so an
+    // options `hostname` overrides it and this connects to AWS despite the URL.
+    // Taking the first argument that yields a host would read `127.0.0.1` and
+    // wave it through at layer 1.
+    expect(() =>
+      http.request('http://127.0.0.1/', { hostname: 'sqs.us-east-1.amazonaws.com' })
+    ).toThrow('(via node:http.request())');
+
+    // The INVERSE, and the reason a last-writer-wins walk was wrong: an options
+    // `host` does NOT beat a URL. Measured on Node 24.15.0 by recording the host
+    // handed to `net.Socket.prototype.connect` — this call connects to
+    // 127.0.0.1, so refusing it would be a FALSE POSITIVE. This assertion used
+    // to read `.toThrow(FENCE_MARKER)` with a comment claiming Node honours
+    // `host` here; it does not.
+    expectNoFence(() =>
+      http.request('http://127.0.0.1:1/', { host: 'sqs.us-east-1.amazonaws.com' })
+    );
+  });
+
+  it('matches Node over the whole {url, hostname, host} merge table', () => {
+    expectAwsFenceViolation();
+    // Every `connects` value below was MEASURED on Node 24.15.0 by replacing
+    // `net.Socket.prototype.connect` with a recorder, not reasoned about — a
+    // previous round of this file got the third row backwards by reasoning.
+    const AWS = 'sqs.us-east-1.amazonaws.com';
+    const cases: ReadonlyArray<{
+      readonly why: string;
+      readonly call: () => http.ClientRequest;
+      readonly connects: string;
+    }> = [
+      {
+        why: 'url only — the URL is the whole answer',
+        call: () => http.request(`http://${AWS}/`),
+        connects: AWS,
+      },
+      {
+        why: 'url + options.hostname — hostname overrides the URL',
+        call: () => http.request('http://127.0.0.1:1/', { hostname: AWS }),
+        connects: AWS,
+      },
+      {
+        why: 'url + options.host — host does NOT override the URL hostname',
+        call: () => http.request('http://127.0.0.1:1/', { host: AWS }),
+        connects: '127.0.0.1',
+      },
+      {
+        why: 'options.host alone — nothing supplies a hostname, so host is used',
+        call: () => http.request({ host: AWS, port: 1 }),
+        connects: AWS,
+      },
+      {
+        why: 'AWS url + a local options.hostname — the override points away from AWS',
+        call: () => http.request(`http://${AWS}/`, { hostname: '127.0.0.1', port: 1 }),
+        connects: '127.0.0.1',
+      },
+      {
+        why: 'AWS url + a local options.host — the URL hostname still wins',
+        call: () => http.request(`http://${AWS}/`, { host: '127.0.0.1' }),
+        connects: AWS,
+      },
+      {
+        why: 'neither — Node defaults to localhost',
+        call: () => http.request({ path: '/', port: 1 }),
+        connects: 'localhost',
+      },
+    ];
+
+    for (const { why, call, connects } of cases) {
+      if (connects === AWS) {
+        expect(call, why).toThrow(FENCE_MARKER);
+      } else {
+        expectNoFence(call, why);
+      }
+    }
+  });
+
+  it('leaves the URL host standing when the options object names no host', () => {
+    expectAwsFenceViolation();
+    // The overwhelmingly common two-argument shape: the options carry a method,
+    // not a host. The URL must still be what is checked.
+    expect(() =>
+      http.request('http://sqs.us-east-1.amazonaws.com/', { method: 'POST' })
+    ).toThrow(FENCE_MARKER);
+  });
+
+  it('normalizes the host before matching (case, port, brackets, trailing dot, URL object)', () => {
+    expectAwsFenceViolation();
+    const cases: ReadonlyArray<readonly [string, string]> = [
+      ['SQS.US-EAST-1.AmazonAWS.COM', 'upper case — AWS hostnames are case-insensitive'],
+      ['sqs.us-east-1.amazonaws.com:443', 'an explicit :port suffix'],
+      ['sqs.us-east-1.amazonaws.com.', 'a fully-qualified trailing dot'],
+      ['SQS.US-EAST-1.AMAZONAWS.COM.:443', 'all three at once'],
+      ['amazonaws.com', 'the apex itself, matched by `host === suffix`'],
+      ['api.aws', 'the api.aws apex'],
+      ['[fd00:ec2::254]', 'a bracketed IPv6 literal'],
+      ['fd00:ec2::254', 'a bare IPv6 literal, which must NOT be read as host:port'],
+    ];
+    for (const [host, why] of cases) {
+      expect(() => https.request({ host }), why).toThrow(FENCE_MARKER);
+    }
+
+    // A `URL` instance, not a string, is a first-class argument form.
+    expect(() => https.request(new URL('https://sqs.us-east-1.amazonaws.com/'))).toThrow(
+      '(via node:https.request())'
+    );
+  });
+
+  it('refuses every link-local credential endpoint the installed SDK knows', () => {
+    expectAwsFenceViolation();
+    const cases: ReadonlyArray<readonly [string, string]> = [
+      ['169.254.169.254', 'IMDSv2 IPv4 (Endpoint.IPv4)'],
+      ['fd00:ec2::254', 'IMDSv2 IPv6 (Endpoint.IPv6)'],
+      ['[fd00:ec2::254]', 'IMDSv2 IPv6, bracketed as the SDK spells it'],
+      ['169.254.170.2', 'ECS task role (CMDS_IP / ECS_CONTAINER_HOST)'],
+      ['169.254.170.23', 'EKS Pod Identity IPv4 (EKS_CONTAINER_HOST_IPv4)'],
+      ['[fd00:ec2::23]', 'EKS Pod Identity IPv6 (EKS_CONTAINER_HOST_IPv6)'],
+      ['fd00:ec2::23', 'EKS Pod Identity IPv6, unbracketed'],
+    ];
+    for (const [host, why] of cases) {
+      expect(() => http.request({ host, path: '/' }), why).toThrow(FENCE_MARKER);
+      expect(() => net.connect({ host, port: 80 }), why).toThrow(FENCE_MARKER);
+    }
+  });
+
+  it('refuses the non-commercial partition suffixes (best-effort, from PARTITION_TABLE)', () => {
+    expectAwsFenceViolation();
+    const cases: ReadonlyArray<readonly [string, string]> = [
+      ['s3.us-iso-east-1.c2s.ic.gov', 'aws-iso'],
+      ['s3.us-isob-east-1.sc2s.sgov.gov', 'aws-iso-b'],
+      ['s3.us-isof-south-1.csp.hci.ic.gov', 'aws-iso-f'],
+      ['s3.eu-isoe-west-1.cloud.adc-e.uk', 'aws-iso-e'],
+      ['s3.eusc-de-east-1.amazonaws.eu', 'aws-eusc'],
+      ['abc123.lambda-url.us-east-1.on.aws', 'a Lambda Function URL'],
+    ];
+    for (const [host, why] of cases) {
+      expect(() => https.request({ host }), why).toThrow(FENCE_MARKER);
+    }
+  });
+
+  it('refuses a raw AWS-bound socket, so no builtin re-import routes around it', () => {
+    expectAwsFenceViolation();
+    expect(() => net.connect({ host: 'sts.us-east-1.amazonaws.com', port: 443 })).toThrow(
+      /net\.Socket\.prototype\.connect/
+    );
+    expect(() => net.connect(443, 'lambda.us-east-1.amazonaws.com')).toThrow(FENCE_MARKER);
+  });
+
+  it('refuses connect(port, host) called directly on the prototype', () => {
+    expectAwsFenceViolation();
+    // `net.connect(port, host)` normalizes into the OPTIONS form before it
+    // reaches `Socket.prototype.connect` (measured: the wrapper receives
+    // `[[{ port, host }, null]]`), so the numeric-first branch is reachable
+    // only this way — and it IS reachable, which is why it is not dead code.
+    const socket = new net.Socket();
+    expect(() => socket.connect(443, 'lambda.us-east-1.amazonaws.com')).toThrow(
+      /net\.Socket\.prototype\.connect/
+    );
+    expect(socket.destroyed, 'the refusal must not leak a live handle').toBe(true);
+  });
+
+  it('refuses global fetch to AWS (undici bottoms out on the socket backstop)', async () => {
+    expectAwsFenceViolation();
+    const error = await fetch('https://sts.us-east-1.amazonaws.com/').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(Error);
+
+    // undici wraps connector failures, so walk the cause chain.
+    expect(messageChain(error)).toContain(FENCE_MARKER);
+  });
+});
+
+describe('AWS network fence — the remedy names the package for the REFUSED endpoint', () => {
+  /**
+   * The message the fence throws for one endpoint.
+   *
+   * The refusal is a REAL one — layer 1 raising on `https.request` — so these
+   * tests exercise the same path a leaked client takes, not a synthetic
+   * re-statement of the remedy builder. Layer 1 throws before a socket exists,
+   * so nothing here leaves a live handle behind.
+   */
+  const refusalMessageFor = (host: string): string => {
+    try {
+      https.request({ host });
+    } catch (error) {
+      return (error as Error).message;
+    }
+    throw new Error(`the fence did not refuse ${host}`);
+  };
+
+  it('derives the package for an endpoint the SDK spells DIFFERENTLY', () => {
+    expectAwsFenceViolation();
+    const message = refusalMessageFor('application-autoscaling.us-east-1.amazonaws.com');
+
+    expect(message).toContain('application-autoscaling.us-east-1.amazonaws.com');
+    // The whole point: the host runs "autoscaling" together, the package splits
+    // it. A naive host -> package transform emits the second string below,
+    // which is not a package that exists — and `.claude/rules/testing.md`
+    // records that a mis-spelled vi.mock target is silently INERT, so shipping
+    // it would be worse than shipping no name.
+    expect(message).toContain("vi.mock('@aws-sdk/client-application-auto-scaling'");
+    expect(message).toContain('ApplicationAutoScalingClient: vi.fn(');
+    expect(message).not.toContain('@aws-sdk/client-application-autoscaling');
+    // And it must not fall back on the hardcoded package the message used to
+    // name for every host, which is the defect this arm exists to pin.
+    expect(message).not.toContain('@aws-sdk/client-route-53');
+  });
+
+  it('derives the package for a second service, where host and package DO agree', () => {
+    expectAwsFenceViolation();
+    const message = refusalMessageFor('cloudformation.us-east-1.amazonaws.com');
+
+    expect(message).toContain('cloudformation.us-east-1.amazonaws.com');
+    expect(message).toContain("vi.mock('@aws-sdk/client-cloudformation'");
+    expect(message).toContain('CloudFormationClient: vi.fn(');
+    expect(message).not.toContain('@aws-sdk/client-route-53');
+  });
+
+  it('names NO package for an endpoint it has no mapping for', () => {
+    expectAwsFenceViolation();
+    const message = refusalMessageFor('sqs.us-east-1.amazonaws.com');
+
+    expect(message).toContain('sqs.us-east-1.amazonaws.com');
+    expect(message).toContain('no package mapping for');
+    // The strong form of "does not guess": for an unmapped endpoint the message
+    // contains no `@aws-sdk/client-*` string at all, so there is nothing a
+    // reader can copy that would resolve to the wrong package — or to none.
+    expect(message).not.toContain('@aws-sdk/client-');
+  });
+
+  it('names no package when SEVERAL endpoints were refused at once', () => {
+    // No arming here: the ledger is drained by hand below, exactly as the
+    // REPORTER block does, so the file's `afterEach` sees a clean test.
+    refusalMessageFor('route53.amazonaws.com');
+    refusalMessageFor('application-autoscaling.us-east-1.amazonaws.com');
+
+    const violations = drainAwsFenceViolations();
+    expect(violations, 'both refusals must be recorded').toHaveLength(2);
+
+    const verdict = auditAwsFenceViolations(violations, false);
+    expect(verdict).toContain('route53.amazonaws.com');
+    expect(verdict).toContain('application-autoscaling.us-east-1.amazonaws.com');
+    // One package printed beside two hosts would re-create the mis-direction
+    // this whole derivation exists to remove.
+    expect(verdict).not.toContain('@aws-sdk/client-');
+    // ...but the REASON must stay true: both of these hosts ARE mapped, so the
+    // unmapped-endpoint sentence would be a fresh false claim in its place.
+    expect(verdict).toContain('Several endpoints were refused');
+    expect(verdict).not.toContain('no package mapping for');
+  });
+});
+
+describe('AWS network fence — the REPORTER itself', () => {
+  /**
+   * The two arms below are the ones the reporter cannot demonstrate in-band:
+   * each of them, left alone, would FAIL the very test asserting on it. So they
+   * drive `auditAwsFenceViolations()` — the pure decision that `tests/setup.ts`
+   * `afterEach` and `afterAll` both call — with input drained out of the real
+   * ledger and the real opt-out flag. Nothing here is a synthetic re-statement
+   * of the rule: the ledger entry comes from a genuine refusal, and the flag
+   * comes from a genuine `expectAwsFenceViolation()`.
+   */
+
+  it('fails a test that ARMS the opt-out and never trips the fence', () => {
+    // Arm it for real, then drain the flag so this test itself stays green —
+    // draining is exactly what the setup file's `afterEach` does.
+    expectAwsFenceViolation();
+    const armed = drainAwsFenceExpectation();
+    expect(armed, 'expectAwsFenceViolation() must set the flag the audit reads').toBe(true);
+    expect(drainAwsFenceExpectation(), 'and the flag must be one-shot').toBe(false);
+
+    const verdict = auditAwsFenceViolations([], armed);
+    expect(verdict).toContain(FENCE_MARKER);
+    expect(verdict).toContain('was armed for this test, but the fence never fired');
+  });
+
+  it('fails a test that trips the fence WITHOUT arming the opt-out', () => {
+    // Deliberately NO expectAwsFenceViolation() here — this is the unarmed
+    // shape, the one a real escape has.
+    expect(() => https.request({ host: 'sqs.us-east-1.amazonaws.com' })).toThrow(FENCE_MARKER);
+
+    const violations = drainAwsFenceViolations();
+    expect(violations, 'the refusal must be RECORDED, not merely thrown').toHaveLength(1);
+    expect(violations[0]).toContain('sqs.us-east-1.amazonaws.com');
+    // Finding 4: the ledger entry names where it came from, so the report is
+    // self-locating even if a future pool shares a worker across test files.
+    expect(violations[0]).toContain('aws-network-fence.test.ts');
+    expect(violations[0]).toContain('WITHOUT arming');
+
+    const verdict = auditAwsFenceViolations(violations, false);
+    expect(verdict).toContain(FENCE_MARKER);
+    // Finding 3: the file, not the test — a module-top-level or `beforeAll`
+    // escape is reported against a test that never made the call.
+    expect(verdict).toContain('this test file reached real AWS');
+    expect(verdict).toContain('sqs.us-east-1.amazonaws.com');
+    // The remedy half must ride along on the report, not only on the throw.
+    // `sqs` is not a row of the fence's package map, so the report must say so
+    // rather than name a package — the message used to hardcode
+    // `@aws-sdk/client-route-53` here, which told the reader to add a mock that
+    // isolates nothing.
+    expect(verdict).toContain('Remedy: mock the SDK PACKAGE');
+    expect(verdict).toContain('no package mapping for');
+    expect(verdict).not.toContain('@aws-sdk/client-');
+  });
+
+  it('says nothing about a clean test, in either arming state', () => {
+    expect(auditAwsFenceViolations([], false)).toBeUndefined();
+    expect(
+      auditAwsFenceViolations(['x (via y)'], true),
+      'armed AND tripped is the legitimate case'
+    ).toBeUndefined();
+  });
+});
+
+describe('AWS network fence — NEGATIVE CONTROL: local traffic is untouched', () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeAll(async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('local-ok');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('allows an ordinary http.request to a local server (layer 1 is scoped)', async () => {
+    const body = await new Promise<string>((resolve, reject) => {
+      const req = http.request({ host: '127.0.0.1', port, path: '/' }, (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      });
+      req.on('error', reject);
+      req.end();
+    });
+
+    expect(body).toBe('local-ok');
+  });
+
+  it('allows a raw socket connect to a local server (layer 2 is scoped)', async () => {
+    await new Promise<void>((resolve, reject) => {
+      const socket = net.connect({ host: '127.0.0.1', port }, () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.on('error', reject);
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('allows a non-AWS hostname that merely contains "amazonaws"', () => {
+    // Suffix matching must be anchored: none of these is an AWS endpoint.
+    //
+    // `notamazonaws.com` is REGISTRABLE, so it is the one hostname here that a
+    // real resolver would answer. The stub `lookup` keeps this a unit test —
+    // without it the case does live DNS (and, on a hit, a TCP handshake), which
+    // is both a flake offline and an outbound call from a suite whose entire
+    // point is that it makes none. The other two use RFC 2606 reserved TLDs.
+    const lookup: LookupFunction = ((
+      _hostname: string,
+      options: { all?: boolean },
+      callback: (...args: unknown[]) => void
+    ) => {
+      if (options.all === true) {
+        callback(null, [{ address: '127.0.0.1', family: 4 }]);
+        return;
+      }
+      callback(null, '127.0.0.1', 4);
+    }) as unknown as LookupFunction;
+
+    for (const host of [
+      'aws.example.invalid',
+      'notamazonaws.com',
+      'amazonaws.com.evil.invalid',
+    ]) {
+      let request: http.ClientRequest | undefined;
+      expect(() => {
+        request = https.request({ host, port: 443, lookup });
+      }, host).not.toThrow();
+      request?.on('error', () => {});
+      request?.destroy();
+    }
+  });
+});

--- a/tests/unit/deployment/deploy-engine-interrupt-cause.test.ts
+++ b/tests/unit/deployment/deploy-engine-interrupt-cause.test.ts
@@ -3,6 +3,44 @@ import { DeployEngine } from '../../../src/deployment/deploy-engine.js';
 import type { CloudFormationTemplate } from '../../../src/types/resource.js';
 import type { ResourceChange, StackState } from '../../../src/types/state.js';
 
+/**
+ * `DeployEngine.deploy()` warms the create-only DescribeType cache for every
+ * distinct resource type in the template (`deploy-engine.ts` -> {@link
+ * getCreateOnlyPropertyPaths} -> `describe-type.ts` ->
+ * `getAwsClients().cloudFormation`), so without a mock this file issues a REAL
+ * `cloudformation:DescribeType` against whatever account the runner is
+ * authenticated to (issue #2081).
+ *
+ * The lookup is mocked to SUCCEED with the type's real registry
+ * `createOnlyProperties`, not to fail. The prefetch is fire-and-forget and its
+ * result is never read here (`calculateDiff` is itself a mock), so neither
+ * choice can move an assertion — which makes the healthy-account path the
+ * honest default: it exercises the same branch a real deploy takes, and it keeps
+ * a "Grant cloudformation:DescribeType" warning — which has nothing to do with
+ * what this file asserts — out of the run.
+ *
+ * `send` reads `command.input.TypeName` and returns the `{ Schema }` shape
+ * `fetchCreateOnlyPropertyPaths` parses; an unlisted type gets `{}`, which that
+ * parser treats as a successful lookup carrying no create-only paths.
+ */
+const CREATE_ONLY_SCHEMAS: Record<string, string[]> = {
+  'AWS::S3::Bucket': ['/properties/BucketName'],
+};
+
+const mockCloudFormationSend = vi.fn((command: { input?: { TypeName?: string } }) => {
+  const typeName = command?.input?.TypeName ?? '';
+  const createOnlyProperties = CREATE_ONLY_SCHEMAS[typeName];
+  return Promise.resolve(
+    createOnlyProperties ? { Schema: JSON.stringify({ createOnlyProperties }) } : {}
+  );
+});
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    cloudFormation: { send: mockCloudFormationSend },
+  }),
+}));
+
 // Capture logger.error lines so the test can assert on the per-resource
 // failure message a cancelled sibling reports.
 const errorLines: string[] = [];

--- a/tests/unit/deployment/intrinsic-getstackoutput-output-reads.test.ts
+++ b/tests/unit/deployment/intrinsic-getstackoutput-output-reads.test.ts
@@ -45,6 +45,42 @@ cfnMockSend.mockImplementation(async () => {
   throw Object.assign(new Error('Stack does not exist'), { name: 'ValidationError' });
 });
 
+// Mock STS (issue #2081): the cross-account (RoleArn) test below routes through
+// `assumeCrossAccountRole` in `src/utils/role-arn.ts`, which builds its OWN
+// `new STSClient({})` — a client no `src/utils/aws-clients.js` mock can reach.
+// Without this the test issued a REAL `sts:AssumeRole` against whatever account
+// the runner is authenticated to.
+//
+// The call is mocked to FAIL, and that is what the test is written around: its
+// own comment says "the STS mock is absent so the cross-account resolution will
+// fail", and what it pins is that `recordedOutputReads` stays empty even on the
+// cross-account ATTEMPT. Making AssumeRole succeed would need a whole fake
+// ephemeral-bucket state backend behind it and would turn this into a different
+// test — the recording site is guarded by `if (!roleArn)`, so the failing attempt
+// exercises exactly the branch under test.
+//
+// The rejection carries the shape the SDK produces for a trust-policy denial
+// (`name` + `$metadata.httpStatusCode`), which is what `assumeCrossAccountRole`
+// re-wraps into its trust-policy hint and what any downstream error classifier
+// inspects.
+const stsMockSend = vi.hoisted(() => vi.fn());
+vi.mock('@aws-sdk/client-sts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@aws-sdk/client-sts')>();
+  return {
+    ...actual,
+    STSClient: vi.fn().mockImplementation(() => ({ send: stsMockSend, destroy: vi.fn() })),
+  };
+});
+stsMockSend.mockImplementation(async () => {
+  throw Object.assign(
+    new Error(
+      'User: arn:aws:iam::999988887777:user/test is not authorized to perform: ' +
+        'sts:AssumeRole on resource: arn:aws:iam::111122223333:role/cdkd-state-reader'
+    ),
+    { name: 'AccessDenied', $metadata: { httpStatusCode: 403, requestId: 'test-request-id' } }
+  );
+});
+
 import { IntrinsicFunctionResolver } from '../../../src/deployment/intrinsic-function-resolver.js';
 import type { ResolverContext } from '../../../src/deployment/intrinsic-function-resolver.js';
 import type { CloudFormationTemplate } from '../../../src/types/resource.js';
@@ -227,7 +263,15 @@ describe('Fn::GetStackOutput records into context.recordedOutputReads (#668)', (
         },
         buildContext({ recordedOutputReads: recorded })
       )
-    ).rejects.toThrow();
+    ).rejects.toThrow(/AssumeRole into arn:aws:iam::111122223333:role\/cdkd-state-reader failed/);
+    // A BARE `rejects.toThrow()` here was satisfied by anything at all — including
+    // the fence's own refusal back when this file issued a real `sts:AssumeRole`,
+    // and including a `TypeError` from a future refactor. The STS mock above is
+    // what makes the matcher pinnable: with the call isolated, the rejection is
+    // deterministically `assumeCrossAccountRole`'s trust-policy wrapper from
+    // `src/utils/role-arn.ts`, so pin it. That is the same defect this whole
+    // change is about (issue #2081).
+    //
     // Whether the cross-account branch succeeded or failed, the
     // recording site is guarded by `if (!roleArn)` and must NOT
     // have pushed.

--- a/tests/unit/deployment/strict-getatt-output-refusal-cause.test.ts
+++ b/tests/unit/deployment/strict-getatt-output-refusal-cause.test.ts
@@ -31,6 +31,44 @@ import type { CloudFormationTemplate } from '../../../src/types/resource.js';
 import type { ResourceChange, StackState } from '../../../src/types/state.js';
 import { STATE_SCHEMA_VERSION_CURRENT } from '../../../src/types/state.js';
 
+/**
+ * `DeployEngine.deploy()` warms the create-only DescribeType cache for every
+ * distinct resource type in the template (`deploy-engine.ts` -> {@link
+ * getCreateOnlyPropertyPaths} -> `describe-type.ts` ->
+ * `getAwsClients().cloudFormation`), so without a mock this file issues a REAL
+ * `cloudformation:DescribeType` against whatever account the runner is
+ * authenticated to (issue #2081).
+ *
+ * The lookup is mocked to SUCCEED with the type's real registry
+ * `createOnlyProperties`, not to fail. The prefetch is fire-and-forget and its
+ * result is never read here (`calculateDiff` is itself a mock), so neither
+ * choice can move an assertion — which makes the healthy-account path the
+ * honest default: it exercises the same branch a real deploy takes, and it keeps
+ * a "Grant cloudformation:DescribeType" warning — which has nothing to do with
+ * what this file asserts — out of the run.
+ *
+ * `send` reads `command.input.TypeName` and returns the `{ Schema }` shape
+ * `fetchCreateOnlyPropertyPaths` parses; an unlisted type gets `{}`, which that
+ * parser treats as a successful lookup carrying no create-only paths.
+ */
+const CREATE_ONLY_SCHEMAS: Record<string, string[]> = {
+  'AWS::SSM::Parameter': ['/properties/Name'],
+};
+
+const mockCloudFormationSend = vi.fn((command: { input?: { TypeName?: string } }) => {
+  const typeName = command?.input?.TypeName ?? '';
+  const createOnlyProperties = CREATE_ONLY_SCHEMAS[typeName];
+  return Promise.resolve(
+    createOnlyProperties ? { Schema: JSON.stringify({ createOnlyProperties }) } : {}
+  );
+});
+
+vi.mock('../../../src/utils/aws-clients.js', () => ({
+  getAwsClients: () => ({
+    cloudFormation: { send: mockCloudFormationSend },
+  }),
+}));
+
 vi.mock('../../../src/utils/logger.js', () => {
   const fns = {
     setLevel: vi.fn(),

--- a/tests/unit/provisioning/dynamodb-billing-mode-junk-previous.test.ts
+++ b/tests/unit/provisioning/dynamodb-billing-mode-junk-previous.test.ts
@@ -17,6 +17,72 @@ vi.mock('../../../src/utils/aws-clients.js', () => ({
   }),
 }));
 
+// Mock `@aws-sdk/client-application-auto-scaling` (issue #2081) — note the
+// hyphen in `auto-scaling`, which does NOT match the `application-autoscaling`
+// service name in the endpoint host. `DynamoDBGlobalTableProvider`
+// builds its OWN `new ApplicationAutoScalingClient({ region })` for the
+// capacity-target reconciliation (`getLocalAutoScalingClient` /
+// `getRegionalAutoScalingClient` / `readAutoScalingSettings`), so the
+// `src/utils/aws-clients.js` mock above — which only supplies `dynamoDB` —
+// never reaches it. Any test whose template carries a
+// `*CapacityAutoScalingSettings` block therefore issued REAL
+// `application-autoscaling` calls against whatever account the runner is
+// authenticated to.
+//
+// The calls are mocked to SUCCEED, against a table with NOTHING registered
+// yet. That state is deliberately chosen to be observationally identical to the
+// pre-fence behaviour while dropping its noise: `readAutoScalingSettings`
+// returns `null` on an empty `ScalableTargets` list exactly as it does on a
+// thrown error, and `probeExistingAutoScalingTargets` re-asserts every target
+// either way — so nothing these tests assert on moves, but the provider no
+// longer takes the best-effort "Could not register auto-scaling target" WARN
+// branch that a failing client would push it down. The reconciliation is an
+// idempotent upsert, so an unregistered table is the ordinary shape for it.
+//
+// Responses are keyed on the command class and carry the fields the provider
+// actually reads (`ScalableTargets` / `ScalingPolicies` / `NextToken`); the
+// write verbs return their real ARN-bearing shapes even though nothing reads
+// them.
+const autoScalingSend = vi.hoisted(() =>
+  vi.fn(async (command: { constructor: { name: string } }) => {
+    switch (command.constructor.name) {
+      case 'DescribeScalableTargetsCommand':
+        return { ScalableTargets: [] };
+      case 'DescribeScalingPoliciesCommand':
+        return { ScalingPolicies: [] };
+      case 'RegisterScalableTargetCommand':
+        return {
+          ScalableTargetARN:
+            'arn:aws:application-autoscaling:us-east-1:123456789012:scalable-target/1234',
+        };
+      case 'PutScalingPolicyCommand':
+        return {
+          PolicyARN:
+            'arn:aws:autoscaling:us-east-1:123456789012:scalingPolicy:1234:resource/dynamodb/table/my-test-table-xxx:policyName/test',
+          Alarms: [],
+        };
+      case 'DeleteScalingPolicyCommand':
+      case 'DeregisterScalableTargetCommand':
+        return {};
+      default:
+        throw new Error(
+          `unmocked application-autoscaling command: ${command.constructor.name}`
+        );
+    }
+  })
+);
+
+vi.mock('@aws-sdk/client-application-auto-scaling', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@aws-sdk/client-application-auto-scaling')>();
+  return {
+    ...actual,
+    ApplicationAutoScalingClient: vi
+      .fn()
+      .mockImplementation(() => ({ send: autoScalingSend, destroy: vi.fn() })),
+  };
+});
+
 vi.mock('../../../src/utils/logger.js', () => {
   childLogger.child.mockReturnValue(childLogger);
   return {

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-billing-mode-shape.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-billing-mode-shape.test.ts
@@ -17,6 +17,72 @@ vi.mock('../../../src/utils/aws-clients.js', () => ({
   }),
 }));
 
+// Mock `@aws-sdk/client-application-auto-scaling` (issue #2081) — note the
+// hyphen in `auto-scaling`, which does NOT match the `application-autoscaling`
+// service name in the endpoint host. `DynamoDBGlobalTableProvider`
+// builds its OWN `new ApplicationAutoScalingClient({ region })` for the
+// capacity-target reconciliation (`getLocalAutoScalingClient` /
+// `getRegionalAutoScalingClient` / `readAutoScalingSettings`), so the
+// `src/utils/aws-clients.js` mock above — which only supplies `dynamoDB` —
+// never reaches it. Any test whose template carries a
+// `*CapacityAutoScalingSettings` block therefore issued REAL
+// `application-autoscaling` calls against whatever account the runner is
+// authenticated to.
+//
+// The calls are mocked to SUCCEED, against a table with NOTHING registered
+// yet. That state is deliberately chosen to be observationally identical to the
+// pre-fence behaviour while dropping its noise: `readAutoScalingSettings`
+// returns `null` on an empty `ScalableTargets` list exactly as it does on a
+// thrown error, and `probeExistingAutoScalingTargets` re-asserts every target
+// either way — so nothing these tests assert on moves, but the provider no
+// longer takes the best-effort "Could not register auto-scaling target" WARN
+// branch that a failing client would push it down. The reconciliation is an
+// idempotent upsert, so an unregistered table is the ordinary shape for it.
+//
+// Responses are keyed on the command class and carry the fields the provider
+// actually reads (`ScalableTargets` / `ScalingPolicies` / `NextToken`); the
+// write verbs return their real ARN-bearing shapes even though nothing reads
+// them.
+const autoScalingSend = vi.hoisted(() =>
+  vi.fn(async (command: { constructor: { name: string } }) => {
+    switch (command.constructor.name) {
+      case 'DescribeScalableTargetsCommand':
+        return { ScalableTargets: [] };
+      case 'DescribeScalingPoliciesCommand':
+        return { ScalingPolicies: [] };
+      case 'RegisterScalableTargetCommand':
+        return {
+          ScalableTargetARN:
+            'arn:aws:application-autoscaling:us-east-1:123456789012:scalable-target/1234',
+        };
+      case 'PutScalingPolicyCommand':
+        return {
+          PolicyARN:
+            'arn:aws:autoscaling:us-east-1:123456789012:scalingPolicy:1234:resource/dynamodb/table/my-test-table-xxx:policyName/test',
+          Alarms: [],
+        };
+      case 'DeleteScalingPolicyCommand':
+      case 'DeregisterScalableTargetCommand':
+        return {};
+      default:
+        throw new Error(
+          `unmocked application-autoscaling command: ${command.constructor.name}`
+        );
+    }
+  })
+);
+
+vi.mock('@aws-sdk/client-application-auto-scaling', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@aws-sdk/client-application-auto-scaling')>();
+  return {
+    ...actual,
+    ApplicationAutoScalingClient: vi
+      .fn()
+      .mockImplementation(() => ({ send: autoScalingSend, destroy: vi.fn() })),
+  };
+});
+
 vi.mock('../../../src/utils/logger.js', () => {
   childLogger.child.mockReturnValue(childLogger);
   return {

--- a/tests/unit/provisioning/dynamodb-globaltable-provider-gsi-live-baseline.test.ts
+++ b/tests/unit/provisioning/dynamodb-globaltable-provider-gsi-live-baseline.test.ts
@@ -17,6 +17,72 @@ vi.mock('../../../src/utils/aws-clients.js', () => ({
   }),
 }));
 
+// Mock `@aws-sdk/client-application-auto-scaling` (issue #2081) — note the
+// hyphen in `auto-scaling`, which does NOT match the `application-autoscaling`
+// service name in the endpoint host. `DynamoDBGlobalTableProvider`
+// builds its OWN `new ApplicationAutoScalingClient({ region })` for the
+// capacity-target reconciliation (`getLocalAutoScalingClient` /
+// `getRegionalAutoScalingClient` / `readAutoScalingSettings`), so the
+// `src/utils/aws-clients.js` mock above — which only supplies `dynamoDB` —
+// never reaches it. Any test whose template carries a
+// `*CapacityAutoScalingSettings` block therefore issued REAL
+// `application-autoscaling` calls against whatever account the runner is
+// authenticated to.
+//
+// The calls are mocked to SUCCEED, against a table with NOTHING registered
+// yet. That state is deliberately chosen to be observationally identical to the
+// pre-fence behaviour while dropping its noise: `readAutoScalingSettings`
+// returns `null` on an empty `ScalableTargets` list exactly as it does on a
+// thrown error, and `probeExistingAutoScalingTargets` re-asserts every target
+// either way — so nothing these tests assert on moves, but the provider no
+// longer takes the best-effort "Could not register auto-scaling target" WARN
+// branch that a failing client would push it down. The reconciliation is an
+// idempotent upsert, so an unregistered table is the ordinary shape for it.
+//
+// Responses are keyed on the command class and carry the fields the provider
+// actually reads (`ScalableTargets` / `ScalingPolicies` / `NextToken`); the
+// write verbs return their real ARN-bearing shapes even though nothing reads
+// them.
+const autoScalingSend = vi.hoisted(() =>
+  vi.fn(async (command: { constructor: { name: string } }) => {
+    switch (command.constructor.name) {
+      case 'DescribeScalableTargetsCommand':
+        return { ScalableTargets: [] };
+      case 'DescribeScalingPoliciesCommand':
+        return { ScalingPolicies: [] };
+      case 'RegisterScalableTargetCommand':
+        return {
+          ScalableTargetARN:
+            'arn:aws:application-autoscaling:us-east-1:123456789012:scalable-target/1234',
+        };
+      case 'PutScalingPolicyCommand':
+        return {
+          PolicyARN:
+            'arn:aws:autoscaling:us-east-1:123456789012:scalingPolicy:1234:resource/dynamodb/table/my-test-table-xxx:policyName/test',
+          Alarms: [],
+        };
+      case 'DeleteScalingPolicyCommand':
+      case 'DeregisterScalableTargetCommand':
+        return {};
+      default:
+        throw new Error(
+          `unmocked application-autoscaling command: ${command.constructor.name}`
+        );
+    }
+  })
+);
+
+vi.mock('@aws-sdk/client-application-auto-scaling', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@aws-sdk/client-application-auto-scaling')>();
+  return {
+    ...actual,
+    ApplicationAutoScalingClient: vi
+      .fn()
+      .mockImplementation(() => ({ send: autoScalingSend, destroy: vi.fn() })),
+  };
+});
+
 vi.mock('../../../src/utils/logger.js', () => {
   childLogger.child.mockReturnValue(childLogger);
   return {

--- a/tests/unit/provisioning/providers/appsync-provider.test.ts
+++ b/tests/unit/provisioning/providers/appsync-provider.test.ts
@@ -13,6 +13,40 @@ vi.mock('@aws-sdk/client-appsync', async (importOriginal) => {
   };
 });
 
+// Mock STS (issue #2081). `AppSyncProvider`'s update path builds the resource
+// ARN through `buildAppSyncArn`, which resolves the caller's account identity
+// via `getAwsAccountInfo` -> `getAwsClients().sts` — an `STSClient` built inside
+// `src/utils/aws-clients.ts`, which the AppSync package mock above cannot reach.
+// Without this the file issued a REAL `sts:GetCallerIdentity` against whatever
+// account the runner is authenticated to.
+//
+// The call is mocked to SUCCEED with a realistic `GetCallerIdentity` response,
+// because success is what a real deploy does: `resolveAccountIdentity` returns a
+// genuine account id and `buildAppSyncArn` builds a genuine ARN.
+//
+// Stated plainly, since a comment here previously claimed otherwise: NO assertion
+// in this file distinguishes the two polarities. Measured — the file is green with
+// this mock resolving and green with it rejecting. The failure arm would flag the
+// fallback id `fabricated: true` (`src/provisioning/providers/appsync-provider.ts`
+// refuses ARN building on that flag), but nothing here reaches an assertion that
+// can tell the difference. The choice is therefore about fidelity to a real
+// deploy, not about discrimination — do not read it as a covered branch.
+const stsMockSend = vi.hoisted(() =>
+  vi.fn(async () => ({
+    Account: '123456789012',
+    Arn: 'arn:aws:iam::123456789012:user/test',
+    UserId: 'AIDATESTUSERID',
+  }))
+);
+
+vi.mock('@aws-sdk/client-sts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@aws-sdk/client-sts')>();
+  return {
+    ...actual,
+    STSClient: vi.fn().mockImplementation(() => ({ send: stsMockSend, destroy: vi.fn() })),
+  };
+});
+
 vi.mock('../../../../src/utils/logger.js', () => {
   const childLogger = {
     debug: vi.fn(),

--- a/tests/unit/provisioning/route53-provider-import-attributes.test.ts
+++ b/tests/unit/provisioning/route53-provider-import-attributes.test.ts
@@ -46,6 +46,38 @@ vi.mock('@aws-sdk/client-route-53', async () => {
   };
 });
 
+// Mock STS (issue #2081). The NEGATIVE CONTROL at the bottom feeds an EMPTY
+// attribute set to the real resolver, which falls through to the
+// physical-id fallback — and that path resolves the caller's account identity
+// through `getAwsClients().sts`, an `STSClient` built inside
+// `src/utils/aws-clients.ts`. Mocking the Route53 package above does not reach
+// it, so the test issued a REAL `sts:GetCallerIdentity` against whatever
+// account the runner is authenticated to.
+//
+// The call is mocked to SUCCEED with a realistic `GetCallerIdentity` response,
+// because success is what a real deploy does — the healthy answer keeps the
+// fallback path measuring its own mechanism rather than a degraded one.
+//
+// Stated plainly, since a comment here previously claimed otherwise: NO assertion
+// in this file distinguishes the two polarities. Measured — the file is green with
+// this mock resolving and green with it rejecting. What it asserts is the
+// `Fn::Join` refusal over a non-list attribute, which never consults the account
+// id, so the `fabricated: true` degraded branch is simply not observed here. The
+// choice is about fidelity, not coverage.
+const stsMockSend = vi.fn(async () => ({
+  Account: '123456789012',
+  Arn: 'arn:aws:iam::123456789012:user/test',
+  UserId: 'AIDATESTUSERID',
+}));
+
+vi.mock('@aws-sdk/client-sts', async () => {
+  const actual = await vi.importActual('@aws-sdk/client-sts');
+  return {
+    ...actual,
+    STSClient: vi.fn().mockImplementation(() => ({ send: stsMockSend, destroy: vi.fn() })),
+  };
+});
+
 const childLogger = {
   debug: vi.fn(),
   info: vi.fn(),


### PR DESCRIPTION
## Summary

A provider that constructs its OWN SDK client is not isolated by a test that
mocks `src/utils/aws-clients.js`. The provider ignores the mock, the client is
real, and the unit test transacts with whatever AWS account the runner is
authenticated to. The dangerous direction is silent: a call that FAILS looks
like an ordinary red, while one that SUCCEEDS creates a real, billable resource
and still reports green.

`tests/setup.ts` is already vitest's `setupFiles`, so the fence goes there.

## The fence is at the NETWORK layer, not the credential layer

Issue go-to-k/cdkd#2081 proposed a credential-resolution fence. That would not have caught
the hazard it measured: credential resolution never failed in the reported
incident, and a client built with explicit dummy credentials skips resolution
entirely while still transacting. A test pins this by constructing a
`Route53Client` with dummy credentials.

Two layers, because one is defeatable:

1. `http` / `https` `request` + `get` on the module's exports object. Whether a
   consumer sees the replacement depends on which BUILD Node loads:
   `@aws-sdk/client-route-53` 3.1018.0 resolves `@smithy/node-http-handler`
   4.5.0, whose `dist-es` build uses a NAMED import and would escape — but 4.5.0
   ships no `exports` field, so Node loads `dist-cjs`, where `node_https.request`
   is read live. The fragile part is that ABSENT `exports` field.
2. `net.Socket.prototype.connect` as a backstop, since Node snapshots a
   builtin's ESM named exports (`@smithy/credential-provider-imds` is written
   that way). Also covers `http2` and undici / global `fetch`.

The boundary is in-process Node APIs ONLY — `child_process`, `worker_threads`
and a numeric connect to an out-of-band-resolved IP all escape, and the source
says so.

## Refusing is not enough

142 sites under `tests/unit/` assert with a bare `rejects.toThrow()`, which the
fence's own error SATISFIES — so an escaped mock stayed invisible. The
billable-resource half of the control worked; the DISCOVERY half did not.
Violations are recorded and an audit FAILS the test that produced one, running
as both `afterEach` and `afterAll` (a violation from an `afterAll` or module top
level was otherwise dropped). Each entry is stamped with its origin at record
time. The opt-out is per-test, silences REPORTING only, and self-verifies —
arming it without tripping the fence fails the test.

## What it found

The issue's open question was *"that other existing tests have the same hole.
Not checked."* The answer is **nine files, 16 tests**, all reaching real AWS:

| Service | Files |
|---|---|
| cloudformation | `diff-calculator` (5), `deploy-engine-interrupt-cause` (1), `strict-getatt-output-refusal-cause` (2) |
| sts | `intrinsic-getstackoutput-output-reads` (1), `route53-provider-import-attributes` (1), `appsync-provider` (1) |
| application-auto-scaling | `dynamodb-billing-mode-junk-previous` (3), `dynamodb-globaltable-provider-billing-mode-shape` (1), `dynamodb-globaltable-provider-gsi-live-baseline` (1) |

`diff-calculator.test.ts` had no `vi.mock` at all and was calling
`cloudformation:DescribeType` for real, with production code silently falling
back on failure — so in an authenticated environment its behaviour depended on
live AWS schema data.

**Six** of the nine are fixed by mocking the SDK PACKAGE the escaping client is
built from. The other **three** — `diff-calculator`,
`deploy-engine-interrupt-cause`, `strict-getatt-output-refusal-cause` — are
fixed by mocking `src/utils/aws-clients.js`, which is CORRECT there: those
clients come from `getAwsClients().cloudFormation` and nothing self-constructs,
so a package mock would isolate nothing. Which mock is right is decided by WHERE
the client is built — which is why the fence's message now derives the package
from the refused host and says plainly when it cannot. None of the nine is fixed
by an allow-list, an opt-out, a skip, or a loosened assertion. Succeed-vs-fail
was chosen per file, because a test that passed through a FALLBACK path and now
passes through a SUCCESS path is not the same test.

## Host resolution mirrors Node, after three passes

The first two rounds REASONED about `request(url, options)` precedence and both
were wrong. Measured on Node 24.15.0: `urlToHttpOptions` contributes `hostname`
and never `host`, and `_http_client` resolves `options.hostname || options.host`.
The two fields are now tracked separately and `hostname ?? host` returned, with
the `hostname` branch keyed on own-key presence rather than truthiness — an
options object owning `hostname: ''` still overrides the URL's. Seven measured
rows are pinned as a table test, and the earlier assertion that encoded the
wrong precedence is inverted into a negative control.

## Test plan

- Suite on the rebased tree: **815 files / 16,879 tests**, zero fence reports.
  That includes three test files merged by peers during review, so the fence and
  the newly-merged tests are verified to coexist — an interaction neither PR's
  own CI could have exercised.
- Mutation-probed including the reporter itself: the audit's armed-but-not-
  tripped arm, the ledger push, the opt-out flag, the origin stamp and the
  file-vs-test attribution each redden the expected cases and restore identical.
- The two arms that had NO test — opt-out armed but not tripped, and an unarmed
  violation failing the test — are covered through an exported seam.
- Reviewed by code / test / security reviewers plus a fix-delta round.

## Won't-do

Issue go-to-k/cdkd#2081's option 1 (a `scripts/` critic) is deliberately not
added — but **not** because it catches a subset. An earlier draft of this body
said that, and it is false. The fence subsumes option 1 only at RUNTIME: it sees
a leaked client when a test EXERCISES it, so a file that mocks `getAwsClients`,
imports a self-constructing provider, and never calls through it stays green
here while a static scan would flag it. That LATENT escape is option 1's
exclusive catch, and it is not hypothetical — **11** files under `tests/unit/**`
match the predicate today, among them
`dynamodb-globaltable-provider-drift-phantoms.test.ts`, whose provider
constructs `new ApplicationAutoScalingClient` at
`src/provisioning/providers/dynamodb-globaltable-provider.ts:354`.

The issue says "choose one", and the runtime control is the one worth having: it
catches every escape that actually TRANSACTS, including shapes no static
predicate anticipates. Option 1's stated advantage — a better message — is
supplied here by the thrown error, which names the refused host and derives the
`vi.mock('@aws-sdk/client-<svc>', ...)` remedy from it rather than hardcoding
one package. The latent-escape gap is recorded in `.claude/rules/testing.md`.

Closes #2081
