### PR TITLE
chore(work-issues): port three LAUNCH_BRANCH fixes the sibling lane's third review round found

### DIFF
--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -295,7 +295,9 @@ shell, and an empty `git switch ""` is not the failure you want):
 
 ```bash
 git show-ref --verify --quiet refs/heads/<LAUNCH_BRANCH> || echo 'gone -> use the fallback'
-[ -z "$(git status --porcelain)" ] \
+DIRTY=$(git status --porcelain)
+[ -z "$DIRTY" ] || echo 'dirty -> commit or stash first, then re-run this block'
+[ -z "$DIRTY" ] \
   && git switch --no-guess <LAUNCH_BRANCH> \
   && git branch -D <each branch this run created>  # AS-IS: no pull, no rebase, no fast-forward
 git branch --show-current      # must print <LAUNCH_BRANCH>
@@ -317,7 +319,12 @@ below forbids — and it does so on exactly the path that was supposed to fall
 through to the fallback. `--no-guess` makes the missing branch an error instead.
 
 The dirty-tree check is a TEST, and it is the FIRST link of the chain rather
-than a line of its own. `git status --porcelain` exits 0 whether the tree is
+than a line of its own — with the outcome ANNOUNCED on the line above it,
+because a chain that simply stops produces no output at all. Making the test the
+chain head fixed one problem and introduced another: a dirty tree used to say
+`exit 1`, and silently doing nothing is a worse answer than either, one line
+below the `|| echo` that exists to keep the neighbouring command
+self-describing. `git status --porcelain` exits 0 whether the tree is
 dirty or clean, so `&&` cannot carry ITS verdict — the guard has to read the
 OUTPUT, which is what `[ -z ... ]` does. But having read it, the result must
 gate what follows: a reader copies a line, not its intent, and an unchained

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -119,7 +119,7 @@ const MEASURED: Record<string, { corpusBytes: number; largest: { file: string; b
   // against work-issues' numbers -- permanently red, with a message naming the
   // wrong file.
   'work-issues': {
-    corpusBytes: 241_365,
+    corpusBytes: 241_829,
     largest: { file: 'implement.md', bytes: 48_340 },
     runnerUp: { file: 'verify.md', bytes: 44_410 },
   },

--- a/tests/unit/scripts/work-issues-launch-mode.test.ts
+++ b/tests/unit/scripts/work-issues-launch-mode.test.ts
@@ -316,7 +316,9 @@ describe('work-issues launch-mode probe', () => {
     // equality subsumes it.
     const PRESCRIBED = [
       "git show-ref --verify --quiet refs/heads/<LAUNCH_BRANCH> || echo 'gone -> use the fallback'",
-      '[ -z "$(git status --porcelain)" ] \\',
+      'DIRTY=$(git status --porcelain)',
+      "[ -z \"$DIRTY\" ] || echo 'dirty -> commit or stash first, then re-run this block'",
+      '[ -z "$DIRTY" ] \\',
       '&& git switch --no-guess <LAUNCH_BRANCH> \\',
       '&& git branch -D <each branch this run created>',
       'git branch --show-current',
@@ -550,10 +552,21 @@ describe('work-issues launch-mode probe', () => {
       // an injected `git -C "<LANE_TREE>" branch -D <LAUNCH_BRANCH>` there pass
       // green (measured). The set of files that MENTION the command is wider
       // than the set that DEFINES it, and it is the mention that misleads.
+      // A carve-out for prose that WARNS AGAINST the very command it names.
+      // Without it the scan forbids the skill from documenting its own hazard --
+      // "Never `git reset --hard` while `LAUNCH_BRANCH` is checked out" reads as
+      // a violation -- which is a fence that blocks the correct edit. Scoped to a
+      // NEGATION in the same sentence, the same shape the fast-forward polarity
+      // check uses, so it cannot be satisfied by an approving mention.
+      const FORBIDS = /\b(never|do not|don't|must not|cannot|no verb may|forbidden)\b/i;
       const hits = skillDocs()
-        .map((doc) => ({ doc, hit: MOVING.exec(read(doc))?.[0] }))
-        .filter((r) => r.hit)
-        .map((r) => `${r.doc}: ${r.hit}`);
+        .flatMap((doc) =>
+          read(doc)
+            .replace(/\s*\n\s*/g, ' ')
+            .split(/(?<=\.)\s+/)
+            .filter((sent) => MOVING.test(sent) && !FORBIDS.test(sent))
+            .map((sent) => `${doc}: ${MOVING.exec(sent)?.[0]}`)
+        );
       expect(
         hits,
         `A skill doc aims a branch-moving verb at LAUNCH_BRANCH. That branch is the outer ` +

--- a/tests/unit/scripts/work-issues-launch-mode.test.ts
+++ b/tests/unit/scripts/work-issues-launch-mode.test.ts
@@ -184,7 +184,20 @@ export function commandLines(block: string): string[] {
       const c = line[i]!;
       if (quote) {
         if (c === quote) quote = null;
-      } else if (c === '"' || c === "'") {
+      } else if (c === '"') {
+        quote = c;
+      } else if (c === "'" && /(^|[\s=(])'/.test(line.slice(Math.max(0, i - 1), i + 1))) {
+        // A single quote OPENS a string only where a string can START -- at the
+        // line's beginning or after whitespace / `=` / `(`. Treating every `'`
+        // as an opener makes an APOSTROPHE INSIDE A WORD ("the tool's branch")
+        // open a string that never closes, so every `#` after it looks quoted
+        // and the trailing comment is never stripped. The caller then compares
+        // the comment-bearing line against the prescribed command and reports a
+        // mismatch for an edit that was fine -- a false FAILURE, which is the
+        // expensive direction for a fence nobody expects to be wrong.
+        // Found on the go-to-k/cdk-local#651 sibling lane, whose copy of this
+        // helper had the same defect (go-to-k/cdkd#2432 shipped it here).
+        // A double quote needs no such rule: `"` does not appear inside words.
         quote = c;
       } else if (c === '#' && i > 0 && /\s/.test(line[i - 1]!)) {
         return line.slice(0, i);
@@ -471,6 +484,36 @@ describe('work-issues launch-mode probe', () => {
     // branches again in the same tree) or never restores at all.
     expect(read(join('references', 'ship.md'))).toMatch(/runs LAST, not per-lane/);
     expect(read(join('references', 'retro.md'))).toMatch(/LAST step of the whole run/);
+  });
+
+  describe('commandLines() -- the helper every block fence reads through', () => {
+    // Direct tests, because until now this helper was exercised only INCIDENTALLY
+    // by whatever the two fenced blocks happened to contain. That is enough to
+    // notice it crashing and not enough to notice it mis-parsing: a helper that
+    // silently keeps a trailing comment makes the ordered-equality fence above
+    // report a mismatch for an edit that was correct, and the failure names the
+    // BLOCK rather than the parser.
+    it.each([
+      ['git status --porcelain   # plain trailing comment', 'git status --porcelain'],
+      // The regression: an apostrophe inside a word is not a string opener.
+      ["echo the tool's name   # a real comment", "echo the tool's name"],
+      // ...while a real single-quoted string still hides a `#`.
+      ["git commit -m 'closes #651'", "git commit -m 'closes #651'"],
+      ['git commit -m "closes #651"', 'git commit -m "closes #651"'],
+      ["git branch --list '<your prefix>*'   # trailing", "git branch --list '<your prefix>*'"],
+      ['git switch --no-guess <LAUNCH_BRANCH>', 'git switch --no-guess <LAUNCH_BRANCH>'],
+      // `#` needs preceding whitespace to start a comment, or `refs/heads/#1`
+      // style arguments would be truncated.
+      ['git show-ref --verify refs/heads/x#y', 'git show-ref --verify refs/heads/x#y'],
+    ])('parses %j', (line, expected) => {
+      expect(commandLines(line)).toEqual([expected]);
+    });
+
+    it('drops blank lines and whole-line comments', () => {
+      expect(commandLines('# a heading\n\ngit status --porcelain\n')).toEqual([
+        'git status --porcelain',
+      ]);
+    });
   });
 
   describe('the withdrawn fast-forward cannot come back anywhere', () => {


### PR DESCRIPTION
Three small fixes to the `/work-issues` LAUNCH_BRANCH machinery that go-to-k/cdkd#2432 shipped hours earlier. All three were found on the go-to-k/cdk-local#651 sibling lane, whose copy of the same code got a third review round; porting them keeps the two repos from diverging.

## 1. An apostrophe inside a word is not a string opener

`commandLines()` strips a trailing `# comment` from each line of a fenced block, quote-aware so a `#` inside a string survives. But it treated EVERY `'` as opening a string, so an apostrophe inside an ordinary word opened one that never closed:

```
echo the tool's name   # a real comment
                ^ opens a "string" that runs to end of line
```

Every `#` after it looked quoted, the comment was never stripped, and the caller then compared the comment-bearing line against the prescribed command and reported a mismatch.

That is a false FAILURE, the expensive direction for a fence: the message names the BLOCK, not the parser, so the next author reads "my recipe is wrong" and edits a recipe that was correct. No current block trips it — every apostrophe in them is paired — which is exactly why it would have sat there until someone wrote a comment with a possessive in it.

A single quote now opens a string only where one can START: line beginning, or after whitespace / `=` / `(`. A double quote needs no such rule, since `"` does not occur inside words.

The helper also gains DIRECT tests. Until now it was exercised only INCIDENTALLY by whatever the two fenced blocks happened to contain — enough to notice it crashing, not enough to notice it mis-parsing, which is the failure it actually has. Seven cases: plain comment, apostrophe-in-word, `#` inside single and double quotes, quoted argument plus comment, no comment, and `refs/heads/x#y` (a `#` without preceding whitespace is not a comment).

## 2. A dirty tree now says so

Making the dirty-tree test the first link of the restore chain (go-to-k/cdkd#2432) fixed one problem and introduced another: `|| exit 1` at least produced a shell error, whereas a chain whose head is false produces NOTHING — one line below the `|| echo` that exists to keep the neighbouring command self-describing. The test now runs once into `DIRTY`, announces the outcome, and gates the chain on the same value, so there is one `git status` call and no silent no-op.

## 3. The moving-verb scan no longer forbids the skill from documenting its own hazard

go-to-k/cdkd#2432's corpus-wide scan flags any branch-moving verb aimed at `LAUNCH_BRANCH` in ANY context — comment, prose or code — which is what makes it useful. But it also flagged prose WARNING against the command it names, so ``Never `git reset --hard` while `LAUNCH_BRANCH` is checked out`` read as a violation. A fence that blocks the correct edit is one the next person weakens.

The carve-out is scoped to a NEGATION in the same sentence — the shape the fast-forward polarity check already uses — so an approving mention cannot satisfy it. Probed both ways: the warning above passes; ``If it is behind, run `git reset --hard origin/main` on `LAUNCH_BRANCH``` fails.

## Verification

Mutation-probed each change: reverting the quote rule fails the apostrophe case and nothing else; the ordered-equality fence caught the recipe change while it was mid-edit; the carve-out was probed in both directions. Full suite 858 files / 17,736 tests green.
