### PR TITLE
docs: give the contributor guide a home on the site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,14 @@
 
 Thank you for your interest in contributing to cdkd!
 
+The full contributor guide — project structure, PR flow, the
+integration-test policy (which verification each PR needs, and why you are
+never required to run the AWS-charging tests yourself), and code style —
+lives at **[cdkd.dev/contributing](https://cdkd.dev/contributing/)**, next
+to the [Architecture](https://cdkd.dev/architecture/),
+[Provider Development](https://cdkd.dev/provider-development/), and
+[Testing](https://cdkd.dev/testing/) deep dives.
+
 ## Development Setup
 
 This repo uses Vite+ for the JavaScript toolchain and runtime/package-manager
@@ -30,90 +38,11 @@ vp env install
 # Install dependencies with the pinned pnpm version
 vp install
 
-# Build
+# Build, test, check
 vp run build
-
-# Run tests
 vp test run
-
-# Type check
-vp run typecheck
-
-# Lint
-vp run lint:fix
-
-# Format
-vp run format
+vp run check
 ```
-
-## Project Structure
-
-See [CLAUDE.md](CLAUDE.md) for detailed architecture documentation.
-
-## Making Changes
-
-1. Create a feature branch from `main`
-2. Make your changes
-3. Run `vp run check && vp test run && vp run build`
-4. Commit with a descriptive message
-5. Open a Pull Request
-
-## Adding a New SDK Provider
-
-See [docs/provider-development.md](docs/provider-development.md) for a step-by-step guide.
-
-## Adding Integration Tests
-
-Add new examples under `tests/integration/`. See existing examples for patterns.
-
-## Running Integration Tests
-
-Integration tests under `tests/integration/` deploy and destroy **real AWS
-resources**, so running them incurs real AWS charges. CI does not run them.
-
-**You are not required to run them.** If your change needs integration
-coverage (see the table below), just say so in your PR — the maintainer runs
-the required tests before merging, at no cost to you. The maintainer's merge
-gates physically block merging until the required integration run has passed,
-so coverage is guaranteed either way; asking is never a burden.
-
-Note this is about *running* the tests, not writing them: if your change adds
-behavior no existing fixture covers (e.g. a new SDK provider), you are still
-expected to add the fixture in the same PR (see "Adding Integration Tests"
-above) — the maintainer can run it for you.
-
-You are welcome to run them yourself against your own AWS account if you
-prefer — see [docs/testing.md](docs/testing.md) for per-test instructions.
-Most `local-*` tests are the exception on cost: they need only a local
-Docker daemon and touch no AWS resources (`local-invoke-from-state` is the
-one exception — it also deploys and destroys real AWS resources).
-
-### When is an integration test needed, and which one?
-
-Which verification a PR needs is derived mechanically from the paths it
-touches. The path lists are the gate scopes in
-[`.markgate.yml`](.markgate.yml) — the maintainer's merge gates read exactly
-those, so the file is the source of truth. In summary:
-
-| Your PR touches | Required verification (gate) |
-| --- | --- |
-| Deletion logic — `src/provisioning/providers/**`, destroy commands, rollback / retry code | An integration test that completes deploy **and destroy** cleanly (`integ-destroy`) |
-| Cross-cutting deploy/destroy code — `src/deployment/deploy-engine.ts`, `src/analyzer/dag-builder.ts`, intrinsic resolution, provider registration | A broad multi-resource test in addition to any feature-specific one (`integ-broad`; the test-name set is listed in `.markgate.yml`) |
-| Local execution — `src/local/**`, `src/cli/commands/local-*.ts` | A `local-*` test — Docker-based, most need no AWS account (`integ-local`) |
-| A state schema version bump in `src/types/state.ts` | The `schema-v<N>-to-v<N+1>-migration` round-trip test (`integ-schema-migration`) |
-| None of the above | No integration test — unit tests and CI are enough |
-
-When in doubt, open the PR and ask; the maintainer will pick and run the
-right tests.
-
-## Code Style
-
-- TypeScript with strict mode, checked by the native TypeScript 7 compiler (`tsc`)
-- ESM modules (`.js` extension in imports)
-- Node native type stripping for TypeScript runners (`node app.ts`)
-- Vite+ tasks in `vite.config.ts`
-- Oxfmt for formatting
-- Oxlint for linting, including type-aware checks
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,10 +39,20 @@ vp env install
 # Install dependencies with the pinned pnpm version
 vp install
 
-# Build, test, check
+# Build
 vp run build
+
+# Run tests
 vp test run
-vp run check
+
+# Type check
+vp run typecheck
+
+# Lint
+vp run lint:fix
+
+# Format
+vp run format
 ```
 
 ## Project Structure
@@ -63,13 +73,47 @@ walkthrough (also summarized in [CLAUDE.md](CLAUDE.md)).
 See [docs/provider-development.md](docs/provider-development.md) for a
 step-by-step guide.
 
-## Integration Tests
+## Adding Integration Tests
 
-Integration tests deploy and destroy **real AWS resources**, and you are
-never required to run them yourself — say so in your PR and the maintainer
-runs the required ones before merging. Which verification a PR needs (and
-the full policy) is in
-[docs/contributing.md](docs/contributing.md#running-integration-tests).
+Add new examples under `tests/integration/`. See existing examples for patterns.
+
+## Running Integration Tests
+
+Integration tests under `tests/integration/` deploy and destroy **real AWS
+resources**, so running them incurs real AWS charges. CI does not run them.
+
+**You are not required to run them.** If your change needs integration
+coverage, just say so in your PR — the maintainer runs the required tests
+before merging, at no cost to you. The maintainer's merge gates physically
+block merging until the required integration run has passed, so coverage is
+guaranteed either way; asking is never a burden.
+
+Note this is about *running* the tests, not writing them: if your change adds
+behavior no existing fixture covers (e.g. a new SDK provider), you are still
+expected to add the fixture in the same PR (see "Adding Integration Tests"
+above) — the maintainer can run it for you.
+
+You are welcome to run them yourself against your own AWS account if you
+prefer — see [docs/testing.md](docs/testing.md) for per-test instructions.
+Most `local-*` tests are the exception on cost: they need only a local
+Docker daemon and touch no AWS resources (`local-invoke-from-state` is the
+one exception — it also deploys and destroys real AWS resources).
+
+Which verification a PR needs is derived mechanically from the paths it
+touches — the per-gate table lives in
+[docs/contributing.md](docs/contributing.md#when-is-an-integration-test-needed-and-which-one)
+(source of truth: the gate scopes in [`.markgate.yml`](.markgate.yml)).
+When in doubt, open the PR and ask; the maintainer will pick and run the
+right tests.
+
+## Code Style
+
+- TypeScript with strict mode, checked by the native TypeScript 7 compiler (`tsc`)
+- ESM modules (`.js` extension in imports)
+- Node native type stripping for TypeScript runners (`node app.ts`)
+- Vite+ tasks in `vite.config.ts`
+- Oxfmt for formatting
+- Oxlint for linting, including type-aware checks
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,11 @@ Thank you for your interest in contributing to cdkd!
 The full contributor guide — project structure, PR flow, the
 integration-test policy (which verification each PR needs, and why you are
 never required to run the AWS-charging tests yourself), and code style —
-lives at **[cdkd.dev/contributing](https://cdkd.dev/contributing/)**, next
-to the [Architecture](https://cdkd.dev/architecture/),
-[Provider Development](https://cdkd.dev/provider-development/), and
-[Testing](https://cdkd.dev/testing/) deep dives.
+lives in **[docs/contributing.md](docs/contributing.md)**, next to the
+[Architecture](docs/architecture.md),
+[Provider Development](docs/provider-development.md), and
+[Testing](docs/testing.md) deep dives (rendered at
+[cdkd.dev/contributing](https://cdkd.dev/contributing/)).
 
 ## Development Setup
 
@@ -43,6 +44,32 @@ vp run build
 vp test run
 vp run check
 ```
+
+## Project Structure
+
+See [docs/architecture.md](docs/architecture.md) for the layer-by-layer
+walkthrough (also summarized in [CLAUDE.md](CLAUDE.md)).
+
+## Making Changes
+
+1. Create a feature branch from `main`
+2. Make your changes
+3. Run `vp run check && vp test run && vp run build`
+4. Commit with a descriptive message
+5. Open a Pull Request
+
+## Adding a New SDK Provider
+
+See [docs/provider-development.md](docs/provider-development.md) for a
+step-by-step guide.
+
+## Integration Tests
+
+Integration tests deploy and destroy **real AWS resources**, and you are
+never required to run them yourself — say so in your PR and the maintainer
+runs the required ones before merging. Which verification a PR needs (and
+the full policy) is in
+[docs/contributing.md](docs/contributing.md#running-integration-tests).
 
 ## License
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,127 @@
+---
+title: Contributing
+description: How to set up a cdkd development environment, make changes, and know which verification your PR needs.
+---
+
+# Contributing to cdkd
+
+Thank you for your interest in contributing to cdkd! Issues and pull
+requests are welcome at [github.com/go-to-k/cdkd](https://github.com/go-to-k/cdkd).
+
+## Development Setup
+
+This repo uses Vite+ for the JavaScript toolchain and runtime/package-manager
+workflows. Developer tasks run on Node.js 24, pinned by `.node-version` and
+managed by Vite+, while the package continues to support users on Node.js 20
+and later. Dependencies are installed with pnpm 11 through Vite+.
+
+The global `vp` CLI itself is pinned by `.mise.toml` via mise's HTTP backend
+against Vite+'s platform CLI tarball. `mise install` also installs
+[markgate](https://github.com/go-to-k/markgate), which the commit-gate hook
+depends on.
+
+```bash
+# Clone the repository
+git clone https://github.com/go-to-k/cdkd.git
+cd cdkd
+
+# Trust the mise config, then install pinned developer tools (vp, markgate, etc.)
+# (mise requires explicit trust on first checkout or whenever .mise.toml changes)
+mise trust
+mise install
+
+# Install the project Node.js version from .node-version with Vite+
+vp env install
+
+# Install dependencies with the pinned pnpm version
+vp install
+
+# Build
+vp run build
+
+# Run tests
+vp test run
+
+# Type check
+vp run typecheck
+
+# Lint
+vp run lint:fix
+
+# Format
+vp run format
+```
+
+## Project Structure
+
+See [Architecture](architecture.md) for the layer-by-layer walkthrough.
+
+## Making Changes
+
+1. Create a feature branch from `main`
+2. Make your changes
+3. Run `vp run check && vp test run && vp run build`
+4. Commit with a descriptive message
+5. Open a Pull Request
+
+## Adding a New SDK Provider
+
+See [Provider Development](provider-development.md) for a step-by-step guide.
+
+## Adding Integration Tests
+
+Add new examples under `tests/integration/`. See existing examples for patterns.
+
+## Running Integration Tests
+
+Integration tests under `tests/integration/` deploy and destroy **real AWS
+resources**, so running them incurs real AWS charges. CI does not run them.
+
+**You are not required to run them.** If your change needs integration
+coverage (see the table below), just say so in your PR — the maintainer runs
+the required tests before merging, at no cost to you. The maintainer's merge
+gates physically block merging until the required integration run has passed,
+so coverage is guaranteed either way; asking is never a burden.
+
+Note this is about *running* the tests, not writing them: if your change adds
+behavior no existing fixture covers (e.g. a new SDK provider), you are still
+expected to add the fixture in the same PR (see "Adding Integration Tests"
+above) — the maintainer can run it for you.
+
+You are welcome to run them yourself against your own AWS account if you
+prefer — see [Testing](testing.md) for per-test instructions.
+Most `local-*` tests are the exception on cost: they need only a local
+Docker daemon and touch no AWS resources (`local-invoke-from-state` is the
+one exception — it also deploys and destroys real AWS resources).
+
+### When is an integration test needed, and which one?
+
+Which verification a PR needs is derived mechanically from the paths it
+touches. The path lists are the gate scopes in
+[`.markgate.yml`](https://github.com/go-to-k/cdkd/blob/main/.markgate.yml) —
+the maintainer's merge gates read exactly those, so the file is the source of
+truth. In summary:
+
+| Your PR touches | Required verification (gate) |
+| --- | --- |
+| Deletion logic — `src/provisioning/providers/**`, destroy commands, rollback / retry code | An integration test that completes deploy **and destroy** cleanly (`integ-destroy`) |
+| Cross-cutting deploy/destroy code — `src/deployment/deploy-engine.ts`, `src/analyzer/dag-builder.ts`, intrinsic resolution, provider registration | A broad multi-resource test in addition to any feature-specific one (`integ-broad`; the test-name set is listed in `.markgate.yml`) |
+| Local execution — `src/local/**`, `src/cli/commands/local-*.ts` | A `local-*` test — Docker-based, most need no AWS account (`integ-local`) |
+| A state schema version bump in `src/types/state.ts` | The `schema-v<N>-to-v<N+1>-migration` round-trip test (`integ-schema-migration`) |
+| None of the above | No integration test — unit tests and CI are enough |
+
+When in doubt, open the PR and ask; the maintainer will pick and run the
+right tests.
+
+## Code Style
+
+- TypeScript with strict mode, checked by the native TypeScript 7 compiler (`tsc`)
+- ESM modules (`.js` extension in imports)
+- Node native type stripping for TypeScript runners (`node app.ts`)
+- Vite+ tasks in `vite.config.ts`
+- Oxfmt for formatting
+- Oxlint for linting, including type-aware checks
+
+## License
+
+Apache 2.0

--- a/vite.docs.config.ts
+++ b/vite.docs.config.ts
@@ -90,6 +90,7 @@ const navigation: SsgNavigationGroup[] = [
   {
     title: 'Contributing',
     items: [
+      { title: 'Contributing Guide', path: '/contributing' },
       { title: 'Architecture', path: '/architecture' },
       { title: 'Provider Development', path: '/provider-development' },
       { title: 'Testing', path: '/testing' },


### PR DESCRIPTION
## Summary

The sidebar's Contributing group linked only the three deep dives (Architecture / Provider Development / Testing); the actual contributor workflow — dev setup, PR flow, the integration-test policy and its gate table — lived solely in the repo's CONTRIBUTING.md with no path to it from the site.

- New `docs/contributing.md` carries the full guide as the Contributing group's first entry ("Contributing Guide"), with repo-relative links rewritten to their site pages (`CLAUDE.md` → Architecture, `docs/*.md` → site-relative, `.markgate.yml` → the GitHub blob URL).
- `CONTRIBUTING.md` keeps the clone / mise / vp setup block (GitHub surfaces the file in the PR UI, so it must stand alone for that moment) and points at cdkd.dev/contributing for everything else — the same treatment the README got.

## Test plan

- Full `vp test run` green (879 files / 18,136 tests) — includes the docs-site link fence (new nav path has a matching page; the page is nav-listed so the nav-or-unlisted check covers it).
- `vp run docs:build` green; `dist/site/contributing/index.html` built.
