### PR TITLE
test(unit): buffer a test's raw stream writes and replay them only when it fails

### DIFF
--- a/.claude/rules/test-stream-fence.md
+++ b/.claude/rules/test-stream-fence.md
@@ -1,0 +1,62 @@
+---
+description: cdkd test-run output discipline (the stream fence in tests/setup.ts)
+paths:
+  - 'tests/setup.ts'
+  - 'tests/stream-fence.ts'
+  - 'tests/unit/stream-fence.test.ts'
+---
+
+# A green run must print nothing
+
+`tests/setup.ts` installs a stream fence (`tests/stream-fence.ts`) that buffers
+raw `process.stdout` / `process.stderr` writes made inside a test and replays
+them, headed by the test's full name, only when that test FAILS.
+
+Vitest attributes and suppresses `console.*`; a raw `stream.write()` bypasses
+that entirely, and product code uses it deliberately where the logger is the
+wrong channel — the deprecated-`--region` notice in `src/cli/options.ts`, the
+SIGINT notices in `src/provisioning/interrupt-watch.ts` and
+`src/cli/commands/destroy-runner.ts`, the critic summaries under `scripts/`.
+Measured 2026-08-30 before the fence: 108 such lines, ~20 KB of `vp test run`'s
+~22 KB full-suite output, all of it from PASSING tests. After: the whole run
+prints well under 2 KB.
+
+That is a correctness property, not a tidiness one. A green run's output is what
+a person or an agent reads to decide whether to trust the run, and 20 KB of
+notices from passing tests is 20 KB a real signal can hide in.
+
+## The capture is bounded at BOTH ends
+
+Vitest runs `afterEach` -> `onTestFinished` -> `onTestFailed` (verified against
+`@vitest/runner` 4.1.10). The fence therefore stops capturing at
+`onTestFinished` while KEEPING the buffer, so the replay driven by
+`onTestFailed` still finds something to replay, and everything after that — a
+later `beforeAll`, `afterAll`, the next file's module top level in a reused
+worker — writes straight through.
+
+**Starting the capture without ever stopping it turns the carve-out into a
+silent SWALLOW, which is strictly worse than the noise the fence removes.** That
+is what the first cut of this fence did, and the docs claimed the opposite; an
+`afterAll` in `tests/unit/stream-fence.test.ts` now asserts the fence is no
+longer capturing once the file's tests are done, so the claim is fenced rather
+than merely written.
+
+## Working with it
+
+- **To ASSERT on such a write, REPLACE `process.stderr.write` and restore it**,
+  rather than spying. That is already this repo's convention — see
+  `tests/unit/cli/options.test.ts` and
+  `tests/unit/provisioning/interrupt-watch.test.ts`, both of which record that
+  `vi.spyOn` does not intercept the stream cleanly under vitest's output
+  capture. A replacement sits ABOVE the fence, so the fence never sees those
+  writes.
+- **`CDKD_TEST_STREAM_PASSTHROUGH=1` disables the fence entirely.** Use it when
+  debugging a hang or a crash: a run that never reaches the end of a test never
+  reaches the replay either, so buffering would hide exactly the output you
+  need.
+- **One buffer per worker, so tests within a file must run SERIALLY.**
+  `it.concurrent` would let one test's capture wipe a peer's buffer and let a
+  failure replay another test's writes. This repo uses none, and
+  `tests/unit/stream-fence.test.ts` fails if that changes.
+
+End-user-facing detail lives in [docs/testing.md](../../docs/testing.md).

--- a/.claude/rules/test-stream-fence.md
+++ b/.claude/rules/test-stream-fence.md
@@ -34,6 +34,11 @@ Vitest runs `afterEach` -> `onTestFinished` -> `onTestFailed` (verified against
 later `beforeAll`, `afterAll`, the next file's module top level in a reused
 worker — writes straight through.
 
+`beforeEach` / `afterEach` are INSIDE the fence, not outside it: they bracket one
+specific test, and `onTestFinished` runs AFTER `afterEach`. So a per-test hook's
+writes follow the same rule as the test body's — replayed when that test fails,
+dropped when it passes.
+
 **Starting the capture without ever stopping it turns the carve-out into a
 silent SWALLOW, which is strictly worse than the noise the fence removes.** That
 is what the first cut of this fence did, and the docs claimed the opposite; an

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -16,6 +16,17 @@ paths:
   TS2307 (PR #1226). Copy the import line from a sibling test. Enforced by
   `tests/unit/scripts/test-import-convention.test.ts` (fails the local test
   run, naming the offending file).
+- **A green run must print nothing.** `tests/setup.ts` installs a stream fence
+  (`tests/stream-fence.ts`) that buffers raw `process.stdout` / `process.stderr`
+  writes made inside a test and replays them, headed by the test name, only when
+  that test FAILS. Vitest attributes and suppresses `console.*`; a raw
+  `stream.write()` bypasses that, and product code uses it deliberately where
+  the logger is the wrong channel (the deprecated-`--region` notice, the SIGINT
+  notices, the `scripts/` critic summaries). Measured before the fence: 108
+  lines / ~20 KB of `vp test run`'s ~22 KB full-suite output came from PASSING
+  tests; after, the whole run prints 628 bytes. Writes outside a test body pass through (nothing to
+  attach them to), and `CDKD_TEST_STREAM_PASSTHROUGH=1` disables the fence for
+  debugging a hang, where a replay that never runs is worse than noise.
 - Mocking: Mock AWS SDK with vi.mock()
 - **Mocking `src/utils/aws-clients.js` does NOT isolate a provider that builds
   its OWN client.** `new Route53Client({ region })` inside a provider ignores

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -16,17 +16,11 @@ paths:
   TS2307 (PR #1226). Copy the import line from a sibling test. Enforced by
   `tests/unit/scripts/test-import-convention.test.ts` (fails the local test
   run, naming the offending file).
-- **A green run must print nothing.** `tests/setup.ts` installs a stream fence
-  (`tests/stream-fence.ts`) that buffers raw `process.stdout` / `process.stderr`
-  writes made inside a test and replays them, headed by the test name, only when
-  that test FAILS. Vitest attributes and suppresses `console.*`; a raw
-  `stream.write()` bypasses that, and product code uses it deliberately where
-  the logger is the wrong channel (the deprecated-`--region` notice, the SIGINT
-  notices, the `scripts/` critic summaries). Measured before the fence: 108
-  lines / ~20 KB of `vp test run`'s ~22 KB full-suite output came from PASSING
-  tests; after, the whole run prints 628 bytes. Writes outside a test body pass through (nothing to
-  attach them to), and `CDKD_TEST_STREAM_PASSTHROUGH=1` disables the fence for
-  debugging a hang, where a replay that never runs is worse than noise.
+- **A green run must print nothing.** `tests/setup.ts` buffers raw
+  `process.stdout` / `process.stderr` writes made inside a test and replays
+  them only when that test FAILS — see
+  [.claude/rules/test-stream-fence.md](test-stream-fence.md) before adding a
+  test that asserts on one, or when a run goes unexpectedly quiet.
 - Mocking: Mock AWS SDK with vi.mock()
 - **Mocking `src/utils/aws-clients.js` does NOT isolate a provider that builds
   its OWN client.** `new Route53Client({ region })` inside a provider ignores

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ Custom Resources handling, the `assertRegionMatch()` region-check helper, and th
 
 ## Testing
 
-Unit tests under `tests/unit/**` (Vitest, AWS SDK mocked via `vi.mock()`). Integration tests under `tests/integration/**` (real AWS account, `us-east-1`). UPDATE testing via `CDKD_TEST_UPDATE=true` and rollback failure injection via `CDKD_TEST_FAIL=true`. A `*Once` primer must be consumed by the test that primed it — `vi.clearAllMocks()` does NOT drain the queue, so a leftover silently shifts every later test in the file; enforced by the `once-leak-detect` CI job (`vp run test:once-leak`, issue #1618). Full guide in [.claude/rules/testing.md](.claude/rules/testing.md) and [docs/testing.md](docs/testing.md).
+Unit tests under `tests/unit/**` (Vitest, AWS SDK mocked via `vi.mock()`). Integration tests under `tests/integration/**` (real AWS account, `us-east-1`). UPDATE testing via `CDKD_TEST_UPDATE=true` and rollback failure injection via `CDKD_TEST_FAIL=true`. A `*Once` primer must be consumed by the test that primed it — `vi.clearAllMocks()` does NOT drain the queue, so a leftover silently shifts every later test in the file; enforced by the `once-leak-detect` CI job (`vp run test:once-leak`, issue #1618). A stream fence in `tests/setup.ts` buffers raw `process.stdout` / `process.stderr` writes made inside a test and replays them only when that test FAILS, so a green run prints its summary and nothing else (`CDKD_TEST_STREAM_PASSTHROUGH=1` opts out while debugging a hang). Full guide in [.claude/rules/testing.md](.claude/rules/testing.md) and [docs/testing.md](docs/testing.md).
 
 ## Debugging Deploy Flow
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1445,6 +1445,43 @@ mechanical swap to `resetAllMocks()` breaks 1181 tests, and the presence of
 implicated a handful of files rather than 182, and needed no remediation batch
 at all.
 
+### Unit-test convention: a green run says nothing
+
+`tests/setup.ts` installs a **stream fence** (`tests/stream-fence.ts`) that
+buffers direct `process.stdout` / `process.stderr` writes made inside a test and
+replays them, headed by the test name, only if that test FAILS.
+
+It exists because vitest attributes and suppresses `console.*` but a raw
+`stream.write()` bypasses that entirely. Product code writes that way on purpose
+where the logger is the wrong channel — the deprecated-`--region` notice in
+`src/cli/options.ts`, the SIGINT notices in `src/provisioning/interrupt-watch.ts`
+and `src/cli/commands/destroy-runner.ts`, the critic summaries under `scripts/` —
+so any suite exercising those paths legitimately printed them. Measured on the
+full suite before the fence: 108 such lines, ~20 KB of `vp test run`'s ~22 KB of
+output, i.e. the reporter's own output was under a tenth of what a PASSING run
+emitted. After: 628 bytes for the same 17,462 tests.
+
+That is a correctness property, not a tidiness one. A green run's output is what
+a person or an agent reads to decide whether to trust the run, and 20 KB of
+notices from passing tests is 20 KB a real signal can hide in.
+
+Two deliberate carve-outs:
+
+- Writes **outside** a test body (module top level, `beforeAll` / `afterAll`)
+  pass straight through. They are diagnostic about the FILE, and there is no
+  failing test to attach them to.
+- `CDKD_TEST_STREAM_PASSTHROUGH=1` disables the fence entirely. Debugging a hang
+  or a crash needs the writes as they happen: a run that never reaches the end of
+  a test never reaches the replay either.
+
+```bash
+CDKD_TEST_STREAM_PASSTHROUGH=1 vp test run tests/unit/cli/destroy-runner-sigint.test.ts
+```
+
+A test that asserts on such a write is unaffected — a `vi.spyOn(process.stderr,
+'write')` replaces the fence's patch for the duration of that test, and the
+fence only ever sees what the spy passes through.
+
 ## 3. Deploy Using cdkd
 
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1469,7 +1469,10 @@ Two deliberate carve-outs:
 
 - Writes **outside** a test body (module top level, `beforeAll` / `afterAll`)
   pass straight through. They are diagnostic about the FILE, and there is no
-  failing test to attach them to.
+  failing test to attach them to. `beforeEach` / `afterEach` are INSIDE the
+  fence, though — they bracket one specific test, and the fence stops at
+  `onTestFinished`, which runs after `afterEach` — so their writes follow the
+  same rule as the test body's: replayed on failure, dropped on a pass.
 - `CDKD_TEST_STREAM_PASSTHROUGH=1` disables the fence entirely. Debugging a hang
   or a crash needs the writes as they happen: a run that never reaches the end of
   a test never reaches the replay either.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1459,7 +1459,7 @@ and `src/cli/commands/destroy-runner.ts`, the critic summaries under `scripts/` 
 so any suite exercising those paths legitimately printed them. Measured on the
 full suite before the fence: 108 such lines, ~20 KB of `vp test run`'s ~22 KB of
 output, i.e. the reporter's own output was under a tenth of what a PASSING run
-emitted. After: 628 bytes for the same 17,462 tests.
+emitted. After: 616 bytes, 15 lines, for a full green run of 17,473 tests.
 
 That is a correctness property, not a tidiness one. A green run's output is what
 a person or an agent reads to decide whether to trust the run, and 20 KB of
@@ -1478,9 +1478,25 @@ Two deliberate carve-outs:
 CDKD_TEST_STREAM_PASSTHROUGH=1 vp test run tests/unit/cli/destroy-runner-sigint.test.ts
 ```
 
-A test that asserts on such a write is unaffected — a `vi.spyOn(process.stderr,
-'write')` replaces the fence's patch for the duration of that test, and the
-fence only ever sees what the spy passes through.
+A test that asserts on such a write is unaffected: the convention here is to
+REPLACE `process.stderr.write` and restore it afterwards (see
+`tests/unit/cli/options.test.ts` and
+`tests/unit/provisioning/interrupt-watch.test.ts`, both of which note that
+`vi.spyOn` does not intercept the stream cleanly under vitest's output capture).
+A replacement sits above the fence, so the fence never sees those writes at all.
+
+The capture is bounded by the test at BOTH ends. `onTestFinished` stops it while
+keeping the buffer — vitest runs `afterEach` -> `onTestFinished` ->
+`onTestFailed`, so the replay still finds something to replay, and everything
+after that (a later `beforeAll`, `afterAll`, the next file's module top level in
+a reused worker) writes straight through. An earlier cut of this fence started
+the capture and never stopped it, which turned the carve-out above into a silent
+swallow; `tests/unit/stream-fence.test.ts` fences that with an `afterAll` that
+asserts the fence is no longer capturing.
+
+One further assumption: one buffer per worker, so tests within a file must run
+SERIALLY. `it.concurrent` would let one test's capture wipe a peer's buffer.
+This repo uses none, and the same test file fails if that changes.
 
 ## 3. Deploy Using cdkd
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -12,6 +12,7 @@ import {
   type MockableImplementation,
 } from './constructable-implementation.js';
 import { installOnceLeakDetector } from './once-leak-detector.js';
+import { installStreamFence } from './stream-fence.js';
 
 /**
  * Global vitest setup — defenses against Node 24 + vitest 1.6.1 surfacing
@@ -90,6 +91,11 @@ vi.fn = ((implementation?: MockableImplementation) => {
 // patch above so it composes over it rather than being overwritten by it, and
 // inert unless `CDKD_ONCE_LEAK_DETECT=1`.
 installOnceLeakDetector();
+
+// Buffer raw `process.stdout` / `process.stderr` writes made inside a test and
+// replay them only when that test FAILS. See tests/stream-fence.ts for why a
+// green run printing 20 KB of product notices is a problem worth solving.
+installStreamFence();
 
 const originalExit = process.exit;
 

--- a/tests/stream-fence.ts
+++ b/tests/stream-fence.ts
@@ -38,6 +38,12 @@ import { beforeEach, onTestFailed, onTestFinished } from 'vite-plus/test';
  *   - writes outside a test body (module top level, `beforeAll` / `afterAll`).
  *     A harness announcing the scratch directory it will clean up is diagnostic
  *     about the FILE, and there is no failing test to attach it to.
+ *     `beforeEach` and `afterEach` are INSIDE the fence, not outside it: they
+ *     bracket a specific test, and `finish()` runs at `onTestFinished`, which is
+ *     after `afterEach`. So a per-test hook's writes are replayed when that test
+ *     fails and dropped when it passes — the same rule as the test body, which
+ *     is the point, since that is where a `withRetry` teardown notice comes
+ *     from.
  *   - anything at all when `CDKD_TEST_STREAM_PASSTHROUGH=1` is set. Debugging a
  *     hang or a crash needs the writes as they happen: a run that never reaches
  *     the end of a test never reaches the replay either.

--- a/tests/stream-fence.ts
+++ b/tests/stream-fence.ts
@@ -40,10 +40,8 @@ import { beforeEach, onTestFailed, onTestFinished } from 'vite-plus/test';
  *     about the FILE, and there is no failing test to attach it to.
  *     `beforeEach` and `afterEach` are INSIDE the fence, not outside it: they
  *     bracket a specific test, and `finish()` runs at `onTestFinished`, which is
- *     after `afterEach`. So a per-test hook's writes are replayed when that test
- *     fails and dropped when it passes — the same rule as the test body, which
- *     is the point, since that is where a `withRetry` teardown notice comes
- *     from.
+ *     after `afterEach`. So a per-test hook's writes follow the same rule as the
+ *     test body's — replayed when that test fails, dropped when it passes.
  *   - anything at all when `CDKD_TEST_STREAM_PASSTHROUGH=1` is set. Debugging a
  *     hang or a crash needs the writes as they happen: a run that never reaches
  *     the end of a test never reaches the replay either.

--- a/tests/stream-fence.ts
+++ b/tests/stream-fence.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { beforeEach, onTestFailed } from 'vite-plus/test';
+import { beforeEach, onTestFailed, onTestFinished } from 'vite-plus/test';
 
 /**
  * Buffer direct `process.stdout` / `process.stderr` writes made DURING a test,
@@ -14,14 +14,24 @@ import { beforeEach, onTestFailed } from 'vite-plus/test';
  * `src/provisioning/interrupt-watch.ts` and `src/cli/commands/destroy-runner.ts`,
  * the critic summaries under `scripts/` — so the suites exercising those paths
  * legitimately trigger them. Measured 2026-08-30 on the full suite: 108 such
- * lines, ~20 KB of the run's ~22 KB of output. The reporter's own output was
- * under a tenth of what a GREEN run printed.
+ * lines, ~20 KB of `vp test run`'s ~22 KB of output. The reporter's own output
+ * was under a tenth of what a GREEN run printed.
  *
  * The point is not tidiness. A green run's output is what a person or an agent
  * reads to decide whether to trust the run, and 20 KB of notices from PASSING
  * tests is 20 KB a real signal can hide in. So the rule is the one the failure
  * output already follows: say nothing when the test passes, say everything when
  * it does not.
+ *
+ * Capture is bounded by the TEST, not merely started by it. `onTestFinished`
+ * stops it while KEEPING the buffer, because vitest runs
+ * `afterEach` -> `onTestFinished` -> `onTestFailed` (verified against
+ * `@vitest/runner` 4.1.10) and a replay driven by the last of those must still
+ * find something to replay. Without that stop the fence never turns off after
+ * the first test: `afterAll`, a later `beforeAll`, and the next file's module
+ * top level in a reused worker would all be captured and then silently dropped
+ * by the following `begin()` — swallowing diagnostics rather than deferring
+ * them, which is strictly worse than the noise this exists to remove.
  *
  * Deliberately NOT buffered:
  *
@@ -31,12 +41,23 @@ import { beforeEach, onTestFailed } from 'vite-plus/test';
  *   - anything at all when `CDKD_TEST_STREAM_PASSTHROUGH=1` is set. Debugging a
  *     hang or a crash needs the writes as they happen: a run that never reaches
  *     the end of a test never reaches the replay either.
+ *
+ * Known limit: one buffer per worker, so the fence assumes tests within a file
+ * run SERIALLY. `it.concurrent` / `describe.concurrent` would let one test's
+ * `begin()` wipe a peer's buffer and let a failure replay another test's
+ * writes. This repo uses neither, and
+ * `tests/unit/stream-fence.test.ts` fails if that stops being true.
  */
 
 export type StreamName = 'stdout' | 'stderr';
 
 export interface CapturedWrite {
   readonly stream: StreamName;
+  /** The chunk exactly as the caller passed it, so the replay is byte-faithful. */
+  readonly chunk: string | Uint8Array;
+  /** The caller's encoding argument, if it passed one rather than a callback. */
+  readonly encoding: BufferEncoding | undefined;
+  /** A readable rendering of {@link chunk}, for assertions and for grepping a replay. */
   readonly text: string;
 }
 
@@ -46,44 +67,55 @@ export interface FenceableStream {
 }
 
 export interface StreamFence {
-  /** Patch `stream.write` so writes made between `begin()` and `end()` are buffered. */
+  /** Patch `stream.write` so writes made while capturing are buffered. */
   attach(stream: FenceableStream, name: StreamName): void;
-  /** Start buffering (called at the start of each test). */
+  /** Start capturing, discarding any previous test's buffer. */
   begin(): void;
-  /** Stop buffering; subsequent writes pass straight through. */
-  end(): void;
-  /**
-   * Write everything buffered so far to the stream it was written to, then
-   * forget it. `label` heads the replay so a run with several failures says
-   * which test each block came from — the attribution the raw writes lack.
-   */
+  /** Stop capturing but KEEP the buffer, so a later `replay()` can still read it. */
+  finish(): void;
+  /** Write everything buffered so far to the stream it was written to, then forget it. */
   replay(label?: string): void;
-  /** What is buffered right now, or `undefined` when not buffering. */
+  /** What is buffered right now, or `undefined` when nothing has been captured yet. */
   buffered(): readonly CapturedWrite[] | undefined;
+  /** Whether writes are currently being diverted into the buffer. */
+  capturing(): boolean;
 }
 
-const toText = (chunk: string | Uint8Array): string =>
-  typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+const isBufferEncoding = (value: unknown): value is BufferEncoding => typeof value === 'string';
+
+const render = (chunk: string | Uint8Array, encoding: BufferEncoding | undefined): string => {
+  if (typeof chunk !== 'string') return Buffer.from(chunk).toString('utf8');
+  // `write('deadbeef', 'hex')` writes BYTES, not those eight characters, so the
+  // readable rendering has to decode the same way the stream would.
+  if (encoding !== undefined && encoding !== 'utf8' && encoding !== 'utf-8') {
+    return Buffer.from(chunk, encoding).toString('utf8');
+  }
+  return chunk;
+};
 
 export function createStreamFence(): StreamFence {
-  const originals = new Map<StreamName, (chunk: string) => boolean>();
+  const originals = new Map<StreamName, FenceableStream['write']>();
 
-  /**
-   * The writes seen since the current test started, or `undefined` when no test
-   * is running — which is what lets the out-of-test writes above pass through.
-   */
+  let capturing = false;
   let captured: CapturedWrite[] | undefined;
+
+  const writeThrough = (write: CapturedWrite): void => {
+    const original = originals.get(write.stream) ?? originals.values().next().value;
+    if (write.encoding === undefined) original?.(write.chunk);
+    else original?.(write.chunk, write.encoding);
+  };
 
   return {
     attach(stream, name) {
       const original = stream.write.bind(stream);
-      originals.set(name, (chunk: string) => original(chunk));
+      originals.set(name, original);
 
       stream.write = ((chunk: string | Uint8Array, encoding?: unknown, callback?: unknown) => {
-        if (captured === undefined) {
+        if (!capturing) {
           return original(chunk, encoding, callback);
         }
-        captured.push({ stream: name, text: toText(chunk) });
+        const enc = isBufferEncoding(encoding) ? encoding : undefined;
+        (captured ??= []).push({ stream: name, chunk, encoding: enc, text: render(chunk, enc) });
         // `write(chunk, cb)` and `write(chunk, encoding, cb)` are both real call
         // shapes and a caller may be awaiting that callback. Swallowing the
         // write must not also swallow its completion signal.
@@ -96,32 +128,46 @@ export function createStreamFence(): StreamFence {
     },
 
     begin() {
+      capturing = true;
       captured = [];
     },
 
-    end() {
-      captured = undefined;
+    finish() {
+      capturing = false;
     },
 
     replay(label) {
       if (captured === undefined || captured.length === 0) return;
       const pending = captured;
-      // Cleared BEFORE writing so the replay's own writes are not re-captured,
-      // and so a second replay in the same test (two `onTestFailed` handlers, a
-      // retry) cannot print the same lines twice.
+      // Cleared BEFORE writing so a second replay in the same test (two
+      // `onTestFailed` handlers, a retry) cannot print the same lines twice.
       captured = [];
       if (label !== undefined) {
-        originals.get('stderr')?.(`stderr | ${label}\n`);
+        // Same shape as vitest's own console attribution, so a replay reads
+        // like the rest of a failure block.
+        writeThrough({
+          stream: 'stderr',
+          chunk: `stderr | ${label}\n`,
+          encoding: undefined,
+          text: '',
+        });
       }
-      for (const write of pending) {
-        originals.get(write.stream)?.(write.text);
-      }
+      for (const write of pending) writeThrough(write);
     },
 
     buffered() {
       return captured;
     },
+
+    capturing() {
+      return capturing;
+    },
   };
+}
+
+/** Whether the fence should stay out of the way entirely. Exported so both arms are testable. */
+export function streamFenceDisabled(env: Record<string, string | undefined>): boolean {
+  return env['CDKD_TEST_STREAM_PASSTHROUGH'] === '1';
 }
 
 const INSTALLED_KEY = '__cdkd_stream_fence__';
@@ -132,7 +178,7 @@ export function activeStreamFence(): StreamFence | undefined {
 }
 
 export function installStreamFence(): void {
-  if (process.env['CDKD_TEST_STREAM_PASSTHROUGH'] === '1') return;
+  if (streamFenceDisabled(process.env)) return;
 
   const host = globalThis as Record<string, unknown>;
   let fence = host[INSTALLED_KEY] as StreamFence | undefined;
@@ -145,12 +191,15 @@ export function installStreamFence(): void {
 
   const installed = fence;
   beforeEach(() => {
-    // Reset at the START of a test rather than clearing at the end: a replay
-    // driven by `onTestFailed` must still find the buffer, and this file does
-    // not get to assume it runs before or after the failure hooks.
     installed.begin();
+    // Runs BEFORE `onTestFailed` and keeps the buffer, so this only closes the
+    // window — everything after it (a later `beforeAll`, `afterAll`, the next
+    // file's top level) writes straight through.
+    onTestFinished(() => installed.finish());
     onTestFailed((context) => {
-      installed.replay(context.task.name);
+      // `fullName` rather than `name`: two same-named tests in different files
+      // are otherwise indistinguishable in a replay.
+      installed.replay(context.task.fullName);
     });
   });
 }

--- a/tests/stream-fence.ts
+++ b/tests/stream-fence.ts
@@ -1,0 +1,156 @@
+/// <reference types="node" />
+
+import { beforeEach, onTestFailed } from 'vite-plus/test';
+
+/**
+ * Buffer direct `process.stdout` / `process.stderr` writes made DURING a test,
+ * and replay them only if that test fails.
+ *
+ * Vitest attributes and (under this repo's reporter) suppresses `console.*`,
+ * but a raw `stream.write()` bypasses that entirely and lands in the run's
+ * output unattributed. Product code writes that way on purpose in the few
+ * places where the logger is the wrong channel — the deprecated-`--region`
+ * notice (`src/cli/options.ts`), the SIGINT notices in
+ * `src/provisioning/interrupt-watch.ts` and `src/cli/commands/destroy-runner.ts`,
+ * the critic summaries under `scripts/` — so the suites exercising those paths
+ * legitimately trigger them. Measured 2026-08-30 on the full suite: 108 such
+ * lines, ~20 KB of the run's ~22 KB of output. The reporter's own output was
+ * under a tenth of what a GREEN run printed.
+ *
+ * The point is not tidiness. A green run's output is what a person or an agent
+ * reads to decide whether to trust the run, and 20 KB of notices from PASSING
+ * tests is 20 KB a real signal can hide in. So the rule is the one the failure
+ * output already follows: say nothing when the test passes, say everything when
+ * it does not.
+ *
+ * Deliberately NOT buffered:
+ *
+ *   - writes outside a test body (module top level, `beforeAll` / `afterAll`).
+ *     A harness announcing the scratch directory it will clean up is diagnostic
+ *     about the FILE, and there is no failing test to attach it to.
+ *   - anything at all when `CDKD_TEST_STREAM_PASSTHROUGH=1` is set. Debugging a
+ *     hang or a crash needs the writes as they happen: a run that never reaches
+ *     the end of a test never reaches the replay either.
+ */
+
+export type StreamName = 'stdout' | 'stderr';
+
+export interface CapturedWrite {
+  readonly stream: StreamName;
+  readonly text: string;
+}
+
+/** The subset of a writable stream this fence needs — kept narrow so a test can pass a fake. */
+export interface FenceableStream {
+  write(chunk: string | Uint8Array, encoding?: unknown, callback?: unknown): boolean;
+}
+
+export interface StreamFence {
+  /** Patch `stream.write` so writes made between `begin()` and `end()` are buffered. */
+  attach(stream: FenceableStream, name: StreamName): void;
+  /** Start buffering (called at the start of each test). */
+  begin(): void;
+  /** Stop buffering; subsequent writes pass straight through. */
+  end(): void;
+  /**
+   * Write everything buffered so far to the stream it was written to, then
+   * forget it. `label` heads the replay so a run with several failures says
+   * which test each block came from — the attribution the raw writes lack.
+   */
+  replay(label?: string): void;
+  /** What is buffered right now, or `undefined` when not buffering. */
+  buffered(): readonly CapturedWrite[] | undefined;
+}
+
+const toText = (chunk: string | Uint8Array): string =>
+  typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+
+export function createStreamFence(): StreamFence {
+  const originals = new Map<StreamName, (chunk: string) => boolean>();
+
+  /**
+   * The writes seen since the current test started, or `undefined` when no test
+   * is running — which is what lets the out-of-test writes above pass through.
+   */
+  let captured: CapturedWrite[] | undefined;
+
+  return {
+    attach(stream, name) {
+      const original = stream.write.bind(stream);
+      originals.set(name, (chunk: string) => original(chunk));
+
+      stream.write = ((chunk: string | Uint8Array, encoding?: unknown, callback?: unknown) => {
+        if (captured === undefined) {
+          return original(chunk, encoding, callback);
+        }
+        captured.push({ stream: name, text: toText(chunk) });
+        // `write(chunk, cb)` and `write(chunk, encoding, cb)` are both real call
+        // shapes and a caller may be awaiting that callback. Swallowing the
+        // write must not also swallow its completion signal.
+        const done = typeof encoding === 'function' ? encoding : callback;
+        if (typeof done === 'function') {
+          (done as () => void)();
+        }
+        return true;
+      }) as FenceableStream['write'];
+    },
+
+    begin() {
+      captured = [];
+    },
+
+    end() {
+      captured = undefined;
+    },
+
+    replay(label) {
+      if (captured === undefined || captured.length === 0) return;
+      const pending = captured;
+      // Cleared BEFORE writing so the replay's own writes are not re-captured,
+      // and so a second replay in the same test (two `onTestFailed` handlers, a
+      // retry) cannot print the same lines twice.
+      captured = [];
+      if (label !== undefined) {
+        originals.get('stderr')?.(`stderr | ${label}\n`);
+      }
+      for (const write of pending) {
+        originals.get(write.stream)?.(write.text);
+      }
+    },
+
+    buffered() {
+      return captured;
+    },
+  };
+}
+
+const INSTALLED_KEY = '__cdkd_stream_fence__';
+
+/** The fence installed over the real process streams, for tests that assert on it. */
+export function activeStreamFence(): StreamFence | undefined {
+  return (globalThis as Record<string, unknown>)[INSTALLED_KEY] as StreamFence | undefined;
+}
+
+export function installStreamFence(): void {
+  if (process.env['CDKD_TEST_STREAM_PASSTHROUGH'] === '1') return;
+
+  const host = globalThis as Record<string, unknown>;
+  let fence = host[INSTALLED_KEY] as StreamFence | undefined;
+  if (fence === undefined) {
+    fence = createStreamFence();
+    host[INSTALLED_KEY] = fence;
+    fence.attach(process.stdout, 'stdout');
+    fence.attach(process.stderr, 'stderr');
+  }
+
+  const installed = fence;
+  beforeEach(() => {
+    // Reset at the START of a test rather than clearing at the end: a replay
+    // driven by `onTestFailed` must still find the buffer, and this file does
+    // not get to assume it runs before or after the failure hooks.
+    installed.begin();
+    onTestFailed((context) => {
+      installed.replay(context.task.name);
+    });
+  });
+}

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -304,17 +304,24 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // literal glob list names are the fence, its suite, and the setup file that
   // installs it, and none of them is named by any other row. Without this the
   // satellite sits under no budget at all. Payload is testing.md + the satellite.
-  ['tests/setup.ts', 62_000, 72_000],                            // measured  64,742
-  // This floor is set by a PROPERTY, not by the table's usual ~12%-under
-  // convention, and the property is stricter: it must sit ABOVE `testing.md`
-  // alone (61,358 B), so that deleting `test-stream-fence.md` outright fails
-  // this row. 51_000 and then 57_000 both sat BELOW it and would have gone
-  // green on exactly that deletion. It leaves 2,742 B of slack under the
-  // measurement and 7,258 B under the cap, which is enough for ordinary
-  // editing of either file. Note the three hooks rows do NOT have this
-  // property -- floored at 108_000 against a 114,298 B hooks.md -- so they are
-  // not the precedent for it; they bound growth, this one also bounds loss.
+  ['tests/setup.ts', 63_500, 72_000],                            // measured  64,742
+  // This floor is set by a PROPERTY rather than by the table's usual ~12%-under
+  // convention, and `the tests/setup.ts floor still discriminates` below
+  // RECOMPUTES that property instead of trusting this number. It must sit above
+  // `testing.md` (61,358 B) plus SUBSTANTIVE_MIN_BYTES, so that gutting
+  // `test-stream-fence.md` down to the smallest size the `substantive content`
+  // case still allows fails HERE. 51_000, 57_000 and 62_000 were each chosen by
+  // hand and each failed to add signal: the first two sat below `testing.md`
+  // alone, and 62_000 was strictly subsumed -- it fired only under 642 B of
+  // satellite, where `substantive content` already fires at 1,500 B, so a
+  // satellite gutted to 1,501 B passed every check in this file. Note the three
+  // hooks rows do NOT have this property -- floored at 108_000 against a
+  // 114,298 B hooks.md -- so they are not a precedent for it; they bound growth,
+  // this one also bounds loss.
 ];
+
+/** A rule file at or under this is frontmatter and little else -- see the `substantive content` case. */
+const SUBSTANTIVE_MIN_BYTES = 1_500;
 
 const SPLIT_ADVICE =
   'Move the detail into a NEW .claude/rules/<area>.md satellite whose `paths:` glob is as narrow as the content, and leave a one-line pointer behind. Do not summarise or delete the text.';
@@ -441,12 +448,12 @@ const CORPUS_FILE_COUNT = 34; // 29 + gate-sibling-repos.md (hooks.md crossed th
                               //  family widening pushed hooks.md past the per-file cap again --
                               //  the #2236 shape repeated. That makes 33.
                               //  + test-stream-fence.md: the stream-fence notes were 1,442 B and
-                              //  testing.md had 970 B of headroom under its 62,000 B payload row,
-                              //  so they could not land there. The satellite is 3,114 B and the
-                              //  pointer left behind is 328 B, which is why testing.md still grew
+                              //  testing.md had 970 B of headroom under its payload row, so they
+                              //  could not land there. The
+                              //  satellite is 3,384 B and the pointer left behind is 328 B,
+                              //  which is why testing.md still grew
                               //  (61,030 -> 61,358 B) rather than shrinking -- a split that leaves
-                              //  a pointer always costs the index file something. The satellite
-                              //  itself is 3,384 B. That makes 34.
+                              //  a pointer always costs the index file something. That makes 34.
 const CORPUS_BYTES_MIN = 899_000;   // measured 914,165 B -- 15,165 B of slack.
                                     // 795_000 -> 899_000: the comment beside the old bound still
                                     // read "measured 808,384 B", 105 KB behind the corpus, so the
@@ -520,7 +527,7 @@ describe('.claude/rules payload fence', () => {
         `${name} is ${f.bytes} B -- barely more than frontmatter. Payload is ` +
           'reduced by moving text to a narrower-`paths:` satellite, never by ' +
           'deleting it. If this file is genuinely a stub, say so in the commit.',
-      ).toBeGreaterThan(1_500);
+      ).toBeGreaterThan(SUBSTANTIVE_MIN_BYTES);
     },
   );
 
@@ -781,11 +788,46 @@ describe('.claude/rules payload fence', () => {
     ).toEqual([]);
   });
 
+  it('the tests/setup.ts floor still discriminates a GUTTED satellite', () => {
+    // A floor that merely exists is not a check. This one has to be BELOW the
+    // live payload and ABOVE the two ways `test-stream-fence.md` can stop
+    // carrying its content, and the margin is recomputed here so it fails when
+    // spent rather than when someone notices.
+    //
+    // Deletion is caught by `CORPUS_FILE_COUNT` and by index reachability
+    // anyway, so it is the GUTTING case that this floor uniquely owns: a
+    // satellite trimmed to just over `SUBSTANTIVE_MIN_BYTES` passes every other
+    // assertion in this file.
+    const row = PAYLOAD_BUDGETS.find(([path]) => path === 'tests/setup.ts');
+    expect(row, 'the tests/setup.ts budget row was removed').toBeDefined();
+    const [, floor, cap] = row as readonly [string, number, number];
+
+    const byName = (name: string): number =>
+      ruleFiles.find((r) => r.name === name)?.bytes ?? 0;
+    const testingOnly = byName('testing.md');
+    const satellite = byName('test-stream-fence.md');
+    expect(satellite, 'test-stream-fence.md is missing').toBeGreaterThan(0);
+
+    expect(
+      testingOnly,
+      `deleting test-stream-fence.md would leave ${testingOnly} B, which the ${floor} B floor ` +
+        'must reject'
+    ).toBeLessThan(floor);
+    expect(
+      testingOnly + SUBSTANTIVE_MIN_BYTES,
+      `gutting test-stream-fence.md to ${SUBSTANTIVE_MIN_BYTES} B would leave ` +
+        `${testingOnly + SUBSTANTIVE_MIN_BYTES} B, at or above the ${floor} B floor -- the floor ` +
+        'no longer discriminates. Raise it (and the cap if needed), or say in the commit why the ' +
+        'gutting case is now covered elsewhere.'
+    ).toBeLessThan(floor);
+    expect(testingOnly + satellite).toBeGreaterThanOrEqual(floor);
+    expect(testingOnly + satellite).toBeLessThanOrEqual(cap);
+  });
+
   it('the two corpus bounds are ordered, so neither can be satisfied by crossing', () => {
-    // Checks ORDERING only -- it cannot know whether the band still brackets a
-    // real measurement, which is what the comments beside the constants are
-    // for. Its job is narrower: stop a future edit from satisfying both bounds
-    // by moving them past each other.
+    // Redundant with the corpus case, which asserts the total against BOTH
+    // bounds and so already fails when they cross. Kept only because it names
+    // the cause directly instead of reporting a total that satisfies neither.
     expect(CORPUS_BYTES_MIN).toBeLessThan(CORPUS_BYTES_MAX);
   });
 

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -216,6 +216,7 @@ const REACH_FLOORS: ReadonlyMap<string, number> = new Map([
   ['providers.md', 92],
   ['state-schema.md', 5],
   ['synthesis.md', 13],
+  ['test-stream-fence.md', 3], // literal list: EXACT, see below
   ['testing.md', 2532],
 ]);
 
@@ -294,6 +295,11 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   ['src/assets/asset-storage.ts', 34_000, 48_000],               // measured  43,787 (asset-bucket-region.md, issue #2240)
   ['src/utils/logger.ts', 38_000, 50_000],                       // measured  43,397
   ['vite.config.ts', 14_000, 21_000],                            // measured  16,712
+  // The representative path for `test-stream-fence.md`: the only paths its
+  // literal glob list names are the fence, its suite, and the setup file that
+  // installs it, and none of them is named by any other row. Without this the
+  // satellite sits under no budget at all. Payload is testing.md + the satellite.
+  ['tests/setup.ts', 51_000, 72_000],                            // measured  64,472
 ];
 
 const SPLIT_ADVICE =
@@ -405,7 +411,9 @@ const ruleFiles: RuleFile[] = readdirSync(RULES_DIR, { recursive: true })
 //   - the UPPER bound catches growth that spreads thinly enough to stay under
 //     every per-file cap.
 // Update these deliberately, with the reason, when the corpus genuinely moves.
-const CORPUS_FILE_COUNT = 33; // 29 + gate-sibling-repos.md (hooks.md crossed the per-file cap, so
+// 29 + gate-sibling-repos.md + test-stream-fence.md (testing.md sat at 61,030 B
+// of its 62,000 B budget, so the stream-fence notes had nowhere to land in it)
+const CORPUS_FILE_COUNT = 34; // hooks.md crossed the per-file cap, so
                               //  its cross-repo gate-aliasing section moved out verbatim,
                               //  go-to-k/cdkd#2236) + asset-bucket-region.md (issue go-to-k/cdkd#2240
                               //  split out of assets.md). Both landed as 30 independently; merged

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -256,7 +256,12 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   ['src/state/s3-state-backend.ts', 43_000, 55_000],         // measured  48,864
   ['src/types/state.ts', 43_000, 55_000],                    // measured  48,864
   ['src/synthesis/synthesizer.ts', 30_000, 40_000],          // measured  34,889
-  ['tests/unit/scripts/rule-file-payload.test.ts', 48_000, 62_000], // measured 55,681
+  // 62_000 -> 68_000: payload is `testing.md` alone, which reached 61,358 B, so
+  // the cap had 642 B of headroom and the next edit to that file would have
+  // failed this row for a reason unrelated to itself -- the same argument that
+  // moved CORPUS_BYTES_MAX. Measured 61,358 B (the 55,681 B beside the old cap
+  // was 5,677 B stale).
+  ['tests/unit/scripts/rule-file-payload.test.ts', 48_000, 68_000], // measured 61,358
   // hooks.md is this path's ONLY matcher, so the payload IS hooks.md's size and
   // this row's CAP is dominated by MAX_RULE_FILE_BYTES no matter where it sits:
   // at 135_000 (as shipped) it was 15,000 B past the per-file cap and could not
@@ -299,12 +304,16 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // literal glob list names are the fence, its suite, and the setup file that
   // installs it, and none of them is named by any other row. Without this the
   // satellite sits under no budget at all. Payload is testing.md + the satellite.
-  ['tests/setup.ts', 57_000, 72_000],                            // measured  64,472
-  // The floor is ~12% under, like the rest of the table, and NOT lower: at
-  // 51_000 it sat 10,358 B below `testing.md` alone, so deleting the whole
-  // satellite would have left this row green -- exactly the direction the
-  // floors exist to catch (the three hooks-satellite rows are floored above
-  // hooks.md's own size for the same reason).
+  ['tests/setup.ts', 62_000, 72_000],                            // measured  64,742
+  // This floor is set by a PROPERTY, not by the table's usual ~12%-under
+  // convention, and the property is stricter: it must sit ABOVE `testing.md`
+  // alone (61,358 B), so that deleting `test-stream-fence.md` outright fails
+  // this row. 51_000 and then 57_000 both sat BELOW it and would have gone
+  // green on exactly that deletion. It leaves 2,742 B of slack under the
+  // measurement and 7,258 B under the cap, which is enough for ordinary
+  // editing of either file. Note the three hooks rows do NOT have this
+  // property -- floored at 108_000 against a 114,298 B hooks.md -- so they are
+  // not the precedent for it; they bound growth, this one also bounds loss.
 ];
 
 const SPLIT_ADVICE =
@@ -436,8 +445,9 @@ const CORPUS_FILE_COUNT = 34; // 29 + gate-sibling-repos.md (hooks.md crossed th
                               //  so they could not land there. The satellite is 3,114 B and the
                               //  pointer left behind is 328 B, which is why testing.md still grew
                               //  (61,030 -> 61,358 B) rather than shrinking -- a split that leaves
-                              //  a pointer always costs the index file something. That makes 34.
-const CORPUS_BYTES_MIN = 899_000;   // measured 913,895 B -- 14,895 B of slack.
+                              //  a pointer always costs the index file something. The satellite
+                              //  itself is 3,384 B. That makes 34.
+const CORPUS_BYTES_MIN = 899_000;   // measured 914,165 B -- 15,165 B of slack.
                                     // 795_000 -> 899_000: the comment beside the old bound still
                                     // read "measured 808,384 B", 105 KB behind the corpus, so the
                                     // floor had ~119 KB of slack and would not have noticed a
@@ -450,15 +460,11 @@ const CORPUS_BYTES_MAX = 928_000;   // growth is the norm here; this catches bul
                                     // hooks-cwd-detector.md split: 902,381 B (the widening's net prose is
                                     // 1,422 B; the satellite's frontmatter + the pointer line are the rest).
                                     // 915_000 -> 928_000 (test-stream-fence.md): this branch added
-                                    // 3,442 B, leaving 1,105 B of headroom -- the next rule-file
+                                    // 3,712 B, leaving 835 B of headroom -- the next rule-file
                                     // edit over 1 KB anywhere would have failed this suite for a
-                                    // reason unrelated to itself. Measured 913,895 B.
+                                    // reason unrelated to itself. Measured 914,165 B.
 
-// Sanity: the two bounds must actually bracket a real measurement, so a future
-// edit cannot satisfy both by moving them past each other.
-if (CORPUS_BYTES_MIN >= CORPUS_BYTES_MAX) {
-  throw new Error('CORPUS_BYTES_MIN must stay below CORPUS_BYTES_MAX');
-}
+
 
 /**
  * The repo's tracked files, read once. Memoised because two per-file suites
@@ -773,6 +779,14 @@ describe('.claude/rules payload fence', () => {
       dead,
       `These \`paths:\` globs match no tracked file, so the rule file never loads for them: ${dead.join(', ')}. Either the glob has a typo, or the code it named was renamed or removed and the notes went with it.`,
     ).toEqual([]);
+  });
+
+  it('the two corpus bounds are ordered, so neither can be satisfied by crossing', () => {
+    // Checks ORDERING only -- it cannot know whether the band still brackets a
+    // real measurement, which is what the comments beside the constants are
+    // for. Its job is narrower: stop a future edit from satisfying both bounds
+    // by moving them past each other.
+    expect(CORPUS_BYTES_MIN).toBeLessThan(CORPUS_BYTES_MAX);
   });
 
   it('every satellite is reachable from an index, and every index row resolves', () => {

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -299,7 +299,12 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // literal glob list names are the fence, its suite, and the setup file that
   // installs it, and none of them is named by any other row. Without this the
   // satellite sits under no budget at all. Payload is testing.md + the satellite.
-  ['tests/setup.ts', 51_000, 72_000],                            // measured  64,472
+  ['tests/setup.ts', 57_000, 72_000],                            // measured  64,472
+  // The floor is ~12% under, like the rest of the table, and NOT lower: at
+  // 51_000 it sat 10,358 B below `testing.md` alone, so deleting the whole
+  // satellite would have left this row green -- exactly the direction the
+  // floors exist to catch (the three hooks-satellite rows are floored above
+  // hooks.md's own size for the same reason).
 ];
 
 const SPLIT_ADVICE =
@@ -411,9 +416,7 @@ const ruleFiles: RuleFile[] = readdirSync(RULES_DIR, { recursive: true })
 //   - the UPPER bound catches growth that spreads thinly enough to stay under
 //     every per-file cap.
 // Update these deliberately, with the reason, when the corpus genuinely moves.
-// 29 + gate-sibling-repos.md + test-stream-fence.md (testing.md sat at 61,030 B
-// of its 62,000 B budget, so the stream-fence notes had nowhere to land in it)
-const CORPUS_FILE_COUNT = 34; // hooks.md crossed the per-file cap, so
+const CORPUS_FILE_COUNT = 34; // 29 + gate-sibling-repos.md (hooks.md crossed the per-file cap, so
                               //  its cross-repo gate-aliasing section moved out verbatim,
                               //  go-to-k/cdkd#2236) + asset-bucket-region.md (issue go-to-k/cdkd#2240
                               //  split out of assets.md). Both landed as 30 independently; merged
@@ -428,12 +431,34 @@ const CORPUS_FILE_COUNT = 34; // hooks.md crossed the per-file cap, so
                               //  detector's entry moved out of hooks.md verbatim when the #2363
                               //  family widening pushed hooks.md past the per-file cap again --
                               //  the #2236 shape repeated. That makes 33.
-const CORPUS_BYTES_MIN = 795_000;   // measured 808,384 B -- 13,384 B of slack
-const CORPUS_BYTES_MAX = 915_000;   // growth is the norm here; this catches bulk growth that stays under every per-file cap.
+                              //  + test-stream-fence.md: the stream-fence notes were 1,442 B and
+                              //  testing.md had 970 B of headroom under its 62,000 B payload row,
+                              //  so they could not land there. The satellite is 3,114 B and the
+                              //  pointer left behind is 328 B, which is why testing.md still grew
+                              //  (61,030 -> 61,358 B) rather than shrinking -- a split that leaves
+                              //  a pointer always costs the index file something. That makes 34.
+const CORPUS_BYTES_MIN = 899_000;   // measured 913,895 B -- 14,895 B of slack.
+                                    // 795_000 -> 899_000: the comment beside the old bound still
+                                    // read "measured 808,384 B", 105 KB behind the corpus, so the
+                                    // floor had ~119 KB of slack and would not have noticed a
+                                    // whole satellite being deleted. Re-measured rather than
+                                    // nudged, since a bound that drifts from its measurement stops
+                                    // being one.
+const CORPUS_BYTES_MAX = 928_000;   // growth is the norm here; this catches bulk growth that stays under every per-file cap.
                                     // 900_000 -> 915_000 (go-to-k/cdkd#2363): origin/main sat at 899,989 B --
                                     // 11 B of headroom -- so ANY rules addition tripped it. Measured after the
                                     // hooks-cwd-detector.md split: 902,381 B (the widening's net prose is
                                     // 1,422 B; the satellite's frontmatter + the pointer line are the rest).
+                                    // 915_000 -> 928_000 (test-stream-fence.md): this branch added
+                                    // 3,442 B, leaving 1,105 B of headroom -- the next rule-file
+                                    // edit over 1 KB anywhere would have failed this suite for a
+                                    // reason unrelated to itself. Measured 913,895 B.
+
+// Sanity: the two bounds must actually bracket a real measurement, so a future
+// edit cannot satisfy both by moving them past each other.
+if (CORPUS_BYTES_MIN >= CORPUS_BYTES_MAX) {
+  throw new Error('CORPUS_BYTES_MIN must stay below CORPUS_BYTES_MAX');
+}
 
 /**
  * The repo's tracked files, read once. Memoised because two per-file suites

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -447,9 +447,13 @@ const CORPUS_FILE_COUNT = 34; // 29 + gate-sibling-repos.md (hooks.md crossed th
                               //  detector's entry moved out of hooks.md verbatim when the #2363
                               //  family widening pushed hooks.md past the per-file cap again --
                               //  the #2236 shape repeated. That makes 33.
-                              //  + test-stream-fence.md: the stream-fence notes were 1,442 B and
-                              //  testing.md had 970 B of headroom under its payload row, so they
-                              //  could not land there. The
+                              //  + test-stream-fence.md: 876 B of stream-fence notes DID land in
+                              //  testing.md first and fit; the file then grew to 1,442 B against
+                              //  970 B of headroom under its payload row and had to move. (That
+                              //  row's cap has since gone to 68_000 for an unrelated reason, so
+                              //  the same text would fit today -- the split is kept because the
+                              //  satellite's narrow `paths:` is the right home for it, not because
+                              //  the cap forced it.) The
                               //  satellite is 3,384 B and the pointer left behind is 328 B,
                               //  which is why testing.md still grew
                               //  (61,030 -> 61,358 B) rather than shrinking -- a split that leaves
@@ -798,30 +802,48 @@ describe('.claude/rules payload fence', () => {
     // anyway, so it is the GUTTING case that this floor uniquely owns: a
     // satellite trimmed to just over `SUBSTANTIVE_MIN_BYTES` passes every other
     // assertion in this file.
+    //
+    // The usable band is structurally narrow -- `satellite - SUBSTANTIVE_MIN_BYTES`,
+    // which is 1,884 B today -- and `testing.md` growing spends it from the
+    // other side, 641 B of it before this case fires. That is not slack to be
+    // debugged away when it runs out: re-derive the floor, or grow the
+    // satellite so the band widens with it.
     const row = PAYLOAD_BUDGETS.find(([path]) => path === 'tests/setup.ts');
     expect(row, 'the tests/setup.ts budget row was removed').toBeDefined();
     const [, floor, cap] = row as readonly [string, number, number];
 
-    const byName = (name: string): number =>
-      ruleFiles.find((r) => r.name === name)?.bytes ?? 0;
-    const testingOnly = byName('testing.md');
-    const satellite = byName('test-stream-fence.md');
-    expect(satellite, 'test-stream-fence.md is missing').toBeGreaterThan(0);
+    // Computed the same way the row itself is -- by GLOB, not by naming the two
+    // files. `testing.md` globs `tests/**`, so a future satellite split out of
+    // it would also match this path and re-subsume the floor while a name-based
+    // version of this case kept reporting green.
+    const matched = ruleFiles.filter((rule) =>
+      (rule.paths ?? []).some((glob) => globToRegExp(glob).test('tests/setup.ts'))
+    );
+    const satellite = matched.find((r) => r.name === 'test-stream-fence.md');
+    expect(satellite, 'test-stream-fence.md no longer matches tests/setup.ts').toBeDefined();
+    const live = matched.reduce((sum, r) => sum + r.bytes, 0);
+    const withoutSatellite = live - (satellite as { bytes: number }).bytes;
 
     expect(
-      testingOnly,
-      `deleting test-stream-fence.md would leave ${testingOnly} B, which the ${floor} B floor ` +
-        'must reject'
+      withoutSatellite,
+      `deleting test-stream-fence.md would leave ${withoutSatellite} B, which the ${floor} B ` +
+        'floor must reject'
     ).toBeLessThan(floor);
     expect(
-      testingOnly + SUBSTANTIVE_MIN_BYTES,
+      withoutSatellite + SUBSTANTIVE_MIN_BYTES,
       `gutting test-stream-fence.md to ${SUBSTANTIVE_MIN_BYTES} B would leave ` +
-        `${testingOnly + SUBSTANTIVE_MIN_BYTES} B, at or above the ${floor} B floor -- the floor ` +
-        'no longer discriminates. Raise it (and the cap if needed), or say in the commit why the ' +
-        'gutting case is now covered elsewhere.'
+        `${withoutSatellite + SUBSTANTIVE_MIN_BYTES} B, at or above the ${floor} B floor -- the ` +
+        'floor no longer discriminates. Raise it (and the cap if needed), or say in the commit ' +
+        'why the gutting case is now covered elsewhere.'
     ).toBeLessThan(floor);
-    expect(testingOnly + satellite).toBeGreaterThanOrEqual(floor);
-    expect(testingOnly + satellite).toBeLessThanOrEqual(cap);
+    expect(
+      live,
+      `the live payload is ${live} B, under the ${floor} B floor this case just required`
+    ).toBeGreaterThanOrEqual(floor);
+    expect(
+      live,
+      `the live payload is ${live} B, over the row's ${cap} B cap`
+    ).toBeLessThanOrEqual(cap);
   });
 
   it('the two corpus bounds are ordered, so neither can be satisfied by crossing', () => {

--- a/tests/unit/stream-fence.test.ts
+++ b/tests/unit/stream-fence.test.ts
@@ -280,13 +280,27 @@ afterAll(() => {
 describe('the fence assumes tests within a file run serially', () => {
   const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-  // Both roots in vite.config.ts's `include`. `src` holds no `.test.ts` today,
-  // which is exactly why the scan below asserts what it FOUND: an arm that
-  // reaches nothing reports clean forever.
+  // Both roots vitest is configured to collect from, taken FROM the config so
+  // the pair cannot drift, with the count each must reach.
+  //
+  // `src` is `exactly: 0` rather than `atLeast: 0`, which asserts nothing:
+  // that arm was found vacuous once already, and `atLeast: 0` left it vacuous.
+  // Written as an equality, adding the first `src/**/*.test.ts` fails here and
+  // forces a real floor to be chosen.
   const ROOTS = [
-    { root: join(REPO_ROOT, 'tests'), atLeast: 800 },
-    { root: join(REPO_ROOT, 'src'), atLeast: 0 },
+    { name: 'tests', atLeast: 800 },
+    { name: 'src', exactly: 0 },
   ] as const;
+
+  it('the roots scanned below are the ones vitest collects from', () => {
+    const config = readFileSync(join(REPO_ROOT, 'vite.config.ts'), 'utf8');
+    const include = /include: \[([^\]]*)\]/.exec(config)?.[1] ?? '';
+    expect(include).toContain("'tests/**/*.test.ts'");
+    expect(include).toContain("'src/**/*.test.ts'");
+    // Two globs, two roots. A third would be scanned by vitest and not by the
+    // critic below.
+    expect(include.split(',').filter((p) => p.trim().length > 0)).toHaveLength(2);
+  });
 
   /**
    * Drop whole-line comments, so PROSE about concurrency is not an offender.
@@ -301,7 +315,13 @@ describe('the fence assumes tests within a file run serially', () => {
   const stripComments = (text: string): string =>
     text
       .split('\n')
-      .filter((line) => !/^\s*(?:\/\/|\/?\*)/.test(line))
+      // The `*` branch is `*` followed by whitespace, another `*`, or `/` — a
+      // JSDoc continuation or terminator. A bare `^\s*\*` also eats a shell
+      // `case` arm like `*) echo ...`, which
+      // `tests/unit/scripts/integ-s3-versions-harness.test.ts:376` has inside a
+      // template literal: the one line in the 840-file corpus this would drop
+      // silently, and a silent drop is the direction that hides a real usage.
+      .filter((line) => !/^\s*(?:\/\/|\/\*|\*(?=[\s*/]|$))/.test(line))
       .join('\n');
 
   const testFilesUnder = (root: string): string[] => {
@@ -314,8 +334,10 @@ describe('the fence assumes tests within a file run serially', () => {
       // a symlink is not a shape this repo uses.
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
         // vite.config.ts excludes these from the run, so a fixture's installed
-        // dependencies are not this critic's business either. Five integ
-        // fixtures create `tests/integration/*/node_modules` during a run.
+        // dependencies are not this critic's business either. Measured: 286 of
+        // the 287 integ fixtures carry a `package.json` and 244 `verify.sh`
+        // scripts install into their own directory, so this is a large tree
+        // that appears mid-run, not a corner case.
         if (entry.name === 'node_modules' || entry.name === 'dist') continue;
         const full = join(dir, entry.name);
         if (entry.isDirectory()) walk(full);
@@ -331,15 +353,22 @@ describe('the fence assumes tests within a file run serially', () => {
     // wipe a peer's buffer and a failure could replay another test's writes.
     // The fence would have to become per-test-context first.
     const offenders: string[] = [];
-    let scanned = 0;
-    for (const { root, atLeast } of ROOTS) {
-      const files = testFilesUnder(root);
-      expect(
-        files.length,
-        `the scan of ${root} found ${files.length} test files, under the ${atLeast} it should ` +
-          'reach -- a checker that sees nothing reports clean forever'
-      ).toBeGreaterThanOrEqual(atLeast);
-      scanned += files.length;
+    for (const spec of ROOTS) {
+      const files = testFilesUnder(join(REPO_ROOT, spec.name));
+      if ('exactly' in spec) {
+        expect(
+          files.length,
+          `the scan of ${spec.name} found ${files.length} test files, not the ${spec.exactly} ` +
+            'recorded here. If test files now live there, give this root a real floor instead ' +
+            'of an equality -- an arm that reaches nothing reports clean forever.'
+        ).toBe(spec.exactly);
+      } else {
+        expect(
+          files.length,
+          `the scan of ${spec.name} found ${files.length} test files, under the ${spec.atLeast} ` +
+            'it should reach -- a checker that sees nothing reports clean forever'
+        ).toBeGreaterThanOrEqual(spec.atLeast);
+      }
 
       for (const file of files) {
         // Comments are stripped before matching, so PROSE about concurrency is
@@ -361,7 +390,6 @@ describe('the fence assumes tests within a file run serially', () => {
       }
     }
 
-    expect(scanned).toBeGreaterThan(0);
     expect(
       offenders,
       'these suites run concurrently, which the stream fence single buffer cannot ' +
@@ -369,15 +397,29 @@ describe('the fence assumes tests within a file run serially', () => {
     ).toEqual([]);
   });
 
-  it('vite.config.ts does not turn concurrency on globally', () => {
+  it('nothing turns concurrency on globally', () => {
     // The cheapest way to break the assumption is not per-suite at all:
     // `sequence: { concurrent: true }` makes EVERY test concurrent at once, and
     // the per-file scan above would report nothing.
     const config = stripComments(readFileSync(join(REPO_ROOT, 'vite.config.ts'), 'utf8'));
+    for (const pattern of [/concurrent\s*:\s*true/, /sequence\.concurrent/]) {
+      expect(
+        pattern.test(config),
+        'vite.config.ts enables vitest concurrency globally; the stream fence in ' +
+          'tests/stream-fence.ts keeps one buffer per worker and cannot serve that'
+      ).toBe(false);
+    }
+
+    // And it must remain the file vitest actually reads: a `vitest.config.*` or
+    // `vitest.workspace.*` takes precedence, so one could set `sequence.concurrent`
+    // while the check above keeps reporting clean about a file nobody loads.
+    const competing = readdirSync(REPO_ROOT).filter((entry) =>
+      /^vitest\.(config|workspace)\./.test(entry)
+    );
     expect(
-      /concurrent\s*:\s*true/.test(config),
-      'vite.config.ts enables vitest concurrency globally; the stream fence in ' +
-        'tests/stream-fence.ts keeps one buffer per worker and cannot serve that'
-    ).toBe(false);
+      competing,
+      `${competing.join(', ')} takes precedence over vite.config.ts, so the assertion above ` +
+        'now reads a file vitest does not load. Move the check, or fold the config back in.'
+    ).toEqual([]);
   });
 });

--- a/tests/unit/stream-fence.test.ts
+++ b/tests/unit/stream-fence.test.ts
@@ -280,12 +280,43 @@ afterAll(() => {
 describe('the fence assumes tests within a file run serially', () => {
   const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
+  // Both roots in vite.config.ts's `include`. `src` holds no `.test.ts` today,
+  // which is exactly why the scan below asserts what it FOUND: an arm that
+  // reaches nothing reports clean forever.
+  const ROOTS = [
+    { root: join(REPO_ROOT, 'tests'), atLeast: 800 },
+    { root: join(REPO_ROOT, 'src'), atLeast: 0 },
+  ] as const;
+
+  /**
+   * Drop whole-line comments, so PROSE about concurrency is not an offender.
+   *
+   * Line-based on purpose. A regex that strips `/*` ... `*\/` spans looks more
+   * thorough and is worse here: `vite.config.ts` contains the glob literal
+   * `'**\/*'`, whose `/*` opens a span that the next real block-comment
+   * terminator closes, swallowing the middle of the file. Measured — with that
+   * version, an injected `sequence: { concurrent: true }` at line 72 went
+   * UNDETECTED and the case passed.
+   */
+  const stripComments = (text: string): string =>
+    text
+      .split('\n')
+      .filter((line) => !/^\s*(?:\/\/|\/?\*)/.test(line))
+      .join('\n');
+
   const testFilesUnder = (root: string): string[] => {
     const found: string[] = [];
     const walk = (dir: string): void => {
+      // `withFileTypes` rather than `statSync`: a broken symlink would make the
+      // whole critic throw rather than report. The trade is that a SYMLINKED
+      // directory or test file is skipped where `statSync` would have followed
+      // it; there are none under either root, and a suite reached only through
+      // a symlink is not a shape this repo uses.
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        // `withFileTypes` rather than `statSync`: a broken symlink under
-        // `tests/` would make the whole critic throw rather than report.
+        // vite.config.ts excludes these from the run, so a fixture's installed
+        // dependencies are not this critic's business either. Five integ
+        // fixtures create `tests/integration/*/node_modules` during a run.
+        if (entry.name === 'node_modules' || entry.name === 'dist') continue;
         const full = join(dir, entry.name);
         if (entry.isDirectory()) walk(full);
         else if (entry.isFile() && entry.name.endsWith('.test.ts')) found.push(full);
@@ -299,25 +330,38 @@ describe('the fence assumes tests within a file run serially', () => {
     // One buffer per worker: with `it.concurrent`, one test's begin() would
     // wipe a peer's buffer and a failure could replay another test's writes.
     // The fence would have to become per-test-context first.
-    //
-    // BOTH roots in vite.config.ts's `include` are scanned, not just `tests/**`
-    // — `src/**/*.test.ts` runs under the same setup file and the same worker.
-    const roots = [join(REPO_ROOT, 'tests'), join(REPO_ROOT, 'src')];
     const offenders: string[] = [];
-    for (const root of roots) {
-      for (const file of testFilesUnder(root)) {
-        // A CALL or a chain, not the words: this very file and
-        // `once-leak-detector.test.ts` both discuss `it.concurrent` in prose,
-        // and a bare-word match reports them as offenders. Anchoring on
-        // `.concurrent` alone rather than on `it|test|describe` also catches
-        // a chained form, where the modifier comes first and the concurrency
-        // marker is not preceded by `it` / `test` / `describe` at all.
-        if (/\.concurrent\s*[(.<]/.test(readFileSync(file, 'utf8'))) {
+    let scanned = 0;
+    for (const { root, atLeast } of ROOTS) {
+      const files = testFilesUnder(root);
+      expect(
+        files.length,
+        `the scan of ${root} found ${files.length} test files, under the ${atLeast} it should ` +
+          'reach -- a checker that sees nothing reports clean forever'
+      ).toBeGreaterThanOrEqual(atLeast);
+      scanned += files.length;
+
+      for (const file of files) {
+        // Comments are stripped before matching, so PROSE about concurrency is
+        // not an offender. Without it the critic reports itself and
+        // `once-leak-detector.test.ts`, both of which discuss the spellings
+        // below in comments — and the natural workaround, rewording the prose,
+        // breaks again the next time someone explains the rule.
+        const text = stripComments(readFileSync(file, 'utf8'));
+        // Two spellings, because vitest has two. The modifier form is matched
+        // as a CALL or a chain rather than by the words `it` / `test` /
+        // `describe`, so a chained modifier cannot slip past -- and because
+        // this file and `once-leak-detector.test.ts` both discuss the modifier
+        // in prose, where a bare-word match would report them as offenders.
+        // The second is the options-object form, `it('x', { concurrent: true },
+        // fn)`, which carries no modifier at all.
+        if (/\.concurrent\s*[(.<]/.test(text) || /concurrent\s*:\s*true/.test(text)) {
           offenders.push(file);
         }
       }
     }
 
+    expect(scanned).toBeGreaterThan(0);
     expect(
       offenders,
       'these suites run concurrently, which the stream fence single buffer cannot ' +
@@ -329,7 +373,7 @@ describe('the fence assumes tests within a file run serially', () => {
     // The cheapest way to break the assumption is not per-suite at all:
     // `sequence: { concurrent: true }` makes EVERY test concurrent at once, and
     // the per-file scan above would report nothing.
-    const config = readFileSync(join(REPO_ROOT, 'vite.config.ts'), 'utf8');
+    const config = stripComments(readFileSync(join(REPO_ROOT, 'vite.config.ts'), 'utf8'));
     expect(
       /concurrent\s*:\s*true/.test(config),
       'vite.config.ts enables vitest concurrency globally; the stream fence in ' +

--- a/tests/unit/stream-fence.test.ts
+++ b/tests/unit/stream-fence.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -278,33 +278,62 @@ afterAll(() => {
 });
 
 describe('the fence assumes tests within a file run serially', () => {
-  it('no suite uses vitest concurrent mode', () => {
+  const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+  const testFilesUnder = (root: string): string[] => {
+    const found: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        // `withFileTypes` rather than `statSync`: a broken symlink under
+        // `tests/` would make the whole critic throw rather than report.
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.isFile() && entry.name.endsWith('.test.ts')) found.push(full);
+      }
+    };
+    walk(root);
+    return found;
+  };
+
+  it('no suite opts into vitest concurrent mode', () => {
     // One buffer per worker: with `it.concurrent`, one test's begin() would
     // wipe a peer's buffer and a failure could replay another test's writes.
     // The fence would have to become per-test-context first.
-    const testsRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+    //
+    // BOTH roots in vite.config.ts's `include` are scanned, not just `tests/**`
+    // — `src/**/*.test.ts` runs under the same setup file and the same worker.
+    const roots = [join(REPO_ROOT, 'tests'), join(REPO_ROOT, 'src')];
     const offenders: string[] = [];
-    const walk = (dir: string): void => {
-      for (const entry of readdirSync(dir)) {
-        const full = join(dir, entry);
-        if (statSync(full).isDirectory()) {
-          walk(full);
-        } else if (entry.endsWith('.test.ts')) {
-          // A CALL or a chain, not the words: this very file and
-          // `once-leak-detector.test.ts` both discuss `it.concurrent` in prose,
-          // and a bare-word match reports them as offenders.
-          if (/\b(?:it|test|describe)\.concurrent\s*[(.<]/.test(readFileSync(full, 'utf8'))) {
-            offenders.push(full);
-          }
+    for (const root of roots) {
+      for (const file of testFilesUnder(root)) {
+        // A CALL or a chain, not the words: this very file and
+        // `once-leak-detector.test.ts` both discuss `it.concurrent` in prose,
+        // and a bare-word match reports them as offenders. Anchoring on
+        // `.concurrent` alone rather than on `it|test|describe` also catches
+        // a chained form, where the modifier comes first and the concurrency
+        // marker is not preceded by `it` / `test` / `describe` at all.
+        if (/\.concurrent\s*[(.<]/.test(readFileSync(file, 'utf8'))) {
+          offenders.push(file);
         }
       }
-    };
-    walk(testsRoot);
+    }
 
     expect(
       offenders,
       'these suites run concurrently, which the stream fence single buffer cannot ' +
         `serve correctly:\n  ${offenders.join('\n  ')}`
     ).toEqual([]);
+  });
+
+  it('vite.config.ts does not turn concurrency on globally', () => {
+    // The cheapest way to break the assumption is not per-suite at all:
+    // `sequence: { concurrent: true }` makes EVERY test concurrent at once, and
+    // the per-file scan above would report nothing.
+    const config = readFileSync(join(REPO_ROOT, 'vite.config.ts'), 'utf8');
+    expect(
+      /concurrent\s*:\s*true/.test(config),
+      'vite.config.ts enables vitest concurrency globally; the stream fence in ' +
+        'tests/stream-fence.ts keeps one buffer per worker and cannot serve that'
+    ).toBe(false);
   });
 });

--- a/tests/unit/stream-fence.test.ts
+++ b/tests/unit/stream-fence.test.ts
@@ -1,23 +1,35 @@
-import { describe, it, expect } from 'vite-plus/test';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect, afterAll } from 'vite-plus/test';
 
 import {
   activeStreamFence,
   createStreamFence,
+  streamFenceDisabled,
   type FenceableStream,
 } from '../stream-fence.js';
 
 /**
  * A stand-in for `process.stdout` / `process.stderr` that records what actually
- * reached the terminal. The fence patches `write` in place, so every assertion
- * below distinguishes "buffered" (nothing here) from "printed" (here).
+ * reached the terminal, and with what arguments. The fence patches `write` in
+ * place, so every assertion below distinguishes "buffered" (nothing here) from
+ * "printed" (here).
  */
-function fakeStream(): FenceableStream & { printed: string[] } {
+function fakeStream(returns = true): FenceableStream & {
+  printed: string[];
+  calls: unknown[][];
+} {
   const printed: string[] = [];
+  const calls: unknown[][] = [];
   return {
     printed,
-    write(chunk: string | Uint8Array) {
+    calls,
+    write(chunk: string | Uint8Array, ...rest: unknown[]) {
       printed.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
-      return true;
+      calls.push([chunk, ...rest]);
+      return returns;
     },
   };
 }
@@ -31,7 +43,23 @@ describe('createStreamFence', () => {
     err.write('module top level\n');
 
     expect(err.printed).toEqual(['module top level\n']);
+    expect(fence.capturing()).toBe(false);
     expect(fence.buffered()).toBeUndefined();
+  });
+
+  it('forwards every argument of a passed-through write and returns the stream own value', () => {
+    // Backpressure is real: product code may do `if (!stream.write(x)) await
+    // drain`. A wrapper that hardcodes `true`, or drops the encoding, changes
+    // the caller's behaviour on a path the fence is supposed to be invisible on.
+    const fence = createStreamFence();
+    const err = fakeStream(false);
+    fence.attach(err, 'stderr');
+
+    const callback = (): void => {};
+    const returned = err.write('body\n', 'utf8', callback);
+
+    expect(returned).toBe(false);
+    expect(err.calls).toEqual([['body\n', 'utf8', callback]]);
   });
 
   it('buffers writes made during a test instead of printing them', () => {
@@ -43,8 +71,9 @@ describe('createStreamFence', () => {
     err.write('Warning: --region is deprecated\n');
 
     expect(err.printed).toEqual([]);
-    expect(fence.buffered()).toEqual([
-      { stream: 'stderr', text: 'Warning: --region is deprecated\n' },
+    expect(fence.capturing()).toBe(true);
+    expect(fence.buffered()?.map((w) => w.text)).toEqual([
+      'Warning: --region is deprecated\n',
     ]);
   });
 
@@ -66,9 +95,6 @@ describe('createStreamFence', () => {
   });
 
   it('heads the replay with the failing test name, on stderr', () => {
-    // The raw writes carry no attribution — that is the whole reason they are
-    // a problem in a run's output. A replay driven by a failure knows which
-    // test it belongs to, so it says so.
     const fence = createStreamFence();
     const out = fakeStream();
     const err = fakeStream();
@@ -77,9 +103,9 @@ describe('createStreamFence', () => {
 
     fence.begin();
     out.write('a stdout notice\n');
-    fence.replay('destroy > releases the lock');
+    fence.replay('destroy.test.ts > destroy > releases the lock');
 
-    expect(err.printed).toEqual(['stderr | destroy > releases the lock\n']);
+    expect(err.printed).toEqual(['stderr | destroy.test.ts > destroy > releases the lock\n']);
     expect(out.printed).toEqual(['a stdout notice\n']);
   });
 
@@ -95,6 +121,20 @@ describe('createStreamFence', () => {
     expect(err.printed).toEqual(['body\n']);
   });
 
+  it('falls back to an attached stream for the header when stderr is not one', () => {
+    // Guards the `?.` on the header write: dropping the header silently is a
+    // worse outcome than putting it on the only stream there is.
+    const fence = createStreamFence();
+    const out = fakeStream();
+    fence.attach(out, 'stdout');
+
+    fence.begin();
+    out.write('body\n');
+    fence.replay('some > test');
+
+    expect(out.printed).toEqual(['stderr | some > test\n', 'body\n']);
+  });
+
   it('does not print the same line twice when replayed more than once', () => {
     const fence = createStreamFence();
     const err = fakeStream();
@@ -106,22 +146,6 @@ describe('createStreamFence', () => {
     fence.replay();
 
     expect(err.printed).toEqual(['once\n']);
-  });
-
-  it('does not re-capture the writes its own replay makes', () => {
-    // The buffer is cleared BEFORE the replay writes, so a replay running while
-    // capture is still active cannot feed itself. Without that ordering the
-    // same line would sit in the buffer again after the replay returned.
-    const fence = createStreamFence();
-    const err = fakeStream();
-    fence.attach(err, 'stderr');
-
-    fence.begin();
-    err.write('boom\n');
-    fence.replay();
-
-    expect(err.printed).toEqual(['boom\n']);
-    expect(fence.buffered()).toEqual([]);
   });
 
   it('invokes the completion callback of a swallowed write in both call shapes', () => {
@@ -159,22 +183,71 @@ describe('createStreamFence', () => {
     expect(err.printed).toEqual(['bytes\n']);
   });
 
-  it('goes back to passing through after the test ends', () => {
+  it('replays a non-utf8 encoding faithfully, and renders it decoded', () => {
+    // `write('6869', 'hex')` writes the two bytes `hi`, not those four
+    // characters. A buffer that keeps only the rendered text would replay the
+    // wrong bytes; one that keeps only the chunk would make `buffered()`
+    // unreadable.
     const fence = createStreamFence();
     const err = fakeStream();
     fence.attach(err, 'stderr');
 
     fence.begin();
-    fence.end();
-    err.write('afterAll diagnostic\n');
+    err.write('6869', 'hex');
 
-    expect(err.printed).toEqual(['afterAll diagnostic\n']);
-    expect(fence.buffered()).toBeUndefined();
+    expect(fence.buffered()?.map((w) => w.text)).toEqual(['hi']);
+
+    fence.replay();
+    expect(err.calls).toEqual([['6869', 'hex']]);
+  });
+
+  it('stops capturing at finish() but keeps the buffer for a later replay', () => {
+    // The ordering this depends on is vitest's: afterEach -> onTestFinished ->
+    // onTestFailed. Clearing the buffer at finish() would make every replay
+    // empty; not stopping capture at all would swallow afterAll and the next
+    // file's top-level writes forever.
+    const fence = createStreamFence();
+    const err = fakeStream();
+    fence.attach(err, 'stderr');
+
+    fence.begin();
+    err.write('during the test\n');
+    fence.finish();
+    err.write('after the test\n');
+
+    expect(fence.capturing()).toBe(false);
+    expect(err.printed).toEqual(['after the test\n']);
+
+    fence.replay();
+    expect(err.printed).toEqual(['after the test\n', 'during the test\n']);
+  });
+
+  it('discards the previous test buffer at begin()', () => {
+    const fence = createStreamFence();
+    const err = fakeStream();
+    fence.attach(err, 'stderr');
+
+    fence.begin();
+    err.write('from the passing test\n');
+    fence.finish();
+    fence.begin();
+    fence.replay();
+
+    expect(err.printed).toEqual([]);
+  });
+});
+
+describe('streamFenceDisabled', () => {
+  it('is off by default and on only for the exact opt-out value', () => {
+    expect(streamFenceDisabled({})).toBe(false);
+    expect(streamFenceDisabled({ CDKD_TEST_STREAM_PASSTHROUGH: '0' })).toBe(false);
+    expect(streamFenceDisabled({ CDKD_TEST_STREAM_PASSTHROUGH: 'true' })).toBe(false);
+    expect(streamFenceDisabled({ CDKD_TEST_STREAM_PASSTHROUGH: '1' })).toBe(true);
   });
 });
 
 describe('the fence installed over the real process streams', () => {
-  const passthrough = process.env['CDKD_TEST_STREAM_PASSTHROUGH'] === '1';
+  const passthrough = streamFenceDisabled(process.env);
 
   it.skipIf(passthrough)('is active while this very test runs', () => {
     // The wiring, not the logic: proves `tests/setup.ts` installed the fence
@@ -182,6 +255,7 @@ describe('the fence installed over the real process streams', () => {
     // the line below would land in the run's output.
     const fence = activeStreamFence();
     expect(fence).toBeDefined();
+    expect(fence?.capturing()).toBe(true);
 
     const marker = 'stream-fence live check — this line must not reach the run output\n';
     process.stderr.write(marker);
@@ -191,5 +265,46 @@ describe('the fence installed over the real process streams', () => {
 
   it.skipIf(!passthrough)('is not installed under CDKD_TEST_STREAM_PASSTHROUGH=1', () => {
     expect(activeStreamFence()).toBeUndefined();
+  });
+});
+
+// The live half of the finish() contract: `afterAll` runs after the last test's
+// `onTestFinished`, so capture must already be off here. If the wiring stopped
+// calling finish(), this write would be buffered and then dropped — exactly the
+// silent-swallow the fence must not do — and the assertion fails the file.
+afterAll(() => {
+  if (streamFenceDisabled(process.env)) return;
+  expect(activeStreamFence()?.capturing()).toBe(false);
+});
+
+describe('the fence assumes tests within a file run serially', () => {
+  it('no suite uses vitest concurrent mode', () => {
+    // One buffer per worker: with `it.concurrent`, one test's begin() would
+    // wipe a peer's buffer and a failure could replay another test's writes.
+    // The fence would have to become per-test-context first.
+    const testsRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+    const offenders: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+          walk(full);
+        } else if (entry.endsWith('.test.ts')) {
+          // A CALL or a chain, not the words: this very file and
+          // `once-leak-detector.test.ts` both discuss `it.concurrent` in prose,
+          // and a bare-word match reports them as offenders.
+          if (/\b(?:it|test|describe)\.concurrent\s*[(.<]/.test(readFileSync(full, 'utf8'))) {
+            offenders.push(full);
+          }
+        }
+      }
+    };
+    walk(testsRoot);
+
+    expect(
+      offenders,
+      'these suites run concurrently, which the stream fence single buffer cannot ' +
+        `serve correctly:\n  ${offenders.join('\n  ')}`
+    ).toEqual([]);
   });
 });

--- a/tests/unit/stream-fence.test.ts
+++ b/tests/unit/stream-fence.test.ts
@@ -280,8 +280,10 @@ afterAll(() => {
 describe('the fence assumes tests within a file run serially', () => {
   const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-  // Both roots vitest is configured to collect from, taken FROM the config so
-  // the pair cannot drift, with the count each must reach.
+  // Both roots vitest is configured to collect from, with the count each must
+  // reach. The list is written out rather than parsed; the case below asserts
+  // the config's `include` against the same two literals, so the pair cannot
+  // drift without one of them failing.
   //
   // `src` is `exactly: 0` rather than `atLeast: 0`, which asserts nothing:
   // that arm was found vacuous once already, and `atLeast: 0` left it vacuous.
@@ -335,9 +337,10 @@ describe('the fence assumes tests within a file run serially', () => {
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
         // vite.config.ts excludes these from the run, so a fixture's installed
         // dependencies are not this critic's business either. Measured: 286 of
-        // the 287 integ fixtures carry a `package.json` and 244 `verify.sh`
-        // scripts install into their own directory, so this is a large tree
-        // that appears mid-run, not a corner case.
+        // the 287 integ fixtures carry a `package.json`, and 215 of the 247
+        // `verify.sh` scripts run `npm install` or `pnpm install` (245 mention
+        // `install` at all, counting `vp install`). So this is a large tree that
+        // appears mid-run, not a corner case.
         if (entry.name === 'node_modules' || entry.name === 'dist') continue;
         const full = join(dir, entry.name);
         if (entry.isDirectory()) walk(full);

--- a/tests/unit/stream-fence.test.ts
+++ b/tests/unit/stream-fence.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vite-plus/test';
+
+import {
+  activeStreamFence,
+  createStreamFence,
+  type FenceableStream,
+} from '../stream-fence.js';
+
+/**
+ * A stand-in for `process.stdout` / `process.stderr` that records what actually
+ * reached the terminal. The fence patches `write` in place, so every assertion
+ * below distinguishes "buffered" (nothing here) from "printed" (here).
+ */
+function fakeStream(): FenceableStream & { printed: string[] } {
+  const printed: string[] = [];
+  return {
+    printed,
+    write(chunk: string | Uint8Array) {
+      printed.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+      return true;
+    },
+  };
+}
+
+describe('createStreamFence', () => {
+  it('passes writes straight through before a test begins', () => {
+    const fence = createStreamFence();
+    const err = fakeStream();
+    fence.attach(err, 'stderr');
+
+    err.write('module top level\n');
+
+    expect(err.printed).toEqual(['module top level\n']);
+    expect(fence.buffered()).toBeUndefined();
+  });
+
+  it('buffers writes made during a test instead of printing them', () => {
+    const fence = createStreamFence();
+    const err = fakeStream();
+    fence.attach(err, 'stderr');
+
+    fence.begin();
+    err.write('Warning: --region is deprecated\n');
+
+    expect(err.printed).toEqual([]);
+    expect(fence.buffered()).toEqual([
+      { stream: 'stderr', text: 'Warning: --region is deprecated\n' },
+    ]);
+  });
+
+  it('replays the buffer to the stream each line was written to, in order', () => {
+    const fence = createStreamFence();
+    const out = fakeStream();
+    const err = fakeStream();
+    fence.attach(out, 'stdout');
+    fence.attach(err, 'stderr');
+
+    fence.begin();
+    err.write('first\n');
+    out.write('second\n');
+    err.write('third\n');
+    fence.replay();
+
+    expect(err.printed).toEqual(['first\n', 'third\n']);
+    expect(out.printed).toEqual(['second\n']);
+  });
+
+  it('heads the replay with the failing test name, on stderr', () => {
+    // The raw writes carry no attribution — that is the whole reason they are
+    // a problem in a run's output. A replay driven by a failure knows which
+    // test it belongs to, so it says so.
+    const fence = createStreamFence();
+    const out = fakeStream();
+    const err = fakeStream();
+    fence.attach(out, 'stdout');
+    fence.attach(err, 'stderr');
+
+    fence.begin();
+    out.write('a stdout notice\n');
+    fence.replay('destroy > releases the lock');
+
+    expect(err.printed).toEqual(['stderr | destroy > releases the lock\n']);
+    expect(out.printed).toEqual(['a stdout notice\n']);
+  });
+
+  it('emits no header when the replay is unlabelled', () => {
+    const fence = createStreamFence();
+    const err = fakeStream();
+    fence.attach(err, 'stderr');
+
+    fence.begin();
+    err.write('body\n');
+    fence.replay();
+
+    expect(err.printed).toEqual(['body\n']);
+  });
+
+  it('does not print the same line twice when replayed more than once', () => {
+    const fence = createStreamFence();
+    const err = fakeStream();
+    fence.attach(err, 'stderr');
+
+    fence.begin();
+    err.write('once\n');
+    fence.replay();
+    fence.replay();
+
+    expect(err.printed).toEqual(['once\n']);
+  });
+
+  it('does not re-capture the writes its own replay makes', () => {
+    // The buffer is cleared BEFORE the replay writes, so a replay running while
+    // capture is still active cannot feed itself. Without that ordering the
+    // same line would sit in the buffer again after the replay returned.
+    const fence = createStreamFence();
+    const err = fakeStream();
+    fence.attach(err, 'stderr');
+
+    fence.begin();
+    err.write('boom\n');
+    fence.replay();
+
+    expect(err.printed).toEqual(['boom\n']);
+    expect(fence.buffered()).toEqual([]);
+  });
+
+  it('invokes the completion callback of a swallowed write in both call shapes', () => {
+    // A caller may await the callback. Swallowing the write must not also
+    // swallow its completion signal, or a `write(chunk, cb)` in product code
+    // would hang for the duration of the test.
+    const fence = createStreamFence();
+    const err = fakeStream();
+    fence.attach(err, 'stderr');
+    fence.begin();
+
+    let twoArg = false;
+    let threeArg = false;
+    err.write('a\n', () => {
+      twoArg = true;
+    });
+    err.write('b\n', 'utf8', () => {
+      threeArg = true;
+    });
+
+    expect(twoArg).toBe(true);
+    expect(threeArg).toBe(true);
+    expect(err.printed).toEqual([]);
+  });
+
+  it('decodes a Uint8Array chunk so the replay is readable text', () => {
+    const fence = createStreamFence();
+    const err = fakeStream();
+    fence.attach(err, 'stderr');
+
+    fence.begin();
+    err.write(new TextEncoder().encode('bytes\n'));
+    fence.replay();
+
+    expect(err.printed).toEqual(['bytes\n']);
+  });
+
+  it('goes back to passing through after the test ends', () => {
+    const fence = createStreamFence();
+    const err = fakeStream();
+    fence.attach(err, 'stderr');
+
+    fence.begin();
+    fence.end();
+    err.write('afterAll diagnostic\n');
+
+    expect(err.printed).toEqual(['afterAll diagnostic\n']);
+    expect(fence.buffered()).toBeUndefined();
+  });
+});
+
+describe('the fence installed over the real process streams', () => {
+  const passthrough = process.env['CDKD_TEST_STREAM_PASSTHROUGH'] === '1';
+
+  it.skipIf(passthrough)('is active while this very test runs', () => {
+    // The wiring, not the logic: proves `tests/setup.ts` installed the fence
+    // AND that its `beforeEach` began a capture for this test. Without both,
+    // the line below would land in the run's output.
+    const fence = activeStreamFence();
+    expect(fence).toBeDefined();
+
+    const marker = 'stream-fence live check — this line must not reach the run output\n';
+    process.stderr.write(marker);
+
+    expect(fence?.buffered()?.some((w) => w.text === marker)).toBe(true);
+  });
+
+  it.skipIf(!passthrough)('is not installed under CDKD_TEST_STREAM_PASSTHROUGH=1', () => {
+    expect(activeStreamFence()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

A green `vp test run` printed **217 lines / 22 KB**, and ~20 KB of that came from
tests that PASSED. This makes it print **15 lines / 616 bytes** instead, for the
same full suite.

Vitest attributes and (under this repo's reporter) suppresses `console.*`, but a
raw `stream.write()` bypasses that entirely and lands in the run's output
unattributed. Product code writes that way on purpose where the logger is the
wrong channel — the deprecated-`--region` notice in `src/cli/options.ts`, the
SIGINT notices in `src/provisioning/interrupt-watch.ts` and
`src/cli/commands/destroy-runner.ts`, the critic summaries under `scripts/` — so
the suites exercising those paths legitimately printed them. Measured before the
change: 108 such lines across 18 files, 67 of them the deprecated-`--region`
warning from two drift suites.

`tests/setup.ts` now installs a stream fence (`tests/stream-fence.ts`) that
buffers those writes and replays them, headed by the failing test's full name,
**only when that test fails**.

This is a correctness property, not a tidiness one. A green run's output is what
a person or an agent reads to decide whether to trust the run, and 20 KB of
notices from passing tests is 20 KB a real signal can hide in.

### What is deliberately not buffered

- Writes **outside** a test body (module top level, `beforeAll` / `afterAll`).
  They are diagnostic about the FILE, and there is no failing test to attach
  them to.
- Anything at all under `CDKD_TEST_STREAM_PASSTHROUGH=1`. Debugging a hang needs
  the writes as they happen: a run that never reaches the end of a test never
  reaches the replay either.

### Bounded at both ends

The capture stops at `onTestFinished` while KEEPING the buffer. vitest runs
`afterEach` -> `onTestFinished` -> `onTestFailed` (read off `@vitest/runner`
4.1.10 rather than assumed), so the replay still finds something to replay, and
everything after it writes straight through.

The first cut of this PR started the capture and never stopped it, which turned
the carve-out above into a silent **swallow** — strictly worse than the noise it
removes — while the docs claimed the opposite. Review round 1 caught it. An
`afterAll` in `tests/unit/stream-fence.test.ts` now asserts the fence is no
longer capturing once a file's tests are done, so the claim is fenced rather
than merely written.

## Test plan

- `tests/unit/stream-fence.test.ts` — 16 tests over the pass-through branch and
  its return value, the buffer lifecycle, replay ordering and stream routing,
  the header and its fallback, double-replay, both `write()` callback shapes,
  `Uint8Array` and non-utf8 encodings, and both arms of the
  `CDKD_TEST_STREAM_PASSTHROUGH` gate.
- Mutation-proven, each probe run and reverted:
  - a throwaway two-test fixture: the passing test's marker does NOT appear in
    the output, the failing test's appears exactly once under a
    `stderr | <full name>` header, and under
    `CDKD_TEST_STREAM_PASSTHROUGH=1` the passing test's marker appears again.
  - dropping the `onTestFinished` wiring fails the file via the `afterAll`.
  - a throwaway `it.concurrent` suite fails the new concurrency critic.
- Full suite: 843 files / 17,477 tests green, 15 lines / 616 bytes of output.

## Review

Five rounds of an independent code reviewer, each scoped to the previous round's
delta.

| Round | Verdict |
| --- | --- |
| 1 | **blocker** — the capture was started and never stopped, so `afterEach` / `afterAll` / next-file writes were buffered and then discarded. The docs claimed the opposite. |
| 2 | 6 items — the carve-out was mis-stated; the concurrency critic missed `src/**`, chained forms and a global `concurrent: true`; both corpus bounds had drifted ~105 KB from their own comments; the new payload floor sat below the file it guards. |
| 3 | **blocker** — the raised floor STILL sat below `testing.md` alone. Plus a comment-stripping regex that ate the middle of the file it was searching. |
| 4 | **blocker** — the floor was strictly SUBSUMED: it fired below 642 B of satellite while another case already fires at 1,500 B. Plus `atLeast: 0`, which asserts nothing. |
| 5 | **no blockers.** 3 minors, 3 nits, all fixed. |

Worth recording because the pattern held for four rounds: **every defect was in a
CHECKER, not in the fence.** The fence itself has been clean since round 1. The
recurring shape is a checker that reports clean because it cannot see its input —
an arm scanning a directory with no files in it, a floor set below the thing it
guards, a floor subsumed by a stricter neighbour, and a comment-stripper that
swallowed the file it was searching. Every fix is now mutation-proven with a
throwaway fixture rather than argued, and the payload floor RECOMPUTES its own
discrimination margin instead of trusting a hand-picked number.

One finding is deferred rather than fixed: 20 of the 28 rows in that budget table
carry a `measured` comment stale by more than 500 B (worst 13,032 B) and three
sit within 72 B of their cap. Filed as #2395 — a 28-row diff in a file where
every number is load-bearing does not belong on top of five review rounds.

## Notes

- `.claude/rules/testing.md` sat at 61,030 B of its 62,000 B payload budget, so
  the notes went into a new `.claude/rules/test-stream-fence.md` satellite whose
  `paths:` list names only the fence, its suite, and the setup file that
  installs it. `tests/unit/scripts/rule-file-payload.test.ts` gains the corpus
  count, the exact reach, and a budget row for `tests/setup.ts` so the satellite
  cannot go dark unnoticed.
- **Won't-do:** no `docs/changelog-cdkd.md` entry. That file records shipped
  changes by "the public-facing surface that changed" and "the user-visible
  behavior delta"; this one has neither — it changes what a test RUN prints, not
  what cdkd does.
