### PR TITLE
docs: point the Getting Started command families at their reference pages

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,13 +80,14 @@ cdkd has three command families:
   `scrub` / `publish-assets`) require a CDK app — they synthesize a template to
   learn what they're operating on. A few operate on the state bucket /
   AWS directly and need no app: `cdkd bootstrap`, `cdkd drift`,
-  `cdkd rollback`, `cdkd events`, `cdkd gc`, `cdkd force-unlock`.
+  `cdkd rollback`, `cdkd events`, `cdkd gc`, `cdkd force-unlock`. See
+  [CLI Reference](cli-reference.md).
 - **`cdkd state ...` subcommands** (`state info` / `list` / `resources`
   / `show` / `orphan` / `destroy` / `migrate` / `refresh-observed`)
   operate on the S3 state bucket only and do NOT need the CDK app —
   use them to inspect / clean up state when the source is gone or
   you don't want to synth. `cdkd state destroy` is the CDK-app-free
-  counterpart of `cdkd destroy`.
+  counterpart of `cdkd destroy`. See [`cdkd state`](cli-state.md).
 - **`cdkd local ...` subcommands** (`local invoke` / `start-api` /
   `run-task` / `start-service` / `start-alb` / `start-cloudfront` /
   `invoke-agentcore` / `start-agentcore`) run synthesized workloads


### PR DESCRIPTION
## Summary

`docs/getting-started.md`'s Usage section names three command families. Only the `cdkd local ...` bullet ended with a route to where that family is documented (`See [Local Execution](local-emulation.md).`); the other two left the reader with no next step from the bullet they were reading.

Gave them the same closing sentence:

- **Top-level commands** → `See [CLI Reference](cli-reference.md).`
- **`cdkd state ...` subcommands** → ``See [`cdkd state`](cli-state.md).``

The paragraph below the code block already links the CLI reference for the full flag matrix. This is a different route — the per-family one, taken from the bullet describing that family, which is exactly what the `local` bullet has been doing.

## Test plan

- `vp run check`, `vp run typecheck:test`, `vp run build`, `vp test run` (883 files, 18208 tests) — green.
- `tests/unit/scripts/docs-site-links.test.ts` — both new link targets verified by the site's own slugger fence.
