### PR TITLE
chore(work-issues): three lessons from the 2026-09-02 three-repo run

### DIFF
--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -189,7 +189,15 @@ Every run appending one more bullet is exactly how a long skill becomes an unrea
   lessons filed twenty minutes apart by two hops):
   - **The session that FINDS the lesson lands all three** — the default, not
     the ambitious option; the narrow exception (cannot pay the remaining gate
-    cycles) is justified in the wrap.
+    cycles) is justified in the wrap. Land the mirror BEFORE the original's
+    review rounds are finished, not after: the mirror gets its own reviewers,
+    and they read the same design with none of the original's momentum behind
+    it. Measured 2026-09-02 — the cdk-local port's reviewers found an unchained
+    `git branch -D` that deletes on a FAILED switch, and a quote-parsing bug,
+    BOTH in code cdkd had already merged past a three-axis panel; cdkd's found
+    a `git switch` DWIM the port had inherited. Neither repo alone would have
+    caught both, so the mirror is a second review pass that happens to also be
+    the deliverable.
   - **Filing a mirror issue covers the WHOLE remainder, in one turn** — file
     into EVERY repo still missing it at once, each issue naming the other
     filings plus the repo already landed; partial filing produced the pairs above.

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -141,8 +141,20 @@ output: a grep over a check log that keeps only error lines reports a dirty
 tree as clean.
 
 ```bash
-gh pr merge <n> --squash --delete-branch     # squash is the repo's only method
+gh pr merge <n> -R <owner>/<repo> --squash --delete-branch   # squash is the only method here
 ```
+
+**`-R` is not optional in a run that touches more than one repo.** Without it
+`gh` infers the repo from the CWD, and a cwd persists across Bash calls — so a
+merge issued after any earlier `cd` into a sibling checkout targets THAT repo.
+Measured 2026-09-02: `gh pr merge 2432` ran against cdk-local because a marker
+check had left the shell there, and it failed only because no PR 2432 existed
+in that repo. Had one existed, the wrong PR would have merged. The error it
+gives is `Could not resolve to a PullRequest with the number of <n>`, which
+reads as a GitHub or permissions problem and sends you to the wrong diagnosis
+entirely. Pass `-R` on EVERY `gh` call in a multi-repo run — `pr view`,
+`pr checks` and `issue comment` mis-target just as silently, they just fail
+less loudly.
 
 (**`--delete-branch` prints a bare `fatal:` line and the merge SUCCEEDED
 anyway — read it as the expected artifact, not a failed merge.** Run from the

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -138,6 +138,22 @@ markers.
   a delta round's blocker was a commit message citing a function that has
   never existed in this repo, reachable only because the orchestrator re-read
   the message itself.
+- **An EXEMPTION is the highest-risk edit a fence can receive, and every round
+  that adds one should probe it in both directions before the round ends.** A
+  carve-out is added to stop a false positive, which means it is written while
+  agreeing that the fence was WRONG — the exact posture in which nobody asks
+  what it now lets through. Measured across one change on 2026-09-02, where
+  three consecutive delta rounds each found the round before it had traded a
+  crude fence for a token-spendable escape: a line-wide `--no-guess` skip that a
+  mention anywhere on the line could buy; a clause-wide negation marker that
+  exempted ELEVEN prescriptive sentences the bare form had flagged, including
+  the composite mutant's own command; and a sentence-scoped one that made an
+  entire fenced code block inherit one exemption. Two questions close it, and
+  both are cheap: does a PRESCRIPTIVE use of the same words spend the exemption
+  (probe one), and is the exemption LOAD-BEARING at all — delete its wiring and
+  the suite must go red, or it is indistinguishable from a fence that never had
+  it. The second question is the one that gets skipped: a decorative carve-out
+  reads as caution and is a gap.
 - **Reviewer subagents spawned BY A LANE report to the MAIN session, not to
   the lane that spawned them.** Completion notifications go to the top-level
   session, so a lane that dispatches reviewers and then waits on their reports

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -119,9 +119,9 @@ const MEASURED: Record<string, { corpusBytes: number; largest: { file: string; b
   // against work-issues' numbers -- permanently red, with a message naming the
   // wrong file.
   'work-issues': {
-    corpusBytes: 242_120,
+    corpusBytes: 244_747,
     largest: { file: 'implement.md', bytes: 48_340 },
-    runnerUp: { file: 'verify.md', bytes: 44_410 },
+    runnerUp: { file: 'verify.md', bytes: 45_623 },
   },
 };
 
@@ -137,7 +137,7 @@ const MIN_REFERENCE_FILES = 6;
 // number is the pre-merge one). The inputs are in MEASURED below and asserted,
 // so only the REASONING lives here: the floor must clear `corpus - largest`,
 // and also `corpus - runnerUp` for the day the two swap places (they have
-// swapped once already). 202_000 clears them by ~9.6k and ~5.7k -- the pair the
+// swapped once already). 203_000 clears them by ~6.6k and ~3.9k -- the pair the
 // 180_000 it replaces was sized to hold -- is strictly TIGHTER than that value
 // (no upper bound is touched), and leaves ~41 KB of narrative compression
 // headroom below it.
@@ -152,7 +152,7 @@ const MIN_REFERENCE_FILES = 6;
 //
 // What this floor does NOT catch, stated plainly because the comment used to
 // imply otherwise: gutting a NON-largest stage file. Deleting the whole of
-// triage.md (38,974 B) would leave 202,080 B -- which the CURRENT floor happens to
+// triage.md (38,974 B) would leave 205,773 B -- which the CURRENT floor happens to
 // catch, by where it landed rather than by design; a smaller file gutted the
 // same way still slips through. A byte floor
 // cannot see that, and raising it until it could would forbid legitimate
@@ -160,7 +160,7 @@ const MIN_REFERENCE_FILES = 6;
 // than size: work-issues-skill-refs.test.ts pins the document COUNT, and
 // work-issues-launch-mode.test.ts pins that each arm-bearing stage file still
 // names the mode it branches on and that the probe still exists exactly once.
-const MIN_REFERENCE_CORPUS_BYTES = 202_000;
+const MIN_REFERENCE_CORPUS_BYTES = 203_000;
 
 function skillNames(): string[] {
   return readdirSync(skillsDir, { withFileTypes: true })


### PR DESCRIPTION
Stage-10 retro for the run that landed the LAUNCH_BRANCH restore contract across cdkd, go-to-k/cdk-local#651 and go-to-k/cdk-real-drift#1854. Three lessons, each into the stage file where it fires.

## `gh` infers the repo from the CWD — and a cwd persists

`references/ship.md` section 9's merge line now carries `-R <owner>/<repo>`, with the reason.

In a run touching more than one repository this is a wrong-repo merge waiting to happen. Measured here: `gh pr merge 2432` ran against **cdk-local**, because an earlier marker check had left the shell in that checkout. It failed only because no PR of that number existed there — had one existed, the wrong PR would have merged. And the error it gives, `Could not resolve to a PullRequest with the number of <n>`, reads as a GitHub or permissions problem, so the natural next step is to go looking in entirely the wrong place.

## An exemption is the highest-risk edit a fence can receive

`references/verify.md` section 8 now asks two questions of every carve-out a review round adds.

A carve-out is written while agreeing the fence was WRONG, which is the exact posture in which nobody asks what it now lets through. Three consecutive delta rounds in this run each found the round before it had traded a crude fence for a token-spendable escape:

- a line-wide `--no-guess` skip that any mention on the line could buy;
- a clause-wide negation marker that exempted **eleven** prescriptive sentences the bare form had flagged, including the composite mutant's own `git branch --force <LAUNCH_BRANCH> origin/main`;
- a sentence-scoped one that made an entire fenced code block inherit a single exemption.

Two questions close it and both are cheap: does a PRESCRIPTIVE use of the same words spend the exemption, and is the exemption **load-bearing** at all — delete its wiring and the suite must go red. The second is the one that gets skipped, and a decorative carve-out reads as caution while being a gap.

## Land the mirror before the original's review ends

`references/retro.md` section 10-c's mirror rule gains the ordering and the reason.

The mirror gets its own reviewers, who read the same design with none of the original's momentum behind it. Here the cdk-local port's reviewers found an unchained `git branch -D` that deletes on a FAILED switch, and a quote-parsing bug — **both in code cdkd had already merged past a three-axis panel** — while cdkd's reviewers found a `git switch` DWIM the port had inherited. Neither repo alone would have caught both. The mirror is a second review pass that happens to also be the deliverable.

## Byte budget

`MIN_REFERENCE_CORPUS_BYTES` 202,000 to 203,000, re-derived at the final tree: corpus 244,747 B, largest `implement.md` 48,340 B, runner-up `verify.md` 45,623 B, so the floor clears the binding case by 6,593 B and the either-largest case by 3,876 B, leaving 41,747 B of compression headroom. `MEASURED` asserts all three against the tree.

## Backlog effect (section 10-0)

3 issues claimed and all 3 closed (this repo's go-to-k/cdkd#2417, go-to-k/cdk-local#651, go-to-k/cdk-real-drift#1858's sibling go-to-k/cdk-real-drift#1854); 4 filed and open (go-to-k/cdkd#2424, go-to-k/cdkd#2433, go-to-k/cdk-local#665, go-to-k/cdk-real-drift#1858). Net +1 across three repos.

Full suite: 866 files / 17,810 tests green.
