### PR TITLE
chore(ci): inherit issue labels from the qualified `owner/repo#N` closing form

### DIFF
--- a/.github/workflows/pr-inherit-issue-labels.yml
+++ b/.github/workflows/pr-inherit-issue-labels.yml
@@ -17,7 +17,8 @@ name: PR inherit issue labels
 # definition from the BASE branch with a write token, which is safe here only
 # because the sole PR-controlled input is the body TEXT: it is fetched
 # server-side with `gh pr view` rather than interpolated from the event payload,
-# and it is scanned for `#<digits>` and never handed to a shell.
+# and it is scanned for `#<digits>`, `<owner>/<repo>#<digits>` and the issue
+# URL form, never handed to a shell.
 #
 # ADD-ONLY. Labels already on the PR are never removed: a human may have
 # curated them, and this workflow re-runs on every `edited`.
@@ -78,7 +79,7 @@ jobs:
           # `$REPO` is interpolated into an ERE, so a `.` in either half of
           # `owner/name` would act as a wildcard and let a near-miss repo pass
           # as this one. Escape it rather than trusting today's name.
-          repo_re=$(printf %s "$REPO" | sed 's/[.[\\*^$()+?{|]/\\\\&/g')
+          repo_re=$(printf %s "$REPO" | sed 's/[.[\\*^$()+?{|]/\\&/g')
           #
           # `|| true` on both greps: `set -o pipefail` plus a no-match grep
           # makes the whole substitution fail, and "this PR closes no issue" is

--- a/.github/workflows/pr-inherit-issue-labels.yml
+++ b/.github/workflows/pr-inherit-issue-labels.yml
@@ -61,16 +61,30 @@ jobs:
             -q '"\(.title)\n\(.body // "")"')
 
           # GitHub's auto-close grammar: a closing keyword, then a parens-FREE
-          # `#N` or a full issue URL in THIS repo. The `Closes (#N)` paren form
+          # `#N`, the qualified `owner/repo#N`, or a full issue URL -- the last
+          # two for THIS repo only. The `Closes (#N)` paren form
           # is deliberately NOT matched -- it does not auto-close either, and
           # `.claude/hooks/closes-paren-form-gate.sh` refuses a merge that uses
           # it, so matching it here would paper over that gate.
+          #
+          # The qualified form is load-bearing, not a nicety: this repo's own
+          # convention asks for `owner/repo#N` in published artifacts, so it is
+          # the spelling most PR bodies carry -- and it was the one form the
+          # regex could not read (issue go-to-k/cdkd#2661; measured 2026-09-05,
+          # three of four merged PRs inherited no labels). Restricting it to
+          # THIS repo is what stops a cdkd PR being labelled from an upstream
+          # `go-to-k/cdk-local#699` it merely cites.
+          #
+          # `$REPO` is interpolated into an ERE, so a `.` in either half of
+          # `owner/name` would act as a wildcard and let a near-miss repo pass
+          # as this one. Escape it rather than trusting today's name.
+          repo_re=$(printf %s "$REPO" | sed 's/[.[\\*^$()+?{|]/\\\\&/g')
           #
           # `|| true` on both greps: `set -o pipefail` plus a no-match grep
           # makes the whole substitution fail, and "this PR closes no issue" is
           # the ordinary case, not an error.
           numbers=$( { printf '%s\n' "$body" \
-            | grep -oiE "\\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\\b[[:space:]]*:?[[:space:]]+(https://github\\.com/$REPO/issues/|#)[0-9]+" \
+            | grep -oiE "\\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\\b[[:space:]]*:?[[:space:]]+(https://github\\.com/$repo_re/issues/|$repo_re#|#)[0-9]+" \
             | grep -oE '[0-9]+$' \
             | sort -u; } || true)
 

--- a/tests/unit/scripts/pr-inherit-issue-labels.test.ts
+++ b/tests/unit/scripts/pr-inherit-issue-labels.test.ts
@@ -208,6 +208,32 @@ describe('pr-inherit-issue-labels workflow', () => {
     expect(posted).toEqual([]);
   });
 
+  it('still matches the LITERAL form of a repo name containing a metachar', () => {
+    // The positive twin of the case below, and the one that discriminates.
+    // The negative alone is one-sided: an OVER-escape that breaks matching
+    // outright also passes it. Shipped review round 1 emitted `\\.` (a literal
+    // backslash then a wildcard), so a dotted repo matched nothing at all --
+    // and the pre-existing URL branch regressed with it -- while every
+    // assertion stayed green.
+    const { posted } = run({
+      REPO: 'go-to-k/cd.d',
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes go-to-k/cd.d#5',
+      ISSUE_5: 'bug',
+    });
+    expect(posted).toEqual(['bug']);
+  });
+
+  it('still matches a full issue URL when the repo name contains a metachar', () => {
+    const { posted } = run({
+      REPO: 'go-to-k/cd.d',
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes https://github.com/go-to-k/cd.d/issues/5',
+      ISSUE_5: 'bug',
+    });
+    expect(posted).toEqual(['bug']);
+  });
+
   it('treats a regex metachar in the repo name as a literal', () => {
     // `$REPO` is interpolated into an ERE. Unescaped, the `.` here is a
     // wildcard and `go-to-k/cdXd#5` passes as this repo -- a near-miss repo

--- a/tests/unit/scripts/pr-inherit-issue-labels.test.ts
+++ b/tests/unit/scripts/pr-inherit-issue-labels.test.ts
@@ -39,11 +39,27 @@ import { dirname, join } from 'node:path';
  *     the earlier overlap case confounded `sort -u` with the `have` filter
  *   - each deny-list entry individually, including the per-channel
  *     `released on @<channel>` form semantic-release actually emitted
+ *   - the QUALIFIED `owner/repo#N` form (issue go-to-k/cdkd#2661), which this
+ *     repo's own convention asks for and which the regex could not read: three
+ *     of the four PRs merged 2026-09-05 inherited no labels at all
+ *   - and, for each branch that interpolates the repo name, BOTH directions
+ *     under a metachar repo name -- the literal form still harvested AND the
+ *     wildcard near-miss rejected. The negative alone cannot tell "escaped
+ *     correctly" from "escaped into oblivion": go-to-k/cdkd#2661's first fix
+ *     emitted a doubled backslash, matched nothing, regressed the URL branch,
+ *     and left every assertion green
  *
  * Mutation-probed 2026-08-26: removing the deny list fails 7 of 17; dropping
  * `sort -u`, re-pointing the POST, accepting the `Closes (#N)` paren form, and
  * narrowing the deny list back to a fixed `released on @experimental` each fail
  * exactly 1.
+ *
+ * Re-probed 2026-09-06 over 24 cases (go-to-k/cdkd#2661): dropping the
+ * qualified alternative, raw-interpolating `$REPO` into the URL branch, and
+ * the doubled-backslash escape each fail exactly the branch they break --
+ * 1, 1 and 2 respectively. Deleting the URL branch outright fails 2; deleting
+ * the qualified branch fails 2, so neither is rescued by the bare-`#`
+ * fallback.
  */
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const WORKFLOW = join(repoRoot, '.github', 'workflows', 'pr-inherit-issue-labels.yml');
@@ -232,6 +248,19 @@ describe('pr-inherit-issue-labels workflow', () => {
       ISSUE_5: 'bug',
     });
     expect(posted).toEqual(['bug']);
+  });
+
+  it('treats the hardcoded `github.com` dot as a literal', () => {
+    // The last unpinned escape in the pattern, found by the round-3 probe:
+    // unescaping this dot left all 24 cases green, so nothing said the host
+    // was matched literally rather than as a wildcard. Correct as written --
+    // this case is what keeps it that way.
+    const { posted } = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes https://githubXcom/go-to-k/cdkd/issues/5',
+      ISSUE_5: 'bug',
+    });
+    expect(posted).toEqual([]);
   });
 
   it('treats a metachar as a literal in the URL branch too', () => {

--- a/tests/unit/scripts/pr-inherit-issue-labels.test.ts
+++ b/tests/unit/scripts/pr-inherit-issue-labels.test.ts
@@ -183,6 +183,53 @@ describe('pr-inherit-issue-labels workflow', () => {
     expect(theirs.posted).toEqual([]);
   });
 
+  it('matches the `owner/repo#N` form for THIS repo (issue go-to-k/cdkd#2661)', () => {
+    // The repo's own convention asks for the qualified `owner/repo#N` spelling
+    // in published artifacts, so this is the form most PR bodies actually
+    // carry. Measured on 2026-09-05: three of four merged PRs inherited NO
+    // labels because the regex accepted only a bare `#N` or a full URL.
+    const { posted } = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes go-to-k/cdkd#41',
+      ISSUE_41: 'severity:medium|effort:small',
+    });
+    expect(posted).toEqual(['effort:small', 'severity:medium']);
+  });
+
+  it('does NOT harvest an `owner/repo#N` reference to ANOTHER repo', () => {
+    // The failure a naive widening introduces: cdkd PR bodies routinely close
+    // a cdkd issue while CITING an upstream one, so labelling this PR from
+    // `go-to-k/cdk-local#699` would be labelling from a different tracker.
+    const { posted } = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes go-to-k/cdk-local#699',
+      ISSUE_699: 'bug',
+    });
+    expect(posted).toEqual([]);
+  });
+
+  it('treats a regex metachar in the repo name as a literal', () => {
+    // `$REPO` is interpolated into an ERE. Unescaped, the `.` here is a
+    // wildcard and `go-to-k/cdXd#5` passes as this repo -- a near-miss repo
+    // harvesting labels into ours. Nothing covered this before go-to-k/cdkd#2661.
+    const { posted } = run({
+      REPO: 'go-to-k/cd.d',
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes go-to-k/cdXd#5',
+      ISSUE_5: 'bug',
+    });
+    expect(posted).toEqual([]);
+  });
+
+  it('does NOT treat a repo whose name PREFIXES this one as this repo', () => {
+    const { posted } = run({
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes go-to-k/cdkd-extra#77',
+      ISSUE_77: 'bug',
+    });
+    expect(posted).toEqual([]);
+  });
+
   it('posts to THIS PR\'s labels endpoint, not somewhere else', () => {
     const { target } = run({
       PR_TITLE: 'fix: x',

--- a/tests/unit/scripts/pr-inherit-issue-labels.test.ts
+++ b/tests/unit/scripts/pr-inherit-issue-labels.test.ts
@@ -234,6 +234,22 @@ describe('pr-inherit-issue-labels workflow', () => {
     expect(posted).toEqual(['bug']);
   });
 
+  it('treats a metachar as a literal in the URL branch too', () => {
+    // The negative twin for the URL branch specifically. Round 2 measured that
+    // escaping the qualified branch while interpolating the RAW `$REPO` into
+    // the URL branch left all 23 other cases green -- the same one-sided gap
+    // round 1 found, one branch over. The case at 'matches a full issue URL in
+    // THIS repo but not in another' cannot catch it, because it uses
+    // `go-to-k/cdkd`, where the escaped and raw spellings are identical.
+    const { posted } = run({
+      REPO: 'go-to-k/cd.d',
+      PR_TITLE: 'fix: x',
+      PR_BODY: 'Closes https://github.com/go-to-k/cdXd/issues/5',
+      ISSUE_5: 'bug',
+    });
+    expect(posted).toEqual([]);
+  });
+
   it('treats a regex metachar in the repo name as a literal', () => {
     // `$REPO` is interpolated into an ERE. Unescaped, the `.` here is a
     // wildcard and `go-to-k/cdXd#5` passes as this repo -- a near-miss repo


### PR DESCRIPTION
## The defect

`.github/workflows/pr-inherit-issue-labels.yml` accepted only a bare `#N` or a
full same-repo issue URL as a closing reference. This repo's convention asks
for the qualified `owner/repo#N` spelling in published artifacts, so the form
most PR bodies actually carry was the one form the regex could not read.

Measured across the four PRs merged on 2026-09-05, every one of which closed
issues carrying `severity:*` / `effort:*` labels:

| PR | inherited labels |
|----|------------------|
| go-to-k/cdkd#2607 | `severity:low`, `effort:small`, `effort:medium`, `severity:medium` |
| go-to-k/cdkd#2620 | none |
| go-to-k/cdkd#2640 | none |
| go-to-k/cdkd#2659 | none |

Nothing was wrong on the issue side — only the inheritance. go-to-k/cdkd#2607
inherited because its body happened to carry a bare `#N`.

## The fix, and what bounds it

The `owner/repo#N` form is now accepted **for this repository only**. That
restriction is the load-bearing half: cdkd PR bodies routinely close a cdkd
issue while CITING an upstream one, so an unrestricted widening would have
labelled a cdkd PR from `go-to-k/cdk-local#699` — a different tracker.

`$REPO` is now escaped before interpolation. It lands inside an ERE, where a
`.` in either half of `owner/name` acts as a wildcard and lets a near-miss repo
pass as this one. That hazard predates this change and nothing covered it.

The `Closes (#N)` paren form stays deliberately unmatched: it does not
auto-close either, and `.claude/hooks/closes-paren-form-gate.sh` refuses a
merge that uses it, so matching it here would paper over that gate.

## Tests

Four assertions, each anchored on a distinct failure:

1. the qualified form for this repo IS harvested
2. another repo's qualified form is NOT
3. a repo whose name merely PREFIXES this one is NOT
4. a regex metachar in the repo name is treated as a literal

Each was verified to kill its own mutant, with the workflow restored
byte-exact between probes:

| mutation | reds |
|---|---|
| drop the `$repo_re#` alternative | only assertion 1 |
| `repo_re="$REPO"` (drop the escaping) | only assertion 4 |

Assertion 1 was written first and confirmed RED against the unfixed workflow
before the fix was applied. Full suite: 896 files, 19,061 tests, 0 type errors.

## Backfill

Labels were applied by hand to go-to-k/cdkd#2620, go-to-k/cdkd#2640 and
go-to-k/cdkd#2659 so the historical record matches what the fixed workflow
would have produced. All four PRs in the table now carry their issues' labels.

## Verification note

This workflow runs on `pull_request`, so THIS PR is itself a live test of the
change — but only once merged, since the workflow that runs for a PR is the one
on the base branch. Its own body uses the qualified form throughout.

Closes go-to-k/cdkd#2661

## Review round 1 found the fix's own escaping was broken

Recorded because the failure is more interesting than the original bug.

The escaping added in the first commit emitted **two** backslashes, so a dotted
repo name became `go-to-k/cd\\.d` — a literal backslash followed by a wildcard.
A correct reference then matched **nothing**, and the pre-existing issue-URL
branch regressed with it. Latent for `go-to-k/cdkd`, which carries no metachar,
so the fix was **inert** rather than wrong today, and would have broken
silently on a rename.

**All four assertions stayed green through it.** The metachar case was
one-sided — it asserted only that a near-miss does *not* match, which an
over-escape that breaks matching outright equally satisfies. My own mutation
probe was misled by the same asymmetry: `repo_re="$REPO"` reddened it, so the
assertion looked load-bearing while it could not tell a working fix from a
dead one.

Fixed to a single backslash, and the discriminating assertions added:

| new assertion | reds under the round-1 spelling |
|---|---|
| literal dotted reference IS harvested | yes |
| dotted issue URL IS harvested (the regressed branch) | yes |

Verified by re-applying the round-1 spelling and running the suite, with the
file restored byte-exact afterwards.

**Lesson worth carrying:** a negative-only assertion about a sanitiser cannot
distinguish "correctly escaped" from "escaped into oblivion". Pair every
"near-miss is rejected" with "the literal form is still accepted".
