### PR TITLE
chore: fold the go-to-k/cdkd#2514 run's lessons back into /work-issues

### DIFF
--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -643,6 +643,14 @@ last `git -C` / `gh -C` flag, and `cd`s to the resolved target before
 gate landed in the main tree, the root cause in
 `feedback_cross_agent_main_tree_contention.md`).
 
+**A hand-typed `markgate` is not the one the hooks run.** `.mise.toml` pins
+0.4.1 and every gate resolves it through mise, but a Homebrew `markgate` 0.2.0
+earlier on `PATH` wins for a bare invocation and cannot parse this repo's
+`hash: diff` gates: `markgate verify check` exits 2 with
+`unknown hash "diff"` against a perfectly fresh marker (measured 2026-09-04).
+That is a false BLOCK, and it reads as a stale marker. Spell any hand check
+`mise exec -- markgate ...`.
+
 **An unreadable target directory is a REFUSAL in every blocking gate** (issue
 [#2027](https://github.com/go-to-k/cdkd/issues/2027)). A hook receives command
 TEXT, not the shell's expansion, so `git -C "$W" add -A && git -C "$W" commit

--- a/.claude/skills/pick-integ/SKILL.md
+++ b/.claude/skills/pick-integ/SKILL.md
@@ -94,6 +94,23 @@ truncated, and the wrap-up names exactly which tests were not run.
    | `src/synthesis/macro-*` | `macro-expansion` |
    | `package.json` (cdk-local bump) | `local-*` cluster (the bump's blast radius) |
 
+   **Mark every name an agent session cannot run, and offer a substitute.** A
+   fixture drives itself from `verify.sh`, or from `run.sh` invoked directly
+   (`migrate-from-cfn`); with neither, `/run-integ` falls back to a standard
+   flow that needs a bare `cdkd deploy`, which the harness refuses (that
+   skill's step 5) — legal only when a human drives the shell. So such a name
+   is a MAINTAINER-only recommendation, never a lane's: go-to-k/cdkd#2514's
+   lane named `bench-cdk-sample` as its broad arm and the parent had to
+   substitute `lambda`. Several BROAD-set entries are in this state — derive
+   the split, never trust a remembered list:
+
+   ```bash
+   for t in NAME1 NAME2; do   # the names about to be recommended
+     d=<LANE_TREE>/tests/integration/$t
+     [ -f "$d/verify.sh" ] || [ -f "$d/run.sh" ] || echo "MAINTAINER-ONLY: $t"
+   done
+   ```
+
 3. **Rank** the union of {changed-area} ∪ {failing} ∪ {stale >14d} ∪
    {expiring soon} ∪ {never-run}:
    - **P0**: changed-area AND (stale OR failing OR never-run).

--- a/.claude/skills/work-issues/references/filing.md
+++ b/.claude/skills/work-issues/references/filing.md
@@ -17,7 +17,17 @@ cannot sit open while site 1's fix drifts away. Two boundaries:
 
 - **A sweep that would make the PR unreviewable is a genuine `next`** — file an
   explicit umbrella naming every site (§3 sorts umbrellas last), and say which
-  sites this lane DID close, so the residue is unambiguous.
+  sites this lane DID close, so the residue is unambiguous. **"Unreviewable" is
+  never reached by drifting into it**, because each widening is small and real:
+  go-to-k/cdkd#2514 asked for a guard hoist at one site and shipped a 2036 LOC
+  PR, successive rounds each finding another data-destroying type the same
+  guard failed open on — all verified, none requested, and the maintainer asked
+  twice whether the run was taking too long. Two tripwires, either one: a SECOND
+  unrequested widening in a lane, or a PR TITLE needing a clause the issue does
+  not name. On a trip, STATE the call in one line — LOC so far, what the next
+  widening adds, in-PR versus filed — before taking it, and `AskUserQuestion`
+  when it would more than double the diff. Not "never fix a data-loss bug you
+  find": the second one is a DECISION made out loud, not a continuation.
 - **Sweep the same ROOT CAUSE, not the same AREA.** Two unrelated bugs in one
   provider are two issues; one wrong assumption at five call sites is one. The
   test: a single sentence describes the fix at every site.

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -42,27 +42,28 @@
 - **Stale-base phantom diff** (§7) — never "restore" the peer's lines a stale
   `git diff main` appears to have removed; rebase instead.
 - **`bash cwd silent reset`** — a persistent Bash cwd can drift back to the
-  main tree between calls; use `git -C <lane tree>` for git ops and re-`cd`
-  before relative paths. **A KILLED or REFUSED call is a named reset trigger,
-  and it lies about the filesystem too**: a timeout can return the shell at
-  the session cwd; a PreToolUse refusal aborts the WHOLE call, so the `mkdir`
-  a later `cd` depends on never ran — and a failed `cd` does NOT stop the rest
-  of its call (lines after one wrote into the main tree). After any timeout or
-  refusal, run `pwd` AND re-verify what the aborted call should have created.
-  **Its worst form is a FALSE GREEN on a verification command**: a gate run
-  from the main tree verifies unmodified `main` and passes (measured:
-  `vp run typecheck:test` RC=0 twice while the lane held 20 type errors; the
-  tell was a COUNT — 123 tests vs 143). Prefix every verification command with
-  `cd <worktree> &&`; when a result is surprisingly clean, check `pwd`. **A
-  BACKGROUNDED call starts from the session cwd**, not the `cd` of an earlier
-  call — make every long-running call print its own `pwd` first. **When a
-  stray main-tree edit has already happened, both obvious repairs are
-  refused** (`git checkout -- <path>` trips `dirty-path-restore-gate`; writing
-  the file back trips `main-tree-edit-gate`): re-apply the edit in the
-  worktree with an ABSOLUTE path, then
-  `git -C <main> stash push -m <label> -- <path>`; drop the stash only after
-  confirming `stash@{0}`'s message is yours — parallel lanes stash too. A
-  blocked call runs NOTHING, preamble included — §6 has the rule.
+  main tree between calls; prefix every verification command with
+  `cd <worktree> &&` and `git -C <lane tree>` every git op (the addressing
+  rule for READS, and the contradicting-answer test, are in
+  `references/launch-mode.md`). **A KILLED or REFUSED call is a named
+  reset trigger, and it lies about the filesystem too**: a timeout can return
+  the shell at the session cwd; a PreToolUse refusal aborts the WHOLE call, so
+  the `mkdir` a later `cd` depends on never ran — and a failed `cd` does NOT
+  stop the rest of its call. After any timeout or refusal, run `pwd` AND
+  re-verify what the aborted call should have created. **Its worst form is a
+  FALSE GREEN on a verification command**: a gate run from the main tree
+  verifies unmodified `main` and passes (measured: `vp run typecheck:test`
+  RC=0 twice while the lane held 20 type errors; the tell was a COUNT — 123
+  tests vs 143) — an unexpectedly clean or short result is a `pwd` check, not
+  a pass. **A BACKGROUNDED call starts from the session cwd**, not the
+  `cd` of an earlier call — make every long-running call print its own `pwd`
+  first. **When a stray main-tree edit has already happened, both obvious
+  repairs are refused** (`git checkout -- <path>` trips
+  `dirty-path-restore-gate`; writing the file back trips
+  `main-tree-edit-gate`): re-apply the edit in the worktree with an ABSOLUTE
+  path, then `git -C <main> stash push -m <label> -- <path>`; drop the stash
+  only after confirming `stash@{0}`'s message is yours — parallel lanes stash
+  too. A blocked call runs NOTHING, preamble included — §6 has the rule.
 - **An IN-PLACE run ends with the Stop hook still calling its lane unmerged,
   and the remedy it names is one this mode forbids.**
   `stop-unmerged-lane-warn.sh` enumerates worktrees ahead of `origin/main`,

--- a/.claude/skills/work-issues/references/launch-mode.md
+++ b/.claude/skills/work-issues/references/launch-mode.md
@@ -131,6 +131,17 @@ fresh shell whose cwd may have silently reset to the main checkout (appendix,
 `$(git rev-parse --show-toplevel)` or from `pwd` answers "the main checkout"
 in precisely the case the value exists to guard.
 
+**The same fault arrives through commands that never MENTION the values** — a
+`sed -n` / `grep` / `cat` on a RELATIVE path, or a bare
+`git branch --show-current` / `git diff`. Read every file this run owns under
+the recorded absolute `<LANE_TREE>`, and treat an answer CONTRADICTING those
+values as a cwd fault, not a finding: in go-to-k/cdkd#2514's run a `main` from
+`git branch --show-current` plus an EMPTY `git diff --stat origin/main..HEAD`
+were read as "the branch was switched, the PR maybe merged", and two "unfixed
+prose" defects were reported that were main's copies of text the lane had
+already fixed. Nothing was re-derived; nothing was read under `<LANE_TREE>`
+either.
+
 **`<LANE_TREE>` and `<MAIN_CHECKOUT>` in a later stage are SUBSTITUTION
 PLACEHOLDERS, not shell variables.** Paste the absolute path from the opening
 report into the command text. Do NOT write `git -C "$LANE_TREE"`: the

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -61,7 +61,11 @@ rm -f /tmp/run-touched.$$
   token is path-shaped or the diff is mostly dotfiles.
 - **A hit is a prompt for judgement, not a verdict** — the check cannot tell a
   citation from a target. Do the item, or re-classify it in the issue with the
-  reason the criterion no longer applies.
+  reason the criterion no longer applies. In a SINGLE-lane run whose PR is the
+  follow-ups' own subject, expect EVERY one to hit and read the issue's REASON
+  instead (go-to-k/cdkd#2514: 10 of 10, all correctly held on scope
+  containment) — a run-wide hit rate is a property of the run's shape, not of
+  the deferrals.
 - **Re-read the REASON, not just the files** — classify-once freezes the
   DECISION, not the PREMISE: "that PR is still open" goes false when it
   merges, and a `next` kept alive on an expired reason is not protected by

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -13,7 +13,10 @@ from, so a merge from the main tree consults the WRONG store (measured
 sentinel blocking with a misleading sha mismatch; go-to-k/cdkd#2363). The
 sentinels are GITIGNORED, so a fresh worktree has none and `markgate set` on a
 sentinel-bound gate refuses (`dead scope: include matches nothing ...`) —
-write the sentinel first (`/run-integ` step 11), never bypass. Never two
+write the sentinel first (`/run-integ` step 11), never bypass. Ordering, not
+just presence: REWRITING a sentinel after its marker is set stales that
+marker, so a second broad run's `.markgate-broad-integ-test` write must be
+followed by another `markgate set integ-broad`. Never two
 lanes' integs or merges concurrently; everything after the merge stays with
 the parent.
 

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -62,18 +62,8 @@ by a probe or a trace, never by re-reading the diff:
   code; re-measured +0–3%). Confirm the probe reaches the added code, as §5
   requires of a mutation probe.
 
-**A fix that CLOSES a member falsifies every sentence that COUNTS the set** —
-the member leaves in the diff while the counter sits in a file the diff never
-touches (four instances in ONE run, go-to-k/cdkd#2410 / go-to-k/cdkd#2275,
-every one caught by a reviewer and none by the author):
-
-```bash
-# The counters sit OUTSIDE the diff, which is why re-reading the diff misses them.
-grep -rn "<the set's noun, then its cardinal>" src/ docs/ .claude/
-```
-
-NAME the member you closed where the count lives; a silent renumber is what
-makes the next reader re-file it.
+**A fix that CLOSES a member falsifies every sentence that COUNTS the set**,
+and those counters sit OUTSIDE the diff — §8-g's COUNT bullet is the remedy.
 
 ### 8-b. Integ ordering vs review rounds and rebases
 
@@ -137,7 +127,8 @@ Unit tests passing is necessary but NOT sufficient:
   `integ-broad` for cross-cutting files). Run it via **`/run-integ <name>`**
   — never raw `cdkd deploy` / `cdkd destroy` from a shell; the skill encodes
   deploy + update + destroy + orphan verification and records the ledger row.
-  `/pick-integ` chooses the fixture(s).
+  `/pick-integ` chooses the fixture(s) and marks which are maintainer-only —
+  never name one it flagged.
 - **Non-deletion source change** → still live-test the fixed path end-to-end
   (deploy → the redeploy that reproduced the bug → destroy), fresh fixture or
   `/run-integ` against an existing one.
@@ -246,9 +237,9 @@ injection, redeploys, and runs a genuinely clean destroy.
 ### 8-e. Watching runs and pollers
 
 **Never leave a real-AWS run unwatched, and do not reach for `timeout`** — it
-does not exist on macOS (exit 127 in 0s reads as an instant completion), and a
-hung integ looks identical to a slow one from outside (one wedged in
-`docker push` for 4h17m). Shell watchdog, firing made visible:
+does not exist on macOS (exit 127 in 0s reads as instant completion), and a
+hung integ is indistinguishable from a slow one (one wedged in `docker push`
+for 4h17m). Shell watchdog, firing made visible:
 
 ```bash
 LOG=$(mktemp)   # assign HERE: a separate block is a separate shell, and
@@ -276,10 +267,10 @@ crash). Pair with a `Monitor` on phase lines AND log-growth stalling.
   call and read the log's own terminal line. Two nearby traps: a `cd` inside
   the backgrounded compound leaves the parent's `$VAR` unset, and `grep -c`
   exits 1 on a count of zero.
-- **A run blocked before its assertions is not a failing fix** — record it as
-  `FAIL` (the bar is exit-code-based) with a ledger note naming the blocker
-  and any hand-removed AWS resources, or the next reader concludes the merged
-  fix is broken.
+- **A run blocked before its assertions is not a failing fix** — record `FAIL`
+  (the bar is exit-code-based) with a ledger note naming the blocker and any
+  hand-removed AWS resources, or the next reader reads the merged fix as
+  broken.
 
 ### 8-f. Fixture environment prechecks
 
@@ -293,15 +284,15 @@ aws s3 ls "s3://cdkd-state-<acct>/cdkd-bootstrap/"                       # which
 ```
 
 **A docker-dependent fixture is an environment blocker — prefer one reaching
-the same code without it** (on the merits, not merely availability). When
-docker is genuinely required (`integ-local`), verify registry reach FIRST
-(`docker pull hello-world` under a 120s cap) — `docker version` answering says
-nothing about registry networking. **Do NOT restart Docker to fix a hang — on
-Docker Desktop the restart IS the likelier cause**: the daemon routes registry
-traffic through a proxy the Desktop APP serves, and a quit-and-reopen can
-leave the self-respawning backend up while the app never finishes launching
-(four consecutive hung pulls; only a manual app restart recovered). Diagnose
-in order, stop at the first line that explains the symptom:
+the same code without it** (on the merits, not availability). When docker is
+required (`integ-local`), verify registry reach FIRST (`docker pull
+hello-world` under a 120s cap) — `docker version` says nothing about registry
+networking. **Do NOT restart Docker to fix a hang — on Docker Desktop the
+restart IS the likelier cause**: the daemon routes registry traffic through a
+proxy the Desktop APP serves, and a quit-and-reopen can leave the
+self-respawning backend up while the app never finishes launching (four
+consecutive hung pulls; only a manual app restart recovered). Diagnose in
+order, stopping at the first line that explains the symptom:
 
 ```bash
 curl -s -o /dev/null -w '%{http_code}\n' --max-time 15 https://registry-1.docker.io/v2/  # 401 = HOST networking fine
@@ -309,10 +300,9 @@ docker info 2>/dev/null | grep -i proxy         # the proxy the daemon depends o
 pgrep -f 'Docker Desktop' >/dev/null && echo app-running || echo APP-NOT-RUNNING
 ```
 
-Ask the maintainer rather than escalating — factory reset / deleting Docker
-data destroys local images and volumes, never yours to spend. Clean up your
-own probes (`kill`ing a `docker pull` wrapper leaves the `com.docker.cli`
-child running).
+Ask the maintainer rather than escalating — a factory reset or deleting Docker
+data destroys local images and volumes, never yours to spend. Clean up your own probes (`kill`ing
+a `docker pull` wrapper leaves the `com.docker.cli` child running).
 
 ### 8-g. Prose claims are verified to the same bar as code
 
@@ -332,10 +322,9 @@ code defects and FIVE false statements in prose. Habits that each caught one:
 - **In a FIX round, the fix invalidated your own prose** — every past-tense
   measurement is stale until re-derived (one run: one code defect, TEN false
   claims — a changelog citing a ledger row the same delta replaced, a fence
-  "claimed rather than probed" whose named case did not exist, a tally
-  patched instead of re-measured, a blanket claim contradicted by its own
-  list). Before a fix round is final, re-derive every number, `file:line`,
-  ledger citation and "measured" verb, and say which tree they came from.
+  "claimed rather than probed" whose named case did not exist). Before a fix
+  round is final, re-derive every `file:line`, ledger citation and "measured"
+  verb, and say which tree they came from; for NUMBERS see the next bullet.
 - **The remedy is to DELETE the unproved clause, not rewrite it** — the
   recurring shape is a CONSEQUENCE bolted onto a verified claim ("X is
   load-bearing: deleting it would hard-fail" — X probed, the consequence
@@ -343,6 +332,18 @@ code defects and FIVE false statements in prose. Habits that each caught one:
   clause from INSIDE a sentence can falsify the survivor, so re-read what
   remains. When the false claim was that something IS fenced, BUILD the fence
   instead.
+- **A COUNT is never repaired by recounting** — give every number in published
+  prose one of three DISPOSITIONS: delete it (preferred — a changelog bullet
+  cannot be re-derived, and an enumeration IS its own count), fence it with a
+  floor AND a cap from a test that reads the code, or attribute it as a dated,
+  explicitly non-derivable measurement. Recounting fails because a widened set
+  falsifies counters in files the diff never touches (go-to-k/cdkd#2410 /
+  go-to-k/cdkd#2275, four in one run, every one caught by a reviewer and none
+  by the author; go-to-k/cdkd#2519 drifted its per-type lists seven times
+  across changelog, docs, PR body and comments, once inside the sentence
+  announcing the previous three were wrong). Sweep them with
+  `grep -rn "<the set's noun, then its cardinal>" src/ docs/ .claude/`, then
+  dispose of each — a silent renumber is what makes the next reader re-file it.
 - **Write the rationale FIRST in a fix round** — the one rationale-first
   round of four was the only one that introduced no new prose defect.
 
@@ -410,7 +411,12 @@ cannot doubt is the premise the lane handed them (go-to-k/cdkd#2383: three
 rounds of lane reviewers each found the next spelling of one defect; the
 independent orchestrator round found the YAML merge key the lane's own
 tripwire had been added to backstop and did not fire on). Take the tier the
-heuristic gives for YOUR pass.
+heuristic gives for YOUR pass, and keep the LATE rounds independent too —
+author-side round COUNT does not converge on the author's blind spot
+(go-to-k/cdkd#2519: its lane rounds reported no blockers; later independent
+rounds kept finding deltas INSIDE the previous round's fix). Three rounds of
+that shape means change the METHOD, not add a round — §5's "three spellings in
+three rounds".
 
 **A reviewer's scratch COPY of a worktree is not detached from git.** A linked
 worktree's `.git` is a FILE pointing into the main repo, and `cp -R` carries

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,9 +122,9 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_641,
-    corpusBytes: 168_089,
-    largest: { file: 'implement.md', bytes: 26_541 },
-    runnerUp: { file: 'verify.md', bytes: 26_455 },
+    corpusBytes: 170_960,
+    largest: { file: 'verify.md', bytes: 27_294 },
+    runnerUp: { file: 'implement.md', bytes: 26_541 },
   },
 };
 
@@ -137,13 +137,20 @@ const MIN_REFERENCE_FILES = 6;
 // RE-DERIVED DOWNWARD 208_000 -> 145_000 by the 2026-09-04 corpus compression
 // pass, exactly the move the assertion's failure message prescribes for a
 // genuine compression ("re-derive it DOWNWARD in the same commit"). Inputs are
-// in MEASURED and asserted: corpus 168,089 B, largest implement.md 26,541 B,
-// runner-up verify.md 26,455 B. The floor must clear `corpus - largest`
-// (141,548) and `corpus - runnerUp` (141,634, the binding direction);
-// 145,000 clears them by 3,452 and 3,366 B and leaves ~23 KB of further
-// compression headroom below the corpus. Growth in a NON-leader file erodes
+// in MEASURED and asserted: corpus 170,960 B, largest verify.md 27,294 B,
+// runner-up implement.md 26,541 B. The floor must clear `corpus - largest`
+// (143,666) and `corpus - runnerUp` (144,419, the binding direction);
+// 145,000 clears them by 1,334 and 581 B. Growth in a NON-leader file erodes
 // the either-largest margin first -- MEASURED's failure message reports both
 // margins, so the next lapse reds this file at the commit that causes it.
+// The 2026-09-04 retro (go-to-k/cdkd#2514's run) spent most of the 3,366 B the
+// compression pass had left: it added rules to filing.md, launch-mode.md,
+// retro.md, ship.md and verify.md, paid for them by merging a duplicated count
+// rule, relocating a repo-wide one to `.claude/rules/hooks.md`, and
+// compressing, and left 581 B. The next addition here has to be
+// paid for by compression FIRST -- retro.md section 10-c forbids buying the
+// room by raising this floor, and note that SPLITTING a stage file makes this
+// bound tighter, not looser (a smaller runner-up raises `corpus - runnerUp`).
 // History worth keeping: the floor was RAISED 206_000 -> 208_000 by the
 // 2026-09-02 retro (go-to-k/cdkd#2459) to fit its additions; retro.md
 // section 10-c now forbids that direction outright -- a retro pays for its


### PR DESCRIPTION
## Summary

Stage 10 (RETRO) of the `/work-issues` run that shipped go-to-k/cdkd#2519 for go-to-k/cdkd#2514. Four
lessons the run actually produced, each amended into the stage file where it
fires; two more landed outside the skill because they belong there.

**1. `filing.md` — a scope tripwire.** go-to-k/cdkd#2514 asked for a guard hoist at one
site. What shipped also widened `STATEFUL_TYPES`, because successive review
rounds each kept finding another type whose delete destroys user data with no
opt-in. (No count here on purpose — the pre-PR and post-PR figures did not
settle on one reading of the source, which is exactly the disposition rule
lesson 3 adds.) Every widening was verified; none was requested; the PR
reached 2036 LOC and the maintainer asked twice whether the run was taking
too long. The existing "a sweep that would make the PR unreviewable is a
genuine `next`" boundary never fired, because unreviewable is never reached by
drifting into it. It now names two tripwires — a SECOND unrequested widening in
one lane, or a PR title needing a clause the issue does not name — and requires
the call to be STATED with its LOC cost before it is taken. It deliberately
does not forbid fixing a data-loss bug you find; it makes the second one a
decision rather than a continuation.

**2. `launch-mode.md` — the recorded values govern READS, not just
re-derivations.** Mid-run the parent's shell cwd reset to the main checkout.
`git branch --show-current` answered `main` and
`git diff --stat origin/main..HEAD` came back empty; both were read as evidence
the lane branch had been switched and its PR possibly merged. Two "unfixed
prose" findings were main's copies of text the lane had already fixed. The
existing rule covers re-deriving `LANE_TREE`, and nothing had been re-derived —
the fault arrived through `sed -n` / `grep` on relative paths. The section now
covers reads, and adds the test: an answer contradicting the recorded values is
a cwd fault, not a finding.

**3. `verify.md` 8-g — a COUNT is never repaired by recounting.** go-to-k/cdkd#2519 drifted
its per-type lists and counts seven times across changelog, docs, PR body and
comments, once inside the very sentence announcing the previous three were
wrong. Every number in published prose now takes one of three dispositions:
deleted (preferred), fenced with a floor AND a cap by a test that reads the
code, or attributed as a dated non-derivable measurement. 8-a's near-duplicate
counter paragraph is merged into it — two blunted bullets is part of how the
drift survived.

**4. `verify.md` 8-i — one rider on an existing rule.** The independent-round
rule held: the lane's own rounds reported "no blockers" and the first
independent round found the fail-open that became most of the PR. What is new
is the round COUNT observation — later independent rounds kept finding deltas
inside the previous round's fix — so the late rounds stay independent, and
three rounds of that shape mean changing METHOD rather than adding a round.
The rule itself is not restated.

Landed outside the work-issues corpus, where each belongs and where it costs
the always-loaded stage files nothing:

- `.claude/skills/pick-integ/SKILL.md` now MARKS fixtures no agent session can
  run and asks for a substitute, rather than dropping them (the standard flow
  is still legal when a human drives the shell). The lane named
  `bench-cdk-sample` as its broad arm; it has neither `verify.sh` nor a
  directly-invoked `run.sh`, `/run-integ`'s standard flow needs a bare
  `cdkd deploy` the harness refuses, and the parent had to substitute
  `lambda`. `/run-integ` already carried the rule at the consuming end; this
  puts it at the producing end, as a derivation rather than a list that can go
  stale.
- `.claude/rules/hooks.md` records that a hand-typed `markgate` is the Homebrew
  0.2.0 earlier on `PATH`, which exits 2 with `unknown hash "diff"` against a
  perfectly fresh marker — a false BLOCK that reads as a stale one. The hooks
  themselves correctly prefer the mise-pinned 0.4.1.
- `ship.md` gains one clause: rewriting a sentinel after its marker is set
  stales that marker.

Paid for per `retro.md` 10-c — the merged count rule, the relocated markgate
entry, a reverted restatement in 8-c and a compression pass over 8-a / 8-e /
8-f / `gotchas.md`. `MIN_REFERENCE_CORPUS_BYTES` is NOT raised; `MEASURED` and
the floor's derivation comment are updated to the new figures, and the comment
now records that the binding runner-up margin fell from 3,366 B to 581 B, that
the next addition must compress first, and that splitting a stage file makes
that bound tighter rather than looser (a smaller runner-up raises
`corpus - runnerUp`).

## Test plan

- `vp check --fix` + `vp run check`: 0 errors (10 pre-existing warnings).
- `vp run typecheck:test`, `vp run build`: pass.
- `vp test run`: 887 files, 18,357 passed / 1 skipped, no type errors.
- `vp run gen:all-matrices` + `vp run audit:coverage:check`: clean, nothing
  regenerated.
- Prose arm of the live test (no `src/**` change): every claim the new text
  makes was resolved against this repo — `.mise.toml`'s `ubi:go-to-k/markgate
  = "0.4.1"` pin, `check-gate.sh`'s mise-first resolution, the measured
  `markgate verify check` rc=2 from the Homebrew binary vs rc=0 from the pinned
  one, which `tests/integration/*/verify.sh` files exist, and `/run-integ`
  step 5's own statement about the standard flow.
- One read-only claim-verification reviewer over the whole diff: 3 major, 3
  minor, 2 nit — all eight FIXED here, none deferred. The majors were a
  `verify.sh`-only runnability probe that false-positives on
  `migrate-from-cfn`'s directly-invoked `run.sh`; a round-count claim about
  go-to-k/cdkd#2519 that its own record contradicts (dropped rather than recounted, per
  the very rule this PR adds); and a rule silently removed by the compression
  pass ("an unexpectedly clean result is a `pwd` check, not a pass" —
  restored). The reviewer also independently re-measured every byte figure and
  confirmed the floor was not raised.
- Gate liveness proved before the first commit: `git commit --dry-run` was
  refused by `check-gate` naming both stale markers.
- No AWS work: `s3://cdkd-state-<acct>/cdkd/` holds 0 `state.json` objects
  (only the `deployments/` events store, which legitimately survives).

No issue is closed by this PR: go-to-k/cdkd#2514 was already closed by
go-to-k/cdkd#2519.
