### PR TITLE
test(scripts): stop the aws-client-defaults fence re-walking the tree, budget the whole file, and floor the text scan

### DIFF
--- a/tests/unit/scripts/aws-client-defaults-fence.test.ts
+++ b/tests/unit/scripts/aws-client-defaults-fence.test.ts
@@ -485,15 +485,43 @@ describe('SDK client construction critic', () => {
       return out;
     }
 
+    /**
+     * BOTH cases below read the SAME immutable tree, and each of them used to
+     * pay for it twice over: `textScan()` walks all 334 `src/**` files (10.8 MB)
+     * and was called twice per case, and `findClientSites` -- a full TypeScript
+     * parse -- ran once per HIT (171) rather than once per distinct FILE (83),
+     * because `textScan().map(...)` parses before `new Map` dedupes and the
+     * SIZE case loops hits directly. Measured on a 12-core host: 751 + 631 ms
+     * as written against 237 ms for one shared scan and one parse per file.
+     * That is what put these two cases at 3.7-4.1 s of the 5 s budget under
+     * partial parallel load and made them flake on CI (issue #2491).
+     *
+     * SCOPED TO THIS DESCRIBE ON PURPOSE. The `regression probes against the
+     * REAL tree` block below rewrites a scratch COPY of `src/` and re-reports
+     * it; a module-level cache keyed by absolute path would be consulted there
+     * too and could hand a probe its PRE-MUTATION verdict, which is a probe
+     * that passes without testing anything. These two cases never mutate, so
+     * sharing between them changes no verdict.
+     */
+    let scanned: ReturnType<typeof textScan> | undefined;
+    const scanOnce = (): ReturnType<typeof textScan> => (scanned ??= textScan());
+    const siteCache = new Map<string, ReturnType<typeof findClientSites>>();
+    function sitesOnce(file: string): ReturnType<typeof findClientSites> {
+      let found = siteCache.get(file);
+      if (found === undefined) {
+        found = findClientSites(file, readFileSync(file, 'utf8'));
+        siteCache.set(file, found);
+      }
+      return found;
+    }
+
     it('finds no construction the AST walk did not, except in prose', () => {
       const detected = new Set<string>();
-      for (const [file, sites] of new Map(
-        textScan().map((h) => [h.file, findClientSites(h.file, readFileSync(h.file, 'utf8'))])
-      )) {
-        for (const site of sites) detected.add(`${file}:${site.line}`);
+      for (const hit of scanOnce()) {
+        for (const site of sitesOnce(hit.file)) detected.add(`${hit.file}:${site.line}`);
       }
 
-      const unexplained = textScan().filter(
+      const unexplained = scanOnce().filter(
         (hit) =>
           !detected.has(`${hit.file}:${hit.line}`) &&
           // A construction NAMED in a comment is not a construction.
@@ -512,11 +540,11 @@ describe('SDK client construction critic', () => {
     it('the two methods agree on the SIZE, not just on the absence of surprises', () => {
       // The floor's other direction: if the AST walk started reporting sites the
       // text scan cannot see, one of them is wrong and it is worth knowing.
-      const scanned = new Set(textScan().map((h) => `${h.file}:${h.line}`));
+      const scannedLines = new Set(scanOnce().map((h) => `${h.file}:${h.line}`));
       const detectedNotScanned: string[] = [];
-      for (const hit of textScan()) {
-        for (const site of findClientSites(hit.file, readFileSync(hit.file, 'utf8'))) {
-          if (!scanned.has(`${hit.file}:${site.line}`)) {
+      for (const hit of scanOnce()) {
+        for (const site of sitesOnce(hit.file)) {
+          if (!scannedLines.has(`${hit.file}:${site.line}`)) {
             detectedNotScanned.push(`${hit.file}:${site.line}`);
           }
         }
@@ -716,4 +744,19 @@ describe('SDK client construction critic', () => {
       expect(result.stderr).toContain('only valid with --check');
     });
   });
-});
+  // FILE-LEVEL, not on the two cases the flake report named (issue #2491).
+  // Eight of the 48 cases here read the REAL tree, and the memoisation above
+  // only helps the two that were WASTING work. The six `regression probes
+  // against the REAL tree` cases each `cpSync` the whole 10.8 MB `src/` tree
+  // and then run `buildReport` over all 334 files, which is legitimately about
+  // a second apiece and does not get cheaper by rewriting; measured under
+  // partial parallel load they sit at 1.5-2.8 s, the largest within 12% of the
+  // two named cases when idle. A timeout on the named pair alone would move
+  // the next flake one test over.
+  //
+  // 15 s rather than the 30 s the report suggested: after the memoisation the
+  // whole file runs in about 2-3 s, so this is ~10x headroom and still fails
+  // loudly. 30 s would silently absorb another 6x regression in a file whose
+  // entire job is to fail loudly. The repo already spells per-test budgets as
+  // `}, 15_000)` and sets no global `testTimeout`, so this adds no mechanism.
+}, 15_000);

--- a/tests/unit/scripts/aws-client-defaults-fence.test.ts
+++ b/tests/unit/scripts/aws-client-defaults-fence.test.ts
@@ -504,7 +504,31 @@ describe('SDK client construction critic', () => {
      * sharing between them changes no verdict.
      */
     let scanned: ReturnType<typeof textScan> | undefined;
-    const scanOnce = (): ReturnType<typeof textScan> => (scanned ??= textScan());
+    function scanOnce(): ReturnType<typeof textScan> {
+      scanned ??= textScan();
+      // THE OTHER METHOD'S FLOOR. `the real tree > still sees the population`
+      // floors the AST walk for exactly this reason, and the text scan --
+      // the half that makes this block a reconciliation rather than a second
+      // green run -- had none: a `CONSTRUCTION` regex that stops matching, or
+      // a `walk()` rooted at the wrong directory, empties BOTH cases below
+      // and they pass with nothing to report, while the AST floor stays green
+      // because that side is unharmed. Measured 171 hits across 83 files;
+      // round numbers below it, per the sibling floor's reasoning.
+      //
+      // Asserted on EVERY call, not once at population: the memo would
+      // otherwise hand the SECOND case a cached empty array with no check,
+      // so a collapsed scan would fail one case and pass the other -- and
+      // "one of the two reconciliation cases is green" is the reading this
+      // block exists to make impossible.
+      expect(
+        scanned.length,
+        'the text scan found almost nothing -- it is the independent half of this ' +
+          'reconciliation, so a collapsed scan makes both cases below vacuous. Check ' +
+          '`CONSTRUCTION` and the directory `walk()` starts from.'
+      ).toBeGreaterThanOrEqual(100);
+      expect(new Set(scanned.map((h) => h.file)).size).toBeGreaterThanOrEqual(50);
+      return scanned;
+    }
     const siteCache = new Map<string, ReturnType<typeof findClientSites>>();
     function sitesOnce(file: string): ReturnType<typeof findClientSites> {
       let found = siteCache.get(file);


### PR DESCRIPTION
Closes #2491

## Summary

`tests/unit/scripts/aws-client-defaults-fence.test.ts` flakes at the 5000 ms default timeout under parallel load. The report named two cases and proposed a per-test timeout on them; measuring every case in the file first showed that is under-scoped, and that only one of the two costs involved is actually waste.

## What changed

- **The waste.** The two named cases (`finds no construction the AST walk did not, except in prose`, `the two methods agree on the SIZE`) each called `textScan()` twice — four full walks of 334 `src/**/*.ts` files, 10.8 MB — and called `findClientSites`, a full TypeScript parse, once per HIT (171) rather than once per distinct FILE (83), because `textScan().map(...)` parses before `new Map` dedupes and the SIZE case loops hits directly. They now share one scan and one parse per file.
- **The memo is scoped to the `the detected population IS the real one` describe, not module level.** The `regression probes against the REAL tree` block below rewrites a scratch COPY of `src/` and re-reports it; a cache keyed by absolute path at module scope could hand a probe its pre-mutation verdict — a probe that passes without testing anything.
- **The explicit budget goes on the FILE, not the two named cases.** The six probe cases `cpSync` the whole tree and re-run `buildReport` over all 334 files, so they are legitimately about a second each and do not get cheaper by rewriting. `15_000` rather than the suggested `30_000`: the file now runs in about 2-3 s, so that is roughly 10x headroom while still failing loudly, where 30 s would absorb another 6x regression silently in a file whose entire job is to fail loudly. The repo already spells per-test budgets as `}, 15_000)` and sets no global `testTimeout`, so this adds no mechanism.
- **A floor on the text-scan population (second commit).** Found by probing the memo: `scanOnce()` returning an empty array left BOTH reconciliation cases green, because `unexplained` and `detectedNotScanned` are derived FROM the scan. Pre-existing, and invisible while the derivation was duplicated in two bodies. `the real tree > still sees the population` already floors the AST walk for exactly this reason; the text scan — the half that makes this block a reconciliation rather than a second green run — had none. Floors at 100 hits / 50 files against a measured 171 / 83, round numbers below the measurement per the sibling floor's reasoning, and asserted on EVERY call rather than once at population so the memo cannot hand the second case a cached empty array unchecked.

## Measurements (12-core host)

Idle, file alone:

```text
                                                            before    after
finds no construction the AST walk did not, except in prose  1514 ms   409 ms
the two methods agree on the SIZE                            1461 ms  under 100 ms
```

Under `tests/unit/scripts` parallelism (58 files, a fraction of a full run's contention):

```text
                                                            before    after
finds no construction the AST walk did not, except in prose  3752 ms   577 ms
the two methods agree on the SIZE                            4103 ms  under 100 ms
slowest case anywhere in the file                            2766 ms  1386 ms
```

The whole directory run also dropped from 196 s to 148 s. The slowest remaining case is 1386 ms against the 15 s budget.

Why the file, not the pair: idle, the six `regression probes against the REAL tree` cases measured 759-1339 ms, the largest within 12% of the named pair, and 1535-2766 ms under the same parallelism. A timeout on the named two moves the next flake one test over.

## Verification

- `vp check --fix` / `vp run check` / `vp run typecheck:test` / `vp run build`: 0 errors.
- `vp test run`: **881 files, 18,203 passed (1 skipped), at the DEFAULT 5000 ms budget** — no `--testTimeout` override. That is the point: go-to-k/cdkd#2511 needed `vp test run --testTimeout=20000` on this same host to get a green full run, so the standard command that `/check` and CI use was no longer reproducing green.
- The describe-level budget was probed by setting it to `1`: 9 cases fail with `Test timed out in 1ms`, so it does bind the nested `it`s rather than being ignored.
- Vacuity probed both ways on the final tree: `scanned ??= []` fails BOTH reconciliation cases with the floor's message, and dropping the AST results (`sitesOnce` returning `[]`) still fails the first. Neither half passes vacuously.
- No `src/` change, so no integ gate applies (`integ-destroy` / `integ-broad` / `integ-local` / `integ-schema-migration` are all n/a — the diff is one file under `tests/unit/scripts/`).

## Note on the issue's estimate

`Estimate: ~30 min` was low; this took closer to 1-2 h. Deciding how to treat the six probe cases, keeping the memo scope off module level, and the floor the memo exposed were the work — not the edit.
