### PR TITLE
docs(getting-started): regroup the commands by task and correct what they do

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,23 +7,6 @@ description: Install cdkd, bootstrap your AWS account, and run your first direct
 
 cdkd works with your existing CDK app as-is — install it, run `cdkd bootstrap` once per AWS account, and replace `cdk deploy` with `cdkd deploy`.
 
-## Prerequisites
-
-- **Node.js** >= 20.0.0
-- **AWS credentials with admin-equivalent permissions** for the resources being deployed. cdkd does NOT route through CloudFormation, so CDK CLI's `cdk-hnb659fds-deploy-role-*` is NOT sufficient — see [`--role-arn`](cli-reference.md).
-
-AWS CDK's `cdk bootstrap` is not required. Instead, run `cdkd bootstrap` once per
-account: it creates the S3 state bucket (`cdkd-state-{accountId}`) that cdkd uses
-to track deployed resources, plus cdkd-owned asset storage (by default a
-`cdkd-assets-{accountId}-{region}` bucket + a
-`cdkd-container-assets-{accountId}-{region}` ECR repo; custom names via
-`--asset-bucket` / `--container-repo`, skip with `--no-assets`; see
-[`cdkd bootstrap`](cli-bootstrap.md#cdkd-bootstrap)). Per-region asset
-storage is added automatically on the first `cdkd deploy` into each region.
-That page also covers existing setups, legacy-mode opt-outs, and how this
-relates to `cdk bootstrap`. If you bootstrapped under an earlier cdkd, see
-[Upgrading from an earlier cdkd version](#upgrading-from-an-earlier-cdkd-version).
-
 ## Installation
 
 ```bash
@@ -31,117 +14,157 @@ npm i -g @go-to-k/cdkd           # latest release
 npm i -g @go-to-k/cdkd@<version> # pin to a specific version
 ```
 
-The installed binary is `cdkd`.
+The installed binary is `cdkd`. Running it requires:
+
+- **Node.js** >= 20.0.0
+- **AWS credentials with admin-equivalent permissions** for the resources being
+  deployed. cdkd does NOT route through CloudFormation, so CDK CLI's
+  `cdk-hnb659fds-deploy-role-*` is NOT sufficient — see
+  [`--role-arn`](cli-reference.md#role-arn).
 
 ## Quick Start
 
 ```bash
-# Bootstrap (creates S3 state bucket + asset storage — one-time setup per AWS account)
+# One-time per AWS account: create the S3 state bucket + asset storage
 cdkd bootstrap
 
-# List stacks in the CDK app
+# List the stacks in the CDK app
 cdkd list
 
-# Deploy your CDK app
-cdkd deploy
-
-# Deploy at maximum speed: skip slow stabilization waits
-cdkd deploy --no-wait
-
-# Check what would change
+# Preview, then deploy
 cdkd diff
+cdkd deploy
 
 # Tear down
 cdkd destroy
 ```
 
-## Usage
+## Bootstrapping
 
-cdkd has three command families:
+AWS CDK's `cdk bootstrap` is not required. Instead, run `cdkd bootstrap` once per
+account: it creates the S3 state bucket (`cdkd-state-{accountId}`) that cdkd uses
+to track deployed resources, plus cdkd-owned asset storage (by default a
+`cdkd-assets-{accountId}-{region}` bucket + a
+`cdkd-container-assets-{accountId}-{region}` ECR repo; custom names via
+`--asset-bucket` / `--container-repo`, skip with `--no-assets`). Per-region asset
+storage is added automatically on the first `cdkd deploy` into each region.
 
-- **Top-level commands** — most (`cdkd deploy` / `destroy` / `diff` /
-  `synth` / `list` / `import` / `export` / `orphan` / `scrub` /
-  `publish-assets`) require a CDK app — they synthesize a template to
-  learn what they're operating on. A few operate on the state bucket /
-  AWS directly and need no app: `cdkd bootstrap`, `cdkd drift`,
-  `cdkd rollback`, `cdkd events`, `cdkd gc`, `cdkd force-unlock`, and
-  `cdkd migrate`, which starts from a CloudFormation stack and writes the
-  CDK app for you. See [CLI Reference](cli-reference.md).
-- **`cdkd state ...` subcommands** (`state info` / `list` / `resources`
-  / `show` / `orphan` / `destroy` / `migrate` / `refresh-observed`)
-  operate on the S3 state bucket only and do NOT need the CDK app —
-  use them to inspect / clean up state when the source is gone or
-  you don't want to synth. `cdkd state destroy` is the CDK-app-free
-  counterpart of `cdkd destroy`. See [`cdkd state`](cli-state.md).
-- **`cdkd local ...` subcommands** (`local invoke` / `start-api` /
-  `run-task` / `start-service` / `start-alb` / `start-cloudfront` /
-  `invoke-agentcore` / `start-agentcore`) run synthesized workloads
-  locally, most of them in Docker containers — no AWS deploy needed.
-  Modeled on
-  `sam local *` but reads CDK state directly via `--from-state`
-  (cdkd-managed) or `--from-cfn-stack` (CFn-managed). See
-  [Local Execution](local-emulation.md).
+[`cdkd bootstrap`](cli-bootstrap.md) covers existing setups,
+legacy-mode opt-outs, and how this relates to `cdk bootstrap`. If you
+bootstrapped under an earlier cdkd, see
+[Upgrading from an earlier cdkd version](#upgrading-from-an-earlier-cdkd-version).
 
-Options like `--app`, `--state-bucket`, and `--context` can be omitted if configured via `cdk.json` or environment variables (`CDKD_APP`, `CDKD_STATE_BUCKET`).
+## Commands by task
+
+Two conventions apply throughout:
+
+- Options like `--app`, `--state-bucket`, and `--context` can be omitted if
+  configured via `cdk.json` or environment variables (`CDKD_APP`,
+  `CDKD_STATE_BUCKET`).
+- Commands that delete AWS resources, or that adopt / release them, ask for
+  confirmation first: `destroy`, `orphan`, `import`, `export`, `rollback`,
+  `gc`, `drift --accept` / `--revert`, `events prune`, `bootstrap --destroy`,
+  and the writing `cdkd state` subcommands. `cdkd deploy` prompts too, but only
+  when it is about to create asset storage in a new region or replace a
+  resource. `-y` / `--yes` answers the prompt and is accepted by every command,
+  so the examples below leave it out — pass it in CI, where an unanswered
+  prompt is a hard error, not a hang.
 
 ### Deploy
 
 ```bash
-cdkd synth
+cdkd list                           # the stacks in the CDK app
+cdkd synth                          # synthesize the CloudFormation template only
 cdkd deploy                         # single-stack auto-detected
 cdkd deploy MyStack                 # by name (or 'MyStage/Api' display path)
 cdkd deploy --all
-cdkd deploy --dry-run               # plan only, no changes
+cdkd deploy --dry-run               # show the changes without applying them
 cdkd deploy --no-rollback           # Terraform-style: keep partial state on failure
-cdkd rollback MyStack               # revert a failed --no-rollback / interrupted deploy
 cdkd deploy --no-wait               # skip multi-minute waits (RDS / ElastiCache / NAT)
 cdkd deploy --full-wait             # also wait where the default does not (ECS steady state, CloudFront Deployed)
+cdkd publish-assets                 # synth + upload assets only, no deploy (typical CI split)
+
+cdkd events MyStack                 # past deploy / destroy runs, newest first
+cdkd events MyStack --run <runId>   # one run's full event stream
 ```
 
-### See what would change
+`--no-wait` / default / `--full-wait` are explained per resource type in
+[Wait Modes](wait-modes.md). `cdkd events` is cdkd's `DescribeStackEvents`
+equivalent — it replays what a past run did, and reads the state bucket, so it
+works without the CDK app.
+
+### Check for differences
+
+Two comparisons, against two different references:
+
+- `cdkd diff` — synthesized template vs cdkd state: what the **next deploy**
+  would change. Needs the CDK app.
+- `cdkd drift` — cdkd state vs **live AWS**: what changed outside cdkd. Reads
+  the state bucket only, so it needs no CDK app, and it can push either side
+  onto the other.
+
+`cdkd deploy --dry-run` runs the first comparison from inside the deploy path
+and prints create / update / delete counts; reach for `cdkd diff` when you want
+to read what actually changed.
 
 ```bash
 cdkd diff MyStack
 cdkd diff MyStack --fail            # exit 1 on any change (CI gate)
 
-# Drift — state vs live AWS, no synth
 cdkd drift MyStack                  # exit 1 if drift
-cdkd drift MyStack --accept --yes   # state ← AWS
-cdkd drift MyStack --revert --yes   # AWS ← state
-
-# Deployment history, cdkd's DescribeStackEvents equivalent (no synth)
-cdkd events MyStack                 # past deploy / destroy runs, newest first
-cdkd events MyStack --run <runId>   # one run's full event stream
+cdkd drift MyStack --accept         # state ← AWS
+cdkd drift MyStack --revert         # AWS ← state
 ```
 
-### Tear down and clean up
+### Recover a failed or interrupted deploy
+
+```bash
+cdkd rollback MyStack               # revert a failed --no-rollback / interrupted deploy
+cdkd force-unlock MyStack           # clear a stale lock left by a force-quit or cancelled CI job
+```
+
+### Tear down
+
+`destroy` deletes the AWS resources **and** the state record; `orphan` deletes
+**only** the state record, leaving the AWS resources in place — see
+[Orphan vs Destroy](orphan-vs-destroy.md).
 
 ```bash
 cdkd destroy MyStack
-cdkd orphan MyStack/MyBucket        # drop one resource from state (AWS resource stays)
-cdkd force-unlock MyStack           # clear a stale lock left by a force-quit or cancelled CI job
-cdkd gc --dry-run                   # reclaim unreferenced cdkd-owned assets (S3 + ECR)
+cdkd destroy --all
+cdkd orphan MyStack/MyBucket        # drop a resource — or everything under an L2
+                                    # path — from state; the AWS resources stay
 ```
 
-### Keep secrets out of state
-
-`cdkd scrub` audits and cleans state so a resolved secret dynamic reference is
-stored as its `{{resolve:...}}` expression. No deploy, no AWS mutation.
+### Reclaim asset storage
 
 ```bash
-cdkd scrub MyStack                  # clean existing state in place
-cdkd scrub MyStack --dry-run        # audit only, report what would change
-cdkd scrub MyStack --dry-run --fail # standing CI gate: exit 1 if plaintext remains
+cdkd gc --dry-run                   # report what would go, without deleting
+cdkd gc                             # one region's unreferenced cdkd-owned assets
+                                    # (S3 + ECR), plus abandoned custom-resource
+                                    # response placeholders (account-wide)
 ```
 
 ### Move between cdkd and CloudFormation
 
 ```bash
-cdkd publish-assets                 # synth + upload only (typical CI split)
-cdkd import MyStack --yes           # adopt existing AWS resources into cdkd state
-cdkd migrate MyCfnStack             # adopt a non-CDK CFn stack, generating the CDK app
-cdkd export MyStack                 # hand a cdkd-managed stack back to CloudFormation
+# A CDK app previously deployed with `cdk deploy`: adopt its resources into
+# cdkd state AND retire the CloudFormation stack (AWS resources are untouched).
+cdkd import MyStack --migrate-from-cloudformation
+
+# Adopt without retiring anything — resources created by hand, by another
+# tool, or by a cdkd deploy whose state file was lost. Physical ids are
+# resolved from the template and, if a same-named CFn stack exists, from it.
+cdkd import MyStack
+cdkd import MyStack --resource MyBucket=my-bucket-name   # only MyBucket, explicit id
+
+# The reverse direction: hand a cdkd-managed stack back to CloudFormation.
+cdkd export MyStack
 ```
+
+See [Importing Existing Resources](import.md) and
+[Exporting to CloudFormation](export.md) for the full flows, including the
+recursive nested-stack walk.
 
 ### Work on state without the CDK app
 
@@ -155,28 +178,66 @@ cdkd state destroy MyStack          # delete AWS resources + state, no CDK app
 cdkd state orphan MyStack           # remove the state record only (AWS resources stay)
 ```
 
-See the **[CLI reference](cli-reference.md)** for the full flag
+### Keep secrets out of state
+
+`cdkd scrub` audits and cleans state so a resolved secret dynamic reference is
+stored as its `{{resolve:...}}` expression. No deploy, no AWS mutation — but it
+does need the CDK app, because only the template still carries the unresolved
+expression.
+
+```bash
+cdkd scrub MyStack                  # clean existing state in place
+cdkd scrub MyStack --dry-run        # audit only, report what would change
+cdkd scrub MyStack --dry-run --fail # standing CI gate: exit 1 if plaintext remains
+```
+
+See the **[CLI Reference](cli-reference.md)** for the full flag
 matrix (`--concurrency`, `--no-aggressive-vpc-parallel`,
 `--allow-unsupported-properties`, `--role-arn`, etc.), per-command details
 including the synth-driven per-resource `cdkd orphan <constructPath>`
 variant, and stage / wildcard pattern matching.
+
+## Which commands need the CDK app
+
+Most top-level commands synthesize a template to learn what they are operating
+on. The rest read the S3 state bucket or AWS directly, so they still work when
+the source is gone or you don't want to synth.
+
+| Family | Needs the CDK app | Commands |
+| --- | --- | --- |
+| Top-level | Yes | `deploy`, `destroy`, `diff`, `synth`, `list`, `import`, `export`, `orphan`, `scrub`, `publish-assets` |
+| Top-level | No | `bootstrap`, `drift`, `rollback`, `events`, `gc`, `force-unlock` |
+| [`cdkd state ...`](cli-state.md) | No | `info`, `list`, `resources`, `show`, `orphan`, `destroy`, `migrate` (consolidate a legacy region-suffixed state bucket), `refresh-observed` |
+| [`cdkd local ...`](local-emulation.md) | Yes — synth only, nothing is deployed | `invoke`, `start-api`, `run-task`, `start-service`, `start-alb`, `start-cloudfront`, `invoke-agentcore`, `start-agentcore` |
+
+Two entries in the first row are softer than the rest: `cdkd destroy`
+synthesizes when an app is configured but otherwise selects stacks straight
+from the state record (only display-path patterns actually need the app), and
+`cdkd export` skips synth entirely when handed a `--template`. `cdkd state
+destroy` is the always-app-free counterpart of `cdkd destroy`. The `local`
+commands are modeled on `sam local *`, and resolve env vars and resource
+references from a deployed stack via `--from-state` (cdkd-managed) or
+`--from-cfn-stack` (CFn-managed).
 
 ## Upgrading from an earlier cdkd version
 
 **No breaking change, no manual step: just deploy.** The first `cdkd deploy` into
 each region auto-creates the cdkd-owned asset storage (interactive runs are asked
 once per region, `--yes` / CI runs create it automatically) and shows a one-time
-in-place UPDATE repointing asset references — content identical, no replacement.
-Downgrading is safe too (older binaries ignore the marker). If you bootstrapped
-under a previous cdkd version, the legacy region-suffixed state bucket name
-(`cdkd-state-{accountId}-{region}`) is still picked up automatically with a
-deprecation warning. Explicit pre-provisioning
-(`cdkd bootstrap --region <r>`), legacy-mode opt-outs, and how this relates to
-`cdk bootstrap`: see [`cdkd bootstrap`](cli-bootstrap.md#cdkd-bootstrap).
+in-place UPDATE repointing asset references at it — content identical, no
+replacement. Downgrading is safe too: an older binary ignores the per-region
+marker that records the opt-in.
+
+A state bucket created by an earlier cdkd keeps its legacy region-suffixed name
+(`cdkd-state-{accountId}-{region}`) and is still picked up automatically, with a
+deprecation warning; `cdkd state migrate` consolidates it into the region-free
+`cdkd-state-{accountId}`. Explicit pre-provisioning is
+`cdkd bootstrap --region <r>`.
 
 ## Next steps
 
-- [Using with AI Agents](ai-agents.md) — install the cdkd skill so Claude Code and other agents deploy with cdkd.
-- [Wait modes](wait-modes.md) — `--no-wait` / default / `--full-wait`: choose what "done" means per resource type.
+- [Core Concepts](concepts.md) — the deploy pipeline, S3 state, and how cdkd decides what to change.
+- [Use with AI Coding Agents](ai-agents.md) — install the cdkd skill so Claude Code and other agents deploy with cdkd.
+- [Wait Modes](wait-modes.md) — `--no-wait` / default / `--full-wait`: choose what "done" means per resource type.
 - [Per-PR Environments in CI](ci-per-pr.md) — one ephemeral stack per pull request, deployed and destroyed by workflow.
-- [CLI reference](cli-reference.md) — every command and flag in detail.
+- [CLI Reference](cli-reference.md) — every command and flag in detail.


### PR DESCRIPTION
## Summary

Rewrites the docs-site Getting Started page. The command groups did not match what the commands are, three descriptions were wrong, and the most-used `cdkd import` mode was missing.

**Structure**

- `## Prerequisites` is gone. The two real prerequisites (Node.js, admin-equivalent credentials) become bullets under `## Installation`, and the bootstrap explanation that filled the rest of it moves to its own `## Bootstrapping` section. Installation is now four lines below the H1 instead of eighteen.
- Commands are regrouped by task: **Deploy** (`list`, `synth`, `deploy`, `publish-assets`, `events`) → **Check for differences** (`diff` + `drift`) → **Recover a failed or interrupted deploy** → **Tear down** → **Reclaim asset storage** → **Move between cdkd and CloudFormation** → **Work on state without the CDK app** → **Keep secrets out of state**. Each group carries a line saying what it compares or changes, so the grouping is legible without reading the code block.
- `diff` and `drift` are one section: both answer "what is different", against different references. `events` sits with `deploy`, since deployment history is part of the deploy loop.
- `publish-assets` moves out of the CloudFormation-migration group into Deploy, where it belongs — it is the synth-plus-upload half of a deploy, not a migration step.
- `scrub` moves to the bottom.
- The needs-a-CDK-app taxonomy becomes a table after the task groups instead of a 22-line bullet list before them.

**Content**

- `cdkd import --migrate-from-cloudformation` is documented, as the first example in its group. The four adjacent operations (`import --migrate-from-cloudformation`, plain `import`, `export`) are now contrasted in one block.
- `--yes` is dropped from every example. It is a global option accepted by all 19 top-level commands and both subcommand families, so showing it on one example read as a property of that command. One sentence up front names the commands that prompt.

**Corrections found by checking every example against the Commander tree and the implementing files**

- `deploy --dry-run` was glossed "plan only, no changes". Asset publishing is not gated on `dryRun` — asset nodes are added to the work graph whenever `--skip-assets` is absent and executed before the engine short-circuits — so a dry run does upload. Reworded to "show the changes without applying them".
- `destroy` was listed as requiring a CDK app. It synthesizes only when an app is configured and otherwise selects stacks from the state record; only display-path patterns need the app.
- `export` was listed the same way, but skips synth entirely when given `--template`.
- `scrub` was placed adjacent to the app-free state commands, implying it is one. It synthesizes — only the template still carries the unresolved `{{resolve:...}}` expression. Now stated in its section.
- The confirmation-prompt list omitted `events prune`, `bootstrap --destroy`, and `cdkd deploy` (which prompts before creating asset storage in a new region, and before a replacement).
- `gc` was described as reclaiming assets; it covers one region's assets plus account-wide custom-resource response placeholders.
- `orphan` was described as dropping one resource; it prefix-matches, so an L2 path drops everything under it.
- The `--role-arn` link pointed at `cli-reference.md#--role-arn`, which does not resolve — anchors slugify leading punctuation away.
- `Next steps` skipped Core Concepts, the next page in the nav, and the AI-agents link text did not match the target page's title.

## Deliberate non-changes

- **`## Upgrading from an earlier cdkd version` is kept, not deleted.** A reviewer read it as history framing that the page-template voice rules ban. It is a live migration note for users on older versions, so it stays; the dangling "the marker" referent and the duplicated `cdkd bootstrap` pointer it carried are fixed.
- **`scrub` stays last rather than swapping with the state group.** A reviewer suggested the swap so `scrub` is not adjacent to the app-free commands; the adjacency is instead fixed by stating outright that `scrub` needs the app.
- **`### Deploy` is not renamed to "Synthesize and deploy".** `events` lives in that group, and the narrower title would fit it worse.

## `cdkd migrate` is left off the page

It is the only command in `src/**` that requires the AWS CDK CLI binary — `cdk migrate --from-stack` for codegen, `cdk synth` on the generated app, and `cdk --version` for a minimum-version check. Every other command runs the user's own app command and never touches the `cdk` binary. Whether the command stays is decided in a separate issue (#2572); it is off the page until then.

## Follow-ups

- Decide whether to deprecate `cdkd migrate` over its AWS CDK CLI dependency (#2572).
- Nothing fences a registered CLI command against the documentation site, which is why `cdkd migrate` shipped with no page and no nav entry (#2573).
- The reference-page request for `cdkd migrate`, closed as superseded (#2569).

## Test plan

- Every one of the 43 `cdkd ...` invocations on the page validated against the real Commander tree from `buildProgram()` via the built `dist/cli.js`: no unknown command, no undeclared flag.
- Each corrected claim traced to the implementing file rather than to `--help` alone.
- `vp run check`, `vp run typecheck:test`, `vp run build`, `vp run gen:all-matrices`, `vp run audit:coverage:check` — clean, nothing regenerated dirty.
- `vp test run` — 887 files, 18370 passed, 1 skipped, no type errors.
- `vp run docs:build`, then the rendered `dist/site/getting-started/index.html` inspected: heading order as intended, the taxonomy table renders, and every internal link and anchor on the page resolves against the built site, including `cli-reference/#role-arn`.
- No AWS mutation: documentation-only change.
