### PR TITLE
chore: fold the go-to-k/cdkd#2438 + go-to-k/cdkd#2447 run's lessons back into /work-issues

### DIFF
--- a/.claude/skills/work-issues/references/filing.md
+++ b/.claude/skills/work-issues/references/filing.md
@@ -104,6 +104,17 @@ record the search so the next lane can see the window was checked:
 Dup-check: searched open issues for <terms> -- none covers this root cause
 ```
 
+**`next` vs `now` is decided by the WORKTREE, not by this PR.** The loud
+question mid-lane is "can this ride THIS PR?" (usually no); the deciding one is
+"is the owning lane's worktree still open?" (quiet, usually yes) — if it is,
+the finding is `now`: a second PR from that same worktree is cheap, and is not
+what `next` is for. `next` becomes the default only once that lane is merged
+and cleaned up. Three times now, and the last is why this rule sits here rather
+than in the appendix — go-to-k/cdkd#2321 / go-to-k/cdkd#2322 came out right by
+accident, and go-to-k/cdkd#2621 was filed `next` as "outside the scope of
+go-to-k/cdkd#2611" 45 minutes before that PR, which was editing the very file
+the issue names, merged.
+
 **File it with its `Severity` / `Effort` values ALSO as labels** — the body
 lines stay exactly as written, and the same two values ride the command:
 

--- a/.claude/skills/work-issues/references/filing.md
+++ b/.claude/skills/work-issues/references/filing.md
@@ -110,8 +110,9 @@ worktree still open?" (usually yes) — and while it is, `next` is weak: another
 PR from that tree costs almost nothing, deps and markers already paid.
 `.claude/rules/session-report.md` owns the criteria and wins on conflict (a
 frozen-scope reason is a SESSION-STATE clause there: legal, expiring, and it
-must name its ending event). This step adds only the TIMING; twice it went
-unasked until wrap (go-to-k/cdkd#2321 / go-to-k/cdkd#2322).
+must name its ending event). This step adds only the TIMING: twice a
+frozen-scope `next` was filed while the owning lane was still open
+(go-to-k/cdkd#2321 / go-to-k/cdkd#2322).
 
 **File it with its `Severity` / `Effort` values ALSO as labels** — the body
 lines stay exactly as written, and the same two values ride the command:

--- a/.claude/skills/work-issues/references/filing.md
+++ b/.claude/skills/work-issues/references/filing.md
@@ -104,16 +104,14 @@ record the search so the next lane can see the window was checked:
 Dup-check: searched open issues for <terms> -- none covers this root cause
 ```
 
-**`next` vs `now` is decided by the WORKTREE, not by this PR.** The loud
-question mid-lane is "can this ride THIS PR?" (usually no); the deciding one is
-"is the owning lane's worktree still open?" (quiet, usually yes) — if it is,
-the finding is `now`: a second PR from that same worktree is cheap, and is not
-what `next` is for. `next` becomes the default only once that lane is merged
-and cleaned up. Three times now, and the last is why this rule sits here rather
-than in the appendix — go-to-k/cdkd#2321 / go-to-k/cdkd#2322 came out right by
-accident, and go-to-k/cdkd#2621 was filed `next` as "outside the scope of
-go-to-k/cdkd#2611" 45 minutes before that PR, which was editing the very file
-the issue names, merged.
+**Ask the WORKTREE question HERE, not at wrap.** Mid-lane the loud question is
+"can this ride THIS PR?" (usually no); the quiet one is "is the owning lane's
+worktree still open?" (usually yes) — and while it is, `next` is weak: another
+PR from that tree costs almost nothing, deps and markers already paid.
+`.claude/rules/session-report.md` owns the criteria and wins on conflict (a
+frozen-scope reason is a SESSION-STATE clause there: legal, expiring, and it
+must name its ending event). This step adds only the TIMING; twice it went
+unasked until wrap (go-to-k/cdkd#2321 / go-to-k/cdkd#2322).
 
 **File it with its `Severity` / `Effort` values ALSO as labels** — the body
 lines stay exactly as written, and the same two values ride the command:

--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -34,9 +34,9 @@ both staged and reformatted shows `MM`); test for a non-empty second column.
 **Start every marker and gate command with an explicit `cd <worktree> &&`.**
 "Repo root" means the WORKTREE's root, and a shell cwd does not reliably
 persist between tool calls. The marker store is PER-WORKTREE (CLAUDE.md →
-multi-session uncommitted-work safety) — a marker recorded in the main checkout is simply
-ABSENT from the lane, surfacing as a `check-gate` refusal reading "you never
-ran /check" seconds after you ran it.
+multi-session uncommitted-work safety) — a marker recorded in the main
+checkout is simply ABSENT from the lane, surfacing as a `check-gate` refusal
+reading "you never ran /check" seconds after you ran it.
 
 **A gated command carries no SIDE-EFFECTING preamble in its Bash call, and
 "gated" means EVERY PreToolUse hook.** The leading `cd <worktree> &&` is fine;

--- a/.claude/skills/work-issues/references/gates-and-pr.md
+++ b/.claude/skills/work-issues/references/gates-and-pr.md
@@ -2,12 +2,12 @@
 
 ## 6. Gates + PR (per lane)
 
-**Before the session's FIRST commit, run CLAUDE.md's gate-liveness probe** —
-`git commit --dry-run -m "gate liveness probe"` as your OWN Bash tool call.
+**Before the session's FIRST commit, run CLAUDE.md's gate-liveness probe.**
 Ordinary git output means the gates are not firing ONLY if something was there
-to trip; with the markers already fresh, use CLAUDE.md's shape probe instead.
-Until the probe is CONCLUSIVE, every gate step below is self-enforced — run
-each by hand and say so in the report.
+to trip; with the markers already fresh — or the tree still CLEAN, which is
+where a retro branch starts — it proves nothing, so use CLAUDE.md's shape
+probe. Until the probe is CONCLUSIVE, every gate step below is self-enforced:
+run each by hand and say so in the report.
 
 From inside the worktree, run the local quality checks and record the markers:
 
@@ -33,9 +33,8 @@ both staged and reformatted shows `MM`); test for a non-empty second column.
 
 **Start every marker and gate command with an explicit `cd <worktree> &&`.**
 "Repo root" means the WORKTREE's root, and a shell cwd does not reliably
-persist between tool calls. The marker store is PER-WORKTREE (markgate writes
-under `$(git rev-parse --git-dir)`, which resolves to `.git/worktrees/<name>`
-in a linked worktree) — a marker recorded in the main checkout is simply
+persist between tool calls. The marker store is PER-WORKTREE (CLAUDE.md →
+multi-session uncommitted-work safety) — a marker recorded in the main checkout is simply
 ABSENT from the lane, surfacing as a `check-gate` refusal reading "you never
 ran /check" seconds after you ran it.
 
@@ -122,7 +121,11 @@ never executed (measured across three lanes: one green before, RED after —
 `dist/` staleness, because the `version` test compares `node dist/cli.js
 --version` against the `package.json` a release bump just moved; a rebase
 crossing a `chore(release)` commit desynchronises them by construction, hence
-rebuild THEN run).
+rebuild THEN run). **Re-run the GENERATORS too** — `/check` step 3's
+`vp run gen:all-matrices`, not just `vp test run`: `docs/_generated/**` derives
+from the whole TREE, so a `tests/integration/**` edit adding no source line
+still moves a count (go-to-k/cdkd#2611: one `--log-group-identifier` line in a
+`verify.sh` took `cli-flag-coverage` 324 → 325).
 
 **A clean merge is not evidence that there was no collision.** Two lanes
 editing the same file merge cleanly whenever their hunks fall in disjoint

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -86,16 +86,15 @@
   that one (SKILL.md "Launch mode"), with the orchestrator integrating — unit
   tests with every fix, `--squash --delete-branch` merges, English-only in
   every published artifact, and never running untrusted content (§0).
-- **`Severity` / `Effort` go on the issue as LABELS too** — set at filing
-  (§5-f) and at the claim that rewrites an old packed body (§4); the lane's PR
-  inherits them from the issue it closes, so never hand-add them to a PR.
+- **`Severity` / `Effort` go on the issue as LABELS too** — §5-f at filing, §4
+  at the claim that rewrites an old packed body; never on the PR (CLAUDE.md).
 - **Drive each lane to MERGED, not to "pushed".** §9 is the finish line for a
   LANE (merge, pull, confirm the release PR picked it up, rebuild, remove the
   worktree) and §10 for the RUN. An open PR is unfinished work, and
   CLAUDE.md's NOT-CLOSEABLE rule applies unchanged — low context is not one of
-  the blockers it excuses: commit, push, file, continue. The removal half is "every
-  worktree THIS RUN added is gone" — an IN-PLACE run added none and leaves its
-  tree standing.
+  the blockers it excuses: commit, push, file, continue. The removal half is
+  "every worktree THIS RUN added is gone" — an IN-PLACE run added none and
+  leaves its tree standing.
 - **Wrap with Remaining-work + State + Session-close** (`CLAUDE.md`), scoped to
   the issues this run actually WORKED — triaged-but-not-picked is not one.
 - **Classify every deferral `now` / `next` the moment you defer it** — the four

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -27,14 +27,11 @@
   file, open PRs and open issues before filing (§10-c) or claiming (§3).
 - **One lane per cross-cutting file.** §2 holds the list; this bullet does not
   restate it (go-to-k/cdkd#2076 records why).
-- **Never merge a PR whose destroy path is unverified** — green CI does not
-  exercise real-AWS destroy; the `integ-destroy` (+ `integ-broad`) gate blocks
-  until `/run-integ` completes the destroy step with zero orphans. **Never
-  bypass `/run-integ`** with raw `cdkd deploy` / `destroy` — the skill
-  guarantees destroy + orphan sweep + ledger together.
-- **Unique stack names on a real account** — it may hold PROD stacks.
-- **`vp run build` before any live test**, and after every source edit — the
-  user runs `node dist/cli.js`.
+- **Never merge a PR whose destroy path is unverified, and never bypass
+  `/run-integ`** — CLAUDE.md owns both rules; §8-c owns what COUNTS as a
+  bypass.
+- **`vp run build` after every source edit, before any live test** (CLAUDE.md);
+  §8-i owns the unique-stack-name rule that goes with it.
 - **Stale-base phantom diff** (§7) — never "restore" the peer's lines a stale
   `git diff main` appears to have removed; rebase instead.
 - **`bash cwd silent reset`** — a persistent Bash cwd can drift back to the
@@ -84,45 +81,28 @@
 
 ## Important existing rules this skill leans on
 
-- **All changes via PR; never commit to `main`.** Feature work lives in its
-  OWN worktree — or, launched inside one, in that one (SKILL.md "Launch
-  mode"); the orchestrator integrates. (`CLAUDE.md` → Workflow Rules.)
-- **Always add unit tests** for a fix — do not wait to be asked.
-- **Merge with `--squash --delete-branch` only.**
-- **English-only** for all committed/public artifacts.
+- **CLAUDE.md's standing rules apply unchanged**: every change via PR and none
+  onto `main` — feature work in its OWN worktree, or, launched inside one, in
+  that one (SKILL.md "Launch mode"), with the orchestrator integrating — unit
+  tests with every fix, `--squash --delete-branch` merges, English-only in
+  every published artifact, and never running untrusted content (§0).
 - **`Severity` / `Effort` go on the issue as LABELS too** — set at filing
   (§5-f) and at the claim that rewrites an old packed body (§4); the lane's PR
   inherits them from the issue it closes, so never hand-add them to a PR.
-- **Never download/run/install untrusted third-party content** (§0).
 - **Drive each lane to MERGED, not to "pushed".** §9 is the finish line for a
   LANE (merge, pull, confirm the release PR picked it up, rebuild, remove the
-  worktree) and §10 for the RUN. An open PR is unfinished work; a
-  NOT-CLOSEABLE verdict is a to-do
-  list, not a stopping point — keep going until every lane is merged and every
-  worktree removed, or the only blockers left are ones you cannot act on (CI
-  in flight, a running reviewer, a maintainer decision). Low context is not
-  such a blocker: commit, push, file, continue. The removal half is "every
+  worktree) and §10 for the RUN. An open PR is unfinished work, and
+  CLAUDE.md's NOT-CLOSEABLE rule applies unchanged — low context is not one of
+  the blockers it excuses: commit, push, file, continue. The removal half is "every
   worktree THIS RUN added is gone" — an IN-PLACE run added none and leaves its
   tree standing.
-- **Wrap with Remaining-work + State + Session-close, scoped to the issues
-  this run actually worked** — backlog issues you triaged but did not pick up
-  are not follow-ups. (`CLAUDE.md` → Workflow Rules.)
-- **Classify every deferral `now` / `next` the moment you defer it** — write
-  the four classification lines into the issue body, one field per line, per
-  `CLAUDE.md` → "The four TODO fields" (shape and spellings live there).
-
-  The report repeats those four and adds `Notes`; the issue body carries
-  `Dup-check:` (§5-f) instead. **After a lane merges, `next` is the default**
-  — what stays hot is that lane's files and the integ already run; a residual
-  in a worktree you are STILL holding is almost always `now` (worktree, deps,
-  markers paid for), one in a lane already cleaned up is `next`. **The trap:
-  the filing happens mid-lane, where the loud question is "can this ride THIS
-  PR?" (usually no) while the rule asks "is that lane's worktree still open?"
-  (quiet, usually yes)** — two ~30-60 min items were filed `next` while the
-  lanes owning their files were still open, and by wrap the classification had
-  become right for the wrong reason (go-to-k/cdkd#2321 / go-to-k/cdkd#2322).
-  Ask the worktree question at FILING time; a separate PR from the same open
-  worktree is cheap, and is not what `next` is for.
+- **Wrap with Remaining-work + State + Session-close** (`CLAUDE.md`), scoped to
+  the issues this run actually WORKED — triaged-but-not-picked is not one.
+- **Classify every deferral `now` / `next` the moment you defer it** — the four
+  classification lines go in the issue body, one field per line, per
+  `CLAUDE.md` → "The four TODO fields". The report repeats those four and adds
+  `Notes`; the body carries `Dup-check:` instead, and §5-f owns the
+  open-worktree test that decides `now` vs `next`.
 - **This flow parks a LOT, so the State line carries most of its weight.** A
   fan-out run spends most wall-clock parked (lane subagents, `gh pr checks
   --watch`, `/run-integ`) — every one is **WAITING**, not STOPPED: one line

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -63,16 +63,12 @@
   and a squash-merged branch reads as ahead forever; the warning's "remove its
   worktree" half is forbidden here (SKILL.md "Launch mode"). Expected, not a
   defect: confirm the PR is MERGED and say so in the wrap. The tree is only
-  clearable from inside by LEAVING the lane branch, which is what §9's
-  IN-PLACE arm does as the run's last step: `git switch
-  --no-guess <LAUNCH_BRANCH> && git branch -D` the lane branch — the branch
-  the probe recorded, restored as-is, with `--no-guess` so a branch surviving
-  only on `origin` fails here instead of being re-created from the remote.
-  That silences the hook — provided `LAUNCH_BRANCH` carries no commits of its
-  own (§9 has the `git rev-list --count` check) — without removing a tree this
-  run does not own. Detach silences it too but leaves the outer tool
-  displaying a detached workspace; it is the fallback for a run launched
-  detached, not the default (go-to-k/cdkd#2417).
+  clearable from inside by LEAVING the lane branch, which is exactly §9's
+  IN-PLACE arm — its recipe, its `--no-guess`, and its
+  `LAUNCH_BRANCH`-carries-no-commits check all live there, and it silences the
+  hook without removing a tree this run does not own. Detach silences it too
+  but leaves the outer tool displaying a detached workspace; it is the fallback
+  for a run launched detached, not the default (go-to-k/cdkd#2417).
 - **A usage-limit interruption does not have to end the run: leave a one-shot
   checkpoint at the reset time**, scheduled when the limit is ANNOUNCED, not
   when it bites (the 2026-09-02 run resumed itself at the reset instant from

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -44,10 +44,7 @@ for n in <the numbers this run filed that are still open>; do
         # often than by full path.
         grep -E "(^|/)$(printf '%s' "$f" | sed 's/[.[\*^$]/\\&/g')\$" \
           /tmp/run-touched.$$ | while read -r hit; do
-            # The body LINE too -- a citation and a target look identical
-            # by name, and the sentence around one usually tells them apart.
-            ctx=$(printf '%s\n' "$b" | grep -m1 -F "$f" | cut -c1-110)
-            echo "PROMOTE #$n -- touched $hit -- body: $ctx"
+            echo "PROMOTE #$n -- this run touched $hit"
           done
       done
 done | sort -u
@@ -61,10 +58,13 @@ rm -f /tmp/run-touched.$$
   what the extraction found; resolve by hand (`git grep -l '<the symbol>'`)
   whenever no token is path-shaped or the diff is mostly dotfiles.
 - **A hit is a prompt for judgement, not a verdict** — it cannot tell a
-  citation from a target, so the recipe prints the body LINE each token came
-  from (go-to-k/cdkd#2621 cites a SIBLING fixture this run touched, by FULL
-  path; a retro shipped that hit as fact). Do the item, or re-classify it in
-  the issue with the reason the criterion no longer applies. When the run's own
+  citation from a target, and the output does not help: go-to-k/cdkd#2621
+  cites a SIBLING fixture this run touched, by FULL path, and a retro shipped
+  that hit as a sourced incident. Open the body and read the SENTENCE around
+  the token before believing any hit (printing it automatically is
+  go-to-k/cdkd#2655, withdrawn from this recipe with two measured defects).
+  Do the item, or re-classify it in the issue with the reason the criterion no
+  longer applies. When the run's own
   PRs ARE the follow-ups' subject — one lane, or several sharing a subsystem — expect
   EVERY one to hit, and read the issue's REASON instead (go-to-k/cdkd#2514 10
   of 10; go-to-k/cdkd#2558's two lanes; all but three across

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -51,12 +51,15 @@ done | sort -u
 rm -f /tmp/run-touched.$$
 ```
 
-- **An EMPTY result is not "nothing to promote" — check the extraction saw a
-  FILE at all.** A body names its subject by SYMBOL as often as by path
-  (go-to-k/cdkd#2442), and a DOTFILE needs the `\.?` prefix above
-  (go-to-k/cdkd#2455); both reported nothing while the criterion fired. Print
-  what the extraction found; resolve by hand (`git grep -l '<the symbol>'`)
-  whenever no token is path-shaped or the diff is mostly dotfiles.
+- **The extraction is wrong in BOTH directions — print what it found and
+  settle every token by hand.** EMPTY can still be a hit (a body names its
+  subject by SYMBOL as often as by path, go-to-k/cdkd#2442; a DOTFILE needs the
+  `\.?` prefix above, go-to-k/cdkd#2455). NON-empty can be none: the match is by
+  BASENAME and 249 files here are named `verify.sh` — go-to-k/cdkd#2621 names
+  `loggroup-never-expire-guard/verify.sh` and matched the run's
+  `loggroup-class-guard/` one, which a retro wrote into a rule as fact before
+  re-reading the issue caught it. Resolve every hit to a FULL PATH, and
+  `git grep -l '<the symbol>'` when no token is path-shaped.
 - **A hit is a prompt for judgement, not a verdict** — the check cannot tell a
   citation from a target. Do the item, or re-classify it in the issue with the
   reason the criterion no longer applies. When the run's own PRs ARE the

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -60,13 +60,12 @@ rm -f /tmp/run-touched.$$
 - **A hit is a prompt for judgement, not a verdict** — it cannot tell a
   citation from a target, and the output does not help: go-to-k/cdkd#2621
   cites a SIBLING fixture this run touched, by FULL path, and a retro wrote
-  that hit into a rule as a sourced incident, unpicked over three review
-  rounds. Open the body and read the SENTENCE around the token before
-  believing any hit (printing it automatically is go-to-k/cdkd#2655,
-  withdrawn from this recipe with two measured defects). Do the item, or
-  re-classify it in the issue with the reason the criterion no longer
-  applies. When the run's own PRs ARE the follow-ups' subject — one lane, or
-  several sharing a subsystem — expect
+  that hit into a rule as a sourced incident, unpicked only by review. Open
+  the body and read the SENTENCE around the token before believing any hit
+  (printing it automatically is go-to-k/cdkd#2655, withdrawn from this recipe
+  with two measured defects). Do the item, or re-classify it in the issue with
+  the reason the criterion no longer applies. When the run's own PRs ARE the
+  follow-ups' subject — one lane, or several sharing a subsystem — expect
   EVERY one to hit, and read the issue's REASON instead (go-to-k/cdkd#2514 10
   of 10; go-to-k/cdkd#2558's two lanes; all but three across
   go-to-k/cdkd#2554's five) — a run-wide hit rate is a property of the run's

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -44,26 +44,28 @@ for n in <the numbers this run filed that are still open>; do
         # often than by full path.
         grep -E "(^|/)$(printf '%s' "$f" | sed 's/[.[\*^$]/\\&/g')\$" \
           /tmp/run-touched.$$ | while read -r hit; do
-            echo "PROMOTE #$n -- this run touched $hit"
+            # The body LINE too -- a citation and a target look identical
+            # by name, and the sentence around one usually tells them apart.
+            ctx=$(printf '%s\n' "$b" | grep -m1 -F "$f" | cut -c1-110)
+            echo "PROMOTE #$n -- touched $hit -- body: $ctx"
           done
       done
 done | sort -u
 rm -f /tmp/run-touched.$$
 ```
 
-- **The extraction is wrong in BOTH directions — print what it found and
-  settle every token by hand.** EMPTY can still be a hit (a body names its
-  subject by SYMBOL as often as by path, go-to-k/cdkd#2442; a DOTFILE needs the
-  `\.?` prefix above, go-to-k/cdkd#2455). NON-empty can be none: the match is by
-  BASENAME and 249 files here are named `verify.sh` — go-to-k/cdkd#2621 names
-  `loggroup-never-expire-guard/verify.sh` and matched the run's
-  `loggroup-class-guard/` one, which a retro wrote into a rule as fact before
-  re-reading the issue caught it. Resolve every hit to a FULL PATH, and
-  `git grep -l '<the symbol>'` when no token is path-shaped.
-- **A hit is a prompt for judgement, not a verdict** — the check cannot tell a
-  citation from a target. Do the item, or re-classify it in the issue with the
-  reason the criterion no longer applies. When the run's own PRs ARE the
-  follow-ups' subject — one lane, or several sharing a subsystem — expect
+- **An EMPTY result is not "nothing to promote" — check the extraction saw a
+  FILE at all.** A body names its subject by SYMBOL as often as by path
+  (go-to-k/cdkd#2442), and a DOTFILE needs the `\.?` prefix above
+  (go-to-k/cdkd#2455); both reported nothing while the criterion fired. Print
+  what the extraction found; resolve by hand (`git grep -l '<the symbol>'`)
+  whenever no token is path-shaped or the diff is mostly dotfiles.
+- **A hit is a prompt for judgement, not a verdict** — it cannot tell a
+  citation from a target, so the recipe prints the body LINE each token came
+  from (go-to-k/cdkd#2621 cites a SIBLING fixture this run touched, by FULL
+  path; a retro shipped that hit as fact). Do the item, or re-classify it in
+  the issue with the reason the criterion no longer applies. When the run's own
+  PRs ARE the follow-ups' subject — one lane, or several sharing a subsystem — expect
   EVERY one to hit, and read the issue's REASON instead (go-to-k/cdkd#2514 10
   of 10; go-to-k/cdkd#2558's two lanes; all but three across
   go-to-k/cdkd#2554's five) — a run-wide hit rate is a property of the run's

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -59,13 +59,14 @@ rm -f /tmp/run-touched.$$
   whenever no token is path-shaped or the diff is mostly dotfiles.
 - **A hit is a prompt for judgement, not a verdict** — it cannot tell a
   citation from a target, and the output does not help: go-to-k/cdkd#2621
-  cites a SIBLING fixture this run touched, by FULL path, and a retro shipped
-  that hit as a sourced incident. Open the body and read the SENTENCE around
-  the token before believing any hit (printing it automatically is
-  go-to-k/cdkd#2655, withdrawn from this recipe with two measured defects).
-  Do the item, or re-classify it in the issue with the reason the criterion no
-  longer applies. When the run's own
-  PRs ARE the follow-ups' subject — one lane, or several sharing a subsystem — expect
+  cites a SIBLING fixture this run touched, by FULL path, and a retro wrote
+  that hit into a rule as a sourced incident, unpicked over three review
+  rounds. Open the body and read the SENTENCE around the token before
+  believing any hit (printing it automatically is go-to-k/cdkd#2655,
+  withdrawn from this recipe with two measured defects). Do the item, or
+  re-classify it in the issue with the reason the criterion no longer
+  applies. When the run's own PRs ARE the follow-ups' subject — one lane, or
+  several sharing a subsystem — expect
   EVERY one to hit, and read the issue's REASON instead (go-to-k/cdkd#2514 10
   of 10; go-to-k/cdkd#2558's two lanes; all but three across
   go-to-k/cdkd#2554's five) — a run-wide hit rate is a property of the run's

--- a/.claude/skills/work-issues/references/ship.md
+++ b/.claude/skills/work-issues/references/ship.md
@@ -36,6 +36,11 @@ force-push, and CI fires within ~30s. **`--watch` does not cover the wait for
 checks to APPEAR** — with none reported it returns at once, so an `until` loop
 wrapping it hot-spins through a full tool timeout (measured 2026-09-05) and a plain `sleep` chain is refused by the harness. Poll
 `gh pr checks <N> --json state` from `Monitor` or a backgrounded loop.
+**Read the verdict from `--json`, never by splitting the human table on
+whitespace** — a matrix job's name carries a parenthesised suffix, so the naive
+split reads `(20)` / `(22)` as statuses and invents non-green checks;
+`awk -F'\t' '{print $2}' | sort | uniq -c` is the table form
+(both reproduced on go-to-k/cdkd#2644).
 
 **~30s is push-to-queue latency, not time-to-verdict**: with runner backlog,
 checks can APPEAR 10+ minutes after a push and settle minutes later — longer

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -155,8 +155,8 @@ Unit tests passing is necessary but NOT sufficient:
     `vp run check` reads neither `ci.yml` nor any hook, and its lint is
     scoped to `src/**`). Run it BEFORE and AFTER; for the BEFORE tree use a
     scratch copy or a re-applied sed-swap, never `git checkout -- <path>` /
-    `git restore <path>` (`dirty-path-restore-gate` blocks that form —
-    go-to-k/cdkd#1700 lost ~200 lines). Flag-order
+    `git restore <path>` (`dirty-path-restore-gate` blocks that form on a
+    DIRTY path — go-to-k/cdkd#1700 lost ~200 lines). Flag-order
     trap: a `vp run` flag after the task name is forwarded to the task and
     rejected — exit 1 from a command that never ran (go-to-k/cdkd#2017); read
     help through `mise exec`, not the bare binary. **Drive the FAILURE

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -134,8 +134,8 @@ Unit tests passing is necessary but NOT sufficient:
   — never raw `cdkd deploy` / `cdkd destroy` from a shell (CLAUDE.md carries
   that rule and why), and **the bypass is not those two command NAMES: it is
   any real-AWS work outside a fixture** — `node dist/cli.js <anything>` and
-  hand-made test resources are the same act, EXIT traps and all (2026-09-05,
-  self-reported). `/pick-integ` chooses the fixture(s) and marks which are
+  hand-made test resources are the same act, EXIT traps and all
+  (go-to-k/cdkd#2653). `/pick-integ` chooses the fixture(s) and marks which are
   maintainer-only — never name one it flagged.
 - **Non-deletion source change** → still live-test the fixed path end-to-end
   (deploy → the redeploy that reproduced the bug → destroy), fresh fixture or
@@ -154,9 +154,9 @@ Unit tests passing is necessary but NOT sufficient:
     `vite.config.ts`, `vp run check` for lint/typecheck config — noting
     `vp run check` reads neither `ci.yml` nor any hook, and its lint is
     scoped to `src/**`). Run it BEFORE and AFTER; for the BEFORE tree use a
-    scratch copy or a re-applied sed-swap, never `git checkout` /
-    `git restore` (`dirty-path-restore-gate` blocks it — go-to-k/cdkd#1700 lost
-    ~200 lines of unrelated work that way). Flag-order
+    scratch copy or a re-applied sed-swap, never `git checkout -- <path>` /
+    `git restore <path>` (`dirty-path-restore-gate` blocks that form —
+    go-to-k/cdkd#1700 lost ~200 lines). Flag-order
     trap: a `vp run` flag after the task name is forwarded to the task and
     rejected — exit 1 from a command that never ran (go-to-k/cdkd#2017); read
     help through `mise exec`, not the bare binary. **Drive the FAILURE
@@ -376,11 +376,10 @@ code defects and FIVE false statements in prose. Habits that each caught one:
 ### 8-i. Fresh deploys, markers, and who sets what
 
 **A fresh deploy is a fresh FIXTURE**: `/new-integ` scaffolds one, `/run-integ`
-deploys and tears it down (§8-c). **UNIQUE
-stack names only** (e.g. `Cdkd<Issue>Verify`), never a shared fixed name — the
-account may hold the maintainer's production stacks. After teardown, sweep for
-orphans it cannot reach (auto-created `/aws/lambda/*` log groups, RETAIN
-resources, Secrets in
+deploys and tears it down (§8-c). **UNIQUE stack names only**
+(e.g. `Cdkd<Issue>Verify`), never a shared fixed name — the account may hold
+the maintainer's production stacks. After teardown, sweep for orphans it cannot
+reach (auto-created `/aws/lambda/*` log groups, RETAIN resources, Secrets in
 recovery, KMS keys pending deletion), then run CLAUDE.md's post-integ
 leftover check — the `deployments/` events store legitimately survives it.
 

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -132,7 +132,10 @@ Unit tests passing is necessary but NOT sufficient:
   integ's **destroy** step completes cleanly (`integ-destroy`, plus
   `integ-broad` for cross-cutting files). Run it via **`/run-integ <name>`**
   — never raw `cdkd deploy` / `cdkd destroy` from a shell (CLAUDE.md carries
-  that rule and why). `/pick-integ` chooses the fixture(s) and marks which are
+  that rule and why), and **the bypass is not those two command NAMES: it is
+  any real-AWS work outside a fixture** — `node dist/cli.js <anything>` and
+  hand-made test resources are the same act, EXIT traps and all (2026-09-05,
+  self-reported). `/pick-integ` chooses the fixture(s) and marks which are
   maintainer-only — never name one it flagged.
 - **Non-deletion source change** → still live-test the fixed path end-to-end
   (deploy → the redeploy that reproduced the bug → destroy), fresh fixture or
@@ -151,9 +154,9 @@ Unit tests passing is necessary but NOT sufficient:
     `vite.config.ts`, `vp run check` for lint/typecheck config — noting
     `vp run check` reads neither `ci.yml` nor any hook, and its lint is
     scoped to `src/**`). Run it BEFORE and AFTER; for the BEFORE tree use a
-    scratch copy or re-applied sed-swap, never `git checkout -- <path>` /
-    `git restore <path>` (`dirty-path-restore-gate` blocks it; one such undo
-    discarded ~200 lines of unrelated work, go-to-k/cdkd#1700). Flag-order
+    scratch copy or a re-applied sed-swap, never `git checkout` /
+    `git restore` (`dirty-path-restore-gate` blocks it — go-to-k/cdkd#1700 lost
+    ~200 lines of unrelated work that way). Flag-order
     trap: a `vp run` flag after the task name is forwarded to the task and
     rejected — exit 1 from a command that never ran (go-to-k/cdkd#2017); read
     help through `mise exec`, not the bare binary. **Drive the FAILURE
@@ -372,10 +375,12 @@ code defects and FIVE false statements in prose. Habits that each caught one:
 
 ### 8-i. Fresh deploys, markers, and who sets what
 
-**Fresh deploys: UNIQUE stack names only** (e.g. `Cdkd<Issue>Verify`), never a
-shared fixed name — the account may hold the maintainer's production stacks.
-Tear down with `cdkd destroy … --force`, then sweep for orphans it cannot
-reach (auto-created `/aws/lambda/*` log groups, RETAIN resources, Secrets in
+**A fresh deploy is a fresh FIXTURE**: `/new-integ` scaffolds one, `/run-integ`
+deploys and tears it down (§8-c). **UNIQUE
+stack names only** (e.g. `Cdkd<Issue>Verify`), never a shared fixed name — the
+account may hold the maintainer's production stacks. After teardown, sweep for
+orphans it cannot reach (auto-created `/aws/lambda/*` log groups, RETAIN
+resources, Secrets in
 recovery, KMS keys pending deletion), then run CLAUDE.md's post-integ
 leftover check — the `deployments/` events store legitimately survives it.
 

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -268,11 +268,11 @@ const MIN_REFERENCE_FILES = 6;
 // -- filing.md's ask-the-worktree-question-HERE timing, gates-and-pr.md's
 // re-run-the-generators clause, ship.md's `gh pr checks` parsing rule,
 // verify.md's what-COUNTS-as-a-bypass clause, and retro.md's
-// read-the-SENTENCE-before-believing-a-hit rider -- and came out
-// 172,746 -> 172,952, i.e. +206 for the round
-// with verify.md 27,876 -> 28,154 taking the lead from implement.md 28,079
-// (untouched); margin 130 -> 127 B. Components, stated so they can be checked
-// rather than believed: filing.md +640, gates-and-pr.md +276, retro.md +376,
+// read-the-SENTENCE-before-believing-a-hit rider -- and came out 172,746 ->
+// 172,952, i.e. +206 for the round, with verify.md 27,876 -> 28,154 taking
+// the lead from implement.md 28,079 (untouched); margin 130 -> 127 B.
+// Components, stated so they can be checked rather than believed:
+// filing.md +640, gates-and-pr.md +276, retro.md +376,
 // ship.md +325, verify.md +278, gotchas.md -1,689, = +206. All of the payment
 // came from ONE file, and by DISPLACEMENT rather than compression: gotchas.md
 // is the appendix, so every rule in it that only restated CLAUDE.md or another
@@ -282,25 +282,18 @@ const MIN_REFERENCE_FILES = 6;
 // section 9). Read that as the appendix's standing hazard: an "existing rules
 // this skill leans on" list is where duplication accumulates without ever
 // looking like growth.
-// The retro.md change is the one worth re-reading before the next fold-back,
-// because this round produced it the expensive way: EVERY review round on this
-// PR found a false PROSE claim in that one bullet, including each round written
-// to correct the previous one -- which is why the sentence above carries no
-// round COUNT, a number every further round would falsify. Round one wrote a
-// promotion-check hit into filing.md as a sourced incident; the next round
-// found the cited issue was a different fixture and blamed a BASENAME
-// collision; the next found that wrong too (the body names the sibling by
-// FULL path, so it was a citation) and escalated from prose to a recipe that
-// prints the body line; the next found THAT recipe pairs a basename hit with
-// the wrong sentence -- reproducing round one's error inside the mechanism
-// built to prevent it; and the round recording the withdrawal still said the
-// false rule had SHIPPED, when it never left this PR. So the recipe change was
-// WITHDRAWN to
-// go-to-k/cdkd#2655 carrying both measured defects, and what ships is the
-// narrow certain part: read the sentence before believing a hit. A reviewer
-// re-derived every byte figure in this file from the tree at EVERY round and
-// found each correct; none of that touches whether the PROSE is true, which
-// is the whole lesson.
+// The retro.md rule is the one worth re-reading before the next fold-back,
+// because of HOW it was arrived at: every review round on this PR found a
+// false PROSE claim in text this PR had added, each round's fix included. The
+// chain ran cited-the-wrong-fixture -> blamed a basename collision (also
+// wrong; the body names the sibling by FULL path) -> escalated to a recipe
+// printing the body line -> that recipe paired a basename hit with the wrong
+// sentence, reproducing the original error inside the mechanism built to
+// prevent it. So the recipe went to go-to-k/cdkd#2655 with both measured
+// defects and only the narrow certain part shipped. A reviewer re-derived
+// every byte figure here from the tree each round and found each correct
+// throughout -- which is the lesson: byte fences cannot see whether the PROSE
+// is true, so the counts above are checkable and the narrative is not.
 // The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,9 +122,9 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_752,
-    corpusBytes: 172_746,
-    largest: { file: 'implement.md', bytes: 28_079 },
-    runnerUp: { file: 'verify.md', bytes: 27_876 },
+    corpusBytes: 173_004,
+    largest: { file: 'verify.md', bytes: 28_149 },
+    runnerUp: { file: 'implement.md', bytes: 28_079 },
   },
 };
 
@@ -264,6 +264,21 @@ const MIN_REFERENCE_FILES = 6;
 // but not free: the second spent 678 B of the `tests/setup.ts` payload band
 // in rule-file-payload.test.ts, whose three governing figures are re-derived
 // there in the same commit.
+// The 2026-09-05 go-to-k/cdkd#2438 + go-to-k/cdkd#2447 retro added four rules
+// -- filing.md's worktree test for `next` vs `now`, gates-and-pr.md's
+// re-run-the-generators clause, ship.md's `gh pr checks` parsing rule,
+// verify.md's what-COUNTS-as-a-bypass clause -- and came out 172,746 ->
+// 173,004 (+258) with verify.md 27,876 -> 28,149 taking the lead from
+// implement.md 28,079 (untouched); margin 130 -> 75 B. Components, stated so
+// they can be checked rather than believed: filing.md +727, gates-and-pr.md
+// +276, ship.md +325, verify.md +273, gotchas.md -1,343, = +258. Nearly all of
+// the payment came from ONE file, and by DISPLACEMENT rather than compression:
+// gotchas.md is the appendix, so every rule in it that only restated CLAUDE.md
+// or another stage was either pointed at or moved to the step where it fires
+// (the deferral trap to filing.md, the unique-stack-name rule to 8-i, the
+// what-counts-as-a-bypass half to 8-c). Read that as the appendix's standing
+// hazard: an "existing rules this skill leans on" list is where duplication
+// accumulates without ever looking like growth.
 // The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,8 +122,8 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_752,
-    corpusBytes: 173_022,
-    largest: { file: 'verify.md', bytes: 28_138 },
+    corpusBytes: 172_966,
+    largest: { file: 'verify.md', bytes: 28_154 },
     runnerUp: { file: 'implement.md', bytes: 28_079 },
   },
 };
@@ -267,27 +267,31 @@ const MIN_REFERENCE_FILES = 6;
 // The 2026-09-05 go-to-k/cdkd#2438 + go-to-k/cdkd#2447 retro added five rules
 // -- filing.md's ask-the-worktree-question-HERE timing, gates-and-pr.md's
 // re-run-the-generators clause, ship.md's `gh pr checks` parsing rule,
-// verify.md's what-COUNTS-as-a-bypass clause, and retro.md's both-directions
-// rewrite of section 10-0's extraction bullet -- and came out 172,746 ->
-// 173,022 (+276) with verify.md 27,876 -> 28,138 taking the lead from
-// implement.md 28,079 (untouched); margin 130 -> 57 B. Components, stated so
-// they can be checked rather than believed: filing.md +598, gates-and-pr.md
-// +276, retro.md +228, ship.md +325, verify.md +262, gotchas.md -1,413,
-// = +276. Nearly all of the payment came from ONE file, and by DISPLACEMENT
-// rather than compression: gotchas.md is the appendix, so every rule in it
-// that only restated CLAUDE.md or another stage was either pointed at or moved
-// to the step where it fires (the deferral trap to filing.md, the
-// unique-stack-name rule to 8-i, the what-counts-as-a-bypass half to 8-c).
-// Read that as the appendix's standing hazard: an "existing rules this skill
-// leans on" list is where duplication accumulates without ever looking like
-// growth.
-// The retro.md rule is the one worth re-reading before the next fold-back,
-// because THIS round produced it the expensive way: section 10-0's promotion
-// check matches a body's file tokens by BASENAME, 249 files here are named
-// `verify.sh`, and the collision was written into filing.md as a sourced
-// incident and shipped to review before a re-read of the issue caught it. Two
-// reviewers had already re-derived every byte figure in this file as correct;
-// none of that touches whether the PROSE is true.
+// verify.md's what-COUNTS-as-a-bypass clause, and retro.md's promotion-check
+// recipe now printing the body LINE each token came from -- and came out
+// 172,746 -> 172,966 (-- yes, NET NEGATIVE against a five-rule round: +220)
+// with verify.md 27,876 -> 28,154 taking the lead from implement.md 28,079
+// (untouched); margin 130 -> 113 B. Components, stated so they can be checked
+// rather than believed: filing.md +640, gates-and-pr.md +276, retro.md +390,
+// ship.md +325, verify.md +278, gotchas.md -1,689, = +220. All of the payment
+// came from ONE file, and by DISPLACEMENT rather than compression: gotchas.md
+// is the appendix, so every rule in it that only restated CLAUDE.md or another
+// stage was either pointed at or moved to the step where it fires (the
+// deferral trap to filing.md, the unique-stack-name rule to 8-i, the
+// what-counts-as-a-bypass half to 8-c, the IN-PLACE restore recipe to
+// section 9). Read that as the appendix's standing hazard: an "existing rules
+// this skill leans on" list is where duplication accumulates without ever
+// looking like growth.
+// The retro.md change is the one worth re-reading before the next fold-back,
+// because this round produced it the expensive way -- TWO rounds of it. Round
+// one wrote a promotion-check hit into filing.md as a sourced incident; round
+// two found the cited issue was a different fixture and re-attributed it to a
+// BASENAME collision; round three found THAT was wrong too (the body names the
+// sibling by FULL path, so it was a citation, and the round-two remedy would
+// not have caught it). The fix is not a fourth sentence telling the reader to
+// judge -- it is the recipe printing the evidence to judge WITH. Three
+// reviewers had re-derived every byte figure in this file as correct
+// throughout; none of that touches whether the PROSE is true.
 // The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,7 +122,7 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_752,
-    corpusBytes: 172_917,
+    corpusBytes: 172_964,
     largest: { file: 'verify.md', bytes: 28_154 },
     runnerUp: { file: 'implement.md', bytes: 28_079 },
   },
@@ -269,11 +269,11 @@ const MIN_REFERENCE_FILES = 6;
 // re-run-the-generators clause, ship.md's `gh pr checks` parsing rule,
 // verify.md's what-COUNTS-as-a-bypass clause, and retro.md's
 // read-the-SENTENCE-before-believing-a-hit rider -- and came out
-// 172,746 -> 172,917, i.e. +171 for the round
+// 172,746 -> 172,964, i.e. +218 for the round
 // with verify.md 27,876 -> 28,154 taking the lead from implement.md 28,079
-// (untouched); margin 130 -> 162 B. Components, stated so they can be checked
-// rather than believed: filing.md +640, gates-and-pr.md +276, retro.md +341,
-// ship.md +325, verify.md +278, gotchas.md -1,689, = +171. All of the payment
+// (untouched); margin 130 -> 115 B. Components, stated so they can be checked
+// rather than believed: filing.md +640, gates-and-pr.md +276, retro.md +388,
+// ship.md +325, verify.md +278, gotchas.md -1,689, = +218. All of the payment
 // came from ONE file, and by DISPLACEMENT rather than compression: gotchas.md
 // is the appendix, so every rule in it that only restated CLAUDE.md or another
 // stage was either pointed at or moved to the step where it fires (the
@@ -292,9 +292,10 @@ const MIN_REFERENCE_FILES = 6;
 // the wrong sentence -- reproducing round one's error inside the mechanism
 // built to prevent it. So the recipe change was WITHDRAWN to
 // go-to-k/cdkd#2655 carrying both measured defects, and what ships is the
-// narrow certain part: read the sentence before believing a hit. Four
-// reviewers re-derived every byte figure in this file as correct throughout;
-// none of that touches whether the PROSE is true, which is the whole lesson.
+// narrow certain part: read the sentence before believing a hit. A reviewer
+// re-derived every byte figure in this file from the tree at EVERY round and
+// found each correct; none of that touches whether the PROSE is true, which
+// is the whole lesson.
 // The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,8 +122,8 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_752,
-    corpusBytes: 173_004,
-    largest: { file: 'verify.md', bytes: 28_149 },
+    corpusBytes: 173_022,
+    largest: { file: 'verify.md', bytes: 28_138 },
     runnerUp: { file: 'implement.md', bytes: 28_079 },
   },
 };
@@ -264,21 +264,30 @@ const MIN_REFERENCE_FILES = 6;
 // but not free: the second spent 678 B of the `tests/setup.ts` payload band
 // in rule-file-payload.test.ts, whose three governing figures are re-derived
 // there in the same commit.
-// The 2026-09-05 go-to-k/cdkd#2438 + go-to-k/cdkd#2447 retro added four rules
-// -- filing.md's worktree test for `next` vs `now`, gates-and-pr.md's
+// The 2026-09-05 go-to-k/cdkd#2438 + go-to-k/cdkd#2447 retro added five rules
+// -- filing.md's ask-the-worktree-question-HERE timing, gates-and-pr.md's
 // re-run-the-generators clause, ship.md's `gh pr checks` parsing rule,
-// verify.md's what-COUNTS-as-a-bypass clause -- and came out 172,746 ->
-// 173,004 (+258) with verify.md 27,876 -> 28,149 taking the lead from
-// implement.md 28,079 (untouched); margin 130 -> 75 B. Components, stated so
-// they can be checked rather than believed: filing.md +727, gates-and-pr.md
-// +276, ship.md +325, verify.md +273, gotchas.md -1,343, = +258. Nearly all of
-// the payment came from ONE file, and by DISPLACEMENT rather than compression:
-// gotchas.md is the appendix, so every rule in it that only restated CLAUDE.md
-// or another stage was either pointed at or moved to the step where it fires
-// (the deferral trap to filing.md, the unique-stack-name rule to 8-i, the
-// what-counts-as-a-bypass half to 8-c). Read that as the appendix's standing
-// hazard: an "existing rules this skill leans on" list is where duplication
-// accumulates without ever looking like growth.
+// verify.md's what-COUNTS-as-a-bypass clause, and retro.md's both-directions
+// rewrite of section 10-0's extraction bullet -- and came out 172,746 ->
+// 173,022 (+276) with verify.md 27,876 -> 28,138 taking the lead from
+// implement.md 28,079 (untouched); margin 130 -> 57 B. Components, stated so
+// they can be checked rather than believed: filing.md +598, gates-and-pr.md
+// +276, retro.md +228, ship.md +325, verify.md +262, gotchas.md -1,413,
+// = +276. Nearly all of the payment came from ONE file, and by DISPLACEMENT
+// rather than compression: gotchas.md is the appendix, so every rule in it
+// that only restated CLAUDE.md or another stage was either pointed at or moved
+// to the step where it fires (the deferral trap to filing.md, the
+// unique-stack-name rule to 8-i, the what-counts-as-a-bypass half to 8-c).
+// Read that as the appendix's standing hazard: an "existing rules this skill
+// leans on" list is where duplication accumulates without ever looking like
+// growth.
+// The retro.md rule is the one worth re-reading before the next fold-back,
+// because THIS round produced it the expensive way: section 10-0's promotion
+// check matches a body's file tokens by BASENAME, 249 files here are named
+// `verify.sh`, and the collision was written into filing.md as a sourced
+// incident and shipped to review before a re-read of the issue caught it. Two
+// reviewers had already re-derived every byte figure in this file as correct;
+// none of that touches whether the PROSE is true.
 // The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,7 +122,7 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_752,
-    corpusBytes: 172_966,
+    corpusBytes: 172_917,
     largest: { file: 'verify.md', bytes: 28_154 },
     runnerUp: { file: 'implement.md', bytes: 28_079 },
   },
@@ -267,13 +267,13 @@ const MIN_REFERENCE_FILES = 6;
 // The 2026-09-05 go-to-k/cdkd#2438 + go-to-k/cdkd#2447 retro added five rules
 // -- filing.md's ask-the-worktree-question-HERE timing, gates-and-pr.md's
 // re-run-the-generators clause, ship.md's `gh pr checks` parsing rule,
-// verify.md's what-COUNTS-as-a-bypass clause, and retro.md's promotion-check
-// recipe now printing the body LINE each token came from -- and came out
-// 172,746 -> 172,966 (-- yes, NET NEGATIVE against a five-rule round: +220)
+// verify.md's what-COUNTS-as-a-bypass clause, and retro.md's
+// read-the-SENTENCE-before-believing-a-hit rider -- and came out
+// 172,746 -> 172,917, i.e. +171 for the round
 // with verify.md 27,876 -> 28,154 taking the lead from implement.md 28,079
-// (untouched); margin 130 -> 113 B. Components, stated so they can be checked
-// rather than believed: filing.md +640, gates-and-pr.md +276, retro.md +390,
-// ship.md +325, verify.md +278, gotchas.md -1,689, = +220. All of the payment
+// (untouched); margin 130 -> 162 B. Components, stated so they can be checked
+// rather than believed: filing.md +640, gates-and-pr.md +276, retro.md +341,
+// ship.md +325, verify.md +278, gotchas.md -1,689, = +171. All of the payment
 // came from ONE file, and by DISPLACEMENT rather than compression: gotchas.md
 // is the appendix, so every rule in it that only restated CLAUDE.md or another
 // stage was either pointed at or moved to the step where it fires (the
@@ -283,15 +283,18 @@ const MIN_REFERENCE_FILES = 6;
 // this skill leans on" list is where duplication accumulates without ever
 // looking like growth.
 // The retro.md change is the one worth re-reading before the next fold-back,
-// because this round produced it the expensive way -- TWO rounds of it. Round
-// one wrote a promotion-check hit into filing.md as a sourced incident; round
-// two found the cited issue was a different fixture and re-attributed it to a
-// BASENAME collision; round three found THAT was wrong too (the body names the
-// sibling by FULL path, so it was a citation, and the round-two remedy would
-// not have caught it). The fix is not a fourth sentence telling the reader to
-// judge -- it is the recipe printing the evidence to judge WITH. Three
-// reviewers had re-derived every byte figure in this file as correct
-// throughout; none of that touches whether the PROSE is true.
+// because this round produced it the expensive way -- FOUR rounds. Round one
+// wrote a promotion-check hit into filing.md as a sourced incident; round two
+// found the cited issue was a different fixture and blamed a BASENAME
+// collision; round three found that wrong too (the body names the sibling by
+// FULL path, so it was a citation) and escalated from prose to a recipe that
+// prints the body line; round four found THAT recipe pairs a basename hit with
+// the wrong sentence -- reproducing round one's error inside the mechanism
+// built to prevent it. So the recipe change was WITHDRAWN to
+// go-to-k/cdkd#2655 carrying both measured defects, and what ships is the
+// narrow certain part: read the sentence before believing a hit. Four
+// reviewers re-derived every byte figure in this file as correct throughout;
+// none of that touches whether the PROSE is true, which is the whole lesson.
 // The next addition here has to be
 // paid for by compression FIRST -- retro.md section 10-c forbids buying the
 // room by raising this floor, and note that SPLITTING a stage file makes this

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -283,21 +283,17 @@ const MIN_REFERENCE_FILES = 6;
 // this skill leans on" list is where duplication accumulates without ever
 // looking like growth.
 // The retro.md rule is the one worth re-reading before the next fold-back,
-// because of HOW it was arrived at: every review round on this PR found a
-// false PROSE claim in text this PR had added, each round's fix included. The
+// because of HOW it was arrived at, which the commit log carries in full: the
 // chain ran cited-the-wrong-fixture -> blamed a basename collision (also
 // wrong; the body names the sibling by FULL path) -> escalated to a recipe
 // printing the body line -> that recipe paired a basename hit with the wrong
 // sentence, reproducing the original error inside the mechanism built to
 // prevent it. So the recipe went to go-to-k/cdkd#2655 with both measured
-// defects and only the narrow certain part shipped. A reviewer re-derived
-// every byte figure here from the tree each round and found each correct
-// throughout -- which is the lesson: byte fences cannot see whether the PROSE
-// is true, so the counts above are checkable and the narrative is not.
-// The next addition here has to be
-// paid for by compression FIRST -- retro.md section 10-c forbids buying the
-// room by raising this floor, and note that SPLITTING a stage file makes this
-// bound tighter, not looser (a smaller runner-up raises `corpus - runnerUp`).
+// defects and only the narrow certain part shipped.
+// The next addition here has to be paid for by compression FIRST -- retro.md
+// section 10-c forbids buying the room by raising this floor, and note that
+// SPLITTING a stage file makes this bound tighter, not looser (a smaller
+// runner-up raises `corpus - runnerUp`).
 // History worth keeping: the floor was RAISED 206_000 -> 208_000 by the
 // 2026-09-02 retro (go-to-k/cdkd#2459) to fit its additions; retro.md
 // section 10-c now forbids that direction outright -- a retro pays for its

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,7 +122,7 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_752,
-    corpusBytes: 172_964,
+    corpusBytes: 172_952,
     largest: { file: 'verify.md', bytes: 28_154 },
     runnerUp: { file: 'implement.md', bytes: 28_079 },
   },
@@ -269,11 +269,11 @@ const MIN_REFERENCE_FILES = 6;
 // re-run-the-generators clause, ship.md's `gh pr checks` parsing rule,
 // verify.md's what-COUNTS-as-a-bypass clause, and retro.md's
 // read-the-SENTENCE-before-believing-a-hit rider -- and came out
-// 172,746 -> 172,964, i.e. +218 for the round
+// 172,746 -> 172,952, i.e. +206 for the round
 // with verify.md 27,876 -> 28,154 taking the lead from implement.md 28,079
-// (untouched); margin 130 -> 115 B. Components, stated so they can be checked
-// rather than believed: filing.md +640, gates-and-pr.md +276, retro.md +388,
-// ship.md +325, verify.md +278, gotchas.md -1,689, = +218. All of the payment
+// (untouched); margin 130 -> 127 B. Components, stated so they can be checked
+// rather than believed: filing.md +640, gates-and-pr.md +276, retro.md +376,
+// ship.md +325, verify.md +278, gotchas.md -1,689, = +206. All of the payment
 // came from ONE file, and by DISPLACEMENT rather than compression: gotchas.md
 // is the appendix, so every rule in it that only restated CLAUDE.md or another
 // stage was either pointed at or moved to the step where it fires (the
@@ -283,14 +283,19 @@ const MIN_REFERENCE_FILES = 6;
 // this skill leans on" list is where duplication accumulates without ever
 // looking like growth.
 // The retro.md change is the one worth re-reading before the next fold-back,
-// because this round produced it the expensive way -- FOUR rounds. Round one
-// wrote a promotion-check hit into filing.md as a sourced incident; round two
+// because this round produced it the expensive way: EVERY review round on this
+// PR found a false PROSE claim in that one bullet, including each round written
+// to correct the previous one -- which is why the sentence above carries no
+// round COUNT, a number every further round would falsify. Round one wrote a
+// promotion-check hit into filing.md as a sourced incident; the next round
 // found the cited issue was a different fixture and blamed a BASENAME
-// collision; round three found that wrong too (the body names the sibling by
+// collision; the next found that wrong too (the body names the sibling by
 // FULL path, so it was a citation) and escalated from prose to a recipe that
-// prints the body line; round four found THAT recipe pairs a basename hit with
+// prints the body line; the next found THAT recipe pairs a basename hit with
 // the wrong sentence -- reproducing round one's error inside the mechanism
-// built to prevent it. So the recipe change was WITHDRAWN to
+// built to prevent it; and the round recording the withdrawal still said the
+// false rule had SHIPPED, when it never left this PR. So the recipe change was
+// WITHDRAWN to
 // go-to-k/cdkd#2655 carrying both measured defects, and what ships is the
 // narrow certain part: read the sentence before believing a hit. A reviewer
 // re-derived every byte figure in this file from the tree at EVERY round and


### PR DESCRIPTION
Stage 10 of the `/work-issues` run that closed go-to-k/cdkd#2518, go-to-k/cdkd#2520, go-to-k/cdkd#2579, go-to-k/cdkd#2447, go-to-k/cdkd#2545 and go-to-k/cdkd#2438. Five rules, each landed in the stage file where it FIRES, paid for by displacing the appendix's restatements — no cap or floor was raised.

## The rules

**`references/retro.md` (section 10-0) — read the SENTENCE around the token before believing a promotion hit.** The check cannot tell a citation from a target, and its output does not help. go-to-k/cdkd#2621 cites a sibling fixture this run touched, by full path, and this retro shipped that hit into a rule as a sourced incident before three review rounds established otherwise. Printing the body line automatically was attempted and WITHDRAWN — see below.

**`references/filing.md` (section 5-f) — ask the WORKTREE question HERE, not at wrap.** Mid-lane the loud question is "can this ride THIS PR?" (usually no); the quiet one is "is the owning lane's worktree still open?". While it is, `next` is weak: another PR from that tree costs almost nothing. The rule deliberately does NOT overrule `.claude/rules/session-report.md`, which owns the criteria and rules a frozen-scope reason legal-but-expiring; all this step adds is the TIMING of the question. Cited by go-to-k/cdkd#2321 / go-to-k/cdkd#2322.

**`references/gates-and-pr.md` (section 7) — re-run the GENERATORS after a rebase, not just the suite.** `docs/_generated/**` derives from the whole tree, so a `tests/integration/**` edit adding no source line still moves a count. Measured on go-to-k/cdkd#2611: one `aws logs put-log-group-deletion-protection --log-group-identifier` line added to a `verify.sh` took `cli-flag-coverage` from 324 to 325. The clause names `/check` step 3's `vp run gen:all-matrices`, so the reader gets the command and not just the hazard.

**`references/ship.md` (section 9) — read a CI verdict from `--json`, never by splitting the human table on whitespace.** A matrix job's name carries a parenthesised suffix, so the naive split reads it as a status. Reproduced on go-to-k/cdkd#2644 while writing this: `awk '{print $2}'` reports `(20)` / `(22)` / `(24)` as statuses and invents three non-green checks, while `awk -F'\t' '{print $2}' | sort | uniq -c` reports the true `8 pass / 1 skipping`. A lane in this run made exactly that false "3 non-green" call.

**`references/verify.md` (sections 8-c and 8-i) — the `/run-integ` bypass is not the two command NAMES.** It is any real-AWS work outside a fixture: `node dist/cli.js <anything>` and resources made by hand for the test are the same act, EXIT traps and all. A lane in this run built a bucket and an IAM role from a hand-written script and ran `state destroy` against them; it self-reported, and no leftovers survived, but the rule as written named only `cdkd deploy` / `cdkd destroy`, so the act read as outside it. Section 8-i carried the loophole in its own text — "Tear down with `cdkd destroy … --force`" — and now says a fresh deploy is a fresh FIXTURE (`/new-integ` scaffolds one, `/run-integ` runs it).

## The review rounds, and why they are the PR's most useful output

Every round found a false PROSE claim in text this PR had added — including the rounds written to correct the previous one. The chain:

1. The filing.md rule cited go-to-k/cdkd#2621 as an instance of the worktree rule. It is not one — go-to-k/cdkd#2621's subject is `loggroup-never-expire-guard/verify.sh`; go-to-k/cdkd#2611 edited `loggroup-class-guard/verify.sh`.
2. The fix removed it and blamed a BASENAME collision. Also wrong: go-to-k/cdkd#2621's body names the class-guard path by FULL path, in a comparison — a citation matched at full path, which "resolve every hit to a FULL PATH" would not have discriminated.
3. So the fix escalated from prose to a recipe printing the body LINE each token came from.
4. That recipe paired a basename hit with the WRONG sentence (`grep -m1` on the token lands on the issue's subject line) — reproducing step 1's false reading inside the mechanism built to prevent it. Second defect: `cut -c1-110` can truncate the token out of its own window.
5. The withdrawal commit then said the false rule had "SHIPPED", when it never left this PR; and a round count went stale in the round that wrote it; and the universal written to replace the count was false (2 of 5).

Section 8-a says not to take the structural fix late in a cascade, and that a cascade ends by making the artifact CLAIM LESS. So: the recipe reverts byte-identical to `origin/main` and is filed as **go-to-k/cdkd#2655** with both measurements and the direction that works; the surviving rule is the narrow certain part (open the body, read the sentence); and the final round DELETED the two comment spans that could not be checked from the repo — an unverifiable claim about reviewers (this PR has zero GitHub reviews; they were subagents), and an open-set universal that the next round would falsify by finding nothing.

Re-checking the run's other six open `next` filings the same way: **no promotion hit survived as a real instance** — go-to-k/cdkd#2610's fourteen sites span ten files, none the one its lane held. So this run produced no instance of the worktree rule at all, and that rule carries only its two verified citations (go-to-k/cdkd#2321 / go-to-k/cdkd#2322, both confirmed lane-open at filing by reading the closing PRs' merge times).

Smaller findings along the way: `dirty-path-restore-gate` blocks the PATH-scoped restore on a DIRTY path only, so verify.md no longer over-claims it; the 8-c clause cites go-to-k/cdkd#2653 rather than an uncitable date; a MEASURED comment called a +220 round "NET NEGATIVE"; several ragged wraps. Two nits accepted as pre-existing design — nothing mechanical resolves the corpus's `§N` pointers, and prose rules are invisible to every fence but the byte floor.

## What it cost, and what paid for it

`gotchas.md` −1,689 B. Every rule in the appendix that only RESTATED `CLAUDE.md` or another stage now points at it, or moved to the step where it fires — including the IN-PLACE Stop-hook bullet's copy of section 9's restore recipe. Corpus 172,746 → 172,952 for five rules (+206); `verify.md` 27,876 → 28,154 takes the lead from `implement.md` 28,079 (untouched), and the binding floor margin goes 130 → **127 B**. Every figure is re-derived in `tests/unit/scripts/skill-file-payload.test.ts`'s asserted `MEASURED` record, re-derived from the tree at every round.

Read the appendix trim as the finding it is: an "Important existing rules this skill leans on" list is where duplication accumulates without ever looking like growth, and one of its bullets was actively contradicting a rule two stage files over.

## Mirrors: filed, not landed

Per `references/retro.md` section 10-c the finding session lands all three repos by default; this session takes the documented narrow exception and files instead, because it cannot pay the sibling repos' gate cycles. Both issues were resolved against that repo's CURRENT state first — merged `.claude/skills/work-issues/` files, open PRs, open issues — and all three FLOW lessons are missing from all three windows in both:

- go-to-k/cdk-local#708
- go-to-k/cdk-real-drift#1886

Each names the other, and each carries a correction comment retracting the go-to-k/cdkd#2621 citation and narrowing the rule the same way this PR did. Each also names the RECONCILIATION its own text needs: both repos currently state the OPPOSITE polarity for the worktree rule (cdk-local `implement.md:255`, cdk-real-drift `triage.md:378`), so a mirror there is a merge of two bullets, not an append. Neither repo has a `filing.md`, and neither has a `gen:` task or `docs/_generated` — the generator lesson maps onto their committed `skill-file-payload` `MEASURED` tables instead, which the issues state.

## Test plan

- `vp check --fix` + `vp run check`, `vp run typecheck:test`, `vp run build` — pass, both rounds.
- `vp test run` — 894 files / 18,979 passed, rooted in this worktree (project asserted per `/check` step 4).
- `vp run gen:all-matrices` + `vp run audit:coverage:check` + `vp run format` — no artifact went dirty.
- Prose arm of the live-test tier (no `src/**` in the diff): every gate, hook, skill, section and path the new text names was resolved against this repo's files. Both commands the new text sends a reader to run were RUN: `vp run gen:all-matrices`, and the whitespace-vs-TAB comparison on go-to-k/cdkd#2644.
- Every incident the new text cites was read at the source, not inherited — which is how the go-to-k/cdkd#2621 citation was caught and removed.
- Reviewers: code + test in parallel (heuristic floor was `1-reviewer`; agent-instruction files are deliberately not down-biased, and the diff has two independent risk axes), then a scoped delta review after EACH fix round. Every one re-derived the byte figures from the tree and confirmed all five caps and floors unchanged; each also found a false prose claim, which is what the chain above records.
- Gate liveness proved by driving `check-gate.sh` directly (rc=2, "Blocked by check-gate") and by `gated-command-preamble-gate` refusing a heredoc chained onto `git commit`. The plain `git commit --dry-run` probe was INCONCLUSIVE here, which is why section 6's wording now names a clean tree as a case where it proves nothing.
- No AWS leftovers: zero surviving `state.json` / `lock.json` / `rollback-journal.json` under `cdkd/`; the only residue is the `deployments/**` events store, which legitimately survives.

No `docs/changelog-cdkd.md` entry: agent-instruction changes ship no user-facing behavior delta, matching every recent retro PR.
