### PR TITLE
chore(hooks): escape the backticks in two shim heredocs, so the shell stops running their comments

### DIFF
--- a/.claude/hooks/integ-destroy-gate.test.sh
+++ b/.claude/hooks/integ-destroy-gate.test.sh
@@ -64,7 +64,7 @@ verdict="\${MARKGATE_MOCK_VERDICT:-stale}"
 case "\$1" in
   verify)
     [ "\$verdict" = "fresh" ] && exit 0
-    # markgate 0.4 `hash: diff` exits 2 when it cannot EVALUATE the gate
+    # markgate 0.4 \`hash: diff\` exits 2 when it cannot EVALUATE the gate
     # (unresolvable base ref, empty delta) as opposed to 1 for a stale
     # marker. Different remedy, so the hook must branch on it.
     [ "\$verdict" = "error" ] && exit 2
@@ -75,7 +75,7 @@ case "\$1" in
       printf 'key:        %s\nstate:      match\n' "\$2"
     elif [ "\$verdict" = "error" ]; then
       # Real 0.4 behavior on this path: the message goes to stderr and
-      # stdout carries no `state:` line at all, so the hook's awk reason
+      # stdout carries no \`state:\` line at all, so the hook's awk reason
       # extraction comes back empty.
       echo "markgate: hash=diff: base ref does not resolve" >&2
       exit 2

--- a/.claude/hooks/verify-pr-gate.test.sh
+++ b/.claude/hooks/verify-pr-gate.test.sh
@@ -49,9 +49,9 @@ cat > "$SHIM_DIR/markgate" <<MARKGATE_EOF
 echo "\$PWD" >> "$CWD_TRACE_FILE"
 # Record the ARGUMENTS too, not only the cwd. Discarding them left this suite
 # unable to see WHICH gate the hook asked about: swapping
-# `markgate verify verify-pr` for `markgate verify check` kept it at 22/22
+# \`markgate verify verify-pr\` for \`markgate verify check\` kept it at 22/22
 # GREEN, and that mutant is a live bypass -- verify-pr-gate would pass whenever
-# `/check` alone is fresh, with `/verify-pr` never having run. Found by a
+# \`/check\` alone is fresh, with \`/verify-pr\` never having run. Found by a
 # sibling repo's round-2 test review, which named the class: nothing asserted
 # what the gate ASKS ITS VERIFIER.
 echo "\$*" >> "$ARGS_TRACE_FILE"


### PR DESCRIPTION
Closes #2078

## The defect

Both `.claude/hooks/integ-destroy-gate.test.sh` and `.claude/hooks/verify-pr-gate.test.sh` write their mocked `markgate` shim through a heredoc whose delimiter is deliberately UNQUOTED, because the body has to interpolate `$CWD_TRACE_FILE` / `$ARGS_TRACE_FILE`. An unquoted delimiter expands the whole body — and both bodies carry backtick code spans inside `#` comments, which the shell then runs as command substitution while writing the file.

## The half go-to-k/cdkd#2078 does not name is the worse one

The issue reports the cosmetic symptom: where the substituted first word is not a real binary, the shell prints an error and writes an empty string.

```console
$ bash .claude/hooks/integ-destroy-gate.test.sh 2>&1 >/dev/null | head -2
.claude/hooks/integ-destroy-gate.test.sh: line 60: hash:: command not found
.claude/hooks/integ-destroy-gate.test.sh: line 60: state:: command not found

$ bash .claude/hooks/verify-pr-gate.test.sh 2>&1 >/dev/null | head -4
markgate: gates.integ-destroy: unknown hash "diff" (want "git-tree" or "files")
markgate: gates.integ-destroy: unknown hash "diff" (want "git-tree" or "files")
.claude/hooks/verify-pr-gate.test.sh: line 47: /check: No such file or directory
.claude/hooks/verify-pr-gate.test.sh: line 47: /verify-pr: No such file or directory
```

The first two lines of that second block are not diagnostics — they are a real `markgate verify` **invocation**. Two of `verify-pr-gate.test.sh`'s four spans name `markgate`, which exists, so the shell ran it and substituted its OUTPUT into the shim's comments. That file was corrupting the mock it writes, not merely printing noise.

Whether an instance of this class is cosmetic or corrupting depends only on whether the first word inside the span happens to name a binary. That is worth stating because it is what makes the class worth caring about at all.

## The fix

Escape the backticks as `` \` ``, matching how both files already escape `\$` throughout. Rewording the comments to drop the code spans was the other option go-to-k/cdkd#2078 offers; escaping preserves the formatting the comments intend and matches the file's existing convention.

Verified by expanding the heredoc the way the suite does and asserting the generated shim contains the literal spans rather than their output:

```text
'`markgate verify verify-pr`'  present in generated shim: True
'`markgate verify check`'      present in generated shim: True
'`/check`'                     present in generated shim: True
'`/verify-pr`'                 present in generated shim: True
```

Both suites still pass — 24/0 and 23/0 — and both now print nothing on stderr but their own results.

## The sweep, and why no fence ships with it

go-to-k/cdkd#2078 asks for a sweep of the hook directory for sibling unquoted-delimiter heredocs carrying backticks. It found exactly these two files; every other unquoted heredoc under `.claude/hooks/**` is free of command substitution.

A one-time sweep is what let the sibling sit there since the suite was written, so a fence is the right instinct. Three designs were tried and **measured**, and all three are recorded on go-to-k/cdkd#2434 rather than left to be guessed at again:

1. **Scan for command substitution in unquoted heredocs** — unsound on SEMANTICS. `$(printf ...)` inside an unquoted heredoc is deliberate in `gated-command-preamble-gate.sh` and `gh-label-validity-gate.sh`. Nothing syntactic separates an intended interpolation from a comment's code span.
2. **The same scan restricted to comment lines** — the right rule, but the heredoc BOUNDARY defeats it. A permissive opener regex reported **1128** violations; tightening it to "not a comment, delimiter ends the line" still reported **211**. Both are defeated by `lib/command-match.test.sh`, which contains heredoc syntax as test DATA. A correct version needs a quote-aware bash walk.
3. **Behavioural — run each suite and reject bash's own `line N:` diagnostics on stderr** — the soundest, and too slow: **45** `*.test.sh` files under `.claude/hooks/`, and a sweep of all of them did not finish inside a **10-minute** timeout (the two suites here alone cost 8.1 s and 3.4 s).

Shipping a scanner with a known blind spot is worse than shipping none, per this repo's own checker rules, so the fix lands alone and the fence is filed with its evidence.

## Verification

- both hook suites: 24/0 and 23/0, stderr free of shell diagnostics
- generated-shim content asserted literally (above)
- `vp check --fix` + `vp run check`: 0 errors
- `vp run typecheck:test`, `vp run build`: pass
- `vp test run`: 856 files / 17,626 tests green
- rebased onto `origin/main` after go-to-k/cdkd#2420 landed mid-lane; no file overlap, and the changelog fence added by go-to-k/cdkd#2430 passes against that PR's fresh changelog entry — incidental evidence it does not false-positive on an ordinary append

Review tier: 8 LOC / 2 files, no security or provider path — `inline`.
