### PR TITLE
docs(providers): the S3 region guards are four, the Cloud Control pair disagree on purpose, and two pointers moved

### DIFF
--- a/.claude/rules/provider-resource-identity.md
+++ b/.claude/rules/provider-resource-identity.md
@@ -28,17 +28,25 @@ lesson that a probe wants exercising in BOTH directions) there, and
 `src/utils/aws-region-resolver.ts` for the fail-OPEN probe traps. Below is only
 what opening the provider will not tell you.
 
-**These guards are SDK-ROUTE-ONLY.** `AWS::S3::Bucket` declares silent-drop
-properties (`AccessControl`, still emitted by CDK's L1 for `accessControl:`), so
-`provider-registry.ts` auto-routes such a bucket to `CloudControlProvider` and
-pins `provisionedBy: 'cc-api'` STICKILY — the type is not in
-`STICKY_CC_MIGRATION_EXEMPT`. On that route `S3BucketProvider.delete` never runs
-at all: no probe, no refusal, no warning, and `CloudControlProvider`'s
-client-region `assertRegionMatch` cannot see a physical id naming a bucket
-elsewhere. One ordinary CDK property gets you there. Tracked as issue
-[#2283](https://github.com/go-to-k/cdkd/issues/2283) and NOT fixed by these
-guards — stated here because a rule file that overstates its coverage is worse
-than one that admits a hole.
+**These guards are SDK-ROUTE-ONLY, and the Cloud Control route has its OWN
+pair.** `AWS::S3::Bucket` declares silent-drop properties (`AccessControl`,
+still emitted by CDK's L1 for `accessControl:`), so `provider-registry.ts`
+auto-routes such a bucket to `CloudControlProvider` and pins
+`provisionedBy: 'cc-api'` STICKILY — the type is not in
+`STICKY_CC_MIGRATION_EXEMPT`. One ordinary CDK property gets you there, and on
+that route `S3BucketProvider.delete` never runs at all. That was issue
+[#2283](https://github.com/go-to-k/cdkd/issues/2283), and it is FIXED (PR
+[#2309](https://github.com/go-to-k/cdkd/issues/2309), extended by
+[#2378](https://github.com/go-to-k/cdkd/issues/2378)) — read
+`confirmDeleteTargetIdentity` and `assertRecordedRegionAgainstClient` in
+`cloud-control-provider.ts`. The one thing to carry across before reading them:
+they answer an INDETERMINATE region in OPPOSITE directions on purpose. The probe
+asks a remote service where a globally unique name lives, so it warns and
+PROCEEDS rather than stranding a role never granted `s3:GetBucketLocation`; the
+comparison is local against a positively recorded region, so it REFUSES. Its
+omission of `ExpectedBucketOwner` is deliberate for the same reason the SDK-side
+guards exist: the hazard is a foreign-account bucket, and passing the parameter
+would turn that collision into a 403 and thence into the proceed arm.
 
 **A guard reporting a failed probe names the error CLASS, never AWS's message,
 and the invariant is per-READER.** That message is not neutral text: on the

--- a/docs/provider-development.md
+++ b/docs/provider-development.md
@@ -1766,17 +1766,49 @@ it while reporting success (issue
 `S3BucketProvider.assertExistingBucketRegion` is the create-side twin of
 `assertRegionMatch`. It reads the bucket's region from the
 `x-amz-bucket-region` header on the 409 itself — no extra call, no extra IAM —
-and falls back to `GetBucketLocation`. Note the delete-side helper is a no-op
+and falls back to `GetBucketLocation`. Note `assertRegionMatch` is a no-op
 without `expectedRegion` while this one always has a region to compare against:
 the create knows where it is deploying.
+
+**There are FOUR of these guards, not two, and `assertRegionMatch` is only the
+generic one.** The two above are the SDK route; the Cloud Control route has its
+own pair, because a bucket declaring a silent-drop property (`AccessControl`) is
+auto-routed there and `S3BucketProvider.delete` never runs at all (issue
+[#2283](https://github.com/go-to-k/cdkd/issues/2283), fixed in
+[#2309](https://github.com/go-to-k/cdkd/issues/2309)):
+
+| Guard | Route / phase | On an INDETERMINATE answer |
+| --- | --- | --- |
+| `S3BucketProvider.assertExistingBucketRegion` | SDK, create | refuses |
+| `assertRegionMatch` (`src/provisioning/region-check.ts`) | generic, delete; update only where a provider opts in (`S3BucketProvider` alone today) | no-op without `expectedRegion` |
+| `CloudControlProvider.confirmDeleteTargetIdentity` | CC, delete, per-type (S3 today) | **warns and PROCEEDS** |
+| `CloudControlProvider.assertRecordedRegionAgainstClient` | CC, delete + update | **refuses** |
+
+The last two sit in the same file and answer indeterminacy in OPPOSITE
+directions, which is deliberate rather than an inconsistency. The probe asks a
+REMOTE service where a globally unique name lives, so a least-privilege role
+never granted `s3:GetBucketLocation` would be stranded by a refusal; the
+comparison is LOCAL and free against a region the caller positively recorded, so
+a client that cannot say where it points cannot be shown to point there. Two
+further details of the probe are decisions, not oversights: it is keyed on a
+per-type set rather than being generic, and it deliberately omits
+`ExpectedBucketOwner` — the opposite of the convention `state.ts` and
+`aws-region-resolver.ts` follow — because the hazard is a name resolving to a
+bucket in ANOTHER ACCOUNT, and the guard has to hear that foreign answer to
+refuse. Passing the parameter would turn every cross-account collision into a
+403, i.e. into the indeterminate arm, i.e. into warn-and-proceed.
 
 Deliberately NOT `HeadBucket`, which 301s cross-region and which SDK v3 turns
 into a synthetic `UnknownError` (`src/utils/aws-region-resolver.ts` records the
 mechanism), and deliberately not that module's `resolveBucketRegion`, which
 never throws and returns a fallback region — wiring it here would turn a
-fail-closed guard into a fail-open one. See `.claude/rules/providers.md` for
-the full rule, including the two legacy `GetBucketLocation` spellings the fold
-must absorb and why the refusal is `markNonRetryable`.
+fail-closed guard into a fail-open one. See
+`.claude/rules/provider-resource-identity.md` for the full rule, including the
+two legacy `GetBucketLocation` spellings the fold must absorb and why the
+refusal is `markNonRetryable`. (`.claude/rules/providers.md` is a routing index
+now — the rules corpus was split under its byte ceiling in issue
+[#2310](https://github.com/go-to-k/cdkd/issues/2310) — so it points on rather
+than carrying the rule itself.)
 
 That guard is scoped to the `BucketAlreadyOwnedByYou` catch on the CREATE path,
 which leaves two neighbouring routes to the wrong bucket that it cannot see —
@@ -1786,8 +1818,8 @@ before the guard existed (issue
 [#2245](https://github.com/go-to-k/cdkd/issues/2245)). `S3BucketProvider` now
 also pre-flights the bucket NAME before `CreateBucket` when the target region is
 `us-east-1`, and shares one `assertStateBucketRegion` between `update()` and
-`delete()`. `.claude/rules/providers.md` carries the mechanism and the three
-rules worth reusing: the pre-flight informs the partial-create CLEANUP GATE only
+`delete()`. `.claude/rules/provider-resource-identity.md` carries the mechanism
+and the three rules worth reusing: the pre-flight informs the partial-create CLEANUP GATE only
 and never replaces `CreateBucket` (the ownership oracle), an unanswered probe is
 kept distinct from a confirmed absence, and the state-record guard PROCEEDS on
 both rather than stranding every update and destroy for a least-privilege role.


### PR DESCRIPTION
Closes #2303

## What the issue said, and what re-measuring found

go-to-k/cdkd#2303 says there are THREE S3 region guards and that two prose files still describe two. Checked against `origin/main`, there are **four**, and the issue's second target file no longer exists in the shape it names.

| Guard | Route / phase | On an INDETERMINATE answer |
| --- | --- | --- |
| `S3BucketProvider.assertExistingBucketRegion` | SDK, create | refuses |
| `assertRegionMatch` (`src/provisioning/region-check.ts`) | generic, delete; update only where a provider opts in (`S3BucketProvider` alone today) | no-op without `expectedRegion` |
| `CloudControlProvider.confirmDeleteTargetIdentity` | CC, delete, per-type (S3 today) | **warns and PROCEEDS** |
| `CloudControlProvider.assertRecordedRegionAgainstClient` | CC, `pre-delete` / `pre-update` / `not-found` | **refuses** |

The count is the least interesting part. What a reader actually needs is that the **two Cloud Control guards answer indeterminacy in opposite directions**, deliberately: the probe asks a REMOTE service where a globally unique name lives, so refusing would strand a least-privilege role never granted `s3:GetBucketLocation`, while the comparison is LOCAL against a region the caller positively recorded. `docs/provider-development.md` now says that, along with why the probe omits `ExpectedBucketOwner` — the opposite of the convention `state.ts` and `aws-region-resolver.ts` follow — because the hazard is a name resolving to a bucket in another ACCOUNT and the guard has to hear the foreign answer. Passing the parameter would turn every cross-account collision into a 403, into the indeterminate arm, into warn-and-proceed.

## A stronger staleness the issue does not name

`.claude/rules/provider-resource-identity.md` said the Cloud Control hole is "tracked as issue go-to-k/cdkd#2283 and **NOT fixed** by these guards". go-to-k/cdkd#2283 closed 2026-08-27 via merged PR go-to-k/cdkd#2309, extended by go-to-k/cdkd#2378. That sentence is **actively false**, not merely incomplete — a strictly worse defect than the incompleteness this issue was filed for, and it sits under a heading claiming the file does not overstate its coverage.

Corrected to point at the two functions. That file states in its own header that it is short because of the `.claude/rules` corpus byte ceiling, so this stays a pointer rather than a second copy of the mechanism.

## Two broken cross-references, fixed in passing

`docs/provider-development.md` sent readers to `.claude/rules/providers.md` twice — for "the full rule, including the two legacy `GetBucketLocation` spellings … and why the refusal is `markNonRetryable`", and for "the mechanism and the three rules worth reusing". That file is a **115-line routing index** now; the rules corpus was split under its byte ceiling in go-to-k/cdkd#2310, and both bodies of content live in `provider-resource-identity.md`.

This is also why the issue's premise about `.claude/rules/providers.md` "carrying the same two-guard framing at around line 99" no longer holds — it was true when filed and the split moved it.

## Verification

Per the issue's own `## Verification (next session)` line, the check is that every claim in the new paragraphs resolves against source as it stands. Each was checked, not carried over from the issue:

- `region-check.ts:187` — `assertRegionMatch`'s early return when `!expectedRegion`, i.e. the no-op arm
- the three `assertRecordedRegionAgainstClient` call sites in `cloud-control-provider.ts` and their phase literals (`pre-update`, `pre-delete`, `not-found`) — which is what makes the "delete + update" claim accurate rather than assumed
- the `GetBucketLocationCommand` import and `bucketLocationToRegion` in `cloud-control-provider.ts`, plus the in-code comment stating the `ExpectedBucketOwner` omission is deliberate
- PRs go-to-k/cdkd#2309 and go-to-k/cdkd#2378 both `MERGED`; issue go-to-k/cdkd#2283 `CLOSED COMPLETED`

Plus the issue's named test: `mise exec -- vp test run tests/unit/scripts/rule-file-payload.test.ts` — 228 passed. Rules corpus 970,262 → **970,874 B** against a 985,000 B ceiling; the byte budget is not raised and `rule-file-payload.test.ts` is not edited.

`vp check --fix` + `vp run check`: 0 errors. `vp run typecheck:test`, `vp run build`: pass. `vp test run`: 856 files, two failures in the spawn-heavy "critic against the REAL tree" family, both green in isolation (179 tests) and neither reading a file this docs-only diff touches — the known multi-worktree contention flake.

No code change; every edit is prose. Review tier: `inline` by size, no security or provider-source path.
