### PR TITLE
chore(work-issues): name the killed/refused-call trigger in the cwd-reset gotcha

### DIFF
--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -68,7 +68,18 @@
   `git diff main` appears to have removed; rebase instead.
 - **`bash cwd silent reset`** — a persistent Bash cwd can drift back to the main
   tree between calls; use `git -C .claude/worktrees/<branch>` for git ops and
-  re-`cd` before relative-path commands. **Its worst form is not a misplaced
+  re-`cd` before relative-path commands. **A KILLED or REFUSED call is a named
+  reset trigger, and it lies about the filesystem too.** After a tool-call
+  timeout kills a call mid-run, the shell can come back at the session cwd:
+  measured 2026-08-28, a 2-minute timeout ended a probe sequence, the cwd
+  silently reset to the main tree, and the next relative-path append was stopped
+  only by `main-tree-edit-gate`, with the recovery costing ~4 calls (and
+  surfacing go-to-k/cdkd#2368 on the way). A PreToolUse refusal aborts the whole
+  call the same way, so the `mkdir` a later call's `cd` depends on never ran —
+  and a failed `cd` does NOT stop the rest of its call: measured the same day,
+  the lines after one wrote into the main tree. So after any timeout or refusal,
+  run `pwd` AND re-verify what the aborted call was supposed to create, before
+  the next relative-path command. **Its worst form is not a misplaced
   edit but a FALSE GREEN on a verification command**, because a gate run from
   the main tree verifies unmodified `main` and passes: on 2026-08-20 a lane
   reported `vp run typecheck:test` RC=0 twice while its own worktree held 20


### PR DESCRIPTION
## What

Retro of the 2026-08-28 `/work-issues` run (lanes go-to-k/cdkd#2365 / go-to-k/cdkd#2366 here, go-to-k/cdk-local#622 / go-to-k/cdk-local#624 in the sibling), per `references/retro.md` section 10. One stage-file amendment; everything else escalated to issues with repros, or dropped with the probe that disproved it.

**`gotchas.md`, the `bash cwd silent reset` bullet**: the bullet prescribed the defenses (`git -C`, re-`cd`, `pwd` receipts) without naming WHEN the reset happens, so each occurrence still arrived as a surprise. The amendment names the two measured triggers — a tool-call timeout killing a call mid-run (the shell comes back at the session cwd), and a PreToolUse refusal (nothing in the aborted call ran, so a later call's `cd` target may not exist — and a failed `cd` does not stop the rest of its call). Both fired on 2026-08-28: the timeout variant cost ~4 recovery calls in the run and surfaced go-to-k/cdkd#2368; the refusal variant wrote into the main tree the same day and was caught by `main-tree-edit-gate`. Amended in place per section 10-c (no sibling bullet), evidence inline.

## What was deliberately NOT restated (section 10-b: escalate, do not restate)

- **The preamble-discard trap fired four times in one run** despite gates-and-pr.md section 6 carrying the rule with three worked examples AND `gated-command-preamble-gate` existing. Probed the gate directly: the `markgate set` shapes ARE covered (rc=2), interpreter one-liner writes (`python3 -c` / `node -e` editing the gated command's own body file) are NOT (rc=0), and the `gh issue create` heredoc shape is a documented trade whose cost side gained live evidence. Filed with the probe matrix as go-to-k/cdkd#2369; no prose added, since a fourth spelling of a rule violated with three would not be load-bearing.
- **`dirty-path-restore-gate`'s documented bypass cannot work for an agent**: `CDKD_ALLOW_DIRTY_RESTORE=1 <cmd>` as a command prefix never reaches the hook process (measured rc=2 with the prefix, rc=0 with the var in the hook's own env). Filed with the repro as go-to-k/cdkd#2368.
- **Suspected pr-body-item-number-gate false positive** on possessive cross-repo refs (`go-to-k/cdkd#2041's`): did not reproduce driving the hook directly — the possessive and parenthesized forms pass (rc=0) while a bare-ref control blocks (rc=2). Dropped as unproven; the observed blocks match the stale-body-file shape section 6 already documents (check mtime).
- **Reviewers finding the banned class inside the PR that bans it** (both sibling lanes): the review flow caught both instances, which is the flow working; verify.md's existing grep-the-shape rules cover the author-side check. Dropped rather than restated.

## Run accounting (section 10-0)

Closed 4 / filed 2 (new 2 / folded 0) across the two repos: closed go-to-k/cdkd#2363, go-to-k/cdkd#2364, go-to-k/cdk-local#620, go-to-k/cdk-local#623; both filings were classified `Session-fit: now (do it in this session)` and closed in-session, so the promotion-check population of open run-filed deferrals is empty. The retro itself files go-to-k/cdkd#2368 / go-to-k/cdkd#2369, both `Session-fit: next (not this session)` with named verification commands; the run's merged diff touches neither hook they name.

## Verification

Prose-only diff (no `src/**`): `vp check --fix` rc=0, `vp run check` rc=0, `vp run typecheck:test` rc=0, `vp run build` rc=0, `vp run test` 17312/17312 rc=0 (includes the skill-file byte-cap suite and the qualified-ref fence over the edited file). Claim-by-claim pass on the new text: the two incidents are this run's own measurements, and go-to-k/cdkd#2368 was filed before this PR so the reference resolves.
