### PR TITLE
chore: fold the go-to-k/cdkd#2553 run's lessons back into the rules

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -40,6 +40,18 @@ paths:
   packages hyphenate where the endpoint host does not, and a mis-named
   `vi.mock` is silently INERT.
 
+### A test that SPAWNS a subprocess must declare its own timeout
+
+Vitest's default 5 s is an IN-PROCESS bound. A case that spawns one of this
+repo's own `.ts` entry points pays Node startup plus type-stripping every time,
+so it passes locally and fails on a loaded CI runner — the direction that reads
+as flakiness rather than an under-declared bound (2026-09-04,
+go-to-k/cdkd#2553: five spawns of `scripts/audit-stateful-candidates.ts` ran in
+~2 s locally, timed out at 5000 ms in CI). Pass the bound as `it`'s third
+argument (`}, 60_000);`), generously — its job is to stop a HANG, not to police
+latency. One cheap spawn of an already-BUILT binary is fine under the default;
+the trigger is a TS entry point, or several spawns in a case.
+
 ### A `*Once` primer must be consumed by the test that primed it (mandatory)
 
 - `vi.clearAllMocks()` clears call RECORDS but does NOT drain the queue seeded by
@@ -275,9 +287,9 @@ partial first page is a silent false pass). References:
 `tests/integration/emr-instance-configs/verify.sh`.
 
 A pager invoked non-interactively is a SEPARATE route to a hang, so
-`export AWS_PAGER=""` near the top of a fixture is cheap insurance — a
-recommendation for NEW and affected fixtures, not a tree-wide invariant.
-Mechanically enforced since issue #1402; user-facing writeup in
+`export AWS_PAGER=""` near the top of a fixture is cheap insurance — for NEW
+and affected fixtures, not a tree-wide invariant. Enforced since issue #1402;
+writeup in
 [docs/integ-fixture-conventions.md](../../docs/integ-fixture-conventions.md).
 
 ### `verify.sh` upstream-cdk callers must pin AND resolve a fixture-local CLI (mandatory)
@@ -492,18 +504,15 @@ after destroy — the shape of `loggroup-kms-associate` and siblings since #958.
 blocker and proposed account-bootstrap infrastructure to avoid a non-problem —
 neither premise survived one `grep` of the fixture tree.)
 
-Two things this rule does NOT say: the `/cleanup` skill's caution stands for
-keys it did not create (only schedule deletion for `KeyManager == CUSTOMER` +
+Two things this rule does NOT say: `/cleanup`'s caution stands for keys it did
+not create (schedule deletion only for `KeyManager == CUSTOMER` +
 `KeyState == Enabled` keys with a cdkd-shaped description, never one with live
-grants or aliases), and a key does keep BILLING through its pending window —
-a cost, not an orphan, and per `feedback_integ_is_not_a_cost` not a reason to
-skip coverage.
+grants or aliases), and a key keeps BILLING through its window — a cost, not an
+orphan, and not a reason to skip coverage.
 
 The generalizable half: when an issue states a BLOCKER as settled fact, grep
-the tree for the blocker before building around it — a sibling fixture may
-already have disproven it. See also
-`feedback_verify_issue_root_cause_before_building_tooling` and
-`feedback_umbrella_issue_row_can_be_already_fixed`. User-facing writeup in
+the tree before building around it — a sibling fixture may already have
+disproven it. User-facing writeup in
 [docs/integ-fixture-conventions.md](../../docs/integ-fixture-conventions.md).
 
 ### `verify.sh` must sweep S3 OBJECT VERSIONS and assert zero (mandatory for secret-seeding fixtures)
@@ -557,21 +566,21 @@ observed live, none visible from reading the script, only from COUNTING what S3
 holds afterwards:
 
 1. **Trap-only sweep.** `trap - EXIT INT TERM` on the success path means a
-   sweep living only in `cleanup` runs on the failure path and never the normal
-   one.
+   sweep living only in `cleanup` never runs on the normal path.
 2. **`printf '%s' | tr | while read`.** `out=$(aws ...)` strips the trailing
-   newline, so `read` returns non-zero on the LAST field and the body never
-   runs for it (verified: 0 of 1 on a single-version key, 346 of 347 on a full
-   listing). Use `printf '%s\n'` AND `|| [ -n "${key}" ]`.
+   newline, so `read` returns non-zero on the LAST field and the body skips it
+   (verified: 0 of 1, and 346 of 347). Use `printf '%s\n'` AND
+   `|| [ -n "${key}" ]`.
 3. **`length(...)` under `--output text`.** `--query` is applied PER PAGE, so a
    >1000-entry listing prints one number per page (measured `1000\n189`).
-   Count ROWS of a `[Key,VersionId]` projection.
+   Count ROWS of a projection. Applies to ANY filtered count, not just a
+   version sweep (go-to-k/cdkd#2553 shipped six such captures in a fixture).
 
-Two shapes are decisions, not style: `([Versions, DeleteMarkers][])[...]` — the
-parentheses are load-bearing (the unparenthesised form returns empty; measured
-0 vs 347) — and the teardown sweep must NOT be noncurrent-only: after
-`aws s3 rm` the DELETE MARKER is the `IsLatest == true` entry, so one marker
-per key would survive forever and the zero-assertion would never pass.
+Two shapes are decisions, not style: the parentheses in
+`([Versions, DeleteMarkers][])[...]` are load-bearing (unparenthesised returns
+empty; measured 0 vs 347), and the teardown sweep must NOT be noncurrent-only —
+after `aws s3 rm` the DELETE MARKER is the `IsLatest == true` entry, so one
+marker per key would survive forever.
 
 EVERY entry point — purge, count AND assertion — refuses a prefix that is not
 `cdkd/<stack>/<region>/` with both segments non-empty. On the purge side that
@@ -586,13 +595,12 @@ convention exists to remove, reintroduced inside its own assertion. Pinned by
 under bash against a fake `aws` that records its own invocation — asserting not
 just a non-zero exit but that no AWS call was attempted at all.
 
-Deletes go through `DeleteObjects` in batches of 1000 (the API maximum); keys
-carrying a quote or a backslash fall back to single-object `delete-object` (the
-payload is built without `jq` — sourcing the helper must not add a `jq`
-dependency). Under `Quiet: true` a successful call returns `{}`, so an `Errors`
-key in the output is a per-object failure reported as overall success
-(confirmed: rc=0 with `Errors` present); it warns, and the retry loop plus the
-zero-assertion are the backstop. **Both AWS calls pin `--output`** — `json` on
+Deletes go through `DeleteObjects` in batches of 1000 (the API maximum); a key
+carrying a quote or backslash falls back to single-object `delete-object`, its
+payload built without `jq` (sourcing the helper must not add that dependency).
+Under `Quiet: true` a success returns `{}`, so an `Errors` key is a per-object
+failure reported as overall success (confirmed: rc=0 with `Errors` present); it
+warns, and the retry loop plus the zero-assertion are the backstop. **Both AWS calls pin `--output`** — `json` on
 the delete, `text` on the listing — because the CLI's format is AMBIENT
 (`AWS_DEFAULT_OUTPUT`, or `output =` in the profile): un-pinned, the delete's
 per-object failure arrives in a shape the `"Errors"` check never matches and
@@ -687,9 +695,8 @@ cleared `> 0`.) Practical rules:
 
 - before trusting a new checker, measure — count parsed items per shape and
   explain any gap against a rough independent count;
-- encode the measurement as assertions with real numeric floors, anchored so a
-  near-miss cannot satisfy them;
-- aggregate floors alone are insufficient: one dead shape hides under them.
+- encode it as assertions with real numeric floors, anchored so a near-miss
+  cannot satisfy them; aggregate floors alone hide one dead shape.
 
 See `tests/unit/scripts/integ-cli-flags.test.ts` for the shape the assertions
 take.

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -109,12 +109,11 @@ markers.
   go-to-k/cdkd#2428's round-2 fixes reverted green; go-to-k/cdkd#2450's
   escaping fix stayed green weakened to keys-only because its fixture had
   nothing to escape).
-- **Reviewer subagents spawned BY A LANE report to the MAIN session**, not to
-  the lane that spawned them — a lane that dispatches reviewers and waits
-  blocks forever while the parent collects verdicts it did not ask for
-  (go-to-k/cdkd#2417). Pick one shape in the dispatch: the lane runs its
-  reviewers synchronously, or the parent owns the review dispatch and relays
-  verdicts down (under §9's queued-versus-`Resuming` rule).
+- **Reviewer subagents spawned BY A LANE report to the MAIN session** — a lane
+  that dispatches and waits blocks forever while the parent collects verdicts
+  it did not ask for (go-to-k/cdkd#2417). Pick one shape: the lane runs them
+  synchronously, or the parent dispatches and relays verdicts down (§9's
+  queued-versus-`Resuming` rule).
 
 ### 8-c. The live-test tiers
 
@@ -350,32 +349,33 @@ code defects and FIVE false statements in prose. Habits that each caught one:
 ### 8-h. Reviewer findings are inputs, not verdicts
 
 - **A reviewer's suggested FIX can be wrong even when its finding is right**
-  — derive regexes, bounds and constants from the code that produces the
-  value, and probe both directions (go-to-k/cdkd#2052: the suggested key
-  filter's `+` would have skipped keys cdkd really writes — the producer's
-  random suffix can be empty — trading over-collection for invisible
-  under-collection).
+  — derive regexes, bounds and constants from the code that PRODUCES the
+  value, and probe both directions (go-to-k/cdkd#2052: the suggested filter's
+  `+` would have skipped keys cdkd really writes, trading over-collection for
+  invisible under-collection).
 - **Check a reviewer's PREMISE before acting, and say so when you decline** —
   record the trace in the PR body; a declined finding with evidence can be
   re-judged, a silently dropped one looks like an oversight.
-- **An ABSENCE claim ("no such fence exists") is the one a reviewer is least
-  able to establish — verify it by RUNNING the thing said not to exist**
-  (acting on one nearly broke a byte budget sitting 2 B under its cap).
-- **Your own BRIEF to a lane agent is a published claim** — the trigger for
-  verification is DESTINATION, not doubt. Grep every mechanism claim before
-  it goes into an instruction; when an agent corrects your brief, say so.
+- **An ABSENCE claim ("no such fence exists", "that string is nowhere in the
+  source") is the one a reviewer is least able to establish — verify it by
+  RUNNING the thing said not to exist** (one nearly broke a byte budget 2 B
+  under its cap). **A grep cannot see an INTERPOLATED string**:
+  go-to-k/cdkd#2553's reviewer called a live integ sentinel dead because its
+  `Failed to update Vault` needle is nowhere in `src` — it is built at runtime
+  from `Failed to ${changeType} ${logicalId}`, and the suggested fix aimed it
+  at the wrapped CAUSE. Find the TEMPLATE, not the literal.
+- **Your own BRIEF is a published claim** — grep every mechanism claim before
+  it goes into an instruction; the trigger is DESTINATION, not doubt.
 - **A REVIEWER brief fails worse** — a false premise aims the whole round at
-  the wrong subject and returns a report that reads as authoritative (a false
-  region-residency mechanism reached three briefs before being caught).
-  Correct one already sent in-flight rather than waiting for the report.
+  the wrong subject and its report still reads as authoritative (a false
+  region-residency mechanism reached three briefs). Correct one in-flight.
 - **When two reviewers CONTRADICT each other, settle it in the code yourself
   before forwarding either** — say which was right and why. **For a claim
-  about an EXTERNAL system, neither reviewer can settle it and neither can
-  you: the tie-break is a MEASUREMENT** (a `NoEcho` masking dispute was
-  settled by a live CFn A/B that overturned the lane's design —
-  go-to-k/cdkd#2274; `CLAUDE.md`'s "never file divergence on folklore"). The
-  tell is grammatical: if the disputed sentence names a service rather than a
-  file, stop reading code and measure.
+  about an EXTERNAL system the tie-break is a MEASUREMENT**, since neither
+  they nor you can settle it (a `NoEcho` dispute was settled by a live CFn A/B
+  that overturned the lane's design — go-to-k/cdkd#2274). The tell is
+  grammatical: a disputed sentence naming a SERVICE rather than a file means
+  stop reading code and measure.
 
 ### 8-i. Fresh deploys, markers, and who sets what
 

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,8 +122,8 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_641,
-    corpusBytes: 170_960,
-    largest: { file: 'verify.md', bytes: 27_294 },
+    corpusBytes: 170_955,
+    largest: { file: 'verify.md', bytes: 27_289 },
     runnerUp: { file: 'implement.md', bytes: 26_541 },
   },
 };
@@ -137,17 +137,19 @@ const MIN_REFERENCE_FILES = 6;
 // RE-DERIVED DOWNWARD 208_000 -> 145_000 by the 2026-09-04 corpus compression
 // pass, exactly the move the assertion's failure message prescribes for a
 // genuine compression ("re-derive it DOWNWARD in the same commit"). Inputs are
-// in MEASURED and asserted: corpus 170,960 B, largest verify.md 27,294 B,
+// in MEASURED and asserted: corpus 170,955 B, largest verify.md 27,289 B,
 // runner-up implement.md 26,541 B. The floor must clear `corpus - largest`
-// (143,666) and `corpus - runnerUp` (144,419, the binding direction);
-// 145,000 clears them by 1,334 and 581 B. Growth in a NON-leader file erodes
+// (143,666) and `corpus - runnerUp` (144,414, the binding direction);
+// 145,000 clears them by 1,334 and 586 B. Growth in a NON-leader file erodes
 // the either-largest margin first -- MEASURED's failure message reports both
 // margins, so the next lapse reds this file at the commit that causes it.
 // The 2026-09-04 retro (go-to-k/cdkd#2514's run) spent most of the 3,366 B the
 // compression pass had left: it added rules to filing.md, launch-mode.md,
 // retro.md, ship.md and verify.md, paid for them by merging a duplicated count
 // rule, relocating a repo-wide one to `.claude/rules/hooks.md`, and
-// compressing, and left 581 B. The next addition here has to be
+// compressing, and left 581 B; the 2026-09-04 go-to-k/cdkd#2553 retro added a
+// reviewer-absence-claim rule to verify.md and paid for it there in full,
+// leaving 586 B. The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this
 // bound tighter, not looser (a smaller runner-up raises `corpus - runnerUp`).


### PR DESCRIPTION
## Summary

Retrospective for the go-to-k/cdkd#2553 run (PR go-to-k/cdkd#2568). Two lessons, each amended into the file where it fires, each paid for by compression in that same file — no cap or floor is raised.

### `.claude/rules/testing.md` — a test that spawns a subprocess must declare its own timeout

Vitest's default 5 s is an **in-process** bound. A case that spawns one of this repo's own `.ts` entry points pays Node startup plus type-stripping every time, so it passes on a developer machine and fails on a loaded CI runner — the direction that reads as a flaky test rather than an under-declared bound.

Measured this run: five spawns of `scripts/audit-stateful-candidates.ts` ran in ~2 s locally and timed out at 5000 ms in CI, where the same suite spent 517 s on imports alone. Twelve other unit files spawn subprocesses today with no declared bound, so the rule scopes the trigger — a TS entry point, or more than one spawn in a case — leaving a single cheap spawn of an already-built binary under the default.

The same file's S3-version-sweep trap list gains one clause: a JMESPath `length(...)` filter under `--output text` is applied **per page**, and that applies to any filtered count, not only a version sweep. This run shipped six such captures in an integ fixture before catching them.

### `work-issues` `references/verify.md` §8-h — a grep cannot see an interpolated string

§8-h already said an ABSENCE claim is the one a reviewer is least able to establish. This run produced the sharpest instance, so the bullet is **amended** rather than joined by a sibling.

A round-3 reviewer reported a blocker: the integ fixture's sentinel greps a needle that "appears nowhere in cdkd". It appears at runtime — the deploy engine builds the per-resource failure line from a template interpolating the change type and the logical id — so the sentinel was live, and the suggested fix would have aimed it at the wrapped *cause* instead. Verified in the source before acting, per the rule that was already there; the amendment names the mechanism that makes this class of absence claim fail, so the next reader resolves it by finding the template rather than the literal.

### Bookkeeping

`tests/unit/scripts/skill-file-payload.test.ts`'s MEASURED record moves **down** with the compression, exactly the move its own comment prescribes. `verify.md` is 27,289 B against the 27,294 B it measured before, and the binding floor margin goes from 581 B to 586 B.

### Net backlog effect

`closed 1 / filed 1 (new 1 / folded 0)` — closed go-to-k/cdkd#2553, filed go-to-k/cdkd#2571.

The promotion check fires on go-to-k/cdkd#2571 because this run created a file its body names, but as a **citation** rather than a target: the fix belongs in `scripts/audit-provider-coverage.ts`, untouched here, and needs a credentialed 10-30 minute regeneration that would stale go-to-k/cdkd#2568's own committed artifact. It stays `Session-fit: next` on the reason its body already carries.

## Test plan

Documentation and rules only; the one code change is the MEASURED record the payload fence reads.

- `vp check --fix` — 0 errors
- `vp run typecheck:test` — clean
- `vp run gen:all-matrices` — no drift
- `vp test run` — 889 files / 18517 tests green
- The three fences that read these files directly (`skill-file-payload`, `rule-file-payload`, `work-issues-skill-refs`) pass, having failed on the intermediate states — the payload fence caught the un-paid-for growth twice and drove the compression.
