### PR TITLE
chore(work-issues): range the worktree probe over the branch, make a lane report its deliverable, and fence a guard at every call site

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -105,31 +105,33 @@ the trigger is a TS entry point, or several spawns in a case.
   and the fixture's clean stack never entered the warn arm, so its
   `not.toContain(...)` assertion was unfalsifiable by construction.
 - **Enumerate the value's uses before probing** (`grep` the identifier in the
-  changed hunk). One probe per use.
+  changed hunk). One probe per use — for a GUARD the uses are its CALL SITES
+  and both directions of its message, each needing its OWN negative:
+  go-to-k/cdkd#2674 fenced a damage sentence in the out-of direction only, so
+  a change confined to the into text went unwatched (2026-09-05).
 - **A negative assertion needs a case where the wrong value would actually be
   EMITTED** — e.g. two DIRTY stacks with different counts (1 and 2), asserting
   the total 3 appears in neither banner.
-- The same shape hides behind mocks: tests that `vi.mock` a module pin what the
-  caller PASSES, never what the far side WRITES (hard-coding `'SUCCEEDED'`
+- The same shape hides behind mocks: a `vi.mock`ed module pins what the caller
+  PASSES, never what the far side WRITES (hard-coding `'SUCCEEDED'`
   inside `recordRunOutcome` passed all 2261 unit tests). When a value crosses a
   module boundary, one case must exercise the far side unmocked.
 - **Do not report a mutation result you did not run — and a probe that changed
   TWO things at once is one you did not run.** A false mutation-table entry
-  surfaces only when a reviewer re-executes every claim; nothing else looks. PR
-  #2612 is the harder half, where the probe WAS run: a comment claimed
-  reordering either consumer "reds four cases", but that probe had edited the
-  rendered line's TEXT in the same pass, so the reds attested to the text edit.
-  Re-measured one mutation at a time — each alone green, BOTH reds one case,
-  i.e. the two mechanisms are mutually redundant, the opposite of what the
-  comment said. One mutation per probe, tree restored byte-exact between them.
+  surfaces only when a reviewer re-executes every claim; nothing else looks.
+  PR #2612 is the harder half, where the probe WAS run: a "reds four cases"
+  claim rested on a probe that had also edited the rendered line's TEXT, and
+  re-measuring one mutation at a time inverted it (each alone green, BOTH reds
+  one case — the two mechanisms are mutually redundant). One mutation per
+  probe, tree restored byte-exact between them.
 - **Give a probe result written into a SOURCE COMMENT the same disposition as a
   count in published prose** — delete it, fence it, or attribute it as a dated
   measurement (`.claude/skills/work-issues/references/verify.md` §8-g). Nothing
-  downstream re-checks such a line: PR #2612's wrong claim was on a branch
-  comment beside a destructive confirm prompt, no test could see it, and only
-  the review round stopped it becoming a fence a later editor would trust.
-  What it should have stated is the invariant the two mechanisms jointly
-  enforce, which is re-derivable and cannot go stale.
+  downstream re-checks such a line: PR #2612's wrong claim sat on a branch
+  comment beside a destructive confirm prompt, invisible to every test, and
+  only review stopped it becoming a fence a later editor would trust. State
+  instead the invariant the two mechanisms jointly enforce, which is
+  re-derivable and cannot go stale.
 
 ## Integration Tests
 

--- a/.claude/skills/work-issues/references/claim.md
+++ b/.claude/skills/work-issues/references/claim.md
@@ -55,8 +55,7 @@ gh issue comment <n> --body "Working on this in PR/branch <ref> — touching <fi
 Claiming to avoid collision with parallel agents."
 ```
 
-(English only — committed/public artifacts are English.) Mandatory, BEFORE the
-first edit — the issue-level twin of the worktree DISJOINT-FILE rule (see
+Mandatory, BEFORE the first edit — the issue-level twin of the worktree DISJOINT-FILE rule (see
 "Claim a filed issue before working it" in `CLAUDE.md`).
 
 **Correct the classification lines in the same turn as the claim.** Claiming is

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -100,7 +100,8 @@
   fan-out run spends most wall-clock parked (lane subagents, `gh pr checks
   --watch`, `/run-integ`) — every one is **WAITING**, not STOPPED: one line
   per lane, naming the lane and its signal. STOPPED only when every lane is
-  merged. CLAUDE.md owns the arm-it-BEFORE-you-write-it rule.
+  merged. CLAUDE.md owns the arm-it-first rule; the incident behind it is a run
+  that wrote `WAITING — Signal: gh pr checks`, armed nothing, and ended.
 - **A lane needing a user decision goes through `AskUserQuestion`, never
   prose** — a prose question ends the turn as STOPPED and loses the other
   lanes' momentum. That prompt is CHAT, not a published artifact, so it goes

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -5,11 +5,9 @@
 - **Claim before editing, always** — an unclaimed lane races a parallel agent
   onto the same cross-cutting file. **Claiming is not winning**: read it back
   and yield to an earlier `createdAt` (§4).
-- **A pushed branch with no PR is a live lane.** `gh pr list` goes blind
-  between a lane's first push and its `gh pr create`;
-  `git for-each-ref --sort=-committerdate refs/remotes/origin` after a fetch
-  sees the push (§2). The window that is the claim's alone is the mirror — a
-  lane with a worktree and nothing pushed (§3, §9).
+- **A pushed branch with no PR is a live lane**, and its mirror — a worktree
+  holding commits it has not pushed — is the window only the claim covers. §2
+  owns both probes; this bullet does not restate them (§3, §9).
 - **A fresh issue is someone's deferral, not free backlog** (§3-0). The author
   field proves nothing about which session filed it; the 60-minute window is
   the whole defence — and §4 is its other half: claim what you FILE, not only

--- a/.claude/skills/work-issues/references/gotchas.md
+++ b/.claude/skills/work-issues/references/gotchas.md
@@ -100,8 +100,7 @@
   fan-out run spends most wall-clock parked (lane subagents, `gh pr checks
   --watch`, `/run-integ`) — every one is **WAITING**, not STOPPED: one line
   per lane, naming the lane and its signal. STOPPED only when every lane is
-  merged. **ARM the signal BEFORE you write the line** (measured: a run wrote
-  `WAITING — Signal: gh pr checks`, armed nothing, and simply ended).
+  merged. CLAUDE.md owns the arm-it-BEFORE-you-write-it rule.
 - **A lane needing a user decision goes through `AskUserQuestion`, never
   prose** — a prose question ends the turn as STOPPED and loses the other
   lanes' momentum. That prompt is CHAT, not a published artifact, so it goes

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -389,8 +389,9 @@ worktree path, allowed files, "do NOT touch other lanes' files; STOP and
 report if the fix needs a forbidden one", and **the REPORT SHAPE — the
 report IS the deliverable**: a lane's tool output never reaches you, so a
 one-line "done" loses the run (2 of 3 lanes, 2026-09-05). Resume a thin one
-with "REPORT ONLY, do not touch the tree"; a plain resume re-edits. A subagent's Bash **bypasses the
-PreToolUse gate hooks** (it can `gh pr create` past `verify-pr-gate`) —
+with "REPORT ONLY, do not touch the tree"; a plain resume re-edits.
+
+A subagent's Bash **bypasses the PreToolUse gate hooks** (it can `gh pr create` past `verify-pr-gate`) —
 enforce quality yourself; the orchestrator still gates the MERGE.
 
 - **Forbid lane agents the FULL SUITE; run it yourself, serially.** Five
@@ -413,10 +414,11 @@ enforce quality yourself; the orchestrator still gates the MERGE.
 - **Never force-push over a commit you did not author** — re-`git fetch` and
   inspect the branch first; STOP if it carries work you did not write.
 - **A new fixture literal must not collide with an existing assertion needle,
-  nor a new fixture RESOURCE with an existing resource's VALUE**
-  (go-to-k/cdkd#2270: a hard-coded URL user equal to the swept needle produced
-  a false LEAK report, worse than a missing assertion). When an arm makes two
-  things equal, ask what ELSE holds that value; scope the sharing. **And check
+  nor a new fixture RESOURCE with an existing resource's VALUE** (a hard-coded
+  URL user equal to the swept needle produced a false LEAK report, worse than a
+  missing assertion; an arm reusing a plaintext an existing assertion owned
+  failed on an assertion the lane never wrote, go-to-k/cdkd#2270). When an arm
+  makes two things equal, ask what ELSE holds that value; scope the sharing. **And check
   the arm's shape actually exercises the fix before spending a run** (two
   separate resources was vacuous — only one holding both leaves let the
   mechanism under test decide).

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -385,8 +385,11 @@ normalization layer sits exactly where a fence goes green-but-inert).
 ### 5-g. Fan-out mechanics
 
 You may fan out **one subagent per lane** (disjoint files): give each its
-worktree path, allowed files, and "do NOT touch other lanes' files; STOP and
-report if the fix needs a forbidden one". A subagent's Bash **bypasses the
+worktree path, allowed files, "do NOT touch other lanes' files; STOP and
+report if the fix needs a forbidden one", and **the REPORT SHAPE — the
+report IS the deliverable**: a lane's tool output never reaches you, so a
+one-line "done" loses the run (2 of 3 lanes, 2026-09-05). Resume a thin one
+with "REPORT ONLY, do not touch the tree"; a plain resume re-edits. A subagent's Bash **bypasses the
 PreToolUse gate hooks** (it can `gh pr create` past `verify-pr-gate`) —
 enforce quality yourself; the orchestrator still gates the MERGE.
 
@@ -400,25 +403,23 @@ enforce quality yourself; the orchestrator still gates the MERGE.
   suite failure as a regression, read the rc AND the error section AND
   `uptime`, and check `ps` for a vitest whose path is not yours; re-run when
   the machine is quiet.
-- Budget two fan-out costs: a lane agent waiting inside a tool call is killed
-  at 600s of silence (background long runs with a log redirect, poll with
+- Budget two fan-out costs: a lane waiting inside a tool call is killed at
+  600s of silence (background long runs with a log redirect, poll with
   short `tail`s), and a fix round re-touching an `integ-*` scope invalidates
-  that gate's marker — that is the gate working; budget the run.
+  that gate's marker — the gate working; budget the run.
 
 **Guardrails every lane prompt must carry** (each learned the hard way):
 
 - **Never force-push over a commit you did not author** — re-`git fetch` and
   inspect the branch first; STOP if it carries work you did not write.
 - **A new fixture literal must not collide with an existing assertion needle,
-  nor a new fixture RESOURCE with an existing resource's VALUE** (a
-  hard-coded URL user equal to the swept needle produced a false LEAK report
-  — worse than a missing assertion; an arm reusing a plaintext an existing
-  assertion owned failed on an assertion the lane never wrote,
-  go-to-k/cdkd#2270). When an arm makes two things equal, ask what ELSE holds
-  that value; scope the sharing. **And check the arm's shape actually
-  exercises the fix before spending a run** (two separate resources was
-  vacuous there — only one resource holding both leaves let the mechanism
-  under test decide the answer).
+  nor a new fixture RESOURCE with an existing resource's VALUE**
+  (go-to-k/cdkd#2270: a hard-coded URL user equal to the swept needle produced
+  a false LEAK report, worse than a missing assertion). When an arm makes two
+  things equal, ask what ELSE holds that value; scope the sharing. **And check
+  the arm's shape actually exercises the fix before spending a run** (two
+  separate resources was vacuous — only one holding both leaves let the
+  mechanism under test decide).
 - **Execute every read expression you write** — jq / JMESPath / `--query`
   are untested code; run each against real output shape, in both directions
   where the expression carries a guard.
@@ -451,9 +452,8 @@ enforce quality yourself; the orchestrator still gates the MERGE.
   cannot produce without having run (`bytes 41822 -> 41799; anchor now 0
   (was 1)`), and read the receipt, not the exit code.
 - **A probe's FIXTURE, not its mutation, decided the outcome** — a region
-  test set `AWS_REGION` to the value where correct code and mutation bind
-  identically. When a probe comes back green, suspect the fixture first — and
-  especially an expected value COINCIDING with the ambient default
-  (assertions pinned to `'us-east-1'`, at once the fixture region and the
-  repo's fallback, left 434 tests green under substitution). Choose a value
-  the default can never produce.
+  test set `AWS_REGION` where correct code and mutation bind identically.
+  Suspect the fixture first when a probe comes back green, especially an
+  expected value COINCIDING with the ambient default (`'us-east-1'` is at once
+  the fixture region and the repo's fallback; 434 tests stayed green under
+  substitution). Choose a value the default can never produce.

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -265,7 +265,6 @@ git fetch origin && git switch -c "$B" origin/main
 
 - `chore:` prefix — `.claude/**` is not `src/**`; `commit-prefix-scope-gate`
   blocks `fix:` / `feat:` here.
-- English only in every committed line.
 - Scope does not exempt you from the markers (CLAUDE.md, "Before every
   commit") — a fresh worktree starts with none, and `/verify-pr` sets all
   three in one pass; run it before the commit. A

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -94,9 +94,9 @@ For each active worktree, find what it ACTUALLY edits:
 # nothing when run IN-PLACE, and the scan reports an empty board — the exact
 # failure this stage exists to prevent. Substitute the recorded path; never
 # `$MAIN_CHECKOUT`, which is empty in this shell.
-git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" log --oneline -1     # the issue it owns
+git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" log --oneline -1                     # the issue it owns -- or main's tip, on a lane yet to commit
 git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" diff --name-only origin/main...HEAD  # EVERY file it holds
-git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" status --porcelain   # editing RIGHT NOW
+git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" status --porcelain                  # editing RIGHT NOW
 ```
 
 **A branch `origin/main..<branch>` reports as ahead is NOT necessarily

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -95,7 +95,7 @@ For each active worktree, find what it ACTUALLY edits:
 # failure this stage exists to prevent. Substitute the recorded path; never
 # `$MAIN_CHECKOUT`, which is empty in this shell.
 git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" log --oneline -1     # the issue it owns
-git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" show --stat HEAD     # files that commit touches
+git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" diff --name-only origin/main...HEAD  # EVERY file it holds
 git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" status --porcelain   # editing RIGHT NOW
 ```
 
@@ -108,9 +108,10 @@ treated as a live peer and a lane wrongly narrowed its scope; the commit had
 merged nine hours earlier as go-to-k/cdk-real-drift#1853). This is the ONE
 probe here that can manufacture a false POSITIVE — argue it DOWN.
 
-The first two worktree probes read COMMITTED state, so on an uncommitted lane
-they describe its base commit rather than the file it holds: where they
-disagree with `status --porcelain`, **the dirty tree is the authority**. A
+The first two probes read COMMITTED state and say nothing about an uncommitted
+lane; the RANGE is load-bearing (`show --stat HEAD` read 1 of the 5 files a
+ten-commit lane held, 2026-09-05). Where they disagree with
+`status --porcelain`, **the dirty tree is the authority**. A
 worktree still on `main`'s tip looks like residue exactly when it is likeliest
 to be a lane writing right now, and its issue thread — a worktree is NAMED for
 the issue its lane took — is the only mark a lane seconds old has left (§9's

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -96,7 +96,7 @@ For each active worktree, find what it ACTUALLY edits:
 # `$MAIN_CHECKOUT`, which is empty in this shell.
 git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" log --oneline -1                     # the issue it owns -- or main's tip, on a lane yet to commit
 git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" diff --name-only origin/main...HEAD  # EVERY file it holds
-git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" status --porcelain                  # editing RIGHT NOW
+git -C "<MAIN_CHECKOUT>/.claude/worktrees/<w>" status --porcelain                   # editing RIGHT NOW
 ```
 
 **A branch `origin/main..<branch>` reports as ahead is NOT necessarily

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -452,7 +452,7 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // literal glob list names are the fence, its suite, and the setup file that
   // installs it, and none of them is named by any other row. Without this the
   // satellite sits under no budget at all. Payload is testing.md + the satellite.
-  ['tests/setup.ts', 48_000, 72_000],                            // measured  49,677 on 2026-09-05 (was 64,742 before the 2026-09-04 compression)
+  ['tests/setup.ts', 48_000, 72_000],                            // measured  49,793 on 2026-09-05 (was 64,742 before the 2026-09-04 compression)
   // 46_000 -> 48_000 on 2026-09-05: the go-to-k/cdkd#2595 retro added 1,126 B of
   // mutation-probe rules to `testing.md`, and the discriminate case below went
   // red exactly as its comment predicts ("testing.md growing spends it from the
@@ -473,10 +473,15 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // not a bigger number here. Unlike the skill corpus, this file has no
   // MEASURED record, so these three figures are the only thing that goes
   // stale silently; re-measure them in any commit that touches `testing.md`.
+  // RE-MEASURED 2026-09-05 after the work-issues retro escalated its
+  // one-sided-fence rule into `testing.md` (+207 B of rule, 91 B of it paid
+  // back by compressing three neighbouring mutation bullets, 46,257 -> 46,373 B
+  // net): payload 49,677 -> 49,793, gutting bound 47,757 -> 47,873, usable
+  // room 242 -> 126 B. Compression there is the only way to buy that back.
   // This floor is set by a PROPERTY rather than by the table's usual ~12%-under
   // convention, and `the tests/setup.ts floor still discriminates` below
   // RECOMPUTES that property instead of trusting this number. It must sit above
-  // `testing.md` (46,257 B) plus SUBSTANTIVE_MIN_BYTES, so that gutting
+  // `testing.md` (46,373 B) plus SUBSTANTIVE_MIN_BYTES, so that gutting
   // `test-stream-fence.md` down to the smallest size the `substantive content`
   // case still allows fails HERE. 51_000, 57_000 and 62_000 were each chosen by
   // hand and each failed to add signal: the first two sat below `testing.md`

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -363,7 +363,14 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // failed this row for a reason unrelated to itself -- the same argument that
   // moved CORPUS_BYTES_MAX. Measured 61,358 B (the 55,681 B beside the old cap
   // was 5,677 B stale).
-  ['tests/unit/scripts/rule-file-payload.test.ts', 38_000, 68_000], // measured 61,358
+  ['tests/unit/scripts/rule-file-payload.test.ts', 38_000, 68_000], // measured 46,373 on 2026-09-06
+  // The 61,358 above is the figure the CAP was derived from and is kept as
+  // history; it is not the live payload. `testing.md` globs `tests/**`, so it
+  // is this row's whole payload too, and the 2026-09-04 compression took it to
+  // 45,579 without anyone re-measuring HERE -- the row read 14,985 B stale
+  // until 2026-09-06. Found by a review of the commit that added the
+  // re-measure instruction below, which had called the `tests/setup.ts` block's
+  // three figures the only ones going stale silently. They are four.
   // hooks.md WAS this path's only matcher, and while that held the cap was
   // dominated by MAX_RULE_FILE_BYTES no matter where it sat: at 135_000 (as
   // shipped) it was 15,000 B past the per-file cap and could not fire at all;
@@ -471,13 +478,20 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // usable room is 242 B and an addition of 243 B reds the discriminate case
   // below. The fix is compression there,
   // not a bigger number here. Unlike the skill corpus, this file has no
-  // MEASURED record, so these three figures are the only thing that goes
-  // stale silently; re-measure them in any commit that touches `testing.md`.
+  // MEASURED record, so these figures are the only thing that goes stale
+  // silently; re-measure them in any commit that touches `testing.md` -- these
+  // three AND the `measured` figure on the rule-file-payload.test.ts row above,
+  // whose payload is `testing.md` alone for the same `tests/**` glob.
   // RE-MEASURED 2026-09-05 after the work-issues retro escalated its
-  // one-sided-fence rule into `testing.md` (+207 B of rule, 91 B of it paid
+  // one-sided-fence rule into `testing.md` (+256 B of rule, 140 B of it paid
   // back by compressing three neighbouring mutation bullets, 46,257 -> 46,373 B
   // net): payload 49,677 -> 49,793, gutting bound 47,757 -> 47,873, usable
   // room 242 -> 126 B. Compression there is the only way to buy that back.
+  // The two components are segmented at the BULLET boundary (the rule's own
+  // bullet 113 -> 369 B; the three compressed ones 1,595 -> 1,455 B) and sum
+  // to the net -- an earlier draft said 207/91, which summed to the right 116
+  // by luck and matched no definition of either part. Both review axes caught
+  // it independently, on the file that exists to stop exactly this.
   // This floor is set by a PROPERTY rather than by the table's usual ~12%-under
   // convention, and `the tests/setup.ts floor still discriminates` below
   // RECOMPUTES that property instead of trusting this number. It must sit above

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -365,9 +365,10 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // was 5,677 B stale).
   // RE-DERIVED DOWNWARD 68_000 -> 52_000 on 2026-09-06, and the sibling
   // `tests/setup.ts` cap with it: both bound a payload that IS `testing.md`
-  // (alone here, plus its satellite there), and both `measured` notes had gone
-  // stale at the 2026-09-04 compression, so both caps were left sized for a
-  // file 15 KB larger than the live one -- the slack condition the
+  // (alone here, plus its satellite there), and both CAPS were left sized for
+  // the pre-compression file. Only THIS row's `measured` note was stale; the
+  // `tests/setup.ts` note tracked its payload correctly, and saying "both
+  // notes" was itself the defect this round is about -- the slack condition the
   // s3-bucket-provider row above records as having "silently absorbed a whole
   // 59 KB satellite". ~12% over the live payload is this table's convention,
   // NOT a ratio recovered from this row's own history.
@@ -488,7 +489,8 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // MEASURED record, so these figures are the only thing that goes stale
   // silently; re-measure them in any commit that touches `testing.md` -- these,
   // plus the `measured` figure and the cap on the rule-file-payload.test.ts row
-  // above and this row's own cap, all of which bound a payload that IS
+  // above and this row's own cap, and the `testing.md (46,373 B)` figure in
+  // the gutting case below -- all of which bound, or are, a payload that IS
   // `testing.md`. Deliberately not stated as a COUNT: this sentence said
   // "three" while enumerating more, twice.
   // RE-MEASURED 2026-09-05 after the work-issues retro escalated its

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -363,14 +363,19 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // failed this row for a reason unrelated to itself -- the same argument that
   // moved CORPUS_BYTES_MAX. Measured 61,358 B (the 55,681 B beside the old cap
   // was 5,677 B stale).
-  ['tests/unit/scripts/rule-file-payload.test.ts', 38_000, 68_000], // measured 46,373 on 2026-09-06
-  // The 61,358 above is the figure the CAP was derived from and is kept as
-  // history; it is not the live payload. `testing.md` globs `tests/**`, so it
-  // is this row's whole payload too, and the 2026-09-04 compression took it to
-  // 45,579 without anyone re-measuring HERE -- the row read 14,985 B stale
-  // until 2026-09-06. Found by a review of the commit that added the
-  // re-measure instruction below, which had called the `tests/setup.ts` block's
-  // three figures the only ones going stale silently. They are four.
+  // RE-DERIVED DOWNWARD 68_000 -> 52_000 on 2026-09-06. The 61,358 above is the
+  // figure the cap was derived from and is kept as history; it stopped being the
+  // live payload at the 2026-09-04 compression, which took `testing.md` to
+  // 45,579 without anyone re-measuring HERE, so the row read 14,985 B stale.
+  // `testing.md` globs `tests/**`, so it is this row's WHOLE payload, and with
+  // `MAX_RULE_FILE_BYTES` at 80,000 this row -- not that cap -- is the binding
+  // fence on it: at 68_000 the file could have grown 21.6 KB unwatched, the
+  // 47%-slack condition the s3-bucket-provider row above records as having
+  // "silently absorbed a whole 59 KB satellite". 52_000 restores the ~12% the
+  // row itself was cut at (61,358 -> 68_000). Correcting the `measured` note
+  // without re-deriving its consequence is what review caught; the cap moves
+  // DOWN with a shrinking payload, never up to fit a growing one.
+  ['tests/unit/scripts/rule-file-payload.test.ts', 38_000, 52_000], // measured 46,373 on 2026-09-06
   // hooks.md WAS this path's only matcher, and while that held the cap was
   // dominated by MAX_RULE_FILE_BYTES no matter where it sat: at 135_000 (as
   // shipped) it was 15,000 B past the per-file cap and could not fire at all;
@@ -480,8 +485,10 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // not a bigger number here. Unlike the skill corpus, this file has no
   // MEASURED record, so these figures are the only thing that goes stale
   // silently; re-measure them in any commit that touches `testing.md` -- these
-  // three AND the `measured` figure on the rule-file-payload.test.ts row above,
-  // whose payload is `testing.md` alone for the same `tests/**` glob.
+  // three AND the `measured` figure and CAP on the rule-file-payload.test.ts
+  // row above, whose payload is `testing.md` alone for the same `tests/**`
+  // glob. That row is why the count is four, not the three this sentence
+  // claimed until 2026-09-06.
   // RE-MEASURED 2026-09-05 after the work-issues retro escalated its
   // one-sided-fence rule into `testing.md` (+256 B of rule, 140 B of it paid
   // back by compressing three neighbouring mutation bullets, 46,257 -> 46,373 B

--- a/tests/unit/scripts/rule-file-payload.test.ts
+++ b/tests/unit/scripts/rule-file-payload.test.ts
@@ -363,18 +363,20 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // failed this row for a reason unrelated to itself -- the same argument that
   // moved CORPUS_BYTES_MAX. Measured 61,358 B (the 55,681 B beside the old cap
   // was 5,677 B stale).
-  // RE-DERIVED DOWNWARD 68_000 -> 52_000 on 2026-09-06. The 61,358 above is the
-  // figure the cap was derived from and is kept as history; it stopped being the
-  // live payload at the 2026-09-04 compression, which took `testing.md` to
-  // 45,579 without anyone re-measuring HERE, so the row read 14,985 B stale.
-  // `testing.md` globs `tests/**`, so it is this row's WHOLE payload, and with
-  // `MAX_RULE_FILE_BYTES` at 80,000 this row -- not that cap -- is the binding
-  // fence on it: at 68_000 the file could have grown 21.6 KB unwatched, the
-  // 47%-slack condition the s3-bucket-provider row above records as having
-  // "silently absorbed a whole 59 KB satellite". 52_000 restores the ~12% the
-  // row itself was cut at (61,358 -> 68_000). Correcting the `measured` note
-  // without re-deriving its consequence is what review caught; the cap moves
-  // DOWN with a shrinking payload, never up to fit a growing one.
+  // RE-DERIVED DOWNWARD 68_000 -> 52_000 on 2026-09-06, and the sibling
+  // `tests/setup.ts` cap with it: both bound a payload that IS `testing.md`
+  // (alone here, plus its satellite there), and both `measured` notes had gone
+  // stale at the 2026-09-04 compression, so both caps were left sized for a
+  // file 15 KB larger than the live one -- the slack condition the
+  // s3-bucket-provider row above records as having "silently absorbed a whole
+  // 59 KB satellite". ~12% over the live payload is this table's convention,
+  // NOT a ratio recovered from this row's own history.
+  //
+  // Read both as dead-slack removal, not as the live fence. What actually
+  // stops `testing.md` growing is the `tests/setup.ts` GUTTING case below,
+  // which binds first and by a wide margin; a first draft of this comment
+  // called this row "the binding fence on it" and review measured that false.
+  // Caps move DOWN with a shrinking payload, never up to fit a growing one.
   ['tests/unit/scripts/rule-file-payload.test.ts', 38_000, 52_000], // measured 46,373 on 2026-09-06
   // hooks.md WAS this path's only matcher, and while that held the cap was
   // dominated by MAX_RULE_FILE_BYTES no matter where it sat: at 135_000 (as
@@ -464,7 +466,7 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // literal glob list names are the fence, its suite, and the setup file that
   // installs it, and none of them is named by any other row. Without this the
   // satellite sits under no budget at all. Payload is testing.md + the satellite.
-  ['tests/setup.ts', 48_000, 72_000],                            // measured  49,793 on 2026-09-05 (was 64,742 before the 2026-09-04 compression)
+  ['tests/setup.ts', 48_000, 56_000],                            // measured  49,793 on 2026-09-05 (was 64,742 before the 2026-09-04 compression)
   // 46_000 -> 48_000 on 2026-09-05: the go-to-k/cdkd#2595 retro added 1,126 B of
   // mutation-probe rules to `testing.md`, and the discriminate case below went
   // red exactly as its comment predicts ("testing.md growing spends it from the
@@ -484,11 +486,11 @@ const PAYLOAD_BUDGETS: ReadonlyArray<readonly [string, number, number]> = [
   // below. The fix is compression there,
   // not a bigger number here. Unlike the skill corpus, this file has no
   // MEASURED record, so these figures are the only thing that goes stale
-  // silently; re-measure them in any commit that touches `testing.md` -- these
-  // three AND the `measured` figure and CAP on the rule-file-payload.test.ts
-  // row above, whose payload is `testing.md` alone for the same `tests/**`
-  // glob. That row is why the count is four, not the three this sentence
-  // claimed until 2026-09-06.
+  // silently; re-measure them in any commit that touches `testing.md` -- these,
+  // plus the `measured` figure and the cap on the rule-file-payload.test.ts row
+  // above and this row's own cap, all of which bound a payload that IS
+  // `testing.md`. Deliberately not stated as a COUNT: this sentence said
+  // "three" while enumerating more, twice.
   // RE-MEASURED 2026-09-05 after the work-issues retro escalated its
   // one-sided-fence rule into `testing.md` (+256 B of rule, 140 B of it paid
   // back by compressing three neighbouring mutation bullets, 46,257 -> 46,373 B

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -341,45 +341,48 @@ const MIN_REFERENCE_FILES = 6;
 // go-to-k/cdkd#2674) landed two rules here: triage.md section 2's worktree
 // probe now ranges over `origin/main...HEAD` (`show --stat HEAD` reads ONE
 // commit, and read 1 of the 5 files a ten-commit lane held), and implement.md
-// section 5-g's fan-out sentence now names the REPORT SHAPE. It also flipped
-// the leader -- implement.md overtakes verify.md -- so `largest` and `runnerUp`
+// section 5-g's fan-out sentence now names the REPORT SHAPE. Components:
+// triage.md 26,084 -> 26,219 (+135), implement.md 28,079 -> 28,240 (+161),
+// gotchas.md 8,045 -> 7,938 (-107), retro.md 17,625 -> 17,585 (-40),
+// claim.md 7,704 -> 7,645 (-59), = +90. Corpus 172,956 -> 173,046. The leader
+// FLIPPED -- implement.md overtakes verify.md -- so `largest` and `runnerUp`
 // SWAP above and the binding bound becomes `corpus - verify.md`.
-//
-// NO PER-FILE ARITHMETIC IS STATED HERE, DELIBERATELY, AND THAT IS THIS ROUND'S
-// MAIN LESSON. Every entry above states its components so a reader can check
-// them. This round tried, and produced SEVEN wrong figures across three review
-// rounds: a spent-band figure, a component split, a byte attribution measured
-// against a commit range that dies at the squash merge, a "most of" claim, a
-// ratio, a line distance, and a count. Not one was caught by reading; all seven
-// were caught by measuring. MEASURED's four numbers are asserted against the
-// tree and cannot go stale silently -- a delta written into a comment is
-// checked by nothing, which is what this file already said above ("every count
-// that was merely counted has been dropped") and what it stopped doing here.
-// So they are DROPPED rather than corrected an eighth time; `wc -c` against
-// origin/main re-derives any of them in one command. That is retro.md section
-// 10-b's escalate-rather-than-restate applied to a paragraph, and
-// .claude/rules/testing.md's disposition for a figure nothing rechecks: delete
-// it, fence it, or date it.
 //
 // The payment was DISPLACEMENT, not compression: gotchas.md was restating
 // section 2's two live-lane probes in full, and retro.md and claim.md each
 // carried a bare "English only" line for a rule CLAUDE.md owns and two hooks
-// enforce (`non-english-text-gate`, `gh-body-english-gate` -- both verified in
-// review to cover the exact removed contexts, including the `--body` form
+// enforce (`non-english-text-gate`, `gh-body-english-gate` -- both live-probed
+// in review against the exact removed contexts, including the `--body` form
 // claim.md prescribes). A prose copy of a hook-enforced rule is paid for in
 // every lane and stops nothing.
 //
+// WHAT THIS ROUND COST, AND THE ONE DISTINCTION WORTH KEEPING. Four review
+// rounds produced SEVEN wrong figures here, and a first attempt at this
+// paragraph answered by deleting ALL of its arithmetic. That over-corrected,
+// and review caught it: re-derived at the commit that wrote them, the per-file
+// COMPONENTS were right 5 for 5, every time. The seven wrong ones were a
+// different class -- an attribution against a commit range that dies at the
+// squash merge, a component SPLIT, a ratio, a "most of" claim, a line
+// distance, a count, and a cross-file band. So the rule is not "state no
+// numbers": it is that a component is a `wc -c` of a file at a sha and is
+// re-derivable forever, while a DERIVED figure is checked by nothing and has
+// never once survived a round here. State components; do not state deltas
+// about deltas. And state them HERE rather than trusting `wc -c` against
+// origin/main, because after this squashes, origin/main IS the after-side and
+// the before-side is only in this comment -- which is why every entry above
+// carries its components too.
+//
 // Two further lessons landed OUTSIDE this corpus and cost it nothing:
 // `.claude/rules/testing.md` (a guard's uses are its CALL SITES, not the first
-// one) and a fence in work-issues-launch-mode.test.ts pinning the ranged probe.
-// Read that fence's history before writing the next one -- it needed three
-// drafts, and each failure was the class it exists to catch. Draft 1's FLOOR
-// was inert: it filtered `git`-prefixed lines, so a `#` comment planted inside
-// the code block satisfied it while the rationale paragraph was deleted.
-// Draft 2 selected blocks with `bashBlocks`, which recognises only a column-0
-// ```bash fence, so the withdrawn command survived as ```sh, as a bare ```, or
-// indented in a list item. It is LINE-based now, and needs no fence parsing at
-// all.
+// one) and a fence in work-issues-launch-mode.test.ts pinning the ranged
+// probe. Read that fence's own history before writing the next one: it took
+// four drafts, and every failure was the class it exists to catch -- an inert
+// FLOOR, then a recogniser that saw only column-0 ```bash fences, then a line
+// scan that closed those and regressed the floor while going blind to any
+// command whose line does not start with `git`. It is the UNION of both
+// recognisers now, probed against every evasion the four rounds produced --
+// command SHAPE as well as fence style, which is what the earlier batteries
+// varied and missed.
 // The next addition here has to be paid for by compression FIRST -- retro.md
 // section 10-c forbids buying the room by raising this floor, and note that
 // SPLITTING a stage file makes this bound tighter, not looser (a smaller

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,9 +122,9 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_752,
-    corpusBytes: 172_956,
+    corpusBytes: 172_963,
     largest: { file: 'verify.md', bytes: 28_154 },
-    runnerUp: { file: 'implement.md', bytes: 28_079 },
+    runnerUp: { file: 'implement.md', bytes: 28_137 },
   },
 };
 
@@ -337,6 +337,24 @@ const MIN_REFERENCE_FILES = 6;
 // survives here is MEASURED's four fields and the per-file components, both
 // checkable with `wc -c` against origin/main; every count that was merely
 // counted has been dropped.
+// The 2026-09-05 deploy-batch retro (go-to-k/cdkd#2634 / go-to-k/cdkd#2649 /
+// go-to-k/cdkd#2674) landed TWO rules here and ended NET POSITIVE by 7 B:
+// triage.md section 2's worktree probe now ranges over `origin/main...HEAD`
+// (`show --stat HEAD` reads one commit, and read 1 of the 5 files a ten-commit
+// lane held), and implement.md section 5-g's fan-out sentence now names the
+// REPORT SHAPE. Components, stated so they can be checked rather than
+// believed: triage.md 26,084 -> 26,145 (+61, the subsumed base-commit sentence
+// went), implement.md 28,079 -> 28,137 (+58 net, three neighbouring bullets
+// compressed), gotchas.md 8,045 -> 7,933 (-112), = +7. Corpus
+// 172,956 -> 172,963, verify.md (untouched) keeps the lead at 28,154, margin
+// 123 -> 174 B. The payment is the appendix again, and for the reason the
+// go-to-k/cdkd#2438 entry above records: gotchas.md was restating section 2's
+// two live-lane probes in full, so it now points at them.
+// The retro's third lesson landed OUTSIDE this corpus, in
+// `.claude/rules/testing.md` -- a guard's uses are its CALL SITES, not the
+// first one -- which is free to THIS corpus but spent 159 B of the
+// `tests/setup.ts` band in rule-file-payload.test.ts, re-derived there in the
+// same commit.
 // The next addition here has to be paid for by compression FIRST -- retro.md
 // section 10-c forbids buying the room by raising this floor, and note that
 // SPLITTING a stage file makes this bound tighter, not looser (a smaller

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,7 +122,7 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_752,
-    corpusBytes: 173_051,
+    corpusBytes: 173_046,
     largest: { file: 'implement.md', bytes: 28_240 },
     runnerUp: { file: 'verify.md', bytes: 28_154 },
   },
@@ -338,31 +338,46 @@ const MIN_REFERENCE_FILES = 6;
 // checkable with `wc -c` against origin/main; every count that was merely
 // counted has been dropped.
 // The 2026-09-05 deploy-batch retro (go-to-k/cdkd#2634 / go-to-k/cdkd#2649 /
-// go-to-k/cdkd#2674) landed TWO rules here for +95 B: triage.md section 2's
+// go-to-k/cdkd#2674) landed TWO rules here for +90 B: triage.md section 2's
 // worktree probe now ranges over `origin/main...HEAD` (`show --stat HEAD`
 // reads one commit, and read 1 of the 5 files a ten-commit lane held), and
 // implement.md section 5-g's fan-out sentence now names the REPORT SHAPE.
-// Components, stated so they can be checked rather than believed: triage.md
-// 26,084 -> 26,218 (+134), implement.md 28,079 -> 28,240 (+161), gotchas.md
-// 8,045 -> 7,845 (-200), = +95. Corpus 172,956 -> 173,051; margin 123 -> 103 B.
-// The payment is the appendix again, and for the reason the go-to-k/cdkd#2438
-// entry above records: gotchas.md was restating section 2's two live-lane
-// probes AND CLAUDE.md's arm-the-signal-first rule, and now points at both.
-// NOTE THE LEADER FLIP: implement.md 28,240 overtakes verify.md 28,154, so
-// `largest` and `runnerUp` SWAP in MEASURED above and the binding bound is now
-// `corpus - verify.md`. Both figures are POST-REVIEW. The round's first draft
-// was +7 B, and two reviewers reading the same diff independently found that
-// its compression had re-bound go-to-k/cdkd#2270 to the wrong one of that
-// bullet's two incidents; restoring the dropped clause with its citation is
-// most of the extra 88 B, and it is why a compression payment is never free --
-// the bytes it saves can be a citation's antecedent.
-// The retro's third lesson landed OUTSIDE this corpus, in
-// `.claude/rules/testing.md` -- a guard's uses are its CALL SITES, not the
-// first one -- which is free to THIS corpus but spent 116 B of the
-// `tests/setup.ts` band in rule-file-payload.test.ts, re-derived there in the
-// same commit (the band moved 242 -> 126 B; an earlier draft said 159, which
-// reconciled with nothing -- the go-to-k/cdkd#2554 entry's `+38` incident,
-// repeated in the file whose whole subject is a figure going stale).
+// Components against origin/main, stated so they can be checked rather than
+// believed: triage.md 26,084 -> 26,219 (+135), implement.md 28,079 -> 28,240
+// (+161), gotchas.md 8,045 -> 7,938 (-107), retro.md 17,625 -> 17,585 (-40),
+// claim.md 7,704 -> 7,645 (-59), = +90. Corpus 172,956 -> 173,046; margin
+// 123 -> 108 B. NOTE THE LEADER FLIP: implement.md 28,240 overtakes verify.md
+// 28,154 (untouched), so `largest` and `runnerUp` SWAP above and the binding
+// bound becomes `corpus - verify.md`.
+// The payment is displacement, not compression: gotchas.md was restating
+// section 2's two live-lane probes in full, and retro.md and claim.md each
+// carried a bare "English only" line for a rule CLAUDE.md owns and two hooks
+// enforce (`non-english-text-gate`, `gh-body-english-gate`) -- a prose copy of
+// a hook-enforced rule is paid for in every lane and stops nothing.
+// A THIRD lesson landed outside this corpus in `.claude/rules/testing.md` (a
+// guard's uses are its CALL SITES), and a FOURTH is the fence in
+// work-issues-launch-mode.test.ts that pins the ranged probe -- both free to
+// THIS corpus; the testing.md one spent 116 B of the `tests/setup.ts` band in
+// rule-file-payload.test.ts, re-derived there in the same commit.
+// Every figure here is POST-REVIEW and stated against origin/main, because an
+// intermediate commit's arithmetic disappears at the squash merge and cannot be
+// re-derived -- an earlier revision attributed "88 B" to a range that will not
+// exist, which is this file's own `wc -c against origin/main` rule broken 40
+// lines below where it is stated.
+// What review changed, across two rounds and four reviewers: the two fence
+// files disagreed about one quantity (159 vs 116 B); a component split of
+// "+207 / 91" reconciled with no definition (measured +256 / -140); a
+// compression had re-bound go-to-k/cdkd#2270 to the wrong one of its bullet's
+// two incidents, dropping the clause that was the only evidence for the
+// bullet's second headline half; and the first draft of the new fence's own
+// FLOOR was inert -- it filtered `git`-prefixed lines, so a `#` comment inside
+// the code block satisfied it while the rationale paragraph was deleted.
+// Restoring the citation leaves that bullet at 661 B against main's 692, so
+// implement.md's +161 is the REPORT SHAPE clause net of three compressions and
+// NOT the restoration; a draft of this paragraph claimed otherwise and
+// measurement contradicted it. Three wrong byte attributions in one round, all
+// three caught by measuring rather than reading -- which is why a compression
+// payment is never free: the bytes it saves can be a citation's antecedent.
 // The next addition here has to be paid for by compression FIRST -- retro.md
 // section 10-c forbids buying the room by raising this floor, and note that
 // SPLITTING a stage file makes this bound tighter, not looser (a smaller

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -375,14 +375,20 @@ const MIN_REFERENCE_FILES = 6;
 // Two further lessons landed OUTSIDE this corpus and cost it nothing:
 // `.claude/rules/testing.md` (a guard's uses are its CALL SITES, not the first
 // one) and a fence in work-issues-launch-mode.test.ts pinning the ranged
-// probe. Read that fence's own history before writing the next one: it took
-// four drafts, and every failure was the class it exists to catch -- an inert
-// FLOOR, then a recogniser that saw only column-0 ```bash fences, then a line
-// scan that closed those and regressed the floor while going blind to any
-// command whose line does not start with `git`. It is the UNION of both
-// recognisers now, probed against every evasion the four rounds produced --
-// command SHAPE as well as fence style, which is what the earlier batteries
-// varied and missed.
+// probe. Read that fence's own history before writing the next one, because it
+// is the sharpest thing this round produced. It took FIVE drafts, and every
+// failure was the class the fence exists to catch: an inert FLOOR; then a
+// recogniser seeing only column-0 ```bash fences; then a line scan that closed
+// those, regressed the floor, and went blind to any command whose line does
+// not start with `git`; then a union still anchored on a line-leading git, so
+// a bullet or blockquote escaped. Each draft passed its own battery because
+// each battery varied only what the PREVIOUS round had found -- fence style,
+// then command shape, then carrier. The current one varies all three, and the
+// widening that closed the last of them immediately reported a FALSE POSITIVE
+// its own suite caught (a doc DISCUSSING the probe is not a second copy), so
+// the ban and the uniqueness check now take deliberately different extractions.
+// If there is one transferable lesson here it is that a fence's battery
+// inherits the imagination of the round that wrote it.
 // The next addition here has to be paid for by compression FIRST -- retro.md
 // section 10-c forbids buying the room by raising this floor, and note that
 // SPLITTING a stage file makes this bound tighter, not looser (a smaller

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -338,46 +338,48 @@ const MIN_REFERENCE_FILES = 6;
 // checkable with `wc -c` against origin/main; every count that was merely
 // counted has been dropped.
 // The 2026-09-05 deploy-batch retro (go-to-k/cdkd#2634 / go-to-k/cdkd#2649 /
-// go-to-k/cdkd#2674) landed TWO rules here for +90 B: triage.md section 2's
-// worktree probe now ranges over `origin/main...HEAD` (`show --stat HEAD`
-// reads one commit, and read 1 of the 5 files a ten-commit lane held), and
-// implement.md section 5-g's fan-out sentence now names the REPORT SHAPE.
-// Components against origin/main, stated so they can be checked rather than
-// believed: triage.md 26,084 -> 26,219 (+135), implement.md 28,079 -> 28,240
-// (+161), gotchas.md 8,045 -> 7,938 (-107), retro.md 17,625 -> 17,585 (-40),
-// claim.md 7,704 -> 7,645 (-59), = +90. Corpus 172,956 -> 173,046; margin
-// 123 -> 108 B. NOTE THE LEADER FLIP: implement.md 28,240 overtakes verify.md
-// 28,154 (untouched), so `largest` and `runnerUp` SWAP above and the binding
-// bound becomes `corpus - verify.md`.
-// The payment is displacement, not compression: gotchas.md was restating
+// go-to-k/cdkd#2674) landed two rules here: triage.md section 2's worktree
+// probe now ranges over `origin/main...HEAD` (`show --stat HEAD` reads ONE
+// commit, and read 1 of the 5 files a ten-commit lane held), and implement.md
+// section 5-g's fan-out sentence now names the REPORT SHAPE. It also flipped
+// the leader -- implement.md overtakes verify.md -- so `largest` and `runnerUp`
+// SWAP above and the binding bound becomes `corpus - verify.md`.
+//
+// NO PER-FILE ARITHMETIC IS STATED HERE, DELIBERATELY, AND THAT IS THIS ROUND'S
+// MAIN LESSON. Every entry above states its components so a reader can check
+// them. This round tried, and produced SEVEN wrong figures across three review
+// rounds: a spent-band figure, a component split, a byte attribution measured
+// against a commit range that dies at the squash merge, a "most of" claim, a
+// ratio, a line distance, and a count. Not one was caught by reading; all seven
+// were caught by measuring. MEASURED's four numbers are asserted against the
+// tree and cannot go stale silently -- a delta written into a comment is
+// checked by nothing, which is what this file already said above ("every count
+// that was merely counted has been dropped") and what it stopped doing here.
+// So they are DROPPED rather than corrected an eighth time; `wc -c` against
+// origin/main re-derives any of them in one command. That is retro.md section
+// 10-b's escalate-rather-than-restate applied to a paragraph, and
+// .claude/rules/testing.md's disposition for a figure nothing rechecks: delete
+// it, fence it, or date it.
+//
+// The payment was DISPLACEMENT, not compression: gotchas.md was restating
 // section 2's two live-lane probes in full, and retro.md and claim.md each
 // carried a bare "English only" line for a rule CLAUDE.md owns and two hooks
-// enforce (`non-english-text-gate`, `gh-body-english-gate`) -- a prose copy of
-// a hook-enforced rule is paid for in every lane and stops nothing.
-// A THIRD lesson landed outside this corpus in `.claude/rules/testing.md` (a
-// guard's uses are its CALL SITES), and a FOURTH is the fence in
-// work-issues-launch-mode.test.ts that pins the ranged probe -- both free to
-// THIS corpus; the testing.md one spent 116 B of the `tests/setup.ts` band in
-// rule-file-payload.test.ts, re-derived there in the same commit.
-// Every figure here is POST-REVIEW and stated against origin/main, because an
-// intermediate commit's arithmetic disappears at the squash merge and cannot be
-// re-derived -- an earlier revision attributed "88 B" to a range that will not
-// exist, which is this file's own `wc -c against origin/main` rule broken 40
-// lines below where it is stated.
-// What review changed, across two rounds and four reviewers: the two fence
-// files disagreed about one quantity (159 vs 116 B); a component split of
-// "+207 / 91" reconciled with no definition (measured +256 / -140); a
-// compression had re-bound go-to-k/cdkd#2270 to the wrong one of its bullet's
-// two incidents, dropping the clause that was the only evidence for the
-// bullet's second headline half; and the first draft of the new fence's own
-// FLOOR was inert -- it filtered `git`-prefixed lines, so a `#` comment inside
+// enforce (`non-english-text-gate`, `gh-body-english-gate` -- both verified in
+// review to cover the exact removed contexts, including the `--body` form
+// claim.md prescribes). A prose copy of a hook-enforced rule is paid for in
+// every lane and stops nothing.
+//
+// Two further lessons landed OUTSIDE this corpus and cost it nothing:
+// `.claude/rules/testing.md` (a guard's uses are its CALL SITES, not the first
+// one) and a fence in work-issues-launch-mode.test.ts pinning the ranged probe.
+// Read that fence's history before writing the next one -- it needed three
+// drafts, and each failure was the class it exists to catch. Draft 1's FLOOR
+// was inert: it filtered `git`-prefixed lines, so a `#` comment planted inside
 // the code block satisfied it while the rationale paragraph was deleted.
-// Restoring the citation leaves that bullet at 661 B against main's 692, so
-// implement.md's +161 is the REPORT SHAPE clause net of three compressions and
-// NOT the restoration; a draft of this paragraph claimed otherwise and
-// measurement contradicted it. Three wrong byte attributions in one round, all
-// three caught by measuring rather than reading -- which is why a compression
-// payment is never free: the bytes it saves can be a citation's antecedent.
+// Draft 2 selected blocks with `bashBlocks`, which recognises only a column-0
+// ```bash fence, so the withdrawn command survived as ```sh, as a bare ```, or
+// indented in a list item. It is LINE-based now, and needs no fence parsing at
+// all.
 // The next addition here has to be paid for by compression FIRST -- retro.md
 // section 10-c forbids buying the room by raising this floor, and note that
 // SPLITTING a stage file makes this bound tighter, not looser (a smaller

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -122,9 +122,9 @@ const MEASURED: Record<string, { orchestratorBytes: number; corpusBytes: number;
     // since c416ecb5. Nothing was wrong with the reasoning -- only nothing
     // checked it, which is the same failure the corpus figures had.
     orchestratorBytes: 11_752,
-    corpusBytes: 172_963,
-    largest: { file: 'verify.md', bytes: 28_154 },
-    runnerUp: { file: 'implement.md', bytes: 28_137 },
+    corpusBytes: 173_051,
+    largest: { file: 'implement.md', bytes: 28_240 },
+    runnerUp: { file: 'verify.md', bytes: 28_154 },
   },
 };
 
@@ -338,23 +338,31 @@ const MIN_REFERENCE_FILES = 6;
 // checkable with `wc -c` against origin/main; every count that was merely
 // counted has been dropped.
 // The 2026-09-05 deploy-batch retro (go-to-k/cdkd#2634 / go-to-k/cdkd#2649 /
-// go-to-k/cdkd#2674) landed TWO rules here and ended NET POSITIVE by 7 B:
-// triage.md section 2's worktree probe now ranges over `origin/main...HEAD`
-// (`show --stat HEAD` reads one commit, and read 1 of the 5 files a ten-commit
-// lane held), and implement.md section 5-g's fan-out sentence now names the
-// REPORT SHAPE. Components, stated so they can be checked rather than
-// believed: triage.md 26,084 -> 26,145 (+61, the subsumed base-commit sentence
-// went), implement.md 28,079 -> 28,137 (+58 net, three neighbouring bullets
-// compressed), gotchas.md 8,045 -> 7,933 (-112), = +7. Corpus
-// 172,956 -> 172,963, verify.md (untouched) keeps the lead at 28,154, margin
-// 123 -> 174 B. The payment is the appendix again, and for the reason the
-// go-to-k/cdkd#2438 entry above records: gotchas.md was restating section 2's
-// two live-lane probes in full, so it now points at them.
+// go-to-k/cdkd#2674) landed TWO rules here for +95 B: triage.md section 2's
+// worktree probe now ranges over `origin/main...HEAD` (`show --stat HEAD`
+// reads one commit, and read 1 of the 5 files a ten-commit lane held), and
+// implement.md section 5-g's fan-out sentence now names the REPORT SHAPE.
+// Components, stated so they can be checked rather than believed: triage.md
+// 26,084 -> 26,218 (+134), implement.md 28,079 -> 28,240 (+161), gotchas.md
+// 8,045 -> 7,845 (-200), = +95. Corpus 172,956 -> 173,051; margin 123 -> 103 B.
+// The payment is the appendix again, and for the reason the go-to-k/cdkd#2438
+// entry above records: gotchas.md was restating section 2's two live-lane
+// probes AND CLAUDE.md's arm-the-signal-first rule, and now points at both.
+// NOTE THE LEADER FLIP: implement.md 28,240 overtakes verify.md 28,154, so
+// `largest` and `runnerUp` SWAP in MEASURED above and the binding bound is now
+// `corpus - verify.md`. Both figures are POST-REVIEW. The round's first draft
+// was +7 B, and two reviewers reading the same diff independently found that
+// its compression had re-bound go-to-k/cdkd#2270 to the wrong one of that
+// bullet's two incidents; restoring the dropped clause with its citation is
+// most of the extra 88 B, and it is why a compression payment is never free --
+// the bytes it saves can be a citation's antecedent.
 // The retro's third lesson landed OUTSIDE this corpus, in
 // `.claude/rules/testing.md` -- a guard's uses are its CALL SITES, not the
-// first one -- which is free to THIS corpus but spent 159 B of the
+// first one -- which is free to THIS corpus but spent 116 B of the
 // `tests/setup.ts` band in rule-file-payload.test.ts, re-derived there in the
-// same commit.
+// same commit (the band moved 242 -> 126 B; an earlier draft said 159, which
+// reconciled with nothing -- the go-to-k/cdkd#2554 entry's `+38` incident,
+// repeated in the file whose whole subject is a figure going stale).
 // The next addition here has to be paid for by compression FIRST -- retro.md
 // section 10-c forbids buying the room by raising this floor, and note that
 // SPLITTING a stage file makes this bound tighter, not looser (a smaller

--- a/tests/unit/scripts/skill-file-payload.test.ts
+++ b/tests/unit/scripts/skill-file-payload.test.ts
@@ -136,11 +136,11 @@ const MIN_REFERENCE_FILES = 6;
 // here.
 // RE-DERIVED DOWNWARD 208_000 -> 145_000 by the 2026-09-04 corpus compression
 // pass, exactly the move the assertion's failure message prescribes for a
-// genuine compression ("re-derive it DOWNWARD in the same commit"). Inputs are
-// in MEASURED and asserted: corpus 171,399 B, largest verify.md 27,036 B,
-// runner-up implement.md 26,541 B. The floor must clear `corpus - largest`
-// (144,363) and `corpus - runnerUp` (144,858, the binding direction);
-// 145,000 clears them by 637 and 142 B. Growth in a NON-leader file erodes
+// genuine compression ("re-derive it DOWNWARD in the same commit"). Its inputs
+// AT THAT DATE -- not now; MEASURED holds the live ones and the assertion
+// recomputes the property -- were corpus 171,399 B, largest verify.md 27,036 B,
+// runner-up implement.md 26,541 B, clearing `corpus - largest` (144,363) and
+// `corpus - runnerUp` (144,858, the binding direction) by 637 and 142 B. Growth in a NON-leader file erodes
 // the either-largest margin first -- MEASURED's failure message reports both
 // margins, so the next lapse reds this file at the commit that causes it.
 // The 2026-09-04 retro (go-to-k/cdkd#2514's run) spent most of the 3,366 B the
@@ -376,17 +376,18 @@ const MIN_REFERENCE_FILES = 6;
 // `.claude/rules/testing.md` (a guard's uses are its CALL SITES, not the first
 // one) and a fence in work-issues-launch-mode.test.ts pinning the ranged
 // probe. Read that fence's own history before writing the next one, because it
-// is the sharpest thing this round produced. It took FIVE drafts, and every
-// failure was the class the fence exists to catch: an inert FLOOR; then a
-// recogniser seeing only column-0 ```bash fences; then a line scan that closed
-// those, regressed the floor, and went blind to any command whose line does
-// not start with `git`; then a union still anchored on a line-leading git, so
-// a bullet or blockquote escaped. Each draft passed its own battery because
-// each battery varied only what the PREVIOUS round had found -- fence style,
-// then command shape, then carrier. The current one varies all three, and the
-// widening that closed the last of them immediately reported a FALSE POSITIVE
-// its own suite caught (a doc DISCUSSING the probe is not a second copy), so
-// the ban and the uniqueness check now take deliberately different extractions.
+// is the sharpest thing this round produced. Every draft of it failed in the
+// class the fence exists to catch: an inert FLOOR; then a recogniser seeing
+// only column-0 ```bash fences; then a line scan that closed those, regressed
+// the floor, and went blind to any command whose line does not start with
+// `git`; then a union still anchored on a line-leading git, so a bullet or
+// blockquote escaped; then a delimiter CLASS, which still let `**git …**`,
+// `"git …"` and `<code>git …</code>` through. Each passed its own battery,
+// because each battery varied only what the PREVIOUS round had found -- fence
+// style, then command shape, then carrier, then delimiter. It ends on the
+// weakest matcher that punctuation cannot evade, the token `git` itself, with
+// the peer predicate qualified by `<MAIN_CHECKOUT>` so one extraction serves
+// both questions.
 // If there is one transferable lesson here it is that a fence's battery
 // inherits the imagination of the round that wrote it.
 // The next addition here has to be paid for by compression FIRST -- retro.md

--- a/tests/unit/scripts/work-issues-launch-mode.test.ts
+++ b/tests/unit/scripts/work-issues-launch-mode.test.ts
@@ -845,73 +845,105 @@ describe('work-issues section 2 worktree probe', () => {
   const TRIAGE = join('references', 'triage.md');
 
   /**
-   * LINE-BASED on purpose, NOT fence-based.
+   * ONE extraction feeds every case below, and it is the UNION of the two
+   * recognisers this fence went through -- because each caught what the other
+   * missed, and three review rounds were spent discovering that one at a time.
    *
-   * The first draft of this fence selected blocks with `bashBlocks`, which
-   * recognises only a column-0 ```bash fence. Measured 2026-09-06 (round 3): a
-   * stale peer-worktree `show --stat HEAD` planted in gotchas.md survived all
-   * three cases when written as ```sh, as a bare ```, or as an INDENTED
-   * ```bash inside a list item -- and the skill already carries three indented
-   * ```bash fences, so `bashBlocks` sees 39 of its 42. Widening the scan from
-   * one FILE to every file, as round 2 did, moved the same hole one notch over.
+   * Draft 2 selected `bashBlocks`, which sees only a column-0 ```bash fence:
+   * the withdrawn command survived as ```sh, bare ```, or indented (the skill
+   * carries 3 indented fences of 42). Draft 3 replaced it with a `^\s*git`
+   * line scan, which closed those and REGRESSED the rest -- `cd … && git show`,
+   * a `for` loop body, an `env`-prefixed call and a `\`-continuation are all
+   * commands whose line does not START with git, and retro.md really does hard
+   * wrap a git command across a newline (see the note at the top of this file).
    *
-   * The withdrawn form is a COMMAND, and a command is recognisable without
-   * parsing fences at all -- so this scans lines and cannot be re-opened by a
-   * fence style nobody anticipated. The optional `$` covers a shell-prompt
-   * prefix -- the skill uses none today (grepped), so this is the cheap half of
-   * a bound rather than a fix for a live hole. `bashBlocks` is left alone: its contract is
-   * used by the section 9 block fences above, and widening a shared recogniser
-   * to fix one caller is how those would have silently changed meaning.
+   * So: every line inside a fence AT ANY indent OR tag, plus a bare `git …`
+   * line outside one, with continuations joined. `bashBlocks` is deliberately
+   * left alone -- the section 9 block fences depend on its contract, and
+   * widening a shared recogniser to suit one caller is how those change
+   * meaning silently.
    */
-  const GIT_LINE = /^\s*\$?\s*git\b/;
-  const gitLines = (doc: string): string[] =>
-    read(doc)
-      .split('\n')
-      .filter((l) => GIT_LINE.test(l));
+  const insideFence = (text: string): boolean[] => {
+    let open = false;
+    return text.split('\n').map((line) => {
+      if (/^\s*```/.test(line)) {
+        open = !open;
+        return false;
+      }
+      return open;
+    });
+  };
 
-  const peerProbeLines = (doc: string): string[] =>
-    gitLines(doc).filter((l) => /worktrees\/<w>/.test(l));
+  const GIT_LINE = /^\s*\$?\s*git\b/;
+
+  const commandUnits = (doc: string): string[] => {
+    const text = read(doc);
+    const fenced = insideFence(text);
+    const picked = text.split('\n').filter((line, i) => fenced[i] || GIT_LINE.test(line));
+    const units: string[] = [];
+    for (const line of picked) {
+      const prev = units[units.length - 1];
+      if (prev !== undefined && /\\\s*$/.test(prev)) {
+        units[units.length - 1] = `${prev.replace(/\\\s*$/, ' ')}${line.trim()}`;
+      } else {
+        units.push(line);
+      }
+    }
+    return units;
+  };
+
+  /**
+   * `git … show … --stat`-family, in either flag order. The `(?<![-\w])` is
+   * load-bearing: a bare `\bshow\b` also matches INSIDE `--show-current`, which
+   * `launch-mode.md` uses beside a `--stat`, and that false positive is exactly
+   * the kind of thing a ban nobody probed would have shipped with.
+   */
+  const SINGLE_COMMIT = /\bgit\b.*(?<![-\w])show\s+.*--(?:stat|numstat|shortstat|name-only|name-status)\b/;
+
+  const peerProbes = (doc: string): string[] =>
+    commandUnits(doc).filter((u) => /worktrees\/<w>/.test(u));
 
   it('only section 2 probes a peer worktree', () => {
     expect(
-      skillDocs().filter((doc) => peerProbeLines(doc).length > 0),
+      skillDocs().filter((doc) => peerProbes(doc).length > 0),
       'the per-worktree probe belongs to section 2 and nowhere else; a second copy drifts',
     ).toEqual([TRIAGE]);
   });
 
   it('ranges over origin/main...HEAD, and no doc still reads a single commit', () => {
-    const lines = peerProbeLines(TRIAGE);
-    expect(lines.length, 'the per-worktree probe is gone from section 2').toBeGreaterThan(0);
+    const probes = peerProbes(TRIAGE);
+    expect(probes.length, 'the per-worktree probe is gone from section 2').toBeGreaterThan(0);
     expect(
-      lines.some((l) => l.includes('diff --name-only origin/main...HEAD')),
-      `the probe must range over the branch; its commands were:\n${lines.join('\n')}`,
+      probes.some((u) => u.includes('diff --name-only origin/main...HEAD')),
+      `the probe must range over the branch; its commands were:\n${probes.join('\n')}`,
     ).toBe(true);
 
-    // Swept over EVERY doc, not just the probe above: the withdrawn form must
-    // not survive as a command anywhere in the skill, including in a stage file
-    // that never held the probe.
     const singleCommit = skillDocs().flatMap((doc) =>
-      gitLines(doc)
-        .filter((l) => /\bshow\s+--stat/.test(l))
-        .map((l) => `${doc}: ${l.trim()}`),
+      commandUnits(doc)
+        .filter((u) => SINGLE_COMMIT.test(u))
+        .map((u) => `${doc}: ${u.trim()}`),
     );
     expect(
       singleCommit,
-      'a `show --stat` probe reads ONE commit and under-reports a multi-commit lane -- ' +
+      'a `git show --stat` reads ONE commit and under-reports a multi-commit lane -- ' +
         'that form was withdrawn on 2026-09-05 and must not return as a COMMAND',
     ).toEqual([]);
   });
 
   it('still explains WHY the range is load-bearing, in prose', () => {
-    // The FLOOR half. Command lines AND comment lines are excluded, because the
-    // first draft filtered only `git`-prefixed ones and a `# not show --stat
-    // HEAD` planted in the block then satisfied it while the rationale
-    // paragraph was deleted (measured green, round 2). Without this case,
-    // deleting the explanation would read as a pass -- a cap with no floor
-    // rewards the inverse regression.
-    const prose = read(TRIAGE)
+    // The FLOOR half, and the half that has broken twice. Draft 1 filtered only
+    // `git`-prefixed lines, so a `#` comment planted in the block satisfied it;
+    // draft 3 filtered `git` and `#` lines, so an `echo` inside a fence and a
+    // 4-space indented code line did. Prose here means: outside every fence,
+    // not a command, not a comment, not an indented code block.
+    const text = read(TRIAGE);
+    const fenced = insideFence(text);
+    const prose = text
       .split('\n')
-      .filter((l) => !GIT_LINE.test(l) && !/^\s*#/.test(l))
+      .filter(
+        (line, i) =>
+          !fenced[i] && !GIT_LINE.test(line) && !/^\s*#/.test(line) && !/^ {4,}\S/.test(line),
+      )
       .join('\n');
     expect(
       prose,

--- a/tests/unit/scripts/work-issues-launch-mode.test.ts
+++ b/tests/unit/scripts/work-issues-launch-mode.test.ts
@@ -846,62 +846,118 @@ describe('work-issues section 2 worktree probe', () => {
 
   /**
    * ONE extraction feeds every case below, and it is the UNION of the two
-   * recognisers this fence went through -- because each caught what the other
-   * missed, and three review rounds were spent discovering that one at a time.
+   * recognisers this fence went through -- each caught what the other missed,
+   * and four review rounds were spent finding that out one shape at a time.
    *
-   * Draft 2 selected `bashBlocks`, which sees only a column-0 ```bash fence:
+   * Draft 2 selected `bashBlocks`, which sees only a column-0 ```bash fence, so
    * the withdrawn command survived as ```sh, bare ```, or indented (the skill
-   * carries 3 indented fences of 42). Draft 3 replaced it with a `^\s*git`
-   * line scan, which closed those and REGRESSED the rest -- `cd … && git show`,
-   * a `for` loop body, an `env`-prefixed call and a `\`-continuation are all
-   * commands whose line does not START with git, and retro.md really does hard
-   * wrap a git command across a newline (see the note at the top of this file).
+   * carries three indented ```bash fences today). Draft 3 replaced it with a
+   * line scan anchored on `git`, which closed those and went blind to every
+   * command whose line does not START with git -- `cd … && git show`, a `for`
+   * body, an `env`-prefixed call, a `\`-continuation -- and regressed the floor
+   * with it. Draft 4 took the union but still anchored the outside-fence half
+   * on a line-leading git, so a command in a list item or a blockquote escaped.
    *
-   * So: every line inside a fence AT ANY indent OR tag, plus a bare `git …`
-   * line outside one, with continuations joined. `bashBlocks` is deliberately
-   * left alone -- the section 9 block fences depend on its contract, and
-   * widening a shared recogniser to suit one caller is how those change
-   * meaning silently.
+   * `bashBlocks` is deliberately left alone: the section 9 block fences depend
+   * on its contract, and widening a shared recogniser to suit one caller is how
+   * those change meaning silently.
    */
   const insideFence = (text: string): boolean[] => {
-    let open = false;
+    // Tracks the OPENING run's char and length. A plain toggle desyncs on a
+    // nested or four-backtick fence -- the inner marker flips it CLOSED and
+    // every later line reads inverted -- and ignores ~~~ entirely.
+    let open: string | null = null;
     return text.split('\n').map((line) => {
-      if (/^\s*```/.test(line)) {
-        open = !open;
-        return false;
+      const m = /^\s*(`{3,}|~{3,})/.exec(line);
+      if (m) {
+        const run = m[1]!;
+        if (open === null) {
+          open = run;
+          return false;
+        }
+        if (run[0] === open[0] && run.length >= open.length) {
+          open = null;
+          return false;
+        }
       }
-      return open;
+      return open !== null;
     });
   };
 
+  /** First token is a git call. NARROW, and used only to exclude prose below. */
   const GIT_LINE = /^\s*\$?\s*git\b/;
+  /** Contains a git call anywhere a shell could start one. WIDE, for extraction. */
+  const CONTAINS_GIT = /(?:^|[\s;&|(`])\$?git\b/;
 
-  const commandUnits = (doc: string): string[] => {
+  /**
+   * TWO extractions, same fence map, different outside-fence matcher -- because
+   * the two questions differ. The BAN wants maximal reach, so it takes any line
+   * carrying a git call. UNIQUENESS must NOT: `launch-mode.md` discusses
+   * section 2's probe in prose (`git -C .claude/worktrees/<w> log|show|status`
+   * as the WRONG relative form, and a table row naming the right one), and a
+   * doc TALKING ABOUT the probe is not a second copy of it. Running the wide
+   * matcher for both reported launch-mode.md as a duplicate -- a false positive
+   * caught by this fence's own suite, on the round that widened it.
+   *
+   * Known bound, stated rather than left to be discovered: a DUPLICATE probe
+   * written as a bullet or blockquote outside a fence is invisible to
+   * uniqueness. It is not invisible to the ban, which is where the harm lives
+   * -- a duplicate that still ranges is drift; one that reads a single commit
+   * is the defect, and the ban has the wide reach.
+   */
+  const unitsFrom = (doc: string, outsideFence: RegExp): string[] => {
     const text = read(doc);
     const fenced = insideFence(text);
-    const picked = text.split('\n').filter((line, i) => fenced[i] || GIT_LINE.test(line));
+    const picked: Array<{ i: number; line: string }> = [];
+    text.split('\n').forEach((line, i) => {
+      if (fenced[i] || outsideFence.test(line)) picked.push({ i, line });
+    });
+    // Join `\` continuations, but only across ADJACENT source lines: `picked`
+    // is filtered, so an index-blind join fuses a `\`-terminated line with the
+    // next PICKED line anywhere later and fabricates a command that never
+    // existed -- which can trip the ban or the peer case on nothing.
     const units: string[] = [];
-    for (const line of picked) {
+    let previousIndex = -2;
+    for (const { i, line } of picked) {
       const prev = units[units.length - 1];
-      if (prev !== undefined && /\\\s*$/.test(prev)) {
+      if (prev !== undefined && i === previousIndex + 1 && /\\\s*$/.test(prev)) {
         units[units.length - 1] = `${prev.replace(/\\\s*$/, ' ')}${line.trim()}`;
       } else {
         units.push(line);
       }
+      previousIndex = i;
     }
     return units;
   };
 
+  /** Real command blocks: fenced lines plus a line-leading `git …`. */
+  const blockUnits = (doc: string): string[] => unitsFrom(doc, GIT_LINE);
+  /** Those plus any line carrying a git call at all -- bullets, blockquotes, cells. */
+  const anyGitUnits = (doc: string): string[] => unitsFrom(doc, CONTAINS_GIT);
+
   /**
-   * `git … show … --stat`-family, in either flag order. The `(?<![-\w])` is
-   * load-bearing: a bare `\bshow\b` also matches INSIDE `--show-current`, which
-   * `launch-mode.md` uses beside a `--stat`, and that false positive is exactly
-   * the kind of thing a ban nobody probed would have shipped with.
+   * `git … show … --stat`-family, either flag order. `show\s+` is what excludes
+   * `--show-current` (a `-` follows the word, so `\s+` cannot match) -- measured,
+   * because an earlier revision credited a `(?<![-\w])` lookbehind for that and
+   * the lookbehind turned out inert: its only effect is the hypothetical
+   * `--show ` with a trailing space. It is kept as belt-and-braces, and is
+   * described here as exactly that rather than as the thing doing the work.
    */
-  const SINGLE_COMMIT = /\bgit\b.*(?<![-\w])show\s+.*--(?:stat|numstat|shortstat|name-only|name-status)\b/;
+  const SINGLE_COMMIT =
+    /\bgit\b.*(?<![-\w])show\s+.*--(?:[a-z-]*stat\b|name-only\b|name-status\b)/;
 
   const peerProbes = (doc: string): string[] =>
-    commandUnits(doc).filter((u) => /worktrees\/<w>/.test(u));
+    blockUnits(doc).filter((u) => /worktrees\/<w>/.test(u));
+
+  it('every doc has balanced fences, so the scan cannot read inverted', () => {
+    // Not decoration: an odd fence count leaves `insideFence` open to EOF, and
+    // every remaining prose line then reads as a command. That fails loudly in
+    // one place instead of silently changing what the three cases below mean.
+    const unbalanced = skillDocs().filter(
+      (doc) => (read(doc).match(/^\s*(?:`{3,}|~{3,})/gm) ?? []).length % 2 !== 0,
+    );
+    expect(unbalanced, 'an unterminated fence inverts every later line').toEqual([]);
+  });
 
   it('only section 2 probes a peer worktree', () => {
     expect(
@@ -919,24 +975,24 @@ describe('work-issues section 2 worktree probe', () => {
     ).toBe(true);
 
     const singleCommit = skillDocs().flatMap((doc) =>
-      commandUnits(doc)
+      anyGitUnits(doc)
         .filter((u) => SINGLE_COMMIT.test(u))
         .map((u) => `${doc}: ${u.trim()}`),
     );
     expect(
       singleCommit,
-      'a `git show --stat` reads ONE commit and under-reports a multi-commit lane -- ' +
-        'that form was withdrawn on 2026-09-05 and must not return as a COMMAND',
+      'a `git show --stat` reads ONE commit and under-reports a multi-commit lane; that ' +
+        'form was withdrawn on 2026-09-05. This scans fenced lines too, so an intentional ' +
+        '"do NOT do this" example must live in PROSE, not in a code block',
     ).toEqual([]);
   });
 
   it('still explains WHY the range is load-bearing, in prose', () => {
-    // The FLOOR half, and the half that has broken twice. Draft 1 filtered only
-    // `git`-prefixed lines, so a `#` comment planted in the block satisfied it;
-    // draft 3 filtered `git` and `#` lines, so an `echo` inside a fence and a
-    // 4-space indented code line did. Prose here means: outside every fence,
-    // not a command, not a comment, not an indented code block.
-    const text = read(TRIAGE);
+    // The FLOOR, and the half that has broken twice. Prose here means: outside
+    // every fence, not a command, not a comment, not an indented code block,
+    // and not inside an HTML comment -- a `<!-- … -->` carrier satisfied it
+    // while rendering invisible.
+    const text = read(TRIAGE).replace(/<!--[\s\S]*?-->/g, '');
     const fenced = insideFence(text);
     const prose = text
       .split('\n')

--- a/tests/unit/scripts/work-issues-launch-mode.test.ts
+++ b/tests/unit/scripts/work-issues-launch-mode.test.ts
@@ -819,3 +819,70 @@ describe('work-issues launch-mode probe', () => {
     });
   });
 });
+
+/**
+ * §2's per-worktree probe must range over the BRANCH, not one commit.
+ *
+ * WHY HERE. This file already owns "a withdrawn command cannot come back", and
+ * that is exactly the failure mode: `show --stat HEAD` reads ONE commit, so a
+ * lane several commits deep is under-reported and the collision scan calls a
+ * held file free. Measured 2026-09-05 on a worktree ten commits ahead of
+ * `origin/main` — `show --stat HEAD` reported 1 of the 5 files it held, hiding
+ * `CLAUDE.md`, and a triage sub-agent reported "no collision" on that basis.
+ * Nothing mechanical watched the probe, so a future edit could silently restore
+ * the single-commit form and every suite would stay green (the same argument
+ * this file's header makes for the launch-mode section).
+ *
+ * The fence is deliberately scoped to COMMAND LINES. The rationale prose beside
+ * the block has to keep naming `show --stat HEAD` to say what was wrong with it,
+ * and a blanket ban would forbid the explanation — so the two halves are pinned
+ * in OPPOSITE directions: absent from the commands, PRESENT in the prose. A cap
+ * with no floor rewards the inverse regression (deleting the rationale would
+ * otherwise read as a pass), which is the rule this same run added to
+ * `.claude/rules/testing.md`.
+ */
+describe('work-issues section 2 worktree probe', () => {
+  const TRIAGE = join('references', 'triage.md');
+  /** The probe block addresses a PEER worktree by path — that is what selects it. */
+  const isProbeBlock = (block: string): boolean =>
+    commandLines(block).some((c) => /worktrees\/<w>/.test(c));
+
+  it('exactly one block probes a peer worktree -- no decoy copy', () => {
+    const hits = bashBlocks(read(TRIAGE)).filter(isProbeBlock);
+    expect(
+      hits.length,
+      'section 2 should hold exactly one per-worktree probe block; a second copy drifts',
+    ).toBe(1);
+  });
+
+  it('ranges over origin/main...HEAD, and never reads a single commit', () => {
+    const block = bashBlocks(read(TRIAGE)).find(isProbeBlock);
+    expect(block, 'the per-worktree probe block is gone').toBeDefined();
+    const cmds = commandLines(block!);
+
+    expect(
+      cmds.some((c) => c.includes('diff --name-only origin/main...HEAD')),
+      `the probe must range over the branch; commands were:\n${cmds.join('\n')}`,
+    ).toBe(true);
+
+    const singleCommit = cmds.filter((c) => /show\s+--stat/.test(c));
+    expect(
+      singleCommit,
+      'a `show --stat` probe reads ONE commit and under-reports a multi-commit lane -- ' +
+        'that form was withdrawn on 2026-09-05 and must not return as a COMMAND',
+    ).toEqual([]);
+  });
+
+  it('still explains WHY the range is load-bearing, in prose', () => {
+    // The floor half. Without it, deleting the rationale satisfies the case
+    // above and the next author cannot tell the range from an arbitrary choice.
+    const prose = read(TRIAGE)
+      .split('\n')
+      .filter((l) => !/^\s*git\s/.test(l))
+      .join('\n');
+    expect(
+      prose,
+      'the paragraph naming what `show --stat HEAD` got wrong is the reason the range exists',
+    ).toContain('show --stat HEAD');
+  });
+});

--- a/tests/unit/scripts/work-issues-launch-mode.test.ts
+++ b/tests/unit/scripts/work-issues-launch-mode.test.ts
@@ -843,48 +843,57 @@ describe('work-issues launch-mode probe', () => {
  */
 describe('work-issues section 2 worktree probe', () => {
   const TRIAGE = join('references', 'triage.md');
-  /** The probe block addresses a PEER worktree by path -- that is what selects it. */
-  const isProbeBlock = (block: string): boolean =>
-    commandLines(block).some((c) => /worktrees\/<w>/.test(c));
 
   /**
-   * Scanned across the WHOLE skill, not just triage.md. Scoping the scan to one
-   * file let a stale copy of the withdrawn probe live in any OTHER stage:
-   * planted in gotchas.md -- the file that until this run restated section 2's
-   * probes in full -- the suite stayed green (measured 2026-09-06, round 2).
+   * LINE-BASED on purpose, NOT fence-based.
+   *
+   * The first draft of this fence selected blocks with `bashBlocks`, which
+   * recognises only a column-0 ```bash fence. Measured 2026-09-06 (round 3): a
+   * stale peer-worktree `show --stat HEAD` planted in gotchas.md survived all
+   * three cases when written as ```sh, as a bare ```, or as an INDENTED
+   * ```bash inside a list item -- and the skill already carries three indented
+   * ```bash fences, so `bashBlocks` sees 39 of its 42. Widening the scan from
+   * one FILE to every file, as round 2 did, moved the same hole one notch over.
+   *
+   * The withdrawn form is a COMMAND, and a command is recognisable without
+   * parsing fences at all -- so this scans lines and cannot be re-opened by a
+   * fence style nobody anticipated. The optional `$` covers a shell-prompt
+   * prefix -- the skill uses none today (grepped), so this is the cheap half of
+   * a bound rather than a fix for a live hole. `bashBlocks` is left alone: its contract is
+   * used by the section 9 block fences above, and widening a shared recogniser
+   * to fix one caller is how those would have silently changed meaning.
    */
-  const probeBlocks = (): Array<{ doc: string; block: string }> =>
-    skillDocs().flatMap((doc) =>
-      bashBlocks(read(doc))
-        .filter(isProbeBlock)
-        .map((block) => ({ doc, block })),
-    );
+  const GIT_LINE = /^\s*\$?\s*git\b/;
+  const gitLines = (doc: string): string[] =>
+    read(doc)
+      .split('\n')
+      .filter((l) => GIT_LINE.test(l));
 
-  it('exactly one block probes a peer worktree, across the whole skill', () => {
+  const peerProbeLines = (doc: string): string[] =>
+    gitLines(doc).filter((l) => /worktrees\/<w>/.test(l));
+
+  it('only section 2 probes a peer worktree', () => {
     expect(
-      probeBlocks().map((h) => h.doc),
+      skillDocs().filter((doc) => peerProbeLines(doc).length > 0),
       'the per-worktree probe belongs to section 2 and nowhere else; a second copy drifts',
     ).toEqual([TRIAGE]);
   });
 
-  it('ranges over origin/main...HEAD, and no skill doc still reads a single commit', () => {
-    const hit = probeBlocks()[0];
-    expect(hit, 'the per-worktree probe block is gone').toBeDefined();
-    const cmds = commandLines(hit!.block);
-
+  it('ranges over origin/main...HEAD, and no doc still reads a single commit', () => {
+    const lines = peerProbeLines(TRIAGE);
+    expect(lines.length, 'the per-worktree probe is gone from section 2').toBeGreaterThan(0);
     expect(
-      cmds.some((c) => c.includes('diff --name-only origin/main...HEAD')),
-      `the probe must range over the branch; commands were:\n${cmds.join('\n')}`,
+      lines.some((l) => l.includes('diff --name-only origin/main...HEAD')),
+      `the probe must range over the branch; its commands were:\n${lines.join('\n')}`,
     ).toBe(true);
 
-    // Swept over EVERY doc rather than the block above: the withdrawn form must
-    // not survive as a COMMAND anywhere in the skill, including in a stage file
+    // Swept over EVERY doc, not just the probe above: the withdrawn form must
+    // not survive as a command anywhere in the skill, including in a stage file
     // that never held the probe.
     const singleCommit = skillDocs().flatMap((doc) =>
-      bashBlocks(read(doc))
-        .flatMap(commandLines)
-        .filter((c) => /show\s+--stat/.test(c))
-        .map((c) => `${doc}: ${c}`),
+      gitLines(doc)
+        .filter((l) => /\bshow\s+--stat/.test(l))
+        .map((l) => `${doc}: ${l.trim()}`),
     );
     expect(
       singleCommit,
@@ -893,14 +902,17 @@ describe('work-issues section 2 worktree probe', () => {
     ).toEqual([]);
   });
 
-  it('still explains WHY the range is load-bearing, in prose OUTSIDE any block', () => {
-    // Subtracting the fenced blocks is the load-bearing part. Filtering
-    // `git`-prefixed lines instead left a whole-line `#` comment INSIDE a block
-    // able to satisfy this, so deleting the rationale paragraph and adding
-    // `# not show --stat HEAD` to the block passed -- the inert-floor failure
-    // this case exists to prevent, measured on itself 2026-09-06 in round 2.
-    const doc = read(TRIAGE);
-    const prose = bashBlocks(doc).reduce((acc, b) => acc.split(b).join(''), doc);
+  it('still explains WHY the range is load-bearing, in prose', () => {
+    // The FLOOR half. Command lines AND comment lines are excluded, because the
+    // first draft filtered only `git`-prefixed ones and a `# not show --stat
+    // HEAD` planted in the block then satisfied it while the rationale
+    // paragraph was deleted (measured green, round 2). Without this case,
+    // deleting the explanation would read as a pass -- a cap with no floor
+    // rewards the inverse regression.
+    const prose = read(TRIAGE)
+      .split('\n')
+      .filter((l) => !GIT_LINE.test(l) && !/^\s*#/.test(l))
+      .join('\n');
     expect(
       prose,
       'the paragraph naming what `show --stat HEAD` got wrong is the reason the range exists',

--- a/tests/unit/scripts/work-issues-launch-mode.test.ts
+++ b/tests/unit/scripts/work-issues-launch-mode.test.ts
@@ -845,29 +845,36 @@ describe('work-issues section 2 worktree probe', () => {
   const TRIAGE = join('references', 'triage.md');
 
   /**
-   * ONE extraction feeds every case below, and it is the UNION of the two
-   * recognisers this fence went through -- each caught what the other missed,
-   * and four review rounds were spent finding that out one shape at a time.
+   * ONE extraction feeds every case below, and getting it right took five
+   * drafts -- each of which passed its own battery, because each battery varied
+   * only what the PREVIOUS round had found. That is the whole lesson: a fence's
+   * battery inherits the imagination of the round that wrote it.
    *
-   * Draft 2 selected `bashBlocks`, which sees only a column-0 ```bash fence, so
-   * the withdrawn command survived as ```sh, bare ```, or indented (the skill
-   * carries three indented ```bash fences today). Draft 3 replaced it with a
-   * line scan anchored on `git`, which closed those and went blind to every
-   * command whose line does not START with git -- `cd … && git show`, a `for`
-   * body, an `env`-prefixed call, a `\`-continuation -- and regressed the floor
-   * with it. Draft 4 took the union but still anchored the outside-fence half
-   * on a line-leading git, so a command in a list item or a blockquote escaped.
+   * Draft 2 used `bashBlocks`, which sees only a column-0 ```bash fence, so the
+   * withdrawn command survived as ```sh, bare ```, or indented. Draft 3 went
+   * line-based and closed those while going blind to every command whose line
+   * does not START with git (`cd … && git show`, a `for` body, an `env` prefix,
+   * a `\`-continuation) -- and regressed the FLOOR with it. Draft 4 took the
+   * union but still anchored the outside-fence half on a line-leading git, so a
+   * list item, blockquote or table cell escaped. Draft 5 widened that to a
+   * character class, which still let `**git …**`, `"git …"`, `[git …](#x)` and
+   * `<code>git …</code>` through -- a class enumerating delimiters is the same
+   * mistake one level down.
    *
-   * `bashBlocks` is deliberately left alone: the section 9 block fences depend
+   * So the matcher is now the weakest thing that cannot be evaded by
+   * PUNCTUATION: the token itself. Measured across all 11 docs, that yields
+   * zero false positives for the ban.
+   *
+   * `bashBlocks` is deliberately untouched -- the section 9 block fences depend
    * on its contract, and widening a shared recogniser to suit one caller is how
    * those change meaning silently.
    */
-  const insideFence = (text: string): boolean[] => {
+  const scanFences = (text: string): { fenced: boolean[]; unterminated: boolean } => {
     // Tracks the OPENING run's char and length. A plain toggle desyncs on a
     // nested or four-backtick fence -- the inner marker flips it CLOSED and
     // every later line reads inverted -- and ignores ~~~ entirely.
     let open: string | null = null;
-    return text.split('\n').map((line) => {
+    const fenced = text.split('\n').map((line) => {
       const m = /^\s*(`{3,}|~{3,})/.exec(line);
       if (m) {
         const run = m[1]!;
@@ -882,40 +889,27 @@ describe('work-issues section 2 worktree probe', () => {
       }
       return open !== null;
     });
+    return { fenced, unterminated: open !== null };
   };
 
-  /** First token is a git call. NARROW, and used only to exclude prose below. */
+  /** The git TOKEN, anywhere. Not a delimiter class -- see the note above. */
+  const CONTAINS_GIT = /\bgit\b/;
+  /** First token is a git call. Narrow, and used only to exclude prose from the floor. */
   const GIT_LINE = /^\s*\$?\s*git\b/;
-  /** Contains a git call anywhere a shell could start one. WIDE, for extraction. */
-  const CONTAINS_GIT = /(?:^|[\s;&|(`])\$?git\b/;
 
-  /**
-   * TWO extractions, same fence map, different outside-fence matcher -- because
-   * the two questions differ. The BAN wants maximal reach, so it takes any line
-   * carrying a git call. UNIQUENESS must NOT: `launch-mode.md` discusses
-   * section 2's probe in prose (`git -C .claude/worktrees/<w> log|show|status`
-   * as the WRONG relative form, and a table row naming the right one), and a
-   * doc TALKING ABOUT the probe is not a second copy of it. Running the wide
-   * matcher for both reported launch-mode.md as a duplicate -- a false positive
-   * caught by this fence's own suite, on the round that widened it.
-   *
-   * Known bound, stated rather than left to be discovered: a DUPLICATE probe
-   * written as a bullet or blockquote outside a fence is invisible to
-   * uniqueness. It is not invisible to the ban, which is where the harm lives
-   * -- a duplicate that still ranges is drift; one that reads a single commit
-   * is the defect, and the ban has the wide reach.
-   */
-  const unitsFrom = (doc: string, outsideFence: RegExp): string[] => {
+  const commandUnits = (doc: string): string[] => {
     const text = read(doc);
-    const fenced = insideFence(text);
+    const { fenced } = scanFences(text);
     const picked: Array<{ i: number; line: string }> = [];
     text.split('\n').forEach((line, i) => {
-      if (fenced[i] || outsideFence.test(line)) picked.push({ i, line });
+      if (fenced[i] || CONTAINS_GIT.test(line)) picked.push({ i, line });
     });
     // Join `\` continuations, but only across ADJACENT source lines: `picked`
     // is filtered, so an index-blind join fuses a `\`-terminated line with the
     // next PICKED line anywhere later and fabricates a command that never
-    // existed -- which can trip the ban or the peer case on nothing.
+    // existed. (Outside a fence the continuation line usually carries no `git`
+    // and so is never picked -- the join is effective inside fences, which is
+    // where the skill's wrapped commands live.)
     const units: string[] = [];
     let previousIndex = -2;
     for (const { i, line } of picked) {
@@ -930,33 +924,37 @@ describe('work-issues section 2 worktree probe', () => {
     return units;
   };
 
-  /** Real command blocks: fenced lines plus a line-leading `git …`. */
-  const blockUnits = (doc: string): string[] => unitsFrom(doc, GIT_LINE);
-  /** Those plus any line carrying a git call at all -- bullets, blockquotes, cells. */
-  const anyGitUnits = (doc: string): string[] => unitsFrom(doc, CONTAINS_GIT);
-
   /**
    * `git … show … --stat`-family, either flag order. `show\s+` is what excludes
-   * `--show-current` (a `-` follows the word, so `\s+` cannot match) -- measured,
-   * because an earlier revision credited a `(?<![-\w])` lookbehind for that and
-   * the lookbehind turned out inert: its only effect is the hypothetical
-   * `--show ` with a trailing space. It is kept as belt-and-braces, and is
-   * described here as exactly that rather than as the thing doing the work.
+   * `--show-current`: a `-` follows the word, so `\s+` cannot match. Measured,
+   * because an earlier revision credited the `(?<![-\w])` lookbehind for that
+   * and the lookbehind is INERT here -- it only blocks a `show` glued to a
+   * preceding word or dash (`--show `, `reshow `). Kept as belt-and-braces, and
+   * described as that rather than as the thing doing the work.
    */
   const SINGLE_COMMIT =
     /\bgit\b.*(?<![-\w])show\s+.*--(?:[a-z-]*stat\b|name-only\b|name-status\b)/;
 
+  /**
+   * A peer-worktree probe addresses `<MAIN_CHECKOUT>`. That qualifier is what
+   * lets ONE wide extraction serve both questions: `launch-mode.md` discusses
+   * this probe in prose, and its bullet naming the WRONG relative form
+   * (`.claude/worktrees/<w>`, no `<MAIN_CHECKOUT>`) was reported as a duplicate
+   * when the predicate was the bare token. A doc talking about the probe is not
+   * a second copy of it.
+   */
   const peerProbes = (doc: string): string[] =>
-    blockUnits(doc).filter((u) => /worktrees\/<w>/.test(u));
+    commandUnits(doc).filter((u) => /<MAIN_CHECKOUT>[^\n]*worktrees\/<w>/.test(u));
 
-  it('every doc has balanced fences, so the scan cannot read inverted', () => {
-    // Not decoration: an odd fence count leaves `insideFence` open to EOF, and
-    // every remaining prose line then reads as a command. That fails loudly in
-    // one place instead of silently changing what the three cases below mean.
-    const unbalanced = skillDocs().filter(
-      (doc) => (read(doc).match(/^\s*(?:`{3,}|~{3,})/gm) ?? []).length % 2 !== 0,
+  it('every doc closes its fences, so the scan cannot read inverted', () => {
+    // Asserts the STATE MACHINE, not marker parity. A parity count fails on a
+    // legitimate nested fence (three markers, balanced) and passes on an
+    // unterminated four-backtick one (two markers) -- both measured, and both
+    // the wrong answer.
+    const unterminated = skillDocs().filter((doc) => scanFences(read(doc)).unterminated);
+    expect(unterminated, 'an unterminated fence makes every later line read as a command').toEqual(
+      [],
     );
-    expect(unbalanced, 'an unterminated fence inverts every later line').toEqual([]);
   });
 
   it('only section 2 probes a peer worktree', () => {
@@ -975,25 +973,27 @@ describe('work-issues section 2 worktree probe', () => {
     ).toBe(true);
 
     const singleCommit = skillDocs().flatMap((doc) =>
-      anyGitUnits(doc)
+      commandUnits(doc)
         .filter((u) => SINGLE_COMMIT.test(u))
         .map((u) => `${doc}: ${u.trim()}`),
     );
     expect(
       singleCommit,
-      'a `git show --stat` reads ONE commit and under-reports a multi-commit lane; that ' +
-        'form was withdrawn on 2026-09-05. This scans fenced lines too, so an intentional ' +
-        '"do NOT do this" example must live in PROSE, not in a code block',
+      'a `git show --stat` reads ONE commit and under-reports a multi-commit lane; that form ' +
+        'was withdrawn on 2026-09-05. PROSE IS SCANNED TOO, so naming it in an explanation ' +
+        'means writing the flags WITHOUT the literal `git` token, the way triage.md section 2 ' +
+        'does -- which is also why the floor below looks for `show --stat HEAD` and not for ' +
+        'the whole command',
     ).toEqual([]);
   });
 
   it('still explains WHY the range is load-bearing, in prose', () => {
-    // The FLOOR, and the half that has broken twice. Prose here means: outside
-    // every fence, not a command, not a comment, not an indented code block,
-    // and not inside an HTML comment -- a `<!-- … -->` carrier satisfied it
-    // while rendering invisible.
+    // The FLOOR, and the half that has broken twice. Prose means: outside every
+    // fence, not a command, not a comment, not an indented code block, and not
+    // inside an HTML comment -- a `<!-- … -->` carrier satisfied this while
+    // rendering invisible.
     const text = read(TRIAGE).replace(/<!--[\s\S]*?-->/g, '');
-    const fenced = insideFence(text);
+    const { fenced } = scanFences(text);
     const prose = text
       .split('\n')
       .filter(

--- a/tests/unit/scripts/work-issues-launch-mode.test.ts
+++ b/tests/unit/scripts/work-issues-launch-mode.test.ts
@@ -843,29 +843,49 @@ describe('work-issues launch-mode probe', () => {
  */
 describe('work-issues section 2 worktree probe', () => {
   const TRIAGE = join('references', 'triage.md');
-  /** The probe block addresses a PEER worktree by path — that is what selects it. */
+  /** The probe block addresses a PEER worktree by path -- that is what selects it. */
   const isProbeBlock = (block: string): boolean =>
     commandLines(block).some((c) => /worktrees\/<w>/.test(c));
 
-  it('exactly one block probes a peer worktree -- no decoy copy', () => {
-    const hits = bashBlocks(read(TRIAGE)).filter(isProbeBlock);
+  /**
+   * Scanned across the WHOLE skill, not just triage.md. Scoping the scan to one
+   * file let a stale copy of the withdrawn probe live in any OTHER stage:
+   * planted in gotchas.md -- the file that until this run restated section 2's
+   * probes in full -- the suite stayed green (measured 2026-09-06, round 2).
+   */
+  const probeBlocks = (): Array<{ doc: string; block: string }> =>
+    skillDocs().flatMap((doc) =>
+      bashBlocks(read(doc))
+        .filter(isProbeBlock)
+        .map((block) => ({ doc, block })),
+    );
+
+  it('exactly one block probes a peer worktree, across the whole skill', () => {
     expect(
-      hits.length,
-      'section 2 should hold exactly one per-worktree probe block; a second copy drifts',
-    ).toBe(1);
+      probeBlocks().map((h) => h.doc),
+      'the per-worktree probe belongs to section 2 and nowhere else; a second copy drifts',
+    ).toEqual([TRIAGE]);
   });
 
-  it('ranges over origin/main...HEAD, and never reads a single commit', () => {
-    const block = bashBlocks(read(TRIAGE)).find(isProbeBlock);
-    expect(block, 'the per-worktree probe block is gone').toBeDefined();
-    const cmds = commandLines(block!);
+  it('ranges over origin/main...HEAD, and no skill doc still reads a single commit', () => {
+    const hit = probeBlocks()[0];
+    expect(hit, 'the per-worktree probe block is gone').toBeDefined();
+    const cmds = commandLines(hit!.block);
 
     expect(
       cmds.some((c) => c.includes('diff --name-only origin/main...HEAD')),
       `the probe must range over the branch; commands were:\n${cmds.join('\n')}`,
     ).toBe(true);
 
-    const singleCommit = cmds.filter((c) => /show\s+--stat/.test(c));
+    // Swept over EVERY doc rather than the block above: the withdrawn form must
+    // not survive as a COMMAND anywhere in the skill, including in a stage file
+    // that never held the probe.
+    const singleCommit = skillDocs().flatMap((doc) =>
+      bashBlocks(read(doc))
+        .flatMap(commandLines)
+        .filter((c) => /show\s+--stat/.test(c))
+        .map((c) => `${doc}: ${c}`),
+    );
     expect(
       singleCommit,
       'a `show --stat` probe reads ONE commit and under-reports a multi-commit lane -- ' +
@@ -873,13 +893,14 @@ describe('work-issues section 2 worktree probe', () => {
     ).toEqual([]);
   });
 
-  it('still explains WHY the range is load-bearing, in prose', () => {
-    // The floor half. Without it, deleting the rationale satisfies the case
-    // above and the next author cannot tell the range from an arbitrary choice.
-    const prose = read(TRIAGE)
-      .split('\n')
-      .filter((l) => !/^\s*git\s/.test(l))
-      .join('\n');
+  it('still explains WHY the range is load-bearing, in prose OUTSIDE any block', () => {
+    // Subtracting the fenced blocks is the load-bearing part. Filtering
+    // `git`-prefixed lines instead left a whole-line `#` comment INSIDE a block
+    // able to satisfy this, so deleting the rationale paragraph and adding
+    // `# not show --stat HEAD` to the block passed -- the inert-floor failure
+    // this case exists to prevent, measured on itself 2026-09-06 in round 2.
+    const doc = read(TRIAGE);
+    const prose = bashBlocks(doc).reduce((acc, b) => acc.split(b).join(''), doc);
     expect(
       prose,
       'the paragraph naming what `show --stat HEAD` got wrong is the reason the range exists',


### PR DESCRIPTION
## Summary

Retrospective fold-back (`/work-issues` §10) for the 2026-09-05 deploy-priority
batch: go-to-k/cdkd#2634 (issues 2616 / 2608 / 2603 / 2598), go-to-k/cdkd#2649
(issue 2567) and go-to-k/cdkd#2674 (the go-to-k/cdkd#2668 stopgap). Three lanes,
all merged, all in-place and serial.

Three rules land, each from a MEASURED failure in that run, each amending the
sentence that was wrong rather than appending a sibling — plus a fence, because
one of the three is the kind a future edit can silently revert.

**1. `references/triage.md` §2 — the worktree probe read ONE commit.** The
collision scan told a lane to run `git -C <worktree> show --stat HEAD` to learn
what a peer holds. That reads a single commit. Measured on a worktree ten commits
ahead of `origin/main`: `show --stat HEAD` reported **1 file**, while
`diff --name-only origin/main...HEAD` reported **5** — the hidden four included
`CLAUDE.md`. A triage sub-agent in this run reported "no collision" for two
issues on that basis. The probe now ranges over the branch, and the trap that
still applies to the neighbouring `log --oneline -1` (a lane yet to commit
reports `main`'s tip) is stated rather than deleted along with it.

**2. `references/implement.md` §5-g — the lane's REPORT is the deliverable.**
The fan-out contract named the worktree path and the allowed files but never the
report. A lane sub-agent's tool output does not reach the orchestrator, so a
one-line "done" loses everything the lane learned. It happened to 2 of the 3
lanes here, and both had to be resumed with an explicit "REPORT ONLY, do not
touch the tree" — now in the text, with why a plain resume is the wrong recovery.

**3. `.claude/rules/testing.md` — a guard's uses are its CALL SITES.** An
ESCALATION, not a new rule: the one-sided-fence lesson lived only in memory (the
weakest tier) and was violated anyway inside this run, which per §10-b is the
signal to move it somewhere load-bearing. It amends the existing "one probe per
use" bullet to say what a *use* is for a guard: every call site, and both
directions of its message. Sourced on go-to-k/cdkd#2674's round 4, whose body
records the incident verbatim.

**4. A fence for rule 1** in `tests/unit/scripts/work-issues-launch-mode.test.ts`,
which already owns "a withdrawn command cannot come back". One fence map feeds
four cases: every doc's fences are balanced; exactly one doc probes a peer
worktree and it is triage.md; that probe ranges and no doc's commands carry a
`git show --stat`-family read; and the PROSE still explains why.

**It took five drafts, and every failure was the class it exists to catch.**
That, more than the rules themselves, is what this PR is worth reading for:

- Draft 1's FLOOR was inert — it filtered `git`-prefixed lines, so a
  `# not show --stat HEAD` planted in the block satisfied it while the
  rationale paragraph was deleted. Measured GREEN.
- Draft 2 used `bashBlocks`, which sees only a column-0 ` ```bash ` fence, so
  the command survived as ` ```sh `, bare ` ``` `, or indented.
- Draft 3 went line-based, closed those, **regressed the floor**, and went blind
  to any command whose line does not start with `git` (`cd … && git show`, a
  `for` body, `env`-prefixed, a `\`-continuation — and `retro.md` really does
  hard-wrap a git command across a newline).
- Draft 4 took the union but still anchored the outside-fence half on a
  line-leading `git`, so a list item, numbered item, blockquote or table cell
  escaped — as did a `~~~` fence, a four-backtick fence (the parity toggle
  desynced on the inner marker), `--patch-with-stat`, and an HTML-comment
  carrier for the floor.
- Draft 5 closed those with a delimiter character class — which still let
  `**git …**`, `*git …*`, `"git …"`, `[git …](#x)`, `<code>git …</code>` and a
  space-less `>git …` through. A class enumerating delimiters is the same
  mistake one level down. Widening it also produced a **false positive its own
  suite caught**: `launch-mode.md` discusses §2's probe in prose, and a doc
  talking about the probe is not a second copy of it.
- Draft 6 ends on the weakest matcher punctuation cannot evade — the token
  `git` itself — with the peer predicate qualified by `<MAIN_CHECKOUT>` so that
  prose ABOUT the probe is excluded by meaning rather than by syntax. That let
  one extraction serve both questions, deleted the two-extraction split, and
  closed the bound draft 5 had documented as unavoidable. The balanced-fence
  assertion added in draft 5 was also wrong in both directions — it measured
  marker parity, so it failed on a legitimate nested fence and passed on an
  unterminated one — and now asserts the state machine itself.

Three residual gaps are filed as go-to-k/cdkd#2683 rather than fixed here: a
prose continuation, four invisible floor carriers, and semantic siblings like
`git log -1 --stat`. None lets the original defect back in silently — replacing
the ranged probe still reds the range assertion.

Each draft passed its own battery, because each battery varied only what the
previous round had found — fence style, then command shape, then carrier. **A
fence's battery inherits the imagination of the round that wrote it**, which is
the general form of the rule this fence was built to enforce.

### Byte budget

Both corpora sit near their floors, and §10-c forbids a retro buying room by
raising a bound. **No bound was raised.** Two caps moved DOWN (below).

- **Skill corpus +90 B**: triage.md +135, implement.md +161, gotchas.md −107,
  retro.md −40, claim.md −59; corpus 172,956 -> 173,046. `MEASURED` asserts
  corpus, orchestrator, largest and runner-up against the tree. **Note the
  leader flip**: implement.md overtakes verify.md, so `largest` / `runnerUp`
  swap.
- **Rules corpus +116 B** in `testing.md`, of which 140 B was paid back by
  compressing three neighbouring mutation bullets. That spends the
  `tests/setup.ts` payload band, re-derived in the same commit.
- Payment was **displacement, not deletion**: `gotchas.md` was restating §2's two
  live-lane probes in full, and `retro.md` and `claim.md` each carried a bare
  "English only" line for a rule CLAUDE.md owns and two hooks enforce
  (`non-english-text-gate`, `gh-body-english-gate` — review live-probed both
  against the exact removed contexts). A prose copy of a hook-enforced rule is
  paid for in every lane and stops nothing.
- **Two caps re-derived DOWNWARD.** Both bound a payload that IS `testing.md`
  (alone, and plus its satellite), and both CAPS were left sized for the
  pre-compression file, ~15 KB larger than the live one — the slack condition
  the `s3-bucket-provider` row records
  as having "silently absorbed a whole 59 KB satellite". 68,000 -> 52,000 and
  72,000 -> 56,000. Both probed; each now names itself. The comment says plainly
  that neither is the live fence (the gutting case binds first, by ~44x) — an
  earlier draft claimed one of them was, and review measured that false. Only
  the first row's `measured` NOTE was stale — the sibling's tracked its payload
  correctly — and a draft that said "both notes" was itself the same defect
  class, caught in review.

### What review cost, and what it is worth recording

Six rounds, twelve reviewer dispatches across two axes, each round scoped to the
previous round's fix because a fix is code no reviewer has seen. Every round
found something real, including several defects inside the fence added to
prevent that very class.

**Seven wrong figures across the first three rounds**, every one a hand-derived
number in a comment that nothing asserts: an attribution measured against a
commit range that dies at the squash merge, a component split, a ratio, a "most
of" claim, a line distance, a count, and a cross-file band. Not one was caught
by reading; all seven by measuring.

Round 3 answered that by deleting **all** arithmetic from the history paragraph.
Round 4's reviewer argued the other side and was right: re-derived at the commit
that wrote them, the per-file **components** were correct 5 for 5, every time.
The seven wrong ones were a different class. So the rule is not "state no
numbers" — a component is a `wc -c` of a file at a sha and stays re-derivable,
while a figure derived from other figures is checked by nothing and did not once
survive a round here. Components are restored; the derived figures stay out. And
they are stated in the comment rather than left to `wc -c` against `origin/main`,
because once this squashes, `origin/main` **is** the after-side.

### Also from the retro, landing outside this PR

- **go-to-k/cdkd#2679** — `integ-broad` is bound only to the root sentinel
  `.markgate-broad-integ-test`, which no branch switch touches, so serial lanes
  sharing one worktree inherit a marker for code no broad integ has seen. It read
  `match` at two of this run's three merges.
- **go-to-k/cdkd#2683** — three residual gaps in the new probe fence, measured
  against the shipped version and deliberately deferred (see above).
- **go-to-k/cdkd#2681** — `pr-review-gate.sh` says `markgate verify` already
  enforces the sha binding via the digest. Measured false. The gate is correct
  (`recorded_sha = head_sha` is the real enforcement) but the comment makes that
  look like a cosmetic duplicate a future edit could delete.
- **Mirrors** go-to-k/cdk-local#710 and go-to-k/cdk-real-drift#1889 for the two
  FLOW lessons, each adapted per repo and cross-linked.
- **Promotion re-checks** on go-to-k/cdkd#2648, go-to-k/cdkd#2651 and
  go-to-k/cdkd#2666: each opened with a clause anchored to a then-in-flight PR
  that has since merged, so the clause expired while the decision stood.

### Judged NOT worth a rule

`pr-review`'s marker verifying against a foreign sha (the manual comparison
`verify.md` §8 prescribes caught it every time, and the gate itself blocks);
a suite reporting every test passing while exiting 1 (four times, including
twice in this PR's own verification — `Worker exited unexpectedly` under peer
load, which three stage files already cover); and a parent instruction
generalizing wrongly across two sibling arms, which two independent reviewers
caught, i.e. the designed control working.

## Test plan

- `vp run check`, `vp run typecheck:test`, `vp run build`, `vp run gen:all-matrices`,
  `vp run audit:coverage:check` — all rc=0, no generated artifact dirty.
- `vp test run` — 901 files / 19,143 tests pass, rooted in this worktree
  (asserted against `pwd -P`, not read off the summary).
- **Every fence proved ALIVE by mutation, one variable at a time, tree restored
  byte-exact and re-verified green after each:**
  - The `tests/setup.ts` gutting floor: +126 B to `testing.md` green, +127 red.
  - Both re-derived caps: each named itself in its own failure message, and each
    was silent at its old value.
  - The skill-corpus `MEASURED` case: +131 B to `triage.md` reds it.
  - The probe fence, against every evasion five review rounds produced, one at
    a time with the tree restored byte-exact between each. Command SHAPES:
    `cd … && git show`, a `for` body, a `\`-continuation, `env`-prefixed,
    `/usr/bin/git`, `show HEAD --stat` (flag order), `--numstat`,
    `--patch-with-stat`. CARRIERS: list item, numbered item, blockquote, table
    cell, 4-space indent, `$`-prompt. FENCE STYLES: ` ```sh `, bare ` ``` `,
    indented, `~~~`, four-backtick nested. FLOOR: rationale deleted alone, and
    with an in-fence `#` comment, an `echo`, a 4-space indented line, or an
    HTML comment planted. Plus the probe reverted, two-dotted, or replaced by
    `HEAD~1`. All red; and a non-adjacent `\`-continuation correctly does NOT
    fabricate a unit.
- No `src/**` change, so no integ gate is in scope; no AWS resources touched.
