### PR TITLE
docs(contributing): integration-test cost policy and per-gate integ requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,40 @@ See [CLAUDE.md](CLAUDE.md) for detailed architecture documentation.
 
 See [docs/provider-development.md](docs/provider-development.md) for a step-by-step guide.
 
+## Integration Tests
+
+Integration tests under `tests/integration/` deploy and destroy **real AWS
+resources**, so running them incurs real AWS charges. CI does not run them.
+
+**You are not required to run them.** If your change needs integration
+coverage (see the table below), just say so in your PR — the maintainer runs
+the required tests before merging, at no cost to you. The maintainer's merge
+gates physically block merging until the required integration run has passed,
+so coverage is guaranteed either way; asking is never a burden.
+
+You are welcome to run them yourself against your own AWS account if you
+prefer — see [docs/testing.md](docs/testing.md) for per-test instructions.
+The `local-*` tests are the exception on cost: they need only a local Docker
+daemon and touch no AWS resources.
+
+### When is an integration test needed, and which one?
+
+Which verification a PR needs is derived mechanically from the paths it
+touches. The path lists are the gate scopes in
+[`.markgate.yml`](.markgate.yml) — the maintainer's merge gates read exactly
+those, so the file is the source of truth. In summary:
+
+| Your PR touches | Required verification (gate) |
+| --- | --- |
+| Deletion logic — `src/provisioning/providers/**`, destroy commands, rollback / retry code | An integration test that completes deploy **and destroy** cleanly (`integ-destroy`) |
+| Cross-cutting deploy/destroy code — `src/deployment/deploy-engine.ts`, `src/analyzer/dag-builder.ts`, intrinsic resolution, provider registration | A broad multi-resource test in addition to any feature-specific one (`integ-broad`; the test-name set is listed in `.markgate.yml`) |
+| Local execution — `src/local/**`, `src/cli/commands/local-*.ts` | A `local-*` test — Docker only, no AWS charges (`integ-local`) |
+| A state schema version bump in `src/types/state.ts` | The `schema-v<N>-to-v<N+1>-migration` round-trip test (`integ-schema-migration`) |
+| None of the above | No integration test — unit tests and CI are enough |
+
+When in doubt, open the PR and ask; the maintainer will pick and run the
+right tests.
+
 ## Adding Integration Tests
 
 Add new examples under `tests/integration/`. See existing examples for patterns.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,9 @@ so coverage is guaranteed either way; asking is never a burden.
 
 You are welcome to run them yourself against your own AWS account if you
 prefer — see [docs/testing.md](docs/testing.md) for per-test instructions.
-The `local-*` tests are the exception on cost: they need only a local Docker
-daemon and touch no AWS resources.
+Most `local-*` tests are the exception on cost: they need only a local
+Docker daemon and touch no AWS resources (`local-invoke-from-state` is the
+one exception — it also deploys and destroys real AWS resources).
 
 ### When is an integration test needed, and which one?
 
@@ -89,7 +90,7 @@ those, so the file is the source of truth. In summary:
 | --- | --- |
 | Deletion logic — `src/provisioning/providers/**`, destroy commands, rollback / retry code | An integration test that completes deploy **and destroy** cleanly (`integ-destroy`) |
 | Cross-cutting deploy/destroy code — `src/deployment/deploy-engine.ts`, `src/analyzer/dag-builder.ts`, intrinsic resolution, provider registration | A broad multi-resource test in addition to any feature-specific one (`integ-broad`; the test-name set is listed in `.markgate.yml`) |
-| Local execution — `src/local/**`, `src/cli/commands/local-*.ts` | A `local-*` test — Docker only, no AWS charges (`integ-local`) |
+| Local execution — `src/local/**`, `src/cli/commands/local-*.ts` | A `local-*` test — Docker-based, most need no AWS account (`integ-local`) |
 | A state schema version bump in `src/types/state.ts` | The `schema-v<N>-to-v<N+1>-migration` round-trip test (`integ-schema-migration`) |
 | None of the above | No integration test — unit tests and CI are enough |
 


### PR DESCRIPTION
## Summary

- Add an "Integration Tests" section to CONTRIBUTING.md stating the cost policy: integration tests deploy real AWS resources and incur charges, CI does not run them, and contributors are NOT required to run them — asking in the PR is enough, and the maintainer runs the required tests before merging (the maintainer's merge gates block merging until they pass, so coverage is guaranteed either way).
- Document WHEN an integration test is needed and WHICH kind, as a path-to-gate summary table derived from the gate scopes in `.markgate.yml` (`integ-destroy` / `integ-broad` / `integ-local` / `integ-schema-migration`). The exact path lists are deliberately not duplicated — `.markgate.yml` is named as the source of truth, so the table cannot drift from the fenced copies that `tests/unit/scripts/cross-cutting-list-sync.test.ts` guards.
- Note the `local-*` cost exception precisely: most need only Docker, while `local-invoke-from-state` also deploys and destroys real AWS resources.

## Why

External contributors have no way to know which integration test a change needs, and may reasonably not want to pay AWS charges to contribute. The gate scopes already encode the answer mechanically; this surfaces it in the contributor-facing doc and makes "just ask" an explicitly supported path.

## Test plan

- Docs-only change (CONTRIBUTING.md is outside both the `check` and `docs` gate scopes). Full `/check` suite run anyway: typecheck, lint, build, 852 test files / 17603 tests pass.
- Verified claims against the tree: CI references `tests/integration/**` only as codegen/lint inputs (never deploys); the four gate scopes match `.markgate.yml`; `docs/testing.md` carries the per-test run instructions the section links to.

https://claude.ai/code/session_01XxNpeqCebgrMHDHJDZRGvb
