### PR TITLE
chore: fold the go-to-k/cdkd#2558 run's lessons back into /work-issues

### DIFF
--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -88,6 +88,25 @@ verify, clean up.
      - `node ../../../dist/cli.js deploy [--all] [<extra-deploy-args>] --region us-east-1 --state-bucket <bucket> --verbose`
      - `node ../../../dist/cli.js destroy [--all] --region us-east-1 --state-bucket <bucket> --force`
 
+   **Never run it unwatched, and do not reach for `timeout`** — it does not
+   exist on macOS (exit 127 in 0s reads as instant completion), and a hung run
+   is indistinguishable from a slow one. Shell watchdog, firing made visible:
+
+   ```bash
+   LOG=$(mktemp)   # assign HERE: a separate block is a separate shell, and
+                   # `> ""` is a loud failure that costs you the whole run
+   bash verify.sh > "$LOG" 2>&1 &
+   VPID=$!
+   ( sleep 1500; kill -9 $VPID 2>/dev/null; echo "WATCHDOG_FIRED" >> "$LOG" ) &
+   WPID=$!
+   wait "$VPID"; RC=$?
+   kill "$WPID" 2>/dev/null
+   grep -c WATCHDOG_FIRED "$LOG" || echo "watchdog did not fire"
+   ```
+
+   The `grep` is load-bearing (`kill -9` surfaces as rc=137, otherwise just a
+   crash).
+
 6. **Verify cleanup**:
    - `aws s3 ls s3://<bucket>/cdkd/ --region us-east-1` — no leftover state.
    - **The state bucket is VERSIONED**, so that listing shows nothing while
@@ -311,11 +330,30 @@ verify, clean up.
   was.** (`cdkd gc` refuses while ANY stack holds a lock — account-wide, by
   design — so a parallel session's lock can stop a gc fixture before its
   first assertion; happened twice on 2026-08-19 from foreign stacks.) Record
-  it as `FAIL` (the bar is exit-code-based) with a note naming the blocker,
-  clean up what the aborted run leaked, and WAIT for the blocker to clear.
+  it as `FAIL` (the bar is exit-code-based) with a ledger note naming the
+  blocker and any hand-removed AWS resources — or the next reader reads the
+  merged fix as broken — clean up what the aborted run leaked, and WAIT for
+  the blocker to clear.
   Never `cdkd force-unlock` a lock you did not take — it belongs to another
   session's in-flight deploy.
 - **Never report success on a successful deploy alone** — destroy must
   complete and the orphan check must pass.
+- **Do NOT restart Docker to fix a hung `local-*` run — on Docker Desktop the
+  restart IS the likelier cause**: the daemon routes registry traffic through
+  a proxy the Desktop APP serves, and a quit-and-reopen can leave the
+  self-respawning backend up while the app never finishes launching (four
+  consecutive hung pulls; only a manual app restart recovered). Diagnose in
+  order, stopping at the first line that explains the symptom:
+
+  ```bash
+  curl -s -o /dev/null -w '%{http_code}\n' --max-time 15 https://registry-1.docker.io/v2/  # 401 = HOST networking fine
+  docker info 2>/dev/null | grep -i proxy         # the proxy the daemon depends on
+  pgrep -f 'Docker Desktop' >/dev/null && echo app-running || echo APP-NOT-RUNNING
+  ```
+
+  Ask the maintainer rather than escalating — a factory reset or deleting
+  Docker data destroys local images and volumes, never yours to spend. Clean
+  up your own probes (`kill`ing a `docker pull` wrapper leaves the
+  `com.docker.cli` child running).
 - **Never bypass this skill** with direct `cdkd deploy` / `cdkd destroy` —
   the orphan-cleanup contract is part of the test, not optional.

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -88,9 +88,10 @@ verify, clean up.
      - `node ../../../dist/cli.js deploy [--all] [<extra-deploy-args>] --region us-east-1 --state-bucket <bucket> --verbose`
      - `node ../../../dist/cli.js destroy [--all] --region us-east-1 --state-bucket <bucket> --force`
 
-   **Never run it unwatched, and do not reach for `timeout`** — it does not
-   exist on macOS (exit 127 in 0s reads as instant completion), and a hung run
-   is indistinguishable from a slow one. Shell watchdog, firing made visible:
+   **Never run it unwatched, and do not reach for `timeout`** — it is not in
+   stock macOS (a Homebrew one may or may not be on PATH, and its absence is
+   exit 127 in 0s, which reads as instant completion), and a hung run is
+   indistinguishable from a slow one. Shell watchdog, firing made visible:
 
    ```bash
    LOG=$(mktemp)   # assign HERE: a separate block is a separate shell, and
@@ -338,9 +339,10 @@ verify, clean up.
   session's in-flight deploy.
 - **Never report success on a successful deploy alone** — destroy must
   complete and the orphan check must pass.
-- **Do NOT restart Docker to fix a hung `local-*` run — on Docker Desktop the
-  restart IS the likelier cause**: the daemon routes registry traffic through
-  a proxy the Desktop APP serves, and a quit-and-reopen can leave the
+- **Do NOT restart Docker to fix a hung docker-dependent run (`local-*`, or
+  an ECR asset push) — on Docker Desktop the restart IS the likelier cause**:
+  the daemon routes registry traffic through a proxy the Desktop APP serves,
+  and a quit-and-reopen can leave the
   self-respawning backend up while the app never finishes launching (four
   consecutive hung pulls; only a manual app restart recovered). Diagnose in
   order, stopping at the first line that explains the symptom:

--- a/.claude/skills/work-issues/references/filing.md
+++ b/.claude/skills/work-issues/references/filing.md
@@ -27,7 +27,11 @@ cannot sit open while site 1's fix drifts away. Two boundaries:
   not name. On a trip, STATE the call in one line — LOC so far, what the next
   widening adds, in-PR versus filed — before taking it, and `AskUserQuestion`
   when it would more than double the diff. Not "never fix a data-loss bug you
-  find": the second one is a DECISION made out loud, not a continuation.
+  find": the second one is a DECISION made out loud, not a continuation. What
+  the fix would leave WRONG if omitted — the remedy text its own refusal
+  prints, a doc sentence the new behaviour contradicts — is a FORCED parallel
+  change, not a widening, and spends no tripwire; the test is whether the
+  artifact ships false without it (go-to-k/cdkd#2565).
 - **Sweep the same ROOT CAUSE, not the same AREA.** Two unrelated bugs in one
   provider are two issues; one wrong assumption at five call sites is one. The
   test: a single sentence describes the fix at every site.

--- a/.claude/skills/work-issues/references/filing.md
+++ b/.claude/skills/work-issues/references/filing.md
@@ -29,9 +29,9 @@ cannot sit open while site 1's fix drifts away. Two boundaries:
   when it would more than double the diff. Not "never fix a data-loss bug you
   find": the second one is a DECISION made out loud, not a continuation. What
   the fix would leave WRONG if omitted — the remedy text its own refusal
-  prints, a doc sentence the new behaviour contradicts — is a FORCED parallel
-  change, not a widening, and spends no tripwire; the test is whether the
-  artifact ships false without it (go-to-k/cdkd#2565).
+  prints — is a FORCED parallel change, not a widening, and spends no
+  tripwire: the test is whether the artifact ships false without it
+  (go-to-k/cdkd#2565).
 - **Sweep the same ROOT CAUSE, not the same AREA.** Two unrelated bugs in one
   provider are two issues; one wrong assumption at five call sites is one. The
   test: a single sentence describes the fix at every site.

--- a/.claude/skills/work-issues/references/launch-mode.md
+++ b/.claude/skills/work-issues/references/launch-mode.md
@@ -170,7 +170,7 @@ tree:
 | 7 | `main` is checked out in the main checkout, so the post-merge `git checkout main && git pull` cannot run here — pull through `git -C "<MAIN_CHECKOUT>"` | §9 |
 | 8 | The post-merge rebuild targets the MAIN checkout for the same reason | §9 |
 | 9 | The retro branch is created in THIS tree too, so the `LAUNCH_BRANCH` restore is the run's LAST step — after the retro PR merges, not inside §9's per-lane cleanup | §10-d |
-| 10 | Serial lanes SHARE this tree's markers and gitignored sentinels (both under `git rev-parse --git-dir`), so lane 2 inherits lane 1's. `integ-broad` is bound ONLY to `.markgate-broad-integ-test`, which no branch switch touches, so it reads FRESH for code its run never saw (measured 2026-09-04). Re-run a broad fixture per LANE | §8 |
+| 10 | Serial lanes SHARE this tree's markers (under `git rev-parse --git-dir`) and its gitignored root sentinels — both per-worktree, so lane 2 inherits lane 1's. `integ-broad` is bound ONLY to `.markgate-broad-integ-test`, which no branch switch touches, so it reads FRESH for code its run never saw (2026-09-04). Re-run a broad fixture per LANE | §8 |
 
 "Four things and nothing else" was the previous count, and it was wrong in the
 direction that matters: this file is not always loaded, SKILL.md is, so an

--- a/.claude/skills/work-issues/references/launch-mode.md
+++ b/.claude/skills/work-issues/references/launch-mode.md
@@ -170,6 +170,7 @@ tree:
 | 7 | `main` is checked out in the main checkout, so the post-merge `git checkout main && git pull` cannot run here — pull through `git -C "<MAIN_CHECKOUT>"` | §9 |
 | 8 | The post-merge rebuild targets the MAIN checkout for the same reason | §9 |
 | 9 | The retro branch is created in THIS tree too, so the `LAUNCH_BRANCH` restore is the run's LAST step — after the retro PR merges, not inside §9's per-lane cleanup | §10-d |
+| 10 | Serial lanes SHARE this tree's markers and gitignored sentinels (both under `git rev-parse --git-dir`), so lane 2 inherits lane 1's. `integ-broad` is bound ONLY to `.markgate-broad-integ-test`, which no branch switch touches, so it reads FRESH for code its run never saw (measured 2026-09-04). Re-run a broad fixture per LANE | §8 |
 
 "Four things and nothing else" was the previous count, and it was wrong in the
 direction that matters: this file is not always loaded, SKILL.md is, so an

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -61,9 +61,10 @@ rm -f /tmp/run-touched.$$
   token is path-shaped or the diff is mostly dotfiles.
 - **A hit is a prompt for judgement, not a verdict** — the check cannot tell a
   citation from a target. Do the item, or re-classify it in the issue with the
-  reason the criterion no longer applies. In a SINGLE-lane run whose PR is the
-  follow-ups' own subject, expect EVERY one to hit and read the issue's REASON
-  instead (go-to-k/cdkd#2514: 10 of 10, all correctly held on scope
+  reason the criterion no longer applies. When the run's own PRs ARE the
+  follow-ups' subject — one lane, or several sharing a subsystem — expect
+  EVERY one to hit and read the issue's REASON instead (go-to-k/cdkd#2514 10
+  of 10, go-to-k/cdkd#2558's run 12 of 12, all correctly held on scope
   containment) — a run-wide hit rate is a property of the run's shape, not of
   the deferrals.
 - **Re-read the REASON, not just the files** — classify-once freezes the

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -64,8 +64,8 @@ rm -f /tmp/run-touched.$$
   reason the criterion no longer applies. When the run's own PRs ARE the
   follow-ups' subject — one lane, or several sharing a subsystem — expect
   EVERY one to hit and read the issue's REASON instead (go-to-k/cdkd#2514 10
-  of 10, go-to-k/cdkd#2558's run 12 of 12, all correctly held on scope
-  containment) — a run-wide hit rate is a property of the run's shape, not of
+  of 10, and again across go-to-k/cdkd#2558's two-lane run, every one
+  correctly held on scope containment) — a run-wide hit rate is a property of the run's shape, not of
   the deferrals.
 - **Re-read the REASON, not just the files** — classify-once freezes the
   DECISION, not the PREMISE: "that PR is still open" goes false when it

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -191,9 +191,9 @@ second and fourth measured on go-to-k/cdkd#2108 / go-to-k/cdkd#2109):
   byte-identical to an earlier phase's is that trap with no fix to blame** —
   the diff is `NO_CHANGE`, the flag under test is never read (the engine
   consults it only under `case 'UPDATE'`), the phase cannot pass, and `set -e`
-  takes every later one with it (go-to-k/cdkd#2565: the three phases proving
-  the regression never ran, past six author-side rounds). Make each phase
-  assert its own change LANDED first.
+  takes every later one with it (go-to-k/cdkd#2565: the fixture stopped at
+  that phase and the three proving the regression never ran, past every
+  author-side round). Make each phase assert its own change LANDED first.
 - **The arm's PREMISE is out of scope, and the tell is both counts zero** —
   `0 leaks AND 0 masks` is an arm that did nothing (go-to-k/cdkd#2176: the
   spelling used was one cdkd deliberately does not resolve, so nothing was
@@ -247,8 +247,8 @@ injection, redeploys, and runs a genuinely clean destroy.
 
 **Never leave a real-AWS run unwatched** — a hung integ is indistinguishable
 from a slow one (one wedged in `docker push` for 4h17m). `/run-integ` step 5
-carries the watchdog recipe and why `timeout` is not an option on macOS; pair
-it with a `Monitor` on phase lines AND on log-growth stalling.
+carries the watchdog recipe and why `timeout` is not the answer; pair it with
+a `Monitor` on phase lines AND on log-growth stalling.
 
 - **ANCHOR the predicate a poller waits on** — a premature DONE is acted on.
   Wait on a line the job writes only at the END, anchored
@@ -378,16 +378,16 @@ left orphans, delete them by direct AWS API call before doing anything else.
 writes it, run by the ORCHESTRATOR after its dispatched reviewers report and
 every blocker is addressed — a lane setting it is the "sub-agent self-review
 is not independent review" failure arriving through the marker (two of three
-lanes on 2026-08-29, go-to-k/cdkd#2383 / go-to-k/cdk-local#631; twice more in
-one run on 2026-09-04, where the one lane whose BRIEF named the prohibition
-was the one that obeyed — so put it in the brief, not only here). The merge
-gate cannot catch it: the sentinel is per-worktree and §9 merges from the
-lane's worktree, so a lane setting it after its final push produces a matching
-sha. The PARENT can, and it is a named step of its own round — read the marker
+lanes on 2026-08-29, go-to-k/cdkd#2383 / go-to-k/cdk-local#631; twice more on
+2026-09-04, where the one lane whose BRIEF named the prohibition was the one
+that obeyed — so put it in the brief, not only here). The merge gate cannot
+catch it: the sentinel is per-worktree and §9 merges from the lane's
+worktree, so a lane setting it after its final push matches. The PARENT can,
+and it is a named step of its own round — read the marker
 BEFORE running `/review-pr`, since one already fresh there can only be the
 lane's (`mise exec -- markgate verify pr-review`, then
-`.markgate-pr-review-sha` against `git rev-parse HEAD`; a sha behind HEAD is
-the tell). On a hit, review from scratch.
+`.markgate-pr-review-sha` against `git rev-parse HEAD`; a sha that is not HEAD
+is the tell). On a hit, review from scratch.
 
 **And your own review round is not optional because the lane already ran one.**
 A lane's reviewers are its children — same brief, same framing — so what they

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -62,8 +62,8 @@ by a probe or a trace, never by re-reading the diff:
   code; re-measured +0–3%). Confirm the probe reaches the added code, as §5
   requires of a mutation probe.
 
-**A fix that CLOSES a member falsifies every sentence that COUNTS the set**,
-and those counters sit OUTSIDE the diff — §8-g's COUNT bullet is the remedy.
+**A fix that CLOSES a member falsifies every sentence COUNTING the set**, in
+files the diff never touches — §8-g's COUNT bullet.
 
 ### 8-b. Integ ordering vs review rounds and rebases
 
@@ -187,17 +187,27 @@ second and fourth measured on go-to-k/cdkd#2108 / go-to-k/cdkd#2109):
   something, a fixture whose ONLY difference is the skipped thing gives the
   command no work ("nothing to revert": two live writes, zero signal). Give
   the fixture a second, ORDINARY difference, and a phase proving the premise
-  before the phase that depends on it.
+  before the phase that depends on it. **A phase re-deploying a template
+  byte-identical to an earlier phase's is that trap with no fix to blame** —
+  the diff is `NO_CHANGE`, the flag under test is never read (the engine
+  consults it only under `case 'UPDATE'`), the phase cannot pass, and `set -e`
+  takes every later one with it (go-to-k/cdkd#2565: the three phases proving
+  the regression never ran, past six author-side rounds). Make each phase
+  assert its own change LANDED first.
 - **The arm's PREMISE is out of scope, and the tell is both counts zero** —
   `0 leaks AND 0 masks` is an arm that did nothing (go-to-k/cdkd#2176: the
   spelling used was one cdkd deliberately does not resolve, so nothing was
   ever plaintext). Prove the premise independently before reading the
   assertions.
-- **A negative assertion is a confluence point** — "the bad value was not
-  written" is satisfied by a correct refusal AND by any unrelated failure
-  that stopped short (measured: fix mutated back, arm stayed green because
-  the revert had errored instead of writing). Assert the POSITIVE marker only
-  the fixed path emits; demote the negative to a stated safety net.
+- **Any outcome REACHABLE BY TWO PATHS is a confluence point** — "the bad
+  value was not written" is satisfied by a correct refusal AND by any
+  unrelated failure that stopped short (measured: fix mutated back, arm
+  stayed green because the revert had errored instead of writing); a REFUSAL
+  is satisfied by the guard firing AND by the probe behind it failing
+  (go-to-k/cdkd#2565: a missing `logs:DescribeLogStreams` grant promotes to
+  the same refusal, so on a role that cannot probe, the phase passes
+  exercising nothing). Assert the POSITIVE marker only the intended path
+  emits; demote the other to a stated safety net.
 - **Every assertion PREDATES your change → the run is somebody else's
   regression net.** `git diff origin/main -- <fixture>` and ask which
   assertion could only pass AFTER your change; if none, add the
@@ -235,25 +245,10 @@ injection, redeploys, and runs a genuinely clean destroy.
 
 ### 8-e. Watching runs and pollers
 
-**Never leave a real-AWS run unwatched, and do not reach for `timeout`** — it
-does not exist on macOS (exit 127 in 0s reads as instant completion), and a
-hung integ is indistinguishable from a slow one (one wedged in `docker push`
-for 4h17m). Shell watchdog, firing made visible:
-
-```bash
-LOG=$(mktemp)   # assign HERE: a separate block is a separate shell, and
-                # `> ""` is a loud failure that costs you the whole run
-bash verify.sh > "$LOG" 2>&1 &
-VPID=$!
-( sleep 1500; kill -9 $VPID 2>/dev/null; echo "WATCHDOG_FIRED" >> "$LOG" ) &
-WPID=$!
-wait "$VPID"; RC=$?
-kill "$WPID" 2>/dev/null
-grep -c WATCHDOG_FIRED "$LOG" || echo "watchdog did not fire"
-```
-
-The `grep` is load-bearing (`kill -9` surfaces as rc=137, otherwise just a
-crash). Pair with a `Monitor` on phase lines AND log-growth stalling.
+**Never leave a real-AWS run unwatched** — a hung integ is indistinguishable
+from a slow one (one wedged in `docker push` for 4h17m). `/run-integ` step 5
+carries the watchdog recipe and why `timeout` is not an option on macOS; pair
+it with a `Monitor` on phase lines AND on log-growth stalling.
 
 - **ANCHOR the predicate a poller waits on** — a premature DONE is acted on.
   Wait on a line the job writes only at the END, anchored
@@ -266,10 +261,8 @@ crash). Pair with a `Monitor` on phase lines AND log-growth stalling.
   call and read the log's own terminal line. Two nearby traps: a `cd` inside
   the backgrounded compound leaves the parent's `$VAR` unset, and `grep -c`
   exits 1 on a count of zero.
-- **A run blocked before its assertions is not a failing fix** — record `FAIL`
-  (the bar is exit-code-based) with a ledger note naming the blocker and any
-  hand-removed AWS resources, or the next reader reads the merged fix as
-  broken.
+- **A run blocked before its assertions is not a failing fix** — `/run-integ`'s
+  "Important" section owns that rule and the ledger note it requires.
 
 ### 8-f. Fixture environment prechecks
 
@@ -286,22 +279,8 @@ aws s3 ls "s3://cdkd-state-<acct>/cdkd-bootstrap/"                       # which
 the same code without it** (on the merits, not availability). When docker is
 required (`integ-local`), verify registry reach FIRST (`docker pull
 hello-world` under a 120s cap) — `docker version` says nothing about registry
-networking. **Do NOT restart Docker to fix a hang — on Docker Desktop the
-restart IS the likelier cause**: the daemon routes registry traffic through a
-proxy the Desktop APP serves, and a quit-and-reopen can leave the
-self-respawning backend up while the app never finishes launching (four
-consecutive hung pulls; only a manual app restart recovered). Diagnose in
-order, stopping at the first line that explains the symptom:
-
-```bash
-curl -s -o /dev/null -w '%{http_code}\n' --max-time 15 https://registry-1.docker.io/v2/  # 401 = HOST networking fine
-docker info 2>/dev/null | grep -i proxy         # the proxy the daemon depends on
-pgrep -f 'Docker Desktop' >/dev/null && echo app-running || echo APP-NOT-RUNNING
-```
-
-Ask the maintainer rather than escalating — a factory reset or deleting Docker
-data destroys local images and volumes, never yours to spend. Clean up your own probes (`kill`ing
-a `docker pull` wrapper leaves the `com.docker.cli` child running).
+networking. `/run-integ`'s "Important" section owns the hang diagnosis, the
+do-NOT-restart-Docker rule, and what is never yours to spend.
 
 ### 8-g. Prose claims are verified to the same bar as code
 
@@ -399,11 +378,16 @@ left orphans, delete them by direct AWS API call before doing anything else.
 writes it, run by the ORCHESTRATOR after its dispatched reviewers report and
 every blocker is addressed — a lane setting it is the "sub-agent self-review
 is not independent review" failure arriving through the marker (two of three
-lanes did exactly this on 2026-08-29, go-to-k/cdkd#2383 /
-go-to-k/cdk-local#631 — so name this marker in the lane's brief). Nothing
-mechanical catches it: the sha-bound sentinel is per-worktree and §9 merges
-from the lane's worktree, so a lane that sets it after its final push produces
-a matching sha. The rule is the only thing standing there.
+lanes on 2026-08-29, go-to-k/cdkd#2383 / go-to-k/cdk-local#631; twice more in
+one run on 2026-09-04, where the one lane whose BRIEF named the prohibition
+was the one that obeyed — so put it in the brief, not only here). The merge
+gate cannot catch it: the sentinel is per-worktree and §9 merges from the
+lane's worktree, so a lane setting it after its final push produces a matching
+sha. The PARENT can, and it is a named step of its own round — read the marker
+BEFORE running `/review-pr`, since one already fresh there can only be the
+lane's (`mise exec -- markgate verify pr-review`, then
+`.markgate-pr-review-sha` against `git rev-parse HEAD`; a sha behind HEAD is
+the tell). On a hit, review from scratch.
 
 **And your own review round is not optional because the lane already ran one.**
 A lane's reviewers are its children — same brief, same framing — so what they
@@ -416,7 +400,8 @@ author-side round COUNT does not converge on the author's blind spot
 (go-to-k/cdkd#2519: its lane rounds reported no blockers; later independent
 rounds kept finding deltas INSIDE the previous round's fix). Three rounds of
 that shape means change the METHOD, not add a round — §5's "three spellings in
-three rounds".
+three rounds". Review the FIXTURE as part of that diff, not as scaffolding
+around it — go-to-k/cdkd#2565's merge blocker was there (§8-d).
 
 **A reviewer's scratch COPY of a worktree is not detached from git.** A linked
 worktree's `.git` is a FILE pointing into the main repo, and `cp -R` carries

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,8 +122,8 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_641,
-    corpusBytes: 170_955,
-    largest: { file: 'verify.md', bytes: 27_289 },
+    corpusBytes: 171_403,
+    largest: { file: 'verify.md', bytes: 27_034 },
     runnerUp: { file: 'implement.md', bytes: 26_541 },
   },
 };
@@ -137,10 +137,10 @@ const MIN_REFERENCE_FILES = 6;
 // RE-DERIVED DOWNWARD 208_000 -> 145_000 by the 2026-09-04 corpus compression
 // pass, exactly the move the assertion's failure message prescribes for a
 // genuine compression ("re-derive it DOWNWARD in the same commit"). Inputs are
-// in MEASURED and asserted: corpus 170,955 B, largest verify.md 27,289 B,
+// in MEASURED and asserted: corpus 171,403 B, largest verify.md 27,034 B,
 // runner-up implement.md 26,541 B. The floor must clear `corpus - largest`
-// (143,666) and `corpus - runnerUp` (144,414, the binding direction);
-// 145,000 clears them by 1,334 and 586 B. Growth in a NON-leader file erodes
+// (144,369) and `corpus - runnerUp` (144,862, the binding direction);
+// 145,000 clears them by 631 and 138 B. Growth in a NON-leader file erodes
 // the either-largest margin first -- MEASURED's failure message reports both
 // margins, so the next lapse reds this file at the commit that causes it.
 // The 2026-09-04 retro (go-to-k/cdkd#2514's run) spent most of the 3,366 B the
@@ -149,7 +149,13 @@ const MIN_REFERENCE_FILES = 6;
 // rule, relocating a repo-wide one to `.claude/rules/hooks.md`, and
 // compressing, and left 581 B; the 2026-09-04 go-to-k/cdkd#2553 retro added a
 // reviewer-absence-claim rule to verify.md and paid for it there in full,
-// leaving 586 B. The next addition here has to be
+// leaving 586 B. The 2026-09-04 go-to-k/cdkd#2558 retro added five rules
+// (verify.md 8-d/8-i, launch-mode.md, filing.md, retro.md) and paid for them
+// by DISPLACING two blocks verify.md was carrying for another skill -- the
+// Docker-hang diagnosis and the real-AWS watchdog recipe now live in
+// .claude/skills/run-integ/SKILL.md, where the commands they wrap are run --
+// plus a de-duplicated blocked-run rule, leaving 138 B.
+// The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this
 // bound tighter, not looser (a smaller runner-up raises `corpus - runnerUp`).

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,8 +122,8 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_641,
-    corpusBytes: 171_403,
-    largest: { file: 'verify.md', bytes: 27_034 },
+    corpusBytes: 171_399,
+    largest: { file: 'verify.md', bytes: 27_036 },
     runnerUp: { file: 'implement.md', bytes: 26_541 },
   },
 };
@@ -137,10 +137,10 @@ const MIN_REFERENCE_FILES = 6;
 // RE-DERIVED DOWNWARD 208_000 -> 145_000 by the 2026-09-04 corpus compression
 // pass, exactly the move the assertion's failure message prescribes for a
 // genuine compression ("re-derive it DOWNWARD in the same commit"). Inputs are
-// in MEASURED and asserted: corpus 171,403 B, largest verify.md 27,034 B,
+// in MEASURED and asserted: corpus 171,399 B, largest verify.md 27,036 B,
 // runner-up implement.md 26,541 B. The floor must clear `corpus - largest`
-// (144,369) and `corpus - runnerUp` (144,862, the binding direction);
-// 145,000 clears them by 631 and 138 B. Growth in a NON-leader file erodes
+// (144,363) and `corpus - runnerUp` (144,858, the binding direction);
+// 145,000 clears them by 637 and 142 B. Growth in a NON-leader file erodes
 // the either-largest margin first -- MEASURED's failure message reports both
 // margins, so the next lapse reds this file at the commit that causes it.
 // The 2026-09-04 retro (go-to-k/cdkd#2514's run) spent most of the 3,366 B the
@@ -154,7 +154,7 @@ const MIN_REFERENCE_FILES = 6;
 // by DISPLACING two blocks verify.md was carrying for another skill -- the
 // Docker-hang diagnosis and the real-AWS watchdog recipe now live in
 // .claude/skills/run-integ/SKILL.md, where the commands they wrap are run --
-// plus a de-duplicated blocked-run rule, leaving 138 B.
+// plus a de-duplicated blocked-run rule, leaving 142 B.
 // The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this


### PR DESCRIPTION
## Summary

Stage 10 (RETRO) of the `/work-issues` run that shipped PR go-to-k/cdkd#2565 for
issue go-to-k/cdkd#2558 — the run's SECOND lane, after go-to-k/cdkd#2519 closed
go-to-k/cdkd#2514 / go-to-k/cdkd#2540 and its own retro landed as
go-to-k/cdkd#2564. Five rules, each amended into the stage file where it fires.
Nothing here is a restatement: where the text already existed and the failure
happened anyway, this says why it did not bite.

**1. `verify.md` 8-i — `pr-review` is a rule with no reader, so give the PARENT
a step.** 8-i already forbids a LANE setting the `pr-review` marker and already
says "name this marker in the lane's brief". A lane set it anyway on
go-to-k/cdkd#2519, and this run's FIRST lane set it again — caught only because
the sentinel sha was four HEADs behind. The one lane whose dispatch brief
carried the prohibition obeyed it, which is the evidence, but restating the
prohibition a third time is what 10-b forbids. The paragraph now says the merge
gate cannot catch it and the PARENT can: read the marker BEFORE running
`/review-pr`, because a marker already fresh at that moment can only be the
lane's. The two commands are in the text and both were run on this tree —
`mise exec -- markgate verify pr-review` returns rc=0 here while
`.markgate-pr-review-sha` holds `e54021ae`, which is not HEAD — exactly the
tell.

**2. `verify.md` 8-d — a phase re-deploying an unchanged template.**
go-to-k/cdkd#2565's merge blocker: a pre-flight phase ran a template
byte-identical to an earlier phase's, so the diff was `NO_CHANGE`, the
`--recreate-via-*` target was never read (the engine consults it only inside
`case 'UPDATE'`), the phase could not pass, and `set -e` took the three phases
that actually prove the regression with it. Every author-side round passed
over it; the independent round found it. Amended into the existing "the arm
is INERT because the command returns early" bullet, which is the same trap with
a fix to blame; the fixture's own header comment now records the mechanism.

**3. `verify.md` 8-d — the confluence bullet was scoped to NEGATIVE assertions,
which is why it read as inapplicable.** It said "a negative assertion is a
confluence point". The instance here is a REFUSAL, which reads as positive: the
fixture asserted the pre-flight refused, but a missing `logs:DescribeLogStreams`
grant promotes to that same refusal, so on a role that cannot probe at all the
phase passes exercising nothing. The bullet is now about any outcome reachable
by two paths, and its existing remedy — assert the POSITIVE marker only the
intended path emits — is what the fixture ended up doing.

**4. `launch-mode.md` — IN-PLACE serial lanes SHARE this tree's markers.** New
row 10. Markers and their gitignored sentinels live under
`git rev-parse --git-dir`, so lane 2 inherits lane 1's, and `integ-broad`'s
`include:` is ONLY `.markgate-broad-integ-test`, which no branch switch touches.
Markers live under the git dir and the sentinels are gitignored at the tree
root; both are per-worktree, which IN-PLACE means per-RUN. Measured here: the
marker read FRESH on this lane's branch while the broad run that earned it
predated this lane's `deploy.ts` / `deploy-engine.ts` changes.
The gate is doing what it is configured to do; what was missing is that IN-PLACE
inverts the "markers are per-worktree, so lanes are independent" assumption into
"one tree, so lanes are NOT independent". The parent re-ran `lambda` on this
tree rather than inheriting it.

**5. `filing.md` — a forced parallel change is not a widening.** The scope
tripwire go-to-k/cdkd#2564 added WORKED: this lane stayed at ~490 LOC of source,
neither arm fired, and the spec reviewer checked them explicitly. The one
out-of-scope-looking change was the provider's remedy text, which the fix would
have left FALSE if omitted. The bullet now carries that test — whether the
artifact ships false without it — so the tripwire is not spent on changes it was
never about.

Plus one wording fix in `retro.md` 10-0: the promotion-check bullet
go-to-k/cdkd#2564 added said "in a SINGLE-lane run", which reads as inapplicable
to this two-lane run even though both lanes shared one subsystem and 12 of 12
`next` filings hit. It now keys on the run's PRs being the follow-ups' subject.

## How the additions were paid for

`tests/unit/scripts/skill-file-payload.test.ts` had 586 B of margin on the
binding `corpus - runnerUp` bound, and `retro.md` 10-c forbids buying room by
raising the floor. Two blocks `verify.md` was carrying on another skill's behalf
were DISPLACED to `.claude/skills/run-integ/SKILL.md`, where the commands they
wrap are actually run:

- the Docker-hang diagnosis (the do-NOT-restart rule, the three-command triage,
  the "never yours to spend" line) → its "## Important" section;
- the real-AWS watchdog recipe and why `timeout` is not an option on macOS →
  the end of step 5, next to the `bash verify.sh` it wraps.

A third bullet — "a run blocked before its assertions is not a failing fix" —
existed VERBATIM in both files; the ledger clause `verify.md` had that
`/run-integ` lacked was merged into `/run-integ`'s copy and `verify.md` now
points at it. `verify.md` also drops 8-a's three-line pointer to 8-g down to
one. Net: corpus 170,955 → 171,403 B, margin 586 → 138 B, floor unchanged at
145,000 — 171,399 B corpus, 637 B of largest-side and 142 B of runner-up-side
margin. `MEASURED` and every number in the comments beside it are re-derived.

## Landed outside the skill corpus

- Memory `mocked-sdk-tests-agree-with-wrong-wire-assumptions`: a FAIL-SAFE
  tightening is a wire assumption too, and is the one nobody classifies as one.
  A reviewer asked the log-group emptiness probe to reject two non-answers
  (absent `logStreams`, empty page with `nextToken`). Correct in the
  conservative direction — but had real CloudWatch answered an empty group with
  `{}`, a deliberately CONDITIONAL data guard would have become unconditional
  with CI green, and the PR's own mocks cannot arbitrate that. The existing rule
  keys on a NEW create/wait/delete SHAPE and this added no call at all, so it
  never fired. Settled by one read-only `DescribeLogStreams` against a
  pre-existing empty log group, driven through the same SDK client and
  deserializer the production path uses.
- Memory `vitest-errors-line-is-not-type-errors-line`: extended with the second
  producer of that signature. `Test Files 889 passed / Tests 18550 passed /
  Type Errors no errors / Errors 1 error`, rc=1, twice while two real-AWS integs
  had just loaded the host; rc=0 on a quiet machine with no source change, and
  CI green on the same sha. Read the `Errors` line's TEXT, not its count; re-run
  when idle and let CI on the same sha be the tiebreaker.
- Issue go-to-k/cdkd#2566's deferral reason was re-derived. 10-0 says
  classify-once freezes the DECISION, not the PREMISE: its reason was "a module
  the same PR is already rewriting", which expired the moment
  go-to-k/cdkd#2565 merged. Rewritten to what the work NEEDS.

## Not recorded, and why

go-to-k/cdkd#2564's `ship.md` sentinel-ordering rule (rewriting a sentinel after
`markgate set` stales the marker) was hit again this run and the text was right;
it needs no edit. The framing "the independent round's blocker was in the
FIXTURE both times" was NOT written down: go-to-k/cdkd#2564's own body records
go-to-k/cdkd#2519's independent-round finding as a source-level fail-open, so
"both times" is unsupported and only the go-to-k/cdkd#2565 instance is cited.

## Review

`/review-pr`'s heuristic puts this at `inline` (6 files, ~165 LOC; agent-
instruction paths are deliberately NOT down-biased, and no up-bias trigger
fires). The tier is a floor, so one read-only reviewer was dispatched against
the prose arm — resolve every claim in the added text against the repo. It
returned one **major** and four minor/nit findings, all applied:

1. major — the new `launch-mode.md` row said markers AND sentinels live under
   `git rev-parse --git-dir`. Only the markers do; the sentinels are
   gitignored at the worktree root. The conclusion (serial lanes share both)
   holds, the stated location did not. Corrected.
2. minor — "a sha behind HEAD is the tell" is false under an `--is-ancestor`
   reading: the stale sentinel held a branch tip that is not an ancestor of
   HEAD. Now "a sha that is not HEAD".
3. minor — "past six author-side rounds" had no source in the PR record. Per
   8-g's own COUNT rule the disposition is DELETE, so the number is gone.
4. nit — a session-only figure in `retro.md`'s promotion bullet was replaced
   by the shape it was evidence for.
5. nit — `timeout` DOES exist here at `/opt/homebrew/bin/timeout`; the
   displaced line now says "not in stock macOS", which is what the exit-127
   symptom actually comes from.

Nothing was left on the reviewer's list: five items, five fixed in this PR,
zero deferred.

## Verification

- `vp check --fix` + `vp run check` + `vp run typecheck:test` + `vp run build`
  all green; `vp run gen:all-matrices` + `audit:coverage:check` + `format` clean.
- `vp test run`: 891 files, 18568 passed, rooted in this worktree, rc=0.
- Live test, prose arm (verify.md 8-c): every gate, marker, sentinel, path,
  section and command the new text names resolved against this repo, and every
  runnable one executed here — the `markgate verify` / sentinel-vs-HEAD pair,
  `git rev-parse --git-dir`, `.markgate.yml`'s `integ-broad` include, and the
  three displaced Docker triage commands (401 / proxy line / app-running).
- No `src/**`, `docs/**`, `README.md`, `CLAUDE.md` or `.claude/rules/**` in the
  diff, so no deploy/destroy tier applies and the `docs` review short-circuits.

This PR closes no issue — it is the run's fold-back.
