### PR TITLE
ci: add Dependabot config for npm and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot version updates.
+#
+# Commit-message prefixes are chosen against this repo's semantic-release
+# rules (.releaserc): `chore(...)` / `ci(...)` do NOT cut a release, which is
+# deliberate — runtime deps use caret ranges, so users already pick up newer
+# AWS SDK clients on install; a lockfile/range bump only affects dev + CI.
+# All prefixes are in pr-title-check.yml's allowed types.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      # 55+ @aws-sdk/client-* deps release in lockstep; one PR, not dozens.
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+      dev-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` (version-update config; previously absent) with two update streams:

- **npm** (pnpm-lock.yaml), weekly (Mon, Asia/Tokyo):
  - `aws-sdk` group — the 55+ `@aws-sdk/*` clients release in lockstep, so they bump as one PR instead of dozens.
  - `dev-dependencies` group — all devDependencies in one PR.
  - Remaining production deps (`cdk-local`, `graphlib`, `archiver`, ...) get individual PRs.
  - `open-pull-requests-limit: 10`.
- **github-actions**, weekly, all actions grouped into one PR (SHA-pinned actions are supported; Dependabot bumps the pin and the version comment).

Commit-message prefixes are chosen against this repo's conventions (rationale is also in a header comment in the file):

- `chore(deps)` / `chore(deps-dev)` for npm, `ci(deps)` for actions — all are allowed types in `pr-title-check.yml`.
- Neither `chore` nor `ci` triggers a semantic-release release (`.releaserc` releases only on `feat` / `fix` / `perf` / breaking / revert). This is deliberate: runtime deps use caret ranges, so users already resolve newer AWS SDK clients at install time — a range/lockfile bump only affects dev + CI, and should not cut a release by itself.

## Test plan

- `vp check --fix` + `vp run check`: 0 errors
- `vp run typecheck:test`, `vp run build`: pass
- `vp test run`: 879 files / 18151 passed (1 skipped), rooted in this worktree
- Config validated against SchemaStore's `dependabot-2.0.json` with ajv: valid
- Live behavior cannot be exercised pre-merge — Dependabot only reads the file from the default branch. Schema validation + prefix cross-check against `pr-title-check.yml` and `.releaserc` are the pre-merge substitute; the first scheduled run after merge is the real confirmation.

https://claude.ai/code/session_016o9o8ecyjHJxvUvSRs7tT5
