### PR TITLE
chore(work-issues): every ownership probe is scoped to YOUR clone, and a peer in another one is invisible to all of them

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -97,6 +97,52 @@ git for-each-ref --sort=-committerdate \
   --format='%(committerdate:iso) %(refname:short)' refs/remotes/origin | head -10
 ```
 
+**Every probe above is scoped to YOUR CLONE, and a peer working the same repo
+from a DIFFERENT clone is invisible to all of them until it pushes.** This is not
+the pre-commit window §3-0 covers; it is a blind spot underneath it, and the
+difference matters because the local probes are the ones §3 and §9 present as
+authoritative. `git worktree list`, `git branch -a` and `git -C <worktree> status
+--porcelain` read the worktree table and refs of the checkout you are standing
+in. Another clone has its own. So the reassuring reading — "no worktree for that
+branch here, so no lane holds it" — is not weak evidence, it is NO evidence, and
+`git worktree add <path> -b <branch>` SUCCEEDING is likewise no evidence: it
+proves only that this clone has no such path or branch.
+
+That leaves exactly one cross-clone signal before a push: **the issue thread**.
+The claim comment (§4) is usually described as the lock; across clones it is also
+the only channel through which the lanes can see each other at all, which is why
+§4's re-read is not a formality and why a claim must be believed on its
+timestamp rather than corroborated against a local probe that cannot see the
+claimant.
+
+Measured here 2026-08-27, and the run that added this paragraph is the one that
+got it wrong. It found 16:29Z and 15:09Z claims on go-to-k/cdkd#2333 /
+go-to-k/cdkd#2339 and go-to-k/cdkd#2340, ran every probe in this section, saw no
+branch, no PR and no worktree, and PUBLICLY re-claimed all three on the stated
+premise that the claiming session had been cleared and its work lost. The lanes
+were live in another clone with uncommitted work; they pushed at 17:21Z and
+18:10Z. Two full duplicate implementations were built — four reviewers, a fix
+round, a live arm — before the peer's stand-down comment surfaced the collision.
+The peer named the probe that would have separated the cases, and it would not
+have: `git -C <worktree> status --porcelain` cannot report a worktree this
+checkout does not have. Nothing local could have. The 16:53Z stand-down request
+sat unread on the issue for two hours because nothing in this flow re-reads a
+claim it has already posted.
+
+Two consequences worth stating as rules rather than as a story:
+
+- **Never write, in a public claim, that another session is gone, cleared, or
+  that its work was lost.** You cannot observe any of those. State what you
+  OBSERVED and where you looked — "no pushed branch, no PR, no worktree in this
+  checkout as of <time>" — and let the timestamp decide ownership. A false
+  assertion about a peer's liveness is the part that cost two hours here,
+  because it reads as settled fact to everyone downstream, and it also went into
+  a correction on go-to-k/cdkd#2346 that then had to be corrected again.
+- **Re-read the claim thread at each checkpoint, not only after posting** — at
+  minimum before the first edit, before the push, and before opening the PR.
+  §4 already says to re-read before pushing; a lane that never reaches a push
+  never reaches that check, which is precisely how this one ran to completion.
+
 **Treat any `origin/*` branch pushed within roughly the last hour as a LIVE lane,
 whatever its PR state**, and read what it owns before picking anything:
 
@@ -125,8 +171,12 @@ git -C .claude/worktrees/<w> show --stat HEAD      # the files that commit touch
 git -C .claude/worktrees/<w> status --porcelain   # what it is editing RIGHT NOW
 ```
 
-**The third probe is the only one that sees a live lane, and it outranks the claim
-comment.** The first two read COMMITTED state, so on a lane that has not committed
+**Among the probes in THIS clone, the third is the only one that sees a live lane,
+and there it outranks the claim comment. Across clones the ranking inverts and the
+claim comment is the only signal at all** -- see the cross-clone paragraph above,
+which is the case this sentence used to be read as covering and does not.
+
+The first two read COMMITTED state, so on a lane that has not committed
 yet they describe whatever its base commit was — somebody else's merged work — while
 saying nothing about the file it is holding. The claim comment does not cover the
 gap either: §4 has it written once, before the first edit, so it names the files the


### PR DESCRIPTION
## Summary

`/work-issues` section 2's ownership probes are presented as the way to find a lane that already owns a file, and sections 3 and 9 treat them as authoritative. Every one of them reads the worktree table and refs of **the checkout you are standing in**. Another clone of the same repo has its own, so a peer working there is invisible to all of them until it pushes.

That is not the pre-commit window section 3-0 already covers. It sits underneath it, and it inverts the reassuring reading: "no worktree for that branch in this checkout" is not weak evidence that nobody holds it, it is **no** evidence. So is a `git worktree add` that succeeds -- it proves only that this clone has no such path or branch.

Which leaves exactly one cross-clone signal before a push: the issue thread.

## The incident, which is this run's own

Measured 2026-08-27, by the run adding this. It found existing claims on go-to-k/cdkd#2333 / go-to-k/cdkd#2339 (16:29:37Z) and go-to-k/cdkd#2340 (15:09:43Z), ran every probe in section 2, saw no branch, no PR and no worktree, and **publicly re-claimed all three** on the stated premise that the claiming session had been cleared and its work lost.

The lanes were live in another clone holding uncommitted work. They pushed at 17:21Z and 18:10Z. Two complete duplicate implementations were built first -- four reviewers, a batched 21-item fix round, a live integ arm -- before the peer's stand-down comment surfaced the collision. That comment had been sitting on the issue since 16:53Z.

The peer named the probe that separates a live pre-commit lane from residue, section 2's `git -C <worktree> status --porcelain`. It would not have helped: it cannot report a worktree this checkout does not have. Nothing local could.

## What changed

Two rules, stated as rules because the story is not the useful part:

- **Never write, in a public claim, that another session is gone, cleared, or that its work was lost.** None of those is observable. State what you observed and where you looked, and let the timestamps decide. The false liveness assertion is what cost the hours here, because it reads as settled fact to everyone downstream -- it also went into a correction on go-to-k/cdkd#2346 that then had to be corrected again.
- **Re-read the claim thread at each checkpoint, not only after posting.** Section 4 says to re-read before pushing; a lane that never reaches a push never reaches that check, which is exactly how this one ran to completion.

Also scopes a sentence this run proved false. Section 2 said the dirty-tree probe "is the only one that sees a live lane, and it outranks the claim comment", full stop. That holds among probes in one clone and **inverts** across clones, where the claim comment is the only signal there is. Left as written it would contradict the paragraph added above it.

## Mechanical follow-up

Section 10-b says that when a rule is already in the text and gets violated anyway, the answer is a hook rather than another sentence. The "re-read before you push" rule was already there. Filed as go-to-k/cdkd#2355 -- a `git push` gate on a competing or stood-down claim, including the identity problem that has to be settled first (in the incident, both claims named the same branch name, so branch name alone cannot separate claimant from rival).

The prose half is here because the cross-clone blind spot itself is **not** locally detectable -- that is the whole finding.

## Verification

Prose-only, no `src/**` change, so per section 8's tier the claims are the artifact. Every one was resolved against the tree rather than asserted:

| Claim | Check | Result |
|---|---|---|
| rules corpus figure cited in the commit | concatenate `.claude/rules/*.md` on `origin/main` | 899,880 B |
| the cap it is measured against | `rule-file-payload.test.ts` | `900_000` |
| the four sections the new text cross-references | grep for their headings | all 4 present |
| the five issues it cites | `gh issue view` | all real, all open |
| timestamps | issue comment `createdAt` + `git log` on the peer branches | as quoted |

`vp run test` 828 files / 17164 tests, rc=0, no type errors. `vp check --fix`, `vp run check`, `vp run typecheck:test`, `vp run build` all rc=0. `work-issues-skill-refs` and `rule-file-payload` both green. `vp run gen:all-matrices` left the tree clean.

Review tier: `inline` (54 LOC, 1 file, no security surface, no `fix:` commits). Agent-instruction files are deliberately not down-biased; the tier is already the floor here.

No integ gate activates -- no `src/**` change.

## Remaining work

- go-to-k/cdkd#2355 -- the `git push` claim gate. `Session-fit: next`, `Severity: medium`, `Effort: medium (M)`, `Estimate: ~2-3 h`.
- go-to-k/cdkd#2354 -- a quoted command LEADER (`"sudo" git commit`) still evades the gate trigger, found while building one of the duplicated lanes and independent of it.

Both duplicated lanes were abandoned rather than pushed; their branches and worktrees are removed and the peer's remote branches were never touched. The findings from their four reviewers that still applied to the peer's implementation -- a bucket-wide `s3:DeleteObjectVersion` grant, and a failed delete reported only at `debug` -- were handed over on go-to-k/cdkd#2340 rather than lost.
