### PR TITLE
chore(integ-ledger): record the merge-gate reruns of PR 2562

### DIFF
--- a/docs/_generated/integ-last-run.tsv
+++ b/docs/_generated/integ-last-run.tsv
@@ -149,7 +149,7 @@ intrinsics-torture-2	2026-07-26T18:57:55Z	PASS	48	verify.sh	0727b sweep-b7 stale
 kinesis-esm-filter	2026-08-10T04:23:28Z	PASS	63	verify.sh	0810 sweep b2; post-#1398 lambda-eventsource re-verify, 5 del 0 err, 0 orph
 kinesis-stream-mode-switch	2026-08-26T08:41:59Z	PASS	120	verify.sh	issue 2178 masker-threading sweep (kinesis); 3 phases, 0 err, 0 orphans
 kms-encryption	2026-07-26T18:20:27Z	PASS	25	standard	0727b sweep-b3 staleness re-run (rc=0); account clean
-lambda	2026-09-07T05:47:18Z	PASS	88	verify.sh	PR 2562 round 2 broad gate (src/cli/commands/scrub.ts comment-only edit, deploy-engine.ts untouched this round): 9 deleted 0 errors 0 orphans; event-log versions swept
+lambda	2026-09-07T07:00:38Z	PASS	80	verify.sh	maintainer merge-gate rerun of PR 2562 (broad gate; deploy-engine.ts in scope): 9 deleted 0 errors, 0 orphans; note: this fixture does NOT sweep state object versions (no list-object-versions in its verify.sh)
 lambda-alias-provisioned-concurrency	2026-07-26T19:16:39Z	PASS	262	verify.sh	0727b sweep-b9 staleness re-run (rc=0); account clean
 lambda-arch-switch	2026-07-26T19:25:15Z	PASS	63	verify.sh	0727b sweep-b10 staleness re-run (rc=0); account clean
 lambda-config-field-removal	2026-08-11T13:09:08Z	PASS	132	verify.sh	issue #609 Lambda 4-prop backfill + review fixes; 5 del 0 err 0 orphans
@@ -261,7 +261,7 @@ schema-v7-to-v8-migration	2026-08-01T09:51:12Z	PASS	92	verify.sh	0801 regression
 schema-v8-to-v9-migration	2026-08-26T02:45:22Z	PASS	171	verify.sh	maintainer-side run at post-blocker-fix head; v8 shadow repro + v9 migration, 0 err 0 orphans
 sdk-ccapi-crossref	2026-08-10T04:23:28Z	PASS	85	verify.sh	0810 sweep b2; post-#1355 CC snapshot path, heterogeneous routing, 4 del 0 err, 0 orph
 secrets-array-nested	2026-08-26T17:19:35Z	PASS	215	verify.sh	gating PR 2295, RE-RUN on the final tree after a round-3 review fix to the arm helper. The identity check in assert_unkeyed_string_array sat AFTER the all-strings check, which rejects any array containing an object first, so the identity branch was UNREACHABLE -- its comment claimed the probe answers true on this fixture Environment[], which was true of the jq expression and false of the helper. Measured before/after: BEFORE reported "elements are object, not all plain strings", AFTER reports the identity message. That guard is the arm own premise, so it is not a nit. POSITIVE: the gate PAIRED the unkeyed Command array and persisted the expression. NEGATIVE CONTROL: it REFUSED the indistinguishable twin. destroy 2 deleted / 0 errors, 0 orphans, 0 surviving state object versions
-secrets-dynamic-ref	2026-09-07T05:45:32Z	PASS	498	verify.sh	PR 2562 round 2 (maintainer re-review; scrub.ts class-doc comment edit): Guard 7b three lines printed, scrub --dry-run clean; 4 deleted 0 err 0 orphans, 0 surviving versions
+secrets-dynamic-ref	2026-09-07T07:26:00Z	PASS	389	verify.sh	maintainer merge-gate rerun of PR 2562 (live arm for the changed behavior): Guard 7b three lines printed incl. the name loop taking the intrinsic Export.Name with neither fallback warning; 4 deleted 0 errors, 0 orphans, 0 surviving state versions
 secrets-rotation-schedule	2026-07-26T19:05:27Z	PASS	66	verify.sh	0727b sweep-b8 staleness re-run (rc=0); account clean
 secretsmanager-update-value-source	2026-09-04T00:49:00Z	PASS	70	verify.sh	rc ok, orph clean, versions swept (maintainer merge-gate rerun of PR 2476)
 serverless-api	2026-07-26T19:45:58Z	PASS	58	verify.sh	0727b sweep-b12 staleness re-run (rc=0); account clean


### PR DESCRIPTION
## Summary

PR go-to-k/cdkd#2562 came from a fork, so its merge-gate integ runs happened on a local head branch that cannot be pushed to the contributor's repository — the mandatory ledger rows had nowhere to land. Recording them here, against `main`, now that it is merged.

Both runs were on the merged tree (`c7720314`, identical to what landed as `a7e1df92` bar the squash).

| test | result | duration | detail |
|---|---|---|---|
| `lambda` | PASS | 80 s | broad gate — `deploy-engine.ts` is in the `integ-broad` scope. 9 deleted, 0 errors, 0 orphans. |
| `secrets-dynamic-ref` | PASS | 389 s | the live arm for that PR's changed behavior. Guard 7b's three lines printed, including the one asserting scrub's name loop took the intrinsic `Export.Name` with neither fallback warning. 4 deleted, 0 errors, 0 orphans, 0 surviving state object versions. |

The `lambda` note also records something the previous rows for that fixture got wrong: `tests/integration/lambda/verify.sh` does **not** sweep state object versions — it has no `list-object-versions` / `delete-object` call anywhere — while earlier rows for it claimed "event-log versions swept". `secrets-dynamic-ref` does sweep, and its row says so on evidence (the run printed `0 surviving object versions`).

## Test plan

- `vp run check` / `vp run typecheck:test` / `vp run build`: 0 errors.
- `vp run gen:all-matrices` / `vp run audit:coverage:check` / `vp run format`: nothing dirty beyond the ledger row itself.
- `vp test run` on the final tree: 917 files, 19,543 passed (1 skipped), no type errors, root-asserted in this worktree — which includes the one-row-per-test / sort invariant the ledger normalizer is fenced by.
- `vp run integ-ledger-normalize` run before committing; `git status --porcelain -- docs/_generated/` clean afterwards.

Ledger-only change: no `src/` edit, so no integ gate applies to this PR itself.
