### PR TITLE
chore(work-issues): close the check-gate hole under .claude/rules, and fence the half-fix

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -706,6 +706,39 @@ grep -rn "<the mishandled call / property / assumption>" src/ | grep -v test
 grep -rln "implements ResourceProvider" src/provisioning/providers/   # per-implementer audits
 ```
 
+**This applies to a FIX ROUND at least as much as to the original find, and
+that is where it actually gets skipped.** The rule above reads as advice for
+discovering a defect; the recurring failure is the fix landing on ONE call site
+while a sibling keeps the defect, usually shipping a comment that asserts
+completeness. Measured across one run on 2026-08-27, FIVE times on two lanes,
+and the last two were in edits made while fixing the previous instance:
+
+| Fix | Sibling that kept the defect |
+| --- | --- |
+| the 2-arg `Fn::Sub` binding check | the bare-string arm, one line over |
+| adding a region-header read | never bounded WHICH errors carry the region |
+| redacting the update/delete warn | the create path, and its own `catch`'s sibling arm |
+| adding a site to one enumeration | the second enumeration in the same file |
+| completing that second enumeration | a third list on the same LINE |
+
+Every one was found by ENUMERATING readers or call sites with grep. None was
+found by re-reading the diff, and three had review rounds that read the diff
+first and missed it. So after writing a fix, before believing it:
+
+```bash
+# Derive the population from the CODE, not from the files your diff touched.
+grep -rn "<the field / helper / message you just changed>" src/ | grep -v test
+```
+
+and check the count against what you changed. If your fix touched two of three
+readers, you have not fixed it -- and if you then write "all N sites now do X",
+you have made it durable, because an overstated invariant is what stops the next
+reader looking. Three of the five above shipped exactly that sentence.
+
+The cheap tell: a fix whose diff touches ONE site while its message says
+"every", "all", "never" or "only". Either derive the population or drop the
+quantifier.
+
 **Grep for the SHAPE, not for a NAME — a name finds only the copies you already
 knew about.** This is the sweep's own version of the defect it exists to
 prevent, and it is easy to miss because the grep looks thorough and returns

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -118,6 +118,28 @@ gates:
       # catches it; what this restores is the LOCAL signal, before the commit
       # rather than minutes later (issue #2041).
       - ".claude/skills/work-issues/**"
+      # `.claude/rules/**` is the #1592 pattern a third time: a checker's INPUT
+      # sitting outside the gate that guards it. TEN tests under
+      # tests/unit/scripts/ read that directory, and
+      # rule-file-payload.test.ts enforces FOUR budgets over it (per-file bytes,
+      # per-line bytes, a repo-wide ratchet on lines over the line cap, and a
+      # CUMULATIVE corpus total). Without this entry a rules edit can flip that
+      # suite red -- or green -- while `check` still verifies fresh, because the
+      # digest never saw the file.
+      #
+      # Measured 2026-08-27, which is why this is here rather than in a comment
+      # somewhere: a lane's `.claude/rules` addition pushed the corpus to
+      # 901,762 B over a 900,000 B ceiling and turned the full suite red, and
+      # `markgate status` reported `check  match` throughout -- both on the
+      # failing tree and after the fix. A marker that can attest to a red tree
+      # is worse than no marker, since the whole point is that the commit gate
+      # trusts it.
+      #
+      # The cost is the same one `work-issues/**` accepted: a rules-only edit
+      # now needs a full `/check`. That is the correct trade -- these files are
+      # edited by nearly every retrospective, which is exactly when the budgets
+      # move.
+      - ".claude/rules/**"
       # CLAUDE.md is a pattern-scanned target of the same checker, so
       # reintroducing banned wording there must stale `check` as well.
       - "CLAUDE.md"


### PR DESCRIPTION
## Summary

Second retrospective for a three-lane `/work-issues` run (go-to-k/cdkd#2230, go-to-k/cdkd#2241 + go-to-k/cdkd#2245, go-to-k/cdkd#2270). Two items: one **mechanical**, one a skill amendment.

## 1. `.claude/rules/**` was a `check`-gate input sitting outside the `check` gate

This is the go-to-k/cdkd#1592 pattern a **third** time, after `scripts/**` and `work-issues/SKILL.md`. **Ten** tests under `tests/unit/scripts/` read `.claude/rules`, and `rule-file-payload.test.ts` enforces four budgets over it: per-file bytes, per-line bytes, a repo-wide ratchet on lines over the line cap, and a **cumulative corpus total**. None of it was in `check`'s `include`.

**Measured, not reasoned.** A lane's `.claude/rules` addition pushed the corpus to **901,762 B over a 900,000 B ceiling** and turned the full suite RED. Throughout that, `markgate status` reported:

```
check   match   11m44s ago   -
```

— on the failing tree, and again after the fix, because the digest never saw the file. A marker that can attest to a red tree is worse than no marker, since the commit gate's entire job is to trust it.

**The cost** is the one `work-issues/**` already accepted: a rules-only edit now needs a full `/check`. That is the right trade — these files are edited by nearly every retrospective, which is precisely when the budgets move.

## 2. The sibling-site sweep applies to a FIX ROUND, not just to the original find

The existing rule reads as advice for *discovering* a defect. The recurring failure is the fix landing on **one call site while a sibling keeps the defect**, usually shipping a comment that asserts completeness.

Five times in one run, across two lanes — and the last two were in edits made *while fixing the previous instance*:

| Fix | Sibling that kept the defect |
| --- | --- |
| the 2-arg `Fn::Sub` binding check | the bare-string arm, one line over |
| adding a region-header read | never bounded WHICH errors carry the region |
| redacting the update/delete warn | the create path, and its own `catch`'s sibling arm |
| adding a site to one enumeration | the second enumeration in the same file |
| completing that second enumeration | a third list on the same LINE |

**Every one was found by enumerating readers or call sites with `grep`. None by re-reading the diff** — and three had review rounds that read the diff first and missed it.

Three also shipped the sentence that makes it durable, because an overstated invariant is what stops the next reader looking. So the amendment carries a cheap tell: **a diff touching ONE site whose message says "every", "all", "never" or "only"** — either derive the population or drop the quantifier.

## Test plan

Prose plus one config line, so section 8's prose arm applies: every gate, path, test and command the new text names was resolved against this repo's files.

- The go-to-k/cdkd#1592 claim verified: `.markgate.yml`'s `check` include did not contain `.claude/rules`, and ten `tests/unit/scripts/*.test.ts` files reference it.
- `tests/unit/scripts/work-issues-skill-refs.test.ts` — 5/5 (no bare `#N` in prose).
- `tests/unit/scripts/rule-file-payload.test.ts` — 190/190.
- `vp run check`, `vp run typecheck:test`, `vp run build` — all rc=0.
- Full suite: **815 files, 16,879 tests**, 0 failures, no type errors.
- `vp run gen:all-matrices` + `audit:coverage:check` — clean.

**Nothing was cut**, and `.claude/rules` is untouched by this commit, so it adds nothing to the corpus that go-to-k/cdkd#2310 tracks.

## Related

go-to-k/cdkd#2310 — the corpus ceiling is ~1,000 B from full on `main`, the long-line ratchet is at 24/24 with zero slack, and the fence's failure message prescribes the *per-file* remedy on a *corpus* assertion, which cannot fix it. That one needs a decision rather than another trim.
