### PR TITLE
chore(work-issues): a fence that covers one row of a two-dimensional guarantee

### DIFF
--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -76,14 +76,13 @@ directions, checked on both sides.
 
 The `&&` is deliberate: unchained, a failed `fetch` still branches, off a stale
 `origin/main`. **`main-tree-branch-gate` is the backstop for running that line
-after a cwd reset, and it now covers this spelling** — it matches in COMMAND
-POSITION and judges the matched SEGMENT, so the chained form is refused (rc=2)
-while `git fetch origin && git switch main` still passes. It did NOT always:
-measured 2026-08-31, the copy then on `main` skipped to the FIRST `git` token,
-read `sub=fetch` and exited 0 — the spelling this file PRINTS was the one it
-missed, while a bare `git switch -c <b> origin/main` was refused. Fixed in
-go-to-k/cdkd#2406; settle which copy is deployed by CONTENT, never by a commit
-subject: `git show origin/main:.claude/hooks/main-tree-branch-gate.sh | grep -c
+after a cwd reset, and since go-to-k/cdkd#2406 it covers this spelling** — it
+matches in COMMAND POSITION and judges the matched SEGMENT, so the chained form
+is refused (rc=2) while `git fetch origin && git switch main` still passes. An
+older copy skipped to the FIRST `git` token and exited 0 on exactly the
+spelling this file PRINTS, so settle which copy a stale worktree has by
+CONTENT, never by a commit subject: `git show
+origin/main:.claude/hooks/main-tree-branch-gate.sh | grep -c
 gate_verb_rest_each` prints non-zero.
 
 **`mise trust` is not optional here, and skipping it fails in the direction that
@@ -141,10 +140,10 @@ from the instance you happened to hit is not a count** — and `Effort` /
 `Estimate` are what a future session budgets from.
 
 **This applies to a FIX ROUND at least as much as to the original find, and
-that is where it actually gets skipped:** the fix lands on ONE call site while
-a sibling keeps the defect, usually shipping a comment asserting completeness.
-Measured 2026-08-27, FIVE times on two lanes, the last two in edits made while
-fixing the previous instance:
+that is where it gets skipped:** the fix lands on ONE call site while a sibling
+keeps the defect, usually shipping a comment asserting completeness. Measured
+2026-08-27, FIVE times on two lanes, the last two while fixing the previous
+instance:
 
 | Fix | Sibling that kept the defect |
 | --- | --- |
@@ -155,7 +154,7 @@ fixing the previous instance:
 | completing that second enumeration | a third list on the same LINE |
 
 Every one was found by ENUMERATING readers or call sites with grep; none by
-re-reading the diff (three had review rounds that read the diff and missed it).
+re-reading the diff (three had review rounds that read it and missed them).
 After writing a fix, before believing it:
 
 ```bash
@@ -197,16 +196,15 @@ measurement reads as evidence and is not.
 
 **Any CLAIM relayed from a subagent's report is unearned in the same way — not
 just a count — and it is the harder half, because there is no command to paste:
-you never ran one.** One 2026-08-26 run published FOUR relayed counts, every
-one wrong ("all nine sibling `clearOnUpdateRemoval` sites" — grep found **78**
-across 14 provider files; "nine mutation probes" — fourteen; "ten unit shapes"
-— thirteen; "a third copy" — nine existed), two into GitHub artifacts that
-outlive the session. Non-numeric claims fail identically: pins reported "each
-probed adversarially" had a PATH decoy never placed on PATH, and deleting six
-left the suite 65/65 green. The tell is grammatical: a number arriving as a
-WORD ("nine sites") was counted by a person or an agent; one arriving as
-output was counted by a machine. Before a relayed claim is published anywhere
-durable, run the query yourself and put it in the text.
+you never ran one.** One 2026-08-26 run published FOUR relayed counts, every one
+wrong ("all nine sibling `clearOnUpdateRemoval` sites" — grep found **78** across
+14 files; "nine mutation probes" — fourteen; "ten unit shapes" — thirteen; "a
+third copy" — nine existed), two into GitHub artifacts outliving the session.
+Non-numeric claims fail identically: pins reported "each probed adversarially"
+had a PATH decoy never placed on PATH, and deleting six left the suite 65/65
+green. The tell is grammatical — a number arriving as a WORD was counted by a
+person or an agent, one arriving as output by a machine. Run the query yourself
+before publishing a relayed claim anywhere durable.
 
 **Before deriving a fix, grep the repo for the SYMPTOM -- something may already
 have solved it.** Different from the sibling-site sweep: that greps the
@@ -217,6 +215,26 @@ go-to-k/cdkd#2227 lane spent a real-AWS round trip rediscovering (SDK v3's
 region-redirect middleware mishandling the empty-body HEAD 301 → synthetic
 `UnknownError`), plus the fail-OPEN trap the fix had to avoid — a grep for
 `UnknownError` or `followRegionRedirects` would have found it in seconds.
+
+**And grep the ISSUE NUMBER — a THIRD sweep, with a different key.** Closing an
+issue falsifies every comment that CITES it, and the dangerous ones are
+invisible to both sweeps above: phrased as **deliberate non-assertions**, they
+carry neither the defect's shape nor its symptom, only a present-tense reason
+for not testing it.
+
+```bash
+git grep -n "<the issue number>" -- src tests docs .claude
+```
+
+Measured 2026-09-03 (go-to-k/cdkd#2466 closing go-to-k/cdkd#2421): four live
+citations, not all reachable from a symptom grep — a forward reference in
+`synth.ts`, an "until it is fixed" bullet in `docs/cli-reference.md`, a
+changelog entry in the present tense, and the valuable one, an entire missing
+test in `tests/integration/local-invoke/verify.sh` ("Deliberately NOT asserted:
+that the template PARSES") sitting in a fixture that already synthesized.
+Adding it cost nothing and immediately found a SECOND failure mode the issue
+never named. Such a non-assertion is usually the cheapest high-value test in
+the change: its author already decided the assertion belonged there.
 
 **A defect the sweep turns up that this lane is NOT fixing gets FILED, and
 the rules for that are their own stage file: `references/filing.md` (§5-f)**
@@ -270,29 +288,27 @@ clean result from the wrong shape is indistinguishable from a clean subject.**
 Auditing go-to-k/cdkd#2096 (2026-08-20) produced SIX confident wrong answers,
 each from a different plausible sampling shape, each hiding a real secret:
 
-- **Newest-N.** The 6 NEWEST state versions cleared `appsync` while versions
+- **Newest-N.** The 6 newest state versions cleared `appsync` while versions
   12-45 held an API key in 17 of 33 — the newest come from the run most likely
   already fixed. Sample across the range, or grep everything.
-- **One global needle.** A single `cdkd-known-*` grep reported
-  `secrets-array-nested` clean while 5 of 7 versions carried
-  `cdkd-array-nested-pw-789`. Each fixture spells its OWN literal — derive the
-  needle per subject, or assert on a needle-INDEPENDENT observable (surviving
-  version count == 0).
+- **One global needle.** Each fixture spells its OWN literal, so a single
+  `cdkd-known-*` grep reported a fixture clean while 5 of 7 versions carried
+  `cdkd-array-nested-pw-789`. Derive the needle per subject, or assert on a
+  needle-INDEPENDENT observable (surviving version count == 0).
 - **A name derived from convention.** `cognito-resource-server`'s stack is
   `CognitoResourceServerStack`, not the `Cdkd…Example` the directory implies;
-  the convention probe returned `0 of 1`. Read the identifier from the subject
+  the probe returned `0 of 1`. Read the identifier from the subject
   (`verify.sh`'s `STACK=`), never infer it.
-- **A silent parse failure inside a pipe.** `aws s3api get-object …
-  /dev/stdout` emits metadata beside the body, so a `json.load` died and the
-  loop counted `0 of 16`; a text match found 4. A parse that can fail must
-  report failing, not fall through to a count.
+- **A silent parse failure inside a pipe.** `s3api get-object … /dev/stdout`
+  emits metadata beside the body, so a `json.load` died and the loop counted
+  `0 of 16` where a text match found 4. A parse that can fail must report
+  failing, not fall through to a count.
 - **A per-page aggregate.** `--query 'length(Versions)'` applies PER PAGE and
-  concatenates: a 1189-entry prefix prints `1000\n189`, and `[ "$n" -ne 0 ]`
-  on that is a bash error. Count ROWS of a projection instead.
-- **Grepping the layer the subject does not use.** `AWS::ApiGateway::ApiKey`
-  is registered to NO provider — it takes the generic Cloud Control readback
-  whose model includes `Value`, so searching `src/provisioning/providers/**`
-  cannot see it.
+  concatenates: a 1189-entry prefix prints `1000\n189`. Count ROWS of a
+  projection instead.
+- **Grepping the layer the subject does not use.** `AWS::ApiGateway::ApiKey` is
+  registered to NO provider — it takes the generic Cloud Control readback whose
+  model includes `Value`, so `src/provisioning/providers/**` cannot see it.
 
 The through-line: every one FAILED CLEAN. Treat "nothing here" as the claim
 needing evidence — run the shape against a case you KNOW is dirty first, and
@@ -314,25 +330,22 @@ shape past `trap`: before adding to any single-slot registration — a signal
 handler, a callback field, an `EXIT` hook — count what is already there.
 
 **COMMIT the round's real fixes BEFORE running any mutation probe.** A probe
-deliberately breaks the tree, so an interruption mid-probe (a session limit, a
-crash) leaves deliberate breakage and unfinished fixes in ONE undifferentiated
-dirty tree. Measured 2026-09-02 on the go-to-k/cdk-real-drift#1841 lane: the
-lane subagent died at the 5-hour session limit mid-probe with 9 dirty files,
-and the resuming session had to read the full diff to establish that none of
-it was probe wreckage before it could commit. With a pre-probe commit the
-separator is just `git diff` — anything unstaged after a probe is the probe's
-(mirrored from go-to-k/cdk-real-drift#1853; go-to-k/cdkd#2416 is this repo's
-filing).
+deliberately breaks the tree, so an interruption mid-probe leaves deliberate
+breakage and unfinished fixes in ONE undifferentiated dirty tree. Measured
+2026-09-02 (go-to-k/cdk-real-drift#1841): a lane subagent died at the session
+limit mid-probe with 9 dirty files, and the resuming session had to read the
+full diff to establish none of it was probe wreckage. With a pre-probe commit
+the separator is just `git diff` — anything unstaged after a probe is the
+probe's (go-to-k/cdkd#2416 is this repo's filing).
 
 **Restore a probe from a BYTE-EXACT COPY, never an inverse string replace.**
-`cp <file> <backup>` before, `cp <backup> <file>` after, proved by
-`git diff -- <file>` printing nothing. An inverse replace is a second edit with
-its own failure modes; Python's `str.replace('', x)` is the sharp one, matching
-between EVERY character so the "revert" rewrites the file. Measured 2026-09-02
-(go-to-k/cdk-real-drift#1854): an 11 KB stage file became 838 KB, and the three
-probes AFTER it scored a corrupted subject, so their verdicts meant nothing
-while still reading as evidence. The DOWNSTREAM probes are the real cost — the
-corrupted file is obvious, they are not.
+`cp <file> <backup>` before, `cp <backup> <file>` after, proved by `git diff --
+<file>` printing nothing. An inverse replace is a second edit with its own
+failure modes; Python's `str.replace('', x)` is the sharp one, matching between
+EVERY character so the "revert" rewrites the file (2026-09-02,
+go-to-k/cdk-real-drift#1854: an 11 KB stage file became 838 KB, and the three
+probes AFTER it scored a corrupted subject). The DOWNSTREAM probes are the real
+cost — the corrupted file is obvious, they are not.
 
 **A mutation probe proves a test discriminates only if it changes the value
 the test READS.** Four vacuous tests shipped across three lanes on 2026-08-19,
@@ -452,17 +465,16 @@ having run nothing (2026-08-20; one reviewer had FOUR).
 the void-probe rule above carries the two false greens that ride this command.
 
 **A repo-wide SCANNER test is calibrated against the PRE-FIX tree, not written
-from the issue's wording.** When the test globs the tree, the issue's
-signature is what its author noticed on ONE instance, never a rule with a
-measured false-positive rate. Run the candidate rule over the still-broken
-tree FIRST, read every hit, and tighten until all are genuine. Done for
-go-to-k/cdkd#1990: 13 bare `#N` hits, all real, while the same regex without
-stripping frontmatter and code spans would have flagged legitimate examples as
-violations. Two markdown-scanner sub-traps: strip on the WHOLE text, not per
-line — an inline code span straddling a hard-wrapped line break makes a
-per-line pass pair one span's closing backtick with the next span's opening
-one and invent findings — and report the HIT's own line, not the start of the
-stripped region.
+from the issue's wording.** The issue's signature is what its author noticed on
+ONE instance, never a rule with a measured false-positive rate. Run the
+candidate over the still-broken tree FIRST, read every hit, and tighten until
+all are genuine (go-to-k/cdkd#1990: 13 bare `#N` hits, all real, while the same
+regex without stripping frontmatter and code spans would have flagged
+legitimate examples). Two markdown sub-traps: strip on the WHOLE text, not per
+line — an inline code span straddling a hard wrap makes a per-line pass pair
+one span's closing backtick with the next span's opening one and invent
+findings — and report the HIT's own line, not the start of the stripped
+region.
 
 **Calibrating against the broken tree is only HALF the measurement, and the
 half it leaves out is the one that lets a fence ship inert.** The pre-fix tree
@@ -472,14 +484,13 @@ defeat your exemption logic. Follow calibration with probes against the REAL
 tree:
 
 - **Write the defect in the spelling a PERSON would write, not the one that is
-  easiest to inject.** go-to-k/cdkd#2052 (2026-08-26): a prefix-sync fence
-  split on `'custom-resource-responses'` *with both quote characters*, so the
-  probe's `` `${'...'}/` `` reds it while the spelling anybody would type —
-  `listRawObjects('custom-resource-responses/')`, trailing slash inside the
-  quote — sailed through, as did any copy outside the fence's hand-written file
-  list. Its author had just read the "grep for the SHAPE, not for a NAME" rule.
-  Mutate a fence the way a future contributor would, and derive the population
-  rather than listing it.
+  easiest to inject.** go-to-k/cdkd#2052 (2026-08-26): a prefix-sync fence split
+  on `'custom-resource-responses'` *with both quote characters*, so the probe's
+  `` `${'...'}/` `` reds it while the spelling anybody would type — trailing
+  slash inside the quote — sailed through, as did any copy outside the fence's
+  hand-written file list. Its author had just read the "grep for the SHAPE" rule
+  above. Mutate a fence the way a future contributor would, and derive the
+  population rather than listing it.
 - **Write the defect in every spelling the language allows** and confirm each
   is flagged. go-to-k/cdkd#2111 (2026-08-20): a scanner for
   `options.region || process.env['AWS_REGION']` calibrated perfectly (19
@@ -495,16 +506,15 @@ tree:
   and missed the files that accept the flag. Derive from what DECLARES the
   option, and make the predicate per-READ rather than per-file.
 
-  The worst population is one derived from the DEFECT itself, because deleting
-  the required thing then drops the subject OUT of the population instead of
-  failing. Sibling-repo probes (2026-08-20) found four such fences in one tree
-  (go-to-k/cdk-real-drift#1797): a gate-parity test selecting gates by
-  `condition.includes('Bash(git commit*)')` stayed 7/7 green with two gates
-  disarmed, and a hook-coverage test enumerating `*.test.sh` could never
-  report the hook with no harness. A STATEFUL scanner fails the same way with
-  no OR: go-to-k/cdk-local#537's scan flipped one `inFence` boolean on any
-  fence marker, so a single nested fence inverted it and muted every later
-  check silently.
+  The worst population is one derived from the DEFECT itself: deleting the
+  required thing drops the subject OUT of the population instead of failing.
+  Four such fences in one tree (2026-08-20, go-to-k/cdk-real-drift#1797) — a
+  gate-parity test selecting gates by `condition.includes('Bash(git commit*)')`
+  stayed 7/7 green with two gates disarmed, and a hook-coverage test
+  enumerating `*.test.sh` could never report the hook with no harness. A
+  STATEFUL scanner fails the same way with no OR: go-to-k/cdk-local#537's scan
+  flipped one `inFence` boolean on any fence marker, so a single nested fence
+  inverted it and muted every later check.
 
   **A population derived from an OPTIONAL language feature is derivable-around
   for free, and a type annotation is the commonest one.** A 2026-08-26 fence
@@ -557,20 +567,19 @@ CLOSED rather than on a better pattern:
   `composes`); `init` emits six, dropping the two a repo is likeliest never to
   have written.
 - **Then the spelling treadmill, which is the real lesson.** Each round patched
-  the one spelling that had just got through while the next sailed past. Block
-  items only -> a FLOW list passed. Unquoted keys only -> `"exclude":` passed.
-  A block scan terminating on `/^ {2}\S/` -> a two-space COMMENT ended it early
-  and left all fourteen cases GREEN while markgate really did subtract. A "raw
-  text" tripwire, added so the guard would not read the parser it protects ->
-  another hand-rolled pattern over the same text, inheriting every blind spot.
-  Last, a YAML merge key (`<<: *anchor`) splicing an `exclude` declared on a
-  SIBLING gate — which that tripwire, added as exactly this backstop, did not
-  fire on either, grepping only the `check` block. go-to-k/cdkd#2383 tallies it
-  as **four spellings across four rounds, each patch moving the hole rather
-  than closing it**. **Three spellings in three rounds is the signal to stop
-  patterning and change instrument** — a YAML parser was a production
-  dependency the whole time, and a third-party, versioned, separately-tested
-  library is not the fence checking its own work.
+  the spelling that had just got through while the next sailed past: block
+  items only, so a FLOW list passed; unquoted keys only, so `"exclude":`
+  passed; a block scan terminating on `/^ {2}\S/`, which a two-space COMMENT
+  ended early, leaving all fourteen cases GREEN while markgate really did
+  subtract; then a "raw text" tripwire that was itself another hand-rolled
+  pattern over the same text, inheriting every blind spot — and it did not fire
+  on the YAML merge key (`<<: *anchor`) splicing an `exclude` from a SIBLING
+  gate, the very case it was added to backstop. go-to-k/cdkd#2383 tallies four
+  spellings across four rounds, each patch moving the hole rather than closing
+  it. **Three spellings in three rounds is the signal to stop patterning and
+  change instrument** — a YAML parser was a production dependency the whole
+  time, and a third-party, versioned, separately-tested library is not the
+  fence checking its own work.
 - **Neither escape was a fifth pattern.** Either parse for real — with
   `parse(text, { merge: true })`, without which `yaml` reports the gate's keys
   as `["hash", "<<"]` and its `exclude` as undefined — then ALLOW-LIST the
@@ -664,10 +673,9 @@ code "cannot have changed behaviour".
 2026-08-19:**
 
 - **Never force-push over a commit you did not author.** A lane agent resumed
-  with edits predating four orchestrator commits on its branch and
-  force-pushed; only the rebase preserved them. Say in the prompt: re-`git
-  fetch` and inspect the branch first, and if it carries work you did not
-  write, STOP and report.
+  with edits predating four orchestrator commits on its branch and force-pushed;
+  only the rebase preserved them. Say in the prompt: re-`git fetch` and inspect
+  the branch first, and STOP if it carries work you did not write.
 - **A new fixture literal must not collide with an existing assertion needle —
   and neither may a new fixture RESOURCE collide with an existing resource's
   VALUE.** The literal form: a `DB_URL` hard-coded `cdkd-user` as its URL user
@@ -685,8 +693,8 @@ code "cannot have changed behaviour".
   **And check the arm's shape actually exercises the fix before spending a run
   on it.** The obvious decoupling there (two separate RESOURCES) was VACUOUS:
   `perResourceSecrets` is keyed by logical id, so two resources get two
-  single-pair bags and redact correctly with or without the fix. One resource holding both leaves was the
-  only shape where the mechanism under test decides the answer.
+  single-pair bags and redact correctly either way. One resource holding both
+  leaves was the only shape where the mechanism under test decides the answer.
 - **Execute every read expression you write.** Two integ runs were lost to
   fixture code, not product defects: the literal collision above, and a `jq`
   assignment written through `to_entries[]`, which builds a new array and is
@@ -737,24 +745,23 @@ because it converts an open gap into a recorded assurance:
 
 - **A scratch harness was silently REPLACED by another agent's file of the
   same name.** Its `__main__` was `pass`, so four probes "passed" having
-  applied nothing — parallel agents share `/tmp`-style scratch space and pick
-  the same obvious filenames. Name scratch files per lane, and make every
-  probe emit a positive receipt it cannot produce without having run —
-  `bytes 41822 -> 41799; anchor now 0 (was 1); changed=True` — then read the
-  receipt rather than the exit code.
+  applied nothing — parallel agents share scratch space and pick the same
+  obvious filenames. Make every probe emit a positive receipt it cannot produce
+  without having run — `bytes 41822 -> 41799; anchor now 0 (was 1)` — and read
+  the receipt rather than the exit code.
 
-  **This rule was already written here and was broken THREE times in one run
+  **That rule was already written here and was broken THREE times in one run
   (2026-08-26), so stop asking agents to invent the name: the ORCHESTRATOR
   assigns each dispatched agent a unique scratch directory IN ITS PROMPT**
   (`$SCRATCHPAD/lane<issue>-private/`, `$SCRATCHPAD/rev-<role>-<sha>/`), plus
-  "never a bare generic name in the scratchpad root". Decided once per run, it
-  cannot be re-derived wrongly per agent. Without it: lane B ran lane A's whole
-  probe table twelve times against lane A's worktree; one reviewer's mutation
-  was restored from `HEAD` by another; and a TRESPASS was reported that had not
-  happened, the `_old-<name>.test.sh` copy a reviewer is TOLD to write beside
-  its subject being indistinguishable, from inside the worktree, from a peer
-  writing there. Only the orchestrator can know which is which. A hook was
-  rejected: it would have to match command TEXT for scratch-path writes, the
+  "never a bare generic name in the scratchpad root" — decided once per run, it
+  cannot be re-derived wrongly per agent. Without it, one lane ran another's
+  whole probe table against that lane's worktree, one reviewer's mutation was
+  restored from `HEAD` by another, and a TRESPASS was reported that had not
+  happened (the `_old-<name>.test.sh` copy a reviewer is TOLD to write beside
+  its subject is indistinguishable, from inside the worktree, from a peer
+  writing there — only the orchestrator can tell). A hook was rejected: it
+  would have to match command TEXT for scratch-path writes, the
   unbounded-bypass shape go-to-k/cdkd#2156 documents.
 - **A probe's FIXTURE, not its mutation, decided the outcome.** A region test
   set `AWS_REGION` to the CONSUMER's region, where the correct code and the

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -80,10 +80,11 @@ after a cwd reset, and since go-to-k/cdkd#2406 it covers this spelling** — it
 matches in COMMAND POSITION and judges the matched SEGMENT, so the chained form
 is refused (rc=2) while `git fetch origin && git switch main` still passes. An
 older copy skipped to the FIRST `git` token and exited 0 on exactly the
-spelling this file PRINTS, so settle which copy a stale worktree has by
-CONTENT, never by a commit subject: `git show
+spelling this file PRINTS, so settle which copy is DEPLOYED by CONTENT, never
+by a commit subject: `git show
 origin/main:.claude/hooks/main-tree-branch-gate.sh | grep -c
-gate_verb_rest_each` prints non-zero.
+gate_verb_rest_each` prints non-zero (drop the `git show` prefix to ask the
+same of the copy in YOUR worktree, which is the one that will fire).
 
 **`mise trust` is not optional here, and skipping it fails in the direction that
 costs most.** An untrusted `.mise.toml` makes `mise exec -- markgate set` error
@@ -198,13 +199,13 @@ measurement reads as evidence and is not.
 just a count — and it is the harder half, because there is no command to paste:
 you never ran one.** One 2026-08-26 run published FOUR relayed counts, every one
 wrong ("all nine sibling `clearOnUpdateRemoval` sites" — grep found **78** across
-14 files; "nine mutation probes" — fourteen; "ten unit shapes" — thirteen; "a
+14 provider files; "nine mutation probes" — fourteen; "ten unit shapes" — thirteen; "a
 third copy" — nine existed), two into GitHub artifacts outliving the session.
 Non-numeric claims fail identically: pins reported "each probed adversarially"
 had a PATH decoy never placed on PATH, and deleting six left the suite 65/65
-green. The tell is grammatical — a number arriving as a WORD was counted by a
-person or an agent, one arriving as output by a machine. Run the query yourself
-before publishing a relayed claim anywhere durable.
+green. The tell is grammatical — a number arriving as a WORD was counted by a person
+or an agent, one arriving as output by a machine. Before publishing a relayed
+claim anywhere durable, run the query yourself and put its OUTPUT in the text.
 
 **Before deriving a fix, grep the repo for the SYMPTOM -- something may already
 have solved it.** Different from the sibling-site sweep: that greps the
@@ -255,16 +256,13 @@ harness** — `.claude/hooks/` carries per-hook `*.test.sh` suites run by
 
 **Run such a harness from BESIDE its subject, never from a scratch copy.**
 Every suite resolves the hook under test from its own script path, so a copy
-runs against a sibling that is not there and every case fails with exit 127 —
-a regression your change did not cause (2026-08-19: `branch-gate.test.sh`
-scores `Pass: 27  Fail: 0` from `.claude/hooks/`, exits 1 from scratch). Say
-`$0` / `${BASH_SOURCE[0]}`-relative rather than naming one spelling (27 of 33
-suites use `${BASH_SOURCE[0]}`, 6 use `$0`); `pr-review-gate.test.sh` derives
-the REPO ROOT the same way, and `run-tests.sh` is itself
-`${BASH_SOURCE[0]}`-relative, so a copied RUNNER cds to the wrong repo
-entirely. The trap is invited by the before/after comparison a hook change
-wants — the obvious `git show origin/main:<suite> > /tmp/x.sh && bash
-/tmp/x.sh`. Instead write the old copy beside the real one as
+runs against a sibling that is not there and every case fails with exit 127 — a
+regression your change did not cause (2026-08-19: `branch-gate.test.sh` scores
+`Pass: 27  Fail: 0` from `.claude/hooks/`, exits 1 from scratch). Resolve
+`${BASH_SOURCE[0]}`-relative; `run-tests.sh` does the same, so a copied RUNNER
+cds to the wrong repo entirely. The trap is invited by the before/after
+comparison a hook change wants — the obvious `git show origin/main:<suite> >
+/tmp/x.sh && bash /tmp/x.sh`. Instead write the old copy beside the real one as
 `.claude/hooks/_old-<name>.test.sh` and delete it after.
 
 §8's scratch-copy idiom is right for a data file, wrong for a runnable
@@ -336,7 +334,8 @@ breakage and unfinished fixes in ONE undifferentiated dirty tree. Measured
 limit mid-probe with 9 dirty files, and the resuming session had to read the
 full diff to establish none of it was probe wreckage. With a pre-probe commit
 the separator is just `git diff` — anything unstaged after a probe is the
-probe's (go-to-k/cdkd#2416 is this repo's filing).
+probe's (mirrored from go-to-k/cdk-real-drift#1853; go-to-k/cdkd#2416 is this
+repo's filing).
 
 **Restore a probe from a BYTE-EXACT COPY, never an inverse string replace.**
 `cp <file> <backup>` before, `cp <backup> <file>` after, proved by `git diff --
@@ -422,20 +421,18 @@ JSON-DOCUMENT secret makes the needle stop occurring. Before trusting a green,
 ask what property of the INPUT the defect depends on.
 
 **When the change alters a CLASSIFIER, hand-picked cases cannot fence it —
-measure the DELTA against the old implementation.** A classifier is any
-function deciding which of several shapes an input is (region-vs-stack-name
-predicate, route selector, error categoriser); its defects live in shapes
-nobody wrote down. go-to-k/cdkd#2001 (2026-08-21) shipped THREE green
-revisions, each fixing the case the previous review named and breaking a
-neighbour, every revision passing a suite that grew one case per round. The
-fence that ends it is a differential walk: enumerate the input space, run BOTH
-the new implementation and a transcription of the old one, and fail on any
-difference outside an explicitly enumerated set of intended classes — a shape
-nobody imagined is a failure by default (it showed three delta classes where
-the comments said two). Get the transcription from
-`git show origin/main:<path>`, not memory, and confirm agreement on the cells
-where they SHOULD agree before trusting the cells where they differ. Two ways
-it goes inert, both measured on that lane:
+measure the DELTA against the old implementation.** A classifier is any function
+deciding which of several shapes an input is (region-vs-stack-name predicate,
+route selector, error categoriser); its defects live in shapes nobody wrote
+down. go-to-k/cdkd#2001 (2026-08-21) shipped THREE green revisions, each fixing
+the case the previous review named and breaking a neighbour. The fence that ends
+it is a differential walk: enumerate the input space, run BOTH the new
+implementation and a transcription of the old one, and fail on any difference
+outside an explicitly enumerated set of intended classes — a shape nobody
+imagined is a failure by default (it showed three delta classes where the
+comments said two). Take the transcription from `git show origin/main:<path>`,
+not memory, and confirm agreement on the cells where they SHOULD agree before
+trusting the cells where they differ. Two ways it goes inert, both measured:
 
 - **Classify by the resulting VALUE, not by the input's shape.** The first cut
   bucketed a differing cell by which key it was, so mutating the fix to return
@@ -444,16 +441,16 @@ it goes inert, both measured on that lane:
   now returns.
 - **Carry a floor per class.** The walk reaches a class only if the input pool
   contains it; one class was real, intended and never reached, so a pool that
-  quietly stops covering one would pass as "no regressions".
+  quietly stops covering one passes as "no regressions".
 
 **A VALUE import from a module other suites `vi.mock` reds those suites.** The
 `type`-only import is invisible to the mock; a runtime one is not, and the
 failure names the EXPORT (`[vitest] No "<CONST>" export ...`), reading as a
-missing symbol in the module you just edited rather than a mocking problem in
-a suite you did not touch (one constant imported into `state-file-keys.ts`
-reddened `gc.test.ts` and `bootstrap-destroy.test.ts`). When two modules must
-agree on a constant and one is widely mocked, spell it in both and fence the
-pair with a test importing both — the sync is what matters.
+missing symbol in the module you just edited rather than a mocking problem in a
+suite you did not touch (one constant imported into `state-file-keys.ts`
+reddened two unrelated suites). When two modules must agree on a constant and
+one is widely mocked, spell it in both and fence the pair with a test importing
+both — the sync is what matters.
 
 **Run probes with `vp test run <path>`, never `vp run test <path>`.** The
 wrapped form puts the Vite+ task runner between caller and verdict, and while
@@ -488,8 +485,8 @@ tree:
   on `'custom-resource-responses'` *with both quote characters*, so the probe's
   `` `${'...'}/` `` reds it while the spelling anybody would type — trailing
   slash inside the quote — sailed through, as did any copy outside the fence's
-  hand-written file list. Its author had just read the "grep for the SHAPE" rule
-  above. Mutate a fence the way a future contributor would, and derive the
+  hand-written file list. Its author had just read the "grep for the SHAPE, not
+  for a NAME" rule above. Mutate a fence the way a future contributor would, and derive the
   population rather than listing it.
 - **Write the defect in every spelling the language allows** and confirm each
   is flagged. go-to-k/cdkd#2111 (2026-08-20): a scanner for
@@ -746,11 +743,11 @@ because it converts an open gap into a recorded assurance:
 - **A scratch harness was silently REPLACED by another agent's file of the
   same name.** Its `__main__` was `pass`, so four probes "passed" having
   applied nothing — parallel agents share scratch space and pick the same
-  obvious filenames. Make every probe emit a positive receipt it cannot produce
-  without having run — `bytes 41822 -> 41799; anchor now 0 (was 1)` — and read
-  the receipt rather than the exit code.
+  obvious filenames. Name scratch files per lane, and make every probe emit a
+  positive receipt it cannot produce without having run — `bytes 41822 ->
+  41799; anchor now 0 (was 1)` — then read the receipt, not the exit code.
 
-  **That rule was already written here and was broken THREE times in one run
+  **The naming rule was already written here and was broken THREE times in one run
   (2026-08-26), so stop asking agents to invent the name: the ORCHESTRATOR
   assigns each dispatched agent a unique scratch directory IN ITS PROMPT**
   (`$SCRATCHPAD/lane<issue>-private/`, `$SCRATCHPAD/rev-<role>-<sha>/`), plus

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -5,9 +5,8 @@
 **When a fix round produces the NEXT round's blocker twice, stop reviewing the
 patch and question its SHAPE.** One lane ran FIVE rounds (2026-08-20) in which
 every blocker was created by the previous round's fix — each locally correct,
-moving the failure one layer out — and every one was found by executing a
-probe or tracing a window, never by re-reading the diff (twice a comment
-confidently asserted the opposite).
+moving the failure one layer out — and every one was found by executing a probe
+or tracing a window, never by re-reading the diff.
 
 - **After round two, ask what the rounds have in common.** There it was one
   structural absence (`destroy.ts` registers no command-level SIGINT handler
@@ -19,7 +18,8 @@ confidently asserted the opposite).
   choice reads as made, not missed.
 - **But filing the structural fix does not STOP the cascade.** In
   go-to-k/cdk-local#596 (2026-08-27) it was filed at round five and the rounds
-  ran to TWELVE. What ended it was making the artifact **CLAIM LESS**: the tell
+  ran to TWELVE (eleven instances of one class, five introduced by fixes). What
+  ended it was making the artifact **CLAIM LESS**: the tell
   is that each round's fix is more SOPHISTICATED than the last while the plain
   rc-only sweeps nearby were right all along (a `grep -q 'does not exist'` also
   matched botocore's own `source_profile ... does not exist`, raised before any
@@ -91,8 +91,9 @@ confidently asserted the opposite).
 load-bearing — and your instrument for measuring that can be structurally blind
 to it.** Ask before believing a widening safe: *what was the thing I am
 deleting actually doing?* go-to-k/cdkd#2333 (2026-08-27, WITHDRAWN after four
-rounds): dequoting structural tokens closed a real bypass, but the only brake
-on a widened `GATE_FLAGS` was that a QUOTED later token happened not to match,
+rounds): dequoting structural tokens closed a real bypass, but go-to-k/cdkd#2156
+had widened `GATE_FLAGS` so after a `-C` any later token can occupy the verb
+slot, and the only brake was that a QUOTED later token happened not to match,
 so removing it BLOCKED `git show "commit"` and 15 more ordinary commands. The
 bypass was real and the fix was worse — and the survey could not have told you,
 returning `NEWLY CONSIDERED 0` because every text it probes lands in ARGUMENT
@@ -144,8 +145,8 @@ correct, the gate doing its job. Sequencing: dispatch reviewers, apply EVERY
 finding including the nits, THEN rebase, THEN run the integ, THEN set the
 markers.
 
-- **Before starting an integ, ask what is still outstanding.** A reviewer
-  still running, an unapplied nit, a coming rebase each stale the marker.
+- **Before starting an integ, ask what is still outstanding.** A reviewer still
+  running, an unapplied nit, a coming rebase each stale the marker;
   `git diff origin/main...HEAD --name-only` against the gate's include list
   answers it in one command.
 - **A rebase can stale a `hash: diff` marker on its own** — the merge base
@@ -234,11 +235,11 @@ go-to-k/cdkd#2108 / go-to-k/cdkd#2109; none visible by reading the script):
 - **The host has the trigger but not the EVIDENCE, or the reverse.** A fix
   keying on recorded state needs the state AND the thing it describes in the
   SAME unit. `cdkd scrub` classifies only a literal `{{resolve:...}}` in the
-  TEMPLATE, so the producer stack (literal, no cross-stack read on record)
-  and the consumer (evidence, no literal) each had half — every fixture would
-  have passed with the fix reverted. Adding one small resource to the stack
-  already carrying the evidence made the arm real — cheaper than a new
-  fixture, so check for it before calling a live arm `next`.
+  TEMPLATE, so the producer stack (literal, no cross-stack read on record) and
+  the consumer (evidence, no literal) each had half — every fixture would have
+  passed with the fix reverted. Adding one small resource to the stack already
+  carrying the evidence made the arm real, cheaper than a new fixture: check
+  for that before calling a live arm `next`.
 - **The arm is INERT because the command returns early.** When the fix SKIPS
   something, a fixture whose only difference is the skipped thing gives the
   command no work: a `drift --revert` arm tampered exactly the now-skipped
@@ -316,32 +317,30 @@ indistinguishable from any other crash. Pair it with a `Monitor` that emits on
 phase lines AND on log-growth stalling.
 
 **ANCHOR the predicate the poller waits on, or it reports DONE while the job
-runs.** A loose predicate fails in the direction that matters: a premature
-DONE is acted on. Two shapes (2026-08-26): a non-empty test (`[ -s "$f" ]`)
-on a file the job ECHOES INTO before starting — the first `PWD=...` line
-satisfied it; and an unanchored substring — `grep -q "test_rc="` matches
-`typecheck_test_rc=` from an EARLIER step. Wait on a line the job writes only
-at the END, anchored (`grep -q "^suite_rc="`), and where the job has a
-process, confirm it is gone (`pgrep -f`) rather than inferring from the file.
+runs** — a premature DONE is acted on. Two shapes (2026-08-26): a non-empty
+test (`[ -s "$f" ]`) on a file the job ECHOES INTO before starting, satisfied
+by the first `PWD=...` line; and an unanchored substring, `grep -q "test_rc="`
+matching `typecheck_test_rc=` from an EARLIER step. Wait on a line the job
+writes only at the END, anchored (`grep -q "^suite_rc="`), and where the job
+has a process, confirm it is gone (`pgrep -f`) rather than inferring from the
+file.
 
 **The harness's "completed, exit 0" is the exit code of the command you
-BACKGROUNDED, which is not always the job you care about.** With
-`nohup <long job> > log 2>&1 & echo started` the wrapper returns immediately:
-measured 2026-08-21, a suite reported "completed (exit code 0)" while still
-executing 90 seconds later. Run the long job as the SOLE command of the
-backgrounded call (no trailing `&`) and read the log's own terminal line, not
-the notification. Two nearby traps: a `cd` inside the backgrounded compound
-leaves the parent's `$VAR` unset, so a follow-up `grep "$LOG"` reads a path
-that never existed; and `grep -c` exits 1 on a count of zero, so a
-verification command ending in one reports FAILED for the very case it was
-checking for.
+BACKGROUNDED, which is not always the job you care about.** With `nohup <long
+job> > log 2>&1 & echo started` the wrapper returns immediately: measured
+2026-08-21, a suite reported "completed (exit code 0)" while still executing 90
+seconds later. Run the long job as the SOLE command of the backgrounded call
+(no trailing `&`) and read the log's own terminal line, not the notification.
+Two nearby traps: a `cd` inside the backgrounded compound leaves the parent's
+`$VAR` unset, so a follow-up `grep "$LOG"` reads a path that never existed; and
+`grep -c` exits 1 on a count of zero, so a verification command ending in one
+reports FAILED for the very case it checks for.
 
 **Check a fixture's unstated PRECONDITIONS before spending a run on it.**
 Fixtures guard themselves and refuse rather than explain, so a wrong region
 costs a full round-trip each time: `asset-bootstrap` took three attempts on
-2026-08-20 — it needs a region that is **CDK-bootstrapped** (its legacy-mode
-phase publishes to the CDK bootstrap bucket) AND has **no cdkd marker** (its
-own guard refuses otherwise). Both conditions are two commands:
+2026-08-20 — it needs a region that is **CDK-bootstrapped** AND has **no cdkd
+marker** (its own guard refuses otherwise). Both are two commands:
 
 ```bash
 aws s3api head-bucket --bucket "cdk-hnb659fds-assets-<acct>-<region>"   # CDK-bootstrapped?
@@ -360,7 +359,8 @@ registry networking, and that is the half that fails.
 **Do NOT restart Docker to fix a hang — on Docker Desktop the restart IS the
 likelier cause.** The daemon routes registry traffic through a proxy the
 Docker Desktop **application** serves, so a quit-and-reopen can leave the
-`com.docker.backend` watchdog up while the app never finishes launching: every
+SELF-RESPAWNING `com.docker.backend` watchdog up (a `pkill` does not clear it)
+while the app never finishes launching: every
 pull then waits on a proxy that is not there while `docker version` keeps
 answering over the local socket (2026-08-20, four consecutive hung pulls; only
 a manual app restart recovered). Diagnose in this order and STOP at the first
@@ -461,12 +461,12 @@ by hand — otherwise the next reader concludes the merged fix is broken.
 
 **A fixture that establishes its precondition on the HAPPY path cannot test the
 arm where the FAILING path creates it — and it stays green while the fix is
-inert.** Every signal says pass. The go-to-k/cdkd#2057 lane (2026-08-20)
-shipped a refusal that could not fire: its evidence (`state.imports[]` /
-`outputReads[]`) was persisted only by the SUCCESS path, so a deploy that both
-INTRODUCES a cross-region read and fails recorded none of it — yet the fixture
-passed, having established the read with a successful deploy first. Four
-diff-reading reviewers passed it; a fifth found it by tracing the evidence.
+inert.** The go-to-k/cdkd#2057 lane (2026-08-20) shipped a refusal that could
+not fire: its evidence (`state.imports[]` / `outputReads[]`) was persisted only
+by the SUCCESS path, so a deploy that both INTRODUCES a cross-region read and
+fails recorded none of it — yet the fixture passed, having established the read
+with a successful deploy first. Four diff-reading reviewers passed it; a fifth
+found it by tracing the evidence.
 When a fix keys on state some earlier step wrote, ask **which step wrote it in
 the fixture, and which step writes it in the reachable case**. If the answer
 is "an earlier, successful one", add the arm where one operation does both —
@@ -671,9 +671,9 @@ service rather than a file, stop reading code and go measure.
 **Fresh deploys: UNIQUE stack names only** (e.g. `Cdkd<Issue>Verify`), never a
 shared fixed name and never a real prod stack — the account may hold the
 maintainer's production stacks. Tear down with `cdkd destroy … --force`, then
-SWEEP for orphans it can't reach (auto-created `/aws/lambda/*` log groups from
-`autoDeleteObjects` custom-resource Lambdas, RETAIN stateful resources,
-Secrets in recovery, KMS keys pending deletion). Confirm state is gone:
+SWEEP for orphans it cannot reach (auto-created `/aws/lambda/*` log groups from
+`autoDeleteObjects` custom-resource Lambdas, RETAIN stateful resources, Secrets
+in recovery, KMS keys pending deletion). Confirm state is gone:
 `aws s3 ls s3://cdkd-state-$(aws sts get-caller-identity --query Account --output text)/cdkd/`
 should show no leftover stack (the `deployments/` events store legitimately
 survives — it is not an orphan). If destroy failed or left orphans, delete
@@ -728,4 +728,6 @@ and if you must copy, copy OUTSIDE every repository, since deleting the `.git`
 file does not detach the copy, it only makes discovery walk UPWARD; and
 **report the TARGET worktree's `git status --porcelain` before AND after the
 round**, which is what makes damage attributable rather than a mystery. Every
-reviewer given these two lines reported clean both ways.
+reviewer given these two lines in that run reported clean both ways. If one
+does cause it, the repair is `git restore --staged` — the INDEX only, never the
+working tree, and the one carve-out to the no-writing-verb rule above.

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -18,17 +18,15 @@ confidently asserted the opposite).
   fix, file the structural one, and reference it from the narrow fix so the
   choice reads as made, not missed.
 - **But filing the structural fix does not STOP the cascade.** In
-  go-to-k/cdk-local#596 (2026-08-27) it was filed at round five and the
-  rounds ran to TWELVE (eleven instances of one class, five introduced by
-  fixes). What ended it was making the artifact **CLAIM LESS**. The tell:
-  each round's fix is more SOPHISTICATED than the last, while the plain
-  rc-only sweeps nearby were correct the whole time — `grep -q 'does not exist'`
-  also matches botocore's `The source_profile ... does not exist`, raised
-  before any network call, so a broken profile reported CLEAN having queried
-  nothing. The sophistication WAS the defect; the sweep now prints raw output
-  and names both outcomes instead of emitting a verdict — a command that
-  claims nothing cannot claim something false. Expect it to feel like a
-  retreat; it is one, and it converges.
+  go-to-k/cdk-local#596 (2026-08-27) it was filed at round five and the rounds
+  ran to TWELVE. What ended it was making the artifact **CLAIM LESS**: the tell
+  is that each round's fix is more SOPHISTICATED than the last while the plain
+  rc-only sweeps nearby were right all along (a `grep -q 'does not exist'` also
+  matched botocore's own `source_profile ... does not exist`, raised before any
+  network call, so a broken profile reported CLEAN having queried nothing). The
+  sweep now prints raw output and names both outcomes instead of emitting a
+  verdict — a command that claims nothing cannot claim something false. Expect
+  it to feel like a retreat; it is one, and it converges.
   - **Fence the REMEDIATION, not just the detection.** The last instance was
     in the repair: `cdk destroy` on names built without the required suffix
     exits 0 SILENTLY, and every fence pinned the DETECTION, so restoring that
@@ -47,6 +45,21 @@ confidently asserted the opposite).
   that every round's finding is a new INPUT CLASS the code got wrong rather
   than a new place the logic was wrong — when that is the shape, stop
   patching instances.
+- **When the shape is "THE FENCE COVERS ONE ROW OF A MULTI-DIMENSIONAL
+  GUARANTEE", widen it to the CROSS PRODUCT before the next fix.** Unlike the
+  shapes around it this is a defect in what can OBSERVE the fix, so a fix can be
+  wholly INERT with every signal green. The tell: the guarantee ranges over two
+  independent things (position AND reader, mode AND platform) while the suite
+  varies one at a time. Count the cells; if the fence has fewer assertions than
+  cells, name the uncovered ones and probe one. **The uncovered cell is not
+  random** — a hazard lives there BECAUSE that cell behaves differently, which
+  is why a "representative case per dimension" skips it. Measured 2026-09-03,
+  go-to-k/cdkd#2466: "every scalar round-trips" spans 4 positions x 2 YAML
+  readers; the suite covered 4 under 1.2 plus ONE under 1.1, and `<<` (the 1.1
+  merge key, special only as a KEY, only under 1.1) sat in the missing cell — so
+  its fix shipped inert through a full 3-axis round, the library's merge tag
+  discarding a correctly-set style. Widening the 1.1 arm to four positions reds
+  it; nothing did before.
 - **When the shape is "TWO SPELLINGS OF ONE QUESTION", the fix is to make both
   sites use ONE predicate verbatim — not to write a better second spelling.**
   A better spelling looks like a fix and passes its own test.
@@ -75,22 +88,18 @@ confidently asserted the opposite).
   written, passed, mutation-probed and reverted, so none of it is rebuilt.
 
 **When the fix WIDENS what a guard catches, the thing you removed may have been
-load-bearing — and the instrument you own for measuring that can be
-structurally blind to it.** Ask before believing a widening safe: *what was
-the thing I am deleting actually doing?* go-to-k/cdkd#2333 (2026-08-27,
-WITHDRAWN after four review rounds): dequoting structural tokens closed a real
-bypass (`git "commit"` evaded every gate), but go-to-k/cdkd#2156 had widened
-`GATE_FLAGS` so after a `-C` any later token can occupy the verb slot — the
-only brake was that a QUOTED later token happened not to match. Removing it
-made `git show "commit"` and 15 more ordinary commands BLOCK, `check-gate` on
-a feature worktree included. The bypass was real and the fix was worse.
-
-**The survey could not have told you.** `false-refusal-survey.sh` returned
-`NEWLY CONSIDERED 0` because every text it probes lands in ARGUMENT position,
-never the flag PREFIX — where the change acted. A measurement taken in the
-wrong position is not weak evidence, it is none, and it reads identically to
-the real thing. Name the POSITION your change acts in, confirm the instrument
-probes it, and build the arm that does before quoting a zero.
+load-bearing — and your instrument for measuring that can be structurally blind
+to it.** Ask before believing a widening safe: *what was the thing I am
+deleting actually doing?* go-to-k/cdkd#2333 (2026-08-27, WITHDRAWN after four
+rounds): dequoting structural tokens closed a real bypass, but the only brake
+on a widened `GATE_FLAGS` was that a QUOTED later token happened not to match,
+so removing it BLOCKED `git show "commit"` and 15 more ordinary commands. The
+bypass was real and the fix was worse — and the survey could not have told you,
+returning `NEWLY CONSIDERED 0` because every text it probes lands in ARGUMENT
+position, never the flag PREFIX where the change acted. A measurement taken in
+the wrong position is not weak evidence, it is none, and it reads identically
+to the real thing: name the POSITION your change acts in, confirm the
+instrument probes it, and build the arm that does before quoting a zero.
 
 - **Derive the reader population before patching readers.** Four rounds each
   found one more consumer deciding a gate outcome from the same text; one
@@ -349,14 +358,13 @@ under a 120s cap — because `docker version` answering says nothing about
 registry networking, and that is the half that fails.
 
 **Do NOT restart Docker to fix a hang — on Docker Desktop the restart IS the
-likelier cause.** The daemon routes registry traffic through
-`http.docker.internal:3128`, a proxy the Docker Desktop **application**
-serves. Quit-and-reopen can leave the self-respawning `com.docker.backend`
-watchdog up while the app never finishes launching — every pull then waits on
-a proxy that is not there, while `docker version` keeps answering over the
-local socket (measured 2026-08-20: four consecutive pulls hung, `pkill` could
-not clear it, only a manual app restart recovered). Diagnose in this order
-and STOP at the first line that explains the symptom:
+likelier cause.** The daemon routes registry traffic through a proxy the
+Docker Desktop **application** serves, so a quit-and-reopen can leave the
+`com.docker.backend` watchdog up while the app never finishes launching: every
+pull then waits on a proxy that is not there while `docker version` keeps
+answering over the local socket (2026-08-20, four consecutive hung pulls; only
+a manual app restart recovered). Diagnose in this order and STOP at the first
+line that explains the symptom:
 
 ```bash
 curl -s -o /dev/null -w '%{http_code}\n' --max-time 15 https://registry-1.docker.io/v2/  # 401 = HOST networking is fine
@@ -709,20 +717,15 @@ the lane's assumptions, not about the diff.
 **A reviewer's scratch COPY of a worktree is not detached from git, so its
 `git add -A` writes to the LIVE tree.** A linked worktree's `.git` is a FILE
 holding `gitdir: <repo>/.git/worktrees/<name>`, and `cp -R` carries the
-pointer: every git command inside the copy reads and WRITES the real
-worktree's index and HEAD. Measured 2026-08-29: a read-only code reviewer
-copied a lane's worktree, ran `git add -A` there, and staged three tracked
-DELETIONS under `tests/integration/local-invoke-layers/` in the live tree,
-which the lane's next commit would have shipped. Nothing announced it — the
-reviewer believed it was on a copy. So two lines belong in every read-only
-reviewer's brief, on top of §5's peer-probe rules: **run no WRITING git verb**
-(`add` / `commit` / `restore` / `checkout` / `stash` / `clean`) anywhere, copy
-included — and if you must copy, copy OUTSIDE every repository, since deleting
-the `.git` file does not detach the copy, it only makes discovery walk UPWARD
-into whatever encloses it; and **report the TARGET worktree's
-`git status --porcelain` before AND after the round.** The before/after pair is
-what makes damage attributable rather than a mystery a later agent finds: that incident surfaced only because the NEXT
-reviewer volunteered "the tree went dirty mid-review, not mine", after which
-the responsible one self-reported and repaired the index with `git restore
---staged` (index only, never the working tree). Every reviewer given these two
-lines in that run reported clean both ways.
+pointer, so every git command inside the copy reads and WRITES the real
+worktree's index and HEAD. Measured 2026-08-29: a read-only reviewer copied a
+lane's worktree, ran `git add -A`, and staged three tracked DELETIONS in the
+live tree — surfaced only because the NEXT reviewer volunteered that the tree
+had gone dirty mid-review. So two lines belong in every read-only reviewer's
+brief, on top of §5's peer-probe rules: **run no WRITING git verb** (`add` /
+`commit` / `restore` / `checkout` / `stash` / `clean`) anywhere, copy included —
+and if you must copy, copy OUTSIDE every repository, since deleting the `.git`
+file does not detach the copy, it only makes discovery walk UPWARD; and
+**report the TARGET worktree's `git status --porcelain` before AND after the
+round**, which is what makes damage attributable rather than a mystery. Every
+reviewer given these two lines reported clean both ways.

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -126,9 +126,9 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_548,
-    corpusBytes: 254_562,
-    largest: { file: 'implement.md', bytes: 48_781 },
-    runnerUp: { file: 'verify.md', bytes: 48_497 },
+    corpusBytes: 255_094,
+    largest: { file: 'implement.md', bytes: 48_960 },
+    runnerUp: { file: 'verify.md', bytes: 48_850 },
   },
 };
 

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -126,9 +126,9 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_548,
-    corpusBytes: 255_094,
-    largest: { file: 'implement.md', bytes: 48_960 },
-    runnerUp: { file: 'verify.md', bytes: 48_850 },
+    corpusBytes: 255_187,
+    largest: { file: 'verify.md', bytes: 48_992 },
+    runnerUp: { file: 'implement.md', bytes: 48_911 },
   },
 };
 


### PR DESCRIPTION
## Summary

Retro from the go-to-k/cdkd#2421 run (PR go-to-k/cdkd#2466), per the skill's own
section 10. That run took **four review rounds**, three of which found a defect
the previous round's fix had created — so the flow itself has something to
learn, and this lands it in the two stages where it fires.

## 1. `references/verify.md` section 8 — a cascade shape the list could not name

Section 8 already tells you to stop patching and question the SHAPE, and offers
three: *two spellings of one question*, *a proxy for a question only another
component can answer*, *a classifier*. All three are defects in the FIX.

This run hit a fourth, which is a defect in **what can OBSERVE the fix** — so
every signal is green and the round ends in agreement:

> the fence covers ONE ROW of a multi-dimensional guarantee

"Every scalar round-trips" ranged over **4 positions x 2 YAML readers**. The
suite asserted 4 positions under 1.2 plus ONE position under 1.1 — 5 of 8
cells, which reads as thorough. `<<` is hazardous in exactly the missing cell
(the 1.1 MERGE key: special only as a KEY, only under 1.1), so its fix shipped
**wholly inert** through a full 3-axis round — the oracle returned the right
answer, the visitor set the right style, and the library's merge tag discarded
it.

The generalizable half is why the missing cell was the dangerous one: **a
hazard lives in a cell BECAUSE that cell behaves differently**, which is the
same property that makes a "representative case per dimension" skip it. So the
instruction is to count cells, not dimensions.

## 2. `references/implement.md` section 5 — a third sweep key

Section 5 has two sweeps: grep the defect's SHAPE (same bug elsewhere) and grep
the SYMPTOM (someone already solved it). This run needed a third:

> grep the ISSUE NUMBER

Closing an issue falsifies every comment that CITES it, and the dangerous ones
are invisible to both existing sweeps because they are phrased as **deliberate
non-assertions** — they carry neither the defect's shape nor its symptom, only
a present-tense reason for not testing it.

Four live citations were found. The valuable one was an entire missing test in
`tests/integration/local-invoke/verify.sh` ("Deliberately NOT asserted: that the
template PARSES"), in a fixture that already synthesized — so adding it cost
nothing, and it immediately found a SECOND failure mode the closed issue never
named.

## Paying for it (section 10-c)

Both stage files were already within ~250 B of the 49 KB cap, so this is net
neutral rather than growth:

| file | before | after | cap |
| --- | --- | --- | --- |
| `implement.md` | 48,781 | 48,960 | 49,000 |
| `verify.md` | 48,497 | 48,850 | 49,000 |

What was cut, and why each is genuinely spent rather than merely shortened:

- **Retired archaeology**: the go-to-k/cdkd#2406 narrative about the *older*
  `main-tree-branch-gate` copy that skipped to the first `git` token. That fix
  is on `main` (verified: the content-probe returns non-zero), so the actionable
  residue is the probe itself, which stays.
- **Folded two adjacent same-lesson paragraphs** in `verify.md` — the widened-
  guard incident and "the survey could not have told you" are one lesson
  (your instrument did not probe where the change acts) told twice.
- **Compressed six incident retellings to rule + citation**, the shape the cap's
  own failure message asks for.

`MEASURED` in `tests/unit/scripts/skill-file-payload.test.ts` is updated in the
same commit, as that fence requires.

## Test plan

- `vp test run` — 877 files / 18,095 tests green, rooted in this worktree.
- `vp run check` / `vp run typecheck:test` / `vp run build` — rc=0.
- Skill fences green: `skill-file-payload` (caps + MEASURED) and
  `work-issues-skill-refs` (every reference qualified `go-to-k/<repo>#N`).
- Prose arm of step 9 — every claim the new text makes was resolved against
  this repo: the `go-to-k/cdkd#2406` content-probe returns 3, and the new
  `git grep -n "<issue number>" -- src tests docs .claude` command was the one
  actually used on the run it documents.
