### PR TITLE
chore(integ): record the pre-merge re-verification runs for PR 2492 in the integ ledger

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -149,7 +149,7 @@ intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 stale
 kinesis-esm-filter	2026-08-10T04:23:28Z	PASS	63	verify.sh	0810 sweep b2; post-#1398 lambda-eventsource re-verify, 5 del 0 err, 0 orph
 kinesis-stream-mode-switch	2026-08-26T08:41:59Z	PASS	120	verify.sh	issue 2178 masker-threading sweep (kinesis); 3 phases, 0 err, 0 orphans
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda	2026-09-03T18:18:00Z	PASS	99	verify.sh	issue #2482 broad gate (intrinsic-function-resolver.ts cross-cutting), re-run after the rebase onto 5d8d93b1; 9 deleted 0 errors 0 orphans
+lambda	2026-09-04T01:27:30Z	PASS	95	verify.sh	pre-merge re-verify of PR 2492 (broad gate); rc ok, orph clean
 lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-arch-switch	2026-07-26T19:25:15Z	PASS	63	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 lambda-config-field-removal	2026-08-11T13:09:08Z	PASS	132	verify.sh	issue #609 Lambda 4-prop backfill + review fixes; 5 del 0 err 0 orphans
@@ -276,7 +276,7 @@ sns-subscription-filter	2026-08-10T05:38:11Z	PASS	39	verify.sh	0810 P2 sweep b9;
 sns-subscription-update	2026-08-20T11:53:45Z	PASS	70	verify.sh	#1967 new fixture, 4 phases. First real-AWS coverage of SNSSubscriptionProvider.update at all: phase 2 proves the internal replacement ran (SubscriptionArn changed, exactly one subscription, state in sync); phase 3 corrupts the physicalId so Unsubscribe throws and asserts cdkd ABORTS -- deploy exit 1, no Subscribe issued, old subscription untouched. Destroy clean, 0 orphans
 sqs-cloudwatch	2026-08-13T11:19:53Z	PASS	-	standard	issue 1815 partition ARN builders; rc 0, destroy clean, 0 orphans
 sqs-esm-max-concurrency	2026-08-10T04:23:28Z	PASS	76	verify.sh	0810 sweep b2; lambda-eventsource re-verify, 5 del 0 err, 0 orph
-ssm-secure-dynamic-ref	2026-09-03T18:14:00Z	PASS	208	verify.sh	issue #2482 new fixture, re-run after the rebase onto 5d8d93b1; two SecureString params seeded out of band, whole/embedded/versioned env forms resolved, state holds expressions; 2 deleted 0 errors 0 orphans, S3 versions swept
+ssm-secure-dynamic-ref	2026-09-04T01:22:57Z	PASS	106	verify.sh	pre-merge re-verify of PR 2492; rc ok, orph clean
 stack-lock-renewal	2026-08-23T02:58:02Z	PASS	539	verify.sh	issue #2168 lock renewal final: 8 probe receipts (S3 answers NoSuchKey/404 for a conditional delete of an absent object) + 29 deploy samples, expiresAt +363s never lapsed never absent; destroy 0 err 0 orph
 state-destroy	2026-08-13T06:35:09Z	PASS	95	standard	PR 1774 gate; state destroy exit-code path, 1 del 0 err, zero-skip run byte-identical (no skipped suffix), orph clean
 state-info-command	2026-08-02T05:07:05Z	PASS	31	verify.sh	new verify.sh (#1335): state info human+json, flag+env sources, 1 del/0 err, 0 orphans


### PR DESCRIPTION
## Summary

Records the two real-AWS integ runs executed while re-verifying PR (#2492) before its merge, per the mandatory ledger contract in `.claude/skills/run-integ/SKILL.md` step 13. The runs happened from the reviewing session's worktree (the markgate markers are per-worktree), so the rows could not ride the fork PR itself.

- `ssm-secure-dynamic-ref` — PASS, 106 s, 0 errors, 0 orphans, 0 surviving state-bucket object versions, both out-of-band parameters removed.
- `lambda` (broad set, `integ-broad` gate — `intrinsic-function-resolver.ts` is cross-cutting) — PASS, 95 s, 9 deleted, 0 errors, 0 orphans.

Ledger normalized (`vp run integ-ledger-normalize`); the diff is the two refreshed rows only.

## Verification

- Full local suite on this branch: 880 files, 18,181 tests passed, no type errors.
- `vp check` / `vp run check` / `vp run typecheck:test` / `vp run build` / `vp run gen:all-matrices` / `vp run audit:coverage:check`: all green.
