### PR TITLE
test(docs): pin the registered command set exactly, so a removal cannot be quietly undone

### DIFF
--- a/tests/unit/scripts/docs-command-nav-coverage.test.ts
+++ b/tests/unit/scripts/docs-command-nav-coverage.test.ts
@@ -251,6 +251,53 @@ const MIN_COMMANDS = 15;
 const MIN_NAV_PATHS = 30;
 
 /**
+ * The EXACT registered top-level command set, as a sorted literal.
+ *
+ * The floors above and the three structures below are both derived from
+ * `buildProgram()`, so they move WITH the tree: adding or removing a command
+ * shifts both sides of every comparison together, and nothing here says which
+ * commands cdkd is supposed to ship. That gap is issue
+ * [#2588](https://github.com/go-to-k/cdkd/issues/2588), found while removing
+ * `cdkd migrate` ([#2572](https://github.com/go-to-k/cdkd/issues/2572)):
+ * re-registering a removed command passes every assertion in this file as long
+ * as it is also given an `UNDOCUMENTED` entry, and adding one there is a single
+ * plausible-looking line.
+ *
+ * A literal fixes that in both directions. Adding a command is a deliberate
+ * one-line edit here with a reviewer looking at it; REMOVING one is the same,
+ * which is the direction a derived comparison can never notice.
+ *
+ * Deliberately NOT the union of the three structures: `UNDOCUMENTED` is empty
+ * as of #2572, so a union-based pin would assert nothing about a command that
+ * ships undocumented -- the case this file exists for. It is keyed on what
+ * commander DISPATCHES, so `list`'s `ls` alias is absent (an alias is not a
+ * command; `src/cli/index.ts`'s `SUBCOMMANDS` is the set that needs aliases,
+ * pinned separately in `tests/unit/cli/subcommand-reorder-population.test.ts`).
+ * `help` is commander's auto-generated command and is filtered by
+ * `topLevelCommandNames`.
+ */
+const REGISTERED_COMMANDS: readonly string[] = [
+  'bootstrap',
+  'deploy',
+  'destroy',
+  'diff',
+  'drift',
+  'events',
+  'export',
+  'force-unlock',
+  'gc',
+  'import',
+  'list',
+  'local',
+  'orphan',
+  'publish-assets',
+  'rollback',
+  'scrub',
+  'state',
+  'synth',
+];
+
+/**
  * Floors on the two CHECKED structures, and on the decoy list.
  *
  * Without them a command can be moved from a checked structure into
@@ -471,6 +518,18 @@ describe('docs command/nav coverage', () => {
       `A command belongs to exactly one of the three structures. Remove the stale entry ` +
         `-- a command listed twice is one whose weaker claim is never checked.`
     ).toEqual([]);
+  });
+
+  it('ships exactly the commands the pinned list names', () => {
+    expect(
+      [...commands].sort(),
+      `The registered top-level command set changed. This is the one assertion in ` +
+        `this file that is not derived from buildProgram(), so it is what makes ADDING ` +
+        `or REMOVING a command a deliberate edit rather than something the derived ` +
+        `checks absorb silently. If the change is intended, update REGISTERED_COMMANDS ` +
+        `in the same commit -- and if a command was ADDED, give it an entry in one of ` +
+        `the three structures too, which the assertions above will demand anyway.`
+    ).toEqual([...REGISTERED_COMMANDS].sort());
   });
 
   it('keeps every structure free of commands that no longer exist', () => {


### PR DESCRIPTION
## Summary

`tests/unit/scripts/docs-command-nav-coverage.test.ts` fences every registered
top-level command against the documentation site — but every assertion in it was
DERIVED from `buildProgram()`. Adding or removing a command moved both sides of
each comparison together, so nothing in the file said which commands cdkd is
supposed to ship.

Concretely: re-registering a removed command passed the whole file, as long as it
was also given an `UNDOCUMENTED` entry — one plausible-looking line. Found while
removing `cdkd migrate` (go-to-k/cdkd#2572, PR go-to-k/cdkd#2589), where nothing
mechanically asserted that the removal stayed done.

`REGISTERED_COMMANDS` is a sorted literal of the 18 commands, compared with
`toEqual`.

## Why a literal, and why keyed on the registered set

The floors (`MIN_COMMANDS`, `MIN_NAV_PATHS`) are deliberately backstops against a
dead parser, not measurements — tightening them would make every ordinary docs
change a test edit, and the file says so. This is the complement: the one
assertion that is not derived, so ADDING or REMOVING a command is a deliberate
edit with a reviewer looking at it.

Keyed on the REGISTERED set rather than the union of the three structures,
because `UNDOCUMENTED` is empty as of go-to-k/cdkd#2572 — a union-based pin would
assert nothing about a command that ships undocumented, which is the case this
file exists for.

Aliases are excluded: an alias is not a command. The set that DOES need them is
`src/cli/index.ts`'s `SUBCOMMANDS`, pinned separately by
`tests/unit/cli/subcommand-reorder-population.test.ts` (also from go-to-k/cdkd#2589).

## Test plan

Probed in BOTH directions against real code, not a synthetic fixture:

- **re-register** a `migrate` command in `src/cli/program.ts` -> this test reds,
  and so does `accounts for every registered top-level command`
  (2 failed / 12 passed)
- **delete** `scrub`'s registration -> this test reds, and so does `keeps every
  structure free of commands that no longer exist` (2 failed / 12 passed)

The removal direction is the one a derived comparison can never notice, which is
the whole point of the literal.

One probe was VOID and is recorded in the commit message rather than dropped: a
first attempt registered the command via an inline `await import('commander')`,
which did not compile, so the suite failed at LOAD and reported `no tests` —
indistinguishable from discrimination. The numbers above are from the compiling
re-run.

Full suite: 883 files, 18440 passed, 1 skipped. Test-only change; no integ gate
scope is touched.

Closes #2588
