### PR TITLE
chore: fold the go-to-k/cdkd#2595 run's lessons back, and re-derive two byte bounds

### DIFF
--- a/.claude/rules/session-report.md
+++ b/.claude/rules/session-report.md
@@ -91,6 +91,32 @@ not a rule; the reader takes the cheaper one. Splitting the work across
 several PRs is normal and needs no permission from this list — decide it on
 review surface, and decide `Session-fit` on the criteria above.
 
+**The neighbouring failure: a reason about the FILING SESSION's own STATE
+expires when that session does.** Not a re-opening of the rule above. That one
+refuses a claim about the PULL REQUEST — the work needs its own, or bundling
+would make this one unreviewable. This is a claim about the SESSION that filed
+it — "PR 2519's scope was frozen at its final review round"
+(go-to-k/cdkd#2554), "the file is held by another open PR's diff"
+(go-to-k/cdkd#2604), "the session that found it is a unit-and-review lane with
+no integ run budgeted" (go-to-k/cdkd#2539). A PR can be named on either side,
+so the mention is not the tell — ask which of the two the sentence is ABOUT.
+Session-state clauses are legal and merely go stale, and classify-once does not
+protect them because it freezes the DECISION, not the PREMISE.
+
+So: prefer a reason the WORK owns; if a session-state clause is written anyway,
+name the event that ends it on the same line, and never let it stand alone.
+go-to-k/cdkd#2604's "unblocked the moment that PR merges" is the model — it is
+what lets a later reader see, without asking anyone, that the reason has
+expired. That applies to the "no file overlap" criterion above too, which is a
+claim about a MOVING target: the lane keeps editing after the reason is written
+(go-to-k/cdkd#2440 was deferred on it, and the lane's merged PR then changed
+that very file `+9/-2`). `/work-issues` `references/retro.md` §10-0 re-checks
+every `next` at end of run and has promoted on this shape in two consecutive
+runs (go-to-k/cdkd#2544, go-to-k/cdkd#2595). No vocabulary gate closes it:
+`.claude/hooks/issue-deferral-criteria-gate.sh` passes go-to-k/cdkd#2595's body
+as filed (measured rc=0, versus rc=2 for the same body reworded to "its own PR"
+or "unreviewable"), and its own header rules out chasing one more spelling.
+
 **Before writing `next`, NAME the next session's verification** — the
 concrete command a FRESH session will run, and that it will be able to run
 it. Not "run the integ": the fixture name. If naming it is hard, that is the

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -101,8 +101,8 @@ the trigger is a TS entry point, or several spawns in a case.
 
 - A probe that flips one use of a value proves that ONE use is pinned. PR #2010:
   a banner read `stackUnaddressed` in a guard AND in the interpolated message;
-  the guard-flip probe failed the test, swapping the INTERPOLATION passed all 18
-  — and the fixture's clean stack never entered the warn arm, so its
+  the guard-flip probe failed the test, swapping the INTERPOLATION did not —
+  and the fixture's clean stack never entered the warn arm, so its
   `not.toContain(...)` assertion was unfalsifiable by construction.
 - **Enumerate the value's uses before probing** (`grep` the identifier in the
   changed hunk). One probe per use.
@@ -113,8 +113,23 @@ the trigger is a TS entry point, or several spawns in a case.
   caller PASSES, never what the far side WRITES (hard-coding `'SUCCEEDED'`
   inside `recordRunOutcome` passed all 2261 unit tests). When a value crosses a
   module boundary, one case must exercise the far side unmocked.
-- **Do not report a mutation result you did not run** — the false entry in that
-  PR's mutation table surfaced only because the reviewer re-executed every claim.
+- **Do not report a mutation result you did not run — and a probe that changed
+  TWO things at once is one you did not run.** A false mutation-table entry
+  surfaces only when a reviewer re-executes every claim; nothing else looks. PR
+  #2612 is the harder half, where the probe WAS run: a comment claimed
+  reordering either consumer "reds four cases", but that probe had edited the
+  rendered line's TEXT in the same pass, so the reds attested to the text edit.
+  Re-measured one mutation at a time — each alone green, BOTH reds one case,
+  i.e. the two mechanisms are mutually redundant, the opposite of what the
+  comment said. One mutation per probe, tree restored byte-exact between them.
+- **Give a probe result written into a SOURCE COMMENT the same disposition as a
+  count in published prose** — delete it, fence it, or attribute it as a dated
+  measurement (`.claude/skills/work-issues/references/verify.md` §8-g). Nothing
+  downstream re-checks such a line: PR #2612's wrong claim was on a branch
+  comment beside a destructive confirm prompt, no test could see it, and only
+  the review round stopped it becoming a fence a later editor would trust.
+  What it should have stated is the invariant the two mechanisms jointly
+  enforce, which is re-derivable and cannot go stale.
 
 ## Integration Tests
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -44,6 +44,50 @@ issues the `Agent` calls.
    The same exclusion lives in `.claude/hooks/pr-review-gate.sh`; keep the two
    regexes in sync.)
 
+   **Then gather each touched `src/` file's recent HISTORY in the same pass**
+   — the recent-defect up-bias in step 3 is the one trigger that cannot be read off
+   `paths`, so a step that does not fetch it leaves the trigger to be
+   remembered rather than evaluated. Measured on go-to-k/cdkd#2612: the loop
+   below scores its two `src/` files 2 and 3, and the tier was still raised
+   from standing memory rather than from a query.
+
+   ```bash
+   BASE=$(gh pr view <N> --json baseRefOid -q .baseRefOid)   # NOT plain HEAD --
+   # run on the PR branch, an unanchored log counts the PR's OWN fix-back
+   # commits and a 2-fix-back PR self-trips the bias.
+   git fetch -q origin
+   # The `if` is the point, not the `echo`. baseRefOid can be missing locally
+   # (shallow clone; a base that exists only on the remote), and then `git log`
+   # dies, `|| true` swallows it, and every file prints 0 -- a VOID probe whose
+   # output is character-identical to a clean one. Warning BESIDE the loop does
+   # not fix that; the loop must not run at all.
+   if git rev-parse --verify -q "$BASE^{commit}" >/dev/null; then
+     for f in $(gh pr view <N> --json files -q '.files[].path' | grep -E '^src/'); do
+       # `|| true` because `grep -c` exits 1 when the count is zero.
+       n=$(git log --oneline -3 "$BASE" -- "$f" | grep -cE '^[a-f0-9]+ fix(\(|:)' || true)
+       printf '%s\t%s\n' "$f" "$n"
+     done   # n >= 2 of the last 3 on a file = evaluate the step-3 bias
+   else
+     echo "base $BASE is not local -- history probe VOID, not zero"
+   fi
+   ```
+
+   **That loop is `^src/`-filtered, and for `.claude/**` no prefix count works
+   at all — which is where the stakes are highest.** `commit-prefix-scope-gate`
+   refuses a `feat:` / `fix:` commit that stages no `src/**` file, so an
+   agent-instruction change lands as `chore:` (or `docs:` / `test:`) and scores
+   zero however many times the file has been corrected: measured on this file,
+   whose last five commits carry no `fix:` while the go-to-k/cdkd#2595 run's
+   retro was correcting a gap in text go-to-k/cdkd#2596 had added to it one run
+   earlier. A nonzero is no better, because a commit staging `src/**` AND a
+   `.claude/**` file may carry `fix:` and score the instruction file for a
+   defect that was never in it (`git log --oneline -5 origin/main --
+   .claude/rules/testing.md` returns go-to-k/cdkd#2450, a `fix(state):`).
+
+   So for a `.claude/**` path, read the SUBJECTS rather than a count
+   (`git log --oneline -5 "$BASE" -- "$f"`) and treat consecutive retro /
+   correction commits on the same file as the recency signal.
+
 2. **Base tier** from `(loc, fc)`:
 
    | Condition | Base tier |
@@ -93,9 +137,10 @@ issues the `Agent` calls.
      trigger, not a path list: `pr-review-gate.sh` reads the diff's stats and
      paths plus the BRANCH's own commit subjects, and has no view of the
      edited file's HISTORY — so it cannot see this and may not require the
-     marker. Raise the tier anyway and say why. The tell is
-     `git log --oneline -8 -- <the file>` coming back as consecutive `fix:`
-     commits. Measured on go-to-k/cdkd#2593: the heuristic said `inline`,
+     marker. Raise the tier anyway and say why. Read the tell off the history
+     step 1 gathered — 2 or more `fix:` commits among a touched file's last 3
+     — rather than from what you remember about the area. Measured on
+     go-to-k/cdkd#2593: the heuristic said `inline`,
      while that log on `src/deployment/recreate-targets.ts` showed the two
      preceding merges were both data-loss-guard fixes and the nearer one
      (go-to-k/cdkd#2565) had fixed a fail-open reading in the very function

--- a/.claude/skills/work-issues/references/filing.md
+++ b/.claude/skills/work-issues/references/filing.md
@@ -126,7 +126,7 @@ cat > /tmp/wi-issue-body-<issue-slug>.md <<'BODY' &&
 <one paragraph: the root cause, and where the evidence for it is>
 
 Dup-check: searched open issues for <terms> -- none covers this root cause
-Session-fit: next (not this session) -- <reason>
+Session-fit: next (not this session) -- <reason the WORK owns, not this session's circumstances -- .claude/rules/session-report.md>
 Severity: high -- <what stays broken while it is undone>
 Effort: large (L) -- <which verification cycle it drags>
 Estimate: ~3 h+ -- <what eats the time>

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -67,16 +67,12 @@ rm -f /tmp/run-touched.$$
   of 10, and again across go-to-k/cdkd#2558's two-lane run, every one
   correctly held on scope containment) — a run-wide hit rate is a property of the run's shape, not of
   the deferrals.
-- **Re-read the REASON, not just the files** — classify-once freezes the
-  DECISION, not the PREMISE: "that PR is still open" goes false when it
-  merges, and a `next` kept alive on an expired reason is not protected by
-  classify-once.
-- **When a hit CONTRADICTS the body's own reason, the BODY is the stale side**
-  — a "no file overlap" reason is a claim about a moving target
-  (go-to-k/cdkd#2440 was deferred on "no overlap with this session's lanes";
-  the lane's merged PR changed that very file `+9/-2`). Prefer a reason the
-  lane cannot falsify by carrying on (what the work NEEDS); correct the issue
-  when this check catches one.
+- **Re-read the REASON, not just the files — and when a hit CONTRADICTS it,
+  the BODY is the stale side.** A reason anchored to the filing session's own
+  state goes false while the decision it justified still stands.
+  `.claude/rules/session-report.md` → Session-fit carries the shape, its
+  boundary against the PR-shaped reason that is refused outright rather than
+  merely expiring, and the incident. Correct the issue when this catches one.
 
 Then split the filed count by what the §5-f window did with each finding:
 

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -257,7 +257,7 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // CLAUDE.md is the representative path for session-report.md (the wrap-report
   // field reference split out of CLAUDE.md by the 2026-09-04 token-diet pass);
   // the band is that one satellite's size.
-  ['CLAUDE.md', 10_000, 20_000], // measured 12,483 at registration (session-report.md alone; re-measure on edit)
+  ['CLAUDE.md', 10_000, 20_000], // 12,483 at registration; 15,550 on 2026-09-05 (session-report.md alone; re-measure on edit)
   // The representative path for docs-page-template.md, whose glob is `docs/**`.
   // A plain docs page matches that file and nothing else, so the band is one
   // satellite's size; `docs/_generated/**` additionally pulls layout-scripts.md
@@ -410,11 +410,20 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // literal glob list names are the fence, its suite, and the setup file that
   // installs it, and none of them is named by any other row. Without this the
   // satellite sits under no budget at all. Payload is testing.md + the satellite.
-  ['tests/setup.ts', 46_000, 72_000],                            // measured  64,742
+  ['tests/setup.ts', 48_000, 72_000],                            // measured  48,999 on 2026-09-05 (was 64,742 before the 2026-09-04 compression)
+  // 46_000 -> 48_000 on 2026-09-05: the go-to-k/cdkd#2595 retro added 1,126 B of
+  // mutation-probe rules to `testing.md`, and the discriminate case below went
+  // red exactly as its comment predicts ("testing.md growing spends it from the
+  // other side"). Re-derived, not debugged away: the floor sits between
+  // `testing.md + SUBSTANTIVE_MIN_BYTES` (47,079, the gutting case it must
+  // reject) and the live payload (48,999, which it must accept), and 48_000
+  // splits that 1,920 B band nearly in half -- 921 B of growth room for
+  // `testing.md`, 999 B of shrink room -- rather than sitting 47 B off one
+  // edge as 46_000 had come to.
   // This floor is set by a PROPERTY rather than by the table's usual ~12%-under
   // convention, and `the tests/setup.ts floor still discriminates` below
   // RECOMPUTES that property instead of trusting this number. It must sit above
-  // `testing.md` (61,358 B) plus SUBSTANTIVE_MIN_BYTES, so that gutting
+  // `testing.md` (45,579 B) plus SUBSTANTIVE_MIN_BYTES, so that gutting
   // `test-stream-fence.md` down to the smallest size the `substantive content`
   // case still allows fails HERE. 51_000, 57_000 and 62_000 were each chosen by
   // hand and each failed to add signal: the first two sat below `testing.md`
@@ -1072,10 +1081,11 @@ describe('.claude/rules payload fence', () => {
     // assertion in this file.
     //
     // The usable band is structurally narrow -- `satellite - SUBSTANTIVE_MIN_BYTES`,
-    // which is 1,884 B today -- and `testing.md` growing spends it from the
-    // other side, 641 B of it before this case fires. That is not slack to be
-    // debugged away when it runs out: re-derive the floor, or grow the
-    // satellite so the band widens with it.
+    // which is 1,920 B today -- and `testing.md` growing spends it from the
+    // other side. It ran out on 2026-09-05 exactly as written: a 1,126 B
+    // addition to `testing.md` reddened this case, and the floor was re-derived
+    // 46_000 -> 48_000 in the same commit. That is the prescribed move -- not
+    // slack to be debugged away, and not a reason to shrink the addition.
     const row = PAYLOAD_BUDGETS.find(([path]) => path === 'tests/setup.ts');
     expect(row, 'the tests/setup.ts budget row was removed').toBeDefined();
     const [, floor, cap] = row as readonly [string, number, number];

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,7 +122,7 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_641,
-    corpusBytes: 171_877,
+    corpusBytes: 171_765,
     largest: { file: 'verify.md', bytes: 27_149 },
     runnerUp: { file: 'implement.md', bytes: 26_908 },
   },
@@ -175,6 +175,18 @@ const MIN_REFERENCE_FILES = 6;
 // paragraph above from the other side: an addition to the largest file moves
 // the binding bound one-for-one, while the same bytes in the runner-up move it
 // not at all.
+// The 2026-09-05 go-to-k/cdkd#2595 retro is the first to end NET NEGATIVE here:
+// it added 83 B to filing.md (a hint at the point where a deferral reason is
+// written) and paid by MERGING retro.md's two adjacent stale-reason bullets
+// into one that POINTS at .claude/rules/session-report.md. Note what "points"
+// had to mean: the first attempt kept the incident and the classify-once
+// sentence beside the pointer, which a review round called out as copying
+// rather than moving -- neither phrase now appears in both files (grepped).
+// filing.md 12,870 -> 12,953, retro.md 17,190 -> 16,995; corpus
+// 171,877 -> 171,765; margin 31 -> 143 B. Its other three
+// lessons landed OUTSIDE this corpus on purpose
+// (.claude/rules/{session-report,testing}.md and
+// .claude/skills/review-pr/SKILL.md), which is why they cost it nothing.
 // The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this


### PR DESCRIPTION
Stage 10 of the four-lane `/work-issues` run (go-to-k/cdkd#2514 → go-to-k/cdkd#2519, go-to-k/cdkd#2558 → go-to-k/cdkd#2565, go-to-k/cdkd#2578 + go-to-k/cdkd#2566 → go-to-k/cdkd#2593, go-to-k/cdkd#2595 → go-to-k/cdkd#2612).

Three of the four lessons land OUTSIDE the `/work-issues` corpus, which is why the corpus comes out **smaller** than it went in.

## 1. A deferral reason about the FILING SESSION expires when that session does

`.claude/rules/session-report.md`, `### Session-fit`, immediately after the "No `next` criterion is about the PR" paragraph go-to-k/cdkd#2597 added.

go-to-k/cdkd#2595 was deferred on "the session filing this is stage 10 of a `/work-issues` run on a `chore:` tooling branch; landing a `src/**` behaviour change there would put a product decision inside a skill-corpus PR". That reason died the moment the previous retro PR merged. §10-0's promotion check caught it — for the **second run running** (go-to-k/cdkd#2544 was the first), and both times the expired reason was scoped to the FILING SESSION rather than to the work.

The rule states the boundary — a `next` reason is refused when it is a claim about the PULL REQUEST (needs its own, would make this one unreviewable) and merely goes stale when it is a claim about the SESSION that filed it — and carries ONE model instance: go-to-k/cdkd#2604's "unblocked the moment that PR merges", the shape that lets a later reader check the reason from outside. It deliberately carries no dataset; see the review-round note at the bottom for why.

**A vocabulary gate cannot reach this**, measured rather than assumed: driving `.claude/hooks/issue-deferral-criteria-gate.sh` with go-to-k/cdkd#2595's body as filed returns **rc=0**, against **rc=2** for the same body reworded to "its own PR" or "unreviewable". That hook's own header already rules out chasing one more spelling ("the third spelling in the third round … change INSTRUMENT rather than chase one more phrase"), so this hop is a rule, not a regex.

Paired with a one-clause hint at the point where the reason is actually written: `references/filing.md`'s issue-body template placeholder.

## 2. One mutation per probe

`.claude/rules/testing.md`, amended onto the existing "do not report a mutation result you did not run" bullet rather than added beside it.

A source comment in go-to-k/cdkd#2612 claimed deleting a guard conjunct left the suite green "while REORDERING either consumer reds four cases". The first half held; the second did not — the probe that produced "four" had changed the rendered line's TEXT at the same time as the ordering, so the reds attested to the text edit. Re-measured one mutation at a time: conjunct alone green, reordering alone green, BOTH reds one case. The two mechanisms are mutually redundant, the opposite of what the comment said, and the reviewer found it. It never reached `main` — `da406cac` corrected it pre-squash — and that is the point: no test could see it, and only the review round stopped it becoming a fence a later editor would trust.

Second half of the same lesson: **nothing downstream re-checks a probe result written into a SOURCE COMMENT**, so it earns §8-g's dispositions like any published count — delete it, fence it, or attribute it as a dated measurement.

## 3. The recent-defect up-bias was right and was still evaluated from memory

`.claude/skills/review-pr/SKILL.md`.

go-to-k/cdkd#2596 added a recent-defect up-bias naming `git log --oneline -8 -- <file>` as the tell. It is correct, and it WOULD have fired here — at `16bce9aa~1` the three most recent merges touching `src/deployment/recreate-targets.ts` were go-to-k/cdkd#2593 / go-to-k/cdkd#2565 / go-to-k/cdkd#2519, all `fix:`. But step 1 fetches only `paths`, so nothing puts that history in front of the reader and the tier was raised from standing memory instead. Step 1 now gathers it in the same pass.

The snippet is anchored at `baseRefOid` — run unanchored on the PR branch it counts the PR's OWN fix-back commits, so a two-fix-back PR self-trips the bias — and tolerates `grep -c`'s exit 1 on zero. Plus one thing the previous hop could not have known: **the `fix:` count is blind to `.claude/**`**, because `commit-prefix-scope-gate` refuses a `feat:`/`fix:` commit that stages no `src/**` file, so an agent-instruction change lands as `chore:`/`docs:`/`test:`. Measured on `review-pr/SKILL.md` itself — no `fix:` in its last five commits, while this very PR corrects a gap in text go-to-k/cdkd#2596 added to it one run earlier. For a `.claude/**` path the recency signal is consecutive retro/correction commits, not a prefix count.

## 4. Two findings went to memory rather than into the corpus

- A **new state is applied by default** and must carve out the cases that already have an answer. go-to-k/cdkd#2612 added a "nothing was established" row and immediately handed it to a typed `NoSuchBucket` — a bucket AWS says is gone provably holds nothing. Both an independent code reviewer and an independent security reviewer found it, in the same round; the carve-out was already sitting in the log-group sibling arm forty lines away.
- Appending a `describe` to a long test file can land it **inside an existing comment paragraph** (it split one across 77 lines here). Nothing catches it — the file parses, the suite is green, the diff shows only the addition.

Both are judgement rather than procedure, and both are cross-repo; the corpus is at 143 B of margin and §10-c forbids buying room by raising the floor.

## Paying for it, and two re-derived bounds

Per §10-c, the addition to `references/filing.md` is paid for by **merging `references/retro.md` §10-0's two adjacent stale-reason bullets into one that POINTS at `.claude/rules/session-report.md`** instead of restating it. Corpus 171,877 → 171,765 B; runner-up margin 31 → 143 B (re-derived four times as `main` moved under the review rounds — go-to-k/cdkd#2618 grew `verify.md`, go-to-k/cdkd#2619 edited `filing.md` and set `corpusBytes` itself). The clause the merge would otherwise have dropped — that the blessed "no file overlap" criterion is itself a moving-target premise (go-to-k/cdkd#2440) — moved into the pointed-at text rather than disappearing.

Two byte bounds re-derived, both in the tightening direction and neither to make room:

- `MEASURED.corpusBytes` in `skill-file-payload.test.ts`, per that file's own contract.
- The `tests/setup.ts` payload **FLOOR**, 46_000 → 48_000. The 1,126 B added to `testing.md` reddened `the tests/setup.ts floor still discriminates a GUTTED satellite` exactly as that case's comment predicts ("`testing.md` growing spends it from the other side"). Re-derived, not debugged away: the floor must sit above `testing.md + SUBSTANTIVE_MIN_BYTES` (47,079) and at or below the live payload (48,999); 48_000 splits that 1,920 B band nearly in half instead of sitting 47 B off one edge as 46_000 had come to. Probed: trimming `test-stream-fence.md` to 1,501 B reds two cases; restored byte-exact.

## Acted on, not merely reported

- **go-to-k/cdkd#2615** (this run's own filing): `Session-fit` reason rewritten to the durable one — a maintainer decision between two shapes with opposite costs — plus the next session's verification command. The expiring "the two PRs that touched this code scoped it out twice" clause is gone.
- **go-to-k/cdkd#2604** (another lane's, so commented rather than edited): its named blocker go-to-k/cdkd#2592 has merged, so its reason has expired.

## Mirror hop

The concept already sits in an OPEN issue in both sibling repos (go-to-k/cdk-local#676, go-to-k/cdk-real-drift#1860, both covering "a deferral reason the promotion check contradicts"), and both repos' `references/retro.md` already carries the CHECKING half. Per §10-c the resolution on an open-issue hit is to COMMENT with what this hop adds, not to file a fourth and fifth issue for the same lesson — done in both, each naming the other. What this hop adds there: the FILING-side rule, the enumeration, the name-your-expiry prescription, and the finding that a vocabulary gate cannot reach it. (The first comment carried a count this PR's review rounds disproved; a correction comment withdrawing it is posted on both.)

## Test plan

- `vp run check` (CI parity), `vp run typecheck:test`, `vp run build` — all pass.
- `vp test run` — **885 files / 18,618 passed / 1 skipped**, rc=0, RUN root asserted as this worktree.
- `vp run gen:all-matrices && vp run audit:coverage:check` — clean, nothing regenerated dirty.
- Live-test (tooling PR, per §10-d's command arm): drove `issue-deferral-criteria-gate.sh` for the rc=0/rc=2 claim; executed the `review-pr` step-1 history snippet against go-to-k/cdkd#2612's files; mutation-probed the re-derived floor.
- No AWS surface. Leftover check anyway: **0** `state.json` objects under `s3://cdkd-state-531991745243/cdkd/` (the prefixes that list are `deployments/` event history, which is by design a separate key layout).

## Review

Five independent `pr-code-reviewer` rounds (tier floor for 156 LOC / 7 files is `inline`; agent-instruction files are deliberately not down-biased and a wrong rule here propagates into every future session, so the floor was treated as a floor). Rounds 1-3 each blocked, every time on this change's **evidence** rather than on its rule:

1. a count that was wrong *and* mutated by the same commit (it had rewritten go-to-k/cdkd#2615's `Session-fit` line), plus a stale base;
2. the replacement enumeration was still wrong — go-to-k/cdkd#2521 and go-to-k/cdkd#2582 are the PR-shaped failure the paragraph above already refuses, and the repo's own gate says so (rc=2 for exactly those two across all nine bodies, rc=0 for the rest);
3. three more defects in the same paragraph — an example that falsified its own generalisation, a dangling "the same sweep", and `REVIEW SURFACE` reused two sentences after the paragraph above uses it with the opposite valence.

Three rounds landing in one paragraph is the signal to change instrument, not wording, so the paragraph stopped carrying a dataset. What survives is the rule, the boundary, one model instance and a reproducible gate measurement — all checkable, none of it prevalence. Rounds 4 and 5 found no blocker; their minors and nits are all fixed here, including two overclaims in this PR's own commit message and a `retro.md` bullet that still *restated* what it claimed to point at.
