### PR TITLE
docs: bring the Local Execution pages onto the shared template

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -165,7 +165,7 @@ The `cdkd local` family is where that is not yet uniform:
 | --- | --- |
 | `local invoke`, `local run-task`, `local invoke-agentcore` | The flag and both environment variables. |
 | `local start-api` | The flag only, so an upper-cased `AWS_REGION` still reaches the Lambda containers it starts. |
-| `local start-service`, `local start-alb`, `local start-cloudfront`, `local start-agentcore` | Neither. Spell the region lower-case on these four. |
+| `local start-service`, `local start-alb`, `local start-cloudfront`, `local start-agentcore` | Neither, apart from the `--from-state` state read, which folds both. Spell the region lower-case on these four. |
 
 The fold is not cosmetic. Everything downstream of the value is case-sensitive,
 and in different ways:
@@ -298,6 +298,16 @@ meaning is "non-zero result", not "the command crashed":
 
 - **`cdkd drift` exits `1` when drift is detected.**
 - **`cdkd diff --fail` exits `1` when any change is detected.**
+
+The `cdkd local` family adds two codes of its own:
+
+| Exit | Meaning |
+| --- | --- |
+| `130` | Interrupted by `^C`. The long-running servers also use it for a clean SIGTERM shutdown, except `local start-cloudfront` and `local start-agentcore`, which exit `0` there. |
+| `N` | `cdkd local run-task` propagates its essential container's own exit code. |
+
+Per-command detail is on each command's page under
+[Local Execution](local-emulation.md).
 
 Exit `2` is carried by the error itself rather than decided by the command that
 catches it, so an intermediate handler re-throwing a partial failure cannot

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -165,7 +165,7 @@ The `cdkd local` family is where that is not yet uniform:
 | --- | --- |
 | `local invoke`, `local run-task`, `local invoke-agentcore` | The flag and both environment variables. |
 | `local start-api` | The flag only, so an upper-cased `AWS_REGION` still reaches the Lambda containers it starts. |
-| `local start-service`, `local start-alb`, `local start-cloudfront`, `local start-agentcore` | Neither. The `--from-state` state read folds `--region` and `--stack-region` for its own S3 client, but nothing folds the environment variables. Spell the region lower-case on these four. |
+| `local start-service`, `local start-alb`, `local start-cloudfront`, `local start-agentcore` | Neither. On the three where `--from-state` is live it folds `--region` for the S3 client and `--stack-region` for the state-record match, but nothing folds the environment variables. Spell the region lower-case on these four. |
 
 The fold is not cosmetic. Everything downstream of the value is case-sensitive,
 and in different ways:
@@ -303,7 +303,7 @@ The `cdkd local` family adds two codes of its own:
 
 | Exit | Meaning |
 | --- | --- |
-| `130` | Interrupted by `^C`, on every `cdkd local` command. `local start-service` and `local start-alb` also exit `130` on SIGTERM, because they bind it to the same handler; the other servers exit `0` there. |
+| `130` | Interrupted by `^C`, on every `cdkd local` command. `local start-service` and `local start-alb` also exit `130` on SIGTERM, because they bind it to the same handler; `local start-api`, `local start-cloudfront` and `local start-agentcore` exit `0` there. |
 | `N` | `cdkd local run-task` propagates its essential container's own exit code. |
 
 Per-command detail is on each command's page under

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -165,7 +165,7 @@ The `cdkd local` family is where that is not yet uniform:
 | --- | --- |
 | `local invoke`, `local run-task`, `local invoke-agentcore` | The flag and both environment variables. |
 | `local start-api` | The flag only, so an upper-cased `AWS_REGION` still reaches the Lambda containers it starts. |
-| `local start-service`, `local start-alb`, `local start-cloudfront`, `local start-agentcore` | Neither, apart from the `--from-state` state read, which folds both. Spell the region lower-case on these four. |
+| `local start-service`, `local start-alb`, `local start-cloudfront`, `local start-agentcore` | Neither. The `--from-state` state read folds `--region` and `--stack-region` for its own S3 client, but nothing folds the environment variables. Spell the region lower-case on these four. |
 
 The fold is not cosmetic. Everything downstream of the value is case-sensitive,
 and in different ways:
@@ -303,7 +303,7 @@ The `cdkd local` family adds two codes of its own:
 
 | Exit | Meaning |
 | --- | --- |
-| `130` | Interrupted by `^C`. The long-running servers also use it for a clean SIGTERM shutdown, except `local start-cloudfront` and `local start-agentcore`, which exit `0` there. |
+| `130` | Interrupted by `^C`, on every `cdkd local` command. `local start-service` and `local start-alb` also exit `130` on SIGTERM, because they bind it to the same handler; the other servers exit `0` there. |
 | `N` | `cdkd local run-task` propagates its essential container's own exit code. |
 
 Per-command detail is on each command's page under

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -147,13 +147,25 @@ without passing through cdkd's logger, so take the **last** line
 
 ## `--region` / `AWS_REGION` (every command)
 
+**Prefer `AWS_REGION` or your AWS profile.** `--region` is deprecated on cdkd's
+own commands: it is hidden from `--help`, it prints a deprecation warning, and it
+will be removed in a future release. It is not a no-op while it lasts — it still
+outranks both the environment variable and the profile. The `cdkd local`
+long-running servers (`start-service`, `start-alb`, `start-cloudfront`,
+`start-agentcore`) are the exception: they carry their own `--region`, which is
+neither hidden nor deprecated.
+
 **A region is folded to its canonical lower-case spelling before it reaches an
 AWS client.** `--region US-EAST-1`, `AWS_REGION=US-EAST-1` and
 `AWS_DEFAULT_REGION=US-EAST-1` all behave exactly as `us-east-1` does.
 
-One exception: `cdkd local start-api` folds the flag but not the environment
-variables, so an upper-cased `AWS_REGION` still reaches the Lambda containers it
-starts. Its three sibling `cdkd local *` commands fold both.
+The `cdkd local` family is where that is not yet uniform:
+
+| Command | What is folded |
+| --- | --- |
+| `local invoke`, `local run-task`, `local invoke-agentcore` | The flag and both environment variables. |
+| `local start-api` | The flag only, so an upper-cased `AWS_REGION` still reaches the Lambda containers it starts. |
+| `local start-service`, `local start-alb`, `local start-cloudfront`, `local start-agentcore` | Neither. Spell the region lower-case on these four. |
 
 The fold is not cosmetic. Everything downstream of the value is case-sensitive,
 and in different ways:
@@ -350,7 +362,8 @@ Lambda functions, API Gateway routes, ECS tasks, ECS Services, ALB front-doors,
 CloudFront distributions, and Bedrock AgentCore Runtimes — without an AWS
 deploy. Most commands run the workload in Docker; `local start-cloudfront`
 serves a CloudFront-Functions + S3-origin distribution in-process (no Docker),
-falling back to Docker/RIE only for a Lambda Function URL origin.
+and reaches for Docker/RIE only when the distribution has a Lambda Function URL
+origin or a Lambda@Edge association.
 
 The full reference for all `cdkd local *` subcommands (`local invoke` /
 `local start-api` / `local run-task` / `local start-service` / `local start-alb` /

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -206,10 +206,10 @@ fallback — apply to the **bootstrap-marker family**: `cdkd bootstrap`,
 `cdkd gc`, and `cdkd bootstrap --destroy`. These three move together because one
 writes the key the other two read.
 
-The `cdkd local` family has its own chain and never falls back to a literal:
-`--region`, then `AWS_REGION`, then `AWS_DEFAULT_REGION`, then the synthesized
-stack's own `env.region`. Every remaining command resolves `--region` →
-`AWS_REGION` and falls back to the `us-east-1` literal.
+The `cdkd local` family reads `AWS_DEFAULT_REGION` too, and adds a fourth step
+of its own: `--region`, then `AWS_REGION`, then `AWS_DEFAULT_REGION`, then the
+region the target stack was synthesized or recorded for. It falls back to the
+`us-east-1` literal only when none of those resolves.
 
 ### The reconciliation
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -140,10 +140,9 @@ without passing through cdkd's logger, so take the **last** line
    `END` / `REPORT` *and* every handler log line — `console.error` included —
    on the container's stdout, so any handler that prints lands ahead of the
    response.
-2. **cdk-local's own logger.** cdkd reuses cdk-local for the container-image
-   build path, and cdk-local has a separate logger with no reservation concept,
-   so `Building container image (platform=...)` and `Skipping docker build ...`
-   print on stdout for a container-image Lambda.
+2. **The container-image build path.** For a container-image Lambda,
+   `Building container image (platform=...)` and `Skipping docker build ...`
+   print on stdout rather than stderr.
 
 ## `--region` / `AWS_REGION` (every command)
 
@@ -205,7 +204,11 @@ so cdkd reads it too and stays in step with a CLI command you just ran.
 The last three steps — `AWS_DEFAULT_REGION`, the profile, and the `us-east-1`
 fallback — apply to the **bootstrap-marker family**: `cdkd bootstrap`,
 `cdkd gc`, and `cdkd bootstrap --destroy`. These three move together because one
-writes the key the other two read. Every other command resolves `--region` →
+writes the key the other two read.
+
+The `cdkd local` family has its own chain and never falls back to a literal:
+`--region`, then `AWS_REGION`, then `AWS_DEFAULT_REGION`, then the synthesized
+stack's own `env.region`. Every remaining command resolves `--region` →
 `AWS_REGION` and falls back to the `us-east-1` literal.
 
 ### The reconciliation

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -204,12 +204,11 @@ so cdkd reads it too and stays in step with a CLI command you just ran.
 The last three steps — `AWS_DEFAULT_REGION`, the profile, and the `us-east-1`
 fallback — apply to the **bootstrap-marker family**: `cdkd bootstrap`,
 `cdkd gc`, and `cdkd bootstrap --destroy`. These three move together because one
-writes the key the other two read.
+writes the key the other two read. Every other command resolves `--region` →
+`AWS_REGION` and falls back to the `us-east-1` literal.
 
-The `cdkd local` family reads `AWS_DEFAULT_REGION` too, and adds a fourth step
-of its own: `--region`, then `AWS_REGION`, then `AWS_DEFAULT_REGION`, then the
-region the target stack was synthesized or recorded for. It falls back to the
-`us-east-1` literal only when none of those resolves.
+The `cdkd local` family resolves its region per command; each command's page
+gives its own chain.
 
 ### The reconciliation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,11 +88,12 @@ cdkd has three command families:
   you don't want to synth. `cdkd state destroy` is the CDK-app-free
   counterpart of `cdkd destroy`.
 - **`cdkd local ...` subcommands** (`local invoke` / `start-api` /
-  `run-task` / `start-service`) run synthesized workloads locally
-  inside Docker containers — no AWS deploy needed. Modeled on
+  `run-task` / `start-service` / `start-alb` / `start-cloudfront` /
+  `invoke-agentcore` / `start-agentcore`) run synthesized workloads
+  locally inside Docker containers — no AWS deploy needed. Modeled on
   `sam local *` but reads CDK state directly via `--from-state`
   (cdkd-managed) or `--from-cfn-stack` (CFn-managed). See
-  [Local execution](local-emulation.md).
+  [Local Execution](local-emulation.md).
 
 Options like `--app`, `--state-bucket`, and `--context` can be omitted if configured via `cdk.json` or environment variables (`CDKD_APP`, `CDKD_STATE_BUCKET`).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,7 +90,8 @@ cdkd has three command families:
 - **`cdkd local ...` subcommands** (`local invoke` / `start-api` /
   `run-task` / `start-service` / `start-alb` / `start-cloudfront` /
   `invoke-agentcore` / `start-agentcore`) run synthesized workloads
-  locally inside Docker containers — no AWS deploy needed. Modeled on
+  locally, most of them in Docker containers — no AWS deploy needed.
+  Modeled on
   `sam local *` but reads CDK state directly via `--from-state`
   (cdkd-managed) or `--from-cfn-stack` (CFn-managed). See
   [Local Execution](local-emulation.md).

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -76,7 +76,9 @@ Every `cdkd local` subcommand accepts these.
 | `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
 | `--verbose` | off | Verbose logging. |
 
-Two more are accepted by every subcommand **except `local start-cloudfront`**:
+`--from-state` and its two bucket flags are accepted everywhere but do nothing on
+`local start-cloudfront`, which reads deployed values only through
+`--from-cfn-stack`. Two more flags are not accepted there at all:
 
 | Flag | Default | Description |
 | --- | --- | --- |
@@ -120,8 +122,8 @@ URL — has no value to resolve to, because nothing has been deployed.
 
 | Flag | Reads | Use when |
 | --- | --- | --- |
-| `--from-state` | cdkd's S3 state for the stack | The stack was deployed with `cdkd deploy`. |
-| `--from-cfn-stack [name]` | A deployed CloudFormation stack's resources | The stack was deployed with the AWS CDK CLI. |
+| `--from-state` | cdkd's S3 state for the stack | The stack was deployed with `cdkd deploy`. Not on `local start-cloudfront`. |
+| `--from-cfn-stack [name]` | A deployed CloudFormation stack's resources | The stack was deployed with the AWS CDK CLI, or the command is `local start-cloudfront`. |
 
 `--from-cfn-stack` resolves `Ref` and `Fn::ImportValue` from the deployed
 physical IDs and exports. `Fn::GetAtt` is not universally recoverable, because a

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -69,7 +69,7 @@ Every `cdkd local` subcommand accepts these.
 | `--from-state` | off | Resolve intrinsic-valued properties against cdkd's deployed S3 state. Mutually exclusive with `--from-cfn-stack`. |
 | `--from-cfn-stack [name]` | — | Resolve them against a deployed CloudFormation stack instead, for apps deployed with the AWS CDK CLI. Bare form uses the cdkd stack name. |
 | `--stack-region <region>` | — | Which region's record to read, and the CloudFormation client region under `--from-cfn-stack`. |
-| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding the state read by `--from-state`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json`, then `cdkd-state-{accountId}` | S3 bucket holding the state read by `--from-state`. The default means `--from-state` works with no configuration on a bootstrapped account. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. |
 | `--profile <profile>` | — | AWS profile. |
 | `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for AWS API calls. |
@@ -101,11 +101,16 @@ optional `Parameters` object for values that apply everywhere.
 
 A `null` value clears the key rather than setting it to the string `"null"`.
 
-For Lambda targets — `local invoke` and `local start-api` — the resource key may
-be either the logical ID or the **CDK display path** (`MyStack/MyHandler`), the
-same form the `<target>` argument accepts; it is matched against the resource's
-`aws:cdk:path` metadata. The two forms coexist in one file, and when both name
-the same key the later JSON entry wins, matching SAM's apply-in-order semantics.
+What the top-level key names depends on what the command runs:
+
+| Command | Key |
+| --- | --- |
+| `local invoke`, `local start-api` | The Lambda's logical ID, or its **CDK display path** (`MyStack/MyHandler`) — the same form the `<target>` argument accepts, matched against the resource's `aws:cdk:path` metadata. |
+| `local run-task`, `local start-service`, `local start-alb` | The **container name**, i.e. `ContainerDefinitions[].Name`. |
+| `local invoke-agentcore`, `local start-agentcore` | The runtime's logical ID or CDK display path. |
+
+For Lambda targets the two forms coexist in one file, and when both name the
+same key the later JSON entry wins, matching SAM's apply-in-order semantics.
 
 ### `--from-state` and `--from-cfn-stack`: resolving deployed values
 

--- a/docs/local-emulation.md
+++ b/docs/local-emulation.md
@@ -1,75 +1,153 @@
 ---
 title: Local Execution
-description: "Run AWS workloads on your machine with cdkd local via Docker — invoke Lambda functions, serve API Gateway, and run ECS tasks with no AWS deploy."
+description: "Run AWS workloads on your machine with cdkd local via Docker — invoke Lambda functions, serve API Gateway and ALB, run ECS tasks and services, and serve CloudFront and Bedrock AgentCore, with no AWS deploy."
 ---
 
-# Local execution
+# Local Execution
 
-`cdkd local *` runs AWS workloads on the developer's machine via Docker
-— no AWS deploy, no `template.yaml` to maintain, no `cdk synth | sam ...`
-round-trip. Reuses cdkd's synthesis / asset / construct-path plumbing
-directly.
+`cdkd local *` runs the AWS workloads in your CDK app on your own machine. There
+is no deploy, no `template.yaml` to maintain, and no `cdk synth | sam ...`
+round-trip — the commands read the same cloud assembly `cdkd deploy` does, so a
+handler edit is testable in seconds.
+
+```bash
+cdkd local invoke MyStack/Handler --event event.json   # one-shot Lambda invoke
+cdkd local start-api                                   # serve every discovered API on localhost
+cdkd local run-task MyStack/Service/TaskDef            # run one ECS task definition
+cdkd local start-service MyStack/Service --watch       # long-running ECS service, hot-reloaded
+cdkd local start-api -a cdk.out                        # skip synthesis, reuse a built assembly
+cdkd local invoke MyStack/Handler --from-state         # resolve intrinsics from deployed state
+```
 
 ## Subcommands
 
-| Subcommand | Emulates | Backed by |
+| Command | Emulates | Shape |
 | --- | --- | --- |
-| [`cdkd local invoke <target>`](local-invoke.md) | One-shot Lambda invoke | AWS Lambda Runtime Interface Emulator (RIE) container |
-| [`cdkd local start-api`](local-start-api.md) | Long-running API Gateway (REST v1 / HTTP API / Function URL) | RIE container pool + `node:http` listener (one server per discovered API) |
-| [`cdkd local run-task <target>`](local-run-task.md) | ECS `RunTask` for one task | docker network + ECS metadata sidecar (`amazon/amazon-ecs-local-container-endpoints`) |
-| [`cdkd local start-service <target>`](local-start-service.md) | Long-running ECS `Service` emulator | `run-task` machinery per replica + per-replica docker subnet allocator + restart-on-exit watcher |
-| [`cdkd local invoke-agentcore <target>`](local-invoke-agentcore.md) | One-shot Bedrock AgentCore Runtime invoke | AgentCore container on port 8080 (HTTP `/invocations` / MCP `/mcp` / A2A `/a2a` / WebSocket `/ws`) |
-| [`cdkd local start-agentcore [target]`](local-start-agentcore.md) | Long-running serve of a Bedrock AgentCore Runtime against a warm container (all four protocols) | AgentCore container on port 8080 (shimmed from cdk-local), booted once + kept warm. HTTP / AGUI: host `node:http` server proxies `POST /invocations` + `GET /ping` and fronts the bidirectional `/ws` endpoint (injects the session-id / Authorization a header-less browser client cannot set), both on one port. MCP serves `POST /mcp`; A2A serves `POST /` (no `/ws`) |
-| [`cdkd local start-alb <targets...>`](local-start-alb.md) | Long-running local ALB front-door for ECS / Lambda backing services | shared ECS service emulator engine (shimmed from cdk-local) + per-listener `node:http(s)` front-door with path / host / header / weighted / redirect / fixed-response routing |
-| [`cdkd local start-cloudfront [target]`](local-start-cloudfront.md) | Long-running local CloudFront distribution (viewer-request -> S3 / Lambda Function URL origin -> viewer-response) | in-process `node:http(s)` server (shimmed from cdk-local) — CloudFront Functions in a `node:vm` sandbox + S3 origin served from the `BucketDeployment` source asset; Lambda Function URL origins run locally via the RIE container (Docker) |
+| [`cdkd local invoke`](local-invoke.md) | One Lambda invocation | One-shot |
+| [`cdkd local start-api`](local-start-api.md) | API Gateway REST v1, HTTP API, WebSocket API and Function URL routes | Server, one per discovered API |
+| [`cdkd local run-task`](local-run-task.md) | ECS `RunTask` for one task definition | One-shot |
+| [`cdkd local start-service`](local-start-service.md) | ECS `Service`, `DesiredCount` replicas with restart-on-exit | Server |
+| [`cdkd local start-alb`](local-start-alb.md) | Application Load Balancer in front of ECS or Lambda targets | Server, one per listener port |
+| [`cdkd local start-cloudfront`](local-start-cloudfront.md) | CloudFront distribution: CloudFront Functions, Lambda@Edge, S3 and Lambda Function URL origins | Server |
+| [`cdkd local invoke-agentcore`](local-invoke-agentcore.md) | One Bedrock AgentCore Runtime invocation | One-shot |
+| [`cdkd local start-agentcore`](local-start-agentcore.md) | Bedrock AgentCore Runtime served against a warm container | Server |
+
+The servers run until `^C`, which tears down every container, sidecar and
+docker network they created.
 
 ## Requirements
 
-Most `cdkd local *` commands require Docker on the developer's machine.
-The first run pulls the relevant base image (~600MB for the
-language-specific Lambda images, ~50MB for `provided.*`, plus the ECS
-metadata sidecar for `run-task`). Subsequent runs reuse the cached
-image; pass `--no-pull` to skip the `docker pull` round-trip
-altogether (per-command `--no-pull` semantics may differ — see each
-section below). The exception is `local start-cloudfront` for a
-CloudFront-Functions + S3-origin-only distribution, which serves
-entirely in-process (CloudFront Functions in a `node:vm` sandbox, S3
-origin from local files) and needs no Docker — but a distribution with
-a Lambda Function URL origin runs that origin's backing Lambda locally
-via the RIE container, so Docker is required in that case.
+Docker is required for everything that runs a workload container: the Lambda
+Runtime Interface Emulator (RIE) behind `local invoke` and `local start-api`,
+the task containers and the ECS metadata sidecar behind `local run-task` /
+`local start-service` / `local start-alb`, and the agent container behind the
+two AgentCore commands.
+
+`local start-cloudfront` is the one command that can run without Docker. A
+distribution whose origins are all S3 and whose only edge logic is CloudFront
+Functions serves entirely in-process — the functions run in a sandboxed VM and
+the S3 content is read from the `BucketDeployment` source in the cloud assembly.
+Docker is required as soon as the distribution has a Lambda Function URL origin
+or a Lambda@Edge association, because those run in RIE containers.
+
+The first run pulls the images it needs: roughly 600 MB for a language-specific
+Lambda base image, 50 MB for `provided.*`, plus the ECS metadata sidecar for the
+task commands. Later runs reuse the cached image. `--no-pull` skips the `docker
+pull` round-trip entirely; its exact scope differs per command, so check the
+command's own page.
 
 ## Common flags
 
-`-a, --app`, `--no-pull`, `--from-state` and `--stack-region` are accepted by
-every `cdkd local` subcommand. `--env-vars` and `--container-host` are
-accepted by all of them **except `start-cloudfront`**.
+Every `cdkd local` subcommand accepts these.
 
-- `-a, --app <cmd-or-dir>` — CDK app command or pre-synthesized
-  `cdk.out` directory. Defaults to synth-every-time; pass `-a cdk.out`
-  to iterate faster.
-- `--env-vars <file>` — SAM-compatible JSON override:
-  `{"LogicalId":{"KEY":"VALUE"}, "Parameters":{...}}`. `null` clears a
-  key. For Lambda (`local invoke` / `local start-api`) the function-specific
-  key may also be a **CDK display path** (`MyStack/MyHandler` — the same
-  form `cdkd local invoke <target>` accepts), matched against the
-  resource's `Metadata['aws:cdk:path']`. Logical-ID and display-path
-  entries coexist; if both list the same key, the later JSON entry wins
-  (matches SAM's apply-in-order semantics).
-- `--no-pull` — Skip `docker pull` (per-command semantics differ;
-  consult each section).
-- `--from-state` — Resolve intrinsic-valued properties against cdkd's
-  deployed S3 state. Off by default; the target stack must have been
-  deployed via `cdkd deploy` first.
-- `--stack-region <region>` — Disambiguate when the same stack name
-  has cdkd state in multiple regions (only with `--from-state`).
-  Region CASE is not significant: the value is matched against the state
-  record's own spelling case-insensitively, so `--stack-region US-EAST-1`
-  reads the `us-east-1` record instead of silently falling back to no
-  state. A record spelled exactly the way you TYPED the
-  flag always wins, so with both `us-east-1` and `US-EAST-1` records
-  present each flag spelling reads its own; that collision is reported at
-  warn, naming the record read and which of the two rules chose it.
-- `--container-host <ip>` — Bind IP for published ports (default
-  `127.0.0.1`). Must be a numeric IP; Docker rejects hostnames in
-  `-p <ip>:<port>:<port>`.
+| Flag | Default | Description |
+| --- | --- | --- |
+| `-a`, `--app <cmd-or-dir>` | `cdk.json` / `CDKD_APP` | CDK app command, or a pre-synthesized cloud assembly directory. Pass `-a cdk.out` to skip synthesis. |
+| `--output <path>` | `cdk.out` | Output directory for synthesis. |
+| `-c`, `--context <key=value...>` | — | CDK context values. Repeatable. |
+| `--no-pull` | off | Skip `docker pull` and use the cached image. Per-command scope differs. |
+| `--from-state` | off | Resolve intrinsic-valued properties against cdkd's deployed S3 state. Mutually exclusive with `--from-cfn-stack`. |
+| `--from-cfn-stack [name]` | — | Resolve them against a deployed CloudFormation stack instead, for apps deployed with the AWS CDK CLI. Bare form uses the cdkd stack name. |
+| `--stack-region <region>` | — | Which region's record to read, and the CloudFormation client region under `--from-cfn-stack`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding the state read by `--from-state`. |
+| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. |
+| `--profile <profile>` | — | AWS profile. |
+| `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for AWS API calls. |
+| `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
+| `--verbose` | off | Verbose logging. |
 
+Two more are accepted by every subcommand **except `local start-cloudfront`**:
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--env-vars <file>` | — | JSON environment-variable overrides, SAM-compatible. |
+| `--container-host <ip>` | `127.0.0.1` | Bind IP for published container ports. Must be a numeric IP — Docker rejects hostnames in `-p <ip>:<port>:<port>`. |
+
+Everything else is per-command; each page's own options table is the complete
+list for that command.
+
+### `--env-vars`: overriding environment variables
+
+The file is SAM-compatible: a top-level object keyed by resource, plus an
+optional `Parameters` object for values that apply everywhere.
+
+```json
+{
+  "MyHandler1234ABCD": { "TABLE_NAME": "local-table", "DEBUG": "1" },
+  "MyStack/MyHandler": { "ENDPOINT": "http://host.docker.internal:4566" },
+  "Parameters": { "LOG_LEVEL": "debug" }
+}
+```
+
+A `null` value clears the key rather than setting it to the string `"null"`.
+
+For Lambda targets — `local invoke` and `local start-api` — the resource key may
+be either the logical ID or the **CDK display path** (`MyStack/MyHandler`), the
+same form the `<target>` argument accepts; it is matched against the resource's
+`aws:cdk:path` metadata. The two forms coexist in one file, and when both name
+the same key the later JSON entry wins, matching SAM's apply-in-order semantics.
+
+### `--from-state` and `--from-cfn-stack`: resolving deployed values
+
+Both are off by default, and they are mutually exclusive. Without either, an
+intrinsic-valued property — a `Ref` to a table name, an `Fn::GetAtt` on a queue
+URL — has no value to resolve to, because nothing has been deployed.
+
+| Flag | Reads | Use when |
+| --- | --- | --- |
+| `--from-state` | cdkd's S3 state for the stack | The stack was deployed with `cdkd deploy`. |
+| `--from-cfn-stack [name]` | A deployed CloudFormation stack's resources | The stack was deployed with the AWS CDK CLI. |
+
+`--from-cfn-stack` resolves `Ref` and `Fn::ImportValue` from the deployed
+physical IDs and exports. `Fn::GetAtt` is not universally recoverable, because a
+stack's resource listing carries no per-attribute values; where cdkd cannot
+recover one it warns and drops the value rather than substituting a wrong one.
+What each command can recover differs, so check its own page.
+
+### `--stack-region`: choosing between records
+
+Only meaningful alongside `--from-state` or `--from-cfn-stack`. Pass it when the
+same stack name has state in more than one region.
+
+Region **case is not significant**: the value is matched against the state
+record's own spelling case-insensitively, so `--stack-region US-EAST-1` reads the
+`us-east-1` record instead of silently falling back to no state at all. A record
+spelled exactly the way you typed the flag always wins, so if both a `us-east-1`
+and a `US-EAST-1` record exist, each flag spelling reads its own. That collision
+is reported at warn level, naming the record read and which of the two rules
+chose it.
+
+## Reaching a server on the host
+
+Containers cannot reach `localhost` on your machine — inside the container,
+`localhost` is the container. Use `host.docker.internal` for a service running
+on the host, which is what an override like
+`"ENDPOINT": "http://host.docker.internal:4566"` is for.
+
+## Related
+
+- [CLI Reference](cli-reference.md) — every cdkd command, the output-stream
+  contract, and the full exit-code table
+- [Getting Started](getting-started.md) — installing cdkd and deploying a first
+  stack
+- [State Management](state-management.md) — what `--from-state` reads

--- a/docs/local-invoke-agentcore.md
+++ b/docs/local-invoke-agentcore.md
@@ -51,9 +51,9 @@ source) are supported.
 | `--ecr-role-arn <arn>` | — | Role to assume before authenticating to ECR, for cross-account or centralized registries. Same-account, same-region pulls need no role. |
 | `--from-state` | off | Substitute `Ref` / `Fn::GetAtt` / `Fn::Sub` / `Fn::ImportValue` in env vars from cdkd's S3 state. Mutually exclusive with `--from-cfn-stack`. See [Environment variables](#environment-variables). |
 | `--from-cfn-stack [cfn-stack-name]` | off | Substitute `Ref` / `Fn::ImportValue` in env vars from a deployed CloudFormation stack, for apps deployed via the upstream CDK CLI. Mutually exclusive with `--from-state`. |
-| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Used only with `--from-state`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json`, then `cdkd-state-{accountId}` | S3 bucket holding cdkd state. Used only with `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Used only with `--from-state`. |
-| `--stack-region <region>` | auto | Region of the state record to read, and the CFn client region for `--from-cfn-stack`. See [Local Execution](local-emulation.md#common-flags). |
+| `--stack-region <region>` | — | Region of the state record to read, and the CFn client region for `--from-cfn-stack`. See [Local Execution](local-emulation.md#common-flags). |
 | `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a pre-synthesized cloud-assembly directory. |
 | `--output <path>` | `cdk.out` | Output directory for synthesis. |
 | `-c`, `--context <key=value...>` | — | Set CDK context values. Repeatable. |
@@ -232,7 +232,7 @@ invoke`](local-invoke.md#output-streams), which shares the same reservation.
 | Code | Meaning |
 | --- | --- |
 | `0` | The agent answered and the response was printed. |
-| `1` | The agent answered with an error, or cdkd could not get as far as an answer. |
+| `1` | The agent answered with an error, or cdkd could not get as far as an answer. Unlike [`cdkd local invoke`](local-invoke.md#exit-codes), an error *answer* is a non-zero exit here. |
 | `130` | `^C` (SIGINT). The container is stopped and removed before the process exits. |
 
 Exit `1` covers both an unhappy answer and a failure to reach one:

--- a/docs/local-invoke-agentcore.md
+++ b/docs/local-invoke-agentcore.md
@@ -9,7 +9,10 @@ description: "Invoke a Bedrock AgentCore Runtime once in a local container over 
 your CDK app in a local Docker container and invokes it once over whichever
 AgentCore protocol the runtime declares. Reach for it to exercise an agent
 against a real request payload before deploying — the agent's outbound calls to
-managed AWS services still reach real AWS.
+managed AWS services still reach real AWS. To drive the same agent repeatedly
+from a client rather than firing one payload, use
+[`cdkd local start-agentcore`](local-start-agentcore.md), which keeps the
+container warm.
 
 ```bash
 cdkd local invoke-agentcore MyStack/MyAgent -e prompt.json     # one-shot POST /invocations
@@ -185,7 +188,7 @@ The runtime's env vars are substituted the same way
 Lambda's. Without a state source, intrinsic-valued entries are warned and
 dropped; `--from-state` reads cdkd's S3 state for the target stack, and
 `--from-cfn-stack [name]` reads a deployed CloudFormation stack via
-`DescribeStackResources` for apps deployed through the upstream CDK CLI. The
+`ListStackResources` for apps deployed through the upstream CDK CLI. The
 two flags are mutually exclusive, and `--env-vars` overrides win over both.
 
 A state source also feeds image resolution: a same-stack ECR repository

--- a/docs/local-invoke-agentcore.md
+++ b/docs/local-invoke-agentcore.md
@@ -1,68 +1,267 @@
 ---
-title: local invoke-agentcore
-description: "Invoke a Bedrock AgentCore Runtime once in a local container over HTTP, MCP, A2A, or WebSocket."
+title: cdkd local invoke-agentcore
+description: "Invoke a Bedrock AgentCore Runtime once in a local container over HTTP, MCP, A2A, AG-UI, or a bidirectional WebSocket."
 ---
 
-# `local invoke-agentcore` (run Bedrock AgentCore Runtime locally)
+# cdkd local invoke-agentcore
 
-`cdkd local invoke-agentcore <target>` runs one Bedrock AgentCore Runtime container locally and invokes it once over the AgentCore protocol declared by the target. Supports the container artifact (`fromContainerAsset` / `fromEcr`) and the `CodeConfiguration` managed-runtime artifact (`fromCodeAsset`, built from source) on the HTTP, MCP, A2A, and AGUI protocols, plus a bidirectional `--ws` mode for streaming. Models cdk-local's `cdkl invoke-agentcore`, ported into cdkd's command tree as a shim over `cdk-local/internal`.
+`cdkd local invoke-agentcore [target]` runs one Bedrock AgentCore Runtime from
+your CDK app in a local Docker container and invokes it once over whichever
+AgentCore protocol the runtime declares. Reach for it to exercise an agent
+against a real request payload before deploying — the agent's outbound calls to
+managed AWS services still reach real AWS.
 
-> **`CodeConfiguration` builds run the bundle as-is (no dependency install).** The `fromCodeAsset` / `fromS3` source build matches the AWS managed runtime: it does **not** `pip install` (`requirements.txt` / `pyproject.toml`) or `npm install` your dependencies — the deployed runtime resolves deps vendored into the bundle at deploy time (e.g. arm64 wheels via `uv pip install --target`). So a bundle that declares a dependency manifest **without vendored deps** now fails locally with `ModuleNotFoundError` the same way it fails deployed (instead of passing locally only because of a local install), and cdkd emits a warning with the vendoring recipe. Vendor your deps into the bundle — which a successful deploy already requires. Container artifacts (`fromContainerAsset` / `fromEcr`) are unaffected. Inherited from cdk-local; applies to `start-agentcore` too (same `buildAgentCoreCodeImage` build).
+```bash
+cdkd local invoke-agentcore MyStack/MyAgent -e prompt.json     # one-shot POST /invocations
+cdkd local invoke-agentcore                                     # pick a runtime interactively (TTY)
+cdkd local invoke-agentcore MyStack/MyAgent --from-state        # resolve env intrinsics from cdkd state
+cdkd local invoke-agentcore MyStack/MyAgent --ws -e first.json  # bidirectional /ws session
+cdkd local invoke-agentcore MyStack/MyAgent --watch --ws        # re-synth + reload on source edits
+cdkd local invoke-agentcore MyStack/MyAgent 2> progress.log | tail -1  # payload is the LAST stdout line
+```
 
-### Target resolution
+Docker is required, and the container is pulled or built on the first run.
+Both the container artifact (`fromContainerAsset` / `fromEcr`) and the
+`CodeConfiguration` managed-runtime artifact (`fromCodeAsset`, built from
+source) are supported.
 
-Same shape as `cdkd local invoke`: accepts a CDK display path (`MyStack/MyAgent`) or stack-qualified logical ID (`MyStack:MyAgentRuntime1234`). Single-stack apps may omit the stack prefix. When the target is omitted in an interactive terminal, an interactive picker prompts from the discovered list (no TTY -> command's required-arg error).
+## Options
 
-### Supported protocols
+| Flag | Default | Description |
+| --- | --- | --- |
+| `[target]` | interactive picker | CDK display path or stack-qualified logical ID of the AgentCore Runtime. See [Target resolution](#target-resolution). |
+| `-e`, `--event <file>` | `{}` | JSON request body file. Its meaning depends on the protocol — see [Protocols](#protocols). |
+| `--event-stdin` | off | Read the request JSON from stdin. Mutually exclusive with `--event`. |
+| `--env-vars <file>` | — | JSON env-var overrides, SAM-compatible shape. See [Local Execution](local-emulation.md#common-flags). |
+| `--session-id <id>` | random UUID | Value of the AgentCore runtime session-id header. |
+| `--ws` | off | Stream over the agent's bidirectional `/ws` endpoint instead of `POST /invocations`. HTTP / AG-UI only. See [`--ws`: bidirectional WebSocket streaming](#ws-bidirectional-websocket-streaming). |
+| `--watch` | off | Re-synth and reload the container on CDK source edits. HTTP / AG-UI only. See [`--watch`: reload on source edits](#watch-reload-on-source-edits). |
+| `--bearer-token <jwt>` | — | Bearer JWT presented when the runtime declares a `customJwtAuthorizer`. See [Inbound authentication](#inbound-authentication). |
+| `--no-verify-auth` | off | Skip inbound JWT verification even when the runtime declares a `customJwtAuthorizer`. A `--bearer-token`, if given, is still forwarded. |
+| `--sigv4` | off | Sign the `/invocations` POST with AWS SigV4 (service `bedrock-agentcore`). Mutually exclusive with `--bearer-token`. See [Inbound authentication](#inbound-authentication). |
+| `--platform <platform>` | `linux/arm64` | `docker --platform` for the agent container. One of `linux/amd64`, `linux/arm64`. AgentCore's deployed architecture is arm64. |
+| `--no-pull` | off | Skip `docker pull`. No-op on the local-build path. See [Local Execution](local-emulation.md#common-flags). |
+| `--no-build` | off | Skip `docker build` on the local-asset path and reuse the previously built tag. No-op on the ECR / registry pull paths. |
+| `--container-host <host>` | `127.0.0.1` | Host IP to bind the agent port to. See [Local Execution](local-emulation.md#common-flags). |
+| `--timeout <ms>` | `120000` | Per-request timeout, applied to `POST /invocations`, `POST /mcp`, and the `/ws` open-to-close window. Raise it for long agent calls. |
+| `--assume-role [arn]` | off | Run the agent under the runtime's execution role instead of your shell credentials. See [Credentials and role assumption](#credentials-and-role-assumption). |
+| `--ecr-role-arn <arn>` | — | Role to assume before authenticating to ECR, for cross-account or centralized registries. Same-account, same-region pulls need no role. |
+| `--from-state` | off | Substitute `Ref` / `Fn::GetAtt` / `Fn::Sub` / `Fn::ImportValue` in env vars from cdkd's S3 state. Mutually exclusive with `--from-cfn-stack`. See [Environment variables](#environment-variables). |
+| `--from-cfn-stack [cfn-stack-name]` | off | Substitute `Ref` / `Fn::ImportValue` in env vars from a deployed CloudFormation stack, for apps deployed via the upstream CDK CLI. Mutually exclusive with `--from-state`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Used only with `--from-state`. |
+| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Used only with `--from-state`. |
+| `--stack-region <region>` | auto | Region of the state record to read, and the CFn client region for `--from-cfn-stack`. See [Local Execution](local-emulation.md#common-flags). |
+| `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a pre-synthesized cloud-assembly directory. |
+| `--output <path>` | `cdk.out` | Output directory for synthesis. |
+| `-c`, `--context <key=value...>` | — | Set CDK context values. Repeatable. |
+| `--profile <profile>` | — | AWS profile. |
+| `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for cdkd's own AWS API calls (state reads, STS, ECR). Distinct from `--assume-role`, which targets the agent's credentials. |
+| `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
+| `--verbose` | off | Verbose logging (on stderr). |
 
-| `Protocol` (CFn) | What runs | Container ports | cdkd dispatch |
+## Target resolution
+
+The optional `[target]` takes the same two forms
+[`cdkd local invoke`](local-invoke.md#target-resolution) accepts:
+
+- **CDK display path** — `MyStack/MyAgent`.
+- **Stack-qualified logical ID** — `MyStack:MyAgentRuntime1234`.
+
+Single-stack apps may omit the stack prefix. Omitting the target entirely in an
+interactive terminal opens a picker over every AgentCore Runtime discovered in
+the app; with no TTY, the command errors and tells you to name one.
+
+## Protocols
+
+The runtime's `Protocol` property decides which client cdkd uses and which
+container port it publishes.
+
+| `Protocol` | Container port | What cdkd sends | `--event` default |
 | --- | --- | --- | --- |
-| `HTTP` (default) | `POST /invocations` (single response or SSE stream) + `GET /ping` | 8080 | `POST /invocations` with `--event` body. SSE stream prints incrementally; non-stream prints `tail -1`. |
-| `MCP` | Model Context Protocol streamable HTTP | 8000 | Session handshake (`initialize` -> `notifications/initialized`) + one JSON-RPC request: defaults to `tools/list` when `--event` is omitted; otherwise `--event` is the JSON-RPC request body. |
-| `A2A` | Agent-to-Agent JSON-RPC at `POST /` | 9000 | Defaults to `agent/getAgentCard` when `--event` is omitted; otherwise `--event` is the JSON-RPC request body. |
-| `AGUI` | AGUI JSON-RPC streaming | 8800 | Streams the agent's response frames. |
-| `--ws` (HTTP only) | Bidirectional `/ws` WebSocket on the HTTP container | 8080 | First frame = `--event` body. Auto-enters a REPL when **stdin** is a TTY — each typed stdin line is a follow-up frame until Ctrl-D / close; piped / non-TTY stdin stays one-shot (only the `--event` frame is sent). The `> ` prompt additionally requires **stdout** to be a TTY, so a redirected stdout keeps the raw frame stream. |
+| `HTTP` (default) | 8080 | `POST /invocations`, after `GET /ping` reports ready. | `{}` as the request body |
+| `MCP` | 8000 (`/mcp`) | Session handshake (`initialize` → `notifications/initialized`), then one JSON-RPC request. | `tools/list` |
+| `A2A` | 9000 (`POST /`) | One JSON-RPC round-trip. | `agent/getCard` |
+| `AGUI` | 8080 | Routed through the same `/invocations` + `/ws` client path as `HTTP` — the AG-UI wire is SSE and WebSocket. | `{}` as the request body |
 
-### Inbound JWT auth (`customJwtAuthorizer`)
+For `MCP` and `A2A`, `--event` is the JSON-RPC request itself: it must be a JSON
+object carrying a string `method`, plus an optional `params`. An empty object
+falls back to the protocol's default method above; anything else fails fast,
+before any Docker work.
 
-When the runtime declares an inbound `customJwtAuthorizer`, `--jwt <token>` verifies the supplied Bearer JWT against the runtime's OIDC discovery URL before the container starts, then forwards it on `/invocations` as `Authorization: Bearer <jwt>`. Verification covers `iss` / `aud` / `exp` / signature + allowedScopes + customClaims. Without `--jwt`, the local invoke proceeds without authorization (mirrors `cdkl`).
+An `HTTP` / `AGUI` response that arrives as an SSE stream is printed
+incrementally as it arrives; a non-streamed response is printed as one final
+line.
 
-### State-source flags
+## `--ws`: bidirectional WebSocket streaming
 
-Same shape as `cdkd local invoke`. Use `--from-state` to substitute Ref / Fn::GetAtt / Fn::Sub / Fn::ImportValue in env vars from cdkd's S3 state for the target stack (after a prior `cdkd deploy`). Use `--from-cfn-stack [name]` to read a deployed CFn stack via `DescribeStackResources` (for CDK apps deployed via the upstream CDK CLI). Mutually exclusive.
+`--ws` opens the HTTP-protocol agent's bidirectional `/ws` endpoint on the same
+port 8080 container, instead of `POST /invocations`. The `--event` body is sent
+as the first frame, and every received frame is printed to stdout until the
+agent closes the stream.
 
-### Credentials + role-assumption
+The two halves of interactive behaviour read **different streams**:
 
-Same shape as `cdkd local invoke`. The container receives the developer's AWS credentials by default (so the agent's outbound AWS calls reach real AWS as the developer); `--assume-role <arn>` (or bare `--assume-role` to auto-resolve from state) assumes the runtime's deployed `RoleArn` first so the agent runs with the narrow function role. `--ecr-role-arn <arn>` is the cross-account ECR image-pull escape hatch.
+| Stream | Condition | Effect |
+| --- | --- | --- |
+| stdin | TTY | A REPL: each typed line is sent as a follow-up text frame until Ctrl-D or the agent closes. |
+| stdin | piped / redirected / CI | Wire-faithful one-shot — only the `--event` frame is sent. Force this in a terminal with `--ws </dev/null`. |
+| stdout | TTY | The `> ` prompt is written between frames. |
+| stdout | redirected / piped | No prompt; the frame stream stays raw, so `--ws > frames.txt` and `--ws \| tail -1` mean what they look like. |
 
-### Options
+`--ws` is ignored with a warning on `MCP` and `A2A` runtimes, which have no
+WebSocket surface.
 
-- `--event <file>` / `--event-stdin` — request body / stdin source.
-- `--env-vars <file>` — SAM-shape env-var overrides.
-- `--platform <linux/amd64|linux/arm64>` — defaults to `linux/arm64` (AgentCore's required arch).
-- `--container-host <host>` — host to bind the container ports to (default `127.0.0.1`).
-- `--session-id <id>` — value of the AgentCore session-id header (auto-generated when omitted).
-- `--jwt <bearer-token>` — verified + forwarded when the runtime declares `customJwtAuthorizer`.
-- `--timeout <ms>` — per-request timeout (default 120000 / 120s).
-- `--ws` — bidirectional `/ws` WebSocket mode (HTTP protocol only). Auto-detects a TTY, and the two halves read DIFFERENT streams. Whether the REPL runs depends on **stdin**: an interactive terminal enters a multi-turn REPL (each stdin line is sent as a follow-up frame until Ctrl-D / agent close), while piped / redirected / CI stdin stays a wire-faithful one-shot (force one-shot in a TTY with `--ws </dev/null`). Whether the `> ` prompt is written depends on **stdout**, because that is the payload stream: with stdout redirected the frames stay raw and unprompted even from a terminal, so `--ws > frames.txt` and `--ws | tail -1` mean what they look like.
-- `--watch` — re-synth + reload the agent container on CDK source edits. See [Hot reload (`--watch`)](#hot-reload-watch) below. Off by default. Supported on the HTTP / AGUI protocols; a no-op WARN for MCP / A2A (their single shot runs once and exits).
-- `--sigv4` — sign `/invocations` with SigV4 (for SigV4-protected runtimes).
-- `--from-state` / `--from-cfn-stack [name]` / `--state-bucket` / `--state-prefix` / `--stack-region` — state-source flags.
-- `--assume-role [arn]` / `--no-assume-role` / `--ecr-role-arn <arn>` — role-assumption flags.
-- `--no-pull` / `--no-build` — pull / build skip.
+## `--watch`: reload on source edits
 
-### Hot reload (`--watch`)
-
-When `--watch` is set, cdkd watches the CDK app **source tree** (the synth working directory, where `cdk.json` lives), honoring `cdk.json`'s `watch.include` / `watch.exclude` and excluding `cdk.out` / `node_modules` / `.git`. On a source edit it re-synths and reloads the agent container, mirroring `cdk watch`.
+`--watch` watches the CDK app's **source tree** — the synth working directory,
+where `cdk.json` lives — honoring `cdk.json`'s `watch.include` /
+`watch.exclude` and excluding `cdk.out`, `node_modules` and `.git`. On a source
+edit it re-synths and reloads the agent container, mirroring `cdk watch`.
 
 A per-firing classifier picks the reload primitive:
 
-- **Soft-reload FAST PATH** — an interpreted-language source edit inside a `CodeConfiguration` (`fromCodeAsset`) source tree (no Dockerfile / dependency-manifest / compiled-source change, asset hash unchanged in a way that matters) takes a `docker cp` of the freshly-synthed source into the running container's WORKDIR + `docker restart`. No `docker build`, no container swap — the container ID + host port are preserved.
-- **Full rebuild** — a Dockerfile / compiled-source / asset-hash-changed / ambiguous edit (or a `fromS3` / non-CDK-asset runtime, or any classifier-context failure) tears down the container (SIGTERM + `docker rm -f`), re-resolves the image (re-running the same image-build pipeline the cold boot runs), and starts a fresh container.
+| Edit | Primitive |
+| --- | --- |
+| An interpreted-language source edit inside a `CodeConfiguration` (`fromCodeAsset`) source tree — no Dockerfile, dependency-manifest or compiled-source change, and no asset-hash change that matters | **Soft reload**: `docker cp` the freshly synthed source into the running container's WORKDIR, then `docker restart`. No `docker build`, no container swap — the container ID and host port are preserved. |
+| A Dockerfile, compiled-source, asset-hash-changed or ambiguous edit; a `fromS3` or non-CDK-asset runtime; any classifier-context failure | **Full rebuild**: tear the container down (SIGTERM, then `docker rm -f`), re-resolve the image through the same build pipeline the cold boot runs, and start a fresh container. |
 
-`--watch` applies to BOTH the `--ws` session path AND the default one-shot `POST /invocations` (the reload re-runs the single shot). On `--ws`, the active socket is closed cleanly on each reload firing so the next session reconnects to the rebuilt / soft-reloaded container. For **MCP / A2A** runtimes `--watch` is a no-op WARN and the single shot proceeds (those protocols run once and exit with no reconnect surface). Reloads are chain-serialized (no two reloads run in parallel); a reload-callback failure exits the watch loop cleanly (the previous container may already be torn down, so it does not block on a stale port). `^C` (SIGINT) tears down the container and exits.
+`--watch` applies to both the `--ws` session path and the default one-shot
+`POST /invocations`, where the reload re-runs the single shot. On `--ws`, the
+active socket is closed cleanly on each firing, so the next session reconnects
+to the rebuilt or soft-reloaded container.
 
-### Implementation notes
+Reloads are chain-serialized — no two run in parallel — and a reload-callback
+failure exits the watch loop cleanly rather than blocking on a stale port, since
+the previous container may already be torn down. `^C` tears the container down
+and exits.
 
-cdkd consumes cdk-local's AgentCore implementation verbatim via shim files (`src/local/agentcore-*.ts`). The actual runtime resolver, code-image builder, S3 bundle downloader, protocol clients (HTTP / MCP / A2A / WebSocket), and SigV4 signer all live in cdk-local (`@cdk-local/internal`); cdkd's command file ports the CLI surface + state-source integration only, mirroring the established pattern from `cdkd local invoke` / `start-api` / `run-task` / `start-service`.
+For `MCP` and `A2A` runtimes `--watch` is a no-op warning and the single shot
+proceeds: those protocols run once and exit, with no reconnect surface for a
+watch loop to drive.
 
+## Inbound authentication
+
+A runtime with no `customJwtAuthorizer` is invoked unauthenticated by default.
+`--sigv4` opts in to signing the `/invocations` POST with AWS SigV4 (service
+`bedrock-agentcore`) using the resolved credentials, matching the cloud default
+for such a runtime.
+
+When the runtime **does** declare a `customJwtAuthorizer`:
+
+| Flags | Behaviour |
+| --- | --- |
+| `--bearer-token <jwt>` | The token is verified against the runtime's OIDC discovery URL **before the container starts** — signature, `iss`, `aud`, `exp`, plus `allowedClients`, `allowedScopes` and `customClaims` — then forwarded on `/invocations` as `Authorization: Bearer <jwt>`. A rejected token errors before any Docker work. |
+| neither flag | The command errors: the runtime requires an inbound JWT. Pass `--bearer-token`, or `--no-verify-auth`. |
+| `--no-verify-auth` | Verification is skipped with a warning. A `--bearer-token`, if present, is still forwarded. |
+| `--sigv4` | Ignored with a warning — the JWT path takes precedence. |
+
+`--sigv4` and `--bearer-token` together are rejected: pick one inbound auth.
+`--sigv4` is also ignored, with a warning, on the `MCP`, `A2A` and `--ws` paths,
+because it signs the HTTP `/invocations` request only.
+
+On `MCP` and `A2A` runtimes cdkd POSTs to the local container's `/mcp` or `/`
+directly, speaking vanilla JSON-RPC. An inbound JWT is an AgentCore
+managed-plane concern that the cloud front door layers on top, so
+`--bearer-token` is **not** applied on those paths; cdkd logs a line saying so.
+
+## Credentials and role assumption
+
+By default the container receives your own AWS credentials, so the agent's
+outbound AWS calls reach real AWS as you.
+
+| Form | Behaviour |
+| --- | --- |
+| `--assume-role <arn>` | Assumes the explicit ARN and forwards the STS-issued temporary credentials to the container. |
+| `--assume-role` (bare) | Uses the runtime's own `RoleArn` when the template carries it as a literal ARN, or resolves it from the loaded stack state. When neither can supply one, cdkd warns and falls back to your shell credentials. |
+| flag omitted | Your shell credentials are forwarded unchanged. |
+
+`--ecr-role-arn <arn>` is separate: it is the cross-account image-pull escape
+hatch, assumed before `ecr:GetAuthorizationToken` and the pull.
+
+## Environment variables
+
+The runtime's env vars are substituted the same way
+[`cdkd local invoke`](local-invoke.md#environment-variables) substitutes a
+Lambda's. Without a state source, intrinsic-valued entries are warned and
+dropped; `--from-state` reads cdkd's S3 state for the target stack, and
+`--from-cfn-stack [name]` reads a deployed CloudFormation stack via
+`DescribeStackResources` for apps deployed through the upstream CDK CLI. The
+two flags are mutually exclusive, and `--env-vars` overrides win over both.
+
+A state source also feeds image resolution: a same-stack ECR repository
+referenced from the runtime's `ContainerUri` is reduced to the deployed image
+URI before the container is resolved.
+
+## `CodeConfiguration` builds
+
+A `fromCodeAsset` / `fromS3` source build matches the AWS managed runtime: it
+runs the bundle **as-is** and does **not** install your dependencies — no `pip
+install` from `requirements.txt` / `pyproject.toml`, no `npm install`. The
+deployed runtime resolves dependencies that were vendored into the bundle at
+deploy time, for example arm64 wheels installed with `uv pip install --target`.
+
+So a bundle that declares a dependency manifest without vendored dependencies
+fails locally with `ModuleNotFoundError` exactly as it fails deployed, instead
+of passing locally only because of a local install. cdkd emits a warning naming
+the vendoring recipe. Vendor your dependencies into the bundle — a successful
+deploy already requires it.
+
+Container artifacts (`fromContainerAsset` / `fromEcr`) are unaffected. The same
+build behaviour applies to
+[`cdkd local start-agentcore`](local-start-agentcore.md).
+
+## Output streams
+
+Everything cdkd's own logger prints goes to **stderr**; stdout carries the
+agent's response. Stdout is not payload-only — the container's own stdout and
+the shared container-build logger also reach it — so the response is the **last
+line** on stdout rather than the only one:
+
+```bash
+cdkd local invoke-agentcore MyStack/Agent 2> progress.log | tail -1
+```
+
+The full account of what reaches stdout is in [`cdkd local
+invoke`](local-invoke.md#output-streams), which shares the same reservation.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The agent answered and the response was printed. |
+| `1` | The agent answered with an error, or cdkd could not get as far as an answer. |
+| `130` | `^C` (SIGINT). The container is stopped and removed before the process exits. |
+
+Exit `1` covers both an unhappy answer and a failure to reach one:
+
+| Cause | Detail |
+| --- | --- |
+| Agent error response | `POST /invocations` returned HTTP 400 or above, or an MCP / A2A response carried a JSON-RPC error. |
+| Readiness timeout | The container did not answer `GET /ping` within `--timeout`. |
+| Target not resolved | No matching runtime, or an ambiguous display path. |
+| Container not started | Docker unavailable, or the image pull or build failed. |
+| Malformed `--event` | The payload is not a valid JSON-RPC request for an `MCP` or `A2A` runtime. |
+| Inbound auth refused | A `customJwtAuthorizer` runtime with no token, or a token the authorizer rejected. |
+| Contradictory flags | `--sigv4` with `--bearer-token`, or `--from-state` with `--from-cfn-stack`. |
+
+The full cross-command table is in the [CLI Reference](cli-reference.md#exit-codes).
+
+## Limitations
+
+- `--ws` and `--watch` apply only to the `HTTP` and `AGUI` protocols. On `MCP`
+  and `A2A` they are ignored with a warning, and the single shot proceeds.
+- `--sigv4` signs `POST /invocations` only — not `/mcp`, not `POST /` for A2A,
+  and not the `/ws` handshake.
+- An inbound JWT is not enforced on the `MCP` and `A2A` paths, because cdkd
+  talks to the container directly rather than through the AgentCore front door.
+- A `CodeConfiguration` build installs no dependencies. See
+  [`CodeConfiguration` builds](#codeconfiguration-builds).
+- One invocation per run. To keep a warm container across many requests, use
+  [`cdkd local start-agentcore`](local-start-agentcore.md).
+
+## Related
+
+- [`cdkd local start-agentcore`](local-start-agentcore.md) — the long-running counterpart, serving a warm container across all four protocols
+- [`cdkd local invoke`](local-invoke.md) — the same one-shot shape for a Lambda function, and the full output-stream and env-var reference
+- [Local Execution](local-emulation.md) — every `cdkd local` subcommand, the Docker requirement, and the flags they share
+- [CLI Reference](cli-reference.md) — every command and the full exit-code table

--- a/docs/local-invoke.md
+++ b/docs/local-invoke.md
@@ -474,7 +474,7 @@ stdout besides the response, neither routed by cdkd's logger:
 | Source | What lands on stdout |
 | --- | --- |
 | The container's own stdout | The runtime emulator puts `START` / `END` / `REPORT` and every handler log line there — `console.error` included — so any handler that prints lands ahead of the response. |
-| The container-image build path | That path is shared with cdk-local, whose logger has no stdout reservation, so `Building container image (platform=...)` and `Skipping docker build ...` print on stdout for a container-image Lambda. |
+| The container-image build path | For a container-image Lambda, `Building container image (platform=...)` and `Skipping docker build ...` print on stdout rather than stderr. |
 
 `docker pull` progress does not: while a command holds the stdout reservation,
 the child process's fd 1 is redirected to fd 2.

--- a/docs/local-invoke.md
+++ b/docs/local-invoke.md
@@ -1,184 +1,194 @@
 ---
-title: local invoke
+title: cdkd local invoke
 description: "Run a single Lambda function from your CDK app in a local Docker container via the AWS Lambda Runtime Interface Emulator — no AWS deploy."
 ---
 
-# `local invoke` (run Lambda functions locally)
+# cdkd local invoke
 
-`cdkd local invoke <target>` runs a Lambda function from a CDK app on
-the developer's machine, inside a Docker container that bundles the
-AWS Lambda Runtime Interface Emulator (RIE). Modeled on
-`sam local invoke` but reusing cdkd's synthesis / asset / construct-path
-plumbing.
+`cdkd local invoke <target>` runs one Lambda function from a CDK app on your
+machine, inside a Docker container that bundles the AWS Lambda Runtime
+Interface Emulator (RIE). It plays the role `sam local invoke` does, but reads
+your CDK app directly — no `template.yaml`, no `cdk synth | sam ...`
+round-trip. Reach for it to exercise a handler against a real event payload
+before you deploy anything.
 
-**Requires Docker.** The first invocation pulls the Lambda base image
-(`public.ecr.aws/lambda/nodejs:<version>`,
-`public.ecr.aws/lambda/python:<version>`,
-`public.ecr.aws/lambda/ruby:<version>`,
-`public.ecr.aws/lambda/java:<version>`,
-`public.ecr.aws/lambda/dotnet:<version>`, or
-`public.ecr.aws/lambda/provided:<al2|al2023>` — ~600MB for the
-language-specific images, ~50MB for the OS-only `provided.*`);
-subsequent invocations reuse the cached image. Pass `--no-pull` to
-skip the `docker pull` round-trip altogether. Supported runtimes:
-`nodejs18.x` / `nodejs20.x` / `nodejs22.x` / `nodejs24.x` /
-`python3.11` / `python3.12` / `python3.13` / `python3.14` /
-`ruby3.2` / `ruby3.3` / `java8.al2` / `java11` / `java17` / `java21` /
-`dotnet6` / `dotnet8` / `provided.al2` / `provided.al2023`. The
-deprecated `go1.x` runtime is rejected with a migration pointer to
-`provided.al2023`. Java, .NET, and `provided.*` are **asset-backed
-only** — inline `Code.ZipFile` is rejected with a routing message
-("use `lambda.Code.fromAsset(...)`") because the Handler shape names
-a compiled artifact (`package.Class::method` for Java's JVM class;
-`Assembly::Namespace.Class::Method` for .NET's CLR assembly; an
-arbitrary `bootstrap` binary for `provided.*`).
+```bash
+cdkd local invoke MyStack/MyApi/Handler                       # default {} event
+cdkd local invoke MyStack/MyApi/Handler -e event.json         # event from a file
+echo '{"k":1}' | cdkd local invoke MyHandler --event-stdin    # single-stack app, event on stdin
+cdkd local invoke MyStack/MyApi/Handler --from-state          # resolve env intrinsics from cdkd state
+cdkd local invoke MyStack/MyApi/Handler --from-state --assume-role   # run under the deployed role
+cdkd local invoke MyStack/Handler -e event.json | tail -1 | jq .body # the payload is the LAST stdout line
+```
 
-A ZIP Lambda's `Architectures: [x86_64]` (default) / `[arm64]` is pinned to
-`--platform linux/amd64` / `linux/arm64` on the container's `docker run`
-(matching the container-image path). On an arch-mismatched host Docker
-emulates the function's declared arch, so a `provided.*` `bootstrap`
-compiled for the other architecture runs instead of failing with
-`fork/exec /var/runtime/bootstrap: exec format error` /
-`Runtime.InvalidEntrypoint`. The same pinning applies to `cdkd local
-start-api`'s warm-container pool.
+Docker is required. The first run pulls the Lambda base image; later runs
+reuse the cached one.
 
-**Container Lambdas** — `lambda.DockerImageFunction(...)` /
-`Code.ImageUri` is supported in addition to ZIP Lambdas. cdkd reads the
-function's local `Dockerfile` from `cdk.out` (via the asset manifest
-keyed off the `:<hash>` suffix on `Code.ImageUri`) and runs `docker build`
-locally, then `docker run` against the resulting image. When no asset
-matches (typically: invoking a stack deployed elsewhere), cdkd falls back
-to `docker pull` from ECR. **Cross-account / cross-region pull is
-supported**: cdkd auto-detects cross-account from `sts:GetCallerIdentity`,
-builds the ECR client for the URI's region, and (when
-`--ecr-role-arn <arn>` is passed) issues `sts:AssumeRole` to pick up
-permissions in the target account. Without `--ecr-role-arn`, cdkd
-falls through to the caller's credentials — works when the target ECR
-repository's resource policy grants the caller directly (AWS surfaces
-`AccessDenied` if missing, with a hint at the flag).
-`Architectures: [x86_64]` (default) and `[arm64]` are honored via
-`--platform linux/amd64` / `linux/arm64` on both the build and the run.
+## Options
 
-### Target resolution
+| Flag | Default | Description |
+| --- | --- | --- |
+| `<target>` | — | CDK display path or stack-qualified logical ID of the Lambda to invoke. Required. See [Target resolution](#target-resolution). |
+| `-e`, `--event <file>` | `{}` | JSON event payload file. |
+| `--event-stdin` | off | Read the event JSON from stdin. Mutually exclusive with `--event`. |
+| `--env-vars <file>` | — | JSON env-var overrides, SAM-compatible shape. See [Local Execution](local-emulation.md#common-flags) and [Resolution priority](#resolution-priority). |
+| `--no-pull` | off | Skip `docker pull`. Semantics differ per code path — see [`--no-pull` and `--no-build` by code path](#no-pull-and-no-build-by-code-path). |
+| `--no-build` | off | Skip `docker build` on the container-image local-build path. See [`--no-pull` and `--no-build` by code path](#no-pull-and-no-build-by-code-path). |
+| `--debug-port <port>` | off | Set `NODE_OPTIONS=--inspect-brk=0.0.0.0:<port>` and publish the port, so a Node debugger can attach and step through the handler. Must be an integer in 1-65535. |
+| `--container-host <host>` | `127.0.0.1` | Host IP to bind the RIE port to. See [Local Execution](local-emulation.md#common-flags). |
+| `--assume-role [arn]` | off | Run the handler under the deployed function's execution role instead of your shell credentials. See [`--assume-role`: run under the deployed execution role](#assume-role-run-under-the-deployed-execution-role). |
+| `--layer-role-arn <arn>` | — | Role to `sts:AssumeRole` before `lambda:GetLayerVersion` on literal-ARN layer entries. See [Literal layer ARNs](#literal-layer-arns). |
+| `--ecr-role-arn <arn>` | — | Role to assume before authenticating to ECR on the container-image pull path. See [Container-image Lambdas](#container-image-lambdas). |
+| `--from-state` | off | Substitute env-var intrinsics from cdkd's S3 state. See [`--from-state`: recover env vars from cdkd state](#from-state-recover-env-vars-from-cdkd-state). |
+| `--from-cfn-stack [cfn-stack-name]` | off | Substitute env-var intrinsics from a deployed CloudFormation stack. Mutually exclusive with `--from-state`. See [`--from-cfn-stack`: recover env vars from CloudFormation](#from-cfn-stack-recover-env-vars-from-cloudformation). |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json`, then `cdkd-state-{accountId}` | S3 bucket holding cdkd state. Used only with `--from-state`. |
+| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Used only with `--from-state`. |
+| `--stack-region <region>` | auto | Region of the state record to read, and the CFn client region for `--from-cfn-stack`. See [Local Execution](local-emulation.md#common-flags). |
+| `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a pre-synthesized cloud-assembly directory. Pass `-a cdk.out` to skip synthesis while iterating. |
+| `--output <path>` | `cdk.out` | Output directory for synthesis. |
+| `-c`, `--context <key=value...>` | — | Set CDK context values. Repeatable. |
+| `--profile <profile>` | — | AWS profile. |
+| `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for cdkd's own AWS API calls (state reads, STS, ECR). Distinct from `--assume-role`, which targets the handler's credentials. |
+| `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
+| `--verbose` | off | Verbose logging (on stderr). |
+
+### `--no-pull` and `--no-build` by code path
+
+| Code path | `--no-pull` | `--no-build` |
+| --- | --- | --- |
+| ZIP Lambda | Skip pulling the public Lambda base image. | No-op — no `docker build` runs. |
+| Container image, local build | No-op — `docker build` does not refresh the `FROM` cache by default. | Reuse the deterministic `cdkd-local-invoke-<hash>` tag from a prior run. Errors with an actionable message when that tag is not in the local registry. |
+| Container image, ECR pull | Skip `docker pull`, and error when the image is not already in the local cache. | No-op — use `--no-pull` to control this path. |
+
+The two flags are compatible with each other.
+
+## Target resolution
 
 The positional `<target>` accepts two forms:
 
-- **CDK display path** — `MyStack/MyApi/Handler`. Matches the same
-  prefix-rule cdkd uses for `cdkd orphan`: an L2 path resolves to the
-  synthesized L1 child (`MyStack/MyApi/Handler/Resource`).
-- **Stack-qualified logical ID** — `MyStack:MyApiHandler1234ABCD`. The
-  colon is unambiguous because logical IDs cannot contain `/` or `:`.
+- **CDK display path** — `MyStack/MyApi/Handler`. An L2 path resolves to the
+  synthesized L1 child (`MyStack/MyApi/Handler/Resource`), the same prefix rule
+  `cdkd orphan` uses.
+- **Stack-qualified logical ID** — `MyStack:MyApiHandler1234ABCD`. The colon is
+  unambiguous, because logical IDs can contain neither `/` nor `:`.
 
-Single-stack apps may omit the stack prefix entirely:
-`cdkd local invoke MyHandler` is valid when the app contains exactly
-one stack (mirrors `cdkd deploy` / `cdkd destroy` auto-detect).
+Single-stack apps may omit the stack prefix entirely: `cdkd local invoke
+MyHandler` is valid when the app contains exactly one stack, mirroring `cdkd
+deploy` / `cdkd destroy` auto-detection.
 
-When the target does not match anything, the error lists every Lambda
-in the resolved stack so the user can copy/paste a valid one.
+When the target matches nothing, the error lists every Lambda in the resolved
+stack, so you can copy a valid one out of it.
 
-### Options
+## Runtimes and images
 
-| Option | Default | Description |
+### Supported runtimes
+
+| Family | Runtimes | Base image | Code source |
+| --- | --- | --- | --- |
+| Node.js | `nodejs18.x`, `nodejs20.x`, `nodejs22.x`, `nodejs24.x` | `public.ecr.aws/lambda/nodejs:<version>` | Asset or inline `Code.ZipFile` |
+| Python | `python3.11`, `python3.12`, `python3.13`, `python3.14` | `public.ecr.aws/lambda/python:<version>` | Asset or inline `Code.ZipFile` |
+| Ruby | `ruby3.2`, `ruby3.3` | `public.ecr.aws/lambda/ruby:<version>` | Asset or inline `Code.ZipFile` |
+| Java | `java8.al2`, `java11`, `java17`, `java21` | `public.ecr.aws/lambda/java:<version>` | Asset only |
+| .NET | `dotnet6`, `dotnet8` | `public.ecr.aws/lambda/dotnet:<version>` | Asset only |
+| OS-only | `provided.al2`, `provided.al2023` | `public.ecr.aws/lambda/provided:<al2\|al2023>` | Asset only |
+
+The language-specific images are roughly 600MB; the OS-only `provided.*` images
+roughly 50MB.
+
+Java, .NET and `provided.*` are **asset-backed only**: inline `Code.ZipFile` is
+rejected with a pointer at `lambda.Code.fromAsset(...)`, because each of those
+`Handler` shapes names a compiled artifact — `package.Class::method` for Java's
+JVM class, `Assembly::Namespace.Class::Method` for .NET's CLR assembly, an
+arbitrary `bootstrap` binary for `provided.*`.
+
+The deprecated `go1.x` runtime is rejected with a migration pointer at
+`provided.al2023`.
+
+### Architecture pinning
+
+A ZIP Lambda's `Architectures: [x86_64]` (the default) or `[arm64]` is pinned to
+`--platform linux/amd64` or `linux/arm64` on the container's `docker run`, the
+same way the container-image path pins it on both build and run. On an
+arch-mismatched host, Docker emulates the function's declared architecture, so a
+`provided.*` `bootstrap` compiled for the other architecture runs rather than
+failing with `fork/exec /var/runtime/bootstrap: exec format error` /
+`Runtime.InvalidEntrypoint`.
+
+The same pinning applies to [`cdkd local start-api`](local-start-api.md)'s
+warm-container pool.
+
+### Container-image Lambdas
+
+`lambda.DockerImageFunction(...)` / `Code.ImageUri` functions are supported
+alongside ZIP Lambdas. cdkd resolves the image in this order:
+
+1. **Asset-manifest hit.** cdkd extracts the asset hash from the `:<hash>` tail
+   of the image URI and looks it up in the stack's asset manifest
+   (`cdk.out/<stack>.assets.json`, `dockerImages[<hash>]`), then runs `docker
+   build` against the recorded build context.
+2. **Single-asset fallback.** When the lookup misses but the manifest holds
+   exactly one Docker asset, that asset is used — this covers digest-pinned
+   URIs.
+3. **ECR pull.** When both miss (typically: invoking a stack deployed
+   elsewhere), cdkd falls back to `docker pull` from ECR.
+
+The ECR-pull path supports cross-account and cross-region registries. cdkd
+detects cross-account from `sts:GetCallerIdentity`, builds the ECR client for
+the URI's own region, and — when `--ecr-role-arn <arn>` is passed — issues
+`sts:AssumeRole` to pick up permissions in the target account before
+`ecr:GetAuthorizationToken` and the pull. Without `--ecr-role-arn`, cdkd uses
+your own credentials directly, which works when the target repository's resource
+policy grants you; otherwise AWS returns `AccessDenied` and cdkd hints at the
+flag. Same-account, same-region pulls need no role.
+
+`ImageConfig` is honored on the `docker run`:
+
+| Template field | Effect |
+| --- | --- |
+| `ImageConfig.Command` | Becomes the container `CMD`. |
+| `ImageConfig.EntryPoint` | Becomes `--entrypoint <first>` plus the rest as positional args. |
+| `ImageConfig.WorkingDirectory` | Becomes `--workdir`. |
+
+When `EntryPoint` is unset — the common case — the image's own entrypoint stays
+in charge. For AWS Lambda base images that is `/lambda-entrypoint.sh`, which
+routes to RIE on port 8080.
+
+## Environment variables
+
+The function's template `Properties.Environment.Variables` entries are handled
+by kind:
+
+| Entry kind | Without a state source | With `--from-state` / `--from-cfn-stack` |
 | --- | --- | --- |
-| `-e, --event <file>` | `{}` | JSON event payload file. |
-| `--event-stdin` | off | Read event JSON from stdin (mutually exclusive with `--event`). |
-| `--env-vars <file>` | — | JSON env-var overrides, SAM-compatible shape: `{"LogicalId":{"KEY":"VALUE"}}` plus an optional top-level `"Parameters"` block applied to every invoke. `null` clears a key. The function-specific key may also be a **CDK display path** (`MyStack/MyHandler` — same form `cdkd local invoke <target>` accepts). Both forms coexist; later JSON entry wins on conflict (SAM apply-in-order). |
-| `--no-pull` | off | Skip `docker pull`. Semantics differ by code path: **ZIP Lambdas** — skip pulling the public Lambda base image. **Container Lambdas, local-build path** — no-op (docker build's default does not refresh the FROM cache). **Container Lambdas, ECR-pull fallback** — skip `docker pull` AND error if the image is not in the local cache (re-run without `--no-pull` or pre-pull manually). |
-| `--no-build` | off | Skip `docker build` on the **Container Lambdas, local-build path** (`Code.ImageUri`). Requires the deterministic `cdkd-local-invoke-<hash>` tag to already be in the local docker registry from a prior `cdkd local invoke` (or manual `docker build`); errors clearly when missing. **No-op for ZIP Lambdas** (no docker build runs there) AND for the **Container Lambdas, ECR-pull fallback** (use `--no-pull` to control that path). Compatible with `--no-pull`. |
-| `--ecr-role-arn <arn>` | — | Role ARN to assume before authenticating against ECR on the **Container Lambdas, ECR-pull fallback** path. Issues `sts:AssumeRole` via the default credential chain and uses the resulting temp creds for `ecr:GetAuthorizationToken` + `docker pull`. Required for cross-account pulls when the caller's identity does not already have direct cross-account access. Same-account / same-region pulls do not need this flag; cross-account without the flag falls back to the caller's credentials (succeeds when an IAM resource policy on the ECR repo grants the caller directly, else AWS surfaces `AccessDenied`). No-op when `--no-pull` is set. |
-| `--layer-role-arn <arn>` | — | Role to `sts:AssumeRole` before calling `lambda:GetLayerVersion` on every literal-ARN entry in `Properties.Layers`. Use only when the developer's own credentials cannot read the layer — typically a cross-account layer. AWS-published public layers (e.g. Lambda Powertools) are readable from every account and need no role. No-op for stacks whose layers are all same-stack `AWS::Lambda::LayerVersion` references. |
-| `--debug-port <port>` | off | Set `NODE_OPTIONS=--inspect-brk=0.0.0.0:<port>` and publish the port; attach a Node debugger to step through the handler. |
-| `--container-host <host>` | `127.0.0.1` | Host to bind the RIE port to. |
-| `--assume-role [arn]` | off | STS-assume the deployed function's execution role and forward the resulting temp credentials to the container, so the handler runs under the deployed role's narrow permissions instead of the developer's typically-admin shell credentials. Three forms: (1) `--assume-role <arn>` assumes the explicit ARN (precedence wins); (2) `--assume-role` (bare) auto-resolves the function's `Properties.Role` from cdkd state (requires `--from-state`); (3) `--no-assume-role` explicitly opts out (forces dev creds even with `--from-state`). Off by default — when omitted, `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` / `AWS_REGION` are passed through unchanged (SAM-compatible default). STS failures degrade to a warn + dev-creds fallback. |
-| `-a, --app <cmd-or-dir>` | — | CDK app command or pre-synthesized `cdk.out` directory. Default: synth every time (Q2 recommendation C). Pass `-a cdk.out` to skip synthesis when iterating. |
-| `--output <dir>` | `cdk.out` | Output directory for synthesis. |
-| `--from-state` | off | Read cdkd's S3 state for the target stack and substitute `Ref` / `Fn::GetAtt` / `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters (`${AWS::AccountId}` / `${AWS::Region}` / `${AWS::Partition}` / `${AWS::URLSuffix}`) in env vars with the deployed physical IDs / attributes. Off by default — keeps PR 1's literal-only / warn-and-drop behavior. See [State-driven env recovery (`--from-state`)](#state-driven-env-recovery-from-state) below. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `DescribeStackResources` and substitute `Ref` / `Fn::ImportValue` placeholders in env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). Bare form uses the cdkd stack name; pass an explicit value when the CFn stack name differs. **Mutually exclusive with `--from-state`** — pick one source. `Fn::GetAtt` in a consumer Lambda's own env vars is recovered from the deployed function config (`lambda:GetFunctionConfiguration`, via `cdk-local@0.10.0`); `Fn::GetAtt` at other sites still warn-and-drops, except a same-stack ECR repository's `Arn` / `RepositoryUri` in a container image URI (synthesized from the recovered physical name + pseudo parameters). See [CloudFormation-driven env recovery (`--from-cfn-stack`)](#cloudformation-driven-env-recovery-from-cfn-stack) below. |
-| `--state-bucket <bucket>` | auto | S3 bucket containing cdkd state. Falls back to `CDKD_STATE_BUCKET` env or `cdk.json context.cdkd.stateBucket`, then the default `cdkd-state-{accountId}`. Only used with `--from-state`. |
-| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Only used with `--from-state`. |
-| `--stack-region <region>` | auto | Region of the state record to read. Required for `--from-state` when the same stack name has state in multiple regions. Also drives the CFn client region for `--from-cfn-stack` (cdkd does not have a separate `--cfn-stack-region` flag). |
+| Literal (string / number / boolean) | Passed through as-is. | Passed through as-is. |
+| Intrinsic (`Ref`, `Fn::GetAtt`, `Fn::Sub`, `Fn::Join`, `Fn::ImportValue`) | Warned by name and **dropped**, rather than silently substituting garbage. | Substituted with the deployed value where the source can supply one; warned and dropped otherwise. |
+| AWS pseudo parameters (`${AWS::AccountId}` / `${AWS::Region}` / `${AWS::Partition}` / `${AWS::URLSuffix}`) | Warned and dropped. | Resolved from `sts:GetCallerIdentity` plus the resolved region. |
 
-### Environment variables
+You can always override any entry — intrinsic or not — with `--env-vars`.
 
-Template `Properties.Environment.Variables` entries:
-
-- **Literal values** (string / number / boolean) are passed through as-is.
-- **Intrinsic-valued entries** (`Ref` / `Fn::GetAtt` / `Fn::Sub` /
-  `Fn::Join`, plus the `${AWS::AccountId}` / `${AWS::Region}` /
-  `${AWS::Partition}` / `${AWS::URLSuffix}` pseudo parameters) need state
-  (and a single `sts:GetCallerIdentity` for `${AWS::AccountId}`) to
-  resolve. Without `--from-state` v1 emits a warning naming the variable
-  and **drops** it (rather than silently substituting garbage); pass
-  `--from-state` (see below) to recover deployed values from cdkd's S3
-  state, or override intrinsics via `--env-vars`.
-
-Standard Lambda runtime env vars are always set: `AWS_LAMBDA_FUNCTION_NAME`,
+These standard Lambda runtime variables are always set, so the handler's
+`context.*` fields look real: `AWS_LAMBDA_FUNCTION_NAME`,
 `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`, `AWS_LAMBDA_FUNCTION_TIMEOUT`,
 `AWS_LAMBDA_FUNCTION_VERSION`, `AWS_LAMBDA_LOG_GROUP_NAME`,
-`AWS_LAMBDA_LOG_STREAM_NAME`. The handler's `context.*` fields look real.
+`AWS_LAMBDA_LOG_STREAM_NAME`.
 
-### State-driven env recovery (`--from-state`)
+### Resolution priority
 
-When the target stack has been deployed with `cdkd deploy`, the function's
-intrinsic-valued env vars (`Ref` / `Fn::GetAtt` / `Fn::Sub`) reference
-resources whose physical IDs only exist in AWS. PR 1's behavior is to
-drop those entries with a warn — correct when there's no source of
-truth, but unhelpful when cdkd already knows them. `--from-state` opts
-in to reading cdkd's S3 state and substituting the deployed values
+Highest wins:
+
+1. The `--env-vars` file's function-specific entry (`{LogicalId: {KEY: VALUE}}`,
+   or the same block keyed by CDK display path).
+2. The `--env-vars` file's global `Parameters` block.
+3. The `--from-state` / `--from-cfn-stack` substituted intrinsic, when a state
+   source is set and the substitution succeeded.
+4. The template's literal value.
+
+## `--from-state`: recover env vars from cdkd state
+
+When the target stack has been deployed with `cdkd deploy`, cdkd already knows
+the physical IDs and attributes its intrinsic-valued env vars point at.
+`--from-state` opts in to reading cdkd's S3 state and substituting those values
 before the env block reaches the container.
-
-**Resolution priority** (highest priority wins):
-
-1. `--env-vars` file function-specific entry (`{LogicalId: {KEY: VALUE}}`).
-2. `--env-vars` file global `Parameters` block.
-3. `--from-state` substituted intrinsic (when the flag is set AND the
-   template entry was a supported intrinsic AND substitution succeeded).
-4. Template literal value.
-
-**Supported intrinsics**: `Ref` (→ `state.resources[id].physicalId`),
-`Fn::GetAtt` (→ `state.resources[id].attributes[attr]`, JSON-stringified
-when the cached value is an object/array), `Fn::Sub` (single-string and
-two-arg forms; `${LogicalId}` / `${LogicalId.attr}` / `${AWS::*}`
-placeholders are substituted in place — the two-arg form's bindings map
-can also carry intrinsic values, recursively resolved), `Fn::Join`
-(every element recursively resolved, then joined), and `Ref: AWS::*`
-pseudo parameters (`AccountId` / `Region` / `Partition` / `URLSuffix`)
-resolved against STS `GetCallerIdentity` + the configured region.
-
-**Failure mode**: per-key best-effort. When a substitution can't be
-produced (state missing for the referenced resource, attribute not
-captured at deploy time, unsupported intrinsic in `Fn::Sub`), the key
-is reported via warn and dropped — same UX as PR 1. State-load
-failures (no state record, multi-region ambiguity without
-`--stack-region`, bucket-resolution error) degrade to warn-and-fall-back
-rather than aborting the whole invoke.
-
-**Auto-assume execution role**: when `--from-state` is paired with bare
-`--assume-role` (no ARN argument), cdkd reads the function's
-`Properties.Role` from cdkd state, resolves `Fn::GetAtt: [<RoleId>, 'Arn']`
-shapes against the sibling IAM Role resource's recorded `Arn` attribute,
-and STS-assumes that role automatically — no manual ARN lookup required.
-When `--from-state` is set WITHOUT `--assume-role`, the legacy hint path
-fires instead: cdkd logs the deployed role ARN once so users can re-run
-with `--assume-role`. Pass `--no-assume-role` to explicitly opt out even
-with `--from-state`; pass `--assume-role <arn>` to override the resolved
-ARN with an explicit one. STS failures (insufficient permissions /
-trust-policy mismatch) degrade to a warn + dev-creds fallback — this is
-a developer-loop tool, not a security boundary.
-
-**Pseudo parameters**: when the function's template env contains any
-intrinsic value, `cdkd local invoke --from-state` issues a single
-`sts:GetCallerIdentity` (for `${AWS::AccountId}`) and derives
-`partition` / `urlSuffix` from the resolved region (`--region` >
-`AWS_REGION` > `AWS_DEFAULT_REGION` > the synth-derived stack region).
-STS failures degrade to warn — substitution still runs for non-`AWS::*`
-refs; affected `${AWS::*}` placeholders fall back to warn + drop.
-Literal-only env maps skip the STS hop.
-
-**Out of scope** (deferred): cross-stack `Fn::ImportValue` /
-`Fn::GetStackOutput`, other intrinsics (`Fn::Select`, `Fn::Split`,
-`Fn::If`, etc.). Anything beyond the listed supported intrinsics is
-treated as unresolved (warn + drop).
 
 ```bash
 # Single-region stack: --from-state alone is enough
@@ -188,314 +198,322 @@ cdkd local invoke MyStack/MyApi/Handler --from-state
 # Multi-region: disambiguate the state record
 cdkd local invoke MyStack/MyApi/Handler --from-state --stack-region us-west-2
 
-# Combine with --env-vars to override a single key (override wins)
+# Combine with --env-vars to override a single key (the override wins)
 cdkd local invoke MyStack/MyApi/Handler --from-state \
   --env-vars '{"Parameters":{"DEBUG":"1"}}'
 ```
 
-### CloudFormation-driven env recovery (`--from-cfn-stack`)
+### Supported intrinsics
 
-`--from-state` only works when the target stack was deployed via `cdkd
-deploy` — cdkd reads its own S3 state and that state only exists for
-cdkd-deployed stacks. For CDK apps deployed via the upstream CDK CLI
-(`cdk deploy` → CloudFormation), use `--from-cfn-stack` instead: cdkd
-calls `cloudformation:DescribeStackResources` against the named CFn
-stack to populate the same per-logical-id physical-id map that
-`--from-state` would have built from cdkd state, then runs the existing
-substitution engine against it.
+| Intrinsic | Resolved from |
+| --- | --- |
+| `Ref: <LogicalId>` | The state record's `resources[id].physicalId`. |
+| `Fn::GetAtt: [<LogicalId>, <attr>]` | The state record's `resources[id].attributes[attr]`, JSON-stringified when the cached value is an object or array. |
+| `Fn::Sub` | Both the single-string and two-arg forms. `${LogicalId}` / `${LogicalId.attr}` / `${AWS::*}` placeholders are substituted in place; the two-arg form's bindings map may itself carry intrinsics, resolved recursively. |
+| `Fn::Join` | Every element is resolved recursively, then joined. |
+| `Ref: AWS::AccountId` / `Region` / `Partition` / `URLSuffix` | One `sts:GetCallerIdentity` plus the resolved region. |
+
+Pseudo-parameter resolution runs only when the env map actually contains an
+intrinsic — a literal-only map skips the STS hop entirely. The region used for
+`partition` / `urlSuffix` follows `--region` > `AWS_REGION` >
+`AWS_DEFAULT_REGION` > the synth-derived stack region. An STS failure warns and
+leaves the `${AWS::*}` placeholders dropped; non-`AWS::*` substitution still
+runs.
+
+### Failure handling
+
+Resolution is per-key best-effort. When a substitution cannot be produced —
+state missing for the referenced resource, the attribute not captured at deploy
+time, an unsupported intrinsic inside `Fn::Sub` — that key is warned and
+dropped, and the invoke proceeds.
+
+State-load failures are equally non-fatal: a missing state record, multi-region
+ambiguity without `--stack-region`, or a bucket-resolution error warns and falls
+back to the no-state behaviour rather than aborting the invoke.
+
+## `--from-cfn-stack`: recover env vars from CloudFormation
+
+`--from-state` only works for stacks deployed by `cdkd deploy`, because that is
+the only thing that writes cdkd's S3 state. For CDK apps deployed through the
+upstream CDK CLI (`cdk deploy` → CloudFormation), use `--from-cfn-stack`: cdkd
+calls `cloudformation:DescribeStackResources` against the named stack to build
+the same per-logical-ID physical-ID map, then runs the same substitution engine
+over it.
 
 ```bash
 # Bare flag — uses the cdkd stack name as the CFn stack name
-# (typical for CDK apps where they match).
 cdk deploy MyStack
 cdkd local invoke MyStack/MyApi/Handler --from-cfn-stack
 
-# Explicit CFn stack name — use when the deployed CFn stack name
-# differs from the cdkd / CDK display name (e.g. when CDK's `stackName`
-# prop was overridden).
+# Explicit CFn stack name — when the deployed name differs from the CDK
+# display name (e.g. CDK's `stackName` prop was overridden)
 cdkd local invoke MyStack/MyApi/Handler --from-cfn-stack MyExplicitCfnStackName
 
-# Cross-region CFn stack — --stack-region drives the CFn client region.
+# Cross-region CFn stack — --stack-region drives the CFn client region
 cdkd local invoke MyStack/MyApi/Handler --from-cfn-stack --stack-region eu-west-1
 ```
 
-**What's resolved**: `Ref: <LogicalId>` against
-`DescribeStackResources` (one CFn API call per stack) and
-`Fn::ImportValue: <ExportName>` against `cloudformation:ListExports`
-(paginated, memoized for one substitution pass).
+### What resolves
 
-**`Fn::GetAtt` is recovered for a consumer Lambda's OWN env vars; other
-sites warn-and-drop.** CFn's `DescribeStackResources` does NOT return
-per-attribute values — it only exposes `(LogicalResourceId,
-PhysicalResourceId, ResourceType)` triplets. But CloudFormation already
-resolved every intrinsic at deploy time, so a consumer Lambda's
-`Environment.Variables` already carries the concrete value. As of
-`cdk-local@0.10.0` (which cdkd consumes through the `--from-cfn-stack`
-shim), env keys whose template value is an `Fn::GetAtt` the static
-substituter could not resolve are filled at runtime by reading the
-deployed function's config (`lambda:GetFunctionConfiguration`) — this
-covers `Fn::GetAtt` / `Fn::Sub` / `Fn::ImportValue` / cross-stack `Ref`
-in Lambda env vars uniformly, without provider-specific describe calls.
-`Fn::GetAtt` at NON-Lambda-env sites (e.g. ECS container env) is still
-warn-and-dropped; override the affected entry via `--env-vars` if the
-value is critical.
+| Intrinsic | Resolved from |
+| --- | --- |
+| `Ref: <LogicalId>` | `cloudformation:DescribeStackResources` — one API call per stack. |
+| `Fn::ImportValue: <ExportName>` | `cloudformation:ListExports`, paginated and memoized for one substitution pass. |
+| `Fn::GetAtt` in a **consumer Lambda's own** env vars | The deployed function's configuration (`lambda:GetFunctionConfiguration`). |
+| `Fn::GetAtt` anywhere else (e.g. an ECS container env) | Nothing — warned and dropped. Override the entry with `--env-vars` if the value is critical. |
+| `Fn::GetStackOutput` | Nothing — rejected with a warn. |
 
-**`Fn::GetStackOutput` is rejected** with a clear warn naming the cdkd-
-vs-CFn gap: it's a cdkd-specific intrinsic with no CloudFormation
-equivalent (CFn cross-stack vocabulary is `Fn::ImportValue` against an
-explicit `Outputs.<name>.Export` block). Use `Fn::ImportValue` or pass
-`--from-state` instead.
+`DescribeStackResources` returns only `(LogicalResourceId,
+PhysicalResourceId, ResourceType)` triplets, with no per-attribute values. But
+CloudFormation already resolved every intrinsic at deploy time, so a consumer
+Lambda's `Environment.Variables` already holds the concrete value: cdkd reads it
+back from the deployed function config, which covers `Fn::GetAtt` / `Fn::Sub` /
+`Fn::ImportValue` / cross-stack `Ref` in Lambda env vars uniformly, with no
+per-service describe calls.
 
-**Mutually exclusive with `--from-state`** — the CLI rejects the
-combination at parse time. The two flags target different state
-sources (cdkd's S3 state vs CloudFormation); asking for both is
-ambiguous about which wins.
+`Fn::GetStackOutput` is a cdkd-specific intrinsic with no CloudFormation
+equivalent — CFn's cross-stack vocabulary is `Fn::ImportValue` against an
+explicit `Outputs.<name>.Export` block. Use `Fn::ImportValue`, or `--from-state`
+instead.
 
-**Region handling**: the CFn client is region-bound at construction
-time using the precedence `--stack-region` > `--region` > `AWS_REGION`
-> `AWS_DEFAULT_REGION` > the synth-derived stack region. There is
-intentionally no separate `--cfn-stack-region` flag — `--stack-region`
-does double duty. When NONE of these signals is set the CLI **throws**
-with a remediation message (distinct from `--from-state`'s silent
-`us-east-1` fallback; CFn `DescribeStackResources` queries a specific
-region and silently picking `us-east-1` would query the wrong stack
-environment).
+### Region handling
 
-**Multi-stack guard**: `local start-api` / `local start-service` route
-multiple stacks in one invocation. Bare `--from-cfn-stack` works there
-because each routed stack uses its own cdkd stack name as the CFn
-stack name. **Explicit `--from-cfn-stack <name>` is rejected** when
-more than one stack is routed (the explicit name would apply to every
-routed stack and silently mismap `Ref` lookups whose logical IDs
-happen to collide between siblings). Use bare `--from-cfn-stack` for
+The CFn client is region-bound at construction using the precedence
+`--stack-region` > `--region` > `AWS_REGION` > `AWS_DEFAULT_REGION` > the
+synth-derived stack region. There is deliberately no separate
+`--cfn-stack-region` flag; `--stack-region` does double duty.
+
+When none of those signals is set, the command **throws** with a remediation
+message rather than falling back to a literal region the way `--from-state`
+does. `DescribeStackResources` queries one specific region, and silently
+choosing `us-east-1` would query the wrong environment.
+
+### Multi-stack routing
+
+[`cdkd local start-api`](local-start-api.md) and [`cdkd local
+start-service`](local-start-service.md) can route several stacks in one
+invocation. Bare `--from-cfn-stack` works there, because each routed stack uses
+its own cdkd stack name as the CFn stack name. An **explicit
+`--from-cfn-stack <name>` is rejected** when more than one stack is routed: the
+one name would apply to every routed stack and silently mismap `Ref` lookups
+whose logical IDs happen to collide between siblings. Use the bare form for
 multi-stack apps, or run one cdkd invocation per stack.
 
-**Failure modes**: `DescribeStackResources` failures (stack not found,
-access denied, throttling) degrade to a per-key warn + drop, same UX as
-the `--from-state` warn-and-fall-back path. `ListExports` failures only
-affect `Fn::ImportValue` resolution; same-stack `Ref` substitutions
-still succeed because they only need the `DescribeStackResources`
-result.
+### CloudFormation failure handling
 
-### Asset resolution
+`DescribeStackResources` failures — stack not found, access denied, throttling —
+degrade to a per-key warn and drop, the same as `--from-state`. `ListExports`
+failures affect only `Fn::ImportValue`; same-stack `Ref` substitutions still
+succeed, because they need only the `DescribeStackResources` result.
 
-**ZIP Lambdas**: cdkd uses the CDK-blessed `Metadata['aws:asset:path']`
-hint on each Lambda's CFn resource (the same source SAM uses) to find
-the local unzipped asset directory under `cdk.out`, and bind-mounts it
-at `/var/task` read-only. `Code.ZipFile` (inline) functions are
-materialized to a tmpdir using the file path implied by the function's
-`Handler` property (`index.handler` → `tmpdir/index.js`).
+## `--assume-role`: run under the deployed execution role
 
-### Lambda Layers
+By default the container inherits your shell's `AWS_ACCESS_KEY_ID` /
+`AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` / `AWS_REGION` unchanged, which is
+SAM-compatible but means the handler usually runs with far wider permissions
+than it has when deployed. `--assume-role` STS-assumes the function's execution
+role and forwards the resulting temporary credentials instead, so an
+IAM-permission bug shows up locally.
 
-Same-stack `AWS::Lambda::LayerVersion` references in
-`Properties.Layers` are resolved automatically and bind-mounted at
-`/opt` (read-only) inside the container. The flow:
+| Form | Behaviour |
+| --- | --- |
+| `--assume-role <arn>` | Assumes the explicit ARN. Takes precedence over anything resolved from state. |
+| `--assume-role` (bare) | Reads the function's `Properties.Role` from cdkd state, resolves `Fn::GetAtt: [<RoleId>, 'Arn']` shapes against the sibling IAM Role's recorded `Arn` attribute, and assumes that. Requires `--from-state`. |
+| flag omitted | Your shell credentials are forwarded unchanged. |
 
-1. `cdkd local invoke` walks `Properties.Layers` left-to-right.
-2. Each entry must be `{Ref: '<LayerLogicalId>'}` or
-   `{Fn::GetAtt: ['<LayerLogicalId>', 'Ref']}` pointing at an
-   `AWS::Lambda::LayerVersion` resource in the same stack. The layer's
-   `Metadata['aws:asset:path']` is read the same way Lambda code is
-   located — the layer asset is unzipped under `cdk.out/asset.<hash>/`
-   ready to bind-mount.
-3. cdkd produces a single bind mount at `/opt`:
-   - **Single layer**: the layer's asset dir is bind-mounted directly
-     (no copy).
-   - **Multiple layers**: each layer's contents are copied into a
-     freshly-allocated tmpdir IN ORDER (later layers overwrite earlier
-     files via `cpSync({force: true})`); the merged tmpdir is then
-     bind-mounted at `/opt` and removed in the cleanup path.
-   - The merge mirrors AWS Lambda's actual runtime behavior: AWS
-     extracts every layer ZIP into `/opt` in template order so later
-     layers shadow earlier files (**"last layer wins on file
-     collision"**). cdkd cannot rely on multiple `-v ...:/opt:ro`
-     entries — Docker rejects duplicate bind mounts at the same target
-     path with `Error response from daemon: Duplicate mount point: /opt`.
-4. The layer's directory layout (`/opt/python/...`,
-   `/opt/nodejs/...`, `/opt/lib/...`, etc.) is the user's
-   responsibility — cdkd does NOT inspect the contents.
+With `--from-state` set but no `--assume-role`, cdkd logs the deployed role ARN
+once, so you can re-run with the flag.
 
-**Literal-ARN layer entries**: a `Layers` entry
-that is the string
-`arn:<partition>:lambda:<region>:<account>:layer:<name>:<version>` is
-resolved by downloading that layer version's ZIP and unzipping it into a
-host tmpdir, which then joins the same `/opt` merge as same-stack layers
-— so "last layer wins" holds across both kinds. This covers
-AWS-published public layers (Lambda Powertools, the Datadog extension)
-and cross-account / cross-region shared layers. Pass
-`--layer-role-arn <arn>` to `sts:AssumeRole` before
-`lambda:GetLayerVersion` when the developer's own credentials cannot
-read the layer — typically a cross-account one; AWS-published public
-layers are readable from every account and need no role.
+An STS failure — insufficient permissions, trust-policy mismatch — degrades to a
+warn plus a fallback to your shell credentials. This is a developer-loop tool,
+not a security boundary.
 
-The ARN's **partition is derived from its region** rather than matched
-against a hardcoded list, so the ARN in any of the eight partitions —
-commercial, `aws-cn`, `aws-us-gov`, `aws-iso`, `aws-iso-b`, `aws-iso-e`,
-`aws-iso-f`, `aws-eusc` — now PARSES; previously only three did, and
-the other five were refused outright at resolution. The two segments must
-also AGREE: `arn:aws-cn:lambda:us-east-1:...` is refused, naming the
-disagreement, because `us-east-1` does not belong to `aws-cn`. A region
-cdkd's partition table does not recognise resolves to the commercial
-partition, so a brand-new commercial region keeps working with `arn:aws:`.
+## Asset resolution
 
-> **Parsing is not the whole path, and the rest is still commercial-only.**
-> The download itself runs through cdk-local, which rebuilds the ARN with a
-> hardcoded `aws` partition before calling `lambda:GetLayerVersion`
-> (`node_modules/cdk-local/dist/local-studio-BBtUAVNy.js:15214` —
-> `` `arn:aws:lambda:${layer.region}:${layer.accountId}:layer:${layer.name}` ``).
-> So a layer ARN in any of the seven non-commercial partitions gets past
-> cdkd's parse and then fails at the AWS call instead. `aws-cn` and
-> `aws-us-gov` already parsed before this change and gain nothing from it;
-> for the five that did not (`aws-iso`, `aws-iso-b`, `aws-iso-e`,
-> `aws-iso-f`, `aws-eusc`) what changed is WHICH failure you get — an
-> AWS-side error naming the real blocker, rather than cdkd refusing to read
-> the ARN at all. End-to-end support for those partitions needs an
-> upstream cdk-local fix.
+**ZIP Lambdas.** cdkd reads the CDK-blessed `Metadata['aws:asset:path']` hint on
+each Lambda's CFn resource — the same source SAM uses — to find the local
+unzipped asset directory under `cdk.out`, and bind-mounts it at `/var/task`
+read-only. Inline `Code.ZipFile` functions are materialized to a tmpdir using
+the file path implied by the function's `Handler` property (`index.handler` →
+`tmpdir/index.js`).
 
-**Out of scope (v1)** — hard-errors with a clear pointer at the
-offending entry:
+**Container-image Lambdas.** See [Container-image
+Lambdas](#container-image-lambdas) above.
 
-- Layer entries that are neither a same-stack reference nor a
-  well-formed layer-version ARN (a malformed ARN, a function ARN, an
-  unversioned layer ARN, or a partition that disagrees with the region).
-- Same-stack refs that don't point at an `AWS::Lambda::LayerVersion`
-  (typo'd logical ID).
-- Same-stack refs to a `LayerVersion` whose `Metadata['aws:asset:path']`
+## Lambda layers
+
+Layers are resolved into a single read-only bind mount at `/opt` inside the
+container. cdkd does not inspect the contents — the layer's internal layout
+(`/opt/python/...`, `/opt/nodejs/...`, `/opt/lib/...`) is yours to get right.
+
+With one layer, that layer's asset directory is bind-mounted directly, with no
+copy. With several, each layer's contents are copied into a fresh tmpdir **in
+template order**, so later layers overwrite earlier files, and the merged tmpdir
+is bind-mounted and removed on cleanup. The merge mirrors what AWS Lambda does
+at runtime — it extracts every layer ZIP into `/opt` in template order, so the
+**last layer wins on a file collision**. cdkd cannot use several `-v ...:/opt:ro`
+entries instead, because Docker rejects duplicate bind mounts at one target with
+`Error response from daemon: Duplicate mount point: /opt`.
+
+### Same-stack layer references
+
+A `Properties.Layers` entry of the form `{Ref: '<LayerLogicalId>'}` or
+`{Fn::GetAtt: ['<LayerLogicalId>', 'Ref']}` must point at an
+`AWS::Lambda::LayerVersion` in the same stack. Its
+`Metadata['aws:asset:path']` is read the same way Lambda code is located, and
+the asset is already unzipped under `cdk.out/asset.<hash>/`, ready to mount.
+
+### Literal layer ARNs
+
+A `Layers` entry that is the string
+`arn:<partition>:lambda:<region>:<account>:layer:<name>:<version>` is resolved
+by downloading that layer version's ZIP and unzipping it into a host tmpdir,
+which then joins the same `/opt` merge — so "last layer wins" holds across both
+kinds. This covers AWS-published public layers (Lambda Powertools, the Datadog
+extension) and cross-account or cross-region shared layers.
+
+Pass `--layer-role-arn <arn>` to `sts:AssumeRole` before
+`lambda:GetLayerVersion` when your own credentials cannot read the layer,
+typically a cross-account one. AWS-published public layers are readable from
+every account and need no role.
+
+The ARN's **partition is derived from its region** rather than matched against a
+fixed list, so an ARN in any of the eight partitions — commercial, `aws-cn`,
+`aws-us-gov`, `aws-iso`, `aws-iso-b`, `aws-iso-e`, `aws-iso-f`, `aws-eusc` —
+parses. The two segments must agree: `arn:aws-cn:lambda:us-east-1:...` is
+refused, naming the disagreement, because `us-east-1` does not belong to
+`aws-cn`. A region cdkd's partition table does not recognise resolves to the
+commercial partition, so a brand-new commercial region keeps working with
+`arn:aws:`.
+
+Parsing is not the whole path, and the **download is commercial-only**: the
+underlying layer download rebuilds the ARN with a hardcoded `aws` partition
+before calling `lambda:GetLayerVersion`. A layer ARN in any non-commercial
+partition therefore gets past cdkd's parse and then fails at the AWS call.
+
+### Rejected layer entries
+
+These hard-error, with the message pointing at the offending entry:
+
+- An entry that is neither a same-stack reference nor a well-formed
+  layer-version ARN — a malformed ARN, a function ARN, an unversioned layer
+  ARN, or a partition that disagrees with the region.
+- A same-stack reference that does not point at an `AWS::Lambda::LayerVersion`
+  (a typo'd logical ID).
+- A same-stack reference to a `LayerVersion` whose `Metadata['aws:asset:path']`
   is missing.
 
-**Container Lambdas** (`Code.ImageUri`): the `Layers` property is
-silently ignored — matches AWS behavior, since container images bake
-their layers at build time and AWS rejects `Layers` on container
-Lambdas at deploy time.
+Container-image Lambdas (`Code.ImageUri`) silently ignore `Layers`, matching AWS:
+container images bake their layers at build time, and AWS rejects `Layers` on a
+container Lambda at deploy time.
 
-**Container Lambdas** (`Code.ImageUri`): cdkd extracts the asset hash
-from the `:<hash>` tail of the image URI (CDK synthesizes the URI as a
-`Fn::Sub` whose body ends in the asset hash) and looks the matching
-entry up in the stack's asset manifest (`cdk.out/<stack>.assets.json`,
-`dockerImages[<hash>]`). When the lookup hits, `cdkd local invoke` calls
-`docker build` against the recorded build context. When the lookup
-misses AND the manifest contains exactly one Docker asset, that single
-asset is used (single-asset fallback — covers digest-pinned URIs). When
-both miss, cdkd falls back to **ECR pull** with cross-account /
-cross-region support: cdkd builds the ECR client for the URI's region
-and (when `--ecr-role-arn <arn>` is passed) issues `sts:AssumeRole` to
-gain credentials in the target account before authenticating to ECR
-and pulling. Without `--ecr-role-arn`, cdkd uses the caller's
-credentials directly (works when the ECR repo's resource policy grants
-the caller, else AWS surfaces `AccessDenied` with a hint at the flag).
-`ImageConfig.Command` becomes the docker run
-CMD; `ImageConfig.EntryPoint` (when set) becomes `--entrypoint <first>`
-plus the rest as positional args; `ImageConfig.WorkingDirectory` becomes
-`--workdir`. When `EntryPoint` is unset (the common case), the image's
-default entrypoint stays in charge — for AWS Lambda base images that's
-`/lambda-entrypoint.sh`, which routes to RIE on port 8080.
+## Ephemeral storage
 
-### Ephemeral storage (`/tmp` cap)
+When the template declares `Properties.EphemeralStorage.Size` — the typical CDK
+shape being `new lambda.Function(this, 'X', { ephemeralStorageSize:
+cdk.Size.gibibytes(2) })` — cdkd adds `--tmpfs /tmp:rw,size=<N>m` to the `docker
+run`, so the container's `/tmp` is a memory-backed filesystem capped at the
+templated value in MiB (`cdk.Size.gibibytes(2)` serializes to `2048`). Handlers
+that exceed the deployed cap fail locally with `ENOSPC` the way they would on
+AWS, and handlers that check free space via `statvfs` / `df` see the configured
+cap instead of the host's overlay filesystem.
 
-When a Lambda's template declares `Properties.EphemeralStorage.Size`
-(typical CDK shape:
-`new lambda.Function(this, 'X', { ephemeralStorageSize: cdk.Size.gibibytes(2) })`),
-`cdkd local invoke` adds `--tmpfs /tmp:rw,size=<N>m` to the `docker run`
-command so the container's `/tmp` is a memory-backed filesystem capped
-at the templated value (`N` MiB; `cdk.Size.gibibytes(2)` serializes to
-`2048`). Handlers that exceed the deployed cap fail locally with
-`ENOSPC` the way they would on AWS, and handlers that detect free space
-via `statvfs` / `df` see the configured cap rather than the host's
-overlay-fs.
+| Template state | Result |
+| --- | --- |
+| `EphemeralStorage.Size` set, ≤ 10240 MiB | `--tmpfs /tmp:rw,size=<N>m`. Applies to both ZIP and container-image Lambdas. |
+| `EphemeralStorage` absent | No `--tmpfs`; `/tmp` is whatever the base image provides. AWS Lambda base images do not mount a sized tmpfs themselves. |
+| Size above the AWS 10240 MiB (10 GiB) ceiling | Hard error at resolve time, with an actionable message, rather than a `docker run` AWS would have refused anyway. |
+| Intrinsic-valued `Size` (the `{Ref: 'SomeParam'}` shape) | Silently no `--tmpfs` — local invoke has no Parameters context to resolve it with. |
 
-Applies to both ZIP and IMAGE (container) Lambdas — `--tmpfs` overlays
-mount-time inside any container regardless of base image. Container
-Lambdas get an `[info]` log line at startup so users notice the
-`/tmp` override on top of whatever their Dockerfile placed there.
+Container-image Lambdas get an `[info]` line at startup, so the `/tmp` override
+on top of whatever the Dockerfile placed there is not a surprise. The same cap
+applies to each cold-started container in [`cdkd local
+start-api`](local-start-api.md)'s warm pool.
 
-When `EphemeralStorage` is absent, no `--tmpfs` is emitted and the
-container's `/tmp` is whatever the base image provides (AWS Lambda
-base images don't mount a sized tmpfs themselves, so the existing
-behavior is preserved). Templates over the AWS 10240 MiB (10 GiB)
-ceiling hard-error at resolve time with an actionable message rather
-than hanging on a `docker run` that AWS would have refused anyway.
-Intrinsic-valued `Size` entries (the `{Ref: 'SomeParam'}` shape) drop
-silently to no-`--tmpfs` since local invoke cannot resolve them
-without the Parameters context the deploy engine has.
+## Reaching a server on the host
 
-The same cap applies to `cdkd local start-api`'s warm container pool
-— each cold-started container for a Lambda with `EphemeralStorage`
-gets the same sized `/tmp`.
+The container can reach a server bound on the host loopback — an
+`AWS_ENDPOINT_URL_*` local endpoint such as a DynamoDB or S3 mock, or a tunneled
+VPC resource — via the `host.docker.internal` hostname.
 
-### Reaching a server on the host (`host.docker.internal`)
+- **Docker Desktop (macOS / Windows)** resolves it natively.
+- **Linux native dockerd** gets the `--add-host
+  host.docker.internal:host-gateway` mapping injected automatically (Docker
+  20.10+).
+- On an older or unavailable daemon the mapping is silently skipped — never an
+  error.
 
-The Lambda container can reach a server bound on the host loopback — an
-`AWS_ENDPOINT_URL_*` local endpoint (e.g. a local DynamoDB / S3 mock), or a
-tunneled VPC resource — via the `host.docker.internal` hostname. Docker
-Desktop (macOS / Windows) resolves it natively; on Linux native dockerd cdkd
-injects the `--add-host host.docker.internal:host-gateway` mapping
-automatically (Docker 20.10+). On an older / unavailable daemon the mapping is
-silently skipped (never an error). The same applies to `cdkd local run-task`
-container runs, and — inherited from cdk-local's ECS service emulator engine —
-to `cdkd local start-service` / `cdkd local start-alb`.
+The same applies to [`cdkd local run-task`](local-run-task.md) container runs,
+and to [`cdkd local start-service`](local-start-service.md) and [`cdkd local
+start-alb`](local-start-alb.md).
 
-### `local invoke` / `local invoke-agentcore` output streams
+## Output streams
 
-**Everything cdkd's own logger prints goes to stderr.** Both commands reserve
-stdout unconditionally, so every cdkd status line -- `Synthesizing CDK
-app...`, `Target: ...`, `Starting container ...`, layer resolution notices,
-and cdkd's `--verbose` debug output -- goes to **stderr**, the way
-`sam local invoke` has always done it. The lines are moved, not suppressed:
-a terminal shows what it always did, and `2>&1` restores the old
-single-stream view.
+**Everything cdkd's own logger prints goes to stderr.** `cdkd local invoke` and
+[`cdkd local invoke-agentcore`](local-invoke-agentcore.md) reserve stdout
+unconditionally, so every cdkd status line — `Synthesizing CDK app...`,
+`Target: ...`, `Starting container ...`, layer-resolution notices, `--verbose`
+debug output — is written to stderr, the way `sam local invoke` does it. A
+terminal shows the same thing it always did, and `2>&1` restores a single-stream
+view.
 
-**But stdout is not yet payload-only, so pipe through `tail -1`.** Two
-things still reach it, neither routed by cdkd's logger:
+**Stdout is not payload-only, so pipe through `tail -1`.** Two things reach
+stdout besides the response, neither routed by cdkd's logger:
 
-1. **The container's own stdout**, piped through by `streamLogs`. The Lambda
-   runtime emulator puts `START` / `END` / `REPORT` *and* every handler log
-   line on the container's stdout -- `console.error` included, which is
-   measured rather than assumed -- so any handler that prints lands ahead of
-   the response.
-2. **cdk-local's own logger.** The container-image build path is reused from
-   cdk-local, which has a separate logger with no reservation concept, so
-   `Building container image (platform=...)` and `Skipping docker build ...`
-   print on stdout for a container-image Lambda.
+| Source | What lands on stdout |
+| --- | --- |
+| The container's own stdout | The runtime emulator puts `START` / `END` / `REPORT` and every handler log line there — `console.error` included — so any handler that prints lands ahead of the response. |
+| The container-image build path | That path is shared with cdk-local, whose logger has no stdout reservation, so `Building container image (platform=...)` and `Skipping docker build ...` print on stdout for a container-image Lambda. |
 
-A third used to be listed here and is now closed: `docker pull` progress
-reached stdout because `runDockerForeground` passes `stdio: 'inherit'`, and
-`cdkd` runs it unconditionally for an ECR image, so it needed no flag at all.
-While a command holds the reservation that child's fd 1 is now redirected to
-fd 2. The remaining gap is `streamLogs` alone.
+`docker pull` progress does not: while a command holds the stdout reservation,
+the child process's fd 1 is redirected to fd 2.
 
 ```bash
-# Safe today: the response payload is always the LAST line on stdout.
+# The response payload is always the LAST line on stdout.
 cdkd local invoke MyStack/Handler --event event.json | tail -1 | jq .body
 cdkd local invoke-agentcore MyStack/Agent 2> progress.log | tail -1
 ```
 
-A ZIP-code Lambda whose handler prints nothing hits neither, so
-`cdkd local invoke MyStack/Handler | jq` does work there -- it is just not a
-guarantee cdkd can make yet for every target.
+A ZIP Lambda whose handler prints nothing hits neither source, so `cdkd local
+invoke MyStack/Handler | jq` does work there — it is just not a guarantee that
+holds for every target.
 
-`local start-api`, `local run-task` and `local start-service` are unaffected --
-their stdout is a human surface (route table, prefixed container logs), not a
-payload.
+[`cdkd local start-api`](local-start-api.md), [`cdkd local
+run-task`](local-run-task.md) and [`cdkd local
+start-service`](local-start-service.md) are unaffected: their stdout is a human
+surface (route table, prefixed container logs), not a payload.
 
-### `local invoke` exit codes
+## Exit codes
 
-- `0` — RIE answered, regardless of whether the handler returned a
-  success payload OR an error payload. Lambda-style: a thrown handler
-  produces a 200 with an error structure on AWS, and we mirror that.
-- `1` — cdkd-side errors before/after the handler ran: Docker not
-  installed, image pull failed, target not found, RIE port unreachable
-  after the readiness window, container exited before responding.
-
-### v1 scope (out of scope, deferred)
-
-| Out of scope | Deferred to |
+| Code | Meaning |
 | --- | --- |
-| The deprecated `go1.x` runtime | Never — AWS retired the managed Go runtime; build Go handlers for `provided.al2023`, which cdkd does emulate |
-| Cross-account / cross-region / pre-existing-ARN Lambda Layers | Shipped — same-stack `AWS::Lambda::LayerVersion` refs and literal layer-version ARNs are both resolved, the latter by downloading the layer version; see the "Lambda Layers" section above |
-| Cross-stack `Fn::ImportValue` / `Fn::GetStackOutput` in `--from-state` | Future PR |
-| `Fn::Select` / `Fn::Split` / `Fn::If` etc. in `--from-state` | Future PR (warn + drop today) |
-| SQS / S3 event source emulation | Future PR |
-| VPC simulation | Never (local can't replicate VPC) |
-| Custom Resources (`Custom::*`) | Never — these are invoked by the deploy framework, not by users. cdkd surfaces a clear error pointing at the underlying ServiceToken Lambda. |
+| `0` | RIE answered — whether the handler returned a success payload **or** an error payload. This mirrors AWS, where a thrown handler still produces a 200 carrying an error structure. |
+| `1` | A cdkd-side error before or after the handler ran: Docker not installed, image pull or build failed, target not found, an invalid flag value, RIE unreachable within the readiness window, or the container exiting before it responded. |
+| `130` | `^C` (SIGINT). The container is stopped and removed, and any merged-layer or inline-code tmpdir is cleaned up, before the process exits. |
 
+The full cross-command table is in the [CLI Reference](cli-reference.md#exit-codes).
+
+## Limitations
+
+- The deprecated `go1.x` runtime is not emulated. Build Go handlers for
+  `provided.al2023`, which is supported.
+- Cross-stack `Fn::ImportValue` and `Fn::GetStackOutput` are not resolved by
+  `--from-state`.
+- `Fn::Select`, `Fn::Split`, `Fn::If` and other intrinsics outside the
+  [supported list](#supported-intrinsics) are warned and dropped rather than
+  resolved.
+- SQS and S3 event-source emulation is not provided. Pass the event body with
+  `--event` instead.
+- VPC placement is not simulated. A handler that depends on VPC-private
+  connectivity needs a tunnel; see [Reaching a server on the
+  host](#reaching-a-server-on-the-host).
+- Custom Resources (`Custom::*`) cannot be invoked as such — they are called by
+  the deploy framework, not by users. cdkd errors with a pointer at the
+  underlying `ServiceToken` Lambda, which you can invoke directly.
+
+## Related
+
+- [Local Execution](local-emulation.md) — every `cdkd local` subcommand, the Docker requirement, and the flags they share
+- [`cdkd local start-api`](local-start-api.md) — the long-running API Gateway emulator over the same RIE containers
+- [`cdkd local invoke-agentcore`](local-invoke-agentcore.md) — the same one-shot shape for a Bedrock AgentCore Runtime
+- [CLI Reference](cli-reference.md) — every command and the full exit-code table

--- a/docs/local-invoke.md
+++ b/docs/local-invoke.md
@@ -217,8 +217,8 @@ cdkd local invoke MyStack/MyApi/Handler --from-state \
 | `Fn::Sub` | Both the single-string and two-arg forms. `${LogicalId}` / `${LogicalId.attr}` / `${AWS::*}` placeholders are substituted in place; the two-arg form's bindings map may itself carry intrinsics, resolved recursively. |
 | `Fn::Join` | Every element is resolved recursively, then joined. |
 | `Ref: AWS::AccountId` / `Region` / `Partition` / `URLSuffix` | One `sts:GetCallerIdentity` plus the resolved region. |
-| `Fn::ImportValue` | The producer stack's state record, in a second pass. Same account and same region only. |
-| `Fn::GetStackOutput` | The named stack's outputs in the same state bucket. Same account and same region only. |
+| `Fn::ImportValue` | The producer stack's state record, in a second pass. Same account, same region. |
+| `Fn::GetStackOutput` | The named stack's outputs. Same account; the intrinsic's own `Region` argument is honoured, so cross-region works. |
 
 The last two open an extra client, so cdkd builds that resolver only when the
 function's environment actually references one of them.
@@ -270,8 +270,7 @@ cdkd local invoke MyStack/MyApi/Handler --from-cfn-stack --stack-region eu-west-
 | `Ref: <LogicalId>` | `cloudformation:ListStackResources`, paginated, once per stack. |
 | `Fn::ImportValue: <ExportName>` | `cloudformation:ListExports`, paginated and memoized for one substitution pass. |
 | `Fn::GetAtt` in a **consumer Lambda's own** env vars | The deployed function's configuration (`lambda:GetFunctionConfiguration`). |
-| `Fn::GetAtt` on a same-stack ECR repository's `Arn` / `RepositoryUri`, in a container image URI | Synthesized from the recovered physical name plus the pseudo parameters. |
-| `Fn::GetAtt` anywhere else (e.g. an ECS container env) | Nothing — warned and dropped. Override the entry with `--env-vars` if the value is critical. |
+| `Fn::GetAtt` anywhere else | Nothing — warned and dropped. Override the entry with `--env-vars` if the value is critical. |
 | `Fn::GetStackOutput` | Nothing — rejected with a warn. |
 
 `ListStackResources` returns only `(LogicalResourceId, PhysicalResourceId,
@@ -388,8 +387,9 @@ Pass `--layer-role-arn <arn>` to `sts:AssumeRole` before
 typically a cross-account one. AWS-published public layers are readable from
 every account and need no role.
 
-**Only a commercial-partition layer ARN downloads.** An `aws-cn`, `aws-us-gov`
-or ISO-partition ARN passes cdkd's parse and then fails at the AWS call, because
+**Only a commercial-partition layer ARN downloads.** An ARN in any of the seven
+non-commercial partitions — `aws-cn`, `aws-us-gov`, `aws-eusc` and the four ISO
+partitions — passes cdkd's parse and then fails at the AWS call, because
 the download rebuilds the ARN with a hardcoded `aws` partition before calling
 `lambda:GetLayerVersion`.
 
@@ -508,9 +508,10 @@ The full cross-command table is in the [CLI Reference](cli-reference.md#exit-cod
 
 - The deprecated `go1.x` runtime is not emulated. Build Go handlers for
   `provided.al2023`, which is supported.
-- Cross-stack `Fn::ImportValue` and `Fn::GetStackOutput` resolve only within one
-  account and one region. A producer stack in another account or region is
-  warned and dropped.
+- Cross-stack references resolve within one AWS account only; a
+  `Fn::GetStackOutput` carrying a `RoleArn` for another account is refused.
+  `Fn::ImportValue` is additionally same-region — a producer stack in another
+  region is warned and dropped.
 - `Fn::Select`, `Fn::Split`, `Fn::If` and other intrinsics outside the
   [supported list](#supported-intrinsics) are warned and dropped rather than
   resolved.

--- a/docs/local-invoke.md
+++ b/docs/local-invoke.md
@@ -43,7 +43,7 @@ reuse the cached one.
 | `--from-cfn-stack [cfn-stack-name]` | off | Substitute env-var intrinsics from a deployed CloudFormation stack. Mutually exclusive with `--from-state`. See [`--from-cfn-stack`: recover env vars from CloudFormation](#from-cfn-stack-recover-env-vars-from-cloudformation). |
 | `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json`, then `cdkd-state-{accountId}` | S3 bucket holding cdkd state. Used only with `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Used only with `--from-state`. |
-| `--stack-region <region>` | auto | Region of the state record to read, and the CFn client region for `--from-cfn-stack`. See [Local Execution](local-emulation.md#common-flags). |
+| `--stack-region <region>` | — | Region of the state record to read, and the CFn client region for `--from-cfn-stack`. See [Local Execution](local-emulation.md#common-flags). |
 | `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a pre-synthesized cloud-assembly directory. Pass `-a cdk.out` to skip synthesis while iterating. |
 | `--output <path>` | `cdk.out` | Output directory for synthesis. |
 | `-c`, `--context <key=value...>` | — | Set CDK context values. Repeatable. |

--- a/docs/local-invoke.md
+++ b/docs/local-invoke.md
@@ -52,6 +52,11 @@ reuse the cached one.
 | `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
 | `--verbose` | off | Verbose logging (on stderr). |
 
+The region used for AWS API calls and for pseudo-parameter substitution is taken
+from `AWS_REGION`, then `AWS_DEFAULT_REGION`, then the synthesized stack's own
+`env.region`. A deprecated `--region` flag still overrides all three; prefer the
+environment variable or your AWS profile.
+
 ### `--no-pull` and `--no-build` by code path
 
 | Code path | `--no-pull` | `--no-build` |
@@ -212,6 +217,11 @@ cdkd local invoke MyStack/MyApi/Handler --from-state \
 | `Fn::Sub` | Both the single-string and two-arg forms. `${LogicalId}` / `${LogicalId.attr}` / `${AWS::*}` placeholders are substituted in place; the two-arg form's bindings map may itself carry intrinsics, resolved recursively. |
 | `Fn::Join` | Every element is resolved recursively, then joined. |
 | `Ref: AWS::AccountId` / `Region` / `Partition` / `URLSuffix` | One `sts:GetCallerIdentity` plus the resolved region. |
+| `Fn::ImportValue` | The producer stack's state record, in a second pass. Same account and same region only. |
+| `Fn::GetStackOutput` | The named stack's outputs in the same state bucket. Same account and same region only. |
+
+The last two open an extra client, so cdkd builds that resolver only when the
+function's environment actually references one of them.
 
 Pseudo-parameter resolution runs only when the env map actually contains an
 intrinsic — a literal-only map skips the STS hop entirely. The region used for
@@ -236,7 +246,7 @@ back to the no-state behaviour rather than aborting the invoke.
 `--from-state` only works for stacks deployed by `cdkd deploy`, because that is
 the only thing that writes cdkd's S3 state. For CDK apps deployed through the
 upstream CDK CLI (`cdk deploy` → CloudFormation), use `--from-cfn-stack`: cdkd
-calls `cloudformation:DescribeStackResources` against the named stack to build
+calls `cloudformation:ListStackResources` against the named stack to build
 the same per-logical-ID physical-ID map, then runs the same substitution engine
 over it.
 
@@ -257,14 +267,15 @@ cdkd local invoke MyStack/MyApi/Handler --from-cfn-stack --stack-region eu-west-
 
 | Intrinsic | Resolved from |
 | --- | --- |
-| `Ref: <LogicalId>` | `cloudformation:DescribeStackResources` — one API call per stack. |
+| `Ref: <LogicalId>` | `cloudformation:ListStackResources`, paginated, once per stack. |
 | `Fn::ImportValue: <ExportName>` | `cloudformation:ListExports`, paginated and memoized for one substitution pass. |
 | `Fn::GetAtt` in a **consumer Lambda's own** env vars | The deployed function's configuration (`lambda:GetFunctionConfiguration`). |
+| `Fn::GetAtt` on a same-stack ECR repository's `Arn` / `RepositoryUri`, in a container image URI | Synthesized from the recovered physical name plus the pseudo parameters. |
 | `Fn::GetAtt` anywhere else (e.g. an ECS container env) | Nothing — warned and dropped. Override the entry with `--env-vars` if the value is critical. |
 | `Fn::GetStackOutput` | Nothing — rejected with a warn. |
 
-`DescribeStackResources` returns only `(LogicalResourceId,
-PhysicalResourceId, ResourceType)` triplets, with no per-attribute values. But
+`ListStackResources` returns only `(LogicalResourceId, PhysicalResourceId,
+ResourceType)` triplets, with no per-attribute values. But
 CloudFormation already resolved every intrinsic at deploy time, so a consumer
 Lambda's `Environment.Variables` already holds the concrete value: cdkd reads it
 back from the deployed function config, which covers `Fn::GetAtt` / `Fn::Sub` /
@@ -285,7 +296,7 @@ synth-derived stack region. There is deliberately no separate
 
 When none of those signals is set, the command **throws** with a remediation
 message rather than falling back to a literal region the way `--from-state`
-does. `DescribeStackResources` queries one specific region, and silently
+does. The CloudFormation client queries one specific region, and silently
 choosing `us-east-1` would query the wrong environment.
 
 ### Multi-stack routing
@@ -301,10 +312,10 @@ multi-stack apps, or run one cdkd invocation per stack.
 
 ### CloudFormation failure handling
 
-`DescribeStackResources` failures — stack not found, access denied, throttling —
+`ListStackResources` failures — stack not found, access denied, throttling —
 degrade to a per-key warn and drop, the same as `--from-state`. `ListExports`
 failures affect only `Fn::ImportValue`; same-stack `Ref` substitutions still
-succeed, because they need only the `DescribeStackResources` result.
+succeed, because they need only the resource listing.
 
 ## `--assume-role`: run under the deployed execution role
 
@@ -377,19 +388,19 @@ Pass `--layer-role-arn <arn>` to `sts:AssumeRole` before
 typically a cross-account one. AWS-published public layers are readable from
 every account and need no role.
 
-The ARN's **partition is derived from its region** rather than matched against a
-fixed list, so an ARN in any of the eight partitions — commercial, `aws-cn`,
+**Only a commercial-partition layer ARN downloads.** An `aws-cn`, `aws-us-gov`
+or ISO-partition ARN passes cdkd's parse and then fails at the AWS call, because
+the download rebuilds the ARN with a hardcoded `aws` partition before calling
+`lambda:GetLayerVersion`.
+
+The parse itself accepts all eight partitions — commercial, `aws-cn`,
 `aws-us-gov`, `aws-iso`, `aws-iso-b`, `aws-iso-e`, `aws-iso-f`, `aws-eusc` —
-parses. The two segments must agree: `arn:aws-cn:lambda:us-east-1:...` is
-refused, naming the disagreement, because `us-east-1` does not belong to
+because the partition is derived from the ARN's region rather than matched
+against a fixed list. The two segments must agree: `arn:aws-cn:lambda:us-east-1:...`
+is refused, naming the disagreement, because `us-east-1` does not belong to
 `aws-cn`. A region cdkd's partition table does not recognise resolves to the
 commercial partition, so a brand-new commercial region keeps working with
 `arn:aws:`.
-
-Parsing is not the whole path, and the **download is commercial-only**: the
-underlying layer download rebuilds the ARN with a hardcoded `aws` partition
-before calling `lambda:GetLayerVersion`. A layer ARN in any non-commercial
-partition therefore gets past cdkd's parse and then fails at the AWS call.
 
 ### Rejected layer entries
 
@@ -497,8 +508,9 @@ The full cross-command table is in the [CLI Reference](cli-reference.md#exit-cod
 
 - The deprecated `go1.x` runtime is not emulated. Build Go handlers for
   `provided.al2023`, which is supported.
-- Cross-stack `Fn::ImportValue` and `Fn::GetStackOutput` are not resolved by
-  `--from-state`.
+- Cross-stack `Fn::ImportValue` and `Fn::GetStackOutput` resolve only within one
+  account and one region. A producer stack in another account or region is
+  warned and dropped.
 - `Fn::Select`, `Fn::Split`, `Fn::If` and other intrinsics outside the
   [supported list](#supported-intrinsics) are warned and dropped rather than
   resolved.

--- a/docs/local-run-task.md
+++ b/docs/local-run-task.md
@@ -225,11 +225,11 @@ in [Which registry hosts count as ECR](#which-registry-hosts-count-as-ecr).
 With neither state flag, a same-stack repository reference fails with an error
 naming them as the way forward; the stack must have been deployed first.
 
-Under `--from-cfn-stack`, an `Fn::GetAtt` elsewhere in the task definition is
-dropped with a warning — a stack's resource listing carries no per-attribute
-values. This ECR case is its one exception: the repository ARN and URI are
-rebuilt from the recovered physical name plus the pseudo parameters, so no
-per-attribute lookup is needed.
+Under `--from-cfn-stack`, an `Fn::GetAtt` in a container's `Environment[].Value`
+is dropped with a warning — a stack's resource listing carries no per-attribute
+values. Image URIs are not affected: the repository ARN and URI are rebuilt from
+the recovered physical name plus the pseudo parameters, so no per-attribute
+lookup is needed.
 
 ## Environment variables and secrets
 
@@ -373,13 +373,13 @@ container cleanup.
 | Code | Meaning |
 | --- | --- |
 | `0` | The essential container exited `0`, or `--detach` started the containers and returned. |
-| `1` | Either the essential container exited `1`, or cdkd failed before running it — Docker unavailable, target not found, network creation failed, secret resolution failed, an unsupported volume type. |
+| `1` | Either the essential container exited `1`, or cdkd itself failed — Docker unavailable, target not found, network creation failed, secret resolution failed, an unsupported volume type. |
 | `130` | `^C`. A first `^C` tears the task down and then exits; a second exits immediately without container cleanup. |
 | `N` | Any other code the essential container exited with; cdkd propagates it verbatim. |
 
-`1` is the one ambiguous code, because it is both a container exit and cdkd's
-own default failure code. A cdkd-side failure always prints an error before it
-exits, and no container output precedes it — that is the discriminator.
+`1` is the one ambiguous code: it is both a container's own exit status and
+cdkd's default for any failure of its own. Read the error line to tell them
+apart.
 
 The full cross-command table is in the [CLI Reference](cli-reference.md#exit-codes).
 

--- a/docs/local-run-task.md
+++ b/docs/local-run-task.md
@@ -24,7 +24,7 @@ cdkd local run-task MyStack/Worker --keep-running          # leave stopped conta
 Docker is required. The first run pulls the AWS-published
 `amazon/amazon-ecs-local-container-endpoints:latest-amd64` metadata sidecar
 alongside each container image; see
-[Local execution](local-emulation.md#requirements).
+[Local Execution](local-emulation.md#requirements).
 
 ## Options
 
@@ -32,20 +32,20 @@ alongside each container image; see
 | --- | --- | --- |
 | `<target>` | — | CDK display path or stack-qualified logical id of the `AWS::ECS::TaskDefinition` to run. Required. |
 | `--cluster <name>` | `cdkd-local` | Cluster name reported by the metadata endpoint, and the prefix of the per-task Docker network name. |
-| `--env-vars <file>` | — | SAM-shape JSON env-var overrides, keyed by container name — see [Local execution](local-emulation.md#common-flags). |
-| `--container-host <ip>` | `127.0.0.1` | Host IP that published container ports bind to. Must be numeric — see [Local execution](local-emulation.md#common-flags). |
+| `--env-vars <file>` | — | SAM-shape JSON env-var overrides, keyed by container name — see [Local Execution](local-emulation.md#common-flags). |
+| `--container-host <ip>` | `127.0.0.1` | Host IP that published container ports bind to. Must be numeric — see [Local Execution](local-emulation.md#common-flags). |
 | `--assume-task-role [arn]` | off | Assume the task definition's `TaskRoleArn` (or the ARN you pass) and serve those credentials through the metadata sidecar. |
-| `--no-pull` | off | Skip `docker pull` for every container image and for the metadata sidecar — see [Local execution](local-emulation.md#common-flags). |
+| `--no-pull` | off | Skip `docker pull` for every container image and for the metadata sidecar — see [Local Execution](local-emulation.md#common-flags). |
 | `--ecr-role-arn <arn>` | — | Role to assume before authenticating to ECR, for cross-account or centralized registries. No-op with `--no-pull`. |
 | `--platform <platform>` | inferred from `RuntimePlatform.CpuArchitecture` | Force `docker run --platform`. Accepts `linux/amd64` or `linux/arm64`. |
 | `--keep-running` | off | Leave the user containers in place when the task exits; the network and sidecar are still torn down. |
 | `--detach` | off | Start the containers in the background and exit, skipping log streaming and automatic teardown. |
-| `--from-state` | off | Substitute deployed values from cdkd's S3 state into image URIs, environment variables and secrets — see [Local execution](local-emulation.md#common-flags). |
+| `--from-state` | off | Substitute deployed values from cdkd's S3 state into image URIs, environment variables and secrets — see [Local Execution](local-emulation.md#common-flags). |
 | `--from-cfn-stack [name]` | off | Substitute from a CloudFormation-deployed stack instead. Bare form uses the cdkd stack name. Mutually exclusive with `--from-state`. |
-| `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region for `--from-cfn-stack` — see [Local execution](local-emulation.md#common-flags). |
+| `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region for `--from-cfn-stack` — see [Local Execution](local-emulation.md#common-flags). |
 | `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state, for `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. |
-| `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a path to a pre-synthesized cloud assembly — see [Local execution](local-emulation.md#common-flags). |
+| `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a path to a pre-synthesized cloud assembly — see [Local Execution](local-emulation.md#common-flags). |
 | `--output <path>` | `cdk.out` | Output directory for synthesis. |
 | `-c`, `--context <key=value...>` | — | Set CDK context values. Repeatable. |
 | `--profile <profile>` | — | AWS profile. Its credentials are forwarded to the sidecar and to the containers. |
@@ -102,6 +102,21 @@ Docker cannot emulate an ENI per task, and security groups are not enforced
 locally. AWS SDK calls from inside a container still reach the public AWS
 endpoints over your own network.
 
+### Reaching a container from the host
+
+Every `ContainerDefinitions[].PortMappings` entry is published on the host, at
+the entry's `HostPort` when the template names one and at the container port
+otherwise, bound to `--container-host` (`127.0.0.1` by default). One log line
+per published port names the endpoint, so a task declaring container port `8080`
+prints `Reach it at 127.0.0.1:8080` as its container starts.
+
+A **privileged host port** — anything below 1024, which a local publish cannot
+take without root, and which macOS Docker Desktop refuses outright — is
+auto-remapped to a free ephemeral port, with a warning naming the port chosen.
+`cdkd local run-task` has no flag to pin that choice; read it off the warning,
+or use [`cdkd local start-service`](local-start-service.md), whose
+`--host-port <containerPort=hostPort>` pins it.
+
 ## AWS credentials in containers
 
 | Situation | What the containers see |
@@ -131,9 +146,23 @@ error that tells you to pass the ARN explicitly.
 
 ### Which registry hosts count as ECR
 
-A URI is treated as ECR only when its host suffix is the one its own region
-actually uses. A look-alike host carrying another region's suffix is
-deliberately not treated as ECR.
+**Only the plain `<account>.dkr.ecr.<region>.<urlSuffix>` host pulls end to
+end.** A FIPS or dual-stack ECR host is recognized as ECR, but the pull fails
+with `no basic auth credentials`: ECR's `GetAuthorizationToken` issues its
+credential against the plain host, the pull targets the host the template names,
+and Docker's credential store is keyed on the hostname verbatim. Point the
+template at the plain host to run the task locally.
+
+The rest of this section is the recognition rule behind that. A URI is treated
+as ECR only when its host suffix is the one its own region actually uses; a
+look-alike host carrying another region's suffix is deliberately not treated as
+ECR. Three endpoint shapes are recognized — the plain
+`<account>.dkr.ecr.<region>.<urlSuffix>`, its FIPS sibling
+`<account>.dkr.ecr-fips.<region>.<urlSuffix>`, and the dual-stack
+`<account>.dkr-ecr[-fips].<region>.on.aws`, whose fixed `on.aws` suffix replaces
+the region's partition suffix. Host matching is case-insensitive, since DNS is;
+Docker accepts an upper-cased registry host but requires a lower-case repository
+path, so cdkd folds only the host.
 
 The same region-to-partition mapping drives `${AWS::Partition}` and
 `${AWS::URLSuffix}` wherever cdkd substitutes them.
@@ -149,21 +178,7 @@ The same region-to-partition mapping drives `${AWS::Partition}` and
 | `us-isof-*` | `aws-iso-f` | `csp.hci.ic.gov` |
 | `eusc-*` | `aws-eusc` | `amazonaws.eu` |
 
-Three registry endpoint shapes are recognized: the plain
-`<account>.dkr.ecr.<region>.<urlSuffix>`, its FIPS sibling
-`<account>.dkr.ecr-fips.<region>.<urlSuffix>`, and the dual-stack
-`<account>.dkr-ecr.<region>.on.aws` /
-`<account>.dkr-ecr-fips.<region>.on.aws`. The dual-stack forms carry the fixed
-`on.aws` suffix rather than the region's partition suffix, and a form spelled
-with the other's suffix is refused. Host matching is case-insensitive, since DNS
-is; Docker accepts an upper-cased registry host but requires a lower-case
-repository path, and cdkd folds only the host.
-
-**Only the plain form pulls end to end today.** For the FIPS and dual-stack
-hosts, the ECR login authenticates against the plain host — that is what
-`GetAuthorizationToken` reports — while the pull targets the host the template
-names, and Docker's credential store is keyed on the hostname verbatim, so the
-pull fails with `no basic auth credentials`.
+A shape spelled with the other family's suffix is refused.
 
 Cross-account and cross-region pulls are supported: cdkd builds the ECR client
 for the URI's own region, and with `--ecr-role-arn <arn>` issues `sts:AssumeRole`
@@ -203,13 +218,16 @@ before the resulting URI is classified:
 | Pass | Resolves | Needs state? |
 | --- | --- | --- |
 | Pseudo parameters | `${AWS::AccountId}` from STS `GetCallerIdentity` (lazy, cached for the run); `${AWS::Region}` from the resolved region; `${AWS::Partition}` and `${AWS::URLSuffix}` derived from it | No |
-| Same-stack ECR repository | `${<LogicalId>}` against an `AWS::ECR::Repository`, and `Fn::GetAtt: [<Repo>, 'RepositoryUri']`, using the deployed physical repository name | Yes — pass `--from-state` |
+| Same-stack ECR repository | `${<LogicalId>}` against an `AWS::ECR::Repository`, and `Fn::GetAtt: [<Repo>, 'Arn' \| 'RepositoryUri']`, using the deployed physical repository name | Yes — `--from-state` or `--from-cfn-stack` |
 
 `${AWS::Partition}` and `${AWS::URLSuffix}` come from the region, per the table
 in [Which registry hosts count as ECR](#which-registry-hosts-count-as-ecr).
-Without `--from-state`, a same-stack repository reference fails with an error
-naming that flag as the way forward; the stack must have been deployed with
-`cdkd deploy` first.
+With neither state flag, a same-stack repository reference fails with an error
+naming them as the way forward; the stack must have been deployed first.
+
+This ECR case is the one exception to `--from-cfn-stack`'s "`Fn::GetAtt` is
+dropped" rule below: the repository ARN and URI are rebuilt from the recovered
+physical name plus the pseudo parameters, so no per-attribute lookup is needed.
 
 ## Environment variables and secrets
 
@@ -365,3 +383,4 @@ The full cross-command table is in the [CLI Reference](cli-reference.md#exit-cod
 - [`cdkd local start-alb`](local-start-alb.md) — put a local Application Load Balancer in front of those services
 - [`cdkd local invoke`](local-invoke.md) — the Lambda equivalent, sharing the target syntax and `--env-vars` shape
 - [Local Execution](local-emulation.md) — the subcommand index, Docker requirements, and the flags common to every `cdkd local` command
+- [CLI Reference](cli-reference.md) — every cdkd command, the output-stream contract, and the full exit-code table

--- a/docs/local-run-task.md
+++ b/docs/local-run-task.md
@@ -10,7 +10,8 @@ app and starts every one of its containers on your Docker host — no AWS deploy
 required. It is the ECS counterpart of [`cdkd local invoke`](local-invoke.md):
 one synchronous task run, each container's stdout/stderr streamed with a
 `[<name>]` prefix, and the essential container's exit code propagated to your
-shell.
+shell. For a service that stays up and restarts its replicas instead, use
+[`cdkd local start-service`](local-start-service.md).
 
 ```bash
 cdkd local run-task MyStack/MyService/TaskDef              # run one task definition
@@ -34,7 +35,7 @@ alongside each container image; see
 | `--cluster <name>` | `cdkd-local` | Cluster name reported by the metadata endpoint, and the prefix of the per-task Docker network name. |
 | `--env-vars <file>` | — | SAM-shape JSON env-var overrides, keyed by container name — see [Local Execution](local-emulation.md#common-flags). |
 | `--container-host <ip>` | `127.0.0.1` | Host IP that published container ports bind to. Must be numeric — see [Local Execution](local-emulation.md#common-flags). |
-| `--assume-task-role [arn]` | off | Assume the task definition's `TaskRoleArn` (or the ARN you pass) and serve those credentials through the metadata sidecar. |
+| `--assume-task-role [arn]` | off | Assume the task definition's `TaskRoleArn` (or the ARN you pass) and serve those credentials through the metadata sidecar. This command accepts only this spelling — its siblings also take `--assume-role`. |
 | `--no-pull` | off | Skip `docker pull` for every container image and for the metadata sidecar — see [Local Execution](local-emulation.md#common-flags). |
 | `--ecr-role-arn <arn>` | — | Role to assume before authenticating to ECR, for cross-account or centralized registries. No-op with `--no-pull`. |
 | `--platform <platform>` | inferred from `RuntimePlatform.CpuArchitecture` | Force `docker run --platform`. Accepts `linux/amd64` or `linux/arm64`. |
@@ -43,7 +44,7 @@ alongside each container image; see
 | `--from-state` | off | Substitute deployed values from cdkd's S3 state into image URIs, environment variables and secrets — see [Local Execution](local-emulation.md#common-flags). |
 | `--from-cfn-stack [name]` | off | Substitute from a CloudFormation-deployed stack instead. Bare form uses the cdkd stack name. Mutually exclusive with `--from-state`. |
 | `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region for `--from-cfn-stack` — see [Local Execution](local-emulation.md#common-flags). |
-| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state, for `--from-state`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json`, then `cdkd-state-{accountId}` | S3 bucket holding cdkd state, for `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. |
 | `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a path to a pre-synthesized cloud assembly — see [Local Execution](local-emulation.md#common-flags). |
 | `--output <path>` | `cdk.out` | Output directory for synthesis. |
@@ -124,7 +125,7 @@ privileged port and lets `--host-port <containerPort=hostPort>` pin the result.
 | Neither `--assume-task-role` nor `--profile` | The sidecar serves whatever the default credential chain resolves on the host. |
 | `--assume-task-role` (bare) | `sts:AssumeRole` against the task definition's resolved `TaskRoleArn`, once at startup; the temporary credentials are served by the sidecar. |
 | `--assume-task-role <arn>` | Same, against the ARN you supplied. |
-| `--profile <p>` without an effective `--assume-task-role` | The profile is resolved through the SDK chain (SSO, IAM Identity Center, `fromIni`, role assumption) and the resulting credentials are both served by the sidecar and written into a read-only shared-credentials file bind-mounted into every container under `[<p>]`. |
+| `--profile <p>` without an effective `--assume-task-role` | Resolved through the SDK chain, then both served by the sidecar and written into a read-only credentials file mounted into every container under `[<p>]`. |
 
 `--assume-task-role` beats the profile file, which beats the plain sidecar
 pass-through. Bare `--assume-task-role` resolves a flat-string `TaskRoleArn`
@@ -170,7 +171,6 @@ The same region-to-partition mapping drives `${AWS::Partition}` and
 
 | Region prefix | Partition | URL suffix |
 | --- | --- | --- |
-| everything else | `aws` | `amazonaws.com` |
 | `us-gov-*` | `aws-us-gov` | `amazonaws.com` |
 | `cn-*` | `aws-cn` | `amazonaws.com.cn` |
 | `us-iso-*` | `aws-iso` | `c2s.ic.gov` |
@@ -178,6 +178,7 @@ The same region-to-partition mapping drives `${AWS::Partition}` and
 | `eu-isoe-*` | `aws-iso-e` | `cloud.adc-e.uk` |
 | `us-isof-*` | `aws-iso-f` | `csp.hci.ic.gov` |
 | `eusc-*` | `aws-eusc` | `amazonaws.eu` |
+| everything else | `aws` | `amazonaws.com` |
 
 Cross-account and cross-region pulls are supported: cdkd builds the ECR client
 for the URI's own region, and with `--ecr-role-arn <arn>` issues `sts:AssumeRole`
@@ -224,9 +225,11 @@ in [Which registry hosts count as ECR](#which-registry-hosts-count-as-ecr).
 With neither state flag, a same-stack repository reference fails with an error
 naming them as the way forward; the stack must have been deployed first.
 
-This ECR case is the one exception to `--from-cfn-stack`'s "`Fn::GetAtt` is
-dropped" rule below: the repository ARN and URI are rebuilt from the recovered
-physical name plus the pseudo parameters, so no per-attribute lookup is needed.
+Under `--from-cfn-stack`, an `Fn::GetAtt` elsewhere in the task definition is
+dropped with a warning — a stack's resource listing carries no per-attribute
+values. This ECR case is its one exception: the repository ARN and URI are
+rebuilt from the recovered physical name plus the pseudo parameters, so no
+per-attribute lookup is needed.
 
 ## Environment variables and secrets
 
@@ -370,9 +373,13 @@ container cleanup.
 | Code | Meaning |
 | --- | --- |
 | `0` | The essential container exited `0`, or `--detach` started the containers and returned. |
-| `N` | The essential container exited `N`; cdkd propagates the code verbatim. |
-| `1` | cdkd-side failure — Docker unavailable, target not found, network creation failed, secret resolution failed, an unsupported volume type. |
+| `1` | Either the essential container exited `1`, or cdkd failed before running it — Docker unavailable, target not found, network creation failed, secret resolution failed, an unsupported volume type. |
 | `130` | `^C`. A first `^C` tears the task down and then exits; a second exits immediately without container cleanup. |
+| `N` | Any other code the essential container exited with; cdkd propagates it verbatim. |
+
+`1` is the one ambiguous code, because it is both a container exit and cdkd's
+own default failure code. A cdkd-side failure always prints an error before it
+exits, and no container output precedes it — that is the discriminator.
 
 The full cross-command table is in the [CLI Reference](cli-reference.md#exit-codes).
 

--- a/docs/local-run-task.md
+++ b/docs/local-run-task.md
@@ -106,9 +106,9 @@ endpoints over your own network.
 
 Every `ContainerDefinitions[].PortMappings` entry is published on the host, at
 the entry's `HostPort` when the template names one and at the container port
-otherwise, bound to `--container-host` (`127.0.0.1` by default). A task
-declaring container port `8080` is reachable at `http://127.0.0.1:8080` as soon
-as its container starts.
+otherwise, bound to `--container-host` (`127.0.0.1` by default), and on the
+mapping's own protocol. A task declaring TCP container port `8080` is reachable
+at `127.0.0.1:8080` as soon as its container starts.
 
 A **privileged host port** — anything the mapping would publish below 1024 —
 fails at `docker run`, because a local publish there needs root and macOS Docker

--- a/docs/local-run-task.md
+++ b/docs/local-run-task.md
@@ -1,231 +1,367 @@
 ---
-title: local run-task
+title: cdkd local run-task
 description: "Run one ECS task definition locally on a Docker network with the ECS metadata sidecar, secrets resolution, and DependsOn container ordering."
 ---
 
-# `local run-task` (run an ECS task definition locally)
+# cdkd local run-task
 
-`cdkd local run-task <Stack/TaskDefinitionPath>` is the ECS counterpart
-of `cdkd local invoke`. It takes an `AWS::ECS::TaskDefinition` defined
-in a CDK app and starts every container on the developer's Docker host
-— no AWS deploy needed.
+`cdkd local run-task <target>` takes an `AWS::ECS::TaskDefinition` out of a CDK
+app and starts every one of its containers on your Docker host — no AWS deploy
+required. It is the ECS counterpart of [`cdkd local invoke`](local-invoke.md):
+one synchronous task run, each container's stdout/stderr streamed with a
+`[<name>]` prefix, and the essential container's exit code propagated to your
+shell.
 
-Implementation Phase 1: synchronous run of one task, stream every
-container's stdout/stderr with a `[<name>]` prefix, propagate the
-essential container's exit code. Phase 2 (`cdkd local start-service` —
-ECS Service replicas + restart policy) and Phase 3 (Service Connect /
-Cloud Map cross-service discovery via `--add-host` DNS overlay) are
-implemented; ALB-emulated path/host-based routing remains deferred.
+```bash
+cdkd local run-task MyStack/MyService/TaskDef              # run one task definition
+cdkd local run-task MyTaskDef --env-vars overrides.json    # SAM-shape env-var overrides
+cdkd local run-task MyStack:MyTaskDefABC123 --from-state   # resolve intrinsics from deployed state
+cdkd local run-task MyStack/Worker --assume-task-role      # containers run with the task role
+cdkd local run-task MyStack/Worker --detach                # start and return; you own teardown
+cdkd local run-task MyStack/Worker --keep-running          # leave stopped containers for a post-mortem
+```
 
-**Requires Docker.** The first run pulls the AWS-published
-`amazon/amazon-ecs-local-container-endpoints:latest-amd64` sidecar (a
-small Go binary maintained by awslabs) plus each container's image.
+Docker is required. The first run pulls the AWS-published
+`amazon/amazon-ecs-local-container-endpoints:latest-amd64` metadata sidecar
+alongside each container image; see
+[Local execution](local-emulation.md#requirements).
 
-### `local run-task` target resolution
+## Options
 
-Same target-syntax rules as `cdkd local invoke`:
-
-- CDK display path (`MyStack/MyService/TaskDef`) — preferred
-- Stack-qualified logical id (`MyStack:MyServiceTaskDefXYZ1234`)
-- Single-stack apps may omit the stack prefix (`MyTaskDef`)
-
-Path matching is prefix-based: an L2 path like `MyStack/MyService/TaskDef`
-resolves to the synthesized L1 child (`MyStack/MyService/TaskDef/Resource`).
-
-### `local run-task` options
-
-| Flag | Default | Behavior |
+| Flag | Default | Description |
 | --- | --- | --- |
-| `--cluster <name>` | `cdkd-local` | Surfaced as `ECS_CONTAINER_METADATA_URI_V4`'s `Cluster` field and used as the docker network prefix (`<name>-task-<rand>`). |
-| `--env-vars <file>` | unset | SAM-shape JSON overlay. Top-level keys are container names; `Parameters` is a global overlay. Same shape as `cdkd local invoke --env-vars`. |
-| `--container-host <ip>` | `127.0.0.1` | Bind IP for `PortMappings` published ports. Must be a numeric IP — Docker rejects hostnames in `-p <ip>:<port>:<port>`. |
-| `--assume-task-role [<arn>]` | unset (host creds pass through) | Bare flag uses the task definition's `TaskRoleArn`. Resolves a flat-string ARN directly; for `{Ref: <Role>}` / `{Fn::GetAtt: [<Role>, 'Arn']}` against a same-stack `AWS::IAM::Role`, cdkd substitutes the caller's account id (via STS `GetCallerIdentity`) into `arn:aws:iam::<account>:role/<RoleLogicalId>`. Pass an explicit ARN to override. Either way, `sts:AssumeRole` runs once at startup; the resulting creds are exposed via the local metadata sidecar at `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`. |
-| `--from-state` | off | Load cdkd S3 state for the target stack and substitute deployed values into (a) `Fn::Sub` / `Fn::GetAtt` ECR image URIs that reference a same-stack `AWS::ECR::Repository`, AND (b) intrinsic-valued `ContainerDefinitions[].Environment[].Value` + `Secrets[].ValueFrom` entries (`Ref` / `Fn::GetAtt` / `Fn::Sub` / `Fn::Join`). Without this flag, env / secret intrinsics are dropped with a per-key warning (matching `cdkd local invoke --from-state` semantics). See "ECR image resolution" and "Env / Secrets substitution" below. Off by default. The stack must have been deployed via `cdkd deploy` first. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `DescribeStackResources` and substitute `Ref` / `Fn::ImportValue` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). Bare form uses the cdkd stack name; pass an explicit value when the CFn stack name differs. **Mutually exclusive with `--from-state`**. `Fn::GetAtt` is warn-and-dropped in v1 (CFn `DescribeStackResources` does not return per-attribute values), except a same-stack ECR repository's `Arn` / `RepositoryUri` in a container image URI, which is synthesized from the recovered physical name + pseudo parameters. |
-| `--stack-region <region>` | unset | Region of the state record to read. Used with `--from-state` when the same stack name has state in multiple regions, and with `--from-cfn-stack` as the CFn client region. |
-| `--no-pull` | off | Skip `docker pull` for every container image and the metadata sidecar. |
-| `--ecr-role-arn <arn>` | — | Role ARN to assume before authenticating against ECR for cross-account / centralized registry pulls. Issues `sts:AssumeRole` via the default credential chain and uses the resulting temp creds for `ecr:GetAuthorizationToken` + `docker pull` on every container whose `Image` resolves to an ECR registry host — the plain `<acct>.dkr.ecr.<region>.<urlSuffix>/...`, its FIPS sibling `<acct>.dkr.ecr-fips.<region>.<urlSuffix>/...`, or the dual-stack `<acct>.dkr-ecr[-fips].<region>.on.aws/...` (the partition suffix is derived from the region, so the partitions `derivePartitionAndUrlSuffix` knows — commercial, `aws-cn`, `aws-us-gov`, `aws-iso`, `aws-iso-b`, `aws-iso-e`, `aws-iso-f`, `aws-eusc` — are matched too). Required when the caller's identity does not already have cross-account access to the target repository. Same-account / same-region pulls do not need this flag. No-op when `--no-pull` is set. |
-| `--platform <platform>` | inferred from `RuntimePlatform.CpuArchitecture` | `linux/amd64` or `linux/arm64`. Threaded into every container's `docker run --platform`. |
-| `--keep-running` | off | Don't `docker rm -f` user containers on task exit (network + sidecar are still torn down). Use when you want to `docker exec` into a stopped container for post-mortems. |
-| `--detach` | off | Start the containers and return without streaming logs or auto-tearing them down. Useful in CI smoke tests; caller manages container lifecycle. |
+| `<target>` | — | CDK display path or stack-qualified logical id of the `AWS::ECS::TaskDefinition` to run. Required. |
+| `--cluster <name>` | `cdkd-local` | Cluster name reported by the metadata endpoint, and the prefix of the per-task Docker network name. |
+| `--env-vars <file>` | — | SAM-shape JSON env-var overrides, keyed by container name — see [Local execution](local-emulation.md#common-flags). |
+| `--container-host <ip>` | `127.0.0.1` | Host IP that published container ports bind to. Must be numeric — see [Local execution](local-emulation.md#common-flags). |
+| `--assume-task-role [arn]` | off | Assume the task definition's `TaskRoleArn` (or the ARN you pass) and serve those credentials through the metadata sidecar. |
+| `--no-pull` | off | Skip `docker pull` for every container image and for the metadata sidecar — see [Local execution](local-emulation.md#common-flags). |
+| `--ecr-role-arn <arn>` | — | Role to assume before authenticating to ECR, for cross-account or centralized registries. No-op with `--no-pull`. |
+| `--platform <platform>` | inferred from `RuntimePlatform.CpuArchitecture` | Force `docker run --platform`. Accepts `linux/amd64` or `linux/arm64`. |
+| `--keep-running` | off | Leave the user containers in place when the task exits; the network and sidecar are still torn down. |
+| `--detach` | off | Start the containers in the background and exit, skipping log streaming and automatic teardown. |
+| `--from-state` | off | Substitute deployed values from cdkd's S3 state into image URIs, environment variables and secrets — see [Local execution](local-emulation.md#common-flags). |
+| `--from-cfn-stack [name]` | off | Substitute from a CloudFormation-deployed stack instead. Bare form uses the cdkd stack name. Mutually exclusive with `--from-state`. |
+| `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region for `--from-cfn-stack` — see [Local execution](local-emulation.md#common-flags). |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state, for `--from-state`. |
+| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. |
+| `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a path to a pre-synthesized cloud assembly — see [Local execution](local-emulation.md#common-flags). |
+| `--output <path>` | `cdk.out` | Output directory for synthesis. |
+| `-c`, `--context <key=value...>` | — | Set CDK context values. Repeatable. |
+| `--profile <profile>` | — | AWS profile. Its credentials are forwarded to the sidecar and to the containers. |
+| `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for cdkd's own AWS API calls. Needs admin-equivalent permissions. |
+| `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
+| `--verbose` | off | Verbose logging. |
 
-Plus the standard shared options: `-a/--app`, `-c/--context`, `--profile`,
-`--role-arn`, `--region`, `--verbose`, `--output`.
+The region used for AWS API calls and for pseudo-parameter substitution is taken
+from `AWS_REGION`, then `AWS_DEFAULT_REGION`, then the synthesized stack's own
+`env.region`. A deprecated `--region` flag still overrides all three; prefer the
+environment variable or your AWS profile.
 
-### Networking model
+## Target resolution
 
-For every task invocation cdkd:
+`<target>` accepts the same forms as [`cdkd local invoke`](local-invoke.md):
 
-1. Creates a fresh docker network `cdkd-local-task-<random>` (or
-   `--cluster <name>-task-<random>`) with subnet `169.254.170.0/24`.
-2. Starts the AWS-published
-   `amazon/amazon-ecs-local-container-endpoints:latest-amd64` sidecar
-   on the network at the well-known IP `169.254.170.2`.
-3. Starts every user container on the same network with
-   `--network-alias <container-name>` so siblings resolve each other by
-   their CFn `ContainerDefinitions[].Name`.
-4. Injects per-container env vars: `ECS_CONTAINER_METADATA_URI_V4=http://169.254.170.2/v4/<container-name>`
-   and (when `--assume-task-role` is set) `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/role/<task-role-arn>`.
+| Form | Example |
+| --- | --- |
+| CDK display path (preferred) | `MyStack/MyService/TaskDef` |
+| Stack-qualified logical id | `MyStack:MyServiceTaskDefXYZ1234` |
+| Bare name, single-stack apps only | `MyTaskDef` |
 
-`awsvpc` network mode is mapped to `bridge` locally with a warn line —
-docker cannot emulate ENI-per-task. AWS SDK calls from inside the
-container still reach public AWS endpoints via the developer network.
+Path matching is prefix-based, so an L2 path such as `MyStack/MyService/TaskDef`
+resolves to the synthesized L1 child `MyStack/MyService/TaskDef/Resource`.
 
-### ECR image resolution
+## Networking model
 
-`ContainerDefinitions[].Image` is parsed in three tiers:
+Each task run creates its own Docker network and sidecar:
 
-1. **Public images** — `public.ecr.aws/...`, `docker.io/...`, `nginx:latest`, etc. → plain `docker pull` (subject to `--no-pull`).
-2. **Direct ECR URIs** — `<account>.dkr.ecr.<region>.<urlSuffix>/<repo>:<tag>` and the other served registry-host forms listed below (flat string, no intrinsics) → `pullEcrImage` (STS check + ECR auth + `docker pull`). The host suffix is matched against the one the URI's region actually uses — one suffix per region prefix: commercial and `us-gov-*` → `amazonaws.com`, `cn-*` → `amazonaws.com.cn`, `us-iso-*` → `c2s.ic.gov`, `us-isob-*` → `sc2s.sgov.gov`, `eu-isoe-*` → `cloud.adc-e.uk`, `us-isof-*` → `csp.hci.ic.gov`, `eusc-*` → `amazonaws.eu`. A look-alike host whose suffix does not belong to that region is deliberately NOT treated as ECR. The FIPS (`<account>.dkr.ecr-fips.<region>.<urlSuffix>`) and dual-stack (`<account>.dkr-ecr.<region>.on.aws`, `<account>.dkr-ecr-fips.<region>.on.aws`) registry endpoints are RECOGNIZED as ECR (the grammar is unified with `cdkd gc`'s — previously only the plain form matched here, so a genuine FIPS or dual-stack registry classified as a public image: anonymous pull, no `docker login`). The dual-stack forms carry the fixed `on.aws` suffix instead of the region's partition suffix, and a form spelled with the other's suffix is refused. **Recognition is not yet a working pull for those three forms**: `ecrLogin` authenticates against the PLAIN host (`<account>.dkr.ecr.<region>.<urlSuffix>`, which is what `GetAuthorizationToken` reports) while the pull targets the host the template names, and docker's credential store is keyed on the hostname verbatim — so the pull fails with `no basic auth credentials`. This is a known limitation; today only the plain form (in any casing) is end-to-end pull-capable. The case fold is unaffected, since an upper-cased plain host is reconciled to the same lower-case spelling on both sides. Every segment is matched case-INSENSITIVELY, since DNS is; docker accepts an upper-cased registry host but requires a lower-case repository path, and cdkd folds only the host. Cross-account / cross-region supported: cdkd builds the ECR client for the URI's region and (when `--ecr-role-arn <arn>` is passed) issues `sts:AssumeRole` to gain credentials in the target account. Without `--ecr-role-arn`, cdkd falls through to the caller's credentials (succeeds when an IAM resource policy grants the caller direct cross-account access).
-3. **CDK-asset images** (`ContainerImage.fromAsset` / `DockerImageAsset`) → `cdk.out/<stack>.assets.json` lookup → `docker build` via the shared `src/assets/docker-build.ts` helper, tagged `cdkd-local-run-task-<asset-hash>`. An image URI is recognized as a CDK asset when it embeds a container-assets ECR repo — either the CDK-bootstrap repo `cdk-<qualifier>-container-assets-<acct>-<region>` (any qualifier, not only the `hnb659fds` default) or the cdkd-owned repo `cdkd-container-assets-<acct>-<region>` that `cdkd deploy` publishes into once a bootstrap marker exists; a migrated stack's rewritten template / `--from-state` state carries the latter, so both classify identically. Custom-named cdkd asset repos (`cdkd bootstrap --container-repo <name>`) are recognized too under `--from-state`: when a container's Image is an ECR-hosted URI whose repo component does not match the conventional shapes (recognized here by a THIRD, narrower host test than tier 2's — a literal `.dkr.ecr.` substring, so today it sees only the plain lower-case form and neither the FIPS / dual-stack endpoints nor a mixed-case host — a known limitation. A miss is a slow path, not a wrong pull: the image falls through to the tier-2 ECR-pull route), cdkd lazily reads the region's bootstrap marker from the state bucket and classifies the image as a CDK asset when its repo component equals the marker's `containerRepo` (best-effort — a missing/unreadable marker falls back to the prefix match, and without `--from-state` no marker read happens, so the image routes through the ECR-pull tier instead: correct, just slower).
+1. A fresh network `cdkd-local-task-<random>` (or `<--cluster>-task-<random>`)
+   with subnet `169.254.170.0/24`.
+2. The AWS-published `amazon/amazon-ecs-local-container-endpoints:latest-amd64`
+   sidecar on that network at the well-known address `169.254.170.2`.
+3. Every user container on the same network with
+   `--network-alias <container-name>`, so siblings resolve each other by their
+   `ContainerDefinitions[].Name`.
+4. Per-container environment:
+   `ECS_CONTAINER_METADATA_URI_V4=http://169.254.170.2/v4/<container-name>`, plus
+   `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/role/<task-role-arn>` when
+   `--assume-task-role` is in play.
 
-For `Fn::Sub` / `Fn::GetAtt` shapes pointing at AWS pseudo parameters or a same-stack ECR repository (the typical `ContainerImage.fromEcrRepository(repo)` synthesis), two additional resolution tiers fire **before** the URI is fed to tier 2:
+The subnet is fixed, so only one `cdkd local run-task` can be active at a time:
+a second concurrent run fails on `docker network create` with a hint naming the
+subnet already in use. [`cdkd local start-service`](local-start-service.md)
+shares one network across every service in a run, and so is not affected.
 
-- **Tier 1 — AWS pseudo-parameter substitution (no state needed)**: `${AWS::AccountId}` → STS `GetCallerIdentity` (lazy, cached for the run); `${AWS::Region}` → `--region` / `AWS_REGION` / `AWS_DEFAULT_REGION`; `${AWS::Partition}` → derived from region (`cn-*` → `aws-cn`, `us-gov-*` → `aws-us-gov`, `us-iso-*` → `aws-iso`, `us-isob-*` → `aws-iso-b`, `us-isof-*` → `aws-iso-f`, `eu-isoe-*` → `aws-iso-e`, `eusc-*` → `aws-eusc`, else `aws`); `${AWS::URLSuffix}` → matches partition. Substituted URI then routes through tier 2.
-- **Tier 2 — same-stack ECR Repository reference (state needed)**: when the `Fn::Sub` body contains `${<LogicalId>}` against an `AWS::ECR::Repository`, or when the template uses `Fn::GetAtt: [<Repo>, 'RepositoryUri']`, cdkd needs the deployed physical repo name. Pass `--from-state` (the stack must have been deployed via `cdkd deploy`); cdkd loads state, substitutes the physical name, then routes through tier 2. Without `--from-state` the error message points back at this flag as the resolution path.
+Containers also get a `host.docker.internal` mapping where the Docker daemon
+supports one, so a container can reach a server bound to your host (a local
+endpoint, a tunnelled VPC resource). On a daemon that does not support it, no
+mapping is added and the run continues.
 
-### Env / Secrets substitution (`--from-state`)
+`awsvpc` network mode is mapped to a Docker bridge network with a warning:
+Docker cannot emulate an ENI per task, and security groups are not enforced
+locally. AWS SDK calls from inside a container still reach the public AWS
+endpoints over your own network.
 
-`ContainerDefinitions[].Environment[].Value` and `Secrets[].ValueFrom`
-entries are commonly intrinsic-valued in real-world CDK ECS apps —
-`table.tableName` synthesizes as `Ref`, `table.tableArn` as
-`Fn::GetAtt`, `ecs.Secret.fromSecretsManager(secret)` as `Ref` against
-the secret (returns the deployed ARN), `ecs.Secret.fromSsmParameter(p)`
-as `Fn::Join` over pseudo parameters + a `Ref` to the parameter, etc.
-Without `--from-state` these intrinsics are silently dropped (matching
-`cdkd local invoke` v1 semantics) and the developer sees an empty env
-var or a missing secret.
+## AWS credentials in containers
 
-`cdkd local run-task --from-state` substitutes every intrinsic-valued
-entry against cdkd's deployed S3 state plus AWS pseudo parameters:
+| Situation | What the containers see |
+| --- | --- |
+| Neither `--assume-task-role` nor `--profile` | The sidecar serves whatever the default credential chain resolves on the host. |
+| `--assume-task-role` (bare) | `sts:AssumeRole` against the task definition's resolved `TaskRoleArn`, once at startup; the temporary credentials are served by the sidecar. |
+| `--assume-task-role <arn>` | Same, against the ARN you supplied. |
+| `--profile <p>` without an effective `--assume-task-role` | The profile is resolved through the SDK chain (SSO, IAM Identity Center, `fromIni`, role assumption) and the resulting credentials are both served by the sidecar and written into a read-only shared-credentials file bind-mounted into every container under `[<p>]`. |
+
+`--assume-task-role` beats the profile file, which beats the plain sidecar
+pass-through. Bare `--assume-task-role` resolves a flat-string `TaskRoleArn`
+directly; for a `{Ref: <Role>}` or `{Fn::GetAtt: [<Role>, 'Arn']}` pointing at a
+same-stack `AWS::IAM::Role`, cdkd fills the caller's account id (from STS
+`GetCallerIdentity`) into `arn:aws:iam::<account>:role/<RoleLogicalId>`. When the
+task definition has no resolvable `TaskRoleArn`, bare `--assume-task-role` is an
+error that tells you to pass the ARN explicitly.
+
+## ECR image resolution
+
+`ContainerDefinitions[].Image` is classified into three tiers:
+
+| Tier | Image shape | How cdkd gets it |
+| --- | --- | --- |
+| Public | `public.ecr.aws/...`, `docker.io/...`, `nginx:latest` | Plain `docker pull` (skipped by `--no-pull`). |
+| ECR | A flat-string ECR registry URI | STS identity check, ECR auth, then `docker pull`. |
+| CDK asset | An image published by `ContainerImage.fromAsset` / `DockerImageAsset` | `cdk.out/<stack>.assets.json` lookup, then `docker build`, tagged `cdkd-local-run-task-<asset-hash>`. |
+
+### Which registry hosts count as ECR
+
+A URI is treated as ECR only when its host suffix is the one its own region
+actually uses. A look-alike host carrying another region's suffix is
+deliberately not treated as ECR.
+
+The same region-to-partition mapping drives `${AWS::Partition}` and
+`${AWS::URLSuffix}` wherever cdkd substitutes them.
+
+| Region prefix | Partition | URL suffix |
+| --- | --- | --- |
+| everything else | `aws` | `amazonaws.com` |
+| `us-gov-*` | `aws-us-gov` | `amazonaws.com` |
+| `cn-*` | `aws-cn` | `amazonaws.com.cn` |
+| `us-iso-*` | `aws-iso` | `c2s.ic.gov` |
+| `us-isob-*` | `aws-iso-b` | `sc2s.sgov.gov` |
+| `eu-isoe-*` | `aws-iso-e` | `cloud.adc-e.uk` |
+| `us-isof-*` | `aws-iso-f` | `csp.hci.ic.gov` |
+| `eusc-*` | `aws-eusc` | `amazonaws.eu` |
+
+Three registry endpoint shapes are recognized: the plain
+`<account>.dkr.ecr.<region>.<urlSuffix>`, its FIPS sibling
+`<account>.dkr.ecr-fips.<region>.<urlSuffix>`, and the dual-stack
+`<account>.dkr-ecr.<region>.on.aws` /
+`<account>.dkr-ecr-fips.<region>.on.aws`. The dual-stack forms carry the fixed
+`on.aws` suffix rather than the region's partition suffix, and a form spelled
+with the other's suffix is refused. Host matching is case-insensitive, since DNS
+is; Docker accepts an upper-cased registry host but requires a lower-case
+repository path, and cdkd folds only the host.
+
+**Only the plain form pulls end to end today.** For the FIPS and dual-stack
+hosts, the ECR login authenticates against the plain host — that is what
+`GetAuthorizationToken` reports — while the pull targets the host the template
+names, and Docker's credential store is keyed on the hostname verbatim, so the
+pull fails with `no basic auth credentials`.
+
+Cross-account and cross-region pulls are supported: cdkd builds the ECR client
+for the URI's own region, and with `--ecr-role-arn <arn>` issues `sts:AssumeRole`
+to obtain credentials in the target account. Without the flag it falls through to
+your own credentials, which succeeds when a repository policy grants you direct
+cross-account access.
+
+### Which images count as CDK assets
+
+An image URI is treated as a CDK asset when it embeds a container-assets ECR
+repository — either the CDK bootstrap repository
+`cdk-<qualifier>-container-assets-<acct>-<region>` (any qualifier, not only the
+`hnb659fds` default) or the cdkd-owned `cdkd-container-assets-<acct>-<region>`
+that `cdkd deploy` publishes into once a bootstrap marker exists. A migrated
+stack's rewritten template and its `--from-state` state carry the latter, so both
+classify identically.
+
+Custom-named cdkd asset repositories (`cdkd bootstrap --container-repo <name>`)
+are recognized under `--from-state`: cdkd lazily reads the region's bootstrap
+marker from the state bucket and treats the image as a CDK asset when its
+repository component matches the marker's `containerRepo`. Two caveats:
+
+- The lookup is best-effort. A missing or unreadable marker falls back to the
+  conventional prefix match, and without `--from-state` no marker is read at all.
+- The host test on this path is narrower than the one above — it looks for a
+  literal `.dkr.ecr.` substring — so it sees only the plain lower-case form.
+
+A miss here is a slow path, not a wrong pull: the image simply routes through the
+ECR-pull tier instead.
+
+### Intrinsic-valued image URIs
+
+When `Image` is an `Fn::Sub` or `Fn::GetAtt` — the shape
+`ContainerImage.fromEcrRepository(repo)` synthesizes — two substitution passes run
+before the resulting URI is classified:
+
+| Pass | Resolves | Needs state? |
+| --- | --- | --- |
+| Pseudo parameters | `${AWS::AccountId}` from STS `GetCallerIdentity` (lazy, cached for the run); `${AWS::Region}` from the resolved region; `${AWS::Partition}` and `${AWS::URLSuffix}` derived from it | No |
+| Same-stack ECR repository | `${<LogicalId>}` against an `AWS::ECR::Repository`, and `Fn::GetAtt: [<Repo>, 'RepositoryUri']`, using the deployed physical repository name | Yes — pass `--from-state` |
+
+`${AWS::Partition}` and `${AWS::URLSuffix}` come from the region, per the table
+in [Which registry hosts count as ECR](#which-registry-hosts-count-as-ecr).
+Without `--from-state`, a same-stack repository reference fails with an error
+naming that flag as the way forward; the stack must have been deployed with
+`cdkd deploy` first.
+
+## Environment variables and secrets
+
+`ContainerDefinitions[].Environment[].Value` and `Secrets[].ValueFrom` are
+routinely intrinsic-valued in real CDK ECS apps: `table.tableName` synthesizes as
+`Ref`, `table.tableArn` as `Fn::GetAtt`,
+`ecs.Secret.fromSecretsManager(secret)` as a `Ref` returning the deployed ARN,
+`ecs.Secret.fromSsmParameter(p)` as an `Fn::Join` over pseudo parameters and a
+`Ref`. Without a state source those intrinsics are dropped and the container sees
+an empty variable or a missing secret.
+
+### Intrinsic substitution
+
+`--from-state` substitutes every intrinsic-valued entry against cdkd's deployed
+S3 state plus the AWS pseudo parameters:
 
 | Intrinsic | Source |
 | --- | --- |
-| `Ref: <LogicalId>` | `state.resources[<LogicalId>].physicalId` |
-| `Fn::GetAtt: [<LogicalId>, <Attr>]` | `state.resources[<LogicalId>].attributes[<Attr>]` |
-| `Fn::Sub: '...${X}...${AWS::Region}...'` | recursive substitution against state + pseudo parameters |
-| `Fn::Join: [<delim>, [<elements>]]` | recursive substitution of every element, then `Array.join` |
-| `Ref: AWS::AccountId` / `AWS::Region` / `AWS::Partition` / `AWS::URLSuffix` | STS `GetCallerIdentity` (lazy, cached) + the resolved region + region-derived partition / URL suffix |
+| `Ref: <LogicalId>` | The resource's recorded physical id |
+| `Fn::GetAtt: [<LogicalId>, <Attr>]` | The attribute captured for that resource at deploy time |
+| `Fn::Sub: '...${X}...${AWS::Region}...'` | Recursive substitution against state plus pseudo parameters |
+| `Fn::Join: [<delim>, [<elements>]]` | Recursive substitution of every element, then joined |
+| `Ref: AWS::AccountId` / `AWS::Region` / `AWS::Partition` / `AWS::URLSuffix` | STS `GetCallerIdentity` (lazy, cached), the resolved region, and the region-derived partition and URL suffix |
 
-Per-key best-effort: when a substitution can't be produced (state
-missing for a referenced logical ID, attribute not captured at deploy
-time, unsupported intrinsic), the env / secret entry is dropped and a
-per-key warning surfaces on the task's warnings line — the run-task
-invocation never aborts. State-load failures (no record, multi-region
-ambiguity without `--stack-region`, bucket resolution error) also
-degrade to warn-and-fall-back rather than hard-fail.
+Substitution is best-effort per key. When a value cannot be produced — no state
+for the referenced logical id, an attribute that was not captured at deploy time,
+an unsupported intrinsic — that one entry is dropped and a warning names it on the
+task's warnings line; the run itself continues. State-load failures (no record,
+multi-region ambiguity without `--stack-region`, a bucket that cannot be
+resolved) degrade the same way rather than failing the run.
 
-Resolved `Secrets[].ValueFrom` strings then flow into the standard
-SecretsManager / SSM resolver below.
+Cross-stack `Fn::ImportValue` and `Fn::GetStackOutput` in environment variables
+and secrets are resolved from the active state source in a second pass. With
+neither `--from-state` nor `--from-cfn-stack`, a warning names both flags as the
+way to substitute them.
 
-### Secrets / SSM parameter resolution
+Resolved `Secrets[].ValueFrom` strings then flow into the resolver below.
 
-`ContainerDefinitions[].Secrets[].ValueFrom` entries are resolved once at
-startup via the AWS SDK (after any `--from-state` intrinsic substitution
-above). Three accepted shapes:
+### Secrets Manager and SSM resolution
 
-| `valueFrom` | API |
+Every `Secrets[].ValueFrom` entry is resolved once at startup, after any
+intrinsic substitution. Three shapes are accepted:
+
+| `ValueFrom` | Call |
 | --- | --- |
-| `arn:aws:secretsmanager:<region>:<account>:secret:<name>` | `SecretsManagerClient.GetSecretValue` |
-| `arn:aws:secretsmanager:<region>:<account>:secret:<name>:<json-key>::` | `GetSecretValue`, then JSON.parse + extract `json-key` |
-| `arn:aws:ssm:<region>:<account>:parameter/<name>` | `SSMClient.GetParameter({ WithDecryption: true })` |
+| `arn:aws:secretsmanager:<region>:<account>:secret:<name>` | `GetSecretValue` |
+| `arn:aws:secretsmanager:<region>:<account>:secret:<name>:<json-key>::` | `GetSecretValue`, then JSON-parse and extract `<json-key>` |
+| `arn:aws:ssm:<region>:<account>:parameter/<name>` | `GetParameter` with decryption |
 
-Resolution failures (NotFound / AccessDenied / network error / invalid
-ARN) hard-fail with the offending container + secret name. The user
-fixes their AWS creds / IAM policy and re-runs. (Mirrors the
-`cdkd local invoke --from-state` philosophy: explicit failure beats
-silently-empty.)
+A resolution failure — not found, access denied, a network error, a malformed ARN
+— is a hard error naming the offending container and secret. Explicit failure
+beats a silently empty variable: fix the credentials or the IAM policy and re-run.
 
-**Secret names that are refused.** When a secret's name is accepted, its VALUE
-reaches the container through the `docker run` spawn environment (a value-less
-`-e KEY` flag, so the plaintext never appears on the argv / `/proc/<pid>/cmdline`).
-The NAME decides whether the secret is forwarded at all: two name shapes are
-**not passed to the container** — no `-e` flag and no spawn-env entry, so the
-value reaches neither the argv nor the spawn environment:
+### Secret names that are not forwarded
 
-- **A name that collides with a variable the docker CLI itself reads** —
-  matched case-insensitively (Windows env lookups are). This is a fixed exact
-  denylist (connection / TLS / behaviour, `PATH` / `PATHEXT` / `HOME` /
-  `USERPROFILE`, the loader / trust / runtime vars, the ssh exec-helper set,
-  and the AWS credential-helper vars `docker-credential-ecr-login` reads) plus
-  the `LD_` / `DYLD_` / `AWS_ENDPOINT_URL_` prefix families; the authoritative
-  list is `DOCKER_CLIENT_ENV_KEYS` / `DOCKER_CLIENT_ENV_PREFIXES` in
-  [src/utils/docker-cmd.ts](https://github.com/go-to-k/cdkd/blob/main/src/utils/docker-cmd.ts). Forwarding such a name
-  would let a template-controlled secret NAME redirect the docker client itself
-  (e.g. a secret named `DOCKER_HOST` pointing the client at a different daemon).
-- **A malformed name** — empty, or containing `=` / NUL. A name containing `=`
-  is the dangerous case: the OS parses the environ entry's name as everything
-  before the first `=`, so a secret named `PATH=/tmp/evil:` would be parsed as
-  `PATH` — a different variable than the collision check saw. An empty or
-  NUL-bearing name simply cannot form a valid environment variable.
+An accepted secret's value reaches the container through the `docker run` spawn
+environment as a value-less `-e KEY` flag, so the plaintext never appears in the
+process arguments. The secret's **name** decides whether it is forwarded at all.
+Two name shapes are dropped entirely — no `-e` flag and no spawn-environment
+entry:
 
-Each refusal is reported with a `warn` identifying the dropped secret(s) so the
-drop is never silent; rename the secret if the container needs the value.
+- **A name that collides with a variable the Docker CLI itself reads**, matched
+  case-insensitively. The set covers connection and TLS settings, behaviour
+  toggles, `PATH` / `PATHEXT` / `HOME` / `USERPROFILE`, the loader, trust and
+  runtime variables, the SSH exec-helper variables, and the AWS credential-helper
+  variables `docker-credential-ecr-login` reads, plus the `LD_`, `DYLD_` and
+  `AWS_ENDPOINT_URL_` prefix families. Forwarding such a name would let a
+  template-controlled secret name redirect the Docker client itself — a secret
+  named `DOCKER_HOST` could point it at a different daemon.
+- **A malformed name** — empty, or containing `=` or NUL. The `=` case is the
+  dangerous one: the OS parses an environment entry's name as everything before
+  the first `=`, so a secret named `PATH=/tmp/evil:` would land as `PATH`, a
+  different variable than the collision check inspected.
 
-### Container start ordering — `DependsOn`
+Each refusal is reported as a warning naming the dropped secret, so the drop is
+never silent. Rename the secret if the container needs its value.
+
+## Container start ordering
+
+Containers start in topological `DependsOn` order; siblings with no relation
+start in template order. A cyclic `DependsOn` is a hard error at discovery that
+names the cycle.
 
 | Condition | What cdkd waits for |
 | --- | --- |
-| `START` | Dependency's `docker run` has returned. |
-| `COMPLETE` | Dependency's container has exited (any code). |
-| `SUCCESS` | Dependency's container has exited with exit code 0. |
-| `HEALTHY` | Dependency's `HEALTHCHECK` reports `healthy` (polled every 1s, capped at 5 min). |
+| `START` | The dependency's `docker run` has returned. |
+| `COMPLETE` | The dependency's container has exited, with any code. |
+| `SUCCESS` | The dependency's container has exited `0`. A non-zero exit is an error naming both containers. |
+| `HEALTHY` | The dependency's `HEALTHCHECK` reports `healthy`, polled once a second and capped at five minutes. |
 
-Cyclic dependencies → hard-error at discovery with the offending cycle
-named. Topological sort decides the start order; siblings with no
-dependsOn relation start in template order.
-
-### Volumes
+## Volumes
 
 | `Volumes[]` shape | Local realization |
 | --- | --- |
-| `Host: { SourcePath: '/some/path' }` | `docker run -v /some/path:<containerPath>` bind mount (caller's responsibility that the host path exists; a missing path emits a warn) |
-| `Host` (no `SourcePath`) | Docker anonymous volume — empty per-task scratch |
-| `DockerVolumeConfiguration: { Scope: 'task' \| 'shared', Driver, DriverOpts }` | `docker volume create --driver <driver> --opt ...` per task; per-task scope is torn down at exit |
-| `EFSVolumeConfiguration` | **Hard-error**. Bind-mount a local directory at the same `containerPath` instead. |
-| `FSxWindowsFileServerVolumeConfiguration` | **Hard-error**. |
+| `Host: { SourcePath: '/some/path' }` | A `docker run -v /some/path:<containerPath>` bind mount. The host path is yours to create; a missing path warns. |
+| `Host` with no `SourcePath` | A Docker anonymous volume — empty per-task scratch space. |
+| `DockerVolumeConfiguration: { Scope, Driver, DriverOpts }` | `docker volume create --driver <driver> --opt ...` per task. A `task`-scoped volume is torn down on exit. |
+| `EFSVolumeConfiguration` | Hard error. Bind-mount a local directory at the same container path instead. |
+| `FSxWindowsFileServerVolumeConfiguration` | Hard error. |
 
-### Lifecycle + teardown
+`Host.SourcePath` may itself be an intrinsic (`Fn::Sub` / `Fn::Join`); it is
+resolved through the same substitution passes as environment variables.
 
-1. The first `essential: true` container (defaults to `containers[0]`
-   when no container declares `essential: false`) drives the task.
-2. When the essential container exits, cdkd `docker stop`s every other
-   container with a 10s grace then `docker rm -f`.
-3. The metadata sidecar is `docker rm -f`'d and the docker network is
-   removed.
+## Lifecycle and teardown
+
+A normal run:
+
+1. The first `essential: true` container drives the task. When no container
+   declares `essential: false`, that is the first container in the template.
+2. When the essential container exits, every other container is `docker stop`ped
+   with a ten-second grace period, then `docker rm -f`ed.
+3. The metadata sidecar is removed and the Docker network is deleted.
 4. cdkd exits with the essential container's exit code.
 
-`^C` triggers the same teardown. Double-`^C` exits 130 immediately
-(skipping container cleanup — same pattern as `cdkd local start-api`).
+`^C` runs the same teardown. A second `^C` exits `130` immediately, skipping
+container cleanup.
 
-`--detach` skips steps 1, 2, and 4. The sidecar and user containers
-stay running for the caller to manage. cdkd prints the network name on
-exit so you can `docker ps --filter network=<name>` to inspect.
-
-`--keep-running` skips step 2 only. The network + sidecar are still
-torn down. Use to `docker exec` into a stopped container post-mortem.
-
-### `local run-task` exit codes
-
-- `0` — essential container exited 0.
-- N (non-zero) — essential container exited N (cdkd propagates the code).
-- Various cdkd-side error codes (Docker missing, target not found,
-  network creation failed, secret resolution failed, ...) follow the
-  global handler's defaults (typically 1).
-
-### `local run-task` Phase 1 scope (out of scope, deferred)
-
-| Out of scope | Why |
+| Flag | Steps skipped |
 | --- | --- |
-| `AWS::ECS::Service` / `DesiredCount` / `LaunchType` | Use `cdkd local start-service` instead |
-| ALB / NLB target group registration / listener rules | Deferred follow-up — needs an HTTP proxy emulator |
-| Service Connect / Cloud Map | Implemented for `cdkd local start-service` via `--add-host` DNS overlay. `cdkd local run-task` is single-task by design; cross-service discovery is meaningful only with multiple long-running services, so it stays out of scope here. |
-| Auto Scaling / Deployment Strategy | Not meaningful locally |
-| Fargate vs EC2 launch-type differences (PID namespace, `awsvpc`-only, ephemeral storage cap) | Local Docker can't enforce these |
-| EFS / FSx volumes | Need real AWS NFS / SMB; hard-error with a routing hint |
-| ECS Exec | Use `docker exec` directly |
-| CloudWatch Logs auto-shipping (`logConfiguration.LogDriver: 'awslogs'`) | stdout/stderr already streamed; skip the driver |
-| X-Ray sidecar's AWS-API mocking | Run the daemon explicitly if you need it |
-| AWS App Mesh / Envoy fidelity | Not meaningful locally |
-| awsvpc / ENI complete fidelity | Map to docker bridge with a warn |
+| `--detach` | 1, 2 and 4. The sidecar and user containers stay up for you to manage; cdkd prints the network name so you can `docker ps --filter network=<name>` to inspect it. |
+| `--keep-running` | 2 only. The network and sidecar are still torn down, leaving the stopped containers for a `docker exec` post-mortem. |
 
+## Limitations
+
+| Not emulated | What to do instead |
+| --- | --- |
+| `AWS::ECS::Service`, `DesiredCount`, `LaunchType` | Use [`cdkd local start-service`](local-start-service.md). |
+| Load-balancer target-group registration and listener rules | Use [`cdkd local start-alb`](local-start-alb.md) for a local front door. |
+| Service Connect / Cloud Map discovery | `run-task` is single-task by design; cross-service discovery lives in [`cdkd local start-service`](local-start-service.md). |
+| Auto Scaling and deployment strategy | Not meaningful for a single local task. |
+| Fargate vs EC2 launch-type differences — PID namespace, `awsvpc`-only constraints, the ephemeral-storage cap | Local Docker cannot enforce them. |
+| `awsvpc` ENI-per-task fidelity, including security groups | Mapped to a Docker bridge network with a warning. Verify security-group behaviour against a real deploy. |
+| EFS and FSx volumes | Hard error; bind-mount a local directory at the same container path. |
+| ECS Exec | Use `docker exec` directly. |
+| CloudWatch Logs shipping via the `awslogs` log driver | stdout and stderr are already streamed, so the driver is skipped. |
+| The X-Ray sidecar's AWS-API mocking | Run the daemon yourself if you need it. |
+| App Mesh / Envoy fidelity | Not meaningful locally. |
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The essential container exited `0`, or `--detach` started the containers and returned. |
+| `N` | The essential container exited `N`; cdkd propagates the code verbatim. |
+| `1` | cdkd-side failure — Docker unavailable, target not found, network creation failed, secret resolution failed, an unsupported volume type. |
+| `130` | `^C`. A first `^C` tears the task down and then exits; a second exits immediately without container cleanup. |
+
+The full cross-command table is in the [CLI Reference](cli-reference.md#exit-codes).
+
+## Related
+
+- [`cdkd local start-service`](local-start-service.md) — the long-running counterpart, running `DesiredCount` replicas of an ECS Service
+- [`cdkd local start-alb`](local-start-alb.md) — put a local Application Load Balancer in front of those services
+- [`cdkd local invoke`](local-invoke.md) — the Lambda equivalent, sharing the target syntax and `--env-vars` shape
+- [Local Execution](local-emulation.md) — the subcommand index, Docker requirements, and the flags common to every `cdkd local` command

--- a/docs/local-run-task.md
+++ b/docs/local-run-task.md
@@ -106,16 +106,16 @@ endpoints over your own network.
 
 Every `ContainerDefinitions[].PortMappings` entry is published on the host, at
 the entry's `HostPort` when the template names one and at the container port
-otherwise, bound to `--container-host` (`127.0.0.1` by default). One log line
-per published port names the endpoint, so a task declaring container port `8080`
-prints `Reach it at 127.0.0.1:8080` as its container starts.
+otherwise, bound to `--container-host` (`127.0.0.1` by default). A task
+declaring container port `8080` is reachable at `http://127.0.0.1:8080` as soon
+as its container starts.
 
-A **privileged host port** — anything below 1024, which a local publish cannot
-take without root, and which macOS Docker Desktop refuses outright — is
-auto-remapped to a free ephemeral port, with a warning naming the port chosen.
-`cdkd local run-task` has no flag to pin that choice; read it off the warning,
-or use [`cdkd local start-service`](local-start-service.md), whose
-`--host-port <containerPort=hostPort>` pins it.
+A **privileged host port** — anything the mapping would publish below 1024 —
+fails at `docker run`, because a local publish there needs root and macOS Docker
+Desktop refuses it outright. This command has neither a remap nor a flag to move
+it: run the container's service on an unprivileged port, or use
+[`cdkd local start-service`](local-start-service.md), which auto-remaps a
+privileged port and lets `--host-port <containerPort=hostPort>` pin the result.
 
 ## AWS credentials in containers
 
@@ -160,7 +160,8 @@ ECR. Three endpoint shapes are recognized — the plain
 `<account>.dkr.ecr.<region>.<urlSuffix>`, its FIPS sibling
 `<account>.dkr.ecr-fips.<region>.<urlSuffix>`, and the dual-stack
 `<account>.dkr-ecr[-fips].<region>.on.aws`, whose fixed `on.aws` suffix replaces
-the region's partition suffix. Host matching is case-insensitive, since DNS is;
+the region's partition suffix. A host spelled with the other family's suffix is
+refused. Host matching is case-insensitive, since DNS is;
 Docker accepts an upper-cased registry host but requires a lower-case repository
 path, so cdkd folds only the host.
 
@@ -177,8 +178,6 @@ The same region-to-partition mapping drives `${AWS::Partition}` and
 | `eu-isoe-*` | `aws-iso-e` | `cloud.adc-e.uk` |
 | `us-isof-*` | `aws-iso-f` | `csp.hci.ic.gov` |
 | `eusc-*` | `aws-eusc` | `amazonaws.eu` |
-
-A shape spelled with the other family's suffix is refused.
 
 Cross-account and cross-region pulls are supported: cdkd builds the ECR client
 for the URI's own region, and with `--ecr-role-arn <arn>` issues `sts:AssumeRole`

--- a/docs/local-run-task.md
+++ b/docs/local-run-task.md
@@ -226,7 +226,7 @@ With neither state flag, a same-stack repository reference fails with an error
 naming them as the way forward; the stack must have been deployed first.
 
 Under `--from-cfn-stack`, an `Fn::GetAtt` in a container's `Environment[].Value`
-is dropped with a warning — a stack's resource listing carries no per-attribute
+or `Secrets[].ValueFrom` is dropped with a warning — a stack's resource listing carries no per-attribute
 values. Image URIs are not affected: the repository ARN and URI are rebuilt from
 the recovered physical name plus the pseudo parameters, so no per-attribute
 lookup is needed.

--- a/docs/local-start-agentcore.md
+++ b/docs/local-start-agentcore.md
@@ -45,7 +45,7 @@ cdkd local start-agentcore MyStack/MyAgent --from-state --watch  # bind cdkd sta
 | `--assume-role [arn]` | off | Assume the runtime's execution role — bare form uses its literal `RoleArn` — and forward temporary credentials into the container. Omit the flag to keep your own shell credentials in the container. |
 | `--ecr-role-arn <arn>` | — | Role to assume before authenticating against ECR, for cross-account or centralized registries. |
 | `--from-state` | off | Resolve intrinsics in the runtime's container image and environment variables from cdkd's S3 state. Mutually exclusive with `--from-cfn-stack`. |
-| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Only meaningful with `--from-state`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json`, then `cdkd-state-{accountId}` | S3 bucket holding cdkd state. Only meaningful with `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Only meaningful with `--from-state`. |
 | `--from-cfn-stack [name]` | off | Resolve the same values from a deployed CloudFormation stack, for apps deployed with the CDK CLI. Bare form uses the resolved stack name. |
 | `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region under `--from-cfn-stack`. |
@@ -167,7 +167,7 @@ Each firing is classified to pick the primitive:
 
 | Change | Primitive |
 | --- | --- |
-| Source-only edits an existing container can absorb | Soft reload: cdkd `docker cp`s the new source into the container and restarts it. |
+| Source-only edits an existing container can absorb | Soft reload: cdkd `docker cp`s the new source into the container and restarts it, keeping the container id and host port. See [`cdkd local invoke-agentcore`](local-invoke-agentcore.md#watch-reload-on-source-edits) for the exact predicate. |
 | Anything requiring a new image | Rebuild: a fresh container boots and the server is re-pointed at it. |
 
 Either way the new container is re-probed for readiness under `--timeout` before

--- a/docs/local-start-agentcore.md
+++ b/docs/local-start-agentcore.md
@@ -18,7 +18,7 @@ cdkd local start-agentcore MyStack/MyAgent                       # serve on an O
 cdkd local start-agentcore                                       # pick a runtime interactively (TTY)
 cdkd local start-agentcore MyStack/MyAgent --port 8080           # pin the host port
 cdkd local start-agentcore MyStack/MyAgent --bearer-token "$JWT" # default token for a customJwtAuthorizer runtime
-cdkd local start-agentcore MyStack/MyAgent --sigv4               # sign forwarded requests for a SigV4 runtime
+cdkd local start-agentcore MyStack/MyAgent --sigv4               # sign forwarded requests when the runtime has no JWT authorizer
 cdkd local start-agentcore MyStack/MyAgent --from-state --watch  # bind cdkd state, reload the container on edits
 ```
 
@@ -59,6 +59,11 @@ cdkd local start-agentcore MyStack/MyAgent --from-state --watch  # bind cdkd sta
 | `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for AWS API calls. |
 | `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
 | `--verbose` | off | Verbose logging. |
+
+**Spell the region lower-case.** This command does not fold an upper-cased
+`--region` / `AWS_REGION` to its canonical spelling, and AWS rejects the raw
+form at signature time (`SignatureDoesNotMatch`, `AuthorizationHeaderMalformed`).
+See [`--region` / `AWS_REGION`](cli-reference.md#region-aws-region-every-command).
 
 ## Target resolution
 
@@ -133,7 +138,7 @@ The container boots without a token being required up front, so `--bearer-token`
 is a default rather than a prerequisite. An unreachable or malformed discovery
 URL falls back to accepting the request, so offline work is not blocked.
 
-### SigV4 runtimes
+### Runtimes with no `customJwtAuthorizer`
 
 `--sigv4` signs each forwarded request with AWS SigV4 for the
 `bedrock-agentcore` service, so the warm container sees the same `Authorization`
@@ -207,3 +212,5 @@ The full cross-command table is in the
   container
 - [Local Execution](local-emulation.md) — every `cdkd local` subcommand, Docker
   requirements, and the flags they share
+- [CLI Reference](cli-reference.md) — every cdkd command, the output-stream
+  contract, and the full exit-code table

--- a/docs/local-start-agentcore.md
+++ b/docs/local-start-agentcore.md
@@ -167,7 +167,7 @@ Each firing is classified to pick the primitive:
 
 | Change | Primitive |
 | --- | --- |
-| Source-only edits an existing container can absorb | Soft reload: the new source is copied in and the container is restarted. |
+| Source-only edits an existing container can absorb | Soft reload: cdkd `docker cp`s the new source into the container and restarts it. |
 | Anything requiring a new image | Rebuild: a fresh container boots and the server is re-pointed at it. |
 
 Either way the new container is re-probed for readiness under `--timeout` before

--- a/docs/local-start-agentcore.md
+++ b/docs/local-start-agentcore.md
@@ -1,112 +1,209 @@
 ---
-title: local start-agentcore
+title: cdkd local start-agentcore
 description: "Keep a Bedrock AgentCore Runtime container warm and serve all four protocols locally, with hot reload and a browser-friendly WebSocket front-door."
 ---
 
-# `local start-agentcore` (serve a Bedrock AgentCore Runtime locally)
+# cdkd local start-agentcore
 
-`cdkd local start-agentcore [target]` is the long-running **serve**
-counterpart of the single-shot `local invoke-agentcore`. It boots the
-AgentCore Runtime container **once** (same image / env / credential
-resolution as `invoke-agentcore`) and keeps it **warm**, serving the
-runtime's native protocol contract so a client can hit it repeatedly:
+`cdkd local start-agentcore [target]` boots an `AWS::BedrockAgentCore::Runtime`
+container **once**, keeps it warm, and serves the runtime's native protocol
+contract on a local port so a client can hit it repeatedly. It is the
+long-running counterpart of the single-shot
+[`cdkd local invoke-agentcore`](local-invoke-agentcore.md) — reach for it when
+you are driving an agent from a client (a browser, an MCP host, a test suite)
+rather than firing one payload. Runs until `^C`. Docker is required.
 
-- **HTTP / AGUI** runtimes serve `POST /invocations` + `GET /ping`
-  (proxied to the warm container, with the session-id / boot-resolved
-  `Authorization` injected and the request/response — including an SSE
-  stream — piped through) **and** the bidirectional `/ws` WebSocket
-  endpoint behind a host bridge that injects the AgentCore session-id
-  (and, under a `customJwtAuthorizer`, the `Authorization` header) on the
-  container upgrade — so a **header-less client** (e.g. a browser
-  `WebSocket`, which cannot set custom upgrade headers) can hold an
-  interactive multi-frame session. Both share the **same host port**; the
-  ready banner prints both an `HTTP contract served on http://...` line
-  and the `Server listening on ws://...` line.
-- **MCP** runtimes serve `POST /mcp`; **A2A** runtimes serve `POST /`
-  (these have no `/ws` bridge, and print a `Server listening on http://...`
-  ready line plus a `<PROTOCOL> contract served on http://...` line).
+```bash
+cdkd local start-agentcore MyStack/MyAgent                       # serve on an OS-assigned port
+cdkd local start-agentcore                                       # pick a runtime interactively (TTY)
+cdkd local start-agentcore MyStack/MyAgent --port 8080           # pin the host port
+cdkd local start-agentcore MyStack/MyAgent --bearer-token "$JWT" # default token for a customJwtAuthorizer runtime
+cdkd local start-agentcore MyStack/MyAgent --sigv4               # sign forwarded requests for a SigV4 runtime
+cdkd local start-agentcore MyStack/MyAgent --from-state --watch  # bind cdkd state, reload the container on edits
+```
 
-Runs until `^C`. Models cdk-local's `cdkl start-agentcore`,
-inherited into cdkd's command tree as a thin
-pass-through to cdk-local's command factory. Requires Docker.
+## Options
 
-### `local start-agentcore` target resolution
+`-a, --app`, `--env-vars`, `--no-pull`, `--from-state`, `--stack-region` and
+`--container-host` behave as they do on every `cdkd local` subcommand; see
+[Local Execution](local-emulation.md#common-flags).
 
-Same shape as `local invoke-agentcore`: a CDK display path
-(`MyStack/MyAgent`) or stack-qualified logical ID. Single-stack apps may
-omit the stack prefix. Omit the target in a TTY for an interactive picker
-over the discovered AgentCore Runtimes.
+| Flag | Default | Description |
+| --- | --- | --- |
+| `[target]` | interactive picker | The runtime to serve, as a CDK display path (`MyStack/MyAgent`) or a stack-qualified logical ID. Omit in a TTY to pick from a list. |
+| `--port <n>` | `0` (OS-assigned) | Host port the client connects to. The HTTP contract and the `/ws` bridge share it. |
+| `--host <ip>` | `127.0.0.1` | Host the local server binds to. |
+| `--session-id <id>` | fresh UUID per request | Pin one AgentCore session id across every forwarded request and `/ws` connection. |
+| `--bearer-token <jwt>` | — | Bearer JWT used when an inbound request carries no `Authorization` of its own. Verified against the runtime's OIDC discovery URL before the container starts. |
+| `--no-verify-auth` | off | Skip inbound JWT verification even when the runtime declares a `customJwtAuthorizer`. A `--bearer-token`, if given, is still forwarded. |
+| `--sigv4` | off | Sign each forwarded request with AWS SigV4 (service `bedrock-agentcore`). Mutually exclusive with `--bearer-token`. |
+| `--timeout <ms>` | `120000` | How long the container has to answer `GET /ping` and become ready. |
+| `--platform <platform>` | `linux/arm64` | `docker --platform` for the agent container. Only `linux/amd64` and `linux/arm64` are accepted. |
+| `--watch` | off | Re-synth and reload the warm container in place on a CDK source change, keeping the local server up. |
+| `--no-pull` | off | Skip `docker pull` and use the cached image. No-op on the local-build path. |
+| `--no-build` | off | Skip `docker build` on the local-asset path and reuse the previously built tag. No-op on the ECR / registry pull paths. |
+| `--assume-role [arn]` | off | Assume the runtime's execution role — bare form uses its literal `RoleArn` — and forward temporary credentials into the container. Omit the flag to keep your own shell credentials in the container. |
+| `--ecr-role-arn <arn>` | — | Role to assume before authenticating against ECR, for cross-account or centralized registries. |
+| `--from-state` | off | Resolve intrinsics in the runtime's container image and environment variables from cdkd's S3 state. Mutually exclusive with `--from-cfn-stack`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Only meaningful with `--from-state`. |
+| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Only meaningful with `--from-state`. |
+| `--from-cfn-stack [name]` | off | Resolve the same values from a deployed CloudFormation stack, for apps deployed with the CDK CLI. Bare form uses the resolved stack name. |
+| `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region under `--from-cfn-stack`. |
+| `--env-vars <file>` | — | SAM-shaped JSON env-var overrides for the agent container. |
+| `--container-host <host>` | `127.0.0.1` | Host IP the agent container's port binds to. Must be a numeric IP. |
+| `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a path to a pre-synthesized cloud assembly. |
+| `--output <path>` | `cdk.out` | Output directory for synthesis. |
+| `-c`, `--context <key=value>` | — | Context value passed to synthesis. Repeatable. |
+| `--region <region>` | `AWS_REGION` / stack / profile | AWS region for SDK calls. |
+| `--profile <profile>` | — | AWS profile. |
+| `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for AWS API calls. |
+| `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
+| `--verbose` | off | Verbose logging. |
 
-### `local start-agentcore` state-source flags
+## Target resolution
 
-`start-agentcore` is one of the factory pass-throughs that bind deployed
-state via the `extraStateProviders` seam: cdk-local's
-start-agentcore factory accepts it, so cdkd threads its S3-backed
-`--from-state` factory in and layers the cdkd-specific `--from-state` /
-`--state-bucket` / `--state-prefix` flags on top of cdk-local's inherited
-`--from-cfn-stack` / `--stack-region`. Use `--from-state` (after a prior
-`cdkd deploy`) or `--from-cfn-stack [name]` (for a stack deployed via the
-upstream CDK CLI) to substitute `Ref` / `Fn::GetAtt` / `Fn::Sub` /
-`Fn::ImportValue` / `Fn::GetStackOutput` intrinsics in the runtime
-container image + environment variables. Mutually exclusive. (`start-alb`,
-`start-service`, and — as of cdk-local 0.128.0 — `start-cloudfront` thread
-`--from-state` the same way.)
+The target names one AgentCore Runtime, as a CDK display path
+(`MyStack/MyAgent`) or a stack-qualified logical ID (`MyStack:MyAgent`).
+Single-stack apps may omit the stack prefix. Omitting the target in a TTY opens
+an interactive picker over the runtimes discovered in the synthesized app — the
+same resolution [`cdkd local invoke-agentcore`](local-invoke-agentcore.md) uses.
 
-### `local start-agentcore` options
+## Protocols and endpoints
 
-- `--port <n>` — serve bind port the client connects to (default
-  `0` = OS-assigned). The HTTP contract and the `/ws` bridge share this
-  one port; the ready banner prints the chosen
-  `http://<host>:<port>` + `ws://<host>:<port>/ws`.
-- `--host <ip>` — serve bind host (default `127.0.0.1`).
-- `--session-id <id>` — pin one AgentCore session-id for every forwarded
-  request / `/ws` connection (default: a fresh UUID each, so each is its
-  own session).
-- `--bearer-token <jwt>` — Bearer JWT presented under a
-  `customJwtAuthorizer` (verified against the runtime's OIDC discovery URL
-  before the container starts, then forwarded on every request and the
-  container `/ws` upgrade). Now the **default-when-missing** fallback — the
-  inbound JWT gate is per request, not boot-time (see below).
-- `--no-verify-auth` — skip the inbound JWT verification (a `--bearer-token`,
-  if given, is still forwarded).
-- `--sigv4` — sign each forwarded request with AWS SigV4 (service
-  `bedrock-agentcore`) when the runtime declares **no** `customJwtAuthorizer`,
-  so the warm container sees the same `Authorization` / `X-Amz-*` headers
-  the cloud receives. Mutually exclusive with `--bearer-token`; ignored
-  (with a warning) when a `customJwtAuthorizer` is declared.
-- `--watch` — re-synth + reload the warm container in place on a CDK
-  source change, keeping the host serve up (only the container rotates; a
-  per-firing classifier picks rebuild vs soft-reload, the same machinery
-  as `invoke-agentcore --ws --watch`). Off by default.
-- `--env-vars <file>` — SAM-shape env-var overrides.
-- `--platform <linux/amd64|linux/arm64>` — defaults to `linux/arm64`
-  (AgentCore's required arch).
-- `--container-host <host>` — host to bind the container ports to.
-- `--timeout <ms>` — per-request timeout.
-- `--from-state` / `--from-cfn-stack [name]` / `--state-bucket` /
-  `--state-prefix` / `--stack-region` — state-source flags (above).
-- `--assume-role [arn]` / `--ecr-role-arn <arn>` — role-assumption +
-  cross-account ECR image-pull flags.
-- `--no-pull` / `--no-build` — pull / build skip.
+The runtime's declared protocol decides what the local server exposes and which
+container port it talks to. All of it is served on the single `--port`.
 
-### `local start-agentcore` inbound auth (`customJwtAuthorizer`)
+| Protocol | Local endpoints | Container port |
+| --- | --- | --- |
+| HTTP / AGUI | `POST /invocations`, `GET /ping`, and the bidirectional `/ws` WebSocket endpoint | `8080` |
+| MCP | `POST /mcp` | `8000` |
+| A2A | `POST /` | `9000` |
 
-When the runtime declares an inbound `customJwtAuthorizer`, the warm serve
-verifies each contract request's `Authorization` **per request** (matching
-the cloud): `401` when the header is missing, `403` when the token is
-invalid, forwarded on a pass. `GET /ping` is unauthenticated. The
-container boots without requiring a token up front; `--bearer-token` is the
-default token used when a request arrives without its own `Authorization`.
-For a SigV4-protected runtime (no `customJwtAuthorizer`) use `--sigv4`
-instead to sign each forwarded request.
+The ready banner names what was bound. An HTTP / AGUI runtime prints both a
+`Server listening on ws://...` line and an
+`HTTP contract served on http://... — POST .../invocations, GET .../ping` line;
+MCP and A2A print a `Server listening on http://...` line plus a
+`<PROTOCOL> contract served on http://...` line. A request to an unserved path
+gets a `404` that names the routes this runtime does serve.
 
-### `local start-agentcore` lifecycle
+```bash
+curl -X POST http://127.0.0.1:8080/invocations -d '{"prompt":"hello"}'  # HTTP / AGUI
+curl http://127.0.0.1:8080/ping                                          # readiness, never authenticated
+```
 
-The container is started once and kept warm; HTTP / AGUI contract requests
-are proxied to it and each `/ws` client opens its own container upgrade
-with the session-id (and optional `Authorization`) injected. `^C`
-(SIGTERM / SIGINT) tears the container down and exits — no
-`cdkd-local-agentcore-*` container is left behind. The studio
-`agentcore-ws` serve kind (cdk-local) spawns this command, but cdkd does
-not embed cdk-local's `studio` command, so that surface is not exposed by
-the cdkd CLI.
+Requests and responses are piped through to the warm container, including an SSE
+stream, with the AgentCore session id injected on the way. `GET /ping` is served
+unauthenticated on every protocol.
+
+### The `/ws` bridge
+
+HTTP and AGUI runtimes also get a `/ws` endpoint on the same host port. Each
+client connection opens its own upgrade to the container, and the bridge injects
+the AgentCore session-id header — and, under a `customJwtAuthorizer`, the
+`Authorization` header — on that upgrade. That is what makes a header-less
+client work: a browser's `WebSocket` cannot set custom upgrade headers, so it
+could not otherwise hold an interactive multi-frame session against the runtime.
+
+MCP and A2A runtimes have no `/ws` bridge.
+
+## Inbound authentication
+
+Which of the two gates applies is decided by the runtime, not by the flags: a
+declared `customJwtAuthorizer` always wins.
+
+| Runtime declares | Gate | Flag to reach for |
+| --- | --- | --- |
+| `customJwtAuthorizer` | Per-request JWT verification on the local server | `--bearer-token`, or `--no-verify-auth` to disable |
+| No `customJwtAuthorizer` | Nothing by default; `--sigv4` signs each forwarded request | `--sigv4` |
+
+### `customJwtAuthorizer` runtimes
+
+The local server verifies each contract request's `Authorization` **per
+request**, matching what the cloud runtime does on every `InvokeAgentRuntime`:
+
+| Inbound request | Result |
+| --- | --- |
+| Carries an `Authorization` header that verifies | Forwarded to the container |
+| Carries an `Authorization` header that fails signature / issuer / expiry / audience / scope checks | `403` |
+| Carries no `Authorization`, and `--bearer-token` was given | The supplied token is used, then verified |
+| Carries no `Authorization`, and no `--bearer-token` | `401` |
+| Any of the above, under `--no-verify-auth` | Forwarded; a `--bearer-token` is still injected |
+
+The container boots without a token being required up front, so `--bearer-token`
+is a default rather than a prerequisite. An unreachable or malformed discovery
+URL falls back to accepting the request, so offline work is not blocked.
+
+### SigV4 runtimes
+
+`--sigv4` signs each forwarded request with AWS SigV4 for the
+`bedrock-agentcore` service, so the warm container sees the same `Authorization`
+and `X-Amz-*` headers it would receive in the cloud. It is mutually exclusive
+with `--bearer-token`, and it is ignored — with a warning — when the runtime
+declares a `customJwtAuthorizer`.
+
+## State sources
+
+`--from-state` (after a `cdkd deploy`) and `--from-cfn-stack [name]` (for a
+stack deployed with the CDK CLI) substitute `Ref`, `Fn::GetAtt`, `Fn::Sub`,
+`Fn::ImportValue` and `Fn::GetStackOutput` intrinsics in the runtime's container
+image and environment variables. The two are mutually exclusive. `--state-bucket`
+and `--state-prefix` scope the cdkd state read; `--stack-region` picks the region
+of the record, and doubles as the CloudFormation client region under
+`--from-cfn-stack`.
+
+## `--watch`: reload the warm container in place
+
+`--watch` re-synthesizes on a CDK source change and rotates only the container —
+the local server, its port and its bindings stay up. `cdk.json`'s
+`watch.include` / `watch.exclude` are honored, and `cdk.out`, `node_modules` and
+`.git` are always excluded.
+
+Each firing is classified to pick the primitive:
+
+| Change | Primitive |
+| --- | --- |
+| Source-only edits an existing container can absorb | Soft reload: the new source is copied in and the container is restarted. |
+| Anything requiring a new image | Rebuild: a fresh container boots and the server is re-pointed at it. |
+
+Either way the new container is re-probed for readiness under `--timeout` before
+traffic resumes.
+
+## Lifecycle
+
+The container is started once and kept warm for the life of the command.
+Contract requests are proxied to it, and each `/ws` client opens its own upgrade
+with the session id — and any `Authorization` — injected.
+
+`^C` (SIGINT) and SIGTERM tear the container down and exit, leaving no
+`cdkd-local-agentcore-*` container behind.
+
+## Limitations
+
+- MCP and A2A runtimes serve request/response only; there is no `/ws` bridge for
+  them.
+- `--sigv4` and `--bearer-token` cannot be combined, and `--sigv4` has no effect
+  on a runtime that declares a `customJwtAuthorizer`.
+- `--platform` accepts only `linux/amd64` and `linux/arm64`. The default is
+  `linux/arm64` because the cloud AgentCore Runtime requires it.
+- Inbound JWT verification falls back to accepting the request when the OIDC
+  discovery URL is unreachable or malformed.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Shut down on SIGTERM. |
+| `1` | Hard error — no such runtime, synthesis failure, an image that would not build or pull, a container that never became ready within `--timeout`, or a `--bearer-token` rejected at boot. |
+| `130` | Shut down on `^C` (SIGINT), or the interactive picker was cancelled. |
+
+The full cross-command table is in the
+[CLI Reference](cli-reference.md#exit-codes).
+
+## Related
+
+- [`cdkd local invoke-agentcore`](local-invoke-agentcore.md) — the one-shot twin
+  of this command, for firing a single payload at a runtime
+- [`cdkd local invoke`](local-invoke.md) — one-shot Lambda invoke via the RIE
+  container
+- [Local Execution](local-emulation.md) — every `cdkd local` subcommand, Docker
+  requirements, and the flags they share

--- a/docs/local-start-alb.md
+++ b/docs/local-start-alb.md
@@ -1,105 +1,243 @@
 ---
-title: local start-alb
+title: cdkd local start-alb
 description: "Front local ECS and Lambda backing services with a local Application Load Balancer — path, host, header, weighted, redirect, and fixed-response routing."
 ---
 
-# `local start-alb` (run an Application Load Balancer locally)
+# cdkd local start-alb
 
-`cdkd local start-alb <Stack/Alb...>` is the long-running
-local Application Load Balancer front-door. It names one or more
-`AWS::ElasticLoadBalancingV2::LoadBalancer` resources from the
-synthesized template, discovers the ECS / Lambda targets behind each
-listener's `forward` action, boots every backing ECS service via the
-same engine `local start-service` uses (replicas, restart-on-exit,
-Service Connect / Cloud Map), and stands up a per-listener local
-`node:http(s)` server that round-robins inbound requests across the
-running replicas and applies the listener rules (path / host / header /
-method / query-string / source-IP) against the backing targets. The
-symmetric counterpart of `local start-api` for ALB-fronted workloads.
+`cdkd local start-alb [targets...]` stands up a local Application Load Balancer
+in front of the ECS services and Lambda functions its listeners point at. It
+boots every backing ECS service, opens one local HTTP(S) server per listener
+port, and applies that listener's rules — path, host, header, method,
+query-string and source-IP — against the running replicas. Reach for it when a
+routing rule, a weighted split or an auth action needs to be exercised without
+a deploy. Docker is required.
 
-The command is a thin wrapper around the shared ECS service emulator
-engine (`runEcsServiceEmulator`, shimmed from `cdk-local/internal`);
-the per-listener front-door owns the routing + auth-guard logic, the
-underlying engine owns the container boot + Cloud Map plumbing.
+```bash
+cdkd local start-alb MyStack/MyAlb                             # serve one ALB on its listener ports
+cdkd local start-alb                                           # pick the load balancers interactively (TTY)
+cdkd local start-alb MyStack/PublicAlb MyStack/InternalAlb     # two ALBs sharing one network + registry
+cdkd local start-alb MyStack/MyAlb --lb-port 80=8080           # remap a privileged listener port
+cdkd local start-alb MyStack/MyAlb --tls --bearer-token "$JWT" # terminate TLS locally, inject a default token
+cdkd local start-alb MyStack/MyAlb --from-state --watch        # bind deployed state, hot-reload on source edits
+```
 
-### `local start-alb` target resolution
+## Options
 
-- `Stack/Alb/...` (display path) or `Stack:LogicalId` (logical id).
-- Single-stack apps may omit the stack prefix.
-- The target MUST resolve to an
-  `AWS::ElasticLoadBalancingV2::LoadBalancer`; passing a Listener or
-  TargetGroup surfaces a clear error naming the available ALBs in the
-  stack.
-- Variadic: multiple ALB targets in one invocation share a single
-  shared docker network + a single Cloud Map registry so ECS services
-  registered to different ALBs still discover each other.
+`-a, --app`, `--env-vars`, `--no-pull`, `--from-state`, `--stack-region` and
+`--container-host` behave as they do on every `cdkd local` subcommand; see
+[Local Execution](local-emulation.md#common-flags).
 
-### `local start-alb` options
+### Front door
 
-| Flag | Default | Behavior |
+| Flag | Default | Description |
 | --- | --- | --- |
-| `--lb-port <listenerPort=hostPort>` | host port == listener port | Remap the local front-door host port for a specific listener port. Repeatable (`--lb-port 80=8080 --lb-port 443=8443`). Use this on macOS to remap a privileged listener port (< 1024) to a non-privileged host port. |
-| `--tls` | off | Terminate TLS locally for cloud-HTTPS listeners. Default: a cloud-HTTPS listener is served over plain HTTP locally (`X-Forwarded-Proto: https` is preserved so the upstream app still sees the deployed listener protocol). Implied by `--tls-cert` / `--tls-key`. Use this when local-dev cookies need `Secure` / `SameSite=None`, when the upstream app inspects TLS metadata, or for mTLS / SNI testing — otherwise plain HTTP is friendlier (no self-signed cert warnings in curl / browser). |
-| `--tls-cert <path>` | — | PEM-encoded server certificate for HTTPS front-door listeners. Implies `--tls`. Must be set together with `--tls-key`. Pass `--tls` alone (without `--tls-cert` / `--tls-key`) to auto-generate a self-signed cert cached under `$XDG_CACHE_HOME/cdk-local/alb-https/`. The deployed Listener Certificates are NOT fetched (ACM private keys are not retrievable). |
-| `--tls-key <path>` | — | PEM-encoded server private key matching `--tls-cert`. Implies `--tls`. Must be set together. |
-| `--no-verify-auth` | off | Disable local enforcement of `authenticate-cognito` / `authenticate-oidc` actions. Every request is served as if the auth check passed. |
-| `--bearer-token <jwt>` | — | Default Bearer JWT injected as `Authorization: Bearer <jwt>` when the inbound request has none. Verified against the same JWKS / OIDC discovery URL the deployed ALB would (signature + iss + aud + exp). Cookie pass-through (`AWSELBAuthSessionCookie-*`) also works. |
-| `--cluster <name>` | `cdkd-local` | Cluster name surfaced to `ECS_CONTAINER_METADATA_URI_V4` and used as the docker network prefix. Same shape as `local start-service`. |
-| `--max-tasks <n>` | `3` | Per-service hard cap on local replica count regardless of template `DesiredCount`. Same shape as `local start-service`. |
-| `--restart-policy <p>` | `on-failure` | Restart-on-exit behavior for backing ECS containers. Same three-state grammar as `local start-service`. |
-| `--env-vars <file>` | — | SAM-shape JSON env-var overrides for backing containers; same format as `local run-task` / `local start-service`. |
-| `--container-host <ip>` | `127.0.0.1` | Host IP to bind published container + front-door ports to. Must be a numeric IP. |
-| `--assume-task-role [arn]` | unset | Assume each backing service's TaskRoleArn (or the supplied ARN). Same three-form grammar as `local start-service`. |
-| `--ecr-role-arn <arn>` | — | Role ARN to assume before ECR `docker pull`. Same shape as `local start-service`. |
-| `--platform <p>` | inferred | Force `--platform linux/amd64` or `linux/arm64`. |
-| `--no-pull` | off | Skip `docker pull` on every container image and the metadata sidecar. |
-| `--from-state` | off | Read cdkd's S3 state for the target stack and substitute `Ref` / `Fn::GetAtt` / `Fn::Sub` / `Fn::ImportValue` / `Fn::GetStackOutput` intrinsics in the resolved backing services' container images, environment variables, secrets, role ARNs, and volumes. Mutually exclusive with `--from-cfn-stack`. Same shape as `local start-service --from-state`. |
-| `--state-bucket <bucket>` | auto | S3 bucket containing cdkd state. Falls back to `CDKD_STATE_BUCKET` env or `cdk.json context.cdkd.stateBucket`, then the default `cdkd-state-{accountId}`. Only used with `--from-state`. |
-| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Only used with `--from-state`. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `DescribeStackResources` and substitute `Ref` / `Fn::ImportValue` intrinsics. For CDK apps deployed via the upstream CDK CLI (`cdk deploy`). Mutually exclusive with `--from-state`. Same shape as `local start-service --from-cfn-stack`. |
-| `--stack-region <region>` | — | Region of the state record to read. Used with `--from-state` when the same stack name has state in multiple regions, and with `--from-cfn-stack` as the CFn client region. |
-| `--watch` | off | Hot reload: re-synth + per-replica reload of every ECS service behind the ALB when the CDK source changes (`cdk.json watch.include` / `watch.exclude` honored; `cdk.out` / `node_modules` / `.git` always excluded). A per-firing classifier picks the per-replica primitive: source-only edits on interpreted-language handlers (Node / Python / Ruby / shell) take a bind-mount **FAST PATH** (`docker cp` + `docker restart`; no `docker build`, sub-second; the front-door pool entry is unchanged since the IP/port are preserved). Dockerfile / dependency manifest / compiled-language source / ambiguous edits fall through to the rebuild rolling primitive — boot a shadow, wait for TCP-ready, atomically register it in the front-door pool, drop the old entry. Either path rolls one replica at a time, so a continuous external request stream against the listener port sees zero connection refusals across the reload. The host front-door (TLS, JWKS cache, Lambda-target containers, listener sockets) stays up across the reload. Lambda target groups behind the ALB are a no-op on reload (the warm RIE container keeps its boot-time image). Off by default; existing replica(s) keep serving when synth fails mid-reload. (cdk-local 0.69.0.) |
-| `--image-override <target=ref>` | — | Pin or locally build a backing service's container image instead of using the deployed registry tag. Same grammar + per-service `--image-build-arg` / `--image-build-secret` / `--image-target` variants as `local start-service`. (cdk-local 0.77.) |
-| `--shadow-ready-timeout <ms>` | `60000` | Per-invocation override of the shadow-replica TCP-ready probe budget. Same shape as `local start-service`. (cdk-local 0.77.) |
+| `[targets...]` | interactive picker | One or more load balancers, as a CDK display path (`MyStack/MyAlb`) or a stack-qualified logical ID. Variadic; omit in a TTY to multi-select. |
+| `--lb-port <listenerPort=hostPort>` | host port == listener port | Bind the front door for one listener on a different host port. Repeatable. |
+| `--tls` | off | Terminate TLS locally for cloud-HTTPS listeners instead of serving them over plain HTTP. |
+| `--tls-cert <path>` | — | PEM server certificate for the HTTPS front door. Implies `--tls`; must be paired with `--tls-key`. |
+| `--tls-key <path>` | — | PEM private key matching `--tls-cert`. Implies `--tls`; must be paired with it. |
+| `--bearer-token <jwt>` | — | Bearer JWT the front door injects as `Authorization` when an inbound request carries none. |
+| `--no-verify-auth` | off | Serve every request as if the `authenticate-cognito` / `authenticate-oidc` check passed. |
 
-When no listener rule matches an inbound request, the local front-door's
-404 now explains which listener fields (path / host / header / method)
-were evaluated, instead of a bare 404 (cdk-local 0.77).
+### Backing services
 
-### `local start-alb` listener / action support
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--cluster <name>` | `cdkd-local` | Cluster name surfaced in `ECS_CONTAINER_METADATA_URI_V4`, and the prefix of the docker network. |
+| `--max-tasks <n>` | `3` | Hard cap on local replicas per service, overriding the template's `DesiredCount`. Cannot exceed 83. |
+| `--restart-policy <policy>` | `on-failure` | What happens when an essential container exits: `on-failure`, `always`, or `none` (run degraded). |
+| `--no-logs` | off | Stop streaming each replica's container output to the terminal. |
+| `--assume-role [arn]` | off | Assume the task definition's `TaskRoleArn` (or an explicit ARN) and forward temporary credentials through the metadata sidecar. |
+| `--assume-task-role [arn]` | off | Deprecated alias of `--assume-role`. Both forms work; `--assume-role` is the cross-command name. |
+| `--ecr-role-arn <arn>` | — | Role to assume before authenticating against ECR, for cross-account or centralized registries. |
+| `--platform <platform>` | task `RuntimePlatform` | Force `linux/amd64` or `linux/arm64` for every container. |
 
-The local front-door reads the synthesized template and emulates these
-listener / action shapes:
+### Container images
 
-- **Listener protocols:** HTTP and HTTPS. A cloud-HTTPS listener is
-  served over plain HTTP locally by default — `X-Forwarded-Proto: https`
-  is preserved so the upstream app still sees the deployed listener
-  protocol. Pass `--tls` to terminate TLS locally (a self-signed cert is
-  auto-generated and cached under `$XDG_CACHE_HOME/cdk-local/alb-https/`),
-  or `--tls-cert` / `--tls-key` to supply your own cert (each flag
-  implies `--tls`). Non-HTTP/HTTPS listeners (TCP / UDP / TLS / NLB) are
-  skipped with a warn.
-- **Rule conditions:** all six ALB fields — `path-pattern`,
-  `host-header`, `http-header`, `http-request-method`,
-  `query-string`, `source-ip`.
-- **Default + rule actions:** `forward` (single target group, weighted
-  forward across multiple target groups), `redirect`, `fixed-response`.
-  `authenticate-cognito` + `authenticate-oidc` enforce a local Bearer-JWT
-  check (or `AWSELBAuthSessionCookie` pass-through) against the same
-  JWKS / OIDC discovery URL the deployed ALB would.
-- **Target groups:** ECS (`AWS::ECS::Service.LoadBalancers[]` binding
-  the TG to the container + port) and Lambda (TG `Targets[].Id` =
-  `{Fn::GetAtt: [<FnLogicalId>, "Arn"]}`).
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--no-pull` | off | Skip `docker pull` for every container image and the metadata sidecar. |
+| `--no-build` | off | Skip `docker build` on the local CDK-asset path and reuse the previously built tag. Errors when that tag is missing. |
+| `--image-override <service=dockerfile>` | — | Build a service's image locally from the named Dockerfile instead of pulling its deployed registry tag. Repeatable; a bare `<dockerfile>` opens a picker. |
+| `--image-build-arg <KEY=VAL>` | — | `docker build --build-arg` pair applied to every `--image-override` build. Repeatable. |
+| `--image-build-secret <id=src>` | — | `docker build --secret id=<id>,src=<src>` entry applied to every `--image-override` build, for `RUN --mount=type=secret`. Repeatable. |
+| `--image-target <stage>` | — | Multi-stage build stage for `--image-override` builds (docker's `--target`). `<service>=<stage>` scopes it to one service; a bare `<stage>` applies globally. |
+| `--no-interactive-overrides` | off | Suppress the boot prompt that asks for a Dockerfile per pinned target, and the `--image-override <dockerfile>` picker. |
+| `--strict-overrides` | off | Fail at boot when any registry-pinned target is still uncovered after overrides and prompts resolve. |
 
-Unsupported listener / action / target shapes are skipped with a per-line
-warn at boot; the front-door still serves what it can.
+### Hot reload
 
-### `local start-alb` lifecycle
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--watch` | off | Re-synth and roll every backing ECS service when the CDK source changes. |
+| `--shadow-ready-timeout <ms>` | `60000` | How long a shadow replica has to accept a TCP connection before the roll gives up. Also read from `CDKD_SHADOW_READY_TIMEOUT_MS`; the flag wins. |
 
-`^C` (SIGINT) and SIGTERM tear down the front-door servers first, then
-every backing service's replicas + sidecar + shared network in parallel.
-Double-`^C` bypasses cleanup and exits 130 immediately so users have an
-escape hatch when docker hangs. The front-door servers always rebind
-the requested host port on restart — there is no in-process state
-across `^C`.
+### State sources
 
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--from-state` | off | Resolve intrinsics in the backing services from cdkd's S3 state. Mutually exclusive with `--from-cfn-stack`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Only meaningful with `--from-state`. |
+| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Only meaningful with `--from-state`. |
+| `--from-cfn-stack [name]` | off | Resolve intrinsics from a deployed CloudFormation stack, for apps deployed with the CDK CLI. Bare form uses the cdkd stack name. |
+| `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region under `--from-cfn-stack`. |
+
+### Shared
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a path to a pre-synthesized cloud assembly. |
+| `--output <path>` | `cdk.out` | Output directory for synthesis. |
+| `-c`, `--context <key=value>` | — | Context value passed to synthesis. Repeatable. |
+| `--env-vars <file>` | — | SAM-shaped JSON env-var overrides for backing containers. |
+| `--container-host <ip>` | `127.0.0.1` | Host IP the published container and front-door ports bind to. Must be a numeric IP. |
+| `--region <region>` | `AWS_REGION` / stack / profile | AWS region for SDK calls. |
+| `--profile <profile>` | — | AWS profile. |
+| `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for AWS API calls. |
+| `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
+| `--verbose` | off | Verbose logging. |
+
+## Target resolution
+
+Each target names an `AWS::ElasticLoadBalancingV2::LoadBalancer`:
+
+- A CDK display path (`MyStack/MyAlb`), or a stack-qualified logical ID
+  (`MyStack:MyAlb`). Single-stack apps may omit the stack prefix.
+- Omit the targets entirely in an interactive terminal to multi-select from a
+  list of the app's load balancers.
+- Naming a Listener or a TargetGroup is an error, and the message lists the
+  load balancers available in the stack.
+
+Passing several load balancers in one invocation puts them on a single shared
+docker network with one Cloud Map registry, so ECS services registered behind
+different load balancers still discover each other.
+
+## Listener and action support
+
+The front door reads the synthesized template and serves these shapes. Anything
+outside them is skipped with a warning at boot, and the rest of the load
+balancer still serves.
+
+| Shape | Supported |
+| --- | --- |
+| Listener protocols | `HTTP` and `HTTPS`. `TCP` / `UDP` / `TLS` (NLB-style) listeners are skipped. |
+| Rule conditions | All six ALB fields: `path-pattern`, `host-header`, `http-header`, `http-request-method`, `query-string`, `source-ip`. |
+| Actions | `forward` (single target group and weighted across several), `redirect`, `fixed-response`. |
+| Auth actions | `authenticate-cognito` and `authenticate-oidc`, enforced as a local Bearer-JWT check. |
+| Target groups | ECS services (bound through `AWS::ECS::Service.LoadBalancers[]`) and Lambda functions (a target group whose `Targets[].Id` is the function's ARN). |
+
+Requests forwarded to a backing replica carry the ALB forwarding headers: the
+client IP appended to any existing `X-Forwarded-For` chain, plus
+`X-Forwarded-Proto` and `X-Forwarded-Port` for the listener. When no rule
+matches and the listener has no locally servable default action, the 404 names
+the request fields that were evaluated rather than returning a bare status.
+
+WebSocket upgrades go through the same rule matching and auth gates. An ECS
+forward target gets a raw TCP bridge to the picked replica; `redirect` and
+`fixed-response` actions answer over the upgrade socket; a Lambda target group
+answers `502`, because Lambda target groups do not carry WebSocket traffic.
+
+### TLS termination
+
+A cloud-HTTPS listener is served over **plain HTTP** locally by default, with
+`X-Forwarded-Proto: https` preserved so the upstream app still sees the deployed
+listener protocol. That is the friendlier default — no self-signed certificate
+warnings in `curl` or a browser.
+
+| Invocation | Front door |
+| --- | --- |
+| (no TLS flag) | Plain HTTP, `X-Forwarded-Proto: https` preserved. |
+| `--tls` | Real HTTPS with a self-signed certificate, generated on first use and cached under `$XDG_CACHE_HOME/cdk-local/alb-https/` (`~/.cache/cdk-local/alb-https/` by default). Requires `openssl` on `PATH`. |
+| `--tls-cert` + `--tls-key` | Real HTTPS with your own PEM pair. Each flag implies `--tls`. |
+
+Reach for `--tls` when local-dev cookies need `Secure` / `SameSite=None`, when
+the app inspects TLS metadata, or for mTLS / SNI testing. The auto-generated
+certificate lists only `DNS:localhost,IP:127.0.0.1` as SubjectAltName, so a
+client validating a non-loopback `--container-host` fails the SAN check — supply
+`--tls-cert` / `--tls-key` with a matching SAN for that case.
+
+### Authentication actions
+
+An `authenticate-cognito` or `authenticate-oidc` action makes the front door
+verify a Bearer JWT against the same JWKS / OIDC discovery URL the deployed load
+balancer would use, checking signature, issuer, audience and expiry. An
+`AWSELBAuthSessionCookie-*` cookie also passes the guard.
+
+- `--bearer-token <jwt>` supplies the token the front door slots in when the
+  inbound request has no `Authorization` header of its own. A caller that
+  presents its own token is verified on that token.
+- `--no-verify-auth` disables the guard entirely, for local work where minting a
+  token is not worth it.
+
+An authenticate action with no locally servable terminal action behind it is
+skipped with a warning.
+
+## `--watch`: hot reload without dropping connections
+
+`--watch` re-synthesizes and reloads the backing services whenever the CDK
+source changes. `cdk.json`'s `watch.include` / `watch.exclude` are honored, and
+`cdk.out`, `node_modules` and `.git` are always excluded.
+
+Each firing is classified per target, which picks the per-replica primitive:
+
+| Change | Primitive |
+| --- | --- |
+| Source-only edits to an interpreted-language handler (Node, Python, Ruby, shell) | Fast path: the new source is copied into each replica and the container is restarted. No rebuild; the front-door pool entry is unchanged because the IP and port are preserved. |
+| Dockerfile, dependency manifest, compiled-language source, or an ambiguous edit | Rebuild: a shadow replica boots, its port is probed for TCP readiness, it is atomically registered in the front-door pool, then the old replica is dropped. |
+
+Both paths roll one replica at a time, so a continuous request stream against a
+listener port sees no connection refusals across the reload. The host front door
+— TLS, the JWKS cache, Lambda target containers and the listener sockets — stays
+up throughout. When synthesis fails mid-reload the existing replicas keep
+serving and a warning is printed.
+
+## Lifecycle
+
+`^C` (SIGINT) and SIGTERM tear the front-door servers down first, then every
+backing service's replicas, sidecar and shared network in parallel. A second
+signal skips cleanup and exits immediately, which is the escape hatch when
+docker itself is wedged — orphan containers may remain, and
+`docker ps --filter name=cdkd-local-` finds them.
+
+Nothing persists in process across a restart: the front-door servers rebind the
+requested host ports each time.
+
+## Limitations
+
+- A listener protocol, action type or target shape outside the tables above is
+  skipped with a per-line warning at boot; the load balancer serves what is left.
+- A listener's ACM `Certificates[]` are not fetched — ACM private keys are not
+  retrievable — so local HTTPS always uses a generated or supplied certificate.
+- Lambda target groups are a no-op on a `--watch` reload: the warm container
+  keeps the image it booted with.
+- `--watch` rolls the existing replicas onto the new image but does not scale the
+  replica count up or down when `DesiredCount` or the `--max-tasks` clamp changes
+  mid-run. A warning names it; restart to pick up the new count.
+- `--max-tasks` cannot exceed 83, the range of the per-replica link-local subnet
+  allocator.
+- Under `--from-cfn-stack`, an `Fn::GetAtt` in a container's `Environment[].Value`
+  is dropped with a warning: CloudFormation's resource listing does not return
+  per-attribute values, and no ECS-side call recovers them from a deployed task.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `1` | Hard error — bad target, synthesis failure, docker or AWS failure, or a boot refused by `--strict-overrides`. |
+| `130` | Shut down on `^C` / SIGTERM, on a second signal (cleanup skipped), or because the interactive picker was cancelled. |
+
+The front door runs until it is signalled, so a successful session ends at `130`
+rather than `0`. The full cross-command table is in the
+[CLI Reference](cli-reference.md#exit-codes).
+
+## Related
+
+- [`cdkd local start-service`](local-start-service.md) — the ECS service emulator
+  that runs the backends this command fronts
+- [`cdkd local start-api`](local-start-api.md) — the API Gateway counterpart of
+  this front door
+- [`cdkd local invoke`](local-invoke.md) — one-shot Lambda invoke, the same RIE
+  container a Lambda target group uses
+- [Local Execution](local-emulation.md) — every `cdkd local` subcommand, Docker
+  requirements, and the flags they share

--- a/docs/local-start-alb.md
+++ b/docs/local-start-alb.md
@@ -15,7 +15,8 @@ a deploy. Docker is required.
 
 Reach for [`cdkd local start-api`](local-start-api.md) instead when the front
 door you want to exercise is API Gateway: an ALB routes to running ECS replicas
-and Lambda target groups, API Gateway routes to Lambda alone.
+and to Lambda target groups, where API Gateway routes to Lambdas and HTTP
+upstreams.
 
 ```bash
 cdkd local start-alb MyStack/MyAlb                             # serve one ALB on its listener ports

--- a/docs/local-start-alb.md
+++ b/docs/local-start-alb.md
@@ -14,9 +14,9 @@ routing rule, a weighted split or an auth action needs to be exercised without
 a deploy. Docker is required.
 
 Reach for [`cdkd local start-api`](local-start-api.md) instead when the front
-door you want to exercise is API Gateway: an ALB routes to running ECS replicas
-and to Lambda target groups, where API Gateway routes to Lambdas and HTTP
-upstreams.
+door you want to exercise is API Gateway. An ALB answers from running ECS
+replicas, Lambda target groups, redirects and fixed responses; API Gateway
+answers from Lambdas, HTTP upstreams and response templates.
 
 ```bash
 cdkd local start-alb MyStack/MyAlb                             # serve one ALB on its listener ports

--- a/docs/local-start-alb.md
+++ b/docs/local-start-alb.md
@@ -50,7 +50,7 @@ cdkd local start-alb MyStack/MyAlb --from-state --watch        # bind deployed s
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--cluster <name>` | `cdkd-local` | Cluster name surfaced in `ECS_CONTAINER_METADATA_URI_V4`, and the prefix of the docker network. |
-| `--max-tasks <n>` | `3` | Hard cap on local replicas per service, overriding the template's `DesiredCount`. Cannot exceed 83 — the ceiling the local address allocator can serve. |
+| `--max-tasks <n>` | `3` | Hard cap on local replicas per service, overriding the template's `DesiredCount`. Cannot exceed 83 — the range of the per-replica link-local /24 subnet allocator. |
 | `--restart-policy <policy>` | `on-failure` | What happens when an essential container exits: `on-failure`, `always`, or `none` (run degraded). |
 | `--no-logs` | off | Stop streaming each replica's container output to the terminal. |
 | `--assume-role [arn]` | off | Assume the task definition's `TaskRoleArn` (or an explicit ARN) and forward temporary credentials through the metadata sidecar. |
@@ -224,8 +224,8 @@ requested host ports each time.
 - `--watch` rolls the existing replicas onto the new image but does not scale the
   replica count up or down when `DesiredCount` or the `--max-tasks` clamp changes
   mid-run. A warning names it; restart to pick up the new count.
-- `--max-tasks` cannot exceed 83, the ceiling the local address allocator can
-  serve.
+- `--max-tasks` cannot exceed 83, the range of the per-replica link-local /24
+  subnet allocator.
 - Under `--from-cfn-stack`, an `Fn::GetAtt` in a container's `Environment[].Value`
   is dropped with a warning: CloudFormation's resource listing does not return
   per-attribute values, and no ECS-side call recovers them from a deployed task.

--- a/docs/local-start-alb.md
+++ b/docs/local-start-alb.md
@@ -193,7 +193,7 @@ Each firing is classified per target, which picks the per-replica primitive:
 | Change | Primitive |
 | --- | --- |
 | Source-only edits to an interpreted-language handler (Node, Python, Ruby, shell) | Fast path: the new source is copied into each replica and the container is restarted. No rebuild; the front-door pool entry is unchanged because the IP and port are preserved. |
-| Dockerfile, dependency manifest, compiled-language source, or an ambiguous edit | Rebuild: a shadow replica boots, its port is probed for TCP readiness, it is atomically registered in the front-door pool, then the old replica is dropped. |
+| Dockerfile, dependency manifest, compiled-language source, or an ambiguous edit | Rebuild: cdkd boots a shadow replica, probes its port for TCP readiness, swaps it into the front-door pool atomically, then drops the old replica. |
 
 Both paths roll one replica at a time, so a continuous request stream against a
 listener port sees no connection refusals across the reload. The host front door

--- a/docs/local-start-alb.md
+++ b/docs/local-start-alb.md
@@ -50,12 +50,11 @@ cdkd local start-alb MyStack/MyAlb --from-state --watch        # bind deployed s
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--cluster <name>` | `cdkd-local` | Cluster name surfaced in `ECS_CONTAINER_METADATA_URI_V4`, and the prefix of the docker network. |
-| `--max-tasks <n>` | `3` | Hard cap on local replicas per service, overriding the template's `DesiredCount`. Cannot exceed 83. |
+| `--max-tasks <n>` | `3` | Hard cap on local replicas per service, overriding the template's `DesiredCount`. Cannot exceed 83 — the ceiling the local address allocator can serve. |
 | `--restart-policy <policy>` | `on-failure` | What happens when an essential container exits: `on-failure`, `always`, or `none` (run degraded). |
 | `--no-logs` | off | Stop streaming each replica's container output to the terminal. |
 | `--assume-role [arn]` | off | Assume the task definition's `TaskRoleArn` (or an explicit ARN) and forward temporary credentials through the metadata sidecar. |
 | `--assume-task-role [arn]` | off | Deprecated alias of `--assume-role` on this command. Both forms work here; note that `cdkd local run-task` accepts only `--assume-task-role`. |
-| `--ecr-role-arn <arn>` | — | Role to assume before authenticating against ECR, for cross-account or centralized registries. |
 | `--platform <platform>` | task `RuntimePlatform` | Force `linux/amd64` or `linux/arm64` for every container. |
 
 ### Container images
@@ -63,10 +62,11 @@ cdkd local start-alb MyStack/MyAlb --from-state --watch        # bind deployed s
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--no-pull` | off | Skip `docker pull` for every container image and the metadata sidecar. |
+| `--ecr-role-arn <arn>` | — | Role to assume before authenticating against ECR, for cross-account or centralized registries. |
 | `--no-build` | off | Skip `docker build` on the local CDK-asset path and reuse the previously built tag. Errors when that tag is missing. |
 | `--image-override <service=dockerfile>` | — | Build a service's image locally from the named Dockerfile instead of pulling its deployed registry tag. Repeatable; a bare `<dockerfile>` opens a picker. |
-| `--image-build-arg <KEY=VAL>` | — | `docker build --build-arg` pair applied to every `--image-override` build. Repeatable. |
-| `--image-build-secret <id=src>` | — | `docker build --secret id=<id>,src=<src>` entry applied to every `--image-override` build, for `RUN --mount=type=secret`. Repeatable. |
+| `--image-build-arg <KEY=VAL>` | — | `docker build --build-arg` pair for every `--image-override` build. Repeatable. `<service>:KEY=VAL` scopes it to one service. |
+| `--image-build-secret <id=src>` | — | `docker build --secret id=<id>,src=<src>` entry for every `--image-override` build, for `RUN --mount=type=secret`. Repeatable. `<service>:id=src` scopes it to one service. |
 | `--image-target <stage>` | — | Multi-stage build stage for `--image-override` builds (docker's `--target`). `<service>=<stage>` scopes it to one service; a bare `<stage>` applies globally. |
 | `--no-interactive-overrides` | off | Suppress the boot prompt that asks for a Dockerfile per pinned target, and the `--image-override <dockerfile>` picker. |
 | `--strict-overrides` | off | Fail at boot when any registry-pinned target is still uncovered after overrides and prompts resolve. |
@@ -83,7 +83,7 @@ cdkd local start-alb MyStack/MyAlb --from-state --watch        # bind deployed s
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--from-state` | off | Resolve intrinsics in the backing services from cdkd's S3 state. Mutually exclusive with `--from-cfn-stack`. |
-| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Only meaningful with `--from-state`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json`, then `cdkd-state-{accountId}` | S3 bucket holding cdkd state. Only meaningful with `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Only meaningful with `--from-state`. |
 | `--from-cfn-stack [name]` | off | Resolve intrinsics from a deployed CloudFormation stack, for apps deployed with the CDK CLI. Bare form uses the cdkd stack name. |
 | `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region under `--from-cfn-stack`. |
@@ -129,7 +129,7 @@ The front door reads the synthesized template and serves these shapes. Anything
 outside them is skipped with a warning at boot, and the rest of the load
 balancer still serves.
 
-| Shape | Supported |
+| Shape | What is served |
 | --- | --- |
 | Listener protocols | `HTTP` and `HTTPS`. `TCP` / `UDP` / `TLS` (NLB-style) listeners are skipped. |
 | Rule conditions | All six ALB fields: `path-pattern`, `host-header`, `http-header`, `http-request-method`, `query-string`, `source-ip`. |
@@ -194,7 +194,7 @@ Each firing is classified per target, which picks the per-replica primitive:
 | Change | Primitive |
 | --- | --- |
 | Source-only edits to an interpreted-language handler (Node, Python, Ruby, shell) | Fast path: the new source is copied into each replica and the container is restarted. No rebuild; the front-door pool entry is unchanged because the IP and port are preserved. |
-| Dockerfile, dependency manifest, compiled-language source, or an ambiguous edit | Rebuild: cdkd boots a shadow replica, probes its port for TCP readiness, swaps it into the front-door pool atomically, then drops the old replica. |
+| Dockerfile, dependency manifest, TypeScript or compiled-language source, or an ambiguous edit | Rebuild: cdkd boots a shadow replica, probes its port for TCP readiness, swaps it into the front-door pool atomically, then drops the old replica. |
 
 Both paths roll one replica at a time, so a continuous request stream against a
 listener port sees no connection refusals across the reload. The host front door
@@ -224,8 +224,8 @@ requested host ports each time.
 - `--watch` rolls the existing replicas onto the new image but does not scale the
   replica count up or down when `DesiredCount` or the `--max-tasks` clamp changes
   mid-run. A warning names it; restart to pick up the new count.
-- `--max-tasks` cannot exceed 83, the range of the per-replica link-local subnet
-  allocator.
+- `--max-tasks` cannot exceed 83, the ceiling the local address allocator can
+  serve.
 - Under `--from-cfn-stack`, an `Fn::GetAtt` in a container's `Environment[].Value`
   is dropped with a warning: CloudFormation's resource listing does not return
   per-attribute values, and no ECS-side call recovers them from a deployed task.

--- a/docs/local-start-alb.md
+++ b/docs/local-start-alb.md
@@ -13,6 +13,10 @@ query-string and source-IP — against the running replicas. Reach for it when a
 routing rule, a weighted split or an auth action needs to be exercised without
 a deploy. Docker is required.
 
+Reach for [`cdkd local start-api`](local-start-api.md) instead when the front
+door you want to exercise is API Gateway: an ALB routes to running ECS replicas
+and Lambda target groups, API Gateway routes to Lambda alone.
+
 ```bash
 cdkd local start-alb MyStack/MyAlb                             # serve one ALB on its listener ports
 cdkd local start-alb                                           # pick the load balancers interactively (TTY)
@@ -49,7 +53,7 @@ cdkd local start-alb MyStack/MyAlb --from-state --watch        # bind deployed s
 | `--restart-policy <policy>` | `on-failure` | What happens when an essential container exits: `on-failure`, `always`, or `none` (run degraded). |
 | `--no-logs` | off | Stop streaming each replica's container output to the terminal. |
 | `--assume-role [arn]` | off | Assume the task definition's `TaskRoleArn` (or an explicit ARN) and forward temporary credentials through the metadata sidecar. |
-| `--assume-task-role [arn]` | off | Deprecated alias of `--assume-role`. Both forms work; `--assume-role` is the cross-command name. |
+| `--assume-task-role [arn]` | off | Deprecated alias of `--assume-role` on this command. Both forms work here; note that `cdkd local run-task` accepts only `--assume-task-role`. |
 | `--ecr-role-arn <arn>` | — | Role to assume before authenticating against ECR, for cross-account or centralized registries. |
 | `--platform <platform>` | task `RuntimePlatform` | Force `linux/amd64` or `linux/arm64` for every container. |
 
@@ -97,6 +101,11 @@ cdkd local start-alb MyStack/MyAlb --from-state --watch        # bind deployed s
 | `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for AWS API calls. |
 | `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
 | `--verbose` | off | Verbose logging. |
+
+**Spell the region lower-case.** This command does not fold an upper-cased
+`--region` / `AWS_REGION` to its canonical spelling, and AWS rejects the raw
+form at signature time (`SignatureDoesNotMatch`, `AuthorizationHeaderMalformed`).
+See [`--region` / `AWS_REGION`](cli-reference.md#region-aws-region-every-command).
 
 ## Target resolution
 
@@ -224,8 +233,8 @@ requested host ports each time.
 
 | Code | Meaning |
 | --- | --- |
-| `1` | Hard error — bad target, synthesis failure, docker or AWS failure, or a boot refused by `--strict-overrides`. |
-| `130` | Shut down on `^C` / SIGTERM, on a second signal (cleanup skipped), or because the interactive picker was cancelled. |
+| `1` | Hard error — bad target, synthesis failure, docker or AWS failure, a boot refused by `--strict-overrides`, or a cancelled interactive picker. |
+| `130` | Shut down on `^C` / SIGTERM, or on a second signal with cleanup skipped. |
 
 The front door runs until it is signalled, so a successful session ends at `130`
 rather than `0`. The full cross-command table is in the
@@ -237,7 +246,11 @@ rather than `0`. The full cross-command table is in the
   that runs the backends this command fronts
 - [`cdkd local start-api`](local-start-api.md) — the API Gateway counterpart of
   this front door
+- [`cdkd local run-task`](local-run-task.md) — the rules every backing container
+  follows for secrets, volumes and `DependsOn` start ordering
 - [`cdkd local invoke`](local-invoke.md) — one-shot Lambda invoke, the same RIE
   container a Lambda target group uses
 - [Local Execution](local-emulation.md) — every `cdkd local` subcommand, Docker
   requirements, and the flags they share
+- [CLI Reference](cli-reference.md) — every cdkd command, the output-stream
+  contract, and the full exit-code table

--- a/docs/local-start-api.md
+++ b/docs/local-start-api.md
@@ -30,7 +30,7 @@ cdkd local start-api --from-state --stage prod  # resolve env vars from deployed
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `[target]` | every discovered API | Serve only the named API. See [Target selection](#target-selection). |
+| `[target]` | every discovered API | Serve only the named API. See [Target selection](#target-resolution). |
 | `--port <port>` | `0` (auto-allocate) | Port for the first server; later servers take `port+1`, `port+2`, and so on. |
 | `--host <host>` | `127.0.0.1` | Bind address for every API server — the address **you** connect to. |
 | `--stack <name>` | single-stack auto-detect | Stack to serve, when neither the target nor `--from-cfn-stack` identifies one. |
@@ -48,7 +48,7 @@ cdkd local start-api --from-state --stage prod  # resolve env vars from deployed
 | `--layer-role-arn <arn>` | — | Role to assume before reading literal-ARN entries in `Properties.Layers`. See [Lambda layers](#lambda-layers). |
 | `--from-state` | off | Substitute deployed physical ids from cdkd's S3 state into Lambda env vars. See [`--from-state`](#from-state). |
 | `--from-cfn-stack [cfn-stack-name]` | off | Substitute deployed physical ids from a CloudFormation stack. See [`--from-cfn-stack`](#from-cfn-stack). |
-| `--stack-region <region>` | auto-discovered | Region of the state record to read, and the CloudFormation client region for `--from-cfn-stack` — see [Local Execution](local-emulation.md#common-flags). |
+| `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region for `--from-cfn-stack` — see [Local Execution](local-emulation.md#common-flags). |
 | `--mtls-truststore <path>` | — | PEM CA bundle that switches the server to HTTPS with client-certificate verification. See [Mutual TLS](#mutual-tls). |
 | `--mtls-cert <path>` | — | PEM server certificate. Must be set together with the other two `--mtls-*` flags. |
 | `--mtls-key <path>` | — | PEM server private key matching `--mtls-cert`. Must be set together with the other two `--mtls-*` flags. |
@@ -60,10 +60,15 @@ cdkd local start-api --from-state --stage prod  # resolve env vars from deployed
 | `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a pre-synthesized cloud assembly directory — see [Local Execution](local-emulation.md#common-flags). |
 | `--output <path>` | `cdk.out` | Output directory for synthesis. |
 | `-c`, `--context <key=value...>` | — | Set a CDK context value. Repeatable. |
-| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Read only with `--from-state`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json`, then `cdkd-state-{accountId}` | S3 bucket holding cdkd state. Read only with `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Read only with `--from-state`. |
 
-## Target selection
+The region used for AWS API calls is taken from `AWS_REGION`, then
+`AWS_DEFAULT_REGION`, then the synthesized stack's own `env.region`. A
+deprecated `--region` flag, hidden from `--help`, still overrides all three;
+prefer the environment variable or your AWS profile.
+
+## Target resolution
 
 Passing a positional target launches exactly one server, for the named API.
 The same target syntax works across `cdkd local invoke`, `cdkd local run-task`
@@ -455,7 +460,9 @@ principal and an empty claims map.
 
 The failure entry has a short TTL of about 60s, so a transient network blip does
 not lock pass-through in for the full success TTL — the next minute's request
-retries the fetch. The warn fires at most once per JWKS URL per server run.
+retries the fetch. The warn is throttled rather than one-shot: it re-fires at
+most once every five minutes per JWKS URL, so a proxy that stays down keeps
+saying so instead of going quiet after the first request.
 
 This is a deliberate trade for a dev tool: a surprising deny is worse than a
 warn plus allow when you are iterating on a handler and a corporate proxy is
@@ -708,14 +715,16 @@ layers are all same-stack references.
 
 ## Container image Lambdas
 
-`lambda.DockerImageFunction` and `Code.ImageUri` are supported on the same terms
-as [`cdkd local invoke`](local-invoke.md). At server boot — and on every
-`--watch` reload — cdkd resolves each container Lambda's image once:
+`lambda.DockerImageFunction` and `Code.ImageUri` are supported. At server boot —
+and on every `--watch` reload — cdkd resolves each container Lambda's image
+once:
 
 - **Local build**, from the `cdk.out` asset manifest when the synthesizer
   produced a matching `dockerImages` entry. `docker build` then runs against the
   recorded build context.
-- **ECR pull**, when no asset matches. Same-account and same-region only.
+- **ECR pull**, when no asset matches. Same-account and same-region only —
+  this command has no `--ecr-role-arn`, so a cross-account registry needs
+  [`cdkd local invoke`](local-invoke.md#container-image-lambdas), which does.
 
 The resulting deterministic `cdkd-local-invoke-<hash>` tag goes into the warm
 pool, which runs it verbatim: no `/var/task` bind mount, no base-image pull, and
@@ -852,7 +861,7 @@ The full cross-command table is in the [CLI Reference](cli-reference.md#exit-cod
 - [`cdkd local start-alb`](local-start-alb.md) — a local Application Load
   Balancer in front of ECS and Lambda backing services
 - [`cdkd local start-cloudfront`](local-start-cloudfront.md) — a local
-  CloudFront distribution over S3 origins and Lambda Function URLs
+  CloudFront distribution over S3 origins, Lambda Function URLs and Lambda@Edge
 - [`cdkd local run-task`](local-run-task.md) — run one ECS task definition
   locally
 - [CLI Reference](cli-reference.md) — every command and the full exit-code table

--- a/docs/local-start-api.md
+++ b/docs/local-start-api.md
@@ -9,7 +9,9 @@ description: "Serve a CDK app's API Gateway routes — REST v1, HTTP API, WebSoc
 Gateway routes in your synthesized CDK app to local Lambda invocations against
 the AWS Lambda Runtime Interface Emulator. Reach for it when you want to
 exercise a whole API — routing, authorizers, CORS, stage variables — against
-real handler code without deploying to AWS.
+real handler code without deploying to AWS. Every route it serves is backed by a
+Lambda; for a front door over running ECS replicas, use
+[`cdkd local start-alb`](local-start-alb.md).
 
 **Docker is required.** The first run pulls the Lambda base image (roughly
 600 MB, once per machine); pass `--no-pull` on later runs to skip the layer
@@ -30,34 +32,34 @@ cdkd local start-api --from-state --stage prod  # resolve env vars from deployed
 | --- | --- | --- |
 | `[target]` | every discovered API | Serve only the named API. See [Target selection](#target-selection). |
 | `--port <port>` | `0` (auto-allocate) | Port for the first server; later servers take `port+1`, `port+2`, and so on. |
-| `--host <host>` | `127.0.0.1` | Bind address for every server. |
+| `--host <host>` | `127.0.0.1` | Bind address for every API server — the address **you** connect to. |
 | `--stack <name>` | single-stack auto-detect | Stack to serve, when neither the target nor `--from-cfn-stack` identifies one. |
 | `--warm` | off | Pre-start one container per routed Lambda at boot, trading RAM for first-request latency. |
 | `--per-lambda-concurrency <n>` | `2` | Container-pool size cap per Lambda. Values above `4` are clamped to `4` with a warn. |
 | `--no-pull` | off | Skip `docker pull` and use the cached base image — see [Local Execution](local-emulation.md#common-flags). |
-| `--container-host <host>` | `127.0.0.1` | Numeric IP the host binds and probes the emulator port on — see [Local Execution](local-emulation.md#common-flags). |
-| `--debug-port-base <port>` | unset | Reserve a contiguous debugger port range, one port per routed Lambda. |
-| `--env-vars <file>` | unset | JSON env-var overrides in SAM's shape — see [Local Execution](local-emulation.md#common-flags). |
-| `--assume-role <arn-or-pair>` | unset | Assume an execution role and forward temporary credentials. See [`--assume-role` and `--assume-role-auto`](#assume-role-and-assume-role-auto). |
+| `--container-host <host>` | `127.0.0.1` | Numeric IP the Lambda **containers'** emulator ports bind to — not where you connect, which is `--host`. See [Local Execution](local-emulation.md#common-flags). |
+| `--debug-port-base <port>` | — | Reserve a contiguous debugger port range, one port per routed Lambda. Every handler blocks until a debugger attaches. See [`--debug-port-base`](#debug-port-base). |
+| `--env-vars <file>` | — | JSON env-var overrides in SAM's shape — see [Local Execution](local-emulation.md#common-flags). |
+| `--assume-role <arn-or-pair>` | — | Assume an execution role and forward temporary credentials. See [`--assume-role` and `--assume-role-auto`](#assume-role-and-assume-role-auto). |
 | `--assume-role-auto` | off | Resolve each routed Lambda's own execution role instead of one global default. |
 | `--watch` | off | Re-synth and re-discover routes when the app source changes. See [`--watch`](#watch). |
 | `--stage <name>` | first attached Stage | Select an API Gateway Stage by `StageName`, per API. See [Stage variables](#stage-variables). |
-| `--api <id>` | unset | Deprecated alias for the positional `[target]`; warns on use and cannot be combined with it. |
-| `--layer-role-arn <arn>` | unset | Role to assume before reading literal-ARN entries in `Properties.Layers`. See [Lambda layers](#lambda-layers). |
+| `--api <id>` | — | Deprecated alias for the positional `[target]`; warns on use and cannot be combined with it. |
+| `--layer-role-arn <arn>` | — | Role to assume before reading literal-ARN entries in `Properties.Layers`. See [Lambda layers](#lambda-layers). |
 | `--from-state` | off | Substitute deployed physical ids from cdkd's S3 state into Lambda env vars. See [`--from-state`](#from-state). |
 | `--from-cfn-stack [cfn-stack-name]` | off | Substitute deployed physical ids from a CloudFormation stack. See [`--from-cfn-stack`](#from-cfn-stack). |
 | `--stack-region <region>` | auto-discovered | Region of the state record to read, and the CloudFormation client region for `--from-cfn-stack` — see [Local Execution](local-emulation.md#common-flags). |
-| `--mtls-truststore <path>` | unset | PEM CA bundle that switches the server to HTTPS with client-certificate verification. See [Mutual TLS](#mutual-tls). |
-| `--mtls-cert <path>` | unset | PEM server certificate. Must be set together with the other two `--mtls-*` flags. |
-| `--mtls-key <path>` | unset | PEM server private key matching `--mtls-cert`. Must be set together with the other two `--mtls-*` flags. |
+| `--mtls-truststore <path>` | — | PEM CA bundle that switches the server to HTTPS with client-certificate verification. See [Mutual TLS](#mutual-tls). |
+| `--mtls-cert <path>` | — | PEM server certificate. Must be set together with the other two `--mtls-*` flags. |
+| `--mtls-key <path>` | — | PEM server private key matching `--mtls-cert`. Must be set together with the other two `--mtls-*` flags. |
 | `--strict-sigv4` | off | Deny requests whose `AWS_IAM` SigV4 signature cannot be verified. See [`--strict-sigv4`](#strict-sigv4). |
 | `--verbose` | off | Verbose logging. |
-| `--profile <profile>` | unset | AWS profile for cdkd's own AWS calls and for the credentials handed to containers. |
+| `--profile <profile>` | — | AWS profile for cdkd's own AWS calls and for the credentials handed to containers. |
 | `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for cdkd's own AWS API calls, such as state and CloudFormation reads. |
 | `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
 | `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a pre-synthesized cloud assembly directory — see [Local Execution](local-emulation.md#common-flags). |
 | `--output <path>` | `cdk.out` | Output directory for synthesis. |
-| `-c`, `--context <key=value...>` | unset | Set a CDK context value. Repeatable. |
+| `-c`, `--context <key=value...>` | — | Set a CDK context value. Repeatable. |
 | `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Read only with `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Read only with `--from-state`. |
 
@@ -199,12 +201,48 @@ Incremental delivery only shows up against the deployed Lambda runtime.
 
 All four non-`AWS_PROXY` REST v1 integration types are emulated end to end.
 
-| Type | Behaviour | Notes |
-| --- | --- | --- |
-| `MOCK` | Renders `Integration.RequestTemplates['application/json']` to extract `{"statusCode": N}`, matches it against `IntegrationResponses[].StatusCode`, then renders that entry's `ResponseTemplates[<content-type>]` against an empty input context. | With no request template, the entry with no `SelectionPattern` is used. Literal `ResponseParameters` headers apply; mapping expressions (`integration.response.*` / `context.*`) are skipped with a warn. |
-| `HTTP_PROXY` | Forwards the request to `Integration.Uri` with `{paramName}` path substitution, honouring `Integration.IntegrationHttpMethod`. | Body is forwarded verbatim. `IntegrationResponses[].SelectionPattern` (a regex against the upstream status as a string) drives the final status; `ResponseParameters` applies. Header mappings (`'literal'` / `method.request.header.X`) apply; querystring and path mappings are recognized but skipped — use `{param}` URI substitution instead. |
-| `HTTP` | `HTTP_PROXY` plus VTL in both directions: `RequestTemplates[<content-type>]` transforms the outgoing body, `IntegrationResponses[].ResponseTemplates[<content-type>]` transforms the upstream body. | Same `RequestParameters` semantics as `HTTP_PROXY`. |
-| `AWS` (Lambda non-proxy) | The VTL request template builds the Lambda event payload — parsed as JSON when the rendered template is valid JSON, otherwise passed through as a string, matching deployed behaviour. The Lambda runs in the same warm container pool as `AWS_PROXY`. | The error envelope (`{errorMessage, errorType?, stackTrace?}`) routes through `SelectionPattern` matched against `errorMessage`. The response template runs with `$inputRoot` set to the parsed Lambda return value. |
+| Type | One-line summary |
+| --- | --- |
+| `MOCK` | Answers from templates alone; no upstream call. |
+| `HTTP_PROXY` | Forwards the request to `Integration.Uri` verbatim. |
+| `HTTP` | `HTTP_PROXY` plus VTL in both directions. |
+| `AWS` (Lambda non-proxy) | Builds the Lambda event from a VTL template and transforms the return value. |
+
+### `MOCK`
+
+Renders `Integration.RequestTemplates['application/json']` to extract
+`{"statusCode": N}`, matches it against `IntegrationResponses[].StatusCode`,
+then renders that entry's `ResponseTemplates[<content-type>]` against an empty
+input context. With no request template, the entry carrying no
+`SelectionPattern` is used. Literal `ResponseParameters` headers apply; mapping
+expressions (`integration.response.*` / `context.*`) are skipped with a warn.
+
+### `HTTP_PROXY`
+
+Forwards the request to `Integration.Uri` with `{paramName}` path substitution,
+honouring `Integration.IntegrationHttpMethod`. The body is forwarded verbatim.
+`IntegrationResponses[].SelectionPattern` — a regex matched against the upstream
+status as a string — drives the final status, and `ResponseParameters` applies.
+Header mappings (`'literal'` / `method.request.header.X`) apply; querystring and
+path mappings are recognized but skipped, so use `{param}` URI substitution
+instead.
+
+### `HTTP`
+
+`HTTP_PROXY` plus VTL in both directions: `RequestTemplates[<content-type>]`
+transforms the outgoing body, and
+`IntegrationResponses[].ResponseTemplates[<content-type>]` transforms the
+upstream body. `RequestParameters` behaves exactly as under `HTTP_PROXY`.
+
+### `AWS` (Lambda non-proxy)
+
+The VTL request template builds the Lambda event payload — parsed as JSON when
+the rendered template is valid JSON, and otherwise passed through as a string,
+matching deployed behaviour. The Lambda runs in the same warm container pool as
+`AWS_PROXY`. The error envelope (`{errorMessage, errorType?, stackTrace?}`)
+routes through `SelectionPattern` matched against `errorMessage`, and the
+response template runs with `$inputRoot` bound to the parsed Lambda return
+value.
 
 `AWS` integrations pointing at a non-Lambda service are not emulated; they
 surface as unsupported 501 routes. Deploy to AWS, or point an `HTTP_PROXY`
@@ -360,18 +398,33 @@ state to resolve them against.
 
 Four authorizer kinds run in front of any discovered route.
 
-| Kind | Declared as | Identity source | Allow | Deny |
-| --- | --- | --- | --- | --- |
-| Lambda TOKEN (REST v1) | `AWS::ApiGateway::Authorizer` with `Type: 'TOKEN'` | The header named by `IdentitySource`, defaulting to `method.request.header.Authorization`, forwarded as `event.authorizationToken` | Context flattened under `event.requestContext.authorizer` | HTTP 403 on policy deny; HTTP 401 without invoking the Lambda when the identity header is missing |
-| Lambda REQUEST | `Type: 'REQUEST'` (REST v1) or `AuthorizerType: 'REQUEST'` (HTTP v2) | The full request snapshot — headers, query string, path parameters | Context under `event.requestContext.authorizer` | REST v1 returns HTTP 401 without invoking the Lambda when identity is missing; HTTP v2 falls through |
-| Cognito User Pool (REST v1) | `Type: 'COGNITO_USER_POOLS'` | `Authorization: Bearer <token>`, verified against the pool's published JWKS | Claims under `event.requestContext.authorizer.claims` | HTTP 403 |
-| JWT (HTTP v2) | `AuthorizerType: 'JWT'` | `Authorization: Bearer <token>`, verified against the issuer's JWKS with `aud` / `client_id` matched against `JwtConfiguration.Audience` | Claims under `event.requestContext.authorizer.jwt.claims` | HTTP 401 |
+| Kind | Declared as | Identity source |
+| --- | --- | --- |
+| Lambda TOKEN (REST v1) | `AWS::ApiGateway::Authorizer` with `Type: 'TOKEN'` | The header named by `IdentitySource`, defaulting to `method.request.header.Authorization`, forwarded as `event.authorizationToken`. |
+| Lambda REQUEST | `Type: 'REQUEST'` (REST v1) or `AuthorizerType: 'REQUEST'` (HTTP v2) | The full request snapshot — headers, query string, path parameters. |
+| Cognito User Pool (REST v1) | `Type: 'COGNITO_USER_POOLS'` | `Authorization: Bearer <token>`, verified against the pool's published JWKS. |
+| JWT (HTTP v2) | `AuthorizerType: 'JWT'` | `Authorization: Bearer <token>`, verified against the issuer's JWKS, with `aud` / `client_id` matched against `JwtConfiguration.Audience`. |
+
+What each one does with the verdict:
+
+| Kind | On allow | On deny |
+| --- | --- | --- |
+| Lambda TOKEN (REST v1) | Context flattened under `event.requestContext.authorizer`. | HTTP 403 on a policy deny; HTTP 401 without invoking the Lambda when the identity header is missing. |
+| Lambda REQUEST | Context under `event.requestContext.authorizer`. | REST v1 returns HTTP 401 without invoking the Lambda when identity is missing; HTTP v2 falls through. |
+| Cognito User Pool (REST v1) | Claims under `event.requestContext.authorizer.claims`. | HTTP 403. |
+| JWT (HTTP v2) | Claims under `event.requestContext.authorizer.jwt.claims`. | HTTP 401. |
 
 A TOKEN authorizer's response must carry a `policyDocument` with at least one
 `{ Effect: 'Allow', Resource: <methodArn> }` statement. cdkd matches `Resource`
 against the request's method ARN — literally, or with `*` / `?` wildcards — on
 every request, and re-evaluates cached verdicts against the new method ARN, so
 a narrow-`Resource` Allow does not leak across routes.
+
+A REQUEST authorizer on an HTTP API v2 route may answer in either shape: the
+IAM-style `policyDocument`, or API Gateway's simple format
+`{ "isAuthorized": true|false, "context": { ... } }`. cdkd reads the simple
+format when `isAuthorized` is a boolean and falls back to the policy parse
+otherwise.
 
 Any other `Type` or `AuthorizerType` is a hard error at discovery, with the
 offending route's location named.
@@ -577,7 +630,7 @@ the default location.
 
 ### `--from-cfn-stack`
 
-Reads a deployed CloudFormation stack through `DescribeStackResources` and
+Reads a deployed CloudFormation stack through `ListStackResources` and
 substitutes `Ref` and `Fn::ImportValue` in Lambda env vars with the deployed
 physical ids and exports. Use it for CDK apps deployed with the upstream CDK
 CLI.
@@ -691,6 +744,16 @@ VPC-only endpoint will fail. Each affected Lambda gets a warn line at startup:
 AWS SDK calls from the container still use your shell credentials, or the
 temporary credentials `--assume-role` issued, and reach the public AWS
 endpoints; nothing about that path changes.
+
+## `--debug-port-base`
+
+`--debug-port-base <port>` allocates one debugger port per routed Lambda,
+`port`, `port+1`, `port+2`, in the order the routes were discovered, and sets
+`NODE_OPTIONS=--inspect-brk=0.0.0.0:<port>` on each container.
+
+`--inspect-brk` **suspends the handler until a debugger attaches**, so every
+route hangs until you connect to that Lambda's port. Serve a single API while
+debugging, and read the boot log to see which port each Lambda received.
 
 ## `--watch`
 

--- a/docs/local-start-api.md
+++ b/docs/local-start-api.md
@@ -1,410 +1,398 @@
 ---
-title: local start-api
-description: "Serve synthesized API Gateway routes (REST v1, HTTP API, Function URL) as long-running local HTTP servers backed by a warm Lambda container pool."
+title: cdkd local start-api
+description: "Serve a CDK app's API Gateway routes — REST v1, HTTP API, WebSocket, Function URL — as long-running local HTTP servers backed by a warm Lambda container pool."
 ---
 
-# `local start-api` (long-running local API server)
+# cdkd local start-api
 
-`cdkd local start-api` stands up a long-running HTTP server that maps
-synthesized API Gateway routes (REST v1, HTTP API, Function URL) to
-local Lambda invocations against the AWS Lambda Runtime Interface
-Emulator. Modeled on `sam local start-api` but reusing cdkd's
-synthesis, asset, and route-discovery plumbing — no `template.yaml`
-round-trip.
+`cdkd local start-api` stands up long-running HTTP servers that map the API
+Gateway routes in your synthesized CDK app to local Lambda invocations against
+the AWS Lambda Runtime Interface Emulator. Reach for it when you want to
+exercise a whole API — routing, authorizers, CORS, stage variables — against
+real handler code without deploying to AWS.
 
-**Requires Docker.** As with `cdkd local invoke`, the first run pulls
-the Lambda base image (~600MB once per machine). Pass `--no-pull` on
-subsequent runs to skip the layer check.
+**Docker is required.** The first run pulls the Lambda base image (roughly
+600 MB, once per machine); pass `--no-pull` on later runs to skip the layer
+check.
 
 ```bash
-cdkd local start-api                              # auto-allocate one port PER discovered API
-cdkd local start-api --port 3000                  # first API → 3000, second API → 3001, ...
-cdkd local start-api MyAdminApi                   # logical id (single-stack apps)
-cdkd local start-api MyStack/MyAdminApi           # OR: CDK Construct path (prefix-matched)
-cdkd local start-api --warm                       # pre-start one container per Lambda
+cdkd local start-api                            # one server per discovered API, ports auto-allocated
+cdkd local start-api --port 3000                # first API on 3000, second on 3001, ...
+cdkd local start-api MyAdminApi                 # serve only the named API (single-stack apps)
+cdkd local start-api MyStack/MyAdminApi         # ... or address it by CDK Construct path
+cdkd local start-api --warm --watch             # pre-start containers, re-synth on source edits
+cdkd local start-api --from-state --stage prod  # resolve env vars from deployed cdkd state
 ```
 
-### One server per API (v0.81+)
+## Options
 
-Every discovered API surface (`AWS::ApiGatewayV2::Api`,
-`AWS::ApiGateway::RestApi`, `AWS::Lambda::Url`) gets its own HTTP
-server on its own port. cdkd prints one `Server listening on
-http://<host>:<port>  (<API> (<kind>))` line per server at startup,
-and one route table per server underneath.
+| Flag | Default | Description |
+| --- | --- | --- |
+| `[target]` | every discovered API | Serve only the named API. See [Target selection](#target-selection). |
+| `--port <port>` | `0` (auto-allocate) | Port for the first server; later servers take `port+1`, `port+2`, and so on. |
+| `--host <host>` | `127.0.0.1` | Bind address for every server. |
+| `--stack <name>` | single-stack auto-detect | Stack to serve, when neither the target nor `--from-cfn-stack` identifies one. |
+| `--warm` | off | Pre-start one container per routed Lambda at boot, trading RAM for first-request latency. |
+| `--per-lambda-concurrency <n>` | `2` | Container-pool size cap per Lambda. Values above `4` are clamped to `4` with a warn. |
+| `--no-pull` | off | Skip `docker pull` and use the cached base image — see [Local Execution](local-emulation.md#common-flags). |
+| `--container-host <host>` | `127.0.0.1` | Numeric IP the host binds and probes the emulator port on — see [Local Execution](local-emulation.md#common-flags). |
+| `--debug-port-base <port>` | unset | Reserve a contiguous debugger port range, one port per routed Lambda. |
+| `--env-vars <file>` | unset | JSON env-var overrides in SAM's shape — see [Local Execution](local-emulation.md#common-flags). |
+| `--assume-role <arn-or-pair>` | unset | Assume an execution role and forward temporary credentials. See [`--assume-role` and `--assume-role-auto`](#assume-role-and-assume-role-auto). |
+| `--assume-role-auto` | off | Resolve each routed Lambda's own execution role instead of one global default. |
+| `--watch` | off | Re-synth and re-discover routes when the app source changes. See [`--watch`](#watch). |
+| `--stage <name>` | first attached Stage | Select an API Gateway Stage by `StageName`, per API. See [Stage variables](#stage-variables). |
+| `--api <id>` | unset | Deprecated alias for the positional `[target]`; warns on use and cannot be combined with it. |
+| `--layer-role-arn <arn>` | unset | Role to assume before reading literal-ARN entries in `Properties.Layers`. See [Lambda layers](#lambda-layers). |
+| `--from-state` | off | Substitute deployed physical ids from cdkd's S3 state into Lambda env vars. See [`--from-state`](#from-state). |
+| `--from-cfn-stack [cfn-stack-name]` | off | Substitute deployed physical ids from a CloudFormation stack. See [`--from-cfn-stack`](#from-cfn-stack). |
+| `--stack-region <region>` | auto-discovered | Region of the state record to read, and the CloudFormation client region for `--from-cfn-stack` — see [Local Execution](local-emulation.md#common-flags). |
+| `--mtls-truststore <path>` | unset | PEM CA bundle that switches the server to HTTPS with client-certificate verification. See [Mutual TLS](#mutual-tls). |
+| `--mtls-cert <path>` | unset | PEM server certificate. Must be set together with the other two `--mtls-*` flags. |
+| `--mtls-key <path>` | unset | PEM server private key matching `--mtls-cert`. Must be set together with the other two `--mtls-*` flags. |
+| `--strict-sigv4` | off | Deny requests whose `AWS_IAM` SigV4 signature cannot be verified. See [`--strict-sigv4`](#strict-sigv4). |
+| `--verbose` | off | Verbose logging. |
+| `--profile <profile>` | unset | AWS profile for cdkd's own AWS calls and for the credentials handed to containers. |
+| `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for cdkd's own AWS API calls, such as state and CloudFormation reads. |
+| `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
+| `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a pre-synthesized cloud assembly directory — see [Local Execution](local-emulation.md#common-flags). |
+| `--output <path>` | `cdk.out` | Output directory for synthesis. |
+| `-c`, `--context <key=value...>` | unset | Set a CDK context value. Repeatable. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Read only with `--from-state`. |
+| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Read only with `--from-state`. |
 
-This is a deliberate departure from `sam local start-api`'s
-single-server-per-template model: realistic CDK apps usually define
-multiple APIs (admin + public, internal + external) with different
-authorizer setups, different CORS configs, and overlapping paths.
-Lumping them into one server forced an awkward "first-match-wins"
-semantic that didn't mirror AWS Lambda's actual routing. Pre-v0.81
-versions did this.
+## Target selection
 
-Port assignment:
+Passing a positional target launches exactly one server, for the named API.
+The same target syntax works across `cdkd local invoke`, `cdkd local run-task`
+and this command.
+
+| Form | Example | Notes |
+| --- | --- | --- |
+| Bare logical id | `MyHttpApi` | Single-stack apps only; multi-stack apps are rejected with a disambiguation hint. |
+| Stack-qualified logical id | `MyStack:MyHttpApi` | Works in any app; required when the same bare id exists in two stacks. |
+| CDK Construct path | `MyStack/MyHttpApi/Resource` | Exact match against the resource's `aws:cdk:path` metadata. |
+| Construct path prefix | `MyStack/MyHttpApi` | Matches when the input is a strict ancestor of the resource's `aws:cdk:path`. |
+
+The logical id is the HTTP API's or REST API's own logical id. For Function
+URLs it is the **backing Lambda's** logical id, and the path forms reference
+the backing Lambda's `aws:cdk:path` rather than the auto-generated URL
+resource — so `cdkd local start-api MyStack/MyHandler` matches the Function URL
+declared by `new lambda.Function(this, 'MyHandler').addFunctionUrl()`.
+
+The path prefix form exists because CDK synthesizes the L1 child one level
+down: `new apigw2.HttpApi(stack, 'MyHttpApi')` lands at
+`MyStack/MyHttpApi/Resource`, and `MyStack/MyHttpApi` resolves it without you
+having to type the `/Resource` suffix.
+
+Routes from templates with no `aws:cdk:path` metadata — hand-rolled `CfnResource`
+definitions, for instance — still match by bare logical id and by
+stack-qualified logical id. Only the two path forms need the metadata.
+
+`--api <id>` is a deprecated alias accepting the same four forms. It warns on
+use, cannot be combined with the positional target, and will be removed in a
+future major release.
+
+## Servers and ports
+
+Every discovered API surface gets its own HTTP server on its own port:
+`AWS::ApiGatewayV2::Api` (HTTP and WebSocket), `AWS::ApiGateway::RestApi`, and
+`AWS::Lambda::Url`. cdkd prints one route table per server, then one listening
+line per server:
+
+```text
+MyPublicApi (HTTP API)  (http://127.0.0.1:3000)
+  GET  /items      -> ItemsHandler   (HTTP API)
+  POST /admin      -> [501 Not Implemented]  (HTTP API)
+
+Server listening on http://127.0.0.1:3000  (MyPublicApi (HTTP API))
+Server listening on http://127.0.0.1:3001  (MyAdminApi (REST API))
+Server listening on ws://127.0.0.1:3002/prod  (MyChatApi (WebSocket API))
+^C to stop and clean up containers.
+```
 
 | `--port` value | Per-API port allocation |
 | --- | --- |
 | `0` (default) | Every server auto-allocates its own port. |
-| `3000` | First API → `3000`, second API → `3001`, third → `3002`, ... |
+| `3000` | First API on `3000`, second on `3001`, third on `3002`, and so on. |
 
-Pass an optional positional `<target>` to launch exactly one server
-for the named API. The same target syntax `cdkd local invoke` /
-`cdkd local run-task` use applies here — the whole `cdkd local *`
-family addresses resources consistently:
+One server per API rather than one server per template is a deliberate
+departure from `sam local start-api`. Real CDK apps usually define several APIs
+— admin and public, internal and external — with different authorizer setups,
+different CORS configuration and overlapping paths; serving them from a single
+port forces a first-match-wins semantic that does not mirror AWS routing.
 
-1. **Bare logical id** — `MyHttpApi`. **Single-stack apps only**;
-   in multi-stack apps cdkd rejects this form with the same
-   disambiguation hint `local invoke` / `local run-task` produce.
-   The id is the HTTP API / REST API logical id, or (for Function
-   URLs) the backing Lambda's logical id.
-2. **Stack-qualified logical id** — `MyStack:MyHttpApi`. Works in
-   any app size; required when the same bare id exists in two stacks.
-3. **CDK Construct path / display path** — `MyStack/MyHttpApi/Resource`.
-   Exact match against the resource's `aws:cdk:path` metadata.
-4. **CDK Construct path prefix** — `MyStack/MyHttpApi`. Matches when
-   the input is a strict ancestor of the resource's `aws:cdk:path`
-   (same prefix rule `cdkd orphan` uses): CDK's
-   `new apigw2.HttpApi(stack, 'MyHttpApi')` synthesizes the L1 child
-   at `MyStack/MyHttpApi/Resource`, so `cdkd local start-api MyStack/MyHttpApi`
-   resolves cleanly without having to type the synthesized
-   `/Resource` suffix.
+Changed in v0.81: earlier releases served every API from one port.
 
-For Function URLs, the path forms reference the **backing Lambda's**
-`aws:cdk:path`, not the auto-generated URL resource — so
-`cdkd local start-api MyStack/MyHandler` matches the Function URL
-declared by `new lambda.Function(this, 'MyHandler').addFunctionUrl()`.
+## Route discovery
 
-Routes from templates without `aws:cdk:path` metadata (hand-rolled
-`cfn.Resource` defs, or older CDK that didn't emit the metadata)
-still match by bare logical id (form 1) and by stack-qualified logical
-id (form 2) — only the path forms (3, 4) need the metadata.
+### Sources
 
-**Deprecated `--api <id>` alias.** Earlier versions used a `--api`
-flag for the same purpose. The flag is still accepted in this release
-(emitting a deprecation warn on use) and accepts the same four forms;
-it will be removed in a future major release. Migrate scripts /
-CI to the positional form. Passing both positional and `--api`
-at once produces an error — they're mutually exclusive.
-
-### Discovered routes
-
-| Source | CFn types |
+| Source | CloudFormation types |
 | --- | --- |
 | HTTP API | `AWS::ApiGatewayV2::Api` (`ProtocolType: HTTP`), `AWS::ApiGatewayV2::Route`, `AWS::ApiGatewayV2::Integration` |
 | REST v1 | `AWS::ApiGateway::RestApi`, `AWS::ApiGateway::Resource`, `AWS::ApiGateway::Method`, `AWS::ApiGateway::Stage` |
+| WebSocket API | `AWS::ApiGatewayV2::Api` (`ProtocolType: WEBSOCKET`), `AWS::ApiGatewayV2::Route`, `AWS::ApiGatewayV2::Integration` |
 | Function URL | `AWS::Lambda::Url` |
 
-Per-route classification (boot never aborts on per-integration
-unsupportedness):
+### Per-route classification
 
-| Class | Trigger | Behavior |
+Boot never aborts because one integration is unsupported. Each discovered route
+lands in one of these classes:
+
+| Class | Trigger | Behaviour |
 | --- | --- | --- |
-| Normal AWS_PROXY | AWS_PROXY integration with a resolvable Lambda Arn | Dispatched to the Lambda via the container pool. |
-| Synthetic CORS preflight | REST v1 `HttpMethod: OPTIONS` + `Integration.Type: MOCK` + `IntegrationResponses[].ResponseParameters` carries literal `method.response.header.*` pairs (the shape CDK's `defaultCorsPreflightOptions` synthesizes) | Captured at boot. The HTTP server returns the captured status + headers directly on OPTIONS without invoking any Lambda. |
-| Streaming Function URL | `AWS::Lambda::Url` with `InvokeMode: RESPONSE_STREAM` | Dispatched via the RIE streaming protocol: the request goes out with `Lambda-Runtime-Function-Response-Mode: streaming` and the response body's JSON prelude (`{statusCode, headers, cookies?}` + an 8-NULL-byte separator + raw body) is parsed; the body Readable is piped to the HTTP client with `Transfer-Encoding: chunked`. Note: AWS's local RIE buffers the response (verified empirically against `public.ecr.aws/lambda/nodejs:20`), so curl observes the chunks in one block locally even though cdkd's pipe / chunked-encoding machinery works correctly — real incremental delivery only manifests against the deployed Lambda runtime. |
-| REST v1 non-AWS_PROXY | `Integration.Type` is one of `MOCK` (non-CORS-preflight), `HTTP_PROXY`, `HTTP`, or `AWS` (Lambda non-proxy). | Dispatched via the per-kind handler in `src/local/rest-v1-integrations.ts`. MOCK / HTTP / AWS apply VTL request + response templates via the hand-rolled engine at `src/local/vtl-engine.ts`. HTTP_PROXY forwards verbatim with `RequestParameters` mappings. AWS Lambda non-proxy uses the same container pool as AWS_PROXY but transforms event payload + response via VTL and routes errors through `IntegrationResponses[].SelectionPattern`. |
-| Deferred-error unsupported | REST v1 AWS integration targeting a non-Lambda service (`:s3:path/...` / `:sqs:action/...` etc.); HTTP_PROXY / HTTP with a non-literal `Uri` (cdkd does not resolve Fn::Sub / Fn::Join in HTTP Uris); HTTP API v2 service integrations (`IntegrationSubtype` set); WebSocket APIs (`ProtocolType: WEBSOCKET`); Function URLs with an unrecognized `AuthType` (anything other than `'NONE'` / `'AWS_IAM'`); routes whose Lambda Arn intrinsic cannot be resolved against the same template (cross-stack / imported references) | Boot continues. The route appears in the route table tagged `[501 Not Implemented]` and a `[warn]` line per route is printed up front. When the route is hit at request time, the HTTP server returns HTTP 501 with `{"message": "Not Implemented", "reason": "<the discovery reason>"}` in the JSON body, without invoking any Lambda. |
-| Hard error | Template-structural problems the discovery layer cannot generate a meaningful route from: missing `Integration` on a Method, non-Ref `RestApiId` / `ApiId`, malformed Route `Target`, ParentId chain failures, missing `PathPart`, unresolvable `TargetFunctionArn` on a Function URL | Boot aborts via `RouteDiscoveryError` with every offending route listed in a single message. |
+| AWS_PROXY | `AWS_PROXY` integration with a resolvable Lambda ARN | Dispatched to the Lambda through the container pool. |
+| Synthetic CORS preflight | REST v1 `OPTIONS` method with a `MOCK` integration whose `IntegrationResponses[].ResponseParameters` carry literal `method.response.header.*` pairs | Captured at boot; the server answers `OPTIONS` with the captured status and headers, invoking no Lambda. |
+| Streaming Function URL | `AWS::Lambda::Url` with `InvokeMode: RESPONSE_STREAM` | Dispatched over the emulator's streaming protocol and piped to the client with `Transfer-Encoding: chunked`. See [Streaming Function URLs](#streaming-function-urls). |
+| REST v1 non-AWS_PROXY | `Integration.Type` is `MOCK` (not a CORS preflight), `HTTP_PROXY`, `HTTP`, or `AWS` | Dispatched by the matching per-kind handler. See [REST v1 integration types](#rest-v1-integration-types). |
+| Unsupported integration | An integration shape cdkd does not emulate | Boot continues. The route is tagged `[501 Not Implemented]` in the route table, a warn line names it up front, and a request to it returns HTTP 501 without invoking any Lambda. |
+| Hard error | A template-structural problem discovery cannot build a route from | Boot aborts, with every offending route listed in one message. |
 
-The deferred-error class lets you run the supported subset of an API
-locally even when the CDK app contains direct AWS-service integrations,
-WebSocket routes, or other unimplemented shapes — only the unsupported
-routes themselves return 501; everything else dispatches as normal.
+A route lands in the unsupported class when it is:
 
-### REST v1 non-AWS_PROXY integrations
+- A REST v1 `AWS` integration targeting a non-Lambda service (`:s3:path/...`,
+  `:sqs:action/...`, and so on).
+- An `HTTP_PROXY` or `HTTP` integration whose `Uri` is not a literal — cdkd
+  does not resolve `Fn::Sub` / `Fn::Join` inside integration URIs.
+- An HTTP API v2 service integration (one that sets `IntegrationSubtype`).
+- A Function URL with an `AuthType` other than `NONE` or `AWS_IAM`.
+- A route whose Lambda ARN intrinsic cannot be resolved against the same
+  template, such as a cross-stack or imported reference.
 
-`cdkd local start-api` emulates all four non-AWS_PROXY REST v1
-integration types end-to-end:
+The 501 body names the reason:
 
-| Type | Behavior | Notes |
-| --- | --- | --- |
-| `MOCK` | Renders `Integration.RequestTemplates['application/json']` (VTL) to extract `{"statusCode": N}`; matches against `IntegrationResponses[].StatusCode`; renders the picked entry's `ResponseTemplates[<content-type>]` (VTL) against an empty input context (`$inputRoot = null`). | When no request template is set, defaults to the entry with no `SelectionPattern`. `ResponseParameters` header literals (`'value'`) apply; mapping expressions (`integration.response.*` / `context.*`) are warn-and-skipped. |
-| `HTTP_PROXY` | Forwards the HTTP request to `Integration.Uri` with `{paramName}` path-placeholder substitution. Honors `Integration.IntegrationHttpMethod`. Applies `Integration.RequestParameters` (header `'literal'` / `method.request.header.X` mappings; querystring / path mappings are recognized but logged-and-skipped — use `{param}` URI substitution instead). | Forwards the upstream body verbatim. `IntegrationResponses[].SelectionPattern` (regex against the upstream status as a string) drives the final HTTP status; `ResponseParameters` applies. |
-| `HTTP` (non-proxy) | HTTP_PROXY + VTL on both directions: `RequestTemplates[<content-type>]` transforms the body before sending; `IntegrationResponses[].ResponseTemplates[<content-type>]` transforms the upstream body before returning. | Same `RequestParameters` semantics as HTTP_PROXY. |
-| `AWS` (Lambda non-proxy) | VTL request template synthesizes the Lambda event payload (parsed as JSON when the rendered template is valid JSON, otherwise passed through as a string — matches AWS-deployed behavior). The Lambda runs in the same warm RIE container pool as AWS_PROXY. Error envelope (`{errorMessage, errorType?, stackTrace?}`) routes through `SelectionPattern` against `errorMessage`. Response template runs with `$inputRoot = <parsed Lambda return value>`. | Direct AWS-service integrations (`Type: 'AWS'` with `Uri` pointing at `:s3:path/...` / `:sqs:action/...` / etc.) are NOT emulated locally — they surface as deferred-501 unsupported routes. Deploy to AWS or pin a public HTTP_PROXY to a mock service. |
+```json
+{ "message": "Not Implemented", "reason": "<the discovery reason>" }
+```
 
-The VTL engine at [src/local/vtl-engine.ts](https://github.com/go-to-k/cdkd/blob/main/src/local/vtl-engine.ts)
-implements a hand-rolled minimal subset of AWS API Gateway's VTL spec.
-Supported features:
-
-- Variable references: `$var`, `${var}`, `$obj.field.subField`
-- Built-ins:
-  - `$input.body` — raw request body
-  - `$input.json('$.path')` — JSON-stringified slice (primitives JSON-quoted)
-  - `$input.path('$.path')` — native value
-  - `$input.params()` — `{header, querystring, path}` union
-  - `$input.params('name')` — path > query > header precedence
-  - `$input.params('header').<name>` / `.querystring` / `.path`
-  - `$context.requestId` / `httpMethod` / `resourcePath` / `stage`
-  - `$context.identity.sourceIp` / `userAgent`
-  - `$util.escapeJavaScript(s)` / `base64Encode` / `base64Decode` / `urlEncode` / `urlDecode` / `parseJson`
-- Directives: `#set($var = expr)`, `#if(cond)` / `#elseif` / `#else` / `#end`, `#foreach($x in $list)` / `#end`, `##` line comments
-- Operators: `&&`, `||`, `!`, `==`, `!=`, `<`, `<=`, `>`, `>=`
-- JSONPath subset: `$`, `$.field`, `$.field.sub`, `$.array[index]`, quoted-string bracket keys
-
-**Intentionally NOT supported** (any usage surfaces `VtlEvaluationError`
-with the offending construct named in the message — converted to
-HTTP 502 + reason JSON body at request time):
-
-- Velocity arithmetic operators (`+ - * /`) outside literal concat
-- User-defined `#macro`
-- `#parse` / `#include`
-- Range operator (`[1..5]`)
-- `$velocityCount` and other Velocity context built-ins
-- JSONPath filter expressions (`$..items`, `$.items[?(@.x > 5)]`)
+Boot aborts only for structural problems: a Method with no `Integration`, a
+non-`Ref` `RestApiId` / `ApiId`, a malformed Route `Target`, a broken
+`ParentId` chain, a missing `PathPart`, or an unresolvable
+`TargetFunctionArn` on a Function URL.
 
 ### Routing precedence
 
-3 tiers per AWS docs: full match → greedy `{proxy+}` → `$default`.
-Within "full match" tier, more literal segments win as a best-effort
-tie-break (AWS does not formally specify multi-route precedence within
-the same tier; cdkd uses literal-segment count as a heuristic).
+Matching runs in three tiers, following the AWS documented order:
 
-### Flags
+1. Full match on the request path.
+2. Greedy `{proxy+}` match.
+3. `$default`.
 
-| Flag | Default | Notes |
+Within the full-match tier, the route with more literal path segments wins.
+AWS does not formally specify precedence between two routes in the same tier,
+so cdkd uses literal-segment count as the tie-break.
+
+### Streaming Function URLs
+
+A Function URL with `InvokeMode: RESPONSE_STREAM` is invoked with
+`Lambda-Runtime-Function-Response-Mode: streaming`. cdkd parses the response
+body's JSON prelude (`{statusCode, headers, cookies?}`, an eight-NULL-byte
+separator, then the raw body) and pipes the body to the HTTP client with
+`Transfer-Encoding: chunked`.
+
+The local emulator buffers the handler's response, so `curl` observes the whole
+body in one block locally even though the chunked pipe works correctly.
+Incremental delivery only shows up against the deployed Lambda runtime.
+
+## REST v1 integration types
+
+All four non-`AWS_PROXY` REST v1 integration types are emulated end to end.
+
+| Type | Behaviour | Notes |
 | --- | --- | --- |
-| `--port <port>` | auto-allocate | First API server's port (subsequent APIs get `port+1`, `port+2`, ...). Pass `0` (default) to auto-allocate each. The actual port assignment is printed at startup. |
-| `--host <host>` | `127.0.0.1` | Bind address. |
-| `--api <id>` | unset | **Deprecated** — use the positional `<target>` argument instead. Same accepted forms (bare logical id, stack-qualified, Construct path, ancestor prefix). Emits a deprecation warn on use. Mutually exclusive with the positional `<target>` — passing both produces an error. Will be removed in a future major release. |
-| `--stack <name>` | single-stack auto-detect | Required when the app has multiple stacks AND no other selector identifies the target. In multi-stack apps the synth stack is picked from the first match of: (1) `--stack <name>`, (2) `--from-cfn-stack <explicit-name>`, (3) the positional target's stack-name prefix (e.g. `MyStack/MyApi` → `MyStack`). |
-| `--warm` | off | Pre-start one container per discovered Lambda at server boot. Trades RAM for first-request latency. |
-| `--per-lambda-concurrency <n>` | `2` | Pool size cap per Lambda. Max 4 in v1; above-cap values are clamped with a warn. |
-| `--no-pull` | off | Skip `docker pull`. |
-| `--container-host <host>` | `127.0.0.1` | IP the host uses to bind/probe the RIE port. Must be a numeric IP — `docker run -p <ip>:<port>:8080` rejects hostnames like `host.docker.internal`. |
-| `--debug-port-base <port>` | unset | Allocate a contiguous `--inspect-brk` port range across Lambdas (one per Lambda). |
-| `--env-vars <file>` | unset | SAM-shape JSON: `{"LogicalId":{"KEY":"VALUE"}, "Parameters":{...}}`. Same format as `cdkd local invoke` — the function-specific key may also be a **CDK display path** (`MyStack/MyHandler`). |
-| `--assume-role <arn-or-pair>` | unset | Repeatable. Bare `<arn>` = global default; `<LogicalId>=<arn>` = per-Lambda override. Per-Lambda > global > (`--assume-role-auto` OR global default) > unset (developer creds passed through). |
-| `--assume-role-auto` | off | Auto-resolve EACH routed Lambda's OWN execution role per-Lambda instead of a single global default: tries the synthesized template's literal-ARN `Properties.Role`, then a deployed-state lookup (pair with `--from-state` / `--from-cfn-stack`), then warns-and-passes-through dev creds on a miss. Slower boot (one STS call per Lambda) but the right shape when each Lambda's deployed role differs. **Mutually exclusive** with the global-default `--assume-role <arn>` form (errors at boot); **compatible** with per-Lambda `--assume-role <LogicalId>=<arn>` overrides (the map wins for named Lambdas, auto-resolve handles the rest). |
-| `--layer-role-arn <arn>` | — | Role to `sts:AssumeRole` before calling `lambda:GetLayerVersion` on every literal-ARN entry in `Properties.Layers`. Use only when the developer's own credentials cannot read the layer — typically a cross-account layer. AWS-published public layers (e.g. Lambda Powertools) are readable from every account and need no role. No-op for stacks whose layers are all same-stack `AWS::Lambda::LayerVersion` references. |
-| `--watch` | off | Hot reload: watch the CDK app **source tree** (the synth working directory, where `cdk.json` lives) and re-synth + re-discover routes on a source edit, mirroring `cdk watch`. `cdk.out` / `node_modules` / `.git` are excluded and `cdk.json`'s `watch.include` / `watch.exclude` are honored. 500ms debounce. Synth failures keep the previous version serving (warn-and-continue, never crashes the server). |
-| `--stage <name>` | first attached | Select an API Gateway Stage by `StageName`. Drives `event.stageVariables` (REST v1 + HTTP API v2). When the override doesn't match any Stage on a given API, that API's routes get `stageVariables: null` and the CLI emits a warn line up front. |
-| `--from-state` | off | Read cdkd S3 state for every routed stack and substitute `Ref` / `Fn::GetAtt` / `Fn::Sub` / `Fn::Join` placeholders + AWS pseudo parameters (`${AWS::AccountId}` / `${AWS::Region}` / `${AWS::Partition}` / `${AWS::URLSuffix}`) in Lambda env vars with the deployed physical IDs / attributes. Off by default — keeps the pre-PR literal-only / warn-and-drop behavior. Mirrors `cdkd local invoke --from-state` and `cdkd local run-task --from-state`. Re-runs against fresh state on every hot-reload firing (`--watch`). State load failures degrade per-stack to warn-and-fall-back so a missing or unreadable state file never aborts the server. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `DescribeStackResources` and substitute `Ref` / `Fn::ImportValue` in Lambda env vars with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). **The bare form is the typical shape** — `cdkd local start-api MyStack/MyApi --from-cfn-stack` resolves to the routed stack's CDK name (`MyStack` here) per routed stack. Pass an explicit value (`--from-cfn-stack <name>`) only when the deployed CFn stack name differs from the CDK stack name (e.g. CDK's `stackName` prop was overridden); the explicit form is rejected when more than one stack is routed in one invocation. **Mutually exclusive with `--from-state`**. `Fn::GetAtt` in a consumer Lambda's own env vars is recovered from the deployed function config (`cdk-local@0.10.0`); other `Fn::GetAtt` sites still warn-and-drop. Same semantics as `cdkd local invoke --from-cfn-stack`. |
-| `--state-bucket <bucket>` | auto | S3 bucket containing cdkd state. Falls back to `CDKD_STATE_BUCKET` env or `cdk.json context.cdkd.stateBucket`, then the default `cdkd-state-{accountId}`. Only used with `--from-state`. |
-| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Only used with `--from-state`. |
-| `--stack-region <region>` | auto | Region of the state record to read. Required for `--from-state` when the same stack name has state in multiple regions. Also drives the CFn client region for `--from-cfn-stack`. |
-| `--mtls-truststore <path>` | unset | PEM-encoded CA bundle for client-certificate verification. When set, the server switches from HTTP to HTTPS and the TLS handshake rejects clients whose certificate doesn't chain to one of these CAs. Must be set together with `--mtls-cert` + `--mtls-key`; partial flag sets are rejected. See the "mTLS (mutual TLS)" section below for the openssl recipe + event-shape details. |
-| `--mtls-cert <path>` | unset | PEM-encoded server certificate for mutual TLS. Self-signed is fine for local dev. Must be set together with `--mtls-truststore` + `--mtls-key`. |
-| `--mtls-key <path>` | unset | PEM-encoded server private key matching `--mtls-cert`. Must be set together with `--mtls-truststore` + `--mtls-cert`. |
+| `MOCK` | Renders `Integration.RequestTemplates['application/json']` to extract `{"statusCode": N}`, matches it against `IntegrationResponses[].StatusCode`, then renders that entry's `ResponseTemplates[<content-type>]` against an empty input context. | With no request template, the entry with no `SelectionPattern` is used. Literal `ResponseParameters` headers apply; mapping expressions (`integration.response.*` / `context.*`) are skipped with a warn. |
+| `HTTP_PROXY` | Forwards the request to `Integration.Uri` with `{paramName}` path substitution, honouring `Integration.IntegrationHttpMethod`. | Body is forwarded verbatim. `IntegrationResponses[].SelectionPattern` (a regex against the upstream status as a string) drives the final status; `ResponseParameters` applies. Header mappings (`'literal'` / `method.request.header.X`) apply; querystring and path mappings are recognized but skipped — use `{param}` URI substitution instead. |
+| `HTTP` | `HTTP_PROXY` plus VTL in both directions: `RequestTemplates[<content-type>]` transforms the outgoing body, `IntegrationResponses[].ResponseTemplates[<content-type>]` transforms the upstream body. | Same `RequestParameters` semantics as `HTTP_PROXY`. |
+| `AWS` (Lambda non-proxy) | The VTL request template builds the Lambda event payload — parsed as JSON when the rendered template is valid JSON, otherwise passed through as a string, matching deployed behaviour. The Lambda runs in the same warm container pool as `AWS_PROXY`. | The error envelope (`{errorMessage, errorType?, stackTrace?}`) routes through `SelectionPattern` matched against `errorMessage`. The response template runs with `$inputRoot` set to the parsed Lambda return value. |
 
-### Hot reload (`--watch`)
+`AWS` integrations pointing at a non-Lambda service are not emulated; they
+surface as unsupported 501 routes. Deploy to AWS, or point an `HTTP_PROXY`
+integration at a mock service.
 
-When `--watch` is set, cdkd installs a [chokidar](https://github.com/paulmillr/chokidar)-backed
-file watcher over the CDK app's **source tree** (the synth working
-directory, where `cdk.json` lives), excluding `cdk.out` / `node_modules`
-/ `.git` and honoring `cdk.json`'s `watch.include` / `watch.exclude`
-(mirroring `cdk watch`). A source edit triggers a debounced (500ms
-window) reload:
+### VTL support
 
-1. Re-run `cdk synth` (skipped when `-a <dir>` was passed at server
-   boot — the directory is treated as already-synthesized).
-2. Re-run route discovery, stage resolution, and CORS-config
-   extraction.
-3. Build per-Lambda specs + a fresh container pool.
-4. Atomically swap the server state. Routes added / removed / changed
-   take effect on the next request.
-5. Dispose the previous pool in the background — in-flight requests
-   complete against the old containers; new requests hit the new
-   pool.
+cdkd implements a minimal subset of API Gateway's VTL:
 
-Synth failures during reload do NOT crash the server. The previous
-version keeps serving and the CLI emits a `[warn]` line naming the
-failure. Reloads serialize, so a burst of file changes coalesces to
-one synth.
+- **Variable references** — `$var`, `${var}`, `$obj.field.subField`.
+- **Request input** — `$input.body`, `$input.json('$.path')` (JSON-stringified
+  slice, primitives JSON-quoted), `$input.path('$.path')` (native value),
+  `$input.params()` (the `{header, querystring, path}` union),
+  `$input.params('name')` (path, then query, then header), and
+  `$input.params('header').<name>` / `.querystring` / `.path`.
+- **Context** — `$context.requestId` / `httpMethod` / `resourcePath` / `stage`,
+  and `$context.identity.sourceIp` / `userAgent`.
+- **Utilities** — `$util.escapeJavaScript`, `base64Encode`, `base64Decode`,
+  `urlEncode`, `urlDecode`, `parseJson`.
+- **Directives** — `#set($var = expr)`, `#if` / `#elseif` / `#else` / `#end`,
+  `#foreach($x in $list)` / `#end`, and `##` line comments.
+- **Operators** — `&&`, `||`, `!`, `==`, `!=`, `<`, `<=`, `>`, `>=`.
+- **JSONPath subset** — `$`, `$.field`, `$.field.sub`, `$.array[index]`, and
+  quoted-string bracket keys.
 
-### CORS preflight
+Anything outside that subset raises a VTL evaluation error naming the offending
+construct, which the server returns as HTTP 502 with the reason in the body.
+See [Limitations](#limitations) for the list.
 
-cdkd's HTTP server intercepts OPTIONS preflight requests for HTTP API
-v2 routes whose `AWS::ApiGatewayV2::Api` has a `CorsConfiguration`:
+### Outbound integration URIs
 
-- Match `Origin` against `AllowOrigins` (literal entries or `*`).
-- Match `Access-Control-Request-Method` against `AllowMethods`.
-- Match each `Access-Control-Request-Headers` entry against
-  `AllowHeaders` (case-insensitive).
-- Respond `204 No Content` with the canonical `Access-Control-Allow-*`
-  headers, plus `Access-Control-Max-Age` / `Access-Control-Expose-Headers`
-  / `Access-Control-Allow-Credentials` when configured.
-- Always set `Vary: Origin` so downstream caches (browser / CDN) do
-  not share the response across origins (load-bearing whenever
-  `Access-Control-Allow-Origin` was derived from the request — the
-  wildcard echo, literal-origin echo, and `AllowCredentials` echo
-  paths all qualify).
+`HTTP` and `HTTP_PROXY` integrations whose `Uri` points at a well-known
+internal address — the EC2 instance metadata service, loopback, link-local, or
+an RFC 1918 range — get a warn line at boot naming the destination, once per
+URI. cdkd does not block the request; the warn is there so a mistyped or
+malicious template URI is visible before it runs in CI.
 
-When `AllowCredentials: true` AND the origin matched via `*`, the
-response echoes the request's literal `Origin` (browser fetch spec
-disallows `*` + credentials).
+## WebSocket APIs
 
-`Access-Control-Request-Headers` lists are validated strictly: a
-malformed entry (e.g. `"Content-Type,,Authorization"` — a trailing /
-embedded empty entry) rejects the preflight rather than silently
-skipping the empty entry. This matches AWS's stricter HTTP API
-behavior on preflight headers.
+An `AWS::ApiGatewayV2::Api` with `ProtocolType: WEBSOCKET` gets its own server,
+listening on `ws://<host>:<port>/<stage>` (`wss://` under mutual TLS). The
+stage comes from the API's `AWS::ApiGatewayV2::Stage`, falling back to `local`
+when the template declares none.
 
-When the user has registered an explicit OPTIONS method on a path
-(an `AWS::ApiGatewayV2::Route` whose `RouteKey` is `OPTIONS /...`)
-**on the same API as the matched route**, preflight interception is
-skipped — the user's Lambda owns the OPTIONS surface. The same-API
-filter is load-bearing in multi-API stacks: an explicit OPTIONS
-route on Stack B's REST v1 API at the same path no longer suppresses
-preflight on Stack A's HTTP API v2.
+The connection lifecycle mirrors the deployed one: the upgrade fires the
+`$connect` route's Lambda, each subsequent client message is routed by the
+API's `RouteSelectionExpression`, and the socket closing fires `$disconnect`.
+Only `$request.body.<key>` selection expressions are supported, optionally
+dot-nested (`$request.body.action.version`).
 
-REST v1 (`AWS::ApiGateway::*`) CORS via Mock OPTIONS methods IS
-intercepted when the synthesized template matches CDK's
-`defaultCorsPreflightOptions` shape: `HttpMethod: 'OPTIONS'` +
-`Integration.Type: 'MOCK'` + `IntegrationResponses[].ResponseParameters`
-carrying literal `method.response.header.Access-Control-Allow-*` pairs.
-The headers are extracted at boot (AWS's `"'value'"` single-quote
-wrappers are stripped) and the HTTP server returns the captured
-status and headers directly on OPTIONS requests — no Lambda
-invocation, no VTL evaluation. The default status code is 204
-(matches the CDK default);
-intrinsic-valued (`Fn::Sub` / `Ref` etc.) `ResponseParameters` are
-dropped silently because cdkd cannot evaluate VTL locally, and if the
-drop leaves zero header literals the route falls back to the deferred-
-error 501 class.
+Handler-side `PostToConnection` calls work against the local server. cdkd
+injects into every WebSocket Lambda's container:
 
-Other REST v1 MOCK shapes (non-OPTIONS methods, MOCK without literal
-header parameters, MOCK with VTL `RequestTemplates` that produce custom
-bodies) are dispatched via the full MOCK handler — see the
-"REST v1 non-AWS_PROXY integrations" section above.
+- `AWS_ENDPOINT_URL_APIGATEWAYMANAGEMENTAPI`, pointing at
+  `http://host.docker.internal:<port>/<stage>` — the same shape the deployed
+  endpoint has, so handlers that build the client explicitly from
+  `domainName` + `stage` and handlers that let the SDK read the env var both
+  work unchanged.
+- Placeholder credentials and a region when neither is already set, because the
+  SDK client refuses to instantiate without them. cdkd's local `@connections`
+  handler does not verify signatures, so the values are opaque.
+- A `host.docker.internal` host mapping, so the URL resolves on native Linux
+  Docker as well as Docker Desktop.
 
-### Stage variables
+That mapping needs Docker 20.10 or newer. When at least one WebSocket API will
+attach, cdkd probes the Docker server version once at boot and fails with an
+explicit message on an older daemon.
 
-`event.stageVariables` is populated from the selected Stage's
-`Variables` (REST v1) / `StageVariables` (HTTP API v2) map.
+Two cases leave an API discovered but not served, each with a warn line naming
+it: an API where any route sets `AuthorizationType` to something other than
+`NONE` (WebSocket authorizers are not emulated, and admitting unauthenticated
+clients would diverge from deployed behaviour), and an API with no
+Lambda-backed routes cdkd can resolve. A malformed WebSocket API is reported
+the same way and does not stop sibling APIs from booting.
 
-- **Default**: the first Stage attached to each API in template
-  order.
-- **`--stage <name>`**: select a Stage by `StageName`. Applied per-API
-  — a `--stage prod` override against an app with three APIs picks
-  the matching Stage on each. APIs without a matching Stage get
-  `stageVariables: null` and surface a warn line at startup. The
-  resolved stage name is threaded into `event.requestContext.stage`
-  for **both** REST v1 and HTTP API v2 routes. AWS supports named
-  stages on HTTP API v2 (`CreateStage` accepts any name; `$default`
-  is the auto-deploy default but not the only option), so a v2
-  template that pins a named Stage gets that name surfaced through
-  the integration event — matching what the deployed endpoint would
-  emit. v2 APIs without a templated Stage continue to use
-  `'$default'`.
-- **Function URL** routes don't have a Stage — `stageVariables` stays
-  `null` regardless of the flag.
-- **Intrinsic-valued entries** (`Ref`, `Fn::GetAtt`, `Fn::Sub`) in
-  the Stage's `Variables` map are dropped with a warn (mirrors
-  PR 1's env-var policy — the local server has no deploy state to
-  resolve them against).
+`--watch` does not hot-reload WebSocket servers — restart the command to pick
+up a route or Lambda change. On shutdown every live socket receives close
+frame 1001 before the containers are torn down.
 
-### Container lifecycle
+## CORS preflight
 
-- One pool per Lambda. Each container's RIE port is bound to its own
-  free host port (`pickFreePort`); the user-facing HTTP server stays on
-  the single `--port`.
-- `acquire()` returns the first idle container in the pool; lazy-grows
-  up to `--per-lambda-concurrency` under a per-Lambda mutex. Above the
-  cap, requests queue.
-- `release()` returns the container to the pool and starts a 60s idle
-  timer. Idle GC fires after 60s of inactivity per pool.
-- Containers are named `cdkd-local-<logicalId>-<pid>-<rand>` so an
-  external sweep can mop up orphans (`docker ps --filter
-  name=cdkd-local-`).
+### HTTP API v2
 
-### Lambda Layers in `local start-api`
+For routes on an `AWS::ApiGatewayV2::Api` carrying a `CorsConfiguration`, the
+server answers `OPTIONS` preflights itself:
 
-`cdkd local start-api` resolves same-stack `AWS::Lambda::LayerVersion`
-references the same way `cdkd local invoke` does — see the **Lambda
-Layers** section under `local invoke` above for the full rules
-(supported reference shapes, last-layer-wins on file collision, the
-single merged `/opt` bind mount, hard-error cases). The merge happens
-once per Lambda at server boot (not per request); the merged tmpdir
-is removed by the graceful shutdown path. Single-layer Lambdas skip
-the copy and bind-mount the layer's asset dir directly.
+- `Origin` is matched against `AllowOrigins` (literal entries or `*`).
+- `Access-Control-Request-Method` is matched against `AllowMethods`.
+- Each `Access-Control-Request-Headers` entry is matched against `AllowHeaders`,
+  case-insensitively.
+- A match returns `204 No Content` with the canonical `Access-Control-Allow-*`
+  headers, plus `Access-Control-Max-Age`, `Access-Control-Expose-Headers` and
+  `Access-Control-Allow-Credentials` when configured.
+- `Vary: Origin` is always set, so browser and CDN caches never share a
+  response across origins.
 
-### Container Lambdas (`Code.ImageUri`) in `local start-api`
+When `AllowCredentials: true` and the origin matched via `*`, the response
+echoes the request's literal `Origin` — the browser fetch spec disallows `*`
+together with credentials.
 
-`cdkd local start-api` supports `lambda.DockerImageFunction` /
-`Code.ImageUri` on the same terms as `cdkd local invoke` (see the
-**Container Lambdas** section under `local invoke` above). At server
-boot — and on every `--watch` reload — cdkd resolves each container
-Lambda's image once: **local-build** from the `cdk.out` asset
-manifest when the synthesizer produced a matching `dockerImages`
-entry (then `docker build` runs against the recorded build context),
-or **ECR-pull** fallback when no asset matches (same-account /
-same-region only, cross-account / cross-region deferred to a
-follow-up). The resulting deterministic
-`cdkd-local-invoke-<hash>` tag goes into the warm container pool;
-the pool runs `docker run` against it verbatim — no `/var/task`
-bind-mount, no base-image pull, `ImageConfig.Command` /
-`ImageConfig.EntryPoint` / `ImageConfig.WorkingDirectory` /
-`--platform` (from `Architectures`) all threaded through. Container
-Lambdas silently ignore `Properties.Layers` (matches AWS's
-invoke-time behavior — layers are baked into the image at build
-time on the IMAGE branch). Hot reload (`--watch`) detects
-Dockerfile / build-context changes via the content-addressed image
-tag: a real source edit flips the tag at the next reload's
-`docker build`, the spec signature compares unequal, and the pool
-entry tears down + restarts so the next request sees the new image.
+`Access-Control-Request-Headers` lists are validated strictly: a malformed entry
+such as `Content-Type,,Authorization` rejects the preflight rather than
+silently skipping the empty element, matching HTTP API's behaviour.
 
-### Graceful shutdown
+Interception is skipped when you have registered an explicit `OPTIONS` route
+(an `AWS::ApiGatewayV2::Route` with a `RouteKey` of `OPTIONS /...`) **on the
+same API** — your Lambda owns the `OPTIONS` surface. The same-API scoping
+matters in multi-API apps: an explicit `OPTIONS` route on one stack's REST API
+does not suppress preflight handling on another stack's HTTP API at the same
+path.
 
-`SIGINT` / `SIGTERM` / `uncaughtException` / `unhandledRejection` all
-run the same dispose path: drain in-flight requests, tear down every
-container (tolerating per-container removal failures — logged at warn,
-loop continues). The verify-time `docker ps --filter` sweep is the
-defense-in-depth backstop.
+### REST v1
 
-Double-`^C` bypasses dispose and exits immediately so the user can
-escape a hung Docker daemon. The skipped containers are reported with
-the `docker ps` cleanup command in the warning.
+REST v1 CORS via Mock `OPTIONS` methods is intercepted when the synthesized
+template matches the shape CDK's `defaultCorsPreflightOptions` produces:
+`HttpMethod: 'OPTIONS'`, `Integration.Type: 'MOCK'`, and
+`IntegrationResponses[].ResponseParameters` carrying literal
+`method.response.header.Access-Control-Allow-*` pairs.
 
-### `local start-api` exit codes
+The headers are extracted at boot, with AWS's `"'value'"` single-quote wrappers
+stripped, and the server returns the captured status and headers directly on
+`OPTIONS` — no Lambda invocation and no VTL evaluation. The default status is
+`204`, matching CDK's default.
 
-- `0` — server started cleanly and shut down on SIGTERM.
-- `1` — startup failure (Docker missing, port bind failed, route
-  discovery rejected) OR uncaught exception during the run.
-- `130` — exited via SIGINT.
+Intrinsic-valued `ResponseParameters` (`Fn::Sub`, `Ref`, and so on) are dropped,
+because they cannot be evaluated locally. If the drop leaves no header literals
+at all, the route falls back to the unsupported 501 class.
 
-### `local start-api` authorizers
+Other REST v1 `MOCK` shapes — non-`OPTIONS` methods, `MOCK` without literal
+header parameters, `MOCK` with VTL request templates producing custom bodies —
+go through the full MOCK handler described in
+[REST v1 integration types](#rest-v1-integration-types).
 
-cdkd supports four authorizer kinds in front of any discovered route:
+## Stage variables
 
-- **Lambda TOKEN** (REST v1) — `AWS::ApiGateway::Authorizer.Type: 'TOKEN'`.
-  The header named in `IdentitySource` (default
-  `method.request.header.Authorization`) is forwarded to the authorizer
-  Lambda as `event.authorizationToken`. The Lambda's response must carry
-  a `policyDocument` with at least one `{ Effect: 'Allow', Resource:
-  <methodArn> }` statement; cdkd matches `Resource` against the
-  request's methodArn (literal or `*`/`?` wildcard) on every request —
-  cached verdicts get re-evaluated against the new methodArn so a
-  narrow-Resource Allow doesn't leak across routes. Allow → context
-  flat under `event.requestContext.authorizer`. Policy-deny → HTTP 403,
-  missing identity header → HTTP 401 without invoking the Lambda.
-- **Lambda REQUEST** — REST v1 (`Type: 'REQUEST'`) and HTTP v2
-  (`AuthorizerType: 'REQUEST'`). The full request snapshot (headers,
-  query string, path parameters) is passed to the authorizer Lambda.
-  HTTP v2 also accepts the simple `{ isAuthorized, context }` response
-  shape in addition to the IAM-policy shape. REST v1 missing-identity →
-  HTTP 401 without invoking the Lambda; HTTP v2 falls through.
-- **Cognito User Pool** (REST v1) — `Type: 'COGNITO_USER_POOLS'`. The
-  Bearer token from `Authorization: Bearer <token>` is verified locally
-  against the user pool's published JWKS. Allow → claims under
-  `event.requestContext.authorizer.claims`. Deny → HTTP 403.
-- **JWT** (HTTP v2) — `AuthorizerType: 'JWT'`. Same JWKS-based
-  verification, with `aud` / `client_id` matched against the
-  `JwtConfiguration.Audience` allowlist. Allow → claims under
-  `event.requestContext.authorizer.jwt.claims`. Deny → HTTP 401.
+`event.stageVariables` is populated from the selected Stage's `Variables` map
+(REST v1) or `StageVariables` map (HTTP API v2), and the resolved stage name is
+threaded into `event.requestContext.stage`.
 
-Authorizer results are cached per `(authorizer, identity)` for the TTL
-declared by the authorizer (REST v1: `AuthorizerResultTtlInSeconds`,
-default 300s, max 3600s; HTTP v2: 0 by default = no cache; JWT: cached
-for `min(remaining-exp, 300s)`).
+| Situation | Result |
+| --- | --- |
+| No `--stage` | The first Stage attached to each API, in template order. |
+| `--stage <name>` | The Stage whose `StageName` matches, resolved per API — one override picks the matching Stage on each of several APIs. |
+| `--stage <name>` with no match on an API | That API's routes get `stageVariables: null` and a warn line at startup. |
+| API with no templated Stage (HTTP API v2) | `requestContext.stage` stays `$default`. |
+| Function URL route | No Stage exists, so `stageVariables` stays `null` regardless of the flag. |
 
-**JWKS-fetch failure → pass-through.** When the JWKS endpoint is
-unreachable at startup, cdkd warns and falls back to a pass-through
-mode where every Bearer token is accepted as if valid (including
-malformed / non-JWT garbage — a real JWT still gets its claims
-surfaced into `event.requestContext.authorizer`, a malformed token
-gets a synthetic `unknown` principal and an empty claims map):
+Intrinsic-valued entries (`Ref`, `Fn::GetAtt`, `Fn::Sub`) in a Stage's
+`Variables` map are dropped with a warn — the local server has no deployed
+state to resolve them against.
+
+## Authorizers
+
+Four authorizer kinds run in front of any discovered route.
+
+| Kind | Declared as | Identity source | Allow | Deny |
+| --- | --- | --- | --- | --- |
+| Lambda TOKEN (REST v1) | `AWS::ApiGateway::Authorizer` with `Type: 'TOKEN'` | The header named by `IdentitySource`, defaulting to `method.request.header.Authorization`, forwarded as `event.authorizationToken` | Context flattened under `event.requestContext.authorizer` | HTTP 403 on policy deny; HTTP 401 without invoking the Lambda when the identity header is missing |
+| Lambda REQUEST | `Type: 'REQUEST'` (REST v1) or `AuthorizerType: 'REQUEST'` (HTTP v2) | The full request snapshot — headers, query string, path parameters | Context under `event.requestContext.authorizer` | REST v1 returns HTTP 401 without invoking the Lambda when identity is missing; HTTP v2 falls through |
+| Cognito User Pool (REST v1) | `Type: 'COGNITO_USER_POOLS'` | `Authorization: Bearer <token>`, verified against the pool's published JWKS | Claims under `event.requestContext.authorizer.claims` | HTTP 403 |
+| JWT (HTTP v2) | `AuthorizerType: 'JWT'` | `Authorization: Bearer <token>`, verified against the issuer's JWKS with `aud` / `client_id` matched against `JwtConfiguration.Audience` | Claims under `event.requestContext.authorizer.jwt.claims` | HTTP 401 |
+
+A TOKEN authorizer's response must carry a `policyDocument` with at least one
+`{ Effect: 'Allow', Resource: <methodArn> }` statement. cdkd matches `Resource`
+against the request's method ARN — literally, or with `*` / `?` wildcards — on
+every request, and re-evaluates cached verdicts against the new method ARN, so
+a narrow-`Resource` Allow does not leak across routes.
+
+Any other `Type` or `AuthorizerType` is a hard error at discovery, with the
+offending route's location named.
+
+### Result caching
+
+Authorizer results are cached per authorizer and identity, for the TTL the
+authorizer declares.
+
+| Authorizer | Cache TTL |
+| --- | --- |
+| REST v1 | `AuthorizerResultTtlInSeconds`, default 300s, maximum 3600s |
+| HTTP v2 | 0 by default, meaning no caching |
+| JWT | `min(remaining exp, 300s)` |
+
+### JWKS pass-through fallback
+
+When the JWKS endpoint is unreachable, cdkd warns and falls back to accepting
+every Bearer token as valid. A real JWT still gets its claims surfaced into
+`event.requestContext.authorizer`; a malformed token gets a synthetic `unknown`
+principal and an empty claims map.
 
 ```text
 [warn] [cognito-jwt] JWKS unreachable at https://cognito-idp.us-east-1.amazonaws.com/us-east-1_xyz/.well-known/jwks.json: ...
@@ -412,91 +400,31 @@ gets a synthetic `unknown` principal and an empty claims map):
         network access to the JWKS URL to enable real signature verification.
 ```
 
-The failure entry has a short TTL (~60s) so a transient blip doesn't
-lock pass-through for the full 1hr success TTL — the next minute's
-request retries the JWKS fetch. The pass-through warn line itself
-fires at most once per JWKS URL per server lifecycle (the warn-set
-is constructed once at server startup, not per request).
+The failure entry has a short TTL of about 60s, so a transient network blip does
+not lock pass-through in for the full success TTL — the next minute's request
+retries the fetch. The warn fires at most once per JWKS URL per server run.
 
-This is a deliberate dev-tool tradeoff: surprising deny is worse than
-warn+allow when the developer is iterating on a function and the JWKS
-URL is blocked by a corporate proxy. **Do NOT rely on this in any
-shared environment** — the dev's machine accepts every token, including
-forged ones.
+This is a deliberate trade for a dev tool: a surprising deny is worse than a
+warn plus allow when you are iterating on a handler and a corporate proxy is
+blocking the JWKS URL. **Do not rely on it in any shared environment** — the
+machine running the server accepts every token, forged ones included.
 
-`AWS_IAM` authorization is supported with **signature-verification-only**
-semantics on BOTH REST v1 (`AuthorizationType: 'AWS_IAM'`) and Function
-URLs (`AuthType: 'AWS_IAM'`) — see the next section. mTLS
-authorizers and any non-TOKEN/REQUEST/COGNITO_USER_POOLS Type /
-non-REQUEST/JWT AuthorizerType still hard-error at discovery with the
-offending route's location named.
+## AWS_IAM authorization
 
-### `local start-api` AWS_IAM authorizer (REST v1 + Function URL, signature verification only)
+Routes declaring REST v1 `AuthorizationType: 'AWS_IAM'` or Function URL
+`AuthType: 'AWS_IAM'` boot and serve requests. cdkd verifies the inbound
+`Authorization: AWS4-HMAC-SHA256 ...` signature against your **local** AWS
+credentials, using the same credential chain every other cdkd command uses:
 
-Routes that declare REST v1 `AuthorizationType: 'AWS_IAM'` OR Function
-URL `AuthType: 'AWS_IAM'` boot and serve requests; cdkd verifies the
-inbound `Authorization: AWS4-HMAC-SHA256 ...` SigV4 signature against
-the developer's **local** AWS credentials (the same default credential
-chain every other cdkd command uses):
+1. Parse the header into its `Credential`, `SignedHeaders` and `Signature` parts.
+2. Reconstruct the canonical request per the SigV4 spec.
+3. Derive the signing key from the local secret access key and the request's
+   date, region and service scope.
+4. Compare the recomputed signature with the header's in constant time.
 
-1. Parse the header into `(Credential, SignedHeaders, Signature)`.
-2. Reconstruct the canonical request per the AWS SigV4 spec.
-3. Derive the signing key from the local secret access key + the
-   request's date / region / service scope.
-4. Constant-time compare the recomputed signature with the header's.
-
-Outcomes:
-
-- **Valid signature with the dev's credentials** → request reaches the
-  handler.
-  - **REST v1**: the handler sees the access-key-id as
-    `event.requestContext.authorizer.principalId` (flat v1 overlay).
-  - **Function URL**: NO authorizer block is synthesized. The base v2
-    event's `requestContext.authorizer` stays `null`. AWS-deployed
-    Function URLs write principal context under
-    `event.requestContext.authorizer.iam.{accessKey, accountId, callerId,
-    userArn, ...}`, and cdkd has no local IAM data plane to populate
-    that block (no STS GetCallerIdentity per request, no policy
-    emulation). Emitting principalId under `.lambda` would mislead
-    handlers that defensive-read `.iam`, so the deployed and local
-    behavior diverge only by absence of identity context — never by
-    location.
-- **No / malformed `Authorization` header**, **signature mismatch
-  under the dev's own credentials**, or any other rejection → 403
-  matching the deployed response:
-  - REST v1: 403 (`{"message":"Missing Authentication Token"}`) for
-    missing-identity, 403 (`{"message":"Forbidden"}`) for policy-deny —
-    matches AWS-deployed API Gateway REST v1 IAM rejection (lowercase
-    `message`).
-  - Function URL: 403 (`{"Message":"Forbidden"}`) for both deny kinds —
-    matches Lambda's deployed Function URL IAM rejection (capital
-    `Message`).
-- **Different `Credential` access-key-id than the dev has** →
-  warn-and-pass. The local server cannot reproduce a signing key it
-  doesn't have, and refusing every foreign-identity request would
-  defeat the dev-tool purpose. The warn fires at most once per foreign
-  access-key-id per server lifecycle.
-
-Pass `--strict-sigv4` to opt IN to fail-closed mode — every
-unverifiable signature (foreign access-key-id, missing local AWS
-credentials, etc.) is denied with the same 403 the deployed API
-Gateway would return. Use this when you want local parity with the
-deployed signature-enforcement boundary. The default (warn-and-pass)
-matches cdk-local's `cdkl start-api`.
-
-**What is NOT verified locally** (deliberately out of scope):
-
-- IAM resource / action / condition policy evaluation. The local
-  server has no IAM data plane. Signature-verified callers reach the
-  handler under their own identity; downstream authorization is the
-  dev's responsibility. Use the deployed API to test the full IAM
-  policy surface.
-- STS temporary credentials' session-token validation against AWS.
-  We accept whatever session-token the request was signed with.
-
-At startup cdkd emits a one-line warn naming every IAM-protected
-route so the developer is aware of the signature-verification-only
-boundary:
+Signature verification is the whole of it — **IAM policy evaluation is not
+emulated**. At startup cdkd names every IAM-protected route so the boundary is
+visible:
 
 ```text
 [warn] 2 route(s) declare AuthorizationType: AWS_IAM — cdkd local start-api
@@ -508,46 +436,61 @@ boundary:
 [warn]   - MyStack/AnotherProtectedMethod
 ```
 
-Tooling that signs requests works out of the box — common helpers
-include `aws-sigv4-sdk` (AWS SDK v3 signer), `curl --aws-sigv4`,
-Postman's AWS Signature auth, and the `awscurl` CLI.
+Tooling that signs requests works out of the box: the AWS SDK v3 signer,
+`curl --aws-sigv4`, Postman's AWS Signature auth, and `awscurl`.
 
-### `local start-api` VPC-config Lambdas
+### Verification outcomes
 
-Lambdas with `Properties.VpcConfig` set still run locally — cdkd does
-NOT block these — but the local container does NOT get attached to the
-deployed VPC's subnets. Calls from the handler to private RDS /
-ElastiCache / VPC-only endpoints will fail. cdkd surfaces a one-line
-warn at startup naming each affected Lambda:
+| Outcome | REST v1 | Function URL |
+| --- | --- | --- |
+| Valid signature under your credentials | Request reaches the handler; the access key id appears as `event.requestContext.authorizer.principalId` | Request reaches the handler; `requestContext.authorizer` stays `null` |
+| Missing or malformed `Authorization` header | HTTP 403 `{"message":"Missing Authentication Token"}` | HTTP 403 `{"Message":"Forbidden"}` |
+| Signature mismatch under your own credentials | HTTP 403 `{"message":"Forbidden"}` | HTTP 403 `{"Message":"Forbidden"}` |
+| `Credential` names an access key id you do not hold | Warn and pass through, once per access key id per server run | Warn and pass through, once per access key id per server run |
 
-```text
-[warn] Lambda MyVpcLambda has VpcConfig — local container will reach external
-        services via the host's network, NOT through the deployed VPC's
-        NAT/private subnets. Calls to private RDS/ElastiCache will fail.
-```
+The response bodies match the deployed services, down to the lowercase
+`message` on API Gateway REST v1 and the capitalized `Message` on Lambda
+Function URLs.
 
-AWS SDK calls from the container still use the developer's shell
-credentials (or `--assume-role`-issued temp creds) and reach the public
-AWS endpoints; nothing about that path changes.
+For Function URLs no authorizer block is synthesized at all. AWS-deployed
+Function URLs write principal context under
+`event.requestContext.authorizer.iam.{accessKey, accountId, callerId, userArn, ...}`,
+and cdkd has no local IAM data plane to fill it. Emitting a `principalId` under
+`.lambda` would mislead handlers that defensively read `.iam`, so local and
+deployed behaviour differ only by the absence of identity context, never by its
+location.
 
-### `local start-api` mTLS (mutual TLS)
+The warn-and-pass default exists because the local server cannot reproduce a
+signing key it does not hold, and refusing every foreign-identity request would
+defeat the purpose of a dev tool.
 
-`cdkd local start-api` supports API Gateway custom-domain mutual TLS:
-when all three `--mtls-truststore <path>` / `--mtls-cert <path>` /
-`--mtls-key <path>` flags are set, the server switches from plain HTTP
-to HTTPS and the TLS handshake itself enforces the client-certificate
-trust check against the supplied CA bundle. Clients without a cert,
-with a self-signed cert, or with a cert that doesn't chain to one of
-the CAs in the trust store are rejected by Node's `tls` module BEFORE
-the request reaches cdkd's per-request handler — no per-request code
-path is needed.
+### `--strict-sigv4`
 
-The verified client certificate is surfaced on the Lambda event under:
+Opts in to fail-closed mode. Every unverifiable signature — a foreign access
+key id, or no local AWS credentials at all — is denied with the same 403 the
+deployed API would return. Use it when you want local parity with the deployed
+signature-enforcement boundary.
 
-- **REST v1**: `event.requestContext.identity.clientCert`
-- **HTTP API v2**: `event.requestContext.authentication.clientCert`
+## Mutual TLS
 
-Both shapes match AWS API Gateway's deployed-mTLS event shape:
+Setting all three of `--mtls-truststore`, `--mtls-cert` and `--mtls-key`
+switches the server from HTTP to HTTPS and makes the TLS handshake itself
+enforce the client-certificate trust check against the supplied CA bundle.
+Clients with no certificate, a self-signed certificate, or one that does not
+chain to a CA in the trust store are rejected before the request reaches any
+cdkd request handler.
+
+Partial flag sets are rejected at parse time, so the server never boots half
+configured: set all three, or none. mTLS runs orthogonally to the TOKEN,
+REQUEST, Cognito and JWT authorizers — the handshake completes first, then the
+authorizer pipeline runs against the already-authenticated client.
+
+### Client certificate on the event
+
+The verified client certificate is surfaced on the Lambda event under
+`event.requestContext.identity.clientCert` (REST v1) or
+`event.requestContext.authentication.clientCert` (HTTP API v2). Both match API
+Gateway's deployed shape:
 
 ```json
 {
@@ -562,17 +505,7 @@ Both shapes match AWS API Gateway's deployed-mTLS event shape:
 }
 ```
 
-mTLS runs ORTHOGONALLY to the existing TOKEN / REQUEST / COGNITO_USER_POOLS
-/ JWT authorizers — the TLS handshake completes first (rejecting
-unknown-CA clients), then the authorizer pipeline runs against the
-already-authenticated client.
-
-**Partial flag sets are rejected at CLI parse time** (the server never
-boots in a half-configured state): if any of the three flags is set,
-all three must be set. Leave all three unset for plain HTTP (the
-pre-PR default).
-
-#### Generating a local CA + server + client cert with openssl
+### Generating a local CA and certificates
 
 ```bash
 # 1. Create a local CA
@@ -608,32 +541,246 @@ curl --cacert ca.pem \
   https://localhost:<port>/items
 ```
 
-#### mTLS scope
+The server certificate and key are for the local server only, so a self-signed
+pair is the normal case. The CLI flags are the authoritative configuration:
+cdkd does not read `AWS::ApiGateway::DomainName` or
+`AWS::ApiGatewayV2::DomainName` mTLS settings out of the template. If your CDK
+app declares mTLS on a domain name, point `--mtls-truststore` at the same CA
+bundle you uploaded to the deployed trust store.
 
-- The mTLS configuration is at the SERVER level (the equivalent of an
-  API Gateway custom-domain `MutualTlsAuthentication.TruststoreUri`).
-  cdkd does NOT parse the synth template's `AWS::ApiGateway::DomainName`
-  / `AWS::ApiGatewayV2::DomainName` resources — the CLI flags are the
-  authoritative source. If your CDK app declares mTLS on a DomainName,
-  you can re-use the same CA bundle locally by pointing
-  `--mtls-truststore` at the file you uploaded to the deployed
-  truststore S3 location.
-- The server cert and key are for the LOCAL server only (clients
-  connect to `localhost`). Self-signed is the typical case.
-- AWS-deployed mTLS uses `MutualTlsAuthentication.TruststoreVersion`
-  for live trust-store updates; the local server reads the
-  `--mtls-truststore` file once at boot. Restart `cdkd local start-api`
-  to pick up a new CA bundle (the `--watch` reload pipeline does NOT
-  re-read the mTLS materials).
+## Environment variables and credentials
 
-### `local start-api` v1 scope (out of scope, deferred)
+### `--env-vars`
 
-| Out of scope | Deferred to |
+A JSON file in SAM's shape:
+`{"LogicalId": {"KEY": "VALUE"}, "Parameters": {...}}`. The function-specific
+key may also be a CDK display path such as `MyStack/MyHandler`. The format is
+shared with [`cdkd local invoke`](local-invoke.md); explicit overrides win over
+values recovered from deployed state.
+
+### `--from-state`
+
+Reads cdkd's S3 state for every routed stack and substitutes `Ref`,
+`Fn::GetAtt`, `Fn::Sub` and `Fn::Join` placeholders — plus the AWS pseudo
+parameters `${AWS::AccountId}`, `${AWS::Region}`, `${AWS::Partition}` and
+`${AWS::URLSuffix}` — in Lambda env vars with the deployed physical ids and
+attributes. Turn it on for stacks already deployed with `cdkd deploy`.
+
+Off by default, in which case unresolvable placeholders are dropped with a
+warn. A state load failure degrades per stack to the same warn-and-fall-back
+path, so a missing or unreadable state file never aborts the server. With
+`--watch`, state is re-read on every reload.
+
+Use `--stack-region` when the same stack name has state in more than one
+region, and `--state-bucket` / `--state-prefix` when the state does not live at
+the default location.
+
+### `--from-cfn-stack`
+
+Reads a deployed CloudFormation stack through `DescribeStackResources` and
+substitutes `Ref` and `Fn::ImportValue` in Lambda env vars with the deployed
+physical ids and exports. Use it for CDK apps deployed with the upstream CDK
+CLI.
+
+The bare form is the typical shape — `cdkd local start-api MyStack/MyApi
+--from-cfn-stack` resolves to the routed stack's CDK name per routed stack.
+Pass an explicit value only when the deployed CloudFormation stack name differs
+from the CDK stack name, for instance because CDK's `stackName` prop was
+overridden; the explicit form is rejected when more than one stack is routed in
+one invocation.
+
+`--from-cfn-stack` is mutually exclusive with `--from-state`.
+`--stack-region` sets the CloudFormation client region. A consumer Lambda's own
+`Fn::GetAtt` env vars are recovered from the deployed function configuration;
+`Fn::GetAtt` at other sites is dropped with a warn.
+
+### `--assume-role` and `--assume-role-auto`
+
+By default the containers inherit your developer credentials. `--assume-role`
+assumes an execution role instead and forwards the STS-issued temporary
+credentials into the container, in two forms:
+
+| Form | Effect |
 | --- | --- |
-| AWS_IAM authorizer (REST v1 + Function URL) — IAM policy evaluation (resource/action/condition). Signature verification IS implemented on both surfaces (REST v1 and Function URL). | Out of scope (the local server has no IAM data plane) |
-| REST v1 AWS integration with non-Lambda service backend (`:s3:path/...` / `:sqs:action/...` / `:dynamodb:action/...` / etc.) | Future work — requires per-service SDK clients, IAM credential threading, and a per-service compatibility matrix. v1 emulates Lambda non-proxy AWS integrations only. |
-| VTL features outside the supported subset (arithmetic outside literal concat, `#macro` / `#parse` / `#include`, range operator, `$velocityCount`, JSONPath filter expressions) | Surface as `VtlEvaluationError` → HTTP 502 + reason body. Hand-roll the missing feature in `src/local/vtl-engine.ts` if a real workload needs it. |
-| WebSocket APIs | Never (different protocol) |
-| Throttling / quotas / usage plans / API keys | Never |
-| Per-Lambda concurrency above 4 | Future work if a real workload needs it |
+| `--assume-role <arn>` | A single global default ARN used for every routed Lambda. |
+| `--assume-role <LogicalId>=<arn>` | A per-Lambda override. Repeatable. |
 
+`--assume-role-auto` resolves **each** routed Lambda's own execution role
+instead of using one global default: it tries the synthesized template's
+literal-ARN `Properties.Role`, then a deployed-state lookup (pair it with
+`--from-state` or `--from-cfn-stack`), then warns and passes the developer
+credentials through on a miss. Boot is slower — one STS call per Lambda — but
+it is the right shape when each Lambda's deployed role differs.
+
+`--assume-role-auto` is mutually exclusive with the global-default
+`--assume-role <arn>` form and errors at boot. It is compatible with per-Lambda
+`--assume-role <LogicalId>=<arn>` overrides: the map wins for the Lambdas it
+names, auto-resolution handles the rest.
+
+Precedence, highest first:
+
+1. A per-Lambda `--assume-role <LogicalId>=<arn>` entry.
+2. `--assume-role-auto`, or the global `--assume-role <arn>` default.
+3. Unset — the developer's own credentials are passed through.
+
+## Container lifecycle
+
+- One container pool per Lambda. Each container's emulator port is bound to its
+  own free host port; the user-facing HTTP server stays on its single port.
+- Acquiring a container returns the first idle one in the pool, growing the pool
+  lazily up to `--per-lambda-concurrency` under a per-Lambda mutex. Above the
+  cap, requests queue.
+- Releasing a container returns it to the pool and starts a 60-second idle
+  timer; the pool's idle collector tears it down when it expires.
+- Containers are named `cdkd-local-<logicalId>-<pid>-<random>`, so an external
+  sweep can find strays with `docker ps --filter name=cdkd-local-`.
+
+## Lambda layers
+
+Same-stack `AWS::Lambda::LayerVersion` references resolve exactly as they do
+for [`cdkd local invoke`](local-invoke.md), which documents the supported
+reference shapes, the last-layer-wins rule on file collisions, the single
+merged `/opt` bind mount, and the hard-error cases.
+
+The merge happens once per Lambda at server boot rather than per request, and
+the merged temporary directory is removed by the shutdown path. A single-layer
+Lambda skips the copy and bind-mounts the layer's asset directory directly.
+
+`--layer-role-arn` names a role to assume before calling
+`lambda:GetLayerVersion` on literal-ARN entries in `Properties.Layers`. Use it
+only when your own credentials cannot read the layer, which in practice means a
+cross-account layer; AWS-published public layers such as Lambda Powertools are
+readable from every account and need no role. It is a no-op for stacks whose
+layers are all same-stack references.
+
+## Container image Lambdas
+
+`lambda.DockerImageFunction` and `Code.ImageUri` are supported on the same terms
+as [`cdkd local invoke`](local-invoke.md). At server boot — and on every
+`--watch` reload — cdkd resolves each container Lambda's image once:
+
+- **Local build**, from the `cdk.out` asset manifest when the synthesizer
+  produced a matching `dockerImages` entry. `docker build` then runs against the
+  recorded build context.
+- **ECR pull**, when no asset matches. Same-account and same-region only.
+
+The resulting deterministic `cdkd-local-invoke-<hash>` tag goes into the warm
+pool, which runs it verbatim: no `/var/task` bind mount, no base-image pull, and
+`ImageConfig.Command`, `ImageConfig.EntryPoint`, `ImageConfig.WorkingDirectory`
+and the `--platform` derived from `Architectures` all threaded through.
+
+Container Lambdas ignore `Properties.Layers`, matching AWS — layers are baked
+into the image at build time. `--watch` detects Dockerfile and build-context
+changes through the content-addressed tag: a real source edit flips the tag at
+the next reload's `docker build`, the pool entry tears down and restarts, and
+the next request sees the new image.
+
+## VPC-config Lambdas
+
+A Lambda with `Properties.VpcConfig` set still runs locally — cdkd does not
+block it — but the container is **not** attached to the deployed VPC's subnets.
+Calls from the handler to a private RDS instance, ElastiCache cluster or
+VPC-only endpoint will fail. Each affected Lambda gets a warn line at startup:
+
+```text
+[warn] Lambda MyVpcLambda has VpcConfig — local container will reach external
+        services via the host's network, NOT through the deployed VPC's
+        NAT/private subnets. Calls to private RDS/ElastiCache will fail.
+```
+
+AWS SDK calls from the container still use your shell credentials, or the
+temporary credentials `--assume-role` issued, and reach the public AWS
+endpoints; nothing about that path changes.
+
+## `--watch`
+
+With `--watch`, cdkd watches the CDK app's **source tree** — the synth working
+directory, where `cdk.json` lives — excluding `cdk.out`, `node_modules` and
+`.git`, and honouring `cdk.json`'s `watch.include` / `watch.exclude`, the same
+way `cdk watch` does. A source edit triggers a reload on a 500 ms debounce:
+
+1. Re-run `cdk synth`. This step is skipped when `-a <dir>` named a
+   pre-synthesized directory at boot.
+2. Re-run route discovery, stage resolution and CORS-config extraction.
+3. Build fresh per-Lambda specs and a fresh container pool.
+4. Atomically swap the server state. Added, removed and changed routes take
+   effect on the next request.
+5. Dispose the previous pool in the background — in-flight requests finish
+   against the old containers, new requests hit the new pool.
+
+A synth failure during reload does not crash the server: the previous version
+keeps serving and a warn line names the failure. Reloads serialize, so a burst
+of file changes coalesces into one synth. WebSocket servers and the mTLS
+materials are not reloaded; restart the command to pick those up.
+
+## Graceful shutdown
+
+`SIGINT`, `SIGTERM`, an uncaught exception and an unhandled rejection all run
+the same dispose path: stop the watcher, drain in-flight requests, close every
+server, dispose every container pool, and remove the temporary directories cdkd
+materialized for inline code, merged layers and synthesized profile
+credentials. A per-container removal failure is logged at warn and the loop
+continues.
+
+A second `Ctrl-C` bypasses dispose and exits immediately, so you can escape a
+hung Docker daemon. The warning names the containers that were skipped along
+with the `docker ps` command to clean them up.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The server shut down cleanly on `SIGTERM`. |
+| `1` | Startup failure — Docker missing or too old, port bind failed, route discovery rejected the template — or an uncaught exception during the run. |
+| `130` | Exited via `SIGINT` (`Ctrl-C`), including the immediate second-`Ctrl-C` exit. |
+
+The full cross-command table is in the [CLI Reference](cli-reference.md#exit-codes).
+
+## Limitations
+
+- IAM resource, action and condition policy evaluation is not emulated. The
+  local server has no IAM data plane, so signature-verified callers reach the
+  handler under their own identity and downstream authorization is up to you.
+  Use the deployed API to test the full IAM policy surface.
+- STS temporary credentials' session tokens are not validated against AWS —
+  whatever session token the request was signed with is accepted.
+- REST v1 `AWS` integrations targeting a non-Lambda service (`:s3:path/...`,
+  `:sqs:action/...`, `:dynamodb:action/...`) are not emulated; the route
+  returns 501. Only Lambda non-proxy `AWS` integrations are supported.
+- `HTTP` and `HTTP_PROXY` integrations need a literal `Uri`; intrinsics in the
+  URI are not resolved.
+- HTTP API v2 service integrations (those setting `IntegrationSubtype`) are not
+  emulated.
+- These VTL features raise an evaluation error, returned as HTTP 502 with the
+  offending construct named: arithmetic operators outside literal concatenation,
+  user-defined `#macro`, `#parse` / `#include`, the range operator (`[1..5]`),
+  `$velocityCount` and other Velocity context built-ins, and JSONPath filter
+  expressions (`$..items`, `$.items[?(@.x > 5)]`).
+- WebSocket authorizers are not emulated; an API with a non-`NONE`
+  `AuthorizationType` on any route accepts no upgrade requests.
+- WebSocket `RouteSelectionExpression` support is limited to
+  `$request.body.<key>` shapes. Header, context and array-index selections are
+  rejected.
+- WebSocket servers are not hot-reloaded by `--watch`; restart to pick up route
+  or Lambda changes.
+- The mTLS trust store is read once at boot. Restart the command to pick up a
+  new CA bundle — the deployed `MutualTlsAuthentication.TruststoreVersion`
+  live-update mechanism has no local equivalent.
+- Container image Lambdas fall back to an ECR pull only within the same account
+  and region.
+- Throttling, quotas, usage plans and API keys are not emulated.
+- Per-Lambda concurrency is capped at 4.
+
+## Related
+
+- [Local Execution](local-emulation.md) — the `cdkd local` family, Docker
+  requirements, and the flags shared across every subcommand
+- [`cdkd local invoke`](local-invoke.md) — one-shot Lambda invocation, layers,
+  container images, and asset resolution
+- [`cdkd local start-alb`](local-start-alb.md) — a local Application Load
+  Balancer in front of ECS and Lambda backing services
+- [`cdkd local start-cloudfront`](local-start-cloudfront.md) — a local
+  CloudFront distribution over S3 origins and Lambda Function URLs
+- [`cdkd local run-task`](local-run-task.md) — run one ECS task definition
+  locally
+- [CLI Reference](cli-reference.md) — every command and the full exit-code table

--- a/docs/local-start-api.md
+++ b/docs/local-start-api.md
@@ -722,8 +722,8 @@ once:
   produced a matching `dockerImages` entry. `docker build` then runs against the
   recorded build context.
 - **ECR pull**, when no asset matches. The ECR client is built for the image
-  URI's own region, so cross-region works. Cross-account works only when the
-  repository policy grants your identity directly: this command has no
+  URI's own region, so cross-region works. Cross-account works only when your own
+  credentials are already permitted on the target repository: this command has no
   `--ecr-role-arn`, so to assume a role first use
   [`cdkd local invoke`](local-invoke.md#container-image-lambdas).
 

--- a/docs/local-start-api.md
+++ b/docs/local-start-api.md
@@ -9,9 +9,9 @@ description: "Serve a CDK app's API Gateway routes — REST v1, HTTP API, WebSoc
 Gateway routes in your synthesized CDK app to local Lambda invocations against
 the AWS Lambda Runtime Interface Emulator. Reach for it when you want to
 exercise a whole API — routing, authorizers, CORS, stage variables — against
-real handler code without deploying to AWS. Every route it serves is backed by a
-Lambda; for a front door over running ECS replicas, use
-[`cdkd local start-alb`](local-start-alb.md).
+real handler code without deploying to AWS. Each route resolves to a Lambda, an
+HTTP upstream, or a response template; for a front door over running ECS
+replicas, use [`cdkd local start-alb`](local-start-alb.md).
 
 **Docker is required.** The first run pulls the Lambda base image (roughly
 600 MB, once per machine); pass `--no-pull` on later runs to skip the layer
@@ -204,7 +204,7 @@ All four non-`AWS_PROXY` REST v1 integration types are emulated end to end.
 | Type | One-line summary |
 | --- | --- |
 | `MOCK` | Answers from templates alone; no upstream call. |
-| `HTTP_PROXY` | Forwards the request to `Integration.Uri` verbatim. |
+| `HTTP_PROXY` | Forwards the request to `Integration.Uri`, body unchanged. |
 | `HTTP` | `HTTP_PROXY` plus VTL in both directions. |
 | `AWS` (Lambda non-proxy) | Builds the Lambda event from a VTL template and transforms the return value. |
 
@@ -747,13 +747,22 @@ endpoints; nothing about that path changes.
 
 ## `--debug-port-base`
 
-`--debug-port-base <port>` allocates one debugger port per routed Lambda,
-`port`, `port+1`, `port+2`, in the order the routes were discovered, and sets
-`NODE_OPTIONS=--inspect-brk=0.0.0.0:<port>` on each container.
+`--debug-port-base <port>` allocates one debugger port per distinct Lambda —
+`port`, `port+1`, `port+2`, in discovery order — and sets
+`NODE_OPTIONS=--inspect-brk=0.0.0.0:<port>` on that Lambda's container.
 
-`--inspect-brk` **suspends the handler until a debugger attaches**, so every
-route hangs until you connect to that Lambda's port. Serve a single API while
-debugging, and read the boot log to see which port each Lambda received.
+Two things to know before reaching for it:
+
+- The set is **every** Lambda the run touches, not just route handlers:
+  authorizer Lambdas and WebSocket-route Lambdas take ports from the same range,
+  in the same order.
+- `--inspect-brk` **suspends the process until a debugger attaches**, so a
+  request to a Node Lambda hangs until you connect to that Lambda's port.
+  `NODE_OPTIONS` is inert on the other runtimes, which are unaffected.
+
+Nothing prints the per-Lambda assignment, so debug one API at a time and count
+from the base in discovery order. Containers start lazily unless you pass
+`--warm`, so the port is not listening until the first request arrives.
 
 ## `--watch`
 

--- a/docs/local-start-api.md
+++ b/docs/local-start-api.md
@@ -30,7 +30,7 @@ cdkd local start-api --from-state --stage prod  # resolve env vars from deployed
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `[target]` | every discovered API | Serve only the named API. See [Target selection](#target-resolution). |
+| `[target]` | every discovered API | Serve only the named API. See [Target resolution](#target-resolution). |
 | `--port <port>` | `0` (auto-allocate) | Port for the first server; later servers take `port+1`, `port+2`, and so on. |
 | `--host <host>` | `127.0.0.1` | Bind address for every API server — the address **you** connect to. |
 | `--stack <name>` | single-stack auto-detect | Stack to serve, when neither the target nor `--from-cfn-stack` identifies one. |
@@ -460,9 +460,8 @@ principal and an empty claims map.
 
 The failure entry has a short TTL of about 60s, so a transient network blip does
 not lock pass-through in for the full success TTL — the next minute's request
-retries the fetch. The warn is throttled rather than one-shot: it re-fires at
-most once every five minutes per JWKS URL, so a proxy that stays down keeps
-saying so instead of going quiet after the first request.
+retries the fetch — and warns again when it fails again, so a proxy that stays
+down keeps saying so rather than going quiet after the first request.
 
 This is a deliberate trade for a dev tool: a surprising deny is worse than a
 warn plus allow when you are iterating on a handler and a corporate proxy is
@@ -722,9 +721,11 @@ once:
 - **Local build**, from the `cdk.out` asset manifest when the synthesizer
   produced a matching `dockerImages` entry. `docker build` then runs against the
   recorded build context.
-- **ECR pull**, when no asset matches. Same-account and same-region only —
-  this command has no `--ecr-role-arn`, so a cross-account registry needs
-  [`cdkd local invoke`](local-invoke.md#container-image-lambdas), which does.
+- **ECR pull**, when no asset matches. The ECR client is built for the image
+  URI's own region, so cross-region works. Cross-account works only when the
+  repository policy grants your identity directly: this command has no
+  `--ecr-role-arn`, so to assume a role first use
+  [`cdkd local invoke`](local-invoke.md#container-image-lambdas).
 
 The resulting deterministic `cdkd-local-invoke-<hash>` tag goes into the warm
 pool, which runs it verbatim: no `/var/task` bind mount, no base-image pull, and

--- a/docs/local-start-cloudfront.md
+++ b/docs/local-start-cloudfront.md
@@ -41,9 +41,9 @@ accept `--env-vars` or `--container-host`.
 | `--tls-key <path>` | — | PEM private key. Implies `--tls`. |
 | `--no-pull` | off | Skip `docker pull` for a Lambda origin's base image and use the cached one. No-op for a distribution with no Lambda. |
 | `--cache-origin` | off | Keep objects fetched from a deployed S3 origin in memory for the session instead of re-reading each request. |
-| `--from-state` | off | Bind a Function URL origin's backing Lambda to cdkd's S3 state. Does **not** reach deployed-S3 origin content — that needs `--from-cfn-stack`. Mutually exclusive with it. |
-| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Only meaningful with `--from-state`. |
-| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Only meaningful with `--from-state`. |
+| `--from-state` | off | Accepted, but **does nothing on this command** — see [State sources](#state-sources). Use `--from-cfn-stack`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Inert here, like `--from-state`. |
+| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Inert here, like `--from-state`. |
 | `--from-cfn-stack [name]` | off | Bind the same values to a deployed CloudFormation stack, for apps deployed with the CDK CLI. Bare form uses the resolved stack name. |
 | `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region under `--from-cfn-stack`. |
 | `--assume-role [arn]` | off | Assume a Lambda origin's deployed execution role and forward temporary credentials into its container. Omit the flag to keep your own shell credentials in the container. |
@@ -61,6 +61,18 @@ accept `--env-vars` or `--container-host`.
 `--region` / `AWS_REGION` to its canonical spelling, and AWS rejects the raw
 form at signature time (`SignatureDoesNotMatch`, `AuthorizationHeaderMalformed`).
 See [`--region` / `AWS_REGION`](cli-reference.md#region-aws-region-every-command).
+
+## State sources
+
+**`--from-state` is inert on this command.** The three cdkd-state flags
+(`--from-state`, `--state-bucket`, `--state-prefix`) parse and are then ignored:
+the deployed-S3 origin reader and the KeyValueStore binding both look for
+`--from-cfn-stack` specifically, and the Lambda origin and Lambda@Edge boot
+paths resolve their environment without consulting cdkd state at all.
+
+`--from-cfn-stack [name]` is the state source that works here. It binds a
+deployed-S3 origin's bucket, backs `cf.kvs()` reads with the deployed
+KeyValueStore, and resolves a Function URL origin's backing Lambda.
 
 ## Target resolution
 
@@ -88,9 +100,10 @@ served per invocation.
 The `<originId>` in `--origin <originId=dir>` is matched verbatim against the
 distribution's `Origins[].Id` in the synthesized template — not a construct
 path and not a logical ID, and CDK generates those ids with a hash suffix. You
-do not have to go looking for one: an origin cdkd cannot resolve raises a
-boot-time warning that spells the whole flag out for you, ending
-`--origin <that id>=<dir>`.
+do not have to go looking for one: an S3 origin whose local source cannot be
+resolved raises a boot-time warning that spells the flag out for you, including
+`--origin <that id>=<dir>`. A custom (non-S3, non-Function-URL) origin warns too,
+but `--origin` does not apply to it — nothing serves it locally.
 
 S3 origin content is resolved out of the cloud assembly: the origin's bucket →
 its `BucketDeployment` custom resource → `SourceObjectKeys` → the staged asset

--- a/docs/local-start-cloudfront.md
+++ b/docs/local-start-cloudfront.md
@@ -43,8 +43,8 @@ accept `--env-vars` or `--container-host`, and its `--from-state` is inert — s
 | `--no-pull` | off | Skip `docker pull` for a Lambda origin's base image and use the cached one. No-op for a distribution with no Lambda. |
 | `--cache-origin` | off | Keep objects fetched from a deployed S3 origin in memory for the session instead of re-reading each request. |
 | `--from-state` | off | Accepted, but **does nothing on this command**, and still conflicts with `--from-cfn-stack` — see [State sources](#state-sources). |
-| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json`, then `cdkd-state-{accountId}` | S3 bucket holding cdkd state. Inert here, like `--from-state`. |
-| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Inert here, like `--from-state`. |
+| `--state-bucket <bucket>` | — | Never read on this command, like `--from-state`. |
+| `--state-prefix <prefix>` | — | Never read on this command, like `--from-state`. |
 | `--from-cfn-stack [name]` | off | Bind the same values to a deployed CloudFormation stack, for apps deployed with the CDK CLI. Bare form uses the resolved stack name. |
 | `--stack-region <region>` | — | The CloudFormation client region under `--from-cfn-stack`. The state-record half does not apply here. |
 | `--assume-role [arn]` | off | Assume a Lambda origin's deployed execution role and forward temporary credentials into its container. Omit the flag to keep your own shell credentials in the container. |

--- a/docs/local-start-cloudfront.md
+++ b/docs/local-start-cloudfront.md
@@ -44,7 +44,7 @@ accept `--env-vars` or `--container-host`, and its `--from-state` is inert — s
 | `--cache-origin` | off | Keep objects fetched from a deployed S3 origin in memory for the session instead of re-reading each request. |
 | `--from-state` | off | Accepted, but **does nothing on this command**, and still conflicts with `--from-cfn-stack` — see [State sources](#state-sources). |
 | `--state-bucket <bucket>` | — | Never read on this command, like `--from-state`. |
-| `--state-prefix <prefix>` | — | Never read on this command, like `--from-state`. |
+| `--state-prefix <prefix>` | `cdkd` | Never read on this command, like `--from-state`. |
 | `--from-cfn-stack [name]` | off | Bind the same values to a deployed CloudFormation stack, for apps deployed with the CDK CLI. Bare form uses the resolved stack name. |
 | `--stack-region <region>` | — | The CloudFormation client region under `--from-cfn-stack`. The state-record half does not apply here. |
 | `--assume-role [arn]` | off | Assume a Lambda origin's deployed execution role and forward temporary credentials into its container. Omit the flag to keep your own shell credentials in the container. |

--- a/docs/local-start-cloudfront.md
+++ b/docs/local-start-cloudfront.md
@@ -34,14 +34,14 @@ accept `--env-vars` or `--container-host`.
 | `[target]` | interactive picker | The distribution to serve, as a CDK construct path (`MyStack/MyDist`), an ancestor prefix, or a stack-qualified logical ID. Omit in a TTY to pick from a list. |
 | `--port <port>` | `0` (auto-allocate) | Port the local HTTP server listens on. |
 | `--host <host>` | `127.0.0.1` | Bind address. |
-| `--origin <originId=dir>` | — | Serve one origin from a local directory. Repeatable. Use it when the origin's `BucketDeployment` source cannot be resolved. |
+| `--origin <originId=dir>` | — | Serve one origin from a local directory. Repeatable. `<originId>` is the distribution's own `Origins[].Id` — see [Origins](#origins). |
 | `--kvs-file <key=file.json>` | — | Back a CloudFront Function's `cf.kvs()` reads with a flat local JSON map. Repeatable. |
 | `--tls` | off | Terminate real HTTPS, using `--tls-cert` / `--tls-key` when supplied and an auto-generated self-signed certificate otherwise. |
 | `--tls-cert <path>` | — | PEM server certificate. Implies `--tls`. |
 | `--tls-key <path>` | — | PEM private key. Implies `--tls`. |
 | `--no-pull` | off | Skip `docker pull` for a Lambda origin's base image and use the cached one. No-op for a distribution with no Lambda. |
 | `--cache-origin` | off | Keep objects fetched from a deployed S3 origin in memory for the session instead of re-reading each request. |
-| `--from-state` | off | Bind a Function URL origin's backing Lambda and a deployed-S3 origin's bucket name to cdkd's S3 state. Mutually exclusive with `--from-cfn-stack`. |
+| `--from-state` | off | Bind a Function URL origin's backing Lambda to cdkd's S3 state. Does **not** reach deployed-S3 origin content — that needs `--from-cfn-stack`. Mutually exclusive with it. |
 | `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Only meaningful with `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Only meaningful with `--from-state`. |
 | `--from-cfn-stack [name]` | off | Bind the same values to a deployed CloudFormation stack, for apps deployed with the CDK CLI. Bare form uses the resolved stack name. |
@@ -56,6 +56,11 @@ accept `--env-vars` or `--container-host`.
 | `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for AWS API calls. |
 | `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
 | `--verbose` | off | Verbose logging. |
+
+**Spell the region lower-case.** This command does not fold an upper-cased
+`--region` / `AWS_REGION` to its canonical spelling, and AWS rejects the raw
+form at signature time (`SignatureDoesNotMatch`, `AuthorizationHeaderMalformed`).
+See [`--region` / `AWS_REGION`](cli-reference.md#region-aws-region-every-command).
 
 ## Target resolution
 
@@ -79,6 +84,13 @@ served per invocation.
 | CDN caching and edge locations | Not reproduced. `--cache-origin` is an origin read-through cache, not CloudFront's. |
 
 ### Origins
+
+The `<originId>` in `--origin <originId=dir>` is matched verbatim against the
+distribution's `Origins[].Id` in the synthesized template — not a construct
+path and not a logical ID, and CDK generates those ids with a hash suffix. You
+do not have to go looking for one: an origin cdkd cannot resolve raises a
+boot-time warning that spells the whole flag out for you, ending
+`--origin <that id>=<dir>`.
 
 S3 origin content is resolved out of the cloud assembly: the origin's bucket →
 its `BucketDeployment` custom resource → `SourceObjectKeys` → the staged asset
@@ -181,3 +193,5 @@ The full cross-command table is in the
   front door
 - [Local Execution](local-emulation.md) — every `cdkd local` subcommand, Docker
   requirements, and the flags they share
+- [CLI Reference](cli-reference.md) — every cdkd command, the output-stream
+  contract, and the full exit-code table

--- a/docs/local-start-cloudfront.md
+++ b/docs/local-start-cloudfront.md
@@ -19,15 +19,16 @@ cdkd local start-cloudfront                                                   # 
 cdkd local start-cloudfront MyStack/MyDistribution --port 8080                # pin the listener port
 cdkd local start-cloudfront MyStack/MyDistribution --origin SiteOrigin=./dist # serve an origin from a local directory
 cdkd local start-cloudfront MyStack/MyDistribution --kvs-file RoutesKvs=./routes.json  # back cf.kvs() from a local file
-cdkd local start-cloudfront MyStack/MyDistribution --from-state --watch       # bind cdkd state, hot-reload on source edits
+cdkd local start-cloudfront MyStack/MyDistribution --from-cfn-stack --watch   # bind deployed state, hot-reload on source edits
 ```
 
 ## Options
 
-`-a, --app`, `--no-pull`, `--from-state` and `--stack-region` behave as they do
-on every `cdkd local` subcommand; see
+`-a, --app`, `--no-pull` and `--stack-region` behave as they do on every
+`cdkd local` subcommand; see
 [Local Execution](local-emulation.md#common-flags). This command does **not**
-accept `--env-vars` or `--container-host`.
+accept `--env-vars` or `--container-host`, and its `--from-state` is inert — see
+[State sources](#state-sources).
 
 | Flag | Default | Description |
 | --- | --- | --- |
@@ -41,7 +42,7 @@ accept `--env-vars` or `--container-host`.
 | `--tls-key <path>` | — | PEM private key. Implies `--tls`. |
 | `--no-pull` | off | Skip `docker pull` for a Lambda origin's base image and use the cached one. No-op for a distribution with no Lambda. |
 | `--cache-origin` | off | Keep objects fetched from a deployed S3 origin in memory for the session instead of re-reading each request. |
-| `--from-state` | off | Accepted, but **does nothing on this command** — see [State sources](#state-sources). Use `--from-cfn-stack`. |
+| `--from-state` | off | Accepted, but **does nothing on this command**, and still conflicts with `--from-cfn-stack` — see [State sources](#state-sources). |
 | `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Inert here, like `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Inert here, like `--from-state`. |
 | `--from-cfn-stack [name]` | off | Bind the same values to a deployed CloudFormation stack, for apps deployed with the CDK CLI. Bare form uses the resolved stack name. |
@@ -72,7 +73,11 @@ paths resolve their environment without consulting cdkd state at all.
 
 `--from-cfn-stack [name]` is the state source that works here. It binds a
 deployed-S3 origin's bucket, backs `cf.kvs()` reads with the deployed
-KeyValueStore, and resolves a Function URL origin's backing Lambda.
+KeyValueStore, and resolves the environment of both Function URL origin Lambdas
+and Lambda@Edge functions.
+
+Passing `--from-state` and `--from-cfn-stack` together is still an error, so
+drop `--from-state` rather than leaving it on as a no-op.
 
 ## Target resolution
 
@@ -92,7 +97,7 @@ served per invocation.
 | S3 origin content | Read from the staged asset directory, or from real S3 under `--from-cfn-stack`. No Docker. |
 | Path routing | In-process, across `DefaultCacheBehavior` plus the ordered `CacheBehaviors[]`, using CloudFront's `*` / `?` glob matching. |
 | `DefaultRootObject` and `CustomErrorResponses` | Applied in-process — the root path resolves to the default root object, and error responses give the SPA fallback. |
-| Custom (non-S3, non-Function-URL) origins | Not run. A warning at boot, `502` at request time. |
+| Custom (non-S3, non-Function-URL) origins | Not fetched. A warning at boot, `502` at request time — unless you point the origin at a directory with `--origin`. |
 | CDN caching and edge locations | Not reproduced. `--cache-origin` is an origin read-through cache, not CloudFront's. |
 
 ### Origins
@@ -102,8 +107,10 @@ distribution's `Origins[].Id` in the synthesized template — not a construct
 path and not a logical ID, and CDK generates those ids with a hash suffix. You
 do not have to go looking for one: an S3 origin whose local source cannot be
 resolved raises a boot-time warning that spells the flag out for you, including
-`--origin <that id>=<dir>`. A custom (non-S3, non-Function-URL) origin warns too,
-but `--origin` does not apply to it — nothing serves it locally.
+`--origin <that id>=<dir>`. A custom (non-S3, non-Function-URL) origin warns
+without naming the flag, but `--origin` works on it just the same — an override
+is applied before the origin is classified, so pointing any origin at a
+directory serves it from there.
 
 S3 origin content is resolved out of the cloud assembly: the origin's bucket →
 its `BucketDeployment` custom resource → `SourceObjectKeys` → the staged asset

--- a/docs/local-start-cloudfront.md
+++ b/docs/local-start-cloudfront.md
@@ -37,16 +37,16 @@ accept `--env-vars` or `--container-host`, and its `--from-state` is inert — s
 | `--host <host>` | `127.0.0.1` | Bind address. |
 | `--origin <originId=dir>` | — | Serve one origin from a local directory. Repeatable. `<originId>` is the distribution's own `Origins[].Id` — see [Origins](#origins). |
 | `--kvs-file <key=file.json>` | — | Back a CloudFront Function's `cf.kvs()` reads with a flat local JSON map. Repeatable. |
-| `--tls` | off | Terminate real HTTPS, using `--tls-cert` / `--tls-key` when supplied and an auto-generated self-signed certificate otherwise. |
-| `--tls-cert <path>` | — | PEM server certificate. Implies `--tls`. |
-| `--tls-key <path>` | — | PEM private key. Implies `--tls`. |
+| `--tls` | off | Terminate real HTTPS. With `--tls-cert` / `--tls-key` it uses your PEM pair; otherwise it generates a self-signed certificate, which needs `openssl` on `PATH`. |
+| `--tls-cert <path>` | — | PEM server certificate. Implies `--tls`; must be paired with `--tls-key`. |
+| `--tls-key <path>` | — | PEM private key. Implies `--tls`; must be paired with `--tls-cert`. |
 | `--no-pull` | off | Skip `docker pull` for a Lambda origin's base image and use the cached one. No-op for a distribution with no Lambda. |
 | `--cache-origin` | off | Keep objects fetched from a deployed S3 origin in memory for the session instead of re-reading each request. |
 | `--from-state` | off | Accepted, but **does nothing on this command**, and still conflicts with `--from-cfn-stack` — see [State sources](#state-sources). |
-| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Inert here, like `--from-state`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json`, then `cdkd-state-{accountId}` | S3 bucket holding cdkd state. Inert here, like `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Inert here, like `--from-state`. |
 | `--from-cfn-stack [name]` | off | Bind the same values to a deployed CloudFormation stack, for apps deployed with the CDK CLI. Bare form uses the resolved stack name. |
-| `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region under `--from-cfn-stack`. |
+| `--stack-region <region>` | — | The CloudFormation client region under `--from-cfn-stack`. The state-record half does not apply here. |
 | `--assume-role [arn]` | off | Assume a Lambda origin's deployed execution role and forward temporary credentials into its container. Omit the flag to keep your own shell credentials in the container. |
 | `--watch` | off | Re-synth and re-resolve the distribution when the CDK source changes. |
 | `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a path to a pre-synthesized cloud assembly. |

--- a/docs/local-start-cloudfront.md
+++ b/docs/local-start-cloudfront.md
@@ -1,100 +1,183 @@
 ---
-title: local start-cloudfront
+title: cdkd local start-cloudfront
 description: "Serve a CloudFront distribution locally — CloudFront Functions in a node:vm sandbox, S3 origins from local assets, and Lambda Function URL origins via the RIE container."
 ---
 
-# `local start-cloudfront` (run a CloudFront distribution locally)
+# cdkd local start-cloudfront
 
-`cdkd local start-cloudfront [target]` serves a CloudFront
-distribution's **viewer-request -> S3 / Lambda Function URL origin ->
-viewer-response** pipeline locally so a routing-function change is
-verifiable in seconds instead of a deploy round-trip. Models cdk-local's
-`cdkl start-cloudfront`, inherited into cdkd's command tree as a thin
-pass-through to `cdk-local`'s command factory. A CloudFront-Functions +
-S3-origin-only distribution is pure-local (no Docker); a distribution
-with a Lambda Function URL origin runs that origin's backing Lambda via
-the RIE container (Docker required). It binds a Function URL origin's
-backing Lambda + a deployed-S3 origin's bucket name to deployed state via
-cdkd's S3-backed `--from-state` (after a prior `cdkd deploy`) OR
-cdk-local's inherited `--from-cfn-stack` / `--stack-region` /
-`--assume-role` (CloudFormation-deployed stacks). The two state sources
-are mutually exclusive.
+`cdkd local start-cloudfront [target]` serves one CloudFront distribution's
+**viewer-request → origin → viewer-response** pipeline on a local port. Reach
+for it when a rewrite function, a cache-behaviour path pattern or an SPA
+fallback needs to be checked in seconds instead of a deploy round-trip. A
+distribution built from CloudFront Functions and S3 origins runs entirely
+in-process and needs no Docker; a Lambda Function URL origin or a Lambda@Edge
+association runs its function in a local RIE container, which does.
 
-As of cdk-local 0.128.0 the start-cloudfront factory
-accepts the `extraStateProviders` seam, so cdkd threads its `--from-state`
-factory in and layers `--from-state` / `--state-bucket` / `--state-prefix`
-on top — the same wiring as `start-agentcore` / `start-alb` /
-`start-service` (`start-cloudfront` was `--from-state`-exempt
-before the seam landed).
+```bash
+cdkd local start-cloudfront MyStack/MyDistribution                            # serve one distribution
+cdkd local start-cloudfront                                                   # pick a distribution interactively (TTY)
+cdkd local start-cloudfront MyStack/MyDistribution --port 8080                # pin the listener port
+cdkd local start-cloudfront MyStack/MyDistribution --origin SiteOrigin=./dist # serve an origin from a local directory
+cdkd local start-cloudfront MyStack/MyDistribution --kvs-file RoutesKvs=./routes.json  # back cf.kvs() from a local file
+cdkd local start-cloudfront MyStack/MyDistribution --from-state --watch       # bind cdkd state, hot-reload on source edits
+```
 
-### `local start-cloudfront` target resolution
+## Options
 
-Names one `AWS::CloudFront::Distribution` by its CDK display path
-(`MyStack/MyDistribution`). Omit the target in a TTY for an interactive
-picker over every distribution in the synthesized app. A single
-distribution is served per invocation.
+`-a, --app`, `--no-pull`, `--from-state` and `--stack-region` behave as they do
+on every `cdkd local` subcommand; see
+[Local Execution](local-emulation.md#common-flags). This command does **not**
+accept `--env-vars` or `--container-host`.
 
-### `local start-cloudfront` what runs locally
+| Flag | Default | Description |
+| --- | --- | --- |
+| `[target]` | interactive picker | The distribution to serve, as a CDK construct path (`MyStack/MyDist`), an ancestor prefix, or a stack-qualified logical ID. Omit in a TTY to pick from a list. |
+| `--port <port>` | `0` (auto-allocate) | Port the local HTTP server listens on. |
+| `--host <host>` | `127.0.0.1` | Bind address. |
+| `--origin <originId=dir>` | — | Serve one origin from a local directory. Repeatable. Use it when the origin's `BucketDeployment` source cannot be resolved. |
+| `--kvs-file <key=file.json>` | — | Back a CloudFront Function's `cf.kvs()` reads with a flat local JSON map. Repeatable. |
+| `--tls` | off | Terminate real HTTPS, using `--tls-cert` / `--tls-key` when supplied and an auto-generated self-signed certificate otherwise. |
+| `--tls-cert <path>` | — | PEM server certificate. Implies `--tls`. |
+| `--tls-key <path>` | — | PEM private key. Implies `--tls`. |
+| `--no-pull` | off | Skip `docker pull` for a Lambda origin's base image and use the cached one. No-op for a distribution with no Lambda. |
+| `--cache-origin` | off | Keep objects fetched from a deployed S3 origin in memory for the session instead of re-reading each request. |
+| `--from-state` | off | Bind a Function URL origin's backing Lambda and a deployed-S3 origin's bucket name to cdkd's S3 state. Mutually exclusive with `--from-cfn-stack`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state. Only meaningful with `--from-state`. |
+| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. Only meaningful with `--from-state`. |
+| `--from-cfn-stack [name]` | off | Bind the same values to a deployed CloudFormation stack, for apps deployed with the CDK CLI. Bare form uses the resolved stack name. |
+| `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region under `--from-cfn-stack`. |
+| `--assume-role [arn]` | off | Assume a Lambda origin's deployed execution role and forward temporary credentials into its container. Omit the flag to keep your own shell credentials in the container. |
+| `--watch` | off | Re-synth and re-resolve the distribution when the CDK source changes. |
+| `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a path to a pre-synthesized cloud assembly. |
+| `--output <path>` | `cdk.out` | Output directory for synthesis. |
+| `-c`, `--context <key=value>` | — | Context value passed to synthesis. Repeatable. |
+| `--region <region>` | `AWS_REGION` / stack / profile | AWS region for SDK calls. |
+| `--profile <profile>` | — | AWS profile. |
+| `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for AWS API calls. |
+| `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
+| `--verbose` | off | Verbose logging. |
 
-- **CloudFront Functions** (`cloudfront-js-1.0` / `2.0`) — the inline
-  rewrite JS associated as `viewer-request` / `viewer-response` runs
-  in-process in a `node:vm` sandbox (async 2.0 handlers awaited). A
-  viewer-request function that returns a `statusCode` short-circuits with
-  a generated response (redirect / fixed body); otherwise the rewritten
-  request continues to the origin, then the viewer-response function runs
-  over the origin response.
-- **S3 origin content** — resolved out of the cloud assembly: the
-  origin's bucket -> its `BucketDeployment` custom resource ->
-  `SourceObjectKeys` -> the staged asset directory (or, under
-  `--from-cfn-stack`, the deployed bucket served from real S3 on demand).
-  Served with `DefaultRootObject` (root only — sub-paths are NOT
-  auto-indexed, matching CloudFront) and `CustomErrorResponses` (the SPA
-  fallback).
-- **Lambda Function URL origins** — the origin's backing Lambda is run
-  locally via the RIE container (the same path as `local invoke`), so a
-  distribution that fronts a Function URL is served end-to-end.
-- **Routing** — path patterns route across the `DefaultCacheBehavior` +
-  ordered `CacheBehaviors[]` (CloudFront `*` / `?` glob matching).
+## Target resolution
 
-### `local start-cloudfront` options
+The target names one `AWS::CloudFront::Distribution`, as a CDK construct path
+(`MyStack/MyDistribution`), an ancestor prefix of one, or a stack-qualified
+logical ID (`MyStack:MyDistribution`). Omitting it in a TTY opens an interactive
+picker over every distribution in the synthesized app. One distribution is
+served per invocation.
 
-- `--port <n>` — listener port (default `0` = collision-bumped).
-- `--host <ip>` — bind IP (default `127.0.0.1`).
-- `--tls` / `--tls-cert <p>` / `--tls-key <p>` — terminate real HTTPS
-  (user-supplied PEM pair or an auto-generated self-signed cert).
-- `--origin <id>=<dir>` — point an origin at a local directory when
-  `BucketDeployment` resolution can't (content uploaded out of band,
-  non-CDK bucket). Repeatable.
-- `--kvs-file <key>=<file>` — supply a CloudFront KeyValueStore's contents
-  from a local JSON file (the AWS-free alternative to `--from-cfn-stack`,
-  which reads the deployed store on demand). `<key>` is a KeyValueStore
-  handle — its `AWS::CloudFront::KeyValueStore` resource logical id, its
-  construct path (`MyStack/RoutesKvs`), or its bare construct id
-  (`RoutesKvs`) — so you no longer have to synth + grep for the
-  hash-suffixed logical id. An unrecognized key (or an ambiguous bare id)
-  fails fast with an error listing the distribution's KeyValueStore
-  candidates. Repeatable.
-- `--cache-origin` — keep fetched deployed-S3 origin objects in memory
-  (only meaningful under `--from-cfn-stack`). Setting it without
-  `--from-cfn-stack` is a no-op and now logs a boot-time WARN saying so
-  (a local BucketDeployment / `--origin <id>=<dir>` origin serves from
-  disk and is never cached).
-- `--no-pull` — skip `docker pull` for a Lambda Function URL origin's
-  base image (no-op for a Function-URL-free distribution).
-- `--from-state` / `--state-bucket <bucket>` / `--state-prefix <prefix>`
-  — bind a Function URL origin's backing Lambda + a deployed-S3 origin's
-  bucket name to cdkd's S3 state (after a prior `cdkd deploy`). Mutually
-  exclusive with `--from-cfn-stack`. `--state-prefix` defaults to `cdkd`.
-- `--from-cfn-stack [name]` / `--stack-region <region>` /
-  `--assume-role [arn]` — the CloudFormation-deployed-stack counterpart of
-  `--from-state` (for apps deployed via the upstream CDK CLI).
-- `--watch` — re-synth + atomically swap the in-memory routing model
-  under the live socket on every CDK source edit.
+## What runs locally
 
-### `local start-cloudfront` scope
+| Piece of the distribution | How it is served |
+| --- | --- |
+| CloudFront Functions (`viewer-request` / `viewer-response`) | In-process, in a `node:vm` sandbox. No Docker. |
+| Lambda@Edge associations (all four stages) | One warm RIE container per distinct function. Docker. |
+| Lambda Function URL origins | The backing Lambda in a local RIE container. Docker. |
+| S3 origin content | Read from the staged asset directory, or from real S3 under `--from-cfn-stack`. No Docker. |
+| Path routing | In-process, across `DefaultCacheBehavior` plus the ordered `CacheBehaviors[]`, using CloudFront's `*` / `?` glob matching. |
+| `DefaultRootObject` and `CustomErrorResponses` | Applied in-process — the root path resolves to the default root object, and error responses give the SPA fallback. |
+| Custom (non-S3, non-Function-URL) origins | Not run. A warning at boot, `502` at request time. |
+| CDN caching and edge locations | Not reproduced. `--cache-origin` is an origin read-through cache, not CloudFront's. |
 
-S3 origins + Lambda Function URL origins. A custom (non-S3, non-Function-URL)
-origin, a `LambdaFunctionAssociations` Lambda@Edge association, and the
-2.0 `cf.fetch` origin API are warn-and-skip (custom / unresolved origins
-return 502).
+### Origins
 
+S3 origin content is resolved out of the cloud assembly: the origin's bucket →
+its `BucketDeployment` custom resource → `SourceObjectKeys` → the staged asset
+directory. Reads are path-traversal safe — a resolved path that escapes the
+origin directory, whether through `../` or a symlink, yields no read.
+
+Two origins cannot be resolved that way, and each has a route out:
+
+| Situation | Result | Remedy |
+| --- | --- | --- |
+| The bucket has no `BucketDeployment` in the app (files uploaded out of band, or a non-CDK bucket) | Warning at boot, `502` at request time | `--origin <id>=<dir>` to serve from disk, or `--from-cfn-stack` to read the deployed bucket from real S3 |
+| The origin points at a custom domain that is neither S3 nor a Function URL | Warning at boot, `502` at request time | None — this origin shape is not served locally |
+
+A URI ending in `/` is **not** auto-indexed, matching CloudFront: only the root
+path resolves to `DefaultRootObject`, and a sub-path directory falls through to
+a missing key unless a function rewrote it.
+
+Under `--from-cfn-stack`, a deployed S3 origin is read from real S3 on every
+request so out-of-band content changes are always current. `--cache-origin`
+trades that for in-memory reuse across the session; the cache is cleared on a
+`--watch` reload and on restart. Passing it without `--from-cfn-stack` is a
+no-op, and a boot-time warning says so.
+
+### CloudFront Functions
+
+Both `cloudfront-js-1.0` and `cloudfront-js-2.0` are compiled and run. A `2.0`
+async handler's promise is awaited. Each invocation gets a fresh sandbox, and
+its synchronous portion is bounded at 5 seconds, so a runaway loop fails that
+one request rather than wedging the server.
+
+- A `viewer-request` function that returns an object with a `statusCode`
+  short-circuits with a generated response — a redirect or a fixed body.
+  Otherwise the rewritten request continues to the origin.
+- A `viewer-response` function then runs over the origin response.
+- A function that returns a non-object, or nothing, is treated as "continue
+  unchanged", matching CloudFront's tolerance of an inspect-only function.
+- A function with no `handler` function declared fails to compile, naming the
+  function.
+
+`cf.kvs()` reads are backed either by `--kvs-file <key>=<file.json>` (no AWS
+calls) or by `--from-cfn-stack`, which reads the deployed store on demand. The
+`<key>` is a KeyValueStore handle — the `AWS::CloudFront::KeyValueStore`
+resource's logical ID, its construct path (`MyStack/RoutesKvs`), or its bare
+construct ID (`RoutesKvs`) — so there is no need to synthesize and grep for a
+hash-suffixed logical ID. An unrecognized key, or an ambiguous bare ID, fails at
+boot with an error listing the distribution's KeyValueStore candidates. With no
+binding resolved, `cf.kvs()` itself still returns a handle and the actionable
+error surfaces on the first read.
+
+## `--watch`: hot reload of the routing model
+
+`--watch` re-synthesizes on every CDK source change and atomically swaps the
+in-memory routing model under the live socket, so the port never closes.
+`cdk.json`'s `watch.include` / `watch.exclude` are honored, and `cdk.out`,
+`node_modules` and `.git` are always excluded. A reload also re-reads any
+`--kvs-file` bindings and clears the deployed-S3 read-through cache. When
+synthesis fails mid-reload, the previous version keeps serving and a warning is
+printed.
+
+Lambda containers — Function URL origins and Lambda@Edge alike — are booted once
+at start-up and are **not** rebuilt by a reload. A Lambda@Edge association added
+after start-up is skipped with a warning; restart to pick it up.
+
+## Lifecycle
+
+The server runs until it is signalled. `^C` (SIGINT) and SIGTERM close the
+watcher and the HTTP server, stop every Lambda Function URL and Lambda@Edge
+container, and close the deployed-S3 readers before exiting.
+
+## Limitations
+
+- Custom origins — anything that is neither an S3 origin nor a Lambda Function
+  URL origin — are not served. They warn at boot and return `502`.
+- The `cloudfront-js-2.0` `cf.fetch` origin API is not reproduced.
+- `cf.kvs()` supports `get` and `exists`. `meta()` and `count()` reject with an
+  error saying so.
+- Lambda containers are booted once and are not rebuilt on a `--watch` reload.
+- A Lambda@Edge function that cannot be booted is skipped with a warning, and its
+  stage does not run; the rest of the distribution still serves.
+- CloudFront's own CDN caching, edge locations and cache keys are not modelled.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Shut down on SIGTERM. |
+| `1` | Hard error — no such distribution, synthesis failure, an unresolvable `--kvs-file` key, or a Lambda origin container that failed to boot. |
+| `130` | Shut down on `^C` (SIGINT), or the interactive picker was cancelled. |
+
+The full cross-command table is in the
+[CLI Reference](cli-reference.md#exit-codes).
+
+## Related
+
+- [`cdkd local invoke`](local-invoke.md) — one-shot Lambda invoke, the same RIE
+  container a Function URL origin and a Lambda@Edge stage use
+- [`cdkd local start-api`](local-start-api.md) — the API Gateway front door, for
+  a distribution whose origin is an API rather than a bucket
+- [`cdkd local start-alb`](local-start-alb.md) — the Application Load Balancer
+  front door
+- [Local Execution](local-emulation.md) — every `cdkd local` subcommand, Docker
+  requirements, and the flags they share

--- a/docs/local-start-service.md
+++ b/docs/local-start-service.md
@@ -30,7 +30,7 @@ Docker is required — see [Local Execution](local-emulation.md#requirements).
 | --- | --- | --- |
 | `[targets...]` | interactive picker | One or more CDK display paths or stack-qualified logical ids of `AWS::ECS::Service` resources. Omit in a TTY to multi-select. |
 | `--cluster <name>` | `cdkd-local` | Cluster name reported by the metadata endpoint, and the prefix of the shared Docker network and per-replica cluster names. |
-| `--max-tasks <n>` | `3` | Hard cap on the local replica count, applied over the template's `DesiredCount`. Must be between `1` and `83` — the range of the per-replica link-local subnet allocator. |
+| `--max-tasks <n>` | `3` | Hard cap on the local replica count, applied over the template's `DesiredCount`. Must be between `1` and `83` — the ceiling the local address allocator can serve. |
 | `--restart-policy <policy>` | `on-failure` | How to react when a replica's essential container exits: `on-failure`, `always`, or `none`. |
 | `--host-port <containerPort=hostPort...>` | host port equals container port | Publish a container port on a specific host port, e.g. `80=8080`. Repeatable. Single-replica services only. |
 | `--no-logs` | off (logs stream) | Stop streaming each replica's container output to your terminal. `docker logs -f <id>` stays available. |
@@ -53,7 +53,7 @@ Docker is required — see [Local Execution](local-emulation.md#requirements).
 | `--from-state` | off | Substitute deployed values from cdkd's S3 state into images, environment variables, secrets, role ARNs and volumes — see [Local Execution](local-emulation.md#common-flags). |
 | `--from-cfn-stack [name]` | off | Substitute from a CloudFormation-deployed stack instead. Bare form uses the cdkd stack name. Mutually exclusive with `--from-state`. |
 | `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region for `--from-cfn-stack` — see [Local Execution](local-emulation.md#common-flags). |
-| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state, for `--from-state`. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json`, then `cdkd-state-{accountId}` | S3 bucket holding cdkd state, for `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. |
 | `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a path to a pre-synthesized cloud assembly — see [Local Execution](local-emulation.md#common-flags). |
 | `--output <path>` | `cdk.out` | Output directory for synthesis. |

--- a/docs/local-start-service.md
+++ b/docs/local-start-service.md
@@ -30,7 +30,7 @@ Docker is required — see [Local Execution](local-emulation.md#requirements).
 | --- | --- | --- |
 | `[targets...]` | interactive picker | One or more CDK display paths or stack-qualified logical ids of `AWS::ECS::Service` resources. Omit in a TTY to multi-select. |
 | `--cluster <name>` | `cdkd-local` | Cluster name reported by the metadata endpoint, and the prefix of the shared Docker network and per-replica cluster names. |
-| `--max-tasks <n>` | `3` | Hard cap on the local replica count, applied over the template's `DesiredCount`. Must be between `1` and `83` — the ceiling the local address allocator can serve. |
+| `--max-tasks <n>` | `3` | Hard cap on the local replica count, applied over the template's `DesiredCount`. Must be between `1` and `83` — the range of the per-replica link-local /24 subnet allocator. |
 | `--restart-policy <policy>` | `on-failure` | How to react when a replica's essential container exits: `on-failure`, `always`, or `none`. |
 | `--host-port <containerPort=hostPort...>` | host port equals container port | Publish a container port on a specific host port, e.g. `80=8080`. Repeatable. Single-replica services only. |
 | `--no-logs` | off (logs stream) | Stop streaming each replica's container output to your terminal. `docker logs -f <id>` stays available. |

--- a/docs/local-start-service.md
+++ b/docs/local-start-service.md
@@ -17,12 +17,12 @@ Connect registry so they can discover each other.
 cdkd local start-service MyStack/Orders                       # one service, DesiredCount replicas
 cdkd local start-service MyStack/Orders MyStack/Frontend      # two services that discover each other
 cdkd local start-service                                      # pick services interactively (TTY only)
-cdkd local start-service MyStack/Orders --max-tasks 1 --host-port 80=8080
+cdkd local start-service MyStack/Orders --max-tasks 1 --host-port 80=8080   # one replica, so a host port can be published
 cdkd local start-service MyStack/Orders --from-state          # resolve intrinsics from deployed state
-cdkd local start-service MyStack/Orders --watch --image-override MyStack/Orders=./Dockerfile
+cdkd local start-service MyStack/Orders --watch --image-override MyStack/Orders=./Dockerfile  # build locally, roll on edits
 ```
 
-Docker is required — see [Local execution](local-emulation.md#requirements).
+Docker is required — see [Local Execution](local-emulation.md#requirements).
 
 ## Options
 
@@ -30,7 +30,7 @@ Docker is required — see [Local execution](local-emulation.md#requirements).
 | --- | --- | --- |
 | `[targets...]` | interactive picker | One or more CDK display paths or stack-qualified logical ids of `AWS::ECS::Service` resources. Omit in a TTY to multi-select. |
 | `--cluster <name>` | `cdkd-local` | Cluster name reported by the metadata endpoint, and the prefix of the shared Docker network and per-replica cluster names. |
-| `--max-tasks <n>` | `3` | Hard cap on the local replica count, applied over the template's `DesiredCount`. Must be between `1` and `83`. |
+| `--max-tasks <n>` | `3` | Hard cap on the local replica count, applied over the template's `DesiredCount`. Must be between `1` and `83` — the range of the per-replica link-local subnet allocator. |
 | `--restart-policy <policy>` | `on-failure` | How to react when a replica's essential container exits: `on-failure`, `always`, or `none`. |
 | `--host-port <containerPort=hostPort...>` | host port equals container port | Publish a container port on a specific host port, e.g. `80=8080`. Repeatable. Single-replica services only. |
 | `--no-logs` | off (logs stream) | Stop streaming each replica's container output to your terminal. `docker logs -f <id>` stays available. |
@@ -42,20 +42,20 @@ Docker is required — see [Local execution](local-emulation.md#requirements).
 | `--image-target <stage or svc=stage...>` | — | A `docker build --target` stage for every override build. Repeatable. `<service>=<stage>` scopes it and beats the global value. |
 | `--no-interactive-overrides` | off (prompts) | Suppress the boot prompt asking for a Dockerfile per pinned target, and the picker fired by a bare `--image-override`. |
 | `--strict-overrides` | off | Fail at boot when any pinned target is still uncovered after `--image-override` and the boot prompt have resolved. |
-| `--env-vars <file>` | — | SAM-shape JSON env-var overrides, keyed by container name — see [Local execution](local-emulation.md#common-flags). |
-| `--container-host <ip>` | `127.0.0.1` | Host IP that published container ports bind to. Must be numeric — see [Local execution](local-emulation.md#common-flags). |
+| `--env-vars <file>` | — | SAM-shape JSON env-var overrides, keyed by container name — see [Local Execution](local-emulation.md#common-flags). |
+| `--container-host <ip>` | `127.0.0.1` | Host IP that published container ports bind to. Must be numeric — see [Local Execution](local-emulation.md#common-flags). |
 | `--assume-role [arn]` | off | Assume the task definition's `TaskRoleArn` (or the ARN you pass) and serve those credentials through the metadata sidecar. |
-| `--assume-task-role [arn]` | off | Deprecated alias of `--assume-role`. Both work; `--assume-role` is the cross-command name. |
-| `--no-pull` | off | Skip `docker pull` for every container image and the metadata sidecar — see [Local execution](local-emulation.md#common-flags). |
+| `--assume-task-role [arn]` | off | Deprecated alias of `--assume-role` on this command. Both work here; note that `cdkd local run-task` accepts only `--assume-task-role`. |
+| `--no-pull` | off | Skip `docker pull` for every container image and the metadata sidecar — see [Local Execution](local-emulation.md#common-flags). |
 | `--no-build` | off | Skip `docker build` on the CDK-asset path and reuse the previously built tag. Errors when that tag is not in the local registry. |
 | `--ecr-role-arn <arn>` | — | Role to assume before authenticating to ECR, for cross-account or centralized registries. |
 | `--platform <platform>` | inferred from `RuntimePlatform.CpuArchitecture` | Force `docker run --platform`. Accepts `linux/amd64` or `linux/arm64`. |
-| `--from-state` | off | Substitute deployed values from cdkd's S3 state into images, environment variables, secrets, role ARNs and volumes — see [Local execution](local-emulation.md#common-flags). |
+| `--from-state` | off | Substitute deployed values from cdkd's S3 state into images, environment variables, secrets, role ARNs and volumes — see [Local Execution](local-emulation.md#common-flags). |
 | `--from-cfn-stack [name]` | off | Substitute from a CloudFormation-deployed stack instead. Bare form uses the cdkd stack name. Mutually exclusive with `--from-state`. |
-| `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region for `--from-cfn-stack` — see [Local execution](local-emulation.md#common-flags). |
+| `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region for `--from-cfn-stack` — see [Local Execution](local-emulation.md#common-flags). |
 | `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state, for `--from-state`. |
 | `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. |
-| `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a path to a pre-synthesized cloud assembly — see [Local execution](local-emulation.md#common-flags). |
+| `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a path to a pre-synthesized cloud assembly — see [Local Execution](local-emulation.md#common-flags). |
 | `--output <path>` | `cdk.out` | Output directory for synthesis. |
 | `-c`, `--context <key=value...>` | — | Set CDK context values. Repeatable. |
 | `--region <region>` | `AWS_REGION`, the stack's region, then the profile's | AWS region for SDK calls. |
@@ -63,6 +63,11 @@ Docker is required — see [Local execution](local-emulation.md#requirements).
 | `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for cdkd's own AWS API calls. |
 | `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
 | `--verbose` | off | Verbose logging. |
+
+**Spell the region lower-case.** This command does not fold an upper-cased
+`--region` / `AWS_REGION` to its canonical spelling, and AWS rejects the raw
+form at signature time (`SignatureDoesNotMatch`, `AuthorizationHeaderMalformed`).
+See [`--region` / `AWS_REGION`](cli-reference.md#region-aws-region-every-command).
 
 ## Target resolution
 
@@ -158,9 +163,11 @@ later replicas fail to boot with
 `Bind for 127.0.0.1:<port> failed: port is already allocated`, and it would not
 match production, where each task has its own ENI.
 
-`--host-port` is most useful on macOS: mapping a privileged container port
-(below 1024) to a non-privileged host port avoids the Docker Desktop
-admin-password prompt.
+A privileged container port — anything the template would publish below 1024,
+which a local publish cannot take without root and which macOS Docker Desktop
+refuses outright — is auto-remapped to a free ephemeral port, with a warning
+naming the port chosen. `--host-port <containerPort>=<hostPort>` pins that
+choice instead of leaving it to the allocator.
 
 ## Image overrides
 
@@ -263,8 +270,21 @@ secret-name refusals and container start ordering all behave as described in
 
 | Code | Meaning |
 | --- | --- |
-| `1` | Hard error — Docker unavailable, no target resolved, a target that is not an ECS Service, an unsupported `TaskDefinition` reference, `--max-tasks` out of range, shared-network creation failed, `--strict-overrides` with an uncovered pinned target, or a conflicting state-source flag combination. |
+| `1` | Hard error, or a cancelled interactive picker. |
 | `130` | Shut down by `^C` or `SIGTERM`. The first signal tears every replica down and then exits; a second exits immediately with no cleanup. |
+
+The refusals behind exit `1`:
+
+| Refusal | When |
+| --- | --- |
+| Docker unavailable | The daemon is not running, or `docker` is not on `PATH`. |
+| No target resolved | Nothing matched, or the terminal is non-interactive and no target was named. |
+| Wrong resource type | The target is a `TaskDefinition`, or any type other than `AWS::ECS::Service`. |
+| Unsupported `TaskDefinition` reference | The service points at a cross-stack or `Fn::ImportValue` task definition. |
+| `--max-tasks` out of range | Outside `1`-`83`. |
+| Shared network creation failed | Usually a leaked network from an interrupted run holding the subnet. |
+| `--strict-overrides` with an uncovered target | A registry-pinned target had no `--image-override` and no prompt answer. |
+| Conflicting state-source flags | `--from-state` with `--from-cfn-stack`, or an explicit `--from-cfn-stack <name>` across several stacks. |
 
 The emulator runs until it is signalled, so there is no exit-`0` path once the
 services are up. The full cross-command table is in the
@@ -275,3 +295,4 @@ services are up. The full cross-command table is in the
 - [`cdkd local run-task`](local-run-task.md) — the one-shot counterpart, and the source of the networking, secrets, volume and ordering behaviour each replica inherits
 - [`cdkd local start-alb`](local-start-alb.md) — put a local Application Load Balancer in front of these services for path, host, header and weighted routing
 - [Local Execution](local-emulation.md) — the subcommand index, Docker requirements, and the flags common to every `cdkd local` command
+- [CLI Reference](cli-reference.md) — every cdkd command, the output-stream contract, and the full exit-code table

--- a/docs/local-start-service.md
+++ b/docs/local-start-service.md
@@ -1,103 +1,277 @@
 ---
-title: local start-service
+title: cdkd local start-service
 description: "Run a long-running local ECS Service emulator — per-replica containers with restart-on-exit watching and zero-downtime hot reload."
 ---
 
-# `local start-service` (run an ECS Service locally)
+# cdkd local start-service
 
-`cdkd local start-service <Stack/ServiceLogicalPath>` is the long-running
-counterpart of `cdkd local run-task`. It locates an
-`AWS::ECS::Service` in the synthesized template, chains into the
-existing `run-task` machinery once per `DesiredCount` replica (clamped
-by `--max-tasks`, default 3), and keeps every replica running until
-`^C`. Failed replicas restart per `--restart-policy on-failure |
-always | none` with exponential backoff (1s → 30s capped) so a
-crash-looping container does not hammer docker.
+`cdkd local start-service <targets...>` is the long-running counterpart of
+[`cdkd local run-task`](local-run-task.md). It finds one or more
+`AWS::ECS::Service` resources in the synthesized template, boots `DesiredCount`
+task replicas of each (capped by `--max-tasks`), and keeps them running —
+restarting a replica when its essential container exits — until you press `^C`.
+Name two or more services and they are booted into a shared Cloud Map / Service
+Connect registry so they can discover each other.
 
-Each replica gets its own per-task docker network on a UNIQUE
-`169.254.<N>.0/24` subnet (170, 171, 172, ...; see
-[src/local/ecs-network.ts](https://github.com/go-to-k/cdkd/blob/main/src/local/ecs-network.ts)
-`buildEndpointSubnet`) so concurrent replicas don't collide on a
-single /24 — the same metadata-endpoint sidecar starts at
-`169.254.<N>.2` per replica and every container's
-`ECS_CONTAINER_METADATA_URI_V4` is rewritten to point at its own
-replica's sidecar.
+```bash
+cdkd local start-service MyStack/Orders                       # one service, DesiredCount replicas
+cdkd local start-service MyStack/Orders MyStack/Frontend      # two services that discover each other
+cdkd local start-service                                      # pick services interactively (TTY only)
+cdkd local start-service MyStack/Orders --max-tasks 1 --host-port 80=8080
+cdkd local start-service MyStack/Orders --from-state          # resolve intrinsics from deployed state
+cdkd local start-service MyStack/Orders --watch --image-override MyStack/Orders=./Dockerfile
+```
 
-> **Host-port publishing and multi-replica services.** A
-> **single-replica** service publishes its container `PortMappings` to
-> the host (`-p <container-host>:<hostPort>:<containerPort>`) so you can
-> `curl localhost:<port>` from the host. A **multi-replica** service
-> (effective replica count > 1 after the `--max-tasks` clamp) does NOT
-> publish host ports: N replicas all map the same container port, so a
-> fixed host-port publish would make the 2nd+ replica fail to boot with
-> `Bind for 127.0.0.1:<port> failed: port is already allocated`. This
-> matches production — real ECS Service Connect / `awsvpc` tasks have
-> per-task ENIs and never share a host port. Peers still reach a
-> multi-replica service by container IP / network alias on the shared
-> docker network; to hit a specific replica from the host, `docker exec`
-> into it or read its IP from `docker inspect`.
+Docker is required — see [Local execution](local-emulation.md#requirements).
 
-### `local start-service` target resolution
+## Options
 
-Same grammar as `local run-task`:
-
-- `Stack/Service/...` (display path) or `Stack:LogicalId` (logical id).
-- Single-stack apps may omit the stack prefix.
-- The target MUST resolve to an `AWS::ECS::Service`; passing a bare
-  TaskDefinition surfaces a clear "use cdkd local run-task" hint.
-
-The Service's `TaskDefinition` property MUST be `{Ref:
-'<TaskDefLogicalId>'}` referencing a same-stack
-`AWS::ECS::TaskDefinition` (the standard CDK shape). Cross-stack
-TaskDefinitions and `Fn::ImportValue` shapes are rejected with a clear
-error.
-
-### `local start-service` options
-
-| Flag | Default | Behavior |
+| Flag | Default | Description |
 | --- | --- | --- |
-| `--cluster <name>` | `cdkd-local` | Cluster name surfaced to `ECS_CONTAINER_METADATA_URI_V4` and used as the docker network prefix. Each replica's network appends `-svc-<service>-r<index>` so per-replica networks are easy to identify in `docker ps`. |
-| `--max-tasks <n>` | `3` | Hard cap on local replica count regardless of template `DesiredCount`. Local dev machines should not run an unbounded number of containers; raise this for production-shape workloads only when warranted. |
-| `--restart-policy <p>` | `on-failure` | Restart-on-exit behavior. `on-failure` restarts only on non-zero exit; `always` restarts on every exit (mirrors ECS Service deployment semantics more closely); `none` shuts the affected replica down and runs the service degraded. |
-| `--env-vars <file>` | — | SAM-shape JSON env-var overrides; same format as `run-task`. |
-| `--container-host <ip>` | `127.0.0.1` | Host IP to bind published container ports to. Must be a numeric IP. |
-| `--assume-task-role [arn]` | unset | Assume the task definition's TaskRoleArn (or the supplied ARN) and forward STS-issued temp credentials via the metadata sidecar so every replica's containers run with the deployed task role. Same three-form grammar as `run-task`. |
-| `--ecr-role-arn <arn>` | — | Role ARN to assume before ECR `docker pull` for cross-account / centralized registries. Same shape as `run-task`. |
-| `--platform <p>` | inferred | Force `--platform linux/amd64` or `linux/arm64`. |
-| `--no-pull` | off | Skip `docker pull` on every container image and the metadata sidecar. |
-| `--from-state` | off | Read cdkd S3 state and substitute intrinsic-valued env / secret / role-ARN / volume entries against the deployed cdkd state. Same shape as `cdkd local run-task --from-state`. |
-| `--from-cfn-stack [cfn-stack-name]` | off | Read a deployed CloudFormation stack via `DescribeStackResources` and substitute `Ref` / `Fn::ImportValue` in container env vars / secrets / image URIs with the deployed physical IDs / exports. Use for CDK apps deployed via the upstream CDK CLI (`cdk deploy`). Bare form uses the cdkd stack name (per target when multiple `<targets...>` are supplied). **Mutually exclusive with `--from-state`**. `Fn::GetAtt` is warn-and-dropped in v1, except a same-stack ECR repository's `Arn` / `RepositoryUri` in a container image URI (synthesized from the recovered physical name + pseudo parameters). Same shape as `cdkd local run-task --from-cfn-stack`. |
-| `--stack-region <region>` | — | Region of the state record to read. Used with `--from-state` when the same stack name has state in multiple regions, and with `--from-cfn-stack` as the CFn client region. |
-| `--host-port <containerPort=hostPort>` | host port == container port | Publish a container port on a specific host port (e.g. `80=8080`); repeatable. Use this on macOS to map a privileged container port (< 1024) to a non-privileged host port and avoid the Docker Desktop admin-password prompt. **Single-replica services only** — multi-replica services do not publish host ports. |
-| `--watch` | off | Hot reload: re-synth + per-replica reload when the CDK source changes (`cdk.json watch.include` / `watch.exclude` honored; `cdk.out` / `node_modules` / `.git` always excluded). A per-firing classifier picks the per-replica primitive: source-only edits on interpreted-language handlers (Node / Python / Ruby / shell) take a bind-mount **FAST PATH** (`docker cp` the new source into each replica + `docker restart`; no `docker build`, sub-second). Dockerfile / dependency manifest / compiled-language source / ambiguous edits fall through to the rebuild rolling primitive — boot a shadow under a bumped generation suffix, wait for its container port to accept a TCP connection, atomically swap Service Connect / Cloud Map registrations, then retire the old container. Either path rolls one replica at a time, so peer services see zero connection refusals across the reload even on multi-replica services. Off by default; existing replica(s) keep serving when synth fails mid-reload. (cdk-local 0.69.0.) Source-only TypeScript edits classify as a **rebuild** (not soft-reload) so precompiled handler setups are not left stale (cdk-local 0.77). |
-| `--image-override <target=ref>` | — | Pin or locally build a replica's container image instead of using the deployed registry tag. `<target>` is a service / container selector; `<ref>` is an image reference, a build directory, or a `Dockerfile` path (`~` is tilde-expanded). Repeatable. Compose with the per-service `--image-build-arg` / `--image-build-secret` / `--image-target` variants for local builds. On `--watch`, a covered override re-builds when its source changes. (cdk-local 0.77.) |
-| `--shadow-ready-timeout <ms>` | `60000` | Per-invocation override of the shadow-replica TCP-ready probe budget used by the rebuild rolling primitive (and the initial boot). Raise it for slow-starting containers. Also settable via `CDKD_SHADOW_READY_TIMEOUT_MS`. (cdk-local 0.77.) |
+| `[targets...]` | interactive picker | One or more CDK display paths or stack-qualified logical ids of `AWS::ECS::Service` resources. Omit in a TTY to multi-select. |
+| `--cluster <name>` | `cdkd-local` | Cluster name reported by the metadata endpoint, and the prefix of the shared Docker network and per-replica cluster names. |
+| `--max-tasks <n>` | `3` | Hard cap on the local replica count, applied over the template's `DesiredCount`. Must be between `1` and `83`. |
+| `--restart-policy <policy>` | `on-failure` | How to react when a replica's essential container exits: `on-failure`, `always`, or `none`. |
+| `--host-port <containerPort=hostPort...>` | host port equals container port | Publish a container port on a specific host port, e.g. `80=8080`. Repeatable. Single-replica services only. |
+| `--no-logs` | off (logs stream) | Stop streaming each replica's container output to your terminal. `docker logs -f <id>` stays available. |
+| `--watch` | off | Re-synthesize and reload replicas when the CDK source changes, one replica at a time. |
+| `--shadow-ready-timeout <ms>` | `60000` | How long the `--watch` rebuild path waits for a shadow replica's port to accept a TCP connection. Also set by `CDKD_SHADOW_READY_TIMEOUT_MS`. |
+| `--image-override <service=dockerfile or dockerfile...>` | — | Replace a service's image with a local `docker build`. Repeatable; a bare Dockerfile opens a picker over the uncovered pinned targets. |
+| `--image-build-arg <KEY=VAL...>` | — | A `docker build --build-arg` pair for every override build. Repeatable. `<service>:KEY=VAL` scopes it to one service. |
+| `--image-build-secret <id=src...>` | — | A `docker build --secret id=<id>,src=<src>` entry for every override build. Repeatable. `<service>:id=src` scopes it to one service. |
+| `--image-target <stage or svc=stage...>` | — | A `docker build --target` stage for every override build. Repeatable. `<service>=<stage>` scopes it and beats the global value. |
+| `--no-interactive-overrides` | off (prompts) | Suppress the boot prompt asking for a Dockerfile per pinned target, and the picker fired by a bare `--image-override`. |
+| `--strict-overrides` | off | Fail at boot when any pinned target is still uncovered after `--image-override` and the boot prompt have resolved. |
+| `--env-vars <file>` | — | SAM-shape JSON env-var overrides, keyed by container name — see [Local execution](local-emulation.md#common-flags). |
+| `--container-host <ip>` | `127.0.0.1` | Host IP that published container ports bind to. Must be numeric — see [Local execution](local-emulation.md#common-flags). |
+| `--assume-role [arn]` | off | Assume the task definition's `TaskRoleArn` (or the ARN you pass) and serve those credentials through the metadata sidecar. |
+| `--assume-task-role [arn]` | off | Deprecated alias of `--assume-role`. Both work; `--assume-role` is the cross-command name. |
+| `--no-pull` | off | Skip `docker pull` for every container image and the metadata sidecar — see [Local execution](local-emulation.md#common-flags). |
+| `--no-build` | off | Skip `docker build` on the CDK-asset path and reuse the previously built tag. Errors when that tag is not in the local registry. |
+| `--ecr-role-arn <arn>` | — | Role to assume before authenticating to ECR, for cross-account or centralized registries. |
+| `--platform <platform>` | inferred from `RuntimePlatform.CpuArchitecture` | Force `docker run --platform`. Accepts `linux/amd64` or `linux/arm64`. |
+| `--from-state` | off | Substitute deployed values from cdkd's S3 state into images, environment variables, secrets, role ARNs and volumes — see [Local execution](local-emulation.md#common-flags). |
+| `--from-cfn-stack [name]` | off | Substitute from a CloudFormation-deployed stack instead. Bare form uses the cdkd stack name. Mutually exclusive with `--from-state`. |
+| `--stack-region <region>` | — | Region of the state record to read, and the CloudFormation client region for `--from-cfn-stack` — see [Local execution](local-emulation.md#common-flags). |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET` / `cdk.json` | S3 bucket holding cdkd state, for `--from-state`. |
+| `--state-prefix <prefix>` | `cdkd` | S3 key prefix for state files. |
+| `-a`, `--app <command>` | `cdk.json` / `CDKD_APP` | CDK app command, or a path to a pre-synthesized cloud assembly — see [Local execution](local-emulation.md#common-flags). |
+| `--output <path>` | `cdk.out` | Output directory for synthesis. |
+| `-c`, `--context <key=value...>` | — | Set CDK context values. Repeatable. |
+| `--region <region>` | `AWS_REGION`, the stack's region, then the profile's | AWS region for SDK calls. |
+| `--profile <profile>` | — | AWS profile. Its credentials are forwarded to the sidecar and to the containers. |
+| `--role-arn <arn>` | `CDKD_ROLE_ARN` | IAM role to assume for cdkd's own AWS API calls. |
+| `-y`, `--yes` | off | Answer interactive prompts with the recommended response. |
+| `--verbose` | off | Verbose logging. |
 
-Each replica's container stdout / stderr is streamed live to the host
-terminal while the service runs (cdk-local 0.77).
+## Target resolution
 
-### `local start-service` lifecycle
+Each `<target>` uses the same grammar as [`cdkd local run-task`](local-run-task.md#target-resolution):
+a CDK display path (`MyStack/Orders`), a stack-qualified logical id
+(`MyStack:MyServiceXYZ`), or — in a single-stack app — a bare name. Omit the
+targets entirely in an interactive terminal and cdkd lists the app's ECS services
+for you to multi-select; in a non-interactive shell, omitting them is an error
+that names the flag forms instead.
 
-`^C` (SIGINT) and SIGTERM trigger a graceful shutdown across every
-replica in parallel — each replica's docker containers + per-replica
-network + metadata sidecar are torn down via the same
-`cleanupEcsRun` path `run-task` uses. Double-`^C` bypasses cleanup and
-exits 130 immediately so users have an escape hatch when docker
-hangs.
+A target must resolve to exactly one `AWS::ECS::Service`:
 
-### `local start-service` scope (deferred follow-ups)
-
-| Deferred | Tracked in / Why |
+| What you named | Result |
 | --- | --- |
-| Local load-balancer emulator (listener + round-robin + target-group health check) | Follow-up — needs an HTTP/TCP proxy emulator. Today's start-service does NOT register replicas to a local listener; reach a single-replica service via its published container ports, or any replica via its docker network IP / alias (multi-replica services skip the host-port publish — see the host-port note above). |
-| Envoy sidecar (L7 routing / retries / circuit breaking / mTLS) | Deferred follow-up — the Cloud Map DNS overlay covers ~80% of debugging use cases; the missing 20% requires the AWS-published Envoy image (~120MB / task). DNS-only mode is the default; an opt-in `--envoy` flag will ship with the sidecar. |
-| Rolling deployment strategy (`DeploymentConfiguration.MaximumPercent` etc.) | Follow-up — meaningful only with the LB emulator. |
-| `HealthCheckGracePeriodSeconds` runtime semantics | Field is parsed and surfaced on `ResolvedEcsService` but not yet acted on. Becomes load-bearing when the LB emulator ships (today's restart policy fires on essential-container exit code, not health-check failure). |
+| One `AWS::ECS::Service` | Booted. |
+| A display path matching several services | Error listing the matches; refine the path or use the `Stack:LogicalId` form. |
+| An `AWS::ECS::TaskDefinition` | Error pointing you at [`cdkd local run-task`](local-run-task.md) for one-shot tasks. |
+| Any other resource type | Error naming the type found. |
+
+The service's `TaskDefinition` property must be a `Ref` to a same-stack
+`AWS::ECS::TaskDefinition` — the shape CDK synthesizes. A cross-stack task
+definition or an `Fn::ImportValue` shape is rejected with an error naming the
+unsupported reference.
+
+`--from-cfn-stack <name>` with an explicit name cannot be combined with targets
+that route to more than one stack: an explicit CloudFormation stack name applies
+to one stack only and would silently mismap logical ids across siblings. Use the
+bare `--from-cfn-stack`, so each stack uses its own name, or run one invocation
+per stack.
+
+## Replicas and restart policy
+
+The number of replicas booted per service is the lesser of the template's
+`DesiredCount` and `--max-tasks`. When the cap bites, a warning names the
+template count, the cap, and the count actually running.
+
+| `--restart-policy` | When an essential container exits |
+| --- | --- |
+| `on-failure` (default) | The replica is restarted only on a non-zero exit code. |
+| `always` | The replica is restarted on every exit, whatever the code. |
+| `none` | The replica stays down and the service runs degraded; a warning names the replica, the policy and the exit code. |
+
+Restarts back off exponentially — 1s, 2s, 4s, 8s, 16s, then 30s for every
+subsequent attempt — so a crash-looping container does not hammer Docker.
+
+## Networking and service discovery
+
+One invocation creates one shared Docker network, `<cluster>-svc-<random>`, on
+subnet `169.254.171.0/24`, with the AWS-published metadata-endpoints sidecar at
+`169.254.171.2`. Every replica of every named service joins it, so peers reach
+each other by container IP or network alias with no extra choreography, and the
+network is torn down once at the end of the run.
+
+Each replica runs under its own cluster name,
+`<cluster>-svc-<service-logical-id>-r<index>`, which is what the metadata
+endpoint reports and what makes replicas easy to pick out of `docker ps`.
+
+Before creating the shared network, cdkd sweeps orphaned `<cluster>-svc-*`
+networks left behind by an interrupted run. Because the subnet is fixed, a leaked
+network would otherwise make every later run fail on
+`Pool overlaps with other one on this address space`. A network counts as
+orphaned when nothing but its own `-metadata` sidecar is still attached.
+
+### Service Connect and Cloud Map
+
+With two or more targets, every service is published into a shared Cloud Map /
+Service Connect registry, and peers are wired up through a Docker `--add-host`
+DNS overlay. Aliases come from `ServiceConnectConfiguration`: the discovery name,
+the discovery name qualified by the namespace, and every client alias DNS name.
+The `Namespace` must be a literal string such as `cdkd.local`; an intrinsic or
+cross-stack namespace reference is rejected.
 
 ### `awsvpc` network mode
 
-ECS Services on Fargate require `awsvpc`. cdkd maps `awsvpc` to a
-per-task docker bridge network with a startup warn; security groups
-are NOT enforced locally and per-task ENIs are not emulated. Full
-rationale in the [awsvpc emulation design note](design/461-awsvpc-decision.md).
+ECS Services on Fargate require `awsvpc`. cdkd maps it to a Docker bridge network
+with a startup warning:
 
+| Real `awsvpc` | Locally |
+| --- | --- |
+| One ENI per task, with a VPC IP | A Docker-assigned IP on the shared bridge network; the metadata endpoint still reports the container's own IP, so code reading the task IP works. |
+| Security groups enforced on ingress and egress | Not enforced. Verify security-group behaviour against a real deploy. |
+| Tasks never share a host port | Multi-replica services do not publish host ports either — see below. |
+
+## Reaching a service from the host
+
+| Effective replica count | Host access |
+| --- | --- |
+| 1 | The container's `PortMappings` are published as `-p <container-host>:<hostPort>:<containerPort>`, so `curl localhost:<port>` works. `--host-port <containerPort>=<hostPort>` remaps the host side. |
+| More than 1 | No host ports are published. Reach a replica by its container IP or network alias on the shared network, or `docker exec` into it. |
+
+Publishing a fixed host port from several replicas would make the second and
+later replicas fail to boot with
+`Bind for 127.0.0.1:<port> failed: port is already allocated`, and it would not
+match production, where each task has its own ENI.
+
+`--host-port` is most useful on macOS: mapping a privileged container port
+(below 1024) to a non-privileged host port avoids the Docker Desktop
+admin-password prompt.
+
+## Image overrides
+
+`--image-override` swaps a service's deployed-registry image for a local
+`docker build`, so `--from-cfn-stack` can keep reading real AWS state while you
+iterate on the application container.
+
+| Form | Effect |
+| --- | --- |
+| `--image-override <service>=<dockerfile>` | Binds that Dockerfile to that service. Passing the same service twice is an error. |
+| `--image-override <dockerfile>` | Opens a multi-select picker over the still-uncovered pinned targets, so one Dockerfile can cover several services. |
+
+The two forms mix freely. `--image-build-arg`, `--image-build-secret` and
+`--image-target` tune those builds; each accepts a global value and a
+service-scoped form (`<service>:KEY=VAL`, `<service>:id=src`,
+`<service>=<stage>`), with the service-scoped value winning for that service.
+`--image-build-secret` enables the standard
+`RUN --mount=type=secret,id=<id>` recipe for private registries and npm tokens,
+and relative `src` paths are resolved against the working directory with `~`
+expanded.
+
+At boot, any target whose image is still pinned to a deployed registry produces a
+warning. `--no-interactive-overrides` suppresses the prompts that would otherwise
+ask you for a Dockerfile; `--strict-overrides` turns those leftover warnings into
+a boot failure. The warnings fire either way.
+
+## `--watch`: hot reload on source changes
+
+`--watch` re-synthesizes and reloads replicas whenever the CDK source changes. It
+honours `watch.include` and `watch.exclude` from `cdk.json`; `cdk.out`,
+`node_modules` and `.git` are always excluded.
+
+Each firing is classified, and the classification picks the per-replica
+primitive:
+
+| Change | Primitive |
+| --- | --- |
+| Source-only edits to an interpreted-language handler (Node, Python, Ruby, shell) | Fast path — `docker cp` the new source into each replica and `docker restart` it. No rebuild, and the container's IP and host port survive, so registrations stay valid. |
+| Dockerfile, dependency-manifest, compiled-language source, TypeScript source, or an edit that cannot be classified | Rebuild — boot a shadow replica under a bumped generation suffix, wait for its port to accept a TCP connection, atomically swap the Cloud Map and front-door registrations, then retire the old container. |
+
+Either path rolls one replica at a time, so peers see no connection refusals
+across a reload even on a multi-replica service. TypeScript source edits take the
+rebuild path deliberately, so a precompiled handler setup is never left stale.
+
+Failures during a reload are non-fatal and leave the running replicas serving:
+
+- Synthesis fails — a warning, and the previous version keeps serving.
+- A target no longer resolves to a service — a warning, and its replicas keep serving.
+- An `--image-override` rebuild fails — a warning, and the previous local image is kept.
+- A shadow replica does not accept a connection within `--shadow-ready-timeout`
+  (default 60000 ms) — the log names the probe that timed out. Raise the budget
+  for slow starters such as JVM apps, heavy ORM initialization, or an
+  `--inspect-brk` attach pause.
+- The effective replica count changed mid-roll because you edited `DesiredCount`
+  or `--max-tasks` — existing replicas move to the new image but the count is not
+  scaled to match; a warning says so. Restart the command to apply the new count.
+
+## Logs
+
+Every booted replica streams its containers' stdout and stderr to your terminal,
+prefixed `[svc=<service> r=<replica-index> c=<container>]` — the same shape
+[`cdkd local run-task`](local-run-task.md) uses. Pass `--no-logs` when the
+interleaved output of a multi-replica or multi-service run is unreadable;
+`docker logs -f <id>` in another terminal still works.
+
+## Lifecycle and teardown
+
+The emulator boots every replica, prints an endpoint banner and then runs until
+it is signalled. `^C` and `SIGTERM` both start the same graceful shutdown:
+
+1. The file watcher is closed and any in-flight reload is drained.
+2. Every replica is torn down in parallel — its containers removed, its
+   registrations dropped.
+3. Temporary credential files are deleted.
+4. The shared network and its metadata sidecar are removed last.
+
+A second `^C` exits `130` immediately without cleanup, so you have an escape
+hatch when Docker hangs. Orphan containers may remain;
+`docker ps --filter name=cdkd-local-` plus `docker rm -f` clears them.
+
+## Limitations
+
+| Not emulated | What to do instead |
+| --- | --- |
+| A load-balancer listener with round-robin and target-group health checks | `start-service` registers no local listener. Reach a single-replica service on its published ports, or use [`cdkd local start-alb`](local-start-alb.md) for a real local front door. |
+| An Envoy sidecar — L7 routing, retries, circuit breaking, mTLS | The Cloud Map DNS overlay covers peer discovery; L7 behaviour is not reproduced. |
+| Rolling deployment configuration (`DeploymentConfiguration.MaximumPercent` and siblings) | `--watch` rolls one replica at a time; the template's deployment percentages are not applied. |
+| `HealthCheckGracePeriodSeconds` | Parsed but not acted on. The restart policy fires on an essential container's exit code, not on health-check failure. |
+| Auto Scaling | Set the replica count with `DesiredCount` and `--max-tasks`. |
+| Security groups and per-task ENIs under `awsvpc` | Not enforced locally; verify against a real deploy. |
+| An intrinsic or cross-stack `ServiceConnectConfiguration.Namespace` | Use a literal namespace name. |
+| A cross-stack or `Fn::ImportValue` `TaskDefinition` reference | Use the standard `Ref` to a same-stack task definition. |
+| `Fn::GetAtt` in container environment variables under `--from-cfn-stack` | Dropped with a warning — `ListStackResources` returns no per-attribute values, and no ECS-side call recovers them from a deployed task or service. Use `--from-state` instead. |
+
+Every limitation of the underlying task runner applies here too — volumes,
+secret-name refusals and container start ordering all behave as described in
+[`cdkd local run-task`](local-run-task.md).
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `1` | Hard error — Docker unavailable, no target resolved, a target that is not an ECS Service, an unsupported `TaskDefinition` reference, `--max-tasks` out of range, shared-network creation failed, `--strict-overrides` with an uncovered pinned target, or a conflicting state-source flag combination. |
+| `130` | Shut down by `^C` or `SIGTERM`. The first signal tears every replica down and then exits; a second exits immediately with no cleanup. |
+
+The emulator runs until it is signalled, so there is no exit-`0` path once the
+services are up. The full cross-command table is in the
+[CLI Reference](cli-reference.md#exit-codes).
+
+## Related
+
+- [`cdkd local run-task`](local-run-task.md) — the one-shot counterpart, and the source of the networking, secrets, volume and ordering behaviour each replica inherits
+- [`cdkd local start-alb`](local-start-alb.md) — put a local Application Load Balancer in front of these services for path, host, header and weighted routing
+- [Local Execution](local-emulation.md) — the subcommand index, Docker requirements, and the flags common to every `cdkd local` command

--- a/docs/local-start-service.md
+++ b/docs/local-start-service.md
@@ -125,11 +125,12 @@ Each replica runs under its own cluster name,
 `<cluster>-svc-<service-logical-id>-r<index>`, which is what the metadata
 endpoint reports and what makes replicas easy to pick out of `docker ps`.
 
-Before creating the shared network, cdkd sweeps orphaned `<cluster>-svc-*`
-networks left behind by an interrupted run. Because the subnet is fixed, a leaked
-network would otherwise make every later run fail on
-`Pool overlaps with other one on this address space`. A network counts as
-orphaned when nothing but its own `-metadata` sidecar is still attached.
+An interrupted run can leave its network behind, and the subnet is fixed, so
+cdkd sweeps orphaned `<cluster>-svc-*` networks before creating the shared one —
+otherwise the next run would fail on `Pool overlaps with other one on this
+address space`. A network counts as orphaned when nothing but its own
+`-metadata` sidecar is still attached, so a network still serving replicas is
+never touched.
 
 ### Service Connect and Cloud Map
 


### PR DESCRIPTION
## Why

The 47-page site audit in go-to-k/cdkd#2505 found the Local Execution group in
the worst shape of any section. Every one of its nine pages opened at H1 and
then used H3 for every section, so each page's on-this-page table of contents
was a flat run of same-level entries with no top-level structure, and its first
section heading rendered a size smaller than every other page's on the site.
Seven contained no example invocation at all, which
`.claude/rules/docs-page-template.md` forbids outright ("A page documenting a
command that contains no example invocation is not finished"). Options were
prose, loose bullets, or absent; six pages documented no exit code; and the
tail of most of them was a roadmap table headed "v1 scope (out of scope,
deferred)" or "Phase 1 scope (out of scope, deferred)".

This is the second theme of that issue. Theme 1 (the CLI reference template and
the change-history purge) shipped in go-to-k/cdkd#2512 and go-to-k/cdkd#2517.

## What changed

Every page now follows the shared skeleton: H1, a one-paragraph intro that says
what the command does and when you reach for it, a synopsis block of real
invocations, `## Options` as a table, behaviour sections at H2 with H3 beneath,
`## Exit codes`, `## Limitations`, `## Related`.

- **Options tables are complete and machine-checked.** Every flag each command
  accepts is now a row, verified flag-for-flag against `node dist/cli.js local
  <cmd> --help`: 22 for `invoke`, 31 for `start-api`, 21 for `run-task`, 34 for
  `start-service`, 39 for `start-alb`, 24 for `start-cloudfront`, 28 each for
  the two AgentCore commands. Nothing in a table is absent from the CLI and
  nothing in the CLI is absent from a table.
- **Exit codes are documented on all nine pages**, each verified against the
  handler that produces it. The asymmetry is real and stated rather than
  smoothed over: `start-service` and `start-alb` bind SIGTERM to their SIGINT
  handler and so exit `130` on a clean shutdown, where every other server exits
  `0`.
- **Limitations survive; the roadmap framing does not.** Every entry in the old
  "out of scope / deferred" tables is still on the page, as a limitation with no
  plan attached.
- **The hub gains the nine common flags it never listed** — `--context`,
  `--from-cfn-stack`, `--output`, `--profile`, `--role-arn`, `--state-bucket`,
  `--state-prefix`, `--verbose`, `--yes` — plus a quick-start block and a
  subcommand table whose cells are one clause instead of a paragraph.

## Source contradictions found and corrected

Checking each page against the binary turned up ten claims the code does not
support:

| Page | Said | Actually |
| --- | --- | --- |
| `local-start-api.md` | WebSocket APIs are a deferred 501 class, "Never (different protocol)" | `discoverWebSocketApis` boots one server per WebSocket API, injects the management-API endpoint, and closes with frame 1001 |
| `local-start-cloudfront.md` | Lambda@Edge is warn-and-skipped | `bootLambdaEdgeFunctions` runs one warm RIE container per distinct function — which also means Docker is required for such a distribution |
| `local-invoke-agentcore.md` | AG-UI serves on port 8800 | 8080, through the HTTP `/invocations` + `/ws` path |
| `local-invoke-agentcore.md` | The inbound token flag is `--jwt` | `--bearer-token`, with `--no-verify-auth` as its escape hatch — both undocumented before |
| `local-invoke-agentcore.md` | A2A's default method is `agent/getAgentCard` | `agent/getCard` |
| `local-start-agentcore.md` | `--timeout` is a per-request timeout | It is the container readiness deadline |
| `local-start-service.md` | Each replica gets its own `169.254.<N>.0/24` subnet | One shared network; the per-replica allocator is unreachable from this command |
| `local-start-service.md` / `local-run-task.md` | `--from-cfn-stack` reads `DescribeStackResources` | Both read `ListStackResources`, through the same cdk-local provider (see the review round below) |
| both `--assume-role` pages | `--no-assume-role` opts out | The parser rejects it on every command that has `--assume-role` (go-to-k/cdkd#2523) |
| `cli-reference.md` | "Its three sibling `cdkd local *` commands fold both" | Written when four local commands existed; eight do now, and the four newest fold neither the flag nor the environment variables. The page carries the split as a table |

`cli-reference.md` also now says `--region` is deprecated and hidden on cdkd's
own commands — true since the flag was deprecated, and never stated on a public
page — with the four cdk-local-backed servers named as the exception.
`getting-started.md` listed four of the eight `cdkd local` subcommands.

## The review round

Three reviewers ran against the first commit — one on the page template, one
falsifying every factual claim against the binary, one reading the nine pages as
a user. The second commit folds what they found, each item re-verified against
the source before being applied. Two were blockers:

- **`--from-state` DOES resolve cross-stack `Fn::ImportValue` and
  `Fn::GetStackOutput`** for `local invoke`, same account and region. The page
  had promoted a stale roadmap row into a hard limitation, contradicting both
  its own `--from-cfn-stack` section and `local run-task`.
- **A cancelled interactive picker exits `1`, not `130`**, on `local start-alb`
  and `local start-service`: both run under cdkd's error handler, which honours
  a custom exit code only on a `CdkdError`, and the picker throws cdk-local's
  own error class. The two commands that DO exit `130` there run under
  cdk-local's handler instead.

Plus three more wrong facts, the largest of which the first commit inherited
rather than introduced: **every `cdkd local * --from-cfn-stack` reads
`ListStackResources`, not `DescribeStackResources`** — four pages named the
wrong API, so an IAM policy written from them granted the wrong action. The
reason it looked plausible is filed as go-to-k/cdkd#2527: cdkd's own
`DescribeStackResources`-based provider is dead code reachable only from its
own test, while the shipped provider comes from cdk-local. `cdkd import`
genuinely does use that API, so the import pages are untouched.

Two things the rewrite had dropped are restored (the same-stack ECR
`Arn` / `RepositoryUri` exception, HTTP API v2's simple `{ isAuthorized }`
authorizer response), and four things a reader could not act without are newly
documented: `--debug-port-base` suspends every handler until a debugger
attaches; `run-task` publishes container ports and cannot pin them; `--origin`'s
key is the distribution's own `Origins[].Id`; and the four commands that do not
fold an upper-cased region.

A third commit closes what the reviews surfaced on the neighbouring page: the
cross-command exit-code table every local page points at listed only `0` / `1` /
`2`, so it promised a superset it did not contain — it now carries `130` and
`run-task`'s container-code pass-through — and the region-fold row that said the
four cdk-local-backed servers fold "neither" now notes that cdkd's own
`--from-state` state read folds both.

A fourth commit corrects four claims the fix round itself got wrong — the class
where agreeing with a finding produces a confidently wrong correction, caught by
reviewing the fix delta rather than re-running the size heuristic:

- `local run-task` has **no** privileged-port auto-remap and prints no per-port
  endpoint line. The fix round had described cdk-local's ECS *service* engine,
  which `start-service` and `start-alb` reach; `run-task` runs cdkd's own
  `ecs-task-runner.ts`, where a privileged port just fails at `docker run`.
- `Fn::GetStackOutput` **does** resolve cross-region under `--from-state` — the
  intrinsic carries its own `Region` — while `Fn::ImportValue` is same-region.
  The fix round had given them one shared, wrong scope.
- `local start-cloudfront --from-state` is **inert**, not merely narrower. The
  fix round removed the false S3-origin half and kept the Function-URL half,
  which is equally false. Filed as go-to-k/cdkd#2528: a flag that parses and is
  ignored is a source bug.
- `local start-api` does not serve Lambdas alone; the opening added in the fix
  round contradicted the same page's `MOCK` and `HTTP_PROXY` sections.

A fifth commit corrects two more, both in material the fourth added rather than
in the original rewrite: `local start-api` exits `0` on SIGTERM too, so the new
cross-command table's exception list was wrong (and contradicted that page's own
table on the same branch); and `--origin` **does** apply to a custom CloudFront
origin — an override short-circuits before the origin is classified — where the
fourth commit had said it does not.

Five review rounds in total, each one reviewing the previous round's delta
rather than re-running the size heuristic. Rounds 4 and 5 exist because that is
what caught them: every defect those two commits fixed was introduced by a fix,
not by the original rewrite.

## Follow-ups filed rather than fixed here

Each is a source change behind the `integ-local` merge gate, which a docs-only
PR does not pay a real-Docker integ cycle for:

- go-to-k/cdkd#2522 — four `cdkd local` commands never fold `--region`
- go-to-k/cdkd#2523 — `--no-assume-role` is advertised but rejected
- go-to-k/cdkd#2524 — the `--stage` help text contradicts the code
- go-to-k/cdkd#2525 — cdk-local's `start-cloudfront` help still says Lambda@Edge
  is skipped
- go-to-k/cdkd#2527 — `src/local/cfn-local-state-provider.ts` is dead code, and
  it names a different CloudFormation API than the provider that runs
- go-to-k/cdkd#2528 — `local start-cloudfront` accepts three cdkd-state flags
  and ignores all of them

## Reviewer findings deliberately not acted on

- **"`--no-assume-role` is documented nowhere" (raised as a blocker).** The flag
  does not exist — the parser rejects it on every command that has
  `--assume-role`. The evidence offered was the CLI's own help string, which is
  the bug (go-to-k/cdkd#2523), not the specification. The pages document the
  real opt-out: omit the flag.
- **The `awsvpc` design note lost its only inbound link.** That page's title is
  literally an issue number, so linking it puts a raw issue reference on a
  public page, which the link fence blocks. The rationale it carried is now an
  on-page comparison table on `local start-service`.
- **`local start-alb` splits its Options into six sub-tables where no sibling
  does.** With 39 flags, one table is a wall; a second reviewer independently
  suggested propagating the split rather than removing it. Kept, and worth
  copying to `local start-api` in a later pass.
- **`## `--no-pull` and `--no-build` by code path` is not headed by a bare flag
  name.** The template's rule is for a section documenting *one* flag; this one
  is a two-flag × three-path matrix, so it is a behaviour section.
- **The `Changed in v0.81` line on `local start-api`.** The template allows
  exactly one version boundary, at the end of its section, in that form.

## Verification

- `vp check --fix` / `vp run check` / `vp run typecheck:test` / `vp run build`
  clean.
- `vp test run`: 882 files, 18206 tests, 0 failures.
- Every Options table diffed against the live `--help` output for its command,
  in both directions.
- Every exit code traced to the handler that emits it.
- `tests/unit/scripts/docs-site-links.test.ts` passes, so every cross-page
  anchor resolves.
- `vp run docs:build` builds the site clean (69 OG images, 201 output files).
  Spot-checked the rendered result: `local start-alb`'s on-this-page table of
  contents now carries sixteen entries with real H2/H3 nesting.

Refs go-to-k/cdkd#2505
