### PR TITLE
chore(work-issues): run lanes as per-issue subagents, with integ and merge serialized by the parent

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -28,23 +28,47 @@ optional** — each file carries hard rules and measured failure modes without
 which the stage summary below is not executable. A bare `§N` anywhere in this
 skill points into the file that holds that section (map in the table).
 
-**Delegate the read-heavy stages to subagents to keep this session's context for
-the lanes.** Two stages are shaped for it:
+**Delegate for context; keep the locks and the serialization in the parent.**
+The placements below are live-proven, not aspirational: on 2026-08-28 two of
+the three skill-split PRs (go-to-k/cdk-local#621, go-to-k/cdk-real-drift#1831)
+were built END-TO-END by lane subagents — worktree, implementation, gates,
+reviewer dispatch, CI — with the parent doing only claims, serialized merges
+and cleanup, and every hook and markgate gate fired inside the lanes' calls
+exactly as in the parent.
 
-- **Triage (stages 0–3)**: dispatch a read-only subagent (general-purpose or
-  Explore) whose prompt is: read `references/triage.md` in full, execute it
-  against this repo, and return ONLY the candidate table — per issue: number,
-  title, target files, rank + the rule that decided it, collision evidence
-  (worktrees / branches / claims found), and any premise-check findings. The raw
-  backlog listing and issue bodies stay out of the parent context. The PARENT
-  then claims (stage 4) — never the subagent, so the claim names the session
-  that will actually do the work.
-- **Retro (stage 10)**: after the last merge, dispatch a subagent with
+- **Triage (stages 0–3): a read-only subagent** (general-purpose or Explore)
+  whose prompt is: read `references/triage.md` in full, execute it against
+  this repo, and return ONLY the candidate table — per issue: number, title,
+  target files, rank + the rule that decided it, collision evidence
+  (worktrees / branches / claims found), and any premise-check findings. The
+  raw backlog listing and issue bodies stay out of the parent context.
+- **Claim (stage 4): the PARENT, never a subagent** — the claim is the lock,
+  so it names the session accountable for the lane; it also names the lane
+  branch/worktree the dispatched subagent will create (§4).
+- **Lanes (stages 5–8): one general-purpose subagent per claimed issue.**
+  Dispatch each with the issue number(s), the posted claim, and the stage
+  files to read at stage entry (`references/{implement,gates-and-pr,verify}.md`).
+  The lane creates its own worktree per §5, implements, runs `/check` +
+  `/check-docs`, opens the PR, dispatches its review tier (a lane may spawn
+  reviewer subagents), addresses findings, and drives CI to green — then
+  STOPS at merge-ready and reports back: PR number, HEAD sha, markers set,
+  review verdicts, integ fixtures still needed, anything deferred. Its
+  diffs, test logs and review round-trips never enter the parent context.
+  A lane must NOT run a real-AWS integ or merge on its own — that is the
+  serialization invariant below, not a capability gap.
+- **Finishing (stage 9): the parent, one lane at a time.** Grant each
+  merge-ready lane its turn — resume the lane agent (SendMessage) to run its
+  named integ fixtures and merge while it holds the turn, or run `/run-integ`
+  and `gh pr merge` yourself FROM THAT LANE'S WORKTREE (merge gates read the
+  worktree the command runs from — §9). Post-merge (pull → release → rebuild
+  → worktree cleanup) follows §9.
+- **Retro (stage 10): a subagent**, dispatched after the last merge with
   `references/retro.md` plus this run's key evidence (what you re-read, what
   the text sent you into, corrections the user made) to measure the backlog
   effect, draft the skill edits, and ship them as the retro PR.
 
-Stages 4–9 run in the parent: they hold the locks, the worktrees, and the gates.
+Running a lane in the parent instead stays legal (a single-lane run, or a lane
+the user wants to watch); the stage files apply unchanged either way.
 
 ## Stages
 
@@ -75,6 +99,10 @@ Stages 4–9 run in the parent: they hold the locks, the worktrees, and the gate
   file (list in §2). (§3)
 - **Never work in the main checkout** — one worktree per lane under
   `.claude/worktrees/<branch>/`. (§5)
+- **Real-AWS integ runs and merges are SERIALIZED across lanes** — the parent
+  grants the turn, one lane at a time; a lane subagent never starts either on
+  its own. Everything else (edits, unit tests, markers, PR create, reviews,
+  CI) runs concurrently, because markgate markers are per-worktree. (§9)
 - **Verification depth is never traded for cost** (CLAUDE.md → "Cost is not a
   tiebreaker"); ranking decides order, never rigor. (§3-a)
 - **English only in every published artifact** — issue bodies/comments, PR

--- a/.claude/skills/work-issues/references/claim.md
+++ b/.claude/skills/work-issues/references/claim.md
@@ -2,6 +2,12 @@
 
 ## 4. CLAIM the chosen issues BEFORE editing
 
+When lanes run as SUBAGENTS (the orchestrator's default for stages 5-8), the
+PARENT posts every claim in this section — the claim is the lock and must name
+the session accountable for the lane — and the claim's `<ref>` names the branch
+/ worktree the dispatched lane agent will create, not a branch the parent
+holds. Everything else in this section is unchanged.
+
 For EACH issue you will start:
 
 ```bash

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -2,6 +2,15 @@
 
 ## 5. One worktree per lane, then implement
 
+This stage (and stages 6-8) normally runs INSIDE a lane subagent the
+orchestrator dispatched — one general-purpose agent per claimed issue, so the
+lane's diffs, test output and review round-trips never land in the parent
+context. Every rule below applies unchanged inside the lane: hooks fire on the
+lane's tool calls, and markgate markers land in the lane's own worktree.
+Two actions are reserved to the parent's serialization turn and are NOT the
+lane's to start: a real-AWS integ run and the merge (the orchestrator's
+serialization invariant; §9). A lane stops at merge-ready and reports.
+
 Never edit in the main checkout — the `main-tree-branch-gate` hook blocks branching
 there anyway. Per lane:
 

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -2,6 +2,19 @@
 
 ## 9. Ship: merge → pull → release → rebuild → cleanup
 
+With subagent lanes, this stage is the PARENT's serialization point: grant one
+merge-ready lane at a time its turn — resume that lane agent (SendMessage) to
+run its named integ fixtures and merge while it holds the turn, or run
+`/run-integ` and `gh pr merge` yourself FROM THAT LANE'S WORKTREE. The
+worktree matters mechanically, not stylistically: merge-gate verdicts
+(pr-review sha sentinel, verify-pr / integ markers) are computed against the
+tree the command runs from, so a merge issued from the main tree consults the
+WRONG store — measured 2026-08-28, when a fresh pr-review marker sat in the
+lane worktree while the main tree's stale sentinel blocked the merge with a
+misleading sha mismatch (go-to-k/cdkd#2363 records the cwd-race side of it).
+Never two lanes' integs or merges concurrently; everything after the merge in
+this section (pull → release → rebuild → cleanup) stays with the parent.
+
 **Before you watch CI, read the PR's merge state** — `/verify-pr` step 3 already
 says why, and the failure mode is silent, so it is worth the pointer here: a PR
 at `mergeable=CONFLICTING state=DIRTY` never fires CI at all, and


### PR DESCRIPTION
## Summary

The skill split (go-to-k/cdkd#2362) delegated triage and retro to subagents; this PR extends the model to the LANES themselves — the dominant parent-context cost (~50-150k tokens per lane of diffs, test output and review round-trips).

- **Orchestrator**: stages 5-8 run as one general-purpose subagent per claimed issue (worktree-isolated). A lane implements, runs `/check` + `/check-docs`, opens its PR, dispatches its review tier, drives CI to green, then STOPS at merge-ready and returns a compact report. The parent claims (stage 4 — the lock names the accountable session), grants real-AWS integ and merge turns one lane at a time (stage 9), and runs post-merge + retro. Running a lane in the parent stays legal.
- **New hard invariant**: real-AWS integ runs and merges are SERIALIZED across lanes by the parent; everything else is concurrent (markgate markers are per-worktree).
- **claim.md**: with subagent lanes, the parent posts every claim, naming the lane branch/worktree the dispatched agent will create.
- **implement.md**: stages 5-8 normally run inside the lane; every rule applies unchanged there (hooks fire on the lane's calls, markers land in its worktree); integ and merge are reserved to the parent's turn.
- **ship.md**: stage 9 is the parent's serialization point; merge from the LANE's worktree, because merge-gate verdicts (pr-review sha sentinel, verify-pr / integ markers) are computed against the tree the command runs from — measured 2026-08-28 when a fresh marker in the lane worktree was invisible to a merge issued from the main tree (go-to-k/cdkd#2363 records the cwd-race side).

Live evidence for the pattern: go-to-k/cdk-local#621 and go-to-k/cdk-real-drift#1831 were built end-to-end by lane subagents on 2026-08-28 — worktree, gates, reviewer dispatch, CI — with the parent doing only claims, serialized merges and cleanup.

## Test plan

- `vp check` / `vp run check` / `vp run typecheck:test` / `vp run build`: pass
- `vp run test`: 17,312 tests pass (skill-file-payload cap: orchestrator 8,933 B <= 12,000; refs/cross-cutting fences green)
- Prose-only change to 4 skill docs; no src, no behavior outside the agent flow
