### PR TITLE
chore(work-issues): fix a gate that blocked the form its own error message prescribes, and a hook suite enumerating zero hooks since #2380

### DIFF
--- a/.claude/hooks/pr-body-item-number-gate.sh
+++ b/.claude/hooks/pr-body-item-number-gate.sh
@@ -24,9 +24,10 @@
 #         close[s]? #N, closed #N, fix[es]? #N, resolve[s]? #N
 #       These are load-bearing for GitHub's auto-close behavior.
 #     - Soft references: refs: #N, ref: #N, references #N, see #N
-#     - Fully-qualified cross-repo refs: owner/repo#N. Unambiguous by
-#       construction, and the form /work-issues section 10-c mandates
-#       for every citation in the mirrored skill files.
+#     - Fully-qualified cross-repo refs: owner/repo#N, bare or wrapped
+#       in markdown emphasis / quotes (**owner/repo#N**, "owner/repo#N").
+#       Unambiguous by construction, and the form /work-issues section
+#       10-c mandates for every citation in the mirrored skill files.
 #     - Parenthetical: (#N)   — used by squash-merge commit messages
 #       like `feat(...): subject (#231)`.
 #     - Inside fenced code blocks (between matching ``` lines).
@@ -168,9 +169,24 @@ find_offender() {
       # is very often parenthesised or a markdown link label, and requiring
       # whitespace rejected `(go-to-k/cdkd#1476)` -- found by writing the
       # body of the very PR that ships this arm, against the patched hook.
+      # It also admits the MARKDOWN EMPHASIS and quoting characters * ~ |
+      # and the double quote, for the same reason one hop later: a PR body
+      # writes a qualified ref bolded far more often than bare, and
+      # `**go-to-k/cdkd#2367**` was refused twice on 2026-08-29 by an
+      # otherwise-correct body, with the gate error telling the author to use
+      # the very form it had just blocked. None of these characters can occur
+      # INSIDE a slug (the segment class is [A-Za-z0-9._-]), so widening the
+      # boundary cannot admit a new item-number shape -- "step 1/2#3" is
+      # still blocked by the letter requirement, bolded or not.
+      # `_` is deliberately NOT here: it is already in the SEGMENT class, so
+      # `_owner/repo#N` parses as a slug whose owner starts with an
+      # underscore and was allowed before this widening. Adding it would be
+      # dead -- measured by dropping each added character in turn and
+      # re-running this hook test suite: * ~ | and the double quote each
+      # redden a case, `_` reddens none.
       # NOTE: no apostrophes in this block -- it sits inside a single-quoted
       # shell string, so one would terminate the perl program.
-      next if $left =~ m{(?:^|[\s(\[])[A-Za-z0-9._-]*[A-Za-z][A-Za-z0-9._-]*/[A-Za-z0-9._-]*[A-Za-z][A-Za-z0-9._-]*$};
+      next if $left =~ m{(?:^|[\s(\[*~|"])[A-Za-z0-9._-]*[A-Za-z][A-Za-z0-9._-]*/[A-Za-z0-9._-]*[A-Za-z][A-Za-z0-9._-]*$};
       # Otherwise: BLOCKED. Print the hit and the full line context.
       print "$hit\n";
       last;

--- a/.claude/hooks/pr-body-item-number-gate.test.sh
+++ b/.claude/hooks/pr-body-item-number-gate.test.sh
@@ -143,6 +143,29 @@ The lambda/vpc\`-deps\`#5 edge.
 Item x/y\`the code\`#7 remains open.
 ")
 
+# M: qualified cross-repo refs wrapped in markdown emphasis / quotes
+# (allowed). A PR body writes a qualified ref bolded far more often than
+# bare, and until 2026-08-29 the gate blocked exactly that while its own
+# error message told the author to use the qualified form.
+M=$(write_file M.md "# Title
+
+- **go-to-k/cdkd#2367** — bolded, the shape that was blocked twice
+- *go-to-k/cdk-local#533* — italic
+- ~~go-to-k/cdk-real-drift#1792~~ — struck through
+- _go-to-k/cdkd#2378_ — underscore emphasis
+- \"go-to-k/cdkd#2374\" — double-quoted
+|go-to-k/cdkd#2376|an unpadded table cell|
+")
+
+# N: the fraction item number, now wrapped in the same emphasis (blocked).
+# Pins that widening the leading boundary did NOT widen the arm itself --
+# 1/2 has no letter in either segment, bolded or not.
+N=$(write_file N.md "# Title
+
+**step 1/2#3**: the second half
+*item 4/5#6*: and another
+")
+
 # --- ALLOW cases ---
 
 # 1. PR create with bare-number body (A) → exit 0.
@@ -186,6 +209,10 @@ run_case "gh pr view not gated" 0 \
 run_case "gh pr create with qualified owner/repo#N allowed" 0 \
   "$(printf '{"tool_input":{"command":"gh pr create --body-file %s"}}' "$J")"
 
+# Emphasised / quoted qualified refs are allowed too (2026-08-29).
+run_case "gh pr create with emphasised qualified owner/repo#N allowed" 0 \
+  "$(printf '{"tool_input":{"command":"gh pr create --body-file %s"}}' "$M")"
+
 # --- BLOCK cases ---
 
 # 2. PR create with #N body (B) → exit 2.
@@ -225,6 +252,11 @@ run_case "gh pr create with code-span slug gadget still blocked" 2 \
 
 run_case "gh pr create with fraction-shaped item number still blocked" 2 \
   "$(printf '{"tool_input":{"command":"gh pr create --body-file %s"}}' "$K")"
+
+# ...and still blocked when wrapped in the emphasis the boundary now admits,
+# which is what pins the 2026-08-29 widening to the BOUNDARY rather than the arm.
+run_case "gh pr create with emphasised fraction-shaped item number still blocked" 2 \
+  "$(printf '{"tool_input":{"command":"gh pr create --body-file %s"}}' "$N")"
 
 run_case "gh pr edit with #N body-file blocked" 2 \
   "$(printf '{"tool_input":{"command":"gh pr edit 123 --body-file %s"}}' "$B")"

--- a/.claude/hooks/unresolved-target-class.test.sh
+++ b/.claude/hooks/unresolved-target-class.test.sh
@@ -88,7 +88,19 @@ for entries in d.get('hooks',{}).values():
     for e in entries:
         for h in e.get('hooks',[]):
             c=(h.get('command') or '').strip()
-            m=re.match(r'^(\.claude/hooks/[A-Za-z0-9._-]+\.sh)\b',c)
+            # A registration may be spelled bare -- `.claude/hooks/x.sh` --
+            # or rooted at the project dir, which go-to-k/cdkd#2380 switched
+            # every entry to on 2026-08-28:
+            #   ${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/x.sh
+            # Anchored at the string start alone this matched NOTHING from
+            # that day on, the population went empty, and the `-z $REGISTERED`
+            # guard below has failed this suite on main ever since -- unseen,
+            # because hooks.yml is path-filtered to `.claude/hooks/**` and the
+            # PR that broke it touched only `.claude/settings.json` (that
+            # filter is widened in the same change as this line).
+            # The optional prefix must be LAZY and end in `/`: a greedy one
+            # eats through `.claude/hooks/` itself and the group never binds.
+            m=re.match(r'^(?:[^\s]*?/)?(\.claude/hooks/[A-Za-z0-9._-]+\.sh)\b',c)
             if m and m.group(1) not in seen: seen.append(m.group(1))
 print("\n".join(seen))
 PY

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -394,10 +394,15 @@ Run integration tests against a real AWS account. These tests deploy actual AWS 
 
     The one-row-per-test invariant is now **enforced by CI** (issue #1112): the
     `integ-last-run ledger is normalized` step re-runs the normalizer and fails on any
-    diff. No manual post-rebase re-check is needed — the whole-file rewrite makes a
-    replayed commit produce an identical file rather than an additive diff, which is what
-    used to let a rebase silently duplicate rows. If a rebase does leave the file dirty,
-    re-run `vp run integ-ledger-normalize` and commit; `--check` reports without writing.
+    diff. The whole-file rewrite makes a REPLAYED commit reproduce the file byte-for-byte
+    instead of appending a duplicate row — but that covers the replay case only. When two
+    lanes recorded the SAME test, the rebase is a CONFLICT, and resolving it keeps both
+    rows: re-run `vp run integ-ledger-normalize` after any rebase that touched this file
+    **and commit the rewrite before pushing**. Measured 2026-08-29: the normalizer was run
+    after the push and its output never committed, so CI turned the PR red. Confirm with
+    `git status --porcelain -- docs/_generated/` rather than the normalizer's own output —
+    a grep over a check log that keeps only error lines reports a dirty tree as clean.
+    (`--check` reports without writing.)
 
 ## Important
 

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -544,6 +544,11 @@ tree:
   the defect lives in is satisfied BY the collapse it exists to catch:
   narrowing that fence's pathspec to the owner file alone still passed 4/4.
   Name the peripheral members a collapse drops FIRST, not the central one.
+  **And derive the floor from a source the fence does not itself read.** A
+  floor computed from the very pool it guards is unfalsifiable, because
+  deleting pool entries moves both sides of the comparison together — measured
+  2026-08-29: emptying the guarded pool left such a fence 10/10 GREEN. Write
+  the expected count as a LITERAL, so the pool shrinking is what reddens it.
 
 And ask the dumbest question last: **is anything RUNNING it?** The nine hook
 harnesses in go-to-k/cdk-real-drift were shell, so neither the vitest task nor
@@ -727,4 +732,10 @@ because it converts an open gap into a recorded assurance:
   the mutation bind identically, so the probe stayed green; the PRODUCER's
   region separated them. Same lesson as choosing the probe's input (section 5,
   above), from the fixture side: when a probe comes back green, suspect the
-  fixture before concluding the code is fenced.
+  fixture before concluding the code is fenced. The commonest instance is an
+  expected value that COINCIDES with the ambient default, and no count of
+  passing cases can see it: assertions pinned to `'us-east-1'` — at once the
+  fixture's region and this repo's hardcoded fallback — cannot separate a
+  threaded binding from a defaulted one, and substituting the literal for the
+  binding left 434 tests green (2026-08-29). Choose a fixture value the
+  default can never produce.

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -284,7 +284,18 @@ pnpm install                  # worktrees have no node_modules
   gets §8's live-test exemption — the prose arm for a SKILL.md / rule edit, the
   command arm (run the suite, drive the failure direction, add the test case)
   as soon as it lands in `.claude/hooks/**` (per §10-b the RIGHT place for a
-  violated written rule).
+  violated written rule). **Run the WHOLE harness there — `bash
+  .claude/hooks/run-tests.sh`, not just your own hook's suite — and read the
+  TALLY, not the exit code of whatever you piped it into.** A hooks edit is
+  what re-triggers the path-filtered `hooks.yml`, so a fence a PEER left inert
+  surfaces as YOUR red CI. Measured 2026-08-29 while shipping this very
+  section: go-to-k/cdkd#2380 had respelled every registration in
+  `.claude/settings.json` as `${CLAUDE_PROJECT_DIR:-.}/...`,
+  `unresolved-target-class.test.sh`'s start-anchored enumeration then matched
+  nothing, so its population guard fired and the suite has failed on `main`
+  since — while the workflow that would have said so never ran, a settings-only
+  PR being outside its `.claude/hooks/**` path filter. Both halves (the
+  enumeration and the filter) were repaired in the retro PR.
 - Agent-instruction files are deliberately NOT down-biased in `/review-pr`'s
   tier heuristic — a wrong rule here propagates into every future session — so
   take the tier the heuristic gives and do not argue it down.

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -12,6 +12,11 @@ tree the command runs from, so a merge issued from the main tree consults the
 WRONG store — measured 2026-08-28, when a fresh pr-review marker sat in the
 lane worktree while the main tree's stale sentinel blocked the merge with a
 misleading sha mismatch (go-to-k/cdkd#2363 records the cwd-race side of it).
+Those sentinels are also GITIGNORED, so a fresh worktree has none at all and
+`markgate set` on a sentinel-bound gate refuses there — `dead scope: include
+matches nothing this gate can see ...; the digest would be a constant that
+never goes stale` — which is the gate declining to record an empty set, not a
+markgate fault. Write the sentinel first (`/run-integ` step 11), never bypass.
 Never two lanes' integs or merges concurrently; everything after the merge in
 this section (pull → release → rebuild → cleanup) stays with the parent.
 
@@ -95,12 +100,31 @@ side that main does not already contain, and assert the residual:
 
 ```bash
 # after resolving, before `git rebase --continue`
-grep -c "<a distinctive phrase from the entry you kept>" docs/changelog-cdkd.md   # must be 1
+PHRASE="<a phrase unique to the entry you kept>"
+git show origin/main:docs/changelog-cdkd.md | grep -c "$PHRASE"   # must be 0
+grep -c "$PHRASE" docs/changelog-cdkd.md                          # must be 1
 diff <(git show origin/main:docs/changelog-cdkd.md) docs/changelog-cdkd.md | grep -c '^<'   # must be 0
 ```
 
-The first line is the one that matters; the second re-checks the paragraph
-above.
+**The first line is what makes the second mean anything.** A needle main
+already carries can never read 1, so the count then passes or fails for
+reasons that have nothing to do with your duplicate. Measured 2026-08-29: the
+phrase first reached for was `CloudControlProvider`, and
+`git show origin/main:docs/changelog-cdkd.md | grep -c CloudControlProvider`
+returned **18** that day — the check was vacuous. Take the phrase from YOUR
+entry's own subject and prove it absent from main's copy before counting. The
+third line re-checks the paragraph above.
+
+**The integ ledger is the OTHER generated file a parallel-lane rebase merges,
+and it fails in a different shape:** keeping both sides yields two rows for
+the SAME test, which `docs/_generated/integ-last-run.tsv`'s one-row-per-test
+invariant forbids and CI's `integ-last-run ledger is normalized` step rejects.
+Re-run `vp run integ-ledger-normalize` after any rebase that touched it **and
+commit the rewrite before pushing** — measured 2026-08-29, the normalizer ran
+but its output was never committed and the PR went red. Confirm with `git
+status --porcelain -- docs/_generated/`, never with the normalizer's own
+output: a grep over a check log that keeps only error lines reports a dirty
+tree as clean.
 
 ```bash
 gh pr merge <n> --squash --delete-branch     # squash is the repo's only method

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -130,7 +130,14 @@ markers.
   an agent handed findings will otherwise fix, verify, and hand back, right
   everywhere except before a real-AWS gate. For reviewers, the reverse:
   dispatch a round SCOPED to the delta and ask for the whole round's findings
-  at once, not trickled.
+  at once, not trickled — **and paste the delta's COMMIT MESSAGE into the
+  brief.** All four reviewer agents read `gh pr diff` / `gh pr view --json
+  files` (`.claude/agents/pr-{code,spec,test,security}-reviewer.md`) and none
+  reads `git log`, so a false claim written into a commit message is invisible
+  to the whole tier however many reviewers you dispatch. Measured 2026-08-29:
+  a delta round's blocker was a commit message citing a function that has
+  never existed in this repo, reachable only because the orchestrator re-read
+  the message itself.
 
 Run `/verify-pr`. It layers CI status, docs consistency, AWS-resource cleanup,
 code review, and a **live-test of the changed behavior** on top of `/check`.

--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -18,11 +18,19 @@ on:
     branches: [main]
     paths:
       - '.claude/hooks/**'
+      # settings.json is what REGISTERS the hooks, and
+      # unresolved-target-class.test.sh derives its whole population from it.
+      # Leaving it out meant go-to-k/cdkd#2380 (a settings-only respelling to
+      # ${CLAUDE_PROJECT_DIR:-.}/...) emptied that population without ever
+      # running this workflow; the breakage only surfaced on the next
+      # unrelated hooks PR, 2026-08-29.
+      - '.claude/settings.json'
       - '.github/workflows/hooks.yml'
   pull_request:
     branches: [main]
     paths:
       - '.claude/hooks/**'
+      - '.claude/settings.json'
       - '.github/workflows/hooks.yml'
 
 jobs:


### PR DESCRIPTION
Retrospective of a four-lane `/work-issues` run (issues go-to-k/cdkd#2346, go-to-k/cdkd#2347, go-to-k/cdkd#2301, go-to-k/cdkd#2367, shipped as go-to-k/cdkd#2374 / go-to-k/cdkd#2376 / go-to-k/cdkd#2378 / go-to-k/cdkd#2382).

**Two of the seven candidate lessons are deliberately NOT written down.** `verify.md` already owns "your own BRIEF is a published claim, and it inherits every fact you relayed without checking", and `implement.md` already says "Classify by the resulting VALUE, not by the input's shape". Section 10-b says a restatement is worse than nothing, so they were dropped with the citation rather than added.

## Two live defects, both invisible to CI by construction

### `pr-body-item-number-gate` refused the form its own error message prescribes

The owner/repo allow-arm required the left boundary to be `(?:^|[\s(\[])`, so `**go-to-k/cdkd#123**` fell through to BLOCKED while the bare form passed. The hook's own inline comment says blocking the qualified form "put the hook and the skill in direct contradiction" — so the gate was wrong, not the convention. This run hit it twice writing a PR body and worked around it by unbolding, which is the wrong repair.

The class is widened to `[\s(\[*~|"]`, with fixtures for the allow case and for the fraction shape that must still block. **`_` was probed and dropped**: it is already a segment character, so `_owner/repo#N` parsed as a slug before this change — shipping it would have added a dead character. Each remaining added character was removed in turn and confirmed to redden a case.

### `unresolved-target-class.test.sh` has been enumerating ZERO hooks since go-to-k/cdkd#2380

That PR respelled every registration in `.claude/settings.json` as `${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/x.sh`. The suite's population regex is start-anchored on `.claude/hooks/`, so it matched nothing, its population guard fired, and `run-tests.sh` exited 1 — **on `main`, right now, reproducible from a clean checkout** (verified independently before writing this).

Nobody saw it because `.github/workflows/hooks.yml` is path-filtered to `.claude/hooks/**` and go-to-k/cdkd#2380 touched only `.claude/settings.json`, so the suite that would have caught it never ran. The next `.claude/hooks/**` PR — this one — would have inherited a red it did not cause.

Both halves fixed: a lazy optional path prefix in the enumeration, and `.claude/settings.json` added to both of `hooks.yml`'s path filters. The suite goes from 0 hooks / FAIL to 25+ enumerated, 13/13 passing.

**The population guard is why this was findable.** It refused to run vacuously rather than reporting 13/13 over an empty population — the exact discipline `implement.md` spends most of its fence material on, paying off on the fence infrastructure itself.

## What the skill text gained

- **The commit MESSAGE is outside every reviewer's reading.** All four reviewer agents take `gh pr diff` / `gh pr view --json files`; none reads `git log`. This run put a citation of a function that exists nowhere in the repo's history into a commit message, and three reviewer rounds did not see it because it was never in their input. `verify.md`'s delta-round rule now requires pasting the message into the brief.
- **A rebase merges the integ ledger as a CONFLICT, not as a replay.** `run-integ` step 13 claimed "no manual post-rebase re-check is needed". The normalizer's byte-for-byte guarantee covers a *replayed* commit; two lanes recording the same test makes it a conflict whose resolution keeps both rows. This run pushed a normalize without committing it and took a PR's CI red. The false clause is deleted, the exception named, and `ship.md` gains the ledger beside the changelog — it is the other generated file a parallel-lane rebase merges.
- **A fresh worktree carries no sentinel**, so `markgate set integ-broad` there answers `dead scope: include matches nothing this gate can see`. Recorded as the diagnostic (the ordering is already in `run-integ` step 11).
- **A duplicate-check needle must be proved absent from main first.** `ship.md` said the count must be 1 but not how to pick the phrase; a needle this run reached for returned 18, because every historical entry contains it. It is now a command pair.
- **A floor derived from the pool it guards is not a floor**, and **an expected value that coincides with the ambient default fences nothing**. Both were proved inert by probe here: emptying the guarded arrays left one fence 10/10 green, and substituting a literal for a threaded binding left 434 tests green because the fixture's region is also this repo's hardcoded default. The second existed only as a memory rule — section 10-b's weakest tier — and was violated anyway, so it is escalated into the skill text.
- **Run the WHOLE hook harness, not just your own hook's suite**, and read the tally rather than a piped exit code. That is how the `main` breakage above was found.

## Promotion check (section 10-0)

go-to-k/cdkd#2373 is this run's only open `next`. Checked against all 68 files the four PRs touched: three hits, all citations rather than targets — the issue names a test file as the spec a future fixture should mirror, and its actual target (a new `tests/integration/<name>/` fixture) does not exist. Its `next` rests on "a NEW integ fixture has to be WRITTEN", which has not expired. **No promotion.**

## Verification

| check | result |
| --- | --- |
| `vp run check` / `typecheck:test` / `build` | rc=0 |
| `vp run test` | rc=0 |
| `bash .claude/hooks/run-tests.sh` | rc=0, 88 suites, zero failing (**pre-fix: 2 failing suite runs**) |
| `pr-body-item-number-gate.test.sh` | 24/24 (pre-fix the new allow case is refused, 23/24) |
| `unresolved-target-class.test.sh` | 13/13 (pre-fix: FAIL, 0 hooks enumerated) |
| `rule-file-payload` / `skill-file-payload` / `work-issues-skill-refs` | rc=0 |

Largest reference file is `implement.md` at 45,970 B against the 49,000 B cap (3,030 B headroom). No cap approached; no other lane's text trimmed.
