### PR TITLE
chore: fold the go-to-k/cdkd#2607 / go-to-k/cdkd#2620 run's lessons back into /work-issues

### DIFF
--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -366,10 +366,12 @@ verify, clean up.
   daemon came back ~40 min later untouched (second instance; the first cost
   ~2 h on 2026-09-03/04 with the same signature). Say so in the report rather
   than spending the run on restarts, and do not pipe the waiting probe through
-  `tail` — that buffers away the progress lines that would show it advancing. Ask the maintainer rather than escalating — a
-  factory reset or deleting Docker data destroys local images and volumes,
-  never yours to spend. Clean up your own probes (`kill`ing a `docker pull`
-  wrapper leaves the `com.docker.cli` child running).
+  `tail` — that buffers away the progress lines that would show it advancing.
+
+  Ask the maintainer rather than escalating — a factory reset or deleting
+  Docker data destroys local images and volumes, never yours to spend. Clean
+  up your own probes (`kill`ing a `docker pull` wrapper leaves the
+  `com.docker.cli` child running).
 - **A fixture that discards the CLI's stderr cannot report its own failure.**
   `RESULT=$(${CDKD} ... 2>/dev/null | tail -1)` under `set -euo pipefail`
   prints the arm header and exits 1 with NO error text, so re-run the failing

--- a/.claude/skills/run-integ/SKILL.md
+++ b/.claude/skills/run-integ/SKILL.md
@@ -344,18 +344,38 @@ verify, clean up.
   the daemon routes registry traffic through a proxy the Desktop APP serves,
   and a quit-and-reopen can leave the
   self-respawning backend up while the app never finishes launching (four
-  consecutive hung pulls; only a manual app restart recovered). Diagnose in
-  order, stopping at the first line that explains the symptom:
+  consecutive hung pulls; only a manual app restart recovered). Three paths
+  fail INDEPENDENTLY — host networking, container networking, and the daemon's
+  own pull path, which egresses differently from container traffic — so name
+  which one is down before touching anything:
 
   ```bash
   curl -s -o /dev/null -w '%{http_code}\n' --max-time 15 https://registry-1.docker.io/v2/  # 401 = HOST networking fine
+  docker run --rm --entrypoint curl <an already-cached image> -s -o /dev/null \
+    -w '%{http_code}\n' --max-time 15 https://registry-1.docker.io/v2/   # 401 = CONTAINER networking fine
+  docker pull hello-world                         # hangs while both 401s return = DAEMON pull path only
   docker info 2>/dev/null | grep -i proxy         # the proxy the daemon depends on
   pgrep -f 'Docker Desktop' >/dev/null && echo app-running || echo APP-NOT-RUNNING
   ```
 
-  Ask the maintainer rather than escalating — a factory reset or deleting
-  Docker data destroys local images and volumes, never yours to spend. Clean
-  up your own probes (`kill`ing a `docker pull` wrapper leaves the
-  `com.docker.cli` child running).
+  **On that third signature, WAIT — it recovers on its own and a restart does
+  not fix it.** Measured 2026-09-05: both curls returned 401 in 0.35 s while
+  every `docker pull` hung indefinitely, including an 8 KB already-cached
+  image, with nothing written to `dockerd.log`; killing both
+  `com.docker.backend` processes and relaunching changed nothing, and the
+  daemon came back ~40 min later untouched (second instance; the first cost
+  ~2 h on 2026-09-03/04 with the same signature). Say so in the report rather
+  than spending the run on restarts, and do not pipe the waiting probe through
+  `tail` — that buffers away the progress lines that would show it advancing. Ask the maintainer rather than escalating — a
+  factory reset or deleting Docker data destroys local images and volumes,
+  never yours to spend. Clean up your own probes (`kill`ing a `docker pull`
+  wrapper leaves the `com.docker.cli` child running).
+- **A fixture that discards the CLI's stderr cannot report its own failure.**
+  `RESULT=$(${CDKD} ... 2>/dev/null | tail -1)` under `set -euo pipefail`
+  prints the arm header and exits 1 with NO error text, so re-run the failing
+  command with stderr attached BEFORE concluding anything about the change
+  under test (2026-09-05: `local-invoke-agentcore`'s `verify.sh:59` rendered a
+  pre-existing synth break — go-to-k/cdkd#2191 — as "the PR under review is
+  swallowing its own errors", and that fixture gates `integ-local`).
 - **Never bypass this skill** with direct `cdkd deploy` / `cdkd destroy` —
   the orphan-cleanup contract is part of the test, not optional.

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -198,8 +198,12 @@ Run each check and report pass/fail:
      a TEST rewrite counts (PR #2420: a round-2 fix replacing a crude
      assertion with a derived one dropped a wire fact the crude form had been
      pinning by accident — only a third round found it). When a round
-     REPLACES an assertion rather than adding one, ask what the old one was
-     pinning.
+     REPLACES an assertion rather than adding one, KEEP BOTH unless you can
+     NAME, in the commit message, the mutation the old one could not catch.
+     "More precise" is not that name: precision is not a superset of what it
+     replaces, and if you cannot name the mutation the replacement is a
+     deletion (issue #2606: four rounds on one PR, each fix blind on a
+     different axis than the assertion it dropped, every one measured green).
    - Corollary for mutation probes: **enumerate the branches the diff ADDS
      and probe each one** — a new `if`, a new token in a rendered string, a
      new early return and a new gate condition are four probes, not one.

--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -2,20 +2,10 @@
 
 ## 6. Gates + PR (per lane)
 
-**Before the session's FIRST commit, prove the gates are ALIVE.** Registration
-is not execution: both siblings spent a day with every gate registered and
-INERT (go-to-k/cdk-real-drift#1801), and an ungated commit looks exactly like
-one that passed. `/hooks` lists what is REGISTERED, so it cannot see this:
-
-```bash
-git commit --dry-run -m "gate liveness probe"   # from the repo root, on main
-```
-
-Run it as YOUR OWN Bash tool call — PreToolUse hooks gate the agent's tool
-calls only. `--dry-run` commits nothing whatever the tree looks like.
-Expected: `Blocked by branch-gate` or `Blocked by check-gate`. Git's ordinary
-output means the gates are NOT firing — every gate step below is then
-self-enforced: run each check by hand and say so in the report.
+**Before the session's FIRST commit, run CLAUDE.md's gate-liveness probe** —
+`git commit --dry-run -m "gate liveness probe"` as your OWN Bash tool call.
+Git's ordinary output means the gates are NOT firing, and every gate step
+below is then self-enforced: run each check by hand and say so in the report.
 
 From inside the worktree, run the local quality checks and record the markers:
 

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -19,14 +19,10 @@
   and say why in the claim (go-to-k/cdkd#1791 passed every §2/§3 gate, was
   claimed, and had to be retracted — nothing but a grep stood between the run
   and the fixture arm its body had already named).
-- **A cross-repo framing spends the deferral budget up front.** When the user
-  says "do this across the repos in one session", `Session-fit: next` is no
-  longer available for anything discovered inside that scope. Three tells make
-  it unarguable: filing the SAME issue body in more than one repo; a
-  mechanical fix whose evidence is live right now; the user already said
-  "finish it here" (measured 2026-08-20: a three-repo run filed the residual
-  gap as three per-repo issues and had to carry them in-session once the user
-  objected). Same session is the bar; same PR only when reviewable together.
+- **A cross-repo framing spends the deferral budget up front.** Inside a "do
+  this across the repos in one session" scope, `Session-fit: next` is off the
+  menu for anything discovered there; `.claude/rules/session-report.md` →
+  Session-fit carries the three tells and the 2026-08-20 measurement.
 - **A mirror issue may already be carried elsewhere** — resolve against the
   file, open PRs and open issues before filing (§10-c) or claiming (§3).
 - **One lane per cross-cutting file.** §2 holds the list; this bullet does not
@@ -113,14 +109,7 @@
   are not follow-ups. (`CLAUDE.md` → Workflow Rules.)
 - **Classify every deferral `now` / `next` the moment you defer it** — write
   the four classification lines into the issue body, one field per line, per
-  `CLAUDE.md` → "The four TODO fields":
-
-  ```text
-  Session-fit: now (do it in this session) | next (not this session) — <reason>
-  Severity: high | medium | low — <what stays broken while it is undone>
-  Effort: small (S) | medium (M) | large (L) — <which verification cycle it drags>
-  Estimate: <duration, e.g. ~1-3 h -- never a bare letter> — <what eats the time>
-  ```
+  `CLAUDE.md` → "The four TODO fields" (shape and spellings live there).
 
   The report repeats those four and adds `Notes`; the issue body carries
   `Dup-check:` (§5-f) instead. **After a lane merges, `next` is the default**
@@ -134,25 +123,16 @@
   become right for the wrong reason (go-to-k/cdkd#2321 / go-to-k/cdkd#2322).
   Ask the worktree question at FILING time; a separate PR from the same open
   worktree is cheap, and is not what `next` is for.
-
-  Close the run with the **not-this-session line** — decision first, then the
-  literal command (`Not this session — start a fresh session with:
-  /work-issues`), no condition attached ("after lane C merges" collapses
-  waiting and handing-off), and keep `next` items off the State line. A `now`
-  found mid-run is a commitment: Remaining work says what you are about to do,
-  the State line is never STOPPED while it is open, the verdict is NOT
-  CLOSEABLE naming it. A final report can only list `next` items and
-  won't-dos.
 - **This flow parks a LOT, so the State line carries most of its weight.** A
   fan-out run spends most wall-clock parked (lane subagents, `gh pr checks
-  --watch`, `/run-integ`) — every one is **WAITING**, not
-  STOPPED: name the lane and the signal per line. Report **STOPPED** only when
-  every lane is merged and nothing is pending. **ARM the signal BEFORE you
-  write the line** — a named signal is not an armed one; the poll, `Monitor`
-  or backgrounded `until` loop is what actually resumes the run (measured: a
-  run wrote `WAITING — Signal: gh pr checks`, armed nothing, and simply
-  ended).
+  --watch`, `/run-integ`) — every one is **WAITING**, not STOPPED: one line
+  per lane, naming the lane and its signal. STOPPED only when every lane is
+  merged. **ARM the signal BEFORE you write the line** (measured: a run wrote
+  `WAITING — Signal: gh pr checks`, armed nothing, and simply ended).
 - **A lane needing a user decision goes through `AskUserQuestion`, never
   prose** — a prose question ends the turn as STOPPED and loses the other
-  lanes' momentum. Everything else (which integ, how many reviewers, how deep
+  lanes' momentum. That prompt is CHAT, not a published artifact, so it goes
+  in the USER's language — CLAUDE.md's English-only rule already draws that
+  line and was over-applied anyway (the go-to-k/cdkd#2522 decision,
+  2026-09-05). Everything else (which integ, how many reviewers, how deep
   to verify) you decide yourself and report as a decision.

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -48,6 +48,14 @@ cat "$(git rev-parse --git-dir)/session-owner" 2>/dev/null   # owner sentinel
 Then read the issue thread for a claim naming this branch — across clones it
 is the only signal the probes above cannot see.
 
+The rule is SYMMETRIC: **the orchestrator does not edit a live lane's tree
+either.** An uncommitted parent edit there is wiped without a trace by the
+lane's next amend + force-push — the lane never sees it and no conflict is
+reported (measured 2026-09-05: a parent-side `.claude/rules` trim vanished
+into go-to-k/cdkd#2620's fix round, and both parties were trimming the same
+cumulative budget). Hand the edit to the lane as an instruction and let the
+lane own the write.
+
 **Take a fresh branch here — ALWAYS, and WITHOUT leaving the tree.** The
 branch this tree arrived on is `LAUNCH_BRANCH`: the OUTER TOOL's, not this
 run's, and §9 puts it back untouched at the end (`references/launch-mode.md`

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -84,6 +84,15 @@ Two rules:
 - **Re-read the claim thread at each checkpoint** — before the first edit,
   before the push, and before opening the PR.
 
+**File-disjoint lanes are not BUDGET-disjoint.** A cumulative cap (the
+`.claude/rules` corpus ceiling; any tree-wide SUM) is spent by every lane at
+once and no probe above sees it, so measure the headroom HERE against
+`CORPUS_BYTES_MAX` in `tests/unit/scripts/rule-file-payload.test.ts`, and drop
+a candidate whose fix must GROW it by more than is left — funding one out of
+another lane's bytes is what the fence's own message forbids (measured
+2026-09-05: 247 B, which left go-to-k/cdkd#2599 unfundable in the run that
+made it stale).
+
 **Treat any `origin/*` branch pushed within roughly the last hour as a LIVE
 lane, whatever its PR state**, and read what it owns first:
 `git diff --stat origin/main...origin/<recent-branch>` (a branch pushed four

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -33,7 +33,17 @@ by a probe or a trace, never by re-reading the diff:
   cell is not random — a hazard lives there BECAUSE that cell behaves
   differently, which is why "a representative case per dimension" skips it
   (go-to-k/cdkd#2466: 4 positions × 2 YAML readers, the `<<` merge key in the
-  missing cell, the fix inert through a full 3-axis round).
+  missing cell, the fix inert through a full 3-axis round). **The POPULATION
+  is one of those dimensions** — a fence that derives its subject list from
+  one directory is blind to the same claim restated outside it, so ask where
+  the claim is WRITTEN and not only where it is implemented
+  (`tests/unit/cli/local-state-source.test.ts` walks `src/` alone, so
+  `.claude/rules/layout-local.md` still named the DELETED fork's
+  CloudFormation API — the exact defect go-to-k/cdkd#2527 was closing, caught
+  only because a reviewer was pointed at the rules delta; same shape in
+  `tests/unit/local/docker-argv-redaction-fence.test.ts`, whose
+  `readdirSync('src/local')` cannot reach go-to-k/cdkd#2623's `src/assets/**`
+  sites).
 - **"TWO SPELLINGS of one question" → make both sites use ONE predicate
   verbatim** — a better second spelling looks like a fix and passes its own
   test (go-to-k/cdkd#2134: `producerRegion !== undefined` disagreed with the

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,9 +122,9 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_641,
-    corpusBytes: 172_151,
-    largest: { file: 'implement.md', bytes: 27_238 },
-    runnerUp: { file: 'verify.md', bytes: 27_205 },
+    corpusBytes: 172_303,
+    largest: { file: 'verify.md', bytes: 27_876 },
+    runnerUp: { file: 'implement.md', bytes: 27_713 },
   },
 };
 
@@ -198,6 +198,20 @@ const MIN_REFERENCE_FILES = 6;
 // 143 -> 54 B. The margin tracks the LEADER alone, so verify.md's own +56 B
 // cost nothing -- it is the runner-up now, and stays free until it overtakes
 // implement.md (33 B of room).
+// The 2026-09-05 go-to-k/cdkd#2607 / go-to-k/cdkd#2620 retro added four rules
+// here (triage.md's budget-disjointness rule, implement.md's orchestrator-side
+// tree rule, verify.md's fence-POPULATION rider, gotchas.md's chat-language
+// rider) costing 1,904 B, and paid 1,752 B of it by deleting five passages
+// that only RESTATED CLAUDE.md or .claude/rules/session-report.md and now
+// point at them instead: gates-and-pr.md's gate-liveness probe, plus
+// gotchas.md's four-field template, not-this-session paragraph, WAITING
+// narrative and cross-repo-framing bullet. Corpus 172,151 -> 172,303 (+152 net
+// for four rules), verify.md 27,205 -> 27,876 takes the lead back from
+// implement.md 27,238 -> 27,713, and the margin goes 54 -> 410 B. The leader
+// swap is why implement.md's +475 B was free: an addition to the RUNNER-UP
+// does not move `corpus - runnerUp` at all, and neither does trimming the
+// leader below it, so every byte of the payment had to come from the other
+// eight files.
 // The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this


### PR DESCRIPTION
## Summary

Stage 10 of the `/work-issues` run that merged go-to-k/cdkd#2607 (six `cdkd local`
command-shim issues in one PR) and go-to-k/cdkd#2620 (the `docker run` argv
redaction). Six amendments, each with its concrete instance attached, landed in
the step where each one fires.

- **`references/triage.md` §2 — file-disjoint lanes are not BUDGET-disjoint.**
  A cumulative cap is spent by every lane at once and no file-overlap probe in
  §2 can see it, so the headroom gets measured at triage rather than discovered
  at a red check. Measured 2026-09-05: the `.claude/rules` corpus sat at
  889,753 B against a 890,000 B ceiling — **247 B** — which is why
  go-to-k/cdkd#2599's rules corrections could not be funded by the very run that
  made them stale, and why the go-to-k/cdkd#2620 lane spent three review rounds
  trimming a 7.7 KB satellite down to 2.2 KB.
- **`references/implement.md` §5-a — the ownership rule is SYMMETRIC.** §5-a
  already told a lane to confirm a tree is its own; it said nothing about the
  orchestrator. An uncommitted parent-side edit in a live lane's tree is wiped
  by the lane's next amend + force-push, with no conflict reported to either
  side. That happened here: a parent-side `.claude/rules` trim vanished into
  go-to-k/cdkd#2620's fix round while both parties were trimming the same
  cumulative budget.
- **`references/verify.md` §8-a — the POPULATION is a dimension of a fence's
  claim.** Folded onto the existing cross-product bullet rather than added
  beside it. Two instances in this one run: `tests/unit/cli/local-state-source.test.ts`
  derives its subject list from `src/` alone, so `.claude/rules/layout-local.md`
  still named the DELETED fork's CloudFormation API — the exact defect
  go-to-k/cdkd#2527 was closing — and it was caught only because a reviewer was
  pointed at the rules delta specifically; and
  `tests/unit/local/docker-argv-redaction-fence.test.ts` derives its module list
  from `readdirSync('src/local')`, so go-to-k/cdkd#2623's `src/assets/**` sites
  can never be caught by it.
- **`references/gotchas.md` — an `AskUserQuestion` prompt is CHAT.** It goes in
  the user's language. CLAUDE.md already draws that line ("the line is whether
  the text becomes PUBLIC") and it was over-applied anyway on the
  go-to-k/cdkd#2522 decision, so the fix is a clause plus a pointer, not a
  second copy of the rule.
- **`/verify-pr` step 8 — a fix round that REPLACES an assertion.** The step
  already said "ask what the old one was pinning", and this run violated it in
  both lanes: four consecutive rounds in one, and a round-6 bounded replacement
  in the other that leaked 272 of 288 probe shapes. A question with no failure
  mode is not load-bearing, so it now demands a NAMED mutation in the commit
  message and keeps both assertions otherwise. Closes go-to-k/cdkd#2606.
- **`/run-integ` — two Docker/fixture corrections.** The existing text implied a
  manual app restart is the remedy; this run measured the opposite signature —
  host curl and container curl both 401 in 0.35 s while every `docker pull` hung
  including an 8 KB cached image, nothing in `dockerd.log`, killing both
  `com.docker.backend` processes changing nothing, and self-recovery ~40 min
  later (second instance; the first cost ~2 h on 2026-09-03/04). The three
  failure paths are now discriminated with a probe each. Separately: a fixture
  that discards the CLI's stderr cannot report its own failure —
  `local-invoke-agentcore`'s `verify.sh:59` runs the invoke as
  `$(... 2>/dev/null | tail -1)`, so a pre-existing synth break
  (go-to-k/cdkd#2191) printed only the arm header and exited 1, and read as
  "the PR under review is swallowing its own errors".

## What was paid for the bytes

The four in-corpus rules cost **1,904 B**, and **1,752 B** of that was paid by
deleting five passages that only RESTATED `CLAUDE.md` or
`.claude/rules/session-report.md` and now point at them instead: the
gate-liveness probe in `gates-and-pr.md`, plus `gotchas.md`'s four-field
template, not-this-session paragraph, WAITING narrative and cross-repo-framing
bullet. Net **+152 B** for four rules.

**No byte cap or corpus floor was raised** — `retro.md` §10-c forbids it, and
`MIN_REFERENCE_CORPUS_BYTES` stays at 145,000. `MEASURED` in
`skill-file-payload.test.ts` is re-derived from the tree (corpus
172,151 → 172,303; `verify.md` takes the lead back from `implement.md`), and the
binding margin widens **54 → 410 B**. The leader swap is why `implement.md`'s
+475 B was free: an addition to the RUNNER-UP does not move `corpus - runnerUp`
at all, so every byte of the payment had to come from the other eight files.

## Claims that did NOT survive verification

Two of the run's own summaries were wrong and are corrected rather than carried
forward:

1. `.claude/rules/layout-local.md` was reported as still carrying the deleted
   fork's `DescribeStackResources` wire mapping. It does not — `fb80c0b1`
   (go-to-k/cdkd#2607) corrected it, along with `layout-scripts.md`, so three of
   go-to-k/cdkd#2599's five statements are already fixed on `main`. The lesson
   survives because the FENCE that should have caught it still cannot; only a
   reviewer did.
2. The `.claude/rules` headroom was reported as ~2.6 KB. It is 247 B — a
   parallel lane spent the difference between the two measurements, which is the
   budget-disjointness lesson demonstrating itself.

## Promotion check (retro §10-0)

Five issues filed and left open by this run: go-to-k/cdkd#2599, go-to-k/cdkd#2600,
go-to-k/cdkd#2602, go-to-k/cdkd#2606, go-to-k/cdkd#2623. The mechanical criterion
fires on four of the five, which is a property of a run whose own PRs are the
follow-ups' subject, so each was judged on its REASON:

- go-to-k/cdkd#2606 — **promoted and done here.**
- go-to-k/cdkd#2599 — the stated reason (a parallel lane owned `.claude/rules/**`)
  was FALSE and is corrected in a comment on the issue, together with the three
  statements that genuinely remain and the measured 247 B blocker that replaces it.
- go-to-k/cdkd#2623 — held at `next`; the half of its reason about raising a live
  PR's review tier has expired and is retired in a comment, the `src/assets/**`
  scope half stands, and its evidence is a file:line code read preserved verbatim
  in the body.
- go-to-k/cdkd#2600 / go-to-k/cdkd#2602 — both blocked on upstream `cdk-local`
  work; reasons hold unchanged.

## Mirror (retro section 10-c)

Lessons 1-5 are FLOW lessons, so they are owed to the two sibling repos. Neither
carries any of them (`git grep` over each repo's `origin/main`
`.claude/skills/work-issues/`, plus their open PRs and open issues — the two
standing mirror issues there are for the 2026-09-02 and 2026-09-04 cdkd runs, and
cdk-local's open port PR go-to-k/cdk-local#702 carries none of these six). Filed
into both in one turn, cross-linked, each naming this PR:
go-to-k/cdk-local#705 (six, including the two `/run-integ` Docker items) and
go-to-k/cdk-real-drift#1885 (five — that repo has no `/run-integ` skill, so the
Docker pair is recorded there as not-applicable rather than mirrored onward).
Each issue tells the taking session to re-resolve every gate name, path and byte
bound against its own repo before writing anything.

## Test plan

- `vp check --fix` + `vp run check`: 0 errors (10 pre-existing warnings);
  `vp run typecheck:test`, `vp run build`, `vp run gen:all-matrices`,
  `vp run audit:coverage:check` all clean with nothing left dirty.
- `vp test run`: **888 files / 18,740 tests passed**, run root asserted equal to
  this worktree.
- `tests/unit/scripts/skill-file-payload.test.ts` — `MEASURED` re-derived; the
  corpus floor property re-established by compression, not by moving the floor.
- `tests/unit/scripts/work-issues-skill-refs.test.ts` — every new citation is
  fully qualified (`go-to-k/cdkd#N`), as these files are a mirror source.
- `tests/unit/scripts/verification-depth-rule.test.ts` — green; the `/run-integ`
  edit adds no cost-downscaling wording.
- Live test, tooling-only prose arm (retro §10-d): every path and command the new
  text names was executed or resolved against this tree —
  `git commit --dry-run -m "gate liveness probe"` returned
  `Blocked by check-gate`, `CORPUS_BYTES_MAX` was read out of
  `rule-file-payload.test.ts:661`, `local-state-source.test.ts`'s population was
  confirmed to be `srcFiles(SRC)`, `docker-argv-redaction-fence.test.ts:71`'s
  `readdirSync(join(REPO_ROOT, 'src', 'local'))` was read, and
  `local-invoke-agentcore/verify.sh:59` was confirmed to be
  `$(... 2>/dev/null | tail -1)`.
- No AWS work in this stage; the account's `cdkd/` prefixes were spot-checked and
  the run-adjacent ones hold only `deployments/**` records from August, which
  `cdkd destroy` deliberately does not remove.

Closes go-to-k/cdkd#2606
