### PR TITLE
chore(work-issues): filing the structural fix does not stop the cascade

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1836,6 +1836,38 @@ Two things follow, and the second is the one that is easy to get backwards:
   a command entrypoint at round five is how round six happens. Take the narrow fix,
   file the structural one, and reference it from the narrow fix so the next reader
   sees the choice was made rather than missed.
+- **But filing the structural fix does not STOP the cascade, and the bullet above
+  used to imply it would.** Measured in go-to-k/cdk-local#596 on 2026-08-27: the
+  structural issue was filed at round five and the rounds ran to TWELVE, producing
+  eleven instances of one defect class in one PR, five of them introduced by the
+  fix for the previous one. What ended it was not a better check — it was making
+  the artifact **CLAIM LESS**.
+
+  The tell is that each round's fix is more SOPHISTICATED than the last. There a
+  `/run-integ` orphan sweep went name scan -> scoped filter -> guarded filter ->
+  stderr classification -> status filter, while the plain rc-only sweeps three
+  lines away were correct the whole time, under the exact conditions that defeated
+  the clever ones: `grep -q 'does not exist'` also matches botocore's
+  `The source_profile ... does not exist`, raised before any network call, so a
+  broken profile reported CLEAN having queried nothing. The sophistication WAS the
+  defect. The sweep now prints raw command output and names both outcomes instead
+  of emitting a verdict — a command that claims nothing cannot claim something
+  false. Expect it to feel like a retreat; it is one, and it is what converges.
+
+  Two corollaries, both paid for there:
+
+  - **Fence the REMEDIATION, not just the detection.** Five of eleven instances
+    arrived through a fix, and the last was in the remediation: `cdk destroy` on
+    names built without the required suffix exits 0 SILENTLY, so the operator read
+    success with the resources still deployed. Every fence to that point pinned
+    the DETECTION, so restoring that line left the suite green. If a procedure
+    both detects and repairs, the repair is where the next instance goes.
+  - **Do not pre-commit to a remedy for a finding you have not seen.** Twice the
+    stated plan was "if instance nine appears, delete the whole thing", announced
+    before instance nine existed; when it arrived, deleting would have left the
+    flow with NO check at all — instance one made permanent. A rule announced in
+    advance is a way of not having to exercise judgement. Say what the next
+    finding would have to SHOW, not what you will do about it.
 - **Ask whether the thing you keep patching is a CLASSIFIER, and if it is, stop
   and build the differential fence in §5 before the next fix.** That section
   already says hand-picked cases cannot fence a classifier — the failure is not


### PR DESCRIPTION
## Summary

Mirrored from cdk-local. This repo's cascade bullets say: after round two name the
structural absence, take the narrow fix, file the structural one. That is exactly
what happened in https://github.com/go-to-k/cdk-local/pull/596 -- the structural
issue (https://github.com/go-to-k/cdk-local/issues/601) was filed at round FIVE --
and the rounds ran to **twelve**, producing **eleven instances of one defect class
in one PR, five of them introduced by the fix for the previous one**.

So the bullets implied a convergence they do not deliver. This adds what actually
ended it, as a new bullet after the existing "do NOT take the structural fix late"
one. The five-round destroy-handler evidence already there is left intact -- it is
this repo's own, and it makes the same point one stage earlier.

## What ended it

Not a better check. Making the artifact **claim less**.

The tell is that each round's fix is more SOPHISTICATED than the last. That PR's
`/run-integ` orphan sweep went name scan -> scoped filter -> guarded filter ->
stderr classification -> status filter, while the plain `rc`-only sweeps three
lines away were correct the whole time, under the exact conditions that defeated
the clever ones:

```text
AWS_PROFILE=broken   # source_profile references a missing profile
  the sophisticated stack scan  -> "AWS clean"
  the rc-only SSM sweep         -> "FAILED to query -- NOT a clean verdict"
```

`grep -q 'does not exist'` also matches botocore's
`The source_profile "x" ... does not exist`, raised BEFORE any network call. The
sophistication WAS the defect. The sweep now prints raw command output and names
both outcomes instead of emitting a verdict.

## Two corollaries

- **Fence the REMEDIATION, not just the detection.** Five of the eleven instances
  arrived through a fix, and the last one was in the remediation: `cdk destroy` on
  names built without the required suffix exits 0 SILENTLY. Every fence up to that
  point pinned the detection, so restoring that line left the suite green --
  measured by the reviewer at 84/0.
- **Do not pre-commit to a remedy for a finding you have not seen.** Twice the
  stated plan was "if instance nine appears, delete the whole thing", announced
  before instance nine existed. When it arrived, deleting would have left the flow
  with NO check at all -- instance one made permanent.

## Test plan

- `vp run verify`: rc=0, 0 errors (8 pre-existing warnings across 329 files).
- Prose-only change to one agent-instruction file; no `src/**` touch, so no
  live-test and no integ.
- Every issue/PR reference is fully qualified as a URL, per the mirrored-file
  convention.

## Cross-repo

cdk-local landed first (https://github.com/go-to-k/cdk-local/pull/606, merged).
cdk-real-drift follows in its own PR. Per the flow's own rule, the session that
finds a flow lesson owns all three landings.
