### PR TITLE
chore(work-issues): a fix that closes a member falsifies the prose counting it, and a renamed LAUNCH_BRANCH leaves nothing to restore

### DIFF
--- a/.claude/skills/work-issues/references/launch-mode.md
+++ b/.claude/skills/work-issues/references/launch-mode.md
@@ -69,13 +69,39 @@ value exists to name (what to put back) is gone. MAIN-CHECKOUT records it and
 does nothing with it: the run never leaves the main checkout, so §9's restore
 arm does not fire there.
 
-**IN-PLACE, `LAUNCH_BRANCH` is a branch to PUT BACK, never one to commit to.**
-§5 branches in place off `origin/main` instead of committing onto it, and the
-reason is not tidiness: `gh pr merge --delete-branch` (§9) deletes the REMOTE
-branch the PR was opened from, so a lane that worked directly on the outer
-tool's branch would delete the outer tool's branch on the way out — a far
-heavier interference than the detached HEAD this whole rule exists to avoid.
-The lane owns its own branch and deletes only that one.
+**IN-PLACE, `LAUNCH_BRANCH` is a branch to PUT BACK, never one to commit to —
+and never one to RENAME.** §5 branches in place off `origin/main` instead of
+committing onto it, and the reason is not tidiness: `gh pr merge
+--delete-branch` (§9) deletes the REMOTE branch the PR was opened from, so a
+lane that worked directly on the outer tool's branch would delete the outer
+tool's branch on the way out — a far heavier interference than the detached HEAD
+this whole rule exists to avoid. The lane owns its own branch and deletes only
+that one.
+
+**A RENAME is the trap, because it looks like taking a lane branch and is
+cheaper than one** — no fetch, no switch, the tree does not move — and it
+DESTROYS the restore target rather than borrowing it: `git branch -m` leaves the
+old name nowhere, local or remote, so §9's `show-ref` finds nothing and the run
+falls through to the detach fallback, the end state ship.md withdrew the same
+day for being visible-surprising in the outer tool's UI. Measured 2026-09-02:
+SIX workspaces renamed their launch branch away between 15:31 and 15:38 local —
+this run's `go-to-k/hawkfish` at 15:34 among them, and three of the six were
+renamed a SECOND time within the next thirteen minutes. A habit, not a slip.
+Only `git switch -c <lane> origin/main` gets you the lane branch.
+
+**The outer tool renames too, so `show-ref` before the restore is mandatory
+rather than defensive** — Orca derives a workspace branch name from a session's
+FIRST PROMPT and can rename a tree out from under a recorded value
+(go-to-k/cdkd#2413). Recovery either way is the reflog, which records the old
+name and the sha it pointed at:
+
+```bash
+git reflog --all --date=iso | grep -i 'Branch: renamed'   # the old name + its sha
+git branch <LAUNCH_BRANCH> <that sha>                     # re-create, then §9 restores
+```
+
+Run that BEFORE §9's `git branch -D <lane>`: a branch's own reflog is deleted
+with the branch, so after the delete the rename survives only in HEAD's copy.
 
 **The guard on the first line is not decoration.** Outside a work tree every
 `git rev-parse` fails and each substitution collapses to the empty string, so

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -83,6 +83,17 @@ FALSE when the state resolves (2026-08-26: a fifth-review-round deferral reason
 survived into the wrap after that PR merged). Keeping a `next` alive on an
 expired reason is not protected by classify-once.
 
+**When a hit CONTRADICTS the body's own reason, the BODY is the stale side, not
+the check.** A reason asserting NO FILE OVERLAP is a claim about a MOVING
+target — the lane keeps editing after the reason is written, and nothing
+re-reads it. Measured 2026-09-02: go-to-k/cdkd#2440 was deferred on
+"`src/local/docker-runner.ts` has no overlap with this session's lanes
+(go-to-k/cdkd#2410 changed no line of it)", and go-to-k/cdkd#2410's merged PR
+changed that file `+9/-2`. So prefer a reason the lane cannot falsify by
+carrying on (what the work NEEDS: a new fixture, an upstream release, a
+maintainer call), correct the issue when this check catches one, and judge the
+item on whatever survives.
+
 Then split the filed count by what the section 5 window did with each finding —
 the aggregate cannot tell the two apart and they mean opposite things:
 

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -129,6 +129,29 @@ returned **18** that day — the check was vacuous. Take the phrase from YOUR
 entry's own subject and prove it absent from main's copy before counting. The
 third line re-checks the paragraph above.
 
+**A GENERATED file in a conflict is REGENERATED, never hand-merged.** Resolve
+it however lets the generator run, then re-run the generator and commit ITS
+output — a hand-merge produces a file matching NEITHER side, which the staleness
+guard rejects with a diff nobody wrote and no generator can explain. Measured
+2026-09-02 on go-to-k/cdkd#2441: `docs/cli-flag-coverage.md` conflicted on a
+parallel-lane rebase, and resolve-to-upstream + regenerate was the only clean
+answer.
+
+**Take upstream's side whole only when the generator DERIVES the file from the
+tree**, which is the usual case (the coverage matrices, the flag matrix) and the
+one where your side carries no information the regenerate cannot recompute. The
+integ ledger is the exception, and the paragraph below is about exactly that:
+its rows record real-AWS RUNS, so upstream-whole would silently drop this lane's
+own row — there it is keep-both, then normalize.
+
+**And know what the generator's INPUT actually is — it is wider than the
+artifact suggests.** The same PR went red having added no flag and touched no
+CLI option declaration: adding a `cdkd list --verbose` assertion to
+`tests/integration/local-invoke/verify.sh` was enough, because the FIXTURE TREE
+is an input to `docs/_generated/cli-flag-coverage.json` alongside
+`src/cli/options.ts`. Regenerate in the same commit as the fixture edit, or CI
+reports the staleness two steps away from its cause.
+
 **The integ ledger is the OTHER generated file a parallel-lane rebase merges,
 and it fails in a different shape:** keeping both sides yields two rows for
 the SAME test, which `docs/_generated/integ-last-run.tsv`'s one-row-per-test

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -103,6 +103,29 @@ probes it, and build the arm that does before quoting a zero.
   real cost was quadratic on large input). Confirm the probe reaches the
   added code, as §5 requires of a mutation probe.
 
+**A round's fix that CLOSES a member falsifies every sentence that COUNTS the
+set — the direction nobody checks, because the fix itself is CORRECT.** Prose is
+a reader too (bullet above) and the one whose staleness a diff cannot show: the
+member LEAVES in the diff, while the counter that still includes it sits in a
+file the diff never touches. Measured four times in ONE run (2026-09-02,
+go-to-k/cdkd#2410 / go-to-k/cdkd#2275): closing `spawnStreaming` left six sites
+saying "THREE mechanisms still reach stdout"; closing `spawnForeground` made the
+corrected count wrong again; `logger.ts`'s caller registry said "four" once
+`state list` became the fifth; and `docs/cli-reference.md` said "nothing is
+locked on the refusing path" while four commands hold a lock there. A REVIEWER
+caught every one and the author none. A fence's own comment is the same surface,
+and its coverage claim is TESTABLE: one asserting it missed only PROSE missed
+five CODE spellings, among them an aliased import that no needle on the name can
+reach by construction.
+
+```bash
+# The counters sit OUTSIDE the diff, which is why re-reading the diff misses them.
+grep -rn "<the set's noun, then its cardinal>" src/ docs/ .claude/
+```
+
+NAME the member you closed where the count lives; a silent renumber is what
+makes the next reader re-file it.
+
 **Run the integ LAST — after the final edit to any gate-scoped file, not after
 the final edit you happened to think of.** Review nits landing in gate scope
 stale the marker: 2026-08-25 cost two real-AWS re-runs (go-to-k/cdkd#2189, a

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -119,9 +119,9 @@ const MEASURED: Record<string, { corpusBytes: number; largest: { file: string; b
   // against work-issues' numbers -- permanently red, with a message naming the
   // wrong file.
   'work-issues': {
-    corpusBytes: 244_747,
+    corpusBytes: 249_677,
     largest: { file: 'implement.md', bytes: 48_340 },
-    runnerUp: { file: 'verify.md', bytes: 45_623 },
+    runnerUp: { file: 'verify.md', bytes: 46_945 },
   },
 };
 
@@ -137,30 +137,47 @@ const MIN_REFERENCE_FILES = 6;
 // number is the pre-merge one). The inputs are in MEASURED below and asserted,
 // so only the REASONING lives here: the floor must clear `corpus - largest`,
 // and also `corpus - runnerUp` for the day the two swap places (they have
-// swapped once already). 203_000 clears them by ~6.6k and ~3.9k -- the pair the
-// 180_000 it replaces was sized to hold -- is strictly TIGHTER than that value
-// (no upper bound is touched), and leaves ~41 KB of narrative compression
+// swapped once already). 206_000 clears them by ~4.7k and ~3.3k -- the pair the
+// 203_000 it replaces was sized to hold -- is strictly TIGHTER than that value
+// (no upper bound is touched), and leaves ~44 KB of narrative compression
 // headroom below it.
 //
-// The EITHER-LARGEST margin is the one that erodes, and this run is why the
-// warning is here rather than in a commit message: it grew SEVEN non-leader
-// stage files, which moves `corpus - runnerUp` up without moving the leader at
-// all, and the floor had to be re-derived FOUR times inside one change as
-// successive review rounds landed. If you are adding to a stage file that is
+// The EITHER-LARGEST margin is the one that erodes, and the go-to-k/cdkd#2417
+// run is why the warning is here rather than in a commit message: it grew SEVEN
+// non-leader stage files, which moves `corpus - runnerUp` up without moving the
+// leader at all, and the floor had to be re-derived FOUR times inside one change
+// as successive review rounds landed. If you are adding to a stage file that is
 // not the largest, expect to re-derive this line -- and MEASURED will tell you
 // so rather than letting it slide.
 //
+// Which HALF a growth spends is not intuitive, and the retro of the
+// go-to-k/cdkd#2410 / go-to-k/cdkd#2275 run got it wrong in this very comment
+// before a reviewer re-derived it. Growing the RUNNER-UP moves `corpus` and
+// `runnerUp` by the same amount, so it leaves `corpus - runnerUp` UNCHANGED and
+// spends only the binding (largest-side) margin; the either-largest margin is
+// spent by growth in every OTHER file. That run added 1,322 B to verify.md and
+// 3,608 B across launch-mode / retro / ship, and it is the SECOND number that
+// moved the either-largest margin -- from 3,876 B under the old 203_000 floor
+// to 268 B -- and forced this raise.
+//
+// The two leaders are now 1,395 B apart -- less than that run's single 1,322 B
+// edit to the runner-up -- so "the day the two swap places" is one ordinary
+// stage-file edit away, not hypothetical. MEASURED names both files, so a swap
+// reds it rather than passing quietly.
+//
 // What this floor does NOT catch, stated plainly because the comment used to
 // imply otherwise: gutting a NON-largest stage file. Deleting the whole of
-// triage.md (38,974 B) would leave 205,773 B -- which the CURRENT floor happens to
-// catch, by where it landed rather than by design; a smaller file gutted the
-// same way still slips through. A byte floor
+// triage.md (38,974 B) would leave 210,703 B, which the CURRENT floor does NOT
+// catch. Earlier revisions of this comment recorded that it DID, "by where it
+// landed rather than by design" -- and that coincidence has now expired exactly
+// as predicted, the corpus having grown past it. A smaller file gutted the same
+// way was never caught either. A byte floor
 // cannot see that, and raising it until it could would forbid legitimate
 // compression. The per-file guards are elsewhere and are about CONTENT rather
 // than size: work-issues-skill-refs.test.ts pins the document COUNT, and
 // work-issues-launch-mode.test.ts pins that each arm-bearing stage file still
 // names the mode it branches on and that the probe still exists exactly once.
-const MIN_REFERENCE_CORPUS_BYTES = 203_000;
+const MIN_REFERENCE_CORPUS_BYTES = 206_000;
 
 function skillNames(): string[] {
   return readdirSync(skillsDir, { withFileTypes: true })

--- a/tests/unit/scripts/work-issues-launch-mode.test.ts
+++ b/tests/unit/scripts/work-issues-launch-mode.test.ts
@@ -108,6 +108,21 @@ const LAUNCH_BRANCH_BEARING: Array<{ doc: string; arm: string; pattern: RegExp }
     pattern: /PUT\s*\n?BACK, never one to commit to/,
   },
   {
+    // Its own row rather than a widening of the pattern above: a RENAME
+    // satisfies "never one to commit to" -- nothing is committed onto the outer
+    // tool's branch -- while destroying the restore target outright, so the two
+    // arms fail independently and deleting one must not stay covered by the
+    // other. Measured 2026-09-02: SIX workspaces renamed their launch branch
+    // away inside SEVEN minutes, one of them the tree that wrote this row.
+    doc: LAUNCH_MODE_DOC,
+    arm: 'the "never one to RENAME" rule (a rename leaves nothing for section 9 to restore)',
+    // `\s+` rather than literal spaces, matching the sibling row's `\s*\n?`:
+    // the phrase currently sits at column 5 of a 77-char wrapped line, so a
+    // few characters added to the clause before it would reflow the wrap
+    // THROUGH the phrase and red this fence on an edit that changed nothing.
+    pattern: /never\s+one\s+to\s+RENAME/,
+  },
+  {
     doc: LAUNCH_MODE_DOC,
     arm: 'consequence row: branch in place, never commit onto LAUNCH_BRANCH',
     pattern: /^\|.*never commit onto `LAUNCH_BRANCH`.*\|$/m,


### PR DESCRIPTION
## What

Stage 10 (the retro) of the `/work-issues` run that shipped go-to-k/cdkd#2441 (issue go-to-k/cdkd#2410, released 0.285.6) and go-to-k/cdkd#2456 (issues go-to-k/cdkd#2275 + go-to-k/cdkd#2435, released 0.285.8). Four lessons folded into the stage file where each one FIRES, plus the byte-budget fence that guards them.

The run was IN-PLACE, so per `references/retro.md` §10-d the retro branch was taken in the lane's own tree — no worktree created, none removed.

## §10-0 — the run's net effect on the backlog

**closed 3 / filed 6 (new 6 / folded 0).**

- Closed: go-to-k/cdkd#2410, go-to-k/cdkd#2275, go-to-k/cdkd#2435 (the last was filed by lane A and taken by lane B in the same run rather than deferred).
- Filed: go-to-k/cdkd#2419, go-to-k/cdkd#2421, go-to-k/cdkd#2429, go-to-k/cdkd#2435, go-to-k/cdkd#2440, go-to-k/cdkd#2454.
- Folded J = 0, verified the way §10-0 prescribes (bodies gaining a checklist row, not `updatedAt`): evidence was added to go-to-k/cdkd#2350 and go-to-k/cdkd#2191 as COMMENTS; neither body gained a checklist row.

**Why M > N**, per §10-0's three candidate reasons — the healthy first one. The CLI's stdout-payload boundary really does have that many INDEPENDENT root causes, with four different owners: cdkd's own logger (fixed here), the container stdout pipe `streamLogs` (go-to-k/cdkd#2419), cdk-local's SECOND `ConsoleLogger` module (go-to-k/cdkd#2429), and the `--json` gate on `state list` (go-to-k/cdkd#2435, fixed). None of the six shares a root cause with another, so there was no umbrella to fold into. The next `/hunt-bugs` should aim at that boundary.

### The promotion check

All five still-open filings HIT against the run's own merged diff (go-to-k/cdkd#2441 + go-to-k/cdkd#2456, 53 files). Per §10-0 a hit is a prompt for judgement, not a verdict — each was judged:

- **go-to-k/cdkd#2419 / go-to-k/cdkd#2429** — citations, not targets. go-to-k/cdkd#2419's remedy needs a per-caller contract decision across three more `streamLogs` commands plus a real-Docker round; go-to-k/cdkd#2429's remedy is an UPSTREAM cdk-local change with no hook in `CdkLocalEmbedConfig`. Both reasons survive. Stay `next`.
- **go-to-k/cdkd#2421** — pure citation: the hits are `synth.ts` / `list.ts` (the CALLERS), while the target `src/utils/yaml.ts` is untouched by the run. Stays `next`. Worth flagging that it is the only `Severity: high` of the six.
- **go-to-k/cdkd#2440** — the check CONTRADICTED the body. Its reason claimed "`src/local/docker-runner.ts` has no overlap with this session's lanes (go-to-k/cdkd#2410 changed no line of it)"; go-to-k/cdkd#2441 changed it `+9/-2`. Corrected on the issue; re-judged and still `next` on what survives (the overlap is a JSDoc note in a different function, and the fix's real scope is a sibling `err.message` sweep across two modules the run never opened).
- **go-to-k/cdkd#2454** — its premise EXPIRED. It was deferred so as not to share go-to-k/cdkd#2275's PR; that PR has merged, so nothing is left to protect, and it lands in three files this run changed. **Re-classified to `Session-fit: now`** on the issue. It needs its own `fix:` PR (a user-visible exit-code change must not ride this `chore(work-issues)` one), which is not a deferral — same session is the bar.

## The four lessons

### 1. `references/verify.md` §8 — a fix that CLOSES a member falsifies the prose that COUNTS the set

The direction nobody checks, because the fix itself is CORRECT. Measured **four times in this one run**, and a REVIEWER caught every one while the author caught none:

| The fix | The prose it falsified |
| --- | --- |
| closed `spawnStreaming`'s leak | six sites still saying "THREE mechanisms still reach stdout" |
| closed `spawnForeground`'s leak | the corrected count, wrong again |
| `state list` became the fifth reserving command | `logger.ts`'s caller registry saying "four" |
| nine prompts now hold a lock while refusing | `docs/cli-reference.md`: "nothing is locked on the refusing path" |

It lands beside "derive the reader population before patching readers" because that is exactly what it extends: **prose is a reader too, and the one whose staleness a diff cannot show** — the member LEAVES in the diff while the counter that still includes it sits in a file the diff never touches. A fence's own comment is the same surface, and its coverage claim is TESTABLE: `readline-prompt-population.test.ts` asserted its regex missed only PROSE, and it missed five CODE spellings, one an aliased import no needle on the name can reach by construction.

It went to `verify.md` rather than `implement.md` deliberately. go-to-k/cdkd#2424 records that `implement.md` has 660 B of headroom and asks for a split rather than another squeeze; forcing this in by shaving unrelated paragraphs would be fighting that issue instead of respecting it, and the operative instruction is a review-round one anyway.

### 2. `references/launch-mode.md` — `LAUNCH_BRANCH` is never one to RENAME

The contract said "a branch to PUT BACK, never one to commit to". It did not forbid RENAMING, and a rename is the trap: it LOOKS like taking a lane branch and is cheaper than one (no fetch, no switch, the tree does not move). It destroys the restore target rather than borrowing it — `git branch -m` leaves the old name nowhere, local or remote, so §9's `show-ref` finds nothing and the run falls through to the detach fallback, the end state `ship.md` withdrew ON THE SAME DAY for being visible-surprising in the outer tool's UI.

Measured 2026-09-02 from `git reflog --all --date=iso | grep 'Branch: renamed'`: **six workspaces renamed their launch branch away between 15:31:45 and 15:38:29 local** — lugworm, ribboneel, hawkfish, bannerfish, tiamat, narwhal, this run's own `go-to-k/hawkfish` at 15:34 among them — and three of the six were renamed a SECOND time by 15:51. Six of six inside seven minutes: a habit, not a slip. The outer tool renames too (Orca derives a workspace branch name from a session's first prompt, go-to-k/cdkd#2413), which is why §9's `show-ref` is mandatory rather than defensive. The recovery is the reflog, and it is now written down.

The existing phrase is preserved byte-identically because `implement.md` and `claim.md` quote it and a fence pins it; the rename clause is appended.

**Pinned by its OWN row in `LAUNCH_BRANCH_BEARING`, not a widened sibling pattern** — a rename SATISFIES "never one to commit to" (nothing is committed onto the outer tool's branch) while still destroying the restore target, so the two arms must fail independently.

### 3. `references/ship.md` §9 — a GENERATED file is REGENERATED, never hand-merged

Generalizes the paragraph that previously covered only the integ ledger. A hand-merge produces a file matching NEITHER side, which the staleness guard rejects with a diff nobody wrote; resolve to upstream and re-run the generator. Measured on go-to-k/cdkd#2441, where `docs/cli-flag-coverage.md` conflicted on a parallel-lane rebase.

Plus the half that is genuinely surprising: **the generator's INPUT is wider than the artifact suggests.** The same PR turned CI red having added no flag and changed no `src/` line — adding a `cdkd list --verbose` assertion to `tests/integration/local-invoke/verify.sh` was enough, because the FIXTURE TREE is the input to `docs/_generated/cli-flag-coverage.json`.

### 4. `references/retro.md` §10-0 — when a hit contradicts the body's own reason, the BODY is stale

Amends the existing "re-read the REASON" paragraph. A deferral reason asserting NO FILE OVERLAP is a claim about a MOVING target: the lane keeps editing after the reason is written and nothing re-reads it. Evidence is go-to-k/cdkd#2440 above. The guidance is to prefer a reason the lane cannot falsify by carrying on — what the work NEEDS (a new fixture, an upstream release, a maintainer decision).

## The fence

`tests/unit/scripts/skill-file-payload.test.ts`: MEASURED re-derived (corpus 249,677; largest `implement.md` 48,340; runner-up `verify.md` 46,945) and `MIN_REFERENCE_CORPUS_BYTES` raised 203,000 -> 206,000.

The raise is not optional and the test says so in its own failure message. Growing the RUNNER-UP spends the either-largest margin twice over (once via the corpus, once via the subtrahend), so under the old 203,000 floor this change would leave **268 B** of it — exactly the erosion the comment beside the floor predicts. At 206,000 the margins are **4,663 (binding) / 3,268 (either-largest)**, with ~44 KB of compression headroom below the floor. The comment's `triage.md` coincidence ("which the CURRENT floor happens to catch, by where it landed rather than by design") has now EXPIRED as it predicted — gutting `triage.md` would leave 210,703 B, which 206,000 does not catch — and the comment now says so rather than carrying a claim the tree contradicts. That correction is lesson 1 applied to this PR's own diff.

## Verification

- `vp check --fix` + `vp run check` (CI parity): 0 errors.
- `vp run typecheck:test`, `vp run build`: pass.
- `vp test run`: **870 files / 17,932 passed | 1 skipped**, run-root asserted as this worktree per `/check` step 4.
- `vp run gen:all-matrices` + `vp run audit:coverage:check`: no generated artifact stale.
- Integ gates: `integ-destroy` / `integ-broad` / `integ-local` / `integ-schema-migration` all **n/a** — the diff touches no file in any of their scopes (verified with each gate's own detection grep).
- AWS: zero live `state.json` keys under `cdkd/` (this PR ran no integ and created nothing).

**Live test — both new fences mutation-probed against the real tree, restored byte-exact:**

- Rewording `never one to RENAME` in `launch-mode.md` reds exactly the new row, naming it; the sibling "never one to commit to" row stays GREEN, which is the independence the row's comment claims.
- Appending ONE byte to `verify.md` reds the MEASURED assertion, reporting `corpus -> +1` and `runner-up verify.md 46945 -> 46946`. Its message also prints the live `floor margins:` pair, which is the independent confirmation of the floor arithmetic above.

## Mirror

Both FLOW lessons (2 and 4) are mirrored as **go-to-k/cdk-local#676** and **go-to-k/cdk-real-drift#1860**, filed together in one turn and cross-referenced, each naming the other plus cdkd as landed. Both were first resolved against all three of each target's windows (merged `origin/main` file, open PRs, open issues) and are absent from every one.

Filed rather than landed, and **the reason is not cost**: go-to-k/cdk-local#675 is an OPEN, in-flight lane editing the very stage files these lessons land in, so landing there now is a guaranteed conflict with a live peer PR — and §10-c forbids a partial mirror ("file into EVERY repo still missing it at once"), so the pair is filed symmetrically rather than one landed and one filed.

## Review

One `pr-code-reviewer` was dispatched. The heuristic tier for this diff is `inline` (~119 LOC), and it was biased UP one step deliberately: the diff is agent-instruction prose that propagates into every future session (which §10-d says is explicitly NOT down-biased), and it carries hand-derived byte arithmetic that is easy to get wrong quietly.

That was the right call — it returned **8 findings, all real, all fixed here** (bucket (a) of the residual-nit sweep; nothing deferred, nothing waived):

1. `MIN_REFERENCE_CORPUS_BYTES`'s comment said the floor "replaces 180_000"; it replaces 203,000.
2. **My own comment stated the wrong mechanism.** I wrote that growing `verify.md` (the RUNNER-UP) spent the either-largest margin. It does not: growing the runner-up moves `corpus` and `runnerUp` equally, leaving `corpus - runnerUp` unchanged, so it spends only the BINDING margin. The either-largest margin was spent by the 3,608 B added to the three non-runner-up files. The comment now says so, and says it got this wrong first.
3. `ship.md` claimed go-to-k/cdkd#2441 "changed no `src/` line" — it changed seven. The true input is `src/cli/options.ts`; reworded.
4. **A self-contradiction I introduced**: "take upstream's side whole" is universal as written, but three paragraphs down the integ ledger's resolution is keep-both + normalize (its rows record real-AWS runs, which no regenerate can recompute). The rule is now scoped to tree-DERIVED artifacts and names the ledger as the exception.
5. The new fence's `/never one to RENAME/` had no newline tolerance, unlike its sibling `/PUT\s*\n?BACK…/`. The phrase sits at column 5 of a 77-char wrapped line, so a few added characters upstream would reflow through it and red the fence on a no-op edit. Widened to `/never\s+one\s+to\s+RENAME/`.
6. An inserted sentence broke the antecedent of the following "this run … grew SEVEN non-leader stage files" (that is the go-to-k/cdkd#2417 run, not this one). Reworded.
7. The leader/runner-up gap is now **1,395 B — smaller than this PR's own 1,322 B edit to the runner-up**, so "the day the two swap places" is one ordinary edit away. Recorded.
8. The reflog recovery only survives §9's `git branch -D` via HEAD's copy. "Run it before deleting the lane branch" added.

Findings 2 and 4 are the ones worth noting: both are this PR's own lesson 1 firing on this PR's own diff — a claim that was true of an earlier draft and went false as the diff grew, with nothing mechanical to notice. Fixing them changed the corpus again, so MEASURED and every derived figure were re-derived a third time, and both fences re-probed after the fixes.

## Remaining work

- **TODO go-to-k/cdkd#2454** — re-classified to `Session-fit: now` by the promotion check above; needs its own `fix:` PR, not this one.
- Everything else this run filed stays `next` with its reason re-verified (see the promotion-check section).
