### PR TITLE
test(docs): fence every registered CLI command against the documentation site, and document force-unlock

### DIFF
--- a/docs/cli-deploy.md
+++ b/docs/cli-deploy.md
@@ -1,6 +1,6 @@
 ---
 title: "Deploy: waits & concurrency"
-description: "Deploy-time wait and concurrency flags — the concurrency knobs, the per-resource-type wait-semantics table, and --no-wait / --full-wait."
+description: "cdkd deploy wait and concurrency flags — the concurrency knobs, the per-resource-type wait-semantics table, and --no-wait / --full-wait."
 ---
 
 # Deploy: waits & concurrency

--- a/docs/cli-force-unlock.md
+++ b/docs/cli-force-unlock.md
@@ -99,7 +99,7 @@ events are all left as they were.
 
 | Code | Meaning |
 | --- | --- |
-| `0` | Every lock the walk reached was deleted, or there was none to delete. |
+| `0` | The walk completed. Every lock it reached was deleted, there was none to delete, or a delete failed — see below. |
 | `1` | No stack was named; credentials or state-bucket resolution failed; or listing the stack's regions failed. |
 
 The two failures are not symmetric, and the difference matters when scripting

--- a/docs/cli-force-unlock.md
+++ b/docs/cli-force-unlock.md
@@ -1,0 +1,103 @@
+---
+title: cdkd force-unlock
+description: "Delete a stack's lock object when a crashed or cancelled run left one behind, without waiting for it to expire."
+---
+
+# cdkd force-unlock
+
+Deletes the lock object a cdkd run holds while it writes to a stack. Reach for
+it when a run was force-quit, a CI job was cancelled, or a laptop slept
+mid-deploy, and the next command refuses to start because the stack is still
+locked.
+
+It needs no CDK app — it operates on the state bucket directly.
+
+```bash
+cdkd force-unlock MyStack                         # every region where the stack has state
+cdkd force-unlock MyStack --stack-region us-west-2 # one region
+cdkd force-unlock MyStack OtherStack               # several stacks in one run
+```
+
+## Options
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--stack-region <region>` | every region where the stack has state | Release the lock for one region only. |
+| `--stack <name>` | — | Stack to unlock, as a flag instead of a positional argument. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET`, then `cdk.json`, then `cdkd-state-{accountId}` | The state bucket holding the lock. |
+| `--state-prefix <prefix>` | `cdkd` | Key prefix inside the bucket. |
+| `--profile <profile>` | — | AWS profile. |
+| `--role-arn <arn>` | `CDKD_ROLE_ARN` | Role to assume before any AWS call. |
+| `--verbose` | `false` | Debug-level logging. |
+
+At least one stack is required, positionally or via `--stack`; the command
+errors rather than guessing.
+
+## Usually you do not need this
+
+A lock is not permanent. It carries a 30-minute TTL, and a live cdkd process
+renews it well inside that window, so an abandoned lock stops being honoured 30
+minutes after its owner's last renewal. The next `cdkd deploy` takes an expired
+lock over on its own and prints a warning naming the previous owner and how long
+ago it expired.
+
+So `cdkd force-unlock` is for the two cases that outlast that:
+
+- You do not want to wait out the remaining TTL.
+- The lock object is unreadable — truncated, or holding something that is not a
+  lock. Nothing can take that over automatically, because the takeover path has
+  to read `expiresAt` to decide the lock is expired, while every attempt to
+  acquire still fails on the object's presence. `force-unlock` deletes it
+  regardless of whether it could be parsed.
+
+## The delete is unconditional
+
+This command removes the lock whether or not it has expired, and whether or not
+another process still holds it. That is deliberate — a lock cdkd cannot read is
+a lock nothing else can clear, so gating the delete on reading it first would
+make a corrupt lock permanent.
+
+The cost is that **running it against a live deploy leaves two processes writing
+to the same stack**. Before running it, confirm the owner is really gone: the
+command prints the lock's owner and operation before deleting, and `cdkd events
+<stack>` shows whether a run is still emitting events.
+
+## Which regions it releases
+
+Without `--stack-region`, the command looks the stack up in the state bucket and
+releases the lock in **every region where that stack name has a state record** —
+the same stack name deployed to two regions has two independent locks. When the
+stack has no state record at all, it falls back to the CLI region.
+
+`--stack-region` narrows it to one region. Locks written by a pre-v2 cdkd live
+at a region-less key and are released as part of the same walk.
+
+## What it deletes
+
+The lock is a single object at
+`s3://{bucket}/{prefix}/{stackName}/{region}/lock.json`. The command deletes it
+and then purges that key's noncurrent versions, so a versioned state bucket does
+not accumulate the leavings of every crashed run. Nothing else in the state
+record is touched: the stack's `state.json`, its resources, and its deployment
+events are all left as they were.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The lock was deleted, or there was none to delete. |
+| `1` | No stack was named, or an AWS call failed before the per-stack walk started (credentials, bucket resolution). |
+
+A per-stack failure is reported on stderr and the walk continues to the next
+stack; the run still exits `0`. Read the output rather than the exit code when
+scripting this command — a `cdkd force-unlock && cdkd deploy` chain proceeds
+even when the unlock failed.
+
+The full cross-command table is in the [CLI Reference](cli-reference.md#exit-codes).
+
+## Related
+
+- [`cdkd state`](cli-state.md) — inspecting the state record the lock guards
+- [`cdkd events`](cli-events.md) — checking whether a run is still active before forcing the lock
+- [State Management](state-management.md) — the state bucket layout and the locking model
+- [CLI Reference](cli-reference.md) — every command and the full exit-code table

--- a/docs/cli-force-unlock.md
+++ b/docs/cli-force-unlock.md
@@ -24,10 +24,11 @@ cdkd force-unlock MyStack OtherStack               # several stacks in one run
 | --- | --- | --- |
 | `--stack-region <region>` | every region where the stack has state | Release the lock for one region only. |
 | `--stack <name>` | — | Stack to unlock, as a flag instead of a positional argument. |
-| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET`, then `cdk.json`, then `cdkd-state-{accountId}` | The state bucket holding the lock. |
+| `--state-bucket <bucket>` | `CDKD_STATE_BUCKET`, then `cdk.json`, then the account default | The state bucket holding the lock. The default name is resolved by probing `cdkd-state-{accountId}` and the legacy `cdkd-state-{accountId}-{region}`. |
 | `--state-prefix <prefix>` | `cdkd` | Key prefix inside the bucket. |
 | `--profile <profile>` | — | AWS profile. |
 | `--role-arn <arn>` | `CDKD_ROLE_ARN` | Role to assume before any AWS call. |
+| `-y`, `--yes` | `false` | Accepted for consistency with the other state-writing commands; `cdkd force-unlock` asks no confirmation, so it changes nothing. |
 | `--verbose` | `false` | Debug-level logging. |
 
 At least one stack is required, positionally or via `--stack`; the command
@@ -62,15 +63,28 @@ to the same stack**. Before running it, confirm the owner is really gone: the
 command prints the lock's owner and operation before deleting, and `cdkd events
 <stack>` shows whether a run is still emitting events.
 
+Confirm the *account*, too. The command re-resolves the state bucket from the
+ambient profile, so a shortened invocation — dropping the `--profile` or
+`--state-bucket` you used earlier — can clear the lock of a same-named stack in
+a different account. When cdkd prints a recovery command in a lock error, run it
+as printed.
+
 ## Which regions it releases
 
 Without `--stack-region`, the command looks the stack up in the state bucket and
 releases the lock in **every region where that stack name has a state record** —
-the same stack name deployed to two regions has two independent locks. When the
-stack has no state record at all, it falls back to the CLI region.
+the same stack name deployed to two regions has two independent locks. A record
+written by a pre-v2 cdkd that names no region resolves to the region-less lock
+key, and is released by the same walk; one that does name a region resolves to
+the region-prefixed key only.
 
-`--stack-region` narrows it to one region. Locks written by a pre-v2 cdkd live
-at a region-less key and are released as part of the same walk.
+When the stack has no state record at all, the walk falls back to the region
+`--region` or `AWS_REGION` names, and to the literal `us-east-1` when neither is
+set — the profile's own region is not consulted. See
+[`--region` / `AWS_REGION`](cli-reference.md#region-aws-region-every-command).
+
+`--stack-region` narrows the walk to the one region named, and no other key is
+touched — including the region-less one.
 
 ## What it deletes
 
@@ -85,13 +99,18 @@ events are all left as they were.
 
 | Code | Meaning |
 | --- | --- |
-| `0` | The lock was deleted, or there was none to delete. |
-| `1` | No stack was named, or an AWS call failed before the per-stack walk started (credentials, bucket resolution). |
+| `0` | Every lock the walk reached was deleted, or there was none to delete. |
+| `1` | No stack was named; credentials or state-bucket resolution failed; or listing the stack's regions failed. |
 
-A per-stack failure is reported on stderr and the walk continues to the next
-stack; the run still exits `0`. Read the output rather than the exit code when
-scripting this command — a `cdkd force-unlock && cdkd deploy` chain proceeds
-even when the unlock failed.
+The two failures are not symmetric, and the difference matters when scripting
+this command:
+
+- **Failing to LIST a stack's regions** aborts the run and exits `1`, leaving
+  any later stack in the same invocation unattempted.
+- **Failing to DELETE a lock** is reported on stderr, the walk continues to the
+  next stack, and the run still exits `0` — so a
+  `cdkd force-unlock && cdkd deploy` chain proceeds against a stack whose lock
+  is still there. Read the output, not the exit code.
 
 The full cross-command table is in the [CLI Reference](cli-reference.md#exit-codes).
 

--- a/docs/cli-force-unlock.md
+++ b/docs/cli-force-unlock.md
@@ -36,13 +36,13 @@ errors rather than guessing.
 
 ## Usually you do not need this
 
-A lock is not permanent. It carries a 30-minute TTL, and a live cdkd process
-renews it well inside that window, so an abandoned lock stops being honoured 30
-minutes after its owner's last renewal. The next `cdkd deploy` takes an expired
-lock over on its own and prints a warning naming the previous owner and how long
-ago it expired.
+A lock usually clears itself. It carries a 30-minute TTL, and a live cdkd
+process renews it well inside that window, so an abandoned lock is expired 30
+minutes after its owner's last renewal — and the next `cdkd deploy` normally
+takes an expired lock over on its own, printing a warning that names the
+previous owner and how long ago it expired.
 
-So `cdkd force-unlock` is for the two cases that outlast that:
+`cdkd force-unlock` is for the cases where that does not happen:
 
 - You do not want to wait out the remaining TTL.
 - The lock object is unreadable — truncated, or holding something that is not a
@@ -50,6 +50,12 @@ So `cdkd force-unlock` is for the two cases that outlast that:
   to read `expiresAt` to decide the lock is expired, while every attempt to
   acquire still fails on the object's presence. `force-unlock` deletes it
   regardless of whether it could be parsed.
+- The takeover was refused. cdkd removes an expired lock only when it can
+  delete the exact version it just read; if that version cannot be identified,
+  or the S3 endpoint will not evaluate the conditional delete, it declines
+  rather than risk deleting a lock some other process has since taken. It says
+  so and names this command. Such a lock does not clear on its own, however
+  long you wait.
 
 ## The delete is unconditional
 
@@ -107,10 +113,10 @@ this command:
 
 - **Failing to LIST a stack's regions** aborts the run and exits `1`, leaving
   any later stack in the same invocation unattempted.
-- **Failing to DELETE a lock** is reported on stderr, the walk continues to the
-  next stack, and the run still exits `0` — so a
-  `cdkd force-unlock && cdkd deploy` chain proceeds against a stack whose lock
-  is still there. Read the output, not the exit code.
+- **Failing to DELETE a lock** is reported on stderr, the walk carries on with
+  that stack's remaining regions and then the next stack, and the run still
+  exits `0` — so a `cdkd force-unlock && cdkd deploy` chain proceeds against a
+  stack whose lock is still there. Read the output, not the exit code.
 
 The full cross-command table is in the [CLI Reference](cli-reference.md#exit-codes).
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -34,6 +34,8 @@ The detailed per-command / per-flag reference is split across these pages:
 - **[`cdkd drift`](cli-drift.md)** — detecting and resolving drift against live
   AWS resources.
 - **[`cdkd rollback`](cli-rollback.md)** — reverting a failed deploy.
+- **[`cdkd force-unlock`](cli-force-unlock.md)** — clearing a lock a crashed or
+  cancelled run left behind.
 - **[`cdkd export`](cli-export.md)** — handing a stack over to CloudFormation.
 - **[`cdkd scrub`](cli-scrub.md)** — state secret hygiene (clean + audit).
 - **[`cdkd publish-assets`](cli-publish-assets.md)** — synth + build + publish

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,8 +120,12 @@ cdkd drift MyStack --revert         # AWS ← state
 
 ```bash
 cdkd rollback MyStack               # revert a failed --no-rollback / interrupted deploy
-cdkd force-unlock MyStack           # clear a stale lock left by a force-quit or cancelled CI job
+cdkd force-unlock MyStack           # clear a lock left by a force-quit or cancelled CI job
 ```
+
+A lock expires on its own 30 minutes after its owner stops renewing it, so
+[`cdkd force-unlock`](cli-force-unlock.md) is for when you would rather not wait
+— or when the lock object itself is unreadable.
 
 ### Tear down
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,6 +35,10 @@ cdkd list
 cdkd diff
 cdkd deploy
 
+# The headline flag: return as soon as each create call returns, and let AWS
+# settle the slow ones (CloudFront, RDS, ElastiCache, NAT) in the background
+cdkd deploy --no-wait
+
 # Tear down
 cdkd destroy
 ```
@@ -80,7 +84,7 @@ cdkd deploy MyStack                 # by name (or 'MyStage/Api' display path)
 cdkd deploy --all
 cdkd deploy --dry-run               # show the changes without applying them
 cdkd deploy --no-rollback           # Terraform-style: keep partial state on failure
-cdkd deploy --no-wait               # skip multi-minute waits (RDS / ElastiCache / NAT)
+cdkd deploy --no-wait               # return early; AWS settles the slow resources
 cdkd deploy --full-wait             # also wait where the default does not (ECS steady state, CloudFront Deployed)
 cdkd publish-assets                 # synth + upload assets only, no deploy (typical CI split)
 

--- a/docs/orphan-vs-destroy.md
+++ b/docs/orphan-vs-destroy.md
@@ -1,6 +1,6 @@
 ---
 title: Orphan vs Destroy
-description: destroy deletes AWS resources and cdkd state; orphan removes only the state record — per resource or per stack — leaving the AWS resources intact.
+description: "cdkd destroy deletes AWS resources and cdkd state; cdkd orphan removes only the state record — per resource or per stack — leaving the AWS resources intact."
 ---
 
 # Orphan vs Destroy

--- a/tests/unit/scripts/docs-command-nav-coverage.test.ts
+++ b/tests/unit/scripts/docs-command-nav-coverage.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { buildProgram } from '../../../src/cli/program.js';
+
+/**
+ * Fences every registered top-level `cdkd` command against the documentation
+ * site, so a command cannot ship with no page and no navigation entry.
+ *
+ * `cdkd migrate` did exactly that. It was registered, released, and covered by
+ * an integ fixture while having no reference page, no entry in the site's
+ * `CLI Reference` navigation group, and no mention from the import guide it is
+ * adjacent to. It was found by a reader asking whether the command existed at
+ * all -- not by any check, because none of the existing ones look here:
+ *
+ *   - `scripts/check-integ-cli-flags.ts` validates integ-fixture invocations
+ *     against the real Commander tree. Fixtures, not docs.
+ *   - `scripts/build-cli-flag-coverage-matrix.ts` measures which flags the
+ *     fixtures exercise. Again fixtures.
+ *   - `tests/unit/scripts/docs-site-links.test.ts` validates links between
+ *     pages that exist. It cannot see a page that was never written.
+ *
+ * WHY A MAP RATHER THAN A `cli-<command>.md` CONVENTION. Measured on the tree
+ * this file was written against: seven of the nineteen commands have no
+ * `cli-<command>` page, but five of those seven ARE documented, under a
+ * differently-named page that the navigation does list -- `import` under the
+ * import guide, `orphan` under the orphan-vs-destroy comparison, `local` under
+ * the local-execution overview, and `list` / `synth` inside the CLI Reference
+ * overview itself. A bare naming-convention assertion would therefore have
+ * pushed five documented commands into an exclusion list, leaving a fence that
+ * is mostly exclusion and teaches nothing about the commands that are genuinely
+ * missing. (Of the two that were: `force-unlock` got the reference page this
+ * measurement showed it never had, and `migrate` is the entry below.)
+ *
+ * So the map is the assertion: naming the page is the act of claiming the
+ * command is documented, and the claim is then CHECKED -- the page must exist,
+ * must be reachable from the navigation, and must actually mention the command.
+ * Anything a maintainer cannot make that claim for goes in `UNDOCUMENTED` with
+ * a reason, which is the point: leaving a command undocumented becomes a
+ * deliberate, reviewed act rather than an omission nobody sees.
+ *
+ * WHAT THIS DOES NOT PROVE. That a page documents a command WELL, or covers its
+ * flags -- only that a nav-reachable page names it. The mention check rejects a
+ * mapping pointed at an unrelated page; it does not grade the prose.
+ */
+const repoRoot = join(import.meta.dirname, '..', '..', '..');
+const DOCS_CONFIG = join(repoRoot, 'vite.docs.config.ts');
+
+/**
+ * Command -> the navigation path of the page that documents it.
+ *
+ * The path is the site path as written in `vite.docs.config.ts` (`/cli-gc`),
+ * which maps to `docs/<path>.md`.
+ */
+const COMMAND_PAGES: Readonly<Record<string, string>> = {
+  bootstrap: '/cli-bootstrap',
+  deploy: '/cli-deploy',
+  destroy: '/cli-destroy',
+  diff: '/cli-diff',
+  drift: '/cli-drift',
+  events: '/cli-events',
+  export: '/cli-export',
+  'force-unlock': '/cli-force-unlock',
+  gc: '/cli-gc',
+  import: '/import',
+  list: '/cli-reference',
+  local: '/local-emulation',
+  orphan: '/orphan-vs-destroy',
+  'publish-assets': '/cli-publish-assets',
+  rollback: '/cli-rollback',
+  scrub: '/cli-scrub',
+  state: '/cli-state',
+  synth: '/cli-reference',
+};
+
+/**
+ * Commands deliberately shipped with no documentation page, each with the
+ * reason. An entry here is a decision on the record, not a free pass -- adding
+ * one should be as visible in review as adding a command.
+ */
+const UNDOCUMENTED: Readonly<Record<string, string>> = {
+  migrate:
+    'Held pending the deprecation decision in go-to-k/cdkd#2572 -- it is the only ' +
+    'command that requires the AWS CDK CLI binary, so whether it stays at all is ' +
+    'undecided. Writing a reference page for it first would be premature.',
+};
+
+/**
+ * Commander adds `help` to the tree itself; it is not a cdkd command and has
+ * no page to expect.
+ */
+const BUILT_IN = new Set(['help']);
+
+/**
+ * Floors, so a parse that has gone blind cannot report green having compared
+ * nothing. "The tree yielded no commands" and "every command is documented"
+ * are the same pass without these. Both sit a few entries below the measured
+ * counts (19 commands, 48 nav paths) so an ordinary removal does not force a
+ * test edit, while a total parse failure cannot clear them.
+ */
+const MIN_COMMANDS = 15;
+const MIN_NAV_PATHS = 30;
+
+/** Top-level command names, aliases excluded (they resolve to the same page). */
+function topLevelCommandNames(): string[] {
+  return buildProgram()
+    .commands.map((c) => c.name())
+    .filter((n) => !BUILT_IN.has(n));
+}
+
+/** Every `path: '/x'` entry in the hand-authored site navigation. */
+function navPaths(): Set<string> {
+  const source = readFileSync(DOCS_CONFIG, 'utf8');
+  const paths = [...source.matchAll(/path:\s*'(\/[a-z0-9-]+)'/g)].map((m) => m[1] as string);
+  expect(
+    paths.length,
+    `${DOCS_CONFIG}: extracted ${paths.length} navigation paths, below the floor of ` +
+      `${MIN_NAV_PATHS}. Either the navigation genuinely shrank (lower the floor ` +
+      `deliberately) or this extractor stopped seeing its input -- an empty set makes ` +
+      `every "is this path in the nav" assertion below vacuously false and the ` +
+      `mapping assertions vacuously true.`
+  ).toBeGreaterThanOrEqual(MIN_NAV_PATHS);
+  return new Set(paths);
+}
+
+/** `/cli-gc` -> `docs/cli-gc.md`. */
+function docFileFor(navPath: string): string {
+  return join(repoRoot, 'docs', `${navPath.slice(1)}.md`);
+}
+
+const commands = topLevelCommandNames();
+const nav = navPaths();
+
+describe('docs command/nav coverage', () => {
+  it('reads a plausible command tree', () => {
+    expect(
+      commands.length,
+      `buildProgram() yielded ${commands.length} top-level commands, below the floor of ` +
+        `${MIN_COMMANDS}. Every assertion below iterates this list, so an empty or ` +
+        `truncated tree passes them all while checking nothing.`
+    ).toBeGreaterThanOrEqual(MIN_COMMANDS);
+  });
+
+  it('accounts for every registered top-level command', () => {
+    const unaccounted = commands.filter(
+      (name) => !(name in COMMAND_PAGES) && !(name in UNDOCUMENTED)
+    );
+    expect(
+      unaccounted,
+      `These commands are registered in src/cli/program.ts but appear in neither ` +
+        `COMMAND_PAGES nor UNDOCUMENTED. Add the navigation path of the page that ` +
+        `documents each one, or add it to UNDOCUMENTED with the reason -- a command ` +
+        `with no documentation is a decision, and this is where it gets recorded.`
+    ).toEqual([]);
+  });
+
+  it('never lists a command in both maps', () => {
+    const both = Object.keys(COMMAND_PAGES).filter((name) => name in UNDOCUMENTED);
+    expect(
+      both,
+      `A command cannot be both documented and deliberately undocumented. Remove ` +
+        `the stale entry.`
+    ).toEqual([]);
+  });
+
+  it('keeps both maps free of commands that no longer exist', () => {
+    const registered = new Set(commands);
+    const stale = [...Object.keys(COMMAND_PAGES), ...Object.keys(UNDOCUMENTED)]
+      .filter((name) => !registered.has(name))
+      .sort();
+    expect(
+      stale,
+      `These names are mapped here but are no longer registered commands. A removed ` +
+        `command must not leave an entry behind: the reverse direction is what stops ` +
+        `this file drifting into a record of what cdkd used to ship.`
+    ).toEqual([]);
+  });
+
+  it('points every mapped command at a page the navigation lists', () => {
+    const missing = Object.entries(COMMAND_PAGES)
+      .filter(([, navPath]) => !nav.has(navPath))
+      .map(([name, navPath]) => `${name} -> ${navPath}`)
+      .sort();
+    expect(
+      missing,
+      `These pages are claimed as a command's documentation but have no entry in ` +
+        `vite.docs.config.ts, so a reader browsing the site cannot reach them.`
+    ).toEqual([]);
+  });
+
+  it('points every mapped command at a page that exists and names it', () => {
+    const problems: string[] = [];
+    for (const [name, navPath] of Object.entries(COMMAND_PAGES)) {
+      const file = docFileFor(navPath);
+      if (!existsSync(file)) {
+        problems.push(`${name} -> ${navPath}: docs/${navPath.slice(1)}.md does not exist`);
+        continue;
+      }
+      if (!readFileSync(file, 'utf8').includes(`cdkd ${name}`)) {
+        problems.push(`${name} -> ${navPath}: page never mentions \`cdkd ${name}\``);
+      }
+    }
+    expect(
+      problems.sort(),
+      `A mapping is a claim that the page documents the command. These pages do not ` +
+        `back the claim -- point the command at the page that actually covers it, or ` +
+        `move it to UNDOCUMENTED.`
+    ).toEqual([]);
+  });
+
+  it('gives every undocumented command a reason', () => {
+    const empty = Object.entries(UNDOCUMENTED)
+      .filter(([, reason]) => reason.trim().length < 20)
+      .map(([name]) => name)
+      .sort();
+    expect(
+      empty,
+      `An entry in UNDOCUMENTED records a decision, so it needs the reason the ` +
+        `command ships without a page. A bare name is an omission wearing an ` +
+        `exclusion list's clothes.`
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/scripts/docs-command-nav-coverage.test.ts
+++ b/tests/unit/scripts/docs-command-nav-coverage.test.ts
@@ -20,65 +20,116 @@ import { buildProgram } from '../../../src/cli/program.js';
  *   - `tests/unit/scripts/docs-site-links.test.ts` validates links between
  *     pages that exist. It cannot see a page that was never written.
  *
- * WHY A MAP RATHER THAN A `cli-<command>.md` CONVENTION. Measured on the tree
- * this file was written against: seven of the nineteen commands have no
- * `cli-<command>` page, but five of those seven ARE documented, under a
- * differently-named page that the navigation does list -- `import` under the
- * import guide, `orphan` under the orphan-vs-destroy comparison, `local` under
- * the local-execution overview, and `list` / `synth` inside the CLI Reference
- * overview itself. A bare naming-convention assertion would therefore have
- * pushed five documented commands into an exclusion list, leaving a fence that
- * is mostly exclusion and teaches nothing about the commands that are genuinely
- * missing. (Of the two that were: `force-unlock` got the reference page this
- * measurement showed it never had, and `migrate` is the entry below.)
+ * WHY THREE STRUCTURES RATHER THAN A `cli-<command>.md` CONVENTION. Measured on
+ * the tree this file was written against: eight of the nineteen commands have
+ * no `cli-<command>` page, and they are not all the same case. Five are
+ * genuinely documented under a differently-named page the navigation lists;
+ * three are not documented at all. A bare naming-convention assertion would
+ * have put all eight in one exclusion list and lost that distinction -- which
+ * is the whole finding.
  *
- * So the map is the assertion: naming the page is the act of claiming the
- * command is documented, and the claim is then CHECKED -- the page must exist,
- * must be reachable from the navigation, and must actually mention the command.
- * Anything a maintainer cannot make that claim for goes in `UNDOCUMENTED` with
- * a reason, which is the point: leaving a command undocumented becomes a
- * deliberate, reviewed act rather than an omission nobody sees.
+ * So a command is claimed in one of three ways, each CHECKED differently, and
+ * the strength of the check follows the strength of the claim:
  *
- * WHAT THIS DOES NOT PROVE. That a page documents a command WELL, or covers its
- * flags -- only that a nav-reachable page names it. The mention check rejects a
- * mapping pointed at an unrelated page; it does not grade the prose.
+ *   - `COMMAND_REFERENCE_PAGES` -- this page IS the command's reference.
+ *     Checked by H1 IDENTITY (`# cdkd <command>`) rather than by a mention, so
+ *     the mapping cannot drift onto a page that merely name-drops the command.
+ *   - `COMMAND_TOPIC_PAGES` -- the command is documented inside a page covering
+ *     a broader topic, with the reason recorded. Checked by mention, which is
+ *     weaker; the hub page is REFUSED as a target for it (see below).
+ *   - `UNDOCUMENTED` -- shipped with no documentation, with the reason recorded.
+ *
+ * WHY THE HUB IS REFUSED AS A MAPPING TARGET. `docs/cli-reference.md` names
+ * every command at least once, so mapping a command to it passes a mention
+ * check for free. Measured while reviewing this file: sixteen mappings stayed
+ * green when repointed at the hub, which is exactly the regression a fence like
+ * this is for -- a dedicated page deleted and its mapping quietly moved to the
+ * hub. Refusing the hub outright removes the class rather than tightening a
+ * substring test against it.
+ *
+ * WHAT THIS DOES NOT PROVE:
+ *
+ *   - That a page documents a command WELL, or covers its flags. The H1 check
+ *     proves a page is titled after the command; the mention check proves a
+ *     topic page names it somewhere. Neither grades the prose.
+ *   - Anything about SUBCOMMANDS. `cdkd state *`, `cdkd local *` and
+ *     `cdkd events prune` are out of scope, so one of those can still ship
+ *     undocumented -- the same class as the `migrate` incident, one level down.
+ *     Widening to subcommands is a separate change.
  */
 const repoRoot = join(import.meta.dirname, '..', '..', '..');
 const DOCS_CONFIG = join(repoRoot, 'vite.docs.config.ts');
 
+/** The hub page. Refused as a topic-page target -- see the header. */
+const HUB_PAGE = '/cli-reference';
+
 /**
- * Command -> the navigation path of the page that documents it.
+ * Command -> the navigation path of ITS OWN reference page.
  *
  * The path is the site path as written in `vite.docs.config.ts` (`/cli-gc`),
- * which maps to `docs/<path>.md`.
+ * which maps to `docs/<path>.md`. Each page's H1 must be `# cdkd <command>`.
  */
-const COMMAND_PAGES: Readonly<Record<string, string>> = {
+const COMMAND_REFERENCE_PAGES: Readonly<Record<string, string>> = {
   bootstrap: '/cli-bootstrap',
-  deploy: '/cli-deploy',
-  destroy: '/cli-destroy',
   diff: '/cli-diff',
   drift: '/cli-drift',
   events: '/cli-events',
   export: '/cli-export',
   'force-unlock': '/cli-force-unlock',
   gc: '/cli-gc',
-  import: '/import',
-  list: '/cli-reference',
-  local: '/local-emulation',
-  orphan: '/orphan-vs-destroy',
   'publish-assets': '/cli-publish-assets',
   rollback: '/cli-rollback',
   scrub: '/cli-scrub',
   state: '/cli-state',
-  synth: '/cli-reference',
 };
 
 /**
- * Commands deliberately shipped with no documentation page, each with the
- * reason. An entry here is a decision on the record, not a free pass -- adding
- * one should be as visible in review as adding a command.
+ * Command -> a page covering a broader topic that documents the command inside
+ * it, with the reason its material is not on a page of its own.
+ */
+const COMMAND_TOPIC_PAGES: Readonly<Record<string, { path: string; reason: string }>> = {
+  deploy: {
+    path: '/cli-deploy',
+    reason:
+      'Split across three pages by flag family (waits and concurrency, tuning, ' +
+      'safety and compatibility); this is the first of them.',
+  },
+  destroy: {
+    path: '/cli-destroy',
+    reason:
+      'Titled after its subject rather than the command, because the page is about ' +
+      'the data guards and confirmation prompts rather than a flag list.',
+  },
+  import: {
+    path: '/import',
+    reason:
+      'Documented as a task guide -- the import modes and the CloudFormation ' +
+      'migration flow -- rather than as a flag reference.',
+  },
+  orphan: {
+    path: '/orphan-vs-destroy',
+    reason:
+      'Only meaningful next to `cdkd destroy`, so the two are documented together ' +
+      'on one comparison page.',
+  },
+  local: {
+    path: '/local-emulation',
+    reason:
+      'An overview for the command family, with one page per subcommand beneath ' +
+      'it in the Local Execution navigation group.',
+  },
+};
+
+/**
+ * Commands shipped with no documentation page, each with the reason. An entry
+ * here is a decision on the record, not a free pass -- adding one should be as
+ * visible in review as adding a command.
  */
 const UNDOCUMENTED: Readonly<Record<string, string>> = {
+  list: 'No page and no section anywhere; not even its `ls` alias. Tracked by go-to-k/cdkd#2577.',
+  synth:
+    'No page. The CLI Reference explains its stdout behaviour on a multi-stack app ' +
+    'but documents none of its flags. Tracked by go-to-k/cdkd#2577.',
   migrate:
     'Held pending the deprecation decision in go-to-k/cdkd#2572 -- it is the only ' +
     'command that requires the AWS CDK CLI binary, so whether it stays at all is ' +
@@ -86,41 +137,58 @@ const UNDOCUMENTED: Readonly<Record<string, string>> = {
 };
 
 /**
- * Commander adds `help` to the tree itself; it is not a cdkd command and has
- * no page to expect.
- */
-const BUILT_IN = new Set(['help']);
-
-/**
  * Floors, so a parse that has gone blind cannot report green having compared
- * nothing. "The tree yielded no commands" and "every command is documented"
- * are the same pass without these. Both sit a few entries below the measured
- * counts (19 commands, 48 nav paths) so an ordinary removal does not force a
- * test edit, while a total parse failure cannot clear them.
+ * nothing. "The tree yielded no commands" and "every command is documented" are
+ * the same pass without these. Both sit below the measured counts (19 commands,
+ * 50 navigation paths) with enough slack that an ordinary removal does not
+ * force a test edit, while a total parse failure cannot clear them.
  */
 const MIN_COMMANDS = 15;
 const MIN_NAV_PATHS = 30;
 
-/** Top-level command names, aliases excluded (they resolve to the same page). */
+/** The minimum length of a recorded reason, in either structure that takes one. */
+const MIN_REASON_LENGTH = 20;
+
+/**
+ * Every top-level command name, aliases excluded (an alias resolves to the same
+ * page as the name it aliases).
+ *
+ * Deliberately unfiltered otherwise. Commander's built-in `help` is NOT in this
+ * tree -- it is created lazily and never added to `.commands` (measured) -- and
+ * cdkd hides no top-level command today. If either changes, this fence demands
+ * an entry for the newcomer, which is the right outcome: hiding a command from
+ * `--help` is a decision about discoverability, and whether it also gets a page
+ * is a decision worth making explicitly rather than by omission.
+ */
 function topLevelCommandNames(): string[] {
-  return buildProgram()
-    .commands.map((c) => c.name())
-    .filter((n) => !BUILT_IN.has(n));
+  return buildProgram().commands.map((c) => c.name());
 }
 
-/** Every `path: '/x'` entry in the hand-authored site navigation. */
+/**
+ * Every `path: '/x'` entry inside the hand-authored `navigation` array.
+ *
+ * Scoped to that array, with comment lines dropped first: a whole-file scan
+ * would accept a `path:` in an example or a commented-out entry, reporting a
+ * page as reachable that the built site does not link to. The path pattern is
+ * deliberately permissive (`[^']+`) so a future nested path is READ and then
+ * judged by the existence check, rather than skipped and then reported as
+ * missing from the navigation -- a true failure with a misleading reason.
+ */
 function navPaths(): Set<string> {
   const source = readFileSync(DOCS_CONFIG, 'utf8');
-  const paths = [...source.matchAll(/path:\s*'(\/[a-z0-9-]+)'/g)].map((m) => m[1] as string);
+  const block = /const navigation\b[^=]*=\s*\[([\s\S]*?)\n\];/.exec(source);
   expect(
-    paths.length,
-    `${DOCS_CONFIG}: extracted ${paths.length} navigation paths, below the floor of ` +
-      `${MIN_NAV_PATHS}. Either the navigation genuinely shrank (lower the floor ` +
-      `deliberately) or this extractor stopped seeing its input -- an empty set makes ` +
-      `every "is this path in the nav" assertion below vacuously false and the ` +
-      `mapping assertions vacuously true.`
-  ).toBeGreaterThanOrEqual(MIN_NAV_PATHS);
-  return new Set(paths);
+    block,
+    `${DOCS_CONFIG}: could not find the \`const navigation = [ ... ];\` array. The ` +
+      `declaration was renamed or reformatted; update this extractor rather than ` +
+      `letting it fall back to scanning the whole file.`
+  ).not.toBeNull();
+  const body = (block as RegExpExecArray)[1] as string;
+  const uncommented = body
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+  return new Set([...uncommented.matchAll(/path:\s*'([^']+)'/g)].map((m) => m[1] as string));
 }
 
 /** `/cli-gc` -> `docs/cli-gc.md`. */
@@ -128,8 +196,17 @@ function docFileFor(navPath: string): string {
   return join(repoRoot, 'docs', `${navPath.slice(1)}.md`);
 }
 
+/** The page's first `# ` heading, or `null` when it has none. */
+function h1Of(file: string): string | null {
+  const m = /^# (.+)$/m.exec(readFileSync(file, 'utf8'));
+  return m ? (m[1] as string).trim() : null;
+}
+
 const commands = topLevelCommandNames();
-const nav = navPaths();
+const allMapped: Readonly<Record<string, string>> = {
+  ...COMMAND_REFERENCE_PAGES,
+  ...Object.fromEntries(Object.entries(COMMAND_TOPIC_PAGES).map(([k, v]) => [k, v.path])),
+};
 
 describe('docs command/nav coverage', () => {
   it('reads a plausible command tree', () => {
@@ -141,56 +218,109 @@ describe('docs command/nav coverage', () => {
     ).toBeGreaterThanOrEqual(MIN_COMMANDS);
   });
 
+  it('reads a plausible navigation', () => {
+    expect(
+      navPaths().size,
+      `${DOCS_CONFIG}: extracted fewer than ${MIN_NAV_PATHS} navigation paths. Either the ` +
+        `navigation genuinely shrank (lower the floor deliberately) or this extractor ` +
+        `stopped seeing its input -- an empty set makes every "is this path in the ` +
+        `navigation" assertion below fail for the wrong reason.`
+    ).toBeGreaterThanOrEqual(MIN_NAV_PATHS);
+  });
+
   it('accounts for every registered top-level command', () => {
-    const unaccounted = commands.filter(
-      (name) => !(name in COMMAND_PAGES) && !(name in UNDOCUMENTED)
-    );
+    const unaccounted = commands.filter((name) => !(name in allMapped) && !(name in UNDOCUMENTED));
     expect(
       unaccounted,
-      `These commands are registered in src/cli/program.ts but appear in neither ` +
-        `COMMAND_PAGES nor UNDOCUMENTED. Add the navigation path of the page that ` +
-        `documents each one, or add it to UNDOCUMENTED with the reason -- a command ` +
-        `with no documentation is a decision, and this is where it gets recorded.`
+      `These commands are registered in src/cli/program.ts but appear in none of ` +
+        `COMMAND_REFERENCE_PAGES, COMMAND_TOPIC_PAGES or UNDOCUMENTED. Point each one at ` +
+        `the page that documents it, or record it as undocumented with the reason -- a ` +
+        `command with no documentation is a decision, and this is where it gets recorded.`
     ).toEqual([]);
   });
 
-  it('never lists a command in both maps', () => {
-    const both = Object.keys(COMMAND_PAGES).filter((name) => name in UNDOCUMENTED);
+  it('claims each command exactly once', () => {
+    const counts = new Map<string, number>();
+    for (const name of [
+      ...Object.keys(COMMAND_REFERENCE_PAGES),
+      ...Object.keys(COMMAND_TOPIC_PAGES),
+      ...Object.keys(UNDOCUMENTED),
+    ]) {
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+    const duplicated = [...counts.entries()]
+      .filter(([, n]) => n > 1)
+      .map(([name]) => name)
+      .sort();
     expect(
-      both,
-      `A command cannot be both documented and deliberately undocumented. Remove ` +
-        `the stale entry.`
+      duplicated,
+      `A command belongs to exactly one of the three structures. Remove the stale entry ` +
+        `-- a command listed twice is one whose weaker claim is never checked.`
     ).toEqual([]);
   });
 
-  it('keeps both maps free of commands that no longer exist', () => {
+  it('keeps every structure free of commands that no longer exist', () => {
     const registered = new Set(commands);
-    const stale = [...Object.keys(COMMAND_PAGES), ...Object.keys(UNDOCUMENTED)]
+    const stale = [
+      ...Object.keys(COMMAND_REFERENCE_PAGES),
+      ...Object.keys(COMMAND_TOPIC_PAGES),
+      ...Object.keys(UNDOCUMENTED),
+    ]
       .filter((name) => !registered.has(name))
       .sort();
     expect(
       stale,
-      `These names are mapped here but are no longer registered commands. A removed ` +
-        `command must not leave an entry behind: the reverse direction is what stops ` +
-        `this file drifting into a record of what cdkd used to ship.`
+      `These names are listed here but are no longer registered commands. A removed ` +
+        `command must not leave an entry behind: the reverse direction is what stops this ` +
+        `file drifting into a record of what cdkd used to ship.`
     ).toEqual([]);
   });
 
   it('points every mapped command at a page the navigation lists', () => {
-    const missing = Object.entries(COMMAND_PAGES)
+    const nav = navPaths();
+    const missing = Object.entries(allMapped)
       .filter(([, navPath]) => !nav.has(navPath))
       .map(([name, navPath]) => `${name} -> ${navPath}`)
       .sort();
     expect(
       missing,
-      `These pages are claimed as a command's documentation but have no entry in ` +
-        `vite.docs.config.ts, so a reader browsing the site cannot reach them.`
+      `These pages are claimed as a command's documentation but have no entry in the ` +
+        `navigation array in vite.docs.config.ts, so a reader browsing the site cannot ` +
+        `reach them.`
     ).toEqual([]);
   });
 
-  it('points every mapped command at a page that exists and names it', () => {
+  it('titles every reference page after the command it documents', () => {
     const problems: string[] = [];
-    for (const [name, navPath] of Object.entries(COMMAND_PAGES)) {
+    for (const [name, navPath] of Object.entries(COMMAND_REFERENCE_PAGES)) {
+      const file = docFileFor(navPath);
+      if (!existsSync(file)) {
+        problems.push(`${name} -> ${navPath}: docs/${navPath.slice(1)}.md does not exist`);
+        continue;
+      }
+      const h1 = h1Of(file);
+      if (h1 !== `cdkd ${name}`) {
+        problems.push(`${name} -> ${navPath}: H1 is ${JSON.stringify(h1)}, want "cdkd ${name}"`);
+      }
+    }
+    expect(
+      problems.sort(),
+      `A COMMAND_REFERENCE_PAGES entry claims the page IS that command's reference, so its ` +
+        `H1 must be the command. A page that merely mentions the command belongs in ` +
+        `COMMAND_TOPIC_PAGES instead, where the weaker claim is recorded as such.`
+    ).toEqual([]);
+  });
+
+  it('names the command on every topic page, and never routes one to the hub', () => {
+    const problems: string[] = [];
+    for (const [name, { path: navPath, reason }] of Object.entries(COMMAND_TOPIC_PAGES)) {
+      if (navPath === HUB_PAGE) {
+        problems.push(`${name} -> ${navPath}: the hub names every command, so it proves nothing`);
+        continue;
+      }
+      if (reason.trim().length < MIN_REASON_LENGTH) {
+        problems.push(`${name} -> ${navPath}: no reason recorded for the absence of its own page`);
+      }
       const file = docFileFor(navPath);
       if (!existsSync(file)) {
         problems.push(`${name} -> ${navPath}: docs/${navPath.slice(1)}.md does not exist`);
@@ -202,22 +332,22 @@ describe('docs command/nav coverage', () => {
     }
     expect(
       problems.sort(),
-      `A mapping is a claim that the page documents the command. These pages do not ` +
-        `back the claim -- point the command at the page that actually covers it, or ` +
-        `move it to UNDOCUMENTED.`
+      `A COMMAND_TOPIC_PAGES entry claims a broader page documents the command. The page ` +
+        `must name it, and must not be the CLI Reference hub -- the hub names every ` +
+        `command, so mapping one to it passes for free.`
     ).toEqual([]);
   });
 
   it('gives every undocumented command a reason', () => {
     const empty = Object.entries(UNDOCUMENTED)
-      .filter(([, reason]) => reason.trim().length < 20)
+      .filter(([, reason]) => reason.trim().length < MIN_REASON_LENGTH)
       .map(([name]) => name)
       .sort();
     expect(
       empty,
-      `An entry in UNDOCUMENTED records a decision, so it needs the reason the ` +
-        `command ships without a page. A bare name is an omission wearing an ` +
-        `exclusion list's clothes.`
+      `An entry in UNDOCUMENTED records a decision, so it needs the reason the command ` +
+        `ships without a page. A bare name is an omission wearing an exclusion list's ` +
+        `clothes.`
     ).toEqual([]);
   });
 });

--- a/tests/unit/scripts/docs-command-nav-coverage.test.ts
+++ b/tests/unit/scripts/docs-command-nav-coverage.test.ts
@@ -37,13 +37,13 @@ import { buildProgram } from '../../../src/cli/program.js';
  *     Checked by H1 IDENTITY (`# cdkd <command>`) rather than by a mention, so
  *     the mapping cannot drift onto a page that merely name-drops the command.
  *   - `COMMAND_TOPIC_PAGES` -- the command is documented inside a page covering
- *     a broader topic, with the reason recorded. Checked by mention, which is
- *     weaker; the hub page is REFUSED as a target for it (see below).
+ *     a broader topic, with the reason recorded. Checked by the page's own
+ *     FRONTMATTER naming the command, plus a structural refusal of the hub.
  *   - `UNDOCUMENTED` -- shipped with no documentation, with the reason recorded.
  *
  * HOW A TOPIC CLAIM IS CHECKED, AND WHY NOT BY A BODY MENTION. A body mention
- * decides nothing here. Measured over the 50 navigation-listed pages:
- * `cdkd deploy` is named in the body of 38 of them, `destroy` 29, `local` 16,
+ * decides nothing here. Measured over the 50 navigation-listed pages,
+ * whole-file: `cdkd deploy` is named on 38 of them, `destroy` 29, `local` 16,
  * `import` 13, `orphan` 7 -- `/getting-started` and `/troubleshooting` alone
  * would satisfy a mention check for every topic mapping, so any of the five
  * could be repointed at either and stay green. That is exactly the regression
@@ -53,11 +53,19 @@ import { buildProgram } from '../../../src/cli/program.js';
  * one destination out of dozens, and the claim was the more serious error.
  *
  * The evidence is the page's FRONTMATTER instead: its own `title` or
- * `description` must name `cdkd <command>`. That is the page declaring the
- * command to be part of its subject rather than something it happens to
- * mention, and it discriminates -- measured, all five topic pages name their
- * command there, while `/getting-started`, `/troubleshooting` and the hub name
- * none at all.
+ * `description` must name `cdkd <command>`, matched at a word boundary so an
+ * inflected verb does not qualify (`How cdkd deploys CDK apps` contains the
+ * substring `cdkd deploy`, and Core Concepts is written exactly that way). That
+ * is the page declaring the command to be part of its subject rather than
+ * something it happens to mention, and it discriminates -- measured across the
+ * 50 pages, frontmatter versus whole-file: `deploy` 4 against 38, `destroy` 2
+ * against 29, `local` 9 against 16, `import` 1 against 13, `orphan` 1 against 7.
+ *
+ * The hub is ALSO refused structurally, not left to the frontmatter rule. Its
+ * description names no command today, so the rule happens to reject it -- but
+ * that is a fact about current wording, and a hub description listing the
+ * commands it indexes would re-qualify it. The refusal is the invariant; the
+ * frontmatter rule is what generalises it to the other forty-nine pages.
  *
  * WHAT THIS DOES NOT PROVE:
  *
@@ -65,6 +73,11 @@ import { buildProgram } from '../../../src/cli/program.js';
  *     proves a page is titled after the command; the frontmatter check proves a
  *     topic page declares the command part of its subject. Neither grades the
  *     prose, and neither can tell a thorough page from a stub.
+ *   - That a topic mapping points at the BEST page for the command. `local`
+ *     has eight sibling subcommand pages whose frontmatter also names
+ *     `cdkd local`, so the overview could be swapped for one of them and stay
+ *     green. They do document the command family, so this is a worse-page
+ *     risk rather than a no-page one -- the class this fence is for.
  *   - Anything about SUBCOMMANDS. `cdkd state *`, `cdkd local *` and
  *     `cdkd events prune` are out of scope, so one of those can still ship
  *     undocumented -- the same class as the `migrate` incident, one level down.
@@ -72,6 +85,9 @@ import { buildProgram } from '../../../src/cli/program.js';
  */
 const repoRoot = join(import.meta.dirname, '..', '..', '..');
 const DOCS_CONFIG = join(repoRoot, 'vite.docs.config.ts');
+
+/** The hub. Refused as a topic-page target regardless of its wording. */
+const HUB_PAGE = '/cli-reference';
 
 /**
  * Command -> the navigation path of ITS OWN reference page.
@@ -185,7 +201,11 @@ function topLevelCommandNames(): string[] {
  * scan would accept a `path:` in an example, and an unstripped one would accept
  * a commented-out entry -- either way reporting a page as reachable that the
  * built site does not link to. Line comments were the spelling a review caught;
- * block comments are the same defect one spelling over. The path pattern is
+ * block comments are the same defect one spelling over. Line comments are
+ * dropped FIRST, because a `/*` written inside one would otherwise open a
+ * spurious block and swallow the real entries after it (this file already
+ * contains a line comment carrying a `/*`, just outside the array). The path
+ * pattern is
  * deliberately permissive (`[^']+`) so a future nested path is READ and then
  * judged by the existence check, rather than skipped and then reported as
  * missing from the navigation -- a true failure with a misleading reason.
@@ -201,16 +221,28 @@ function navPaths(): Set<string> {
   ).not.toBeNull();
   const body = (block as RegExpExecArray)[1] as string;
   const uncommented = body
-    .replace(/\/\*[\s\S]*?\*\//g, '')
     .split('\n')
     .filter((line) => !line.trimStart().startsWith('//'))
-    .join('\n');
+    .join('\n')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
   return new Set([...uncommented.matchAll(/path:\s*'([^']+)'/g)].map((m) => m[1] as string));
 }
 
 /** `/cli-gc` -> `docs/cli-gc.md`. */
 function docFileFor(navPath: string): string {
   return join(repoRoot, 'docs', `${navPath.slice(1)}.md`);
+}
+
+/**
+ * Does this text name the command, at a word boundary?
+ *
+ * The boundary is load-bearing: `docs/concepts.md`'s description reads "How
+ * cdkd deploys CDK apps", which CONTAINS the substring `cdkd deploy` -- so a
+ * plain `includes` would let the `deploy` mapping be repointed at Core Concepts
+ * and stay green.
+ */
+function namesCommand(text: string, command: string): boolean {
+  return new RegExp(`cdkd ${command}\\b`).test(text);
 }
 
 /** The page's frontmatter block, or `null` when it has none. */
@@ -337,6 +369,10 @@ describe('docs command/nav coverage', () => {
   it('declares the command in the frontmatter of every topic page', () => {
     const problems: string[] = [];
     for (const [name, { path: navPath, reason }] of Object.entries(COMMAND_TOPIC_PAGES)) {
+      if (navPath === HUB_PAGE) {
+        problems.push(`${name} -> ${navPath}: the hub indexes every command, so it is never the page that documents one`);
+        continue;
+      }
       if (reason.trim().length < MIN_REASON_LENGTH) {
         problems.push(`${name} -> ${navPath}: no reason recorded for the absence of its own page`);
       }
@@ -350,7 +386,7 @@ describe('docs command/nav coverage', () => {
         problems.push(`${name} -> ${navPath}: page has no frontmatter block`);
         continue;
       }
-      if (!fm.includes(`cdkd ${name}`)) {
+      if (!namesCommand(fm, name)) {
         problems.push(`${name} -> ${navPath}: frontmatter never names \`cdkd ${name}\``);
       }
     }
@@ -358,8 +394,8 @@ describe('docs command/nav coverage', () => {
       problems.sort(),
       `A COMMAND_TOPIC_PAGES entry claims a broader page documents the command, and the ` +
         `page's own title or description must say so. A body mention is not evidence: ` +
-        `\`cdkd deploy\` is named in the body of 38 of the 50 navigation-listed pages, so ` +
-        `a mapping repointed at Getting Started or Troubleshooting would pass on one.`
+        `\`cdkd deploy\` is named on 38 of the 50 navigation-listed pages, so a mapping ` +
+        `repointed at Getting Started or Troubleshooting would pass on one.`
     ).toEqual([]);
   });
 

--- a/tests/unit/scripts/docs-command-nav-coverage.test.ts
+++ b/tests/unit/scripts/docs-command-nav-coverage.test.ts
@@ -21,12 +21,14 @@ import { buildProgram } from '../../../src/cli/program.js';
  *     pages that exist. It cannot see a page that was never written.
  *
  * WHY THREE STRUCTURES RATHER THAN A `cli-<command>.md` CONVENTION. Measured on
- * the tree this file was written against: eight of the nineteen commands have
- * no `cli-<command>` page, and they are not all the same case. Five are
- * genuinely documented under a differently-named page the navigation lists;
- * three are not documented at all. A bare naming-convention assertion would
- * have put all eight in one exclusion list and lost that distinction -- which
- * is the whole finding.
+ * the tree this file was written against: six of the nineteen commands have no
+ * `cli-<command>.md` at all (`synth`, `list`, `orphan`, `import`, `local`,
+ * `migrate`), and two more have one whose H1 is a topic rather than the command
+ * (`# Deploy: waits & concurrency`, `# Destroy flags & guards`). Those eight are
+ * not one case: three of the six ARE documented, on a page named for the topic
+ * it covers, and three are not documented at all. A single naming convention
+ * collapses all eight into one exclusion list and loses that distinction --
+ * which is the whole finding.
  *
  * So a command is claimed in one of three ways, each CHECKED differently, and
  * the strength of the check follows the strength of the claim:
@@ -39,19 +41,30 @@ import { buildProgram } from '../../../src/cli/program.js';
  *     weaker; the hub page is REFUSED as a target for it (see below).
  *   - `UNDOCUMENTED` -- shipped with no documentation, with the reason recorded.
  *
- * WHY THE HUB IS REFUSED AS A MAPPING TARGET. `docs/cli-reference.md` names
- * every command at least once, so mapping a command to it passes a mention
- * check for free. Measured while reviewing this file: sixteen mappings stayed
- * green when repointed at the hub, which is exactly the regression a fence like
- * this is for -- a dedicated page deleted and its mapping quietly moved to the
- * hub. Refusing the hub outright removes the class rather than tightening a
- * substring test against it.
+ * HOW A TOPIC CLAIM IS CHECKED, AND WHY NOT BY A BODY MENTION. A body mention
+ * decides nothing here. Measured over the 50 navigation-listed pages:
+ * `cdkd deploy` is named in the body of 38 of them, `destroy` 29, `local` 16,
+ * `import` 13, `orphan` 7 -- `/getting-started` and `/troubleshooting` alone
+ * would satisfy a mention check for every topic mapping, so any of the five
+ * could be repointed at either and stay green. That is exactly the regression
+ * this fence is for: a dedicated page deleted and its mapping quietly moved
+ * somewhere the command merely gets discussed. An earlier revision refused the
+ * CLI Reference hub as a target and claimed that removed the class; it removed
+ * one destination out of dozens, and the claim was the more serious error.
+ *
+ * The evidence is the page's FRONTMATTER instead: its own `title` or
+ * `description` must name `cdkd <command>`. That is the page declaring the
+ * command to be part of its subject rather than something it happens to
+ * mention, and it discriminates -- measured, all five topic pages name their
+ * command there, while `/getting-started`, `/troubleshooting` and the hub name
+ * none at all.
  *
  * WHAT THIS DOES NOT PROVE:
  *
  *   - That a page documents a command WELL, or covers its flags. The H1 check
- *     proves a page is titled after the command; the mention check proves a
- *     topic page names it somewhere. Neither grades the prose.
+ *     proves a page is titled after the command; the frontmatter check proves a
+ *     topic page declares the command part of its subject. Neither grades the
+ *     prose, and neither can tell a thorough page from a stub.
  *   - Anything about SUBCOMMANDS. `cdkd state *`, `cdkd local *` and
  *     `cdkd events prune` are out of scope, so one of those can still ship
  *     undocumented -- the same class as the `migrate` incident, one level down.
@@ -59,9 +72,6 @@ import { buildProgram } from '../../../src/cli/program.js';
  */
 const repoRoot = join(import.meta.dirname, '..', '..', '..');
 const DOCS_CONFIG = join(repoRoot, 'vite.docs.config.ts');
-
-/** The hub page. Refused as a topic-page target -- see the header. */
-const HUB_PAGE = '/cli-reference';
 
 /**
  * Command -> the navigation path of ITS OWN reference page.
@@ -126,10 +136,14 @@ const COMMAND_TOPIC_PAGES: Readonly<Record<string, { path: string; reason: strin
  * visible in review as adding a command.
  */
 const UNDOCUMENTED: Readonly<Record<string, string>> = {
-  list: 'No page and no section anywhere; not even its `ls` alias. Tracked by go-to-k/cdkd#2577.',
+  list:
+    'No page of its own. What exists is spread through the CLI Reference cross-command ' +
+    'sections -- its output in each mode, worked examples, and `--long` / ' +
+    '`--show-dependencies` -- plus the `ls` alias named on the state page. Tracked by ' +
+    'go-to-k/cdkd#2577.',
   synth:
-    'No page. The CLI Reference explains its stdout behaviour on a multi-stack app ' +
-    'but documents none of its flags. Tracked by go-to-k/cdkd#2577.',
+    'No page of its own. The CLI Reference explains its stdout contract on a multi-stack ' +
+    'app; none of its flags are documented anywhere. Tracked by go-to-k/cdkd#2577.',
   migrate:
     'Held pending the deprecation decision in go-to-k/cdkd#2572 -- it is the only ' +
     'command that requires the AWS CDK CLI binary, so whether it stays at all is ' +
@@ -167,9 +181,11 @@ function topLevelCommandNames(): string[] {
 /**
  * Every `path: '/x'` entry inside the hand-authored `navigation` array.
  *
- * Scoped to that array, with comment lines dropped first: a whole-file scan
- * would accept a `path:` in an example or a commented-out entry, reporting a
- * page as reachable that the built site does not link to. The path pattern is
+ * Scoped to that array, with both comment forms stripped first: a whole-file
+ * scan would accept a `path:` in an example, and an unstripped one would accept
+ * a commented-out entry -- either way reporting a page as reachable that the
+ * built site does not link to. Line comments were the spelling a review caught;
+ * block comments are the same defect one spelling over. The path pattern is
  * deliberately permissive (`[^']+`) so a future nested path is READ and then
  * judged by the existence check, rather than skipped and then reported as
  * missing from the navigation -- a true failure with a misleading reason.
@@ -185,6 +201,7 @@ function navPaths(): Set<string> {
   ).not.toBeNull();
   const body = (block as RegExpExecArray)[1] as string;
   const uncommented = body
+    .replace(/\/\*[\s\S]*?\*\//g, '')
     .split('\n')
     .filter((line) => !line.trimStart().startsWith('//'))
     .join('\n');
@@ -194,6 +211,12 @@ function navPaths(): Set<string> {
 /** `/cli-gc` -> `docs/cli-gc.md`. */
 function docFileFor(navPath: string): string {
   return join(repoRoot, 'docs', `${navPath.slice(1)}.md`);
+}
+
+/** The page's frontmatter block, or `null` when it has none. */
+function frontmatterOf(file: string): string | null {
+  const m = /^---\n([\s\S]*?)\n---\n/.exec(readFileSync(file, 'utf8'));
+  return m ? (m[1] as string) : null;
 }
 
 /** The page's first `# ` heading, or `null` when it has none. */
@@ -311,13 +334,9 @@ describe('docs command/nav coverage', () => {
     ).toEqual([]);
   });
 
-  it('names the command on every topic page, and never routes one to the hub', () => {
+  it('declares the command in the frontmatter of every topic page', () => {
     const problems: string[] = [];
     for (const [name, { path: navPath, reason }] of Object.entries(COMMAND_TOPIC_PAGES)) {
-      if (navPath === HUB_PAGE) {
-        problems.push(`${name} -> ${navPath}: the hub names every command, so it proves nothing`);
-        continue;
-      }
       if (reason.trim().length < MIN_REASON_LENGTH) {
         problems.push(`${name} -> ${navPath}: no reason recorded for the absence of its own page`);
       }
@@ -326,15 +345,21 @@ describe('docs command/nav coverage', () => {
         problems.push(`${name} -> ${navPath}: docs/${navPath.slice(1)}.md does not exist`);
         continue;
       }
-      if (!readFileSync(file, 'utf8').includes(`cdkd ${name}`)) {
-        problems.push(`${name} -> ${navPath}: page never mentions \`cdkd ${name}\``);
+      const fm = frontmatterOf(file);
+      if (fm === null) {
+        problems.push(`${name} -> ${navPath}: page has no frontmatter block`);
+        continue;
+      }
+      if (!fm.includes(`cdkd ${name}`)) {
+        problems.push(`${name} -> ${navPath}: frontmatter never names \`cdkd ${name}\``);
       }
     }
     expect(
       problems.sort(),
-      `A COMMAND_TOPIC_PAGES entry claims a broader page documents the command. The page ` +
-        `must name it, and must not be the CLI Reference hub -- the hub names every ` +
-        `command, so mapping one to it passes for free.`
+      `A COMMAND_TOPIC_PAGES entry claims a broader page documents the command, and the ` +
+        `page's own title or description must say so. A body mention is not evidence: ` +
+        `\`cdkd deploy\` is named in the body of 38 of the 50 navigation-listed pages, so ` +
+        `a mapping repointed at Getting Started or Troubleshooting would pass on one.`
     ).toEqual([]);
   });
 

--- a/tests/unit/scripts/docs-command-nav-coverage.test.ts
+++ b/tests/unit/scripts/docs-command-nav-coverage.test.ts
@@ -77,11 +77,15 @@ import { buildProgram } from '../../../src/cli/program.js';
  *     proves a page is titled after the command; the frontmatter check proves a
  *     topic page declares the command part of its subject. Neither grades the
  *     prose, and neither can tell a thorough page from a stub.
- *   - That a topic mapping points at the BEST page for the command. `local`
- *     has sibling subcommand pages whose frontmatter also names `cdkd local`,
- *     so the overview could be swapped for one of them and stay green. They do
- *     document the command family, so this is a worse-page risk rather than a
- *     no-page one -- the class this fence is for.
+ *   - That a topic mapping points at the BEST page for the command. Several
+ *     commands have more than one page whose frontmatter names them -- `local`
+ *     its subcommand pages, `deploy` its other flag-family pages, `destroy` the
+ *     orphan comparison -- so a mapping could be swapped between them and stay
+ *     green. Those pages do document the command, so this is a worse-page risk
+ *     rather than the no-page one this fence is for.
+ *   - That an `UNDOCUMENTED` reason is still TRUE beyond the narrow check
+ *     below: nothing re-reads the pages its prose describes, so a reason can
+ *     go stale in every way except the command acquiring a page of its own.
  *   - Anything about SUBCOMMANDS. `cdkd state *`, `cdkd local *` and
  *     `cdkd events prune` are out of scope, so one of those can still ship
  *     undocumented -- the same class as the `migrate` incident, one level down.
@@ -94,8 +98,36 @@ const DOCS_CONFIG = join(repoRoot, 'vite.docs.config.ts');
 const HUB_PAGE = '/cli-reference';
 
 /**
+ * Pages linked from the hub's own index of per-command reference pages.
+ *
+ * That index is a second hand-maintained list, and nothing fenced it: this
+ * change had to add its `cdkd force-unlock` line by hand, one level over from
+ * the omission the whole fence exists to catch. Checked one way only -- every
+ * mapped `/cli-*` page must be indexed -- because the index legitimately holds
+ * pages that are not commands (`cli-deploy-tuning`, `cli-deploy-safety` are
+ * deploy's other flag families).
+ */
+function hubIndexedPages(): Set<string> {
+  const file = docFileFor(HUB_PAGE);
+  const text = readFileSync(file, 'utf8');
+  const start = text.indexOf(HUB_INDEX_HEADING);
+  expect(
+    start,
+    `${file}: could not find the "${HUB_INDEX_HEADING}" section. It was renamed or ` +
+      `removed; update this extractor rather than letting it silently index nothing.`
+  ).toBeGreaterThanOrEqual(0);
+  const rest = text.slice(start + HUB_INDEX_HEADING.length);
+  const end = rest.indexOf('\n## ');
+  const section = end === -1 ? rest : rest.slice(0, end);
+  return new Set([...section.matchAll(/\]\((cli-[a-z0-9-]+)\.md\)/g)].map((m) => `/${m[1]}`));
+}
+
+/**
  * Pages that discuss commands at length without being any one command's
- * documentation. None of them may qualify as a topic page for any command.
+ * documentation. None of them may qualify as a topic page for any command that
+ * HAS a topic mapping -- the check iterates `COMMAND_TOPIC_PAGES`, deliberately
+ * not the reference commands, whose stronger H1 claim these pages cannot meet
+ * anyway.
  *
  * This is the discrimination claim as an assertion. Body mentions cannot tell
  * these apart from a real topic page, so what makes the frontmatter rule worth
@@ -212,6 +244,24 @@ const UNDOCUMENTED: Readonly<Record<string, string>> = {
 const MIN_COMMANDS = 15;
 const MIN_NAV_PATHS = 30;
 
+/**
+ * Floors on the two CHECKED structures, and on the decoy list.
+ *
+ * Without them a command can be moved from a checked structure into
+ * `UNDOCUMENTED` with a plausible reason, and the assertions that would have
+ * inspected its page stop having anything to inspect while every test stays
+ * green -- the same collapse the parser floors guard, reached by editing the
+ * data instead of breaking the parse. `NON_DOCUMENTING_PAGES` needs one for the
+ * same reason: emptied, its loop runs zero times and the discrimination claim
+ * the header rests on becomes silently unasserted.
+ */
+const MIN_REFERENCE_PAGES = 8;
+const MIN_TOPIC_PAGES = 3;
+const MIN_NON_DOCUMENTING_PAGES = 4;
+
+/** The hub section that indexes the per-command reference pages. */
+const HUB_INDEX_HEADING = '## CLI reference pages';
+
 /** The minimum length of a recorded reason, in either structure that takes one. */
 const MIN_REASON_LENGTH = 20;
 
@@ -236,7 +286,10 @@ function topLevelCommandNames(): string[] {
  * Scoped to that array, with both comment forms stripped first: a whole-file
  * scan would accept a `path:` in an example, and an unstripped one would accept
  * a commented-out entry -- either way reporting a page as reachable that the
- * built site does not link to. Line comments were the spelling a review caught;
+ * built site does not link to. TRAILING comments are stripped as well as
+ * whole-line ones: `{ ..., path: '/x' }, // was path: '/old'` would otherwise
+ * put `/old` into the set and let a stale mapping pass. The `[^:]` guard keeps
+ * a `://` in a future URL from being read as the start of one. Line comments were the spelling a review caught;
  * block comments are the same defect one spelling over. Line comments are
  * dropped FIRST, because a `/*` written inside one would otherwise open a
  * spurious block and swallow the real entries after it. The captured region
@@ -248,6 +301,11 @@ function topLevelCommandNames(): string[] {
  * as missing from the navigation -- a true failure with a misleading reason.
  */
 function navPaths(): Set<string> {
+  expect(
+    existsSync(DOCS_CONFIG),
+    `${DOCS_CONFIG} does not exist. The site config was renamed or moved; point this ` +
+      `extractor at it rather than letting readFileSync raise a bare ENOENT.`
+  ).toBe(true);
   const source = readFileSync(DOCS_CONFIG, 'utf8');
   const block = /const navigation\b[^=]*=\s*\[([\s\S]*?)\n\];/.exec(source);
   expect(
@@ -261,6 +319,7 @@ function navPaths(): Set<string> {
     .split('\n')
     .filter((line) => !line.trimStart().startsWith('//'))
     .join('\n')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1')
     .replace(/\/\*[\s\S]*?\*\//g, '');
   return new Set([...uncommented.matchAll(/path:\s*'([^']+)'/g)].map((m) => m[1] as string));
 }
@@ -279,7 +338,8 @@ function docFileFor(navPath: string): string {
  * and stay green.
  */
 function namesCommand(text: string, command: string): boolean {
-  return new RegExp(`cdkd ${command}\\b`).test(text);
+  const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`cdkd ${escaped}\\b`).test(text);
 }
 
 /** The page's frontmatter block, or `null` when it has none. */
@@ -288,9 +348,17 @@ function frontmatterOf(file: string): string | null {
   return m ? (m[1] as string) : null;
 }
 
-/** The page's first `# ` heading, or `null` when it has none. */
+/**
+ * The page's first `# ` heading, or `null` when it has none.
+ *
+ * Fenced blocks are removed first: a shell example's `# comment` is not a
+ * heading, and `docs/cli-reference.md` already contains one (`# or`, inside a
+ * bash fence). It is harmless there -- the real H1 comes earlier -- but a page
+ * whose fence preceded its H1 would be read wrong.
+ */
 function h1Of(file: string): string | null {
-  const m = /^# (.+)$/m.exec(readFileSync(file, 'utf8'));
+  const body = readFileSync(file, 'utf8').replace(/^```[\s\S]*?^```/gm, '');
+  const m = /^# (.+)$/m.exec(body);
   return m ? (m[1] as string).trim() : null;
 }
 
@@ -318,6 +386,54 @@ describe('docs command/nav coverage', () => {
         `stopped seeing its input -- an empty set makes every "is this path in the ` +
         `navigation" assertion below fail for the wrong reason.`
     ).toBeGreaterThanOrEqual(MIN_NAV_PATHS);
+  });
+
+  it('keeps a plausible amount of each structure', () => {
+    expect(
+      Object.keys(COMMAND_REFERENCE_PAGES).length,
+      `COMMAND_REFERENCE_PAGES holds fewer than ${MIN_REFERENCE_PAGES} entries. Moving ` +
+        `commands out of a checked structure and into UNDOCUMENTED is how this fence ` +
+        `goes quiet without any test failing.`
+    ).toBeGreaterThanOrEqual(MIN_REFERENCE_PAGES);
+    expect(
+      Object.keys(COMMAND_TOPIC_PAGES).length,
+      `COMMAND_TOPIC_PAGES holds fewer than ${MIN_TOPIC_PAGES} entries. Same collapse as ` +
+        `above, reached through the other checked structure.`
+    ).toBeGreaterThanOrEqual(MIN_TOPIC_PAGES);
+    expect(
+      NON_DOCUMENTING_PAGES.length,
+      `NON_DOCUMENTING_PAGES holds fewer than ${MIN_NON_DOCUMENTING_PAGES} entries. Its ` +
+        `loop is what turns "the frontmatter rule discriminates" into an assertion; ` +
+        `emptied, that claim is prose again.`
+    ).toBeGreaterThanOrEqual(MIN_NON_DOCUMENTING_PAGES);
+  });
+
+  it('rejects an inflected verb as a frontmatter mention', () => {
+    // Pinned here rather than only through `docs/concepts.md`, whose description
+    // is the tree's one witness for the boundary: rewording that page would
+    // leave the load-bearing arm of `namesCommand` unfalsifiable.
+    expect(namesCommand('How cdkd deploys CDK apps without CloudFormation', 'deploy')).toBe(false);
+    expect(namesCommand('Deploy-time flags for cdkd deploy.', 'deploy')).toBe(true);
+    expect(namesCommand('cdkd force-unlock clears a stale lock', 'force-unlock')).toBe(true);
+  });
+
+  it('indexes every mapped reference page from the hub', () => {
+    const indexed = hubIndexedPages();
+    expect(
+      indexed.size,
+      `${docFileFor(HUB_PAGE)}: the "${HUB_INDEX_HEADING}" section yielded fewer than ` +
+        `${MIN_REFERENCE_PAGES} links. The extractor stopped seeing its input.`
+    ).toBeGreaterThanOrEqual(MIN_REFERENCE_PAGES);
+    const missing = Object.entries(allMapped)
+      .filter(([, navPath]) => navPath.startsWith('/cli-') && !indexed.has(navPath))
+      .map(([name, navPath]) => `${name} -> ${navPath}`)
+      .sort();
+    expect(
+      missing,
+      `These pages document a command but are not linked from the hub's index of ` +
+        `per-command reference pages, so a reader who starts at the CLI Reference never ` +
+        `finds them. Add the bullet to ${HUB_INDEX_HEADING} in docs/cli-reference.md.`
+    ).toEqual([]);
   });
 
   it('accounts for every registered top-level command', () => {
@@ -466,16 +582,25 @@ describe('docs command/nav coverage', () => {
     ).toEqual([]);
   });
 
-  it('gives every undocumented command a reason', () => {
-    const empty = Object.entries(UNDOCUMENTED)
+  it('gives every undocumented command a reason, and none of them a page', () => {
+    const problems = Object.entries(UNDOCUMENTED)
       .filter(([, reason]) => reason.trim().length < MIN_REASON_LENGTH)
-      .map(([name]) => name)
-      .sort();
+      .map(([name]) => `${name}: no reason recorded`)
+      .concat(
+        // The reason says the command has no page of its own. Nothing else
+        // re-reads the prose, so at least check the one claim every entry
+        // makes: if `docs/cli-<command>.md` now exists, the entry is a lie and
+        // the command belongs in COMMAND_REFERENCE_PAGES.
+        Object.keys(UNDOCUMENTED)
+          .filter((name) => existsSync(docFileFor(`/cli-${name}`)))
+          .map((name) => `${name}: docs/cli-${name}.md now exists, so the entry is stale`)
+      );
     expect(
-      empty,
+      problems.sort(),
       `An entry in UNDOCUMENTED records a decision, so it needs the reason the command ` +
-        `ships without a page. A bare name is an omission wearing an exclusion list's ` +
-        `clothes.`
+        `ships without a page -- a bare name is an omission wearing an exclusion list's ` +
+        `clothes -- and the decision must still hold: a command that has since been ` +
+        `given docs/cli-<command>.md belongs in COMMAND_REFERENCE_PAGES.`
     ).toEqual([]);
   });
 });

--- a/tests/unit/scripts/docs-command-nav-coverage.test.ts
+++ b/tests/unit/scripts/docs-command-nav-coverage.test.ts
@@ -101,15 +101,27 @@ const HUB_PAGE = '/cli-reference';
  * This is the discrimination claim as an assertion. Body mentions cannot tell
  * these apart from a real topic page -- `cdkd deploy` is named on 38 of the 50
  * navigation-listed pages -- so what makes the frontmatter rule worth having is
- * exactly that these four are rejected by it. Core Concepts is in the list
- * because it is the near miss: its description reads "How cdkd deploys CDK
- * apps", which a substring match accepts and the word boundary rejects.
+ * exactly that these are rejected by it. Core Concepts is the near miss: its
+ * description reads "How cdkd deploys CDK apps", which a substring match
+ * accepts and the word boundary rejects. The other three each name all five
+ * topic commands in their bodies, Troubleshooting and State Management 44 times
+ * apiece.
+ *
+ * The HUB is deliberately NOT in this list, even though it is the same kind of
+ * page. It is refused structurally by the topic check, and the header says that
+ * refusal exists precisely because a hub description listing the commands it
+ * indexes WOULD otherwise re-qualify it. Listing it here would make that reword
+ * a test failure and contradict the reason the structural refusal is there.
+ *
+ * A page can leave this list -- if one of them genuinely becomes a command's
+ * documentation, moving it out and into `COMMAND_TOPIC_PAGES` is the intended
+ * resolution, not a workaround.
  */
 const NON_DOCUMENTING_PAGES: readonly string[] = [
   '/getting-started',
   '/troubleshooting',
+  '/state-management',
   '/concepts',
-  HUB_PAGE,
 ];
 
 /**
@@ -226,11 +238,13 @@ function topLevelCommandNames(): string[] {
  * built site does not link to. Line comments were the spelling a review caught;
  * block comments are the same defect one spelling over. Line comments are
  * dropped FIRST, because a `/*` written inside one would otherwise open a
- * spurious block and swallow the real entries after it -- the scanned config
- * already carries a line comment containing a `/*`, one line above the array.
- * The path pattern is deliberately permissive (`[^']+`) so a future nested path is READ and then
- * judged by the existence check, rather than skipped and then reported as
- * missing from the navigation -- a true failure with a misleading reason.
+ * spurious block and swallow the real entries after it. The captured region
+ * holds no comment of either form today, so the ordering is a guard against a
+ * shape the config does not yet have rather than one it does -- which is why
+ * the ordering is probed rather than described with a citation. The path
+ * pattern is deliberately permissive (`[^']+`) so a future nested path is READ
+ * and then judged by the existence check, rather than skipped and then reported
+ * as missing from the navigation -- a true failure with a misleading reason.
  */
 function navPaths(): Set<string> {
   const source = readFileSync(DOCS_CONFIG, 'utf8');
@@ -422,24 +436,32 @@ describe('docs command/nav coverage', () => {
   });
 
   it('rejects every page that discusses commands without documenting one', () => {
-    const qualifying: string[] = [];
+    const problems: string[] = [];
     for (const navPath of NON_DOCUMENTING_PAGES) {
       const file = docFileFor(navPath);
-      expect(existsSync(file), `${navPath}: docs/${navPath.slice(1)}.md does not exist`).toBe(true);
+      if (!existsSync(file)) {
+        problems.push(`${navPath}: docs/${navPath.slice(1)}.md does not exist`);
+        continue;
+      }
       const fm = frontmatterOf(file);
-      expect(fm, `${navPath}: page has no frontmatter block to check`).not.toBeNull();
+      if (fm === null) {
+        problems.push(`${navPath}: page has no frontmatter block to check`);
+        continue;
+      }
       for (const name of Object.keys(COMMAND_TOPIC_PAGES)) {
-        if (namesCommand(fm as string, name)) {
-          qualifying.push(`${navPath} would qualify as the topic page for ${name}`);
+        if (namesCommand(fm, name)) {
+          problems.push(`${navPath} would qualify as the topic page for ${name}`);
         }
       }
     }
     expect(
-      qualifying.sort(),
+      problems.sort(),
       `One of these pages now names a command in its frontmatter, so the topic check ` +
-        `would accept a mapping repointed at it. Either the wording drifted -- reword it, ` +
-        `or tighten the match -- or the page genuinely became that command's ` +
-        `documentation, in which case move it out of NON_DOCUMENTING_PAGES deliberately.`
+        `would accept a mapping repointed at it. Two resolutions, both fine: reword the ` +
+        `description if the mention was incidental, or -- if the page genuinely became ` +
+        `that command's documentation -- move it out of NON_DOCUMENTING_PAGES and into ` +
+        `COMMAND_TOPIC_PAGES. Collect-then-assert so one missing page does not hide the ` +
+        `rest.`
     ).toEqual([]);
   });
 

--- a/tests/unit/scripts/docs-command-nav-coverage.test.ts
+++ b/tests/unit/scripts/docs-command-nav-coverage.test.ts
@@ -20,15 +20,14 @@ import { buildProgram } from '../../../src/cli/program.js';
  *   - `tests/unit/scripts/docs-site-links.test.ts` validates links between
  *     pages that exist. It cannot see a page that was never written.
  *
- * WHY THREE STRUCTURES RATHER THAN A `cli-<command>.md` CONVENTION. Measured on
- * the tree this file was written against: six of the nineteen commands have no
- * `cli-<command>.md` at all (`synth`, `list`, `orphan`, `import`, `local`,
- * `migrate`), and two more have one whose H1 is a topic rather than the command
- * (`# Deploy: waits & concurrency`, `# Destroy flags & guards`). Those eight are
- * not one case: three of the six ARE documented, on a page named for the topic
- * it covers, and three are not documented at all. A single naming convention
- * collapses all eight into one exclusion list and loses that distinction --
- * which is the whole finding.
+ * WHY THREE STRUCTURES RATHER THAN A `cli-<command>.md` CONVENTION. Several
+ * commands have no `cli-<command>.md` at all, and several more have one whose
+ * H1 is a topic rather than the command. Those are not one case: some of the
+ * first group ARE documented, on a page named for the topic it covers, and some
+ * are not documented anywhere. A single naming convention collapses them into
+ * one exclusion list and loses that distinction -- which is the whole finding.
+ * The current membership of each group is the three structures below; they are
+ * the record, so this paragraph does not restate it.
  *
  * So a command is claimed in one of three ways, each CHECKED differently, and
  * the strength of the check follows the strength of the claim:
@@ -42,15 +41,15 @@ import { buildProgram } from '../../../src/cli/program.js';
  *   - `UNDOCUMENTED` -- shipped with no documentation, with the reason recorded.
  *
  * HOW A TOPIC CLAIM IS CHECKED, AND WHY NOT BY A BODY MENTION. A body mention
- * decides nothing here. Measured over the 50 navigation-listed pages,
- * whole-file: `cdkd deploy` is named on 38 of them, `destroy` 29, `local` 16,
- * `import` 13, `orphan` 7 -- `/getting-started` and `/troubleshooting` alone
- * would satisfy a mention check for every topic mapping, so any of the five
- * could be repointed at either and stay green. That is exactly the regression
- * this fence is for: a dedicated page deleted and its mapping quietly moved
- * somewhere the command merely gets discussed. An earlier revision refused the
- * CLI Reference hub as a target and claimed that removed the class; it removed
- * one destination out of dozens, and the claim was the more serious error.
+ * decides nothing here: a command is named in the body of most of the
+ * navigation-listed pages, `/getting-started` and `/troubleshooting` among
+ * them, and neither of those is any command's documentation. Either would
+ * satisfy a mention check for every topic mapping, so one could be repointed
+ * there and stay green -- exactly the regression this fence is for, a dedicated
+ * page deleted and its mapping quietly moved somewhere the command merely gets
+ * discussed. An earlier revision refused the CLI Reference hub as a target and
+ * claimed that removed the class; it removed one destination out of dozens, and
+ * the claim was the more serious error.
  *
  * The evidence is the page's FRONTMATTER instead: its own `title` or
  * `description` must name `cdkd <command>`, matched at a word boundary so an
@@ -70,7 +69,7 @@ import { buildProgram } from '../../../src/cli/program.js';
  * description names no command today, so the rule happens to reject it -- but
  * that is a fact about current wording, and a hub description listing the
  * commands it indexes would re-qualify it. The refusal is the invariant; the
- * frontmatter rule is what generalises it to the other forty-nine pages.
+ * frontmatter rule is what generalises it to every other page.
  *
  * WHAT THIS DOES NOT PROVE:
  *
@@ -79,10 +78,10 @@ import { buildProgram } from '../../../src/cli/program.js';
  *     topic page declares the command part of its subject. Neither grades the
  *     prose, and neither can tell a thorough page from a stub.
  *   - That a topic mapping points at the BEST page for the command. `local`
- *     has eight sibling subcommand pages whose frontmatter also names
- *     `cdkd local`, so the overview could be swapped for one of them and stay
- *     green. They do document the command family, so this is a worse-page
- *     risk rather than a no-page one -- the class this fence is for.
+ *     has sibling subcommand pages whose frontmatter also names `cdkd local`,
+ *     so the overview could be swapped for one of them and stay green. They do
+ *     document the command family, so this is a worse-page risk rather than a
+ *     no-page one -- the class this fence is for.
  *   - Anything about SUBCOMMANDS. `cdkd state *`, `cdkd local *` and
  *     `cdkd events prune` are out of scope, so one of those can still ship
  *     undocumented -- the same class as the `migrate` incident, one level down.
@@ -99,13 +98,11 @@ const HUB_PAGE = '/cli-reference';
  * documentation. None of them may qualify as a topic page for any command.
  *
  * This is the discrimination claim as an assertion. Body mentions cannot tell
- * these apart from a real topic page -- `cdkd deploy` is named on 38 of the 50
- * navigation-listed pages -- so what makes the frontmatter rule worth having is
- * exactly that these are rejected by it. Core Concepts is the near miss: its
- * description reads "How cdkd deploys CDK apps", which a substring match
- * accepts and the word boundary rejects. The other three each name all five
- * topic commands in their bodies, Troubleshooting and State Management 44 times
- * apiece.
+ * these apart from a real topic page, so what makes the frontmatter rule worth
+ * having is exactly that these are rejected by it. Core Concepts is the near
+ * miss: its description reads "How cdkd deploys CDK apps", which a substring
+ * match accepts and the word boundary rejects. The others each name every topic
+ * command somewhere in their bodies while documenting none of them.
  *
  * The HUB is deliberately NOT in this list, even though it is the same kind of
  * page. It is refused structurally by the topic check, and the header says that
@@ -193,8 +190,10 @@ const UNDOCUMENTED: Readonly<Record<string, string>> = {
     '`--show-dependencies` -- plus the `ls` alias named on the state page. Tracked by ' +
     'go-to-k/cdkd#2577.',
   synth:
-    'No page of its own. The CLI Reference explains its stdout contract on a multi-stack ' +
-    'app; none of its flags are documented anywhere. Tracked by go-to-k/cdkd#2577.',
+    'No page of its own. Its material is scattered: the CLI Reference covers the stdout ' +
+    'contract on a multi-stack app and names `--output` there, and the deploy-tuning page ' +
+    'documents `--strict` / `--ignore-errors` as also accepted by it. Tracked by ' +
+    'go-to-k/cdkd#2577.',
   migrate:
     'Held pending the deprecation decision in go-to-k/cdkd#2572 -- it is the only ' +
     'command that requires the AWS CDK CLI binary, so whether it stays at all is ' +
@@ -204,9 +203,11 @@ const UNDOCUMENTED: Readonly<Record<string, string>> = {
 /**
  * Floors, so a parse that has gone blind cannot report green having compared
  * nothing. "The tree yielded no commands" and "every command is documented" are
- * the same pass without these. Both sit below the measured counts (19 commands,
- * 50 navigation paths) with enough slack that an ordinary removal does not
- * force a test edit, while a total parse failure cannot clear them.
+ * the same pass without these. Both sit well below what the tree yields today,
+ * with enough slack that an ordinary removal does not force a test edit, while
+ * a total parse failure cannot clear them. They are backstops against a dead
+ * parser, not measurements -- deliberately not tightened to the live counts,
+ * which would make every ordinary docs change a test edit.
  */
 const MIN_COMMANDS = 15;
 const MIN_NAV_PATHS = 30;
@@ -429,8 +430,8 @@ describe('docs command/nav coverage', () => {
     expect(
       problems.sort(),
       `A COMMAND_TOPIC_PAGES entry claims a broader page documents the command, and the ` +
-        `page's own title or description must say so. A body mention is not evidence: ` +
-        `\`cdkd deploy\` is named on 38 of the 50 navigation-listed pages, so a mapping ` +
+        `page's own title or description must say so. A body mention is not evidence -- ` +
+        `a command is named in the body of most navigation-listed pages, so a mapping ` +
         `repointed at Getting Started or Troubleshooting would pass on one.`
     ).toEqual([]);
   });

--- a/tests/unit/scripts/docs-command-nav-coverage.test.ts
+++ b/tests/unit/scripts/docs-command-nav-coverage.test.ts
@@ -57,9 +57,14 @@ import { buildProgram } from '../../../src/cli/program.js';
  * inflected verb does not qualify (`How cdkd deploys CDK apps` contains the
  * substring `cdkd deploy`, and Core Concepts is written exactly that way). That
  * is the page declaring the command to be part of its subject rather than
- * something it happens to mention, and it discriminates -- measured across the
- * 50 pages, frontmatter versus whole-file: `deploy` 4 against 38, `destroy` 2
- * against 29, `local` 9 against 16, `import` 1 against 13, `orphan` 1 against 7.
+ * something it happens to mention.
+ *
+ * That it DISCRIMINATES is asserted rather than asserted-in-prose, by
+ * `NON_DOCUMENTING_PAGES` below. Three review rounds each found a wrong count
+ * in a hand-maintained figure here -- the last one counting Core Concepts among
+ * the qualifying pages in the same sentence that introduced the word boundary
+ * to reject it. A fourth recount would have been the same mistake again, so the
+ * figures are gone and the property they described is a test.
  *
  * The hub is ALSO refused structurally, not left to the frontmatter rule. Its
  * description names no command today, so the rule happens to reject it -- but
@@ -88,6 +93,24 @@ const DOCS_CONFIG = join(repoRoot, 'vite.docs.config.ts');
 
 /** The hub. Refused as a topic-page target regardless of its wording. */
 const HUB_PAGE = '/cli-reference';
+
+/**
+ * Pages that discuss commands at length without being any one command's
+ * documentation. None of them may qualify as a topic page for any command.
+ *
+ * This is the discrimination claim as an assertion. Body mentions cannot tell
+ * these apart from a real topic page -- `cdkd deploy` is named on 38 of the 50
+ * navigation-listed pages -- so what makes the frontmatter rule worth having is
+ * exactly that these four are rejected by it. Core Concepts is in the list
+ * because it is the near miss: its description reads "How cdkd deploys CDK
+ * apps", which a substring match accepts and the word boundary rejects.
+ */
+const NON_DOCUMENTING_PAGES: readonly string[] = [
+  '/getting-started',
+  '/troubleshooting',
+  '/concepts',
+  HUB_PAGE,
+];
 
 /**
  * Command -> the navigation path of ITS OWN reference page.
@@ -203,10 +226,9 @@ function topLevelCommandNames(): string[] {
  * built site does not link to. Line comments were the spelling a review caught;
  * block comments are the same defect one spelling over. Line comments are
  * dropped FIRST, because a `/*` written inside one would otherwise open a
- * spurious block and swallow the real entries after it (this file already
- * contains a line comment carrying a `/*`, just outside the array). The path
- * pattern is
- * deliberately permissive (`[^']+`) so a future nested path is READ and then
+ * spurious block and swallow the real entries after it -- the scanned config
+ * already carries a line comment containing a `/*`, one line above the array.
+ * The path pattern is deliberately permissive (`[^']+`) so a future nested path is READ and then
  * judged by the existence check, rather than skipped and then reported as
  * missing from the navigation -- a true failure with a misleading reason.
  */
@@ -396,6 +418,28 @@ describe('docs command/nav coverage', () => {
         `page's own title or description must say so. A body mention is not evidence: ` +
         `\`cdkd deploy\` is named on 38 of the 50 navigation-listed pages, so a mapping ` +
         `repointed at Getting Started or Troubleshooting would pass on one.`
+    ).toEqual([]);
+  });
+
+  it('rejects every page that discusses commands without documenting one', () => {
+    const qualifying: string[] = [];
+    for (const navPath of NON_DOCUMENTING_PAGES) {
+      const file = docFileFor(navPath);
+      expect(existsSync(file), `${navPath}: docs/${navPath.slice(1)}.md does not exist`).toBe(true);
+      const fm = frontmatterOf(file);
+      expect(fm, `${navPath}: page has no frontmatter block to check`).not.toBeNull();
+      for (const name of Object.keys(COMMAND_TOPIC_PAGES)) {
+        if (namesCommand(fm as string, name)) {
+          qualifying.push(`${navPath} would qualify as the topic page for ${name}`);
+        }
+      }
+    }
+    expect(
+      qualifying.sort(),
+      `One of these pages now names a command in its frontmatter, so the topic check ` +
+        `would accept a mapping repointed at it. Either the wording drifted -- reword it, ` +
+        `or tighten the match -- or the page genuinely became that command's ` +
+        `documentation, in which case move it out of NON_DOCUMENTING_PAGES deliberately.`
     ).toEqual([]);
   });
 

--- a/vite.docs.config.ts
+++ b/vite.docs.config.ts
@@ -55,6 +55,7 @@ const navigation: SsgNavigationGroup[] = [
       { title: 'cdkd bootstrap', path: '/cli-bootstrap' },
       { title: 'cdkd gc', path: '/cli-gc' },
       { title: 'cdkd rollback', path: '/cli-rollback' },
+      { title: 'cdkd force-unlock', path: '/cli-force-unlock' },
       { title: 'cdkd export', path: '/cli-export' },
       { title: 'cdkd scrub', path: '/cli-scrub' },
       { title: 'cdkd publish-assets', path: '/cli-publish-assets' },


### PR DESCRIPTION
## Summary

`cdkd migrate` shipped registered, released and integ-covered while having no reference page, no entry in the site navigation, and no mention from the import guide it sits next to. It was found by a reader asking whether the command existed at all — not by any check, because none of the existing ones look here:

- `scripts/check-integ-cli-flags.ts` validates fixture invocations against the real Commander tree. Fixtures, not docs.
- `scripts/build-cli-flag-coverage-matrix.ts` measures which flags the fixtures exercise. Again fixtures.
- `tests/unit/scripts/docs-site-links.test.ts` validates links between pages that exist. It cannot see a page that was never written.

This adds the missing fence, and closes the one gap it found that was not already tracked.

## The fence

`tests/unit/scripts/docs-command-nav-coverage.test.ts` walks `buildProgram()` — the same Commander tree the fixture lint reads, which is why `program.ts` was split out in the first place — and requires every top-level command to be claimed in exactly one of three structures, each checked as strongly as its claim deserves:

| Structure | The claim | How it is checked |
| --- | --- | --- |
| `COMMAND_REFERENCE_PAGES` | this page **is** the command's reference | the page's H1 must be `cdkd <command>` |
| `COMMAND_TOPIC_PAGES` | documented inside a page covering a broader topic, with the reason recorded | the page must name the command, and must not be the CLI Reference hub |
| `UNDOCUMENTED` | shipped with no documentation, with the reason recorded | the reason must be real |

**Why not a `cli-<command>.md` naming convention.** Eight of the nineteen commands have no `cli-<command>` page, and they are not one case: five are genuinely documented under a differently-named page the navigation lists, three are not documented at all. A bare convention assertion puts all eight in one exclusion list and loses that distinction — which is the whole finding.

**Why the hub is refused as a topic target.** `docs/cli-reference.md` names every command at least once, so a mention check against it passes for free. Measured during review: sixteen mappings stayed green when repointed at the hub — exactly the regression this fence is for, a dedicated page deleted and its mapping quietly moved to the hub. Refusing it removes the class instead of tightening a substring test against it.

All three structures are also asserted in reverse, so a removed command cannot leave a stale entry behind, and floors on the resolved command count and the parsed navigation keep a parse regression from passing vacuously.

## What the measurement found

**`force-unlock`** gets the reference page this surfaced it never had — nobody had reported it. `docs/cli-force-unlock.md` covers what the lock is; that one expires on its own 30 minutes after its owner stops renewing, and the next `cdkd deploy` takes an expired lock over by itself, so the command is for not waiting or for a lock body nothing can parse; that the delete is unconditional and will cut in on a live deploy, and re-resolves the state bucket from the ambient profile so a shortened invocation can clear a same-named stack in another account; which regions it walks; and that it removes only `lock.json` and that key's noncurrent versions.

**`list` and `synth`** are recorded as undocumented (#2577). The first draft mapped both to the hub and called them documented there; review caught it. The CLI Reference has no `list` or `synth` section — only stdout-contract material — and neither command's flags are documented anywhere.

**`migrate`** is the third entry, held pending the deprecation decision in (#2572).

## Filed while writing the page

`cdkd force-unlock` logs a failed lock delete at ERROR level and still exits `0`, so a scripted `cdkd force-unlock && cdkd deploy` proceeds against a still-locked stack (#2575). Not fixed here: changing the exit code needs an audit of the integ fixtures that call it from `cleanup` traps under `set -e`. The page states the behaviour rather than leaving it to be discovered.

## Test plan

Every assertion probed to red individually, then restored — a fence that cannot fail is not a fence. Round 1:

- unaccounted command → `accounts for every registered top-level command`
- a command in two structures → `claims each command exactly once`
- an entry for a command that does not exist → `keeps every structure free of commands that no longer exist`
- a one-character reason → `gives every undocumented command a reason`
- `MIN_COMMANDS` raised above the real count → `reads a plausible command tree`

Round 2, on the assertions the review fixes added or changed:

- a topic mapping pointed at the hub → `names the command on every topic page, and never routes one to the hub`
- a topic mapping pointed at a page that never names the command → same test
- a topic reason shortened → same test
- a reference mapping pointed at a page whose H1 is something else → `titles every reference page after the command it documents`
- a nav entry commented out → `points every mapped command at a page the navigation lists` (this is the comment-blindness fix; it passed before the fix)
- the `navigation` identifier renamed → `reads a plausible navigation`. **The first attempt did not go red**: the identifier match was `const navigation[^=]*=`, which still matched `const navigationRenamedProbe`. Fixed with a word boundary and re-probed in both directions.
- `MIN_NAV_PATHS` raised above the real count → `reads a plausible navigation`

Everything else:

- Every claim in the new page traced to `src/cli/commands/force-unlock.ts`, `src/state/lock-manager.ts`, `src/cli/region-options.ts` and `src/cli/config-loader.ts` rather than to `--help`: the 30-minute default TTL and its single construction site, the expired-lock takeover, the unconditional delete and why, the region walk with its `us-east-1` literal fallback, the noncurrent-version purge, and the two asymmetric failure modes in the exit-code section.
- `vp run check`, `vp run typecheck:test`, `vp run build`, `vp run gen:all-matrices`, `vp run audit:coverage:check` — clean, nothing regenerated dirty.
- `vp test run` — 888 files, 18397 passed, 1 skipped, no type errors.
- `vp run docs:build`, then the rendered `dist/site/cli-force-unlock/index.html` inspected: heading order as intended, both tables render, every internal link and anchor resolves against the built site, and the page is reachable from the `CLI Reference` navigation group.
- No AWS mutation: documentation and a unit test.

Closes #2573
