### PR TITLE
chore(work-issues): fence the cross-lane corpus budget, because saying it twice did not work

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -2738,6 +2738,8 @@ itself be refused by a gate whose scope the incoming range touches. Then say the
 resulting HEADROOM out loud in the report, because it is what tells the next lane
 whether its own addition will red the same fence.
 
+**For the `.claude/rules` corpus specifically this is now MECHANICAL, and the reason it had to become mechanical is worth carrying: the paragraph above already said all of this and a run still hit the collision by hand.** On 2026-08-27 two lanes of ONE `/work-issues` run measured 899,843 B and 899,902 B against a 900,000 B cap, both green, merging to 900,025 B. Neither branch's CI could see it, and the second to merge would have been blamed for a budget the first one spent. `tests/unit/scripts/rule-file-payload.test.ts` now projects the merge — `origin/main`'s corpus plus THIS branch's delta against its own merge base — and fails on the projected number rather than the working-tree one. On a rebased branch the two are equal and the assertion is a no-op; on a stale one it is the only thing that sees the collision. **A cumulative budget in any OTHER file still needs the hand measurement above** — the fence knows about that one corpus, not about the shape.
+
 **And when you hand the trim to someone else, check the target is REACHABLE from
 that lane's own bytes before naming it.** The lane can only spend what it added;
 everything else in the file belongs to other lanes and is not its to cut. So the

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -494,6 +494,81 @@ describe('.claude/rules payload fence', () => {
     ).toBeLessThanOrEqual(CORPUS_BYTES_MAX);
   });
 
+  // The ceiling above measures the WORKING TREE. That is the merge result only
+  // when this branch is rebased onto current `origin/main` -- and a cumulative
+  // budget is spent by every lane at once, so two branches can each be green in
+  // isolation and land over the cap together. Neither branch's CI can see it,
+  // and whichever merges SECOND is blamed for a budget the first one spent.
+  //
+  // Measured 2026-08-27, two lanes of one `/work-issues` run: go-to-k/cdkd#2291
+  // at 899,843 B and go-to-k/cdkd#2330 at 899,902 B, both green, merging to
+  // 900,025 B -- 25 B over. It was caught by hand, which is not a mechanism.
+  //
+  // So project the merge instead of assuming the rebase: `origin/main`'s corpus
+  // plus THIS branch's delta against its own merge base. On a rebased branch
+  // that equals the working tree and this assertion is a no-op; on a stale one
+  // it is the only thing that sees the collision.
+  it('the corpus still fits once this branch is merged into origin/main', () => {
+    const corpusAt = (rev: string): number | undefined => {
+      let names: string[];
+      try {
+        names = execFileSync('git', ['ls-tree', '-r', '--name-only', rev, '.claude/rules'], {
+          cwd: repoRoot,
+          encoding: 'utf-8',
+        })
+          .split('\n')
+          .filter((n) => n.endsWith('.md'));
+      } catch {
+        return undefined; // rev unresolvable (shallow clone, never fetched)
+      }
+      let total = 0;
+      for (const name of names) {
+        total += execFileSync('git', ['show', `${rev}:${name}`, '--'], {
+          cwd: repoRoot,
+          maxBuffer: 64 * 1024 * 1024,
+        }).length;
+      }
+      return total;
+    };
+
+    let mergeBase: string | undefined;
+    try {
+      mergeBase = execFileSync('git', ['merge-base', 'origin/main', 'HEAD'], {
+        cwd: repoRoot,
+        encoding: 'utf-8',
+      }).trim();
+    } catch {
+      mergeBase = undefined;
+    }
+
+    const mainTotal = corpusAt('origin/main');
+    const baseTotal = mergeBase === undefined ? undefined : corpusAt(mergeBase);
+
+    // No `origin/main` to project against -- a shallow clone, or a fresh clone
+    // that has never fetched. Skipping is right: this assertion is ABOUT the
+    // relationship to that ref, so without it there is nothing to be wrong.
+    // The working-tree ceiling above still applies either way.
+    if (mainTotal === undefined || baseTotal === undefined) return;
+
+    const worktreeTotal = ruleFiles.reduce((n, r) => n + r.bytes, 0);
+    const delta = worktreeTotal - baseTotal;
+    const projected = mainTotal + delta;
+
+    expect(
+      projected,
+      `This branch adds ${delta} B to the rules corpus. Against origin/main's ` +
+        `current ${mainTotal} B that projects to ${projected} B, over the ` +
+        `${CORPUS_BYTES_MAX} B ceiling -- even though the working tree is ` +
+        `${worktreeTotal} B and passes on its own.\n\n` +
+        'A parallel lane has spent part of the same budget. Rebase onto ' +
+        'origin/main and re-measure: the number this fails on is the one the ' +
+        'merge produces. Then fund your addition by cutting what your own ' +
+        'change made stale -- never by trimming another lane\'s entry, which ' +
+        'is not yours to spend. ' +
+        SPLIT_ADVICE,
+    ).toBeLessThanOrEqual(CORPUS_BYTES_MAX);
+  });
+
   it.each(ruleFiles.map((r) => [r.name] as const))(
     '%s stays under the per-file byte cap',
     (name) => {


### PR DESCRIPTION
## Summary

A cumulative budget is spent by every lane at once, so two branches can each be green in isolation and land over the cap together. Neither branch's CI can see it, and whichever merges SECOND is blamed for a budget the first one spent.

Measured 2026-08-27 during one `/work-issues` run: the go-to-k/cdkd#2291 lane at **899,843 B** and the go-to-k/cdkd#2330 lane at **899,902 B** against a **900,000 B** ceiling — both green — projecting to **900,025 B** merged. It was caught by hand, which is not a mechanism.

## Why a test rather than another sentence

The skill already carried a paragraph telling the reader to measure what the merge produces rather than the branch. It was read, and the collision happened anyway. That is this repo's own standard for escalating from prose to a mechanism, so this adds the mechanism and turns the paragraph into a pointer.

## What it does

`tests/unit/scripts/rule-file-payload.test.ts` gains one assertion: `origin/main`'s corpus plus THIS branch's delta against its own merge base, checked against the same ceiling.

- On a **rebased** branch the projection equals the working tree and the assertion is a no-op.
- On a **stale** branch it is the only thing that sees the collision.
- It **skips** when `origin/main` is unresolvable (shallow clone, never fetched) — the assertion is ABOUT the relationship to that ref, so without it there is nothing to be wrong, and the pre-existing working-tree ceiling still applies.

The failure message says what to do and what NOT to do: rebase and re-measure, then fund the addition by cutting what your own change made stale — never by trimming another lane's entry, which is not yours to spend.

## Probe

A green assertion is not a discriminating one, and this one is a no-op on exactly the tree it would normally be probed on. So the probe was run on a branch made **deliberately stale**, where the two numbers diverge:

```
worktree     899,795 B
projection   899,880 B     (origin/main had grown by 85 B)
```

With the ceiling set BETWEEN them at 899,850 B:

```
Tests  1 failed | 195 passed (196)
FAIL  the corpus still fits once this branch is merged into origin/main
      expected 899880 to be less than or equal to 899850
```

The pre-existing working-tree assertion **passes** (899,795 ≤ 899,850) and exactly one test fails — the new one — naming both numbers and the cause. A rebased branch cannot produce that separation, so probing on one would have proved nothing.

Restored afterwards and re-verified: ceiling back at 900,000, 196/196.

## Scope

The fence knows about that ONE corpus, not about the shape. A cumulative budget in any other file still needs the hand measurement the skill describes, and the amended paragraph says so rather than implying the class is covered.

## Test plan

- 828 test files / 17,164 tests, rc=0, cache bypassed.
- `rule-file-payload.test.ts` 196/196, with the discriminating probe above.
