### PR TITLE
chore: fold the go-to-k/cdkd#2333 run's lessons back into /work-issues

### DIFF
--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -229,7 +229,10 @@ assertion targeted an observable the BROKEN code also produces — a confluence
 point. Name the discriminator first and assert THAT (which client, which
 region, what the second invocation saw); "the happy path still happens" is
 almost never it. A test that still passes under the mutation that motivated
-it is worse than no test.
+it is worse than no test. **And a case pinning "the tool does NOTHING here"
+must record what the input DOES** — one asserted a padded token comes back
+unchanged while that input really runs `git commit`, so a live bypass became
+its own alibi (go-to-k/cdkd#2333).
 
 **A probe that reports NO discrimination is a claim about the FENCE — three
 other things produce identical output.** Ask in order before touching the
@@ -237,20 +240,17 @@ fence: (1) **did the edit land?** (`sed`/`perl` fail silently in ways that
 read as "no match"; prove with `grep -c '<anchor>'` and require exactly 1);
 (2) **does the case's execution path REACH the edited line?** (the fix is a
 case that must take that path, not a fence change); (3) **did the command run
-where you think it did?** (a relative-path edit under a reset cwd lands in
-another worktree, and the confirming `git status` runs in the same wrong
-tree — use absolute paths and confirm by a property the wrong tree cannot
-fake). Plus one fixture shape: **an expected value must be an INDEPENDENT
-variable from the one under test.** Only after all four does "the fence is
-weak" remain.
+where you think it did?** (appendix, "Bash cwd silent reset" — absolute paths,
+and a property the wrong tree cannot fake). Plus one fixture shape: **an
+expected value must be an INDEPENDENT variable from the one under test.** Only
+after all four does "the fence is weak" remain.
 
 **A RED probe is void as easily as a green one** — an anchor matching TWICE
 mutates every copy (the red belongs to a broader change), and an edit that
 does not COMPILE fails the suite at LOAD, indistinguishable from
-discrimination. Read the TALLY and failure TEXT, never the rc — which lies in
-both directions (a suite can `skipIf` itself when `dist/` is absent; a run
-whose every test passes can still exit non-zero, §6's rc rule). A load error
-or a short test count VOIDS the probe.
+discrimination. Read the TALLY and failure TEXT, never the rc — it lies in
+both directions (§6's rc rule; a suite can `skipIf` itself when `dist/` is
+absent). A load error or a short test count VOIDS the probe.
 
 **When you REJECT part of a prescribed fix, make the rejection a PROBE by
 APPLYING it.** The usual probe breaks the code to prove a test discriminates;
@@ -267,9 +267,12 @@ fix probed with a SCALAR secret came back green under its own motivating
 mutation; only a JSON-document secret makes the needle stop occurring. Ask
 what property of the INPUT the defect depends on.
 
-**Publishing a probe MATRIX re-measures it on the tree you are about to
-merge** (`references/verify.md` §8-g); carrying one forward across rounds is
-wrong even when every row was true when written.
+**A probe MATRIX that must recur is a SCRIPT, not a re-measured table** —
+§8-g's "delete the number" disposition. Re-measuring on the merge tree was
+already the rule and a table went stale TWICE in one lane anyway, a reviewer
+catching each; a harness instead PRINTS the tallies and exits non-zero when a
+mutant discriminates nothing, so an inert probe is reported, not assumed
+absent (go-to-k/cdkd#2333, `.claude/hooks/lib/command-match-mutants.sh`).
 
 **A VALUE import from a module other suites `vi.mock` reds those suites** —
 the failure names the EXPORT, reading as a missing symbol rather than a

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -57,13 +57,12 @@ by a probe or a trace, never by re-reading the diff:
   measured in the wrong position is not weak evidence; it is none.
 - **Derive the reader population before patching readers** — one grep returns
   every consumer at once; patching one per round IS the cascade.
-- **A benchmark must exercise the path the change is on** (a lane published
-  "+20% latency" from a run whose input took an early return before the new
-  code; re-measured +0–3%). Confirm the probe reaches the added code, as §5
-  requires of a mutation probe.
-
-**A fix that CLOSES a member falsifies every sentence COUNTING the set**, in
-files the diff never touches — §8-g's COUNT bullet.
+- **A benchmark or COST FENCE must exercise the path the change is on** — a
+  lane published "+20% latency" from a run that early-returned before the new
+  code; go-to-k/cdkd#2333's latency case was vacuous twice, first bailing at a
+  bound, then plateauing because cost is per SEGMENT and the payload had two.
+  Build the payload that was actually EXPENSIVE, and measure the threshold
+  with the fix AND with it deleted.
 
 ### 8-b. Integ ordering vs review rounds and rebases
 
@@ -71,12 +70,9 @@ files the diff never touches — §8-g's COUNT bullet.
 after the final edit you happened to think of. Review nits landing in gate
 scope stale the marker (two real-AWS re-runs on 2026-08-25 alone). Sequence:
 dispatch reviewers → apply EVERY finding including nits → rebase → integ →
-markers.
+markers. `git diff origin/main...HEAD --name-only` against the gate's include
+list says in one command whether anything is still outstanding.
 
-- **Before starting an integ, ask what is still outstanding** — a reviewer
-  still running, an unapplied nit, a coming rebase each stale the marker.
-  `git diff origin/main...HEAD --name-only` against the gate's include list
-  answers it in one command.
 - **A rebase can stale a `hash: diff` marker on its own** — the merge base
   moves, so an incoming change to a file this branch also touches invalidates
   it. Rebase BEFORE the integ; push first so CI runs alongside the integ
@@ -124,10 +120,9 @@ Unit tests passing is necessary but NOT sufficient:
 - **Deletion / DAG-order / state-cleanup change** → unmergeable until an
   integ's **destroy** step completes cleanly (`integ-destroy`, plus
   `integ-broad` for cross-cutting files). Run it via **`/run-integ <name>`**
-  — never raw `cdkd deploy` / `cdkd destroy` from a shell; the skill encodes
-  deploy + update + destroy + orphan verification and records the ledger row.
-  `/pick-integ` chooses the fixture(s) and marks which are maintainer-only —
-  never name one it flagged.
+  — never raw `cdkd` from a shell, CLAUDE.md's rule and why. `/pick-integ`
+  chooses the fixture(s) and marks which are maintainer-only — never name one
+  it flagged.
 - **Non-deletion source change** → still live-test the fixed path end-to-end
   (deploy → the redeploy that reproduced the bug → destroy), fresh fixture or
   `/run-integ` against an existing one.
@@ -261,8 +256,6 @@ a `Monitor` on phase lines AND on log-growth stalling.
   call and read the log's own terminal line. Two nearby traps: a `cd` inside
   the backgrounded compound leaves the parent's `$VAR` unset, and `grep -c`
   exits 1 on a count of zero.
-- **A run blocked before its assertions is not a failing fix** — `/run-integ`'s
-  "Important" section owns that rule and the ledger note it requires.
 
 ### 8-f. Fixture environment prechecks
 
@@ -280,7 +273,8 @@ the same code without it** (on the merits, not availability). When docker is
 required (`integ-local`), verify registry reach FIRST (`docker pull
 hello-world` under a 120s cap) — `docker version` says nothing about registry
 networking. `/run-integ`'s "Important" section owns the hang diagnosis, the
-do-NOT-restart-Docker rule, and what is never yours to spend.
+do-NOT-restart-Docker rule, what is never yours to spend, and the rule that a
+run blocked before its assertions is not a failing fix (with its ledger note).
 
 ### 8-g. Prose claims are verified to the same bar as code
 
@@ -336,6 +330,11 @@ code defects and FIVE false statements in prose. Habits that each caught one:
   rounds have each found a defect inside the last one's fix, the APPROACH
   changes — WITHDRAW the speculative addition rather than bounding it, and
   brief the next round to report only demonstrable defects.
+- **After several rounds, ask whether the change is worth merging AT ALL, and
+  say you are not looking for reassurance** — price the residue in what an
+  adversary pays (go-to-k/cdkd#2333 buys one byte: an 18-byte residue against
+  the 17-byte shape closed, so the incidental case is the purchase). The
+  question returns a merge CONDITION; "any blockers?" cannot.
 - **A reviewer's suggested FIX can be wrong even when its finding is right**
   — derive regexes, bounds and constants from the code that PRODUCES the value
   and probe both directions (go-to-k/cdkd#2052).
@@ -365,14 +364,8 @@ code defects and FIVE false statements in prose. Habits that each caught one:
 shared fixed name — the account may hold the maintainer's production stacks.
 Tear down with `cdkd destroy … --force`, then sweep for orphans it cannot
 reach (auto-created `/aws/lambda/*` log groups, RETAIN resources, Secrets in
-recovery, KMS keys pending deletion). Confirm state is gone:
-
-```bash
-aws s3 ls s3://cdkd-state-$(aws sts get-caller-identity --query Account --output text)/cdkd/
-```
-
-(the `deployments/` events store legitimately survives). If destroy failed or
-left orphans, delete them by direct AWS API call before doing anything else.
+recovery, KMS keys pending deletion), then run CLAUDE.md's post-integ
+leftover check — the `deployments/` events store legitimately survives it.
 
 `/verify-pr` sets `check` + `docs` + `verify-pr`; `/run-integ` sets the
 `integ-*` markers — together they unblock `gh pr merge`.

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -50,11 +50,12 @@ by a probe or a trace, never by re-reading the diff:
   the probes.
 - **When the fix WIDENS what a guard catches, ask what the thing you are
   deleting was actually DOING — and confirm the instrument you measure with
-  probes the POSITION your change acts in** (go-to-k/cdkd#2333, WITHDRAWN
-  after four rounds: the removed quote-behaviour was the only brake on an
-  earlier widening, and the survey returned zero because every probe landed
-  in argument position, never the flag prefix the change acted on). A zero
-  measured in the wrong position is not weak evidence; it is none.
+  probes the POSITION your change acts in** (go-to-k/cdkd#2333's FIRST
+  attempt, withdrawn after four rounds: the removed quote-behaviour was the
+  only brake on an earlier widening, and the survey returned zero because
+  every probe landed in argument position, never the flag prefix the change
+  acted on). A zero measured in the wrong position is not weak evidence; it is
+  none.
 - **Derive the reader population before patching readers** — one grep returns
   every consumer at once; patching one per round IS the cascade.
 - **A benchmark or COST FENCE must exercise the path the change is on** — a
@@ -120,9 +121,9 @@ Unit tests passing is necessary but NOT sufficient:
 - **Deletion / DAG-order / state-cleanup change** → unmergeable until an
   integ's **destroy** step completes cleanly (`integ-destroy`, plus
   `integ-broad` for cross-cutting files). Run it via **`/run-integ <name>`**
-  — never raw `cdkd` from a shell, CLAUDE.md's rule and why. `/pick-integ`
-  chooses the fixture(s) and marks which are maintainer-only — never name one
-  it flagged.
+  — never raw `cdkd deploy` / `cdkd destroy` from a shell (CLAUDE.md carries
+  that rule and why). `/pick-integ` chooses the fixture(s) and marks which are
+  maintainer-only — never name one it flagged.
 - **Non-deletion source change** → still live-test the fixed path end-to-end
   (deploy → the redeploy that reproduced the bug → destroy), fresh fixture or
   `/run-integ` against an existing one.
@@ -308,8 +309,9 @@ code defects and FIVE false statements in prose. Habits that each caught one:
   prose one of three DISPOSITIONS: delete it (preferred — a changelog bullet
   cannot be re-derived, and an enumeration IS its own count), fence it with a
   floor AND a cap from a test that reads the code, or attribute it as a dated,
-  explicitly non-derivable measurement. Recounting fails because a widened set
-  falsifies counters in files the diff never touches (go-to-k/cdkd#2410 /
+  explicitly non-derivable measurement. Recounting fails because a set that
+  GAINS or LOSES a member — a fix closing one counts — falsifies counters in
+  files the diff never touches (go-to-k/cdkd#2410 /
   go-to-k/cdkd#2275, four in one run, every one caught by a reviewer and none
   by the author; go-to-k/cdkd#2519 drifted its per-type lists seven times
   across changelog, docs, PR body and comments, once inside the sentence

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,9 +122,9 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_641,
-    corpusBytes: 172_041,
+    corpusBytes: 172_151,
     largest: { file: 'implement.md', bytes: 27_238 },
-    runnerUp: { file: 'verify.md', bytes: 27_095 },
+    runnerUp: { file: 'verify.md', bytes: 27_205 },
   },
 };
 
@@ -193,9 +193,11 @@ const MIN_REFERENCE_FILES = 6;
 // 8-a duplicated out of 8-g, two CLAUDE.md restatements (the post-integ
 // leftover check, the never-run-raw-cdkd rule), a `/run-integ` pointer 8-e
 // and 8-f both carried, and an appendix restatement of the cwd-reset trap.
-// implement.md 26,908 -> 27,238 and verify.md 27,149 -> 27,095, which SWAPS
-// which of the two is the leader; corpus 171,765 -> 172,041, margin
-// 143 -> 54 B.
+// implement.md 26,908 -> 27,238 and verify.md 27,149 -> 27,205, which SWAPS
+// which of the two is the leader; corpus 171,765 -> 172,151, margin
+// 143 -> 54 B. The margin tracks the LEADER alone, so verify.md's own +56 B
+// cost nothing -- it is the runner-up now, and stays free until it overtakes
+// implement.md (33 B of room).
 // The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,9 +122,9 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_641,
-    corpusBytes: 171_765,
-    largest: { file: 'verify.md', bytes: 27_149 },
-    runnerUp: { file: 'implement.md', bytes: 26_908 },
+    corpusBytes: 172_041,
+    largest: { file: 'implement.md', bytes: 27_238 },
+    runnerUp: { file: 'verify.md', bytes: 27_095 },
   },
 };
 
@@ -187,6 +187,15 @@ const MIN_REFERENCE_FILES = 6;
 // lessons landed OUTSIDE this corpus on purpose
 // (.claude/rules/{session-report,testing}.md and
 // .claude/skills/review-pr/SKILL.md), which is why they cost it nothing.
+// The 2026-09-05 go-to-k/cdkd#2333 retro added four rules (implement.md's
+// probe-matrix and pinned-non-action rules, verify.md's cost-fence and
+// merge-worth rules) and paid ~500 B for them by deleting a cross-reference
+// 8-a duplicated out of 8-g, two CLAUDE.md restatements (the post-integ
+// leftover check, the never-run-raw-cdkd rule), a `/run-integ` pointer 8-e
+// and 8-f both carried, and an appendix restatement of the cwd-reset trap.
+// implement.md 26,908 -> 27,238 and verify.md 27,149 -> 27,095, which SWAPS
+// which of the two is the leader; corpus 171,765 -> 172,041, margin
+// 143 -> 54 B.
 // The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this


### PR DESCRIPTION
## Summary

Stage 10 of the `/work-issues` run that closed go-to-k/cdkd#2333 (PR
go-to-k/cdkd#2626). Four rules, each from an incident the run measured, plus
the byte-record re-derivation `tests/unit/scripts/skill-file-payload.test.ts`
asserts.

**`references/implement.md` §5-e**

1. **A probe MATRIX that must recur is a SCRIPT, not a re-measured table.**
   The rule this replaces already said to re-measure a published matrix on the
   merge tree. It was followed, and the table was still stale TWICE inside one
   lane — first measured before eleven cases landed, then on a 541-case tree
   while the file's own floor said 543, so every published row summed to one
   less than the case count. A reviewer caught it each time. What ended it was
   deleting the numbers and shipping
   `.claude/hooks/lib/command-match-mutants.sh`, which prints them and exits
   non-zero when a mutant discriminates nothing — so a probe gone inert is
   reported rather than assumed absent (it reported exactly that, once, after
   a later fix made one mutant redundant).
2. **A case pinning "the tool does NOTHING here" must record what the input
   DOES.** A `dq_same` case asserted a padded token comes back unchanged
   without recording that the pinned input really runs `git commit`, so a live
   bypass read as expected behaviour.

**`references/verify.md`**

3. **§8-a: a benchmark or COST FENCE must exercise the path the change is
   on.** The wall-clock case was vacuous twice: first its payload bailed at a
   bound after ~17 iterations (0.645 s with all three bounds removed, against
   a 3 s budget), then a second payload plateaued because the cost is per
   SEGMENT and it had two. The rule now says to build the payload that was
   actually expensive and measure the threshold from both sides.
4. **§8-h: after several rounds, ask whether the change is worth merging AT
   ALL, and say you are not looking for reassurance.** Ranked by attacker
   cost, the cheapest residue is 18 bytes against the 17-byte shape closed, so
   the change buys the incidental case rather than the chosen spelling. Asking
   the question that way returned a verdict with a merge condition attached;
   "any blockers?" cannot.

**Dropped as subsumed:** "prefer the edit that DELETES a case over the edit
that adds a budget" — three rounds of blockers all came from adding accounting
(a byte cap, a raised cap, a span exemption) and the converging round removed
it, but §8-a already says "expect the fix to feel like a retreat; it
converges", and a near-duplicate bullet blunts both.

**Paid for by compression, per `references/retro.md` §10-c** (which forbids
buying room by raising the byte bound): a cross-reference §8-a duplicated out
of §8-g, two CLAUDE.md restatements (the post-integ leftover check, the
never-run-raw-`cdkd` rule), a `/run-integ` pointer §8-e and §8-f both carried,
and an appendix restatement of the cwd-reset trap. Net corpus +386 B;
implement.md and verify.md swap leader, so `MEASURED` and the derivation
comment beside `MIN_REFERENCE_CORPUS_BYTES` are re-derived (margin 143 -> 54
B, and the comment now says why verify.md's own growth cost zero).

Second commit is this PR's own self-review: the §8-a line deleted as a
duplicate was NOT one — it covered the set SHRINKING while §8-g covered only a
widened set — so §8-g now carries both directions; §8-a's go-to-k/cdkd#2333
citation read as if the ISSUE was withdrawn rather than its first attempt; and
one compression had widened "never raw `cdkd deploy` / `cdkd destroy`" into
"never raw `cdkd`", forbidding read-only commands.

## Backlog effect

`closed 1 / filed 2 (new 2 / folded 0)`. Net +1, and honestly so: the issue
worked was a hook-parser bug whose fix audited the shared matcher's readers,
and that audit is what produced both follow-ups — go-to-k/cdkd#2605 (the
false-refusal survey has no READ-VERB shape, so its zero cannot see the class
that withdrew the first attempt) and go-to-k/cdkd#2614
(`main-tree-edit-gate.sh` parses its own `cd` and misses a quoted command
word). Both carry the four classification fields and a `Dup-check:` line. The
§10-0 promotion check hits on both — each body cites files PR
go-to-k/cdkd#2626 touched — and both are citations rather than targets: their
subjects (`false-refusal-survey.sh`, `main-tree-edit-gate.sh`) are untouched
by the run, and each reason is stated as what the work NEEDS (a full
re-measurement pass; its own before/after against a real main checkout) rather
than as a no-overlap claim the lane could falsify by carrying on. Both held at
`Session-fit: next`.

## Test plan

- `vp check --fix` + `vp run check` + `vp run typecheck:test` + `vp run build`
  — clean.
- `vp test run` — 885 files / 18,629 tests pass, rooted in this worktree. (An
  intermediate run had 11 failures across 4 tree-scanning suites at load
  average 26; all four passed in isolation and the re-run was green — the
  host-load artifact `references/gates-and-pr.md` §6 describes.)
- `vp run gen:all-matrices` + `vp run audit:coverage:check` — no generated
  artifact dirty.
- Prose live-test (§8-c's prose arm): every gate, path, skill and section this
  text names resolved against the tree — `/run-integ`'s "Important" section
  really owns the blocked-run rule (`SKILL.md:322` / `:330`), §8-g really
  carries the "delete it (preferred)" disposition, gotchas.md really carries
  the `bash cwd silent reset` entry, §6 really carries the "all green is the
  EXIT CODE" rule, and CLAUDE.md really carries both restated rules.
- `bash .claude/hooks/lib/command-match-mutants.sh` — rc=0, all ten mutants
  reduced the pass count against an unmutated 545, which is the behaviour the
  new rule describes; the non-zero arm is read off the script's own exit
  logic.
- `tests/unit/scripts/{skill-file-payload,work-issues-skill-refs,work-issues-launch-mode,verification-depth-rule}.test.ts`
  — 127 pass.
