### PR TITLE
chore(ci): make a stale release PR recoverable on demand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,25 @@ name: Release
 # NO CI checks (and ci-green-gate blocks an agent-side `gh pr merge` on it).
 # Its diff is only version/CHANGELOG/manifest; the maintainer merges it via
 # the web UI. To get CI on release PRs, hand the release-please step a PAT.
+#
+# Known behavior: release-please does NOT rebuild a standing release PR whose
+# computed release is unchanged — it logs `PR #N remained the same` and leaves
+# the branch on the base it was cut from. So a change to a file release-please
+# OWNS (CHANGELOG.md) that lands on main afterwards is absent from the release
+# branch, and GitHub can still report the PR MERGEABLE: merging it would take
+# the branch's stale copy and undo that change. Seen on go-to-k/cdkd#2503,
+# which was closed and recreated as go-to-k/cdkd#2508 after CHANGELOG.md was
+# normalized. Remedy: close the release PR, delete its branch, and re-run this
+# workflow — which is what `workflow_dispatch` below is for. Re-running is
+# safe: release-please recomputes the identical release from main.
 
 on:
   push:
     branches:
       - main
+  # Manual re-run: recreate a stale release PR (see the note above), or refresh
+  # one without waiting for the next merge. release-please is idempotent.
+  workflow_dispatch:
 
 permissions: {}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,20 @@ such PRs) and `ci-green-gate` blocks an agent-side merge of it — the
 maintainer merges the release PR via the web UI (its diff is only
 version/CHANGELOG/manifest, already CI-covered on main).
 
+**A standing release PR can go STALE, and it stays mergeable while it is.**
+release-please does not rebuild a release PR whose computed release is
+unchanged — it logs `PR #N remained the same` and leaves the branch on the
+base it was cut from. So anything that later lands on `main` in a file
+release-please OWNS (`CHANGELOG.md`, `package.json`'s version,
+`.release-please-manifest.json`) is missing from that branch, and merging the
+PR takes the branch's stale copy and reverts it. Measured on #2503, whose
+branch predated the CHANGELOG normalization (#2504): GitHub reported it
+MERGEABLE while merging it would have undone 285 header conversions. The
+remedy is to close the release PR, delete its branch, and re-run the release
+workflow (`workflow_dispatch` exists for exactly this) — release-please
+recomputes the identical release from current `main`. So after any PR that
+edits one of those files, check whether a release PR is open and recreate it.
+
 ## Node.js Version
 
 - **`package.json` engines**: Node.js >= 20.0.0 (the lower bound for users of cdkd).


### PR DESCRIPTION
## Summary

A standing release PR can go **stale and stay mergeable**, and there was no way to recreate it on demand. Both halves are fixed here.

### The behavior

release-please does not rebuild a release PR whose computed release is unchanged — it logs `PR #N remained the same` and leaves the branch on the base it was cut from. So anything landing on `main` afterwards in a file release-please **owns** (`CHANGELOG.md`, `package.json`'s version, `.release-please-manifest.json`) is absent from that branch, and GitHub still reports the PR **MERGEABLE**: merging it takes the stale copy and reverts the change.

### Measured, not reasoned about

Release PR go-to-k/cdkd#2503 was cut before the CHANGELOG normalization (go-to-k/cdkd#2504) merged. After that merge:

- the release run logged `PR #2503 remained the same`;
- `gh api .../contents/CHANGELOG.md?ref=release-please--branches--main--components--cdkd` returned the **pre-normalization** file (no `# Changelog` title);
- `gh pr view 2503 --json mergeable` reported **MERGEABLE** — merging it would have undone 285 header conversions.

Closing it, deleting its branch, and re-running the workflow produced go-to-k/cdkd#2508, whose diff inserts `0.285.14` **at the top**, directly under the preamble and above `0.285.13`. That is also the end-to-end confirmation that the normalization fixed the splice point against the real action, not just against the fence.

### What changed

1. `.github/workflows/release.yml` — `workflow_dispatch:` added beside `push: main`, because executing the remedy above required `gh run rerun` on an unrelated older push run. Re-running is safe at any time: release-please recomputes the identical release from `main`. The trigger addition does not affect npm OIDC trusted publishing, which binds to the workflow **file name** (unchanged). The header records the behavior, the symptom, the measurement and the remedy.
2. `CLAUDE.md` Release Flow — the same warning, ending with the actionable rule: after any PR that edits one of those files, check whether a release PR is open and recreate it.

### Not fenced, deliberately

No test asserts `workflow_dispatch`. It is a convenience trigger, not an invariant, and pinning it would only make the file harder to edit. The YAML was verified to parse with both triggers and both jobs intact, and the v0 fence's cases that read this file still pass.

## Test plan

- `vp check --fix` / `vp run check` / `vp run typecheck:test` / `vp run build`: rc=0
- `vp test run`: 880 files / 18183 tests passed, no type errors
- Workflow parse check: `triggers: {"push":{"branches":["main"]},"workflow_dispatch":null}`, `jobs: release-please,publish`
- The live sequence above (stale branch inspected, PR recreated, placement verified on go-to-k/cdkd#2508)
