### PR TITLE
chore(work-issues): fence a delegated trim target and an unanchored poll predicate

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1951,6 +1951,22 @@ indistinguishable from any other crash. Pair it with a `Monitor` that emits on
 phase lines AND on log-growth stalling, so a wedge announces itself instead of
 being discovered hours later.
 
+**ANCHOR the predicate the poller waits on, or it reports DONE while the job
+runs.** This flow polls constantly — for a lane agent, a gate chain, a real-AWS
+run — and a loose predicate fails in the one direction that matters, since a
+premature DONE is acted on. Two shapes, both hit on 2026-08-26 in one run.
+A non-empty test (`[ -s "$f" ]`) on an output file the job ECHOES INTO before
+starting: the `PWD=...` line the chain prints first satisfies it, so the poller
+returned at once and the integ looked finished seconds in. And an unanchored
+substring: `grep -q "test_rc="` matches `typecheck_test_rc=` from an EARLIER
+step in the same chain, so a poller waiting for the suite reported done at the
+typecheck. Wait on a line the job writes only at the END, matched anchored
+(`grep -q "^suite_rc="`), and where the job has a process, confirm it is gone
+(`pgrep -f` on its command) rather than inferring it from the file. Neither bug
+touched the work — both were caught by reading the output — but each cost a
+round of re-checking, and the second one nearly had a merge sequence start
+against an unfinished suite.
+
 **The harness's "completed, exit 0" is the exit code of the command you
 BACKGROUNDED, which is not always the job you care about.** Write
 `nohup <long job> > log 2>&1 & echo started` into a backgrounded call and the
@@ -2403,6 +2419,22 @@ without touching the working tree, which matters because an actual `git merge` c
 itself be refused by a gate whose scope the incoming range touches. Then say the
 resulting HEADROOM out loud in the report, because it is what tells the next lane
 whether its own addition will red the same fence.
+
+**And when you hand the trim to someone else, check the target is REACHABLE from
+that lane's own bytes before naming it.** The lane can only spend what it added;
+everything else in the file belongs to other lanes and is not its to cut. So the
+floor is `merge-base size`, not zero, and a target below that floor is an
+instruction to cut somebody else's entry — which is the one thing the same
+paragraph forbids. Measured 2026-08-26: `.claude/rules/hooks.md` came to
+122,724 B against a 120,000 B cap, a trim was dispatched with a target of
+"≤ 118,000 B, i.e. at least 2,000 B of headroom", and that was arithmetically
+impossible — the merge base ALONE was 118,586 B, so reverting the lane's entry
+in full still lands 586 B above the target. The agent did the arithmetic,
+refused, and reported the ceiling (1,414 B of possible headroom) instead of
+quietly cutting a neighbour. Do that subtraction when you WRITE the target:
+`cap - merge_base_size` is the most headroom any single lane can leave, and if
+that number is small the finding is that the FILE is full, which is a different
+issue from this lane's diff.
 
 ```bash
 git checkout main && git pull origin main    # bring the merges local


### PR DESCRIPTION
## Summary

Retrospective from the `/work-issues` run that landed go-to-k/cdkd#2306 /
go-to-k/cdkd#2307 / go-to-k/cdkd#2308. Two lessons, both orchestrator mistakes,
both caught by someone else, neither covered by the existing text.

## Section 9 — a delegated trim target must be arithmetically REACHABLE

The cumulative-budget paragraph already says to measure the merge result rather
than the branch, and it fired exactly as written: `.claude/rules/hooks.md`
measured **119,340 B** on the branch — a comfortable-looking 660 B of headroom —
and **122,724 B** after rebasing onto a peer merge that had grown the same file
by 3,384 B mid-review. `rule-file-payload.test.ts` went 2 failed / 188 passed.

What it does not cover is what happens when the TRIM is delegated with a number
attached. A lane can only spend the bytes it added; everything else belongs to
other lanes, and the same paragraph forbids cutting those — so the floor is the
merge-base size, not zero.

The dispatched target was "≤ 118,000 B, i.e. at least 2,000 B of headroom". The
merge base **alone** was 118,586 B, so reverting the lane's entry in full still
lands 586 B above it: the instruction was unsatisfiable except by cutting a
neighbour's entry. The agent did the subtraction, refused, and reported the real
ceiling — **1,414 B** is the most headroom any single lane can leave in that file.

`cap − merge_base_size` is one subtraction and belongs in the moment the target
is written. When it comes out small, the finding is that the FILE is full, which
is a different issue from the lane's diff (folded into go-to-k/cdkd#2288).

## Section 8 — ANCHOR the predicate a poller waits on

This flow polls constantly — lane agents, gate chains, real-AWS runs — and a
loose predicate fails in the one direction that matters, because a premature
DONE gets acted on. Two shapes, both hit in this one run:

| Predicate | Why it fired early |
|---|---|
| `[ -s "$f" ]` on a task output file | the job ECHOES `PWD=...` before starting, satisfying the non-empty test seconds into a 23-minute integ |
| `grep -q "test_rc="` | matches `typecheck_test_rc=` from an earlier step of the same chain, so a poller waiting on the suite returned at the typecheck |

Remedy: wait on a line the job writes only at the END, matched anchored
(`grep -q "^suite_rc="`), and where there is a process, confirm it is gone with
`pgrep -f` rather than inferring it from a file.

Neither bug corrupted any work — both were caught by reading the output rather
than the predicate — but the second nearly started a merge sequence against an
unfinished suite.

## Placement

Both paragraphs sit where they fire: the trim rule beside the cumulative-budget
measurement it extends, the poll rule beside the watchdog guidance that already
covers the opposite failure (a run that hangs).

## Not proposed as hooks

Neither is mechanically detectable. A hook cannot see the predicate a poller
waits on, and the trim target is a number in a prompt. Per section 10-b that
leaves the skill as the right home.

## One thing deliberately NOT added

`gated-command-preamble-gate.sh` refused this orchestrator **four times** in this
run — a heredoc chained with `markgate set` + `git commit`, then with
`gh pr create` twice, then with `gh issue create`. Each refusal cost one retry
and nothing else, because the gate is doing precisely its job. No prose is
proposed for it: the rule is already in section 6 with three worked examples,
the hook already exists as section 10-b's prescribed escalation, and a fifth
restatement would not change a habit the mechanism already catches 4/4. Recorded
here so the frequency is visible rather than silently absorbed.

## Test plan

- Full suite: **815 files / 16,879 tests**, `Type Errors no errors`, rc=0.
- `tests/unit/scripts/work-issues-skill-refs.test.ts` 5/5 — no bare `#N`
  introduced (verified separately over the added lines).
- Every number asserted above re-derived from the tree: `120,000 − 118,586 =
  1,414` and `118,586 − 118,000 = 586`.
