### PR TITLE
chore(work-issues): the pr-review marker is the orchestrator's, a reviewer's worktree copy writes to the live tree, and the treadmill stops at round three

### DIFF
--- a/.claude/agents/pr-code-reviewer.md
+++ b/.claude/agents/pr-code-reviewer.md
@@ -14,6 +14,17 @@ You find bugs the implementing agent might have missed. The caller provides a PR
 2. **PR contents at tip** — `git fetch origin <branch>` then `git show origin/<branch>:<path>` for any file. Do NOT check out the branch. (Paths are relative to the repo's working tree — the agent inherits the parent session's cwd, which is the repo root.)
 3. **Project conventions** — `CLAUDE.md` at the repo root for ESM `.js` imports, no `any`, etc.
 
+**Never run a WRITING git verb — anywhere, including in a copy.** `checkout`,
+`add`, `commit`, `restore`, `stash`, `clean` and `reset` all mutate the tree you
+were asked to READ. A copy is not an escape: a linked worktree's `.git` is a
+FILE holding `gitdir: <repo>/.git/worktrees/<name>`, which `cp -R` carries, so a
+`git add -A` inside the copy stages into the REAL worktree's index — measured
+2026-08-29, three tracked deletions staged in a live lane worktree, noticed only
+because a later reviewer said the tree had gone dirty and it was not theirs.
+Report the target worktree's `git status --porcelain` at the START and at the
+END of your round; if it is non-empty at the start, say so rather than restoring
+anything (a peer may be mid-probe).
+
 ## Review focus
 
 Read every changed file end-to-end. For each, ask:

--- a/.claude/agents/pr-security-reviewer.md
+++ b/.claude/agents/pr-security-reviewer.md
@@ -23,6 +23,17 @@ process-launch surfaces, deletion logic), IN ADDITION to the size-tier panel.
    lines.
 4. **Project conventions** — `CLAUDE.md` at the repo root.
 
+**Never run a WRITING git verb — anywhere, including in a copy.** `checkout`,
+`add`, `commit`, `restore`, `stash`, `clean` and `reset` all mutate the tree you
+were asked to READ. A copy is not an escape: a linked worktree's `.git` is a
+FILE holding `gitdir: <repo>/.git/worktrees/<name>`, which `cp -R` carries, so a
+`git add -A` inside the copy stages into the REAL worktree's index — measured
+2026-08-29, three tracked deletions staged in a live lane worktree, noticed only
+because a later reviewer said the tree had gone dirty and it was not theirs.
+Report the target worktree's `git status --porcelain` at the START and at the
+END of your round; if it is non-empty at the start, say so rather than restoring
+anything (a peer may be mid-probe).
+
 ## Review focus
 
 ### 1. Sensitive-value flow tracing (your load-bearing job)

--- a/.claude/agents/pr-spec-reviewer.md
+++ b/.claude/agents/pr-spec-reviewer.md
@@ -16,6 +16,17 @@ You verify whether a PR's implementation matches a design doc. The caller provid
 2. **PR diff** — `gh pr diff <N>` for the full diff, `gh pr view <N> --json files -q '.files[].path'` for the file list.
 3. **PR contents at tip** — `git fetch origin <branch>` then `git show origin/<branch>:<path>` for any file. Do NOT check out the branch — leave the parent worktree on main. (Paths are relative to the repo's working tree — the agent inherits the parent session's cwd, which is the repo root.)
 
+**Never run a WRITING git verb — anywhere, including in a copy.** `checkout`,
+`add`, `commit`, `restore`, `stash`, `clean` and `reset` all mutate the tree you
+were asked to READ. A copy is not an escape: a linked worktree's `.git` is a
+FILE holding `gitdir: <repo>/.git/worktrees/<name>`, which `cp -R` carries, so a
+`git add -A` inside the copy stages into the REAL worktree's index — measured
+2026-08-29, three tracked deletions staged in a live lane worktree, noticed only
+because a later reviewer said the tree had gone dirty and it was not theirs.
+Report the target worktree's `git status --porcelain` at the START and at the
+END of your round; if it is non-empty at the start, say so rather than restoring
+anything (a peer may be mid-probe).
+
 ## Review focus (the ENTIRE scope)
 
 For each D-decision and C-fix in the design doc, verify the implementation matches with a file:line citation. Nothing else. Do NOT comment on:

--- a/.claude/agents/pr-test-reviewer.md
+++ b/.claude/agents/pr-test-reviewer.md
@@ -14,6 +14,17 @@ You verify the test suite actually covers the new behavior. The caller provides 
 2. **Test contents** — `git fetch origin <branch>` then `git show origin/<branch>:tests/<path>`. (Paths are relative to the repo's working tree — the agent inherits the parent session's cwd, which is the repo root.)
 3. **Implementation files** to identify untested branches.
 
+**Never run a WRITING git verb — anywhere, including in a copy.** `checkout`,
+`add`, `commit`, `restore`, `stash`, `clean` and `reset` all mutate the tree you
+were asked to READ. A copy is not an escape: a linked worktree's `.git` is a
+FILE holding `gitdir: <repo>/.git/worktrees/<name>`, which `cp -R` carries, so a
+`git add -A` inside the copy stages into the REAL worktree's index — measured
+2026-08-29, three tracked deletions staged in a live lane worktree, noticed only
+because a later reviewer said the tree had gone dirty and it was not theirs.
+Report the target worktree's `git status --porcelain` at the START and at the
+END of your round; if it is non-empty at the start, say so rather than restoring
+anything (a peer may be mid-probe).
+
 ## Review focus
 
 For each meaningful new behavior in the implementation, find a corresponding test or flag the gap. Specifically watch for:

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -291,9 +291,9 @@ wants — the obvious `git show origin/main:<suite> > /tmp/x.sh && bash
 /tmp/x.sh`. Instead write the old copy beside the real one as
 `.claude/hooks/_old-<name>.test.sh` and delete it after.
 
-The idiom is right for a data file and wrong for a runnable harness — and
-wrong for a WORKTREE, in a way that writes to the live tree rather than merely
-failing; §8 has the mechanism and what a reviewer's brief owes because of it.
+§8's scratch-copy idiom is right for a data file, wrong for a runnable
+harness, and wrong for a WORKTREE in a way that WRITES to the live tree rather
+than failing; §8 carries the mechanism and what a reviewer's brief owes for it.
 
 **When the issue reports a stale ENTRY in an enumerated list, audit the whole
 list, in both directions, before fixing the named entry.** Drift almost never
@@ -312,9 +312,9 @@ clean result from the wrong shape is indistinguishable from a clean subject.**
 Auditing go-to-k/cdkd#2096 (2026-08-20) produced SIX confident wrong answers,
 each from a different plausible sampling shape, each hiding a real secret:
 
-- **Newest-N.** The 6 NEWEST state versions cleared `appsync`; versions 12-45
-  held an API key in 17 of 33 — the newest versions come from the run most
-  likely already fixed. Sample across the range, or grep everything.
+- **Newest-N.** The 6 NEWEST state versions cleared `appsync` while versions
+  12-45 held an API key in 17 of 33 — the newest come from the run most likely
+  already fixed. Sample across the range, or grep everything.
 - **One global needle.** A single `cdkd-known-*` grep reported
   `secrets-array-nested` clean while 5 of 7 versions carried
   `cdkd-array-nested-pw-789`. Each fixture spells its OWN literal — derive the
@@ -490,24 +490,23 @@ tree:
   probe's `` `${'...'}/` `` reds it while the spelling anybody would type —
   `listRawObjects('custom-resource-responses/')`, trailing slash inside the
   quote — sailed through, as did any copy outside the fence's hand-written file
-  list. It was written by someone who had just read the "grep for the SHAPE,
-  not for a NAME" rule. Mutate a fence the way a future contributor would, and
-  derive the population rather than listing it.
+  list. Its author had just read the "grep for the SHAPE, not for a NAME" rule.
+  Mutate a fence the way a future contributor would, and derive the population
+  rather than listing it.
 - **Write the defect in every spelling the language allows** and confirm each
   is flagged. go-to-k/cdkd#2111 (2026-08-20): a scanner for
   `options.region || process.env['AWS_REGION']` calibrated perfectly (19
-  violations, zero false positives) and matched `||` only — the tree already
-  used `??` at four sites, and the rule was blind to the `opts.` / `args.` bag
-  names two other files use. Widening it immediately surfaced a real unfiled
-  bug.
+  violations, 0 false positives) yet matched `||` only, while the tree used
+  `??` at four sites and two files spell the bag `opts.` / `args.`. Widening it
+  surfaced a real unfiled bug.
 - **Delete the thing the fence REQUIRES, and watch it fail.** A predicate of
   whole-file substrings OR'd together is satisfied by any one: the "every
   region-taking handler folds" fence passed 130/130 while a probe deleted the
-  ONLY fold from four handlers at once, each still containing a different
-  accepted substring. Its POPULATION was wrong too — derived from "mentions
+  ONLY fold from four handlers at once, each still holding a different accepted
+  substring. Its POPULATION was wrong too — derived from "mentions
   `options.region`", it pulled in helpers that merely RECEIVE a folded value
-  while missing the files that actually accept the flag. Derive from what
-  declares the option, and make the predicate per-READ rather than per-file.
+  and missed the files that accept the flag. Derive from what DECLARES the
+  option, and make the predicate per-READ rather than per-file.
 
   The worst population is one derived from the DEFECT itself, because deleting
   the required thing then drops the subject OUT of the population instead of
@@ -557,9 +556,10 @@ written.
 
 **When a fence must read another tool's CONFIG, parse it with a real parser and
 fail CLOSED on anything unmodelled — do not hand-roll a scanner, and do not
-patch one per spelling.** Measured over five review rounds across
-go-to-k/cdkd#2381, go-to-k/cdk-real-drift#1838 and go-to-k/cdk-local#630
-(2026-08-29), all three reaching the same end:
+patch one per spelling.** Measured across go-to-k/cdkd#2383,
+go-to-k/cdk-real-drift#1838 and go-to-k/cdk-local#631 (2026-08-29) — three
+different fences over the same config, all three ending on one that fails
+CLOSED rather than on a better pattern:
 
 - **The unused key.** markgate resolves a `hash: files` gate as `include` MINUS
   `exclude`. No repo in the family had ever written an `exclude`, so the fence
@@ -567,33 +567,33 @@ go-to-k/cdkd#2381, go-to-k/cdk-real-drift#1838 and go-to-k/cdk-local#630
   would already have subtracted from. Read the tool's OWN schema, from the
   pinned binary rather than its `init` template: 0.4.1 has eight gate keys
   (`hash` / `include` / `exclude` / `base` / `ttl` / `state_dir` / `requires` /
-  `composes`) and `init` emits six, omitting the two a repo is likeliest not to
+  `composes`); `init` emits six, dropping the two a repo is likeliest never to
   have written.
 - **Then the spelling treadmill, which is the real lesson.** Each round patched
-  the one spelling that had just got through while the next sailed past: block
-  items only -> a FLOW list passed; unquoted keys only -> `"exclude":` passed;
-  a block scan terminating on `/^ {2}\S/` -> a two-space COMMENT ended it early
-  and left all fourteen cases GREEN while markgate really did subtract; and
-  fifth, a YAML merge key (`<<: *anchor`) splicing an `exclude` declared on a
-  SIBLING gate. **Three spellings in three rounds is the signal to stop
+  the one spelling that had just got through while the next sailed past. Block
+  items only -> a FLOW list passed. Unquoted keys only -> `"exclude":` passed.
+  A block scan terminating on `/^ {2}\S/` -> a two-space COMMENT ended it early
+  and left all fourteen cases GREEN while markgate really did subtract. A "raw
+  text" tripwire, added so the guard would not read the parser it protects ->
+  another hand-rolled pattern over the same text, inheriting every blind spot.
+  Last, a YAML merge key (`<<: *anchor`) splicing an `exclude` declared on a
+  SIBLING gate — which that tripwire, added as exactly this backstop, did not
+  fire on either, grepping only the `check` block. go-to-k/cdkd#2383 tallies it
+  as **four spellings across four rounds, each patch moving the hole rather
+  than closing it**. **Three spellings in three rounds is the signal to stop
   patterning and change instrument** — a YAML parser was a production
-  dependency the whole time. A "raw text" tripwire does not escape it: added so
-  the guard would not read the parser it protects, it was another hand-rolled
-  pattern over the same text and inherited every blind spot, the merge key
-  included (it grepped only the `check` block). A third-party, versioned,
-  separately-tested library is not the fence checking its own work.
-- **Neither escape was a sixth pattern.** Either parse for real — with
+  dependency the whole time, and a third-party, versioned, separately-tested
+  library is not the fence checking its own work.
+- **Neither escape was a fifth pattern.** Either parse for real — with
   `parse(text, { merge: true })`, without which `yaml` reports the gate's keys
   as `["hash", "<<"]` and its `exclude` as undefined — then ALLOW-LIST the
   tool's own keys, fail CLOSED outside them, and raw-scan the WHOLE `gates:`
   map. Or, where the repo has no parser to reach for, REFUSE the construct
   rather than model it: go-to-k/cdk-local#631 took that route and then held
-  against every respelling its reviewers could construct, including the
-  items-at-the-parent-key's-own-indent and two-spaces-after-the-dash forms an
-  earlier scanner silently dropped. Refusal is the STRICTER option, not the
-  weaker one — an unmodelled shape stops the fence instead of passing through
-  it, which is why an allow-list also beats deny-listing the spellings someone
-  happened to think of.
+  against every respelling its reviewers constructed. Refusal is the STRICTER
+  option, not the weaker one — an unmodelled shape stops the fence instead of
+  passing through it, which is why an allow-list also beats deny-listing the
+  spellings someone happened to think of.
 - **And the probe that establishes any of this must move ONE variable.** The
   rule's first draft published "adding `exclude` while holding `include`
   constant takes `verify` from rc=1 to rc=0" — measured, it stays rc=1, because
@@ -678,9 +678,9 @@ code "cannot have changed behaviour".
 
 - **Never force-push over a commit you did not author.** A lane agent resumed
   with edits predating four orchestrator commits on its branch and
-  force-pushed; nothing was lost only because the rebase preserved them. Say
-  in the prompt: re-`git fetch` and inspect the branch before any force-push;
-  if it carries work you did not write, STOP and report.
+  force-pushed; only the rebase preserved them. Say in the prompt: re-`git
+  fetch` and inspect the branch first, and if it carries work you did not
+  write, STOP and report.
 - **A new fixture literal must not collide with an existing assertion needle —
   and neither may a new fixture RESOURCE collide with an existing resource's
   VALUE.** The literal form: a `DB_URL` hard-coded `cdkd-user` as its URL user
@@ -697,8 +697,8 @@ code "cannot have changed behaviour".
 
   **And check the arm's shape actually exercises the fix before spending a run
   on it.** The obvious decoupling there (two separate RESOURCES) was VACUOUS:
-  `perResourceSecrets` is keyed by logical id, so two resources redact
-  correctly with or without the fix. One resource holding both leaves was the
+  `perResourceSecrets` is keyed by logical id, so two resources get two
+  single-pair bags and redact correctly with or without the fix. One resource holding both leaves was the
   only shape where the mechanism under test decides the answer.
 - **Execute every read expression you write.** Two integ runs were lost to
   fixture code, not product defects: the literal collision above, and a `jq`
@@ -728,7 +728,9 @@ code "cannot have changed behaviour".
   reviewer: peers are probing this same worktree, `git status --porcelain`
   must be EMPTY before you start a probe, and if it is not, WAIT and re-check
   rather than restoring — a `git show HEAD:<path>` over a peer's edit reverts
-  it. And read any surprising probe result as possibly theirs first.
+  it. And read any surprising probe result as possibly theirs first. §8 adds
+  the AFTER half of that check and the copied-worktree hazard; both also live
+  in `.claude/agents/pr-*-reviewer.md`, so no dispatch can omit them.
 
   **That is a DURATION constraint, not just a precondition, and the
   ORCHESTRATOR breaks it more easily than a lane agent does.** A clean tree at
@@ -755,26 +757,24 @@ because it converts an open gap into a recorded assurance:
   receipt rather than the exit code.
 
   **This rule was already written here and was broken THREE times in one run
-  (2026-08-26), so the fix is to stop asking agents to invent the name: the
-  ORCHESTRATOR assigns each dispatched agent a unique scratch directory IN ITS
-  PROMPT** (`$SCRATCHPAD/lane<issue>-private/`,
-  `$SCRATCHPAD/rev-<role>-<sha>/`), and every prompt says never to write a
-  bare generic name in the scratchpad root. Decided once per run, it cannot be
-  re-derived wrongly per agent. Without it: lane B ran lane A's whole probe
-  table against lane A's worktree; one reviewer's mutation was restored from
-  `HEAD` by another; and a live cross-session TRESPASS was reported that had
-  not happened, because the `_old-<name>.test.sh` copy a reviewer is TOLD to
-  write beside its subject is indistinguishable, from inside the worktree, from
-  a peer writing there — only the orchestrator can know which is which. A hook
-  was rejected: it would have to match command TEXT for scratch-path writes,
-  the unbounded-bypass shape go-to-k/cdkd#2156 documents.
+  (2026-08-26), so stop asking agents to invent the name: the ORCHESTRATOR
+  assigns each dispatched agent a unique scratch directory IN ITS PROMPT**
+  (`$SCRATCHPAD/lane<issue>-private/`, `$SCRATCHPAD/rev-<role>-<sha>/`), plus
+  "never a bare generic name in the scratchpad root". Decided once per run, it
+  cannot be re-derived wrongly per agent. Without it: lane B ran lane A's whole
+  probe table twelve times against lane A's worktree; one reviewer's mutation
+  was restored from `HEAD` by another; and a TRESPASS was reported that had not
+  happened, the `_old-<name>.test.sh` copy a reviewer is TOLD to write beside
+  its subject being indistinguishable, from inside the worktree, from a peer
+  writing there. Only the orchestrator can know which is which. A hook was
+  rejected: it would have to match command TEXT for scratch-path writes, the
+  unbounded-bypass shape go-to-k/cdkd#2156 documents.
 - **A probe's FIXTURE, not its mutation, decided the outcome.** A region test
   set `AWS_REGION` to the CONSUMER's region, where the correct code and the
   mutation bind identically; only the PRODUCER's region separated them. When a
-  probe comes back green, suspect the fixture before concluding the code is
-  fenced — and no count of passing cases can see the commonest instance, an
-  expected value COINCIDING with the ambient default: assertions pinned to
-  `'us-east-1'`, at once the fixture's region and this repo's hardcoded
-  fallback, cannot tell a threaded binding from a defaulted one, and
-  substituting the literal for the binding left 434 tests green (2026-08-29).
-  Choose a fixture value the default can never produce.
+  probe comes back green, suspect the fixture first — and no count of passing
+  cases can see the commonest instance, an expected value COINCIDING with the
+  ambient default: assertions pinned to `'us-east-1'`, at once the fixture's
+  region and this repo's hardcoded fallback, cannot tell a threaded binding
+  from a defaulted one, and substituting the literal for the binding left 434
+  tests green (2026-08-29). Choose a value the default can never produce.

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -289,9 +289,11 @@ the REPO ROOT the same way, and `run-tests.sh` is itself
 entirely. The trap is invited by the before/after comparison a hook change
 wants — the obvious `git show origin/main:<suite> > /tmp/x.sh && bash
 /tmp/x.sh`. Instead write the old copy beside the real one as
-`.claude/hooks/_old-<name>.test.sh` and delete it after. This is the one place
-§8's scratch-copy idiom does NOT transfer: right for a data file, wrong for a
-runnable harness.
+`.claude/hooks/_old-<name>.test.sh` and delete it after.
+
+The idiom is right for a data file and wrong for a runnable harness — and
+wrong for a WORKTREE, in a way that writes to the live tree rather than merely
+failing; §8 has the mechanism and what a reviewer's brief owes because of it.
 
 **When the issue reports a stale ENTRY in an enumerated list, audit the whole
 list, in both directions, before fixing the named entry.** Drift almost never
@@ -483,16 +485,14 @@ defeat your exemption logic. Follow calibration with probes against the REAL
 tree:
 
 - **Write the defect in the spelling a PERSON would write, not the one that is
-  easiest to inject.** On the go-to-k/cdkd#2052 lane (2026-08-26) a
-  prefix-sync fence split on `'custom-resource-responses'` *with both quote
-  characters*, and the probe used `` `${'custom-resource-responses'}/` ``,
-  which reds it; the spelling anybody would type —
-  `listRawObjects('custom-resource-responses/')` — puts the trailing slash
-  before the closing quote and sailed through, as did a copy in any file
-  outside the fence's hand-written list. That fence was the very mechanism the
-  "grep for the SHAPE, not for a NAME" rule prescribes, written by someone who
-  had just read that rule — so mutate a fence the way a future contributor
-  would, and derive the population rather than listing it.
+  easiest to inject.** go-to-k/cdkd#2052 (2026-08-26): a prefix-sync fence
+  split on `'custom-resource-responses'` *with both quote characters*, so the
+  probe's `` `${'...'}/` `` reds it while the spelling anybody would type —
+  `listRawObjects('custom-resource-responses/')`, trailing slash inside the
+  quote — sailed through, as did any copy outside the fence's hand-written file
+  list. It was written by someone who had just read the "grep for the SHAPE,
+  not for a NAME" rule. Mutate a fence the way a future contributor would, and
+  derive the population rather than listing it.
 - **Write the defect in every spelling the language allows** and confirm each
   is flagged. go-to-k/cdkd#2111 (2026-08-20): a scanner for
   `options.region || process.env['AWS_REGION']` calibrated perfectly (19
@@ -557,9 +557,9 @@ written.
 
 **When a fence must read another tool's CONFIG, parse it with a real parser and
 fail CLOSED on anything unmodelled — do not hand-roll a scanner, and do not
-patch one per spelling.** Measured over three review rounds on
-go-to-k/cdkd#2381 (2026-08-29), with the sibling go-to-k/cdk-real-drift#1838
-reaching the same end:
+patch one per spelling.** Measured over five review rounds across
+go-to-k/cdkd#2381, go-to-k/cdk-real-drift#1838 and go-to-k/cdk-local#630
+(2026-08-29), all three reaching the same end:
 
 - **The unused key.** markgate resolves a `hash: files` gate as `include` MINUS
   `exclude`. No repo in the family had ever written an `exclude`, so the fence
@@ -569,23 +569,31 @@ reaching the same end:
   (`hash` / `include` / `exclude` / `base` / `ttl` / `state_dir` / `requires` /
   `composes`) and `init` emits six, omitting the two a repo is likeliest not to
   have written.
-- **Then the spelling treadmill, which is the real lesson.** The first fix was
-  a line scanner, and each round patched the one spelling that had just got
-  through while the next one sailed past: block items only -> a FLOW list
-  passed; unquoted keys only -> `"exclude":` passed; the block scan terminated
-  on `/^ {2}\S/` -> a two-space COMMENT between `include` and `exclude` ended
-  it early and left all fourteen cases GREEN while markgate really did
-  subtract. **Three spellings in three rounds is the signal to stop patterning
-  and change instrument.** A YAML parser was a production dependency the whole
-  time.
-- **A "raw text" tripwire does not escape this.** It was added precisely so the
-  guard would not read the parser it protects — and it inherited every blind
-  spot anyway, because it was another hand-rolled pattern over the same text.
-  Reading a REAL parser is not the failure that guard was for: a third-party,
-  versioned, separately-tested library is not the fence checking its own work.
-  What replaces the tripwire is an ALLOW-LIST of the tool's keys plus an
-  explicit refusal list — strictly stronger than deny-listing the spellings
-  someone happened to think of.
+- **Then the spelling treadmill, which is the real lesson.** Each round patched
+  the one spelling that had just got through while the next sailed past: block
+  items only -> a FLOW list passed; unquoted keys only -> `"exclude":` passed;
+  a block scan terminating on `/^ {2}\S/` -> a two-space COMMENT ended it early
+  and left all fourteen cases GREEN while markgate really did subtract; and
+  fifth, a YAML merge key (`<<: *anchor`) splicing an `exclude` declared on a
+  SIBLING gate. **Three spellings in three rounds is the signal to stop
+  patterning and change instrument** — a YAML parser was a production
+  dependency the whole time. A "raw text" tripwire does not escape it: added so
+  the guard would not read the parser it protects, it was another hand-rolled
+  pattern over the same text and inherited every blind spot, the merge key
+  included (it grepped only the `check` block). A third-party, versioned,
+  separately-tested library is not the fence checking its own work.
+- **Neither escape was a sixth pattern.** Either parse for real — with
+  `parse(text, { merge: true })`, without which `yaml` reports the gate's keys
+  as `["hash", "<<"]` and its `exclude` as undefined — then ALLOW-LIST the
+  tool's own keys, fail CLOSED outside them, and raw-scan the WHOLE `gates:`
+  map. Or, where the repo has no parser to reach for, REFUSE the construct
+  rather than model it: go-to-k/cdk-local#631 took that route and then held
+  against every respelling its reviewers could construct, including the
+  items-at-the-parent-key's-own-indent and two-spaces-after-the-dash forms an
+  earlier scanner silently dropped. Refusal is the STRICTER option, not the
+  weaker one — an unmodelled shape stops the fence instead of passing through
+  it, which is why an allow-list also beats deny-listing the spellings someone
+  happened to think of.
 - **And the probe that establishes any of this must move ONE variable.** The
   rule's first draft published "adding `exclude` while holding `include`
   constant takes `verify` from rc=1 to rc=0" — measured, it stays rc=1, because
@@ -681,20 +689,17 @@ code "cannot have changed behaviour".
   report is worse than a missing assertion, being indistinguishable from the
   real thing. The RESOURCE form is the same trap one level up
   (go-to-k/cdkd#2270, 2026-08-26): an arm testing a same-plaintext COLLAPSE
-  necessarily gives two leaves one plaintext — that sharing is what makes the
-  arm discriminate — and it reused the plaintext of a leaf a pre-existing
-  assertion already owned, which then failed on an assertion the lane never
-  wrote. When an arm deliberately makes two things equal, ask what ELSE
-  already holds that value: give the arm its own secret / key / name. The
-  repair is to scope the sharing, not break it — breaking it retires the
-  fence.
+  must give two leaves one plaintext — that sharing is what makes it
+  discriminate — and it reused a plaintext a pre-existing assertion already
+  owned, failing on an assertion the lane never wrote. When an arm makes two
+  things equal, ask what ELSE holds that value and give the arm its own secret
+  / key / name. Scope the sharing; breaking it retires the fence.
 
   **And check the arm's shape actually exercises the fix before spending a run
-  on it.** The obvious decoupling there (two separate RESOURCES) would have
-  been VACUOUS: `perResourceSecrets` is keyed by logical id, so two resources
-  get two single-pair bags and redact correctly with or without the fix. One
-  resource holding both leaves was the only shape where the mechanism under
-  test decides the answer.
+  on it.** The obvious decoupling there (two separate RESOURCES) was VACUOUS:
+  `perResourceSecrets` is keyed by logical id, so two resources redact
+  correctly with or without the fix. One resource holding both leaves was the
+  only shape where the mechanism under test decides the answer.
 - **Execute every read expression you write.** Two integ runs were lost to
   fixture code, not product defects: the literal collision above, and a `jq`
   assignment written through `to_entries[]`, which builds a new array and is
@@ -755,27 +760,21 @@ because it converts an open gap into a recorded assurance:
   PROMPT** (`$SCRATCHPAD/lane<issue>-private/`,
   `$SCRATCHPAD/rev-<role>-<sha>/`), and every prompt says never to write a
   bare generic name in the scratchpad root. Decided once per run, it cannot be
-  re-derived wrongly per agent. Without it: lane B ran lane A's entire probe
-  table twelve times against lane A's worktree; a reviewer's mutation was
-  restored from `HEAD` by a second reviewer; and an agent reported a live
-  cross-session TRESPASS that had not happened, because the
-  `_old-<name>.test.sh` copies a reviewer is TOLD to write beside their
-  subject look identical, from inside the worktree, to a peer writing there —
-  a collision and a correct convention are indistinguishable to the lane being
-  written into, so the orchestrator has to be the one who knows which is
-  which. A hook was considered and rejected: it would have to match command
-  TEXT for scratch-path writes, the unbounded-bypass-spelling shape
-  go-to-k/cdkd#2156 documents. Pre-assignment moves the decision instead of
-  trying to police it.
+  re-derived wrongly per agent. Without it: lane B ran lane A's whole probe
+  table against lane A's worktree; one reviewer's mutation was restored from
+  `HEAD` by another; and a live cross-session TRESPASS was reported that had
+  not happened, because the `_old-<name>.test.sh` copy a reviewer is TOLD to
+  write beside its subject is indistinguishable, from inside the worktree, from
+  a peer writing there — only the orchestrator can know which is which. A hook
+  was rejected: it would have to match command TEXT for scratch-path writes,
+  the unbounded-bypass shape go-to-k/cdkd#2156 documents.
 - **A probe's FIXTURE, not its mutation, decided the outcome.** A region test
-  set `AWS_REGION` to the CONSUMER's region, under which the correct code and
-  the mutation bind identically, so the probe stayed green; the PRODUCER's
-  region separated them. Same lesson as choosing the probe's input (section 5,
-  above), from the fixture side: when a probe comes back green, suspect the
-  fixture before concluding the code is fenced. The commonest instance is an
-  expected value that COINCIDES with the ambient default, and no count of
-  passing cases can see it: assertions pinned to `'us-east-1'` — at once the
-  fixture's region and this repo's hardcoded fallback — cannot separate a
-  threaded binding from a defaulted one, and substituting the literal for the
-  binding left 434 tests green (2026-08-29). Choose a fixture value the
-  default can never produce.
+  set `AWS_REGION` to the CONSUMER's region, where the correct code and the
+  mutation bind identically; only the PRODUCER's region separated them. When a
+  probe comes back green, suspect the fixture before concluding the code is
+  fenced — and no count of passing cases can see the commonest instance, an
+  expected value COINCIDING with the ambient default: assertions pinned to
+  `'us-east-1'`, at once the fixture's region and this repo's hardcoded
+  fallback, cannot tell a threaded binding from a defaulted one, and
+  substituting the literal for the binding left 434 tests green (2026-08-29).
+  Choose a fixture value the default can never produce.

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -608,23 +608,27 @@ of through the review. Measured 2026-08-29: two of three lanes in one run
 independent review existed. §5's "a lane stops at merge-ready" was already
 written and did not prevent it, because recording a marker reads as part of
 finishing rather than as merging — so name this marker in the lane's brief.
-The gate is not what breaks: `pr-review-gate.sh` compares the recorded
-`.markgate-pr-review-sha` sentinel against the PR's current HEAD and refuses
-with `bound to <sha> (mismatch)`, so a lane-set marker does not authorize an
-unreviewed merge; what it destroys is the record.
+And nothing mechanical catches it, so do not read the sha binding as a
+backstop. `pr-review-gate.sh` compares the recorded `.markgate-pr-review-sha`
+sentinel against the PR's current HEAD and refuses with
+`bound to <sha> (mismatch)` — which catches a marker a later PUSH left behind,
+not a marker set by the wrong AGENT. It cannot tell who set it; the sentinel is
+per-worktree, and §9 merges from the lane's own worktree, so a lane that sets it
+after its final push produces a matching sha and merges unreviewed. The rule is
+the only thing standing there.
 
 **And your own review round is not optional because the lane already ran one.**
-A lane's reviewers are its children — same brief, same framing — so they clear
-what the lane already believes. Measured 2 for 2 in that run: on
-go-to-k/cdk-real-drift#1838 the lane's own 3-axis round reported clean and the
-orchestrator's independent 3-axis pass found a HIGH blocker (a flow-style
-`exclude:` that a hand-rolled YAML scanner could not see, leaving its "no
-exclude declared" tripwire green while markgate really did subtract); on
-go-to-k/cdkd#2383 the same again one spelling deeper (a merge key
-`<<: *anchor` anchored on a SIBLING gate, invisible to both the parser and a
-tripwire that grepped only the `check` block). Both were reproduced against the
-pinned markgate 0.4.1. Take the tier the heuristic gives for YOUR pass; a
-lane's clean round is not a measurement that lowers it.
+A lane's reviewers are its children — same brief, same framing — so the thing
+they are least able to doubt is the premise the lane handed them. Measured on
+go-to-k/cdkd#2383 (2026-08-29): three rounds of the lane's own reviewers each
+found the next spelling of one defect, and it took an independent
+orchestrator-level round — round 4, A/B-ing the hand-rolled parser against the
+`yaml` library over 15 spellings and then against markgate 0.4.1 itself — to
+find the YAML merge key, **the spelling the lane's raw-text tripwire had been
+added specifically to backstop and did not fire on**. The sibling
+go-to-k/cdk-real-drift#1838 spent its own rounds on the same class. So take the
+tier the heuristic gives for YOUR pass: a lane's clean round is evidence about
+the lane's assumptions, not about the diff.
 
 **A reviewer's scratch COPY of a worktree is not detached from git, so its
 `git add -A` writes to the LIVE tree.** A linked worktree's `.git` is a FILE
@@ -637,10 +641,11 @@ which the lane's next commit would have shipped. Nothing announced it — the
 reviewer believed it was on a copy. So two lines belong in every read-only
 reviewer's brief, on top of §5's peer-probe rules: **run no WRITING git verb**
 (`add` / `commit` / `restore` / `checkout` / `stash` / `clean`) anywhere, copy
-included, severing the pointer with `rm .git` if you must copy at all; and
-**report the TARGET worktree's `git status --porcelain` before AND after the
-round.** The before/after pair is what makes damage attributable rather than a
-mystery a later agent finds: that incident surfaced only because the NEXT
+included — and if you must copy, copy OUTSIDE every repository, since deleting
+the `.git` file does not detach the copy, it only makes discovery walk UPWARD
+into whatever encloses it; and **report the TARGET worktree's
+`git status --porcelain` before AND after the round.** The before/after pair is
+what makes damage attributable rather than a mystery a later agent finds: that incident surfaced only because the NEXT
 reviewer volunteered "the tree went dirty mid-review, not mine", after which
 the responsible one self-reported and repaired the index with `git restore
 --staged` (index only, never the working tree). Every reviewer given these two

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -597,3 +597,51 @@ them by direct AWS API call before doing anything else.
 
 `/verify-pr` sets the `check` + `docs` + `verify-pr` markers, and `/run-integ`
 sets the `integ-*` markers — together they unblock `gh pr merge`.
+
+**`pr-review` is not on that list, and a LANE must never set it.** `/review-pr`
+writes it, run by the ORCHESTRATOR, after the reviewers it dispatched have
+reported and every blocker is addressed — the marker records who reviewed what
+at which sha, so a lane setting it is the "sub-agent self-review is not
+independent review" failure of `CLAUDE.md` arriving through the marker instead
+of through the review. Measured 2026-08-29: two of three lanes in one run
+(go-to-k/cdkd#2383, go-to-k/cdk-local#631) set it themselves before any
+independent review existed. §5's "a lane stops at merge-ready" was already
+written and did not prevent it, because recording a marker reads as part of
+finishing rather than as merging — so name this marker in the lane's brief.
+The gate is not what breaks: `pr-review-gate.sh` compares the recorded
+`.markgate-pr-review-sha` sentinel against the PR's current HEAD and refuses
+with `bound to <sha> (mismatch)`, so a lane-set marker does not authorize an
+unreviewed merge; what it destroys is the record.
+
+**And your own review round is not optional because the lane already ran one.**
+A lane's reviewers are its children — same brief, same framing — so they clear
+what the lane already believes. Measured 2 for 2 in that run: on
+go-to-k/cdk-real-drift#1838 the lane's own 3-axis round reported clean and the
+orchestrator's independent 3-axis pass found a HIGH blocker (a flow-style
+`exclude:` that a hand-rolled YAML scanner could not see, leaving its "no
+exclude declared" tripwire green while markgate really did subtract); on
+go-to-k/cdkd#2383 the same again one spelling deeper (a merge key
+`<<: *anchor` anchored on a SIBLING gate, invisible to both the parser and a
+tripwire that grepped only the `check` block). Both were reproduced against the
+pinned markgate 0.4.1. Take the tier the heuristic gives for YOUR pass; a
+lane's clean round is not a measurement that lowers it.
+
+**A reviewer's scratch COPY of a worktree is not detached from git, so its
+`git add -A` writes to the LIVE tree.** A linked worktree's `.git` is a FILE
+holding `gitdir: <repo>/.git/worktrees/<name>`, and `cp -R` carries the
+pointer: every git command inside the copy reads and WRITES the real
+worktree's index and HEAD. Measured 2026-08-29: a read-only code reviewer
+copied a lane's worktree, ran `git add -A` there, and staged three tracked
+DELETIONS under `tests/integration/local-invoke-layers/` in the live tree,
+which the lane's next commit would have shipped. Nothing announced it — the
+reviewer believed it was on a copy. So two lines belong in every read-only
+reviewer's brief, on top of §5's peer-probe rules: **run no WRITING git verb**
+(`add` / `commit` / `restore` / `checkout` / `stash` / `clean`) anywhere, copy
+included, severing the pointer with `rm .git` if you must copy at all; and
+**report the TARGET worktree's `git status --porcelain` before AND after the
+round.** The before/after pair is what makes damage attributable rather than a
+mystery a later agent finds: that incident surfaced only because the NEXT
+reviewer volunteered "the tree went dirty mid-review, not mine", after which
+the responsible one self-reported and repaired the index with `git restore
+--staged` (index only, never the working tree). Every reviewer given these two
+lines in that run reported clean both ways.


### PR DESCRIPTION
## Summary

Stage-10 retrospective for the `/work-issues` run that landed go-to-k/cdkd#2383, go-to-k/cdk-local#631 and go-to-k/cdk-real-drift#1838 — one root cause fixed in all three repos ("every file the unit suite reads as INPUT must be inside the markgate `check` gate's include, else an edit leaves a recorded marker reporting FRESH while the suite is red").

Agent-instruction prose plus the four reviewer agent files. One PR per repo; the sibling PRs carry the same lessons adapted to their own gates.

## What changed, and where it fires

**`references/verify.md`** (section 8 — where the review round is dispatched):

- **The `pr-review` marker is the ORCHESTRATOR's; a lane must never set it.** The closing sentence of section 8 enumerated `check` / `docs` / `verify-pr` / `integ-*` and omitted `pr-review`, and two of the run's three lanes (go-to-k/cdkd#2383, go-to-k/cdk-local#631) filled the gap by setting it themselves before any independent review existed. Section 5's "a lane stops at merge-ready" was already written and did not prevent it, because recording a marker reads as part of *finishing* rather than as *merging* — so the amended sentence names the marker for the lane's brief.

  **And nothing mechanical catches it.** The first draft of this paragraph said the sha binding did, and review proved that false: `pr-review-gate.sh` compares `recorded_sha` to `head_sha` and cannot tell WHO set it. The sentinel is per-worktree and the merge is issued from the lane's own worktree, so a lane that sets the marker after its final push produces a matching sha and merges unreviewed. What the binding catches is a marker a later PUSH left behind. The rule is the only thing standing there — which is why it is load-bearing rather than tidy.

- **Your own review round is not optional because the lane already ran one.** A lane's reviewers are its children — same brief, same framing — so the thing they are least able to doubt is the premise the lane handed them. The measurement is go-to-k/cdkd#2383's own record: three rounds of the lane's reviewers each found the next spelling of one defect, and it took an independent orchestrator-level round (round 4, A/B-ing the hand-rolled parser against the `yaml` library over 15 spellings and then against markgate 0.4.1 itself) to find the YAML merge key — **the spelling the lane's raw-text tripwire had been added specifically to backstop and did not fire on**.

- **A reviewer's scratch COPY of a worktree is not detached from git.** A linked worktree's `.git` is a FILE holding `gitdir: <repo>/.git/worktrees/<name>`, so `cp -R` carries the pointer and every git command inside the copy reads and WRITES the real worktree's index and HEAD. Measured this run: a read-only code reviewer copied a lane worktree, ran `git add -A` there, and staged three tracked DELETIONS under `tests/integration/local-invoke-layers/` in the live tree — the lane's next commit would have shipped them. Nothing announced it; a LATER reviewer noticed the tree had gone dirty and said it was not theirs, after which the responsible reviewer self-reported and repaired the index with `git restore --staged` (index only, no working-tree write).

  Two lines therefore belong in every read-only reviewer's brief: no WRITING git verb anywhere (copying outside every repository if you must copy at all — deleting the `.git` file does not detach a copy, it only makes discovery walk UPWARD), and a before/after `git status --porcelain` of the target worktree. Every reviewer given those lines in this run reported clean both ways.

**`.claude/agents/pr-{code,spec,test,security}-reviewer.md`** — because the rule above was REGISTERED in section 8 and executed nowhere: none of the agent files carried it, so a dispatch from those templates omitted it. Each now carries the rule, amended onto the "Do NOT check out the branch" input line that already forbade the narrower case, and section 5 points at it rather than restating the mechanism a second time.

**`references/implement.md`** (section 5):

- The scratch-copy rule claimed the hook-harness case was "the one place" section 8's scratch-copy idiom does not transfer. It is not — it now names the worktree case, which fails by WRITING rather than by failing loudly.
- The fence-config block said "three review rounds". go-to-k/cdkd#2383 tallies **four spellings across four rounds, each patch moving the hole rather than closing it**, and the last was not a spelling of `exclude` at all: a merge key splicing an `exclude` declared on a SIBLING gate, which defeats a real parser too without `parse(text, { merge: true })` (`yaml` otherwise reports the gate's keys as `["hash", "<<"]`). **Neither escape was a fifth pattern**: parse for real plus an allow-list of the tool's own keys that fails CLOSED plus a raw scan of the WHOLE `gates:` map — or, where the repo has no parser to reach for, refuse the construct outright (go-to-k/cdk-local#631 took that route with no `yaml` dependency).

## What was cut to pay for it

`tests/unit/scripts/skill-file-payload.test.ts` caps `references/implement.md` at 49,000 B and it sat at 48,670 B, so the additions had to be paid for in bytes, not just in principle. Compressed to rule + citation form (the shape go-to-k/cdkd#2377 established): the "raw text tripwire" bullet, folded into the treadmill bullet it restated; the go-to-k/cdkd#2052 prefix-sync-fence narrative; the scratch-directory-assignment narrative (go-to-k/cdkd#2156); the region-fixture narrative; the go-to-k/cdkd#2270 shared-plaintext narrative and its follow-on; the force-push and Newest-N bullets. `implement.md` ends at 48,890 B — larger content, and the review round's request to restore two shed measurements ("twelve times", the two single-pair bags) was paid for by compressing further rather than by dropping them.

## Test plan

- `vp check --fix` and `vp run check`: 0 errors. `vp run typecheck:test`: pass. `vp run build`: pass.
- `vp run test`: 842 files / 17,450 tests pass, no type errors — including `tests/unit/scripts/work-issues-skill-refs.test.ts` (every reference fully qualified as `go-to-k/<repo>#N`) and `tests/unit/scripts/skill-file-payload.test.ts` (the byte cap above).
- `check` and `docs` markers recorded from this worktree, after the review-fix round rather than before it.
- Live-test tier: prose-only diff with no `src/**` path, so the exemption applies in its PROSE arm — every gate, hook, sentinel, path, dependency and issue reference the new text names was resolved against this repo's own files by an independent read-only reviewer, claim by claim. It returned one blocker-class correction (the sha-binding claim above), three minors and three nits; all are fixed in the second commit, and each incident cited was re-read from its own PR/issue body rather than from the number.

## Deliberately not done here

The `pr-review` marker is **not** set on this PR, and this agent is not merging it. That is the first lesson in the diff: the marker belongs to the orchestrator, after the reviewers it dispatched have reported.

## Backlog effect for the whole run

`closed 4 / filed 4 (new 4 / folded 0)` — zero left open, zero `Session-fit: next` deferrals. Closed: go-to-k/cdk-real-drift#1837, go-to-k/cdkd#2381, go-to-k/cdk-local#630, go-to-k/cdkd#2384. Filed = the same four; every one was filed and fixed inside the run, which is why `filed` equals `closed` rather than exceeding it.
