### PR TITLE
chore(work-issues): a negation in the neighbourhood is not a prohibition

### DIFF
--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -386,6 +386,11 @@ branch was already a lane before this run touched it: restore it anyway (it is
 still not yours to move) and say so in the wrap, because the warning you then see
 is about the outer tool's work, not yours.
 
+Concretely, and stated so the fence has prose to permit: never `git pull` into
+`<LAUNCH_BRANCH>`, never `git merge --ff-only origin/main` onto it, never
+`git rebase <LAUNCH_BRANCH>`, and never `git branch -D <LAUNCH_BRANCH>`. The
+branch is not yours to move, and it is not yours to remove.
+
 **AS-IS is the whole rule: RESTORE, never ADJUST.** The first draft of this step
 fast-forwarded `LAUNCH_BRANCH` to `origin/main` on the way back, so it would not
 be left "stale"; that clause is WITHDRAWN. The tree and the branch are the outer

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -119,7 +119,7 @@ const MEASURED: Record<string, { corpusBytes: number; largest: { file: string; b
   // against work-issues' numbers -- permanently red, with a message naming the
   // wrong file.
   'work-issues': {
-    corpusBytes: 241_829,
+    corpusBytes: 242_120,
     largest: { file: 'implement.md', bytes: 48_340 },
     runnerUp: { file: 'verify.md', bytes: 44_410 },
   },

--- a/tests/unit/scripts/work-issues-launch-mode.test.ts
+++ b/tests/unit/scripts/work-issues-launch-mode.test.ts
@@ -570,7 +570,17 @@ describe('work-issues launch-mode probe', () => {
       // `git branch -f <LAUNCH_BRANCH> origin/main` added to a launch-mode.md
       // block was NOT caught. The restore and fallback blocks are covered by
       // their ordered equality; every OTHER block in every OTHER file was not.
-      const FORBIDS = /\b(never|do not|don't|must not|cannot|no verb may|forbidden)\b/i;
+      // The carve-out is a NEGATION IMMEDIATELY BEFORE the command, not a marker
+      // loose in the surrounding text. Measured on the go-to-k/cdk-local#651
+      // sibling, whose round-3 version allowed the marker anywhere in the clause:
+      // eleven PRESCRIPTIVE sentences its previous form had flagged became exempt,
+      // including the composite mutant's own
+      // `git branch --force <LAUNCH_BRANCH> origin/main`. The same held here with a
+      // narrower set -- "Clean up with `git branch -D <LAUNCH_BRANCH>` -- you
+      // cannot leave it dangling" spent the exemption on a `cannot` that negated
+      // something else entirely. A word in the neighbourhood is not a prohibition;
+      // a word in FRONT of the verb is.
+      const FORBIDS = /\b(never|do not|don't|must not|no verb may)\b[^.\n]{0,24}$/i;
       const fenced = /^[ \t]*```[\s\S]*?^[ \t]*```/gm;
       const hits = skillDocs().flatMap((doc) => {
         const text = read(doc);
@@ -578,12 +588,21 @@ describe('work-issues launch-mode probe', () => {
           .flatMap((block) => block.split('\n'))
           .filter((line) => MOVING.test(line))
           .map((line) => `${doc} [code]: ${MOVING.exec(line)?.[0]}`);
+        // Windows are bounded by PARAGRAPHS and by TABLE ROWS as well as by
+        // sentences. A markdown table contains no sentence-ending period, so
+        // splitting on `.` alone makes an entire table one window and lets any
+        // row's wording carve every other row -- the same over-joining that made
+        // a whole fenced block inherit one exemption (go-to-k/cdkd#2448).
         const inProse = text
           .replace(fenced, '')
-          .replace(/\s*\n\s*/g, ' ')
-          .split(/(?<=\.)\s+/)
-          .filter((sent) => MOVING.test(sent) && !FORBIDS.test(sent))
-          .map((sent) => `${doc} [prose]: ${MOVING.exec(sent)?.[0]}`);
+          .split(/\n{2,}|(?=^[ \t]*\|)|(?<=\|[ \t]*)$/m)
+          .flatMap((para) => para.replace(/\s*\n\s*/g, ' ').split(/(?<=\.)\s+/))
+          .flatMap((win) => {
+            const hit = MOVING.exec(win);
+            if (!hit) return [];
+            // Adjacency: does a prohibition sit immediately in front of THIS match?
+            return FORBIDS.test(win.slice(0, hit.index)) ? [] : [`${doc} [prose]: ${hit[0]}`];
+          });
         return [...inCode, ...inProse];
       });
       expect(


### PR DESCRIPTION
Closes the last of the carve-out defects the go-to-k/cdk-local#651 sibling's fourth review round surfaced. Same class as go-to-k/cdkd#2448, one level finer.

## A negation in the neighbourhood is not a prohibition

go-to-k/cdkd#2446 added a carve-out so the skill could document its own hazard, and go-to-k/cdkd#2448 stopped it leaking into code blocks. It still let the marker sit ANYWHERE in the window, so a PRESCRIPTIVE sentence carrying an unrelated negation went unflagged:

```
Clean up with `git branch -D <LAUNCH_BRANCH>` -- you cannot leave it dangling.
```

The `cannot` negates the dangling, not the delete. The sibling's review measured eleven such strings becoming exempt once its marker set widened — including the composite mutant's own `git branch --force <LAUNCH_BRANCH> origin/main`. This repo's set was narrower, so it lost less, but the shape was identical.

The carve-out now requires the negation **immediately in front of the match**, and the loosest markers are dropped.

## Windows are bounded by tables too, not just sentences

A markdown table has no sentence-ending period, so splitting on `.` alone made an entire table ONE window and let any row's wording carve every other row — the same over-joining that let a fenced block inherit one exemption in go-to-k/cdkd#2448. Windows now break on paragraphs and on table rows as well.

## …which made the carve-out inert, so section 9 now names the banned commands

With both fixes in, nothing left in the corpus legitimately needed the carve-out — deleting the wiring stayed green. That is the "degradation probe becomes a gap" shape: a decorative exemption that no test can tell from a missing one.

So `references/ship.md` now says outright: never `git pull` into `<LAUNCH_BRANCH>`, never `git merge --ff-only origin/main` onto it, never `git rebase`, never `git branch -D <LAUNCH_BRANCH>`. That is exactly the prose the carve-out exists to permit, it is worth stating regardless, and deleting the wiring is red again.

## Probes

| case | expected | result |
|---|---|---|
| carve-out wiring deleted | red (load-bearing) | red |
| ``Clean up with `git branch -D <LAUNCH_BRANCH>` -- you cannot leave it dangling`` | red (prescriptive) | red |
| ``Do not `git reset --hard origin/main` on `LAUNCH_BRANCH``` | green (genuine warning) | green |

Full suite: 866 files / 17,810 tests green.
