### PR TITLE
chore(hooks): ci-green-gate advised polling for a value gh never returns

### DIFF
--- a/.claude/hooks/ci-green-gate.sh
+++ b/.claude/hooks/ci-green-gate.sh
@@ -143,9 +143,19 @@ while check-build-test was red; main stayed red until fix-forward
 it returns at once instead of waiting for them to appear, so wrapping
 it in a retry loop just spins. Poll until checks EXIST, then watch:
 
-  gh pr checks ${pr_number:-<PR>} --json name,state   # [] = not registered yet
+  # Wait for the FIRST row. The discriminator is an EMPTY stdout, not the
+  # exit code: rc=1 means EITHER "no checks reported" OR "a check failed".
+  until [ -n "$(gh pr checks ${pr_number:-<PR>} 2>/dev/null)" ]; do sleep 20; done
   gh pr checks ${pr_number:-<PR>} --watch             # once a row exists
   # merge only after every check reports pass/skipping
+
+  # Measured 2026-09-06 (gh 2.89), all four states:
+  #   no checks reported  rc=1  stdout 0 bytes   message on STDERR
+  #   a check FAILED      rc=1  stdout non-empty
+  #   still running       rc=8  stdout non-empty
+  #   all pass            rc=0  stdout non-empty
+  # So `--json name,state` buys nothing here (it is 0 bytes in the same
+  # case), and polling on rc alone spins forever on a genuinely failing PR.
 
 If this repo genuinely has no CI, bypass explicitly:
   CDKD_SKIP_CI_GREEN_GATE=1 gh pr merge ${pr_number:-<PR>} --squash --delete-branch

--- a/.claude/hooks/ci-green-gate.sh
+++ b/.claude/hooks/ci-green-gate.sh
@@ -145,7 +145,12 @@ it in a retry loop just spins. Poll until checks EXIST, then watch:
 
   # Wait for the FIRST row. The discriminator is an EMPTY stdout, not the
   # exit code: rc=1 means EITHER "no checks reported" OR "a check failed".
-  until [ -n "$(gh pr checks ${pr_number:-<PR>} 2>/dev/null)" ]; do sleep 20; done
+  while :; do
+    out=\$(gh pr checks ${pr_number:-<PR>} 2>/dev/null); rc=\$?
+    [ -n "\$out" ] && break        # rows exist -- --watch can take over
+    [ "\$rc" = 1 ] || { echo "gh pr checks failed (rc=\$rc)"; break; }
+    sleep 20
+  done
   gh pr checks ${pr_number:-<PR>} --watch             # once a row exists
   # merge only after every check reports pass/skipping
 
@@ -154,7 +159,7 @@ it in a retry loop just spins. Poll until checks EXIST, then watch:
   #   a check FAILED      rc=1  stdout non-empty
   #   still running       rc=8  stdout non-empty
   #   all pass            rc=0  stdout non-empty
-  # So `--json name,state` buys nothing here (it is 0 bytes in the same
+  # So \`--json name,state\` buys nothing here (it is 0 bytes in the same
   # case), and polling on rc alone spins forever on a genuinely failing PR.
 
 If this repo genuinely has no CI, bypass explicitly:

--- a/.claude/hooks/ci-green-gate.test.sh
+++ b/.claude/hooks/ci-green-gate.test.sh
@@ -102,8 +102,12 @@ run_case "quoted body in echo" one-fail "echo \"next step: gh pr merge 123\"" 0
 # The retired text told the agent to poll `gh pr checks --json name,state`
 # until it returned something other than `[]`. `gh` never returns `[]`: with no
 # checks it exits 1 with an EMPTY stdout and a message on stderr. Measured
-# 2026-09-06 (gh 2.89) across all four states, which is what the shim above
-# models:
+# 2026-09-06 (gh 2.89) across all four states. The `no-checks`, `one-fail`,
+# `pending` and `all-pass` fixtures above match those measurements; nothing
+# here claims the shim is faithful in EVERY respect (`with-skipping`'s rc is
+# unverified, and a live PR's rc moves as its checks progress — two readings of
+# the same PR minutes apart disagreed). The four that the cases below depend on
+# are the ones that were measured:
 #
 #   no checks reported  rc=1  stdout 0 bytes   message on STDERR
 #   a check FAILED      rc=1  stdout non-empty
@@ -113,6 +117,38 @@ run_case "quoted body in echo" one-fail "echo \"next step: gh pr merge 123\"" 0
 # So rc=1 is AMBIGUOUS and the discriminator is the empty stdout. These cases
 # run the advised predicate itself against the shim, rather than asserting the
 # message's wording — a wording test would keep passing if `gh` changed.
+# The cases below drive a predicate this FILE defines, which pins the SHAPE of
+# the advice but reads nothing the hook prints — measured: reverting the hook's
+# advice to the retired `[]` form, or replacing it with nonsense, left this
+# suite 18/18 green. So the hook's own stderr is asserted first, and the
+# predicate cases are what explain WHY that text is the right text.
+check_message() {
+  local name="$1" needle="$2" want="$3"   # want = present | absent
+  local payload out got
+  payload=$(printf '{"tool_input":{"command":"gh pr merge 123 --squash"},"cwd":"%s"}' "$REPO_ROOT")
+  out=$(printf '%s' "$payload" | GH_FIXTURE=no-checks PATH="$SHIM_DIR:$PATH" bash "$HOOK" 2>&1)
+  case "$out" in (*"$needle"*) got=present ;; (*) got=absent ;; esac
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    fail_log="$fail_log
+  FAIL: $name (expected $want, got $got)"
+  fi
+}
+
+# The advice must be PRINTED, not executed. `cat >&2 <<EOF` is an UNQUOTED
+# heredoc, so an unescaped `$( )` in the body runs at refusal time: the block
+# then shows `until [ -n "" ]` — an unconditional infinite loop, i.e. exactly
+# the hot-spin #2630 removes — and fires a second live `gh` call from inside a
+# PreToolUse hook. Asserting the literal is what catches that.
+check_message "advice prints the stdout-keyed poll" 'out=$(gh pr checks 123 2>/dev/null); rc=$?' present
+check_message "advice keeps its rc-1 disambiguation" '[ "$rc" = 1 ] || {' present
+check_message "advice no longer names the retired []" '[] = not registered yet' absent
+# The shape the unescaped heredoc produces. Distinct from the assertions above:
+# those reds if the text is REMOVED, this one reds if it is EXECUTED.
+check_message "advice was not expanded by the heredoc" 'until [ -n "" ]' absent
+
 advice_says_registered() {
   # The predicate the hook now prints, verbatim in shape.
   [ -n "$(GH_FIXTURE="$1" PATH="$SHIM_DIR:$PATH" gh pr checks 123 2>/dev/null)" ]

--- a/.claude/hooks/ci-green-gate.test.sh
+++ b/.claude/hooks/ci-green-gate.test.sh
@@ -97,6 +97,61 @@ run_case "gh pr create passes" one-fail "gh pr create --title x" 0
 run_case "quoted body in issue create" one-fail "gh issue create --body \"remember to gh pr merge 123 later\"" 0
 run_case "quoted body in echo" one-fail "echo \"next step: gh pr merge 123\"" 0
 
+# --- The ADVICE the no-checks branch prints must itself discriminate (#2630) ---
+#
+# The retired text told the agent to poll `gh pr checks --json name,state`
+# until it returned something other than `[]`. `gh` never returns `[]`: with no
+# checks it exits 1 with an EMPTY stdout and a message on stderr. Measured
+# 2026-09-06 (gh 2.89) across all four states, which is what the shim above
+# models:
+#
+#   no checks reported  rc=1  stdout 0 bytes   message on STDERR
+#   a check FAILED      rc=1  stdout non-empty
+#   still running       rc=8  stdout non-empty
+#   all pass            rc=0  stdout non-empty
+#
+# So rc=1 is AMBIGUOUS and the discriminator is the empty stdout. These cases
+# run the advised predicate itself against the shim, rather than asserting the
+# message's wording — a wording test would keep passing if `gh` changed.
+advice_says_registered() {
+  # The predicate the hook now prints, verbatim in shape.
+  [ -n "$(GH_FIXTURE="$1" PATH="$SHIM_DIR:$PATH" gh pr checks 123 2>/dev/null)" ]
+}
+
+check_advice() {
+  local name="$1" fixture="$2" expect="$3"
+  if advice_says_registered "$fixture"; then got=registered; else got=absent; fi
+  if [ "$got" = "$expect" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    fail_log="$fail_log
+  FAIL: $name (expected $expect, got $got)"
+  fi
+}
+
+check_advice "advice: no-checks reads as ABSENT" no-checks absent
+# The three that must all read as REGISTERED. `one-fail` is the load-bearing
+# one: it shares rc=1 with no-checks, so a predicate keyed on the exit code
+# would report it absent and the advised loop would spin forever on a PR whose
+# checks had already run and failed.
+check_advice "advice: a failing check reads as REGISTERED" one-fail registered
+check_advice "advice: a pending check reads as REGISTERED" pending registered
+check_advice "advice: all-pass reads as REGISTERED" all-pass registered
+
+# Guard-the-guard: the retired predicate must FAIL this suite, or the four
+# cases above would pass under the very advice #2630 retired.
+retired_says_registered() {
+  [ "$(GH_FIXTURE="$1" PATH="$SHIM_DIR:$PATH" gh pr checks 123 2>/dev/null)" != "[]" ]
+}
+if retired_says_registered no-checks; then
+  pass=$((pass + 1))   # retired form calls an EMPTY answer "registered" -> it never waits
+else
+  fail=$((fail + 1))
+  fail_log="$fail_log
+  FAIL: guard-the-guard expected the retired []-predicate to misread no-checks"
+fi
+
 echo "ci-green-gate.test: $pass passed, $fail failed"
 if [ "$fail" -gt 0 ]; then
   echo "$fail_log"


### PR DESCRIPTION
Closes #2630

## The defect

When `ci-green-gate` blocks a merge because no check has registered yet, it told the agent how to wait:

```
gh pr checks <PR> --json name,state   # [] = not registered yet
```

`gh` never returns `[]`. Measured 2026-09-06 (gh 2.89), each against a real PR in this repo:

| state | rc | stdout | stderr |
|---|---|---|---|
| no checks reported | 1 | **0 bytes** | message |
| a check FAILED | 1 | 671 B | — |
| still running | 8 | 478 B | — |
| all pass | 0 | 698 B | — |

The advised poll therefore reads an **empty stdout**, never the sentinel it was told to wait for. Under `set -e` the rc=1 aborts; without it the condition is never true — the hot-spin the advice exists to prevent. I hit the adjacent `--watch` surprise twice in the session that filed this, once burning a 10-minute timeout on an `until` loop wrapped around it.

## The obvious fix is also wrong

**rc=1 is ambiguous** — "no checks reported" *or* "a check failed". A predicate keyed on the exit code reports a PR whose checks already ran and FAILED as "not registered yet", and waits for it forever. That is worse than the bug being fixed: it converts a loud red into a hang.

The discriminator is the empty stdout. `--json name,state` buys nothing either — 0 bytes in the same case.

The gate's **refusal logic is untouched**; only the remediation text changed.

## The measurement is enforced, not recorded

`ci-green-gate.test.sh` already modelled all four states in its `gh` shim, so the new cases run **the advised predicate itself** against those fixtures rather than asserting the message's wording. A wording test would keep passing if `gh` changed behaviour — which is precisely this issue.

`one-fail` is the load-bearing fixture (it shares rc=1 with `no-checks`). A **guard-the-guard** case pins that the retired `!= "[]"` predicate *misreads* `no-checks`, so the four new cases cannot pass under the advice they replace.

Probes, one mutation at a time:

| mutation | result |
|---|---|
| predicate keyed on the exit code | **red** — "a failing check reads as REGISTERED" |
| shim prints its no-checks message to stdout | **red** — "no-checks reads as ABSENT" |

Both fail for the right reason. Full hook harness: 46/46 ok. Full suite 893 files / 18,943 tests.

## Provenance

Found by mirroring this session's `/work-issues` lessons into cdk-real-drift (go-to-k/cdk-real-drift#1883): that repo wrote its own version of the waiting rule, **measured the command rather than copying the sentence**, and the sentence did not survive the measurement. The sibling's copy was already correct; this one was not.

## No real-AWS run

`.claude/hooks/**` is in the `check` gate's scope but in the activation pattern of no integ gate.