### PR TITLE
chore: a review NIT is not a work item — fold the go-to-k/cdkd#2571 run's lesson into verify.md

### DIFF
--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -327,34 +327,37 @@ code defects and FIVE false statements in prose. Habits that each caught one:
 
 ### 8-h. Reviewer findings are inputs, not verdicts
 
+- **A NIT is not a work item.** Fix what a reviewer DEMONSTRATES is wrong;
+  leave the polish. Over four rounds on go-to-k/cdkd#2592 every blocker was
+  fixed correctly and every NEW defect came from a low-severity suggestion —
+  a "no escape hatch" nit produced a flag that could not reach green; a "walk
+  `err.cause`" nit, a walk claiming one hop while recursing unbounded. The
+  tell: the new code answers a hypothetical, not an observation. When three
+  rounds have each found a defect inside the last one's fix, the APPROACH
+  changes — WITHDRAW the speculative addition rather than bounding it, and
+  brief the next round to report only demonstrable defects.
 - **A reviewer's suggested FIX can be wrong even when its finding is right**
-  — derive regexes, bounds and constants from the code that PRODUCES the
-  value, and probe both directions (go-to-k/cdkd#2052: the suggested filter's
-  `+` would have skipped keys cdkd really writes, trading over-collection for
-  invisible under-collection).
-- **Check a reviewer's PREMISE before acting, and say so when you decline** —
-  record the trace in the PR body; a declined finding with evidence can be
-  re-judged, a silently dropped one looks like an oversight.
-- **An ABSENCE claim ("no such fence exists", "that string is nowhere in the
-  source") is the one a reviewer is least able to establish — verify it by
-  RUNNING the thing said not to exist** (one nearly broke a byte budget 2 B
-  under its cap). **A grep cannot see an INTERPOLATED string**:
-  go-to-k/cdkd#2553's reviewer called a live integ sentinel dead because its
-  `Failed to update Vault` needle is nowhere in `src` — it is built at runtime
-  from `Failed to ${changeType} ${logicalId}`, and the suggested fix aimed it
-  at the wrapped CAUSE. Find the TEMPLATE, not the literal.
+  — derive regexes, bounds and constants from the code that PRODUCES the value
+  and probe both directions (go-to-k/cdkd#2052).
+- **Check a reviewer's PREMISE before acting, and record a decline in the PR
+  body** — with evidence it can be re-judged; silently dropped it reads as an
+  oversight.
+- **An ABSENCE claim ("that string is nowhere in the source") is the one a
+  reviewer is least able to establish — verify it by RUNNING the thing said
+  not to exist.** **A grep cannot see an INTERPOLATED string**:
+  go-to-k/cdkd#2553's reviewer called a live integ sentinel dead over a needle
+  built at runtime from `Failed to ${changeType} ${logicalId}`. Find the
+  TEMPLATE.
 - **Your own BRIEF is a published claim** — grep every mechanism claim before
-  it goes into an instruction; the trigger is DESTINATION, not doubt.
-- **A REVIEWER brief fails worse** — a false premise aims the whole round at
-  the wrong subject and its report still reads as authoritative (a false
-  region-residency mechanism reached three briefs). Correct one in-flight.
-- **When two reviewers CONTRADICT each other, settle it in the code yourself
-  before forwarding either** — say which was right and why. **For a claim
-  about an EXTERNAL system the tie-break is a MEASUREMENT**, since neither
-  they nor you can settle it (a `NoEcho` dispute was settled by a live CFn A/B
-  that overturned the lane's design — go-to-k/cdkd#2274). The tell is
-  grammatical: a disputed sentence naming a SERVICE rather than a file means
-  stop reading code and measure.
+  it ships in an instruction; the trigger is DESTINATION, not doubt.
+- **A REVIEWER brief fails worse** — a false premise aims the round at the
+  wrong subject and the report still reads as authoritative (one false
+  mechanism reached three briefs). Correct one in-flight.
+- **When two reviewers CONTRADICT each other, settle it in the code yourself**
+  — say which was right and why. **For a claim about an EXTERNAL system the
+  tie-break is a MEASUREMENT** (go-to-k/cdkd#2274, a `NoEcho` dispute settled
+  by a live CFn A/B): a disputed sentence naming a SERVICE, not a file, means
+  stop reading and measure.
 
 ### 8-i. Fresh deploys, markers, and who sets what
 

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,8 +122,8 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_641,
-    corpusBytes: 171_743,
-    largest: { file: 'verify.md', bytes: 27_036 },
+    corpusBytes: 171_856,
+    largest: { file: 'verify.md', bytes: 27_149 },
     runnerUp: { file: 'implement.md', bytes: 26_908 },
   },
 };
@@ -168,6 +168,13 @@ const MIN_REFERENCE_FILES = 6;
 // by zero for anything added there, until it overtakes verify.md (128 B of
 // room at this writing) and the bound snaps tighter. Read a widening margin as
 // evidence about the file that shrank, never as room the additions created.
+// The 2026-09-05 go-to-k/cdkd#2571 retro then added ONE rule to verify.md 8-h
+// -- a nit is not a work item, measured over four review rounds -- and paid
+// for it entirely inside 8-h by compressing six neighbouring bullets, landing
+// +113 B net on the LARGEST file. Margin 165 -> 52 B. That confirms the
+// paragraph above from the other side: an addition to the largest file moves
+// the binding bound one-for-one, while the same bytes in the runner-up move it
+// not at all.
 // The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this


### PR DESCRIPTION
## Summary

Retrospective for the go-to-k/cdkd#2571 run (PR go-to-k/cdkd#2592). **One rule**, from the run's own measurement, paid for inside the section it lands in.

### The lesson: a review NIT is not a work item

PR go-to-k/cdkd#2592 took four review rounds, and rounds 1–3 **each found a defect inside the previous round's fix**. The pattern only became legible on the third repetition, and it is not the one the rounds looked like from inside: **every blocker was fixed correctly, and every NEW defect came from implementing a reviewer's low-severity suggestion.**

| Round | Nit | What it produced |
|---|---|---|
| 1 | "no escape hatch for a permanently unresolvable type" | `--allow-undetermined`, which could not reach green — the same `--check` that refuses its output runs on every PR, so a report written past the refusal leaves `main` permanently red |
| 2 | "the classifier does not walk `err.cause`" | a walk whose comment claimed one hop while the code recursed unbounded: a permanent error wrapped two deep was retried, and a two-element cycle threw `RangeError` from inside the retry's catch, discarding a half-hour AWS walk |

Neither addition answered an observation. Both answered a **hypothetical**, which is the tell the new rule names.

What ended it was changing the approach rather than the code: **withdraw** the speculative addition rather than bounding it, and brief the next round to report only demonstrable defects. Round 4 came back clean on both axes, and one reviewer explicitly declined to report a polish observation on the grounds that it was "the class that broke rounds 2 and 3" — the brief reproduced the discipline in the reviewer.

`references/verify.md` §8-h ("Reviewer findings are inputs, not verdicts") is where it fires.

### Paid for in place

The rule is paid for entirely inside §8-h — six neighbouring bullets compressed, **+113 B net**. No cap and no floor is raised; `retro.md` §10-c forbids buying room that way.

### MEASURED, resolved against a peer

A peer retro landed in the same window and grew `implement.md` by 367 B, so `MEASURED` is re-derived against **that** state rather than the one this edit was written on:

```
corpus     171,856      largest  verify.md 27,149      runner-up  implement.md 26,908
binding margin (corpus - runnerUp)   165 B -> 52 B
```

Which confirms the peer's own note from the other side, and the comment now says so: bytes added to the **largest** file move the binding bound one-for-one, while the same bytes in the runner-up move it not at all.

## Test plan

Documentation and rules only; the one code change is the `MEASURED` record the payload fence reads.

- `vp check --fix` — 0 errors
- `vp run typecheck:test` — clean
- `vp run gen:all-matrices` — no drift
- `vp test run` — 883 files / 18510 tests green
- `skill-file-payload`, `rule-file-payload` and `work-issues-skill-refs` all pass; the payload fence drove the compression, failing on each intermediate state until the addition was paid for.
