### PR TITLE
chore(rules): split hooks.md's authoring half out, and widen the satellite-index fence to reach it

### DIFF
--- a/.claude/rules/hooks-authoring.md
+++ b/.claude/rules/hooks-authoring.md
@@ -2,6 +2,7 @@
 description: Authoring a cdkd hook - why every Bash gate stays unconditional, and the unquoted-heredoc trap that executes a refusal message's worked example instead of printing it
 paths:
   - '.claude/hooks/*.sh'
+  - '.claude/settings.json'
 ---
 
 # Why every Bash gate stays unconditional

--- a/.claude/rules/hooks-authoring.md
+++ b/.claude/rules/hooks-authoring.md
@@ -1,0 +1,56 @@
+---
+description: Authoring a cdkd hook - why every Bash gate stays unconditional, and the unquoted-heredoc trap that executes a refusal message's worked example instead of printing it
+paths:
+  - '.claude/hooks/*.sh'
+---
+
+# Why every Bash gate stays unconditional
+
+**Every Bash-targeting `PreToolUse` entry in `.claude/settings.json` uses the
+coarse `Bash` matcher AND no per-hook `if:` condition.** The absent `if:` is
+the load-bearing half: each gate parses the command itself, which is what
+lets gates catch the `cd <path> && ...` and `gh -C <path>` spellings.
+
+The `if:` fields silently never fired (go-to-k/cdkd#1455 / #1476 — see "The
+`if:` layer is GONE" in [hooks.md](hooks.md), which this file split out of). Their removal also immunises cdkd against the
+go-to-k/cdk-real-drift#1788 bypass class (measured 2026-08-19 via
+go-to-k/cdkd#2016: that repo's matcher was the coarse `Bash` too — the
+asymmetry was per-hook `if:` conditions; cdkd carries 0 `if:` fields across
+35 Bash hooks, and `check-gate` / `verify-pr-gate` answer rc=2 for the bare
+and the `cd <wt> && ...` spellings alike). This matters because
+`/work-issues` writes commands in exactly that form. **Fenced by
+`tests/unit/scripts/settings-bash-matcher-coverage.test.ts`**: fails on any
+per-hook `if:`, any command-narrowed `Bash(...)` matcher, and the removal of
+`check-gate` / `verify-pr-gate` / `non-english-text-gate` from the coarse
+entry, with a parser floor so "found nothing" cannot pass as "everything
+matches".
+
+# Writing a hook's refusal message
+
+**A hook that prints its remediation with `cat >&2 <<EOF` is running an
+UNQUOTED heredoc**, so `$( )`, backticks and `$var` in the body expand at
+REFUSAL time rather than printing. That matters here more than in ordinary
+shell, because a refusal message is exactly where a worked example belongs:
+the useful advice is a command, and a command is what the heredoc eats.
+
+Measured 2026-09-06 (issue [#2630](https://github.com/go-to-k/cdkd/issues/2630),
+PR [#2652](https://github.com/go-to-k/cdkd/pull/2652)): `ci-green-gate`'s
+no-checks branch gained an advised poll containing `$(gh pr checks ...)`. The
+agent read `until [ -n "" ]; do sleep 20; done` — an unconditional infinite
+loop, since the substitution had already run and returned empty — preceded by
+a `command not found` line from an unescaped backtick, and the gate fired a
+SECOND live `gh` call from inside a PreToolUse hook. The advice shipped the
+exact hot-spin it was written to remove, deterministically: that branch only
+runs when stdout is empty.
+
+Two rules follow:
+
+- **Escape every `$` and backtick you mean to PRINT** (`\$(`, `` \` ``), or
+  switch the delimiter to `<<'EOF'` and interpolate the few values you do want
+  with a separate `printf`. `${pr_number:-<PR>}` in that message is deliberate
+  — it is the one value that SHOULD expand.
+- **Assert the rendered message in the hook's test harness**, not a
+  re-statement of it. A case that drives a predicate the test file declares
+  passes just as well when the hook's text is reverted or replaced with
+  nonsense; only reading the hook's own stderr catches an executed heredoc,
+  because the damage is visible nowhere else.

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -31,26 +31,7 @@ vp run test:hooks     # or: bash .claude/hooks/run-tests.sh
   git repos, ~6 min). `.github/workflows/hooks.yml` runs it on `macos-latest`
   (the only runner image with bash 3.2) on any `.claude/hooks/**` PR.
 
-# Why every Bash gate stays unconditional
-
-**Every Bash-targeting `PreToolUse` entry in `.claude/settings.json` uses the
-coarse `Bash` matcher AND no per-hook `if:` condition.** The absent `if:` is
-the load-bearing half: each gate parses the command itself, which is what
-lets gates catch the `cd <path> && ...` and `gh -C <path>` spellings.
-
-The `if:` fields silently never fired (go-to-k/cdkd#1455 / #1476 — see "The
-`if:` layer is GONE" below). Their removal also immunises cdkd against the
-go-to-k/cdk-real-drift#1788 bypass class (measured 2026-08-19 via
-go-to-k/cdkd#2016: that repo's matcher was the coarse `Bash` too — the
-asymmetry was per-hook `if:` conditions; cdkd carries 0 `if:` fields across
-35 Bash hooks, and `check-gate` / `verify-pr-gate` answer rc=2 for the bare
-and the `cd <wt> && ...` spellings alike). This matters because
-`/work-issues` writes commands in exactly that form. **Fenced by
-`tests/unit/scripts/settings-bash-matcher-coverage.test.ts`**: fails on any
-per-hook `if:`, any command-narrowed `Bash(...)` matcher, and the removal of
-`check-gate` / `verify-pr-gate` / `non-english-text-gate` from the coarse
-entry, with a parser floor so "found nothing" cannot pass as "everything
-matches".
+Authoring a hook — why every Bash gate stays unconditional, and why an unquoted `cat >&2 <<EOF` EXECUTES the advice it means to print: [hooks-authoring.md](hooks-authoring.md).
 
 # Other PreToolUse safety hooks
 

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -219,9 +219,13 @@ const REACH_FLOORS: ReadonlyMap<string, number> = new Map([
   ['docker-argv-redaction.md', 8], // literal list: EXACT, see below
   ['docs-page-template.md', 63], // `docs/**`; measured 79 tracked files (80%, per the convention above)
   ['hooks.md', 68],
-  // 93 files: the 46 hooks and their 46 `.test.sh` suites, which ONE glob
-  // reaches because a suite's name also ends in `.sh`, plus
-  // `.claude/settings.json`. That last path is not decoration -- the
+  // 93 files: the 92 entries `.claude/hooks/*.sh` reaches at depth 1 -- 46
+  // whose names end `.test.sh` and 46 that do not, which ONE glob covers
+  // because a suite's name also ends in `.sh` -- plus `.claude/settings.json`.
+  // The 46/46 is a coincidence of counts, NOT a pairing: `run-tests.sh` is a
+  // runner rather than a hook, `post-merge-sync-reminder.sh` has no suite, and
+  // `markgate-gate-name-class.test.sh` / `unresolved-target-class.test.sh` are
+  // suites belonging to no single hook. That last path is not decoration -- the
   // "Why every Bash gate stays unconditional" section moved here is ABOUT
   // settings.json (the coarse `Bash` matcher, the absent per-hook `if:`), so a
   // `.claude/hooks/*.sh`-only glob took 1,226 B dark for the one file the text
@@ -372,7 +376,7 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // landmine shape CORPUS_BYTES_MAX's comment names) and its branch-gate bullet
   // one line past the >4000 B ratchet. Moved out verbatim, hooks.md is 115,030 B
   // and the satellite 6,454 B.
-  ['.claude/hooks/branch-gate.sh', 74_000, 140_000], // measured 121,484
+  ['.claude/hooks/branch-gate.sh', 74_000, 140_000], // measured 94,795
   // The shared matcher pulls hooks.md AND the class-fence satellite, which is
   // the only path that loads both. hooks.md outgrew the 120,000 per-file cap on
   // its own, so the two CLASS fences moved to a satellite of their own rather
@@ -385,14 +389,14 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // Deliberately NOT added to the command-match row above: that path already
   // carries hooks.md + hooks-class-fences.md and has ~15 KB of headroom, which
   // adding a third file would spend down to about 1 KB.
-  ['.claude/hooks/integ-local-gate.sh', 76_000, 140_000], // measured 97,376
+  ['.claude/hooks/integ-local-gate.sh', 76_000, 140_000], // measured 97,404
   // The cwd-race detector's entry moved out of hooks.md when the #2363
   // widening pushed that file past the 120,000 B per-file cap (the #2236
   // precedent). This path is the representative one for the satellite
   // (its two globs are the hook and its .test.sh, per the REACH_FLOORS
   // entry above); without this row the satellite would sit under no
   // budget. Payload is hooks.md + hooks-cwd-detector.md.
-  ['.claude/hooks/main-tree-git-cwd-detector.sh', 73_000, 140_000], // measured 94,052
+  ['.claude/hooks/main-tree-git-cwd-detector.sh', 73_000, 140_000], // measured 94,080
   // main-tree-branch-gate's entry moved out of hooks.md on 2026-09-01, when the
   // argument-parse rewrite's measured before/after table pushed that file to
   // 122,862 B -- past the same 120,000 B per-file cap, and one line past the
@@ -400,7 +404,7 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // globs are the hook and its suite, per the REACH_FLOORS entry above);
   // without this row the satellite would sit under no budget at all. Payload is
   // hooks.md + hooks-main-tree-branch.md.
-  ['.claude/hooks/main-tree-branch-gate.sh', 82_000, 152_000], // measured 104,271
+  ['.claude/hooks/main-tree-branch-gate.sh', 82_000, 152_000], // measured 104,299
   //   The comment here read "measured 124,200" and the payload was already
   //   124,758 when it was written -- 558 B behind on the day it shipped, because
   //   the satellite kept being edited after the figure was taken. Re-measured at
@@ -415,7 +419,7 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // pushed that file to 122,559 B, past the same cap. Representative path for
   // the satellite (its four globs are the two hooks and their suites, per the
   // REACH_FLOORS entry above). Payload is hooks.md + hooks-stop.md.
-  ['.claude/hooks/stop-warn.sh', 77_000, 140_000], // measured 98,454
+  ['.claude/hooks/stop-warn.sh', 77_000, 140_000], // measured 98,482
   // Second review round, 2026-08-25: three heavy paths still carried no budget
   // at all. `masked-retry-logger.ts` is the 2nd-heaviest path in the repo and
   // was covered only by prose, in the `region-check.ts` row's claim to speak
@@ -1275,16 +1279,24 @@ describe('.claude/rules payload fence', () => {
       // a perfectly good index row, and an earlier form reported it as missing
       // because it required the text to repeat the filename.
       for (const m of rows.join('\n').matchAll(/\[[^\]]+\]\(([a-z0-9-]+\.md)\)/g)) {
-        // Credit a link only to the family this index OWNS. `linked` is
-        // shared across indexes while `prefix` is per-index, so without this
-        // a prose sentence in hooks.md naming a `layout-*` file would satisfy
-        // code-layout.md's orphan check -- silently granting prose mode to a
-        // table index, which the comment above says must never happen. Latent
-        // today (hooks.md links only `hooks-*` files and two unprefixed ones),
-        // so it is a fence against the next editor, not a live fix.
+        // TWO separate questions, and the order matters. Does the target
+        // EXIST is asked of every link an index makes, including the
+        // unprefixed ones -- hooks.md prose names `session-report.md` and
+        // `gate-sibling-repos.md`, and a rename of either must still be
+        // reported. Filtering by family first shadowed exactly that: the
+        // first cut of this fix put the `continue` above this line and
+        // narrowed the dangling-link half live, not latently (round 2 on
+        // go-to-k/cdkd#2657 -- the fix for one half quietly deleting the
+        // other is why every fix round gets reviewed).
+        if (!ruleFiles.some((r) => r.name === m[1]!)) broken.push(`${idx} -> ${m[1]!}`);
+        // Does it COUNT as this family's index entry is asked only of the
+        // family this index OWNS. `linked` is shared across indexes while
+        // `prefix` is per-index, so without this a prose sentence in hooks.md
+        // naming a `layout-*` file would satisfy code-layout.md's orphan
+        // check -- silently granting prose mode to a table index, which the
+        // comment above says must never happen.
         if (!prefix.test(m[1]!)) continue;
         linked.add(m[1]!);
-        if (!ruleFiles.some((r) => r.name === m[1]!)) broken.push(`${idx} -> ${m[1]!}`);
       }
     }
     expect(broken, `Index rows point at rule files that do not exist: ${broken.join(', ')}.`).toEqual(

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -219,6 +219,11 @@ const REACH_FLOORS: ReadonlyMap<string, number> = new Map([
   ['docker-argv-redaction.md', 8], // literal list: EXACT, see below
   ['docs-page-template.md', 63], // `docs/**`; measured 79 tracked files (80%, per the convention above)
   ['hooks.md', 68],
+  // `.claude/hooks/*.sh` -- the 92 hooks and their .test.sh siblings (the
+  // suites end in .sh, so one glob reaches both). Floor at ~80% per the
+  // convention above: this satellite is the AUTHORING half of hooks.md and
+  // must never be narrowed to the handful of hooks a lane happens to edit.
+  ['hooks-authoring.md', 73],
   ['hooks-class-fences.md', 5], // literal list: EXACT, see below
   ['hooks-main-tree-branch.md', 2], // literal list: EXACT, see below
   ['hooks-branch-gate.md', 2], // literal list: EXACT, see below
@@ -571,7 +576,20 @@ const ruleFiles: RuleFile[] = readdirSync(RULES_DIR, { recursive: true })
 //   - the UPPER bound catches growth that spreads thinly enough to stay under
 //     every per-file cap.
 // Update these deliberately, with the reason, when the corpus genuinely moves.
-const CORPUS_FILE_COUNT = 45; // 29 + gate-sibling-repos.md (hooks.md crossed the per-file cap, so
+const CORPUS_FILE_COUNT = 46; // + hooks-authoring.md (go-to-k/cdkd#2630): hooks.md crossed the
+                              //  per-file cap for the FOURTH time, exactly as the comment above
+                              //  this file's hooks.md row predicted it would -- that row records
+                              //  the decision that the next lane needing more than 2,531 B in
+                              //  hooks.md splits rather than trims or nudges the cap, and this is
+                              //  that lane. Two AUTHORING sections moved out verbatim under a
+                              //  `.claude/hooks/*.sh` glob: "Why every Bash gate stays
+                              //  unconditional" (already there) and the new refusal-message
+                              //  heredoc rule. They belong together -- both answer "how do I
+                              //  write a hook", which every OTHER section of hooks.md does not.
+                              //  hooks.md was 79,891 B on origin/main with the new rule already
+                              //  over the 80,000 cap; it is 78,844 B after the split, the
+                              //  satellite is 3,187 B and the pointer left behind is 179 B.
+                              //  That makes 46. // 29 + gate-sibling-repos.md (hooks.md crossed the per-file cap, so
                               //  its cross-repo gate-aliasing section moved out verbatim,
                               //  go-to-k/cdkd#2236) + asset-bucket-region.md (issue go-to-k/cdkd#2240
                               //  split out of assets.md). Both landed as 30 independently; merged
@@ -1209,10 +1227,22 @@ describe('.claude/rules payload fence', () => {
     // -- which is why nothing noticed. It stops being findable by a human
     // reading code-layout.md, which is how the next split decides where text
     // belongs.
-    const indexes = ['code-layout.md', 'providers.md'];
+    // Two index SHAPES, because the corpus has two. `code-layout.md` /
+    // `providers.md` index their families with a TABLE, so a row is required
+    // there for the reasons below. The `hooks-*` family's index is `hooks.md`
+    // itself, which has no table -- all five pre-existing satellites are
+    // reached by a PROSE sentence at the point the text was lifted from, which
+    // is the right shape for that family and the only one available. Prose is
+    // the weaker mode (the probes below show why), so it is granted only to
+    // the family that has no alternative, not to the table indexes.
+    const indexes: readonly { file: string; prefix: RegExp; rowsOnly: boolean }[] = [
+      { file: 'code-layout.md', prefix: /^layout-/, rowsOnly: true },
+      { file: 'providers.md', prefix: /^provider-/, rowsOnly: true },
+      { file: 'hooks.md', prefix: /^hooks-/, rowsOnly: false },
+    ];
     const linked = new Set<string>();
     const broken: string[] = [];
-    for (const idx of indexes) {
+    for (const { file: idx, rowsOnly } of indexes) {
       // TABLE ROWS only, and only OUTSIDE fenced code blocks. A prose pointer
       // elsewhere in the file also makes a satellite findable, but it is not
       // the index -- a review probe deleted `layout-utils.md`'s row and the
@@ -1228,12 +1258,17 @@ describe('.claude/rules payload fence', () => {
           inFence = !inFence;
           continue;
         }
-        if (!inFence && line.trimStart().startsWith('|')) rows.push(line);
+        // A self-link is never an index entry: it is what a split leaves
+        // behind when the pointer is written into the SATELLITE instead of the
+        // file it was lifted from. Excluded here so that shape cannot satisfy
+        // the check from inside an index file either.
+        if (!inFence && (rowsOnly ? line.trimStart().startsWith('|') : true)) rows.push(line);
       }
       // Link TEXT is unconstrained: a row reading `[utils](layout-utils.md)` is
       // a perfectly good index row, and an earlier form reported it as missing
       // because it required the text to repeat the filename.
       for (const m of rows.join('\n').matchAll(/\[[^\]]+\]\(([a-z0-9-]+\.md)\)/g)) {
+        if (m[1]! === idx) continue;
         linked.add(m[1]!);
         if (!ruleFiles.some((r) => r.name === m[1]!)) broken.push(`${idx} -> ${m[1]!}`);
       }
@@ -1243,10 +1278,10 @@ describe('.claude/rules payload fence', () => {
     );
     const orphans = ruleFiles
       .map((r) => r.name)
-      .filter((n) => /^(layout|provider)-/.test(n) && !linked.has(n));
+      .filter((n) => indexes.some((i) => i.prefix.test(n)) && !linked.has(n));
     expect(
       orphans,
-      `${orphans.join(', ')} are satellites that no index links to. They still load by their own \`paths:\`, so no budget notices -- but the next person deciding where a paragraph belongs reads the index, not the directory. Add a row to code-layout.md or providers.md.`,
+      `${orphans.join(', ')} are satellites that no index links to. They still load by their own \`paths:\`, so no budget notices -- but the next person deciding where a paragraph belongs reads the index, not the directory. Add a row to code-layout.md or providers.md, or -- for a \`hooks-*\` satellite -- a prose pointer in hooks.md at the point the text was lifted from. The pointer belongs in the file the text LEFT, not in the satellite: a satellite naming itself is not an inbound link and does not count here.`,
     ).toEqual([]);
   });
 

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -219,11 +219,18 @@ const REACH_FLOORS: ReadonlyMap<string, number> = new Map([
   ['docker-argv-redaction.md', 8], // literal list: EXACT, see below
   ['docs-page-template.md', 63], // `docs/**`; measured 79 tracked files (80%, per the convention above)
   ['hooks.md', 68],
-  // `.claude/hooks/*.sh` -- the 92 hooks and their .test.sh siblings (the
-  // suites end in .sh, so one glob reaches both). Floor at ~80% per the
+  // 93 files: the 46 hooks and their 46 `.test.sh` suites, which ONE glob
+  // reaches because a suite's name also ends in `.sh`, plus
+  // `.claude/settings.json`. That last path is not decoration -- the
+  // "Why every Bash gate stays unconditional" section moved here is ABOUT
+  // settings.json (the coarse `Bash` matcher, the absent per-hook `if:`), so a
+  // `.claude/hooks/*.sh`-only glob took 1,226 B dark for the one file the text
+  // describes, and no assertion here could see it: a floor is computed against
+  // the satellite's OWN glob, so narrowing the glob narrows the floor with it.
+  // Review caught it; that is the gap, not a fence. Floor at ~80% per the
   // convention above: this satellite is the AUTHORING half of hooks.md and
   // must never be narrowed to the handful of hooks a lane happens to edit.
-  ['hooks-authoring.md', 73],
+  ['hooks-authoring.md', 74],
   ['hooks-class-fences.md', 5], // literal list: EXACT, see below
   ['hooks-main-tree-branch.md', 2], // literal list: EXACT, see below
   ['hooks-branch-gate.md', 2], // literal list: EXACT, see below
@@ -370,7 +377,7 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // the only path that loads both. hooks.md outgrew the 120,000 per-file cap on
   // its own, so the two CLASS fences moved to a satellite of their own rather
   // than the cap being raised -- a cap that moves when it fires is not a cap.
-  ['.claude/hooks/lib/command-match.sh', 76_000, 140_000], // measured 132,187
+  ['.claude/hooks/lib/command-match.sh', 76_000, 140_000], // measured 96,138
   // The four `integ-*` gates were the heaviest UNBUDGETED paths once
   // `gate-sibling-repos.md` split out of hooks.md: this row is the only one
   // that names them, so without it the satellite sits under no budget at all
@@ -378,14 +385,14 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // Deliberately NOT added to the command-match row above: that path already
   // carries hooks.md + hooks-class-fences.md and has ~15 KB of headroom, which
   // adding a third file would spend down to about 1 KB.
-  ['.claude/hooks/integ-local-gate.sh', 76_000, 140_000], // measured 132,814
+  ['.claude/hooks/integ-local-gate.sh', 76_000, 140_000], // measured 97,376
   // The cwd-race detector's entry moved out of hooks.md when the #2363
   // widening pushed that file past the 120,000 B per-file cap (the #2236
   // precedent). This path is the representative one for the satellite
   // (its two globs are the hook and its .test.sh, per the REACH_FLOORS
   // entry above); without this row the satellite would sit under no
   // budget. Payload is hooks.md + hooks-cwd-detector.md.
-  ['.claude/hooks/main-tree-git-cwd-detector.sh', 73_000, 140_000], // measured 129,490
+  ['.claude/hooks/main-tree-git-cwd-detector.sh', 73_000, 140_000], // measured 94,052
   // main-tree-branch-gate's entry moved out of hooks.md on 2026-09-01, when the
   // argument-parse rewrite's measured before/after table pushed that file to
   // 122,862 B -- past the same 120,000 B per-file cap, and one line past the
@@ -393,7 +400,7 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // globs are the hook and its suite, per the REACH_FLOORS entry above);
   // without this row the satellite would sit under no budget at all. Payload is
   // hooks.md + hooks-main-tree-branch.md.
-  ['.claude/hooks/main-tree-branch-gate.sh', 82_000, 152_000], // measured 135,138
+  ['.claude/hooks/main-tree-branch-gate.sh', 82_000, 152_000], // measured 104,271
   //   The comment here read "measured 124,200" and the payload was already
   //   124,758 when it was written -- 558 B behind on the day it shipped, because
   //   the satellite kept being edited after the figure was taken. Re-measured at
@@ -408,7 +415,7 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // pushed that file to 122,559 B, past the same cap. Representative path for
   // the satellite (its four globs are the two hooks and their suites, per the
   // REACH_FLOORS entry above). Payload is hooks.md + hooks-stop.md.
-  ['.claude/hooks/stop-warn.sh', 77_000, 140_000], // measured 133,753
+  ['.claude/hooks/stop-warn.sh', 77_000, 140_000], // measured 98,454
   // Second review round, 2026-08-25: three heavy paths still carried no budget
   // at all. `masked-retry-logger.ts` is the 2nd-heaviest path in the repo and
   // was covered only by prose, in the `region-check.ts` row's claim to speak
@@ -577,11 +584,15 @@ const ruleFiles: RuleFile[] = readdirSync(RULES_DIR, { recursive: true })
 //     every per-file cap.
 // Update these deliberately, with the reason, when the corpus genuinely moves.
 const CORPUS_FILE_COUNT = 46; // + hooks-authoring.md (go-to-k/cdkd#2630): hooks.md crossed the
-                              //  per-file cap for the FOURTH time, exactly as the comment above
-                              //  this file's hooks.md row predicted it would -- that row records
-                              //  the decision that the next lane needing more than 2,531 B in
-                              //  hooks.md splits rather than trims or nudges the cap, and this is
-                              //  that lane. Two AUTHORING sections moved out verbatim under a
+                              //  per-file cap again -- at least the seventh split off this one
+                              //  file, counting the six satellites it already points at, so do not
+                              //  read the ordinals in the older entries below as a running total.
+                              //  The comment above this file's hooks.md row records the decision
+                              //  that the next lane needing more room there splits rather than
+                              //  trims someone else's entry or nudges the cap, and this is that
+                              //  lane. (That comment's "2,531 B" was measured against the retired
+                              //  120,000 cap; under the re-derived 80,000 one main's headroom was
+                              //  109 B. The DECISION is what carried over, not the figure.) Two AUTHORING sections moved out verbatim under a
                               //  `.claude/hooks/*.sh` glob: "Why every Bash gate stays
                               //  unconditional" (already there) and the new refusal-message
                               //  heredoc rule. They belong together -- both answer "how do I
@@ -1242,7 +1253,7 @@ describe('.claude/rules payload fence', () => {
     ];
     const linked = new Set<string>();
     const broken: string[] = [];
-    for (const { file: idx, rowsOnly } of indexes) {
+    for (const { file: idx, prefix, rowsOnly } of indexes) {
       // TABLE ROWS only, and only OUTSIDE fenced code blocks. A prose pointer
       // elsewhere in the file also makes a satellite findable, but it is not
       // the index -- a review probe deleted `layout-utils.md`'s row and the
@@ -1258,17 +1269,20 @@ describe('.claude/rules payload fence', () => {
           inFence = !inFence;
           continue;
         }
-        // A self-link is never an index entry: it is what a split leaves
-        // behind when the pointer is written into the SATELLITE instead of the
-        // file it was lifted from. Excluded here so that shape cannot satisfy
-        // the check from inside an index file either.
         if (!inFence && (rowsOnly ? line.trimStart().startsWith('|') : true)) rows.push(line);
       }
       // Link TEXT is unconstrained: a row reading `[utils](layout-utils.md)` is
       // a perfectly good index row, and an earlier form reported it as missing
       // because it required the text to repeat the filename.
       for (const m of rows.join('\n').matchAll(/\[[^\]]+\]\(([a-z0-9-]+\.md)\)/g)) {
-        if (m[1]! === idx) continue;
+        // Credit a link only to the family this index OWNS. `linked` is
+        // shared across indexes while `prefix` is per-index, so without this
+        // a prose sentence in hooks.md naming a `layout-*` file would satisfy
+        // code-layout.md's orphan check -- silently granting prose mode to a
+        // table index, which the comment above says must never happen. Latent
+        // today (hooks.md links only `hooks-*` files and two unprefixed ones),
+        // so it is a fence against the next editor, not a live fix.
+        if (!prefix.test(m[1]!)) continue;
         linked.add(m[1]!);
         if (!ruleFiles.some((r) => r.name === m[1]!)) broken.push(`${idx} -> ${m[1]!}`);
       }
@@ -1281,7 +1295,7 @@ describe('.claude/rules payload fence', () => {
       .filter((n) => indexes.some((i) => i.prefix.test(n)) && !linked.has(n));
     expect(
       orphans,
-      `${orphans.join(', ')} are satellites that no index links to. They still load by their own \`paths:\`, so no budget notices -- but the next person deciding where a paragraph belongs reads the index, not the directory. Add a row to code-layout.md or providers.md, or -- for a \`hooks-*\` satellite -- a prose pointer in hooks.md at the point the text was lifted from. The pointer belongs in the file the text LEFT, not in the satellite: a satellite naming itself is not an inbound link and does not count here.`,
+      `${orphans.join(', ')} are satellites that no index links to. They still load by their own \`paths:\`, so no budget notices -- but the next person deciding where a paragraph belongs reads the index, not the directory. Add a row to code-layout.md or providers.md, or -- for a \`hooks-*\` satellite -- a prose pointer in hooks.md at the point the text was lifted from. The pointer belongs in the file the text LEFT, not in the satellite -- only the index files above are scanned, so a satellite naming itself is not an inbound link and cannot clear this.`,
     ).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

The heredoc rule added in go-to-k/cdkd#2652 pushed `.claude/rules/hooks.md`
past the 80,000 B per-file cap in
`tests/unit/scripts/rule-file-payload.test.ts`. That file's own comment beside
the `hooks.md` row had already decided what this lane should do:

> the NEXT lane that needs more than 2,531 B in hooks.md splits it (the
> go-to-k/cdkd#2236 shape), rather than trimming someone else's entry or
> nudging this constant. Stated here so that lane inherits a decision instead
> of a surprise.

So `CORPUS_FILE_COUNT` goes 45 -> 46 by the recorded decision, not by a fresh
judgment call.

**The split.** Two sections move verbatim into a new
`.claude/rules/hooks-authoring.md`: the new refusal-message heredoc rule and
the existing "Why every Bash gate stays unconditional". Both answer *how do I
write a hook*, which no other section of `hooks.md` does. Both had to move —
`hooks.md` had 109 B of headroom, so a pointer alone could not have fit.
Measured: `hooks.md` 79,891 B on `origin/main` -> 78,844 B; satellite 3,215 B;
pointer 179 B.

## What review caught, and why nothing else could

The split shipped with a **major** defect, found in round 1.

`hooks.md` serves three globs — `.claude/hooks/**`, `.claude/settings.json`,
`.markgate.yml`. The section moved out is *about* `.claude/settings.json`: its
first sentence is the coarse `Bash` matcher and the absent per-hook `if:`. The
satellite was given `.claude/hooks/*.sh` alone — topically right, and it took
1,226 B dark for the one file the text describes. Measured: `settings.json`
pulled 78,844 B before the fix (hooks.md alone), 82,059 B after.

**No assertion here could have seen it.** `REACH_FLOORS` exists to notice a
satellite's glob being narrowed, but a floor is computed against that
satellite's *own* glob — so narrowing the glob narrows the floor with it. The
payload budgets are keyed on paths someone thought to add a row for, and there
is no `.claude/settings.json` row. Fixed by adding the path and raising the
floor 73 -> 74.

Two smaller defects from the same split, also fixed: the pointer was written
into the SATELLITE, naming itself, instead of into `hooks.md` where the text
was lifted from; and the moved text's "see 'The `if:` layer is GONE' below"
stopped resolving, since that section stayed behind.

## The fence widening

The self-naming pointer should have been caught. `rule-file-payload.test.ts`
already has an "every satellite is reachable from an index" case — but it
derived its population from two filename prefixes (`layout-`, `provider-`)
while its message claimed *every satellite*, so all six `hooks-*` satellites
sat outside it. That is a fence not watching the field it claims, in the
corpus's own fence.

`hooks.md` joins as a third index for the `hooks-` prefix, in **prose mode**:
it has no table, and all five pre-existing satellites are already reached by a
sentence at the lift point. Prose is the weaker mode — the existing comment
records two review probes that defeated it — so it is granted only to the
family that has no alternative, never to the table indexes. Round 1 then found
that the first cut of this granted prose mode to the table indexes anyway: one
`linked` Set was shared across indexes while `prefix` was per-index, so a prose
sentence in `hooks.md` naming a `layout-*` file would have satisfied
`code-layout.md`'s orphan check. Links are now credited per family.

## Test plan

`vp test run` — 894 files, 18,984 tests, 1 skipped, rooted in this worktree
(`RUN` header asserted against `pwd -P`). `vp check --fix`, `vp run check`,
`vp run typecheck:test`, `vp run build`, `vp run gen:all-matrices` +
`vp run audit:coverage:check` all clean; no generated artifact was stale.

**Break-tested against the real defects** — one mutation per probe, tree
restored byte-exact between them, each verified to red on the right *target*
rather than merely to red:

| Probe | Mutation | Result |
| --- | --- | --- |
| A | delete the pointer line from `hooks.md` | reds naming `hooks-authoring.md` |
| B | additionally re-add it self-referentially inside the satellite — the tree this PR started from | still reds naming `hooks-authoring.md` |
| C | guard-the-guard: delete the pre-existing `layout-utils.md` table row | reds naming `layout-utils.md`, so table mode survived the widening |
| D | prose link to `layout-utils.md` in `hooks.md` **and** its `code-layout.md` row deleted | reds — prose cannot rescue a table family |

Probes A and C were re-run against the changed fence after the fix round, not
carried over.

Five `// measured N` payload figures on the `.claude/hooks` rows were stale by
~36 KB from a change before this one; re-measured on this tree as 96,138 /
97,376 / 94,052 / 104,271 / 98,454. Two unverified counts in the same comments
were corrected: "the 92 hooks and their `.test.sh` siblings" (92 *is* 46 + 46)
and "the FOURTH time" (at least the seventh split off `hooks.md`).

No `src/**` change, so no CLI, state-schema, provider or dependency surface is
touched; `integ-destroy` / `integ-broad` / `integ-local` /
`integ-schema-migration` are all out of scope for this diff.

## Review

Three rounds, each scoped to the previous round's fix delta. Rounds 1 and 2
both found the fix round damaging what it was fixing, which is why round 3 ran
at all; round 3 came back clean and the recursion stopped there.

- **Round 1, major** — the `settings.json` dark-bytes defect above, plus six
  smaller findings: a `linked` Set shared across index families, an inert
  self-link guard, three unverified counts, and five stale `// measured N`
  figures.
- **Round 2** — round 1's per-family filter had been placed ABOVE the
  existence check, so links to unprefixed targets stopped being
  existence-checked at all: a live regression, not the latent one the commit
  message claimed. Four of the five re-measured figures were also stale by
  exactly 28 B, because they were taken before the same commit grew the
  satellite — this PR's own defect class, re-committed inside the fix for it.
  A sixth row of that class had been missed entirely.
- **Round 3** — clean. Verified all six figures independently, all four claims
  in the corrected 46/46 comment, and that the reordering credits and reports
  exactly what it did before.

## Left out, deliberately

Eight prefix-less satellites remain outside the fence's population, and
`docs-page-template.md` is a **live orphan** behind that gap — grepping every
`.md`, `.ts`, `.yml` and `.sh` in the repo finds no rule file and no
`CLAUDE.md` section pointing at it, only three lines of the payload test
itself. Closing that class needs a discriminator between a satellite and a
top-level rule file, plus a decision about where that page's pointer belongs —
a design question rather than a residual of this split, so it is filed as
go-to-k/cdkd#2656 (`Session-fit: next`, `Severity: low`, `Effort: small (S)`,
`Estimate: 45m`) rather than folded in here.

Round 3 also found four Markdown shapes the assertion's link parser cannot see
— tilde and indented fences, links inside HTML comments, anchored links
(`](file.md#sec)`, which has a live occurrence at `.claude/rules/providers.md:69`
and fails toward a FALSE orphan as well as a missed one), and reference-style
links. All four are pre-existing parser gaps rather than regressions from this
diff, and all four are latent: no satellite in the corpus is mis-reported
today. Filed as go-to-k/cdkd#2663 (`Session-fit: next`, `Severity: low`,
`Effort: small (S)`, `Estimate: ~1-2 h`) — the fix is to harden one scanner,
not to bolt on four cases.

One further round-3 nit is shipped as-is rather than filed: `broken` collects
one entry per link OCCURRENCE, so a file linked twice from the same index is
named twice in the failure message (round 2's probe F showed
`hooks.md -> session-report.md` twice). The assertion still fails correctly and
still names the right file — this is message noise, and de-duplicating it would
cost a `Set` round-trip to make a failure that already reads correctly read
slightly tidier.
