### PR TITLE
chore(cli): align the package description and CLI help with the README tagline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@go-to-k/cdkd",
   "version": "0.285.10",
-  "description": "CDK Direct - Deploy AWS CDK apps directly via SDK/Cloud Control API",
+  "description": "Drop-in CDK CLI for existing CDK apps - up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -43,7 +43,9 @@ export function buildProgram(): Command {
 
   program
     .name('cdkd')
-    .description('CDK Direct - Deploy AWS CDK apps directly via SDK/Cloud Control API')
+    .description(
+      'Drop-in CDK CLI for existing CDK apps - up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation'
+    )
     // `getCdkdVersion()` carries the `typeof` guard the build-time define
     // needs: this module is imported directly by unit tests, where tsdown's
     // `define` has not run and a bare reference would throw ReferenceError. The


### PR DESCRIPTION
## Summary

`package.json`'s `description` and `program.description()` both carried
`CDK Direct - Deploy AWS CDK apps directly via SDK/Cloud Control API`. That
says what cdkd does but not why anyone would pick it: neither differentiator
(drop-in on an existing CDK app, and the speed) appeared on either surface.
The npm package page and `cdkd --help` are where a first-time reader meets the
project, and README.md line 7 already has a sentence that does this job.

Point all three at the same line:

```
Drop-in CDK CLI for existing CDK apps - up to 15x faster deploys via direct AWS SDK calls instead of CloudFormation
```

README keeps its em dash. The package description and the CLI help use an ASCII
hyphen, since those two render in terminals and in `npm search` output where the
dash is not guaranteed to be legible.

## Notes

- The `up to 15x` claim is kept rather than softened. On npm, the package page
  renders the README directly beneath the description, so the Benchmark section
  that substantiates it is on the same page. `cdkd --help` is the one surface
  where it appears without a citation; `up to` keeps it accurate as an upper
  bound.
- Cost of keeping the number: a benchmark change now touches three places
  instead of two. That is noticed while editing the README, so it is not a
  silent drift risk.
- No test asserts either string (`tests/unit/cli/program.test.ts` does not
  cover `.description()`), and no doc quotes them, so the only reader affected
  is a human.

## Test plan

- `vp check --fix` / `vp run check` - 0 errors
- `vp run typecheck:test` - pass
- `vp run build` - pass
- `vp test run` - 877 files, 18032 passed / 1 skipped, rooted at this worktree
- `vp run gen:all-matrices` + `vp run audit:coverage:check` - no generated
  artifact went stale
- Live test: `node dist/cli.js --help` prints the new tagline (commander wraps
  it across two lines at terminal width); `node dist/cli.js deploy --help`
  still prints its own per-command description
- `node -e` round-trip on `package.json` confirms the JSON parses and the
  field reads back byte-for-byte
