### PR TITLE
test(provisioning): drive the custom-resource poll deadline instead of racing it

### DIFF
--- a/tests/unit/provisioning/custom-resource-provider-response-body-log.test.ts
+++ b/tests/unit/provisioning/custom-resource-provider-response-body-log.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 // Issue #2250: the custom-resource S3 poll used to debug-log
 // `body.substring(0, 200)` of the RESPONSE DOCUMENT. `Data` is the documented
@@ -38,6 +40,37 @@ import {
  */
 const GENERATED_SECRET = 'pw-9f3a-DO-NOT-LOG-8b21';
 
+// Issue #2312: the poll gates its work on `while (Date.now() - startTime <
+// timeoutMs)`, so the arms below need TWO things at once — at least one
+// iteration (the log fires inside the loop BODY) and then an expiry (they
+// assert the timeout rejection). No wall-clock budget can promise both: too
+// small and a loaded machine crosses the deadline before the first mocked
+// `GetObject` resolves, so the body never runs and the line is `undefined`;
+// too large and the arm either hangs or stops timing out. Three arms used a
+// 1 ms budget and flaked exactly that way — five observed reds, in CI and
+// locally, on branches that never touched this file.
+//
+// So the deadline is not raced, it is DRIVEN: `Date.now` is frozen at a fixed
+// instant and the only thing that advances it is the poll's own `sleep`, which
+// runs once per iteration AFTER the body. The first loop check therefore always
+// passes, the body always emits its line, and the second check always fails.
+// One iteration, one expiry, on any machine at any load.
+//
+// A sequence-based `Date.now` stub was the other option and is rejected: it
+// binds the arm to the loop's CALL COUNT (today 4 for a one-iteration timeout —
+// `startTime`, the passing check, the failing check, and `elapsedMin`; the only
+// in-body read is behind `if (useBackoff)`), and miscounting it would be its own
+// flake. A frozen clock plus a sleep-driven step is insensitive to that count.
+//
+// `vi.useFakeTimers()` is rejected for a different reason: this file already
+// replaces `customResourceRetryDelays.sleep`, so the poll's waits never reach a
+// timer at all — faking timers would control nothing here while adding a second
+// clock to reason about.
+/** Every poll's budget. Never expires by real time; see the note above. */
+const POLL_TIMEOUT_MS = 60_000;
+/** What one `sleep` adds to the fake clock — enough to expire that budget. */
+const CLOCK_STEP_MS = 5 * POLL_TIMEOUT_MS;
+
 /** Private-method seam: the poll is internal, and it is what carries the log. */
 interface PollSeam {
   pollS3Response(
@@ -51,8 +84,13 @@ interface PollSeam {
 
 const debugLines: string[] = [];
 let debugSpy: ReturnType<typeof vi.spyOn>;
+let nowSpy: ReturnType<typeof vi.spyOn>;
 const realSleep = customResourceRetryDelays.sleep;
 const realLogger = getLogger();
+
+/** The fake clock the poll reads, and the iteration count that drives it. */
+let clockMs = 0;
+let sleepCalls = 0;
 
 /** Wire the S3 poll to hand back exactly `body` on every GetObject. */
 function respondWith(body: string): void {
@@ -95,14 +133,75 @@ describe('CustomResourceProvider poll response-body logging (issue #2250)', () =
     // its level from the GLOBAL logger, so a locally built one would sit at
     // `info` and emit nothing.
     setLogger(new ConsoleLogger('debug', false));
-    // The non-terminal arms poll until the timeout; keep the waits free.
-    customResourceRetryDelays.sleep = () => Promise.resolve();
+    // The clock the poll's deadline is measured against (issue #2312). Frozen:
+    // real time passing moves nothing. `ConsoleLogger`'s own timestamp comes
+    // from `new Date()`, which this does not touch, so the rendered lines still
+    // carry a real one.
+    clockMs = 1_700_000_000_000;
+    sleepCalls = 0;
+    nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clockMs);
+    // The non-terminal arms poll until the timeout; keep the waits free — and
+    // make this the ONE thing that advances the clock, so an iteration always
+    // completes before the deadline moves.
+    customResourceRetryDelays.sleep = () => {
+      sleepCalls += 1;
+      clockMs += CLOCK_STEP_MS;
+      // A zero-delay TIMER, not `Promise.resolve()`. The waits are still free,
+      // but a resolved promise is a microtask: a poll loop whose deadline stops
+      // advancing would then spin without ever yielding, so vitest's own test
+      // timeout could never fire and the worker died of heap exhaustion with no
+      // test named (measured — a 14 s run ending in `Worker exited
+      // unexpectedly`). Yielding to the macrotask queue turns that same
+      // breakage into a named, bounded timeout failure.
+      return new Promise((resolve) => setTimeout(resolve, 0));
+    };
   });
 
   afterEach(() => {
     debugSpy.mockRestore();
+    nowSpy.mockRestore();
     customResourceRetryDelays.sleep = realSleep;
     setLogger(realLogger);
+  });
+
+  // The two arms below fence issue #2312's fix. They are not about the log
+  // line at all — they are what stops a later edit from quietly handing the
+  // poll's deadline back to the wall clock, which is how three of the arms
+  // below became a merge-blocking coin flip.
+  //
+  // They run FIRST on purpose. Un-freezing the clock does not make the poll
+  // arms fail an assertion — it makes the loop spin until the worker dies of
+  // heap exhaustion (measured: a 14 s run ending in `Worker exited
+  // unexpectedly`, no test names, no assertion). Declared first, the fence
+  // NAMES what broke before anything can hang.
+
+  it('FENCE: every poll here takes its budget from the controlled clock', () => {
+    // A literal budget is the regression: small enough to expire and the body
+    // never runs, large enough to run and the arm stops expiring. Neither is
+    // visible in a green run, so it is checked structurally.
+    const source = readFileSync(fileURLToPath(import.meta.url), 'utf8');
+    const budgets = [...source.matchAll(/\.pollS3Response\(([^)]*)\)/g)].map((m) =>
+      m[1].split(',').pop()!.trim()
+    );
+    // A scanner that matched nothing would pass vacuously: one floor per arm
+    // that exists today, so a regex that stops seeing the call shape fails
+    // loudly instead of reporting a clean tree.
+    expect(budgets.length).toBeGreaterThanOrEqual(7);
+    for (const budget of budgets) {
+      expect(budget).toBe('POLL_TIMEOUT_MS');
+    }
+  });
+
+  it('FENCE: the clock advances only when a poll sleeps', async () => {
+    // The structural arm above cannot see the clock being unfrozen — the call
+    // sites would still read `POLL_TIMEOUT_MS` while the deadline went back to
+    // real time. This one fails if either half of the mechanism is removed.
+    const before = Date.now();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(Date.now()).toBe(before); // 25 ms of real time moved the poll's clock by 0
+
+    await customResourceRetryDelays.sleep(1);
+    expect(Date.now()).toBeGreaterThan(before + POLL_TIMEOUT_MS); // one iteration expires any budget
   });
 
   it('logs Status / PhysicalResourceId / Data KEYS, never a Data value', async () => {
@@ -114,7 +213,12 @@ describe('CustomResourceProvider poll response-body logging (issue #2250)', () =
       })
     );
 
-    await newProvider().pollS3Response('cdkd/cr-response/req.json', 'MyCustomRes', 'Create', 5000);
+    await newProvider().pollS3Response(
+      'cdkd/cr-response/req.json',
+      'MyCustomRes',
+      'Create',
+      POLL_TIMEOUT_MS
+    );
 
     const line = responseLine();
     expect(line).toBeDefined();
@@ -145,7 +249,12 @@ describe('CustomResourceProvider poll response-body logging (issue #2250)', () =
       })
     );
 
-    await newProvider().pollS3Response('cdkd/cr-response/req.json', 'MyCustomRes', 'Create', 5000);
+    await newProvider().pollS3Response(
+      'cdkd/cr-response/req.json',
+      'MyCustomRes',
+      'Create',
+      POLL_TIMEOUT_MS
+    );
 
     const line = responseLine();
     expect(line).toBeDefined();
@@ -171,7 +280,12 @@ describe('CustomResourceProvider poll response-body logging (issue #2250)', () =
       })
     );
 
-    await newProvider().pollS3Response('cdkd/cr-response/req.json', 'MyCustomRes', 'Create', 5000);
+    await newProvider().pollS3Response(
+      'cdkd/cr-response/req.json',
+      'MyCustomRes',
+      'Create',
+      POLL_TIMEOUT_MS
+    );
 
     const line = responseLine();
     expect(line).toBeDefined();
@@ -202,7 +316,12 @@ describe('CustomResourceProvider poll response-body logging (issue #2250)', () =
       })
     );
 
-    await newProvider().pollS3Response('cdkd/cr-response/req.json', 'MyCustomRes', 'Create', 5000);
+    await newProvider().pollS3Response(
+      'cdkd/cr-response/req.json',
+      'MyCustomRes',
+      'Create',
+      POLL_TIMEOUT_MS
+    );
 
     const line = responseLine();
     expect(line).toBeDefined();
@@ -220,9 +339,17 @@ describe('CustomResourceProvider poll response-body logging (issue #2250)', () =
     respondWith(truncated);
 
     await expect(
-      newProvider().pollS3Response('cdkd/cr-response/req.json', 'MyCustomRes', 'Create', 1)
+      newProvider().pollS3Response(
+        'cdkd/cr-response/req.json',
+        'MyCustomRes',
+        'Create',
+        POLL_TIMEOUT_MS
+      )
     ).rejects.toThrow(/Timeout waiting for custom resource response/);
 
+    // The iteration is a PRECONDITION, not a race: exactly one poll ran, and
+    // the expiry came from the clock that poll's own sleep advanced.
+    expect(sleepCalls).toBe(1);
     const line = responseLine();
     expect(line).toBeDefined();
     expect(line).not.toContain(GENERATED_SECRET);
@@ -239,9 +366,15 @@ describe('CustomResourceProvider poll response-body logging (issue #2250)', () =
     respondWith(JSON.stringify(GENERATED_SECRET));
 
     await expect(
-      newProvider().pollS3Response('cdkd/cr-response/req.json', 'MyCustomRes', 'Create', 1)
+      newProvider().pollS3Response(
+        'cdkd/cr-response/req.json',
+        'MyCustomRes',
+        'Create',
+        POLL_TIMEOUT_MS
+      )
     ).rejects.toThrow(/Timeout waiting for custom resource response/);
 
+    expect(sleepCalls).toBe(1);
     const line = responseLine();
     expect(line).toBeDefined();
     expect(line).not.toContain(GENERATED_SECRET);
@@ -256,9 +389,15 @@ describe('CustomResourceProvider poll response-body logging (issue #2250)', () =
     respondWith(JSON.stringify({ Data: GENERATED_SECRET }));
 
     await expect(
-      newProvider().pollS3Response('cdkd/cr-response/req.json', 'MyCustomRes', 'Create', 1)
+      newProvider().pollS3Response(
+        'cdkd/cr-response/req.json',
+        'MyCustomRes',
+        'Create',
+        POLL_TIMEOUT_MS
+      )
     ).rejects.toThrow(/Timeout waiting for custom resource response/);
 
+    expect(sleepCalls).toBe(1);
     const line = responseLine();
     expect(line).toBeDefined();
     expect(rendered()).not.toContain(GENERATED_SECRET);


### PR DESCRIPTION
## Summary

Three arms in `custom-resource-provider-response-body-log.test.ts` drove the private poll seam with a **1 ms** budget. `pollS3Response` gates its work on `while (Date.now() - startTime < timeoutMs)`, so under load the deadline could expire before the first check and the loop body never ran — no debug line, and an assertion on the rendered envelope failing with `expected undefined to be defined`.

Observed five times. The fifth is the one that made this urgent: it failed the `once-leak-detect` job on PR go-to-k/cdkd#2351 with `1 failed | 17,224 passed`, while the sibling PR passed the same job on a tree of the same shape in the same window. `ci-green-gate` refuses `gh pr merge` while any check reports fail, so this test had started gating merges on a coin flip.

## Why a bigger budget is not the fix

The failing arm asserts BOTH that the poll REJECTS with a timeout AND that the diagnostic line was emitted. It needs one iteration **and then** an expiry, and no wall-clock budget guarantees both: too small and the loop never runs, too large and the arm stops timing out. The race is inherent to expressing that requirement as a duration.

So the deadline is now **driven rather than raced**. `Date.now` is stubbed to a frozen value, and the poll's own `customResourceRetryDelays.sleep` stub is the only thing that advances it — by five times the budget. Because `sleep` runs after the loop body, the first check always passes, the body always emits, and the second check always fails. One iteration plus one expiry, mechanically. The timeout arms additionally assert `sleepCalls === 1`, so "the loop ran once" is a stated precondition rather than a hope.

All seven arms now share one `POLL_TIMEOUT_MS`; the `1` is gone from all three sites, not only the one that failed in CI. The issue anticipated that ("any other case in the file using a 1 ms budget has the same exposure") and the modelled preemption confirms it — the three arms fail *together*, not independently.

`vi.useFakeTimers()` was rejected with a reason: this file replaces `customResourceRetryDelays.sleep` wholesale, so the poll's wait never reaches a timer. Fake timers would control nothing and add a second clock.

## A correction to the issue's stated mechanism

go-to-k/cdkd#2312 says the deadline expires "before the first mocked `GetObject` resolves, so the loop body never executes". Measured: that is not the path. The loop condition is evaluated only at the TOP of each pass, so a slow `GetObject` cannot lose the line — injecting delay into the mock changes nothing. The only losing window is between `startTime = Date.now()` and the first `while`, a few instructions of `process.on('SIGINT', …)` registration and `try` entry. Injecting a 2 ms preemption exactly there reproduces the CI signature: the three 1 ms arms go red, the four 5000 ms arms stay green. The issue's conclusion was right and its mechanism was not.

## Test plan

- **Determinism.** 25/25 green quiet; 30/30 green under load; 30/30 green at load peak (load average 26-34 on a 15-core machine, with a full `vp run test` plus 20 `yes` processes as the load).
- **The diagnosis reproduces.** Old file + a 2 ms preemption in the window above → exactly the three 1 ms arms red with the CI signature. New file + a 5000 ms stall in the same window → all seven behaviour arms green.
- **The arms still discriminate.** Eight mutations against `src/` (applied and restored, each verified by `md5` against HEAD; `src/` is byte-identical at the end). Five break what each arm asserts — the envelope rendering, the unparseable-body diagnostic and its char count, the non-object-JSON message, the `<absent>` placeholder — and all go red. Three (`M5a` / `M5b` / `M5c`) make the loop SUCCEED instead of timing out, and all three red with `promise resolved … instead of rejecting`, which is what proves the timeout arm did not become vacuous.
- **Two fences, both probed red.** A structural scan requiring every `.pollS3Response(` call to pass `POLL_TIMEOUT_MS`, with a floor of 7 call sites so the scanner cannot silently stop seeing its input (restoring a `1` reds it; breaking the regex reds the floor). A behavioural arm asserting the clock does not move with real time and that one `sleep` outruns any budget — which catches an unfreezing the structural scan cannot see.

## Found and fixed along the way

Stubbing `sleep` as `Promise.resolve()` starves the event loop when the deadline stops advancing: the loop spins on microtasks, vitest's test timeout is a timer and cannot fire, and the worker dies of heap exhaustion reporting **no test name and no assertion** — a 14 s run ending in `Worker exited unexpectedly`. A zero-delay *timer* makes the same breakage report as a named 5 s timeout instead, at effectively the same cost (one `sleep` per arm on the happy path).

No `src/` change: `git diff --name-only -- src/` is empty.

Closes #2312
